### PR TITLE
Support the Intel ME version format

### DIFF
--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -37,6 +37,8 @@ fu_common_version_format_from_string (const gchar *str)
 		return FU_VERSION_FORMAT_BCD;
 	if (g_strcmp0 (str, "plain") == 0)
 		return FU_VERSION_FORMAT_PLAIN;
+	if (g_strcmp0 (str, "intel-me") == 0)
+		return FU_VERSION_FORMAT_INTEL_ME;
 	return FU_VERSION_FORMAT_QUAD;
 }
 
@@ -61,6 +63,8 @@ fu_common_version_format_to_string (FuVersionFormat kind)
 		return "bcd";
 	if (kind == FU_VERSION_FORMAT_PLAIN)
 		return "plain";
+	if (kind == FU_VERSION_FORMAT_INTEL_ME)
+		return "intel-me";
 	return NULL;
 }
 
@@ -110,6 +114,14 @@ fu_common_version_from_uint32 (guint32 val, FuVersionFormat kind)
 					FU_COMMON_VERSION_DECODE_BCD(val >> 16),
 					FU_COMMON_VERSION_DECODE_BCD(val >> 8),
 					FU_COMMON_VERSION_DECODE_BCD(val));
+	}
+	if (kind == FU_VERSION_FORMAT_INTEL_ME) {
+		/* aaa+11.bbbbb.cccccccc.dddddddddddddddd */
+		return g_strdup_printf ("%u.%u.%u.%u",
+					((val >> 29) & 0x07) + 0x0b,
+					 (val >> 24) & 0x1f,
+					 (val >> 16) & 0xff,
+					  val & 0xffff);
 	}
 	return NULL;
 }

--- a/src/fu-common-version.h
+++ b/src/fu-common-version.h
@@ -17,6 +17,7 @@
  * @FU_VERSION_FORMAT_TRIPLET:		Use Microsoft-style AA.BB.CCDD version numbers
  * @FU_VERSION_FORMAT_PAIR:		Use two AABB.CCDD version numbers
  * @FU_VERSION_FORMAT_BCD:		Use binary coded decimal notation
+ * @FU_VERSION_FORMAT_INTEL_ME:		Use Intel ME-style notation
  *
  * The flags used when parsing version numbers.
  **/
@@ -27,6 +28,7 @@ typedef enum {
 	FU_VERSION_FORMAT_TRIPLET,	/* Since: 1.2.0 */
 	FU_VERSION_FORMAT_PAIR,		/* Since: 1.2.0 */
 	FU_VERSION_FORMAT_BCD,		/* Since: 1.2.0 */
+	FU_VERSION_FORMAT_INTEL_ME,	/* Since: 1.2.0 */
 	/*< private >*/
 	FU_VERSION_FORMAT_LAST
 } FuVersionFormat;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2959,6 +2959,8 @@ fu_common_version_func (void)
 		{ 0xff000100,	"255.0.256",		FU_VERSION_FORMAT_TRIPLET },
 		{ 0x0,		"0",			FU_VERSION_FORMAT_PLAIN },
 		{ 0xff000100,	"4278190336",		FU_VERSION_FORMAT_PLAIN },
+		{ 0x0,		"11.0.0.0",		FU_VERSION_FORMAT_INTEL_ME },
+		{ 0xffffffff,	"18.31.255.65535",	FU_VERSION_FORMAT_INTEL_ME },
 		{ 0,		NULL }
 	};
 	struct {


### PR DESCRIPTION
This slightly weird encoding is going to be used by Lenovo for firmware updates.
It will also be used to quirk the ME UEFI device added from the ESRT.