### PR TITLE
uefi: add support for tpm2-tools 4.X

### DIFF
--- a/plugins/uefi/fu-self-test.c
+++ b/plugins/uefi/fu-self-test.c
@@ -43,13 +43,17 @@ fu_uefi_pcrs_2_0_func (void)
 	g_autoptr(FuUefiPcrs) pcrs = fu_uefi_pcrs_new ();
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) pcr0s = NULL;
+	g_autoptr(GPtrArray) pcr1s = NULL;
 	g_autoptr(GPtrArray) pcrXs = NULL;
 
 	g_setenv ("FWUPD_UEFI_TPM2_YAML_DATA",
 		  "sha1 :\n"
 		  "  0  : cbd9e4112727bc75761001abcb2dddd87a66caf5\n"
 		  "sha256 :\n"
-		  "  0  : 122de8b579cce17b0703ca9f9716d6f99125af9569e7303f51ea7f85d317f01e\n", TRUE);
+		  /* old output format of tpm2_listpcrs and tpm2_pcrlist */
+		  "  0  : 122de8b579cce17b0703ca9f9716d6f99125af9569e7303f51ea7f85d317f01e\n"
+		  /* new output format of tpm2_pcrread */
+		  "  1 : 0x0D89E7CA2C487EED36DB5684826B4ABF0904D3BDCD74E61999573570CF3F9C75\n", TRUE);
 
 	ret = fu_uefi_pcrs_setup (pcrs, &error);
 	g_assert_no_error (error);
@@ -57,6 +61,9 @@ fu_uefi_pcrs_2_0_func (void)
 	pcr0s = fu_uefi_pcrs_get_checksums (pcrs, 0);
 	g_assert_nonnull (pcr0s);
 	g_assert_cmpint (pcr0s->len, ==, 2);
+	pcr1s = fu_uefi_pcrs_get_checksums (pcrs, 1);
+	g_assert_nonnull (pcr1s);
+	g_assert_cmpint (pcr1s->len, ==, 1);
 	pcrXs = fu_uefi_pcrs_get_checksums (pcrs, 999);
 	g_assert_nonnull (pcrXs);
 	g_assert_cmpint (pcrXs->len, ==, 0);

--- a/plugins/uefi/fu-uefi-pcrs.c
+++ b/plugins/uefi/fu-uefi-pcrs.c
@@ -61,6 +61,7 @@ fu_uefi_pcrs_parse_line (const gchar *line, gpointer user_data)
 	/* parse hash */
 	str = g_string_new (split[1]);
 	fu_common_string_replace (str, " ", "");
+	fu_common_string_replace (str, "0x", "");
 	if ((str->len != 40 && str->len != 64) || !_g_string_isxdigit (str)) {
 		g_debug ("not SHA-1 or SHA-256, skipping: %s", split[1]);
 		return;
@@ -144,10 +145,14 @@ fu_uefi_pcrs_setup (FuUefiPcrs *self, GError **error)
 	} else {
 		g_autofree gchar *argv0 = NULL;
 
-		/* old name, then new name */
+		/* tpm2-tools 2 tool name */
 		argv0 = fu_common_find_program_in_path ("tpm2_listpcrs", NULL);
 		if (argv0 == NULL)
+			/* tpm2-tools 3 tool name */
 			argv0 = fu_common_find_program_in_path ("tpm2_pcrlist", error);
+		if (argv0 == NULL)
+			/* tpm2-tools 4 tool name */
+			argv0 = fu_common_find_program_in_path ("tpm2_pcrread", error);
 		if (argv0 == NULL)
 			return FALSE;
 		if (!fu_uefi_pcrs_setup_tpm20 (self, argv0, error))


### PR DESCRIPTION
A first [release candiate](https://github.com/tpm2-software/tpm2-tools/releases/tag/4.0-rc0) for tpm2-tools 4.0 has been tagged. This is a major release that contains many [backwards-incompatible changes](https://github.com/tpm2-software/tpm2-tools/blob/c02b68d56f1ce7a67b1be580b7efe128d26447bf/CHANGELOG.md#40-rc0---2019-08-19). fwupd only uses `tpm2_pcrlist`, which has been renamed to `tpm2_pcrread` and its output format has been slightly changed from
```
$ tpm2_pcrlist 
sha1 :
  0  : ffffffffffffffffffffffffffffffffffffffff
  [...]
sha256 :
  0  : ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
  [...]
```
to
```
$ tpm2_pcrread 
sha1:
  0 : 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  [...]
sha256:
  0 : 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  [...]
```

 This PR adds support for the new version while retaining backwards compatibility with tpm2-tools 2 and 3.