### PR TITLE
Add fu_device_rescan() and a FuDevice->rescan() vfunc

### DIFF
--- a/src/fu-debug.c
+++ b/src/fu-debug.c
@@ -17,6 +17,7 @@ typedef struct {
 	GOptionGroup	*group;
 	gboolean	 verbose;
 	gboolean	 console;
+	gboolean	 no_timestamp;
 	gchar		**plugin_verbose;
 	gchar		**daemon_verbose;
 } FuDebug;
@@ -73,11 +74,13 @@ fu_debug_handler_cb (const gchar *log_domain,
 		return;
 
 	/* time header */
-	tmp = g_strdup_printf ("%02i:%02i:%02i:%04i",
-			       g_date_time_get_hour (dt),
-			       g_date_time_get_minute (dt),
-			       g_date_time_get_second (dt),
-			       g_date_time_get_microsecond (dt) / 1000);
+	if (!self->no_timestamp) {
+		tmp = g_strdup_printf ("%02i:%02i:%02i:%04i",
+				       g_date_time_get_hour (dt),
+				       g_date_time_get_minute (dt),
+				       g_date_time_get_second (dt),
+				       g_date_time_get_microsecond (dt) / 1000);
+	}
 
 	/* each file should have set this */
 	if (log_domain == NULL)
@@ -129,6 +132,9 @@ fu_debug_pre_parse_hook (GOptionContext *context,
 		{ "verbose", 'v', 0, G_OPTION_ARG_NONE, &self->verbose,
 		  /* TRANSLATORS: turn on all debugging */
 		  N_("Show debugging information for all domains"), NULL },
+		{ "no-timestamp", '\0', 0, G_OPTION_ARG_NONE, &self->no_timestamp,
+		  /* TRANSLATORS: turn on all debugging */
+		  N_("Do not include timestamp prefix"), NULL },
 		{ "plugin-verbose", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &self->plugin_verbose,
 		  /* TRANSLATORS: this is for plugin development */
 		  N_("Show plugin verbose information"), "PLUGIN-NAME" },

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -2101,6 +2101,41 @@ fu_device_probe (FuDevice *self, GError **error)
 }
 
 /**
+ * fu_device_rescan:
+ * @self: A #FuDevice
+ * @error: A #GError, or %NULL
+ *
+ * Rescans a device, re-adding GUIDs or flags based on some hardware change.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.2.11
+ **/
+gboolean
+fu_device_rescan (FuDevice *self, GError **error)
+{
+	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (self);
+
+	g_return_val_if_fail (FU_IS_DEVICE (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	/* remove all GUIDs */
+	g_ptr_array_set_size (fu_device_get_instance_ids (self), 0);
+	g_ptr_array_set_size (fu_device_get_guids (self), 0);
+
+	/* subclassed */
+	if (klass->rescan != NULL) {
+		if (!klass->rescan (self, error)) {
+			fu_device_convert_instance_ids (self);
+			return FALSE;
+		}
+	}
+
+	fu_device_convert_instance_ids (self);
+	return TRUE;
+}
+
+/**
  * fu_device_convert_instance_ids:
  * @self: A #FuDevice
  *

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -40,6 +40,8 @@ struct _FuDeviceClass
 							 GError		**error);
 	gboolean		 (*probe)		(FuDevice	*self,
 							 GError		**error);
+	gboolean		 (*rescan)		(FuDevice	*self,
+							 GError		**error);
 	FuFirmware		*(*prepare_firmware)	(FuDevice	*self,
 							 GBytes		*fw,
 							 FwupdInstallFlags flags,
@@ -110,6 +112,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_get_modified(d)		fwupd_device_get_modified(FWUPD_DEVICE(d))
 #define fu_device_get_guids(d)			fwupd_device_get_guids(FWUPD_DEVICE(d))
 #define fu_device_get_guid_default(d)		fwupd_device_get_guid_default(FWUPD_DEVICE(d))
+#define fu_device_get_instance_ids(d)		fwupd_device_get_instance_ids(FWUPD_DEVICE(d))
 #define fu_device_get_icons(d)			fwupd_device_get_icons(FWUPD_DEVICE(d))
 #define fu_device_get_name(d)			fwupd_device_get_name(FWUPD_DEVICE(d))
 #define fu_device_get_serial(d)			fwupd_device_get_serial(FWUPD_DEVICE(d))
@@ -231,6 +234,8 @@ gboolean	 fu_device_close			(FuDevice	*self,
 gboolean	 fu_device_probe			(FuDevice	*self,
 							 GError		**error);
 gboolean	 fu_device_setup			(FuDevice	*self,
+							 GError		**error);
+gboolean	 fu_device_rescan			(FuDevice	*self,
 							 GError		**error);
 gboolean	 fu_device_activate			(FuDevice	*self,
 							 GError		**error);

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -86,6 +86,9 @@ gboolean	 fu_plugin_runner_usb_device_added	(FuPlugin	*self,
 gboolean	 fu_plugin_runner_udev_device_added	(FuPlugin	*self,
 							 FuUdevDevice	*device,
 							 GError		**error);
+gboolean	 fu_plugin_runner_udev_device_changed	(FuPlugin	*self,
+							 FuUdevDevice	*device,
+							 GError		**error);
 void		 fu_plugin_runner_device_removed	(FuPlugin	*self,
 							 FuDevice	*device);
 void		 fu_plugin_runner_device_register	(FuPlugin	*self,

--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -80,6 +80,9 @@ gboolean	 fu_plugin_usb_device_added		(FuPlugin	*plugin,
 gboolean	 fu_plugin_udev_device_added		(FuPlugin	*plugin,
 							 FuUdevDevice	*device,
 							 GError		**error);
+gboolean	 fu_plugin_udev_device_changed		(FuPlugin	*plugin,
+							 FuUdevDevice	*device,
+							 GError		**error);
 gboolean	 fu_plugin_device_removed		(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GError		**error);


### PR DESCRIPTION
This allows the plugin to cause a superclassed ->rescan() to be called in
response to some vague hardware change.
