### PR TITLE
trivial: fu-util: cleanup fwupdmgr get-details output

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#define G_LOG_DOMAIN				"FuMain"
+
 #include <config.h>
 
 #include <stdio.h>
@@ -145,7 +147,7 @@ fu_util_print_device_tree (GNode *n, gpointer data)
 	g_auto(GStrv) split = NULL;
 
 	/* root node */
-	if (dev == NULL) {
+	if (dev == NULL && g_getenv ("FWUPD_VERBOSE") == NULL) {
 		g_print ("○\n");
 		return FALSE;
 	}


### PR DESCRIPTION
* Show "No Device ID" if no matching devices
* Don't show flags if no flags available

Before:
```
  Device ID:
  Description:          Updating the MST FW improves display performance.

  Flags:
  GUID:                 0a52c8c7-26d5-59a0-ae44-6b00e276d775

```

After:
```
  Device ID:            No Device ID
  Description:          Updating the MST FW improves display performance.

  GUID:                 0a52c8c7-26d5-59a0-ae44-6b00e276d775

```

Type of pull request:
- [x] Code fix
