### PR TITLE
trivial: fu-util: Drop GUID support from get-devices

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -858,7 +858,6 @@ gchar *
 fu_util_device_to_string (FwupdDevice *dev, guint idt)
 {
 	FwupdUpdateState state;
-	GPtrArray *guids = fwupd_device_get_guids (dev);
 	GString *str = g_string_new (NULL);
 	const gchar *tmp;
 	const gchar *tmp2;
@@ -978,16 +977,6 @@ fu_util_device_to_string (FwupdDevice *dev, guint idt)
 		fu_common_string_append_kv (str, idt + 1, _("Flags"), flags_str->str);
 	}
 
-	/* all GUIDs for this hardware */
-	for (guint i = 0; i < guids->len; i++) {
-		tmp = g_ptr_array_index (guids, i);
-		if (i == 0) {
-			/* TRANSLATORS: global ID common to all similar hardware */
-			fu_common_string_append_kv (str, idt + 1, ngettext ("GUID", "GUIDs", guids->len), tmp);
-		} else {
-			fu_common_string_append_kv (str, idt + 1, "", tmp);
-		}
-	}
 	return g_string_free (str, FALSE);
 }
 


### PR DESCRIPTION
To the average user this is not a useful feature.  None of the command
line options will take a GUID as an argument.
Really it's an internal representation of device to firwmare upgrade CAB file.

This simplifies this output:
```
├─VMM3320 inside Dell WD15/TB16/TB18 wired Dock:
│     Device ID:           585c346c009da3cc19a400fb59a4ed8d0cbd0151
│     Summary:             Multi-Stream Transport Device
│     Current version:     3.12.002
│     Vendor:              Synaptics
│     Update State:        success
│     Flags:               updatable|registered
│     GUIDs:               c1e81f96-234e-597d-b9cb-6477d0652868
│                          152a9833-41e6-5c21-9dde-0ff8984f3e20
│                          c1e2bea5-4cf2-5f84-b965-533e8e5fea45
│                          0a52c8c7-26d5-59a0-ae44-6b00e276d775
│                          82460515-30d3-5cdf-be4c-571340842a10
│                          51000744-2de6-5a52-8a86-d5f69fd73d34
│                          d6072785-6fc0-5f83-9d49-11376e7f48b1
│                          6bc9fc61-618a-535f-a629-98345e11336e
│                          4e4e06b6-8217-5cf0-8eff-ce5e987d531a
```

To this:
```
├─VMM3320 inside Dell WD15/TB16/TB18 wired Dock:
│     Device ID:           585c346c009da3cc19a400fb59a4ed8d0cbd0151
│     Summary:             Multi-Stream Transport Device
│     Current version:     3.12.002
│     Vendor:              Synaptics
│     Update State:        success
│     Flags:               updatable|registered
```

Those who are developing upgrades to devices can run fwupdmgr --verbose and
will get the verbose output that includes GUIDs:

```
VMM3320 inside Dell WD15/TB16/TB18 wired Dock
  DeviceId:             585c346c009da3cc19a400fb59a4ed8d0cbd0151
  Guid:                 c1e81f96-234e-597d-b9cb-6477d0652868
  Guid:                 152a9833-41e6-5c21-9dde-0ff8984f3e20
  Guid:                 c1e2bea5-4cf2-5f84-b965-533e8e5fea45
  Guid:                 0a52c8c7-26d5-59a0-ae44-6b00e276d775
  Guid:                 82460515-30d3-5cdf-be4c-571340842a10
  Guid:                 51000744-2de6-5a52-8a86-d5f69fd73d34
  Guid:                 d6072785-6fc0-5f83-9d49-11376e7f48b1
  Guid:                 6bc9fc61-618a-535f-a629-98345e11336e
  Guid:                 4e4e06b6-8217-5cf0-8eff-ce5e987d531a
  Summary:              Multi-Stream Transport Device
  Plugin:               synapticsmst
  Flags:                updatable|registered
  Vendor:               Synaptics
  Version:              3.12.002
  VersionFormat:        triplet
  Icon:                 video-display
  Created:              2019-08-28
  Modified:             2019-08-28
  UpdateState:          success
```

If they run this as an administrator they'll also get the strings used to build the GUID:
```
VMM3320 inside Dell WD15/TB16/TB18 wired Dock
  DeviceId:             585c346c009da3cc19a400fb59a4ed8d0cbd0151
  Guid:                 c1e81f96-234e-597d-b9cb-6477d0652868 <- MST-wd15-274
  Guid:                 152a9833-41e6-5c21-9dde-0ff8984f3e20 <- MST-wd15-vmm3320-274
  Guid:                 c1e2bea5-4cf2-5f84-b965-533e8e5fea45 <- MST-tb16-274
  Guid:                 0a52c8c7-26d5-59a0-ae44-6b00e276d775 <- MST-tb16-vmm3320-274
  Guid:                 82460515-30d3-5cdf-be4c-571340842a10 <- MST-tb18-274
  Guid:                 51000744-2de6-5a52-8a86-d5f69fd73d34 <- MST-tb18-vmm3320-274
  Guid:                 d6072785-6fc0-5f83-9d49-11376e7f48b1 <- MST-leaf
  Guid:                 6bc9fc61-618a-535f-a629-98345e11336e <- MST-leaf-vmm3320-274
  Guid:                 4e4e06b6-8217-5cf0-8eff-ce5e987d531a <- MST-leaf-274
  Summary:              Multi-Stream Transport Device
  Plugin:               synapticsmst
  Flags:                updatable|registered
  Vendor:               Synaptics
  Version:              3.12.002
  VersionFormat:        triplet
  Icon:                 video-display
  Created:              2019-08-28
  Modified:             2019-08-28
  UpdateState:          success
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
