### PR TITLE
thunderbolt: Add support for kernel safety checks

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -232,6 +232,7 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %if 0%{?have_redfish}
 %config(noreplace)%{_sysconfdir}/fwupd/redfish.conf
 %endif
+%config(noreplace)%{_sysconfdir}/fwupd/thunderbolt.conf
 %dir %{_libexecdir}/fwupd
 %{_libexecdir}/fwupd/fwupd
 %{_libexecdir}/fwupd/fwupdtool

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -45,6 +45,9 @@ executable('tbtfwucli',
   ],
 )
 
+install_data(['thunderbolt.conf'],
+  install_dir:  join_paths(sysconfdir, 'fwupd')
+)
 # we use functions from 2.52 in the tests
 if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
   cargs += '-DFU_OFFLINE_DESTDIR="/tmp/fwupd-self-test"'

--- a/plugins/thunderbolt/thunderbolt.conf
+++ b/plugins/thunderbolt/thunderbolt.conf
@@ -1,0 +1,6 @@
+[thunderbolt]
+
+# Minimum kernel version to allow use of this plugin
+# It's important that all backports from this kernel have been
+# made if using an older kernel
+MinimumKernelVersion=4.13.0


### PR DESCRIPTION
There are commits to the Thunderbolt kernel driver that make sure
that the upgrade process goes smoothly.  If these commits aren't
present then it will look like a fwupd problem, when it's actually
a kernel problem.

In the case of backported kernels these might be missed.  When
running on an older kernel require `--force` to install firmware
unless the distribution vendor disables this behavior.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
