### PR TITLE
Use tree output for everything possible

### DIFF
--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -31,7 +31,7 @@ void		 fu_util_print_data		(const gchar	*title,
 guint		 fu_util_prompt_for_number	(guint		 maxnum);
 gboolean	 fu_util_prompt_for_boolean	(gboolean	 def);
 
-gboolean	 fu_util_print_device_tree	(GNode *n, gpointer data);
+void		 fu_util_print_tree		(GNode *n,	gpointer data);
 gboolean	 fu_util_is_interesting_device	(FwupdDevice	*dev);
 gchar		*fu_util_get_user_cache_path	(const gchar	*fn);
 SoupSession	*fu_util_setup_networking	(GError		**error);
@@ -72,6 +72,8 @@ gchar		*fu_util_convert_description	(const gchar	*xml,
 gchar		*fu_util_device_to_string	(FwupdDevice	*dev,
 						 guint		 idt);
 gchar		*fu_util_release_to_string	(FwupdRelease	*rel,
+						 guint		 idt);
+gchar		*fu_util_remote_to_string	(FwupdRemote *remote,
 						 guint		 idt);
 
 G_END_DECLS


### PR DESCRIPTION
This makes devices, releases, remotes, history and updates all use tree output.

I think it looks most successful when you look at what get-updates output can do:

```
No upgrades for Thunderbolt controller in Dell dock, current is 43.00: 40.00=older
No upgrades for Package level of Dell dock, current is 01.00.08.01: 01.00.04.01=older
No upgrades for RTS5413 in Dell dock, current is 01.21: 01.21=same
No upgrades for RTS5487 in Dell dock, current is 01.47: 01.47=same
No upgrades for VMM5331 in Dell dock, current is 05.04.00: 05.03.10=older
No upgrades for WD19TB, current is 01.00.00.02: 01.00.00.00=older
○
└─XPS 13 9380 System Firmware:
  │   Device ID:           6c24a747f97668873b761558e322398a91dbf394
  │   Current version:     0.1.6.0
  │   Minimum Version:     0.1.6.0
  │   Vendor:              Dell Inc.
  │   Flags:               internal|updatable|require-ac|supported|registered|needs-reboot
  │
  └─XPS 13 9380 System Update:
        Version:           0.1.7.0
        Remote ID:         lvfs
        Summary:           Firmware for the Dell XPS 13 9380
        License:           proprietary
        Size:              0x1563d67
        Vendor:            Dell Inc.
        Flags:             is-upgrade
        Description:       This stable release fixes the following issues:

       Fixed the issue where the Dell Power Manager displays an error when a 130W Type-C adapter is connected to the system.

       new functionality has also been added:

       Added a new feature to automatically suspend BitLocker before upgrading the firmware. After the firmware upgrade is complete, BitLocker is automatically enabled.
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
