### PR TITLE
flashrom: switch to upstream source

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -215,7 +215,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 # delete most files from the subproject
 rm ${RPM_BUILD_ROOT}%{_includedir}/libflashrom.h
 rm ${RPM_BUILD_ROOT}%{_libdir}/libflashrom.so
-rm ${RPM_BUILD_ROOT}%{_libdir}/pkgconfig/libflashrom.pc
+rm ${RPM_BUILD_ROOT}%{_libdir}/pkgconfig/flashrom.pc
 rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %endif
 

--- a/subprojects/flashrom.wrap
+++ b/subprojects/flashrom.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = flashrom
-url = https://github.com/fwupd/flashrom.git
-revision = wip/hughsie/fwupd
+url = https://github.com/flashrom/flashrom
+revision = 2f6936bd926b6d4f21680e2cdc160fc580c3ecb3


### PR DESCRIPTION
Once upstream flashrom tags a release (>1.1) this should be updated
and as it starts to flow into distros turned on by default.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
