### PR TITLE
dell: Use TSS to query and build TPM vendor strings for GUIDs

### DIFF
--- a/plugins/dell/README.md
+++ b/plugins/dell/README.md
@@ -16,6 +16,23 @@ These devices uses custom GUIDs for Dell-specific hardware.
 
 In both cases the `system-id` is derived from the SMBIOS Product SKU property.
 
+TPM GUIDs are also built using the TSS properties
+`TPM2_PT_FAMILY_INDICATOR`, `TPM2_PT_MANUFACTURER`, and `TPM2_PT_VENDOR_STRING_*`
+These are built hierarchically with more parts for each GUID:
+ * `DELL-TPM-$FAMILY-$MANUFACTURER-$VENDOR_STRING_1`
+ * `DELL-TPM-$FAMILY-$MANUFACTURER-$VENDOR_STRING_1$VENDOR_STRING_2`
+ * `DELL-TPM-$FAMILY-$MANUFACTURER-$VENDOR_STRING_1$VENDOR_STRING_2$VENDOR_STRING_3`
+ * `DELL-TPM-$FAMILY-$MANUFACTURER-$VENDOR_STRING_1$VENDOR_STRING_2$VENDOR_STRING_3$VENDOR_STRING_4`
+
+If there are non-ASCII values in any vendor string or any vendor is missing that octet will be skipped.
+
+Example resultant GUIDs from a real system containing a TPM from Nuvoton:
+```
+  Guid:                 7d65b10b-bb24-552d-ade5-590b3b278188 <- DELL-TPM-2.0-NTC-NPCT
+  Guid:                 6f5ddd3a-8339-5b2a-b9a6-cf3b92f6c86d <- DELL-TPM-2.0-NTC-NPCT75x
+  Guid:                 fe462d4a-e48f-5069-9172-47330fc5e838 <- DELL-TPM-2.0-NTC-NPCT75xrls
+```
+
 Build Requirements
 ------------------
 

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -637,8 +637,8 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		}
 		fu_device_set_flashes_left (dev, out->flashes_left);
 	} else {
-		g_debug ("%s updating disabled due to TPM ownership",
-			pretty_tpm_name);
+		fu_device_set_update_error (dev,
+					    "Updating disabled due to TPM ownership");
 	}
 	fu_plugin_device_register (plugin, dev);
 
@@ -666,8 +666,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		if ((out->status & TPM_OWN_MASK) == 0 && out->flashes_left > 0) {
 			fu_device_set_flashes_left (dev_alt, out->flashes_left);
 		} else {
-			g_debug ("%s mode switch disabled due to TPM ownership",
-				 pretty_tpm_name);
+			fu_device_set_update_error (dev_alt, "mode switch disabled due to TPM ownership");
 		}
 		fu_plugin_device_register (plugin, dev_alt);
 	}

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -68,6 +68,7 @@ fu_plugin_dell_tpm_func (void)
 	const guint8 fw[30] = { 'F', 'W', 0x00 };
 	gboolean ret;
 	struct tpm_status tpm_out;
+	const gchar *tpm_server_running = g_getenv ("TPM_SERVER_RUNNING");
 	g_autoptr(FuPlugin) plugin_dell = NULL;
 	g_autoptr(FuPlugin) plugin_uefi = NULL;
 	g_autoptr(GBytes) blob_fw = g_bytes_new_static (fw, sizeof(fw));
@@ -126,6 +127,13 @@ fu_plugin_dell_tpm_func (void)
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
 	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	if (!ret) {
+		if (tpm_server_running == NULL &&
+		    g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
+			g_test_skip ("no physical or simulated TPM 2.0 device available");
+			return;
+		}
+	}
 	g_assert_true (ret);
 	g_assert_cmpint (devices->len, ==, 2);
 

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -27,6 +27,7 @@ shared_module('fu_plugin_dell',
     plugin_deps,
     efivar,
     libsmbios_c,
+    tpm2tss,
   ],
 )
 
@@ -54,6 +55,7 @@ if get_option('tests')
       sqlite,
       libsmbios_c,
       valgrind,
+      tpm2tss,
     ],
     link_with : [
       libfwupdprivate,

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -835,7 +835,7 @@ fu_common_strstrip (const gchar *str)
 
 	/* find last non-space char */
 	for (guint i = head; str[i] != '\0'; i++) {
-		if (str[i] != ' ')
+		if (!g_ascii_isspace (str[i]))
 			tail = i;
 	}
 	return g_strndup (str + head, tail - head + 1);


### PR DESCRIPTION
These are a more scalable way to apply firmware across a variety of
platforms.

An example:
```
XPS 13 7390 TPM 2.0
  DeviceId:             c56e9f77cfee65151bdef90310776f9d62827f5a
  Guid:                 a4352c96-f8d7-526c-8485-7f84085f348e <- 0962-2.0
  Guid:                 6eaf178c-8b69-5016-9b51-1d866cd2ae2f <- DELL-TPM-2.0-NPCT
  Guid:                 9c4af226-139b-562a-b27c-98dcf46b4b72 <- DELL-TPM-2.0-NPCT-75x
  Guid:                 67c02020-e1c5-5ca7-ad89-7fa1dfde6465 <- DELL-TPM-2.0-NPCT-75x-\u0002\u0001
  Guid:                 7967697a-ee78-5dd4-846f-6eda95960009 <- DELL-TPM-2.0-NPCT-75x-\u0002\u0001-rls
  Summary:              Platform TPM device
  Plugin:               uefi
  Flags:                internal|require-ac|registered
  Vendor:               Dell Inc.
  Version:              7.2.1.0
  VersionFormat:        quad
  Icon:                 computer
  Created:              2019-09-04
```

When this system is queried using tpm2-tools:
```
$ sudo tpm2_getcap -c properties-fixed
TPM_PT_FAMILY_INDICATOR:
  as UINT32:                0x08322e3000
  as string:                "2.0"
TPM_PT_LEVEL:               0
TPM_PT_REVISION:            1.38
TPM_PT_DAY_OF_YEAR:         0x00000008
TPM_PT_YEAR:                0x000007e2
TPM_PT_MANUFACTURER:        0x4e544300
TPM_PT_VENDOR_STRING_1:
  as UINT32:                0x4e504354
  as string:                "NPCT"
TPM_PT_VENDOR_STRING_2:
  as UINT32:                0x37357800
  as string:                "75x"
TPM_PT_VENDOR_STRING_3:
  as UINT32:                0x02010024
  as string:                ""
TPM_PT_VENDOR_STRING_4:
  as UINT32:                0x726c7300
  as string:                "rls"
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
