### PR TITLE
fu-util: show release output in get-details again

### DIFF
--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -835,7 +835,7 @@ fu_common_strstrip (const gchar *str)
 
 	/* find last non-space char */
 	for (guint i = head; str[i] != '\0'; i++) {
-		if (str[i] != ' ')
+		if (!g_ascii_isspace (str[i]))
 			tail = i;
 	}
 	return g_strndup (str + head, tail - head + 1);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -824,12 +824,8 @@ fu_util_convert_description (const gchar *xml, GError **error)
 		g_set_object (&n, n2);
 	}
 
-	/* remove extra newline */
-	if (str->len > 0)
-		g_string_truncate (str, str->len - 1);
-
 	/* success */
-	return g_string_free (g_steal_pointer (&str), FALSE);
+	return fu_common_strstrip (str->str);
 }
 
 static gchar *

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -375,7 +375,10 @@ fu_util_build_device_tree (FuUtilPrivate *priv, GNode *root, GPtrArray *devs, Fw
 		    !fu_util_is_interesting_device (dev_tmp))
 			continue;
 		if (fwupd_device_get_parent (dev_tmp) == dev) {
+			FwupdRelease *rel = fwupd_device_get_release_default (dev_tmp);
 			GNode *child = g_node_append_data (root, dev_tmp);
+			if (rel != NULL)
+				g_node_append_data (child, rel);
 			fu_util_build_device_tree (priv, child, devs, dev_tmp);
 		}
 	}
@@ -497,12 +500,7 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 	array = fwupd_client_get_details (priv->client, values[0], NULL, error);
 	if (array == NULL)
 		return FALSE;
-	for (guint i = 0; i < array->len; i++) {
-		FwupdDevice *dev = g_ptr_array_index (array, i);
-		if (!fu_util_filter_device (priv, dev))
-			continue;
-		g_node_append_data (root, dev);
-	}
+	fu_util_build_device_tree (priv, root, array, NULL);
 	fu_util_print_tree (root, priv);
 
 	return TRUE;


### PR DESCRIPTION
This was lost in the move to tree output
```
$ fwupdmgr get-details tpm.cab
Decompressing…           [***************************************]
○
└─XPS 13 9380 TPM 2.0:
  │   Device ID:           1a433daa3acb71e6befadcf2b1a783c1549663b1
  │   Description:         Updating the system firmware improves performance.
  │
  │   Flags:               internal|updatable|require-ac|registered|needs-reboot
  │
  └─TPM 2.0 Update:
        Version:           7.2.0.2
        Summary:           Firmware for the Dell TPM 2.0
        License:           proprietary
        Size:              1.1 MB
        Vendor:            Dell Inc.
        Flags:             none
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
