### PR TITLE
fu-util-common: try to show DMI product name only once

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -40,6 +40,7 @@ typedef struct {
 	gboolean			 tainted;
 	guint				 percentage;
 	gchar				*daemon_version;
+	gchar				*host_product;
 	GDBusConnection			*conn;
 	GDBusProxy			*proxy;
 } FwupdClientPrivate;
@@ -59,6 +60,7 @@ enum {
 	PROP_PERCENTAGE,
 	PROP_DAEMON_VERSION,
 	PROP_TAINTED,
+	PROP_HOST_PRODUCT,
 	PROP_LAST
 };
 
@@ -101,6 +103,15 @@ fwupd_client_helper_new (void)
 #pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FwupdClientHelper, fwupd_client_helper_free)
 #pragma clang diagnostic pop
+
+static void
+fwupd_client_set_host_product (FwupdClient *client, const gchar *host_product)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_free (priv->host_product);
+	priv->host_product = g_strdup (host_product);
+	g_object_notify (G_OBJECT (client), "host-product");
+}
 
 static void
 fwupd_client_set_daemon_version (FwupdClient *client, const gchar *daemon_version)
@@ -154,6 +165,12 @@ fwupd_client_properties_changed_cb (GDBusProxy *proxy,
 		val = g_dbus_proxy_get_cached_property (proxy, "DaemonVersion");
 		if (val != NULL)
 			fwupd_client_set_daemon_version (client, g_variant_get_string (val, NULL));
+	}
+	if (g_variant_dict_contains (dict, "HostProduct")) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property (proxy, "HostProduct");
+		if (val != NULL)
+			fwupd_client_set_host_product (client, g_variant_get_string (val, NULL));
 	}
 }
 
@@ -249,6 +266,10 @@ fwupd_client_connect (FwupdClient *client, GCancellable *cancellable, GError **e
 	val2 = g_dbus_proxy_get_cached_property (priv->proxy, "Tainted");
 	if (val2 != NULL)
 		priv->tainted = g_variant_get_boolean (val2);
+	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostProduct");
+	if (val != NULL)
+		fwupd_client_set_host_product (client, g_variant_get_string (val, NULL));
+
 	return TRUE;
 }
 
@@ -1151,6 +1172,24 @@ fwupd_client_get_daemon_version (FwupdClient *client)
 }
 
 /**
+ * fwupd_client_get_host_product:
+ * @client: A #FwupdClient
+ *
+ * Gets the string that represents the host running fwupd
+ *
+ * Returns: a string, or %NULL for unknown.
+ *
+ * Since: 1.3.1
+ **/
+const gchar *
+fwupd_client_get_host_product (FwupdClient *client)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
+	return priv->host_product;
+}
+
+/**
  * fwupd_client_get_status:
  * @client: A #FwupdClient
  *
@@ -1672,6 +1711,9 @@ fwupd_client_get_property (GObject *object, guint prop_id,
 	case PROP_DAEMON_VERSION:
 		g_value_set_string (value, priv->daemon_version);
 		break;
+	case PROP_HOST_PRODUCT:
+		g_value_set_string (value, priv->host_product);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
@@ -1836,6 +1878,18 @@ fwupd_client_class_init (FwupdClientClass *klass)
 	pspec = g_param_spec_string ("daemon-version", NULL, NULL,
 				     NULL, G_PARAM_READABLE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property (object_class, PROP_DAEMON_VERSION, pspec);
+
+	/**
+	 * FwupdClient:host-product:
+	 *
+	 * The host product string
+	 *
+	 * Since: 1.3.1
+	 */
+	pspec = g_param_spec_string ("host-product", NULL, NULL,
+				     NULL, G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_DAEMON_VERSION, pspec);
+
 }
 
 static void
@@ -1850,6 +1904,7 @@ fwupd_client_finalize (GObject *object)
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 
 	g_free (priv->daemon_version);
+	g_free (priv->host_product);
 	if (priv->conn != NULL)
 		g_object_unref (priv->conn);
 	if (priv->proxy != NULL)

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -127,6 +127,7 @@ FwupdStatus	 fwupd_client_get_status		(FwupdClient	*client);
 gboolean	 fwupd_client_get_tainted		(FwupdClient	*client);
 guint		 fwupd_client_get_percentage		(FwupdClient	*client);
 const gchar	*fwupd_client_get_daemon_version	(FwupdClient	*client);
+const gchar	*fwupd_client_get_host_product		(FwupdClient	*client);
 
 GPtrArray	*fwupd_client_get_remotes		(FwupdClient	*client,
 							 GCancellable	*cancellable,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -374,6 +374,7 @@ LIBFWUPD_1.2.10 {
 
 LIBFWUPD_1.3.1 {
   global:
+    fwupd_client_get_host_product;
     fwupd_remote_get_remotes_dir;
     fwupd_remote_set_remotes_dir;
   local: *;

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -654,7 +654,6 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	struct tpm_status *out = NULL;
 	g_autoptr (FuDevice) dev_alt = NULL;
 	g_autoptr (FuDevice) dev = NULL;
-	const gchar *product_name = "Unknown";
 
 	fu_dell_clear_smi (data->smi_obj);
 	out = (struct tpm_status *) data->smi_obj->output;
@@ -721,11 +720,8 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 						     FWUPD_VERSION_FORMAT_QUAD);
 
 	/* make it clear that the TPM is a discrete device of the product */
-	if (!data->smi_obj->fake_smbios) {
-		product_name = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
-	}
-	pretty_tpm_name = g_strdup_printf ("%s TPM %s", product_name, tpm_mode);
-	pretty_tpm_name_alt = g_strdup_printf ("%s TPM %s", product_name, tpm_mode_alt);
+	pretty_tpm_name = g_strdup_printf ("TPM %s", tpm_mode);
+	pretty_tpm_name_alt = g_strdup_printf ("TPM %s", tpm_mode_alt);
 
 	/* build Standard device nodes */
 	dev = fu_device_new ();

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -138,12 +138,12 @@ fu_plugin_dell_tpm_func (void)
 	g_assert_cmpint (devices->len, ==, 2);
 
 	/* make sure 2.0 is locked */
-	device_v20 = _find_device_by_name (devices, "Unknown TPM 2.0");
+	device_v20 = _find_device_by_name (devices, "TPM 2.0");
 	g_assert_nonnull (device_v20);
 	g_assert_true (fu_device_has_flag (device_v20, FWUPD_DEVICE_FLAG_LOCKED));
 
 	/* make sure not allowed to flash 1.2 */
-	device_v12 = _find_device_by_name (devices, "Unknown TPM 1.2");
+	device_v12 = _find_device_by_name (devices, "TPM 1.2");
 	g_assert_nonnull (device_v12);
 	g_assert_false (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 
@@ -172,12 +172,12 @@ fu_plugin_dell_tpm_func (void)
 	g_assert (ret);
 
 	/* make sure not allowed to flash 1.2 */
-	device_v12 = _find_device_by_name (devices, "Unknown TPM 1.2");
+	device_v12 = _find_device_by_name (devices, "TPM 1.2");
 	g_assert_nonnull (device_v12);
 	g_assert_false (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 
 	/* try to unlock 2.0 */
-	device_v20 = _find_device_by_name (devices, "Unknown TPM 2.0");
+	device_v20 = _find_device_by_name (devices, "TPM 2.0");
 	g_assert_nonnull (device_v20);
 	ret = fu_plugin_runner_unlock (plugin_uefi, device_v20, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
@@ -203,10 +203,10 @@ fu_plugin_dell_tpm_func (void)
 	g_assert (ret);
 
 	/* make sure allowed to flash 1.2 but not 2.0 */
-	device_v12 = _find_device_by_name (devices, "Unknown TPM 1.2");
+	device_v12 = _find_device_by_name (devices, "TPM 1.2");
 	g_assert_nonnull (device_v12);
 	g_assert_true (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
-	device_v20 = _find_device_by_name (devices, "Unknown TPM 2.0");
+	device_v20 = _find_device_by_name (devices, "TPM 2.0");
 	g_assert_nonnull (device_v20);
 	g_assert_false (fu_device_has_flag (device_v20, FWUPD_DEVICE_FLAG_UPDATABLE));
 
@@ -238,10 +238,10 @@ fu_plugin_dell_tpm_func (void)
 	g_assert (ret);
 
 	/* make sure allowed to flash 2.0 but not 1.2 */
-	device_v20 = _find_device_by_name (devices, "Unknown TPM 2.0");
+	device_v20 = _find_device_by_name (devices, "TPM 2.0");
 	g_assert_nonnull (device_v20);
 	g_assert_true (fu_device_has_flag (device_v20, FWUPD_DEVICE_FLAG_UPDATABLE));
-	device_v12 = _find_device_by_name (devices, "Unknown TPM 1.2");
+	device_v12 = _find_device_by_name (devices, "TPM 1.2");
 	g_assert_nonnull (device_v12);
 	g_assert_false (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -380,8 +380,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 
 	fu_device_set_metadata (dev, "sysfs-path", devpath);
 	name = g_udev_device_get_sysfs_attr (device, "device_name");
-	if (name == NULL && is_host)
-		name = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
 	if (name != NULL) {
 		if (is_host) {
 			g_autofree gchar *pretty_name = NULL;

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -505,16 +505,8 @@ fu_plugin_uefi_get_name_for_type (FuPlugin *plugin, FuUefiDeviceKind device_kind
 
 	/* set Display Name prefix for capsules that are not PCI cards */
 	display_name = g_string_new (fu_plugin_uefi_uefi_type_to_string (device_kind));
-	if (device_kind == FU_UEFI_DEVICE_KIND_DEVICE_FIRMWARE) {
+	if (device_kind == FU_UEFI_DEVICE_KIND_DEVICE_FIRMWARE)
 		g_string_prepend (display_name, "UEFI ");
-	} else {
-		const gchar *tmp;
-		tmp = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
-		if (tmp != NULL && tmp[0] != '\0') {
-			g_string_prepend (display_name, " ");
-			g_string_prepend (display_name, tmp);
-		}
-	}
 	return g_string_free (display_name, FALSE);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4145,6 +4145,13 @@ fu_engine_get_tainted (FuEngine *self)
 	return self->tainted;
 }
 
+const gchar *
+fu_engine_get_host_product (FuEngine *self)
+{
+	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);
+	return fu_hwids_get_value (self->hwids, FU_HWIDS_KEY_PRODUCT_NAME);
+}
+
 gboolean
 fu_engine_load_plugins (FuEngine *self, GError **error)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -48,6 +48,7 @@ gboolean	 fu_engine_load				(FuEngine	*self,
 gboolean	 fu_engine_load_plugins			(FuEngine	*self,
 							 GError		**error);
 gboolean	 fu_engine_get_tainted			(FuEngine	*self);
+const gchar	*fu_engine_get_host_product		(FuEngine *self);
 FwupdStatus	 fu_engine_get_status			(FuEngine	*self);
 XbSilo		*fu_engine_get_silo_from_blob		(FuEngine	*self,
 							 GBytes		*blob_cab,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1363,6 +1363,9 @@ fu_main_daemon_get_property (GDBusConnection *connection_, const gchar *sender,
 	if (g_strcmp0 (property_name, "Status") == 0)
 		return g_variant_new_uint32 (fu_engine_get_status (priv->engine));
 
+	if (g_strcmp0 (property_name, "HostProduct") == 0)
+		return g_variant_new_string (fu_engine_get_host_product (priv->engine));
+
 	/* return an error */
 	g_set_error (error,
 		     G_DBUS_ERROR,

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -294,11 +294,18 @@ fu_util_filter_device (FuUtilPrivate *priv, FwupdDevice *dev)
 	return TRUE;
 }
 
+static gchar *
+fu_util_get_tree_title (FuUtilPrivate *priv)
+{
+	return g_strdup (fu_engine_get_host_product (priv->engine));
+}
+
 static gboolean
 fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* load engine */
 	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
@@ -336,7 +343,7 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 		}
 	}
 	if (g_node_n_nodes (root, G_TRAVERSE_ALL) > 1)
-		fu_util_print_tree (root, priv);
+		fu_util_print_tree (root, title);
 	/* save the device state for other applications to see */
 	if (!fu_util_save_current_state (priv, error))
 		return FALSE;
@@ -350,6 +357,7 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) array = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 	gint fd;
 
 	/* load engine */
@@ -387,7 +395,7 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		g_node_append_data (root, dev);
 	}
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }
@@ -433,6 +441,7 @@ static gboolean
 fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 	g_autoptr(GPtrArray) devs = NULL;
 
 	/* load engine */
@@ -451,7 +460,7 @@ fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 		return TRUE;
 	}
 	fu_util_build_device_tree (priv, root, devs, NULL);
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	/* save the device state for other applications to see */
 	return fu_util_save_current_state (priv, error);
@@ -1340,6 +1349,7 @@ fu_util_get_history (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* load engine */
 	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
@@ -1357,7 +1367,7 @@ fu_util_get_history (FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		g_node_append_data (root, dev);
 	}
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -223,6 +223,9 @@ fu_util_is_interesting_device (FwupdDevice *dev)
 		return TRUE;
 	if (fwupd_device_get_update_error (dev) != NULL)
 		return TRUE;
+	/* device not plugged in, get-details */
+	if (fwupd_device_get_flags (dev) == 0)
+		return TRUE;
 	return FALSE;
 }
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -160,9 +160,11 @@ fu_util_traverse_tree (GNode *n, gpointer data)
 
 	/* root node */
 	if (n->data == NULL && g_getenv ("FWUPD_VERBOSE") == NULL) {
-		g_print ("○\n");
+		const gchar *str = data;
+		g_print ("%s\n│\n", str != NULL ? str : "○");
 		return FALSE;
 	}
+
 	if (n->parent == NULL)
 		return FALSE;
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -384,11 +384,18 @@ fu_util_build_device_tree (FuUtilPrivate *priv, GNode *root, GPtrArray *devs, Fw
 	}
 }
 
+static gchar *
+fu_util_get_tree_title (FuUtilPrivate *priv)
+{
+	return g_strdup (fwupd_client_get_host_product (priv->client));
+}
+
 static gboolean
 fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GNode) root = g_node_new (NULL);
 	g_autoptr(GPtrArray) devs = NULL;
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* get results from daemon */
 	devs = fwupd_client_get_devices (priv->client, NULL, error);
@@ -402,7 +409,7 @@ fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 		return TRUE;
 	}
 	fu_util_build_device_tree (priv, root, devs, NULL);
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	/* nag? */
 	if (!fu_util_perhaps_show_unreported (priv, error))
@@ -488,6 +495,7 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) array = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* check args */
 	if (g_strv_length (values) != 1) {
@@ -501,7 +509,7 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 	if (array == NULL)
 		return FALSE;
 	fu_util_build_device_tree (priv, root, array, NULL);
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }
@@ -787,6 +795,7 @@ fu_util_get_history (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* get all devices from the history database */
 	devices = fwupd_client_get_history (priv->client, NULL, error);
@@ -800,7 +809,7 @@ fu_util_get_history (FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		g_node_append_data (root, dev);
 	}
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }
@@ -1193,6 +1202,7 @@ fu_util_get_releases (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FwupdDevice) dev = NULL;
 	g_autoptr(GPtrArray) rels = NULL;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	dev = fu_util_get_device_or_prompt (priv, values, error);
 	if (dev == NULL)
@@ -1213,7 +1223,7 @@ fu_util_get_releases (FuUtilPrivate *priv, gchar **values, GError **error)
 		FwupdRelease *rel = g_ptr_array_index (rels, i);
 		g_node_append_data (root, rel);
 	}
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }
@@ -1400,6 +1410,7 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) devices = NULL;
 	gboolean supported = FALSE;
 	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	/* are the remotes very old */
 	if (!fu_util_perhaps_refresh_remotes (priv, error))
@@ -1440,7 +1451,7 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	if (g_node_n_nodes (root, G_TRAVERSE_ALL) > 1)
-		fu_util_print_tree (root, priv);
+		fu_util_print_tree (root, title);
 
 	/* nag? */
 	if (!fu_util_perhaps_show_unreported (priv, error))
@@ -1464,6 +1475,7 @@ fu_util_get_remotes (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GNode) root = g_node_new (NULL);
 	g_autoptr(GPtrArray) remotes = NULL;
+	g_autofree gchar *title = fu_util_get_tree_title (priv);
 
 	remotes = fwupd_client_get_remotes (priv->client, NULL, error);
 	if (remotes == NULL)
@@ -1479,7 +1491,7 @@ fu_util_get_remotes (FuUtilPrivate *priv, gchar **values, GError **error)
 		FwupdRemote *remote_tmp = g_ptr_array_index (remotes, i);
 		g_node_append_data (root, remote_tmp);
 	}
-	fu_util_print_tree (root, priv);
+	fu_util_print_tree (root, title);
 
 	return TRUE;
 }

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -23,6 +23,17 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='HostProduct' type='s' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The product name string for the host.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='Tainted' type='b' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
Before:
```
○
├─XPS 13 7390 TPM 2.0:
│     Device ID:           c56e9f77cfee65151bdef90310776f9d62827f5a
│     Summary:             Platform TPM device
│     Current version:     7.2.1.0
│     Vendor:              Dell Inc.
│     Update Error:        Updating disabled due to TPM ownership
│     Flags:               internal|require-ac|registered
└─XPS 13 7390 System Firmware:
      Device ID:           b6c08fb9e5384d9d101853cc1ca20cf0ce2df2e2
      Current version:     0.1.1.1
      Minimum Version:     0.1.1.1
      Vendor:              Dell Inc.
      Flags:               internal|updatable|require-ac|registered|needs-reboot

```

After:
```
○ XPS 13 7390
│
├─TPM 2.0:
│     Device ID:           c56e9f77cfee65151bdef90310776f9d62827f5a
│     Summary:             Platform TPM device
│     Current version:     7.2.1.0
│     Vendor:              Dell Inc.
│     Update Error:        Updating disabled due to TPM ownership
│     Flags:               internal|require-ac|registered
└─System Firmware:
      Device ID:           b6c08fb9e5384d9d101853cc1ca20cf0ce2df2e2
      Current version:     0.1.1.1
      Minimum Version:     0.1.1.1
      Vendor:              Dell Inc.
      Flags:               internal|updatable|require-ac|registered|needs-reboot
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
