### PR TITLE
Add a DMI quirk for the Minnowboard Turbot

### DIFF
--- a/plugins/uefi/uefi.quirk
+++ b/plugins/uefi/uefi.quirk
@@ -20,3 +20,7 @@ Flags = use-shim-unique
 # Star Labs Lite (Mk II)
 [Guid=797f8bae-0ea2-4c0f-8a30-7d10ccfacbc0]
 Flags = use-shim-unique,no-ux-capsule
+
+# Silicom Minnowboard Turbot D0/D1 PLATFORM
+[HwId=386c2f52-44ec-55d3-b802-47631bfb8451]
+Flags = uefi-force-enable

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -151,5 +151,7 @@ void		 fu_plugin_add_runtime_version		(FuPlugin	*self,
 void		 fu_plugin_add_compile_version		(FuPlugin	*self,
 							 const gchar	*component_id,
 							 const gchar	*version);
+gboolean	 fu_plugin_has_custom_flag		(FuPlugin	*self,
+							 const gchar	*flag);
 
 G_END_DECLS


### PR DESCRIPTION
The fwupd UEFI plugin refuses to start if bit 3 of the "BIOS Characteristics
Extension Byte 2" (13h) is cleared. Bit 3 is UEFI Specification is supported.

Fixes https://github.com/fwupd/fwupd/issues/1342
