### PR TITLE
Move D-Bus conf file to datadir/dbus-1/system.d

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -265,7 +265,7 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/vendor-directory.conf
 %config(noreplace)%{_sysconfdir}/pki/fwupd
 %{_sysconfdir}/pki/fwupd-metadata
-%{_sysconfdir}/dbus-1/system.d/org.freedesktop.fwupd.conf
+%{_datadir}/dbus-1/system.d/org.freedesktop.fwupd.conf
 %{_datadir}/bash-completion/completions/fwupdmgr
 %{_datadir}/bash-completion/completions/fwupdtool
 %{_datadir}/bash-completion/completions/fwupdagent

--- a/data/meson.build
+++ b/data/meson.build
@@ -27,7 +27,7 @@ install_data(['org.freedesktop.fwupd.svg'],
 
 if build_daemon
   install_data(['org.freedesktop.fwupd.conf'],
-    install_dir : join_paths(sysconfdir, 'dbus-1', 'system.d')
+    install_dir : join_paths(datadir, 'dbus-1', 'system.d')
   )
   install_data(['90-fwupd-devices.rules'],
     install_dir : join_paths(udevdir, 'rules.d')


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
