### PR TITLE
Support <issues> in AppStream metadata

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -17,6 +17,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */
 #define FWUPD_RESULT_KEY_PROTOCOL		"Protocol"	/* s */
 #define FWUPD_RESULT_KEY_CATEGORIES		"Categories"	/* as */
+#define FWUPD_RESULT_KEY_ISSUES			"Issues"	/* as */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -31,6 +31,7 @@ static void fwupd_release_finalize	 (GObject *object);
 typedef struct {
 	GPtrArray			*checksums;
 	GPtrArray			*categories;
+	GPtrArray			*issues;
 	GHashTable			*metadata;
 	gchar				*description;
 	gchar				*filename;
@@ -237,6 +238,47 @@ fwupd_release_set_protocol (FwupdRelease *release, const gchar *protocol)
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
 	g_free (priv->protocol);
 	priv->protocol = g_strdup (protocol);
+}
+
+/**
+ * fwupd_release_get_issues:
+ * @release: A #FwupdRelease
+ *
+ * Gets the list of issues fixed in this release.
+ *
+ * Returns: (element-type utf8) (transfer none): the issues, which may be empty
+ *
+ * Since: 1.3.2
+ **/
+GPtrArray *
+fwupd_release_get_issues (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->issues;
+}
+
+/**
+ * fwupd_release_add_issue:
+ * @release: A #FwupdRelease
+ * @issue: the update issue, e.g. `CVE-2019-12345`
+ *
+ * Adds an resolved issue to this release.
+ *
+ * Since: 1.3.2
+ **/
+void
+fwupd_release_add_issue (FwupdRelease *release, const gchar *issue)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_return_if_fail (issue != NULL);
+	for (guint i = 0; i < priv->issues->len; i++) {
+		const gchar *issue_tmp = g_ptr_array_index (priv->issues, i);
+		if (g_strcmp0 (issue_tmp, issue) == 0)
+			return;
+	}
+	g_ptr_array_add (priv->issues, g_strdup (issue));
 }
 
 /**
@@ -1112,6 +1154,14 @@ fwupd_release_to_variant (FwupdRelease *release)
 				       FWUPD_RESULT_KEY_CATEGORIES,
 				       g_variant_new_strv (strv, -1));
 	}
+	if (priv->issues->len > 0) {
+		g_autofree const gchar **strv = g_new0 (const gchar *, priv->issues->len + 1);
+		for (guint i = 0; i < priv->issues->len; i++)
+			strv[i] = (const gchar *) g_ptr_array_index (priv->issues, i);
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_ISSUES,
+				       g_variant_new_strv (strv, -1));
+	}
 	if (priv->checksums->len > 0) {
 		g_autoptr(GString) str = g_string_new ("");
 		for (guint i = 0; i < priv->checksums->len; i++) {
@@ -1216,6 +1266,12 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 		g_autofree const gchar **strv = g_variant_get_strv (value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_release_add_category (release, strv[i]);
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_ISSUES) == 0) {
+		g_autofree const gchar **strv = g_variant_get_strv (value, NULL);
+		for (guint i = 0; strv[i] != NULL; i++)
+			fwupd_release_add_issue (release, strv[i]);
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_CHECKSUM) == 0) {
@@ -1374,6 +1430,15 @@ fwupd_release_to_json (FwupdRelease *release, JsonBuilder *builder)
 		}
 		json_builder_end_array (builder);
 	}
+	if (priv->issues->len > 0) {
+		json_builder_set_member_name (builder, FWUPD_RESULT_KEY_ISSUES);
+		json_builder_begin_array (builder);
+		for (guint i = 0; i < priv->issues->len; i++) {
+			const gchar *tmp = g_ptr_array_index (priv->issues, i);
+			json_builder_add_string_value (builder, tmp);
+		}
+		json_builder_end_array (builder);
+	}
 	if (priv->checksums->len > 0) {
 		json_builder_set_member_name (builder, FWUPD_RESULT_KEY_CHECKSUM);
 		json_builder_begin_array (builder);
@@ -1445,6 +1510,10 @@ fwupd_release_to_string (FwupdRelease *release)
 		const gchar *tmp = g_ptr_array_index (priv->categories, i);
 		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_CATEGORIES, tmp);
 	}
+	for (guint i = 0; i < priv->issues->len; i++) {
+		const gchar *tmp = g_ptr_array_index (priv->issues, i);
+		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_ISSUES, tmp);
+	}
 	for (guint i = 0; i < priv->checksums->len; i++) {
 		const gchar *checksum = g_ptr_array_index (priv->checksums, i);
 		g_autofree gchar *checksum_display = fwupd_checksum_format_for_display (checksum);
@@ -1484,6 +1553,7 @@ fwupd_release_init (FwupdRelease *release)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	priv->categories = g_ptr_array_new_with_free_func (g_free);
+	priv->issues = g_ptr_array_new_with_free_func (g_free);
 	priv->checksums = g_ptr_array_new_with_free_func (g_free);
 	priv->metadata = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 }
@@ -1510,6 +1580,7 @@ fwupd_release_finalize (GObject *object)
 	g_free (priv->remote_id);
 	g_free (priv->update_message);
 	g_ptr_array_unref (priv->categories);
+	g_ptr_array_unref (priv->issues);
 	g_ptr_array_unref (priv->checksums);
 	g_hash_table_unref (priv->metadata);
 

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -37,6 +37,9 @@ void		 fwupd_release_set_version		(FwupdRelease	*release,
 const gchar	*fwupd_release_get_uri			(FwupdRelease	*release);
 void		 fwupd_release_set_uri			(FwupdRelease	*release,
 							 const gchar	*uri);
+GPtrArray	*fwupd_release_get_issues		(FwupdRelease	*release);
+void		 fwupd_release_add_issue		(FwupdRelease	*release,
+							 const gchar	*issue);
 GPtrArray	*fwupd_release_get_categories		(FwupdRelease	*release);
 void		 fwupd_release_add_category		(FwupdRelease	*release,
 							 const gchar	*category);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -379,3 +379,10 @@ LIBFWUPD_1.3.1 {
     fwupd_remote_set_remotes_dir;
   local: *;
 } LIBFWUPD_1.2.10;
+
+LIBFWUPD_1.3.2 {
+  global:
+    fwupd_release_add_issue;
+    fwupd_release_get_issues;
+  local: *;
+} LIBFWUPD_1.3.1;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -327,6 +327,7 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	guint64 tmp64;
 	g_autofree gchar *version_rel = NULL;
 	g_autoptr(GPtrArray) cats = NULL;
+	g_autoptr(GPtrArray) issues = NULL;
 	g_autoptr(XbNode) description = NULL;
 
 	/* set from the component */
@@ -417,6 +418,13 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 		for (guint i = 0; i < cats->len; i++) {
 			XbNode *n = g_ptr_array_index (cats, i);
 			fwupd_release_add_category (rel, xb_node_get_text (n));
+		}
+	}
+	issues = xb_node_query (component, "issues/issue", 0, NULL);
+	if (issues != NULL) {
+		for (guint i = 0; i < issues->len; i++) {
+			XbNode *n = g_ptr_array_index (issues, i);
+			fwupd_release_add_issue (rel, xb_node_get_text (n));
 		}
 	}
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1034,6 +1034,7 @@ fu_util_device_to_string (FwupdDevice *dev, guint idt)
 gchar *
 fu_util_release_to_string (FwupdRelease *rel, guint idt)
 {
+	GPtrArray *issues = fwupd_release_get_issues (rel);
 	GString *str = g_string_new (NULL);
 	guint64 flags = fwupd_release_get_flags (rel);
 	g_autoptr(GString) flags_str = g_string_new (NULL);
@@ -1112,6 +1113,15 @@ fu_util_release_to_string (FwupdRelease *rel, guint idt)
 		desc = fu_util_convert_description (fwupd_release_get_description (rel), NULL);
 		/* TRANSLATORS: multiline description of device */
 		fu_common_string_append_kv (str, idt + 1, _("Description"), desc);
+	}
+	for (guint i = 0; i < issues->len; i++) {
+		const gchar *issue = g_ptr_array_index (issues, i);
+		if (i == 0) {
+			/* TRANSLATORS: issue fixed with the release, e.g. CVE */
+			fu_common_string_append_kv (str, idt + 1, ngettext ("Issue", "Issues", issues->len), issue);
+		} else {
+			fu_common_string_append_kv (str, idt + 1, "", issue);
+		}
 	}
 
 	return g_string_free (str, FALSE);


### PR DESCRIPTION
When the LVFS switches over to outputting <issues> rather than appending to the
update description we need to be in a position to display the new data.
