### PR TITLE
Do not crash when starting tpm2-abrmd

### DIFF
--- a/src/fu-debug.c
+++ b/src/fu-debug.c
@@ -166,7 +166,6 @@ fu_debug_post_parse_hook (GOptionContext *context,
 	}
 
 	/* redirect all domains to be able to change FWUPD_VERBOSE at runtime */
-	g_log_set_fatal_mask (NULL, G_LOG_LEVEL_MASK);
 	g_log_set_default_handler (fu_debug_handler_cb, self);
 
 	/* are we on an actual TTY? */


### PR DESCRIPTION
The value G_LOG_LEVEL_MASK includes debugging, which tpm2-abrmd is certainly
allowed to use.

Fixes https://github.com/fwupd/fwupd/issues/1353

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
