### PR TITLE
uefi, dell-esrt: Show firmware version when capsule updates unavailable

### DIFF
--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -87,6 +87,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "uefi");
 }
 
 gboolean
@@ -159,9 +160,10 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	g_autoptr(FuDevice) dev = fu_device_new ();
 
 	/* create a dummy device so we can unlock the feature */
-	fu_device_set_id (dev, "UEFI-dummy-dev0");
+	fu_device_set_id (dev, "UEFI-dummy");
 	fu_device_set_name (dev, "Dell UEFI updates");
 	fu_device_set_summary (dev, "Enable UEFI Update Functionality");
+	fu_device_add_instance_id (dev, "main-system-firmware");
 	fu_device_add_guid (dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version (dev, "0", FWUPD_VERSION_FORMAT_NUMBER);
 	fu_device_add_icon (dev, "computer");

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -773,7 +773,7 @@ fu_plugin_unlock (FuPlugin *plugin, FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_plugin_uefi_create_dummy (FuPlugin *plugin, GError **error)
+fu_plugin_uefi_create_dummy (FuPlugin *plugin, const gchar *reason, GError **error)
 {
 	const gchar *key;
 	g_autoptr(FuDevice) dev = fu_device_new ();
@@ -786,8 +786,7 @@ fu_plugin_uefi_create_dummy (FuPlugin *plugin, GError **error)
 	key = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION);
 	if (key != NULL)
 		fu_device_set_version (dev, key, FWUPD_VERSION_FORMAT_PLAIN);
-	key = "Firmware can not be updated in legacy mode, switch to UEFI mode.";
-	fu_device_set_update_error (dev, key);
+	fu_device_set_update_error (dev, reason);
 
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
@@ -820,16 +819,20 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 
 	/* are the EFI dirs set up so we can update each device */
 	if (!fu_uefi_vars_supported (&error_local)) {
+		const gchar *reason = "Firmware can not be updated in legacy mode, switch to UEFI mode";
 		g_warning ("%s", error_local->message);
-		return fu_plugin_uefi_create_dummy (plugin, error);
+		return fu_plugin_uefi_create_dummy (plugin, reason, error);
 	}
 
 	/* get the directory of ESRT entries */
 	sysfsfwdir = fu_common_get_path (FU_PATH_KIND_SYSFSDIR_FW);
 	esrt_path = g_build_filename (sysfsfwdir, "efi", "esrt", NULL);
-	entries = fu_uefi_get_esrt_entry_paths (esrt_path, error);
-	if (entries == NULL)
-		return FALSE;
+	entries = fu_uefi_get_esrt_entry_paths (esrt_path, &error_local);
+	if (entries == NULL) {
+		const gchar *reason = "UEFI Capsule updates not available or enabled";
+		g_warning ("%s", error_local->message);
+		return fu_plugin_uefi_create_dummy (plugin, reason, error);
+	}
 
 	/* make sure that efivarfs is rw */
 	if (!fu_plugin_uefi_ensure_efivarfs_rw (&error_efivarfs))


### PR DESCRIPTION
When the system doesn't support UEFI capsule updates no firmware version
is displayed for the BIOS.  Fix this by creating a dummy device:
```
├─System Firmware:
│     Device ID:           123fd4143619569d8ddb6ea47d1d3911eb5ef07a
│     Current version:     1.7.0
│     Vendor:              Dell Inc.
│     Update Error:        UEFI Capsule updates not available or enabled
│     Flags:               internal|require-ac|registered|needs-reboot
```

If the dell-esrt plugin determines that capsule updates can be enabled
however, make the device it creates replace the dummy device:
```
├─Dell UEFI updates:
│     Device ID:           123fd4143619569d8ddb6ea47d1d3911eb5ef07a
│     Summary:             Enable UEFI Update Functionality
│     Current version:     0
│     Update Error:        Firmware updates disabled; run 'fwupdmgr unlock' to enable
│     Flags:               locked|supported|registered|needs-reboot
```

Fixes: #1366

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
