### PR TITLE
Allow parsing a raw SREC file

### DIFF
--- a/src/fu-firmware.h
+++ b/src/fu-firmware.h
@@ -30,14 +30,22 @@ struct _FuFirmwareClass
 	void			 (*to_string)		(FuFirmware	*self,
 							 guint		 indent,
 							 GString	*str);
+	gboolean		 (*tokenize)		(FuFirmware	*self,
+							 GBytes		*fw,
+							 FwupdInstallFlags flags,
+							 GError		**error);
 	/*< private >*/
-	gpointer		 padding[29];
+	gpointer		 padding[28];
 };
 
 FuFirmware	*fu_firmware_new			(void);
 FuFirmware	*fu_firmware_new_from_bytes		(GBytes		*fw);
 gchar		*fu_firmware_to_string			(FuFirmware	*self);
 
+gboolean	 fu_firmware_tokenize			(FuFirmware	*self,
+							 GBytes		*fw,
+							 FwupdInstallFlags flags,
+							 GError		**error);
 gboolean	 fu_firmware_parse			(FuFirmware	*self,
 							 GBytes		*fw,
 							 FwupdInstallFlags flags,

--- a/src/fu-srec-firmware.c
+++ b/src/fu-srec-firmware.c
@@ -16,34 +16,64 @@
 
 struct _FuSrecFirmware {
 	FuFirmware		 parent_instance;
+	GPtrArray		*records;
 };
 
 G_DEFINE_TYPE (FuSrecFirmware, fu_srec_firmware, FU_TYPE_FIRMWARE)
 
-static gboolean
-fu_srec_firmware_parse (FuFirmware *firmware,
-			GBytes *fw,
-			guint64 addr_start,
-			guint64 addr_end,
-			FwupdInstallFlags flags,
-			GError **error)
+/**
+ * fu_srec_firmware_get_records:
+ * @self: A #FuSrecFirmware
+ *
+ * Returns the raw records from SREC tokenization.
+ *
+ * This might be useful if the plugin is expecting the SREC file to be a list
+ * of operations, rather than a simple linear image with filled holes.
+ *
+ * Returns: (transfer none) (element-type FuSrecFirmwareRecord): records
+ *
+ * Since: 1.3.2
+ **/
+GPtrArray *
+fu_srec_firmware_get_records (FuSrecFirmware *self)
 {
+	g_return_val_if_fail (FU_IS_SREC_FIRMWARE (self), NULL);
+	return self->records;
+}
+
+static void
+fu_srec_firmware_record_free (FuSrecFirmwareRecord *rcd)
+{
+	g_byte_array_unref (rcd->buf);
+	g_free (rcd);
+}
+
+static FuSrecFirmwareRecord *
+fu_srec_firmware_record_new (guint ln, guint8 kind, guint32 addr)
+{
+	FuSrecFirmwareRecord *rcd = g_new0 (FuSrecFirmwareRecord, 1);
+	rcd->ln = ln;
+	rcd->kind = kind;
+	rcd->addr = addr;
+	rcd->buf = g_byte_array_new ();
+	return rcd;
+}
+
+static gboolean
+fu_srec_firmware_tokenize (FuFirmware *firmware, GBytes *fw,
+			   FwupdInstallFlags flags, GError **error)
+{
+	FuSrecFirmware *self = FU_SREC_FIRMWARE (firmware);
 	const gchar *data;
 	gboolean got_eof = FALSE;
-	gboolean got_hdr = FALSE;
 	gsize sz = 0;
-	guint16 data_cnt = 0;
-	guint32 addr32_last = 0;
-	guint32 img_address = 0;
 	g_auto(GStrv) lines = NULL;
-	g_autoptr(FuFirmwareImage) img = fu_firmware_image_new (NULL);
-	g_autoptr(GBytes) img_bytes = NULL;
-	g_autoptr(GByteArray) outbuf = g_byte_array_new ();
 
 	/* parse records */
 	data = g_bytes_get_data (fw, &sz);
 	lines = fu_common_strnsplit (data, sz, "\n", -1);
 	for (guint ln = 0; lines[ln] != NULL; ln++) {
+		FuSrecFirmwareRecord *rcd;
 		const gchar *line = lines[ln];
 		gsize linesz;
 		guint32 rec_addr32;
@@ -113,15 +143,6 @@ fu_srec_firmware_parse (FuFirmware *firmware,
 		switch (rec_kind) {
 		case 0:
 			addrsz = 2;
-			if (got_hdr) {
-				g_set_error (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_INVALID_FILE,
-					     "duplicate header record at line %u",
-					     ln + 1);
-				return FALSE;
-			}
-			got_hdr = TRUE;
 			break;
 		case 1:
 			addrsz = 2;
@@ -179,99 +200,15 @@ fu_srec_firmware_parse (FuFirmware *firmware,
 			 ln + 1, rec_kind, rec_addr32,
 			 (guint) rec_count - addrsz - 1);
 
-		/* header */
-		if (rec_kind == 0) {
-			g_autoptr(GString) modname = g_string_new (NULL);
-			if (rec_addr32 != 0x0) {
-				g_set_error (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_INVALID_FILE,
-					     "invalid header record address, got %04x at line %u",
-					     rec_addr32, ln + 1);
-				return FALSE;
-			}
-
-			/* could be anything, lets assume text */
+		/* data */
+		rcd = fu_srec_firmware_record_new (ln + 1, rec_kind, rec_addr32);
+		if (rec_kind == 1 || rec_kind == 2 || rec_kind == 3) {
 			for (guint8 i = 4 + (addrsz * 2); i <= rec_count * 2; i += 2) {
 				guint8 tmp = fu_firmware_strparse_uint8 (line + i);
-				if (!g_ascii_isgraph (tmp))
-					break;
-				g_string_append_c (modname, tmp);
-			}
-			if (modname->len != 0)
-				fu_firmware_image_set_id (img, modname->str);
-			continue;
-		}
-
-		/* verify we got all records */
-		if (rec_kind == 5) {
-			if (rec_addr32 != data_cnt) {
-				g_set_error (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_INVALID_FILE,
-					     "count record was not valid, got 0x%02x expected 0x%02x at line %u",
-					     (guint) rec_addr32, (guint) data_cnt, ln + 1);
-				return FALSE;
+				fu_byte_array_append_uint8 (rcd->buf, tmp);
 			}
 		}
-
-		/* data */
-		if (rec_kind == 1 || rec_kind == 2 || rec_kind == 3) {
-			/* invalid */
-			if (!got_hdr) {
-				g_set_error (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_INVALID_FILE,
-					     "missing header record at line %u",
-					     ln + 1);
-				return FALSE;
-			}
-			/* does not make sense */
-			if (rec_addr32 < addr32_last) {
-				g_set_error (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_INVALID_FILE,
-					     "invalid address 0x%x, last was 0x%x at line %u",
-					     (guint) rec_addr32,
-					     (guint) addr32_last,
-					     ln + 1);
-				return FALSE;
-			}
-			if (rec_addr32 < addr_start) {
-				g_debug ("ignoring data at 0x%x as before start address 0x%x at line %u",
-					 (guint) rec_addr32, (guint) addr_start, ln + 1);
-			} else {
-				guint bytecnt = 0;
-				guint32 len_hole = rec_addr32 - addr32_last;
-
-				/* fill any holes, but only up to 1Mb to avoid a DoS */
-				if (addr32_last > 0 && len_hole > 0x100000) {
-					g_set_error (error,
-						     FWUPD_ERROR,
-						     FWUPD_ERROR_INVALID_FILE,
-						     "hole of 0x%x bytes too large to fill at line %u",
-						     (guint) len_hole, ln + 1);
-					return FALSE;
-				}
-				if (addr32_last > 0x0 && len_hole > 1) {
-					g_debug ("filling address 0x%08x to 0x%08x at line %u",
-						 addr32_last + 1, addr32_last + len_hole - 1, ln + 1);
-					for (guint j = 0; j < len_hole; j++)
-						fu_byte_array_append_uint8 (outbuf, 0xff);
-				}
-
-				/* add data */
-				for (guint8 i = 4 + (addrsz * 2); i <= rec_count * 2; i += 2) {
-					guint8 tmp = fu_firmware_strparse_uint8 (line + i);
-					fu_byte_array_append_uint8 (outbuf, tmp);
-					bytecnt++;
-				}
-				if (img_address == 0x0)
-					img_address = rec_addr32;
-				addr32_last = rec_addr32 + bytecnt;
-			}
-			data_cnt++;
-		}
+		g_ptr_array_add (self->records, rcd);
 	}
 
 	/* no EOF */
@@ -281,6 +218,124 @@ fu_srec_firmware_parse (FuFirmware *firmware,
 				     FWUPD_ERROR_INVALID_FILE,
 				     "no EOF, perhaps truncated file");
 		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_srec_firmware_parse (FuFirmware *firmware,
+			GBytes *fw,
+			guint64 addr_start,
+			guint64 addr_end,
+			FwupdInstallFlags flags,
+			GError **error)
+{
+	FuSrecFirmware *self = FU_SREC_FIRMWARE (firmware);
+	gboolean got_hdr = FALSE;
+	guint16 data_cnt = 0;
+	guint32 addr32_last = 0;
+	guint32 img_address = 0;
+	g_autoptr(FuFirmwareImage) img = fu_firmware_image_new (NULL);
+	g_autoptr(GBytes) img_bytes = NULL;
+	g_autoptr(GByteArray) outbuf = g_byte_array_new ();
+
+	/* parse records */
+	for (guint j = 0; j < self->records->len; j++) {
+		FuSrecFirmwareRecord *rcd = g_ptr_array_index (self->records, j);
+
+		/* header */
+		if (rcd->kind == 0) {
+			g_autoptr(GString) modname = g_string_new (NULL);
+
+			/* check for duplicate */
+			if (got_hdr) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "duplicate header record at line %u",
+					     rcd->ln);
+				return FALSE;
+			}
+
+			/* could be anything, lets assume text */
+			for (guint8 i = 0; i < rcd->buf->len; i++) {
+				gchar tmp = rcd->buf->data[i];
+				if (!g_ascii_isgraph (tmp))
+					break;
+				g_string_append_c (modname, tmp);
+			}
+			if (modname->len != 0)
+				fu_firmware_image_set_id (img, modname->str);
+			got_hdr = TRUE;
+			continue;
+		}
+
+		/* verify we got all records */
+		if (rcd->kind == 5) {
+			if (rcd->addr != data_cnt) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "count record was not valid, got 0x%02x expected 0x%02x at line %u",
+					     (guint) rcd->addr, (guint) data_cnt, rcd->ln);
+				return FALSE;
+			}
+			continue;
+		}
+
+		/* data */
+		if (rcd->kind == 1 || rcd->kind == 2 || rcd->kind == 3) {
+			/* invalid */
+			if (!got_hdr) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "missing header record at line %u",
+					     rcd->ln);
+				return FALSE;
+			}
+
+			/* does not make sense */
+			if (rcd->addr < addr32_last) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_INVALID_FILE,
+					     "invalid address 0x%x, last was 0x%x at line %u",
+					     (guint) rcd->addr,
+					     (guint) addr32_last,
+					     rcd->ln);
+				return FALSE;
+			}
+			if (rcd->addr < addr_start) {
+				g_debug ("ignoring data at 0x%x as before start address 0x%x at line %u",
+					 (guint) rcd->addr, (guint) addr_start, rcd->ln);
+			} else {
+				guint32 len_hole = rcd->addr - addr32_last;
+
+				/* fill any holes, but only up to 1Mb to avoid a DoS */
+				if (addr32_last > 0 && len_hole > 0x100000) {
+					g_set_error (error,
+						     FWUPD_ERROR,
+						     FWUPD_ERROR_INVALID_FILE,
+						     "hole of 0x%x bytes too large to fill at line %u",
+						     (guint) len_hole, rcd->ln);
+					return FALSE;
+				}
+				if (addr32_last > 0x0 && len_hole > 1) {
+					g_debug ("filling address 0x%08x to 0x%08x at line %u",
+						 addr32_last + 1, addr32_last + len_hole - 1, rcd->ln);
+					for (guint i = 0; i < len_hole; i++)
+						fu_byte_array_append_uint8 (outbuf, 0xff);
+				}
+
+				/* add data */
+				g_byte_array_append (outbuf, rcd->buf->data, rcd->buf->len);
+				if (img_address == 0x0)
+					img_address = rcd->addr;
+				addr32_last = rcd->addr + rcd->buf->len;
+			}
+			data_cnt++;
+		}
 	}
 
 	/* add single image */
@@ -292,15 +347,26 @@ fu_srec_firmware_parse (FuFirmware *firmware,
 }
 
 static void
+fu_srec_firmware_finalize (GObject *object)
+{
+	FuSrecFirmware *self = FU_SREC_FIRMWARE (object);
+	g_ptr_array_unref (self->records);
+}
+
+static void
 fu_srec_firmware_init (FuSrecFirmware *self)
 {
+	self->records = g_ptr_array_new_with_free_func ((GFreeFunc) fu_srec_firmware_record_free);
 }
 
 static void
 fu_srec_firmware_class_init (FuSrecFirmwareClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS (klass);
+	object_class->finalize = fu_srec_firmware_finalize;
 	klass_firmware->parse = fu_srec_firmware_parse;
+	klass_firmware->tokenize = fu_srec_firmware_tokenize;
 }
 
 FuFirmware *

--- a/src/fu-srec-firmware.h
+++ b/src/fu-srec-firmware.h
@@ -13,6 +13,14 @@ G_BEGIN_DECLS
 #define FU_TYPE_SREC_FIRMWARE (fu_srec_firmware_get_type ())
 G_DECLARE_FINAL_TYPE (FuSrecFirmware, fu_srec_firmware, FU, SREC_FIRMWARE, FuFirmware)
 
+typedef struct {
+	guint		 ln;
+	guint8		 kind;
+	guint32		 addr;
+	GByteArray	*buf;
+} FuSrecFirmwareRecord;
+
 FuFirmware	*fu_srec_firmware_new		(void);
+GPtrArray	*fu_srec_firmware_get_records	(FuSrecFirmware		*self);
 
 G_END_DECLS


### PR DESCRIPTION
At least two vendors are not using SREC according to the spec. They are using
it like a recipe to write specific values at specific addresses.

All the logic like line lengths and checksumming (and therefore all the various
checks for malicious firmware are still valid), so provide a new function to
just tokenize the file and to not assign a padded image.
