### PR TITLE
trivial: fix wget command in fu-tool.c

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -671,7 +671,7 @@ fu_util_install_task_sort_cb (gconstpointer a, gconstpointer b)
 static gboolean
 fu_util_download_out_of_process (const gchar *uri, const gchar *fn, GError **error)
 {
-	const gchar *argv[][5] = { { "wget", uri, "-o", fn, NULL },
+	const gchar *argv[][5] = { { "wget", uri, "-O", fn, NULL },
 				   { "curl", uri, "--output", fn, NULL },
 				   { NULL } };
 	for (guint i = 0; argv[i][0] != NULL; i++) {


### PR DESCRIPTION
-o <arg> will redirect stdout to <arg>, -O <arg> what we want to be
using, it saves the file to <arg>.

Signed-off-by: Filipe Laíns <lains@archlinux.org>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
