### PR TITLE
Align the key values to the text *width* not the number of bytes

### DIFF
--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -1123,6 +1123,32 @@ fu_common_string_replace (GString *string, const gchar *search, const gchar *rep
 	return count;
 }
 
+/**
+ * fu_common_strwidth:
+ * @text: The string to operate on
+ *
+ * Returns the width of the string in displayed characters on the console.
+ *
+ * Returns: width of text
+ *
+ * Since: 1.3.2
+ **/
+gsize
+fu_common_strwidth (const gchar *text)
+{
+	const gchar *p = text;
+	gsize width = 0;
+	while (*p) {
+		gunichar c = g_utf8_get_char (p);
+		if (g_unichar_iswide (c))
+			width += 2;
+		else if (!g_unichar_iszerowidth (c))
+			width += 1;
+		p = g_utf8_next_char (p);
+	}
+	return width;
+}
+
 void
 fu_common_string_append_kv (GString *str, guint idt, const gchar *key, const gchar *value)
 {
@@ -1138,7 +1164,7 @@ fu_common_string_append_kv (GString *str, guint idt, const gchar *key, const gch
 		g_string_append (str, "  ");
 	if (key[0] != '\0') {
 		g_string_append_printf (str, "%s:", key);
-		keysz = (idt * 2) + strlen (key) + 1;
+		keysz = (idt * 2) + fu_common_strwidth (key) + 1;
 	} else {
 		keysz = idt * 2;
 	}

--- a/src/fu-common.h
+++ b/src/fu-common.h
@@ -142,6 +142,7 @@ gboolean	 fu_common_bytes_compare_raw	(const guint8	*buf1,
 						 GError		**error);
 GBytes		*fu_common_bytes_pad		(GBytes		*bytes,
 						 gsize		 sz);
+gsize		 fu_common_strwidth		(const gchar	*text);
 gboolean	 fu_memcpy_safe			(guint8		*dst,
 						 gsize		 dst_sz,
 						 gsize		 dst_offset,

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -11,6 +11,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 
+#include "fu-common.h"
 #include "fu-progressbar.h"
 
 static void fu_progressbar_finalize	 (GObject *obj);
@@ -160,7 +161,7 @@ fu_progressbar_refresh (FuProgressbar *self, FwupdStatus status, guint percentag
 	}
 	title = fu_progressbar_status_to_string (status);
 	g_string_append (str, title);
-	for (i = g_utf8_strlen (str->str, -1); i < self->length_status; i++)
+	for (i = fu_common_strwidth (str->str); i < self->length_status; i++)
 		g_string_append_c (str, ' ');
 
 	/* add progressbar */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -80,7 +80,7 @@ fu_util_print_data (const gchar *title, const gchar *msg)
 	g_print ("%s:", title);
 
 	/* pad */
-	title_len = strlen (title) + 1;
+	title_len = fu_common_strwidth (title) + 1;
 	lines = g_strsplit (msg, "\n", -1);
 	for (guint j = 0; lines[j] != NULL; j++) {
 		for (gsize i = title_len; i < 25; i++)
@@ -495,11 +495,11 @@ fu_util_cmd_array_to_string (GPtrArray *array)
 		FuUtilCmd *item = g_ptr_array_index (array, i);
 		g_string_append (string, "  ");
 		g_string_append (string, item->name);
-		len = strlen (item->name) + 2;
+		len = fu_common_strwidth (item->name) + 2;
 		if (item->arguments != NULL) {
 			g_string_append (string, " ");
 			g_string_append (string, item->arguments);
-			len += strlen (item->arguments) + 1;
+			len += fu_common_strwidth (item->arguments) + 1;
 		}
 		if (len < max_len) {
 			for (gsize j = len; j < max_len + 1; j++)
@@ -647,7 +647,7 @@ fu_util_strsplit_words (const gchar *text, guint line_len)
 	for (guint i = 0; tokens[i] != NULL; i++) {
 
 		/* current line plus new token is okay */
-		if (curline->len + strlen (tokens[i]) < line_len) {
+		if (curline->len + fu_common_strwidth (tokens[i]) < line_len) {
 			g_string_append_printf (curline, "%s ", tokens[i]);
 			continue;
 		}
@@ -677,15 +677,15 @@ fu_util_warning_box_line (const gchar *start,
 {
 	guint offset = 0;
 	if (start != NULL) {
-		offset += g_utf8_strlen (start, -1);
+		offset += fu_common_strwidth (start);
 		g_print ("%s", start);
 	}
 	if (text != NULL) {
-		offset += g_utf8_strlen (text, -1);
+		offset += fu_common_strwidth (text);
 		g_print ("%s", text);
 	}
 	if (end != NULL)
-		offset += g_utf8_strlen (end, -1);
+		offset += fu_common_strwidth (end);
 	for (guint i = offset; i < width; i++)
 		g_print ("%s", padding);
 	if (end != NULL)
@@ -1219,7 +1219,7 @@ fu_util_remote_to_string (FwupdRemote *remote, guint idt)
 	}
 	tmp = fwupd_remote_get_password (remote);
 	if (tmp != NULL) {
-		g_autofree gchar *hidden = g_strnfill (strlen (tmp), '*');
+		g_autofree gchar *hidden = g_strnfill (fu_common_strwidth (tmp), '*');
 		/* TRANSLATORS: remote filename base */
 		fu_common_string_append_kv (str, idt + 1, _("Password"), hidden);
 	}


### PR DESCRIPTION
This fixes the output when using locales like zh_CN.utf-8
