### PR TITLE
Fix snap fresh installation

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -13,7 +13,7 @@ install_if_missing share/polkit-1/rules.d/org.freedesktop.fwupd.rules /usr
 #install dbus related items
 install_if_missing share/dbus-1/system-services/org.freedesktop.fwupd.service /usr
 install_if_missing share/dbus-1/interfaces/org.freedesktop.fwupd.xml /usr
-install_if_missing etc/dbus-1/system.d/org.freedesktop.fwupd.conf /
+install_if_missing share/dbus-1/system.d/org.freedesktop.fwupd.conf /
 #activation via systemd
 install_if_missing etc/systemd/system/fwupd-activate.service /
 systemctl daemon-reload


### PR DESCRIPTION
CC @LinuxOnTheDesktop 

There was a regression on snap that you could only catch on fresh install.  It didn't happen in upgrades or channel refreshes (which is what was tested).

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
