### PR TITLE
trivial: dell: make failures to add GUIDs non-fatal (Fixes: #1396)

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -835,6 +835,8 @@ fu_plugin_init (FuPlugin *plugin)
 	data->smi_obj = g_malloc0 (sizeof (FuDellSmiObj));
 	if (g_getenv ("FWUPD_DELL_VERBOSE") != NULL)
 		g_setenv ("LIBSMBIOS_C_DEBUG_OUTPUT_ALL", "1", TRUE);
+	else
+		g_setenv ("TSS2_LOG", "esys+error,tcti+none", FALSE);
 	if (fu_dell_supported (plugin))
 		data->smi_obj->smi = dell_smi_factory (DELL_SMI_DEFAULTS);
 	data->smi_obj->fake_smbios = FALSE;

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -654,6 +654,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	struct tpm_status *out = NULL;
 	g_autoptr (FuDevice) dev_alt = NULL;
 	g_autoptr (FuDevice) dev = NULL;
+	g_autoptr(GError) error_tss = NULL;
 
 	fu_dell_clear_smi (data->smi_obj);
 	out = (struct tpm_status *) data->smi_obj->output;
@@ -749,8 +750,8 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 					    "Updating disabled due to TPM ownership");
 	}
 	/* build GUIDs from TSS strings */
-	if (!fu_plugin_dell_add_tpm_model (dev, error))
-		return FALSE;
+	if (!fu_plugin_dell_add_tpm_model (dev, &error_tss))
+		g_debug ("could not build instances: %s", error_tss->message);
 
 	if (!fu_device_setup (dev, error))
 		return FALSE;

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -103,6 +103,12 @@ fu_plugin_dell_tpm_func (void)
 	g_assert_no_error (error);
 	g_assert (ret);
 
+	if (tpm_server_running == NULL &&
+	    (getuid () != 0 || geteuid () != 0)) {
+		g_test_skip ("TPM tests require simulated TPM2.0 running or need root access with physical TPM");
+		return;
+	}
+
 	/* inject fake data (no TPM) */
 	tpm_out.ret = -2;
 	fu_plugin_dell_inject_fake_data (plugin_dell,
@@ -127,13 +133,6 @@ fu_plugin_dell_tpm_func (void)
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
 	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
-	if (!ret) {
-		if (tpm_server_running == NULL &&
-		    g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
-			g_test_skip ("no physical or simulated TPM 2.0 device available");
-			return;
-		}
-	}
 	g_assert_true (ret);
 	g_assert_cmpint (devices->len, ==, 2);
 

--- a/plugins/uefi/fu-self-test.c
+++ b/plugins/uefi/fu-self-test.c
@@ -50,6 +50,7 @@ fu_uefi_pcrs_2_0_func (void)
 	g_autoptr(GPtrArray) pcr0s = NULL;
 	g_autoptr(GPtrArray) pcrXs = NULL;
 	const gchar *tpm_server_running = g_getenv ("TPM_SERVER_RUNNING");
+	g_setenv ("FWUPD_FORCE_TPM2", "1", TRUE);
 
 	if (!fu_uefi_pcrs_setup (pcrs, &error)) {
 		if (tpm_server_running == NULL &&
@@ -65,6 +66,7 @@ fu_uefi_pcrs_2_0_func (void)
 	pcrXs = fu_uefi_pcrs_get_checksums (pcrs, 999);
 	g_assert_nonnull (pcrXs);
 	g_assert_cmpint (pcrXs->len, ==, 0);
+	g_unsetenv ("FWUPD_FORCE_TPM2");
 }
 
 static void

--- a/plugins/uefi/fu-self-test.c
+++ b/plugins/uefi/fu-self-test.c
@@ -52,6 +52,12 @@ fu_uefi_pcrs_2_0_func (void)
 	const gchar *tpm_server_running = g_getenv ("TPM_SERVER_RUNNING");
 	g_setenv ("FWUPD_FORCE_TPM2", "1", TRUE);
 
+	if (tpm_server_running == NULL &&
+	    (getuid () != 0 || geteuid () != 0)) {
+		g_test_skip ("TPM2.0 tests require simulated TPM2.0 running or need root access with physical TPM");
+		return;
+	}
+
 	if (!fu_uefi_pcrs_setup (pcrs, &error)) {
 		if (tpm_server_running == NULL &&
 		    g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {

--- a/plugins/uefi/fu-uefi-pcrs.c
+++ b/plugins/uefi/fu-uefi-pcrs.c
@@ -188,7 +188,8 @@ fu_uefi_pcrs_setup (FuUefiPcrs *self, GError **error)
 	sysfstpmdir = fu_common_get_path (FU_PATH_KIND_SYSFSDIR_TPM);
 	devpath = g_build_filename (sysfstpmdir, "tpm0", NULL);
 	fn_pcrs = g_build_filename (devpath, "pcrs", NULL);
-	if (g_file_test (fn_pcrs, G_FILE_TEST_EXISTS)) {
+	if (g_file_test (fn_pcrs, G_FILE_TEST_EXISTS) &&
+	    g_getenv ("FWUPD_FORCE_TPM2") == NULL) {
 		if (!fu_uefi_pcrs_setup_tpm12 (self, fn_pcrs, error))
 			return FALSE;
 


### PR DESCRIPTION
Avoids situations that the TSS doesn't handle well such as TPM1.2.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
