### PR TITLE
Add support for automatically uploading reports

### DIFF
--- a/data/remotes.d/lvfs-testing.conf
+++ b/data/remotes.d/lvfs-testing.conf
@@ -9,4 +9,5 @@ ReportURI=https://fwupd.org/lvfs/firmware/report
 Username=
 Password=
 OrderBefore=lvfs,fwupd
+AutomaticReports=false
 ApprovalRequired=false

--- a/data/remotes.d/lvfs.conf
+++ b/data/remotes.d/lvfs.conf
@@ -7,4 +7,5 @@ Keyring=gpg
 MetadataURI=https://cdn.fwupd.org/downloads/firmware.xml.gz
 ReportURI=https://fwupd.org/lvfs/firmware/report
 OrderBefore=fwupd
+AutomaticReports=false
 ApprovalRequired=false

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -64,6 +64,7 @@ const gchar	*fwupd_remote_get_metadata_uri		(FwupdRemote	*self);
 const gchar	*fwupd_remote_get_metadata_uri_sig	(FwupdRemote	*self);
 gboolean	 fwupd_remote_get_enabled		(FwupdRemote	*self);
 gboolean	 fwupd_remote_get_approval_required	(FwupdRemote	*self);
+gboolean	 fwupd_remote_get_automatic_reports	(FwupdRemote	*self);
 gint		 fwupd_remote_get_priority		(FwupdRemote	*self);
 guint64		 fwupd_remote_get_age			(FwupdRemote	*self);
 FwupdRemoteKind	 fwupd_remote_get_kind			(FwupdRemote	*self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -396,5 +396,6 @@ LIBFWUPD_1.3.3 {
     fwupd_release_get_detach_image;
     fwupd_release_set_detach_caption;
     fwupd_release_set_detach_image;
+    fwupd_remote_get_automatic_reports;
   local: *;
 } LIBFWUPD_1.3.2;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -551,7 +551,7 @@ fu_engine_modify_remote (FuEngine *self,
 {
 	FwupdRemote *remote;
 	const gchar *filename;
-	const gchar *keys[] = { "Enabled", "MetadataURI", "FirmwareBaseURI", NULL };
+	const gchar *keys[] = { "Enabled", "MetadataURI", "FirmwareBaseURI", "AutomaticReports", NULL };
 	g_autoptr(GKeyFile) keyfile = g_key_file_new ();
 
 	/* check remote is valid */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1270,6 +1270,9 @@ fu_util_remote_to_string (FwupdRemote *remote, guint idt)
 	if (tmp != NULL) {
 		/* TRANSLATORS: URI to send success/failure reports */
 		fu_common_string_append_kv (str, idt + 1, _("Report URI"), tmp);
+		/* TRANSLATORS: Boolean value to automatically send reports */
+		fu_common_string_append_kv (str, idt + 1, _("Automatic Reporting"),
+					    fwupd_remote_get_automatic_reports (remote) ? "true" : "false");
 	}
 
 	return g_string_free (str, FALSE);


### PR DESCRIPTION
This is not 1.3.2 material, I'm expecting it fits into the bigger stuff that you want to overhaul reporting some in 1.3.3.

The basic idea is to extend the nag to either be:
* Less annoying to people who never want to upload stuff
* Less annoying to people who want to help as much as possible

The configuration option is a daemon property with the idea being if someone opts in from one client but uses another the other clients can follow the same behavior.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
