### PR TITLE
Do not enumerate physical devices when running the internal self tests

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4683,10 +4683,12 @@ fu_engine_load (FuEngine *self, FuEngineLoadFlags flags, GError **error)
 	g_signal_connect (self->usb_ctx, "device-removed",
 			  G_CALLBACK (fu_engine_usb_device_removed_cb),
 			  self);
-	g_usb_context_enumerate (self->usb_ctx);
+	if ((flags & FU_ENGINE_LOAD_FLAG_NO_ENUMERATE) == 0)
+		g_usb_context_enumerate (self->usb_ctx);
 
 	/* coldplug udev devices */
-	fu_engine_enumerate_udev (self);
+	if ((flags & FU_ENGINE_LOAD_FLAG_NO_ENUMERATE) == 0)
+		fu_engine_enumerate_udev (self);
 
 	/* update the db for devices that were updated during the reboot */
 	if (!fu_engine_update_history_database (self, error))

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -32,6 +32,7 @@ G_DECLARE_FINAL_TYPE (FuEngine, fu_engine, FU, ENGINE, GObject)
 typedef enum {
 	FU_ENGINE_LOAD_FLAG_NONE		= 0,
 	FU_ENGINE_LOAD_FLAG_READONLY_FS		= 1 << 0,
+	FU_ENGINE_LOAD_FLAG_NO_ENUMERATE	= 1 << 1,
 	/*< private >*/
 	FU_ENGINE_LOAD_FLAG_LAST
 } FuEngineLoadFlags;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -98,7 +98,7 @@ fu_engine_generate_md_func (void)
 	g_assert (ret);
 
 	/* load engine and check the device was found */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -777,7 +777,7 @@ fu_engine_device_unlock_func (void)
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -831,7 +831,7 @@ fu_engine_require_hwid_func (void)
 	fu_engine_set_silo (engine, silo_empty);
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -961,7 +961,7 @@ fu_engine_downgrade_func (void)
 	testdatadir = fu_test_get_filename (TESTDATADIR, ".");
 	g_assert (testdatadir != NULL);
 	g_setenv ("FU_SELF_TEST_REMOTES_DIR", testdatadir, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1072,7 +1072,7 @@ fu_engine_install_duration_func (void)
 	testdatadir = fu_test_get_filename (TESTDATADIR, ".");
 	g_assert (testdatadir != NULL);
 	g_setenv ("FU_SELF_TEST_REMOTES_DIR", testdatadir, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1137,7 +1137,7 @@ fu_engine_history_func (void)
 	testdatadir = fu_test_get_filename (TESTDATADIR, ".");
 	g_assert (testdatadir != NULL);
 	g_setenv ("FU_SELF_TEST_REMOTES_DIR", testdatadir, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1266,7 +1266,7 @@ fu_engine_history_inherit (void)
 	testdatadir = fu_test_get_filename (TESTDATADIR, ".");
 	g_assert (testdatadir != NULL);
 	g_setenv ("FU_SELF_TEST_REMOTES_DIR", testdatadir, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1377,7 +1377,7 @@ fu_engine_history_error_func (void)
 	testdatadir = fu_test_get_filename (TESTDATADIR, ".");
 	g_assert (testdatadir != NULL);
 	g_setenv ("FU_SELF_TEST_REMOTES_DIR", testdatadir, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -2206,7 +2206,7 @@ fu_plugin_hash_func (void)
 	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
 	gboolean ret = FALSE;
 
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 


### PR DESCRIPTION
We don't need to enumerate USB and UDev devices in the self tests. In the case
where the probe fails (due to a permissions error, as not running as root) we
don't want the tests to fail.
