### PR TITLE
Detect unmounted ESP (Fixes: #1405)

### DIFF
--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -491,6 +491,7 @@ main (int argc, char **argv)
 	/* change behaviour */
 	sysfsdir = fu_common_get_path (FU_PATH_KIND_SYSFSDIR_FW);
 	g_setenv ("FWUPD_UEFI_ESP_PATH", sysfsdir, TRUE);
+	g_setenv ("FWUPD_UEFI_TEST", "1", TRUE);
 	g_setenv ("FWUPD_DELL_FAKE_SMBIOS", "1", FALSE);
 
 	/* only critical and error are fatal */

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -378,8 +378,6 @@ fu_plugin_update (FuPlugin *plugin,
 {
 	const gchar *str;
 	guint32 flashes_left;
-	g_autofree gchar *efibootmgr_path = NULL;
-	g_autofree gchar *boot_variables = NULL;
 	g_autoptr(GError) error_splash = NULL;
 
 	/* test the flash counter */
@@ -422,16 +420,6 @@ fu_plugin_update (FuPlugin *plugin,
 	/* record if we had an invalid header during update */
 	str = fu_uefi_missing_capsule_header (device) ? "True" : "False";
 	fu_plugin_add_report_metadata (plugin, "MissingCapsuleHeader", str);
-
-	/* record boot information to system log for future debugging */
-	efibootmgr_path = fu_common_find_program_in_path ("efibootmgr", NULL);
-	if (efibootmgr_path != NULL) {
-		g_autofree gchar *cmd = g_strdup_printf ("%s -v", efibootmgr_path);
-		if (!g_spawn_command_line_sync (cmd,
-						&boot_variables, NULL, NULL, error))
-			return FALSE;
-		g_message ("Boot Information:\n%s", boot_variables);
-	}
 
 	return TRUE;
 }

--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -303,7 +303,7 @@ fu_uefi_bootmgr_bootnext (const gchar *esp_path,
 	g_autofree gchar *target_app = NULL;
 
 	/* skip for self tests */
-	if (g_getenv ("FWUPD_UEFI_ESP_PATH") != NULL)
+	if (g_getenv ("FWUPD_UEFI_TEST") != NULL)
 		return TRUE;
 
 	/* if secure boot was turned on this might need to be installed separately */

--- a/plugins/uefi/fu-uefi-common.h
+++ b/plugins/uefi/fu-uefi-common.h
@@ -72,7 +72,7 @@ gboolean	 fu_uefi_get_framebuffer_size	(guint32	*width,
 						 guint32	*height,
 						 GError		**error);
 gboolean	 fu_uefi_secure_boot_enabled	(void);
-gchar		*fu_uefi_guess_esp_path		(void);
+gchar		*fu_uefi_guess_esp_path		(GError		**error);
 gboolean	 fu_uefi_check_esp_path		(const gchar	*path,
 						 GError		**error);
 gboolean	 fu_uefi_check_esp_free_space	(const gchar	*path,

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -363,7 +363,7 @@ fu_uefi_device_write_update_info (FuUefiDevice *self,
 	};
 
 	/* set the body as the device path */
-	if (g_getenv ("FWUPD_UEFI_ESP_PATH") != NULL) {
+	if (g_getenv ("FWUPD_UEFI_TEST") != NULL) {
 		g_debug ("not building device path, in tests....");
 		return TRUE;
 	}

--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -164,10 +164,11 @@ main (int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 	} else {
-		esp_path = fu_uefi_guess_esp_path ();
+		g_autoptr(GError) error_local = NULL;
+		esp_path = fu_uefi_guess_esp_path (&error_local);
 		if (esp_path == NULL) {
-			g_printerr ("Unable to determine EFI system partition "
-				    "location, override using --esp-path\n");
+			g_printerr ("%s: override using --esp-path\n",
+				    error_local->message);
 			return EXIT_FAILURE;
 		}
 	}

--- a/plugins/uefi/fu-uefi-udisks.c
+++ b/plugins/uefi/fu-uefi-udisks.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+
+#include "fu-uefi-udisks.h"
+#include "fwupd-common.h"
+#include "fwupd-error.h"
+
+#define UDISKS_DBUS_SERVICE		"org.freedesktop.UDisks2"
+#define UDISKS_DBUS_PATH		"/org/freedesktop/UDisks2/Manager"
+#define UDISKS_DBUS_MANAGER_INTERFACE	"org.freedesktop.UDisks2.Manager"
+#define UDISKS_DBUS_PART_INTERFACE 	"org.freedesktop.UDisks2.Partition"
+#define UDISKS_DBUS_FILE_INTERFACE	"org.freedesktop.UDisks2.Filesystem"
+#define ESP_DISK_TYPE			"c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+
+gboolean
+fu_uefi_udisks_objpath (const gchar *path)
+{
+	return g_str_has_prefix (path, "/org/freedesktop/UDisks2/");
+}
+
+static GDBusProxy *
+fu_uefi_udisks_get_dbus_proxy (const gchar *path, const gchar *interface,
+			       GError **error)
+{
+	g_autoptr(GDBusConnection) connection = NULL;
+	g_autoptr(GDBusProxy) proxy = NULL;
+
+	connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
+	if (connection == NULL) {
+		g_prefix_error (error, "failed to get bus: ");
+		return NULL;
+	}
+	proxy = g_dbus_proxy_new_sync (connection,
+				       G_DBUS_PROXY_FLAGS_NONE, NULL,
+				       UDISKS_DBUS_SERVICE,
+				       path,
+				       interface,
+				       NULL, error);
+	if (proxy == NULL) {
+		g_prefix_error (error, "failed to find %s: ", UDISKS_DBUS_SERVICE);
+		return NULL;
+	}
+	return g_steal_pointer (&proxy);
+}
+
+
+GPtrArray *
+fu_uefi_udisks_get_block_devices (GError **error)
+{
+	g_autoptr(GVariant) output = NULL;
+	g_autoptr(GDBusProxy) proxy = NULL;
+	g_autoptr(GPtrArray) devices = NULL;
+	g_autoptr(GVariantIter) iter = NULL;
+	GVariant *input;
+	GVariantBuilder builder;
+	const gchar *obj;
+
+	proxy = fu_uefi_udisks_get_dbus_proxy (UDISKS_DBUS_PATH,
+					       UDISKS_DBUS_MANAGER_INTERFACE,
+					       error);
+	if (proxy == NULL)
+		return NULL;
+	g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
+	input = g_variant_new ("(a{sv})", &builder);
+	output =  g_dbus_proxy_call_sync (proxy,
+					  "GetBlockDevices", g_variant_ref (input),
+					  G_DBUS_CALL_FLAGS_NONE,
+					  -1, NULL, error);
+	if (output == NULL)
+		return FALSE;
+	devices = g_ptr_array_new_with_free_func (g_free);
+	g_variant_get (output, "(ao)", &iter);
+	while (g_variant_iter_next (iter, "o", &obj))
+		g_ptr_array_add (devices, g_strdup (obj));
+
+	return g_steal_pointer (&devices);
+}
+
+gboolean
+fu_uefi_udisks_objpath_is_esp (const gchar *obj)
+{
+	g_autoptr(GDBusProxy) proxy = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autoptr(GVariant) val = NULL;
+	const gchar *str;
+
+	proxy = fu_uefi_udisks_get_dbus_proxy (obj,
+					       UDISKS_DBUS_PART_INTERFACE,
+					       &error_local);
+	if (proxy == NULL) {
+		g_warning ("Failed to initialize d-bus proxy: %s",
+			   error_local->message);
+		return FALSE;
+	}
+	val = g_dbus_proxy_get_cached_property (proxy, "Type");
+	if (val == NULL)
+		return FALSE;
+
+	g_variant_get (val, "s", &str);
+	return g_strcmp0 (str, ESP_DISK_TYPE) == 0;
+}
+
+gchar *
+fu_uefi_udisks_objpath_mount (const gchar *path, GError **error)
+{
+	GVariant *input;
+	GVariantBuilder builder;
+	const gchar *str;
+	g_autoptr(GDBusProxy) proxy = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	g_return_val_if_fail (fu_uefi_udisks_objpath (path), NULL);
+
+	proxy = fu_uefi_udisks_get_dbus_proxy (path,
+					       UDISKS_DBUS_FILE_INTERFACE,
+					       error);
+	if (proxy == NULL)
+		return NULL;
+
+	g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
+	input = g_variant_new ("(a{sv})", &builder);
+	val = g_dbus_proxy_call_sync (proxy,
+				      "Mount", input,
+				      G_DBUS_CALL_FLAGS_NONE,
+				      -1, NULL, error);
+	if (val == NULL)
+		return NULL;
+	g_variant_get (val, "(s)", &str);
+
+	return g_strdup (str);
+}

--- a/plugins/uefi/fu-uefi-udisks.h
+++ b/plugins/uefi/fu-uefi-udisks.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+GPtrArray	*fu_uefi_udisks_get_block_devices	(GError		**error);
+gboolean	 fu_uefi_udisks_objpath			(const gchar	*path);
+gboolean	 fu_uefi_udisks_objpath_is_esp		(const gchar	*obj);
+gchar		*fu_uefi_udisks_objpath_mount		(const gchar	*path,
+							 GError		**error);

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -23,6 +23,7 @@ shared_module('fu_plugin_uefi',
     'fu-uefi-devpath.c',
     'fu-uefi-pcrs.c',
     'fu-uefi-update-info.c',
+    'fu-uefi-udisks.c',
     'fu-uefi-vars.c',
   ],
   include_directories : [
@@ -58,6 +59,7 @@ executable(
     'fu-uefi-devpath.c',
     'fu-uefi-pcrs.c',
     'fu-uefi-update-info.c',
+    'fu-uefi-udisks.c',
     'fu-uefi-vars.c',
   ],
   include_directories : [
@@ -102,6 +104,7 @@ if get_option('tests')
       'fu-uefi-pcrs.c',
       'fu-uefi-update-info.c',
       'fu-uefi-vars.c',
+      'fu-uefi-udisks.c',
       'fu-ucs2.c',
     ],
     include_directories : [


### PR DESCRIPTION
This is also 1.3.3 material, early comments appreciated.

There is definitely a memory leak going on with the dbus comms.  Can tell from
```g_atomic_ref_count_dec: assertion 'g_atomitc_int_get (arc) > 0``` showing up in the logs but I'm not sure what i'm doing wrong.  If you spot it, appreciated!

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
