### PR TITLE
Export the instructions for detaching the device

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -12,6 +12,8 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_CHECKSUM		"Checksum"	/* as */
 #define FWUPD_RESULT_KEY_CREATED		"Created"	/* t */
 #define FWUPD_RESULT_KEY_DESCRIPTION		"Description"	/* s */
+#define FWUPD_RESULT_KEY_DETACH_CAPTION		"DetachCaption"	/* s */
+#define FWUPD_RESULT_KEY_DETACH_IMAGE		"DetachImage"	/* s */
 #define FWUPD_RESULT_KEY_DEVICE_ID		"DeviceId"	/* s */
 #define FWUPD_RESULT_KEY_PARENT_DEVICE_ID	"ParentDeviceId"/* s */
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -40,6 +40,8 @@ typedef struct {
 	gchar				*details_url;
 	gchar				*source_url;
 	gchar				*appstream_id;
+	gchar				*detach_caption;
+	gchar				*detach_image;
 	gchar				*license;
 	gchar				*name;
 	gchar				*name_variant_suffix;
@@ -716,6 +718,78 @@ fwupd_release_set_appstream_id (FwupdRelease *release, const gchar *appstream_id
 }
 
 /**
+ * fwupd_release_get_detach_caption:
+ * @release: A #FwupdRelease
+ *
+ * Gets the optional text caption used to manually detach the device.
+ *
+ * Returns: the string caption, or %NULL if unset
+ *
+ * Since: 1.3.3
+ **/
+const gchar *
+fwupd_release_get_detach_caption (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->detach_caption;
+}
+
+/**
+ * fwupd_release_set_detach_caption:
+ * @release: A #FwupdRelease
+ * @detach_caption: string caption
+ *
+ * Sets the optional text caption used to manually detach the device.
+ *
+ * Since: 1.3.3
+ **/
+void
+fwupd_release_set_detach_caption (FwupdRelease *release, const gchar *detach_caption)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_free (priv->detach_caption);
+	priv->detach_caption = g_strdup (detach_caption);
+}
+
+/**
+ * fwupd_release_get_detach_image:
+ * @release: A #FwupdRelease
+ *
+ * Gets the optional image used to manually detach the device.
+ *
+ * Returns: the URI, or %NULL if unset
+ *
+ * Since: 1.3.3
+ **/
+const gchar *
+fwupd_release_get_detach_image (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->detach_image;
+}
+
+/**
+ * fwupd_release_set_detach_image:
+ * @release: A #FwupdRelease
+ * @detach_image: a fully qualified URI
+ *
+ * Sets the optional image used to manually detach the device.
+ *
+ * Since: 1.3.3
+ **/
+void
+fwupd_release_set_detach_image (FwupdRelease *release, const gchar *detach_image)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_free (priv->detach_image);
+	priv->detach_image = g_strdup (detach_image);
+}
+
+/**
  * fwupd_release_get_size:
  * @release: A #FwupdRelease
  *
@@ -1148,6 +1222,16 @@ fwupd_release_to_variant (FwupdRelease *release)
 				       FWUPD_RESULT_KEY_APPSTREAM_ID,
 				       g_variant_new_string (priv->appstream_id));
 	}
+	if (priv->detach_caption != NULL) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_DETACH_CAPTION,
+				       g_variant_new_string (priv->detach_caption));
+	}
+	if (priv->detach_image != NULL) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_DETACH_IMAGE,
+				       g_variant_new_string (priv->detach_image));
+	}
 	if (priv->filename != NULL) {
 		g_variant_builder_add (&builder, "{sv}",
 				       FWUPD_RESULT_KEY_FILENAME,
@@ -1274,6 +1358,14 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_APPSTREAM_ID) == 0) {
 		fwupd_release_set_appstream_id (release, g_variant_get_string (value, NULL));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_DETACH_CAPTION) == 0) {
+		fwupd_release_set_detach_caption (release, g_variant_get_string (value, NULL));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_DETACH_IMAGE) == 0) {
+		fwupd_release_set_detach_image (release, g_variant_get_string (value, NULL));
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_FILENAME) == 0) {
@@ -1514,6 +1606,8 @@ fwupd_release_to_json (FwupdRelease *release, JsonBuilder *builder)
 		json_builder_end_array (builder);
 	}
 	fwupd_release_json_add_int (builder, FWUPD_RESULT_KEY_INSTALL_DURATION, priv->install_duration);
+	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_DETACH_CAPTION, priv->detach_caption);
+	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_DETACH_IMAGE, priv->detach_image);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
 
 	/* metadata */
@@ -1574,6 +1668,8 @@ fwupd_release_to_string (FwupdRelease *release)
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_VENDOR, priv->vendor);
 	fwupd_pad_kv_tfl (str, FWUPD_RESULT_KEY_FLAGS, priv->flags);
 	fwupd_pad_kv_int (str, FWUPD_RESULT_KEY_INSTALL_DURATION, priv->install_duration);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETACH_CAPTION, priv->detach_caption);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETACH_IMAGE, priv->detach_image);
 	if (priv->update_message != NULL)
 		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
 	/* metadata */
@@ -1614,6 +1710,8 @@ fwupd_release_finalize (GObject *object)
 	g_free (priv->filename);
 	g_free (priv->protocol);
 	g_free (priv->appstream_id);
+	g_free (priv->detach_caption);
+	g_free (priv->detach_image);
 	g_free (priv->license);
 	g_free (priv->name);
 	g_free (priv->name_variant_suffix);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -69,6 +69,12 @@ void		 fwupd_release_set_protocol		(FwupdRelease	*release,
 const gchar	*fwupd_release_get_appstream_id		(FwupdRelease	*release);
 void		 fwupd_release_set_appstream_id		(FwupdRelease	*release,
 							 const gchar	*appstream_id);
+const gchar	*fwupd_release_get_detach_caption	(FwupdRelease	*release);
+void		 fwupd_release_set_detach_caption	(FwupdRelease	*release,
+							 const gchar	*detach_caption);
+const gchar	*fwupd_release_get_detach_image		(FwupdRelease	*release);
+void		 fwupd_release_set_detach_image		(FwupdRelease	*release,
+							 const gchar	*detach_image);
 const gchar	*fwupd_release_get_remote_id		(FwupdRelease	*release);
 void		 fwupd_release_set_remote_id		(FwupdRelease	*release,
 							 const gchar	*remote_id);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -389,3 +389,12 @@ LIBFWUPD_1.3.2 {
     fwupd_release_set_name_variant_suffix;
   local: *;
 } LIBFWUPD_1.3.1;
+
+LIBFWUPD_1.3.3 {
+  global:
+    fwupd_release_get_detach_caption;
+    fwupd_release_get_detach_image;
+    fwupd_release_set_detach_caption;
+    fwupd_release_set_detach_image;
+  local: *;
+} LIBFWUPD_1.3.2;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -428,6 +428,12 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 			fwupd_release_add_issue (rel, xb_node_get_text (n));
 		}
 	}
+	tmp = xb_node_query_text (component, "screenshots/screenshot/caption", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_detach_caption (rel, tmp);
+	tmp = xb_node_query_text (component, "screenshots/screenshot/image", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_detach_image (rel, tmp);
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_protocol (rel, tmp);


### PR DESCRIPTION
Somewhat embarrassingly we were not actually showing the 8bitdo manual detach
images because... we were not actually exporting them. I don't know how this
ever worked in GNOME Software, but it would also explain the low 'success' rate
of the 8bitdo firmware on the LVFS.

This will also be used by Logitech in the future for the C1 Unifying devices.

To work in gnome-softare, this also needs the matching functionality to call
gs_app_add_screenshot() with the new exported data.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation
