### PR TITLE
Add some success messages when CLI tasks have completed

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1958,7 +1958,7 @@ fu_util_modify_config (FuUtilPrivate *priv, gchar **values, GError **error)
 					 error))
 		return FALSE;
 	if (!priv->assume_yes) {
-		g_print ("%s\n [Y|n]: ",
+		g_print ("%s [Y|n]: ",
 			/* TRANSLATORS: configuration changes only take effect on restart */
 			 _("Restart the daemon to make the change effective?"));
 		if (!fu_util_prompt_for_boolean (FALSE))


### PR DESCRIPTION
Updating firware is sometimes scary, and for user-facing CLI tools we ought to
show some kind of reassurance than it went well.

Fixes some of https://github.com/fwupd/fwupd/issues/1409
