### PR TITLE
trivial: fu-udev-device: fix some assertions

### DIFF
--- a/src/fu-udev-device.c
+++ b/src/fu-udev-device.c
@@ -161,7 +161,7 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	}
 
 	/* try harder to find a vendor name the user will recognise */
-	if (fu_device_get_vendor (device) == NULL) {
+	if (udev_parent != NULL && fu_device_get_vendor (device) == NULL) {
 		g_autoptr(GUdevDevice) device_tmp = g_object_ref (udev_parent);
 		for (guint i = 0; i < 0xff; i++) {
 			g_autoptr(GUdevDevice) parent = NULL;


### PR DESCRIPTION
These seem to be caused by udev_parent being `NULL`.

```
19:26:06:0220 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0220 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0220 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0221 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0221 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0221 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0221 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0221 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0221 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0222 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0222 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0222 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0222 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0223 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0223 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0223 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0223 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0223 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0223 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0224 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0224 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0224 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0224 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0224 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0224 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0225 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0225 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0225 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0225 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0225 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0225 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0225 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0225 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0226 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0226 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0226 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0226 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0226 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0226 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0226 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0227 GLib-GObject         g_object_ref: assertion 'G_IS_OBJECT (object)' failed
19:26:06:0227 GUdev                g_udev_device_get_property: assertion 'G_UDEV_IS_DEVICE (device)' failed
19:26:06:0227 GUdev                g_udev_device_get_parent: assertion 'G_UDEV_IS_DEVICE (device)' failed
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
