### PR TITLE
Some systemd fixes

### DIFF
--- a/contrib/debian/fwupd.preinst
+++ b/contrib/debian/fwupd.preinst
@@ -7,3 +7,10 @@ if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
 	dpkg-maintscript-helper rm_conffile \
 		/etc/fwupd.conf 1.0.0~ -- "$@"
 fi
+
+# 1.3.2 had fwupd-refresh.service and fwupd.service both claiming
+# this directory, but fwupd-refresh.service used DynamicUser directive
+# meaning no other unit could access it.
+if [ -L /var/cache/fwupd ]; then
+	rm -f /var/cache/fwupd
+fi

--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -6,7 +6,7 @@ After=network.target network-online.target systemd-networkd.service NetworkManag
 [Service]
 Type=oneshot
 RuntimeDirectory=@motd_dir@
-CacheDirectory=fwupd
+CacheDirectory=fwupdmgr
 RuntimeDirectoryPreserve=yes
 StandardError=null
 ExecStart=@bindir@/fwupdmgr refresh

--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -10,7 +10,9 @@ CacheDirectory=fwupdmgr
 RuntimeDirectoryPreserve=yes
 StandardError=null
 ExecStart=@bindir@/fwupdmgr refresh
-ExecStart=@bindir@/fwupdmgr get-updates --log @motd_file@
+#Don't update MOTD for now until https://github.com/systemd/systemd/issues/13688
+#is better figured out
+#ExecStart=@bindir@/fwupdmgr get-updates --log @motd_file@
 DynamicUser=yes
 RestrictAddressFamilies=AF_NETLINK AF_UNIX AF_INET AF_INET6
 SystemCallFilter=~@mount


### PR DESCRIPTION
It was reported in Debian a problem with the unit failing to start.
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=932617

It looks to me it's caused by a change in behavior in systemd 242 that it will chown directories when running so that means that both fwupdmgr (confined via systemd DynamicUser) and fwupd can't both take it.  So give fwupdmgr it's own persistent cache directory instead.

Also it seems that there might be a bug with runtime directory behavior in systemd as a very simple reproducer causes the problems.  Disable the motd population for now until we have a better grasp on it.
https://github.com/systemd/systemd/issues/13688

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
