### PR TITLE
trivial: fedora: clean up systemd issue from 1.3.2

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -221,6 +221,11 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 
 %find_lang %{name}
 
+%pre
+if [ -L %{_localstatedir}/cache/fwupd ]; then
+    rm -f %{_localstatedir}/cache/fwupd
+fi
+
 %post
 %systemd_post fwupd.service
 


### PR DESCRIPTION
this applies the same fix from dc7e7c3808d564d5769b2845dbd66a3651f72e07
to fedora

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
