### PR TITLE
thunderbolt: Fix usage of incorrect type for return value

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-image.c
+++ b/plugins/thunderbolt/fu-thunderbolt-image.c
@@ -684,7 +684,7 @@ fu_thunderbolt_image_validate (GBytes  *controller_fw,
 			g_set_error (error,
 				     FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
 				     "Unknown controller");
-			return FALSE;
+			return VALIDATION_FAILED;
 		}
 		hw_info = &unknown;
 	}


### PR DESCRIPTION
This seems like a bug, as `FALSE` == `0` == `VALIDATION_PASSED`
Am I missing something?

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
