### PR TITLE
synaptics-rmi: Also add the product ID as a GUID without the minor version

### DIFF
--- a/plugins/synaptics-rmi/README.md
+++ b/plugins/synaptics-rmi/README.md
@@ -14,6 +14,7 @@ The HID DeviceInstanceId values are used, e.g. `HIDRAW\VEN_06CB&DEV_4875`.
 These devices also use custom GUID values constructed using the board ID, e.g.
 
  * `SYNAPTICS_RMI\TM3038-002`
+ * `SYNAPTICS_RMI\TM3038`
 
 Firmware Format
 ---------------


### PR DESCRIPTION
Firmware may be suitable for all products that match the 'major ID' and so we
should provide an extra GUID to use in this case.