### PR TITLE
Read firmware back from the device as a FuFirmware

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -374,12 +374,13 @@ fu_altos_device_write_firmware (FuDevice *device,
 	return TRUE;
 }
 
-static GBytes *
+static FuFirmware *
 fu_altos_device_read_firmware (FuDevice *device, GError **error)
 {
 	FuAltosDevice *self = FU_ALTOS_DEVICE (device);
 	guint flash_len;
 	g_autoptr(FuDeviceLocker) locker  = NULL;
+	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GString) buf = g_string_new (NULL);
 
 	/* check kind */
@@ -433,7 +434,8 @@ fu_altos_device_read_firmware (FuDevice *device, GError **error)
 	}
 
 	/* success */
-	return g_bytes_new (buf->str, buf->len);
+	fw = g_bytes_new (buf->str, buf->len);
+	return fu_firmware_new_from_bytes (fw);
 }
 
 static gboolean

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -259,11 +259,12 @@ fu_csr_device_upload_chunk (FuCsrDevice *self, GError **error)
 			    sz - FU_CSR_COMMAND_HEADER_SIZE);
 }
 
-static GBytes *
+static FuFirmware *
 fu_csr_device_upload (FuDevice *device, GError **error)
 {
 	FuCsrDevice *self = FU_CSR_DEVICE (device);
 	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(GBytes) fw = NULL;
 	guint32 total_sz = 0;
 	gsize done_sz = 0;
 
@@ -323,7 +324,8 @@ fu_csr_device_upload (FuDevice *device, GError **error)
 	}
 
 	/* notify UI */
-	return dfu_utils_bytes_join_array (chunks);
+	fw = dfu_utils_bytes_join_array (chunks);
+	return fu_firmware_new_from_bytes (fw);
 }
 
 static gboolean

--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1998,11 +1998,12 @@ dfu_device_get_quirks_as_string (DfuDevice *device)
 	return g_string_free (str, FALSE);
 }
 
-static GBytes *
+static FuFirmware *
 dfu_device_read_firmware (FuDevice *device, GError **error)
 {
 	DfuDevice *self = DFU_DEVICE (device);
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
+	g_autoptr(GBytes) fw = NULL;
 
 	/* get data from hardware */
 	g_debug ("uploading from device->host");
@@ -2015,7 +2016,8 @@ dfu_device_read_firmware (FuDevice *device, GError **error)
 		return NULL;
 
 	/* get the checksum */
-	return dfu_firmware_write_data (dfu_firmware, error);
+	fw = dfu_firmware_write_data (dfu_firmware, error);
+	return fu_firmware_new_from_bytes (fw);
 }
 
 static gboolean

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -37,13 +37,14 @@ fu_optionrom_device_probe (FuUdevDevice *device, GError **error)
 	return TRUE;
 }
 
-static GBytes *
+static FuFirmware *
 fu_optionrom_device_read_firmware (FuDevice *device, GError **error)
 {
 	FuUdevDevice *udev_device = FU_UDEV_DEVICE (device);
 	g_autofree gchar *guid = NULL;
 	g_autofree gchar *rom_fn = NULL;
 	g_autoptr(FuRom) rom = NULL;
+	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GFile) file = NULL;
 
 	/* open the file */
@@ -81,7 +82,8 @@ fu_optionrom_device_read_firmware (FuDevice *device, GError **error)
 	fu_device_add_guid (device, guid);
 
 	/* get new data */
-	return fu_rom_get_data (rom);
+	fw = fu_rom_get_data (rom);
+	return fu_firmware_new_from_bytes (fw);
 }
 
 static void

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -417,18 +417,20 @@ fu_plugin_superio_fix_signature (FuSuperioDevice *self, GBytes *fw, GError **err
 	return g_bytes_new_take (g_steal_pointer (&buf2), sz);
 }
 
-static GBytes *
+static FuFirmware *
 fu_superio_it89_device_read_firmware (FuDevice *device, GError **error)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
 	guint64 fwsize = fu_device_get_firmware_size_min (device);
 	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GBytes) fw = NULL;
 
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
 	blob = fu_superio_it89_device_read_addr (self, 0x0, fwsize,
 						 fu_superio_it89_device_progress_cb,
 						 error);
-	return fu_plugin_superio_fix_signature (self, blob, error);
+	fw = fu_plugin_superio_fix_signature (self, blob, error);
+	return fu_firmware_new_from_bytes (fw);
 }
 
 static gboolean

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1899,11 +1899,11 @@ fu_device_prepare_firmware (FuDevice *self,
  *
  * Reads firmware from the device by calling a plugin-specific vfunc.
  *
- * Returns: (transfer full): A #GBytes, or %NULL for error
+ * Returns: (transfer full): A #FuFirmware, or %NULL for error
  *
  * Since: 1.0.8
  **/
-GBytes *
+FuFirmware *
 fu_device_read_firmware (FuDevice *self, GError **error)
 {
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (self);

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -26,7 +26,7 @@ struct _FuDeviceClass
 							 FuFirmware	*firmware,
 							 FwupdInstallFlags flags,
 							 GError		**error);
-	GBytes			*(*read_firmware)	(FuDevice	*self,
+	FuFirmware		*(*read_firmware)	(FuDevice	*self,
 							 GError		**error);
 	gboolean		 (*detach)		(FuDevice	*self,
 							 GError		**error);
@@ -218,7 +218,7 @@ FuFirmware	*fu_device_prepare_firmware		(FuDevice	*self,
 							 GBytes		*fw,
 							 FwupdInstallFlags flags,
 							 GError		**error);
-GBytes		*fu_device_read_firmware		(FuDevice	*self,
+FuFirmware	*fu_device_read_firmware		(FuDevice	*self,
 							 GError		**error);
 gboolean	 fu_device_attach			(FuDevice	*self,
 							 GError		**error);


### PR DESCRIPTION
Returning a GBytes is not good enough when the device may be returning multiple
partitions which have to be stored as FuFirmwareImage objects.
