### PR TITLE
trivial: Add klass->to_string for superclassed FuFirmwareImage objects

### DIFF
--- a/src/fu-firmware-image.c
+++ b/src/fu-firmware-image.c
@@ -243,17 +243,23 @@ void
 fu_firmware_image_add_string (FuFirmwareImage *self, guint idt, GString *str)
 {
 	FuFirmwareImagePrivate *priv = GET_PRIVATE (self);
+	FuFirmwareImageClass *klass = FU_FIRMWARE_IMAGE_GET_CLASS (self);
+
 	fu_common_string_append_kv (str, idt, G_OBJECT_TYPE_NAME (self), NULL);
 	if (priv->id != NULL)
-		fu_common_string_append_kv (str, idt + 1, "ID", priv->id);
+		fu_common_string_append_kv (str, idt, "ID", priv->id);
 	if (priv->idx != 0x0)
-		fu_common_string_append_kx (str, idt + 1, "Index", priv->idx);
+		fu_common_string_append_kx (str, idt, "Index", priv->idx);
 	if (priv->addr != 0x0)
-		fu_common_string_append_kx (str, idt + 1, "Address", priv->addr);
+		fu_common_string_append_kx (str, idt, "Address", priv->addr);
 	if (priv->bytes != NULL) {
-		fu_common_string_append_kx (str, idt + 1, "Data",
+		fu_common_string_append_kx (str, idt, "Data",
 					    g_bytes_get_size (priv->bytes));
 	}
+
+	/* vfunc */
+	if (klass->to_string != NULL)
+		klass->to_string (self, idt, str);
 }
 
 /**

--- a/src/fu-firmware-image.h
+++ b/src/fu-firmware-image.h
@@ -19,8 +19,11 @@ struct _FuFirmwareImageClass
 						 GBytes			*fw,
 						 FwupdInstallFlags	 flags,
 						 GError			**error);
+	void			 (*to_string)	(FuFirmwareImage	*self,
+						 guint			 idt,
+						 GString		*str);
 	/*< private >*/
-	gpointer		 padding[30];
+	gpointer		 padding[29];
 };
 
 FuFirmwareImage	*fu_firmware_image_new		(GBytes			*bytes);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4064,13 +4064,13 @@ fu_firmware_func (void)
 	str = fu_firmware_to_string (firmware);
 	g_assert_cmpstr (str, ==, "FuFirmware:\n"
 				  "  FuFirmwareImage:\n"
-				  "    ID:                  primary\n"
-				  "    Index:               0xd\n"
-				  "    Address:             0x200\n"
+				  "  ID:                    primary\n"
+				  "  Index:                 0xd\n"
+				  "  Address:               0x200\n"
 				  "  FuFirmwareImage:\n"
-				  "    ID:                  secondary\n"
-				  "    Index:               0x17\n"
-				  "    Address:             0x400\n");
+				  "  ID:                    secondary\n"
+				  "  Index:                 0x17\n"
+				  "  Address:               0x400\n");
 }
 
 int


### PR DESCRIPTION
This matches the behaviour of FuFirmware.
