### PR TITLE
Fix 8bitdo SN30/SF30 error reporting

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -167,6 +167,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "historical";
 	if (device_flag == FWUPD_DEVICE_FLAG_ONLY_SUPPORTED)
 		return "only-supported";
+	if (device_flag == FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)
+		return "will-disappear";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -235,6 +237,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_HISTORICAL;
 	if (g_strcmp0 (device_flag, "only-supported") == 0)
 		return FWUPD_DEVICE_FLAG_ONLY_SUPPORTED;
+	if (g_strcmp0 (device_flag, "will-disappear") == 0)
+		return FWUPD_DEVICE_FLAG_WILL_DISAPPEAR;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -91,6 +91,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_HISTORICAL		Device is for historical data only
  * @FWUPD_DEVICE_FLAG_ENSURE_SEMVER:		Ensure the version is a valid semantic version, e.g. numbers separated with dots
  * @FWUPD_DEVICE_FLAG_ONLY_SUPPORTED:		Only devices supported in the metadata will be opened
+ * @FWUPD_DEVICE_FLAG_WILL_DISAPPEAR:		Device will disappear after update and can't be verified
  *
  * The device flags.
  **/
@@ -119,6 +120,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_ENSURE_SEMVER		(1u << 21)	/* Since: 1.2.9 */
 #define FWUPD_DEVICE_FLAG_HISTORICAL		(1u << 22)	/* Since: 1.3.2 */
 #define FWUPD_DEVICE_FLAG_ONLY_SUPPORTED	(1u << 23)	/* Since: 1.3.3 */
+#define FWUPD_DEVICE_FLAG_WILL_DISAPPEAR	(1u << 24)	/* Since: 1.3.3 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -59,10 +59,10 @@ InstallDuration = 120
 # NES30PRO
 [DeviceInstanceId=USB\VID_2002&PID_9000]
 Plugin = ebitdo
-Flags = none
+Flags = will-disappear
 [DeviceInstanceId=USB\VID_2DC8&PID_9001]
 Plugin = ebitdo
-Flags = none
+Flags = will-disappear
 InstallDuration = 120
 
 # FC30_ARCADE
@@ -78,10 +78,10 @@ InstallDuration = 120
 ## Dinput mode (Start + B)
 [DeviceInstanceId=USB\VID_2DC8&PID_6000]
 Plugin = ebitdo
-Flags = none
+Flags = will-disappear
 [DeviceInstanceId=USB\VID_2DC8&PID_6001]
 Plugin = ebitdo
-Flags = none
+Flags = will-disappear
 InstallDuration = 120
 
 # M30

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -362,7 +362,6 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 	guint32 payload_len;
 	guint32 serial_new[3];
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GError) error_local = NULL;
 	const guint32 app_key_index[16] = {
 		0x186976e5, 0xcac67acd, 0x38f27fee, 0x0a4948f1,
 		0xb75b7753, 0x1f8ffa5c, 0xbff8cf43, 0xc4936167,
@@ -460,20 +459,12 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 				 FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA,
 				 FU_EBITDO_PKT_CMD_FW_UPDATE_HEADER,
 				 (const guint8 *) hdr, sizeof(FuEbitdoFirmwareHeader),
-				 &error_local)) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "failed to set up firmware header: %s",
-			     error_local->message);
+				 error)) {
+		g_prefix_error (error, "failed to set up firmware header:");
 		return FALSE;
 	}
-	if (!fu_ebitdo_device_receive (self, NULL, 0, &error_local)) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "failed to get ACK for fw update header: %s",
-			     error_local->message);
+	if (!fu_ebitdo_device_receive (self, NULL, 0, error)) {
+		g_prefix_error (error, "failed to get ACK for fw update header: ");
 		return FALSE;
 	}
 
@@ -491,20 +482,12 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 					 FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA,
 					 FU_EBITDO_PKT_CMD_FW_UPDATE_DATA,
 					 payload_data + offset, chunk_sz,
-					 &error_local)) {
-			g_set_error (error,
-				     G_IO_ERROR,
-				     G_IO_ERROR_INVALID_DATA,
-				     "Failed to write firmware @0x%04x: %s",
-				     offset, error_local->message);
+					 error)) {
+			g_prefix_error (error, "Failed to write firmware @0x%04x: ", offset);
 			return FALSE;
 		}
-		if (!fu_ebitdo_device_receive (self, NULL, 0, &error_local)) {
-			g_set_error (error,
-				     G_IO_ERROR,
-				     G_IO_ERROR_INVALID_DATA,
-				     "Failed to get ACK for write firmware @0x%04x: %s",
-				     offset, error_local->message);
+		if (!fu_ebitdo_device_receive (self, NULL, 0, error)) {
+			g_prefix_error (error, "Failed to get ACK for write firmware @0x%04x: ", offset);
 			return FALSE;
 		}
 	}
@@ -524,12 +507,8 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 				 FU_EBITDO_PKT_CMD_FW_SET_ENCODE_ID,
 				 (guint8 *) serial_new,
 				 sizeof(serial_new),
-				 &error_local)) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "failed to set encoding ID: %s",
-			     error_local->message);
+				 error)) {
+		g_prefix_error (error, "failed to set encoding ID: ");
 		return FALSE;
 	}
 
@@ -539,20 +518,12 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 				 FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA,
 				 FU_EBITDO_PKT_CMD_FW_UPDATE_OK,
 				 NULL, 0,
-				 &error_local)) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "failed to mark firmware as successful: %s",
-			     error_local->message);
+				 error)) {
+		g_prefix_error (error, "failed to mark firmware as successful: ");
 		return FALSE;
 	}
-	if (!fu_ebitdo_device_receive (self, NULL, 0, &error_local)) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "failed to get ACK for mark firmware as successful: %s",
-			     error_local->message);
+	if (!fu_ebitdo_device_receive (self, NULL, 0, error)) {
+		g_prefix_error (error, "failed to get ACK for mark firmware as successful: ");
 		return FALSE;
 	}
 

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -424,9 +424,11 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 		return FALSE;
 	}
 
-	/* print details about the firmware */
+
 	hdr = (FuEbitdoFirmwareHeader *) g_bytes_get_data (fw, NULL);
-	fu_ebitdo_dump_firmware_header (hdr);
+	/* print details about the firmware */
+	if (g_getenv ("FWUPD_EBITDO_VERBOSE") != NULL)
+		fu_ebitdo_dump_firmware_header (hdr);
 
 	/* check the file size */
 	payload_len = (guint32) (g_bytes_get_size (fw) - sizeof (FuEbitdoFirmwareHeader));

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -532,11 +532,16 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 	/* when doing a soft-reboot the device does not re-enumerate properly
 	 * so manually reboot the GUsbDevice */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	if (!g_usb_device_reset (usb_device, error)) {
 		g_prefix_error (error, "failed to force-reset device: ");
 		return FALSE;
 	}
+
+	/* not all 8bito devices come back in the right mode */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR))
+		fu_device_set_remove_delay (device, 0);
+	else
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success! */
 	return TRUE;

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -476,6 +476,12 @@ fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 	}
 
+	/* device won't come back in right mode */
+	if (fu_device_has_flag (item->device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+		g_debug ("copying will-disappear to new device");
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR);
+	}
+
 	/* copy the parent if not already set */
 	if (fu_device_get_parent (item->device) != NULL &&
 	    fu_device_get_parent (device) == NULL) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1883,6 +1883,12 @@ fu_engine_update_attach (FuEngine *self, const gchar *device_id, GError **error)
 					      error);
 	if (plugin == NULL)
 		return FALSE;
+
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+		g_debug ("skipping attach due to will-disappear flag");
+		return TRUE;
+	}
+
 	if (!fu_plugin_runner_update_attach (plugin, device, error))
 		return FALSE;
 	return TRUE;
@@ -1936,6 +1942,12 @@ fu_engine_update_reload (FuEngine *self, const gchar *device_id, GError **error)
 					      error);
 	if (plugin == NULL)
 		return FALSE;
+
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+		g_debug ("skipping reload due to will-disappear flag");
+		return TRUE;
+	}
+
 	if (!fu_plugin_runner_update_reload (plugin, device, error)) {
 		g_prefix_error (error, "failed to reload device: ");
 		return FALSE;


### PR DESCRIPTION
These controllers don't come back into the correct mode for fwupd after flash so 3 failures occur:
1. Waiting for replug
2. Trying to attach to application mode again
3. Trying to reload for version info

Skip those steps so that the flash process completes successfully.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
