### PR TITLE
wacom-emr: Fix a regression for EMR devices

### DIFF
--- a/plugins/wacom-raw/fu-wacom-emr-device.h
+++ b/plugins/wacom-raw/fu-wacom-emr-device.h
@@ -9,6 +9,6 @@
 #include "fu-wacom-device.h"
 
 #define FU_TYPE_WACOM_EMR_DEVICE (fu_wacom_emr_device_get_type ())
-G_DECLARE_FINAL_TYPE (FuWacomEmrDevice, fu_wacom_emr_device, FU, WACOM_EMR_DEVICE, FuUdevDevice)
+G_DECLARE_FINAL_TYPE (FuWacomEmrDevice, fu_wacom_emr_device, FU, WACOM_EMR_DEVICE, FuWacomDevice)
 
 FuWacomEmrDevice	*fu_wacom_emr_device_new	(FuUdevDevice	*device);


### PR DESCRIPTION
Actually trying to instantiate the object leads to:

    Specified class size for type 'FuWacomEmrDevice' is smaller than the
    parent type's 'FuWacomDevice' class size.

Fixes https://github.com/fwupd/fwupd/issues/1456
