### PR TITLE
trivial: make verify and verify-update safer

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -169,6 +169,10 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "only-supported";
 	if (device_flag == FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)
 		return "will-disappear";
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_VERIFY)
+		return "can-verify";
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE)
+		return "can-verify-image";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -239,6 +243,10 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_ONLY_SUPPORTED;
 	if (g_strcmp0 (device_flag, "will-disappear") == 0)
 		return FWUPD_DEVICE_FLAG_WILL_DISAPPEAR;
+	if (g_strcmp0 (device_flag, "can-verify") == 0)
+		return FWUPD_DEVICE_FLAG_CAN_VERIFY;
+	if (g_strcmp0 (device_flag, "can-verify-image") == 0)
+		return FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -92,6 +92,8 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_ENSURE_SEMVER:		Ensure the version is a valid semantic version, e.g. numbers separated with dots
  * @FWUPD_DEVICE_FLAG_ONLY_SUPPORTED:		Only devices supported in the metadata will be opened
  * @FWUPD_DEVICE_FLAG_WILL_DISAPPEAR:		Device will disappear after update and can't be verified
+ * @FWUPD_DEVICE_FLAG_CAN_VERIFY:		Device checksums can be compared against metadata
+ * @FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE:		Image can be dumped from device for verification
  *
  * The device flags.
  **/
@@ -121,6 +123,8 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_HISTORICAL		(1u << 22)	/* Since: 1.3.2 */
 #define FWUPD_DEVICE_FLAG_ONLY_SUPPORTED	(1u << 23)	/* Since: 1.3.3 */
 #define FWUPD_DEVICE_FLAG_WILL_DISAPPEAR	(1u << 24)	/* Since: 1.3.3 */
+#define FWUPD_DEVICE_FLAG_CAN_VERIFY		(1u << 25)	/* Since: 1.3.3 */
+#define FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE	(1u << 26)	/* Since: 1.3.3 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -91,6 +91,7 @@ fu_optionrom_device_init (FuOptionromDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 }
 
 static void

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -448,6 +448,7 @@ fu_superio_device_init (FuSuperioDevice *self)
 {
 	fu_device_set_physical_id (FU_DEVICE (self), "/dev/port");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_set_summary (FU_DEVICE (self), "Embedded Controller");
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -468,7 +468,7 @@ fu_superio_it89_device_detach (FuDevice *device, GError **error)
 	}
 
 	/* success */
-	fu_device_add_flag (self, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	return TRUE;
 }
 

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -434,6 +434,7 @@ static void
 fu_synaprom_device_init (FuSynapromDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_name (FU_DEVICE (self), "Prometheus");
 	fu_device_set_summary (FU_DEVICE (self), "Fingerprint reader");

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -41,6 +41,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_set_name (device, "Integrated_Webcam(TM)");
 	fu_device_add_icon (device, "preferences-desktop-keyboard");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY);
 	fu_device_set_summary (device, "A fake webcam");
 	fu_device_set_vendor (device, "ACME Corp.");
 	fu_device_set_vendor_id (device, "USB:0x046D");

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -100,6 +100,11 @@ fu_plugin_verify (FuPlugin *plugin,
 		  FuPluginVerifyFlags flags,
 		  GError **error)
 {
+	if (g_strcmp0 (fu_device_get_version (device), "1.2.2") == 0) {
+		fu_device_add_checksum (device, "90d0ad436d21e0687998cd2127b2411135e1f730");
+		fu_device_add_checksum (device, "921631916a60b295605dbae6a0309f9b64e2401b3de8e8506e109fc82c586e3a");
+		return TRUE;
+	}
 	if (g_strcmp0 (fu_device_get_version (device), "1.2.3") == 0) {
 		fu_device_add_checksum (device, "7998cd212721e068b2411135e1f90d0ad436d730");
 		fu_device_add_checksum (device, "dbae6a0309b3de8e850921631916a60b2956056e109fc82c586e3f9b64e2401a");

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -554,6 +554,7 @@ fu_uefi_device_probe (FuDevice *device, GError **error)
 	/* set the PCR0 as the device checksum */
 	if (self->kind == FU_UEFI_DEVICE_KIND_SYSTEM_FIRMWARE) {
 		g_autoptr(GError) error_local = NULL;
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY);
 		if (!fu_uefi_device_add_system_checksum (device, &error_local))
 			g_warning ("Failed to get PCR0s: %s", error_local->message);
 	}

--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -215,6 +215,32 @@ fu_common_version_ensure_semver (const gchar *version)
 gchar *
 fu_common_version_parse (const gchar *version)
 {
+	return fu_common_version_parse_from_format (version, FWUPD_VERSION_FORMAT_TRIPLET);
+}
+
+/**
+ * fu_common_version_parse_from_format
+ * @version: A version number
+ * @fmt: A FwupdVersionFormat
+ *
+ * Returns a dotted decimal version string from a version string using fmt.
+ * The supported formats are:
+ *
+ * - Dotted decimal, e.g. "1.2.3"
+ * - Base 16, a hex number *with* a 0x prefix, e.g. "0x10203"
+ * - Base 10, a string containing just [0-9], e.g. "66051"
+ * - Date in YYYYMMDD format, e.g. 20150915
+ *
+ * Anything with a '.' or that doesn't match [0-9] or 0x[a-f,0-9] is considered
+ * a string and returned without modification.
+ *
+ * Returns: A version number, e.g. "1.0.3"
+ *
+ * Since: 1.3.3
+ */
+gchar *
+fu_common_version_parse_from_format (const gchar *version, FwupdVersionFormat fmt)
+{
 	const gchar *version_noprefix = version;
 	gchar *endptr = NULL;
 	guint64 tmp;
@@ -246,7 +272,7 @@ fu_common_version_parse (const gchar *version)
 		return g_strdup (version);
 	if (tmp == 0)
 		return g_strdup (version);
-	return fu_common_version_from_uint32 ((guint32) tmp, FWUPD_VERSION_FORMAT_TRIPLET);
+	return fu_common_version_from_uint32 ((guint32) tmp, fmt);
 }
 
 /**

--- a/src/fu-common-version.h
+++ b/src/fu-common-version.h
@@ -16,6 +16,8 @@ gchar		*fu_common_version_from_uint32	(guint32	 val,
 gchar		*fu_common_version_from_uint16	(guint16	 val,
 						 FwupdVersionFormat kind);
 gchar		*fu_common_version_parse	(const gchar	*version);
+gchar		*fu_common_version_parse_from_format	(const gchar	*version,
+							 FwupdVersionFormat	fmt);
 gchar		*fu_common_version_ensure_semver (const gchar	*version);
 FwupdVersionFormat	 fu_common_version_guess_format	(const gchar	*version);
 gboolean	 fu_common_version_verify_format	(const gchar	*version,

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1405,6 +1405,14 @@ fu_device_get_physical_id (FuDevice *self)
 	return priv->physical_id;
 }
 
+void
+fu_device_add_flag (FuDevice *self, FwupdDeviceFlags flag)
+{
+	if (flag & FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE)
+		flag |= FWUPD_DEVICE_FLAG_CAN_VERIFY;
+	fwupd_device_add_flag (FWUPD_DEVICE (self), flag);
+}
+
 static void
 fu_device_set_custom_flag (FuDevice *self, const gchar *hint)
 {
@@ -1911,8 +1919,10 @@ fu_device_read_firmware (FuDevice *self, GError **error)
 	g_return_val_if_fail (FU_IS_DEVICE (self), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
-	/* no plugin-specific method */
-	if (klass->read_firmware == NULL) {
+
+	/* no plugin-specific method or device doesn't support */
+	if (!fu_device_has_flag (self, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE) ||
+	    klass->read_firmware == NULL) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -83,7 +83,6 @@ struct _FuDeviceClass
 FuDevice	*fu_device_new				(void);
 
 /* helpful casting macros */
-#define fu_device_add_flag(d,v)			fwupd_device_add_flag(FWUPD_DEVICE(d),v)
 #define fu_device_remove_flag(d,v)		fwupd_device_remove_flag(FWUPD_DEVICE(d),v)
 #define fu_device_has_flag(d,v)			fwupd_device_has_flag(FWUPD_DEVICE(d),v)
 #define fu_device_has_instance_id(d,v)		fwupd_device_has_instance_id(FWUPD_DEVICE(d),v)
@@ -179,6 +178,8 @@ void		 fu_device_set_physical_id		(FuDevice	*self,
 const gchar	*fu_device_get_logical_id		(FuDevice	*self);
 void		 fu_device_set_logical_id		(FuDevice	*self,
 							 const gchar	*logical_id);
+void		 fu_device_add_flag			(FuDevice	*self,
+							 FwupdDeviceFlags flag);
 const gchar	*fu_device_get_custom_flags		(FuDevice	*self);
 gboolean	 fu_device_has_custom_flag		(FuDevice	*self,
 							 const gchar	*hint);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -860,14 +860,27 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 	/* try again with the system metadata */
 	if (release == NULL) {
 		GPtrArray *guids = fu_device_get_guids (device);
+		FwupdVersionFormat fmt = fu_device_get_version_format (device);
 		for (guint i = 0; i < guids->len; i++) {
 			const gchar *guid = g_ptr_array_index (guids, i);
 			g_autofree gchar *xpath2 = NULL;
+			g_autoptr(GPtrArray) releases = NULL;
 			xpath2 = g_strdup_printf ("components/component/"
 						  "provides/firmware[@type='flashed'][text()='%s']/"
-						  "../../releases/release[@version='%s']",
-						  guid, version);
-			release = xb_silo_query_first (self->silo, xpath2, NULL);
+						  "../../releases/release",
+						  guid);
+			releases = xb_silo_query (self->silo, xpath2, 0, error);
+			if (releases == NULL)
+				return FALSE;
+			for (guint j = 0; j < releases->len; j++) {
+				XbNode *rel = g_ptr_array_index (releases, j);
+				const gchar *rel_ver = xb_node_get_attr (rel, "version");
+				g_autofree gchar *tmp_ver = fu_common_version_parse_from_format (rel_ver, fmt);
+				if (fu_common_vercmp (tmp_ver, version) == 0) {
+					release = g_object_ref (rel);
+					break;
+				}
+			}
 			if (release != NULL)
 				break;
 		}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -922,13 +922,14 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 
 		/* get all checksums to display a useful error */
 		xb_string_append_union (xpath, "checksum[@target='device']");
-		xb_string_append_union (xpath, "checksum[@target='content']");
+		if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE))
+			xb_string_append_union (xpath, "checksum[@target='content']");
 		csums = xb_node_query (release, xpath->str, 0, NULL);
 		if (csums == NULL) {
 			g_set_error (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_FOUND,
-				     "No device or content checksum for %s",
+				     "No stored checksums for %s",
 				     version);
 			return FALSE;
 		}
@@ -944,7 +945,8 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_FOUND,
-			     "For v%s expected %s, got %s",
+			     "For %s %s expected %s, got %s",
+			     fu_device_get_name (device),
 			     version,
 			     checksums_metadata->str,
 			     checksums_device->str);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -827,10 +827,12 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 	if (plugin == NULL)
 		return FALSE;
 
-	/* set the device firmware hash */
-	if (!fu_plugin_runner_verify (plugin, device,
-				      FU_PLUGIN_VERIFY_FLAG_NONE, error))
-		return FALSE;
+	/* update the device firmware hashes if possible */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE)) {
+		if (!fu_plugin_runner_verify (plugin, device,
+					      FU_PLUGIN_VERIFY_FLAG_NONE, error))
+			return FALSE;
+	}
 
 	/* find component in metadata */
 	version = fu_device_get_version (device);
@@ -874,7 +876,7 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_FOUND,
-			     "No version %s", version);
+			     "No release found for version %s", version);
 		return FALSE;
 	}
 

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1752,7 +1752,6 @@ fu_plugin_runner_verify (FuPlugin *self,
 	/* optional */
 	g_module_symbol (priv->module, "fu_plugin_verify", (gpointer *) &func);
 	if (func == NULL) {
-		g_debug ("running superclassed read_firmware() on %s", priv->name);
 		return fu_plugin_device_read_firmware (self, device, error);
 	}
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1056,6 +1056,7 @@ fu_util_verify_update (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FwupdDevice) dev = NULL;
 
+	priv->filter_include |= FWUPD_DEVICE_FLAG_CAN_VERIFY;
 	dev = fu_util_get_device_or_prompt (priv, values, error);
 	if (dev == NULL)
 		return FALSE;
@@ -1489,6 +1490,7 @@ fu_util_verify (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FwupdDevice) dev = NULL;
 
+	priv->filter_include |= FWUPD_DEVICE_FLAG_CAN_VERIFY;
 	dev = fu_util_get_device_or_prompt (priv, values, error);
 	if (dev == NULL)
 		return FALSE;
@@ -2450,7 +2452,7 @@ main (int argc, char *argv[])
 		     "verify",
 		     "[DEVICE_ID]",
 		     /* TRANSLATORS: command description */
-		     _("Gets the cryptographic hash of the dumped firmware"),
+		     _("Checks cryptographic hash matches firmware"),
 		     fu_util_verify);
 	fu_util_cmd_array_add (cmd_array,
 		     "unlock",
@@ -2504,7 +2506,7 @@ main (int argc, char *argv[])
 		     "verify-update",
 		     "[DEVICE_ID]",
 		     /* TRANSLATORS: command description */
-		     _("Update the stored metadata with current ROM contents"),
+		     _("Update the stored cryptographic hash with current ROM contents"),
 		     fu_util_verify_update);
 	fu_util_cmd_array_add (cmd_array,
 		     "modify-remote",


### PR DESCRIPTION
Don't show output for all devices - it doesn't work for most of them.

I also found that running verify on my Synaptics touchpad device puts it
into a pretty bad state until reboot.  That's of course a problem on
it's own, but at least prompting for it will prevent it from easily
happening.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
