### PR TITLE
plugins: Add coreboot plugin

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -289,6 +289,7 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %{_libdir}/fwupd-plugins-3/libfu_plugin_amt.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_ata.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_colorhug.so
+%{_libdir}/fwupd-plugins-3/libfu_plugin_coreboot.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_csr.so
 %if 0%{?have_dell}
 %{_libdir}/fwupd-plugins-3/libfu_plugin_dell.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,6 +19,7 @@ option('plugin_uefi', type : 'boolean', value : true, description : 'enable UEFI
 option('plugin_nvme', type : 'boolean', value : true, description : 'enable NVMe support')
 option('plugin_modem_manager', type : 'boolean', value : false, description : 'enable ModemManager support')
 option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
+option('plugin_coreboot', type : 'boolean', value : true, description : 'enable coreboot support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
 option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
 option('elogind', type : 'boolean', value : false, description : 'enable elogind support')

--- a/plugins/coreboot/README.md
+++ b/plugins/coreboot/README.md
@@ -1,0 +1,43 @@
+coreboot
+========
+
+Introduction
+------------
+
+Until now only the version detection has been implemented.
+
+System identification
+---------------------
+
+coreboot can be detected the following ways:
+1. by parsing SMBIOS type 0 vendor string. On coreboot enabled platforms
+   it's always `coreboot`.
+2. by parsing ACPI tables. An ACPI device with the _HID `BOOT0000` exists.
+   (This HID has been reserved for coreboot enabled platforms)
+3. by parsing the devicetree. A node under *firmware/coreboot* with the
+   compatible id `coreboot` exists.
+
+coreboot version string
+-----------------------
+
+The coreboot version string always starts with `CBET`.
+After the prefix the *version*, *major*, *minor* string follows and finally
+the *build string*, containing the exact commit and repository state, follows.
+
+For example:
+> CBET4000 4.10-989-gc8a4e4b9c5-dirty
+
+GUID Generation
+---------------
+
+These device uses hardware ID values which are derived from SMBIOS.
+The following HWIDs are added on coreboot enabled platforms:
+
+* HardwareID-3
+* HardwareID-4
+* HardwareID-5
+* HardwareID-6
+* HardwareID-10
+
+They do match the values provided by `fwupdtool hwids` or
+the `ComputerHardwareIds.exe` Windows utility.

--- a/plugins/coreboot/fu-coreboot-common.c
+++ b/plugins/coreboot/fu-coreboot-common.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 9elements Agency GmbH <patrick.rudolph@9elements.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <stdio.h>
+
+#include "fu-plugin-coreboot.h"
+
+/* Tries to convert the coreboot version string to a triplet string.
+ * Returns NULL on error.
+ */
+const gchar *
+fu_plugin_coreboot_version_string_to_triplet (const gchar *coreboot_version,
+					      GError **error)
+{
+	guint cb_version = 0;
+	guint cb_major = 0;
+	guint cb_minor = 0;
+	guint cb_build = 0;
+	gint rc;
+
+	rc = sscanf (coreboot_version, "CBET%u %u.%u-%u", &cb_version, &cb_major,
+			&cb_minor, &cb_build);
+	if (rc < 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "Failed to parse firmware version");
+		return NULL;
+	}
+
+	/* Sanity check */
+	if (cb_major == 0 || cb_version == 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "Invalid firmware version");
+		return NULL;
+	}
+
+	return g_strdup_printf ("%u.%u.%u", cb_major, cb_minor, cb_build);
+}
+
+/* convert firmware type to user friendly string representation */
+const gchar*
+fu_plugin_coreboot_get_name_for_type (FuPlugin *plugin,
+				      const gchar *vboot_partition)
+{
+	GString *display_name;
+
+	if (vboot_partition != NULL) {
+		display_name = g_string_new (vboot_partition);
+		g_string_prepend (display_name, ", VBOOT partition ");
+	} else {
+		display_name = g_string_new ("");
+	}
+
+	g_string_prepend (display_name, "coreboot System Firmware");
+	return g_string_free (display_name, FALSE);
+}

--- a/plugins/coreboot/fu-plugin-coreboot.c
+++ b/plugins/coreboot/fu-plugin-coreboot.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2019 9elements Agency GmbH <patrick.rudolph@9elements.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include "fu-plugin-vfuncs.h"
+#include "fu-device-metadata.h"
+#include "fu-device-private.h"
+#include "fu-plugin-coreboot.h"
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+}
+
+gboolean
+fu_plugin_coldplug (FuPlugin *plugin, GError **error)
+{
+	g_autofree const gchar *triplet = NULL;
+	g_autofree gchar *name = NULL;
+	const gchar *major;
+	const gchar *minor;
+	const gchar *vendor;
+	const gchar *version;
+	GBytes *bios_table;
+	gboolean updatable = FALSE; /* TODO: Implement update support */
+	g_autoptr(FuDevice) dev = NULL;
+
+	/* don't inlcude FU_HWIDS_KEY_BIOS_VERSION */
+	static const gchar *hwids[] = {
+		"HardwareID-3",
+		"HardwareID-4",
+		"HardwareID-5",
+		"HardwareID-6",
+		"HardwareID-10",
+	};
+
+	vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+	if (vendor == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_FOUND,
+			     "Failed to get DMI value FU_HWIDS_KEY_BIOS_VENDOR");
+		return FALSE;
+	}
+
+	version = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION);
+	if (version != NULL)
+		triplet = fu_plugin_coreboot_version_string_to_triplet (version, error);
+
+	if (version == NULL || triplet == NULL) {
+		major = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_MAJOR_RELEASE);
+		if (major == NULL) {
+			g_set_error (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_NOT_FOUND,
+				     "Missing BIOS major release");
+			return FALSE;
+		}
+		minor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_MINOR_RELEASE);
+		if (minor == NULL) {
+			g_set_error (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_NOT_FOUND,
+				     "Missing BIOS minor release");
+			return FALSE;
+		}
+		triplet = g_strdup_printf ("%s.%s.0", major, minor);
+	}
+
+	if (triplet == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "No version string found");
+
+		return FALSE;
+	}
+	dev = fu_device_new ();
+
+	fu_device_set_version (dev, triplet, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_summary (dev, "Open Source system boot firmware");
+	fu_device_set_id (dev, vendor);
+	fu_device_set_vendor (dev, vendor);
+	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_icon (dev, "computer");
+	name = fu_plugin_coreboot_get_name_for_type (plugin, NULL);
+	if (name == NULL)
+		name = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
+	fu_device_set_name (dev, name);
+	fu_device_set_vendor (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER));
+	fu_device_add_instance_id (dev, "main-system-firmware");
+
+	for (guint i = 0; i < G_N_ELEMENTS (hwids); i++) {
+		char *str;
+		str = fu_plugin_get_hwid_replace_value (plugin, hwids[i], NULL);
+		if (str != NULL)
+			fu_device_add_instance_id (dev, str);
+	}
+
+	bios_table = fu_plugin_get_smbios_data (plugin, FU_SMBIOS_STRUCTURE_TYPE_BIOS);
+	if (bios_table != NULL) {
+		guint32 bios_characteristics;
+		gsize len;
+		const guint8 *value = g_bytes_get_data (bios_table, &len);
+		if (len >= 0x9) {
+			gint firmware_size = (value[0x9] + 1) * 64 * 1024;
+			fu_device_set_firmware_size_max (dev, firmware_size);
+		}
+		if (len >= (0xa + sizeof(guint32))) {
+			memcpy (&bios_characteristics, &value[0xa], sizeof (guint32));
+			/* Read the "BIOS is upgradeable (Flash)" flag */
+			if (!(bios_characteristics & (1 << 11)))
+				updatable = FALSE;
+		}
+	}
+
+	if (updatable)
+		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+
+	/* convert instances to GUID */
+	fu_device_convert_instance_ids (dev);
+
+	fu_plugin_device_add (plugin, dev);
+
+	return TRUE;
+}
+
+gboolean
+fu_plugin_startup (FuPlugin *plugin, GError **error)
+{
+	const gchar *vendor;
+
+	vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+	if (g_strcmp0 (vendor, "coreboot") != 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_FOUND,
+			     "No coreboot detected on this machine.");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+

--- a/plugins/coreboot/fu-plugin-coreboot.h
+++ b/plugins/coreboot/fu-plugin-coreboot.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2019 9elements Agency GmbH <patrick.rudolph@9elements.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-plugin.h"
+#include "fu-device.h"
+
+const gchar *	fu_plugin_coreboot_version_string_to_triplet	(const gchar	*coreboot_version,
+								 GError		**error);
+
+const gchar*	fu_plugin_coreboot_get_name_for_type	(FuPlugin	*plugin,
+							 const gchar	*vboot_partition);

--- a/plugins/coreboot/meson.build
+++ b/plugins/coreboot/meson.build
@@ -1,0 +1,24 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginCoreboot"']
+
+shared_module('fu_plugin_coreboot',
+  sources : [
+    'fu-plugin-coreboot.c',
+    'fu-coreboot-common.c',
+  ],
+  include_directories : [
+    include_directories('../..'),
+    include_directories('../../src'),
+    include_directories('../../libfwupd'),
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
+  c_args : [
+    cargs,
+  ],
+  dependencies : [
+    plugin_deps,
+  ],
+)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,6 +1,7 @@
 subdir('ata')
 subdir('dfu')
 subdir('colorhug')
+subdir('coreboot')
 subdir('ebitdo')
 subdir('fastboot')
 subdir('steelseries')

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -510,6 +510,29 @@ fu_plugin_check_hwid (FuPlugin *self, const gchar *hwid)
 }
 
 /**
+ * fu_plugin_get_hwid_replace_value:
+ * @self: A #FuPlugin
+ * @keys: A key, e.g. `HardwareID-3` or %FU_HWIDS_KEY_PRODUCT_SKU
+ * @error: A #GError or %NULL
+ *
+ * Gets the replacement value for a specific key. All hardware IDs on a
+ * specific system can be shown using the `fwupdmgr hwids` command.
+ *
+ * Returns: (transfer full): a string, or %NULL for error.
+ *
+ * Since: 1.3.3
+ **/
+gchar *
+fu_plugin_get_hwid_replace_value (FuPlugin *self, const gchar *keys, GError **error)
+{
+	FuPluginPrivate *priv = GET_PRIVATE (self);
+	if (priv->hwids == NULL)
+		return NULL;
+
+	return fu_hwids_get_replace_values (priv->hwids, keys, error);
+}
+
+/**
  * fu_plugin_get_hwids:
  * @self: A #FuPlugin
  *

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -118,6 +118,9 @@ void		 fu_plugin_cache_add			(FuPlugin	*self,
 							 gpointer	 dev);
 gboolean	 fu_plugin_check_hwid			(FuPlugin	*self,
 							 const gchar	*hwid);
+gchar		*fu_plugin_get_hwid_replace_value	(FuPlugin	*self,
+							 const gchar	*keys,
+							 GError		**error);
 GPtrArray	*fu_plugin_get_hwids			(FuPlugin	*self);
 gboolean	 fu_plugin_check_supported		(FuPlugin	*self,
 							 const gchar	*guid);


### PR DESCRIPTION
Detect and parse current coreboot version.
An update mechanism isn't implemented as the kernel interface isn't
stable yet and will be implemented in a seperate commit.

Tested on coreboot enabled machine.
Example output:
coreboot System Firmware
  DeviceId:             81104bde9db7cb037936659ea727c739f47a5029
  Guid:                 230c8b18-8d9b-53ec-838b-6cfc0383493a <- main-system-firmware
  Guid:                 661cc3dc-620e-5de6-b50f-e908aaf481c9 <- LENOVO&ThinkPad T410&2537VG5&coreboot&CBET4000 4.10-991-ga726bfeb7d-dirty
  Guid:                 8a05bfaf-6915-54dc-aecb-1c1416a7be8e <- LENOVO&ThinkPad T410&2537VG5&coreboot
  Summary:              Open Source system boot firmware
  Plugin:               coreboot
  Flags:                internal|registered
  Vendor:               LENOVO
  Version:              4.10.991
  VersionFormat:        triplet
  Icon:                 computer
  Created:              2019-10-14

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>

Type of pull request:
- [x] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
