### PR TITLE
trivial: synaptics-cxaudio: Add Google Pixel buds

### DIFF
--- a/plugins/synaptics-cxaudio/synaptics-cxaudio.quirk
+++ b/plugins/synaptics-cxaudio/synaptics-cxaudio.quirk
@@ -10,6 +10,10 @@ Guid = SYNAPTICS_CXAUDIO\CX2198X
 [DeviceInstanceId=USB\VID_17EF&PID_A396]
 Guid = SYNAPTICS_CXAUDIO\CX2198X
 
+# Google Pixel USB-C headphones
+[DeviceInstanceId=USB\VID_18D1&PID_5033]
+Guid = SYNAPTICS_CXAUDIO\CX2198X
+
 [Guid=SYNAPTICS_CXAUDIO\CX2098X]
 Plugin = synaptics_cxaudio
 ChipIdBase = 20980


### PR DESCRIPTION
I saw a mention that they're actually CX21986 and had some on hand.
They do enumerate:

```
├─Pixel USB-C earbuds:
│     Device ID:           672c087de09848d9e7ee32aa1dea2fbeb8b81e6b
│     Summary:             CX21986 USB audio device
│     Current version:     71.133.20
│     Bootloader Version:  03.01.00.00
│     Vendor:              Google (USB:0x18D1)
│     Install Duration:    3 seconds
│     Flags:               updatable|registered
│     GUIDs:               d76048a5-ca69-5cb8-ac86-d418d70c5f29
│                          98043a29-72c5-549b-ad23-de4e2db20a14
│                          93279fe8-d478-531b-9637-05d026be3c2e
│                          8b71f776-f6d0-549d-9547-42740b24bbbc
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
