### PR TITLE
trivial: fu-util: break out of automatic reports if one is not automatic

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -345,8 +345,10 @@ fu_util_perhaps_show_unreported (FuUtilPrivate *priv, GError **error)
 		g_debug ("%s is %d", fwupd_remote_get_title (remote), remote_automatic);
 		if (remote_automatic && !all_automatic)
 			all_automatic = TRUE;
-		if (!remote_automatic && all_automatic)
+		if (!remote_automatic && all_automatic) {
 			all_automatic = FALSE;
+			break;
+		}
 	}
 
 	/* check that they can be reported */


### PR DESCRIPTION
Currently this is controlled by the order of remotes enumerated and might
return the wrong result with too many remotes.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
