### PR TITLE
trivial: colorhug: fix a crash that occurs when flashing sometimes

### DIFF
--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -137,10 +137,13 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 
 	/* check error code */
 	if (buf[0] != CH_ERROR_NONE) {
+		const gchar *msg = ch_strerror (buf[0]);
+		if (msg == NULL)
+			msg = "unknown error";
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INTERNAL,
-				     ch_strerror (buf[0]));
+				     msg);
 		return FALSE;
 	}
 


### PR DESCRIPTION
If calling `ch_strerror` with some values returns `NULL` which makes
the `GError` not get populated.

```
    (self=0x560d7b57e160 [FuPlugin], device=0x560d7b5c4520 [FuColorhugDevice], symbol_name=0x560d7a3d4258 "fu_plugin_update_attach", device_func=0x560d7a3a4ac1 <fu_plugin_device_attach>, error=0x7ffc57a51040) at ../src/fu-plugin.c:1049
    (self=0x560d7b4b9830 [FuEngine], device_id=0x560d7b64f200 "d45c9d222f7eeb3987c6a7674478bc6aec127b3f", blob_fw2=0x560d7b62c0d0, flags=FWUPD_INSTALL_FLAG_NONE, error=0x7ffc57a51150)
    at ../src/fu-engine.c:2001
    at ../src/fu-engine.c:2064
    at ../src/fu-engine.c:1687
    at ../src/fu-engine.c:1441

(gdb) print error_local
$1 = (GError_autoptr) 0x0
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
