### PR TITLE
trivial: coreboot: fix a clang compiler error

### DIFF
--- a/plugins/coreboot/fu-coreboot-common.c
+++ b/plugins/coreboot/fu-coreboot-common.c
@@ -12,9 +12,8 @@
 #include "fu-plugin-coreboot.h"
 
 /* Tries to convert the coreboot version string to a triplet string.
- * Returns NULL on error.
- */
-const gchar *
+ * Returns NULL on error. */
+gchar *
 fu_plugin_coreboot_version_string_to_triplet (const gchar *coreboot_version,
 					      GError **error)
 {
@@ -47,7 +46,7 @@ fu_plugin_coreboot_version_string_to_triplet (const gchar *coreboot_version,
 }
 
 /* convert firmware type to user friendly string representation */
-const gchar*
+gchar *
 fu_plugin_coreboot_get_name_for_type (FuPlugin *plugin,
 				      const gchar *vboot_partition)
 {

--- a/plugins/coreboot/fu-plugin-coreboot.c
+++ b/plugins/coreboot/fu-plugin-coreboot.c
@@ -25,14 +25,14 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
-	g_autofree const gchar *triplet = NULL;
-	g_autofree gchar *name = NULL;
 	const gchar *major;
 	const gchar *minor;
 	const gchar *vendor;
 	const gchar *version;
 	GBytes *bios_table;
 	gboolean updatable = FALSE; /* TODO: Implement update support */
+	g_autofree gchar *name = NULL;
+	g_autofree gchar *triplet = NULL;
 	g_autoptr(FuDevice) dev = NULL;
 
 	/* don't inlcude FU_HWIDS_KEY_BIOS_VERSION */
@@ -94,9 +94,11 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (dev, "computer");
 	name = fu_plugin_coreboot_get_name_for_type (plugin, NULL);
-	if (name == NULL)
-		name = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
-	fu_device_set_name (dev, name);
+	if (name != NULL) {
+		fu_device_set_name (dev, name);
+	} else {
+		fu_device_set_name (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME));
+	}
 	fu_device_set_vendor (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER));
 	fu_device_add_instance_id (dev, "main-system-firmware");
 

--- a/plugins/coreboot/fu-plugin-coreboot.h
+++ b/plugins/coreboot/fu-plugin-coreboot.h
@@ -9,8 +9,7 @@
 #include "fu-plugin.h"
 #include "fu-device.h"
 
-const gchar *	fu_plugin_coreboot_version_string_to_triplet	(const gchar	*coreboot_version,
+gchar		*fu_plugin_coreboot_version_string_to_triplet	(const gchar	*coreboot_version,
 								 GError		**error);
-
-const gchar*	fu_plugin_coreboot_get_name_for_type	(FuPlugin	*plugin,
-							 const gchar	*vboot_partition);
+gchar		*fu_plugin_coreboot_get_name_for_type		(FuPlugin	*plugin,
+								const gchar	*vboot_partition);


### PR DESCRIPTION
```
../plugins/coreboot/fu-plugin-coreboot.c:96:7: error: assigning to 'gchar *' (aka 'char *') from 'const gchar *' (aka 'const char *') discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]

        name = fu_plugin_coreboot_get_name_for_type (plugin, NULL);

             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

../plugins/coreboot/fu-plugin-coreboot.c:98:8: error: assigning to 'gchar *' (aka 'char *') from 'const gchar *' (aka 'const char *') discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]

                name = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME);
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
