### PR TITLE
trivial: don't try to enable LVFS from systemd

### DIFF
--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -16,5 +16,5 @@ ProtectKernelModules=yes
 ProtectControlGroups=yes
 RestrictRealtime=yes
 SuccessExitStatus=2
-ExecStart=@bindir@/fwupdmgr refresh
+ExecStart=@bindir@/fwupdmgr refresh --no-metadata-check
 @dynamic_options@

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1326,6 +1326,12 @@ fu_util_download_metadata (FuUtilPrivate *priv, GError **error)
 
 	/* no web remote is declared; try to enable LVFS */
 	if (!download_remote_enabled) {
+		/* we don't want to ask anything */
+		if (priv->no_metadata_check) {
+			g_debug ("skipping metadata check");
+			return TRUE;
+		}
+
 		if (!fu_util_download_metadata_enable_lvfs (priv, error))
 			return FALSE;
 	}


### PR DESCRIPTION
This was reported in Debian:

> approximately a few times a day fwupd is automatically called as "fwupd
> refresh". Unfortunately on my system it gets stuck in a busy loop trying
> to read from a stream. I believe that it fails to read, but it also
> fails to acknowledge an error condition, therefore keeping trying.
> 
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=942568

To me it looks like LVFS is disabled and trying to enable from systemd which isn't going so great.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
