### PR TITLE
ebitdo: if the device has the will disappear flag, don't wait for ack…

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -8,7 +8,7 @@ Flags = is-bootloader
 InstallDuration = 120
 [DeviceInstanceId=USB\VID_0483&PID_5760]
 Plugin = ebitdo
-Flags = is-bootloader
+Flags = is-bootloader,will-disappear
 InstallDuration = 120
 
 # FC30


### PR DESCRIPTION
… (Fixes: #994)

Some 8bitdo receivers seem to automatically reboot when done writing,
so just stop if we have that flag and notice this behavior.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
