### PR TITLE
trivial: dell: work around a memory leak caught by address sanitizer

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -118,9 +118,14 @@ static guint8 enclosure_whitelist [] = { 0x03, /* desktop */
 static guint16
 fu_dell_get_system_id (FuPlugin *plugin)
 {
+	FuPluginData *data = fu_plugin_get_data (plugin);
 	const gchar *system_id_str = NULL;
 	guint16 system_id = 0;
 	gchar *endptr = NULL;
+
+	/* don't care for test suite */
+	if (data->smi_obj->fake_smbios)
+		return 0;
 
 	system_id_str = fu_plugin_get_dmi_value (plugin,
 		FU_HWIDS_KEY_PRODUCT_SKU);


### PR DESCRIPTION
It appears to only happen on non-dell systems trying to look up system
ID through `sysinfo_get_dell_system_id`

Other than CI non-dell systems won't be running this code.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
