### PR TITLE
Add a systemd preset file for `fwupd-refresh.service`

### DIFF
--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -14,6 +14,7 @@ usr/lib/*/fwupdoffline
 usr/lib/*/fwupdtool
 usr/share/man/man1/*
 lib/systemd/system/*
+lib/systemd/system-preset/*
 lib/systemd/system-shutdown/*
 var/lib/fwupd
 lib/udev/rules.d/*

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -287,6 +287,7 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %{_unitdir}/fwupd.service
 %{_unitdir}/fwupd-refresh.service
 %{_unitdir}/fwupd-refresh.timer
+%{_presetdir}/fwupd-refresh.preset
 %{_unitdir}/system-update.target.wants/
 %dir %{_localstatedir}/lib/fwupd
 %dir %{_datadir}/fwupd/quirks.d

--- a/data/motd/fwupd-refresh.preset
+++ b/data/motd/fwupd-refresh.preset
@@ -1,0 +1,1 @@
+disable fwupd-refresh.service

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -11,6 +11,8 @@ con2.set('motd_fullpath', motd_fullpath)
 if get_option('systemd')
   install_data(['fwupd-refresh.timer'],
     install_dir: systemdunitdir)
+  install_data(['fwupd-refresh.preset'],
+    install_dir: systemdsystempresetdir)
 
   dynamic_options = []
   if systemd.version().version_compare('>= 243')

--- a/meson.build
+++ b/meson.build
@@ -306,6 +306,7 @@ if build_standalone and get_option('systemd')
   if systemdunitdir == '' and get_option('systemd')
     systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
   endif
+  systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir')
 endif
 
 if build_standalone and get_option('elogind')


### PR DESCRIPTION
Makes `fwupd-refresh.service` strictly opt-in.

Some distros are defaulting to all systemd services on and causing
more refreshes than desirable by default, especially when using
both `gnome-software` and `fwupd-refresh.service`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
