### PR TITLE
uefi: use `genpeimg` to mark ASLR and DP/NX on EFI binary

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -893,6 +893,20 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="mingw-w64-tools">
+    <distro id="fedora">
+      <package />
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="gir1.2-pango-1.0">
     <distro id="centos">
       <package>pango-devel</package>

--- a/contrib/debian/lintian/fwupd
+++ b/contrib/debian/lintian/fwupd
@@ -6,5 +6,5 @@ fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/system
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_upower.so
 #EFI applications are PE executables
 fwupd: executable-not-elf-or-script usr/lib/fwupd/efi/*.efi
-fwupd: portable-executable-missing-security-features usr/lib/fwupd/efi/*.efi ASLR DEP/NX
+fwupd: portable-executable-missing-security-features usr/lib/fwupd/efi/*.efi SafeSEH
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_modem_manager.so

--- a/meson.build
+++ b/meson.build
@@ -235,6 +235,7 @@ if build_standalone and get_option('plugin_uefi')
   objcopy = find_program ('objcopy')
   readelf = find_program ('readelf')
   tpm2tss = dependency('tss2-esys', version : '>= 2.0')
+  genpeimg = find_program ('genpeimg', required: false)
 
   efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
   conf.set_quoted ('EFI_APP_LOCATION', efi_app_location)

--- a/plugins/uefi/efi/generate_binary.sh
+++ b/plugins/uefi/efi/generate_binary.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+output=$2
+objcopy_cmd=$(which objcopy)
+genpeimg_cmd=$(which genpeimg)
+
+$objcopy_cmd  -j .text \
+              -j .sdata \
+              -j .data \
+              -j .dynamic \
+              -j .dynsym \
+              -j .rel \
+              -j .rela \
+              -j .reloc \
+              $*
+
+if [ -n "${genpeimg_cmd}" ]; then
+        $genpeimg_cmd -d \
+                      +d \
+                      -d \
+                      +n \
+                      -d \
+                      +s \
+                      $output
+fi

--- a/plugins/uefi/efi/meson.build
+++ b/plugins/uefi/efi/meson.build
@@ -135,20 +135,11 @@ so = custom_target('fwup.so',
                              efi_ldflags + ['@INPUT@'] +
                              ['-lefi', '-lgnuefi', libgcc_file_name])
 
+build_tool = join_paths(meson.source_root(), 'plugins', 'uefi', 'efi', 'generate_binary.sh')
 app = custom_target(efi_name,
                     input : so,
                     output : efi_name,
-                    command : [objcopy,
-                               '-j', '.text',
-                               '-j', '.sdata',
-                               '-j', '.data',
-                               '-j', '.dynamic',
-                               '-j', '.dynsym',
-                               '-j', '.rel',
-                               '-j', '.rela',
-                               '-j', '.reloc']
-                               + efi_format +
-                               ['@INPUT@', '@OUTPUT@'],
+                    command : [build_tool, '@INPUT@', '@OUTPUT@', efi_format],
                     install : true,
                     install_dir : efi_app_location)
 


### PR DESCRIPTION
If the tool is available at build time use it to this.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
