### PR TITLE
ebitdo: Add SN30Pro+ to recognized quirk list (Fixes: #1503)

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -84,6 +84,13 @@ Plugin = ebitdo
 Flags = will-disappear
 InstallDuration = 120
 
+# SN30 PRO+
+## Dinput mode (Start + B)
+[DeviceInstanceId=USB\VID_2DC8&PID_6002]
+Plugin = ebitdo
+Flags = will-disappear
+InstallDuration = 120
+
 # M30
 [DeviceInstanceId=USB\VID_2DC8&PID_5006]
 Plugin = ebitdo


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This should get the plugin enumerating the SN30Pro+ and have it behave like the SN30Pro (expecting it to boot back up in Nintendo Switch mode after flashing)