### PR TITLE
thunderbolt: Create a unique GUID including Thunderbolt controller path

### DIFF
--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -31,6 +31,12 @@ When the device is in "safe mode" the GUID is hardcoded using:
 
  * `TBT-$(vid)$(pid)-native` when native, and `TBT-$(vid)$(pid)` otherwise.
 
+Additionally for host system thunderbolt controllers another GUID is added
+containing the PCI slot designation of the controller.  This is intended to be
+used for systems with multiple host controllers to disambiguiate between controllers.
+
+* `TBT-$(vid)$(pid)-native-$(slot)`
+
 Runtime Power Management
 ------------------------
 

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -286,6 +286,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	g_autofree gchar *version = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autofree gchar *device_id = NULL;
+	g_autofree gchar *device_id_with_path = NULL;
 	g_autoptr(FuDevice) dev = NULL;
 	g_autoptr(GError) error_vid = NULL;
 	g_autoptr(GError) error_did = NULL;
@@ -362,6 +363,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 			 * so don't try to read a native attribute from their NVM */
 			if (is_host && gen < 4) {
 				g_autoptr(GError) native_error = NULL;
+				g_autoptr(GUdevDevice) udev_parent = NULL;
 				if (!fu_plugin_thunderbolt_is_native (device,
 								      &is_native,
 								      &native_error)) {
@@ -372,6 +374,14 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 				fu_plugin_add_report_metadata (plugin,
 							       "ThunderboltNative",
 							       is_native ? "True" : "False");
+				udev_parent = g_udev_device_get_parent_with_subsystem (device, "pci", NULL);
+				if (udev_parent != NULL)
+					device_id_with_path = g_strdup_printf ("TBT-%04x%04x%s-%s",
+									       (guint) vid,
+									       (guint) did,
+									       is_native ? "-native" : "",
+									       g_udev_device_get_property (udev_parent,
+													   "PCI_SLOT_NAME"));
 			}
 			vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
 			device_id = g_strdup_printf ("TBT-%04x%04x%s",
@@ -412,6 +422,8 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_set_vendor_id (dev, vendor_id);
 	if (device_id != NULL)
 		fu_device_add_instance_id (dev, device_id);
+	if (device_id_with_path != NULL)
+		fu_device_add_instance_id (dev, device_id_with_path);
 	if (version != NULL)
 		fu_device_set_version (dev, version, FWUPD_VERSION_FORMAT_PAIR);
 	if (is_host)


### PR DESCRIPTION
Systems with multiple host controllers will most likely have a different
NVM image for each controller but there is no guarantee that the device_id
within the NVM image varies from one controller to another.

To account for this, build a GUID that contains the last element of the
Thunderbolt controller's udev path.

Sample GUID strings from an XPS 9380 (which only contains one host controller):
```
│     GUIDs:               0f401ed2-b847-532a-adc8-3193fc737be6 ← TBT-00d408af-native
│                          92516c2c-c6b6-5a30-a4c1-6722aa6ae2e0 ← TBT-00d408af-native:0-0
```

This commit follows the presumption that the kernel will enumerate the controllers
in the same order every time.

Type of pull request:
- [x] Feature

FYI: This hasn't actually been tested on a system with multiple host controllers yet, so let's please wait to merge until actually tested.