### PR TITLE
Allow verifying the device image itself from fwupdtool

### DIFF
--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -21,6 +21,7 @@ _fwupdtool_cmd_list=(
 	'smbios-dump'
 	'attach'
 	'detach'
+	'firmware-read'
 	'verify-update'
 	'watch'
 )
@@ -86,7 +87,7 @@ _fwupdtool()
 	esac
 
 	case $command in
-	get-details|install|install-blob)
+	get-details|install|install-blob|firmware-read)
 		#find files
 		if [[ "$prev" = "$command" ]]; then
 			_filedir

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -96,6 +96,10 @@ gboolean	 fu_engine_verify			(FuEngine	*self,
 gboolean	 fu_engine_verify_update		(FuEngine	*self,
 							 const gchar	*device_id,
 							 GError		**error);
+GBytes		*fu_engine_firmware_read		(FuEngine	*self,
+							 FuDevice	*device,
+							 FwupdInstallFlags flags,
+							 GError		**error);
 gboolean	 fu_engine_modify_remote		(FuEngine	*self,
 							 const gchar	*remote_id,
 							 const gchar	*key,


### PR DESCRIPTION
To debug flashing failures it's sometimes requried to get a SPI dump of the
hardware to analysis.

Add a debug-only command that lets us dump the device from the engine.
