### PR TITLE
synaptics-prometheus: Don't add a config-subdevice in bootloader mode

### DIFF
--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -204,7 +204,8 @@ fu_synaprom_device_setup (FuDevice *device, GError **error)
 	}
 
 	/* add updatable config child, if this is a production sensor */
-	if (pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR) {
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER) &&
+	    pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR) {
 		g_autoptr(FuSynapromConfig) cfg = fu_synaprom_config_new (self);
 		if (!fu_device_setup (FU_DEVICE (cfg), error)) {
 			g_prefix_error (error, "failed to get config version: ");


### PR DESCRIPTION
We can't use the IOTA mechanism in bootloader mode, and failing to create the
FuSynapromDevice object means we can't recover the hardware if the flash failed.
