### PR TITLE
Move the version definition of a release into `.version`

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,12 +1,16 @@
 fwupd Release Notes
 
-Write release entries:
+0. Create release version
 
-git log --format="%s" --cherry-pick --right-only 1.3.3... | grep -i -v trivial | grep -v Merge | sort | uniq
+export release_ver=
+
+1. Write release entries:
+
+git log --format="%s" --cherry-pick --right-only $(git describe --tags --abbrev=0)..HEAD | grep -i -v trivial | grep -v Merge | sort | uniq
 Add any user visible changes into ../data/org.freedesktop.fwupd.metainfo.xml
 appstream-util appdata-to-news ../data/org.freedesktop.fwupd.metainfo.xml > NEWS
 
-Update translations:
+2. Update translations:
 
 ninja-build fwupd-pot
 tx push --source
@@ -14,10 +18,7 @@ tx pull --all --force --minimum-perc=5
 ninja-build fix-translations
 git add ../po/*.po
 
-2. Commit changes to git:
-
-# MAKE SURE THIS IS CORRECT
-export release_ver="1.3.4"
+3. Commit changes to git:
 
 git commit -a -m "Release fwupd ${release_ver}"
 git tag -s -f -m "Release fwupd ${release_ver}" "${release_ver}"
@@ -25,21 +26,14 @@ git tag -s -f -m "Release fwupd ${release_ver}" "${release_ver}"
 git push --tags
 git push
 
-3. Generate the tarball:
+4. Generate the tarball:
 
 ninja dist
 
-3a. Generate the additional verification metadata
+4a. Generate the additional verification metadata
 
 gpg -b -a meson-dist/fwupd-${release_ver}.tar.xz
 
-4. Upload tarball:
+5. Upload tarball:
 
 scp meson-dist/fwupd-${release_ver}.tar.* hughsient@people.freedesktop.org:~/public_html/releases
-
-5. Do post release version bump in meson.build
-
-6. Commit changes:
-
-git commit -a -m "trivial: post release version bump"
-git push

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -16,9 +16,7 @@ makedepends=('meson' 'valgrind' 'gobject-introspection' 'gtk-doc' 'python-pillow
 pkgver() {
     cd ${pkgname}
 
-    VERSION=$(git describe | sed 's/-/.r/;s/-/./')
-    [ -z $VERSION ] && VERSION=$(head meson.build | grep ' version :' | cut -d \' -f2)
-
+    VERSION=$(./contrib/get-version.py | sed 's/-/.r/;s/-/./')
     echo $VERSION
 }
 

--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -11,8 +11,7 @@ fi
 #prepare
 export DEBFULLNAME="CI Builder"
 export DEBEMAIL="ci@travis-ci.org"
-VERSION=`git describe | sed 's/-/+r/;s/-/+/'`
-[ -z $VERSION ] && VERSION=`head meson.build | grep ' version :' | cut -d \' -f2`
+VERSION=`./contrib/get-version.py | sed 's/-/+r/;s/-/+/'`
 rm -rf build/
 mkdir -p build
 shopt -s extglob

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -20,7 +20,7 @@ meson .. \
     -Dplugin_synaptics=true $@
 ninja-build dist
 popd
-VERSION=`meson introspect build --projectinfo | jq -r .version`
+VERSION=`./contrib/get-version.py`
 mkdir -p $HOME/rpmbuild/SOURCES/
 mv build/meson-dist/fwupd-$VERSION.tar.xz $HOME/rpmbuild/SOURCES/
 

--- a/contrib/get-version.py
+++ b/contrib/get-version.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2019 Dell, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+
+import xml.etree.ElementTree as etree
+import os
+import subprocess
+
+def sanitize_for_ci(version):
+    if not 'CI' in os.environ:
+        return version
+    OS=os.getenv('OS')
+    if not OS:
+        return version
+    if "fedora" in OS:
+        return version.replace('-','.')
+    return version
+
+def get_version_git():
+    try:
+        version = subprocess.check_output(['git', 'describe'], stderr=subprocess.DEVNULL)
+        return version.strip().decode('utf-8')
+    except subprocess.CalledProcessError:
+        return ''
+
+def get_version():
+    tree = etree.parse(os.path.join("data", "org.freedesktop.fwupd.metainfo.xml"))
+    version = ''
+    for child in tree.findall('releases'):
+        for release in child:
+            if not "version" in release.attrib:
+                continue
+            if release.attrib['version'] > version:
+                version = release.attrib['version']
+    return version
+
+if __name__ == '__main__':
+
+    version = get_version_git()
+    if version:
+        version = sanitize_for_ci(version)
+    else:
+        version = get_version()
+    print(version)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('fwupd', 'c',
-  version : '1.3.4',
+  version : run_command('contrib/get-version.py').stdout().strip(),
   license : 'LGPL-2.1+',
   meson_version : '>=0.47.0',
   default_options : ['warning_level=2', 'c_std=c99'],
@@ -9,22 +9,19 @@ fwupd_version = meson.project_version()
 varr = fwupd_version.split('.')
 fwupd_major_version = varr[0]
 fwupd_minor_version = varr[1]
-fwupd_micro_version = varr[2]
-
+fwupd_micro_version = varr[2].split('-')[0]
 conf = configuration_data()
+
+if varr[2].contains('-')
+  fwupd_dirty_version = varr[2].split('-')[1]
+  fwupd_commit = varr[2].split('-')[2]
+  conf.set('FWUPD_DIRTY_VERSION', fwupd_dirty_version)
+  conf.set_quoted('FWUPD_COMMIT_VERSION', fwupd_commit)
+endif
 conf.set('FWUPD_MAJOR_VERSION', fwupd_major_version)
 conf.set('FWUPD_MINOR_VERSION', fwupd_minor_version)
 conf.set('FWUPD_MICRO_VERSION', fwupd_micro_version)
 conf.set_quoted('PACKAGE_VERSION', fwupd_version)
-
-archiver = find_program('git', required : false)
-if archiver.found()
-  result = run_command('git', 'describe')
-  if result.returncode() == 0
-    describe = result.stdout().strip()
-    conf.set_quoted('FWUPD_GIT_DESCRIBE', describe)
-  endif
-endif
 
 # libtool versioning - this applies to libfwupd
 #

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -28,6 +28,10 @@ fu_synapticsmst_check_amdgpu_safe (GError **error)
 	g_autofree gchar *buf = NULL;
 	g_auto(GStrv) lines = NULL;
 
+	/* no module support in the kernel, we can't test for amdgpu module */
+	if (!g_file_test ("/proc/modules", G_FILE_TEST_EXISTS))
+		return TRUE;
+
 	if (!g_file_get_contents ("/proc/modules", &buf, &bufsz, error))
 		return FALSE;
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -252,19 +252,31 @@ fu_util_get_user_cache_path (const gchar *fn)
 }
 
 gchar *
-fu_util_get_versions (void)
+fu_util_get_client_version (void)
 {
 	GString *string = g_string_new ("");
 
 	g_string_append_printf (string,
-				"client version:\t%i.%i.%i\n",
+				"%i.%i.%i",
 				FWUPD_MAJOR_VERSION,
 				FWUPD_MINOR_VERSION,
 				FWUPD_MICRO_VERSION);
-#ifdef FWUPD_GIT_DESCRIBE
+#ifdef FWUPD_DIRTY_VERSION
 	g_string_append_printf (string,
-				"checkout info:\t%s\n", FWUPD_GIT_DESCRIBE);
+				"-%i-%s",
+				FWUPD_DIRTY_VERSION,
+				FWUPD_COMMIT_VERSION);
 #endif
+	return g_string_free (string, FALSE);
+}
+
+gchar *
+fu_util_get_versions (void)
+{
+	GString *string = g_string_new ("");
+	g_autofree gchar *client_version = fu_util_get_client_version ();
+
+	g_string_append_printf (string, "client version:\t%s\n", client_version);
 	g_string_append_printf (string,
 				"compile-time dependency versions\n");
 	g_string_append_printf (string,

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -34,6 +34,7 @@ gboolean	 fu_util_is_interesting_device	(FwupdDevice	*dev);
 gchar		*fu_util_get_user_cache_path	(const gchar	*fn);
 SoupSession	*fu_util_setup_networking	(GError		**error);
 
+gchar		*fu_util_get_client_version	(void);
 gchar		*fu_util_get_versions		(void);
 
 void		 fu_util_warning_box		(const gchar	*str,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2276,10 +2276,7 @@ fu_util_private_free (FuUtilPrivate *priv)
 static gboolean
 fu_util_check_daemon_version (FuUtilPrivate *priv, GError **error)
 {
-	g_autofree gchar *client = g_strdup_printf ("%i.%i.%i",
-						    FWUPD_MAJOR_VERSION,
-						    FWUPD_MINOR_VERSION,
-						    FWUPD_MICRO_VERSION);
+	g_autofree gchar *client = fu_util_get_client_version ();
 	const gchar *daemon = fwupd_client_get_daemon_version (priv->client);
 
 	if (g_strcmp0 (daemon, client) != 0) {


### PR DESCRIPTION
This is inspired by a change in flashrom to read the version string for meson
dynamically.

When making a release just put the version into `.version` to make the tarball
and tag the release as approriate.

No need for "post release version bump", this happens automatically from git
now by there being a dirty commit.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
