### PR TITLE
trivial: Fix a compile error with older versions of gudev

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -27,13 +27,6 @@ struct _FuAltosDevice {
 
 G_DEFINE_TYPE (FuAltosDevice, fu_altos_device, FU_TYPE_USB_DEVICE)
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 static void
 fu_altos_device_finalize (GObject *object)
 {

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -75,13 +75,6 @@ struct _FuAtaDevice {
 
 G_DEFINE_TYPE (FuAtaDevice, fu_ata_device, FU_TYPE_UDEV_DEVICE)
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 guint8
 fu_ata_device_get_transfer_mode (FuAtaDevice *self)
 {

--- a/plugins/modem-manager/fu-mm-utils.c
+++ b/plugins/modem-manager/fu-mm-utils.c
@@ -7,6 +7,9 @@
 #include "config.h"
 
 #include <gio/gio.h>
+
+#include "fu-udev-device.h"
+
 #include "fu-mm-utils.h"
 
 gboolean

--- a/plugins/modem-manager/fu-mm-utils.h
+++ b/plugins/modem-manager/fu-mm-utils.h
@@ -10,14 +10,6 @@
 #include "config.h"
 #include <gudev/gudev.h>
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 gboolean	fu_mm_utils_get_udev_port_info	(GUdevDevice	 *dev,
 						 gchar		**device_sysfs_path,
 						 gint		 *port_ifnum,

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -23,13 +23,6 @@ struct _FuNvmeDevice {
 
 G_DEFINE_TYPE (FuNvmeDevice, fu_nvme_device, FU_TYPE_UDEV_DEVICE)
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 static void
 fu_nvme_device_to_string (FuDevice *device, guint idt, GString *str)
 {

--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -18,13 +18,6 @@
 #define BOLT_DBUS_PATH		"/org/freedesktop/bolt"
 #define BOLT_DBUS_INTERFACE	"org.freedesktop.bolt1.Power"
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 /* empirically measured amount of time for the TBT device to come and go */
 #define TBT_NEW_DEVICE_TIMEOUT	2 /* s */
 

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -19,13 +19,6 @@
 #include "fu-device-metadata.h"
 #include "fu-thunderbolt-image.h"
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 #define TBT_NVM_RETRY_TIMEOUT				200	/* ms */
 #define FU_PLUGIN_THUNDERBOLT_UPDATE_TIMEOUT		60000	/* ms */
 

--- a/plugins/unifying/fu-unifying-runtime.c
+++ b/plugins/unifying/fu-unifying-runtime.c
@@ -22,10 +22,6 @@ struct _FuUnifyingRuntime
 
 G_DEFINE_TYPE (FuUnifyingRuntime, fu_unifying_runtime, FU_TYPE_UDEV_DEVICE)
 
-#ifndef HAVE_GUDEV_232
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#endif
-
 static void
 fu_unifying_runtime_to_string (FuDevice *device, guint idt, GString *str)
 {

--- a/src/fu-udev-device.c
+++ b/src/fu-udev-device.c
@@ -44,13 +44,6 @@ typedef struct
 
 G_DEFINE_TYPE_WITH_PRIVATE (FuUdevDevice, fu_udev_device, FU_TYPE_DEVICE)
 
-#ifndef HAVE_GUDEV_232
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
-#pragma clang diagnostic pop
-#endif
-
 enum {
 	PROP_0,
 	PROP_UDEV_DEVICE,

--- a/src/fu-udev-device.h
+++ b/src/fu-udev-device.h
@@ -26,6 +26,14 @@ struct _FuUdevDeviceClass
 	gpointer	__reserved[29];
 };
 
+#ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
+#pragma clang diagnostic pop
+#endif
+
 FuUdevDevice	*fu_udev_device_new			(GUdevDevice	*udev_device);
 GUdevDevice	*fu_udev_device_get_dev			(FuUdevDevice	*self);
 const gchar	*fu_udev_device_get_device_file		(FuUdevDevice	*self);


### PR DESCRIPTION
Just move the G_DEFINE_AUTOPTR_CLEANUP_FUNC to the internal header to avoid
forgetting to define this in each plugin.
