### PR TITLE
Create a dummy device for failing to load plugins

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4369,6 +4369,15 @@ fu_engine_load_plugins (FuEngine *self, GError **error)
 		/* if loaded from fu_engine_load() open the plugin */
 		if (self->usb_ctx != NULL) {
 			if (!fu_plugin_open (plugin, filename, &error_local)) {
+				g_autoptr(FuDevice) device = fu_device_new ();
+				g_autofree gchar *dev_name = g_strdup_printf ("%s device", name);
+				fu_device_set_name (device, dev_name);
+				fu_device_set_id (device, filename);
+				fu_device_set_quirks (device, self->quirks);
+				fu_device_add_instance_id (device, filename);
+				fu_device_set_update_error (device, error_local->message);
+				fu_device_setup (device, NULL);
+				fu_engine_add_device (self, device);
 				g_warning ("%s", error_local->message);
 				continue;
 			}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4369,8 +4369,7 @@ fu_engine_load_plugins (FuEngine *self, GError **error)
 		/* if loaded from fu_engine_load() open the plugin */
 		if (self->usb_ctx != NULL) {
 			if (!fu_plugin_open (plugin, filename, &error_local)) {
-				g_warning ("failed to open plugin %s: %s",
-					   filename, error_local->message);
+				g_warning ("%s", error_local->message);
 				continue;
 			}
 		}

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -354,8 +354,8 @@ fu_plugin_open (FuPlugin *self, const gchar *filename, GError **error)
 		g_set_error (error,
 			     G_IO_ERROR,
 			     G_IO_ERROR_FAILED,
-			     "failed to open plugin: %s",
-			     g_module_error ());
+			     "failed to open plugin %s: %s",
+			     filename, g_module_error ());
 		return FALSE;
 	}
 


### PR DESCRIPTION
One way to address the stuff mentioned in https://github.com/fwupd/fwupd/issues/1526.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
