### PR TITLE
fastboot: Fix a regression when updating modem firmware

### DIFF
--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -695,6 +695,7 @@ fu_fastboot_device_init (FuFastbootDevice *self)
 	/* this is a safe default, even using USBv1 */
 	self->blocksz = 512;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_set_remove_delay (FU_DEVICE (self), FASTBOOT_REMOVE_DELAY_RE_ENUMERATE);
 }
 


### PR DESCRIPTION
Set `IS_BOOTLOADER` unconditionally when in fastboot mode. This seems logically
what it is; a degraded mode that's able to update firmware without runtime
functionality.

Fixes https://github.com/fwupd/fwupd/issues/1532
