### PR TITLE
udev-device: fix offset of vendor id of hidraw devices

### DIFF
--- a/src/fu-udev-device.c
+++ b/src/fu-udev-device.c
@@ -152,7 +152,7 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	    g_strcmp0 (priv->subsystem, "hidraw") == 0) {
 		tmp = g_udev_device_get_property (udev_parent, "HID_ID");
 		if (tmp != NULL && strlen (tmp) == 22) {
-			priv->vendor = fu_udev_device_read_uint16 (tmp + 10);
+			priv->vendor = fu_udev_device_read_uint16 (tmp + 9);
 			priv->model = fu_udev_device_read_uint16 (tmp + 18);
 		}
 		tmp = g_udev_device_get_property (udev_parent, "HID_NAME");


### PR DESCRIPTION
The read property from hidraw HID_ID is 0018:00002D1F:00004946 where
the vendor id 2D1F starts from offset 9 from base address.

This change probes the hidraw vid/pid with a wanted plugin properly.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
