### PR TITLE
fu-udev-device: Adjust bounds checking to be safer

### DIFF
--- a/src/fu-udev-device.h
+++ b/src/fu-udev-device.h
@@ -31,8 +31,8 @@ GUdevDevice	*fu_udev_device_get_dev			(FuUdevDevice	*self);
 const gchar	*fu_udev_device_get_device_file		(FuUdevDevice	*self);
 const gchar	*fu_udev_device_get_sysfs_path		(FuUdevDevice	*self);
 const gchar	*fu_udev_device_get_subsystem		(FuUdevDevice	*self);
-guint16		 fu_udev_device_get_vendor		(FuUdevDevice	*self);
-guint16		 fu_udev_device_get_model		(FuUdevDevice	*self);
+guint32		 fu_udev_device_get_vendor		(FuUdevDevice	*self);
+guint32		 fu_udev_device_get_model		(FuUdevDevice	*self);
 guint8		 fu_udev_device_get_revision		(FuUdevDevice	*self);
 guint		 fu_udev_device_get_slot_depth		(FuUdevDevice	*self,
 							 const gchar	*subsystem);


### PR DESCRIPTION
Right now different integer sizes are used willy nilly and could
conceivably lead to overflow issues.

Additionally the values that come out of the kernel for `HID_ID`
are actually 8 digits, so they should be represented by a larger
data type.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation


This is a follow up for #1535 which is still correct, but this should hopefully scale better and be less fragile.