### PR TITLE
synapticsmst: filter invalid chip IDs

### DIFF
--- a/plugins/synapticsmst/fu-synapticsmst-device.c
+++ b/plugins/synapticsmst/fu-synapticsmst-device.c
@@ -1047,6 +1047,13 @@ fu_synapticsmst_device_rescan (FuDevice *device, GError **error)
 		return FALSE;
 	}
 	self->chip_id = (buf_ver[0] << 8) | (buf_ver[1]);
+	if (self->chip_id == 0) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_INVALID_DATA,
+				     "invalid chip ID");
+		return FALSE;
+	}
 	self->family = fu_synapticsmst_family_from_chip_id (self->chip_id);
 
 	/* check the active bank for debugging */


### PR DESCRIPTION
This device was showing up from a LG 38UC99-W USB-C monitor
```
VMM0000:
      Device ID:           d762543f8c20f636e6fff031a000078d3e10c600
      Summary:             Multi-Stream Transport Device
      Current version:     0.00.000
      Vendor:              Synaptics
      GUIDs:               42addef4-40f9-5e89-b925-d564e35ed368 ← MST-(null)-vmm0000-0
                           cf8c03c5-18bf-53c4-971f-4a08f88932b5 ← MST-(null)-0
                           e9427b6a-7389-5461-a592-1da5f8ec99fd ← MST-(null)
      Device Flags:        • Updatable
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
