### PR TITLE
Skip cleanup after device is done updating if `will-disappear` is set…

### DIFF
--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -512,8 +512,14 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 	/* when doing a soft-reboot the device does not re-enumerate properly
 	 * so manually reboot the GUsbDevice */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	if (!g_usb_device_reset (usb_device, error)) {
-		g_prefix_error (error, "failed to force-reset device: ");
+	if (!g_usb_device_reset (usb_device, &error_local)) {
+		g_prefix_error (&error_local, "failed to force-reset device: ");
+		if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+			fu_device_set_remove_delay (device, 0);
+			g_debug ("%s", error_local->message);
+			return TRUE;
+		}
+		g_propagate_error (error, g_steal_pointer (&error_local));
 		return FALSE;
 	}
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1872,7 +1872,14 @@ fu_engine_device_cleanup (FuEngine *self,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
-	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+		g_debug ("skipping device cleanup due to will-disappear flag");
+		return TRUE;
+	}
+
+	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
 	return fu_device_cleanup (device, flags, error);


### PR DESCRIPTION
… (Fixes: #1529)

This fixes a regression introduced by 2031ce3bf67885a4db247fa4088b36ae50011ca0
that leads to:
```
USB error on device 2dc8:5750 : No such device (it may have been disconnected) [-4]
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
