### PR TITLE
fu-util: Allow overriding daemon/client check with environment variable

### DIFF
--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -125,6 +125,7 @@ gboolean	 fwupd_client_modify_device		(FwupdClient	*client,
 							 GError		**error);
 FwupdStatus	 fwupd_client_get_status		(FwupdClient	*client);
 gboolean	 fwupd_client_get_tainted		(FwupdClient	*client);
+gboolean	 fwupd_client_get_daemon_interactive	(FwupdClient	*client);
 guint		 fwupd_client_get_percentage		(FwupdClient	*client);
 const gchar	*fwupd_client_get_daemon_version	(FwupdClient	*client);
 const gchar	*fwupd_client_get_host_product		(FwupdClient	*client);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -399,3 +399,9 @@ LIBFWUPD_1.3.3 {
     fwupd_remote_get_automatic_reports;
   local: *;
 } LIBFWUPD_1.3.2;
+
+LIBFWUPD_1.3.4 {
+  global:
+    fwupd_client_get_daemon_interactive;
+  local: *;
+} LIBFWUPD_1.3.3;

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -15,6 +15,7 @@
 #include <glib-unix.h>
 #include <locale.h>
 #include <polkit/polkit.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "fwupd-device-private.h"
@@ -1368,6 +1369,9 @@ fu_main_daemon_get_property (GDBusConnection *connection_, const gchar *sender,
 
 	if (g_strcmp0 (property_name, "HostMachineId") == 0)
 		return g_variant_new_string (fu_engine_get_host_machine_id (priv->engine));
+
+	if (g_strcmp0 (property_name, "Interactive") == 0)
+		return g_variant_new_boolean (isatty (fileno (stdout)) != 0);
 
 	/* return an error */
 	g_set_error (error,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2719,6 +2719,7 @@ main (int argc, char *argv[])
 #ifdef HAVE_SYSTEMD
 	/* make sure the correct daemon is in use */
 	if ((priv->flags & FWUPD_INSTALL_FLAG_FORCE) == 0 &&
+	    !fwupd_client_get_daemon_interactive (priv->client) &&
 	    !fu_util_using_correct_daemon (&error)) {
 		g_printerr ("%s\n", error->message);
 		return EXIT_FAILURE;

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -56,6 +56,17 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='Interactive' type='b' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            If the daemon is running on an interactive terminal.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='Status' type='u' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
The check is mostly for making sure that if someone installs a snap that
they don't try to use a non-snapped command line client or vice versa.

However this makes development annoying because it is common to launch
the daemon manually in verbose mode without systemd when checking a
problem.  So allow setting an environment variable to make the client
ignore this check.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
