### PR TITLE
Update dependencies.xml

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -418,6 +418,7 @@
       <package />
     </distro>
     <distro id="debian">
+      <control />
       <package variant="x86_64" />
       <package variant="s390x" />
       <package variant="i386" />


### PR DESCRIPTION
get-version.py depends on git

And, not sure where it should be put, but a dependency for libfwupd2 of libxmlb is needed.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
