### PR TITLE
modem-manager: explicitly use plain version format

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -236,7 +236,7 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 		fu_device_set_vendor (device, mm_modem_get_manufacturer (modem));
 	if (mm_modem_get_model (modem) != NULL)
 		fu_device_set_name (device, mm_modem_get_model (modem));
-	fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_UNKNOWN);
+	fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PLAIN);
 	for (guint i = 0; device_ids[i] != NULL; i++)
 		fu_device_add_instance_id (device, device_ids[i]);
 
@@ -804,7 +804,7 @@ fu_mm_device_udev_new (MMManager *manager,
 	fu_device_set_physical_id (FU_DEVICE (self), info->physical_id);
 	fu_device_set_vendor (FU_DEVICE (self), info->vendor);
 	fu_device_set_name (FU_DEVICE (self), info->name);
-	fu_device_set_version (FU_DEVICE (self), info->version, FWUPD_VERSION_FORMAT_UNKNOWN);
+	fu_device_set_version (FU_DEVICE (self), info->version, FWUPD_VERSION_FORMAT_PLAIN);
 	self->update_methods = info->update_methods;
 	self->detach_fastboot_at = g_strdup (info->detach_fastboot_at);
 	self->port_at_ifnum = info->port_at_ifnum;


### PR DESCRIPTION
The devices managed by this plugin expose version strings that are to
be treated as plain ASCII and compared just as plain ASCII.

Type of pull request:
- [X ] Improvement
