### PR TITLE
trivial: Detect the USB version automatically

### DIFF
--- a/plugins/vli-usbhub/fu-vli-usbhub-device.c
+++ b/plugins/vli-usbhub/fu-vli-usbhub-device.c
@@ -680,10 +680,12 @@ fu_vli_usbhub_device_dump_firmware (FuVliUsbhubDevice *self, gsize bufsz, GError
 static gboolean
 fu_vli_usbhub_device_probe (FuDevice *device, GError **error)
 {
+	guint16 usbver = fu_usb_device_get_spec (FU_USB_DEVICE (device));
+
 	/* quirks now applied... */
-	if (fu_device_has_custom_flag (device, "usb3")) {
+	if (usbver > 0x0300 || fu_device_has_custom_flag (device, "usb3")) {
 		fu_device_set_summary (device, "USB 3.x Hub");
-	} else if (fu_device_has_custom_flag (device, "usb2")) {
+	} else if (usbver > 0x0200 || fu_device_has_custom_flag (device, "usb2")) {
 		fu_device_set_summary (device, "USB 2.x Hub");
 	} else {
 		fu_device_set_summary (device, "USB Hub");

--- a/src/fu-usb-device.c
+++ b/src/fu-usb-device.c
@@ -373,6 +373,30 @@ fu_usb_device_get_platform_id (FuUsbDevice *self)
 }
 
 /**
+ * fu_usb_device_get_spec:
+ * @self: A #FuUsbDevice
+ *
+ * Gets the string USB revision for the device.
+ *
+ * Return value: a specification revision in BCD format, or 0x0 if not supported
+ *
+ * Since: 1.3.4
+ **/
+guint16
+fu_usb_device_get_spec (FuUsbDevice *self)
+{
+#if G_USB_CHECK_VERSION(0,3,1)
+	FuUsbDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_USB_DEVICE (self), 0x0);
+	if (priv->usb_device == NULL)
+		return 0x0;
+	return g_usb_device_get_spec (priv->usb_device);
+#else
+	return 0x0;
+#endif
+}
+
+/**
  * fu_usb_device_set_dev:
  * @device: A #FuUsbDevice
  * @usb_device: A #GUsbDevice, or %NULL

--- a/src/fu-usb-device.h
+++ b/src/fu-usb-device.h
@@ -40,6 +40,7 @@ struct _FuUsbDeviceClass
 FuUsbDevice	*fu_usb_device_new			(GUsbDevice	*usb_device);
 guint16		 fu_usb_device_get_vid			(FuUsbDevice	*self);
 guint16		 fu_usb_device_get_pid			(FuUsbDevice	*self);
+guint16		 fu_usb_device_get_spec			(FuUsbDevice	*self);
 GUsbDevice	*fu_usb_device_get_dev			(FuUsbDevice	*device);
 void		 fu_usb_device_set_dev			(FuUsbDevice	*device,
 							 GUsbDevice	*usb_device);


### PR DESCRIPTION
Unfortunately we can't remove the usb2 and usb3 custom flags as we don't yet
depend on a new enough GUsb version.
