### PR TITLE
fwupdtool: don't show a warning when calling `get-plugins`

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4277,16 +4277,20 @@ fu_engine_plugin_set_coldplug_delay_cb (FuPlugin *plugin, guint duration, FuEngi
 void
 fu_engine_add_plugin (FuEngine *self, FuPlugin *plugin)
 {
-	/* plugin does not match built version */
-	if (fu_plugin_get_build_hash (plugin) == NULL) {
-		const gchar *name = fu_plugin_get_name (plugin);
-		g_warning ("%s should call fu_plugin_set_build_hash()", name);
-		self->tainted = TRUE;
-	} else if (g_strcmp0 (fu_plugin_get_build_hash (plugin), FU_BUILD_HASH) != 0) {
-		const gchar *name = fu_plugin_get_name (plugin);
-		g_warning ("%s has incorrect built version %s",
-				name, fu_plugin_get_build_hash (plugin));
-		self->tainted = TRUE;
+	if (fu_plugin_is_open (plugin)) {
+		/* plugin does not match built version */
+		if (fu_plugin_get_build_hash (plugin) == NULL) {
+			const gchar *name = fu_plugin_get_name (plugin);
+			g_warning ("%s should call fu_plugin_set_build_hash()",
+				   name);
+			self->tainted = TRUE;
+		} else if (g_strcmp0 (fu_plugin_get_build_hash (plugin),
+				      FU_BUILD_HASH) != 0) {
+			const gchar *name = fu_plugin_get_name (plugin);
+			g_warning ("%s has incorrect built version %s",
+				   name, fu_plugin_get_build_hash (plugin));
+			self->tainted = TRUE;
+		}
 	}
 
 	fu_plugin_list_add (self->plugin_list, plugin);

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -13,6 +13,7 @@
 #define FU_OFFLINE_TRIGGER_FILENAME	FU_OFFLINE_DESTDIR "/system-update"
 
 FuPlugin	*fu_plugin_new				(void);
+gboolean	 fu_plugin_is_open			(FuPlugin	*self);
 void		 fu_plugin_set_usb_context		(FuPlugin	*self,
 							 GUsbContext	*usb_ctx);
 void		 fu_plugin_set_hwids			(FuPlugin	*self,

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -107,6 +107,23 @@ typedef gboolean	 (*FuPluginUdevDeviceAddedFunc)	(FuPlugin	*self,
 							 GError		**error);
 
 /**
+ * fu_plugin_is_open:
+ * @self: A #FuPlugin
+ *
+ * Determines if the plugin is opened
+ *
+ * Returns: TRUE for opened, FALSE for not
+ *
+ * Since: 1.3.5
+ **/
+gboolean
+fu_plugin_is_open (FuPlugin *self)
+{
+	FuPluginPrivate *priv = GET_PRIVATE (self);
+	return priv->module != NULL;
+}
+
+/**
  * fu_plugin_get_name:
  * @self: A #FuPlugin
  *


### PR DESCRIPTION
The plugins are not opened for this function so of course they
won't set their build hashes.

Fixes errors like this:
`uefi should call fu_plugin_set_build_hash()`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
