### PR TITLE
Use the correct unlocker when using GRWLock

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -585,7 +585,7 @@ void
 fu_device_add_parent_guid (FuDevice *self, const gchar *guid)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_if_fail (FU_IS_DEVICE (self));
 	g_return_if_fail (guid != NULL);
@@ -1149,7 +1149,7 @@ void
 fu_device_remove_metadata (FuDevice *self, const gchar *key)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&priv->metadata_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&priv->metadata_mutex);
 	g_return_if_fail (FU_IS_DEVICE (self));
 	g_return_if_fail (key != NULL);
 	g_return_if_fail (locker != NULL);
@@ -1170,7 +1170,7 @@ void
 fu_device_set_metadata (FuDevice *self, const gchar *key, const gchar *value)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&priv->metadata_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&priv->metadata_mutex);
 	g_return_if_fail (FU_IS_DEVICE (self));
 	g_return_if_fail (key != NULL);
 	g_return_if_fail (value != NULL);

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -371,7 +371,7 @@ fu_history_load (FuHistory *self, GError **error)
 	g_autofree gchar *dirname = NULL;
 	g_autofree gchar *filename = NULL;
 	g_autoptr(GFile) file = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&self->db_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&self->db_mutex);
 
 	/* already done */
 	if (self->db != NULL)
@@ -462,7 +462,7 @@ fu_history_modify_device (FuHistory *self, FuDevice *device, GError **error)
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 	g_return_val_if_fail (FU_IS_DEVICE (device), FALSE);
@@ -513,7 +513,7 @@ fu_history_add_device (FuHistory *self, FuDevice *device, FwupdRelease *release,
 	gint rc;
 	g_autofree gchar *metadata = NULL;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 	g_return_val_if_fail (FU_IS_DEVICE (device), FALSE);
@@ -593,7 +593,7 @@ fu_history_remove_all_with_state (FuHistory *self,
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 
@@ -624,7 +624,7 @@ fu_history_remove_all (FuHistory *self, GError **error)
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 
@@ -651,7 +651,7 @@ fu_history_remove_device (FuHistory *self,  FuDevice *device, GError **error)
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 	g_return_val_if_fail (FU_IS_DEVICE (device), FALSE);
@@ -835,7 +835,7 @@ fu_history_clear_approved_firmware (FuHistory *self, GError **error)
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 
@@ -865,7 +865,7 @@ fu_history_add_approved_firmware (FuHistory *self,
 {
 	gint rc;
 	g_autoptr(sqlite3_stmt) stmt = NULL;
-	g_autoptr(GRWLockReaderLocker) locker = NULL;
+	g_autoptr(GRWLockWriterLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_HISTORY (self), FALSE);
 	g_return_val_if_fail (checksum != NULL, FALSE);

--- a/src/fu-idle.c
+++ b/src/fu-idle.c
@@ -118,7 +118,7 @@ fu_idle_reset (FuIdle *self)
 void
 fu_idle_uninhibit (FuIdle *self, guint32 token)
 {
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&self->items_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&self->items_mutex);
 
 	g_return_if_fail (FU_IS_IDLE (self));
 	g_return_if_fail (token != 0);
@@ -139,7 +139,7 @@ guint32
 fu_idle_inhibit (FuIdle *self, const gchar *reason)
 {
 	FuIdleItem *item;
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&self->items_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&self->items_mutex);
 
 	g_return_val_if_fail (FU_IS_IDLE (self), 0);
 	g_return_val_if_fail (reason != NULL, 0);

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -215,7 +215,7 @@ void
 fu_plugin_cache_add (FuPlugin *self, const gchar *id, gpointer dev)
 {
 	FuPluginPrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&priv->devices_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&priv->devices_mutex);
 	g_return_if_fail (FU_IS_PLUGIN (self));
 	g_return_if_fail (id != NULL);
 	g_return_if_fail (locker != NULL);
@@ -235,7 +235,7 @@ void
 fu_plugin_cache_remove (FuPlugin *self, const gchar *id)
 {
 	FuPluginPrivate *priv = GET_PRIVATE (self);
-	g_autoptr(GRWLockReaderLocker) locker = g_rw_lock_writer_locker_new (&priv->devices_mutex);
+	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new (&priv->devices_mutex);
 	g_return_if_fail (FU_IS_PLUGIN (self));
 	g_return_if_fail (id != NULL);
 	g_return_if_fail (locker != NULL);


### PR DESCRIPTION
Linux doesn't care if you use g_rw_lock_reader_unlock() on a write lock, but
Windows really does.
