### PR TITLE
trivial: plugins: only build coreboot when option set

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,7 +1,6 @@
 subdir('ata')
 subdir('dfu')
 subdir('colorhug')
-subdir('coreboot')
 subdir('ebitdo')
 subdir('fastboot')
 subdir('jabra')
@@ -72,4 +71,8 @@ endif
 
 if get_option('plugin_flashrom')
 subdir('flashrom')
+endif
+
+if get_option('plugin_coreboot')
+subdir('coreboot')
 endif


### PR DESCRIPTION
The option was set but wasn't being used.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
