### PR TITLE
Ensure the _get_type() gets the same ABI version as the constructor

### DIFF
--- a/libfwupd/generate-version-script.py
+++ b/libfwupd/generate-version-script.py
@@ -47,10 +47,6 @@ class LdVersionScript:
         for node in cls.findall(XMLNS + 'function'):
             self._add_node(node)
 
-        # add the constructor
-        for node in cls.findall(XMLNS + 'constructor'):
-            self._add_node(node)
-
         # choose the lowest version method for the _get_type symbol
         version_lowest = None
         if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
@@ -59,6 +55,13 @@ class LdVersionScript:
 
         # add all class methods
         for node in cls.findall(XMLNS + 'method'):
+            version_tmp = self._add_node(node)
+            if version_tmp:
+                if not version_lowest or version_tmp < version_lowest:
+                    version_lowest = version_tmp
+
+        # add the constructor
+        for node in cls.findall(XMLNS + 'constructor'):
             version_tmp = self._add_node(node)
             if version_tmp:
                 if not version_lowest or version_tmp < version_lowest:


### PR DESCRIPTION
This was also causing the _get_type() symbol to be ignored for objects without
any class methods except constructors.
