### PR TITLE
trivial: Use prefixes for DATADIR in config.h for portability

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -328,8 +328,8 @@ fwupd_build_machine_id (const gchar *salt, GError **error)
 	gsize sz = 0;
 
 	/* one of these has to exist */
-	fns[0] = g_build_filename (SYSCONFDIR, "machine-id", NULL);
-	fns[1] = g_build_filename (LOCALSTATEDIR, "lib", "dbus", "machine-id", NULL);
+	fns[0] = g_build_filename (FWUPD_SYSCONFDIR, "machine-id", NULL);
+	fns[1] = g_build_filename (FWUPD_LOCALSTATEDIR, "lib", "dbus", "machine-id", NULL);
 	fns[2] = g_strdup ("/etc/machine-id");
 	fns[3] = g_strdup ("/var/lib/dbus/machine-id");
 	for (guint i = 0; fns[i] != NULL; i++) {

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -147,7 +147,7 @@ fwupd_remote_download_func (void)
 	g_autoptr(GError) error = NULL;
 
 	remote = fwupd_remote_new ();
-	directory = g_build_filename (LOCALSTATEDIR,
+	directory = g_build_filename (FWUPD_LOCALSTATEDIR,
 				      "lib",
 				      "fwupd",
 				      "remotes.d",
@@ -166,9 +166,9 @@ fwupd_remote_download_func (void)
 	g_assert_cmpstr (fwupd_remote_get_title (remote), ==, "Linux Vendor Firmware Service");
 	g_assert_cmpstr (fwupd_remote_get_report_uri (remote), ==, "https://fwupd.org/lvfs/firmware/report");
 	g_assert_cmpstr (fwupd_remote_get_filename_cache (remote), ==,
-			 LOCALSTATEDIR "/lib/fwupd/remotes.d/lvfs/metadata.xml.gz");
+			 FWUPD_LOCALSTATEDIR "/lib/fwupd/remotes.d/lvfs/metadata.xml.gz");
 	g_assert_cmpstr (fwupd_remote_get_filename_cache_sig (remote), ==,
-			 LOCALSTATEDIR "/lib/fwupd/remotes.d/lvfs/metadata.xml.gz.asc");
+			 FWUPD_LOCALSTATEDIR "/lib/fwupd/remotes.d/lvfs/metadata.xml.gz.asc");
 }
 
 /* verify we used the FirmwareBaseURI just for firmware */
@@ -183,7 +183,7 @@ fwupd_remote_baseuri_func (void)
 	g_autoptr(GError) error = NULL;
 
 	remote = fwupd_remote_new ();
-	directory = g_build_filename (LOCALSTATEDIR,
+	directory = g_build_filename (FWUPD_LOCALSTATEDIR,
 				      "lib",
 				      "fwupd",
 				      "remotes.d",
@@ -219,7 +219,7 @@ fwupd_remote_nopath_func (void)
 	g_autofree gchar *directory = NULL;
 
 	remote = fwupd_remote_new ();
-	directory = g_build_filename (LOCALSTATEDIR,
+	directory = g_build_filename (FWUPD_LOCALSTATEDIR,
 				      "lib",
 				      "fwupd",
 				      "remotes.d",

--- a/meson.build
+++ b/meson.build
@@ -344,21 +344,21 @@ endif
 gnome = import('gnome')
 i18n = import('i18n')
 
-conf.set_quoted('BINDIR', bindir)
-conf.set_quoted('LIBEXECDIR', libexecdir)
-conf.set_quoted('DATADIR', datadir)
-conf.set_quoted('LOCALSTATEDIR', localstatedir)
-conf.set_quoted('SYSCONFDIR', sysconfdir)
+conf.set_quoted('FWUPD_BINDIR', bindir)
+conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
+conf.set_quoted('FWUPD_DATADIR', datadir)
+conf.set_quoted('FWUPD_LOCALSTATEDIR', localstatedir)
+conf.set_quoted('FWUPD_SYSCONFDIR', sysconfdir)
+conf.set_quoted('FWUPD_LOCALEDIR', localedir)
 
 if build_standalone
 plugin_dir = join_paths(libdir, 'fwupd-plugins-3')
-conf.set_quoted('PLUGINDIR', plugin_dir)
+conf.set_quoted('FWUPD_PLUGINDIR', plugin_dir)
 endif
 
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set_quoted('VERSION', meson.project_version())
-conf.set_quoted('LOCALEDIR', localedir)
 configure_file(
   output : 'config.h',
   configuration : conf

--- a/plugins/dfu/dfu-tool.c
+++ b/plugins/dfu/dfu-tool.c
@@ -1240,7 +1240,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -175,7 +175,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 
 	/* if the original firmware doesn't exist, grab it now */
 	basename = g_strdup_printf ("flashrom-%s.bin", fu_device_get_id (device));
-	firmware_orig = g_build_filename (LOCALSTATEDIR, "lib", "fwupd",
+	firmware_orig = g_build_filename (FWUPD_LOCALSTATEDIR, "lib", "fwupd",
 					  "builder", basename, NULL);
 	if (!fu_common_mkdir_parent (firmware_orig, error))
 		return FALSE;

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -94,7 +94,7 @@ static GBytes *
 fu_plugin_uefi_get_splash_data (guint width, guint height, GError **error)
 {
 	const gchar * const *langs = g_get_language_names ();
-	const gchar *localedir = LOCALEDIR;
+	const gchar *localedir = FWUPD_LOCALEDIR;
 	const gsize chunk_size = 1024 * 1024;
 	gsize buf_idx = 0;
 	gsize buf_sz = chunk_size;

--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -108,7 +108,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/src/fu-agent.c
+++ b/src/fu-agent.c
@@ -160,7 +160,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -963,8 +963,8 @@ fu_common_get_path (FuPathKind path_kind)
 			return g_strdup (tmp);
 		tmp = g_getenv ("SNAP_USER_DATA");
 		if (tmp != NULL)
-			return g_build_filename (tmp, LOCALSTATEDIR, NULL);
-		return g_build_filename (LOCALSTATEDIR, NULL);
+			return g_build_filename (tmp, FWUPD_LOCALSTATEDIR, NULL);
+		return g_build_filename (FWUPD_LOCALSTATEDIR, NULL);
 	/* /sys/firmware */
 	case FU_PATH_KIND_SYSFSDIR_FW:
 		tmp = g_getenv ("FWUPD_SYSFSFWDIR");
@@ -990,8 +990,8 @@ fu_common_get_path (FuPathKind path_kind)
 			return g_strdup (tmp);
 		tmp = g_getenv ("SNAP_USER_DATA");
 		if (tmp != NULL)
-			return g_build_filename (tmp, SYSCONFDIR, NULL);
-		return g_strdup (SYSCONFDIR);
+			return g_build_filename (tmp, FWUPD_SYSCONFDIR, NULL);
+		return g_strdup (FWUPD_SYSCONFDIR);
 	/* /usr/lib/<triplet>/fwupd-plugins-3 */
 	case FU_PATH_KIND_PLUGINDIR_PKG:
 		tmp = g_getenv ("FWUPD_PLUGINDIR");
@@ -999,8 +999,8 @@ fu_common_get_path (FuPathKind path_kind)
 			return g_strdup (tmp);
 		tmp = g_getenv ("SNAP");
 		if (tmp != NULL)
-			return g_build_filename (tmp, PLUGINDIR, NULL);
-		return g_build_filename (PLUGINDIR, NULL);
+			return g_build_filename (tmp, FWUPD_PLUGINDIR, NULL);
+		return g_build_filename (FWUPD_PLUGINDIR, NULL);
 	/* /usr/share/fwupd */
 	case FU_PATH_KIND_DATADIR_PKG:
 		tmp = g_getenv ("FWUPD_DATADIR");
@@ -1008,8 +1008,8 @@ fu_common_get_path (FuPathKind path_kind)
 			return g_strdup (tmp);
 		tmp = g_getenv ("SNAP");
 		if (tmp != NULL)
-			return g_build_filename (tmp, DATADIR, PACKAGE_NAME, NULL);
-		return g_build_filename (DATADIR, PACKAGE_NAME, NULL);
+			return g_build_filename (tmp, FWUPD_DATADIR, PACKAGE_NAME, NULL);
+		return g_build_filename (FWUPD_DATADIR, PACKAGE_NAME, NULL);
 	/* /usr/libexec/fwupd/efi */
 	case FU_PATH_KIND_EFIAPPDIR:
 		tmp = g_getenv ("FWUPD_EFIAPPDIR");

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1531,7 +1531,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/src/fu-offline.c
+++ b/src/fu-offline.c
@@ -149,7 +149,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1970,7 +1970,7 @@ fu_plugin_runner_update (FuPlugin *self,
 		/* delete cab file */
 		release = fu_device_get_release_default (device_pending);
 		tmp = fwupd_release_get_filename (release);
-		if (tmp != NULL && g_str_has_prefix (tmp, LIBEXECDIR)) {
+		if (tmp != NULL && g_str_has_prefix (tmp, FWUPD_LIBEXECDIR)) {
 			g_autoptr(GError) error_delete = NULL;
 			g_autoptr(GFile) file = NULL;
 			file = g_file_new_for_path (tmp);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1645,7 +1645,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2449,7 +2449,7 @@ main (int argc, char *argv[])
 
 	setlocale (LC_ALL, "");
 
-	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+	bindtextdomain (GETTEXT_PACKAGE, FWUPD_LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 


### PR DESCRIPTION
DATADIR is an enumerated type in MinGW, and the other names are very generic.
