### PR TITLE
fu-util-common: Invert default behavior for reboot and shutdown prompts

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -438,7 +438,7 @@ fu_util_prompt_complete (FwupdDeviceFlags flags, gboolean prompt, GError **error
 				 _("An update requires the system to shutdown to complete."),
 				 /* TRANSLATORS: shutdown to apply the update */
 				 _("Shutdown now?"));
-			if (!fu_util_prompt_for_boolean (TRUE))
+			if (!fu_util_prompt_for_boolean (FALSE))
 				return TRUE;
 		}
 		return fu_util_update_shutdown (error);
@@ -450,7 +450,7 @@ fu_util_prompt_complete (FwupdDeviceFlags flags, gboolean prompt, GError **error
 				 _("An update requires a reboot to complete."),
 				 /* TRANSLATORS: reboot to apply the update */
 				 _("Restart now?"));
-			if (!fu_util_prompt_for_boolean (TRUE))
+			if (!fu_util_prompt_for_boolean (FALSE))
 				return TRUE;
 		}
 		return fu_util_update_reboot (error);


### PR DESCRIPTION
Current behavior for the prompt:
```
Y … Restart & Update
y … Restart & Update
N … Tool abort & Update complete after next Power cycle
n …Tool abort & Update complete after next Power cycle
0 … Pause -> (Push anykey) -> Restart & Update
* … Pause -> (Push anykey) -> Restart & Update
“”(Enter Only) … Restart & Update
```

If someone just keeps pressing enter without reading the system will reboot
which might lead to data loss.

Set the default scenario to abort reboot, so they can just see the message
to reboot instead.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
