### PR TITLE
Set the protocol per-device not per-plugin

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -545,6 +545,7 @@ fu_altos_device_init (FuAltosDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_vendor (FU_DEVICE (self), "altusmetrum.org");
 	fu_device_set_summary (FU_DEVICE (self), "A USB hardware random number generator");
+	fu_device_set_protocol (FU_DEVICE (self), "org.altusmetrum.altos");
 
 	/* requires manual step */
 	if (!fu_device_has_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER))

--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.altusmetrum.altos");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ALTOS_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "altos", FU_TYPE_ALTOS_FIRMWARE);
 }

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -661,6 +661,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
+	fu_device_set_protocol (FU_DEVICE (self), "org.t13.ata");
 	fu_udev_device_set_readonly (FU_UDEV_DEVICE (self), TRUE);
 }
 

--- a/plugins/ata/fu-plugin-ata.c
+++ b/plugins/ata/fu-plugin-ata.c
@@ -16,6 +16,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "block");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.t13.ata");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ATA_DEVICE);
 }

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -455,6 +455,7 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 {
 	/* this is the application code */
 	self->start_addr = CH_EEPROM_ADDR_RUNCODE;
+	fu_device_set_protocol (FU_DEVICE (self), "com.hughski.colorhug");
 	fu_device_set_remove_delay (FU_DEVICE (self),
 				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -15,6 +15,5 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.hughski.colorhug");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_COLORHUG_DEVICE);
 }

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -548,8 +548,9 @@ fu_csr_device_close (FuUsbDevice *device, GError **error)
 }
 
 static void
-fu_csr_device_init (FuCsrDevice *device)
+fu_csr_device_init (FuCsrDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.qualcomm.dfu");
 }
 
 static void

--- a/plugins/csr/fu-plugin-csr.c
+++ b/plugins/csr/fu-plugin-csr.c
@@ -15,6 +15,5 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.qualcomm.dfu");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CSR_DEVICE);
 }

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -988,6 +988,7 @@ fu_dell_dock_ec_init (FuDellDockEc *self)
 {
 	self->data = g_new0 (FuDellDockDockDataStructure, 1);
 	self->raw_versions = g_new0 (FuDellDockDockPackageFWVersion, 1);
+	fu_device_set_protocol (FU_DEVICE (self), "com.dell.dock");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -972,6 +972,7 @@ fu_dell_dock_mst_finalize (GObject *object)
 static void
 fu_dell_dock_mst_init (FuDellDockMst *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.mst");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -280,8 +280,10 @@ fu_dell_dock_tbt_finalize (GObject *object)
 }
 
 static void
-fu_dell_dock_tbt_init (FuDellDockTbt *device)
-{}
+fu_dell_dock_tbt_init (FuDellDockTbt *self)
+{
+	fu_device_set_protocol (FU_DEVICE (self), "com.intel.thunderbolt");
+}
 
 static void
 fu_dell_dock_tbt_class_init (FuDellDockTbtClass *klass)

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -142,6 +142,7 @@ fu_dell_dock_status_finalize (GObject *object)
 static void
 fu_dell_dock_status_init (FuDellDockStatus *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.dell.dock");
 }
 
 static void

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -33,8 +33,6 @@ fu_plugin_init (FuPlugin *plugin)
 
 	/* currently slower performance, but more reliable in corner cases */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "synapticsmst");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.dell.dock");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.mst");
 }
 
 static gboolean

--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -332,6 +332,13 @@ dfu_device_add_targets (DfuDevice *device, GError **error)
 			priv->version = DFU_VERSION_DFU_1_1;
 		}
 
+		/* set expected protocol */
+		if (priv->version == DFU_VERSION_DFUSE) {
+			fu_device_set_protocol (FU_DEVICE (device), "com.st.dfuse");
+		} else {
+			fu_device_set_protocol (FU_DEVICE (device), "org.usb.dfu");
+		}
+
 		/* fix up the transfer size */
 		if (priv->transfer_size == 0xffff) {
 			priv->transfer_size = 0x0400;

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -15,7 +15,5 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.usb.dfu");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.st.dfuse");
 	fu_plugin_set_device_gtype (plugin, DFU_TYPE_DEVICE);
 }

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -578,6 +578,7 @@ fu_ebitdo_device_prepare_firmware (FuDevice *device,
 static void
 fu_ebitdo_device_init (FuEbitdoDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.8bitdo");
 }
 
 static void

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.8bitdo");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_EBITDO_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "8bitdo", FU_TYPE_EBITDO_FIRMWARE);
 }

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -478,6 +478,7 @@ fu_emmc_device_write_firmware (FuDevice *device,
 static void
 fu_emmc_device_init (FuEmmcDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "org.jedec.mmc");
 	fu_device_add_icon (FU_DEVICE (self), "media-memory");
 }
 

--- a/plugins/emmc/fu-plugin-emmc.c
+++ b/plugins/emmc/fu-plugin-emmc.c
@@ -16,6 +16,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "block");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.jedec.mmc");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_EMMC_DEVICE);
 }

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -694,6 +694,7 @@ fu_fastboot_device_init (FuFastbootDevice *self)
 {
 	/* this is a safe default, even using USBv1 */
 	self->blocksz = 512;
+	fu_device_set_protocol (FU_DEVICE (self), "com.google.fastboot");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_set_remove_delay (FU_DEVICE (self), FASTBOOT_REMOVE_DELAY_RE_ENUMERATE);

--- a/plugins/fastboot/fu-plugin-fastboot.c
+++ b/plugins/fastboot/fu-plugin-fastboot.c
@@ -15,6 +15,5 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.google.fastboot");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_FASTBOOT_DEVICE);
 }

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -41,7 +41,6 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.flashrom");
 }
 
 void
@@ -101,6 +100,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 			g_autoptr(FuDevice) dev = fu_device_new ();
 			fu_device_set_id (dev, device_id);
 			fu_device_set_quirks (dev, fu_plugin_get_quirks (plugin));
+			fu_device_set_protocol (dev, "org.flashrom");
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 			fu_device_set_name (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME));

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -588,6 +588,7 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 			self->is_updatable = TRUE;
 			fu_device_remove_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		}
+		fu_device_set_protocol (FU_DEVICE (device), "com.logitech.unifyingsigned");
 	}
 	idx = fu_logitech_hidpp_peripheral_feature_get_idx (self, HIDPP_FEATURE_DFU);
 	if (idx != 0x00) {
@@ -1020,6 +1021,7 @@ fu_logitech_hidpp_peripheral_init (FuLogitechHidPpPeripheral *self)
 	self->feature_index = g_ptr_array_new_with_free_func (g_free);
 	fu_device_add_parent_guid (FU_DEVICE (self), "HIDRAW\\VEN_046D&DEV_C52B");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_protocol (FU_DEVICE (self), "com.logitech.unifying");
 
 	/* there are a lot of unifying peripherals, but not all respond
 	 * well to opening -- so limit to ones with issued updates */

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -35,8 +35,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.logitech.unifying");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.logitech.unifyingsigned");
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "unifying");
 

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -431,6 +431,7 @@ fu_nvme_device_init (FuNvmeDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_summary (FU_DEVICE (self), "NVM Express Solid State Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
+	fu_device_set_protocol (FU_DEVICE (self), "org.nvmexpress");
 	fu_udev_device_set_readonly (FU_UDEV_DEVICE (self), TRUE);
 }
 

--- a/plugins/nvme/fu-plugin-nvme.c
+++ b/plugins/nvme/fu-plugin-nvme.c
@@ -16,6 +16,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "nvme");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.nvmexpress");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_NVME_DEVICE);
 }

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -121,7 +121,6 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	data->client = fu_redfish_client_new ();
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.dmtf.redfish");
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 }
 

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -123,6 +123,7 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 	id = g_strdup_printf ("Redfish-Inventory-%s",
 			      json_object_get_string_member (member, "Id"));
 	fu_device_set_id (dev, id);
+	fu_device_set_protocol (dev, "org.dmtf.redfish");
 
 	fu_device_add_guid (dev, guid);
 	if (json_object_has_member (member, "Name"))

--- a/plugins/rts54hid/fu-plugin-rts54hid.c
+++ b/plugins/rts54hid/fu-plugin-rts54hid.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.realtek.rts54");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_RTS54HID_DEVICE);
 
 	/* register the custom types */

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -377,6 +377,7 @@ fu_rts54hid_device_write_firmware (FuDevice *device,
 static void
 fu_rts54hid_device_init (FuRts54HidDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54");
 }
 
 static void

--- a/plugins/rts54hub/fu-plugin-rts54hub.c
+++ b/plugins/rts54hub/fu-plugin-rts54hub.c
@@ -15,6 +15,5 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.realtek.rts54");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_RTS54HUB_DEVICE);
 }

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -416,6 +416,7 @@ fu_rts54hub_device_prepare_firmware (FuDevice *device,
 static void
 fu_rts54hub_device_init (FuRts54HubDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 

--- a/plugins/solokey/fu-plugin-solokey.c
+++ b/plugins/solokey/fu-plugin-solokey.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.solokeys");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SOLOKEY_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "solokey", FU_TYPE_SOLOKEY_FIRMWARE);
 }

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -484,6 +484,7 @@ fu_solokey_device_init (FuSolokeyDevice *self)
 	self->cid = 0xffffffff;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
+	fu_device_set_protocol (FU_DEVICE (self), "com.solokeys");
 	fu_device_set_name (FU_DEVICE (self), "Solo Secure");
 	fu_device_set_summary (FU_DEVICE (self), "An open source FIDO2 security key");
 	fu_device_add_icon (FU_DEVICE (self), "applications-internet");

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -90,7 +90,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "tw.com.ite.superio");
 }
 
 gboolean

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -396,6 +396,7 @@ fu_superio_device_init (FuSuperioDevice *self)
 	fu_device_set_physical_id (FU_DEVICE (self), "/dev/port");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_set_protocol (FU_DEVICE (self), "tw.com.ite.superio");
 	fu_device_set_summary (FU_DEVICE (self), "Embedded Controller");
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }

--- a/plugins/synaptics-prometheus/fu-plugin-synaptics-prometheus.c
+++ b/plugins/synaptics-prometheus/fu-plugin-synaptics-prometheus.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.prometheus");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPROM_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "synaprom", FU_TYPE_SYNAPROM_FIRMWARE);
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -203,6 +203,7 @@ fu_synaprom_config_write_firmware (FuDevice *device,
 static void
 fu_synaprom_config_init (FuSynapromConfig *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus.config");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_logical_id (FU_DEVICE (self), "cfg");
 	fu_device_set_name (FU_DEVICE (self), "Prometheus IOTA Config");

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -436,6 +436,7 @@ fu_synaprom_device_init (FuSynapromDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY);
+	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_name (FU_DEVICE (self), "Prometheus");
 	fu_device_set_summary (FU_DEVICE (self), "Fingerprint reader");

--- a/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
+++ b/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.rmi");
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPTICS_RMI_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "rmi", FU_TYPE_SYNAPTICS_RMI_FIRMWARE);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -996,6 +996,7 @@ static void
 fu_synaptics_rmi_device_init (FuSynapticsRmiDevice *self)
 {
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE (self);
+	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.rmi");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_name (FU_DEVICE (self), "Touchpad");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -171,7 +171,6 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "drm");	/* used for uevent only */
 	fu_plugin_add_udev_subsystem (plugin, "drm_dp_aux_dev");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.mst");
 }
 
 void

--- a/plugins/synapticsmst/fu-synapticsmst-device.c
+++ b/plugins/synapticsmst/fu-synapticsmst-device.c
@@ -68,6 +68,7 @@ fu_synapticsmst_device_finalize (GObject *object)
 static void
 fu_synapticsmst_device_init (FuSynapticsmstDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.mst");
 	fu_device_set_vendor (FU_DEVICE (self), "Synaptics");
 	fu_device_set_summary (FU_DEVICE (self), "Multi-Stream Transport Device");
 	fu_device_add_icon (FU_DEVICE (self), "video-display");

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -20,7 +20,6 @@ fu_plugin_init (FuPlugin *plugin)
 		fu_plugin_set_build_hash (plugin, "invalid");
 	else
 		fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.acme.test");
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	g_debug ("init");
 }
@@ -43,6 +42,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_add_icon (device, "preferences-desktop-keyboard");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY);
+	fu_device_set_protocol (device, "com.acme.test");
 	fu_device_set_summary (device, "A fake webcam");
 	fu_device_set_vendor (device, "ACME Corp.");
 	fu_device_set_vendor_id (device, "USB:0x046D");

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -407,6 +407,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	if (is_host)
 		fu_device_set_summary (dev, "Unmatched performance for high-speed I/O");
 	fu_device_add_icon (dev, "thunderbolt");
+	fu_device_set_protocol (dev, "com.intel.thunderbolt");
 
 	fu_device_set_quirks (dev, fu_plugin_get_quirks (plugin));
 	vendor = g_udev_device_get_sysfs_attr (device, "vendor_name");
@@ -640,7 +641,6 @@ fu_plugin_init (FuPlugin *plugin)
 	const gchar *subsystems[] = { "thunderbolt", NULL };
 
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.intel.thunderbolt");
 	data->udev = g_udev_client_new (subsystems);
 	g_signal_connect (data->udev, "uevent",
 			  G_CALLBACK (udev_uevent_cb), plugin);

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -37,7 +37,6 @@ fu_plugin_init (FuPlugin *plugin)
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	data->bgrt = fu_uefi_bgrt_new ();
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "upower");
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.uefi.capsule");
 	fu_plugin_add_compile_version (plugin, "com.redhat.efivar", EFIVAR_LIBRARY_VERSION);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 }

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -721,6 +721,7 @@ fu_uefi_device_probe (FuDevice *device, GError **error)
 static void
 fu_uefi_device_init (FuUefiDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "org.uefi.capsule");
 }
 
 static void

--- a/plugins/vli-usbhub/fu-plugin-vli-usbhub.c
+++ b/plugins/vli-usbhub/fu-plugin-vli-usbhub.c
@@ -17,7 +17,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.vli.usbhub");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_VLI_USBHUB_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "vli-usbhub", FU_TYPE_VLI_USBHUB_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, "vli-usbhub-pd", FU_TYPE_VLI_USBHUB_PD_FIRMWARE);

--- a/plugins/vli-usbhub/fu-vli-usbhub-device.c
+++ b/plugins/vli-usbhub/fu-vli-usbhub-device.c
@@ -1498,6 +1498,7 @@ fu_vli_usbhub_device_init (FuVliUsbhubDevice *self)
 	self->spi_cmd_read_id		= 0x9f;
 	self->spi_cmd_read_id_sz = 2;
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
+	fu_device_set_protocol (FU_DEVICE (self), "com.vli.usbhub");
 	fu_device_set_firmware_size_max (FU_DEVICE (self), 0x20000);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.wacom.raw");
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 
 	/* register the custom types */

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -339,6 +339,7 @@ fu_wacom_device_set_quirk_kv (FuDevice *device,
 static void
 fu_wacom_device_init (FuWacomDevice *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.raw");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 }

--- a/plugins/wacom-usb/fu-plugin-wacom-usb.c
+++ b/plugins/wacom-usb/fu-plugin-wacom-usb.c
@@ -16,7 +16,6 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.wacom.usb");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_WAC_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "wacom", FU_TYPE_WAC_FIRMWARE);
 }

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -850,6 +850,7 @@ fu_wac_device_init (FuWacDevice *self)
 	self->checksums = g_array_new (FALSE, FALSE, sizeof(guint32));
 	self->configuration = 0xffff;
 	self->firmware_index = 0xffff;
+	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.usb");
 	fu_device_add_icon (FU_DEVICE (self), "input-tablet");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_install_duration (FU_DEVICE (self), 10);

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -186,6 +186,9 @@ void		 fu_device_set_physical_id		(FuDevice	*self,
 const gchar	*fu_device_get_logical_id		(FuDevice	*self);
 void		 fu_device_set_logical_id		(FuDevice	*self,
 							 const gchar	*logical_id);
+const gchar	*fu_device_get_protocol			(FuDevice	*self);
+void		 fu_device_set_protocol			(FuDevice	*self,
+							 const gchar	*protocol);
 void		 fu_device_add_flag			(FuDevice	*self,
 							 FwupdDeviceFlags flag);
 const gchar	*fu_device_get_custom_flags		(FuDevice	*self);

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -71,7 +71,6 @@ typedef enum {
  * @FU_PLUGIN_RULE_RUN_BEFORE:		Order the plugin before another
  * @FU_PLUGIN_RULE_BETTER_THAN:		Is better than another plugin
  * @FU_PLUGIN_RULE_INHIBITS_IDLE:	The plugin inhibits the idle shutdown
- * @FU_PLUGIN_RULE_SUPPORTS_PROTOCOL:	The plugin supports a well known protocol
  *
  * The rules used for ordering plugins.
  * Plugins are expected to add rules in fu_plugin_initialize().
@@ -82,7 +81,6 @@ typedef enum {
 	FU_PLUGIN_RULE_RUN_BEFORE,
 	FU_PLUGIN_RULE_BETTER_THAN,
 	FU_PLUGIN_RULE_INHIBITS_IDLE,
-	FU_PLUGIN_RULE_SUPPORTS_PROTOCOL,
 	/*< private >*/
 	FU_PLUGIN_RULE_LAST
 } FuPluginRule;


### PR DESCRIPTION
Some plugins have devices with more than one protocol. Logically the protocol
belongs to the device, not the plugin, and in the future we could use this to
further check firmware that's about to be deployed.

This is also not exported into libfwupd (yet?) as it's remains a debug-feature
only -- protocols are not actually required for devices to be added.