### PR TITLE
trivial: Allow compiling without <fnmatch.h>

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -7,7 +7,9 @@
 #include "config.h"
 
 #include <glib-object.h>
+#ifdef HAVE_FNMATCH_H
 #include <fnmatch.h>
+#endif
 
 #include "fwupd-client.h"
 #include "fwupd-common.h"
@@ -27,8 +29,13 @@ fu_test_compare_lines (const gchar *txt1, const gchar *txt2, GError **error)
 		return TRUE;
 
 	/* matches a pattern */
+#ifdef HAVE_FNMATCH_H
 	if (fnmatch (txt2, txt1, FNM_NOESCAPE) == 0)
 		return TRUE;
+#else
+	if (g_strcmp0 (txt1, txt2) == 0)
+		return TRUE;
+#endif
 
 	/* save temp files and diff them */
 	if (!g_file_set_contents ("/tmp/a", txt1, -1, error))

--- a/meson.build
+++ b/meson.build
@@ -239,6 +239,9 @@ endif
 if cc.has_header('poll.h')
   conf.set('HAVE_POLL_H', '1')
 endif
+if cc.has_header('fnmatch.h')
+  conf.set('HAVE_FNMATCH_H', '1')
+endif
 if cc.has_function('getuid')
   conf.set('HAVE_GETUID', '1')
 endif

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -10,9 +10,10 @@
 #include <string.h>
 #include <efivar.h>
 #include <efivar/efiboot.h>
-#include <fnmatch.h>
 
 #include "fu-device-metadata.h"
+
+#include "fu-common.h"
 
 #include "fu-uefi-common.h"
 #include "fu-uefi-device.h"
@@ -462,7 +463,7 @@ fu_uefi_device_cleanup_esp (FuDevice *device, GError **error)
 	pattern = g_build_filename (esp_path, "EFI/*/fw/fwupd-*.cap", NULL);
 	for (guint i = 0; i < files->len; i++) {
 		const gchar *fn = g_ptr_array_index (files, i);
-		if (fnmatch (pattern, fn, 0) == 0) {
+		if (fu_common_fnmatch (pattern, fn)) {
 			g_autoptr(GFile) file = g_file_new_for_path (fn);
 			g_debug ("deleting %s", fn);
 			if (!g_file_delete (file, NULL, error))

--- a/plugins/uefi/fu-uefi-vars.c
+++ b/plugins/uefi/fu-uefi-vars.c
@@ -9,7 +9,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <fnmatch.h>
 #include <linux/fs.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -154,7 +153,7 @@ fu_uefi_vars_delete_with_glob (const gchar *guid, const gchar *name_glob, GError
 		return FALSE;
 	nameguid_glob = g_strdup_printf ("%s-%s", name_glob, guid);
 	while ((fn = g_dir_read_name (dir)) != NULL) {
-		if (fnmatch (nameguid_glob, fn, 0) == 0) {
+		if (fu_common_fnmatch (nameguid_glob, fn)) {
 			g_autofree gchar *keyfn = g_build_filename (efivardir, fn, NULL);
 			g_autoptr(GFile) file = g_file_new_for_path (keyfn);
 			if (!fu_uefi_vars_set_immutable (keyfn, FALSE, NULL, error)) {

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -11,6 +11,10 @@
 #include <gio/gunixinputstream.h>
 #include <glib/gstdio.h>
 
+#ifdef HAVE_FNMATCH_H
+#include <fnmatch.h>
+#endif
+
 #include <archive_entry.h>
 #include <archive.h>
 #include <errno.h>
@@ -1621,6 +1625,29 @@ fu_common_realpath (const gchar *filename, GError **error)
 		return NULL;
 	}
 	return g_strdup (full_tmp);
+}
+
+/**
+ * fu_common_fnmatch:
+ * @pattern: a glob pattern, e.g. `*foo*`
+ * @str: a string to match against the pattern, e.g. `bazfoobar`
+ *
+ * Matches a string against a glob pattern.
+ *
+ * Return value: %TRUE if the string matched
+ *
+ * Since: 1.3.5
+ **/
+gboolean
+fu_common_fnmatch (const gchar *pattern, const gchar *str)
+{
+	g_return_val_if_fail (pattern != NULL, FALSE);
+	g_return_val_if_fail (str != NULL, FALSE);
+#ifdef HAVE_FNMATCH_H
+	return fnmatch (pattern, str, FNM_NOESCAPE) == 0;
+#else
+	return g_strcmp0 (pattern, str) == 0;
+#endif
 }
 
 /**

--- a/src/fu-common.h
+++ b/src/fu-common.h
@@ -89,6 +89,8 @@ gboolean	 fu_common_spawn_sync		(const gchar * const *argv,
 gchar		*fu_common_get_path		(FuPathKind	 path_kind);
 gchar		*fu_common_realpath		(const gchar	*filename,
 						 GError		**error);
+gboolean	 fu_common_fnmatch		(const gchar	*pattern,
+						 const gchar	*str);
 gboolean	 fu_common_rmtree		(const gchar	*directory,
 						 GError		**error);
 GPtrArray	*fu_common_get_files_recursive	(const gchar	*path,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -14,7 +14,6 @@
 #ifdef HAVE_GUDEV
 #include <gudev/gudev.h>
 #endif
-#include <fnmatch.h>
 #include <string.h>
 #ifdef HAVE_UTSNAME_H
 #include <sys/utsname.h>
@@ -1018,7 +1017,7 @@ fu_engine_require_vercmp (XbNode *req, const gchar *version, GError **error)
 		rc = fu_common_vercmp (version, version_req);
 		ret = rc >= 0;
 	} else if (g_strcmp0 (tmp, "glob") == 0) {
-		ret = fnmatch (version_req, version, 0) == 0;
+		ret = fu_common_fnmatch (version_req, version);
 	} else if (g_strcmp0 (tmp, "regex") == 0) {
 		ret = g_regex_match_simple (version_req, version, 0, 0);
 	} else {
@@ -4331,7 +4330,7 @@ fu_engine_is_plugin_name_whitelisted (FuEngine *self, const gchar *name)
 		return TRUE;
 	for (guint i = 0; i < self->plugin_filter->len; i++) {
 		const gchar *name_tmp = g_ptr_array_index (self->plugin_filter, i);
-		if (fnmatch (name_tmp, name, 0) == 0)
+		if (fu_common_fnmatch (name_tmp, name))
 			return TRUE;
 	}
 	return FALSE;

--- a/src/fu-test.c
+++ b/src/fu-test.c
@@ -10,7 +10,6 @@
 
 #include <limits.h>
 #include <stdlib.h>
-#include <fnmatch.h>
 
 #include "fu-test.h"
 #include "fu-common.h"
@@ -113,7 +112,7 @@ fu_test_compare_lines (const gchar *txt1, const gchar *txt2, GError **error)
 		return TRUE;
 
 	/* matches a pattern */
-	if (fnmatch (txt2, txt1, FNM_NOESCAPE) == 0)
+	if (fu_common_fnmatch (txt2, txt1))
 		return TRUE;
 
 	/* save temp files and diff them */


### PR DESCRIPTION
This also allows us to add a Win32 implementation if required in the future.
