### PR TITLE
trivial: Do not include fu-test.c in libfwupdprivate

### DIFF
--- a/docs/fwupd-docs.xml
+++ b/docs/fwupd-docs.xml
@@ -63,7 +63,6 @@
     <xi:include href="xml/fu-plugin.xml"/>
     <xi:include href="xml/fu-quirks.xml"/>
     <xi:include href="xml/fu-smbios.xml"/>
-    <xi:include href="xml/fu-test.xml"/>
     <xi:include href="xml/fu-udev-device.xml"/>
     <xi:include href="xml/fu-usb-device.xml"/>
   </reference>

--- a/plugins/ata/fu-test.c
+++ b/plugins/ata/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/ata/meson.build
+++ b/plugins/ata/meson.build
@@ -39,6 +39,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-ata-device.c',
     ],
     include_directories : [

--- a/plugins/dell/fu-test.c
+++ b/plugins/dell/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -40,6 +40,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-dell-smi.c',
       'fu-plugin-dell.c',
     ],

--- a/plugins/dfu/fu-test.c
+++ b/plugins/dfu/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -115,7 +115,8 @@ if get_option('tests')
     'dfu-self-test',
     fu_hash,
     sources : [
-      'dfu-self-test.c'
+      'dfu-self-test.c',
+      'fu-test.c',
     ],
     include_directories : [
       include_directories('..'),

--- a/plugins/nitrokey/fu-test.c
+++ b/plugins/nitrokey/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -34,6 +34,7 @@ if get_option('tests')
     sources : [
       'fu-nitrokey-common.c',
       'fu-self-test.c',
+      'fu-test.c',
     ],
     include_directories : [
       include_directories('../..'),

--- a/plugins/nvme/fu-test.c
+++ b/plugins/nvme/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -40,6 +40,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-nvme-common.c',
       'fu-nvme-device.c',
     ],

--- a/plugins/optionrom/fu-test.c
+++ b/plugins/optionrom/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/optionrom/meson.build
+++ b/plugins/optionrom/meson.build
@@ -58,6 +58,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-rom.c',
     ],
     include_directories : [

--- a/plugins/redfish/fu-test.c
+++ b/plugins/redfish/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -35,6 +35,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-redfish-client.c',
       'fu-redfish-common.c',
     ],

--- a/plugins/synaptics-prometheus/fu-test.c
+++ b/plugins/synaptics-prometheus/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -37,6 +37,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-synaprom-common.c',
       'fu-synaprom-config.c',
       'fu-synaprom-device.c',

--- a/plugins/synapticsmst/fu-test.c
+++ b/plugins/synapticsmst/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/synapticsmst/meson.build
+++ b/plugins/synapticsmst/meson.build
@@ -38,6 +38,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-synapticsmst-common.c',
       'fu-synapticsmst-connection.c',
       'fu-synapticsmst-device.c',

--- a/plugins/thunderbolt/fu-test.c
+++ b/plugins/thunderbolt/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -56,6 +56,7 @@ if get_option('tests') and umockdev.found() and gio.version().version_compare('>
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-plugin-thunderbolt.c',
       'fu-thunderbolt-image.c',
     ],

--- a/plugins/uefi/fu-test.c
+++ b/plugins/uefi/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -96,6 +96,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-uefi-bgrt.c',
       'fu-uefi-bootmgr.c',
       'fu-uefi-common.c',

--- a/plugins/wacom-usb/fu-test.c
+++ b/plugins/wacom-usb/fu-test.c
@@ -1,0 +1,1 @@
+../../src/fu-test.c

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -39,6 +39,7 @@ if get_option('tests')
     fu_hash,
     sources : [
       'fu-self-test.c',
+      'fu-test.c',
       'fu-wac-common.c',
       'fu-wac-firmware.c',
     ],

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,6 @@ libfwupdprivate_src = [
   'fu-quirks.c',
   'fu-smbios.c',
   'fu-srec-firmware.c',
-  'fu-test.c',
   'fu-usb-device.c',
 ]
 


### PR DESCRIPTION
Use symlinks -- the file is a trivial helper used by various different modules,
and it's overkill to create a private or shared library just for 4 functions.

It also means there are no ordering issues when we split out fwupdplugin.
