### PR TITLE
[WIP]plugin/coreboot: Add sysfs parsers

### DIFF
--- a/plugins/coreboot/README.md
+++ b/plugins/coreboot/README.md
@@ -38,6 +38,25 @@ For example:
 
 The coreboot DMI version string always starts with `CBET`.
 
+CBMEM
+-----
+The coreboot memory object is similar to *UEFI Runtime Data*. It resides in
+DRAM and has been marked reserved in the e820 table or devicetree.
+
+The CBMEM have a known header which holds the ID and the payload length. The
+content is coreboot specific and might not be of interrest for the OS.
+
+coreboot tables
+---------------
+coreboot tables are similar to ACPI tables. They reside in CBMEM and provide
+useful information to the payload and OS.
+For example:
+* the firmware version string
+* the firmware size in bytes
+* the mainboard vendor and name
+* a list of all CBMEM buffers installed at runtime
+* a pointer to a CBMEM buffer holding the flash layout descriptor
+
 GUID Generation
 ---------------
 

--- a/plugins/coreboot/fu-coreboot-sysfs.c
+++ b/plugins/coreboot/fu-coreboot-sysfs.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2019 9elements Agency GmbH <patrick.rudolph@9elements.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <stdio.h>
+
+#include "fu-plugin-coreboot.h"
+
+#define SYSFS_BUS "/sys/bus/coreboot/"
+
+/* Tries to detect the 'coreboot' kernel module presence. */
+gboolean
+fu_plugin_coreboot_sysfs_probe (void)
+{
+	return g_file_test(SYSFS_BUS, G_FILE_TEST_EXISTS|
+				      G_FILE_TEST_IS_DIR);
+}
+
+/* iterates over sysfs directories until the given ID is found. */
+static gchar *
+fu_plugin_coreboot_find_sysfs (const guint id,
+			       const gchar *base_path,
+			       const gchar *extension_path,
+			       GError **error)
+{
+	GDir *dir;
+	const gchar *subdir = NULL;
+	gchar *tmp = NULL;
+	gboolean ret;
+
+	dir = g_dir_open (base_path, 0, error);
+	if (!dir)
+		return NULL;
+
+	while (1) {
+		gchar *fp;
+		guint64 i;
+
+		subdir = g_dir_read_name(dir);
+		if (!subdir)
+			break;
+
+		fp = g_strdup_printf ("%s/%s/%s/id", base_path, subdir,
+				      extension_path);
+
+		ret = g_file_get_contents (fp, &tmp, NULL, NULL);
+		g_free (fp);
+
+		if (!ret) {
+			continue;
+		}
+		i = g_ascii_strtoull (tmp, NULL, 16);
+		g_free (tmp);
+
+		if (id == i)
+			break;
+	};
+
+	g_dir_close (dir);
+
+	if (subdir == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_ARGUMENT,
+			     "Requested id not found");
+		return NULL;
+	}
+	return g_strdup_printf ("%s/%s/%s/", base_path, subdir, extension_path);
+}
+
+/* Returns the coreboot tables with given tag */
+gchar *
+fu_plugin_coreboot_find_cb_table (const guint tag, gsize *length,
+				  GError **error)
+{
+	gchar *fp;
+	gboolean ret;
+	gchar *path;
+	gchar *tmp;
+
+	path = fu_plugin_coreboot_find_sysfs (tag, SYSFS_BUS "/devices/",
+					      "attributes", error);
+	if (!path)
+		return NULL;
+
+	fp = g_strdup_printf ("%s/data", path);
+	g_free (path);
+
+	ret = g_file_get_contents (fp, &tmp, length, error);
+	g_free (fp);
+
+	if (!ret)
+		return NULL;
+
+	return tmp;
+}
+
+/* Returns the CBMEM buffer with given id */
+gchar *
+fu_plugin_coreboot_find_cbmem (const guint id, gsize *length, goffset *address,
+			       GError **error)
+{
+	gchar *fp;
+	gboolean ret;
+	gchar *tmp;
+	gchar *path;
+
+	path = fu_plugin_coreboot_find_sysfs (id, SYSFS_BUS "/drivers/cbmem/",
+					      "cbmem_attributes", error);
+	if (!path)
+		return NULL;
+
+	if (address != NULL) {
+		/* Store the physical CBMEM buffer address if requested */
+
+		fp = g_strdup_printf ("%s/address", path);
+
+		ret = g_file_get_contents (fp, &tmp, NULL, error);
+		g_free (fp);
+
+		if (!ret) {
+			g_free (path);
+			return NULL;
+		}
+
+		*address = (goffset) g_ascii_strtoull (tmp, NULL, 16);
+		g_free (tmp);
+	}
+
+	fp = g_strdup_printf ("%s/data", path);
+	g_free (path);
+
+	ret = g_file_get_contents (fp, &tmp, length, error);
+	g_free (fp);
+
+	if (!ret)
+		return NULL;
+
+	return tmp;
+}

--- a/plugins/coreboot/fu-plugin-coreboot.h
+++ b/plugins/coreboot/fu-plugin-coreboot.h
@@ -14,3 +14,12 @@ gchar		*fu_plugin_coreboot_version_string_to_triplet	(const gchar	*coreboot_vers
 gchar		*fu_plugin_coreboot_get_name_for_type		(FuPlugin	*plugin,
 								const gchar	*vboot_partition);
 const gchar	*fu_plugin_coreboot_get_version_string		(FuPlugin	*plugin);
+/* fu-coreboot-sysfs.c */
+gchar		*fu_plugin_coreboot_find_cb_table		(const guint	tag,
+								gsize		*length,
+								GError 		**error);
+gchar		*fu_plugin_coreboot_find_cbmem			(const guint	id,
+								gsize		*length,
+								goffset		*address,
+								GError		**error);
+gboolean	fu_plugin_coreboot_sysfs_probe			(void);

--- a/plugins/coreboot/meson.build
+++ b/plugins/coreboot/meson.build
@@ -8,6 +8,7 @@ shared_module('fu_plugin_coreboot',
   sources : [
     'fu-plugin-coreboot.c',
     'fu-coreboot-common.c',
+    'fu-coreboot-sysfs.c',
   ],
   include_directories : [
     root_incdir,


### PR DESCRIPTION
Requires Linux to be build with branch:
https://github.com/9elements/linux/tree/google_firmware_generic

Send upstream here:
https://lkml.org/lkml/2019/11/20/500

Provides /dev/mem free access to coreboot tables and CBMEM.

Signed-off-by: Patrick Rudolph <patrick.rudolph@9elements.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [x] Documentation
