### PR TITLE
Export the device protocol to the client --verbose output

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -92,6 +92,9 @@ void		 fwupd_device_add_checksum		(FwupdDevice	*device,
 const gchar	*fwupd_device_get_plugin		(FwupdDevice	*device);
 void		 fwupd_device_set_plugin		(FwupdDevice	*device,
 							 const gchar	*plugin);
+const gchar	*fwupd_device_get_protocol		(FwupdDevice	*device);
+void		 fwupd_device_set_protocol		(FwupdDevice	*device,
+							 const gchar	*protocol);
 const gchar	*fwupd_device_get_vendor		(FwupdDevice	*device);
 void		 fwupd_device_set_vendor		(FwupdDevice	*device,
 							 const gchar	*vendor);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -35,6 +35,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_NAME			"Name"		/* s */
 #define FWUPD_RESULT_KEY_NAME_VARIANT_SUFFIX	"NameVariantSuffix"	/* s */
 #define FWUPD_RESULT_KEY_PLUGIN			"Plugin"	/* s */
+#define FWUPD_RESULT_KEY_PROTOCOL		"Protocol"	/* s */
 #define FWUPD_RESULT_KEY_RELEASE		"Release"	/* a{sv} */
 #define FWUPD_RESULT_KEY_REMOTE_ID		"RemoteId"	/* s */
 #define FWUPD_RESULT_KEY_SERIAL			"Serial"	/* s */

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -405,3 +405,10 @@ LIBFWUPD_1.3.4 {
     fwupd_client_get_daemon_interactive;
   local: *;
 } LIBFWUPD_1.3.3;
+
+LIBFWUPD_1.3.6 {
+  global:
+    fwupd_device_get_protocol;
+    fwupd_device_set_protocol;
+  local: *;
+} LIBFWUPD_1.3.4;


### PR DESCRIPTION
It turns out this is useful for debugging.
