### PR TITLE
Improve debugging on autopkgtest

### DIFF
--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
-sed "s,^BlacklistPlugins=test,BlacklistPlugins=," -i /etc/fwupd/daemon.conf
+sed "s,^BlacklistPlugins=.*,BlacklistPlugins=," -i /etc/fwupd/daemon.conf
+sed "s,^VerboseDomains=.*,VerboseDomains=*,"  -i /etc/fwupd/daemon.conf
 gnome-desktop-testing-runner fwupd

--- a/data/installed-tests/fwupdmgr.sh
+++ b/data/installed-tests/fwupdmgr.sh
@@ -2,6 +2,7 @@
 
 exec 2>&1
 dirname=`dirname $0`
+device=08d460be0f1f9f128413f816022a6439e0078018
 
 # ---
 echo "Getting the list of remotes..."
@@ -15,7 +16,7 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
 echo "Update the device hash database..."
-fwupdmgr verify-update
+fwupdmgr verify-update $device
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
@@ -25,7 +26,7 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
 echo "Testing the verification of firmware..."
-fwupdmgr verify
+fwupdmgr verify $device
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
@@ -45,17 +46,17 @@ rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
 
 # ---
 echo "Testing the verification of firmware (again)..."
-fwupdmgr verify
+fwupdmgr verify $device
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
 echo "Downgrading to older release (requires network access)"
-fwupdmgr downgrade
+fwupdmgr downgrade $device
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---
 echo "Downgrading to older release (should be none)"
-fwupdmgr downgrade
+fwupdmgr downgrade $device
 rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
 
 # ---

--- a/data/installed-tests/fwupdmgr.sh
+++ b/data/installed-tests/fwupdmgr.sh
@@ -4,80 +4,87 @@ exec 2>&1
 dirname=`dirname $0`
 device=08d460be0f1f9f128413f816022a6439e0078018
 
+error()
+{
+        rc=$1
+        journalctl -u fwupd -b || true
+        exit $rc
+}
+
 # ---
 echo "Getting the list of remotes..."
 fwupdmgr get-remotes
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Enabling fwupd-tests remote..."
 fwupdmgr enable-remote fwupd-tests
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Update the device hash database..."
 fwupdmgr verify-update $device
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Getting devices (should be one)..."
 fwupdmgr get-devices --no-unreported-check
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Testing the verification of firmware..."
 fwupdmgr verify $device
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Getting updates (should be one)..."
 fwupdmgr --no-unreported-check --no-metadata-check get-updates
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Installing test firmware..."
 fwupdmgr install ${dirname}/fakedevice124.cab
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Getting updates (should be none)..."
 fwupdmgr --no-unreported-check --no-metadata-check get-updates
-rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 2 ]]; then error $rc; fi
 
 # ---
 echo "Testing the verification of firmware (again)..."
 fwupdmgr verify $device
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Downgrading to older release (requires network access)"
 fwupdmgr downgrade $device
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Downgrading to older release (should be none)"
 fwupdmgr downgrade $device
-rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 2 ]]; then error $rc; fi
 
 # ---
 echo "Updating all devices to latest release (requires network access)"
 fwupdmgr --no-unreported-check --no-metadata-check --no-reboot-check update
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Getting updates (should be none)..."
 fwupdmgr --no-unreported-check --no-metadata-check get-updates
-rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 2 ]]; then error $rc; fi
 
 # ---
 echo "Refreshing from the LVFS (requires network access)..."
 fwupdmgr refresh
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # ---
 echo "Flashing actual devices (requires specific hardware)"
 ${dirname}/hardware.py
-rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
 # success!
 exit 0


### PR DESCRIPTION
There have been a few transient failures on autopkgtest that are currently very difficult to debug.  Try to improve the installed-tests to work better on autopkgtest and to show verbose daemon logs when failures have happened.
 
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
