### PR TITLE
fu-util/fu-tool: Hide output for update commands when nothing to be done (Fixes: #1618)

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -340,7 +340,10 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 					       fwupd_device_get_id (dev),
 					       &error_local);
 		if (rels == NULL) {
-			g_printerr ("%s\n", error_local->message);
+			if (g_error_matches (error_local, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
+				g_debug ("%s\n", error_local->message);
+			else
+				g_printerr ("%s\n", error_local->message);
 			continue;
 		}
 		child = g_node_append_data (root, dev);
@@ -971,7 +974,10 @@ fu_util_update_all (FuUtilPrivate *priv, GError **error)
 		device_id = fu_device_get_id (dev);
 		rels = fu_engine_get_upgrades (priv->engine, device_id, &error_local);
 		if (rels == NULL) {
-			g_printerr ("%s\n", error_local->message);
+			if (g_error_matches (error_local, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
+				g_debug ("%s\n", error_local->message);
+			else
+				g_printerr ("%s\n", error_local->message);
 			continue;
 		}
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1628,16 +1628,19 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		if (!fu_util_filter_device (priv, dev))
 			continue;
-		supported = TRUE;
 
 		/* get the releases for this device and filter for validity */
 		rels = fwupd_client_get_upgrades (priv->client,
 						  fwupd_device_get_id (dev),
 						  NULL, &error_local);
 		if (rels == NULL) {
-			g_printerr ("%s\n", error_local->message);
+			if (g_error_matches (error_local, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
+				g_debug ("%s\n", error_local->message);
+			else
+				g_printerr ("%s\n", error_local->message);
 			continue;
 		}
+		supported = TRUE;
 		child = g_node_append_data (root, dev);
 
 		/* add all releases */
@@ -1822,16 +1825,19 @@ fu_util_update_all (FuUtilPrivate *priv, GError **error)
 			continue;
 		if (!fu_util_filter_device (priv, dev))
 			continue;
-		supported = TRUE;
 
 		/* get the releases for this device and filter for validity */
 		rels = fwupd_client_get_upgrades (priv->client,
 						  fwupd_device_get_id (dev),
 						  NULL, &error_local);
 		if (rels == NULL) {
-			g_printerr ("%s\n", error_local->message);
+			if (g_error_matches (error_local, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
+				g_debug ("%s\n", error_local->message);
+			else
+				g_printerr ("%s\n", error_local->message);
 			continue;
 		}
+		supported = TRUE;
 		rel = g_ptr_array_index (rels, 0);
 		/* TRANSLATORS: message letting the user know an upgrade is available
 		 * %1 is the device name and %2 and %3 are version strings */


### PR DESCRIPTION

Avoid confusing messages like:
```
No releases found for device: no HWIDs matched 90706264-e399-575b-a9fb-077ead03b9b4
```

Which aren't actually useful to the user.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
