### PR TITLE
fu-engine: clarify which device doesn't have matching FW (Fixes: #1618)

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3537,13 +3537,15 @@ fu_engine_get_releases_for_device (FuEngine *self, FuDevice *device, GError **er
 	if (releases->len == 0) {
 		if (error_all != NULL) {
 			g_propagate_prefixed_error (error, g_steal_pointer (&error_all),
-						    "No releases found for device: ");
+						    "No releases found for %s: ",
+						    fu_device_get_name (device));
 			return NULL;
 		}
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOTHING_TO_DO,
-			     "No releases found for device");
+			     "No releases found for %s",
+			     fu_device_get_name (device));
 		return NULL;
 	}
 	return releases;


### PR DESCRIPTION
Alternative approach to #1622 
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
