### PR TITLE
trivial: wacom-raw: mark all Moffett SKUs as self recovery

### DIFF
--- a/plugins/wacom-raw/wacom-raw.quirk
+++ b/plugins/wacom-raw/wacom-raw.quirk
@@ -11,16 +11,19 @@ Guid = WacomAES
 [DeviceInstanceId=HIDRAW\VEN_2D1F&DEV_4970]
 Plugin = wacom_raw
 Guid = WacomAES
+Flags = self-recovery
 
 # Moffet 14-Sharp-HH
 [DeviceInstanceId=HIDRAW\VEN_2D1F&DEV_4971]
 Plugin = wacom_raw
 Guid = WacomAES
+Flags = self-recovery
 
 # Moffet 14-Sharp-VIA
 [DeviceInstanceId=HIDRAW\VEN_2D1F&DEV_4972]
 Plugin = wacom_raw
 Guid = WacomAES
+Flags = self-recovery
 
 # Dell Latitude 5175
 [DeviceInstanceId=HIDRAW\VEN_056A&DEV_4807]


### PR DESCRIPTION
These will all support the recovery feature added by 59970600adc171a183dddb90908e88b73727b832

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
