### PR TITLE
Wip/hughsie/vendor

### DIFF
--- a/plugins/altos/README.md
+++ b/plugins/altos/README.md
@@ -34,6 +34,11 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_1D50&PID_60C6`
  * `USB\VID_1D50`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x1D50`
+
 ### List Information
 
 Command:    `l\n`

--- a/plugins/amt/README.md
+++ b/plugins/amt/README.md
@@ -20,3 +20,8 @@ GUID Generation
 ---------------
 
 These devices use the existing GUID provided by the AMT host interface.
+
+Vendor ID Security
+------------------
+
+The device is not upgradable and thus requires no vendor ID set.

--- a/plugins/ata/README.md
+++ b/plugins/ata/README.md
@@ -34,6 +34,11 @@ These device use the Microsoft DeviceInstanceId values, e.g.
 See https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-ide-devices
 for more details.
 
+Vendor ID Security
+------------------
+
+No vendor ID is set as there is no vendor field in the IDENTIFY response.
+
 Quirk use
 ---------
 This plugin uses the following plugin-specific quirks:

--- a/plugins/colorhug/README.md
+++ b/plugins/colorhug/README.md
@@ -29,3 +29,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_273F&PID_1001&REV_0001`
  * `USB\VID_273F&PID_1001`
  * `USB\VID_273F`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x273F`

--- a/plugins/coreboot/README.md
+++ b/plugins/coreboot/README.md
@@ -52,3 +52,8 @@ The following HWIDs are added on coreboot enabled platforms:
 
 They do match the values provided by `fwupdtool hwids` or
 the `ComputerHardwareIds.exe` Windows utility.
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the BIOS vendor, in this instance `DMI:coreboot`

--- a/plugins/coreboot/fu-plugin-coreboot.c
+++ b/plugins/coreboot/fu-plugin-coreboot.c
@@ -91,6 +91,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	}
 	fu_device_set_vendor (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER));
 	fu_device_add_instance_id (dev, "main-system-firmware");
+	fu_device_set_vendor_id (dev, "DMI:coreboot");
 
 	for (guint i = 0; i < G_N_ELEMENTS (hwids); i++) {
 		char *str;

--- a/plugins/csr/README.md
+++ b/plugins/csr/README.md
@@ -34,3 +34,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_0A12&PID_1337&REV_2520`
  * `USB\VID_0A12&PID_1337`
  * `USB\VID_0A12`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0A12`

--- a/plugins/dell-dock/README.md
+++ b/plugins/dell-dock/README.md
@@ -48,6 +48,11 @@ These devices use several different generation schemes, e.g.
  * MST Hub: `MST-panamera-vmm5331-259`
  * Thunderbolt Controller: `TBT-00d4b070`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x413C`
+
 Custom flag use:
 ----------------
 This plugin uses the following plugin-specific custom flags:

--- a/plugins/dell-esrt/README.md
+++ b/plugins/dell-esrt/README.md
@@ -12,6 +12,11 @@ GUID Generation
 
 These device uses a hardcoded GUID of `2d47f29b-83a2-4f31-a2e8-63474f4d4c2e`.
 
+Vendor ID Security
+------------------
+
+The vendor ID is hardcoded to `PCI:0x1028`.
+
 Build Requirements
 ------------------
 

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -163,6 +163,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_set_id (dev, "UEFI-dummy");
 	fu_device_set_name (dev, "Dell UEFI updates");
 	fu_device_set_summary (dev, "Enable UEFI Update Functionality");
+	fu_device_set_vendor_id (dev, "PCI:0x1028");
 	fu_device_add_instance_id (dev, "main-system-firmware");
 	fu_device_add_guid (dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version (dev, "0", FWUPD_VERSION_FORMAT_NUMBER);

--- a/plugins/dell/README.md
+++ b/plugins/dell/README.md
@@ -33,6 +33,11 @@ Example resultant GUIDs from a real system containing a TPM from Nuvoton:
   Guid:                 fe462d4a-e48f-5069-9172-47330fc5e838 <- DELL-TPM-2.0-NTC-NPCT75xrls
 ```
 
+Vendor ID Security
+------------------
+
+The vendor ID is hardcoded to `TPM:DELL`.
+
 Build Requirements
 ------------------
 

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -286,6 +286,7 @@ fu_plugin_dock_node (FuPlugin *plugin, const gchar *platform,
 		dock_name = g_strdup_printf ("Dell %s", dock_type);
 	}
 	fu_device_set_vendor (dev, "Dell Inc.");
+	fu_device_set_vendor_id (dev, "PCI:0x1028");
 	fu_device_set_name (dev, dock_name);
 	fu_device_set_metadata (dev, FU_DEVICE_METADATA_UEFI_DEVICE_KIND, "device-firmware");
 	if (type == DOCK_TYPE_TB16) {
@@ -734,6 +735,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	fu_device_add_instance_id (dev, tpm_guid_raw);
 	fu_device_add_instance_id (dev, "system-tpm");
 	fu_device_set_vendor (dev, "Dell Inc.");
+	fu_device_set_vendor_id (dev, "PCI:0x1028");
 	fu_device_set_name (dev, pretty_tpm_name);
 	fu_device_set_summary (dev, "Platform TPM device");
 	fu_device_set_version (dev, version_str, FWUPD_VERSION_FORMAT_QUAD);
@@ -768,6 +770,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		fu_device_set_id (dev_alt, tpm_id_alt);
 		fu_device_add_instance_id (dev_alt, tpm_guid_raw_alt);
 		fu_device_set_vendor (dev, "Dell Inc.");
+		fu_device_set_vendor_id (dev, "PCI:0x1028");
 		fu_device_set_name (dev_alt, pretty_tpm_name_alt);
 		fu_device_set_summary (dev_alt, "Alternate mode for platform TPM device");
 		fu_device_add_flag (dev_alt, FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/dfu/README.md
+++ b/plugins/dfu/README.md
@@ -27,6 +27,11 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_273F&PID_1003`
  * `USB\VID_273F`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, for example `USB:0x0A12`
+
 Quirk use
 ---------
 This plugin uses the following plugin-specific quirks:

--- a/plugins/ebitdo/README.md
+++ b/plugins/ebitdo/README.md
@@ -31,3 +31,16 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_2DC8&PID_AB11&REV_0001`
  * `USB\VID_2DC8&PID_AB11`
  * `USB\VID_2DC8`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, which is set to various different
+values depending on the model and device mode. The list of USB VIDs used is:
+
+ * `USB:0x2DC8`
+ * `USB:0x0483`
+ * `USB:0x1002`
+ * `USB:0x1235`
+ * `USB:0x2002`
+ * `USB:0x8000`

--- a/plugins/emmc/README.md
+++ b/plugins/emmc/README.md
@@ -19,3 +19,8 @@ These devices use the following instance values:
  * `EMMC\%NAME%`
  * `EMMC\%MANFID%&%OEMID%`
  * `EMMC\%MANFID%&%OEMID%&%NAME%`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the EMMC vendor, for example set to `EMMC:{$manfid}`

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -138,6 +138,7 @@ fu_emmc_device_probe (FuUdevDevice *device, GError **error)
 	g_autofree gchar *name_only = NULL;
 	g_autofree gchar *man_oem = NULL;
 	g_autofree gchar *man_oem_name = NULL;
+	g_autofree gchar *vendor_id = NULL;
 
 	udev_parent = g_udev_device_get_parent_with_subsystem (udev_device, "mmc", NULL);
 	if (udev_parent == NULL) {
@@ -199,7 +200,8 @@ fu_emmc_device_probe (FuUdevDevice *device, GError **error)
 
 	/* set the vendor */
 	tmp = g_udev_device_get_sysfs_attr (udev_parent, "manfid");
-	fu_device_set_vendor_id (FU_DEVICE (device), tmp);
+	vendor_id = g_strdup_printf ("EMMC:%s", tmp);
+	fu_device_set_vendor_id (FU_DEVICE (device), vendor_id);
 	fu_device_set_vendor (FU_DEVICE (device), fu_emmc_device_get_manufacturer (manfid));
 
 	/* set the physical ID */

--- a/plugins/fastboot/README.md
+++ b/plugins/fastboot/README.md
@@ -38,3 +38,8 @@ This plugin uses the following plugin-specific quirk:
 | Quirk                  | Description                      | Minimum fwupd version |
 |------------------------|----------------------------------|-----------------------|
 | `FastbootBlockSize`    | Block size to use for transfers  | 1.2.2                 |
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, for example `USB:0x18D1`

--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -23,3 +23,8 @@ GUID Generation
 These device uses hardware ID values which are derived from SMBIOS. They should
 match the values provided by `fwupdtool hwids` or the `ComputerHardwareIds.exe`
 Windows utility.
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the BIOS vendor, for example `DMI:Google`

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -85,8 +85,10 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	GPtrArray *hwids = fu_plugin_get_hwids (plugin);
+	const gchar *dmi_vendor;
 	g_autoptr(GPtrArray) devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 
+	dmi_vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
 	for (guint i = 0; i < hwids->len; i++) {
 		const gchar *guid = g_ptr_array_index (hwids, i);
 		const gchar *quirk_str;
@@ -110,6 +112,10 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 					       fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION),
 					       FWUPD_VERSION_FORMAT_UNKNOWN);
 			fu_device_add_guid (dev, guid);
+			if (dmi_vendor != NULL) {
+				g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);
+				fu_device_set_vendor_id (FU_DEVICE (dev), vendor_id);
+			}
 			g_ptr_array_add (devices, g_steal_pointer (&dev));
 			break;
 		}

--- a/plugins/jabra/README.md
+++ b/plugins/jabra/README.md
@@ -21,3 +21,8 @@ This plugin uses the following plugin-specific quirks:
 | Quirk         | Description                                  | fwupd version |
 |---------------|----------------------------------------------|---------------|
 |`JabraMagic`   | Two magic bytes sent to detach into DFU mode.|1.3.3          |
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0A12`

--- a/plugins/logitech-hidpp/README.md
+++ b/plugins/logitech-hidpp/README.md
@@ -41,6 +41,12 @@ When in runtime mode, the HID raw DeviceInstanceId values are used:
  * `HIDRAW\VEN_046D&DEV_C52B`
  * `HIDRAW\VEN_046D`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the vendor ID, in this instance set to `USB:0x046D`
+in bootloader and `HIDRAW:0x046D` in runtime mode.
+
 Design Notes
 ------------
 

--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -16,6 +16,11 @@ These device use the ModemManager "Firmware Device IDs" as the GUID, e.g.
  * `USB\VID_413C&PID_81D7`
  * `USB\VID_413C`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, for example `USB:0x413C`
+
 Update method: fastboot
 -----------------------
 

--- a/plugins/nitrokey/README.md
+++ b/plugins/nitrokey/README.md
@@ -19,3 +19,9 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_20A0&PID_4109&REV_0001`
  * `USB\VID_20A0&PID_4109`
  * `USB\VID_20A0`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x20A0`
+in runtime mode and `USB:0x03EB` in bootloader mode.

--- a/plugins/nvme/README.md
+++ b/plugins/nvme/README.md
@@ -49,3 +49,8 @@ This plugin uses the following plugin-specific quirks:
 |------------------------|---------------------------------------------|-----------------------|
 | `NvmeBlockSize`        | The block size used for NVMe writes         | 1.1.3                 |
 | `Flags`                | `force-align` if image should be padded     | 1.2.4                 |
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the udev vendor, for example set to `NVME:0x1179`

--- a/plugins/optionrom/README.md
+++ b/plugins/optionrom/README.md
@@ -19,3 +19,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `PCI\VEN_%04X&DEV_%04X`
 
 Additionally, GUIDs found in OptionROMs may also be added.
+
+Vendor ID Security
+------------------
+
+The device is not upgradable and thus requires no vendor ID set.

--- a/plugins/redfish/README.md
+++ b/plugins/redfish/README.md
@@ -26,6 +26,11 @@ GUID Generation
 These devices use the provided GUID provided in the `SoftwareId` parameter
 without modification. Devices without GUIDs are not supported.
 
+Vendor ID Security
+------------------
+
+No vendor ID is set as there is no vendor field in the schema.
+
 Setting Service IP Manually
 ---------------------------
 

--- a/plugins/rts54hid/README.md
+++ b/plugins/rts54hid/README.md
@@ -33,6 +33,11 @@ Child I²C devices are created using the device number as a suffix, for instance
 
  * `USB\VID_0BDA&PID_1100&I2C_01`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0BDA`
+
 Quirk use
 ---------
 This plugin uses the following plugin-specific quirks:

--- a/plugins/rts54hub/README.md
+++ b/plugins/rts54hub/README.md
@@ -28,3 +28,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_0BDA&PID_5423&REV_0001`
  * `USB\VID_0BDA&PID_5423`
  * `USB\VID_0BDA`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0BDA`

--- a/plugins/solokey/README.md
+++ b/plugins/solokey/README.md
@@ -26,3 +26,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
 
  * `USB\VID_0483&PID_A2CA&REV_0001`
  * `USB\VID_0483&PID_A2CA`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0483`

--- a/plugins/steelseries/README.md
+++ b/plugins/steelseries/README.md
@@ -16,3 +16,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_1038&PID_1702&REV_0001`
  * `USB\VID_1038&PID_1702`
  * `USB\VID_1038`
+
+Vendor ID Security
+------------------
+
+The device is not upgradable and thus requires no vendor ID set.

--- a/plugins/superio/README.md
+++ b/plugins/superio/README.md
@@ -22,3 +22,8 @@ GUID Generation
 These devices use a custom GUID generated using the SuperIO chipset name:
 
  * `SuperIO-$(chipset)`, for example `SuperIO-IT8512`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the baseboard vendor, for example `DMI:Star Labs`

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -17,6 +17,7 @@
 static gboolean
 fu_plugin_superio_coldplug_chipset (FuPlugin *plugin, const gchar *chipset, GError **error)
 {
+	const gchar *dmi_vendor;
 	g_autoptr(FuSuperioDevice) dev = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autofree gchar *key = g_strdup_printf ("SuperIO=%s", chipset);
@@ -64,6 +65,13 @@ fu_plugin_superio_coldplug_chipset (FuPlugin *plugin, const gchar *chipset, GErr
 			     G_IO_ERROR_NOT_SUPPORTED,
 			     "SuperIO chip %s has unsupported Id", chipset);
 		return FALSE;
+	}
+
+	/* set vendor ID as the motherboard vendor */
+	dmi_vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BASEBOARD_MANUFACTURER);
+	if (dmi_vendor != NULL) {
+		g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);
+		fu_device_set_vendor_id (FU_DEVICE (dev), vendor_id);
 	}
 
 	/* unlock */

--- a/plugins/synaptics-cxaudio/README.md
+++ b/plugins/synaptics-cxaudio/README.md
@@ -31,6 +31,11 @@ These devices also use custom GUID values, e.g.
  * `SYNAPTICS_CXAUDIO\CX2198X`
  * `SYNAPTICS_CXAUDIO\CX21985`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x17EF`
+
 Quirk Use
 ---------
 

--- a/plugins/synaptics-prometheus/README.md
+++ b/plugins/synaptics-prometheus/README.md
@@ -24,3 +24,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
 
  * `USB\VID_06CB&PID_00A9&REV_0001`
  * `USB\VID_06CB&PID_00A9`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x06CB`

--- a/plugins/synaptics-rmi/README.md
+++ b/plugins/synaptics-rmi/README.md
@@ -16,6 +16,12 @@ These devices also use custom GUID values constructed using the board ID, e.g.
  * `SYNAPTICS_RMI\TM3038-002`
  * `SYNAPTICS_RMI\TM3038`
 
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the udev vendor, in this instance set to `HIDRAW:0x06CB`
+
 Firmware Format
 ---------------
 

--- a/plugins/synapticsmst/README.md
+++ b/plugins/synapticsmst/README.md
@@ -25,6 +25,11 @@ These devices use custom GUID values, e.g.
 Please refer to the plugin source for more details about how the GUID is
 constructed for specific hardware.
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the PCI vendor, for example set to `DRM_DP_AUX_DEV:0x$(vid)`
+
 ## Requirements
 ### (Kernel) DP Aux Interface
 Kernel 4.6 introduced an DRM DP Aux interface for manipulation of the registers

--- a/plugins/test/README.md
+++ b/plugins/test/README.md
@@ -11,3 +11,8 @@ GUID Generation
 
 The devices created by this plugin use hardcoded GUIDs that do not correspond
 to any kind of DeviceInstanceId values.
+
+Vendor ID Security
+------------------
+
+The fake device is only for local testing and thus requires no vendor ID set.

--- a/plugins/thelio-io/README.md
+++ b/plugins/thelio-io/README.md
@@ -15,3 +15,8 @@ GUID Generation
 These devices use the standard USB DeviceInstanceId values, e.g.
 
  * `USB\VID_1209&PID_1776&REV_0001`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x1209`

--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -37,6 +37,11 @@ used for systems with multiple host controllers to disambiguiate between control
 
 * `TBT-$(vid)$(pid)-native-$(slot)`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the udev vendor, for example set to `TBT:0x$(vid)`
+
 Runtime Power Management
 ------------------------
 

--- a/plugins/tpm-eventlog/README.md
+++ b/plugins/tpm-eventlog/README.md
@@ -10,3 +10,8 @@ may help in explaining why PCR0 values are differing for some firmware.
 The device exposed is not upgradable in any way and is just for debugging.
 The created device will be a child device of the system TPM device, which may
 or may not be upgradable.
+
+Vendor ID Security
+------------------
+
+The device is not upgradable and thus requires no vendor ID set.

--- a/plugins/tpm/README.md
+++ b/plugins/tpm/README.md
@@ -25,3 +25,8 @@ Example GUIDs from a real system containing a TPM from Intel:
   Guid:                 34801700-3a50-5b05-820c-fe14580e4c2d <- TPM\VEN_INTC&DEV_0000
   Guid:                 03f304f4-223e-54f4-b2c1-c3cf3b5817c6 <- TPM\VEN_INTC&DEV_0000&VER_2.0
 ```
+
+Vendor ID Security
+------------------
+
+The device is not upgradable and thus requires no vendor ID set.

--- a/plugins/uefi-recovery/README.md
+++ b/plugins/uefi-recovery/README.md
@@ -15,3 +15,8 @@ GUID Generation
 
 All the HwId GUIDs are used for the fake UEFI device, and so should be used in
 the firmware metadata for releases that should recover the system.
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the BIOS vendor, for example `DMI:LENOVO`

--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -35,6 +35,7 @@ gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
 	GPtrArray *hwids = fu_plugin_get_hwids (plugin);
+	const gchar *dmi_vendor;
 	g_autoptr(FuDevice) device = fu_device_new ();
 	fu_device_set_id (device, "uefi-recovery");
 	fu_device_set_name (device, "System Firmware ESRT Recovery");
@@ -49,6 +50,14 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		const gchar *hwid = g_ptr_array_index (hwids, i);
 		fu_device_add_guid (device, hwid);
 	}
+
+	/* set vendor ID as the BIOS vendor */
+	dmi_vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+	if (dmi_vendor != NULL) {
+		g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);
+		fu_device_set_vendor_id (device, vendor_id);
+	}
+
 	fu_plugin_device_register (plugin, device);
 	return TRUE;
 }

--- a/plugins/uefi/README.md
+++ b/plugins/uefi/README.md
@@ -33,6 +33,13 @@ system device the `main-system-firmware` GUID is also added.
 For compatibility with Windows 10, the plugin also adds GUIDs of the form
 `UEFI\RES_{$(esrt)}`.
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the BIOS vendor, for example `DMI:LENOVO` for all
+devices that are not marked as supporting Firmware Management Protocol. For FMP
+device no vendor ID is set.
+
 UEFI Unlock Support
 -------------------
 

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -557,6 +557,16 @@ fu_plugin_uefi_coldplug_device (FuPlugin *plugin, FuUefiDevice *dev, GError **er
 			fu_device_set_vendor (FU_DEVICE (dev), vendor);
 	}
 
+	/* set vendor ID as the BIOS vendor */
+	if (fu_uefi_device_get_kind (dev) != FU_UEFI_DEVICE_KIND_FMP) {
+		const gchar *dmi_vendor;
+		dmi_vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+		if (dmi_vendor != NULL) {
+			g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);
+			fu_device_set_vendor_id (FU_DEVICE (dev), vendor_id);
+		}
+	}
+
 	/* success */
 	return TRUE;
 }

--- a/plugins/upower/README.md
+++ b/plugins/upower/README.md
@@ -5,3 +5,8 @@ Introduction
 ------------
 
 This plugin is used to ensure that some updates are not done on battery power.
+
+Vendor ID Security
+------------------
+
+This protocol does not create a device and thus requires no vendor ID set.

--- a/plugins/vli-usbhub/README.md
+++ b/plugins/vli-usbhub/README.md
@@ -39,6 +39,11 @@ Optional I²C child devices use just one extra GUID, e.g.
 
  * `VLI_USBHUB_I2C\MSP430`
 
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, for example set to `USB:0x2109`
+
 Quirk Use
 ---------
 

--- a/plugins/wacom-raw/README.md
+++ b/plugins/wacom-raw/README.md
@@ -31,3 +31,8 @@ This plugin uses the following plugin-specific quirks:
 | `WacomI2cFlashBlockSize`| Block size to transfer firmware     | 1.2.4                 |
 | `WacomI2cFlashBaseAddr` | Base address for firmware           | 1.2.4                 |
 | `WacomI2cFlashSize`     | Maximum size of the firmware zone   | 1.2.4                 |
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the udev vendor, in this instance set to `HIDRAW:0x056A`

--- a/plugins/wacom-usb/README.md
+++ b/plugins/wacom-usb/README.md
@@ -39,3 +39,8 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_056A&PID_0378&REV_0001`
  * `USB\VID_056A&PID_0378`
  * `USB\VID_056A`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, for example set to `USB:0x056A`


### PR DESCRIPTION
We probably ought to get a lot more serious about setting the vendor ID on LVFS vendor accounts. Notable omissions are ATA and Redfish, both of which not supplying anything like a vendor ID. Ideas welcome for those two.