### PR TITLE
trivial: synaptics-rmi: hardcode Vendor string

### DIFF
--- a/plugins/synaptics-rmi/synaptics-rmi.quirk
+++ b/plugins/synaptics-rmi/synaptics-rmi.quirk
@@ -1,2 +1,3 @@
 [DeviceInstanceId=HIDRAW\VEN_06CB]
 Plugin = synaptics_rmi
+Vendor = Synaptics


### PR DESCRIPTION
Right now vendor string is detected by walking up the udev chain
until a vendor is found.  On some systems this is finding incorrect
data such as `Intel Corporation` for the vendor on the touchpad.

As the plugin only supports Synaptics devices, Correct it by hardcoding
vendor to `Synaptics`.

Sample output:
```
└─Touchpad:
      Device ID:           b26933c085b020ecf84c490812458523aee710ac
      Current version:     1.5.2767034
      Bootloader Version:  54.0
      Vendor:              Synaptics (HIDRAW:0x06CB)
      GUIDs:               f4384034-9243-5334-8075-a534be913e46 ← HIDRAW\VEN_06CB&DEV_76AF&REV_00
                           424bd00e-9789-5cdf-a12a-3c81bc4676d6 ← HIDRAW\VEN_06CB&DEV_76AF
                           140f4458-951b-5bb9-85e2-879bd5b02615 ← SYNAPTICS_RMI\TM3038-003
                           b29d3c85-cd0e-503e-9c7e-f6731c1eaf2d ← SYNAPTICS_RMI\TM3038
      Device Flags:        • Internal device
                           • Updatable
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
