### PR TITLE
plugins/coreboot: Add missing fu_hash dependency

### DIFF
--- a/plugins/coreboot/meson.build
+++ b/plugins/coreboot/meson.build
@@ -5,6 +5,7 @@ install_data(['coreboot.quirk'],
 )
 
 shared_module('fu_plugin_coreboot',
+  fu_hash,
   sources : [
     'fu-plugin-coreboot.c',
     'fu-coreboot-common.c',


### PR DESCRIPTION
This fixes the build when using samurai in place of ninja.