### PR TITLE
Don't always get the vendor ID for udev devices using the parent

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -182,6 +182,7 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	/* fallback to the parent */
 	udev_parent = g_udev_device_get_parent (priv->udev_device);
 	if (udev_parent != NULL &&
+	    priv->flags & FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT &&
 	    priv->vendor == 0x0 && priv->model == 0x0 && priv->revision == 0x0) {
 		priv->vendor = fu_udev_device_get_sysfs_attr_as_uint32 (udev_parent, "vendor");
 		priv->model = fu_udev_device_get_sysfs_attr_as_uint32 (udev_parent, "device");
@@ -222,7 +223,8 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	}
 
 	/* try harder to find a vendor name the user will recognise */
-	if (udev_parent != NULL && fu_device_get_vendor (device) == NULL) {
+	if (priv->flags & FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT &&
+	    udev_parent != NULL && fu_device_get_vendor (device) == NULL) {
 		g_autoptr(GUdevDevice) device_tmp = g_object_ref (udev_parent);
 		for (guint i = 0; i < 0xff; i++) {
 			g_autoptr(GUdevDevice) parent = NULL;

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -37,6 +37,7 @@ struct _FuUdevDeviceClass
  * @FU_UDEV_DEVICE_FLAG_NONE:			No flags set
  * @FU_UDEV_DEVICE_FLAG_OPEN_READ:		Open the device read-only
  * @FU_UDEV_DEVICE_FLAG_OPEN_WRITE:		Open the device write-only
+ * @FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT:	Get the vendor ID fallback from the parent
  *
  * Flags used when opening the device using fu_device_open().
  **/
@@ -44,6 +45,7 @@ typedef enum {
 	FU_UDEV_DEVICE_FLAG_NONE		= 0,
 	FU_UDEV_DEVICE_FLAG_OPEN_READ		= 1 << 0,
 	FU_UDEV_DEVICE_FLAG_OPEN_WRITE		= 1 << 1,
+	FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT	= 1 << 2,
 	/*< private >*/
 	FU_UDEV_DEVICE_FLAG_LAST
 } FuUdevDeviceFlags;

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -432,7 +432,9 @@ fu_nvme_device_init (FuNvmeDevice *self)
 	fu_device_set_summary (FU_DEVICE (self), "NVM Express Solid State Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_set_protocol (FU_DEVICE (self), "org.nvmexpress");
-	fu_udev_device_set_flags (FU_UDEV_DEVICE (self), FU_UDEV_DEVICE_FLAG_OPEN_READ);
+	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
+				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
+				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
 }
 
 static void

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -92,6 +92,9 @@ fu_optionrom_device_init (FuOptionromDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
+				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
+				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -73,6 +73,10 @@ fu_synaptics_mst_device_init (FuSynapticsMstDevice *self)
 	fu_device_set_vendor_id (FU_DEVICE (self), "DRM_DP_AUX_DEV:0x06CB");
 	fu_device_set_summary (FU_DEVICE (self), "Multi-Stream Transport Device");
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
+	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
+				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
+				  FU_UDEV_DEVICE_FLAG_OPEN_WRITE |
+				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
 }
 
 static void


### PR DESCRIPTION
Fixes bugs like https://github.com/fwupd/fwupd/issues/1673
