### PR TITLE
Shut down automatically when there is system memory pressure

### DIFF
--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 %%%OS%%%
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -7,6 +7,7 @@ RUN echo fubar > /etc/machine-id
 RUN dnf -y update
 RUN echo fubar > /etc/machine-id
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
+RUN dnf -y update glib2 glib2-devel --releasever=32
 RUN mkdir /build
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
We can just rescan hardware if required; near OOM it's just more important to
free what we can and get out of the way.
