### PR TITLE
Allow quirking devices that always require a version check

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -179,6 +179,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "self-recovery";
 	if (device_flag == FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)
 		return "usable-during-update";
+	if (device_flag == FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED)
+		return "version-check-required";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -259,6 +261,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_SELF_RECOVERY;
 	if (g_strcmp0 (device_flag, "usable-during-update") == 0)
 		return FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE;
+	if (g_strcmp0 (device_flag, "version-check-required") == 0)
+		return FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -97,6 +97,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_DUAL_IMAGE:		Device update architecture uses A/B partitions for updates
  * @FWUPD_DEVICE_FLAG_SELF_RECOVERY:		In flashing mode device will only accept intended payloads
  * @FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE:	Device remains usable while fwupd flashes or schedules the update
+ * @FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED:	All firmware updates for this device require a firmware version check
  *
  * The device flags.
  **/
@@ -131,6 +132,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_DUAL_IMAGE		(1u << 27)	/* Since: 1.3.3 */
 #define FWUPD_DEVICE_FLAG_SELF_RECOVERY		(1u << 28)	/* Since: 1.3.3 */
 #define FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE	(1u << 29)	/* Since: 1.3.3 */
+#define FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED (1u << 30)	/* Since: 1.3.7 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1066,6 +1066,10 @@ fu_util_device_flag_to_string (guint64 device_flag)
 		/* TRANSLATORS: Device remains usable during update */
 		return _("Device is usable for the duration of the update");
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED) {
+		/* TRANSLATORS: a version check is required for all firmware */
+		return _("Device firmware is required to have a version check");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN) {
 		return NULL;
 	}


### PR DESCRIPTION
These are devices that we have to be careful with the version numbers, for
instance only updating from versions that have already had data migration
completed.

The new flag can be set in quirk files or on the objects directly.
