### PR TITLE
1_2_x: Fix always being able to reinstall same firmware on dell system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - OS=debian-x86_64
   - OS=arch
   - OS=debian-i386
-  - OS=ubuntu-x86_64
 
 install:
   - ./contrib/ci/generate_docker.py

--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -31,20 +31,6 @@ fi
 EDITOR=/bin/true dch --create --package fwupd -v $VERSION "CI Build"
 debuild --no-lintian --preserve-envvar CI --preserve-envvar CC
 
-#check lintian output
-#suppress tags that are side effects of building in docker this way
-lintian ../*changes \
-	-IE \
-	--pedantic \
-	--no-tag-display-limit \
-	--suppress-tags bad-distribution-in-changes-file \
-	--suppress-tags source-contains-unsafe-symlink \
-	--suppress-tags changelog-should-mention-nmu \
-	--suppress-tags debian-watch-file-in-native-package \
-	--suppress-tags source-nmu-has-incorrect-version-number \
-	--suppress-tags no-symbols-control-file \
-	--allow-root
-
 #if invoked outside of CI
 if [ ! -f /.dockerenv ]; then
 	echo "Not running in a container, please manually install packages"

--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -215,6 +215,31 @@ fu_common_version_ensure_semver (const gchar *version)
 gchar *
 fu_common_version_parse (const gchar *version)
 {
+	return fu_common_version_parse_from_format (version, FWUPD_VERSION_FORMAT_TRIPLET);
+}
+
+/**
+ * fu_common_version_parse_from_format
+ * @version: A version number
+ * @fmt: A FwupdVersionFormat
+ *
+ * Returns a dotted decimal version string from a version string using fmt.
+ * The supported formats are:
+ *
+ * - Dotted decimal, e.g. "1.2.3"
+ * - Base 16, a hex number *with* a 0x prefix, e.g. "0x10203"
+ * - Base 10, a string containing just [0-9], e.g. "66051"
+ * - Date in YYYYMMDD format, e.g. 20150915
+ *
+ * Anything with a '.' or that doesn't match [0-9] or 0x[a-f,0-9] is considered
+ * a string and returned without modification.
+ *
+ * Returns: A version number, e.g. "1.0.3"
+ *
+ */
+gchar *
+fu_common_version_parse_from_format (const gchar *version, FwupdVersionFormat fmt)
+{
 	const gchar *version_noprefix = version;
 	gchar *endptr = NULL;
 	guint64 tmp;
@@ -246,7 +271,7 @@ fu_common_version_parse (const gchar *version)
 		return g_strdup (version);
 	if (tmp == 0)
 		return g_strdup (version);
-	return fu_common_version_from_uint32 ((guint32) tmp, FWUPD_VERSION_FORMAT_TRIPLET);
+	return fu_common_version_from_uint32 ((guint32) tmp, fmt);
 }
 
 /**

--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -52,7 +52,8 @@ fu_common_version_from_uint32 (guint32 val, FwupdVersionFormat kind)
 					(val >> 16) & 0xffff,
 					val & 0xffff);
 	}
-	if (kind == FWUPD_VERSION_FORMAT_NUMBER) {
+	if (kind == FWUPD_VERSION_FORMAT_NUMBER ||
+	    kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		/* AABBCCDD */
 		return g_strdup_printf ("%" G_GUINT32_FORMAT, val);
 	}
@@ -109,7 +110,8 @@ fu_common_version_from_uint16 (guint16 val, FwupdVersionFormat kind)
 					(guint) (val >> 8) & 0xff,
 					(guint) val & 0xff);
 	}
-	if (kind == FWUPD_VERSION_FORMAT_NUMBER) {
+	if (kind == FWUPD_VERSION_FORMAT_NUMBER ||
+	    kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		return g_strdup_printf ("%" G_GUINT16_FORMAT, val);
 	}
 	g_critical ("failed to convert version format %s: %u",

--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -347,8 +347,8 @@ fu_common_version_verify_format (const gchar *version,
 
 /**
  * fu_common_vercmp:
- * @version_a: the release version, e.g. 1.2.3
- * @version_b: the release version, e.g. 1.2.3.1
+ * @version_a: the semver release version, e.g. 1.2.3
+ * @version_b: the semver release version, e.g. 1.2.3.1
  *
  * Compares version numbers for sorting.
  *
@@ -360,8 +360,6 @@ gint
 fu_common_vercmp (const gchar *version_a, const gchar *version_b)
 {
 	guint longest_split;
-	g_autofree gchar *str_a = NULL;
-	g_autofree gchar *str_b = NULL;
 	g_auto(GStrv) split_a = NULL;
 	g_auto(GStrv) split_b = NULL;
 
@@ -374,10 +372,8 @@ fu_common_vercmp (const gchar *version_a, const gchar *version_b)
 		return 0;
 
 	/* split into sections, and try to parse */
-	str_a = fu_common_version_parse (version_a);
-	str_b = fu_common_version_parse (version_b);
-	split_a = g_strsplit (str_a, ".", -1);
-	split_b = g_strsplit (str_b, ".", -1);
+	split_a = g_strsplit (version_a, ".", -1);
+	split_b = g_strsplit (version_b, ".", -1);
 	longest_split = MAX (g_strv_length (split_a), g_strv_length (split_b));
 	for (guint i = 0; i < longest_split; i++) {
 		gchar *endptr_a = NULL;

--- a/src/fu-common-version.h
+++ b/src/fu-common-version.h
@@ -18,6 +18,8 @@ gchar		*fu_common_version_from_uint32	(guint32	 val,
 gchar		*fu_common_version_from_uint16	(guint16	 val,
 						 FwupdVersionFormat kind);
 gchar		*fu_common_version_parse	(const gchar	*version);
+gchar		*fu_common_version_parse_from_format	(const gchar	*version,
+							 FwupdVersionFormat	fmt);
 gchar		*fu_common_version_ensure_semver (const gchar	*version);
 FwupdVersionFormat	 fu_common_version_guess_format	(const gchar	*version);
 gboolean	 fu_common_version_verify_format	(const gchar	*version,

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -111,10 +111,11 @@ fu_install_task_check_requirements (FuInstallTask *self,
 {
 	const gchar *tmp;
 	const gchar *version;
-	const gchar *version_release;
+	const gchar *version_release_raw;
 	const gchar *version_lowest;
 	gboolean matches_guid = FALSE;
 	gint vercmp;
+	g_autofree gchar *version_release = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) provides = NULL;
 	g_autoptr(XbNode) release = NULL;
@@ -209,8 +210,8 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	}
 
 	/* is this a downgrade or re-install */
-	version_release = xb_node_get_attr (release, "version");
-	if (version_release == NULL) {
+	version_release_raw = xb_node_get_attr (release, "version");
+	if (version_release_raw == NULL) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_FILE,
@@ -273,6 +274,8 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	}
 
 	/* check semver */
+	version_release = fu_common_version_parse_from_format (version_release_raw,
+							       fu_device_get_version_format (self->device));
 	vercmp = fu_common_vercmp (version, version_release);
 	if (vercmp == 0 && (flags & FWUPD_INSTALL_FLAG_ALLOW_REINSTALL) == 0) {
 		g_set_error (error,

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -3623,10 +3623,6 @@ fu_common_vercmp_func (void)
 	g_assert_cmpint (fu_common_vercmp ("1.2.3", "1.2.3"), ==, 0);
 	g_assert_cmpint (fu_common_vercmp ("001.002.003", "001.002.003"), ==, 0);
 
-	/* same, not dotted decimal */
-	g_assert_cmpint (fu_common_vercmp ("1.2.3", "0x1020003"), ==, 0);
-	g_assert_cmpint (fu_common_vercmp ("0x10203", "0x10203"), ==, 0);
-
 	/* upgrade and downgrade */
 	g_assert_cmpint (fu_common_vercmp ("1.2.3", "1.2.4"), <, 0);
 	g_assert_cmpint (fu_common_vercmp ("001.002.000", "001.002.009"), <, 0);


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This is a backport from master (see commit messages for details on the commits that were backported).

From my tests with 1_2_X today:
```

# fwupdmgr get-devices
.
.
.
XPS 13 9380 System Firmware
  DeviceId:             6c24a747f97668873b761558e322398a91dbf394
  Guid:                 ce945437-7358-49f1-95d8-6b694a10a755
  Plugin:               uefi
  Flags:                internal|updatable|require-ac|supported|registered|needs-reboot
  Checksum:             SHA1(6ddd903e2a0e59dd22e626257b38ac0737e574ac)
  Checksum:             SHA256(4bdad6114fdbce849c3682ca72fa8a07f49cc61ed0a196cc02dc10a5df523383)
  Vendor:               Dell Inc.
  Version:              0.1.8.0
  VersionLowest:        0.1.8.0
  VersionFormat:        quad
  Icon:                 computer
  Created:              2020-01-07
.
.
.

# fwupdmgr get-details ~/Downloads/d4507ad4ff7af71f5a5fdd1c29bd8c76bd256c2e-XPS_9380_1.8.0.cab 
Decompressing…           [***************************************]
XPS 13 9380 System Firmware
  DeviceId:             16294dd046748031285c8b36bb7a2368199f2363
  Guid:                 ce945437-7358-49f1-95d8-6b694a10a755
  Description:          <p>Updating the system firmware improves performance.</p>
  Flags:                internal|updatable|require-ac|supported|registered|needs-reboot
  VersionFormat:        quad
  
  [Release]
  AppstreamId:          com.dell.uefice945437.firmware
  RemoteId:             lvfs
  Summary:              Firmware for the Dell XPS 13 9380
  Version:              0.1.8.0
  Checksum:             SHA1(c9c42149217d4cc11aba624c7723e3556d8fcb4b)
  License:              proprietary
  Size:                 22.4 MB
  Homepage:             http://support.dell.com/
  Vendor:               Dell Inc.
  Flags:                none

# fwupdmgr install ~/Downloads/d4507ad4ff7af71f5a5fdd1c29bd8c76bd256c2e-XPS_9380_1.8.0.cab 
Decompressing…           [***************************************]
Authenticating…          [***************************************]
Installing on XPS 13 9380 System Firmware…                  -    ]
Scheduling…              [***************************************]

An update requires a reboot to complete. Restart now? [Y|n]: n
```

After this set of changes:
```
# fwupdmgr get-devices
.
.
.
XPS 13 9380 System Firmware
  DeviceId:             6c24a747f97668873b761558e322398a91dbf394
  Guid:                 ce945437-7358-49f1-95d8-6b694a10a755
  Plugin:               uefi
  Flags:                internal|updatable|require-ac|supported|registered|needs-reboot
  Checksum:             SHA1(6ddd903e2a0e59dd22e626257b38ac0737e574ac)
  Checksum:             SHA256(4bdad6114fdbce849c3682ca72fa8a07f49cc61ed0a196cc02dc10a5df523383)
  Vendor:               Dell Inc.
  Version:              0.1.8.0
  VersionLowest:        0.1.8.0
  VersionFormat:        quad
  Icon:                 computer
  Created:              2020-01-07
.
.
.

# fwupdmgr get-details ~/Downloads/d4507ad4ff7af71f5a5fdd1c29bd8c76bd256c2e-XPS_9380_1.8.0.cab
Decompressing…           [***************************************]
XPS 13 9380 System Firmware
  DeviceId:             16294dd046748031285c8b36bb7a2368199f2363
  Guid:                 ce945437-7358-49f1-95d8-6b694a10a755
  Description:          <p>Updating the system firmware improves performance.</p>
  Flags:                internal|updatable|require-ac|supported|registered|needs-reboot
  VersionFormat:        quad
  
  [Release]
  AppstreamId:          com.dell.uefice945437.firmware
  RemoteId:             lvfs
  Summary:              Firmware for the Dell XPS 13 9380
  Version:              0.1.8.0
  Checksum:             SHA1(c9c42149217d4cc11aba624c7723e3556d8fcb4b)
  License:              proprietary
  Size:                 22.4 MB
  Homepage:             http://support.dell.com/
  Vendor:               Dell Inc.
  Flags:                none

# fwupdmgr install ~/Downloads/d4507ad4ff7af71f5a5fdd1c29bd8c76bd256c2e-XPS_9380_1.8.0.cab
Decompressing…           [***************************************]
Specified firmware is already installed '0.1.8.0'

# fwupdmgr install ~/Downloads/d4507ad4ff7af71f5a5fdd1c29bd8c76bd256c2e-XPS_9380_1.8.0.cab --allow-reinstall
Decompressing…           [***************************************]
Authenticating…          [***************************************]
Installing on XPS 13 9380 System Firmware…         |             ]
Scheduling…              [***************************************]

An update requires a reboot to complete. Restart now? [Y|n]:
```