### PR TITLE
fu-remote-list: emit a changed signal when modifying a remote

### DIFF
--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -271,6 +271,7 @@ fu_remote_list_set_key_value (FuRemoteList *self,
 		g_prefix_error (error, "failed to load %s: ", filename);
 		return FALSE;
 	}
+	fu_remote_list_emit_changed (self);
 	return TRUE;
 }
 


### PR DESCRIPTION
This should notify the daemon of changes before the inotify letting
the data store get reloaded and fix autopkgtest race conditions.
Fixes: #1648

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
