### PR TITLE
Revert "trivial: Attempt to fix Debian CI"

### DIFF
--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -32,17 +32,17 @@ debuild --no-lintian --preserve-envvar CI --preserve-envvar CC
 
 #check lintian output
 #suppress tags that are side effects of building in docker this way
-#lintian ../*changes \
-#	-IE \
-#	--pedantic \
-#	--no-tag-display-limit \
-#	--suppress-tags bad-distribution-in-changes-file \
-#	--suppress-tags source-contains-unsafe-symlink \
-#	--suppress-tags changelog-should-mention-nmu \
-#	--suppress-tags debian-watch-file-in-native-package \
-#	--suppress-tags source-nmu-has-incorrect-version-number \
-#	--suppress-tags no-symbols-control-file \
-#	--allow-root
+lintian ../*changes \
+	-IE \
+	--pedantic \
+	--no-tag-display-limit \
+	--suppress-tags bad-distribution-in-changes-file \
+	--suppress-tags source-contains-unsafe-symlink \
+	--suppress-tags changelog-should-mention-nmu \
+	--suppress-tags debian-watch-file-in-native-package \
+	--suppress-tags source-nmu-has-incorrect-version-number \
+	--suppress-tags no-symbols-control-file \
+	--allow-root
 
 #if invoked outside of CI
 if [ ! -f /.dockerenv ]; then


### PR DESCRIPTION
There appears to have been some transient failure over the holiday that pre-empted this commit getting added that I can tell.  I think it's since been fixed, confirming CI works now.

This reverts commit 9e8037483a8899608746554af58b0c675ddd9f66.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
