### PR TITLE
trivial: Allow setting an ID of NULL for the FuFirmwareImage

### DIFF
--- a/libfwupdplugin/fu-firmware-image.c
+++ b/libfwupdplugin/fu-firmware-image.c
@@ -50,7 +50,7 @@ fu_firmware_image_get_version (FuFirmwareImage *self)
 /**
  * fu_firmware_image_set_version:
  * @self: A #FuFirmwareImage
- * @version: A string version, or %NULL
+ * @version: (nullable): A string version, or %NULL
  *
  * Sets an optional version that represents the firmware image.
  *
@@ -68,7 +68,7 @@ fu_firmware_image_set_version (FuFirmwareImage *self, const gchar *version)
 /**
  * fu_firmware_image_set_id:
  * @self: a #FuPlugin
- * @id: image ID, e.g. "config"
+ * @id: (nullable): image ID, e.g. "config"
  *
  * Since: 1.3.1
  **/
@@ -77,7 +77,6 @@ fu_firmware_image_set_id (FuFirmwareImage *self, const gchar *id)
 {
 	FuFirmwareImagePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_FIRMWARE_IMAGE (self));
-	g_return_if_fail (id != NULL);
 	g_free (priv->id);
 	priv->id = g_strdup (id);
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -143,8 +143,7 @@ fu_synaptics_rmi_firmware_add_image (FuFirmware *firmware, const gchar *id,
 {
 	g_autoptr(GBytes) bytes = g_bytes_new (data, sz);
 	g_autoptr(FuFirmwareImage) img = fu_firmware_image_new (bytes);
-	if (id != NULL)
-		fu_firmware_image_set_id (img, id);
+	fu_firmware_image_set_id (img, id);
 	fu_firmware_add_image (firmware, img);
 }
 


### PR DESCRIPTION
There's no reason to prevent NULL, and doing so means the caller has to check
before setting the value. Only one subclassed type was actually doing this...
