### PR TITLE
Fixing the "Linux Firmware Updater" bootentry won't be deleted

### DIFF
--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -408,7 +408,7 @@ fwup_delete_boot_entry(VOID)
 		/* check if the variable name is Boot#### */
 		if (CompareGuid(&vendor_guid, &global_variable_guid) != 0)
 			continue;
-		if (StrCmp(variable_name, L"Boot") != 0)
+		if ((StrLen(variable_name) != 8) || (StrnCmp(variable_name, L"Boot", 4) != 0))
 			continue;
 
 		UINTN info_size = 0;
@@ -427,8 +427,9 @@ fwup_delete_boot_entry(VOID)
 		 * check with EFI_LOAD_OPTION description
 		 */
 		EFI_LOAD_OPTION *load_op = (EFI_LOAD_OPTION *) info_ptr;
-		if (_StrHasPrefix(load_op->description, L"Linux Firmware Updater") ||
-		    _StrHasPrefix(load_op->description, L"Linux-Firmware-Updater")) {
+
+		if (_StrHasPrefix(&load_op->description, L"Linux Firmware Updater") ||
+		    _StrHasPrefix(&load_op->description, L"Linux-Firmware-Updater")) {
 			/* delete the boot path from BootOrder list */
 			rc = fwup_delete_boot_order(variable_name, vendor_guid);
 			if (EFI_ERROR(rc)) {

--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -365,19 +365,6 @@ fwup_delete_boot_order(CHAR16 *name, EFI_GUID guid)
 	return rc;
 }
 
-/* TODO: move to gnu-efi: https://github.com/vathpela/gnu-efi/issues/7 */
-static BOOLEAN
-_StrHasPrefix(IN CONST CHAR16 *s1, IN CONST CHAR16 *s2)
-{
-	while (*s2) {
-		if (*s1 == L'\0' || *s1 != *s2)
-			return FALSE;
-		s1  += 1;
-		s2  += 1;
-	}
-	return TRUE;
-}
-
 static EFI_STATUS
 fwup_delete_boot_entry(VOID)
 {
@@ -428,8 +415,9 @@ fwup_delete_boot_entry(VOID)
 		 */
 		EFI_LOAD_OPTION *load_op = (EFI_LOAD_OPTION *) info_ptr;
 
-		if (_StrHasPrefix(&load_op->description, L"Linux Firmware Updater") ||
-		    _StrHasPrefix(&load_op->description, L"Linux-Firmware-Updater")) {
+		if (CompareMem(&load_op->description, L"Linux Firmware Updater", sizeof(L"Linux Firmware Updater")) == 0 ||
+		    CompareMem(&load_op->description, L"Linux Firmware Updater", sizeof(L"Linux-Firmware-Updater")) == 0) {
+
 			/* delete the boot path from BootOrder list */
 			rc = fwup_delete_boot_order(variable_name, vendor_guid);
 			if (EFI_ERROR(rc)) {


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation

1. Fixing the fwup_delete_variable will get EFI_INVALID_PARAMETER returned.
2. Fixing the bootentry boot#### never been found and hang when checking the bootentry created by fwupd.
3. Get rid of _StrHasPrefix by using CompareMem
https://github.com/vathpela/gnu-efi/issues/7