### PR TITLE
Correctly import PKCS-7 remote metadata

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3060,7 +3060,7 @@ fu_engine_update_metadata (FuEngine *self, const gchar *remote_id,
 		return FALSE;
 
 	/* read signature */
-	bytes_sig = g_input_stream_read_bytes (stream_sig, 0x800, NULL, error);
+	bytes_sig = g_input_stream_read_bytes (stream_sig, 0x100000, NULL, error);
 	if (bytes_sig == NULL)
 		return FALSE;
 


### PR DESCRIPTION
The PEM data is larger than 2kB, which was a crazy-small max size for a
signature. Make this a more respectable 1Mb so that we can load PKCS-7
signatures with full certificate info included.

This wasn't being tested in the self tests as it only affects data read from
the remote file descriptor.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
