### PR TITLE
trivial: debian: Don't use --parents when rmdir'ing /var/*/fwupdate

### DIFF
--- a/contrib/debian/fwupd.postinst
+++ b/contrib/debian/fwupd.postinst
@@ -27,6 +27,6 @@ rm -f /var/lib/fwupdate/done
 rm -f /var/cache/fwupdate/done
 for dir in /var/cache/fwupdate /var/lib/fwupdate; do
 	if [ -d $dir ]; then
-	        rmdir --parents --ignore-fail-on-non-empty $dir || true
+	        rmdir --ignore-fail-on-non-empty $dir || true
 	fi
 done


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X ] Code fix
- [ ] Feature
- [ ] Documentation
