### PR TITLE
trivial: debian: Don't use --parents when rmdir'ing /var/*/fwupdate

### DIFF
--- a/contrib/debian/fwupd.postinst
+++ b/contrib/debian/fwupd.postinst
@@ -29,6 +29,6 @@ rm -f /var/lib/fwupdate/done
 rm -f /var/cache/fwupdate/done
 for dir in /var/cache/fwupdate /var/lib/fwupdate; do
 	if [ -d $dir ]; then
-	        rmdir --parents --ignore-fail-on-non-empty $dir || true
+	        rmdir --ignore-fail-on-non-empty $dir || true
 	fi
 done


### PR DESCRIPTION
Calling 'rmdir --parents /var/cache/fwupdate' will cause it to attempt
to rmdir /var/cache and /var. Those directories are very unlikely to be
empty, so it should always quietly fail. However, there's not benefit
in attempting those removals, so let's quit doing it.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ X] Code fix
- [ ] Feature
- [ ] Documentation
