### PR TITLE
trivial: synaptics-mst: adjust last part of triplet to be 2 digits not 3

### DIFF
--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1038,7 +1038,7 @@ fu_synaptics_mst_device_rescan (FuDevice *device, GError **error)
 					      buf_ver, 3, error))
 		return FALSE;
 
-	version = g_strdup_printf ("%1d.%02d.%03d", buf_ver[0], buf_ver[1], buf_ver[2]);
+	version = g_strdup_printf ("%1d.%02d.%02d", buf_ver[0], buf_ver[1], buf_ver[2]);
 	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_TRIPLET);
 
 	/* read board ID */


### PR DESCRIPTION
Synaptics versions are encoded as BCD, the largest version that will
ever be represented in this field is '99'.

Using 3 digits in this field has caused multiple problems in upgrades from
LVFS.

1. Devices are being upgraded when not necessary.
IE `5.3.10 > 5.3.010`

2. Device upgrades are deemed failures as follows:

```
BootTime=1571436076,
CompileVersion(com.redhat.efivar)=37,
CompileVersion(com.redhat.fwupdate)=12,
CompileVersion(org.freedesktop.fwupd)=1.3.2,
CompileVersion(org.freedesktop.gusb)=0.3.0,
CpuArchitecture=x86_64,
DistroId=fedora,
DistroVariant=workstation,
DistroVersion=32,
FirmwareId=1915,
Flags=4194346,
Guid=f15aa55c-9cd5-5942-85ae-a6bf8740b96c,
MachineId=97aa89528b88d9631867a4e20c68a5208124ef592e19d05f0c5e7d22bd4d7afb,
Plugin=synapticsmst,
RuntimeVersion(com.dell.libsmbios)=2.4,
RuntimeVersion(com.redhat.fwupdate)=12,
RuntimeVersion(org.freedesktop.appstream-glib)=0.7.14,
RuntimeVersion(org.freedesktop.fwupd)=1.3.2,
RuntimeVersion(org.kernel)=5.4.0-0.rc2.git2.1.fc32.x86_64,
UpdateError=device version not updated on success, 05.03.10 != 5.03.010,
UpdateState=failed,
VersionNew=05.03.10,
VersionOld=5.03.010

```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
