### PR TITLE
ci: fedora: force correct rpm package version

### DIFF
--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -21,11 +21,12 @@ meson .. \
 ninja-build dist
 popd
 VERSION=`./contrib/get-version.py`
+RPMVERSION=${VERSION//-/.}
 mkdir -p $HOME/rpmbuild/SOURCES/
 mv build/meson-dist/fwupd-$VERSION.tar.xz $HOME/rpmbuild/SOURCES/
 
 #generate a spec file
-sed "s,#VERSION#,$VERSION,;
+sed "s,#VERSION#,$RPMVERSION,;
      s,#TARBALL_VERSION#,$VERSION,;
      s,#BUILD#,1,;
      s,#LONGDATE#,`date '+%a %b %d %Y'`,;


### PR DESCRIPTION
RPM doesn't allow '-' in the version number,
so this must be fixed if also when building from
an untagged git tree.

sanitize_for_ci() from get-version.py
fixes it only when build is CI environment.

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
