### PR TITLE
Detect kernel lockdown

### DIFF
--- a/data/tests/lockdown/locked/lockdown
+++ b/data/tests/lockdown/locked/lockdown
@@ -1,0 +1,1 @@
+none integrity [confidentiality]

--- a/data/tests/lockdown/none/lockdown
+++ b/data/tests/lockdown/none/lockdown
@@ -1,0 +1,1 @@
+[none] integrity confidentiality

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -55,6 +55,7 @@ typedef guint FuEndianType;
  * @FU_PATH_KIND_SYSFSDIR_TPM:		The TPM sysfs directory (IE /sys/class/tpm)
  * @FU_PATH_KIND_POLKIT_ACTIONS:	The directory for policy kit actions (IE /usr/share/polkit-1/actions/)
  * @FU_PATH_KIND_OFFLINE_TRIGGER:	The file for the offline trigger (IE /system-update)
+ * @FU_PATH_KIND_SYSFSDIR_SECURITY:	The sysfs security location (IE /sys/kernel/security)
  *
  * Path types to use when dynamically determining a path at runtime
  **/
@@ -72,6 +73,7 @@ typedef enum {
 	FU_PATH_KIND_SYSFSDIR_TPM,
 	FU_PATH_KIND_POLKIT_ACTIONS,
 	FU_PATH_KIND_OFFLINE_TRIGGER,
+	FU_PATH_KIND_SYSFSDIR_SECURITY,
 	/*< private >*/
 	FU_PATH_KIND_LAST
 } FuPathKind;
@@ -214,3 +216,4 @@ gchar		**fu_common_strnsplit		(const gchar	*str,
 						 gsize		 sz,
 						 const gchar	*delimiter,
 						 gint		 max_tokens);
+gboolean	 fu_common_kernel_locked_down	(void);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -454,6 +454,28 @@ fu_plugin_quirks_device_func (void)
 	g_assert (fu_device_has_flag (device_tmp, FWUPD_DEVICE_FLAG_UPDATABLE));
 }
 
+static void fu_common_kernel_lockdown_func (void)
+{
+	gboolean ret;
+	g_autofree gchar *old_kernel_dir = g_build_filename (TESTDATADIR_SRC,
+							     "lockdown", NULL);
+	g_autofree gchar *locked_dir = g_build_filename (TESTDATADIR_SRC,
+							 "lockdown", "locked", NULL);
+	g_autofree gchar *none_dir = g_build_filename (TESTDATADIR_SRC,
+							"lockedown", "none", NULL);
+
+	g_setenv ("FWUPD_SYSFSSECURITYDIR", old_kernel_dir, TRUE);
+	ret = fu_common_kernel_locked_down ();
+	g_assert_false (ret);
+
+	g_setenv ("FWUPD_SYSFSSECURITYDIR", locked_dir, TRUE);
+	ret = fu_common_kernel_locked_down ();
+	g_assert_true (ret);
+
+	g_setenv ("FWUPD_SYSFSSECURITYDIR", none_dir, TRUE);
+	ret = fu_common_kernel_locked_down ();
+	g_assert_false (ret);
+}
 
 static void
 fu_common_firmware_builder_func (void)
@@ -1590,6 +1612,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/common{spawn)", fu_common_spawn_func);
 	g_test_add_func ("/fwupd/common{spawn-timeout)", fu_common_spawn_timeout_func);
 	g_test_add_func ("/fwupd/common{firmware-builder}", fu_common_firmware_builder_func);
+	g_test_add_func ("/fwupd/common{kernel-lockdown}", fu_common_kernel_lockdown_func);
 	g_test_add_func ("/fwupd/hwids", fu_hwids_func);
 	g_test_add_func ("/fwupd/smbios", fu_smbios_func);
 	g_test_add_func ("/fwupd/smbios3", fu_smbios3_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -525,3 +525,9 @@ LIBFWUPDPLUGIN_1.3.6 {
     fu_udev_device_set_flags;
   local: *;
 } LIBFWUPDPLUGIN_1.3.5;
+
+LIBFWUPDPLUGIN_1.3.8 {
+  global:
+    fu_common_kernel_locked_down;
+  local: *;
+} LIBFWUPDPLUGIN_1.3.6;

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -103,7 +103,17 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
-	GPtrArray *hwids = fu_plugin_get_hwids (plugin);
+	GPtrArray *hwids;
+
+	if (fu_common_kernel_locked_down ()) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "not supported when kernel locked down");
+		return FALSE;
+	}
+
+	hwids = fu_plugin_get_hwids (plugin);
 	for (guint i = 0; i < hwids->len; i++) {
 		const gchar *tmp;
 		const gchar *guid = g_ptr_array_index (hwids, i);


### PR DESCRIPTION
This should avoid at least one cause of this showing up in dmesg every time fwupd starts:

```
Lockdown: fwupd: /dev/mem,kmem,port is restricted; see man kernel_lockdown.7
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
