### PR TITLE
vli: Add the DEV instance ID to all devices

### DIFF
--- a/plugins/vli/README.md
+++ b/plugins/vli/README.md
@@ -27,6 +27,10 @@ These devices use the standard USB DeviceInstanceId values, e.g.
  * `USB\VID_17EF&PID_3083`
  * `USB\VID_17EF`
 
+All VLI devices also use custom GUID values for the device type, e.g.
+
+ * `USB\VID_17EF&PID_3083&DEV_VL812B3`
+
 These devices also use custom GUID values for the SPI flash configuration, e.g.
 
  * `VLI_USBHUB\SPI_37303840`

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -554,8 +554,21 @@ fu_vli_device_setup (FuDevice *device, GError **error)
 	}
 
 	/* subclassed further */
-	if (klass->setup != NULL)
-		return klass->setup (self, error);
+	if (klass->setup != NULL) {
+		if (!klass->setup (self, error))
+			return FALSE;
+	}
+
+	/* add extra DEV GUID too */
+	if (priv->kind != FU_VLI_DEVICE_KIND_UNKNOWN) {
+		GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (self));
+		g_autofree gchar *devid1 = NULL;
+		devid1 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&DEV_%s",
+					  g_usb_device_get_vid (usb_device),
+					  g_usb_device_get_pid (usb_device),
+					  fu_vli_common_device_kind_to_string (priv->kind));
+		fu_device_add_instance_id (device, devid1);
+	}
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
In some composite dock hardware there are two USB devices exported to the host,
both with the same VID:PID values. We need to use the device type (e.g. VL812B3)
to differenciate the devices and install the correct fw on the correct device.

@memily