### PR TITLE
Cleanup ancient fwupdate-* EFI variables too (Fixes: #1739)

### DIFF
--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -460,7 +460,7 @@ fu_uefi_device_cleanup_esp (FuDevice *device, GError **error)
 	files = fu_common_get_files_recursive (esp_path, error);
 	if (files == NULL)
 		return FALSE;
-	pattern = g_build_filename (esp_path, "EFI/*/fw/fwupd-*.cap", NULL);
+	pattern = g_build_filename (esp_path, "EFI/*/fw/fwupd*.cap", NULL);
 	for (guint i = 0; i < files->len; i++) {
 		const gchar *fn = g_ptr_array_index (files, i);
 		if (fu_common_fnmatch (pattern, fn)) {
@@ -472,7 +472,7 @@ fu_uefi_device_cleanup_esp (FuDevice *device, GError **error)
 	}
 
 	/* delete any old variables */
-	if (!fu_uefi_vars_delete_with_glob (FU_UEFI_VARS_GUID_FWUPDATE, "fwupd-*", error))
+	if (!fu_uefi_vars_delete_with_glob (FU_UEFI_VARS_GUID_FWUPDATE, "fwupd*-*", error))
 		return FALSE;
 
 	return TRUE;


### PR DESCRIPTION
It seems that fwupd.efi is picking up both fwupdate-* and fwupd-*
entries that are sitting around in efivarfs.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
