### PR TITLE
Support the new gnuefi file locations

### DIFF
--- a/plugins/uefi/efi/meson.build
+++ b/plugins/uefi/efi/meson.build
@@ -30,10 +30,17 @@ if not have_gnu_efi
   error('gnu-efi support requested, but headers were not found')
 endif
 
-arch_lds = 'elf_@0@_efi.lds'.format(gnu_efi_path_arch)
+arch_lds = 'efi.lds'
+arch_crt = 'crt0.o'
 if efi_ldsdir == ''
-  efi_ldsdir = join_paths(efi_libdir, 'gnuefi')
+  efi_ldsdir = join_paths(efi_libdir, 'gnuefi', gnu_efi_path_arch)
   cmd = run_command('test', '-f', join_paths(efi_ldsdir, arch_lds))
+  if cmd.returncode() != 0
+    arch_lds = 'elf_@0@_efi.lds'.format(gnu_efi_path_arch)
+    arch_crt = 'crt0-efi-@0@.o'.format(gnu_efi_path_arch)
+    efi_ldsdir = join_paths(efi_libdir, 'gnuefi')
+    cmd = run_command('test', '-f', join_paths(efi_ldsdir, arch_lds))
+  endif
   if cmd.returncode() != 0
     efi_ldsdir = efi_libdir
     cmd = run_command('test', '-f', join_paths(efi_ldsdir, arch_lds))
@@ -93,8 +100,8 @@ efi_ldflags = ['-T',
                '-Bsymbolic',
                '-nostdlib',
                '-znocombreloc',
-               '-L', efi_libdir,
-               join_paths(efi_ldsdir, 'crt0-efi-@0@.o'.format(gnu_efi_path_arch))]
+               '-L', efi_ldsdir,
+               join_paths(efi_ldsdir, arch_crt)]
 if efi_arch == 'aarch64' or efi_arch == 'arm'
   # Aarch64 and ARM32 don't have an EFI capable objcopy. Use 'binary'
   # instead, and add required symbols manually.


### PR DESCRIPTION
gnu-efi 3.0.11 moves a few files around, e.g.

    /usr/lib64/gnuefi/elf_x64_efi.lds -> /usr/lib64/gnuefi/x64/efi.lds

...and this causes the UEFI EFI helper to fail to link.

Add support for the 'new' paths and fall back to the old ones.

Fixes https://github.com/fwupd/fwupd/issues/1736

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
