### PR TITLE
trivial: Re-order circleci commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
     docker:
       - image: fedora:31
     steps:
-      - checkout
       - run:
           name: "Install deps"
           command: dnf install -y diffutils
@@ -40,6 +39,7 @@ jobs:
                                   git-core
                                   gnutls-utils
                                   meson
+                                  git
                                   gcc
                                   gcab
                                   mingw32-nsis
@@ -52,6 +52,7 @@ jobs:
                                   mingw64-json-glib
                                   mingw64-libsoup
                                   wine
+      - checkout
       - run:
           name: "Build Win32"
           command: ./contrib/ci/build_windows.sh
@@ -67,13 +68,13 @@ jobs:
     docker:
       - image: ubuntu:18.04
     steps:
-      - checkout
       - run:
           name: "Update apt"
           command: apt update
       - run:
           name: "install snapcraft"
-          command: apt install snapcraft -y
+          command: apt install snapcraft git -y
+      - checkout
       - run:
           name: "Build Snap"
           command: snapcraft


### PR DESCRIPTION
This should allow using a git client provided by the OS, not CircleCI.

Hopefully it helps the deployment job for the next release.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
