### PR TITLE
trivial: drop `bsdtar` from lgtm

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,7 +5,6 @@ extraction:
   cpp:
     prepare:
       packages:
-      - bsdtar
       - python3-gi
       - libcogl-pango-dev
       - python3-pil

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,6 +6,7 @@ extraction:
     prepare:
       packages:
       - python3-gi
+      - libarchive-tools
       - libcogl-pango-dev
       - python3-pil
       - python3-cairo


### PR DESCRIPTION
`/bin/tar` is provided by the package `tar` anyway.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
