### PR TITLE
Revert 7b15a4d646845496da18ddff6a48e83f6d50173a

### DIFF
--- a/plugins/uefi/efi/fwup-debug.c
+++ b/plugins/uefi/efi/fwup-debug.c
@@ -58,12 +58,12 @@ fwup_log(FwupLogLevel level, const char *func, const char *file, const int line,
 
 	if (debugging) {
 		_cleanup_free CHAR16 *out1 = NULL;
-		out1 = PoolPrint(L"%a:%d:%a(): %s", file, line, func, tmp);
+		out1 = PoolPrint(L"%a:%d:%a(): %s\n", file, line, func, tmp);
 		if (out1 == NULL) {
 			Print(L"fwupdate: Allocation for debug log failed!\n");
 			return;
 		}
-		Print(L"%s\n", out1);
+		Print(L"%s", out1);
 		fwupd_debug_efivar_append(out1);
 	} else {
 		switch (level) {

--- a/plugins/uefi/efi/fwup-efi.c
+++ b/plugins/uefi/efi/fwup-efi.c
@@ -17,27 +17,16 @@ fwup_delete_variable(CHAR16 *name, EFI_GUID *guid)
 {
 	EFI_STATUS rc;
 	UINT32 attrs = 0;
-	UINTN size = 0;
 
 	/* get the attrs so we can delete it */
-	rc = uefi_call_wrapper(RT->GetVariable, 5, name, guid, &attrs, &size, NULL);
+	rc = uefi_call_wrapper(RT->GetVariable, 5, name, guid, &attrs, NULL, NULL);
 	if (EFI_ERROR(rc)) {
-		if (rc == EFI_BUFFER_TOO_SMALL) {
-			_cleanup_free VOID *buf = fwup_malloc(size);
-			if (buf == NULL)
-				return EFI_OUT_OF_RESOURCES;
-			rc = uefi_call_wrapper(RT->GetVariable, 5, name, guid, &attrs, &size, buf);
-			if (EFI_ERROR(rc)) {
-				fwup_debug(L"Could not get attr: %r", rc);
-				return rc;
-			}
-		} else if (rc == EFI_NOT_FOUND) {
+		if (rc == EFI_NOT_FOUND) {
 			fwup_debug(L"Not deleting variable '%s' as not found", name);
 			return EFI_SUCCESS;
-		} else {
-			fwup_debug(L"Could not get variable '%s' for delete: %r", name, rc);
-			return rc;
 		}
+		fwup_debug(L"Could not get variable '%s' for delete: %r", name, rc);
+		return rc;
 	}
 	return uefi_call_wrapper(RT->SetVariable, 5, name, guid, attrs, 0, NULL);
 }

--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -408,9 +408,7 @@ fwup_delete_boot_entry(VOID)
 		/* check if the variable name is Boot#### */
 		if (CompareGuid(&vendor_guid, &global_variable_guid) != 0)
 			continue;
-		if (StrLen(variable_name) != 8)
-			continue;
-		if (StrnCmp(variable_name, L"Boot", 4) != 0)
+		if (StrCmp(variable_name, L"Boot") != 0)
 			continue;
 
 		UINTN info_size = 0;


### PR DESCRIPTION
This code is obviously causing regressions and the algorithm in use for deleting the various boot variables needs some adjusting.  For now, revert that commit to unbreak systems and perhaps algorithm can be adjusted later.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
