### PR TITLE
synaptics-cxaudio: Make the verfmt match that of the existing Windows…

### DIFF
--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -622,9 +622,9 @@ fu_synaptics_cxaudio_device_setup (FuDevice *device, GError **error)
 		g_prefix_error (error, "failed to read EEPROM patch version: ");
 		return FALSE;
 	}
-	version_patch = g_strdup_printf ("%u.%u.%u",
+	version_patch = g_strdup_printf ("%02X-%02X-%02X",
 					 verbuf_patch[0], verbuf_patch[1], verbuf_patch[2]);
-	fu_device_set_version (device, version_patch, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, version_patch, FWUPD_VERSION_FORMAT_PLAIN);
 
 	/* find out if patch supports additional capabilities (optional) */
 	cap_str = g_usb_device_get_string_descriptor (usb_device,


### PR DESCRIPTION
… tools

This is causing too much confusion, and we don't actually need to force to a
dotted decimal for any reason.
