### PR TITLE
upower: Decrease minimum battery requirement to 10%

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -250,6 +250,7 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %doc README.md AUTHORS
 %license COPYING
 %config(noreplace)%{_sysconfdir}/fwupd/daemon.conf
+%config(noreplace)%{_sysconfdir}/fwupd/upower.conf
 %if 0%{?have_uefi}
 %config(noreplace)%{_sysconfdir}/fwupd/uefi.conf
 %endif

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -9,7 +9,7 @@
 #include "fu-plugin-vfuncs.h"
 #include "fu-hash.h"
 
-#define MINIMUM_BATTERY_PERCENTAGE	30
+#define MINIMUM_BATTERY_PERCENTAGE	10
 
 struct FuPluginData {
 	GDBusProxy		*upower_proxy;

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -21,3 +21,7 @@ shared_module('fu_plugin_upower',
     plugin_deps,
   ],
 )
+
+install_data(['upower.conf'],
+  install_dir:  join_paths(sysconfdir, 'fwupd')
+)

--- a/plugins/upower/upower.conf
+++ b/plugins/upower/upower.conf
@@ -1,0 +1,5 @@
+[upower]
+
+# The threshold to to require battery be at or above to allow updates
+# Measure in percent
+BatteryThreshold=10


### PR DESCRIPTION
Dell's behavioral spec for this aligns the threshold for this at 10%
rather than 30%.

Validation engineers have have a flurry of reports about this behavioral difference when comparing it to Windows.  So align it to the Dell spec.  If this is contentious as a general adjustment, I can adjust the PR to examine the vendor from SMBIOS data and have a Dell value in addition to general value.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
