### PR TITLE
uefi: Apply capsule update even with single valid capsule

### DIFF
--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -577,16 +577,17 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
 		fwup_info(L"Adding new capsule");
 		rc = fwup_add_update_capsule(updates[i], &capsules[j], &cbd_data[j], image);
 		if (EFI_ERROR(rc)) {
-			/* ignore a failing UX capsule */
-			if (rc == EFI_UNSUPPORTED &&
-			    CompareGuid(&updates[i]->info->guid, &ux_capsule_guid) == 0) {
-				fwup_debug(L"GOP unsuitable: %r", rc);
-				continue;
-			}
-			fwup_warning(L"Could not build update list: %r", rc);
-			return rc;
+			/* ignore a failing capsule */
+			fwup_warning(L"Could not add capsule with guid %g for update: %r",
+				     updates[i]->info->guid, rc);
+			continue;
 		}
 		j++;
+	}
+
+	if (j == 0) {
+		fwup_warning(L"Could not build update list: %r\n", rc);
+		return rc;
 	}
 	n_updates = j;
 	fwup_debug(L"n_updates: %d", n_updates);


### PR DESCRIPTION
Currently if there is an invalid boot entry for firmware update, the fwupd
EFI program will not call UpdateCapsule(), even if there is a valid entry.

For example, if the following entries exist the firmware update will fail:

HD(1,GPT,A672BBCA-325E-4D6F-91E1-DD57FAA85A9C)/\EFI\rhel\fw\fwupdate-6cialq.cap ... /*Valid entry*/
HD(1,GPT,E8176B29-6F73-43F2-AE8E-05E09DE20EE5)/\EFI\fedora\fw\fwupd-6dcbd5ed-e82d-4c44-bda1-7194199ad92a.cap ... /*InValid entry*/

Ensure capsule update is happening even if a valid capsule entry exists.

Signed-off-by: Bhaskar Upadhaya <bupadhaya@marvell.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
