### PR TITLE
Fix a critical warning when installing some firmware

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1767,7 +1767,7 @@ fu_engine_schedule_update (FuEngine *self,
 
 static gboolean
 fu_engine_install_release (FuEngine *self,
-			   FuDevice *device,
+			   FuDevice *device_orig,
 			   XbNode *component,
 			   XbNode *rel,
 			   FwupdInstallFlags flags,
@@ -1780,6 +1780,7 @@ fu_engine_install_release (FuEngine *self,
 	g_autofree gchar *version_orig = NULL;
 	g_autofree gchar *version_rel = NULL;
 	g_autoptr(FuDevice) device_tmp = NULL;
+	g_autoptr(FuDevice) device = g_object_ref (device_orig);
 	g_autoptr(GBytes) blob_fw2 = NULL;
 	g_autoptr(GError) error_local = NULL;
 


### PR DESCRIPTION
If the device replugs, then we were doing `g_set_object(&device, device_tmp)`
which worked, but had the unfortunate effect of not unwinding properly as
`device` was a function parameter rather than a local variable.

The observed effect using `watch ((GObject*)$1)->ref_count` was the refcount was
double-decremented and thus we got a critical warning on the final valid unref.
Fix this by copying the function parameter to a local variable which we can
then change if the device replugs.
