### PR TITLE
Generate an additional UEFI quirk file using the stable LVFS metadata

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -10,6 +10,11 @@ git log --format="%s" --cherry-pick --right-only $(git describe --tags --abbrev=
 Add any user visible changes into ../data/org.freedesktop.fwupd.metainfo.xml
 appstream-util appdata-to-news ../data/org.freedesktop.fwupd.metainfo.xml > NEWS
 
+1.5. Update ESRT names:
+
+fwupdmgr refresh
+ninja-build uefi-update-quirk
+
 2. Update translations:
 
 ninja-build fwupd-pot

--- a/plugins/uefi/generate-quirk.py
+++ b/plugins/uefi/generate-quirk.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 20202 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+import sys
+import gzip
+import xml.etree.ElementTree as etree
+
+def get_kind_from_component(md):
+
+    # ideally we would use <category> but that's not available in the XML yet
+    name = md.find('name').text
+    if name.find('Embedded Controller') != -1:
+        return 'Embedded Controller'
+    if name.find('Corporate ME') != -1:
+        return 'Intel Management Engine'
+    if name.find('Consumer ME') != -1:
+        return 'Intel Management Engine'
+    return None
+
+def generate_quirk_from_xml(infn, outfn):
+
+    # parse GZipped XML
+    with gzip.open(infn, 'rb') as xml:
+        tree = etree.parse(xml)
+
+    # look for any interesting devices
+    seen_guids = {}
+    with open(outfn, 'w') as out:
+        out.write('# generated using {} -- DO NOT EDIT\n'.format(os.path.basename(sys.argv[0])))
+        for md in tree.findall('component'):
+
+            # filter by protocol
+            protocol = None
+            for val in md.findall('custom/value'):
+                if val.attrib['key'] == 'LVFS::UpdateProtocol':
+                    protocol = val.text
+            if protocol != 'org.uefi.capsule':
+                continue
+
+            # it is unlikely, but there might be multiple GUIDs here
+            guids = []
+            for prov in md.findall('provides/firmware'):
+                if prov.text in seen_guids:
+                    continue
+                guids.append(prov.text)
+            if not guids:
+                continue
+
+            # map to a suitable name for fwupd
+            kind = get_kind_from_component(md)
+            if not kind:
+                continue
+
+            # output another chunk
+            appstream_id = md.find('id').text
+            out.write('\n# from {}\n'.format(appstream_id))
+            for guid in guids:
+                out.write('[Guid={}]\n'.format(guid))
+                out.write('Name = {}\n'.format(kind))
+                seen_guids[guid] = True
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('invalid args, expected INPUT OUTPUT')
+        sys.exit(1)
+    generate_quirk_from_xml(sys.argv[1], sys.argv[2])

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -7,7 +7,18 @@ if efi_os_dir != ''
   cargs += '-DEFI_OS_DIR="' + efi_os_dir + '"'
 endif
 
-install_data(['uefi.quirk'],
+run_target('uefi-update-quirk',
+  command: [
+    python3.path(),
+    join_paths(meson.current_source_dir(), 'generate-quirk.py'),
+    '/var/lib/fwupd/remotes.d/lvfs/metadata.xml.gz', 'uefi-lvfs-generated.quirk'
+  ]
+)
+
+install_data([
+    'uefi.quirk',
+    'uefi-lvfs-generated.quirk',
+  ],
   install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
 )
 

--- a/plugins/uefi/uefi-lvfs-generated.quirk
+++ b/plugins/uefi/uefi-lvfs-generated.quirk
@@ -1,0 +1,273 @@
+# generated using generate-quirk.py -- DO NOT EDIT
+
+# from com.lenovo.ThinkPadN1CHT.firmware
+[Guid=ffaf3e12-a6ea-4352-851b-76c6455913c6]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN1CRM.firmware
+[Guid=63451986-0c42-42db-9a18-342a8455ac68]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1CRN.firmware
+[Guid=03d3297b-3851-4379-95ad-12e21a96c80a]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1FHT.firmware
+[Guid=4c2e5b5c-6467-43af-afeb-7bc72d96b9c3]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN1FRM.firmware
+[Guid=cb3c1682-5386-4591-bd29-7c1f441b7ccb]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1FRN.firmware
+[Guid=95f9a8f4-9531-483c-afee-c3f12774ff4b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1MHT.firmware
+[Guid=74997a6b-1adf-4b12-b994-401f06ea8c72]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN1MRM.firmware
+[Guid=1c7df930-c51b-43f2-af4e-01239686ff2d]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1MRN.firmware
+[Guid=c35736d2-9e47-4578-93e9-68d5b04ea77e]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1NRM.firmware
+[Guid=1ccf85a8-c3fb-4720-b762-a58edceaec43]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1NRN.firmware
+[Guid=cdd74097-79ca-451b-b28c-4cf1f6f412a6]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1QHT.firmware
+[Guid=4b37c365-ecb2-4d89-8e15-e93c27c6ce12]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN1QRM.firmware
+[Guid=bcff5fd8-0a99-48ad-b630-40e8eadb190e]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1QRN.firmware
+[Guid=1c0f9993-38e5-4a62-8dab-f2efee639b63]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1URMP51.firmware
+[Guid=6fa2d32b-ec53-44fa-94d6-5ab363c51968]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1URMP71.firmware
+[Guid=604799ec-12a5-4b22-817a-358135296a78]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1URNP51.firmware
+[Guid=bec0a796-5688-499f-b208-9fc1d1e734a6]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1URNP71.firmware
+[Guid=b879dc99-6712-40ce-aaa9-de8ff2271d03]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1VRM.firmware
+[Guid=482fc957-9251-47a0-9f32-354f1194c588]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1VRN.firmware
+[Guid=1ce1e757-cd07-48e4-9685-c6e7e6eb45b9]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1WHT.firmware
+[Guid=e2acd8e4-a376-47bb-a316-4f1e62a8ca1f]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN1WRM.firmware
+[Guid=e9124c4a-fdff-42e5-b2ad-f745db345953]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1WRN.firmware
+[Guid=d95d3ada-eef1-464f-8a2a-a11232b8556b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1XRM.firmware
+[Guid=3173dd58-1527-495b-aa36-edeaaad42404]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN1XRN.firmware
+[Guid=845ca60d-cb3b-4f53-b822-ba0e86e996a8]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN20HT.firmware
+[Guid=3f4a527b-6588-45b8-b2d3-dc61189b63cb]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN20RM.firmware
+[Guid=84bf8333-8724-471e-b60b-5759bdbd9785]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN20RN.firmware
+[Guid=6d28cd9f-7bcd-4fb9-9f10-0372e2962fc4]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN22HT.firmware
+[Guid=4d254d6e-cd67-477b-97d5-bc3048af45c4]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN22RM.firmware
+[Guid=39a39e45-38ce-4b05-809b-60351bf88ec4]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN22RN.firmware
+[Guid=676af093-2a5c-4238-9c29-db8063a33532]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN23HT.firmware
+[Guid=3babca5f-b2bf-4f4b-a72e-2bdc84eb4019]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN23RM.firmware
+[Guid=42a0a96e-c9f3-438f-9687-7826be33e4ce]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN23RN.firmware
+[Guid=9c9d9769-32fa-4841-b550-ea998e754e99]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN24HT.firmware
+[Guid=b87a926d-189c-49a1-b1ff-921099b1de89]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN24RM.firmware
+[Guid=dd31d983-cf3b-4c84-acc9-70caa94e827b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN24RN.firmware
+[Guid=9e21f98b-fe98-455c-b388-da5450ab6979]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN25HT.firmware
+[Guid=6c6c8104-65e5-45c2-8e31-059df92ef3fd]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN25RM.firmware
+[Guid=99e3fcfb-842a-4c54-8f0e-d55c80e626a3]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN25RN.firmware
+[Guid=7c38c98a-c3e9-4c15-b0cd-c634d441cf7f]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN27RM.firmware
+[Guid=ae82a157-cc81-419a-88e4-a983a76075db]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN27RN.firmware
+[Guid=72e9217b-717e-4908-b428-fe4df390177b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2CHT.firmware
+[Guid=88b8ba7e-296b-4f9e-929f-dcc19318dbcf]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2CRM.firmware
+[Guid=971682af-21a0-46e3-91c0-825702c2ba70]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2CRMP1X1.firmware
+[Guid=4226a48a-8c1e-4f66-8f54-7e5dc33dcba9]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2CRN.firmware
+[Guid=6f92af2c-dbf3-449d-a37b-6986b5532908]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2CRNP1X1.firmware
+[Guid=b49ed72d-e186-4fa6-9761-3242da3c3be9]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2HHT.firmware
+[Guid=f72e048b-65bd-4e71-9071-1ac7045223e5]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2HRM.firmware
+[Guid=32c6986c-23ac-4dff-8d8b-d43a58ec48f7]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2HRN.firmware
+[Guid=c3e4be53-e714-4ea1-bb9c-7fe13a98b556]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2IHT.firmware
+[Guid=38ea6335-29ca-417b-8cd4-6b4e5e866f92]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2IRM.firmware
+[Guid=2c0665e2-fdbd-495e-b8e4-69d92b9c119a]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2IRN.firmware
+[Guid=bf2d0f8b-f9a9-400c-8914-36c225d16eb4]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2JHT.firmware
+[Guid=be9a5f93-930b-40bf-8864-815268ea4ea3]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2JRM.firmware
+[Guid=aeac19da-0c78-4b86-a718-1a043947d83b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2JRN.firmware
+[Guid=ef5cdc85-9cf6-469d-9cb7-920b7dd6672b]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadN2NHT.firmware
+[Guid=54bdce35-631e-47a6-a3ee-382f64814f68]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2OHT.firmware
+[Guid=5aaaa50f-8348-43aa-befe-7fc4b9838ab5]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2QHT.firmware
+[Guid=ef793001-2e3e-42fa-ad94-c8d75c62909e]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadN2SHT.firmware
+[Guid=2fe0ea63-da1e-4291-b9dc-c8de40fdc4d3]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadP50RM.firmware
+[Guid=671d19d0-d43c-4852-98d9-1ce16f9967e4]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadR0FHT.firmware
+[Guid=a28cc671-fabc-4eb1-9a7b-a10a5223c64e]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadR0FMF.firmware
+[Guid=a121e4b0-a3b9-4f15-b2f6-5f793e21414c]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadR0FMV.firmware
+[Guid=f9689424-6c5c-40cc-999b-9a8c2e6ad63d]
+Name = Intel Management Engine
+
+# from com.lenovo.ThinkPadR0IHT.firmware
+[Guid=18dfeb28-b8a4-4cec-97ce-b0599416a13e]
+Name = Embedded Controller
+
+# from com.lenovo.ThinkPadR0ZHT32W.firmware
+[Guid=1cca605f-f419-4b52-be63-3e8e0ad08503]
+Name = Embedded Controller
+
+# from com.nec.NECN1CRM.firmware
+[Guid=62fb54f3-3c50-4e07-9700-345e3aca428a]
+Name = Intel Management Engine
+
+# from com.nec.NECN1CRN.firmware
+[Guid=868e792f-6e39-46d9-9fd4-c337513a7cbc]
+Name = Intel Management Engine


### PR DESCRIPTION
The UEFI ESRT table just gives us a table of GUIDs with some basic flags, and
isn't very useful to end users. This is acceptable for Dell as there is only
typically one ESRT entry, which is for the system firmware. On typical Lenovo
hardware there might be half-a-dozen different 'Device' entries which all look
very similar.

As it's not possible to get a channel-of-data from the ODMs to fwupd, use the
existing LVFS metadata to generate some better names for these devices.
Although this looks like a lot of repeated data, libxmlb helpfully dedupes the
strings for us, making the quirk store only slightly larger.

Also, I've deliberately made this a manual step as we're not going to have
internet access on distro builders, and I'd also like the fwupd tarball output
to be deterministic and repeatable.
