### PR TITLE
ci: use standalone script to generate build dependencies

### DIFF
--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -104,6 +104,8 @@ Each distribution will have ***package*** elements and ***control*** elements.
 * ___inclusive___ elements represent an inclusive list of architectures to be installed on
 * ___exclusive___ elements represent an exclusive list of architectures to not be installed on
 
+For convenience there is also a standalone script __generate_dependencies.py__ that parses ___dependencies.xml___.
+
 Dockerfile.in
 -------------
 The ***Dockerfile.in*** file will be used as a template to build the container.  No hardcoded dependencies should be put in this file.  They should be stored in ***dependencies.xml***.

--- a/contrib/ci/generate_dependencies.py
+++ b/contrib/ci/generate_dependencies.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2017-2018 Dell, Inc.
+# Copyright (C) 2020 Intel, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+import os
+import sys
+import argparse
+import xml.etree.ElementTree as etree
+
+def parse_dependencies(OS, SUBOS, requested_type):
+    deps = []
+    dep = ''
+    directory = os.path.dirname(sys.argv[0])
+    tree = etree.parse(os.path.join(directory, "dependencies.xml"))
+    root = tree.getroot()
+    for child in root:
+        if "type" not in child.attrib or "id" not in child.attrib:
+            continue
+        for distro in child:
+            if "id" not in distro.attrib:
+                continue
+            if distro.attrib["id"] != OS:
+                continue
+            packages = distro.findall("package")
+            for package in packages:
+                if SUBOS:
+                    if 'variant' not in package.attrib:
+                        continue
+                    if package.attrib['variant'] != SUBOS:
+                        continue
+                if package.text:
+                    dep = package.text
+                else:
+                    dep = child.attrib["id"]
+                if child.attrib["type"] == requested_type and dep:
+                    deps.append(dep)
+    return deps
+
+if __name__ == '__main__':
+
+    try:
+        import distro
+        target = distro.linux_distribution()[0]
+    except ModuleNotFoundError:
+        target = None
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-o", "--os",
+                        default=target,
+                        choices=["fedora",
+                                 "centos",
+                                 "flatpak",
+                                 "debian",
+                                 "ubuntu",
+                                 "arch"],
+                        help="dependencies for OS")
+    args = parser.parse_args()
+
+    target = os.getenv('OS', args.os)
+    if target is None:
+        print("Missing OS environment variable")
+        sys.exit(1)
+
+    _os = target.lower()
+    _sub_os = ''
+    split = target.split('-')
+    if len(split) >= 2:
+        _os, _sub_os = split[:2]
+    dependencies = parse_dependencies(_os, _sub_os, "build")
+    print(*dependencies, sep='\n')

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -7,9 +7,9 @@
 import os
 import subprocess
 import sys
-import xml.etree.ElementTree as etree
 import tempfile
 import shutil
+from generate_dependencies import parse_dependencies
 
 def get_container_cmd():
     '''return docker or podman as container manager'''
@@ -18,34 +18,6 @@ def get_container_cmd():
         return 'docker'
     if shutil.which('podman'):
         return 'podman'
-
-def parse_dependencies(OS, SUBOS, requested_type):
-    deps = []
-    dep = ''
-    tree = etree.parse(os.path.join(directory, "dependencies.xml"))
-    root = tree.getroot()
-    for child in root:
-        if not "type" in child.attrib or not "id" in child.attrib:
-            continue
-        for distro in child:
-            if not "id" in distro.attrib:
-                continue
-            if distro.attrib["id"] != OS:
-                continue
-            packages = distro.findall("package")
-            for package in packages:
-                if SUBOS:
-                    if not 'variant' in package.attrib:
-                        continue
-                    if package.attrib['variant'] != SUBOS:
-                        continue
-                if package.text:
-                    dep = package.text
-                else:
-                    dep = child.attrib["id"]
-                if child.attrib["type"] == requested_type and dep:
-                    deps.append(dep)
-    return deps
 
 directory = os.path.dirname(sys.argv[0])
 TARGET=os.getenv('OS')


### PR DESCRIPTION
Sometimes it is desirable to create a build environment
outside of docker.
Move dependencies parser to a standalone python script
and call it from generate_docker.py

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [v] Feature
- [ ] Documentation
