### PR TITLE
Move binaries around to better adhere to FHS 3.0

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -426,6 +426,15 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="libglib2.0-doc">
+    <distro id="debian">
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="libglib2.0-dev">
     <distro id="centos">
       <package>glib2-devel</package>

--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -6,6 +6,7 @@ Uploaders: Steve McIntyre <93sam@debian.org>,
            Matthias Klumpp <mak@debian.org>,
            Mario Limonciello <mario.limonciello@dell.com>
 Build-Depends: %%%DYNAMIC%%%
+Build-Depends-Indep: libglib2.0-doc <!nodoc>
 Standards-Version: 4.5.0
 Section: admin
 Homepage: https://github.com/fwupd/fwupd

--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -8,11 +8,11 @@ usr/share/icons/*
 usr/share/polkit-1/*
 usr/share/locale
 usr/share/metainfo/*
-usr/lib/*/fwupd
-usr/lib/*/fwupdagent
-usr/lib/*/fwupdoffline
-usr/lib/*/fwupdtool
-usr/lib/*/fwupdtpmevlog
+usr/libexec/fwupd/fwupd
+usr/libexec/fwupd/fwupdagent
+usr/libexec/fwupd/fwupdoffline
+usr/libexec/fwupd/fwupdtool
+usr/libexec/fwupd/fwupdtpmevlog
 usr/share/man/man1/*
 lib/systemd/system/*
 lib/systemd/system-preset/*

--- a/contrib/debian/gen_signing_json
+++ b/contrib/debian/gen_signing_json
@@ -12,7 +12,7 @@ OUT="$DIR/files.json"
 BINARY=$(find debian/tmp -name '*.efi' | xargs basename)
 
 # Actually needs full path within the binary deb
-BINARY="usr/lib/${SOURCE}/efi/${BINARY}"
+BINARY="usr/libexec/${SOURCE}/efi/${BINARY}"
 
 rm -f $OUT
 

--- a/contrib/debian/lintian/fwupd
+++ b/contrib/debian/lintian/fwupd
@@ -6,6 +6,6 @@ fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/system
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_upower.so
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_uefi_recovery.so
 #EFI applications are PE executables
-fwupd: executable-not-elf-or-script usr/lib/fwupd/efi/*.efi
-fwupd: portable-executable-missing-security-features usr/lib/fwupd/efi/*.efi SafeSEH
+fwupd: executable-not-elf-or-script usr/libexec/fwupd/efi/*.efi
+fwupd: portable-executable-missing-security-features usr/libexec/fwupd/efi/*.efi SafeSEH
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_modem_manager.so

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -49,16 +49,16 @@ override_dh_auto_configure:
 	else \
 		export FLASHROM="-Dplugin_flashrom=false"; \
 	fi; \
-	dh_auto_configure -- $$UEFI $$DELL $$FLASHROM $$CI -Dplugin_dummy=true -Dgtkdoc=true --libexecdir=/usr/lib
+	dh_auto_configure -- $$UEFI $$DELL $$FLASHROM $$CI -Dplugin_dummy=true -Dgtkdoc=true
 
 override_dh_install:
 	find debian/tmp/usr -type f -name "*a" -print | xargs rm -f
 	sed -i 's,wheel,sudo,' ./debian/tmp/usr/share/polkit-1/rules.d/org.freedesktop.fwupd.rules
 	dh_install
 	#install the EFI binaries if needed
-	if [ -d debian/tmp/usr/lib/fwupd/efi/ ]; then \
-		dh_install -pfwupd usr/lib/fwupd/efi ;\
-		dh_install -pfwupd usr/lib/fwupd/fwupdate; \
+	if [ -d debian/tmp/usr/libexec/fwupd/efi/ ]; then \
+		dh_install -pfwupd usr/libexec/fwupd/efi ;\
+		dh_install -pfwupd usr/libexec/fwupd/fwupdate; \
 	fi
 	#if build with meson subproject in CI need to install this too
 	if [ ! -z "$$CI" ] && [ -f debian/tmp/usr/lib/xb-tool ]; then \
@@ -103,9 +103,9 @@ override_dh_auto_test:
 override_dh_builddeb:
 	dh_builddeb
 ifeq (ubuntu,$(SB_STYLE))
-	if [ -d debian/tmp/usr/lib/fwupd/efi/ ]; then \
+	if [ -d debian/tmp/usr/libexec/fwupd/efi/ ]; then \
 		mkdir -p debian/fwupd-images/$(deb_version) ;\
-		cp debian/tmp/usr/lib/fwupd/efi/fwupd*.efi debian/fwupd-images/$(deb_version) ;\
+		cp debian/tmp/usr/libexec/fwupd/efi/fwupd*.efi debian/fwupd-images/$(deb_version) ;\
 		echo $(deb_version) > debian/fwupd-images/$(deb_version)/version ;\
 		tar -C debian/fwupd-images -czvf ../$(tar_name) . ;\
 		dpkg-distaddfile $(tar_name) raw-uefi - ;\

--- a/contrib/debian/signing-template/fwupd-SIGNARCH-signed.install
+++ b/contrib/debian/signing-template/fwupd-SIGNARCH-signed.install
@@ -1,1 +1,1 @@
-*.efi.signed /usr/lib/fwupd/efi
+*.efi.signed /usr/libexec/fwupd/efi

--- a/contrib/debian/signing-template/rules
+++ b/contrib/debian/signing-template/rules
@@ -4,12 +4,12 @@
 PACKAGE_NAME  := fwupd
 SIG_PKG_NAME  := fwupd-SIGNARCH-signed
 SIGNATURE_DIR := debian/signatures/$(PACKAGE_NAME)
-BINARY        := $(shell find /usr/lib/fwupd/efi -name '*.efi' | xargs basename)
+BINARY        := $(shell find /usr/libexec/fwupd/efi -name '*.efi' | xargs basename)
 
 %:
 	dh $@
 
 override_dh_auto_build:
-	cp /usr/lib/fwupd/efi/$(BINARY) .
-	sbattach --attach $(SIGNATURE_DIR)/usr/lib/fwupd/efi/$(BINARY).sig $(BINARY)
+	cp /usr/libexec/fwupd/efi/$(BINARY) .
+	sbattach --attach $(SIGNATURE_DIR)/usr/libexec/fwupd/efi/$(BINARY).sig $(BINARY)
 	mv $(BINARY) $(BINARY).signed


### PR DESCRIPTION
Include some updates from packaging in Debian, and then also shuffle some binaries that users can execute around to `usr/lib`.
See #1783 for more details.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

CC:
@bigon
@martinezjavier 
