### PR TITLE
Add a plugin vfunc to run after subclassed FuDevice creation

### DIFF
--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -86,6 +86,9 @@ gboolean	 fu_plugin_runner_udev_device_added	(FuPlugin	*self,
 gboolean	 fu_plugin_runner_udev_device_changed	(FuPlugin	*self,
 							 FuUdevDevice	*device,
 							 GError		**error);
+gboolean	 fu_plugin_runner_device_created	(FuPlugin	*self,
+							 FuDevice	*device,
+							 GError		**error);
 void		 fu_plugin_runner_device_removed	(FuPlugin	*self,
 							 FuDevice	*device);
 void		 fu_plugin_runner_device_register	(FuPlugin	*self,

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -325,6 +325,19 @@ gboolean	 fu_plugin_device_removed		(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GError		**error);
 /**
+ * fu_plugin_device_created
+ * @plugin: A #FuPlugin
+ * @device: A #FuDevice
+ * @error: A #GError or %NULL
+ *
+ * Function run when the subclassed device has been created.
+ *
+ * Since: 1.3.9
+ **/
+gboolean	 fu_plugin_device_created		(FuPlugin	*plugin,
+							 FuDevice	*dev,
+							 GError		**error);
+/**
  * fu_plugin_device_registered
  * @plugin: A #FuPlugin
  * @device: A #FuDevice

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -531,3 +531,9 @@ LIBFWUPDPLUGIN_1.3.8 {
     fu_common_kernel_locked_down;
   local: *;
 } LIBFWUPDPLUGIN_1.3.6;
+
+LIBFWUPDPLUGIN_1.3.9 {
+  global:
+    fu_plugin_runner_device_created;
+  local: *;
+} LIBFWUPDPLUGIN_1.3.8;


### PR DESCRIPTION
Sometimes the plugin will want to influence the subclassed device, for instance
by reading a per-plugin config file. At the moment there's no way to do this,
as even _device_registered() is explicitly designed for devices *not* created
by the plugin itself.

Even if _device_registered() was changed to include the plugin creating the
object it would still happen well after the device has done _probe() and/or
_setup() and would probably be too late to do anything useful.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
