### PR TITLE
Always check for PLAIN when doing vercmp() operations

### DIFF
--- a/libfwupdplugin/fu-common-version.c
+++ b/libfwupdplugin/fu-common-version.c
@@ -450,6 +450,29 @@ fu_common_version_verify_format (const gchar *version,
 }
 
 /**
+ * fu_common_vercmp_full:
+ * @version_a: the semver release version, e.g. 1.2.3
+ * @version_b: the semver release version, e.g. 1.2.3.1
+ * @fmt: a #FwupdVersionFormat, e.g. %FWUPD_VERSION_FORMAT_PLAIN
+ *
+ * Compares version numbers for sorting taking into account the version format
+ * if required.
+ *
+ * Returns: -1 if a < b, +1 if a > b, 0 if they are equal, and %G_MAXINT on error
+ *
+ * Since: 1.3.9
+ */
+gint
+fu_common_vercmp_full (const gchar *version_a,
+		       const gchar *version_b,
+		       FwupdVersionFormat fmt)
+{
+	if (fmt == FWUPD_VERSION_FORMAT_PLAIN)
+		return g_strcmp0 (version_a, version_b);
+	return fu_common_vercmp (version_a, version_b);
+}
+
+/**
  * fu_common_vercmp:
  * @version_a: the semver release version, e.g. 1.2.3
  * @version_b: the semver release version, e.g. 1.2.3.1

--- a/libfwupdplugin/fu-common-version.h
+++ b/libfwupdplugin/fu-common-version.h
@@ -10,7 +10,11 @@
 #include <fwupd.h>
 
 gint		 fu_common_vercmp		(const gchar	*version_a,
-						 const gchar	*version_b);
+						 const gchar	*version_b)
+G_DEPRECATED_FOR(fu_common_vercmp_full);
+gint		 fu_common_vercmp_full		(const gchar	*version_a,
+						 const gchar	*version_b,
+						 FwupdVersionFormat fmt);
 gchar		*fu_common_version_from_uint64	(guint64	 val,
 						 FwupdVersionFormat kind);
 gchar		*fu_common_version_from_uint32	(guint32	 val,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -534,6 +534,7 @@ LIBFWUPDPLUGIN_1.3.8 {
 
 LIBFWUPDPLUGIN_1.3.9 {
   global:
+    fu_common_vercmp_full;
     fu_plugin_get_config_value_boolean;
     fu_plugin_runner_device_created;
   local: *;

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -427,7 +427,9 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 	}
 
 	/* minimum EC version this code will support */
-	if (fu_common_vercmp (self->ec_version, self->ec_minimum_version) < 0) {
+	if (fu_common_vercmp_full (self->ec_version,
+				   self->ec_minimum_version,
+				   FWUPD_VERSION_FORMAT_QUAD) < 0) {
 		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
 			     "dock containing EC version %s is not supported",
 			     self->ec_version);
@@ -439,7 +441,7 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 
 	/* Determine if the passive flow should be used when flashing */
 	hub_version = fu_device_get_version (self->symbiote);
-	if (fu_common_vercmp (hub_version, "1.42") >= 0) {
+	if (fu_common_vercmp_full (hub_version, "1.42", FWUPD_VERSION_FORMAT_PAIR) >= 0) {
 		g_debug ("using passive flow");
 		self->passive_flow = PASSIVE_REBOOT_MASK;
 		fu_device_set_custom_flags (device, "skip-restart");

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -199,14 +199,17 @@ fu_dell_dock_tbt_setup (FuDevice *device, GError **error)
 		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PAIR);
 
 	/* minimum version of NVM that supports this feature */
-	if (version == NULL || fu_common_vercmp (version, MIN_NVM) < 0) {
+	if (version == NULL ||
+	    fu_common_vercmp_full (version, MIN_NVM, FWUPD_VERSION_FORMAT_PAIR) < 0) {
 		fu_device_set_update_error (device,
 					   "Updates over I2C are disabled due to insuffient NVM version");
 		return TRUE;
 	}
 	/* minimum Hub2 version that supports this feature */
 	hub_version = fu_device_get_version (self->symbiote);
-	if (fu_common_vercmp (hub_version, self->hub_minimum_version) < 0) {
+	if (fu_common_vercmp_full (hub_version,
+				   self->hub_minimum_version,
+				   FWUPD_VERSION_FORMAT_PAIR) < 0) {
 		fu_device_set_update_error (device,
 					   "Updates over I2C are disabled due to insufficient USB 3.1 G2 hub version");
 		return TRUE;

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -267,7 +267,9 @@ fu_plugin_mm_setup_manager (FuPlugin *plugin)
 	const gchar *version = mm_manager_get_version (priv->manager);
 	GList *list;
 
-	if (fu_common_vercmp (version, MM_REQUIRED_VERSION) < 0) {
+	if (fu_common_vercmp_full (version,
+				   MM_REQUIRED_VERSION,
+				   FWUPD_VERSION_FORMAT_TRIPLET) < 0) {
 		g_warning ("ModemManager %s is available, but need at least %s",
 			   version, MM_REQUIRED_VERSION);
 		return;

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -50,7 +50,9 @@ fu_plugin_thunderbolt_safe_kernel (FuPlugin *plugin, GError **error)
 		return TRUE;
 	}
 
-	if (fu_common_vercmp (name_tmp.release, minimum_kernel) < 0) {
+	if (fu_common_vercmp_full (name_tmp.release,
+				   minimum_kernel,
+				   FWUPD_VERSION_FORMAT_TRIPLET) < 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INTERNAL,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -901,7 +901,7 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 				XbNode *rel = g_ptr_array_index (releases, j);
 				const gchar *rel_ver = xb_node_get_attr (rel, "version");
 				g_autofree gchar *tmp_ver = fu_common_version_parse_from_format (rel_ver, fmt);
-				if (fu_common_vercmp (tmp_ver, version) == 0) {
+				if (fu_common_vercmp_full (tmp_ver, version, fmt) == 0) {
 					release = g_object_ref (rel);
 					break;
 				}
@@ -983,7 +983,10 @@ fu_engine_verify (FuEngine *self, const gchar *device_id, GError **error)
 }
 
 static gboolean
-fu_engine_require_vercmp (XbNode *req, const gchar *version, GError **error)
+fu_engine_require_vercmp (XbNode *req,
+			  const gchar *version,
+			  FwupdVersionFormat fmt,
+			  GError **error)
 {
 	gboolean ret = FALSE;
 	gint rc = 0;
@@ -991,22 +994,22 @@ fu_engine_require_vercmp (XbNode *req, const gchar *version, GError **error)
 	const gchar *version_req = xb_node_get_attr (req, "version");
 
 	if (g_strcmp0 (tmp, "eq") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc == 0;
 	} else if (g_strcmp0 (tmp, "ne") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc != 0;
 	} else if (g_strcmp0 (tmp, "lt") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc < 0;
 	} else if (g_strcmp0 (tmp, "gt") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc > 0;
 	} else if (g_strcmp0 (tmp, "le") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc <= 0;
 	} else if (g_strcmp0 (tmp, "ge") == 0) {
-		rc = fu_common_vercmp (version, version_req);
+		rc = fu_common_vercmp_full (version, version_req, fmt);
 		ret = rc >= 0;
 	} else if (g_strcmp0 (tmp, "glob") == 0) {
 		ret = fu_common_fnmatch (version_req, version);
@@ -1062,7 +1065,9 @@ fu_engine_check_requirement_not_child (FuEngine *self, XbNode *req,
 				     fu_device_get_name (device));
 			return FALSE;
 		}
-		if (fu_engine_require_vercmp (req, version, NULL)) {
+		if (fu_engine_require_vercmp (req, version,
+					      fu_device_get_version_format (child),
+					      NULL)) {
 			g_set_error (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
@@ -1103,7 +1108,9 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req,
 	/* old firmware version */
 	if (xb_node_get_text (req) == NULL) {
 		const gchar *version = fu_device_get_version (device_actual);
-		if (!fu_engine_require_vercmp (req, version, &error_local)) {
+		if (!fu_engine_require_vercmp (req, version,
+					       fu_device_get_version_format (device_actual),
+					       &error_local)) {
 			if (g_strcmp0 (xb_node_get_attr (req, "compare"), "ge") == 0) {
 				g_set_error (error,
 					     FWUPD_ERROR,
@@ -1125,7 +1132,9 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req,
 	/* bootloader version */
 	if (g_strcmp0 (xb_node_get_text (req), "bootloader") == 0) {
 		const gchar *version = fu_device_get_version_bootloader (device_actual);
-		if (!fu_engine_require_vercmp (req, version, &error_local)) {
+		if (!fu_engine_require_vercmp (req, version,
+					       fu_device_get_version_format (device_actual),
+					       &error_local)) {
 			if (g_strcmp0 (xb_node_get_attr (req, "compare"), "ge") == 0) {
 				g_set_error (error,
 					     FWUPD_ERROR,
@@ -1149,7 +1158,9 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req,
 	if (g_strcmp0 (xb_node_get_text (req), "vendor-id") == 0 &&
 	    fu_device_get_vendor_id (device_actual) != NULL) {
 		const gchar *version = fu_device_get_vendor_id (device_actual);
-		if (!fu_engine_require_vercmp (req, version, &error_local)) {
+		if (!fu_engine_require_vercmp (req, version,
+					       fu_device_get_version_format (device_actual),
+					       &error_local)) {
 			g_set_error (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_FILE,
@@ -1193,7 +1204,9 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req,
 		version = fu_device_get_version (device_actual);
 		if (version != NULL &&
 		    xb_node_get_attr (req, "compare") != NULL &&
-		    !fu_engine_require_vercmp (req, version, &error_local)) {
+		    !fu_engine_require_vercmp (req, version,
+					       fu_device_get_version_format (device_actual),
+					       &error_local)) {
 			if (g_strcmp0 (xb_node_get_attr (req, "compare"), "ge") == 0) {
 				g_set_error (error,
 					     FWUPD_ERROR,
@@ -1239,7 +1252,7 @@ fu_engine_check_requirement_id (FuEngine *self, XbNode *req, GError **error)
 			     xb_node_get_text (req));
 		return FALSE;
 	}
-	if (!fu_engine_require_vercmp (req, version, &error_local)) {
+	if (!fu_engine_require_vercmp (req, version, FWUPD_VERSION_FORMAT_UNKNOWN, &error_local)) {
 		if (g_strcmp0 (xb_node_get_attr (req, "compare"), "ge") == 0) {
 			g_set_error (error,
 				     FWUPD_ERROR,
@@ -1774,6 +1787,7 @@ fu_engine_install_release (FuEngine *self,
 			   GError **error)
 {
 	FuPlugin *plugin;
+	FwupdVersionFormat fmt;
 	GBytes *blob_fw;
 	const gchar *tmp = NULL;
 	g_autofree gchar *release_key = NULL;
@@ -1896,9 +1910,10 @@ fu_engine_install_release (FuEngine *self,
 	}
 
 	/* for online updates, verify the version changed if not a re-install */
+	fmt = fu_device_get_version_format (device);
 	if (version_rel != NULL &&
-	    fu_common_vercmp (version_orig, version_rel) != 0 &&
-	    fu_common_vercmp (version_orig, fu_device_get_version (device)) == 0) {
+	    fu_common_vercmp_full (version_orig, version_rel, fmt) != 0 &&
+	    fu_common_vercmp_full (version_orig, fu_device_get_version (device), fmt) == 0) {
 		g_autofree gchar *str = NULL;
 		fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);
 		str = g_strdup_printf ("device version not updated on success, %s != %s",
@@ -1962,7 +1977,7 @@ fu_engine_sort_release_versions_cb (gconstpointer a, gconstpointer b, gpointer u
 		g_prefix_error (helper->error, "failed to get release version: ");
 		return 0;
 	}
-	return fu_common_vercmp (va, vb);
+	return fu_common_vercmp_full (va, vb, fu_device_get_version_format (helper->device));
 }
 
 static gboolean
@@ -3478,12 +3493,14 @@ fu_engine_get_remote_by_id (FuEngine *self, const gchar *remote_id, GError **err
 
 
 static gint
-fu_engine_sort_releases_cb (gconstpointer a, gconstpointer b)
+fu_engine_sort_releases_cb (gconstpointer a, gconstpointer b, gpointer user_data)
 {
+	FuDevice *device = FU_DEVICE (user_data);
 	FwupdRelease *rel_a = FWUPD_RELEASE (*((FwupdRelease **) a));
 	FwupdRelease *rel_b = FWUPD_RELEASE (*((FwupdRelease **) b));
-	return fu_common_vercmp (fwupd_release_get_version (rel_b),
-				fwupd_release_get_version (rel_a));
+	return fu_common_vercmp_full (fwupd_release_get_version (rel_b),
+				      fwupd_release_get_version (rel_a),
+				      fu_device_get_version_format (device));
 }
 
 static gboolean
@@ -3506,6 +3523,7 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 					     GPtrArray *releases,
 					     GError **error)
 {
+	FwupdVersionFormat fmt = fu_device_get_version_format (device);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuInstallTask) task = fu_install_task_new (device, component);
 	g_autoptr(GPtrArray) releases_tmp = NULL;
@@ -3560,8 +3578,9 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 			continue;
 
 		/* test for upgrade or downgrade */
-		vercmp = fu_common_vercmp (fwupd_release_get_version (rel),
-					  fu_device_get_version (device));
+		vercmp = fu_common_vercmp_full (fwupd_release_get_version (rel),
+						fu_device_get_version (device),
+						fmt);
 		if (vercmp > 0)
 			fwupd_release_add_flag (rel, FWUPD_RELEASE_FLAG_IS_UPGRADE);
 		else if (vercmp < 0)
@@ -3569,8 +3588,9 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 
 		/* lower than allowed to downgrade to */
 		if (fu_device_get_version_lowest (device) != NULL &&
-		    fu_common_vercmp (fwupd_release_get_version (rel),
-				      fu_device_get_version_lowest (device)) < 0) {
+		    fu_common_vercmp_full (fwupd_release_get_version (rel),
+					   fu_device_get_version_lowest (device),
+					   fmt) < 0) {
 			fwupd_release_add_flag (rel, FWUPD_RELEASE_FLAG_BLOCKED_VERSION);
 		}
 
@@ -3724,7 +3744,7 @@ fu_engine_get_releases (FuEngine *self, const gchar *device_id, GError **error)
 				     "No releases for device");
 		return NULL;
 	}
-	g_ptr_array_sort (releases, fu_engine_sort_releases_cb);
+	g_ptr_array_sort_with_data (releases, fu_engine_sort_releases_cb, device);
 	return g_steal_pointer (&releases);
 }
 
@@ -3814,7 +3834,7 @@ fu_engine_get_downgrades (FuEngine *self, const gchar *device_id, GError **error
 		}
 		return NULL;
 	}
-	g_ptr_array_sort (releases, fu_engine_sort_releases_cb);
+	g_ptr_array_sort_with_data (releases, fu_engine_sort_releases_cb, device);
 	return g_steal_pointer (&releases);
 }
 
@@ -3962,7 +3982,7 @@ fu_engine_get_upgrades (FuEngine *self, const gchar *device_id, GError **error)
 		}
 		return NULL;
 	}
-	g_ptr_array_sort (releases, fu_engine_sort_releases_cb);
+	g_ptr_array_sort_with_data (releases, fu_engine_sort_releases_cb, device);
 	return g_steal_pointer (&releases);
 }
 
@@ -4239,8 +4259,9 @@ fu_engine_device_inherit_history (FuEngine *self, FuDevice *device)
 	 * we can't just check for version_new=version to allow for re-installs */
 	if (fu_device_has_flag (device_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 		FwupdRelease *release = fu_device_get_release_default (device_history);
-		if (fu_common_vercmp (fu_device_get_version (device),
-				      fwupd_release_get_version (release)) != 0) {
+		if (fu_common_vercmp_full (fu_device_get_version (device),
+					   fwupd_release_get_version (release),
+					   fu_device_get_version_format (device)) != 0) {
 			g_debug ("inheriting needs-activation for %s as version %s != %s",
 				 fu_device_get_name (device),
 				 fu_device_get_version (device),
@@ -5007,8 +5028,9 @@ fu_engine_update_history_device (FuEngine *self, FuDevice *dev_history, GError *
 	}
 
 	/* the system is running with the new firmware version */
-	if (fu_common_vercmp (fu_device_get_version (dev),
-			      fwupd_release_get_version (rel_history)) == 0) {
+	if (fu_common_vercmp_full (fu_device_get_version (dev),
+				   fwupd_release_get_version (rel_history),
+				   fu_device_get_version_format (dev)) == 0) {
 		GPtrArray *checksums;
 		g_debug ("installed version %s matching history %s",
 			 fu_device_get_version (dev),

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -345,7 +345,8 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	/* compare to the lowest supported version, if it exists */
 	version_lowest = fu_device_get_version_lowest (self->device);
 	if (version_lowest != NULL &&
-	    fu_common_vercmp (version_lowest, version) > 0 &&
+	    fu_common_vercmp_full (version_lowest, version,
+				   fu_device_get_version_format (self->device)) > 0 &&
 	    (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
@@ -358,12 +359,12 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	/* check semver */
 	if (fu_device_get_version_format (self->device) == FWUPD_VERSION_FORMAT_PLAIN) {
 		version_release = g_strdup (version_release_raw);
-		vercmp = g_strcmp0 (version, version_release);
 	} else {
 		version_release = fu_common_version_parse_from_format (version_release_raw,
 								       fu_device_get_version_format (self->device));
-		vercmp = fu_common_vercmp (version, version_release);
 	}
+	vercmp = fu_common_vercmp_full (version, version_release,
+					fu_device_get_version_format (self->device));
 	if (vercmp == 0 && (flags & FWUPD_INSTALL_FLAG_ALLOW_REINSTALL) == 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,

--- a/src/fu-offline.c
+++ b/src/fu-offline.c
@@ -219,8 +219,9 @@ main (int argc, char *argv[])
 			continue;
 
 		/* tell the user what's going to happen */
-		vercmp = fu_common_vercmp (fwupd_device_get_version (dev),
-					   fwupd_release_get_version (rel));
+		vercmp = fu_common_vercmp_full (fwupd_device_get_version (dev),
+						fwupd_release_get_version (rel),
+						fwupd_device_get_version_format (dev));
 		if (vercmp == 0) {
 			/* TRANSLATORS: the first replacement is a display name
 			 * e.g. "ColorHugALS" and the second is a version number

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2110,8 +2110,9 @@ fu_util_reinstall (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	for (guint j = 0; j < rels->len; j++) {
 		FwupdRelease *rel_tmp = g_ptr_array_index (rels, j);
-		if (fu_common_vercmp (fwupd_release_get_version (rel_tmp),
-		    fu_device_get_version (dev)) == 0) {
+		if (fu_common_vercmp_full (fwupd_release_get_version (rel_tmp),
+					   fu_device_get_version (dev),
+					   fwupd_device_get_version_format (dev)) == 0) {
 			rel = g_object_ref (rel_tmp);
 			break;
 		}


### PR DESCRIPTION
In 1de7cc we checked the version format when checking for update, but there are
many other places that are doing verfmt-insensitive comparisons. For instance,
the predicates in <requires> all fail if the device version format is plain.
his breaks updating some NVMe drives where the `ne` requirements are not
semantic versions.

To avoid trying to catch all the bugs in different places, and in case we have
a future verfmt that should be treated another way, refactor this out in to a
common function and deprecate the old function.
