### PR TITLE
uefi: For UEFI device firmware don't default to triplet

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -472,7 +472,7 @@ fu_plugin_uefi_get_version_format_for_type (FuPlugin *plugin, FuUefiDeviceKind d
 
 	/* we have no information for devices */
 	if (device_kind == FU_UEFI_DEVICE_KIND_DEVICE_FIRMWARE)
-		return FWUPD_VERSION_FORMAT_TRIPLET;
+		return FWUPD_VERSION_FORMAT_PLAIN;
 
 	content = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER);
 	if (content == NULL)


### PR DESCRIPTION
By definition if we don't know the format that the vendor is using
we should be defaulting to a plain integer instead.

This matches what Windows device manager renders for
Firmware Resource version as well.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
