### PR TITLE
fu-device-list: Check protocol before de-duping devices

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -569,9 +569,12 @@ fu_device_list_add (FuDeviceList *self, FuDevice *device)
 		return;
 	}
 
-	/* added the same device from a different plugin */
-	if (item != NULL && g_strcmp0 (fu_device_get_plugin (item->device),
-				       fu_device_get_plugin (device)) != 0) {
+	/* added the same device, supporting same protocol, from a different plugin */
+	if (item != NULL &&
+	    g_strcmp0 (fu_device_get_plugin (item->device),
+		       fu_device_get_plugin (device)) != 0 &&
+	    g_strcmp0 (fu_device_get_protocol (item->device),
+		       fu_device_get_protocol (device)) == 0) {
 		if (fu_device_get_priority (device) < fu_device_get_priority (item->device)) {
 			g_debug ("ignoring device %s [%s] as better device %s [%s] already exists",
 				 fu_device_get_id (device),


### PR DESCRIPTION
Some Dell devices offer the exact same GUID in UEFI as well as in NVME
plugins.  These devices can be flashed in either way, but the payload
for them is different.

The UEFI payload includes relevant headers and metadata to be acceptable
from a capsule.  The NVME payload is raw data that the drive will process.

Since baa9e75ca86f29239de03f7ab86a3e1309c37ac0, fwupd should enforce that
the correct device is flashed with the correct protocol.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
