### PR TITLE
Remove support for GCab less than v1.0

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -642,7 +642,6 @@ fu_common_endian_func (void)
 static GBytes *
 _build_cab (GCabCompression compression, ...)
 {
-#ifdef HAVE_GCAB_1_0
 	gboolean ret;
 	va_list args;
 	g_autoptr(GCabCabinet) cabinet = NULL;
@@ -694,9 +693,6 @@ _build_cab (GCabCompression compression, ...)
 	g_assert_no_error (error);
 	g_assert (ret);
 	return g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (op));
-#else
-	return NULL;
-#endif
 }
 
 static void
@@ -734,10 +730,6 @@ fu_common_store_cab_func (void)
 			   "firmware.dfu", "world",
 			   "firmware.dfu.asc", "signature",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (silo);
@@ -784,10 +776,6 @@ fu_common_store_cab_unsigned_func (void)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (silo);
@@ -829,10 +817,6 @@ fu_common_store_cab_folder_func (void)
 	"</component>",
 			   "lvfs\\firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (silo);
@@ -860,10 +844,6 @@ fu_common_store_cab_error_no_metadata_func (void)
 			   "foo.txt", "hello",
 			   "bar.txt", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null (silo);
@@ -889,10 +869,6 @@ fu_common_store_cab_error_wrong_size_func (void)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null (silo);
@@ -917,10 +893,6 @@ fu_common_store_cab_error_missing_file_func (void)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null (silo);
@@ -943,10 +915,6 @@ fu_common_store_cab_error_size_func (void)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 123, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null (silo);
@@ -971,10 +939,6 @@ fu_common_store_cab_error_wrong_checksum_func (void)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null (silo);

--- a/meson.build
+++ b/meson.build
@@ -219,13 +219,7 @@ if get_option('gpg')
   conf.set('ENABLE_GPG', '1')
 endif
 libm = cc.find_library('m', required: false)
-libgcab = dependency('libgcab-1.0', fallback : ['gcab', 'gcab_dep'])
-if libgcab.version().version_compare('>= 0.8')
-  conf.set('HAVE_GCAB_0_8', '1')
-endif
-if libgcab.version().version_compare('>= 1.0')
-  conf.set('HAVE_GCAB_1_0', '1')
-endif
+libgcab = dependency('libgcab-1.0', version : '>= 1.0', fallback : ['gcab', 'gcab_dep'])
 gcab = find_program('gcab', required : true)
 bashcomp = dependency('bash-completion', required: false)
 python3 = find_program('python3')

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1086,7 +1086,7 @@ fu_engine_require_hwid_func (gconstpointer user_data)
 	g_autoptr(XbSilo) silo_empty = xb_silo_new ();
 	g_autoptr(XbSilo) silo = NULL;
 
-#if !defined(HAVE_GCAB_0_8) && defined(__s390x__)
+#if defined(__s390x__)
 	/* See https://github.com/fwupd/fwupd/issues/318 for more information */
 	g_test_skip ("Skipping HWID test on s390x due to known problem with gcab");
 	return;
@@ -2747,7 +2747,6 @@ fu_keyring_pkcs7_self_signed_func (gconstpointer user_data)
 static GBytes *
 _build_cab (GCabCompression compression, ...)
 {
-#ifdef HAVE_GCAB_1_0
 	gboolean ret;
 	va_list args;
 	g_autoptr(GCabCabinet) cabinet = NULL;
@@ -2799,9 +2798,6 @@ _build_cab (GCabCompression compression, ...)
 	g_assert_no_error (error);
 	g_assert (ret);
 	return g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (op));
-#else
-	return NULL;
-#endif
 }
 
 static void
@@ -2868,10 +2864,6 @@ fu_plugin_composite_func (gconstpointer user_data)
 	"</component>",
 			   "firmware.bin", "world",
 			   NULL);
-	if (blob == NULL) {
-		g_test_skip ("libgcab too old");
-		return;
-	}
 	silo = fu_common_cab_build_silo (blob, 10240, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (silo);


### PR DESCRIPTION
We can fall back to the subproject version if required for CI targets.