### PR TITLE
Decouple the version format from the version itself

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -106,9 +106,6 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_update_state(d,v)		fwupd_device_set_update_state(FWUPD_DEVICE(d),v)
 #define fu_device_set_vendor(d,v)		fwupd_device_set_vendor(FWUPD_DEVICE(d),v)
 #define fu_device_set_vendor_id(d,v)		fwupd_device_set_vendor_id(FWUPD_DEVICE(d),v)
-#define fu_device_set_version_lowest(d,v)	fwupd_device_set_version_lowest(FWUPD_DEVICE(d),v)
-#define fu_device_set_version_bootloader(d,v)	fwupd_device_set_version_bootloader(FWUPD_DEVICE(d),v)
-#define fu_device_set_version_format(d,v)	fwupd_device_set_version_format(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_raw(d,v)		fwupd_device_set_version_raw(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_lowest_raw(d,v)	fwupd_device_set_version_lowest_raw(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_bootloader_raw(d,v)	fwupd_device_set_version_bootloader_raw(FWUPD_DEVICE(d),v)
@@ -183,9 +180,14 @@ void		 fu_device_set_metadata_integer		(FuDevice	*self,
 							 guint		 value);
 void		 fu_device_set_id			(FuDevice	*self,
 							 const gchar	*id);
-void		 fu_device_set_version			(FuDevice	*self,
-							 const gchar	*version,
+void		 fu_device_set_version_format		(FuDevice	*self,
 							 FwupdVersionFormat fmt);
+void		 fu_device_set_version			(FuDevice	*self,
+							 const gchar	*version);
+void		 fu_device_set_version_lowest		(FuDevice	*self,
+							 const gchar	*version);
+void		 fu_device_set_version_bootloader	(FuDevice	*self,
+							 const gchar	*version);
 const gchar	*fu_device_get_physical_id		(FuDevice	*self);
 void		 fu_device_set_physical_id		(FuDevice	*self,
 							 const gchar	*physical_id);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -145,7 +145,8 @@ fu_device_version_format_func (void)
 {
 	g_autoptr(FuDevice) device = fu_device_new ();
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ENSURE_SEMVER);
-	fu_device_set_version (device, "Ver1.2.3 RELEASE", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "Ver1.2.3 RELEASE");
 	g_assert_cmpstr (fu_device_get_version (device), ==, "1.2.3");
 }
 

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -243,10 +243,12 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	}
 
 	/* set the version if the revision has been set */
-	if (fu_device_get_version (device) == NULL) {
+	if (fu_device_get_version (device) == NULL &&
+	    fu_device_get_version_format (device) == FWUPD_VERSION_FORMAT_UNKNOWN) {
 		if (priv->revision != 0x00) {
 			g_autofree gchar *version = g_strdup_printf ("%02x", priv->revision);
-			fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (device, version);
 		}
 	}
 
@@ -284,10 +286,11 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 	}
 
 	/* set revision */
-	if (fu_device_get_version (device) == NULL) {
+	if (fu_device_get_version (device) == NULL &&
+	    fu_device_get_version_format (device) == FWUPD_VERSION_FORMAT_UNKNOWN) {
 		tmp = g_udev_device_get_property (priv->udev_device, "ID_REVISION");
 		if (tmp != NULL)
-			fu_device_set_version (device, tmp, FWUPD_VERSION_FORMAT_UNKNOWN);
+			fu_device_set_version (device, tmp);
 	}
 
 	/* set vendor ID */

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -231,7 +231,8 @@ fu_usb_device_open (FuDevice *device, GError **error)
 		/* although guessing is a route to insanity, if the device has
 		 * provided the extra data it's because the BCD type was not
 		 * suitable -- and INTEL_ME is not relevant here */
-		fu_device_set_version (device, tmp, fu_common_version_guess_format (tmp));
+		fu_device_set_version_format (device, fu_common_version_guess_format (tmp));
+		fu_device_set_version (device, tmp);
 	}
 
 	/* get GUID from the descriptor if set */
@@ -304,10 +305,12 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 
 	/* set the version if the release has been set */
 	release = g_usb_device_get_release (priv->usb_device);
-	if (release != 0x0) {
+	if (release != 0x0 &&
+	    fu_device_get_version_format (device) == FWUPD_VERSION_FORMAT_UNKNOWN) {
 		g_autofree gchar *version = NULL;
 		version = fu_common_version_from_uint16 (release, FWUPD_VERSION_FORMAT_BCD);
-		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_BCD);
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_BCD);
+		fu_device_set_version (device, version);
 	}
 
 	/* add GUIDs in order of priority */

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -535,6 +535,9 @@ LIBFWUPDPLUGIN_1.3.8 {
 LIBFWUPDPLUGIN_1.3.9 {
   global:
     fu_common_vercmp_full;
+    fu_device_set_version_bootloader;
+    fu_device_set_version_format;
+    fu_device_set_version_lowest;
     fu_plugin_get_config_value_boolean;
     fu_plugin_runner_device_created;
   local: *;

--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -492,8 +492,7 @@ fu_altos_device_probe_bootloader (FuAltosDevice *self, GError **error)
 
 		/* version number */
 		if (g_str_has_prefix (lines[i], "software-version ")) {
-			fu_device_set_version (FU_DEVICE (self), lines[i] + 17,
-					       FWUPD_VERSION_FORMAT_TRIPLET);
+			fu_device_set_version (FU_DEVICE (self), lines[i] + 17);
 			continue;
 		}
 
@@ -549,8 +548,7 @@ fu_altos_device_probe (FuDevice *device, GError **error)
 			     version);
 		return FALSE;
 	}
-	fu_device_set_version (FU_DEVICE (self), version + 19,
-			       FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (FU_DEVICE (self), version + 19);
 
 	/* success */
 	return TRUE;
@@ -560,6 +558,7 @@ static void
 fu_altos_device_init (FuAltosDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_vendor (FU_DEVICE (self), "altusmetrum.org");
 	fu_device_set_summary (FU_DEVICE (self), "A USB hardware random number generator");
 	fu_device_set_protocol (FU_DEVICE (self), "org.altusmetrum.altos");

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -531,8 +531,9 @@ fu_plugin_amt_create_device (GError **error)
 			continue;
 		}
 	}
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_INTEL_ME);
 	if (version_fw->len > 0)
-		fu_device_set_version (dev, version_fw->str, FWUPD_VERSION_FORMAT_INTEL_ME);
+		fu_device_set_version (dev, version_fw->str);
 	if (version_bl->len > 0)
 		fu_device_set_version_bootloader (dev, version_bl->str);
 

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -382,9 +382,7 @@ fu_ata_device_parse_id (FuAtaDevice *self, const guint8 *buf, gsize sz, GError *
 		g_autofree gchar *tmp = NULL;
 		tmp = fu_ata_device_get_string (id, 23, 26);
 		if (tmp != NULL)
-			fu_device_set_version (device, tmp, FWUPD_VERSION_FORMAT_PLAIN);
-	} else {
-		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (device, tmp);
 	}
 
 	/* get OUI if set */
@@ -837,6 +835,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_set_protocol (FU_DEVICE (self), "org.t13.ata");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 }
 

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -326,7 +326,7 @@ fu_colorhug_device_setup (FuDevice *device, GError **error)
 		version = fu_colorhug_device_get_version (self, &error_local);
 		if (version != NULL) {
 			g_debug ("obtained fwver using API '%s'", version);
-			fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_TRIPLET);
+			fu_device_set_version (device, version);
 		} else {
 			g_warning ("failed to get firmware version: %s",
 				   error_local->message);
@@ -456,6 +456,7 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 	/* this is the application code */
 	self->start_addr = CH_EEPROM_ADDR_RUNCODE;
 	fu_device_set_protocol (FU_DEVICE (self), "com.hughski.colorhug");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_remove_delay (FU_DEVICE (self),
 				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/coreboot/fu-plugin-coreboot.c
+++ b/plugins/coreboot/fu-plugin-coreboot.c
@@ -77,8 +77,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		return FALSE;
 	}
 	dev = fu_device_new ();
-
-	fu_device_set_version (dev, triplet, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (dev, triplet);
 	fu_device_set_summary (dev, "Open Source system boot firmware");
 	fu_device_set_id (dev, "coreboot");
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -185,7 +185,8 @@ fu_dell_dock_hid_get_hub_version (FuDevice *self,
 	version = g_strdup_printf ("%02x.%02x",
 				   cmd_buffer.data[10],
 				   cmd_buffer.data[11]);
-	fu_device_set_version (self, version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version_format (self, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (self, version);
 	return TRUE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -113,7 +113,8 @@ fu_dell_dock_hub_write_fw (FuDevice *device,
 
 	/* dock will reboot to re-read; this is to appease the daemon */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (device, dynamic_version);
 	return TRUE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -372,7 +372,8 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 			    device_entry[i].version.version_8[2],
 			    device_entry[i].version.version_8[3]);
 			g_debug ("\tParsed version %s", self->ec_version);
-			fu_device_set_version (FU_DEVICE (self), self->ec_version, FWUPD_VERSION_FORMAT_QUAD);
+			fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
+			fu_device_set_version (FU_DEVICE (self), self->ec_version);
 
 		} else if (map->device_type == FU_DELL_DOCK_DEVICETYPE_MST) {
 			self->raw_versions->mst_version = device_entry[i].version.version_32;
@@ -792,7 +793,8 @@ fu_dell_dock_ec_write_fw (FuDevice *device,
 		return FALSE;
 
 	/* dock will reboot to re-read; this is to appease the daemon */
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, dynamic_version);
 
 	/* activate passive behavior */
 	if (self->passive_flow)

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -846,7 +846,8 @@ fu_dell_dock_mst_write_fw (FuDevice *device,
 
 	/* dock will reboot to re-read; this is to appease the daemon */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, dynamic_version);
 
 	/* disable remote control now */
 	return fu_dell_dock_mst_disable_remote_control (self->symbiote, error);
@@ -912,8 +913,10 @@ fu_dell_dock_mst_setup (FuDevice *device, GError **error)
 	/* set version from EC if we know it */
 	parent = fu_device_get_parent (device);
 	version = fu_dell_dock_ec_get_mst_version (parent);
-	if (version != NULL)
-		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_TRIPLET);
+	if (version != NULL) {
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+		fu_device_set_version (device, version);
+	}
 
 	fu_dell_dock_clone_updatable (device);
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -137,7 +137,8 @@ fu_dell_dock_tbt_write_fw (FuDevice *device,
 
 	/* dock will reboot to re-read; this is to appease the daemon */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (device, dynamic_version);
 
 	return TRUE;
 }
@@ -195,8 +196,10 @@ fu_dell_dock_tbt_setup (FuDevice *device, GError **error)
 	/* set version from EC if we know it */
 	parent = fu_device_get_parent (device);
 	version = fu_dell_dock_ec_get_tbt_version (parent);
-	if (version != NULL)
-		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PAIR);
+	if (version != NULL) {
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (device, version);
+	}
 
 	/* minimum version of NVM that supports this feature */
 	if (version == NULL ||

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -48,7 +48,8 @@ fu_dell_dock_status_setup (FuDevice *device, GError **error)
 	status_version = fu_dell_dock_ec_get_status_version (parent);
 
 	dynamic_version = fu_dell_dock_status_ver_string (status_version);
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, dynamic_version);
 	fu_device_set_logical_id (FU_DEVICE (device), "status");
 
 	fu_dell_dock_clone_updatable (device);
@@ -91,7 +92,8 @@ fu_dell_dock_status_write (FuDevice *device,
 
 	/* dock will reboot to re-read; this is to appease the daemon */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_set_version (device, dynamic_version, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, dynamic_version);
 	return TRUE;
 }
 

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -166,7 +166,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_set_vendor_id (dev, "PCI:0x1028");
 	fu_device_add_instance_id (dev, "main-system-firmware");
 	fu_device_add_guid (dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
-	fu_device_set_version (dev, "0", FWUPD_VERSION_FORMAT_NUMBER);
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_NUMBER);
+	fu_device_set_version (dev, "0");
 	fu_device_add_icon (dev, "computer");
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -297,8 +297,9 @@ fu_plugin_dock_node (FuPlugin *plugin, const gchar *platform,
 	fu_device_add_icon (dev, "computer");
 	fu_device_add_guid (dev, component_guid);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_set_version_format (dev, version_format);
 	if (version != NULL) {
-		fu_device_set_version (dev, version, version_format);
+		fu_device_set_version (dev, version);
 		if (fu_plugin_dell_capsule_supported (plugin)) {
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
@@ -738,7 +739,8 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	fu_device_set_vendor_id (dev, "PCI:0x1028");
 	fu_device_set_name (dev, pretty_tpm_name);
 	fu_device_set_summary (dev, "Platform TPM device");
-	fu_device_set_version (dev, version_str, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (dev, version_str);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_icon (dev, "computer");

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -227,8 +227,9 @@ fu_ebitdo_device_set_version (FuEbitdoDevice *self, guint32 version)
 {
 	g_autofree gchar *tmp = NULL;
 	tmp = g_strdup_printf ("%u.%02u", version / 100, version % 100);
-	fu_device_set_version (FU_DEVICE (self), tmp, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_version_raw (FU_DEVICE (self), version);
+	fu_device_set_version (FU_DEVICE (self), tmp);
 }
 
 static gboolean

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -216,8 +216,10 @@ fu_emmc_device_probe (FuUdevDevice *device, GError **error)
 
 	/* firwmare version */
 	tmp = g_udev_device_get_sysfs_attr (udev_parent, "fwrev");
-	if (tmp != NULL)
-		fu_device_set_version (FU_DEVICE (device), tmp, FWUPD_VERSION_FORMAT_NUMBER);
+	if (tmp != NULL) {
+		fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_NUMBER);
+		fu_device_set_version (FU_DEVICE (device), tmp);
+	}
 
 	return TRUE;
 }

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -318,8 +318,10 @@ fu_fastboot_device_setup (FuDevice *device, GError **error)
 	/* bootloader version */
 	if (!fu_fastboot_device_getvar (device, "version-bootloader", &version_bootloader, error))
 		return FALSE;
-	if (version_bootloader != NULL && version_bootloader[0] != '\0')
+	if (version_bootloader != NULL && version_bootloader[0] != '\0') {
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PAIR);
 		fu_device_set_version_bootloader (device, version_bootloader);
+	}
 
 	/* serialno */
 	if (!fu_fastboot_device_getvar (device, "serialno", &serialno, error))

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -108,9 +108,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 			fu_device_set_name (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_NAME));
 			fu_device_set_vendor (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER));
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_ENSURE_SEMVER);
-			fu_device_set_version (dev,
-					       fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION),
-					       FWUPD_VERSION_FORMAT_UNKNOWN);
+			fu_device_set_version (dev, fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION));
 			fu_device_add_guid (dev, guid);
 			if (dmi_vendor != NULL) {
 				g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -179,7 +179,7 @@ fu_fresco_pd_device_setup (FuDevice *device, GError **error)
 		}
 	}
 	version = fu_fresco_pd_version_from_buf (ver);
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (FU_DEVICE (self), version);
 
 	/* get customer ID */
 	self->customer_id = ver[1];
@@ -401,6 +401,7 @@ fu_fresco_pd_device_init (FuFrescoPdDevice *self)
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_protocol (FU_DEVICE (self), "com.frescologic.pd");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_install_duration (FU_DEVICE (self), 15);
 	fu_device_set_remove_delay (FU_DEVICE (self), 20000);
 	fu_device_set_firmware_size (FU_DEVICE (self), 0x4400);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -70,11 +70,9 @@ fu_logitech_hidpp_bootloader_nordic_setup (FuLogitechHidPpBootloader *self, GErr
 	if (version_fw == NULL) {
 		g_warning ("failed to get firmware version: %s",
 			   error_local->message);
-		fu_device_set_version (FU_DEVICE (self), "RQR12.00_B0000",
-				       FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (FU_DEVICE (self), "RQR12.00_B0000");
 	} else {
-		fu_device_set_version (FU_DEVICE (self), version_fw,
-				       FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (FU_DEVICE (self), version_fw);
 	}
 
 	return TRUE;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -221,8 +221,7 @@ fu_logitech_hidpp_bootloader_texas_write_firmware (FuDevice *device,
 static gboolean
 fu_logitech_hidpp_bootloader_texas_setup (FuLogitechHidPpBootloader *self, GError **error)
 {
-	fu_device_set_version (FU_DEVICE (self), "RQR24.00_B0000",
-			       FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (FU_DEVICE (self), "RQR24.00_B0000");
 	return TRUE;
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -445,9 +445,9 @@ fu_logitech_hidpp_bootloader_init (FuLogitechHidPpBootloader *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_icon (FU_DEVICE (self), "preferences-desktop-keyboard");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_name (FU_DEVICE (self), "Unifying Receiver");
 	fu_device_set_summary (FU_DEVICE (self), "A miniaturised USB wireless receiver (bootloader)");
-	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_UNIFYING_DEVICE_TIMEOUT_MS);
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -343,8 +343,7 @@ fu_logitech_hidpp_peripheral_fetch_firmware_info (FuLogitechHidPpPeripheral *sel
 					     build);
 		g_debug ("firmware entity 0x%02x version is %s", i, version);
 		if (msg->data[0] == 0) {
-			fu_device_set_version (FU_DEVICE (self), version,
-					       FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (FU_DEVICE (self), version);
 			self->cached_fw_entity = i;
 		} else if (msg->data[0] == 1) {
 			fu_device_set_version_bootloader (FU_DEVICE (self), version);
@@ -596,9 +595,7 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 		fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		if (fu_device_get_version (device) == NULL) {
 			g_debug ("repairing device in bootloader mode");
-			fu_device_set_version (FU_DEVICE (device),
-					       "MPK00.00_B0000",
-					       FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (FU_DEVICE (device), "MPK00.00_B0000");
 		}
 	}
 
@@ -1022,6 +1019,7 @@ fu_logitech_hidpp_peripheral_init (FuLogitechHidPpPeripheral *self)
 	fu_device_add_parent_guid (FU_DEVICE (self), "HIDRAW\\VEN_046D&DEV_C52B");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_protocol (FU_DEVICE (self), "com.logitech.unifying");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 
 	/* there are a lot of unifying peripherals, but not all respond
 	 * well to opening -- so limit to ones with issued updates */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -214,7 +214,7 @@ fu_logitech_hidpp_runtime_setup_internal (FuDevice *device, GError **error)
 						 config[3],
 						 (guint16) config[4] << 8 |
 						 config[5]);
-	fu_device_set_version (device, version_fw, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (device, version_fw);
 
 	/* get bootloader version */
 	if (self->version_bl_major > 0) {
@@ -320,6 +320,7 @@ static void
 fu_logitech_hidpp_runtime_init (FuLogitechHidPpRuntime *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_add_icon (FU_DEVICE (self), "preferences-desktop-keyboard");
 	fu_device_set_name (FU_DEVICE (self), "Unifying Receiver");
 	fu_device_set_summary (FU_DEVICE (self), "A miniaturised USB wireless receiver");

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -236,7 +236,7 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 		fu_device_set_vendor (device, mm_modem_get_manufacturer (modem));
 	if (mm_modem_get_model (modem) != NULL)
 		fu_device_set_name (device, mm_modem_get_model (modem));
-	fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (device, version);
 	for (guint i = 0; device_ids[i] != NULL; i++)
 		fu_device_add_instance_id (device, device_ids[i]);
 
@@ -710,6 +710,7 @@ fu_mm_device_init (FuMmDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary (FU_DEVICE (self), "Mobile broadband device");
 	fu_device_add_icon (FU_DEVICE (self), "network-modem");
 }
@@ -804,7 +805,7 @@ fu_mm_device_udev_new (MMManager *manager,
 	fu_device_set_physical_id (FU_DEVICE (self), info->physical_id);
 	fu_device_set_vendor (FU_DEVICE (self), info->vendor);
 	fu_device_set_name (FU_DEVICE (self), info->name);
-	fu_device_set_version (FU_DEVICE (self), info->version, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (FU_DEVICE (self), info->version);
 	self->update_methods = info->update_methods;
 	self->detach_fastboot_at = g_strdup (info->detach_fastboot_at);
 	self->port_at_ifnum = info->port_at_ifnum;

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -185,7 +185,7 @@ fu_nitrokey_device_setup (FuDevice *device, GError **error)
 		fu_common_dump_raw (G_LOG_DOMAIN, "payload", buf_reply, sizeof(buf_reply));
 	memcpy (&payload, buf_reply, sizeof(payload));
 	version = g_strdup_printf ("%u.%u", payload.VersionMajor, payload.VersionMinor);
-	fu_device_set_version (FU_DEVICE (device), version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (FU_DEVICE (device), version);
 
 	/* success */
 	return TRUE;
@@ -211,6 +211,7 @@ fu_nitrokey_device_init (FuNitrokeyDevice *device)
 {
 	fu_device_set_remove_delay (FU_DEVICE (device), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_PAIR);
 }
 
 static void

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -190,7 +190,8 @@ fu_nvme_device_set_version (FuNvmeDevice *self, const gchar *version, GError **e
 
 	/* unset */
 	if (fmt == FWUPD_VERSION_FORMAT_UNKNOWN || fmt == FWUPD_VERSION_FORMAT_PLAIN) {
-		fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (FU_DEVICE (self), version);
 		return TRUE;
 	}
 
@@ -207,7 +208,8 @@ fu_nvme_device_set_version (FuNvmeDevice *self, const gchar *version, GError **e
 			return FALSE;
 		}
 		version_new = fu_common_version_from_uint32 (tmp, FWUPD_VERSION_FORMAT_QUAD);
-		fu_device_set_version (FU_DEVICE (self), version_new, fmt);
+		fu_device_set_version_format (FU_DEVICE (self), fmt);
+		fu_device_set_version (FU_DEVICE (self), version_new);
 		return TRUE;
 	}
 

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -68,8 +68,7 @@ fu_optionrom_device_read_firmware (FuDevice *device, GError **error)
 			 fu_device_get_id (device),
 			 fu_device_get_version (device),
 			 fu_rom_get_version (rom));
-		fu_device_set_version (device, fu_rom_get_version (rom),
-				       FWUPD_VERSION_FORMAT_UNKNOWN);
+		fu_device_set_version (device, fu_rom_get_version (rom));
 	}
 
 	/* Also add the GUID from the firmware as the firmware may be more

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -129,10 +129,8 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 	if (json_object_has_member (member, "Name"))
 		fu_device_set_name (dev, json_object_get_string_member (member, "Name"));
 	fu_device_set_summary (dev, "Redfish device");
-	if (json_object_has_member (member, "Version")) {
-		fu_device_set_version (dev, json_object_get_string_member (member, "Version"),
-				       FWUPD_VERSION_FORMAT_UNKNOWN);
-	}
+	if (json_object_has_member (member, "Version"))
+		fu_device_set_version (dev, json_object_get_string_member (member, "Version"));
 	if (json_object_has_member (member, "LowestSupportedVersion"))
 		fu_device_set_version_lowest (dev, json_object_get_string_member (member, "LowestSupportedVersion"));
 	if (json_object_has_member (member, "Description"))

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -246,7 +246,7 @@ fu_rts54hid_device_ensure_status (FuRts54HidDevice *self, GError **error)
 
 	/* hub version is more accurate than bcdVersion */
 	version = g_strdup_printf ("%x.%x", buf[0x40 + 10], buf[0x40 + 11]);
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (FU_DEVICE (self), version);
 	return TRUE;
 }
 
@@ -378,6 +378,7 @@ static void
 fu_rts54hid_device_init (FuRts54HidDevice *self)
 {
 	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 
 static void

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -63,14 +63,6 @@ fu_solokey_device_exchange (GByteArray *req, guint8 cmd, guint32 addr, GByteArra
 }
 
 static gboolean
-fu_solokey_device_probe (FuUsbDevice *device, GError **error)
-{
-	/* always disregard the bcdVersion */
-	fu_device_set_version (FU_DEVICE (device), NULL, FWUPD_VERSION_FORMAT_UNKNOWN);
-	return TRUE;
-}
-
-static gboolean
 fu_solokey_device_open (FuUsbDevice *device, GError **error)
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
@@ -124,7 +116,7 @@ fu_solokey_device_open (FuUsbDevice *device, GError **error)
 		fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		fu_device_remove_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER);
 	} else {
-		fu_device_set_version (FU_DEVICE (device), split[1], FWUPD_VERSION_FORMAT_TRIPLET);
+		fu_device_set_version (FU_DEVICE (device), split[1]);
 		fu_device_remove_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER);
 	}
@@ -487,6 +479,7 @@ fu_solokey_device_init (FuSolokeyDevice *self)
 	self->cid = 0xffffffff;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_protocol (FU_DEVICE (self), "com.solokeys");
 	fu_device_set_name (FU_DEVICE (self), "Solo Secure");
 	fu_device_set_summary (FU_DEVICE (self), "An open source FIDO2 security key");
@@ -503,5 +496,4 @@ fu_solokey_device_class_init (FuSolokeyDeviceClass *klass)
 	klass_device->setup = fu_solokey_device_setup;
 	klass_usb_device->open = fu_solokey_device_open;
 	klass_usb_device->close = fu_solokey_device_close;
-	klass_usb_device->probe = fu_solokey_device_probe;
 }

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -87,7 +87,7 @@ fu_steelseries_device_setup (FuDevice *device, GError **error)
 		return FALSE;
 	}
 	version = g_strdup_printf ("%i.%i.%i", data[0], data[1], data[2]);
-	fu_device_set_version (FU_DEVICE (device), version, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (FU_DEVICE (device), version);
 
 	/* success */
 	return TRUE;
@@ -114,6 +114,7 @@ fu_steelseries_device_close (FuUsbDevice *device, GError **error)
 static void
 fu_steelseries_device_init (FuSteelseriesDevice *device)
 {
+	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_TRIPLET);
 }
 
 static void

--- a/plugins/superio/fu-superio-it85-device.c
+++ b/plugins/superio/fu-superio-it85-device.c
@@ -59,7 +59,7 @@ fu_superio_it85_device_setup (FuSuperioDevice *self, GError **error)
 		g_prefix_error (error, "failed to get EC version: ");
 		return FALSE;
 	}
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_UNKNOWN);
+	fu_device_set_version (FU_DEVICE (self), version);
 	return TRUE;
 }
 

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -111,7 +111,7 @@ fu_superio_it89_device_setup (FuSuperioDevice *self, GError **error)
 		return FALSE;
 	}
 	version = g_strdup_printf ("%02u.%02u", version_tmp[0], version_tmp[1]);
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (FU_DEVICE (self), version);
 
 	/* get size from the EC */
 	if (!fu_superio_it89_device_ec_size (self, error))
@@ -670,6 +670,7 @@ fu_superio_it89_device_init (FuSuperioIt89Device *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ONLY_OFFLINE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 
 static void

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -624,7 +624,7 @@ fu_synaptics_cxaudio_device_setup (FuDevice *device, GError **error)
 	}
 	version_patch = g_strdup_printf ("%02X-%02X-%02X",
 					 verbuf_patch[0], verbuf_patch[1], verbuf_patch[2]);
-	fu_device_set_version (device, version_patch, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (device, version_patch);
 
 	/* find out if patch supports additional capabilities (optional) */
 	cap_str = g_usb_device_get_string_descriptor (usb_device,
@@ -850,6 +850,7 @@ fu_synaptics_cxaudio_device_init (FuSynapticsCxaudioDevice *self)
 	self->sw_reset_supported = TRUE;
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_install_duration (FU_DEVICE (self), 3); /* seconds */
 	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.cxaudio");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -73,6 +73,7 @@ fu_synaptics_mst_device_init (FuSynapticsMstDevice *self)
 	fu_device_set_vendor_id (FU_DEVICE (self), "DRM_DP_AUX_DEV:0x06CB");
 	fu_device_set_summary (FU_DEVICE (self), "Multi-Stream Transport Device");
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
 				  FU_UDEV_DEVICE_FLAG_OPEN_WRITE |
@@ -1039,7 +1040,7 @@ fu_synaptics_mst_device_rescan (FuDevice *device, GError **error)
 		return FALSE;
 
 	version = g_strdup_printf ("%1d.%02d.%02d", buf_ver[0], buf_ver[1], buf_ver[2]);
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (FU_DEVICE (self), version);
 
 	/* read board ID */
 	if (!fu_synaptics_mst_device_read_board_id (self, connection, buf_ver, error))

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -105,7 +105,7 @@ fu_synaprom_config_setup (FuDevice *device, GError **error)
 
 	/* no downgrades are allowed */
 	version = g_strdup_printf ("%04u", GUINT16_FROM_LE(cfg.version));
-	fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (FU_DEVICE (self), version);
 	fu_device_set_version_lowest (FU_DEVICE (self), version);
 	return TRUE;
 }
@@ -200,6 +200,7 @@ fu_synaprom_config_init (FuSynapromConfig *self)
 {
 	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus.config");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_logical_id (FU_DEVICE (self), "cfg");
 	fu_device_set_name (FU_DEVICE (self), "Prometheus IOTA Config");
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -144,7 +144,7 @@ fu_synaprom_device_set_version (FuSynapromDevice *self,
 
 	/* set display version */
 	str = g_strdup_printf ("%02u.%02u.%u", vmajor, vminor, buildnum);
-	fu_device_set_version (FU_DEVICE (self), str, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (FU_DEVICE (self), str);
 
 	/* we need this for checking the firmware compatibility later */
 	self->vmajor = vmajor;
@@ -421,6 +421,7 @@ fu_synaprom_device_init (FuSynapromDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_name (FU_DEVICE (self), "Prometheus");

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -578,8 +578,8 @@ fu_synaptics_rmi_device_setup (FuDevice *device, GError **error)
 				  f01_basic->data[2],
 				  f01_basic->data[3],
 				  priv->flash.build_id);
-	fu_device_set_version (device, fw_ver, FWUPD_VERSION_FORMAT_TRIPLET);
-	bl_ver = g_strdup_printf ("%u.0", priv->flash.bootloader_id[1]);
+	fu_device_set_version (device, fw_ver);
+	bl_ver = g_strdup_printf ("%u.0.0", priv->flash.bootloader_id[1]);
 	fu_device_set_version_bootloader (device, bl_ver);
 
 	/* success */
@@ -1000,6 +1000,7 @@ fu_synaptics_rmi_device_init (FuSynapticsRmiDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_name (FU_DEVICE (self), "Touchpad");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	priv->functions = g_ptr_array_new_with_free_func (g_free);
 }
 

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -43,8 +43,9 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_set_summary (device, "A fake webcam");
 	fu_device_set_vendor (device, "ACME Corp.");
 	fu_device_set_vendor_id (device, "USB:0x046D");
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version_bootloader (device, "0.1.2");
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_set_version_lowest (device, "1.2.0");
 	if (g_strcmp0 (g_getenv ("FWUPD_PLUGIN_TEST"), "registration") == 0) {
 		fu_plugin_device_register (plugin, device);
@@ -69,7 +70,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		fu_device_set_logical_id (child1, "child1");
 		fu_device_add_guid (child1, "7fddead7-12b5-4fb9-9fa0-6d30305df755");
 		fu_device_set_name (child1, "Module1");
-		fu_device_set_version (child1, "1", FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version_format (child1, FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (child1, "1");
 		fu_device_add_parent_guid (child1, "b585990a-003e-5270-89d5-3705a17f9a43");
 		fu_device_add_flag (child1, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_plugin_device_add (plugin, child1);
@@ -81,7 +83,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		fu_device_set_logical_id (child2, "child2");
 		fu_device_add_guid (child2, "b8fe6b45-8702-4bcd-8120-ef236caac76f");
 		fu_device_set_name (child2, "Module2");
-		fu_device_set_version (child2, "10", FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version_format (child2, FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (child2, "10");
 		fu_device_add_parent_guid (child2, "b585990a-003e-5270-89d5-3705a17f9a43");
 		fu_device_add_flag (child2, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_plugin_device_add (plugin, child2);
@@ -172,11 +175,12 @@ fu_plugin_update (FuPlugin *plugin,
 
 	/* composite test, upgrade composite devices */
 	if (g_strcmp0 (test, "composite") == 0) {
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PLAIN);
 		if (g_strcmp0 (fu_device_get_logical_id (device), "child1") == 0) {
-			fu_device_set_version (device, "2", FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (device, "2");
 			return TRUE;
 		} else if (g_strcmp0 (fu_device_get_logical_id (device), "child2") == 0) {
-			fu_device_set_version (device, "11", FWUPD_VERSION_FORMAT_PLAIN);
+			fu_device_set_version (device, "11");
 			return TRUE;
 		}
 	}
@@ -186,13 +190,14 @@ fu_plugin_update (FuPlugin *plugin,
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 	} else {
 		g_autofree gchar *ver = fu_plugin_test_get_version (blob_fw);
+		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
 		if (ver != NULL) {
-			fu_device_set_version (device, ver, FWUPD_VERSION_FORMAT_TRIPLET);
+			fu_device_set_version (device, ver);
 		} else {
 			if (flags & FWUPD_INSTALL_FLAG_ALLOW_OLDER) {
-				fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+				fu_device_set_version (device, "1.2.2");
 			} else {
-				fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+				fu_device_set_version (device, "1.2.3");
 			}
 		}
 	}
@@ -213,7 +218,8 @@ fu_plugin_update (FuPlugin *plugin,
 gboolean
 fu_plugin_activate (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	return TRUE;
 }
 

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -43,7 +43,7 @@ fu_thelio_io_device_probe (FuDevice *device, GError **error)
 	if (!g_file_get_contents(fn, &buf, NULL, error))
 		return FALSE;
 
-	fu_device_set_version (device, (const gchar *) buf, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, (const gchar *) buf);
 
 	return TRUE;
 }
@@ -87,6 +87,7 @@ fu_thelio_io_device_init (FuThelioIoDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 }
 
 static void

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -410,7 +410,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_set_summary (dev, "Unmatched performance for high-speed I/O");
 	fu_device_add_icon (dev, "thunderbolt");
 	fu_device_set_protocol (dev, "com.intel.thunderbolt");
-
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_quirks (dev, fu_plugin_get_quirks (plugin));
 	vendor = g_udev_device_get_sysfs_attr (device, "vendor_name");
 	if (vendor != NULL)
@@ -422,7 +422,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	if (device_id_with_path != NULL)
 		fu_device_add_instance_id (dev, device_id_with_path);
 	if (version != NULL)
-		fu_device_set_version (dev, version, FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (dev, version);
 	if (is_host)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
@@ -481,7 +481,7 @@ fu_plugin_thunderbolt_change (FuPlugin *plugin, GUdevDevice *device)
 	}
 
 	version = fu_plugin_thunderbolt_udev_get_version (device);
-	fu_device_set_version (dev, version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (dev, version);
 }
 
 static gboolean

--- a/plugins/tpm/fu-tpm-device.c
+++ b/plugins/tpm/fu-tpm-device.c
@@ -224,7 +224,8 @@ fu_tpm_device_setup (FuDevice *device, GError **error)
 	/* this has to be done after _add_instance_id() sets the quirks */
 	verfmt = fu_device_get_version_format (device);
 	version = fu_common_version_from_uint64 (version_raw, verfmt);
-	fu_device_set_version (device, version, verfmt);
+	fu_device_set_version_format (device, verfmt);
+	fu_device_set_version (device, version);
 
 	/* success */
 	return TRUE;

--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -39,7 +39,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	g_autoptr(FuDevice) device = fu_device_new ();
 	fu_device_set_id (device, "uefi-recovery");
 	fu_device_set_name (device, "System Firmware ESRT Recovery");
-	fu_device_set_version (device, "0.0.0", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "0.0.0");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -736,7 +736,8 @@ fu_plugin_unlock (FuPlugin *plugin, FuDevice *device, GError **error)
 	fu_device_set_flags (device_alt, device_flags_alt & ~FWUPD_DEVICE_FLAG_UPDATABLE);
 
 	/* make sure that this unlocked device can be updated */
-	fu_device_set_version (device, "0.0.0.0", FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, "0.0.0.0");
 	return TRUE;
 }
 
@@ -746,6 +747,7 @@ fu_plugin_uefi_create_dummy (FuPlugin *plugin, const gchar *reason, GError **err
 	const gchar *key;
 	g_autoptr(FuDevice) dev = fu_device_new ();
 
+	fu_device_set_version_format (dev, FWUPD_VERSION_FORMAT_PLAIN);
 	key = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_MANUFACTURER);
 	if (key != NULL)
 		fu_device_set_vendor (dev, key);
@@ -753,7 +755,7 @@ fu_plugin_uefi_create_dummy (FuPlugin *plugin, const gchar *reason, GError **err
 	fu_device_set_name (dev, key);
 	key = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VERSION);
 	if (key != NULL)
-		fu_device_set_version (dev, key, FWUPD_VERSION_FORMAT_PLAIN);
+		fu_device_set_version (dev, key);
 	fu_device_set_update_error (dev, reason);
 
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -681,8 +681,9 @@ fu_uefi_device_probe (FuDevice *device, GError **error)
 	/* set versions */
 	version_format = fu_device_get_version_format (device);
 	version = fu_common_version_from_uint32 (self->fw_version, version_format);
-	fu_device_set_version (device, version, version_format);
+	fu_device_set_version_format (device, version_format);
 	fu_device_set_version_raw (device, self->fw_version);
+	fu_device_set_version (device, version);
 	if (self->fw_version_lowest != 0) {
 		version_lowest = fu_common_version_from_uint32 (self->fw_version_lowest,
 							        version_format);

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -293,7 +293,7 @@ fu_vli_pd_device_setup (FuVliDevice *device, GError **error)
 	version_raw = fu_common_read_uint32 (verbuf, G_BIG_ENDIAN);
 	fu_device_set_version_raw (FU_DEVICE (self), version_raw);
 	version_str = fu_common_version_from_uint32 (version_raw, FWUPD_VERSION_FORMAT_QUAD);
-	fu_device_set_version (FU_DEVICE (self), version_str, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (FU_DEVICE (self), version_str);
 
 	/* get device kind if not already in ROM mode */
 	if (fu_vli_device_get_kind (device) == FU_VLI_DEVICE_KIND_UNKNOWN) {
@@ -519,6 +519,7 @@ fu_vli_pd_device_init (FuVliPdDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_vli_device_set_spi_auto_detect (FU_VLI_DEVICE (self), FALSE);
 }
 

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -167,7 +167,7 @@ fu_vli_pd_parade_device_read_fw_ver (FuVliPdParadeDevice *self, GError **error)
 
 	/* format version triplet */
 	version_str = g_strdup_printf ("%u.%u.%u", buf[0], buf[1], buf[2]);
-	fu_device_set_version (FU_DEVICE (self), version_str, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (FU_DEVICE (self), version_str);
 	return TRUE;
 }
 
@@ -663,6 +663,7 @@ fu_vli_pd_parade_device_init (FuVliPdParadeDevice *self)
 	self->page7 = 0x1E;
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_set_install_duration (FU_DEVICE (self), 15); /* seconds */
 	fu_device_set_logical_id (FU_DEVICE (self), "PS186");

--- a/plugins/vli/fu-vli-usbhub-i2c-device.c
+++ b/plugins/vli/fu-vli-usbhub-i2c-device.c
@@ -66,7 +66,7 @@ fu_vli_usbhub_i2c_device_setup (FuDevice *device, GError **error)
 
 	/* set version */
 	version = g_strdup_printf ("%x.%x.%x", buf[0], buf[1], buf[2]);
-	fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, version);
 	return TRUE;
 }
 
@@ -253,6 +253,7 @@ fu_vli_usbhub_i2c_device_init (FuVliUsbhubI2cDevice *self)
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_set_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_logical_id (FU_DEVICE (self), "I2C");
 	fu_device_set_summary (FU_DEVICE (self), "I²C Dock Management Device");
 }

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -60,9 +60,9 @@ fu_vli_usbhub_pd_device_probe (FuDevice *device, GError **error)
 	fu_device_set_name (device, fu_vli_common_device_kind_to_string (self->device_kind));
 
 	/* use header to populate device info */
-	fwver_str = fu_common_version_from_uint32 (fwver, FWUPD_VERSION_FORMAT_QUAD);
-	fu_device_set_version (device, fwver_str, FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_version_raw (device, fwver);
+	fwver_str = fu_common_version_from_uint32 (fwver, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, fwver_str);
 	instance_id1 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&DEV_%s",
 					GUINT16_FROM_LE (self->hdr.vid),
 					GUINT16_FROM_LE (self->hdr.pid),
@@ -204,6 +204,7 @@ fu_vli_usbhub_pd_device_init (FuVliUsbhubPdDevice *self)
 	fu_device_set_protocol (FU_DEVICE (self), "com.vli.usbhub");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_install_duration (FU_DEVICE (self), 15); /* seconds */
 	fu_device_set_logical_id (FU_DEVICE (self), "PD");
 	fu_device_set_summary (FU_DEVICE (self), "USB-C Power Delivery Device");

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -125,7 +125,7 @@ fu_wacom_aes_device_setup (FuDevice *device, GError **error)
 
 	/* get firmware version */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		fu_device_set_version (device, "0.0", FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (device, "0.0");
 		/* get the recovery PID if supported */
 		if (!fu_wacom_aes_add_recovery_hwid (device, &error_local))
 			g_debug ("failed to get HwID: %s", error_local->message);
@@ -142,7 +142,7 @@ fu_wacom_aes_device_setup (FuDevice *device, GError **error)
 			return FALSE;
 		fw_ver = fu_common_read_uint16 (data + 11, G_LITTLE_ENDIAN);
 		version = g_strdup_printf ("%04x.%02x", fw_ver, data[13]);
-		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (device, version);
 	}
 
 	/* success */
@@ -236,6 +236,7 @@ static void
 fu_wacom_aes_device_init (FuWacomAesDevice *self)
 {
 	fu_device_set_name (FU_DEVICE (self), "Wacom AES Device");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -342,6 +342,7 @@ fu_wacom_device_init (FuWacomDevice *self)
 	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.raw");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -30,7 +30,7 @@ fu_wacom_emr_device_setup (FuDevice *device, GError **error)
 
 	/* get firmware version */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		fu_device_set_version (device, "0.0", FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (device, "0.0");
 	} else {
 		guint16 fw_ver;
 		guint8 data[19] = { 0x03, 0x0 }; /* 0x03 is an unknown ReportID */
@@ -41,7 +41,7 @@ fu_wacom_emr_device_setup (FuDevice *device, GError **error)
 		fw_ver = fu_common_read_uint16 (data + 11, G_LITTLE_ENDIAN);
 		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		version = fu_common_version_from_uint16 (fw_ver, FWUPD_VERSION_FORMAT_PAIR);
-		fu_device_set_version (device, version, FWUPD_VERSION_FORMAT_PAIR);
+		fu_device_set_version (device, version);
 		fu_device_set_version_raw (device, fw_ver);
 	}
 

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -689,7 +689,7 @@ fu_wac_device_add_modules_bluetooth (FuWacDevice *self, GError **error)
 	module = fu_wac_module_bluetooth_new (usb_device);
 	fu_device_add_child (FU_DEVICE (self), FU_DEVICE (module));
 	fu_device_set_name (FU_DEVICE (module), name);
-	fu_device_set_version (FU_DEVICE (module), version, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version (FU_DEVICE (module), version);
 	return TRUE;
 }
 
@@ -759,7 +759,7 @@ fu_wac_device_add_modules (FuWacDevice *self, GError **error)
 						fu_device_get_name (FU_DEVICE (self)));
 			fu_device_add_child (FU_DEVICE (self), FU_DEVICE (module));
 			fu_device_set_name (FU_DEVICE (module), name);
-			fu_device_set_version (FU_DEVICE (module), version, FWUPD_VERSION_FORMAT_PAIR);
+			fu_device_set_version (FU_DEVICE (module), version);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_BLUETOOTH:
 			module = fu_wac_module_bluetooth_new (usb_device);
@@ -767,10 +767,10 @@ fu_wac_device_add_modules (FuWacDevice *self, GError **error)
 						fu_device_get_name (FU_DEVICE (self)));
 			fu_device_add_child (FU_DEVICE (self), FU_DEVICE (module));
 			fu_device_set_name (FU_DEVICE (module), name);
-			fu_device_set_version (FU_DEVICE (module), version, FWUPD_VERSION_FORMAT_PAIR);
+			fu_device_set_version (FU_DEVICE (module), version);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_MAIN:
-			fu_device_set_version (FU_DEVICE (self), version, FWUPD_VERSION_FORMAT_PAIR);
+			fu_device_set_version (FU_DEVICE (self), version);
 			break;
 		default:
 			g_warning ("unknown submodule type 0x%0x", fw_type);
@@ -853,6 +853,7 @@ fu_wac_device_init (FuWacDevice *self)
 	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.usb");
 	fu_device_add_icon (FU_DEVICE (self), "input-tablet");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_install_duration (FU_DEVICE (self), 10);
 }
 

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -457,8 +457,8 @@ fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device
 	    fu_device_get_version (device) == NULL) {
 		const gchar *version = fu_device_get_version (item->device);
 		g_debug ("copying old version %s to new device", version);
-		fu_device_set_version (device, version,
-				       fu_device_get_version_format (item->device));
+		fu_device_set_version_format (device, fu_device_get_version_format (item->device));
+		fu_device_set_version (device, version);
 	}
 
 	/* always use the runtime version */
@@ -466,8 +466,8 @@ fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device
 	    fu_device_has_flag (item->device, FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER)) {
 		const gchar *version = fu_device_get_version (item->device);
 		g_debug ("forcing runtime version %s to new device", version);
-		fu_device_set_version (device, version,
-				       fu_device_get_version_format (item->device));
+		fu_device_set_version_format (device, fu_device_get_version_format (item->device));
+		fu_device_set_version (device, version);
 	}
 
 	/* allow another plugin to handle the write too */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1931,8 +1931,8 @@ fu_engine_install_release (FuEngine *self,
 	    g_strcmp0 (fu_device_get_version (device), version_rel) != 0) {
 		g_warning ("new device version '%s' was is not '%s', fixing up",
 			   fu_device_get_version (device), version_rel);
-		fu_device_set_version (device, version_rel,
-				       fu_device_get_version_format (device));
+		fu_device_set_version_format (device, fu_device_get_version_format (device));
+		fu_device_set_version (device, version_rel);
 	}
 
 	/* success */
@@ -5135,8 +5135,8 @@ fu_engine_update_history_device (FuEngine *self, FuDevice *dev_history, GError *
 			const gchar *csum = g_ptr_array_index (checksums, i);
 			fu_device_add_checksum (dev_history, csum);
 		}
-		fu_device_set_version (dev_history, fu_device_get_version (dev),
-				       fu_device_get_version_format (dev));
+		fu_device_set_version_format (dev_history, fu_device_get_version_format (dev));
+		fu_device_set_version (dev_history, fu_device_get_version (dev));
 		fu_device_remove_flag (dev_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 		fu_device_set_update_state (dev_history, FWUPD_UPDATE_STATE_SUCCESS);
 		return fu_history_modify_device (self->history, dev_history, error);

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -116,7 +116,7 @@ fu_history_device_from_stmt (sqlite3_stmt *stmt)
 	/* version_old */
 	tmp = (const gchar *) sqlite3_column_text (stmt, 13);
 	if (tmp != NULL)
-		fu_device_set_version (device, tmp, FWUPD_VERSION_FORMAT_UNKNOWN);
+		fu_device_set_version (device, tmp);
 
 	/* checksum_device */
 	tmp = (const gchar *) sqlite3_column_text (stmt, 14);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -143,7 +143,8 @@ fu_engine_generate_md_func (gconstpointer user_data)
 	g_assert_no_error (error);
 	g_assert (ret);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	component = fu_engine_get_component_by_guids (engine, device);
 	g_assert_nonnull (component);
 
@@ -247,7 +248,8 @@ fu_engine_requirements_version_require_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_version_bootloader (device, "4.5.6");
 	fu_device_set_vendor_id (device, "FFFF");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
@@ -335,12 +337,14 @@ fu_engine_requirements_child_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_version_bootloader (device, "4.5.6");
 	fu_device_set_vendor_id (device, "FFFF");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
-	fu_device_set_version (child, "0.0.999", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (child, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (child, "0.0.999");
 	fu_device_add_child (device, child);
 
 	/* make the component require three things */
@@ -387,12 +391,14 @@ fu_engine_requirements_child_fail_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_version_bootloader (device, "4.5.6");
 	fu_device_set_vendor_id (device, "FFFF");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
-	fu_device_set_version (child, "0.0.1", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (child, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (child, "0.0.1");
 	fu_device_add_child (device, child);
 
 	/* make the component require three things */
@@ -482,7 +488,8 @@ fu_engine_requirements_device_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_version_bootloader (device, "4.5.6");
 	fu_device_set_vendor_id (device, "FFFF");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
@@ -529,7 +536,8 @@ fu_engine_requirements_device_plain_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "5101AALB", FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_version (device, "5101AALB");
 	fu_device_set_vendor_id (device, "FFFF");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -577,7 +585,8 @@ fu_engine_requirements_version_format_func (gconstpointer user_data)
 		"</component>";
 
 	/* set up a dummy device */
-	fu_device_set_version (device, "1.2.3.4", FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version (device, "1.2.3.4");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
 
@@ -631,7 +640,8 @@ fu_engine_requirements_other_device_func (gconstpointer user_data)
 	fu_engine_set_silo (engine, silo_empty);
 
 	/* set up a dummy device */
-	fu_device_set_version (device1, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
 	fu_device_add_flag (device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
 
@@ -640,7 +650,8 @@ fu_engine_requirements_other_device_func (gconstpointer user_data)
 	fu_device_set_vendor_id (device2, "USB:FFFF");
 	fu_device_set_protocol (device2, "com.acme");
 	fu_device_set_name (device2, "Secondary firmware");
-	fu_device_set_version (device2, "4.5.6", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device2, "4.5.6");
 	fu_device_set_vendor_id (device2, "FFFF");
 	fu_device_add_guid (device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 	fu_engine_add_device (engine, device2);
@@ -700,7 +711,8 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 	fu_device_set_protocol (device1, "com.acme");
 	fu_device_set_name (device1, "NVME device");
 	fu_device_set_vendor_id (device1, "ACME");
-	fu_device_set_version (device1, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
 	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag (device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_engine_add_device (engine, device1);
@@ -709,7 +721,8 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 	fu_device_set_protocol (device2, "org.bar");
 	fu_device_set_name (device2, "UEFI device");
 	fu_device_set_vendor_id (device2, "ACME");
-	fu_device_set_version (device2, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device2, "1.2.3");
 	fu_device_add_guid (device2, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag (device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_engine_add_device (engine, device2);
@@ -780,7 +793,8 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 	/* set up child device */
 	fu_device_set_id (device2, "child");
 	fu_device_set_name (device2, "child");
-	fu_device_set_version (device2, "4.5.6", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device2, "4.5.6");
 	fu_device_add_flag (device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_guid (device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 
@@ -789,7 +803,8 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 	fu_device_set_vendor_id (device1, "USB:FFFF");
 	fu_device_set_protocol (device1, "com.acme");
 	fu_device_set_name (device1, "parent");
-	fu_device_set_version (device1, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
 	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_child (device1, device2);
 	fu_engine_add_device (engine, device1);
@@ -1113,7 +1128,8 @@ fu_engine_require_hwid_func (gconstpointer user_data)
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_engine_add_device (engine, device);
@@ -1243,7 +1259,8 @@ fu_engine_downgrade_func (gconstpointer user_data)
 	g_clear_error (&error);
 
 	/* add a device so we can get upgrades and downgrades */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -1339,7 +1356,8 @@ fu_engine_install_duration_func (gconstpointer user_data)
 	g_assert (ret);
 
 	/* add a device so we can get the install duration */
-	fu_device_set_version (device, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.3");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -1401,7 +1419,8 @@ fu_engine_history_func (gconstpointer user_data)
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -1527,7 +1546,8 @@ fu_engine_multiple_rels_func (gconstpointer user_data)
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -1597,7 +1617,8 @@ fu_engine_history_inherit (gconstpointer user_data)
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -1648,7 +1669,8 @@ fu_engine_history_inherit (gconstpointer user_data)
 	g_assert_cmpstr (fu_device_get_version (device), ==, "1.2.3");
 
 	/* emulate getting the flag for a fresh boot on old firmware */
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	ret = fu_engine_install (engine, task, blob_cab,
 				 FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error (error);
@@ -1664,7 +1686,8 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_device_set_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_engine_add_device (engine, device);
 	g_assert_true (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
 }
@@ -1705,7 +1728,8 @@ fu_engine_history_error_func (gconstpointer user_data)
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
-	fu_device_set_version (device, "1.2.2", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_set_vendor_id (device, "USB:FFFF");
 	fu_device_set_protocol (device, "com.acme");
@@ -2000,7 +2024,8 @@ fu_device_list_compatible_func (gconstpointer user_data)
 	fu_device_set_id (device1, "device1");
 	fu_device_set_plugin (device1, "plugin-for-runtime");
 	fu_device_set_vendor_id (device1, "USB:0x20A0");
-	fu_device_set_version (device1, "1.2.3", FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
 	fu_device_add_instance_id (device1, "foobar");
 	fu_device_add_instance_id (device1, "bootloader");
 	fu_device_set_remove_delay (device1, 100);
@@ -2475,7 +2500,8 @@ fu_history_func (gconstpointer user_data)
 	device = fu_device_new ();
 	fu_device_set_id (device, "self-test");
 	fu_device_set_name (device, "ColorHug"),
-	fu_device_set_version (device, "3.0.1", FWUPD_VERSION_FORMAT_TRIPLET),
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "3.0.1"),
 	fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);
 	fu_device_set_update_error (device, "word");
 	fu_device_add_guid (device, "827edddd-9bb6-5632-889f-2c01255503da");


### PR DESCRIPTION
If we say that the version format should be the same for the `version_lowest`
and the `version_bootloader` then it does not always make sense to set it at
the same time.

Moving the `version_format` to a standalone first-class property also means it
can be typically be set in the custom device `_init()` function, which means we
don't need to worry about *changing* ther version format as set by the USB and
UDev superclass helpers.
