### PR TITLE
Always return AppStream markup for remote agreements

### DIFF
--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -103,12 +103,12 @@ _fwupd_remote_get_agreement_default (FwupdRemote *self, GError **error)
 
 	/* this is designed as a fallback; the actual warning should ideally
 	 * come from the LVFS instance that is serving the remote */
-	g_string_append_printf (str, "%s\n",
+	g_string_append_printf (str, "<p>%s</p>",
 				/* TRANSLATORS: show the user a warning */
 				_("Your distributor may not have verified any of "
 				  "the firmware updates for compatibility with your "
 				  "system or connected devices."));
-	g_string_append_printf (str, "%s\n",
+	g_string_append_printf (str, "<p>%s</p>",
 				/* TRANSLATORS: show the user a warning */
 				_("Enabling this remote is done at your own risk."));
 	return str;


### PR DESCRIPTION
At the moment we're returning plain text for the embargo remotes and AppStream
markup for LVFS remotes. This fixes the warning on the console:

    $ fwupdmgr enable-remote lenovo_thinkpad-embargo
    failed to compile foo: Document must begin with an element (e.g. <book>)
