### PR TITLE
Improved fish shell completion

### DIFF
--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -1,5 +1,9 @@
 function __fish_fwupdmgr_devices --description 'Get device IDs used by fwupdmgr'
-    fwupdmgr get-devices | string replace -f -r '.*Device ID:\s*(.*)' '$1'
+    set -l ids (fwupdmgr get-devices | string replace -f -r '.*Device ID:\s*(.*)' '$1')
+    set -l names (fwupdmgr get-devices | string replace -f -r '.*─(.*):$' '$1')
+    for i in (seq (count $ids))
+        echo -e "$ids[$i]\t$names[$i]"
+    end
 end
 
 function __fish_fwupdmgr_remotes --description 'Get remote IDs used by fwupdmgr'


### PR DESCRIPTION
Just a small addition to the fish shell completion script I previously contributed. When completing device IDs, it now shows the device name as a description. This makes it easier to select the correct hex value.

![deviceid-completion](https://user-images.githubusercontent.com/5670236/75808534-87e32580-5d87-11ea-82c0-0682af260760.png)

Though, it is of limited use when most of the devices are just "UEFI Device Firmware".

By the way, @superm1 I think your bash completion broke when output format for `get-devices` and `get-remotes` changed a while back. Completing device and remote IDs in bash is currently not working.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
