### PR TITLE
Fix bash completion

### DIFF
--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -66,7 +66,7 @@ _show_device_ids()
 	local description
 	OLDIFS=$IFS
 	IFS=$'\n'
-	description="$(command fwupdmgr get-devices | command awk '!/DeviceId/ { line = $0 }; /DeviceId/ { print $2 " {" line "}"}')"
+	description="$(command fwupdagent get-devices 2>/dev/null | sed -e 's,"Name" :,,; s,",,g; s,\,,,g; s,[[:space:]]\+,,' | command awk '!/DeviceId/ { line = $0 }; /DeviceId/ { print $3 " { "line" }"}')"
 	COMPREPLY+=( $(compgen -W "${description}" -- "$cur") )
 	IFS=$OLDIFS
 }
@@ -74,7 +74,7 @@ _show_device_ids()
 _show_remotes()
 {
 	local remotes
-	remotes="$(command fwupdmgr get-remotes | command awk '/Remote ID/ { print $3 }')"
+	remotes="$(command fwupdmgr get-remotes | command awk '/Remote ID/ { print $4 }')"
 	COMPREPLY+=( $(compgen -W "${remotes}" -- "$cur") )
 }
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -538,11 +538,20 @@ fu_util_cmd_array_run (GPtrArray *array,
 		       gchar **values,
 		       GError **error)
 {
+	g_auto(GStrv) values_copy = g_new0 (gchar *, g_strv_length (values) + 1);
+
+	/* clear out bash completion sentinel */
+	for (guint i = 0; values[i] != NULL; i++) {
+		if (g_strcmp0 (values[i], "{") == 0)
+			break;
+		values_copy[i] = g_strdup (values[i]);
+	}
+
 	/* find command */
 	for (guint i = 0; i < array->len; i++) {
 		FuUtilCmd *item = g_ptr_array_index (array, i);
 		if (g_strcmp0 (item->name, command) == 0)
-			return item->callback (priv, values, error);
+			return item->callback (priv, values_copy, error);
 	}
 
 	/* not found */


### PR DESCRIPTION
Thanks @exploide for the notification it was broken.  Resolve `get-devices` and `get-remotes` output to work properly.  Hopefully by slicing and dicing `fwupdagent` output the `get-devices` is less likely to break in the future.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
