### PR TITLE
disable snap and doc deployment for 1_3_X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,23 +183,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
-      - publish-docs:
-          requires:
-            - build-ubuntu-x86_64
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
       - build-snap:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-      - publish-stable:
-          requires:
-            - build-snap
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
(This is merging to 1_3_X)

We don't use snap channels (currently), so we don't want a potential
1.3.10 to overwrite a 1.4.1 in the future.

Also we want documentation to always be the latest.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
