### PR TITLE
fix fwupd.shutdown.in according to the movement of fwupdtool to bindir

### DIFF
--- a/data/fwupd.shutdown.in
+++ b/data/fwupd.shutdown.in
@@ -4,4 +4,4 @@
 [ -f @localstatedir@/lib/fwupd/pending.db ] || exit 0
 
 # activate firmware when we have a read-only filesysten
-@libexecdir@/fwupd/fwupdtool activate
+@bindir@/fwupdtool activate


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

I think that this file has been forgotten, when the movement of fwupdtool to bindir has been done. At least I get an error message now during shutdown.