### PR TITLE
trivial: case insensitive while explorering cabinet files

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2649,9 +2649,10 @@ fu_engine_create_metadata (FuEngine *self, XbBuilder *builder,
 		g_autoptr(XbBuilderSource) source = NULL;
 		g_autoptr(GError) error_local = NULL;
 		const gchar *fn = g_ptr_array_index (files, i);
+		g_autofree gchar *fn_lowercase = g_ascii_strdown (fn, -1);
 
 		/* check is cab file */
-		if (!g_str_has_suffix (fn, ".cab")) {
+		if (!g_str_has_suffix (fn_lowercase, ".cab")) {
 			g_debug ("ignoring: %s", fn);
 			continue;
 		}


### PR DESCRIPTION
The cabinet file's extension name disregards uppercase or lowercase

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
