### PR TITLE
Add hexadecimal version format

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -519,6 +519,8 @@ fwupd_version_format_from_string (const gchar *str)
 		return FWUPD_VERSION_FORMAT_SURFACE;
 	if (g_strcmp0 (str, "dell-bios") == 0)
 		return FWUPD_VERSION_FORMAT_DELL_BIOS;
+	if (g_strcmp0 (str, "hex") == 0)
+		return FWUPD_VERSION_FORMAT_HEX;
 	return FWUPD_VERSION_FORMAT_UNKNOWN;
 }
 
@@ -557,5 +559,7 @@ fwupd_version_format_to_string (FwupdVersionFormat kind)
 		return "surface";
 	if (kind == FWUPD_VERSION_FORMAT_DELL_BIOS)
 		return "dell-bios";
+	if (kind == FWUPD_VERSION_FORMAT_HEX)
+		return "hex";
 	return NULL;
 }

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -258,6 +258,7 @@ typedef enum {
  * @FWUPD_VERSION_FORMAT_SURFACE_LEGACY:	Legacy Microsoft Surface 10b.12b.10b
  * @FWUPD_VERSION_FORMAT_SURFACE:		Microsoft Surface 8b.16b.8b
  * @FWUPD_VERSION_FORMAT_DELL_BIOS:		Dell BIOS BB.CC.DD style
+ * @FWUPD_VERSION_FORMAT_HEX:			Hexadecimal 0xAABCCDD style
  *
  * The flags used when parsing version numbers.
  *
@@ -277,6 +278,7 @@ typedef enum {
 	FWUPD_VERSION_FORMAT_SURFACE_LEGACY,		/* Since: 1.3.4 */
 	FWUPD_VERSION_FORMAT_SURFACE,			/* Since: 1.3.4 */
 	FWUPD_VERSION_FORMAT_DELL_BIOS,			/* Since: 1.3.6 */
+	FWUPD_VERSION_FORMAT_HEX,		/* Since: 1.4.0 */
 	/*< private >*/
 	FWUPD_VERSION_FORMAT_LAST
 } FwupdVersionFormat;

--- a/libfwupdplugin/fu-common-version.c
+++ b/libfwupdplugin/fu-common-version.c
@@ -53,6 +53,10 @@ fu_common_version_from_uint64 (guint64 val, FwupdVersionFormat kind)
 		/* AABBCCDD */
 		return g_strdup_printf ("%" G_GUINT64_FORMAT, val);
 	}
+	if (kind == FWUPD_VERSION_FORMAT_HEX) {
+		/* 0xAABBCCDDEEFFGGHH */
+		return g_strdup_printf ("0x%08x%08x", (guint32) (val >> 32), (guint32) (val & 0xffffffff));
+	}
 	g_critical ("failed to convert version format %s: %" G_GUINT64_FORMAT "",
 		    fwupd_version_format_to_string (kind), val);
 	return NULL;
@@ -143,6 +147,10 @@ fu_common_version_from_uint32 (guint32 val, FwupdVersionFormat kind)
 					(val >> 8) & 0xff,
 					val & 0xff);
 	}
+	if (kind == FWUPD_VERSION_FORMAT_HEX) {
+		/* 0xAABBCCDD */
+		return g_strdup_printf ("0x%08x", val);
+	}
 	g_critical ("failed to convert version format %s: %u",
 		    fwupd_version_format_to_string (kind), val);
 	return NULL;
@@ -175,6 +183,10 @@ fu_common_version_from_uint16 (guint16 val, FwupdVersionFormat kind)
 	if (kind == FWUPD_VERSION_FORMAT_NUMBER ||
 	    kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		return g_strdup_printf ("%" G_GUINT16_FORMAT, val);
+	}
+	if (kind == FWUPD_VERSION_FORMAT_HEX) {
+		/* 0xAABB */
+		return g_strdup_printf ("0x%04x", val);
 	}
 	g_critical ("failed to convert version format %s: %u",
 		    fwupd_version_format_to_string (kind), val);
@@ -404,6 +416,8 @@ fu_common_version_convert_base (FwupdVersionFormat fmt)
 		return FWUPD_VERSION_FORMAT_TRIPLET;
 	if (fmt == FWUPD_VERSION_FORMAT_BCD)
 		return FWUPD_VERSION_FORMAT_PAIR;
+	if (fmt == FWUPD_VERSION_FORMAT_HEX)
+		return FWUPD_VERSION_FORMAT_NUMBER;
 	return fmt;
 }
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1105,6 +1105,7 @@ fu_common_version_func (void)
 		{ 0x226a4b00,	"137.2706.768",		FWUPD_VERSION_FORMAT_SURFACE_LEGACY },
 		{ 0x6001988,	"6.25.136",		FWUPD_VERSION_FORMAT_SURFACE },
 		{ 0x00ff0001,	"255.0.1",		FWUPD_VERSION_FORMAT_DELL_BIOS },
+		{ 0xc8,		"0x000000c8",		FWUPD_VERSION_FORMAT_HEX },
 		{ 0,		NULL }
 	};
 	struct {
@@ -1118,6 +1119,7 @@ fu_common_version_func (void)
 		{ 0xff,		"0.255",		FWUPD_VERSION_FORMAT_PAIR },
 		{ 0xffffffffffffffff, "4294967295.4294967295", FWUPD_VERSION_FORMAT_PAIR },
 		{ 0x0,		"0",			FWUPD_VERSION_FORMAT_NUMBER },
+		{ 0x11000000c8,		"0x00000011000000c8",	FWUPD_VERSION_FORMAT_HEX },
 		{ 0,		NULL }
 	};
 	struct {


### PR DESCRIPTION
CPU microcode is distributed with a hexadecimal version.

Without this, UEFI device firmware for microcode shows with master:
```
Current version:     200
```

Various formats to try to render it:
```
•	Plain: 200
•	BCD: 0.0.0.128
•	Quad:  0.0.0.128
```

With this PR (and a quirk to set `VersionFormat` in place) renders as
```
Current version:     0x000000c8
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
