### PR TITLE
Don't build/install fwupdagent man page if agent build is not requested

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -193,20 +193,22 @@ if build_daemon and get_option('man')
     install : true,
     install_dir : join_paths(mandir, 'man1'),
   )
-  custom_target('fwupdagent-man',
-    input : fwupdagent,
-    output : 'fwupdagent.1',
-    command : [
-      help2man, '@INPUT@',
-      '--no-info',
-      '--output', '@OUTPUT@',
-      '--name', 'Firmware updating agent',
-      '--manual', 'User Commands',
-      '--version-string', fwupd_version,
-    ],
-    install : true,
-    install_dir : join_paths(mandir, 'man1'),
-  )
+  if get_option('agent')
+    custom_target('fwupdagent-man',
+      input : fwupdagent,
+      output : 'fwupdagent.1',
+      command : [
+        help2man, '@INPUT@',
+        '--no-info',
+        '--output', '@OUTPUT@',
+        '--name', 'Firmware updating agent',
+        '--manual', 'User Commands',
+        '--version-string', fwupd_version,
+      ],
+      install : true,
+      install_dir : join_paths(mandir, 'man1'),
+    )
+  endif
 endif
 if get_option('man')
   custom_target('fwupdtool-man',


### PR DESCRIPTION
Otherwise build fails with:

  src/meson.build:196:2: ERROR: Unknown variable "fwupdagent".

Gentoo-bug: https://bugs.gentoo.org/711682
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
