### PR TITLE
trivial: only install bash-completion for `fwupdmgr` if compiled with…

### DIFF
--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -21,13 +21,13 @@ configure_file(
   install: true,
   install_dir: tgt)
 
-if build_daemon
+if build_daemon and get_option('agent')
 configure_file(
   input : 'fwupdmgr.in',
   output : 'fwupdmgr',
   configuration : con2,
   install: true,
   install_dir: tgt)
-endif # build_daemon
+endif # build_daemon and get_option('agent')
 
 endif # bashcomp.found()


### PR DESCRIPTION
… agent

`fwupdmgr`'s bash completion now uses `fwupdagent` for at least one command.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
