### PR TITLE
Start fwupd-activate.service after snapd.service

### DIFF
--- a/contrib/snap/activate-shutdown/fwupd-activate.service
+++ b/contrib/snap/activate-shutdown/fwupd-activate.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Activate fwupd updates
-RequiresMountsFor=/snap/fwupd/current
+After=snapd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Instead of using `RequiresMountsFor=/snap/fwupd/current`, which will not work since `/snap/fwupd/current` is a symlink [1].

This will work since the mount units generated by snapd all have `Before=snapd.service`, so will be stopped after `snapd.service` during shutdown.

With `After=snapd.service`, `fwupd-activate.service` will then stop before `snapd.service`, at a point when all snap mount units are still alive.

Fixes the issue where `fwupd-activate.service` hangs when stopped, causing a stop job timeout during shutdown.

[1] See https://github.com/systemd/systemd/issues/8907

Closes #1654

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

@superm1 @hughsie 