### PR TITLE
trivial: update command consumes device ids in fish shell completion

### DIFF
--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -59,7 +59,7 @@ complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify -d 'Checks cryptogr
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify-update -d 'Update the stored cryptographic hash with current ROM contents'
 
 # commands exclusively consuming device IDs
-set -l deviceid_consumers activate clear-results downgrade get-releases get-results reinstall unlock verify verify-update
+set -l deviceid_consumers activate clear-results downgrade get-releases get-results reinstall unlock update verify verify-update
 # complete device IDs
 complete -c fwupdmgr -n "__fish_seen_subcommand_from $deviceid_consumers" -x -a "(__fish_fwupdmgr_devices)"
 # complete files and device IDs


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

I learned in #1872 that `update` can take a device ID. This PR reflects that in fish autocompletion.