### PR TITLE
ccgx: Add a firmare parser for cyacd files

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -315,6 +315,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libdir}/fwupd-plugins-3/libfu_plugin_altos.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_amt.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_ata.so
+%{_libdir}/fwupd-plugins-3/libfu_plugin_ccgx.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_colorhug.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_coreboot.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_csr.so

--- a/libfwupdplugin/fu-firmware-image.c
+++ b/libfwupdplugin/fu-firmware-image.c
@@ -298,7 +298,7 @@ fu_firmware_image_add_string (FuFirmwareImage *self, guint idt, GString *str)
 	if (priv->addr != 0x0)
 		fu_common_string_append_kx (str, idt, "Address", priv->addr);
 	if (priv->version != NULL)
-		fu_common_string_append_kv (str, 0, "Version", priv->version);
+		fu_common_string_append_kv (str, idt, "Version", priv->version);
 	if (priv->bytes != NULL) {
 		fu_common_string_append_kx (str, idt, "Data",
 					    g_bytes_get_size (priv->bytes));

--- a/plugins/ccgx/README.md
+++ b/plugins/ccgx/README.md
@@ -1,0 +1,8 @@
+Cypress support
+===============
+
+Firmware Format
+---------------
+The daemon will decompress the cabinet archive and extract several firmware
+blobs in cyacd file format. See https://community.cypress.com/docs/DOC-10562
+for more details.

--- a/plugins/ccgx/fu-ccgx-common.h
+++ b/plugins/ccgx/fu-ccgx-common.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+/* metadata valid signature "CY" */
+#define CCGX_METADATA_VALID_SIG 0x4359
+
+typedef struct __attribute__((packed)) {
+	guint8	fw_checksum;		/* firmware checksum */
+	guint32	fw_entry;		/* firmware entry address */
+	guint16	last_boot_row;		/* last flash row of bootloader or previous firmware */
+	guint8	reserved1[2];		/* reserved */
+	guint32	fw_size;		/* firmware size */
+	guint8	reserved2[9];		/* reserved */
+	guint16	metadata_valid;		/* meta data valid "CY" */
+	guint8	reserved3[4];		/* reserved */
+	guint32	boot_seq;		/* boot sequence number */
+} CCGxMetaData;

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware-image.c
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware-image.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-common.h"
+#include "fu-firmware-common.h"
+
+#include "fu-ccgx-cyacd-firmware-image.h"
+
+struct _FuCcgxCyacdFirmwareImage {
+	FuFirmwareImageClass	 parent_instance;
+	GPtrArray		*records;
+};
+
+G_DEFINE_TYPE (FuCcgxCyacdFirmwareImage, fu_ccgx_cyacd_firmware_image, FU_TYPE_FIRMWARE_IMAGE)
+
+GPtrArray *
+fu_ccgx_cyacd_firmware_image_get_records (FuCcgxCyacdFirmwareImage *self)
+{
+	g_return_val_if_fail (FU_IS_CCGX_CYACD_FIRMWARE_IMAGE (self), NULL);
+	return self->records;
+}
+
+static void
+fu_ccgx_cyacd_firmware_image_record_free (FuCcgxCyacdFirmwareImageRecord *rcd)
+{
+	if (rcd->data != NULL)
+		g_bytes_unref (rcd->data);
+	g_free (rcd);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuCcgxCyacdFirmwareImageRecord, fu_ccgx_cyacd_firmware_image_record_free)
+
+gboolean
+fu_ccgx_cyacd_firmware_image_parse_header (FuCcgxCyacdFirmwareImage *self,
+					   const gchar *line,
+					   GError **error)
+{
+	if (strlen (line) != 12) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "invalid header, expected == 12 chars");
+		return FALSE;
+	}
+	fu_firmware_image_set_addr (FU_FIRMWARE_IMAGE (self),
+				    fu_firmware_strparse_uint32 (line));
+	return TRUE;
+}
+
+gboolean
+fu_ccgx_cyacd_firmware_image_add_record (FuCcgxCyacdFirmwareImage *self,
+					 const gchar *line, GError **error)
+{
+	guint16 linesz = strlen (line);
+	guint16 buflen;
+	guint8 checksum_file;
+	guint8 checksum_calc = 0;
+	g_autoptr(FuCcgxCyacdFirmwareImageRecord) rcd = NULL;
+	g_autoptr(GByteArray) data = g_byte_array_new ();
+
+	/* https://community.cypress.com/docs/DOC-10562 */
+	if (linesz < 12) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "invalid record, expected >= 12 chars");
+		return FALSE;
+	}
+
+	/* parse */
+	rcd = g_new0 (FuCcgxCyacdFirmwareImageRecord, 1);
+	rcd->array_id = fu_firmware_strparse_uint8 (line + 0);
+	rcd->row_number = fu_firmware_strparse_uint16 (line + 2);
+	buflen = fu_firmware_strparse_uint16 (line + 6);
+	if (linesz != (buflen * 2) + 12) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "invalid record, expected %u chars, got %u",
+			     (guint) (buflen * 2) + 12, linesz);
+		return FALSE;
+	}
+
+	/* parse payload, adding checksum */
+	for (guint i = 0; i < buflen; i++) {
+		guint8 tmp = fu_firmware_strparse_uint8 (line + 10 + (i * 2));
+		fu_byte_array_append_uint8 (data, tmp);
+		checksum_calc += tmp;
+	}
+	rcd->data = g_byte_array_free_to_bytes (g_steal_pointer (&data));
+
+	/* verify 2s complement checksum */
+	checksum_file = fu_firmware_strparse_uint8 (line + (buflen * 2) + 10);
+	for (guint i = 0; i < 5; i++) {
+		guint8 tmp = fu_firmware_strparse_uint8 (line + (i * 2));
+		checksum_calc += tmp;
+	}
+	checksum_calc = 1 + ~checksum_calc;
+	if (checksum_file != checksum_calc)  {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INVALID_FILE,
+			     "checksum invalid, got %02x, expected %02x",
+			     checksum_calc, checksum_file);
+		return FALSE;
+	}
+
+	/* success */
+	g_ptr_array_add (self->records, g_steal_pointer (&rcd));
+	return TRUE;
+}
+
+static void
+fu_ccgx_cyacd_firmware_image_init (FuCcgxCyacdFirmwareImage *self)
+{
+	self->records = g_ptr_array_new_with_free_func ((GFreeFunc) fu_ccgx_cyacd_firmware_image_record_free);
+}
+
+static void
+fu_ccgx_cyacd_firmware_image_finalize (GObject *object)
+{
+	FuCcgxCyacdFirmwareImage *self = FU_CCGX_CYACD_FIRMWARE_IMAGE (object);
+	g_ptr_array_unref (self->records);
+	G_OBJECT_CLASS (fu_ccgx_cyacd_firmware_image_parent_class)->finalize (object);
+}
+
+static void
+fu_ccgx_cyacd_firmware_image_class_init (FuCcgxCyacdFirmwareImageClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_ccgx_cyacd_firmware_image_finalize;
+}
+
+FuFirmwareImage *
+fu_ccgx_cyacd_firmware_image_new (void)
+{
+	return FU_FIRMWARE_IMAGE (g_object_new (FU_TYPE_CCGX_CYACD_FIRMWARE_IMAGE, NULL));
+}

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware-image.h
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware-image.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-firmware-image.h"
+
+#define FU_TYPE_CCGX_CYACD_FIRMWARE_IMAGE (fu_ccgx_cyacd_firmware_image_get_type ())
+G_DECLARE_FINAL_TYPE (FuCcgxCyacdFirmwareImage, fu_ccgx_cyacd_firmware_image, FU, CCGX_CYACD_FIRMWARE_IMAGE, FuFirmwareImage)
+
+typedef struct {
+	guint8		 array_id;
+	guint16		 row_number;
+	GBytes		*data;
+} FuCcgxCyacdFirmwareImageRecord;
+
+FuFirmwareImage	*fu_ccgx_cyacd_firmware_image_new		(void);
+gboolean	 fu_ccgx_cyacd_firmware_image_parse_header	(FuCcgxCyacdFirmwareImage	*self,
+								 const gchar			*line,
+								 GError				**error);
+gboolean	 fu_ccgx_cyacd_firmware_image_add_record	(FuCcgxCyacdFirmwareImage	*self,
+								 const gchar			*line,
+								 GError				**error);
+GPtrArray	*fu_ccgx_cyacd_firmware_image_get_records	(FuCcgxCyacdFirmwareImage	*self);

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware-image.h
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware-image.h
@@ -22,6 +22,8 @@ FuFirmwareImage	*fu_ccgx_cyacd_firmware_image_new		(void);
 gboolean	 fu_ccgx_cyacd_firmware_image_parse_header	(FuCcgxCyacdFirmwareImage	*self,
 								 const gchar			*line,
 								 GError				**error);
+gboolean	 fu_ccgx_cyacd_firmware_image_parse_md_block	(FuCcgxCyacdFirmwareImage	*self,
+								 GError				**error);
 gboolean	 fu_ccgx_cyacd_firmware_image_add_record	(FuCcgxCyacdFirmwareImage	*self,
 								 const gchar			*line,
 								 GError				**error);

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware.c
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware.c
@@ -74,6 +74,8 @@ fu_ccgx_cyacd_firmware_parse (FuFirmware *firmware,
 	}
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmwareImage *img = g_ptr_array_index (images, i);
+		if (!fu_ccgx_cyacd_firmware_image_parse_md_block (FU_CCGX_CYACD_FIRMWARE_IMAGE (img), error))
+			return FALSE;
 		fu_firmware_add_image (firmware, img);
 	}
 

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware.c
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-common.h"
+
+#include "fu-ccgx-cyacd-firmware.h"
+#include "fu-ccgx-cyacd-firmware-image.h"
+
+struct _FuCcgxCyacdFirmware {
+	FuFirmwareClass		 parent_instance;
+};
+
+G_DEFINE_TYPE (FuCcgxCyacdFirmware, fu_ccgx_cyacd_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_ccgx_cyacd_firmware_parse (FuFirmware *firmware,
+			      GBytes *fw,
+			      guint64 addr_start,
+			      guint64 addr_end,
+			      FwupdInstallFlags flags,
+			      GError **error)
+{
+	gsize sz = 0;
+	guint idx = 0;
+	const gchar *data = g_bytes_get_data (fw, &sz);
+	g_auto(GStrv) lines = fu_common_strnsplit (data, sz, "\n", -1);
+	g_autoptr(FuFirmwareImage) img_current = NULL;
+	g_autoptr(GPtrArray) images = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+
+	for (guint ln = 0; lines[ln] != NULL; ln++) {
+		g_strdelimit (lines[ln], "\r\x1a", '\0');
+		if (lines[ln][0] == '\0')
+			continue;
+
+		/* create a new image section */
+		if (lines[ln][0] != ':') {
+			if (img_current != NULL)
+				g_object_unref (img_current);
+			img_current = fu_ccgx_cyacd_firmware_image_new ();
+			if (!fu_ccgx_cyacd_firmware_image_parse_header (FU_CCGX_CYACD_FIRMWARE_IMAGE (img_current),
+									lines[ln], error))
+				return FALSE;
+			g_ptr_array_add (images, g_object_ref (img_current));
+			fu_firmware_image_set_idx (img_current, idx++);
+
+		/* data */
+		} else {
+			if (img_current == NULL) {
+				g_set_error_literal (error,
+						     FWUPD_ERROR,
+						     FWUPD_ERROR_NOT_SUPPORTED,
+						     "no header record before data");
+				return FALSE;
+			}
+			if (!fu_ccgx_cyacd_firmware_image_add_record (FU_CCGX_CYACD_FIRMWARE_IMAGE (img_current),
+								      lines[ln] + 1, error)) {
+				g_prefix_error (error, "error on line %u: ", ln + 1);
+				return FALSE;
+			}
+		}
+	}
+	if (images->len == 0) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "no images found in file");
+		return FALSE;
+	}
+	for (guint i = 0; i < images->len; i++) {
+		FuFirmwareImage *img = g_ptr_array_index (images, i);
+		fu_firmware_add_image (firmware, img);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_ccgx_cyacd_firmware_init (FuCcgxCyacdFirmware *self)
+{
+}
+
+static void
+fu_ccgx_cyacd_firmware_class_init (FuCcgxCyacdFirmwareClass *klass)
+{
+	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS (klass);
+	klass_firmware->parse = fu_ccgx_cyacd_firmware_parse;
+}
+
+FuFirmware *
+fu_ccgx_cyacd_firmware_new (void)
+{
+	return FU_FIRMWARE (g_object_new (FU_TYPE_CCGX_CYACD_FIRMWARE, NULL));
+}

--- a/plugins/ccgx/fu-ccgx-cyacd-firmware.h
+++ b/plugins/ccgx/fu-ccgx-cyacd-firmware.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-firmware.h"
+
+#define FU_TYPE_CCGX_CYACD_FIRMWARE (fu_ccgx_cyacd_firmware_get_type ())
+G_DECLARE_FINAL_TYPE (FuCcgxCyacdFirmware, fu_ccgx_cyacd_firmware, FU,CCGX_CYACD_FIRMWARE, FuFirmware)
+
+FuFirmware	*fu_ccgx_cyacd_firmware_new		(void);

--- a/plugins/ccgx/fu-plugin-ccgx.c
+++ b/plugins/ccgx/fu-plugin-ccgx.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020 Cypress Semiconductor Corporation.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-hash.h"
+#include "fu-plugin-vfuncs.h"
+
+#include "fu-ccgx-cyacd-firmware.h"
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	fu_plugin_add_firmware_gtype (plugin, "ccgx-cyacd", FU_TYPE_CCGX_CYACD_FIRMWARE);
+}

--- a/plugins/ccgx/meson.build
+++ b/plugins/ccgx/meson.build
@@ -1,0 +1,26 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginCcgx"']
+
+shared_module('fu_plugin_ccgx',
+  fu_hash,
+  sources : [
+    'fu-plugin-ccgx.c',
+    'fu-ccgx-cyacd-firmware.c',
+    'fu-ccgx-cyacd-firmware-image.c',
+  ],
+  include_directories : [
+    root_incdir,
+    fwupd_incdir,
+    fwupdplugin_incdir,
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  link_with : [
+    fwupd,
+    fwupdplugin,
+  ],
+  c_args : cargs,
+  dependencies : [
+    plugin_deps,
+    gudev,
+  ],
+)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,3 +1,4 @@
+subdir('ccgx')
 subdir('cpu')
 subdir('dfu')
 subdir('colorhug')


### PR DESCRIPTION
These are visually similar to Intel hex files, but different enough to demand
their own parser. Multiple images can be stored in one firmware file, with the
`addr` set to the SiliconID and the `idx` set to the position in the file.
