### PR TITLE
csr: Parse the firmware as a DFU file

### DIFF
--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -10,7 +10,7 @@
 
 #include "fu-chunk.h"
 #include "fu-csr-device.h"
-#include "fu-ihex-firmware.h"
+#include "fu-dfu-firmware.h"
 
 #include "dfu-common.h"
 
@@ -332,7 +332,7 @@ fu_csr_device_prepare_firmware (FuDevice *device,
 				FwupdInstallFlags flags,
 				GError **error)
 {
-	g_autoptr(FuFirmware) firmware = fu_ihex_firmware_new ();
+	g_autoptr(FuFirmware) firmware = fu_dfu_firmware_new ();
 
 	/* parse the file */
 	if (!fu_firmware_parse (firmware, fw, flags, error))


### PR DESCRIPTION
This was changed to Intel hex in 7afd7cba0d327b155b2201c9fbb5414ced9cfe06,
probbaly due to a copy-paste mistake. Change it back to DFU.

Fixes https://github.com/fwupd/fwupd/issues/1890
