### PR TITLE
trivial: Export fu_device_add_instance_id_full() for plugins to use

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -11,20 +11,6 @@
 
 #define fu_device_set_plugin(d,v)		fwupd_device_set_plugin(FWUPD_DEVICE(d),v)
 
-/**
- * FuDeviceInstanceFlags:
- * @FU_DEVICE_INSTANCE_FLAG_NONE:		No flags set
- * @FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS:	Only use instance ID for quirk matching
- *
- * The flags to use when interacting with a device instance
- **/
-typedef enum {
-	FU_DEVICE_INSTANCE_FLAG_NONE		= 0,
-	FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS	= 1 << 0,
-	/*< private >*/
-	FU_DEVICE_INSTANCE_FLAG_LAST
-} FuDeviceInstanceFlags;
-
 GPtrArray	*fu_device_get_parent_guids		(FuDevice	*self);
 gboolean	 fu_device_has_parent_guid		(FuDevice	*self,
 							 const gchar	*guid);
@@ -44,8 +30,5 @@ gboolean	 fu_device_ensure_id			(FuDevice	*self,
 void		 fu_device_incorporate_from_component	(FuDevice	*device,
 							 XbNode		*component);
 void		 fu_device_convert_instance_ids		(FuDevice	*self);
-void		 fu_device_add_instance_id_full		(FuDevice	*self,
-							 const gchar	*instance_id,
-							 FuDeviceInstanceFlags flags);
 gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 GPtrArray	*fu_device_get_possible_plugins		(FuDevice	*self);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -69,6 +69,20 @@ struct _FuDeviceClass
 };
 
 /**
+ * FuDeviceInstanceFlags:
+ * @FU_DEVICE_INSTANCE_FLAG_NONE:		No flags set
+ * @FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS:	Only use instance ID for quirk matching
+ *
+ * The flags to use when interacting with a device instance
+ **/
+typedef enum {
+	FU_DEVICE_INSTANCE_FLAG_NONE		= 0,
+	FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS	= 1 << 0,
+	/*< private >*/
+	FU_DEVICE_INSTANCE_FLAG_LAST
+} FuDeviceInstanceFlags;
+
+/**
  * FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE:
  *
  * The default removal delay for device re-enumeration taking into account a
@@ -153,6 +167,9 @@ gboolean	 fu_device_has_guid			(FuDevice	*self,
 							 const gchar	*guid);
 void		 fu_device_add_instance_id		(FuDevice	*self,
 							 const gchar	*instance_id);
+void		 fu_device_add_instance_id_full		(FuDevice	*self,
+							 const gchar	*instance_id,
+							 FuDeviceInstanceFlags flags);
 FuDevice	*fu_device_get_alternate		(FuDevice	*self);
 FuDevice	*fu_device_get_root			(FuDevice	*self);
 FuDevice	*fu_device_get_parent			(FuDevice	*self);

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -391,7 +391,7 @@ fu_ata_device_parse_id (FuAtaDevice *self, const guint8 *buf, gsize sz, GError *
 	if (self->oui > 0x0) {
 		g_autofree gchar *tmp = NULL;
 		tmp = g_strdup_printf ("OUI\\%06x", self->oui);
-		fu_device_add_instance_id (device, tmp);
+		fu_device_add_instance_id_full (device, tmp, FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		has_oui_quirk = fu_device_get_vendor (FU_DEVICE (self)) != NULL;
 	}
 

--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -57,7 +57,6 @@ fu_ata_oui_func (void)
 	fu_device_convert_instance_ids (FU_DEVICE (dev));
 	str = fu_device_to_string (FU_DEVICE (dev));
 	g_debug ("%s", str);
-	g_assert_true (fu_device_has_guid (FU_DEVICE (dev), "OUI\\002538"));
 	g_assert_cmpint (fu_ata_device_get_transfer_mode (dev), ==, 0xe);
 	g_assert_cmpint (fu_ata_device_get_transfer_blocks (dev), ==, 0x1);
 	g_assert_cmpstr (fu_device_get_serial (FU_DEVICE (dev)), ==, "S3Z1NB0K862928X");

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1120,15 +1120,21 @@ fu_synaptics_mst_device_rescan (FuDevice *device, GError **error)
 	switch (self->family) {
 	case FU_SYNAPTICS_MST_FAMILY_TESLA:
 		fu_device_set_firmware_size_max (device, 0x10000);
-		fu_device_add_instance_id (device, "MST-tesla");
+		fu_device_add_instance_id_full (device,
+						"MST-tesla",
+						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		break;
 	case FU_SYNAPTICS_MST_FAMILY_LEAF:
 		fu_device_set_firmware_size_max (device, 0x10000);
-		fu_device_add_instance_id (device, "MST-leaf");
+		fu_device_add_instance_id_full (device,
+						"MST-leaf",
+						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		break;
 	case FU_SYNAPTICS_MST_FAMILY_PANAMERA:
 		fu_device_set_firmware_size_max (device, 0x80000);
-		fu_device_add_instance_id (device, "MST-panamera");
+		fu_device_add_instance_id_full (device,
+						"MST-panamera",
+						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 		break;
 	default:

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -543,7 +543,8 @@ fu_vli_device_setup (FuDevice *device, GError **error)
 
 			/* load the SPI parameters from quirks */
 			spi_id = g_strdup_printf ("VLI_USBHUB\\SPI_%s", flash_id);
-			fu_device_add_instance_id (FU_DEVICE (self), spi_id);
+			fu_device_add_instance_id_full (FU_DEVICE (self), spi_id,
+							FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 
 			/* add extra instance IDs to include the SPI variant */
 			devid2 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&SPI_%s&REV_%04X",

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -66,13 +66,17 @@ fu_wacom_device_check_mpu (FuWacomDevice *self, GError **error)
 
 	/* W9013 */
 	if (rsp.resp == 0x2e) {
-		fu_device_add_instance_id (FU_DEVICE (self), "WacomEMR_W9013");
+		fu_device_add_instance_id_full (FU_DEVICE (self),
+						"WacomEMR_W9013",
+						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		return TRUE;
 	}
 
 	/* W9021 */
 	if (rsp.resp == 0x45) {
-		fu_device_add_instance_id (FU_DEVICE (self), "WacomEMR_W9021");
+		fu_device_add_instance_id_full (FU_DEVICE (self),
+						"WacomEMR_W9021",
+						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 		return TRUE;
 	}
 


### PR DESCRIPTION
Sometimes we only want to add the instance ID to get the quirk matches, and it
is confusing to see the "fake" IDs in the 'fwupdmgr get-devices' output.
