### PR TITLE
vli: Only reboot the USB hub once

### DIFF
--- a/plugins/vli/fu-plugin-vli.c
+++ b/plugins/vli/fu-plugin-vli.c
@@ -25,33 +25,3 @@ fu_plugin_init (FuPlugin *plugin)
 	g_type_ensure (FU_TYPE_VLI_USBHUB_DEVICE);
 	g_type_ensure (FU_TYPE_VLI_PD_DEVICE);
 }
-
-/* reboot the FuVliUsbhubDevice if we update the FuVliUsbhubPdDevice */
-static FuDevice *
-fu_plugin_vli_get_parent (GPtrArray *devices)
-{
-	for (guint i = 0; i < devices->len; i++) {
-		FuDevice *dev = g_ptr_array_index (devices, i);
-		FuDevice *parent = fu_device_get_parent (dev);
-		if (parent != NULL && FU_IS_VLI_USBHUB_DEVICE (parent))
-			return g_object_ref (parent);
-		if (FU_IS_VLI_USBHUB_DEVICE (dev))
-			return g_object_ref (dev);
-	}
-	return NULL;
-}
-
-gboolean
-fu_plugin_composite_cleanup (FuPlugin *plugin,
-			     GPtrArray *devices,
-			     GError **error)
-{
-	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(FuDevice) parent = fu_plugin_vli_get_parent (devices);
-	if (parent == NULL)
-		return TRUE;
-	locker = fu_device_locker_new (parent, error);
-	if (locker == NULL)
-		return FALSE;
-	return fu_device_attach (parent, error);
-}

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -192,6 +192,17 @@ fu_vli_usbhub_pd_device_write_firmware (FuDevice *device,
 	return TRUE;
 }
 
+/* reboot the parent FuVliUsbhubDevice if we update the FuVliUsbhubPdDevice */
+static gboolean
+fu_vli_usbhub_pd_device_attach (FuDevice *device, GError **error)
+{
+	FuDevice *parent = fu_device_get_parent (device);
+	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (parent, error);
+	if (locker == NULL)
+		return FALSE;
+	return fu_device_attach (parent, error);
+}
+
 static void
 fu_vli_usbhub_pd_device_init (FuVliUsbhubPdDevice *self)
 {
@@ -211,6 +222,7 @@ fu_vli_usbhub_pd_device_class_init (FuVliUsbhubPdDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	klass_device->to_string = fu_vli_usbhub_pd_device_to_string;
 	klass_device->probe = fu_vli_usbhub_pd_device_probe;
+	klass_device->attach = fu_vli_usbhub_pd_device_attach;
 	klass_device->read_firmware = fu_vli_usbhub_pd_device_read_firmware;
 	klass_device->write_firmware = fu_vli_usbhub_pd_device_write_firmware;
 	klass_device->prepare_firmware = fu_vli_usbhub_pd_device_prepare_firmware;


### PR DESCRIPTION
The cleanup action for the FuVliUsbhubPdDevice is correct, but was not
conditionalized in the composite cleanup, which meant we would reboot twice
for a normal USB hub update.

Move the parent reboot into the right place, although this does mean we might
reboot twice in the rare event of scheduing a FuVliUsbhubPdDevice *and*
FuVliUsbhubDevice update in the same transaction -- but resetting the device
state between updates is arguably correct anyway...
