### PR TITLE
logitech_hidpp: show devices for all peripherals not just supported ones

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -25,3 +25,6 @@ VerboseDomains=
 
 # Update the message of the day (MOTD) on device and metadata changes
 UpdateMotd=true
+
+# For some plugins, enumerate only devices supported by metadata
+EnumerateAllDevices=true

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -12,11 +12,6 @@ CounterpartGuid = USB\VID_0BDA&PID_5800
 [DeviceInstanceId=USB\VID_0BDA&PID_5800]
 Flags = detach-for-attach
 
-# on PC platforms the DW1820A firmware is loaded at runtime and can't
-# be stored on the device itself as the flash chip is unpopulated
-[DeviceInstanceId=USB\VID_0A5C&PID_6412]
-Flags = only-supported
-
 # Openmoko Freerunner / GTA02
 [DeviceInstanceId=USB\VID_1D50&PID_5119]
 Plugin = dfu

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -56,6 +56,7 @@ fu_config_reload (FuConfig *self, GError **error)
 	g_auto(GStrv) plugins = NULL;
 	g_autofree gchar *domains = NULL;
 	g_autoptr(GKeyFile) keyfile = g_key_file_new ();
+	g_autoptr(GError) error_update_motd = NULL;
 	g_autoptr(GError) error_enumerate_all = NULL;
 
 	g_debug ("loading config values from %s", self->config_file);
@@ -133,7 +134,11 @@ fu_config_reload (FuConfig *self, GError **error)
 	self->update_motd = g_key_file_get_boolean (keyfile,
 						   "fwupd",
 						   "UpdateMotd",
-						   NULL);
+						   &error_update_motd);
+	if (!self->update_motd && error_update_motd != NULL) {
+		g_debug ("failed to read UpdateMotd key: %s", error_update_motd->message);
+		self->update_motd = TRUE;
+	}
 
 	/* whether to only show supported devices for some plugins */
 	self->enumerate_all_devices = g_key_file_get_boolean (keyfile,

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -27,3 +27,4 @@ GPtrArray	*fu_config_get_blacklist_devices	(FuConfig	*self);
 GPtrArray	*fu_config_get_blacklist_plugins	(FuConfig	*self);
 GPtrArray	*fu_config_get_approved_firmware	(FuConfig	*self);
 gboolean	 fu_config_get_update_motd		(FuConfig	*self);
+gboolean	 fu_config_get_enumerate_all_devices	(FuConfig	*self);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -501,6 +501,7 @@ fu_engine_modify_config (FuEngine *self, const gchar *key, const gchar *value, G
 		"IdleTimeout",
 		"VerboseDomains",
 		"UpdateMotd",
+		"EnumerateAllDevices",
 		NULL };
 
 	g_return_val_if_fail (FU_IS_ENGINE (self), FALSE);
@@ -4880,6 +4881,10 @@ fu_engine_plugin_check_supported_cb (FuPlugin *plugin, const gchar *guid, FuEngi
 {
 	g_autoptr(XbNode) n = NULL;
 	g_autofree gchar *xpath = NULL;
+
+	if (fu_config_get_enumerate_all_devices (self->config))
+		return TRUE;
+
 	xpath = g_strdup_printf ("components/component/"
 				 "provides/firmware[@type='flashed'][text()='%s']",
 				 guid);


### PR DESCRIPTION
At least to discuss.  This fixes all my Logitech peripherals not showing up.  I finally now understand the experience for stuff not currently connected too and why the DJ changes are important.

@FFY00 I think that the plugin will need to respond to change events to update version string (both connect and disconnect most likely).

Fixes: #1877

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
