### PR TITLE
Add FuDeviceRetry helper object

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */
@@ -99,6 +99,10 @@ typedef enum {
  * e.g. unplug, press a magic button and then replug.
  */
 #define FU_DEVICE_REMOVE_DELAY_USER_REPLUG		40000
+
+typedef gboolean (*FuDeviceRetryFunc)			(FuDevice	*device,
+							 gpointer	 user_data,
+							 GError		**error);
 
 FuDevice	*fu_device_new				(void);
 
@@ -293,3 +297,12 @@ gboolean	 fu_device_poll				(FuDevice	*self,
 							 GError		**error);
 void		 fu_device_set_poll_interval		(FuDevice	*self,
 							 guint		 interval);
+void		 fu_device_retry_add_recovery		(FuDevice	*self,
+							 GQuark		 domain,
+							 gint		 code,
+							 FuDeviceRetryFunc func);
+gboolean	 fu_device_retry			(FuDevice	*self,
+							 FuDeviceRetryFunc func,
+							 guint		 count,
+							 gpointer	 user_data,
+							 GError		**error);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -548,6 +548,8 @@ LIBFWUPDPLUGIN_1.4.0 {
     fu_cabinet_set_size_max;
     fu_device_get_root;
     fu_device_locker_close;
+    fu_device_retry;
+    fu_device_retry_add_recovery;
     fu_device_set_version_bootloader;
     fu_device_set_version_format;
     fu_device_set_version_lowest;


### PR DESCRIPTION
Sometimes plugins need to retry various commands send to hardware, either due
to unreliable transfers (e.g. using USB bulk) or from slightly quirky hardware.

Between them they seem to get various things wrong; either the error messages
are repeated and thus difficult to parse, or they just get the memory handling
of `g_propagate_prefixed_error()` wrong.

Providing a helper object we can reduce the amount of boilerplate. Additionally
we can support a 'reset' function that can try to automatically recover the
hardware for specific error domains and codes.
