### PR TITLE
Swap out GUID for multiple controllers with same ID

### DIFF
--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -31,12 +31,6 @@ When the device is in "safe mode" the GUID is hardcoded using:
 
  * `TBT-$(vid)$(pid)-native` when native, and `TBT-$(vid)$(pid)` otherwise.
 
-Additionally for host system thunderbolt controllers another GUID is added
-containing the PCI slot designation of the controller.  This is intended to be
-used for systems with multiple host controllers to disambiguiate between controllers.
-
-* `TBT-$(vid)$(pid)-native-$(slot)`
-
 Vendor ID Security
 ------------------
 

--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -31,6 +31,12 @@ When the device is in "safe mode" the GUID is hardcoded using:
 
  * `TBT-$(vid)$(pid)-native` when native, and `TBT-$(vid)$(pid)` otherwise.
 
+Additionally for host system thunderbolt controllers another GUID is added
+containing the domain designation of the controller.  This is intended to be
+used for systems with multiple host controllers to disambiguiate between controllers.
+
+* `TBT-$(vid)$(pid)-native-controller$(num)`
+
 Vendor ID Security
 ------------------
 

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -282,6 +282,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	g_autofree gchar *version = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autofree gchar *device_id = NULL;
+	g_autofree gchar *domain_id = NULL;
 	g_autoptr(FuDevice) dev = NULL;
 	g_autoptr(GError) error_vid = NULL;
 	g_autoptr(GError) error_did = NULL;
@@ -357,6 +358,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 			/* USB4 controllers don't have a concept of legacy vs native
 			 * so don't try to read a native attribute from their NVM */
 			if (is_host && gen < 4) {
+				g_autofree gchar *domain = g_path_get_basename (devpath);
 				g_autoptr(GError) native_error = NULL;
 				if (!fu_plugin_thunderbolt_is_native (device,
 								      &is_native,
@@ -368,6 +370,12 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 				fu_plugin_add_report_metadata (plugin,
 							       "ThunderboltNative",
 							       is_native ? "True" : "False");
+				domain_id = g_strdup_printf ("TBT-%04x%04x%s-controller%s",
+								(guint) vid,
+								(guint) did,
+								is_native ? "-native" : "",
+								domain);
+
 			}
 			vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
 			device_id = g_strdup_printf ("TBT-%04x%04x%s",
@@ -409,6 +417,8 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_set_vendor_id (dev, vendor_id);
 	if (device_id != NULL)
 		fu_device_add_instance_id (dev, device_id);
+	if (domain_id != NULL)
+		fu_device_add_instance_id (dev, domain_id);
 	if (version != NULL)
 		fu_device_set_version (dev, version);
 	if (is_host)

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -282,7 +282,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	g_autofree gchar *version = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autofree gchar *device_id = NULL;
-	g_autofree gchar *device_id_with_path = NULL;
 	g_autoptr(FuDevice) dev = NULL;
 	g_autoptr(GError) error_vid = NULL;
 	g_autoptr(GError) error_did = NULL;
@@ -359,7 +358,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 			 * so don't try to read a native attribute from their NVM */
 			if (is_host && gen < 4) {
 				g_autoptr(GError) native_error = NULL;
-				g_autoptr(GUdevDevice) udev_parent = NULL;
 				if (!fu_plugin_thunderbolt_is_native (device,
 								      &is_native,
 								      &native_error)) {
@@ -370,14 +368,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 				fu_plugin_add_report_metadata (plugin,
 							       "ThunderboltNative",
 							       is_native ? "True" : "False");
-				udev_parent = g_udev_device_get_parent_with_subsystem (device, "pci", NULL);
-				if (udev_parent != NULL)
-					device_id_with_path = g_strdup_printf ("TBT-%04x%04x%s-%s",
-									       (guint) vid,
-									       (guint) did,
-									       is_native ? "-native" : "",
-									       g_udev_device_get_property (udev_parent,
-													   "PCI_SLOT_NAME"));
 			}
 			vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
 			device_id = g_strdup_printf ("TBT-%04x%04x%s",
@@ -419,8 +409,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_set_vendor_id (dev, vendor_id);
 	if (device_id != NULL)
 		fu_device_add_instance_id (dev, device_id);
-	if (device_id_with_path != NULL)
-		fu_device_add_instance_id (dev, device_id_with_path);
 	if (version != NULL)
 		fu_device_set_version (dev, version);
 	if (is_host)


### PR DESCRIPTION
Here's the third try at a GUID that is unique but consistent enough when two controllers on the host system share the same vendor ID and device ID.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
