### PR TITLE
ccgx: Add extra instance IDs to match specific firmware

### DIFF
--- a/plugins/ccgx/README.md
+++ b/plugins/ccgx/README.md
@@ -66,11 +66,13 @@ These devices use the standard USB DeviceInstanceId values, e.g.
 
  * `USB\VID_17EF&PID_A38F`
 
-They additionally add one InstanceId which corresponds to the device mode, e.g.
+They additionally add other instance IDs which corresponds to the silicon ID,
+application ID and device mode, e.g.
 
  * `USB\VID_17EF&PID_A38F&MODE_BOOT`
- * `USB\VID_17EF&PID_A38F&MODE_FW1`
- * `USB\VID_17EF&PID_A38F&MODE_FW2`
+ * `USB\VID_17EF&PID_A38F&SID_1234`
+ * `USB\VID_17EF&PID_A38F&SID_1234&APP_5678`
+ * `USB\VID_17EF&PID_A38F&SID_1234&APP_5678&MODE_FW2`
 
 Vendor ID Security
 ------------------

--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -10,7 +10,7 @@ GType = FuCcgxHpiDevice
 ImageKind = dual-asymmetric
 ParentGuid = USB\VID_17EF&PID_A391
 
-[DeviceInstanceId=USB\VID_04B4&PID_521A&MODE_FW1]
+[DeviceInstanceId=USB\VID_04B4&PID_521A&MODE_FW2]
 UpdateMessage = Run firmware update again to upgrade the primary firmware.
 
 # Lenovo Hybrid Dock

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1294,6 +1294,33 @@ fu_ccgx_hpi_device_setup (FuDevice *device, GError **error)
 		fu_device_set_version (device, version);
 	}
 
+	/* add extra instance IDs */
+	if (self->silicon_id != 0x0) {
+		g_autofree gchar *instance_id1 = NULL;
+		instance_id1 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&SID_%04X",
+						fu_usb_device_get_vid (FU_USB_DEVICE (device)),
+						fu_usb_device_get_pid (FU_USB_DEVICE (device)),
+						self->silicon_id);
+		fu_device_add_instance_id (device, instance_id1);
+	}
+	if (self->silicon_id != 0x0 && self->fw_app_type != 0x0) {
+		g_autofree gchar *instance_id2 = NULL;
+		g_autofree gchar *instance_id3 = NULL;
+		instance_id2 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&SID_%04X&APP_%04X",
+						fu_usb_device_get_vid (FU_USB_DEVICE (device)),
+						fu_usb_device_get_pid (FU_USB_DEVICE (device)),
+						self->silicon_id,
+						self->fw_app_type);
+		fu_device_add_instance_id (device, instance_id2);
+		instance_id3 = g_strdup_printf ("USB\\VID_%04X&PID_%04X&SID_%04X&APP_%04X&MODE_%s",
+						fu_usb_device_get_vid (FU_USB_DEVICE (device)),
+						fu_usb_device_get_pid (FU_USB_DEVICE (device)),
+						self->silicon_id,
+						self->fw_app_type,
+						fu_ccgx_fw_mode_to_string (self->fw_mode));
+		fu_device_add_instance_id (device, instance_id3);
+	}
+
 	/* not supported in boot mode */
 	if (self->fw_mode == FW_MODE_BOOT) {
 		fu_device_remove_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);


### PR DESCRIPTION
The VID:PID of the device in HPI mode is shared between multiple vendors, and
so we need to use both the silicon ID and the application ID to match specific
firmware updates.
