### PR TITLE
trivial: Use the same source version string between daemon and client

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,17 +17,14 @@ conf.set('FWUPD_MINOR_VERSION', fwupd_minor_version)
 conf.set('FWUPD_MICRO_VERSION', fwupd_micro_version)
 conf.set_quoted('PACKAGE_VERSION', fwupd_version)
 
-# non tagged builds
+# get source version, falling back to package version
 git = find_program('git', required : false)
 if git.found()
-  git_version = run_command(git, 'describe').stdout().strip()
-  if git_version.contains('-')
-    fwupd_dirty_version = git_version.split('-')[1]
-    fwupd_commit = git_version.split('-')[2]
-    conf.set('FWUPD_DIRTY_VERSION', fwupd_dirty_version)
-    conf.set_quoted('FWUPD_COMMIT_VERSION', fwupd_commit)
-  endif
+  source_version = run_command(git, 'describe').stdout().strip()
+else
+  source_version = fwupd_version
 endif
+conf.set_quoted('SOURCE_VERSION', source_version)
 
 # libtool versioning - this applies to libfwupd
 #

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1374,7 +1374,7 @@ fu_main_daemon_get_property (GDBusConnection *connection_, const gchar *sender,
 	fu_engine_idle_reset (priv->engine);
 
 	if (g_strcmp0 (property_name, "DaemonVersion") == 0)
-		return g_variant_new_string (VERSION);
+		return g_variant_new_string (SOURCE_VERSION);
 
 	if (g_strcmp0 (property_name, "Tainted") == 0)
 		return g_variant_new_boolean (fu_engine_get_tainted (priv->engine));

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -266,31 +266,11 @@ fu_util_get_user_cache_path (const gchar *fn)
 }
 
 gchar *
-fu_util_get_client_version (void)
-{
-	GString *string = g_string_new ("");
-
-	g_string_append_printf (string,
-				"%i.%i.%i",
-				FWUPD_MAJOR_VERSION,
-				FWUPD_MINOR_VERSION,
-				FWUPD_MICRO_VERSION);
-#ifdef FWUPD_DIRTY_VERSION
-	g_string_append_printf (string,
-				"-%i-%s",
-				FWUPD_DIRTY_VERSION,
-				FWUPD_COMMIT_VERSION);
-#endif
-	return g_string_free (string, FALSE);
-}
-
-gchar *
 fu_util_get_versions (void)
 {
 	GString *string = g_string_new ("");
-	g_autofree gchar *client_version = fu_util_get_client_version ();
 
-	g_string_append_printf (string, "client version:\t%s\n", client_version);
+	g_string_append_printf (string, "client version:\t%s\n", SOURCE_VERSION);
 	g_string_append_printf (string,
 				"compile-time dependency versions\n");
 	g_string_append_printf (string,

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -33,8 +33,6 @@ void		 fu_util_print_tree		(GNode *n,	gpointer data);
 gboolean	 fu_util_is_interesting_device	(FwupdDevice	*dev);
 gchar		*fu_util_get_user_cache_path	(const gchar	*fn);
 SoupSession	*fu_util_setup_networking	(GError		**error);
-
-gchar		*fu_util_get_client_version	(void);
 gchar		*fu_util_get_versions		(void);
 
 void		 fu_util_warning_box		(const gchar	*str,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2368,16 +2368,15 @@ fu_util_private_free (FuUtilPrivate *priv)
 static gboolean
 fu_util_check_daemon_version (FuUtilPrivate *priv, GError **error)
 {
-	g_autofree gchar *client = fu_util_get_client_version ();
 	const gchar *daemon = fwupd_client_get_daemon_version (priv->client);
 
-	if (g_strcmp0 (daemon, client) != 0) {
+	if (g_strcmp0 (daemon, SOURCE_VERSION) != 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,
 			     /* TRANSLATORS: error message */
 			     _("Unsupported daemon version %s, client version is %s"),
-			     daemon, client);
+			     daemon, SOURCE_VERSION);
 		return FALSE;
 	}
 


### PR DESCRIPTION
This fixes the common problem encountered when developing plugins:

    ./src/fwupdmgr get-devices
    Unsupported daemon version 1.4.0, client version is 1.4.0-179-gcf8095d5
