### PR TITLE
trivial: snap: build using meson 0.54

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,7 +72,7 @@ parts:
     after: [nettle]
   meson:
     plugin: python
-    source: https://github.com/mesonbuild/meson/releases/download/0.51.2/meson-0.51.2.tar.gz
+    source: https://github.com/mesonbuild/meson/releases/download/0.54.0/meson-0.54.0.tar.gz
     build-packages:
       - ninja-build
       - python3-distutils-extra


### PR DESCRIPTION
libjcat bumped the meson dep up newer than we were using.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
