### PR TITLE
logitech_hidpp: don't set bootloader as updatable

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -436,7 +436,6 @@ fu_logitech_hidpp_bootloader_request (FuLogitechHidPpBootloader *self,
 static void
 fu_logitech_hidpp_bootloader_init (FuLogitechHidPpBootloader *self)
 {
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_icon (FU_DEVICE (self), "preferences-desktop-keyboard");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);


### PR DESCRIPTION
I noticed this when trying to replicate issues in https://github.com/fwupd/fwupd/issues/1914

Bootloader is not actually updatable and the protocol isn't actually set
leading to a daemon warning when installing replacement firmware for the runtime.

```
15:03:42:0124 FuEngine             device 14ee44ec8b5a38110f48482adeb389e97a706747 [Unifying Receiver] does not define an update protocol
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
