### PR TITLE
trivial: fix self tests for empty `/etc/machine-id` (LP: #1870051)

### DIFF
--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -58,7 +58,7 @@ with open(out.name, 'w') as wfd:
                 wfd.write("RUN yum -y install \\\n")
             elif OS == "debian" or OS == "ubuntu":
                 wfd.write("RUN apt update -qq && \\\n")
-                wfd.write("\tapt install -yq --no-install-recommends\\\n")
+                wfd.write("\tDEBIAN_FRONTEND=noninteractive apt install -yq --no-install-recommends\\\n")
             elif OS == "arch":
                 wfd.write("RUN pacman -Syu --noconfirm --needed\\\n")
             for i in range(0, len(deps)):

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2708,6 +2708,7 @@ static void
 fu_keyring_pkcs7_self_signed_func (gconstpointer user_data)
 {
 #ifdef ENABLE_PKCS7
+	static const gchar payload_str[] = "Hello, world!";
 	gboolean ret;
 	g_autoptr(FuKeyring) kr = NULL;
 	g_autoptr(FuKeyringResult) kr_result = NULL;
@@ -2726,8 +2727,7 @@ fu_keyring_pkcs7_self_signed_func (gconstpointer user_data)
 	ret = fu_keyring_setup (kr, &error);
 	g_assert_no_error (error);
 	g_assert_true (ret);
-	payload = fu_common_get_contents_bytes ("/etc/machine-id", &error);
-	g_assert_no_error (error);
+	payload = g_bytes_new_static (payload_str, sizeof (payload_str));
 	g_assert_nonnull (payload);
 	signature = fu_keyring_sign_data (kr, payload, FU_KEYRING_SIGN_FLAG_ADD_TIMESTAMP, &error);
 	g_assert_no_error (error);


### PR DESCRIPTION
This ports the fix https://github.com/hughsie/libjcat/commit/6ac46df8e754006b0e8900e16a8ee6412a8d7360
from libjcat to fwupd 1_3_X.  master is not affected.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
