### PR TITLE
Export the release creation time

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -22,6 +22,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_ISSUES			"Issues"	/* as */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
+#define FWUPD_RESULT_KEY_URGENCY		"Urgency"	/* u */
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */
 #define FWUPD_RESULT_KEY_GUID			"Guid"		/* as */
 #define FWUPD_RESULT_KEY_INSTANCE_IDS		"InstanceIds"	/* as */

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -489,6 +489,54 @@ fwupd_release_flag_from_string (const gchar *release_flag)
 }
 
 /**
+ * fwupd_release_urgency_to_string:
+ * @release_urgency: A #FwupdReleaseUrgency, e.g. %FWUPD_RELEASE_URGENCY_HIGH
+ *
+ * Converts an enumerated value to a string.
+ *
+ * Return value: identifier string
+ *
+ * Since: 1.4.0
+ **/
+const gchar *
+fwupd_release_urgency_to_string (FwupdReleaseUrgency release_urgency)
+{
+	if (release_urgency == FWUPD_RELEASE_URGENCY_LOW)
+		return "low";
+	if (release_urgency == FWUPD_RELEASE_URGENCY_MEDIUM)
+		return "medium";
+	if (release_urgency == FWUPD_RELEASE_URGENCY_HIGH)
+		return "high";
+	if (release_urgency == FWUPD_RELEASE_URGENCY_CRITICAL)
+		return "critical";
+	return NULL;
+}
+
+/**
+ * fwupd_release_urgency_from_string:
+ * @release_urgency: A string, e.g. `trusted-payload`
+ *
+ * Converts a string to an enumerated value.
+ *
+ * Return value: enumerated value
+ *
+ * Since: 1.4.0
+ **/
+FwupdReleaseUrgency
+fwupd_release_urgency_from_string (const gchar *release_urgency)
+{
+	if (g_strcmp0 (release_urgency, "low") == 0)
+		return FWUPD_RELEASE_URGENCY_LOW;
+	if (g_strcmp0 (release_urgency, "medium") == 0)
+		return FWUPD_RELEASE_URGENCY_MEDIUM;
+	if (g_strcmp0 (release_urgency, "high") == 0)
+		return FWUPD_RELEASE_URGENCY_HIGH;
+	if (g_strcmp0 (release_urgency, "critical") == 0)
+		return FWUPD_RELEASE_URGENCY_CRITICAL;
+	return FWUPD_RELEASE_URGENCY_UNKNOWN;
+}
+
+/**
  * fwupd_version_format_from_string:
  * @str: A string, e.g. `quad`
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -167,6 +167,26 @@ typedef guint64 FwupdDeviceFlags;
 typedef guint64 FwupdReleaseFlags;
 
 /**
+ * FwupdReleaseUrgency:
+ * @FWUPD_RELEASE_URGENCY_UNKNOWN:		Unknown
+ * @FWUPD_RELEASE_URGENCY_LOW:			Low
+ * @FWUPD_RELEASE_URGENCY_MEDIUM:		Medium
+ * @FWUPD_RELEASE_URGENCY_HIGH:			High
+ * @FWUPD_RELEASE_URGENCY_CRITICAL:		Critical, e.g. a security fix
+ *
+ * The release urgency.
+ **/
+typedef enum {
+	FWUPD_RELEASE_URGENCY_UNKNOWN,				/* Since: 1.4.0 */
+	FWUPD_RELEASE_URGENCY_LOW,				/* Since: 1.4.0 */
+	FWUPD_RELEASE_URGENCY_MEDIUM,				/* Since: 1.4.0 */
+	FWUPD_RELEASE_URGENCY_HIGH,				/* Since: 1.4.0 */
+	FWUPD_RELEASE_URGENCY_CRITICAL,				/* Since: 1.4.0 */
+	/*< private >*/
+	FWUPD_RELEASE_URGENCY_LAST
+} FwupdReleaseUrgency;
+
+/**
  * FwupdInstallFlags:
  * @FWUPD_INSTALL_FLAG_NONE:			No flags set
  * @FWUPD_INSTALL_FLAG_OFFLINE:			Schedule this for next boot
@@ -291,6 +311,8 @@ const gchar	*fwupd_device_flag_to_string		(FwupdDeviceFlags device_flag);
 FwupdDeviceFlags fwupd_device_flag_from_string		(const gchar	*device_flag);
 const gchar	*fwupd_release_flag_to_string		(FwupdReleaseFlags release_flag);
 FwupdReleaseFlags fwupd_release_flag_from_string	(const gchar	*release_flag);
+const gchar	*fwupd_release_urgency_to_string	(FwupdReleaseUrgency release_urgency);
+FwupdReleaseUrgency fwupd_release_urgency_from_string	(const gchar	*release_urgency);
 const gchar	*fwupd_update_state_to_string		(FwupdUpdateState update_state);
 FwupdUpdateState fwupd_update_state_from_string		(const gchar	*update_state);
 const gchar	*fwupd_trust_flag_to_string		(FwupdTrustFlags trust_flag);

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -51,6 +51,7 @@ typedef struct {
 	gchar				*version;
 	gchar				*remote_id;
 	guint64				 size;
+	guint64				 created;
 	guint32				 install_duration;
 	FwupdReleaseFlags		 flags;
 	gchar				*update_message;
@@ -825,6 +826,41 @@ fwupd_release_set_size (FwupdRelease *release, guint64 size)
 }
 
 /**
+ * fwupd_release_get_created:
+ * @release: A #FwupdRelease
+ *
+ * Gets when the update was created.
+ *
+ * Returns: UTC timestamp in UNIX format, or 0 if unset
+ *
+ * Since: 1.4.0
+ **/
+guint64
+fwupd_release_get_created (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), 0);
+	return priv->created;
+}
+
+/**
+ * fwupd_release_set_created:
+ * @release: A #FwupdRelease
+ * @created: UTC timestamp in UNIX format
+ *
+ * Sets when the update was created.
+ *
+ * Since: 1.4.0
+ **/
+void
+fwupd_release_set_created (FwupdRelease *release, guint64 created)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	priv->created = created;
+}
+
+/**
  * fwupd_release_get_summary:
  * @release: A #FwupdRelease
  *
@@ -1262,6 +1298,11 @@ fwupd_release_to_variant (FwupdRelease *release)
 				       FWUPD_RESULT_KEY_SIZE,
 				       g_variant_new_uint64 (priv->size));
 	}
+	if (priv->created != 0) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_CREATED,
+				       g_variant_new_uint64 (priv->created));
+	}
 	if (priv->summary != NULL) {
 		g_variant_builder_add (&builder, "{sv}",
 				       FWUPD_RESULT_KEY_SUMMARY,
@@ -1390,6 +1431,10 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_SIZE) == 0) {
 		fwupd_release_set_size (release, g_variant_get_uint64 (value));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_CREATED) == 0) {
+		fwupd_release_set_created (release, g_variant_get_uint64 (value));
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_SUMMARY) == 0) {
@@ -1588,6 +1633,7 @@ fwupd_release_to_json (FwupdRelease *release, JsonBuilder *builder)
 	}
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_LICENSE, priv->license);
 	fwupd_release_json_add_int (builder, FWUPD_RESULT_KEY_SIZE, priv->size);
+	fwupd_release_json_add_int (builder, FWUPD_RESULT_KEY_CREATED, priv->created);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_URI, priv->uri);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_HOMEPAGE, priv->homepage);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_DETAILS_URL, priv->details_url);
@@ -1661,6 +1707,7 @@ fwupd_release_to_string (FwupdRelease *release)
 	}
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_LICENSE, priv->license);
 	fwupd_pad_kv_siz (str, FWUPD_RESULT_KEY_SIZE, priv->size);
+	fwupd_pad_kv_siz (str, FWUPD_RESULT_KEY_CREATED, priv->created);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_URI, priv->uri);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_HOMEPAGE, priv->homepage);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETAILS_URL, priv->details_url);

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -54,6 +54,7 @@ typedef struct {
 	guint64				 created;
 	guint32				 install_duration;
 	FwupdReleaseFlags		 flags;
+	FwupdReleaseUrgency		 urgency;
 	gchar				*update_message;
 } FwupdReleasePrivate;
 
@@ -1167,6 +1168,41 @@ fwupd_release_has_flag (FwupdRelease *release, FwupdReleaseFlags flag)
 }
 
 /**
+ * fwupd_release_get_urgency:
+ * @release: A #FwupdRelease
+ *
+ * Gets the release urgency.
+ *
+ * Returns: the release urgency, or 0 if unset
+ *
+ * Since: 1.4.0
+ **/
+FwupdReleaseUrgency
+fwupd_release_get_urgency (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), 0);
+	return priv->urgency;
+}
+
+/**
+ * fwupd_release_set_urgency:
+ * @release: A #FwupdRelease
+ * @urgency: the release urgency, e.g. %FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD
+ *
+ * Sets the release urgency.
+ *
+ * Since: 1.4.0
+ **/
+void
+fwupd_release_set_urgency (FwupdRelease *release, FwupdReleaseUrgency urgency)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	priv->urgency = urgency;
+}
+
+/**
  * fwupd_release_get_install_duration:
  * @release: A #FwupdRelease
  *
@@ -1376,6 +1412,11 @@ fwupd_release_to_variant (FwupdRelease *release)
 				       FWUPD_RESULT_KEY_TRUST_FLAGS,
 				       g_variant_new_uint64 (priv->flags));
 	}
+	if (priv->urgency != 0) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_URGENCY,
+				       g_variant_new_uint32 (priv->urgency));
+	}
 	if (g_hash_table_size (priv->metadata) > 0) {
 		g_variant_builder_add (&builder, "{sv}",
 				       FWUPD_RESULT_KEY_METADATA,
@@ -1490,6 +1531,10 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_TRUST_FLAGS) == 0) {
 		fwupd_release_set_flags (release, g_variant_get_uint64 (value));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_URGENCY) == 0) {
+		fwupd_release_set_urgency (release, g_variant_get_uint32 (value));
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_INSTALL_DURATION) == 0) {
@@ -1712,6 +1757,10 @@ fwupd_release_to_string (FwupdRelease *release)
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_HOMEPAGE, priv->homepage);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETAILS_URL, priv->details_url);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_SOURCE_URL, priv->source_url);
+	if (priv->urgency != FWUPD_RELEASE_URGENCY_UNKNOWN) {
+		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_URGENCY,
+				  fwupd_release_urgency_to_string (priv->urgency));
+	}
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_VENDOR, priv->vendor);
 	fwupd_pad_kv_tfl (str, FWUPD_RESULT_KEY_FLAGS, priv->flags);
 	fwupd_pad_kv_int (str, FWUPD_RESULT_KEY_INSTALL_DURATION, priv->install_duration);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -125,6 +125,9 @@ void		 fwupd_release_remove_flag		(FwupdRelease	*release,
 							 FwupdReleaseFlags flag);
 gboolean	 fwupd_release_has_flag			(FwupdRelease	*release,
 							 FwupdReleaseFlags flag);
+FwupdReleaseUrgency fwupd_release_get_urgency		(FwupdRelease	*release);
+void		 fwupd_release_set_urgency		(FwupdRelease	*release,
+							 FwupdReleaseUrgency urgency);
 guint32		 fwupd_release_get_install_duration	(FwupdRelease	*release);
 void		 fwupd_release_set_install_duration	(FwupdRelease	*release,
 							 guint32	 duration);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -105,6 +105,9 @@ void		 fwupd_release_set_source_url		(FwupdRelease	*release,
 guint64		 fwupd_release_get_size			(FwupdRelease	*release);
 void		 fwupd_release_set_size			(FwupdRelease	*release,
 							 guint64	 size);
+guint64		 fwupd_release_get_created		(FwupdRelease	*release);
+void		 fwupd_release_set_created		(FwupdRelease	*release,
+							 guint64	 created);
 const gchar	*fwupd_release_get_license		(FwupdRelease	*release);
 void		 fwupd_release_set_license		(FwupdRelease	*release,
 							 const gchar	*license);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -129,6 +129,11 @@ fwupd_enums_func (void)
 		g_assert_cmpstr (tmp, !=, NULL);
 		g_assert_cmpint (fwupd_trust_flag_from_string (tmp), ==, i);
 	}
+	for (guint i = FWUPD_RELEASE_URGENCY_UNKNOWN + 1; i < FWUPD_RELEASE_URGENCY_LAST; i++) {
+		const gchar *tmp = fwupd_release_urgency_to_string (i);
+		g_assert_cmpstr (tmp, !=, NULL);
+		g_assert_cmpint (fwupd_release_urgency_from_string (tmp), ==, i);
+	}
 	for (guint i = 1; i < FWUPD_VERSION_FORMAT_LAST; i++) {
 		const gchar *tmp = fwupd_version_format_to_string (i);
 		g_assert_cmpstr (tmp, !=, NULL);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -429,6 +429,10 @@ LIBFWUPD_1.4.0 {
     fwupd_device_set_version_bootloader_raw;
     fwupd_device_set_version_lowest_raw;
     fwupd_release_get_created;
+    fwupd_release_get_urgency;
     fwupd_release_set_created;
+    fwupd_release_set_urgency;
+    fwupd_release_urgency_from_string;
+    fwupd_release_urgency_to_string;
   local: *;
 } LIBFWUPD_1.3.7;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -428,5 +428,7 @@ LIBFWUPD_1.4.0 {
     fwupd_device_get_version_lowest_raw;
     fwupd_device_set_version_bootloader_raw;
     fwupd_device_set_version_lowest_raw;
+    fwupd_release_get_created;
+    fwupd_release_set_created;
   local: *;
 } LIBFWUPD_1.3.7;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -401,6 +401,9 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 			fwupd_release_set_size (rel, *sizeptr);
 		}
 	}
+	tmp = xb_node_get_attr (release, "urgency");
+	if (tmp != NULL)
+		fwupd_release_set_urgency (rel, fwupd_release_urgency_from_string (tmp));
 	tmp64 = xb_node_get_attr_as_uint (release, "install_duration");
 	if (tmp64 != G_MAXUINT64)
 		fwupd_release_set_install_duration (rel, tmp64);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -404,6 +404,9 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp64 = xb_node_get_attr_as_uint (release, "install_duration");
 	if (tmp64 != G_MAXUINT64)
 		fwupd_release_set_install_duration (rel, tmp64);
+	tmp64 = xb_node_get_attr_as_uint (release, "timestamp");
+	if (tmp64 != G_MAXUINT64)
+		fwupd_release_set_created (rel, tmp64);
 	cats = xb_node_query (component, "categories/category", 0, NULL);
 	if (cats != NULL) {
 		for (guint i = 0; i < cats->len; i++) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1326,6 +1326,13 @@ fu_util_release_to_string (FwupdRelease *rel, guint idt)
 		/* TRANSLATORS: file size of the download */
 		fu_common_string_append_kv (str, idt + 1, _("Size"), tmp);
 	}
+	if (fwupd_release_get_created (rel) != 0) {
+		gint64 value = (gint64) fwupd_release_get_created (rel);
+		g_autoptr(GDateTime) date = g_date_time_new_from_unix_utc (value);
+		g_autofree gchar *tmp = g_date_time_format (date, "%F");
+		/* TRANSLATORS: when the update was built */
+		fu_common_string_append_kv (str, idt + 1, _("Created"), tmp);
+	}
 	if (fwupd_release_get_details_url (rel) != NULL) {
 		/* TRANSLATORS: more details about the update link */
 		fu_common_string_append_kv (str, idt + 1, _("Details"),

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1286,6 +1286,29 @@ fu_util_license_to_string (const gchar *license)
 	return license;
 }
 
+static const gchar *
+fu_util_release_urgency_to_string (FwupdReleaseUrgency release_urgency)
+{
+	if (release_urgency == FWUPD_RELEASE_URGENCY_LOW) {
+		/* TRANSLATORS: the release urgency */
+		return _("Low");
+	}
+	if (release_urgency == FWUPD_RELEASE_URGENCY_MEDIUM) {
+		/* TRANSLATORS: the release urgency */
+		return _("Medium");
+	}
+	if (release_urgency == FWUPD_RELEASE_URGENCY_HIGH) {
+		/* TRANSLATORS: the release urgency */
+		return _("High");
+	}
+	if (release_urgency == FWUPD_RELEASE_URGENCY_CRITICAL) {
+		/* TRANSLATORS: the release urgency */
+		return _("Critical");
+	}
+	/* TRANSLATORS: unknown release urgency */
+	return _("Unknown");
+}
+
 gchar *
 fu_util_release_to_string (FwupdRelease *rel, guint idt)
 {
@@ -1332,6 +1355,12 @@ fu_util_release_to_string (FwupdRelease *rel, guint idt)
 		g_autofree gchar *tmp = g_date_time_format (date, "%F");
 		/* TRANSLATORS: when the update was built */
 		fu_common_string_append_kv (str, idt + 1, _("Created"), tmp);
+	}
+	if (fwupd_release_get_urgency (rel) != FWUPD_RELEASE_URGENCY_UNKNOWN) {
+		FwupdReleaseUrgency tmp = fwupd_release_get_urgency (rel);
+		/* TRANSLATORS: how important the release is */
+		fu_common_string_append_kv (str, idt + 1, _("Urgency"),
+					    fu_util_release_urgency_to_string (tmp));
 	}
 	if (fwupd_release_get_details_url (rel) != NULL) {
 		/* TRANSLATORS: more details about the update link */


### PR DESCRIPTION
Show it in the various command line tools if it has been set by the vendor.

Fixes https://github.com/fwupd/fwupd/issues/1945
