### PR TITLE
Load the signature to get the aliased CDN-safe version of the metadata

### DIFF
--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -72,6 +72,9 @@ FwupdKeyringKind fwupd_remote_get_keyring_kind		(FwupdRemote	*self);
 gchar		*fwupd_remote_build_firmware_uri	(FwupdRemote	*self,
 							 const gchar	*url,
 							 GError		**error);
+gboolean	 fwupd_remote_load_signature		(FwupdRemote	*self,
+							 const gchar	*filename,
+							 GError		**error);
 
 FwupdRemote	*fwupd_remote_from_variant		(GVariant	*value);
 GPtrArray	*fwupd_remote_array_from_variant	(GVariant	*value);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -434,5 +434,6 @@ LIBFWUPD_1.4.0 {
     fwupd_release_set_urgency;
     fwupd_release_urgency_from_string;
     fwupd_release_urgency_to_string;
+    fwupd_remote_load_signature;
   local: *;
 } LIBFWUPD_1.3.7;

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -45,6 +45,7 @@ fwupd = shared_library(
   dependencies : [
     giounix,
     soup,
+    libjcat,
     libjsonglib,
   ],
   c_args : [


### PR DESCRIPTION
Switch to downloading the signature first, which we can then load to get the
suffixed build-specific URL of the actual metadata file. You need to have
libjcat 0.1.1 installed and fwupd built against the new version for this to
work.

Fixes https://github.com/fwupd/fwupd/issues/391
