### PR TITLE
Install the installed-tests only if tests are enabled

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -10,9 +10,9 @@ endif
 
 if get_option('tests')
   subdir('tests')
-endif
-if build_daemon
-  subdir('installed-tests')
+  if build_daemon
+    subdir('installed-tests')
+  endif
 endif
 
 if build_standalone


### PR DESCRIPTION
The README says: "A test suite that can be used to interact with a fake device is installed when configured with `-Ddaemon=true` and `-Dtests=true`", so actually only install these tests when tests are enabled.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
