### PR TITLE
Only auto-add counterpart GUIDs when required

### DIFF
--- a/data/device-tests/devices/realtek-rts5855.json
+++ b/data/device-tests/devices/realtek-rts5855.json
@@ -1,0 +1,16 @@
+{
+  "name": "Realtek RTS5855 Webcam",
+  "guids": [
+    "9829f051-47f5-55e7-87dc-a49cf55602e2"
+  ],
+  "releases": [
+    {
+      "version": "0.4",
+      "file": "ff989c4b71c92a4a217dfb2f82c1c87691b8eb31-rts5855_v0.4.cab"
+    },
+    {
+      "version": "0.3",
+      "file": "ed5c411d6b74c363209f408f87618fa5c31b50ab-v0.3.cab"
+    }
+  ]
+}

--- a/data/device-tests/devices/starlabs-phison-ata.json
+++ b/data/device-tests/devices/starlabs-phison-ata.json
@@ -1,0 +1,12 @@
+{
+  "name": "Star Labs Phison ATA",
+  "guids": [
+    "a8e0709c-5214-53df-bd41-5faf36394126"
+  ],
+  "releases": [
+    {
+      "version": "SBFM61.3",
+      "file": "af3c38880938de1d86b3ab72f193c975df51868e-SBFM.cab"
+    }
+  ]
+}

--- a/data/device-tests/devices/synaptics-prometheus.json
+++ b/data/device-tests/devices/synaptics-prometheus.json
@@ -1,0 +1,12 @@
+{
+  "name": "Prometheus Fingerprint Reader",
+  "guids": [
+    "8088f861-6318-5b1e-9ce4-fbddbedb09ac"
+  ],
+  "releases": [
+    {
+      "version": "10.01.3121519",
+      "file": "7c260a13ea6df444f7a1fa8fa2bf431876a8c7203b6aeac371564aad30756ff1-Synaptics-Prometheus-10.01.3121519.cab"
+    }
+  ]
+}

--- a/data/device-tests/devices/wacom-intuos-bt-m-bluetooth.json
+++ b/data/device-tests/devices/wacom-intuos-bt-m-bluetooth.json
@@ -1,0 +1,12 @@
+{
+  "name": "Wacom Intuos BT-M [bluetooth]",
+  "guids": [
+    "230fb992-35c7-56b1-8236-7f5674a04153"
+  ],
+  "releases": [
+    {
+      "version": "1.12",
+      "file": "1ee4f3dc9fd08acd4c6bc833b25e7061f85ddd40122148d66940cd3ddd748920-Wacom-Intuos_BT-M_BluetoothFW-1.12.cab"
+    }
+  ]
+}

--- a/data/device-tests/devices/wacom-intuos-bt-m-main.json
+++ b/data/device-tests/devices/wacom-intuos-bt-m-main.json
@@ -1,0 +1,12 @@
+{
+  "name": "Wacom Intuos BT-M [main]",
+  "guids": [
+    "edf56833-dbe5-56ca-a651-734b01bb02ba"
+  ],
+  "releases": [
+    {
+      "version": "1.66",
+      "file": "d16b682de56c42b134f1e5af7f9926c62dc246df851648e49aa1d1d0e5b38532-Wacom-Intuos_BT-M_MainFW-1.66.cab"
+    }
+  ]
+}

--- a/data/device-tests/hardware.py
+++ b/data/device-tests/hardware.py
@@ -134,6 +134,7 @@ if __name__ == '__main__':
 
     # run each test
     for fn in sorted(device_fns):
+        print('{}:'.format(fn))
         with open(fn, 'r') as f:
             try:
                 obj = json.load(f)

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -189,6 +189,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "md-set-name-category";
 	if (device_flag == FWUPD_DEVICE_FLAG_MD_SET_VERFMT)
 		return "md-set-verfmt";
+	if (device_flag == FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS)
+		return "add-counterpart-guids";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -279,6 +281,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY;
 	if (g_strcmp0 (device_flag, "md-set-verfmt") == 0)
 		return FWUPD_DEVICE_FLAG_MD_SET_VERFMT;
+	if (g_strcmp0 (device_flag, "add-counterpart-guids") == 0)
+		return FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -102,6 +102,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_MD_SET_NAME:		Set the device name from the metadata <name> if available
  * @FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY:	Set the device name from the metadata <category> if available
  * @FWUPD_DEVICE_FLAG_MD_SET_VERFMT:		Set the device version format from the metadata if available
+ * @FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS:	Add counterpart GUIDs from an alternate mode like bootloader
  *
  * The device flags.
  **/
@@ -141,6 +142,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_MD_SET_NAME		(1llu << 32)	/* Since: 1.4.0 */
 #define FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY	(1llu << 33)	/* Since: 1.4.0 */
 #define FWUPD_DEVICE_FLAG_MD_SET_VERFMT		(1llu << 34)	/* Since: 1.4.0 */
+#define FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS	(1llu << 35)	/* Since: 1.4.0 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -459,6 +459,7 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_remove_delay (FU_DEVICE (self),
 				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 }
 
 static void

--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1837,5 +1837,6 @@ dfu_device_init (DfuDevice *device)
 	priv->transfer_size = 64;
 	fu_device_add_icon (FU_DEVICE (device), "drive-harddisk-usb");
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_set_remove_delay (FU_DEVICE (device), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -581,6 +581,7 @@ static void
 fu_ebitdo_device_init (FuEbitdoDevice *self)
 {
 	fu_device_set_protocol (FU_DEVICE (self), "com.8bitdo");
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 }
 
 static void

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -699,6 +699,7 @@ fu_fastboot_device_init (FuFastbootDevice *self)
 	fu_device_set_protocol (FU_DEVICE (self), "com.google.fastboot");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_set_remove_delay (FU_DEVICE (self), FASTBOOT_REMOVE_DELAY_RE_ENUMERATE);
 }
 

--- a/plugins/jabra/fu-jabra-device.c
+++ b/plugins/jabra/fu-jabra-device.c
@@ -142,6 +142,7 @@ static void
 fu_jabra_device_init (FuJabraDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_set_remove_delay (FU_DEVICE (self), 20000); /* 10+10s! */
 }
 

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -134,6 +134,7 @@ fu_nitrokey_device_init (FuNitrokeyDevice *device)
 {
 	fu_device_set_remove_delay (FU_DEVICE (device), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_retry_set_delay (FU_DEVICE (device), 100);
 }

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -674,6 +674,7 @@ fu_vli_device_init (FuVliDevice *self)
 	priv->spi_cmds[FU_VLI_DEVICE_SPI_REQ_READ_ID]		= 0x9f;
 	priv->spi_cmd_read_id_sz = 2;
 	priv->spi_auto_detect = TRUE;
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -791,6 +791,7 @@ fu_wac_device_init (FuWacDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_install_duration (FU_DEVICE (self), 10);
+	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -297,6 +297,9 @@ fu_wac_module_set_property (GObject *object, guint prop_id,
 static void
 fu_wac_module_init (FuWacModule *self)
 {
+	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.usb");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -151,9 +151,11 @@ fu_wac_module_refresh (FuWacModule *self, GError **error)
 	if (priv->command != buf[2] || priv->status != buf[3]) {
 		priv->command = buf[2];
 		priv->status = buf[3];
-		g_debug ("command: %s, status: %s",
-			 fu_wac_module_command_to_string (priv->command),
-			 fu_wac_module_status_to_string (priv->status));
+		if (g_getenv ("FWUPD_WACOM_VERBOSE") != NULL) {
+			g_debug ("command: %s, status: %s",
+				 fu_wac_module_command_to_string (priv->command),
+				 fu_wac_module_status_to_string (priv->status));
+		}
 	}
 
 	/* success */

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -470,8 +470,14 @@ fu_device_list_add_missing_guids (FuDevice *device_new, FuDevice *device_old)
 	for (guint i = 0; i < guids_old->len; i++) {
 		const gchar *guid_tmp = g_ptr_array_index (guids_old, i);
 		if (!fu_device_has_guid (device_new, guid_tmp)) {
-			g_debug ("adding GUID %s to device", guid_tmp);
-			fu_device_add_counterpart_guid (device_new, guid_tmp);
+			if (fu_device_has_flag (device_new, FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS)) {
+				g_debug ("adding GUID %s to device", guid_tmp);
+				fu_device_add_counterpart_guid (device_new, guid_tmp);
+			} else {
+				g_debug ("not adding GUID %s to device, use "
+					 "FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS if required",
+					 guid_tmp);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Doing this unconditionally means we accidentally 'bleed' one device mode into
another in a non-obvious way. For instance, a device might have two operating
modes with different GUIDs. If firmware is supplied for both modes in the same
cabinet archive then we might accidentally match the 'wrong' firmware when
the daemon has observed a mode switch and added the counterpart GUIDs.

We only really need the counterpart GUIDs when switching between Jabra and DFU
devices where the DFU bootloader VID:PID is not manually tagged with
`CounterpartGuid` in a quirk file. In the general case lets keep it simple to
avoid difficult to find bugs.
