### PR TITLE
logitech-hidpp: Add two new GUIDs that are useful for the new device …

### DIFF
--- a/plugins/logitech-hidpp/README.md
+++ b/plugins/logitech-hidpp/README.md
@@ -38,6 +38,8 @@ These devices use the standard USB DeviceInstanceId values when in DFU mode:
 
 When in runtime mode, the HID raw DeviceInstanceId values are used:
 
+ * `HIDRAW\VEN_046D&DEV_C52B&TYPE_SIGNED`
+ * `HIDRAW\VEN_046D&DEV_C52B&TYPE_LEGACY`
  * `HIDRAW\VEN_046D&DEV_C52B`
  * `HIDRAW\VEN_046D`
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -219,6 +219,7 @@ fu_logitech_hidpp_runtime_setup_internal (FuDevice *device, GError **error)
 	/* get bootloader version */
 	if (self->version_bl_major > 0) {
 		g_autofree gchar *version_bl = NULL;
+		g_autofree gchar *devid3 = NULL;
 		version_bl = fu_logitech_hidpp_format_version ("BOT",
 						self->version_bl_major,
 						config[8],
@@ -230,9 +231,16 @@ fu_logitech_hidpp_runtime_setup_internal (FuDevice *device, GError **error)
 		    (self->version_bl_major == 0x03 && config[8] >= 0x02)) {
 			self->signed_firmware = TRUE;
 			fu_device_set_protocol (device, "com.logitech.unifyingsigned");
+			devid3 = g_strdup_printf ("HIDRAW\\VEN_%04X&DEV_%04X&TYPE_SIGNED",
+						  fu_udev_device_get_vendor (FU_UDEV_DEVICE (device)),
+						  fu_udev_device_get_model (FU_UDEV_DEVICE (device)));
 		} else {
 			fu_device_set_protocol (device, "com.logitech.unifying");
+			devid3 = g_strdup_printf ("HIDRAW\\VEN_%04X&DEV_%04X&TYPE_LEGACY",
+						  fu_udev_device_get_vendor (FU_UDEV_DEVICE (device)),
+						  fu_udev_device_get_model (FU_UDEV_DEVICE (device)));
 		}
+		fu_device_add_instance_id (FU_DEVICE (device), devid3);
 	}
 
 	/* enable HID++ notifications */


### PR DESCRIPTION
…tests

The new regresion device tests are awesome, but dumb. They look for a specific
GUID and run a test if found. The Logitech unifying devices in runtime mode
currently have the same set of GUIDs.

Add a new GUID which can be used by the regression tests without adding a ton
of complexity in the client code doing a requirements check.

FIXME: If a good idea also have to edit the GUIDs used in device-tests/devices/logitech-*
