### PR TITLE
trivial: Allow filtering the device-test by the protocol

### DIFF
--- a/data/device-tests/devices/logitech-rqr12-signed.json
+++ b/data/device-tests/devices/logitech-rqr12-signed.json
@@ -4,6 +4,7 @@
     "9d131a0c-a606-580f-8eda-80587250b8d6",
     "d637baf7-3ab5-502a-8169-2545302e44e2"
   ],
+  "protocol": "com.logitech.unifyingsigned",
   "releases": [
     {
       "version": "RQR12.11_B0032",

--- a/data/device-tests/devices/logitech-rqr12.json
+++ b/data/device-tests/devices/logitech-rqr12.json
@@ -3,6 +3,7 @@
   "guids": [
     "9d131a0c-a606-580f-8eda-80587250b8d6"
   ],
+  "protocol": "com.logitech.unifying",
   "releases": [
     {
       "version": "RQR12.05_B0028",

--- a/data/device-tests/devices/logitech-rqr24-signed.json
+++ b/data/device-tests/devices/logitech-rqr24-signed.json
@@ -6,6 +6,7 @@
     "111c9951-f819-5c48-93ef-205a8f8b96c1",
     "40410bd7-57eb-5c82-9eac-abf893861221"
   ],
+  "protocol": "com.logitech.unifyingsigned",
   "releases": [
     {
       "version": "RQR24.11_B0036",

--- a/data/device-tests/devices/logitech-rqr24.json
+++ b/data/device-tests/devices/logitech-rqr24.json
@@ -3,6 +3,7 @@
   "guids": [
     "cc4cbfa9-bf9d-540b-b92b-172ce31013c1"
   ],
+  "protocol": "com.logitech.unifying",
   "releases": [
     {
       "version": "RQR24.03_B0027",


### PR DESCRIPTION
This allows us to run the device tests with all 4 supported types of unifying
dongles plugged in at the same time.
