### PR TITLE
Do not conditionalize attach() and detach() on IS_BOOTLOADER

### DIFF
--- a/data/device-tests/devices/lenovo-03x7609-vli-tier1.json
+++ b/data/device-tests/devices/lenovo-03x7609-vli-tier1.json
@@ -1,0 +1,12 @@
+{
+  "name": "Lenovo USB-C Dock Gen2 (VLI Tier 1)",
+  "guids": [
+    "c6381f16-fe6d-5c45-a4ad-b619af4f0f0e"
+  ],
+  "releases": [
+    {
+      "version": "13.24",
+      "file": "ae0ef92b8179f5279e4481b4a352effe21b1dd0d91ff8226de998709aa97f622-Lenovo-Gen2_Dock.cab"
+    }
+  ]
+}

--- a/data/device-tests/devices/lenovo-03x7609-vli-tier2.json
+++ b/data/device-tests/devices/lenovo-03x7609-vli-tier2.json
@@ -1,0 +1,12 @@
+{
+  "name": "Lenovo USB-C Dock Gen2 (VLI Tier 2)",
+  "guids": [
+    "8b2439a7-f319-5583-950a-236eeecfe918"
+  ],
+  "releases": [
+    {
+      "version": "13.23",
+      "file": "ae0ef92b8179f5279e4481b4a352effe21b1dd0d91ff8226de998709aa97f622-Lenovo-Gen2_Dock.cab"
+    }
+  ]
+}

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -989,10 +989,6 @@ static gboolean
 fu_plugin_device_attach (FuPlugin *self, FuDevice *device, GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		g_debug ("already in runtime mode, skipping");
-		return TRUE;
-	}
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
@@ -1003,10 +999,6 @@ static gboolean
 fu_plugin_device_detach (FuPlugin *self, FuDevice *device, GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		g_debug ("already in bootloader mode, skipping");
-		return TRUE;
-	}
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -173,6 +173,12 @@ fu_colorhug_device_detach (FuDevice *device, GError **error)
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE (device);
 	g_autoptr(GError) error_local = NULL;
 
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
+
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_msg (self, CH_CMD_RESET,
 				     NULL, 0, /* in */
@@ -194,6 +200,12 @@ fu_colorhug_device_attach (FuDevice *device, GError **error)
 {
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE (device);
 	g_autoptr(GError) error_local = NULL;
+
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_msg (self, CH_CMD_BOOT_FLASH,

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -146,6 +146,12 @@ fu_ep963x_device_detach (FuDevice *device, GError **error)
 	const guint8 buf[] = { 'E', 'P', '9', '6', '3' };
 	g_autoptr(GError) error_local = NULL;
 
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
+
 	if (!fu_ep963x_device_write_icp (self, FU_EP963_OPCODE_SUBMCU_ENTER_ICP,
 					 buf, sizeof(buf),
 					 &error_local)) {
@@ -168,6 +174,12 @@ fu_ep963x_device_attach (FuDevice *device, GError **error)
 	FuEp963xDevice *self = FU_EP963X_DEVICE (device);
 	const guint8 buf[] = { 0x00 };
 	g_autoptr(GError) error_local = NULL;
+
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_ep963x_device_write_icp (self, 0x02,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -624,6 +624,12 @@ fu_logitech_hidpp_peripheral_detach (FuDevice *device, GError **error)
 	guint8 idx;
 	g_autoptr(FuLogitechHidPpHidppMsg) msg = fu_logitech_hidpp_msg_new ();
 
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
+
 	/* this requires user action */
 	idx = fu_logitech_hidpp_peripheral_feature_get_idx (self, HIDPP_FEATURE_DFU_CONTROL);
 	if (idx != 0x00) {
@@ -960,6 +966,12 @@ fu_logitech_hidpp_peripheral_attach (FuDevice *device, GError **error)
 	FuLogitechHidPpPeripheral *self = FU_UNIFYING_PERIPHERAL (device);
 	guint8 idx;
 	g_autoptr(FuLogitechHidPpHidppMsg) msg = fu_logitech_hidpp_msg_new ();
+
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 
 	/* if we're in bootloader mode, we should be able to get this feature */
 	idx = fu_logitech_hidpp_peripheral_feature_get_idx (self, HIDPP_FEATURE_DFU);

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -250,12 +250,6 @@ fu_synaprom_config_detach (FuDevice *device, GError **error)
 }
 
 static void
-fu_synaprom_config_flags_notify_cb (FuDevice *parent, GParamSpec *pspec, FuDevice *device)
-{
-	fu_device_incorporate_flag (device, parent, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-}
-
-static void
 fu_synaprom_config_class_init (FuSynapromConfigClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
@@ -278,11 +272,5 @@ fu_synaprom_config_new (FuSynapromDevice *device)
 	self = g_object_new (FU_TYPE_SYNAPROM_CONFIG,
 			     "parent", device,
 			     NULL);
-
-	/* mirror the bootloader flag on the parent to the child */
-	if (fu_device_has_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
-		fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-	g_signal_connect (device, "notify::flags",
-			  G_CALLBACK (fu_synaprom_config_flags_notify_cb), self);
 	return FU_SYNAPROM_CONFIG (self);
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -354,6 +354,12 @@ fu_synaprom_device_attach (FuDevice *device, GError **error)
 	gsize actual_len = 0;
 	guint8 data[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
+
 	ret = g_usb_device_control_transfer (usb_device,
 					     G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					     G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -388,6 +394,12 @@ fu_synaprom_device_detach (FuDevice *device, GError **error)
 	gboolean ret;
 	gsize actual_len = 0;
 	guint8 data[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00 };
+
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
 
 	ret = g_usb_device_control_transfer (usb_device,
 					     G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -983,6 +983,12 @@ fu_synaptics_rmi_device_attach (FuDevice *device, GError **error)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE (device);
 
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
+
 	/* reset device */
 	if (!fu_synaptics_rmi_device_reset (self, error))
 		return FALSE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -33,6 +33,12 @@ fu_synaptics_rmi_v5_device_detach (FuDevice *device, GError **error)
 	FuSynapticsRmiFlash *flash = fu_synaptics_rmi_device_get_flash (self);
 	g_autoptr(GByteArray) enable_req = g_byte_array_new ();
 
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
+
 	/* disable interrupts */
 	if (!fu_synaptics_rmi_device_disable_irqs (self, error))
 		return FALSE;

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -442,6 +442,12 @@ fu_vli_pd_device_detach_vl103 (FuDevice *device, GError **error)
 	FuVliPdDevice *self = FU_VLI_PD_DEVICE (device);
 	g_autoptr(GError) error_local = NULL;
 
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
+
 	/* write GPIOs */
 	if (!fu_vli_pd_device_write_gpios (self, error))
 		return FALSE;
@@ -477,6 +483,12 @@ fu_vli_pd_device_detach (FuDevice *device, GError **error)
 	FuVliPdDevice *self = FU_VLI_PD_DEVICE (device);
 	guint8 tmp = 0;
 	g_autoptr(GError) error_local = NULL;
+
+	/* sanity check */
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in bootloader mode, skipping");
+		return TRUE;
+	}
 
 	/* write GPIOs */
 	if (!fu_vli_pd_device_write_gpios (self, error))
@@ -537,6 +549,12 @@ static gboolean
 fu_vli_pd_device_attach (FuDevice *device, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
+
+	/* sanity check */
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 
 	/* chip reset command works only for non-VL103 */
 	if (!g_usb_device_control_transfer (fu_usb_device_get_dev (FU_USB_DEVICE (device)),

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -106,6 +106,10 @@ fu_wacom_device_detach (FuDevice *device, GError **error)
 		FU_WACOM_RAW_FW_REPORT_ID,
 		FU_WACOM_RAW_FW_CMD_DETACH,
 	};
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 	if (!fu_wacom_device_set_feature (self, buf, sizeof(buf), error)) {
 		g_prefix_error (error, "failed to switch to bootloader mode: ");
 		return FALSE;
@@ -125,6 +129,10 @@ fu_wacom_device_attach (FuDevice *device, GError **error)
 		.echo = FU_WACOM_RAW_ECHO_DEFAULT,
 		0x00
 	};
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_debug ("already in runtime mode, skipping");
+		return TRUE;
+	}
 	if (!fu_wacom_device_set_feature (self, (const guint8 *) &req, sizeof(req), error)) {
 		g_prefix_error (error, "failed to switch to runtime mode: ");
 		return FALSE;


### PR DESCRIPTION
This is nice in theory, until you need to look at the bootloader status of the
parent, or of a different device entirely. Handle this in plugins for the few
cases we care about and stop setting or clearing IS_BOOTLOADER manually just to
get the vfuncs to be run.

Note: I do not think we want to use cleanup() for attaching devices not in
bootloader states -- as cleanup is only run at the end of the composite update.
