### PR TITLE
trivial: skip some self tests if system isn't set up properly

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -442,6 +442,11 @@ fwupd_client_devices_func (void)
 
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect (client, NULL, &error);
+	if (ret == FALSE && g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT)) {
+		g_debug ("%s", error->message);
+		g_test_skip ("timeout connecting to daemon");
+		return;
+	}
 	g_assert_no_error (error);
 	g_assert_true (ret);
 	if (fwupd_client_get_daemon_version (client) == NULL) {
@@ -491,6 +496,11 @@ fwupd_client_remotes_func (void)
 
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect (client, NULL, &error);
+	if (ret == FALSE && g_error_matches (error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT)) {
+		g_debug ("%s", error->message);
+		g_test_skip ("timeout connecting to daemon");
+		return;
+	}
 	g_assert_no_error (error);
 	g_assert_true (ret);
 	if (fwupd_client_get_daemon_version (client) == NULL) {

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -168,7 +168,7 @@ if get_option('tests')
       '-DFU_LOCAL_REMOTE_DIR="' + localremotetestdir + '"',
     ],
   )
-  test('fwupd-self-test', e)
+  test('fwupd-self-test', e, timeout: 60)
 endif
 
 fwupd_incdir = include_directories('.')


### PR DESCRIPTION
```
ok 10 /fwupd/client{remotes} # SKIP no valid daemon: Error calling StartServiceByName for org.freedesktop.fwupd: Failed to activate service 'org.freedesktop.fwupd': timed out (service_start_timeout=25000ms)
ok 11 /fwupd/client{devices} # SKIP no valid daemon: Error calling StartServiceByName for org.freedesktop.fwupd: Failed to activate service 'org.freedesktop.fwupd': timed out (service_start_timeout=25000ms)

```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
