### PR TITLE
Define SOURCE_VERSION when building a package

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,9 @@ conf.set_quoted('PACKAGE_VERSION', fwupd_version)
 git = find_program('git', required : false)
 if git.found()
   source_version = run_command(git, 'describe').stdout().strip()
+  if source_version == ''
+    source_version = fwupd_version
+  endif
 else
   source_version = fwupd_version
 endif


### PR DESCRIPTION
In this case git exists, but there's no git checkout and so the source version
is an empty string.
