### PR TITLE
logitech_hidpp: decrease verbosity of messages that hid++ ID is missing

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -508,8 +508,8 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 	/* did not get ID */
 	if (self->hidpp_id == HIDPP_DEVICE_ID_UNSET) {
 		g_set_error_literal (error,
-				     G_IO_ERROR,
-				     G_IO_ERROR_FAILED,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
 				     "no HID++ ID");
 		return FALSE;
 	}


### PR DESCRIPTION
These are a regression of 9e755e2a5 when devices are asleep.
However due to the current kernel and daemon architecture, logitech devices
are not checked again at any time so if the device isn't awake when
fwupd is started or the unifying dongle is plugged in it won't be present.

This will be changed in the future when the kernel has change events
associated with devices waking up.

Fixes: #1973

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
