### PR TITLE
Expose device physical id to clients

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -38,6 +38,9 @@ void		 fwupd_device_set_id			(FwupdDevice	*device,
 const gchar	*fwupd_device_get_parent_id		(FwupdDevice	*device);
 void		 fwupd_device_set_parent_id		(FwupdDevice	*device,
 							 const gchar	*parent_id);
+const gchar	*fwupd_device_get_physical_id		(FwupdDevice	*device);
+void		 fwupd_device_set_physical_id		(FwupdDevice	*device,
+							 const gchar	*physical_id);
 FwupdDevice	*fwupd_device_get_parent		(FwupdDevice	*device);
 void		 fwupd_device_set_parent		(FwupdDevice	*device,
 							 FwupdDevice	*parent);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */
 #define FWUPD_RESULT_KEY_GUID			"Guid"		/* as */
 #define FWUPD_RESULT_KEY_INSTANCE_IDS		"InstanceIds"	/* as */
+#define FWUPD_RESULT_KEY_PHYSICAL_ID		"PhysicalId"	/* s */
 #define FWUPD_RESULT_KEY_HOMEPAGE		"Homepage"	/* s */
 #define FWUPD_RESULT_KEY_DETAILS_URL		"DetailsUrl"	/* s */
 #define FWUPD_RESULT_KEY_SOURCE_URL		"SourceUrl"	/* s */

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -439,3 +439,10 @@ LIBFWUPD_1.4.0 {
     fwupd_remote_load_signature;
   local: *;
 } LIBFWUPD_1.3.7;
+
+LIBFWUPD_1.4.1 {
+  global:
+    fwupd_device_get_physical_id;
+    fwupd_device_set_physical_id;
+  local: *;
+} LIBFWUPD_1.4.0;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1252,6 +1252,12 @@ fu_util_device_to_string (FwupdDevice *dev, guint idt)
 		}
 	}
 
+	tmp = fwupd_device_get_physical_id (dev);
+	if (tmp != NULL) {
+		/* TRANSLATORS: Physical ID for hardware */
+		fu_common_string_append_kv (str, idt + 1, _("Physical ID"), tmp);
+	}
+
 	/* TRANSLATORS: description of device ability */
 	tmp = _("Device Flags");
 	for (guint i = 0; i < 64; i++) {


### PR DESCRIPTION
To allow fwupd clients to better communicate which device is going to be
updated to the user it may be required to know which physical device a
fwupd device refers to. To that end expose the physical id that fwupd
already keeps.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ x] Feature
- [ ] Documentation
