### PR TITLE
ccgx: Install both FW1 and FW2 firmwares

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -191,6 +191,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "md-set-verfmt";
 	if (device_flag == FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS)
 		return "add-counterpart-guids";
+	if (device_flag == FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED)
+		return "another-install-required";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -283,6 +285,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_MD_SET_VERFMT;
 	if (g_strcmp0 (device_flag, "add-counterpart-guids") == 0)
 		return FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS;
+	if (g_strcmp0 (device_flag, "another-install-required") == 0)
+		return FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -103,6 +103,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY:	Set the device name from the metadata <category> if available
  * @FWUPD_DEVICE_FLAG_MD_SET_VERFMT:		Set the device version format from the metadata if available
  * @FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS:	Add counterpart GUIDs from an alternate mode like bootloader
+ * @FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED:	Requires the install to be retried by the client
  *
  * The device flags.
  **/
@@ -143,6 +144,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY	(1llu << 33)	/* Since: 1.4.0 */
 #define FWUPD_DEVICE_FLAG_MD_SET_VERFMT		(1llu << 34)	/* Since: 1.4.0 */
 #define FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS	(1llu << 35)	/* Since: 1.4.0 */
+#define FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED (1llu << 36)	/* Since: 1.4.1 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1354,10 +1354,12 @@ fu_ccgx_hpi_device_setup (FuDevice *device, GError **error)
 	}
 
 	/* need to do FW2 now */
-	if (self->fw_mode == FW_MODE_FW1)
+	if (self->fw_image_type == FW_IMAGE_TYPE_DUAL_ASYMMETRIC &&
+	    self->fw_mode == FW_MODE_FW1) {
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED);
-	else
+	} else {
 		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED);
+	}
 
 	/* start with no events in the queue */
 	return fu_ccgx_hpi_device_clear_all_events (self,

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1353,6 +1353,12 @@ fu_ccgx_hpi_device_setup (FuDevice *device, GError **error)
 			g_usleep (HPI_CMD_RESET_COMPLETE_DELAY_US);
 	}
 
+	/* need to do FW2 now */
+	if (self->fw_mode == FW_MODE_FW1)
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED);
+	else
+		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_INSTALL_REQUIRED);
+
 	/* start with no events in the queue */
 	return fu_ccgx_hpi_device_clear_all_events (self,
 						    HPI_CMD_SETUP_EVENT_CLEAR_TIME_MS,


### PR DESCRIPTION
We have to do this client-side rather than using ANOTHER_WRITE_REQUIRED
as the device changes from `HID -> HPI-FW2 -> HPI->FW1 -> HID -> HPI-FW2` which
is somewhat complicated to handle in the daemon.

Using a 'client-side' retry loop also allows us to recover hub hardware when
one installing the correct device firmware on one device makes another device
appear, for instance making a shared SPI PD controller re-appear from a failed
hub upgrade.
