### PR TITLE
Allow devices to match the proxy device by GUID

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -220,6 +220,9 @@ void		 fu_device_set_physical_id		(FuDevice	*self,
 const gchar	*fu_device_get_logical_id		(FuDevice	*self);
 void		 fu_device_set_logical_id		(FuDevice	*self,
 							 const gchar	*logical_id);
+const gchar	*fu_device_get_proxy_guid		(FuDevice	*self);
+void		 fu_device_set_proxy_guid		(FuDevice	*self,
+							 const gchar	*proxy_guid);
 const gchar	*fu_device_get_protocol			(FuDevice	*self);
 void		 fu_device_set_protocol			(FuDevice	*self,
 							 const gchar	*protocol);

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -51,6 +51,7 @@ gboolean	 fu_quirks_lookup_by_id_iter		(FuQuirks	*self,
 #define	FU_QUIRKS_GUID				"Guid"
 #define	FU_QUIRKS_COUNTERPART_GUID		"CounterpartGuid"
 #define	FU_QUIRKS_PARENT_GUID			"ParentGuid"
+#define	FU_QUIRKS_PROXY_GUID			"ProxyGuid"
 #define	FU_QUIRKS_CHILDREN			"Children"
 #define	FU_QUIRKS_VERSION			"Version"
 #define	FU_QUIRKS_VENDOR			"Vendor"

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -575,6 +575,8 @@ LIBFWUPDPLUGIN_1.4.0 {
 LIBFWUPDPLUGIN_1.4.1 {
   global:
     fu_device_get_proxy;
+    fu_device_get_proxy_guid;
     fu_device_set_proxy;
+    fu_device_set_proxy_guid;
   local: *;
 } LIBFWUPDPLUGIN_1.4.0;


### PR DESCRIPTION
This allows us to use a proxy even if the proxy device was created in a
different plugin or where the GTypes are not known to each other.
