### PR TITLE
build: Install systemd files relative to our prefix

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -92,7 +92,7 @@ if get_option('systemd') and build_daemon
     output : 'fwupd.shutdown',
     configuration : con2,
     install: true,
-    install_dir: systemd.get_pkgconfig_variable('systemdshutdowndir'),
+    install_dir: systemd_shutdown_dir,
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -350,10 +350,15 @@ if build_standalone and get_option('systemd')
   conf.set('HAVE_SYSTEMD' , '1')
   conf.set('HAVE_LOGIND' , '1')
   systemdunitdir = get_option('systemdunitdir')
-  if systemdunitdir == '' and get_option('systemd')
-    systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+  systemd_root_prefix = get_option('systemd_root_prefix')
+  if systemd_root_prefix == ''
+    systemd_root_prefix = prefix
   endif
-  systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir')
+  if systemdunitdir == '' and get_option('systemd')
+    systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir', define_variable: ['rootprefix', systemd_root_prefix])
+  endif
+  systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir', define_variable: ['rootprefix', systemd_root_prefix])
+  systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir', define_variable: ['rootprefix', systemd_root_prefix])
 endif
 
 if build_standalone and get_option('elogind')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,7 @@ option('plugin_modem_manager', type : 'boolean', value : false, description : 'e
 option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
 option('plugin_coreboot', type : 'boolean', value : true, description : 'enable coreboot support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
+option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on (defaults to prefix)')
 option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
 option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
 option('tests', type : 'boolean', value : true, description : 'enable tests')


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

-----

It is a good practice to install files relative to our own variables

bassi.io/articles/2018/03/15/pkg-config-and-paths

and it is required on systems like NixOS.

See also systemd/systemd@1c2c7c6



Note that on next systemd release, this will likely need to be changed:  https://github.com/systemd/systemd/commit/4908de44b0a0409f84a7cdc5641b114d6ce8ba03