### PR TITLE
build: Allow overriding prefix for systemd file installation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -92,7 +92,7 @@ if get_option('systemd') and build_daemon
     output : 'fwupd.shutdown',
     configuration : con2,
     install: true,
-    install_dir: systemd.get_pkgconfig_variable('systemdshutdowndir'),
+    install_dir: systemd_shutdown_dir,
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -349,11 +349,16 @@ if build_standalone and get_option('systemd')
   systemd = dependency('systemd', version : '>= 211')
   conf.set('HAVE_SYSTEMD' , '1')
   conf.set('HAVE_LOGIND' , '1')
-  systemdunitdir = get_option('systemdunitdir')
-  if systemdunitdir == '' and get_option('systemd')
+  systemd_root_prefix = get_option('systemd_root_prefix')
+  if systemd_root_prefix == ''
     systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+    systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir')
+    systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir')
+  else
+    systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir', define_variable: ['rootprefix', systemd_root_prefix])
+    systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir', define_variable: ['rootprefix', systemd_root_prefix])
+    systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir', define_variable: ['rootprefix', systemd_root_prefix])
   endif
-  systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir')
 endif
 
 if build_standalone and get_option('elogind')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('plugin_modem_manager', type : 'boolean', value : false, description : 'e
 option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
 option('plugin_coreboot', type : 'boolean', value : true, description : 'enable coreboot support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
-option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
+option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
 option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
 option('tests', type : 'boolean', value : true, description : 'enable tests')
 option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Replaces #2004

It is a good practice to install files relative to our own variables
bassi.io/articles/2018/03/15/pkg-config-and-paths
and it is required on systems like NixOS.

Unfortunately, systemd allows overriding the root prefix,
see also systemd/systemd@1c2c7c6,
so we cannot just do that.

Let's at least make the systemd installation prefix overridable.

This will also allow us to drop `systemdsystemunitdir` option since
systemd hardcodes it to `${rootprefix}/lib/systemd/system`.