### PR TITLE
trivial: Remove double call to g_source_remove()

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -620,10 +620,6 @@ fu_device_list_add (FuDeviceList *self, FuDevice *device)
 	if (item != NULL && item->remove_id != 0) {
 		g_debug ("found existing device %s, reusing item",
 			 fu_device_get_id (item->device));
-		if (item->remove_id != 0) {
-			g_source_remove (item->remove_id);
-			item->remove_id = 0;
-		}
 		fu_device_list_replace (self, item, device);
 		return;
 	}


### PR DESCRIPTION
The fu_device_list_replace() function does this automatically.
