### PR TITLE
build: Install bash-completion relative to datadir

### DIFF
--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -1,12 +1,12 @@
 if bashcomp.found()
-  tgt = bashcomp.get_pkgconfig_variable('completionsdir',
-                                         define_variable: [ 'prefix', prefix ],
+  completions_dir = bashcomp.get_pkgconfig_variable('completionsdir',
+    define_variable: bashcomp.version().version_compare('>= 2.10') ? ['datadir', datadir] : ['prefix', prefix],
   )
 
 
 if get_option('agent')
     install_data(['fwupdagent'],
-      install_dir : tgt,
+      install_dir : completions_dir,
     )
 endif # get_option('agent')
 
@@ -19,7 +19,7 @@ configure_file(
   output : 'fwupdtool',
   configuration : con2,
   install: true,
-  install_dir: tgt)
+  install_dir: completions_dir)
 
 if build_daemon and get_option('agent')
 configure_file(
@@ -27,7 +27,7 @@ configure_file(
   output : 'fwupdmgr',
   configuration : con2,
   install: true,
-  install_dir: tgt)
+  install_dir: completions_dir)
 endif # build_daemon and get_option('agent')
 
 endif # bashcomp.found()


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Since bash-completion 2.9, it was no longer possible to override
the `completionsdir` through prefix. [1] In 2.10, the overridability
was re-estabilished but this time through `datadir` variable. [2]

This should not really matter except for developers installing the project
into a custom prefix or distros using per-package prefixes like NixOS.

[1]: scop/bash-completion@81ba2c7
[2]: scop/bash-completion#344

Tested on NixOS with bash-completion 2.9 with the offending patch [1] reverted and with 2.10.