### PR TITLE
vli: Use GPIOB to reset the VL817 found in two Lenovo products

### DIFF
--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -45,6 +45,8 @@ fu_vli_usbhub_pd_device_probe (FuDevice *device, GError **error)
 	guint32 fwver;
 	g_autofree gchar *fwver_str = NULL;
 	g_autofree gchar *instance_id1 = NULL;
+	g_autofree gchar *instance_id2 = NULL;
+	g_autofree gchar *instance_id3 = NULL;
 
 	/* get version */
 	fwver = GUINT32_FROM_BE (self->hdr.fwver);
@@ -67,6 +69,16 @@ fu_vli_usbhub_pd_device_probe (FuDevice *device, GError **error)
 					GUINT16_FROM_LE (self->hdr.pid),
 					fu_vli_common_device_kind_to_string (self->device_kind));
 	fu_device_add_instance_id (device, instance_id1);
+
+	/* add standard GUIDs in order of priority */
+	instance_id2 = g_strdup_printf ("USB\\VID_%04X&PID_%04X",
+					GUINT16_FROM_LE (self->hdr.vid),
+					GUINT16_FROM_LE (self->hdr.pid));
+	fu_device_add_instance_id (device, instance_id2);
+	instance_id3 = g_strdup_printf ("USB\\VID_%04X",
+					GUINT16_FROM_LE (self->hdr.vid));
+	fu_device_add_instance_id_full (device, instance_id3,
+					FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 
 	/* these have a backup section */
 	if (fu_vli_common_device_kind_get_offset (self->device_kind) == VLI_USBHUB_FLASHMAP_ADDR_PD)

--- a/plugins/vli/vli-usbhub-lenovo.quirk
+++ b/plugins/vli/vli-usbhub-lenovo.quirk
@@ -162,12 +162,18 @@ Flags = usb2,has-shared-spi-pd
 [DeviceInstanceId=USB\VID_17EF&PID_3094]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-shared-spi-pd
+Flags = usb3,has-shared-spi-pd,attach-with-gpiob
 CounterpartGuid = USB\VID_17EF&PID_3095
 [DeviceInstanceId=USB\VID_17EF&PID_3095]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb2,has-shared-spi-pd
+Flags = usb2,attach-with-gpiob
+ParentGuid = USB\VID_17EF&PID_3094
+[DeviceInstanceId=USB\VID_17EF&PID_3097]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2
+ParentGuid = USB\VID_17EF&PID_3094
 
 # Lenovo Travel Hub 1in3
 [DeviceInstanceId=USB\VID_17EF&PID_7228]
@@ -195,12 +201,12 @@ Flags = usb2,has-shared-spi-pd
 [DeviceInstanceId=USB\VID_17EF&PID_1039]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-shared-spi-pd
+Flags = usb3,has-shared-spi-pd,attach-with-gpiob
 CounterpartGuid = USB\VID_17EF&PID_103A
 [DeviceInstanceId=USB\VID_17EF&PID_103A]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb2,has-shared-spi-pd
+Flags = usb2,has-shared-spi-pd,attach-with-gpiob
 
 # Lenovo Gen2 dock
 [DeviceInstanceId=USB\VID_17EF&PID_A391]


### PR DESCRIPTION
If these devices really are shared SPI then we don't need to redirect the attach to another device and can directly handle the quirk in the usb hub device.  tl;dr: I over-thought the problem.