### PR TITLE
Allow specifying the device on the command line by GUID

### DIFF
--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -99,6 +99,10 @@ FwupdDevice	*fwupd_client_get_device_by_id		(FwupdClient	*client,
 							 const gchar	*device_id,
 							 GCancellable	*cancellable,
 							 GError		**error);
+GPtrArray	*fwupd_client_get_devices_by_guid	(FwupdClient	*client,
+							 const gchar	*guid,
+							 GCancellable	*cancellable,
+							 GError		**error);
 gboolean	 fwupd_client_install			(FwupdClient	*client,
 							 const gchar	*device_id,
 							 const gchar	*filename,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -442,6 +442,7 @@ LIBFWUPD_1.4.0 {
 
 LIBFWUPD_1.4.1 {
   global:
+    fwupd_client_get_devices_by_guid;
     fwupd_device_id_is_valid;
   local: *;
 } LIBFWUPD_1.4.0;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3535,6 +3535,44 @@ fu_engine_get_device (FuEngine *self, const gchar *device_id, GError **error)
 }
 
 /**
+ * fu_engine_get_devices_by_guid:
+ * @self: A #FuEngine
+ * @guid: A GUID
+ * @error: A #GError, or %NULL
+ *
+ * Gets a specific device.
+ *
+ * Returns: (transfer full): a device, or %NULL if not found
+ **/
+GPtrArray *
+fu_engine_get_devices_by_guid (FuEngine *self, const gchar *guid, GError **error)
+{
+	g_autoptr(GPtrArray) devices = NULL;
+	g_autoptr(GPtrArray) devices_tmp = NULL;
+
+	/* find the devices by GUID */
+	devices_tmp = fu_device_list_get_all (self->device_list);
+	devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+	for (guint i = 0; i < devices_tmp->len; i++) {
+		FuDevice *dev_tmp = g_ptr_array_index (devices_tmp, i);
+		if (fu_device_has_guid (dev_tmp, guid))
+			g_ptr_array_add (devices, g_object_ref (dev_tmp));
+	}
+
+	/* nothing */
+	if (devices->len == 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_FOUND,
+			     "failed to find any device providing %s", guid);
+		return NULL;
+	}
+
+	/* success */
+	return g_steal_pointer (&devices);
+}
+
+/**
  * fu_engine_get_history:
  * @self: A #FuEngine
  * @error: A #GError, or %NULL

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -60,6 +60,9 @@ GPtrArray	*fu_engine_get_devices			(FuEngine	*self,
 FuDevice	*fu_engine_get_device			(FuEngine	*self,
 							 const gchar	*device_id,
 							 GError		**error);
+GPtrArray	*fu_engine_get_devices_by_guid		(FuEngine	*self,
+							 const gchar	*guid,
+							 GError		**error);
 GPtrArray	*fu_engine_get_history			(FuEngine	*self,
 							 GError		**error);
 FwupdRemote 	*fu_engine_get_remote_by_id		(FuEngine	*self,


### PR DESCRIPTION
The GUID is the only stable identifier, and allowing using the GUID makes it
much easier to test specific devices.
