### PR TITLE
thunderbolt: Don't show safe mode errors for USB4 host controllers

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -333,7 +333,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 
 	version = fu_plugin_thunderbolt_udev_get_version (device);
 	/* test for safe mode */
-	if (is_host && version == NULL) {
+	if (is_host && version == NULL && gen < 4) {
 		g_autoptr(GError) error_local = NULL;
 		g_autofree gchar *test_safe = NULL;
 		g_autofree gchar *safe_path = NULL;


### PR DESCRIPTION
USB4 Controllers were showing up like this:

USB4 Controller:
     Device ID:           3df660bc4bdb67fd6fc101b34c6fd8cd235e3f97
     Summary:             Unmatched performance for high-speed I/O
     Current version:     00.00
     Update Error:        Device is in safe mode
     GUID:                4d86f168-e1cc-5995-afd3-ae9df6a14f5e -> TBT-safemode
     Device Flags:         Internal device
                           Requires AC power

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

cc @djcampello 