### PR TITLE
Clarify invalid arguments display (Fixes: #2045)

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2277,17 +2277,14 @@ main (int argc, char *argv[])
 	/* run the specified command */
 	ret = fu_util_cmd_array_run (cmd_array, priv, argv[1], (gchar**) &argv[2], &error);
 	if (!ret) {
+		g_printerr ("%s\n", error->message);
 		if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS)) {
-			g_autofree gchar *tmp = NULL;
-			tmp = g_option_context_get_help (priv->context, TRUE, NULL);
-			g_print ("%s\n\n%s", error->message, tmp);
-			return EXIT_FAILURE;
-		}
-		if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
-			g_print ("%s\n", error->message);
+			/* TRANSLATORS: error message explaining command to run to how to get help */
+			g_printerr ("\n%s\n", _("Use fwupdtool --help for help"));
+		} else if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
+			g_debug ("%s\n", error->message);
 			return EXIT_NOTHING_TO_DO;
 		}
-		g_print ("%s\n", error->message);
 		return EXIT_FAILURE;
 	}
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2434,14 +2434,6 @@ fu_util_check_polkit_actions (GError **error)
 	return TRUE;
 }
 
-static void
-fu_util_display_help (FuUtilPrivate *priv)
-{
-	g_autofree gchar *tmp = NULL;
-	tmp = g_option_context_get_help (priv->context, TRUE, NULL);
-	g_printerr ("%s\n", tmp);
-}
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuUtilPrivate, fu_util_private_free)
@@ -2829,15 +2821,17 @@ main (int argc, char *argv[])
 	/* run the specified command */
 	ret = fu_util_cmd_array_run (cmd_array, priv, argv[1], (gchar**) &argv[2], &error);
 	if (!ret) {
-		ret = EXIT_FAILURE;
 		g_printerr ("%s\n", error->message);
-		if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS))
-			fu_util_display_help (priv);
-		else if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
-			ret = EXIT_NOTHING_TO_DO;
-	} else {
-		ret = EXIT_SUCCESS;
+		if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS)) {
+			/* TRANSLATORS: error message explaining command to run to how to get help */
+			g_printerr ("\n%s\n", _("Use fwupdmgr --help for help"));
+		} else if (g_error_matches (error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
+			g_debug ("%s\n", error->message);
+			return EXIT_NOTHING_TO_DO;
+		}
+		return EXIT_FAILURE;
 	}
 
-	return ret;
+	/* success */
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Avoid a wall of text and instead direct people to `--help` output.
Also sync up this section of code between `fu-util.c` and `fu-tool.c`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
