### PR TITLE
uefi: Manually call fu_device_setup() during coldplug

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -499,6 +499,8 @@ fu_plugin_uefi_coldplug_device (FuPlugin *plugin, FuUefiDevice *dev, GError **er
 	/* probe to get add GUIDs (and hence any quirk fixups) */
 	if (!fu_device_probe (FU_DEVICE (dev), error))
 		return FALSE;
+	if (!fu_device_setup (FU_DEVICE (dev), error))
+		return FALSE;
 
 	/* if not already set by quirks */
 	if (fu_device_get_custom_flags (FU_DEVICE (dev)) == NULL) {


### PR DESCRIPTION
This forces the daemon to convert the main-system-firmware instance ID to a
GUID, which allows us to find it using fu_device_list_get_by_guid()
