### PR TITLE
Switch the default of EnumerateAllDevices to false

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -27,4 +27,4 @@ VerboseDomains=
 UpdateMotd=true
 
 # For some plugins, enumerate only devices supported by metadata
-EnumerateAllDevices=true
+EnumerateAllDevices=false


### PR DESCRIPTION
This was causing dozens of regressions to be reported.
