### PR TITLE
synaptics-rmi: Whitelist the specific device to avoid causing regress…

### DIFF
--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -1007,6 +1007,9 @@ fu_synaptics_rmi_device_init (FuSynapticsRmiDevice *self)
 	fu_device_set_name (FU_DEVICE (self), "Touchpad");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
+	/* there are a lot of Synaptics HID peripherals, but not all respond
+	 * well to probing -- so limit to ones with issued updates */
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ONLY_SUPPORTED);
 	priv->functions = g_ptr_array_new_with_free_func (g_free);
 }
 

--- a/plugins/synaptics-rmi/synaptics-rmi.quirk
+++ b/plugins/synaptics-rmi/synaptics-rmi.quirk
@@ -1,3 +1,10 @@
 [DeviceInstanceId=HIDRAW\VEN_06CB]
 Plugin = synaptics_rmi
 Vendor = Synaptics
+
+[DeviceInstanceId=HIDRAW\VEN_06CB&DEV_4875]
+Flags = ~only-supported
+[DeviceInstanceId=HIDRAW\VEN_06CB&DEV_76AF]
+Flags = ~only-supported
+[DeviceInstanceId=HIDRAW\VEN_06CB&DEV_CD8B]
+Flags = ~only-supported


### PR DESCRIPTION
…ions

Apparently some RMI4 devices get upset when setting the RMA page.

Fixes https://github.com/fwupd/fwupd/issues/2052
