### PR TITLE
check dfuMANIFEST state before validating successful write

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -871,6 +871,14 @@ dfu_device_refresh (DfuDevice *device, GError **error)
 	if (!dfu_device_ensure_interface (device, error))
 		return FALSE;
 
+	/* Device that cannot communicate via the USB after the
+	 * Manifestation phase indicated this limitation to the
+	 * host by clearing bmAttributes bit bitManifestationTolerant.
+	 * so we assume the operation was succesful */
+	if (priv->state == DFU_STATE_DFU_MANIFEST &&
+	    !(priv->attributes & DFU_DEVICE_ATTRIBUTE_MANIFEST_TOL))
+		return TRUE;
+
 	if (!g_usb_device_control_transfer (usb_device,
 					    G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
 					    G_USB_DEVICE_REQUEST_TYPE_CLASS,

--- a/plugins/dfu/dfu-target-stm.c
+++ b/plugins/dfu/dfu-target-stm.c
@@ -29,6 +29,8 @@ G_DEFINE_TYPE (DfuTargetStm, dfu_target_stm, DFU_TYPE_TARGET)
 static gboolean
 dfu_target_stm_attach (DfuTarget *target, GError **error)
 {
+	/* downloading empty payload will cause a dfu to leave,
+	 * the returned status will be dfuMANIFEST and expect the device to disconnect */
 	g_autoptr(GBytes) bytes_tmp = g_bytes_new (NULL, 0);
 	return dfu_target_download_chunk (target, 2, bytes_tmp, error);
 }

--- a/plugins/dfu/dfu-tool.c
+++ b/plugins/dfu/dfu-tool.c
@@ -938,8 +938,11 @@ dfu_tool_write (DfuToolPrivate *priv, gchar **values, GError **error)
 	/* do host reset */
 	if (!fu_device_attach (FU_DEVICE (device), error))
 		return FALSE;
-	if (!dfu_device_wait_for_replug (priv, device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE, error))
-		return FALSE;
+
+	if (dfu_device_has_attribute (device, DFU_DEVICE_ATTRIBUTE_MANIFEST_TOL)) {
+		if (!dfu_device_wait_for_replug (priv, device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE, error))
+			return FALSE;
+	}
 
 	/* success */
 	g_print ("%u bytes successfully downloaded to device\n",


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

flash stm32f7 ends with log error,  This is PR validates dfuMANIFEST state to return earlier.
```
device-write:	93%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.185: got #00aa chunk @0x8065000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.188: got #00ab chunk @0x8065800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.188: setting percentage 94% of device-verify
device-write:	94%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.191: got #00ac chunk @0x8066000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.194: got #00ad chunk @0x8066800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.194: setting percentage 95% of device-verify
device-write:	95%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.197: got #00ae chunk @0x8067000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.200: got #00af chunk @0x8067800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.200: setting percentage 96% of device-verify
device-write:	96%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.203: got #00b0 chunk @0x8068000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.203: setting percentage 97% of device-verify
device-write:	97%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.206: got #00b1 chunk @0x8068800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.209: got #00b2 chunk @0x8069000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.209: setting percentage 98% of device-verify
device-write:	98%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.212: got #00b3 chunk @0x8069800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.215: got #00b4 chunk @0x806a000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.215: setting percentage 99% of device-verify
device-write:	99%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.218: got #00b5 chunk @0x806a800 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.221: got #00b6 chunk @0x806b000 of size 2048
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.221: setting percentage 100% of device-verify
device-write:	100%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.221: setting action idle
idle:	100%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.221: refreshed status=OK and state=dfuIDLE (dnload=0)
device-restart:	100%
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.222: refreshed status=OK and state=dfuMANIFEST (dnload=1)
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.222: setting action device-busy
(dfu-tool:308390): FuPluginDfu-DEBUG: 04:26:52.222: sleeping for 1ms…
cannot get device state: transfer failed
```
