### PR TITLE
support MATEKF722SE quirck

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -43,6 +43,7 @@
  * * `use-protocol-zero`:	Fix up the protocol number
  * * `legacy-protocol`:		Use a legacy protocol version
  * * `detach-for-attach`:	Requires a DFU_REQUEST_DETACH to attach
+ * * `absent-sector-size`:	In absense of sector size, assume byte
  *
  * Default value: `none`
  *

--- a/plugins/dfu/dfu-target.c
+++ b/plugins/dfu/dfu-target.c
@@ -198,6 +198,15 @@ dfu_target_parse_sector (DfuTarget *target,
 		return FALSE;
 	}
 
+	/* handle weirdness */
+	if (fu_device_has_custom_flag (FU_DEVICE (dfu_target_get_device (target)),
+				       "absent-sector-size")) {
+		if (tmp[1] == '\0') {
+			tmp[1] = tmp[0];
+			tmp[0] = 'B';
+		}
+	}
+
 	/* get multiplier */
 	switch (tmp[0]) {
 	case 'B':		/* byte */

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -325,6 +325,7 @@ DfuAltName = @Flash/0x0/1*32Kg
 
 # STM32F745 dfuse bootloader
 [DeviceInstanceId=USB\VID_0483&PID_DF11]
+Flags = absent-sector-size
 Plugin = dfu
 DfuForceVersion = 011a
 DfuForceTimeout = 5000


### PR DESCRIPTION
MATEKF722SE has unconvetional behavior for dfu protocol,
sector size isn't specified and sector type is shiffted left by 1
this happens only for one sector

sector parsing from MATEKF722SE
*016Kg
*64Kg
*128Kg
*048 e
*528e
*004 e

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
