### PR TITLE
cpu: Parse the CPU flags to detect the CET status

### DIFF
--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -10,13 +10,49 @@
 
 struct _FuCpuDevice {
 	FuDevice		 parent_instance;
+	gboolean		 has_shstk;
+	gboolean		 has_ibt;
 };
 
 G_DEFINE_TYPE (FuCpuDevice, fu_cpu_device, FU_TYPE_DEVICE)
 
-static void fu_cpu_device_parse_section (FuDevice *dev, const gchar *data)
+gboolean
+fu_cpu_device_has_shstk (FuCpuDevice *self)
+{
+	return self->has_shstk;
+}
+
+gboolean
+fu_cpu_device_has_ibt (FuCpuDevice *self)
+{
+	return self->has_ibt;
+}
+
+static void
+fu_cpu_device_to_string (FuDevice *device, guint idt, GString *str)
+{
+	FuCpuDevice *self = FU_CPU_DEVICE (device);
+	fu_common_string_append_kb (str, idt, "HasSHSTK", self->has_shstk);
+	fu_common_string_append_kb (str, idt, "HasIBT", self->has_ibt);
+}
+
+static void
+fu_cpu_device_parse_flags (FuCpuDevice *self, const gchar *data)
+{
+	g_auto(GStrv) flags = g_strsplit (data, " ", -1);
+	for (guint i = 0; flags[i] != NULL; i++) {
+		if (g_strcmp0 (flags[i], "shstk") == 0)
+			self->has_shstk = TRUE;
+		if (g_strcmp0 (flags[i], "ibt") == 0)
+			self->has_ibt = TRUE;
+	}
+}
+
+static void
+fu_cpu_device_parse_section (FuDevice *dev, const gchar *data)
 {
 	g_auto(GStrv) lines = NULL;
+	FuCpuDevice *self = FU_CPU_DEVICE (dev);
 
 	lines = g_strsplit (data, "\n", 0);
 	for (guint i = 0; lines[i] != NULL; i++) {
@@ -38,6 +74,10 @@ static void fu_cpu_device_parse_section (FuDevice *dev, const gchar *data)
 				g_autofree gchar *tmp = g_strdup_printf ("cpu:%s", g_strchug (fields[1]));
 				fu_device_set_physical_id (dev, tmp);
 			}
+		} else if (g_str_has_prefix (lines[i], "flags")) {
+			g_auto(GStrv) fields = g_strsplit (lines[i], ":", -1);
+			if (fields[1] != NULL)
+				fu_cpu_device_parse_flags (self, fields[1]);
 		}
 	}
 }
@@ -54,6 +94,8 @@ fu_cpu_device_init (FuCpuDevice *self)
 static void
 fu_cpu_device_class_init (FuCpuDeviceClass *klass)
 {
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	klass_device->to_string = fu_cpu_device_to_string;
 }
 
 FuCpuDevice *

--- a/plugins/cpu/fu-cpu-device.h
+++ b/plugins/cpu/fu-cpu-device.h
@@ -12,3 +12,5 @@
 G_DECLARE_FINAL_TYPE (FuCpuDevice, fu_cpu_device, FU, CPU_DEVICE, FuDevice)
 
 FuCpuDevice		*fu_cpu_device_new		(const gchar	*section);
+gboolean		 fu_cpu_device_has_shstk	(FuCpuDevice	*self);
+gboolean		 fu_cpu_device_has_ibt		(FuCpuDevice	*self);


### PR DESCRIPTION
New enough hardware to have this feature isn't going to be in the marketplace
for a while. To use that newer hardware requires a very recent kernel (5.6 at
least, although it will probably be at least 5.9 by the time the hardware is
released).

The CET status will be used in future functionality.
