### PR TITLE
trivial: reword the security cases for a few plugins

### DIFF
--- a/plugins/acpi-facp/fu-plugin-acpi-facp.c
+++ b/plugins/acpi-facp/fu-plugin-acpi-facp.c
@@ -29,7 +29,7 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	/* create attr */
 	attr = fwupd_security_attr_new ("org.uefi.ACPI.Facp");
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
-	fwupd_security_attr_set_name (attr, "Suspend2Idle");
+	fwupd_security_attr_set_name (attr, "Suspend To Idle");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load FACP table */

--- a/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
+++ b/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
@@ -71,7 +71,7 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 
 	/* create attr */
 	attr = fwupd_security_attr_new ("org.kernel.CheckLockdown");
-	fwupd_security_attr_set_name (attr, "Linux Kernel");
+	fwupd_security_attr_set_name (attr, "Linux Kernel Lockdown");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
 
@@ -79,7 +79,7 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!g_file_load_contents (data->file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path (data->file);
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, "Not supported");
 		return;
 	}
 	if (g_strstr_len (buf, bufsz, "[integrity]") == NULL &&

--- a/plugins/linux-tainted/fu-plugin-linux-tainted.c
+++ b/plugins/linux-tainted/fu-plugin-linux-tainted.c
@@ -71,7 +71,7 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 
 	/* create attr */
 	attr = fwupd_security_attr_new ("org.kernel.CheckTainted");
-	fwupd_security_attr_set_name (attr, "Linux Kernel");
+	fwupd_security_attr_set_name (attr, "Linux Kernel Taint");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
 


### PR DESCRIPTION
On a system that is not at all locked down running an old kernel several
of the items are a bit confusing.

```
Runtime Suffix -!
✔  fwupd plugins: OK
✔  Linux Kernel: OK
✘  Linux Kernel: Could not open file
✘  Linux Swap: Not encrypted
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
