### PR TITLE
trivial: if not specified try to use some better dbx defaults

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -289,11 +289,16 @@ if build_standalone and get_option('plugin_uefi')
   efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
   conf.set_quoted ('EFI_APP_LOCATION', efi_app_location)
 
-  # e.g. could be:
-  # * /usr/share/dbxtool for Red Hat
-  # * /usr/share/secureboot/updates/dbx for Ubuntu
   efi_dbxdir = get_option('efi_dbxdir')
+  if efi_dbxdir == ''
+    foreach dir : ['/usr/share/secureboot/updates/dbx', '/usr/share/dbxtool']
+      if run_command('[', '-d', dir, ']').returncode() == 0
+        efi_dbxdir = dir
+      endif
+    endforeach
+  endif
   if efi_dbxdir != ''
+    message('efi-dbxdir: "@0@"'.format(efi_dbxdir))
     conf.set_quoted ('FWUPD_EFI_DBXDIR', efi_dbxdir)
   endif
 


### PR DESCRIPTION
On Ubuntu and Fedora try to look for existing dbx database
directories.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
