### PR TITLE
trivial: add versioning into HSI measurement

### DIFF
--- a/libfwupdplugin/fu-security-attrs-private.h
+++ b/libfwupdplugin/fu-security-attrs-private.h
@@ -6,10 +6,25 @@
 
 #pragma once
 
+/**
+ * FuSecurityAttrsFlags:
+ * @FU_SECURITY_ATTRS_FLAG_NONE:		No flags set
+ * @FU_SECURITY_ATTRS_FLAG_ADD_VERSION:		Add the daemon version to the HSI string
+ *
+ * The flags to use when calculating an HSI version.
+ **/
+typedef enum {
+	FU_SECURITY_ATTRS_FLAG_NONE			= 0,
+	FU_SECURITY_ATTRS_FLAG_ADD_VERSION		= 1 << 0,
+	/*< private >*/
+	FU_SECURITY_ATTRS_FLAG_LAST
+} FuSecurityAttrsFlags;
+
 #include "fu-security-attrs.h"
 
 FuSecurityAttrs	*fu_security_attrs_new			(void);
-gchar		*fu_security_attrs_calculate_hsi	(FuSecurityAttrs	*self);
+gchar		*fu_security_attrs_calculate_hsi	(FuSecurityAttrs	*self,
+							 FuSecurityAttrsFlags    flags);
 void		 fu_security_attrs_depsolve		(FuSecurityAttrs	*self);
 GVariant	*fu_security_attrs_to_variant		(FuSecurityAttrs	*self);
 GPtrArray	*fu_security_attrs_get_all		(FuSecurityAttrs	*self);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1753,12 +1753,14 @@ fu_security_attrs_hsi_func (void)
 	g_autofree gchar *hsi5 = NULL;
 	g_autofree gchar *hsi6 = NULL;
 	g_autofree gchar *hsi7 = NULL;
+	g_autofree gchar *hsi8 = NULL;
+	g_autofree gchar *expected_hsi8 = NULL;
 	g_autoptr(FuSecurityAttrs) attrs = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* no attrs */
 	attrs = fu_security_attrs_new ();
-	hsi1 = fu_security_attrs_calculate_hsi (attrs);
+	hsi1 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi1, ==, "HSI:0");
 
 	/* just success from HSI:1 */
@@ -1767,7 +1769,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fu_security_attrs_append (attrs, attr);
-	hsi2 = fu_security_attrs_calculate_hsi (attrs);
+	hsi2 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi2, ==, "HSI:1");
 	g_clear_object (&attr);
 
@@ -1776,7 +1778,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_set_plugin (attr, "test");
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
 	fu_security_attrs_append (attrs, attr);
-	hsi3 = fu_security_attrs_calculate_hsi (attrs);
+	hsi3 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi3, ==, "HSI:1");
 	g_clear_object (&attr);
 
@@ -1788,7 +1790,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_add_obsolete (attr, "org.fwupd.hsi.PRX");
 	fu_security_attrs_append (attrs, attr);
 	fu_security_attrs_depsolve (attrs);
-	hsi4 = fu_security_attrs_calculate_hsi (attrs);
+	hsi4 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi4, ==, "HSI:3");
 	g_clear_object (&attr);
 
@@ -1798,7 +1800,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
-	hsi5 = fu_security_attrs_calculate_hsi (attrs);
+	hsi5 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi5, ==, "HSI:3");
 	g_clear_object (&attr);
 
@@ -1809,7 +1811,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fu_security_attrs_append (attrs, attr);
-	hsi6 = fu_security_attrs_calculate_hsi (attrs);
+	hsi6 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi6, ==, "HSI:3+UA");
 	g_clear_object (&attr);
 
@@ -1818,8 +1820,21 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_set_plugin (attr, "test");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
-	hsi7 = fu_security_attrs_calculate_hsi (attrs);
+	hsi7 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
 	g_assert_cmpstr (hsi7, ==, "HSI:3+UA!");
+	g_clear_object (&attr);
+
+	/* show version in the attribute */
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_KERNEL_SWAP);
+	fwupd_security_attr_set_plugin (attr, "test");
+	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
+	fu_security_attrs_append (attrs, attr);
+	hsi8 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
+	expected_hsi8 = g_strdup_printf ("HSI:3+UA! (v%d.%d.%d)",
+					FWUPD_MAJOR_VERSION,
+					FWUPD_MINOR_VERSION,
+					FWUPD_MICRO_VERSION);
+	g_assert_cmpstr (hsi8, ==, expected_hsi8);
 	g_clear_object (&attr);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3604,7 +3604,7 @@ fu_engine_get_history_set_hsi_attrs (FuEngine *self, FuDevice *device)
 	}
 
 	/* computed value */
-	host_security_id = fu_security_attrs_calculate_hsi (attrs);
+	host_security_id = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
 	fu_device_set_metadata (device, "HSI", host_security_id);
 }
 
@@ -5218,7 +5218,8 @@ fu_engine_get_host_security_id (FuEngine *self)
 		self->host_security_id = NULL;
 		self->host_security_id_valid = TRUE;
 		attrs = fu_engine_get_host_security_attrs (self);
-		self->host_security_id = fu_security_attrs_calculate_hsi (attrs);
+		self->host_security_id = fu_security_attrs_calculate_hsi (attrs,
+									  FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
 	}
 
 	return self->host_security_id;


### PR DESCRIPTION
Show the fwupd version in the HSI string so items can be cross
referenced to the spec from when they were first added

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
