### PR TITLE
Allow client tools to translate the HSI attributes and results

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -24,7 +24,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
 #define FWUPD_RESULT_KEY_URGENCY		"Urgency"	/* u */
 #define FWUPD_RESULT_KEY_HSI_LEVEL		"HsiLevel"	/* u */
-#define FWUPD_RESULT_KEY_HSI_RESULT		"HsiResult"	/* s */
+#define FWUPD_RESULT_KEY_HSI_RESULT		"HsiResult"	/* u */
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */
 #define FWUPD_RESULT_KEY_GUID			"Guid"		/* as */
 #define FWUPD_RESULT_KEY_INSTANCE_IDS		"InstanceIds"	/* as */

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -71,6 +71,68 @@ typedef enum {
 	FWUPD_SECURITY_ATTR_LEVEL_LAST			= 6	/* perhaps increased in the future */
 } FwupdSecurityAttrLevel;
 
+/**
+ * FwupdSecurityAttrResult:
+ * @FWUPD_SECURITY_ATTR_RESULT_UNKNOWN:			Not known
+ * @FWUPD_SECURITY_ATTR_RESULT_ENABLED:			Enabled
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED:		Not enabled
+ * @FWUPD_SECURITY_ATTR_RESULT_VALID:			Valid
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_VALID:		Not valid
+ * @FWUPD_SECURITY_ATTR_RESULT_LOCKED:			Locked
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED:		Not locked
+ * @FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED:		Encrypted
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_ENCRYPTED:		Not encrypted
+ * @FWUPD_SECURITY_ATTR_RESULT_TAINTED:			Tainted
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_TAINTED:		Not tainted
+ * @FWUPD_SECURITY_ATTR_RESULT_FOUND:			Found
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND:		NOt found
+ * @FWUPD_SECURITY_ATTR_RESULT_SUPPORTED:		Supported
+ * @FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED:		Not supported
+ *
+ * The HSI result.
+ **/
+typedef enum {
+	FWUPD_SECURITY_ATTR_RESULT_UNKNOWN,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_ENABLED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_VALID,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_VALID,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_LOCKED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_ENCRYPTED,		/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_TAINTED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_TAINTED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_FOUND,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_SUPPORTED,			/* Since: 1.5.0 */
+	FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED,		/* Since: 1.5.0 */
+	/*< private >*/
+	FWUPD_SECURITY_ATTR_RESULT_LAST
+} FwupdSecurityAttrResult;
+
+#define FWUPD_SECURITY_ATTR_ID_ACPI_DMAR		"org.fwupd.hsi.AcpiDmar"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM		"org.fwupd.hsi.EncryptedRam"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_FWUPD_ATTESTATION	"org.fwupd.hsi.FwupdAttestation"	/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_FWUPD_PLUGINS		"org.fwupd.hsi.FwupdPlugins"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_FWUPD_UPDATES		"org.fwupd.hsi.FwupdUpdates"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_INTEL_AMT		"org.fwupd.hsi.IntelAmt"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_INTEL_CET		"org.fwupd.hsi.IntelCet"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_IOMMU			"org.fwupd.hsi.Iommu"			/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_KERNEL_LOCKDOWN		"org.fwupd.hsi.KernelLockdown"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_KERNEL_SWAP		"org.fwupd.hsi.KernelSwap"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_KERNEL_TAINTED		"org.fwupd.hsi.KernelTainted"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_MEI_MANUFACTURING_MODE	"org.fwupd.hsi.MeiManufacturingMode"	/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_SPI_BIOSWE		"org.fwupd.hsi.SpiBioswe"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_SPI_BLE			"org.fwupd.hsi.SpiBle"			/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_SPI_SMM_BWP		"org.fwupd.hsi.SpiSmmBwp"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE		"org.fwupd.hsi.SuspendToIdle"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM		"org.fwupd.hsi.SuspendToRam"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_TPM_RECONSTRUCTION_PCR0	"org.fwupd.hsi.TpmReconstructionPcr0"	/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_TPM_VERSION_20		"org.fwupd.hsi.TpmVersion20"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_UEFI_DBX			"org.fwupd.hsi.UefiDbx"			/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_UEFI_SECUREBOOT		"org.fwupd.hsi.UefiSecureBoot"		/* Since: 1.5.0 */
+
 FwupdSecurityAttr *fwupd_security_attr_new		(const gchar		*appstream_id);
 gchar		*fwupd_security_attr_to_string		(FwupdSecurityAttr	*self);
 
@@ -80,15 +142,18 @@ void		 fwupd_security_attr_set_appstream_id	(FwupdSecurityAttr	*self,
 FwupdSecurityAttrLevel fwupd_security_attr_get_level	(FwupdSecurityAttr	*self);
 void		 fwupd_security_attr_set_level		(FwupdSecurityAttr	*self,
 							 FwupdSecurityAttrLevel	 level);
+FwupdSecurityAttrResult fwupd_security_attr_get_result	(FwupdSecurityAttr	*self);
+void		 fwupd_security_attr_set_result		(FwupdSecurityAttr	*self,
+							 FwupdSecurityAttrResult result);
 const gchar	*fwupd_security_attr_get_name		(FwupdSecurityAttr	*self);
 void		 fwupd_security_attr_set_name		(FwupdSecurityAttr	*self,
 							 const gchar		*name);
 const gchar	*fwupd_security_attr_get_plugin		(FwupdSecurityAttr	*self);
 void		 fwupd_security_attr_set_plugin		(FwupdSecurityAttr	*self,
 							 const gchar		*plugin);
-const gchar	*fwupd_security_attr_get_result		(FwupdSecurityAttr	*self);
-void		 fwupd_security_attr_set_result		(FwupdSecurityAttr	*self,
-							 const gchar		*result);
+const gchar	*fwupd_security_attr_get_url		(FwupdSecurityAttr	*self);
+void		 fwupd_security_attr_set_url		(FwupdSecurityAttr	*self,
+							 const gchar		*url);
 GPtrArray	*fwupd_security_attr_get_obsoletes	(FwupdSecurityAttr	*self);
 void		 fwupd_security_attr_add_obsolete	(FwupdSecurityAttr	*self,
 							 const gchar		*appstream_id);
@@ -103,6 +168,7 @@ gboolean	 fwupd_security_attr_has_flag		(FwupdSecurityAttr	*self,
 							 FwupdSecurityAttrFlags flag);
 const gchar	*fwupd_security_attr_flag_to_string	(FwupdSecurityAttrFlags flag);
 const gchar	*fwupd_security_attr_flag_to_suffix	(FwupdSecurityAttrFlags flag);
+const gchar	*fwupd_security_attr_result_to_string	(FwupdSecurityAttrResult result);
 
 FwupdSecurityAttr *fwupd_security_attr_from_variant	(GVariant		*value);
 GPtrArray	*fwupd_security_attr_array_from_variant	(GVariant		*value);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -465,15 +465,18 @@ LIBFWUPD_1.5.0 {
     fwupd_security_attr_get_plugin;
     fwupd_security_attr_get_result;
     fwupd_security_attr_get_type;
+    fwupd_security_attr_get_url;
     fwupd_security_attr_has_flag;
     fwupd_security_attr_has_obsolete;
     fwupd_security_attr_new;
+    fwupd_security_attr_result_to_string;
     fwupd_security_attr_set_appstream_id;
     fwupd_security_attr_set_flags;
     fwupd_security_attr_set_level;
     fwupd_security_attr_set_name;
     fwupd_security_attr_set_plugin;
     fwupd_security_attr_set_result;
+    fwupd_security_attr_set_url;
     fwupd_security_attr_to_json;
     fwupd_security_attr_to_string;
     fwupd_security_attr_to_variant;

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -262,11 +262,24 @@ fu_security_attrs_depsolve (FuSecurityAttrs *self)
 		for (guint j = 0; j < obsoletes->len; j++) {
 			const gchar *obsolete = g_ptr_array_index (obsoletes, j);
 			FwupdSecurityAttr *attr_tmp = g_hash_table_lookup (attrs_by_id, obsolete);
+
+			/* by AppStream ID */
 			if (attr_tmp != NULL) {
 				g_debug ("security attr %s obsoleted by %s", obsolete,
-					 fwupd_security_attr_get_appstream_id (attr));
+					 fwupd_security_attr_get_appstream_id (attr_tmp));
 				fwupd_security_attr_add_flag (attr_tmp,
 							      FWUPD_SECURITY_ATTR_FLAG_OBSOLETED);
+			}
+
+			/* by plugin name */
+			for (guint k = 0; k < self->attrs->len; k++) {
+				attr_tmp = g_ptr_array_index (self->attrs, k);
+				if (g_strcmp0 (obsolete, fwupd_security_attr_get_plugin (attr_tmp)) == 0) {
+					g_debug ("security attr %s obsoleted by %s", obsolete,
+						 fwupd_security_attr_get_appstream_id (attr_tmp));
+					fwupd_security_attr_add_flag (attr_tmp,
+								      FWUPD_SECURITY_ATTR_FLAG_OBSOLETED);
+				}
 			}
 		}
 	}

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1762,9 +1762,9 @@ fu_security_attrs_hsi_func (void)
 	g_assert_cmpstr (hsi1, ==, "HSI:0");
 
 	/* just success from HSI:1 */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.BIOSWE");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SPI_BIOSWE);
 	fwupd_security_attr_set_plugin (attr, "test");
-	fwupd_security_attr_set_level (attr, 1);
+	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fu_security_attrs_append (attrs, attr);
 	hsi2 = fu_security_attrs_calculate_hsi (attrs);
@@ -1772,20 +1772,20 @@ fu_security_attrs_hsi_func (void)
 	g_clear_object (&attr);
 
 	/* add failed from HSI:2, so still HSI:1 */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.PRX");
+	attr = fwupd_security_attr_new ("org.fwupd.hsi.PRX");
 	fwupd_security_attr_set_plugin (attr, "test");
-	fwupd_security_attr_set_level (attr, 2);
+	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
 	fu_security_attrs_append (attrs, attr);
 	hsi3 = fu_security_attrs_calculate_hsi (attrs);
 	g_assert_cmpstr (hsi3, ==, "HSI:1");
 	g_clear_object (&attr);
 
 	/* add attr from HSI:3, obsoleting the failure */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.BIOSGuard");
+	attr = fwupd_security_attr_new ("org.fwupd.hsi.BIOSGuard");
 	fwupd_security_attr_set_plugin (attr, "test");
-	fwupd_security_attr_set_level (attr, 3);
+	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_add_obsolete (attr, "org.fwupd.Hsi.PRX");
+	fwupd_security_attr_add_obsolete (attr, "org.fwupd.hsi.PRX");
 	fu_security_attrs_append (attrs, attr);
 	fu_security_attrs_depsolve (attrs);
 	hsi4 = fu_security_attrs_calculate_hsi (attrs);
@@ -1793,7 +1793,7 @@ fu_security_attrs_hsi_func (void)
 	g_clear_object (&attr);
 
 	/* add taint that was fine */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.PluginsTainted");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_FWUPD_PLUGINS);
 	fwupd_security_attr_set_plugin (attr, "test");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
@@ -1803,7 +1803,7 @@ fu_security_attrs_hsi_func (void)
 	g_clear_object (&attr);
 
 	/* add updates and attestation */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.LVFS");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_FWUPD_UPDATES);
 	fwupd_security_attr_set_plugin (attr, "test");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION);
@@ -1814,7 +1814,7 @@ fu_security_attrs_hsi_func (void)
 	g_clear_object (&attr);
 
 	/* add issue that was uncool */
-	attr = fwupd_security_attr_new ("org.fwupd.Hsi.Swap");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_KERNEL_SWAP);
 	fwupd_security_attr_set_plugin (attr, "test");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);

--- a/plugins/acpi-dmar/fu-plugin-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-plugin-acpi-dmar.c
@@ -31,10 +31,9 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 		return;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.uefi.ACPI.Dmar");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_ACPI_DMAR);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
-	fwupd_security_attr_set_name (attr, "Pre-boot kernel DMA protection");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load DMAR table */
@@ -43,20 +42,21 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	blob = fu_common_get_contents_bytes (fn, &error_local);
 	if (blob == NULL) {
 		g_warning ("failed to load %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not load DMAR");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	dmar = fu_acpi_dmar_new (blob, &error_local);
 	if (dmar == NULL) {
 		g_warning ("failed to parse %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not parse DMAR");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (!fu_acpi_dmar_get_opt_in (dmar)) {
-		fwupd_security_attr_set_result (attr, "Unavailable");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }

--- a/plugins/acpi-facp/fu-plugin-acpi-facp.c
+++ b/plugins/acpi-facp/fu-plugin-acpi-facp.c
@@ -27,10 +27,9 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.uefi.ACPI.Facp");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
-	fwupd_security_attr_set_name (attr, "Suspend To Idle");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load FACP table */
@@ -39,20 +38,21 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	blob = fu_common_get_contents_bytes (fn, &error_local);
 	if (blob == NULL) {
 		g_warning ("failed to load %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not load FACP");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	facp = fu_acpi_facp_new (blob, &error_local);
 	if (facp == NULL) {
 		g_warning ("failed to parse %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not parse FACP");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (!fu_acpi_facp_get_s2i (facp)) {
-		fwupd_security_attr_set_result (attr, "Default set as suspend-to-ram (S3)");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -579,15 +579,16 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 		return;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("com.intel.AMT");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_INTEL_AMT);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
-	fwupd_security_attr_set_name (attr, "Intel AMT");
 	fu_security_attrs_append (attrs, attr);
 	if (data->provisioned) {
-		fwupd_security_attr_set_result (attr, "Provisioned");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 		return;
 	}
 
+	/* success */
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }

--- a/plugins/cpu/fu-plugin-cpu.c
+++ b/plugins/cpu/fu-plugin-cpu.c
@@ -59,21 +59,20 @@ fu_plugin_add_security_attrs_intel_cet (FuPlugin *plugin, FuSecurityAttrs *attrs
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("com.intel.CET");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_INTEL_CET);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
-	fwupd_security_attr_set_name (attr, "Intel control enforcement technology (CET)");
 	fu_security_attrs_append (attrs, attr);
 
 	/* check for CET */
 	if (!data->has_cet) {
-		fwupd_security_attr_set_result (attr, "Unavailable");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Available");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }
 
 static void
@@ -83,21 +82,20 @@ fu_plugin_add_security_attrs_intel_tme (FuPlugin *plugin, FuSecurityAttrs *attrs
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("com.intel.TME");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
-	fwupd_security_attr_set_name (attr, "Intel total memory encryption (TME)");
 	fu_security_attrs_append (attrs, attr);
 
 	/* check for TME */
 	if (!data->has_tme) {
-		fwupd_security_attr_set_result (attr, "Unavailable");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Available");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }
 
 void

--- a/plugins/iommu/fu-plugin-iommu.c
+++ b/plugins/iommu/fu-plugin-iommu.c
@@ -41,17 +41,17 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.IOMMU");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_IOMMU);
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
-	fwupd_security_attr_set_name (attr, "IOMMU");
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fu_security_attrs_append (attrs, attr);
 
 	if (!data->has_iommu) {
-		fwupd_security_attr_set_result (attr, "Not found");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }

--- a/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
+++ b/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
@@ -70,9 +70,8 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.CheckLockdown");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_KERNEL_LOCKDOWN);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
-	fwupd_security_attr_set_name (attr, "Linux Kernel Lockdown");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
 
@@ -80,16 +79,16 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!g_file_load_contents (data->file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path (data->file);
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Not supported");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strstr_len (buf, bufsz, "[integrity]") == NULL &&
 	    g_strstr_len (buf, bufsz, "[confidentiality]") == NULL) {
-		fwupd_security_attr_set_result (attr, "Not locked down");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Locked down");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }

--- a/plugins/linux-sleep/fu-plugin-linux-sleep.c
+++ b/plugins/linux-sleep/fu-plugin-linux-sleep.c
@@ -25,24 +25,24 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GFile) file = g_file_new_for_path ("/sys/power/mem_sleep");
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.CheckS3Sleep");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
-	fwupd_security_attr_set_name (attr, "Linux Kernel S3 Sleep");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load file */
 	if (!g_file_load_contents (file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path (file);
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Deep sleep status unavailable");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strstr_len (buf, bufsz, "[deep]") != NULL) {
-		fwupd_security_attr_set_result (attr, "System configured to suspend-to-ram (S3)");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 }

--- a/plugins/linux-spi-lpc/fu-plugin-linux-spi-lpc.c
+++ b/plugins/linux-spi-lpc/fu-plugin-linux-spi-lpc.c
@@ -28,28 +28,33 @@ fu_plugin_add_security_attr_bioswe (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.BIOSWE");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SPI_BIOSWE);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "SPI");
-	fwupd_security_attr_add_obsolete (attr, "org.fwupd.plugin.pci-bcr");
+	fwupd_security_attr_add_obsolete (attr, "pci_bcr");
 	fu_security_attrs_append (attrs, attr);
+
+	/* maybe the kernel module does not exist */
+	if (!g_file_test (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, G_FILE_TEST_IS_DIR)) {
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
+		return;
+	}
 
 	/* load file */
 	fn = g_build_filename (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, "bioswe", NULL);
 	if (!g_file_get_contents (fn, &buf, &bufsz, &error_local)) {
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strcmp0 (buf, "0\n") != 0) {
-		fwupd_security_attr_set_result (attr, "Write enabled");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Write disabled");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }
 
 static void
@@ -62,27 +67,32 @@ fu_plugin_add_security_attr_ble (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.BLE");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SPI_BLE);
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "SPI");
-	fwupd_security_attr_add_obsolete (attr, "org.fwupd.plugin.pci-bcr");
+	fwupd_security_attr_add_obsolete (attr, "pci_bcr");
 	fu_security_attrs_append (attrs, attr);
+
+	/* maybe the kernel module does not exist */
+	if (!g_file_test (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, G_FILE_TEST_IS_DIR)) {
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
+		return;
+	}
 
 	/* load file */
 	fn = g_build_filename (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, "ble", NULL);
 	if (!g_file_get_contents (fn, &buf, &bufsz, &error_local)) {
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strcmp0 (buf, "1\n") != 0) {
-		fwupd_security_attr_set_result (attr, "Lock disabled");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Lock enabled");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 }
 
 static void
@@ -95,27 +105,32 @@ fu_plugin_add_security_attr_smm_bwp (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.SMM_BWP");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_SPI_SMM_BWP);
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "BIOS region of SPI");
-	fwupd_security_attr_add_obsolete (attr, "org.fwupd.plugin.pci-bcr");
+	fwupd_security_attr_add_obsolete (attr, "pci_bcr");
 	fu_security_attrs_append (attrs, attr);
+
+	/* maybe the kernel module does not exist */
+	if (!g_file_test (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, G_FILE_TEST_IS_DIR)) {
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
+		return;
+	}
 
 	/* load file */
 	fn = g_build_filename (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, "smm_bwp", NULL);
 	if (!g_file_get_contents (fn, &buf, &bufsz, &error_local)) {
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strcmp0 (buf, "1\n") != 0) {
-		fwupd_security_attr_set_result (attr, "Writable by OS");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Writable only through BIOS");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_LOCKED);
 }
 
 void
@@ -124,17 +139,6 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	/* only Intel */
 	if (!fu_common_is_cpu_intel ())
 		return;
-
-	/* maybe the kernel module does not exist */
-	if (!g_file_test (FU_PLUGIN_LINUX_SPI_LPC_SYSFS_DIR, G_FILE_TEST_IS_DIR)) {
-		g_autoptr(FwupdSecurityAttr) attr = NULL;
-		attr = fwupd_security_attr_new ("org.fwupd.plugin.linux-spi-lpc");
-		fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-		fwupd_security_attr_set_name (attr, "SPI");
-		fwupd_security_attr_set_result (attr, "Kernel support not present");
-		fu_security_attrs_append (attrs, attr);
-		return;
-	}
 
 	/* look for the three files in sysfs */
 	fu_plugin_add_security_attr_bioswe (plugin, attrs);

--- a/plugins/linux-swap/fu-plugin-linux-swap.c
+++ b/plugins/linux-swap/fu-plugin-linux-swap.c
@@ -72,40 +72,40 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.Swap");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_KERNEL_SWAP);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
-	fwupd_security_attr_set_name (attr, "Linux Swap");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load list of swaps */
 	if (!g_file_load_contents (data->file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path (data->file);
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	swap = fu_linux_swap_new (buf, bufsz, &error_local);
 	if (swap == NULL) {
 		g_autofree gchar *fn = g_file_get_path (data->file);
 		g_warning ("could not parse %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not parse file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 
 	/* none configured */
 	if (!fu_linux_swap_get_enabled (swap)) {
 		fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* add security attribute */
 	if (!fu_linux_swap_get_encrypted (swap)) {
-		fwupd_security_attr_set_result (attr, "Not encrypted");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENCRYPTED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Encrypted");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED);
 }

--- a/plugins/linux-tainted/fu-plugin-linux-tainted.c
+++ b/plugins/linux-tainted/fu-plugin-linux-tainted.c
@@ -70,9 +70,8 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(GError) error_local = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.kernel.CheckTainted");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_KERNEL_TAINTED);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
-	fwupd_security_attr_set_name (attr, "Linux Kernel Taint");
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
 
@@ -80,14 +79,15 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!g_file_load_contents (data->file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path (data->file);
 		g_warning ("could not open %s: %s", fn, error_local->message);
-		fwupd_security_attr_set_result (attr, "Could not open file");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 	if (g_strcmp0 (buf, "0\n") != 0) {
-		fwupd_security_attr_set_result (attr, "Tainted");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_TAINTED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_TAINTED);
 }

--- a/plugins/pci-mei/fu-plugin-pci-mei.c
+++ b/plugins/pci-mei/fu-plugin-pci-mei.c
@@ -64,18 +64,18 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 		return;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("com.intel.MEI");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_MEI_MANUFACTURING_MODE);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "MEI");
 	fu_security_attrs_append (attrs, attr);
 
 	/* load file */
 	if ((priv->mei_cfg & (1 << 4)) != 0) {
-		fwupd_security_attr_set_result (attr, "Manufacturing Mode");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_LOCKED);
 }

--- a/plugins/tpm-eventlog/fu-plugin-tpm-eventlog.c
+++ b/plugins/tpm-eventlog/fu-plugin-tpm-eventlog.c
@@ -132,23 +132,22 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.trustedcomputinggroup.TpmEventLog");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_TPM_RECONSTRUCTION_PCR0);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
-	fwupd_security_attr_set_name (attr, "TPM Reconstruction");
 	fu_security_attrs_append (attrs, attr);
 
 	/* check reconstructed to PCR0 */
 	if (!fu_plugin_get_enabled (plugin)) {
-		fwupd_security_attr_set_result (attr, "No binary bios measurements available");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		return;
 	}
 	if (!data->reconstructed) {
-		fwupd_security_attr_set_result (attr, "Did not match PCR0 reading");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Matched PCR0 reading");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
 }

--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -41,23 +41,22 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("org.trustedcomputinggroup.Tpm");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_TPM_VERSION_20);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "TPM");
 	fu_security_attrs_append (attrs, attr);
 
 	/* check exists, and in v2.0 mode */
 	if (!data->has_tpm) {
-		fwupd_security_attr_set_result (attr, "Not found");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		return;
 	}
 	if (!data->has_tpm_v20) {
-		fwupd_security_attr_set_result (attr, "Not in v2.0 mode");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "v2.0");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.h
@@ -8,6 +8,4 @@
 
 #include <gio/gio.h>
 
-#define FU_UEFI_DBX_DATA_URL	"https://uefi.org/revocationlistfile"
-
 gchar		*fu_uefi_dbx_get_dbxupdate	(GError		**error);

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -97,21 +97,20 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
-	attr = fwupd_security_attr_new ("com.uefi.SecureBoot");
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_UEFI_SECUREBOOT);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
 	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
-	fwupd_security_attr_set_name (attr, "UEFI Secure Boot");
 	fu_security_attrs_append (attrs, attr);
 
 	/* SB disabled */
 	if (!fu_efivar_secure_boot_enabled ()) {
-		fwupd_security_attr_set_result (attr, "Disabled");
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		return;
 	}
 
 	/* success */
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result (attr, "Enabled");
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 }
 
 static GBytes *

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -12,6 +12,7 @@ src/fu-main.c
 src/fu-offline.c
 src/fu-progressbar.c
 src/fu-remote-list.c
+src/fu-security-attr.c
 src/fu-tool.c
 src/fu-util.c
 src/fu-util-common.c

--- a/src/fu-security-attr.c
+++ b/src/fu-security-attr.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include <config.h>
+#include <glib/gi18n.h>
+
+#include "fu-security-attr.h"
+
+const gchar *
+fu_security_attr_get_name (FwupdSecurityAttr *attr)
+{
+	const gchar *appstream_id = fwupd_security_attr_get_appstream_id (attr);
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_SPI_BIOSWE) == 0) {
+		/* TRANSLATORS: Title: SPI refers to the flash chip in the computer */
+		return _("SPI write");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_SPI_BLE) == 0) {
+		/* TRANSLATORS: Title: SPI refers to the flash chip in the computer */
+		return _("SPI lock");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_SPI_SMM_BWP) == 0) {
+		/* TRANSLATORS: Title: SPI refers to the flash chip in the computer */
+		return _("SPI BIOS region");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_ACPI_DMAR) == 0) {
+		/* TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack  */
+		return _("Pre-boot DMA protection");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_INTEL_AMT) == 0) {
+		/* TRANSLATORS: Title: AMT = Active Management Technology */
+		return _("Intel AMT");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_INTEL_CET) == 0) {
+		/* TRANSLATORS: Title: CET = Control-flow Enforcement Technology */
+		return _("Intel CET");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM) == 0) {
+		/* TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME */
+		return _("Encrypted RAM");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_IOMMU) == 0) {
+		/* TRANSLATORS: Title: https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit */
+		return _("IOMMU");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_KERNEL_LOCKDOWN) == 0) {
+		/* TRANSLATORS: Title: lockdown is a security mode of the kernel */
+		return _("Linux kernel lockdown");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_KERNEL_TAINTED) == 0) {
+		/* TRANSLATORS: Title: if it's tainted or not */
+		return _("Linux kernel");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_KERNEL_SWAP) == 0) {
+		/* TRANSLATORS: Title: swap space or swap partition */
+		return _("Linux swap");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_RAM) == 0) {
+		/* TRANSLATORS: Title: sleep state */
+		return _("Suspend-to-ram");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_SUSPEND_TO_IDLE) == 0) {
+		/* TRANSLATORS: Title: a better sleep state */
+		return _("Suspend-to-idle");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_UEFI_DBX) == 0) {
+		/* TRANSLATORS: Title: dbx is the database with revoked hashes */
+		return _("UEFI dbx");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_UEFI_SECUREBOOT) == 0) {
+		/* TRANSLATORS: Title: SB is a way of locking down UEFI */
+		return _("UEFI secure boot");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_TPM_RECONSTRUCTION_PCR0) == 0) {
+		/* TRANSLATORS: Title: the PCR is rebuilt from the TPM event log */
+		return _("TPM PCR0 reconstruction");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_TPM_VERSION_20) == 0) {
+		/* TRANSLATORS: Title: TPM = Trusted Platform Module */
+		return _("TPM v2.0");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_MEI_MANUFACTURING_MODE) == 0) {
+		/* TRANSLATORS: Title: MEI = Intel Management Engine */
+		return _("MEI manufacturing mode");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_FWUPD_UPDATES) == 0) {
+		/* TRANSLATORS: Title: if firmware updates are available */
+		return _("Firmware updates");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_FWUPD_ATTESTATION) == 0) {
+		/* TRANSLATORS: Title: if we can verify the firmware checksums */
+		return _("Firmware attestation");
+	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_FWUPD_PLUGINS) == 0) {
+		/* TRANSLATORS: Title: if the fwupd plugins are all present and correct */
+		return _("fwupd plugins");
+	}
+
+	/* we should not get here */
+	return fwupd_security_attr_get_name (attr);
+}
+
+const gchar *
+fu_security_attr_get_result (FwupdSecurityAttr *attr)
+{
+	FwupdSecurityAttrResult result = fwupd_security_attr_get_result (attr);
+	if (result == FWUPD_SECURITY_ATTR_RESULT_VALID) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Valid");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_VALID) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Not Valid");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_ENABLED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Enabled");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Disabled");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_LOCKED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Locked");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Unlocked");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Encrypted");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_ENCRYPTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Unencrypted");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_TAINTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Tainted");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_TAINTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Untainted");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_FOUND) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Found");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Not found");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_SUPPORTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Supported");
+	}
+	if (result == FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("Not supported");
+	}
+
+	/* fallback */
+	if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS)) {
+		/* TRANSLATORS: Suffix: the HSI result */
+		return _("OK");
+	}
+
+	/* TRANSLATORS: Suffix: the fallback HSI result */
+	return _("Failed");
+}

--- a/src/fu-security-attr.h
+++ b/src/fu-security-attr.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupd.h>
+
+const gchar	*fu_security_attr_get_name	(FwupdSecurityAttr	*attr);
+const gchar	*fu_security_attr_get_result	(FwupdSecurityAttr	*attr);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -25,6 +25,7 @@
 #include "fu-plugin-list.h"
 #include "fu-progressbar.h"
 #include "fu-hash.h"
+#include "fu-security-attr.h"
 #include "fu-security-attrs.h"
 #include "fu-smbios-private.h"
 
@@ -2806,6 +2807,15 @@ fu_plugin_composite_func (gconstpointer user_data)
 	}
 }
 
+static void
+fu_security_attr_func (gconstpointer user_data)
+{
+	g_autoptr(FwupdSecurityAttr) attr = fwupd_security_attr_new (NULL);
+	for (guint i = 0; i < FWUPD_SECURITY_ATTR_RESULT_LAST; i++) {
+		fwupd_security_attr_set_result (attr, i);
+		g_assert_cmpstr (fu_security_attr_get_result (attr), !=, NULL);
+	}
+}
 
 static void
 fu_memcpy_func (gconstpointer user_data)
@@ -2987,6 +2997,8 @@ main (int argc, char **argv)
 			      fu_plugin_module_func);
 	g_test_add_data_func ("/fwupd/memcpy", self,
 			      fu_memcpy_func);
+	g_test_add_data_func ("/fwupd/security-attr", self,
+			      fu_security_attr_func);
 	g_test_add_data_func ("/fwupd/device-list", self,
 			      fu_device_list_func);
 	g_test_add_data_func ("/fwupd/device-list{delay}", self,

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -16,6 +16,7 @@
 #include "fu-common.h"
 #include "fu-util-common.h"
 #include "fu-device.h"
+#include "fu-security-attr.h"
 #include "fu-security-attrs.h"
 
 #ifdef HAVE_SYSTEMD
@@ -1553,20 +1554,25 @@ static void
 fu_security_attr_append_str (FwupdSecurityAttr *attr, GString *str)
 {
 	if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED)) {
-		g_string_append_printf (str, "\033[37m✦\033[0m  ");
+		g_string_append (str, "✦  ");
 	} else if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS)) {
-		g_string_append_printf (str, "\033[32m✔\033[0m  ");
+		g_string_append (str, "✔ ");
 	} else {
-		g_string_append_printf (str, "\033[31m✘\033[0m  ");
+		g_string_append (str, "✘ ");
 	}
-	g_string_append_printf (str, "%s", fwupd_security_attr_get_name (attr));
-	if (fwupd_security_attr_get_result (attr) != NULL) {
-		g_string_append_printf (str, ": %s",
-					fwupd_security_attr_get_result (attr));
+	g_string_append_printf (str, "%s:", fu_security_attr_get_name (attr));
+	for (guint i = fu_common_strwidth (fu_security_attr_get_name (attr)); i < 30; i++)
+		g_string_append (str, " ");
+	if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED)) {
+		g_string_append_printf (str, "\033[37m\033[1m%s\033[0m", fu_security_attr_get_result (attr));
+	} else if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS)) {
+		g_string_append_printf (str, "\033[32m\033[1m%s\033[0m", fu_security_attr_get_result (attr));
 	} else {
+		g_string_append_printf (str, "\033[31m\033[1m%s\033[0m", fu_security_attr_get_result (attr));
+	}
+	if (fwupd_security_attr_get_url (attr) != NULL) {
 		g_string_append_printf (str, ": %s",
-					fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS)
-					? "OK" : "Failed");
+					fwupd_security_attr_get_url (attr));
 	}
 	if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED))
 		g_string_append (str, " (obsoleted)");

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ fwupdmgr = executable(
     'fu-util.c',
     'fu-history.c',
     'fu-progressbar.c',
+    'fu-security-attr.c',
     'fu-util-common.c',
     systemd_src
   ],
@@ -49,6 +50,7 @@ fwupdagent = executable(
   'fwupdagent',
   sources : [
     'fu-agent.c',
+    'fu-security-attr.c',
     'fu-util-common.c',
     systemd_src,
   ],
@@ -80,6 +82,7 @@ fwupdoffline = executable(
   sources : [
     'fu-history.c',
     'fu-offline.c',
+    'fu-security-attr.c',
     'fu-util-common.c',
     systemd_src
   ],
@@ -132,6 +135,7 @@ fwupdtool = executable(
     'fu-plugin-list.c',
     'fu-progressbar.c',
     'fu-remote-list.c',
+    'fu-security-attr.c',
     'fu-util-common.c',
     systemd_src
   ],
@@ -230,6 +234,7 @@ executable(
     'fu-main.c',
     'fu-plugin-list.c',
     'fu-remote-list.c',
+    'fu-security-attr.c',
     systemd_src
   ],
   include_directories : [
@@ -286,6 +291,7 @@ if get_option('tests')
       'fu-plugin-list.c',
       'fu-progressbar.c',
       'fu-remote-list.c',
+      'fu-security-attr.c',
       'fu-self-test.c',
       systemd_src
     ],


### PR DESCRIPTION
To do this, rely on the AppStream ID to map to a translated string (providing a
fallback for clients that do not care) and switch the free-form result string
into a set of enumerated values that can be translated.

This fixes some of the problems where some things have to be enabled to "pass"
and other attributes have to be some other state. For cases where we want the
user to "do" something, provide a URL to a wiki page that we update out-of-band
of fwupd releases.
