### PR TITLE
Export the host vendor and family

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -45,6 +45,9 @@ typedef struct {
 	guint				 percentage;
 	gchar				*daemon_version;
 	gchar				*host_product;
+	gchar				*host_family;
+	gchar				*host_sku;
+	gchar				*host_vendor;
 	gchar				*host_machine_id;
 	gchar				*host_security_id;
 	GDBusConnection			*conn;
@@ -67,6 +70,9 @@ enum {
 	PROP_DAEMON_VERSION,
 	PROP_TAINTED,
 	PROP_HOST_PRODUCT,
+	PROP_HOST_FAMILY,
+	PROP_HOST_SKU,
+	PROP_HOST_VENDOR,
 	PROP_HOST_MACHINE_ID,
 	PROP_HOST_SECURITY_ID,
 	PROP_INTERACTIVE,
@@ -120,6 +126,33 @@ fwupd_client_set_host_product (FwupdClient *client, const gchar *host_product)
 	g_free (priv->host_product);
 	priv->host_product = g_strdup (host_product);
 	g_object_notify (G_OBJECT (client), "host-product");
+}
+
+static void
+fwupd_client_set_host_family (FwupdClient *client, const gchar *host_family)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_free (priv->host_family);
+	priv->host_family = g_strdup (host_family);
+	g_object_notify (G_OBJECT (client), "host-family");
+}
+
+static void
+fwupd_client_set_host_sku (FwupdClient *client, const gchar *host_sku)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_free (priv->host_sku);
+	priv->host_sku = g_strdup (host_sku);
+	g_object_notify (G_OBJECT (client), "host-sku");
+}
+
+static void
+fwupd_client_set_host_vendor (FwupdClient *client, const gchar *host_vendor)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_free (priv->host_vendor);
+	priv->host_vendor = g_strdup (host_vendor);
+	g_object_notify (G_OBJECT (client), "host-vendor");
 }
 
 static void
@@ -206,6 +239,24 @@ fwupd_client_properties_changed_cb (GDBusProxy *proxy,
 		val = g_dbus_proxy_get_cached_property (proxy, "HostProduct");
 		if (val != NULL)
 			fwupd_client_set_host_product (client, g_variant_get_string (val, NULL));
+	}
+	if (g_variant_dict_contains (dict, "HostFamily")) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property (proxy, "HostFamily");
+		if (val != NULL)
+			fwupd_client_set_host_family (client, g_variant_get_string (val, NULL));
+	}
+	if (g_variant_dict_contains (dict, "HostSku")) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property (proxy, "HostSku");
+		if (val != NULL)
+			fwupd_client_set_host_sku (client, g_variant_get_string (val, NULL));
+	}
+	if (g_variant_dict_contains (dict, "HostVendor")) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property (proxy, "HostVendor");
+		if (val != NULL)
+			fwupd_client_set_host_vendor (client, g_variant_get_string (val, NULL));
 	}
 	if (g_variant_dict_contains (dict, "HostMachineId")) {
 		g_autoptr(GVariant) val = NULL;
@@ -319,6 +370,15 @@ fwupd_client_connect (FwupdClient *client, GCancellable *cancellable, GError **e
 	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostProduct");
 	if (val != NULL)
 		fwupd_client_set_host_product (client, g_variant_get_string (val, NULL));
+	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostFamily");
+	if (val != NULL)
+		fwupd_client_set_host_family (client, g_variant_get_string (val, NULL));
+	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostSku");
+	if (val != NULL)
+		fwupd_client_set_host_sku (client, g_variant_get_string (val, NULL));
+	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostVendor");
+	if (val != NULL)
+		fwupd_client_set_host_vendor (client, g_variant_get_string (val, NULL));
 	val = g_dbus_proxy_get_cached_property (priv->proxy, "HostMachineId");
 	if (val != NULL)
 		fwupd_client_set_host_machine_id (client, g_variant_get_string (val, NULL));
@@ -1360,6 +1420,60 @@ fwupd_client_get_host_product (FwupdClient *client)
 }
 
 /**
+ * fwupd_client_get_host_family:
+ * @client: A #FwupdClient
+ *
+ * Gets the string that represents the host running fwupd
+ *
+ * Returns: a string, or %NULL for unknown.
+ *
+ * Since: 1.5.0
+ **/
+const gchar *
+fwupd_client_get_host_family (FwupdClient *client)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_return_val_if_fail (FWUPD_IS_CLIENT (client), NULL);
+	return priv->host_family;
+}
+
+/**
+ * fwupd_client_get_host_sku:
+ * @client: A #FwupdClient
+ *
+ * Gets the string that represents the host running fwupd
+ *
+ * Returns: a string, or %NULL for unknown.
+ *
+ * Since: 1.5.0
+ **/
+const gchar *
+fwupd_client_get_host_sku (FwupdClient *client)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_return_val_if_fail (FWUPD_IS_CLIENT (client), NULL);
+	return priv->host_sku;
+}
+
+/**
+ * fwupd_client_get_host_vendor:
+ * @client: A #FwupdClient
+ *
+ * Gets the string that represents the host running fwupd
+ *
+ * Returns: a string, or %NULL for unknown.
+ *
+ * Since: 1.5.0
+ **/
+const gchar *
+fwupd_client_get_host_vendor (FwupdClient *client)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE (client);
+	g_return_val_if_fail (FWUPD_IS_CLIENT (client), NULL);
+	return priv->host_vendor;
+}
+
+/**
  * fwupd_client_get_host_machine_id:
  * @client: A #FwupdClient
  *
@@ -1947,6 +2061,15 @@ fwupd_client_get_property (GObject *object, guint prop_id,
 	case PROP_HOST_PRODUCT:
 		g_value_set_string (value, priv->host_product);
 		break;
+	case PROP_HOST_FAMILY:
+		g_value_set_string (value, priv->host_family);
+		break;
+	case PROP_HOST_SKU:
+		g_value_set_string (value, priv->host_sku);
+		break;
+	case PROP_HOST_VENDOR:
+		g_value_set_string (value, priv->host_vendor);
+		break;
 	case PROP_HOST_MACHINE_ID:
 		g_value_set_string (value, priv->host_machine_id);
 		break;
@@ -2144,6 +2267,39 @@ fwupd_client_class_init (FwupdClientClass *klass)
 	g_object_class_install_property (object_class, PROP_HOST_PRODUCT, pspec);
 
 	/**
+	 * FwupdClient:host-family:
+	 *
+	 * The host family string, e.g. "ThinkPad P50"
+	 *
+	 * Since: 1.5.0
+	 */
+	pspec = g_param_spec_string ("host-family", NULL, NULL,
+				     NULL, G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_HOST_FAMILY, pspec);
+
+	/**
+	 * FwupdClient:host-sku:
+	 *
+	 * The host SKU string, e.g. "ABC12345"
+	 *
+	 * Since: 1.5.0
+	 */
+	pspec = g_param_spec_string ("host-sku", NULL, NULL,
+				     NULL, G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_HOST_SKU, pspec);
+
+	/**
+	 * FwupdClient:host-vendor:
+	 *
+	 * The host vendor string, e.g. "Lenovo"
+	 *
+	 * Since: 1.5.0
+	 */
+	pspec = g_param_spec_string ("host-vendor", NULL, NULL,
+				     NULL, G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_HOST_VENDOR, pspec);
+
+	/**
 	 * FwupdClient:host-machine-id:
 	 *
 	 * The host machine-id string
@@ -2179,6 +2335,9 @@ fwupd_client_finalize (GObject *object)
 
 	g_free (priv->daemon_version);
 	g_free (priv->host_product);
+	g_free (priv->host_family);
+	g_free (priv->host_sku);
+	g_free (priv->host_vendor);
 	g_free (priv->host_machine_id);
 	g_free (priv->host_security_id);
 	if (priv->conn != NULL)

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -136,6 +136,9 @@ gboolean	 fwupd_client_get_daemon_interactive	(FwupdClient	*client);
 guint		 fwupd_client_get_percentage		(FwupdClient	*client);
 const gchar	*fwupd_client_get_daemon_version	(FwupdClient	*client);
 const gchar	*fwupd_client_get_host_product		(FwupdClient	*client);
+const gchar	*fwupd_client_get_host_family		(FwupdClient	*client);
+const gchar	*fwupd_client_get_host_sku		(FwupdClient	*client);
+const gchar	*fwupd_client_get_host_vendor		(FwupdClient	*client);
 const gchar	*fwupd_client_get_host_machine_id	(FwupdClient	*client);
 const gchar	*fwupd_client_get_host_security_id	(FwupdClient	*client);
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -449,8 +449,11 @@ LIBFWUPD_1.4.1 {
 
 LIBFWUPD_1.5.0 {
   global:
+    fwupd_client_get_host_family;
     fwupd_client_get_host_security_attrs;
     fwupd_client_get_host_security_id;
+    fwupd_client_get_host_sku;
+    fwupd_client_get_host_vendor;
     fwupd_security_attr_add_flag;
     fwupd_security_attr_add_obsolete;
     fwupd_security_attr_array_from_variant;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5061,6 +5061,33 @@ fu_engine_get_host_product (FuEngine *self)
 }
 
 const gchar *
+fu_engine_get_host_family (FuEngine *self)
+{
+	const gchar *result = NULL;
+	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);
+	result = fu_hwids_get_value (self->hwids, FU_HWIDS_KEY_FAMILY);
+	return result != NULL ? result : "Unknown";
+}
+
+const gchar *
+fu_engine_get_host_sku (FuEngine *self)
+{
+	const gchar *result = NULL;
+	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);
+	result = fu_hwids_get_value (self->hwids, FU_HWIDS_KEY_PRODUCT_SKU);
+	return result != NULL ? result : "Unknown";
+}
+
+const gchar *
+fu_engine_get_host_vendor (FuEngine *self)
+{
+	const gchar *result = NULL;
+	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);
+	result = fu_hwids_get_value (self->hwids, FU_HWIDS_KEY_MANUFACTURER);
+	return result != NULL ? result : "Unknown";
+}
+
+const gchar *
 fu_engine_get_host_machine_id (FuEngine *self)
 {
 	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -48,8 +48,11 @@ gboolean	 fu_engine_load				(FuEngine	*self,
 gboolean	 fu_engine_load_plugins			(FuEngine	*self,
 							 GError		**error);
 gboolean	 fu_engine_get_tainted			(FuEngine	*self);
-const gchar	*fu_engine_get_host_product		(FuEngine *self);
-const gchar	*fu_engine_get_host_machine_id		(FuEngine *self);
+const gchar	*fu_engine_get_host_product		(FuEngine	*self);
+const gchar	*fu_engine_get_host_family		(FuEngine	*self);
+const gchar	*fu_engine_get_host_sku			(FuEngine	*self);
+const gchar	*fu_engine_get_host_vendor		(FuEngine	*self);
+const gchar	*fu_engine_get_host_machine_id		(FuEngine	*self);
 const gchar	*fu_engine_get_host_security_id		(FuEngine	*self);
 FwupdStatus	 fu_engine_get_status			(FuEngine	*self);
 XbSilo		*fu_engine_get_silo_from_blob		(FuEngine	*self,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1395,6 +1395,15 @@ fu_main_daemon_get_property (GDBusConnection *connection_, const gchar *sender,
 	if (g_strcmp0 (property_name, "HostProduct") == 0)
 		return g_variant_new_string (fu_engine_get_host_product (priv->engine));
 
+	if (g_strcmp0 (property_name, "HostFamily") == 0)
+		return g_variant_new_string (fu_engine_get_host_family (priv->engine));
+
+	if (g_strcmp0 (property_name, "HostSku") == 0)
+		return g_variant_new_string (fu_engine_get_host_sku (priv->engine));
+
+	if (g_strcmp0 (property_name, "HostVendor") == 0)
+		return g_variant_new_string (fu_engine_get_host_vendor (priv->engine));
+
 	if (g_strcmp0 (property_name, "HostMachineId") == 0)
 		return g_variant_new_string (fu_engine_get_host_machine_id (priv->engine));
 

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -34,6 +34,39 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='HostFamily' type='s' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The product family string for the host.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
+    <property name='HostSku' type='s' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The product SKU string for the host.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
+    <property name='HostVendor' type='s' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The product vendor string for the host.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='HostMachineId' type='s' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
The 'product name' is not typically what the hardware is known as. We need the
vendor and family if the user is going to recognise the hardware.
