### PR TITLE
Skip module unloading only if we are actually running under valgrind

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2792,10 +2792,11 @@ fu_plugin_finalize (GObject *object)
 	g_free (priv->data);
 	/* Must happen as the last step to avoid prematurely
 	 * freeing memory held by the plugin */
-#ifndef RUNNING_ON_VALGRIND
+#ifdef RUNNING_ON_VALGRIND
+	if (RUNNING_ON_VALGRIND == 0)
+#endif
 	if (priv->module != NULL)
 		g_module_close (priv->module);
-#endif
 
 	G_OBJECT_CLASS (fu_plugin_parent_class)->finalize (object);
 }


### PR DESCRIPTION
See also: https://github.com/fwupd/fwupd/issues/2119
Fixes: 576c012 ("Do not dlclose modules when running under valgrind")

Type of pull request:
- [x] Code fix

This fix makes issue #2119 more reproducible.