### PR TITLE
Initial Chrome OS EC plugin 

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -766,7 +766,7 @@
     </distro>
     <distro id="debian">
       <control>
-        <version>(>= 0.2.9)</version>
+        <version>(>= 0.3.3)</version>
       </control>
       <package variant="x86_64" />
       <package variant="s390x">libgusb-dev:s390x</package>
@@ -774,7 +774,7 @@
     </distro>
     <distro id="ubuntu">
       <control>
-        <version>(>= 0.2.9)</version>
+        <version>(>= 0.3.3)</version>
       </control>
       <package variant="x86_64" />
     </distro>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -1,6 +1,6 @@
 %global glib2_version 2.45.8
 %global libxmlb_version 0.1.3
-%global libgusb_version 0.2.11
+%global libgusb_version 0.3.3
 %global libsoup_version 2.51.92
 %global libjcat_version 0.1.0
 %global systemd_version 231

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -336,6 +336,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libdir}/fwupd-plugins-3/libfu_plugin_ccgx.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_colorhug.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_coreboot.so
+%{_libdir}/fwupd-plugins-3/libfu_plugin_cros_ec.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_csr.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_cpu.so
 %if 0%{?have_dell}

--- a/meson.build
+++ b/meson.build
@@ -195,7 +195,7 @@ else
 endif
 libxmlb = dependency('xmlb', version : '>= 0.1.13', fallback : ['libxmlb', 'libxmlb_dep'])
 libjcat = dependency('jcat', version : '>= 0.1.0', fallback : ['libjcat', 'libjcat_dep'])
-gusb = dependency('gusb', version : '>= 0.2.9', fallback : ['gusb', 'gusb_dep'])
+gusb = dependency('gusb', version : '>= 0.3.3', fallback : ['gusb', 'gusb_dep'])
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')
 endif

--- a/plugins/cros-ec/README.md
+++ b/plugins/cros-ec/README.md
@@ -1,0 +1,41 @@
+Chrome OS EC Support
+===================
+
+Introduction
+------------
+
+This plugin provides support for the firmware updates for Chrome OS EC
+project based devices.
+
+Initially, it supports the USB endpoint updater, but lays the groundwork for
+future updaters which use other update methods other than the USB endpoint.
+
+This is based on the chromeos ec project's usb_updater2 application [1].
+
+Information about the USB update protocol is available at [2].
+
+Firmware Format
+---------------
+
+The plugin at the moment does not support a firmware payload, but will
+support the Google firmware format used in Chrome OS firmware
+known as `flashmap`[3].
+
+GUID Generation
+---------------
+
+These devices use the standard USB DeviceInstanceId values, e.g.
+
+ * `USB\VID_18D1&PID_501A`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, which is set to various different
+values depending on the model and device mode. The list of USB VIDs used is:
+
+ * `USB:0x18D1`
+
+[1] https://chromium.googlesource.com/chromiumos/platform/ec/+/master/extra/usb_updater/usb_updater2.c
+[2] https://chromium.googlesource.com/chromiumos/platform/ec/+/master/docs/usb_updater.md
+[3] https://www.chromium.org/chromium-os/firmware-porting-guide/fmap

--- a/plugins/cros-ec/cros-ec.quirk
+++ b/plugins/cros-ec/cros-ec.quirk
@@ -1,0 +1,4 @@
+# Servo Micro
+[DeviceInstanceId=USB\VID_18D1&PID_501A]
+Plugin = cros_ec
+Summary = Servo Micro (aka "uServo") Debug Board

--- a/plugins/cros-ec/data/lsusb-servo-micro.txt
+++ b/plugins/cros-ec/data/lsusb-servo-micro.txt
@@ -1,0 +1,239 @@
+
+Bus 003 Device 006: ID 18d1:501a Google Inc. 
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.00
+  bDeviceClass            0 (Defined at Interface level)
+  bDeviceSubClass         0 
+  bDeviceProtocol         0 
+  bMaxPacketSize0        64
+  idVendor           0x18d1 Google Inc.
+  idProduct          0x501a 
+  bcdDevice            1.00
+  iManufacturer           1 Google Inc.
+  iProduct                2 Servo Micro
+  iSerial                 3 CMO653-00166-040491U00771
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength          170
+    bNumInterfaces          7
+    bConfigurationValue     1
+    iConfiguration          4 servo_micro_v2.4.17-df61092c3
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              100mA
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     80 
+      bInterfaceProtocol      1 
+      iInterface              6 UART3
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x01  EP 1 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0020  1x 32 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     83 
+      bInterfaceProtocol    255 
+      iInterface             10 Firmware update
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     81 
+      bInterfaceProtocol      1 
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x03  EP 3 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        3
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     80 
+      bInterfaceProtocol      1 
+      iInterface              7 Servo Shell
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x84  EP 4 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x04  EP 4 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        4
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     82 
+      bInterfaceProtocol      1 
+      iInterface              5 I2C
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x85  EP 5 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x05  EP 5 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        5
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     80 
+      bInterfaceProtocol      1 
+      iInterface              8 CPU
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x86  EP 6 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x06  EP 6 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0020  1x 32 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        6
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass     80 
+      bInterfaceProtocol      1 
+      iInterface              9 EC
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x87  EP 7 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval              10
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x07  EP 7 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0020  1x 32 bytes
+        bInterval               0
+Device Status:     0x0000
+  (Bus Powered)

--- a/plugins/cros-ec/fu-cros-ec-common.c
+++ b/plugins/cros-ec/fu-cros-ec-common.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Benson Leung <bleung@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-cros-ec-common.h"
+
+gboolean
+fu_cros_ec_parse_version (const gchar *version_raw,
+			  struct cros_ec_version *version, GError **error)
+{
+	g_auto(GStrv) v_split = NULL;
+	g_auto(GStrv) marker_split = NULL;
+	g_auto(GStrv) triplet_split = NULL;
+
+	if (NULL == version_raw || 0 == strlen (version_raw)) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INTERNAL,
+				     "no version string to parse");
+		return FALSE;
+	}
+
+	/* sample version string: cheese_v1.1.1755-4da9520 */
+	v_split = g_strsplit (version_raw, "_v", 2);
+	if (g_strv_length (v_split) < 2) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INTERNAL,
+				     "version marker not found");
+		return FALSE;
+	}
+	marker_split = g_strsplit_set (v_split[1], "-+", 2);
+	if (g_strv_length (marker_split) < 2) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INTERNAL,
+			     "hash marker not found: %s", v_split[1]);
+		return FALSE;
+	}
+	triplet_split = g_strsplit_set (marker_split[0], ".", 3);
+	if (g_strv_length (triplet_split) < 3) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INTERNAL,
+			     "improper version triplet: %s", marker_split[0]);
+		return FALSE;
+	}
+	g_strlcpy (version->triplet, marker_split[0], 32);
+	if (g_strlcpy (version->boardname, v_split[0], 32) == 0) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INTERNAL,
+				     "empty board name");
+		return FALSE;
+	}
+	if (g_strlcpy (version->sha1, marker_split[1], 32) == 0) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INTERNAL,
+				     "empty SHA");
+		return FALSE;
+	}
+	version->dirty = (g_strrstr(v_split[1], "+") != NULL);
+
+	return TRUE;
+}

--- a/plugins/cros-ec/fu-cros-ec-common.h
+++ b/plugins/cros-ec/fu-cros-ec-common.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2020 Benson Leung <bleung@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define UPDATE_PROTOCOL_VERSION 6
+
+/*
+ * This is the format of the update PDU header.
+ *
+ * block digest: the first four bytes of the sha1 digest of the rest of the
+ *               structure (can be 0 on boards where digest is ignored).
+ * block_base:   offset of this PDU into the flash SPI.
+ */
+typedef struct __attribute__((packed)) {
+	guint32  block_digest;
+	guint32  block_base;
+	/* The actual payload goes here. */
+} update_command;
+
+/*
+ * This is the frame format the host uses when sending update PDUs over USB.
+ *
+ * The PDUs are up to 1K bytes in size, they are fragmented into USB chunks of
+ * 64 bytes each and reassembled on the receive side before being passed to
+ * the flash update function.
+ *
+ * The flash update function receives the unframed PDU body (starting at the
+ * cmd field below), and puts its reply into the same buffer the PDU was in.
+ */
+struct update_frame_header {
+	guint32 block_size; /* Total frame size, including this field. */
+	update_command cmd;
+};
+
+/*
+ * A convenience structure which allows to group together various revision
+ * fields of the header created by the signer (cr50-specific).
+ *
+ * These fields are compared when deciding if versions of two images are the
+ * same or when deciding which one of the available images to run.
+ */
+struct signed_header_version {
+	guint32 minor;
+	guint32 major;
+	guint32 epoch;
+};
+
+/*
+ * Response to the connection establishment request.
+ *
+ * When responding to the very first packet of the update sequence, the
+ * original USB update implementation was responding with a four byte value,
+ * just as to any other block of the transfer sequence.
+ *
+ * It became clear that there is a need to be able to enhance the update
+ * protocol, while staying backwards compatible.
+ *
+ * All newer protocol versions (starting with version 2) respond to the very
+ * first packet with an 8 byte or larger response, where the first 4 bytes are
+ * a version specific data, and the second 4 bytes - the protocol version
+ * number.
+ *
+ * This way the host receiving of a four byte value in response to the first
+ * packet is considered an indication of the target running the 'legacy'
+ * protocol, version 1. Receiving of an 8 byte or longer response would
+ * communicates the protocol version in the second 4 bytes.
+ */
+struct first_response_pdu {
+	guint32 return_value;
+
+	/* The below fields are present in versions 2 and up. */
+
+	/* Type of header following (one of first_response_pdu_header_type) */
+	guint16 header_type;
+
+	/* Must be UPDATE_PROTOCOL_VERSION */
+	guint16 protocol_version;
+
+	/* In version 6 and up, a board-specific header follows. */
+	union {
+		/* cr50 (header_type = UPDATE_HEADER_TYPE_CR50) */
+		struct {
+			/* The below fields are present in versions 3 and up. */
+			guint32  backup_ro_offset;
+			guint32  backup_rw_offset;
+
+			/* The below fields are present in versions 4 and up. */
+			/*
+			 * Versions of the currently active RO and RW sections.
+			 */
+			struct signed_header_version shv[2];
+
+			/* The below fields are present in versions 5 and up */
+			/* keyids of the currently active RO and RW sections. */
+			guint32 keyid[2];
+		} cr50;
+		/* Common code (header_type = UPDATE_HEADER_TYPE_COMMON) */
+		struct {
+			/* Maximum PDU size */
+			guint32 maximum_pdu_size;
+
+			/* Flash protection status */
+			guint32 flash_protection;
+
+			/* Offset of the other region */
+			guint32 offset;
+
+			/* Version string of the other region */
+			gchar version[32];
+
+			/* Minimum rollback version that RO will accept */
+			gint32 min_rollback;
+
+			/* RO public key version */
+			guint32 key_version;
+		} common;
+	};
+};
+
+enum first_response_pdu_header_type {
+	UPDATE_HEADER_TYPE_CR50 = 0, /* Must be 0 for backwards compatibility */
+	UPDATE_HEADER_TYPE_COMMON = 1,
+};

--- a/plugins/cros-ec/fu-cros-ec-common.h
+++ b/plugins/cros-ec/fu-cros-ec-common.h
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#pragma once
+
+#include <glib.h>
+
+#include "fu-plugin.h"
+
 #define UPDATE_PROTOCOL_VERSION 6
 
 /*
@@ -123,3 +129,14 @@ enum first_response_pdu_header_type {
 	UPDATE_HEADER_TYPE_CR50 = 0, /* Must be 0 for backwards compatibility */
 	UPDATE_HEADER_TYPE_COMMON = 1,
 };
+
+struct cros_ec_version {
+	gchar	 boardname[32];
+	gchar	 triplet[32];
+	gchar	 sha1[32];
+	gboolean dirty;
+};
+
+gboolean	fu_cros_ec_parse_version	(const gchar 		*version_raw,
+						 struct cros_ec_version *version,
+						 GError **error);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -322,7 +322,26 @@ static void
 fu_cros_ec_usb_device_to_string (FuDevice *device, guint idt, GString *str)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+	g_autofree gchar *min_rollback = NULL;
+
 	fu_common_string_append_kv (str, idt, "GitHash", self->version.sha1);
+	fu_common_string_append_kb (str, idt, "Dirty",
+				    self->version.dirty);
+	fu_common_string_append_ku (str, idt, "ProtocolVersion",
+				    self->protocol_version);
+	fu_common_string_append_ku (str, idt, "HeaderType",
+				    self->header_type);
+	fu_common_string_append_ku (str, idt, "MaxPDUSize",
+				    self->targ.common.maximum_pdu_size);
+	fu_common_string_append_kx (str, idt, "FlashProtectionStatus",
+				    self->targ.common.flash_protection);
+	fu_common_string_append_kv (str, idt, "RawVersion",
+				    self->targ.common.version);
+	fu_common_string_append_ku (str, idt, "KeyVersion",
+				    self->targ.common.key_version);
+	min_rollback = g_strdup_printf ("%" G_GINT32_FORMAT,
+					self->targ.common.min_rollback);
+	fu_common_string_append_kv (str, idt, "MinRollback", min_rollback);
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -289,6 +289,7 @@ fu_cros_ec_usb_device_setup (FuDevice *device, GError **error)
 	}
 
 	fu_device_set_version (FU_DEVICE (device), self->version.triplet);
+	fu_device_add_instance_id (FU_DEVICE (device), self->version.boardname);
 
 	/* success */
 	return TRUE;
@@ -318,11 +319,19 @@ fu_cros_ec_usb_device_init (FuCrosEcUsbDevice *device)
 }
 
 static void
+fu_cros_ec_usb_device_to_string (FuDevice *device, guint idt, GString *str)
+{
+	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+	fu_common_string_append_kv (str, idt, "GitHash", self->version.sha1);
+}
+
+static void
 fu_cros_ec_usb_device_class_init (FuCrosEcUsbDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->setup = fu_cros_ec_usb_device_setup;
+	klass_device->to_string = fu_cros_ec_usb_device_to_string;
 	klass_usb_device->open = fu_cros_ec_usb_device_open;
 	klass_usb_device->probe = fu_cros_ec_usb_device_probe;
 	klass_usb_device->close = fu_cros_ec_usb_device_close;

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Benson Leung <bleung@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-cros-ec-usb-device.h"
+
+G_DEFINE_TYPE (FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU_TYPE_USB_DEVICE)
+
+static gboolean
+fu_cros_ec_usb_device_open (FuUsbDevice *device, GError **error)
+{
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_device_setup (FuDevice *device, GError **error)
+{
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_device_close (FuUsbDevice *device, GError **error)
+{
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_cros_ec_usb_device_init (FuCrosEcUsbDevice *device)
+{
+	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_TRIPLET);
+}
+
+static void
+fu_cros_ec_usb_device_class_init (FuCrosEcUsbDeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
+	klass_device->setup = fu_cros_ec_usb_device_setup;
+	klass_usb_device->open = fu_cros_ec_usb_device_open;
+	klass_usb_device->close = fu_cros_ec_usb_device_close;
+}

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -10,11 +10,96 @@
 
 #include "fu-cros-ec-usb-device.h"
 
+#define USB_SUBCLASS_GOOGLE_UPDATE	0x53
+#define USB_PROTOCOL_GOOGLE_UPDATE	0xff
+
+struct _FuCrosEcUsbDevice {
+	FuUsbDevice		parent_instance;
+	guint8			iface_idx; 	/* bInterfaceNumber */
+	guint8			ep_num;		/* bEndpointAddress */
+	guint16			chunk_len; 	/* wMaxPacketSize */
+
+};
+
 G_DEFINE_TYPE (FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU_TYPE_USB_DEVICE)
+
+static gboolean
+fu_cros_ec_usb_device_find_interface (FuUsbDevice *device,
+				      GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+	g_autoptr(GPtrArray) intfs = NULL;
+
+	/* based on usb_updater2's find_interfacei() and find_endpoint() */
+
+	intfs = g_usb_device_get_interfaces (usb_device, error);
+	if (intfs == NULL)
+		return FALSE;
+	for (guint i = 0; i < intfs->len; i++) {
+		GUsbInterface *intf = g_ptr_array_index (intfs, i);
+		if (g_usb_interface_get_class (intf) == 255 &&
+		    g_usb_interface_get_subclass (intf) == USB_SUBCLASS_GOOGLE_UPDATE &&
+		    g_usb_interface_get_protocol (intf) == USB_PROTOCOL_GOOGLE_UPDATE) {
+			GUsbEndpoint *ep;
+			g_autoptr(GPtrArray) endpoints = NULL;
+
+			endpoints = g_usb_interface_get_endpoints (intf);
+			if (NULL == endpoints || 0 == endpoints->len)
+				continue;
+			ep = g_ptr_array_index (endpoints, 0);
+			self->iface_idx = g_usb_interface_get_number (intf);
+			self->ep_num = g_usb_endpoint_get_address (ep) & 0x7f;
+			self->chunk_len = g_usb_endpoint_get_maximum_packet_size (ep);
+
+			return TRUE;
+		}
+	}
+	g_set_error_literal (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_FOUND,
+			     "no update interface found");
+	return FALSE;
+}
 
 static gboolean
 fu_cros_ec_usb_device_open (FuUsbDevice *device, GError **error)
 {
+	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+
+	if (!g_usb_device_claim_interface (usb_device, self->iface_idx,
+					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
+					   error)) {
+		g_prefix_error (error, "failed to claim interface: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cros_ec_usb_device_probe (FuUsbDevice *device, GError **error)
+{
+	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+
+	/* very much like usb_updater2's usb_findit() */
+
+	if (!fu_cros_ec_usb_device_find_interface (device, error)) {
+		g_prefix_error (error, "failed to find update interface: ");
+		return FALSE;
+	}
+
+	if (self->chunk_len == 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "wMaxPacketSize isn't valid: %" G_GUINT16_FORMAT,
+			     self->chunk_len);
+		return FALSE;
+	}
+
 	/* success */
 	return TRUE;
 }
@@ -29,6 +114,16 @@ fu_cros_ec_usb_device_setup (FuDevice *device, GError **error)
 static gboolean
 fu_cros_ec_usb_device_close (FuUsbDevice *device, GError **error)
 {
+	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+
+	if (!g_usb_device_release_interface (usb_device, self->iface_idx,
+					     G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
+					     error)) {
+		g_prefix_error (error, "failed to release interface: ");
+		return FALSE;
+	}
+
 	/* success */
 	return TRUE;
 }
@@ -46,5 +141,6 @@ fu_cros_ec_usb_device_class_init (FuCrosEcUsbDeviceClass *klass)
 	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->setup = fu_cros_ec_usb_device_setup;
 	klass_usb_device->open = fu_cros_ec_usb_device_open;
+	klass_usb_device->probe = fu_cros_ec_usb_device_probe;
 	klass_usb_device->close = fu_cros_ec_usb_device_close;
 }

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Benson Leung <bleung@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-plugin.h"
+
+#define FU_TYPE_CROS_EC_USB_DEVICE (fu_cros_ec_usb_device_get_type ())
+G_DECLARE_DERIVABLE_TYPE (FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
+
+struct _FuCrosEcUsbDeviceClass
+{
+	FuUsbDeviceClass	parent_class;
+};

--- a/plugins/cros-ec/fu-cros-ec-usb-device.h
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.h
@@ -9,7 +9,7 @@
 #include "fu-plugin.h"
 
 #define FU_TYPE_CROS_EC_USB_DEVICE (fu_cros_ec_usb_device_get_type ())
-G_DECLARE_DERIVABLE_TYPE (FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
+G_DECLARE_FINAL_TYPE (FuCrosEcUsbDevice, fu_cros_ec_usb_device, FU, CROS_EC_USB_DEVICE, FuUsbDevice)
 
 struct _FuCrosEcUsbDeviceClass
 {

--- a/plugins/cros-ec/fu-plugin-cros-ec.c
+++ b/plugins/cros-ec/fu-plugin-cros-ec.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020 Benson Leung <bleung@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-plugin-vfuncs.h"
+#include "fu-hash.h"
+
+#include "fu-cros-ec-usb-device.h"
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	fu_plugin_set_device_gtype (plugin, FU_TYPE_CROS_EC_USB_DEVICE);
+}

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -9,6 +9,7 @@ shared_module('fu_plugin_cros_ec',
   sources : [
     'fu-plugin-cros-ec.c',
     'fu-cros-ec-usb-device.c',
+    'fu-cros-ec-common.c',
   ],
   include_directories : [
     root_incdir,
@@ -18,6 +19,7 @@ shared_module('fu_plugin_cros_ec',
   install : true,
   install_dir: plugin_dir,
   link_with : [
+    fwupd,
     fwupdplugin,
   ],
   c_args : cargs,

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -1,0 +1,27 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginCrosEc"']
+
+install_data(['cros-ec.quirk'],
+  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+)
+
+shared_module('fu_plugin_cros_ec',
+  fu_hash,
+  sources : [
+    'fu-plugin-cros-ec.c',
+    'fu-cros-ec-usb-device.c',
+  ],
+  include_directories : [
+    root_incdir,
+    fwupd_incdir,
+    fwupdplugin_incdir,
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  link_with : [
+    fwupdplugin,
+  ],
+  c_args : cargs,
+  dependencies : [
+    plugin_deps,
+  ],
+)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,6 +1,7 @@
 subdir('acpi-dmar')
 subdir('acpi-facp')
 subdir('ccgx')
+subdir('cros-ec')
 subdir('cpu')
 subdir('dfu')
 subdir('colorhug')

--- a/subprojects/gusb.wrap
+++ b/subprojects/gusb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = gusb
 url = https://github.com/hughsie/libgusb.git
-revision = 43b327a1e213aff00833842c455a796a068077cd
+revision = 0.3.3


### PR DESCRIPTION
Type of pull request:
- [ X] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Initial checkin of the Chrome OS EC USB plugin. For now, this will check and provide the version number of a Servo Micro debug dongle. (https://chromium.googlesource.com/chromiumos/third_party/hdctools/+/refs/heads/master/docs/servo_micro.md).

Further changes will add support for the firmware file format and complete the mechanism of flashing the payload, as well as adding support for other USB targets.