### PR TITLE
dell-dock: Capture the dock SKU in metadata

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -172,6 +172,22 @@ fu_dell_dock_ec_set_board (FuDevice *device)
 		fu_device_set_summary (device, summary);
 }
 
+const gchar *
+fu_dell_dock_ec_get_module_type (FuDevice *device)
+{
+	FuDellDockEc *self = FU_DELL_DOCK_EC (device);
+	switch (self->data->module_type) {
+	case MODULE_TYPE_SINGLE:
+		return "WD19";
+	case MODULE_TYPE_DUAL:
+		return "WD19DC";
+	case MODULE_TYPE_TBT:
+		return "WD19TB";
+	default:
+		return NULL;
+	}
+}
+
 gboolean
 fu_dell_dock_ec_needs_tbt (FuDevice *device)
 {

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.h
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.h
@@ -26,6 +26,7 @@ G_DECLARE_FINAL_TYPE (FuDellDockEc, fu_dell_dock_ec, FU, DELL_DOCK_EC, FuDevice)
 
 FuDellDockEc 	*fu_dell_dock_ec_new			(FuDevice *proxy);
 
+const gchar	*fu_dell_dock_ec_get_module_type	(FuDevice *device);
 gboolean	 fu_dell_dock_ec_needs_tbt		(FuDevice *device);
 gboolean	 fu_dell_dock_ec_tbt_passive		(FuDevice *device);
 gboolean	 fu_dell_dock_ec_modify_lock		(FuDevice *self,

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -165,6 +165,25 @@ fu_plugin_dell_dock_get_ec (GPtrArray *devices)
 }
 
 gboolean
+fu_plugin_composite_prepare (FuPlugin *plugin, GPtrArray *devices,
+			     GError **error)
+{
+	FuDevice *parent = fu_plugin_dell_dock_get_ec (devices);
+	const gchar *sku;
+	if (parent == NULL)
+		return TRUE;
+	sku = fu_dell_dock_ec_get_module_type (parent);
+	if (sku == NULL) {
+		g_set_error_literal (error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL,
+				     "unable to detect SKU");
+		return FALSE;
+	}
+	fu_plugin_add_report_metadata (plugin, "DellDockSKU", sku);
+
+	return TRUE;
+}
+
+gboolean
 fu_plugin_composite_cleanup (FuPlugin *plugin,
 			     GPtrArray *devices,
 			     GError **error)


### PR DESCRIPTION
Should be helpful in reproducing failure reports.
If no opposition, I do intend to backport this back as far as possible too in hopes it increases the content in failure reports.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
