### PR TITLE
trivial: drop libgpgme deps

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -495,24 +495,6 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency type="build" id="libgpgme11-dev">
-    <distro id="centos">
-      <package>gpgme-devel</package>
-    </distro>
-    <distro id="fedora">
-      <package>gpgme-devel</package>
-    </distro>
-    <distro id="debian">
-      <control />
-      <package variant="x86_64" />
-      <package variant="s390x">libgpgme-dev:s390x</package>
-      <package variant="i386" />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-    </distro>
-  </dependency>
   <dependency type="build" id="gnome-desktop-testing">
     <distro id="fedora">
       <package />

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -56,7 +56,6 @@ BuildRequires: libsoup-devel >= %{libsoup_version}
 BuildRequires: libjcat-devel >= %{libjcat_version}
 BuildRequires: polkit-devel >= 0.103
 BuildRequires: sqlite-devel
-BuildRequires: gpgme-devel
 BuildRequires: systemd >= %{systemd_version}
 BuildRequires: libarchive-devel
 BuildRequires: gobject-introspection-devel


### PR DESCRIPTION
These aren't needed anymore since moving to libjcat
Note: snap still keeps them because libjcat builds in snap and
needs them.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
