### PR TITLE
trivial: detect `cpuid.h` and also look for host architecture

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,8 @@ if build_standalone and get_option('plugin_altos')
   libelf = dependency('libelf')
 endif
 
+host_cpu = host_machine.cpu_family()
+
 if cc.has_header('sys/utsname.h')
   conf.set('HAVE_UTSNAME_H', '1')
 endif
@@ -258,7 +260,7 @@ endif
 if cc.has_header('fnmatch.h')
   conf.set('HAVE_FNMATCH_H', '1')
 endif
-if cc.has_header('cpuid.h')
+if cc.has_header('cpuid.h') and (host_cpu == 'x86' or host_cpu == 'x86_64')
   conf.set('HAVE_CPUID_H', '1')
 endif
 if cc.has_function('getuid')
@@ -305,17 +307,16 @@ if build_standalone and get_option('plugin_uefi')
     conf.set_quoted ('FWUPD_EFI_DBXDIR', efi_dbxdir)
   endif
 
-  efi_arch = host_machine.cpu_family()
-  if efi_arch == 'x86'
+  if host_cpu == 'x86'
           EFI_MACHINE_TYPE_NAME = 'ia32'
           gnu_efi_arch = 'ia32'
-  elif efi_arch == 'x86_64'
+  elif host_cpu == 'x86_64'
           EFI_MACHINE_TYPE_NAME = 'x64'
           gnu_efi_arch = 'x86_64'
-  elif efi_arch == 'arm'
+  elif host_cpu == 'arm'
           EFI_MACHINE_TYPE_NAME = 'arm'
           gnu_efi_arch = 'arm'
-  elif efi_arch == 'aarch64'
+  elif host_cpu == 'aarch64'
           EFI_MACHINE_TYPE_NAME = 'aa64'
           gnu_efi_arch = 'aarch64'
   else

--- a/plugins/uefi/efi/meson.build
+++ b/plugins/uefi/efi/meson.build
@@ -90,13 +90,13 @@ compile_args = ['-Og',
 if get_option('werror')
     compile_args += '-Werror'
 endif
-if efi_arch == 'x86_64'
+if host_cpu == 'x86_64'
   compile_args += ['-mno-red-zone',
                    '-mno-sse',
                    '-mno-mmx',
                    '-DEFI_FUNCTION_WRAPPER',
                    '-DGNU_EFI_USE_MS_ABI']
-elif efi_arch == 'ia32'
+elif host_cpu == 'x86'
   compile_args += ['-mno-sse',
                    '-mno-mmx',
                    '-mno-red-zone',
@@ -113,7 +113,7 @@ efi_ldflags = ['-T',
                '-L', efi_ldsdir,
                '-L', efi_libdir,
                join_paths(efi_ldsdir, arch_crt)]
-if efi_arch == 'aarch64' or efi_arch == 'arm'
+if host_cpu == 'aarch64' or host_cpu == 'arm'
   # Aarch64 and ARM32 don't have an EFI capable objcopy. Use 'binary'
   # instead, and add required symbols manually.
   efi_ldflags += ['--defsym=EFI_SUBSYSTEM=0xa']


### PR DESCRIPTION
Fixes cross compilation for arm with clang which provides cpuid.h
but helpfully has this error:
```
 #if !(__x86_64__ || __i386__)
 #error this header is for x86 only
 #endif
```

Fixes: #2131

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
