### PR TITLE
Skip module unloading only if we are actually running under valgrind

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2792,10 +2792,12 @@ fu_plugin_finalize (GObject *object)
 	g_free (priv->data);
 	/* Must happen as the last step to avoid prematurely
 	 * freeing memory held by the plugin */
-#ifndef RUNNING_ON_VALGRIND
+#ifdef RUNNING_ON_VALGRIND
+	if (priv->module != NULL && RUNNING_ON_VALGRIND == 0)
+#else
 	if (priv->module != NULL)
-		g_module_close (priv->module);
 #endif
+		g_module_close (priv->module);
 
 	G_OBJECT_CLASS (fu_plugin_parent_class)->finalize (object);
 }

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -16,6 +16,11 @@
 #include "fu-plugin-vfuncs.h"
 #include "fu-hash.h"
 
+typedef struct {
+	FuPlugin		*plugin_uefi;
+	FuPlugin		*plugin_dell;
+} FuTest;
+
 static FuDevice *
 _find_device_by_id (GPtrArray *devices, const gchar *device_id)
 {
@@ -62,56 +67,20 @@ fu_engine_plugin_device_register_cb (FuPlugin *plugin_dell,
 }
 
 static void
-fu_plugin_dell_tpm_func (void)
+fu_plugin_dell_tpm_func (gconstpointer user_data)
 {
+	FuTest *self = (FuTest *) user_data;
 	FuDevice *device_v12;
 	FuDevice *device_v20;
 	const guint8 fw[30] = { 'F', 'W', 0x00 };
 	gboolean ret;
+	gulong added_id;
+	gulong register_id;
 	struct tpm_status tpm_out;
 	const gchar *tpm_server_running = g_getenv ("TPM_SERVER_RUNNING");
-	g_autofree gchar *pluginfn_uefi = NULL;
-	g_autofree gchar *pluginfn_dell = NULL;
-	g_autoptr(FuPlugin) plugin_dell = NULL;
-	g_autoptr(FuPlugin) plugin_uefi = NULL;
 	g_autoptr(GBytes) blob_fw = g_bytes_new_static (fw, sizeof(fw));
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
-
-	pluginfn_uefi = g_build_filename (PLUGINBUILDDIR, "..", "uefi",
-					  "libfu_plugin_uefi." G_MODULE_SUFFIX,
-					  NULL);
-	pluginfn_dell = g_build_filename (PLUGINBUILDDIR,
-					  "libfu_plugin_dell." G_MODULE_SUFFIX,
-					  NULL);
-
-	memset (&tpm_out, 0x0, sizeof(tpm_out));
-
-	plugin_uefi = fu_plugin_new ();
-	ret = fu_plugin_open (plugin_uefi, pluginfn_uefi, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	ret = fu_plugin_runner_startup (plugin_uefi, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
-	g_signal_connect (plugin_uefi, "device-added",
-			  G_CALLBACK (_plugin_device_added_cb),
-			  devices);
-
-	plugin_dell = fu_plugin_new ();
-	ret = fu_plugin_open (plugin_dell, pluginfn_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	ret = fu_plugin_runner_startup (plugin_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	g_signal_connect (plugin_dell, "device-register",
-			  G_CALLBACK (fu_engine_plugin_device_register_cb),
-			  plugin_uefi);
-	ret = fu_plugin_runner_coldplug (plugin_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
 
 #ifdef HAVE_GETUID
 	if (tpm_server_running == NULL &&
@@ -121,12 +90,28 @@ fu_plugin_dell_tpm_func (void)
 	}
 #endif
 
+	memset (&tpm_out, 0x0, sizeof(tpm_out));
+
+	devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+	added_id =
+	g_signal_connect (self->plugin_uefi, "device-added",
+			  G_CALLBACK (_plugin_device_added_cb),
+			  devices);
+
+	register_id =
+	g_signal_connect (self->plugin_dell, "device-register",
+			  G_CALLBACK (fu_engine_plugin_device_register_cb),
+			  self->plugin_uefi);
+	ret = fu_plugin_runner_coldplug (self->plugin_dell, &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+
 	/* inject fake data (no TPM) */
 	tpm_out.ret = -2;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, FALSE);
-	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	ret = fu_plugin_dell_detect_tpm (self->plugin_dell, &error);
 	g_assert_no_error (error);
 	g_assert_false (ret);
 	g_assert_cmpint (devices->len, ==, 0);
@@ -141,10 +126,10 @@ fu_plugin_dell_tpm_func (void)
 	tpm_out.fw_version = 0;
 	tpm_out.status = TPM_EN_MASK | (TPM_1_2_MODE << 8);
 	tpm_out.flashes_left = 0;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
-	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	ret = fu_plugin_dell_detect_tpm (self->plugin_dell, &error);
 	g_assert_true (ret);
 	g_assert_cmpint (devices->len, ==, 2);
 
@@ -159,7 +144,7 @@ fu_plugin_dell_tpm_func (void)
 	g_assert_false (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 
 	/* try to unlock 2.0 */
-	ret = fu_plugin_runner_unlock (plugin_uefi, device_v20, &error);
+	ret = fu_plugin_runner_unlock (self->plugin_uefi, device_v20, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_false (ret);
 	g_clear_error (&error);
@@ -175,10 +160,10 @@ fu_plugin_dell_tpm_func (void)
 	 */
 	tpm_out.status = TPM_EN_MASK | TPM_OWN_MASK | (TPM_1_2_MODE << 8);
 	tpm_out.flashes_left = 125;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
-	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	ret = fu_plugin_dell_detect_tpm (self->plugin_dell, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -190,7 +175,7 @@ fu_plugin_dell_tpm_func (void)
 	/* try to unlock 2.0 */
 	device_v20 = _find_device_by_name (devices, "TPM 2.0");
 	g_assert_nonnull (device_v20);
-	ret = fu_plugin_runner_unlock (plugin_uefi, device_v20, &error);
+	ret = fu_plugin_runner_unlock (self->plugin_uefi, device_v20, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_false (ret);
 	g_clear_error (&error);
@@ -206,10 +191,10 @@ fu_plugin_dell_tpm_func (void)
 	 */
 	tpm_out.status = TPM_EN_MASK | (TPM_1_2_MODE << 8);
 	tpm_out.flashes_left = 125;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
-	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	ret = fu_plugin_dell_detect_tpm (self->plugin_dell, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -222,7 +207,7 @@ fu_plugin_dell_tpm_func (void)
 	g_assert_false (fu_device_has_flag (device_v20, FWUPD_DEVICE_FLAG_UPDATABLE));
 
 	/* try to unlock 2.0 */
-	ret = fu_plugin_runner_unlock (plugin_uefi, device_v20, &error);
+	ret = fu_plugin_runner_unlock (self->plugin_uefi, device_v20, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -241,10 +226,10 @@ fu_plugin_dell_tpm_func (void)
 	 */
 	tpm_out.status = TPM_EN_MASK | (TPM_2_0_MODE << 8);
 	tpm_out.flashes_left = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &tpm_out, 0, 0,
 					 NULL, TRUE);
-	ret = fu_plugin_dell_detect_tpm (plugin_dell, &error);
+	ret = fu_plugin_dell_detect_tpm (self->plugin_dell, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -257,7 +242,7 @@ fu_plugin_dell_tpm_func (void)
 	g_assert_false (fu_device_has_flag (device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 
 	/* With one flash left we need an override */
-	ret = fu_plugin_runner_update (plugin_uefi, device_v20, blob_fw,
+	ret = fu_plugin_runner_update (self->plugin_uefi, device_v20, blob_fw,
 				       FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_false (ret);
@@ -266,62 +251,45 @@ fu_plugin_dell_tpm_func (void)
 	/* test override */
 	g_test_expect_message ("FuPluginUefi", G_LOG_LEVEL_WARNING,
 			       "missing or invalid embedded capsule header");
-	ret = fu_plugin_runner_update (plugin_uefi, device_v20, blob_fw,
+	ret = fu_plugin_runner_update (self->plugin_uefi, device_v20, blob_fw,
 				       FWUPD_INSTALL_FLAG_FORCE, &error);
 	g_test_assert_expected_messages ();
 	g_assert_no_error (error);
 	g_assert (ret);
+
+	/* all */
+	g_signal_handler_disconnect (self->plugin_uefi, added_id);
+	g_signal_handler_disconnect (self->plugin_dell, register_id);
 }
 
 static void
-fu_plugin_dell_dock_func (void)
+fu_plugin_dell_dock_func (gconstpointer user_data)
 {
+	FuTest *self = (FuTest *) user_data;
 	gboolean ret;
 	guint32 out[4] = { 0x0, 0x0, 0x0, 0x0 };
 	DOCK_UNION buf;
 	DOCK_INFO *dock_info;
-	g_autofree gchar *pluginfn_uefi = NULL;
-	g_autofree gchar *pluginfn_dell = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
-	g_autoptr(FuPlugin) plugin_uefi = fu_plugin_new ();
-	g_autoptr(FuPlugin) plugin_dell = fu_plugin_new ();
+	gulong added_id;
+	gulong register_id;
 
-	pluginfn_uefi = g_build_filename (PLUGINBUILDDIR, "..", "uefi",
-					  "libfu_plugin_uefi." G_MODULE_SUFFIX,
-					  NULL);
-	pluginfn_dell = g_build_filename (PLUGINBUILDDIR,
-					  "libfu_plugin_dell." G_MODULE_SUFFIX,
-					  NULL);
-
-	ret = fu_plugin_open (plugin_uefi, pluginfn_uefi, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	ret = fu_plugin_runner_startup (plugin_uefi, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
 	devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
-	g_signal_connect (plugin_uefi, "device-added",
+	added_id =
+	g_signal_connect (self->plugin_uefi, "device-added",
 			  G_CALLBACK (_plugin_device_added_cb),
 			  devices);
-	ret = fu_plugin_open (plugin_dell, pluginfn_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	ret = fu_plugin_runner_startup (plugin_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
-	g_signal_connect (plugin_dell, "device-register",
+	register_id =
+	g_signal_connect (self->plugin_dell, "device-register",
 			  G_CALLBACK (fu_engine_plugin_device_register_cb),
-			  plugin_uefi);
-	ret = fu_plugin_runner_coldplug (plugin_dell, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
+			  self->plugin_uefi);
 
 	/* make sure bad device doesn't trigger this */
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					   (guint32 *) &out,
 					   0x1234, 0x4321, NULL, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, &error);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, &error);
 	g_assert_false (ret);
 	g_clear_error (&error);
 	g_assert_cmpint (devices->len, ==, 0);
@@ -329,11 +297,11 @@ fu_plugin_dell_dock_func (void)
 	/* inject a USB dongle matching correct VID/PID */
 	out[0] = 0;
 	out[1] = 0;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					   (guint32 *) &out,
 					   DOCK_NIC_VID, DOCK_NIC_PID,
 					   NULL, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, &error);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, &error);
 	g_assert_true (ret);
 	g_clear_error (&error);
 	g_assert_cmpint (devices->len, ==, 0);
@@ -363,11 +331,11 @@ fu_plugin_dell_dock_func (void)
 		"Dock1,Cable,Cyp,TBT_Cable,0 :Query 2 2 2 3 0", 44);
 	out[0] = 0;
 	out[1] = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					   (guint32 *) &out,
 					   DOCK_NIC_VID, DOCK_NIC_PID,
 					   buf.buf, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, NULL);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, NULL);
 	g_assert (ret);
 	g_assert_cmpint (devices->len, ==, 4);
 	g_ptr_array_set_size (devices, 0);
@@ -398,11 +366,11 @@ fu_plugin_dell_dock_func (void)
 		"Dock1,Cable,Cyp,TBT_Cable,0 :Query 2 2 2 3 0", 44);
 	out[0] = 0;
 	out[1] = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					   (guint32 *) &out,
 					   DOCK_NIC_VID, DOCK_NIC_PID,
 					   buf.buf, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, NULL);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, NULL);
 	g_assert (ret);
 	g_assert_cmpint (devices->len, ==, 3);
 	g_ptr_array_set_size (devices, 0);
@@ -430,11 +398,11 @@ fu_plugin_dell_dock_func (void)
 		"Dock1,Cable,Cyp,IE_Cable,0 :Query 2 2 2 1 0", 43);
 	out[0] = 0;
 	out[1] = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					   (guint32 *) &out,
 					   DOCK_NIC_VID, DOCK_NIC_PID,
 					   buf.buf, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, &error);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, &error);
 	g_assert (ret);
 	g_assert_no_error (error);
 	g_assert_cmpint (devices->len, ==, 3);
@@ -463,11 +431,11 @@ fu_plugin_dell_dock_func (void)
 		"Dock1,Cable,Cyp,IE_Cable,0 :Query 2 2 2 1 0", 43);
 	out[0] = 0;
 	out[1] = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &out,
 					 DOCK_NIC_VID, DOCK_NIC_PID,
 					 buf.buf, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, &error);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, &error);
 	g_assert (ret);
 	g_assert_no_error (error);
 	g_assert_cmpint (devices->len, ==, 2);
@@ -490,20 +458,72 @@ fu_plugin_dell_dock_func (void)
 		"Dock1,EC,MIPS32,FUT_Dock,0 :Query 2 0 2 2 0", 43);
 	out[0] = 0;
 	out[1] = 1;
-	fu_plugin_dell_inject_fake_data (plugin_dell,
+	fu_plugin_dell_inject_fake_data (self->plugin_dell,
 					 (guint32 *) &out,
 					 DOCK_NIC_VID, DOCK_NIC_PID,
 					 buf.buf, FALSE);
-	ret = fu_plugin_usb_device_added (plugin_dell, NULL, &error);
+	ret = fu_plugin_usb_device_added (self->plugin_dell, NULL, &error);
 	g_assert_false (ret);
 	g_assert_cmpint (devices->len, ==, 0);
 	g_free (buf.record);
+
+	/* all */
+	g_signal_handler_disconnect (self->plugin_uefi, added_id);
+	g_signal_handler_disconnect (self->plugin_dell, register_id);
 }
+
+static void
+fu_test_self_init (FuTest *self)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	g_autofree gchar *pluginfn_uefi = NULL;
+	g_autofree gchar *pluginfn_dell = NULL;
+
+	self->plugin_uefi = fu_plugin_new ();
+	pluginfn_uefi = g_build_filename (PLUGINBUILDDIR, "..", "uefi",
+					  "libfu_plugin_uefi." G_MODULE_SUFFIX,
+					  NULL);
+	ret = fu_plugin_open (self->plugin_uefi, pluginfn_uefi, &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+	ret = fu_plugin_runner_startup (self->plugin_uefi, &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+
+	self->plugin_dell = fu_plugin_new ();
+	pluginfn_dell = g_build_filename (PLUGINBUILDDIR,
+					  "libfu_plugin_dell." G_MODULE_SUFFIX,
+					  NULL);
+	ret = fu_plugin_open (self->plugin_dell, pluginfn_dell, &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+	ret = fu_plugin_runner_startup (self->plugin_dell, &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+}
+
+static void
+fu_test_self_free (FuTest *self)
+{
+	if (self->plugin_uefi != NULL)
+		g_object_unref (self->plugin_uefi);
+	if (self->plugin_dell != NULL)
+		g_object_unref (self->plugin_dell);
+	g_free (self);
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuTest, fu_test_self_free)
+#pragma clang diagnostic pop
 
 int
 main (int argc, char **argv)
 {
 	g_autofree gchar *sysfsdir = NULL;
+	g_autoptr(FuTest) self = g_new0 (FuTest, 1);
+
 	g_test_init (&argc, &argv, NULL);
 
 	/* change path */
@@ -521,7 +541,8 @@ main (int argc, char **argv)
 	g_assert_cmpint (g_mkdir_with_parents ("/tmp/fwupd-self-test/var/lib/fwupd", 0755), ==, 0);
 
 	/* tests go here */
-	g_test_add_func ("/fwupd/plugin{dell:tpm}", fu_plugin_dell_tpm_func);
-	g_test_add_func ("/fwupd/plugin{dell:dock}", fu_plugin_dell_dock_func);
+	fu_test_self_init (self);
+	g_test_add_data_func ("/fwupd/plugin{dell:tpm}", self, fu_plugin_dell_tpm_func);
+	g_test_add_data_func ("/fwupd/plugin{dell:dock}", self, fu_plugin_dell_dock_func);
 	return g_test_run ();
 }


### PR DESCRIPTION
See also: https://github.com/fwupd/fwupd/issues/2119
Reported-by: Anton Farygin <rider@altlinux.org>

Based on a patch by Gleb Fotengauer-Malinovskiy <glebfm@altlinux.org>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
