### PR TITLE
Fix regression when using GetDetails on a device with _MD_SET_NAME set

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3587,7 +3587,8 @@ fu_engine_get_details (FuEngine *self, gint fd, GError **error)
 			fwupd_release_set_remote_id (rel, remote_id);
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_SUPPORTED);
 		}
-		fu_engine_md_refresh_device_from_component (self, dev, component);
+		if (fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_MD_SET_VERFMT))
+			fu_engine_md_refresh_device_verfmt (self, dev, component);
 
 		/* if this matched a device on the system, ensure all the
 		 * requirements passed before setting UPDATABLE */


### PR DESCRIPTION
In f430da0 we added code that was supposed to copy the verfmt from the component
to the device. We accidentally overwrote the component-provided <name> because
the device had _MD_SET_NAME set.

Use the specific function to just set the verfmt like we intended.
