### PR TITLE
trivial: fix windows and snap CI

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -39,6 +39,10 @@ meson .. \
     -Dlibjcat:man=false \
     -Dlibjcat:gpg=false \
     -Dlibjcat:introspection=false \
+    -Dgusb:tests=false \
+    -Dgusb:docs=false \
+    -Dgusb:introspection=false \
+    -Dgusb:vapi=false \
     -Dgudev=false $@
 meson introspect . --projectinfo | jq -r .version > $DESTDIR/VERSION
 ninja -v

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -174,6 +174,10 @@ parts:
                        -Dman=false,
                        -Dplugin_modem_manager=true,
                        -Dudevdir=$SNAPCRAFT_STAGE/lib/udev,
+                       "-Dgusb:tests=false",
+                       "-Dgusb:docs=false",
+                       "-Dgusb:introspection=false",
+                       "-Dgusb:vapi=false",
                        "-Dlibxmlb:gtkdoc=false",
                        "-Dlibxmlb:introspection=false",
                        "-Dlibjcat:man=false",
@@ -196,7 +200,6 @@ parts:
       - libefivar-dev
       - libftdi1-dev
       - libgudev-1.0-dev
-      - libgusb-dev
       - libgcab-dev
       - libglib2.0-dev
       - libgpgme11-dev
@@ -219,7 +222,6 @@ parts:
       - libefivar1
       - libefiboot1
       - libelf1
-      - libgusb2
       - libusb-1.0-0
       - libgudev-1.0-0
       - libgpgme11


### PR DESCRIPTION
Introducing newer gusb caused these builds to run gusb as a subproject
and hence the introspection binaries were looked for.

Fixes: cd65ae ("Require libgusb 0.3.3")

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
