### PR TITLE
trivial: logitech_hidpp: set the protocol properly when bootloader un…

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -230,10 +230,10 @@ fu_logitech_hidpp_runtime_setup_internal (FuDevice *device, GError **error)
 		    (self->version_bl_major == 0x03 && config[8] >= 0x02)) {
 			self->signed_firmware = TRUE;
 			fu_device_set_protocol (device, "com.logitech.unifyingsigned");
-		} else {
-			fu_device_set_protocol (device, "com.logitech.unifying");
 		}
 	}
+	if (!self->signed_firmware)
+		fu_device_set_protocol (device, "com.logitech.unifying");
 
 	/* enable HID++ notifications */
 	if (!fu_logitech_hidpp_runtime_enable_notifications (self, error)) {


### PR DESCRIPTION
…known

This appears to be a regression from c6ae0d998b7e5577b3de4763c25d9d90056bebf1
where the case of bootloader version 0 didn't get protocol set.

Fixes: #2156

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
