### PR TITLE
Add a plugin to fail the HSI runtime for WPBT

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -347,6 +347,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %dir %{_libdir}/fwupd-plugins-3
 %{_libdir}/fwupd-plugins-3/libfu_plugin_acpi_dmar.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_acpi_facp.so
+%{_libdir}/fwupd-plugins-3/libfu_plugin_acpi_wpbt.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_altos.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_amt.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_ata.so

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -112,6 +112,7 @@ typedef enum {
 } FwupdSecurityAttrResult;
 
 #define FWUPD_SECURITY_ATTR_ID_ACPI_DMAR		"org.fwupd.hsi.AcpiDmar"		/* Since: 1.5.0 */
+#define FWUPD_SECURITY_ATTR_ID_ACPI_WPBT		"org.fwupd.hsi.AcpiWpbt"		/* Since: 1.5.0 */
 #define FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM		"org.fwupd.hsi.EncryptedRam"		/* Since: 1.5.0 */
 #define FWUPD_SECURITY_ATTR_ID_FWUPD_ATTESTATION	"org.fwupd.hsi.FwupdAttestation"	/* Since: 1.5.0 */
 #define FWUPD_SECURITY_ATTR_ID_FWUPD_PLUGINS		"org.fwupd.hsi.FwupdPlugins"		/* Since: 1.5.0 */

--- a/plugins/acpi-wpbt/README.md
+++ b/plugins/acpi-wpbt/README.md
@@ -1,0 +1,23 @@
+ACPI WPBT
+=========
+
+Introduction
+------------
+
+This plugin checks if the WPBT ACPI table has been exported. Although unused by
+Linux, Microsoft Windows will execute the EXE file specified by the WPBT table.
+The launching of the executable may be conditionalized on it being signed by a
+specific cryptographic key or can depend on site or system policy.
+
+WPBT should be disabled in the machine firmware setup, and it certainly should
+not be enabled by default at the factory. Most commonly WPBT is enabled when
+enabling the Computrace feature.
+
+Computrace uses WPBT for legitimate hardware recovery purposes. Less commonly
+an OEM may use it to install OEM-specific drivers and utilities.
+
+The result will be stored in a security attribute for HSI.
+
+If you wish to ignore the HSI failure (for example, because Computrace is
+actually desired) then you can remove this runtime issue by setting
+`BlacklistPlugins=acpi_wpbt` in `/etc/fwupd/daemon.conf`

--- a/plugins/acpi-wpbt/fu-plugin-acpi-wpbt.c
+++ b/plugins/acpi-wpbt/fu-plugin-acpi-wpbt.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-plugin-vfuncs.h"
+#include "fu-hash.h"
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+}
+
+void
+fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
+{
+	g_autofree gchar *fn = NULL;
+	g_autofree gchar *path = NULL;
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+
+	/* create attr */
+	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_ACPI_WPBT);
+	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
+	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
+	fu_security_attrs_append (attrs, attr);
+
+	/* load WPBT table */
+	path = fu_common_get_path (FU_PATH_KIND_ACPI_TABLES);
+	fn = g_build_filename (path, "WPBT", NULL);
+	if (g_file_test (fn, G_FILE_TEST_EXISTS)) {
+		gsize bufsz = 0;
+		guint8 csum = 0;
+		g_autofree gchar *buf = NULL;
+		g_autoptr(GError) error_local = NULL;
+
+		if (!g_file_get_contents (fn, &buf, &bufsz, &error_local)) {
+			g_warning ("failed to read %s: %s", fn, error_local->message);
+			fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
+			return;
+		}
+		/* test if the checksum is valid */
+		for (gsize i = 0; i < bufsz; i++)
+			csum += buf[i];
+		if (csum != 0) {
+			fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
+			return;
+		}
+		fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
+		return;
+	}
+
+	/* success */
+	fwupd_security_attr_set_result (attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+}

--- a/plugins/acpi-wpbt/meson.build
+++ b/plugins/acpi-wpbt/meson.build
@@ -1,0 +1,23 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiWpbt"']
+
+shared_module('fu_plugin_acpi_wpbt',
+  fu_hash,
+  sources : [
+    'fu-plugin-acpi-wpbt.c',
+  ],
+  include_directories : [
+    root_incdir,
+    fwupd_incdir,
+    fwupdplugin_incdir,
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  link_with : [
+    fwupd,
+    fwupdplugin,
+  ],
+  c_args : cargs,
+  dependencies : [
+    plugin_deps,
+  ],
+)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,5 +1,6 @@
 subdir('acpi-dmar')
 subdir('acpi-facp')
+subdir('acpi-wpbt')
 subdir('bios')
 subdir('ccgx')
 subdir('cros-ec')

--- a/src/fu-security-attr.c
+++ b/src/fu-security-attr.c
@@ -164,6 +164,10 @@ fu_security_attr_get_name (FwupdSecurityAttr *attr)
 		 * debugging of Intel processors using the USB3 port */
 		return g_strdup (_("Intel DCI debugger"));
 	}
+	if (g_strcmp0 (appstream_id, FWUPD_SECURITY_ATTR_ID_ACPI_WPBT) == 0) {
+		/* TRANSLATORS: Title: the firmware sets an EXE for Windows to run...  */
+		return g_strdup (_("Windows Platform Binary Table"));
+	}
 
 	/* we should not get here */
 	return g_strdup (fwupd_security_attr_get_name (attr));


### PR DESCRIPTION
The logic of the runtime failure is that it is something the user can fix
without requiring help from the OEM.
