### PR TITLE
fu-main: Make it clearer what lost name is and bump it to warning

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1493,7 +1493,7 @@ fu_main_on_name_lost_cb (GDBusConnection *connection,
 			 gpointer user_data)
 {
 	FuMainPrivate *priv = (FuMainPrivate *) user_data;
-	g_debug ("FuMain: lost name: %s", name);
+	g_warning ("another service has claimed the dbus name %s", name);
 	g_main_loop_quit (priv->loop);
 }
 


### PR DESCRIPTION
This happens often enough when people switch from snap to distro
package that we should mention it in non-verbose logs.

Fixes: #2112

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
