### PR TITLE
Record the UEFI failure in more cases

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5707,6 +5707,7 @@ fu_engine_update_history_device (FuEngine *self, FuDevice *dev_history, GError *
 		fu_device_set_version (dev_history, fu_device_get_version (dev));
 		fu_device_remove_flag (dev_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 		fu_device_set_update_state (dev_history, FWUPD_UPDATE_STATE_SUCCESS);
+		fu_device_set_update_error (dev_history, NULL);
 		return fu_history_modify_device (self->history, dev_history, error);
 	}
 
@@ -5723,11 +5724,14 @@ fu_engine_update_history_device (FuEngine *self, FuDevice *dev_history, GError *
 	if (fu_device_get_update_state (dev) != FWUPD_UPDATE_STATE_FAILED &&
 	    fu_device_get_update_state (dev) != FWUPD_UPDATE_STATE_FAILED_TRANSIENT) {
 		g_debug ("falling back to generic failure");
+		fu_device_set_update_state (dev_history, FWUPD_UPDATE_STATE_FAILED);
 		fu_device_set_update_error (dev_history, "failed to run update on reboot");
+	} else {
+		fu_device_set_update_state (dev_history, fu_device_get_update_state (dev));
+		fu_device_set_update_error (dev_history, fu_device_get_update_error (dev));
 	}
 
 	/* update the state in the database */
-	fu_device_set_update_error (dev_history, fu_device_get_update_error (dev));
 	return fu_history_modify_device (self->history, dev_history, error);
 }
 


### PR DESCRIPTION
Ensure the historical error is set for failed NEEDS_REBOOT UEFI devices that do
not set LastAttemptStatus.
