### PR TITLE
uefi: check for free space after cleaning up ESP

### DIFF
--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -515,9 +515,9 @@ fu_uefi_device_prepare (FuDevice *device,
 	/* sanity checks */
 	if (!fu_uefi_device_is_esp_mounted (device, error))
 		return FALSE;
-	if (!fu_uefi_device_check_esp_free (device, error))
-		return FALSE;
 	if (!fu_uefi_device_cleanup_esp (device, error))
+		return FALSE;
+	if (!fu_uefi_device_check_esp_free (device, error))
 		return FALSE;
 
 	return TRUE;


### PR DESCRIPTION
In a very small ESP situation it's possible that the amount of free
space is insufficient until it's actually been cleaned.

Fixes: #2179

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
