### PR TITLE
trivial: fu-util: correct an assertion when no remotes configured

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1244,6 +1244,7 @@ static gboolean
 fu_util_check_oldest_remote (FuUtilPrivate *priv, guint64 *age_oldest, GError **error)
 {
 	g_autoptr(GPtrArray) remotes = NULL;
+	gboolean checked = FALSE;
 
 	/* get the age of the oldest enabled remotes */
 	remotes = fwupd_client_get_remotes (priv->client, NULL, error);
@@ -1255,8 +1256,17 @@ fu_util_check_oldest_remote (FuUtilPrivate *priv, guint64 *age_oldest, GError **
 			continue;
 		if (fwupd_remote_get_kind (remote) != FWUPD_REMOTE_KIND_DOWNLOAD)
 			continue;
+		checked = TRUE;
 		if (fwupd_remote_get_age (remote) > *age_oldest)
 			*age_oldest = fwupd_remote_get_age (remote);
+	}
+	if (!checked) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOTHING_TO_DO,
+				     /* TRANSLATORS: error message for a user who ran fwupdmgr refresh recently but no remotes */
+				     "No remotes enabled.");
+		return FALSE;
 	}
 	return TRUE;
 }


### PR DESCRIPTION
```
(fwupdmgr:185983): FuMain-CRITICAL **: 15:20:57.044: fu_util_time_to_str: assertion 'tmp != 0' failed
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
