### PR TITLE
dell-dock: Add more module types to the enum

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -100,9 +100,13 @@ typedef struct __attribute__ ((packed)) {
 } FuDellDockEcQueryEntry;
 
 typedef enum {
-	MODULE_TYPE_SINGLE = 1,
-	MODULE_TYPE_DUAL,
-	MODULE_TYPE_TBT,
+	MODULE_TYPE_45_TBT = 1,
+	MODULE_TYPE_45,
+	MODULE_TYPE_130_TBT,
+	MODULE_TYPE_130_DP,
+	MODULE_TYPE_130_UNIVERSAL,
+	MODULE_TYPE_240_TRIN,
+	MODULE_TYPE_210_DUAL,
 } FuDellDockDockModule;
 
 typedef struct __attribute__ ((packed)) {
@@ -177,14 +181,22 @@ fu_dell_dock_ec_get_module_type (FuDevice *device)
 {
 	FuDellDockEc *self = FU_DELL_DOCK_EC (device);
 	switch (self->data->module_type) {
-	case MODULE_TYPE_SINGLE:
-		return "WD19";
-	case MODULE_TYPE_DUAL:
-		return "WD19DC";
-	case MODULE_TYPE_TBT:
-		return "WD19TB";
+	case MODULE_TYPE_45_TBT:
+		return "45 (TBT)";
+	case MODULE_TYPE_45:
+		return "45";
+	case MODULE_TYPE_130_TBT:
+		return "130 (TBT)";
+	case MODULE_TYPE_130_DP:
+		return "130 (DP)";
+	case MODULE_TYPE_130_UNIVERSAL:
+		return "130 (Universal)";
+	case MODULE_TYPE_240_TRIN:
+		return "240 (Trinity)";
+	case MODULE_TYPE_210_DUAL:
+		return "210 (Dual)";
 	default:
-		return NULL;
+		return "unknown";
 	}
 }
 
@@ -195,7 +207,8 @@ fu_dell_dock_ec_needs_tbt (FuDevice *device)
 	gboolean port0_tbt_mode = self->data->port0_dock_status & TBT_MODE_MASK;
 
 	/* check for TBT module type */
-	if (self->data->module_type != MODULE_TYPE_TBT)
+	if (self->data->module_type != MODULE_TYPE_130_TBT &&
+	    self->data->module_type != MODULE_TYPE_45_TBT)
 		return FALSE;
 	g_debug ("found thunderbolt dock, port mode: %d", port0_tbt_mode);
 
@@ -393,7 +406,8 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 			    device_entry[i].version.version_8[3]);
 			g_debug ("\tParsed version %s", self->mst_version);
 		} else if (map->device_type == FU_DELL_DOCK_DEVICETYPE_TBT &&
-			   self->data->module_type == MODULE_TYPE_TBT) {
+			   (self->data->module_type == MODULE_TYPE_130_TBT ||
+			    self->data->module_type == MODULE_TYPE_45_TBT)) {
 			/* guard against invalid Thunderbolt version read from EC */
 			if (!fu_dell_dock_test_valid_byte (device_entry[i].version.version_8, 2)) {
 				g_warning ("[EC bug] EC read invalid Thunderbolt version %08x",
@@ -426,7 +440,8 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 	}
 
 	/* Thunderbolt SKU takes a little longer */
-	if (self->data->module_type == MODULE_TYPE_TBT) {
+	if (self->data->module_type == MODULE_TYPE_130_TBT ||
+	    self->data->module_type == MODULE_TYPE_45_TBT) {
 		guint64 tmp = fu_device_get_install_duration (device);
 		fu_device_set_install_duration (device, tmp + 20);
 	}

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -173,12 +173,8 @@ fu_plugin_composite_prepare (FuPlugin *plugin, GPtrArray *devices,
 	if (parent == NULL)
 		return TRUE;
 	sku = fu_dell_dock_ec_get_module_type (parent);
-	if (sku == NULL) {
-		g_set_error_literal (error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL,
-				     "unable to detect SKU");
-		return FALSE;
-	}
-	fu_plugin_add_report_metadata (plugin, "DellDockSKU", sku);
+	if (sku != NULL)
+		fu_plugin_add_report_metadata (plugin, "DellDockSKU", sku);
 
 	return TRUE;
 }


### PR DESCRIPTION
Unfortunately module type has more than I previously realized.  This wasn't caught because of the large number of options that can be plugged into the dock.

The meanings that previously were applied fortunately worked for
the most important case (130-180W TBT) but didn't for single C, dual
C or small power (45W) cases.

Since composite_prepare was trying to read and interpret these, it
causes failures when these other ones are encountered.

I reproduced this on a 130W adapter plugged into a single C (type 0x4).
This meant the update wouldn't install since NULL was returned for the
type.

In case a new module ID is added later, also return an "unknown" for
the metadata.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
