### PR TITLE
Add support for a delayed activation flow for Thunderbolt

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1140,6 +1140,79 @@ fu_udev_device_pread (FuUdevDevice *self, goffset port, guint8 *data, GError **e
 	return fu_udev_device_pread_full (self, port, data, 0x1, error);
 }
 
+
+/**
+ * fu_udev_device_write_sysfs:
+ * @self: A #FuUdevDevice
+ * @attribute: sysfs attribute name
+ * @val: data to write into the attribute
+ * @error: A #GError, or %NULL
+ *
+ * Writes data into a sysfs attribute
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.5.0
+ **/
+gboolean
+fu_udev_device_write_sysfs (FuUdevDevice *self, const gchar *attribute,
+			    const gchar *val, GError **error)
+{
+#ifndef _WIN32
+	ssize_t n;
+	int r;
+	int fd;
+	g_autofree gchar *path = NULL;
+
+	g_return_val_if_fail (FU_IS_UDEV_DEVICE (self), FALSE);
+	g_return_val_if_fail (attribute != NULL, FALSE);
+	g_return_val_if_fail (val != NULL, FALSE);
+
+	path = g_build_filename (fu_udev_device_get_sysfs_path (self),
+				 attribute, NULL);
+	fd = open (path, O_WRONLY | O_CLOEXEC);
+	if (fd < 0) {
+		g_set_error (error, G_IO_ERROR,
+			     g_io_error_from_errno (errno),
+			     "could not open %s: %s",
+			     path,
+			     g_strerror (errno));
+		return FALSE;
+	}
+
+	do {
+		n = write (fd, val, strlen (val));
+		if (n < 1 && errno != EINTR) {
+			g_set_error (error, G_IO_ERROR,
+				     g_io_error_from_errno (errno),
+				     "could not write to %s: %s",
+				     path,
+				     g_strerror (errno));
+			(void) close (fd);
+			return FALSE;
+		}
+	} while (n < 1);
+
+	r = close (fd);
+	if (r < 0 && errno != EINTR) {
+		g_set_error (error, G_IO_ERROR,
+			     g_io_error_from_errno (errno),
+			     "could not close %s: %s",
+			     path,
+			     g_strerror (errno));
+		return FALSE;
+	}
+
+	return TRUE;
+#else
+	g_set_error_literal (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "sysfs attributes not supported on Windows");
+	return FALSE;
+#endif
+}
+
 static void
 fu_udev_device_get_property (GObject *object, guint prop_id,
 			    GValue *value, GParamSpec *pspec)

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -101,3 +101,8 @@ const gchar	*fu_udev_device_get_sysfs_attr		 (FuUdevDevice	*self,
 							  const gchar	*attr,
 							  GError	**error);
 gchar		*fu_udev_device_get_parent_name		(FuUdevDevice	*self);
+
+gboolean	 fu_udev_device_write_sysfs		(FuUdevDevice	*self,
+							 const gchar	*attribute,
+							 const gchar	*val,
+							 GError		**error);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -603,5 +603,6 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_udev_device_get_sysfs_attr;
     fu_udev_device_pread_full;
     fu_udev_device_pwrite_full;
+    fu_udev_device_write_sysfs;
   local: *;
 } LIBFWUPDPLUGIN_1.4.1;

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -57,6 +57,21 @@ fu_plugin_device_created (FuPlugin *plugin, FuDevice *dev, GError **error)
 }
 
 void
+fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
+{
+	if (g_strcmp0 (fu_device_get_plugin (device), "thunderbolt") != 0)
+		return;
+
+	/* Operating system will handle finishing updates later */
+	if (fu_plugin_get_config_value_boolean (plugin, "DelayedActivation")) {
+		g_debug ("Turning on delayed activation for %s",
+			 fu_device_get_name (device));
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_SKIPS_RESTART);
+	}
+}
+
+void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);

--- a/plugins/thunderbolt/thunderbolt.conf
+++ b/plugins/thunderbolt/thunderbolt.conf
@@ -4,3 +4,6 @@
 # It's important that all backports from this kernel have been
 # made if using an older kernel
 MinimumKernelVersion=4.13.0
+
+# Forces delaying activation until shutdown/logout/reboot
+DelayedActivation=false


### PR DESCRIPTION
This allows delaying the activation of Thunderbolt firmware until
shutdown/reboot or when the dock is unplugged.

This functionality requires features in the kernel:
https://lore.kernel.org/linux-usb/20200622143035.25327-1-mario.limonciello@dell.com/T/#t

Matrix of cases to support:

* Distro Old Linux kernel (doesn't support authenticate on disconnect)

  - WD19TB: Should have `skips-restart` flag set
    No flush or activate features called in `thunderbolt` plugin.
    `dell_dock` plugin will activate at end of composite update

  - All other devices: Shouldn't have flags set
    Should authenticate in Thunderbolt plugin.
    `1 > nvm_authenticate`

* Distro New Linux kernel (supports authenticate on disconnect)

  - WD19TB: Should have `usable-during-update` flag set but not `skips-restart`
    Should flush image to SPI in `thunderbolt` plugin
    `2 > nvm_authenticate_on_disconnect`
    Should configure TBT device for authenticate on disconnect
    `1 > nvm_authenticate_on_disconnect`
    `dell_dock` plugin will configure dock for authenticate on disconnect

  - All other devices: Shouldn't have flags set
    Should authenticate in `thunderbolt` plugin.
    `1 > nvm_authenticate`

* ChromeOS (supports authenticate on disconnect)

  - `thunerbolt.conf` will have `DelayedActivation=true`.

  - WD19TB: Should have `usable-during-update` flag set but not `skips-restart`
    Should flush image to SPI in `thunderbolt` plugin
    `2 > nvm_authenticate_on_disconnect`
    Should configure device for authenticate on disconnect
    `1 > nvm_authenticate_on_disconnect`
    `dell_dock` plugin will configure dock for authenticate on disconnect

  - All other devices: Should have both `usable-during-update` and `skips-restart` set
    Should flush image to SPI in `thunderbolt` plugin
    `2 > nvm_authenticate`
    Will activate upon logout/shutdown/reboot
    `1 > nvm_authenticate`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
