### PR TITLE
trivial: add Vendor ID into Modem manager devices

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -3,38 +3,46 @@
 [DeviceInstanceId=USB\VID_413C&PID_81D7]
 Summary = Dell DW5821e LTE modem
 CounterpartGuid = USB\VID_413C&PID_81D6
+VendorId = USB:0x413C
 
 # DW5821e in fastboot mode
 [DeviceInstanceId=USB\VID_413C&PID_81D6]
 Summary = Dell DW5821e LTE modem (fastboot)
 CounterpartGuid = USB\VID_413C&PID_81D7
+VendorId = USB:0x413C
 
 # DW5821e/eSIM
 [DeviceInstanceId=USB\VID_413C&PID_81E0]
 Summary = Dell DW5821e/eSIM LTE modem
 CounterpartGuid = USB\VID_413C&PID_81E1
+VendorId = USB:0x413C
 
 # DW5821e/eSIM in fastboot mode
 [DeviceInstanceId=USB\VID_413C&PID_81E1]
 Summary = Dell DW5821e/eSIM LTE modem (fastboot)
 CounterpartGuid = USB\VID_413C&PID_81E0
+VendorId = USB:0x413C
 
 # T77W968
 [DeviceInstanceId=USB\VID_0489&PID_E0B4]
 Summary = Foxconn T77w968 LTE modem
 CounterpartGuid = USB\VID_0489&PID_E0B7
+VendorId = USB:0x0489
 
 # T77W968 in fastboot mode
 [DeviceInstanceId=USB\VID_0489&PID_E0B7]
 Summary = Foxconn T77w968 LTE modem (fastboot)
 CounterpartGuid = USB\VID_0489&PID_E0B4
+VendorId = USB:0x0489
 
 # T77W968/eSIM
 [DeviceInstanceId=USB\VID_0489&PID_E0B5]
 Summary = Foxconn T77w968/eSIM LTE modem
 CounterpartGuid = USB\VID_0489&PID_E0B8
+VendorId = USB:0x0489
 
 # T77W968/eSIM in fastboot mode
 [DeviceInstanceId=USB\VID_0489&PID_E0B8]
 Summary = Foxconn T77w968/eSIM LTE modem (fastboot)
 CounterpartGuid = USB\VID_0489&PID_E0B5
+VendorId = USB:0x0489


### PR DESCRIPTION
I don't actually know for sure this will fix it sufficiently or it's the correct vendor ID in this instance, so hopefully @wicadmin or @aleksander0m  you can double check it.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
