### PR TITLE
Add XB_QUERY_FLAG_FORCE_NODE_CACHE

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -708,6 +708,9 @@ fu_common_store_cab_func (void)
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbNode) req = NULL;
 	g_autoptr(XbSilo) silo = NULL;
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	g_autoptr(XbQuery) query = NULL;
+#endif
 
 	/* create silo */
 	blob = _build_cab (GCAB_COMPRESSION_NONE,
@@ -740,7 +743,17 @@ fu_common_store_cab_func (void)
 	component = xb_silo_query_first (silo, "components/component/id[text()='com.acme.example.firmware']/..", &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (component);
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	query = xb_query_new_full (xb_node_get_silo (component),
+				   "releases/release",
+				   XB_QUERY_FLAG_FORCE_NODE_CACHE,
+				   &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (query);
+	rel = xb_node_query_first_full (component, query, &error);
+#else
 	rel = xb_node_query_first (component, "releases/release", &error);
+#endif
 	g_assert_no_error (error);
 	g_assert_nonnull (rel);
 	g_assert_cmpstr (xb_node_get_attr (rel, "version"), ==, "1.2.3");
@@ -764,6 +777,9 @@ fu_common_store_cab_unsigned_func (void)
 	g_autoptr(XbNode) csum = NULL;
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbSilo) silo = NULL;
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	g_autoptr(XbQuery) query = NULL;
+#endif
 
 	/* create silo */
 	blob = _build_cab (GCAB_COMPRESSION_NONE,
@@ -784,7 +800,17 @@ fu_common_store_cab_unsigned_func (void)
 	component = xb_silo_query_first (silo, "components/component/id[text()='com.acme.example.firmware']/..", &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (component);
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	query = xb_query_new_full (xb_node_get_silo (component),
+				   "releases/release",
+				   XB_QUERY_FLAG_FORCE_NODE_CACHE,
+				   &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (query);
+	rel = xb_node_query_first_full (component, query, &error);
+#else
 	rel = xb_node_query_first (component, "releases/release", &error);
+#endif
 	g_assert_no_error (error);
 	g_assert_nonnull (rel);
 	g_assert_cmpstr (xb_node_get_attr (rel, "version"), ==, "1.2.3");
@@ -803,6 +829,9 @@ fu_common_store_cab_folder_func (void)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbSilo) silo = NULL;
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	g_autoptr(XbQuery) query = NULL;
+#endif
 
 	/* create silo */
 	blob = _build_cab (GCAB_COMPRESSION_NONE,
@@ -823,7 +852,17 @@ fu_common_store_cab_folder_func (void)
 	component = xb_silo_query_first (silo, "components/component/id[text()='com.acme.example.firmware']/..", &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (component);
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	query = xb_query_new_full (xb_node_get_silo (component),
+				   "releases/release",
+				   XB_QUERY_FLAG_FORCE_NODE_CACHE,
+				   &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (query);
+	rel = xb_node_query_first_full (component, query, &error);
+#else
 	rel = xb_node_query_first (component, "releases/release", &error);
+#endif
 	g_assert_no_error (error);
 	g_assert_nonnull (rel);
 	g_assert_cmpstr (xb_node_get_attr (rel, "version"), ==, "1.2.3");

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2136,6 +2136,9 @@ fu_engine_install (FuEngine *self,
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(XbNode) rel_newest = NULL;
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	g_autoptr(XbQuery) query = NULL;
+#endif
 
 	g_return_val_if_fail (FU_IS_ENGINE (self), FALSE);
 	g_return_val_if_fail (XB_IS_NODE (component), FALSE);
@@ -2169,7 +2172,17 @@ fu_engine_install (FuEngine *self,
 	}
 
 	/* get the newest version */
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+	query = xb_query_new_full (xb_node_get_silo (component),
+				   "releases/release",
+				   XB_QUERY_FLAG_FORCE_NODE_CACHE,
+				   error);
+	if (query == NULL)
+		return FALSE;
+	rel_newest = xb_node_query_first_full (component, query, &error_local);
+#else
 	rel_newest = xb_node_query_first (component, "releases/release", &error_local);
+#endif
 	if (rel_newest == NULL) {
 		g_set_error (error,
 			     FWUPD_ERROR,
@@ -2207,7 +2220,11 @@ fu_engine_install (FuEngine *self,
 	/* install each intermediate release, or install only the newest version */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_INSTALL_ALL_RELEASES)) {
 		g_autoptr(GPtrArray) rels = NULL;
+#if LIBXMLB_CHECK_VERSION(0,2,0)
+		rels = xb_node_query_full (component, query, &error_local);
+#else
 		rels = xb_node_query (component, "releases/release", 0, &error_local);
+#endif
 		if (rels == NULL) {
 			g_set_error (error,
 				     FWUPD_ERROR,


### PR DESCRIPTION
Newer versions of libxmlb do not auto-cache XbNodes, and we have to opt-into
this behaviour for the _set_data() and _get_data() to work.

Although this is a behaviour change which also increases complexity, it lowers
our RSS usage by 200kB which is about a quarter of the total RSS used...
