### PR TITLE
trivial: modem-manager: chomp vendor string

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -251,7 +251,7 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 		if (!g_file_get_contents (path, &value, NULL, &error_local)) {
 			g_warning ("failed to set vendor ID: %s", error_local->message);
 		} else {
-			g_autofree gchar *vendor_id = g_strdup_printf ("USB:0x%s", value);
+			g_autofree gchar *vendor_id = g_strdup_printf ("USB:0x%s", g_strchomp (value));
 			fu_device_set_vendor_id (device, vendor_id);
 		}
 	}


### PR DESCRIPTION
Reading the sysfs file seemed to have also eaten the `\n` as mentioned
on a bug.

```
├DW5821e Snapdragon X20 LTE:
│     Device ID:           fa707b9af86ff44bc17316b6c3e5ea82aab3ce86
│     Summary:             Mobile broadband device
│     Current version:     T77W968.F1.0.0.4.2.GC.010
│     Vendor:              Dell Inc. (USB:0x413c
│     )
│     GUIDs:               64da2d58-8d1b-5e5b-b793-f88ba5a25a8f
│                          761d6124-0002-5185-b767-9adf67bf1a5e
│                          795e079d-093b-5503-aa59-35b832480e95
│     Device Flags:        • Updatable
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
