### PR TITLE
trivial: thunderbolt: don't set update error for missing nvmem

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -316,7 +316,6 @@ fu_thunderbolt_device_setup (FuDevice *device, GError **error)
 			fu_device_add_flag (device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 		} else {
 			device_id = g_strdup ("TBT-fixed");
-			fu_device_set_update_error (device, "Missing non-active nvmem");
 		}
 		fu_device_add_instance_id (device, device_id);
 		if (domain_id != NULL)


### PR DESCRIPTION
Trying to explain why ICL thunderbolt isn't updatable doesn't help
people.  It just causes fwupdmgr and fwupdtool to show the device
front and center with a confusing message.

Instead don't populate the message and by the default device filter
it will be hidden.

See #2212 for background.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
