### PR TITLE
Drop the automatic /usr/bin/python3 rpmbuild dependency

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -6,6 +6,10 @@
 %global systemd_version 231
 %global json_glib_version 1.1.1
 
+# although we ship a few tiny python files these are utilities that 99.99%
+# of users do not need -- use this to avoid dragging python onto CoreOS
+%global __requires_exclude ^%{python3}$
+
 %define alphatag                #ALPHATAG#
 
 %global enable_ci 0


### PR DESCRIPTION
We ship 4 *tiny* python scripts that are useful for ODMs and other people
working with low level firmware blobs.

These helper utilities do not warrant dragging Python onto the CoreOS image.
