### PR TITLE
Do not show a critical warning if the user-cache is not set

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -840,7 +840,9 @@ fu_util_download_if_required (FuUtilPrivate *priv, const gchar *perhapsfn, GErro
 		return g_strdup (perhapsfn);
 
 	/* download the firmware to a cachedir */
-	filename = fu_util_get_user_cache_path (perhapsfn);
+	filename = fu_util_get_user_cache_path (perhapsfn, error);
+	if (filename == NULL)
+		return NULL;
 	if (!fu_common_mkdir_parent (filename, error))
 		return NULL;
 	if (!fu_util_download_out_of_process (perhapsfn, filename, error))
@@ -1852,7 +1854,9 @@ fu_util_refresh_remote (FuUtilPrivate *priv, FwupdRemote *remote, GError **error
 	g_autoptr(GBytes) bytes_sig = NULL;
 
 	/* payload */
-	fn_raw = fu_util_get_user_cache_path (fwupd_remote_get_metadata_uri (remote));
+	fn_raw = fu_util_get_user_cache_path (fwupd_remote_get_metadata_uri (remote), error);
+	if (fn_raw == NULL)
+		return FALSE;
 	if (!fu_common_mkdir_parent (fn_raw, error))
 		return FALSE;
 	if (!fu_util_download_out_of_process (fwupd_remote_get_metadata_uri (remote),
@@ -1863,7 +1867,9 @@ fu_util_refresh_remote (FuUtilPrivate *priv, FwupdRemote *remote, GError **error
 		return FALSE;
 
 	/* signature */
-	fn_sig = fu_util_get_user_cache_path (fwupd_remote_get_metadata_uri_sig (remote));
+	fn_sig = fu_util_get_user_cache_path (fwupd_remote_get_metadata_uri_sig (remote), error);
+	if (fn_sig == NULL)
+		return FALSE;
 	if (!fu_util_download_out_of_process (fwupd_remote_get_metadata_uri_sig (remote),
 					      fn_sig, error))
 		return FALSE;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -248,7 +248,7 @@ fu_util_is_interesting_device (FwupdDevice *dev)
 }
 
 gchar *
-fu_util_get_user_cache_path (const gchar *fn)
+fu_util_get_user_cache_path (const gchar *fn, GError **error)
 {
 	const gchar *root = g_get_user_cache_dir ();
 	g_autofree gchar *basename = g_path_get_basename (fn);
@@ -257,6 +257,15 @@ fu_util_get_user_cache_path (const gchar *fn)
 	/* if run from a systemd unit, use the cache directory set there */
 	if (g_getenv ("CACHE_DIRECTORY") != NULL)
 		root = g_getenv ("CACHE_DIRECTORY");
+
+	/* does exist */
+	if (root == NULL) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_NOT_FOUND,
+				     "user cache location not found");
+		return NULL;
+	}
 
 	/* return the legacy path if it exists rather than renaming it to
 	 * prevent problems when using old and new versions of fwupd */

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -31,7 +31,8 @@ gboolean	 fu_util_prompt_for_boolean	(gboolean	 def);
 
 void		 fu_util_print_tree		(GNode *n,	gpointer data);
 gboolean	 fu_util_is_interesting_device	(FwupdDevice	*dev);
-gchar		*fu_util_get_user_cache_path	(const gchar	*fn);
+gchar		*fu_util_get_user_cache_path	(const gchar	*fn,
+						 GError		**error);
 SoupSession	*fu_util_setup_networking	(GError		**error);
 gchar		*fu_util_get_versions		(void);
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -573,7 +573,9 @@ fu_util_download_if_required (FuUtilPrivate *priv, const gchar *perhapsfn, GErro
 		return g_strdup (perhapsfn);
 
 	/* download the firmware to a cachedir */
-	filename = fu_util_get_user_cache_path (perhapsfn);
+	filename = fu_util_get_user_cache_path (perhapsfn, error);
+	if (filename == NULL)
+		return NULL;
 	if (!fu_common_mkdir_parent (filename, error))
 		return NULL;
 	if (!fu_util_download_file (priv, uri, filename, NULL, error))
@@ -1188,7 +1190,9 @@ fu_util_download_metadata_for_remote (FuUtilPrivate *priv,
 	/* download the signature */
 	basename_asc = g_path_get_basename (fwupd_remote_get_filename_cache_sig (remote));
 	basename_id_asc = g_strdup_printf ("%s-%s", fwupd_remote_get_id (remote), basename_asc);
-	filename_asc = fu_util_get_user_cache_path (basename_id_asc);
+	filename_asc = fu_util_get_user_cache_path (basename_id_asc, error);
+	if (filename_asc == NULL)
+		return FALSE;
 	if (!fu_common_mkdir_parent (filename_asc, error))
 		return FALSE;
 	uri_sig = soup_uri_new (fwupd_remote_get_metadata_uri_sig (remote));
@@ -1202,7 +1206,9 @@ fu_util_download_metadata_for_remote (FuUtilPrivate *priv,
 	/* download the metadata */
 	basename = g_path_get_basename (fwupd_remote_get_filename_cache (remote));
 	basename_id = g_strdup_printf ("%s-%s", fwupd_remote_get_id (remote), basename);
-	filename = fu_util_get_user_cache_path (basename_id);
+	filename = fu_util_get_user_cache_path (basename_id, error);
+	if (filename == NULL)
+		return FALSE;
 	uri = soup_uri_new (fwupd_remote_get_metadata_uri (remote));
 	if (!fu_util_download_file (priv, uri, filename, NULL, error))
 		return FALSE;
@@ -1733,7 +1739,9 @@ fu_util_update_device_with_release (FuUtilPrivate *priv,
 	g_print ("Downloading %s for %s...\n",
 		 fwupd_release_get_version (rel),
 		 fwupd_device_get_name (dev));
-	fn = fu_util_get_user_cache_path (uri_str);
+	fn = fu_util_get_user_cache_path (uri_str, error);
+	if (fn == NULL)
+		return FALSE;
 	if (!fu_common_mkdir_parent (fn, error))
 		return FALSE;
 	checksums = fwupd_release_get_checksums (rel);


### PR DESCRIPTION
Fixes half of https://github.com/fwupd/fwupd/issues/2223
