### PR TITLE
Support LVFS::UpdateImage in GUI clients

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -135,6 +135,9 @@ void		 fwupd_device_set_update_error		(FwupdDevice	*device,
 const gchar	*fwupd_device_get_update_message	(FwupdDevice	*device);
 void		 fwupd_device_set_update_message	(FwupdDevice	*device,
 							 const gchar	*update_message);
+const gchar	*fwupd_device_get_update_image		(FwupdDevice	*device);
+void		 fwupd_device_set_update_image		(FwupdDevice	*device,
+							 const gchar	*update_image);
 FwupdStatus	 fwupd_device_get_status		(FwupdDevice	*self);
 void		 fwupd_device_set_status		(FwupdDevice	*self,
 							 FwupdStatus	 status);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -47,6 +47,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_SUMMARY		"Summary"	/* s */
 #define FWUPD_RESULT_KEY_TRUST_FLAGS		"TrustFlags"	/* t */
 #define FWUPD_RESULT_KEY_UPDATE_MESSAGE		"UpdateMessage"	/* s */
+#define FWUPD_RESULT_KEY_UPDATE_IMAGE		"UpdateImage"	/* s */
 #define FWUPD_RESULT_KEY_UPDATE_ERROR		"UpdateError"	/* s */
 #define FWUPD_RESULT_KEY_UPDATE_STATE		"UpdateState"	/* u */
 #define FWUPD_RESULT_KEY_URI			"Uri"		/* s */

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -56,6 +56,7 @@ typedef struct {
 	FwupdReleaseFlags		 flags;
 	FwupdReleaseUrgency		 urgency;
 	gchar				*update_message;
+	gchar				*update_image;
 } FwupdReleasePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (FwupdRelease, fwupd_release, G_TYPE_OBJECT)
@@ -207,6 +208,42 @@ fwupd_release_set_update_message (FwupdRelease *release, const gchar *update_mes
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
 	g_free (priv->update_message);
 	priv->update_message = g_strdup (update_message);
+}
+
+/**
+ * fwupd_release_get_update_image:
+ * @release: A #FwupdRelease
+ *
+ * Gets the update image.
+ *
+ * Returns: the update image URL, or %NULL if unset
+ *
+ * Since: 1.4.5
+ **/
+const gchar *
+fwupd_release_get_update_image (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->update_image;
+}
+
+/**
+ * fwupd_release_set_update_image:
+ * @release: A #FwupdRelease
+ * @update_image: the update image URL
+ *
+ * Sets the update image.
+ *
+ * Since: 1.4.5
+ **/
+void
+fwupd_release_set_update_image (FwupdRelease *release, const gchar *update_image)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_free (priv->update_image);
+	priv->update_image = g_strdup (update_image);
 }
 
 /**
@@ -1545,6 +1582,10 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 		fwupd_release_set_update_message (release, g_variant_get_string (value, NULL));
 		return;
 	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_UPDATE_IMAGE) == 0) {
+		fwupd_release_set_update_image (release, g_variant_get_string (value, NULL));
+		return;
+	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_METADATA) == 0) {
 		g_hash_table_unref (priv->metadata);
 		priv->metadata = _variant_to_hash_kv (value);
@@ -1700,6 +1741,7 @@ fwupd_release_to_json (FwupdRelease *release, JsonBuilder *builder)
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_DETACH_CAPTION, priv->detach_caption);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_DETACH_IMAGE, priv->detach_image);
 	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
+	fwupd_release_json_add_string (builder, FWUPD_RESULT_KEY_UPDATE_IMAGE, priv->update_image);
 
 	/* metadata */
 	keys = g_hash_table_get_keys (priv->metadata);
@@ -1768,6 +1810,8 @@ fwupd_release_to_string (FwupdRelease *release)
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETACH_IMAGE, priv->detach_image);
 	if (priv->update_message != NULL)
 		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
+	if (priv->update_message != NULL)
+		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_UPDATE_IMAGE, priv->update_image);
 	/* metadata */
 	keys = g_hash_table_get_keys (priv->metadata);
 	for (GList *l = keys; l != NULL; l = l->next) {
@@ -1820,6 +1864,7 @@ fwupd_release_finalize (GObject *object)
 	g_free (priv->version);
 	g_free (priv->remote_id);
 	g_free (priv->update_message);
+	g_free (priv->update_image);
 	g_ptr_array_unref (priv->categories);
 	g_ptr_array_unref (priv->issues);
 	g_ptr_array_unref (priv->checksums);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -134,6 +134,9 @@ void		 fwupd_release_set_install_duration	(FwupdRelease	*release,
 const gchar	*fwupd_release_get_update_message	(FwupdRelease	*release);
 void		 fwupd_release_set_update_message	(FwupdRelease	*release,
 							 const gchar	*update_message);
+const gchar	*fwupd_release_get_update_image		(FwupdRelease	*release);
+void		 fwupd_release_set_update_image		(FwupdRelease	*release,
+							 const gchar	*update_image);
 
 FwupdRelease	*fwupd_release_from_variant		(GVariant	*value);
 GPtrArray	*fwupd_release_array_from_variant	(GVariant	*value);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -447,6 +447,15 @@ LIBFWUPD_1.4.1 {
   local: *;
 } LIBFWUPD_1.4.0;
 
+LIBFWUPD_1.4.5 {
+  global:
+    fwupd_device_get_update_image;
+    fwupd_device_set_update_image;
+    fwupd_release_get_update_image;
+    fwupd_release_set_update_image;
+  local: *;
+} LIBFWUPD_1.4.1;
+
 LIBFWUPD_1.5.0 {
   global:
     fwupd_client_get_host_security_attrs;
@@ -484,4 +493,4 @@ LIBFWUPD_1.5.0 {
     fwupd_security_attr_to_string;
     fwupd_security_attr_to_variant;
   local: *;
-} LIBFWUPD_1.4.1;
+} LIBFWUPD_1.4.5;

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1009,6 +1009,10 @@ fu_device_set_quirk_kv (FuDevice *self,
 		fu_device_set_update_message (self, value);
 		return TRUE;
 	}
+	if (g_strcmp0 (key, FU_QUIRKS_UPDATE_IMAGE) == 0) {
+		fu_device_set_update_image (self, value);
+		return TRUE;
+	}
 	if (g_strcmp0 (key, FU_QUIRKS_ICON) == 0) {
 		fu_device_add_icon (self, value);
 		return TRUE;
@@ -3164,6 +3168,9 @@ fu_device_incorporate_from_component (FuDevice *self, XbNode *component)
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateMessage']", NULL);
 	if (tmp != NULL)
 		fwupd_device_set_update_message (FWUPD_DEVICE (self), tmp);
+	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateImage']", NULL);
+	if (tmp != NULL)
+		fwupd_device_set_update_image (FWUPD_DEVICE (self), tmp);
 }
 
 static void

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -125,6 +125,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_serial(d,v)		fwupd_device_set_serial(FWUPD_DEVICE(d),v)
 #define fu_device_set_summary(d,v)		fwupd_device_set_summary(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_message(d,v)	fwupd_device_set_update_message(FWUPD_DEVICE(d),v)
+#define fu_device_set_update_image(d,v)		fwupd_device_set_update_image(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_error(d,v)		fwupd_device_set_update_error(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_state(d,v)		fwupd_device_set_update_state(FWUPD_DEVICE(d),v)
 #define fu_device_set_vendor(d,v)		fwupd_device_set_vendor(FWUPD_DEVICE(d),v)

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -64,5 +64,6 @@ gboolean	 fu_quirks_lookup_by_id_iter		(FuQuirks	*self,
 #define	FU_QUIRKS_GTYPE				"GType"
 #define	FU_QUIRKS_PROTOCOL			"Protocol"
 #define	FU_QUIRKS_UPDATE_MESSAGE		"UpdateMessage"
+#define	FU_QUIRKS_UPDATE_IMAGE			"UpdateImage"
 #define	FU_QUIRKS_PRIORITY			"Priority"
 #define	FU_QUIRKS_REMOVE_DELAY			"RemoveDelay"

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -454,6 +454,9 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateMessage']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_update_message (rel, tmp);
+	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateImage']", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_update_image (rel, tmp);
 	return TRUE;
 }
 
@@ -4112,6 +4115,7 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 		XbNode *release = g_ptr_array_index (releases_tmp, i);
 		const gchar *remote_id;
 		const gchar *update_message;
+		const gchar *update_image;
 		gint vercmp;
 		GPtrArray *checksums;
 		g_autoptr(FwupdRelease) rel = fwupd_release_new ();
@@ -4172,7 +4176,12 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 		update_message = fwupd_release_get_update_message (rel);
 		if (fwupd_device_get_update_message (FWUPD_DEVICE (device)) == NULL &&
 		    update_message != NULL) {
-			    fwupd_device_set_update_message (FWUPD_DEVICE (device), update_message);
+			fwupd_device_set_update_message (FWUPD_DEVICE (device), update_message);
+		}
+		update_image = fwupd_release_get_update_image (rel);
+		if (fwupd_device_get_update_image (FWUPD_DEVICE (device)) == NULL &&
+		    update_image != NULL) {
+			fwupd_device_set_update_image (FWUPD_DEVICE (device), update_image);
 		}
 		/* success */
 		g_ptr_array_add (releases, g_steal_pointer (&rel));


### PR DESCRIPTION
The idea here is that we can show the user both a string and an optional
line-art image when the update has completed. The line art is often more well
understood for non-English speakers.
