### PR TITLE
Remove potentially problematic language

### DIFF
--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -53,7 +53,7 @@ mkdir -p dist
 cp $HOME/rpmbuild/RPMS/*/*.rpm dist
 
 if [ "$CI" = "true" ]; then
-	sed "s,^BlacklistPlugins=test;invalid,BlacklistPlugins=," -i /etc/fwupd/daemon.conf
+	sed "s,^DisabledPlugins=test;invalid,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 
 	# set up enough PolicyKit and D-Bus to run the daemon
 	mkdir -p /run/dbus

--- a/contrib/debian/fwupd-tests.postinst
+++ b/contrib/debian/fwupd-tests.postinst
@@ -7,7 +7,7 @@ set -e
 if [ "$1" = configure ] && [ -z "$2" ]; then
 	if [ -f /etc/fwupd/daemon.conf ]; then
 		if [ "$CI" = "true" ]; then
-			sed "s,^BlacklistPlugins=test;invalid,BlacklistPlugins=," -i /etc/fwupd/daemon.conf
+			sed "s,^DisabledPlugins=test;invalid,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 		else
 			echo "To enable test suite, modify /etc/fwupd/daemon.conf"
 		fi

--- a/contrib/debian/fwupd-tests.postrm
+++ b/contrib/debian/fwupd-tests.postrm
@@ -6,7 +6,7 @@ set -e
 if [ "$1" = remove -o "$1" = purge ]; then
 	if [ -f /etc/fwupd/daemon.conf ]; then
 		if [ "$CI" = "true" ]; then
-			sed "s,^BlacklistPlugins=,BlacklistPlugins=test;invalid," -i /etc/fwupd/daemon.conf
+			sed "s,^DisabledPlugins=,DisabledPlugins=test;invalid," -i /etc/fwupd/daemon.conf
 		else
 			echo "To disable test suite, modify /etc/fwupd/daemon.conf"
 		fi

--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
-sed "s,^BlacklistPlugins=.*,BlacklistPlugins=," -i /etc/fwupd/daemon.conf
+sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 sed "s,^VerboseDomains=.*,VerboseDomains=*,"  -i /etc/fwupd/daemon.conf
 gnome-desktop-testing-runner fwupd

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -38,7 +38,7 @@ _fwupdtool_opts=(
 	'--allow-older'
 	'--force'
 	'--show-all-devices'
-	'--plugin-whitelist'
+	'--plugin-enable'
 	'--prepare'
 	'--cleanup'
 	'--filter'
@@ -82,7 +82,7 @@ _fwupdtool()
 	command=${COMP_WORDS[1]}
 
 	case $prev in
-	--plugin-whitelist)
+	--plugin-enable)
 		_show_plugins
 		return 0
 		;;

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -1,12 +1,12 @@
 [fwupd]
 
-# Allow blacklisting specific devices by their GUID
+# Allow blocking specific devices by their GUID
 # Uses semicolons as delimiter
-BlacklistDevices=
+DisabledDevices=
 
-# Allow blacklisting specific plugins
+# Allow blocking specific plugins
 # Uses semicolons as delimiter
-BlacklistPlugins=test;invalid
+DisabledPlugins=test;invalid
 
 # Maximum archive size that can be loaded in Mb, with 0 for the default
 ArchiveSizeMax=0

--- a/data/installed-tests/README.md
+++ b/data/installed-tests/README.md
@@ -9,7 +9,7 @@ By default this test suite is disabled.
 Enabling
 =======
 To enable the test suite:
-1. Modify `/etc/fwupd/daemon.conf` to remove the `test` plugin from `BlacklistPlugins`
+1. Modify `/etc/fwupd/daemon.conf` to remove the `test` plugin from `DisabledPlugins`
    ```
    # sed "s,^Enabled=false,Enabled=true," -i /etc/fwupd/remotes.d/fwupd-tests.conf
    ```

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -802,7 +802,7 @@ fwupd_client_proxy_call_cb (GObject *source, GAsyncResult *res, gpointer user_da
 /**
  * fwupd_client_modify_config
  * @client: A #FwupdClient
- * @key: key, e.g. `BlacklistPlugins`
+ * @key: key, e.g. `DisabledPlugins`
  * @value: value, e.g. `*`
  * @cancellable: the #GCancellable, or %NULL
  * @error: the #GError, or %NULL

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -397,7 +397,7 @@ fu_csr_device_probe (FuUsbDevice *device, GError **error)
 {
 	FuCsrDevice *self = FU_CSR_DEVICE (device);
 
-	/* devices have to be whitelisted */
+	/* proxy the quirk delay */
 	if (fu_device_has_custom_flag (FU_DEVICE (device),
 				       FU_CSR_DEVICE_FLAG_REQUIRE_DELAY))
 		self->quirks = FU_CSR_DEVICE_QUIRK_REQUIRE_DELAY;

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -17,11 +17,11 @@
 #include "fu-plugin-vfuncs.h"
 #include "fu-hash.h"
 
-/* Whitelisted smbios class/select commands */
+/* allowed smbios class/select commands */
 #define CLASS_ADMIN_PROP	10
 #define SELECT_ADMIN_PROP	3
 
-/* whitelisted tokens */
+/* allowed tokens */
 #define CAPSULE_EN_TOKEN	0x0461
 #define CAPSULE_DIS_TOKEN	0x0462
 

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -93,7 +93,7 @@ struct da_structure {
 /**
  * Devices that should allow modeswitching
  */
-static guint16 tpm_switch_whitelist[] = {0x06F2, 0x06F3, 0x06DD, 0x06DE, 0x06DF,
+static guint16 tpm_switch_allowlist[] = {0x06F2, 0x06F3, 0x06DD, 0x06DE, 0x06DF,
 					 0x06DB, 0x06DC, 0x06BB, 0x06C6, 0x06BA,
 					 0x06B9, 0x05CA, 0x06C7, 0x06B7, 0x06E0,
 					 0x06E5, 0x06D9, 0x06DA, 0x06E4, 0x0704,
@@ -106,7 +106,7 @@ static guint16 tpm_switch_whitelist[] = {0x06F2, 0x06F3, 0x06DD, 0x06DE, 0x06DF,
 /**
   * Dell device types to run
   */
-static guint8 enclosure_whitelist [] = { 0x03, /* desktop */
+static guint8 enclosure_allowlist [] = { 0x03, /* desktop */
 					 0x04, /* low profile desktop */
 					 0x06, /* mini tower */
 					 0x07, /* tower */
@@ -180,8 +180,8 @@ fu_dell_supported (FuPlugin *plugin)
 	value = g_bytes_get_data (enclosure, &len);
 	if (len == 0)
 		return FALSE;
-	for (guint i = 0; i < G_N_ELEMENTS (enclosure_whitelist); i++) {
-		if (enclosure_whitelist[i] == value[0])
+	for (guint i = 0; i < G_N_ELEMENTS (enclosure_allowlist); i++) {
+		if (enclosure_allowlist[i] == value[0])
 			return TRUE;
 	}
 
@@ -693,8 +693,8 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	else if (system_id == 0)
 		return FALSE;
 
-	for (guint i = 0; i < G_N_ELEMENTS (tpm_switch_whitelist); i++) {
-		if (tpm_switch_whitelist[i] == system_id) {
+	for (guint i = 0; i < G_N_ELEMENTS (tpm_switch_allowlist); i++) {
+		if (tpm_switch_allowlist[i] == system_id) {
 			can_switch_modes = TRUE;
 		}
 	}

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -236,7 +236,7 @@ static gboolean
 fu_ebitdo_device_validate (FuEbitdoDevice *self, GError **error)
 {
 	const gchar *ven;
-	const gchar *whitelist[] = {
+	const gchar *allowlist[] = {
 		"8Bitdo",
 		"SFC30",
 		NULL };
@@ -245,7 +245,7 @@ fu_ebitdo_device_validate (FuEbitdoDevice *self, GError **error)
 	if (fu_usb_device_get_vid (FU_USB_DEVICE (self)) == 0x2dc8)
 		return TRUE;
 
-	/* verify the vendor prefix against a whitelist */
+	/* verify the vendor prefix against a allowlist */
 	ven = fu_device_get_vendor (FU_DEVICE (self));
 	if (ven == NULL) {
 		g_set_error (error,
@@ -254,14 +254,14 @@ fu_ebitdo_device_validate (FuEbitdoDevice *self, GError **error)
 			     "could not check vendor descriptor: ");
 		return FALSE;
 	}
-	for (guint i = 0; whitelist[i] != NULL; i++) {
-		if (g_str_has_prefix (ven, whitelist[i]))
+	for (guint i = 0; allowlist[i] != NULL; i++) {
+		if (g_str_has_prefix (ven, allowlist[i]))
 			return TRUE;
 	}
 	g_set_error (error,
 		     G_IO_ERROR,
 		     G_IO_ERROR_INVALID_DATA,
-		     "vendor '%s' did not match whitelist, "
+		     "vendor '%s' did not match allowlist, "
 		     "probably not a 8Bitdo device…", ven);
 	return FALSE;
 }

--- a/plugins/uefi-dbx/README.md
+++ b/plugins/uefi-dbx/README.md
@@ -4,5 +4,5 @@ UEFI dbx Support
 Introduction
 ------------
 
-This plugin checks if the UEFI dbx contains all the most recent blacklisted
+This plugin checks if the UEFI dbx contains all the most recent revoked
 checksums. The result will be stored in an security attribute for HSI.

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -27,8 +27,8 @@ struct _FuConfig
 {
 	GObject			 parent_instance;
 	GFileMonitor		*monitor;
-	GPtrArray		*blacklist_devices;	/* (element-type utf-8) */
-	GPtrArray		*blacklist_plugins;	/* (element-type utf-8) */
+	GPtrArray		*disabled_devices;	/* (element-type utf-8) */
+	GPtrArray		*disabled_plugins;	/* (element-type utf-8) */
 	GPtrArray		*approved_firmware;	/* (element-type utf-8) */
 	guint64			 archive_size_max;
 	guint			 idle_timeout;
@@ -64,30 +64,30 @@ fu_config_reload (FuConfig *self, GError **error)
 					G_KEY_FILE_NONE, error))
 		return FALSE;
 
-	/* get blacklisted devices */
-	g_ptr_array_set_size (self->blacklist_devices, 0);
+	/* get disabled devices */
+	g_ptr_array_set_size (self->disabled_devices, 0);
 	devices = g_key_file_get_string_list (keyfile,
 					      "fwupd",
-					      "BlacklistDevices",
+					      "DisabledDevices",
 					      NULL, /* length */
 					      NULL);
 	if (devices != NULL) {
 		for (guint i = 0; devices[i] != NULL; i++) {
-			g_ptr_array_add (self->blacklist_devices,
+			g_ptr_array_add (self->disabled_devices,
 					 g_strdup (devices[i]));
 		}
 	}
 
-	/* get blacklisted plugins */
-	g_ptr_array_set_size (self->blacklist_plugins, 0);
+	/* get disabled plugins */
+	g_ptr_array_set_size (self->disabled_plugins, 0);
 	plugins = g_key_file_get_string_list (keyfile,
 					      "fwupd",
-					      "BlacklistPlugins",
+					      "DisabledPlugins",
 					      NULL, /* length */
 					      NULL);
 	if (plugins != NULL) {
 		for (guint i = 0; plugins[i] != NULL; i++) {
-			g_ptr_array_add (self->blacklist_plugins,
+			g_ptr_array_add (self->disabled_plugins,
 					 g_strdup (plugins[i]));
 		}
 	}
@@ -221,10 +221,10 @@ fu_config_get_idle_timeout (FuConfig *self)
 }
 
 GPtrArray *
-fu_config_get_blacklist_devices (FuConfig *self)
+fu_config_get_disabled_devices (FuConfig *self)
 {
 	g_return_val_if_fail (FU_IS_CONFIG (self), NULL);
-	return self->blacklist_devices;
+	return self->disabled_devices;
 }
 
 guint64
@@ -235,10 +235,10 @@ fu_config_get_archive_size_max (FuConfig *self)
 }
 
 GPtrArray *
-fu_config_get_blacklist_plugins (FuConfig *self)
+fu_config_get_disabled_plugins (FuConfig *self)
 {
 	g_return_val_if_fail (FU_IS_CONFIG (self), NULL);
-	return self->blacklist_plugins;
+	return self->disabled_plugins;
 }
 
 GPtrArray *
@@ -279,8 +279,8 @@ static void
 fu_config_init (FuConfig *self)
 {
 	self->archive_size_max = 512 * 0x100000;
-	self->blacklist_devices = g_ptr_array_new_with_free_func (g_free);
-	self->blacklist_plugins = g_ptr_array_new_with_free_func (g_free);
+	self->disabled_devices = g_ptr_array_new_with_free_func (g_free);
+	self->disabled_plugins = g_ptr_array_new_with_free_func (g_free);
 	self->approved_firmware = g_ptr_array_new_with_free_func (g_free);
 }
 
@@ -291,8 +291,8 @@ fu_config_finalize (GObject *obj)
 
 	if (self->monitor != NULL)
 		g_object_unref (self->monitor);
-	g_ptr_array_unref (self->blacklist_devices);
-	g_ptr_array_unref (self->blacklist_plugins);
+	g_ptr_array_unref (self->disabled_devices);
+	g_ptr_array_unref (self->disabled_plugins);
 	g_ptr_array_unref (self->approved_firmware);
 	g_free (self->config_file);
 

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -23,8 +23,8 @@ gboolean	 fu_config_set_key_value		(FuConfig	*self,
 
 guint64		 fu_config_get_archive_size_max		(FuConfig	*self);
 guint		 fu_config_get_idle_timeout		(FuConfig	*self);
-GPtrArray	*fu_config_get_blacklist_devices	(FuConfig	*self);
-GPtrArray	*fu_config_get_blacklist_plugins	(FuConfig	*self);
+GPtrArray	*fu_config_get_disabled_devices		(FuConfig	*self);
+GPtrArray	*fu_config_get_disabled_plugins		(FuConfig	*self);
 GPtrArray	*fu_config_get_approved_firmware	(FuConfig	*self);
 gboolean	 fu_config_get_update_motd		(FuConfig	*self);
 gboolean	 fu_config_get_enumerate_all_devices	(FuConfig	*self);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2047,9 +2047,9 @@ main (int argc, char *argv[])
 		{ "show-all-devices", '\0', 0, G_OPTION_ARG_NONE, &priv->show_all_devices,
 			/* TRANSLATORS: command line option */
 			_("Show devices that are not updatable"), NULL },
-		{ "plugin-whitelist", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &plugin_glob,
+		{ "plugin-enable", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &plugin_glob,
 			/* TRANSLATORS: command line option */
-			_("Manually whitelist specific plugins"), NULL },
+			_("Manually enable specific plugins"), NULL },
 		{ "prepare", '\0', 0, G_OPTION_ARG_NONE, &priv->prepare_blob,
 			/* TRANSLATORS: command line option */
 			_("Run the plugin composite prepare routine when using install-blob"), NULL },
@@ -2355,7 +2355,7 @@ main (int argc, char *argv[])
 		return EXIT_SUCCESS;
 	}
 
-	/* any plugin whitelist specified */
+	/* any plugin allowlist specified */
 	for (guint i = 0; plugin_glob != NULL && plugin_glob[i] != NULL; i++)
 		fu_engine_add_plugin_filter (priv->engine, plugin_glob[i]);
 

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -580,7 +580,7 @@
         <doc:doc>
           <doc:summary>
             <doc:para>
-              The key, e.g. 'BlacklistPlugins'.
+              The key, e.g. 'DisabledPlugins'.
             </doc:para>
           </doc:summary>
         </doc:doc>


### PR DESCRIPTION
Red Hat wants to drive an initiative in correcting problematic and potentially
divisive language in open source projects. These naming conventions and
descriptive phrases are hurtful and offensive to many of our colleagues across
the open source universe.
