### PR TITLE
ccgx: add extra 45% removal time for worst case

### DIFF
--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -1,4 +1,4 @@
-# Lenovo Gen2 Dock
+# Lenovo ThinkPad USB-C Dock Gen2
 [DeviceInstanceId=USB\VID_17EF&PID_A38F]
 Plugin = ccgx
 GType = FuCcgxHidDevice
@@ -23,7 +23,7 @@ Flags = is-bootloader
 Summary = CCGx Power Delivery Device
 CounterpartGuid = USB\VID_04B4&PID_521A&SID_1F00&APP_6D64&MODE_FW1
 
-# Lenovo Hybrid Dock
+# Lenovo ThinkPad USB-C Dock Hybrid
 [DeviceInstanceId=USB\VID_17EF&PID_A354]
 Plugin = ccgx
 GType = FuCcgxHidDevice
@@ -51,7 +51,7 @@ Summary = CCGx Power Delivery Device (Symmetric FW1)
 [DeviceInstanceId=USB\VID_04B4&PID_5218&SID_1F00&APP_6432&MODE_FW2]
 Summary = CCGx Power Delivery Device (Symmetric FW2)
 
-# HP Adicora Dock A Type
+# HP USB-C Dock G5
 [DeviceInstanceId=USB\VID_03F0&PID_046B]
 Plugin = ccgx
 GType = FuCcgxDmcDevice
@@ -59,10 +59,10 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_0363
 Name = HP USB-C Dock G5
 ImageKind = dmc-composite
-InstallDuration = 190
-RemoveDelay = 150000
+InstallDuration = 233
+RemoveDelay = 203000
 
-# HP Adicora Dock D Type
+# HP USB-C/A Universal Dock G2
 [DeviceInstanceId=USB\VID_03F0&PID_0A6B]
 Plugin = ccgx
 GType = FuCcgxDmcDevice
@@ -70,5 +70,5 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_096B
 Name = HP USB-C/A Universal Dock G2
 ImageKind = dmc-composite
-InstallDuration = 110
-RemoveDelay = 85000
+InstallDuration = 125
+RemoveDelay = 107000


### PR DESCRIPTION
Type of pull request:
- [ ] Code fix
    Add 45% extra removal time for worst case
   1. G5 Dock
        Removal time = 203 sec = 140 + 140*0.45 (Actual time is 140 s)
        Total install time = 233 sec = 30 (FW Writing) + 203 sec (removal time)
   2. G2 Dock
        Removal time  = 107 sec = 74 + 74*0.45  (Actual time is 74 s)
        Total install time = 125 sec = 18 (FW Writing) + 107 sec (removal time)
  