### PR TITLE
Cache the FuSecurityAttrs in the daemon

### DIFF
--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -108,6 +108,21 @@ fu_security_attrs_get_all (FuSecurityAttrs *self)
 }
 
 /**
+ * fu_security_attrs_remove_all:
+ * @self: A #FuSecurityAttrs
+ *
+ * Removes all the attributes in the object.
+ *
+ * Since: 1.5.0
+ **/
+void
+fu_security_attrs_remove_all (FuSecurityAttrs *self)
+{
+	g_return_if_fail (FU_IS_SECURITY_ATTRS (self));
+	return g_ptr_array_set_size (self->attrs, 0);
+}
+
+/**
  * fu_security_attrs_calculate_hsi:
  * @self: A #FuSecurityAttrs
  * @flags: Flags to use while calcuating the HSI

--- a/libfwupdplugin/fu-security-attrs.h
+++ b/libfwupdplugin/fu-security-attrs.h
@@ -16,3 +16,4 @@ G_DECLARE_FINAL_TYPE (FuSecurityAttrs, fu_security_attrs, FU, SECURITY_ATTRS, GO
 
 void		 fu_security_attrs_append		(FuSecurityAttrs	*self,
 							 FwupdSecurityAttr	*attr);
+void		 fu_security_attrs_remove_all		(FuSecurityAttrs	*self);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -609,6 +609,7 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_security_attrs_get_all;
     fu_security_attrs_get_type;
     fu_security_attrs_new;
+    fu_security_attrs_remove_all;
     fu_security_attrs_to_variant;
   local: *;
 } LIBFWUPDPLUGIN_1.4.5;


### PR DESCRIPTION
At the moment at startup we're calculating the attrs so we can export the HSI
string property on the D-Bus interface. Running `fwupdtool security` actually
gets all the security attributes at least twice!
