### PR TITLE
ccgx: modify installation time for hp g2 dock

### DIFF
--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -70,5 +70,5 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_096B
 Name = HP USB-C/A Universal Dock G2
 ImageKind = dmc-composite
-InstallDuration = 125
-RemoveDelay = 107000
+InstallDuration = 180
+RemoveDelay = 162000


### PR DESCRIPTION
Modify installation time for HP G2 Dock due to HP request.