### PR TITLE
vli: vl103 has backup feature

### DIFF
--- a/plugins/vli/vli-pd.quirk
+++ b/plugins/vli/vli-pd.quirk
@@ -18,6 +18,7 @@ DeviceKind = VL102
 [DeviceInstanceId=USB\VID_2109&PID_0103]
 Plugin = vli
 GType = FuVliPdDevice
+Flags = dual-image
 DeviceKind = VL103
 [DeviceInstanceId=USB\VID_2109&PID_0104]
 Plugin = vli
@@ -52,6 +53,7 @@ GType = FuVliPdDevice
 [DeviceInstanceId=USB\VID_17EF&PID_7212]
 Plugin = vli
 GType = FuVliPdDevice
+Flag = dual-image
 
 # Lenovo
 [DeviceInstanceId=USB\VID_17EF&PID_7215]


### PR DESCRIPTION
Type of pull request:
- [ x ] Feature

During some testing for USB-C to HDMI adapter, we found that one copy of the VL103 PD FW was getting installed (at 0x02XXXX only instead of both 0x02XXXX and 0x03XXXX). OEM wishes for two copies of the VL103 PD FW to be installed during update. Sorry.

