### PR TITLE
fu-util: Allow get-updates without download remotes

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1333,8 +1333,8 @@ fu_util_perhaps_refresh_remotes (FuUtilPrivate *priv, GError **error)
 		return TRUE;
 	}
 
-	if (!fu_util_check_oldest_remote (priv, &age_oldest, error))
-		return FALSE;
+	if (!fu_util_check_oldest_remote (priv, &age_oldest, NULL))
+		return TRUE;
 
 	/* metadata is new enough */
 	if (age_oldest < 60 * 60 * 24 * age_limit_days)


### PR DESCRIPTION
If a system is configured without any downloadable remotes (e.g. with
a remote pointing to a local directory) the call of

fwupdmgr get-updates

fails by outputting "No remotes enabled." even though the call
"get-remotes" clearly shows the configured remote.

I found the following commit:

commit 991c95697e7f98585ec46c8cadfc1f7525e7f244
Author: Mario Limonciello <mario.limonciello@dell.com>
Date:   Wed Jun 17 15:23:13 2020 -0500

    trivial: fu-util: correct an assertion when no remotes configured

introduced the problem. In the call chain:

fu_util_get_updates
-> fu_util_perhaps_refresh_remotes
-> fu_util_check_oldest_remote

the function fu_util_check_oldest_remote now returns FALSE if no
remote of kind FWUPD_REMOTE_KIND_DOWNLOAD is found.

The function fu_util_perhaps_refresh_remotes then returns FALSE
indicating failure even though without a downloadable remote the
concept of refreshing is not useful.

I think, we should return TRUE in this case, as no refresh is needed
and the operation can continue.

As the failure of fu_util_check_oldest_remote is ignored we also need
to pass NULL as error pointer here.

The use-case of this scenario without downloadable remote is by
distributing firmware updates through software updates where the
vendor directory with the capsule file is provided.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
