### PR TITLE
trivial: Export fwupd_client_ensure_networking()

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -278,7 +278,20 @@ fwupd_client_signal_cb (GDBusProxy *proxy,
 	g_debug ("Unknown signal name '%s' from %s", signal_name, sender_name);
 }
 
-static gboolean
+/**
+ * fwupd_client_ensure_networking:
+ * @client: A #FwupdClient
+ * @error: the #GError, or %NULL
+ *
+ * Sets up the client networking support ready for use. Most other download and
+ * upload methods call this automatically, and do you only need to call this if
+ * the session is being used outside the #FwupdClient.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.4.5
+ **/
+gboolean
 fwupd_client_ensure_networking (FwupdClient *client, GError **error)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -231,5 +231,7 @@ GBytes		*fwupd_client_upload_bytes		(FwupdClient	*client,
 							 FwupdClientUploadFlags flags,
 							 GCancellable	*cancellable,
 							 GError		**error);
+gboolean	 fwupd_client_ensure_networking		(FwupdClient	*client,
+							 GError		**error);
 
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -450,6 +450,7 @@ LIBFWUPD_1.4.1 {
 LIBFWUPD_1.4.5 {
   global:
     fwupd_client_download_bytes;
+    fwupd_client_ensure_networking;
     fwupd_client_install_bytes;
     fwupd_client_install_release;
     fwupd_client_refresh_remote;


### PR DESCRIPTION
This is required when the calling application needs the low-level soup-session
with the user agent set correctly rather than using the helper methods like
fwupd_client_download_bytes().

This is what GNOME Software needs to handle the GsApp progress completion.
