### PR TITLE
Wip/hughsie/runtime update protocol

### DIFF
--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -136,6 +136,7 @@ fu_nitrokey_device_init (FuNitrokeyDevice *device)
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_protocol (FU_DEVICE (device), "org.usb.dfu");
 	fu_device_retry_set_delay (FU_DEVICE (device), 100);
 }
 

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -98,6 +98,7 @@ fu_thelio_io_device_init (FuThelioIoDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
 }
 
 static void


### PR DESCRIPTION
This isn't 100% true, as these are the runtime devices only used for detaching.