### PR TITLE
Replace github.com/hughsie with github.com/fwupd for two files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 Type of pull request:
-- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
+- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
 - [ ] Code fix
 - [ ] Feature
 - [ ] Documentation

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -21,7 +21,7 @@ struct FuPluginData {
 	guint			 drm_changed_id;
 };
 
-/* see https://github.com/hughsie/fwupd/issues/1121 for more details */
+/* see https://github.com/fwupd/fwupd/issues/1121 for more details */
 static gboolean
 fu_synaptics_mst_check_amdgpu_safe (GError **error)
 {


### PR DESCRIPTION
Related to https://github.com/fwupd/fwupd/issues/2278

The fwupd repository used to be located in @hughsie 's personal silo but is now located within the organization @fwupd . Currently the links to the old repository get redirected to the new repository. This pull request replaces the links to the old repo with the ones to the new repo.