### PR TITLE
Refresh the handle to device before testing ANOTHER_WRITE_REQUIRED

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2487,6 +2487,10 @@ fu_engine_update_prepare (FuEngine *self,
 	device = fu_engine_get_device_by_id (self, device_id, error);
 	if (device == NULL)
 		return FALSE;
+
+	/* don't rely on a plugin clearing this */
+	fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+
 	str = fu_device_to_string (device);
 	g_debug ("performing prepare on %s", str);
 	if (!fu_engine_device_prepare (self, device, flags, error))
@@ -2792,6 +2796,8 @@ fu_engine_install_blob (FuEngine *self,
 	 * must return TRUE rather than an error */
 	device_id = g_strdup (fu_device_get_id (device));
 	do {
+		g_autoptr(FuDevice) device_tmp = NULL;
+
 		/* check for a loop */
 		if (++retries > 5) {
 			g_set_error_literal (error,
@@ -2800,9 +2806,6 @@ fu_engine_install_blob (FuEngine *self,
 					     "aborting device write loop, limit 5");
 			return FALSE;
 		}
-
-		/* don't rely on a plugin clearing this */
-		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 
 		/* signal to all the plugins the update is about to happen */
 		if (!fu_engine_update_prepare (self, flags, device_id, error))
@@ -2820,7 +2823,14 @@ fu_engine_install_blob (FuEngine *self,
 		if (!fu_engine_update_attach (self, device_id, error))
 			return FALSE;
 
-	} while (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED));
+		/* the device and plugin both may have changed */
+		device_tmp = fu_engine_get_device_by_id (self, device_id, error);
+		if (device_tmp == NULL)
+			return FALSE;
+		if (!fu_device_has_flag (device_tmp, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED))
+			break;
+
+	} while (TRUE);
 
 	/* get the new version number */
 	if (!fu_engine_update_reload (self, device_id, error))


### PR DESCRIPTION
fu_engine_install_blob may result in the device being reset during attach or
detach and needing to be replugged.
The device handle we're holding may be stale, but it is still used by the do
while loop itself for the ANOTHER_WRITE_REQUIRED test.

Similar to the other functions in the loop, let's get the device handle by id
in case that happened.

Original patch by Benson Leung <bleung@chromium.org>, many thanks.

Fixes https://github.com/fwupd/fwupd/issues/2297
