### PR TITLE
trivial: Don't skip methods on plain structs

### DIFF
--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -5,6 +5,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 RUN dnf -y update
+RUN dnf -y install https://kojipkgs.fedoraproject.org//packages/pesign/113/12.fc31/x86_64/pesign-113-12.fc31.x86_64.rpm
 RUN echo fubar > /etc/machine-id
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
 RUN dnf -y update glib2 glib2-devel --releasever=32

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -243,7 +243,10 @@ Data files for installed tests.
 %global efiarch aa64
 %endif
 %global fwup_efi_fn $RPM_BUILD_ROOT%{_libexecdir}/fwupd/efi/fwupd%{efiarch}.efi
-%pesign -s -i %{fwup_efi_fn} -o %{fwup_efi_fn}.signed
+%pesign -s -i %{fwup_efi_fn} -o %{fwup_efi_fn}.tmp
+%define __pesign_client_cert fwupd-signer
+%pesign -s -i %{fwup_efi_fn}.tmp -o %{fwup_efi_fn}.signed
+rm -vf %{fwup_efi_fn}.tmp
 %endif
 
 mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg

--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -56,9 +56,6 @@ class LdVersionScript:
 
         # choose the lowest version method for the _get_type symbol
         version_lowest = None
-        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
-            return
-        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # add all class methods
         for node in cls.findall(XMLNS + 'method'):
@@ -77,6 +74,10 @@ class LdVersionScript:
                     version_lowest
                 ):
                     version_lowest = version_tmp
+
+        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
+            return
+        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # finally add the get_type symbol
         if version_lowest:

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -277,6 +277,7 @@ LIBFWUPDPLUGIN_1.1.2 {
     fu_chunk_array_new;
     fu_chunk_array_new_from_bytes;
     fu_chunk_new;
+    fu_chunk_to_string;
     fu_common_find_program_in_path;
     fu_common_strstrip;
     fu_common_strtoull;


### PR DESCRIPTION
This resulted in losing g_usb_source_set_callback@LIBGUSB_0.1.0 which causes a
build failure when building gusb as a subproject.

Signed-off-by: Richard Hughes <richard@hughsie.com>
