### PR TITLE
uefi-dbx: Move the HSI failure from HSI:1 to a runtime issue

### DIFF
--- a/plugins/uefi-dbx/fu-plugin-uefi-dbx.c
+++ b/plugins/uefi-dbx/fu-plugin-uefi-dbx.c
@@ -58,7 +58,7 @@ fu_plugin_add_security_attrs (FuPlugin *plugin, FuSecurityAttrs *attrs)
 	/* create attr */
 	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_UEFI_DBX);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
-	fwupd_security_attr_set_level (attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append (attrs, attr);
 
 	/* no binary blob */


### PR DESCRIPTION
The dbx is controlled by the local admin now, and is something the user can fix
themselves.
