### PR TITLE
fwupd-remote: Download remote firmware on local remote

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -1469,9 +1469,11 @@ fwupd_client_install_release (FwupdClient *client,
 	g_autofree gchar *checksum_actual = NULL;
 	g_autofree gchar *uri_str = NULL;
 	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(SoupURI) uri = NULL;
 
 	/* work out what remote-specific URI fields this should use */
 	uri_tmp = fwupd_release_get_uri (release);
+	uri = soup_uri_new (uri_tmp);
 	remote_id = fwupd_release_get_remote_id (release);
 	if (remote_id != NULL) {
 		g_autoptr(FwupdRemote) remote = NULL;
@@ -1482,8 +1484,8 @@ fwupd_client_install_release (FwupdClient *client,
 		if (remote == NULL)
 			return FALSE;
 
-		/* local and directory remotes have the firmware already */
-		if (fwupd_remote_get_kind (remote) == FWUPD_REMOTE_KIND_LOCAL) {
+		/* local and directory remotes may have the firmware already */
+		if (fwupd_remote_get_kind (remote) == FWUPD_REMOTE_KIND_LOCAL && uri == NULL) {
 			const gchar *fn_cache = fwupd_remote_get_filename_cache (remote);
 			g_autofree gchar *path = g_path_get_dirname (fn_cache);
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1006,6 +1006,7 @@ fu_util_install_release (FuUtilPrivate *priv, FwupdRelease *rel, GError **error)
 	const gchar *remote_id;
 	const gchar *uri_tmp;
 	g_auto(GStrv) argv = NULL;
+	g_autoptr(SoupURI) uri = NULL;
 
 	uri_tmp = fwupd_release_get_uri (rel);
 	if (uri_tmp == NULL) {
@@ -1032,8 +1033,9 @@ fu_util_install_release (FuUtilPrivate *priv, FwupdRelease *rel, GError **error)
 		return FALSE;
 
 	argv = g_new0 (gchar *, 2);
-	/* local remotes have the firmware already */
-	if (fwupd_remote_get_kind (remote) == FWUPD_REMOTE_KIND_LOCAL) {
+	/* local remotes may have the firmware already */
+	uri = soup_uri_new (uri_tmp);
+	if (fwupd_remote_get_kind (remote) == FWUPD_REMOTE_KIND_LOCAL && uri == NULL) {
 		const gchar *fn_cache = fwupd_remote_get_filename_cache (remote);
 		g_autofree gchar *path = g_path_get_dirname (fn_cache);
 		argv[0] = g_build_filename (path, uri_tmp, NULL);


### PR DESCRIPTION
This adds a new kind of remote for local metadata (similar to LOCAL) and
remote firmware files (similar to DOWNLOAD). In this way the device can
control the available firmware without having to keep a local copy of
the firmware itself. This option is also useful to setup a remote mirror
with just firmware files without the complete LVFS website support.

Type of pull request: Feature
