### PR TITLE
uefi-dbx: Allow updating the dbx using the LVFS

### DIFF
--- a/plugins/uefi-dbx/README.md
+++ b/plugins/uefi-dbx/README.md
@@ -4,5 +4,38 @@ UEFI dbx Support
 Introduction
 ------------
 
-This plugin checks if the UEFI dbx contains all the most recent revoked
+Updating the UEFI revocation database prevents starting EFI binaries with known
+security issues, and is typically no longer done from a firmware update due to
+the risk of the machine being "bricked" if the bootloader is not updated first.
+
+This plugin also checks if the UEFI dbx contains all the most recent revoked
 checksums. The result will be stored in an security attribute for HSI.
+
+Firmware Format
+---------------
+
+The daemon will decompress the cabinet archive and extract a firmware blob in
+EFI_SIGNATURE_LIST format.
+
+See https://www.uefi.org/sites/default/files/resources/UEFI%20Spec%202_6.pdf
+for details.
+
+This plugin supports the following protocol ID:
+
+ * org.uefi.dbx
+
+GUID Generation
+---------------
+
+These devices use the GUID constructed of the uppercase SHA256 of the X509
+certificates found in the system KEK and optionally the EFI architecture. e.g.
+
+ * `UEFI\CRT_{sha256}`
+ * `UEFI\CRT_{sha256}&ARCH_{arch}`
+
+...where `arch` is typically one of `IA32`, `X64`, `ARM` or `AA64`
+
+Vendor ID Security
+------------------
+
+The vendor ID is hardcoded to `UEFI:Microsoft` for all devices.

--- a/plugins/uefi-dbx/fu-efi-signature-common.c
+++ b/plugins/uefi-dbx/fu-efi-signature-common.c
@@ -35,3 +35,25 @@ fu_efi_signature_list_array_inclusive (GPtrArray *outer, GPtrArray *inner)
 	}
 	return TRUE;
 }
+
+guint
+fu_efi_signature_list_array_version (GPtrArray *siglists)
+{
+	guint csum_cnt = 0;
+	const gchar *ignored_guids[] = {
+		FU_EFI_SIGNATURE_GUID_OVMF,
+		NULL };
+	for (guint j = 0; j < siglists->len; j++) {
+		FuEfiSignatureList *siglist = g_ptr_array_index (siglists, j);
+		GPtrArray *items = fu_efi_signature_list_get_all (siglist);
+		for (guint i = 0; i < items->len; i++) {
+			FuEfiSignature *sig = g_ptr_array_index (items, i);
+			if (fu_efi_signature_get_kind (sig) != FU_EFI_SIGNATURE_KIND_SHA256)
+				continue;
+			if (g_strv_contains (ignored_guids, fu_efi_signature_get_owner (sig)))
+				continue;
+			csum_cnt++;
+		}
+	}
+	return csum_cnt;
+}

--- a/plugins/uefi-dbx/fu-efi-signature-common.h
+++ b/plugins/uefi-dbx/fu-efi-signature-common.h
@@ -10,3 +10,4 @@
 
 gboolean	 fu_efi_signature_list_array_inclusive	(GPtrArray	*outer,
 							 GPtrArray	*inner);
+guint		 fu_efi_signature_list_array_version	(GPtrArray	*siglists);

--- a/plugins/uefi-dbx/fu-efi-signature.c
+++ b/plugins/uefi-dbx/fu-efi-signature.c
@@ -29,6 +29,18 @@ fu_efi_signature_kind_to_string (FuEfiSignatureKind kind)
 	return "unknown";
 }
 
+const gchar *
+fu_efi_signature_guid_to_string (const gchar *guid)
+{
+	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_ZERO) == 0)
+		return "zero";
+	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_MICROSOFT) == 0)
+		return "microsoft";
+	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_OVMF) == 0)
+		return "ovmf";
+	return guid;
+}
+
 FuEfiSignature *
 fu_efi_signature_new (FuEfiSignatureKind kind, const gchar *owner, GBytes *data)
 {

--- a/plugins/uefi-dbx/fu-efi-signature.h
+++ b/plugins/uefi-dbx/fu-efi-signature.h
@@ -18,7 +18,12 @@ typedef enum {
 	FU_EFI_SIGNATURE_KIND_LAST
 } FuEfiSignatureKind;
 
+#define FU_EFI_SIGNATURE_GUID_ZERO		"00000000-0000-0000-0000-000000000000"
+#define FU_EFI_SIGNATURE_GUID_MICROSOFT		"77fa9abd-0359-4d32-bd60-28f4e78f784b"
+#define FU_EFI_SIGNATURE_GUID_OVMF		"a0baa8a3-041d-48a8-bc87-c36d121b5e3d"
+
 const gchar	*fu_efi_signature_kind_to_string	(FuEfiSignatureKind kind);
+const gchar	*fu_efi_signature_guid_to_string	(const gchar	*guid);
 
 FuEfiSignature	*fu_efi_signature_new			(FuEfiSignatureKind kind,
 							 const gchar	*owner,

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-efivar.h"
+
+#include "fu-efi-signature-common.h"
+#include "fu-efi-signature-parser.h"
+#include "fu-uefi-dbx-device.h"
+
+struct _FuUefiDbxDevice {
+	FuDevice		 parent_instance;
+};
+
+G_DEFINE_TYPE (FuUefiDbxDevice, fu_uefi_dbx_device, FU_TYPE_DEVICE)
+
+static gboolean
+fu_uefi_dbx_device_write_firmware (FuDevice *device,
+				   FuFirmware *firmware,
+				   FwupdInstallFlags install_flags,
+				   GError **error)
+{
+	const guint8 *buf;
+	gsize bufsz = 0;
+	g_autoptr(GBytes) fw = NULL;
+
+	/* get default image */
+	fw = fu_firmware_get_image_default_bytes (firmware, error);
+	if (fw == NULL)
+		return FALSE;
+
+	/* write entire chunk to efivarfs */
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
+	buf = g_bytes_get_data (fw, &bufsz);
+	if (!fu_efivar_set_data (FU_EFIVAR_GUID_SECURITY_DATABASE,
+				 "dbx", buf, bufsz,
+				 FU_EFIVAR_ATTR_APPEND_WRITE |
+				 FU_EFIVAR_ATTR_TIME_BASED_AUTHENTICATED_WRITE_ACCESS |
+				 FU_EFIVAR_ATTR_RUNTIME_ACCESS |
+				 FU_EFIVAR_ATTR_BOOTSERVICE_ACCESS |
+				 FU_EFIVAR_ATTR_NON_VOLATILE,
+				 error)) {
+		return FALSE;
+	}
+
+	/* success! */
+	return TRUE;
+}
+
+static gboolean
+fu_uefi_dbx_device_set_version_number (FuDevice *device, GError **error)
+{
+	gsize bufsz = 0;
+	g_autofree gchar *version = NULL;
+	g_autofree guint8 *buf = NULL;
+	g_autoptr(GPtrArray) dbx = NULL;
+
+	/* use the number of checksums in the dbx as a version number, ignoring
+	 * some owners that do not make sense */
+	if (!fu_efivar_get_data (FU_EFIVAR_GUID_SECURITY_DATABASE, "dbx",
+				 &buf, &bufsz, NULL, error))
+		return FALSE;
+	dbx = fu_efi_signature_parser_new (buf, bufsz,
+					   FU_EFI_SIGNATURE_PARSER_FLAGS_NONE,
+					   error);
+	if (dbx == NULL)
+		return FALSE;
+	version = g_strdup_printf ("%u", fu_efi_signature_list_array_version (dbx));
+	fu_device_set_version (device, version);
+	fu_device_set_version_lowest (device, version);
+	return TRUE;
+}
+
+static gboolean
+fu_uefi_dbx_device_probe (FuDevice *device, GError **error)
+{
+	gsize bufsz = 0;
+	g_autofree gchar *arch_up = NULL;
+	g_autofree guint8 *buf = NULL;
+	g_autoptr(GPtrArray) kek = NULL;
+
+	/* use each of the certificates in the KEK to generate the GUIDs */
+	if (!fu_efivar_get_data (FU_EFIVAR_GUID_EFI_GLOBAL, "KEK",
+				 &buf, &bufsz, NULL, error))
+		return FALSE;
+	kek = fu_efi_signature_parser_new (buf, bufsz,
+					   FU_EFI_SIGNATURE_PARSER_FLAGS_NONE,
+					   error);
+	if (kek == NULL)
+		return FALSE;
+	arch_up = g_utf8_strup (EFI_MACHINE_TYPE_NAME, -1);
+	for (guint i = 0; i < kek->len; i++) {
+		FuEfiSignatureList *siglist = g_ptr_array_index (kek, i);
+		GPtrArray *sigs = fu_efi_signature_list_get_all (siglist);
+		for (guint j = 0; j < sigs->len; j++) {
+			FuEfiSignature *sig = g_ptr_array_index (sigs, j);
+			g_autofree gchar *checksum_up = NULL;
+			g_autofree gchar *devid1 = NULL;
+			g_autofree gchar *devid2 = NULL;
+
+			checksum_up = g_utf8_strup (fu_efi_signature_get_checksum (sig), -1);
+			devid1 = g_strdup_printf ("UEFI\\CRT_%s", checksum_up);
+			fu_device_add_instance_id (device, devid1);
+			devid2 = g_strdup_printf ("UEFI\\CRT_%s&ARCH_%s",
+						  checksum_up, arch_up);
+			fu_device_add_instance_id (device, devid2);
+		}
+	}
+	return fu_uefi_dbx_device_set_version_number (device, error);
+}
+
+static void
+fu_uefi_dbx_device_init (FuUefiDbxDevice *self)
+{
+	fu_device_set_physical_id (FU_DEVICE (self), "dbx");
+	fu_device_set_name (FU_DEVICE (self), "UEFI dbx");
+	fu_device_set_summary (FU_DEVICE (self), "UEFI Revocation Database");
+	fu_device_set_vendor_id (FU_DEVICE (self), "UEFI:Linux Foundation");
+	fu_device_set_protocol (FU_DEVICE (self), "org.uefi.dbx");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_NUMBER);
+	fu_device_set_install_duration (FU_DEVICE (self), 1);
+	fu_device_add_icon (FU_DEVICE (self), "computer");
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_parent_guid (FU_DEVICE (self), "main-system-firmware");
+	if (!fu_common_is_live_media ())
+		fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+}
+
+static void
+fu_uefi_dbx_device_class_init (FuUefiDbxDeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	klass_device->probe = fu_uefi_dbx_device_probe;
+	klass_device->write_firmware = fu_uefi_dbx_device_write_firmware;
+}
+
+FuUefiDbxDevice *
+fu_uefi_dbx_device_new (void)
+{
+	FuUefiDbxDevice *self;
+	self = g_object_new (FU_TYPE_UEFI_DBX_DEVICE, NULL);
+	return self;
+}

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-plugin.h"
+
+#define FU_TYPE_UEFI_DBX_DEVICE (fu_uefi_dbx_device_get_type ())
+G_DECLARE_FINAL_TYPE (FuUefiDbxDevice, fu_uefi_dbx_device, FU, UEFI_DBX_DEVICE, FuDevice)
+
+FuUefiDbxDevice	*fu_uefi_dbx_device_new			(void);

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -5,6 +5,7 @@ shared_module('fu_plugin_uefi_dbx',
   sources : [
     'fu-plugin-uefi-dbx.c',
     'fu-uefi-dbx-common.c',
+    'fu-uefi-dbx-device.c',
     'fu-efi-signature.c',
     'fu-efi-signature-common.c',
     'fu-efi-signature-list.c',


### PR DESCRIPTION
The GUID is built using the SHA256 of the certificates in the KEK.
