### PR TITLE
Don't run debian packaging when subproject is active

### DIFF
--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -23,6 +23,14 @@ sed s/quilt/native/ debian/source/format -i
 #generate control file
 ./contrib/ci/generate_debian.py
 
+#check if we have all deps available
+#if some are missing, we're going to use subproject instead and
+#packaging CI will fail
+if ! dpkg-checkbuilddeps; then
+	./contrib/ci/ubuntu.sh
+	exit 0
+fi
+
 #clone test firmware
 if [ "$CI_NETWORK" = "true" ]; then
 	./contrib/ci/get_test_firmware.sh

--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -9,6 +9,7 @@ if [ "$CI_NETWORK" = "true" ]; then
 fi
 
 #evaluate using Ubuntu's buildflags
+#evaluate using Debian/Ubuntu's buildflags
 eval "$(dpkg-buildflags --export=sh)"
 #filter out -Bsymbolic-functions
 export LDFLAGS=$(dpkg-buildflags --get LDFLAGS | sed "s/-Wl,-Bsymbolic-functions\s//")

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -56,9 +56,7 @@ override_dh_install:
 	if [ -d debian/tmp/usr/libexec/fwupd/efi/ ]; then \
 		dh_install -pfwupd usr/libexec/fwupd/efi ;\
 	fi
-	if [ -z "$$CI" ]; then \
-		dh_missing -a --fail-missing; \
-	fi
+	dh_missing -a --fail-missing
 
 	#this is placed in fwupd-tests
 	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-3/libfu_plugin_test.so


### PR DESCRIPTION
Cleaner fix for https://github.com/fwupd/fwupd/pull/2289
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
