### PR TITLE
dfu: Support download of large DFU firmware

### DIFF
--- a/plugins/dfu/dfu-target.c
+++ b/plugins/dfu/dfu-target.c
@@ -1106,7 +1106,7 @@ dfu_target_download_element_dfu (DfuTarget *target,
 {
 	DfuTargetPrivate *priv = GET_PRIVATE (target);
 	GBytes *bytes;
-	guint16 nr_chunks;
+	guint32 nr_chunks;
 	guint16 transfer_size = dfu_device_get_transfer_size (priv->device);
 
 	/* round up as we have to transfer incomplete blocks */
@@ -1121,7 +1121,7 @@ dfu_target_download_element_dfu (DfuTarget *target,
 		return FALSE;
 	}
 	dfu_target_set_action (target, FWUPD_STATUS_DEVICE_WRITE);
-	for (guint16 i = 0; i < nr_chunks + 1; i++) {
+	for (guint32 i = 0; i < nr_chunks + 1; i++) {
 		gsize length;
 		guint32 offset;
 		g_autoptr(GBytes) bytes_tmp = NULL;


### PR DESCRIPTION
The nr_chunks is defined as an unsigned short, the max value is
65536. Assume the transfer_size reported by device is 4096, the
maximum size of DFU firmware supported is 65536 * 4096 = 256MB.

To support larger DFU firmware, we can change the guint16 to
guint32.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
