### PR TITLE
build: fix systemd_root_prefix for systemd 246

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -378,7 +378,7 @@ if build_standalone and get_option('systemd')
   else
     systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir', define_variable: ['rootprefix', systemd_root_prefix])
     systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir', define_variable: ['rootprefix', systemd_root_prefix])
-    systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir', define_variable: ['rootprefix', systemd_root_prefix])
+    systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir', define_variable: [systemd.version().version_compare('>= 246') ? 'root_prefix' : 'rootprefix', systemd_root_prefix])
   endif
 endif
 


### PR DESCRIPTION
systemd 246 replaced the variable names (https://github.com/systemd/systemd/commit/4908de44b0a0409f84a7cdc5641b114d6ce8ba03).
The old ones are kept for backwards compatibility but some of them interpolate new variable names so redefining them breaks.
Curiously, only systemdshutdowndir is affected by that here.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
