### PR TITLE
dfu: Support polling the status from device in dfuManifest state

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -44,6 +44,7 @@
  * * `legacy-protocol`:		Use a legacy protocol version
  * * `detach-for-attach`:	Requires a DFU_REQUEST_DETACH to attach
  * * `absent-sector-size`:	In absence of sector size, assume byte
+ * * `manifest-poll`:		Requires polling via GetStatus in dfuManifest state
  *
  * Default value: `none`
  *

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -329,3 +329,43 @@ Flags = absent-sector-size
 Plugin = dfu
 DfuForceVersion = 011a
 DfuForceTimeout = 5000
+
+# Poly Studio
+[DeviceInstanceId=USB\VID_095D&PID_9217]
+Plugin = dfu
+Flags = manifest-poll
+[DeviceInstanceId=USB\VID_095D&PID_9218]
+Plugin = dfu
+Flags = manifest-poll
+
+# Poly Eagle Eye Cube
+[DeviceInstanceId=USB\VID_095D&PID_9212]
+Plugin = dfu
+Flags = manifest-poll
+[DeviceInstanceId=USB\VID_095D&PID_9213]
+Plugin = dfu
+Flags = manifest-poll
+
+# Poly P30
+[DeviceInstanceId=USB\VID_095D&PID_9290]
+Plugin = dfu
+Flags = manifest-poll
+[DeviceInstanceId=USB\VID_095D&PID_9291]
+Plugin = dfu
+Flags = manifest-poll
+
+# Poly ULCC
+[DeviceInstanceId=USB\VID_095D&PID_9160]
+Plugin = dfu
+Flags = manifest-poll
+[DeviceInstanceId=USB\VID_095D&PID_927B]
+Plugin = dfu
+Flags = manifest-poll
+
+# Poly Eagle Eye Mini
+[DeviceInstanceId=USB\VID_095D&PID_3001]
+Plugin = dfu
+Flags = manifest-poll
+[DeviceInstanceId=USB\VID_095D&PID_3002]
+Plugin = dfu
+Flags = manifest-poll


### PR DESCRIPTION
Some devices may accumulate the firmware image and perform the
entire reprogramming operation at one time. In this case, the
device enters dfuMANIFEST-SYNC or dfuMANIFEST state after
dfuDNLOAD-IDLE.

The fwupd shall be able to poll the status from the device via
DFU_GETSTATUS until the device completes the reprogramming or
reports an error.

For details, please refer to Section 7. Manifestation Phase and
A.1 Interface State Transition Diagram in the USB DFU protocol.
https://www.usb.org/sites/default/files/DFU_1.1.pdf

For not affecting the other DFU capable devices, introduce a quirk
"poll-in-manifest" to limit the logic.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
