### PR TITLE
dfu: Introduce a qurik to specify device removal delay

### DIFF
--- a/plugins/dfu/dfu-tool.c
+++ b/plugins/dfu/dfu-tool.c
@@ -278,7 +278,7 @@ dfu_device_wait_for_replug (DfuToolPrivate *priv, DfuDevice *device, guint timeo
 	/* watch the device disappear and re-appear */
 	usb_device2 = g_usb_context_wait_for_replug (usb_context,
 						     usb_device,
-						     FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE,
+						     timeout,
 						     error);
 	if (usb_device2 == NULL)
 		return FALSE;
@@ -918,10 +918,9 @@ dfu_tool_write (DfuToolPrivate *priv, gchar **values, GError **error)
 		if (!fu_device_detach (FU_DEVICE (device), error))
 			return FALSE;
 		if (!dfu_device_wait_for_replug (priv, device,
-						 FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE,
-						 error)) {
+						 fu_device_get_remove_delay (FU_DEVICE (device)),
+						 error))
 			return FALSE;
-		}
 	}
 
 	/* allow wildcards */
@@ -941,7 +940,7 @@ dfu_tool_write (DfuToolPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	if (dfu_device_has_attribute (device, DFU_DEVICE_ATTRIBUTE_MANIFEST_TOL)) {
-		if (!dfu_device_wait_for_replug (priv, device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE, error))
+		if (!dfu_device_wait_for_replug (priv, device, fu_device_get_remove_delay (FU_DEVICE (device)), error))
 			return FALSE;
 	}
 

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -334,38 +334,48 @@ DfuForceTimeout = 5000
 [DeviceInstanceId=USB\VID_095D&PID_9217]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 40000
 [DeviceInstanceId=USB\VID_095D&PID_9218]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 40000
 
 # Poly Eagle Eye Cube
 [DeviceInstanceId=USB\VID_095D&PID_9212]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 30000
 [DeviceInstanceId=USB\VID_095D&PID_9213]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 30000
 
 # Poly P30
 [DeviceInstanceId=USB\VID_095D&PID_9290]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 40000
 [DeviceInstanceId=USB\VID_095D&PID_9291]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 40000
 
 # Poly ULCC
 [DeviceInstanceId=USB\VID_095D&PID_9160]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 50000
 [DeviceInstanceId=USB\VID_095D&PID_927B]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 50000
 
 # Poly Eagle Eye Mini
 [DeviceInstanceId=USB\VID_095D&PID_3001]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 9000
 [DeviceInstanceId=USB\VID_095D&PID_3002]
 Plugin = dfu
 Flags = manifest-poll
+RemoveDelay = 9000


### PR DESCRIPTION
A new quirk "DfuRemovalDelay" is added. This allows us to specify
a device removal delay for re-enumeration. This is required if
it takes longer time than the default
(FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE) for the device being detached
to DFU or attached to normal mode.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
