### PR TITLE
dfu: Allow device to attach to normal without a bus reset

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -45,6 +45,7 @@
  * * `detach-for-attach`:	Requires a DFU_REQUEST_DETACH to attach
  * * `absent-sector-size`:	In absence of sector size, assume byte
  * * `manifest-poll`:		Requires polling via GetStatus in dfuManifest state
+ * * `no-bus-reset-attach`:	Do not require a bus reset to attach to normal
  *
  * Default value: `none`
  *
@@ -1365,7 +1366,10 @@ dfu_device_attach (FuDevice *device, GError **error)
 		return FALSE;
 
 	/* normal DFU mode just needs a bus reset */
-	if (!dfu_target_attach (target, error))
+	if (fu_device_has_custom_flag (device, "no-bus-reset-attach") &&
+	    dfu_device_has_attribute (self, DFU_DEVICE_ATTRIBUTE_WILL_DETACH))
+		g_debug ("Bus reset is not required. Device will reboot to normal");
+	else if (!dfu_target_attach (target, error))
 		return FALSE;
 
 	/* success */

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -333,12 +333,12 @@ DfuForceTimeout = 5000
 # Poly Studio
 [DeviceInstanceId=USB\VID_095D&PID_9217]
 Plugin = dfu
-Flags = manifest-poll
-RemoveDelay = 40000
+Flags = manifest-poll,no-bus-reset-attach
+RemoveDelay = 60000
 [DeviceInstanceId=USB\VID_095D&PID_9218]
 Plugin = dfu
-Flags = manifest-poll
-RemoveDelay = 40000
+Flags = manifest-poll,no-bus-reset-attach
+RemoveDelay = 60000
 
 # Poly Eagle Eye Cube
 [DeviceInstanceId=USB\VID_095D&PID_9212]
@@ -354,21 +354,21 @@ RemoveDelay = 30000
 [DeviceInstanceId=USB\VID_095D&PID_9290]
 Plugin = dfu
 Flags = manifest-poll
-RemoveDelay = 40000
+RemoveDelay = 60000
 [DeviceInstanceId=USB\VID_095D&PID_9291]
 Plugin = dfu
 Flags = manifest-poll
-RemoveDelay = 40000
+RemoveDelay = 60000
 
 # Poly ULCC
 [DeviceInstanceId=USB\VID_095D&PID_9160]
 Plugin = dfu
-Flags = manifest-poll
-RemoveDelay = 50000
+Flags = manifest-poll,no-bus-reset-attach
+RemoveDelay = 60000
 [DeviceInstanceId=USB\VID_095D&PID_927B]
 Plugin = dfu
-Flags = manifest-poll
-RemoveDelay = 50000
+Flags = manifest-poll,no-bus-reset-attach
+RemoveDelay = 60000
 
 # Poly Eagle Eye Mini
 [DeviceInstanceId=USB\VID_095D&PID_3001]


### PR DESCRIPTION
As described in DFU protocol (7. Manifestation Phase), after the
firmware reprogramming is done, if bitWillDetach = 1, it doesn't
require the host to issue a USB bus reset, but the device can
generate a detach-attach sequence itself to go back to normal.

Add a quirk flag "no-bus-reset-attach" to skip the bus reset in
dfu_device_attach(), and increase the "RemoveDelay" as well.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
