### PR TITLE
thunderbolt: Call fu_device_set_physical_id() during probe for retimer

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -222,6 +222,9 @@ fu_thunderbolt_device_probe (FuUdevDevice *device, GError **error)
 	/* retimer */
 	} else if (g_strcmp0 (tmp, "thunderbolt_retimer") == 0) {
 		self->device_type = FU_THUNDERBOLT_DEVICE_TYPE_RETIMER;
+		tmp = g_path_get_basename (fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device)));
+		if (tmp != NULL)
+			fu_device_set_physical_id (FU_DEVICE (device), tmp);
 	/* domain or unsupported */
 	} else {
 		g_set_error (error,


### PR DESCRIPTION
Error will show up if (priv->physical_id == NULL) on
fu_device_ensure_id(). This method is called after probe but before
setup on fu_device_open.

Call fu_device_set_physical_id() on fu_thunderbolt_device_probe()
for the retimer case.

Fixes https://github.com/fwupd/fwupd/issues/2371

Change-Id: I0e462fff5e8abf6073318f6424b6736afc8259b8

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ X ] Code fix
- [ ] Feature
- [ ] Documentation
