### PR TITLE
thunderbolt: ignore host controller in SW CM mode (Fixes: #2373)

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -444,7 +444,6 @@ fu_thunderbolt_device_setup (FuDevice *device, GError **error)
 	g_autoptr(GError) error_version = NULL;
 
 	self->devpath = g_strdup (fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device)));
-	fu_device_set_metadata (device, "sysfs-path", self->devpath);
 
 	/* try to read the version */
 	if (!fu_thunderbolt_device_get_version (self, &error_version)) {


### PR DESCRIPTION
nvm_version will not export in SW CM, there is no point in fwupd
displaying a device for it.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
