### PR TITLE
Allow simulating a composite update without applying firmware

### DIFF
--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -40,6 +40,7 @@ _fwupdtool_opts=(
 	'--allow-reinstall'
 	'--allow-older'
 	'--force'
+	'--simulate'
 	'--show-all-devices'
 	'--plugins'
 	'--prepare'

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -220,6 +220,7 @@ typedef enum {
  * @FWUPD_INSTALL_FLAG_ALLOW_OLDER:		Allow downgrading firmware
  * @FWUPD_INSTALL_FLAG_FORCE:			Force the update even if not a good idea
  * @FWUPD_INSTALL_FLAG_NO_HISTORY:		Do not write to the history database
+ * @FWUPD_INSTALL_FLAG_SIMULATE:		Do not write to the hardware, but do all other steps
  *
  * Flags to set when performing the firwmare update or install.
  **/
@@ -230,6 +231,7 @@ typedef enum {
 	FWUPD_INSTALL_FLAG_ALLOW_OLDER		= 1 << 2,	/* Since: 0.7.0 */
 	FWUPD_INSTALL_FLAG_FORCE		= 1 << 3,	/* Since: 0.7.1 */
 	FWUPD_INSTALL_FLAG_NO_HISTORY		= 1 << 4,	/* Since: 1.0.8 */
+	FWUPD_INSTALL_FLAG_SIMULATE		= 1 << 5,	/* Since: 1.5.0 */
 	/*< private >*/
 	FWUPD_INSTALL_FLAG_LAST
 } FwupdInstallFlags;

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2291,6 +2291,16 @@ fu_plugin_runner_update (FuPlugin *self,
 		return TRUE;
 	}
 
+	/* simulation */
+	if (flags & FWUPD_INSTALL_FLAG_SIMULATE) {
+		g_debug ("simulating, skipping write");
+		for (guint i = 0; i < 100; i++) {
+			fu_device_set_progress (device, i);
+			g_usleep (10 * 1000);
+		}
+		return TRUE;
+	}
+
 	/* optional */
 	g_module_symbol (priv->module, "fu_plugin_update", (gpointer *) &update_func);
 	if (update_func == NULL) {

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2115,6 +2115,7 @@ main (int argc, char *argv[])
 	gboolean allow_reinstall = FALSE;
 	gboolean force = FALSE;
 	gboolean ret;
+	gboolean simulate = FALSE;
 	gboolean version = FALSE;
 	gboolean interactive = isatty (fileno (stdout)) != 0;
 	g_auto(GStrv) plugin_glob = NULL;
@@ -2133,6 +2134,9 @@ main (int argc, char *argv[])
 		{ "allow-older", '\0', 0, G_OPTION_ARG_NONE, &allow_older,
 			/* TRANSLATORS: command line option */
 			_("Allow downgrading firmware versions"), NULL },
+		{ "simulate", '\0', 0, G_OPTION_ARG_NONE, &simulate,
+			/* TRANSLATORS: command line option */
+			_("Simulate installation of the new firmware"), NULL },
 		{ "force", '\0', 0, G_OPTION_ARG_NONE, &force,
 			/* TRANSLATORS: command line option */
 			_("Override plugin warning"), NULL },
@@ -2448,6 +2452,10 @@ main (int argc, char *argv[])
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 	if (force)
 		priv->flags |= FWUPD_INSTALL_FLAG_FORCE;
+	if (simulate) {
+		priv->flags |= FWUPD_INSTALL_FLAG_SIMULATE;
+		priv->flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
+	}
 
 	/* load engine */
 	priv->engine = fu_engine_new (FU_APP_FLAGS_NO_IDLE_SOURCES);


### PR DESCRIPTION
This allows us to run all the composite firmware vfuncs, as well as the actual
FuDevice ->detach() and ->attach() functions so that we can test the ordering
and enumeration of composite devices without actually writing to SPI.
