### PR TITLE
synaptics-cxaudio: Fix the topology of the audio device on the TR dock

### DIFF
--- a/plugins/synaptics-cxaudio/synaptics-cxaudio.quirk
+++ b/plugins/synaptics-cxaudio/synaptics-cxaudio.quirk
@@ -1,7 +1,7 @@
 # ThinkPad TBT3-TR Gen 2 dock
 [DeviceInstanceId=USB\VID_17EF&PID_3083]
 Guid = SYNAPTICS_CXAUDIO\CX2098X
-ParentGuid = TBT-01081720
+ParentGuid = USB\VID_17EF&PID_307F&HUB_0006
 
 # ThinkPad TBT3-MS Gen 2 dock
 [DeviceInstanceId=USB\VID_17EF&PID_3092]


### PR DESCRIPTION
This ensures we perform the updates in this order:

* cxaudio
* vli
* thunderbolt

As any other order causes enumeration failures.

Fixes some of https://github.com/fwupd/fwupd/issues/2377
