### PR TITLE
thunderbolt: make sure that authorized has been set before flashing f…

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -1754,18 +1754,6 @@ fu_plugin_usb_device_added (FuPlugin *self, FuUsbDevice *device, GError **error)
 }
 
 static gboolean
-fu_plugin_udev_device_changed (FuPlugin *self, FuUdevDevice *device, GError **error)
-{
-	g_autoptr(FuDeviceLocker) locker = NULL;
-
-	/* open */
-	locker = fu_device_locker_new (FU_DEVICE (device), error);
-	if (locker == NULL)
-		return FALSE;
-	return fu_device_rescan (FU_DEVICE (device), error);
-}
-
-static gboolean
 fu_plugin_udev_device_added (FuPlugin *self, FuUdevDevice *device, GError **error)
 {
 	FuPluginPrivate *priv = GET_PRIVATE (self);
@@ -1944,14 +1932,8 @@ fu_plugin_runner_udev_device_changed (FuPlugin *self, FuUdevDevice *device, GErr
 
 	/* optional */
 	g_module_symbol (priv->module, "fu_plugin_udev_device_changed", (gpointer *) &func);
-	if (func == NULL) {
-		if (priv->device_gtype != G_TYPE_INVALID ||
-		    fu_device_get_specialized_gtype (FU_DEVICE (device)) != G_TYPE_INVALID) {
-			if (!fu_plugin_udev_device_changed (self, device, error))
-				return FALSE;
-		}
+	if (func == NULL)
 		return TRUE;
-	}
 	g_debug ("performing udev_device_changed() on %s", priv->name);
 	if (!func (self, device, &error_local)) {
 		if (error_local == NULL) {

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -76,8 +76,11 @@ static guint signals[SIGNAL_LAST] = { 0 };
 void
 fu_udev_device_emit_changed (FuUdevDevice *self)
 {
+	g_autoptr(GError) error = NULL;
 	g_return_if_fail (FU_IS_UDEV_DEVICE (self));
 	g_debug ("FuUdevDevice emit changed");
+	if (!fu_device_rescan (FU_DEVICE (self), &error))
+		g_debug ("%s", error->message);
 	g_signal_emit (self, signals[SIGNAL_CHANGED], 0);
 }
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -26,6 +26,7 @@
 #include "fu-plugin-private.h"
 #include "fu-thunderbolt-firmware.h"
 #include "fu-thunderbolt-firmware-update.h"
+#include "fu-udev-device-private.h"
 
 static gchar *
 udev_mock_add_domain (UMockdevTestbed *bed, int id)
@@ -891,8 +892,7 @@ fu_thunderbolt_gudev_uevent_cb (GUdevClient *gudev_client,
 		const gchar *uuid = g_udev_device_get_sysfs_attr (udev_device, "unique_id");
 		MockTree *target = (MockTree *) mock_tree_find_uuid (tt->tree, uuid);
 		g_assert_nonnull (target);
-		fu_plugin_runner_udev_device_changed (tt->plugin, FU_UDEV_DEVICE (target->fu_device),
-						      &error_local);
+		fu_udev_device_emit_changed (FU_UDEV_DEVICE (target->fu_device));
 		return;
 	}
 }

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -396,7 +396,7 @@ mock_tree_attach_device (gpointer user_data)
 						  "device", dev->id,
 						  "vendor", "042",
 						  "vendor_name", "GNOME.org",
-						  "authorized", "0",
+						  "authorized", "1",
 						  "nvm_authenticate", authenticate,
 						  "nvm_version", tree->nvm_version,
 						  "unique_id", tree->uuid,

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -20,6 +20,7 @@
 #include "fu-thunderbolt-device.h"
 #include "fu-thunderbolt-firmware.h"
 #include "fu-thunderbolt-firmware-update.h"
+#include "fu-udev-device-private.h"
 
 typedef enum {
 	FU_THUNDERBOLT_DEVICE_TYPE_DEVICE_CONTROLLER,

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -392,10 +392,8 @@ fu_thunderbolt_device_setup_retimer (FuDevice *device, GError **error)
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE (device);
 	guint16 did;
 	guint16 vid;
-	g_autofree gchar *idx = g_path_get_basename (self->devpath);
 	g_autofree gchar *instance = NULL;
 
-	fu_device_set_physical_id (device, idx);
 	/* as defined in PCIe 4.0 spec */
 	fu_device_set_summary (device, "A physical layer protocol-aware, software-transparent extension device "
 				        "that forms two separate electrical link segments");
@@ -425,7 +423,7 @@ fu_thunderbolt_device_setup_retimer (FuDevice *device, GError **error)
 	instance = g_strdup_printf ("TBT-%04x%04x-retimer%s",
 				    (guint) vid,
 				    (guint) did,
-				    idx);
+				    fu_device_get_physical_id (device));
 	fu_device_add_instance_id (device, instance);
 
 	/* hardcoded for now:


### PR DESCRIPTION
…irmware

If the device is not authorized, it may cause a composite update that it's part
of to not behave properly.

See #2374 for more details

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
