### PR TITLE
Check returned volumes before accessing them

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2035,6 +2035,8 @@ fu_util_prompt_for_volume (GError **error)
 
 	/* exactly one */
 	volumes = fu_common_get_volumes_by_kind (FU_VOLUME_KIND_ESP, error);
+	if (volumes == NULL)
+		return NULL;
 	if (volumes->len == 1) {
 		volume = g_ptr_array_index (volumes, 0);
 		/* TRANSLATORS: Volume has been chosen by the user */


### PR DESCRIPTION
Without udisks2 installed the list of volumes is empty and fwupdtool
esp-list segfaults.


Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation