### PR TITLE
Do not show HSI obsoleted attributes by default

### DIFF
--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -47,7 +47,7 @@ _fwupdmgr_opts=(
 	'--no-metadata-check'
 	'--no-reboot-check'
 	'--no-safety-check'
-	'--show-all-devices'
+	'--show-all'
 	'--sign'
 	'--filter'
 	'--disable-ssl-strict'

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -40,7 +40,7 @@ _fwupdtool_opts=(
 	'--allow-reinstall'
 	'--allow-older'
 	'--force'
-	'--show-all-devices'
+	'--show-all'
 	'--plugins'
 	'--prepare'
 	'--cleanup'

--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -26,7 +26,7 @@ complete -c fwupdmgr -l no-metadata-check -d 'Do not check for old metadata'
 complete -c fwupdmgr -l no-reboot-check -d 'Do not check for reboot after update'
 complete -c fwupdmgr -l no-safety-check -d 'Do not perform device safety checks'
 complete -c fwupdmgr -l no-history -d 'Do not write to the history database'
-complete -c fwupdmgr -l show-all-devices -d 'Show devices that are not updatable'
+complete -c fwupdmgr -l show-all -d 'Show all results'
 complete -c fwupdmgr -l disable-ssl-strict -d 'Ignore SSL strict checks when downloading files'
 complete -c fwupdmgr -l filter -d 'Filter with a set of device flags'
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2160,6 +2160,9 @@ main (int argc, char *argv[])
 		{ "plugins", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &plugin_glob,
 			/* TRANSLATORS: command line option */
 			_("Manually enable specific plugins"), NULL },
+		{ "plugin-whitelist", '\0', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING_ARRAY, &plugin_glob,
+			/* TRANSLATORS: command line option */
+			_("Manually enable specific plugins"), NULL },
 		{ "prepare", '\0', 0, G_OPTION_ARG_NONE, &priv->prepare_blob,
 			/* TRANSLATORS: command line option */
 			_("Run the plugin composite prepare routine when using install-blob"), NULL },

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -24,6 +24,14 @@ typedef struct {
 	FuUtilCmdFunc	 callback;
 } FuUtilCmd;
 
+typedef enum {
+	FU_SECURITY_ATTR_TO_STRING_FLAG_NONE			= 0,
+	FU_SECURITY_ATTR_TO_STRING_FLAG_SHOW_OBSOLETES		= 1 << 0,
+	FU_SECURITY_ATTR_TO_STRING_FLAG_SHOW_URLS		= 1 << 1,
+	/*< private >*/
+	FU_SECURITY_ATTR_TO_STRING_FLAG_LAST
+} FuSecurityAttrToStringFlags;
+
 void		 fu_util_print_data		(const gchar	*title,
 						 const gchar	*msg);
 guint		 fu_util_prompt_for_number	(guint		 maxnum);
@@ -76,7 +84,8 @@ gchar		*fu_util_release_to_string	(FwupdRelease	*rel,
 						 guint		 idt);
 gchar		*fu_util_remote_to_string	(FwupdRemote *remote,
 						 guint		 idt);
-gchar		*fu_util_security_attrs_to_string (GPtrArray	*attrs);
+gchar		*fu_util_security_attrs_to_string (GPtrArray	*attrs,
+						FuSecurityAttrToStringFlags flags);
 gboolean	 fu_util_send_report		(FwupdClient	*client,
 						 const gchar	*report_uri,
 						 const gchar	*data,


### PR DESCRIPTION
When one result is obsoleted by another, then do not show the old result by
default.

Additionally hide the HSI URLs as this was designed more for GUI clients like
gnome-firmware than CLI tools such as fwupdmgr.
