### PR TITLE
Add FuFirmwareFlags to allow opt-in dedupe of added images

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -36,12 +36,32 @@ struct _FuFirmwareClass
 	gpointer		 padding[28];
 };
 
+/**
+ * FuFirmwareFlags:
+ * @FU_FIRMWARE_FLAG_NONE:			No flags set
+ * @FU_FIRMWARE_FLAG_DEDUPE_ID:			Dedupe imges by ID
+ * @FU_FIRMWARE_FLAG_DEDUPE_IDX:		Dedupe imges by IDX
+ *
+ * The firmware flags.
+ **/
+#define FU_FIRMWARE_FLAG_NONE			(0u)		/* Since: 1.5.0 */
+#define FU_FIRMWARE_FLAG_DEDUPE_ID		(1u << 0)	/* Since: 1.5.0 */
+#define FU_FIRMWARE_FLAG_DEDUPE_IDX		(1u << 1)	/* Since: 1.5.0 */
+typedef guint64 FuFirmwareFlags;
+
+const gchar	*fu_firmware_flag_to_string		(FuFirmwareFlags flag);
+FuFirmwareFlags	 fu_firmware_flag_from_string		(const gchar	*flag);
+
 FuFirmware	*fu_firmware_new			(void);
 FuFirmware	*fu_firmware_new_from_bytes		(GBytes		*fw);
 gchar		*fu_firmware_to_string			(FuFirmware	*self);
 const gchar	*fu_firmware_get_version		(FuFirmware	*self);
 void		 fu_firmware_set_version		(FuFirmware	*self,
 							 const gchar	*version);
+void		 fu_firmware_add_flag			(FuFirmware	*firmware,
+							 FuFirmwareFlags flag);
+gboolean	 fu_firmware_has_flag			(FuFirmware	*firmware,
+							 FuFirmwareFlags flag);
 
 gboolean	 fu_firmware_tokenize			(FuFirmware	*self,
 							 GBytes		*fw,

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1635,6 +1635,51 @@ fu_firmware_func (void)
 }
 
 static void
+fu_firmware_dedupe_func (void)
+{
+	g_autoptr(FuFirmware) firmware = fu_firmware_new ();
+	g_autoptr(FuFirmwareImage) img1 = fu_firmware_image_new (NULL);
+	g_autoptr(FuFirmwareImage) img1_old = fu_firmware_image_new (NULL);
+	g_autoptr(FuFirmwareImage) img2 = fu_firmware_image_new (NULL);
+	g_autoptr(FuFirmwareImage) img2_old = fu_firmware_image_new (NULL);
+	g_autoptr(FuFirmwareImage) img_id = NULL;
+	g_autoptr(FuFirmwareImage) img_idx = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fu_firmware_add_flag (firmware, FU_FIRMWARE_FLAG_DEDUPE_ID);
+	fu_firmware_add_flag (firmware, FU_FIRMWARE_FLAG_DEDUPE_IDX);
+
+	fu_firmware_image_set_idx (img1_old, 13);
+	fu_firmware_image_set_id (img1_old, "DAVE");
+	fu_firmware_add_image (firmware, img1_old);
+
+	fu_firmware_image_set_idx (img1, 13);
+	fu_firmware_image_set_id (img1, "primary");
+	fu_firmware_add_image (firmware, img1);
+
+
+	fu_firmware_image_set_idx (img2_old, 123456);
+	fu_firmware_image_set_id (img2_old, "secondary");
+	fu_firmware_add_image (firmware, img2_old);
+
+	fu_firmware_image_set_idx (img2, 23);
+	fu_firmware_image_set_id (img2, "secondary");
+	fu_firmware_add_image (firmware, img2);
+
+	img_id = fu_firmware_get_image_by_id (firmware, "primary", &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (img_id);
+	g_assert_cmpint (fu_firmware_image_get_idx (img_id), ==, 13);
+	g_assert_cmpstr (fu_firmware_image_get_id (img_id), ==, "primary");
+
+	img_idx = fu_firmware_get_image_by_idx (firmware, 23, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (img_idx);
+	g_assert_cmpint (fu_firmware_image_get_idx (img_idx), ==, 23);
+	g_assert_cmpstr (fu_firmware_image_get_id (img_idx), ==, "secondary");
+}
+
+static void
 fu_efivar_func (void)
 {
 	gboolean ret;
@@ -1928,6 +1973,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/smbios", fu_smbios_func);
 	g_test_add_func ("/fwupd/smbios3", fu_smbios3_func);
 	g_test_add_func ("/fwupd/firmware", fu_firmware_func);
+	g_test_add_func ("/fwupd/firmware{dedupe}", fu_firmware_dedupe_func);
 	g_test_add_func ("/fwupd/firmware{ihex}", fu_firmware_ihex_func);
 	g_test_add_func ("/fwupd/firmware{ihex-offset}", fu_firmware_ihex_offset_func);
 	g_test_add_func ("/fwupd/firmware{ihex-signed}", fu_firmware_ihex_signed_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -617,6 +617,10 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_common_is_cpu_intel;
     fu_device_report_metadata_post;
     fu_device_report_metadata_pre;
+    fu_firmware_add_flag;
+    fu_firmware_flag_from_string;
+    fu_firmware_flag_to_string;
+    fu_firmware_has_flag;
     fu_fmap_firmware_get_type;
     fu_fmap_firmware_new;
     fu_plugin_runner_add_security_attrs;


### PR DESCRIPTION
The function fu_firmware_add_image() has the comment text 'If an image with the
same ID is present it is replaced' which has not been true for some time.

This was removed, as the common case of adding two images with no ID would only
leave one. However, some plugins do actually want to dedupe on the ID or IDX,
so provide a flag they can set which enables this functionality without
introducing regressions into other plugins.
