### PR TITLE
Allow plugins to match using the SUBSYS IDs

### DIFF
--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -63,6 +63,8 @@ const gchar	*fu_udev_device_get_sysfs_path		(FuUdevDevice	*self);
 const gchar	*fu_udev_device_get_subsystem		(FuUdevDevice	*self);
 guint32		 fu_udev_device_get_vendor		(FuUdevDevice	*self);
 guint32		 fu_udev_device_get_model		(FuUdevDevice	*self);
+guint32		 fu_udev_device_get_subsystem_vendor	(FuUdevDevice	*self);
+guint32		 fu_udev_device_get_subsystem_model	(FuUdevDevice	*self);
 guint8		 fu_udev_device_get_revision		(FuUdevDevice	*self);
 guint		 fu_udev_device_get_slot_depth		(FuUdevDevice	*self,
 							 const gchar	*subsystem);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -630,5 +630,7 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_security_attrs_new;
     fu_security_attrs_remove_all;
     fu_security_attrs_to_variant;
+    fu_udev_device_get_subsystem_model;
+    fu_udev_device_get_subsystem_vendor;
   local: *;
 } LIBFWUPDPLUGIN_1.4.6;


### PR DESCRIPTION
This is the same format specified by Microsoft in "Identifiers for PCI Devices"
https://docs.microsoft.com/en-us/windows-hardware/drivers/install/identifiers-for-pci-devices
