### PR TITLE
flag_require_ac documentation: System requires external power source

### DIFF
--- a/data/org.freedesktop.fwupd.metainfo.xml
+++ b/data/org.freedesktop.fwupd.metainfo.xml
@@ -450,7 +450,7 @@
           <li>Do not fail to start the daemon if tpm2_pcrlist hangs</li>
           <li>Do not fail when scheduling more than one update to be run offline</li>
           <li>Do not let failing to find DBus prevent fwuptool from starting</li>
-          <li>Do not schedule an update on battery power if it requires AC power</li>
+          <li>Do not schedule an update on battery power if it requires an external power source</li>
           <li>Include all device checksums in the LVFS report</li>
           <li>Rename the shimx64.efi binary for known broken firmware</li>
           <li>Upload the UPDATE_INFO entry for the UEFI UX capsule</li>

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -88,7 +88,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_INTERNAL:			Device cannot be removed easily
  * @FWUPD_DEVICE_FLAG_UPDATABLE:		Device is updatable in this or any other mode
  * @FWUPD_DEVICE_FLAG_ONLY_OFFLINE:		Update can only be done from offline mode
- * @FWUPD_DEVICE_FLAG_REQUIRE_AC:		Requires AC power
+ * @FWUPD_DEVICE_FLAG_REQUIRE_AC:		System requires external power source
  * @FWUPD_DEVICE_FLAG_LOCKED:			Is locked and can be unlocked
  * @FWUPD_DEVICE_FLAG_SUPPORTED:		Is found in current metadata
  * @FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER:		Requires a bootloader mode to be manually enabled by the user

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -967,7 +967,7 @@ fu_util_device_flag_to_string (guint64 device_flag)
 	}
 	if (device_flag == FWUPD_DEVICE_FLAG_REQUIRE_AC) {
 		/* TRANSLATORS: Must be plugged in to an outlet */
-		return _("Requires AC power");
+		return _("System requires external power source");
 	}
 	if (device_flag == FWUPD_DEVICE_FLAG_LOCKED) {
 		/* TRANSLATORS: Is locked and can be unlocked */


### PR DESCRIPTION
Related to https://github.com/fwupd/fwupd/issues/2345

This fixes the wording issue discussed in https://github.com/fwupd/fwupd/issues/2345 . A system that has the flag "require_ac" does not actually run on alternating current. The device runs on direct current but just needs to be plugged into an external power source / an outlet.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
