### PR TITLE
Add the missing fu_firmware_image_parse()

### DIFF
--- a/libfwupdplugin/fu-firmware-image.c
+++ b/libfwupdplugin/fu-firmware-image.c
@@ -189,6 +189,40 @@ fu_firmware_image_set_bytes (FuFirmwareImage *self, GBytes *bytes)
 }
 
 /**
+ * fu_firmware_image_parse:
+ * @self: A #FuFirmwareImage
+ * @fw: A #GBytes
+ * @flags: some #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @error: A #GError, or %NULL
+ *
+ * Parses a firmware image, typically checking image CRCs and/or headers.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.5.0
+ **/
+gboolean
+fu_firmware_image_parse (FuFirmwareImage *self,
+			 GBytes *fw,
+			 FwupdInstallFlags flags,
+			 GError **error)
+{
+	FuFirmwareImageClass *klass = FU_FIRMWARE_IMAGE_GET_CLASS (self);
+
+	g_return_val_if_fail (FU_IS_FIRMWARE_IMAGE (self), FALSE);
+	g_return_val_if_fail (fw != NULL, FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	/* subclassed */
+	if (klass->parse != NULL)
+		return klass->parse (self, fw, flags, error);
+
+	/* just add entire blob */
+	fu_firmware_image_set_bytes (self, fw);
+	return TRUE;
+}
+
+/**
  * fu_firmware_image_write:
  * @self: a #FuPlugin
  * @error: A #GError, or %NULL

--- a/libfwupdplugin/fu-firmware-image.h
+++ b/libfwupdplugin/fu-firmware-image.h
@@ -49,6 +49,10 @@ void		 fu_firmware_image_set_idx	(FuFirmwareImage	*self,
 						 guint64		 idx);
 void		 fu_firmware_image_set_bytes	(FuFirmwareImage	*self,
 						 GBytes			*bytes);
+gboolean	 fu_firmware_image_parse	(FuFirmwareImage	*self,
+						 GBytes			*fw,
+						 FwupdInstallFlags	 flags,
+						 GError			**error);
 GBytes		*fu_firmware_image_write	(FuFirmwareImage	*self,
 						 GError			**error);
 GBytes		*fu_firmware_image_write_chunk	(FuFirmwareImage	*self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -621,6 +621,7 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_firmware_flag_from_string;
     fu_firmware_flag_to_string;
     fu_firmware_has_flag;
+    fu_firmware_image_parse;
     fu_fmap_firmware_get_type;
     fu_fmap_firmware_new;
     fu_plugin_runner_add_security_attrs;


### PR DESCRIPTION
We provided the FuFirmwareImage->parse() vfunc, but did not provide any way to
actually call it...
