### PR TITLE
uefi: Fix critical warning regression with 'fwupdate -a'

### DIFF
--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -327,6 +327,7 @@ main (int argc, char *argv[])
 			g_printerr ("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}
+		fu_uefi_device_set_esp (dev, esp);
 		if (flags != NULL)
 			fu_device_set_custom_flags (FU_DEVICE (dev), flags);
 		if (!fu_device_prepare (FU_DEVICE (dev),


### PR DESCRIPTION
Set the ESP when creating the device with a known GUID.

Fixes https://github.com/fwupd/fwupd/issues/2406
