### PR TITLE
Add fu_device_dump_firmware()

### DIFF
--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -30,7 +30,7 @@ _fwupdtool_cmd_list=(
 	'smbios-dump'
 	'attach'
 	'detach'
-	'firmware-read'
+	'firmware-dump'
 	'refresh'
 	'verify-update'
 	'watch'
@@ -100,7 +100,7 @@ _fwupdtool()
 	esac
 
 	case $command in
-	get-details|install|install-blob|firmware-read)
+	get-details|install|install-blob|firmware-dump)
 		#find files
 		if [[ "$prev" = "$command" ]]; then
 			_filedir

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -74,8 +74,10 @@ struct _FuDeviceClass
 							 GError		**error);
 	gboolean		 (*unbind_driver)	(FuDevice	*self,
 							 GError		**error);
+	GBytes			*(*dump_firmware)	(FuDevice	*self,
+							 GError		**error);
 	/*< private >*/
-	gpointer	padding[12];
+	gpointer	padding[11];
 };
 
 /**
@@ -283,6 +285,8 @@ FuFirmware	*fu_device_prepare_firmware		(FuDevice	*self,
 							 FwupdInstallFlags flags,
 							 GError		**error);
 FuFirmware	*fu_device_read_firmware		(FuDevice	*self,
+							 GError		**error);
+GBytes		*fu_device_dump_firmware		(FuDevice	*self,
 							 GError		**error);
 gboolean	 fu_device_attach			(FuDevice	*self,
 							 GError		**error);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -462,6 +462,95 @@ fu_firmware_add_image (FuFirmware *self, FuFirmwareImage *img)
 }
 
 /**
+ * fu_firmware_remove_image:
+ * @self: a #FuPlugin
+ * @img: A #FuFirmwareImage
+ * @error: A #GError, or %NULL
+ *
+ * Remove an image from the firmware.
+ *
+ * Returns: %TRUE if the image was removed
+ *
+ * Since: 1.5.0
+ **/
+gboolean
+fu_firmware_remove_image (FuFirmware *self, FuFirmwareImage *img, GError **error)
+{
+	FuFirmwarePrivate *priv = GET_PRIVATE (self);
+
+	g_return_val_if_fail (FU_IS_FIRMWARE (self), FALSE);
+	g_return_val_if_fail (FU_IS_FIRMWARE_IMAGE (img), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	if (g_ptr_array_remove (priv->images, img))
+		return TRUE;
+
+	/* did not exist */
+	g_set_error (error,
+		     FWUPD_ERROR,
+		     FWUPD_ERROR_NOT_FOUND,
+		     "image %s not found in firmware",
+		     fu_firmware_image_get_id (img));
+	return FALSE;
+}
+
+/**
+ * fu_firmware_remove_image_by_idx:
+ * @self: a #FuPlugin
+ * @idx: index
+ * @error: A #GError, or %NULL
+ *
+ * Removes the first image from the firmware matching the index.
+ *
+ * Returns: %TRUE if an image was removed
+ *
+ * Since: 1.5.0
+ **/
+gboolean
+fu_firmware_remove_image_by_idx (FuFirmware *self, guint64 idx, GError **error)
+{
+	FuFirmwarePrivate *priv = GET_PRIVATE (self);
+	g_autoptr(FuFirmwareImage) img = NULL;
+
+	g_return_val_if_fail (FU_IS_FIRMWARE (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	img = fu_firmware_get_image_by_idx (self, idx, error);
+	if (img == NULL)
+		return FALSE;
+	g_ptr_array_remove (priv->images, img);
+	return TRUE;
+}
+
+/**
+ * fu_firmware_remove_image_by_id:
+ * @self: a #FuPlugin
+ * @id: (nullable): image ID, e.g. "config"
+ * @error: A #GError, or %NULL
+ *
+ * Removes the first image from the firmware matching the ID.
+ *
+ * Returns: %TRUE if an image was removed
+ *
+ * Since: 1.5.0
+ **/
+gboolean
+fu_firmware_remove_image_by_id (FuFirmware *self, const gchar *id, GError **error)
+{
+	FuFirmwarePrivate *priv = GET_PRIVATE (self);
+	g_autoptr(FuFirmwareImage) img = NULL;
+
+	g_return_val_if_fail (FU_IS_FIRMWARE (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	img = fu_firmware_get_image_by_id (self, id, error);
+	if (img == NULL)
+		return FALSE;
+	g_ptr_array_remove (priv->images, img);
+	return TRUE;
+}
+
+/**
  * fu_firmware_get_images:
  * @self: a #FuFirmware
  *

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -95,6 +95,15 @@ gboolean	 fu_firmware_write_file			(FuFirmware	*self,
 
 void		 fu_firmware_add_image			(FuFirmware	*self,
 							 FuFirmwareImage *img);
+gboolean	 fu_firmware_remove_image		(FuFirmware	*self,
+							 FuFirmwareImage *img,
+							 GError		**error);
+gboolean	 fu_firmware_remove_image_by_idx	(FuFirmware	*self,
+							 guint64	 idx,
+							 GError		**error);
+gboolean	 fu_firmware_remove_image_by_id		(FuFirmware	*self,
+							 const gchar	*id,
+							 GError		**error);
 GPtrArray	*fu_firmware_get_images			(FuFirmware	*self);
 FuFirmwareImage *fu_firmware_get_image_by_id		(FuFirmware	*self,
 							 const gchar	*id,

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1652,12 +1652,14 @@ fu_firmware_dfu_func (void)
 static void
 fu_firmware_func (void)
 {
+	gboolean ret;
 	g_autoptr(FuFirmware) firmware = fu_firmware_new ();
 	g_autoptr(FuFirmwareImage) img1 = fu_firmware_image_new (NULL);
 	g_autoptr(FuFirmwareImage) img2 = fu_firmware_image_new (NULL);
 	g_autoptr(FuFirmwareImage) img_id = NULL;
 	g_autoptr(FuFirmwareImage) img_idx = NULL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(GPtrArray) images = NULL;
 	g_autofree gchar *str = NULL;
 
 	fu_firmware_image_set_addr (img1, 0x200);
@@ -1703,6 +1705,19 @@ fu_firmware_func (void)
 				  "  ID:                   secondary\n"
 				  "  Index:                0x17\n"
 				  "  Address:              0x400\n");
+
+	ret = fu_firmware_remove_image_by_idx (firmware, 0xd, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	ret = fu_firmware_remove_image_by_id (firmware, "secondary", &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	images = fu_firmware_get_images (firmware);
+	g_assert_nonnull (images);
+	g_assert_cmpint (images->len, ==, 0);
+	ret = fu_firmware_remove_image_by_id (firmware, "NOTGOINGTOEXIST", &error);
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_false (ret);
 }
 
 static void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -632,6 +632,9 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_firmware_image_parse;
     fu_firmware_image_set_filename;
     fu_firmware_image_set_offset;
+    fu_firmware_remove_image;
+    fu_firmware_remove_image_by_id;
+    fu_firmware_remove_image_by_idx;
     fu_fmap_firmware_get_type;
     fu_fmap_firmware_new;
     fu_plugin_runner_add_security_attrs;

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -616,6 +616,7 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_common_filename_glob;
     fu_common_is_cpu_intel;
     fu_device_bind_driver;
+    fu_device_dump_firmware;
     fu_device_report_metadata_post;
     fu_device_report_metadata_pre;
     fu_device_unbind_driver;

--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -381,13 +381,12 @@ fu_altos_device_write_firmware (FuDevice *device,
 	return TRUE;
 }
 
-static FuFirmware *
-fu_altos_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+fu_altos_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuAltosDevice *self = FU_ALTOS_DEVICE (device);
 	guint flash_len;
 	g_autoptr(FuDeviceLocker) locker  = NULL;
-	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GString) buf = g_string_new (NULL);
 
 	/* check kind */
@@ -441,8 +440,7 @@ fu_altos_device_read_firmware (FuDevice *device, GError **error)
 	}
 
 	/* success */
-	fw = g_bytes_new (buf->str, buf->len);
-	return fu_firmware_new_from_bytes (fw);
+	return g_bytes_new (buf->str, buf->len);
 }
 
 static gboolean
@@ -577,6 +575,6 @@ fu_altos_device_class_init (FuAltosDeviceClass *klass)
 	klass_device->probe = fu_altos_device_probe;
 	klass_device->prepare_firmware = fu_altos_device_prepare_firmware;
 	klass_device->write_firmware = fu_altos_device_write_firmware;
-	klass_device->read_firmware = fu_altos_device_read_firmware;
+	klass_device->dump_firmware = fu_altos_device_dump_firmware;
 	object_class->finalize = fu_altos_device_finalize;
 }

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -188,12 +188,11 @@ fu_csr_device_upload_chunk (FuCsrDevice *self, GError **error)
 			    sizeof(buf) - FU_CSR_COMMAND_HEADER_SIZE);
 }
 
-static FuFirmware *
+static GBytes *
 fu_csr_device_upload (FuDevice *device, GError **error)
 {
 	FuCsrDevice *self = FU_CSR_DEVICE (device);
 	g_autoptr(GPtrArray) chunks = NULL;
-	g_autoptr(GBytes) fw = NULL;
 	guint32 total_sz = 0;
 	gsize done_sz = 0;
 
@@ -253,8 +252,7 @@ fu_csr_device_upload (FuDevice *device, GError **error)
 	}
 
 	/* notify UI */
-	fw = dfu_utils_bytes_join_array (chunks);
-	return fu_firmware_new_from_bytes (fw);
+	return dfu_utils_bytes_join_array (chunks);
 }
 
 static gboolean
@@ -434,7 +432,7 @@ fu_csr_device_class_init (FuCsrDeviceClass *klass)
 	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->to_string = fu_csr_device_to_string;
 	klass_device->write_firmware = fu_csr_device_download;
-	klass_device->read_firmware = fu_csr_device_upload;
+	klass_device->dump_firmware = fu_csr_device_upload;
 	klass_device->prepare_firmware = fu_csr_device_prepare_firmware;
 	klass_device->attach = fu_csr_device_attach;
 	klass_device->setup = fu_csr_device_setup;

--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1679,12 +1679,11 @@ dfu_device_error_fixup (DfuDevice *device, GError **error)
 	}
 }
 
-static FuFirmware *
-dfu_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+dfu_device_dump_firmware (FuDevice *device, GError **error)
 {
 	DfuDevice *self = DFU_DEVICE (device);
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
-	g_autoptr(GBytes) fw = NULL;
 
 	/* get data from hardware */
 	g_debug ("uploading from device->host");
@@ -1697,8 +1696,7 @@ dfu_device_read_firmware (FuDevice *device, GError **error)
 		return NULL;
 
 	/* get the checksum */
-	fw = dfu_firmware_write_data (dfu_firmware, error);
-	return fu_firmware_new_from_bytes (fw);
+	return dfu_firmware_write_data (dfu_firmware, error);
 }
 
 static gboolean
@@ -1825,7 +1823,7 @@ dfu_device_class_init (DfuDeviceClass *klass)
 	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->set_quirk_kv = dfu_device_set_quirk_kv;
 	klass_device->to_string = dfu_device_to_string;
-	klass_device->read_firmware = dfu_device_read_firmware;
+	klass_device->dump_firmware = dfu_device_dump_firmware;
 	klass_device->write_firmware = dfu_device_write_firmware;
 	klass_device->attach = dfu_device_attach;
 	klass_device->detach = dfu_device_detach;

--- a/plugins/optionrom/fu-rom.c
+++ b/plugins/optionrom/fu-rom.c
@@ -112,7 +112,7 @@ fu_rom_blank_serial_numbers (guint8 *buffer, guint buffer_sz)
 }
 
 static gchar *
-fu_rom_get_hex_dump (guint8 *buffer, guint32 sz)
+fu_rom_get_hex_dump (const guint8 *buffer, guint32 sz)
 {
 	GString *str = g_string_new ("");
 	for (guint32 i = 0; i < sz; i++)
@@ -135,7 +135,7 @@ typedef struct {
 } FooRomPciCertificateHdr;
 
 static void
-fu_rom_pci_print_certificate_data (guint8 *buffer, gssize sz)
+fu_rom_pci_print_certificate_data (const guint8 *buffer, gssize sz)
 {
 	guint16 off = 0;
 	g_autofree gchar *hdr_str = NULL;
@@ -155,7 +155,7 @@ fu_rom_pci_print_certificate_data (guint8 *buffer, gssize sz)
 		g_debug ("     ISBN segment @%02x: %s", off, segment_str);
 		h.segment_kind = buffer[off+1];
 		h.next_offset = (guint16) (((guint16) buffer[off+14] << 8) + buffer[off+13]);
-		h.data = &buffer[off+29];
+		h.data = (guint8 *) &buffer[off+29];
 
 		/* calculate last block length automatically */
 		if (h.next_offset == 0)
@@ -396,7 +396,7 @@ fu_rom_pci_parse_data (FuRomPciHeader *hdr)
 }
 
 static FuRomPciHeader *
-fu_rom_pci_get_header (guint8 *buffer, guint32 sz)
+fu_rom_pci_get_header (const guint8 *buffer, guint32 sz)
 {
 	FuRomPciHeader *hdr;
 
@@ -536,15 +536,17 @@ fu_rom_find_version (FuRomKind kind, FuRomPciHeader *hdr)
 
 gboolean
 fu_rom_load_data (FuRom *self,
-		  guint8 *buffer, gsize buffer_sz,
+		  GBytes *blob,
 		  FuRomLoadFlags flags,
 		  GCancellable *cancellable,
 		  GError **error)
 {
 	FuRomPciHeader *hdr = NULL;
-	guint32 sz = buffer_sz;
 	guint32 jump = 0;
 	guint32 hdr_sz = 0;
+	gsize buffer_sz = 0;
+	const guint8 *buffer = g_bytes_get_data (blob, &buffer_sz);
+	guint32 sz = buffer_sz;
 
 	g_return_val_if_fail (FU_IS_ROM (self), FALSE);
 
@@ -682,19 +684,16 @@ fu_rom_load_data (FuRom *self,
 	return TRUE;
 }
 
-gboolean
-fu_rom_load_file (FuRom *self, GFile *file, FuRomLoadFlags flags,
-		  GCancellable *cancellable, GError **error)
+GBytes *
+fu_rom_dump_firmware (GFile *file, GCancellable *cancellable, GError **error)
 {
-	const gssize buffer_sz = 0x400000;
-	gssize sz;
 	guint number_reads = 0;
-	g_autoptr(GError) error_local = NULL;
 	g_autofree gchar *fn = NULL;
-	g_autofree guint8 *buffer = NULL;
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GInputStream) stream = NULL;
 
-	g_return_val_if_fail (FU_IS_ROM (self), FALSE);
+	g_return_val_if_fail (G_IS_FILE (file), NULL);
 
 	/* open file */
 	stream = G_INPUT_STREAM (g_file_read (file, cancellable, &error_local));
@@ -719,38 +718,20 @@ fu_rom_load_file (FuRom *self, GFile *file, FuRomLoadFlags flags,
 			return FALSE;
 	}
 
-	/* read out the header */
-	buffer = g_malloc ((gsize) buffer_sz);
-	sz = g_input_stream_read (stream, buffer, buffer_sz,
-				  cancellable, error);
-	if (sz < 0)
-		return FALSE;
-	if (sz < 512) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INVALID_FILE,
-			     "Firmware too small: %" G_GSSIZE_FORMAT " bytes", sz);
-		return FALSE;
-	}
-
 	/* ensure we got enough data to fill the buffer */
-	while (sz < buffer_sz) {
-		gssize sz_chunk;
-		sz_chunk = g_input_stream_read (stream,
-						buffer + sz,
-						buffer_sz - sz,
-						cancellable,
-						error);
-		if (sz_chunk == 0)
+	while (TRUE) {
+		gssize sz;
+		guint8 tmp[32 * 1024] = { 0x0 };
+		sz = g_input_stream_read (stream, tmp, sizeof(tmp), cancellable, error);
+		if (sz == 0)
 			break;
-		g_debug ("ROM returned 0x%04x bytes, adding 0x%04x...",
-			 (guint) sz, (guint) sz_chunk);
-		if (sz_chunk < 0)
+		g_debug ("ROM returned 0x%04x bytes", (guint) sz);
+		if (sz < 0)
 			return FALSE;
-		sz += sz_chunk;
+		g_byte_array_append (buf, tmp, sz);
 
 		/* check the firmware isn't serving us small chunks */
-		if (number_reads++ > 16) {
+		if (number_reads++ > 1024) {
 			g_set_error_literal (error,
 					     FWUPD_ERROR,
 					     FWUPD_ERROR_INVALID_FILE,
@@ -758,9 +739,28 @@ fu_rom_load_file (FuRom *self, GFile *file, FuRomLoadFlags flags,
 			return FALSE;
 		}
 	}
-	g_debug ("ROM buffer filled %" G_GSSIZE_FORMAT "kb/%" G_GSSIZE_FORMAT "kb",
-		 sz / 0x400, buffer_sz / 0x400);
-	return fu_rom_load_data (self, buffer, sz, flags, cancellable, error);
+	if (buf->len < 512) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INVALID_FILE,
+			     "firmware too small: %u bytes", buf->len);
+		return FALSE;
+	}
+	return g_byte_array_free_to_bytes (g_steal_pointer (&buf));
+}
+
+gboolean
+fu_rom_load_file (FuRom *self, GFile *file, FuRomLoadFlags flags,
+		  GCancellable *cancellable, GError **error)
+{
+	g_autoptr(GBytes) blob = NULL;
+
+	g_return_val_if_fail (FU_IS_ROM (self), FALSE);
+
+	blob = fu_rom_dump_firmware (file, cancellable, error);
+	if (blob == NULL)
+		return FALSE;
+	return fu_rom_load_data (self, blob, flags, cancellable, error);
 }
 
 FuRomKind

--- a/plugins/optionrom/fu-rom.h
+++ b/plugins/optionrom/fu-rom.h
@@ -34,8 +34,7 @@ gboolean	 fu_rom_load_file			(FuRom		*self,
 							 GCancellable	*cancellable,
 							 GError		**error);
 gboolean	 fu_rom_load_data			(FuRom		*self,
-							 guint8		*buffer,
-							 gsize		 buffer_sz,
+							 GBytes		*blob,
 							 FuRomLoadFlags	 flags,
 							 GCancellable	*cancellable,
 							 GError		**error);
@@ -48,3 +47,6 @@ GBytes		*fu_rom_get_data			(FuRom		*self);
 guint16		 fu_rom_get_vendor			(FuRom		*self);
 guint16		 fu_rom_get_model			(FuRom		*self);
 const gchar	*fu_rom_kind_to_string			(FuRomKind	 kind);
+GBytes		*fu_rom_dump_firmware			(GFile		*file,
+							 GCancellable	*cancellable,
+							 GError		**error);

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -417,18 +417,26 @@ fu_plugin_superio_fix_signature (FuSuperioDevice *self, GBytes *fw, GError **err
 	return g_bytes_new_take (g_steal_pointer (&buf2), sz);
 }
 
+static GBytes *
+fu_superio_it89_device_dump_firmware (FuDevice *device, GError **error)
+{
+	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
+	guint64 fwsize = fu_device_get_firmware_size_min (device);
+
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
+	return fu_superio_it89_device_read_addr (self, 0x0, fwsize,
+						 fu_superio_it89_device_progress_cb,
+						 error);
+}
+
 static FuFirmware *
 fu_superio_it89_device_read_firmware (FuDevice *device, GError **error)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
-	guint64 fwsize = fu_device_get_firmware_size_min (device);
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
-	fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
-	blob = fu_superio_it89_device_read_addr (self, 0x0, fwsize,
-						 fu_superio_it89_device_progress_cb,
-						 error);
+	blob = fu_superio_it89_device_dump_firmware (device, error);
 	fw = fu_plugin_superio_fix_signature (self, blob, error);
 	return fu_firmware_new_from_bytes (fw);
 }
@@ -681,6 +689,7 @@ fu_superio_it89_device_class_init (FuSuperioIt89DeviceClass *klass)
 	klass_device->attach = fu_superio_it89_device_attach;
 	klass_device->detach = fu_superio_it89_device_detach;
 	klass_device->read_firmware = fu_superio_it89_device_read_firmware;
+	klass_device->dump_firmware = fu_superio_it89_device_dump_firmware;
 	klass_device->write_firmware = fu_superio_it89_device_write_firmware;
 	klass_superio_device->setup = fu_superio_it89_device_setup;
 }

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -362,18 +362,14 @@ fu_vli_pd_device_prepare_firmware (FuDevice *device,
 	return g_steal_pointer (&firmware);
 }
 
-static FuFirmware *
-fu_vli_pd_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+fu_vli_pd_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuVliPdDevice *self = FU_VLI_PD_DEVICE (device);
-	g_autoptr(GBytes) fw = NULL;
-	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_VERIFY);
-	fw = fu_vli_device_spi_read (FU_VLI_DEVICE (self), 0x0,
-				     fu_device_get_firmware_size_max (device),
-				     error);
-	if (fw == NULL)
-		return NULL;
-	return fu_firmware_new_from_bytes (fw);
+	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_READ);
+	return fu_vli_device_spi_read (FU_VLI_DEVICE (self), 0x0,
+				       fu_device_get_firmware_size_max (device),
+				       error);
 }
 
 static gboolean
@@ -688,7 +684,7 @@ fu_vli_pd_device_class_init (FuVliPdDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	FuVliDeviceClass *klass_vli_device = FU_VLI_DEVICE_CLASS (klass);
-	klass_device->read_firmware = fu_vli_pd_device_read_firmware;
+	klass_device->dump_firmware = fu_vli_pd_device_dump_firmware;
 	klass_device->write_firmware = fu_vli_pd_device_write_firmware;
 	klass_device->prepare_firmware = fu_vli_pd_device_prepare_firmware;
 	klass_device->attach = fu_vli_pd_device_attach;

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -579,8 +579,8 @@ fu_vli_pd_parade_device_write_firmware (FuDevice *device,
 	return TRUE;
 }
 
-static FuFirmware *
-fu_vli_pd_parade_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+fu_vli_pd_parade_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuVliPdDevice *parent = FU_VLI_PD_DEVICE (fu_device_get_parent (device));
 	FuVliPdParadeDevice *self = FU_VLI_PD_PARADE_DEVICE (device);
@@ -610,7 +610,7 @@ fu_vli_pd_parade_device_read_firmware (FuDevice *device, GError **error)
 							 error))
 			return NULL;
 	}
-	return fu_firmware_new_from_bytes (fw);
+	return g_steal_pointer (&fw);
 }
 
 static gboolean
@@ -657,7 +657,7 @@ fu_vli_pd_parade_device_class_init (FuVliPdParadeDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	klass_device->to_string = fu_vli_pd_parade_device_to_string;
 	klass_device->probe = fu_vli_pd_parade_device_probe;
-	klass_device->read_firmware = fu_vli_pd_parade_device_read_firmware;
+	klass_device->dump_firmware = fu_vli_pd_parade_device_dump_firmware;
 	klass_device->write_firmware = fu_vli_pd_parade_device_write_firmware;
 }
 

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -948,18 +948,14 @@ fu_vli_usbhub_device_update_v2 (FuVliUsbhubDevice *self, FuFirmware *firmware, G
 	return TRUE;
 }
 
-static FuFirmware *
-fu_vli_usbhub_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+fu_vli_usbhub_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE (device);
-	g_autoptr(GBytes) fw = NULL;
-	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_VERIFY);
-	fw = fu_vli_device_spi_read (FU_VLI_DEVICE (self), 0x0,
-				     fu_device_get_firmware_size_max (device),
-				     error);
-	if (fw == NULL)
-		return NULL;
-	return fu_firmware_new_from_bytes (fw);
+	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_READ);
+	return fu_vli_device_spi_read (FU_VLI_DEVICE (self), 0x0,
+				       fu_device_get_firmware_size_max (device),
+				       error);
 }
 
 static gboolean
@@ -1007,7 +1003,7 @@ fu_vli_usbhub_device_class_init (FuVliUsbhubDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	FuVliDeviceClass *klass_vli_device = FU_VLI_DEVICE_CLASS (klass);
 	klass_device->probe = fu_vli_usbhub_device_probe;
-	klass_device->read_firmware = fu_vli_usbhub_device_read_firmware;
+	klass_device->dump_firmware = fu_vli_usbhub_device_dump_firmware;
 	klass_device->write_firmware = fu_vli_usbhub_device_write_firmware;
 	klass_device->prepare_firmware = fu_vli_usbhub_device_prepare_firmware;
 	klass_device->attach = fu_vli_usbhub_device_attach;

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -123,13 +123,12 @@ fu_vli_usbhub_pd_device_prepare_firmware (FuDevice *device,
 	return g_steal_pointer (&firmware);
 }
 
-static FuFirmware *
-fu_vli_usbhub_pd_device_read_firmware (FuDevice *device, GError **error)
+static GBytes *
+fu_vli_usbhub_pd_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuVliUsbhubDevice *parent = FU_VLI_USBHUB_DEVICE (fu_device_get_parent (device));
 	FuVliUsbhubPdDevice *self = FU_VLI_USBHUB_PD_DEVICE (device);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GBytes) fw = NULL;
 
 	/* open device */
 	locker = fu_device_locker_new (parent, error);
@@ -137,14 +136,11 @@ fu_vli_usbhub_pd_device_read_firmware (FuDevice *device, GError **error)
 		return NULL;
 
 	/* read */
-	fu_device_set_status (FU_DEVICE (device), FWUPD_STATUS_DEVICE_VERIFY);
-	fw = fu_vli_device_spi_read (FU_VLI_DEVICE (parent),
-				     fu_vli_common_device_kind_get_offset (self->device_kind),
-				     fu_device_get_firmware_size_max (device),
-				     error);
-	if (fw == NULL)
-		return NULL;
-	return fu_firmware_new_from_bytes (fw);
+	fu_device_set_status (FU_DEVICE (device), FWUPD_STATUS_DEVICE_READ);
+	return fu_vli_device_spi_read (FU_VLI_DEVICE (parent),
+				       fu_vli_common_device_kind_get_offset (self->device_kind),
+				       fu_device_get_firmware_size_max (device),
+				       error);
 }
 
 static gboolean
@@ -221,7 +217,7 @@ fu_vli_usbhub_pd_device_class_init (FuVliUsbhubPdDeviceClass *klass)
 	klass_device->to_string = fu_vli_usbhub_pd_device_to_string;
 	klass_device->probe = fu_vli_usbhub_pd_device_probe;
 	klass_device->attach = fu_vli_usbhub_pd_device_attach;
-	klass_device->read_firmware = fu_vli_usbhub_pd_device_read_firmware;
+	klass_device->dump_firmware = fu_vli_usbhub_pd_device_dump_firmware;
 	klass_device->write_firmware = fu_vli_usbhub_pd_device_write_firmware;
 	klass_device->prepare_firmware = fu_vli_usbhub_pd_device_prepare_firmware;
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2753,13 +2753,13 @@ fu_engine_update (FuEngine *self,
 }
 
 GBytes *
-fu_engine_firmware_read (FuEngine *self,
+fu_engine_firmware_dump (FuEngine *self,
 			 FuDevice *device,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(GBytes) fw = NULL;
 
 	/* open, detach, read, attach, serialize */
 	locker = fu_device_locker_new (device, error);
@@ -2769,8 +2769,8 @@ fu_engine_firmware_read (FuEngine *self,
 	}
 	if (!fu_device_detach (device, error))
 		return NULL;
-	firmware = fu_device_read_firmware (device, error);
-	if (firmware == NULL) {
+	fw = fu_device_dump_firmware (device, error);
+	if (fw == NULL) {
 		g_autoptr(GError) error_local = NULL;
 		if (!fu_device_attach (device, &error_local)) {
 			g_warning ("failed to attach after read image failure: %s",
@@ -2780,7 +2780,7 @@ fu_engine_firmware_read (FuEngine *self,
 	}
 	if (!fu_device_attach (device, error))
 		return NULL;
-	return fu_firmware_write (firmware, error);
+	return g_steal_pointer (&fw);
 }
 
 gboolean

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -116,7 +116,7 @@ gboolean	 fu_engine_verify			(FuEngine	*self,
 gboolean	 fu_engine_verify_update		(FuEngine	*self,
 							 const gchar	*device_id,
 							 GError		**error);
-GBytes		*fu_engine_firmware_read		(FuEngine	*self,
+GBytes		*fu_engine_firmware_dump		(FuEngine	*self,
 							 FuDevice	*device,
 							 FwupdInstallFlags flags,
 							 GError		**error);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -751,7 +751,7 @@ fu_util_install_blob (FuUtilPrivate *priv, gchar **values, GError **error)
 }
 
 static gboolean
-fu_util_firmware_read (FuUtilPrivate *priv, gchar **values, GError **error)
+fu_util_firmware_dump (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(GBytes) blob_empty = g_bytes_new (NULL, 0);
@@ -800,7 +800,7 @@ fu_util_firmware_read (FuUtilPrivate *priv, gchar **values, GError **error)
 			  G_CALLBACK (fu_util_update_device_changed_cb), priv);
 
 	/* dump firmware */
-	blob_fw = fu_engine_firmware_read (priv->engine, device, priv->flags, error);
+	blob_fw = fu_engine_firmware_dump (priv->engine, device, priv->flags, error);
 	if (blob_fw == NULL)
 		return FALSE;
 	return fu_common_set_contents_bytes (values[0], blob_fw, error);
@@ -2601,11 +2601,11 @@ main (int argc, char *argv[])
 		     _("Update the stored metadata with current contents"),
 		     fu_util_verify_update);
 	fu_util_cmd_array_add (cmd_array,
-		     "firmware-read",
+		     "firmware-dump",
 		     "FILENAME [DEVICE-ID|GUID]",
 		     /* TRANSLATORS: command description */
 		     _("Read a firmware blob from a device"),
-		     fu_util_firmware_read);
+		     fu_util_firmware_dump);
 	fu_util_cmd_array_add (cmd_array,
 		     "firmware-convert",
 		     "FILENAME-SRC FILENAME-DST [FIRMWARE-TYPE-SRC] [FIRMWARE-TYPE-DST]",


### PR DESCRIPTION
Conceptually we were trying to stuff subtly different actions into one vfunc:

 * Read firmware from the device to update the verification checksums

 * Read a firmware blob from the device for debugging

For the first action we might want to mask out the sections of the flash with
serial numbers (so the verification hashes match the ones published on the LVFS)
and for the second we want just a raw ROM file from the hardware with no
pre-processing that we can compare against an external SPI dumper.

Split out ->dump_firmware to get the raw blob, and allow plugins to also
implement ->read_firmware() if they have to mask out specific offsets or remove
specific images from the FuFirmware container.

In the common case when masking is not required, fall back to using a 'binary'
FuFirmware automatically to make most plugins simpler.
