### PR TITLE
Allow to filter get-updates on device-id

### DIFF
--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -98,7 +98,7 @@ _fwupdmgr()
 	esac
 
 	case $command in
-	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update)
+	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update|get-updates)
 		if [[ "$prev" = "$command" ]]; then
 			_show_device_ids
 		else

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -109,7 +109,7 @@ _fwupdtool()
 			_show_modifiers
 		fi
 		;;
-	attach|detach|activate|verify-update|reinstall)
+	attach|detach|activate|verify-update|reinstall|get-updates)
 		if [[ "$prev" = "$command" ]]; then
 			_show_device_ids
 		#modifiers


### PR DESCRIPTION
This change allows to get available updates for a given device. This is
similar to what is done for the update and activate commands.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ X ] Feature
- [ ] Documentation
