### PR TITLE
Add a device flag for when a detach-less firmware dump is possible

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -201,6 +201,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "has-multiple-branches";
 	if (device_flag == FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL)
 		return "backup-before-install";
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME)
+		return "can-dump-runtime";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -303,6 +305,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES;
 	if (g_strcmp0 (device_flag, "backup-before-install") == 0)
 		return FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL;
+	if (g_strcmp0 (device_flag, "can-dump-runtime") == 0)
+		return FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -128,6 +128,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_SKIPS_RESTART:		Device relies upon activation or power cycle to load firmware
  * @FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES:	Device supports switching to a different stream of firmware
  * @FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL:	Device firmware should be saved before installing firmware
+ * @FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME:		Device can dump firmware from runtime without detaching
  *
  * The device flags.
  **/
@@ -173,6 +174,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_SKIPS_RESTART		(1llu << 38)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES	(1llu << 39)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL	(1llu << 40)	/* Since: 1.5.0 */
+#define FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME	(1llu << 41)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -103,6 +103,7 @@ fu_optionrom_device_init (FuOptionromDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
 				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -684,6 +684,7 @@ fu_vli_device_init (FuVliDevice *self)
 	priv->spi_auto_detect = TRUE;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NO_GUID_MATCHING);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME);
 }
 
 static void

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1081,6 +1081,10 @@ fu_util_device_flag_to_string (guint64 device_flag)
 		/* TRANSLATORS: save the old firmware to disk before installing the new one */
 		return _("Device will backup firmware before installing");
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_DUMP_RUNTIME) {
+		/* TRANSLATORS: the device can dump firmware from the normal runtime mode */
+		return _("Device can dump firmware in runtime mode");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_MD_SET_NAME) {
 		/* skip */
 		return NULL;


### PR DESCRIPTION
This would indicate to the use that the device is not going to 'go away' for a
few seconds and is better UX than just unconditionally detaching when it's not
actually required.
