### PR TITLE
trivial: Allow fwuptool to handle firmware that switches branch

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2711,7 +2711,8 @@ main (int argc, char *argv[])
 		/* set our implemented feature set */
 		fu_engine_request_set_feature_flags (priv->request,
 						     FWUPD_FEATURE_FLAG_DETACH_ACTION |
-						     FWUPD_FEATURE_FLAG_UPDATE_ACTION);
+						     FWUPD_FEATURE_FLAG_UPDATE_ACTION |
+						     FWUPD_FEATURE_FLAG_SWITCH_BRANCH);
 	}
 
 	/* get a list of the commands */


### PR DESCRIPTION
This allows testing the bcm57xx firmware with fwupdtool.