### PR TITLE
Do not auto-detach when dumping firmware

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1684,6 +1684,15 @@ dfu_device_dump_firmware (FuDevice *device, GError **error)
 {
 	DfuDevice *self = DFU_DEVICE (device);
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* require detach -> attach */
+	locker = fu_device_locker_new_full (device,
+					    (FuDeviceLockerFunc) fu_device_detach,
+					    (FuDeviceLockerFunc) fu_device_attach,
+					    error);
+	if (locker == NULL)
+		return NULL;
 
 	/* get data from hardware */
 	g_debug ("uploading from device->host");

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -422,6 +422,15 @@ fu_superio_it89_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
 	guint64 fwsize = fu_device_get_firmware_size_min (device);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* require detach -> attach */
+	locker = fu_device_locker_new_full (device,
+					    (FuDeviceLockerFunc) fu_device_detach,
+					    (FuDeviceLockerFunc) fu_device_attach,
+					    error);
+	if (locker == NULL)
+		return NULL;
 
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
 	return fu_superio_it89_device_read_addr (self, 0x0, fwsize,

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -367,6 +367,15 @@ static GBytes *
 fu_vli_pd_device_dump_firmware (FuDevice *device, GError **error)
 {
 	FuVliPdDevice *self = FU_VLI_PD_DEVICE (device);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* require detach -> attach */
+	locker = fu_device_locker_new_full (device,
+					    (FuDeviceLockerFunc) fu_device_detach,
+					    (FuDeviceLockerFunc) fu_device_attach,
+					    error);
+	if (locker == NULL)
+		return NULL;
 	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_READ);
 	return fu_vli_device_spi_read (FU_VLI_DEVICE (self), 0x0,
 				       fu_device_get_firmware_size_max (device),

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2761,28 +2761,14 @@ fu_engine_firmware_dump (FuEngine *self,
 			 GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GBytes) fw = NULL;
 
-	/* open, detach, read, attach, serialize */
+	/* open, read, close */
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL) {
 		g_prefix_error (error, "failed to open device for firmware read: ");
 		return NULL;
 	}
-	if (!fu_device_detach (device, error))
-		return NULL;
-	fw = fu_device_dump_firmware (device, error);
-	if (fw == NULL) {
-		g_autoptr(GError) error_local = NULL;
-		if (!fu_device_attach (device, &error_local)) {
-			g_warning ("failed to attach after read image failure: %s",
-				   error_local->message);
-		}
-		return NULL;
-	}
-	if (!fu_device_attach (device, error))
-		return NULL;
-	return g_steal_pointer (&fw);
+	return fu_device_dump_firmware (device, error);
 }
 
 gboolean


### PR DESCRIPTION
This allows us to handle this in the plugin, which might mean detaching the
*proxy* device. It's also very important as a few plugins reboot the device
in ->attach() to get the new firmware version, which isn't required for a dump.

This partially reverts a58510b2460e780f8488e399d83252290b7f97ce and does the
detach and attach in the few plugins where actually required.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
