### PR TITLE
libfwupd: Actually use the JCat file to select the metadata file

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -2802,6 +2802,10 @@ fwupd_client_refresh_remote_signature_cb (GObject *source,
 		return;
 	}
 	data->signature = g_steal_pointer (&bytes);
+	if (!fwupd_remote_load_signature_bytes (data->remote, data->signature, &error)) {
+		g_task_return_error (task, g_steal_pointer (&error));
+		return;
+	}
 
 	/* download metadata */
 	fwupd_client_download_bytes_async (self,

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2168,25 +2168,6 @@ fu_util_refresh_remote (FuUtilPrivate *priv, FwupdRemote *remote, GError **error
 	g_autoptr(GBytes) bytes_raw = NULL;
 	g_autoptr(GBytes) bytes_sig = NULL;
 
-	/* payload */
-	metadata_uri = fwupd_remote_get_metadata_uri (remote);
-	if (metadata_uri == NULL) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_NOTHING_TO_DO,
-			     "no metadata URI available for %s",
-			     fwupd_remote_get_id (remote));
-		return FALSE;
-	}
-	fn_raw = fu_util_get_user_cache_path (metadata_uri);
-	if (!fu_common_mkdir_parent (fn_raw, error))
-		return FALSE;
-	if (!fu_util_download_out_of_process (metadata_uri, fn_raw, error))
-		return FALSE;
-	bytes_raw = fu_common_get_contents_bytes (fn_raw, error);
-	if (bytes_raw == NULL)
-		return FALSE;
-
 	/* signature */
 	metadata_uri = fwupd_remote_get_metadata_uri_sig (remote);
 	if (metadata_uri == NULL) {
@@ -2198,10 +2179,31 @@ fu_util_refresh_remote (FuUtilPrivate *priv, FwupdRemote *remote, GError **error
 		return FALSE;
 	}
 	fn_sig = fu_util_get_user_cache_path (metadata_uri);
+	if (!fu_common_mkdir_parent (fn_sig, error))
+		return FALSE;
 	if (!fu_util_download_out_of_process (metadata_uri, fn_sig, error))
 		return FALSE;
 	bytes_sig = fu_common_get_contents_bytes (fn_sig, error);
 	if (bytes_sig == NULL)
+		return FALSE;
+	if (!fwupd_remote_load_signature_bytes (remote, bytes_sig, error))
+		return FALSE;
+
+	/* payload */
+	metadata_uri = fwupd_remote_get_metadata_uri (remote);
+	if (metadata_uri == NULL) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOTHING_TO_DO,
+			     "no metadata URI available for %s",
+			     fwupd_remote_get_id (remote));
+		return FALSE;
+	}
+	fn_raw = fu_util_get_user_cache_path (metadata_uri);
+	if (!fu_util_download_out_of_process (metadata_uri, fn_raw, error))
+		return FALSE;
+	bytes_raw = fu_common_get_contents_bytes (fn_raw, error);
+	if (bytes_raw == NULL)
 		return FALSE;
 
 	/* send to daemon */


### PR DESCRIPTION
This recent regression was caused when porting libfwupd to the async model.

Fixes https://github.com/fwupd/fwupd/issues/2360
