### PR TITLE
uefi: Make udisks2 errors more apparent

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -2325,7 +2325,7 @@ fu_common_get_esp_for_path (const gchar *esp_path, GError **error)
 		return NULL;
 	for (guint i = 0; i < volumes->len; i++) {
 		FuVolume *vol = g_ptr_array_index (volumes, i);
-		g_autofree gchar *vol_basename = g_path_get_basename (fu_volume_get_id (vol));
+		g_autofree gchar *vol_basename = g_path_get_basename (fu_volume_get_mount_point (vol));
 		if (g_strcmp0 (basename, vol_basename) == 0)
 			return g_object_ref (vol);
 	}


### PR DESCRIPTION
When support for dynamically mounting disks was added for https://github.com/fwupd/fwupd/commit/25ba41579fb170cf3a29cb2753733172a54984cd
udisks2 became a harder dependency and it was less obvious to users.

Create devices but show an error in why devices aren't updatable if
it's not found.

Users can still configure ESP manually in `uefi.conf`

Fixes: #2444

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
