### PR TITLE
bcm57xx: Improve reliability when flashing

### DIFF
--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -53,12 +53,12 @@ fu_bcm57xx_device_probe (FuUdevDevice *device, GError **error)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GPtrArray) ifaces = NULL;
 
-	/* only enumerate number 1 */
-	if (fu_udev_device_get_number (device) != 1) {
+	/* only enumerate number 0 */
+	if (fu_udev_device_get_number (device) != 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
-				     "only device 1 supported on multi-device card");
+				     "only device 0 supported on multi-device card");
 		return FALSE;
 	}
 

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -36,7 +36,7 @@
 #define REG_NVM_WRITE				0x7008
 
 /* offsets into BAR[2] */
-#define REG_APE_MODE				0x10000
+#define REG_APE_MODE				0x0
 
 typedef struct {
 	guint8	*buf;
@@ -418,21 +418,6 @@ fu_bcm57xx_recovery_device_activate (FuDevice *device, GError **error)
 {
 	BcmRegAPEMode mode = { 0 };
 	FuBcm57xxRecoveryDevice *self = FU_BCM57XX_RECOVERY_DEVICE (device);
-	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(FuDeviceLocker) locker2 = NULL;
-
-	locker = fu_device_locker_new_full (self,
-					    (FuDeviceLockerFunc) fu_bcm57xx_recovery_device_nvram_acquire_lock,
-					    (FuDeviceLockerFunc) fu_bcm57xx_recovery_device_nvram_release_lock,
-					    error);
-	if (locker == NULL)
-		return FALSE;
-	locker2 = fu_device_locker_new_full (self,
-					     (FuDeviceLockerFunc) fu_bcm57xx_recovery_device_nvram_enable,
-					     (FuDeviceLockerFunc) fu_bcm57xx_recovery_device_nvram_disable,
-					     error);
-	if (locker2 == NULL)
-		return FALSE;
 
 	/* halt */
 	mode.bits.Halt = 1;


### PR DESCRIPTION
- Use pci function 0 instead of 1 when flashing firmware.
  In certain situations, the BCM5719 NVM controller can lockup if
  a function other than 0 is used to read from NVM word-by-word like
  the kernel driver does.
- Fix APE_MODE offset in BAR[2] to enable proper resetting of the APE.
- Remove unnededed NVRam lock when resetting the APE.

Signed-off-by: Evan Lojewski <github@meklort.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
