### PR TITLE
fwupdtool: Enable the switch-branch client feature.

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2736,7 +2736,8 @@ main (int argc, char *argv[])
 		/* set our implemented feature set */
 		fu_engine_request_set_feature_flags (priv->request,
 						     FWUPD_FEATURE_FLAG_DETACH_ACTION |
-						     FWUPD_FEATURE_FLAG_UPDATE_ACTION);
+						     FWUPD_FEATURE_FLAG_UPDATE_ACTION |
+						     FWUPD_FEATURE_FLAG_SWITCH_BRANCH);
 	}
 
 	/* get a list of the commands */


### PR DESCRIPTION
This enabled fwupdtool to flash firmware with the switch-branch client feature requirement set.

Signed-off-by: Evan Lojewski <github@meklort.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
