### PR TITLE
Fix header names and remove check for <sys/errno.h>.

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -11,7 +11,7 @@
 #include <fcntl.h>
 #include <string.h>
 #ifdef HAVE_ERRNO_H
-#include <sys/errno.h>
+#include <errno.h>
 #endif
 #ifdef HAVE_IOCTL_H
 #include <sys/ioctl.h>

--- a/meson.build
+++ b/meson.build
@@ -254,7 +254,7 @@ endif
 if cc.has_header('sys/ioctl.h')
   conf.set('HAVE_IOCTL_H', '1')
 endif
-if cc.has_header('sys/errno.h')
+if cc.has_header('errno.h')
   conf.set('HAVE_ERRNO_H', '1')
 endif
 if cc.has_header('sys/socket.h')

--- a/src/fu-polkit-agent.c
+++ b/src/fu-polkit-agent.c
@@ -22,7 +22,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/wait.h>
 #include <glib.h>
 


### PR DESCRIPTION
- <sys/poll.h> should be <poll.h>
- <sys/errno.h> should be <errno.h>

In the case of <errno.h>, no other source file has guards for including
it, so their detection was removed.

---

There are a few weird defines, such as `HAVE_IOCTL_H`, which aren't used for all source files - some have `#ifdef`s to include `<sys/ioctl.h>`, others include it unconditionally. Should this be the case? I can make a PR to make it consistent, if desired.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
