### PR TITLE
trivial: fix shutdown error on fwupdtool activate

### DIFF
--- a/data/fwupd.shutdown.in
+++ b/data/fwupd.shutdown.in
@@ -4,4 +4,8 @@
 [ -f @localstatedir@/lib/fwupd/pending.db ] || exit 0
 
 # activate firmware when we have a read-only filesysten
-@bindir@/fwupdtool activate
+if !@bindir@/fwupdtool activate; then
+        ret=$?
+        [ "$ret" -eq "2" ] && exit 0
+        exit $ret
+fi


### PR DESCRIPTION
EXIT_NOTHING_TO_DO needs to be caught by the shutdown script too.
Fixes: #2463

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
