### PR TITLE
contrib: fwupd.spec : install tests only when enabled.

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -483,6 +483,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libdir}/pkgconfig/fwupd.pc
 %{_libdir}/pkgconfig/fwupdplugin.pc
 
+%if 0%{?enable_tests}
 %files tests
 %dir %{_datadir}/installed-tests/fwupd
 %{_datadir}/installed-tests/fwupd/fwupd-tests.xml
@@ -492,6 +493,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libexecdir}/installed-tests/fwupd/*
 %dir %{_sysconfdir}/fwupd/remotes.d
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/fwupd-tests.conf
+%endif
 
 %changelog
 * #LONGDATE# Richard Hughes <richard@hughsie.com> #VERSION#-0.#BUILD##ALPHATAG#


### PR DESCRIPTION
Install tests in the rpm package only when tests are enabled.

Signed-off-by: Tomas Winkler <tomas.winkler@intel.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
