### PR TITLE
Parse the HEX version before comparing for equality

### DIFF
--- a/libfwupdplugin/fu-common-version.c
+++ b/libfwupdplugin/fu-common-version.c
@@ -482,6 +482,13 @@ fu_common_vercmp_full (const gchar *version_a,
 {
 	if (fmt == FWUPD_VERSION_FORMAT_PLAIN)
 		return g_strcmp0 (version_a, version_b);
+	if (fmt == FWUPD_VERSION_FORMAT_HEX) {
+		g_autofree gchar *hex_a = NULL;
+		g_autofree gchar *hex_b = NULL;
+		hex_a = fu_common_version_parse_from_format (version_a, fmt);
+		hex_b = fu_common_version_parse_from_format (version_b, fmt);
+		return fu_common_vercmp (hex_a, hex_b);
+	}
 	return fu_common_vercmp (version_a, version_b);
 }
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1314,6 +1314,7 @@ fu_common_vercmp_func (void)
 	/* same */
 	g_assert_cmpint (fu_common_vercmp ("1.2.3", "1.2.3"), ==, 0);
 	g_assert_cmpint (fu_common_vercmp ("001.002.003", "001.002.003"), ==, 0);
+	g_assert_cmpint (fu_common_vercmp_full ("0x00000002", "0x2", FWUPD_VERSION_FORMAT_HEX), ==, 0);
 
 	/* upgrade and downgrade */
 	g_assert_cmpint (fu_common_vercmp ("1.2.3", "1.2.4"), <, 0);


### PR DESCRIPTION
This fixes the error: 'Update Error: device version not updated on success,
0x00000002 != 0x0002' -- it seems a bit crazy to have to specify 32 bits of
zero digits in the firmware.metainfo.xml
