### PR TITLE
trivial: Fix build error on build=standalone and polkit=true

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -11,7 +11,7 @@ daemon_dep = []
 if get_option('systemd')
   systemd_src += 'fu-systemd.c'
 endif
-if get_option('polkit')
+if build_daemon and get_option('polkit')
   client_src += 'fu-polkit-agent.c'
   daemon_dep += polkit
 endif


### PR DESCRIPTION
This fixes error introduced by 11b71f49787190a9924ad35dec33180b9d4f0081

ERROR: Unknown variable "polkit".

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ X ] Code fix
- [ ] Feature
- [ ] Documentation
