### PR TITLE
When compiled without PK require signed payloads for Install/Activate commands and root user for all other commands

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -606,11 +606,6 @@ fu_main_authorize_activate_cb (GObject *source, GAsyncResult *res, gpointer user
 		g_dbus_method_invocation_return_gerror (helper->invocation, error);
 		return;
 	}
-#else
-	if (!fu_main_authorization_is_trusted (helper->request, &error)) {
-		g_dbus_method_invocation_return_gerror (helper->invocation, error);
-		return;
-	}
 #endif /* HAVE_POLKIT */
 
 	/* authenticated */
@@ -708,11 +703,6 @@ fu_main_authorize_install_cb (GObject *source, GAsyncResult *res, gpointer user_
 	auth = polkit_authority_check_authorization_finish (POLKIT_AUTHORITY (source),
 							    res, &error);
 	if (!fu_main_authorization_is_valid (auth, &error)) {
-		g_dbus_method_invocation_return_gerror (helper->invocation, error);
-		return;
-	}
-#else
-	if (!fu_main_authorization_is_trusted (helper->request, &error)) {
 		g_dbus_method_invocation_return_gerror (helper->invocation, error);
 		return;
 	}

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -324,8 +324,13 @@ fu_engine_requirements_client_pass_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -465,8 +470,13 @@ fu_engine_requirements_child_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -560,8 +570,13 @@ fu_engine_requirements_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -617,8 +632,13 @@ fu_engine_requirements_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -664,8 +684,13 @@ fu_engine_requirements_device_plain_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -780,8 +805,13 @@ fu_engine_requirements_other_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -868,8 +898,13 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
 
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -936,8 +971,13 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert_false (ret);
+#endif
 }
 
 static void
@@ -1385,12 +1425,17 @@ fu_engine_downgrade_func (gconstpointer user_data)
 	fu_device_set_name (device, "Test Device");
 	fu_device_add_guid (device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
+#ifndef HAVE_POLKIT
+	g_test_expect_message ("FuEngine", G_LOG_LEVEL_WARNING, "*archive signature missing or not trusted");
+#endif
 	fu_engine_add_device (engine, device);
 	devices = fu_engine_get_devices (engine, &error);
 	g_assert_no_error (error);
 	g_assert (devices != NULL);
 	g_assert_cmpint (devices->len, ==, 1);
+#ifdef HAVE_POLKIT
 	g_assert (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_SUPPORTED));
+#endif
 	g_assert (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	/* get the releases for one device */
@@ -1398,9 +1443,16 @@ fu_engine_downgrade_func (gconstpointer user_data)
 					   request,
 					   fu_device_get_id (device),
 					   &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (releases != NULL);
 	g_assert_cmpint (releases->len, ==, 4);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert (releases == NULL);
+	g_test_skip ("Compiling without PK requires trusted payloads for tests");
+	return;
+#endif
 
 	/* no upgrades, as no firmware is approved */
 	releases_up = fu_engine_get_upgrades (engine,
@@ -1445,7 +1497,9 @@ fu_engine_downgrade_func (gconstpointer user_data)
 static void
 fu_engine_install_duration_func (gconstpointer user_data)
 {
+#ifdef HAVE_POLKIT
 	FwupdRelease *rel;
+#endif
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new ();
 	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
@@ -1495,23 +1549,32 @@ fu_engine_install_duration_func (gconstpointer user_data)
 	fu_device_add_guid (device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_set_install_duration (device, 999);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
+#ifndef HAVE_POLKIT
+	g_test_expect_message ("FuEngine", G_LOG_LEVEL_WARNING, "*archive signature missing or not trusted");
+#endif
 	fu_engine_add_device (engine, device);
 	devices = fu_engine_get_devices (engine, &error);
 	g_assert_no_error (error);
 	g_assert (devices != NULL);
 	g_assert_cmpint (devices->len, ==, 1);
+#ifdef HAVE_POLKIT
 	g_assert (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_SUPPORTED));
-
+#endif
 	/* check the release install duration */
 	releases = fu_engine_get_releases (engine,
 					   request,
 					   fu_device_get_id (device),
 					   &error);
+#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (releases != NULL);
 	g_assert_cmpint (releases->len, ==, 1);
 	rel = FWUPD_RELEASE (g_ptr_array_index (releases, 0));
 	g_assert_cmpint (fwupd_release_get_install_duration (rel), ==, 120);
+#else
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
+	g_assert (releases == NULL);
+#endif
 }
 
 static void
@@ -2917,7 +2980,13 @@ fu_plugin_composite_func (gconstpointer user_data)
 			g_ptr_array_add (install_tasks, g_steal_pointer (&task));
 		}
 	}
+#ifdef HAVE_POLKIT
 	g_assert_cmpint (install_tasks->len, ==, 3);
+#else
+	g_assert_cmpint (install_tasks->len, ==, 0);
+	g_test_skip ("Compiling without PK support requires signed payloads");
+	return;
+#endif
 
 	/* install the cab */
 	ret = fu_engine_install_tasks (engine,


### PR DESCRIPTION
This can allow running daemon as a specific user and let client run as that same specific user and be considered the trusted user to communicate with the daemon.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
