### PR TITLE
Show an error when a plugin is missing dependencies (Fixes: #1526)

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -339,6 +339,8 @@ fwupd_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		return "esp-not-found";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_LEGACY_BIOS)
 		return "legacy-bios";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_FAILED_OPEN)
+		return "failed-open";
 	if (plugin_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -377,6 +379,8 @@ fwupd_plugin_flag_from_string (const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND;
 	if (g_strcmp0 (plugin_flag, "legacy-bios") == 0)
 		return FWUPD_PLUGIN_FLAG_LEGACY_BIOS;
+	if (g_strcmp0 (plugin_flag, "failed-open") == 0)
+		return FWUPD_PLUGIN_FLAG_FAILED_OPEN;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -232,6 +232,7 @@ typedef enum {
  * @FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED:	The efivar filesystem is not found
  * @FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND:		The EFI ESP not found
  * @FWUPD_PLUGIN_FLAG_LEGACY_BIOS:		System running in legacy CSM mode
+ * @FWUPD_PLUGIN_FLAG_FAILED_OPEN:		Failed to open plugin (missing dependency)
  *
  * The plugin flags.
  **/
@@ -245,6 +246,7 @@ typedef enum {
 #define FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED	(1u << 6)	/* Since: 1.5.0 */
 #define FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND		(1u << 7)	/* Since: 1.5.0 */
 #define FWUPD_PLUGIN_FLAG_LEGACY_BIOS		(1u << 8)	/* Since: 1.5.0 */
+#define FWUPD_PLUGIN_FLAG_FAILED_OPEN		(1u << 9)	/* Since: 1.5.0 */
 #define FWUPD_PLUGIN_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 1.5.0 */
 typedef guint64 FwupdPluginFlags;
 

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -431,6 +431,8 @@ fu_plugin_open (FuPlugin *self, const gchar *filename, GError **error)
 			     G_IO_ERROR_FAILED,
 			     "failed to open plugin %s: %s",
 			     filename, g_module_error ());
+		fu_plugin_add_flag (self, FWUPD_PLUGIN_FLAG_FAILED_OPEN);
+		fu_plugin_add_flag (self, FWUPD_PLUGIN_FLAG_USER_WARNING);
 		return FALSE;
 	}
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5933,6 +5933,7 @@ fu_engine_load_plugins (FuEngine *self, GError **error)
 		if (self->usb_ctx != NULL) {
 			if (!fu_plugin_open (plugin, filename, &error_local)) {
 				g_warning ("cannot load: %s", error_local->message);
+				fu_engine_add_plugin (self, plugin);
 				continue;
 			}
 		}

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1345,6 +1345,10 @@ fu_util_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		/* TRANSLATORS: partition refers to something on disk, again, hey Arch users */
 		return _("UEFI ESP partition not detected or configured");
 	}
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_FAILED_OPEN) {
+		/* TRANSLATORS: Failed to open plugin, hey Arch users */
+		return _("Plugin dependencies missing");
+	}
 
 	/* fall back for unknown types */
 	return fwupd_plugin_flag_to_string (plugin_flag);


### PR DESCRIPTION
```
$ sudo mv /usr/lib/x86_64-linux-gnu/libtss2-esys.so.0.0.0 /usr/lib/x86_64-linux-gnu/libtss2-esys.so.0.0.0.renamed
$ sudo fwupdtool get-devices --plugins=uefi
14:15:48:0735 FuEngine             cannot load: failed to open plugin /usr/local/lib/x86_64-linux-gnu/fwupd-plugins-3/libfu_plugin_uefi.so: libtss2-esys.so.0: cannot open shared object file: No such file or directory
Loading…                 [-                                      ]14:15:48:0753 FuEngine             failed to update history database: device ID b6c08fb9e5384d9d101853cc1ca20cf0ce2df2e2 was not found
Loading…                 [***************************************]
WARNING: Plugin depdendencies missing
No detected devices
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
