### PR TITLE
Add fu_byte_array_set_size()

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -2001,6 +2001,24 @@ fu_byte_array_append_uint32 (GByteArray *array, guint32 data, FuEndianType endia
 }
 
 /**
+ * fu_byte_array_set_size:
+ * @array: a #GByteArray
+ * @length:  the new size of the GByteArray
+ *
+ * Sets the size of the GByteArray, expanding it with NULs if necessary.
+ *
+ * Since: 1.5.0
+ **/
+void
+fu_byte_array_set_size (GByteArray *array, guint length)
+{
+	guint oldlength = array->len;
+	g_byte_array_set_size (array, length);
+	if (length > oldlength)
+		memset (array->data + oldlength, 0x0, length - oldlength);
+}
+
+/**
  * fu_common_kernel_locked_down:
  *
  * Determines if kernel lockdown in effect

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -182,6 +182,8 @@ gboolean	 fu_common_read_uint32_safe	(const guint8	*buf,
 						 FuEndianType	 endian,
 						 GError		**error);
 
+void		 fu_byte_array_set_size		(GByteArray	*array,
+						 guint		 length);
 void		 fu_byte_array_append_uint8	(GByteArray	*array,
 						 guint8		 data);
 void		 fu_byte_array_append_uint16	(GByteArray	*array,

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -108,6 +108,24 @@ fu_archive_cab_func (void)
 }
 
 static void
+fu_common_byte_array_func (void)
+{
+	g_autoptr(GByteArray) array = g_byte_array_new ();
+
+	fu_byte_array_append_uint8 (array, (guint8) 'h');
+	fu_byte_array_append_uint8 (array, (guint8) 'e');
+	fu_byte_array_append_uint8 (array, (guint8) 'l');
+	fu_byte_array_append_uint8 (array, (guint8) 'l');
+	fu_byte_array_append_uint8 (array, (guint8) 'o');
+	g_assert_cmpint (array->len, ==, 5);
+	g_assert_cmpint (memcmp (array->data, "hello", array->len), ==, 0);
+
+	fu_byte_array_set_size (array, 10);
+	g_assert_cmpint (array->len, ==, 10);
+	g_assert_cmpint (memcmp (array->data, "hello\0\0\0\0\0", array->len), ==, 0);
+}
+
+static void
 fu_common_crc_func (void)
 {
 	guint8 buf[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
@@ -2078,6 +2096,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/plugin{quirks-performance}", fu_plugin_quirks_performance_func);
 	g_test_add_func ("/fwupd/plugin{quirks-device}", fu_plugin_quirks_device_func);
 	g_test_add_func ("/fwupd/chunk", fu_chunk_func);
+	g_test_add_func ("/fwupd/common{byte-array}", fu_common_byte_array_func);
 	g_test_add_func ("/fwupd/common{crc}", fu_common_crc_func);
 	g_test_add_func ("/fwupd/common{string-append-kv}", fu_common_string_append_kv_func);
 	g_test_add_func ("/fwupd/common{version-guess-format}", fu_common_version_guess_format_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -618,6 +618,7 @@ LIBFWUPDPLUGIN_1.4.7 {
 
 LIBFWUPDPLUGIN_1.5.0 {
   global:
+    fu_byte_array_set_size;
     fu_common_cpuid;
     fu_common_crc16;
     fu_common_crc32;

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -102,7 +102,7 @@ goodixmoc_device_cmd_recv (GUsbDevice  *usbdevice,
 	*/
 	while (1) {
 		g_autoptr(GByteArray) reply = g_byte_array_new ();
-		g_byte_array_set_size (reply, GX_FLASH_TRANSFER_BLOCK_SIZE);
+		fu_byte_array_set_size (reply, GX_FLASH_TRANSFER_BLOCK_SIZE);
 		if (!g_usb_device_bulk_transfer (usbdevice,
 						 GX_USB_BULK_EP_IN,
 						 reply->data,

--- a/plugins/synaptics-prometheus/fu-synaprom-common.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-common.c
@@ -41,7 +41,7 @@ GByteArray *
 fu_synaprom_reply_new (gsize cmdlen)
 {
 	GByteArray *blob = g_byte_array_new ();
-	g_byte_array_set_size (blob, cmdlen);
+	fu_byte_array_set_size (blob, cmdlen);
 	return blob;
 }
 

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -403,7 +403,7 @@ fu_synaptics_rmi_firmware_generate_v0x (void)
 	GByteArray *buf = g_byte_array_new ();
 
 	/* create empty block */
-	g_byte_array_set_size (buf, RMI_IMG_FW_OFFSET + 0x4 + 0x4);
+	fu_byte_array_set_size (buf, RMI_IMG_FW_OFFSET + 0x4 + 0x4);
 	buf->data[RMI_IMG_IO_OFFSET] = 0x0;			/* no build_id or package_id */
 	buf->data[RMI_IMG_BOOTLOADER_VERSION_OFFSET] = 0x2;	/* not hierarchical */
 	memcpy (buf->data + RMI_IMG_PRODUCT_ID_OFFSET, "Example", 7);
@@ -436,7 +436,7 @@ fu_synaptics_rmi_firmware_generate_v10 (void)
 	};
 
 	/* create empty block */
-	g_byte_array_set_size (buf, RMI_IMG_FW_OFFSET + 0x48);
+	fu_byte_array_set_size (buf, RMI_IMG_FW_OFFSET + 0x48);
 	buf->data[RMI_IMG_IO_OFFSET] = 0x1;
 	buf->data[RMI_IMG_BOOTLOADER_VERSION_OFFSET] = 16;	/* hierarchical */
 	memcpy (buf->data + RMI_IMG_PRODUCT_ID_OFFSET, "Example", 7);


### PR DESCRIPTION
The GLib g_byte_array_set_size() function does not zero the contents if the
array size is larger, which leads to unpredictable output when using valgrind.
