### PR TITLE
trivial: match all elan devices in quirk

### DIFF
--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -1,12 +1,4 @@
-[DeviceInstanceId=HIDRAW\VEN_04F3&DEV_3010]
-Plugin = elantp
-GType = FuElantpHidDevice
-
-[DeviceInstanceId=HIDRAW\VEN_04F3&DEV_30C5]
-Plugin = elantp
-GType = FuElantpHidDevice
-
-[DeviceInstanceId=HIDRAW\VEN_04F3&DEV_314F]
+[DeviceInstanceId=HIDRAW\VEN_04F3]
 Plugin = elantp
 GType = FuElantpHidDevice
 

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -53,6 +53,16 @@ fu_elantp_hid_device_probe (FuUdevDevice *device, GError **error)
 		return FALSE;
 	}
 
+	/* i2c-hid */
+	if (fu_udev_device_get_model (device) < 0x3000 ||
+	    fu_udev_device_get_model (device) >= 0x4000) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "not i2c-hid touchpad");
+		return FALSE;
+	}
+
 	/* set the physical ID */
 	return fu_udev_device_set_physical_id (device, "hid", error);
 }

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -231,7 +231,7 @@ fu_elantp_i2c_device_setup (FuDevice *device, GError **error)
 	}
 	instance_id_ic_type = g_strdup_printf ("ELANTP\\ICTYPE_%02X", ic_type);
 	fu_device_add_instance_id (device, instance_id_ic_type);
-	
+
 	/* define the extra instance IDs (ic_type + module_id) */
 	instance_id2 = g_strdup_printf ("ELANTP\\ICTYPE_%02X&MOD_%04X",
 					ic_type, self->module_id);
@@ -340,8 +340,8 @@ fu_elantp_i2c_device_write_firmware (FuDevice *device,
 		g_autofree guint8 *blk = g_malloc0 (blksz);
 
 		/* write block */
-		blk[0] = ETP_I2C_IAP_REG_L; 
-		blk[1] = ETP_I2C_IAP_REG_H; 
+		blk[0] = ETP_I2C_IAP_REG_L;
+		blk[1] = ETP_I2C_IAP_REG_H;
 		if (!fu_memcpy_safe (blk, blksz, 0x2,			/* dst */
 				     chk->data, chk->data_sz, 0x0,	/* src */
 				     chk->data_sz, error))
@@ -428,7 +428,7 @@ fu_elantp_i2c_device_detach (FuDevice *device, GError **error)
 	} else {
 		ic_type = (tmp >> 8) & 0xFF;
 	}
-	
+
 	/* get IAP firmware version */
 	if (!fu_elantp_i2c_device_read_cmd (self,
 					    self->pattern == 0 ? ETP_CMD_I2C_IAP_VERSION : ETP_CMD_I2C_IAP_VERSION_2,
@@ -470,7 +470,6 @@ fu_elantp_i2c_device_detach (FuDevice *device, GError **error)
 						     "failed to set IAP type");
 				return FALSE;
 			}
-			
 		}
 	}
 	if (!fu_elantp_i2c_device_write_cmd (self,


### PR DESCRIPTION
Here's what I had in mind.  Untested:

In probe routine, check whether they are actually i2c-hid touchpad
by looking at pid.

fixes #2494

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
