### PR TITLE
fu-engine: Set a device when checking requirements for fu_engine_get_…

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3721,7 +3721,7 @@ fu_engine_get_result_from_component (FuEngine *self,
 	}
 
 	/* check we can install it */
-	task = fu_install_task_new (NULL, component);
+	task = fu_install_task_new (dev, component);
 	if (!fu_engine_check_requirements (self, request, task,
 					   FWUPD_INSTALL_FLAG_NONE,
 					   error))


### PR DESCRIPTION
…result_from_component

The trust flags are only checked if check_requirements is called, which
only happens when a device has been set.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
