### PR TITLE
elantp: Modify the correct input for the iap reg.

### DIFF
--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -2,6 +2,10 @@
 Plugin = elantp
 GType = FuElantpHidDevice
 
+# ThinkPad X1 Carbon Gen 9
+[HwId=6c87726f-b545-549e-840a-189422ea21d0]
+Flags = elantp-recovery
+
 # Lenovo X1 Nano Gen1
 [HwId=4c20262a-aee0-5d6e-ba72-6d29b23fe350]
 Flags = elantp-recovery

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -426,7 +426,7 @@ fu_elantp_hid_device_detach (FuDevice *device, GError **error)
 			
 			if (!fu_elantp_hid_device_write_cmd (self,
 							     ETP_CMD_I2C_IAP_TYPE,
-							     self->fw_page_size,
+							     self->fw_page_size / 2,
 							     error))
 				return FALSE;
 			if (!fu_elantp_hid_device_read_cmd (self, ETP_CMD_I2C_IAP_TYPE,
@@ -435,7 +435,7 @@ fu_elantp_hid_device_detach (FuDevice *device, GError **error)
 				return FALSE;
 			}
 			self->iap_type = fu_common_read_uint16 (buf, G_LITTLE_ENDIAN);
-			if (self->iap_type != self->fw_page_size) {
+			if (self->iap_type != self->fw_page_size / 2) {
 				g_set_error_literal (error,
 						     FWUPD_ERROR,
 						     FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -454,7 +454,7 @@ fu_elantp_i2c_device_detach (FuDevice *device, GError **error)
 			/* set the IAP type, presumably some kind of ABI */
 			if (!fu_elantp_i2c_device_write_cmd (self,
 							     ETP_CMD_I2C_IAP_TYPE,
-							     self->fw_page_size ,
+							     self->fw_page_size / 2,
 							     error))
 				return FALSE;
 			if (!fu_elantp_i2c_device_read_cmd (self, ETP_CMD_I2C_IAP_TYPE ,
@@ -463,7 +463,7 @@ fu_elantp_i2c_device_detach (FuDevice *device, GError **error)
 				return FALSE;
 			}
 			self->iap_type = fu_common_read_uint16 (buf, G_LITTLE_ENDIAN);
-			if (self->iap_type != self->fw_page_size) {
+			if (self->iap_type != self->fw_page_size / 2) {
 				g_set_error_literal (error,
 						     FWUPD_ERROR,
 						     FWUPD_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
1. Modify the correct input for the iap reg (byte -> word).
2. Add new HWID for ThinkPad X1 Carbon Gen 9.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
