### PR TITLE
trivial: Split check for signed metadata when no polkit

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1441,6 +1441,21 @@ fu_engine_check_requirement (FuEngine *self,
 }
 
 gboolean
+fu_engine_check_trust (FuInstallTask *task, GError **error)
+{
+#ifndef HAVE_POLKIT
+	if ((fu_install_task_get_trust_flags (task) & FWUPD_TRUST_FLAG_PAYLOAD) == 0) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INVALID_FILE,
+				     "archive signature missing or not trusted");
+		return FALSE;
+	}
+#endif
+	return TRUE;
+}
+
+gboolean
 fu_engine_check_requirements (FuEngine *self,
 			      FuEngineRequest *request,
 			      FuInstallTask *task,
@@ -1471,16 +1486,6 @@ fu_engine_check_requirements (FuEngine *self,
 			g_propagate_error (error, g_steal_pointer (&error_local));
 			return FALSE;
 	}
-
-#ifndef HAVE_POLKIT
-	if ((fu_install_task_get_trust_flags (task) & FWUPD_TRUST_FLAG_PAYLOAD) == 0) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_INVALID_FILE,
-				     "archive signature missing or not trusted");
-		return FALSE;
-	}
-#endif
 
 	return TRUE;
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3726,7 +3726,7 @@ fu_engine_get_result_from_component (FuEngine *self,
 	}
 
 	/* check we can install it */
-	task = fu_install_task_new (dev, component);
+	task = fu_install_task_new (NULL, component);
 	if (!fu_engine_check_requirements (self, request, task,
 					   FWUPD_INSTALL_FLAG_NONE,
 					   error))

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -194,6 +194,8 @@ void		 fu_engine_add_plugin			(FuEngine	*self,
 void		 fu_engine_add_runtime_version		(FuEngine	*self,
 							 const gchar	*component_id,
 							 const gchar	*version);
+gboolean	 fu_engine_check_trust			(FuInstallTask	*task,
+							 GError		**error);
 gboolean	 fu_engine_check_requirements		(FuEngine	*self,
 							 FuEngineRequest *request,
 							 FuInstallTask	*task,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -902,6 +902,10 @@ fu_main_install_with_helper (FuMainAuthHelper *helper_ref, GError **error)
 				g_ptr_array_add (errors, g_steal_pointer (&error_local));
 				continue;
 			}
+			if (!fu_engine_check_trust (task, &error_local)) {
+				g_ptr_array_add (errors, g_steal_pointer (&error_local));
+				continue;
+			}
 
 			/* if component should have an update message from CAB */
 			fu_device_incorporate_from_component (device, component);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -324,13 +324,8 @@ fu_engine_requirements_client_pass_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -470,13 +465,8 @@ fu_engine_requirements_child_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -570,13 +560,8 @@ fu_engine_requirements_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -632,13 +617,8 @@ fu_engine_requirements_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -684,13 +664,8 @@ fu_engine_requirements_device_plain_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -805,13 +780,8 @@ fu_engine_requirements_other_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -898,13 +868,8 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
 
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -971,13 +936,8 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 	ret = fu_engine_check_requirements (engine, request, task,
 					    FWUPD_INSTALL_FLAG_NONE,
 					    &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (ret);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert_false (ret);
-#endif
 }
 
 static void
@@ -1443,16 +1403,9 @@ fu_engine_downgrade_func (gconstpointer user_data)
 					   request,
 					   fu_device_get_id (device),
 					   &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (releases != NULL);
 	g_assert_cmpint (releases->len, ==, 4);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert (releases == NULL);
-	g_test_skip ("Compiling without PK requires trusted payloads for tests");
-	return;
-#endif
 
 	/* no upgrades, as no firmware is approved */
 	releases_up = fu_engine_get_upgrades (engine,
@@ -1497,9 +1450,7 @@ fu_engine_downgrade_func (gconstpointer user_data)
 static void
 fu_engine_install_duration_func (gconstpointer user_data)
 {
-#ifdef HAVE_POLKIT
 	FwupdRelease *rel;
-#endif
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new ();
 	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
@@ -1565,16 +1516,11 @@ fu_engine_install_duration_func (gconstpointer user_data)
 					   request,
 					   fu_device_get_id (device),
 					   &error);
-#ifdef HAVE_POLKIT
 	g_assert_no_error (error);
 	g_assert (releases != NULL);
 	g_assert_cmpint (releases->len, ==, 1);
 	rel = FWUPD_RELEASE (g_ptr_array_index (releases, 0));
 	g_assert_cmpint (fwupd_release_get_install_duration (rel), ==, 120);
-#else
-	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert (releases == NULL);
-#endif
 }
 
 static void
@@ -2980,13 +2926,7 @@ fu_plugin_composite_func (gconstpointer user_data)
 			g_ptr_array_add (install_tasks, g_steal_pointer (&task));
 		}
 	}
-#ifdef HAVE_POLKIT
 	g_assert_cmpint (install_tasks->len, ==, 3);
-#else
-	g_assert_cmpint (install_tasks->len, ==, 0);
-	g_test_skip ("Compiling without PK support requires signed payloads");
-	return;
-#endif
 
 	/* install the cab */
 	ret = fu_engine_install_tasks (engine,


### PR DESCRIPTION
Checking this requirement at daemon startup meant that trust was
evaluated before releases could actually be checked.

It's only important to check at install time.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
