### PR TITLE
Fix regression when filtering different priorities

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -678,7 +678,7 @@ fu_device_list_add (FuDeviceList *self, FuDevice *device)
 
 	/* is the device waiting to be replugged? */
 	item = fu_device_list_find_by_id (self, fu_device_get_id (device), NULL);
-	if (item != NULL) {
+	if (item != NULL && item->remove_id != 0) {
 		g_debug ("found existing device %s, reusing item",
 			 fu_device_get_id (item->device));
 		fu_device_list_replace (self, item, device);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2035,18 +2035,23 @@ fu_device_list_delay_func (gconstpointer user_data)
 	g_assert_cmpint (changed_cnt, ==, 0);
 
 	/* add the same device again */
+	g_test_expect_message ("FuDeviceList", G_LOG_LEVEL_WARNING,
+			       "ignoring device*existing device*already exists");
 	fu_device_list_add (device_list, device1);
 	g_assert_cmpint (added_cnt, ==, 1);
 	g_assert_cmpint (removed_cnt, ==, 0);
-	g_assert_cmpint (changed_cnt, ==, 1);
+	g_assert_cmpint (changed_cnt, ==, 0);
 
-	/* add a device with the same ID */
+	/* remove device */
+	fu_device_list_remove (device_list, device1);
+
+	/* add a different device with the same ID */
 	fu_device_set_id (device2, "device1");
 	fu_device_list_add (device_list, device2);
 	fu_device_set_remove_delay (device2, 100);
 	g_assert_cmpint (added_cnt, ==, 1);
 	g_assert_cmpint (removed_cnt, ==, 0);
-	g_assert_cmpint (changed_cnt, ==, 2);
+	g_assert_cmpint (changed_cnt, ==, 1);
 
 	/* spin a bit */
 	fu_test_loop_run_with_timeout (10);


### PR DESCRIPTION
We need to check if the device is in the remove timeout before unconditionally
replacing a device on insert.

Fixes https://github.com/fwupd/fwupd/issues/2510
