### PR TITLE
Fix probe warning for the Logitech Unifying device

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -28,3 +28,5 @@ void		 fu_device_incorporate_from_component	(FuDevice	*device,
 void		 fu_device_convert_instance_ids		(FuDevice	*self);
 gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 GPtrArray	*fu_device_get_possible_plugins		(FuDevice	*self);
+void		 fu_device_add_possible_plugin		(FuDevice	*self,
+							 const gchar	*plugin);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -169,12 +169,22 @@ fu_device_get_possible_plugins (FuDevice *self)
  * Adds a plugin name to the list of plugins that *might* be able to handle this
  * device. This is tyically called from a quirk handler.
  *
- * Since: 1.3.3
+ * Duplicate plugin names are ignored.
+ *
+ * Since: 1.5.1
  **/
-static void
+void
 fu_device_add_possible_plugin (FuDevice *self, const gchar *plugin)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
+
+	g_return_if_fail (FU_IS_DEVICE (self));
+	g_return_if_fail (plugin != NULL);
+
+	/* add if it does not already exist */
+	if (g_ptr_array_find_with_equal_func (priv->possible_plugins, plugin,
+					      g_str_equal, NULL))
+		return;
 	g_ptr_array_add (priv->possible_plugins, g_strdup (plugin));
 }
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1066,6 +1066,19 @@ fu_device_poll_func (void)
 }
 
 static void
+fu_device_func (void)
+{
+	g_autoptr(FuDevice) device = fu_device_new ();
+	g_autoptr(GPtrArray) possible_plugins = NULL;
+
+	/* only add one plugin name of the same type */
+	fu_device_add_possible_plugin (device, "test");
+	fu_device_add_possible_plugin (device, "test");
+	possible_plugins = fu_device_get_possible_plugins (device);
+	g_assert_cmpint (possible_plugins->len, ==, 1);
+}
+
+static void
 fu_device_flags_func (void)
 {
 	g_autoptr(FuDevice) device = fu_device_new ();
@@ -2138,6 +2151,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/firmware{dfu}", fu_firmware_dfu_func);
 	g_test_add_func ("/fwupd/archive{invalid}", fu_archive_invalid_func);
 	g_test_add_func ("/fwupd/archive{cab}", fu_archive_cab_func);
+	g_test_add_func ("/fwupd/device", fu_device_func);
 	g_test_add_func ("/fwupd/device{flags}", fu_device_flags_func);
 	g_test_add_func ("/fwupd/device{parent}", fu_device_parent_func);
 	g_test_add_func ("/fwupd/device{incorporate}", fu_device_incorporate_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -672,6 +672,7 @@ LIBFWUPDPLUGIN_1.5.0 {
 
 LIBFWUPDPLUGIN_1.5.1 {
   global:
+    fu_device_add_possible_plugin;
     fu_efivar_space_used;
   local: *;
 } LIBFWUPDPLUGIN_1.5.0;


### PR DESCRIPTION
The same plugin name was being added to the device from the quirk file more than
once, and so we enumerated the device *again* and tried to add a duplicate
device -- the device list correctly refusing to do so.

Check the plugin name does not already exist before adding it, and add a self
test to catch this for the future.
