### PR TITLE
contrib/ci: switch TPM simulator from ibmswtpm to swtpm

### DIFF
--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -19,8 +19,8 @@ popd
 chown nobody . -R
 
 # install and run TPM simulator necessary for plugins/uefi/uefi-self-test
-pacman -S --noconfirm ibm-sw-tpm2 tpm2-tools
-tpm_server &
+pacman -S --noconfirm swtpm tpm2-tools
+swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &
 trap "kill $!" EXIT
 # extend a PCR0 value for test suite
 sleep 2


### PR DESCRIPTION
Upstream tpm2-tss [is moving](https://github.com/tpm2-software/tpm2-tss/pull/1542#issue-334294643) from [ibmswtpm](http://ibmswtpm.sourceforge.net/) to [swtpm](https://github.com/stefanberger/swtpm) as the default TPM simulator. ibmswtpm still works fine and will be kept around for the foreseeable future, but adapt to the upstream decision in case ibmswtpm should ever get dropped from the official Arch Linux repositories (currently there are no plans to do so).

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation