### PR TITLE
thunderbolt: recognize authorized value of '2' as well

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -137,7 +137,7 @@ fu_thunderbolt_device_check_authorized (FuThunderboltDevice *self, GError **erro
 			     g_strerror (errno));
 		return FALSE;
 	}
-	if (status == 1)
+	if (status == 1 || status == 2)
 		fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	else
 		update_error = "Not authorized";


### PR DESCRIPTION
This means that the user performed a challenge to authorize the
device.
Fixes: #2526

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
