### PR TITLE
Show a less scary fwupdate output for devices without info

### DIFF
--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -257,11 +257,19 @@ main (int argc, char *argv[])
 
 			/* load any existing update info */
 			info = fu_uefi_device_load_update_info (dev, &error_local);
+			g_print ("Information for the update status entry %u:\n", i);
 			if (info == NULL) {
-				g_printerr ("failed: %s\n", error_local->message);
+				if (g_error_matches (error_local,
+						     G_IO_ERROR,
+						     G_IO_ERROR_NOT_FOUND)) {
+					g_print ("  Firmware GUID: {%s}\n",
+						 fu_uefi_device_get_guid (dev));
+					g_print ("  Update Status: No update info found\n\n");
+				} else {
+					g_printerr ("Failed: %s\n\n", error_local->message);
+				}
 				continue;
 			}
-			g_print ("Information for the update status entry %u:\n", i);
 			g_print ("  Information Version: %" G_GUINT32_FORMAT "\n",
 				 fu_uefi_update_info_get_version (info));
 			g_print ("  Firmware GUID: {%s}\n",


### PR DESCRIPTION
Before:

    Information for the update status entry 0:
      Information Version: 7
      Firmware GUID: {ddc0ee61-e7f0-4e7d-acc5-c070a398838e}
      Capsule Flags: 0x00000000x
      Hardware Instance: 0
      Update Status: attempted
      Capsule File Path: /EFI/fedora/fw/fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e.cap

    failed: Error opening file /sys/firmware/efi/efivars/fwupd-671d19d0-43c-
    4852-98d9-1ce16f9967e4-0-0abba7dc-e516-4167-bbf5-4d9d1c739416: No such file
    or directory
    failed: Error opening file /sys/firmware/efi/efivars/fwupd-a9971959-9246-
    4a5b-b2f2-ba6fdcb19349-0-0abba7dc-e516-4167-bbf5-4d9d1c739416: No such file
    or directory

After:

    Information for the update status entry 0:
      Information Version: 7
      Firmware GUID: {ddc0ee61-e7f0-4e7d-acc5-c070a398838e}
      Capsule Flags: 0x00000000x
      Hardware Instance: 0
      Update Status: attempted
      Capsule File Path: /EFI/fedora/fw/fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e.cap

    Information for the update status entry 1:
      Firmware GUID: {671d19d0-d43c-4852-98d9-1ce16f9967e4}
      Update Status: No update info found

    Information for the update status entry 2:
      Firmware GUID: {a9971959-9246-4a5b-b2f2-ba6fdcb19349}
      Update Status: No update info found

Fixes https://github.com/fwupd/fwupd/issues/2530
