### PR TITLE
uefi: a new option for uefi configuration to use UEFI removable path

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -241,7 +241,7 @@ fu_plugin_uefi_write_splash_data (FuPlugin *plugin,
 
 	/* save to a predicatable filename */
 	esp_path = fu_volume_get_mount_point (data->esp);
-	directory = fu_uefi_get_esp_path_for_os (esp_path);
+	directory = fu_uefi_get_esp_path_for_os (device, esp_path);
 	basename = g_strdup_printf ("fwupd-%s.cap", FU_EFIVAR_GUID_UX_CAPSULE);
 	fn = g_build_filename (directory, "fw", basename, NULL);
 	if (!fu_common_mkdir_parent (fn, error))
@@ -425,6 +425,7 @@ static void
 fu_plugin_uefi_load_config (FuPlugin *plugin, FuDevice *device)
 {
 	gboolean disable_shim;
+	gboolean fallback_removable_path;
 	guint64 sz_reqd = FU_UEFI_COMMON_REQUIRED_ESP_FREE_SPACE;
 	g_autofree gchar *require_esp_free_space = NULL;
 
@@ -439,6 +440,12 @@ fu_plugin_uefi_load_config (FuPlugin *plugin, FuDevice *device)
 	fu_device_set_metadata_boolean (device,
 					"RequireShimForSecureBoot",
 					!disable_shim);
+
+	/* check if using UEFI removeable path */
+	fallback_removable_path = fu_plugin_get_config_value_boolean (plugin, "FallbacktoRemovablePath");
+	fu_device_set_metadata_boolean (device,
+					"FallbacktoRemovablePath",
+					fallback_removable_path);
 }
 
 static void

--- a/plugins/uefi/fu-uefi-bootmgr.h
+++ b/plugins/uefi/fu-uefi-bootmgr.h
@@ -10,6 +10,8 @@
 #include <glib.h>
 #include <efivar.h>
 
+#include "fu-device.h"
+
 typedef enum {
 	FU_UEFI_BOOTMGR_FLAG_NONE		= 0,
 	FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB	= 1 << 0,
@@ -17,7 +19,8 @@ typedef enum {
 	FU_UEFI_BOOTMGR_FLAG_LAST
 } FuUefiBootmgrFlags;
 
-gboolean	 fu_uefi_bootmgr_bootnext	(const gchar		*esp_path,
+gboolean	 fu_uefi_bootmgr_bootnext	(FuDevice 		*device,
+						 const gchar		*esp_path,
 						 const gchar		*description,
 						 FuUefiBootmgrFlags	 flags,
 						 GError			**error);

--- a/plugins/uefi/fu-uefi-common.h
+++ b/plugins/uefi/fu-uefi-common.h
@@ -11,6 +11,8 @@
 
 #include "fwupd-common.h"
 
+#include "fu-device.h"
+
 #define EFI_CAPSULE_HEADER_FLAGS_PERSIST_ACROSS_RESET	0x00010000
 #define EFI_CAPSULE_HEADER_FLAGS_POPULATE_SYSTEM_TABLE	0x00020000
 #define EFI_CAPSULE_HEADER_FLAGS_INITIATE_RESET		0x00040000
@@ -58,7 +60,8 @@ typedef struct __attribute__((__packed__)) {
 /* the biggest size SPI part currently seen */
 #define FU_UEFI_COMMON_REQUIRED_ESP_FREE_SPACE		(32 * 1024 * 1024)
 
-gchar		*fu_uefi_get_esp_app_path	(const gchar	*esp_path,
+gchar		*fu_uefi_get_esp_app_path	(FuDevice       *device,
+						 const gchar	*esp_path,
 						 const gchar	*cmd,
 						 GError		**error);
 gchar		*fu_uefi_get_built_app_path	(GError		**error);
@@ -70,7 +73,8 @@ gboolean	 fu_uefi_get_bitmap_size	(const guint8	*buf,
 gboolean	 fu_uefi_get_framebuffer_size	(guint32	*width,
 						 guint32	*height,
 						 GError		**error);
-gchar		*fu_uefi_get_esp_path_for_os	(const gchar	*esp_path);
+gchar		*fu_uefi_get_esp_path_for_os	(FuDevice 	*device,
+						 const gchar	*esp_path);
 GPtrArray	*fu_uefi_get_esrt_entry_paths	(const gchar	*esrt_path,
 						 GError		**error);
 guint64		 fu_uefi_read_file_as_uint64	(const gchar	*path,

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -560,7 +560,7 @@ fu_uefi_device_write_firmware (FuDevice *device,
 		return FALSE;
 
 	/* save the blob to the ESP */
-	directory = fu_uefi_get_esp_path_for_os (esp_path);
+	directory = fu_uefi_get_esp_path_for_os (device, esp_path);
 	basename = g_strdup_printf ("fwupd-%s.cap", self->fw_class);
 	fn = g_build_filename (directory, "fw", basename, NULL);
 	if (!fu_common_mkdir_parent (fn, error))
@@ -588,7 +588,7 @@ fu_uefi_device_write_firmware (FuDevice *device,
 	/* some legacy devices use the old name to deduplicate boot entries */
 	if (fu_device_has_custom_flag (device, "use-legacy-bootmgr-desc"))
 		bootmgr_desc = "Linux-Firmware-Updater";
-	if (!fu_uefi_bootmgr_bootnext (esp_path, bootmgr_desc, flags, error))
+	if (!fu_uefi_bootmgr_bootnext (device, esp_path, bootmgr_desc, flags, error))
 		return FALSE;
 
 	/* success! */

--- a/plugins/uefi/uefi.conf
+++ b/plugins/uefi/uefi.conf
@@ -10,3 +10,7 @@
 
 # amount of free space required on the ESP, for example using 0x2000000 for 32Mb
 #RequireESPFreeSpace=
+
+# with the UEFI removable path enabled, the default esp path is set to /EFI/boot
+# the shim EFI binary and presumably this is $ESP/EFI/boot/bootx64.efi
+#FallbacktoRemovablePath=false


### PR DESCRIPTION
Per discussion of #2513, Ubuntu Core was going to use UEFI removable
path as default esp path, and it needs to change some parts around
getting the esp path and searching the shim app path. Also, a new option
"FallbacktoRemovablePath" is added into uefi.conf to be applied in this
case, and it will be false by default.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
