### PR TITLE
Remove the duplicate parent-child data in FwupdDevice and FuDevice

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -41,6 +41,8 @@ void		 fwupd_device_set_parent_id		(FwupdDevice	*device,
 FwupdDevice	*fwupd_device_get_parent		(FwupdDevice	*device);
 void		 fwupd_device_set_parent		(FwupdDevice	*device,
 							 FwupdDevice	*parent);
+void		 fwupd_device_add_child			(FwupdDevice	*device,
+							 FwupdDevice	*child);
 GPtrArray	*fwupd_device_get_children		(FwupdDevice	*device);
 const gchar	*fwupd_device_get_name			(FwupdDevice	*device);
 void		 fwupd_device_set_name			(FwupdDevice	*device,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -610,3 +610,9 @@ LIBFWUPD_1.5.0 {
     fwupd_security_attr_to_variant;
   local: *;
 } LIBFWUPD_1.4.6;
+
+LIBFWUPD_1.5.1 {
+  global:
+    fwupd_device_add_child;
+  local: *;
+} LIBFWUPD_1.5.0;


### PR DESCRIPTION
The FuDevice derives from FwupdDevice, and yet both objects have a (potentially
different) parent and set of children. This is super confusing, and just not
required.

Removing the duplication also removes a sizable memory leak when hotplugging
composite devices as the parent was ref'd by the child and the child was ref'd
by the parent in different objects... Fun to debug...
