### PR TITLE
Updated fish completions to 1.5.0

### DIFF
--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -18,7 +18,8 @@ complete -c fwupdmgr -l version -d 'Show client and daemon versions'
 complete -c fwupdmgr -l offline -d 'Schedule installation for next reboot when possible'
 complete -c fwupdmgr -l allow-reinstall -d 'Allow reinstalling existing firmware versions'
 complete -c fwupdmgr -l allow-older -d 'Allow downgrading firmware versions'
-complete -c fwupdmgr -l force -d 'Override warnings and force the action'
+complete -c fwupdmgr -l allow-branch-switch -d 'Allow switching firmware branch'
+complete -c fwupdmgr -l force -d 'Force the action by relaxing some runtime checks'
 complete -c fwupdmgr -s y -l assume-yes -d 'Answer yes to all questions'
 complete -c fwupdmgr -l sign -d 'Sign the uploaded data with the client certificate'
 complete -c fwupdmgr -l no-unreported-check -d 'Do not check for unreported history'
@@ -29,9 +30,11 @@ complete -c fwupdmgr -l no-history -d 'Do not write to the history database'
 complete -c fwupdmgr -l show-all -d 'Show all results'
 complete -c fwupdmgr -l disable-ssl-strict -d 'Ignore SSL strict checks when downloading files'
 complete -c fwupdmgr -l filter -d 'Filter with a set of device flags'
+complete -c fwupdmgr -l ignore-power -d 'Ignore requirement of external power source'
 
 # complete subcommands
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a activate -d 'Activate devices'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a block-firmware -d 'Blocks a specific firmware from being installed'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a clear-history -d 'Erase all firmware update history'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a clear-offline -d 'Clears any updates scheduled to be updated offline'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a clear-results -d 'Clears the results from the last update'
@@ -39,6 +42,7 @@ complete -c fwupdmgr -n '__fish_use_subcommand' -x -a disable-remote -d 'Disable
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a downgrade -d 'Downgrades the firmware on a device'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a enable-remote -d 'Enables a given remote'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-approved-firmware -d 'Gets the list of approved firmware'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-blocked-firmware -d 'Gets the list of blocked firmware'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-details -d 'Gets details about a firmware file'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-devices -d 'Get all devices that support firmware updates'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-history -d 'Show history of firmware updates'
@@ -47,20 +51,22 @@ complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-remotes -d 'Gets the c
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-results -d 'Gets the results from the last update'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-updates -d 'Gets the list of updates for connected hardware'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a install -d 'Install a firmware file on this hardware'
-complete -c fwupdmgr -n '__fish_use_subcommand' -x -a modify-config -d 'Modifies a daemon configuration value.'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a modify-config -d 'Modifies a daemon configuration value'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a modify-remote -d 'Modifies a given remote'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a refresh -d 'Refresh metadata from remote server'
-complete -c fwupdmgr -n '__fish_use_subcommand' -x -a reinstall -d 'Reinstall current firmware on the device.'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a reinstall -d 'Reinstall current firmware on the device'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a report-history -d 'Share firmware history with the developers'
-complete -c fwupdmgr -n '__fish_use_subcommand' -x -a set-approved-firmware -d 'Sets the list of approved firmware.'
-complete -c fwupdmgr -n '__fish_use_subcommand' -x -a switch-branch -d 'Switch the firmware branch on the device.'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a security -d 'Gets the host security attributes'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a set-approved-firmware -d 'Sets the list of approved firmware'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a switch-branch -d 'Switch the firmware branch on the device'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a unblock-firmware -d 'Blocks a specific firmware from being installed'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a unlock -d 'Unlocks the device for firmware access'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a update -d 'Updates all firmware to latest versions available'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify -d 'Checks cryptographic hash matches firmware'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify-update -d 'Update the stored cryptographic hash with current ROM contents'
 
 # commands exclusively consuming device IDs
-set -l deviceid_consumers activate clear-results downgrade get-releases get-results reinstall unlock update verify verify-update
+set -l deviceid_consumers activate clear-results downgrade get-releases get-results get-updates reinstall switch-branch unlock update verify verify-update
 # complete device IDs
 complete -c fwupdmgr -n "__fish_seen_subcommand_from $deviceid_consumers" -x -a "(__fish_fwupdmgr_devices)"
 # complete files and device IDs


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [x] Documentation

Just updated the fish completions to conform with v1.5.0.

By the way, I noticed in the `--help` output:

```
unblock-firmware [CHECKSUM]       Blocks a specific firmware from being installed
```

This is a copy and waste error, isn't it? Probably should be `Unblocks a...`