### PR TITLE
Notify the service manager when idle-quitting

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1179,6 +1179,24 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="libsystemd-dev">
+    <distro id="centos">
+      <package>systemd-devel</package>
+    </distro>
+    <distro id="fedora">
+      <package>systemd-devel</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="s390x">libsystemd-dev:s390x</package>
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="shared-mime-info">
     <distro id="arch">
       <package />

--- a/meson.build
+++ b/meson.build
@@ -376,6 +376,7 @@ endif
 
 if build_standalone and get_option('systemd')
   systemd = dependency('systemd', version : '>= 211')
+  libsystemd = dependency('libsystemd')
   conf.set('HAVE_SYSTEMD' , '1')
   conf.set('HAVE_LOGIND' , '1')
   systemd_root_prefix = get_option('systemd_root_prefix')
@@ -388,6 +389,8 @@ if build_standalone and get_option('systemd')
     systemdsystempresetdir = systemd.get_pkgconfig_variable('systemdsystempresetdir', define_variable: ['rootprefix', systemd_root_prefix])
     systemd_shutdown_dir = systemd.get_pkgconfig_variable('systemdshutdowndir', define_variable: [systemd.version().version_compare('>= 246') ? 'root_prefix' : 'rootprefix', systemd_root_prefix])
   endif
+else
+  libsystemd = dependency('', required: false)
 endif
 
 if build_standalone and get_option('elogind')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,6 +213,7 @@ parts:
       - libsmbios-dev
       - libsoup2.4-dev
       - libsqlite3-dev
+      - libsystemd-dev
       - locales
       - pkg-config
       - systemd

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -17,6 +17,9 @@
 #ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
 #endif
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <jcat.h>
@@ -2028,6 +2031,11 @@ main (int argc, char *argv[])
 	/* wait */
 	g_message ("Daemon ready for requests (locale %s)", g_getenv ("LANG"));
 	g_main_loop_run (priv->loop);
+
+#ifdef HAVE_SYSTEMD
+	/* notify the service manager */
+	sd_notify (0, "STOPPING=1");
+#endif
 
 	/* success */
 	return EXIT_SUCCESS;

--- a/src/meson.build
+++ b/src/meson.build
@@ -266,6 +266,7 @@ executable(
     valgrind,
     libarchive,
     libjsonglib,
+    libsystemd,
     daemon_dep
   ],
   link_with : [


### PR DESCRIPTION
This makes sure that the main process won't get SIGTERM on shutdown.

Inspired from a patch by Jonathan Kang <jonathankang@gnome.org>
