### PR TITLE
Remove HSI update and attestation suffixes

### DIFF
--- a/docs/hsi.xml
+++ b/docs/hsi.xml
@@ -201,23 +201,6 @@
       </para>
     </refsect2>
 
-    <refsect3 id="org.fwupd.hsi.Fwupd.Updates">
-      <title>HSI Runtime Suffix <code>U</code></title>
-      <para>
-        Updates available on the <ulink url="https://fwupd.org/">
-        Linux Vendor Firmware Service </ulink> which are less than 12 months old.
-      </para>
-    </refsect3>
-
-    <refsect3 id="org.fwupd.hsi.Fwupd.Attestation">
-      <title>HSI Runtime Suffix <code>A</code></title>
-      <para>
-        Attestation data is available to verify the current system firmware.
-        For most UEFI platforms, this is usually the Trusted Platform Module (TPM)
-        PCR0 hash, but other attestation checksums could be used.
-      </para>
-    </refsect3>
-
     <refsect3 id="runtime-bang">
       <title>HSI Runtime Suffix <code>!</code></title>
       <para>

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -159,8 +159,6 @@ fu_security_attrs_calculate_hsi (FuSecurityAttrs	*self,
 	FwupdSecurityAttrFlags attr_flags = FWUPD_SECURITY_ATTR_FLAG_NONE;
 	GString *str = g_string_new ("HSI:");
 	const FwupdSecurityAttrFlags hpi_suffixes[] = {
-		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES,
-		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION,
 		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE,
 		FWUPD_SECURITY_ATTR_FLAG_NONE,
 	};
@@ -198,25 +196,14 @@ fu_security_attrs_calculate_hsi (FuSecurityAttrs	*self,
 		FwupdSecurityAttr *attr = g_ptr_array_index (self->attrs, i);
 		if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED))
 			continue;
-		/* positive things */
-		if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES) ||
-		    fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION)) {
-			if (!fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
-				continue;
-		}
-		/* negative things */
-		if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE)) {
-			if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
-				continue;
-		}
+		if (fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE) &&
+		    fwupd_security_attr_has_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
+			continue;
 		attr_flags |= fwupd_security_attr_get_flags (attr);
 	}
 
 	g_string_append_printf (str, "%u", hsi_number);
-	if (attr_flags & (FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES |
-			  FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION |
-			  FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE)) {
-		g_string_append (str, "+");
+	if (attr_flags & FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE) {
 		for (guint j = 0; hpi_suffixes[j] != FWUPD_SECURITY_ATTR_FLAG_NONE; j++) {
 			if (attr_flags & hpi_suffixes[j])
 				g_string_append (str, fwupd_security_attr_flag_to_suffix (hpi_suffixes[j]));

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2060,13 +2060,11 @@ fu_security_attrs_hsi_func (void)
 	/* add updates and attestation */
 	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_FWUPD_UPDATES);
 	fwupd_security_attr_set_plugin (attr, "test");
-	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES);
-	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION);
 	fwupd_security_attr_add_flag (attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fwupd_security_attr_set_url (attr, "http://test");
 	fu_security_attrs_append (attrs, attr);
 	hsi6 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr (hsi6, ==, "HSI:3+UA");
+	g_assert_cmpstr (hsi6, ==, "HSI:3");
 	g_clear_object (&attr);
 
 	/* add issue that was uncool */
@@ -2076,7 +2074,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_set_url (attr, "http://test");
 	fu_security_attrs_append (attrs, attr);
 	hsi7 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr (hsi7, ==, "HSI:3+UA!");
+	g_assert_cmpstr (hsi7, ==, "HSI:3!");
 	g_clear_object (&attr);
 
 	/* show version in the attribute */
@@ -2086,7 +2084,7 @@ fu_security_attrs_hsi_func (void)
 	fwupd_security_attr_set_url (attr, "http://test");
 	fu_security_attrs_append (attrs, attr);
 	hsi8 = fu_security_attrs_calculate_hsi (attrs, FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
-	expected_hsi8 = g_strdup_printf ("HSI:3+UA! (v%d.%d.%d)",
+	expected_hsi8 = g_strdup_printf ("HSI:3! (v%d.%d.%d)",
 					FWUPD_MAJOR_VERSION,
 					FWUPD_MINOR_VERSION,
 					FWUPD_MICRO_VERSION);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1738,8 +1738,6 @@ fu_util_security_attrs_to_string (GPtrArray *attrs, FuSecurityAttrToStringFlags 
 {
 	FwupdSecurityAttrFlags flags = FWUPD_SECURITY_ATTR_FLAG_NONE;
 	const FwupdSecurityAttrFlags hpi_suffixes[] = {
-		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_UPDATES,
-		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ATTESTATION,
 		FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE,
 		FWUPD_SECURITY_ATTR_FLAG_NONE,
 	};


### PR DESCRIPTION
The logic here is that the attestation is more than just the PCR0 value, and
multiple device firmware (such as EC, ME, etc.) needs to be included to validate
the system.

By the same logic, updates for the system firmware do not tell the whole story,
and confuse HSI as a specification. Remove them.
