### PR TITLE
Allow components to set the icon from the metadata

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -189,6 +189,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "md-set-name-category";
 	if (device_flag == FWUPD_DEVICE_FLAG_MD_SET_VERFMT)
 		return "md-set-verfmt";
+	if (device_flag == FWUPD_DEVICE_FLAG_MD_SET_ICON)
+		return "md-set-icon";
 	if (device_flag == FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS)
 		return "add-counterpart-guids";
 	if (device_flag == FWUPD_DEVICE_FLAG_NO_GUID_MATCHING)
@@ -291,6 +293,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY;
 	if (g_strcmp0 (device_flag, "md-set-verfmt") == 0)
 		return FWUPD_DEVICE_FLAG_MD_SET_VERFMT;
+	if (g_strcmp0 (device_flag, "md-set-icon") == 0)
+		return FWUPD_DEVICE_FLAG_MD_SET_ICON;
 	if (g_strcmp0 (device_flag, "add-counterpart-guids") == 0)
 		return FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS;
 	if (g_strcmp0 (device_flag, "no-guid-matching") == 0)

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -128,6 +128,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_SKIPS_RESTART:		Device relies upon activation or power cycle to load firmware
  * @FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES:	Device supports switching to a different stream of firmware
  * @FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL:	Device firmware should be saved before installing firmware
+ * @FWUPD_DEVICE_FLAG_MD_SET_ICON:		Set the device icon from the metadata if available
  *
  * The device flags.
  **/
@@ -173,6 +174,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_SKIPS_RESTART		(1llu << 38)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES	(1llu << 39)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL	(1llu << 40)	/* Since: 1.5.0 */
+#define FWUPD_DEVICE_FLAG_MD_SET_ICON		(1llu << 41)	/* Since: 1.5.2 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -675,6 +675,7 @@ fu_uefi_device_probe (FuDevice *device, GError **error)
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_MD_SET_VERFMT);
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_MD_SET_ICON);
 
 	/* add icons */
 	if (self->kind == FU_UEFI_DEVICE_KIND_DEVICE_FIRMWARE) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3074,6 +3074,23 @@ fu_engine_md_refresh_device_name (FuEngine *self, FuDevice *device, XbNode *comp
 	}
 }
 
+static void
+fu_engine_md_refresh_device_icon (FuEngine *self, FuDevice *device, XbNode *component)
+{
+	const gchar *icon = NULL;
+
+	/* require data */
+	if (component == NULL)
+		return;
+
+	/* copy 1:1 */
+	icon = xb_node_query_text (component, "icon", NULL);
+	if (icon != NULL) {
+		fu_device_add_icon (device, icon);
+		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_MD_SET_ICON);
+	}
+}
+
 static const gchar *
 fu_common_device_category_to_name (const gchar *cat)
 {
@@ -3186,6 +3203,8 @@ fu_engine_md_refresh_device_from_component (FuEngine *self, FuDevice *device, Xb
 		fu_engine_md_refresh_device_name (self, device, component);
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_MD_SET_NAME_CATEGORY))
 		fu_engine_md_refresh_device_name_category (self, device, component);
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_MD_SET_ICON))
+		fu_engine_md_refresh_device_icon (self, device, component);
 
 	/* fix the version */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_MD_SET_VERFMT))

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1111,6 +1111,10 @@ fu_util_device_flag_to_string (guint64 device_flag)
 		/* skip */
 		return NULL;
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_MD_SET_ICON) {
+		/* skip */
+		return NULL;
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */
 		return NULL;


### PR DESCRIPTION
In this case, we want to set the generic ESRT entry to have the icon 'battery'.
