### PR TITLE
Add a flag to indicate if packages are supported

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -27,7 +27,7 @@ build() {
     if [ -n "$CI" ]; then
         export CI="--wrap-mode=default"
     fi
-    arch-meson -D b_lto=false $CI ../build
+    arch-meson -D b_lto=false $CI ../build -Dsupported_build=true
 
     ninja -v -C ../build
 }

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -48,7 +48,7 @@ override_dh_auto_configure:
 	else \
 		export UEFI="-Dplugin_uefi=false -Dplugin_redfish=false -Dplugin_nvme=false -Dplugin_msr=false"; \
 	fi; \
-	dh_auto_configure -- $$UEFI $$DELL $$FLASHROM $$CI -Dplugin_dummy=true -Dgtkdoc=true
+	dh_auto_configure -- $$UEFI $$DELL $$FLASHROM $$CI -Dplugin_dummy=true -Dgtkdoc=true -Dsupported_build=true
 
 override_dh_install:
 	find debian/tmp/usr -type f -name "*a" -print | xargs rm -f

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -246,7 +246,8 @@ can be flashed using flashrom. It is probably not required on servers.
 %else
     -Dplugin_modem_manager=false \
 %endif
-    -Dman=true
+    -Dman=true \
+    -Dsupported_build=true
 
 %meson_build
 

--- a/meson.build
+++ b/meson.build
@@ -402,6 +402,10 @@ if build_standalone and get_option('consolekit')
   conf.set('HAVE_CONSOLEKIT' , '1')
 endif
 
+if get_option('supported_build')
+    conf.set('SUPPORTED_BUILD', '1')
+endif
+
 gnome = import('gnome')
 i18n = import('i18n')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,7 @@ option('plugin_modem_manager', type : 'boolean', value : false, description : 'e
 option('plugin_msr', type : 'boolean', value : true, description : 'enable MSR support')
 option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
 option('plugin_coreboot', type : 'boolean', value : true, description : 'enable coreboot support')
+option('supported_build', type : 'boolean', value : false, description: 'distribution package with upstream support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
 option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
 option('elogind', type : 'boolean', value : false, description : 'enable elogind support')

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -186,6 +186,7 @@ fu_util_start_engine (FuUtilPrivate *priv, FuEngineLoadFlags flags, GError **err
 			    fmt);
 	}
 	fu_util_show_plugin_warnings (priv);
+	fu_util_show_unsupported_warn ();
 	return TRUE;
 }
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1995,3 +1995,15 @@ fu_util_switch_branch_warning (FwupdDevice *dev,
 	}
 	return TRUE;
 }
+
+void
+fu_util_show_unsupported_warn (void)
+{
+#ifndef SUPPORTED_BUILD
+	g_autofree gchar *fmt = NULL;
+	/* TRANSLATORS: this is a prefix on the console */
+	fmt = fu_util_term_format (_("WARNING:"), FU_UTIL_CLI_COLOR_YELLOW);
+	/* TRANSLATORS: unsupported build of the package */
+	g_printerr ("%s %s\n", fmt, _("This package has not been validated, it may not work properly."));
+#endif
+}

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -118,3 +118,4 @@ gboolean	 fu_util_switch_branch_warning	(FwupdDevice	*dev,
 						 FwupdRelease	*rel,
 						 gboolean	 assume_yes,
 						 GError		**error);
+void		 fu_util_show_unsupported_warn	(void);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3120,6 +3120,9 @@ main (int argc, char *argv[])
 	/* show user-visible warnings from the plugins */
 	fu_util_show_plugin_warnings (priv);
 
+	/* show any unsupported warnings */
+	fu_util_show_unsupported_warn ();
+
 	/* we know the runtime daemon version now */
 	fwupd_client_set_user_agent_for_package (priv->client, "fwupdmgr", PACKAGE_VERSION);
 


### PR DESCRIPTION
Anyone can easily add this, but it makes it clearer that by default hand
build, snap, and flatpak are not checked by anyone.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
