### PR TITLE
trivial: installed-tests: skip tests requiring network by default

### DIFF
--- a/data/installed-tests/fwupdmgr.sh
+++ b/data/installed-tests/fwupdmgr.sh
@@ -56,6 +56,11 @@ echo "Testing the verification of firmware (again)..."
 fwupdmgr verify $device
 rc=$?; if [[ $rc != 0 ]]; then error $rc; fi
 
+if [ -z "$CI_NETWORK" ]; then
+        echo "Skipping remaining tests due to CI_NETWORK not being set"
+        exit 0
+fi
+
 # ---
 echo "Downgrading to older release (requires network access)"
 fwupdmgr downgrade $device -y


### PR DESCRIPTION
Most of the installed tests will skip if files needed to be fetched
from network are not available.  Do the same thing for fwupdmgr
tests.

Fixes: #2566

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
