### PR TITLE
synaptics-mst: Improve reliability by waiting 2 seconds after writing data

### DIFF
--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -859,7 +859,10 @@ fu_synaptics_mst_device_write_firmware (FuDevice *device,
 			return FALSE;
 		}
 	}
+
+	/* wait for flash clear to settle */
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_sleep_with_progress (device, 2);
 	return TRUE;
 }
 


### PR DESCRIPTION
On failure, you get this:

    no device found on drm_dp_aux5: Memory query failed: failed to write command
    failed to get device after update: failed to wait for detach replug
