### PR TITLE
trivial: Fix a logic thinko to unbreak switch-branch

### DIFF
--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -57,8 +57,8 @@ fu_bcm57xx_device_probe (FuUdevDevice *device, GError **error)
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GPtrArray) ifaces = NULL;
 
-	/* only enumerate number 0 */
-	if (fu_udev_device_get_number (device) != 0) {
+	/* only enumerate first device */
+	if (fu_udev_device_get_number (device) != 1) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1220,11 +1220,10 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req, FuDevice *dev
 	}
 
 	/* vendor ID */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0 &&
-	    g_strcmp0 (xb_node_get_text (req), "vendor-id") == 0 &&
+	if (g_strcmp0 (xb_node_get_text (req), "vendor-id") == 0 &&
 	    fu_device_get_vendor_id (device_actual) != NULL) {
-		const gchar *version = fu_device_get_vendor_id (device_actual);
-		if (!fu_engine_require_vercmp (req, version,
+		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0 &&
+		    !fu_engine_require_vercmp (req, fu_device_get_vendor_id (device_actual),
 					       fu_device_get_version_format (device_actual),
 					       &error_local)) {
 			g_set_error (error,


### PR DESCRIPTION
We still want to return TRUE, rather than falling through as if the requirement
type was unknown.

Fixes https://github.com/fwupd/fwupd/issues/2578
