### PR TITLE
Install modules-load configs in libdir

### DIFF
--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -5,7 +5,7 @@ install_data(['msr.quirk'],
 )
 
 install_data(['fwupd-msr.conf'],
-  install_dir: join_paths(sysconfdir, 'modules-load.d')
+  install_dir: join_paths(libdir, 'modules-load.d')
 )
 
 shared_module('fu_plugin_msr',

--- a/plugins/platform-integrity/meson.build
+++ b/plugins/platform-integrity/meson.build
@@ -7,7 +7,7 @@ install_data([
 )
 
 install_data(['fwupd-platform-integrity.conf'],
-  install_dir: join_paths(sysconfdir, 'modules-load.d')
+  install_dir: join_paths(libdir, 'modules-load.d')
 )
 
 shared_module('fu_plugin_platform_integrity',


### PR DESCRIPTION
This change follows the convention that packaged distro/vendor configs should be installed to `/usr` while leaving `/etc` for admin/local system changes.

I believe this will break the Snap install and remove hooks, I'm not sure what to do there, can Snap pick up `libdir/modules-load.d` configs?.
Also, the deb spec (`contrib/fwupd.spec.in`) might need an update.  
If both considered merge blocking then I don't mind letting someone with experience with Snap and deb packages handle this PR.