### PR TITLE
trivial: tr_gen2 has same rtd21xx as mini dock

### DIFF
--- a/plugins/vli/vli-usbhub-lenovo.quirk
+++ b/plugins/vli/vli-usbhub-lenovo.quirk
@@ -159,6 +159,13 @@ Plugin = vli
 GType = FuVliUsbhubDevice
 Flags = usb2
 ParentGuid = USB\VID_17EF&PID_721D
+[DeviceInstanceId=USB\VID_17EF&PID_721C]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = has-rtd21xx
+ParentGuid = USB\VID_17EF&PID_721D
+[DeviceInstanceId=USB\VID_17EF&PID_721C&I2C_REALTEK]
+Name = RTD2181S
 
 # Lenovo USB-C Mini dock
 [DeviceInstanceId=USB\VID_17EF&PID_3094]


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

I'm not sure whomst is responsible for making the fix; but an ODM noticed that TR_Gen2 was missing the realtex flag in the quirk files and requested help. 
