### PR TITLE
trivial: uefi: don't let user's environment fail UEFI/Dell test suite

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -620,6 +620,10 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 	g_autofree gchar *nvram_total_str = NULL;
 	g_autoptr(GError) error_local = NULL;
 
+	/* don't let user's environment influence test suite failures */
+	if (g_getenv ("FWUPD_UEFI_TEST") != NULL)
+		return TRUE;
+
 	/* some platforms have broken SMBIOS data */
 	if (fu_plugin_has_custom_flag (plugin, "uefi-force-enable"))
 		return TRUE;


### PR DESCRIPTION
Comment from https://github.com/fwupd/fwupd/issues/2553#issuecomment-728218741
makes it clear that test suite should ignore some of environment.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
