### PR TITLE
libfwupd: Add fwupd_client_download_file()

### DIFF
--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -1981,6 +1981,7 @@ fwupd_client_download_bytes (FwupdClient *self,
 	g_return_val_if_fail (url != NULL, NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+	g_return_val_if_fail (fwupd_client_get_user_agent (self) != NULL, NULL);
 
 	/* connect */
 	if (!fwupd_client_connect (self, cancellable, error))
@@ -2030,6 +2031,7 @@ fwupd_client_download_file (FwupdClient *self,
 	g_return_val_if_fail (G_IS_FILE (file), FALSE);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+	g_return_val_if_fail (fwupd_client_get_user_agent (self) != NULL, FALSE);
 
 	/* download then write */
 	bytes = fwupd_client_download_bytes (self, url, flags, cancellable, error);

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -164,6 +164,12 @@ GBytes		*fwupd_client_download_bytes		(FwupdClient	*self,
 							 FwupdClientDownloadFlags flags,
 							 GCancellable	*cancellable,
 							 GError		**error);
+gboolean	 fwupd_client_download_file		(FwupdClient	*self,
+							 const gchar	*url,
+							 GFile		*file,
+							 FwupdClientDownloadFlags flags,
+							 GCancellable	*cancellable,
+							 GError		**error);
 GBytes		*fwupd_client_upload_bytes		(FwupdClient	*self,
 							 const gchar	*url,
 							 const gchar	*payload,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -619,6 +619,7 @@ LIBFWUPD_1.5.1 {
 
 LIBFWUPD_1.5.2 {
   global:
+    fwupd_client_download_file;
     fwupd_client_get_user_agent;
   local: *;
 } LIBFWUPD_1.5.1;


### PR DESCRIPTION
I'm porting gnome-software to use this new API and this would be a very useful
thing to provide. No async API as we want to avoid writing temp files in most
cases -- this is just for legacy apps.
