### PR TITLE
libfwupd: Restore recognizing gpg and pkcs7 types still

### DIFF
--- a/data/tests/firmware-base-uri.conf
+++ b/data/tests/firmware-base-uri.conf
@@ -1,6 +1,6 @@
 [fwupd Remote]
 Enabled=true
 Type=download
-Keyring=gpg
+Keyring=jcat
 MetadataURI=https://s3.amazonaws.com/lvfsbucket/downloads/firmware.xml.gz
 FirmwareBaseURI=https://my.fancy.cdn/

--- a/data/tests/firmware-nopath.conf
+++ b/data/tests/firmware-nopath.conf
@@ -1,5 +1,5 @@
 [fwupd Remote]
 Enabled=true
 Type=download
-Keyring=gpg
+Keyring=jcat
 MetadataURI=https://s3.amazonaws.com/lvfsbucket/downloads/firmware.xml.gz


### PR DESCRIPTION
The snap-store intends to ship an updated libfwupd library but
to use it with whatever version daemon is on the host system.

This means that the library needs to still work with older metadata
signing types.

This fixes the following error in that scenario:
```Failed to update metadata for lvfs: Keyring kind jcat not supported```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

CC @kenvandine 