### PR TITLE
Restrict loading component types of firmware

### DIFF
--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -676,7 +676,9 @@ fu_cabinet_parse (FuCabinet *self,
 		return FALSE;
 
 	/* sanity check */
-	components = xb_silo_query (self->silo, "components/component", 0, &error_local);
+	components = xb_silo_query (self->silo,
+				    "components/component[@type='firmware']",
+				    0, &error_local);
 	if (components == NULL) {
 		g_set_error (error,
 			     FWUPD_ERROR,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -853,7 +853,9 @@ fu_main_install_with_helper (FuMainAuthHelper *helper_ref, GError **error)
 		return FALSE;
 
 	/* for each component in the silo */
-	components = xb_silo_query (helper->silo, "components/component", 0, error);
+	components = xb_silo_query (helper->silo,
+				    "components/component[@type='firmware']",
+				    0, error);
 	if (components == NULL)
 		return FALSE;
 	helper->action_ids = g_ptr_array_new_with_free_func (g_free);


### PR DESCRIPTION
This would allow us to add other component types in the future, for instance a
'generic' type that adds information to the composite device.

Any generic components would need to have a requirement of 1.5.2 to avoid
showing a runtime warning when trying to get the local file details.
