### PR TITLE
fu-main: Fix sender_features insert with wrong size

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1532,11 +1532,13 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		return;
 	}
 	if (g_strcmp0 (method_name, "SetFeatureFlags") == 0) {
-		guint64 feature_flags = 0;
-		g_variant_get (parameters, "(t)", &feature_flags);
-		g_debug ("Called %s(%" G_GUINT64_FORMAT ")", method_name, feature_flags);
+		FwupdFeatureFlags feature_flags;
+		guint64 feature_flags_u64 = 0;
+		g_variant_get (parameters, "(t)", &feature_flags_u64);
+		g_debug ("Called %s(%" G_GUINT64_FORMAT ")", method_name, feature_flags_u64);
 
 		/* old flags for the same sender will be automatically destroyed */
+		feature_flags = feature_flags_u64;
 		g_hash_table_insert (priv->sender_features,
 				     g_strdup (sender),
 				     g_memdup (&feature_flags, sizeof(feature_flags)));


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

`fu_main_daemon_method_call` stores a pointer to a `guint64` in the `priv->sender_features` hashtable.  However, wherever this pointer is extracted from the hashtable, it is casted to a `FwupdFeatureFlags*` and dereferenced.  Since `guint64` does not have the same size as `FwupdFeatureFlags`, this is undefined behaviour.  On a big endian system, the typical result will be that the higher order bits of the `guint64` are accessed, giving a `0` result.