### PR TITLE
bcm57xx: Fix CRC check

### DIFF
--- a/plugins/bcm57xx/fu-bcm57xx-common.c
+++ b/plugins/bcm57xx/fu-bcm57xx-common.c
@@ -14,7 +14,7 @@
 guint32
 fu_bcm57xx_nvram_crc (const guint8 *buf, gsize bufsz)
 {
-	return GUINT32_FROM_BE(fu_common_crc32 (buf, bufsz));
+	return GUINT32_SWAP_LE_BE (fu_common_crc32 (buf, bufsz));
 }
 
 gboolean

--- a/plugins/bcm57xx/fu-bcm57xx-common.c
+++ b/plugins/bcm57xx/fu-bcm57xx-common.c
@@ -14,7 +14,7 @@
 guint32
 fu_bcm57xx_nvram_crc (const guint8 *buf, gsize bufsz)
 {
-	return GUINT32_SWAP_LE_BE (fu_common_crc32 (buf, bufsz));
+	return fu_common_crc32 (buf, bufsz);
 }
 
 gboolean
@@ -27,7 +27,7 @@ fu_bcm57xx_verify_crc (GBytes *fw, GError **error)
 
 	/* expected */
 	if (!fu_common_read_uint32_safe (buf, bufsz, bufsz - sizeof(guint32),
-					 &crc_file, G_BIG_ENDIAN, error))
+					 &crc_file, G_LITTLE_ENDIAN, error))
 		return FALSE;
 
 	/* reality */

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -71,7 +71,7 @@ fu_bcm57xx_dict_image_write (FuFirmwareImage *image, GError **error)
 
 	/* add CRC */
 	crc = fu_bcm57xx_nvram_crc (buf, bufsz);
-	fu_byte_array_append_uint32 (blob, crc, G_BIG_ENDIAN);
+	fu_byte_array_append_uint32 (blob, crc, G_LITTLE_ENDIAN);
 	return g_byte_array_free_to_bytes (g_steal_pointer (&blob));
 }
 

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -443,7 +443,7 @@ fu_bcm57xx_firmware_write (FuFirmware *firmware, GError **error)
 	fu_byte_array_append_uint32 (buf, self->phys_addr, G_BIG_ENDIAN);
 	fu_byte_array_append_uint32 (buf, g_bytes_get_size (blob_stage1) / sizeof(guint32), G_BIG_ENDIAN);
 	fu_byte_array_append_uint32 (buf, BCM_NVRAM_STAGE1_BASE, G_BIG_ENDIAN);
-	fu_byte_array_append_uint32 (buf, fu_bcm57xx_nvram_crc (buf->data, buf->len), G_BIG_ENDIAN);
+	fu_byte_array_append_uint32 (buf, fu_bcm57xx_nvram_crc (buf->data, buf->len), G_LITTLE_ENDIAN);
 
 	/* add directory entries */
 	blob_dicts = g_ptr_array_new_with_free_func ((GDestroyNotify) g_bytes_unref);

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -104,7 +104,7 @@ fu_bcm57xx_stage1_image_write (FuFirmwareImage *image, GError **error)
 
 	/* add CRC */
 	crc = fu_bcm57xx_nvram_crc (buf, bufsz);
-	fu_byte_array_append_uint32 (blob, crc, G_BIG_ENDIAN);
+	fu_byte_array_append_uint32 (blob, crc, G_LITTLE_ENDIAN);
 	return g_byte_array_free_to_bytes (g_steal_pointer (&blob));
 }
 

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -61,7 +61,7 @@ fu_bcm57xx_stage2_image_write (FuFirmwareImage *image, GError **error)
 	g_byte_array_append (blob, buf, bufsz);
 
 	/* add CRC */
-	fu_byte_array_append_uint32 (blob, fu_bcm57xx_nvram_crc (buf, bufsz), G_BIG_ENDIAN);
+	fu_byte_array_append_uint32 (blob, fu_bcm57xx_nvram_crc (buf, bufsz), G_LITTLE_ENDIAN);
 	return g_byte_array_free_to_bytes (g_steal_pointer (&blob));
 }
 


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

The function `fu_bcm57xx_nvram_crc` calls `GUINT32_FROM_BE` on a locally computed number, which makes absolutely no sense.  AFAICT this is an attempt to wall-paper over the fact that the call to `fu_common_read_uint32_safe` incorrectly uses `G_BIG_ENDIAN` instead of `G_LITTLE_ENDIAN` to read the (little endian) CRC value from the fw image.

This "worked" on little-endian, since `GUINT32_FROM_BE` would swap the CRC backwards, so that it compared equal to the CRC fetched from the image, which was also backwards.  But on big-endian `GUINT32_FROM_BE` naturally does nothing and so the comparison fails.
