### PR TITLE
Allow the client to send PKCS7 and GPG signatures

### DIFF
--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -191,9 +191,6 @@ fu_remote_list_add_for_path (FuRemoteList *self, const gchar *path, GError **err
 			return FALSE;
 		}
 
-		/* force this to JCat, it's the only thing we support */
-		fwupd_remote_set_keyring_kind (remote, FWUPD_KEYRING_KIND_JCAT);
-
 		/* watch the remote_list file and the XML file itself */
 		if (!fu_remote_list_add_inotify (self, filename, error))
 			return FALSE;


### PR DESCRIPTION
This restores compatibility when running with a new daemon and old remote files
and properly fixes all combinations of the regression casued by the commit
2f49da7f4e9ed300c91956531e3dbdb4da628da5 which appeared in the 1.5.2 release.
