### PR TITLE
trivial: fu-engine: If a device is using delayed activation don't flag failure

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2185,7 +2185,8 @@ fu_engine_install_release (FuEngine *self,
 	fmt = fu_device_get_version_format (device);
 	if (version_rel != NULL &&
 	    fu_common_vercmp_full (version_orig, version_rel, fmt) != 0 &&
-	    fu_common_vercmp_full (version_orig, fu_device_get_version (device), fmt) == 0) {
+	    fu_common_vercmp_full (version_orig, fu_device_get_version (device), fmt) == 0 &&
+	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_SKIPS_RESTART)) {
 		g_autofree gchar *str = NULL;
 		fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);
 		str = g_strdup_printf ("device version not updated on success, %s != %s",


### PR DESCRIPTION
Should hopefully fix this failure:
```
Plugin thunderbolt
UpdateError device version not updated on success, 43.00 != 40.00
VersionNew 43.00
VersionOld 40.00
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
