### PR TITLE
trivial: make platform integrity plugin optional and disabled by default

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -23,6 +23,7 @@ meson .. \
     -Dplugin_altos=false \
     -Dplugin_dell=false \
     -Dplugin_nvme=false \
+    -Dplugin_platform_integrity=false \
     -Dtpm=false \
     -Dsystemd=false \
     -Dplugin_emmc=false \

--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -18,7 +18,7 @@ eval "$(dpkg-buildflags --export=sh)"
 export LDFLAGS=$(dpkg-buildflags --get LDFLAGS | sed "s/-Wl,-Bsymbolic-functions\s//")
 
 rm -rf build
-meson build -Dman=false -Dgtkdoc=true -Dgusb:tests=false
+meson build -Dman=false -Dgtkdoc=true -Dgusb:tests=false -Dplugin_platform_integrity=true
 #build with clang
 ninja -C build test -v
 

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -325,7 +325,6 @@ done
 %if 0%{?have_msr}
 /usr/lib/modules-load.d/fwupd-msr.conf
 %endif
-/usr/lib/modules-load.d/fwupd-platform-integrity.conf
 %{_datadir}/dbus-1/system.d/org.freedesktop.fwupd.conf
 %{_datadir}/bash-completion/completions/fwupdmgr
 %{_datadir}/bash-completion/completions/fwupdtool
@@ -414,7 +413,6 @@ done
 %{_libdir}/fwupd-plugins-3/libfu_plugin_optionrom.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_pci_bcr.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_pci_mei.so
-%{_libdir}/fwupd-plugins-3/libfu_plugin_platform_integrity.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_redfish.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_rts54hid.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_rts54hub.so

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,6 +22,7 @@ option('plugin_modem_manager', type : 'boolean', value : false, description : 'e
 option('plugin_msr', type : 'boolean', value : true, description : 'enable MSR support')
 option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
 option('plugin_coreboot', type : 'boolean', value : true, description : 'enable coreboot support')
+option('plugin_platform_integrity', type : 'boolean', value : false, description : 'enable platform integrity support')
 option('supported_build', type : 'boolean', value : false, description: 'distribution package with upstream support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
 option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -22,7 +22,6 @@ subdir('dell-dock')
 subdir('nitrokey')
 subdir('pci-bcr')
 subdir('pci-mei')
-subdir('platform-integrity')
 subdir('rts54hid')
 subdir('rts54hub')
 subdir('solokey')
@@ -129,4 +128,8 @@ endif
 
 if get_option('plugin_coreboot')
 subdir('coreboot')
+endif
+
+if get_option('plugin_platform_integrity')
+subdir('platform-integrity')
 endif

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,4 +21,3 @@ systemctl enable fwupd-activate
 systemctl start fwupd-activate
 #kernel modules
 install_if_missing usr/lib/modules-load.d/fwupd-msr.conf /
-install_if_missing usr/lib/modules-load.d/fwupd-platform-integrity.conf /


### PR DESCRIPTION
Fixes: #2634
When it's upstream, we may consider to change this for some distros.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
