### PR TITLE
Allow setting the GMainContext when used for sync methods

### DIFF
--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -51,11 +51,11 @@ fwupd_client_helper_free (FwupdClientHelper *helper)
 }
 
 static FwupdClientHelper *
-fwupd_client_helper_new (void)
+fwupd_client_helper_new (FwupdClient *self)
 {
 	FwupdClientHelper *helper;
 	helper = g_new0 (FwupdClientHelper, 1);
-	helper->context = g_main_context_new ();
+	helper->context = fwupd_client_get_main_context (self);
 	helper->loop = g_main_loop_new (helper->context, FALSE);
 	return helper;
 }
@@ -90,17 +90,16 @@ fwupd_client_connect_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 gboolean
 fwupd_client_connect (FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_connect_async (self, cancellable, fwupd_client_connect_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -131,7 +130,7 @@ fwupd_client_get_devices_cb (GObject *source, GAsyncResult *res, gpointer user_d
 GPtrArray *
 fwupd_client_get_devices (FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -142,11 +141,10 @@ fwupd_client_get_devices (FwupdClient *self, GCancellable *cancellable, GError *
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_devices_async (self, cancellable,
 					fwupd_client_get_devices_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -177,7 +175,7 @@ fwupd_client_get_plugins_cb (GObject *source, GAsyncResult *res, gpointer user_d
 GPtrArray *
 fwupd_client_get_plugins (FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -188,11 +186,10 @@ fwupd_client_get_plugins (FwupdClient *self, GCancellable *cancellable, GError *
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_plugins_async (self, cancellable,
 					fwupd_client_get_plugins_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -223,7 +220,7 @@ fwupd_client_get_history_cb (GObject *source, GAsyncResult *res, gpointer user_d
 GPtrArray *
 fwupd_client_get_history (FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -234,11 +231,10 @@ fwupd_client_get_history (FwupdClient *self, GCancellable *cancellable, GError *
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_history_async (self, cancellable,
 					fwupd_client_get_history_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -271,7 +267,7 @@ GPtrArray *
 fwupd_client_get_releases (FwupdClient *self, const gchar *device_id,
 			   GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -283,11 +279,10 @@ fwupd_client_get_releases (FwupdClient *self, const gchar *device_id,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_releases_async (self, device_id, cancellable,
 					 fwupd_client_get_releases_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -320,7 +315,7 @@ GPtrArray *
 fwupd_client_get_downgrades (FwupdClient *self, const gchar *device_id,
 			     GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -332,11 +327,10 @@ fwupd_client_get_downgrades (FwupdClient *self, const gchar *device_id,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_downgrades_async (self, device_id, cancellable,
 					   fwupd_client_get_downgrades_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -369,7 +363,7 @@ GPtrArray *
 fwupd_client_get_upgrades (FwupdClient *self, const gchar *device_id,
 			   GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -381,11 +375,10 @@ fwupd_client_get_upgrades (FwupdClient *self, const gchar *device_id,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_upgrades_async (self, device_id, cancellable,
 					   fwupd_client_get_upgrades_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -420,7 +413,7 @@ fwupd_client_get_details_bytes (FwupdClient *self,
 				GCancellable *cancellable,
 				GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (bytes != NULL, NULL);
@@ -432,13 +425,12 @@ fwupd_client_get_details_bytes (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_details_bytes_async (self, bytes,
 					      cancellable,
 					      fwupd_client_get_details_bytes_cb,
 					      helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -477,7 +469,7 @@ fwupd_client_get_details (FwupdClient *self,
 {
 #ifdef HAVE_GIO_UNIX
 	g_autoptr(GUnixInputStream) istr = NULL;
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (filename != NULL, NULL);
@@ -492,12 +484,11 @@ fwupd_client_get_details (FwupdClient *self,
 	istr = fwupd_unix_input_stream_from_fn (filename, error);
 	if (istr == NULL)
 		return NULL;
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_details_stream_async (self, istr, cancellable,
 					       fwupd_client_get_details_cb,
 					       helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -539,7 +530,7 @@ fwupd_client_verify (FwupdClient *self,
 		     GCancellable *cancellable,
 		     GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -551,12 +542,11 @@ fwupd_client_verify (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_verify_async (self, device_id, cancellable,
 				   fwupd_client_verify_cb,
 				   helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -591,7 +581,7 @@ fwupd_client_verify_update (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -603,12 +593,11 @@ fwupd_client_verify_update (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_verify_update_async (self, device_id, cancellable,
 					  fwupd_client_verify_update_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -643,7 +632,7 @@ fwupd_client_unlock (FwupdClient *self,
 		     GCancellable *cancellable,
 		     GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -655,12 +644,11 @@ fwupd_client_unlock (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_unlock_async (self, device_id, cancellable,
 				   fwupd_client_unlock_cb,
 				   helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -697,7 +685,7 @@ fwupd_client_modify_config (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (key != NULL, FALSE);
@@ -710,13 +698,12 @@ fwupd_client_modify_config (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_modify_config_async (self, key, value,
 					  cancellable,
 					  fwupd_client_modify_config_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -752,7 +739,7 @@ fwupd_client_activate (FwupdClient *self,
 		       const gchar *device_id, /* yes, this is the wrong way around :/ */
 		       GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -764,13 +751,12 @@ fwupd_client_activate (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_activate_async (self, device_id,
 				     cancellable,
 				     fwupd_client_activate_cb,
 				     helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -805,7 +791,7 @@ fwupd_client_clear_results (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -817,13 +803,12 @@ fwupd_client_clear_results (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_clear_results_async (self, device_id,
 					  cancellable,
 					  fwupd_client_clear_results_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -856,7 +841,7 @@ FwupdDevice *
 fwupd_client_get_results (FwupdClient *self, const gchar *device_id,
 			  GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -868,11 +853,10 @@ fwupd_client_get_results (FwupdClient *self, const gchar *device_id,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_results_async (self, device_id, cancellable,
 					fwupd_client_get_results_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->device == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -905,7 +889,7 @@ fwupd_client_get_host_security_attrs (FwupdClient *self,
 				      GCancellable *cancellable,
 				      GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -916,12 +900,11 @@ fwupd_client_get_host_security_attrs (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_host_security_attrs_async (self, cancellable,
 						    fwupd_client_get_host_security_attrs_cb,
 						    helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -956,7 +939,7 @@ fwupd_client_get_device_by_id (FwupdClient *self,
 			       GCancellable *cancellable,
 			       GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -968,12 +951,11 @@ fwupd_client_get_device_by_id (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_device_by_id_async (self, device_id, cancellable,
 					     fwupd_client_get_device_by_id_cb,
 					     helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->device == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1007,7 +989,7 @@ GPtrArray *
 fwupd_client_get_devices_by_guid (FwupdClient *self, const gchar *guid,
 				  GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (guid != NULL, NULL);
@@ -1019,12 +1001,11 @@ fwupd_client_get_devices_by_guid (FwupdClient *self, const gchar *guid,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_devices_by_guid_async (self, guid, cancellable,
 						fwupd_client_get_devices_by_guid_cb,
 						helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1067,7 +1048,7 @@ fwupd_client_install (FwupdClient *self,
 {
 #ifdef HAVE_GIO_UNIX
 	g_autoptr(GUnixInputStream) istr = NULL;
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -1085,13 +1066,12 @@ fwupd_client_install (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_install_stream_async (self, device_id, istr, filename,
 					   install_flags, cancellable,
 				           fwupd_client_install_fd_cb,
 				           helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1137,7 +1117,7 @@ fwupd_client_install_bytes (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -1150,13 +1130,12 @@ fwupd_client_install_bytes (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_install_bytes_async (self, device_id, bytes, install_flags,
 					  cancellable,
 					  fwupd_client_install_bytes_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1194,7 +1173,7 @@ fwupd_client_install_release (FwupdClient *self,
 			      GCancellable *cancellable,
 			      GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (FWUPD_IS_DEVICE (device), FALSE);
@@ -1207,13 +1186,12 @@ fwupd_client_install_release (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_install_release_async (self, device, release,
 					    install_flags, cancellable,
 					    fwupd_client_install_release_cb,
 					    helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1262,7 +1240,7 @@ fwupd_client_update_metadata (FwupdClient *self,
 #ifdef HAVE_GIO_UNIX
 	g_autoptr(GUnixInputStream) istr = NULL;
 	g_autoptr(GUnixInputStream) istr_sig = NULL;
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (remote_id != NULL, FALSE);
@@ -1283,12 +1261,11 @@ fwupd_client_update_metadata (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_update_metadata_stream_async (self, remote_id, istr, istr_sig, cancellable,
 						   fwupd_client_update_metadata_cb,
 					           helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1339,7 +1316,7 @@ fwupd_client_update_metadata_bytes (FwupdClient *self,
 				    GCancellable *cancellable,
 				    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (remote_id != NULL, FALSE);
@@ -1353,13 +1330,12 @@ fwupd_client_update_metadata_bytes (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_update_metadata_bytes_async (self, remote_id, metadata, signature,
 						  cancellable,
 						  fwupd_client_update_metadata_bytes_cb,
 						  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1397,7 +1373,7 @@ fwupd_client_refresh_remote (FwupdClient *self,
 			     GCancellable *cancellable,
 			     GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (FWUPD_IS_REMOTE (remote), FALSE);
@@ -1405,12 +1381,11 @@ fwupd_client_refresh_remote (FwupdClient *self,
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_refresh_remote_async (self, remote, cancellable,
 					   fwupd_client_refresh_remote_cb,
 					   helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1451,7 +1426,7 @@ fwupd_client_modify_remote (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (remote_id != NULL, FALSE);
@@ -1465,13 +1440,12 @@ fwupd_client_modify_remote (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_modify_remote_async (self, remote_id, key, value,
 					  cancellable,
 					  fwupd_client_modify_remote_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1504,7 +1478,7 @@ fwupd_client_get_report_metadata (FwupdClient *self,
 				  GCancellable *cancellable,
 				  GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -1515,12 +1489,11 @@ fwupd_client_get_report_metadata (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_report_metadata_async (self, cancellable,
 						fwupd_client_get_report_metadata_cb,
 						helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->hash == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1562,7 +1535,7 @@ fwupd_client_modify_device (FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -1576,13 +1549,12 @@ fwupd_client_modify_device (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_modify_device_async (self, device_id, key, value,
 					  cancellable,
 					  fwupd_client_modify_device_cb,
 					  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1613,7 +1585,7 @@ fwupd_client_get_remotes_cb (GObject *source, GAsyncResult *res, gpointer user_d
 GPtrArray *
 fwupd_client_get_remotes (FwupdClient *self, GCancellable *cancellable, GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), NULL);
@@ -1624,11 +1596,10 @@ fwupd_client_get_remotes (FwupdClient *self, GCancellable *cancellable, GError *
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_remotes_async (self, cancellable,
 					fwupd_client_get_remotes_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1717,7 +1688,7 @@ fwupd_client_get_approved_firmware (FwupdClient *self,
 				    GCancellable *cancellable,
 				    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 	gchar **argv;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
@@ -1729,12 +1700,11 @@ fwupd_client_get_approved_firmware (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_approved_firmware_async (self, cancellable,
 						  fwupd_client_get_approved_firmware_cb,
 						  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1774,7 +1744,7 @@ fwupd_client_set_approved_firmware (FwupdClient *self,
 				    GCancellable *cancellable,
 				    GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 	g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func (g_free);
 
 	/* connect */
@@ -1786,12 +1756,11 @@ fwupd_client_set_approved_firmware (FwupdClient *self,
 		g_ptr_array_add (array, g_strdup (checksums[i]));
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_set_approved_firmware_async (self, array, cancellable,
 						  fwupd_client_set_approved_firmware_cb,
 						  helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1824,7 +1793,7 @@ fwupd_client_get_blocked_firmware (FwupdClient *self,
 				   GCancellable *cancellable,
 				   GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 	gchar **argv;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
@@ -1836,12 +1805,11 @@ fwupd_client_get_blocked_firmware (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_get_blocked_firmware_async (self, cancellable,
 						 fwupd_client_get_blocked_firmware_cb,
 						 helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->array == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -1881,7 +1849,7 @@ fwupd_client_set_blocked_firmware (FwupdClient *self,
 				   GCancellable *cancellable,
 				   GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 	g_autoptr(GPtrArray) array = g_ptr_array_new_with_free_func (g_free);
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
@@ -1897,12 +1865,11 @@ fwupd_client_set_blocked_firmware (FwupdClient *self,
 		g_ptr_array_add (array, g_strdup (checksums[i]));
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_set_blocked_firmware_async (self, array, cancellable,
 						 fwupd_client_set_blocked_firmware_cb,
 						 helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1941,7 +1908,7 @@ fwupd_client_set_feature_flags (FwupdClient *self,
 				GCancellable *cancellable,
 				GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), FALSE);
 	g_return_val_if_fail (cancellable == NULL || G_IS_CANCELLABLE (cancellable), FALSE);
@@ -1952,12 +1919,11 @@ fwupd_client_set_feature_flags (FwupdClient *self,
 		return FALSE;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_set_feature_flags_async (self, feature_flags, cancellable,
 					      fwupd_client_set_feature_flags_cb,
 					      helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (!helper->ret) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
@@ -1994,7 +1960,7 @@ fwupd_client_self_sign (FwupdClient *self,
 			GCancellable *cancellable,
 			GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (value != NULL, NULL);
@@ -2006,12 +1972,11 @@ fwupd_client_self_sign (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_self_sign_async (self, value, flags, cancellable,
 				      fwupd_client_self_sign_cb,
 				      helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->str == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -2049,7 +2014,7 @@ fwupd_client_download_bytes (FwupdClient *self,
 			     GCancellable *cancellable,
 			     GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (url != NULL, NULL);
@@ -2062,11 +2027,10 @@ fwupd_client_download_bytes (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_download_bytes_async (self, url, flags, cancellable,
 					   fwupd_client_download_bytes_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->bytes == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;
@@ -2159,7 +2123,7 @@ fwupd_client_upload_bytes (FwupdClient *self,
 			   GCancellable *cancellable,
 			   GError **error)
 {
-	g_autoptr(FwupdClientHelper) helper = fwupd_client_helper_new ();
+	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (self), NULL);
 	g_return_val_if_fail (url != NULL, NULL);
@@ -2171,11 +2135,10 @@ fwupd_client_upload_bytes (FwupdClient *self,
 		return NULL;
 
 	/* call async version and run loop until complete */
-	g_main_context_push_thread_default (helper->context);
+	helper = fwupd_client_helper_new (self);
 	fwupd_client_upload_bytes_async (self, url, payload, signature, flags, cancellable,
 					 fwupd_client_upload_bytes_cb, helper);
 	g_main_loop_run (helper->loop);
-	g_main_context_pop_thread_default (helper->context);
 	if (helper->bytes == NULL) {
 		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return NULL;

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -68,6 +68,9 @@ typedef enum {
 } FwupdClientUploadFlags;
 
 FwupdClient	*fwupd_client_new			(void);
+GMainContext	*fwupd_client_get_main_context		(FwupdClient	*self);
+void		 fwupd_client_set_main_context		(FwupdClient	*self,
+							 GMainContext	*main_ctx);
 void		 fwupd_client_connect_async		(FwupdClient	*self,
 							 GCancellable	*cancellable,
 							 GAsyncReadyCallback callback,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -626,6 +626,8 @@ LIBFWUPD_1.5.2 {
 
 LIBFWUPD_1.5.3 {
   global:
+    fwupd_client_get_main_context;
+    fwupd_client_set_main_context;
     fwupd_remote_set_keyring_kind;
   local: *;
 } LIBFWUPD_1.5.2;


### PR DESCRIPTION
Use the 'default' main context by default so that we still get the signals
delivered via g_object_notify() but allow the library user to specify an
alternate GMainContext as required.

Using g_main_context_push_thread_default() works for PackageKit as signals are
returned using g_signal_emit() which is synchronous, and so doesn't use the
main context at all.

Use the same style of API which we did for libgusb all those years ago instead.
