### PR TITLE
contrib/ci: Fix Arch cache issues

### DIFF
--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -19,7 +19,7 @@ popd
 chown nobody . -R
 
 # install and run TPM simulator necessary for plugins/uefi/uefi-self-test
-pacman -S --noconfirm swtpm tpm2-tools
+pacman -Syu --noconfirm swtpm tpm2-tools
 swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &
 trap "kill $!" EXIT
 # extend a PCR0 value for test suite


### PR DESCRIPTION
Update cache (which also requires to update the system) to avoid cache issues like the one seen in https://github.com/fwupd/fwupd/pull/2633

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x]  Code fix
- [ ] Feature
- [ ] Documentation

@superm1 In answer to https://github.com/fwupd/fwupd/pull/2633#issuecomment-737500794, the cache was only updated during Docker build (`-y` subaction). So since you splitted that to be daily, the cache would not be refreshed. I’m not sure against which kind of distro breakage you want to protect, but refreshing the cache and installing new packages requires to upgrade installed packages (`-u` subaction, to avoid e.g. ABI breakage), so it’s not very different from re-generating the Docker image (just a bit faster).