### PR TITLE
Add a CI tester for running libfwupd with QT threads

### DIFF
--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -32,6 +32,11 @@ export TPM_SERVER_RUNNING=1
 sudo -E -u nobody PKGEXT='.pkg.tar' makepkg -e --noconfirm
 pacman -U --noconfirm *.pkg.*
 
+#run the CI tests for Qt5
+pacman -Syu --noconfirm qt5-base
+meson qt5-thread-test ../contrib/ci/qt5-thread-test
+ninja -C qt5-thread-test test
+
 # move the package to working dir
 mv *.pkg.* ../dist
 

--- a/contrib/ci/qt5-thread-test/meson.build
+++ b/contrib/ci/qt5-thread-test/meson.build
@@ -1,0 +1,23 @@
+project('qt5-thread-test', 'cpp',
+  license : 'LGPL-2.1+',
+)
+add_project_arguments('-fPIC', language : 'cpp')
+qt5core = dependency('Qt5Core')
+qt5concurrent = dependency('Qt5Concurrent')
+glib2 = dependency('glib-2.0')
+gio2 = dependency('gio-2.0')
+fwupd = dependency('fwupd')
+e = executable(
+  'qt-thread-test',
+  sources : [
+    'qt-thread-test.cpp'
+  ],
+  dependencies : [
+    qt5core,
+    qt5concurrent,
+    glib2,
+    gio2,
+    fwupd,
+  ],
+)
+test('qt-thread-test', e, timeout: 60)

--- a/contrib/ci/qt5-thread-test/qt-thread-test.cpp
+++ b/contrib/ci/qt5-thread-test/qt-thread-test.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Aleix Pol <aleixpol@kde.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+extern "C" {
+#include <fwupd.h>
+}
+
+#include <QCoreApplication>
+#include <QtConcurrentRun>
+#include <QFutureWatcher>
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    auto client = fwupd_client_new();
+    auto cancellable = g_cancellable_new();
+    g_autoptr(GError) error = nullptr;
+
+    auto fw = new QFutureWatcher<GPtrArray*>(&app);
+    QObject::connect(fw, &QFutureWatcher<GPtrArray*>::finished, [fw]() {
+        QCoreApplication::exit(0);
+    });
+    fw->setFuture(QtConcurrent::run([&] {
+        return fwupd_client_get_devices(client, cancellable, &error);
+    }));
+
+    return app.exec();
+}


### PR DESCRIPTION
This only runs on Arch to avoid giving the extra dependencies to all
the distro CI builds.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
