### PR TITLE
Lower the CURL version required to fix build in RHEL

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -1,7 +1,7 @@
 %global glib2_version 2.45.8
 %global libxmlb_version 0.1.3
 %global libgusb_version 0.3.5
-%global libcurl_version 7.62.0
+%global libcurl_version 7.61.0
 %global libjcat_version 0.1.0
 %global systemd_version 231
 %global json_glib_version 1.1.1

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -97,7 +97,9 @@ static guint signals [SIGNAL_LAST] = { 0 };
 G_DEFINE_TYPE_WITH_PRIVATE (FwupdClient, fwupd_client, G_TYPE_OBJECT)
 #define GET_PRIVATE(o) (fwupd_client_get_instance_private (o))
 
+#ifdef HAVE_LIBCURL_7_62_0
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(CURLU, curl_url_cleanup)
+#endif
 
 static void
 fwupd_client_curl_helper_free (FwupdCurlHelper *helper)
@@ -2335,8 +2337,13 @@ fwupd_client_install_release_download_cb (GObject *source, GAsyncResult *res, gp
 static gboolean
 fwupd_client_is_url (const gchar *perhaps_url)
 {
+#ifdef HAVE_LIBCURL_7_62_0
 	g_autoptr(CURLU) h = curl_url ();
 	return curl_url_set (h, CURLUPART_URL, perhaps_url, 0) == CURLUE_OK;
+#else
+	return g_str_has_prefix (perhaps_url, "http://") ||
+		g_str_has_prefix (perhaps_url, "https://");
+#endif
 }
 
 static void

--- a/meson.build
+++ b/meson.build
@@ -208,7 +208,10 @@ endif
 libjcat = dependency('jcat', version : '>= 0.1.0', fallback : ['libjcat', 'libjcat_dep'])
 libjsonglib = dependency('json-glib-1.0', version : '>= 1.1.1')
 valgrind = dependency('valgrind', required: false)
-libcurl = dependency('libcurl', version : '>= 7.62.0')
+libcurl = dependency('libcurl', version : '>= 7.61.0')
+if libcurl.version().version_compare('>= 7.62.0')
+  conf.set('HAVE_LIBCURL_7_62_0', '1')
+endif
 if build_daemon
   if get_option('polkit')
     polkit = dependency('polkit-gobject-1', version : '>= 0.103')

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2009,11 +2009,18 @@ fu_util_show_unsupported_warn (void)
 #endif
 }
 
+#ifdef HAVE_LIBCURL_7_62_0
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(CURLU, curl_url_cleanup)
+#endif
 
 gboolean
 fu_util_is_url (const gchar *perhaps_url)
 {
+#ifdef HAVE_LIBCURL_7_62_0
 	g_autoptr(CURLU) h = curl_url ();
 	return curl_url_set (h, CURLUPART_URL, perhaps_url, 0) == CURLUE_OK;
+#else
+	return g_str_has_prefix (perhaps_url, "http://") ||
+		g_str_has_prefix (perhaps_url, "https://");
+#endif
 }


### PR DESCRIPTION
Some vendors really really want 1.5.x in newer RHEL versions, but the version
of curl is too old. Add #ifdefs so that we can emulate (somewhat imperfectly)
the 'new' CURLU functonality.
