### PR TITLE
trivial: Allow turning off the FMAP binary search when fuzzing

### DIFF
--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -264,6 +264,7 @@ typedef guint64 FwupdPluginFlags;
  * @FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM:		Ignore firmware CRCs and checksums
  * @FWUPD_INSTALL_FLAG_IGNORE_VID_PID:		Ignore firmware vendor and project checks
  * @FWUPD_INSTALL_FLAG_IGNORE_POWER:		Ignore requirement of external power source
+ * @FWUPD_INSTALL_FLAG_NO_SEARCH:		Do not use heuristics when parsing the image
  *
  * Flags to set when performing the firmware update or install.
  **/
@@ -278,6 +279,7 @@ typedef enum {
 	FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM	= 1 << 6,	/* Since: 1.5.0 */
 	FWUPD_INSTALL_FLAG_IGNORE_VID_PID	= 1 << 7,	/* Since: 1.5.0 */
 	FWUPD_INSTALL_FLAG_IGNORE_POWER		= 1 << 8,	/* Since: 1.5.0 */
+	FWUPD_INSTALL_FLAG_NO_SEARCH		= 1 << 9,	/* Since: 1.5.0 */
 	/*< private >*/
 	FWUPD_INSTALL_FLAG_LAST
 } FwupdInstallFlags;

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -174,7 +174,7 @@ fu_fmap_firmware_parse (FuFirmware *firmware,
 	FuFmapFirmwareClass *klass_firmware = FU_FMAP_FIRMWARE_GET_CLASS (firmware);
 	gsize image_len;
 	guint8 *image = (guint8 *)g_bytes_get_data (fw, &image_len);
-	gsize offset;
+	gsize offset = 0;
 	const FuFmap *fmap;
 
 	/* corrupt */
@@ -186,9 +186,12 @@ fu_fmap_firmware_parse (FuFirmware *firmware,
 		return FALSE;
 	}
 
-	if (!fmap_find (image, image_len, &offset, error)) {
-		g_prefix_error (error, "cannot find fmap in image: ");
-		return FALSE;
+	/* only search for the fmap signature if not fuzzing */
+	if ((flags & FWUPD_INSTALL_FLAG_NO_SEARCH) == 0) {
+		if (!fmap_find (image, image_len, &offset, error)) {
+			g_prefix_error (error, "cannot find fmap in image: ");
+			return FALSE;
+		}
 	}
 
 	fmap = (const FuFmap *)(image + offset);


### PR DESCRIPTION
This speeds up the fuzzing task from 22ms to 33us.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
