### PR TITLE
thunderbolt: Add maple ridge firmware parsing support

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-firmware.c
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware.c
@@ -120,6 +120,8 @@ fu_thunderbolt_firmware_family_to_string (FuThunderboltFamily family)
 		return "Titan Ridge";
 	if (family == _FAMILY_BB)
 		return "BB";
+	if (family == _FAMILY_MR)
+		return "Maple Ridge";
 	return "Unknown";
 }
 
@@ -382,6 +384,13 @@ fu_thunderbolt_firmware_parse (FuFirmware *firmware,
 		{ 0x15EA, 3, _FAMILY_TR, 2 }, /* TR 4C */
 		{ 0x15EF, 3, _FAMILY_TR, 2 }, /* TR 4C device */
 		{ 0x15EE, 3, _FAMILY_BB, 0 }, /* BB device */
+		/* Maple ridge devices
+		 * NOTE: These are expected to be flashed via UEFI capsules *not* Thunderbolt plugin
+		 * Flashing via fwupd will require matching kernel work.
+		 * They're left here only for parsing the binaries
+		 */
+		{ 0x1136, 4, _FAMILY_MR, 2 },
+		{ 0x1137, 4, _FAMILY_MR, 2 },
 		{ 0 }
 	};
 
@@ -442,7 +451,7 @@ fu_thunderbolt_firmware_parse (FuFirmware *firmware,
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,
-			     "Unknown controller");
+			     "Unknown controller: %x", priv->device_id);
 		return FALSE;
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-firmware.h
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware.h
@@ -28,6 +28,7 @@ typedef enum {
 	_FAMILY_AR_C,
 	_FAMILY_TR,
 	_FAMILY_BB,
+	_FAMILY_MR,
 } FuThunderboltFamily;
 
 struct _FuThunderboltFirmwareClass


### PR DESCRIPTION
CC @westeri, @YehezkelShB

This is based upon https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git/commit/?h=next&id=db0746e3399ee87ee5f957880811da16faa89fb8 but I found that parsing an image I have locally it's missing an ID 
0x1136.  So I think that's got to be added to kernel still too, no?

If you can please confirm the values I selected for these IDs.  Here's how a local binary parses.
```
FuThunderboltFirmwareUpdate:
Family:                 Maple Ridge
IsHost:                 true
IsNative:               true
DeviceId:               0x1136
VendorId:               0xd4
ModelId:                0xa58
FlashSize:              0x0
Generation:             0x4
Ports:                  0x2
HasPd:                  true
Section0:               0x4000
Section1:               0x4210
Section2:               0x4610
Section3:               0x22958
  FuFirmwareImage:
  Data:                 0x67000
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
