### PR TITLE
synaptics-prometheus: Fix flashing a fingerprint reader that is in use

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -203,6 +203,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "has-multiple-branches";
 	if (device_flag == FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL)
 		return "backup-before-install";
+	if (device_flag == FWUPD_DEVICE_FLAG_RETRY_OPEN)
+		return "retry-open";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -307,6 +309,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES;
 	if (g_strcmp0 (device_flag, "backup-before-install") == 0)
 		return FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL;
+	if (g_strcmp0 (device_flag, "retry-open") == 0)
+		return FWUPD_DEVICE_FLAG_RETRY_OPEN;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -129,6 +129,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES:	Device supports switching to a different stream of firmware
  * @FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL:	Device firmware should be saved before installing firmware
  * @FWUPD_DEVICE_FLAG_MD_SET_ICON:		Set the device icon from the metadata if available
+ * @FWUPD_DEVICE_FLAG_RETRY_OPEN:		Retry the device open up to 5 times if it fails
  *
  * The device flags.
  **/
@@ -175,6 +176,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_HAS_MULTIPLE_BRANCHES	(1llu << 39)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL	(1llu << 40)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_MD_SET_ICON		(1llu << 41)	/* Since: 1.5.2 */
+#define FWUPD_DEVICE_FLAG_RETRY_OPEN		(1llu << 42)	/* Since: 1.5.5 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -374,6 +374,13 @@ gboolean	 fu_device_retry			(FuDevice	*self,
 							 gpointer	 user_data,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
+gboolean	 fu_device_retry_full			(FuDevice	*self,
+							 FuDeviceRetryFunc func,
+							 guint		 count,
+							 guint		 delay,
+							 gpointer	 user_data,
+							 GError		**error)
+							 G_GNUC_WARN_UNUSED_RESULT;
 gboolean	 fu_device_bind_driver			(FuDevice	*self,
 							 const gchar	*subsystem,
 							 const gchar	*driver,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -699,3 +699,9 @@ LIBFWUPDPLUGIN_1.5.4 {
     fu_common_bytes_new_offset;
   local: *;
 } LIBFWUPDPLUGIN_1.5.3;
+
+LIBFWUPDPLUGIN_1.5.5 {
+  global:
+    fu_device_retry_full;
+  local: *;
+} LIBFWUPDPLUGIN_1.5.4;

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -440,6 +440,7 @@ fu_synaprom_device_init (FuSynapromDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_RETRY_OPEN);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1120,6 +1120,10 @@ fu_util_device_flag_to_string (guint64 device_flag)
 		/* skip */
 		return NULL;
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_RETRY_OPEN) {
+		/* skip */
+		return NULL;
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN) {
 		return NULL;
 	}


### PR DESCRIPTION
The fprint daemon only keeps the device open for 5 seconds and then releases it,
which seems like a small window to hit.

But! We're asking the user to authenticate with the same device we're about to
upgrade so a different part of the stack woke up the hardware just before we're
about to deploy an update onto it.

Just wait a couple of seconds to make sure the device is idle.

Fixes https://github.com/fwupd/fwupd/issues/2650
