### PR TITLE
Allow using fwupdtool as non-root for firmware commands

### DIFF
--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -236,6 +236,10 @@ fu_fmap_firmware_parse (FuFirmware *firmware,
 		g_autoptr(FuFirmwareImage) img = NULL;
 		g_autoptr(GBytes) bytes = NULL;
 
+		/* skip */
+		if (area->size == 0)
+			continue;
+
 		img = fu_firmware_image_new (NULL);
 		bytes = fu_common_bytes_new_offset (fw,
 						    (gsize) area->offset,

--- a/plugins/cpu/fu-plugin-cpu.c
+++ b/plugins/cpu/fu-plugin-cpu.c
@@ -37,6 +37,10 @@ fu_plugin_add_security_attrs_intel_cet_enabled (FuPlugin *plugin, FuSecurityAttr
 	FuCpuDevice *device = fu_plugin_cache_lookup (plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
+	/* no CPU */
+	if (device == NULL)
+		return;
+
 	/* create attr */
 	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_INTEL_CET_ENABLED);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
@@ -63,6 +67,10 @@ fu_plugin_add_security_attrs_intel_cet_active (FuPlugin *plugin, FuSecurityAttrs
 	g_autofree gchar *toolfn = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 	g_autoptr(GError) error_local = NULL;
+
+	/* no CPU */
+	if (device == NULL)
+		return;
 
 	/* check for CET */
 	if (!fu_cpu_device_has_flag (device, FU_CPU_DEVICE_FLAG_SHSTK) ||
@@ -98,6 +106,10 @@ fu_plugin_add_security_attrs_intel_tme (FuPlugin *plugin, FuSecurityAttrs *attrs
 	FuCpuDevice *device = fu_plugin_cache_lookup (plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
+	/* no CPU */
+	if (device == NULL)
+		return;
+
 	/* create attr */
 	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM);
 	fwupd_security_attr_set_plugin (attr, fu_plugin_get_name (plugin));
@@ -120,6 +132,10 @@ fu_plugin_add_security_attrs_intel_smap (FuPlugin *plugin, FuSecurityAttrs *attr
 {
 	FuCpuDevice *device = fu_plugin_cache_lookup (plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
+
+	/* no CPU */
+	if (device == NULL)
+		return;
 
 	/* create attr */
 	attr = fwupd_security_attr_new (FWUPD_SECURITY_ATTR_ID_INTEL_SMAP);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -25,14 +25,19 @@ G_DECLARE_FINAL_TYPE (FuEngine, fu_engine, FU, ENGINE, GObject)
 /**
  * FuEngineLoadFlags:
  * @FU_ENGINE_LOAD_FLAG_NONE:		No flags set
- * @FU_ENGINE_LOAD_FLAG_READONLY_FS:	Ignore readonly filesystem errors
+ * @FU_ENGINE_LOAD_FLAG_READONLY:	Ignore readonly filesystem errors
+ * @FU_ENGINE_LOAD_FLAG_COLDPLUG:	Enumerate devices
+ * @FU_ENGINE_LOAD_FLAG_REMOTES:	Enumerate remotes
+ * @FU_ENGINE_LOAD_FLAG_HWINFO:		Load details about the hardware
  *
  * The flags to use when loading the engine.
  **/
 typedef enum {
 	FU_ENGINE_LOAD_FLAG_NONE		= 0,
-	FU_ENGINE_LOAD_FLAG_READONLY_FS		= 1 << 0,
-	FU_ENGINE_LOAD_FLAG_NO_ENUMERATE	= 1 << 1,
+	FU_ENGINE_LOAD_FLAG_READONLY		= 1 << 0,
+	FU_ENGINE_LOAD_FLAG_COLDPLUG		= 1 << 1,
+	FU_ENGINE_LOAD_FLAG_REMOTES		= 1 << 2,
+	FU_ENGINE_LOAD_FLAG_HWINFO		= 1 << 3,
 	/*< private >*/
 	FU_ENGINE_LOAD_FLAG_LAST
 } FuEngineLoadFlags;

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1969,7 +1969,11 @@ main (int argc, char *argv[])
 	g_signal_connect (priv->engine, "percentage-changed",
 			  G_CALLBACK (fu_main_engine_percentage_changed_cb),
 			  priv);
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NONE, &error)) {
+	if (!fu_engine_load (priv->engine,
+			     FU_ENGINE_LOAD_FLAG_COLDPLUG |
+			     FU_ENGINE_LOAD_FLAG_HWINFO |
+			     FU_ENGINE_LOAD_FLAG_REMOTES,
+			     &error)) {
 		g_printerr ("Failed to load engine: %s\n", error->message);
 		return EXIT_FAILURE;
 	}

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -133,7 +133,7 @@ fu_engine_generate_md_func (gconstpointer user_data)
 	g_assert (ret);
 
 	/* load engine and check the device was found */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_REMOTES, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -162,7 +162,7 @@ fu_plugin_hash_func (gconstpointer user_data)
 	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
 	gboolean ret = FALSE;
 
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1172,7 +1172,7 @@ fu_engine_device_unlock_func (gconstpointer user_data)
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1228,7 +1228,7 @@ fu_engine_require_hwid_func (gconstpointer user_data)
 	fu_engine_set_silo (engine, silo_empty);
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1358,7 +1358,7 @@ fu_engine_downgrade_func (gconstpointer user_data)
 	g_assert (ret);
 
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_REMOTES, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1487,7 +1487,7 @@ fu_engine_install_duration_func (gconstpointer user_data)
 	g_assert (ret);
 
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_REMOTES, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1556,7 +1556,7 @@ fu_engine_history_func (gconstpointer user_data)
 	fu_engine_add_plugin (engine, self->plugin);
 
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1683,7 +1683,7 @@ fu_engine_multiple_rels_func (gconstpointer user_data)
 	fu_engine_add_plugin (engine, self->plugin);
 
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1754,7 +1754,7 @@ fu_engine_history_inherit (gconstpointer user_data)
 	g_setenv ("FWUPD_PLUGIN_TEST", "fail", TRUE);
 	fu_engine_add_plugin (engine, self->plugin);
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);
@@ -1865,7 +1865,7 @@ fu_engine_history_error_func (gconstpointer user_data)
 	fu_engine_add_plugin (engine, self->plugin);
 
 	g_setenv ("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
-	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, &error);
+	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (fu_engine_get_status (engine), ==, FWUPD_STATUS_IDLE);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -304,7 +304,7 @@ fu_main_engine_percentage_changed_cb (FuEngine *engine,
 static gboolean
 fu_util_watch (FuUtilPrivate *priv, gchar **values, GError **error)
 {
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_COLDPLUG, error))
 		return FALSE;
 	g_main_loop_run (priv->loop);
 	return TRUE;
@@ -462,7 +462,11 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 	gboolean latest_header = FALSE;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
@@ -558,7 +562,11 @@ fu_util_get_details (FuUtilPrivate *priv, gchar **values, GError **error)
 	gint fd;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
@@ -652,7 +660,11 @@ fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) devs = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
@@ -762,7 +774,11 @@ fu_util_install_blob (FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -939,7 +955,11 @@ fu_util_install (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* handle both forms */
@@ -1241,7 +1261,11 @@ fu_util_update (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	}
 
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	priv->current_operation = FU_UTIL_OPERATION_UPDATE;
@@ -1284,7 +1308,11 @@ fu_util_reinstall (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	}
 
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	dev = fu_util_get_device (priv, values[0], error);
@@ -1347,7 +1375,11 @@ fu_util_detach (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -1375,7 +1407,11 @@ fu_util_unbind_driver (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -1401,7 +1437,11 @@ fu_util_bind_driver (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -1435,7 +1475,11 @@ fu_util_attach (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -1497,7 +1541,7 @@ fu_util_activate (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_READONLY_FS, error))
+	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	/* parse arguments */
@@ -1748,7 +1792,7 @@ fu_util_get_firmware_types (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) firmware_types = NULL;
 
 	/* load engine */
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, error))
+	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	firmware_types = fu_engine_get_firmware_gtype_ids (priv->engine);
@@ -1819,7 +1863,7 @@ fu_util_firmware_parse (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, error))
+	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -1870,7 +1914,7 @@ fu_util_firmware_extract (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, error))
+	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -1952,7 +1996,7 @@ fu_util_firmware_build (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, error))
+	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	/* parse XML */
@@ -2050,7 +2094,7 @@ fu_util_firmware_convert (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_NO_ENUMERATE, error))
+	if (!fu_engine_load (priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -2112,7 +2156,11 @@ fu_util_verify_update (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDevice) dev = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* get device */
@@ -2144,7 +2192,11 @@ fu_util_get_history (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autofree gchar *title = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
@@ -2273,7 +2325,11 @@ fu_util_refresh (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) remotes = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* download new metadata */
@@ -2300,7 +2356,7 @@ fu_util_get_remotes (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autofree gchar *title = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_REMOTES, error))
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
@@ -2342,7 +2398,11 @@ fu_util_security (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	}
 
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* TRANSLATORS: this is a string like 'HSI:2-U' */
@@ -2477,7 +2537,11 @@ fu_util_switch_branch (FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuDevice) dev = NULL;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_HWINFO |
+				   FU_ENGINE_LOAD_FLAG_REMOTES,
+				   error))
 		return FALSE;
 
 	/* find the device and check it has multiple branches */


### PR DESCRIPTION
Just avoid loading SMBIOS and re-generating remotes when all we want to use is
the firmware loader. It also speeds up the self tests somewhat too.
