### PR TITLE
dfu: Show a warning if we fail to release the interface

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1237,9 +1237,13 @@ dfu_device_close (FuUsbDevice *device, GError **error)
 
 	/* release interface */
 	if (priv->claimed_interface) {
-		g_usb_device_release_interface (usb_device,
-						(gint) priv->iface_number,
-						0, NULL);
+		g_autoptr(GError) error_local = NULL;
+		if (!g_usb_device_release_interface (usb_device,
+						     (gint) priv->iface_number,
+						     0, &error_local)) {
+			g_warning ("failed to release interface: %s",
+				   error_local->message);
+		}
 		priv->claimed_interface = FALSE;
 	}
 


### PR DESCRIPTION
I'm not returning FALSE here as it might break plugins.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
