### PR TITLE
Always return DBus signals in the GMainContext that created the FwupdClient

### DIFF
--- a/contrib/ci/qt5-thread-test/meson.build
+++ b/contrib/ci/qt5-thread-test/meson.build
@@ -7,6 +7,8 @@ qt5concurrent = dependency('Qt5Concurrent')
 glib2 = dependency('glib-2.0')
 gio2 = dependency('gio-2.0')
 fwupd = dependency('fwupd')
+env = environment()
+env.set('G_DEBUG', 'fatal-criticals')
 e = executable(
   'qt-thread-test',
   sources : [
@@ -20,4 +22,4 @@ e = executable(
     fwupd,
   ],
 )
-test('qt-thread-test', e, timeout: 60)
+test('qt-thread-test', e, timeout: 60, env: env)

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -47,7 +47,8 @@ typedef GObject		*(*FwupdClientObjectNewFunc)	(void);
 static void fwupd_client_finalize	 (GObject *object);
 
 typedef struct {
-	GMainContext			*main_ctx;
+	GMainContext			*main_ctx_sync;
+	GMainContext			*main_ctx_prxy;
 	FwupdStatus			 status;
 	gboolean			 tainted;
 	gboolean			 interactive;
@@ -297,15 +298,15 @@ GMainContext *
 fwupd_client_get_main_context (FwupdClient *self)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
-	if (priv->main_ctx != NULL)
-		return g_main_context_ref (priv->main_ctx);
+	if (priv->main_ctx_sync != NULL)
+		return g_main_context_ref (priv->main_ctx_sync);
 	return g_main_context_ref_thread_default ();
 }
 
 /**
  * fwupd_client_set_main_context:
  * @self: A #FwupdClient
- * @main_ctx: #GMainContext
+ * @main_ctx: (nullable): #GMainContext or %NULL
  *
  * Sets the internal #GMainContext to use for synchronous methods.
  *
@@ -315,9 +316,11 @@ void
 fwupd_client_set_main_context (FwupdClient *self, GMainContext *main_ctx)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
-	if (main_ctx != priv->main_ctx)
-		g_main_context_unref (priv->main_ctx);
-	priv->main_ctx = g_main_context_ref (main_ctx);
+	if (main_ctx == priv->main_ctx_sync)
+		return;
+	g_clear_pointer (&priv->main_ctx_sync, g_main_context_unref);
+	if (main_ctx != NULL)
+		priv->main_ctx_sync = g_main_context_ref (main_ctx);
 }
 
 /**
@@ -498,6 +501,11 @@ fwupd_client_connect_get_bus_cb (GObject *source,
 		g_task_return_error (task, g_steal_pointer (&error));
 		return;
 	}
+
+	/* we want the GDBusProxy to emit signals in the thread default
+	 * main context of the thread which called fwupd_client_new()
+	 * not the first one that caused a fwupd_client_connect_async()... */
+	g_main_context_push_thread_default (priv->main_ctx_prxy);
 	g_dbus_proxy_new (priv->conn,
 			  G_DBUS_PROXY_FLAGS_NONE,
 			  NULL,
@@ -507,6 +515,7 @@ fwupd_client_connect_get_bus_cb (GObject *source,
 			  g_task_get_cancellable (task),
 			  fwupd_client_connect_get_proxy_cb,
 			  g_object_ref (task));
+	g_main_context_pop_thread_default (priv->main_ctx_prxy);
 }
 
 /**
@@ -2121,6 +2130,10 @@ fwupd_client_install_stream_async (FwupdClient *self,
  *
  * Install firmware onto a specific device.
  *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
+ *
  * Since: 1.5.0
  **/
 void
@@ -2194,6 +2207,10 @@ fwupd_client_install_bytes_finish (FwupdClient *self, GAsyncResult *res, GError 
  * @callback_data: the data to pass to @callback
  *
  * Install firmware onto a specific device.
+ *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
  *
  * Since: 1.5.0
  **/
@@ -2423,6 +2440,10 @@ fwupd_client_install_release_remote_cb (GObject *source, GAsyncResult *res, gpoi
  * @callback_data: the data to pass to @callback
  *
  * Installs a new release on a device, downloading the firmware if required.
+ *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
  *
  * Since: 1.5.0
  **/
@@ -2852,6 +2873,10 @@ fwupd_client_update_metadata_stream_async (FwupdClient *self,
  * The @remote_id allows the firmware to be tagged so that the remote can be
  * matched when the firmware is downloaded.
  *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
+ *
  * Since: 1.5.0
  **/
 void
@@ -3048,6 +3073,10 @@ fwupd_client_refresh_remote_signature_cb (GObject *source,
  * @callback_data: the data to pass to @callback
  *
  * Refreshes a remote by downloading new metadata.
+ *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
  *
  * Since: 1.5.0
  **/
@@ -4127,6 +4156,10 @@ fwupd_client_download_bytes_thread_cb (GTask *task,
  * You must have called fwupd_client_connect_async() on @self before using
  * this method.
  *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
+ *
  * Since: 1.5.0
  **/
 void
@@ -4253,6 +4286,10 @@ fwupd_client_upload_bytes_thread_cb (GTask *task,
  *
  * You must have called fwupd_client_connect_async() on @self before using
  * this method.
+ *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the thread default main context of the thread which
+ * called fwupd_client_new().
  *
  * Since: 1.5.0
  **/
@@ -4651,6 +4688,8 @@ fwupd_client_class_init (FwupdClientClass *klass)
 static void
 fwupd_client_init (FwupdClient *self)
 {
+	FwupdClientPrivate *priv = GET_PRIVATE (self);
+	priv->main_ctx_prxy = g_main_context_ref_thread_default ();
 }
 
 static void
@@ -4659,7 +4698,8 @@ fwupd_client_finalize (GObject *object)
 	FwupdClient *self = FWUPD_CLIENT (object);
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
 
-	g_clear_pointer (&priv->main_ctx, g_main_context_unref);
+	g_clear_pointer (&priv->main_ctx_sync, g_main_context_unref);
+	g_clear_pointer (&priv->main_ctx_prxy, g_main_context_unref);
 	g_free (priv->user_agent);
 	g_free (priv->daemon_version);
 	g_free (priv->host_product);


### PR DESCRIPTION
Without this patch the GDBusProxy will forever emit signals in the thread
default main context of the thread which called fwupd_client_connect_async()
which may be different to the thread context of the g_dbus_proxy_call().
