### PR TITLE
Make the 'id' for fu_plugin_add_firmware_gtype() optional

### DIFF
--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ALTOS_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "altos", FU_TYPE_ALTOS_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_ALTOS_FIRMWARE);
 }

--- a/plugins/bcm57xx/fu-plugin-bcm57xx.c
+++ b/plugins/bcm57xx/fu-plugin-bcm57xx.c
@@ -21,7 +21,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "pci");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_BCM57XX_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "bcm57xx", FU_TYPE_BCM57XX_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "optionrom");
 	g_type_ensure (FU_TYPE_BCM57XX_DICT_IMAGE);
 	g_type_ensure (FU_TYPE_BCM57XX_STAGE1_IMAGE);

--- a/plugins/ccgx/fu-plugin-ccgx.c
+++ b/plugins/ccgx/fu-plugin-ccgx.c
@@ -19,8 +19,8 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_firmware_gtype (plugin, "ccgx", FU_TYPE_CCGX_FIRMWARE);
-	fu_plugin_add_firmware_gtype (plugin, "ccgx", FU_TYPE_CCGX_DMC_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_CCGX_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_HPI_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_DMC_DEVICE);

--- a/plugins/cros-ec/fu-plugin-cros-ec.c
+++ b/plugins/cros-ec/fu-plugin-cros-ec.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CROS_EC_USB_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "cros-ec", FU_TYPE_CROS_EC_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_CROS_EC_FIRMWARE);
 }

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_EBITDO_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "8bitdo", FU_TYPE_EBITDO_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_EBITDO_FIRMWARE);
 }

--- a/plugins/elantp/fu-plugin-elantp.c
+++ b/plugins/elantp/fu-plugin-elantp.c
@@ -33,7 +33,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "i2c-dev");
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
-	fu_plugin_add_firmware_gtype (plugin, "elantp", FU_TYPE_ELANTP_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ELANTP_I2C_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ELANTP_HID_DEVICE);
 }

--- a/plugins/ep963x/fu-plugin-ep963x.c
+++ b/plugins/ep963x/fu-plugin-ep963x.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_EP963X_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "ep963x", FU_TYPE_EP963X_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_EP963X_FIRMWARE);
 }

--- a/plugins/fresco-pd/fu-plugin-fresco-pd.c
+++ b/plugins/fresco-pd/fu-plugin-fresco-pd.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_FRESCO_PD_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "fresco-pd", FU_TYPE_FRESCO_PD_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_FRESCO_PD_FIRMWARE);
 }

--- a/plugins/hailuck/fu-plugin-hailuck.c
+++ b/plugins/hailuck/fu-plugin-hailuck.c
@@ -17,7 +17,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_firmware_gtype (plugin, "hailuck", FU_TYPE_HAILUCK_KBD_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_HAILUCK_KBD_FIRMWARE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_HAILUCK_BL_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_HAILUCK_KBD_DEVICE);
 }

--- a/plugins/solokey/fu-plugin-solokey.c
+++ b/plugins/solokey/fu-plugin-solokey.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SOLOKEY_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "solokey", FU_TYPE_SOLOKEY_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SOLOKEY_FIRMWARE);
 }

--- a/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
+++ b/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "conexant", FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
 }

--- a/plugins/synaptics-prometheus/fu-plugin-synaptics-prometheus.c
+++ b/plugins/synaptics-prometheus/fu-plugin-synaptics-prometheus.c
@@ -17,5 +17,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPROM_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "synaprom", FU_TYPE_SYNAPROM_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPROM_FIRMWARE);
 }

--- a/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
+++ b/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
@@ -18,5 +18,5 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPTICS_RMI_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "rmi", FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -77,8 +77,8 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem (plugin, "thunderbolt");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_THUNDERBOLT_DEVICE);
-	fu_plugin_add_firmware_gtype (plugin, "thunderbolt", FU_TYPE_THUNDERBOLT_FIRMWARE);
-	fu_plugin_add_firmware_gtype (plugin, "thunderbolt-update", FU_TYPE_THUNDERBOLT_FIRMWARE_UPDATE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE_UPDATE);
 	/* dell-dock plugin uses a slower bus for flashing */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "dell_dock");
 }

--- a/plugins/vli/fu-plugin-vli.c
+++ b/plugins/vli/fu-plugin-vli.c
@@ -18,8 +18,8 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_firmware_gtype (plugin, "vli-usbhub", FU_TYPE_VLI_USBHUB_FIRMWARE);
-	fu_plugin_add_firmware_gtype (plugin, "vli-pd", FU_TYPE_VLI_PD_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_VLI_USBHUB_FIRMWARE);
+	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_VLI_PD_FIRMWARE);
 
 	/* register the custom types */
 	g_type_ensure (FU_TYPE_VLI_USBHUB_DEVICE);


### PR DESCRIPTION
We can work out the correct value automatically in all cases but one, and it's
less for the plugin author to get wrong...

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
