### PR TITLE
Allow updates to depend on device flags

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -205,6 +205,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "backup-before-install";
 	if (device_flag == FWUPD_DEVICE_FLAG_RETRY_OPEN)
 		return "retry-open";
+	if (device_flag == FWUPD_DEVICE_FLAG_HAS_UPGRADE)
+		return "has-upgrade";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -311,6 +313,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL;
 	if (g_strcmp0 (device_flag, "retry-open") == 0)
 		return FWUPD_DEVICE_FLAG_RETRY_OPEN;
+	if (g_strcmp0 (device_flag, "has-upgrade") == 0)
+		return FWUPD_DEVICE_FLAG_HAS_UPGRADE;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -130,6 +130,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL:	Device firmware should be saved before installing firmware
  * @FWUPD_DEVICE_FLAG_MD_SET_ICON:		Set the device icon from the metadata if available
  * @FWUPD_DEVICE_FLAG_RETRY_OPEN:		Retry the device open up to 5 times if it fails
+ * @FWUPD_DEVICE_FLAG_HAS_UPGRADE:		Device has an update that is pending
  *
  * The device flags.
  **/
@@ -177,6 +178,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL	(1llu << 40)	/* Since: 1.5.0 */
 #define FWUPD_DEVICE_FLAG_MD_SET_ICON		(1llu << 41)	/* Since: 1.5.2 */
 #define FWUPD_DEVICE_FLAG_RETRY_OPEN		(1llu << 42)	/* Since: 1.5.5 */
+#define FWUPD_DEVICE_FLAG_HAS_UPGRADE		(1llu << 43)	/* Since: 1.5.5 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -415,6 +415,73 @@ fu_engine_requirements_unsupported_func (gconstpointer user_data)
 }
 
 static void
+fu_engine_requirements_latest_func (gconstpointer user_data)
+{
+	gboolean ret;
+	g_autoptr(FuDevice) device1 = fu_device_new ();
+	g_autoptr(FuDevice) device2 = fu_device_new ();
+	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new ();
+	g_autoptr(FuInstallTask) task = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbNode) component = NULL;
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(XbSilo) silo_empty = xb_silo_new ();
+	const gchar *xml =
+		"<component>"
+		"  <requires>"
+		"    <device type=\"flag\">has-upgrade</device>"
+		"    <device type=\"flag\">1ff60ab2-3905-06a1-b476-0371f00c9e9b:~has-upgrade</device>"
+		"  </requires>"
+		"  <provides>"
+		"    <firmware type=\"flashed\">12345678-1234-1234-1234-123456789012</firmware>"
+		"  </provides>"
+		"  <releases>"
+		"    <release version=\"1.2.4\">"
+		"      <checksum type=\"sha1\" filename=\"bios.bin\" target=\"content\"/>"
+		"    </release>"
+		"  </releases>"
+		"</component>";
+
+	/* no metadata in daemon */
+	fu_engine_set_silo (engine, silo_empty);
+
+	/* set up a dummy device */
+	fu_device_set_id (device2, "me");
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
+	fu_device_add_flag (device1, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (device1, FWUPD_DEVICE_FLAG_HAS_UPGRADE);
+	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
+
+	/* set up a different device */
+	fu_device_set_id (device2, "bios");
+	fu_device_add_vendor_id (device2, "USB:FFFF");
+	fu_device_set_protocol (device2, "com.acme");
+	fu_device_set_name (device2, "BIOS firmware");
+	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device2, "4.5.6");
+	fu_device_add_guid (device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_engine_add_device (engine, device2);
+
+	/* import firmware metainfo */
+	silo = xb_silo_new_from_xml (xml, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (silo);
+	component = xb_silo_query_first (silo, "component", &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (component);
+
+	/* check this passes */
+	task = fu_install_task_new (device1, component);
+	ret = fu_engine_check_requirements (engine, request, task,
+					    FWUPD_INSTALL_FLAG_NONE,
+					    &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+}
+
+static void
 fu_engine_requirements_child_func (gconstpointer user_data)
 {
 	gboolean ret;
@@ -3204,6 +3271,8 @@ main (int argc, char **argv)
 			      fu_engine_requirements_parent_device_func);
 	g_test_add_data_func ("/fwupd/engine{requirements_protocol_check_func}", self,
 			      fu_engine_requirements_protocol_check_func);
+	g_test_add_data_func ("/fwupd/engine{requirements-latest}", self,
+			      fu_engine_requirements_latest_func);
 	g_test_add_data_func ("/fwupd/engine{requirements-not-child}", self,
 			      fu_engine_requirements_child_func);
 	g_test_add_data_func ("/fwupd/engine{requirements-not-child-fail}", self,


### PR DESCRIPTION
This could be used, for instance to require a different device having no
pending updates. Another use case is to only deploy the new firmware onto
devices that have been tagged as supported or even not stuck in bootloader mode.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
