### PR TITLE
trivial: Fix a warning generated by new versions of meson

### DIFF
--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -81,7 +81,7 @@ libfwupd_dep = declare_dependency(
 
 pkgg = import('pkgconfig')
 pkgg.generate(
-  libraries : fwupd,
+  fwupd,
   requires : [ 'gio-2.0' ],
   subdirs : 'fwupd-1',
   version : meson.project_version(),


### PR DESCRIPTION
This fixes:

    DEPRECATION: Library fwupd was passed to the "libraries" keyword argument of
    a previous call to generate() method instead of first positional argument.
    Adding fwupd to "Requires" field, but this is a deprecated behaviour that
    will change in a future version of Meson.
