### PR TITLE
Correct some logic errors in daemon with handling of thunderbolt plugin

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2137,10 +2137,6 @@ fu_plugin_runner_device_register (FuPlugin *self, FuDevice *device)
 	if (priv->module == NULL)
 		return;
 
-	/* don't notify plugins on their own devices */
-	if (g_strcmp0 (fu_device_get_plugin (device), fu_plugin_get_name (self)) == 0)
-		return;
-
 	/* optional */
 	g_module_symbol (priv->module, "fu_plugin_device_registered", (gpointer *) &func);
 	if (func != NULL) {

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -63,7 +63,8 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 		return;
 
 	/* Operating system will handle finishing updates later */
-	if (fu_plugin_get_config_value_boolean (plugin, "DelayedActivation")) {
+	if (fu_plugin_get_config_value_boolean (plugin, "DelayedActivation") &&
+	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
 		g_debug ("Turning on delayed activation for %s",
 			 fu_device_get_name (device));
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2237,7 +2237,7 @@ fu_engine_install_release (FuEngine *self,
 	if (version_rel != NULL &&
 	    fu_common_vercmp_full (version_orig, version_rel, fmt) != 0 &&
 	    fu_common_vercmp_full (version_orig, fu_device_get_version (device), fmt) == 0 &&
-	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_SKIPS_RESTART)) {
+	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 		g_autofree gchar *str = NULL;
 		fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);
 		str = g_strdup_printf ("device version not updated on success, %s != %s",


### PR DESCRIPTION
The main issue is purely cosmetic, but it leads to erroneous failure reports.
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

CC @YehezkelShB 
@djcampello: some of this is ChromeOS specific fixes I found while fixing the generic issue that was flagging reports. 