### PR TITLE
Only include the start year in the copyright header

### DIFF
--- a/contrib/ci/generate_dependencies.py
+++ b/contrib/ci/generate_dependencies.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (C) 2017-2018 Dell, Inc.
+# Copyright (C) 2017 Dell, Inc.
 # Copyright (C) 2020 Intel, Inc.
 #
 # SPDX-License-Identifier: LGPL-2.1+

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (C) 2017-2018 Dell, Inc.
+# Copyright (C) 2017 Dell, Inc.
 #
 # SPDX-License-Identifier: LGPL-2.1+
 #

--- a/contrib/debian/copyright.in
+++ b/contrib/debian/copyright.in
@@ -9,7 +9,7 @@ License: CC0-1.0
 
 Files: debian/*
 Copyright: 2015 Daniel Jared Dominguez <Jared_Dominguez@Dell.com>
-           2015-2018 Mario Limonciello <mario.limonciello@dell.com>
+           2015 Mario Limonciello <mario.limonciello@dell.com>
 License: LGPL-2.1+
 
 License: LGPL-2.1+

--- a/data/tests/multiple-rels/firmware.metainfo.xml
+++ b/data/tests/multiple-rels/firmware.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2017-2019 Richard Hughes <richard@hughsie.com> -->
+<!-- Copyright 2017 Richard Hughes <richard@hughsie.com> -->
 <component type="firmware">
   <id>com.hughski.test.firmware</id>
   <provides>

--- a/libfwupd/fwupd-client-private.h
+++ b/libfwupd/fwupd-client-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-common.h
+++ b/libfwupd/fwupd-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-cabinet.h
+++ b/libfwupdplugin/fu-cabinet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-chunk.h
+++ b/libfwupdplugin/fu-chunk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-common-guid.c
+++ b/libfwupdplugin/fu-common-guid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-common-guid.h
+++ b/libfwupdplugin/fu-common-guid.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-common-version.c
+++ b/libfwupdplugin/fu-common-version.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-common-version.h
+++ b/libfwupdplugin/fu-common-version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-efivar.c
+++ b/libfwupdplugin/fu-efivar.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-efivar.h
+++ b/libfwupdplugin/fu-efivar.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-firmware-common.c
+++ b/libfwupdplugin/fu-firmware-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-firmware-common.h
+++ b/libfwupdplugin/fu-firmware-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-hid-device.h
+++ b/libfwupdplugin/fu-hid-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-io-channel.h
+++ b/libfwupdplugin/fu-io-channel.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-udev-device-private.h
+++ b/libfwupdplugin/fu-udev-device-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/libfwupdplugin/fu-volume-private.h
+++ b/libfwupdplugin/fu-volume-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/altos/fu-altos-device.h
+++ b/plugins/altos/fu-altos-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/altos/fu-altos-firmware.c
+++ b/plugins/altos/fu-altos-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/altos/fu-altos-firmware.h
+++ b/plugins/altos/fu-altos-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Evan Lojewski
+ * Copyright (C) 2018 Evan Lojewski
  * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: GPL-2+

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Evan Lojewski
+ * Copyright (C) 2018 Evan Lojewski
  * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 Evan Lojewski
+ * Copyright (C) 2018 Evan Lojewski
  * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: GPL-2+

--- a/plugins/colorhug/fu-colorhug-common.c
+++ b/plugins/colorhug/fu-colorhug-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/colorhug/fu-colorhug-common.h
+++ b/plugins/colorhug/fu-colorhug-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/colorhug/fu-colorhug-device.h
+++ b/plugins/colorhug/fu-colorhug-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/csr/fu-csr-device.h
+++ b/plugins/csr/fu-csr-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2017-2018 Dell, Inc.
+ * Copyright (C) 2017 Dell, Inc.
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-device.h
+++ b/plugins/dfu/dfu-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-firmware.c
+++ b/plugins/dfu/dfu-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-firmware.h
+++ b/plugins/dfu/dfu-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-target.c
+++ b/plugins/dfu/dfu-target.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/dfu/dfu-target.h
+++ b/plugins/dfu/dfu-target.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/ebitdo/fu-ebitdo-firmware.h
+++ b/plugins/ebitdo/fu-ebitdo-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/goodix-moc/fu-goodixmoc-common.c
+++ b/plugins/goodix-moc/fu-goodixmoc-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 boger wang <boger@goodix.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/goodix-moc/fu-goodixmoc-common.h
+++ b/plugins/goodix-moc/fu-goodixmoc-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 boger wang <boger@goodix.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 boger wang <boger@goodix.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/goodix-moc/fu-goodixmoc-device.h
+++ b/plugins/goodix-moc/fu-goodixmoc-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 boger wang <boger@goodix.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/goodix-moc/fu-plugin-goodixmoc.c
+++ b/plugins/goodix-moc/fu-plugin-goodixmoc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 boger wang <boger@goodix.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-common.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-common.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-self-test.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-self-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-redfish-client.h
+++ b/plugins/redfish/fu-redfish-client.h
@@ -1,5 +1,5 @@
  /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-redfish-common.c
+++ b/plugins/redfish/fu-redfish-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-redfish-common.h
+++ b/plugins/redfish/fu-redfish-common.h
@@ -1,5 +1,5 @@
  /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/steelseries/fu-plugin-steelseries.c
+++ b/plugins/steelseries/fu-plugin-steelseries.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/steelseries/fu-steelseries-device.h
+++ b/plugins/steelseries/fu-steelseries-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/superio/fu-superio-common.h
+++ b/plugins/superio/fu-superio-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/superio/fu-superio-it85-device.c
+++ b/plugins/superio/fu-superio-it85-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/superio/fu-superio-it85-device.h
+++ b/plugins/superio/fu-superio-it85-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/superio/fu-superio-it89-device.h
+++ b/plugins/superio/fu-superio-it89-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-common.h
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2019 Synaptics Incorporated
+ * Copyright (C) 2005 Synaptics Incorporated
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2005-2019 Synaptics Incorporated
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2005 Synaptics Incorporated
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2019 Synaptics Incorporated
+ * Copyright (C) 2005 Synaptics Incorporated
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.h
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2019 Synaptics Incorporated
+ * Copyright (C) 2005 Synaptics Incorporated
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2017 Mario Limonciello <mario.limonciello@dell.com>
  * Copyright (C) 2017 Peichen Huang <peichenhuang@tw.synaptics.com>
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/synaptics-mst/fu-synaptics-mst-connection.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-connection.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2016 Mario Limonciello <mario.limonciello@dell.com>
  * Copyright (C) 2017 Peichen Huang <peichenhuang@tw.synaptics.com>
  *

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2016 Mario Limonciello <mario.limonciello@dell.com>
  * Copyright (C) 2017 Peichen Huang <peichenhuang@tw.synaptics.com>
  * Copyright (C) 2018 Ryan Chang <ryan.chang@synaptics.com>

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-common.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-common.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-common.h
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-common.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v6-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v6-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2012-2014 Andrew Duggan
- * Copyright (C) 2012-2019 Synaptics Inc.
+ * Copyright (C) 2012 Andrew Duggan
+ * Copyright (C) 2012 Synaptics Inc.
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/uefi-capsule/efi/fwup-efi.h
+++ b/plugins/uefi-capsule/efi/fwup-efi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/efi/fwupdate.c
+++ b/plugins/uefi-capsule/efi/fwupdate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Red Hat, Inc.
+ * Copyright (C) 2014 Red Hat, Inc.
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.h
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-devpath.c
+++ b/plugins/uefi-capsule/fu-uefi-devpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-capsule/fu-uefi-devpath.h
+++ b/plugins/uefi-capsule/fu-uefi-devpath.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Peter Jones <pjones@redhat.com>
+ * Copyright (C) 2015 Peter Jones <pjones@redhat.com>
  * Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-common.c
+++ b/plugins/vli/fu-vli-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-common.h
+++ b/plugins/vli/fu-vli-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-common.c
+++ b/plugins/vli/fu-vli-pd-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-common.h
+++ b/plugins/vli/fu-vli-pd-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 VIA Corporation
+ * Copyright (C) 2015 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-firmware.h
+++ b/plugins/vli/fu-vli-pd-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 VIA Corporation
+ * Copyright (C) 2015 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-common.c
+++ b/plugins/vli/fu-vli-usbhub-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-common.h
+++ b/plugins/vli/fu-vli-usbhub-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-firmware.h
+++ b/plugins/vli/fu-vli-usbhub-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-i2c-common.c
+++ b/plugins/vli/fu-vli-usbhub-i2c-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-i2c-common.h
+++ b/plugins/vli/fu-vli-usbhub-i2c-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 VIA Corporation
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/vli/fu-vli-usbhub-msp430-device.h
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
+ * Copyright (C) 2017 VIA Corporation
  * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2017-2019 VIA Corporation
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 VIA Corporation
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.h
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-aes-device.h
+++ b/plugins/wacom-raw/fu-wacom-aes-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-common.c
+++ b/plugins/wacom-raw/fu-wacom-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-common.h
+++ b/plugins/wacom-raw/fu-wacom-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-device.h
+++ b/plugins/wacom-raw/fu-wacom-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-raw/fu-wacom-emr-device.h
+++ b/plugins/wacom-raw/fu-wacom-emr-device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/plugins/wacom-usb/fu-wac-firmware.h
+++ b/plugins/wacom-usb/fu-wac-firmware.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-debug.c
+++ b/src/fu-debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-debug.h
+++ b/src/fu-debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2011 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-firmware-dump.c
+++ b/src/fu-firmware-dump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-history.h
+++ b/src/fu-history.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-install-task.h
+++ b/src/fu-install-task.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-keyring-utils.c
+++ b/src/fu-keyring-utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-keyring-utils.h
+++ b/src/fu-keyring-utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-offline.c
+++ b/src/fu-offline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-polkit-agent.c
+++ b/src/fu-polkit-agent.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Lennart Poettering <lennart@poettering.net>
  * Copyright (C) 2012 Matthias Klumpp <matthias@tenstral.net>
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-polkit-agent.h
+++ b/src/fu-polkit-agent.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Lennart Poettering <lennart@poettering.net>
  * Copyright (C) 2012 Matthias Klumpp <matthias@tenstral.net>
- * Copyright (C) 2015-2020 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-remote-list.h
+++ b/src/fu-remote-list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-systemd.c
+++ b/src/fu-systemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-systemd.h
+++ b/src/fu-systemd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */


### PR DESCRIPTION
The end year is legally and functionally redundant, and more importantly causes
cherry-pick conflicts when trying to maintain old branches. Use git for history.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
