### PR TITLE
Make building the plugins shared objects optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -164,12 +164,19 @@ add_project_arguments('-D_GNU_SOURCE', language : 'c')
 if get_option('build') == 'all'
   build_standalone = true
   build_daemon = true
+  build_plugins = true
 elif get_option('build') == 'standalone'
   build_standalone = true
   build_daemon = false
+  build_plugins = true
 elif get_option('build') == 'library'
   build_standalone = false
   build_daemon = false
+  build_plugins = false
+elif get_option('build') == 'fuzzing'
+  build_standalone = true
+  build_daemon = false
+  build_plugins = false
 endif
 
 prefix = get_option('prefix')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
+option('build', type : 'combo', choices : ['all', 'standalone', 'library', 'fuzzing'], value : 'all', description : 'build type')
 option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
 option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
 option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')

--- a/plugins/acpi-dmar/meson.build
+++ b/plugins/acpi-dmar/meson.build
@@ -1,27 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiDmar"']
 
-shared_module('fu_plugin_acpi_dmar',
-  fu_hash,
-  sources : [
-    'fu-plugin-acpi-dmar.c',
-    'fu-acpi-dmar.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_acpi_dmar',
+    fu_hash,
+    sources : [
+      'fu-plugin-acpi-dmar.c',
+      'fu-acpi-dmar.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/acpi-facp/meson.build
+++ b/plugins/acpi-facp/meson.build
@@ -1,27 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiFacp"']
 
-shared_module('fu_plugin_acpi_facp',
-  fu_hash,
-  sources : [
-    'fu-plugin-acpi-facp.c',
-    'fu-acpi-facp.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_acpi_facp',
+    fu_hash,
+    sources : [
+      'fu-plugin-acpi-facp.c',
+      'fu-acpi-facp.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/altos/meson.build
+++ b/plugins/altos/meson.build
@@ -1,30 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginAltos"']
 
-install_data(['altos.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_altos',
-  fu_hash,
-  sources : [
-    'fu-altos-device.c',
-    'fu-altos-firmware.c',
-    'fu-plugin-altos.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    libelf,
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['altos.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_altos',
+    fu_hash,
+    sources : [
+      'fu-altos-device.c',
+      'fu-altos-firmware.c',
+      'fu-plugin-altos.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      libelf,
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/amt/meson.build
+++ b/plugins/amt/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginAmt"']
 
-shared_module('fu_plugin_amt',
-  fu_hash,
-  sources : [
-    'fu-plugin-amt.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_amt',
+    fu_hash,
+    sources : [
+      'fu-plugin-amt.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/ata/meson.build
+++ b/plugins/ata/meson.build
@@ -1,36 +1,37 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginAta"']
 
-install_data([
-  'ata.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_ata',
-  fu_hash,
-  sources : [
-    'fu-plugin-ata.c',
-    'fu-ata-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-    '-DLOCALSTATEDIR="' + localstatedir + '"',
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'ata.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_ata',
+    fu_hash,
+    sources : [
+      'fu-plugin-ata.c',
+      'fu-ata-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+      '-DLOCALSTATEDIR="' + localstatedir + '"',
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/bcm57xx/meson.build
+++ b/plugins/bcm57xx/meson.build
@@ -3,35 +3,38 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginBcm57xx"']
 install_data(['bcm57xx.quirk'],
   install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
 )
-shared_module('fu_plugin_bcm57xx',
-  fu_hash,
-  sources : [
-    'fu-plugin-bcm57xx.c',
-    'fu-bcm57xx-common.c',
-    'fu-bcm57xx-device.c',
-    'fu-bcm57xx-dict-image.c',
-    'fu-bcm57xx-firmware.c',
-    'fu-bcm57xx-recovery-device.c',
-    'fu-bcm57xx-stage1-image.c',
-    'fu-bcm57xx-stage2-image.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    valgrind,
-  ],
-)
+
+if build_plugins
+  shared_module('fu_plugin_bcm57xx',
+    fu_hash,
+    sources : [
+      'fu-plugin-bcm57xx.c',
+      'fu-bcm57xx-common.c',
+      'fu-bcm57xx-device.c',
+      'fu-bcm57xx-dict-image.c',
+      'fu-bcm57xx-firmware.c',
+      'fu-bcm57xx-recovery-device.c',
+      'fu-bcm57xx-stage1-image.c',
+      'fu-bcm57xx-stage2-image.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      valgrind,
+    ],
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/bios/meson.build
+++ b/plugins/bios/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginBios"']
 
-shared_module('fu_plugin_bios',
-  fu_hash,
-  sources : [
-    'fu-plugin-bios.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_bios',
+    fu_hash,
+    sources : [
+      'fu-plugin-bios.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/ccgx/meson.build
+++ b/plugins/ccgx/meson.build
@@ -1,39 +1,40 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginCcgx"']
 
-install_data([
-  'ccgx-ids.quirk',
-  'ccgx.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_ccgx',
-  fu_hash,
-  sources : [
-    'fu-plugin-ccgx.c',
-    'fu-ccgx-common.c',
-    'fu-ccgx-firmware.c',
-    'fu-ccgx-hid-device.c',
-    'fu-ccgx-hpi-common.c',
-    'fu-ccgx-hpi-device.c',
-    'fu-ccgx-dmc-device.c',
-    'fu-ccgx-dmc-firmware.c',
-    'fu-ccgx-dmc-common.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    gudev,
-  ],
-)
+if build_plugins
+  install_data([
+    'ccgx-ids.quirk',
+    'ccgx.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_ccgx',
+    fu_hash,
+    sources : [
+      'fu-plugin-ccgx.c',
+      'fu-ccgx-common.c',
+      'fu-ccgx-firmware.c',
+      'fu-ccgx-hid-device.c',
+      'fu-ccgx-hpi-common.c',
+      'fu-ccgx-hpi-device.c',
+      'fu-ccgx-dmc-device.c',
+      'fu-ccgx-dmc-firmware.c',
+      'fu-ccgx-dmc-common.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      gudev,
+    ],
+  )
+endif

--- a/plugins/colorhug/meson.build
+++ b/plugins/colorhug/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginColorHug"']
 
-install_data([
-  'colorhug.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+if build_plugins
+  install_data([
+    'colorhug.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_colorhug',
+    fu_hash,
+    sources : [
+      'fu-colorhug-common.c',
+      'fu-colorhug-device.c',
+      'fu-plugin-colorhug.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
 )
-
-shared_module('fu_plugin_colorhug',
-  fu_hash,
-  sources : [
-    'fu-colorhug-common.c',
-    'fu-colorhug-device.c',
-    'fu-plugin-colorhug.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+endif

--- a/plugins/coreboot/meson.build
+++ b/plugins/coreboot/meson.build
@@ -1,30 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginCoreboot"']
 
-install_data(['coreboot.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_coreboot',
-  fu_hash,
-  sources : [
-    'fu-plugin-coreboot.c',
-    'fu-coreboot-common.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : [
-    cargs,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['coreboot.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_coreboot',
+    fu_hash,
+    sources : [
+      'fu-plugin-coreboot.c',
+      'fu-coreboot-common.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : [
+      cargs,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/cpu/meson.build
+++ b/plugins/cpu/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginCpu"']
 
-install_data(['cpu.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_cpu',
-  fu_hash,
-  sources : [
-    'fu-plugin-cpu.c',
-    'fu-cpu-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['cpu.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_cpu',
+    fu_hash,
+    sources : [
+      'fu-plugin-cpu.c',
+      'fu-cpu-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if cc.has_argument('-fcf-protection')
   libfwupdcethelper = static_library('fwupdcethelper',

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -1,10 +1,10 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginCrosEc"']
 
-install_data(['cros-ec.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_cros_ec',
+if build_plugins
+  install_data(['cros-ec.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_cros_ec',
   fu_hash,
   sources : [
     'fu-plugin-cros-ec.c',
@@ -28,3 +28,4 @@ shared_module('fu_plugin_cros_ec',
     plugin_deps,
   ],
 )
+endif

--- a/plugins/csr/meson.build
+++ b/plugins/csr/meson.build
@@ -1,29 +1,30 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginCsr"']
 
-install_data(['csr-aiaiai.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_csr',
-  fu_hash,
-  sources : [
-    'fu-csr-device.c',
-    'fu-plugin-csr.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-    plugindfu_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupdplugin,
-    dfu,
-  ],
-)
+if build_plugins
+  install_data(['csr-aiaiai.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_csr',
+    fu_hash,
+    sources : [
+      'fu-csr-device.c',
+      'fu-plugin-csr.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+      plugindfu_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupdplugin,
+      dfu,
+    ],
+  )
+endif

--- a/plugins/dell-dock/meson.build
+++ b/plugins/dell-dock/meson.build
@@ -1,35 +1,36 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginDellDock"']
 
-install_data(['dell-dock.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_dell_dock',
-  fu_hash,
-  sources : [
-    'fu-plugin-dell-dock.c',
-    'fu-dell-dock-common.c',
-    'fu-dell-dock-hid.c',
-    'fu-dell-dock-status.c',
-    'fu-dell-dock-i2c-ec.c',
-    'fu-dell-dock-hub.c',
-    'fu-dell-dock-i2c-tbt.c',
-    'fu-dell-dock-i2c-mst.c'
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    gudev,
-  ],
-)
+if build_plugins
+  install_data(['dell-dock.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_dell_dock',
+    fu_hash,
+    sources : [
+      'fu-plugin-dell-dock.c',
+      'fu-dell-dock-common.c',
+      'fu-dell-dock-hid.c',
+      'fu-dell-dock-status.c',
+      'fu-dell-dock-i2c-ec.c',
+      'fu-dell-dock-hub.c',
+      'fu-dell-dock-i2c-tbt.c',
+      'fu-dell-dock-i2c-mst.c'
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      gudev,
+    ],
+  )
+endif

--- a/plugins/dell-esrt/meson.build
+++ b/plugins/dell-esrt/meson.build
@@ -1,33 +1,34 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginDellEsrt"']
 
-install_data(['metadata.xml'],
-  install_dir : join_paths(datadir, 'fwupd', 'remotes.d', 'dell-esrt')
-)
-
-shared_module('fu_plugin_dell_esrt',
-  fu_hash,
-  sources : [
-    'fu-plugin-dell-esrt.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-    libsmbios_c,
-  ],
-)
+if build_plugins
+  install_data(['metadata.xml'],
+    install_dir : join_paths(datadir, 'fwupd', 'remotes.d', 'dell-esrt')
+  )
+  shared_module('fu_plugin_dell_esrt',
+    fu_hash,
+    sources : [
+      'fu-plugin-dell-esrt.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+      libsmbios_c,
+    ],
+  )
+endif
 
 # replace @datadir@
 con2 = configuration_data()

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -1,35 +1,36 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginDell"']
 
-install_data(['dell.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_dell',
-  fu_hash,
-  sources : [
-    'fu-plugin-dell.c',
-    'fu-dell-smi.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : [
-    cargs,
-  ],
-  dependencies : [
-    plugin_deps,
-    libsmbios_c,
-    tpm2tss,
-  ],
-)
+if build_plugins
+  install_data(['dell.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_dell',
+    fu_hash,
+    sources : [
+      'fu-plugin-dell.c',
+      'fu-dell-smi.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : [
+      cargs,
+    ],
+    dependencies : [
+      plugin_deps,
+      libsmbios_c,
+      tpm2tss,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadir = join_paths(meson.current_source_dir(), 'tests')

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -1,9 +1,5 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginDfu"']
 
-install_data(['dfu.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
 dfu = static_library(
   'dfu',
   fu_hash,
@@ -40,28 +36,33 @@ dfu = static_library(
   ],
 )
 
-shared_module('fu_plugin_dfu',
-  fu_hash,
-  sources : [
-    'fu-plugin-dfu.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-    dfu,
-  ],
-)
+if build_plugins
+  install_data(['dfu.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_dfu',
+    fu_hash,
+    sources : [
+      'fu-plugin-dfu.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+      dfu,
+    ],
+  )
+endif
 
 dfu_tool = executable(
   'dfu-tool',

--- a/plugins/ebitdo/meson.build
+++ b/plugins/ebitdo/meson.build
@@ -1,30 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginEbitdo"']
 
-install_data(['ebitdo.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_ebitdo',
-  fu_hash,
-  sources : [
-    'fu-plugin-ebitdo.c',
-    'fu-ebitdo-common.c',
-    'fu-ebitdo-device.c',
-    'fu-ebitdo-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['ebitdo.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_ebitdo',
+    fu_hash,
+    sources : [
+      'fu-plugin-ebitdo.c',
+      'fu-ebitdo-common.c',
+      'fu-ebitdo-device.c',
+      'fu-ebitdo-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/elantp/meson.build
+++ b/plugins/elantp/meson.build
@@ -1,36 +1,37 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginElantp"']
 
-install_data([
-  'elantp.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_elantp',
-  fu_hash,
-  sources : [
-    'fu-plugin-elantp.c',
-    'fu-elantp-common.c',
-    'fu-elantp-firmware.c',
-    'fu-elantp-hid-device.c',
-    'fu-elantp-i2c-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-    '-DLOCALSTATEDIR="' + localstatedir + '"',
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'elantp.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_elantp',
+    fu_hash,
+    sources : [
+      'fu-plugin-elantp.c',
+      'fu-elantp-common.c',
+      'fu-elantp-firmware.c',
+      'fu-elantp-hid-device.c',
+      'fu-elantp-i2c-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+      '-DLOCALSTATEDIR="' + localstatedir + '"',
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/emmc/meson.build
+++ b/plugins/emmc/meson.build
@@ -1,27 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginEmmc"']
 
-install_data(['emmc.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-shared_module('fu_plugin_emmc',
-  fu_hash,
-  sources : [
-    'fu-plugin-emmc.c',
-    'fu-emmc-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['emmc.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_emmc',
+    fu_hash,
+    sources : [
+      'fu-plugin-emmc.c',
+      'fu-emmc-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/ep963x/meson.build
+++ b/plugins/ep963x/meson.build
@@ -1,32 +1,33 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginEp963x"']
 
-install_data([
-  'ep963x.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_ep963x',
-  fu_hash,
-  sources : [
-    'fu-ep963x-common.c',
-    'fu-ep963x-device.c',
-    'fu-ep963x-firmware.c',
-    'fu-plugin-ep963x.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'ep963x.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_ep963x',
+    fu_hash,
+    sources : [
+      'fu-ep963x-common.c',
+      'fu-ep963x-device.c',
+      'fu-ep963x-firmware.c',
+      'fu-plugin-ep963x.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/fastboot/meson.build
+++ b/plugins/fastboot/meson.build
@@ -1,28 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginFastboot"']
 
-install_data(['fastboot.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_fastboot',
-  fu_hash,
-  sources : [
-    'fu-plugin-fastboot.c',
-    'fu-fastboot-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['fastboot.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_fastboot',
+    fu_hash,
+    sources : [
+      'fu-plugin-fastboot.c',
+      'fu-fastboot-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginFlashrom"']
 
-install_data(['flashrom.quirk'],
-  install_dir: join_paths(get_option('datadir'), 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_flashrom',
-  fu_hash,
-  sources : [
-    'fu-plugin-flashrom.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : [
-    cargs,
-    '-DLOCALSTATEDIR="' + localstatedir + '"',
-  ],
-  dependencies : [
-    plugin_deps,
-    libflashrom,
-  ],
-)
+if build_plugins
+  install_data(['flashrom.quirk'],
+    install_dir: join_paths(get_option('datadir'), 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_flashrom',
+    fu_hash,
+    sources : [
+      'fu-plugin-flashrom.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : [
+      cargs,
+      '-DLOCALSTATEDIR="' + localstatedir + '"',
+    ],
+    dependencies : [
+      plugin_deps,
+      libflashrom,
+    ],
+  )
+endif

--- a/plugins/fresco-pd/meson.build
+++ b/plugins/fresco-pd/meson.build
@@ -1,30 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginFrescoPd"']
 
-install_data(['fresco-pd.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_fresco_pd',
-  fu_hash,
-  sources : [
-    'fu-plugin-fresco-pd.c',
-    'fu-fresco-pd-common.c',
-    'fu-fresco-pd-device.c',
-    'fu-fresco-pd-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['fresco-pd.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_fresco_pd',
+    fu_hash,
+    sources : [
+      'fu-plugin-fresco-pd.c',
+      'fu-fresco-pd-common.c',
+      'fu-fresco-pd-device.c',
+      'fu-fresco-pd-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/goodix-moc/meson.build
+++ b/plugins/goodix-moc/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginGoodixMoc"']
 
-install_data([
-  'goodixmoc.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_goodixmoc',
-  fu_hash,
-  sources : [
-    'fu-goodixmoc-common.c',
-    'fu-goodixmoc-device.c',
-    'fu-plugin-goodixmoc.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'goodixmoc.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_goodixmoc',
+    fu_hash,
+    sources : [
+      'fu-goodixmoc-common.c',
+      'fu-goodixmoc-device.c',
+      'fu-plugin-goodixmoc.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/hailuck/meson.build
+++ b/plugins/hailuck/meson.build
@@ -1,34 +1,35 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginNovatek"']
 
-install_data([
-  'hailuck.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_hailuck',
-  fu_hash,
-  sources : [
-    'fu-hailuck-common.c',
-    'fu-hailuck-bl-device.c',
-    'fu-hailuck-kbd-device.c',
-    'fu-hailuck-kbd-firmware.c',
-    'fu-hailuck-tp-device.c',
-    'fu-plugin-hailuck.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'hailuck.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_hailuck',
+    fu_hash,
+    sources : [
+      'fu-hailuck-common.c',
+      'fu-hailuck-bl-device.c',
+      'fu-hailuck-kbd-device.c',
+      'fu-hailuck-kbd-firmware.c',
+      'fu-hailuck-tp-device.c',
+      'fu-plugin-hailuck.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/iommu/meson.build
+++ b/plugins/iommu/meson.build
@@ -1,29 +1,30 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginIommu"']
 
-install_data([
-  'iommu.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_iommu',
-  fu_hash,
-  sources : [
-    'fu-plugin-iommu.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupdplugin,
-    fwupd,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'iommu.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_iommu',
+    fu_hash,
+    sources : [
+      'fu-plugin-iommu.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupdplugin,
+      fwupd,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/jabra/meson.build
+++ b/plugins/jabra/meson.build
@@ -1,28 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginJabra"']
 
-install_data(['jabra.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_jabra',
-  fu_hash,
-  sources : [
-    'fu-plugin-jabra.c',
-    'fu-jabra-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['jabra.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_jabra',
+    fu_hash,
+    sources : [
+      'fu-plugin-jabra.c',
+      'fu-jabra-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/linux-lockdown/meson.build
+++ b/plugins/linux-lockdown/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxLockdown"']
 
-shared_module('fu_plugin_linux_lockdown',
-  fu_hash,
-  sources : [
-    'fu-plugin-linux-lockdown.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_linux_lockdown',
+    fu_hash,
+    sources : [
+      'fu-plugin-linux-lockdown.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/linux-sleep/meson.build
+++ b/plugins/linux-sleep/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSleep"']
 
-shared_module('fu_plugin_linux_sleep',
-  fu_hash,
-  sources : [
-    'fu-plugin-linux-sleep.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_linux_sleep',
+    fu_hash,
+    sources : [
+      'fu-plugin-linux-sleep.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/linux-swap/meson.build
+++ b/plugins/linux-swap/meson.build
@@ -1,27 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSwap"']
 
-shared_module('fu_plugin_linux_swap',
-  fu_hash,
-  sources : [
-    'fu-plugin-linux-swap.c',
-    'fu-linux-swap.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_linux_swap',
+    fu_hash,
+    sources : [
+      'fu-plugin-linux-swap.c',
+      'fu-linux-swap.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/linux-tainted/meson.build
+++ b/plugins/linux-tainted/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxTainted"']
 
-shared_module('fu_plugin_linux_tainted',
-  fu_hash,
-  sources : [
-    'fu-plugin-linux-tainted.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_linux_tainted',
+    fu_hash,
+    sources : [
+      'fu-plugin-linux-tainted.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/logind/meson.build
+++ b/plugins/logind/meson.build
@@ -1,23 +1,25 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogind"']
 
-shared_module('fu_plugin_logind',
-  fu_hash,
-  sources : [
-    'fu-plugin-logind.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_logind',
+    fu_hash,
+    sources : [
+      'fu-plugin-logind.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/logitech-hidpp/meson.build
+++ b/plugins/logitech-hidpp/meson.build
@@ -1,41 +1,41 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechHidPp"']
 
-install_data([
-  'logitech-hidpp.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-
-shared_module('fu_plugin_logitech_hidpp',
-  fu_hash,
-  sources : [
-    'fu-plugin-logitech-hidpp.c',
-    'fu-logitech-hidpp-bootloader.c',
-    'fu-logitech-hidpp-bootloader-nordic.c',
-    'fu-logitech-hidpp-bootloader-texas.c',
-    'fu-logitech-hidpp-common.c',
-    'fu-logitech-hidpp-hidpp.c',
-    'fu-logitech-hidpp-hidpp-msg.c',
-    'fu-logitech-hidpp-peripheral.c',
-    'fu-logitech-hidpp-runtime.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'logitech-hidpp.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_logitech_hidpp',
+    fu_hash,
+    sources : [
+      'fu-plugin-logitech-hidpp.c',
+      'fu-logitech-hidpp-bootloader.c',
+      'fu-logitech-hidpp-bootloader-nordic.c',
+      'fu-logitech-hidpp-bootloader-texas.c',
+      'fu-logitech-hidpp-common.c',
+      'fu-logitech-hidpp-hidpp.c',
+      'fu-logitech-hidpp-hidpp-msg.c',
+      'fu-logitech-hidpp-peripheral.c',
+      'fu-logitech-hidpp-runtime.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -1,34 +1,35 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginMm"']
 
-install_data(['modem-manager.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_modem_manager',
-  fu_hash,
-  sources : [
-    'fu-plugin-modem-manager.c',
-    'fu-mm-device.c',
-    'fu-qmi-pdc-updater.c',
-    'fu-mm-utils.c'
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-    libmm_glib,
-    libqmi_glib,
-  ],
-)
+if build_plugins
+  install_data(['modem-manager.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_modem_manager',
+    fu_hash,
+    sources : [
+      'fu-plugin-modem-manager.c',
+      'fu-mm-device.c',
+      'fu-qmi-pdc-updater.c',
+      'fu-mm-utils.c'
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+      libmm_glib,
+      libqmi_glib,
+    ],
+  )
+endif

--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -1,33 +1,33 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginMsr"']
 
-install_data(['msr.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-if get_option('systemd')
-install_data(['fwupd-msr.conf'],
-  install_dir: systemd_modules_load_dir,
-)
+if build_plugins
+  install_data(['msr.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  if get_option('systemd')
+    install_data(['fwupd-msr.conf'],
+      install_dir: systemd_modules_load_dir,
+    )
+  endif
+  shared_module('fu_plugin_msr',
+    fu_hash,
+    sources : [
+      'fu-plugin-msr.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
 endif
-
-shared_module('fu_plugin_msr',
-  fu_hash,
-  sources : [
-    'fu-plugin-msr.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginNitrokey"']
 
-install_data(['nitrokey.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_nitrokey',
-  fu_hash,
-  sources : [
-    'fu-nitrokey-device.c',
-    'fu-nitrokey-common.c',
-    'fu-plugin-nitrokey.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['nitrokey.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_nitrokey',
+    fu_hash,
+    sources : [
+      'fu-nitrokey-device.c',
+      'fu-nitrokey-common.c',
+      'fu-plugin-nitrokey.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -1,37 +1,38 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginNvme"']
 
-install_data([
-  'nvme.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_nvme',
-  fu_hash,
-  sources : [
-    'fu-plugin-nvme.c',
-    'fu-nvme-common.c',
-    'fu-nvme-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-    '-DLOCALSTATEDIR="' + localstatedir + '"',
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'nvme.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_nvme',
+    fu_hash,
+    sources : [
+      'fu-plugin-nvme.c',
+      'fu-nvme-common.c',
+      'fu-nvme-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+      '-DLOCALSTATEDIR="' + localstatedir + '"',
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/optionrom/meson.build
+++ b/plugins/optionrom/meson.build
@@ -1,32 +1,33 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginOptionrom"']
 
-install_data(['optionrom.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_optionrom',
-  fu_hash,
-  sources : [
-    'fu-plugin-optionrom.c',
-    'fu-optionrom-device.c',
-    'fu-rom.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['optionrom.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_optionrom',
+    fu_hash,
+    sources : [
+      'fu-plugin-optionrom.c',
+      'fu-optionrom-device.c',
+      'fu-rom.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 optionrom_tool = executable(
   'fu-rom-tool',

--- a/plugins/pci-bcr/meson.build
+++ b/plugins/pci-bcr/meson.build
@@ -1,27 +1,28 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginPciBcr"']
 
-install_data(['pci-bcr.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_pci_bcr',
-  fu_hash,
-  sources : [
-    'fu-plugin-pci-bcr.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['pci-bcr.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_pci_bcr',
+    fu_hash,
+    sources : [
+      'fu-plugin-pci-bcr.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/pci-mei/meson.build
+++ b/plugins/pci-mei/meson.build
@@ -1,28 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginPciMei"']
 
-install_data(['pci-mei.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_pci_mei',
-  fu_hash,
-  sources : [
-    'fu-plugin-pci-mei.c',
-    'fu-mei-common.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['pci-mei.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_pci_mei',
+    fu_hash,
+    sources : [
+      'fu-plugin-pci-mei.c',
+      'fu-mei-common.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/pixart-rf/meson.build
+++ b/plugins/pixart-rf/meson.build
@@ -1,25 +1,27 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginPixartRf"']
 
-shared_module('fu_plugin_pixart_rf',
-  fu_hash,
-  sources : [
-    'fu-plugin-pixart-rf.c',
-    'fu-pxi-device.c',
-    'fu-pxi-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_pixart_rf',
+    fu_hash,
+    sources : [
+      'fu-plugin-pixart-rf.c',
+      'fu-pxi-device.c',
+      'fu-pxi-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+  )
+endif

--- a/plugins/platform-integrity/meson.build
+++ b/plugins/platform-integrity/meson.build
@@ -1,35 +1,36 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginPlatformIntegrity"']
 
-install_data([
-  'platform-integrity.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
+if build_plugins
+  install_data([
+    'platform-integrity.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
 
-if get_option('systemd')
-install_data(['fwupd-platform-integrity.conf'],
-  install_dir: systemd_modules_load_dir,
-)
+  if get_option('systemd')
+  install_data(['fwupd-platform-integrity.conf'],
+    install_dir: systemd_modules_load_dir,
+  )
+  endif
+  shared_module('fu_plugin_platform_integrity',
+    fu_hash,
+    sources : [
+      'fu-plugin-platform-integrity.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
 endif
-
-shared_module('fu_plugin_platform_integrity',
-  fu_hash,
-  sources : [
-    'fu-plugin-platform-integrity.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -1,34 +1,35 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginRedfish"']
 
-shared_module('fu_plugin_redfish',
-  fu_hash,
-  sources : [
-    'fu-plugin-redfish.c',
-    'fu-redfish-client.c',
-    'fu-redfish-common.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    libcurl,
-    libjsonglib,
-  ],
-)
-
-install_data(['redfish.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
+if build_plugins
+  shared_module('fu_plugin_redfish',
+    fu_hash,
+    sources : [
+      'fu-plugin-redfish.c',
+      'fu-redfish-client.c',
+      'fu-redfish-common.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      libcurl,
+      libjsonglib,
+    ],
+  )
+  install_data(['redfish.conf'],
+    install_dir:  join_paths(sysconfdir, 'fwupd')
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/rts54hid/meson.build
+++ b/plugins/rts54hid/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginRts54Hid"']
 
-install_data([
-  'rts54hid.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_rts54hid',
-  fu_hash,
-  sources : [
-    'fu-rts54hid-device.c',
-    'fu-rts54hid-module.c',
-    'fu-plugin-rts54hid.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'rts54hid.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_rts54hid',
+    fu_hash,
+    sources : [
+      'fu-rts54hid-device.c',
+      'fu-rts54hid-module.c',
+      'fu-plugin-rts54hid.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/rts54hub/meson.build
+++ b/plugins/rts54hub/meson.build
@@ -1,30 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginRts54Hub"']
 
-install_data([
-  'rts54hub.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_rts54hub',
-  fu_hash,
-  sources : [
-    'fu-rts54hub-device.c',
-    'fu-plugin-rts54hub.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'rts54hub.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_rts54hub',
+    fu_hash,
+    sources : [
+      'fu-rts54hub-device.c',
+      'fu-plugin-rts54hub.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/solokey/meson.build
+++ b/plugins/solokey/meson.build
@@ -1,32 +1,33 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSoloKey"']
 
-install_data([
-  'solokey.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_solokey',
-  fu_hash,
-  sources : [
-    'fu-solokey-device.c',
-    'fu-solokey-firmware.c',
-    'fu-plugin-solokey.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    libjsonglib,
-  ],
-)
+if build_plugins
+  install_data([
+    'solokey.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_solokey',
+    fu_hash,
+    sources : [
+      'fu-solokey-device.c',
+      'fu-solokey-firmware.c',
+      'fu-plugin-solokey.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      libjsonglib,
+    ],
+  )
+endif

--- a/plugins/steelseries/meson.build
+++ b/plugins/steelseries/meson.build
@@ -1,27 +1,28 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSteelSeries"']
 
-install_data(['steelseries.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_steelseries',
-  fu_hash,
-  sources : [
-    'fu-plugin-steelseries.c',
-    'fu-steelseries-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['steelseries.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_steelseries',
+    fu_hash,
+    sources : [
+      'fu-plugin-steelseries.c',
+      'fu-steelseries-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/superio/meson.build
+++ b/plugins/superio/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSuperio"']
 
-install_data(['superio.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_superio',
-  fu_hash,
-  sources : [
-    'fu-plugin-superio.c',
-    'fu-superio-device.c',
-    'fu-superio-it85-device.c',
-    'fu-superio-it89-device.c',
-    'fu-superio-common.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['superio.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_superio',
+    fu_hash,
+    sources : [
+      'fu-plugin-superio.c',
+      'fu-superio-device.c',
+      'fu-superio-it85-device.c',
+      'fu-superio-it89-device.c',
+      'fu-superio-common.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/synaptics-cxaudio/meson.build
+++ b/plugins/synaptics-cxaudio/meson.build
@@ -1,29 +1,30 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsCxaudio"']
 
-install_data(['synaptics-cxaudio.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_synaptics_cxaudio',
-  fu_hash,
-  sources : [
-    'fu-plugin-synaptics-cxaudio.c',
-    'fu-synaptics-cxaudio-device.c',
-    'fu-synaptics-cxaudio-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['synaptics-cxaudio.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_synaptics_cxaudio',
+    fu_hash,
+    sources : [
+      'fu-plugin-synaptics-cxaudio.c',
+      'fu-synaptics-cxaudio-device.c',
+      'fu-synaptics-cxaudio-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -1,35 +1,36 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsMST"']
 
-install_data(['synaptics-mst.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_synaptics_mst',
-  fu_hash,
-  sources : [
-    'fu-plugin-synaptics-mst.c',
-    'fu-synaptics-mst-common.c',
-    'fu-synaptics-mst-connection.c',
-    'fu-synaptics-mst-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : [
-    cargs,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['synaptics-mst.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_synaptics_mst',
+    fu_hash,
+    sources : [
+      'fu-plugin-synaptics-mst.c',
+      'fu-synaptics-mst-common.c',
+      'fu-synaptics-mst-connection.c',
+      'fu-synaptics-mst-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : [
+      cargs,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -1,34 +1,35 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsPrometheus"']
 
-install_data(['synaptics-prometheus.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_synaptics_prometheus',
-  fu_hash,
-  sources : [
-    'fu-plugin-synaptics-prometheus.c',
-    'fu-synaprom-common.c',
-    'fu-synaprom-config.c',
-    'fu-synaprom-device.c',
-    'fu-synaprom-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['synaptics-prometheus.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_synaptics_prometheus',
+    fu_hash,
+    sources : [
+      'fu-plugin-synaptics-prometheus.c',
+      'fu-synaprom-common.c',
+      'fu-synaprom-config.c',
+      'fu-synaprom-device.c',
+      'fu-synaprom-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -1,33 +1,34 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsRmi"']
 
-install_data(['synaptics-rmi.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_synaptics_rmi',
-  fu_hash,
-  sources : [
-    'fu-plugin-synaptics-rmi.c',
-    'fu-synaptics-rmi-common.c',
-    'fu-synaptics-rmi-device.c',
-    'fu-synaptics-rmi-v5-device.c',
-    'fu-synaptics-rmi-v6-device.c',
-    'fu-synaptics-rmi-v7-device.c',
-    'fu-synaptics-rmi-firmware.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-)
+if build_plugins
+  install_data(['synaptics-rmi.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_synaptics_rmi',
+    fu_hash,
+    sources : [
+      'fu-plugin-synaptics-rmi.c',
+      'fu-synaptics-rmi-common.c',
+      'fu-synaptics-rmi-device.c',
+      'fu-synaptics-rmi-v5-device.c',
+      'fu-synaptics-rmi-v6-device.c',
+      'fu-synaptics-rmi-v7-device.c',
+      'fu-synaptics-rmi-firmware.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+  )
+endif

--- a/plugins/test/meson.build
+++ b/plugins/test/meson.build
@@ -5,29 +5,32 @@ if get_option('plugin_dummy')
   install_dummy = true
 endif
 
-shared_module('fu_plugin_test',
-  fu_hash,
-  sources : [
-    'fu-plugin-test.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : install_dummy,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_test',
+    fu_hash,
+    sources : [
+      'fu-plugin-test.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : install_dummy,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
-shared_module('fu_plugin_invalid',
+if build_plugins
+  shared_module('fu_plugin_invalid',
   sources : [
     'fu-plugin-invalid.c',
   ],
@@ -46,3 +49,4 @@ shared_module('fu_plugin_invalid',
     plugin_deps,
   ],
 )
+endif

--- a/plugins/thelio-io/meson.build
+++ b/plugins/thelio-io/meson.build
@@ -1,28 +1,29 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginThelioIo"']
 
-install_data(['thelio-io.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_thelio_io',
-  fu_hash,
-  sources : [
-    'fu-plugin-thelio-io.c',
-    'fu-thelio-io-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['thelio-io.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_thelio_io',
+    fu_hash,
+    sources : [
+      'fu-plugin-thelio-io.c',
+      'fu-thelio-io-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -1,38 +1,41 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginThunderbolt"']
 cargs += '-DTESTDATADIR="' + join_paths(meson.source_root(), 'data', 'tests') + '"'
-install_data([
-  'thunderbolt.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
-  fu_hash,
-  sources : [
-    'fu-plugin-thunderbolt.c',
-    'fu-thunderbolt-device.c',
-    'fu-thunderbolt-firmware.c',
-    'fu-thunderbolt-firmware-update.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
 
-install_data(['thunderbolt.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
+if build_plugins
+  install_data(['thunderbolt.conf'],
+    install_dir:  join_paths(sysconfdir, 'fwupd')
+  )
+  install_data([
+    'thunderbolt.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
+    fu_hash,
+    sources : [
+      'fu-plugin-thunderbolt.c',
+      'fu-thunderbolt-device.c',
+      'fu-thunderbolt-firmware.c',
+      'fu-thunderbolt-firmware-update.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
+
 # we use functions from 2.52 in the tests
 if get_option('tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
   cargs += '-DPLUGINBUILDDIR="' + meson.current_build_dir() + '"'

--- a/plugins/tpm-eventlog/meson.build
+++ b/plugins/tpm-eventlog/meson.build
@@ -1,30 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginTpmEventlog"']
 
-shared_module('fu_plugin_tpm_eventlog',
-  fu_hash,
-  sources : [
-    'fu-plugin-tpm-eventlog.c',
-    'fu-tpm-eventlog-common.c',
-    'fu-tpm-eventlog-device.c',
-    'fu-tpm-eventlog-parser.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupdplugin,
-    fwupd,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    tpm2tss,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_tpm_eventlog',
+    fu_hash,
+    sources : [
+      'fu-plugin-tpm-eventlog.c',
+      'fu-tpm-eventlog-common.c',
+      'fu-tpm-eventlog-device.c',
+      'fu-tpm-eventlog-parser.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupdplugin,
+      fwupd,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      tpm2tss,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginTpm"']
 
-install_data([
-  'tpm.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_tpm',
-  fu_hash,
-  sources : [
-    'fu-plugin-tpm.c',
-    'fu-tpm-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupdplugin,
-    fwupd,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    tpm2tss,
-  ],
-)
+if build_plugins
+  install_data([
+    'tpm.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_tpm',
+    fu_hash,
+    sources : [
+      'fu-plugin-tpm.c',
+      'fu-tpm-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupdplugin,
+      fwupd,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      tpm2tss,
+    ],
+  )
+endif

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -7,40 +7,42 @@ if efi_os_dir != ''
   cargs += '-DEFI_OS_DIR="' + efi_os_dir + '"'
 endif
 
-install_data(['uefi-capsule.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
-
-shared_module('fu_plugin_uefi_capsule',
-  fu_hash,
-  sources : [
-    'fu-plugin-uefi-capsule.c',
-    'fu-uefi-bgrt.c',
-    'fu-ucs2.c',
-    'fu-uefi-bootmgr.c',
-    'fu-uefi-common.c',
-    'fu-uefi-device.c',
-    'fu-uefi-devpath.c',
-    'fu-uefi-pcrs.c',
-    'fu-uefi-update-info.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    efiboot,
-    tpm2tss,
-  ],
-)
+if build_plugins
+  install_data(['uefi-capsule.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_uefi_capsule',
+    fu_hash,
+    sources : [
+      'fu-plugin-uefi-capsule.c',
+      'fu-uefi-bgrt.c',
+      'fu-ucs2.c',
+      'fu-uefi-bootmgr.c',
+      'fu-uefi-common.c',
+      'fu-uefi-device.c',
+      'fu-uefi-devpath.c',
+      'fu-uefi-pcrs.c',
+      'fu-uefi-update-info.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      efiboot,
+      tpm2tss,
+    ],
+  )
+endif
 
 fwupdate = executable(
   'fwupdate',

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -1,29 +1,31 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefiDbx"']
 
-shared_module('fu_plugin_uefi_dbx',
-  fu_hash,
-  sources : [
-    'fu-plugin-uefi-dbx.c',
-    'fu-uefi-dbx-common.c',
-    'fu-uefi-dbx-device.c',
-    'fu-efi-image.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_uefi_dbx',
+    fu_hash,
+    sources : [
+      'fu-plugin-uefi-dbx.c',
+      'fu-uefi-dbx-common.c',
+      'fu-uefi-dbx-device.c',
+      'fu-efi-image.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()

--- a/plugins/uefi-pk/meson.build
+++ b/plugins/uefi-pk/meson.build
@@ -1,24 +1,26 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefiPk"']
 
-shared_module('fu_plugin_uefi_pk',
-  fu_hash,
-  sources : [
-    'fu-plugin-uefi-pk.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-    gnutls,
-  ],
-)
+if build_plugins
+  shared_module('fu_plugin_uefi_pk',
+    fu_hash,
+    sources : [
+      'fu-plugin-uefi-pk.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+      gnutls,
+    ],
+  )
+endif

--- a/plugins/uefi-recovery/meson.build
+++ b/plugins/uefi-recovery/meson.build
@@ -1,29 +1,30 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefiRecovery"']
 
-install_data(['uefi-recovery.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_uefi_recovery',
-  fu_hash,
-  sources : [
-    'fu-plugin-uefi-recovery.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : [
-    cargs,
-  ],
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data(['uefi-recovery.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_uefi_recovery',
+    fu_hash,
+    sources : [
+      'fu-plugin-uefi-recovery.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : [
+      cargs,
+    ],
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -1,27 +1,28 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
 
-shared_module('fu_plugin_upower',
-  fu_hash,
-  sources : [
-    'fu-plugin-upower.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
-
-install_data(['upower.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
+if build_plugins
+  install_data(['upower.conf'],
+    install_dir:  join_paths(sysconfdir, 'fwupd')
+  )
+  shared_module('fu_plugin_upower',
+    fu_hash,
+    sources : [
+      'fu-plugin-upower.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -1,48 +1,49 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginVliUsbhub"']
 
-install_data([
-  'vli-pd.quirk',
-  'vli-usbhub.quirk',
-  'vli-usbhub-lenovo.quirk',
-  'vli-usbhub-hyper.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_vli',
-  fu_hash,
-  sources : [
-    'fu-plugin-vli.c',
-    'fu-vli-common.c',
-    'fu-vli-device.c',
-    'fu-vli-pd-common.c',
-    'fu-vli-pd-device.c',
-    'fu-vli-pd-firmware.c',
-    'fu-vli-pd-parade-device.c',
-    'fu-vli-usbhub-common.c',
-    'fu-vli-usbhub-device.c',
-    'fu-vli-usbhub-firmware.c',
-    'fu-vli-usbhub-i2c-common.c',
-    'fu-vli-usbhub-msp430-device.c',
-    'fu-vli-usbhub-pd-device.c',
-    'fu-vli-usbhub-rtd21xx-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-)
+if build_plugins
+  install_data([
+    'vli-pd.quirk',
+    'vli-usbhub.quirk',
+    'vli-usbhub-lenovo.quirk',
+    'vli-usbhub-hyper.quirk',
+    ],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_vli',
+    fu_hash,
+    sources : [
+      'fu-plugin-vli.c',
+      'fu-vli-common.c',
+      'fu-vli-device.c',
+      'fu-vli-pd-common.c',
+      'fu-vli-pd-device.c',
+      'fu-vli-pd-firmware.c',
+      'fu-vli-pd-parade-device.c',
+      'fu-vli-usbhub-common.c',
+      'fu-vli-usbhub-device.c',
+      'fu-vli-usbhub-firmware.c',
+      'fu-vli-usbhub-i2c-common.c',
+      'fu-vli-usbhub-msp430-device.c',
+      'fu-vli-usbhub-pd-device.c',
+      'fu-vli-usbhub-rtd21xx-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+  )
+endif
 
 if get_option('tests')
   e = executable(

--- a/plugins/wacom-raw/meson.build
+++ b/plugins/wacom-raw/meson.build
@@ -1,31 +1,32 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginWacomRaw"']
 
-install_data(['wacom-raw.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_wacom_raw',
-  fu_hash,
-  sources : [
-    'fu-plugin-wacom-raw.c',
-    'fu-wacom-common.c',
-    'fu-wacom-device.c',
-    'fu-wacom-aes-device.c',
-    'fu-wacom-emr-device.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-)
+if build_plugins
+  install_data(['wacom-raw.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_wacom_raw',
+    fu_hash,
+    sources : [
+      'fu-plugin-wacom-raw.c',
+      'fu-wacom-common.c',
+      'fu-wacom-device.c',
+      'fu-wacom-aes-device.c',
+      'fu-wacom-emr-device.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+  )
+endif

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -1,36 +1,37 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginWacomUsb"']
 
-install_data(['wacom-usb.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
-shared_module('fu_plugin_wacom_usb',
-  fu_hash,
-  sources : [
-    'fu-wac-common.c',
-    'fu-wac-device.c',
-    'fu-wac-firmware.c',
-    'fu-wac-module.c',
-    'fu-wac-module-bluetooth.c',
-    'fu-wac-module-touch.c',
-    'fu-plugin-wacom-usb.c',
-  ],
-  include_directories : [
-    root_incdir,
-    fwupd_incdir,
-    fwupdplugin_incdir,
-  ],
-  install : true,
-  install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
-    plugin_deps,
-  ],
-  link_with : [
-    fwupd,
-    fwupdplugin,
-  ],
-)
+if build_plugins
+  install_data(['wacom-usb.quirk'],
+    install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+  )
+  shared_module('fu_plugin_wacom_usb',
+    fu_hash,
+    sources : [
+      'fu-wac-common.c',
+      'fu-wac-device.c',
+      'fu-wac-firmware.c',
+      'fu-wac-module.c',
+      'fu-wac-module-bluetooth.c',
+      'fu-wac-module-touch.c',
+      'fu-plugin-wacom-usb.c',
+    ],
+    include_directories : [
+      root_incdir,
+      fwupd_incdir,
+      fwupdplugin_incdir,
+    ],
+    install : true,
+    install_dir: plugin_dir,
+    c_args : cargs,
+    dependencies : [
+      plugin_deps,
+    ],
+    link_with : [
+      fwupd,
+      fwupdplugin,
+    ],
+  )
+endif
 
 if get_option('tests')
   testdatadirs = environment()


### PR DESCRIPTION
When building the static fuzz targets we cannot link shared objects. We also
can make the list of built targets a lot smaller!

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
