### PR TITLE
uefi-dbx: Ignore the legacy OVMF dummy GUID for the version

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -157,6 +157,7 @@ fu_efi_signature_list_get_version (FuEfiSignatureList *self)
 	guint csum_cnt = 0;
 	const gchar *ignored_guids[] = {
 		FU_EFI_SIGNATURE_GUID_OVMF,
+		FU_EFI_SIGNATURE_GUID_OVMF_LEGACY,
 		NULL };
 	g_autoptr(GPtrArray) sigs = NULL;
 	sigs = fu_firmware_get_images (FU_FIRMWARE (self));

--- a/libfwupdplugin/fu-efi-signature.h
+++ b/libfwupdplugin/fu-efi-signature.h
@@ -24,6 +24,7 @@ typedef enum {
 #define FU_EFI_SIGNATURE_GUID_ZERO		"00000000-0000-0000-0000-000000000000"
 #define FU_EFI_SIGNATURE_GUID_MICROSOFT		"77fa9abd-0359-4d32-bd60-28f4e78f784b"
 #define FU_EFI_SIGNATURE_GUID_OVMF		"a0baa8a3-041d-48a8-bc87-c36d121b5e3d"
+#define FU_EFI_SIGNATURE_GUID_OVMF_LEGACY	"d5c1df0b-1bac-4edf-ba48-08834009ca5a"
 
 const gchar	*fu_efi_signature_kind_to_string	(FuEfiSignatureKind	 kind);
 

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -80,7 +80,8 @@ fu_dbxtool_guid_to_string (const gchar *guid)
 		return "zero";
 	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_MICROSOFT) == 0)
 		return "microsoft";
-	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_OVMF) == 0)
+	if (g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_OVMF) == 0 ||
+	    g_strcmp0 (guid, FU_EFI_SIGNATURE_GUID_OVMF_LEGACY) == 0)
 		return "ovmf";
 	return guid;
 }


### PR DESCRIPTION
This was changed recently in https://sourceforge.net/p/edk2/code/29270/

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
