### PR TITLE
Show a console warning if the system clock is not set

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2702,6 +2702,7 @@ main (int argc, char *argv[])
 	gboolean verbose = FALSE;
 	gboolean version = FALSE;
 	g_autoptr(FuUtilPrivate) priv = g_new0 (FuUtilPrivate, 1);
+	g_autoptr(GDateTime) dt_now = g_date_time_new_now_utc ();
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GError) error_polkit = NULL;
 	g_autoptr(GPtrArray) cmd_array = fu_util_cmd_array_new ();
@@ -3043,6 +3044,17 @@ main (int argc, char *argv[])
 					      "to do this automatically in the future "
 					      "export DISABLE_SSL_STRICT in your environment"));
 		g_setenv ("DISABLE_SSL_STRICT", "1", TRUE);
+	}
+
+	/* this doesn't have to be precise (e.g. using the build-year) as we just
+	 * want to check the clock is not set to the default of 1970-01-01... */
+	if (g_date_time_get_year (dt_now) < 2021) {
+		g_autofree gchar *fmt = NULL;
+		/* TRANSLATORS: this is a prefix on the console */
+		fmt = fu_util_term_format (_("WARNING:"), FU_UTIL_TERM_COLOR_RED);
+		/* TRANSLATORS: try to help */
+		g_printerr ("%s %s\n", fmt, _("The system clock has not been set "
+					      "correctly and downloading files may fail."));
 	}
 
 	/* non-TTY consoles cannot answer questions */


### PR DESCRIPTION
If the date is wrong, the SSL certificate may not be in a valid date range and
the user gets a rather unhelpful 'SSL handshake failed' error message.

Detect the most common case and show a warning when starting fwupdmgr.

Fixes https://github.com/fwupd/fwupd/issues/2723

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
