### PR TITLE
rename config section in uefi_capsule.conf to plugin name

### DIFF
--- a/plugins/uefi-capsule/uefi_capsule.conf
+++ b/plugins/uefi-capsule/uefi_capsule.conf
@@ -1,4 +1,4 @@
-[uefi]
+[uefi_capsule]
 
 # the shim loader is required to chainload the fwupd EFI binary unless
 # the fwupd.efi file has been self-signed manually


### PR DESCRIPTION
in ee2e2c36749298e58b34dca163ea48a7fc925da6 the plugin name was changed
from uefi to uefi_capsule. while the config file name was changed, the
section name should also be changed.

fixes #2748

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
