### PR TITLE
trivial: adjust error for no UEFI capsules

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -465,7 +465,7 @@ fu_plugin_build_device_update_error (FuPlugin *self)
 	if (fu_plugin_has_flag (self, FWUPD_PLUGIN_FLAG_LEGACY_BIOS))
 		return "Not updatable in legacy BIOS mode";
 	if (fu_plugin_has_flag (self, FWUPD_PLUGIN_FLAG_CAPSULES_UNSUPPORTED))
-		return "Not updatable as UEFI capsule updates not enabled";
+		return "Not updatable as UEFI capsule updates not enabled in firmware setup";
 	if (fu_plugin_has_flag (self, FWUPD_PLUGIN_FLAG_UNLOCK_REQUIRED))
 		return "Not updatable as requires unlock";
 	if (fu_plugin_has_flag (self, FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED))

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1310,7 +1310,7 @@ fu_util_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 	}
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_CAPSULES_UNSUPPORTED) {
 		/* TRANSLATORS: capsule updates are an optional BIOS feature */
-		return _("UEFI capsule updates not available or enabled");
+		return _("UEFI capsule updates not available or enabled in firmware setup");
 	}
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_UNLOCK_REQUIRED) {
 		/* TRANSLATORS: user needs to run a command */


### PR DESCRIPTION
Point people towards firwmare setup instead (Fixes: #1454)

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
