### PR TITLE
trivial: for create containers workflow don't fail fast

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -7,6 +7,7 @@ jobs:
   push_to_registry:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [fedora, debian-x86_64, arch, debian-i386]
 


### PR DESCRIPTION
Just because Arch fails to build or push one day, don't
make all the containers fail to build or push.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
