### PR TITLE
trivial: in the no updatable devices case, show error again

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -670,19 +670,21 @@ fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	title = fu_util_get_tree_title (priv);
 
-	/* print */
+	/* get devices and build tree */
 	devs = fu_engine_get_devices (priv->engine, error);
 	if (devs == NULL)
 		return FALSE;
+	if (devs->len > 0) {
+		fwupd_device_array_ensure_parents (devs);
+		fu_util_build_device_tree (priv, root, devs, NULL);
+	}
 
 	/* print */
-	if (devs->len == 0) {
+	if (g_node_n_children (root) == 0) {
 		/* TRANSLATORS: nothing attached that can be upgraded */
 		g_print ("%s\n", _("No hardware detected with firmware update capability"));
 		return TRUE;
 	}
-	fwupd_device_array_ensure_parents (devs);
-	fu_util_build_device_tree (priv, root, devs, NULL);
 	fu_util_print_tree (root, title);
 
 	/* save the device state for other applications to see */

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -538,14 +538,15 @@ fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 	devs = fwupd_client_get_devices (priv->client, NULL, error);
 	if (devs == NULL)
 		return FALSE;
+	if (devs->len > 0)
+		fu_util_build_device_tree (priv, root, devs, NULL);
 
 	/* print */
-	if (devs->len == 0) {
+	if (g_node_n_children (root) == 0) {
 		/* TRANSLATORS: nothing attached that can be upgraded */
 		g_print ("%s\n", _("No hardware detected with firmware update capability"));
 		return TRUE;
 	}
-	fu_util_build_device_tree (priv, root, devs, NULL);
 	fu_util_print_tree (root, title);
 
 	/* nag? */


### PR DESCRIPTION
Since we added a CPU and everything has a CPU the error stopped
showing up.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
