### PR TITLE
Use a quarter of the RAM size as the archive maximum

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -19,6 +19,10 @@
 #include <shlwapi.h>
 #endif
 
+#ifdef _WIN32
+#include <sysinfoapi.h>
+#endif
+
 #ifdef HAVE_CPUID_H
 #include <cpuid.h>
 #endif
@@ -31,6 +35,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "fwupd-error.h"
 
@@ -2342,6 +2347,28 @@ fu_common_is_live_media (void)
 			return TRUE;
 	}
 	return FALSE;
+}
+
+/**
+ * fu_common_get_memory_size:
+ *
+ * Returns the size of physical memory.
+ *
+ * Returns: bytes
+ *
+ * Since: 1.5.6
+ **/
+guint64
+fu_common_get_memory_size (void)
+{
+#ifdef _WIN32
+	MEMORYSTATUSEX status;
+	status.dwLength = sizeof(status);
+	GlobalMemoryStatusEx (&status);
+	return (guint64) status.ullTotalPhys;
+#else
+	return sysconf (_SC_PHYS_PAGES) * sysconf (_SC_PAGE_SIZE);
+#endif
 }
 
 static GPtrArray *

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -280,6 +280,7 @@ gboolean	 fu_common_is_cpu_intel		(void)
 G_DEPRECATED_FOR(fu_common_get_cpu_vendor);
 FuCpuVendor	 fu_common_get_cpu_vendor	(void);
 gboolean	 fu_common_is_live_media	(void);
+guint64		 fu_common_get_memory_size	(void);
 GPtrArray	*fu_common_get_volumes_by_kind	(const gchar	*kind,
 						 GError		**error)
 						 G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -724,6 +724,7 @@ LIBFWUPDPLUGIN_1.5.5 {
 
 LIBFWUPDPLUGIN_1.5.6 {
   global:
+    fu_common_get_memory_size;
     fu_plugin_get_devices;
   local: *;
 } LIBFWUPDPLUGIN_1.5.5;


### PR DESCRIPTION
It is impossible to choose a static default that is appropriate for both a tiny
ARM IoT device and a giant Xeon server.

Fixes https://github.com/fwupd/fwupd/issues/2760

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
