### PR TITLE
Do not show Unknown [***] for every client connection

### DIFF
--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -297,6 +297,12 @@ fu_progressbar_update (FuProgressbar *self, FwupdStatus status, guint percentage
 {
 	g_return_if_fail (FU_IS_PROGRESSBAR (self));
 
+	/* ignore initial client connection */
+	if (self->status == FWUPD_STATUS_UNKNOWN && status == FWUPD_STATUS_IDLE) {
+		self->status = status;
+		return;
+	}
+
 	/* use cached value */
 	if (status == FWUPD_STATUS_UNKNOWN)
 		status = self->status;


### PR DESCRIPTION
Ignore the initial client state change from UNKNOWN to IDLE which was being set
as part of the fix in fb36f22.

Fixes https://github.com/fwupd/fwupd/issues/2766

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
