### PR TITLE
altos: Clarify ChaosKey name

### DIFF
--- a/plugins/altos/altos.quirk
+++ b/plugins/altos/altos.quirk
@@ -2,7 +2,7 @@
 [DeviceInstanceId=USB\VID_1D50&PID_60C6]
 Plugin = altos
 Flags = ~is-bootloader
-Name = Altos ChaosKey
+Name = Altus-Metrum ChaosKey
 CounterpartGuid = USB\VID_FFFE&PID_000A
 
 [DeviceInstanceId=USB\VID_FFFE&PID_000A]


### PR DESCRIPTION
While the firmware is altos, the product is better known as "Altus-Metrum ChaosKey".

As in, I was confused to see:

```
$ sudo fwupdmgr update
• Altos ChaosKey has the latest available firmware version
...
```

I was expecting:
```
$ sudo fwupdmgr update
• Altus-Metrum ChaosKey has the latest available firmware version
...
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

@keith-packard