### PR TITLE
Add GUIDs straight away if ->setup() has already been called

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1415,6 +1415,7 @@ fu_device_add_instance_id_full (FuDevice *self,
 				const gchar *instance_id,
 				FuDeviceInstanceFlags flags)
 {
+	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_autofree gchar *guid = NULL;
 	if (fwupd_guid_is_valid (instance_id)) {
 		g_warning ("use fu_device_add_guid(\"%s\") instead!", instance_id);
@@ -1430,6 +1431,10 @@ fu_device_add_instance_id_full (FuDevice *self,
 	fu_device_add_guid_quirks (self, guid);
 	if ((flags & FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS) == 0)
 		fwupd_device_add_instance_id (FWUPD_DEVICE (self), instance_id);
+
+	/* already done by ->setup(), so this must be ->registered() */
+	if (priv->done_setup)
+		fwupd_device_add_guid (FWUPD_DEVICE (self), guid);
 }
 
 /**

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1128,6 +1128,30 @@ fu_device_func (void)
 }
 
 static void
+fu_device_instance_ids_func (void)
+{
+	gboolean ret;
+	g_autoptr(FuDevice) device = fu_device_new ();
+	g_autoptr(GError) error = NULL;
+
+	/* sanity check */
+	g_assert_false (fu_device_has_guid (device, "c0a26214-223b-572a-9477-cde897fe8619"));
+
+	/* add a deferred instance ID that only gets converted on ->setup */
+	fu_device_add_instance_id (device, "foobarbaz");
+	g_assert_false (fu_device_has_guid (device, "c0a26214-223b-572a-9477-cde897fe8619"));
+
+	ret = fu_device_setup (device, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	g_assert_true (fu_device_has_guid (device, "c0a26214-223b-572a-9477-cde897fe8619"));
+
+	/* this gets added immediately */
+	fu_device_add_instance_id (device, "bazbarfoo");
+	g_assert_true (fu_device_has_guid (device, "77e49bb0-2cd6-5faf-bcee-5b7fbe6e944d"));
+}
+
+static void
 fu_device_flags_func (void)
 {
 	g_autoptr(FuDevice) device = fu_device_new ();
@@ -2191,6 +2215,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/archive{invalid}", fu_archive_invalid_func);
 	g_test_add_func ("/fwupd/archive{cab}", fu_archive_cab_func);
 	g_test_add_func ("/fwupd/device", fu_device_func);
+	g_test_add_func ("/fwupd/device{instance-ids}", fu_device_instance_ids_func);
 	g_test_add_func ("/fwupd/device{flags}", fu_device_flags_func);
 	g_test_add_func ("/fwupd/device{parent}", fu_device_parent_func);
 	g_test_add_func ("/fwupd/device{incorporate}", fu_device_incorporate_func);


### PR DESCRIPTION
We only convert the instance IDs to GUID after setup() has been called, which
means if we add even more instance IDs to the device in functions like
fu_plugin_device_registered() they never actually get converted to the GUID
form too.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
