### PR TITLE
flashrom: Do not allow flashing if BLE is enabled

### DIFF
--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -30,6 +30,16 @@ fu_plugin_init (FuPlugin *plugin)
 	priv->bcr_addr = 0xdc;
 }
 
+static void
+fu_plugin_pci_bcr_set_updatable (FuPlugin *plugin, FuDevice *dev)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	if (priv->bcr & BCR_BLE) {
+		fu_device_remove_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+		fu_device_set_update_error (dev, "BIOS locked");
+	}
+}
+
 void
 fu_plugin_device_registered (FuPlugin *plugin, FuDevice *dev)
 {
@@ -41,6 +51,15 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *dev)
 				 priv->bcr_addr, tmp);
 			priv->bcr_addr = tmp;
 		}
+	}
+	if (g_strcmp0 (fu_device_get_plugin (dev), "flashrom") == 0 &&
+	    fu_device_has_instance_id (dev, "main-system-firmware")) {
+		/* PCI\VEN_8086 added first */
+		if (priv->has_device) {
+			fu_plugin_pci_bcr_set_updatable (plugin, dev);
+			return;
+		}
+		fu_plugin_cache_add (plugin, "main-system-firmware", dev);
 	}
 }
 
@@ -131,6 +150,7 @@ gboolean
 fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data (plugin);
+	FuDevice *device_msf;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* not supported */
@@ -159,6 +179,13 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 		g_prefix_error (error, "could not read BCR: ");
 		return FALSE;
 	}
+
+	/* main-system-firmware device added first, probably from flashrom */
+	device_msf = fu_plugin_cache_lookup (plugin, "main-system-firmware");
+	if (device_msf != NULL)
+		fu_plugin_pci_bcr_set_updatable (plugin, device_msf);
+
+	/* success */
 	priv->has_device = TRUE;
 	return TRUE;
 }


### PR DESCRIPTION
If BLE is set flashrom isn't going to work and the user would get a super scary
warning.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
