### PR TITLE
pci-bcr: Only mark the device non-updatable if WPD unset and BLE set

### DIFF
--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -34,7 +34,7 @@ static void
 fu_plugin_pci_bcr_set_updatable (FuPlugin *plugin, FuDevice *dev)
 {
 	FuPluginData *priv = fu_plugin_get_data (plugin);
-	if (priv->bcr & BCR_BLE) {
+	if ((priv->bcr & BCR_WPD) == 0 && (priv->bcr & BCR_BLE) > 0) {
 		fu_device_remove_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_device_set_update_error (dev, "BIOS locked");
 	}


### PR DESCRIPTION
It's unusual, but if BIOS lock enable is enabled (so we cannot *change* the
value of BIOSWE) but the BIOS is already WE then we can write to the hardware
just fine.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
