### PR TITLE
Add the PCRs to the report metadata

### DIFF
--- a/plugins/tpm-eventlog/fu-plugin-tpm-eventlog.c
+++ b/plugins/tpm-eventlog/fu-plugin-tpm-eventlog.c
@@ -68,6 +68,18 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		const gchar *csum = g_ptr_array_index (data->pcr0s, i);
 		fu_device_add_checksum (FU_DEVICE (dev), csum);
 	}
+	for (guint i = 0; i < data->pcr0s->len; i++) {
+		const gchar *csum = g_ptr_array_index (data->pcr0s, i);
+		GChecksumType csum_type = fwupd_checksum_guess_kind (csum);
+		if (csum_type == G_CHECKSUM_SHA1) {
+			fu_plugin_add_report_metadata (plugin, "Pcr0_SHA1", csum);
+			continue;
+		}
+		if (csum_type == G_CHECKSUM_SHA256) {
+			fu_plugin_add_report_metadata (plugin, "Pcr0_SHA256", csum);
+			continue;
+		}
+	}
 
 	/* add optional report metadata */
 	str = fu_tpm_eventlog_device_report_metadata (dev);


### PR DESCRIPTION
Although we could reconstruct the PCRn metadata on the LVFS from the (already
included) event log, it's much more scalable if the client just provides the
data that we want to filter by.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
