### PR TITLE
system76-launch: Add a plugin for the System76 Launch Configurable Keyboard

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -442,6 +442,7 @@ done
 %{_libdir}/fwupd-plugins-3/libfu_plugin_synaptics_cxaudio.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_synaptics_prometheus.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_synaptics_rmi.so
+%{_libdir}/fwupd-plugins-3/libfu_plugin_system76_launch.so
 %if 0%{?enable_dummy}
 %{_libdir}/fwupd-plugins-3/libfu_plugin_test.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_invalid.so
@@ -504,4 +505,3 @@ done
 %changelog
 * #LONGDATE# Richard Hughes <richard@hughsie.com> #VERSION#-0.#BUILD##ALPHATAG#
 - Update from git
-

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -25,6 +25,7 @@ subdir('ata')
 subdir('elantp')
 subdir('optionrom')
 subdir('superio')
+subdir('system76-launch')
 subdir('thelio-io')
 subdir('wacom-raw')
 endif

--- a/plugins/system76-launch/README.md
+++ b/plugins/system76-launch/README.md
@@ -1,0 +1,26 @@
+System76 Launch Support
+=================
+
+Introduction
+------------
+
+This plugin is used to detach the System76 Launch device to DFU mode.
+
+To switch to bootloader mode a USB packet must be written, as specified by the
+System76 EC protocol.
+
+GUID Generation
+---------------
+
+These devices use the standard USB DeviceInstanceId values, e.g.
+
+ * `USB\VID_3384&PID_0001&REV_0001`
+
+Vendor ID Security
+------------------
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x3384`
+
+External interface access
+-------------------------
+This plugin requires read/write access to `/dev/bus/usb`.

--- a/plugins/system76-launch/fu-plugin-system76-launch.c
+++ b/plugins/system76-launch/fu-plugin-system76-launch.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2021 Jeremy Soller <jeremy@system76.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-plugin-vfuncs.h"
+
+#include "fu-system76-launch-device.h"
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYSTEM76_LAUNCH_DEVICE);
+}

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2021 Jeremy Soller <jeremy@system76.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-system76-launch-device.h"
+
+#define SYSTEM76_LAUNCH_CMD_VERSION	3
+#define SYSTEM76_LAUNCH_CMD_RESET	6
+#define SYSTEM76_LAUNCH_TIMEOUT		1000
+
+struct _FuSystem76LaunchDevice {
+	FuUsbDevice			 parent_instance;
+};
+
+G_DEFINE_TYPE (FuSystem76LaunchDevice, fu_system76_launch_device, FU_TYPE_USB_DEVICE)
+
+static gboolean
+fu_system76_launch_device_setup (FuDevice *device, GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
+	const guint8 ep_in = 0x82;
+	const guint8 ep_out = 0x03;
+	guint8 data[32] = { 0 };
+	gsize actual_len = 0;
+	g_autofree gchar *version = NULL;
+
+	/* send version command */
+	data[0] = SYSTEM76_LAUNCH_CMD_VERSION;
+	if (!g_usb_device_interrupt_transfer (usb_device,
+					      ep_out,
+					      data,
+					      sizeof(data),
+					      &actual_len,
+					      SYSTEM76_LAUNCH_TIMEOUT,
+					      NULL,
+					      error)) {
+		g_prefix_error (error, "failed to send version command: ");
+		return FALSE;
+	}
+	if (actual_len < sizeof(data)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "version command truncated: sent %" G_GSIZE_FORMAT " bytes",
+			     actual_len);
+		return FALSE;
+	}
+
+	/* receive version response */
+	if (!g_usb_device_interrupt_transfer (usb_device,
+					      ep_in,
+					      data,
+					      sizeof(data),
+					      &actual_len,
+					      SYSTEM76_LAUNCH_TIMEOUT,
+					      NULL,
+					      error)) {
+		g_prefix_error (error, "failed to read version response: ");
+		return FALSE;
+	}
+	if (actual_len < sizeof(data)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVALID_DATA,
+			     "version response truncated: received %" G_GSIZE_FORMAT " bytes",
+			     actual_len);
+		return FALSE;
+	}
+
+	version = g_strdup_printf ("%s", &data[2]);
+	fu_device_set_version (device, version);
+
+	return TRUE;
+}
+
+static gboolean
+fu_system76_launch_device_detach (FuDevice *device, GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
+	const guint8 ep_out = 0x03;
+	guint8 data[32] = { 0 };
+	gsize actual_len = 0;
+	g_autofree gchar *version = NULL;
+
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
+
+	/* send reset command, should result in bootloader device appearing */
+	data[0] = SYSTEM76_LAUNCH_CMD_RESET;
+	if (!g_usb_device_interrupt_transfer (usb_device,
+					      ep_out,
+					      data,
+					      sizeof(data),
+					      &actual_len,
+					      SYSTEM76_LAUNCH_TIMEOUT,
+					      NULL,
+					      error)) {
+		g_prefix_error (error, "failed to send reset command: ");
+		return FALSE;
+	}
+
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+
+	return TRUE;
+}
+
+static gboolean
+fu_system76_launch_device_open (FuUsbDevice *device, GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	const guint8 iface_idx = 0x01;
+
+	if (!g_usb_device_claim_interface (usb_device, iface_idx,
+					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
+					   error)) {
+		g_prefix_error (error, "failed to claim interface: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_system76_launch_device_close (FuUsbDevice *device, GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	const guint8 iface_idx = 0x01;
+
+	if (!g_usb_device_release_interface (usb_device, iface_idx,
+					     G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
+					     error)) {
+		g_prefix_error (error, "failed to release interface: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void
+fu_system76_launch_device_init (FuSystem76LaunchDevice *device)
+{
+	fu_device_set_remove_delay (FU_DEVICE (device), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
+	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_protocol (FU_DEVICE (device), "org.usb.dfu");
+	fu_device_retry_set_delay (FU_DEVICE (device), 100);
+}
+
+static void
+fu_system76_launch_device_class_init (FuSystem76LaunchDeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
+	klass_device->setup = fu_system76_launch_device_setup;
+	klass_device->detach = fu_system76_launch_device_detach;
+	klass_usb_device->open = fu_system76_launch_device_open;
+	klass_usb_device->close = fu_system76_launch_device_close;
+}

--- a/plugins/system76-launch/fu-system76-launch-device.h
+++ b/plugins/system76-launch/fu-system76-launch-device.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2021 Jeremy Soller <jeremy@system76.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-plugin.h"
+
+#define FU_TYPE_SYSTEM76_LAUNCH_DEVICE (fu_system76_launch_device_get_type ())
+G_DECLARE_FINAL_TYPE (FuSystem76LaunchDevice, fu_system76_launch_device, FU, SYSTEM76_LAUNCH_DEVICE, FuUsbDevice)

--- a/plugins/system76-launch/meson.build
+++ b/plugins/system76-launch/meson.build
@@ -1,0 +1,27 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginSystem76Launch"']
+
+install_data(['system76-launch.quirk'],
+  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+)
+
+shared_module('fu_plugin_system76_launch',
+  fu_hash,
+  sources : [
+    'fu-plugin-system76-launch.c',
+    'fu-system76-launch-device.c',
+  ],
+  include_directories : [
+    root_incdir,
+    fwupd_incdir,
+    fwupdplugin_incdir,
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  link_with : [
+    fwupdplugin,
+  ],
+  c_args : cargs,
+  dependencies : [
+    plugin_deps,
+  ],
+)

--- a/plugins/system76-launch/system76-launch.quirk
+++ b/plugins/system76-launch/system76-launch.quirk
@@ -1,0 +1,4 @@
+# System76 Launch
+[DeviceInstanceId=USB\VID_3384&PID_0001&REV_0001]
+Plugin = system76_launch
+CounterpartGuid = USB\VID_03EB&PID_2FF4


### PR DESCRIPTION
This plugin supports reading the keyboard firmware version at runtime and
rebooting the keyboard to USB DFU mode. Tested with firmware uploaded to
embargo-system76.

Type of pull request:
- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

New plugin checklist:
- [x] Fill out `README.md` with update protocol
- [x] Fill out `README.md` with any custom quirks and flags
- [x] Fill out `README.md` with the vendor ID security value
- [ ] CI run for at least one target
- [ ] Document targets CI isn't currently run and the reasons (i.e. minimum versions needed or distribution limitations etc).