### PR TITLE
uefi-capsule: Check if the fwupd BootXXXX entry exists on failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-uefi.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-uefi.md
@@ -53,3 +53,4 @@ $ tree /boot
 - Is this a regression?
 - Are you using an NVMe disk?
 - Is secure boot enabled?
+- Is this a Lenovo system with 'Boot Order Lock' turned on in the BIOS?

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.h
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.h
@@ -19,6 +19,7 @@ typedef enum {
 	FU_UEFI_BOOTMGR_FLAG_LAST
 } FuUefiBootmgrFlags;
 
+gboolean	 fu_uefi_bootmgr_verify_fwupd	(GError			**error);
 gboolean	 fu_uefi_bootmgr_bootnext	(FuDevice 		*device,
 						 const gchar		*esp_path,
 						 const gchar		*description,

--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -14,6 +14,10 @@ Flags = use-shim-unique,no-ux-capsule
 [HwId=386c2f52-44ec-55d3-b802-47631bfb8451]
 Flags = uefi-force-enable
 
+# Lenovo
+[HwId=6de5d951-d755-576b-bd09-c5cf66b27234]
+Flags = boot-order-lock,use-legacy-bootmgr-desc
+
 # Lenovo ThinkPad X1 Yoga 4th
 [HwId=1138930e-8df1-5ae0-b946-7b0d9c9b4a79]
 Flags = no-coalesce


### PR DESCRIPTION
Some systems remove the BootXXXX entry we add (so we can run fwupdx64.efi) and
thus the firmware update does not run. Most commonly this failure is seen with
Lenovo systems that call the helpful option 'Boot Order Lock'.

Hopefully when we depend on the new kernel bios interface sysfs API in we can
check in ->prepare(), not after reboot, but until that we can mark the update
failure as transient as the user can actually fix the problem themselves.

Fixes https://github.com/fwupd/fwupd/issues/2801

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
