### PR TITLE
Run the child setup when calling the parent device

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1181,6 +1181,33 @@ fu_device_flags_func (void)
 }
 
 static void
+fu_device_children_func (void)
+{
+	gboolean ret;
+	g_autoptr(FuDevice) child = fu_device_new ();
+	g_autoptr(FuDevice) parent = fu_device_new ();
+	g_autoptr(GError) error = NULL;
+
+	fu_device_set_physical_id (child, "dummy");
+	fu_device_set_physical_id (parent, "dummy");
+
+	/* set up family */
+	fu_device_add_child (parent, child);
+
+	/* set an instance ID that will be converted to a GUID when the parent
+	 * calls ->setup */
+	fu_device_add_instance_id (child, "foo");
+	g_assert_false (fu_device_has_guid (child, "b84ed8ed-a7b1-502f-83f6-90132e68adef"));
+
+	/* setup parent, which also calls setup on child too (and thus also
+	 * converts the instance ID to a GUID) */
+	ret = fu_device_setup (parent, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+	g_assert_true (fu_device_has_guid (child, "b84ed8ed-a7b1-502f-83f6-90132e68adef"));
+}
+
+static void
 fu_device_parent_func (void)
 {
 	g_autoptr(FuDevice) child = fu_device_new ();
@@ -2249,6 +2276,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/device{instance-ids}", fu_device_instance_ids_func);
 	g_test_add_func ("/fwupd/device{flags}", fu_device_flags_func);
 	g_test_add_func ("/fwupd/device{parent}", fu_device_parent_func);
+	g_test_add_func ("/fwupd/device{children}", fu_device_children_func);
 	g_test_add_func ("/fwupd/device{incorporate}", fu_device_incorporate_func);
 	if (g_test_slow ())
 		g_test_add_func ("/fwupd/device{poll}", fu_device_poll_func);


### PR DESCRIPTION
If we're creating the child device using `Children=FuFooDevice|FOO&I2C_01` in
the quirk file then there's not actually anywhere to call FuDevice->setup()
on the child.

The logical place to do it is when we setup the parent, which is a NOP if
already called for the child. We also don't need to convert the child instance
IDs as it's already being handled during the child setup.

Tested-By: Ricky Wu <ricky_wu@realtek.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
