### PR TITLE
libfwupd: Add fwupd_release_add_location()

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -5,6 +5,7 @@ Planned API/ABI changes for next release
  * Remove the `soup-session` fallback property in `FwupdClient`.
  * Remove fwupd_device_set_vendor_id() and fwupd_device_get_vendor_id()
  * Remove the deprecated flags like `FWUPD_DEVICE_FLAG_MD_SET_ICON`
+ * Remove `fwupd_release_get_uri()` and `fwupd_release_set_uri()`
 
 Migration from Version 0.9.x
 ============================

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -54,6 +54,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_UPDATE_ERROR		"UpdateError"	/* s */
 #define FWUPD_RESULT_KEY_UPDATE_STATE		"UpdateState"	/* u */
 #define FWUPD_RESULT_KEY_URI			"Uri"		/* s */
+#define FWUPD_RESULT_KEY_LOCATIONS		"Locations"	/* as */
 #define FWUPD_RESULT_KEY_VENDOR_ID		"VendorId"	/* s */
 #define FWUPD_RESULT_KEY_VENDOR			"Vendor"	/* s */
 #define FWUPD_RESULT_KEY_VENDOR			"Vendor"	/* s */

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -34,8 +34,13 @@ gchar		*fwupd_release_to_string		(FwupdRelease	*release);
 const gchar	*fwupd_release_get_version		(FwupdRelease	*release);
 void		 fwupd_release_set_version		(FwupdRelease	*release,
 							 const gchar	*version);
+G_DEPRECATED_FOR(fwupd_release_get_locations)
 const gchar	*fwupd_release_get_uri			(FwupdRelease	*release);
+G_DEPRECATED_FOR(fwupd_release_add_location)
 void		 fwupd_release_set_uri			(FwupdRelease	*release,
+							 const gchar	*uri);
+GPtrArray	*fwupd_release_get_locations		(FwupdRelease	*release);
+void		 fwupd_release_add_location		(FwupdRelease	*release,
 							 const gchar	*uri);
 GPtrArray	*fwupd_release_get_issues		(FwupdRelease	*release);
 void		 fwupd_release_add_issue		(FwupdRelease	*release,

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -346,7 +346,8 @@ fwupd_device_func (void)
 	fwupd_release_set_filename (rel, "firmware.bin");
 	fwupd_release_set_appstream_id (rel, "org.dave.ColorHug.firmware");
 	fwupd_release_set_size (rel, 1024);
-	fwupd_release_set_uri (rel, "http://foo.com");
+	fwupd_release_add_location (rel, "http://foo.com");
+	fwupd_release_add_location (rel, "ftp://foo.com");
 	fwupd_release_set_version (rel, "1.2.3");
 	fwupd_device_add_release (dev, rel);
 	str = fwupd_device_to_string (dev);
@@ -380,6 +381,7 @@ fwupd_device_func (void)
 		"  Checksum:             SHA1(deadbeef)\n"
 		"  Size:                 1.0 kB\n"
 		"  Uri:                  http://foo.com\n"
+		"  Uri:                  ftp://foo.com\n"
 		"  Flags:                trusted-payload\n", &error);
 	g_assert_no_error (error);
 	g_assert (ret);
@@ -426,6 +428,10 @@ fwupd_device_func (void)
 		"        \"deadbeef\"\n"
 		"      ],\n"
 		"      \"Size\" : 1024,\n"
+		"      \"Locations\" : [\n"
+		"        \"http://foo.com\",\n"
+		"        \"ftp://foo.com\"\n"
+		"      ],\n"
 		"      \"Uri\" : \"http://foo.com\",\n"
 		"      \"Flags\" : [\n"
 		"        \"trusted-payload\"\n"

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -639,3 +639,10 @@ LIBFWUPD_1.5.5 {
     fwupd_device_has_vendor_id;
   local: *;
 } LIBFWUPD_1.5.3;
+
+LIBFWUPD_1.5.6 {
+  global:
+    fwupd_release_add_location;
+    fwupd_release_get_locations;
+  local: *;
+} LIBFWUPD_1.5.5;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1097,18 +1097,21 @@ static gboolean
 fu_util_install_release (FuUtilPrivate *priv, FwupdRelease *rel, GError **error)
 {
 	FwupdRemote *remote;
+	GPtrArray *locations;
 	const gchar *remote_id;
 	const gchar *uri_tmp;
 	g_auto(GStrv) argv = NULL;
 
-	uri_tmp = fwupd_release_get_uri (rel);
-	if (uri_tmp == NULL) {
+	/* get the default release only until other parts of fwupd can cope */
+	locations = fwupd_release_get_locations (rel);
+	if (locations->len == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_FILE,
 				     "release missing URI");
 		return FALSE;
 	}
+	uri_tmp = g_ptr_array_index (locations, 0);
 	remote_id = fwupd_release_get_remote_id (rel);
 	if (remote_id == NULL) {
 		g_set_error (error,


### PR DESCRIPTION
The metadata might want to pass more than one location URI to the client, for
instance if the file is available from more than one HTTP mirror.

Use the noun of location to match the AppStream <artifact> naming; this is the
last place where LVFS AppStream diverges from the official specification and
it would be good to bring fwupd back into line -- although the LVFS will have
to write both elements for a very long time.

See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

Also: we're not changing the format of the `Uri` GVariant key to preserve both
forward and backwards compatibility of the library. We can remove it when we
next break API.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
