### PR TITLE
libfwupd: Add fwupd_client_install_release2_async()

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -6,6 +6,7 @@ Planned API/ABI changes for next release
  * Remove fwupd_device_set_vendor_id() and fwupd_device_get_vendor_id()
  * Remove the deprecated flags like `FWUPD_DEVICE_FLAG_MD_SET_ICON`
  * Remove `fwupd_release_get_uri()` and `fwupd_release_set_uri()`
+ * Rename `fwupd_client_install_release2_async()` to `fwupd_client_install_release_async()`
 
 Migration from Version 0.9.x
 ============================

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -119,6 +119,15 @@ gboolean	 fwupd_client_install_release		(FwupdClient	*self,
 							 FwupdInstallFlags install_flags,
 							 GCancellable	*cancellable,
 							 GError		**error)
+							 G_GNUC_WARN_UNUSED_RESULT
+G_DEPRECATED_FOR(fwupd_client_install_release2);
+gboolean	 fwupd_client_install_release2		(FwupdClient	*self,
+							 FwupdDevice	*device,
+							 FwupdRelease	*release,
+							 FwupdInstallFlags install_flags,
+							 FwupdClientDownloadFlags download_flags,
+							 GCancellable	*cancellable,
+							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
 gboolean	 fwupd_client_update_metadata		(FwupdClient	*self,
 							 const gchar	*remote_id,

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -2391,6 +2391,7 @@ typedef struct {
 	FwupdDevice		*device;
 	FwupdRelease		*release;
 	FwupdInstallFlags	 install_flags;
+	FwupdClientDownloadFlags download_flags;
 } FwupdClientInstallReleaseData;
 
 static void
@@ -2547,18 +2548,19 @@ fwupd_client_install_release_remote_cb (GObject *source, GAsyncResult *res, gpoi
 
 	/* download file */
 	fwupd_client_download_bytes_async (FWUPD_CLIENT (source), uri_str,
-					   FWUPD_CLIENT_DOWNLOAD_FLAG_NONE,
+					   data->download_flags,
 					   cancellable,
 					   fwupd_client_install_release_download_cb,
 					   g_steal_pointer (&task));
 }
 
 /**
- * fwupd_client_install_release_async:
+ * fwupd_client_install_release2_async:
  * @self: A #FwupdClient
  * @device: A #FwupdDevice
  * @release: A #FwupdRelease
  * @install_flags: the #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_ALLOW_REINSTALL
+ * @download_flags: the #FwupdClientDownloadFlags, e.g. %FWUPD_CLIENT_DOWNLOAD_FLAG_DISABLE_IPFS
  * @cancellable: the #GCancellable, or %NULL
  * @callback: the function to run on completion
  * @callback_data: the data to pass to @callback
@@ -2569,16 +2571,17 @@ fwupd_client_install_release_remote_cb (GObject *source, GAsyncResult *res, gpoi
  * emitted in the global default main context, if not explicitly set with
  * fwupd_client_set_main_context().
  *
- * Since: 1.5.0
+ * Since: 1.5.6
  **/
 void
-fwupd_client_install_release_async (FwupdClient *self,
-				    FwupdDevice *device,
-				    FwupdRelease *release,
-				    FwupdInstallFlags install_flags,
-				    GCancellable *cancellable,
-				    GAsyncReadyCallback callback,
-				    gpointer callback_data)
+fwupd_client_install_release2_async (FwupdClient *self,
+				     FwupdDevice *device,
+				     FwupdRelease *release,
+				     FwupdInstallFlags install_flags,
+				     FwupdClientDownloadFlags download_flags,
+				     GCancellable *cancellable,
+				     GAsyncReadyCallback callback,
+				     gpointer callback_data)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
 	g_autoptr(GTask) task = NULL;
@@ -2596,6 +2599,7 @@ fwupd_client_install_release_async (FwupdClient *self,
 	data = g_new0 (FwupdClientInstallReleaseData, 1);
 	data->device = g_object_ref (device);
 	data->release = g_object_ref (release);
+	data->download_flags = download_flags;
 	data->install_flags = install_flags;
 	g_task_set_task_data (task, data, (GDestroyNotify) fwupd_client_install_release_data_free);
 
@@ -2617,7 +2621,7 @@ fwupd_client_install_release_async (FwupdClient *self,
 		uri_tmp = g_ptr_array_index (locations, 0);
 		fwupd_client_download_bytes_async (self,
 						   uri_tmp,
-						   FWUPD_CLIENT_DOWNLOAD_FLAG_NONE,
+						   download_flags,
 						   cancellable,
 						   fwupd_client_install_release_download_cb,
 						   g_steal_pointer (&task));
@@ -2628,6 +2632,39 @@ fwupd_client_install_release_async (FwupdClient *self,
 	fwupd_client_get_remote_by_id_async (self, remote_id, cancellable,
 					     fwupd_client_install_release_remote_cb,
 					     g_steal_pointer (&task));
+}
+
+/**
+ * fwupd_client_install_release_async:
+ * @self: A #FwupdClient
+ * @device: A #FwupdDevice
+ * @release: A #FwupdRelease
+ * @install_flags: the #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_ALLOW_REINSTALL
+ * @cancellable: the #GCancellable, or %NULL
+ * @callback: the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Installs a new release on a device, downloading the firmware if required.
+ *
+ * NOTE: This method is thread-safe, but progress signals will be
+ * emitted in the global default main context, if not explicitly set with
+ * fwupd_client_set_main_context().
+ *
+ * Since: 1.5.0
+ * Deprecated: 1.5.6
+ **/
+void
+fwupd_client_install_release_async (FwupdClient *self,
+				    FwupdDevice *device,
+				    FwupdRelease *release,
+				    FwupdInstallFlags install_flags,
+				    GCancellable *cancellable,
+				    GAsyncReadyCallback callback,
+				    gpointer callback_data)
+{
+	return fwupd_client_install_release2_async (self, device, release, install_flags,
+						    FWUPD_CLIENT_DOWNLOAD_FLAG_NONE,
+						    cancellable, callback, callback_data);
 }
 
 /**

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -257,6 +257,15 @@ void		 fwupd_client_install_release_async	(FwupdClient	*self,
 							 FwupdInstallFlags install_flags,
 							 GCancellable	*cancellable,
 							 GAsyncReadyCallback callback,
+							 gpointer	 callback_data)
+G_DEPRECATED_FOR(fwupd_client_install_release2_async);
+void		 fwupd_client_install_release2_async	(FwupdClient	*self,
+							 FwupdDevice	*device,
+							 FwupdRelease	*release,
+							 FwupdInstallFlags install_flags,
+							 FwupdClientDownloadFlags download_flags,
+							 GCancellable	*cancellable,
+							 GAsyncReadyCallback callback,
 							 gpointer	 callback_data);
 gboolean	 fwupd_client_install_release_finish	(FwupdClient	*self,
 							 GAsyncResult	*res,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -642,6 +642,8 @@ LIBFWUPD_1.5.5 {
 
 LIBFWUPD_1.5.6 {
   global:
+    fwupd_client_install_release2;
+    fwupd_client_install_release2_async;
     fwupd_release_add_location;
     fwupd_release_get_locations;
   local: *;

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1531,8 +1531,9 @@ fu_util_update_device_with_release (FuUtilPrivate *priv,
 					     error))
 			return FALSE;
 	}
-	return fwupd_client_install_release (priv->client, dev, rel, priv->flags,
-					     priv->cancellable, error);
+	return fwupd_client_install_release2 (priv->client, dev, rel, priv->flags,
+					      FWUPD_CLIENT_DOWNLOAD_FLAG_NONE,
+					      priv->cancellable, error);
 }
 
 static gboolean


### PR DESCRIPTION
We forgot to include FwupdClientDownloadFlags when adding the original method
fwupd_client_install_release() -- and we want to use additional download flags
for operations in the future.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
