### PR TITLE
dfu: Show the DfuTargets when calling DfuDevice->to_string()

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -134,6 +134,10 @@ dfu_device_to_string (FuDevice *device, guint idt, GString *str)
 	fu_common_string_append_kx (str, idt, "IfaceNumber", priv->iface_number);
 	fu_common_string_append_kx (str, idt, "DnloadTimeout", priv->dnload_timeout);
 	fu_common_string_append_kx (str, idt, "TimeoutMs", priv->timeout_ms);
+	for (guint i = 0; i < priv->targets->len; i++) {
+		DfuTarget *target = g_ptr_array_index (priv->targets, i);
+		dfu_target_to_string (target, idt + 1, str);
+	}
 }
 
 /**

--- a/plugins/dfu/dfu-target.h
+++ b/plugins/dfu/dfu-target.h
@@ -83,3 +83,6 @@ gboolean	 dfu_target_download			(DfuTarget	*target,
 							 GError		**error);
 gboolean	 dfu_target_mass_erase			(DfuTarget	*target,
 							 GError		**error);
+void		 dfu_target_to_string			(DfuTarget	*target,
+							 guint		 idt,
+							 GString	*str);


### PR DESCRIPTION
This is a much more standard way of doing this.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
