### PR TITLE
trivial: Fix potential crash when doing crazy things

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -247,6 +247,11 @@ static void
 fwupd_client_set_host_product (FwupdClient *self, const gchar *host_product)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->host_product, host_product) == 0)
+		return;
+
 	g_free (priv->host_product);
 	priv->host_product = g_strdup (host_product);
 	fwupd_client_object_notify (self, "host-product");
@@ -256,6 +261,11 @@ static void
 fwupd_client_set_host_machine_id (FwupdClient *self, const gchar *host_machine_id)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->host_machine_id, host_machine_id) == 0)
+		return;
+
 	g_free (priv->host_machine_id);
 	priv->host_machine_id = g_strdup (host_machine_id);
 	fwupd_client_object_notify (self, "host-machine-id");
@@ -265,6 +275,11 @@ static void
 fwupd_client_set_host_security_id (FwupdClient *self, const gchar *host_security_id)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->host_security_id, host_security_id) == 0)
+		return;
+
 	g_free (priv->host_security_id);
 	priv->host_security_id = g_strdup (host_security_id);
 	fwupd_client_object_notify (self, "host-security-id");
@@ -274,6 +289,11 @@ static void
 fwupd_client_set_daemon_version (FwupdClient *self, const gchar *daemon_version)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->daemon_version, daemon_version) == 0)
+		return;
+
 	g_free (priv->daemon_version);
 	priv->daemon_version = g_strdup (daemon_version);
 	fwupd_client_object_notify (self, "daemon-version");
@@ -4171,8 +4191,14 @@ void
 fwupd_client_set_user_agent (FwupdClient *self, const gchar *user_agent)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (self);
+
 	g_return_if_fail (FWUPD_IS_CLIENT (self));
 	g_return_if_fail (user_agent != NULL);
+
+	/* not changed */
+	if (g_strcmp0 (priv->user_agent, user_agent) == 0)
+		return;
+
 	g_free (priv->user_agent);
 	priv->user_agent = g_strdup (user_agent);
 }

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -172,6 +172,11 @@ fwupd_device_set_summary (FwupdDevice *device, const gchar *summary)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->summary, summary) == 0)
+		return;
+
 	g_free (priv->summary);
 	priv->summary = g_strdup (summary);
 }
@@ -208,6 +213,11 @@ fwupd_device_set_branch (FwupdDevice *device, const gchar *branch)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->branch, branch) == 0)
+		return;
+
 	g_free (priv->branch);
 	priv->branch = g_strdup (branch);
 }
@@ -244,6 +254,11 @@ fwupd_device_set_serial (FwupdDevice *device, const gchar *serial)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->serial, serial) == 0)
+		return;
+
 	g_free (priv->serial);
 	priv->serial = g_strdup (serial);
 }
@@ -280,6 +295,11 @@ fwupd_device_set_id (FwupdDevice *device, const gchar *id)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->id, id) == 0)
+		return;
+
 	g_free (priv->id);
 	priv->id = g_strdup (id);
 }
@@ -316,6 +336,11 @@ fwupd_device_set_parent_id (FwupdDevice *device, const gchar *parent_id)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->parent_id, parent_id) == 0)
+		return;
+
 	g_free (priv->parent_id);
 	priv->parent_id = g_strdup (parent_id);
 }
@@ -633,6 +658,11 @@ fwupd_device_set_name (FwupdDevice *device, const gchar *name)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->name, name) == 0)
+		return;
+
 	g_free (priv->name);
 	priv->name = g_strdup (name);
 }
@@ -669,6 +699,11 @@ fwupd_device_set_vendor (FwupdDevice *device, const gchar *vendor)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->vendor, vendor) == 0)
+		return;
+
 	g_free (priv->vendor);
 	priv->vendor = g_strdup (vendor);
 }
@@ -827,6 +862,11 @@ fwupd_device_set_description (FwupdDevice *device, const gchar *description)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->description, description) == 0)
+		return;
+
 	g_free (priv->description);
 	priv->description = g_strdup (description);
 }
@@ -863,6 +903,11 @@ fwupd_device_set_version (FwupdDevice *device, const gchar *version)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version, version) == 0)
+		return;
+
 	g_free (priv->version);
 	priv->version = g_strdup (version);
 }
@@ -899,6 +944,11 @@ fwupd_device_set_version_lowest (FwupdDevice *device, const gchar *version_lowes
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version_lowest, version_lowest) == 0)
+		return;
+
 	g_free (priv->version_lowest);
 	priv->version_lowest = g_strdup (version_lowest);
 }
@@ -970,6 +1020,11 @@ fwupd_device_set_version_bootloader (FwupdDevice *device, const gchar *version_b
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version_bootloader, version_bootloader) == 0)
+		return;
+
 	g_free (priv->version_bootloader);
 	priv->version_bootloader = g_strdup (version_bootloader);
 }
@@ -1111,6 +1166,11 @@ fwupd_device_set_plugin (FwupdDevice *device, const gchar *plugin)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->plugin, plugin) == 0)
+		return;
+
 	g_free (priv->plugin);
 	priv->plugin = g_strdup (plugin);
 }
@@ -1147,6 +1207,11 @@ fwupd_device_set_protocol (FwupdDevice *device, const gchar *protocol)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->protocol, protocol) == 0)
+		return;
+
 	g_free (priv->protocol);
 	priv->protocol = g_strdup (protocol);
 }
@@ -2007,6 +2072,11 @@ fwupd_device_set_update_message (FwupdDevice *device, const gchar *update_messag
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->update_message, update_message) == 0)
+		return;
+
 	g_free (priv->update_message);
 	priv->update_message = g_strdup (update_message);
 }
@@ -2043,6 +2113,11 @@ fwupd_device_set_update_image (FwupdDevice *device, const gchar *update_image)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->update_image, update_image) == 0)
+		return;
+
 	g_free (priv->update_image);
 	priv->update_image = g_strdup (update_image);
 }
@@ -2079,6 +2154,11 @@ fwupd_device_set_update_error (FwupdDevice *device, const gchar *update_error)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
+
+	/* not changed */
+	if (g_strcmp0 (priv->update_error, update_error) == 0)
+		return;
+
 	g_free (priv->update_error);
 	priv->update_error = g_strdup (update_error);
 }

--- a/libfwupd/fwupd-plugin.c
+++ b/libfwupd/fwupd-plugin.c
@@ -70,6 +70,11 @@ fwupd_plugin_set_name (FwupdPlugin *plugin, const gchar *name)
 	FwupdPluginPrivate *priv = GET_PRIVATE (plugin);
 	g_return_if_fail (FWUPD_IS_PLUGIN (plugin));
 	g_return_if_fail (name != NULL);
+
+	/* not changed */
+	if (g_strcmp0 (priv->name, name) == 0)
+		return;
+
 	g_free (priv->name);
 	priv->name = g_strdup (name);
 	g_object_notify (G_OBJECT (plugin), "name");

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -99,6 +99,11 @@ fwupd_release_set_remote_id (FwupdRelease *release, const gchar *remote_id)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->remote_id, remote_id) == 0)
+		return;
+
 	g_free (priv->remote_id);
 	priv->remote_id = g_strdup (remote_id);
 }
@@ -135,6 +140,11 @@ fwupd_release_set_version (FwupdRelease *release, const gchar *version)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version, version) == 0)
+		return;
+
 	g_free (priv->version);
 	priv->version = g_strdup (version);
 }
@@ -171,6 +181,11 @@ fwupd_release_set_filename (FwupdRelease *release, const gchar *filename)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->filename, filename) == 0)
+		return;
+
 	g_free (priv->filename);
 	priv->filename = g_strdup (filename);
 }
@@ -207,6 +222,11 @@ fwupd_release_set_update_message (FwupdRelease *release, const gchar *update_mes
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->update_message, update_message) == 0)
+		return;
+
 	g_free (priv->update_message);
 	priv->update_message = g_strdup (update_message);
 }
@@ -243,6 +263,11 @@ fwupd_release_set_update_image (FwupdRelease *release, const gchar *update_image
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->update_image, update_image) == 0)
+		return;
+
 	g_free (priv->update_image);
 	priv->update_image = g_strdup (update_image);
 }
@@ -279,6 +304,11 @@ fwupd_release_set_protocol (FwupdRelease *release, const gchar *protocol)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->protocol, protocol) == 0)
+		return;
+
 	g_free (priv->protocol);
 	priv->protocol = g_strdup (protocol);
 }
@@ -657,6 +687,11 @@ fwupd_release_set_homepage (FwupdRelease *release, const gchar *homepage)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->homepage, homepage) == 0)
+		return;
+
 	g_free (priv->homepage);
 	priv->homepage = g_strdup (homepage);
 }
@@ -693,6 +728,11 @@ fwupd_release_set_details_url (FwupdRelease *release, const gchar *details_url)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->details_url, details_url) == 0)
+		return;
+
 	g_free (priv->details_url);
 	priv->details_url = g_strdup (details_url);
 }
@@ -729,6 +769,11 @@ fwupd_release_set_source_url (FwupdRelease *release, const gchar *source_url)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->source_url, source_url) == 0)
+		return;
+
 	g_free (priv->source_url);
 	priv->source_url = g_strdup (source_url);
 }
@@ -765,6 +810,11 @@ fwupd_release_set_description (FwupdRelease *release, const gchar *description)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->description, description) == 0)
+		return;
+
 	g_free (priv->description);
 	priv->description = g_strdup (description);
 }
@@ -801,6 +851,11 @@ fwupd_release_set_appstream_id (FwupdRelease *release, const gchar *appstream_id
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->appstream_id, appstream_id) == 0)
+		return;
+
 	g_free (priv->appstream_id);
 	priv->appstream_id = g_strdup (appstream_id);
 }
@@ -837,6 +892,11 @@ fwupd_release_set_detach_caption (FwupdRelease *release, const gchar *detach_cap
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->detach_caption, detach_caption) == 0)
+		return;
+
 	g_free (priv->detach_caption);
 	priv->detach_caption = g_strdup (detach_caption);
 }
@@ -873,6 +933,11 @@ fwupd_release_set_detach_image (FwupdRelease *release, const gchar *detach_image
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->detach_image, detach_image) == 0)
+		return;
+
 	g_free (priv->detach_image);
 	priv->detach_image = g_strdup (detach_image);
 }
@@ -979,6 +1044,11 @@ fwupd_release_set_summary (FwupdRelease *release, const gchar *summary)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->summary, summary) == 0)
+		return;
+
 	g_free (priv->summary);
 	priv->summary = g_strdup (summary);
 }
@@ -1015,6 +1085,11 @@ fwupd_release_set_branch (FwupdRelease *release, const gchar *branch)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->branch, branch) == 0)
+		return;
+
 	g_free (priv->branch);
 	priv->branch = g_strdup (branch);
 }
@@ -1051,6 +1126,11 @@ fwupd_release_set_vendor (FwupdRelease *release, const gchar *vendor)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->vendor, vendor) == 0)
+		return;
+
 	g_free (priv->vendor);
 	priv->vendor = g_strdup (vendor);
 }
@@ -1087,6 +1167,11 @@ fwupd_release_set_license (FwupdRelease *release, const gchar *license)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->license, license) == 0)
+		return;
+
 	g_free (priv->license);
 	priv->license = g_strdup (license);
 }
@@ -1123,6 +1208,11 @@ fwupd_release_set_name (FwupdRelease *release, const gchar *name)
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->name, name) == 0)
+		return;
+
 	g_free (priv->name);
 	priv->name = g_strdup (name);
 }
@@ -1159,6 +1249,11 @@ fwupd_release_set_name_variant_suffix (FwupdRelease *release, const gchar *name_
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE (release);
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
+
+	/* not changed */
+	if (g_strcmp0 (priv->name_variant_suffix, name_variant_suffix) == 0)
+		return;
+
 	g_free (priv->name_variant_suffix);
 	priv->name_variant_suffix = g_strdup (name_variant_suffix);
 }

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -88,6 +88,11 @@ static void
 fwupd_remote_set_title (FwupdRemote *self, const gchar *title)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->title, title) == 0)
+		return;
+
 	g_free (priv->title);
 	priv->title = g_strdup (title);
 }
@@ -105,6 +110,11 @@ void
 fwupd_remote_set_agreement (FwupdRemote *self, const gchar *agreement)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->agreement, agreement) == 0)
+		return;
+
 	g_free (priv->agreement);
 	priv->agreement = g_strdup (agreement);
 }
@@ -113,6 +123,11 @@ static void
 fwupd_remote_set_checksum (FwupdRemote *self, const gchar *checksum)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->checksum, checksum) == 0)
+		return;
+
 	g_free (priv->checksum);
 	priv->checksum = g_strdup (checksum);
 }
@@ -121,8 +136,14 @@ static void
 fwupd_remote_set_password (FwupdRemote *self, const gchar *password)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->password, password) == 0)
+		return;
+
 	if (password != NULL && password[0] == '\0')
 		password = NULL;
+	g_free (priv->password);
 	priv->password = g_strdup (password);
 }
 
@@ -154,6 +175,11 @@ static void
 fwupd_remote_set_id (FwupdRemote *self, const gchar *id)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+
+	/* not changed */
+	if (g_strcmp0 (priv->id, id) == 0)
+		return;
+
 	g_free (priv->id);
 	priv->id = g_strdup (id);
 	g_strdelimit (priv->id, ".", '\0');
@@ -163,6 +189,8 @@ static void
 fwupd_remote_set_filename_source (FwupdRemote *self, const gchar *filename_source)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+	if (priv->filename_source == filename_source)
+		return;
 	g_free (priv->filename_source);
 	priv->filename_source = g_strdup (filename_source);
 }
@@ -343,6 +371,10 @@ fwupd_remote_set_filename_cache (FwupdRemote *self, const gchar *filename)
 	const gchar *suffix;
 
 	g_return_if_fail (FWUPD_IS_REMOTE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->filename_cache, filename) == 0)
+		return;
 
 	g_free (priv->filename_cache);
 	priv->filename_cache = g_strdup (filename);
@@ -737,6 +769,11 @@ fwupd_remote_set_remotes_dir (FwupdRemote *self, const gchar *directory)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FWUPD_IS_REMOTE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->remotes_dir, directory) == 0)
+		return;
+
 	g_free (priv->remotes_dir);
 	priv->remotes_dir = g_strdup (directory);
 }

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -228,6 +228,10 @@ fwupd_security_attr_set_appstream_id (FwupdSecurityAttr *self, const gchar *apps
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FWUPD_IS_SECURITY_ATTR (self));
 
+	/* not changed */
+	if (g_strcmp0 (priv->appstream_id, appstream_id) == 0)
+		return;
+
 	/* sanity check */
 	if (!g_str_has_prefix (appstream_id, "org.fwupd.hsi."))
 		g_critical ("HSI attributes need to have a 'org.fwupd.hsi.' prefix");
@@ -268,6 +272,11 @@ fwupd_security_attr_set_name (FwupdSecurityAttr *self, const gchar *name)
 {
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FWUPD_IS_SECURITY_ATTR (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->name, name) == 0)
+		return;
+
 	g_free (priv->name);
 	priv->name = g_strdup (name);
 }
@@ -286,6 +295,11 @@ fwupd_security_attr_set_plugin (FwupdSecurityAttr *self, const gchar *plugin)
 {
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FWUPD_IS_SECURITY_ATTR (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->plugin, plugin) == 0)
+		return;
+
 	g_free (priv->plugin);
 	priv->plugin = g_strdup (plugin);
 }
@@ -304,6 +318,11 @@ fwupd_security_attr_set_url (FwupdSecurityAttr *self, const gchar *url)
 {
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FWUPD_IS_SECURITY_ATTR (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->url, url) == 0)
+		return;
+
 	g_free (priv->url);
 	priv->url = g_strdup (url);
 }

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -654,6 +654,11 @@ fu_device_set_equivalent_id (FuDevice *self, const gchar *equivalent_id)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_DEVICE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->equivalent_id, equivalent_id) == 0)
+		return;
+
 	g_free (priv->equivalent_id);
 	priv->equivalent_id = g_strdup (equivalent_id);
 }
@@ -692,6 +697,11 @@ fu_device_set_alternate_id (FuDevice *self, const gchar *alternate_id)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_DEVICE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->alternate_id, alternate_id) == 0)
+		return;
+
 	g_free (priv->alternate_id);
 	priv->alternate_id = g_strdup (alternate_id);
 }
@@ -2028,6 +2038,11 @@ fu_device_set_logical_id (FuDevice *self, const gchar *logical_id)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_DEVICE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->logical_id, logical_id) == 0)
+		return;
+
 	g_free (priv->logical_id);
 	priv->logical_id = g_strdup (logical_id);
 	priv->device_id_valid = FALSE;
@@ -2067,6 +2082,11 @@ fu_device_set_proxy_guid (FuDevice *self, const gchar *proxy_guid)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_DEVICE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->proxy_guid, proxy_guid) == 0)
+		return;
+
 	g_free (priv->proxy_guid);
 	priv->proxy_guid = g_strdup (proxy_guid);
 }
@@ -2126,6 +2146,11 @@ fu_device_set_physical_id (FuDevice *self, const gchar *physical_id)
 	FuDevicePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_DEVICE (self));
 	g_return_if_fail (physical_id != NULL);
+
+	/* not changed */
+	if (g_strcmp0 (priv->physical_id, physical_id) == 0)
+		return;
+
 	g_free (priv->physical_id);
 	priv->physical_id = g_strdup (physical_id);
 	priv->device_id_valid = FALSE;

--- a/libfwupdplugin/fu-firmware-image.c
+++ b/libfwupdplugin/fu-firmware-image.c
@@ -63,6 +63,11 @@ fu_firmware_image_set_version (FuFirmwareImage *self, const gchar *version)
 {
 	FuFirmwareImagePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_FIRMWARE_IMAGE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version, version) == 0)
+		return;
+
 	g_free (priv->version);
 	priv->version = g_strdup (version);
 }
@@ -99,6 +104,11 @@ fu_firmware_image_set_filename (FuFirmwareImage *self, const gchar *filename)
 {
 	FuFirmwareImagePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_FIRMWARE_IMAGE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->filename, filename) == 0)
+		return;
+
 	g_free (priv->filename);
 	priv->filename = g_strdup (filename);
 }
@@ -115,6 +125,11 @@ fu_firmware_image_set_id (FuFirmwareImage *self, const gchar *id)
 {
 	FuFirmwareImagePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_FIRMWARE_IMAGE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->id, id) == 0)
+		return;
+
 	g_free (priv->id);
 	priv->id = g_strdup (id);
 }

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -140,6 +140,11 @@ fu_firmware_set_version (FuFirmware *self, const gchar *version)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_FIRMWARE (self));
+
+	/* not changed */
+	if (g_strcmp0 (priv->version, version) == 0)
+		return;
+
 	g_free (priv->version);
 	priv->version = g_strdup (version);
 }

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -173,6 +173,11 @@ fu_plugin_set_build_hash (FuPlugin *self, const gchar *build_hash)
 	FuPluginPrivate *priv = GET_PRIVATE (self);
 	g_return_if_fail (FU_IS_PLUGIN (self));
 	g_return_if_fail (build_hash != NULL);
+
+	/* not changed */
+	if (g_strcmp0 (priv->build_hash, build_hash) == 0)
+		return;
+
 	g_free (priv->build_hash);
 	priv->build_hash = g_strdup (build_hash);
 }

--- a/plugins/dfu/dfu-target.c
+++ b/plugins/dfu/dfu-target.c
@@ -622,6 +622,11 @@ void
 dfu_target_set_alt_name (DfuTarget *target, const gchar *alt_name)
 {
 	DfuTargetPrivate *priv = GET_PRIVATE (target);
+
+	/* not changed */
+	if (g_strcmp0 (priv->alt_name, alt_name) == 0)
+		return;
+
 	g_free (priv->alt_name);
 	priv->alt_name = g_strdup (alt_name);
 }


### PR DESCRIPTION
Fix the asan crash when feeding the value back into itself, e.g

    fu_firmware_set_version (firmware, fu_firmware_get_version (firmware));

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
