### PR TITLE
trivial: Add getters to FuChunk

### DIFF
--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -21,6 +21,130 @@
  */
 
 /**
+ * fu_chunk_get_idx:
+ * @self: a #FuChunk
+ *
+ * Gets the index of the chunk.
+ *
+ * Return value: index
+ *
+ * Since: 1.5.6
+ **/
+guint32
+fu_chunk_get_idx (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, G_MAXUINT32);
+	return self->idx;
+}
+
+/**
+ * fu_chunk_get_page:
+ * @self: a #FuChunk
+ *
+ * Gets the page of the chunk.
+ *
+ * Return value: page
+ *
+ * Since: 1.5.6
+ **/
+guint32
+fu_chunk_get_page (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, G_MAXUINT32);
+	return self->page;
+}
+
+/**
+ * fu_chunk_get_address:
+ * @self: a #FuChunk
+ *
+ * Gets the address of the chunk.
+ *
+ * Return value: address
+ *
+ * Since: 1.5.6
+ **/
+guint32
+fu_chunk_get_address (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, G_MAXUINT32);
+	return self->address;
+}
+
+/**
+ * fu_chunk_get_data:
+ * @self: a #FuChunk
+ *
+ * Gets the data of the chunk.
+ *
+ * Return value: bytes
+ *
+ * Since: 1.5.6
+ **/
+const guint8 *
+fu_chunk_get_data (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, NULL);
+	return self->data;
+}
+
+/**
+ * fu_chunk_get_data_out:
+ * @self: a #FuChunk
+ *
+ * Gets the mutable data of the chunk.
+ *
+ * WARNING: At the moment fu_chunk_get_data_out() returns the same data as
+ * fu_chunk_get_data() in all cases. The caller should verify the data passed to
+ * fu_chunk_array_new() is also writable (i.e. not `const` or `mmap`) before
+ * using this function.
+ *
+ * Return value: (transfer none): bytes
+ *
+ * Since: 1.5.6
+ **/
+guint8 *
+fu_chunk_get_data_out (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, NULL);
+	return (guint8 *) self->data;
+}
+
+/**
+ * fu_chunk_get_data_sz:
+ * @self: a #FuChunk
+ *
+ * Gets the data size of the chunk.
+ *
+ * Return value: size in bytes
+ *
+ * Since: 1.5.6
+ **/
+guint32
+fu_chunk_get_data_sz (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, G_MAXUINT32);
+	return self->data_sz;
+}
+
+/**
+ * fu_chunk_get_bytes:
+ * @self: a #FuChunk
+ *
+ * Gets the data as bytes of the chunk.
+ *
+ * Return value: (transfer full): a #GBytes
+ *
+ * Since: 1.5.6
+ **/
+GBytes *
+fu_chunk_get_bytes (FuChunk *self)
+{
+	g_return_val_if_fail (self != NULL, NULL);
+	return g_bytes_new_static (self->data, self->data_sz);
+}
+
+/**
  * fu_chunk_new: (skip):
  * @idx: the packet number
  * @page: the hardware memory page

--- a/libfwupdplugin/fu-chunk.h
+++ b/libfwupdplugin/fu-chunk.h
@@ -16,6 +16,14 @@ typedef struct {
 	guint32		 data_sz;
 } FuChunk;
 
+guint32		 fu_chunk_get_idx			(FuChunk	*self);
+guint32		 fu_chunk_get_page			(FuChunk	*self);
+guint32		 fu_chunk_get_address			(FuChunk	*self);
+const guint8	*fu_chunk_get_data			(FuChunk	*self);
+guint8		*fu_chunk_get_data_out			(FuChunk	*self);
+guint32		 fu_chunk_get_data_sz			(FuChunk	*self);
+GBytes		*fu_chunk_get_bytes			(FuChunk	*self);
+
 FuChunk		*fu_chunk_new				(guint32	 idx,
 							 guint32	 page,
 							 guint32	 address,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -724,6 +724,13 @@ LIBFWUPDPLUGIN_1.5.5 {
 
 LIBFWUPDPLUGIN_1.5.6 {
   global:
+    fu_chunk_get_address;
+    fu_chunk_get_bytes;
+    fu_chunk_get_data;
+    fu_chunk_get_data_out;
+    fu_chunk_get_data_sz;
+    fu_chunk_get_idx;
+    fu_chunk_get_page;
     fu_common_get_memory_size;
     fu_common_strjoin_array;
     fu_common_uri_get_scheme;

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -752,10 +752,10 @@ fu_ata_device_write_firmware (FuDevice *device,
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 		if (!fu_ata_device_fw_download (self,
-						chk->idx,
-						chk->address,
-						chk->data,
-						chk->data_sz,
+						fu_chunk_get_idx (chk),
+						fu_chunk_get_address (chk),
+						fu_chunk_get_data (chk),
+						fu_chunk_get_data_sz (chk),
 						error)) {
 			g_prefix_error (error, "failed to write chunk %u: ", i);
 			return FALSE;

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -343,8 +343,9 @@ fu_bcm57xx_device_dump_firmware (FuDevice *device, GError **error)
 	chunks = fu_chunk_array_new (buf, bufsz, 0x0, 0x0, FU_BCM57XX_BLOCK_SZ);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		if (!fu_bcm57xx_device_nvram_read (self, chk->address,
-						   (guint8 *) chk->data, chk->data_sz,
+		if (!fu_bcm57xx_device_nvram_read (self, fu_chunk_get_address (chk),
+						   fu_chunk_get_data_out (chk),
+						   fu_chunk_get_data_sz (chk),
 						   error))
 			return NULL;
 		fu_device_set_progress_full (device, i, chunks->len - 1);
@@ -481,8 +482,9 @@ fu_bcm57xx_device_write_firmware (FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes (blob, 0x0, 0x0, FU_BCM57XX_BLOCK_SZ);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		if (!fu_bcm57xx_device_nvram_write (self, chk->address,
-						    chk->data, chk->data_sz,
+		if (!fu_bcm57xx_device_nvram_write (self, fu_chunk_get_address (chk),
+						    fu_chunk_get_data (chk),
+						    fu_chunk_get_data_sz (chk),
 						    error))
 			return FALSE;
 		fu_device_set_progress_full (device, i, chunks->len - 1);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -509,8 +509,8 @@ fu_cros_ec_usb_device_transfer_block (FuDevice *device, gpointer user_data,
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 
 		if (!fu_cros_ec_usb_device_do_xfer (self,
-						    (guint8 *)chk->data,
-						    chk->data_sz,
+						    fu_chunk_get_data_out (chk),
+						    fu_chunk_get_data_sz (chk),
 						    NULL,
 						    0, FALSE,
 						    NULL, error)) {

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -374,7 +374,7 @@ fu_csr_device_download (FuDevice *device,
 	/* send to hardware */
 	for (idx = 0; idx < chunks->len; idx++) {
 		FuChunk *chk = g_ptr_array_index (chunks, idx);
-		g_autoptr(GBytes) blob_tmp = g_bytes_new_static (chk->data, chk->data_sz);
+		g_autoptr(GBytes) blob_tmp = fu_chunk_get_bytes (chk);
 
 		/* send packet */
 		if (!fu_csr_device_download_chunk (self, idx, blob_tmp, error))

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -310,17 +310,20 @@ fu_elantp_hid_device_write_firmware (FuDevice *device,
 	chunks = fu_chunk_array_new (buf + iap_addr, bufsz - iap_addr, 0x0, 0x0, self->fw_page_size);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		guint16 csum_tmp = fu_elantp_calc_checksum (chk->data, chk->data_sz);
+		guint16 csum_tmp = fu_elantp_calc_checksum (fu_chunk_get_data (chk),
+							    fu_chunk_get_data_sz (chk));
 		gsize blksz = self->fw_page_size + 3;
 		g_autofree guint8 *blk = g_malloc0 (blksz);
 
 		/* write block */
 		blk[0] = 0x0B; /* report ID */
 		if (!fu_memcpy_safe (blk, blksz, 0x1,			/* dst */
-				     chk->data, chk->data_sz, 0x0,	/* src */
-				     chk->data_sz, error))
+				     fu_chunk_get_data (chk),
+				     fu_chunk_get_data_sz (chk), 0x0,	/* src */
+				     fu_chunk_get_data_sz (chk), error))
 			return FALSE;
-		fu_common_write_uint16 (blk + chk->data_sz + 1, csum_tmp, G_LITTLE_ENDIAN);
+		fu_common_write_uint16 (blk + fu_chunk_get_data_sz (chk) + 1,
+					csum_tmp, G_LITTLE_ENDIAN);
 
 		if (!fu_elantp_hid_device_send_cmd (self, blk, blksz, NULL, 0, error))
 			return FALSE;

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -382,7 +382,7 @@ fu_emmc_device_write_firmware (FuDevice *device,
 		for (guint i = 0; i < chunks->len; i++) {
 			FuChunk *chk = g_ptr_array_index (chunks, i);
 
-			mmc_ioc_cmd_set_data (multi_cmd->cmds[1], chk->data);
+			mmc_ioc_cmd_set_data (multi_cmd->cmds[1], fu_chunk_get_data (chk));
 
 			if (!fu_udev_device_ioctl (FU_UDEV_DEVICE (self),
 						   MMC_IOC_MULTI_CMD, (guint8 *) multi_cmd,

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -246,7 +246,7 @@ fu_ep963x_device_write_firmware (FuDevice *device,
 	blocks = fu_chunk_array_new_from_bytes (fw, 0x00, 0x00,
 						FU_EP963_TRANSFER_BLOCK_SIZE);
 	for (guint i = 0; i < blocks->len; i++) {
-		FuChunk *blk = g_ptr_array_index (blocks, i);
+		FuChunk *chk2 = g_ptr_array_index (blocks, i);
 		guint8 buf[] = { i };
 		g_autoptr(GPtrArray) chunks = NULL;
 
@@ -264,8 +264,9 @@ fu_ep963x_device_write_firmware (FuDevice *device,
 		}
 
 		/* 4 byte chunks */
-		chunks = fu_chunk_array_new (blk->data, blk->data_sz,
-					     blk->address, 0x0,
+		chunks = fu_chunk_array_new (fu_chunk_get_data (chk2),
+					     fu_chunk_get_data_sz (chk2),
+					     fu_chunk_get_address (chk2), 0x0,
 					     FU_EP963_TRANSFER_CHUNK_SIZE);
 		for (guint j = 0; j < chunks->len; j++) {
 			FuChunk *chk = g_ptr_array_index (chunks, j);
@@ -275,13 +276,14 @@ fu_ep963x_device_write_firmware (FuDevice *device,
 			if (!fu_ep963x_device_write (self,
 						     FU_EP963_USB_CONTROL_ID,
 						     FU_EP963_OPCODE_SUBMCU_WRITE_BLOCK_DATA,
-						     chk->data, chk->data_sz,
+						     fu_chunk_get_data (chk),
+						     fu_chunk_get_data_sz (chk),
 						     &error_loop)) {
 				g_set_error (error,
 					     FWUPD_ERROR,
 					     FWUPD_ERROR_WRITE,
 					     "failed to write 0x%x: %s",
-					     (guint) chk->address,
+					     (guint) fu_chunk_get_address (chk),
 					     error_loop->message);
 				return FALSE;
 			}
@@ -296,7 +298,7 @@ fu_ep963x_device_write_firmware (FuDevice *device,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_WRITE,
 				     "failed to write 0x%x: %s",
-				     (guint) blk->address,
+				     (guint) fu_chunk_get_address (chk2),
 				     error_local->message);
 			return FALSE;
 		}

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -281,7 +281,10 @@ fu_fastboot_device_download (FuDevice *device, GBytes *fw, GError **error)
 						self->blocksz);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		if (!fu_fastboot_device_write (device, chk->data, chk->data_sz, error))
+		if (!fu_fastboot_device_write (device,
+					       fu_chunk_get_data (chk),
+					       fu_chunk_get_data_sz (chk),
+					       error))
 			return FALSE;
 		fu_device_set_progress_full (device, (gsize) i, (gsize) chunks->len * 2);
 	}

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -337,7 +337,9 @@ fu_goodixmoc_device_write_firmware (FuDevice *device,
 		g_autoptr(GByteArray) req = g_byte_array_new ();
 		g_autoptr(GError) error_block = NULL;
 
-		g_byte_array_append (req, chk->data, chk->data_sz);
+		g_byte_array_append (req,
+				     fu_chunk_get_data (chk),
+				     fu_chunk_get_data_sz (chk));
 
 		/* the last chunk */
 		if (i == chunks->len - 1) {

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -133,9 +133,9 @@ fu_hailuck_tp_device_write_firmware (FuDevice *device,
 		fu_byte_array_append_uint8 (buf, FU_HAILUCK_REPORT_ID_LONG);
 		fu_byte_array_append_uint8 (buf, FU_HAILUCK_CMD_WRITE_TP);
 		fu_byte_array_append_uint16 (buf, 0xCCCC, G_LITTLE_ENDIAN);
-		fu_byte_array_append_uint16 (buf, chk->address, G_LITTLE_ENDIAN);
+		fu_byte_array_append_uint16 (buf, fu_chunk_get_address (chk), G_LITTLE_ENDIAN);
 		fu_byte_array_append_uint16 (buf, 0xCCCC, G_LITTLE_ENDIAN);
-		g_byte_array_append (buf, chk->data, chk->data_sz);
+		g_byte_array_append (buf, fu_chunk_get_data (chk), fu_chunk_get_data_sz (chk));
 		fu_byte_array_append_uint8 (buf, 0xEE);
 		fu_byte_array_append_uint8 (buf, 0xD2);
 		fu_byte_array_append_uint16 (buf, 0xCCCC, G_LITTLE_ENDIAN);

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -342,9 +342,9 @@ fu_nvme_device_write_firmware (FuDevice *device,
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 		if (!fu_nvme_device_fw_download (self,
-						 chk->address,
-						 chk->data,
-						 chk->data_sz,
+						 fu_chunk_get_address (chk),
+						 fu_chunk_get_data (chk),
+						 fu_chunk_get_data_sz (chk),
 						 error)) {
 			g_prefix_error (error, "failed to write chunk %u: ", i);
 			return FALSE;

--- a/plugins/pixart-rf/fu-pxi-device.c
+++ b/plugins/pixart-rf/fu-pxi-device.c
@@ -196,8 +196,8 @@ fu_pxi_device_check_support_resume (FuPxiDevice *self,
 	/* calculate device current checksum */
 	for (guint i = 0; i < self->offset; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		checksum_tmp += fu_pxi_device_calculate_checksum (chk->data,
-								  chk->data_sz);
+		checksum_tmp += fu_pxi_device_calculate_checksum (fu_chunk_get_data (chk),
+								  fu_chunk_get_data_sz (chk));
 	}
 
 	/* check current file is different with previous fw bin or not */
@@ -247,7 +247,7 @@ fu_pxi_device_wait_notify (FuPxiDevice *self,
 }
 
 static gboolean
-fu_pxi_device_fw_object_create (FuPxiDevice *self, const FuChunk *chk, GError **error)
+fu_pxi_device_fw_object_create (FuPxiDevice *self, FuChunk *chk, GError **error)
 {
 	guint8 opcode = 0;
 	g_autoptr(GByteArray) req = g_byte_array_new ();
@@ -255,8 +255,8 @@ fu_pxi_device_fw_object_create (FuPxiDevice *self, const FuChunk *chk, GError **
 	/* request */
 	fu_byte_array_append_uint8 (req, PXI_HID_DEV_OTA_OUTPUT_REPORT_ID);
 	fu_byte_array_append_uint8 (req, FU_PXI_DEVICE_CMD_FW_OBJECT_CREATE);
-	fu_byte_array_append_uint32 (req, chk->address, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32 (req, chk->data_sz, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32 (req, fu_chunk_get_address (chk), G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32 (req, fu_chunk_get_data_sz (chk), G_LITTLE_ENDIAN);
 	if (!fu_udev_device_pwrite_full (FU_UDEV_DEVICE (self), 0x0,
 					 req->data, req->len, error))
 		return FALSE;
@@ -279,20 +279,20 @@ fu_pxi_device_fw_object_create (FuPxiDevice *self, const FuChunk *chk, GError **
 }
 
 static gboolean
-fu_pxi_device_write_payload (FuPxiDevice *self, const FuChunk *chk, GError **error)
+fu_pxi_device_write_payload (FuPxiDevice *self, FuChunk *chk, GError **error)
 {
 	g_autoptr(GByteArray) req = g_byte_array_new ();
 	fu_byte_array_append_uint8 (req, PXI_HID_DEV_OTA_OUTPUT_REPORT_ID);
-	g_byte_array_append (req, chk->data, chk->data_sz);
+	g_byte_array_append (req, fu_chunk_get_data (chk), fu_chunk_get_data_sz (chk));
 	return fu_udev_device_pwrite_full (FU_UDEV_DEVICE (self), 0x0,
 					   req->data, req->len, error);
 }
 
 static gboolean
-fu_pxi_device_write_chunk (FuPxiDevice *self, const FuChunk *chk, GError **error)
+fu_pxi_device_write_chunk (FuPxiDevice *self, FuChunk *chk, GError **error)
 {
 	guint32 prn = 0;
-	guint16 checksum = fu_pxi_device_calculate_checksum (chk->data, chk->data_sz);
+	guint16 checksum;
 	guint16 checksum_device = 0;
 	g_autoptr(GPtrArray) chunks = NULL;
 
@@ -301,7 +301,9 @@ fu_pxi_device_write_chunk (FuPxiDevice *self, const FuChunk *chk, GError **error
 		return FALSE;
 
 	/* write payload */
-	chunks = fu_chunk_array_new (chk->data, chk->data_sz, chk->address,
+	chunks = fu_chunk_array_new (fu_chunk_get_data (chk),
+				     fu_chunk_get_data_sz (chk),
+				     fu_chunk_get_address (chk),
 				     0x0, self->mtu_size);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk2 = g_ptr_array_index (chunks, i);
@@ -330,6 +332,8 @@ fu_pxi_device_write_chunk (FuPxiDevice *self, const FuChunk *chk, GError **error
 	}
 
 	/* the last chunk */
+	checksum = fu_pxi_device_calculate_checksum (fu_chunk_get_data (chk),
+						     fu_chunk_get_data_sz (chk));
 	self->checksum += checksum;
 	if (checksum_device != self->checksum ) {
 		g_set_error (error,

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -285,9 +285,9 @@ fu_rts54hid_device_write_firmware (FuDevice *device,
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 		/* write chunk */
 		if (!fu_rts54hid_device_write_flash (self,
-						     chk->address,
-						     chk->data,
-						     chk->data_sz,
+						     fu_chunk_get_address (chk),
+						     fu_chunk_get_data (chk),
+						     fu_chunk_get_data_sz (chk),
 						     error))
 			return FALSE;
 

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -258,8 +258,8 @@ fu_rts54hid_module_write_firmware (FuDevice *module,
 
 		/* write chunk */
 		if (!fu_rts54hid_module_i2c_write (self,
-						   chk->data,
-						   chk->data_sz,
+						   fu_chunk_get_data (chk),
+						   fu_chunk_get_data_sz (chk),
 						   error))
 			return FALSE;
 

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -360,9 +360,9 @@ fu_rts54hub_device_write_firmware (FuDevice *device,
 
 		/* write chunk */
 		if (!fu_rts54hub_device_write_flash (self,
-						     chk->address,
-						     chk->data,
-						     chk->data_sz,
+						     fu_chunk_get_address (chk),
+						     fu_chunk_get_data (chk),
+						     fu_chunk_get_data_sz (chk),
 						     error))
 			return FALSE;
 

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -270,11 +270,13 @@ fu_solokey_device_packet (FuSolokeyDevice *self, guint8 cmd,
 					     SOLO_USB_HID_EP_SIZE - 5);
 		for (guint i = 0; i < chunks->len; i++) {
 			FuChunk *chk = g_ptr_array_index (chunks, i);
-			guint8 seq = chk->idx;
+			guint8 seq = fu_chunk_get_idx (chk);
 			g_autoptr(GByteArray) req2 = g_byte_array_new ();
 			g_byte_array_append (req2, buf_cid, sizeof(buf_cid));
 			g_byte_array_append (req2, &seq, sizeof(seq));
-			g_byte_array_append (req2, chk->data, chk->data_sz);
+			g_byte_array_append (req2,
+					     fu_chunk_get_data (chk),
+					     fu_chunk_get_data_sz (chk));
 			if (!fu_solokey_device_packet_tx (self, req2, error))
 				return NULL;
 		}
@@ -447,8 +449,10 @@ fu_solokey_device_write_firmware (FuDevice *device,
 		g_autoptr(GByteArray) res = NULL;
 		g_autoptr(GError) error_local = NULL;
 
-		g_byte_array_append (buf, chk->data, chk->data_sz);
-		fu_solokey_device_exchange (req, SOLO_BOOTLOADER_WRITE, chk->address, buf);
+		g_byte_array_append (buf,
+				     fu_chunk_get_data (chk),
+				     fu_chunk_get_data_sz (chk));
+		fu_solokey_device_exchange (req, SOLO_BOOTLOADER_WRITE, fu_chunk_get_address (chk), buf);
 		res = fu_solokey_device_packet (self, SOLO_BOOTLOADER_HID_CMD_BOOT, req, &error_local);
 		if (res == NULL) {
 			g_set_error (error,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -341,10 +341,10 @@ fu_synaptics_rmi_v5_device_write_firmware (FuDevice *device,
 		if (!fu_synaptics_rmi_v5_device_write_block (self,
 							     RMI_F34_WRITE_FW_BLOCK,
 							     address,
-							     chk->data,
-							     chk->data_sz,
+							     fu_chunk_get_data (chk),
+							     fu_chunk_get_data_sz (chk),
 							     error)) {
-			g_prefix_error (error, "failed to write bin block %u: ", chk->idx);
+			g_prefix_error (error, "failed to write bin block %u: ", fu_chunk_get_idx (chk));
 			return FALSE;
 		}
 		fu_device_set_progress_full (device, (gsize) i,
@@ -368,10 +368,10 @@ fu_synaptics_rmi_v5_device_write_firmware (FuDevice *device,
 			if (!fu_synaptics_rmi_v5_device_write_block (self,
 								     RMI_F34_WRITE_SIGNATURE,
 								     address,
-								     chk->data,
-								     chk->data_sz,
+								     fu_chunk_get_data (chk),
+								     fu_chunk_get_data_sz (chk),
 								     error)) {
-				g_prefix_error (error, "failed to write bin block %u: ", chk->idx);
+				g_prefix_error (error, "failed to write bin block %u: ", fu_chunk_get_idx (chk));
 				return FALSE;
 			}
 			fu_device_set_progress_full (device, (gsize) i,
@@ -392,10 +392,10 @@ fu_synaptics_rmi_v5_device_write_firmware (FuDevice *device,
 		if (!fu_synaptics_rmi_v5_device_write_block (self,
 							     RMI_F34_WRITE_CONFIG_BLOCK,
 							     address,
-							     chk->data,
-							     chk->data_sz,
+							     fu_chunk_get_data (chk),
+							     fu_chunk_get_data_sz (chk),
 							     error)) {
-			g_prefix_error (error, "failed to write cfg block %u: ", chk->idx);
+			g_prefix_error (error, "failed to write cfg block %u: ", fu_chunk_get_idx (chk));
 			return FALSE;
 		}
 		fu_device_set_progress_full (device,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -219,9 +219,9 @@ fu_synaptics_rmi_v7_device_write_blocks (FuSynapticsRmiDevice *self,
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 		g_autoptr(GByteArray) req = g_byte_array_new ();
-		g_byte_array_append (req, chk->data, chk->data_sz);
+		g_byte_array_append (req, fu_chunk_get_data (chk), fu_chunk_get_data_sz (chk));
 		if (!fu_synaptics_rmi_device_write (self, address, req, error)) {
-			g_prefix_error (error, "failed to write block @0x%x:%x: ", address, chk->address);
+			g_prefix_error (error, "failed to write block @0x%x:%x: ", address, fu_chunk_get_address (chk));
 			return FALSE;
 		}
 	}
@@ -287,7 +287,7 @@ fu_synaptics_rmi_v7_device_write_partition (FuSynapticsRmiDevice *self,
 		g_autoptr(GByteArray) req_trans_sz = g_byte_array_new ();
 		g_autoptr(GByteArray) req_cmd = g_byte_array_new ();
 		fu_byte_array_append_uint16 (req_trans_sz,
-					     chk->data_sz / flash->block_size,
+					     fu_chunk_get_data_sz (chk) / flash->block_size,
 					     G_LITTLE_ENDIAN);
 		if (!fu_synaptics_rmi_device_write (self,
 						    f34->data_base + 0x3,
@@ -306,8 +306,8 @@ fu_synaptics_rmi_v7_device_write_partition (FuSynapticsRmiDevice *self,
 		}
 		if (!fu_synaptics_rmi_v7_device_write_blocks (self,
 							      f34->data_base + 0x5,
-							      chk->data,
-							      chk->data_sz,
+							      fu_chunk_get_data (chk),
+							      fu_chunk_get_data_sz (chk),
 							      error))
 			return FALSE;
 		fu_device_set_progress_full (FU_DEVICE (self), (gsize) i, (gsize) chunks->len);

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -476,8 +476,8 @@ fu_vli_pd_parade_device_write_firmware (FuDevice *device,
 		return FALSE;
 	blocks = fu_chunk_array_new_from_bytes (fw, 0x0, 0x0, 0x10000);
 	for (guint i = 1; i < blocks->len; i++) {
-		FuChunk *block = g_ptr_array_index (blocks, i);
-		if (!fu_vli_pd_parade_device_block_erase (self, block->idx, error))
+		FuChunk *chk = g_ptr_array_index (blocks, i);
+		if (!fu_vli_pd_parade_device_block_erase (self, fu_chunk_get_idx (chk), error))
 			return FALSE;
 		fu_device_set_progress_full (FU_DEVICE (self), i, blocks->len);
 	}
@@ -494,8 +494,8 @@ fu_vli_pd_parade_device_write_firmware (FuDevice *device,
 	/* write blocks */
 	fu_device_set_status (FU_DEVICE (self), FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 1; i < blocks->len; i++) {
-		FuChunk *block = g_ptr_array_index (blocks, i);
-		if (!fu_vli_pd_parade_device_block_write (self, block->idx, block->data, error))
+		FuChunk *chk = g_ptr_array_index (blocks, i);
+		if (!fu_vli_pd_parade_device_block_write (self, fu_chunk_get_idx (chk), fu_chunk_get_data (chk), error))
 			return FALSE;
 		fu_device_set_progress_full (FU_DEVICE (self), i, blocks->len);
 	}
@@ -507,11 +507,11 @@ fu_vli_pd_parade_device_write_firmware (FuDevice *device,
 	fw_verify = _g_bytes_new_sized (g_bytes_get_size (fw));
 	blocks_verify = fu_chunk_array_new_from_bytes (fw_verify, 0x0, 0x0, 0x10000);
 	for (guint i = 1; i < blocks_verify->len; i++) {
-		FuChunk *block = g_ptr_array_index (blocks_verify, i);
+		FuChunk *chk = g_ptr_array_index (blocks_verify, i);
 		if (!fu_vli_pd_parade_device_block_read (self,
-							 block->idx,
-							 (guint8 *) block->data,
-							 block->data_sz,
+							 fu_chunk_get_idx (chk),
+							 fu_chunk_get_data_out (chk),
+							 fu_chunk_get_data_sz (chk),
 							 error))
 			return FALSE;
 		fu_device_set_progress_full (FU_DEVICE (self), i, blocks->len);
@@ -602,11 +602,11 @@ fu_vli_pd_parade_device_dump_firmware (FuDevice *device, GError **error)
 	fw = _g_bytes_new_sized (fu_device_get_firmware_size_max (device));
 	blocks = fu_chunk_array_new_from_bytes (fw, 0x0, 0x0, 0x10000);
 	for (guint i = 0; i < blocks->len; i++) {
-		FuChunk *block = g_ptr_array_index (blocks, i);
+		FuChunk *chk = g_ptr_array_index (blocks, i);
 		if (!fu_vli_pd_parade_device_block_read (self,
-							 block->idx,
-							 (guint8 *) block->data,
-							 block->data_sz,
+							 fu_chunk_get_idx (chk),
+							 fu_chunk_get_data_out (chk),
+							 fu_chunk_get_data_sz (chk),
 							 error))
 			return NULL;
 	}

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -409,10 +409,10 @@ fu_vli_usbhub_rtd21xx_device_write_firmware (FuDevice *device,
 		if (!fu_vli_usbhub_device_i2c_write (parent,
 						     UC_FOREGROUND_SLAVE_ADDR,
 						     UC_FOREGROUND_ISP_DATA_OPCODE,
-						     (guint8 *) chk->data,
-						     chk->data_sz,
+						     fu_chunk_get_data_out (chk),
+						     fu_chunk_get_data_sz (chk),
 						     error)) {
-			g_prefix_error (error, "failed to write @0x%04x: ", chk->address);
+			g_prefix_error (error, "failed to write @0x%04x: ", fu_chunk_get_address (chk));
 			return FALSE;
 		}
 

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -221,10 +221,10 @@ fu_wacom_aes_device_write_firmware (FuDevice *device, GPtrArray *chunks, GError 
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
 		if (!fu_wacom_aes_device_write_block (self,
-						      chk->idx,
-						      chk->address,
-						      chk->data,
-						      chk->data_sz,
+						      fu_chunk_get_idx (chk),
+						      fu_chunk_get_address (chk),
+						      fu_chunk_get_data (chk),
+						      fu_chunk_get_data_sz (chk),
 						      error))
 			return FALSE;
 		fu_device_set_progress_full (device, (gsize) i, (gsize) chunks->len);

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -207,13 +207,13 @@ fu_wacom_emr_device_write_firmware (FuDevice *device, GPtrArray *chunks, GError 
 	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index (chunks, i);
-		if (fu_wacom_common_block_is_empty (chk->data, chk->data_sz))
+		if (fu_wacom_common_block_is_empty (fu_chunk_get_data (chk), fu_chunk_get_data_sz (chk)))
 			continue;
 		if (!fu_wacom_emr_device_write_block (self,
-						      chk->idx,
-						      chk->address,
-						      chk->data,
-						      chk->data_sz,
+						      fu_chunk_get_idx (chk),
+						      fu_chunk_get_address (chk),
+						      fu_chunk_get_data (chk),
+						      fu_chunk_get_data_sz (chk),
 						      error))
 			return FALSE;
 		fu_device_set_progress_full (device, (gsize) i, (gsize) chunks->len);

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -547,8 +547,11 @@ fu_wac_device_write_firmware (FuDevice *device,
 							self->write_block_sz);
 		for (guint j = 0; j < chunks->len; j++) {
 			FuChunk *chk = g_ptr_array_index (chunks, j);
-			g_autoptr(GBytes) blob_chunk = g_bytes_new (chk->data, chk->data_sz);
-			if (!fu_wac_device_write_block (self, chk->address, blob_chunk, error))
+			g_autoptr(GBytes) blob_chunk = fu_chunk_get_bytes (chk);
+			if (!fu_wac_device_write_block (self,
+							fu_chunk_get_address (chk),
+							blob_chunk,
+							error))
 				return FALSE;
 		}
 

--- a/plugins/wacom-usb/fu-wac-module-touch.c
+++ b/plugins/wacom-usb/fu-wac-module-touch.c
@@ -80,14 +80,14 @@ fu_wac_module_touch_write_firmware (FuDevice *device,
 		/* build G11T data packet */
 		memset (buf, 0xff, sizeof(buf));
 		buf[0] = 0x01; /* writing */
-		buf[1] = chk->idx + 1;
-		fu_common_write_uint32 (&buf[2], chk->address, G_LITTLE_ENDIAN);
+		buf[1] = fu_chunk_get_idx (chk) + 1;
+		fu_common_write_uint32 (&buf[2], fu_chunk_get_address (chk), G_LITTLE_ENDIAN);
 		buf[6] = 0x10; /* no idea! */
-		memcpy (&buf[7], chk->data, chk->data_sz);
+		memcpy (&buf[7], fu_chunk_get_data (chk), fu_chunk_get_data_sz (chk));
 		blob_chunk = g_bytes_new (buf, sizeof(buf));
 		if (!fu_wac_module_set_feature (self, FU_WAC_MODULE_COMMAND_DATA,
 						blob_chunk, error)) {
-			g_prefix_error (error, "failed to write block %u: ", chk->idx);
+			g_prefix_error (error, "failed to write block %u: ", fu_chunk_get_idx (chk));
 			return FALSE;
 		}
 


### PR DESCRIPTION
At the moment FuChunks are sometimes mutable, and sometimes immutable, and it's
all a bit too low level for comfort.

Before we can do any kind of optimisation or verification we need plugins to
stop reading directly from the C structure. The aim here is to make FuChunk
optionally mutable without making assumptions about the memory model, and also
to be able to introspect it for the docs.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
