### PR TITLE
Add fu_firmware_new_from_gtypes() for future usage

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -61,6 +61,10 @@ FuFirmwareFlags	 fu_firmware_flag_from_string		(const gchar	*flag);
 
 FuFirmware	*fu_firmware_new			(void);
 FuFirmware	*fu_firmware_new_from_bytes		(GBytes		*fw);
+FuFirmware	*fu_firmware_new_from_gtypes		(GBytes		*fw,
+							 FwupdInstallFlags flags,
+							 GError		**error,
+							 ...);
 gchar		*fu_firmware_to_string			(FuFirmware	*self);
 const gchar	*fu_firmware_get_version		(FuFirmware	*self);
 void		 fu_firmware_set_version		(FuFirmware	*self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -741,6 +741,7 @@ LIBFWUPDPLUGIN_1.5.6 {
     fu_common_get_memory_size;
     fu_common_strjoin_array;
     fu_common_uri_get_scheme;
+    fu_firmware_new_from_gtypes;
     fu_hwids_add_smbios_override;
     fu_hwids_get_keys;
     fu_plugin_get_devices;


### PR DESCRIPTION
This allows a plugin to define a 'set' of firmwares that it would find
acceptable, for instance either accepting DFU, DfuSe or just a plain binary.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
