### PR TITLE
Clear the pending flag if restarting the system

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6388,7 +6388,8 @@ fu_engine_update_history_database (FuEngine *self, GError **error)
 		g_autoptr(GError) error_local = NULL;
 
 		/* not in the required state */
-		if (fu_device_get_update_state (dev) != FWUPD_UPDATE_STATE_NEEDS_REBOOT)
+		if (fu_device_get_update_state (dev) != FWUPD_UPDATE_STATE_NEEDS_REBOOT &&
+		    fu_device_get_update_state (dev) != FWUPD_UPDATE_STATE_PENDING)
 			continue;
 
 		/* try to save the new update-state, but ignoring any error */


### PR DESCRIPTION
If any update is scheduled for SuperIO, and something changes (such as entering
S3, disconnecting the charger) before the update is installed, then the update
will get stuck.

Fixes https://github.com/fwupd/fwupd/issues/2830

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
