### PR TITLE
trivial: contrib/install_dell_bios_exe.py: recognize the plugin rename

### DIFF
--- a/contrib/firmware_packager/install_dell_bios_exe.py
+++ b/contrib/firmware_packager/install_dell_bios_exe.py
@@ -72,7 +72,7 @@ def find_uefi_device(client, deviceid):
         if not item.has_flag(1 << 8):
             continue
         # return the first hit for UEFI plugin
-        if item.get_plugin() == 'uefi':
+        if item.get_plugin() == 'uefi' or item.get_plugin() == 'uefi-capsule':
             print("Installing to %s" % item.get_name())
             return item.get_guid_default(), item.get_id(), item.get_version()
     print("Couldn't find any UEFI devices")


### PR DESCRIPTION
uefi was renamed to uefi-capsule and now this script forgot the change.
Allow both to work so this script runs on new or older fwupd.

Fixes: #2840

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
