### PR TITLE
trivial: Use json-glib from master to get a fuzzing crash fix

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -217,7 +217,6 @@ def _build(bld: Builder) -> None:
     src = bld.checkout_source(
         "json-glib",
         url="https://gitlab.gnome.org/GNOME/json-glib.git",
-        commit="c30c988ac3b0d9e7c332232e3c3969818749b239",
     )
     bld.build_meson_project(
         src,


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/json-glib/-/commit/7711cbc7f8d85d909bd4ccaa0c4c0f8d306f872f

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
