### PR TITLE
Allow building without SBAT metadata

### DIFF
--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -26,8 +26,3 @@ ninja -C build test -v
 ninja -C build install -v
 mkdir -p dist/docs
 cp build/docs/* dist/docs -R
-
-#run static analysis (these mostly won't be critical)
-if [ "$CC" = "clang" ]; then
-	ninja -C build scan-build -v
-fi

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -229,11 +229,13 @@ or server machines.
 %if 0%{?have_uefi}
     -Dplugin_uefi_capsule=true \
     -Dplugin_uefi_pk=true \
+%ifarch x86_64
     -Defi_sbat_distro_id="fedora" \
     -Defi_sbat_distro_summary="The Fedora Project" \
     -Defi_sbat_distro_pkgname="%{name}" \
     -Defi_sbat_distro_version="%{version}" \
     -Defi_sbat_distro_url="https://src.fedoraproject.org/rpms/%{name}" \
+%endif
     -Dtpm=true \
 %else
     -Dplugin_uefi_capsule=false \

--- a/plugins/uefi-capsule/efi/generate_binary.py
+++ b/plugins/uefi-capsule/efi/generate_binary.py
@@ -21,6 +21,10 @@ def _run_objcopy_sbat(args, tfd):
     with open(args.infile, "rb") as ifd:
         tfd.write(ifd.read())
 
+    # not specified
+    if not args.sbat_distro_id:
+        return
+
     with tempfile.NamedTemporaryFile() as sfd:
 
         # spec
@@ -45,18 +49,17 @@ def _run_objcopy_sbat(args, tfd):
         )
 
         # distro specifics, falling back to the project defaults
-        if args.sbat_distro_id:
-            sfd.write(
-                "{0}-{1},{2},{3},{4},{5},{6}\n".format(
-                    args.project_name,
-                    args.sbat_distro_id,
-                    args.sbat_distro_generation or args.sbat_generation,
-                    args.sbat_distro_summary or FWUPD_SUMMARY,
-                    args.sbat_distro_pkgname,
-                    args.sbat_distro_version or args.project_version,
-                    args.sbat_distro_url or FWUPD_URL,
-                ).encode()
-            )
+        sfd.write(
+            "{0}-{1},{2},{3},{4},{5},{6}\n".format(
+                args.project_name,
+                args.sbat_distro_id,
+                args.sbat_distro_generation or args.sbat_generation,
+                args.sbat_distro_summary or FWUPD_SUMMARY,
+                args.sbat_distro_pkgname,
+                args.sbat_distro_version or args.project_version,
+                args.sbat_distro_url or FWUPD_URL,
+            ).encode()
+        )
 
         # all written
         sfd.seek(0)

--- a/plugins/uefi-capsule/efi/meson.build
+++ b/plugins/uefi-capsule/efi/meson.build
@@ -156,7 +156,7 @@ so = custom_target('fwup.so',
 
 # sanity check the packager set this to *SOMETHING*
 if get_option('efi_sbat_distro_id') == '' and get_option('supported_build')
-    error('-Defi_sbat_distro_id is unset, see plugins/uefi-capsule/README.md')
+    warning('-Defi_sbat_distro_id is unset, see plugins/uefi-capsule/README.md')
 endif
 
 app = custom_target(efi_name,


### PR DESCRIPTION
Two reasons:

 * It seems a bit antisocial to hard-require all this data without fair warning
 * The aarch64 pesign crashes when trying to sign the binary with SBAT metadata
