### PR TITLE
contrib/PKGBUILD: Ensure pkgver gets expanded as an bash variable

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -31,7 +31,7 @@ build() {
         -Defi_sbat_distro_id="arch" \
         -Defi_sbat_distro_summary="Arch Linux" \
         -Defi_sbat_distro_pkgname="${pkgname}" \
-        -Defi_sbat_distro_version="$(pkgver)" \
+        -Defi_sbat_distro_version="${pkgver}" \
         -Defi_sbat_distro_url="https://archlinux.org/packages/community/x86_64/${pkgname}/" \
         -Dsupported_build=true
 


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>

Type of pull request:
- [x] Code fix