### PR TITLE
Call the superclass directly from subclassed devices

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -6,3 +6,6 @@ Planned API/ABI changes for next release
  * Remove fu_plugin_get_usb_context() and fu_plugin_set_usb_context()
  * Remove fu_plugin_runner_usb_device_added(), fu_plugin_runner_udev_device_added()
    and fu_plugin_runner_udev_device_changed()
+ * Remove FuHidDevice->open() and FuHidDevice->close()
+ * Remove FuUsbDevice->probe(), FuUsbDevice->open() and FuUsbDevice->close()
+ * Remove FuUdevDevice->to_string(), FuUdevDevice->probe(), FuUdevDevice->open() and FuUdevDevice->close()

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -170,8 +170,10 @@ fu_udev_device_to_string (FuDevice *device, guint idt, GString *str)
 #endif
 
 	/* subclassed */
-	if (klass->to_string != NULL)
+	if (klass->to_string != NULL) {
+		g_warning ("FuUdevDevice->to_string is deprecated!");
 		klass->to_string (self, idt, str);
+	}
 }
 
 static void
@@ -498,6 +500,7 @@ fu_udev_device_probe (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->probe != NULL) {
+		g_warning ("FuUdevDevice->probe is deprecated!");
 		if (!klass->probe (self, error))
 			return FALSE;
 	}
@@ -1226,6 +1229,7 @@ fu_udev_device_open (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->open != NULL) {
+		g_warning ("FuUdevDevice->open is deprecated!");
 		if (!klass->open (self, error))
 			return FALSE;
 	}
@@ -1277,6 +1281,7 @@ fu_udev_device_close (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->close != NULL) {
+		g_warning ("FuUdevDevice->close is deprecated!");
 		if (!klass->close (self, error))
 			return FALSE;
 	}

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -267,6 +267,7 @@ fu_usb_device_open (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->open != NULL) {
+		g_warning ("FuUsbDevice->open is deprecated!");
 		if (!klass->open (self, error))
 			return FALSE;
 	}
@@ -292,6 +293,7 @@ fu_usb_device_close (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->close != NULL) {
+		g_warning ("FuUsbDevice->close is deprecated!");
 		if (!klass->close (self, error))
 			return FALSE;
 	}
@@ -372,6 +374,7 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->probe != NULL) {
+		g_warning ("FuUsbDevice->probe is deprecated!");
 		if (!klass->probe (self, error))
 			return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -738,17 +738,18 @@ fu_bcm57xx_recovery_device_init (FuBcm57xxRecoveryDevice *self)
 }
 
 static gboolean
-fu_bcm57xx_recovery_device_probe (FuUdevDevice *device, GError **error)
+fu_bcm57xx_recovery_device_probe (FuDevice *device, GError **error)
 {
-	/* success */
-	return fu_udev_device_set_physical_id (device, "pci", error);
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_bcm57xx_recovery_device_parent_class)->probe (device, error))
+		return FALSE;
+	return fu_udev_device_set_physical_id (FU_UDEV_DEVICE (device), "pci", error);
 }
 
 static void
 fu_bcm57xx_recovery_device_class_init (FuBcm57xxRecoveryDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev_device = FU_UDEV_DEVICE_CLASS (klass);
 	klass_device->activate = fu_bcm57xx_recovery_device_activate;
 	klass_device->prepare_firmware = fu_bcm57xx_recovery_device_prepare_firmware;
 	klass_device->setup = fu_bcm57xx_recovery_device_setup;
@@ -759,7 +760,7 @@ fu_bcm57xx_recovery_device_class_init (FuBcm57xxRecoveryDeviceClass *klass)
 	klass_device->dump_firmware = fu_bcm57xx_recovery_device_dump_firmware;
 	klass_device->attach = fu_bcm57xx_recovery_device_attach;
 	klass_device->detach = fu_bcm57xx_recovery_device_detach;
-	klass_udev_device->probe = fu_bcm57xx_recovery_device_probe;
+	klass_device->probe = fu_bcm57xx_recovery_device_probe;
 }
 
 FuBcm57xxRecoveryDevice *

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -145,10 +145,14 @@ fu_cros_ec_usb_device_find_interface (FuUsbDevice *device,
 }
 
 static gboolean
-fu_cros_ec_usb_device_open (FuUsbDevice *device, GError **error)
+fu_cros_ec_usb_device_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_cros_ec_usb_device_parent_class)->open (device, error))
+		return FALSE;
 
 	if (!g_usb_device_claim_interface (usb_device, self->iface_idx,
 					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
@@ -162,13 +166,17 @@ fu_cros_ec_usb_device_open (FuUsbDevice *device, GError **error)
 }
 
 static gboolean
-fu_cros_ec_usb_device_probe (FuUsbDevice *device, GError **error)
+fu_cros_ec_usb_device_probe (FuDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
 
+	/* FuUsbDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_cros_ec_usb_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* very much like usb_updater2's usb_findit() */
 
-	if (!fu_cros_ec_usb_device_find_interface (device, error)) {
+	if (!fu_cros_ec_usb_device_find_interface (FU_USB_DEVICE (device), error)) {
 		g_prefix_error (error, "failed to find update interface: ");
 		return FALSE;
 	}
@@ -843,9 +851,9 @@ fu_cros_ec_usb_device_write_firmware (FuDevice *device,
 }
 
 static gboolean
-fu_cros_ec_usb_device_close (FuUsbDevice *device, GError **error)
+fu_cros_ec_usb_device_close (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
 
 	if (!g_usb_device_release_interface (usb_device, self->iface_idx,
@@ -855,8 +863,8 @@ fu_cros_ec_usb_device_close (FuUsbDevice *device, GError **error)
 		return FALSE;
 	}
 
-	/* success */
-	return TRUE;
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_cros_ec_usb_device_parent_class)->close (device, error);
 }
 
 static FuFirmware *
@@ -980,14 +988,13 @@ static void
 fu_cros_ec_usb_device_class_init (FuCrosEcUsbDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->attach = fu_cros_ec_usb_device_attach;
 	klass_device->detach = fu_cros_ec_usb_device_detach;
 	klass_device->prepare_firmware = fu_cros_ec_usb_device_prepare_firmware;
 	klass_device->setup = fu_cros_ec_usb_device_setup;
 	klass_device->to_string = fu_cros_ec_usb_device_to_string;
 	klass_device->write_firmware = fu_cros_ec_usb_device_write_firmware;
-	klass_usb_device->open = fu_cros_ec_usb_device_open;
-	klass_usb_device->probe = fu_cros_ec_usb_device_probe;
-	klass_usb_device->close = fu_cros_ec_usb_device_close;
+	klass_device->open = fu_cros_ec_usb_device_open;
+	klass_device->probe = fu_cros_ec_usb_device_probe;
+	klass_device->close = fu_cros_ec_usb_device_close;
 }

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -400,17 +400,20 @@ fu_dfu_csr_device_download (FuDevice *device,
 }
 
 static gboolean
-fu_dfu_csr_device_probe (FuUsbDevice *device, GError **error)
+fu_dfu_csr_device_probe (FuDevice *device, GError **error)
 {
 	FuDfuCsrDevice *self = FU_DFU_CSR_DEVICE (device);
 
+	/* FuUsbDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_dfu_csr_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* proxy the quirk delay */
-	if (fu_device_has_custom_flag (FU_DEVICE (device),
-				       FU_DFU_CSR_DEVICE_FLAG_REQUIRE_DELAY))
+	if (fu_device_has_custom_flag (device, FU_DFU_CSR_DEVICE_FLAG_REQUIRE_DELAY))
 		self->quirks = FU_DFU_CSR_DEVICE_QUIRK_REQUIRE_DELAY;
 
 	/* hardcoded */
-	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 
 	/* success */
 	return TRUE;
@@ -438,12 +441,11 @@ static void
 fu_dfu_csr_device_class_init (FuDfuCsrDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->to_string = fu_dfu_csr_device_to_string;
 	klass_device->write_firmware = fu_dfu_csr_device_download;
 	klass_device->dump_firmware = fu_dfu_csr_device_upload;
 	klass_device->prepare_firmware = fu_dfu_csr_device_prepare_firmware;
 	klass_device->attach = fu_dfu_csr_device_attach;
 	klass_device->setup = fu_dfu_csr_device_setup;
-	klass_usb_device->probe = fu_dfu_csr_device_probe;
+	klass_device->probe = fu_dfu_csr_device_probe;
 }

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -41,21 +41,25 @@ fu_elantp_hid_device_to_string (FuDevice *device, guint idt, GString *str)
 }
 
 static gboolean
-fu_elantp_hid_device_probe (FuUdevDevice *device, GError **error)
+fu_elantp_hid_device_probe (FuDevice *device, GError **error)
 {
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_elantp_hid_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* check is valid */
-	if (g_strcmp0 (fu_udev_device_get_subsystem (device), "hidraw") != 0) {
+	if (g_strcmp0 (fu_udev_device_get_subsystem (FU_UDEV_DEVICE (device)), "hidraw") != 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,
 			     "is not correct subsystem=%s, expected hidraw",
-			     fu_udev_device_get_subsystem (device));
+			     fu_udev_device_get_subsystem (FU_UDEV_DEVICE (device)));
 		return FALSE;
 	}
 
 	/* i2c-hid */
-	if (fu_udev_device_get_model (device) < 0x3000 ||
-	    fu_udev_device_get_model (device) >= 0x4000) {
+	if (fu_udev_device_get_model (FU_UDEV_DEVICE (device)) < 0x3000 ||
+	    fu_udev_device_get_model (FU_UDEV_DEVICE (device)) >= 0x4000) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
@@ -64,7 +68,7 @@ fu_elantp_hid_device_probe (FuUdevDevice *device, GError **error)
 	}
 
 	/* set the physical ID */
-	return fu_udev_device_set_physical_id (device, "hid", error);
+	return fu_udev_device_set_physical_id (FU_UDEV_DEVICE (device), "hid", error);
 }
 
 static gboolean
@@ -566,7 +570,6 @@ fu_elantp_hid_device_class_init (FuElantpHidDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev_device = FU_UDEV_DEVICE_CLASS (klass);
 	object_class->finalize = fu_elantp_hid_device_finalize;
 	klass_device->to_string = fu_elantp_hid_device_to_string;
 	klass_device->attach = fu_elantp_hid_device_attach;
@@ -576,5 +579,5 @@ fu_elantp_hid_device_class_init (FuElantpHidDeviceClass *klass)
 	klass_device->reload = fu_elantp_hid_device_setup;
 	klass_device->write_firmware = fu_elantp_hid_device_write_firmware;
 	klass_device->prepare_firmware = fu_elantp_hid_device_prepare_firmware;
-	klass_udev_device->probe = fu_elantp_hid_device_probe;
+	klass_device->probe = fu_elantp_hid_device_probe;
 }

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -292,9 +292,14 @@ fu_goodixmoc_device_attach (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_goodixmoc_device_open (FuUsbDevice *device, GError **error)
+fu_goodixmoc_device_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_goodixmoc_device_parent_class)->open (device, error))
+		return FALSE;
+
 	return g_usb_device_claim_interface (usb_device, GX_USB_INTERFACE,
 					     G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
 					     error);
@@ -421,9 +426,8 @@ static void
 fu_goodixmoc_device_class_init(FuGoodixMocDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS(klass);
 	klass_device->write_firmware = fu_goodixmoc_device_write_firmware;
 	klass_device->setup = fu_goodixmoc_device_setup;
 	klass_device->attach = fu_goodixmoc_device_attach;
-	klass_usb_device->open = fu_goodixmoc_device_open;
+	klass_device->open = fu_goodixmoc_device_open;
 }

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -36,15 +36,19 @@ fu_hailuck_bl_device_attach (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_hailuck_bl_device_probe (FuUsbDevice *device, GError **error)
+fu_hailuck_bl_device_probe (FuDevice *device, GError **error)
 {
 	g_autofree gchar *devid = NULL;
 
+	/* FuUsbDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_hailuck_bl_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* add extra keyboard-specific GUID */
 	devid = g_strdup_printf ("USB\\VID_%04X&PID_%04X&MODE_KBD",
-				 fu_usb_device_get_vid (device),
-				 fu_usb_device_get_pid (device));
-	fu_device_add_instance_id (FU_DEVICE (device), devid);
+				 fu_usb_device_get_vid (FU_USB_DEVICE (device)),
+				 fu_usb_device_get_pid (FU_USB_DEVICE (device)));
+	fu_device_add_instance_id (device, devid);
 
 	/* success */
 	return TRUE;
@@ -276,10 +280,9 @@ static void
 fu_hailuck_bl_device_class_init (FuHailuckBlDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->dump_firmware = fu_hailuck_bl_device_dump_firmware;
 	klass_device->prepare_firmware = fu_hailuck_bl_device_prepare_firmware;
 	klass_device->write_firmware = fu_hailuck_bl_device_write_firmware;
 	klass_device->attach = fu_hailuck_bl_device_attach;
-	klass_usb_device->probe = fu_hailuck_bl_device_probe;
+	klass_device->probe = fu_hailuck_bl_device_probe;
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -258,10 +258,14 @@ fu_logitech_hidpp_bootloader_set_bl_version (FuLogitechHidPpBootloader *self, GE
 }
 
 static gboolean
-fu_logitech_hidpp_bootloader_open (FuUsbDevice *device, GError **error)
+fu_logitech_hidpp_bootloader_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	const guint idx = 0x00;
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_logitech_hidpp_bootloader_parent_class)->open (device, error))
+		return FALSE;
 
 	/* claim the only interface */
 	if (!g_usb_device_claim_interface (usb_device, idx,
@@ -316,9 +320,9 @@ fu_logitech_hidpp_bootloader_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_logitech_hidpp_bootloader_close (FuUsbDevice *device, GError **error)
+fu_logitech_hidpp_bootloader_close (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	if (usb_device != NULL) {
 		if (!g_usb_device_release_interface (usb_device, 0x00,
 						     G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
@@ -326,7 +330,9 @@ fu_logitech_hidpp_bootloader_close (FuUsbDevice *device, GError **error)
 			return FALSE;
 		}
 	}
-	return TRUE;
+
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_logitech_hidpp_bootloader_parent_class)->close (device, error);
 }
 
 gboolean
@@ -462,10 +468,9 @@ static void
 fu_logitech_hidpp_bootloader_class_init (FuLogitechHidPpBootloaderClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->to_string = fu_logitech_hidpp_bootloader_to_string;
 	klass_device->attach = fu_logitech_hidpp_bootloader_attach;
 	klass_device->setup = fu_logitech_hidpp_bootloader_setup;
-	klass_usb_device->open = fu_logitech_hidpp_bootloader_open;
-	klass_usb_device->close = fu_logitech_hidpp_bootloader_close;
+	klass_device->open = fu_logitech_hidpp_bootloader_open;
+	klass_device->close = fu_logitech_hidpp_bootloader_close;
 }

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -15,12 +15,16 @@ struct _FuOptionromDevice {
 G_DEFINE_TYPE (FuOptionromDevice, fu_optionrom_device, FU_TYPE_UDEV_DEVICE)
 
 static gboolean
-fu_optionrom_device_probe (FuUdevDevice *device, GError **error)
+fu_optionrom_device_probe (FuDevice *device, GError **error)
 {
 	g_autofree gchar *fn = NULL;
 
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_optionrom_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* does the device even have ROM? */
-	fn = g_build_filename (fu_udev_device_get_sysfs_path (device), "rom", NULL);
+	fn = g_build_filename (fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device)), "rom", NULL);
 	if (!g_file_test (fn, G_FILE_TEST_EXISTS)) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
@@ -30,7 +34,7 @@ fu_optionrom_device_probe (FuUdevDevice *device, GError **error)
 	}
 
 	/* set the physical ID */
-	return fu_udev_device_set_physical_id (device, "pci", error);
+	return fu_udev_device_set_physical_id (FU_UDEV_DEVICE (device), "pci", error);
 }
 
 static GBytes *
@@ -133,8 +137,7 @@ fu_optionrom_device_class_init (FuOptionromDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev_device = FU_UDEV_DEVICE_CLASS (klass);
 	object_class->finalize = fu_optionrom_device_finalize;
 	klass_device->dump_firmware = fu_optionrom_device_dump_firmware;
-	klass_udev_device->probe = fu_optionrom_device_probe;
+	klass_device->probe = fu_optionrom_device_probe;
 }

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -241,12 +241,16 @@ fu_rts54hid_device_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_rts54hid_device_close (FuHidDevice *device, GError **error)
+fu_rts54hid_device_close (FuDevice *device, GError **error)
 {
 	FuRts54HidDevice *self = FU_RTS54HID_DEVICE (device);
 
 	/* set MCU to normal clock rate */
-	return fu_rts54hid_device_set_clock_mode (self, FALSE, error);
+	if (!fu_rts54hid_device_set_clock_mode (self, FALSE, error))
+		return FALSE;
+
+	/* FuHidDevice->close */
+	return FU_DEVICE_CLASS (fu_rts54hid_device_parent_class)->close (device, error);
 }
 
 static gboolean
@@ -318,9 +322,8 @@ static void
 fu_rts54hid_device_class_init (FuRts54HidDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuHidDeviceClass *klass_hid_device = FU_HID_DEVICE_CLASS (klass);
 	klass_device->write_firmware = fu_rts54hid_device_write_firmware;
 	klass_device->to_string = fu_rts54hid_device_to_string;
 	klass_device->setup = fu_rts54hid_device_setup;
-	klass_hid_device->close = fu_rts54hid_device_close;
+	klass_device->close = fu_rts54hid_device_close;
 }

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -377,7 +377,7 @@ fu_rts54hub_device_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_rts54hub_device_close (FuUsbDevice *device, GError **error)
+fu_rts54hub_device_close (FuDevice *device, GError **error)
 {
 	FuRts54HubDevice *self = FU_RTS54HUB_DEVICE (device);
 
@@ -389,8 +389,8 @@ fu_rts54hub_device_close (FuUsbDevice *device, GError **error)
 		}
 	}
 
-	/* success */
-	return TRUE;
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_rts54hub_device_parent_class)->close (device, error);
 }
 
 static gboolean
@@ -508,10 +508,9 @@ static void
 fu_rts54hub_device_class_init (FuRts54HubDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->write_firmware = fu_rts54hub_device_write_firmware;
 	klass_device->setup = fu_rts54hub_device_setup;
 	klass_device->to_string = fu_rts54hub_device_to_string;
 	klass_device->prepare_firmware = fu_rts54hub_device_prepare_firmware;
-	klass_usb_device->close = fu_rts54hub_device_close;
+	klass_device->close = fu_rts54hub_device_close;
 }

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -15,10 +15,14 @@
 G_DEFINE_TYPE (FuSteelseriesDevice, fu_steelseries_device, FU_TYPE_USB_DEVICE)
 
 static gboolean
-fu_steelseries_device_open (FuUsbDevice *device, GError **error)
+fu_steelseries_device_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	const guint8 iface_idx = 0x00;
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_steelseries_device_parent_class)->open (device, error))
+		return FALSE;
 
 	/* get firmware version on SteelSeries Rival 100 */
 	if (!g_usb_device_claim_interface (usb_device, iface_idx,
@@ -94,9 +98,9 @@ fu_steelseries_device_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_steelseries_device_close (FuUsbDevice *device, GError **error)
+fu_steelseries_device_close (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	const guint8 iface_idx = 0x00;
 
 	/* we're done here */
@@ -107,8 +111,8 @@ fu_steelseries_device_close (FuUsbDevice *device, GError **error)
 		return FALSE;
 	}
 
-	/* success */
-	return TRUE;
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_steelseries_device_parent_class)->close (device, error);
 }
 
 static void
@@ -121,8 +125,7 @@ static void
 fu_steelseries_device_class_init (FuSteelseriesDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->setup = fu_steelseries_device_setup;
-	klass_usb_device->open = fu_steelseries_device_open;
-	klass_usb_device->close = fu_steelseries_device_close;
+	klass_device->open = fu_steelseries_device_open;
+	klass_device->close = fu_steelseries_device_close;
 }

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -111,10 +111,14 @@ fu_superio_device_regdump (FuSuperioDevice *self, guint8 ldn, GError **error)
 }
 
 static void
-fu_superio_device_to_string (FuUdevDevice *device, guint idt, GString *str)
+fu_superio_device_to_string (FuDevice *device, guint idt, GString *str)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
 	FuSuperioDevicePrivate *priv = GET_PRIVATE (self);
+
+	/* FuUdevDevice->to_string */
+	FU_DEVICE_CLASS (fu_superio_device_parent_class)->to_string (device, idt, str);
+
 	fu_common_string_append_kv (str, idt, "Chipset", priv->chipset);
 	fu_common_string_append_kx (str, idt, "Id", priv->id);
 	fu_common_string_append_kx (str, idt, "Port", priv->port);
@@ -413,7 +417,6 @@ fu_superio_device_class_init (FuSuperioDeviceClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	GParamSpec *pspec;
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev_device = FU_UDEV_DEVICE_CLASS (klass);
 
 	/* properties */
 	object_class->get_property = fu_superio_device_get_property;
@@ -437,7 +440,7 @@ fu_superio_device_class_init (FuSuperioDeviceClass *klass)
 	g_object_class_install_property (object_class, PROP_ID, pspec);
 
 	object_class->finalize = fu_superio_device_finalize;
-	klass_udev_device->to_string = fu_superio_device_to_string;
+	klass_device->to_string = fu_superio_device_to_string;
 	klass_device->probe = fu_superio_device_probe;
 	klass_device->setup = fu_superio_device_setup;
 	klass_device->prepare_firmware = fu_superio_device_prepare_firmware;

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -64,9 +64,14 @@ typedef struct __attribute__((packed)) {
 G_DEFINE_TYPE (FuSynapromDevice, fu_synaprom_device, FU_TYPE_USB_DEVICE)
 
 static gboolean
-fu_synaprom_device_open (FuUsbDevice *device, GError **error)
+fu_synaprom_device_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_synaprom_device_parent_class)->open (device, error))
+		return FALSE;
+
 	if (!g_usb_device_claim_interface (usb_device, 0x0,
 					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
 					   error)) {
@@ -454,14 +459,13 @@ static void
 fu_synaprom_device_class_init (FuSynapromDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->write_firmware = fu_synaprom_device_write_firmware;
 	klass_device->prepare_firmware = fu_synaprom_device_prepare_fw;
 	klass_device->setup = fu_synaprom_device_setup;
 	klass_device->reload = fu_synaprom_device_setup;
 	klass_device->attach = fu_synaprom_device_attach;
 	klass_device->detach = fu_synaprom_device_detach;
-	klass_usb_device->open = fu_synaprom_device_open;
+	klass_device->open = fu_synaprom_device_open;
 }
 
 FuSynapromDevice *

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -83,10 +83,14 @@ fu_synaptics_rmi_flash_to_string (FuSynapticsRmiFlash *flash, guint idt, GString
 }
 
 static void
-fu_synaptics_rmi_device_to_string (FuUdevDevice *device, guint idt, GString *str)
+fu_synaptics_rmi_device_to_string (FuDevice *device, guint idt, GString *str)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE (device);
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE (self);
+
+	/* FuUdevDevice->to_string */
+	FU_DEVICE_CLASS (fu_synaptics_rmi_device_parent_class)->to_string (device, idt, str);
+
 	fu_common_string_append_kx (str, idt, "CurrentPage", priv->current_page);
 	fu_common_string_append_kx (str, idt, "InIepMode", priv->in_iep_mode);
 	fu_common_string_append_kx (str, idt, "MaxPage", priv->max_page);
@@ -822,9 +826,8 @@ fu_synaptics_rmi_device_class_init (FuSynapticsRmiDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_device_udev = FU_UDEV_DEVICE_CLASS (klass);
 	object_class->finalize = fu_synaptics_rmi_device_finalize;
-	klass_device_udev->to_string = fu_synaptics_rmi_device_to_string;
+	klass_device->to_string = fu_synaptics_rmi_device_to_string;
 	klass_device->prepare_firmware = fu_synaptics_rmi_device_prepare_firmware;
 	klass_device->setup = fu_synaptics_rmi_device_setup;
 	klass_device->write_firmware = fu_synaptics_rmi_device_write_firmware;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -719,32 +719,38 @@ fu_synaptics_rmi_ps2_device_write_bus_select (FuSynapticsRmiDevice *rmi_device,
 }
 
 static gboolean
-fu_synaptics_rmi_ps2_device_probe (FuUdevDevice *device, GError **error)
+fu_synaptics_rmi_ps2_device_probe (FuDevice *device, GError **error)
 {
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_synaptics_rmi_ps2_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* psmouse is the usual mode, but serio is needed for update */
-	if (g_strcmp0 (fu_udev_device_get_driver (device), "serio_raw") == 0) {
-		fu_device_add_flag (FU_DEVICE (device),
-				    FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	if (g_strcmp0 (fu_udev_device_get_driver (FU_UDEV_DEVICE (device)), "serio_raw") == 0) {
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	} else {
-		fu_device_remove_flag (FU_DEVICE (device),
-				       FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	}
 
 	/* set the physical ID */
-	return fu_udev_device_set_physical_id (device, "platform", error);
+	return fu_udev_device_set_physical_id (FU_UDEV_DEVICE (device), "platform", error);
 }
 
 static gboolean
-fu_synaptics_rmi_ps2_device_open (FuUdevDevice *device, GError **error)
+fu_synaptics_rmi_ps2_device_open (FuDevice *device, GError **error)
 {
 	FuSynapticsRmiPs2Device *self = FU_SYNAPTICS_RMI_PS2_DEVICE (device);
 	guint8 buf[2] = { 0x0 };
 
+	/* FuUdevDevice->open */
+	if (!FU_DEVICE_CLASS (fu_synaptics_rmi_ps2_device_parent_class)->open (device, error))
+		return FALSE;
+
 	/* create channel */
-	self->io_channel = fu_io_channel_unix_new (fu_udev_device_get_fd (device));
+	self->io_channel = fu_io_channel_unix_new (fu_udev_device_get_fd (FU_UDEV_DEVICE (device)));
 
 	/* in serio_raw mode */
-	if (fu_device_has_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
 
 		/* clear out any data in the serio_raw queue */
 		for(guint i = 0; i < 0xffff; i++) {
@@ -784,13 +790,14 @@ fu_synaptics_rmi_ps2_device_open (FuUdevDevice *device, GError **error)
 }
 
 static gboolean
-fu_synaptics_rmi_ps2_device_close (FuUdevDevice *device, GError **error)
+fu_synaptics_rmi_ps2_device_close (FuDevice *device, GError **error)
 {
 	FuSynapticsRmiPs2Device *self = FU_SYNAPTICS_RMI_PS2_DEVICE (device);
-	fu_udev_device_set_fd (device, -1);
+	fu_udev_device_set_fd (FU_UDEV_DEVICE (device), -1);
 	g_clear_object (&self->io_channel);
-	return TRUE;
-}
+
+	/* FuUdevDevice->close */
+	return FU_DEVICE_CLASS (fu_synaptics_rmi_ps2_device_parent_class)->close (device, error);}
 
 static gboolean
 fu_synaptics_rmi_ps2_device_detach (FuDevice *device, GError **error)
@@ -926,14 +933,13 @@ static void
 fu_synaptics_rmi_ps2_device_class_init (FuSynapticsRmiPs2DeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev = FU_UDEV_DEVICE_CLASS (klass);
 	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_CLASS (klass);
 	klass_device->attach = fu_synaptics_rmi_ps2_device_attach;
 	klass_device->detach = fu_synaptics_rmi_ps2_device_detach;
 	klass_device->setup = fu_synaptics_rmi_ps2_device_setup;
-	klass_udev->probe = fu_synaptics_rmi_ps2_device_probe;
-	klass_udev->open = fu_synaptics_rmi_ps2_device_open;
-	klass_udev->close = fu_synaptics_rmi_ps2_device_close;
+	klass_device->probe = fu_synaptics_rmi_ps2_device_probe;
+	klass_device->open = fu_synaptics_rmi_ps2_device_open;
+	klass_device->close = fu_synaptics_rmi_ps2_device_close;
 	klass_rmi->read = fu_synaptics_rmi_ps2_device_read;
 	klass_rmi->write = fu_synaptics_rmi_ps2_device_write;
 	klass_rmi->set_page = fu_synaptics_rmi_ps2_device_set_page;

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -108,10 +108,14 @@ fu_system76_launch_device_detach (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_system76_launch_device_open (FuUsbDevice *device, GError **error)
+fu_system76_launch_device_open (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	const guint8 iface_idx = 0x01;
+
+	/* FuUsbDevice->open */
+	if (!FU_DEVICE_CLASS (fu_system76_launch_device_parent_class)->open (device, error))
+		return FALSE;
 
 	if (!g_usb_device_claim_interface (usb_device, iface_idx,
 					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
@@ -124,9 +128,9 @@ fu_system76_launch_device_open (FuUsbDevice *device, GError **error)
 }
 
 static gboolean
-fu_system76_launch_device_close (FuUsbDevice *device, GError **error)
+fu_system76_launch_device_close (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	const guint8 iface_idx = 0x01;
 
 	if (!g_usb_device_release_interface (usb_device, iface_idx,
@@ -136,7 +140,8 @@ fu_system76_launch_device_close (FuUsbDevice *device, GError **error)
 		return FALSE;
 	}
 
-	return TRUE;
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_system76_launch_device_parent_class)->close (device, error);
 }
 
 static void
@@ -154,9 +159,8 @@ static void
 fu_system76_launch_device_class_init (FuSystem76LaunchDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	klass_device->setup = fu_system76_launch_device_setup;
 	klass_device->detach = fu_system76_launch_device_detach;
-	klass_usb_device->open = fu_system76_launch_device_open;
-	klass_usb_device->close = fu_system76_launch_device_close;
+	klass_device->open = fu_system76_launch_device_open;
+	klass_device->close = fu_system76_launch_device_close;
 }

--- a/plugins/tpm/fu-tpm-device.c
+++ b/plugins/tpm/fu-tpm-device.c
@@ -30,9 +30,12 @@ fu_tpm_device_get_family (FuTpmDevice *self)
 }
 
 static gboolean
-fu_tpm_device_probe (FuUdevDevice *device, GError **error)
+fu_tpm_device_probe (FuDevice *device, GError **error)
 {
-	return fu_udev_device_set_physical_id (device, "tpm", error);
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_tpm_device_parent_class)->probe (device, error))
+		return FALSE;
+	return fu_udev_device_set_physical_id (FU_UDEV_DEVICE (device), "tpm", error);
 }
 
 static gboolean
@@ -262,8 +265,7 @@ fu_tpm_device_class_init (FuTpmDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUdevDeviceClass *klass_udev_device = FU_UDEV_DEVICE_CLASS (klass);
 	object_class->finalize = fu_tpm_device_finalize;
 	klass_device->setup = fu_tpm_device_setup;
-	klass_udev_device->probe = fu_tpm_device_probe;
+	klass_device->probe = fu_tpm_device_probe;
 }

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -764,9 +764,9 @@ fu_wac_device_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_wac_device_close (FuUsbDevice *device, GError **error)
+fu_wac_device_close (FuDevice *device, GError **error)
 {
-	GUsbDevice *usb_device = fu_usb_device_get_dev (device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 
 	/* reattach wacom.ko */
 	if (!g_usb_device_release_interface (usb_device, 0x00, /* HID */
@@ -783,8 +783,8 @@ fu_wac_device_close (FuUsbDevice *device, GError **error)
 	 * this should let the kernel unstick itself. */
 	g_usleep (20 * 1000);
 
-	/* success */
-	return TRUE;
+	/* FuUsbDevice->close */
+	return FU_DEVICE_CLASS (fu_wac_device_parent_class)->close (device, error);
 }
 
 static gboolean
@@ -826,12 +826,11 @@ fu_wac_device_class_init (FuWacDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
-	FuUsbDeviceClass *klass_usb_device = FU_USB_DEVICE_CLASS (klass);
 	object_class->finalize = fu_wac_device_finalize;
 	klass_device->prepare_firmware = fu_wac_device_prepare_firmware;
 	klass_device->write_firmware = fu_wac_device_write_firmware;
 	klass_device->to_string = fu_wac_device_to_string;
 	klass_device->setup = fu_wac_device_setup;
 	klass_device->cleanup = fu_wac_device_cleanup;
-	klass_usb_device->close = fu_wac_device_close;
+	klass_device->close = fu_wac_device_close;
 }


### PR DESCRIPTION
This allows a device subclass to call the parent method after doing an initial
action, or even deliberately not call the *generic* parent method at all.

It also simplifies the plugins; you no longer have to remember what the plugin
is deriving from and accidentally clobber the wrong superclass method.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
