### PR TITLE
trivial: don't hardcode expected plugins list for CI

### DIFF
--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -80,7 +80,7 @@ mkdir -p dist
 cp $HOME/rpmbuild/RPMS/*/*.rpm dist
 
 if [ "$CI" = "true" ]; then
-	sed "s,^DisabledPlugins=test;invalid,DisabledPlugins=," -i /etc/fwupd/daemon.conf
+	sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 
 	# set up enough PolicyKit and D-Bus to run the daemon
 	mkdir -p /run/dbus

--- a/contrib/debian/fwupd-tests.postinst
+++ b/contrib/debian/fwupd-tests.postinst
@@ -7,7 +7,7 @@ set -e
 if [ "$1" = configure ] && [ -z "$2" ]; then
 	if [ -f /etc/fwupd/daemon.conf ]; then
 		if [ "$CI" = "true" ]; then
-			sed "s,^DisabledPlugins=test;invalid,DisabledPlugins=," -i /etc/fwupd/daemon.conf
+			sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 		else
 			echo "To enable test suite, modify /etc/fwupd/daemon.conf"
 		fi


### PR DESCRIPTION
Let these get turned on no matter what we change in daemon.conf

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
