### PR TITLE
trivial: ci: add a workaround for arch container generation issue

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      # TODO(#122): Remove step when https://github.com/actions/virtual-environments/issues/2658 fixed
+      - name: update runc # https://github.com/actions/virtual-environments/issues/2698#issuecomment-779262068
+        if: startsWith(matrix.os, 'arch')
+        run: |
+          sudo apt-get install --assume-yes libseccomp-dev
+          git clone https://github.com/opencontainers/runc
+          cd runc && git checkout v1.0.0-rc93 && make -j`nproc` && sudo make install
+          cd .. && rm --recursive runc
       - name: "Generate Dockerfile"
         env:
           OS: ${{ matrix.os }}


### PR DESCRIPTION
This should be dropped at some point hopefully when the new
docker release has landed.
See: https://github.com/actions/virtual-environments/issues/2658
Fixes: #2894

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
