### PR TITLE
synaptics-mst: Do not allow updating a device with no customer ID

### DIFF
--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -71,7 +71,6 @@ fu_plugin_synaptics_mst_device_rescan (FuPlugin *plugin, FuDevice *device)
 		if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_REGISTERED))
 			fu_plugin_device_remove (plugin, device);
 	} else {
-		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_plugin_device_add (plugin, device);
 	}
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1177,7 +1177,13 @@ fu_synaptics_mst_device_rescan (FuDevice *device, GError **error)
 	guid3 = g_strdup_printf ("MST-%s", name_family);
 	fu_device_add_instance_id (FU_DEVICE (self), guid3);
 
-	/* success */
+	/* this is not a valid customer ID */
+	if ((self->board_id >> 8) == 0x0) {
+		fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
+		fu_device_set_update_error (device, "cannot update as CustomerID is unset");
+	} else {
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	}
 	return TRUE;
 }
 


### PR DESCRIPTION
This is typically when the OEM is using the reference hardware design.

Prevent updates, as there might be a new bug introduced in the reference
firmware that only manifests on one OEM's product. It's up to the OEM to do the
testing and validation.

We need something to tie it back to a physical device model if it's using a
reference firmware and we want to update it.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
