### PR TITLE
Drop unused heap pages after startup has completed

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -14,6 +14,7 @@
 #include <glib/gi18n.h>
 #include <glib-unix.h>
 #include <locale.h>
+#include <malloc.h>
 #ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
 #endif
@@ -2035,6 +2036,9 @@ main (int argc, char *argv[])
 		g_idle_add (fu_main_timed_exit_cb, priv->loop);
 	else if (timed_exit)
 		g_timeout_add_seconds (5, fu_main_timed_exit_cb, priv->loop);
+
+	/* drop heap except one page */
+	malloc_trim (4096);
 
 	/* wait */
 	g_message ("Daemon ready for requests (locale %s)", g_getenv ("LANG"));


### PR DESCRIPTION
Although glibc calls this when memory gets low automatically, we can invoke it
manually when we've loaded all plugins and coldplugged all devices.

This has no effect when using proper heap benchmarks like massif, but random
Reddit users just looking at the RSS column in an 'easy-to-use memory profiler'
will see a much lower numbers.

Where this feature might actually be useful is after a libxmlb metadata rebuild
where we dirtied a lot of heap just parsing XML.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
