### PR TITLE
Fix GVariant declarations in fu_bluez_device_write

### DIFF
--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -381,9 +381,9 @@ fu_bluez_device_write (FuBluezDevice *self,
 	g_autoptr(GDBusProxy) proxy = NULL;
 	g_autoptr(GVariantBuilder) opt_builder = NULL;
 	g_autoptr(GVariantBuilder) val_builder = NULL;
-	g_autoptr(GVariant) opt_variant = NULL;
 	g_autoptr(GVariant) ret = NULL;
-	g_autoptr(GVariant) val_variant = NULL;
+	GVariant *opt_variant = NULL;
+	GVariant *val_variant = NULL;
 
 	path = g_hash_table_lookup (priv->uuid_paths, uuid);
 	if (path == NULL) {


### PR DESCRIPTION
References to opt_variant and val_variant are sunk in a subsequent
variant creation and consumed by g_dbus_proxy_call_sync. They don't need
to be freed in this context.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
