### PR TITLE
trivial: Only allow verify-update for plugins that support _CAN_VERIFY

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2212,6 +2212,14 @@ fu_plugin_runner_verify (FuPlugin *self,
 	/* optional */
 	g_module_symbol (priv->module, "fu_plugin_verify", (gpointer *) &func);
 	if (func == NULL) {
+		if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY)) {
+			g_set_error (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "device %s does not support verification",
+				     fu_device_get_id (device));
+			return FALSE;
+		}
 		return fu_plugin_device_read_firmware (self, device, error);
 	}
 


### PR DESCRIPTION
If the user explicitly specifies the device-id then we do not do the front-end
filtering. If the device detaches without being able to attach then the hardware
could be left in the bootloader state.

See https://github.com/fwupd/fwupd/issues/2926#issuecomment-784234180

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
