### PR TITLE
Add a backend ID to the device

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -284,6 +284,9 @@ void		 fu_device_set_physical_id		(FuDevice	*self,
 const gchar	*fu_device_get_logical_id		(FuDevice	*self);
 void		 fu_device_set_logical_id		(FuDevice	*self,
 							 const gchar	*logical_id);
+const gchar	*fu_device_get_backend_id		(FuDevice	*self);
+void		 fu_device_set_backend_id		(FuDevice	*self,
+							 const gchar	*backend_id);
 const gchar	*fu_device_get_proxy_guid		(FuDevice	*self);
 void		 fu_device_set_proxy_guid		(FuDevice	*self,
 							 const gchar	*proxy_guid);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -564,6 +564,9 @@ fu_udev_device_set_dev (FuUdevDevice *self, GUdevDevice *udev_device)
 	fu_udev_device_set_driver (self, g_udev_device_get_driver (priv->udev_device));
 	fu_udev_device_set_device_file (self, g_udev_device_get_device_file (priv->udev_device));
 
+	/* so we can display something sensible for unclaimed devices */
+	fu_device_set_backend_id (FU_DEVICE (self), g_udev_device_get_sysfs_path (priv->udev_device));
+
 	/* fall back to the first thing handled by misc drivers */
 	if (priv->device_file == NULL) {
 		/* perhaps we should unconditionally fall back? or perhaps

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -770,3 +770,10 @@ LIBFWUPDPLUGIN_1.5.7 {
     fu_firmware_set_version_raw;
   local: *;
 } LIBFWUPDPLUGIN_1.5.6;
+
+LIBFWUPDPLUGIN_1.5.8 {
+  global:
+    fu_device_get_backend_id;
+    fu_device_set_backend_id;
+  local: *;
+} LIBFWUPDPLUGIN_1.5.7;

--- a/src/fu-backend.h
+++ b/src/fu-backend.h
@@ -29,6 +29,8 @@ const gchar	*fu_backend_get_name			(FuBackend	*self);
 gboolean	 fu_backend_get_enabled			(FuBackend	*self);
 void		 fu_backend_set_enabled			(FuBackend	*self,
 							 gboolean	 enabled);
+FuDevice	*fu_backend_lookup_by_id		(FuBackend	*self,
+							 const gchar	*device_id);
 gboolean	 fu_backend_setup			(FuBackend	*self,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5991,16 +5991,16 @@ fu_engine_backend_device_removed_cb (FuBackend *backend, FuDevice *device, FuEng
 	if (g_getenv ("FWUPD_PROBE_VERBOSE") != NULL) {
 		g_debug ("%s removed %s",
 			 fu_backend_get_name (backend),
-			 fu_device_get_physical_id (device));
+			 fu_device_get_backend_id (device));
 	}
 
 	/* go through each device and remove any that match */
 	devices = fu_device_list_get_all (self->device_list);
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device_tmp = g_ptr_array_index (devices, i);
-		if (g_strcmp0 (fu_device_get_physical_id (device_tmp),
-			       fu_device_get_physical_id (device)) == 0) {
-			g_debug ("auto-removing GUsbDevice");
+		if (g_strcmp0 (fu_device_get_backend_id (device_tmp),
+			       fu_device_get_backend_id (device)) == 0) {
+			g_debug ("auto-removing backend device");
 			fu_device_list_remove (self->device_list, device_tmp);
 		}
 	}
@@ -6022,7 +6022,7 @@ fu_engine_backend_device_added_cb (FuBackend *backend, FuDevice *device, FuEngin
 	fu_device_set_quirks (device, self->quirks);
 	if (!fu_device_probe (device, &error_local)) {
 		g_warning ("failed to probe device %s: %s",
-			   fu_device_get_physical_id (device),
+			   fu_device_get_backend_id (device),
 			   error_local->message);
 		return;
 	}
@@ -6053,7 +6053,7 @@ fu_engine_backend_device_added_cb (FuBackend *backend, FuDevice *device, FuEngin
 				continue;
 			}
 			g_warning ("failed to add device %s: %s",
-				   fu_device_get_physical_id (device),
+				   fu_device_get_backend_id (device),
 				   error->message);
 			continue;
 		}


### PR DESCRIPTION
This is typically a Linux sysfs path or USB platform ID and is used in a
different way to the physical ID. The physical ID is only set for some devices
after setup() and depends on the subsystem list, and this would not be defined
for devices that do not match a plugin.

This also fixes an regression where the FuDeviceList fails to match the new
FuUdevDevice device in fu_device_list_get_by_guids_removed() and instead
silently gets 'fixed up' only if FWUPD_DEVICE_FLAG_NO_GUID_MATCHING is not set.

This also allows us to move the various backends device caches to FuBackend as
we now have a suitable ID that is for just the backend to use.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
