### PR TITLE
Support for GATT characteristic signals/notifications

### DIFF
--- a/libfwupdplugin/fu-bluez-device.h
+++ b/libfwupdplugin/fu-bluez-device.h
@@ -27,3 +27,9 @@ gboolean		 fu_bluez_device_write		(FuBluezDevice	*self,
 							 const gchar	*uuid,
 							 GByteArray	*buf,
 							 GError		**error);
+gboolean		 fu_bluez_device_notify_start	(FuBluezDevice	*self,
+							 const gchar	*uuid,
+							 GError		**error);
+gboolean		 fu_bluez_device_notify_stop	(FuBluezDevice	*self,
+							 const gchar	*uuid,
+							 GError		**error);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -773,6 +773,8 @@ LIBFWUPDPLUGIN_1.5.7 {
 
 LIBFWUPDPLUGIN_1.5.8 {
   global:
+    fu_bluez_device_notify_start;
+    fu_bluez_device_notify_stop;
     fu_device_get_backend_id;
     fu_device_set_backend_id;
   local: *;


### PR DESCRIPTION
This adds three methods to bluez devices:

  - fu_bluez_device_connect_signal: to register a callback for a signal
    on a BlueZ object.
  - fu_bluez_device_start_notify: to enable notifications for property
    changes in a specific object.
  - fu_bluez_device_stop_notify: to disable notifications for property
    changes in a specific object.

NOTE that currently this is implemented for GATT characteristics only,
but can be extended to other types of objects.

Listening for property changes in a bluez characteristic requires a
long-lived connection or proxy, so this also refactors bluez device
UUIDs into a simple object that keeps the path, the proxy and the signal
id in case a callback is registered for this UUID.

An additional advantage of this is that fwupd no longer creates a
throwaway proxy object for every read and write UUID operation.

API
===

Subclasses of FuBluezDevice don't need to handle the FuBluezUuid
directly and can reference a UUID using the UUID string only:

    #define READ_WRITE_CHAR "0000ff01-0000-1000-8000-00805f9b34fb"

    fu_bluez_device_connect_signal (bluez_dev,
                                    READ_WRITE_CHAR,
                                    "g-properties-changed",
                                    fu_pxi_ble_device_readwrite_notify_cb,
                                    error);

    fu_bluez_device_start_notify (bluez_dev,
                                  READ_WRITE_CHAR,
                                  error);

Limitations
===========

  - Bluez device UUIDs are still for characteristics only.
  - Only one signal/callback per UUID.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
