### PR TITLE
system76-launch: Prompt for unlock keypress if reset command is blocked

### DIFF
--- a/plugins/system76-launch/meson.build
+++ b/plugins/system76-launch/meson.build
@@ -19,6 +19,7 @@ shared_module('fu_plugin_system76_launch',
   install : true,
   install_dir: plugin_dir,
   link_with : [
+    fwupd,
     fwupdplugin,
   ],
   c_args : cargs,


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

This addresses https://github.com/fwupd/fwupd/discussions/2937. Some cleanup was done so that the response from the `RESET` command can be captured. Now both the `VERSION` and `RESET` commands go through `fu_system76_launch_device_command`.

An error is returned to the user indicating how to unlock the device if the `RESET` command is blocked. To support the use of `FWUPD_ERROR_NEEDS_USER_ACTION`, `fwupd` had to be linked.