### PR TITLE
Support more than one protocol for a given device

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -7,6 +7,7 @@ Planned API/ABI changes for next release
  * Remove the deprecated flags like `FWUPD_DEVICE_FLAG_MD_SET_ICON`
  * Remove `fwupd_release_get_uri()` and `fwupd_release_set_uri()`
  * Rename `fwupd_client_install_release2_async()` to `fwupd_client_install_release_async()`
+ * Remove fwupd_device_set_protocol() and fwupd_device_get_protocol()
 
 Migration from Version 0.9.x
 ============================

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -107,9 +107,16 @@ void		 fwupd_device_add_checksum		(FwupdDevice	*device,
 const gchar	*fwupd_device_get_plugin		(FwupdDevice	*device);
 void		 fwupd_device_set_plugin		(FwupdDevice	*device,
 							 const gchar	*plugin);
+G_DEPRECATED_FOR(fwupd_device_get_protocols)
 const gchar	*fwupd_device_get_protocol		(FwupdDevice	*device);
+G_DEPRECATED_FOR(fwupd_device_add_protocol)
 void		 fwupd_device_set_protocol		(FwupdDevice	*device,
 							 const gchar	*protocol);
+void		 fwupd_device_add_protocol		(FwupdDevice	*device,
+							 const gchar	*protocol);
+gboolean	 fwupd_device_has_protocol		(FwupdDevice	*device,
+							 const gchar	*protocol);
+GPtrArray	*fwupd_device_get_protocols		(FwupdDevice	*device);
 const gchar	*fwupd_device_get_vendor		(FwupdDevice	*device);
 void		 fwupd_device_set_vendor		(FwupdDevice	*device,
 							 const gchar	*vendor);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -648,3 +648,11 @@ LIBFWUPD_1.5.6 {
     fwupd_release_get_locations;
   local: *;
 } LIBFWUPD_1.5.5;
+
+LIBFWUPD_1.5.8 {
+  global:
+    fwupd_device_add_protocol;
+    fwupd_device_get_protocols;
+    fwupd_device_has_protocol;
+  local: *;
+} LIBFWUPD_1.5.6;

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -9,3 +9,4 @@ Planned API/ABI changes for next release
  * Remove FuHidDevice->open() and FuHidDevice->close()
  * Remove FuUsbDevice->probe(), FuUsbDevice->open() and FuUsbDevice->close()
  * Remove FuUdevDevice->to_string(), FuUdevDevice->probe(), FuUdevDevice->open() and FuUdevDevice->close()
+ * Remove fu_device_get_protocol() and fu_device_set_protocol()

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1156,7 +1156,9 @@ fu_device_set_quirk_kv (FuDevice *self,
 		return TRUE;
 	}
 	if (g_strcmp0 (key, FU_QUIRKS_PROTOCOL) == 0) {
-		fu_device_set_protocol (self, value);
+		g_auto(GStrv) sections = g_strsplit (value, ",", -1);
+		for (guint i = 0; sections[i] != NULL; i++)
+			fu_device_add_protocol (self, sections[i]);
 		return TRUE;
 	}
 	if (g_strcmp0 (key, FU_QUIRKS_VERSION) == 0) {
@@ -2164,7 +2166,10 @@ const gchar *
 fu_device_get_protocol (FuDevice *self)
 {
 	g_return_val_if_fail (FU_IS_DEVICE (self), NULL);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return fwupd_device_get_protocol (FWUPD_DEVICE (self));
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -2180,7 +2185,7 @@ void
 fu_device_set_protocol (FuDevice *self, const gchar *protocol)
 {
 	g_return_if_fail (FU_IS_DEVICE (self));
-	fwupd_device_set_protocol (FWUPD_DEVICE (self), protocol);
+	fwupd_device_add_protocol (FWUPD_DEVICE (self), protocol);
 }
 
 /**

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -143,6 +143,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_has_flag(d,v)			fwupd_device_has_flag(FWUPD_DEVICE(d),v)
 #define fu_device_has_instance_id(d,v)		fwupd_device_has_instance_id(FWUPD_DEVICE(d),v)
 #define fu_device_has_vendor_id(d,v)		fwupd_device_has_vendor_id(FWUPD_DEVICE(d),v)
+#define fu_device_has_protocol(d,v)		fwupd_device_has_protocol(FWUPD_DEVICE(d),v)
 #define fu_device_add_checksum(d,v)		fwupd_device_add_checksum(FWUPD_DEVICE(d),v)
 #define fu_device_add_release(d,v)		fwupd_device_add_release(FWUPD_DEVICE(d),v)
 #define fu_device_add_icon(d,v)			fwupd_device_add_icon(FWUPD_DEVICE(d),v)
@@ -160,6 +161,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_update_state(d,v)		fwupd_device_set_update_state(FWUPD_DEVICE(d),v)
 #define fu_device_set_vendor(d,v)		fwupd_device_set_vendor(FWUPD_DEVICE(d),v)
 #define fu_device_add_vendor_id(d,v)		fwupd_device_add_vendor_id(FWUPD_DEVICE(d),v)
+#define fu_device_add_protocol(d,v)		fwupd_device_add_protocol(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_raw(d,v)		fwupd_device_set_version_raw(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_lowest_raw(d,v)	fwupd_device_set_version_lowest_raw(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_bootloader_raw(d,v)	fwupd_device_set_version_bootloader_raw(FWUPD_DEVICE(d),v)
@@ -190,6 +192,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_get_version_lowest_raw(d)	fwupd_device_get_version_lowest_raw(FWUPD_DEVICE(d))
 #define fu_device_get_version_bootloader_raw(d)	fwupd_device_get_version_bootloader_raw(FWUPD_DEVICE(d))
 #define fu_device_get_vendor_ids(d)		fwupd_device_get_vendor_ids(FWUPD_DEVICE(d))
+#define fu_device_get_protocols(d)		fwupd_device_get_protocols(FWUPD_DEVICE(d))
 #define fu_device_get_flashes_left(d)		fwupd_device_get_flashes_left(FWUPD_DEVICE(d))
 #define fu_device_get_install_duration(d)	fwupd_device_get_install_duration(FWUPD_DEVICE(d))
 
@@ -292,7 +295,9 @@ void		 fu_device_set_backend_id		(FuDevice	*self,
 const gchar	*fu_device_get_proxy_guid		(FuDevice	*self);
 void		 fu_device_set_proxy_guid		(FuDevice	*self,
 							 const gchar	*proxy_guid);
+G_DEPRECATED_FOR(fu_device_get_protocols)
 const gchar	*fu_device_get_protocol			(FuDevice	*self);
+G_DEPRECATED_FOR(fu_device_add_protocol)
 void		 fu_device_set_protocol			(FuDevice	*self,
 							 const gchar	*protocol);
 guint		 fu_device_get_priority			(FuDevice	*self);

--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -560,7 +560,7 @@ fu_altos_device_init (FuAltosDevice *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_vendor (FU_DEVICE (self), "altusmetrum.org");
 	fu_device_set_summary (FU_DEVICE (self), "A USB hardware random number generator");
-	fu_device_set_protocol (FU_DEVICE (self), "org.altusmetrum.altos");
+	fu_device_add_protocol (FU_DEVICE (self), "org.altusmetrum.altos");
 
 	/* requires manual step */
 	if (!fu_device_has_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER))

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -826,7 +826,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
-	fu_device_set_protocol (FU_DEVICE (self), "org.t13.ata");
+	fu_device_add_protocol (FU_DEVICE (self), "org.t13.ata");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 }

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -612,7 +612,7 @@ fu_bcm57xx_device_close (FuDevice *device, GError **error)
 static void
 fu_bcm57xx_device_init (FuBcm57xxDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.broadcom.bcm57xx");
+	fu_device_add_protocol (FU_DEVICE (self), "com.broadcom.bcm57xx");
 	fu_device_add_icon (FU_DEVICE (self), "network-wired");
 
 	/* other values are set from a quirk */

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -722,7 +722,7 @@ fu_bcm57xx_recovery_device_init (FuBcm57xxRecoveryDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IGNORE_VALIDATION);
-	fu_device_set_protocol (FU_DEVICE (self), "com.broadcom.bcm57xx");
+	fu_device_add_protocol (FU_DEVICE (self), "com.broadcom.bcm57xx");
 	fu_device_add_icon (FU_DEVICE (self), "network-wired");
 	fu_device_set_logical_id (FU_DEVICE (self), "recovery");
 

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -647,7 +647,7 @@ fu_ccgx_dmc_device_init (FuCcgxDmcDevice *self)
 {
 	self->ep_intr_in = DMC_INTERRUPT_PIPE_ID;
 	self->ep_bulk_out = DMC_BULK_PIPE_ID;
-	fu_device_set_protocol (FU_DEVICE (self), "com.cypress.ccgx.dmc");
+	fu_device_add_protocol (FU_DEVICE (self), "com.cypress.ccgx.dmc");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);

--- a/plugins/ccgx/fu-ccgx-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-hid-device.c
@@ -75,7 +75,7 @@ fu_ccgx_hid_device_setup (FuDevice *device, GError **error)
 static void
 fu_ccgx_hid_device_init (FuCcgxHidDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.cypress.ccgx");
+	fu_device_add_protocol (FU_DEVICE (self), "com.cypress.ccgx");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_WILL_DISAPPEAR);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1585,7 +1585,7 @@ fu_ccgx_hpi_device_init (FuCcgxHpiDevice *self)
 	self->ep_bulk_out = PD_I2C_USB_EP_BULK_OUT;
 	self->ep_bulk_in = PD_I2C_USB_EP_BULK_IN;
 	self->ep_intr_in = PD_I2C_USB_EP_INTR_IN;
-	fu_device_set_protocol (FU_DEVICE (self), "com.cypress.ccgx");
+	fu_device_add_protocol (FU_DEVICE (self), "com.cypress.ccgx");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -480,7 +480,7 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 {
 	/* this is the application code */
 	self->start_addr = CH_EEPROM_ADDR_RUNCODE;
-	fu_device_set_protocol (FU_DEVICE (self), "com.hughski.colorhug");
+	fu_device_add_protocol (FU_DEVICE (self), "com.hughski.colorhug");
 	fu_device_set_remove_delay (FU_DEVICE (self),
 				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -950,7 +950,7 @@ fu_cros_ec_usb_device_detach (FuDevice *device, GError **error)
 static void
 fu_cros_ec_usb_device_init (FuCrosEcUsbDevice *device)
 {
-	fu_device_set_protocol (FU_DEVICE (device), "com.google.usb.crosec");
+	fu_device_add_protocol (FU_DEVICE (device), "com.google.usb.crosec");
 	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag (FU_DEVICE (device), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_TRIPLET);

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -40,7 +40,7 @@ fu_dell_dock_hub_probe (FuDevice *device, GError **error)
 
 	fu_device_set_logical_id (device, "hub");
 	fu_device_add_instance_id (device, devid);
-	fu_device_set_protocol (device, "com.dell.dock");
+	fu_device_add_protocol (device, "com.dell.dock");
 
 	return TRUE;
 }

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -956,7 +956,7 @@ fu_dell_dock_ec_init (FuDellDockEc *self)
 {
 	self->data = g_new0 (FuDellDockDockDataStructure, 1);
 	self->raw_versions = g_new0 (FuDellDockDockPackageFWVersion, 1);
-	fu_device_set_protocol (FU_DEVICE (self), "com.dell.dock");
+	fu_device_add_protocol (FU_DEVICE (self), "com.dell.dock");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -965,7 +965,7 @@ fu_dell_dock_mst_close (FuDevice *device, GError **error)
 static void
 fu_dell_dock_mst_init (FuDellDockMst *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.mst");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.mst");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -276,7 +276,7 @@ fu_dell_dock_tbt_finalize (GObject *object)
 static void
 fu_dell_dock_tbt_init (FuDellDockTbt *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.intel.thunderbolt");
+	fu_device_add_protocol (FU_DEVICE (self), "com.intel.thunderbolt");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -144,7 +144,7 @@ fu_dell_dock_status_finalize (GObject *object)
 static void
 fu_dell_dock_status_init (FuDellDockStatus *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.dell.dock");
+	fu_device_add_protocol (FU_DEVICE (self), "com.dell.dock");
 }
 
 static void

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -433,7 +433,7 @@ fu_dfu_csr_device_setup (FuDevice *device, GError **error)
 static void
 fu_dfu_csr_device_init (FuDfuCsrDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.qualcomm.dfu");
+	fu_device_add_protocol (FU_DEVICE (self), "com.qualcomm.dfu");
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 }
 

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -350,9 +350,9 @@ fu_dfu_device_add_targets (FuDfuDevice *self, GError **error)
 
 		/* set expected protocol */
 		if (priv->version == DFU_VERSION_DFUSE) {
-			fu_device_set_protocol (FU_DEVICE (self), "com.st.dfuse");
+			fu_device_add_protocol (FU_DEVICE (self), "com.st.dfuse");
 		} else {
-			fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
+			fu_device_add_protocol (FU_DEVICE (self), "org.usb.dfu");
 		}
 
 		/* fix up the transfer size */

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -596,7 +596,7 @@ fu_ebitdo_device_prepare_firmware (FuDevice *device,
 static void
 fu_ebitdo_device_init (FuEbitdoDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.8bitdo");
+	fu_device_add_protocol (FU_DEVICE (self), "com.8bitdo");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 }

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -550,7 +550,7 @@ fu_elantp_hid_device_init (FuElantpHidDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_summary (FU_DEVICE (self), "Elan Touchpad");
 	fu_device_add_icon (FU_DEVICE (self), "input-touchpad");
-	fu_device_set_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
+	fu_device_add_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_priority (FU_DEVICE (self), 1); /* better than i2c */
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -624,7 +624,7 @@ fu_elantp_i2c_device_init (FuElantpI2cDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_summary (FU_DEVICE (self), "Elan Touchpad (I²C Recovery)");
 	fu_device_add_icon (FU_DEVICE (self), "input-touchpad");
-	fu_device_set_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
+	fu_device_add_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_HEX);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -495,7 +495,7 @@ fu_emmc_device_write_firmware (FuDevice *device,
 static void
 fu_emmc_device_init (FuEmmcDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "org.jedec.mmc");
+	fu_device_add_protocol (FU_DEVICE (self), "org.jedec.mmc");
 	fu_device_add_icon (FU_DEVICE (self), "media-memory");
 }
 

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -319,7 +319,7 @@ static void
 fu_ep963x_device_init (FuEp963xDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_set_protocol (FU_DEVICE (self), "tw.com.exploretech.ep963x");
+	fu_device_add_protocol (FU_DEVICE (self), "tw.com.exploretech.ep963x");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_NUMBER);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_firmware_size (FU_DEVICE (self), FU_EP963_FIRMWARE_SIZE);

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -708,7 +708,7 @@ fu_fastboot_device_init (FuFastbootDevice *self)
 {
 	/* this is a safe default, even using USBv1 */
 	self->blocksz = 512;
-	fu_device_set_protocol (FU_DEVICE (self), "com.google.fastboot");
+	fu_device_add_protocol (FU_DEVICE (self), "com.google.fastboot");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE (FuFlashromDevice, fu_flashrom_device, FU_TYPE_DEVICE)
 static void
 fu_flashrom_device_init (FuFlashromDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "org.flashrom");
+	fu_device_add_protocol (FU_DEVICE (self), "org.flashrom");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -388,7 +388,7 @@ fu_fresco_pd_device_init (FuFrescoPdDevice *self)
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_set_protocol (FU_DEVICE (self), "com.frescologic.pd");
+	fu_device_add_protocol (FU_DEVICE (self), "com.frescologic.pd");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_install_duration (FU_DEVICE (self), 15);
 	fu_device_set_remove_delay (FU_DEVICE (self), 20000);

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -413,7 +413,7 @@ fu_goodixmoc_device_init (FuGoodixMocDevice *self)
 	fu_device_add_flag (FU_DEVICE(self), FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION);
 	fu_device_set_version_format (FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_remove_delay (FU_DEVICE(self), 5000);
-	fu_device_set_protocol (FU_DEVICE (self), "com.goodix.goodixmoc");
+	fu_device_add_protocol (FU_DEVICE (self), "com.goodix.goodixmoc");
 	fu_device_set_name (FU_DEVICE(self), "Fingerprint Sensor");
 	fu_device_set_summary (FU_DEVICE(self), "Match-On-Chip Fingerprint Sensor");
 	fu_device_set_vendor (FU_DEVICE(self), "Goodix");

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -265,7 +265,7 @@ static void
 fu_hailuck_bl_device_init (FuHailuckBlDevice *self)
 {
 	fu_device_set_firmware_size (FU_DEVICE (self), 0x4000);
-	fu_device_set_protocol (FU_DEVICE (self), "com.hailuck.kbd");
+	fu_device_add_protocol (FU_DEVICE (self), "com.hailuck.kbd");
 	fu_device_set_name (FU_DEVICE (self), "Keyboard [bootloader]");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/hailuck/fu-hailuck-kbd-device.c
+++ b/plugins/hailuck/fu-hailuck-kbd-device.c
@@ -67,7 +67,7 @@ static void
 fu_hailuck_kbd_device_init (FuHailuckKbdDevice *self)
 {
 	fu_device_set_firmware_size (FU_DEVICE (self), 0x4000);
-	fu_device_set_protocol (FU_DEVICE (self), "com.hailuck.kbd");
+	fu_device_add_protocol (FU_DEVICE (self), "com.hailuck.kbd");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -202,7 +202,7 @@ fu_hailuck_tp_device_init (FuHailuckTpDevice *self)
 {
 	fu_device_retry_set_delay (FU_DEVICE (self), 50); /* ms */
 	fu_device_set_firmware_size (FU_DEVICE (self), 0x6018);
-	fu_device_set_protocol (FU_DEVICE (self), "com.hailuck.tp");
+	fu_device_add_protocol (FU_DEVICE (self), "com.hailuck.tp");
 	fu_device_set_logical_id (FU_DEVICE (self), "TP");
 	fu_device_set_name (FU_DEVICE (self), "Touchpad");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/jabra/fu-jabra-device.c
+++ b/plugins/jabra/fu-jabra-device.c
@@ -150,7 +150,7 @@ fu_jabra_device_init (FuJabraDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_remove_delay (FU_DEVICE (self), 20000); /* 10+10s! */
-	fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
+	fu_device_add_protocol (FU_DEVICE (self), "org.usb.dfu");
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -251,9 +251,9 @@ fu_logitech_hidpp_bootloader_set_bl_version (FuLogitechHidPpBootloader *self, GE
 
 	if ((major == 0x01 && minor >= 0x04) ||
 	    (major == 0x03 && minor >= 0x02))
-		fu_device_set_protocol (FU_DEVICE (self), "com.logitech.unifyingsigned");
+		fu_device_add_protocol (FU_DEVICE (self), "com.logitech.unifyingsigned");
 	else
-		fu_device_set_protocol (FU_DEVICE (self), "com.logitech.unifying");
+		fu_device_add_protocol (FU_DEVICE (self), "com.logitech.unifying");
 	return TRUE;
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -585,6 +585,7 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 	if (idx != 0x00) {
 		self->is_updatable = TRUE;
 		fu_device_remove_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+		fu_device_add_protocol (FU_DEVICE (self), "com.logitech.unifying");
 	}
 	idx = fu_logitech_hidpp_peripheral_feature_get_idx (self, HIDPP_FEATURE_DFU_CONTROL_SIGNED);
 	if (idx != 0x00) {
@@ -605,7 +606,7 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 			self->is_updatable = TRUE;
 			fu_device_remove_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		}
-		fu_device_set_protocol (FU_DEVICE (device), "com.logitech.unifyingsigned");
+		fu_device_add_protocol (FU_DEVICE (device), "com.logitech.unifyingsigned");
 	}
 	idx = fu_logitech_hidpp_peripheral_feature_get_idx (self, HIDPP_FEATURE_DFU);
 	if (idx != 0x00) {
@@ -615,6 +616,10 @@ fu_logitech_hidpp_peripheral_setup (FuDevice *device, GError **error)
 			g_debug ("repairing device in bootloader mode");
 			fu_device_set_version (FU_DEVICE (device), "MPK00.00_B0000");
 		}
+		/* we do not actually know which protocol when in recovery mode,
+		 * so force the metadata to have the specific regex set up */
+		fu_device_add_protocol (FU_DEVICE (self), "com.logitech.unifying");
+		fu_device_add_protocol (FU_DEVICE (self), "com.logitech.unifyingsigned");
 	}
 
 	/* this device may have changed state */
@@ -1049,7 +1054,6 @@ fu_logitech_hidpp_peripheral_init (FuLogitechHidPpPeripheral *self)
 	self->feature_index = g_ptr_array_new_with_free_func (g_free);
 	fu_device_add_parent_guid (FU_DEVICE (self), "HIDRAW\\VEN_046D&DEV_C52B");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
-	fu_device_set_protocol (FU_DEVICE (self), "com.logitech.unifying");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 
 	/* there are a lot of unifying peripherals, but not all respond

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -234,11 +234,11 @@ fu_logitech_hidpp_runtime_setup_internal (FuDevice *device, GError **error)
 		if ((self->version_bl_major == 0x01 && config[8] >= 0x04) ||
 		    (self->version_bl_major == 0x03 && config[8] >= 0x02)) {
 			self->signed_firmware = TRUE;
-			fu_device_set_protocol (device, "com.logitech.unifyingsigned");
+			fu_device_add_protocol (device, "com.logitech.unifyingsigned");
 		}
 	}
 	if (!self->signed_firmware)
-		fu_device_set_protocol (device, "com.logitech.unifying");
+		fu_device_add_protocol (device, "com.logitech.unifying");
 
 	/* enable HID++ notifications */
 	if (!fu_logitech_hidpp_runtime_enable_notifications (self, error)) {

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -214,7 +214,7 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 				break;
 			}
 		}
-		fu_device_set_protocol (device, "com.google.fastboot");
+		fu_device_add_protocol (device, "com.google.fastboot");
 	}
 	if (self->update_methods & MM_MODEM_FIRMWARE_UPDATE_METHOD_QMI_PDC) {
 		for (guint i = 0; i < n_ports; i++) {
@@ -225,8 +225,8 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 			}
 		}
 		/* only set if fastboot wasn't already set */
-		if (fu_device_get_protocol (device) == NULL)
-			fu_device_set_protocol (device, "com.qualcomm.qmi_pdc");
+		if (fu_device_get_protocols (device)->len == 0)
+			fu_device_add_protocol (device, "com.qualcomm.qmi_pdc");
 	}
 	mm_modem_port_info_array_free (ports, n_ports);
 

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -137,7 +137,7 @@ fu_nitrokey_device_init (FuNitrokeyDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
-	fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
+	fu_device_add_protocol (FU_DEVICE (self), "org.usb.dfu");
 	fu_device_retry_set_delay (FU_DEVICE (self), 100);
 }
 

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -19,6 +19,7 @@ shared_module('fu_plugin_nitrokey',
   install : true,
   install_dir: plugin_dir,
   link_with : [
+    fwupd,
     fwupdplugin,
   ],
   c_args : cargs,

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -399,7 +399,7 @@ fu_nvme_device_init (FuNvmeDevice *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary (FU_DEVICE (self), "NVM Express Solid State Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
-	fu_device_set_protocol (FU_DEVICE (self), "org.nvmexpress");
+	fu_device_add_protocol (FU_DEVICE (self), "org.nvmexpress");
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
 				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);

--- a/plugins/pixart-rf/fu-pxi-device.c
+++ b/plugins/pixart-rf/fu-pxi-device.c
@@ -654,7 +654,7 @@ fu_pxi_device_init (FuPxiDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_vendor_id (FU_DEVICE (self), "USB:0x093A");
-	fu_device_set_protocol (FU_DEVICE (self), "com.pixart.rf");
+	fu_device_add_protocol (FU_DEVICE (self), "com.pixart.rf");
 }
 
 static void

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -147,7 +147,7 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 	id = g_strdup_printf ("Redfish-Inventory-%s",
 			      json_object_get_string_member (member, "Id"));
 	fu_device_set_id (dev, id);
-	fu_device_set_protocol (dev, "org.dmtf.redfish");
+	fu_device_add_protocol (dev, "org.dmtf.redfish");
 
 	fu_device_add_guid (dev, guid);
 	if (json_object_has_member (member, "Name"))

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -314,7 +314,7 @@ fu_rts54hid_device_write_firmware (FuDevice *device,
 static void
 fu_rts54hid_device_init (FuRts54HidDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54");
+	fu_device_add_protocol (FU_DEVICE (self), "com.realtek.rts54");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -500,7 +500,7 @@ fu_rts54hub_device_prepare_firmware (FuDevice *device,
 static void
 fu_rts54hub_device_init (FuRts54HubDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54");
+	fu_device_add_protocol (FU_DEVICE (self), "com.realtek.rts54");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
@@ -573,7 +573,7 @@ static void
 fu_rts54hub_rtd21xx_device_init (FuRts54hubRtd21xxDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
-	fu_device_set_protocol (FU_DEVICE (self), "com.realtek.rts54.i2c");
+	fu_device_add_protocol (FU_DEVICE (self), "com.realtek.rts54.i2c");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -500,7 +500,7 @@ fu_solokey_device_init (FuSolokeyDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_set_protocol (FU_DEVICE (self), "com.solokeys");
+	fu_device_add_protocol (FU_DEVICE (self), "com.solokeys");
 	fu_device_set_name (FU_DEVICE (self), "Solo Secure");
 	fu_device_set_summary (FU_DEVICE (self), "An open source FIDO2 security key");
 	fu_device_add_icon (FU_DEVICE (self), "applications-internet");

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -395,7 +395,7 @@ fu_superio_device_init (FuSuperioDevice *self)
 	fu_device_set_physical_id (FU_DEVICE (self), "/dev/port");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
-	fu_device_set_protocol (FU_DEVICE (self), "tw.com.ite.superio");
+	fu_device_add_protocol (FU_DEVICE (self), "tw.com.ite.superio");
 	fu_device_set_summary (FU_DEVICE (self), "Embedded Controller");
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -761,7 +761,7 @@ fu_synaptics_cxaudio_device_init (FuSynapticsCxaudioDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_install_duration (FU_DEVICE (self), 3); /* seconds */
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.cxaudio");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.cxaudio");
 	fu_device_retry_set_delay (FU_DEVICE (self), 100); /* ms */
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -69,7 +69,7 @@ fu_synaptics_mst_device_finalize (GObject *object)
 static void
 fu_synaptics_mst_device_init (FuSynapticsMstDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.mst");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.mst");
 	fu_device_set_vendor (FU_DEVICE (self), "Synaptics");
 	fu_device_add_vendor_id (FU_DEVICE (self), "DRM_DP_AUX_DEV:0x06CB");
 	fu_device_set_summary (FU_DEVICE (self), "Multi-Stream Transport Device");

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -216,7 +216,7 @@ fu_synaprom_config_write_firmware (FuDevice *device,
 static void
 fu_synaprom_config_init (FuSynapromConfig *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus.config");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.prometheus.config");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_logical_id (FU_DEVICE (self), "cfg");

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -447,7 +447,7 @@ fu_synaprom_device_init (FuSynapromDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.prometheus");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.prometheus");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_name (FU_DEVICE (self), "Prometheus");
 	fu_device_set_summary (FU_DEVICE (self), "Fingerprint reader");

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -812,7 +812,7 @@ static void
 fu_synaptics_rmi_device_init (FuSynapticsRmiDevice *self)
 {
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE (self);
-	fu_device_set_protocol (FU_DEVICE (self), "com.synaptics.rmi");
+	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.rmi");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	priv->current_page = 0xfe;

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -165,7 +165,7 @@ fu_system76_launch_device_init (FuSystem76LaunchDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
-	fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
+	fu_device_add_protocol (FU_DEVICE (self), "org.usb.dfu");
 	fu_device_retry_set_delay (FU_DEVICE (self), 100);
 }
 

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -38,7 +38,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_add_icon (device, "preferences-desktop-keyboard");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
-	fu_device_set_protocol (device, "com.acme.test");
+	fu_device_add_protocol (device, "com.acme.test");
 	fu_device_set_summary (device, "A fake webcam");
 	fu_device_set_vendor (device, "ACME Corp.");
 	fu_device_add_vendor_id (device, "USB:0x046D");
@@ -64,7 +64,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 
 		child1 = fu_device_new ();
 		fu_device_add_vendor_id (child1, "USB:FFFF");
-		fu_device_set_protocol (child1, "com.acme");
+		fu_device_add_protocol (child1, "com.acme");
 		fu_device_set_physical_id (child1, "fake");
 		fu_device_set_logical_id (child1, "child1");
 		fu_device_add_guid (child1, "7fddead7-12b5-4fb9-9fa0-6d30305df755");
@@ -77,7 +77,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 
 		child2 = fu_device_new ();
 		fu_device_add_vendor_id (child2, "USB:FFFF");
-		fu_device_set_protocol (child2, "com.acme");
+		fu_device_add_protocol (child2, "com.acme");
 		fu_device_set_physical_id (child2, "fake");
 		fu_device_set_logical_id (child2, "child2");
 		fu_device_add_guid (child2, "b8fe6b45-8702-4bcd-8120-ef236caac76f");

--- a/plugins/test/fu-test-ble-device.c
+++ b/plugins/test/fu-test-ble-device.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE (FuTestBleDevice, fu_test_ble_device, FU_TYPE_BLUEZ_DEVICE)
 static void
 fu_test_ble_device_init (FuTestBleDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "org.test.testble");
+	fu_device_add_protocol (FU_DEVICE (self), "org.test.testble");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 }
 

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -99,7 +99,7 @@ fu_thelio_io_device_init (FuThelioIoDevice *self)
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_set_protocol (FU_DEVICE (self), "org.usb.dfu");
+	fu_device_add_protocol (FU_DEVICE (self), "org.usb.dfu");
 }
 
 static void

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -790,7 +790,7 @@ fu_thunderbolt_device_init (FuThunderboltDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_icon (FU_DEVICE (self), "thunderbolt");
-	fu_device_set_protocol (FU_DEVICE (self), "com.intel.thunderbolt");
+	fu_device_add_protocol (FU_DEVICE (self), "com.intel.thunderbolt");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
 

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -721,7 +721,7 @@ fu_uefi_device_probe (FuDevice *device, GError **error)
 static void
 fu_uefi_device_init (FuUefiDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "org.uefi.capsule");
+	fu_device_add_protocol (FU_DEVICE (self), "org.uefi.capsule");
 }
 
 static void

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -141,7 +141,7 @@ fu_uefi_dbx_device_init (FuUefiDbxDevice *self)
 	fu_device_set_name (FU_DEVICE (self), "UEFI dbx");
 	fu_device_set_summary (FU_DEVICE (self), "UEFI Revocation Database");
 	fu_device_add_vendor_id (FU_DEVICE (self), "UEFI:Linux Foundation");
-	fu_device_set_protocol (FU_DEVICE (self), "org.uefi.dbx");
+	fu_device_add_protocol (FU_DEVICE (self), "org.uefi.dbx");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_NUMBER);
 	fu_device_set_install_duration (FU_DEVICE (self), 1);
 	fu_device_add_icon (FU_DEVICE (self), "computer");

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -678,7 +678,7 @@ static void
 fu_vli_pd_device_init (FuVliPdDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.pd");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.pd");
 	fu_device_set_summary (FU_DEVICE (self), "USB PD");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -647,7 +647,7 @@ fu_vli_pd_parade_device_init (FuVliPdParadeDevice *self)
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.i2c");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_set_install_duration (FU_DEVICE (self), 15); /* seconds */
 	fu_device_set_logical_id (FU_DEVICE (self), "PS186");
 	fu_device_set_summary (FU_DEVICE (self), "DisplayPort 1.4a to HDMI 2.0b Protocol Converter");

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -975,7 +975,7 @@ static void
 fu_vli_usbhub_device_init (FuVliUsbhubDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.usbhub");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.usbhub");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -323,7 +323,7 @@ static void
 fu_vli_usbhub_msp430_device_init (FuVliUsbhubMsp430Device *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.i2c");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_logical_id (FU_DEVICE (self), "I2C");

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -244,7 +244,7 @@ static void
 fu_vli_usbhub_pd_device_init (FuVliUsbhubPdDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.usbhub");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.usbhub");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -494,7 +494,7 @@ static void
 fu_vli_usbhub_rtd21xx_device_init (FuVliUsbhubRtd21xxDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
-	fu_device_set_protocol (FU_DEVICE (self), "com.vli.i2c");
+	fu_device_add_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -357,7 +357,7 @@ fu_wacom_device_set_quirk_kv (FuDevice *device,
 static void
 fu_wacom_device_init (FuWacomDevice *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.raw");
+	fu_device_add_protocol (FU_DEVICE (self), "com.wacom.raw");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -802,7 +802,7 @@ fu_wac_device_init (FuWacDevice *self)
 	self->checksums = g_array_new (FALSE, FALSE, sizeof(guint32));
 	self->configuration = 0xffff;
 	self->firmware_index = 0xffff;
-	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.usb");
+	fu_device_add_protocol (FU_DEVICE (self), "com.wacom.usb");
 	fu_device_add_icon (FU_DEVICE (self), "input-tablet");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -305,7 +305,7 @@ fu_wac_module_set_property (GObject *object, guint prop_id,
 static void
 fu_wac_module_init (FuWacModule *self)
 {
-	fu_device_set_protocol (FU_DEVICE (self), "com.wacom.usb");
+	fu_device_add_protocol (FU_DEVICE (self), "com.wacom.usb");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5389,7 +5389,7 @@ fu_engine_add_device (FuEngine *self, FuDevice *device)
 
 	/* does the device not have an assigned protocol */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE) &&
-	    fu_device_get_protocol (device) == NULL) {
+	    fu_device_get_protocols (device)->len == 0) {
 		g_warning ("device %s [%s] does not define an update protocol",
 			   fu_device_get_id (device),
 			   fu_device_get_name (device));

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -10,6 +10,7 @@
 
 #include <fwupd.h>
 
+#include "fu-common.h"
 #include "fu-common-version.h"
 #include "fu-device-private.h"
 #include "fu-install-task.h"
@@ -254,16 +255,17 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	protocol = xb_node_query_text (self->component,
 				       "custom/value[@key='LVFS::UpdateProtocol']",
 				       NULL);
-	if (fu_device_get_protocol (self->device) != NULL && protocol != NULL &&
-	    g_strcmp0 (fu_device_get_protocol (self->device), protocol) != 0 &&
+	if (fu_device_get_protocols (self->device)->len != 0 && protocol != NULL &&
+	    !fu_device_has_protocol (self->device, protocol) &&
 	    (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
+		g_autofree gchar *str = NULL;
+		str = fu_common_strjoin_array ("|", fu_device_get_protocols (self->device));
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,
 			     "Device %s does not support %s, only %s",
 			     fu_device_get_name (self->device),
-			     protocol,
-			     fu_device_get_protocol (self->device));
+			     protocol, str);
 		return FALSE;
 	}
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -762,7 +762,7 @@ fu_engine_requirements_other_device_func (gconstpointer user_data)
 	/* set up a different device */
 	fu_device_set_id (device2, "id2");
 	fu_device_add_vendor_id (device2, "USB:FFFF");
-	fu_device_set_protocol (device2, "com.acme");
+	fu_device_add_protocol (device2, "com.acme");
 	fu_device_set_name (device2, "Secondary firmware");
 	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version (device2, "4.5.6");
@@ -823,7 +823,7 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 	fu_engine_set_silo (engine, silo_empty);
 
 	fu_device_set_id (device1, "NVME");
-	fu_device_set_protocol (device1, "com.acme");
+	fu_device_add_protocol (device1, "com.acme");
 	fu_device_set_name (device1, "NVME device");
 	fu_device_add_vendor_id (device1, "ACME");
 	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -833,7 +833,7 @@ fu_engine_requirements_protocol_check_func (gconstpointer user_data)
 	fu_engine_add_device (engine, device1);
 
 	fu_device_set_id (device2, "UEFI");
-	fu_device_set_protocol (device2, "org.bar");
+	fu_device_add_protocol (device2, "org.bar");
 	fu_device_set_name (device2, "UEFI device");
 	fu_device_add_vendor_id (device2, "ACME");
 	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -918,7 +918,7 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 	/* set up a parent device */
 	fu_device_set_id (device1, "parent");
 	fu_device_add_vendor_id (device1, "USB:FFFF");
-	fu_device_set_protocol (device1, "com.acme");
+	fu_device_add_protocol (device1, "com.acme");
 	fu_device_set_name (device1, "parent");
 	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version (device1, "1.2.3");
@@ -958,7 +958,7 @@ fu_engine_device_parent_func (gconstpointer user_data)
 	/* add child */
 	fu_device_set_id (device1, "child");
 	fu_device_add_vendor_id (device2, "USB:FFFF");
-	fu_device_set_protocol (device2, "com.acme");
+	fu_device_add_protocol (device2, "com.acme");
 	fu_device_add_instance_id (device1, "child-GUID-1");
 	fu_device_add_parent_guid (device1, "parent-GUID");
 	fu_device_convert_instance_ids (device1);
@@ -967,7 +967,7 @@ fu_engine_device_parent_func (gconstpointer user_data)
 	/* parent */
 	fu_device_set_id (device2, "parent");
 	fu_device_add_vendor_id (device2, "USB:FFFF");
-	fu_device_set_protocol (device2, "com.acme");
+	fu_device_add_protocol (device2, "com.acme");
 	fu_device_add_instance_id (device2, "parent-GUID");
 	fu_device_set_vendor (device2, "oem");
 	fu_device_convert_instance_ids (device2);
@@ -1020,13 +1020,13 @@ fu_engine_partial_hash_func (gconstpointer user_data)
 	/* add two dummy devices */
 	fu_device_set_id (device1, "device1");
 	fu_device_add_vendor_id (device1, "USB:FFFF");
-	fu_device_set_protocol (device1, "com.acme");
+	fu_device_add_protocol (device1, "com.acme");
 	fu_device_set_plugin (device1, "test");
 	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
 	fu_engine_add_device (engine, device1);
 	fu_device_set_id (device2, "device21");
 	fu_device_add_vendor_id (device2, "USB:FFFF");
-	fu_device_set_protocol (device2, "com.acme");
+	fu_device_add_protocol (device2, "com.acme");
 	fu_device_set_plugin (device2, "test");
 	fu_device_set_equivalent_id (device2, "b92f5b7560b84ca005a79f5a15de3c003ce494cf");
 	fu_device_add_guid (device2, "87654321-1234-1234-1234-123456789012");
@@ -1099,7 +1099,7 @@ fu_engine_device_unlock_func (gconstpointer user_data)
 	/* add a dummy device */
 	fu_device_set_id (device, "UEFI-dummy-dev0");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_add_guid (device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_PLAIN);
@@ -1150,7 +1150,7 @@ fu_engine_require_hwid_func (gconstpointer user_data)
 	/* add a dummy device */
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version (device, "1.2.2");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -1287,7 +1287,7 @@ fu_engine_downgrade_func (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.3");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_add_guid (device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
@@ -1402,7 +1402,7 @@ fu_engine_install_duration_func (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.3");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_add_guid (device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_set_install_duration (device, 999);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
@@ -1472,7 +1472,7 @@ fu_engine_history_func (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_set_plugin (device, "test");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -1599,7 +1599,7 @@ fu_engine_multiple_rels_func (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_set_plugin (device, "test");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -1670,7 +1670,7 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_set_plugin (device, "test");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
@@ -1732,7 +1732,7 @@ fu_engine_history_inherit (gconstpointer user_data)
 	device = fu_device_new ();
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
 	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -1781,7 +1781,7 @@ fu_engine_history_error_func (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
-	fu_device_set_protocol (device, "com.acme");
+	fu_device_add_protocol (device, "com.acme");
 	fu_device_set_name (device, "Test Device");
 	fu_device_set_plugin (device, "test");
 	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");


### PR DESCRIPTION
Devices may want to support more than one protocol, and for some devices
(e.g. Unifying peripherals stuck in bootloader mode) you might not even be able
to query for the correct protocol anyway.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
