### PR TITLE
Allow enabling plugins only matching a specific HwId

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -345,6 +345,8 @@ fwupd_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		return "legacy-bios";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_FAILED_OPEN)
 		return "failed-open";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID)
+		return "require-hwid";
 	if (plugin_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -385,6 +387,8 @@ fwupd_plugin_flag_from_string (const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_LEGACY_BIOS;
 	if (g_strcmp0 (plugin_flag, "failed-open") == 0)
 		return FWUPD_PLUGIN_FLAG_FAILED_OPEN;
+	if (g_strcmp0 (plugin_flag, "require-hwid") == 0)
+		return FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -235,6 +235,7 @@ typedef enum {
  * @FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND:		The EFI ESP not found
  * @FWUPD_PLUGIN_FLAG_LEGACY_BIOS:		System running in legacy CSM mode
  * @FWUPD_PLUGIN_FLAG_FAILED_OPEN:		Failed to open plugin (missing dependency)
+ * @FWUPD_PLUGIN_FLAG_REQUIRE_HWID:		A specific HWID is required
  *
  * The plugin flags.
  **/
@@ -249,6 +250,7 @@ typedef enum {
 #define FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND		(1u << 7)	/* Since: 1.5.0 */
 #define FWUPD_PLUGIN_FLAG_LEGACY_BIOS		(1u << 8)	/* Since: 1.5.0 */
 #define FWUPD_PLUGIN_FLAG_FAILED_OPEN		(1u << 9)	/* Since: 1.5.0 */
+#define FWUPD_PLUGIN_FLAG_REQUIRE_HWID		(1u << 10)	/* Since: 1.5.8 */
 #define FWUPD_PLUGIN_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 1.5.0 */
 typedef guint64 FwupdPluginFlags;
 

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -1,15 +1,15 @@
 # Purism
 [HwId=a0ce5085-2dea-5086-ae72-45810a186ad0]
-DeviceId=librem15v3
+Plugin=flashrom
 
 # Libretrend
 [HwId=52b68c34-6b31-5ecc-8a5c-de37e666ccd5]
-DeviceId=LT1000
+Plugin=flashrom
 VersionFormat=quad
 
 # Starlabs LabTop L4
 [HwId=baf1d04e-fd16-5e6a-93cc-1c23d171f879]
-DeviceId=StarlabsLabTopL4
+Plugin=flashrom
 
 # Starlabs LabTop L4 (in coreboot)
 [Guid=0ee5867c-93f0-5fb4-adf1-9d686ea1183a]

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -24,6 +24,8 @@ fu_flashrom_device_init (FuFlashromDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_instance_id (FU_DEVICE (self), "main-system-firmware");
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_ENSURE_SEMVER);
+	fu_device_set_physical_id (FU_DEVICE (self), "flashrom");
+	fu_device_set_logical_id (FU_DEVICE (self), "bios");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }

--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -15,19 +15,7 @@ fu_plugin_init (FuPlugin *plugin)
 	/* make sure that UEFI plugin is ready to receive devices */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "uefi_capsule");
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-}
-
-gboolean
-fu_plugin_startup (FuPlugin *plugin, GError **error)
-{
-	if (!fu_plugin_has_custom_flag (plugin, "requires-uefi-recovery")) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_SUPPORTED,
-				     "not required");
-		return FALSE;
-	}
-	return TRUE;
+	fu_plugin_add_flag (plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
 }
 
 gboolean

--- a/plugins/uefi-recovery/uefi-recovery.quirk
+++ b/plugins/uefi-recovery/uefi-recovery.quirk
@@ -1,3 +1,3 @@
 # Silicom Minnowboard Turbot MNW2MAX1.X64.0100.R01.1811141729
 [HwId=ea358e00-39f1-55b6-97be-a39225a585e1]
-Flags = requires-uefi-recovery
+Plugin = uefi_recovery

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -138,6 +138,7 @@ fu_util_show_plugin_warnings (FuUtilPrivate *priv)
 	/* never show these, they're way too generic */
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
+	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
 
 	/* print */
 	for (guint i = 0; i < 64; i++) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1330,6 +1330,8 @@ fu_util_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		return NULL;
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_USER_WARNING)
 		return NULL;
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID)
+		return NULL;
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_NONE) {
 		/* TRANSLATORS: Plugin is active and in use */
 		return _("Enabled");
@@ -1378,6 +1380,7 @@ fu_util_plugin_flag_to_cli_text (FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_UNKNOWN:
 	case FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE:
 	case FWUPD_PLUGIN_FLAG_USER_WARNING:
+	case FWUPD_PLUGIN_FLAG_REQUIRE_HWID:
 		return NULL;
 	case FWUPD_PLUGIN_FLAG_NONE:
 		return fu_util_term_format (fu_util_plugin_flag_to_string (plugin_flag),

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2683,6 +2683,7 @@ fu_util_show_plugin_warnings (FuUtilPrivate *priv)
 	/* never show these, they're way too generic */
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
+	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
 
 	/* print */
 	for (guint i = 0; i < 64; i++) {


### PR DESCRIPTION
At the moment plugins are doing this a few different ways; either looping
through the HwIds manually (e.g. flashrom) or setting a custom flag that is
checked in fu_plugin_setup (e.g. uefi-recovery).

Define a standard 'Plugin' HwId quirk to simplify plugins.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
