### PR TITLE
superio: Ensure quirks are set on the new devices

### DIFF
--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -25,11 +25,13 @@ fu_plugin_superio_coldplug_chipset (FuPlugin *plugin, const gchar *chipset, GErr
 		dev = g_object_new (FU_TYPE_SUPERIO_IT85_DEVICE,
 				    "device-file", "/dev/port",
 				    "chipset", chipset,
+				    "quirks", fu_plugin_get_quirks (plugin),
 				    NULL);
 	} else if (g_strcmp0 (chipset, "IT8987") == 0) {
 		dev = g_object_new (FU_TYPE_SUPERIO_IT89_DEVICE,
 				    "device-file", "/dev/port",
 				    "chipset", chipset,
+				    "quirks", fu_plugin_get_quirks (plugin),
 				    NULL);
 	} else {
 		g_set_error (error,


### PR DESCRIPTION
Fixes a regression in 79a217a2a617224465e02c8cd7ebb8d3c5277c25

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
