### PR TITLE
libxmlb.wrap: Bump revision

### DIFF
--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.1.14
+revision = 0.2.1


### PR DESCRIPTION
Newer revision of the libxmlb solves wrong MIME type problem at FreeBSD

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
