### PR TITLE
Add fu_device_set_battery_level()

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -329,6 +329,9 @@ guint64		 fu_device_get_firmware_size_max	(FuDevice	*self);
 guint		 fu_device_get_progress			(FuDevice	*self);
 void		 fu_device_set_progress			(FuDevice	*self,
 							 guint		 progress);
+guint		 fu_device_get_battery_level		(FuDevice	*self);
+void		 fu_device_set_battery_level		(FuDevice	*self,
+							 guint		 battery_level);
 void		 fu_device_set_progress_full		(FuDevice	*self,
 							 gsize		 progress_done,
 							 gsize		 progress_total);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -779,7 +779,9 @@ LIBFWUPDPLUGIN_1.5.8 {
     fu_common_write_uint32_safe;
     fu_common_write_uint8_safe;
     fu_device_get_backend_id;
+    fu_device_get_battery_level;
     fu_device_set_backend_id;
+    fu_device_set_battery_level;
     fu_ifd_access_to_string;
     fu_ifd_firmware_check_jedec_cmd;
     fu_ifd_firmware_get_type;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-peripheral.c
@@ -15,7 +15,6 @@
 struct _FuLogitechHidPpPeripheral
 {
 	FuUdevDevice		 parent_instance;
-	guint8			 battery_level;
 	guint8			 cached_fw_entity;
 	guint8			 hidpp_id;
 	guint8			 hidpp_version;
@@ -267,7 +266,6 @@ fu_logitech_hidpp_peripheral_to_string (FuDevice *device, guint idt, GString *st
 
 	fu_common_string_append_ku (str, idt, "HidppVersion", self->hidpp_version);
 	fu_common_string_append_kx (str, idt, "HidppId", self->hidpp_id);
-	fu_common_string_append_ku (str, idt, "BatteryLevel", self->battery_level);
 	fu_common_string_append_kb (str, idt, "IsUpdatable", self->is_updatable);
 	fu_common_string_append_kb (str, idt, "IsActive", self->is_active);
 	for (guint i = 0; i < self->feature_index->len; i++) {
@@ -380,7 +378,7 @@ fu_logitech_hidpp_peripheral_fetch_battery_level (FuLogitechHidPpPeripheral *sel
 				return FALSE;
 			}
 			if (msg->data[0] != 0x00)
-				self->battery_level = msg->data[0];
+				fu_device_set_battery_level (FU_DEVICE (self), msg->data[0]);
 			return TRUE;
 		}
 	}
@@ -395,7 +393,7 @@ fu_logitech_hidpp_peripheral_fetch_battery_level (FuLogitechHidPpPeripheral *sel
 		msg->hidpp_version = self->hidpp_version;
 		if (fu_logitech_hidpp_transfer (self->io_channel, msg, NULL)) {
 			if (msg->data[0] != 0x00)
-				self->battery_level = msg->data[0];
+				fu_device_set_battery_level (FU_DEVICE (self), msg->data[0]);
 			return TRUE;
 		}
 
@@ -404,16 +402,16 @@ fu_logitech_hidpp_peripheral_fetch_battery_level (FuLogitechHidPpPeripheral *sel
 		if (fu_logitech_hidpp_transfer (self->io_channel, msg, NULL)) {
 			switch (msg->data[0]) {
 			case 1: /* 0 - 10 */
-				self->battery_level = 5;
+				fu_device_set_battery_level (FU_DEVICE (self), 5);
 				break;
 			case 3: /* 11 - 30 */
-				self->battery_level = 20;
+				fu_device_set_battery_level (FU_DEVICE (self), 20);
 				break;
 			case 5: /* 31 - 80 */
-				self->battery_level = 55;
+				fu_device_set_battery_level (FU_DEVICE (self), 55);
 				break;
 			case 7: /* 81 - 100 */
-				self->battery_level = 90;
+				fu_device_set_battery_level (FU_DEVICE (self), 90);
 				break;
 			default:
 				g_warning ("unknown battery percentage: 0x%02x",

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -129,6 +129,8 @@ static guint signals[SIGNAL_LAST] = { 0 };
 
 G_DEFINE_TYPE (FuEngine, fu_engine, G_TYPE_OBJECT)
 
+#define FU_ENGINE_BATTERY_LEVEL_THRESHOLD	10 /* % */
+
 static void
 fu_engine_emit_changed (FuEngine *self)
 {
@@ -2622,6 +2624,19 @@ fu_engine_device_prepare (FuEngine *self,
 		g_prefix_error (error, "failed to open device for prepare: ");
 		return FALSE;
 	}
+
+	/* check battery level is sane -- if the device needs a higher
+	 * threshold then it can be checked in FuDevice->prepare() */
+	if (fu_device_get_battery_level (device) > 0 &&
+	    fu_device_get_battery_level (device) < FU_ENGINE_BATTERY_LEVEL_THRESHOLD) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,
+			     "battery level is too low: %u%%",
+			     fu_device_get_battery_level (device));
+		return FALSE;
+	}
+
 	return fu_device_prepare (device, flags, error);
 }
 


### PR DESCRIPTION
We want to make it as easy as possible for devices to refuse to update on low
battery, as this will likely be one of the WWCB requirements.

Ideally devices will check the battery level inside the firmware, but by also
providing the battery level to fwupd we can give the user a warning *before*
the update has started and without switching the device into bootloader mode.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
