### PR TITLE
Stopped updatable flag being removed if PciBcrAddr=0

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -10,7 +10,6 @@ VersionFormat=quad
 # Star LabTop Mk III (HwId)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
 Plugin=flashrom
-PciBcrAddr = 0x0
 
 # Star LabTop Mk IV (HwId)
 [baf1d04e-fd16-5e6a-93cc-1c23d171f879]


### PR DESCRIPTION
PciBcr gets a false positive for `SPI write` and removes the updateable flag. chipsec correctly detects BIOSWE and BLE, by looking at 1f.5. Adjusting the visibility of 1f.5 in the firmware doesn't change the result of PcrBcr.

To get flashrom working, changed to not remove the updatable flag if the PcrBcrAddr quirk is 0 (but doesn't solve the false-positive issue).

### coreboot
```
HSI-1
✔ Intel DCI debugger:            Disabled
✔ SPI lock:                      Enabled
✔ SPI write:                     Disabled
✔ UEFI platform key:             Valid
✘ SPI BIOS region:               Unlocked
✘ TPM v2.0:                      Not found
```
```
[*] BC = 0x0000008B << BIOS Control (b:d.f 00:31.5 + 0xDC)
    [00] BIOSWE           = 1 << BIOS Write Enable 
    [01] BLE              = 1 << BIOS Lock Enable 
    [02] SRC              = 2 << SPI Read Configuration 
    [04] TSS              = 0 << Top Swap Status 
    [05] SMM_BWP          = 0 << SMM BIOS Write Protection 
    [06] BBS              = 0 << Boot BIOS Strap 
    [07] BILD             = 1 << BIOS Interface Lock Down 
[-] BIOS region write protection is disabled!
```

### AMI (BIOS Locked Enabled)
```
HSI-1
✔ Intel DCI debugger:            Disabled
✔ SPI BIOS region:               Locked
✔ SPI lock:                      Enabled
✔ SPI write:                     Disabled
✔ UEFI platform key:             Valid
✘ TPM v2.0:                      Not found
```
```
[*] BC = 0x00000AAA << BIOS Control (b:d.f 00:31.5 + 0xDC)
    [00] BIOSWE           = 0 << BIOS Write Enable 
    [01] BLE              = 1 << BIOS Lock Enable 
    [02] SRC              = 2 << SPI Read Configuration 
    [04] TSS              = 0 << Top Swap Status 
    [05] SMM_BWP          = 1 << SMM BIOS Write Protection 
    [06] BBS              = 0 << Boot BIOS Strap 
    [07] BILD             = 1 << BIOS Interface Lock Down 
[+] BIOS region write protection is enabled (writes restricted to SMM)
```

### AMI (BIOS Lock Disabled)
```
HSI-1
✔ Intel DCI debugger:            Disabled
✔ SPI write:                     Disabled
✔ UEFI platform key:             Valid
✘ SPI BIOS region:               Unlocked
✘ SPI lock:                      Disabled
✘ TPM v2.0:                      Not found
```
```
[*] BC = 0x00000A89 << BIOS Control (b:d.f 00:31.5 + 0xDC)
    [00] BIOSWE           = 1 << BIOS Write Enable 
    [01] BLE              = 0 << BIOS Lock Enable 
    [02] SRC              = 2 << SPI Read Configuration 
    [04] TSS              = 0 << Top Swap Status 
    [05] SMM_BWP          = 0 << SMM BIOS Write Protection 
    [06] BBS              = 0 << Boot BIOS Strap 
    [07] BILD             = 1 << BIOS Interface Lock Down 
[-] BIOS region write protection is disabled!
```

