### PR TITLE
backport uefi-capsule: Specify the section flags for .sbat for 1_2_X

### DIFF
--- a/plugins/uefi/efi/generate_sbat.py
+++ b/plugins/uefi/efi/generate_sbat.py
@@ -70,6 +70,8 @@ def _generate_sbat(args):
             args.objcopy,
             "--add-section",
             ".sbat={}".format(sfd.name),
+            "--set-section-flags",
+            ".sbat=contents,alloc,load,readonly,data",
             args.outfile,
         ]
         subprocess.run(argv, check=True)


### PR DESCRIPTION
When using "objcopy -O binary" to generate AArch64 EFI images, it
silently drops the sections without "alloc" or "load" or the sections
with "unload", and this caused the content of .sbat was skipped in the
final EFI image.

This commit sets the common read-only data section flags to .sbat to
make sure the content will be copied.

Signed-off-by: Gary Lin <glin@suse.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
