### PR TITLE
trivial: Add fu_firmware_get_alignment()

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -109,6 +109,9 @@ GBytes		*fu_firmware_get_bytes			(FuFirmware	*self,
 							 GError		**error);
 void		 fu_firmware_set_bytes			(FuFirmware	*self,
 							 GBytes		*bytes);
+guint8		 fu_firmware_get_alignment		(FuFirmware	*self);
+void		 fu_firmware_set_alignment		(FuFirmware	*self,
+							 guint8		 alignment);
 void		 fu_firmware_add_chunk			(FuFirmware	*self,
 							 FuChunk	*chk);
 GPtrArray	*fu_firmware_get_chunks			(FuFirmware	*self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -758,6 +758,7 @@ LIBFWUPDPLUGIN_1.6.0 {
   global:
     fu_firmware_add_chunk;
     fu_firmware_get_addr;
+    fu_firmware_get_alignment;
     fu_firmware_get_bytes;
     fu_firmware_get_checksum;
     fu_firmware_get_chunks;
@@ -766,6 +767,7 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_firmware_get_idx;
     fu_firmware_get_offset;
     fu_firmware_set_addr;
+    fu_firmware_set_alignment;
     fu_firmware_set_bytes;
     fu_firmware_set_filename;
     fu_firmware_set_id;


### PR DESCRIPTION
I need this from two different FuFirmware superclasses, and I think it makes
sense in the base object.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
