### PR TITLE
trivial: Add fu_firmware_get_size()

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -102,6 +102,9 @@ void		 fu_firmware_set_addr			(FuFirmware	*self,
 guint64		 fu_firmware_get_offset			(FuFirmware	*self);
 void		 fu_firmware_set_offset			(FuFirmware	*self,
 							 guint64	 offset);
+gsize		 fu_firmware_get_size			(FuFirmware	*self);
+void		 fu_firmware_set_size			(FuFirmware	*self,
+							 gsize		 offset);
 guint64		 fu_firmware_get_idx			(FuFirmware	*self);
 void		 fu_firmware_set_idx			(FuFirmware	*self,
 							 guint64	 idx);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -768,6 +768,7 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_firmware_get_id;
     fu_firmware_get_idx;
     fu_firmware_get_offset;
+    fu_firmware_get_size;
     fu_firmware_set_addr;
     fu_firmware_set_alignment;
     fu_firmware_set_bytes;
@@ -775,6 +776,7 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_firmware_set_id;
     fu_firmware_set_idx;
     fu_firmware_set_offset;
+    fu_firmware_set_size;
     fu_firmware_write_chunk;
     fu_ifd_access_to_string;
     fu_ifd_firmware_check_jedec_cmd;


### PR DESCRIPTION
The idea here is to return the size of the firmware, including the header,
footer or other encapsulation. It would be expected that this value would
include the alignment if provided.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
