### PR TITLE
fu-tool: fix a regression where activate stopped working in c7d870aa9

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1549,7 +1549,12 @@ fu_util_activate (FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_util_start_engine (priv, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_util_start_engine (priv,
+				   FU_ENGINE_LOAD_FLAG_READONLY |
+				   FU_ENGINE_LOAD_FLAG_COLDPLUG |
+				   FU_ENGINE_LOAD_FLAG_REMOTES |
+				   FU_ENGINE_LOAD_FLAG_HWINFO,
+				   error))
 		return FALSE;
 
 	/* parse arguments */


### PR DESCRIPTION
Activate was no longer calling coldplug meaning even if devices were
in the pending database they wouldn't activate.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
