### PR TITLE
 backport synaptics-rmi: Do not match all HIDRAW\VEN_06CB devices

### DIFF
--- a/plugins/synaptics-rmi/synaptics-rmi.quirk
+++ b/plugins/synaptics-rmi/synaptics-rmi.quirk
@@ -1,7 +1,5 @@
-[DeviceInstanceId=HIDRAW\VEN_06CB]
-Plugin = synaptics_rmi
-Vendor = Synaptics
-
 # Dell K12A kbd-dock
 [DeviceInstanceId=HIDRAW\VEN_06CB&DEV_2819]
+Plugin = synaptics_rmi
+Vendor = Synaptics
 Flags = only-supported


### PR DESCRIPTION
Apparently, some devices will not respond well to probing.

See bug https://bugs.launchpad.net/ubuntu/+source/linux-firmware/+bug/1886912

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
