### PR TITLE
backport: disable synaptics-rmi for 1-3-x

### DIFF
--- a/plugins/synaptics-rmi/synaptics-rmi.quirk
+++ b/plugins/synaptics-rmi/synaptics-rmi.quirk
@@ -1,3 +1,7 @@
 [DeviceInstanceId=HIDRAW\VEN_06CB]
 Plugin = synaptics_rmi
 Vendor = Synaptics
+
+# Dell K12A kbd-dock
+[DeviceInstanceId=HIDRAW\VEN_06CB&DEV_2819]
+Flags = only-supported

--- a/plugins/synaptics-rmi/synaptics-rmi.quirk
+++ b/plugins/synaptics-rmi/synaptics-rmi.quirk
@@ -1,7 +1,5 @@
-[DeviceInstanceId=HIDRAW\VEN_06CB]
-Plugin = synaptics_rmi
-Vendor = Synaptics
-
 # Dell K12A kbd-dock
 [DeviceInstanceId=HIDRAW\VEN_06CB&DEV_2819]
+Plugin = synaptics_rmi
+Vendor = Synaptics
 Flags = only-supported


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/linux-firmware/+bug/1886912 for background 

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
