### PR TITLE
Allow reading the PciBcrAddr quirk from flashrom devices

### DIFF
--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -30,9 +30,29 @@ fu_flashrom_device_init (FuFlashromDevice *self)
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }
 
+static gboolean
+fu_flashrom_device_set_quirk_kv (FuDevice *device,
+				 const gchar *key,
+				 const gchar *value,
+				 GError **error)
+{
+	if (g_strcmp0 (key, "PciBcrAddr") == 0) {
+		guint64 tmp = fu_common_strtoull (value);
+		fu_device_set_metadata_integer (device, "PciBcrAddr", tmp);
+		return TRUE;
+	}
+	g_set_error_literal (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "no supported");
+	return FALSE;
+}
+
 static void
 fu_flashrom_device_class_init (FuFlashromDeviceClass *klass)
 {
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	klass_device->set_quirk_kv = fu_flashrom_device_set_quirk_kv;
 }
 
 FuDevice *


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
