### PR TITLE
cros-ec: Add D501 Baklava device support

### DIFF
--- a/plugins/cros-ec/cros-ec.quirk
+++ b/plugins/cros-ec/cros-ec.quirk
@@ -8,6 +8,11 @@ Summary = Servo Micro (aka "uServo") Debug Board
 Plugin = cros_ec
 Summary = Quiche Reference Board
 
+# Baklava (D501)
+[USB\VID_0502&PID_1195]
+Plugin = cros_ec
+Summary = D501 Device (Google Quiche derivative)
+
 # Gingerbread
 [USB\VID_18D1&PID_5049]
 Plugin = cros_ec


### PR DESCRIPTION
Baklava is based on Quiche and will work with cros-ec plugin.

fixes #3044

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

Add support for the D501 Baklava device. Basically a quiche variant.