### PR TITLE
cros-ec: Fix call to fu_memdup_safe in fu_cros_ec_usb_device_do_xfer

### DIFF
--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -202,15 +202,16 @@ fu_cros_ec_usb_device_do_xfer (FuCrosEcUsbDevice * self, const guint8 *outbuf,
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (self));
 	gsize actual = 0;
-	g_autofree guint8 *outbuf_tmp = NULL;
-
-	/* make mutable */
-	outbuf_tmp = fu_memdup_safe (outbuf, outlen, error);
-	if (outbuf_tmp == NULL)
-		return FALSE;
 
 	/* send data out */
 	if (outbuf != NULL && outlen > 0) {
+		g_autofree guint8 *outbuf_tmp = NULL;
+
+		/* make mutable */
+		outbuf_tmp = fu_memdup_safe (outbuf, outlen, error);
+		if (outbuf_tmp == NULL)
+			return FALSE;
+
 		if (!g_usb_device_bulk_transfer (usb_device, self->ep_num,
 						 outbuf_tmp, outlen,
 						 &actual, BULK_SEND_TIMEOUT_MS,


### PR DESCRIPTION
outbuf == NULL is a valid condition in fu_cros_ec_usb_device_do_xfer. That's
how we use this function to specify a read with no outbound buffer, like the
reply at the end of sending a block.
Since 9b11af985f68 ("Add fu_memdup_safe()"), however, the call to fu_memdup_safe
always fails if outbuf, the dst, is NULL.

Fix this by moving this into the if (outbuf != NULL && outlen > 0)  block below.

Fixes: 9b11af985f68 ("Add fu_memdup_safe()")
fixes #3064

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
