### PR TITLE
trivial: cros-ec: Fix error string to use inlen

### DIFF
--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -245,7 +245,7 @@ fu_cros_ec_usb_device_do_xfer (FuCrosEcUsbDevice * self, const guint8 *outbuf,
 				     G_IO_ERROR_PARTIAL_INPUT,
 				     "only received %" G_GSIZE_FORMAT "/%"
 				     G_GSIZE_FORMAT " bytes",
-				     actual, outlen);
+				     actual, inlen);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
Looks like this error message was copy/pasted from above.
Since we're testing whether actual != inlen, the error message should
output inlen.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
