### PR TITLE
fu-tool: fix array access in fw_util_verify_update

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2275,7 +2275,7 @@ fu_util_verify_update (FuUtilPrivate *priv, gchar **values, GError **error)
 
 	/* get device */
 	if (g_strv_length (values) == 1) {
-		dev = fu_util_get_device (priv, values[1], error);
+		dev = fu_util_get_device (priv, values[0], error);
 		if (dev == NULL)
 			return FALSE;
 	} else {


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

I stumbled across a sigfault when running `fwupdtool verify-update <guid>`:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055e0daadd547 in fu_util_get_device (priv=0x55e0dbbced00, id=0x0, error=0x7ffdf49d4938) at ../src/fu-tool.c:446
446		for (guint i = 0; id[i] != '\0'; i++) {
[Current thread is 1 (Thread 0x7f876abed8c0 (LWP 31473))]
(gdb) bt
#0  0x000055e0daadd547 in fu_util_get_device (priv=0x55e0dbbced00, id=0x0, error=0x7ffdf49d4938) at ../src/fu-tool.c:446
#1  0x000055e0daae2819 in fu_util_verify_update (priv=0x55e0dbbced00, values=0x55e0dbbb5ca0, error=0x7ffdf49d4938) at ../src/fu-tool.c:2220
#2  0x000055e0daae7aa1 in fu_util_cmd_array_run
    (array=0x55e0dbbcee00, priv=0x55e0dbbced00, command=0x7ffdf49d6760 "verify-update", values=0x7ffdf49d4e38, error=0x7ffdf49d4938)
    at ../src/fu-util-common.c:551
#3  0x000055e0daae52a9 in main (argc=3, argv=0x7ffdf49d4e28) at ../src/fu-tool.c:3186
```