### PR TITLE
Tweak the SBAT output for a vendor string

### DIFF
--- a/plugins/uefi/efi/generate_sbat.py
+++ b/plugins/uefi/efi/generate_sbat.py
@@ -51,7 +51,7 @@ def _generate_sbat(args):
 
         # distro specifics, falling back to the project defaults
         sfd.write(
-            "{0}-{1},{2},{3},{4},{5},{6}\n".format(
+            "{0}.{1},{2},{3},{4},{5},{6}\n".format(
                 args.project_name,
                 args.sbat_distro_id,
                 args.sbat_distro_generation or args.sbat_generation,


### PR DESCRIPTION
The format is meant to be "<project>.<vendor>" with a period as a
separator.

Signed-off-by: Steve McIntyre <93sam@debian.org>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
