### PR TITLE
Ask the user to confirm all CLI actions

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1251,14 +1251,15 @@ fu_util_update_all (FuUtilPrivate *priv, GError **error)
 			continue;
 		}
 
+		rel = g_ptr_array_index (rels, 0);
 		if (!priv->no_safety_check) {
 			if (!fu_util_prompt_warning (dev,
+						     rel,
 						     fu_util_get_tree_title (priv),
 						     error))
 				return FALSE;
 		}
 
-		rel = g_ptr_array_index (rels, 0);
 		if (!fu_util_install_release (priv, rel, &error_local)) {
 			g_printerr ("%s\n", error_local->message);
 			continue;

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -59,6 +59,7 @@ void		 fu_util_warning_box		(const gchar	*title,
 						 const gchar	*body,
 						 guint		 width);
 gboolean	fu_util_prompt_warning		(FwupdDevice	*device,
+						 FwupdRelease	*release,
 						 const gchar	*machine,
 						 GError		**error);
 gboolean	fu_util_prompt_complete		(FwupdDeviceFlags flags,


### PR DESCRIPTION
For some users typing 'fwupdmgr update' just deploys all updates to all hardware,
and that might come as a shock. Ask the user to confirm all actions explicitly
and show the update notes in a warning box rather than plain text on the console.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
