### PR TITLE
Fix build on musl.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -318,6 +318,12 @@ endif
 if cc.has_header('fnmatch.h')
   conf.set('HAVE_FNMATCH_H', '1')
 endif
+if cc.has_header('malloc.h')
+  conf.set('HAVE_MALLOC_H', '1')
+  if cc.has_function('malloc_trim', prefix: '#include <malloc.h>')
+	 conf.set('HAVE_MALLOC_TRIM', '1')
+  endif
+endif
 if cc.has_header('cpuid.h') and cc.has_header_symbol('cpuid.h', '__get_cpuid_count') and (host_cpu == 'x86' or host_cpu == 'x86_64')
   conf.set('HAVE_CPUID_H', '1')
 else

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -14,7 +14,9 @@
 #include <glib/gi18n.h>
 #include <glib-unix.h>
 #include <locale.h>
+#ifdef HAVE_MALLOC_H
 #include <malloc.h>
+#endif
 #ifdef HAVE_POLKIT
 #include <polkit/polkit.h>
 #endif
@@ -2041,7 +2043,7 @@ main (int argc, char *argv[])
 	else if (timed_exit)
 		g_timeout_add_seconds (5, fu_main_timed_exit_cb, priv->loop);
 
-#ifdef __linux__
+#ifdef HAVE_MALLOC_TRIM
 	/* drop heap except one page */
 	malloc_trim (4096);
 #endif


### PR DESCRIPTION
malloc_trim isn't a linux function, it's a GNU extension to malloc.  We
can check for it in meson.build, which avoids hardcoding platform
knowledge.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
