### PR TITLE
Add fu_device_set_battery_threshold()

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -330,6 +330,9 @@ void		 fu_device_set_progress			(FuDevice	*self,
 guint		 fu_device_get_battery_level		(FuDevice	*self);
 void		 fu_device_set_battery_level		(FuDevice	*self,
 							 guint		 battery_level);
+guint		 fu_device_get_battery_threshold	(FuDevice	*self);
+void		 fu_device_set_battery_threshold	(FuDevice	*self,
+							 guint		 battery_threshold);
 void		 fu_device_set_progress_full		(FuDevice	*self,
 							 gsize		 progress_done,
 							 gsize		 progress_total);

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -510,6 +510,7 @@ fu_quirks_init (FuQuirks *self)
 	fu_quirks_add_possible_key (self, FU_QUIRKS_PRIORITY);
 	fu_quirks_add_possible_key (self, FU_QUIRKS_PROTOCOL);
 	fu_quirks_add_possible_key (self, FU_QUIRKS_PROXY_GUID);
+	fu_quirks_add_possible_key (self, FU_QUIRKS_BATTERY_THRESHOLD);
 	fu_quirks_add_possible_key (self, FU_QUIRKS_REMOVE_DELAY);
 	fu_quirks_add_possible_key (self, FU_QUIRKS_SUMMARY);
 	fu_quirks_add_possible_key (self, FU_QUIRKS_UPDATE_IMAGE);

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -70,4 +70,5 @@ void		 fu_quirks_add_possible_key		(FuQuirks	*self,
 #define	FU_QUIRKS_UPDATE_MESSAGE		"UpdateMessage"
 #define	FU_QUIRKS_UPDATE_IMAGE			"UpdateImage"
 #define	FU_QUIRKS_PRIORITY			"Priority"
+#define	FU_QUIRKS_BATTERY_THRESHOLD		"BatteryThreshold"
 #define	FU_QUIRKS_REMOVE_DELAY			"RemoveDelay"

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -761,6 +761,8 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_byte_array_set_size_full;
     fu_common_align_up;
     fu_device_add_security_attrs;
+    fu_device_get_battery_threshold;
+    fu_device_set_battery_threshold;
     fu_firmware_add_chunk;
     fu_firmware_build_from_xml;
     fu_firmware_export;

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -164,7 +164,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,
-			     "Cannot install update when battery "
+			     "Cannot install update when system battery "
 			     "is not at least %" G_GUINT64_FORMAT "%% unless forced",
 			      data->minimum_battery);
 		return FALSE;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -129,8 +129,6 @@ static guint signals[SIGNAL_LAST] = { 0 };
 
 G_DEFINE_TYPE (FuEngine, fu_engine, G_TYPE_OBJECT)
 
-#define FU_ENGINE_BATTERY_LEVEL_THRESHOLD	10 /* % */
-
 static void
 fu_engine_emit_changed (FuEngine *self)
 {
@@ -2625,10 +2623,9 @@ fu_engine_device_prepare (FuEngine *self,
 		return FALSE;
 	}
 
-	/* check battery level is sane -- if the device needs a higher
-	 * threshold then it can be checked in FuDevice->prepare() */
+	/* check battery level is sane */
 	if (fu_device_get_battery_level (device) > 0 &&
-	    fu_device_get_battery_level (device) < FU_ENGINE_BATTERY_LEVEL_THRESHOLD) {
+	    fu_device_get_battery_level (device) < fu_device_get_battery_threshold (device)) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,


### PR DESCRIPTION
This allows a device to set a custom 'check battery level is X%' value from
either the plugin or from a quirk.

Type of pull request:
- [X] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
