### PR TITLE
trivial: ci: disable LTO for clang (fixes: #3089)

### DIFF
--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -13,6 +13,8 @@ fi
 
 #evaluate using Ubuntu's buildflags
 #evaluate using Debian/Ubuntu's buildflags
+#disable link time optimization, Ubuntu currently only sets it for GCC
+export DEB_BUILD_MAINT_OPTIONS="optimize=-lto"
 eval "$(dpkg-buildflags --export=sh)"
 #filter out -Bsymbolic-functions
 export LDFLAGS=$(dpkg-buildflags --get LDFLAGS | sed "s/-Wl,-Bsymbolic-functions\s//")


### PR DESCRIPTION
We'll see if this is enough to get it disabled.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
