### PR TITLE
Split out a shared system context

### DIFF
--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-context.h"
+#include "fu-hwids.h"
+#include "fu-quirks.h"
+
+FuContext	*fu_context_new				(void);
+gboolean	 fu_context_load_hwinfo			(FuContext	*self,
+							 GError		**error);
+gboolean	 fu_context_load_quirks			(FuContext	*self,
+							 FuQuirksLoadFlags flags,
+							 GError		**error);
+void		 fu_context_set_runtime_versions	(FuContext	*self,
+							 GHashTable	*runtime_versions);
+void		 fu_context_set_compile_versions	(FuContext	*self,
+							 GHashTable	*compile_versions);
+void		 fu_context_add_firmware_gtype		(FuContext	*self,
+							 const gchar	*id,
+							 GType		 gtype);
+GPtrArray	*fu_context_get_firmware_gtype_ids	(FuContext	*self);
+GType		 fu_context_get_firmware_gtype_by_id	(FuContext	*self,
+							 const gchar	*id);
+GPtrArray	*fu_context_get_udev_subsystems		(FuContext	*self);

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1,0 +1,603 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN				"FuContext"
+
+#include "config.h"
+
+#include "fu-common.h"
+#include "fu-context-private.h"
+#include "fu-hwids.h"
+#include "fu-smbios-private.h"
+
+/**
+ * SECTION:fu-context
+ * @short_description: a context shared between all the plugins and the daemon
+ *
+ * An object that represents the shared system state. This object is shared
+ * between the engine, the plugins and the devices.
+ */
+
+typedef struct {
+	FuHwids			*hwids;
+	FuSmbios		*smbios;
+	FuQuirks		*quirks;
+	GHashTable		*runtime_versions;
+	GHashTable		*compile_versions;
+	GPtrArray		*udev_subsystems;
+	GHashTable		*firmware_gtypes;
+} FuContextPrivate;
+
+enum {
+	SIGNAL_SECURITY_CHANGED,
+	SIGNAL_LAST
+};
+
+static guint signals[SIGNAL_LAST] = { 0 };
+
+G_DEFINE_TYPE_WITH_PRIVATE (FuContext, fu_context, G_TYPE_OBJECT)
+
+#define GET_PRIVATE(o) (fu_context_get_instance_private (o))
+
+/**
+ * fu_context_get_smbios_string:
+ * @self: A #FuContext
+ * @structure_type: A SMBIOS structure type, e.g. %FU_SMBIOS_STRUCTURE_TYPE_BIOS
+ * @offset: A SMBIOS offset
+ *
+ * Gets a hardware SMBIOS string.
+ *
+ * The @type and @offset can be referenced from the DMTF SMBIOS specification:
+ * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.1.1.pdf
+ *
+ * Returns: A string, or %NULL
+ *
+ * Since: 1.6.0
+ **/
+const gchar *
+fu_context_get_smbios_string (FuContext *self, guint8 structure_type, guint8 offset)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	return fu_smbios_get_string (priv->smbios, structure_type, offset, NULL);
+}
+
+/**
+ * fu_context_get_smbios_data:
+ * @self: A #FuContext
+ * @structure_type: A SMBIOS structure type, e.g. %FU_SMBIOS_STRUCTURE_TYPE_BIOS
+ *
+ * Gets a hardware SMBIOS data.
+ *
+ * Returns: (transfer full): A #GBytes, or %NULL
+ *
+ * Since: 1.6.0
+ **/
+GBytes *
+fu_context_get_smbios_data (FuContext *self, guint8 structure_type)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	return fu_smbios_get_data (priv->smbios, structure_type, NULL);
+}
+
+/**
+ * fu_context_get_smbios_integer:
+ * @self: A #FuContext
+ * @type: A structure type, e.g. %FU_SMBIOS_STRUCTURE_TYPE_BIOS
+ * @offset: A structure offset
+ *
+ * Reads an integer value from the SMBIOS string table of a specific structure.
+ *
+ * The @type and @offset can be referenced from the DMTF SMBIOS specification:
+ * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.1.1.pdf
+ *
+ * Returns: an integer, or %G_MAXUINT if invalid or not found
+ *
+ * Since: 1.6.0
+ **/
+guint
+fu_context_get_smbios_integer (FuContext *self, guint8 type, guint8 offset)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), G_MAXUINT);
+	return fu_smbios_get_integer (priv->smbios, type, offset, NULL);
+}
+
+/**
+ * fu_context_has_hwid_guid:
+ * @self: A #FuContext
+ * @guid: A GUID, e.g. `059eb22d-6dc7-59af-abd3-94bbe017f67c`
+ *
+ * Finds out if a hardware GUID exists.
+ *
+ * Returns: %TRUE if the GUID exists
+ *
+ * Since: 1.6.0
+ **/
+gboolean
+fu_context_has_hwid_guid (FuContext *self, const gchar *guid)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), FALSE);
+	return fu_hwids_has_guid (priv->hwids, guid);
+}
+
+/**
+ * fu_context_get_hwid_guids:
+ * @self: A #FuContext
+ *
+ * Returns all the HWIDs defined in the system. All hardware IDs on a
+ * specific system can be shown using the `fwupdmgr hwids` command.
+ *
+ * Returns: (transfer none) (element-type utf8): An array of GUIDs
+ *
+ * Since: 1.6.0
+ **/
+GPtrArray *
+fu_context_get_hwid_guids (FuContext *self)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	return fu_hwids_get_guids (priv->hwids);
+}
+
+/**
+ * fu_context_get_hwid_value:
+ * @self: A #FuContext
+ * @key: A DMI ID, e.g. `BiosVersion`
+ *
+ * Gets the cached value for one specific key that is valid ASCII and suitable
+ * for display.
+ *
+ * Returns: the string, e.g. `1.2.3`, or %NULL if not found
+ *
+ * Since: 1.6.0
+ **/
+const gchar *
+fu_context_get_hwid_value (FuContext *self, const gchar *key)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	g_return_val_if_fail (key != NULL, NULL);
+	return fu_hwids_get_value (priv->hwids, key);
+}
+
+/**
+ * fu_context_get_hwid_replace_value:
+ * @self: A #FuContext
+ * @keys: A key, e.g. `HardwareID-3` or %FU_HWIDS_KEY_PRODUCT_SKU
+ * @error: A #GError or %NULL
+ *
+ * Gets the replacement value for a specific key. All hardware IDs on a
+ * specific system can be shown using the `fwupdmgr hwids` command.
+ *
+ * Returns: (transfer full): a string, or %NULL for error.
+ *
+ * Since: 1.6.0
+ **/
+gchar *
+fu_context_get_hwid_replace_value (FuContext *self, const gchar *keys, GError **error)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	g_return_val_if_fail (keys != NULL, NULL);
+	return fu_hwids_get_replace_values (priv->hwids, keys, error);
+}
+
+/**
+ * fu_context_add_runtime_version:
+ * @self: A #FuContext
+ * @component_id: An AppStream component id, e.g. "org.gnome.Software"
+ * @version: A version string, e.g. "1.2.3"
+ *
+ * Sets a runtime version of a specific dependency.
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_add_runtime_version (FuContext *self,
+				const gchar *component_id,
+				const gchar *version)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (component_id != NULL);
+	g_return_if_fail (version != NULL);
+
+	if (priv->runtime_versions == NULL)
+		return;
+	g_hash_table_insert (priv->runtime_versions,
+			     g_strdup (component_id),
+			     g_strdup (version));
+}
+
+/**
+ * fu_context_set_runtime_versions:
+ * @self: A #FuContext
+ * @runtime_versions: A #GHashTables
+ *
+ * Sets the runtime versions for a plugin
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_set_runtime_versions (FuContext *self, GHashTable *runtime_versions)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (runtime_versions != NULL);
+	priv->runtime_versions = g_hash_table_ref (runtime_versions);
+}
+
+/**
+ * fu_context_add_compile_version:
+ * @self: A #FuContext
+ * @component_id: An AppStream component id, e.g. "org.gnome.Software"
+ * @version: A version string, e.g. "1.2.3"
+ *
+ * Sets a compile-time version of a specific dependency.
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_add_compile_version (FuContext *self,
+				const gchar *component_id,
+				const gchar *version)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (component_id != NULL);
+	g_return_if_fail (version != NULL);
+
+	if (priv->compile_versions == NULL)
+		return;
+	g_hash_table_insert (priv->compile_versions,
+			     g_strdup (component_id),
+			     g_strdup (version));
+}
+
+/**
+ * fu_context_set_compile_versions:
+ * @self: A #FuContext
+ * @compile_versions: A #GHashTables
+ *
+ * Sets the compile time versions for a plugin
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_set_compile_versions (FuContext *self, GHashTable *compile_versions)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (compile_versions != NULL);
+	priv->compile_versions = g_hash_table_ref (compile_versions);
+}
+
+/**
+ * fu_context_add_udev_subsystem:
+ * @self: a #FuContext
+ * @subsystem: a subsystem name, e.g. `pciport`
+ *
+ * Registers the udev subsystem to be watched by the daemon.
+ *
+ * Plugins can use this method only in fu_plugin_init()
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_add_udev_subsystem (FuContext *self, const gchar *subsystem)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (subsystem != NULL);
+
+	for (guint i = 0; i < priv->udev_subsystems->len; i++) {
+		const gchar *subsystem_tmp = g_ptr_array_index (priv->udev_subsystems, i);
+		if (g_strcmp0 (subsystem_tmp, subsystem) == 0)
+			return;
+	}
+	g_debug ("added udev subsystem watch of %s", subsystem);
+	g_ptr_array_add (priv->udev_subsystems, g_strdup (subsystem));
+}
+
+/**
+ * fu_context_get_udev_subsystems:
+ * @self: A #FuContext
+ *
+ * Gets the udev subsystems required by all plugins.
+ *
+ * Returns: (transfer none) (element-type utf8): List of subsystems
+ *
+ * Since: 1.6.0
+ **/
+GPtrArray *
+fu_context_get_udev_subsystems (FuContext *self)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+	return priv->udev_subsystems;
+}
+
+/**
+ * fu_context_add_firmware_gtype:
+ * @self: a #FuContext
+ * @id: (nullable): An optional string describing the type, e.g. "ihex"
+ * @gtype: a #GType e.g. `FU_TYPE_FOO_FIRMWARE`
+ *
+ * Adds a firmware #GType which is used when creating devices. If @id is not
+ * specified then it is guessed using the #GType name.
+ *
+ * Plugins can use this method only in fu_plugin_init()
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_add_firmware_gtype (FuContext *self, const gchar *id, GType gtype)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (id != NULL);
+	g_return_if_fail (gtype != G_TYPE_INVALID);
+	g_hash_table_insert (priv->firmware_gtypes, g_strdup (id), GSIZE_TO_POINTER (gtype));
+}
+
+/**
+ * fu_context_get_firmware_gtype_by_id:
+ * @self: a #FuContext
+ * @id: An string describing the type, e.g. "ihex"
+ *
+ * Returns the #GType using the firmware @id.
+ *
+ * Returns: a #GType, or %G_TYPE_INVALID
+ *
+ * Since: 1.6.0
+ **/
+GType
+fu_context_get_firmware_gtype_by_id (FuContext *self, const gchar *id)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), G_TYPE_INVALID);
+	g_return_val_if_fail (id != NULL, G_TYPE_INVALID);
+	return GPOINTER_TO_SIZE (g_hash_table_lookup (priv->firmware_gtypes, id));
+}
+
+static gint
+fu_context_gtypes_sort_cb (gconstpointer a, gconstpointer b)
+{
+	const gchar *stra = *((const gchar **) a);
+	const gchar *strb = *((const gchar **) b);
+	return g_strcmp0 (stra, strb);
+}
+
+/**
+ * fu_context_get_firmware_gtype_ids:
+ * @self: a #FuContext
+ *
+ * Returns all the firmware #GType IDs.
+ *
+ * Returns: (transfer none) (element-type utf8): List of subsystems
+ *
+ * Since: 1.6.0
+ **/
+GPtrArray *
+fu_context_get_firmware_gtype_ids (FuContext *self)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	GPtrArray *firmware_gtypes = g_ptr_array_new_with_free_func (g_free);
+	g_autoptr(GList) keys = g_hash_table_get_keys (priv->firmware_gtypes);
+
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+
+	for (GList *l = keys; l != NULL; l = l->next) {
+		const gchar *id = l->data;
+		g_ptr_array_add (firmware_gtypes, g_strdup (id));
+	}
+	g_ptr_array_sort (firmware_gtypes, fu_context_gtypes_sort_cb);
+	return firmware_gtypes;
+}
+
+/**
+ * fu_context_add_quirk_key:
+ * @self: a #FuContext
+ * @key: A quirk string, e.g. `DfuVersion`
+ *
+ * Adds a possible quirk key. If added by a plugin it should be namespaced
+ * using the plugin name, where possible.
+ *
+ * Plugins can use this method only in fu_plugin_init()
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_add_quirk_key (FuContext *self, const gchar *key)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_return_if_fail (key != NULL);
+	if (priv->quirks == NULL)
+		return;
+	fu_quirks_add_possible_key (priv->quirks, key);
+}
+
+/**
+ * fu_context_lookup_quirk_by_id:
+ * @self: A #FuContext
+ * @guid: GUID to lookup
+ * @key: An ID to match the entry, e.g. "Summary"
+ *
+ * Looks up an entry in the hardware database using a string value.
+ *
+ * Returns: (transfer none): values from the database, or %NULL if not found
+ *
+ * Since: 1.6.0
+ **/
+const gchar *
+fu_context_lookup_quirk_by_id (FuContext *self, const gchar *guid, const gchar *key)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), NULL);
+
+	/* exact ID */
+	return fu_quirks_lookup_by_id (priv->quirks, guid, key);
+}
+
+/**
+ * fu_context_lookup_quirk_by_id_iter:
+ * @self: A #FuContext
+ * @guid: GUID to lookup
+ * @iter_cb: (scope async): A #FuContextLookupIter
+ * @user_data: user data passed to @iter_cb
+ *
+ * Looks up all entries in the hardware database using a GUID value.
+ *
+ * Returns: %TRUE if the ID was found, and @iter was called
+ *
+ * Since: 1.6.0
+ **/
+gboolean
+fu_context_lookup_quirk_by_id_iter (FuContext *self, const gchar *guid,
+				    FuContextLookupIter iter_cb, gpointer user_data)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_CONTEXT (self), FALSE);
+	g_return_val_if_fail (guid != NULL, FALSE);
+	g_return_val_if_fail (iter_cb != NULL, FALSE);
+	return fu_quirks_lookup_by_id_iter (priv->quirks, guid, (FuQuirksIter) iter_cb, user_data);
+}
+
+/**
+ * fu_context_security_changed:
+ * @self: A #FuContext
+ *
+ * Informs the daemon that the HSI state may have changed.
+ *
+ * Since: 1.6.0
+ **/
+void
+fu_context_security_changed (FuContext *self)
+{
+	g_return_if_fail (FU_IS_CONTEXT (self));
+	g_signal_emit (self, signals[SIGNAL_SECURITY_CHANGED], 0);
+}
+
+/**
+ * fu_context_load_hwinfo:
+ * @self: A #FuContext
+ * @error: (nullable): A #GError, or %NULL
+ *
+ * Loads all hardware information parts of the context.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.6.0
+ **/
+gboolean
+fu_context_load_hwinfo (FuContext *self, GError **error)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_autoptr(GError) error_smbios = NULL;
+	g_autoptr(GError) error_hwids = NULL;
+
+	g_return_val_if_fail (FU_IS_CONTEXT (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	if (!fu_smbios_setup (priv->smbios, &error_smbios))
+		g_warning ("Failed to load SMBIOS: %s", error_smbios->message);
+	if (!fu_hwids_setup (priv->hwids, priv->smbios, &error_hwids))
+		g_warning ("Failed to load HWIDs: %s", error_hwids->message);
+
+	/* always */
+	return TRUE;
+}
+
+/**
+ * fu_context_load_quirks:
+ * @self: A #FuContext
+ * @error: (nullable): A #GError, or %NULL
+ *
+ * Loads all quirks into the context.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.6.0
+ **/
+gboolean
+fu_context_load_quirks (FuContext *self, FuQuirksLoadFlags flags, GError **error)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	g_autoptr(GError) error_local = NULL;
+
+	g_return_val_if_fail (FU_IS_CONTEXT (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	/* rebuild silo if required */
+	if (!fu_quirks_load (priv->quirks, flags, &error_local))
+		g_warning ("Failed to load quirks: %s", error_local->message);
+
+	/* always */
+	return TRUE;
+}
+
+static void
+fu_context_finalize (GObject *object)
+{
+	FuContext *self = FU_CONTEXT (object);
+	FuContextPrivate *priv = GET_PRIVATE (self);
+
+	g_object_unref (priv->hwids);
+	g_object_unref (priv->quirks);
+	g_object_unref (priv->smbios);
+	g_hash_table_unref (priv->firmware_gtypes);
+	g_ptr_array_unref (priv->udev_subsystems);
+
+	G_OBJECT_CLASS (fu_context_parent_class)->finalize (object);
+}
+
+static void
+fu_context_class_init (FuContextClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	signals[SIGNAL_SECURITY_CHANGED] =
+		g_signal_new ("security-changed",
+			      G_TYPE_FROM_CLASS (object_class), G_SIGNAL_RUN_LAST,
+			      G_STRUCT_OFFSET (FuContextClass, security_changed),
+			      NULL, NULL, g_cclosure_marshal_VOID__VOID,
+			      G_TYPE_NONE, 0);
+
+	object_class->finalize = fu_context_finalize;
+}
+
+static void
+fu_context_init (FuContext *self)
+{
+	FuContextPrivate *priv = GET_PRIVATE (self);
+	priv->smbios = fu_smbios_new ();
+	priv->hwids = fu_hwids_new ();
+	priv->udev_subsystems = g_ptr_array_new_with_free_func (g_free);
+	priv->firmware_gtypes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+	priv->quirks = fu_quirks_new ();
+}
+
+/**
+ * fu_context_new:
+ *
+ * Creates a new #FuContext
+ *
+ * Returns: the object
+ *
+ * Since: 1.6.0
+ **/
+FuContext *
+fu_context_new (void)
+{
+	return FU_CONTEXT (g_object_new (FU_TYPE_CONTEXT, NULL));
+}

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+#define FU_TYPE_CONTEXT (fu_context_get_type ())
+G_DECLARE_DERIVABLE_TYPE (FuContext, fu_context, FU, CONTEXT, GObject)
+
+struct _FuContextClass {
+	GObjectClass	 parent_class;
+	/* signals */
+	void		 (* security_changed)		(FuContext	*self);
+	/*< private >*/
+	gpointer	 padding[30];
+};
+
+typedef void	(*FuContextLookupIter)			(FuContext	*self,
+							 const gchar	*key,
+							 const gchar	*value,
+							 gpointer	 user_data);
+
+const gchar	*fu_context_get_smbios_string		(FuContext	*self,
+							 guint8		 structure_type,
+							 guint8		 offset);
+guint		 fu_context_get_smbios_integer		(FuContext	*self,
+							 guint8		 type,
+							 guint8		 offset);
+GBytes		*fu_context_get_smbios_data		(FuContext	*self,
+							 guint8		 structure_type);
+gboolean	 fu_context_has_hwid_guid		(FuContext	*self,
+							 const gchar	*guid);
+GPtrArray	*fu_context_get_hwid_guids		(FuContext	*self);
+const gchar	*fu_context_get_hwid_value		(FuContext	*self,
+							 const gchar	*key);
+gchar		*fu_context_get_hwid_replace_value	(FuContext	*self,
+							 const gchar	*keys,
+							 GError		**error)
+							 G_GNUC_WARN_UNUSED_RESULT;
+void		 fu_context_add_runtime_version		(FuContext	*self,
+							 const gchar	*component_id,
+							 const gchar	*version);
+void		 fu_context_add_compile_version		(FuContext	*self,
+							 const gchar	*component_id,
+							 const gchar	*version);
+void		 fu_context_add_udev_subsystem		(FuContext	*self,
+							 const gchar	*subsystem);
+const gchar	*fu_context_lookup_quirk_by_id		(FuContext	*self,
+							 const gchar	*guid,
+							 const gchar	*key);
+gboolean	 fu_context_lookup_quirk_by_id_iter	(FuContext	*self,
+							 const gchar	*guid,
+							 FuContextLookupIter iter_cb,
+							 gpointer	 user_data);
+void		 fu_context_add_quirk_key		(FuContext	*self,
+							 const gchar	*key);
+void		 fu_context_security_changed		(FuContext	*self);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -9,8 +9,8 @@
 #include <glib-object.h>
 #include <fwupd.h>
 
+#include "fu-context.h"
 #include "fu-firmware.h"
-#include "fu-quirks.h"
 #include "fu-common-version.h"
 #include "fu-security-attrs.h"
 
@@ -344,9 +344,9 @@ void		 fu_device_set_progress_full		(FuDevice	*self,
 							 gsize		 progress_total);
 void		 fu_device_sleep_with_progress		(FuDevice	*self,
 							 guint		 delay_secs);
-void		 fu_device_set_quirks			(FuDevice	*self,
-							 FuQuirks	*quirks);
-FuQuirks	*fu_device_get_quirks			(FuDevice	*self);
+void		 fu_device_set_context			(FuDevice	*self,
+							 FuContext	*ctx);
+FuContext	*fu_device_get_context			(FuDevice	*self);
 FwupdRelease	*fu_device_get_release_default		(FuDevice	*self);
 GType		 fu_device_get_specialized_gtype	(FuDevice	*self);
 void		 fu_device_add_internal_flag		(FuDevice	*self,

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -6,25 +6,12 @@
 
 #pragma once
 
-#include "fu-quirks.h"
+#include "fu-context.h"
 #include "fu-plugin.h"
 #include "fu-security-attrs.h"
-#include "fu-smbios.h"
 
-FuPlugin	*fu_plugin_new				(void);
+FuPlugin	*fu_plugin_new				(FuContext	*ctx);
 gboolean	 fu_plugin_is_open			(FuPlugin	*self);
-void		 fu_plugin_set_hwids			(FuPlugin	*self,
-							 FuHwids	*hwids);
-void		 fu_plugin_set_udev_subsystems		(FuPlugin	*self,
-							 GPtrArray	*udev_subsystems);
-void		 fu_plugin_set_quirks			(FuPlugin	*self,
-							 FuQuirks	*quirks);
-void		 fu_plugin_set_runtime_versions		(FuPlugin	*self,
-							 GHashTable	*runtime_versions);
-void		 fu_plugin_set_compile_versions		(FuPlugin	*self,
-							 GHashTable	*compile_versions);
-void		 fu_plugin_set_smbios			(FuPlugin	*self,
-							 FuSmbios	*smbios);
 guint		 fu_plugin_get_order			(FuPlugin	*self);
 void		 fu_plugin_set_order			(FuPlugin	*self,
 							 guint		 order);

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -8,6 +8,8 @@
 
 #include "fu-plugin.h"
 #include "fu-device.h"
+#include "fu-hwids.h"
+#include "fu-quirks.h"
 #include "fu-security-attrs.h"
 
 /* for in-tree plugins only */

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -15,10 +15,9 @@
 #include "fu-common.h"
 #include "fu-common-guid.h"
 #include "fu-common-version.h"
+#include "fu-context.h"
 #include "fu-device.h"
 #include "fu-device-locker.h"
-#include "fu-quirks.h"
-#include "fu-hwids.h"
 #include "fu-usb-device.h"
 //#include "fu-hid-device.h"
 #ifdef HAVE_GUDEV
@@ -52,10 +51,6 @@ struct _FuPluginClass
 	gboolean	 (* check_supported)		(FuPlugin	*self,
 							 const gchar	*guid);
 	void		 (* rules_changed)		(FuPlugin	*self);
-	gboolean	 (* add_firmware_gtype)		(FuPlugin	*self,
-							 const gchar	*id,
-							 GType		 gtype);
-	void		 (* security_changed)		(FuPlugin	*self);
 	/*< private >*/
 	gpointer	padding[20];
 };
@@ -102,6 +97,7 @@ const gchar	*fu_plugin_get_name			(FuPlugin	*self);
 FuPluginData	*fu_plugin_get_data			(FuPlugin	*self);
 FuPluginData	*fu_plugin_alloc_data			(FuPlugin	*self,
 							 gsize		 data_sz);
+FuContext	*fu_plugin_get_context			(FuPlugin	*self);
 void		 fu_plugin_set_build_hash		(FuPlugin	*self,
 							 const gchar	*build_hash);
 void		 fu_plugin_device_add			(FuPlugin	*self,
@@ -110,14 +106,11 @@ void		 fu_plugin_device_remove		(FuPlugin	*self,
 							 FuDevice	*device);
 void		 fu_plugin_device_register		(FuPlugin	*self,
 							 FuDevice	*device);
-void		 fu_plugin_security_changed		(FuPlugin	*self);
 void		 fu_plugin_set_device_gtype		(FuPlugin	*self,
 							 GType		 device_gtype);
 void		 fu_plugin_add_firmware_gtype		(FuPlugin	*self,
 							 const gchar	*id,
 							 GType		 gtype);
-void		 fu_plugin_add_possible_quirk_key	(FuPlugin	*self,
-							 const gchar	*possible_key);
 gpointer	 fu_plugin_cache_lookup			(FuPlugin	*self,
 							 const gchar	*id);
 void		 fu_plugin_cache_remove			(FuPlugin	*self,
@@ -125,33 +118,10 @@ void		 fu_plugin_cache_remove			(FuPlugin	*self,
 void		 fu_plugin_cache_add			(FuPlugin	*self,
 							 const gchar	*id,
 							 gpointer	 dev);
-gboolean	 fu_plugin_check_hwid			(FuPlugin	*self,
-							 const gchar	*hwid);
-gchar		*fu_plugin_get_hwid_replace_value	(FuPlugin	*self,
-							 const gchar	*keys,
-							 GError		**error)
-							 G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray	*fu_plugin_get_devices			(FuPlugin	*self);
-GPtrArray	*fu_plugin_get_hwids			(FuPlugin	*self);
-const gchar	*fu_plugin_get_dmi_value		(FuPlugin	*self,
-							 const gchar	*dmi_id);
-const gchar	*fu_plugin_get_smbios_string		(FuPlugin	*self,
-							 guint8		 structure_type,
-							 guint8		 offset);
-GBytes		*fu_plugin_get_smbios_data		(FuPlugin	*self,
-							 guint8		 structure_type);
 void		 fu_plugin_add_rule			(FuPlugin	*self,
 							 FuPluginRule	 rule,
 							 const gchar	*name);
-void		 fu_plugin_add_udev_subsystem		(FuPlugin	*self,
-							 const gchar	*subsystem);
-FuQuirks	*fu_plugin_get_quirks			(FuPlugin	*self);
-const gchar	*fu_plugin_lookup_quirk_by_id		(FuPlugin	*self,
-							 const gchar	*group,
-							 const gchar	*key);
-guint64		 fu_plugin_lookup_quirk_by_id_as_uint64	(FuPlugin	*self,
-							 const gchar	*group,
-							 const gchar	*key);
 void		 fu_plugin_add_report_metadata		(FuPlugin	*self,
 							 const gchar	*key,
 							 const gchar	*value);
@@ -159,11 +129,5 @@ gchar		*fu_plugin_get_config_value		(FuPlugin	*self,
 							 const gchar	*key);
 gboolean	 fu_plugin_get_config_value_boolean	(FuPlugin	*self,
 							 const gchar	*key);
-void		 fu_plugin_add_runtime_version		(FuPlugin	*self,
-							 const gchar	*component_id,
-							 const gchar	*version);
-void		 fu_plugin_add_compile_version		(FuPlugin	*self,
-							 const gchar	*component_id,
-							 const gchar	*version);
 gboolean	 fu_plugin_has_custom_flag		(FuPlugin	*self,
 							 const gchar	*flag);

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -16,12 +16,16 @@ G_DECLARE_FINAL_TYPE (FuQuirks, fu_quirks, FU, QUIRKS, GObject)
  * FuQuirksLoadFlags:
  * @FU_QUIRKS_LOAD_FLAG_NONE:		No flags set
  * @FU_QUIRKS_LOAD_FLAG_READONLY_FS:	Ignore readonly filesystem errors
+ * @FU_QUIRKS_LOAD_FLAG_NO_CACHE:	Do not save to a persistent cache
+ * @FU_QUIRKS_LOAD_FLAG_NO_VERIFY:	Do not check the key files for errors
  *
  * The flags to use when loading quirks.
  **/
 typedef enum {
 	FU_QUIRKS_LOAD_FLAG_NONE		= 0,
 	FU_QUIRKS_LOAD_FLAG_READONLY_FS		= 1 << 0,
+	FU_QUIRKS_LOAD_FLAG_NO_CACHE		= 1 << 1,
+	FU_QUIRKS_LOAD_FLAG_NO_VERIFY		= 1 << 2,
 	/*< private >*/
 	FU_QUIRKS_LOAD_FLAG_LAST
 } FuQuirksLoadFlags;

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -20,6 +20,7 @@
 #include <libfwupdplugin/fu-common-cab.h>
 #include <libfwupdplugin/fu-common-guid.h>
 #include <libfwupdplugin/fu-common-version.h>
+#include <libfwupdplugin/fu-context.h>
 #include <libfwupdplugin/fu-device.h>
 #include <libfwupdplugin/fu-device-locker.h>
 #include <libfwupdplugin/fu-device-metadata.h>
@@ -28,14 +29,11 @@
 #include <libfwupdplugin/fu-firmware.h>
 #include <libfwupdplugin/fu-firmware-common.h>
 #include <libfwupdplugin/fu-fmap-firmware.h>
-#include <libfwupdplugin/fu-hwids.h>
 #include <libfwupdplugin/fu-ihex-firmware.h>
 #include <libfwupdplugin/fu-io-channel.h>
 #include <libfwupdplugin/fu-plugin.h>
 #include <libfwupdplugin/fu-plugin-vfuncs.h>
-#include <libfwupdplugin/fu-quirks.h>
 #include <libfwupdplugin/fu-security-attrs.h>
-#include <libfwupdplugin/fu-smbios.h>
 #include <libfwupdplugin/fu-srec-firmware.h>
 #include <libfwupdplugin/fu-efi-signature.h>
 #include <libfwupdplugin/fu-efi-signature-list.h>

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -58,12 +58,6 @@ LIBFWUPDPLUGIN_0.8.0 {
   local: *;
 } LIBFWUPDPLUGIN_0.7.2;
 
-LIBFWUPDPLUGIN_0.9.1 {
-  global:
-    fu_plugin_check_hwid;
-  local: *;
-} LIBFWUPDPLUGIN_0.8.0;
-
 LIBFWUPDPLUGIN_0.9.3 {
   global:
     fu_hwids_get_guid;
@@ -76,7 +70,7 @@ LIBFWUPDPLUGIN_0.9.3 {
     fu_hwids_new;
     fu_hwids_setup;
   local: *;
-} LIBFWUPDPLUGIN_0.9.1;
+} LIBFWUPDPLUGIN_0.8.0;
 
 LIBFWUPDPLUGIN_0.9.5 {
   global:
@@ -98,17 +92,13 @@ LIBFWUPDPLUGIN_0.9.7 {
     fu_device_set_metadata_boolean;
     fu_device_set_metadata_integer;
     fu_plugin_device_register;
-    fu_plugin_get_dmi_value;
     fu_plugin_runner_device_register;
-    fu_plugin_set_hwids;
   local: *;
 } LIBFWUPDPLUGIN_0.9.5;
 
 LIBFWUPDPLUGIN_0.9.8 {
   global:
     fu_device_to_string;
-    fu_plugin_get_smbios_data;
-    fu_plugin_get_smbios_string;
   local: *;
 } LIBFWUPDPLUGIN_0.9.7;
 
@@ -123,7 +113,6 @@ LIBFWUPDPLUGIN_1.0.0 {
     fu_plugin_has_rule;
     fu_plugin_set_order;
     fu_plugin_set_priority;
-    fu_plugin_set_smbios;
     fu_smbios_get_data;
     fu_smbios_get_string;
     fu_smbios_get_type;
@@ -138,9 +127,6 @@ LIBFWUPDPLUGIN_1.0.0 {
 LIBFWUPDPLUGIN_1.0.1 {
   global:
     fu_chunk_array_to_string;
-    fu_plugin_get_quirks;
-    fu_plugin_lookup_quirk_by_id;
-    fu_plugin_set_quirks;
     fu_quirks_get_type;
     fu_quirks_load;
     fu_quirks_lookup_by_id;
@@ -166,11 +152,9 @@ LIBFWUPDPLUGIN_1.0.3 {
     fu_common_write_uint16;
     fu_common_write_uint32;
     fu_device_get_progress;
-    fu_device_get_quirks;
     fu_device_get_status;
     fu_device_set_progress;
     fu_device_set_progress_full;
-    fu_device_set_quirks;
     fu_device_set_status;
     fu_usb_device_is_open;
   local: *;
@@ -196,15 +180,6 @@ LIBFWUPDPLUGIN_1.0.6 {
   local: *;
 } LIBFWUPDPLUGIN_1.0.5;
 
-LIBFWUPDPLUGIN_1.0.7 {
-  global:
-    fu_plugin_add_compile_version;
-    fu_plugin_add_runtime_version;
-    fu_plugin_set_compile_versions;
-    fu_plugin_set_runtime_versions;
-  local: *;
-} LIBFWUPDPLUGIN_1.0.6;
-
 LIBFWUPDPLUGIN_1.0.8 {
   global:
     fu_common_error_array_get_best;
@@ -227,7 +202,7 @@ LIBFWUPDPLUGIN_1.0.8 {
     fu_plugin_name_compare;
     fu_plugin_order_compare;
   local: *;
-} LIBFWUPDPLUGIN_1.0.7;
+} LIBFWUPDPLUGIN_1.0.6;
 
 LIBFWUPDPLUGIN_1.0.9 {
   global:
@@ -251,7 +226,6 @@ LIBFWUPDPLUGIN_1.1.1 {
   global:
     fu_device_get_priority;
     fu_device_set_priority;
-    fu_plugin_get_hwids;
     fu_plugin_get_priority;
   local: *;
 } LIBFWUPDPLUGIN_1.1.0;
@@ -281,15 +255,12 @@ LIBFWUPDPLUGIN_1.1.2 {
     fu_device_set_physical_id;
     fu_device_set_poll_interval;
     fu_device_setup;
-    fu_plugin_add_udev_subsystem;
-    fu_plugin_lookup_quirk_by_id_as_uint64;
     fu_plugin_runner_device_removed;
     fu_plugin_runner_update_attach;
     fu_plugin_runner_update_cleanup;
     fu_plugin_runner_update_detach;
     fu_plugin_runner_update_prepare;
     fu_plugin_runner_update_reload;
-    fu_plugin_set_udev_subsystems;
     fu_udev_device_emit_changed;
     fu_udev_device_get_dev;
     fu_udev_device_get_model;
@@ -452,7 +423,6 @@ LIBFWUPDPLUGIN_1.3.3 {
     fu_firmware_set_version;
     fu_firmware_write_file;
     fu_plugin_add_firmware_gtype;
-    fu_plugin_get_hwid_replace_value;
     fu_plugin_set_device_gtype;
     fu_quirks_lookup_by_id_iter;
     fu_udev_device_get_fd;
@@ -606,7 +576,6 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_fmap_firmware_new;
     fu_plugin_runner_add_security_attrs;
     fu_plugin_runner_device_added;
-    fu_plugin_security_changed;
     fu_security_attrs_append;
     fu_security_attrs_calculate_hsi;
     fu_security_attrs_depsolve;
@@ -737,7 +706,6 @@ LIBFWUPDPLUGIN_1.5.8 {
     fu_device_get_battery_level;
     fu_device_set_backend_id;
     fu_device_set_battery_level;
-    fu_plugin_add_possible_quirk_key;
     fu_quirks_add_possible_key;
     fu_udev_device_set_logical_id;
   local: *;
@@ -748,11 +716,37 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_byte_array_align_up;
     fu_byte_array_set_size_full;
     fu_common_align_up;
+    fu_context_add_compile_version;
+    fu_context_add_firmware_gtype;
+    fu_context_add_quirk_key;
+    fu_context_add_runtime_version;
+    fu_context_add_udev_subsystem;
+    fu_context_get_firmware_gtype_by_id;
+    fu_context_get_firmware_gtype_ids;
+    fu_context_get_hwid_guids;
+    fu_context_get_hwid_replace_value;
+    fu_context_get_hwid_value;
+    fu_context_get_smbios_data;
+    fu_context_get_smbios_integer;
+    fu_context_get_smbios_string;
+    fu_context_get_type;
+    fu_context_get_udev_subsystems;
+    fu_context_has_hwid_guid;
+    fu_context_load_hwinfo;
+    fu_context_load_quirks;
+    fu_context_lookup_quirk_by_id;
+    fu_context_lookup_quirk_by_id_iter;
+    fu_context_new;
+    fu_context_security_changed;
+    fu_context_set_compile_versions;
+    fu_context_set_runtime_versions;
     fu_device_add_security_attrs;
     fu_device_get_battery_threshold;
+    fu_device_get_context;
     fu_device_inhibit;
     fu_device_remove_flag;
     fu_device_set_battery_threshold;
+    fu_device_set_context;
     fu_device_uninhibit;
     fu_firmware_add_chunk;
     fu_firmware_build_from_xml;
@@ -777,6 +771,7 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_firmware_set_offset;
     fu_firmware_set_size;
     fu_firmware_write_chunk;
+    fu_plugin_get_context;
     fu_xmlb_builder_insert_kb;
     fu_xmlb_builder_insert_kv;
     fu_xmlb_builder_insert_kx;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -7,6 +7,7 @@ fwupdplugin_src = [
   'fu-common-cab.c',
   'fu-common-guid.c',
   'fu-common-version.c',    # fuzzing
+  'fu-context.c',           # fuzzing
   'fu-device-locker.c',     # fuzzing
   'fu-device.c',            # fuzzing
   'fu-dfu-firmware.c',      # fuzzing
@@ -15,13 +16,13 @@ fwupdplugin_src = [
   'fu-firmware-common.c',   # fuzzing
   'fu-dfuse-firmware.c',    # fuzzing
   'fu-fmap-firmware.c',     # fuzzing
-  'fu-hwids.c',
+  'fu-hwids.c',             # fuzzing
   'fu-ihex-firmware.c',     # fuzzing
   'fu-io-channel.c',        # fuzzing
   'fu-plugin.c',
   'fu-quirks.c',            # fuzzing
   'fu-security-attrs.c',
-  'fu-smbios.c',
+  'fu-smbios.c',            # fuzzing
   'fu-srec-firmware.c',     # fuzzing
   'fu-efi-signature.c',
   'fu-efi-signature-list.c',
@@ -40,6 +41,7 @@ fwupdplugin_headers = [
   'fu-common-cab.h',
   'fu-common-guid.h',
   'fu-common-version.h',
+  'fu-context.h',
   'fu-deprecated.h',
   'fu-device.h',
   'fu-device-metadata.h',
@@ -84,6 +86,7 @@ fu_hash = custom_target(
 
 fwupdplugin_headers_private = [
   fu_hash,
+  'fu-context-private.h',
   'fu-device-private.h',
   'fu-plugin-private.h',
   'fu-security-attrs-private.h',
@@ -126,7 +129,8 @@ fwupdplugin = library(
   'fwupdplugin',
   sources : [
     fwupdplugin_src,
-    fwupdplugin_headers
+    fwupdplugin_headers,
+    fwupdplugin_headers_private,
   ],
   soversion : libfwupdplugin_lt_current,
   version : libfwupdplugin_lt_version,

--- a/plugins/ata/fu-plugin-ata.c
+++ b/plugins/ata/fu-plugin-ata.c
@@ -13,7 +13,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "block");
+	fu_context_add_udev_subsystem (ctx, "block");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ATA_DEVICE);
 }

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -73,8 +73,8 @@ fu_bcm57xx_device_probe (FuDevice *device, GError **error)
 	}
 
 	/* we need this even for non-recovery to reset APE */
-	fu_device_set_quirks (FU_DEVICE (self->recovery),
-			      fu_device_get_quirks (FU_DEVICE (self)));
+	fu_device_set_context (FU_DEVICE (self->recovery),
+			       fu_device_get_context (FU_DEVICE (self)));
 	fu_device_incorporate (FU_DEVICE (self->recovery), FU_DEVICE (self));
 	if (!fu_device_probe (FU_DEVICE (self->recovery), error))
 		return FALSE;

--- a/plugins/bcm57xx/fu-plugin-bcm57xx.c
+++ b/plugins/bcm57xx/fu-plugin-bcm57xx.c
@@ -17,8 +17,9 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "pci");
+	fu_context_add_udev_subsystem (ctx, "pci");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_BCM57XX_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "optionrom");

--- a/plugins/bios/fu-plugin-bios.c
+++ b/plugins/bios/fu-plugin-bios.c
@@ -18,9 +18,10 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	const gchar *vendor;
 
-	vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+	vendor = fu_context_get_hwid_value (ctx, FU_HWIDS_KEY_BIOS_VENDOR);
 	if (g_strcmp0 (vendor, "coreboot") == 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,

--- a/plugins/ccgx/fu-plugin-ccgx.c
+++ b/plugins/ccgx/fu-plugin-ccgx.c
@@ -17,13 +17,14 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_CCGX_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_HPI_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_CCGX_DMC_DEVICE);
-	fu_plugin_add_possible_quirk_key (plugin, "CcgxFlashRowSize");
-	fu_plugin_add_possible_quirk_key (plugin, "CcgxFlashSize");
-	fu_plugin_add_possible_quirk_key (plugin, "CcgxImageKind");
+	fu_context_add_quirk_key (ctx, "CcgxFlashRowSize");
+	fu_context_add_quirk_key (ctx, "CcgxFlashSize");
+	fu_context_add_quirk_key (ctx, "CcgxImageKind");
 }

--- a/plugins/cpu/fu-plugin-cpu.c
+++ b/plugins/cpu/fu-plugin-cpu.c
@@ -19,8 +19,9 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	g_autoptr(FuCpuDevice) dev = fu_cpu_device_new ();
-	fu_device_set_quirks (FU_DEVICE (dev), fu_plugin_get_quirks (plugin));
+	fu_device_set_context (FU_DEVICE (dev), ctx);
 	if (!fu_device_probe (FU_DEVICE (dev), error))
 		return FALSE;
 	if (!fu_device_setup (FU_DEVICE (dev), error))

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -24,16 +24,18 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
+
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockBlobBuildOffset");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockBlobMajorOffset");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockBlobMinorOffset");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockBlobVersionOffset");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockBoardMin");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockHubVersionLowest");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockInstallDurationI2C");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockUnlockTarget");
-	fu_plugin_add_possible_quirk_key (plugin, "DellDockVersionLowest");
+	fu_context_add_quirk_key (ctx, "DellDockBlobBuildOffset");
+	fu_context_add_quirk_key (ctx, "DellDockBlobMajorOffset");
+	fu_context_add_quirk_key (ctx, "DellDockBlobMinorOffset");
+	fu_context_add_quirk_key (ctx, "DellDockBlobVersionOffset");
+	fu_context_add_quirk_key (ctx, "DellDockBoardMin");
+	fu_context_add_quirk_key (ctx, "DellDockHubVersionLowest");
+	fu_context_add_quirk_key (ctx, "DellDockInstallDurationI2C");
+	fu_context_add_quirk_key (ctx, "DellDockUnlockTarget");
+	fu_context_add_quirk_key (ctx, "DellDockVersionLowest");
 
 	/* allow these to be built by quirks */
 	g_type_ensure (FU_TYPE_DELL_DOCK_STATUS);
@@ -48,9 +50,10 @@ fu_plugin_dell_dock_create_node (FuPlugin *plugin,
 				 FuDevice *device,
 				 GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
-	fu_device_set_quirks (device, fu_plugin_get_quirks (plugin));
+	fu_device_set_context (device, ctx);
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -121,6 +121,7 @@ static guint8 enclosure_allowlist [] = { 0x03, /* desktop */
 static guint16
 fu_dell_get_system_id (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	const gchar *system_id_str = NULL;
 	guint16 system_id = 0;
@@ -130,8 +131,7 @@ fu_dell_get_system_id (FuPlugin *plugin)
 	if (data->smi_obj->fake_smbios)
 		return 0;
 
-	system_id_str = fu_plugin_get_dmi_value (plugin,
-		FU_HWIDS_KEY_PRODUCT_SKU);
+	system_id_str = fu_context_get_hwid_value (ctx, FU_HWIDS_KEY_PRODUCT_SKU);
 	if (system_id_str != NULL)
 		system_id = g_ascii_strtoull (system_id_str, &endptr, 16);
 	if (system_id == 0 || endptr == system_id_str)
@@ -143,6 +143,7 @@ fu_dell_get_system_id (FuPlugin *plugin)
 static gboolean
 fu_dell_supported (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	g_autoptr(GBytes) de_table = NULL;
 	g_autoptr(GBytes) da_table = NULL;
 	g_autoptr(GBytes) enclosure = NULL;
@@ -151,7 +152,7 @@ fu_dell_supported (FuPlugin *plugin)
 	gsize len;
 
 	/* make sure that Dell SMBIOS methods are available */
-	de_table = fu_plugin_get_smbios_data (plugin, 0xDE);
+	de_table = fu_context_get_smbios_data (ctx, 0xDE);
 	if (de_table == NULL)
 		return FALSE;
 	value = g_bytes_get_data (de_table, &len);
@@ -159,7 +160,7 @@ fu_dell_supported (FuPlugin *plugin)
 		return FALSE;
 	if (*value != 0xDE)
 		return FALSE;
-	da_table = fu_plugin_get_smbios_data (plugin, 0xDA);
+	da_table = fu_context_get_smbios_data (ctx, 0xDA);
 	if (da_table == NULL)
 		return FALSE;
 	da_values = (struct da_structure *) g_bytes_get_data (da_table, &len);
@@ -172,7 +173,7 @@ fu_dell_supported (FuPlugin *plugin)
 	}
 
 	/* only run on intended Dell hw types */
-	enclosure = fu_plugin_get_smbios_data (plugin,
+	enclosure = fu_context_get_smbios_data (ctx,
 					       FU_SMBIOS_STRUCTURE_TYPE_CHASSIS);
 	if (enclosure == NULL)
 		return FALSE;
@@ -440,12 +441,13 @@ fu_plugin_backend_device_added (FuPlugin *plugin,
 gboolean
 fu_plugin_get_results (FuPlugin *plugin, FuDevice *device, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	g_autoptr(GBytes) de_table = NULL;
 	const gchar *tmp = NULL;
 	const guint16 *completion_code;
 	gsize len;
 
-	de_table = fu_plugin_get_smbios_data (plugin, 0xDE);
+	de_table = fu_context_get_smbios_data (ctx, 0xDE);
 	completion_code = g_bytes_get_data (de_table, &len);
 	if (len < 8) {
 		g_set_error (error,
@@ -823,6 +825,7 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	g_autofree gchar *tmp = NULL;
 
@@ -830,7 +833,7 @@ fu_plugin_init (FuPlugin *plugin)
 	tmp = g_strdup_printf ("%d.%d",
 			       smbios_get_library_version_major(),
 			       smbios_get_library_version_minor());
-	fu_plugin_add_runtime_version (plugin, "com.dell.libsmbios", tmp);
+	fu_context_add_runtime_version (ctx, "com.dell.libsmbios", tmp);
 	g_debug ("Using libsmbios %s", tmp);
 
 	data->smi_obj = g_malloc0 (sizeof (FuDellSmiObj));

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -10,6 +10,7 @@
 #include <glib/gstdio.h>
 #include <stdlib.h>
 
+#include "fu-context-private.h"
 #include "fu-device-private.h"
 #include "fu-plugin-private.h"
 #include "fu-plugin-dell.h"
@@ -487,11 +488,12 @@ static void
 fu_test_self_init (FuTest *self)
 {
 	gboolean ret;
+	g_autoptr(FuContext) ctx = fu_context_new ();
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *pluginfn_uefi = NULL;
 	g_autofree gchar *pluginfn_dell = NULL;
 
-	self->plugin_uefi_capsule = fu_plugin_new ();
+	self->plugin_uefi_capsule = fu_plugin_new (ctx);
 	pluginfn_uefi = g_build_filename (PLUGINBUILDDIR, "..", "uefi-capsule",
 					  "libfu_plugin_uefi_capsule." G_MODULE_SUFFIX,
 					  NULL);
@@ -502,7 +504,7 @@ fu_test_self_init (FuTest *self)
 	g_assert_no_error (error);
 	g_assert (ret);
 
-	self->plugin_dell = fu_plugin_new ();
+	self->plugin_dell = fu_plugin_new (ctx);
 	pluginfn_dell = g_build_filename (PLUGINBUILDDIR,
 					  "libfu_plugin_dell." G_MODULE_SUFFIX,
 					  NULL);

--- a/plugins/dfu/fu-dfu-tool.c
+++ b/plugins/dfu/fu-dfu-tool.c
@@ -18,6 +18,7 @@
 #include "fu-dfu-sector.h"
 
 #include "fu-chunk.h"
+#include "fu-context-private.h"
 #include "fu-dfuse-firmware.h"
 #include "fu-device-locker.h"
 
@@ -29,7 +30,7 @@ typedef struct {
 	gboolean		 force;
 	gchar			*device_vid_pid;
 	guint16			 transfer_size;
-	FuQuirks		*quirks;
+	FuContext		*ctx;
 } FuDfuTool;
 
 static void
@@ -40,7 +41,7 @@ fu_dfu_tool_free (FuDfuTool *self)
 	g_free (self->device_vid_pid);
 	if (self->cancellable != NULL)
 		g_object_unref (self->cancellable);
-	g_object_unref (self->quirks);
+	g_object_unref (self->ctx);
 	if (self->cmd_array != NULL)
 		g_ptr_array_unref (self->cmd_array);
 	g_free (self);
@@ -229,7 +230,7 @@ fu_dfu_tool_get_default_device (FuDfuTool *self, GError **error)
 			return NULL;
 		}
 		device = fu_dfu_device_new (usb_device);
-		fu_device_set_quirks (FU_DEVICE (device), self->quirks);
+		fu_device_set_context (FU_DEVICE (device), self->ctx);
 		return device;
 	}
 
@@ -238,7 +239,7 @@ fu_dfu_tool_get_default_device (FuDfuTool *self, GError **error)
 	for (guint i = 0; i < devices->len; i++) {
 		GUsbDevice *usb_device = g_ptr_array_index (devices, i);
 		g_autoptr(FuDfuDevice) device = fu_dfu_device_new (usb_device);
-		fu_device_set_quirks (FU_DEVICE (device), self->quirks);
+		fu_device_set_context (FU_DEVICE (device), self->ctx);
 		if (fu_device_probe (FU_DEVICE (device), NULL))
 			return g_steal_pointer (&device);
 	}
@@ -910,8 +911,8 @@ main (int argc, char *argv[])
 		     fu_dfu_tool_replace_data);
 
 	/* use quirks */
-	self->quirks = fu_quirks_new ();
-	if (!fu_quirks_load (self->quirks, FU_QUIRKS_LOAD_FLAG_NONE, &error)) {
+	self->ctx = fu_context_new ();
+	if (!fu_context_load_quirks (self->ctx, FU_QUIRKS_LOAD_FLAG_NONE, &error)) {
 		/* TRANSLATORS: quirks are device-specific workarounds */
 		g_print ("%s: %s\n", _("Failed to load quirks"), error->message);
 		return EXIT_FAILURE;

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -13,9 +13,10 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_DFU_DEVICE);
-	fu_plugin_add_possible_quirk_key (plugin, "DfuAltName");
-	fu_plugin_add_possible_quirk_key (plugin, "DfuForceTimeout");
-	fu_plugin_add_possible_quirk_key (plugin, "DfuForceVersion");
+	fu_context_add_quirk_key (ctx, "DfuAltName");
+	fu_context_add_quirk_key (ctx, "DfuForceTimeout");
+	fu_context_add_quirk_key (ctx, "DfuForceVersion");
 }

--- a/plugins/elantp/fu-plugin-elantp.c
+++ b/plugins/elantp/fu-plugin-elantp.c
@@ -29,13 +29,14 @@ fu_plugin_device_created (FuPlugin *plugin, FuDevice *dev, GError **error)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "i2c-dev");
-	fu_plugin_add_udev_subsystem (plugin, "hidraw");
+	fu_context_add_udev_subsystem (ctx, "i2c-dev");
+	fu_context_add_udev_subsystem (ctx, "hidraw");
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
-	fu_plugin_add_possible_quirk_key (plugin, "ElantpI2cTargetAddress");
-	fu_plugin_add_possible_quirk_key (plugin, "ElantpIapPassword");
-	fu_plugin_add_possible_quirk_key (plugin, "ElantpIcPageCount");
+	fu_context_add_quirk_key (ctx, "ElantpI2cTargetAddress");
+	fu_context_add_quirk_key (ctx, "ElantpIapPassword");
+	fu_context_add_quirk_key (ctx, "ElantpIcPageCount");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ELANTP_I2C_DEVICE);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_ELANTP_HID_DEVICE);
 }

--- a/plugins/emmc/fu-plugin-emmc.c
+++ b/plugins/emmc/fu-plugin-emmc.c
@@ -13,7 +13,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "block");
+	fu_context_add_udev_subsystem (ctx, "block");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_EMMC_DEVICE);
 }

--- a/plugins/iommu/fu-plugin-iommu.c
+++ b/plugins/iommu/fu-plugin-iommu.c
@@ -15,9 +15,10 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "iommu");
+	fu_context_add_udev_subsystem (ctx, "iommu");
 }
 
 gboolean

--- a/plugins/jabra/fu-plugin-jabra.c
+++ b/plugins/jabra/fu-plugin-jabra.c
@@ -13,9 +13,10 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_JABRA_DEVICE);
-	fu_plugin_add_possible_quirk_key (plugin, "JabraMagic");
+	fu_context_add_quirk_key (ctx, "JabraMagic");
 }
 
 /* slightly weirdly, this takes us from appIDLE back into the actual

--- a/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
+++ b/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
@@ -88,8 +88,9 @@ fu_plugin_linux_lockdown_changed_cb (GFileMonitor *monitor,
 				     gpointer user_data)
 {
 	FuPlugin *plugin = FU_PLUGIN (user_data);
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_linux_lockdown_rescan (plugin);
-	fu_plugin_security_changed (plugin);
+	fu_context_security_changed (ctx);
 }
 
 gboolean

--- a/plugins/linux-swap/fu-plugin-linux-swap.c
+++ b/plugins/linux-swap/fu-plugin-linux-swap.c
@@ -41,7 +41,8 @@ fu_plugin_linux_swap_changed_cb (GFileMonitor *monitor,
 				 gpointer user_data)
 {
 	FuPlugin *plugin = FU_PLUGIN (user_data);
-	fu_plugin_security_changed (plugin);
+	FuContext *ctx = fu_plugin_get_context (plugin);
+	fu_context_security_changed (ctx);
 }
 
 gboolean

--- a/plugins/linux-tainted/fu-plugin-linux-tainted.c
+++ b/plugins/linux-tainted/fu-plugin-linux-tainted.c
@@ -40,7 +40,8 @@ fu_plugin_linux_tainted_changed_cb (GFileMonitor *monitor,
 				 gpointer user_data)
 {
 	FuPlugin *plugin = FU_PLUGIN (user_data);
-	fu_plugin_security_changed (plugin);
+	FuContext *ctx = fu_plugin_get_context (plugin);
+	fu_context_security_changed (ctx);
 }
 
 gboolean

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -33,8 +33,9 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "hidraw");
+	fu_context_add_udev_subsystem (ctx, "hidraw");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "unifying");
 
 	/* register the custom types */

--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -43,9 +43,10 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "msr");
+	fu_context_add_udev_subsystem (ctx, "msr");
 }
 
 gboolean

--- a/plugins/nvme/fu-plugin-nvme.c
+++ b/plugins/nvme/fu-plugin-nvme.c
@@ -13,7 +13,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "nvme");
+	fu_context_add_udev_subsystem (ctx, "nvme");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_NVME_DEVICE);
 }

--- a/plugins/optionrom/fu-plugin-optionrom.c
+++ b/plugins/optionrom/fu-plugin-optionrom.c
@@ -13,8 +13,9 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "pci");
+	fu_context_add_udev_subsystem (ctx, "pci");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "udev");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_OPTIONROM_DEVICE);
 }

--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -21,10 +21,11 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *priv = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "pci");
-	fu_plugin_add_possible_quirk_key (plugin, "PciBcrAddr");
+	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_context_add_quirk_key (ctx, "PciBcrAddr");
 
 	/* this is true except for some Atoms */
 	priv->bcr_addr = 0xdc;

--- a/plugins/pci-mei/fu-plugin-pci-mei.c
+++ b/plugins/pci-mei/fu-plugin-pci-mei.c
@@ -51,9 +51,10 @@ fu_mei_hfsts_to_string (FuPlugin *plugin, guint idt, GString *str)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "pci");
+	fu_context_add_udev_subsystem (ctx, "pci");
 }
 
 static FuMeiFamily

--- a/plugins/pixart-rf/fu-plugin-pixart-rf.c
+++ b/plugins/pixart-rf/fu-plugin-pixart-rf.c
@@ -15,8 +15,9 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "hidraw");
+	fu_context_add_udev_subsystem (ctx, "hidraw");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_PXI_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "pixart", FU_TYPE_PXI_FIRMWARE);
 }

--- a/plugins/platform-integrity/fu-plugin-platform-integrity.c
+++ b/plugins/platform-integrity/fu-plugin-platform-integrity.c
@@ -16,9 +16,10 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "platform-integrity");
+	fu_context_add_udev_subsystem (ctx, "platform-integrity");
 }
 
 void

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -48,12 +48,13 @@ gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	gboolean ca_check;
 	g_autofree gchar *redfish_uri = NULL;
 	g_autoptr(GBytes) smbios_data = NULL;
 
 	/* optional */
-	smbios_data = fu_plugin_get_smbios_data (plugin, REDFISH_SMBIOS_TABLE_TYPE);
+	smbios_data = fu_context_get_smbios_data (ctx, REDFISH_SMBIOS_TABLE_TYPE);
 
 	/* read the conf file */
 	redfish_uri = fu_plugin_get_config_value (plugin, "Uri");

--- a/plugins/rts54hid/fu-plugin-rts54hid.c
+++ b/plugins/rts54hid/fu-plugin-rts54hid.c
@@ -14,11 +14,12 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_RTS54HID_DEVICE);
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54TargetAddr");
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54I2cSpeed");
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54RegisterAddrLen");
+	fu_context_add_quirk_key (ctx, "Rts54TargetAddr");
+	fu_context_add_quirk_key (ctx, "Rts54I2cSpeed");
+	fu_context_add_quirk_key (ctx, "Rts54RegisterAddrLen");
 
 	/* register the custom types */
 	g_type_ensure (FU_TYPE_RTS54HID_MODULE);

--- a/plugins/rts54hub/fu-plugin-rts54hub.c
+++ b/plugins/rts54hub/fu-plugin-rts54hub.c
@@ -14,10 +14,11 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_RTS54HUB_DEVICE);
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54TargetAddr");
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54I2cSpeed");
-	fu_plugin_add_possible_quirk_key (plugin, "Rts54RegisterAddrLen");
+	fu_context_add_quirk_key (ctx, "Rts54TargetAddr");
+	fu_context_add_quirk_key (ctx, "Rts54I2cSpeed");
+	fu_context_add_quirk_key (ctx, "Rts54RegisterAddrLen");
 	g_type_ensure (FU_TYPE_RTS54HUB_RTD21XX_DEVICE);
 }

--- a/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
+++ b/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
@@ -14,11 +14,12 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
-	fu_plugin_add_possible_quirk_key (plugin, "CxaudioChipIdBase");
-	fu_plugin_add_possible_quirk_key (plugin, "CxaudioPatch1ValidAddr");
-	fu_plugin_add_possible_quirk_key (plugin, "CxaudioPatch2ValidAddr");
-	fu_plugin_add_possible_quirk_key (plugin, "CxaudioSoftwareReset");
+	fu_context_add_quirk_key (ctx, "CxaudioChipIdBase");
+	fu_context_add_quirk_key (ctx, "CxaudioPatch1ValidAddr");
+	fu_context_add_quirk_key (ctx, "CxaudioPatch2ValidAddr");
+	fu_context_add_quirk_key (ctx, "CxaudioSoftwareReset");
 }

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -119,6 +119,7 @@ fu_plugin_backend_device_changed (FuPlugin *plugin, FuDevice *device, GError **e
 gboolean
 fu_plugin_backend_device_added (FuPlugin *plugin, FuDevice *device, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *priv = fu_plugin_get_data (plugin);
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(FuSynapticsMstDevice) dev = NULL;
@@ -134,7 +135,7 @@ fu_plugin_backend_device_added (FuPlugin *plugin, FuDevice *device, GError **err
 
 	/* for SynapticsMstDeviceKind=system devices */
 	fu_synaptics_mst_device_set_system_type (FU_SYNAPTICS_MST_DEVICE (dev),
-						fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_SKU));
+						 fu_context_get_hwid_value (ctx, FU_HWIDS_KEY_PRODUCT_SKU));
 
 	/* this might fail if there is nothing connected */
 	fu_plugin_synaptics_mst_device_rescan (plugin, FU_DEVICE (dev));
@@ -168,16 +169,17 @@ fu_plugin_update (FuPlugin *plugin,
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *priv = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 
 	/* devices added by this plugin */
 	priv->devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "drm");	/* used for uevent only */
-	fu_plugin_add_udev_subsystem (plugin, "drm_dp_aux_dev");
+	fu_context_add_udev_subsystem (ctx, "drm");	/* used for uevent only */
+	fu_context_add_udev_subsystem (ctx, "drm_dp_aux_dev");
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
-	fu_plugin_add_possible_quirk_key (plugin, "SynapticsMstDeviceKind");
+	fu_context_add_quirk_key (ctx, "SynapticsMstDeviceKind");
 }
 
 void

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -12,6 +12,7 @@
 
 #include "fu-synaptics-mst-firmware.h"
 
+#include "fu-context-private.h"
 #include "fu-plugin-private.h"
 
 static void
@@ -26,7 +27,7 @@ _test_add_fake_devices_from_dir (FuPlugin *plugin, const gchar *path)
 {
 	const gchar *basename;
 	gboolean ret;
-	g_autoptr(FuQuirks) quirks = fu_quirks_new ();
+	g_autoptr(FuContext) ctx = fu_context_new ();
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GDir) dir = g_dir_open (path, 0, &error);
 	g_assert_no_error (error);
@@ -37,7 +38,7 @@ _test_add_fake_devices_from_dir (FuPlugin *plugin, const gchar *path)
 		if (!g_str_has_prefix (basename, "drm_dp_aux"))
 			continue;
 		dev = g_object_new (FU_TYPE_UDEV_DEVICE,
-				    "quirks", quirks,
+				    "context", ctx,
 				    "physical-id", "PCI_SLOT_NAME=0000:3e:00.0",
 				    "logical-id", basename,
 				    "subsystem", "drm_dp_aux_dev",
@@ -56,7 +57,8 @@ fu_plugin_synaptics_mst_none_func (void)
 {
 	gboolean ret;
 	const gchar *ci = g_getenv ("CI_NETWORK");
-	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
+	g_autoptr(FuContext) ctx = fu_context_new ();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new (ctx);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 	g_autofree gchar *pluginfn = NULL;
@@ -94,7 +96,8 @@ fu_plugin_synaptics_mst_tb16_func (void)
 {
 	gboolean ret;
 	const gchar *ci = g_getenv ("CI_NETWORK");
-	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
+	g_autoptr(FuContext) ctx = fu_context_new ();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new (ctx);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 	g_autofree gchar *pluginfn = NULL;

--- a/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
+++ b/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
@@ -15,9 +15,10 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "hidraw");
-	fu_plugin_add_udev_subsystem (plugin, "serio");
+	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_context_add_udev_subsystem (ctx, "serio");
 	g_type_ensure (FU_TYPE_SYNAPTICS_RMI_HID_DEVICE);
 	g_type_ensure (FU_TYPE_SYNAPTICS_RMI_PS2_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -49,9 +49,10 @@ fu_plugin_thunderbolt_safe_kernel (FuPlugin *plugin, GError **error)
 gboolean
 fu_plugin_device_created (FuPlugin *plugin, FuDevice *dev, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_INHIBITS_IDLE,
 			    "thunderbolt requires device wakeup");
-	fu_device_set_quirks (dev, fu_plugin_get_quirks (plugin));
+	fu_device_set_context (dev, ctx);
 	return TRUE;
 }
 
@@ -75,8 +76,9 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "thunderbolt");
+	fu_context_add_udev_subsystem (ctx, "thunderbolt");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_THUNDERBOLT_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE_UPDATE);

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -23,6 +23,7 @@
 
 #include <locale.h>
 
+#include "fu-context-private.h"
 #include "fu-plugin-private.h"
 #include "fu-thunderbolt-firmware.h"
 #include "fu-thunderbolt-firmware-update.h"
@@ -904,7 +905,15 @@ test_set_up (ThunderboltTest *tt, gconstpointer params)
 	g_autofree gchar *pluginfn = NULL;
 	g_autofree gchar *sysfs = NULL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new ();
 	const gchar *udev_subsystems[] = { "thunderbolt", NULL };
+
+	ret = fu_context_load_quirks (ctx,
+				      FU_QUIRKS_LOAD_FLAG_NO_CACHE |
+				      FU_QUIRKS_LOAD_FLAG_NO_VERIFY,
+				      &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
 
 	tt->bed = umockdev_testbed_new ();
 	g_assert_nonnull (tt->bed);
@@ -912,7 +921,7 @@ test_set_up (ThunderboltTest *tt, gconstpointer params)
 	sysfs = umockdev_testbed_get_sys_dir (tt->bed);
 	g_debug ("mock sysfs at %s", sysfs);
 
-	tt->plugin = fu_plugin_new ();
+	tt->plugin = fu_plugin_new (ctx);
 	g_assert_nonnull (tt->plugin);
 
 	pluginfn = g_build_filename (PLUGINBUILDDIR,

--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -18,9 +18,10 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "tpm");
+	fu_context_add_udev_subsystem (ctx, "tpm");
 	fu_plugin_set_device_gtype (plugin, FU_TYPE_TPM_DEVICE);
 }
 

--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -21,7 +21,8 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
-	GPtrArray *hwids = fu_plugin_get_hwids (plugin);
+	FuContext *ctx = fu_plugin_get_context (plugin);
+	GPtrArray *hwids = fu_context_get_hwid_guids (ctx);
 	const gchar *dmi_vendor;
 	g_autoptr(FuDevice) device = fu_device_new ();
 	fu_device_set_id (device, "uefi-recovery");
@@ -40,7 +41,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	}
 
 	/* set vendor ID as the BIOS vendor */
-	dmi_vendor = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_BIOS_VENDOR);
+	dmi_vendor = fu_context_get_hwid_value (ctx, FU_HWIDS_KEY_BIOS_VENDOR);
 	if (dmi_vendor != NULL) {
 		g_autofree gchar *vendor_id = g_strdup_printf ("DMI:%s", dmi_vendor);
 		fu_device_add_vendor_id (device, vendor_id);

--- a/plugins/vli/fu-plugin-vli.c
+++ b/plugins/vli/fu-plugin-vli.c
@@ -16,15 +16,16 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_VLI_USBHUB_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_VLI_PD_FIRMWARE);
-	fu_plugin_add_possible_quirk_key (plugin, "VliDeviceKind");
-	fu_plugin_add_possible_quirk_key (plugin, "VliSpiAutoDetect");
-	fu_plugin_add_possible_quirk_key (plugin, "VliSpiCmdChipErase");
-	fu_plugin_add_possible_quirk_key (plugin, "VliSpiCmdReadId");
-	fu_plugin_add_possible_quirk_key (plugin, "VliSpiCmdReadIdSz");
-	fu_plugin_add_possible_quirk_key (plugin, "VliSpiCmdSectorErase");
+	fu_context_add_quirk_key (ctx, "VliDeviceKind");
+	fu_context_add_quirk_key (ctx, "VliSpiAutoDetect");
+	fu_context_add_quirk_key (ctx, "VliSpiCmdChipErase");
+	fu_context_add_quirk_key (ctx, "VliSpiCmdReadId");
+	fu_context_add_quirk_key (ctx, "VliSpiCmdReadIdSz");
+	fu_context_add_quirk_key (ctx, "VliSpiCmdSectorErase");
 
 	/* register the custom types */
 	g_type_ensure (FU_TYPE_VLI_USBHUB_DEVICE);

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -14,11 +14,12 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_add_udev_subsystem (plugin, "hidraw");
-	fu_plugin_add_possible_quirk_key (plugin, "WacomI2cFlashBlockSize");
-	fu_plugin_add_possible_quirk_key (plugin, "WacomI2cFlashBaseAddr");
-	fu_plugin_add_possible_quirk_key (plugin, "WacomI2cFlashSize");
+	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_context_add_quirk_key (ctx, "WacomI2cFlashBlockSize");
+	fu_context_add_quirk_key (ctx, "WacomI2cFlashBaseAddr");
+	fu_context_add_quirk_key (ctx, "WacomI2cFlashSize");
 
 	/* register the custom types */
 	g_type_ensure (FU_TYPE_WACOM_AES_DEVICE);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -14,6 +14,7 @@
 #include "fwupd-enums.h"
 
 #include "fu-common.h"
+#include "fu-context.h"
 #include "fu-engine-request.h"
 #include "fu-install-task.h"
 #include "fu-plugin.h"
@@ -180,9 +181,7 @@ gboolean	 fu_engine_modify_config		(FuEngine	*self,
 							 const gchar	*key,
 							 const gchar	*value,
 							 GError		**error);
-GPtrArray	*fu_engine_get_firmware_gtype_ids	(FuEngine	*engine);
-GType		 fu_engine_get_firmware_gtype_by_id	(FuEngine	*engine,
-							 const gchar	*id);
+FuContext	*fu_engine_get_context			(FuEngine	*engine);
 void		 fu_engine_md_refresh_device_from_component (FuEngine	*self,
 							 FuDevice	*device,
 							 XbNode		*component);

--- a/src/fu-firmware-dump.c
+++ b/src/fu-firmware-dump.c
@@ -10,6 +10,7 @@
 #include <locale.h>
 #include <stdlib.h>
 
+#include "fu-context-private.h"
 #include "fu-engine.h"
 
 typedef struct {
@@ -129,6 +130,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuUtil, fu_util_private_free)
 int
 main (int argc, char **argv)
 {
+	FuContext *ctx;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) firmware_types = NULL;
 	g_autoptr(GOptionContext) context = NULL;
@@ -175,11 +177,12 @@ main (int argc, char **argv)
 	}
 
 	/* get all parser objects */
-	firmware_types = fu_engine_get_firmware_gtype_ids (self->engine);
+	ctx = fu_engine_get_context (self->engine);
+	firmware_types = fu_context_get_firmware_gtype_ids (ctx);
 	self->array = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
 	for (guint i = 0; i < firmware_types->len; i++) {
 		const gchar *id = g_ptr_array_index (firmware_types, i);
-		GType gtype = fu_engine_get_firmware_gtype_by_id (self->engine, id);
+		GType gtype = fu_context_get_firmware_gtype_by_id (ctx, id);
 		g_ptr_array_add (self->array, g_object_new (gtype, NULL));
 	}
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -159,7 +159,7 @@ fu_plugin_hash_func (gconstpointer user_data)
 	GError *error = NULL;
 	g_autofree gchar *pluginfn = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
-	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new (NULL);
 	gboolean ret = FALSE;
 
 	ret = fu_engine_load (engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
@@ -1003,7 +1003,7 @@ fu_engine_partial_hash_func (gconstpointer user_data)
 	g_autoptr(FuDevice) device1 = fu_device_new ();
 	g_autoptr(FuDevice) device2 = fu_device_new ();
 	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
-	g_autoptr(FuPlugin) plugin = fu_plugin_new ();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new (NULL);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GError) error_none = NULL;
 	g_autoptr(GError) error_both = NULL;
@@ -2266,8 +2266,8 @@ fu_plugin_list_func (gconstpointer user_data)
 	GPtrArray *plugins;
 	FuPlugin *plugin;
 	g_autoptr(FuPluginList) plugin_list = fu_plugin_list_new ();
-	g_autoptr(FuPlugin) plugin1 = fu_plugin_new ();
-	g_autoptr(FuPlugin) plugin2 = fu_plugin_new ();
+	g_autoptr(FuPlugin) plugin1 = fu_plugin_new (NULL);
+	g_autoptr(FuPlugin) plugin2 = fu_plugin_new (NULL);
 	g_autoptr(GError) error = NULL;
 
 	fu_plugin_set_name (plugin1, "plugin1");
@@ -2298,8 +2298,8 @@ fu_plugin_list_depsolve_func (gconstpointer user_data)
 	FuPlugin *plugin;
 	gboolean ret;
 	g_autoptr(FuPluginList) plugin_list = fu_plugin_list_new ();
-	g_autoptr(FuPlugin) plugin1 = fu_plugin_new ();
-	g_autoptr(FuPlugin) plugin2 = fu_plugin_new ();
+	g_autoptr(FuPlugin) plugin1 = fu_plugin_new (NULL);
+	g_autoptr(FuPlugin) plugin2 = fu_plugin_new (NULL);
 	g_autoptr(GError) error = NULL;
 
 	fu_plugin_set_name (plugin1, "plugin1");
@@ -3044,7 +3044,7 @@ main (int argc, char **argv)
 	fu_self_test_mkroot ();
 
 	/* load the test plugin */
-	self->plugin = fu_plugin_new ();
+	self->plugin = fu_plugin_new (NULL);
 	pluginfn = g_build_filename (PLUGINBUILDDIR,
 				     "libfu_plugin_test." G_MODULE_SUFFIX,
 				     NULL);


### PR DESCRIPTION
There is a lot of code in fwupd that just assigns a shared object type to
a FuPlugin, and then for each device on that plugin assigns that same shared
object to each FuDevice.

Rather than proxy several kinds of information stores over two different levels
of abstraction create a 'context' which contains the shared *system* state
between the daemon, the plugins and the daemon.

This will allow us to hold other per-machine state in the future, for instance
the system battery level or AC state.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
