### PR TITLE
Do not show a GType failure when using fwupdtool

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1252,13 +1252,6 @@ fu_device_set_quirk_kv (FuDevice *self,
 			return TRUE;
 		}
 		priv->specialized_gtype = g_type_from_name (value);
-		if (priv->specialized_gtype == G_TYPE_INVALID) {
-			g_set_error (error,
-				     G_IO_ERROR,
-				     G_IO_ERROR_NOT_FOUND,
-				     "device GType %s not supported", value);
-			return FALSE;
-		}
 		return TRUE;
 	}
 	if (g_strcmp0 (key, FU_QUIRKS_CHILDREN) == 0) {


### PR DESCRIPTION
If only one plugin is enabled and there exists a device match for a GType that
has not been registered then the user sees a GType error about not being able
to create a device that wouldn't be created anyway.

By removing the error in the quirk parser we will catch actual errors in
fu_plugin_runner_backend_device_added() which actually does chcek for
FWUPD_PLUGIN_FLAG_DISABLED.

Fixes https://github.com/fwupd/fwupd/issues/3099

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
