### PR TITLE
dfu-tool: Avoid runtime warning (overriding error)

### DIFF
--- a/plugins/dfu/fu-dfu-tool.c
+++ b/plugins/dfu/fu-dfu-tool.c
@@ -222,11 +222,9 @@ fu_dfu_tool_get_default_device (FuDfuTool *self, GError **error)
 							    (guint16) pid,
 							    error);
 		if (usb_device == NULL) {
-			g_set_error (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_FOUND,
-				     "no device matches for %04x:%04x",
-				     (guint) vid, (guint) pid);
+			g_prefix_error (error,
+					"no device matches for %04x:%04x: ",
+					(guint) vid, (guint) pid);
 			return NULL;
 		}
 		device = fu_dfu_device_new (usb_device);


### PR DESCRIPTION
We were seeing:

```
,----
| (dfu-tool:1139827): GLib-WARNING **: 17:34:42.671: GError set over the top of a previous GError or uninitialized memory.
| This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
| The overwriting error message was: no device matches for 1234:abcd
`----
``
This is because we were attempting to overwrite libgusb's error with one
for fwupd, and glib rightfully complains. Since we're likely more
interested in the fwupd error (since it's specifically
FWUPD_ERROR_NOT_FOUND), let's ignore the error from gusb.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
