### PR TITLE
fu-engine: Don't inherit activation flags for devices

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -198,6 +198,8 @@ fu_device_internal_flag_to_string (FuDeviceInternalFlags flag)
 		return "retry-open";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID)
 		return "replug-match-guid";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION)
+		return "inherit-activation";
 	return NULL;
 }
 
@@ -230,6 +232,8 @@ fu_device_internal_flag_from_string (const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_ENSURE_SEMVER;
 	if (g_strcmp0 (flag, "retry-open") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN;
+	if (g_strcmp0 (flag, "inherit-activation"))
+		return FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -210,6 +210,7 @@ FuDevice	*fu_device_new				(void);
  * @FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON:		Set the device icon from the metadata if available
  * @FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN:			Retry the device open up to 5 times if it fails
  * @FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID:		Match GUIDs on device replug where the physical and logical IDs will be different
+ * @FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION:		Inherit activation status from the history database on startup
  *
  * The device internal flags.
  **/
@@ -224,6 +225,7 @@ typedef enum {
 	FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON		= (1llu << 6),	/* Since: 1.5.5 */
 	FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN		= (1llu << 7),	/* Since: 1.5.5 */
 	FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID	= (1llu << 8),	/* Since: 1.5.8 */
+	FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION	= (1llu << 9),  /* Since: 1.5.9 */
 	/*< private >*/
 	FU_DEVICE_INTERNAL_FLAG_UNKNOWN			= G_MAXUINT64,
 } FuDeviceInternalFlags;

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -824,6 +824,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	self->transfer_mode = ATA_SUBCMD_MICROCODE_DOWNLOAD_CHUNKS;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_add_protocol (FU_DEVICE (self), "org.t13.ata");

--- a/plugins/solokey/fu-solokey-firmware.c
+++ b/plugins/solokey/fu-solokey-firmware.c
@@ -120,7 +120,6 @@ fu_solokey_firmware_write (FuFirmware *firmware, GError **error)
 {
 	g_autofree gchar *buf_base64 = NULL;
 	g_autoptr(FuFirmware) img = NULL;
-	g_autoptr(GByteArray) buf = g_byte_array_new ();
 	g_autoptr(GBytes) buf_blob = NULL;
 	g_autoptr(GString) str = g_string_new (NULL);
 	g_autoptr(JsonBuilder) builder = json_builder_new ();

--- a/plugins/thunderbolt/fu-thunderbolt-firmware.c
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware.c
@@ -133,7 +133,6 @@ fu_thunderbolt_firmware_export (FuFirmware *firmware,
 {
 	FuThunderboltFirmware *self = FU_THUNDERBOLT_FIRMWARE (firmware);
 	FuThunderboltFirmwarePrivate *priv = GET_PRIVATE (self);
-	g_autoptr(XbBuilderNode) bc = NULL;
 
 	fu_xmlb_builder_insert_kv (bn, "family",
 				   fu_thunderbolt_firmware_family_to_string (priv->family));

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5320,7 +5320,8 @@ fu_engine_device_inherit_history (FuEngine *self, FuDevice *device)
 	/* the device is still running the old firmware version and so if it
 	 * required activation before, it still requires it now -- note:
 	 * we can't just check for version_new=version to allow for re-installs */
-	if (fu_device_has_flag (device_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
+	if (fu_device_has_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION) &&
+	    fu_device_has_flag (device_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 		FwupdRelease *release = fu_device_get_release_default (device_history);
 		if (fu_common_vercmp_full (fu_device_get_version (device),
 					   fwupd_release_get_version (release),

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5663,7 +5663,6 @@ static gchar *
 fu_engine_attrs_calculate_hsi_for_chassis (FuEngine *self)
 {
 	guint val;
-	g_autoptr(GError) error = NULL;
 
 	/* get chassis type from SMBIOS data */
 	val = fu_context_get_smbios_integer (self->ctx,

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1730,6 +1730,7 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_engine_set_silo (engine, silo_empty);
 	fu_engine_add_plugin (engine, self->plugin);
 	device = fu_device_new ();
+	fu_device_add_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
 	fu_device_add_protocol (device, "com.acme");
@@ -1739,6 +1740,24 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_engine_add_device (engine, device);
 	g_assert_true (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
+	/* emulate not getting the flag */
+	g_object_unref (engine);
+	g_object_unref (device);
+	engine = fu_engine_new (FU_APP_FLAGS_NONE);
+	fu_engine_set_silo (engine, silo_empty);
+	fu_engine_add_plugin (engine, self->plugin);
+	device = fu_device_new ();
+	fu_device_set_id (device, "test_device");
+	fu_device_add_vendor_id (device, "USB:FFFF");
+	fu_device_add_protocol (device, "com.acme");
+	fu_device_set_name (device, "Test Device");
+	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
+	fu_engine_add_device (engine, device);
+	g_assert_false (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
 }
 
 static void


### PR DESCRIPTION
This was originally added for the WD19 which can actually advertise
it's own activation state from the hardware.

Fixes: #3106

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
