### PR TITLE
Set the system battery state and level on the FuContext shared state

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -3281,6 +3281,32 @@ fu_common_align_up (gsize value, guint8 alignment)
 }
 
 /**
+ * fu_battery_state_to_string:
+ * @battery_state: a #FuBatteryState, e.g. %FU_BATTERY_STATE_FULLY_CHARGED
+ *
+ * Converts an enumerated type to a string.
+ *
+ * Returns: a string, or %NULL for invalid
+ *
+ * Since: 1.6.0
+ **/
+const gchar *
+fu_battery_state_to_string (FuBatteryState battery_state)
+{
+	if (battery_state == FU_BATTERY_STATE_UNKNOWN)
+		return "unknown";
+	if (battery_state == FU_BATTERY_STATE_CHARGING)
+		return "charging";
+	if (battery_state == FU_BATTERY_STATE_DISCHARGING)
+		return "discharging";
+	if (battery_state == FU_BATTERY_STATE_EMPTY)
+		return "empty";
+	if (battery_state == FU_BATTERY_STATE_FULLY_CHARGED)
+		return "fully-charged";
+	return NULL;
+}
+
+/**
  * fu_xmlb_builder_insert_kv:
  * @bn: #JsonBuilder
  * @key: string key

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -101,6 +101,34 @@ typedef enum {
 	FU_CPU_VENDOR_LAST
 } FuCpuVendor;
 
+/**
+ * FU_BATTERY_VALUE_INVALID:
+ *
+ * This value signifies the battery level is either unset, or the value cannot
+ * be discovered.
+ */
+#define FU_BATTERY_VALUE_INVALID			101
+
+/**
+ * FuBatteryState:
+ * @FU_BATTERY_STATE_UNKNOWN:		Unknown
+ * @FU_BATTERY_STATE_CHARGING:		Charging
+ * @FU_BATTERY_STATE_DISCHARGING:	Discharging
+ * @FU_BATTERY_STATE_EMPTY:		Empty
+ * @FU_BATTERY_STATE_FULLY_CHARGED:	Fully charged
+ *
+ * The device battery state.
+ **/
+typedef enum {
+	FU_BATTERY_STATE_UNKNOWN,
+	FU_BATTERY_STATE_CHARGING,
+	FU_BATTERY_STATE_DISCHARGING,
+	FU_BATTERY_STATE_EMPTY,
+	FU_BATTERY_STATE_FULLY_CHARGED,
+	/*< private >*/
+	FU_BATTERY_STATE_LAST
+} FuBatteryState;
+
 typedef void	(*FuOutputHandler)		(const gchar	*line,
 						 gpointer	 user_data);
 
@@ -364,6 +392,7 @@ guint32		 fu_common_crc32_full		(const guint8	*buf,
 gchar		*fu_common_uri_get_scheme	(const gchar	*uri);
 gsize		 fu_common_align_up		(gsize		 value,
 						 guint8		 alignment);
+const gchar	*fu_battery_state_to_string	(FuBatteryState	 battery_state);
 
 void		 fu_xmlb_builder_insert_kv	(XbBuilderNode	*bn,
 						 const gchar	*key,

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -8,6 +8,8 @@
 
 #include <gio/gio.h>
 
+#include "fu-common.h"
+
 #define FU_TYPE_CONTEXT (fu_context_get_type ())
 G_DECLARE_DERIVABLE_TYPE (FuContext, fu_context, FU, CONTEXT, GObject)
 
@@ -59,3 +61,13 @@ gboolean	 fu_context_lookup_quirk_by_id_iter	(FuContext	*self,
 void		 fu_context_add_quirk_key		(FuContext	*self,
 							 const gchar	*key);
 void		 fu_context_security_changed		(FuContext	*self);
+
+FuBatteryState	 fu_context_get_battery_state		(FuContext	*self);
+void		 fu_context_set_battery_state		(FuContext	*self,
+							 FuBatteryState	 battery_state);
+guint		 fu_context_get_battery_level		(FuContext	*self);
+void		 fu_context_set_battery_level		(FuContext	*self,
+							 guint		 battery_level);
+guint		 fu_context_get_battery_threshold	(FuContext	*self);
+void		 fu_context_set_battery_threshold	(FuContext	*self,
+							 guint		 battery_threshold);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -713,6 +713,7 @@ LIBFWUPDPLUGIN_1.5.8 {
 
 LIBFWUPDPLUGIN_1.6.0 {
   global:
+    fu_battery_state_to_string;
     fu_byte_array_align_up;
     fu_byte_array_set_size_full;
     fu_common_align_up;
@@ -721,6 +722,9 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_context_add_quirk_key;
     fu_context_add_runtime_version;
     fu_context_add_udev_subsystem;
+    fu_context_get_battery_level;
+    fu_context_get_battery_state;
+    fu_context_get_battery_threshold;
     fu_context_get_firmware_gtype_by_id;
     fu_context_get_firmware_gtype_ids;
     fu_context_get_hwid_guids;
@@ -738,6 +742,9 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_context_lookup_quirk_by_id_iter;
     fu_context_new;
     fu_context_security_changed;
+    fu_context_set_battery_level;
+    fu_context_set_battery_state;
+    fu_context_set_battery_threshold;
     fu_context_set_compile_versions;
     fu_context_set_runtime_versions;
     fu_device_add_security_attrs;

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -1,6 +1,9 @@
 if host_machine.system() == 'linux'
 cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
 
+install_data(['upower.quirk'],
+  install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
+
 shared_module('fu_plugin_upower',
   fu_hash,
   sources : [

--- a/plugins/upower/upower.conf
+++ b/plugins/upower/upower.conf
@@ -2,4 +2,4 @@
 
 # The threshold to to require battery be at or above to allow updates
 # Measure in percent
-BatteryThreshold=10
+#BatteryThreshold=10

--- a/plugins/upower/upower.quirk
+++ b/plugins/upower/upower.quirk
@@ -1,0 +1,2 @@
+[LENOVO]
+BatteryThreshold = 25


### PR DESCRIPTION
This allows plugins to set the battery power state of the *machine* which means
we can automatically inhibit devices with FWUPD_DEVICE_FLAG_REQUIRE_AC set.

It also allows to set the BatteryThreshold to 25% for Lenovo hardware, and we
can override other vendors with further quirks as required.

Fixes https://github.com/fwupd/fwupd/issues/3084
