### PR TITLE
Add a new internal flag for whether or not to inherit activation

### DIFF
--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -13,6 +13,8 @@ fi
 
 #evaluate using Ubuntu's buildflags
 #evaluate using Debian/Ubuntu's buildflags
+#disable link time optimization, Ubuntu currently only sets it for GCC
+export DEB_BUILD_MAINT_OPTIONS="optimize=-lto"
 eval "$(dpkg-buildflags --export=sh)"
 #filter out -Bsymbolic-functions
 export LDFLAGS=$(dpkg-buildflags --get LDFLAGS | sed "s/-Wl,-Bsymbolic-functions\s//")

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -186,6 +186,8 @@ fu_device_internal_flag_to_string (FuDeviceInternalFlags flag)
 		return "retry-open";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID)
 		return "replug-match-guid";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION)
+		return "inherit-activation";
 	return NULL;
 }
 
@@ -218,6 +220,8 @@ fu_device_internal_flag_from_string (const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_ENSURE_SEMVER;
 	if (g_strcmp0 (flag, "retry-open") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN;
+	if (g_strcmp0 (flag, "inherit-activation"))
+		return FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -208,6 +208,7 @@ FuDevice	*fu_device_new				(void);
  * @FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON:		Set the device icon from the metadata if available
  * @FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN:			Retry the device open up to 5 times if it fails
  * @FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID:		Match GUIDs on device replug where the physical and logical IDs will be different
+ * @FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION:		Inherit activation status from the history database on startup
  *
  * The device internal flags.
  **/
@@ -222,6 +223,7 @@ typedef enum {
 	FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON		= (1llu << 6),	/* Since: 1.5.5 */
 	FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN		= (1llu << 7),	/* Since: 1.5.5 */
 	FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID	= (1llu << 8),	/* Since: 1.5.8 */
+	FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION	= (1llu << 9),  /* Since: 1.5.9 */
 	/*< private >*/
 	FU_DEVICE_INTERNAL_FLAG_UNKNOWN			= G_MAXUINT64,
 } FuDeviceInternalFlags;

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -824,6 +824,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	self->transfer_mode = ATA_SUBCMD_MICROCODE_DOWNLOAD_CHUNKS;
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_add_protocol (FU_DEVICE (self), "org.t13.ata");

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5362,7 +5362,8 @@ fu_engine_device_inherit_history (FuEngine *self, FuDevice *device)
 	/* the device is still running the old firmware version and so if it
 	 * required activation before, it still requires it now -- note:
 	 * we can't just check for version_new=version to allow for re-installs */
-	if (fu_device_has_flag (device_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
+	if (fu_device_has_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION) &&
+	    fu_device_has_flag (device_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 		FwupdRelease *release = fu_device_get_release_default (device_history);
 		if (fu_common_vercmp_full (fu_device_get_version (device),
 					   fwupd_release_get_version (release),

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1730,6 +1730,7 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_engine_set_silo (engine, silo_empty);
 	fu_engine_add_plugin (engine, self->plugin);
 	device = fu_device_new ();
+	fu_device_add_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 	fu_device_set_id (device, "test_device");
 	fu_device_add_vendor_id (device, "USB:FFFF");
 	fu_device_add_protocol (device, "com.acme");
@@ -1739,6 +1740,24 @@ fu_engine_history_inherit (gconstpointer user_data)
 	fu_device_set_version (device, "1.2.2");
 	fu_engine_add_device (engine, device);
 	g_assert_true (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
+	/* emulate not getting the flag */
+	g_object_unref (engine);
+	g_object_unref (device);
+	engine = fu_engine_new (FU_APP_FLAGS_NONE);
+	fu_engine_set_silo (engine, silo_empty);
+	fu_engine_add_plugin (engine, self->plugin);
+	device = fu_device_new ();
+	fu_device_set_id (device, "test_device");
+	fu_device_add_vendor_id (device, "USB:FFFF");
+	fu_device_add_protocol (device, "com.acme");
+	fu_device_set_name (device, "Test Device");
+	fu_device_add_guid (device, "12345678-1234-1234-1234-123456789012");
+	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "1.2.2");
+	fu_engine_add_device (engine, device);
+	g_assert_false (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
+
 }
 
 static void


### PR DESCRIPTION
The activation flag is stored into the history database, but not all
plugins will want to inherit it on coldplug the next time the daemon
is started.

For example the Dell Dock plugin will query this information from the
device and it will prevent getting into a bad state as a result.
Fixes: #3106

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
