### PR TITLE
flashrom: make fu-flashrom-device a derivable type

### DIFF
--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -62,6 +62,15 @@ Vendor ID Security
 
 The vendor ID is set from the BIOS vendor, for example `DMI:Google`
 
+Quirk use
+---------
+This plugin uses the following plugin-specific quirks:
+
+| Quirk                  | Description                                 | Minimum fwupd version |
+|------------------------|---------------------------------------------|-----------------------|
+|`FlashromProgrammer`    | Used to specify the libflashrom programmer to be used.     | 1.5.9                 |
+
+
 External interface access
 ---
 This plugin requires access to all interfaces that `libflashrom` has been compiled for.

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -10,39 +10,73 @@
 
 #include <libflashrom.h>
 
-struct _FuFlashromDevice {
-	FuDevice			 parent_instance;
+typedef struct {
+	FuFlashromDevice		 parent_instance;
+	gchar				*programmer_name;
+	gchar				*programmer_args;
 	gsize				 flash_size;
 	struct flashrom_flashctx	*flashctx;
-	struct flashrom_layout		*layout;
 	struct flashrom_programmer	*flashprog;
-};
+} FuFlashromDevicePrivate;
 
-G_DEFINE_TYPE (FuFlashromDevice, fu_flashrom_device, FU_TYPE_DEVICE)
+G_DEFINE_TYPE_WITH_PRIVATE (FuFlashromDevice, fu_flashrom_device, FU_TYPE_DEVICE)
+
+#define GET_PRIVATE(o) (fu_flashrom_device_get_instance_private (o))
+
+void
+fu_flashrom_device_set_programmer_name (FuFlashromDevice *self, const gchar *name)
+{
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_FLASHROM_DEVICE (self));
+	g_free (priv->programmer_name);
+	priv->programmer_name = g_strdup (name);
+}
+
+gchar *
+fu_flashrom_device_get_programmer_name (FuFlashromDevice *self)
+{
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_FLASHROM_DEVICE (self), NULL);
+	return priv->programmer_name;
+}
+
+void
+fu_flashrom_device_set_programmer_args (FuFlashromDevice *self, const gchar *args)
+{
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_if_fail (FU_IS_FLASHROM_DEVICE (self));
+	g_free (priv->programmer_args);
+	priv->programmer_args = g_strdup (args);
+}
+
+gsize
+fu_flashrom_device_get_flash_size (FuFlashromDevice *self)
+{
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_FLASHROM_DEVICE (self), 0);
+	return priv->flash_size;
+}
+
+struct flashrom_flashctx *
+fu_flashrom_device_get_flashctx (FuFlashromDevice *self)
+{
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_FLASHROM_DEVICE (self), NULL);
+	return priv->flashctx;
+}
 
 static void
 fu_flashrom_device_init (FuFlashromDevice *self)
 {
 	fu_device_add_protocol (FU_DEVICE (self), "org.flashrom");
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
-	fu_device_add_instance_id (FU_DEVICE (self), "main-system-firmware");
-	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_ENSURE_SEMVER);
-	fu_device_set_physical_id (FU_DEVICE (self), "flashrom");
-	fu_device_set_logical_id (FU_DEVICE (self), "bios");
-	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_add_icon (FU_DEVICE (self), "computer");
 }
 
 static void
 fu_flashrom_device_finalize (GObject *object)
 {
-	FuFlashromDevice *self = FU_FLASHROM_DEVICE (object);
-	flashrom_layout_release (self->layout);
-	flashrom_programmer_shutdown (self->flashprog);
-	flashrom_flash_release (self->flashctx);
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (FU_FLASHROM_DEVICE (object));
+	g_free (priv->programmer_name);
+	g_free (priv->programmer_args);
 	G_OBJECT_CLASS (fu_flashrom_device_parent_class)->finalize (object);
 }
 
@@ -57,6 +91,10 @@ fu_flashrom_device_set_quirk_kv (FuDevice *device,
 		fu_device_set_metadata_integer (device, "PciBcrAddr", tmp);
 		return TRUE;
 	}
+	if (g_strcmp0 (key, "FlashromProgrammer") == 0) {
+		fu_flashrom_device_set_programmer_name (FU_FLASHROM_DEVICE (device), value);
+		return TRUE;
+	}
 	g_set_error_literal (error,
 			     G_IO_ERROR,
 			     G_IO_ERROR_NOT_SUPPORTED,
@@ -65,19 +103,30 @@ fu_flashrom_device_set_quirk_kv (FuDevice *device,
 }
 
 static gboolean
-fu_flashrom_device_setup (FuDevice *device, GError **error)
+fu_flashrom_device_prepare (FuDevice *device,
+			    FwupdInstallFlags flags,
+			    GError **error)
 {
-	FuFlashromDevice *self = FU_FLASHROM_DEVICE (device);
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (FU_FLASHROM_DEVICE (device));
 	gint rc;
 
-	if (flashrom_programmer_init (&self->flashprog, "internal", NULL)) {
+	if (priv->programmer_name == NULL) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "programmer not specified");
+		return FALSE;
+	}
+
+	if (flashrom_programmer_init (&priv->flashprog, priv->programmer_name,
+				      priv->programmer_args)) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
 				     "programmer initialization failed");
 		return FALSE;
 	}
-	rc = flashrom_flash_probe (&self->flashctx, self->flashprog, NULL);
+	rc = flashrom_flash_probe (&priv->flashctx, priv->flashprog, NULL);
 	if (rc == 3) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
@@ -99,8 +148,8 @@ fu_flashrom_device_setup (FuDevice *device, GError **error)
 				     "flash probe failed: unknown error");
 		return FALSE;
 	}
-	self->flash_size = flashrom_flash_getsize (self->flashctx);
-	if (self->flash_size == 0) {
+	priv->flash_size = flashrom_flash_getsize (priv->flashctx);
+	if (priv->flash_size == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
@@ -112,108 +161,16 @@ fu_flashrom_device_setup (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_flashrom_device_prepare (FuDevice *device,
-			  FwupdInstallFlags flags,
-			  GError **error)
+fu_flashrom_device_cleanup (FuDevice *device,
+			    FwupdInstallFlags flags,
+			    GError **error)
 {
-	FuFlashromDevice *self = FU_FLASHROM_DEVICE (device);
-	g_autofree gchar *firmware_orig = NULL;
-	g_autofree gchar *localstatedir = NULL;
-	g_autofree gchar *basename = NULL;
-
-	/* if the original firmware doesn't exist, grab it now */
-	basename = g_strdup_printf ("flashrom-%s.bin", fu_device_get_id (device));
-	localstatedir = fu_common_get_path (FU_PATH_KIND_LOCALSTATEDIR_PKG);
-	firmware_orig = g_build_filename (localstatedir, "builder", basename, NULL);
-	if (!fu_common_mkdir_parent (firmware_orig, error))
-		return FALSE;
-	if (!g_file_test (firmware_orig, G_FILE_TEST_EXISTS)) {
-		g_autofree guint8 *newcontents = g_malloc0 (self->flash_size);
-		g_autoptr(GBytes) buf = NULL;
-
-		fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
-		if (flashrom_image_read (self->flashctx, newcontents, self->flash_size)) {
-			g_set_error_literal (error,
-					     FWUPD_ERROR,
-					     FWUPD_ERROR_READ,
-					     "failed to back up original firmware");
-			return FALSE;
-		}
-		buf = g_bytes_new_static (newcontents, self->flash_size);
-		if (!fu_common_set_contents_bytes (firmware_orig, buf, error))
-			return FALSE;
-	}
-
+	FuFlashromDevicePrivate *priv = GET_PRIVATE (FU_FLASHROM_DEVICE (device));
+	flashrom_flash_release (priv->flashctx);
+	flashrom_programmer_shutdown (priv->flashprog);
 	return TRUE;
 }
 
-static gboolean
-fu_flashrom_device_write_firmware (FuDevice *device,
-				   FuFirmware *firmware,
-				   FwupdInstallFlags flags,
-				   GError **error)
-{
-	FuFlashromDevice *self = FU_FLASHROM_DEVICE (device);
-	gsize sz = 0;
-	gint rc;
-	const guint8 *buf;
-	g_autoptr(GBytes) blob_fw = fu_firmware_get_bytes (firmware, error);
-	if (blob_fw == NULL)
-		return FALSE;
-
-	buf = g_bytes_get_data (blob_fw, &sz);
-
-	if (flashrom_layout_read_from_ifd (&self->layout, self->flashctx, NULL, 0)) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_READ,
-				     "failed to read layout from Intel ICH descriptor");
-		return FALSE;
-	}
-
-	/* include bios region for safety reasons */
-	if (flashrom_layout_include_region (self->layout, "bios")) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_SUPPORTED,
-				     "invalid region name");
-		return FALSE;
-	}
-
-	/* write region */
-	flashrom_layout_set (self->flashctx, self->layout);
-	if (sz != self->flash_size) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_NOT_SUPPORTED,
-			     "invalid image size 0x%x, expected 0x%x",
-			     (guint) sz, (guint) self->flash_size);
-		return FALSE;
-	}
-
-	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
-	fu_device_set_progress (device, 0); /* urgh */
-	rc = flashrom_image_write (self->flashctx, (void *) buf, sz, NULL /* refbuffer */);
-	if (rc != 0) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_WRITE,
-			     "image write failed, err=%i", rc);
-		return FALSE;
-	}
-
-	fu_device_set_status (device, FWUPD_STATUS_DEVICE_VERIFY);
-	if (flashrom_image_verify (self->flashctx, (void *) buf, sz)) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_WRITE,
-			     "image verify failed");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
 static void
 fu_flashrom_device_class_init (FuFlashromDeviceClass *klass)
 {
@@ -221,13 +178,6 @@ fu_flashrom_device_class_init (FuFlashromDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
 	object_class->finalize = fu_flashrom_device_finalize;
 	klass_device->set_quirk_kv = fu_flashrom_device_set_quirk_kv;
-	klass_device->setup = fu_flashrom_device_setup;
 	klass_device->prepare = fu_flashrom_device_prepare;
-	klass_device->write_firmware = fu_flashrom_device_write_firmware;
-}
-
-FuDevice *
-fu_flashrom_device_new (void)
-{
-	return FU_DEVICE (g_object_new (FU_TYPE_FLASHROM_DEVICE, NULL));
+	klass_device->cleanup = fu_flashrom_device_cleanup;
 }

--- a/plugins/flashrom/fu-flashrom-device.h
+++ b/plugins/flashrom/fu-flashrom-device.h
@@ -8,7 +8,18 @@
 
 #include "fu-plugin.h"
 
-#define FU_TYPE_FLASHROM_DEVICE (fu_flashrom_device_get_type ())
-G_DECLARE_FINAL_TYPE (FuFlashromDevice, fu_flashrom_device, FU, FLASHROM_DEVICE, FuDevice)
+struct _FuFlashromDeviceClass {
+	FuDeviceClass			 parent_class;
+};
 
-FuDevice	*fu_flashrom_device_new			(void);
+#define FU_TYPE_FLASHROM_DEVICE (fu_flashrom_device_get_type ())
+G_DECLARE_DERIVABLE_TYPE (FuFlashromDevice, fu_flashrom_device, FU,
+			  FLASHROM_DEVICE, FuDevice)
+
+void		 fu_flashrom_device_set_programmer_name	(FuFlashromDevice *self,
+							 const gchar *name);
+gchar		*fu_flashrom_device_get_programmer_name (FuFlashromDevice *self);
+void		 fu_flashrom_device_set_programmer_args	(FuFlashromDevice *self,
+							 const gchar *args);
+gsize		 fu_flashrom_device_get_flash_size	(FuFlashromDevice *self);
+struct flashrom_flashctx *fu_flashrom_device_get_flashctx (FuFlashromDevice *self);

--- a/plugins/flashrom/fu-flashrom-internal-device.c
+++ b/plugins/flashrom/fu-flashrom-internal-device.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2021 Daniel Campello <campello@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-flashrom-device.h"
+#include "fu-flashrom-internal-device.h"
+
+#include <libflashrom.h>
+
+struct _FuFlashromInternalDevice {
+	FuFlashromDevice		 parent_instance;
+};
+
+G_DEFINE_TYPE (FuFlashromInternalDevice, fu_flashrom_internal_device,
+	       FU_TYPE_FLASHROM_DEVICE)
+
+static void
+fu_flashrom_internal_device_init (FuFlashromInternalDevice *self)
+{
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_add_instance_id (FU_DEVICE (self), "main-system-firmware");
+	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_ENSURE_SEMVER);
+	fu_device_set_physical_id (FU_DEVICE (self), "flashrom");
+	fu_device_set_logical_id (FU_DEVICE (self), "bios");
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_icon (FU_DEVICE (self), "computer");
+}
+
+static gboolean
+fu_flashrom_internal_device_prepare (FuDevice *device,
+				     FwupdInstallFlags flags,
+				     GError **error)
+{
+	g_autofree gchar *firmware_orig = NULL;
+	g_autofree gchar *localstatedir = NULL;
+	g_autofree gchar *basename = NULL;
+
+	/* FuFlashromDevice->prepare */
+	if (!FU_DEVICE_CLASS
+	    (fu_flashrom_internal_device_parent_class)->prepare(device, flags,
+								error))
+		return FALSE;
+
+	/* if the original firmware doesn't exist, grab it now */
+	basename = g_strdup_printf ("flashrom-%s.bin", fu_device_get_id (device));
+	localstatedir = fu_common_get_path (FU_PATH_KIND_LOCALSTATEDIR_PKG);
+	firmware_orig = g_build_filename (localstatedir, "builder", basename, NULL);
+	if (!fu_common_mkdir_parent (firmware_orig, error))
+		return FALSE;
+	if (!g_file_test (firmware_orig, G_FILE_TEST_EXISTS)) {
+		FuFlashromDevice *parent = FU_FLASHROM_DEVICE (device);
+		struct flashrom_flashctx *flashctx = fu_flashrom_device_get_flashctx (parent);
+		gsize flash_size = fu_flashrom_device_get_flash_size (parent);
+		g_autofree guint8 *newcontents = g_malloc0 (flash_size);
+		g_autoptr(GBytes) buf = NULL;
+
+		fu_device_set_status (device, FWUPD_STATUS_DEVICE_READ);
+		if (flashrom_image_read (flashctx, newcontents, flash_size)) {
+			g_set_error_literal (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_READ,
+					     "failed to back up original firmware");
+			return FALSE;
+		}
+		buf = g_bytes_new_static (newcontents, flash_size);
+		if (!fu_common_set_contents_bytes (firmware_orig, buf, error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_flashrom_internal_device_write_firmware (FuDevice *device,
+					    FuFirmware *firmware,
+					    FwupdInstallFlags flags,
+					    GError **error)
+{
+	FuFlashromDevice *parent = FU_FLASHROM_DEVICE (device);
+	struct flashrom_flashctx *flashctx = fu_flashrom_device_get_flashctx (parent);
+	gsize flash_size = fu_flashrom_device_get_flash_size (parent);
+	struct flashrom_layout *layout;
+	gsize sz = 0;
+	gint rc;
+	const guint8 *buf;
+	g_autoptr(GBytes) blob_fw = fu_firmware_get_bytes (firmware, error);
+	if (blob_fw == NULL)
+		return FALSE;
+
+	buf = g_bytes_get_data (blob_fw, &sz);
+
+	if (flashrom_layout_read_from_ifd (&layout, flashctx, NULL, 0)) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_READ,
+				     "failed to read layout from Intel ICH descriptor");
+		return FALSE;
+	}
+
+	/* include bios region for safety reasons */
+	if (flashrom_layout_include_region (layout, "bios")) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "invalid region name");
+		return FALSE;
+	}
+
+	/* write region */
+	flashrom_layout_set (flashctx, layout);
+	if (sz != flash_size) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "invalid image size 0x%x, expected 0x%x",
+			     (guint) sz, (guint) flash_size);
+		return FALSE;
+	}
+
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
+	fu_device_set_progress (device, 0); /* urgh */
+	rc = flashrom_image_write (flashctx, (void *) buf, sz, NULL /* refbuffer */);
+	if (rc != 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_WRITE,
+			     "image write failed, err=%i", rc);
+		return FALSE;
+	}
+
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_VERIFY);
+	if (flashrom_image_verify (flashctx, (void *) buf, sz)) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_WRITE,
+			     "image verify failed");
+		return FALSE;
+	}
+	flashrom_layout_release (layout);
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_flashrom_internal_device_class_init (FuFlashromInternalDeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	klass_device->prepare = fu_flashrom_internal_device_prepare;
+	klass_device->write_firmware = fu_flashrom_internal_device_write_firmware;
+}
+
+FuDevice *
+fu_flashrom_internal_device_new (void)
+{
+	return FU_DEVICE (g_object_new (FU_TYPE_FLASHROM_INTERNAL_DEVICE, NULL));
+}

--- a/plugins/flashrom/fu-flashrom-internal-device.h
+++ b/plugins/flashrom/fu-flashrom-internal-device.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2021 Daniel Campello <campello@chromium.org>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-flashrom-device.h"
+
+#define FU_TYPE_FLASHROM_INTERNAL_DEVICE (fu_flashrom_internal_device_get_type ())
+G_DECLARE_FINAL_TYPE (FuFlashromInternalDevice, fu_flashrom_internal_device, FU,
+		      FLASHROM_INTERNAL_DEVICE, FuFlashromDevice)
+
+FuDevice	*fu_flashrom_internal_device_new			(void);

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 #include "fu-plugin-vfuncs.h"
-#include "fu-flashrom-device.h"
+#include "fu-flashrom-internal-device.h"
 
 #include <libflashrom.h>
 
@@ -34,10 +34,13 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	FuContext *ctx = fu_plugin_get_context (plugin);
+
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "linux_lockdown");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "coreboot"); /* obsoleted */
 	fu_plugin_add_flag (plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
+	fu_context_add_quirk_key (ctx, "FlashromProgrammer");
 }
 
 static int
@@ -164,7 +167,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context (plugin);
 	const gchar *dmi_vendor;
-	g_autoptr(FuDevice) device = fu_flashrom_device_new ();
+	g_autoptr(FuDevice) device = fu_flashrom_internal_device_new ();
 
 	fu_device_set_context (device, ctx);
 	fu_device_set_name (device, fu_context_get_hwid_value (ctx, FU_HWIDS_KEY_PRODUCT_NAME));
@@ -179,6 +182,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_plugin_flashrom_device_set_version (plugin, device);
 	fu_plugin_flashrom_device_set_hwids (plugin, device);
 	fu_plugin_flashrom_device_set_bios_info (plugin, device);
+	fu_flashrom_device_set_programmer_name (FU_FLASHROM_DEVICE (device), "internal");
 	if (!fu_device_setup (device, error))
 		return FALSE;
 

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -9,6 +9,7 @@ shared_module('fu_plugin_flashrom',
   fu_hash,
   sources : [
     'fu-flashrom-device.c',
+    'fu-flashrom-internal-device.c',
     'fu-plugin-flashrom.c',
   ],
   include_directories : [


### PR DESCRIPTION
This change allows other device types to derive from common flashrom
code in the flashrom-device type.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ X ] Code fix
- [ ] Feature
- [ ] Documentation
