### PR TITLE
Wip/analogix simpler

### DIFF
--- a/plugins/analogix/fu-analogix-common.h
+++ b/plugins/analogix/fu-analogix-common.h
@@ -35,7 +35,8 @@ typedef enum {
 	ANX_BB_RQT_GET_UPDATE_STATUS		= 0x10,
 	ANX_BB_RQT_READ_FW_VER			= 0x12,
 	ANX_BB_RQT_READ_CUS_VER			= 0x13,
-	ANX_BB_RQT_READ_FW_RVER			= 0x19
+	ANX_BB_RQT_READ_FW_RVER			= 0x19,
+	ANX_BB_RQT_READ_CUS_RVER        = 0x1c
 } AnxBbRqtCode;
 
 /* wValue low byte */

--- a/plugins/analogix/fu-analogix-common.h
+++ b/plugins/analogix/fu-analogix-common.h
@@ -18,7 +18,7 @@
 #define OCM_FLASH_SIZE				0x18000
 #define SECURE_OCM_TX_SIZE			0x3000
 #define SECURE_OCM_RX_SIZE			0x3000
-#define CUSTOM_FLASH_SIZE			0x1000
+#define CUSTOM_FLASH_SIZE			0x2000
 #define MAX_FILE_SIZE (OCM_FLASH_SIZE+SECURE_OCM_TX_SIZE+ \
 		       SECURE_OCM_RX_SIZE+CUSTOM_FLASH_SIZE+0x1000)
 
@@ -26,7 +26,7 @@
 #define FLASH_TXFW_ADDR				0x31000
 #define FLASH_RXFW_ADDR				0x34000
 #define FLASH_CUSTOM_ADDR			0x38000
-#define OCM_FW_VERSION_ADDR			0x4FF0
+#define OCM_FW_VERSION_ADDR			0x14FF0
 
 /* bRequest for Phoenix-Lite Billboard */
 typedef enum {

--- a/plugins/analogix/fu-analogix-common.h
+++ b/plugins/analogix/fu-analogix-common.h
@@ -15,11 +15,11 @@
 #define BILLBOARD_SUBCLASS			0x00
 #define BILLBOARD_PROTOCOL			0x00
 #define BILLBOARD_MAX_PACKET_SIZE		64
-#define OCM_FLASH_SZIE				0x18000
+#define OCM_FLASH_SIZE				0x18000
 #define SECURE_OCM_TX_SIZE			0x3000
 #define SECURE_OCM_RX_SIZE			0x3000
 #define CUSTOM_FLASH_SIZE			0x1000
-#define MAX_FILE_SIZE (OCM_FLASH_SZIE+SECURE_OCM_TX_SIZE+ \
+#define MAX_FILE_SIZE (OCM_FLASH_SIZE+SECURE_OCM_TX_SIZE+ \
 		       SECURE_OCM_RX_SIZE+CUSTOM_FLASH_SIZE+0x1000)
 
 #define FLASH_OCM_ADDR				0x1000
@@ -52,23 +52,5 @@ typedef enum {
 	UPDATE_STATUS_FINISH,
 	UPDATE_STATUS_ERROR			= 0xFF
 } AnxUpdateStatus;
-
-#define HEX_LINE_HEADER_SIZE			9
-
-typedef struct __attribute__ ((packed)){
-	guint32 fw_start_addr;
-	guint32 fw_end_addr;
-	guint32 fw_payload_len;
-	guint32 custom_start_addr;
-	guint32 custom_payload_len;
-	guint32 secure_tx_start_addr;
-	guint32 secure_tx_payload_len;
-	guint32 secure_rx_start_addr;
-	guint32 secure_rx_payload_len;
-	guint32 total_len;
-	guint16 custom_ver;
-	guint16 fw_ver;
-} AnxImgHeader;
-
 
 const gchar	*fu_analogix_update_status_to_string	(AnxUpdateStatus	 status);

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -14,8 +14,6 @@
 struct _FuAnalogixDevice {
 	FuUsbDevice	 parent_instance;
 	guint8		 iface_idx;		/* bInterfaceNumber */
-	guint8		 ep_num;		/* bEndpointAddress */
-	guint16		 chunk_len;		/* wMaxPacketSize */
 	guint16		 custom_version;
 	guint16		 fw_version;
 };
@@ -27,8 +25,6 @@ fu_analogix_device_to_string (FuDevice *device, guint idt, GString *str)
 {
 	FuAnalogixDevice *self = FU_ANALOGIX_DEVICE (device);
 	fu_common_string_append_kx (str, idt, "IfaceIdx", self->iface_idx);
-	fu_common_string_append_kx (str, idt, "EpNum", self->ep_num);
-	fu_common_string_append_kx (str, idt, "ChunkLen", self->chunk_len);
 	fu_common_string_append_kx (str, idt, "CustomVersion", self->custom_version);
 	fu_common_string_append_kx (str, idt, "FwVersion", self->fw_version);
 }
@@ -225,7 +221,6 @@ fu_analogix_device_find_interface (FuUsbDevice *device, GError **error)
 			if (endpoints == NULL)
 				continue;
 			self->iface_idx = g_usb_interface_get_number (intf);
-			self->chunk_len = BILLBOARD_MAX_PACKET_SIZE;
 			return TRUE;
 		}
 	}

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -328,10 +328,6 @@ fu_analogix_device_write_firmware (FuDevice *device,
 	g_autoptr(FuFirmware) fw_srx = NULL;
 	g_autoptr(FuFirmware) fw_stx = NULL;
 
-	/* get header and payload */
-	if (fw_ocm == NULL)
-		return FALSE;
-
 	/* OCM -> SECURE_TX -> SECURE_RX -> CUSTOM_DEF */
 	fw_cus = fu_firmware_get_image_by_id (firmware, "custom", NULL);
 	if (fw_cus != NULL) {

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -190,12 +190,12 @@ fu_analogix_device_setup (FuDevice *device, GError **error)
 		return FALSE;
 
 	/*  get custom version */
-	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_VER, 0, 0,
-					 &buf_custom[1], 1, error))
-		return FALSE;
-	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_RVER, 0, 0,
-				         &buf_custom[0], 1, error))
-		return FALSE;
+//	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_VER, 0, 0,
+//					 &buf_custom[1], 1, error))
+//		return FALSE;
+//	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_RVER, 0, 0,
+//				         &buf_custom[0], 1, error))
+//		return FALSE;
 	self->fw_version = fu_common_read_uint16 (buf_fw, G_LITTLE_ENDIAN);
 	self->custom_version = fu_common_read_uint16 (buf_custom, G_LITTLE_ENDIAN);
 

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -185,12 +185,12 @@ fu_analogix_device_setup (FuDevice *device, GError **error)
 		return FALSE;
 
 	/*  get custom version */
-//	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_VER, 0, 0,
-//					 &buf_custom[1], 1, error))
-//		return FALSE;
-//	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_RVER, 0, 0,
-//				         &buf_custom[0], 1, error))
-//		return FALSE;
+	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_VER, 0, 0,
+					 &buf_custom[1], 1, error))
+		return FALSE;
+	if (!fu_analogix_device_receive (self, ANX_BB_RQT_READ_CUS_RVER, 0, 0,
+				         &buf_custom[0], 1, error))
+		return FALSE;
 	self->fw_version = fu_common_read_uint16 (buf_fw, G_LITTLE_ENDIAN);
 	self->custom_version = fu_common_read_uint16 (buf_custom, G_LITTLE_ENDIAN);
 

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -48,8 +48,8 @@ fu_analogix_firmware_parse (FuFirmware *firmware,
 	if (g_bytes_get_size (blob) == OCM_FLASH_SIZE) {
 		blob_ocm = g_bytes_ref (blob);
 	} else if (g_bytes_get_size (blob) == CUSTOM_FLASH_SIZE) {
-		/* custom */
-		blob_cus = g_bytes_ref (blob);
+		/* custom , only first 4K bytes are needed */
+		blob_cus = fu_common_bytes_new_offset (blob, 0, CUSTOM_FLASH_SIZE/2, error);
 	} else {
 		blob_ocm = fu_common_bytes_new_offset (blob,
 						       0,


### PR DESCRIPTION
This simplifies the parsing considerably. Using the provided test files I get:

	[hughsie@hughsie-work build (wip/analogix-simpler %)]$ sudo ./src/fwupdtool firmware-parse --plugins analogix /home/hughsie/Downloads/1*.hex analogix
	Loading…                 [***************************************]
	<firmware gtype="FuAnalogixFirmware">
	  <flags>has-checksum</flags>
	  <addr>0x1000</addr>
	  <data size="0x18000">o</data>
	  <firmware>
	    <id>ocm</id>
	    <version>22.ef</version>
	    <version_raw>0x22ef</version_raw>
	    <addr>0x1000</addr>
	    <data size="0x18000">o</data>
	  </firmware>
	</firmware>
	[hughsie@hughsie-work build (wip/analogix-simpler %)]$ sudo ./src/fwupdtool firmware-parse --plugins analogix /home/hughsie/Downloads/2*.hex analogix
	Loading…                 [***************************************]
	<firmware gtype="FuAnalogixFirmware">
	  <flags>has-checksum</flags>
	  <addr>0x1000</addr>
	  <data size="0x36000">o</data>
	  <firmware>
	    <id>ocm</id>
	    <version>e3.aa</version>
	    <version_raw>0xe3aa</version_raw>
	    <addr>0x1000</addr>
	    <data size="0x18000">#</data>
	  </firmware>
	  <firmware>
	    <id>stx</id>
	    <addr>0x31000</addr>
	    <data size="0x3000">
	    </data>
	  </firmware>
	</firmware>
