### PR TITLE
Quit the running fwupd instance when running fwupdtool

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1791,6 +1791,10 @@ fu_main_on_name_lost_cb (GDBusConnection *connection,
 			 gpointer user_data)
 {
 	FuMainPrivate *priv = (FuMainPrivate *) user_data;
+	if (priv->update_in_progress) {
+		g_warning ("name lost during a firmware update, ignoring");
+		return;
+	}
 	g_warning ("another service has claimed the dbus name %s", name);
 	g_main_loop_quit (priv->loop);
 }


### PR DESCRIPTION
Also, this ensures we can't run more than one fwupdtool instance at a time.

Fixes https://github.com/fwupd/fwupd/issues/3019

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
