### PR TITLE
flashrom/lspcon: avoid parsing sysfs paths

### DIFF
--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -118,3 +118,5 @@ gboolean	 fu_udev_device_write_sysfs		(FuUdevDevice	*self,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
 const gchar	*fu_udev_device_get_devtype		(FuUdevDevice	*self);
+GPtrArray 	*fu_udev_device_get_siblings_with_subsystem (FuUdevDevice *self,
+							     const gchar *subsystem);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -781,6 +781,7 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_firmware_write_chunk;
     fu_ihex_firmware_set_padding_value;
     fu_plugin_get_context;
+    fu_udev_device_get_siblings_with_subsystem;
     fu_xmlb_builder_insert_kb;
     fu_xmlb_builder_insert_kv;
     fu_xmlb_builder_insert_kx;

--- a/plugins/flashrom/fu-flashrom-lspcon-i2c-spi-device.c
+++ b/plugins/flashrom/fu-flashrom-lspcon-i2c-spi-device.c
@@ -11,13 +11,12 @@
 
 #include <libflashrom.h>
 
-#define I2C_PATH_REGEX "/i2c-([0-9]+)/"
 #define HID_LENGTH 8
 #define DEVICE_GUID_FORMAT "FLASHROM-LSPCON-I2C-SPI\\VEN_%s&DEV_%s"
 
 struct _FuFlashromLspconI2cSpiDevice {
 	FuFlashromDevice	  parent_instance;
-	gint			  bus_number;
+	gchar			 *bus_path;
 	guint8			  active_partition;
 };
 
@@ -49,6 +48,15 @@ static struct flashrom_layout layout = {
 	.entries = entries, .num_entries = sizeof(entries) / sizeof(entries[0])
 };
 
+static void
+fu_flashrom_lspcon_i2c_spi_device_finalize(GObject *object)
+{
+	FuFlashromLspconI2cSpiDevice *self =
+		FU_FLASHROM_LSPCON_I2C_SPI_DEVICE (object);
+
+	g_free (self->bus_path);
+	G_OBJECT_CLASS (fu_flashrom_lspcon_i2c_spi_device_parent_class)->finalize (object);
+}
 
 static void
 fu_flashrom_lspcon_i2c_spi_device_init (FuFlashromLspconI2cSpiDevice *self)
@@ -64,9 +72,7 @@ fu_flashrom_lspcon_i2c_spi_device_probe (FuDevice *device, GError **error)
 	FuFlashromDevice *flashrom_device = FU_FLASHROM_DEVICE (device);
 	FuDeviceClass *klass =
 		FU_DEVICE_CLASS (fu_flashrom_lspcon_i2c_spi_device_parent_class);
-	g_autoptr(GRegex) regex = NULL;
-	g_autoptr(GMatchInfo) info = NULL;
-	const gchar *path = NULL;
+	g_autoptr(GPtrArray) sibling_buses = NULL;
 
 	/* FuFlashromDevice->probe */
 	if (!klass->probe (device, error))
@@ -81,15 +87,35 @@ fu_flashrom_lspcon_i2c_spi_device_probe (FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	/* get bus number out of sysfs path */
-	path = fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device));
-	regex = g_regex_new (I2C_PATH_REGEX, 0, 0, error);
-	if (regex && g_regex_match_full (regex, path, -1, 0, 0, &info, error)) {
-		self->bus_number = g_ascii_strtoll ( g_match_info_fetch (info, 1),
-					       NULL, 10);
-		return TRUE;
+	/* locate an I2C bus that is a sibling of this device, assumed to be
+	 * the bus the device is connected to */
+	sibling_buses = fu_udev_device_get_siblings_with_subsystem (FU_UDEV_DEVICE (self), "i2c-dev");
+	for (guint i = 0; i < sibling_buses->len; i++) {
+		FuUdevDevice *bus_device = g_ptr_array_index (sibling_buses, i);
+		const gchar *bus_path = fu_udev_device_get_device_file (bus_device);
+
+		if (bus_path == NULL) {
+			g_info ("ignoring bus %s with no device file",
+			        fu_udev_device_get_sysfs_path (bus_device));
+			continue;
+		}
+
+		self->bus_path = g_strdup (bus_path);
+		/* if there are other buses, ignore them (because we already
+		 * have one) but note they exist */
+		if (i < (sibling_buses->len - 1))
+			g_debug ("%u additional buses found but ignored",
+				 sibling_buses->len - i - 1);
+		break;
 	}
-	return FALSE;
+
+	if (self->bus_path == NULL) {
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND,
+			     "Failed to identify I2C bus corresponding to %s",
+			     fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (self)));
+		return FALSE;
+	}
+	return TRUE;
 }
 
 static gboolean
@@ -103,7 +129,7 @@ fu_flashrom_lspcon_i2c_spi_device_open (FuDevice *device,
 	g_autofree gchar *temp = NULL;
 
 	/* flashrom_programmer_init() mutates the programmer_args string. */
-	temp = g_strdup_printf ("bus=%d", self->bus_number);
+	temp = g_strdup_printf ("devpath=%s", self->bus_path);
 	fu_flashrom_device_set_programmer_args (flashrom_device, temp);
 
 	return klass->open (device, error);
@@ -268,7 +294,10 @@ fu_flashrom_lspcon_i2c_spi_device_write_firmware (FuDevice *device,
 static void
 fu_flashrom_lspcon_i2c_spi_device_class_init (FuFlashromLspconI2cSpiDeviceClass *klass)
 {
+	GObjectClass *klass_object = G_OBJECT_CLASS (klass);
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+
+	klass_object->finalize = fu_flashrom_lspcon_i2c_spi_device_finalize;
 	klass_device->probe = fu_flashrom_lspcon_i2c_spi_device_probe;
 	klass_device->open = fu_flashrom_lspcon_i2c_spi_device_open;
 	klass_device->setup = fu_flashrom_lspcon_i2c_spi_device_setup;


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Parsing bus numbers out of sysfs paths may be fragile, so use udev to find the I2C bus matching a LSPCON device. Support for specifying an I2C bus by path rather than number is also required in flashrom, implemented at https://review.coreboot.org/c/flashrom/+/51967; the flashrom dependency will require an update to provide this support once merged upstream.