### PR TITLE
Mark the Lenovo VL103 no-power USB-C dongle as dual-image

### DIFF
--- a/plugins/vli/vli-pd.quirk
+++ b/plugins/vli/vli-pd.quirk
@@ -65,6 +65,7 @@ GType = FuVliPdDevice
 [USB\VID_17EF&PID_7223]
 Plugin = vli
 GType = FuVliPdDevice
+Flags = dual-image
 
 # Samsung
 [USB\VID_04E8&PID_A025]


### PR DESCRIPTION
This fixes flashing when in normal runtime mode.

Resolves https://github.com/fwupd/fwupd/issues/2940

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
