### PR TITLE
Add a utility to resign firmware files

### DIFF
--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -9,6 +9,7 @@ _fwupdtool_cmd_list=(
 	'firmware-export'
 	'firmware-extract'
 	'firmware-parse'
+	'firmware-sign'
 	'get-updates'
 	'get-upgrades'
 	'get-details'

--- a/libfwupdplugin/fu-cabinet.h
+++ b/libfwupdplugin/fu-cabinet.h
@@ -26,6 +26,30 @@ typedef enum {
 	FU_CABINET_PARSE_FLAG_LAST
 } FuCabinetParseFlags;
 
+/**
+ * FuCabinetExportFlags:
+ * @FU_CABINET_EXPORT_FLAG_NONE:		No flags set
+ *
+ * The flags to use when exporting the archive.
+ **/
+typedef enum {
+	FU_CABINET_EXPORT_FLAG_NONE		= 0,
+	/*< private >*/
+	FU_CABINET_EXPORT_FLAG_LAST
+} FuCabinetExportFlags;
+
+/**
+ * FuCabinetSignFlags:
+ * @FU_CABINET_SIGN_FLAG_NONE:		No flags set
+ *
+ * The flags to use when signing the archive.
+ **/
+typedef enum {
+	FU_CABINET_SIGN_FLAG_NONE		= 0,
+	/*< private >*/
+	FU_CABINET_SIGN_FLAG_LAST
+} FuCabinetSignFlags;
+
 FuCabinet	*fu_cabinet_new			(void);
 void		 fu_cabinet_set_size_max	(FuCabinet		*self,
 						 guint64		 size_max);
@@ -34,6 +58,22 @@ void		 fu_cabinet_set_jcat_context	(FuCabinet		*self,
 gboolean	 fu_cabinet_parse		(FuCabinet		*self,
 						 GBytes			*data,
 						 FuCabinetParseFlags	 flags,
+						 GError			**error)
+						 G_GNUC_WARN_UNUSED_RESULT;
+gboolean	 fu_cabinet_sign		(FuCabinet		*self,
+						 GBytes			*cert,
+						 GBytes			*privkey,
+						 FuCabinetSignFlags	 flags,
+						 GError			**error)
+						 G_GNUC_WARN_UNUSED_RESULT;
+void		 fu_cabinet_add_file		(FuCabinet		*self,
+						 const gchar		*basename,
+						 GBytes			*data);
+GBytes		*fu_cabinet_get_file		(FuCabinet		*self,
+						 const gchar		*basename,
+						 GError			**error);
+GBytes		*fu_cabinet_export		(FuCabinet		*self,
+						 FuCabinetExportFlags	 flags,
 						 GError			**error)
 						 G_GNUC_WARN_UNUSED_RESULT;
 XbSilo		*fu_cabinet_get_silo		(FuCabinet		*self);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -716,6 +716,10 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_byte_array_align_up;
     fu_byte_array_set_size_full;
     fu_bytes_get_data_safe;
+    fu_cabinet_add_file;
+    fu_cabinet_export;
+    fu_cabinet_get_file;
+    fu_cabinet_sign;
     fu_common_align_up;
     fu_context_add_compile_version;
     fu_context_add_firmware_gtype;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <jcat.h>
 
+#include "fu-cabinet.h"
 #include "fu-context-private.h"
 #include "fu-device-private.h"
 #include "fu-engine.h"
@@ -844,6 +845,53 @@ fu_util_install_blob (FuUtilPrivate *priv, gchar **values, GError **error)
 
 	/* success */
 	return fu_util_prompt_complete (priv->completion_flags, TRUE, error);
+}
+
+static gboolean
+fu_util_firmware_sign (FuUtilPrivate *priv, gchar **values, GError **error)
+{
+	g_autoptr(FuCabinet) cabinet = fu_cabinet_new ();
+	g_autoptr(GBytes) archive_blob_new = NULL;
+	g_autoptr(GBytes) archive_blob_old = NULL;
+	g_autoptr(GBytes) cert = NULL;
+	g_autoptr(GBytes) privkey = NULL;
+
+	/* invalid args */
+	if (g_strv_length (values) != 3) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INVALID_ARGS,
+				     "Invalid arguments, expected firmware.cab "
+				     "certificate.pem privatekey.pfx");
+		return FALSE;
+	}
+
+	/* load arguments */
+	archive_blob_old = fu_common_get_contents_bytes (values[0], error);
+	if (archive_blob_old == NULL)
+		return FALSE;
+	cert = fu_common_get_contents_bytes (values[1], error);
+	if (cert == NULL)
+		return FALSE;
+	privkey = fu_common_get_contents_bytes (values[2], error);
+	if (privkey == NULL)
+		return FALSE;
+
+	/* load, sign, export */
+	if (!fu_cabinet_parse (cabinet, archive_blob_old,
+			       FU_CABINET_PARSE_FLAG_NONE,
+			       error))
+		return FALSE;
+	if (!fu_cabinet_sign (cabinet, cert, privkey,
+			      FU_CABINET_SIGN_FLAG_NONE,
+			      error))
+		return FALSE;
+	archive_blob_new = fu_cabinet_export (cabinet,
+					      FU_CABINET_EXPORT_FLAG_NONE,
+					      error);
+	if (archive_blob_new == NULL)
+		return FALSE;
+	return fu_common_set_contents_bytes (values[0], archive_blob_new, error);
 }
 
 static gboolean
@@ -3094,6 +3142,13 @@ main (int argc, char *argv[])
 		     /* TRANSLATORS: command description */
 		     _("Update the stored metadata with current contents"),
 		     fu_util_verify_update);
+	fu_util_cmd_array_add (cmd_array,
+		     "firmware-sign",
+		     /* TRANSLATORS: command argument: uppercase, spaces->dashes */
+		     _("FILENAME CERTIFICATE PRIVATE-KEY"),
+		     /* TRANSLATORS: command description */
+		     _("Sign a firmware with a new key"),
+		     fu_util_firmware_sign);
 	fu_util_cmd_array_add (cmd_array,
 		     "firmware-dump",
 		     /* TRANSLATORS: command argument: uppercase, spaces->dashes */


### PR DESCRIPTION
This can be used like this:

    fwupdtool firmware-sign firmware.cab rhughes_signed.pem rhughes.key

Test signing certificates can be generated using the example script here:
https://github.com/hughsie/libjcat/blob/master/contrib/build-certs.py although
these certificates should not be used for enterprise use.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
