### PR TITLE
fu-tool.c: Use traditional UNIX record locks if OFD is not available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -352,6 +352,9 @@ endif
 if cc.has_header_symbol('fcntl.h', 'F_WRLCK')
   conf.set('HAVE_WRLCK', '1')
 endif
+if cc.has_header_symbol('fcntl.h', 'F_OFD_SETLK')
+  conf.set('HAVE_OFD', '1')
+endif
 if cc.has_function('pwrite', args : '-D_XOPEN_SOURCE')
   conf.set('HAVE_PWRITE', '1')
 endif

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2811,6 +2811,7 @@ fu_util_lock (FuUtilPrivate *priv, GError **error)
 	}
 
 	/* write lock */
+#ifdef HAVE_OFD
 	if (fcntl (priv->lock_fd, F_OFD_SETLK, &lockp) < 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
@@ -2819,6 +2820,16 @@ fu_util_lock (FuUtilPrivate *priv, GError **error)
 			     lockfn);
 		return FALSE;
 	}
+#else
+	if (fcntl (priv->lock_fd, F_SETLK, &lockp) < 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "another instance has locked %s",
+			     lockfn);
+		return FALSE;
+	}
+#endif
 
 	/* success */
 	g_debug ("locked %s", lockfn);


### PR DESCRIPTION
Open file description locks are Linux-specific. If fwupd is not built
for Linux, it should use the traditional UNIX record locks (F_SETLK).

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
