### PR TITLE
cpu/meson.build: Do not build fwupdcethelper for DragonflyBSD

### DIFF
--- a/plugins/cpu/meson.build
+++ b/plugins/cpu/meson.build
@@ -27,7 +27,7 @@ shared_module('fu_plugin_cpu',
   ],
 )
 
-if cc.has_argument('-fcf-protection')
+if cc.has_argument('-fcf-protection') and host_machine.system() != 'dragonfly'
   libfwupdcethelper = static_library('fwupdcethelper',
     sources : [
       'fu-cpu-helper-cet-common.c',


### PR DESCRIPTION
The DragonFlyBSD compiler throws assembler error during the library
compilation: Error: no such instruction: 'endbr64'.

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
