### PR TITLE
fu_dfu_tool_get_default_device: Avoid use-after-free

### DIFF
--- a/plugins/dfu/fu-dfu-tool.c
+++ b/plugins/dfu/fu-dfu-tool.c
@@ -229,7 +229,7 @@ fu_dfu_tool_get_default_device (FuDfuTool *self, GError **error)
 		}
 		device = fu_dfu_device_new (usb_device);
 		fu_device_set_context (FU_DEVICE (device), self->ctx);
-		return device;
+		return g_steal_pointer (&device);
 	}
 
 	/* auto-detect first device */


### PR DESCRIPTION
fu_dfu_tool_get_default_device returns a newly create FuDfuDevice `device`; but since it is marked as `g_autoptr`, it is destroyed when leaving the scope and the caller receives garbage.

```
,----
| ==697985== Invalid read of size 8
| ==697985==    at 0x4B50F49: g_type_check_instance_is_fundamentally_a (gtype.c:4080)
| ==697985==    by 0x4B3A988: g_object_unref (gobject.c:3421)
| ==697985==    by 0x406CF3: glib_autoptr_clear_GObject (gobject-autocleanups.h:27)
| ==697985==    by 0x406DD5: glib_autoptr_clear_FwupdDevice (gusb-autocleanups.h:17)
| ==697985==    by 0x406E9C: glib_autoptr_clear_FuDevice (fu-device.h:18)
| ==697985==    by 0x406EE3: glib_autoptr_clear_FuUsbDevice (fu-usb-device.h:22)
| ==697985==    by 0x406F6A: glib_autoptr_clear_FuDfuDevice (fu-dfu-device.h:19)
| ==697985==    by 0x406F88: glib_autoptr_cleanup_FuDfuDevice (fu-dfu-device.h:19)
| ==697985==    by 0x40898D: fu_dfu_tool_read (fu-dfu-tool.c:577)
| ==697985==    by 0x407518: fu_dfu_tool_run (fu-dfu-tool.c:162)
| ==697985==    by 0x4097E0: main (fu-dfu-tool.c:959)
| ==697985==  Address 0x67fbfe0 is 640 bytes inside a block of size 672 free'd
| ==697985==    at 0x48430E4: free (vg_replace_malloc.c:755)
| ==697985==    by 0x4BD124C: g_free (gmem.c:199)
| ==697985==    by 0x4BEB76F: g_slice_free1 (gslice.c:1180)
| ==697985==    by 0x4B4FDBB: g_type_free_instance (gtype.c:1993)
| ==697985==    by 0x406CF3: glib_autoptr_clear_GObject (gobject-autocleanups.h:27)
| ==697985==    by 0x406DD5: glib_autoptr_clear_FwupdDevice (gusb-autocleanups.h:17)
| ==697985==    by 0x406E9C: glib_autoptr_clear_FuDevice (fu-device.h:18)
| ==697985==    by 0x406EE3: glib_autoptr_clear_FuUsbDevice (fu-usb-device.h:22)
| ==697985==    by 0x406F6A: glib_autoptr_clear_FuDfuDevice (fu-dfu-device.h:19)
| ==697985==    by 0x406F88: glib_autoptr_cleanup_FuDfuDevice (fu-dfu-device.h:19)
| ==697985==    by 0x407762: fu_dfu_tool_get_default_device (fu-dfu-tool.c:191)
| ==697985==    by 0x408736: fu_dfu_tool_read (fu-dfu-tool.c:592)
| ==697985==  Block was alloc'd at
| ==697985==    at 0x484086F: malloc (vg_replace_malloc.c:380)
| ==697985==    by 0x4BD4938: g_malloc (gmem.c:106)
| ==697985==    by 0x4BEC1F4: g_slice_alloc (gslice.c:1069)
| ==697985==    by 0x4BEC85D: g_slice_alloc0 (gslice.c:1095)
| ==697985==    by 0x4B5511A: g_type_create_instance (gtype.c:1893)
| ==697985==    by 0x4B3CB8C: g_object_new_internal (gobject.c:1939)
| ==697985==    by 0x4B3E107: g_object_new_valist (gobject.c:2282)
| ==697985==    by 0x4B3E63C: g_object_new (gobject.c:1782)
| ==697985==    by 0x40B0CF: fu_dfu_device_new (fu-dfu-device.c:571)
| ==697985==    by 0x407723: fu_dfu_tool_get_default_device (fu-dfu-tool.c:230)
| ==697985==    by 0x408736: fu_dfu_tool_read (fu-dfu-tool.c:592)
| ==697985==    by 0x407518: fu_dfu_tool_run (fu-dfu-tool.c:162)
`----
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
