### PR TITLE
Check FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN when calculating the SUPPORTED flag

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2203,6 +2203,16 @@ fu_device_set_logical_id (FuDevice *self, const gchar *logical_id)
 	if (g_strcmp0 (priv->logical_id, logical_id) == 0)
 		return;
 
+	/* not allowed after ->probe() and ->setup() have completed */
+	if (priv->done_setup) {
+		g_warning ("cannot change %s logical ID from %s to %s as "
+			   "FuDevice->setup() has already completed",
+			   fu_device_get_id (self),
+			   priv->logical_id,
+			   logical_id);
+		return;
+	}
+
 	g_free (priv->logical_id);
 	priv->logical_id = g_strdup (logical_id);
 	priv->device_id_valid = FALSE;
@@ -2326,6 +2336,16 @@ fu_device_set_physical_id (FuDevice *self, const gchar *physical_id)
 	/* not changed */
 	if (g_strcmp0 (priv->physical_id, physical_id) == 0)
 		return;
+
+	/* not allowed after ->probe() and ->setup() have completed */
+	if (priv->done_setup) {
+		g_warning ("cannot change %s physical ID from %s to %s as "
+			   "FuDevice->setup() has already completed",
+			   fu_device_get_id (self),
+			   priv->physical_id,
+			   physical_id);
+		return;
+	}
 
 	g_free (priv->physical_id);
 	priv->physical_id = g_strdup (physical_id);

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -109,15 +109,18 @@ static gboolean
 fu_flashrom_device_probe (FuDevice *device, GError **error)
 {
 	const gchar *dev_name = NULL;
-	g_autofree gchar *path = NULL;
+	const gchar *sysfs_path = NULL;
 
 	/* FuUdevDevice->probe */
 	if (!FU_DEVICE_CLASS (fu_flashrom_device_parent_class)->probe (device, error))
 		return FALSE;
 
-	path = g_strdup_printf ("DEVNAME=%s",
-				fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device)));
-	fu_device_set_physical_id (device, path);
+	sysfs_path = fu_udev_device_get_sysfs_path (FU_UDEV_DEVICE (device));
+	if (sysfs_path != NULL) {
+		g_autofree gchar *physical_id = NULL;
+		physical_id = g_strdup_printf ("DEVNAME=%s", sysfs_path);
+		fu_device_set_physical_id (device, physical_id);
+	}
 	dev_name = fu_udev_device_get_sysfs_attr (FU_UDEV_DEVICE (device), "name", NULL);
 	if (dev_name != NULL) {
 		fu_device_add_instance_id_full (device, dev_name,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4580,7 +4580,8 @@ fu_engine_get_releases_for_device (FuEngine *self,
 	}
 
 	/* only show devices that can be updated */
-	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE)) {
+	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE) &&
+	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN)) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
If the device is on battery power, the device will have at least one inhibit
and be in FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN state.

It's still supported, and it's misleading to suggest there are no updates
available. Just check both flags.

Fixes the 3rd half (sic) of https://github.com/fwupd/fwupd/issues/3156

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
