### PR TITLE
1_4_X: Add an option to avoid building UEFI binary

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -39,3 +39,4 @@ option('efi_sbat_distro_summary', type : 'string', value : '', description : 'SB
 option('efi_sbat_distro_pkgname', type : 'string', value : '', description : 'SBAT distribution package name, e.g. fwupd')
 option('efi_sbat_distro_version', type : 'string', value : '', description : 'SBAT distribution version, e.g. fwupd-1.5.6.fc33')
 option('efi_sbat_distro_url', type : 'string', value : '', description : 'SBAT distribution URL, e.g. https://src.fedoraproject.org/rpms/fwupd')
+option('efi_binary', type: 'boolean', value: 'true', description : 'build included UEFI binary if missing')

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -1,4 +1,9 @@
-subdir('efi')
+if get_option('efi_binary')
+  efi_binary = dependency('fwupd-efi', required: false)
+  if not efi_binary.found()
+    subdir('efi')
+  endif
+endif
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefi"']
 


### PR DESCRIPTION
This will allow packagers to choose to distribute the binary from
the fwupd-efi subproject instead.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
