### PR TITLE
1_1_X: Add an option to avoid building UEFI binary

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,3 +24,4 @@ option('efi-ld', type : 'string', value : 'ld', description : 'the linker to use
 option('efi-libdir', type : 'string', description : 'path to the EFI lib directory')
 option('efi-ldsdir', type : 'string', description : 'path to the EFI lds directory')
 option('efi-includedir', type : 'string', value : '/usr/include/efi', description : 'path to the EFI header directory')
+option('efi_binary', type: 'boolean', value: 'true', description : 'build included UEFI binary if missing')

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -1,4 +1,9 @@
-subdir('efi')
+if get_option('efi_binary')
+  efi_binary = dependency('fwupd-efi', required: false)
+  if not efi_binary.found()
+    subdir('efi')
+  endif
+endif
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefi"']
 cargs += '-DEFI_APP_LOCATION_BUILD="' + app.full_path() + '"'


### PR DESCRIPTION
This will allow packagers to choose to distribute the binary from
the fwupd-efi subproject instead.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
