### PR TITLE
flashrom: support multiple device GTypes on I2C

### DIFF
--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -4,7 +4,16 @@ Flashrom
 Introduction
 ------------
 
-This plugin uses `flashrom` to update the system firmware.
+This plugin uses `libflashrom` to update various types of device:
+
+ * system firmware
+ * Parade Technologies DisplayPort-to-HDMI converters
+
+Though these devices are very dissimilar, they must currently be handled in a
+single plugin because the underlying APIs in `libflashrom` are not reentrant:
+it has internal global state that means it cannot be safely used from multiple
+points in a single process, as it may be if multiple plugins were to use the
+library.
 
 Firmware Format
 ---------------

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -40,6 +40,7 @@ Plugin = flashrom
 # Parade PS175
 [1AF80175:00]
 Plugin=flashrom
+GType=FuFlashromLspconI2cSpiDevice
 FlashromProgrammer=lspcon_i2c_spi
 Name=PS175
 Vendor=Parade


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [x] Documentation

In order to support multiple kinds of I2C devices, the flashrom plugin must
provide its own backend_device_added function to determine the correct
specialized GType for a given device because there is no standard way for
fwupd to identify I2C devices beyond simply matching a udev subsystem.
In order to support additional GTypes, the plugin does additional probing
based on sysfs name which is suitable for the current LSPCON support and
planned future devices.

While support for various different kinds of device would be better implemented
in different plugins to achieve logical separation of devices that share only
an underlying library, libflashrom as it currently exists does not support
such a use case: document that reasoning in the plugin's README.