### PR TITLE
Switch from libproxy to GProxyResolver

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -16,7 +16,6 @@ meson .. \
     --bindir=$target \
     -Dbuild=standalone \
     -Dpolkit=false \
-    -Dproxy=false \
     -Dplugin_flashrom=false \
     -Dplugin_uefi_capsule=false \
     -Dplugin_redfish=false \

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -833,27 +833,6 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency type="build" id="libproxy-dev">
-    <distro id="arch">
-      <package>libproxy</package>
-    </distro>
-    <distro id="centos">
-      <package>libproxy-devel</package>
-    </distro>
-    <distro id="fedora">
-      <package>libproxy-devel</package>
-    </distro>
-    <distro id="debian">
-      <control />
-      <package variant="x86_64" />
-      <package variant="s390x">libproxy-dev:s390x</package>
-      <package variant="i386" />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-    </distro>
-  </dependency>
   <dependency type="build" id="libtool-bin">
     <distro id="debian">
       <control />

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -37,10 +37,6 @@ if get_option('curl')
   libfwupd_deps += libcurl
 endif
 
-if get_option('proxy')
-  libfwupd_deps += libproxy
-endif
-
 libfwupd_src = [
   'fwupd-client.c',
   'fwupd-client-sync.c',

--- a/meson.build
+++ b/meson.build
@@ -230,10 +230,6 @@ if get_option('curl')
     conf.set('HAVE_LIBCURL_7_62_0', '1')
   endif
 endif
-if get_option('proxy')
-  libproxy = dependency('libproxy-1.0')
-  conf.set('HAVE_LIBPROXY', '1')
-endif
 if build_daemon
   if get_option('polkit')
     polkit = dependency('polkit-gobject-1', version : '>= 0.103')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,7 +40,6 @@ option('elogind', type : 'boolean', value : false, description : 'enable elogind
 option('tests', type : 'boolean', value : true, description : 'enable tests')
 option('soup_session_compat', type : 'boolean', value : true, description : 'enable SoupSession runtime compatibility support')
 option('curl', type : 'boolean', value : true, description : 'enable libcurl support')
-option('proxy', type : 'boolean', value : true, description : 'enable libproxy support')
 option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
 option('efi_os_dir', type: 'string', description : 'the hardcoded name of OS directory in ESP, e.g. fedora')
 option('efi_binary', type: 'boolean', value : true, description : 'generate uefi binary if missing')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -211,7 +211,6 @@ parts:
       - libpango1.0-dev
       - libpci-dev
       - libpolkit-gobject-1-dev
-      - libproxy-dev
       - libsmbios-dev
       - libsqlite3-dev
       - libsystemd-dev
@@ -232,7 +231,6 @@ parts:
       - libgpgme11
       - libjson-glib-1.0-0
       - libpolkit-gobject-1-0
-      - libproxy1v5
       - libsmbios-c2
       - glib-networking
       - libglib2.0-bin


### PR DESCRIPTION
GProxyResolver will use libproxy only when required. TIL.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
