### PR TITLE
Fix regression in build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -369,6 +369,9 @@ endif
 if build_standalone and get_option('plugin_uefi_capsule')
   efiboot = dependency('efiboot')
 
+  efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
+  conf.set_quoted('EFI_APP_LOCATION', efi_app_location)
+
   if host_cpu == 'x86'
           EFI_MACHINE_TYPE_NAME = 'ia32'
   elif host_cpu == 'x86_64'


### PR DESCRIPTION
Reverts small part of 99832622e157067e40896815ace0f8f7a153e8af

`EFI_APP_LOCATION` conf var (or `FWUPD_EFIAPPDIR` env var) is needed for
```
  fu_common_get_path (FU_KIND_PATH_EFIAPPDIR)
```
to function properly

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
