### PR TITLE
flashrom: allow devices to control when the programmer is opened

### DIFF
--- a/plugins/flashrom/fu-flashrom-device.h
+++ b/plugins/flashrom/fu-flashrom-device.h
@@ -16,10 +16,26 @@ struct _FuFlashromDeviceClass {
 G_DECLARE_DERIVABLE_TYPE (FuFlashromDevice, fu_flashrom_device, FU,
 			  FLASHROM_DEVICE, FuUdevDevice)
 
+/**
+ * FuFlashromDeviceFlags:
+ * @FU_FLASHROM_DEVICE_FLAG_NONE:		No flags set
+ * @FU_FLASHROM_DEVICE_FLAG_OPEN_PROGRAMMER:	Call open_programmer on FuDevice->open
+ */
+typedef enum {
+	FU_FLASHROM_DEVICE_FLAG_NONE = 0,
+	FU_FLASHROM_DEVICE_FLAG_OPEN_PROGRAMMER = 1,
+} FuFlashromDeviceFlags;
+
 void		 fu_flashrom_device_set_programmer_name	(FuFlashromDevice *self,
 							 const gchar	*name);
 const gchar	*fu_flashrom_device_get_programmer_name (FuFlashromDevice *self);
 void		 fu_flashrom_device_set_programmer_args	(FuFlashromDevice *self,
 							 const gchar	*args);
+FuFlashromDeviceFlags fu_flashrom_device_get_flags (FuFlashromDevice *self);
+void 		 fu_flashrom_device_set_flags (FuFlashromDevice *self,
+					       FuFlashromDeviceFlags flags);
+gboolean 	 fu_flashrom_device_open_programmer (FuFlashromDevice *self,
+						     GError **error);
+void		 fu_flashrom_device_close_programmer (FuFlashromDevice *self);
 gsize		 fu_flashrom_device_get_flash_size	(FuFlashromDevice *self);
 struct flashrom_flashctx *fu_flashrom_device_get_flashctx (FuFlashromDevice *self);

--- a/plugins/flashrom/fu-flashrom-internal-device.c
+++ b/plugins/flashrom/fu-flashrom-internal-device.c
@@ -21,6 +21,9 @@ G_DEFINE_TYPE (FuFlashromInternalDevice, fu_flashrom_internal_device,
 static void
 fu_flashrom_internal_device_init (FuFlashromInternalDevice *self)
 {
+	fu_flashrom_device_set_flags (FU_FLASHROM_DEVICE (self),
+				      FU_FLASHROM_DEVICE_FLAG_OPEN_PROGRAMMER);
+
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);

--- a/plugins/flashrom/fu-flashrom-lspcon-i2c-spi-device.c
+++ b/plugins/flashrom/fu-flashrom-lspcon-i2c-spi-device.c
@@ -77,6 +77,9 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FlashromLayout, dispose_flash_layout);
 static void
 fu_flashrom_lspcon_i2c_spi_device_init (FuFlashromLspconI2cSpiDevice *self)
 {
+	fu_flashrom_device_set_flags (FU_FLASHROM_DEVICE (self),
+				      FU_FLASHROM_DEVICE_FLAG_OPEN_PROGRAMMER);
+
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 }
@@ -141,7 +144,6 @@ fu_flashrom_lspcon_i2c_spi_device_open (FuDevice *device,
 		return FALSE;
 	}
 	fu_udev_device_set_fd (FU_UDEV_DEVICE (self), bus_fd);
-	fu_udev_device_set_flags (FU_UDEV_DEVICE (self), FU_UDEV_DEVICE_FLAG_NONE);
 
 	return klass->open (device, error);
 }


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Some devices need better control over when the flashrom programmer is opened,
because opening the programmer and probing the flash may involve the device
changing mode, such as entering a bootloader mode which should be done in
detach() rather than open(). Add a flag for flashrom devices allowing them
to indicate if opening the device should automatically connect the programmer,
otherwise allowing them to explicitly connect at a device-controlled time.

This change supports a new device I'm currently working on support for, where connecting flashrom to it puts it into a bootloader mode in which its normal functionality is unavailable.