### PR TITLE
modem-manager: add generic support for PCI based modems

### DIFF
--- a/plugins/modem-manager/fu-mm-utils.c
+++ b/plugins/modem-manager/fu-mm-utils.c
@@ -12,59 +12,129 @@
 
 #include "fu-mm-utils.h"
 
-gboolean
-fu_mm_utils_get_udev_port_info (GUdevDevice	 *device,
-				gchar		**out_device_sysfs_path,
-				gint		 *out_port_ifnum,
-				GError		**error)
+static gchar *
+find_device_bus_subsystem (GUdevDevice *device)
 {
-	gint port_ifnum = -1;
-	const gchar *aux;
-	g_autoptr(GUdevDevice) parent = NULL;
-	g_autofree gchar *device_sysfs_path = NULL;
+	g_autoptr(GUdevDevice) iter = NULL;
 
-	/* ID_USB_INTERFACE_NUM is set on the port device itself */
-	aux = g_udev_device_get_property (device, "ID_USB_INTERFACE_NUM");
-	if (aux != NULL)
-		port_ifnum = (guint16) g_ascii_strtoull (aux, NULL, 16);
-
-	/* we need to traverse all parents of the give udev device until we find
-	 * the first 'usb_device' reported, which is the GUdevDevice associated with
-	 * the full USB device (i.e. all ports of the same device).
-	 */
-	parent = g_udev_device_get_parent (device);
-	while (parent != NULL) {
+	iter = g_object_ref (device);
+	while (iter != NULL) {
 		g_autoptr(GUdevDevice) next = NULL;
+		const gchar *subsys;
 
-		if (g_strcmp0 (g_udev_device_get_devtype (parent), "usb_device") == 0) {
-			device_sysfs_path = g_strdup (g_udev_device_get_sysfs_path (parent));
-			break;
+		/* stop search as soon as we find a parent object
+		 * of one of the bus subsystems supported in
+		 * ModemManager */
+		subsys = g_udev_device_get_subsystem (iter);
+		if ((g_strcmp0 (subsys, "usb") == 0)      ||
+		    (g_strcmp0 (subsys, "pcmcia") == 0)   ||
+		    (g_strcmp0 (subsys, "pci") == 0)      ||
+		    (g_strcmp0 (subsys, "platform") == 0) ||
+		    (g_strcmp0 (subsys, "pnp") == 0)      ||
+		    (g_strcmp0 (subsys, "sdio") == 0)) {
+			return g_ascii_strup (subsys, -1);
 		}
 
-		/* check next parent */
-		next = g_udev_device_get_parent (parent);
-		g_set_object (&parent, next);
+		next = g_udev_device_get_parent (iter);
+		g_set_object (&iter, next);
 	}
 
-	if (parent == NULL) {
+	/* no more parents to check */
+	return NULL;
+}
+
+gboolean
+fu_mm_utils_get_udev_port_info (GUdevDevice	 *device,
+				gchar		**out_device_bus,
+				gchar		**out_device_sysfs_path,
+				gint		 *out_port_usb_ifnum,
+				GError		**error)
+{
+	gint port_usb_ifnum = -1;
+	g_autoptr(GUdevDevice) parent = NULL;
+	g_autofree gchar *device_sysfs_path = NULL;
+	g_autofree gchar *device_bus = NULL;
+
+	/* lookup the main bus the device is in; for supported devices it will
+	 * usually be either 'PCI' or 'USB' */
+	device_bus = find_device_bus_subsystem (device);
+	if (device_bus == NULL) {
 		g_set_error (error,
 			     G_IO_ERROR,
 			     G_IO_ERROR_NOT_FOUND,
-			     "failed to lookup device info: parent usb_device not found");
+			     "failed to lookup device info: bus not found");
 		return FALSE;
 	}
 
-	if (out_port_ifnum != NULL)
-		*out_port_ifnum = port_ifnum;
+	if (g_strcmp0 (device_bus, "USB") == 0) {
+		/* ID_USB_INTERFACE_NUM is set on the port device itself */
+		const gchar *aux = g_udev_device_get_property (device, "ID_USB_INTERFACE_NUM");
+		if (aux != NULL)
+			port_usb_ifnum = (guint16) g_ascii_strtoull (aux, NULL, 16);
+
+		/* we need to traverse all parents of the give udev device until we find
+		 * the first 'usb_device' reported, which is the GUdevDevice associated with
+		 * the full USB device (i.e. all ports of the same device).
+		 */
+		parent = g_udev_device_get_parent (device);
+		while (parent != NULL) {
+			g_autoptr(GUdevDevice) next = NULL;
+
+			if (g_strcmp0 (g_udev_device_get_devtype (parent), "usb_device") == 0) {
+				device_sysfs_path = g_strdup (g_udev_device_get_sysfs_path (parent));
+				break;
+			}
+
+			/* check next parent */
+			next = g_udev_device_get_parent (parent);
+			g_set_object (&parent, next);
+		}
+	} else if (g_strcmp0 (device_bus, "PCI") == 0) {
+		/* the first parent in the 'pci' subsystem is our physical device */
+		parent = g_udev_device_get_parent (device);
+		while (parent != NULL) {
+			g_autoptr(GUdevDevice) next = NULL;
+
+			if (g_strcmp0 (g_udev_device_get_subsystem (parent), "pci") == 0) {
+				device_sysfs_path = g_strdup (g_udev_device_get_sysfs_path (parent));
+				break;
+			}
+
+			/* check next parent */
+			next = g_udev_device_get_parent (parent);
+			g_set_object (&parent, next);
+		}
+	} else {
+		/* other subsystems, we don't support firmware upgrade for those */
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "device bus unsupported: %s", device_bus);
+		return FALSE;
+	}
+
+	if (device_sysfs_path == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_FOUND,
+			     "failed to lookup device info: physical device not found");
+		return FALSE;
+	}
+
+	if (out_port_usb_ifnum != NULL)
+		*out_port_usb_ifnum = port_usb_ifnum;
 	if (out_device_sysfs_path != NULL)
 		*out_device_sysfs_path = g_steal_pointer (&device_sysfs_path);
+	if (out_device_bus != NULL)
+		*out_device_bus = g_steal_pointer (&device_bus);
 	return TRUE;
 }
 
 gboolean
 fu_mm_utils_get_port_info (const gchar	 *path,
+			   gchar	**out_device_bus,
 			   gchar	**out_device_sysfs_path,
-			   gint		 *out_port_ifnum,
+			   gint		 *out_port_usb_ifnum,
 			   GError	**error)
 {
 	g_autoptr(GUdevClient) client = NULL;
@@ -80,5 +150,5 @@ fu_mm_utils_get_port_info (const gchar	 *path,
 		return FALSE;
 	}
 
-	return fu_mm_utils_get_udev_port_info (dev, out_device_sysfs_path, out_port_ifnum, error);
+	return fu_mm_utils_get_udev_port_info (dev, out_device_bus, out_device_sysfs_path, out_port_usb_ifnum, error);
 }

--- a/plugins/modem-manager/fu-mm-utils.h
+++ b/plugins/modem-manager/fu-mm-utils.h
@@ -11,12 +11,14 @@
 #include <gudev/gudev.h>
 
 gboolean	fu_mm_utils_get_udev_port_info	(GUdevDevice	 *dev,
+						 gchar		**device_bus,
 						 gchar		**device_sysfs_path,
-						 gint		 *port_ifnum,
+						 gint		 *port_usb_ifnum,
 						 GError		**error);
 gboolean	fu_mm_utils_get_port_info	(const gchar	 *path,
+						 gchar		**device_bus,
 						 gchar		**device_sysfs_path,
-						 gint		 *port_ifnum,
+						 gint		 *port_usb_ifnum,
 						 GError		**error);
 
 #endif /* __FU_MM_UTILS_H */


### PR DESCRIPTION
No longer rely on the modems being USB based, we can also support PCI based devices with the same protocols.

Type of pull request:
- [X ] Feature
