### PR TITLE
Check the versions of libfwupd and libfwupdplugin at startup

### DIFF
--- a/libfwupd/fwupd-version.c
+++ b/libfwupd/fwupd-version.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fwupd-version.h"
+
+/**
+ * fwupd_version_string:
+ *
+ * Gets the libfwupd installed runtime version.
+ *
+ * This may be different to the *build-time* version if the daemon and library
+ * objects somehow get out of sync.
+ *
+ * Returns: version string
+ *
+ * Since: 1.6.1
+ **/
+const gchar *
+fwupd_version_string (void)
+{
+	return G_STRINGIFY(FWUPD_MAJOR_VERSION) "."
+		G_STRINGIFY(FWUPD_MINOR_VERSION) "."
+		G_STRINGIFY(FWUPD_MICRO_VERSION);
+}

--- a/libfwupd/fwupd-version.h.in
+++ b/libfwupd/fwupd-version.h.in
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <glib.h>
+
 /**
  * SECTION:fwupd-version
  * @short_description: Obtains the version for the installed fwupd
@@ -59,3 +61,5 @@
      (FWUPD_MAJOR_VERSION == (major) && FWUPD_MINOR_VERSION > (minor)) || \
      (FWUPD_MAJOR_VERSION == (major) && FWUPD_MINOR_VERSION == (minor) && \
       FWUPD_MICRO_VERSION >= (micro)))
+
+const gchar	*fwupd_version_string			(void);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -663,3 +663,9 @@ LIBFWUPD_1.6.0 {
     fwupd_device_set_composite_id;
   local: *;
 } LIBFWUPD_1.5.8;
+
+LIBFWUPD_1.6.1 {
+  global:
+    fwupd_version_string;
+  local: *;
+} LIBFWUPD_1.6.0;

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -48,6 +48,7 @@ libfwupd_src = [
   'fwupd-release.c',        # fuzzing
   'fwupd-plugin.c',
   'fwupd-remote.c',
+  'fwupd-version.c',
 ]
 
 fwupd_mapfile = 'fwupd.map'

--- a/libfwupdplugin/fu-version.c
+++ b/libfwupdplugin/fu-version.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-version.h"
+
+/**
+ * fu_version_string:
+ *
+ * Gets the libfwupdplugin installed runtime version.
+ *
+ * This may be different to the *build-time* version if the daemon and library
+ * objects somehow get out of sync.
+ *
+ * Returns: version string
+ *
+ * Since: 1.6.1
+ **/
+const gchar *
+fu_version_string (void)
+{
+	return G_STRINGIFY(FWUPD_MAJOR_VERSION) "."
+		G_STRINGIFY(FWUPD_MINOR_VERSION) "."
+		G_STRINGIFY(FWUPD_MICRO_VERSION);
+}

--- a/libfwupdplugin/fu-version.h
+++ b/libfwupdplugin/fu-version.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <glib.h>
+
+const gchar	*fu_version_string			(void);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -791,3 +791,9 @@ LIBFWUPDPLUGIN_1.6.0 {
     fu_xmlb_builder_insert_kx;
   local: *;
 } LIBFWUPDPLUGIN_1.5.8;
+
+LIBFWUPDPLUGIN_1.6.1 {
+  global:
+    fu_version_string;
+  local: *;
+} LIBFWUPDPLUGIN_1.6.0;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -30,6 +30,7 @@ fwupdplugin_src = [
   'fu-udev-device.c',
   'fu-usb-device.c',
   'fu-hid-device.c',
+  'fu-version.c',
 ]
 
 fwupdplugin_headers = [

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -52,6 +52,7 @@
 #include "fu-security-attr.h"
 #include "fu-security-attrs-private.h"
 #include "fu-udev-device-private.h"
+#include "fu-version.h"
 
 #ifdef HAVE_GUDEV
 #include "fu-udev-backend.h"
@@ -6302,6 +6303,26 @@ fu_engine_load (FuEngine *self, FuEngineLoadFlags flags, GError **error)
 	/* avoid re-loading a second time if fu-tool or fu-util request to */
 	if (self->loaded)
 		return TRUE;
+
+	/* sanity check libraries are in sync with daemon */
+	if (g_strcmp0 (fwupd_version_string (), VERSION) != 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVAL,
+			     "libfwupd version %s does not match daemon %s",
+			     fwupd_version_string (),
+			     VERSION);
+		return FALSE;
+	}
+	if (g_strcmp0 (fu_version_string (), VERSION) != 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_INVAL,
+			     "libfwupdplugin version %s does not match daemon %s",
+			     fu_version_string (),
+			     VERSION);
+		return FALSE;
+	}
 
 /* TODO: Read registry key [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography] "MachineGuid" */
 #ifndef _WIN32


### PR DESCRIPTION
This prevents super-hard-to-debug crashes like we saw in #3197 where the user
was mixing PPAs and official versions.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
