### PR TITLE
Switch lock directory from /var/run to /run/lock

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -1253,6 +1253,9 @@ fu_common_get_path (FuPathKind path_kind)
 			return g_build_filename (tmp, NULL);
 		basedir = fu_common_get_path (FU_PATH_KIND_LOCALSTATEDIR);
 		return g_build_filename (basedir, "cache", PACKAGE_NAME, NULL);
+	/* /run/lock */
+	case FU_PATH_KIND_LOCKDIR:
+		return g_strdup ("/run/lock");
 	case FU_PATH_KIND_OFFLINE_TRIGGER:
 		tmp = g_getenv ("FWUPD_OFFLINE_TRIGGER");
 		if (tmp != NULL)

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -61,6 +61,7 @@ typedef guint FuEndianType;
  * @FU_PATH_KIND_OFFLINE_TRIGGER:	The file for the offline trigger (IE /system-update)
  * @FU_PATH_KIND_SYSFSDIR_SECURITY:	The sysfs security location (IE /sys/kernel/security)
  * @FU_PATH_KIND_ACPI_TABLES:		The location of the ACPI tables
+ * @FU_PATH_KIND_LOCKDIR:		The lock directory (IE /run/lock)
  *
  * Path types to use when dynamically determining a path at runtime
  **/
@@ -81,6 +82,7 @@ typedef enum {
 	FU_PATH_KIND_OFFLINE_TRIGGER,
 	FU_PATH_KIND_SYSFSDIR_SECURITY,
 	FU_PATH_KIND_ACPI_TABLES,
+	FU_PATH_KIND_LOCKDIR,
 	/*< private >*/
 	FU_PATH_KIND_LAST
 } FuPathKind;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2841,12 +2841,12 @@ fu_util_lock (FuUtilPrivate *priv, GError **error)
 		.l_type = F_WRLCK,
 		.l_whence = SEEK_SET,
 	};
-	g_autofree gchar *localstatedir = NULL;
+	g_autofree gchar *lockdir = NULL;
 	g_autofree gchar *lockfn = NULL;
 
 	/* open file */
-	localstatedir = fu_common_get_path (FU_PATH_KIND_LOCALSTATEDIR);
-	lockfn = g_build_filename (localstatedir, "run", "fwupdtool", NULL);
+	lockdir = fu_common_get_path (FU_PATH_KIND_LOCKDIR);
+	lockfn = g_build_filename (lockdir, "fwupdtool", NULL);
 	if (!fu_common_mkdir_parent (lockfn, error))
 		return FALSE;
 	priv->lock_fd = g_open (lockfn, O_RDWR | O_CREAT, S_IRWXU);


### PR DESCRIPTION
This allows for proper locking between executions of fwupdtool in
Chromium OS minijail environment. It is needed after commit
9cf5f8f7ff7b93473eabf21e8482bb8feace039a was introduced.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ X ] Code fix
- [ ] Feature
- [ ] Documentation
