### PR TITLE
chromeos build flag for conditionally-compiled code

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -153,7 +153,12 @@ GHashTable *
 fwupd_get_os_release (GError **error)
 {
 	const gchar *filename = NULL;
-	const gchar *paths[] = { "/etc/os-release", "/usr/lib/os-release", NULL };
+	const gchar *paths[] = {
+		"/etc/os-release",
+		"/usr/lib/os-release",
+		"/etc/lsb-release",
+		NULL, /* last entry */
+	};
 	g_autofree gchar *buf = NULL;
 	g_auto(GStrv) lines = NULL;
 	g_autoptr(GHashTable) hash = NULL;


### PR DESCRIPTION
Add a meson option to enable ChromeOS-specific code that is compiled-out
depending on a preprocessor macro.

Fix fwupd_get_os_release to support ChromeOS, as it doesn't have
os-release files.

Currently, any fwupdtool operation that starts the engine with the FU_ENGINE_LOAD_FLAG_REMOTES flag fails in ChromeOS:

```
$ fwupdtool get-devices
Failed to load remotes: No os-release found
```
This is a way (not the only one) to fix that. Maybe the ifdef'd code can be in fu-engine.c instead.
I chose OS_CHROMEOS as a macro based on other examples from the ChromeOS ecosystem: https://chromium.googlesource.com/chromiumos/third_party/libcamera/+/185574b741f0eca6c6225f4dec6be847aa73738f%5E%21/#F0


Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation
