### PR TITLE
trivial: Add back pesign to the fwupd docker images

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
 <dependencies>
+  <dependency type="build" id="pesign">
+    <distro id="fedora">
+      <package />
+    </distro>
+  </dependency>
   <dependency type="build" id="abigail-tools">
     <distro id="ubuntu">
       <package variant="x86_64" />


### PR DESCRIPTION
This is needed as fwupd-efi uses the fwupd images, and pesign is a
build-time dep of the Fedora package.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
