### PR TITLE
colorhug: Ignore the failure to get the reply on device reset

### DIFF
--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -58,6 +58,7 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (self));
 	guint8 buf[] = { [0] = cmd, [1 ... CH_USB_HID_EP_SIZE - 1] = 0x00 };
 	gsize actual_length = 0;
+	g_autoptr(GError) error_local = NULL;
 
 	/* check size */
 	if (ibufsz > sizeof(buf) - 1) {
@@ -95,8 +96,17 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 					      &actual_length,
 					      CH_DEVICE_USB_TIMEOUT,
 					      NULL, /* cancellable */
-					      error)) {
-		g_prefix_error (error, "failed to send request: ");
+					      &error_local)) {
+		if (cmd == CH_CMD_RESET &&
+		    g_error_matches (error_local,
+				     G_USB_DEVICE_ERROR,
+				     G_USB_DEVICE_ERROR_NO_DEVICE)) {
+			g_debug ("ignoring '%s' on reset", error_local->message);
+			return TRUE;
+		}
+		g_propagate_prefixed_error (error,
+					    g_steal_pointer (&error_local),
+					    "failed to send request: ");
 		return FALSE;
 	}
 	if (actual_length != CH_USB_HID_EP_SIZE) {
@@ -116,8 +126,17 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 					      &actual_length,
 					      CH_DEVICE_USB_TIMEOUT,
 					      NULL, /* cancellable */
-					      error)) {
-		g_prefix_error (error, "failed to get reply: ");
+					      &error_local)) {
+		if (cmd == CH_CMD_RESET &&
+		    g_error_matches (error_local,
+				     G_USB_DEVICE_ERROR,
+				     G_USB_DEVICE_ERROR_NO_DEVICE)) {
+			g_debug ("ignoring '%s' on reset", error_local->message);
+			return TRUE;
+		}
+		g_propagate_prefixed_error (error,
+					    g_steal_pointer (&error_local),
+					    "failed to get reply: ");
 		return FALSE;
 	}
 	if (g_getenv ("FWUPD_COLORHUG_VERBOSE") != NULL)


### PR DESCRIPTION
Reading the response works on Linux, but fails on FreeBSD.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
