### PR TITLE
Enable building uefi-capsule plugin on FreeBSD 

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-devpath.c
+++ b/plugins/uefi-capsule/fu-uefi-devpath.c
@@ -13,6 +13,14 @@
 
 #include "fwupd-error.h"
 
+#ifndef EFIDP_END_TYPE
+#define EFIDP_END_TYPE      0x7f
+#endif
+
+#ifndef EFIDP_END_ENTIRE
+#define EFIDP_END_ENTIRE    0xff
+#endif
+
 typedef struct {
 	guint8	 type;
 	guint8	 subtype;

--- a/plugins/uefi-capsule/fu-uefi-devpath.c
+++ b/plugins/uefi-capsule/fu-uefi-devpath.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include <efivar.h>
+#include <efivar-dp.h>
 
 #include "fu-common.h"
 #include "fu-uefi-devpath.h"

--- a/plugins/uefi-capsule/fu-uefi-devpath.c
+++ b/plugins/uefi-capsule/fu-uefi-devpath.c
@@ -6,19 +6,20 @@
 
 #include "config.h"
 
+#if defined(__linux__)
+#include <efivar.h>
+#elif defined(__FreeBSD__)
 #include <efivar.h>
 #include <efivar-dp.h>
+#endif
 
 #include "fu-common.h"
 #include "fu-uefi-devpath.h"
 
 #include "fwupd-error.h"
 
-#ifndef EFIDP_END_TYPE
+#if defined(__FreeBSD__)
 #define EFIDP_END_TYPE      0x7f
-#endif
-
-#ifndef EFIDP_END_ENTIRE
 #define EFIDP_END_ENTIRE    0xff
 #endif
 


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

FreeBSD has Linux-like `<efivar-dp.h>` header, but it doesn't define type constants and it's not included implicitly by `<efivar.h>`.