### PR TITLE
trivial: Fix a warning when compiling on Windows

### DIFF
--- a/libfwupd/fwupd-client-private.h
+++ b/libfwupd/fwupd-client-private.h
@@ -12,6 +12,13 @@
 #include <gio/gunixinputstream.h>
 #endif
 
+void		 fwupd_client_download_bytes2_async	(FwupdClient	*self,
+							 GPtrArray	*urls,
+							 FwupdClientDownloadFlags flags,
+							 GCancellable	*cancellable,
+							 GAsyncReadyCallback callback,
+							 gpointer	 callback_data);
+
 #ifdef HAVE_GIO_UNIX
 void		 fwupd_client_get_details_stream_async	(FwupdClient	*self,
 							 GUnixInputStream *istr,
@@ -30,12 +37,6 @@ void		 fwupd_client_update_metadata_stream_async(FwupdClient	*self,
 							 const gchar	*remote_id,
 							 GUnixInputStream *istr,
 							 GUnixInputStream *istr_sig,
-							 GCancellable	*cancellable,
-							 GAsyncReadyCallback callback,
-							 gpointer	 callback_data);
-void		 fwupd_client_download_bytes2_async	(FwupdClient	*self,
-							 GPtrArray	*urls,
-							 FwupdClientDownloadFlags flags,
 							 GCancellable	*cancellable,
 							 GAsyncReadyCallback callback,
 							 gpointer	 callback_data);


### PR DESCRIPTION
Move the function prototype out of the GUnixInputStream-using ones.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
