### PR TITLE
analogix plugin requires gusb

### DIFF
--- a/plugins/analogix/meson.build
+++ b/plugins/analogix/meson.build
@@ -1,3 +1,4 @@
+if get_option('gusb')
 cargs = ['-DG_LOG_DOMAIN="FuPluginAnalogix"']
 
 install_data(['analogix.quirk'],
@@ -28,3 +29,4 @@ shared_module('fu_plugin_analogix',
     plugin_deps,
   ],
 )
+endif


### PR DESCRIPTION
Otherwise the following build error happens:
```
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:54:10: error: ‘G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE’ undeclared (first use in this function)
     54 |          G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:54:10: note: each undeclared identifier is reported only once for each function it appears in
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:55:10: error: ‘G_USB_DEVICE_REQUEST_TYPE_VENDOR’ undeclared (first use in this function)
     55 |          G_USB_DEVICE_REQUEST_TYPE_VENDOR,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:56:10: error: ‘G_USB_DEVICE_RECIPIENT_DEVICE’ undeclared (first use in this function)
     56 |          G_USB_DEVICE_RECIPIENT_DEVICE,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c: In function ‘fu_analogix_device_receive’:
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:96:10: error: ‘G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST’ undeclared (first use in this function)
     96 |          G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:97:10: error: ‘G_USB_DEVICE_REQUEST_TYPE_VENDOR’ undeclared (first use in this function)
     97 |          G_USB_DEVICE_REQUEST_TYPE_VENDOR,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ../fwupd-1.6.0/plugins/analogix/fu-analogix-device.c:98:10: error: ‘G_USB_DEVICE_RECIPIENT_DEVICE’ undeclared (first use in this function)
     98 |          G_USB_DEVICE_RECIPIENT_DEVICE,
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
  and more...

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
