### PR TITLE
Also use the FirmwareBaseURI for the detach and update images

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -548,8 +548,17 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	if (tmp != NULL)
 		fwupd_release_set_detach_caption (rel, tmp);
 	tmp = xb_node_query_text (component, "screenshots/screenshot/image", NULL);
-	if (tmp != NULL)
-		fwupd_release_set_detach_image (rel, tmp);
+	if (tmp != NULL) {
+		if (remote != NULL) {
+			g_autofree gchar *img = NULL;
+			img = fwupd_remote_build_firmware_uri (remote, tmp, error);
+			if (img == NULL)
+				return FALSE;
+			fwupd_release_set_detach_image (rel, img);
+		} else {
+			fwupd_release_set_detach_image (rel, tmp);
+		}
+	}
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_protocol (rel, tmp);
@@ -557,8 +566,17 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	if (tmp != NULL)
 		fwupd_release_set_update_message (rel, tmp);
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateImage']", NULL);
-	if (tmp != NULL)
-		fwupd_release_set_update_image (rel, tmp);
+	if (tmp != NULL) {
+		if (remote != NULL) {
+			g_autofree gchar *img = NULL;
+			img = fwupd_remote_build_firmware_uri (remote, tmp, error);
+			if (img == NULL)
+				return FALSE;
+			fwupd_release_set_update_image (rel, img);
+		} else {
+			fwupd_release_set_update_image (rel, tmp);
+		}
+	}
 
 	/* sort the locations by scheme */
 	g_ptr_array_sort_with_data (fwupd_release_get_locations (rel),


### PR DESCRIPTION
If a company has mirrored the entire LVFS repo for privacy reasons
they'll certainly want to download the images from the same place.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
