### PR TITLE
ESRT access on FreeBSD

### DIFF
--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -795,7 +795,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	const gchar *str;
-	guint entry_count;
+	GPtrArray *entries;
 	g_autoptr(GError) error_udisks2 = NULL;
 	g_autoptr(GError) error_efivarfs = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -805,7 +805,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	if (!fu_uefi_esrt_setup (esrt, error))
 		return FALSE;
 
-	entry_count = fu_uefi_esrt_get_entry_count (esrt);
+	entries = fu_uefi_esrt_get_entries (esrt);
 
 	/* make sure that efivarfs is rw */
 	if (!fu_plugin_uefi_capsule_ensure_efivarfs_rw (&error_efivarfs)) {
@@ -826,8 +826,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	}
 
 	/* add each device */
-	for (guint i = 0; i < entry_count; i++) {
-		FuUefiEsrtEntry *entry = fu_uefi_esrt_get_entry (esrt, i);
+	for (guint i = 0; i < entries->len; i++) {
+		FuUefiEsrtEntry *entry = g_ptr_array_index (entries, i);
 		g_autoptr(GError) error_parse = NULL;
 		g_autoptr(FuUefiDevice) dev = fu_uefi_device_new_from_entry (entry, &error_parse);
 		if (dev == NULL) {

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -144,8 +144,6 @@ fu_uefi_bitmap_func (void)
 	g_assert_cmpint (height, ==, 24);
 }
 
-#ifdef __linux__
-
 static void
 fu_uefi_device_func (void)
 {
@@ -153,6 +151,11 @@ fu_uefi_device_func (void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
 	FuUefiEsrtEntry *entry = NULL;
+
+#ifndef __linux__
+	g_test_skip ("ESRT data is mocked only on Linux");
+	return;
+#endif
 
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
@@ -185,6 +188,11 @@ fu_uefi_plugin_func (void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
+
+#ifndef __linux__
+	g_test_skip ("ESRT data is mocked only on Linux");
+	return;
+#endif
 
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
@@ -235,6 +243,11 @@ fu_uefi_update_info_func (void)
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
 	FuUefiEsrtEntry *entry = NULL;
 
+#ifndef __linux__
+	g_test_skip ("ESRT data is mocked only on Linux");
+	return;
+#endif
+
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
 	g_assert_true (fu_uefi_esrt_get_entry_count (esrt) > 0);
@@ -257,8 +270,6 @@ fu_uefi_update_info_func (void)
 			 "/EFI/fedora/fw/fwupd-697bd920-12cf-4da9-8385-996909bc6559.cap");
 }
 
-#endif
-
 int
 main (int argc, char **argv)
 {
@@ -277,11 +288,8 @@ main (int argc, char **argv)
 	g_test_add_func ("/uefi/bgrt", fu_uefi_bgrt_func);
 	g_test_add_func ("/uefi/framebuffer", fu_uefi_framebuffer_func);
 	g_test_add_func ("/uefi/bitmap", fu_uefi_bitmap_func);
-	/* on linux ESRT data can be faked easily */
-#ifdef __linux__
 	g_test_add_func ("/uefi/device", fu_uefi_device_func);
 	g_test_add_func ("/uefi/update-info", fu_uefi_update_info_func);
 	g_test_add_func ("/uefi/plugin", fu_uefi_plugin_func);
-#endif
 	return g_test_run ();
 }

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -147,10 +147,11 @@ fu_uefi_bitmap_func (void)
 static void
 fu_uefi_device_func (void)
 {
+	GPtrArray *entries;
+	FuUefiEsrtEntry *entry;
 	g_autoptr(FuUefiDevice) dev = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
-	FuUefiEsrtEntry *entry = NULL;
 
 #ifndef __linux__
 	g_test_skip ("ESRT data is mocked only on Linux");
@@ -159,9 +160,11 @@ fu_uefi_device_func (void)
 
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
-	g_assert_true (fu_uefi_esrt_get_entry_count (esrt) > 0);
 
-	entry = fu_uefi_esrt_get_entry (esrt, 0);
+	entries = fu_uefi_esrt_get_entries (esrt);
+	g_assert_true (entries->len > 0);
+
+	entry = g_ptr_array_index (entries, 0);
 	dev = fu_uefi_device_new_from_entry (entry, &error);
 	g_assert_nonnull (dev);
 	g_assert_no_error (error);
@@ -184,7 +187,7 @@ static void
 fu_uefi_plugin_func (void)
 {
 	FuUefiDevice *dev;
-	guint entry_count;
+	GPtrArray *entries;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
@@ -196,12 +199,12 @@ fu_uefi_plugin_func (void)
 
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
-	entry_count = fu_uefi_esrt_get_entry_count (esrt);
+	entries = fu_uefi_esrt_get_entries (esrt);
 
 	/* add each device */
 	devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
-	for (guint i = 0; i < entry_count; i++) {
-		FuUefiEsrtEntry *entry = fu_uefi_esrt_get_entry (esrt, i);
+	for (guint i = 0; i < entries->len; i++) {
+		FuUefiEsrtEntry *entry = g_ptr_array_index (entries, i);
 		g_autoptr(GError) error_local = NULL;
 		g_autoptr(FuUefiDevice) dev_tmp = fu_uefi_device_new_from_entry (entry, &error_local);
 		if (dev_tmp == NULL) {
@@ -237,11 +240,12 @@ fu_uefi_plugin_func (void)
 static void
 fu_uefi_update_info_func (void)
 {
+	GPtrArray *entries;
+	FuUefiEsrtEntry *entry;
 	g_autoptr(FuUefiDevice) dev = NULL;
 	g_autoptr(FuUefiUpdateInfo) info = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new ();
-	FuUefiEsrtEntry *entry = NULL;
 
 #ifndef __linux__
 	g_test_skip ("ESRT data is mocked only on Linux");
@@ -250,9 +254,11 @@ fu_uefi_update_info_func (void)
 
 	g_assert_true (fu_uefi_esrt_setup (esrt, &error));
 	g_assert_no_error (error);
-	g_assert_true (fu_uefi_esrt_get_entry_count (esrt) > 0);
 
-	entry = fu_uefi_esrt_get_entry (esrt, 0);
+	entries = fu_uefi_esrt_get_entries (esrt);
+	g_assert_true (entries->len > 0);
+
+	entry = g_ptr_array_index (entries, 0);
 	dev = fu_uefi_device_new_from_entry (entry, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (dev);

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -193,35 +193,6 @@ fu_uefi_get_bitmap_size (const guint8 *buf,
 	return TRUE;
 }
 
-static gint
-fu_uefi_strcmp_sort_cb (gconstpointer a, gconstpointer b)
-{
-	const gchar *stra = *((const gchar **) a);
-	const gchar *strb = *((const gchar **) b);
-	return g_strcmp0 (stra, strb);
-}
-
-GPtrArray *
-fu_uefi_get_esrt_entry_paths (const gchar *esrt_path, GError **error)
-{
-	GPtrArray *entries = g_ptr_array_new_with_free_func (g_free);
-	const gchar *fn;
-	g_autofree gchar *esrt_entries = NULL;
-	g_autoptr(GDir) dir = NULL;
-
-	/* search ESRT */
-	esrt_entries = g_build_filename (esrt_path, "entries", NULL);
-	dir = g_dir_open (esrt_entries, 0, error);
-	if (dir == NULL)
-		return NULL;
-	while ((fn = g_dir_read_name (dir)) != NULL)
-		g_ptr_array_add (entries, g_build_filename (esrt_entries, fn, NULL));
-
-	/* sort by name */
-	g_ptr_array_sort (entries, fu_uefi_strcmp_sort_cb);
-	return entries;
-}
-
 gchar *
 fu_uefi_get_esp_path_for_os (FuDevice *device, const gchar *base)
 {

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -75,7 +75,5 @@ gboolean	 fu_uefi_get_framebuffer_size	(guint32	*width,
 						 GError		**error);
 gchar		*fu_uefi_get_esp_path_for_os	(FuDevice 	*device,
 						 const gchar	*esp_path);
-GPtrArray	*fu_uefi_get_esrt_entry_paths	(const gchar	*esrt_path,
-						 GError		**error);
 guint64		 fu_uefi_read_file_as_uint64	(const gchar	*path,
 						 const gchar	*attr_name);

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -9,6 +9,7 @@
 
 #include "fu-plugin.h"
 #include "fu-uefi-device.h"
+#include "fu-uefi-esrt.h"
 #include "fu-uefi-update-info.h"
 
 #define FU_TYPE_UEFI_DEVICE (fu_uefi_device_get_type ())
@@ -37,7 +38,7 @@ typedef enum {
 } FuUefiDeviceStatus;
 
 FuUefiDevice	*fu_uefi_device_new_from_guid		(const gchar	*guid);
-FuUefiDevice	*fu_uefi_device_new_from_entry		(const gchar	*entry_path,
+FuUefiDevice	*fu_uefi_device_new_from_entry		(FuUefiEsrtEntry *entry,
 							 GError		**error);
 FuUefiDevice	*fu_uefi_device_new_from_dev		(FuDevice	*dev);
 void		 fu_uefi_device_set_esp			(FuUefiDevice	*self,

--- a/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
@@ -122,21 +122,12 @@ fu_uefi_esrt_new (void)
 	return FU_UEFI_ESRT (self);
 }
 
-guint
-fu_uefi_esrt_get_entry_count (FuUefiEsrt *self)
-{
-	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), 0);
-
-	return self->entries->len;
-}
-
-FuUefiEsrtEntry *
-fu_uefi_esrt_get_entry (FuUefiEsrt *self, guint idx)
+GPtrArray *
+fu_uefi_esrt_get_entries (FuUefiEsrt *self)
 {
 	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), NULL);
-	g_return_val_if_fail (idx < self->entries->len, NULL);
 
-	return FU_UEFI_ESRT_ENTRY (g_ptr_array_index (self->entries, idx));
+	return self->entries;
 }
 
 const gchar *

--- a/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
@@ -38,7 +38,6 @@ fu_uefi_esrt_entry_new (gint idx)
 static void
 fu_uefi_esrt_entry_init (FuUefiEsrtEntry *self)
 {
-	self->sysctl_name = NULL;
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-freebsd.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2021 3mdeb Embedded Systems Consulting
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#include "fu-common.h"
+#include "fu-uefi-common.h"
+#include "fu-uefi-esrt.h"
+
+struct _FuUefiEsrtEntry {
+	GObject		 parent_instance;
+	gchar		*sysctl_name;
+};
+
+G_DEFINE_TYPE (FuUefiEsrtEntry, fu_uefi_esrt_entry, G_TYPE_OBJECT)
+
+struct _FuUefiEsrt {
+	GObject		 parent_instance;
+	GPtrArray	*entries;		/* of FuUefiEsrtEntry */
+};
+
+G_DEFINE_TYPE (FuUefiEsrt, fu_uefi_esrt, G_TYPE_OBJECT)
+
+static FuUefiEsrtEntry *
+fu_uefi_esrt_entry_new (gint idx)
+{
+	FuUefiEsrtEntry *self = g_object_new (FU_TYPE_UEFI_ESRT_ENTRY, NULL);
+	self->sysctl_name = g_strdup_printf ("hw.efi.esrt.entry%d", idx);
+	return FU_UEFI_ESRT_ENTRY (self);
+}
+
+static void
+fu_uefi_esrt_entry_init (FuUefiEsrtEntry *self)
+{
+	self->sysctl_name = NULL;
+}
+
+static void
+fu_uefi_esrt_entry_finalize (GObject *object)
+{
+	FuUefiEsrtEntry *self = FU_UEFI_ESRT_ENTRY (object);
+	g_free (self->sysctl_name);
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_entry_class_init (FuUefiEsrtEntryClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_entry_finalize;
+}
+
+static gchar *
+fu_uefi_get_sysctl_string (const gchar *name)
+{
+	g_autofree gchar *value = NULL;
+	size_t len = 0;
+
+	if (sysctlbyname (name, NULL, &len, NULL, 0))
+		return NULL;
+
+	value = g_malloc (len);
+	if (sysctlbyname (name, value, &len, NULL, 0))
+		return NULL;
+
+	return g_steal_pointer (&value);
+}
+
+static guint64
+fu_uefi_get_sysctl_uint64 (const gchar *name)
+{
+	g_autofree gchar *value = fu_uefi_get_sysctl_string (name);
+	return fu_common_strtoull (value);
+}
+
+gboolean
+fu_uefi_esrt_setup (FuUefiEsrt *self, GError **error)
+{
+	guint entry_count = 0;
+
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), FALSE);
+
+	entry_count = fu_uefi_get_sysctl_uint64 ("hw.efi.esrt.fw_resource_count");
+	for (guint i = 0; i < entry_count; i++)
+		g_ptr_array_add (self->entries, fu_uefi_esrt_entry_new (i));
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_uefi_esrt_finalize (GObject *object)
+{
+	FuUefiEsrt *self = FU_UEFI_ESRT (object);
+	g_ptr_array_unref (self->entries);
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_class_init (FuUefiEsrtClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_finalize;
+}
+
+static void
+fu_uefi_esrt_init (FuUefiEsrt *self)
+{
+	self->entries = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+}
+
+FuUefiEsrt *
+fu_uefi_esrt_new (void)
+{
+	FuUefiEsrt *self = g_object_new (FU_TYPE_UEFI_ESRT, NULL);
+	return FU_UEFI_ESRT (self);
+}
+
+guint
+fu_uefi_esrt_get_entry_count (FuUefiEsrt *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), 0);
+
+	return self->entries->len;
+}
+
+FuUefiEsrtEntry *
+fu_uefi_esrt_get_entry (FuUefiEsrt *self, guint idx)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), NULL);
+	g_return_val_if_fail (idx < self->entries->len, NULL);
+
+	return FU_UEFI_ESRT_ENTRY (g_ptr_array_index (self->entries, idx));
+}
+
+const gchar *
+fu_uefi_esrt_entry_get_id (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), NULL);
+	return self->sysctl_name;
+}
+
+gchar *
+fu_uefi_esrt_entry_get_class (FuUefiEsrtEntry *self)
+{
+	g_autofree gchar *name = NULL;
+
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), NULL);
+
+	name = g_build_path (".", self->sysctl_name, "fw_class", NULL);
+	return fu_uefi_get_sysctl_string (name);
+}
+
+static guint64
+fu_uefi_get_entry_field (FuUefiEsrtEntry *entry, const gchar *field_name)
+{
+	g_autofree gchar *name = g_build_path (".", entry->sysctl_name,
+                                               field_name, NULL);
+	return fu_uefi_get_sysctl_uint64 (name);
+}
+
+guint32
+fu_uefi_esrt_entry_get_kind (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "fw_type");
+}
+
+guint32
+fu_uefi_esrt_entry_get_capsule_flags (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "capsule_flags");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "fw_version");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_lowest (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "lowest_supported_fw_version");
+}
+
+guint32
+fu_uefi_esrt_entry_get_status (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "last_attempt_status");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_error (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_get_entry_field (self, "last_attempt_version");
+}

--- a/plugins/uefi-capsule/fu-uefi-esrt-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-linux.c
@@ -120,21 +120,12 @@ fu_uefi_esrt_new (void)
 	return FU_UEFI_ESRT (self);
 }
 
-guint
-fu_uefi_esrt_get_entry_count (FuUefiEsrt *self)
-{
-	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), 0);
-
-	return self->entries->len;
-}
-
-FuUefiEsrtEntry *
-fu_uefi_esrt_get_entry (FuUefiEsrt *self, guint idx)
+GPtrArray *
+fu_uefi_esrt_get_entries (FuUefiEsrt *self)
 {
 	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), NULL);
-	g_return_val_if_fail (idx < self->entries->len, NULL);
 
-	return FU_UEFI_ESRT_ENTRY (g_ptr_array_index (self->entries, idx));
+	return self->entries;
 }
 
 const gchar *

--- a/plugins/uefi-capsule/fu-uefi-esrt-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-linux.c
@@ -35,7 +35,6 @@ fu_uefi_esrt_entry_new (gchar *path)
 static void
 fu_uefi_esrt_entry_init (FuUefiEsrtEntry *self)
 {
-	self->path = NULL;
 }
 
 static void
@@ -83,7 +82,7 @@ fu_uefi_esrt_setup (FuUefiEsrt *self, GError **error)
 	while ((fn = g_dir_read_name (dir)) != NULL) {
 		gchar *path = g_build_filename (esrt_entries, fn, NULL);
 		g_ptr_array_add (self->entries, fu_uefi_esrt_entry_new (path));
-    }
+	}
 
 	/* sort by name */
 	g_ptr_array_sort (self->entries, fu_uefi_entry_sort_cb);

--- a/plugins/uefi-capsule/fu-uefi-esrt-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-linux.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2021 3mdeb Embedded Systems Consulting
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-common.h"
+#include "fu-uefi-common.h"
+#include "fu-uefi-esrt.h"
+
+struct _FuUefiEsrtEntry {
+	GObject		 parent_instance;
+	gchar		*path;
+};
+
+G_DEFINE_TYPE (FuUefiEsrtEntry, fu_uefi_esrt_entry, G_TYPE_OBJECT)
+
+struct _FuUefiEsrt {
+	GObject		 parent_instance;
+	GPtrArray	*entries;		/* of FuUefiEsrtEntry */
+};
+
+G_DEFINE_TYPE (FuUefiEsrt, fu_uefi_esrt, G_TYPE_OBJECT)
+
+static FuUefiEsrtEntry *
+fu_uefi_esrt_entry_new (gchar *path)
+{
+	FuUefiEsrtEntry *self = g_object_new (FU_TYPE_UEFI_ESRT_ENTRY, NULL);
+	self->path = path;
+	return FU_UEFI_ESRT_ENTRY (self);
+}
+
+static void
+fu_uefi_esrt_entry_init (FuUefiEsrtEntry *self)
+{
+	self->path = NULL;
+}
+
+static void
+fu_uefi_esrt_entry_finalize (GObject *object)
+{
+	FuUefiEsrtEntry *self = FU_UEFI_ESRT_ENTRY (object);
+	g_free (self->path);
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_entry_class_init (FuUefiEsrtEntryClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_entry_finalize;
+}
+
+static gint
+fu_uefi_entry_sort_cb (gconstpointer a, gconstpointer b)
+{
+	const FuUefiEsrtEntry *obja = *((const FuUefiEsrtEntry **) a);
+	const FuUefiEsrtEntry *objb = *((const FuUefiEsrtEntry **) b);
+	return g_strcmp0 (obja->path, objb->path);
+}
+
+gboolean
+fu_uefi_esrt_setup (FuUefiEsrt *self, GError **error)
+{
+	g_autofree gchar *sysfsfwdir = NULL;
+	g_autofree gchar *esrt_path = NULL;
+	g_autofree gchar *esrt_entries = NULL;
+	const gchar *fn = NULL;
+	g_autoptr(GDir) dir = NULL;
+
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), FALSE);
+
+	/* get the directory of ESRT entries */
+	sysfsfwdir = fu_common_get_path (FU_PATH_KIND_SYSFSDIR_FW);
+	esrt_path = g_build_filename (sysfsfwdir, "efi", "esrt", NULL);
+
+	/* search ESRT */
+	esrt_entries = g_build_filename (esrt_path, "entries", NULL);
+	dir = g_dir_open (esrt_entries, 0, error);
+	g_return_val_if_fail (dir != NULL, FALSE);
+	while ((fn = g_dir_read_name (dir)) != NULL) {
+		gchar *path = g_build_filename (esrt_entries, fn, NULL);
+		g_ptr_array_add (self->entries, fu_uefi_esrt_entry_new (path));
+    }
+
+	/* sort by name */
+	g_ptr_array_sort (self->entries, fu_uefi_entry_sort_cb);
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_uefi_esrt_finalize (GObject *object)
+{
+	FuUefiEsrt *self = FU_UEFI_ESRT (object);
+	g_ptr_array_unref (self->entries);
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_class_init (FuUefiEsrtClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_finalize;
+}
+
+static void
+fu_uefi_esrt_init (FuUefiEsrt *self)
+{
+	self->entries = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+}
+
+FuUefiEsrt *
+fu_uefi_esrt_new (void)
+{
+	FuUefiEsrt *self = g_object_new (FU_TYPE_UEFI_ESRT, NULL);
+	return FU_UEFI_ESRT (self);
+}
+
+guint
+fu_uefi_esrt_get_entry_count (FuUefiEsrt *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), 0);
+
+	return self->entries->len;
+}
+
+FuUefiEsrtEntry *
+fu_uefi_esrt_get_entry (FuUefiEsrt *self, guint idx)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), NULL);
+	g_return_val_if_fail (idx < self->entries->len, NULL);
+
+	return FU_UEFI_ESRT_ENTRY (g_ptr_array_index (self->entries, idx));
+}
+
+const gchar *
+fu_uefi_esrt_entry_get_id (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), NULL);
+	return self->path;
+}
+
+gchar *
+fu_uefi_esrt_entry_get_class (FuUefiEsrtEntry *self)
+{
+	g_autofree gchar *fw_class_fn = NULL;
+	gchar *fw_class = NULL;
+
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), NULL);
+
+	fw_class_fn = g_build_filename (self->path, "fw_class", NULL);
+	if (g_file_get_contents (fw_class_fn, &fw_class, NULL, NULL))
+		g_strdelimit (fw_class, "\n", '\0');
+
+	return fw_class;
+}
+
+guint32
+fu_uefi_esrt_entry_get_kind (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path, "fw_type");
+}
+
+guint32
+fu_uefi_esrt_entry_get_capsule_flags (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path, "capsule_flags");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path, "fw_version");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_lowest (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path,
+                                            "lowest_supported_fw_version");
+}
+
+guint32
+fu_uefi_esrt_entry_get_status (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path, "last_attempt_status");
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_error (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return fu_uefi_read_file_as_uint64 (self->path, "last_attempt_version");
+}

--- a/plugins/uefi-capsule/fu-uefi-esrt-windows.c
+++ b/plugins/uefi-capsule/fu-uefi-esrt-windows.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2021 3mdeb Embedded Systems Consulting
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-common.h"
+#include "fu-uefi-common.h"
+#include "fu-uefi-esrt.h"
+
+struct _FuUefiEsrtEntry {
+	GObject		 parent_instance;
+};
+
+G_DEFINE_TYPE (FuUefiEsrtEntry, fu_uefi_esrt_entry, G_TYPE_OBJECT)
+
+struct _FuUefiEsrt {
+	GObject		 parent_instance;
+	GPtrArray	*entries;		/* of FuUefiEsrtEntry */
+};
+
+G_DEFINE_TYPE (FuUefiEsrt, fu_uefi_esrt, G_TYPE_OBJECT)
+
+static void
+fu_uefi_esrt_entry_init (FuUefiEsrtEntry *self)
+{
+}
+
+static void
+fu_uefi_esrt_entry_finalize (GObject *object)
+{
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_entry_class_init (FuUefiEsrtEntryClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_entry_finalize;
+}
+
+gboolean
+fu_uefi_esrt_setup (FuUefiEsrt *self, GError **error)
+{
+	g_set_error_literal (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "ESRT access wasn't implemented for Windows");
+	return FALSE;
+}
+
+static void
+fu_uefi_esrt_finalize (GObject *object)
+{
+	FuUefiEsrt *self = FU_UEFI_ESRT (object);
+	g_ptr_array_unref (self->entries);
+	G_OBJECT_CLASS (fu_uefi_esrt_parent_class)->finalize (object);
+}
+
+static void
+fu_uefi_esrt_class_init (FuUefiEsrtClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_uefi_esrt_finalize;
+}
+
+static void
+fu_uefi_esrt_init (FuUefiEsrt *self)
+{
+	self->entries = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
+}
+
+FuUefiEsrt *
+fu_uefi_esrt_new (void)
+{
+	FuUefiEsrt *self = g_object_new (FU_TYPE_UEFI_ESRT, NULL);
+	return FU_UEFI_ESRT (self);
+}
+
+GPtrArray *
+fu_uefi_esrt_get_entries (FuUefiEsrt *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT (self), NULL);
+
+	return self->entries;
+}
+
+const gchar *
+fu_uefi_esrt_entry_get_id (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), NULL);
+	return "";
+}
+
+gchar *
+fu_uefi_esrt_entry_get_class (FuUefiEsrtEntry *self)
+{
+	return NULL;
+}
+
+guint32
+fu_uefi_esrt_entry_get_kind (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}
+
+guint32
+fu_uefi_esrt_entry_get_capsule_flags (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}
+
+guint32
+fu_uefi_esrt_entry_get_version (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_lowest (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}
+
+guint32
+fu_uefi_esrt_entry_get_status (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}
+
+guint32
+fu_uefi_esrt_entry_get_version_error (FuUefiEsrtEntry *self)
+{
+	g_return_val_if_fail (FU_IS_UEFI_ESRT_ENTRY (self), 0x0);
+	return 0x0;
+}

--- a/plugins/uefi-capsule/fu-uefi-esrt.h
+++ b/plugins/uefi-capsule/fu-uefi-esrt.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 3mdeb Embedded Systems Consulting
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#define FU_TYPE_UEFI_ESRT (fu_uefi_esrt_get_type ())
+G_DECLARE_FINAL_TYPE (FuUefiEsrt, fu_uefi_esrt, FU, UEFI_ESRT, GObject)
+
+#define FU_TYPE_UEFI_ESRT_ENTRY (fu_uefi_esrt_entry_get_type ())
+G_DECLARE_FINAL_TYPE (FuUefiEsrtEntry, fu_uefi_esrt_entry, FU, UEFI_ESRT_ENTRY, GObject)
+
+FuUefiEsrt	*fu_uefi_esrt_new		(void);
+gboolean	 fu_uefi_esrt_setup		(FuUefiEsrt	*self,
+						 GError		**error);
+guint		 fu_uefi_esrt_get_entry_count  	(FuUefiEsrt *self);
+FuUefiEsrtEntry	*fu_uefi_esrt_get_entry		(FuUefiEsrt	*self,
+						 guint		idx);
+
+const gchar	*fu_uefi_esrt_entry_get_id		(FuUefiEsrtEntry *self);
+gchar		*fu_uefi_esrt_entry_get_class		(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_kind		(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_capsule_flags	(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_version		(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_version_lowest	(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_status		(FuUefiEsrtEntry *self);
+guint32		 fu_uefi_esrt_entry_get_version_error	(FuUefiEsrtEntry *self);

--- a/plugins/uefi-capsule/fu-uefi-esrt.h
+++ b/plugins/uefi-capsule/fu-uefi-esrt.h
@@ -15,9 +15,7 @@ G_DECLARE_FINAL_TYPE (FuUefiEsrtEntry, fu_uefi_esrt_entry, FU, UEFI_ESRT_ENTRY, 
 FuUefiEsrt	*fu_uefi_esrt_new		(void);
 gboolean	 fu_uefi_esrt_setup		(FuUefiEsrt	*self,
 						 GError		**error);
-guint		 fu_uefi_esrt_get_entry_count  	(FuUefiEsrt *self);
-FuUefiEsrtEntry	*fu_uefi_esrt_get_entry		(FuUefiEsrt	*self,
-						 guint		idx);
+GPtrArray	*fu_uefi_esrt_get_entries	(FuUefiEsrt	*self);
 
 const gchar	*fu_uefi_esrt_entry_get_id		(FuUefiEsrtEntry *self);
 gchar		*fu_uefi_esrt_entry_get_class		(FuUefiEsrtEntry *self);

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -202,9 +202,9 @@ main (int argc, char *argv[])
 	}
 
 	if (action_list || action_supported || action_info) {
+		GPtrArray *entries;
 		g_autoptr(FuUefiEsrt) esrt = fu_uefi_esrt_new();
 		g_autoptr(GError) error_local = NULL;
-		guint entry_count;
 
 		/* obtain ESRT entries */
 		if (!fu_uefi_esrt_setup (esrt, &error_local)) {
@@ -212,12 +212,12 @@ main (int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 
-		entry_count = fu_uefi_esrt_get_entry_count (esrt);
+		entries = fu_uefi_esrt_get_entries (esrt);
 
 		/* add each device */
 		devices = g_ptr_array_new_with_free_func ((GDestroyNotify) g_object_unref);
-		for (guint i = 0; i < entry_count; i++) {
-			FuUefiEsrtEntry *entry = fu_uefi_esrt_get_entry (esrt, i);
+		for (guint i = 0; i < entries->len; i++) {
+			FuUefiEsrtEntry *entry = g_ptr_array_index (entries, i);
 			g_autoptr(GError) error_parse = NULL;
 			g_autoptr(FuUefiDevice) dev = fu_uefi_device_new_from_entry (entry, &error_parse);
 			if (dev == NULL) {

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -10,6 +10,8 @@ endif
 install_data(['uefi-capsule.quirk'],
   install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
 
+esrt_impl_source = 'fu-uefi-esrt-@0@.c'.format(host_machine.system())
+
 shared_module('fu_plugin_uefi_capsule',
   fu_hash,
   sources : [
@@ -22,6 +24,7 @@ shared_module('fu_plugin_uefi_capsule',
     'fu-uefi-devpath.c',
     'fu-uefi-pcrs.c',
     'fu-uefi-update-info.c',
+    esrt_impl_source,
   ],
   include_directories : [
     root_incdir,
@@ -56,6 +59,7 @@ fwupdate = executable(
     'fu-uefi-devpath.c',
     'fu-uefi-pcrs.c',
     'fu-uefi-update-info.c',
+    esrt_impl_source,
   ],
   include_directories : [
     root_incdir,
@@ -136,6 +140,7 @@ if get_option('tests')
       'fu-uefi-pcrs.c',
       'fu-uefi-update-info.c',
       'fu-ucs2.c',
+      esrt_impl_source,
     ],
     include_directories : [
       root_incdir,


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin
- [ ] Code fix
- [x] Feature
- [ ] Documentation

***

This introduces new `GObject` for accessing ESRT in a platform-specific way. The implementation is provided in separate source files, which otherwise would consist of a lot of `#ifdef`s.

FreeBSD implementation targets [this upstream patch](https://reviews.freebsd.org/D30104).

Had to disable several tests on FreeBSD which rely on sysfs mocking as being Linux-specific. FreebBSD's version uses `sysctl()` which is not as straightforward to mock.