### PR TITLE
fu-engine: Add support for a sibling requirement

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1411,7 +1411,35 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req, FuDevice *dev
 			if (device_tmp == NULL)
 				return FALSE;
 			g_set_object (&device_actual, device_tmp);
-
+		/* look for a sibling */
+		} else if (depth == 0) {
+			FuDevice *child = NULL;
+			FuDevice *parent = fu_device_get_parent (device_actual);
+			GPtrArray *children;
+			if (parent == NULL) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_NOT_SUPPORTED,
+					     "No parent specified for device %s",
+					     fu_device_get_name (device_actual));
+				return FALSE;
+			}
+			children = fu_device_get_children (parent);
+			for (guint i = 0 ; i < children->len; i++) {
+				child = g_ptr_array_index (children, i);
+				if (fu_device_has_guid (child, guid))
+					break;
+				child = NULL;
+			}
+			if (child == NULL) {
+				g_set_error (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_NOT_SUPPORTED,
+					     "No sibling found with GUID of %s",
+					     guid);
+				return FALSE;
+			}
+			g_set_object (&device_actual, child);
 		/* verify the parent device has the GUID */
 		} else {
 			if (!fu_device_has_guid (device_actual, guid)) {

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -723,6 +723,110 @@ fu_engine_requirements_version_format_func (gconstpointer user_data)
 }
 
 static void
+fu_engine_requirements_sibling_device_func (gconstpointer user_data)
+{
+	gboolean ret;
+	g_autoptr(FuDevice) device1 = fu_device_new ();
+	g_autoptr(FuDevice) device2 = fu_device_new ();
+	g_autoptr(FuDevice) unrelated_device3 = fu_device_new ();
+	g_autoptr(FuDevice) parent = fu_device_new ();
+	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new ();
+	g_autoptr(FuInstallTask) task = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(XbNode) component = NULL;
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(XbSilo) silo_empty = xb_silo_new ();
+	const gchar *xml =
+		"<component>"
+		"  <requires>"
+		"    <firmware depth=\"0\">1ff60ab2-3905-06a1-b476-0371f00c9e9b</firmware>"
+		"  </requires>"
+		"  <provides>"
+		"    <firmware type=\"flashed\">12345678-1234-1234-1234-123456789012</firmware>"
+		"  </provides>"
+		"  <releases>"
+		"    <release version=\"1.2.4\">"
+		"      <checksum type=\"sha1\" filename=\"bios.bin\" target=\"content\"/>"
+		"    </release>"
+		"  </releases>"
+		"</component>";
+
+	/* no metadata in daemon */
+	fu_engine_set_silo (engine, silo_empty);
+
+	/* set up a dummy device */
+	fu_device_set_id (device1, "id1");
+	fu_device_set_version_format (device1, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device1, "1.2.3");
+	fu_device_add_vendor_id (device1, "FFFF");
+	fu_device_add_flag (device1, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_guid (device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_protocol (device1, "com.acme");
+	fu_engine_add_device (engine, device1);
+
+	/* setup the parent */
+	fu_device_set_id (parent, "parent");
+	fu_device_set_version_format (parent, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (parent, "1.0.0");
+	fu_device_add_flag (parent, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_guid (parent, "42f3d696-0b6f-4d69-908f-357f98ef115e");
+	fu_device_add_protocol (parent, "com.acme");
+	fu_device_add_child (parent, device1);
+	fu_engine_add_device (engine, parent);
+
+	/* set up a different device */
+	fu_device_set_id (unrelated_device3, "id3");
+	fu_device_add_vendor_id (unrelated_device3, "USB:FFFF");
+	fu_device_add_protocol (unrelated_device3, "com.acme");
+	fu_device_set_name (unrelated_device3, "Foo bar device");
+	fu_device_set_version_format (unrelated_device3, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (unrelated_device3, "1.5.3");
+	fu_device_add_vendor_id (unrelated_device3, "FFFF");
+	fu_device_add_flag (unrelated_device3, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_guid (unrelated_device3, "3e455c08-352e-4a16-84d3-f04287289fa2");
+	fu_engine_add_device (engine, unrelated_device3);
+
+	/* import firmware metainfo */
+	silo = xb_silo_new_from_xml (xml, &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (silo);
+	component = xb_silo_query_first (silo, "component", &error);
+	g_assert_no_error (error);
+	g_assert_nonnull (component);
+
+	/* check this fails */
+	task = fu_install_task_new (device1, component);
+	ret = fu_engine_check_requirements (engine, request, task,
+					    FWUPD_INSTALL_FLAG_NONE,
+					    &error);
+	g_assert_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false (ret);
+	g_clear_error (&error);
+
+	/* set up a sibling device */
+	fu_device_set_id (device2, "id2");
+	fu_device_add_vendor_id (device2, "USB:FFFF");
+	fu_device_add_protocol (device2, "com.acme");
+	fu_device_set_name (device2, "Secondary firmware");
+	fu_device_set_version_format (device2, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device2, "4.5.6");
+	fu_device_add_vendor_id (device2, "FFFF");
+	fu_device_add_flag (device2, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_guid (device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_device_add_child (parent, device2);
+	fu_engine_add_device (engine, device2);
+
+	/* check this passes */
+	task = fu_install_task_new (device1, component);
+	ret = fu_engine_check_requirements (engine, request, task,
+					    FWUPD_INSTALL_FLAG_NONE,
+					    &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+}
+
+static void
 fu_engine_requirements_other_device_func (gconstpointer user_data)
 {
 	gboolean ret;
@@ -3152,6 +3256,8 @@ main (int argc, char **argv)
 			      fu_engine_generate_md_func);
 	g_test_add_data_func ("/fwupd/engine{requirements-other-device}", self,
 			      fu_engine_requirements_other_device_func);
+	g_test_add_data_func ("/fwupd/engine{fu_engine_requirements_sibling_device_func}", self,
+			      fu_engine_requirements_sibling_device_func);
 	g_test_add_data_func ("/fwupd/plugin{composite}", self,
 			      fu_plugin_composite_func);
 	g_test_add_data_func ("/fwupd/history", self,


### PR DESCRIPTION
This allow setting 'other-device' requirements of depth=0 to find
devices only with a common parent.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

CC @CragW 

Matching documentation change: https://gitlab.com/fwupd/lvfs-website/-/merge_requests/1007