### PR TITLE
Add N30 Pro 2 gamepad

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -113,3 +113,8 @@ Plugin = ebitdo
 Flags = ~is-bootloader
 InstallDuration = 120
 
+# N30 Pro 2
+[USB\VID_2DC8&PID_9015]
+Plugin = ebitdo
+Flags = ~is-bootloader
+

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -415,6 +415,10 @@ fu_ebitdo_device_write_firmware (FuDevice *device,
 			g_string_append (msg, "press and hold LB+RB+Xbox buttons "
 					      "both white LED and green LED blink, ");
 			break;
+		case 0x9015: /* N30 Pro 2 */
+ 		    g_string_append (msg, "press and hold L1+R1+START buttons "
+ 					      "until the yellow LED blinks, ");
+			break;
 		default:
 			g_string_append (msg, "do what it says in the manual, ");
 			break;


### PR DESCRIPTION
Type of pull request:
- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

The PID information of N30 pro 2 (PID_9015) is different from that of SN30 Pro (PID_6001).