### PR TITLE
More fixes for UEFI Capsule plugin on FreeBSD

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -2772,11 +2772,11 @@ fu_common_get_block_devices (GError **error)
 		return NULL;
 	}
 	g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
-	output =  g_dbus_proxy_call_sync (proxy,
-					  "GetBlockDevices",
-					  g_variant_new ("(a{sv})", &builder),
-					  G_DBUS_CALL_FLAGS_NONE,
-					  -1, NULL, error);
+	output = g_dbus_proxy_call_sync (proxy,
+					 "GetBlockDevices",
+					 g_variant_new ("(a{sv})", &builder),
+					 G_DBUS_CALL_FLAGS_NONE,
+					 -1, NULL, error);
 	if (output == NULL) {
 		if (error != NULL)
 			g_dbus_error_strip_remote_error (*error);
@@ -2801,7 +2801,6 @@ fu_common_get_block_devices (GError **error)
 		}
 		g_ptr_array_add (devices, g_steal_pointer (&proxy_blk));
 	}
-
 
 	return g_steal_pointer (&devices);
 }

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -2781,7 +2781,7 @@ fu_common_get_block_devices (GError **error)
 		if (error != NULL)
 			g_dbus_error_strip_remote_error (*error);
 		g_prefix_error (error, "failed to call %s.%s(): ",
-				UDISKS_DBUS_SERVICE,
+				UDISKS_DBUS_MANAGER_INTERFACE,
 				"GetBlockDevices");
 		return NULL;
 	}

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -710,6 +710,7 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 	return TRUE;
 }
 
+#ifdef __linux__
 static gboolean
 fu_plugin_uefi_capsule_ensure_efivarfs_rw (GError **error)
 {
@@ -734,6 +735,7 @@ fu_plugin_uefi_capsule_ensure_efivarfs_rw (GError **error)
 
 	return TRUE;
 }
+#endif
 
 gboolean
 fu_plugin_unlock (FuPlugin *plugin, FuDevice *device, GError **error)
@@ -839,11 +841,14 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	const gchar *str;
 	g_autoptr(GError) error_udisks2 = NULL;
+#ifdef __linux__
 	g_autoptr(GError) error_efivarfs = NULL;
+#endif
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(FuBackend) backend = fu_uefi_backend_new ();
 
+#ifdef __linux__
 	/* make sure that efivarfs is rw */
 	if (!fu_plugin_uefi_capsule_ensure_efivarfs_rw (&error_efivarfs)) {
 		fu_plugin_add_flag (plugin, FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED);
@@ -851,6 +856,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		fu_plugin_add_flag (plugin, FWUPD_PLUGIN_FLAG_USER_WARNING);
 		g_warning ("%s", error_efivarfs->message);
 	}
+#endif
 
 	if (data->esp == NULL) {
 		data->esp = fu_common_get_esp_default (&error_udisks2);

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -583,14 +583,14 @@ fu_plugin_uefi_capsule_smbios_enabled (FuPlugin *plugin, GError **error)
 		return FALSE;
 	}
 	data = g_bytes_get_data (bios_information, &sz);
-	if (sz < 0x13) {
+	if (sz < 0x14) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INVALID_FILE,
 			     "offset bigger than size %" G_GSIZE_FORMAT, sz);
 		return FALSE;
 	}
-	if (data[1] < 0x13) {
+	if (data[1] < 0x14) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
@@ -94,7 +94,7 @@ fu_uefi_backend_coldplug (FuBackend *backend, GError **error)
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
-				     "not supported");
+				     "ESRT kernel support is missing");
 		return FALSE;
 	}
 	for (guint i = 0; i < entry_count; i++) {


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

***

* Use kenv variable to determine UEFI support (SMBIOS doesn't provide the information).
* Run Linux-specific checks only on Linux.
* Work around `bsdisks` not implementing parts of  UDisks2 (`Manager` object is missing, `Type` field contains FS type name).
* Several small corrections of related code.