### PR TITLE
Use the parent physical ID to autoset the device parent

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -17,6 +17,9 @@ FuDeviceInternalFlags fu_device_internal_flag_from_string (const gchar	*flag);
 GPtrArray	*fu_device_get_parent_guids		(FuDevice	*self);
 gboolean	 fu_device_has_parent_guid		(FuDevice	*self,
 							 const gchar	*guid);
+GPtrArray	*fu_device_get_parent_physical_ids	(FuDevice	*self);
+gboolean	 fu_device_has_parent_physical_id	(FuDevice	*self,
+							 const gchar	*physical_id);
 void		 fu_device_set_parent			(FuDevice	*self,
 							 FuDevice	*parent);
 gint		 fu_device_get_order			(FuDevice	*self);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -229,6 +229,7 @@ FuDevice	*fu_device_new				(void);
  * @FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION:		Inherit activation status from the history database on startup
  * @FU_DEVICE_INTERNAL_FLAG_IS_OPEN:			The device opened successfully and ready to use
  * @FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER:		Do not attempt to read the device serial number
+ * @FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN:	Automatically assign the parent for children of this device
  *
  * The device internal flags.
  **/
@@ -246,6 +247,7 @@ typedef enum {
 	FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION	= (1llu << 9),  /* Since: 1.5.9 */
 	FU_DEVICE_INTERNAL_FLAG_IS_OPEN			= (1llu << 10),	/* Since: 1.6.1 */
 	FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER	= (1llu << 11),	/* Since: 1.6.2 */
+	FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN	= (1llu << 12),	/* Since: 1.6.2 */
 	/*< private >*/
 	FU_DEVICE_INTERNAL_FLAG_UNKNOWN			= G_MAXUINT64,
 } FuDeviceInternalFlags;
@@ -275,6 +277,8 @@ void		 fu_device_add_child			(FuDevice	*self,
 							 FuDevice	*child);
 void		 fu_device_add_parent_guid		(FuDevice	*self,
 							 const gchar	*guid);
+void		 fu_device_add_parent_physical_id	(FuDevice	*self,
+							 const gchar	*physical_id);
 void		 fu_device_add_counterpart_guid		(FuDevice	*self,
 							 const gchar	*guid);
 FuDevice	*fu_device_get_proxy			(FuDevice	*self);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -287,6 +287,7 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 	g_autofree gchar *devid0 = NULL;
 	g_autofree gchar *devid1 = NULL;
 	g_autofree gchar *devid2 = NULL;
+	g_autofree gchar *platform_id = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autoptr(GPtrArray) intfs = NULL;
 
@@ -343,6 +344,18 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 					  g_usb_interface_get_class (intf));
 		fu_device_add_instance_id_full (device, intid3,
 						FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
+	}
+
+	/* add 2 levels of parent IDs */
+	platform_id = g_strdup (g_usb_device_get_platform_id (priv->usb_device));
+	for (guint i = 0; i < 2; i++) {
+		gchar *tok = g_strrstr (platform_id, ":");
+		if (tok == NULL)
+			break;
+		*tok = '\0';
+		if (g_strcmp0 (platform_id, "usb") == 0)
+			break;
+		fu_device_add_parent_physical_id (device, platform_id);
 	}
 #endif
 

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -819,5 +819,8 @@ LIBFWUPDPLUGIN_1.6.1 {
 LIBFWUPDPLUGIN_1.6.2 {
   global:
     fu_common_check_kernel_version;
+    fu_device_add_parent_physical_id;
+    fu_device_get_parent_physical_ids;
+    fu_device_has_parent_physical_id;
   local: *;
 } LIBFWUPDPLUGIN_1.6.1;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1046,7 +1046,7 @@ fu_engine_requirements_parent_device_func (gconstpointer user_data)
 }
 
 static void
-fu_engine_device_parent_func (gconstpointer user_data)
+fu_engine_device_parent_guid_func (gconstpointer user_data)
 {
 	g_autoptr(FuDevice) device1 = fu_device_new ();
 	g_autoptr(FuDevice) device2 = fu_device_new ();
@@ -1096,6 +1096,75 @@ fu_engine_device_parent_func (gconstpointer user_data)
 	g_assert_cmpint (fu_device_get_order (device1), ==, -1);
 	g_assert_cmpint (fu_device_get_order (device2), ==, 0);
 	g_assert_cmpint (fu_device_get_order (device3), ==, -1);
+}
+
+static void
+fu_engine_device_parent_id_func (gconstpointer user_data)
+{
+	g_autoptr(FuDevice) device1 = fu_device_new ();
+	g_autoptr(FuDevice) device2 = fu_device_new ();
+	g_autoptr(FuDevice) device3 = fu_device_new ();
+	g_autoptr(FuDevice) device4 = fu_device_new ();
+	g_autoptr(FuEngine) engine = fu_engine_new (FU_APP_FLAGS_NONE);
+	g_autoptr(XbSilo) silo_empty = xb_silo_new ();
+
+	/* no metadata in daemon */
+	fu_engine_set_silo (engine, silo_empty);
+
+	/* add child */
+	fu_device_set_id (device1, "child1");
+	fu_device_set_name (device1, "Child1");
+	fu_device_set_physical_id (device1, "child-ID1");
+	fu_device_add_vendor_id (device1, "USB:FFFF");
+	fu_device_add_protocol (device1, "com.acme");
+	fu_device_add_instance_id (device1, "child-GUID-1");
+	fu_device_add_parent_physical_id (device1, "parent-ID-notfound");
+	fu_device_add_parent_physical_id (device1, "parent-ID");
+	fu_device_convert_instance_ids (device1);
+	fu_engine_add_device (engine, device1);
+
+	/* parent */
+	fu_device_set_id (device2, "parent");
+	fu_device_set_name (device2, "Parent");
+	fu_device_set_physical_id (device2, "parent-ID");
+	fu_device_add_vendor_id (device2, "USB:FFFF");
+	fu_device_add_protocol (device2, "com.acme");
+	fu_device_add_instance_id (device2, "parent-GUID");
+	fu_device_set_vendor (device2, "oem");
+	fu_device_add_internal_flag (device2, FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN);
+	fu_device_convert_instance_ids (device2);
+
+	/* add another child */
+	fu_device_set_id (device3, "child2");
+	fu_device_set_name (device3, "Child2");
+	fu_device_set_physical_id (device3, "child-ID2");
+	fu_device_add_instance_id (device3, "child-GUID-2");
+	fu_device_add_parent_physical_id (device3, "parent-ID");
+	fu_device_convert_instance_ids (device3);
+	fu_device_add_child (device2, device3);
+
+	/* add two together */
+	fu_engine_add_device (engine, device2);
+
+	/* add non-child */
+	fu_device_set_id (device4, "child4");
+	fu_device_set_name (device4, "Child4");
+	fu_device_set_physical_id (device4, "child-ID4");
+	fu_device_add_vendor_id (device4, "USB:FFFF");
+	fu_device_add_protocol (device4, "com.acme");
+	fu_device_add_instance_id (device4, "child-GUID-4");
+	fu_device_add_parent_physical_id (device4, "parent-ID");
+	fu_device_convert_instance_ids (device4);
+	fu_engine_add_device (engine, device4);
+
+	/* this is normally done by fu_plugin_device_add() */
+	fu_engine_add_device (engine, device4);
+
+	/* verify both children were adopted */
+	g_assert (fu_device_get_parent (device3) == device2);
+	g_assert (fu_device_get_parent (device4) == device2);
+	g_assert (fu_device_get_parent (device1) == device2);
+	g_assert_cmpstr (fu_device_get_vendor (device3), ==, "oem");
 }
 
 static void
@@ -3246,8 +3315,10 @@ main (int argc, char **argv)
 			      fu_engine_requirements_device_plain_func);
 	g_test_add_data_func ("/fwupd/engine{requirements-version-format}", self,
 			      fu_engine_requirements_version_format_func);
-	g_test_add_data_func ("/fwupd/engine{device-auto-parent}", self,
-			      fu_engine_device_parent_func);
+	g_test_add_data_func ("/fwupd/engine{device-auto-parent-id}", self,
+			      fu_engine_device_parent_id_func);
+	g_test_add_data_func ("/fwupd/engine{device-auto-parent-guid}", self,
+			      fu_engine_device_parent_guid_func);
 	g_test_add_data_func ("/fwupd/engine{install-duration}", self,
 			      fu_engine_install_duration_func);
 	g_test_add_data_func ("/fwupd/engine{generate-md}", self,


### PR DESCRIPTION
Of course, this only works if the parent and child both *export* a
FuDevice of the same physical kind, e.g. USB.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
