### PR TITLE
trivial: don't set priority between thunderbolt and dell-dock plugins

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -82,8 +82,6 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_THUNDERBOLT_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE_UPDATE);
-	/* dell-dock plugin uses a slower bus for flashing */
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "dell_dock");
 }
 
 gboolean


### PR DESCRIPTION
The dell-dock plugin has a check whether or not to create the I2C based
child device based upon whether thunderbolt link is active during probe.

So there will never be a situation that daemon needs to de-duplicate and
set priority between the two plugins.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Stemmed from this conversation: https://github.com/fwupd/fwupd/pull/3327#discussion_r648245102
CC @CragW