### PR TITLE
Allow building the documentation with gi-docgen and gtk-doc

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -24,7 +24,7 @@ extraction:
     - "export LD_LIBRARY_PATH=$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"
     configure:
       command:
-      - "meson setup _lgtm_build_dir -Defi_binary=false -Dplugin_uefi_capsule_splash=false"
+      - "meson setup _lgtm_build_dir -Defi_binary=false -Dplugin_uefi_capsule_splash=false -Ddocs=none"
     index:
       build_command:
       - "ninja -C _lgtm_build_dir"

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -30,6 +30,7 @@ build() {
     arch-meson -D b_lto=false $CI ../build \
         -Dplugin_intel_spi=true \
         -Dlzma=true \
+        -Ddocs=gtkdoc \
         -Defi_binary=false \
         -Dsupported_build=true
 

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -15,6 +15,7 @@ meson .. \
     --libexecdir=$target \
     --bindir=$target \
     -Dbuild=standalone \
+    -Ddocs=none \
     -Dpolkit=false \
     -Dplugin_flashrom=false \
     -Dplugin_uefi_capsule=false \

--- a/contrib/ci/centos.sh
+++ b/contrib/ci/centos.sh
@@ -20,7 +20,7 @@ meson .. \
 	-Dplugin_synaptics_mst=true \
 	-Dplugin_flashrom=true \
 	-Dintrospection=true \
-	-Dgtkdoc=true \
+	-Ddocs=gtkdoc \
 	-Dpkcs7=false \
 	-Dman=true
 ninja-build -v

--- a/contrib/ci/check-abi
+++ b/contrib/ci/check-abi
@@ -88,6 +88,7 @@ def build_install(revision):
                 "--libdir=lib",
                 "-Db_coverage=false",
                 "-Dgtkdoc=false",
+                "-Ddocs=none",
                 "-Dgusb:docs=false",
                 "-Dtests=false",
             ]

--- a/contrib/ci/debian_s390x.sh
+++ b/contrib/ci/debian_s390x.sh
@@ -23,7 +23,7 @@ meson .. \
 	-Dplugin_msr=false \
 	-Dplugin_redfish=false \
 	-Dintrospection=false \
-	-Dgtkdoc=false \
+	-Ddocs=none \
 	-Dlibxmlb:introspection=false \
 	-Dlibxmlb:gtkdoc=false \
 	-Dman=false

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -543,6 +543,7 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <!-- TODO: Drop build dependency after switching to gidoc-gen -->
   <dependency type="build" id="gtk-doc-tools">
     <distro id="arch">
       <package>gtk-doc</package>
@@ -1052,6 +1053,60 @@
     </distro>
     <distro id="ubuntu">
       <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <!-- These are needed for gi-docgen -->
+  <dependency type="build" id="python3-pygments">
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="python3-typogrify">
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="fedora">
+      <package />
+    </distro>
+  </dependency>
+  <dependency type="build" id="python3-toml">
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="fedora">
+      <package />
+    </distro>
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="python3-markdown">
+    <distro id="fedora">
+      <package />
+    </distro>
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="python3-jinja2">
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="fedora">
+      <package />
+    </distro>
+    <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
   </dependency>

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -15,7 +15,7 @@ if [ "$QUBES" = "true" ]; then
 fi
 
 meson .. \
-    -Dgtkdoc=true \
+    -Ddocs=none \
     -Dman=true \
     -Dtests=true \
     -Dgusb:tests=false \

--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -20,7 +20,7 @@ eval "$(dpkg-buildflags --export=sh)"
 export LDFLAGS=$(dpkg-buildflags --get LDFLAGS | sed "s/-Wl,-Bsymbolic-functions\s//")
 
 rm -rf build
-meson build -Dman=false -Dgtkdoc=true -Dgusb:tests=false -Dplugin_platform_integrity=true
+meson build -Dman=false -Ddocs=gtkdoc -Dgusb:tests=false -Dplugin_platform_integrity=true
 #build with clang
 ninja -C build test -v
 

--- a/contrib/debian/fwupd-doc.install
+++ b/contrib/debian/fwupd-doc.install
@@ -1,1 +1,1 @@
-usr/share/gtk-doc
+usr/share/*doc

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -48,7 +48,7 @@ ifneq ($(QUBES_OPTION),)
 	CONFARGS += -Dqubes=true
 endif
 
-CONFARGS += -Dplugin_dummy=true -Dgtkdoc=true -Dsupported_build=true
+CONFARGS += -Dplugin_dummy=true -Ddocs=gtkdoc -Dsupported_build=true
 
 %:
 	dh $@ --with gir

--- a/contrib/freebsd/Makefile
+++ b/contrib/freebsd/Makefile
@@ -54,6 +54,7 @@ MESON_ARGS=	-Dgudev=false \
 		-Dpolkit=false \
 		-Dsystemd=false \
 		-Dtests=false \
+		-Ddocs=gtkdoc \
 		-Defi_binary=false
 
 .include <bsd.port.mk>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -15,7 +15,7 @@
 %global enable_ci 0
 %global enable_tests 1
 %global enable_dummy 1
-%global __meson_wrap_mode default
+%global __meson_wrap_mode nodownload
 
 # fwupd.efi is only available on these arches
 %ifarch x86_64 aarch64
@@ -223,7 +223,7 @@ fwupd wrapper for Qubes OS
 %if 0%{?enable_ci}
     --werror \
 %endif
-    -Dgtkdoc=true \
+    -Ddocs=gtkdoc \
 %if 0%{?enable_tests}
     -Dtests=true \
 %else

--- a/docs/fwupd.toml.in
+++ b/docs/fwupd.toml.in
@@ -1,0 +1,35 @@
+[library]
+version = "@version@"
+browse_url = "https://github.com/fwupd/fwupd"
+repository_url = "https://github.com/fwupd/fwupd.git"
+website_url = "https://www.fwupd.org"
+authors = "fwupd Development Team"
+logo_url = "org.freedesktop.fwupd.svg"
+license = "LGPL-2.1-or-later"
+description = "Functionality exported by libfwupd for client applications"
+dependencies = [ "GObject-2.0", "Gio-2.0"]
+devhelp = true
+search_index = true
+
+  [dependencies."GObject-2.0"]
+  name = "GObject"
+  description = "The base type system library"
+  docs_url = "https://developer.gnome.org/gobject/stable/"
+
+  [dependencies."Gio-2.0"]
+  name = "Gio"
+  description = "A modern, easy-to-use VFS API"
+  docs_url = "https://developer.gnome.org/gio/stable/"
+
+[theme]
+name = "basic"
+show_index_summary = true
+show_class_hierarchy = true
+
+[source-location]
+base_url = "https://github.com/fwupd/fwupd/blob/master/"
+
+[extra]
+content_images = [
+  "../data/org.freedesktop.fwupd.svg",
+]

--- a/docs/fwupdplugin.toml.in
+++ b/docs/fwupdplugin.toml.in
@@ -1,0 +1,41 @@
+[library]
+version = "@version@"
+browse_url = "https://github.com/fwupd/fwupd"
+repository_url = "https://github.com/fwupd/fwupd.git"
+website_url = "https://www.fwupd.org"
+authors = "fwupd Development Team"
+logo_url = "org.freedesktop.fwupd.svg"
+license = "LGPL-2.1-or-later"
+description = "Functionality available to fwupd plugins"
+dependencies = [ "GObject-2.0", "Gio-2.0"]
+devhelp = true
+search_index = true
+
+  [dependencies."GObject-2.0"]
+  name = "GObject"
+  description = "The base type system library"
+  docs_url = "https://developer.gnome.org/gobject/stable/"
+
+  [dependencies."Gio-2.0"]
+  name = "Gio"
+  description = "A modern, easy-to-use VFS API"
+  docs_url = "https://developer.gnome.org/gio/stable/"
+
+[theme]
+name = "basic"
+show_index_summary = true
+show_class_hierarchy = true
+
+[source-location]
+base_url = "https://github.com/fwupd/fwupd/blob/master/"
+
+[extra]
+content_files = [
+  "tutorial.md",
+  "hsi.md",
+]
+content_images = [
+  "architecture-plan.svg",
+  "../data/org.freedesktop.fwupd.svg",
+]
+urlmap_file = "urlmap.js"

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,12 +1,80 @@
-gnome.gtkdoc(
-  'fwupd',
-  src_dir : [
-    join_paths(meson.source_root(), 'libfwupd'),
-    join_paths(meson.source_root(), 'libfwupdplugin'),
-    join_paths(meson.build_root(), 'libfwupd'),
-    join_paths(meson.build_root(), 'libfwupdplugin'),
-    join_paths(meson.current_source_dir()),
-  ],
-  main_xml : 'fwupd-docs.xml',
-  install : true
-)
+if get_option('docs') == 'docgen'
+  toml_conf = configuration_data()
+  toml_conf.set('version', meson.project_version())
+
+  fwupd_toml = configure_file(
+    input: 'fwupd.toml.in',
+    output: 'fwupd.toml',
+    configuration: toml_conf
+  )
+
+  fwupdplugin_toml = configure_file(
+    input: 'fwupdplugin.toml.in',
+    output: 'fwupdplugin.toml',
+    configuration: toml_conf
+  )
+
+  custom_target('doc-fwupd',
+    input: [
+      fwupd_toml,
+      fwupd_gir[0],
+    ],
+    output: 'libfwupd',
+    command: [
+      gidocgen,
+      'generate',
+      '--quiet',
+      '--add-include-path=@0@'.format(meson.current_build_dir() / '../libfwupd'),
+      '--config=@INPUT0@',
+      '--output-dir=@OUTPUT@',
+      '--no-namespace-dir',
+      '--content-dir=@0@'.format(meson.current_source_dir()),
+      '@INPUT1@',
+    ],
+    depends: [
+      fwupd_gir[0],
+    ],
+    build_by_default: true,
+    install: true,
+    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+  )
+
+  custom_target('doc-fwupdplugin',
+    input: [
+      fwupdplugin_toml,
+      fwupdplugin_gir[0],
+    ],
+    output: 'libfwupdplugin',
+    command: [
+      gidocgen,
+      'generate',
+      '--quiet',
+      '--add-include-path=@0@'.format(meson.current_build_dir() / '../libfwupd'),
+      '--add-include-path=@0@'.format(meson.current_build_dir() / '../libfwupdplugin'),
+      '--config=@INPUT0@',
+      '--output-dir=@OUTPUT@',
+      '--no-namespace-dir',
+      '--content-dir=@0@'.format(meson.current_source_dir()),
+      '@INPUT1@',
+    ],
+    depends: [
+      fwupdplugin_gir[0],
+    ],
+    build_by_default: true,
+    install: true,
+    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+  )
+elif get_option('docs') == 'gtkdoc'
+  gnome.gtkdoc(
+    'fwupd',
+    src_dir : [
+      join_paths(meson.source_root(), 'libfwupd'),
+      join_paths(meson.source_root(), 'libfwupdplugin'),
+      join_paths(meson.build_root(), 'libfwupd'),
+      join_paths(meson.build_root(), 'libfwupdplugin'),
+      join_paths(meson.current_source_dir()),
+    ],
+    main_xml : 'fwupd-docs.xml',
+    install : true
+  )
+endif

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -2034,7 +2034,7 @@ fwupd_client_download_bytes_cb (GObject *source, GAsyncResult *res, gpointer use
  * @cancellable: (nullable): optional #GCancellable
  * @error: (nullable): optional return location for an error
  *
- * Downloads data from a remote server. The fwupd_client_set_user_agent() function
+ * Downloads data from a remote server. The [method@Client.set_user_agent] function
  * should be called before this method is used.
  *
  * Returns: (transfer full): downloaded data, or %NULL for error
@@ -2081,7 +2081,7 @@ fwupd_client_download_bytes (FwupdClient *self,
  * @cancellable: (nullable): optional #GCancellable
  * @error: (nullable): optional return location for an error
  *
- * Downloads data from a remote server. The fwupd_client_set_user_agent() function
+ * Downloads data from a remote server. The [method@Client.set_user_agent] function
  * should be called before this method is used.
  *
  * Returns: %TRUE if the file was written
@@ -2141,7 +2141,7 @@ fwupd_client_upload_bytes_cb (GObject *source, GAsyncResult *res, gpointer user_
  * @cancellable: (nullable): optional #GCancellable
  * @error: (nullable): optional return location for an error
  *
- * Uploads data to a remote server. The fwupd_client_set_user_agent() function
+ * Uploads data to a remote server. The [method@Client.set_user_agent] function
  * should be called before this method is used.
  *
  * Returns: (transfer full): response data, or %NULL for error

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -36,12 +36,11 @@
 typedef GObject		*(*FwupdClientObjectNewFunc)	(void);
 
 /**
- * SECTION:fwupd-client
- * @short_description: a way of interfacing with the daemon
+ * FwupdClient:
  *
  * An object that allows client code to call the daemon methods synchronously.
  *
- * See also: #FwupdDevice
+ * See also: [class@FwupdDevice]
  */
 
 static void fwupd_client_finalize	 (GObject *object);
@@ -475,7 +474,7 @@ fwupd_client_set_main_context (FwupdClient *self, GMainContext *main_ctx)
  *
  * Sets up the client networking support ready for use. Most other download and
  * upload methods call this automatically, and do you only need to call this if
- * the session is being used outside the #FwupdClient.
+ * the session is being used outside the [class@FwupdClient].
  *
  * Returns: %TRUE for success
  *
@@ -712,7 +711,7 @@ fwupd_client_connect_async (FwupdClient *self, GCancellable *cancellable,
  * @res: the asynchronous result
  * @error: (nullable): optional return location for an error
  *
- * Gets the result of fwupd_client_connect_async().
+ * Gets the result of [method@Client.connect_async].
  *
  * Returns: %TRUE for success
  *
@@ -791,7 +790,7 @@ fwupd_client_get_host_security_attrs_cb (GObject *source,
  *
  * Gets all the host security attributes from the daemon.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -892,7 +891,7 @@ fwupd_client_get_report_metadata_cb (GObject *source,
  *
  * Gets all the report metadata from the daemon.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -972,7 +971,7 @@ fwupd_client_get_devices_cb (GObject *source,
  *
  * Gets all the devices registered with the daemon.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1049,7 +1048,7 @@ fwupd_client_get_plugins_cb (GObject *source,
  *
  * Gets all the plugins being used by the daemon.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1126,7 +1125,7 @@ fwupd_client_get_history_cb (GObject *source,
  *
  * Gets all the history.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1216,7 +1215,7 @@ fwupd_client_get_device_by_id_cb (GObject *source,
  *
  * Gets a device by it's device ID.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1316,7 +1315,7 @@ fwupd_client_get_devices_by_guid_cb (GObject *source,
  * Gets any devices that provide a specific GUID. An error is returned if no
  * devices contains this GUID.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1396,7 +1395,7 @@ fwupd_client_get_releases_cb (GObject *source,
  *
  * Gets all the releases for a specific device
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1478,7 +1477,7 @@ fwupd_client_get_downgrades_cb (GObject *source,
  *
  * Gets all the downgrades for a specific device.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -1560,7 +1559,7 @@ fwupd_client_get_upgrades_cb (GObject *source,
  *
  * Gets all the upgrades for a specific device.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -2115,7 +2114,7 @@ fwupd_client_get_results_cb (GObject *source,
  *
  * Gets the results of a previous firmware update for a specific device.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -2283,7 +2282,7 @@ fwupd_client_install_stream_async (FwupdClient *self,
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/
@@ -2361,7 +2360,7 @@ fwupd_client_install_bytes_finish (FwupdClient *self, GAsyncResult *res, GError 
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/
@@ -2655,7 +2654,7 @@ fwupd_client_filter_locations (GPtrArray *locations,
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.6
  **/
@@ -2721,7 +2720,7 @@ fwupd_client_install_release2_async (FwupdClient *self,
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  * Deprecated: 1.5.6
@@ -3122,7 +3121,7 @@ fwupd_client_update_metadata_stream_async (FwupdClient *self,
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/
@@ -3323,7 +3322,7 @@ fwupd_client_refresh_remote_signature_cb (GObject *source,
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/
@@ -3410,7 +3409,7 @@ fwupd_client_get_remotes_cb (GObject *source,
  *
  * Gets the list of remotes that have been configured for the system.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -3493,7 +3492,7 @@ fwupd_client_get_approved_firmware_cb (GObject *source,
  *
  * Gets the list of approved firmware.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -3662,7 +3661,7 @@ fwupd_client_get_blocked_firmware_cb (GObject *source,
  *
  * Gets the list of blocked firmware.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -3906,7 +3905,7 @@ fwupd_client_self_sign_cb (GObject *source, GAsyncResult *res, gpointer user_dat
  *
  * Signs the data using the client self-signed certificate.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * Since: 1.5.0
@@ -4541,15 +4540,15 @@ fwupd_client_download_bytes2_async (FwupdClient *self,
  * @callback: the function to run on completion
  * @callback_data: the data to pass to @callback
  *
- * Downloads data from a remote server. The fwupd_client_set_user_agent() function
+ * Downloads data from a remote server. The [method@Client.set_user_agent] function
  * should be called before this method is used.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/
@@ -4651,15 +4650,15 @@ fwupd_client_upload_bytes_thread_cb (GTask *task,
  * @callback: the function to run on completion
  * @callback_data: the data to pass to @callback
  *
- * Uploads data to a remote server. The fwupd_client_set_user_agent() function
+ * Uploads data to a remote server. The [method@Client.set_user_agent] function
  * should be called before this method is used.
  *
- * You must have called fwupd_client_connect_async() on @self before using
+ * You must have called [method@Client.connect_async] on @self before using
  * this method.
  *
  * NOTE: This method is thread-safe, but progress signals will be
  * emitted in the global default main context, if not explicitly set with
- * fwupd_client_set_main_context().
+ * [method@Client.set_main_context].
  *
  * Since: 1.5.0
  **/

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -311,7 +311,7 @@ fwupd_build_user_agent_system (void)
  * Before freaking out about theoretical privacy implications, much more data
  * than this is sent to each and every website you visit.
  *
- * Rather that using this function you should use fwupd_client_set_user_agent_for_package()
+ * Rather that using this function you should use [method@Client.set_user_agent_for_package]
  * which uses the *runtime* version of the daemon rather than the *build-time*
  * version.
  *

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -17,12 +17,11 @@
 #include "fwupd-release-private.h"
 
 /**
- * SECTION:fwupd-device
- * @short_description: a hardware device
+ * FwupdDevice:
  *
  * An object that represents a physical device on the host.
  *
- * See also: #FwupdRelease
+ * See also: [class@FwupdRelease]
  */
 
 static void fwupd_device_finalize	 (GObject *object);

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -9,16 +9,6 @@
 #include "fwupd-enums.h"
 
 /**
- * SECTION:fwupd-enums
- * @short_description: enumerated values shared by the daemon and library
- *
- * This file also provides helper functions to map enums to strings and back
- * again.
- *
- * See also: #fwupd-error
- */
-
-/**
  * fwupd_status_to_string:
  * @status: a status, e.g. %FWUPD_STATUS_DECOMPRESSING
  *

--- a/libfwupd/fwupd-error.c
+++ b/libfwupd/fwupd-error.c
@@ -13,16 +13,6 @@
 #include "fwupd-error.h"
 
 /**
- * SECTION:fwupd-error
- * @short_description: an error domain shared by the daemon and library
- *
- * This file also provides helper functions to map errors to strings and back
- * again.
- *
- * See also: #fwupd-enums
- */
-
-/**
  * fwupd_error_to_string:
  * @error: an enumerated error, e.g. %FWUPD_ERROR_VERSION_NEWER
  *

--- a/libfwupd/fwupd-plugin.c
+++ b/libfwupd/fwupd-plugin.c
@@ -12,12 +12,11 @@
 #include "fwupd-plugin-private.h"
 
 /**
- * SECTION:fwupd-plugin
- * @short_description: a hardware plugin
+ * FwupdPlugin:
  *
  * An object that represents a fwupd plugin.
  *
- * See also: #FwupdRelease
+ * See also: [class@FwupdRelease]
  */
 
 static void fwupd_plugin_finalize	 (GObject *object);

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -16,14 +16,13 @@
 #include "fwupd-release-private.h"
 
 /**
- * SECTION:fwupd-release
- * @short_description: a firmware release
+ * FwupdRelease:
  *
  * An object that represents a firmware release with a specific version.
  * Devices can have more than one release, and the releases are typically
  * ordered by their version.
  *
- * See also: #FwupdDevice
+ * See also: [class@FwupdDevice]
  */
 
 static void fwupd_release_finalize	 (GObject *object);

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -17,12 +17,11 @@
 #include "fwupd-remote-private.h"
 
 /**
- * SECTION:fwupd-remote
- * @short_description: a source of firmware
+ * FwupdRemote:
  *
  * An object that represents a source of metadata that provides firmware.
  *
- * See also: #FwupdClient
+ * See also: [class@FwupdClient]
  */
 
 static void fwupd_remote_finalize	 (GObject *obj);

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -14,7 +14,7 @@
 #include "fwupd-security-attr-private.h"
 
 /**
- * SECTION:fwupd-security-attr
+ * FwupdSecurityAttr:
  *
  * An object that represents an Host Security ID attribute.
  */

--- a/libfwupd/fwupd-version.h.in
+++ b/libfwupd/fwupd-version.h.in
@@ -8,14 +8,6 @@
 
 #include <glib.h>
 
-/**
- * SECTION:fwupd-version
- * @short_description: Obtains the version for the installed fwupd
- *
- * These compile time macros allow the user to enable parts of client code
- * depending on the version of libfwupd installed.
- */
-
 #if !defined (__FWUPD_H_INSIDE__) && !defined (FWUPD_COMPILATION)
 #error "Only <fwupd.h> can be included directly."
 #endif
@@ -55,6 +47,9 @@
  *
  * Check whether a fwupd version equal to or greater than
  * major.minor.micro.
+ *
+ * These compile time macros allow the user to enable parts of client code
+ * depending on the version of libfwupd installed.
  */
 #define FWUPD_CHECK_VERSION(major,minor,micro)    \
     (FWUPD_MAJOR_VERSION > (major) || \

--- a/libfwupd/fwupd.h
+++ b/libfwupd/fwupd.h
@@ -6,11 +6,6 @@
 
 #pragma once
 
-/**
- * SECTION:fwupd
- * @short_description: Helper objects for accessing fwupd
- */
-
 #define __FWUPD_H_INSIDE__
 
 #include <libfwupd/fwupd-client.h>

--- a/libfwupdplugin/fu-archive.c
+++ b/libfwupdplugin/fu-archive.c
@@ -19,9 +19,9 @@
 #include "fwupd-error.h"
 
 /**
- * SECTION:fu-archive
- * @title: FuArchive
- * @short_description: an in-memory archive decompressor
+ * FuArchive:
+ *
+ * An in-memory archive decompressor
  */
 
 struct _FuArchive {

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -18,12 +18,11 @@
 #define DEFAULT_PROXY_TIMEOUT	5000
 
 /**
- * SECTION:fu-bluez-device
- * @short_description: a BlueZ Bluetooth device
+ * FuBluezDevice:
  *
  * An object that represents a BlueZ Bluetooth device.
  *
- * See also: #FuBluezDevice
+ * See also: [class@FuDevice]
  */
 
 typedef struct {

--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -18,6 +18,14 @@
 #include "fwupd-enums.h"
 #include "fwupd-error.h"
 
+/**
+ * FuCabinet:
+ *
+ * Cabinet archive parser and writer.
+ *
+ * See also: [class@FuArchive]
+ */
+
 struct _FuCabinet {
 	GObject			 parent_instance;
 	guint64			 size_max;

--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -14,11 +14,9 @@
 #include "fu-common.h"
 
 /**
- * SECTION:fu-chunk
- * @short_description: A packet of chunked data
+ * FuChunk:
  *
- * An object that represents a packet of data.
- *
+ * An object that represents a packet of chunked data.
  */
 
 struct _FuChunk {

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -38,15 +38,6 @@
 #include "fu-volume-private.h"
 
 /**
- * SECTION:fu-common
- * @short_description: common functionality for plugins to use
- *
- * Helper functions that can be used by the daemon and plugins.
- *
- * See also: #FuPlugin
- */
-
-/**
  * fu_common_rmtree:
  * @directory: a directory name
  * @error: (nullable): optional return location for an error

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -13,8 +13,7 @@
 #include "fu-smbios-private.h"
 
 /**
- * SECTION:fu-context
- * @short_description: a context shared between all the plugins and the daemon
+ * FuContext:
  *
  * An object that represents the shared system state. This object is shared
  * between the engine, the plugins and the devices.

--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -17,14 +17,12 @@
 #include "fu-usb-device.h"
 
 /**
- * SECTION:fu-device-locker
- * @title: FuDeviceLocker
- * @short_description: a device helper object
+ * FuDeviceLocker:
  *
  * An object that makes it easy to close a device when an object goes out of
  * scope.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 struct _FuDeviceLocker {

--- a/libfwupdplugin/fu-device-metadata.h
+++ b/libfwupdplugin/fu-device-metadata.h
@@ -9,17 +9,6 @@
 #include <glib.h>
 
 /**
- * SECTION:fu-device-metadata
- * @short_description: a device helper object
- *
- * An object that makes it easy to close a device when an object goes out of
- * scope.
- *
- * See also: #FuDevice
- */
-
-
-/**
  * FU_DEVICE_METADATA_TBT_IS_SAFE_MODE:
  *
  * If the Thunderbolt hardware is stuck in safe mode.

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -27,12 +27,11 @@
 #define FU_DEVICE_DEFAULT_BATTERY_THRESHOLD		10 /* % */
 
 /**
- * SECTION:fu-device
- * @short_description: a physical or logical device
+ * FuDevice:
  *
  * An object that represents a physical or logical device.
  *
- * See also: #FuDeviceLocker
+ * See also: [class@FuDeviceLocker]
  */
 
 static void fu_device_finalize			 (GObject *object);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -14,12 +14,11 @@
 #include "fu-dfu-firmware-private.h"
 
 /**
- * SECTION:fu-dfu-firmware
- * @short_description: DFU firmware image
+ * FuDfuFirmware:
  *
  * An object that represents a DFU firmware image.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 typedef struct {

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -16,12 +16,11 @@
 #include "fu-dfuse-firmware.h"
 
 /**
- * SECTION:fu-dfuse-firmware
- * @short_description: DfuSe firmware image
+ * FuDfuseFirmware:
  *
  * An object that represents a DfuSe firmware image.
  *
- * See also: #FuDfuFirmware
+ * See also: [class@FuDfuFirmware]
  */
 
 G_DEFINE_TYPE (FuDfuseFirmware, fu_dfuse_firmware, FU_TYPE_DFU_FIRMWARE)

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -14,12 +14,11 @@
 #include "fu-efi-signature-list.h"
 
 /**
- * SECTION:fu-efi-signature-list
- * @short_description: Parser for EFI_SIGNATURE_LIST
+ * FuEfiSignatureList:
  *
  * An object that represents a UEFI SignatureList.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 struct _FuEfiSignatureList {

--- a/libfwupdplugin/fu-efi-signature.c
+++ b/libfwupdplugin/fu-efi-signature.c
@@ -9,12 +9,11 @@
 #include "fu-efi-signature-private.h"
 
 /**
- * SECTION:fu-efi-signature
- * @short_description: Parser for EFI_SIGNATURE
+ * FuEfiSignature:
  *
  * An object that represents a UEFI Signature.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 struct _FuEfiSignature {

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -13,11 +13,10 @@
 #include "fu-firmware.h"
 
 /**
- * SECTION:fu-firmware
- * @short_description: a firmware file
+ * FuFirmware:
  *
  * An object that represents a firmware file.
- * See also: #FuDfuFirmware, #FuIhexFirmware, #FuSrecFirmware
+ * See also: [class@FuDfuFirmware], [class@FuIhexFirmware], [class@FuSrecFirmware]
  */
 
 typedef struct {

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -11,6 +11,14 @@
 #include "fu-common.h"
 #include "fu-fmap-firmware.h"
 
+/**
+ * FuFmapFirmware:
+ *
+ * An object that represents a FMAP firmware image.
+ *
+ * See also: [class@FuFirmware]
+ */
+
 #define FMAP_SIGNATURE		"__FMAP__"
 #define FMAP_AREANAME		"FMAP"
 

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -20,12 +20,11 @@
 #define FU_HID_DEVICE_RETRIES				10
 
 /**
- * SECTION:fu-hid-device
- * @short_description: a HID device
+ * FuHidDevice:
  *
  * An object that represents a HID device.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 typedef struct

--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -17,6 +17,16 @@
 #include "fwupd-common.h"
 #include "fwupd-error.h"
 
+/**
+ * FuHwids:
+ *
+ * An object that represents a the hardware IDs on the system.
+ * Note, these are called "CHIDs" in Microsoft Windows and the results here
+ * will match that of `ComputerHardwareIds.exe`.
+ *
+ * See also: [class@FuSmbios]
+ */
+
 struct _FuHwids {
 	GObject			 parent_instance;
 	GHashTable		*hash_dmi_hw;		/* BiosVersion->"1.2.3 " */

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -15,12 +15,11 @@
 #include "fu-ihex-firmware.h"
 
 /**
- * SECTION:fu-ihex-firmware
- * @short_description: Ihex firmware image
+ * FuIhexFirmware:
  *
- * An object that represents a Ihex firmware image.
+ * An object that represents a Intel hex (ihex) firmware image.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 typedef struct {

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -22,6 +22,12 @@
 #include "fu-common.h"
 #include "fu-io-channel.h"
 
+/**
+ * FuIOChannel:
+ *
+ * An object that represents a bidirectional IO channel.
+ */
+
 struct _FuIOChannel {
 	GObject			 parent_instance;
 	gint			 fd;

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -20,17 +20,6 @@
 #endif
 
 /**
- * SECTION:fu-plugin-vfuncs
- * @short_description: Virtual functions for plugins
- *
- * Optional functions that a plugin can implement.  If implemented they will
- * be automatically called by the daemon as part of the plugin lifecycle.
- *
- * See also: #FuPlugin
- */
-
-
-/**
  * fu_plugin_init:
  * @plugin: A #FuPlugin
  *

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -20,12 +20,11 @@
 #include "fu-mutex.h"
 
 /**
- * SECTION:fu-plugin
- * @short_description: a daemon plugin
+ * FuPlugin:
  *
  * An object that represents a plugin run by the daemon.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 static void fu_plugin_finalize			 (GObject *object);
@@ -2048,7 +2047,7 @@ fu_plugin_set_priority (FuPlugin *self, guint priority)
  * for example the plugin specified by @name will be ordered after this plugin
  * when %FU_PLUGIN_RULE_RUN_AFTER is used.
  *
- * NOTE: the depsolver is iterative and may not solve overly-complicated rules;
+ * NOTE: The depsolver is iterative and may not solve overly-complicated rules;
  * If depsolving fails then fwupd will not start.
  *
  * Since: 1.0.0

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -22,8 +22,7 @@
 #include "fwupd-remote-private.h"
 
 /**
- * SECTION:fu-quirks
- * @short_description: device quirks
+ * FuQuirks:
  *
  * Quirks can be used to modify device behavior.
  * When fwupd is installed in long-term support distros it's very hard to
@@ -43,7 +42,7 @@
  * obviously need code changes, but allows us to get most existing devices working
  * in an easy way without the user compiling anything.
  *
- * See also: #FuDevice, #FuPlugin
+ * See also: [class@FuDevice], [class@FuPlugin]
  */
 
 static void fu_quirks_finalize	 (GObject *obj);

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -14,6 +14,12 @@
 #include "fu-security-attrs-private.h"
 #include "fwupd-security-attr-private.h"
 
+/**
+ * FuSecurityAttrs:
+ *
+ * An object that represents one specific HSI attribute.
+ */
+
 struct _FuSecurityAttrs {
 	GObject			 parent_instance;
 	GPtrArray		*attrs;

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -16,6 +16,15 @@
 #include "fu-smbios-private.h"
 #include "fwupd-error.h"
 
+/**
+ * FuSmbios:
+ *
+ * An object that collects the SMBIOS data on the system, either using DMI or
+ * Device Tree.
+ *
+ * See also: [class@FuHwids]
+ */
+
 struct _FuSmbios {
 	FuFirmware		 parent_instance;
 	guint32			 structure_table_len;

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -15,12 +15,11 @@
 #include "fu-srec-firmware.h"
 
 /**
- * SECTION:fu-srec-firmware
- * @short_description: SREC firmware image
+ * FuSrecFirmware:
  *
  * An object that represents a SREC firmware image.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 typedef struct {

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -27,12 +27,11 @@
 #include "fu-udev-device-private.h"
 
 /**
- * SECTION:fu-udev-device
- * @short_description: a udev device
+ * FuUdevDevice:
  *
  * An object that represents a udev device.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 typedef struct

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -12,12 +12,11 @@
 #include "fu-usb-device-private.h"
 
 /**
- * SECTION:fu-usb-device
- * @short_description: a USB device
+ * FuUsbDevice:
  *
  * An object that represents a USB device.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 typedef struct

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -16,9 +16,9 @@
 #include "fu-volume-private.h"
 
 /**
- * SECTION:fu-volume
- * @title: FuVolume
- * @short_description: Volume abstraction that uses UDisks
+ * FuVolume:
+ *
+ * Volume abstraction that uses UDisks
  */
 
 struct _FuVolume {

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -6,11 +6,6 @@
 
 #pragma once
 
-/**
- * SECTION:fwupdplugin
- * @short_description: Helper objects for plugins interacting with fwupd daemon
- */
-
 #define __FWUPDPLUGIN_H_INSIDE__
 
 #include <libfwupdplugin/fu-archive.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -214,7 +214,7 @@ if get_option('introspection') and get_option('gusb')
     namespace : 'FwupdPlugin',
     symbol_prefix : 'fu',
     identifier_prefix : 'Fu',
-    export_packages : 'fu',
+    export_packages : 'fwupdplugin',
     extra_args : '-DHAVE_GUSB',
     include_directories : [
       fwupd_incdir,

--- a/meson.build
+++ b/meson.build
@@ -535,10 +535,16 @@ endif
 
 root_incdir = include_directories('.')
 
-if get_option('gtkdoc')
-  gtkdocscan = find_program('gtkdoc-scan', required : true)
-  subdir('docs')
+if get_option('docs') == 'gtkdoc'
+  gtkdocscan = find_program('gtkdoc-scan')
+elif get_option('docs') == 'docgen'
+  gidocgen_dep = dependency('gi-docgen',
+    version: '>= 2021.1',
+    fallback: ['gi-docgen', 'dummy_dep'],
+  )
+  gidocgen = find_program('gi-docgen')
 endif
+
 subdir('libfwupd')
 if build_daemon and get_option('polkit')
   subdir('policy')
@@ -551,6 +557,7 @@ if build_standalone
   subdir('plugins')
   subdir('contrib')
 endif
+subdir('docs')
 
 if get_option('systemd') and build_daemon
   meson.add_install_script('meson_post_install.sh', systemdunitdir, localstatedir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option('build', type : 'combo', choices : ['all', 'standalone', 'library'], valu
 option('agent', type : 'boolean', value : true, description : 'enable the fwupd agent')
 option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
 option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
-option('gtkdoc', type : 'boolean', value : false, description : 'enable developer documentation')
+option('docs', type : 'combo', choices : ['none', 'gtkdoc', 'docgen'], value : 'docgen', description : 'developer documentation type')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
 option('lvfs', type : 'boolean', value : true, description : 'enable LVFS remotes')
 option('man', type : 'boolean', value : true, description : 'enable man pages')

--- a/plugins/dfu/fu-dfu-common.c
+++ b/plugins/dfu/fu-dfu-common.c
@@ -4,13 +4,6 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-/**
- * SECTION:fu-dfu-common
- * @short_description: Common functions for DFU
- *
- * These helper objects allow converting from enum values to strings.
- */
-
 #include "config.h"
 
 #include <string.h>

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -5,8 +5,7 @@
  */
 
 /**
- * SECTION:fu-dfu-device
- * @short_description: Object representing a DFU-capable device
+ * FuDfuDevice:
  *
  * This object allows two things:
  *
@@ -17,7 +16,7 @@
  *    file. The file format is chosen automatically, with DfuSe being
  *    chosen if the device contains more than one target.
  *
- * See also: #FuDfuTarget, #FuDfuseFirmware
+ * See also: [class@FuDfuTarget], [class@FuDfuseFirmware]
  */
 
 /**

--- a/plugins/dfu/fu-dfu-sector.c
+++ b/plugins/dfu/fu-dfu-sector.c
@@ -5,8 +5,7 @@
  */
 
 /**
- * SECTION:fu-dfu-sector
- * @short_description: Object representing a sector on a chip
+ * FuDfuSector:
  *
  * This object represents an sector of memory at a specific address on the
  * device itself.
@@ -17,7 +16,7 @@
  * You can think of these objects as flash segments on devices, where a
  * complete block can be erased and then written to.
  *
- * See also: #DfuElement
+ * See also: [class@FuChunk]
  */
 
 #include "config.h"

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -5,8 +5,7 @@
  */
 
 /**
- * SECTION:fu-dfu-target
- * @short_description: Object representing a DFU-capable target
+ * FuDfuTarget:
  *
  * This object allows uploading and downloading an image onto a
  * specific DFU-capable target.
@@ -15,7 +14,7 @@
  * want to update one target on the device. Most users will want to
  * update all the targets on the device at the same time.
  *
- * See also: #FuDfuDevice, #FuFirmware
+ * See also: [class@FuDfuDevice], [class@FuFirmware]
  */
 
 #include "config.h"

--- a/plugins/intel-spi/fu-efi-firmware-filesystem.c
+++ b/plugins/intel-spi/fu-efi-firmware-filesystem.c
@@ -11,12 +11,11 @@
 #include "fu-efi-firmware-filesystem.h"
 
 /**
- * SECTION:fu-uefi-firmware-filesystem
- * @short_description: UEFI FFS
+ * FuEfiFirmwareFilesystem:
  *
  * An object that represents a UEFI FFS volume.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 G_DEFINE_TYPE (FuEfiFirmwareFilesystem, fu_efi_firmware_filesystem, FU_TYPE_FIRMWARE)

--- a/plugins/intel-spi/fu-efi-firmware-volume.c
+++ b/plugins/intel-spi/fu-efi-firmware-volume.c
@@ -12,12 +12,11 @@
 #include "fu-efi-firmware-volume.h"
 
 /**
- * SECTION:fu-uefi-firmware-volume
- * @short_description: UEFI Volume
+ * FuEfiFirmwareVolume:
  *
  * An object that represents a UEFI file volume.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 typedef struct {

--- a/plugins/intel-spi/fu-ifd-bios.c
+++ b/plugins/intel-spi/fu-ifd-bios.c
@@ -11,12 +11,11 @@
 #include "fu-ifd-bios.h"
 
 /**
- * SECTION:fu-ifd-bios
- * @short_description: Intel BIOS section
+ * FuIfdBios:
  *
  * An object that represents an Intel BIOS section.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 G_DEFINE_TYPE (FuIfdBios, fu_ifd_bios, FU_TYPE_IFD_IMAGE)

--- a/plugins/intel-spi/fu-ifd-firmware.c
+++ b/plugins/intel-spi/fu-ifd-firmware.c
@@ -12,12 +12,11 @@
 #include "fu-ifd-bios.h"
 
 /**
- * SECTION:fu-ifd-firmware
- * @short_description: IFD firmware image
+ * FuIfdFirmware:
  *
  * An object that represents a Intel Flash Descriptor.
  *
- * See also: #FuFirmware
+ * See also: [class@FuFirmware]
  */
 
 typedef struct {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -173,7 +173,7 @@ parts:
     meson-parameters: [--prefix=/,
                        -Dtests=false,
                        -Dbuild=all,
-                       -Dgtkdoc=false,
+                       -Ddocs=none,
                        -Dintrospection=false,
                        -Dman=false,
                        -Dplugin_modem_manager=true,

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -18,8 +18,7 @@
 #include "fwupd-error.h"
 
 /**
- * SECTION:fu-device-list
- * @short_description: a list of devices
+ * FuDeviceList:
  *
  * This list of devices provides a way to find a device using either the
  * device-id or a GUID.
@@ -28,7 +27,7 @@
  * has been changed. If the #FuDevice has changed during a device replug then
  * the ::changed signal will be emitted instead of ::added and then ::removed.
  *
- * See also: #FuDevice
+ * See also: [class@FuDevice]
  */
 
 static void fu_device_list_finalize	 (GObject *obj);

--- a/src/fu-plugin-list.c
+++ b/src/fu-plugin-list.c
@@ -16,14 +16,13 @@
 #include "fwupd-error.h"
 
 /**
- * SECTION:fu-plugin-list
- * @short_description: a list of plugins
+ * FuPluginList:
  *
  * This list of plugins provides a way to get the specific plugin quickly using
  * a hash table and also any plugin-list specific functionality such as
  * sorting by dependency order.
  *
- * See also: #FuPlugin
+ * See also: [class@FuPlugin]
  */
 
 static void fu_plugin_list_finalize	 (GObject *obj);

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,5 +1,6 @@
 gusb
 gcab
+gi-docgen
 flashrom
 libjcat
 libxmlb

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+directory=gi-docgen
+url=https://gitlab.gnome.org/GNOME/gi-docgen.git
+revision=main
+depth=1


### PR DESCRIPTION
Until gi-docgen is declared stable support both of them.
This effectively means that hand builds and CI builds will use
gi-docgen, but distro builds use gtk-doc-tools.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [X] Documentation
