### PR TITLE
Update ESRT access implementation for FreeBSD

### DIFF
--- a/contrib/ci/build_freebsd_package.sh
+++ b/contrib/ci/build_freebsd_package.sh
@@ -32,13 +32,16 @@ if [ -z "$GITHUB_SHA" ] || [ -z "$GITHUB_REPOSITORY" ] || \
     exit 1
 fi
 
-set -e
+# Include-file of libefivar port uses GCC-specific builtin function
+export CC=gcc
+
+set -xe
 mkdir -p /usr/local/etc/pkg/repos/
 # Fix meson flag problem https://www.mail-archive.com/freebsd-ports@freebsd.org/msg86617.html
 cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
 sed -i .old 's|url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly"|url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest"|' \
 /usr/local/etc/pkg/repos/FreeBSD.conf
-pkg install -y meson
+pkg install -y meson efivar
 pkg upgrade -y meson
 cd /usr
 git clone https://github.com/3mdeb/freebsd-ports.git --depth 1 -b fwupd ports
@@ -52,9 +55,10 @@ sed -i .old "s/GH_TAGNAME=.*$/GH_TAGNAME=\t${GITHUB_SHA}/" Makefile
 sed -i .old "s/GH_ACCOUNT=.*$/GH_ACCOUNT=\t${GITHUB_REPOSITORY_OWNER}/" Makefile
 sed -i .old "s/DISTVERSION=.*$/DISTVERSION=\t${GITHUB_TAG}/" Makefile
 make makesum
+make clean
+make
 make makeplist > plist
 sed -i "" "1d" plist
-make clean
 make package
 make install
 cp /usr/ports/sysutils/fwupd/work/pkg/fwupd*.txz \

--- a/libfwupdplugin/fu-efivar-freebsd.c
+++ b/libfwupdplugin/fu-efivar-freebsd.c
@@ -11,6 +11,7 @@
 
 #include <efivar.h>
 
+#include "fu-common.h"
 #include "fu-efivar-impl.h"
 
 #include "fwupd-error.h"
@@ -55,7 +56,7 @@ fu_efivar_delete_with_glob_impl (const gchar *guid, const gchar *name_glob, GErr
 	efi_str_to_guid (guid, &guid_to_delete);
 
 	while (efi_get_next_variable_name (&guidt, &name)) {
-		if (memcmp (&guid_to_delete, guidt, sizeof (guidt)) != 0)
+		if (memcmp (&guid_to_delete, guidt, sizeof (guid_to_delete)) != 0)
 			continue;
 		if (!fu_common_fnmatch (name, name_glob))
 			continue;
@@ -105,7 +106,6 @@ fu_efivar_get_data_impl (const gchar *guid, const gchar *name, guint8 **data,
 GPtrArray *
 fu_efivar_get_names_impl (const gchar *guid, GError **error)
 {
-	const gchar *name_guid;
 	g_autoptr(GPtrArray) names = g_ptr_array_new_with_free_func (g_free);
 	efi_guid_t *guidt = NULL;
 	gchar *name = NULL;
@@ -172,7 +172,7 @@ fu_efivar_set_data_impl (const gchar *guid, const gchar *name, const guint8 *dat
 	efi_guid_t guidt;
 	efi_str_to_guid (guid, &guidt);
 
-	if (efi_set_variable (guidt, name, data, sz, attr) != 0) {
+	if (efi_set_variable (guidt, name, (guint8 *)data, sz, attr) != 0) {
 		g_set_error (error,
 			     G_IO_ERROR,
 			     G_IO_ERROR_FAILED,

--- a/meson.build
+++ b/meson.build
@@ -281,7 +281,7 @@ if get_option('default_library') != 'static'
     platform_deps += cc.find_library('shlwapi')
   endif
   if host_machine.system() == 'freebsd'
-    platform_deps += cc.find_library('efivar')
+    platform_deps += dependency('efivar')
   endif
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -366,6 +366,12 @@ if cc.has_function('pwrite', args : '-D_XOPEN_SOURCE')
   conf.set('HAVE_PWRITE', '1')
 endif
 
+if host_machine.system() == 'freebsd'
+  if cc.has_type('struct efi_esrt_entry_v1', prefix: '#include <sys/types.h>\n#include <sys/efiio.h>')
+    conf.set('HAVE_FREEBSD_ESRT', '1')
+  endif
+endif
+
 if build_standalone and get_option('plugin_tpm')
   tpm2tss = dependency('tss2-esys', version : '>= 2.0')
   conf.set('HAVE_TSS2', '1')

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -47,6 +47,7 @@ shared_module('fu_plugin_uefi_capsule',
   c_args : cargs,
   dependencies : [
     plugin_deps,
+    platform_deps,
     efiboot,
     tpm2tss,
   ],
@@ -75,6 +76,7 @@ fwupdate = executable(
   ],
   dependencies : [
     plugin_deps,
+    platform_deps,
     efiboot,
     tpm2tss,
   ],
@@ -156,6 +158,7 @@ if get_option('tests')
     ],
     dependencies : [
       plugin_deps,
+      platform_deps,
       efiboot,
       tpm2tss,
     ],

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -59,6 +59,7 @@ endif
 
 dbxtool = executable(
   'dbxtool',
+  fu_hash,
   sources : [
     'fu-dbxtool.c',
     'fu-uefi-dbx-common.c',


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

***

Upstream kernel [patch](https://reviews.freebsd.org/D30104) was rejected in its original form. `sysctl()` interface was changed to `ioctl()` and it won't compile now without updated patch applied. Actually patch update wasn't yet sent upstream, but you can see it [here](https://github.com/3mdeb/freebsd-src/pull/2). We believe that's basically final form of the API.

I've also faced some issues with efivars, which weren't noticed during review. Maybe cherry-pick it separately.