### PR TITLE
flashrom: probe PS175 version via DPCD, not direct flash access

### DIFF
--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -72,6 +72,7 @@ This plugin uses the following plugin-specific quirks:
 | Quirk                  | Description                                 | Minimum fwupd version |
 |------------------------|---------------------------------------------|-----------------------|
 |`FlashromProgrammer`    | Used to specify the libflashrom programmer to be used.     | 1.5.9                 |
+|`ParadeLspconAuxDeviceName` | sysfs name of the drm_dp_aux_dev device over which to read LSPCON version | 1.6.1 |
 
 
 External interface access

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -43,3 +43,6 @@ Plugin=flashrom
 FlashromProgrammer=lspcon_i2c_spi
 Name=PS175
 Vendor=Parade
+
+[FLASHROM-LSPCON-I2C-SPI\HwidFamily=Google_Hatch]
+ParadeLspconAuxDeviceName=DPDDC-B

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -44,6 +44,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_FLASHROM_LSPCON_I2C_SPI_DEVICE);
 	fu_context_add_udev_subsystem (ctx, "i2c");
 	fu_context_add_quirk_key (ctx, "FlashromProgrammer");
+	fu_context_add_quirk_key (ctx, "ParadeLspconAuxDeviceName");
 }
 
 static int

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -1,6 +1,10 @@
 if get_option('plugin_flashrom')
 cargs = ['-DG_LOG_DOMAIN="FuPluginFlashrom"']
 
+if not get_option('gudev')
+  warning('gudev is required for LSPCON version detection')
+endif
+
 install_data(['flashrom.quirk'],
   install_dir: join_paths(get_option('datadir'), 'fwupd', 'quirks.d')
 )


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

---

The LSPCON mostly appears to work normally while flashing, but some functions
such as hotplug detection appear to stop working. Avoid opening the flashrom
programmer for the device unless actually flashing it, and change to reading
the device firmware version from DPCD to achieve that. A new quirk is used
to determine the device over which to access DPCD, keyed by system HWID family.

cc @djcampello 