### PR TITLE
trivial: modem-manager: don't convert instance IDs to GUIDs in probe

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -11,7 +11,6 @@
 #include "fu-io-channel.h"
 #include "fu-archive.h"
 #include "fu-mm-device.h"
-#include "fu-device-private.h"
 #include "fu-mm-utils.h"
 #include "fu-qmi-pdc-updater.h"
 
@@ -325,9 +324,6 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 			}
 		}
 	}
-
-	/* convert the instance IDs to GUIDs */
-	fu_device_convert_instance_ids (device);
 
 	return TRUE;
 }


### PR DESCRIPTION
This already happens during setup, there shouldn't be a need to depend
on the private header to accomplish this.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
