### PR TITLE
modem-manager: Do not convert instance IDs to GUIDs manually

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3593,6 +3593,10 @@ fu_device_setup (FuDevice *self, GError **error)
 	g_return_val_if_fail (FU_IS_DEVICE (self), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
+	/* should have already been called */
+	if (!fu_device_probe (self, error))
+		return FALSE;
+
 	/* already done */
 	if (priv->done_setup)
 		return TRUE;

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -10,7 +10,6 @@
 #include <string.h>
 
 #include "fu-mm-device.h"
-#include "fu-device-private.h"
 #include "fu-mm-utils.h"
 #include "fu-qmi-pdc-updater.h"
 
@@ -324,9 +323,6 @@ fu_mm_device_probe_default (FuDevice *device, GError **error)
 			}
 		}
 	}
-
-	/* convert the instance IDs to GUIDs */
-	fu_device_convert_instance_ids (device);
 
 	return TRUE;
 }

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -220,7 +220,7 @@ fu_plugin_mm_device_add (FuPlugin *plugin, MMObject *modem)
 		return;
 	}
 	dev = fu_mm_device_new (priv->manager, modem);
-	if (!fu_device_probe (FU_DEVICE (dev), &error)) {
+	if (!fu_device_setup (FU_DEVICE (dev), &error)) {
 		g_warning ("failed to probe MM device: %s", error->message);
 		return;
 	}


### PR DESCRIPTION
This already happens during setup, there shouldn't be a need to depend
on the private header to accomplish this.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
