### PR TITLE
synaptics-prometheus: Fix enumeration of the config child

### DIFF
--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -221,10 +221,6 @@ fu_synaprom_device_setup (FuDevice *device, GError **error)
 	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER) &&
 	    pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR) {
 		g_autoptr(FuSynapromConfig) cfg = fu_synaprom_config_new (self);
-		if (!fu_device_setup (FU_DEVICE (cfg), error)) {
-			g_prefix_error (error, "failed to get config version: ");
-			return FALSE;
-		}
 		fu_device_add_child (FU_DEVICE (device), FU_DEVICE (cfg));
 	}
 


### PR DESCRIPTION
Do not manually call config setup before adding the parent.

The ->setup() action is called on children explicitly in fu_device_setup()
after the parent device has all the required properties.

Fixes https://github.com/fwupd/fwupd/issues/3364

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
