### PR TITLE
Fix blocking of updates for inhibited devices

### DIFF
--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -297,8 +297,7 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	}
 
 	/* no update abilities */
-	if (!fu_device_has_flag (self->device, FWUPD_DEVICE_FLAG_UPDATABLE) &&
-	    !fu_device_has_flag (self->device, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN)) {
+	if (!fu_device_has_flag (self->device, FWUPD_DEVICE_FLAG_UPDATABLE)) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
If the device is inhibited no install tasks should run on it.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

CC @CragW 