### PR TITLE
Allow probing Synaptics MST w/ amdgpu on newer enough kernels

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -319,6 +319,7 @@ done
 %config(noreplace)%{_sysconfdir}/fwupd/uefi_capsule.conf
 %endif
 %config(noreplace)%{_sysconfdir}/fwupd/redfish.conf
+%config(noreplace)%{_sysconfdir}/fwupd/synaptics_mst.conf
 %config(noreplace)%{_sysconfdir}/fwupd/thunderbolt.conf
 %dir %{_libexecdir}/fwupd
 %{_libexecdir}/fwupd/fwupd

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -371,6 +371,8 @@ gchar		*fu_common_strsafe		(const gchar	*str,
 gchar		*fu_common_strjoin_array	(const gchar	*separator,
 						 GPtrArray	*array);
 gboolean	 fu_common_kernel_locked_down	(void);
+gboolean	 fu_common_check_kernel_version	(const gchar	*minimum_kernel,
+						 GError		**error);
 gboolean	 fu_common_cpuid		(guint32	 leaf,
 						 guint32	*eax,
 						 guint32	*ebx,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -815,3 +815,9 @@ LIBFWUPDPLUGIN_1.6.1 {
     fu_version_string;
   local: *;
 } LIBFWUPDPLUGIN_1.6.0;
+
+LIBFWUPDPLUGIN_1.6.2 {
+  global:
+    fu_common_check_kernel_version;
+  local: *;
+} LIBFWUPDPLUGIN_1.6.1;

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -36,6 +36,10 @@ shared_module('fu_plugin_synaptics_mst',
   ],
 )
 
+install_data(['synaptics_mst.conf'],
+  install_dir:  join_paths(sysconfdir, 'fwupd')
+)
+
 if get_option('tests')
   testdatadirs = environment()
   testdatadirs.set('G_TEST_SRCDIR', meson.current_source_dir())

--- a/plugins/synaptics-mst/synaptics_mst.conf
+++ b/plugins/synaptics-mst/synaptics_mst.conf
@@ -1,0 +1,5 @@
+[synaptics_mst]
+# Minimum kernel version to allow use of this plugin on amdgpu
+# It's important that all backports from this kernel have been
+# made if using an older kernel
+MinimumAmdGpuKernelVersion=5.2.0

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -7,7 +7,6 @@
 #include "config.h"
 
 #include <fwupdplugin.h>
-#include <sys/utsname.h>
 
 #include "fu-thunderbolt-device.h"
 #include "fu-thunderbolt-firmware.h"
@@ -17,33 +16,13 @@ static gboolean
 fu_plugin_thunderbolt_safe_kernel (FuPlugin *plugin, GError **error)
 {
 	g_autofree gchar *minimum_kernel = NULL;
-	struct utsname name_tmp;
-
-	memset (&name_tmp, 0, sizeof(struct utsname));
-	if (uname (&name_tmp) < 0) {
-		g_debug ("Failed to read current kernel version");
-		return TRUE;
-	}
 
 	minimum_kernel = fu_plugin_get_config_value (plugin, "MinimumKernelVersion");
 	if (minimum_kernel == NULL) {
 		g_debug ("Ignoring kernel safety checks");
 		return TRUE;
 	}
-
-	if (fu_common_vercmp_full (name_tmp.release,
-				   minimum_kernel,
-				   FWUPD_VERSION_FORMAT_TRIPLET) < 0) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INTERNAL,
-			     "kernel %s may not have full Thunderbolt support",
-			     name_tmp.release);
-		return FALSE;
-	}
-	g_debug ("Using kernel %s (minimum %s)", name_tmp.release, minimum_kernel);
-
-	return TRUE;
+	return fu_common_check_kernel_version (minimum_kernel, error);
 }
 
 gboolean


### PR DESCRIPTION
I've found that the original problem we had has been fixed in current kernels.  It appears to be fixed by https://github.com/torvalds/linux/commit/8ae5b1d78d4acbe9755570f26703962877f9108a

Running with an AMD Renoir system I can find that it probes properly as far back as kernel 5.8 (but can't check much earlier due to lack of kernel support for Renoir).
```
~/fwupd$ sudo fwupdtool get-devices --plugins synaptics-mst
Loading…                 [***************************************]
WARNING: This package has not been validated, it may not work properly.
20Y10015US
│
└─VMM5322:
      Device ID:          81905eb4059e79f42c9f19fdcb195beeae5f38fa
      Summary:            Multi-Stream Transport Device
      Current version:    5.05.05
      Vendor:             Synaptics (DRM_DP_AUX_DEV:0x06CB)
      GUIDs:              e6b5bc25-d512-51b0-b23c-25fdf483b15d ← MST-595
                          f15aa55c-9cd5-5942-85ae-a6bf8740b96c ← MST-panamera
                          e0b67325-e8ff-5171-93e9-aaf098589166 ← MST-panamera-vmm5322-595
                          50f72ec0-b147-56d7-b1a4-6af9256b2d6a ← MST-panamera-595
      Device Flags:       • Updatable
                          • Device stages updates
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
