### PR TITLE
trivial: device-tests: Add HP USB-C Dock G5 firmware v1.0.13

### DIFF
--- a/data/device-tests/devices/hp-dock-g5.json
+++ b/data/device-tests/devices/hp-dock-g5.json
@@ -11,6 +11,10 @@
     {
       "version": "1.0.11.0",
       "file": "61467bb36546de4449bfc72f9001fb0824606a8ef0b268383f145acf59c473f8-HP-USBC_DOCK_G5-V1.0.11.0.cab"
+    },
+    {
+      "version": "1.0.13.0",
+      "file": "c15a0df7386812781d1f376fe54729e64f69b2a8a6c4b580914d4f6740e4fcc3-HP-USBC_DOCK_G5-V1.0.13.0.cab"
     }
   ]
 }


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

Just adding a new firmware to this device-test.