### PR TITLE
libfwupd: Show unconverted GUIDs when debugging

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -402,8 +402,8 @@ fwupd_device_func (void)
 	ret = fu_test_compare_lines (str_ascii->str,
 		"ColorHug2\n"
 		"  DeviceId:             USB:foo\n"
-		"  Guid:                 2082b5e0-7a64-478a-b1b2-e3404fab6dad\n"
 		"  Guid:                 00000000-0000-0000-0000-000000000000\n"
+		"  Guid:                 2082b5e0-7a64-478a-b1b2-e3404fab6dad\n"
 		"  Flags:                updatable|require-ac\n"
 		"  Checksum:             SHA1(beefdead)\n"
 		"  Icon:                 input-gaming,input-mouse\n"


### PR DESCRIPTION
Add a suffix to any GUIDs that are currently unconverted InstanceIDs.

This makes plugin development much easier as you can now see why GUID
quirks in the subclassed ->setup() are not matching.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
