### PR TITLE
vli: Call the superclassed probe explicitly

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -489,6 +489,10 @@ fu_vli_usbhub_device_probe (FuDevice *device, GError **error)
 {
 	guint16 usbver = fu_usb_device_get_spec (FU_USB_DEVICE (device));
 
+	/* FuUsbDevice->probe */
+	if (!FU_DEVICE_CLASS (fu_vli_usbhub_device_parent_class)->probe (device, error))
+		return FALSE;
+
 	/* quirks now applied... */
 	if (usbver > 0x0300 || fu_device_has_custom_flag (device, "usb3")) {
 		fu_device_set_summary (device, "USB 3.x Hub");


### PR DESCRIPTION
Although this leads to the same end result, it's better to list the
InstanceIDs in order of specificity.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
