### PR TITLE
trivial: Allow plugins to use fu_device_convert_instance_ids()

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -29,7 +29,6 @@ gboolean	 fu_device_ensure_id			(FuDevice	*self,
 							 G_GNUC_WARN_UNUSED_RESULT;
 void		 fu_device_incorporate_from_component	(FuDevice	*device,
 							 XbNode		*component);
-void		 fu_device_convert_instance_ids		(FuDevice	*self);
 gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 GPtrArray	*fu_device_get_possible_plugins		(FuDevice	*self);
 void		 fu_device_add_possible_plugin		(FuDevice	*self,

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -465,3 +465,4 @@ GHashTable	*fu_device_report_metadata_pre		(FuDevice	*self);
 GHashTable	*fu_device_report_metadata_post		(FuDevice	*self);
 void		 fu_device_add_security_attrs		(FuDevice	*self,
 							 FuSecurityAttrs *attrs);
+void		 fu_device_convert_instance_ids		(FuDevice	*self);


### PR DESCRIPTION
This may be required if the plugin has a _custom_ ->setup() vfunc and
needs the quirks added before the actual ->setup() vfunc returns --
for example in the FuVliDeviceClass.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
