### PR TITLE
vli: Be more specific when matching the MSP430

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3618,6 +3618,12 @@ fu_device_setup (FuDevice *self, GError **error)
 	/* convert the instance IDs to GUIDs */
 	fu_device_convert_instance_ids (self);
 
+	/* subclassed */
+	if (klass->ready != NULL) {
+		if (!klass->ready (self, error))
+			return FALSE;
+	}
+
 	priv->done_setup = TRUE;
 	return TRUE;
 }

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -99,6 +99,9 @@ struct _FuDeviceClass
 							 G_GNUC_WARN_UNUSED_RESULT;
 	void			 (*add_security_attrs)	(FuDevice	*self,
 							 FuSecurityAttrs *attrs);
+	gboolean		 (*ready)		(FuDevice	*self,
+							 GError		**error)
+							 G_GNUC_WARN_UNUSED_RESULT;
 	/*< private >*/
 	gpointer	padding[10];
 #endif

--- a/plugins/vli/fu-vli-device.h
+++ b/plugins/vli/fu-vli-device.h
@@ -16,8 +16,6 @@ G_DECLARE_DERIVABLE_TYPE (FuVliDevice, fu_vli_device, FU, VLI_DEVICE, FuUsbDevic
 struct _FuVliDeviceClass
 {
 	FuUsbDeviceClass	parent_class;
-	gboolean		 (*setup)		(FuVliDevice	*self,
-							 GError		**error);
 	gboolean		 (*spi_chip_erase)	(FuVliDevice	*self,
 							 GError		**error);
 	gboolean		 (*spi_sector_erase)	(FuVliDevice	*self,

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -587,7 +587,7 @@ fu_vli_usbhub_device_rtd21xx_setup (FuVliUsbhubDevice *self, GError **error)
 }
 
 static gboolean
-fu_vli_usbhub_device_setup (FuVliDevice *device, GError **error)
+fu_vli_usbhub_device_ready (FuDevice *device, GError **error)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE (device);
 	g_autoptr(GError) error_tmp = NULL;
@@ -1006,7 +1006,7 @@ fu_vli_usbhub_device_class_init (FuVliUsbhubDeviceClass *klass)
 	klass_device->prepare_firmware = fu_vli_usbhub_device_prepare_firmware;
 	klass_device->attach = fu_vli_usbhub_device_attach;
 	klass_device->to_string = fu_vli_usbhub_device_to_string;
-	klass_vli_device->setup = fu_vli_usbhub_device_setup;
+	klass_device->ready = fu_vli_usbhub_device_ready;
 	klass_vli_device->spi_chip_erase = fu_vli_usbhub_device_spi_chip_erase;
 	klass_vli_device->spi_sector_erase = fu_vli_usbhub_device_spi_sector_erase;
 	klass_vli_device->spi_read_data = fu_vli_usbhub_device_spi_read_data;

--- a/plugins/vli/vli-usbhub-lenovo.quirk
+++ b/plugins/vli/vli-usbhub-lenovo.quirk
@@ -32,8 +32,10 @@ ParentGuid = TBT-01081720
 [USB\VID_17EF&PID_307F]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-msp430
+Flags = usb3
 CounterpartGuid = USB\VID_17EF&PID_3080
+[USB\VID_17EF&PID_307F&HUB_0002]
+Flags = usb3,has-msp430
 [USB\VID_17EF&PID_307F&HUB_0006]
 ParentGuid = USB\VID_17EF&PID_307F&HUB_0002
 [USB\VID_17EF&PID_3080]


### PR DESCRIPTION
Add a FuDevice->ready() vfunc that is run after ->setup()
This allows plugins to perform setup actions that require quirk matches
after the instance IDs have been converted. This allows us to also
remove FuVliDevice->setup() as the ordering chain has been broken.

There are two USB-3 hubs internally (with the same VID&PID), and the
MSP430 is only attached to the top-level one.

Fixes https://github.com/fwupd/fwupd/issues/3366

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
