### PR TITLE
wacom-usb: Legacy Bluetooth module reports version numbers in little-endian

### DIFF
--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -654,7 +654,7 @@ fu_wac_device_add_modules_bluetooth (FuWacDevice *self, GError **error)
 	}
 
 	if (!fu_common_read_uint16_safe (buf, sizeof(buf), 1, &fw_ver,
-					 G_BIG_ENDIAN, error))
+					 G_LITTLE_ENDIAN, error))
 		return FALSE;
 	version = fu_common_version_from_uint16 (fw_ver, FWUPD_VERSION_FORMAT_BCD);
 


### PR DESCRIPTION
While the modern firmware interfaces report their version numbers in
big-endian form, reading the legacy Bluetooth module version via the
FU_WAC_REPORT_ID_GET_FIRMWARE_VERSION_BLUETOOTH report requires us to
actually parse a little-endian value. This difference was overlooked
when making changes to the version parsing code in commit 50a4ec70e6a8.
This commit restores the proper interpretation.

Fixes: 50a4ec70e6a8 (wacom_usb: Firmware versions are packed BCD, not "decimal")

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
