### PR TITLE
Allow adding and removing custom flags on devices

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -34,3 +34,4 @@ gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 GPtrArray	*fu_device_get_possible_plugins		(FuDevice	*self);
 void		 fu_device_add_possible_plugin		(FuDevice	*self,
 							 const gchar	*plugin);
+gchar		*fu_device_get_custom_flags		(FuDevice	*self);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -329,11 +329,14 @@ void		 fu_device_add_flag			(FuDevice	*self,
 							 FwupdDeviceFlags flag);
 void		 fu_device_remove_flag			(FuDevice	*self,
 							 FwupdDeviceFlags flag);
-const gchar	*fu_device_get_custom_flags		(FuDevice	*self);
 gboolean	 fu_device_has_custom_flag		(FuDevice	*self,
 							 const gchar	*hint);
 void		 fu_device_set_custom_flags		(FuDevice	*self,
 							 const gchar	*custom_flags);
+void		 fu_device_add_custom_flag		(FuDevice	*self,
+							 const gchar	*custom_flag);
+void		 fu_device_remove_custom_flag		(FuDevice	*self,
+							 const gchar	*custom_flag);
 void		 fu_device_set_name			(FuDevice	*self,
 							 const gchar	*value);
 guint		 fu_device_get_remove_delay		(FuDevice	*self);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1393,6 +1393,7 @@ fu_device_inhibit_func (void)
 static void
 fu_device_flags_func (void)
 {
+	g_autofree gchar *custom_flags = NULL;
 	g_autoptr(FuDevice) device = fu_device_new ();
 
 	/* bitfield */
@@ -1424,6 +1425,29 @@ fu_device_flags_func (void)
 							   FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_custom_flags (device, "~is-bootloader");
 	g_assert_cmpint (fu_device_get_flags (device), ==, FWUPD_DEVICE_FLAG_UPDATABLE);
+
+	/* custom */
+	custom_flags = fu_device_get_custom_flags (device);
+	g_assert_cmpstr (custom_flags, ==, NULL);
+	fu_device_set_custom_flags (device, "foo,bar,baz");
+	fu_device_set_custom_flags (device, "baz,baz");
+	custom_flags = fu_device_get_custom_flags (device);
+	g_assert_cmpstr (custom_flags, ==, "baz");
+	g_assert_true (fu_device_has_custom_flag (device, "baz"));
+	g_assert_false (fu_device_has_custom_flag (device, "foo"));
+
+	/* custom negation */
+	fu_device_set_custom_flags (device, "baz,~baz");
+	g_assert_false (fu_device_has_custom_flag (device, "baz"));
+
+	/* custom add and remove */
+	fu_device_add_custom_flag (device, "foo");
+	fu_device_add_custom_flag (device, "bar");
+	g_assert_true (fu_device_has_custom_flag (device, "foo"));
+	g_assert_true (fu_device_has_custom_flag (device, "bar"));
+	fu_device_remove_custom_flag (device, "bar");
+	g_assert_true (fu_device_has_custom_flag (device, "foo"));
+	g_assert_false (fu_device_has_custom_flag (device, "bar"));
 }
 
 static void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -819,5 +819,7 @@ LIBFWUPDPLUGIN_1.6.1 {
 LIBFWUPDPLUGIN_1.6.2 {
   global:
     fu_common_check_kernel_version;
+    fu_device_add_custom_flag;
+    fu_device_remove_custom_flag;
   local: *;
 } LIBFWUPDPLUGIN_1.6.1;

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -508,11 +508,9 @@ fu_plugin_uefi_capsule_coldplug_device (FuPlugin *plugin, FuUefiDevice *dev, GEr
 	if (!fu_device_setup (FU_DEVICE (dev), error))
 		return FALSE;
 
-	/* if not already set by quirks */
-	if (fu_device_get_custom_flags (FU_DEVICE (dev)) == NULL &&
-	    fu_plugin_has_custom_flag (plugin, "use-legacy-bootmgr-desc")) {
-		fu_device_set_custom_flags (FU_DEVICE (dev), "use-legacy-bootmgr-desc");
-	}
+	/* propagate from plugin flag to device flag */
+	if (fu_plugin_has_custom_flag (plugin, "use-legacy-bootmgr-desc"))
+		fu_device_add_custom_flag (FU_DEVICE (dev), "use-legacy-bootmgr-desc");
 
 	/* set fallback name if nothing else is set */
 	device_kind = fu_uefi_device_get_kind (dev);

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -541,8 +541,8 @@ fu_device_list_item_set_device (FuDeviceItem *item, FuDevice *device)
 static void
 fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device)
 {
-	const gchar *custom_flags;
 	GPtrArray *vendor_ids;
+	g_autofree gchar *custom_flags = NULL;
 
 	/* clear timeout if scheduled */
 	if (item->remove_id != 0) {


### PR DESCRIPTION
The CustomFlags feature is a bit of a hack where we just join the flags
and store in the device metadata section as a string. This makes it
inefficient to check if just one flag exists as we have to split the
string to a temporary array each time.

Rather than adding to the hack by splitting, appending (if not exists)
then joining again, store the custom flags in an actual array.

This means we have to change the fu_device_get_custom_flags() ABI
slightly, but this isn't something plugins should really be using.

This allows us to support negating custom properties (e.g. ~hint) and
also allows quirks to append custom values without duplicating them on
each GUID match, e.g.

	[USB\VID_17EF&PID_307F]
	Plugin = customflag1
	[USB\VID_17EF&PID_307F&HUB_0002]
	Flags = customflag2

...would result in `customflag1,customflag2` which is the same as you'd
get from an enumerated device flag doing the same thing.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
