### PR TITLE
Allow adding and removing custom flags on devices

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -37,3 +37,6 @@ gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 GPtrArray	*fu_device_get_possible_plugins		(FuDevice	*self);
 void		 fu_device_add_possible_plugin		(FuDevice	*self,
 							 const gchar	*plugin);
+guint64		 fu_device_get_private_flags		(FuDevice	*self);
+void		 fu_device_set_private_flags		(FuDevice	*self,
+							 guint64	 flag);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -339,7 +339,8 @@ void		 fu_device_remove_flag			(FuDevice	*self,
 							 FwupdDeviceFlags flag);
 const gchar	*fu_device_get_custom_flags		(FuDevice	*self);
 gboolean	 fu_device_has_custom_flag		(FuDevice	*self,
-							 const gchar	*hint);
+							 const gchar	*hint)
+							 G_DEPRECATED_FOR(fu_device_has_private_flag);
 void		 fu_device_set_custom_flags		(FuDevice	*self,
 							 const gchar	*custom_flags);
 void		 fu_device_set_name			(FuDevice	*self,
@@ -476,3 +477,12 @@ GHashTable	*fu_device_report_metadata_pre		(FuDevice	*self);
 GHashTable	*fu_device_report_metadata_post		(FuDevice	*self);
 void		 fu_device_add_security_attrs		(FuDevice	*self,
 							 FuSecurityAttrs *attrs);
+void		 fu_device_register_private_flag	(FuDevice	*self,
+							 guint64	 value,
+							 const gchar	*value_str);
+void		 fu_device_add_private_flag		(FuDevice	*self,
+							 guint64	 flag);
+void		 fu_device_remove_private_flag		(FuDevice	*self,
+							 guint64	 flag);
+gboolean	 fu_device_has_private_flag		(FuDevice	*self,
+							 guint64	 flag);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1390,6 +1390,39 @@ fu_device_inhibit_func (void)
 	g_assert_false (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN));
 }
 
+#define TEST_FLAG_FOO	(1 << 0)
+#define TEST_FLAG_BAR	(1 << 1)
+#define TEST_FLAG_BAZ	(1 << 2)
+
+static void
+fu_device_private_flags_func (void)
+{
+	g_autofree gchar *tmp = NULL;
+	g_autoptr(FuDevice) device = fu_device_new ();
+
+	fu_device_register_private_flag (device, TEST_FLAG_FOO, "foo");
+	fu_device_register_private_flag (device, TEST_FLAG_BAR, "bar");
+
+	fu_device_set_custom_flags (device, "foo");
+	g_assert_cmpint (fu_device_get_private_flags (device), ==, TEST_FLAG_FOO);
+	fu_device_set_custom_flags (device, "bar");
+	g_assert_cmpint (fu_device_get_private_flags (device), ==, TEST_FLAG_FOO | TEST_FLAG_BAR);
+	fu_device_set_custom_flags (device, "~bar");
+	g_assert_cmpint (fu_device_get_private_flags (device), ==, TEST_FLAG_FOO);
+	fu_device_set_custom_flags (device, "baz");
+	g_assert_cmpint (fu_device_get_private_flags (device), ==, TEST_FLAG_FOO);
+	fu_device_add_private_flag (device, TEST_FLAG_BAZ);
+	g_assert_cmpint (fu_device_get_private_flags (device), ==, TEST_FLAG_FOO | TEST_FLAG_BAZ);
+
+	tmp = fu_device_to_string (device);
+	g_assert_cmpstr (tmp, ==,
+		"FuDevice:\n"
+		"Unknown Device\n"
+		"  Flags:                none\n"
+		"  CustomFlags:          baz\n" /* compat */
+		"  PrivateFlags:         foo\n");
+}
+
 static void
 fu_device_flags_func (void)
 {
@@ -2942,6 +2975,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/device{instance-ids}", fu_device_instance_ids_func);
 	g_test_add_func ("/fwupd/device{composite-id}", fu_device_composite_id_func);
 	g_test_add_func ("/fwupd/device{flags}", fu_device_flags_func);
+	g_test_add_func ("/fwupd/device{custom-flags}", fu_device_private_flags_func);
 	g_test_add_func ("/fwupd/device{inhibit}", fu_device_inhibit_func);
 	g_test_add_func ("/fwupd/device{parent}", fu_device_parent_func);
 	g_test_add_func ("/fwupd/device{children}", fu_device_children_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -820,7 +820,13 @@ LIBFWUPDPLUGIN_1.6.2 {
   global:
     fu_common_check_kernel_version;
     fu_device_add_parent_physical_id;
+    fu_device_add_private_flag;
     fu_device_get_parent_physical_ids;
+    fu_device_get_private_flags;
     fu_device_has_parent_physical_id;
+    fu_device_has_private_flag;
+    fu_device_register_private_flag;
+    fu_device_remove_private_flag;
+    fu_device_set_private_flags;
   local: *;
 } LIBFWUPDPLUGIN_1.6.1;

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -26,6 +26,14 @@ struct _FuCcgxDmcDevice {
 	DmcUpdateModel		update_model;
 };
 
+
+/**
+ * FU_CCGX_DMC_DEVICE_FLAG_HAS_MANUAL_REPLUG:
+ *
+ * Needs a manual replug from the end-user.
+ */
+#define FU_CCGX_DMC_DEVICE_FLAG_HAS_MANUAL_REPLUG		(1 << 0)
+
 G_DEFINE_TYPE (FuCcgxDmcDevice, fu_ccgx_dmc_device, FU_TYPE_USB_DEVICE)
 
 static gboolean
@@ -541,10 +549,9 @@ static gboolean
 fu_ccgx_dmc_device_attach (FuDevice *device, GError **error)
 {
 	FuCcgxDmcDevice *self = FU_CCGX_DMC_DEVICE (device);
-	gboolean manual_replug = FALSE;
+	gboolean manual_replug;
 
-	if (fu_device_has_custom_flag (device, "has-manual-replug"))
-		manual_replug = TRUE;
+	manual_replug = fu_device_has_private_flag (device, FU_CCGX_DMC_DEVICE_FLAG_HAS_MANUAL_REPLUG);
 
 	if (fu_device_get_update_state (self) != FWUPD_UPDATE_STATE_SUCCESS)
 		return TRUE;
@@ -657,6 +664,9 @@ fu_ccgx_dmc_device_init (FuCcgxDmcDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_CCGX_DMC_DEVICE_FLAG_HAS_MANUAL_REPLUG,
+					 "has-manual-replug");
 }
 
 static void

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -20,7 +20,7 @@
  *
  * Since: 1.0.3
  */
-#define FU_COLORHUG_DEVICE_FLAG_HALFSIZE	"halfsize"
+#define FU_COLORHUG_DEVICE_FLAG_HALFSIZE	(1 << 0)
 
 struct _FuColorhugDevice {
 	FuUsbDevice		 parent_instance;
@@ -321,7 +321,7 @@ fu_colorhug_device_probe (FuDevice *device, GError **error)
 		return FALSE;
 
 	/* compact memory layout */
-	if (fu_device_has_custom_flag (device, FU_COLORHUG_DEVICE_FLAG_HALFSIZE))
+	if (fu_device_has_private_flag (device, FU_COLORHUG_DEVICE_FLAG_HALFSIZE))
 		self->start_addr = CH_EEPROM_ADDR_RUNCODE_ALS;
 
 	/* add hardcoded bits */
@@ -534,6 +534,9 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_COLORHUG_DEVICE_FLAG_HALFSIZE,
+					 "halfsize");
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -70,6 +70,11 @@ typedef struct {
 	gsize payload_size;
 } FuCrosEcUsbBlockInfo;
 
+#define FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN		(1 << 0)
+#define FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN		(1 << 1)
+#define FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO	(1 << 2)
+#define FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL		(1 << 3)
+
 static gboolean
 fu_cros_ec_usb_device_get_configuration (FuCrosEcUsbDevice *self,
 					 GError **error)
@@ -707,10 +712,7 @@ fu_cros_ec_usb_device_reset_to_ro (FuDevice *device, GError **error)
 	gsize response_size = 1;
 	g_autoptr(GError) error_local = NULL;
 
-	if (fu_device_has_custom_flag (device, "ro-written"))
-		fu_device_set_custom_flags (device, "ro-written,rebooting-to-ro");
-	else
-		fu_device_set_custom_flags (device, "rebooting-to-ro");
+	fu_device_add_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 	if (!fu_cros_ec_usb_device_send_subcommand  (device, subcommand, command_body,
 				     command_body_size, &response,
 				     &response_size, FALSE, &error_local)) {
@@ -760,7 +762,9 @@ fu_cros_ec_usb_device_write_firmware (FuDevice *device,
 	FuCrosEcFirmware *cros_ec_firmware = FU_CROS_EC_FIRMWARE (firmware);
 	gint num_txed_sections = 0;
 
-	if (fu_device_has_custom_flag (device, "rebooting-to-ro")) {
+	fu_device_remove_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
+
+	if (fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO)) {
 		gsize response_size = 1;
 		guint8 response;
 		guint16 subcommand = UPDATE_EXTRA_CMD_STAY_IN_RO;
@@ -768,6 +772,7 @@ fu_cros_ec_usb_device_write_firmware (FuDevice *device,
 		gsize command_body_size = 0;
 		START_RESP start_resp;
 
+		fu_device_remove_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO);
 		if (!fu_cros_ec_usb_device_send_subcommand  (device, subcommand, command_body,
 							     command_body_size, &response,
 							     &response_size, FALSE, error)) {
@@ -789,15 +794,22 @@ fu_cros_ec_usb_device_write_firmware (FuDevice *device,
 		}
 	}
 
-	if (fu_device_has_custom_flag (device, "rw-written") && self->in_bootloader) {
+	if (fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) && self->in_bootloader) {
 		/*
-		 * we had previously written to the rw region but somehow
-		 * ended back up here while still in bootloader; this is
-		 * a transitory state due to the fact that we have to boot
-		 * through RO to get to RW. Set another write required to
-		 * allow the RO region to auto-jump to RW
+		 * We had previously written to the rw region (while we were
+		 * booted from ro region), but somehow landed in ro again after
+		 * a reboot. Since we wrote rw already, we wanted to jump
+		 * to the new rw so we could evaluate ro.
+		 *
+		 * This is a transitory state due to the fact that we have to
+		 * boot through RO to get to RW. Set another write required to
+		 * allow the RO region to auto-jump to RW.
+		 *
+		 * Special flow: write phase skips actual write -> attach skips
+		 * send of reset command, just sets wait for replug, and
+		 * device restart status.
 		 */
-		fu_device_set_custom_flags (device, "special,rw-written");
+		fu_device_add_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 		return TRUE;
 	}
@@ -855,20 +867,14 @@ fu_cros_ec_usb_device_write_firmware (FuDevice *device,
 		return FALSE;
 	}
 
-	if (self->in_bootloader) {
-		if (fu_device_has_custom_flag (device, "ro-written"))
-			fu_device_set_custom_flags (device, "ro-written,rw-written");
-		else
-			fu_device_set_custom_flags (device, "rw-written");
-	} else if (fu_device_has_custom_flag (device, "rw-written")) {
-		fu_device_set_custom_flags (device, "ro-written,rw-written");
-	} else {
-		fu_device_set_custom_flags (device, "ro-written");
-	}
+	if (self->in_bootloader)
+		fu_device_add_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN);
+	else
+		fu_device_add_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN);
 
 	/* logical XOR */
-	if (fu_device_has_custom_flag (device, "rw-written") !=
-	    fu_device_has_custom_flag (device, "ro-written"))
+	if (fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) !=
+	    fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN))
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 
 	/* success */
@@ -921,16 +927,25 @@ fu_cros_ec_usb_device_attach (FuDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
 
-	if (self->in_bootloader && fu_device_has_custom_flag (device, "special")) {
-		fu_device_set_remove_delay (device, CROS_EC_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_remove_delay (device, CROS_EC_REMOVE_DELAY_RE_ENUMERATE);
+	if (self->in_bootloader &&
+	    fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL)) {
+
+		/*
+		 * attach after the SPECIAL flag was set. The EC will auto-jump
+		 * from ro -> rw, so we do not need to send an explicit
+		 * reset_to_ro. We just need to set for another wait for replug
+		 * as a detach + reenumeration is expected as we jump from
+		 * ro -> rw.
+		 */
+		fu_device_remove_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL);
 		fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 		return TRUE;
 	}
 
-	fu_device_set_remove_delay (device, CROS_EC_REMOVE_DELAY_RE_ENUMERATE);
-	if (fu_device_has_custom_flag (device, "ro-written") &&
-	    !fu_device_has_custom_flag (device, "rw-written")) {
+	if (fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN) &&
+	    !fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN)) {
 		if (!fu_cros_ec_usb_device_reset_to_ro (device, error)) {
 			return FALSE;
 		}
@@ -949,8 +964,8 @@ fu_cros_ec_usb_device_detach (FuDevice *device, GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE (device);
 
-	if (fu_device_has_custom_flag (device, "rw-written") &&
-	    !fu_device_has_custom_flag (device, "ro-written"))
+	if (fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN) &&
+	    !fu_device_has_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN))
 		return TRUE;
 
 	if (self->in_bootloader) {
@@ -959,7 +974,7 @@ fu_cros_ec_usb_device_detach (FuDevice *device, GError **error)
 		return TRUE;
 	} else if (self->targ.common.flash_protection != 0x0) {
 		/* in RW, and RO region is write protected, so jump to RO */
-		fu_device_set_custom_flags (device, "ro-written");
+		fu_device_add_private_flag (device, FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN);
 		fu_device_set_remove_delay (device, CROS_EC_REMOVE_DELAY_RE_ENUMERATE);
 		if (!fu_cros_ec_usb_device_reset_to_ro (device, error))
 			return FALSE;
@@ -973,13 +988,25 @@ fu_cros_ec_usb_device_detach (FuDevice *device, GError **error)
 }
 
 static void
-fu_cros_ec_usb_device_init (FuCrosEcUsbDevice *device)
+fu_cros_ec_usb_device_init (FuCrosEcUsbDevice *self)
 {
-	fu_device_add_protocol (FU_DEVICE (device), "com.google.usb.crosec");
-	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_internal_flag (FU_DEVICE (device), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
-	fu_device_set_version_format (FU_DEVICE (device), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_protocol (FU_DEVICE (self), "com.google.usb.crosec");
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_CROS_EC_USB_DEVICE_FLAG_RO_WRITTEN,
+					 "ro-written");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_CROS_EC_USB_DEVICE_FLAG_RW_WRITTEN,
+					 "rw-written");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_CROS_EC_USB_DEVICE_FLAG_REBOOTING_TO_RO,
+					 "rebooting-to-ro");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_CROS_EC_USB_DEVICE_FLAG_SPECIAL,
+					 "special");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -173,6 +173,9 @@ static void
 fu_dell_dock_hub_init (FuDellDockHub *self)
 {
 	fu_device_retry_set_delay (FU_DEVICE (self), 1000);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE,
+					 "has-bridge");
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-hub.h
+++ b/plugins/dell-dock/fu-dell-dock-hub.h
@@ -22,4 +22,11 @@
 #define FU_TYPE_DELL_DOCK_HUB (fu_dell_dock_hub_get_type ())
 G_DECLARE_FINAL_TYPE (FuDellDockHub, fu_dell_dock_hub, FU, DELL_DOCK_HUB, FuHidDevice)
 
+/**
+ * FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE:
+ *
+ * A bridge is present, possibly with extended devices.
+ */
+#define FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE	(1 << 0)
+
 FuDellDockHub 	*fu_dell_dock_hub_new		(FuUsbDevice *device);

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -144,7 +144,7 @@ fu_plugin_backend_device_added (FuPlugin *plugin,
 		return FALSE;
 	fu_plugin_device_add (plugin, FU_DEVICE (hub));
 
-	if (fu_device_has_custom_flag (FU_DEVICE (hub), "has-bridge")) {
+	if (fu_device_has_private_flag (FU_DEVICE (hub), FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE)) {
 		g_autoptr(GError) error_local = NULL;
 
 		/* only add the device with parent to cache */

--- a/plugins/dfu/fu-dfu-common.h
+++ b/plugins/dfu/fu-dfu-common.h
@@ -106,6 +106,115 @@ typedef enum {
 	FU_DFU_STATE_LAST
 } FuDfuState;
 
+/**
+ * FU_DFU_DEVICE_FLAG_ATTACH_EXTRA_RESET:
+ *
+ * Device needs resetting twice for attach.
+ */
+#define FU_DFU_DEVICE_FLAG_ATTACH_EXTRA_RESET			(1 << 0)
+/**
+ * FU_DFU_DEVICE_FLAG_ATTACH_UPLOAD_DOWNLOAD:
+ *
+ * An upload or download is required for attach.
+ */
+#define FU_DFU_DEVICE_FLAG_ATTACH_UPLOAD_DOWNLOAD		(1 << 1)
+/**
+ * FU_DFU_DEVICE_FLAG_FORCE_DFU_MODE:
+ *
+ * Force DFU mode.
+ */
+#define FU_DFU_DEVICE_FLAG_FORCE_DFU_MODE			(1 << 2)
+/**
+ * FU_DFU_DEVICE_FLAG_IGNORE_POLLTIMEOUT:
+ *
+ * Ignore the device download timeout.
+ */
+#define FU_DFU_DEVICE_FLAG_IGNORE_POLLTIMEOUT			(1 << 3)
+/**
+ * FU_DFU_DEVICE_FLAG_IGNORE_RUNTIME:
+ *
+ * Device has broken DFU runtime support.
+ */
+#define FU_DFU_DEVICE_FLAG_IGNORE_RUNTIME			(1 << 4)
+/**
+ * FU_DFU_DEVICE_FLAG_IGNORE_UPLOAD:
+ *
+ * Uploading from the device is broken.
+ */
+#define FU_DFU_DEVICE_FLAG_IGNORE_UPLOAD			(1 << 5)
+/**
+ * FU_DFU_DEVICE_FLAG_NO_DFU_RUNTIME:
+ *
+ * No DFU runtime interface is provided.
+ */
+#define FU_DFU_DEVICE_FLAG_NO_DFU_RUNTIME			(1 << 6)
+/**
+ * FU_DFU_DEVICE_FLAG_NO_GET_STATUS_UPLOAD:
+ *
+ * Do not do GetStatus when uploading.
+ */
+#define FU_DFU_DEVICE_FLAG_NO_GET_STATUS_UPLOAD			(1 << 7)
+/**
+ * FU_DFU_DEVICE_FLAG_NO_PID_CHANGE:
+ *
+ * Accept the same VID:PID when changing modes.
+ */
+#define FU_DFU_DEVICE_FLAG_NO_PID_CHANGE			(1 << 8)
+/**
+ * FU_DFU_DEVICE_FLAG_USE_ANY_INTERFACE:
+ *
+ * Use any interface for DFU.
+ */
+#define FU_DFU_DEVICE_FLAG_USE_ANY_INTERFACE			(1 << 9)
+/**
+ * FU_DFU_DEVICE_FLAG_USE_ATMEL_AVR:
+ *
+ * Device uses the ATMEL bootloader.
+ */
+#define FU_DFU_DEVICE_FLAG_USE_ATMEL_AVR			(1 << 10)
+/**
+ * FU_DFU_DEVICE_FLAG_USE_PROTOCOL_ZERO:
+ *
+ * Fix up the protocol number.
+ */
+#define FU_DFU_DEVICE_FLAG_USE_PROTOCOL_ZERO			(1 << 11)
+/**
+ * FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL:
+ *
+ * Use a legacy protocol version.
+ */
+#define FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL			(1 << 12)
+/**
+ * FU_DFU_DEVICE_FLAG_DETACH_FOR_ATTACH:
+ *
+ * Requires a FU_DFU_REQUEST_DETACH to attach.
+ */
+#define FU_DFU_DEVICE_FLAG_DETACH_FOR_ATTACH			(1 << 13)
+/**
+ * FU_DFU_DEVICE_FLAG_ABSENT_SECTOR_SIZE:
+ *
+ * In absence of sector size, assume byte.
+ */
+#define FU_DFU_DEVICE_FLAG_ABSENT_SECTOR_SIZE			(1 << 14)
+/**
+ * FU_DFU_DEVICE_FLAG_MANIFEST_POLL:
+ *
+ * Requires polling via GetStatus in dfuManifest state.
+ */
+#define FU_DFU_DEVICE_FLAG_MANIFEST_POLL			(1 << 15)
+/**
+ * FU_DFU_DEVICE_FLAG_NO_BUS_RESET_ATTACH:
+ *
+ * Do not require a bus reset to attach to normal.
+ */
+#define FU_DFU_DEVICE_FLAG_NO_BUS_RESET_ATTACH			(1 << 16)
+/**
+ * FU_DFU_DEVICE_FLAG_GD32:
+ *
+ * Uses the slightly weird GD32 variant of DFU.
+ */
+#define FU_DFU_DEVICE_FLAG_GD32					(1 << 17)
+
 const gchar	*fu_dfu_state_to_string			(FuDfuState	 state);
 const gchar	*fu_dfu_status_to_string		(FuDfuStatus	 status);
 

--- a/plugins/dfu/fu-dfu-target-avr.c
+++ b/plugins/dfu/fu-dfu-target-avr.c
@@ -160,8 +160,8 @@ fu_dfu_target_avr_select_memory_unit (FuDfuTarget *target,
 	guint8 buf[4];
 
 	/* check legacy protocol quirk */
-	if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
-				       "legacy-protocol")) {
+	if (fu_device_has_private_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
+					FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL)) {
 		g_debug ("ignoring select memory unit as legacy protocol");
 		return TRUE;
 	}
@@ -420,8 +420,8 @@ fu_dfu_target_avr_setup (FuDfuTarget *target, GError **error)
 		return TRUE;
 
 	/* different methods for AVR vs. AVR32 */
-	if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
-				       "legacy-protocol")) {
+	if (fu_device_has_private_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
+					FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL)) {
 		chunk_sig = fu_dfu_target_avr_get_chip_signature (target, error);
 		if (chunk_sig == NULL)
 			return FALSE;
@@ -541,8 +541,8 @@ fu_dfu_target_avr_download_element (FuDfuTarget *target,
 	}
 
 	/* the original AVR protocol uses a half-size control block */
-	if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
-				       "legacy-protocol")) {
+	if (fu_device_has_private_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
+					FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL)) {
 		header_sz = ATMEL_AVR_CONTROL_BLOCK_SIZE;
 	}
 
@@ -565,8 +565,8 @@ fu_dfu_target_avr_download_element (FuDfuTarget *target,
 
 		/* select page if required */
 		if (fu_chunk_get_page (chk2) != page_last) {
-			if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
-						       "legacy-protocol")) {
+			if (fu_device_has_private_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
+							FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL)) {
 				if (!fu_dfu_target_avr_select_memory_page (target,
 									fu_chunk_get_page (chk2),
 									error))
@@ -663,8 +663,8 @@ fu_dfu_target_avr_upload_element (FuDfuTarget *target,
 
 		/* select page if required */
 		if (fu_chunk_get_page (chk) != page_last) {
-			if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
-						       "legacy-protocol")) {
+			if (fu_device_has_private_flag (FU_DEVICE (fu_dfu_target_get_device (target)),
+							FU_DFU_DEVICE_FLAG_LEGACY_PROTOCOL)) {
 				if (!fu_dfu_target_avr_select_memory_page (target,
 									   fu_chunk_get_page (chk),
 									   error))

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -203,8 +203,8 @@ fu_dfu_target_parse_sector (FuDfuTarget *self,
 	}
 
 	/* handle weirdness */
-	if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (self)),
-				       "absent-sector-size")) {
+	if (fu_device_has_private_flag (FU_DEVICE (priv->device),
+					FU_DFU_DEVICE_FLAG_ABSENT_SECTOR_SIZE)) {
 		if (tmp[1] == '\0') {
 			tmp[1] = tmp[0];
 			tmp[0] = 'B';
@@ -654,7 +654,7 @@ fu_dfu_target_setup (FuDfuTarget *self, GError **error)
 {
 	FuDfuTargetClass *klass = FU_DFU_TARGET_GET_CLASS (self);
 	FuDfuTargetPrivate *priv = GET_PRIVATE (self);
-	FuDevice *device = FU_DEVICE (fu_dfu_target_get_device (self));
+	FuDevice *device = FU_DEVICE (priv->device);
 
 	g_return_val_if_fail (FU_IS_DFU_TARGET (self), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -671,7 +671,8 @@ fu_dfu_target_setup (FuDfuTarget *self, GError **error)
 
 	/* GD32VF103 devices features and peripheral list */
 	if (priv->alt_setting == 0x0 &&
-	    fu_device_has_custom_flag (device, "gd32")) {
+	    fu_device_has_private_flag (FU_DEVICE (priv->device),
+					FU_DFU_DEVICE_FLAG_GD32)) {
 		/*             RB R8 R6 R4  VB V8
 		 * Flash (KB) 128 64 32 16 128 64
 		 *             TB T8 T6 T4  CB C8 C6 C4
@@ -1368,7 +1369,8 @@ fu_dfu_target_download (FuDfuTarget *self,
 			return FALSE;
 	}
 
-	if (fu_device_has_custom_flag (FU_DEVICE (fu_dfu_target_get_device (self)), "manifest-poll") &&
+	if (fu_device_has_private_flag (FU_DEVICE (priv->device),
+					FU_DFU_DEVICE_FLAG_MANIFEST_POLL) &&
 	    fu_dfu_device_has_attribute (priv->device, FU_DFU_DEVICE_ATTR_MANIFEST_TOL))
 		if (!fu_dfu_target_manifest_wait (self, error))
 			return FALSE;

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -51,6 +51,19 @@ struct _FuIntelSpiDevice {
 
 #define PCI_BASE_ADDRESS_0			0x0010
 
+/**
+ * FU_INTEL_SPI_DEVICE_FLAG_ICH:
+ *
+ * Device is an I/O Controller Hub.
+ */
+#define FU_INTEL_SPI_DEVICE_FLAG_ICH			(1 << 0)
+/**
+ * FU_INTEL_SPI_DEVICE_FLAG_PCH:
+ *
+ * Device is a Platform Controller Hub.
+ */
+#define FU_INTEL_SPI_DEVICE_FLAG_PCH			(1 << 1)
+
 G_DEFINE_TYPE (FuIntelSpiDevice, fu_intel_spi_device, FU_TYPE_DEVICE)
 
 static void
@@ -291,7 +304,7 @@ fu_intel_spi_device_setup (FuDevice *device, GError **error)
 	guint64 total_size = 0;
 	guint8 comp1_density;
 	guint8 comp2_density;
-	guint16 reg_pr0 = fu_device_has_custom_flag (device, "ICH") ? ICH9_REG_PR0 : PCH100_REG_FPR0;
+	guint16 reg_pr0 = fu_device_has_private_flag (device, FU_INTEL_SPI_DEVICE_FLAG_ICH) ? ICH9_REG_PR0 : PCH100_REG_FPR0;
 
 	/* dump everything */
 	if (g_getenv ("FWUPD_INTEL_SPI_VERBOSE") != NULL) {
@@ -501,6 +514,12 @@ fu_intel_spi_device_init (FuIntelSpiDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 	fu_device_set_physical_id (FU_DEVICE (self), "intel_spi");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_INTEL_SPI_DEVICE_FLAG_ICH,
+					 "ICH");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_INTEL_SPI_DEVICE_FLAG_PCH,
+					 "PCH");
 }
 
 static void

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -21,6 +21,13 @@ struct _FuNvmeDevice {
 	guint64			 write_block_size;
 };
 
+/**
+ * FU_NVME_DEVICE_FLAG_FORCE_ALIGN:
+ *
+ * Force alignment of the firmware file.
+ */
+#define FU_NVME_DEVICE_FLAG_FORCE_ALIGN		(1 << 0)
+
 G_DEFINE_TYPE (FuNvmeDevice, fu_nvme_device, FU_TYPE_UDEV_DEVICE)
 
 static void
@@ -330,7 +337,7 @@ fu_nvme_device_write_firmware (FuDevice *device,
 
 	/* some vendors provide firmware files whose sizes are not multiples
 	 * of blksz *and* the device won't accept blocks of different sizes */
-	if (fu_device_has_custom_flag (device, "force-align")) {
+	if (fu_device_has_private_flag (device, FU_NVME_DEVICE_FLAG_FORCE_ALIGN)) {
 		fw2 = fu_common_bytes_align (fw, block_size, 0xff);
 	} else {
 		fw2 = g_bytes_ref (fw);
@@ -403,6 +410,9 @@ fu_nvme_device_init (FuNvmeDevice *self)
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
 				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_NVME_DEVICE_FLAG_FORCE_ALIGN,
+					 "force-align");
 }
 
 static void

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -41,6 +41,13 @@
 
 #define FLASH_SETTLE_TIME		5000000	/* us */
 
+/**
+ * FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID:
+ *
+ * Ignore board ID firmware mismatch.
+ */
+#define FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID		(1 << 0)
+
 struct _FuSynapticsMstDevice {
 	FuUdevDevice		 parent_instance;
 	gchar			*device_kind;
@@ -81,6 +88,9 @@ fu_synaptics_mst_device_init (FuSynapticsMstDevice *self)
 				  FU_UDEV_DEVICE_FLAG_OPEN_READ |
 				  FU_UDEV_DEVICE_FLAG_OPEN_WRITE |
 				  FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
+					 "ignore-board-id");
 }
 
 static void
@@ -793,7 +803,7 @@ fu_synaptics_mst_device_prepare_firmware (FuDevice *device,
 	if (!fu_firmware_parse (firmware, fw, flags, error))
 		return NULL;
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0 &&
-	    !fu_device_has_custom_flag (device, "ignore-board-id")) {
+	    !fu_device_has_private_flag (device, FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID)) {
 		guint16 board_id = fu_synaptics_mst_firmware_get_board_id (FU_SYNAPTICS_MST_FIRMWARE (firmware));
 		if (board_id != self->board_id) {
 			g_set_error (error,

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -310,7 +310,7 @@ fu_plugin_uefi_capsule_update_splash (FuPlugin *plugin, FuDevice *device, GError
 	};
 
 	/* no UX capsule support, so deleting var if it exists */
-	if (fu_device_has_custom_flag (device, "no-ux-capsule")) {
+	if (fu_device_has_private_flag (device, FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE)) {
 		g_debug ("not providing UX capsule");
 		return fu_efivar_delete (FU_EFIVAR_GUID_FWUPDATE,
 					    "fwupd-ux-capsule", error);
@@ -509,9 +509,9 @@ fu_plugin_uefi_capsule_coldplug_device (FuPlugin *plugin, FuUefiDevice *dev, GEr
 		return FALSE;
 
 	/* if not already set by quirks */
-	if (fu_device_get_custom_flags (FU_DEVICE (dev)) == NULL &&
-	    fu_plugin_has_custom_flag (plugin, "use-legacy-bootmgr-desc")) {
-		fu_device_set_custom_flags (FU_DEVICE (dev), "use-legacy-bootmgr-desc");
+	if (fu_plugin_has_custom_flag (plugin, "use-legacy-bootmgr-desc")) {
+		fu_device_add_private_flag (FU_DEVICE (dev),
+					    FU_UEFI_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC);
 	}
 
 	/* set fallback name if nothing else is set */

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -599,11 +599,11 @@ fu_uefi_device_write_firmware (FuDevice *device,
 	/* update the firmware before the bootloader runs */
 	if (fu_device_get_metadata_boolean (device, "RequireShimForSecureBoot"))
 		flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB;
-	if (fu_device_has_custom_flag (device, "use-shim-unique"))
+	if (fu_device_has_private_flag (device, FU_UEFI_DEVICE_FLAG_USE_SHIM_UNIQUE))
 		flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_UNIQUE;
 
 	/* some legacy devices use the old name to deduplicate boot entries */
-	if (fu_device_has_custom_flag (device, "use-legacy-bootmgr-desc"))
+	if (fu_device_has_private_flag (device, FU_UEFI_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC))
 		bootmgr_desc = "Linux-Firmware-Updater";
 	if (!fu_uefi_bootmgr_bootnext (device, esp_path, bootmgr_desc, flags, error))
 		return FALSE;
@@ -776,6 +776,15 @@ static void
 fu_uefi_device_init (FuUefiDevice *self)
 {
 	fu_device_add_protocol (FU_DEVICE (self), "org.uefi.capsule");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE,
+					 "no-ux-capsule");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_UEFI_DEVICE_FLAG_USE_SHIM_UNIQUE,
+					 "use-shim-unique");
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_UEFI_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC,
+					 "use-legacy-bootmgr-desc");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -37,6 +37,25 @@ typedef enum {
 	FU_UEFI_DEVICE_STATUS_LAST
 } FuUefiDeviceStatus;
 
+/**
+ * FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE:
+ *
+ * No not use the additional UX capsule.
+ */
+#define FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE		(1 << 0)
+/**
+ * FU_UEFI_DEVICE_FLAG_USE_SHIM_UNIQUE:
+ *
+ * Use a unique shim filename to work around a common BIOS bug.
+ */
+#define FU_UEFI_DEVICE_FLAG_USE_SHIM_UNIQUE		(1 << 1)
+/**
+ * FU_UEFI_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC:
+ *
+ * Use the legacy boot manager description to work around a Lenovo BIOS bug.
+ */
+#define FU_UEFI_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC	(1 << 2)
+
 FuUefiDevice	*fu_uefi_device_new_from_guid		(const gchar	*guid);
 FuUefiDevice	*fu_uefi_device_new_from_dev		(FuDevice	*dev);
 void		 fu_uefi_device_set_esp			(FuUefiDevice	*self,

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -18,6 +18,13 @@ struct _FuVliPdDevice
 	FuVliDevice		 parent_instance;
 };
 
+/**
+ * FU_VLI_PD_DEVICE_FLAG_HAS_I2C_PS186:
+ *
+ * Device has a PS186 attached via I²C.
+ */
+#define FU_VLI_PD_DEVICE_FLAG_HAS_I2C_PS186		(1 << 0)
+
 G_DEFINE_TYPE (FuVliPdDevice, fu_vli_pd_device, FU_TYPE_VLI_DEVICE)
 
 static gboolean
@@ -319,7 +326,7 @@ fu_vli_pd_device_setup (FuDevice *device, GError **error)
 		fu_device_remove_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 
 	/* detect any I²C child, e.g. parade device */
-	if (fu_device_has_custom_flag (FU_DEVICE (self), "has-i2c-ps186")) {
+	if (fu_device_has_private_flag (device, FU_VLI_PD_DEVICE_FLAG_HAS_I2C_PS186)) {
 		if (!fu_vli_pd_device_parade_setup (self, error))
 			return FALSE;
 	}
@@ -688,6 +695,9 @@ fu_vli_pd_device_init (FuVliPdDevice *self)
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_vli_device_set_spi_auto_detect (FU_VLI_DEVICE (self), FALSE);
+	fu_device_register_private_flag (FU_DEVICE (self),
+					 FU_VLI_PD_DEVICE_FLAG_HAS_I2C_PS186,
+					 "has-i2c-ps186");
 
 	/* connect up attach or detach vfuncs when kind is known */
 	g_signal_connect (self, "notify::kind",

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -541,7 +541,7 @@ fu_device_list_item_set_device (FuDeviceItem *item, FuDevice *device)
 static void
 fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device)
 {
-	const gchar *custom_flags;
+	guint64 private_flags;
 	GPtrArray *vendor_ids;
 
 	/* clear timeout if scheduled */
@@ -562,10 +562,10 @@ fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device
 	}
 
 	/* copy over custom flags */
-	custom_flags = fu_device_get_custom_flags (item->device);
-	if (custom_flags != NULL) {
-		g_debug ("copying old custom flags %s to new device", custom_flags);
-		fu_device_set_custom_flags (device, custom_flags);
+	private_flags = fu_device_get_private_flags (item->device);
+	if (private_flags != 0) {
+		g_debug ("copying old custom flags 0x%x to new device", (guint) private_flags);
+		fu_device_set_private_flags (device, private_flags);
 	}
 
 	/* copy over the version strings if not set */


### PR DESCRIPTION
The CustomFlags feature is a bit of a hack where we just join the flags
and store in the device metadata section as a string. This makes it
inefficient to check if just one flag exists as we have to split the
string to a temporary array each time.

Rather than adding to the hack by splitting, appending (if not exists)
then joining again, store the flags in the plugin privdata directly.

This allows us to support negating custom properties (e.g. ~hint) and
also allows quirks to append custom values without duplicating them on
each GUID match, e.g.

[USB\VID_17EF&PID_307F]
Plugin = customflag1
[USB\VID_17EF&PID_307F&HUB_0002]
Flags = customflag2

...would result in customflag1,customflag2 which is the same as you'd
get from an enumerated device flag doing the same thing.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
