### PR TITLE
wacom-usb: Add "no serial" flag to other CTL-X100 products

### DIFF
--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -15,7 +15,7 @@ Flags = use-runtime-version
 [USB\VID_056A&PID_0374]
 Plugin = wacom_usb
 GType = FuWacDevice
-Flags = use-runtime-version
+Flags = use-runtime-version,no-serial-number
 
 # Intuos S 3rd-gen (USB) [CTL-4100 - Android Mode]
 [USB\VID_2D1F&PID_0374]
@@ -26,7 +26,7 @@ GType = FuWacAndroidDevice
 [USB\VID_056A&PID_0375]
 Plugin = wacom_usb
 GType = FuWacDevice
-Flags = use-runtime-version
+Flags = use-runtime-version,no-serial-number
 
 # Intuos M 3rd-gen (USB) [CTL-6100 - Android Mode]
 [USB\VID_2D1F&PID_0375]


### PR DESCRIPTION
Both the wired-only and wireless-capable versions of the CTL-4100 /
CTL-6100 will switch into "Android mode" if their string descriptors are
read too many times. A previous commit added the "no-serial-number"
flag to the wireless variants to work around this problem; this commit
adds the flag to the wired-only variants.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
