### PR TITLE
Bump minimum required meson version to correct build warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version : '1.6.2',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.47.0',
+  meson_version : '>=0.50.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
Sets the minimum required version to 0.50.0 since we are using features
which are not available prior to that release:

    WARNING: Project specifies a minimum meson_version '>=0.47.0' but uses
    features which were added in newer versions:
     * 0.49.0: {'/ with string arguments'}
     * 0.50.0: {'install arg in configure_file'}

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
