### PR TITLE
Add a new path for configuring runtime firmware load path

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -1175,6 +1175,12 @@ fu_common_get_path (FuPathKind path_kind)
 		if (tmp != NULL)
 			return g_strdup (tmp);
 		return g_strdup ("/sys/firmware/acpi/tables");
+	/* /sys/module/firmware_class/parameters/path */
+	case FU_PATH_KIND_FIRMWARE_SEARCH:
+		tmp = g_getenv ("FWUPD_FIRMWARESEARCH");
+		if (tmp != NULL)
+			return g_strdup (tmp);
+		return g_strdup ("/sys/module/firmware_class/parameters/path");
 	/* /etc */
 	case FU_PATH_KIND_SYSCONFDIR:
 		tmp = g_getenv ("FWUPD_SYSCONFDIR");

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -67,6 +67,7 @@ typedef guint FuEndianType;
  * @FU_PATH_KIND_SYSFSDIR_SECURITY:	The sysfs security location (IE /sys/kernel/security)
  * @FU_PATH_KIND_ACPI_TABLES:		The location of the ACPI tables
  * @FU_PATH_KIND_LOCKDIR:		The lock directory (IE /run/lock)
+ * @FU_PATH_KIND_FIRMWARE_SEARCH:	The path to configure the kernel policy for runtime loading other than /lib/firmware (IE /sys/module/firmware_class/parameters/path)
  *
  * Path types to use when dynamically determining a path at runtime
  **/
@@ -88,6 +89,7 @@ typedef enum {
 	FU_PATH_KIND_SYSFSDIR_SECURITY,
 	FU_PATH_KIND_ACPI_TABLES,
 	FU_PATH_KIND_LOCKDIR,
+	FU_PATH_KIND_FIRMWARE_SEARCH,
 	/*< private >*/
 	FU_PATH_KIND_LAST
 } FuPathKind;


### PR DESCRIPTION
The kernel allows configuring this, and certain plugins will use this
path to be able to load firmware in the kernel driver through runtime,
but to flash to the device.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
