### PR TITLE
Use an internal device flag rather that using a custom flag

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -213,6 +213,8 @@ fu_device_internal_flag_to_string (FuDeviceInternalFlags flag)
 		return "no-serial-number";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN)
 		return "auto-parent-children";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET)
+		return "attach-extra-reset";
 	return NULL;
 }
 
@@ -255,6 +257,8 @@ fu_device_internal_flag_from_string (const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER;
 	if (g_strcmp0 (flag, "auto-parent-children") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN;
+	if (g_strcmp0 (flag, "attach-extra-reset") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -230,6 +230,7 @@ FuDevice	*fu_device_new				(void);
  * @FU_DEVICE_INTERNAL_FLAG_IS_OPEN:			The device opened successfully and ready to use
  * @FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER:		Do not attempt to read the device serial number
  * @FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN:	Automatically assign the parent for children of this device
+ * @FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET:		Device needs resetting twice for attach after the firmware update
  *
  * The device internal flags.
  **/
@@ -248,6 +249,7 @@ typedef enum {
 	FU_DEVICE_INTERNAL_FLAG_IS_OPEN			= (1llu << 10),	/* Since: 1.6.1 */
 	FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER	= (1llu << 11),	/* Since: 1.6.2 */
 	FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN	= (1llu << 12),	/* Since: 1.6.2 */
+	FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET	= (1llu << 13),	/* Since: 1.6.2 */
 	/*< private >*/
 	FU_DEVICE_INTERNAL_FLAG_UNKNOWN			= G_MAXUINT64,
 } FuDeviceInternalFlags;

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -28,7 +28,6 @@
  * DFU 1.0 or 1.1 specification. The list of supported quirks is thus:
  *
  * * `none`:			No device quirks
- * * `attach-extra-reset`:	Device needs resetting twice for attach
  * * `attach-upload-download`:	An upload or download is required for attach
  * * `force-dfu-mode`:		Force DFU mode
  * * `ignore-polltimeout`:	Ignore the device download timeout
@@ -1336,7 +1335,7 @@ fu_dfu_device_probe (FuDevice *device, GError **error)
 
 	/* hardware from Jabra literally reboots if you try to retry a failed
 	 * write -- there's no way to avoid blocking the daemon like this... */
-	if (fu_device_has_custom_flag (device, "attach-extra-reset"))
+	if (fu_device_has_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET))
 		fu_device_sleep_with_progress (device, 10); /* seconds */
 
 	/* success */

--- a/plugins/jabra/fu-plugin-jabra.c
+++ b/plugins/jabra/fu-plugin-jabra.c
@@ -33,7 +33,7 @@ fu_plugin_update_cleanup (FuPlugin *plugin,
 
 	/* check for a property on the *dfu* FuDevice, which is also why we
 	 * can't just rely on using FuDevice->cleanup() */
-	if (!fu_device_has_custom_flag (device, "attach-extra-reset"))
+	if (!fu_device_has_internal_flag (device, FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET))
 		return TRUE;
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)


### PR DESCRIPTION
If this is shared between plugins it needs to be specified in a shared
place.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
