### PR TITLE
trivial: get the fwupd-efi 1.1 release instead

### DIFF
--- a/subprojects/fwupd-efi.wrap
+++ b/subprojects/fwupd-efi.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = fwupd-efi
 url = https://github.com/fwupd/fwupd-efi
-revision = 1.0
+revision = 1.1


### PR DESCRIPTION
It's all build system improvements.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
