### PR TITLE
Draft: flashrom: Add Tuxedo laptop support

### DIFF
--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -69,12 +69,31 @@ Quirk use
 ---------
 This plugin uses the following plugin-specific quirks:
 
-| Quirk                  | Description                                 | Minimum fwupd version |
-|------------------------|---------------------------------------------|-----------------------|
-|`FlashromProgrammer`    | Used to specify the libflashrom programmer to be used.     | 1.5.9                 |
+| Quirk                         | Description                                             | Minimum fwupd version |
+|-------------------------------|---------------------------------------------------------|-----------------------|
+|`FlashromProgrammer`           | Used to specify the libflashrom programmer to be used.  | 1.5.9                 |
+|`FlashromNeedsFdopssUnlock`    | Enables ME region flashing via FDOPSS override.         | 1.6.2                 |
 
+The flashrom plugin uses the firmware size obtained from DMI, in case that value
+is not correct, it's possible to add a `FirmwareSizeMax` quirk for your device.
 
 External interface access
 ---
 This plugin requires access to all interfaces that `libflashrom` has been compiled for.
 This typically is `/sys/bus/spi` but there may be other interfaces as well.
+
+
+Unlocking the ME region
+-----------------------
+
+Some machines support unlocking the ME region of the SPI chip for flashing via
+the use of the Intel ME Debug Mode Pin-Strap (FDOPSS). In that case, before
+installing an update, the device will need to be unlocked.
+To unlock the ME region, run:
+
+```bash
+# fwupdmgr unlock
+```
+
+You will then be prompted to shut down the machine for the unlock to take effect.
+After powering it on again, you will be able to update the device as usual.

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -43,3 +43,19 @@ Plugin=flashrom
 FlashromProgrammer=lspcon_i2c_spi
 Name=PS175
 Vendor=Parade
+
+# Tuxedo InifinityBook S14 Gen6
+[6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+Plugin=flashrom
+[3847cf02-6408-5e49-98c5-ce319258cc80]
+# DMI reports the size of the BIOS region, flashrom needs the size of the entire SPI flash
+FirmwareSizeMax=0x1000000
+FlashromNeedsFdopssUnlock=true
+
+# Tuxedo InifinityBook S15 Gen6
+[60f53465-e8fc-5122-b79b-f7b03f063037]
+Plugin=flashrom
+[dc0de287-201b-5240-b8d2-0e5cead707ea]
+# DMI reports the size of the BIOS region, flashrom needs the size of the entire SPI flash
+FirmwareSizeMax=0x1000000
+FlashromNeedsFdopssUnlock=true

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -44,6 +44,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_FLASHROM_LSPCON_I2C_SPI_DEVICE);
 	fu_context_add_udev_subsystem (ctx, "i2c");
 	fu_context_add_quirk_key (ctx, "FlashromProgrammer");
+	fu_context_add_quirk_key (ctx, "FlashromNeedsFdopssUnlock");
 }
 
 static int
@@ -119,6 +120,7 @@ fu_plugin_flashrom_device_set_bios_info (FuPlugin *plugin, FuDevice *device)
 	guint32 bios_char = 0x0;
 	guint8 bios_sz = 0x0;
 	g_autoptr(GBytes) bios_table = NULL;
+	guint64 cur_fw_size = fu_device_get_firmware_size_max (device);
 
 	/* get SMBIOS info */
 	bios_table = fu_context_get_smbios_data (ctx, FU_SMBIOS_STRUCTURE_TYPE_BIOS);
@@ -127,7 +129,7 @@ fu_plugin_flashrom_device_set_bios_info (FuPlugin *plugin, FuDevice *device)
 
 	/* ROM size */
 	buf = g_bytes_get_data (bios_table, &bufsz);
-	if (fu_common_read_uint8_safe (buf, bufsz, 0x9, &bios_sz, NULL)) {
+	if (cur_fw_size == 0 && fu_common_read_uint8_safe (buf, bufsz, 0x9, &bios_sz, NULL)) {
 		guint64 firmware_size = (bios_sz + 1) * 64 * 1024;
 		fu_device_set_firmware_size_max (device, firmware_size);
 	}
@@ -192,6 +194,19 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	/* success */
 	fu_plugin_device_add (plugin, device);
 	return TRUE;
+}
+
+gboolean
+fu_plugin_unlock (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	if (flashrom_unlock_me ())
+		return TRUE;
+
+	g_set_error_literal (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "could not unlock ME region");
+	return FALSE;
 }
 
 gboolean


### PR DESCRIPTION
This PR adds the ability to flash the ME region of the flash in Tuxedo laptops through
the use of Flash Descriptor Override Pin Strap, aka ME debug mode.

In addition, this PR enables the `FirmwareSizeMax` quirk to work in the flashrom plugin,
as Tuxedo laptop report a different flash size in DMI than what flashrom requires.

It depends on changes to libflashrom that we are in the process of submitting to upstream.

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>
Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
