### PR TITLE
Remove the vendor string from the device name where required

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -176,7 +176,6 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_update_image(d,v)		fwupd_device_set_update_image(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_error(d,v)		fwupd_device_set_update_error(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_state(d,v)		fwupd_device_set_update_state(FWUPD_DEVICE(d),v)
-#define fu_device_set_vendor(d,v)		fwupd_device_set_vendor(FWUPD_DEVICE(d),v)
 #define fu_device_add_vendor_id(d,v)		fwupd_device_add_vendor_id(FWUPD_DEVICE(d),v)
 #define fu_device_add_protocol(d,v)		fwupd_device_add_protocol(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_raw(d,v)		fwupd_device_set_version_raw(FWUPD_DEVICE(d),v)
@@ -345,6 +344,8 @@ void		 fu_device_set_custom_flags		(FuDevice	*self,
 							 const gchar	*custom_flags);
 void		 fu_device_set_name			(FuDevice	*self,
 							 const gchar	*value);
+void		 fu_device_set_vendor			(FuDevice	*self,
+							 const gchar	*vendor);
 guint		 fu_device_get_remove_delay		(FuDevice	*self);
 void		 fu_device_set_remove_delay		(FuDevice	*self,
 							 guint		 remove_delay);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -237,6 +237,25 @@ fu_device_open_refcount_func (void)
 }
 
 static void
+fu_device_name_func (void)
+{
+	g_autoptr(FuDevice) device1 = fu_device_new ();
+	g_autoptr(FuDevice) device2 = fu_device_new ();
+
+	/* vendor then name */
+	fu_device_set_vendor (device1, "Hughski");
+	fu_device_set_name (device1, "Hughski ColorHug(TM)_Pro");
+	g_assert_cmpstr (fu_device_get_vendor (device1), ==, "Hughski");
+	g_assert_cmpstr (fu_device_get_name (device1), ==, "ColorHug™ Pro");
+
+	/* name then vendor */
+	fu_device_set_name (device2, "Hughski ColorHug(TM)_Pro");
+	fu_device_set_vendor (device2, "Hughski");
+	g_assert_cmpstr (fu_device_get_vendor (device2), ==, "Hughski");
+	g_assert_cmpstr (fu_device_get_name (device2), ==, "ColorHug™ Pro");
+}
+
+static void
 fu_device_metadata_func (void)
 {
 	g_autoptr(FuDevice) device = fu_device_new ();
@@ -2984,6 +3003,7 @@ main (int argc, char **argv)
 		g_test_add_func ("/fwupd/device{poll}", fu_device_poll_func);
 	g_test_add_func ("/fwupd/device-locker{success}", fu_device_locker_func);
 	g_test_add_func ("/fwupd/device-locker{fail}", fu_device_locker_fail_func);
+	g_test_add_func ("/fwupd/device{name}", fu_device_name_func);
 	g_test_add_func ("/fwupd/device{metadata}", fu_device_metadata_func);
 	g_test_add_func ("/fwupd/device{open-refcount}", fu_device_open_refcount_func);
 	g_test_add_func ("/fwupd/device{version-format}", fu_device_version_format_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -828,6 +828,7 @@ LIBFWUPDPLUGIN_1.6.2 {
     fu_device_register_private_flag;
     fu_device_remove_private_flag;
     fu_device_set_private_flags;
+    fu_device_set_vendor;
     fu_i2c_device_read_full;
     fu_i2c_device_set_bus_number;
     fu_i2c_device_write_full;


### PR DESCRIPTION
This means we don't display something like 'Logitech Logitech Product'
when showing the devices on one line.

This is now required in two plugins so move it to common code. Also
support setting the properties in either order to prevent regressions
when using the device name as part of the instance ID.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
