### PR TITLE
Move amdgpu safety check into the engine

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -319,7 +319,6 @@ done
 %config(noreplace)%{_sysconfdir}/fwupd/uefi_capsule.conf
 %endif
 %config(noreplace)%{_sysconfdir}/fwupd/redfish.conf
-%config(noreplace)%{_sysconfdir}/fwupd/synaptics_mst.conf
 %config(noreplace)%{_sysconfdir}/fwupd/thunderbolt.conf
 %dir %{_libexecdir}/fwupd
 %{_libexecdir}/fwupd/fwupd

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -42,3 +42,8 @@ BlockedFirmware=
 #
 # If unset or no schemes are listed, the default will be: file,https,http,ipfs
 UriSchemes=
+
+# Minimum kernel version to allow use of drm_dp_aux devices on amdgpu
+# It's important that all backports from this kernel have been
+# made if using an older kernel
+MinimumAmdGpuKernelVersion=5.2.0

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -21,37 +21,6 @@ struct FuPluginData {
 	guint			 drm_changed_id;
 };
 
-/* see https://github.com/fwupd/fwupd/issues/1121 for more details */
-static gboolean
-fu_synaptics_mst_check_amdgpu_safe (FuPlugin *plugin, GError **error)
-{
-	gsize bufsz = 0;
-	g_autofree gchar *minimum_kernel = NULL;
-	g_autofree gchar *buf = NULL;
-	g_auto(GStrv) lines = NULL;
-
-	minimum_kernel = fu_plugin_get_config_value (plugin, "MinimumAmdGpuKernelVersion");
-	if (minimum_kernel == NULL) {
-		g_debug ("Ignoring kernel safety checks");
-		return TRUE;
-	}
-
-	/* no module support in the kernel, we can't test for amdgpu module */
-	if (!g_file_test ("/proc/modules", G_FILE_TEST_EXISTS))
-		return TRUE;
-
-	if (!g_file_get_contents ("/proc/modules", &buf, &bufsz, error))
-		return FALSE;
-
-	lines = g_strsplit (buf, "\n", -1);
-	for (guint i = 0; lines[i] != NULL; i++) {
-		if (g_str_has_prefix (lines[i], "amdgpu "))
-			return fu_common_check_kernel_version (minimum_kernel, error);
-	}
-
-	return TRUE;
-}
-
 static void
 fu_plugin_synaptics_mst_device_rescan (FuPlugin *plugin, FuDevice *device)
 {
@@ -143,12 +112,6 @@ fu_plugin_backend_device_added (FuPlugin *plugin, FuDevice *device, GError **err
 	fu_plugin_synaptics_mst_device_rescan (plugin, FU_DEVICE (dev));
 	g_ptr_array_add (priv->devices, g_steal_pointer (&dev));
 	return TRUE;
-}
-
-gboolean
-fu_plugin_startup (FuPlugin *plugin, GError **error)
-{
-	return fu_synaptics_mst_check_amdgpu_safe (plugin, error);
 }
 
 gboolean

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -36,10 +36,6 @@ shared_module('fu_plugin_synaptics_mst',
   ],
 )
 
-install_data(['synaptics_mst.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
-
 if get_option('tests')
   testdatadirs = environment()
   testdatadirs.set('G_TEST_SRCDIR', meson.current_source_dir())

--- a/plugins/synaptics-mst/synaptics_mst.conf
+++ b/plugins/synaptics-mst/synaptics_mst.conf
@@ -1,5 +1,0 @@
-[synaptics_mst]
-# Minimum kernel version to allow use of this plugin on amdgpu
-# It's important that all backports from this kernel have been
-# made if using an older kernel
-MinimumAmdGpuKernelVersion=5.2.0

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -31,3 +31,4 @@ guint		 fu_config_get_uri_scheme_prio		(FuConfig	*self,
 							 const gchar	*protocol);
 gboolean	 fu_config_get_update_motd		(FuConfig	*self);
 gboolean	 fu_config_get_enumerate_all_devices	(FuConfig	*self);
+const gchar	*fu_config_get_minimum_amdgpu_dpaux	(FuConfig	*self);


### PR DESCRIPTION
There are now multiple plugins using drm_dp_aux_dev interface which
may potentially be combined with an amdgpu.  Prevent exercising this
interface with any plugin using DP aux unless a new enough kernel is
installed.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
