### PR TITLE
Watch for children added or removed after setup has been completed

### DIFF
--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -477,6 +477,36 @@ fwupd_device_add_child (FwupdDevice *self, FwupdDevice *child)
 }
 
 /**
+ * fwupd_device_remove_child:
+ * @self: a #FwupdDevice
+ * @child: Another #FwupdDevice
+ *
+ * Removes a child device.
+ *
+ * NOTE: You should never call this function from user code, it is for daemon
+ * use only.
+ *
+ * Since: 1.6.2
+ **/
+void
+fwupd_device_remove_child (FwupdDevice *self, FwupdDevice *child)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (self);
+
+	/* remove if the child exists */
+	for (guint i = 0; i < priv->children->len; i++) {
+		FwupdDevice *child_tmp = g_ptr_array_index (priv->children, i);
+		if (child_tmp == child) {
+			g_object_weak_unref (G_OBJECT (child),
+					     fwupd_device_child_finalized_cb,
+					     self);
+			g_ptr_array_remove_index (priv->children, i);
+			return;
+		}
+	}
+}
+
+/**
  * fwupd_device_get_guids:
  * @self: a #FwupdDevice
  *

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -46,6 +46,8 @@ void		 fwupd_device_set_parent		(FwupdDevice	*self,
 							 FwupdDevice	*parent);
 void		 fwupd_device_add_child			(FwupdDevice	*self,
 							 FwupdDevice	*child);
+void		 fwupd_device_remove_child		(FwupdDevice	*self,
+							 FwupdDevice	*child);
 GPtrArray	*fwupd_device_get_children		(FwupdDevice	*self);
 const gchar	*fwupd_device_get_name			(FwupdDevice	*self);
 void		 fwupd_device_set_name			(FwupdDevice	*self,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -671,3 +671,9 @@ LIBFWUPD_1.6.1 {
     fwupd_version_string;
   local: *;
 } LIBFWUPD_1.6.0;
+
+LIBFWUPD_1.6.2 {
+  global:
+    fwupd_device_remove_child;
+  local: *;
+} LIBFWUPD_1.6.1;

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -102,8 +102,12 @@ struct _FuDeviceClass
 	gboolean		 (*ready)		(FuDevice	*self,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
+	void			 (*child_added)		(FuDevice	*self,	/* signal */
+							 FuDevice	*child);
+	void			 (*child_removed)	(FuDevice	*self,	/* signal */
+							 FuDevice	*child);
 	/*< private >*/
-	gpointer	padding[9];
+	gpointer	padding[7];
 #endif
 };
 
@@ -275,6 +279,8 @@ FuDevice	*fu_device_get_root			(FuDevice	*self);
 FuDevice	*fu_device_get_parent			(FuDevice	*self);
 GPtrArray	*fu_device_get_children			(FuDevice	*self);
 void		 fu_device_add_child			(FuDevice	*self,
+							 FuDevice	*child);
+void		 fu_device_remove_child			(FuDevice	*self,
 							 FuDevice	*child);
 void		 fu_device_add_parent_guid		(FuDevice	*self,
 							 const gchar	*guid);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -490,6 +490,7 @@ static void
 fu_plugin_devices_func (void)
 {
 	g_autoptr(FuDevice) device = fu_device_new ();
+	g_autoptr(FuDevice) child = fu_device_new ();
 	g_autoptr(FuPlugin) plugin = fu_plugin_new (NULL);
 	GPtrArray *devices;
 
@@ -498,9 +499,20 @@ fu_plugin_devices_func (void)
 	g_assert_cmpint (devices->len, ==, 0);
 
 	fu_device_set_id (device, "testdev");
+	fu_device_set_name (device, "testdev");
 	fu_plugin_device_add (plugin, device);
 	g_assert_cmpint (devices->len, ==, 1);
 	fu_plugin_device_remove (plugin, device);
+	g_assert_cmpint (devices->len, ==, 0);
+
+	/* add a child after adding the parent to the plugin */
+	fu_device_set_id (child, "child");
+	fu_device_set_name (child, "child");
+	fu_device_add_child (device, child);
+	g_assert_cmpint (devices->len, ==, 1);
+
+	/* remove said child */
+	fu_device_remove_child (device, child);
 	g_assert_cmpint (devices->len, ==, 0);
 }
 

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -826,6 +826,7 @@ LIBFWUPDPLUGIN_1.6.2 {
     fu_device_has_parent_physical_id;
     fu_device_has_private_flag;
     fu_device_register_private_flag;
+    fu_device_remove_child;
     fu_device_remove_private_flag;
     fu_device_set_private_flags;
     fu_device_set_vendor;


### PR DESCRIPTION
Some devices may 'discover' child devices during poll, rather than the
more usual case of adding them as children during setup.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
