### PR TITLE
Add a test UEFI device that can be used to test capsules

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -526,6 +526,7 @@ done
 %{_datadir}/installed-tests/fwupd/*.test
 %{_datadir}/installed-tests/fwupd/*.cab
 %{_datadir}/installed-tests/fwupd/*.sh
+%{_datadir}/installed-tests/fwupd/efi
 %{_datadir}/fwupd/device-tests/*.json
 %{_libexecdir}/installed-tests/fwupd/*
 %dir %{_sysconfdir}/fwupd/remotes.d

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -185,4 +185,24 @@ if get_option('tests')
   )
   test('uefi-self-test', e, env: env)
 endif
+
+# to use these do `sudo systemctl edit fwupd.service` and set
+# Environment="FWUPD_SYSFSFWDIR=/usr/share/installed-tests/fwupd"
+install_data([
+    'tests/efi/esrt/entries/entry0/capsule_flags',
+    'tests/efi/esrt/entries/entry0/fw_class',
+    'tests/efi/esrt/entries/entry0/fw_type',
+    'tests/efi/esrt/entries/entry0/fw_version',
+    'tests/efi/esrt/entries/entry0/last_attempt_status',
+    'tests/efi/esrt/entries/entry0/last_attempt_version',
+    'tests/efi/esrt/entries/entry0/lowest_supported_fw_version',
+  ],
+  install_dir : join_paths(installed_test_datadir, 'efi/esrt/entries/entry0'),
+)
+install_data([
+    'tests/efi/efivars/CapsuleMax-39b68c46-f7fb-441b-b6ec-16b0f69821f3',
+  ],
+  install_dir : join_paths(installed_test_datadir, 'efi/efivars'),
+)
+
 endif

--- a/plugins/uefi-capsule/tests/example/.gitignore
+++ b/plugins/uefi-capsule/tests/example/.gitignore
@@ -1,0 +1,2 @@
+firmware.bin
+firmware.cab

--- a/plugins/uefi-capsule/tests/example/build.sh
+++ b/plugins/uefi-capsule/tests/example/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+appstream-util validate-relax firmware.metainfo.xml
+echo -n "hello world" > firmware.bin
+gcab --create --nopath firmware.cab firmware.bin firmware.metainfo.xml

--- a/plugins/uefi-capsule/tests/example/firmware.metainfo.xml
+++ b/plugins/uefi-capsule/tests/example/firmware.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2021 Richard Hughes <richard@hughsie.com> -->
+<component type="firmware">
+  <id>example.firmware</id>
+  <name>UEFI Firmware</name>
+  <summary>Example UEFI firmware for fwupd</summary>
+  <description>
+    <p>
+      The test device can be updated using the UEFI capsule plugin.
+    </p>
+  </description>
+  <provides>
+    <firmware type="flashed">ddc0ee61-e7f0-4e7d-acc5-c070a398838e</firmware>
+  </provides>
+  <url type="homepage">https://fwupd.org/</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>CC0-1.0</project_license>
+  <developer_name>Richard Hughes</developer_name>
+  <releases>
+    <release urgency="high" version="1.2.3" date="2021-07-02">
+      <checksum filename="firmware.bin" target="content"/>
+      <description>
+        <p>
+          This release updates a frobnicator to frob faster.
+        </p>
+      </description>
+    </release>
+  </releases>
+  <requires>
+    <id compare="ge" version="1.6.2">org.freedesktop.fwupd</id>
+  </requires>
+</component>


### PR DESCRIPTION
Enable the 'test' plugin in /etc/fwupd/daemon.conf and then use
something like:

    fwupdmgr install plugins/test/example/firmware.cab

Fixes https://github.com/fwupd/fwupd/issues/3441

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
