### PR TITLE
Copy the device update state when replugging

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -608,6 +608,15 @@ fu_device_list_replace (FuDeviceList *self, FuDeviceItem *item, FuDevice *device
 		fu_device_set_parent (device, parent);
 	}
 
+	/* copy the update state if known */
+	if (fu_device_get_update_state (item->device) != FWUPD_UPDATE_STATE_UNKNOWN &&
+	    fu_device_get_update_state (device) == FWUPD_UPDATE_STATE_UNKNOWN) {
+		FwupdUpdateState update_state = fu_device_get_update_state (item->device);
+		g_debug ("copying update state %s to new device",
+			 fwupd_update_state_to_string (update_state));
+		fu_device_set_update_state (device, update_state);
+	}
+
 	/* assign the new device */
 	g_set_object (&item->device_old, item->device);
 	fu_device_list_item_set_device (item, device);


### PR DESCRIPTION
At the moment we saving the new state as 'unknown' which explains why
we're getting so few LVFS reports uploaded for USB devices that perform
a replug...

Tested with a ColorHug2.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
