### PR TITLE
acpi-phat: Prevent a corrupt PHAT table from allocating ~4GB of memory

### DIFF
--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -88,6 +88,14 @@ fu_acpi_phat_health_record_parse (FuFirmware *firmware,
 		} else {
 			ubufsz = dataoff - 28;
 		}
+		if (ubufsz > bufsz) {
+			g_set_error (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_INVALID_DATA,
+				     "device path too large: 0x%x",
+				     (guint) ubufsz);
+			return FALSE;
+		}
 
 		/* check this is an even number of bytes */
 		if (ubufsz % 2 != 0) {


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35761

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
