### PR TITLE
Move amdgpu safety check into the plugin

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -319,7 +319,6 @@ done
 %config(noreplace)%{_sysconfdir}/fwupd/uefi_capsule.conf
 %endif
 %config(noreplace)%{_sysconfdir}/fwupd/redfish.conf
-%config(noreplace)%{_sysconfdir}/fwupd/synaptics_mst.conf
 %config(noreplace)%{_sysconfdir}/fwupd/thunderbolt.conf
 %dir %{_libexecdir}/fwupd
 %{_libexecdir}/fwupd/fwupd

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -337,6 +337,8 @@ fwupd_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		return "failed-open";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID)
 		return "require-hwid";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD)
+		return "kernel-too-old";
 	if (plugin_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -379,6 +381,8 @@ fwupd_plugin_flag_from_string (const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_FAILED_OPEN;
 	if (g_strcmp0 (plugin_flag, "require-hwid") == 0)
 		return FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
+	if (g_strcmp0 (plugin_flag, "kernel-too-old") == 0)
+		return FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -668,6 +668,14 @@ typedef enum {
  */
 #define FWUPD_PLUGIN_FLAG_REQUIRE_HWID		(1u << 10)
 /**
+ * FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD:
+ *
+ * The feature is not supported as the kernel is too old.
+ *
+ * Since: 1.6.2
+ */
+#define FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD	(1u << 11)
+/**
  * FWUPD_PLUGIN_FLAG_UNKNOWN:
  *
  * The plugin flag is Unknown.

--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -26,4 +26,6 @@ void		 fu_context_add_firmware_gtype		(FuContext	*self,
 GPtrArray	*fu_context_get_firmware_gtype_ids	(FuContext	*self);
 GType		 fu_context_get_firmware_gtype_by_id	(FuContext	*self,
 							 const gchar	*id);
+void		 fu_context_add_udev_subsystem		(FuContext	*self,
+							 const gchar	*subsystem);
 GPtrArray	*fu_context_get_udev_subsystems		(FuContext	*self);

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -58,8 +58,6 @@ void		 fu_context_add_runtime_version		(FuContext	*self,
 void		 fu_context_add_compile_version		(FuContext	*self,
 							 const gchar	*component_id,
 							 const gchar	*version);
-void		 fu_context_add_udev_subsystem		(FuContext	*self,
-							 const gchar	*subsystem);
 const gchar	*fu_context_lookup_quirk_by_id		(FuContext	*self,
 							 const gchar	*guid,
 							 const gchar	*key);

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -116,6 +116,8 @@ void		 fu_plugin_add_device_gtype		(FuPlugin	*self,
 void		 fu_plugin_add_firmware_gtype		(FuPlugin	*self,
 							 const gchar	*id,
 							 GType		 gtype);
+void		 fu_plugin_add_udev_subsystem		(FuPlugin	*self,
+							 const gchar	*subsystem);
 gpointer	 fu_plugin_cache_lookup			(FuPlugin	*self,
 							 const gchar	*id);
 void		 fu_plugin_cache_remove			(FuPlugin	*self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -834,6 +834,7 @@ LIBFWUPDPLUGIN_1.6.2 {
     fu_i2c_device_read_full;
     fu_i2c_device_set_bus_number;
     fu_i2c_device_write_full;
+    fu_plugin_add_udev_subsystem;
     fu_udev_device_get_children_with_subsystem;
     fu_udev_device_set_dev;
   local: *;

--- a/plugins/ata/fu-plugin-ata.c
+++ b/plugins/ata/fu-plugin-ata.c
@@ -13,8 +13,7 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "block");
+	fu_plugin_add_udev_subsystem (plugin, "block");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_ATA_DEVICE);
 }

--- a/plugins/bcm57xx/fu-plugin-bcm57xx.c
+++ b/plugins/bcm57xx/fu-plugin-bcm57xx.c
@@ -17,9 +17,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_plugin_add_udev_subsystem (plugin, "pci");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_BCM57XX_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_BCM57XX_DICT_IMAGE);

--- a/plugins/elantp/fu-plugin-elantp.c
+++ b/plugins/elantp/fu-plugin-elantp.c
@@ -31,8 +31,8 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "i2c-dev");
-	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_plugin_add_udev_subsystem (plugin, "i2c-dev");
+	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
 	fu_context_add_quirk_key (ctx, "ElantpI2cTargetAddress");
 	fu_context_add_quirk_key (ctx, "ElantpIapPassword");

--- a/plugins/emmc/fu-plugin-emmc.c
+++ b/plugins/emmc/fu-plugin-emmc.c
@@ -13,8 +13,7 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "block");
+	fu_plugin_add_udev_subsystem (plugin, "block");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_EMMC_DEVICE);
 }

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -42,7 +42,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "coreboot"); /* obsoleted */
 	fu_plugin_add_flag (plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_FLASHROM_LSPCON_I2C_SPI_DEVICE);
-	fu_context_add_udev_subsystem (ctx, "i2c");
+	fu_plugin_add_udev_subsystem (plugin, "i2c");
 	fu_context_add_quirk_key (ctx, "FlashromProgrammer");
 }
 

--- a/plugins/intel-spi/fu-plugin-intel-spi.c
+++ b/plugins/intel-spi/fu-plugin-intel-spi.c
@@ -29,7 +29,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_EFI_FIRMWARE_VOLUME);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_IFD_BIOS);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_IFD_FIRMWARE);
-	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_plugin_add_udev_subsystem (plugin, "pci");
 	fu_context_add_quirk_key (ctx, "IntelSpiKind");
 	fu_context_add_quirk_key (ctx, "IntelSpiBar");
 	fu_context_add_quirk_key (ctx, "IntelSpiBarProxy");

--- a/plugins/iommu/fu-plugin-iommu.c
+++ b/plugins/iommu/fu-plugin-iommu.c
@@ -15,10 +15,9 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "iommu");
+	fu_plugin_add_udev_subsystem (plugin, "iommu");
 }
 
 gboolean

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -31,9 +31,8 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "unifying");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_UNIFYING_BOOTLOADER_NORDIC);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_UNIFYING_BOOTLOADER_TEXAS);

--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -42,10 +42,9 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "msr");
+	fu_plugin_add_udev_subsystem (plugin, "msr");
 }
 
 gboolean

--- a/plugins/nvme/fu-plugin-nvme.c
+++ b/plugins/nvme/fu-plugin-nvme.c
@@ -13,8 +13,7 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "nvme");
+	fu_plugin_add_udev_subsystem (plugin, "nvme");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_NVME_DEVICE);
 }

--- a/plugins/optionrom/fu-plugin-optionrom.c
+++ b/plugins/optionrom/fu-plugin-optionrom.c
@@ -13,9 +13,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_plugin_add_udev_subsystem (plugin, "pci");
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_CONFLICTS, "udev");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_OPTIONROM_DEVICE);
 }

--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -24,7 +24,7 @@ fu_plugin_init (FuPlugin *plugin)
 	FuContext *ctx = fu_plugin_get_context (plugin);
 	FuPluginData *priv = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_plugin_add_udev_subsystem (plugin, "pci");
 	fu_context_add_quirk_key (ctx, "PciBcrAddr");
 
 	/* this is true except for some Atoms */

--- a/plugins/pci-mei/fu-plugin-pci-mei.c
+++ b/plugins/pci-mei/fu-plugin-pci-mei.c
@@ -51,10 +51,9 @@ fu_mei_hfsts_to_string (FuPlugin *plugin, guint idt, GString *str)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "pci");
+	fu_plugin_add_udev_subsystem (plugin, "pci");
 }
 
 static FuMeiFamily

--- a/plugins/pixart-rf/fu-plugin-pixart-rf.c
+++ b/plugins/pixart-rf/fu-plugin-pixart-rf.c
@@ -15,9 +15,8 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_PXI_BLE_DEVICE);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_PXI_RECEIVER_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, "pixart", FU_TYPE_PXI_FIRMWARE);

--- a/plugins/platform-integrity/fu-plugin-platform-integrity.c
+++ b/plugins/platform-integrity/fu-plugin-platform-integrity.c
@@ -18,7 +18,7 @@ fu_plugin_init (FuPlugin *plugin)
 	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "platform-integrity");
+	fu_plugin_add_udev_subsystem (plugin, "platform-integrity");
 }
 
 void

--- a/plugins/realtek-mst/fu-plugin-realtek-mst.c
+++ b/plugins/realtek-mst/fu-plugin-realtek-mst.c
@@ -16,6 +16,6 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_context_add_quirk_key (ctx, "RealtekMstDpAuxName");
 
-	fu_context_add_udev_subsystem (ctx, "i2c");
+	fu_plugin_add_udev_subsystem (plugin, "i2c");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_REALTEK_MST_DEVICE);
 }

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -36,10 +36,6 @@ shared_module('fu_plugin_synaptics_mst',
   ],
 )
 
-install_data(['synaptics_mst.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
-
 if get_option('tests')
   testdatadirs = environment()
   testdatadirs.set('G_TEST_SRCDIR', meson.current_source_dir())

--- a/plugins/synaptics-mst/synaptics_mst.conf
+++ b/plugins/synaptics-mst/synaptics_mst.conf
@@ -1,5 +1,0 @@
-[synaptics_mst]
-# Minimum kernel version to allow use of this plugin on amdgpu
-# It's important that all backports from this kernel have been
-# made if using an older kernel
-MinimumAmdGpuKernelVersion=5.2.0

--- a/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
+++ b/plugins/synaptics-rmi/fu-plugin-synaptics-rmi.c
@@ -15,10 +15,9 @@
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "hidraw");
-	fu_context_add_udev_subsystem (ctx, "serio");
+	fu_plugin_add_udev_subsystem (plugin, "hidraw");
+	fu_plugin_add_udev_subsystem (plugin, "serio");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_SYNAPTICS_RMI_HID_DEVICE);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_SYNAPTICS_RMI_PS2_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -55,9 +55,8 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "thunderbolt");
+	fu_plugin_add_udev_subsystem (plugin, "thunderbolt");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_THUNDERBOLT_DEVICE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE);
 	fu_plugin_add_firmware_gtype (plugin, NULL, FU_TYPE_THUNDERBOLT_FIRMWARE_UPDATE);

--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -18,10 +18,9 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_context_add_udev_subsystem (ctx, "tpm");
+	fu_plugin_add_udev_subsystem (plugin, "tpm");
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_TPM_DEVICE);
 }
 

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -19,7 +19,7 @@ fu_plugin_init (FuPlugin *plugin)
 	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_WACOM_AES_DEVICE);
 	fu_plugin_add_device_gtype (plugin, FU_TYPE_WACOM_EMR_DEVICE);
-	fu_context_add_udev_subsystem (ctx, "hidraw");
+	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 	fu_context_add_quirk_key (ctx, "WacomI2cFlashBlockSize");
 	fu_context_add_quirk_key (ctx, "WacomI2cFlashBaseAddr");
 	fu_context_add_quirk_key (ctx, "WacomI2cFlashSize");

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1457,6 +1457,10 @@ fu_util_plugin_flag_to_string (FwupdPluginFlags plugin_flag)
 		/* TRANSLATORS: Failed to open plugin, hey Arch users */
 		return _("Plugin dependencies missing");
 	}
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD) {
+		/* TRANSLATORS: The kernel does not support this plugin */
+		return _("Running kernel is too old");
+	}
 
 	/* fall back for unknown types */
 	return fwupd_plugin_flag_to_string (plugin_flag);
@@ -1483,6 +1487,7 @@ fu_util_plugin_flag_to_cli_text (FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_UNLOCK_REQUIRED:
 	case FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED:
 	case FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND:
+	case FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD:
 		return fu_util_term_format (fu_util_plugin_flag_to_string (plugin_flag),
 					    FU_UTIL_TERM_COLOR_RED);
 	default:


### PR DESCRIPTION
There are now multiple plugins using drm_dp_aux_dev interface which
may potentially be combined with an amdgpu. Prevent exercising this
interface with any plugin using DP aux unless a new enough kernel is
installed.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
