### PR TITLE
Standardize some of the device summary text

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -555,7 +555,7 @@ fu_altos_device_init (FuAltosDevice *self)
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_vendor (FU_DEVICE (self), "altusmetrum.org");
-	fu_device_set_summary (FU_DEVICE (self), "A USB hardware random number generator");
+	fu_device_set_summary (FU_DEVICE (self), "USB hardware random number generator");
 	fu_device_add_protocol (FU_DEVICE (self), "org.altusmetrum.altos");
 
 	/* requires manual step */

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -825,7 +825,7 @@ fu_ata_device_init (FuAtaDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag (FU_DEVICE (self), FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
-	fu_device_set_summary (FU_DEVICE (self), "ATA Drive");
+	fu_device_set_summary (FU_DEVICE (self), "ATA drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_add_protocol (FU_DEVICE (self), "org.t13.ata");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -160,7 +160,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	/* create a dummy device so we can unlock the feature */
 	fu_device_set_id (dev, "UEFI-dummy");
 	fu_device_set_name (dev, "Dell UEFI updates");
-	fu_device_set_summary (dev, "Enable UEFI Update Functionality");
+	fu_device_set_summary (dev, "UEFI update functionality");
 	fu_device_add_vendor_id (dev, "PCI:0x1028");
 	fu_device_add_instance_id (dev, "main-system-firmware");
 	fu_device_add_guid (dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -271,9 +271,9 @@ fu_plugin_dock_node (FuPlugin *plugin, const gchar *platform,
 	fu_device_set_name (dev, dock_name);
 	fu_device_set_metadata (dev, FU_DEVICE_METADATA_UEFI_DEVICE_KIND, "device-firmware");
 	if (type == DOCK_TYPE_TB16) {
-		fu_device_set_summary (dev, "A Thunderbolt™ 3 docking station");
+		fu_device_set_summary (dev, "Thunderbolt™ 3 docking station");
 	} else if (type == DOCK_TYPE_WD15) {
-		fu_device_set_summary (dev, "A USB type-C docking station");
+		fu_device_set_summary (dev, "USB type-C docking station");
 	}
 	fu_device_add_icon (dev, "computer");
 	fu_device_add_guid (dev, component_guid);

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -559,7 +559,7 @@ fu_elantp_hid_device_init (FuElantpHidDevice *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_set_summary (FU_DEVICE (self), "Elan Touchpad");
+	fu_device_set_summary (FU_DEVICE (self), "Touchpad");
 	fu_device_add_icon (FU_DEVICE (self), "input-touchpad");
 	fu_device_add_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_HEX);

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -630,7 +630,7 @@ fu_elantp_i2c_device_init (FuElantpI2cDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
-	fu_device_set_summary (FU_DEVICE (self), "Elan Touchpad (I²C Recovery)");
+	fu_device_set_summary (FU_DEVICE (self), "Touchpad (I²C recovery)");
 	fu_device_add_icon (FU_DEVICE (self), "input-touchpad");
 	fu_device_add_protocol (FU_DEVICE (self), "tw.com.emc.elantp");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_HEX);

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -419,7 +419,7 @@ fu_goodixmoc_device_init (FuGoodixMocDevice *self)
 	fu_device_set_remove_delay (FU_DEVICE(self), 5000);
 	fu_device_add_protocol (FU_DEVICE (self), "com.goodix.goodixmoc");
 	fu_device_set_name (FU_DEVICE(self), "Fingerprint Sensor");
-	fu_device_set_summary (FU_DEVICE(self), "Match-On-Chip Fingerprint Sensor");
+	fu_device_set_summary (FU_DEVICE(self), "Match-On-Chip fingerprint sensor");
 	fu_device_set_vendor (FU_DEVICE(self), "Goodix");
 	fu_device_set_install_duration (FU_DEVICE(self), 10);
 	fu_device_set_firmware_size_min (FU_DEVICE(self), 0x20000);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -455,7 +455,7 @@ fu_logitech_hidpp_bootloader_init (FuLogitechHidPpBootloader *self)
 	fu_device_add_icon (FU_DEVICE (self), "preferences-desktop-keyboard");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_name (FU_DEVICE (self), "Unifying Receiver");
-	fu_device_set_summary (FU_DEVICE (self), "A miniaturised USB wireless receiver (bootloader)");
+	fu_device_set_summary (FU_DEVICE (self), "Miniaturised USB wireless receiver (bootloader)");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_UNIFYING_DEVICE_TIMEOUT_MS);
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -277,6 +277,6 @@ fu_logitech_hidpp_runtime_init (FuLogitechHidPpRuntime *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_add_icon (FU_DEVICE (self), "preferences-desktop-keyboard");
 	fu_device_set_name (FU_DEVICE (self), "Unifying Receiver");
-	fu_device_set_summary (FU_DEVICE (self), "A miniaturised USB wireless receiver");
+	fu_device_set_summary (FU_DEVICE (self), "Miniaturised USB wireless receiver");
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -404,7 +404,7 @@ fu_nvme_device_init (FuNvmeDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
-	fu_device_set_summary (FU_DEVICE (self), "NVM Express Solid State Drive");
+	fu_device_set_summary (FU_DEVICE (self), "NVM Express solid state drive");
 	fu_device_add_icon (FU_DEVICE (self), "drive-harddisk");
 	fu_device_add_protocol (FU_DEVICE (self), "org.nvmexpress");
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -500,7 +500,7 @@ fu_solokey_device_init (FuSolokeyDevice *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_protocol (FU_DEVICE (self), "com.solokeys");
 	fu_device_set_name (FU_DEVICE (self), "Solo Secure");
-	fu_device_set_summary (FU_DEVICE (self), "An open source FIDO2 security key");
+	fu_device_set_summary (FU_DEVICE (self), "Open source FIDO2 security key");
 	fu_device_add_icon (FU_DEVICE (self), "applications-internet");
 }
 

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -507,7 +507,7 @@ fu_superio_device_init (FuSuperioDevice *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_protocol (FU_DEVICE (self), "tw.com.ite.superio");
-	fu_device_set_summary (FU_DEVICE (self), "Embedded Controller");
+	fu_device_set_summary (FU_DEVICE (self), "Embedded controller");
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 }
 

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -81,7 +81,7 @@ fu_synaptics_mst_device_init (FuSynapticsMstDevice *self)
 	fu_device_add_protocol (FU_DEVICE (self), "com.synaptics.mst");
 	fu_device_set_vendor (FU_DEVICE (self), "Synaptics");
 	fu_device_add_vendor_id (FU_DEVICE (self), "DRM_DP_AUX_DEV:0x06CB");
-	fu_device_set_summary (FU_DEVICE (self), "Multi-Stream Transport Device");
+	fu_device_set_summary (FU_DEVICE (self), "Multi-stream transport device");
 	fu_device_add_icon (FU_DEVICE (self), "video-display");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_udev_device_set_flags (FU_UDEV_DEVICE (self),

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -221,6 +221,8 @@ fu_synaprom_config_init (FuSynapromConfig *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_logical_id (FU_DEVICE (self), "cfg");
 	fu_device_set_name (FU_DEVICE (self), "Prometheus IOTA Config");
+	fu_device_set_summary (FU_DEVICE (self), "Fingerprint reader config");
+	fu_device_add_icon (FU_DEVICE (self), "touchpad-disabled");
 }
 
 static void

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -39,7 +39,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_protocol (device, "com.acme.test");
-	fu_device_set_summary (device, "A fake webcam");
+	fu_device_set_summary (device, "Fake webcam");
 	fu_device_set_vendor (device, "ACME Corp.");
 	fu_device_add_vendor_id (device, "USB:0x046D");
 	fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -775,6 +775,7 @@ fu_uefi_device_set_property (GObject *object, guint prop_id,
 static void
 fu_uefi_device_init (FuUefiDevice *self)
 {
+	fu_device_set_summary (FU_DEVICE (self), "UEFI ESRT device");
 	fu_device_add_protocol (FU_DEVICE (self), "org.uefi.capsule");
 	fu_device_register_private_flag (FU_DEVICE (self),
 					 FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE,

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -138,7 +138,7 @@ fu_uefi_dbx_device_init (FuUefiDbxDevice *self)
 {
 	fu_device_set_physical_id (FU_DEVICE (self), "dbx");
 	fu_device_set_name (FU_DEVICE (self), "UEFI dbx");
-	fu_device_set_summary (FU_DEVICE (self), "UEFI Revocation Database");
+	fu_device_set_summary (FU_DEVICE (self), "UEFI revocation database");
 	fu_device_add_vendor_id (FU_DEVICE (self), "UEFI:Linux Foundation");
 	fu_device_add_protocol (FU_DEVICE (self), "org.uefi.dbx");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_NUMBER);

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -689,7 +689,7 @@ fu_vli_pd_device_init (FuVliPdDevice *self)
 {
 	fu_device_add_icon (FU_DEVICE (self), "audio-card");
 	fu_device_add_protocol (FU_DEVICE (self), "com.vli.pd");
-	fu_device_set_summary (FU_DEVICE (self), "USB PD");
+	fu_device_set_summary (FU_DEVICE (self), "USB power distribution device");
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_set_remove_delay (FU_DEVICE (self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -650,7 +650,7 @@ fu_vli_pd_parade_device_init (FuVliPdParadeDevice *self)
 	fu_device_add_protocol (FU_DEVICE (self), "com.vli.i2c");
 	fu_device_set_install_duration (FU_DEVICE (self), 15); /* seconds */
 	fu_device_set_logical_id (FU_DEVICE (self), "PS186");
-	fu_device_set_summary (FU_DEVICE (self), "DisplayPort 1.4a to HDMI 2.0b Protocol Converter");
+	fu_device_set_summary (FU_DEVICE (self), "DisplayPort 1.4a to HDMI 2.0b protocol converter");
 	fu_device_set_firmware_size (FU_DEVICE (self), 0x40000);
 }
 

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -543,15 +543,15 @@ fu_vli_usbhub_device_probe (FuDevice *device, GError **error)
 	/* quirks now applied... */
 	if (usbver > 0x0300 ||
 	    fu_device_has_private_flag (device, FU_VLI_USBHUB_DEVICE_FLAG_USB3)) {
-		fu_device_set_summary (device, "USB 3.x Hub");
+		fu_device_set_summary (device, "USB 3.x hub");
 		/* prefer to show the USB 3 device and only fall back to the
 		 * USB 2 version as a recovery */
 		fu_device_set_priority (device, 1);
 	} else if (usbver > 0x0200 ||
 		   fu_device_has_private_flag (device, FU_VLI_USBHUB_DEVICE_FLAG_USB2)) {
-		fu_device_set_summary (device, "USB 2.x Hub");
+		fu_device_set_summary (device, "USB 2.x hub");
 	} else {
-		fu_device_set_summary (device, "USB Hub");
+		fu_device_set_summary (device, "USB hub");
 	}
 	return TRUE;
 }

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -327,7 +327,7 @@ fu_vli_usbhub_msp430_device_init (FuVliUsbhubMsp430Device *self)
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_logical_id (FU_DEVICE (self), "I2C");
-	fu_device_set_summary (FU_DEVICE (self), "I²C Dock Management Device");
+	fu_device_set_summary (FU_DEVICE (self), "I²C dock management device");
 
 	/* the MSP device reboot takes down the entire hub for ~60 seconds */
 	fu_device_set_remove_delay (FU_DEVICE (self), 120 * 1000);

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -258,7 +258,7 @@ fu_vli_usbhub_pd_device_init (FuVliUsbhubPdDevice *self)
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_install_duration (FU_DEVICE (self), 15); /* seconds */
 	fu_device_set_logical_id (FU_DEVICE (self), "PD");
-	fu_device_set_summary (FU_DEVICE (self), "USB-C Power Delivery Device");
+	fu_device_set_summary (FU_DEVICE (self), "USB-C power delivery device");
 }
 
 static void


### PR DESCRIPTION
This is supposed to be 'Sentence case' with no trailing fullstop.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
