### PR TITLE
trivial: Don't set a device ID if setting a physical ID

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
@@ -37,7 +37,6 @@ fu_uefi_backend_device_new (struct efi_esrt_entry_v1 *entry, guint64 idx, GError
 {
 	g_autoptr(FuUefiDevice) dev = NULL;
 	g_autofree gchar *fw_class = NULL;
-	g_autofree gchar *id = NULL;
 	g_autofree gchar *phys_id = NULL;
 	uint32_t status;
 
@@ -64,8 +63,6 @@ fu_uefi_backend_device_new (struct efi_esrt_entry_v1 *entry, guint64 idx, GError
 			    NULL);
 
 	/* set ID */
-	id = g_strdup_printf ("UEFI-%s-dev0", fw_class);
-	fu_device_set_id (FU_DEVICE (dev), id);
 	phys_id = g_strdup_printf ("ESRT/%u", (guint)idx);
 	fu_device_set_physical_id (FU_DEVICE (dev), phys_id);
 	return g_steal_pointer (&dev);

--- a/plugins/uefi-capsule/fu-uefi-backend-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-linux.c
@@ -39,7 +39,6 @@ fu_uefi_backend_device_new (const gchar *path)
 	g_autoptr(FuUefiDevice) dev = NULL;
 	g_autofree gchar *fw_class = NULL;
 	g_autofree gchar *fw_class_fn = NULL;
-	g_autofree gchar *id = NULL;
 
 	g_return_val_if_fail (path != NULL, NULL);
 
@@ -67,8 +66,6 @@ fu_uefi_backend_device_new (const gchar *path)
 			    NULL);
 
 	/* set ID */
-	id = g_strdup_printf ("UEFI-%s-dev0", fw_class);
-	fu_device_set_id (FU_DEVICE (dev), id);
 	fu_device_set_physical_id (FU_DEVICE (dev), path);
 	return g_steal_pointer (&dev);
 }


### PR DESCRIPTION
This isn't actually doing anything as setting a physical ID invalides
the manually-set ID.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
