### PR TITLE
trivial: Don't fail tests on old GLib versions

### DIFF
--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1503,7 +1503,16 @@ fu_firmware_export (FuFirmware *self,
 		if (flags & FU_FIRMWARE_EXPORT_FLAG_ASCII_DATA) {
 			datastr = fu_common_strsafe ((const gchar *) buf, MIN (bufsz, 16));
 		} else {
+#if GLIB_CHECK_VERSION(2,61,0)
 			datastr = g_base64_encode (buf, bufsz);
+#else
+			/* older GLib versions can't cope with buf=NULL */
+			if (buf == NULL || bufsz == 0) {
+				datastr = g_strdup ("");
+			} else {
+				datastr = g_base64_encode (buf, bufsz);
+			}
+#endif
 		}
 		xb_builder_node_insert_text (bn, "data", datastr,
 					     "size", dataszstr,


### PR DESCRIPTION
We were silently depending on 2.61.0 by accident.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
