### PR TITLE
redfish: Restore compatibility with old libcurl versions

### DIFF
--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -41,7 +41,11 @@ fu_redfish_backend_request_new (FuRedfishBackend *self)
  {
 	FuRedfishRequest *request = g_object_new (FU_TYPE_REDFISH_REQUEST, NULL);
 	CURL *curl;
+#ifdef HAVE_LIBCURL_7_62_0
 	CURLU *uri;
+#else
+	g_autofree gchar *uri_base = NULL;
+#endif
 	g_autofree gchar *user_agent = NULL;
 	g_autofree gchar *port = g_strdup_printf ("%u", self->port);
 
@@ -51,11 +55,19 @@ fu_redfish_backend_request_new (FuRedfishBackend *self)
 
 	/* set up defaults */
 	curl = fu_redfish_request_get_curl (request);
+#ifdef HAVE_LIBCURL_7_62_0
 	uri = fu_redfish_request_get_uri (request);
 	curl_url_set (uri, CURLUPART_SCHEME, self->use_https ? "https" : "http", 0);
 	curl_url_set (uri, CURLUPART_HOST, self->hostname, 0);
 	curl_url_set (uri, CURLUPART_PORT, port, 0);
 	curl_easy_setopt (curl, CURLOPT_CURLU, uri);
+#else
+	uri_base = g_strdup_printf ("%s://%s:%s",
+				    self->use_https ? "https" : "http",
+				    self->hostname,
+				    port);
+	fu_redfish_request_set_uri_base (request, uri_base);
+#endif
 
 	/* since DSP0266 makes Basic Authorization a requirement,
 	* it is safe to use Basic Auth for all implementations */

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -11,7 +11,11 @@
 struct _FuRedfishRequest {
 	GObject			 parent_instance;
 	CURL			*curl;
+#ifdef HAVE_LIBCURL_7_62_0
 	CURLU			*uri;
+#else
+	gchar			*uri_base;
+#endif
 	GByteArray		*buf;
 	glong			 status_code;
 	JsonParser		*json_parser;
@@ -38,12 +42,21 @@ fu_redfish_request_get_curl (FuRedfishRequest *self)
 	return self->curl;
 }
 
+#ifdef HAVE_LIBCURL_7_62_0
 CURLU *
 fu_redfish_request_get_uri (FuRedfishRequest *self)
 {
 	g_return_val_if_fail (FU_IS_REDFISH_REQUEST (self), NULL);
 	return self->uri;
 }
+#else
+void
+fu_redfish_request_set_uri_base (FuRedfishRequest *self, const gchar *uri_base)
+{
+	g_return_if_fail (FU_IS_REDFISH_REQUEST (self));
+	self->uri_base = g_strdup (uri_base);
+}
+#endif
 
 glong
 fu_redfish_request_get_status_code (FuRedfishRequest *self)
@@ -142,7 +155,11 @@ fu_redfish_request_perform (FuRedfishRequest *self,
 			    GError **error)
 {
 	CURLcode res;
+#ifdef HAVE_LIBCURL_7_62_0
 	g_autoptr(curlptr) uri_str = NULL;
+#else
+	g_autofree gchar *uri_str = NULL;
+#endif
 
 	g_return_val_if_fail (FU_IS_REDFISH_REQUEST (self), FALSE);
 	g_return_val_if_fail (path != NULL, FALSE);
@@ -163,8 +180,19 @@ fu_redfish_request_perform (FuRedfishRequest *self,
 	}
 
 	/* do request */
+#ifdef HAVE_LIBCURL_7_62_0
 	curl_url_set (self->uri, CURLUPART_PATH, path, 0);
 	curl_url_get (self->uri, CURLUPART_URL, &uri_str, 0);
+#else
+	uri_str = g_strdup_printf ("%s%s", self->uri_base, path);
+	if (curl_easy_setopt (self->curl, CURLOPT_URL, uri_str) != CURLE_OK) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INVALID_FILE,
+				     "failed to create message for URI");
+		return FALSE;
+	}
+#endif
 	res = curl_easy_perform (self->curl);
 	curl_easy_getinfo (self->curl, CURLINFO_RESPONSE_CODE, &self->status_code);
 	if (g_getenv ("FWUPD_REDFISH_VERBOSE") != NULL) {
@@ -235,7 +263,9 @@ static void
 fu_redfish_request_init (FuRedfishRequest *self)
 {
 	self->curl = curl_easy_init ();
+#ifdef HAVE_LIBCURL_7_62_0
 	self->uri = curl_url ();
+#endif
 	self->buf = g_byte_array_new ();
 	self->json_parser = json_parser_new ();
 	curl_easy_setopt (self->curl, CURLOPT_WRITEFUNCTION, fu_redfish_request_write_cb);
@@ -251,7 +281,11 @@ fu_redfish_request_finalize (GObject *object)
 	g_object_unref (self->json_parser);
 	g_byte_array_unref (self->buf);
 	curl_easy_cleanup (self->curl);
+#ifdef HAVE_LIBCURL_7_62_0
 	curl_url_cleanup (self->uri);
+#else
+	g_free (self->uri_base);
+#endif
 	G_OBJECT_CLASS (fu_redfish_request_parent_class)->finalize (object);
 }
 

--- a/plugins/redfish/fu-redfish-request.h
+++ b/plugins/redfish/fu-redfish-request.h
@@ -10,10 +10,6 @@
 
 #include <curl/curl.h>
 
-#ifndef HAVE_LIBCURL_7_62_0
-#error libcurl >= 7.62.0 required
-#endif
-
 #define FU_TYPE_REDFISH_REQUEST (fu_redfish_request_get_type ())
 G_DECLARE_FINAL_TYPE (FuRedfishRequest, fu_redfish_request, FU, REDFISH_REQUEST, GObject)
 
@@ -31,7 +27,12 @@ JsonObject	*fu_redfish_request_get_json_object	(FuRedfishRequest	*self);
 CURL		*fu_redfish_request_get_curl		(FuRedfishRequest	*self);
 void		 fu_redfish_request_set_curlsh		(FuRedfishRequest	*self,
 							 CURLSH			*curlsh);
+#ifdef HAVE_LIBCURL_7_62_0
 CURLU		*fu_redfish_request_get_uri		(FuRedfishRequest	*self);
+#else
+void		 fu_redfish_request_set_uri_base	(FuRedfishRequest	*self,
+							 const gchar		*uri_base);
+#endif
 glong		 fu_redfish_request_get_status_code	(FuRedfishRequest	*self);
 void		 fu_redfish_request_set_cache		(FuRedfishRequest	*self,
 							 GHashTable		*cache);


### PR DESCRIPTION
Making the redfish plugin disabled on RHEL 8 was... unpopular.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
