### PR TITLE
Add a device flag to control child removal

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -232,6 +232,8 @@ fu_device_internal_flag_to_string (FuDeviceInternalFlags flag)
 		return "attach-extra-reset";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN)
 		return "inhibit-children";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE_CHILDREN)
+		return "no-auto-remove-children";
 	return NULL;
 }
 
@@ -278,6 +280,8 @@ fu_device_internal_flag_from_string (const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET;
 	if (g_strcmp0 (flag, "inhibit-children") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN;
+	if (g_strcmp0 (flag, "no-auto-remove-children") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE_CHILDREN;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -238,6 +238,7 @@ FuDevice	*fu_device_new				(void);
  * @FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN:	Automatically assign the parent for children of this device
  * @FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET:		Device needs resetting twice for attach after the firmware update
  * @FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN:		Children of the device are inhibited by the parent
+ * @FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE_CHILDREN:	Do not auto-remove clildren in the device list
  *
  * The device internal flags.
  **/
@@ -258,6 +259,7 @@ typedef enum {
 	FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN	= (1llu << 12),	/* Since: 1.6.2 */
 	FU_DEVICE_INTERNAL_FLAG_ATTACH_EXTRA_RESET	= (1llu << 13),	/* Since: 1.6.2 */
 	FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN	= (1llu << 14),	/* Since: 1.6.2 */
+	FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE_CHILDREN	= (1llu << 15),	/* Since: 1.6.2 */
 	/*< private >*/
 	FU_DEVICE_INTERNAL_FLAG_UNKNOWN			= G_MAXUINT64,
 } FuDeviceInternalFlags;


### PR DESCRIPTION
At the moment the device list auto-removes children when the parent is
removed. This was originally working around the bug that the child
devices had no backend ID, and thus were not matched like the parent
in fu_engine_backend_device_removed_cb() and removed automatically.

Using the workaround means that the children are potentially removed
before the parent depending on the order of the device list -- which
might be modified by replug events.

I think the old cleanup is probably an anti-pattern, and going forward
composite devices should probably define _NO_AUTO_REMOVE_CHILDREN but
we don't want to change this behaviour for plugins already expecting
the old flow, or for devices with no parent backend IDs.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
