### PR TITLE
trivial: override support for fwupd build by runtime environment vari…

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2137,6 +2137,9 @@ fu_util_show_unsupported_warn (void)
 {
 #ifndef SUPPORTED_BUILD
 	g_autofree gchar *fmt = NULL;
+
+	if (g_getenv ("FWUPD_SUPPORTED") != NULL)
+                return;
 	/* TRANSLATORS: this is a prefix on the console */
 	fmt = fu_util_term_format (_("WARNING:"), FU_UTIL_TERM_COLOR_YELLOW);
 	/* TRANSLATORS: unsupported build of the package */


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

If a specific fwupd build went through certain level of validation cycle thereafter pursuing to remove the warning message of untested, it is now available by adding a custom environment variable at runtime. 

I've tested it with adding env `FWUPD_SUPPORTED` to `fwupd-command` from a snap build locally.