### PR TITLE
emmc: use sysattr insted of udev attr lookup for device name

### DIFF
--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -176,17 +176,8 @@ fu_emmc_device_probe (FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	/* add instance IDs */
-	tmp = g_udev_device_get_property (udev_device, "ID_NAME");
-	if (tmp == NULL) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_SUPPORTED,
-				     "has no ID_NAME");
-		return FALSE;
-	}
-
 	/* name */
+	tmp = g_udev_device_get_sysfs_attr (udev_parent, "name");
 	fu_device_set_name (device, tmp);
 	name_only = g_strdup_printf ("EMMC\\%s", fu_device_get_name (device));
 	fu_device_add_instance_id (device, name_only);


### PR DESCRIPTION
/run/udev/data/b* location of eMMC devices appears to be inaccessible
early on in the boot process which makes fwupd to skip eMMC devices if
the daemon started too early. ID_NAME udev attribute is effectively
copied from the sysfs attribute [1], thus making use of it is more
reliable.

[1] https://kernel.googlesource.com/pub/scm/linux/hotplug/udev/+/1ed38f41749dde482e164e692255b60c38b5d876/etc/udev/rules.d/60-persistent-storage.rules#42
