### PR TITLE
DRAFT: cpu: intel: Add support for microcode update via cpu plugin

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -1181,6 +1181,12 @@ fu_common_get_path (FuPathKind path_kind)
 		if (tmp != NULL)
 			return g_strdup (tmp);
 		return g_strdup ("/sys/module/firmware_class/parameters/path");
+	/* /sys/devices/system/cpu/microcode/reload */
+	case FU_PATH_KIND_MICROCODE_RELOAD:
+		tmp = g_getenv ("FWUPD_MICROCODE_RELOAD");
+		if (tmp != NULL)
+			return g_strdup (tmp);
+		return g_strdup ("/sys/devices/system/cpu/microcode/reload");
 	/* /etc */
 	case FU_PATH_KIND_SYSCONFDIR:
 		tmp = g_getenv ("FWUPD_SYSCONFDIR");

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -69,6 +69,7 @@ typedef guint FuEndianType;
  * @FU_PATH_KIND_LOCKDIR:		The lock directory (IE /run/lock)
  * @FU_PATH_KIND_SYSFSDIR_FW_ATTRIB	The firmware attributes directory (IE /sys/class/firmware-attributes)
  * @FU_PATH_KIND_FIRMWARE_SEARCH:	The path to configure the kernel policy for runtime loading other than /lib/firmware (IE /sys/module/firmware_class/parameters/path)
+ * @FU_PATH_KIND_MICROCODE_RELOAD:	The sysfs path to do late microcode load
  *
  * Path types to use when dynamically determining a path at runtime
  **/
@@ -92,6 +93,7 @@ typedef enum {
 	FU_PATH_KIND_LOCKDIR,
 	FU_PATH_KIND_SYSFSDIR_FW_ATTRIB,
 	FU_PATH_KIND_FIRMWARE_SEARCH,
+	FU_PATH_KIND_MICROCODE_RELOAD,
 	/*< private >*/
 	FU_PATH_KIND_LAST
 } FuPathKind;

--- a/plugins/cpu/README.md
+++ b/plugins/cpu/README.md
@@ -6,6 +6,16 @@ This plugin reads the sysfs attributes associated with CPU microcode.
 It displays a read-only value of the CPU microcode version loaded onto
 the physical CPU at fwupd startup.
 
+This plugin can also update the microcode for supported CPU vendors. It can
+late load microcode using sysfs and early load via initramfs for subsequent
+boots.
+
+Note: For debian based distros, there is a dependency on kernel module "msr" to
+be loaded. This is required for msr plugin to work in general which updates the
+microcode version for cpu plugin.
+This can be manually done as:
+ # modprobe msr
+
 ## GUID Generation
 
 These devices add extra instance IDs from the CPUID values, e.g.

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -1,9 +1,18 @@
 /*
  * Copyright (C) 2019 Mario Limonciello <mario.limonciello@dell.com>
+ * Copyright (C) 2021 Intel Corporation
  *
  * SPDX-License-Identifier: GPL-2+
  */
 
+#include <sys/utsname.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include "config.h"
 
 #include <fwupdplugin.h>
@@ -13,9 +22,14 @@
 struct _FuCpuDevice {
 	FuDevice		 parent_instance;
 	FuCpuDeviceFlag		 flags;
+	guint32			 family_id;
+	guint32			 model_id;
+	guint32			 stepping_id;
 };
 
 G_DEFINE_TYPE (FuCpuDevice, fu_cpu_device, FU_TYPE_DEVICE)
+
+#define UCODE_BKP_EXTN	".bkp"
 
 gboolean
 fu_cpu_device_has_flag (FuCpuDevice *self, FuCpuDeviceFlag flag)
@@ -95,12 +109,40 @@ fu_cpu_device_convert_vendor (const gchar *vendor)
 	return vendor;
 }
 
+static gboolean
+fu_cpu_is_updatable (const gchar *ucode_dir)
+{
+	g_autofree gchar *sysfs_ucode_reload = fu_common_get_path (FU_PATH_KIND_MICROCODE_RELOAD);
+
+	/* This path may not be present on older kernels and won't be supported */
+        if (g_access (sysfs_ucode_reload, R_OK|W_OK) < 0)
+                return FALSE;
+
+	if (ucode_dir != NULL) {
+		if (g_access (ucode_dir, R_OK|W_OK) < 0)
+			return FALSE;
+	} else {
+		 if (g_access ("/lib/firmware", R_OK|W_OK) < 0)
+                        return FALSE;
+	}
+
+	/* check if /boot is writable for initramfs update */
+	if (g_access ("/boot", R_OK|W_OK) < 0)
+		return FALSE;
+
+	return TRUE;
+}
+
 static void
 fu_cpu_device_init (FuCpuDevice *self)
 {
 	fu_device_add_guid_full (FU_DEVICE (self), "cpu",
 				 FU_DEVICE_INSTANCE_FLAG_NO_QUIRKS);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_INTERNAL);
+	if (fu_cpu_is_updatable (NULL)) {
+		fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+		fu_device_add_protocol (FU_DEVICE (self), "org.kernel.microcode-reload");
+	}
 	fu_device_add_icon (FU_DEVICE (self), "computer");
 	fu_device_set_version_format (FU_DEVICE (self), FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_physical_id (FU_DEVICE (self), "cpu:0");
@@ -109,6 +151,7 @@ fu_cpu_device_init (FuCpuDevice *self)
 static gboolean
 fu_cpu_device_add_instance_ids (FuDevice *device, GError **error)
 {
+	FuCpuDevice *self = FU_CPU_DEVICE (device);
 	guint32 eax = 0;
 	guint32 family_id;
 	guint32 family_id_ext;
@@ -135,6 +178,10 @@ fu_cpu_device_add_instance_ids (FuDevice *device, GError **error)
 		model_id |= model_id_ext << 4;
 	if (family_id == 15)
 		family_id += family_id_ext;
+
+	self->family_id		= family_id;
+	self->model_id		= model_id;
+	self->stepping_id	= stepping_id;
 
 	devid1 = g_strdup_printf ("CPUID\\PRO_%01X&FAM_%02X",
 				  processor_id,
@@ -176,6 +223,8 @@ fu_cpu_device_probe_manufacturer_id (FuDevice *device, GError **error)
 			     sizeof(guint32), error))
 		return FALSE;
 	fu_device_set_vendor (device, fu_cpu_device_convert_vendor (str));
+	if (fu_common_get_cpu_vendor () == FU_CPU_VENDOR_INTEL)
+		fu_device_add_vendor_id (device, fu_cpu_device_convert_vendor ("CPU:INTEL"));
 	return TRUE;
 }
 
@@ -382,6 +431,223 @@ fu_cpu_device_add_security_attrs (FuDevice *device, FuSecurityAttrs *attrs)
 	fu_cpu_device_add_security_attrs_intel_smap (self, attrs);
 }
 
+static gboolean
+fu_cpu_late_load_microcode (GError **error)
+{
+	char reload_char = '1';
+	int fd;
+	g_autofree gchar *sysfs_ucode_reload = fu_common_get_path (FU_PATH_KIND_MICROCODE_RELOAD);
+
+	fd = open (sysfs_ucode_reload, O_WRONLY);
+	if (fd < 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_FAILED,
+			     "failed to open %s", sysfs_ucode_reload);
+		return FALSE;
+	}
+	if (write (fd, &reload_char, 1) < 0) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_FAILED,
+			     "failed to write to %s", sysfs_ucode_reload);
+		close (fd);
+		return FALSE;
+	}
+
+	close (fd);
+	return TRUE;
+}
+
+static gboolean
+fu_cpu_update_initrd_microcode (GError **error)
+{
+	struct utsname kernel_name;
+	g_autoptr(GError) error_local = NULL;
+	const gchar *argv[5] = {NULL};
+
+	if (fu_common_find_program_in_path ("update-initramfs", &error_local) != NULL) {
+		memset (&kernel_name, 0, sizeof(struct utsname));
+		if (uname (&kernel_name) < 0) {
+			g_set_error_literal (error,
+					     G_IO_ERROR,
+					     G_IO_ERROR_FAILED,
+					     "failed to read current kernel version");
+			return FALSE;
+		}
+		argv[0] = "update-initramfs";
+		argv[1] = "u";
+		argv[2] = "-k";
+		argv[3] =  kernel_name.release;
+		argv[4] = NULL;
+
+	} else if (fu_common_find_program_in_path ("dracut", &error_local) != NULL) {
+		argv[0] = "dracut";
+		argv[1] = "-f";
+		argv[2]	= NULL;
+	} else {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_NOT_SUPPORTED,
+				     "couldn't find a tool to update the initial ramdisk with the new microcode");
+		return FALSE;
+	}
+
+	if (!fu_common_spawn_sync (argv, NULL, NULL, 0, NULL, error)) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_FAILED,
+			     "failed to run initrd command: %s", argv[0]);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_cpu_restore_microcode (const gchar *ucode_path)
+{
+	g_autofree gchar *ucode_bkp_path = NULL;
+
+	if (ucode_path == NULL)
+		return FALSE;
+
+	if (!g_remove (ucode_path))
+		return FALSE;
+
+	/* Now restore from backup if it exists */
+	ucode_bkp_path = g_strdup_printf ("%s%s", ucode_path, UCODE_BKP_EXTN);
+
+	if (ucode_bkp_path == NULL)
+		return FALSE;
+
+	if (!g_file_test (ucode_bkp_path, G_FILE_TEST_EXISTS))
+		return TRUE;
+
+	if (g_rename (ucode_bkp_path, ucode_path) < 0)
+		return FALSE;
+
+	return TRUE;
+}
+
+static void
+fu_cpu_wr_fw_cleanup (FuDevice *device, const gchar *msg, GError **error)
+{
+	if (msg) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_FAILED,
+				     msg);
+	}
+	fu_device_set_status (device, FWUPD_STATUS_IDLE);
+}
+
+static gboolean
+fu_cpu_device_write_firmware (FuDevice *device, FuFirmware *firmware,
+				FwupdInstallFlags flags, GError **error)
+{
+	FuCpuDevice *self = FU_CPU_DEVICE (device);
+	g_autoptr(GOutputStream) ostream = NULL;
+	g_autofree gchar *ucode_dir = NULL;
+	g_autofree gchar *vendor = NULL;
+	g_autofree gchar *ucode_bkp_path = NULL;
+	g_autofree gchar *ucode_path = NULL;
+	g_autoptr(GBytes) ucode_blob = NULL;
+	GFile *ucode_fd;
+	gssize size;
+
+	/* how do we set fw version using MSR plugin ? */
+
+	vendor = g_ascii_strdown (fu_device_get_vendor(device), -1);
+	ucode_dir = g_strdup_printf ("/lib/firmware/%s-ucode", vendor);
+
+	/* check device updatable */
+	if (!fu_cpu_is_updatable (ucode_dir)) {
+		fu_cpu_wr_fw_cleanup (device, "device not updatable", error);
+		return FALSE;
+	}
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_VERIFY);
+
+	if (firmware == NULL) {
+		fu_cpu_wr_fw_cleanup (device, "firmware is NULL", error);
+		return FALSE;
+	}
+
+	ucode_blob = fu_firmware_get_bytes (firmware, error);
+	if (ucode_blob == NULL) {
+		fu_cpu_wr_fw_cleanup (device, "firmware blob is NULL", error);
+		return FALSE;
+	}
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
+
+	if (g_getenv ("FWUPD_CPU_VERBOSE") != NULL)
+		fu_common_dump_bytes (G_LOG_DOMAIN, "microcode", ucode_blob);
+
+	ucode_path = g_strdup_printf ("%s/%02x-%02x-%02x", ucode_dir,
+					self->family_id, self->model_id,
+					self->stepping_id);
+	ucode_bkp_path = g_strdup_printf ("%s%s", ucode_path, UCODE_BKP_EXTN);
+
+	if (ucode_path == NULL || ucode_bkp_path == NULL) {
+		fu_cpu_wr_fw_cleanup (device, "failed to allocate memory", error);
+		return FALSE;
+	}
+
+	/* only do update if we can make backup of existing microcode */
+	if (g_file_test (ucode_path, G_FILE_TEST_EXISTS)) {
+		if (g_rename (ucode_path, ucode_bkp_path) < 0) {
+			fu_cpu_wr_fw_cleanup (device, "failed to create backup of existing microcode", error);
+			return FALSE;
+		}
+	}
+
+	ucode_fd = g_file_new_for_path (ucode_path);
+	ostream = G_OUTPUT_STREAM (g_file_replace (ucode_fd, NULL, FALSE,
+					G_FILE_CREATE_NONE, NULL, error));
+
+	if (ostream == NULL) {
+		fu_cpu_wr_fw_cleanup (device, "failed to create ucode file", error);
+		/* restore previous microcode */
+		if (!fu_cpu_restore_microcode (ucode_path))
+			g_prefix_error (error, "failed to restore previous microcode: ");
+		return FALSE;
+	}
+
+	size = g_output_stream_write_bytes (ostream, ucode_blob, NULL, error);
+	if (!g_output_stream_close (ostream, NULL, error)) {
+		fu_cpu_wr_fw_cleanup (device, "failed to close ostream", error);
+		if (!fu_cpu_restore_microcode (ucode_path))
+			g_prefix_error (error, "failed to restore previous microcode: ");
+		return FALSE;
+	}
+	if (size < 0) {
+		fu_cpu_wr_fw_cleanup (device, "failed to write ucode file", error);
+		if (!fu_cpu_restore_microcode (ucode_path))
+			g_prefix_error (error, "failed to restore previous microcode: ");
+		return FALSE;
+	}
+
+	if (!fu_cpu_late_load_microcode (error)) {
+		fu_cpu_wr_fw_cleanup (device, "microcode late load failed", error);
+		if (!fu_cpu_restore_microcode (ucode_path))
+			g_prefix_error (error, "failed to restore microcode after late load failure: ");
+		return FALSE;
+	}
+
+	/* TODO again how to check the microcode version? check if updated and set it */
+
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
+	if (!fu_cpu_update_initrd_microcode (error)) {
+		fu_cpu_wr_fw_cleanup (device, "microcode initrd update failed", error);
+		if (!fu_cpu_restore_microcode (ucode_path))
+			g_prefix_error (error, "failed to restore microcode after initrd update failure: ");
+		return FALSE;
+	}
+
+	fu_device_set_status (device, FWUPD_STATUS_IDLE);
+	return TRUE;
+}
+
 static void
 fu_cpu_device_class_init (FuCpuDeviceClass *klass)
 {
@@ -390,6 +656,7 @@ fu_cpu_device_class_init (FuCpuDeviceClass *klass)
 	klass_device->probe = fu_cpu_device_probe;
 	klass_device->set_quirk_kv = fu_cpu_device_set_quirk_kv;
 	klass_device->add_security_attrs = fu_cpu_device_add_security_attrs;
+	klass_device->write_firmware = fu_cpu_device_write_firmware;
 }
 
 FuCpuDevice *


### PR DESCRIPTION
A CPU microcode update can be done by the BIOS, during kernel bootup and
post boot. This commit add the functionality to update microcode post
boot and also update initrd image so that microcode gets update at next
bootup as well.

Plugin uses the interface provided in sysfs for late loading of
microcode. It also uses system tools "dracut" or "update-initramfs" to
update the initrd image with the updated microcode.

Known issue: 
- on some distributions, user has to manually load msr kernel module 
for microcode version to populate
- currently there's no support to read new microcode version after update, in cpu plugin 

Signed-off-by: Naissa Conde naissa.conde@intel.com
Signed-off-by: Pawan Gupta pawan.kumar.gupta@intel.com

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
