### PR TITLE
fu-engine: Preserve NEEDS_REBOOT on successful update

### DIFF
--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -151,6 +151,7 @@ fu_plugin_update (FuPlugin *plugin,
 {
 	const gchar *test = g_getenv ("FWUPD_PLUGIN_TEST");
 	gboolean requires_activation = g_strcmp0 (test, "requires-activation") == 0;
+	gboolean requires_reboot = g_strcmp0 (test, "requires-reboot") == 0;
 	if (g_strcmp0 (test, "fail") == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
@@ -189,6 +190,8 @@ fu_plugin_update (FuPlugin *plugin,
 	/* upgrade, or downgrade */
 	if (requires_activation) {
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+	} else if (requires_reboot) {
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	} else {
 		g_autofree gchar *ver = fu_plugin_test_get_version (blob_fw);
 		fu_device_set_version_format (device, FWUPD_VERSION_FORMAT_TRIPLET);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2502,9 +2502,6 @@ fu_engine_install_release (FuEngine *self,
 		fu_device_set_update_error (device, str);
 	}
 
-	/* success */
-	fu_engine_emit_changed (self);
-
 	return TRUE;
 }
 
@@ -2693,8 +2690,13 @@ fu_engine_install (FuEngine *self,
 			return FALSE;
 	}
 
-	/* success */
-	fu_device_set_update_state (device, FWUPD_UPDATE_STATE_SUCCESS);
+	/* mark success unless needs a reboot */
+	if (fu_device_get_update_state (device) != FWUPD_UPDATE_STATE_NEEDS_REBOOT)
+		fu_device_set_update_state (device, FWUPD_UPDATE_STATE_SUCCESS);
+
+	/* make the UI update */
+	fu_engine_emit_changed (self);
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Currently the SUCCESS state overrides NEEDS_REBOOT, thus making the
devices considered for successive get-upgrades within same boot. The
change preserves the NEEDS_REBOOT state. It also adds a missed
'changed' signal, which otherwise would skip updating the persistent
state.
