### PR TITLE
trivial: Remove the unused parent instance from the private struct

### DIFF
--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -30,7 +30,6 @@
 static void fwupd_remote_finalize	 (GObject *obj);
 
 typedef struct {
-	GObject			 parent_instance;
 	FwupdRemoteKind		 kind;
 	FwupdKeyringKind	 keyring_kind;
 	gchar			*id;

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -26,7 +26,6 @@
  */
 
 typedef struct {
-	FuBluezDevice		 parent_instance;
 	GDBusObjectManager	*object_manager;
 	GDBusProxy		*proxy;
 	GHashTable		*uuids;		/* utf8 : FuBluezDeviceUuidHelper */

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -29,7 +29,6 @@
 
 typedef struct
 {
-	FuUsbDevice		*usb_device;
 	guint8			 interface;
 	gboolean		 interface_autodetect;
 	FuHidDeviceFlags	 flags;

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -28,7 +28,6 @@
 
 typedef struct
 {
-	FuUdevDevice		*udev_device;
 	guint			 bus_number;
 } FuI2cDevicePrivate;
 

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -23,7 +23,6 @@
  */
 
 typedef struct {
-	FuFirmware		 parent_instance;
 	GPtrArray		*records;
 	guint8			 padding_value;
 } FuIhexFirmwarePrivate;

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -23,7 +23,6 @@
  */
 
 typedef struct {
-	FuFirmware		 parent_instance;
 	GPtrArray		*records;
 } FuSrecFirmwarePrivate;
 

--- a/plugins/intel-spi/fu-ifd-device.c
+++ b/plugins/intel-spi/fu-ifd-device.c
@@ -13,7 +13,6 @@
 #include "fu-intel-spi-device.h"
 
 typedef struct {
-	FuDevice		 parent_instance;
 	FuIfdRegion		 region;
 	guint32			 offset;
 	FuIfdAccess		 access[FU_IFD_REGION_MAX];

--- a/plugins/intel-spi/fu-pci-device.c
+++ b/plugins/intel-spi/fu-pci-device.c
@@ -13,7 +13,6 @@
 #include "fu-pci-device.h"
 
 typedef struct {
-	FuDevice		 parent_instance;
 	guint32			 bus;
 	guint32			 dev;
 	guint32			 fun;

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -12,7 +12,6 @@
 #include "fu-vli-device.h"
 
 typedef struct {
-	FuUsbDevice		 parent_instance;
 	FuVliDeviceKind		 kind;
 	gboolean		 spi_auto_detect;
 	FuVliDeviceSpiReq	 spi_cmds[FU_VLI_DEVICE_SPI_REQ_LAST];


### PR DESCRIPTION
I assume at some point we forgot to remove it when converting an object
from FINAL to DERIVABLE and the anti-pattern just got copied around the
codebase...

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
