### PR TITLE
Open the device proxy in the engine where required

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1098,6 +1098,26 @@ fu_device_get_proxy (FuDevice *self)
 }
 
 /**
+ * fu_device_get_proxy_with_fallback:
+ * @self: a #FuDevice
+ *
+ * Gets the proxy device, falling back to the device itself.
+ *
+ * Returns: (transfer none): a device
+ *
+ * Since: 1.6.2
+ **/
+FuDevice *
+fu_device_get_proxy_with_fallback (FuDevice *self)
+{
+	FuDevicePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FU_IS_DEVICE (self), NULL);
+	if (priv->proxy != NULL)
+		return priv->proxy;
+	return self;
+}
+
+/**
  * fu_device_get_children:
  * @self: a #FuDevice
  *

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -310,6 +310,7 @@ void		 fu_device_add_counterpart_guid		(FuDevice	*self,
 FuDevice	*fu_device_get_proxy			(FuDevice	*self);
 void		 fu_device_set_proxy			(FuDevice	*self,
 							 FuDevice	*proxy);
+FuDevice	*fu_device_get_proxy_with_fallback	(FuDevice	*self);
 const gchar	*fu_device_get_metadata			(FuDevice	*self,
 							 const gchar	*key);
 gboolean	 fu_device_get_metadata_boolean		(FuDevice	*self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -829,6 +829,7 @@ LIBFWUPDPLUGIN_1.6.2 {
     fu_device_emit_request;
     fu_device_get_parent_physical_ids;
     fu_device_get_private_flags;
+    fu_device_get_proxy_with_fallback;
     fu_device_get_request_cnt;
     fu_device_has_parent_physical_id;
     fu_device_has_private_flag;

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -299,8 +299,9 @@ fu_vli_usbhub_device_spi_write_data (FuVliDevice *self,
 #define VL817_ADDR_GPIO_GET_INPUT_DATA		0xF6A2	/* 0=low, 1=high */
 
 static gboolean
-fu_vli_usbhub_device_attach_full (FuDevice *device, FuDevice *proxy, GError **error)
+fu_vli_usbhub_device_attach (FuDevice *device, GError **error)
 {
+	FuDevice *proxy = fu_device_get_proxy_with_fallback (device);
 	g_autoptr(GError) error_local = NULL;
 
 	/* update UI */
@@ -360,25 +361,6 @@ fu_vli_usbhub_device_attach_full (FuDevice *device, FuDevice *proxy, GError **er
 	/* success */
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
-}
-
-static gboolean
-fu_vli_usbhub_device_attach (FuDevice *device, GError **error)
-{
-	FuDevice *proxy = fu_device_get_proxy (device);
-
-	/* if we do this in another plugin, perhaps move to the engine? */
-	if (proxy != NULL) {
-		g_autoptr(FuDeviceLocker) locker = NULL;
-		g_debug ("using proxy device %s", fu_device_get_id (proxy));
-		locker = fu_device_locker_new (proxy, error);
-		if (locker == NULL)
-			return FALSE;
-		return fu_vli_usbhub_device_attach_full (device, proxy, error);
-	}
-
-	/* normal case */
-	return fu_vli_usbhub_device_attach_full (device, device, error);
 }
 
 /* disable hub sleep states -- not really required by 815~ hubs */


### PR DESCRIPTION
The benefit of using the proxy device is that we can 'use' the proxy
device for device access, but 'report' the progress on the passed
FuDevice instance.

This means the front-end reports the device status correctly when
updating composite devices that us proxies.

The comment always said we should move it to the daemon if another
plugin started doing this, and that is now.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
