### PR TITLE
Addition of FWUPD_DEVICE_FLAG_REQUIRE_AC Flag to fu-plugin-test.c

### DIFF
--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -37,6 +37,7 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_add_guid (device, "b585990a-003e-5270-89d5-3705a17f9a43");
 	fu_device_set_name (device, "Integrated_Webcam(TM)");
 	fu_device_add_icon (device, "preferences-desktop-keyboard");
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_protocol (device, "com.acme.test");


### PR DESCRIPTION
This commit is a solution to the issue filed at
https://github.com/fwupd/fwupd/issues/3501. It sets a the AC power flag for the
fake webcam device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
