### PR TITLE
trivial: Do not save the self test quirk silo to disk

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -596,7 +596,7 @@ fu_plugin_quirks_func (void)
 	g_autoptr(FuContext) ctx = fu_context_new ();
 	g_autoptr(GError) error = NULL;
 
-	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NONE, &error);
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -626,7 +626,7 @@ fu_plugin_quirks_performance_func (void)
 	g_autoptr(GError) error = NULL;
 	const gchar *keys[] = { "Name", "Children", "Flags", NULL };
 
-	ret = fu_quirks_load (quirks, FU_QUIRKS_LOAD_FLAG_NONE, &error);
+	ret = fu_quirks_load (quirks, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -652,7 +652,7 @@ fu_plugin_quirks_device_func (void)
 	g_autoptr(FuContext) ctx = fu_context_new ();
 	g_autoptr(GError) error = NULL;
 
-	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NONE, &error);
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -1384,6 +1384,11 @@ fu_device_instance_ids_func (void)
 	g_autoptr(FuDevice) device = fu_device_new_with_context (ctx);
 	g_autoptr(GError) error = NULL;
 
+	/* do not save silo */
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+
 	/* sanity check */
 	g_assert_false (fu_device_has_guid (device, "c0a26214-223b-572a-9477-cde897fe8619"));
 
@@ -1541,6 +1546,11 @@ fu_device_children_func (void)
 	g_autoptr(FuDevice) child = fu_device_new ();
 	g_autoptr(FuDevice) parent = fu_device_new_with_context (ctx);
 	g_autoptr(GError) error = NULL;
+
+	/* do not save silo */
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
 
 	fu_device_set_physical_id (child, "dummy");
 	fu_device_set_physical_id (parent, "dummy");

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -494,6 +494,11 @@ fu_test_self_init (FuTest *self)
 	g_autofree gchar *pluginfn_uefi = NULL;
 	g_autofree gchar *pluginfn_dell = NULL;
 
+	/* do not save silo */
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+
 	self->plugin_uefi_capsule = fu_plugin_new (ctx);
 	pluginfn_uefi = g_build_filename (PLUGINBUILDDIR, "..", "uefi-capsule",
 					  "libfu_plugin_uefi_capsule." G_MODULE_SUFFIX,

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -168,6 +168,11 @@ fu_uefi_plugin_func (void)
 	return;
 #endif
 
+	/* do not save silo */
+	ret = fu_context_load_quirks (ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error (error);
+	g_assert_true (ret);
+
 	/* add each device */
 	ret = fu_backend_coldplug (backend, &error);
 	g_assert_no_error (error);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -30,6 +30,7 @@ G_DECLARE_FINAL_TYPE (FuEngine, fu_engine, FU, ENGINE, GObject)
  * @FU_ENGINE_LOAD_FLAG_COLDPLUG:	Enumerate devices
  * @FU_ENGINE_LOAD_FLAG_REMOTES:	Enumerate remotes
  * @FU_ENGINE_LOAD_FLAG_HWINFO:		Load details about the hardware
+ * @FU_ENGINE_LOAD_FLAG_NO_CACHE:	Do not save persistent xmlb silos
  *
  * The flags to use when loading the engine.
  **/
@@ -39,6 +40,7 @@ typedef enum {
 	FU_ENGINE_LOAD_FLAG_COLDPLUG		= 1 << 1,
 	FU_ENGINE_LOAD_FLAG_REMOTES		= 1 << 2,
 	FU_ENGINE_LOAD_FLAG_HWINFO		= 1 << 3,
+	FU_ENGINE_LOAD_FLAG_NO_CACHE		= 1 << 4,
 	/*< private >*/
 	FU_ENGINE_LOAD_FLAG_LAST
 } FuEngineLoadFlags;

--- a/src/fu-remote-list.h
+++ b/src/fu-remote-list.h
@@ -17,12 +17,14 @@ G_DECLARE_FINAL_TYPE (FuRemoteList, fu_remote_list, FU, REMOTE_LIST, GObject)
  * FuRemoteListLoadFlags:
  * @FU_REMOTE_LIST_LOAD_FLAG_NONE:		No flags set
  * @FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS:	Ignore readonly filesystem errors
+ * @FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE:		Do not save persistent xmlb silos
  *
  * The flags to use when loading a remote_listuration file.
  **/
 typedef enum {
 	FU_REMOTE_LIST_LOAD_FLAG_NONE		= 0,
 	FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS	= 1 << 0,
+	FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE	= 1 << 1,
 	/*< private >*/
 	FU_REMOTE_LIST_LOAD_FLAG_LAST
 } FuRemoteListLoadFlags;


### PR DESCRIPTION
This also speeds up the tests as the amount of pointless i/o is reduced.

Fixes https://github.com/fwupd/fwupd/issues/3522

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
