### PR TITLE
powerd: Adding case for devices that ignore power

### DIFF
--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -86,6 +86,10 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 		return FALSE;
 	}
 
+	/* permit updates when the device does not care about power conditions */
+	if (flags & FWUPD_INSTALL_FLAG_IGNORE_POWER)
+		return TRUE;
+
 	/* parse and use for battery-check conditions */
 	g_variant_get (powerd_response,
 		       "(uud)",


### PR DESCRIPTION
This adds a condition in the power plugin that permits updates for devices that don't take
any power conditions into account.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
