### PR TITLE
Do not assume the metainfo file is NUL-terminated

### DIFF
--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -485,10 +485,10 @@ fu_cabinet_build_silo_file (FuCabinet *self,
 				     "no GBytes from GCabFile");
 		return FALSE;
 	}
-	if (!xb_builder_source_load_xml (source,
-					 g_bytes_get_data (blob, NULL),
-					 XB_BUILDER_SOURCE_FLAG_NONE,
-					 &error_local)) {
+	if (!xb_builder_source_load_bytes (source,
+					   blob,
+					   XB_BUILDER_SOURCE_FLAG_NONE,
+					   &error_local)) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INVALID_FILE,


### PR DESCRIPTION
This was only true by accident. We'll need another fix for the LVFS to
add the missing NUL to restore compatibility for older clients.

Fixes https://github.com/fwupd/fwupd/issues/3533

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
