### PR TITLE
reformat-code.py: add argumentless mode for formatting diffs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,8 @@ from the PackageKit Coding Style.
 * Trailing whitespace is forbidden
 
 * Pointers should be checked for NULL explicitly, e.g. `foo != NULL` not `!foo`
+
+`./contrib/reformat-code.py` can be used in order to get automated
+formatting. Calling the script without arguments formats the current
+patch while passing filenames will do whole-file formatting on the
+specified files.


### PR DESCRIPTION
This is basically implementing `git diff -U0 | clang-format-diff-11 -p1 | sed '/^+/s/g_autoptr (/g_autoptr(/g;/^+/s/sizeof (/sizeof(/g;/^+/s/g_auto (/g_auto{/g' | patch -p0`