### PR TITLE
synaptics-prometheus: Fix enumeration of the config child

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -26,7 +26,7 @@ class Builder:
             "OUT", os.path.realpath(os.path.join(DEFAULT_BUILDDIR, "out"))
         )
         self.srcdir = self._ensure_environ("SRC", os.path.realpath(".."))
-        self.ldflags = ["-lpthread", "-lresolv", "-ldl", "-lffi", "-lz"]
+        self.ldflags = ["-lpthread", "-lresolv", "-ldl", "-lffi", "-lz", "-llzma"]
 
         # defined in env
         self.cflags = ["-Wno-deprecated-declarations"]
@@ -331,6 +331,18 @@ def _build(bld: Builder) -> None:
 
 
 if __name__ == "__main__":
+
+    # install missing deps here rather than patching the Dockerfile in oss-fuzz
+    try:
+        subprocess.check_call(
+            ["apt-get", "install", "-y", "liblzma-dev"], stdout=open(os.devnull, "wb")
+        )
+    except FileNotFoundError:
+        pass
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+        sys.exit(1)
+
     _builder = Builder()
     _build(_builder)
     sys.exit(0)

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -221,10 +221,6 @@ fu_synaprom_device_setup (FuDevice *device, GError **error)
 	    !fu_device_has_flag (device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER) &&
 	    pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR) {
 		g_autoptr(FuSynapromConfig) cfg = fu_synaprom_config_new (self);
-		if (!fu_device_setup (FU_DEVICE (cfg), error)) {
-			g_prefix_error (error, "failed to get config version: ");
-			return FALSE;
-		}
 		fu_device_add_child (FU_DEVICE (device), FU_DEVICE (cfg));
 	}
 


### PR DESCRIPTION
Do not manually call config setup before adding the parent.

The ->setup() action is called on children explicitly in fu_device_setup()
after the parent device has all the required properties.

(Backport from master)
Fixes: https://github.com/fwupd/fwupd/issues/3554

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
