### PR TITLE
trivial: ci: timeout freebsd CI after 20 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
 
   build-freebsd:
     runs-on: macos-latest
+    timeout-minutes: 20
     name: build-freebsd-package
     steps:
     - name: Checkout


### PR DESCRIPTION
There have been a few jobs that were left running an hour pulling
a file, and that shouldn't block us and waste CI minutes.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
