### PR TITLE
powerd: Creating recurring powerd callback

### DIFF
--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -14,61 +14,60 @@ struct FuPluginData {
 };
 
 void
-fu_plugin_init (FuPlugin *plugin)
+fu_plugin_init(FuPlugin *plugin)
 {
-	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
-	fu_plugin_alloc_data (plugin, sizeof(FuPluginData));
+	fu_plugin_set_build_hash(plugin, FU_BUILD_HASH);
+	fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 }
 
 void
-fu_plugin_destroy (FuPlugin *plugin)
+fu_plugin_destroy(FuPlugin *plugin)
 {
-	FuPluginData *data = fu_plugin_get_data (plugin);
+	FuPluginData *data = fu_plugin_get_data(plugin);
 	if (data->proxy != NULL)
-		g_object_unref (data->proxy);
+		g_object_unref(data->proxy);
 }
 
 gboolean
-fu_plugin_startup (FuPlugin *plugin, GError **error)
+fu_plugin_startup(FuPlugin *plugin, GError **error)
 {
-	FuPluginData *data = fu_plugin_get_data (plugin);
+	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *name_owner = NULL;
 
 	/* establish proxy for method call to powerd */
-	data->proxy =
-	    g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
-					   G_DBUS_PROXY_FLAGS_NONE,
-					   NULL,
-					   "org.chromium.PowerManager",
-					   "/org/chromium/PowerManager",
-					   "org.chromium.PowerManager",
-					   NULL,
-					   error);
+	data->proxy = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SYSTEM,
+						    G_DBUS_PROXY_FLAGS_NONE,
+						    NULL,
+						    "org.chromium.PowerManager",
+						    "/org/chromium/PowerManager",
+						    "org.chromium.PowerManager",
+						    NULL,
+						    error);
 
 	if (data->proxy == NULL) {
-		g_prefix_error (error, "failed to establish proxy: ");
+		g_prefix_error(error, "failed to establish proxy: ");
 		return FALSE;
 	}
-	name_owner = g_dbus_proxy_get_name_owner (data->proxy);
+	name_owner = g_dbus_proxy_get_name_owner(data->proxy);
 	if (name_owner == NULL) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_NOT_SUPPORTED,
-			     "no service that owns the name for %s",
-			     g_dbus_proxy_get_name (data->proxy));
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "no service that owns the name for %s",
+			    g_dbus_proxy_get_name(data->proxy));
 		return FALSE;
 	}
 	return TRUE;
 }
 
 gboolean
-fu_plugin_update_prepare (FuPlugin *plugin,
-			  FwupdInstallFlags flags,
-			  FuDevice *device,
-			  GError **error)
+fu_plugin_update_prepare(FuPlugin *plugin,
+			 FwupdInstallFlags flags,
+			 FuDevice *device,
+			 GError **error)
 {
-	FuContext *ctx = fu_plugin_get_context (plugin);
-	FuPluginData *data = fu_plugin_get_data (plugin);
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	FuPluginData *data = fu_plugin_get_data(plugin);
 	guint32 power_type = 0;
 	guint32 current_state = 0;
 	gdouble current_level = 0;
@@ -79,24 +78,20 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 		return TRUE;
 
 	/* making method call to "GetBatteryState" through the proxy */
-	powerd_response = g_dbus_proxy_call_sync (data->proxy,
-						  "GetBatteryState",
-						  NULL,
-						  G_DBUS_CALL_FLAGS_NONE,
-						  -1,
-						  NULL,
-						  error);
+	powerd_response = g_dbus_proxy_call_sync(data->proxy,
+						 "GetBatteryState",
+						 NULL,
+						 G_DBUS_CALL_FLAGS_NONE,
+						 -1,
+						 NULL,
+						 error);
 	if (powerd_response == NULL) {
-		g_prefix_error (error, "battery information was not loaded: ");
+		g_prefix_error(error, "battery information was not loaded: ");
 		return FALSE;
 	}
 
 	/* parse and use for battery-check conditions */
-	g_variant_get (powerd_response,
-		       "(uud)",
-		       &power_type,
-		       &current_state,
-		       &current_level);
+	g_variant_get(powerd_response, "(uud)", &power_type, &current_state, &current_level);
 
 	/* checking if percentage is invalid */
 	if (current_level < 1 || current_level > 100)
@@ -104,24 +99,24 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 
 	/* blocking updates if there is no AC power or if battery
 	 * percentage is too low */
-	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_REQUIRE_AC) &&
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC) &&
 	    current_state == FU_BATTERY_STATE_DISCHARGING) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_AC_POWER_REQUIRED,
-			     "Cannot install update without external power "
-			     "unless forced ");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AC_POWER_REQUIRED,
+			    "Cannot install update without external power "
+			    "unless forced ");
 		return FALSE;
 	}
 	if (fu_context_get_battery_threshold(ctx) != FU_BATTERY_VALUE_INVALID &&
 	    current_level != FU_BATTERY_VALUE_INVALID &&
 	    current_level < fu_context_get_battery_threshold(ctx)) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,
-			     "Cannot install update when system battery "
-			     "is not at least %u%% unless forced",
-			     fu_context_get_battery_threshold (ctx));
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,
+			    "Cannot install update when system battery "
+			    "is not at least %u%% unless forced",
+			    fu_context_get_battery_threshold(ctx));
 		return FALSE;
 	}
 	return TRUE;


### PR DESCRIPTION
This CL moves the battery information retrieval into a new function,
called "fu_plugin_powerd_callback()", which returns the information in a
struct.

This information is then used in fu_plugin_update_prepare() for battery
checks. There is also a g_timeout_add() function being created in
fu_plugin_startup() in order to enable the plugin to repeatedly send a method
call to powerd.

fu_plugin_update_prepare is removed as its functionality is now handled
by src/fu-engine.c

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
