### PR TITLE
Some adjustments to make contrib/reformat-code.py more friendly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
       name: clang-format
       language: script
       entry: ./contrib/reformat-code.py
+      types: [c]
 -   repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,5 +58,5 @@ from the PackageKit Coding Style.
 
 `./contrib/reformat-code.py` can be used in order to get automated
 formatting. Calling the script without arguments formats the current
-patch while passing filenames will do whole-file formatting on the
-specified files.
+patch while passing commits will do formatting on everything changed since that
+commit.

--- a/contrib/reformat-code.py
+++ b/contrib/reformat-code.py
@@ -8,12 +8,27 @@
 import os
 import sys
 import subprocess
+import argparse
 
 CLANG_DIFF_FORMATTERS = [
     "clang-format-diff-11",
     "clang-format-diff-13",
     "clang-format-diff",
 ]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Reformat C code to match project style",
+        epilog="Call with no argument to reformat uncommitted code.",
+    )
+    parser.add_argument(
+        "commit", nargs="*", default="", help="Reformat all changes since this commit"
+    )
+    parser.add_argument(
+        "--debug", action="store_true", help="Display all launched commands"
+    )
+    return parser.parse_args()
 
 
 def select_clang_version(formatters):
@@ -32,28 +47,44 @@ def select_clang_version(formatters):
 
 ## Entry Point ##
 if __name__ == "__main__":
+    args = parse_args()
     base = os.getenv("GITHUB_BASE_REF")
     if base:
         base = "origin/%s" % base
     else:
+        if args.commit:
+            base = args.commit[0]
+        else:
+            base = "HEAD"
+    cmd = ["git", "describe", base]
+    if args.debug:
+        print(cmd)
+    ret = subprocess.run(cmd, capture_output=True)
+    if ret.returncode:
+        if args.debug:
+            print(ret.stderr)
         base = "HEAD"
+    print("Reformatting code against %s" % base)
     formatter = select_clang_version(CLANG_DIFF_FORMATTERS)
-    ret = subprocess.run(
-        ["git", "diff", "-U0", base], capture_output=True, check=True, text=True
-    )
+    cmd = ["git", "diff", "-U0", base]
+    if args.debug:
+        print(cmd)
+    ret = subprocess.run(cmd, capture_output=True, text=True)
     if ret.returncode:
-        print("Failed to run git diff: %s" % ret.stderr)
+        print("Failed to run %s\n%s" % (cmd, ret.stderr.strip()))
         sys.exit(1)
-    ret = subprocess.run(
-        [formatter, "-p1"], input=ret.stdout, capture_output=True, text=True
-    )
+    cmd = [formatter, "-p1"]
+    if args.debug:
+        print(cmd)
+    ret = subprocess.run(cmd, input=ret.stdout, capture_output=True, text=True)
     if ret.returncode:
-        print("Failed to run formatter: %s % ret.stderr")
+        print("Failed to run %s\n%s" % (cmd, ret.stderr.strip()))
         sys.exit(1)
-    ret = subprocess.run(
-        ["patch", "-p0"], input=ret.stdout, capture_output=True, text=True
-    )
+    cmd = ["patch", "-p0"]
+    if args.debug:
+        print(cmd)
+    ret = subprocess.run(cmd, input=ret.stdout, capture_output=True, text=True)
     if ret.returncode:
-        print("Failed to run patch: %s" % ret.stderr)
+        print("Failed to run %s\n%s" % (cmd, ret.stderr.strip()))
         sys.exit(1)
     sys.exit(0)


### PR DESCRIPTION
This should let someone who failed to set it up the first time before they committed easily run it.

Workflow I envision:
1. Person does some cool new feature but forgot to run contrib/setup first.
2. We tell them to fix it up, adjust for pre-commit CI failure
3. They run `./contrib/setup`, but their commit is still unhappy because pre-commit runs "during" commit.
4. They run `./contrib/reformat-code.py master` and their code is reformatted.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
