### PR TITLE
trivial: only build powerd on new enough glib

### DIFF
--- a/plugins/powerd/meson.build
+++ b/plugins/powerd/meson.build
@@ -1,4 +1,4 @@
-if host_machine.system() == 'linux'
+if host_machine.system() == 'linux' and gio.version().version_compare('>=2.58')
   cargs = ['-DG_LOG_DOMAIN="FuPluginPowerd"']
 
 shared_module('fu_plugin_powerd',


### PR DESCRIPTION
snap has an older glib and the plugin fails to compile.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
