### PR TITLE
redfish: Disable the uefi_capsule plugin if coldplug succeeded

### DIFF
--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -36,6 +36,10 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 		FuDevice *device = g_ptr_array_index (devices, i);
 		fu_plugin_device_add (plugin, device);
 	}
+
+	/* this is no longer relevant */
+	if (devices->len > 0)
+		fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "uefi_capsule");
 	return TRUE;
 }
 


### PR DESCRIPTION
We don't want to show the big warning about the missing ESRT on server
hardware that is managed by a BMC:

    WARNING: UEFI capsule updates not available or enabled in firmware setup
      See https://github.com/fwupd/fwupd/wiki/PluginFlag:capsules-unsupported for more information.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
