### PR TITLE
plugin modem-manager: XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY is only available in >=libxmlb-0.2.2

### DIFF
--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -630,7 +630,11 @@ fu_firehose_updater_run_action (FuFirehoseUpdater *self, XbNode *node, guint max
 
 	action = xb_node_get_element (node);
 
+#if LIBXMLB_CHECK_VERSION(0,2,2)
 	cmd_str = xb_node_export (node, XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY, error);
+#else
+	cmd_str = xb_node_export (node, XB_NODE_EXPORT_FLAG_NONE, error);
+#endif
 	if (cmd_str == NULL)
 		return FALSE;
 	cmd_bytearray = g_byte_array_new_take ((guint8 *)cmd_str, strlen (cmd_str));


### PR DESCRIPTION
Closes: https://github.com/fwupd/fwupd/issues/3600

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
