### PR TITLE
dfu: Add support for Poly Studio P21 usb device

### DIFF
--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -414,3 +414,13 @@ RemoveDelay = 90000
 Plugin = dfu
 Flags = manifest-poll
 RemoveDelay = 90000
+
+# Poly Studio P21
+[USB\VID_095D&PID_9298]
+Plugin = dfu
+Flags = manifest-poll
+RemoveDelay = 9000
+[USB\VID_095D&PID_9299]
+Plugin = dfu
+Flags = manifest-poll
+RemoveDelay = 9000


### PR DESCRIPTION
Specify the Flags in dfu.qurik for Poly Studio P21's camera.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
