### PR TITLE
realtek-mst: add support for RTD2141B

### DIFF
--- a/plugins/realtek-mst/realtek-mst.quirk
+++ b/plugins/realtek-mst/realtek-mst.quirk
@@ -7,3 +7,9 @@ Name = RTD2142
 
 [REALTEK-MST\NAME_10EC2142:00&FAMILY_Google_Hatch]
 RealtekMstDpAuxName = DPDDC-C
+
+[REALTEK-MST\NAME_10EC2141:00]
+Name = RTD2141B
+
+[REALTEK-MST\NAME_10EC2141:00&FAMILY_Google_Zork]
+RealtekMstDrmCardKernelName = card0-DP-1


### PR DESCRIPTION
The RTD2141B has the same update protocol as RTD2142, but the Chromebook
targets that use it require us to find the drm_dp_aux_dev i2c channel
differently because the AMD display driver doesn't give each output a
unique name in sysfs like the Intel one does, so it must be found by walking sysfs from the drm
device representing an output (which does have a unique name).

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

cc @djcampello 