### PR TITLE
elantp: Fix a crash when starting the daemon

### DIFF
--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -161,10 +161,6 @@ fu_elantp_hid_device_setup (FuDevice *device, GError **error)
 	g_autofree gchar *version_bl = NULL;
 	g_autofree gchar *version = NULL;
 
-	/* FuUsbDevice->setup */
-	if (!FU_DEVICE_CLASS (fu_elantp_hid_device_parent_class)->setup (device, error))
-		return FALSE;
-
 	/* get pattern */
 	if (!fu_elantp_hid_device_read_cmd (self,
 					    ETP_CMD_I2C_GET_HID_ID,


### PR DESCRIPTION
FuElantpHidDevice derives from FuUdevDevice, not FuUsbDevice -- and the
former does not define a class->setup vfunc.

Fixes https://github.com/fwupd/fwupd/issues/3548

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
