### PR TITLE
redfish: Add a per-vendor quirk to set all devices as requiring a reboot

### DIFF
--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -34,6 +34,8 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	devices = fu_backend_get_devices (FU_BACKEND (data->backend));
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device = g_ptr_array_index (devices, i);
+		if (fu_plugin_has_custom_flag(plugin, "reset-required"))
+			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 		fu_plugin_device_add (plugin, device);
 	}
 

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -40,8 +40,10 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	}
 
 	/* this is no longer relevant */
-	if (devices->len > 0)
+	if (devices->len > 0) {
+		fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "bios");
 		fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "uefi_capsule");
+	}
 	return TRUE;
 }
 

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -72,10 +72,10 @@ fu_redfish_backend_request_new (FuRedfishBackend *self)
 
 	/* since DSP0266 makes Basic Authorization a requirement,
 	* it is safe to use Basic Auth for all implementations */
-	curl_easy_setopt (curl, CURLOPT_HTTPAUTH, (glong) CURLAUTH_BASIC);
-	curl_easy_setopt (curl, CURLOPT_TIMEOUT, (glong) 30);
-	curl_easy_setopt (curl, CURLOPT_USERNAME, self->username);
-	curl_easy_setopt (curl, CURLOPT_PASSWORD, self->password);
+	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BASIC);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)180);
+	curl_easy_setopt(curl, CURLOPT_USERNAME, self->username);
+	curl_easy_setopt(curl, CURLOPT_PASSWORD, self->password);
 
 	/* setup networking */
 	user_agent = g_strdup_printf ("%s/%s", PACKAGE_NAME, PACKAGE_VERSION);

--- a/plugins/redfish/redfish.quirk
+++ b/plugins/redfish/redfish.quirk
@@ -1,6 +1,6 @@
 # Lenovo ThinkSystem
 [42f00735-c9ab-5374-bd63-a5deee5881e0]
-Flags = wildcard-targets
+Flags = wildcard-targets,reset-required
 
 [REDFISH\VENDOR_Lenovo&ID_BMC-Backup]
 ParentGuid = REDFISH\VENDOR_Lenovo&ID_BMC-Primary

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -134,6 +134,8 @@ fu_util_show_plugin_warnings (FuUtilPrivate *priv)
 	plugins = fu_engine_get_plugins (priv->engine);
 	for (guint i = 0; i < plugins->len; i++) {
 		FwupdPlugin *plugin = g_ptr_array_index (plugins, i);
+		if (fwupd_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
+			continue;
 		if (!fwupd_plugin_has_flag (plugin, FWUPD_PLUGIN_FLAG_USER_WARNING))
 			continue;
 		flags |= fwupd_plugin_get_flags (plugin);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3018,6 +3018,8 @@ fu_util_show_plugin_warnings (FuUtilPrivate *priv)
 	/* get a superset so we do not show the same message more than once */
 	for (guint i = 0; i < plugins->len; i++) {
 		FwupdPlugin *plugin = g_ptr_array_index (plugins, i);
+		if (fwupd_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
+			continue;
 		if (!fwupd_plugin_has_flag (plugin, FWUPD_PLUGIN_FLAG_USER_WARNING))
 			continue;
 		flags |= fwupd_plugin_get_flags (plugin);


### PR DESCRIPTION
Some versions of XCC do not send the Base.1.10.ResetRequired message.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
