### PR TITLE
Fix detection of 8Bitdo wireless usb adapter

### DIFF
--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -141,18 +141,24 @@ fu_ebitdo_device_receive (FuEbitdoDevice *self,
 	    hdr->subtype == FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA &&
 	    hdr->cmd == FU_EBITDO_PKT_CMD_FW_GET_VERSION) {
 		if (out != NULL) {
-			if (hdr->payload_len != out_len) {
-				g_set_error (error,
-					     G_IO_ERROR,
-					     G_IO_ERROR_INVALID_DATA,
-					     "outbuf size wrong, expected %" G_GSIZE_FORMAT " got %u",
-					     out_len,
-					     hdr->payload_len);
+			if (hdr->payload_len < out_len) {
+				g_set_error(error,
+					    G_IO_ERROR,
+					    G_IO_ERROR_INVALID_DATA,
+					    "payload too small, expected %" G_GSIZE_FORMAT
+					    " got %u",
+					    out_len,
+					    hdr->payload_len);
 				return FALSE;
 			}
-			if (!fu_memcpy_safe (out, out_len, 0x0,					/* dst */
-					     packet, sizeof(packet), sizeof(FuEbitdoPkt),	/* src */
-					     hdr->payload_len, error))
+			if (!fu_memcpy_safe(out,
+					    out_len,
+					    0x0, /* dst */
+					    packet,
+					    sizeof(packet),
+					    sizeof(FuEbitdoPkt), /* src */
+					    out_len,
+					    error))
 				return FALSE;
 		}
 		return TRUE;


### PR DESCRIPTION
Limits copying the get version response payload to the size of the out buffer.
Devices that return a larger payload pack the necessary version information at the beginning of the payload.

Fixes: #1661

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
