### PR TITLE
Fix cleanup and plugin to have the correct args order

### DIFF
--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -44,10 +44,10 @@ gboolean	 fu_plugin_runner_coldplug_cleanup	(FuPlugin	*self,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_prepare(FuPlugin *self, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_runner_prepare(FuPlugin *self, FuDevice *device, FwupdInstallFlags flags, GError **error)
     G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_cleanup(FuPlugin *self, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_runner_cleanup(FuPlugin *self, FuDevice *device, FwupdInstallFlags flags, GError **error)
     G_GNUC_WARN_UNUSED_RESULT;
 gboolean	 fu_plugin_runner_composite_prepare	(FuPlugin	*self,
 							 GPtrArray	*devices,

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -206,8 +206,8 @@ fu_plugin_detach(FuPlugin *plugin, FuDevice *dev, GError **error);
 /**
  * fu_plugin_prepare:
  * @plugin: a plugin
- * @flags: install flags
  * @dev: a device
+ * @flags: install flags
  * @error: (nullable): optional return location for an error
  *
  * Prepares the device to receive an update.
@@ -215,12 +215,12 @@ fu_plugin_detach(FuPlugin *plugin, FuDevice *dev, GError **error);
  * Since: 1.7.0
  **/
 gboolean
-fu_plugin_prepare(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *dev, GError **error);
+fu_plugin_prepare(FuPlugin *plugin, FuDevice *dev, FwupdInstallFlags flags, GError **error);
 /**
  * fu_plugin_cleanup
  * @plugin: a plugin
- * @flags: install flags
  * @dev: a device
+ * @flags: install flags
  * @error: (nullable): optional return location for an error
  *
  * Cleans up the device after receiving an update.
@@ -228,7 +228,7 @@ fu_plugin_prepare(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *dev, GErr
  * Since: 1.7.0
  **/
 gboolean
-fu_plugin_cleanup(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *dev, GError **error);
+fu_plugin_cleanup(FuPlugin *plugin, FuDevice *dev, FwupdInstallFlags flags, GError **error);
 /**
  * fu_plugin_composite_prepare
  * @plugin: a plugin

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -69,10 +69,10 @@ typedef void		 (*FuPluginDeviceRegisterFunc)	(FuPlugin	*self,
 typedef gboolean	 (*FuPluginDeviceFunc)		(FuPlugin	*self,
 							 FuDevice	*device,
 							 GError		**error);
-typedef gboolean	 (*FuPluginFlaggedDeviceFunc)	(FuPlugin	*self,
-							 FwupdInstallFlags flags,
-							 FuDevice	*device,
-							 GError		**error);
+typedef gboolean (*FuPluginFlaggedDeviceFunc)(FuPlugin *self,
+					      FuDevice *device,
+					      FwupdInstallFlags flags,
+					      GError **error);
 typedef gboolean	 (*FuPluginDeviceArrayFunc)	(FuPlugin	*self,
 							 GPtrArray	*devices,
 							 GError		**error);
@@ -878,9 +878,11 @@ fu_plugin_runner_device_generic (FuPlugin *self, FuDevice *device,
 }
 
 static gboolean
-fu_plugin_runner_flagged_device_generic (FuPlugin *self, FwupdInstallFlags flags,
-					 FuDevice *device,
-					 const gchar *symbol_name, GError **error)
+fu_plugin_runner_flagged_device_generic(FuPlugin *self,
+					FuDevice *device,
+					FwupdInstallFlags flags,
+					const gchar *symbol_name,
+					GError **error)
 {
 	FuPluginPrivate *priv = GET_PRIVATE (self);
 	FuPluginFlaggedDeviceFunc func = NULL;
@@ -899,7 +901,7 @@ fu_plugin_runner_flagged_device_generic (FuPlugin *self, FwupdInstallFlags flags
 	if (func == NULL)
 		return TRUE;
 	g_debug ("%s(%s)", symbol_name + 10, fu_plugin_get_name (self));
-	if (!func (self, flags, device, &error_local)) {
+	if (!func(self, device, flags, &error_local)) {
 		if (error_local == NULL) {
 			g_critical ("unset plugin error in %s(%s)",
 				    fu_plugin_get_name (self), symbol_name + 10);
@@ -1156,11 +1158,11 @@ fu_plugin_runner_composite_cleanup (FuPlugin *self, GPtrArray *devices, GError *
  * Since: 1.7.0
  **/
 gboolean
-fu_plugin_runner_prepare(FuPlugin *self, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_runner_prepare(FuPlugin *self, FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
 	return fu_plugin_runner_flagged_device_generic(self,
-						       flags,
 						       device,
+						       flags,
 						       "fu_plugin_prepare",
 						       error);
 }
@@ -1179,11 +1181,11 @@ fu_plugin_runner_prepare(FuPlugin *self, FwupdInstallFlags flags, FuDevice *devi
  * Since: 1.7.0
  **/
 gboolean
-fu_plugin_runner_cleanup(FuPlugin *self, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_runner_cleanup(FuPlugin *self, FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
 	return fu_plugin_runner_flagged_device_generic(self,
-						       flags,
 						       device,
+						       flags,
 						       "fu_plugin_cleanup",
 						       error);
 }

--- a/plugins/jabra/fu-plugin-jabra.c
+++ b/plugins/jabra/fu-plugin-jabra.c
@@ -22,7 +22,7 @@ fu_plugin_init (FuPlugin *plugin)
 /* slightly weirdly, this takes us from appIDLE back into the actual
  * runtime mode where the device actually works */
 gboolean
-fu_plugin_cleanup(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_cleanup(FuPlugin *plugin, FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
 	GUsbDevice *usb_device;
 	g_autoptr(FuDeviceLocker) locker = NULL;

--- a/plugins/logind/fu-plugin-logind.c
+++ b/plugins/logind/fu-plugin-logind.c
@@ -65,7 +65,7 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 }
 
 gboolean
-fu_plugin_prepare(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_prepare(FuPlugin *plugin, FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	g_autoptr(GError) error_local = NULL;
@@ -114,7 +114,7 @@ fu_plugin_prepare(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *device, G
 }
 
 gboolean
-fu_plugin_cleanup(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *device, GError **error)
+fu_plugin_cleanup(FuPlugin *plugin, FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	if (data->logind_fd == 0)

--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -141,13 +141,13 @@ fu_plugin_startup(FuPlugin *plugin, GError **error)
 }
 
 gboolean
-fu_plugin_prepare(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *dev, GError **error)
+fu_plugin_prepare(FuPlugin *plugin, FuDevice *dev, FwupdInstallFlags flags, GError **error)
 {
 	return fu_plugin_powerd_create_suspend_file(error);
 }
 
 gboolean
-fu_plugin_cleanup(FuPlugin *plugin, FwupdInstallFlags flags, FuDevice *dev, GError **error)
+fu_plugin_cleanup(FuPlugin *plugin, FuDevice *dev, FwupdInstallFlags flags, GError **error)
 {
 	return fu_plugin_powerd_delete_suspend_file(error);
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2637,7 +2637,7 @@ fu_engine_install (FuEngine *self,
 		}
 		plugin = fu_plugin_list_find_by_name (self->plugin_list, "upower", NULL);
 		if (plugin != NULL) {
-			if (!fu_plugin_runner_prepare(plugin, flags, device, error))
+			if (!fu_plugin_runner_prepare(plugin, device, flags, error))
 				return FALSE;
 		}
 		release_tmp = fu_engine_create_release_metadata (self, device, plugin, error);
@@ -2858,7 +2858,7 @@ fu_engine_prepare(FuEngine *self, FwupdInstallFlags flags, const gchar *device_i
 		return FALSE;
 	for (guint j = 0; j < plugins->len; j++) {
 		FuPlugin *plugin_tmp = g_ptr_array_index (plugins, j);
-		if (!fu_plugin_runner_prepare(plugin_tmp, flags, device, error))
+		if (!fu_plugin_runner_prepare(plugin_tmp, device, flags, error))
 			return FALSE;
 	}
 
@@ -2887,7 +2887,7 @@ fu_engine_cleanup(FuEngine *self, FwupdInstallFlags flags, const gchar *device_i
 		return FALSE;
 	for (guint j = 0; j < plugins->len; j++) {
 		FuPlugin *plugin_tmp = g_ptr_array_index (plugins, j);
-		if (!fu_plugin_runner_cleanup(plugin_tmp, flags, device, error))
+		if (!fu_plugin_runner_cleanup(plugin_tmp, device, flags, error))
 			return FALSE;
 	}
 


### PR DESCRIPTION
All the other vfuncs have 'plugin, device, flags' but prepare and
cleanup vfuncs being 'plugin, flags, device' order has been triggering
my OCD for the last few years.

We've just broken the symbol names, so it's the right time to fix this.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
