### PR TITLE
vli: VL819 into quirk

### DIFF
--- a/plugins/vli/vli-usbhub.quirk
+++ b/plugins/vli/vli-usbhub.quirk
@@ -48,12 +48,32 @@ Plugin = vli
 GType = FuVliUsbhubDevice
 Flags = usb2
 
+# VL819
+[USB\VID_2109&PID_0819]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb3
+[USB\VID_2109&PID_2819]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2
+
 # VL820
 [USB\VID_2109&PID_0820]
 Plugin = vli
 GType = FuVliUsbhubDevice
 Flags = usb3,has-shared-spi-pd
 [USB\VID_2109&PID_2820]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2,has-shared-spi-pd
+
+# VL822
+[USB\VID_2109&PID_0822]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb3,has-shared-spi-pd
+[USB\VID_2109&PID_2822]
 Plugin = vli
 GType = FuVliUsbhubDevice
 Flags = usb2,has-shared-spi-pd


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Thank you Mario, for bringing ./contrib/reformat-code.py to our attention. We were not aware a clang format script had been made. Much help!

Added VL819 and VL822 to vli-usbhub quirk file. We're not sure if our local fwupdmgr get-device is having cocktails with edit distance one but we'll attach our output for your viewing pleasure just in case...
![usb2_usb3](https://user-images.githubusercontent.com/5896872/129321740-c7375926-f172-41cd-aa8d-444a673ff53e.png)
