### PR TITLE
dfu: Introduct a quirk to allow zero polltimeout in dfuDNLOAD.

### DIFF
--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -338,89 +338,89 @@ DfuForceTimeout = 5000
 # Poly Studio
 [USB\VID_095D&PID_9217]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout
 RemoveDelay = 60000
 [USB\VID_095D&PID_9218]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout
 RemoveDelay = 60000
 
 # Poly Eagle Eye Cube
 [USB\VID_095D&PID_9212]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 30000
 [USB\VID_095D&PID_9213]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 30000
 
 # Poly Studio P15
 [USB\VID_095D&PID_9290]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 60000
 [USB\VID_095D&PID_9291]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 60000
 
 # Poly ULCC
 [USB\VID_095D&PID_9160]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout
 RemoveDelay = 60000
 [USB\VID_095D&PID_927B]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout
 RemoveDelay = 60000
 
 # Poly Eagle Eye Mini
 [USB\VID_095D&PID_3001]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 [USB\VID_095D&PID_3002]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 
 # Poly Studio R30
 [USB\VID_095D&PID_92B2]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 60000
 [USB\VID_095D&PID_92B3]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 60000
 
 # Poly Studio P5
 [USB\VID_095D&PID_9296]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 [USB\VID_095D&PID_9297]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 
 # Poly Studio E70
 [USB\VID_095D&PID_92A1]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 90000
 [USB\VID_095D&PID_92A2]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 90000
 
 # Poly Studio P21
 [USB\VID_095D&PID_9298]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 [USB\VID_095D&PID_9299]
 Plugin = dfu
-Flags = manifest-poll
+Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000

--- a/plugins/dfu/fu-dfu-common.h
+++ b/plugins/dfu/fu-dfu-common.h
@@ -214,6 +214,12 @@ typedef enum {
  * Uses the slightly weird GD32 variant of DFU.
  */
 #define FU_DFU_DEVICE_FLAG_GD32					(1 << 17)
+/**
+ * FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT:
+ *
+ * Allows the zero bwPollTimeout from GetStatus in dfuDNLOAD-SYNC state.
+ */
+#define FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT (1 << 18)
 
 const gchar	*fu_dfu_state_to_string			(FuDfuState	 state);
 const gchar	*fu_dfu_status_to_string		(FuDfuStatus	 status);

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -890,7 +890,9 @@ fu_dfu_device_refresh (FuDfuDevice *self, GError **error)
 		priv->dnload_timeout = buf[1] +
 					(((guint32) buf[2]) << 8) +
 					(((guint32) buf[3]) << 16);
-		if (priv->dnload_timeout == 0) {
+		if (priv->dnload_timeout == 0 &&
+		    !fu_device_has_private_flag(FU_DEVICE(self),
+						FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT)) {
 			priv->dnload_timeout = DFU_DEVICE_DNLOAD_TIMEOUT_DEFAULT;
 			g_debug ("no dnload-timeout, using default of %ums",
 				 priv->dnload_timeout);
@@ -1965,4 +1967,7 @@ fu_dfu_device_init (FuDfuDevice *self)
 	fu_device_register_private_flag (FU_DEVICE (self),
 					 FU_DFU_DEVICE_FLAG_GD32,
 					 "gd32");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT,
+					"allow-zero-polltimeout");
 }


### PR DESCRIPTION
Some Poly usb devices report zero in the bwPollTimeout field of
GET_STATUS request. The host can issue the next DFU_DNLOAD
request immediately without any delay.

Introduced a private flag to skip the default DNLOAD timeout
(5ms) fix. It could remarkably reduce the firmware downloading
time taking into account the large firmware (more than 500MB).

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
