### PR TITLE
FreeBSD CI fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,5 +109,5 @@ jobs:
       with:
         name: Binary package
         path: |
-          fwupd*.txz
+          fwupd*.pkg
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,38 @@ jobs:
       with:
         name: artifacts
         path: ./out/artifacts
+
+  build-freebsd:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    name: build-freebsd-package
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Find tag
+      id: tagger
+      uses: jimschubert/query-tag-action@v1
+    - name: Build
+      id: test
+      uses: vmactions/freebsd-vm@v0.1.4
+      with:
+        usesh: true
+        mem: 8192
+        prepare: |
+          pkg install -y git python3 glib meson pkgconf gobject-introspection \
+            vala gtk-doc json-glib gpgme gnutls sqlite3 curl gcab libarchive \
+            libelf libgpg-error gettext-tools gtk-update-icon-cache atk pango \
+            binutils gcc
+        sync: rsync
+        run: ./contrib/ci/build_freebsd_package.sh
+          --GITHUB_SHA=${GITHUB_SHA}
+          --GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}
+          --GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+          --GITHUB_TAG=${{steps.tagger.outputs.tag}}
+    - name: Upload fwupd binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Binary package
+        path: |
+          fwupd*.txz
+

--- a/contrib/ci/build_freebsd_package.sh
+++ b/contrib/ci/build_freebsd_package.sh
@@ -61,5 +61,5 @@ make makeplist > plist
 sed -i "" "1d" plist
 make package
 make install
-cp /usr/ports/sysutils/fwupd/work/pkg/fwupd*.txz \
-~/work/fwupd/fwupd/fwupd-freebsd-${GITHUB_TAG}-${GITHUB_SHA}.txz || exit 1
+cp /usr/ports/sysutils/fwupd/work/pkg/fwupd*.pkg \
+~/work/fwupd/fwupd/fwupd-freebsd-${GITHUB_TAG}-${GITHUB_SHA}.pkg || exit 1

--- a/contrib/ci/build_freebsd_package.sh
+++ b/contrib/ci/build_freebsd_package.sh
@@ -39,6 +39,7 @@ set -xe
 mkdir -p /usr/local/etc/pkg/repos/
 # Fix meson flag problem https://www.mail-archive.com/freebsd-ports@freebsd.org/msg86617.html
 cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
+# Use latest pkg repo instead of quaterly https://wiki.freebsd.org/Ports/QuarterlyBranch
 sed -i .old 's|url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly"|url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest"|' \
 /usr/local/etc/pkg/repos/FreeBSD.conf
 pkg install -y meson efivar
@@ -57,8 +58,12 @@ sed -i .old "s/DISTVERSION=.*$/DISTVERSION=\t${GITHUB_TAG}/" Makefile
 make makesum
 make clean
 make
-make makeplist > plist
-sed -i "" "1d" plist
+# Generate current list of files in the pkg-plist
+make makeplist > pkg-plist
+sed -i "" "1d" pkg-plist
+sed -i "" "s/%%PORTDOCS%%%%DOCSDIR%%/%%DOCSDIR%%/g" pkg-plist
+# Build artifact
+make clean
 make package
 make install
 cp /usr/ports/sysutils/fwupd/work/pkg/fwupd*.pkg \


### PR DESCRIPTION
The changes fix two problems:
* The extension of the generated artifact is `.pkg`, not `.txz` 
* The generated `pkg-plist` was not taken into account during the package build
The build must be cleaned when the new `pkg-plist` appears. Build system creates stage directories based on the `pkg-plist`, which are used to create the package. 

PR fixes https://github.com/fwupd/fwupd/pull/3578.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
