### PR TITLE
trivial: fix a compilation dependency error (Fixes: #3657)

### DIFF
--- a/plugins/tpm-eventlog/meson.build
+++ b/plugins/tpm-eventlog/meson.build
@@ -60,6 +60,7 @@ endif
 
 fwupdtpmevlog = executable(
   'fwupdtpmevlog',
+  fu_hash,
   sources : [
     'fu-tpm-eventlog.c',
     'fu-tpm-eventlog-common.c',


### PR DESCRIPTION
Reproducible by manually calling failing build targets first
```
ninja -C build plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o
ninja: Entering directory `build'
[1/1] Compiling C object plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o
FAILED: plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o
cc -Iplugins/tpm-eventlog/fwupdtpmevlog.p -Iplugins/tpm-eventlog -I../plugins/tpm-eventlog -I. -I.. -Ilibfwupd -I../libfwupd -Ilibfwupdplugin -I../libfwupdplugin -I/usr/include/libxmlb-1 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/gudev-1.0 -I/usr/include/json-glib-1.0 -I/usr/include/gusb-1 -I/usr/include/libusb-1.0 -I/usr/include/tss2 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -g -Waggregate-return -Wunused -Warray-bounds -Wcast-align -Wclobbered -Wdeclaration-after-statement -Wdiscarded-qualifiers -Wduplicated-branches -Wduplicated-cond -Wempty-body -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-signedness -Wignored-qualifiers -Wimplicit-function-declaration -Winit-self -Wlogical-op -Wmaybe-uninitialized -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-cast-function-type -Wno-address-of-packed-member -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-suggest-attribute=format -Wno-unused-parameter -Wold-style-definition -Woverride-init -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing -Wstrict-prototypes -Wswitch-default -Wtype-limits -Wundef -Wuninitialized -Wunused-but-set-variable -Wunused-variable -Wvla -Wwrite-strings -fstack-protector-strong -DFWUPD_COMPILATION -D_DEFAULT_SOURCE -DFWUPD_DISABLE_DEPRECATED -D_BSD_SOURCE -D__BSD_VISIBLE -D_XOPEN_SOURCE=700 -D_GNU_SOURCE -pthread -MD -MQ plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o -MF plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o.d -o plugins/tpm-eventlog/fwupdtpmevlog.p/fu-tpm-eventlog-common.c.o -c ../plugins/tpm-eventlog/fu-tpm-eventlog-common.c
In file included from ../libfwupdplugin/fwupdplugin.h:33,
                 from ../plugins/tpm-eventlog/fu-tpm-eventlog-common.h:9,
                 from ../plugins/tpm-eventlog/fu-tpm-eventlog-common.c:9:
../libfwupdplugin/fu-plugin-vfuncs.h:17:10: fatal error: fu-hash.h: No such file or directory
   17 | #include "fu-hash.h"
      |          ^~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.

```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
