### PR TITLE
dfu: add quirks for AVer ATLAS CAM/CAM520 Pro2

### DIFF
--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -424,3 +424,15 @@ RemoveDelay = 9000
 Plugin = dfu
 Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
+
+# AVer ATLAS CAM
+[DeviceInstanceId=USB\VID_2574&PID_0A70]
+Plugin = dfu
+Flags = detach-for-attach
+RemoveDelay = 60000
+
+# AVer CAM520 Pro2
+[DeviceInstanceId=USB\VID_2574&PID_0A30]
+Plugin = dfu
+Flags = detach-for-attach
+RemoveDelay = 180000

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -426,13 +426,13 @@ Flags = manifest-poll,allow-zero-polltimeout
 RemoveDelay = 9000
 
 # AVer ATLAS CAM
-[DeviceInstanceId=USB\VID_2574&PID_0A70]
+[USB\VID_2574&PID_0A70]
 Plugin = dfu
 Flags = detach-for-attach
 RemoveDelay = 60000
 
 # AVer CAM520 Pro2
-[DeviceInstanceId=USB\VID_2574&PID_0A30]
+[USB\VID_2574&PID_0A30]
 Plugin = dfu
 Flags = detach-for-attach
 RemoveDelay = 180000


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Add VID (AVer) & PID (ATLAS CAM / CAM520 Pro2) in dfu qurik