### PR TITLE
trivial: make gi-docgen a host dependency on cross

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -555,6 +555,7 @@ elif get_option('docs') == 'docgen'
   endif
   gidocgen_dep = dependency('gi-docgen',
     version: '>= 2021.1',
+    native: true,
     fallback: ['gi-docgen', 'dummy_dep'],
   )
   gidocgen = find_program('gi-docgen')


### PR DESCRIPTION
this patch makes meson look for gi-docgen on the host system instead in cross paths

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
