### PR TITLE
dell-dock: add device GUID earlier even setup yet done

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-common.h
+++ b/plugins/dell-dock/fu-dell-dock-common.h
@@ -27,9 +27,12 @@
 #include "fu-dell-dock-status.h"
 #include "fu-dell-dock-usb-usb4.h"
 
-#define DELL_DOCK_EC_INSTANCE_ID   "USB\\VID_413C&PID_B06E&hub&embedded"
-#define DELL_DOCK_TBT_INSTANCE_ID  "TBT-00d4b070"
-#define DELL_DOCK_USB4_INSTANCE_ID "TBT-00d4b071"
+#define DELL_DOCK_DOCK1_INSTANCE_ID  "USB\\VID_413C&PID_B06E&hub&status"
+#define DELL_DOCK_DOCK2_INSTANCE_ID  "USB\\VID_413C&PID_B06E&hub&salomon_mlk_status"
+#define DELL_DOCK_EC_INSTANCE_ID     "USB\\VID_413C&PID_B06E&hub&embedded"
+#define DELL_DOCK_TBT_INSTANCE_ID    "TBT-00d4b070"
+#define DELL_DOCK_USB4_INSTANCE_ID   "TBT-00d4b071"
+#define DELL_DOCK_VM5331_INSTANCE_ID "MST-panamera-vmm5331-259"
 #define GR_USB_VID		   0x8087
 #define GR_USB_PID		   0x0B40
 

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -66,6 +66,7 @@ fu_plugin_dell_dock_probe(FuPlugin *plugin, FuDevice *proxy, GError **error)
 	g_autoptr(FuDellDockEc) ec_device = NULL;
 	g_autoptr(FuDellDockMst) mst_device = NULL;
 	g_autoptr(FuDellDockStatus) status_device = NULL;
+	FuContext *ctx = fu_plugin_get_context(plugin);
 
 	/* create ec endpoint */
 	ec_device = fu_dell_dock_ec_new(proxy);
@@ -74,17 +75,22 @@ fu_plugin_dell_dock_probe(FuPlugin *plugin, FuDevice *proxy, GError **error)
 
 	/* create mst endpoint */
 	mst_device = fu_dell_dock_mst_new();
+	instance = DELL_DOCK_VM5331_INSTANCE_ID;
+	fu_device_set_context(FU_DEVICE(mst_device), ctx);
+	fu_device_add_guid(FU_DEVICE(mst_device), fwupd_guid_hash_string(instance));
 	fu_device_add_child(FU_DEVICE(ec_device), FU_DEVICE(mst_device));
-	fu_device_add_instance_id(FU_DEVICE(mst_device), "MST-panamera-vmm5331-259");
+	fu_device_add_instance_id(FU_DEVICE(mst_device), instance);
 	if (!fu_plugin_dell_dock_create_node(plugin, FU_DEVICE(mst_device), error))
 		return FALSE;
 
 	/* create package version endpoint */
 	status_device = fu_dell_dock_status_new();
 	if (fu_dell_dock_module_is_usb4(FU_DEVICE(ec_device)))
-		instance = "USB\\VID_413C&PID_B06E&hub&salomon_mlk_status";
+		instance = DELL_DOCK_DOCK2_INSTANCE_ID;
 	else
-		instance = "USB\\VID_413C&PID_B06E&hub&status";
+		instance = DELL_DOCK_DOCK1_INSTANCE_ID;
+	fu_device_set_context(FU_DEVICE(status_device), ctx);
+	fu_device_add_guid(FU_DEVICE(status_device), fwupd_guid_hash_string(instance));
 	fu_device_add_child(FU_DEVICE(ec_device), FU_DEVICE(status_device));
 	fu_device_add_instance_id(FU_DEVICE(status_device), instance);
 	if (!fu_plugin_dell_dock_create_node(plugin, FU_DEVICE(status_device), error))


### PR DESCRIPTION
This commit resolves a warning message at runtime:
- no GUIDs for device ...

fu_device_add_child emits a child-added signal afterwards the engine
try to add given device and verify whether GUIDs is set.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
