### PR TITLE
dell-dock: cleanup needs to handle activation between devices in dock

### DIFF
--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -161,6 +161,34 @@ fu_plugin_backend_device_added(FuPlugin *plugin, FuDevice *device, GError **erro
 	return TRUE;
 }
 
+static void
+fu_plugin_dell_dock_separate_activation(FuPlugin *plugin)
+{
+	GPtrArray *devices = fu_plugin_get_devices(plugin);
+	FuDevice *device_ec = NULL;
+	FuDevice *device_usb4 = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	for (guint i = 0; i < devices->len; i++) {
+		FuDevice *device_tmp = g_ptr_array_index(devices, i);
+		if (FU_IS_DELL_DOCK_EC(device_tmp))
+			device_ec = device_tmp;
+		else if (FU_IS_DELL_DOCK_USB4(device_tmp))
+			device_usb4 = device_tmp;
+	}
+	/* both usb4 and ec device are found */
+	if (device_usb4 && device_ec) {
+		if (fu_device_has_flag(device_usb4, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION) &&
+		    fu_device_has_flag(device_ec, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
+			fu_device_remove_flag(FU_DEVICE(device_ec),
+					      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+			g_debug("activate for %s is inhibited by %s",
+				fu_device_get_name(device_ec),
+				fu_device_get_name(device_usb4));
+		}
+	}
+}
+
 void
 fu_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 {
@@ -176,35 +204,8 @@ fu_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 
 	/* online activation is mutually exclusive between usb4 and ec */
 	if (g_strcmp0(fu_device_get_plugin(device), "dell_dock") == 0 &&
-	    (FU_IS_DELL_DOCK_EC(device) || FU_IS_DELL_DOCK_USB4(device))) {
-		GPtrArray *devices = fu_plugin_get_devices(plugin);
-		FuDevice *device_ec = NULL;
-		FuDevice *device_usb4 = NULL;
-		for (guint i = 0; i < devices->len; i++) {
-			FuDevice *device_tmp = g_ptr_array_index(devices, i);
-			if (FU_IS_DELL_DOCK_EC(device_tmp))
-				device_ec = device_tmp;
-			else if (FU_IS_DELL_DOCK_USB4(device_tmp))
-				device_usb4 = device_tmp;
-		}
-		/* both usb4 and ec device are found */
-		if (device_usb4 && device_ec) {
-			if (fu_device_has_flag(device_usb4, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION) &&
-			    fu_device_has_flag(device_ec, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
-				fu_device_remove_flag(FU_DEVICE(device_ec),
-						      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-				g_debug("activate for %s is inhibited by %s",
-					fu_device_get_name(device_ec),
-					fu_device_get_name(device_usb4));
-			} else if (fu_device_has_flag(device_usb4,
-						      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
-				fu_device_remove_flag(FU_DEVICE(device_usb4),
-						      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-				g_debug("activate for %s is invalid",
-					fu_device_get_name(device_usb4));
-			}
-		}
-	}
+	    (FU_IS_DELL_DOCK_EC(device) || FU_IS_DELL_DOCK_USB4(device)))
+		fu_plugin_dell_dock_separate_activation(plugin);
 
 	if (g_strcmp0(fu_device_get_plugin(device), "thunderbolt") != 0 ||
 	    fu_device_has_flag(device, FWUPD_DEVICE_FLAG_INTERNAL))
@@ -296,6 +297,8 @@ fu_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GError **error
 			}
 		}
 	}
+	/* separate activation flag between usb4 and ec device */
+	fu_plugin_dell_dock_separate_activation(plugin);
 
 	locker = fu_device_locker_new(parent, error);
 	if (locker == NULL)


### PR DESCRIPTION
Not only _registered but also _cleanup needs to separate the activation, for it to work in daemon.


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
