### PR TITLE
Allow using a per-device global percentage completion

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -146,6 +146,7 @@ and then calls the vfuncs to update the device.
     fu_plugin_write_firmware (FuPlugin *plugin,
                       FuDevice *dev,
                       GBytes *blob_fw,
+                      FuProgress *progress,
                       FwupdInstallFlags flags,
                       GError **error)
     {
@@ -212,19 +213,19 @@ handle the device ID, although the registered plugin can change during the
 attach and detach phases.
 
     gboolean
-    fu_plugin_detach (FuPlugin *plugin, FuDevice *device, GError **error)
+    fu_plugin_detach (FuPlugin *plugin, FuDevice *device, FuProgress *progress, GError **error)
     {
         if (hardware_in_bootloader)
             return TRUE;
-        return _device_detach(device, error);
+        return _device_detach(device, progress, error);
     }
 
     gboolean
-    fu_plugin_attach (FuPlugin *plugin, FuDevice *device, GError **error)
+    fu_plugin_attach (FuPlugin *plugin, FuDevice *device, FuProgress *progress, GError **error)
     {
         if (!hardware_in_bootloader)
             return TRUE;
-        return _device_attach(device, error);
+        return _device_attach(device, progress, error);
     }
 
     gboolean

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -18,6 +18,12 @@ Remember: Plugins should be upstream!
 * Migrate from fu_device_get_protocol() to fu_device_get_protocols() and fu_device_set_protocol() to fu_device_add_protocol()
 * Migrate from fu_device_has_custom_flag() to fu_device_has_private_flag()
 * Migrate from fu_udev_device_set_readonly() to fu_udev_device_set_flags()
+* Migrate from fu_device_sleep_with_progress() to fu_progress_sleep() -- but be aware the unit of time has changed from *seconds* to *milliseconds*
+* Migrate from fu_device_get_status() to fu_progress_get_status()
+* Migrate from fu_device_set_status() to fu_progress_set_status()
+* Migrate from fu_device_get_progress() to fu_progress_get_percentage()
+* Migrate from fu_device_set_progress_full() to fu_progress_set_percentage_full()
+* Migrate from fu_device_set_progress() to fu_progress_set_steps(), fu_progress_add_step() and fu_progress_done -- see the FuProgress docs for more details!
 
 ## Planned API/ABI changes for next release
 

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -50,3 +50,5 @@ guint64
 fu_device_get_private_flags(FuDevice *self);
 void
 fu_device_set_private_flags(FuDevice *self, guint64 flag);
+void
+fu_device_set_progress(FuDevice *self, FuProgress *progress);

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -57,9 +57,11 @@ fu_plugin_runner_composite_cleanup(FuPlugin *self,
 				   GPtrArray *devices,
 				   GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_attach(FuPlugin *self, FuDevice *device, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_plugin_runner_attach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_detach(FuPlugin *self, FuDevice *device, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_plugin_runner_detach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fu_plugin_runner_reload(FuPlugin *self, FuDevice *device, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
@@ -84,13 +86,17 @@ gboolean
 fu_plugin_runner_write_firmware(FuPlugin *self,
 				FuDevice *device,
 				GBytes *blob_fw,
+				FuProgress *progress,
 				FwupdInstallFlags flags,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_verify(FuPlugin *self, FuDevice *device, FuPluginVerifyFlags flags, GError **error)
-    G_GNUC_WARN_UNUSED_RESULT;
+fu_plugin_runner_verify(FuPlugin *self,
+			FuDevice *device,
+			FuProgress *progress,
+			FuPluginVerifyFlags flags,
+			GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_activate(FuPlugin *self, FuDevice *device, GError **error);
+fu_plugin_runner_activate(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error);
 gboolean
 fu_plugin_runner_unlock(FuPlugin *self, FuDevice *device, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean

--- a/libfwupdplugin/fu-plugin-vfuncs.h
+++ b/libfwupdplugin/fu-plugin-vfuncs.h
@@ -98,6 +98,7 @@ fu_plugin_coldplug_cleanup(FuPlugin *plugin, GError **error);
  * @plugin: a plugin
  * @dev: a device
  * @blob_fw: a data blob
+ * @progress: a #FuProgress
  * @flags: install flags
  * @error: (nullable): optional return location for an error
  *
@@ -109,6 +110,7 @@ gboolean
 fu_plugin_write_firmware(FuPlugin *plugin,
 			 FuDevice *dev,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error);
 /**
@@ -150,7 +152,7 @@ fu_plugin_unlock(FuPlugin *plugin, FuDevice *dev, GError **error);
  * Since: 1.2.6
  **/
 gboolean
-fu_plugin_activate(FuPlugin *plugin, FuDevice *dev, GError **error);
+fu_plugin_activate(FuPlugin *plugin, FuDevice *dev, FuProgress *progress, GError **error);
 /**
  * fu_plugin_clear_results:
  * @plugin: a plugin
@@ -186,7 +188,7 @@ fu_plugin_get_results(FuPlugin *plugin, FuDevice *dev, GError **error);
  * Since: 1.0.2
  **/
 gboolean
-fu_plugin_attach(FuPlugin *plugin, FuDevice *dev, GError **error);
+fu_plugin_attach(FuPlugin *plugin, FuDevice *dev, FuProgress *progress, GError **error);
 /**
  * fu_plugin_detach:
  * @plugin: a plugin
@@ -198,7 +200,7 @@ fu_plugin_attach(FuPlugin *plugin, FuDevice *dev, GError **error);
  * Since: 1.7.0
  **/
 gboolean
-fu_plugin_detach(FuPlugin *plugin, FuDevice *dev, GError **error);
+fu_plugin_detach(FuPlugin *plugin, FuDevice *dev, FuProgress *progress, GError **error);
 /**
  * fu_plugin_prepare:
  * @plugin: a plugin

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -1,0 +1,921 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuProgress"
+
+#include "config.h"
+
+#include <math.h>
+
+#include "fu-progress.h"
+
+/**
+ * FuProgress:
+ *
+ * Objects can use fu_progress_set_percentage() if the absolute percentage
+ * is known. Percentages should always go up, not down.
+ *
+ * Modules usually set the number of steps that are expected using
+ * fu_progress_set_steps() and then after each section is completed,
+ * the fu_progress_step_done() function should be called. This will automatically
+ * call fu_progress_set_percentage() with the correct values.
+ *
+ * #FuProgress allows sub-modules to be "chained up" to the parent module
+ * so that as the sub-module progresses, so does the parent.
+ * The child can be reused for each section, and chains can be deep.
+ *
+ * To get a child object, you should use fu_progress_get_child() and then
+ * use the result in any sub-process. You should ensure that the child
+ * is not re-used without calling fu_progress_step_done().
+ *
+ * There are a few nice touches in this module, so that if a module only has
+ * one progress step, the child progress is used for parent updates.
+ *
+ *    static void
+ *    _do_something(FuProgress *self)
+ *    {
+ *       // setup correct number of steps
+ *       fu_progress_set_steps(self, 2);
+ *
+ *       // run a sub function
+ *       _do_something_else1(fu_progress_get_child(self));
+ *
+ *       // this section done
+ *       fu_progress_step_done(self);
+ *
+ *       // run another sub function
+ *       _do_something_else2(fu_progress_get_child(self));
+ *
+ *       // this progress done (all complete)
+ *       fu_progress_step_done(self);
+ *    }
+ *
+ * See also: [class@FuDevice]
+ */
+
+typedef struct {
+	gchar *id;
+	FuProgressFlags flags;
+	guint percentage;
+	FwupdStatus status;
+	GPtrArray *steps;
+	gboolean profile;
+	GTimer *timer;
+	guint step_now;
+	guint step_max;
+	gulong percentage_child_id;
+	gulong status_child_id;
+	FuProgress *child;
+	FuProgress *parent; /* no-ref */
+} FuProgressPrivate;
+
+typedef struct {
+	FwupdStatus status;
+	guint value;
+	gdouble profile;
+} FuProgressStep;
+
+enum { SIGNAL_PERCENTAGE_CHANGED, SIGNAL_STATUS_CHANGED, SIGNAL_LAST };
+
+static guint signals[SIGNAL_LAST] = {0};
+
+G_DEFINE_TYPE_WITH_PRIVATE(FuProgress, fu_progress, G_TYPE_OBJECT)
+#define GET_PRIVATE(o) (fu_progress_get_instance_private(o))
+
+/**
+ * fu_progress_get_id:
+ * @self: a #FuProgress
+ *
+ * Return the id of the progress, which is normally set by the caller.
+ *
+ * Returns: progress ID
+ *
+ * Since: 1.7.0
+ **/
+const gchar *
+fu_progress_get_id(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), NULL);
+	return priv->id;
+}
+
+/**
+ * fu_progress_set_id:
+ * @self: a #FuProgress
+ * @id: progress ID, normally `G_STRLOC`
+ *
+ * Sets the id of the progress.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_id(FuProgress *self, const gchar *id)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(id != NULL);
+
+	/* not changed */
+	if (g_strcmp0(priv->id, id) == 0)
+		return;
+
+	/* set id */
+	g_free(priv->id);
+	priv->id = g_strdup(id);
+}
+
+/**
+ * fu_progress_get_status:
+ * @self: a #FuProgress
+ *
+ * Return the status of the progress, which is normally indirectly by fu_progress_add_step().
+ *
+ * Returns: status
+ *
+ * Since: 1.7.0
+ **/
+FwupdStatus
+fu_progress_get_status(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), FWUPD_STATUS_UNKNOWN);
+	return priv->status;
+}
+
+/**
+ * fu_progress_flag_to_string:
+ * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
+ *
+ * Converts an progress flag to a string.
+ *
+ * Returns: identifier string
+ *
+ * Since: 1.7.0
+ **/
+const gchar *
+fu_progress_flag_to_string(FuProgressFlags flag)
+{
+	if (flag == FU_PROGRESS_FLAG_GUESSED)
+		return "guessed";
+	if (flag == FU_PROGRESS_FLAG_NO_PROFILE)
+		return "no-profile";
+	return NULL;
+}
+
+/**
+ * fu_progress_flag_from_string:
+ * @flag: a string, e.g. `guessed`
+ *
+ * Converts a string to an progress flag.
+ *
+ * Returns: enumerated value
+ *
+ * Since: 1.7.0
+ **/
+FuProgressFlags
+fu_progress_flag_from_string(const gchar *flag)
+{
+	if (g_strcmp0(flag, "guessed") == 0)
+		return FU_PROGRESS_FLAG_GUESSED;
+	if (g_strcmp0(flag, "no-profile") == 0)
+		return FU_PROGRESS_FLAG_NO_PROFILE;
+	return FU_PROGRESS_FLAG_UNKNOWN;
+}
+
+/**
+ * fu_progress_add_flag:
+ * @self: a #FuProgress
+ * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
+ *
+ * Adds a flag.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_add_flag(FuProgress *self, FuProgressFlags flag)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	priv->flags |= flag;
+}
+
+/**
+ * fu_progress_remove_flag:
+ * @self: a #FuProgress
+ * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
+ *
+ * Removes a flag.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	priv->flags &= ~flag;
+}
+
+/**
+ * fu_progress_has_flag:
+ * @self: a #FuProgress
+ * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
+ *
+ * Tests for a flag.
+ *
+ * Since: 1.7.0
+ **/
+gboolean
+fu_progress_has_flag(FuProgress *self, FuProgressFlags flag)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), FALSE);
+	return (priv->flags & flag) > 0;
+}
+
+/**
+ * fu_progress_set_status:
+ * @self: a #FuProgress
+ * @status: device status
+ *
+ * Sets the status of the progress.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_status(FuProgress *self, FwupdStatus status)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+
+	/* not changed */
+	if (priv->status == status)
+		return;
+
+	/* save */
+	priv->status = status;
+	g_signal_emit(self, signals[SIGNAL_STATUS_CHANGED], 0, status);
+}
+
+/**
+ * fu_progress_get_percentage:
+ * @self: a #FuProgress
+ *
+ * Get the last set progress percentage.
+ *
+ * Return value: The percentage value, or %G_MAXUINT for error
+ *
+ * Since: 1.7.0
+ **/
+guint
+fu_progress_get_percentage(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), G_MAXUINT);
+	return priv->percentage;
+}
+
+static void
+fu_progress_build_parent_chain(FuProgress *self, GString *str, guint level)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	if (priv->parent != NULL)
+		fu_progress_build_parent_chain(priv->parent, str, level + 1);
+	g_string_append_printf(str,
+			       "%u) %s (%u/%u)\n",
+			       level,
+			       priv->id,
+			       priv->step_now,
+			       priv->step_max);
+}
+
+/**
+ * fu_progress_set_percentage:
+ * @self: a #FuProgress
+ * @percentage: value between 0% and 100%
+ *
+ * Sets the progress percentage complete.
+ *
+ * NOTE: this must be above what was previously set, or it will be rejected.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_percentage(FuProgress *self, guint percentage)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(percentage <= 100);
+
+	/* is it the same */
+	if (percentage == priv->percentage)
+		return;
+
+	/* is it less */
+	if (percentage < priv->percentage) {
+		if (priv->profile) {
+			g_autoptr(GString) str = g_string_new(NULL);
+			fu_progress_build_parent_chain(self, str, 0);
+			g_warning("percentage should not go down from %u to %u: %s",
+				  priv->percentage,
+				  percentage,
+				  str->str);
+		}
+		return;
+	}
+
+	/* save */
+	priv->percentage = percentage;
+	g_signal_emit(self, signals[SIGNAL_PERCENTAGE_CHANGED], 0, percentage);
+}
+
+/**
+ * fu_progress_set_percentage_full:
+ * @self: a #FuDevice
+ * @progress_done: the bytes already done
+ * @progress_total: the total number of bytes
+ *
+ * Sets the progress completion using the raw progress values.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_percentage_full(FuProgress *self, gsize progress_done, gsize progress_total)
+{
+	gdouble percentage = 0.f;
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(progress_done <= progress_total);
+	if (progress_total > 0)
+		percentage = (100.f * (gdouble)progress_done) / (gdouble)progress_total;
+	fu_progress_set_percentage(self, (guint)percentage);
+}
+
+/**
+ * fu_progress_set_profile:
+ * @self: A #FuProgress
+ * @profile: if profiling should be enabled
+ *
+ * This enables profiling of FuProgress. This may be useful in development,
+ * but be warned; enabling profiling makes #FuProgress very slow.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_profile(FuProgress *self, gboolean profile)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	priv->profile = profile;
+}
+
+/**
+ * fu_progress_get_profile:
+ * @self: A #FuProgress
+ * @profile:
+ *
+ * Returns if the profile is enabled for this progress.
+ *
+ * Return value: if profiling should be enabled
+ *
+ * Since: 1.7.0
+ **/
+static gboolean
+fu_progress_get_profile(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), FALSE);
+	return priv->profile;
+}
+
+/**
+ * fu_progress_reset:
+ * @self: A #FuProgress
+ *
+ * Resets the #FuProgress object to unset
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_reset(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+
+	/* reset values */
+	priv->step_max = 0;
+	priv->step_now = 0;
+	priv->percentage = 0;
+
+	/* only use the timer if profiling; it's expensive */
+	if (priv->profile)
+		g_timer_start(priv->timer);
+
+	/* disconnect client */
+	if (priv->percentage_child_id != 0) {
+		g_signal_handler_disconnect(priv->child, priv->percentage_child_id);
+		priv->percentage_child_id = 0;
+	}
+	if (priv->status_child_id != 0) {
+		g_signal_handler_disconnect(priv->child, priv->status_child_id);
+		priv->status_child_id = 0;
+	}
+	g_clear_object(&priv->child);
+
+	/* no more step data */
+	g_ptr_array_set_size(priv->steps, 0);
+}
+
+/**
+ * fu_progress_set_steps:
+ * @self: A #FuProgress
+ * @step_max: The number of sub-tasks in this progress, can be 0
+ *
+ * Sets the number of sub-tasks, i.e. how many times the fu_progress_step_done()
+ * function will be called in the loop.
+ *
+ * The progress ID must be set fu_progress_set_id() before this method is used.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_set_steps(FuProgress *self, guint step_max)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(priv->id != NULL);
+
+	/* only use the timer if profiling; it's expensive */
+	if (priv->profile)
+		g_timer_start(priv->timer);
+
+	/* set step_max */
+	priv->step_max = step_max;
+}
+
+/**
+ * fu_progress_get_steps:
+ * @self: A #FuProgress
+ *
+ * Gets the number of sub-tasks, i.e. how many times the fu_progress_step_done()
+ * function will be called in the loop.
+ *
+ * Return value: number of sub-tasks in this progress
+ *
+ * Since: 1.7.0
+ **/
+guint
+fu_progress_get_steps(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), G_MAXUINT);
+	return priv->step_max;
+}
+
+/**
+ * fu_progress_add_step:
+ * @self: A #FuProgress
+ * @status: status value to use for this phase
+ * @value: A step weighting variable argument array
+ *
+ * This sets the step weighting, which you will want to do if one action
+ * will take a bigger chunk of time than another.
+ *
+ * The progress ID must be set fu_progress_set_id() before this method is used.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_add_step(FuProgress *self, FwupdStatus status, guint value)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	FuProgressStep *step;
+
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(priv->id != NULL);
+
+	/* current status */
+	if (priv->steps->len == 0)
+		fu_progress_set_status(self, status);
+
+	/* save data */
+	step = g_new0(FuProgressStep, 1);
+	step->status = status;
+	step->value = value;
+	step->profile = .0;
+	g_ptr_array_add(priv->steps, step);
+
+	/* in case anything is not using ->steps */
+	fu_progress_set_steps(self, priv->steps->len);
+}
+
+/**
+ * fu_progress_finished:
+ * @self: A #FuProgress
+ *
+ * Called when the step_now sub-task wants to finish early and still complete.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_finished(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(priv->id != NULL);
+
+	/* is already at 100%? */
+	if (priv->step_now == priv->step_max)
+		return;
+
+	/* all done */
+	priv->step_now = priv->step_max;
+	fu_progress_set_percentage(self, 100);
+	fu_progress_set_status(self, FWUPD_STATUS_UNKNOWN);
+}
+
+static gdouble
+fu_progress_discrete_to_percent(guint discrete, guint step_max)
+{
+	/* check we are in range */
+	if (discrete > step_max)
+		return 100;
+	if (step_max == 0) {
+		g_warning("step_max is 0!");
+		return 0;
+	}
+	return ((gdouble)discrete * (100.0f / (gdouble)(step_max)));
+}
+
+static gdouble
+fu_progress_get_step_percentage(FuProgress *self, guint idx)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	guint current = 0;
+	guint total = 0;
+
+	for (guint i = 0; i < priv->steps->len; i++) {
+		FuProgressStep *step = g_ptr_array_index(priv->steps, i);
+		if (i <= idx)
+			current += step->value;
+		total += step->value;
+	}
+	return ((gdouble)current * 100.f) / (gdouble)total;
+}
+
+static void
+fu_progress_child_status_changed_cb(FuProgress *child, FwupdStatus status, FuProgress *self)
+{
+	fu_progress_set_status(self, status);
+}
+
+static void
+fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	gdouble offset;
+	gdouble range;
+	gdouble extra;
+	guint parent_percentage;
+
+	/* propagate up the stack if FuProgress has only one step */
+	if (priv->step_max == 1) {
+		fu_progress_set_percentage(self, percentage);
+		return;
+	}
+
+	/* did we call done on a self that did not have a size set? */
+	if (priv->step_max == 0)
+		return;
+
+	/* already at >= 100% */
+	if (priv->step_now >= priv->step_max) {
+		g_warning("already at %u/%u step_max", priv->step_now, priv->step_max);
+		return;
+	}
+
+	/* we have to deal with non-linear step_max */
+	if (priv->steps->len > 0) {
+		/* we don't store zero */
+		if (priv->step_now == 0) {
+			gdouble pc = fu_progress_get_step_percentage(self, 0);
+			parent_percentage = percentage * pc / 100;
+		} else {
+			gdouble pc1 = fu_progress_get_step_percentage(self, priv->step_now - 1);
+			gdouble pc2 = fu_progress_get_step_percentage(self, priv->step_now);
+			/* bi-linearly interpolate */
+			parent_percentage = (((100 - percentage) * pc1) + (percentage * pc2)) / 100;
+		}
+		goto out;
+	}
+
+	/* get the offset */
+	offset = fu_progress_discrete_to_percent(priv->step_now, priv->step_max);
+
+	/* get the range between the parent step and the next parent step */
+	range = fu_progress_discrete_to_percent(priv->step_now + 1, priv->step_max) - offset;
+	if (range < 0.01)
+		return;
+
+	/* get the extra contributed by the child */
+	extra = ((gdouble)percentage / 100.0f) * range;
+
+	/* emit from the parent */
+	parent_percentage = (guint)(offset + extra);
+out:
+	fu_progress_set_percentage(self, parent_percentage);
+}
+
+static void
+fu_progress_set_parent(FuProgress *self, FuProgress *parent)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	priv->parent = parent; /* no ref! */
+	priv->profile = fu_progress_get_profile(parent);
+}
+
+/**
+ * fu_progress_get_child:
+ * @self: A #FuProgress
+ *
+ * Monitor a child and proxy back up to the parent with the correct percentage.
+ *
+ * Return value: (transfer none): A new %FuProgress or %NULL for failure
+ *
+ * Since: 1.7.0
+ **/
+FuProgress *
+fu_progress_get_child(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+
+	g_return_val_if_fail(FU_IS_PROGRESS(self), NULL);
+	g_return_val_if_fail(priv->id != NULL, NULL);
+
+	/* already created child */
+	if (priv->child != NULL)
+		return priv->child;
+
+	/* connect up signals */
+	priv->child = fu_progress_new(NULL);
+	priv->percentage_child_id =
+	    g_signal_connect(priv->child,
+			     "percentage-changed",
+			     G_CALLBACK(fu_progress_child_percentage_changed_cb),
+			     self);
+	priv->status_child_id = g_signal_connect(priv->child,
+						 "status-changed",
+						 G_CALLBACK(fu_progress_child_status_changed_cb),
+						 self);
+	fu_progress_set_parent(priv->child, self);
+	return priv->child;
+}
+
+static void
+fu_progress_show_profile(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	gdouble division;
+	gdouble total_time = 0.0f;
+	gboolean close_enough = TRUE;
+	g_autoptr(GString) str = NULL;
+
+	/* not accurate enough for a profile result */
+	if (priv->flags & FU_PROGRESS_FLAG_NO_PROFILE)
+		return;
+
+	/* get the total time so we can work out the divisor */
+	str = g_string_new("raw timing data was { ");
+	for (guint i = 0; i < priv->step_max; i++) {
+		FuProgressStep *step = g_ptr_array_index(priv->steps, i);
+		g_string_append_printf(str, "%.3f, ", step->profile);
+	}
+	if (priv->step_max > 0)
+		g_string_set_size(str, str->len - 2);
+	g_string_append(str, " } -- ");
+
+	/* get the total time so we can work out the divisor */
+	for (guint i = 0; i < priv->step_max; i++) {
+		FuProgressStep *step = g_ptr_array_index(priv->steps, i);
+		total_time += step->profile;
+	}
+	if (total_time < 0.001)
+		return;
+	division = total_time / 100.0f;
+
+	/* what we set */
+	g_string_append(str, "steps were set as [ ");
+	for (guint i = 0; i < priv->step_max; i++) {
+		FuProgressStep *step = g_ptr_array_index(priv->steps, i);
+		g_string_append_printf(str, "%u ", step->value);
+	}
+
+	/* what we _should_ have set */
+	g_string_append_printf(str, "] but should have been [ ");
+	for (guint i = 0; i < priv->step_max; i++) {
+		FuProgressStep *step = g_ptr_array_index(priv->steps, i);
+		g_string_append_printf(str, "%.0f ", step->profile / division);
+
+		/* this is sufficiently different to what we guessed */
+		if (fabs((gdouble)step->value - step->profile / division) > 5)
+			close_enough = FALSE;
+	}
+	g_string_append(str, "]");
+	if (priv->flags & FU_PROGRESS_FLAG_GUESSED) {
+#ifdef SUPPORTED_BUILD
+		g_debug("%s at %s", str->str, priv->id);
+#else
+		g_warning("%s at %s", str->str, priv->id);
+		g_warning("Please see "
+			  "https://github.com/fwupd/fwupd/wiki/Daemon-Warning:-FuProgress-steps");
+#endif
+	} else if (!close_enough) {
+		g_debug("%s at %s", str->str, priv->id);
+	}
+}
+
+/**
+ * fu_progress_step_done:
+ * @self: A #FuProgress
+ *
+ * Called when the step_now sub-task has finished.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_step_done(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	gdouble percentage;
+
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(priv->id != NULL);
+
+	/* did we call done on a self that did not have a size set? */
+	if (priv->step_max == 0) {
+		g_autoptr(GString) str = g_string_new(NULL);
+		fu_progress_build_parent_chain(self, str, 0);
+		g_warning("progress done when no size set! [%s]: %s", priv->id, str->str);
+		return;
+	}
+
+	/* save the duration in the array */
+	if (priv->profile) {
+		if (priv->steps->len > 0) {
+			FuProgressStep *step = g_ptr_array_index(priv->steps, priv->step_now);
+			step->profile = g_timer_elapsed(priv->timer, NULL);
+		}
+		g_timer_start(priv->timer);
+	}
+
+	/* is already at 100%? */
+	if (priv->step_now >= priv->step_max) {
+		g_autoptr(GString) str = g_string_new(NULL);
+		fu_progress_build_parent_chain(self, str, 0);
+		g_warning("already at 100%% [%s]: %s", priv->id, str->str);
+		return;
+	}
+
+	/* is child not at 100%? */
+	if (priv->child != NULL) {
+		FuProgressPrivate *child_priv = GET_PRIVATE(priv->child);
+		if (child_priv->step_now != child_priv->step_max) {
+			g_autoptr(GString) str = g_string_new(NULL);
+			fu_progress_build_parent_chain(priv->child, str, 0);
+			g_warning("child is at %u/%u step_max and parent done [%s]\n%s",
+				  child_priv->step_now,
+				  child_priv->step_max,
+				  priv->id,
+				  str->str);
+			/* do not abort, as we want to clean this up */
+		}
+	}
+
+	/* another */
+	priv->step_now++;
+
+	/* update status */
+	if (priv->steps->len > 0) {
+		if (priv->step_now == priv->step_max) {
+			fu_progress_set_status(self, FWUPD_STATUS_UNKNOWN);
+		} else {
+			FuProgressStep *step = g_ptr_array_index(priv->steps, priv->step_now);
+			fu_progress_set_status(self, step->status);
+		}
+	}
+
+	/* find new percentage */
+	if (priv->steps->len == 0) {
+		percentage = fu_progress_discrete_to_percent(priv->step_now, priv->step_max);
+	} else {
+		percentage = fu_progress_get_step_percentage(self, priv->step_now - 1);
+	}
+	fu_progress_set_percentage(self, (guint)percentage);
+
+	/* show any profiling stats */
+	if (priv->profile && priv->step_now == priv->step_max && priv->steps->len > 0)
+		fu_progress_show_profile(self);
+
+	/* reset child if it exists */
+	if (priv->child != NULL)
+		fu_progress_reset(priv->child);
+}
+
+/**
+ * fu_progress_sleep:
+ * @self: a #FuProgress
+ * @delay_ms: the delay in milliseconds
+ *
+ * Sleeps, setting the device progress from 0..100% as time continues.
+ *
+ * Since: 1.7.0
+ **/
+void
+fu_progress_sleep(FuProgress *self, guint delay_ms)
+{
+	gulong delay_us_pc = (delay_ms * 1000) / 100;
+
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(delay_ms > 0);
+
+	fu_progress_set_percentage(self, 0);
+	for (guint i = 0; i < 100; i++) {
+		g_usleep(delay_us_pc);
+		fu_progress_set_percentage(self, i + 1);
+	}
+}
+
+static void
+fu_progress_init(FuProgress *self)
+{
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+	priv->timer = g_timer_new();
+	priv->steps = g_ptr_array_new_with_free_func(g_free);
+}
+
+static void
+fu_progress_finalize(GObject *object)
+{
+	FuProgress *self = FU_PROGRESS(object);
+	FuProgressPrivate *priv = GET_PRIVATE(self);
+
+	fu_progress_reset(self);
+	g_free(priv->id);
+	g_ptr_array_unref(priv->steps);
+	g_timer_destroy(priv->timer);
+
+	G_OBJECT_CLASS(fu_progress_parent_class)->finalize(object);
+}
+
+static void
+fu_progress_class_init(FuProgressClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_progress_finalize;
+
+	signals[SIGNAL_PERCENTAGE_CHANGED] =
+	    g_signal_new("percentage-changed",
+			 G_TYPE_FROM_CLASS(object_class),
+			 G_SIGNAL_RUN_LAST,
+			 G_STRUCT_OFFSET(FuProgressClass, percentage_changed),
+			 NULL,
+			 NULL,
+			 g_cclosure_marshal_VOID__UINT,
+			 G_TYPE_NONE,
+			 1,
+			 G_TYPE_UINT);
+	signals[SIGNAL_STATUS_CHANGED] =
+	    g_signal_new("status-changed",
+			 G_TYPE_FROM_CLASS(object_class),
+			 G_SIGNAL_RUN_LAST,
+			 G_STRUCT_OFFSET(FuProgressClass, status_changed),
+			 NULL,
+			 NULL,
+			 g_cclosure_marshal_VOID__UINT,
+			 G_TYPE_NONE,
+			 1,
+			 G_TYPE_UINT);
+}
+
+/**
+ * fu_progress_new:
+ * @id: (nullable): progress ID, normally `G_STRLOC`
+ *
+ * Return value: A new #FuProgress instance.
+ *
+ * Since: 1.7.0
+ **/
+FuProgress *
+fu_progress_new(const gchar *id)
+{
+	FuProgress *self;
+	self = g_object_new(FU_TYPE_PROGRESS, NULL);
+	if (id != NULL)
+		fu_progress_set_id(self, id);
+	return FU_PROGRESS(self);
+}

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2021 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupd.h>
+#include <gio/gio.h>
+
+#define FU_TYPE_PROGRESS (fu_progress_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuProgress, fu_progress, FU, PROGRESS, GObject)
+
+struct _FuProgressClass {
+	GObjectClass parent_class;
+	/* signals */
+	void (*percentage_changed)(FuProgress *self, guint value);
+	void (*status_changed)(FuProgress *self, FwupdStatus status);
+	/*< private >*/
+	gpointer padding[29];
+};
+
+/**
+ * FuProgressFlags:
+ *
+ * The progress internal flags.
+ **/
+typedef guint64 FuProgressFlags;
+
+/**
+ * FU_PROGRESS_FLAG_NONE:
+ *
+ * No flags set.
+ *
+ * Since: 1.7.0
+ */
+#define FU_PROGRESS_FLAG_NONE (0)
+
+/**
+ * FU_PROGRESS_FLAG_UNKNOWN:
+ *
+ * Unknown flag value.
+ *
+ * Since: 1.7.0
+ */
+#define FU_PROGRESS_FLAG_UNKNOWN G_MAXUINT64
+
+/**
+ * FU_PROGRESS_FLAG_GUESSED:
+ *
+ * The steps have not been measured on real hardware and have been guessed.
+ *
+ * Since: 1.7.0
+ */
+#define FU_PROGRESS_FLAG_GUESSED (1ull << 0)
+
+/**
+ * FU_PROGRESS_FLAG_NO_PROFILE:
+ *
+ * The steps cannot be accurate enough for a profile result.
+ *
+ * Since: 1.7.0
+ */
+#define FU_PROGRESS_FLAG_NO_PROFILE (1ull << 1)
+
+FuProgress *
+fu_progress_new(const gchar *id);
+const gchar *
+fu_progress_get_id(FuProgress *self);
+void
+fu_progress_set_id(FuProgress *self, const gchar *id);
+const gchar *
+fu_progress_flag_to_string(FuProgressFlags flag);
+FuProgressFlags
+fu_progress_flag_from_string(const gchar *flag);
+void
+fu_progress_add_flag(FuProgress *self, FuProgressFlags flag);
+void
+fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag);
+gboolean
+fu_progress_has_flag(FuProgress *self, FuProgressFlags flag);
+FwupdStatus
+fu_progress_get_status(FuProgress *self);
+void
+fu_progress_set_status(FuProgress *self, FwupdStatus status);
+void
+fu_progress_set_percentage(FuProgress *self, guint percentage);
+void
+fu_progress_set_percentage_full(FuProgress *self, gsize progress_done, gsize progress_total);
+guint
+fu_progress_get_percentage(FuProgress *self);
+void
+fu_progress_set_profile(FuProgress *self, gboolean profile);
+void
+fu_progress_reset(FuProgress *self);
+void
+fu_progress_set_steps(FuProgress *self, guint step_max);
+guint
+fu_progress_get_steps(FuProgress *self);
+void
+fu_progress_add_step(FuProgress *self, FwupdStatus status, guint value);
+void
+fu_progress_finished(FuProgress *self);
+void
+fu_progress_step_done(FuProgress *self);
+FuProgress *
+fu_progress_get_child(FuProgress *self);
+void
+fu_progress_sleep(FuProgress *self, guint delay_ms);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3401,6 +3401,223 @@ fu_ifd_image_xml_func(void)
 	g_assert_cmpstr(csum1, ==, csum2);
 }
 
+typedef struct {
+	guint last_percentage;
+	guint updates;
+} FuProgressHelper;
+
+static void
+fu_progress_percentage_changed_cb(FuProgress *progress, guint percentage, gpointer data)
+{
+	FuProgressHelper *helper = (FuProgressHelper *)data;
+	helper->last_percentage = percentage;
+	helper->updates++;
+}
+
+static void
+fu_progress_func(void)
+{
+	FuProgressHelper helper = {0};
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_progress_percentage_changed_cb),
+			 &helper);
+
+	fu_progress_set_steps(progress, 5);
+
+	fu_progress_step_done(progress);
+	g_assert_cmpint(helper.updates, ==, 1);
+	g_assert_cmpint(helper.last_percentage, ==, 20);
+
+	for (guint i = 0; i < 4; i++)
+		fu_progress_step_done(progress);
+	g_assert_cmpint(helper.last_percentage, ==, 100);
+	g_assert_cmpint(helper.updates, ==, 5);
+}
+
+static void
+fu_progress_child_func(void)
+{
+	FuProgressHelper helper = {0};
+	FuProgress *child;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* reset */
+	fu_progress_set_steps(progress, 2);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_progress_percentage_changed_cb),
+			 &helper);
+
+	/* parent: |-----------------------|-----------------------|
+	 * step1:  |-----------------------|
+	 * child:                          |-------------|---------|
+	 */
+
+	/* PARENT UPDATE */
+	g_debug("parent update #1");
+	fu_progress_step_done(progress);
+	g_assert_cmpint(helper.updates, ==, 1);
+	g_assert_cmpint(helper.last_percentage, ==, 50);
+
+	/* now test with a child */
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 2);
+
+	g_debug("child update #1");
+	fu_progress_step_done(child);
+	g_assert_cmpint(helper.updates, ==, 2);
+	g_assert_cmpint(helper.last_percentage, ==, 75);
+
+	/* child update */
+	g_debug("child update #2");
+	fu_progress_step_done(child);
+	g_assert_cmpint(helper.updates, ==, 3);
+	g_assert_cmpint(helper.last_percentage, ==, 100);
+
+	/* parent update */
+	g_debug("parent update #2");
+	fu_progress_step_done(progress);
+
+	/* ensure we ignored the duplicate */
+	g_assert_cmpint(helper.updates, ==, 3);
+	g_assert_cmpint(helper.last_percentage, ==, 100);
+}
+
+static void
+fu_progress_parent_one_step_proxy_func(void)
+{
+	FuProgressHelper helper = {0};
+	FuProgress *child;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* one step */
+	fu_progress_set_steps(progress, 1);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_progress_percentage_changed_cb),
+			 &helper);
+
+	/* now test with a child */
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 2);
+
+	/* child set value */
+	fu_progress_set_percentage(child, 33);
+
+	/* ensure 1 updates for progress with one step and ensure using child value as parent */
+	g_assert_cmpint(helper.updates, ==, 1);
+	g_assert_cmpint(helper.last_percentage, ==, 33);
+}
+
+static void
+fu_progress_non_equal_steps_func(void)
+{
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	FuProgress *child;
+	FuProgress *grandchild;
+
+	/* test non-equal steps */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 60);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 20);
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 0);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_ERASE);
+
+	/* child step should increment according to the custom steps */
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 2);
+
+	/* start child */
+	fu_progress_step_done(child);
+
+	/* verify 10% */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 10);
+
+	/* finish child */
+	fu_progress_step_done(child);
+
+	fu_progress_step_done(progress);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_WRITE);
+
+	/* verify 20% */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 20);
+
+	/* child step should increment according to the custom steps */
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_add_step(child, FWUPD_STATUS_DEVICE_RESTART, 25);
+	fu_progress_add_step(child, FWUPD_STATUS_DEVICE_WRITE, 75);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_RESTART);
+
+	/* start child */
+	fu_progress_step_done(child);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_WRITE);
+
+	/* verify bilinear interpolation is working */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 35);
+
+	/*
+	 * 0        20                             80         100
+	 * |---------||----------------------------||---------|
+	 *            |       35                   |
+	 *            |-------||-------------------| (25%)
+	 *                     |              75.5 |
+	 *                     |---------------||--| (90%)
+	 */
+	grandchild = fu_progress_get_child(child);
+	fu_progress_set_id(grandchild, G_STRLOC);
+	fu_progress_add_step(grandchild, FWUPD_STATUS_DEVICE_ERASE, 90);
+	fu_progress_add_step(grandchild, FWUPD_STATUS_DEVICE_WRITE, 10);
+
+	fu_progress_step_done(grandchild);
+
+	/* verify bilinear interpolation (twice) is working for subpercentage */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 75);
+
+	fu_progress_step_done(grandchild);
+
+	/* finish child */
+	fu_progress_step_done(child);
+
+	fu_progress_step_done(progress);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_READ);
+
+	/* verify 80% */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 80);
+
+	fu_progress_step_done(progress);
+
+	/* verify 100% */
+	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 100);
+	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_UNKNOWN);
+}
+
+static void
+fu_progress_finish_func(void)
+{
+	FuProgress *child;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* check straight finish */
+	fu_progress_set_steps(progress, 3);
+
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 3);
+	fu_progress_finished(child);
+
+	/* parent step done after child finish */
+	fu_progress_step_done(progress);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -3416,6 +3633,11 @@ main(int argc, char **argv)
 	g_setenv("FWUPD_OFFLINE_TRIGGER", "/tmp/fwupd-self-test/system-update", TRUE);
 	g_setenv("FWUPD_LOCALSTATEDIR", "/tmp/fwupd-self-test/var", TRUE);
 
+	g_test_add_func("/fwupd/progress", fu_progress_func);
+	g_test_add_func("/fwupd/progress{child}", fu_progress_child_func);
+	g_test_add_func("/fwupd/progress{parent-1-step}", fu_progress_parent_one_step_proxy_func);
+	g_test_add_func("/fwupd/progress{no-equal}", fu_progress_non_equal_steps_func);
+	g_test_add_func("/fwupd/progress{finish}", fu_progress_finish_func);
 	g_test_add_func("/fwupd/security-attrs{hsi}", fu_security_attrs_hsi_func);
 	g_test_add_func("/fwupd/plugin{devices}", fu_plugin_devices_func);
 	g_test_add_func("/fwupd/plugin{device-inhibit-children}",

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -36,6 +36,7 @@
 #include <libfwupdplugin/fu-io-channel.h>
 #include <libfwupdplugin/fu-plugin-vfuncs.h>
 #include <libfwupdplugin/fu-plugin.h>
+#include <libfwupdplugin/fu-progress.h>
 #include <libfwupdplugin/fu-security-attrs.h>
 #include <libfwupdplugin/fu-srec-firmware.h>
 #include <libfwupdplugin/fu-udev-device.h>

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -150,11 +150,6 @@ LIBFWUPDPLUGIN_1.0.3 {
     fu_common_read_uint32;
     fu_common_write_uint16;
     fu_common_write_uint32;
-    fu_device_get_progress;
-    fu_device_get_status;
-    fu_device_set_progress;
-    fu_device_set_progress_full;
-    fu_device_set_status;
     fu_usb_device_is_open;
   local: *;
 } LIBFWUPDPLUGIN_1.0.2;
@@ -550,7 +545,6 @@ LIBFWUPDPLUGIN_1.5.0 {
     fu_device_dump_firmware;
     fu_device_report_metadata_post;
     fu_device_report_metadata_pre;
-    fu_device_sleep_with_progress;
     fu_device_unbind_driver;
     fu_efivar_get_data_bytes;
     fu_efivar_secure_boot_enabled_full;
@@ -867,6 +861,7 @@ LIBFWUPDPLUGIN_1.6.2 {
 
 LIBFWUPDPLUGIN_1.7.0 {
   global:
+    fu_device_set_progress;
     fu_plugin_runner_attach;
     fu_plugin_runner_cleanup;
     fu_plugin_runner_detach;
@@ -874,5 +869,28 @@ LIBFWUPDPLUGIN_1.7.0 {
     fu_plugin_runner_reload;
     fu_plugin_runner_write_firmware;
     fu_plugin_set_config_value;
+    fu_progress_add_flag;
+    fu_progress_add_step;
+    fu_progress_finished;
+    fu_progress_flag_from_string;
+    fu_progress_flag_to_string;
+    fu_progress_get_child;
+    fu_progress_get_id;
+    fu_progress_get_percentage;
+    fu_progress_get_status;
+    fu_progress_get_steps;
+    fu_progress_get_type;
+    fu_progress_has_flag;
+    fu_progress_new;
+    fu_progress_remove_flag;
+    fu_progress_reset;
+    fu_progress_set_id;
+    fu_progress_set_percentage;
+    fu_progress_set_percentage_full;
+    fu_progress_set_profile;
+    fu_progress_set_status;
+    fu_progress_set_steps;
+    fu_progress_sleep;
+    fu_progress_step_done;
   local: *;
 } LIBFWUPDPLUGIN_1.6.2;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -28,6 +28,7 @@ fwupdplugin_src = [
   'fu-io-channel.c',        # fuzzing
   'fu-plugin.c',
   'fu-quirks.c',            # fuzzing
+  'fu-progress.c',          # fuzzing
   'fu-security-attrs.c',
   'fu-smbios.c',            # fuzzing
   'fu-srec-firmware.c',     # fuzzing
@@ -101,6 +102,7 @@ fwupdplugin_headers = [
   'fu-plugin.h',
   'fu-quirks.h',
   'fu-security-attrs.h',
+  'fu-progress.h',
   'fu-smbios.h',
   'fu-srec-firmware.h',
   'fu-efi-signature.h',

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -300,7 +300,7 @@ fu_bcm57xx_device_nvram_check(FuBcm57xxDevice *self, GError **error)
 }
 
 static gboolean
-fu_bcm57xx_device_activate(FuDevice *device, GError **error)
+fu_bcm57xx_device_activate(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
 	g_autoptr(FuDeviceLocker) locker1 = NULL;
@@ -320,7 +320,7 @@ fu_bcm57xx_device_activate(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* activate, causing APE reset, then close, then attach */
-	if (!fu_device_activate(FU_DEVICE(self->recovery), error))
+	if (!fu_device_activate(FU_DEVICE(self->recovery), progress, error))
 		return FALSE;
 
 	/* ensure we attach before we close */
@@ -328,20 +328,20 @@ fu_bcm57xx_device_activate(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* wait for the device to restart before calling reload() */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_BUSY);
-	fu_device_sleep_with_progress(device, 5); /* seconds */
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
+	fu_progress_sleep(progress, 5000);
 	return TRUE;
 }
 
 static GBytes *
-fu_bcm57xx_device_dump_firmware(FuDevice *device, GError **error)
+fu_bcm57xx_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
 	const gsize bufsz = fu_device_get_firmware_size_max(FU_DEVICE(self));
 	g_autofree guint8 *buf = g_malloc0(bufsz);
 	g_autoptr(GPtrArray) chunks = NULL;
 
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_READ);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 	chunks = fu_chunk_array_mutable_new(buf, bufsz, 0x0, 0x0, FU_BCM57XX_BLOCK_SZ);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
@@ -351,7 +351,7 @@ fu_bcm57xx_device_dump_firmware(FuDevice *device, GError **error)
 						  fu_chunk_get_data_sz(chk),
 						  error))
 			return NULL;
-		fu_device_set_progress_full(device, i, chunks->len - 1);
+		fu_progress_set_percentage_full(progress, i + 1, chunks->len - 1);
 	}
 
 	/* read from hardware */
@@ -359,13 +359,13 @@ fu_bcm57xx_device_dump_firmware(FuDevice *device, GError **error)
 }
 
 static FuFirmware *
-fu_bcm57xx_device_read_firmware(FuDevice *device, GError **error)
+fu_bcm57xx_device_read_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_bcm57xx_firmware_new();
 	g_autoptr(GBytes) fw = NULL;
 
 	/* read from hardware */
-	fw = fu_bcm57xx_device_dump_firmware(device, error);
+	fw = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
 	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, error))
@@ -394,6 +394,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	g_autoptr(FuFirmware) img_ape = NULL;
 	g_autoptr(FuFirmware) img_stage1 = NULL;
 	g_autoptr(FuFirmware) img_stage2 = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GPtrArray) images = NULL;
 
 	/* try to parse NVRAM, stage1 or APE */
@@ -423,7 +424,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* get the existing firmware from the device */
-	fw_old = fu_bcm57xx_device_dump_firmware(device, error);
+	fw_old = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw_old == NULL)
 		return NULL;
 	if (!fu_firmware_parse(firmware, fw_old, flags, error)) {
@@ -467,6 +468,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_bcm57xx_device_write_firmware(FuDevice *device,
 				 FuFirmware *firmware,
+				 FuProgress *progress,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -475,14 +477,21 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) blob_verify = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 19);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2);
+
 	/* build the images into one linear blob of the correct size */
-	fu_device_set_status(device, FWUPD_STATUS_DECOMPRESSING);
 	blob = fu_firmware_write(firmware, error);
 	if (blob == NULL)
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* hit hardware */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 0x0, FU_BCM57XX_BLOCK_SZ);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
@@ -492,19 +501,28 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 						   fu_chunk_get_data_sz(chk),
 						   error))
 			return FALSE;
-		fu_device_set_progress_full(device, i, chunks->len - 1);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						i + 1,
+						chunks->len - 1);
 	}
+	fu_progress_step_done(progress);
 
 	/* verify */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_VERIFY);
-	blob_verify = fu_bcm57xx_device_dump_firmware(device, error);
+	blob_verify =
+	    fu_bcm57xx_device_dump_firmware(device, fu_progress_get_child(progress), error);
 	if (blob_verify == NULL)
 		return FALSE;
 	if (!fu_common_bytes_compare(blob, blob_verify, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* reset APE */
-	return fu_device_activate(device, error);
+	if (!fu_device_activate(device, fu_progress_get_child(progress), error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
 }
 
 static gboolean
@@ -617,6 +635,17 @@ fu_bcm57xx_device_close(FuDevice *device, GError **error)
 }
 
 static void
+fu_bcm57xx_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+}
+
+static void
 fu_bcm57xx_device_init(FuBcm57xxDevice *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.broadcom.bcm57xx");
@@ -654,4 +683,5 @@ fu_bcm57xx_device_class_init(FuBcm57xxDeviceClass *klass)
 	klass_device->dump_firmware = fu_bcm57xx_device_dump_firmware;
 	klass_device->probe = fu_bcm57xx_device_probe;
 	klass_device->to_string = fu_bcm57xx_device_to_string;
+	klass_device->set_progress = fu_bcm57xx_device_set_progress;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -341,6 +341,7 @@ fu_bcm57xx_recovery_device_nvram_read(FuBcm57xxRecoveryDevice *self,
 				      guint32 address,
 				      guint32 *buf,
 				      gsize bufsz,
+				      FuProgress *progress,
 				      GError **error)
 {
 	for (guint i = 0; i < bufsz; i++) {
@@ -376,7 +377,7 @@ fu_bcm57xx_recovery_device_nvram_read(FuBcm57xxRecoveryDevice *self,
 			return FALSE;
 		buf[i] = GUINT32_FROM_BE(val32);
 		address += sizeof(guint32);
-		fu_device_set_progress_full(FU_DEVICE(self), i, bufsz);
+		fu_progress_set_percentage_full(progress, i + 1, bufsz);
 	}
 
 	/* success */
@@ -388,6 +389,7 @@ fu_bcm57xx_recovery_device_nvram_write(FuBcm57xxRecoveryDevice *self,
 				       guint32 address,
 				       const guint32 *buf,
 				       gsize bufsz_dwrds,
+				       FuProgress *progress,
 				       GError **error)
 {
 	const guint32 page_size_dwrds = 64;
@@ -434,7 +436,7 @@ fu_bcm57xx_recovery_device_nvram_write(FuBcm57xxRecoveryDevice *self,
 			return FALSE;
 		}
 		address += sizeof(guint32);
-		fu_device_set_progress_full(FU_DEVICE(self), i, bufsz_dwrds);
+		fu_progress_set_percentage_full(progress, i + 1, bufsz_dwrds);
 	}
 
 	/* success */
@@ -442,14 +444,14 @@ fu_bcm57xx_recovery_device_nvram_write(FuBcm57xxRecoveryDevice *self,
 }
 
 static gboolean
-fu_bcm57xx_recovery_device_detach(FuDevice *device, GError **error)
+fu_bcm57xx_recovery_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	/* unbind tg3 */
 	return fu_device_unbind_driver(device, error);
 }
 
 static gboolean
-fu_bcm57xx_recovery_device_attach(FuDevice *device, GError **error)
+fu_bcm57xx_recovery_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
 
@@ -470,7 +472,7 @@ fu_bcm57xx_recovery_device_attach(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_bcm57xx_recovery_device_activate(FuDevice *device, GError **error)
+fu_bcm57xx_recovery_device_activate(FuDevice *device, FuProgress *progress, GError **error)
 {
 	BcmRegAPEMode mode = {0};
 	FuBcm57xxRecoveryDevice *self = FU_BCM57XX_RECOVERY_DEVICE(device);
@@ -497,7 +499,7 @@ fu_bcm57xx_recovery_device_activate(FuDevice *device, GError **error)
 }
 
 static GBytes *
-fu_bcm57xx_recovery_device_dump_firmware(FuDevice *device, GError **error)
+fu_bcm57xx_recovery_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuBcm57xxRecoveryDevice *self = FU_BCM57XX_RECOVERY_DEVICE(device);
 	gsize bufsz_dwrds = fu_device_get_firmware_size_max(FU_DEVICE(self)) / sizeof(guint32);
@@ -506,7 +508,7 @@ fu_bcm57xx_recovery_device_dump_firmware(FuDevice *device, GError **error)
 	g_autoptr(FuDeviceLocker) locker2 = NULL;
 
 	/* read from hardware */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_READ);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 	locker = fu_device_locker_new_full(
 	    self,
 	    (FuDeviceLockerFunc)fu_bcm57xx_recovery_device_nvram_acquire_lock,
@@ -521,7 +523,12 @@ fu_bcm57xx_recovery_device_dump_firmware(FuDevice *device, GError **error)
 				      error);
 	if (locker2 == NULL)
 		return NULL;
-	if (!fu_bcm57xx_recovery_device_nvram_read(self, 0x0, buf_dwrds, bufsz_dwrds, error))
+	if (!fu_bcm57xx_recovery_device_nvram_read(self,
+						   0x0,
+						   buf_dwrds,
+						   bufsz_dwrds,
+						   progress,
+						   error))
 		return NULL;
 	if (!fu_device_locker_close(locker2, error))
 		return NULL;
@@ -557,6 +564,7 @@ fu_bcm57xx_recovery_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_bcm57xx_recovery_device_write_firmware(FuDevice *device,
 					  FuFirmware *firmware,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {
@@ -569,11 +577,18 @@ fu_bcm57xx_recovery_device_write_firmware(FuDevice *device,
 	g_autoptr(FuDeviceLocker) locker2 = NULL;
 	g_autoptr(GBytes) blob = NULL;
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 5);
+
 	/* build the images into one linear blob of the correct size */
-	fu_device_set_status(device, FWUPD_STATUS_DECOMPRESSING);
 	blob = fu_firmware_write(firmware, error);
 	if (blob == NULL)
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* align into uint32_t buffer */
 	buf = g_bytes_get_data(blob, &bufsz);
@@ -590,7 +605,6 @@ fu_bcm57xx_recovery_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* hit hardware */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	locker = fu_device_locker_new_full(
 	    self,
 	    (FuDeviceLockerFunc)fu_bcm57xx_recovery_device_nvram_acquire_lock,
@@ -605,15 +619,26 @@ fu_bcm57xx_recovery_device_write_firmware(FuDevice *device,
 	    error);
 	if (locker2 == NULL)
 		return FALSE;
-	if (!fu_bcm57xx_recovery_device_nvram_write(self, 0x0, buf_dwrds, bufsz_dwrds, error))
+	if (!fu_bcm57xx_recovery_device_nvram_write(self,
+						    0x0,
+						    buf_dwrds,
+						    bufsz_dwrds,
+						    fu_progress_get_child(progress),
+						    error))
 		return FALSE;
 	if (!fu_device_locker_close(locker2, error))
 		return FALSE;
 	if (!fu_device_locker_close(locker, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* reset APE */
-	return fu_device_activate(device, error);
+	if (!fu_device_activate(device, fu_progress_get_child(progress), error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
 }
 
 static gboolean
@@ -623,6 +648,15 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 	guint32 fwversion = 0;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(FuDeviceLocker) locker2 = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* enable */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 80); /* nvram */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* veraddr */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* version */
 
 	locker = fu_device_locker_new_full(
 	    self,
@@ -638,14 +672,17 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 				      error);
 	if (locker2 == NULL)
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* get NVRAM version */
 	if (!fu_bcm57xx_recovery_device_nvram_read(self,
 						   BCM_NVRAM_STAGE1_BASE + BCM_NVRAM_STAGE1_VERSION,
 						   &fwversion,
 						   1,
+						   fu_progress_get_child(progress),
 						   error))
 		return FALSE;
+	fu_progress_step_done(progress);
 	if (fwversion != 0x0) {
 		g_autofree gchar *fwversion_str = NULL;
 
@@ -656,6 +693,8 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 		fu_device_set_version(device, fwversion_str);
 		fu_device_set_version_raw(device, fwversion);
 		fu_device_set_branch(device, BCM_FW_BRANCH_OSS_FIRMWARE);
+		fu_progress_step_done(progress);
+		fu_progress_step_done(progress);
 	} else {
 		guint32 bufver[4] = {0x0};
 		guint32 veraddr = 0;
@@ -667,8 +706,10 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 							       BCM_NVRAM_STAGE1_VERADDR,
 							   &veraddr,
 							   1,
+							   fu_progress_get_child(progress),
 							   error))
 			return FALSE;
+		fu_progress_step_done(progress);
 		veraddr = GUINT32_FROM_BE(veraddr);
 		if (veraddr > BCM_PHYS_ADDR_DEFAULT)
 			veraddr -= BCM_PHYS_ADDR_DEFAULT;
@@ -676,8 +717,10 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 							   BCM_NVRAM_STAGE1_BASE + veraddr,
 							   bufver,
 							   4,
+							   fu_progress_get_child(progress),
 							   error))
 			return FALSE;
+		fu_progress_step_done(progress);
 		veritem = fu_bcm57xx_veritem_new((guint8 *)bufver, sizeof(bufver));
 		if (veritem != NULL) {
 			fu_device_set_version(device, veritem->version);
@@ -797,6 +840,17 @@ fu_bcm57xx_recovery_device_close(FuDevice *device, GError **error)
 }
 
 static void
+fu_bcm57xx_recovery_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+}
+
+static void
 fu_bcm57xx_recovery_device_init(FuBcm57xxRecoveryDevice *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
@@ -842,6 +896,7 @@ fu_bcm57xx_recovery_device_class_init(FuBcm57xxRecoveryDeviceClass *klass)
 	klass_device->attach = fu_bcm57xx_recovery_device_attach;
 	klass_device->detach = fu_bcm57xx_recovery_device_detach;
 	klass_device->probe = fu_bcm57xx_recovery_device_probe;
+	klass_device->set_progress = fu_bcm57xx_recovery_device_set_progress;
 }
 
 FuBcm57xxRecoveryDevice *

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -196,7 +196,7 @@ fu_colorhug_device_msg(FuColorhugDevice *self,
 }
 
 static gboolean
-fu_colorhug_device_detach(FuDevice *device, GError **error)
+fu_colorhug_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
@@ -206,8 +206,6 @@ fu_colorhug_device_detach(FuDevice *device, GError **error)
 		g_debug("already in bootloader mode, skipping");
 		return TRUE;
 	}
-
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_msg(self,
 				    CH_CMD_RESET,
 				    NULL,
@@ -227,7 +225,7 @@ fu_colorhug_device_detach(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_colorhug_device_attach(FuDevice *device, GError **error)
+fu_colorhug_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
@@ -237,8 +235,6 @@ fu_colorhug_device_attach(FuDevice *device, GError **error)
 		g_debug("already in runtime mode, skipping");
 		return TRUE;
 	}
-
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_msg(self,
 				    CH_CMD_BOOT_FLASH,
 				    NULL,
@@ -444,6 +440,7 @@ ch_colorhug_device_calculate_checksum(const guint8 *data, guint32 len)
 static gboolean
 fu_colorhug_device_write_firmware(FuDevice *device,
 				  FuFirmware *firmware,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
@@ -451,27 +448,33 @@ fu_colorhug_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 19);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 44);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 35);
+
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
 
-	/* build packets */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       self->start_addr,
-					       0x00, /* page_sz */
-					       CH_FLASH_TRANSFER_BLOCK_SIZE);
-
 	/* don't auto-boot firmware */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_colorhug_device_set_flash_success(self, FALSE, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* erase flash */
 	if (!fu_colorhug_device_erase(self, self->start_addr, g_bytes_get_size(fw), error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* write each block */
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       self->start_addr,
+					       0x00, /* page_sz */
+					       CH_FLASH_TRANSFER_BLOCK_SIZE);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 		guint8 buf[CH_FLASH_TRANSFER_BLOCK_SIZE + 4];
@@ -507,11 +510,13 @@ fu_colorhug_device_write_firmware(FuDevice *device,
 		}
 
 		/* update progress */
-		fu_device_set_progress_full(device, (gsize)i, (gsize)chunks->len * 2);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)i + 1,
+						(gsize)chunks->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* verify each block */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_VERIFY);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 		guint8 buf[3];
@@ -550,11 +555,24 @@ fu_colorhug_device_write_firmware(FuDevice *device,
 		}
 
 		/* update progress */
-		fu_device_set_progress_full(device, (gsize)chunks->len + i, (gsize)chunks->len * 2);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)i + 1,
+						(gsize)chunks->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* success! */
 	return TRUE;
+}
+
+static void
+fu_colorhug_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 57);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 43);	/* reload */
 }
 
 static void
@@ -582,4 +600,5 @@ fu_colorhug_device_class_init(FuColorhugDeviceClass *klass)
 	klass_device->setup = fu_colorhug_device_setup;
 	klass_device->open = fu_colorhug_device_open;
 	klass_device->probe = fu_colorhug_device_probe;
+	klass_device->set_progress = fu_colorhug_device_set_progress;
 }

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -60,6 +60,7 @@ fu_dell_dock_status_setup(FuDevice *device, GError **error)
 static gboolean
 fu_dell_dock_status_write(FuDevice *device,
 			  FuFirmware *firmware,
+			  FuProgress *progress,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
@@ -96,7 +97,6 @@ fu_dell_dock_status_write(FuDevice *device,
 		return FALSE;
 
 	/* dock will reboot to re-read; this is to appease the daemon */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_version(device, dynamic_version);
 	return TRUE;
@@ -144,6 +144,16 @@ fu_dell_dock_status_finalize(GObject *object)
 }
 
 static void
+fu_dell_dock_status_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 13); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 72);	 /* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 9);	 /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 7);	 /* reload */
+}
+
+static void
 fu_dell_dock_status_init(FuDellDockStatus *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.dell.dock");
@@ -160,6 +170,7 @@ fu_dell_dock_status_class_init(FuDellDockStatusClass *klass)
 	klass_device->open = fu_dell_dock_status_open;
 	klass_device->close = fu_dell_dock_status_close;
 	klass_device->set_quirk_kv = fu_dell_dock_status_set_quirk_kv;
+	klass_device->set_progress = fu_dell_dock_status_set_progress;
 }
 
 FuDellDockStatus *

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -311,7 +311,8 @@ fu_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GError **error
 		return FALSE;
 
 	if (needs_activation && dev != NULL) {
-		if (!fu_device_activate(dev, error))
+		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+		if (!fu_device_activate(dev, progress, error))
 			return FALSE;
 	}
 

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -80,6 +80,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	g_autoptr(GBytes) blob_fw = g_bytes_new_static(fw, sizeof(fw));
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 #ifdef HAVE_GETUID
 	if (tpm_server_running == NULL && (getuid() != 0 || geteuid() != 0)) {
@@ -234,6 +235,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	ret = fu_plugin_runner_write_firmware(self->plugin_uefi_capsule,
 					      device_v20,
 					      blob_fw,
+					      progress,
 					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
@@ -244,6 +246,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	ret = fu_plugin_runner_write_firmware(self->plugin_uefi_capsule,
 					      device_v20,
 					      blob_fw,
+					      progress,
 					      FWUPD_INSTALL_FLAG_FORCE,
 					      &error);
 	g_assert_no_error(error);

--- a/plugins/dfu/fu-dfu-device.h
+++ b/plugins/dfu/fu-dfu-device.h
@@ -65,9 +65,12 @@ fu_dfu_device_get_runtime_pid(FuDfuDevice *self);
 guint16
 fu_dfu_device_get_runtime_release(FuDfuDevice *self);
 gboolean
-fu_dfu_device_reset(FuDfuDevice *self, GError **error);
+fu_dfu_device_reset(FuDfuDevice *self, FuProgress *progress, GError **error);
 FuFirmware *
-fu_dfu_device_upload(FuDfuDevice *self, FuDfuTargetTransferFlags flags, GError **error);
+fu_dfu_device_upload(FuDfuDevice *self,
+		     FuProgress *progress,
+		     FuDfuTargetTransferFlags flags,
+		     GError **error);
 gboolean
 fu_dfu_device_refresh(FuDfuDevice *self, GError **error);
 gboolean

--- a/plugins/dfu/fu-dfu-target-private.h
+++ b/plugins/dfu/fu-dfu-target-private.h
@@ -16,23 +16,25 @@ FuDfuTarget *
 fu_dfu_target_new(void);
 
 GBytes *
-fu_dfu_target_upload_chunk(FuDfuTarget *self, guint16 index, gsize buf_sz, GError **error);
+fu_dfu_target_upload_chunk(FuDfuTarget *self,
+			   guint16 index,
+			   gsize buf_sz,
+			   FuProgress *progress,
+			   GError **error);
 gboolean
-fu_dfu_target_download_chunk(FuDfuTarget *self, guint16 index, GBytes *bytes, GError **error);
+fu_dfu_target_download_chunk(FuDfuTarget *self,
+			     guint16 index,
+			     GBytes *bytes,
+			     FuProgress *progress,
+			     GError **error);
 gboolean
-fu_dfu_target_attach(FuDfuTarget *self, GError **error);
+fu_dfu_target_attach(FuDfuTarget *self, FuProgress *progress, GError **error);
 void
 fu_dfu_target_set_alt_idx(FuDfuTarget *self, guint8 alt_idx);
 void
 fu_dfu_target_set_alt_setting(FuDfuTarget *self, guint8 alt_setting);
 
 /* for the other implementations */
-void
-fu_dfu_target_set_action(FuDfuTarget *self, FwupdStatus action);
-void
-fu_dfu_target_set_percentage_raw(FuDfuTarget *self, guint percentage);
-void
-fu_dfu_target_set_percentage(FuDfuTarget *self, guint value, guint total);
 void
 fu_dfu_target_set_alt_name(FuDfuTarget *self, const gchar *alt_name);
 void

--- a/plugins/dfu/fu-dfu-target.h
+++ b/plugins/dfu/fu-dfu-target.h
@@ -40,19 +40,20 @@ typedef enum {
 
 struct _FuDfuTargetClass {
 	GUsbDeviceClass parent_class;
-	void (*percentage_changed)(FuDfuTarget *self, guint percentage);
 	void (*action_changed)(FuDfuTarget *self, FwupdStatus action);
 	gboolean (*setup)(FuDfuTarget *self, GError **error);
-	gboolean (*attach)(FuDfuTarget *self, GError **error);
-	gboolean (*detach)(FuDfuTarget *self, GError **error);
-	gboolean (*mass_erase)(FuDfuTarget *self, GError **error);
+	gboolean (*attach)(FuDfuTarget *self, FuProgress *progress, GError **error);
+	gboolean (*detach)(FuDfuTarget *self, FuProgress *progress, GError **error);
+	gboolean (*mass_erase)(FuDfuTarget *self, FuProgress *progress, GError **error);
 	FuChunk *(*upload_element)(FuDfuTarget *self,
 				   guint32 address,
 				   gsize expected_size,
 				   gsize maximum_size,
+				   FuProgress *progress,
 				   GError **error);
 	gboolean (*download_element)(FuDfuTarget *self,
 				     FuChunk *chk,
+				     FuProgress *progress,
 				     FuDfuTargetTransferFlags flags,
 				     GError **error);
 };
@@ -70,6 +71,7 @@ fu_dfu_target_get_alt_name_for_display(FuDfuTarget *self, GError **error);
 gboolean
 fu_dfu_target_upload(FuDfuTarget *self,
 		     FuFirmware *firmware,
+		     FuProgress *progress,
 		     FuDfuTargetTransferFlags flags,
 		     GError **error);
 gboolean
@@ -77,9 +79,10 @@ fu_dfu_target_setup(FuDfuTarget *self, GError **error);
 gboolean
 fu_dfu_target_download(FuDfuTarget *self,
 		       FuFirmware *image,
+		       FuProgress *progress,
 		       FuDfuTargetTransferFlags flags,
 		       GError **error);
 gboolean
-fu_dfu_target_mass_erase(FuDfuTarget *self, GError **error);
+fu_dfu_target_mass_erase(FuDfuTarget *self, FuProgress *progress, GError **error);
 void
 fu_dfu_target_to_string(FuDfuTarget *self, guint idt, GString *str);

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -194,6 +194,17 @@ fu_flashrom_device_close(FuDevice *device, GError **error)
 }
 
 static void
+fu_flashrom_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 100); /* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0);	/* reload */
+}
+
+static void
 fu_flashrom_device_class_init(FuFlashromDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
@@ -203,4 +214,5 @@ fu_flashrom_device_class_init(FuFlashromDeviceClass *klass)
 	klass_device->probe = fu_flashrom_device_probe;
 	klass_device->open = fu_flashrom_device_open;
 	klass_device->close = fu_flashrom_device_close;
+	klass_device->set_progress = fu_flashrom_device_set_progress;
 }

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -226,7 +226,6 @@ fu_fresco_pd_device_panther_reset_device(FuFrescoPdDevice *self, GError **error)
 	g_autoptr(GError) error_local = NULL;
 
 	g_debug("resetting target device");
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_RESTART);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* ignore when the device reset before completing the transaction */
@@ -246,6 +245,7 @@ fu_fresco_pd_device_panther_reset_device(FuFrescoPdDevice *self, GError **error)
 static gboolean
 fu_fresco_pd_device_write_firmware(FuDevice *device,
 				   FuFirmware *firmware,
+				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {
@@ -256,6 +256,15 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 	guint8 config[3] = {0x0};
 	guint8 start_symbols[2] = {0x0};
 	g_autoptr(GBytes) fw = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* enable mtp write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50);	/* copy-mmio */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 46); /* customize */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* boot */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2);
 
 	/* get default blob, which we know is already bigger than FirmwareMin */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -277,7 +286,6 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 	/* 0xA001<bit 2> = b'0
 	 * 0x6C00<bit 1> = b'0
 	 * 0x6C04 = 0x08 */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_BUSY);
 	g_debug("disable MCU, and enable mtp write");
 	if (!fu_fresco_pd_device_and_byte(self, 0xa001, ~(1 << 2), error)) {
 		g_prefix_error(error, "failed to disable MCU bit 2: ");
@@ -293,7 +301,6 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 	}
 
 	/* fill safe code in the boot code */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint16 i = 0; i < 0x400; i += 3) {
 		for (guint j = 0; j < 3; j++) {
 			if (!fu_fresco_pd_device_read_byte(self,
@@ -328,6 +335,7 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 		} else if (config[0] == 0x00 && config[1] == 0x00 && config[2] != 0x00)
 			break;
 	}
+	fu_progress_step_done(progress);
 
 	/* copy buf offset [0 - 0x3FFFF] to mmio address [0x2000 - 0x5FFF] */
 	g_debug("fill firmware body");
@@ -337,8 +345,11 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 						  buf[byte_index],
 						  error))
 			return FALSE;
-		fu_device_set_progress_full(device, (gsize)byte_index, 0x4000);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)byte_index + 1,
+						0x4000);
 	}
+	fu_progress_step_done(progress);
 
 	/* write file buf 0x4200 ~ 0x4205, 6 bytes to internal address 0x6600 ~ 0x6605
 	 * write file buf 0x4210 ~ 0x4215, 6 bytes to internal address 0x6610 ~ 0x6615
@@ -364,6 +375,7 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 	}
 	if (!fu_fresco_pd_device_set_byte(self, 0x6630, buf[0x4230], error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* overwrite firmware file's boot code area (0x4020 ~ 0x41ff) to the area on the device
 	 * marked by begin_addr example: if the begin_addr = 0x6420, then copy file buf [0x4020 ~
@@ -386,9 +398,26 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 						  error))
 			return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* reset the device */
-	return fu_fresco_pd_device_panther_reset_device(self, error);
+	if (!fu_fresco_pd_device_panther_reset_device(self, error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_fresco_pd_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 100); /* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0);	/* reload */
 }
 
 static void
@@ -412,4 +441,5 @@ fu_fresco_pd_device_class_init(FuFrescoPdDeviceClass *klass)
 	klass_device->setup = fu_fresco_pd_device_setup;
 	klass_device->write_firmware = fu_fresco_pd_device_write_firmware;
 	klass_device->prepare_firmware = fu_fresco_pd_device_prepare_firmware;
+	klass_device->set_progress = fu_fresco_pd_device_set_progress;
 }

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -19,13 +19,12 @@ struct _FuHailuckBlDevice {
 G_DEFINE_TYPE(FuHailuckBlDevice, fu_hailuck_bl_device, FU_TYPE_HID_DEVICE)
 
 static gboolean
-fu_hailuck_bl_device_attach(FuDevice *device, GError **error)
+fu_hailuck_bl_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	guint8 buf[6] = {
 	    FU_HAILUCK_REPORT_ID_SHORT,
 	    FU_HAILUCK_CMD_ATTACH,
 	};
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(device),
 				      buf[0],
 				      buf,
@@ -111,7 +110,7 @@ fu_hailuck_bl_device_read_block(FuHailuckBlDevice *self,
 }
 
 static GBytes *
-fu_hailuck_bl_device_dump_firmware(FuDevice *device, GError **error)
+fu_hailuck_bl_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuHailuckBlDevice *self = FU_HAILUCK_BL_DEVICE(device);
 	gsize fwsz = fu_device_get_firmware_size_max(device);
@@ -119,7 +118,7 @@ fu_hailuck_bl_device_dump_firmware(FuDevice *device, GError **error)
 	g_autoptr(GPtrArray) chunks = NULL;
 
 	/* tell device amount of data to send */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_READ);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 	if (!fu_hailuck_bl_device_read_block_start(self, fwsz, error))
 		return NULL;
 
@@ -133,7 +132,7 @@ fu_hailuck_bl_device_dump_firmware(FuDevice *device, GError **error)
 						     fu_chunk_get_data_sz(chk),
 						     error))
 			return NULL;
-		fu_device_set_progress_full(device, i, chunks->len - 1);
+		fu_progress_set_percentage_full(progress, i + 1, chunks->len);
 	}
 
 	/* success */
@@ -141,7 +140,7 @@ fu_hailuck_bl_device_dump_firmware(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_hailuck_bl_device_erase(FuHailuckBlDevice *self, GError **error)
+fu_hailuck_bl_device_erase(FuHailuckBlDevice *self, FuProgress *progress, GError **error)
 {
 	guint8 buf[6] = {
 	    FU_HAILUCK_REPORT_ID_SHORT,
@@ -155,7 +154,7 @@ fu_hailuck_bl_device_erase(FuHailuckBlDevice *self, GError **error)
 				      FU_HID_DEVICE_FLAG_IS_FEATURE,
 				      error))
 		return FALSE;
-	fu_device_sleep_with_progress(FU_DEVICE(self), 2);
+	fu_progress_sleep(progress, 2000);
 	return TRUE;
 }
 
@@ -225,6 +224,7 @@ fu_hailuck_bl_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_hailuck_bl_device_write_firmware(FuDevice *device,
 				    FuFirmware *firmware,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {
@@ -235,18 +235,25 @@ fu_hailuck_bl_device_write_firmware(FuDevice *device,
 	g_autoptr(GPtrArray) chunks = NULL;
 	g_autofree guint8 *chk0_data = NULL;
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1); /* block 0 */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 9);
+
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
 
 	/* erase all contents */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
-	if (!fu_hailuck_bl_device_erase(self, error))
+	if (!fu_hailuck_bl_device_erase(self, fu_progress_get_child(progress), error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* tell device amount of data to expect */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_hailuck_bl_device_write_block_start(self, g_bytes_get_size(fw), error))
 		return FALSE;
 
@@ -270,8 +277,11 @@ fu_hailuck_bl_device_write_firmware(FuDevice *device,
 						      fu_chunk_get_data_sz(chk),
 						      error))
 			return FALSE;
-		fu_device_set_progress_full(device, i, chunks->len);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						i + 1,
+						chunks->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* retry write of first block */
 	if (!fu_hailuck_bl_device_write_block_start(self, g_bytes_get_size(fw), error))
@@ -281,10 +291,11 @@ fu_hailuck_bl_device_write_firmware(FuDevice *device,
 					      fu_chunk_get_data_sz(chk0),
 					      error))
 		return FALSE;
-	fu_device_set_progress_full(device, chunks->len, chunks->len);
+	fu_progress_step_done(progress);
 
 	/* verify */
-	fw_new = fu_hailuck_bl_device_dump_firmware(device, error);
+	fw_new = fu_hailuck_bl_device_dump_firmware(device, fu_progress_get_child(progress), error);
+	fu_progress_step_done(progress);
 	return fu_common_bytes_compare(fw, fw_new, error);
 }
 

--- a/plugins/intel-spi/fu-ifd-device.c
+++ b/plugins/intel-spi/fu-ifd-device.c
@@ -78,7 +78,7 @@ fu_ifd_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static GBytes *
-fu_ifd_device_dump_firmware(FuDevice *device, GError **error)
+fu_ifd_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuIfdDevice *self = FU_IFD_DEVICE(device);
 	FuIfdDevicePrivate *priv = GET_PRIVATE(self);
@@ -88,18 +88,19 @@ fu_ifd_device_dump_firmware(FuDevice *device, GError **error)
 					device,
 					priv->offset,
 					total_size,
+					progress,
 					error);
 }
 
 static FuFirmware *
-fu_ifd_device_read_firmware(FuDevice *device, GError **error)
+fu_ifd_device_read_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuIfdDevice *self = FU_IFD_DEVICE(device);
 	FuIfdDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(FuFirmware) firmware = fu_ifd_image_new();
 	g_autoptr(GBytes) blob = NULL;
 
-	blob = fu_ifd_device_dump_firmware(device, error);
+	blob = fu_ifd_device_dump_firmware(device, progress, error);
 	if (blob == NULL)
 		return NULL;
 	if (priv->region == FU_IFD_REGION_BIOS)

--- a/plugins/intel-spi/fu-intel-spi-device.h
+++ b/plugins/intel-spi/fu-intel-spi-device.h
@@ -16,4 +16,5 @@ fu_intel_spi_device_dump(FuIntelSpiDevice *self,
 			 FuDevice *device,
 			 guint32 offset,
 			 guint32 length,
+			 FuProgress *progress,
 			 GError **error);

--- a/plugins/jabra/fu-jabra-device.c
+++ b/plugins/jabra/fu-jabra-device.c
@@ -53,6 +53,7 @@ fu_jabra_device_prepare(FuDevice *device, FwupdInstallFlags flags, GError **erro
 	guint8 rep = 0x00;
 	guint8 iface_hid;
 	guint8 buf[33] = {0x00};
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error_local = NULL;
 
 	/* parse string and create magic packet */
@@ -110,7 +111,7 @@ fu_jabra_device_prepare(FuDevice *device, FwupdInstallFlags flags, GError **erro
 	}
 
 	/* wait for device to re-appear and be added to the dfu plugin */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }

--- a/plugins/jabra/fu-plugin-jabra.c
+++ b/plugins/jabra/fu-plugin-jabra.c
@@ -26,6 +26,7 @@ fu_plugin_cleanup(FuPlugin *plugin, FuDevice *device, FwupdInstallFlags flags, G
 {
 	GUsbDevice *usb_device;
 	g_autoptr(FuDeviceLocker) locker = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error_local = NULL;
 
 	/* check for a property on the *dfu* FuDevice, which is also why we
@@ -35,7 +36,7 @@ fu_plugin_cleanup(FuPlugin *plugin, FuDevice *device, FwupdInstallFlags flags, G
 	locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
 	usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
 	if (!g_usb_device_reset(usb_device, &error_local)) {
 		g_set_error(error,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -115,6 +115,7 @@ fu_logitech_hidpp_bootloader_texas_clear_ram_buffer(FuLogitechHidPpBootloader *s
 static gboolean
 fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 						  FuFirmware *firmware,
+						  FuProgress *progress,
 						  FwupdInstallFlags flags,
 						  GError **error)
 {
@@ -124,6 +125,20 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 	g_autoptr(GPtrArray) reqs = NULL;
 	g_autoptr(FuLogitechHidPpBootloaderRequest) req =
 	    fu_logitech_hidpp_bootloader_request_new();
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	if (fu_device_has_private_flag(device, FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED)) {
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 3);
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1); /* clear */
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 18);
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 79);
+	} else {
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 11);
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1); /* clear */
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 75);
+		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 12);
+	}
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -136,16 +151,16 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* erase all flash pages */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
 	if (!fu_logitech_hidpp_bootloader_texas_erase_all(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* set existing RAM buffer to 0xff's */
 	if (!fu_logitech_hidpp_bootloader_texas_clear_ram_buffer(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* write to RAM buffer */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < reqs->len; i++) {
 		payload = g_ptr_array_index(reqs, i);
 
@@ -213,15 +228,14 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 		}
 
 		/* update progress */
-		fu_device_set_progress_full(device, i * 32, reqs->len * 32);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress), i + 1, reqs->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* check CRC */
 	if (!fu_logitech_hidpp_bootloader_texas_compute_and_test_crc(self, error))
 		return FALSE;
-
-	/* mark as complete */
-	fu_device_set_progress_full(device, reqs->len * 32, reqs->len * 32);
+	fu_progress_step_done(progress);
 
 	/* success! */
 	return TRUE;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -208,7 +208,7 @@ fu_logitech_hidpp_bootloader_get_blocksize(FuLogitechHidPpBootloader *self)
 }
 
 static gboolean
-fu_logitech_hidpp_bootloader_attach(FuDevice *device, GError **error)
+fu_logitech_hidpp_bootloader_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuLogitechHidPpBootloader *self = FU_UNIFYING_BOOTLOADER(device);
 	g_autoptr(FuLogitechHidPpBootloaderRequest) req =
@@ -252,10 +252,13 @@ fu_logitech_hidpp_bootloader_set_bl_version(FuLogitechHidPpBootloader *self, GEr
 	}
 	fu_device_set_version_bootloader(FU_DEVICE(self), version);
 
-	if ((major == 0x01 && minor >= 0x04) || (major == 0x03 && minor >= 0x02))
+	if ((major == 0x01 && minor >= 0x04) || (major == 0x03 && minor >= 0x02)) {
+		fu_device_add_private_flag(FU_DEVICE(self),
+					   FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED);
 		fu_device_add_protocol(FU_DEVICE(self), "com.logitech.unifyingsigned");
-	else
+	} else {
 		fu_device_add_protocol(FU_DEVICE(self), "com.logitech.unifying");
+	}
 	return TRUE;
 }
 
@@ -471,6 +474,9 @@ fu_logitech_hidpp_bootloader_init(FuLogitechHidPpBootloader *self)
 	fu_device_set_name(FU_DEVICE(self), "Unifying Receiver");
 	fu_device_set_summary(FU_DEVICE(self), "Miniaturised USB wireless receiver (bootloader)");
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_UNIFYING_DEVICE_TIMEOUT_MS);
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED,
+					"is-signed");
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.h
@@ -19,6 +19,15 @@ struct _FuLogitechHidPpBootloaderClass {
 	FuHidDeviceClass parent_class;
 };
 
+/**
+ * FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED:
+ *
+ * Device requires signed firmware.
+ *
+ * Since: 1.7.0
+ */
+#define FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED (1 << 0)
+
 typedef enum {
 	FU_UNIFYING_BOOTLOADER_CMD_GENERAL_ERROR = 0x01,
 	FU_UNIFYING_BOOTLOADER_CMD_READ = 0x10,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.h
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.h
@@ -84,6 +84,9 @@ fu_logitech_hidpp_device_set_hidpp_pid(FuLogitechHidPpDevice *self, guint16 hidp
 const gchar *
 fu_logitech_hidpp_device_get_model_id(FuLogitechHidPpDevice *self);
 gboolean
-fu_logitech_hidpp_device_attach(FuLogitechHidPpDevice *self, guint8 entity, GError **error);
+fu_logitech_hidpp_device_attach(FuLogitechHidPpDevice *self,
+				guint8 entity,
+				FuProgress *progress,
+				GError **error);
 FuLogitechHidPpDevice *
 fu_logitech_hidpp_device_new(FuUdevDevice *parent);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
@@ -24,7 +24,7 @@ fu_logitech_hidpp_radio_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static gboolean
-fu_logitech_hidpp_radio_attach(FuDevice *device, GError **error)
+fu_logitech_hidpp_radio_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuLogitechHidPpRadio *self = FU_HIDPP_RADIO(device);
 	FuDevice *parent = fu_device_get_parent(device);
@@ -35,13 +35,15 @@ fu_logitech_hidpp_radio_attach(FuDevice *device, GError **error)
 	if (locker == NULL)
 		return FALSE;
 
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	return fu_logitech_hidpp_device_attach(FU_HIDPP_DEVICE(parent), self->entity, error);
+	return fu_logitech_hidpp_device_attach(FU_HIDPP_DEVICE(parent),
+					       self->entity,
+					       progress,
+					       error);
 }
 
 static gboolean
-fu_logitech_hidpp_radio_detach(FuDevice *device, GError **error)
+fu_logitech_hidpp_radio_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
 	g_autoptr(FuDeviceLocker) locker = NULL;
@@ -51,16 +53,15 @@ fu_logitech_hidpp_radio_detach(FuDevice *device, GError **error)
 	if (locker == NULL)
 		return FALSE;
 
-	if (!fu_device_has_flag(parent, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
+	if (!fu_device_has_flag(parent, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	}
-	return fu_device_detach(parent, error);
+	return fu_device_detach(parent, progress, error);
 }
 
 static gboolean
 fu_logitech_hidpp_radio_write_firmware(FuDevice *device,
 				       FuFirmware *firmware,
+				       FuProgress *progress,
 				       FwupdInstallFlags flags,
 				       GError **error)
 {
@@ -76,9 +77,7 @@ fu_logitech_hidpp_radio_write_firmware(FuDevice *device,
 	locker = fu_device_locker_new(parent, error);
 	if (locker == NULL)
 		return FALSE;
-
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
-	return fu_device_write_firmware(parent, fw, flags, error);
+	return fu_device_write_firmware(parent, fw, progress, flags, error);
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -20,7 +20,7 @@ struct _FuLogitechHidPpRuntimeBolt {
 G_DEFINE_TYPE(FuLogitechHidPpRuntimeBolt, fu_logitech_hidpp_runtime_bolt, FU_TYPE_HIDPP_RUNTIME)
 
 static gboolean
-fu_logitech_hidpp_runtime_bolt_detach(FuDevice *device, GError **error)
+fu_logitech_hidpp_runtime_bolt_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuLogitechHidPpRuntime *self = FU_HIDPP_RUNTIME(device);
 	g_autoptr(FuLogitechHidPpHidppMsg) msg = fu_logitech_hidpp_msg_new();

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuLogitechHidPpRuntimeUnifying,
 #define GET_PRIVATE(o) (fu_logitech_hidpp_runtime_unifying_get_instance_private(o))
 
 static gboolean
-fu_logitech_hidpp_runtime_unifying_detach(FuDevice *device, GError **error)
+fu_logitech_hidpp_runtime_unifying_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuLogitechHidPpRuntime *self = FU_HIDPP_RUNTIME(device);
 	g_autoptr(FuLogitechHidPpHidppMsg) msg = fu_logitech_hidpp_msg_new();
@@ -152,12 +152,23 @@ fu_logitech_hidpp_runtime_unifying_setup(FuDevice *device, GError **error)
 }
 
 static void
+fu_logitech_hidpp_runtime_unifying_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 70);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 4); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 27);	/* reload */
+}
+
+static void
 fu_logitech_hidpp_runtime_unifying_class_init(FuLogitechHidPpRuntimeUnifyingClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 
 	klass_device->detach = fu_logitech_hidpp_runtime_unifying_detach;
 	klass_device->setup = fu_logitech_hidpp_runtime_unifying_setup;
+	klass_device->set_progress = fu_logitech_hidpp_runtime_unifying_set_progress;
 }
 
 static void

--- a/plugins/modem-manager/fu-firehose-updater.h
+++ b/plugins/modem-manager/fu-firehose-updater.h
@@ -23,6 +23,7 @@ gboolean
 fu_firehose_updater_write(FuFirehoseUpdater *self,
 			  XbSilo *silo,
 			  GPtrArray *action_nodes,
+			  FuProgress *progress,
 			  GError **error);
 gboolean
 fu_firehose_updater_close(FuFirehoseUpdater *self, GError **error);

--- a/plugins/modem-manager/fu-mbim-qdu-updater.h
+++ b/plugins/modem-manager/fu-mbim-qdu-updater.h
@@ -23,6 +23,7 @@ fu_mbim_qdu_updater_write(FuMbimQduUpdater *self,
 			  const gchar *filename,
 			  GBytes *blob,
 			  FuDevice *device,
+			  FuProgress *progress,
 			  GError **error);
 gchar *
 fu_mbim_qdu_updater_check_ready(FuMbimQduUpdater *self, GError **error);

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
@@ -370,7 +371,7 @@ fu_plugin_destroy(FuPlugin *plugin)
 }
 
 gboolean
-fu_plugin_detach(FuPlugin *plugin, FuDevice *device, GError **error)
+fu_plugin_detach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
 	g_autoptr(FuDeviceLocker) locker = NULL;
@@ -397,7 +398,7 @@ fu_plugin_detach(FuPlugin *plugin, FuDevice *device, GError **error)
 	}
 
 	/* reset */
-	if (!fu_device_detach(device, error)) {
+	if (!fu_device_detach(device, progress, error)) {
 		fu_plugin_mm_uninhibit_device(plugin);
 		return FALSE;
 	}
@@ -414,7 +415,7 @@ fu_plugin_mm_device_attach_finished(gpointer user_data)
 }
 
 gboolean
-fu_plugin_attach(FuPlugin *plugin, FuDevice *device, GError **error)
+fu_plugin_attach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
@@ -434,7 +435,7 @@ fu_plugin_attach(FuPlugin *plugin, FuDevice *device, GError **error)
 	 * so that engine can setup the device "waiting" logic before the actual
 	 * attach procedure happens (which will reset the module if it worked
 	 * properly) */
-	if (!fu_device_attach(device, error))
+	if (!fu_device_attach(device, progress, error))
 		return FALSE;
 
 	/* this signal will always be emitted asynchronously */

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -38,7 +38,7 @@ fu_optionrom_device_probe(FuDevice *device, GError **error)
 }
 
 static GBytes *
-fu_optionrom_device_dump_firmware(FuDevice *device, GError **error)
+fu_optionrom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuUdevDevice *udev_device = FU_UDEV_DEVICE(device);
 	guint number_reads = 0;

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -550,6 +550,7 @@ flash_iface_read(FuRealtekMstDevice *self,
 		 guint32 address,
 		 guint8 *buf,
 		 const gsize buf_size,
+		 FuProgress *progress,
 		 GError **error)
 {
 	gsize bytes_read = 0;
@@ -591,7 +592,7 @@ flash_iface_read(FuRealtekMstDevice *self,
 			return FALSE;
 
 		bytes_read += read_len;
-		fu_device_set_progress_full(FU_DEVICE(self), bytes_read, buf_size);
+		fu_progress_set_percentage_full(progress, bytes_read, buf_size);
 	}
 	return TRUE;
 }
@@ -648,7 +649,11 @@ flash_iface_erase_block(FuRealtekMstDevice *self, guint32 address, GError **erro
 }
 
 static gboolean
-flash_iface_write(FuRealtekMstDevice *self, guint32 address, GBytes *data, GError **error)
+flash_iface_write(FuRealtekMstDevice *self,
+		  guint32 address,
+		  GBytes *data,
+		  FuProgress *progress,
+		  GError **error)
 {
 	gsize bytes_written = 0;
 	gsize total_size = g_bytes_get_size(data);
@@ -704,14 +709,14 @@ flash_iface_write(FuRealtekMstDevice *self, guint32 address, GBytes *data, GErro
 		}
 
 		bytes_written += chunk_size;
-		fu_device_set_progress_full(FU_DEVICE(self), bytes_written, total_size);
+		fu_progress_set_percentage_full(progress, i + 1, chunks->len);
 	}
 
 	return TRUE;
 }
 
 static gboolean
-fu_realtek_mst_device_detach(FuDevice *device, GError **error)
+fu_realtek_mst_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 
@@ -719,7 +724,6 @@ fu_realtek_mst_device_detach(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* Switch to programming mode (stops regular operation) */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!mst_write_register(self, REG_MCU_MODE, MCU_MODE_ISP, error))
 		return FALSE;
 	g_debug("wait for ISP mode ready");
@@ -733,7 +737,6 @@ fu_realtek_mst_device_detach(FuDevice *device, GError **error)
 		return FALSE;
 
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-	fu_device_set_status(device, FWUPD_STATUS_IDLE);
 
 	/* Disable hardware write protect, assuming Flash ~WP is connected to
 	 * device pin 88, a GPIO. */
@@ -743,6 +746,7 @@ fu_realtek_mst_device_detach(FuDevice *device, GError **error)
 static gboolean
 fu_realtek_mst_device_write_firmware(FuDevice *device,
 				     FuFirmware *firmware,
+				     FuProgress *progress,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {
@@ -759,26 +763,45 @@ fu_realtek_mst_device_write_firmware(FuDevice *device,
 
 	g_return_val_if_fail(g_bytes_get_size(firmware_bytes) == FLASH_USER_SIZE, FALSE);
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 70);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 9);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* flag */
+
 	if (!mst_ensure_device_address(self, I2C_ADDR_ISP, error))
 		return FALSE;
 
 	/* erase old image */
 	g_debug("erase old image from %#x", base_addr);
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
 	for (guint32 offset = 0; offset < FLASH_USER_SIZE; offset += FLASH_BLOCK_SIZE) {
-		fu_device_set_progress_full(device, offset, FLASH_USER_SIZE);
 		if (!flash_iface_erase_block(self, base_addr + offset, error))
 			return FALSE;
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						offset + FLASH_BLOCK_SIZE,
+						FLASH_USER_SIZE);
 	}
+	fu_progress_step_done(progress);
 
 	/* write new image */
 	g_debug("write new image to %#x", base_addr);
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
-	if (!flash_iface_write(self, base_addr, firmware_bytes, error))
+	if (!flash_iface_write(self,
+			       base_addr,
+			       firmware_bytes,
+			       fu_progress_get_child(progress),
+			       error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_VERIFY);
-	if (!flash_iface_read(self, base_addr, readback_buf, FLASH_USER_SIZE, error))
+	/* verify */
+	if (!flash_iface_read(self,
+			      base_addr,
+			      readback_buf,
+			      FLASH_USER_SIZE,
+			      fu_progress_get_child(progress),
+			      error))
 		return FALSE;
 	if (memcmp(g_bytes_get_data(firmware_bytes, NULL), readback_buf, FLASH_USER_SIZE) != 0) {
 		g_set_error(error,
@@ -787,22 +810,27 @@ fu_realtek_mst_device_write_firmware(FuDevice *device,
 			    "flash contents after write do not match firmware image");
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* Erase old flag and write new one. The MST appears to modify the
 	 * flag value once booted, so we always write the same value here and
 	 * it picks up what we've updated. */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
 	if (!flash_iface_erase_sector(self, flag_addr & ~(FLASH_SECTOR_SIZE - 1), error))
 		return FALSE;
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
-	return flash_iface_write(self,
-				 flag_addr,
-				 g_bytes_new_static(flag_data, sizeof(flag_data)),
-				 error);
+	if (!flash_iface_write(self,
+			       flag_addr,
+			       g_bytes_new_static(flag_data, sizeof(flag_data)),
+			       fu_progress_get_child(progress),
+			       error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
 }
 
 static FuFirmware *
-fu_realtek_mst_device_read_firmware(FuDevice *device, GError **error)
+fu_realtek_mst_device_read_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 	guint32 bank_address;
@@ -824,30 +852,30 @@ fu_realtek_mst_device_read_firmware(FuDevice *device, GError **error)
 	image_bytes = g_malloc0(FLASH_USER_SIZE);
 	if (!mst_ensure_device_address(self, I2C_ADDR_ISP, error))
 		return NULL;
-	if (!flash_iface_read(self, bank_address, image_bytes, FLASH_USER_SIZE, error))
+	if (!flash_iface_read(self, bank_address, image_bytes, FLASH_USER_SIZE, progress, error))
 		return NULL;
 	return fu_firmware_new_from_bytes(
 	    g_bytes_new_take(g_steal_pointer(&image_bytes), FLASH_USER_SIZE));
 }
 
 static GBytes *
-fu_realtek_mst_device_dump_firmware(FuDevice *device, GError **error)
+fu_realtek_mst_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 	g_autofree guint8 *flash_contents = g_malloc0(FLASH_SIZE);
 
 	if (!mst_ensure_device_address(self, I2C_ADDR_ISP, error))
 		return NULL;
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_READ);
-	if (!flash_iface_read(self, 0, flash_contents, FLASH_SIZE, error))
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
+	if (!flash_iface_read(self, 0, flash_contents, FLASH_SIZE, progress, error))
 		return NULL;
-	fu_device_set_status(device, FWUPD_STATUS_IDLE);
+	fu_progress_set_status(progress, FWUPD_STATUS_IDLE);
 
 	return g_bytes_new_take(g_steal_pointer(&flash_contents), FLASH_SIZE);
 }
 
 static gboolean
-fu_realtek_mst_device_attach(FuDevice *device, GError **error)
+fu_realtek_mst_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 	guint8 value;
@@ -865,7 +893,6 @@ fu_realtek_mst_device_attach(FuDevice *device, GError **error)
 		g_autoptr(GError) error_local = NULL;
 
 		g_debug("resetting device to exit ISP mode");
-		fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 
 		/* Set register EE bit 2 to request reset. This write can fail
 		 * spuriously, so we ignore the write result and verify the device is
@@ -895,8 +922,18 @@ fu_realtek_mst_device_attach(FuDevice *device, GError **error)
 	}
 
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-	fu_device_set_status(device, FWUPD_STATUS_IDLE);
 	return TRUE;
+}
+
+static void
+fu_realtek_mst_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
 }
 
 static void
@@ -942,4 +979,5 @@ fu_realtek_mst_device_class_init(FuRealtekMstDeviceClass *klass)
 	klass_device->read_firmware = fu_realtek_mst_device_read_firmware;
 	/* dump whole flash */
 	klass_device->dump_firmware = fu_realtek_mst_device_dump_firmware;
+	klass_device->set_progress = fu_realtek_mst_device_set_progress;
 }

--- a/plugins/redfish/fu-redfish-device.h
+++ b/plugins/redfish/fu-redfish-device.h
@@ -45,4 +45,7 @@ struct _FuRedfishDeviceClass {
 FuRedfishBackend *
 fu_redfish_device_get_backend(FuRedfishDevice *self);
 gboolean
-fu_redfish_device_poll_task(FuRedfishDevice *self, const gchar *location, GError **error);
+fu_redfish_device_poll_task(FuRedfishDevice *self,
+			    const gchar *location,
+			    FuProgress *progress,
+			    GError **error);

--- a/plugins/redfish/fu-redfish-legacy-device.c
+++ b/plugins/redfish/fu-redfish-legacy-device.c
@@ -18,7 +18,7 @@ struct _FuRedfishLegacyDevice {
 G_DEFINE_TYPE(FuRedfishLegacyDevice, fu_redfish_legacy_device, FU_TYPE_REDFISH_DEVICE)
 
 static gboolean
-fu_redfish_legacy_device_detach(FuDevice *dev, GError **error)
+fu_redfish_legacy_device_detach(FuDevice *dev, FuProgress *progress, GError **error)
 {
 	FuRedfishLegacyDevice *self = FU_REDFISH_LEGACY_DEVICE(dev);
 	FuRedfishBackend *backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self));
@@ -44,7 +44,7 @@ fu_redfish_legacy_device_detach(FuDevice *dev, GError **error)
 }
 
 static gboolean
-fu_redfish_legacy_device_attach(FuDevice *dev, GError **error)
+fu_redfish_legacy_device_attach(FuDevice *dev, FuProgress *progress, GError **error)
 {
 	FuRedfishLegacyDevice *self = FU_REDFISH_LEGACY_DEVICE(dev);
 	FuRedfishBackend *backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self));
@@ -71,6 +71,7 @@ fu_redfish_legacy_device_attach(FuDevice *dev, GError **error)
 static gboolean
 fu_redfish_legacy_device_write_firmware(FuDevice *device,
 					FuFirmware *firmware,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {
@@ -93,7 +94,7 @@ fu_redfish_legacy_device_write_firmware(FuDevice *device,
 	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, g_bytes_get_data(fw, NULL));
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)g_bytes_get_size(fw));
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_WRITE);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_redfish_request_perform(request,
 					fu_redfish_backend_get_push_uri_path(backend),
 					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
@@ -111,7 +112,17 @@ fu_redfish_legacy_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 	location = json_object_get_string_member(json_obj, "@odata.id");
-	return fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, error);
+	return fu_redfish_device_poll_task(FU_REDFISH_DEVICE(self), location, progress, error);
+}
+
+static void
+fu_redfish_legacy_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0);	/* reload */
 }
 
 static void
@@ -127,4 +138,5 @@ fu_redfish_legacy_device_class_init(FuRedfishLegacyDeviceClass *klass)
 	klass_device->attach = fu_redfish_legacy_device_attach;
 	klass_device->detach = fu_redfish_legacy_device_detach;
 	klass_device->write_firmware = fu_redfish_legacy_device_write_firmware;
+	klass_device->set_progress = fu_redfish_legacy_device_set_progress;
 }

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -296,6 +296,7 @@ fu_test_redfish_update_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GBytes) blob_fw = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	devices = fu_plugin_get_devices(self->plugin);
 	g_assert_nonnull(devices);
@@ -311,6 +312,7 @@ fu_test_redfish_update_func(gconstpointer user_data)
 	ret = fu_plugin_runner_write_firmware(self->plugin,
 					      dev,
 					      blob_fw,
+					      progress,
 					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_no_error(error);
@@ -321,6 +323,7 @@ fu_test_redfish_update_func(gconstpointer user_data)
 	ret = fu_plugin_runner_write_firmware(self->plugin,
 					      dev,
 					      blob_fw,
+					      progress,
 					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_WRITE);

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -209,6 +209,7 @@ fu_rts54hid_module_set_quirk_kv(FuDevice *device,
 static gboolean
 fu_rts54hid_module_write_firmware(FuDevice *module,
 				  FuFirmware *firmware,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
@@ -235,7 +236,7 @@ fu_rts54hid_module_write_firmware(FuDevice *module,
 	}
 
 	/* write each block */
-	fu_device_set_status(module, FWUPD_STATUS_DEVICE_WRITE);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 
@@ -247,7 +248,7 @@ fu_rts54hid_module_write_firmware(FuDevice *module,
 			return FALSE;
 
 		/* update progress */
-		fu_device_set_progress_full(module, (gsize)i, (gsize)chunks->len * 2);
+		fu_progress_set_percentage_full(progress, (gsize)i + 1, (gsize)chunks->len);
 	}
 
 	/* success! */

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -427,12 +427,20 @@ fu_rts54hub_device_close(FuDevice *device, GError **error)
 static gboolean
 fu_rts54hub_device_write_firmware(FuDevice *device,
 				  FuFirmware *firmware,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
 	FuRts54HubDevice *self = FU_RTS54HUB_DEVICE(device);
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 46);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 52);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1);
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -449,9 +457,9 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 	}
 
 	/* erase spare flash bank only if it is not empty */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
 	if (!fu_rts54hub_device_erase_flash(self, 1, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* set MCU clock to high clock mode */
 	if (!fu_rts54hub_device_highclockmode(self, 0x0001, error)) {
@@ -465,14 +473,11 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 
-	/* build packets */
+	/* write each block */
 	chunks = fu_chunk_array_new_from_bytes(fw,
 					       0x00, /* start addr */
 					       0x00, /* page_sz */
 					       FU_RTS54HUB_DEVICE_BLOCK_SIZE);
-
-	/* write each block */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 
@@ -485,18 +490,21 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 			return FALSE;
 
 		/* update progress */
-		fu_device_set_progress_full(device, (gsize)i, (gsize)chunks->len - 1);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)i + 1,
+						(gsize)chunks->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* get device to authenticate the firmware */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_VERIFY);
 	if (!fu_rts54hub_device_flash_authentication(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* send software reset to run available flash code */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_rts54hub_device_reset_flash(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* don't reset the vendor command enable, the device will be rebooted */
 	self->vendor_cmd = FU_RTS54HUB_VENDOR_CMD_NONE;
@@ -529,6 +537,16 @@ fu_rts54hub_device_prepare_firmware(FuDevice *device,
 }
 
 static void
+fu_rts54hub_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0);	 /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 62);	 /* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 38); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0);	 /* reload */
+}
+
+static void
 fu_rts54hub_device_init(FuRts54HubDevice *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.realtek.rts54");
@@ -544,4 +562,5 @@ fu_rts54hub_device_class_init(FuRts54HubDeviceClass *klass)
 	klass_device->to_string = fu_rts54hub_device_to_string;
 	klass_device->prepare_firmware = fu_rts54hub_device_prepare_firmware;
 	klass_device->close = fu_rts54hub_device_close;
+	klass_device->set_progress = fu_rts54hub_device_set_progress;
 }

--- a/plugins/solokey/fu-solokey-device.c
+++ b/plugins/solokey/fu-solokey-device.c
@@ -423,7 +423,6 @@ fu_solokey_device_verify(FuSolokeyDevice *self, GBytes *fw_sig, GError **error)
 	g_autoptr(GByteArray) res = NULL;
 	g_autoptr(GByteArray) sig = g_byte_array_new();
 
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_VERIFY);
 	fu_byte_array_append_bytes(sig, fw_sig);
 	fu_solokey_device_exchange(req, SOLO_BOOTLOADER_DONE, 0x00, sig);
 	res = fu_solokey_device_packet(self, SOLO_BOOTLOADER_HID_CMD_BOOT, req, error);
@@ -447,6 +446,7 @@ fu_solokey_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_solokey_device_write_firmware(FuDevice *device,
 				 FuFirmware *firmware,
+				 FuProgress *progress,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -454,6 +454,12 @@ fu_solokey_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GBytes) fw_sig = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10);
 
 	/* build packets */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -465,7 +471,6 @@ fu_solokey_device_write_firmware(FuDevice *device,
 					       2048);
 
 	/* write each block */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 		g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -490,14 +495,33 @@ fu_solokey_device_write_firmware(FuDevice *device,
 		}
 
 		/* update progress */
-		fu_device_set_progress_full(device, (gsize)i, (gsize)chunks->len);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)i + 1,
+						(gsize)chunks->len);
 	}
+	fu_progress_step_done(progress);
 
 	/* verify the signature and reboot back to runtime */
 	fw_sig = fu_firmware_get_image_by_id_bytes(firmware, FU_FIRMWARE_ID_SIGNATURE, error);
 	if (fw_sig == NULL)
 		return FALSE;
-	return fu_solokey_device_verify(self, fw_sig, error);
+	if (!fu_solokey_device_verify(self, fw_sig, error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_solokey_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
 }
 
 static void
@@ -522,4 +546,5 @@ fu_solokey_device_class_init(FuSolokeyDeviceClass *klass)
 	klass_device->setup = fu_solokey_device_setup;
 	klass_device->open = fu_solokey_device_open;
 	klass_device->close = fu_solokey_device_close;
+	klass_device->set_progress = fu_solokey_device_set_progress;
 }

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -473,6 +473,17 @@ fu_superio_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
+fu_superio_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+}
+
+static void
 fu_superio_device_init(FuSuperioDevice *self)
 {
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
@@ -517,4 +528,5 @@ fu_superio_device_class_init(FuSuperioDeviceClass *klass)
 	klass_device->probe = fu_superio_device_probe;
 	klass_device->setup = fu_superio_device_setup;
 	klass_device->prepare_firmware = fu_superio_device_prepare_firmware;
+	klass_device->set_progress = fu_superio_device_set_progress;
 }

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -834,11 +834,10 @@ static void
 fu_synaptics_cxaudio_device_set_progress(FuDevice *self, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* detach */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);	/* write */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* attach */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 3); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 37);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 60);	/* reload */
 }
 
 static void

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -119,13 +119,14 @@ gboolean
 fu_plugin_write_firmware(FuPlugin *plugin,
 			 FuDevice *device,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_write_firmware(device, blob_fw, flags, error))
+	if (!fu_device_write_firmware(device, blob_fw, progress, flags, error))
 		return FALSE;
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SKIPS_RESTART))
 		fu_plugin_device_remove(plugin, device);

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -76,6 +76,7 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) reply = NULL;
 	g_autoptr(GByteArray) request = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autofree gchar *devid = NULL;
 
 	/* get IOTA */
@@ -84,7 +85,12 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	request = fu_synaprom_request_new(FU_SYNAPROM_CMD_IOTA_FIND, &cmd, sizeof(cmd));
 	reply = fu_synaprom_reply_new(sizeof(FuSynapromReplyIotaFindHdr) +
 				      FU_SYNAPROM_MAX_IOTA_READ_SIZE);
-	if (!fu_synaprom_device_cmd_send(FU_SYNAPROM_DEVICE(parent), request, reply, 5000, error))
+	if (!fu_synaprom_device_cmd_send(FU_SYNAPROM_DEVICE(parent),
+					 request,
+					 reply,
+					 progress,
+					 5000,
+					 error))
 		return FALSE;
 	if (reply->len < sizeof(hdr) + sizeof(cfg)) {
 		g_set_error(error,
@@ -213,6 +219,7 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 static gboolean
 fu_synaprom_config_write_firmware(FuDevice *device,
 				  FuFirmware *firmware,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
@@ -225,7 +232,7 @@ fu_synaprom_config_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* I assume the CFG/MFW difference is detected in the device...*/
-	return fu_synaprom_device_write_fw(FU_SYNAPROM_DEVICE(parent), fw, error);
+	return fu_synaprom_device_write_fw(FU_SYNAPROM_DEVICE(parent), fw, progress, error);
 }
 
 static void
@@ -259,17 +266,17 @@ fu_synaprom_config_constructed(GObject *obj)
 }
 
 static gboolean
-fu_synaprom_config_attach(FuDevice *device, GError **error)
+fu_synaprom_config_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
-	return fu_device_attach(parent, error);
+	return fu_device_attach(parent, progress, error);
 }
 
 static gboolean
-fu_synaprom_config_detach(FuDevice *device, GError **error)
+fu_synaprom_config_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
-	return fu_device_detach(parent, error);
+	return fu_device_detach(parent, progress, error);
 }
 
 static void

--- a/plugins/synaptics-prometheus/fu-synaprom-device.h
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.h
@@ -26,10 +26,14 @@ gboolean
 fu_synaprom_device_cmd_send(FuSynapromDevice *device,
 			    GByteArray *request,
 			    GByteArray *reply,
+			    FuProgress *progress,
 			    guint timeout_ms,
 			    GError **error);
 gboolean
-fu_synaprom_device_write_fw(FuSynapromDevice *self, GBytes *fw, GError **error);
+fu_synaprom_device_write_fw(FuSynapromDevice *self,
+			    GBytes *fw,
+			    FuProgress *progress,
+			    GError **error);
 
 /* for self tests */
 void

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -819,16 +819,25 @@ fu_synaptics_rmi_device_disable_irqs(FuSynapticsRmiDevice *self, GError **error)
 static gboolean
 fu_synaptics_rmi_device_write_firmware(FuDevice *device,
 				       FuFirmware *firmware,
+				       FuProgress *progress,
 				       FwupdInstallFlags flags,
 				       GError **error)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE(device);
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 	if (priv->f34->function_version == 0x0 || priv->f34->function_version == 0x1) {
-		return fu_synaptics_rmi_v5_device_write_firmware(device, firmware, flags, error);
+		return fu_synaptics_rmi_v5_device_write_firmware(device,
+								 firmware,
+								 progress,
+								 flags,
+								 error);
 	}
 	if (priv->f34->function_version == 0x2) {
-		return fu_synaptics_rmi_v7_device_write_firmware(device, firmware, flags, error);
+		return fu_synaptics_rmi_v7_device_write_firmware(device,
+								 firmware,
+								 progress,
+								 flags,
+								 error);
 	}
 	g_set_error(error,
 		    FWUPD_ERROR,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -882,7 +882,7 @@ fu_synaptics_rmi_ps2_device_close(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_synaptics_rmi_ps2_device_detach(FuDevice *device, GError **error)
+fu_synaptics_rmi_ps2_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE(device);
 	FuSynapticsRmiFunction *f34;
@@ -911,10 +911,10 @@ fu_synaptics_rmi_ps2_device_detach(FuDevice *device, GError **error)
 	if (f34 == NULL)
 		return FALSE;
 	if (f34->function_version == 0x0 || f34->function_version == 0x1) {
-		if (!fu_synaptics_rmi_v5_device_detach(device, error))
+		if (!fu_synaptics_rmi_v5_device_detach(device, progress, error))
 			return FALSE;
 	} else if (f34->function_version == 0x2) {
-		if (!fu_synaptics_rmi_v7_device_detach(device, error))
+		if (!fu_synaptics_rmi_v7_device_detach(device, progress, error))
 			return FALSE;
 	} else {
 		g_set_error(error,
@@ -950,7 +950,7 @@ fu_synaptics_rmi_ps2_device_setup(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_synaptics_rmi_ps2_device_attach(FuDevice *device, GError **error)
+fu_synaptics_rmi_ps2_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuSynapticsRmiDevice *rmi_device = FU_SYNAPTICS_RMI_DEVICE(device);
 
@@ -964,8 +964,7 @@ fu_synaptics_rmi_ps2_device_attach(FuDevice *device, GError **error)
 	fu_synaptics_rmi_device_set_iepmode(rmi_device, FALSE);
 
 	/* delay after writing */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
-	fu_device_sleep_with_progress(device, 2);
+	fu_progress_sleep(progress, 2000);
 
 	/* reset device */
 	if (!fu_synaptics_rmi_device_enter_iep_mode(rmi_device,
@@ -978,7 +977,7 @@ fu_synaptics_rmi_ps2_device_attach(FuDevice *device, GError **error)
 	}
 
 	/* delay after reset */
-	fu_device_sleep_with_progress(device, 5);
+	fu_progress_sleep(progress, 5000);
 
 	/* back to psmouse */
 	if (!fu_udev_device_write_sysfs(FU_UDEV_DEVICE(device), "drvctl", "psmouse", error)) {

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.h
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.h
@@ -11,10 +11,11 @@
 #include "fu-synaptics-rmi-device.h"
 
 gboolean
-fu_synaptics_rmi_v5_device_detach(FuDevice *device, GError **error);
+fu_synaptics_rmi_v5_device_detach(FuDevice *device, FuProgress *progress, GError **error);
 gboolean
 fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 					  FuFirmware *firmware,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error);
 gboolean

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.h
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.h
@@ -11,10 +11,11 @@
 #include "fu-synaptics-rmi-device.h"
 
 gboolean
-fu_synaptics_rmi_v7_device_detach(FuDevice *device, GError **error);
+fu_synaptics_rmi_v7_device_detach(FuDevice *device, FuProgress *progress, GError **error);
 gboolean
 fu_synaptics_rmi_v7_device_write_firmware(FuDevice *device,
 					  FuFirmware *firmware,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error);
 gboolean

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -196,6 +196,7 @@ gboolean
 fu_plugin_write_firmware(FuPlugin *plugin,
 			 FuDevice *device,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -210,23 +211,20 @@ fu_plugin_write_firmware(FuPlugin *plugin,
 				    "device was not in supported mode");
 		return FALSE;
 	}
-	fu_device_set_status(device, FWUPD_STATUS_DECOMPRESSING);
-	for (guint i = 1; i <= data->delay_decompress_ms; i++) {
-		guint progress = (100 * i) / data->delay_decompress_ms;
+	fu_progress_set_status(progress, FWUPD_STATUS_DECOMPRESSING);
+	for (guint i = 0; i <= data->delay_decompress_ms; i++) {
 		g_usleep(1000);
-		fu_device_set_progress(device, progress);
+		fu_progress_set_percentage_full(progress, i, data->delay_decompress_ms);
 	}
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
-	for (guint i = 1; i <= data->delay_write_ms; i++) {
-		guint progress = (100 * i) / data->delay_write_ms;
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
+	for (guint i = 0; i <= data->delay_write_ms; i++) {
 		g_usleep(1000);
-		fu_device_set_progress(device, progress);
+		fu_progress_set_percentage_full(progress, i, data->delay_write_ms);
 	}
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_VERIFY);
-	for (guint i = 1; i <= data->delay_verify_ms; i++) {
-		guint progress = (100 * i) / data->delay_verify_ms;
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
+	for (guint i = 0; i <= data->delay_verify_ms; i++) {
 		g_usleep(1000);
-		fu_device_set_progress(device, progress);
+		fu_progress_set_percentage_full(progress, i, data->delay_verify_ms);
 	}
 
 	/* composite test, upgrade composite devices */
@@ -275,7 +273,7 @@ fu_plugin_write_firmware(FuPlugin *plugin,
 }
 
 gboolean
-fu_plugin_activate(FuPlugin *plugin, FuDevice *device, GError **error)
+fu_plugin_activate(FuPlugin *plugin, FuDevice *device, FuProgress *process, GError **error)
 {
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.3");

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1186,6 +1186,7 @@ test_update_working(ThunderboltTest *tt, gconstpointer user_data)
 	const gchar *version_after;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(UpdateContext) up_ctx = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* test sanity check */
 	g_assert_nonnull(tree);
@@ -1194,7 +1195,8 @@ test_update_working(ThunderboltTest *tt, gconstpointer user_data)
 	/* simulate an update, where the device goes away and comes back
 	 * after the time in the last parameter (given in ms) */
 	up_ctx = mock_tree_prepare_for_update(tree, plugin, "42.23", fw_data, 1000);
-	ret = fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, 0, &error);
+	ret =
+	    fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, progress, 0, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1203,7 +1205,7 @@ test_update_working(ThunderboltTest *tt, gconstpointer user_data)
 	ret = mock_tree_settle(tree, plugin);
 	g_assert_true(ret);
 
-	ret = fu_plugin_runner_attach(plugin, tree->fu_device, &error);
+	ret = fu_plugin_runner_attach(plugin, tree->fu_device, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1232,6 +1234,7 @@ test_update_wd19(ThunderboltTest *tt, gconstpointer user_data)
 	const gchar *version_before;
 	const gchar *version_after;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* test sanity check */
 	g_assert_nonnull(tree);
@@ -1242,7 +1245,8 @@ test_update_wd19(ThunderboltTest *tt, gconstpointer user_data)
 	fu_device_add_flag(tree->fu_device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
 	version_before = fu_device_get_version(tree->fu_device);
 
-	ret = fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, 0, &error);
+	ret =
+	    fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, progress, 0, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1263,6 +1267,7 @@ test_update_fail(ThunderboltTest *tt, gconstpointer user_data)
 	const gchar *version_after;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(UpdateContext) up_ctx = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* test sanity check */
 	g_assert_nonnull(tree);
@@ -1274,7 +1279,8 @@ test_update_fail(ThunderboltTest *tt, gconstpointer user_data)
 	up_ctx = mock_tree_prepare_for_update(tree, plugin, "42.23", fw_data, 1000);
 	up_ctx->result = UPDATE_FAIL_DEVICE_INTERNAL;
 
-	ret = fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, 0, &error);
+	ret =
+	    fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, progress, 0, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1284,7 +1290,7 @@ test_update_fail(ThunderboltTest *tt, gconstpointer user_data)
 	ret = mock_tree_settle(tree, plugin);
 	g_assert_true(ret);
 
-	ret = fu_plugin_runner_attach(plugin, tree->fu_device, &error);
+	ret = fu_plugin_runner_attach(plugin, tree->fu_device, progress, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
 	g_assert_false(ret);
 
@@ -1310,6 +1316,7 @@ test_update_fail_nowshow(ThunderboltTest *tt, gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(UpdateContext) up_ctx = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* test sanity check */
 	g_assert_nonnull(tree);
@@ -1321,7 +1328,8 @@ test_update_fail_nowshow(ThunderboltTest *tt, gconstpointer user_data)
 	up_ctx = mock_tree_prepare_for_update(tree, plugin, "42.23", fw_data, 1000);
 	up_ctx->result = UPDATE_FAIL_DEVICE_NOSHOW;
 
-	ret = fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, 0, &error);
+	ret =
+	    fu_plugin_runner_write_firmware(plugin, tree->fu_device, fw_data, progress, 0, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -320,6 +320,7 @@ gboolean
 fu_plugin_write_firmware(FuPlugin *plugin,
 			 FuDevice *device,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -352,12 +353,12 @@ fu_plugin_write_firmware(FuPlugin *plugin,
 	g_assert(str != NULL);
 
 	/* perform the update */
-	fu_device_set_status(device, FWUPD_STATUS_SCHEDULING);
+	fu_progress_set_status(progress, FWUPD_STATUS_SCHEDULING);
 	if (!fu_plugin_uefi_capsule_update_splash(plugin, device, &error_splash)) {
 		g_debug("failed to upload UEFI UX capsule text: %s", error_splash->message);
 	}
 
-	return fu_device_write_firmware(device, blob_fw, flags, error);
+	return fu_device_write_firmware(device, blob_fw, progress, flags, error);
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -147,6 +147,7 @@ fu_uefi_cod_device_get_results(FuDevice *device, GError **error)
 static gboolean
 fu_uefi_cod_device_write_firmware(FuDevice *device,
 				  FuFirmware *firmware,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -766,6 +766,17 @@ fu_uefi_device_set_property(GObject *object, guint prop_id, const GValue *value,
 }
 
 static void
+fu_uefi_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+}
+
+static void
 fu_uefi_device_init(FuUefiDevice *self)
 {
 	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device");
@@ -824,6 +835,7 @@ fu_uefi_device_class_init(FuUefiDeviceClass *klass)
 	klass_device->report_metadata_pre = fu_uefi_device_report_metadata_pre;
 	klass_device->report_metadata_post = fu_uefi_device_report_metadata_post;
 	klass_device->get_results = fu_uefi_device_get_results;
+	klass_device->set_progress = fu_uefi_device_set_progress;
 
 	pspec =
 	    g_param_spec_string("fw-class",

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -109,6 +109,7 @@ fu_uefi_grub_device_mkconfig(FuDevice *device,
 static gboolean
 fu_uefi_grub_device_write_firmware(FuDevice *device,
 				   FuFirmware *firmware,
+				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -47,6 +47,7 @@ fu_uefi_nvram_device_get_results(FuDevice *device, GError **error)
 static gboolean
 fu_uefi_nvram_device_write_firmware(FuDevice *device,
 				    FuFirmware *firmware,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -387,6 +387,7 @@ main(int argc, char *argv[])
 	if (apply != NULL) {
 		g_autoptr(FuContext) ctx = fu_context_new();
 		g_autoptr(FuBackend) backend = fu_uefi_backend_new(ctx);
+		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 		g_autoptr(FuUefiDevice) dev = NULL;
 		g_autoptr(GError) error_local = NULL;
 		g_autoptr(GBytes) fw = NULL;
@@ -427,6 +428,7 @@ main(int argc, char *argv[])
 		}
 		if (!fu_device_write_firmware(FU_DEVICE(dev),
 					      fw,
+					      progress,
 					      FWUPD_INSTALL_FLAG_NONE,
 					      &error_local)) {
 			g_printerr("failed: %s\n", error_local->message);

--- a/plugins/vli/fu-vli-device.h
+++ b/plugins/vli/fu-vli-device.h
@@ -60,9 +60,13 @@ fu_vli_device_get_spi_cmd(FuVliDevice *self, FuVliDeviceSpiReq req, guint8 *cmd,
 gboolean
 fu_vli_device_spi_erase_sector(FuVliDevice *self, guint32 addr, GError **error);
 gboolean
-fu_vli_device_spi_erase_all(FuVliDevice *self, GError **error);
+fu_vli_device_spi_erase_all(FuVliDevice *self, FuProgress *progress, GError **error);
 gboolean
-fu_vli_device_spi_erase(FuVliDevice *self, guint32 addr, gsize sz, GError **error);
+fu_vli_device_spi_erase(FuVliDevice *self,
+			guint32 addr,
+			gsize sz,
+			FuProgress *progress,
+			GError **error);
 gboolean
 fu_vli_device_spi_read_block(FuVliDevice *self,
 			     guint32 addr,
@@ -70,16 +74,22 @@ fu_vli_device_spi_read_block(FuVliDevice *self,
 			     gsize bufsz,
 			     GError **error);
 GBytes *
-fu_vli_device_spi_read(FuVliDevice *self, guint32 address, gsize bufsz, GError **error);
+fu_vli_device_spi_read(FuVliDevice *self,
+		       guint32 address,
+		       gsize bufsz,
+		       FuProgress *progress,
+		       GError **error);
 gboolean
 fu_vli_device_spi_write_block(FuVliDevice *self,
 			      guint32 address,
 			      const guint8 *buf,
 			      gsize bufsz,
+			      FuProgress *progress,
 			      GError **error);
 gboolean
 fu_vli_device_spi_write(FuVliDevice *self,
 			guint32 address,
 			const guint8 *buf,
 			gsize bufsz,
+			FuProgress *progress,
 			GError **error);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -346,13 +346,10 @@ fu_vli_usbhub_device_spi_write_data(FuVliDevice *self,
 #define VL817_ADDR_GPIO_GET_INPUT_DATA	0xF6A2 /* 0=low, 1=high */
 
 static gboolean
-fu_vli_usbhub_device_attach(FuDevice *device, GError **error)
+fu_vli_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy_with_fallback(device);
 	g_autoptr(GError) error_local = NULL;
-
-	/* update UI */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 
 	/* some hardware has to toggle a GPIO to reset the entire PCB */
 	if (fu_vli_device_get_kind(FU_VLI_DEVICE(proxy)) == FU_VLI_DEVICE_KIND_VL817 &&
@@ -840,11 +837,20 @@ fu_vli_usbhub_device_prepare_firmware(FuDevice *device,
 }
 
 static gboolean
-fu_vli_usbhub_device_update_v1(FuVliUsbhubDevice *self, FuFirmware *firmware, GError **error)
+fu_vli_usbhub_device_update_v1(FuVliUsbhubDevice *self,
+			       FuFirmware *firmware,
+			       FuProgress *progress,
+			       GError **error)
 {
 	gsize bufsz = 0;
 	const guint8 *buf;
 	g_autoptr(GBytes) fw = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
 
 	/* simple image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -852,47 +858,66 @@ fu_vli_usbhub_device_update_v1(FuVliUsbhubDevice *self, FuFirmware *firmware, GE
 		return FALSE;
 
 	/* erase */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_ERASE);
-	if (!fu_vli_device_spi_erase_all(FU_VLI_DEVICE(self), error)) {
+	if (!fu_vli_device_spi_erase_all(FU_VLI_DEVICE(self),
+					 fu_progress_get_child(progress),
+					 error)) {
 		g_prefix_error(error, "failed to erase chip: ");
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* write in chunks */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_WRITE);
 	buf = g_bytes_get_data(fw, &bufsz);
-	if (!fu_vli_device_spi_write(FU_VLI_DEVICE(self), 0x0, buf, bufsz, error))
+	if (!fu_vli_device_spi_write(FU_VLI_DEVICE(self),
+				     0x0,
+				     buf,
+				     bufsz,
+				     fu_progress_get_child(progress),
+				     error))
 		return FALSE;
 
 	/* success */
+	fu_progress_step_done(progress);
 	return TRUE;
 }
 
 /* if no header1 or ROM code update, write data directly */
 static gboolean
-fu_vli_usbhub_device_update_v2_recovery(FuVliUsbhubDevice *self, GBytes *fw, GError **error)
+fu_vli_usbhub_device_update_v2_recovery(FuVliUsbhubDevice *self,
+					GBytes *fw,
+					FuProgress *progress,
+					GError **error)
 {
 	gsize bufsz = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
+
 	/* erase */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_ERASE);
 	for (guint32 addr = 0; addr < bufsz; addr += 0x1000) {
 		if (!fu_vli_device_spi_erase_sector(FU_VLI_DEVICE(self), addr, error)) {
 			g_prefix_error(error, "failed to erase sector @0x%x: ", addr);
 			return FALSE;
 		}
-		fu_device_set_progress_full(FU_DEVICE(self), (gsize)addr, bufsz);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						(gsize)addr,
+						bufsz);
 	}
+	fu_progress_step_done(progress);
 
 	/* write in chunks */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_vli_device_spi_write(FU_VLI_DEVICE(self),
 				     VLI_USBHUB_FLASHMAP_ADDR_HD1,
 				     buf,
 				     bufsz,
+				     fu_progress_get_child(progress),
 				     error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* success */
 	return TRUE;
@@ -909,7 +934,10 @@ fu_vli_usbhub_device_hd1_is_valid(FuVliUsbhubHeader *hdr)
 }
 
 static gboolean
-fu_vli_usbhub_device_hd1_recover(FuVliUsbhubDevice *self, FuVliUsbhubHeader *hdr, GError **error)
+fu_vli_usbhub_device_hd1_recover(FuVliUsbhubDevice *self,
+				 FuVliUsbhubHeader *hdr,
+				 FuProgress *progress,
+				 GError **error)
 {
 	/* point to HD2, i.e. updated firmware */
 	if (hdr->next_ptr != VLI_USBHUB_FLASHMAP_IDX_HD2) {
@@ -930,6 +958,7 @@ fu_vli_usbhub_device_hd1_recover(FuVliUsbhubDevice *self, FuVliUsbhubHeader *hdr
 					   VLI_USBHUB_FLASHMAP_ADDR_HD1,
 					   (const guint8 *)hdr,
 					   sizeof(FuVliUsbhubHeader),
+					   progress,
 					   error)) {
 		g_prefix_error(error,
 			       "failed to write header1 block at 0x%x: ",
@@ -943,7 +972,10 @@ fu_vli_usbhub_device_hd1_recover(FuVliUsbhubDevice *self, FuVliUsbhubHeader *hdr
 }
 
 static gboolean
-fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self, FuFirmware *firmware, GError **error)
+fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
+			       FuFirmware *firmware,
+			       FuProgress *progress,
+			       GError **error)
 {
 	gsize buf_fwsz = 0;
 	guint32 hd1_fw_sz;
@@ -974,11 +1006,15 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self, FuFirmware *firmware, GE
 							   VLI_USBHUB_FLASHMAP_ADDR_HD1_BACKUP,
 							   (const guint8 *)&self->hd1_hdr,
 							   sizeof(hdr),
+							   progress,
 							   error)) {
 				g_prefix_error(error, "failed to write block at header 1: ");
 				return FALSE;
 			}
-			if (!fu_vli_usbhub_device_hd1_recover(self, &self->hd1_hdr, error)) {
+			if (!fu_vli_usbhub_device_hd1_recover(self,
+							      &self->hd1_hdr,
+							      progress,
+							      error)) {
 				g_prefix_error(error, "failed to write header: ");
 				return FALSE;
 			}
@@ -999,9 +1035,9 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self, FuFirmware *firmware, GE
 		}
 		if (!fu_vli_usbhub_device_hd1_is_valid(&self->hd1_hdr)) {
 			g_debug("backup header is also invalid, starting recovery");
-			return fu_vli_usbhub_device_update_v2_recovery(self, fw, error);
+			return fu_vli_usbhub_device_update_v2_recovery(self, fw, progress, error);
 		}
-		if (!fu_vli_usbhub_device_hd1_recover(self, &self->hd1_hdr, error)) {
+		if (!fu_vli_usbhub_device_hd1_recover(self, &self->hd1_hdr, progress, error)) {
 			g_prefix_error(error, "failed to get root header in backup zone: ");
 			return FALSE;
 		}
@@ -1027,21 +1063,32 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self, FuFirmware *firmware, GE
 	hd2_fw_offset = GUINT16_FROM_BE(hdr.usb3_fw_addr);
 	g_debug("FW2 @0x%x (length 0x%x, offset 0x%x)", hd2_fw_addr, hd2_fw_sz, hd2_fw_offset);
 
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 72);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 8); /* HD2 */
+
 	/* make space */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_ERASE);
-	if (!fu_vli_device_spi_erase(FU_VLI_DEVICE(self), hd2_fw_addr, hd2_fw_sz, error))
+	if (!fu_vli_device_spi_erase(FU_VLI_DEVICE(self),
+				     hd2_fw_addr,
+				     hd2_fw_sz,
+				     fu_progress_get_child(progress),
+				     error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* perform the actual write */
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_vli_device_spi_write(FU_VLI_DEVICE(self),
 				     hd2_fw_addr,
 				     buf_fw + hd2_fw_offset,
 				     hd2_fw_sz,
+				     fu_progress_get_child(progress),
 				     error)) {
 		g_prefix_error(error, "failed to write payload: ");
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* map into header */
 	if (!fu_memcpy_safe((guint8 *)&self->hd2_hdr,
@@ -1072,29 +1119,33 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self, FuFirmware *firmware, GE
 					   VLI_USBHUB_FLASHMAP_ADDR_HD2,
 					   (const guint8 *)&self->hd2_hdr,
 					   sizeof(self->hd2_hdr),
+					   fu_progress_get_child(progress),
 					   error)) {
 		g_prefix_error(error, "failed to write HD2: ");
 		return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* success */
 	return TRUE;
 }
 
 static GBytes *
-fu_vli_usbhub_device_dump_firmware(FuDevice *device, GError **error)
+fu_vli_usbhub_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE(device);
-	fu_device_set_status(FU_DEVICE(self), FWUPD_STATUS_DEVICE_READ);
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 	return fu_vli_device_spi_read(FU_VLI_DEVICE(self),
 				      0x0,
 				      fu_device_get_firmware_size_max(device),
+				      progress,
 				      error);
 }
 
 static gboolean
 fu_vli_usbhub_device_write_firmware(FuDevice *device,
 				    FuFirmware *firmware,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {
@@ -1110,9 +1161,9 @@ fu_vli_usbhub_device_write_firmware(FuDevice *device,
 
 	/* use correct method */
 	if (self->update_protocol == 0x1)
-		return fu_vli_usbhub_device_update_v1(self, firmware, error);
+		return fu_vli_usbhub_device_update_v1(self, firmware, progress, error);
 	if (self->update_protocol == 0x2)
-		return fu_vli_usbhub_device_update_v2(self, firmware, error);
+		return fu_vli_usbhub_device_update_v2(self, firmware, progress, error);
 
 	/* not sure what to do */
 	g_set_error(error,
@@ -1121,6 +1172,17 @@ fu_vli_usbhub_device_write_firmware(FuDevice *device,
 		    "update protocol 0x%x not supported",
 		    self->update_protocol);
 	return FALSE;
+}
+
+static void
+fu_vli_usbhub_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
 }
 
 static void
@@ -1161,6 +1223,7 @@ fu_vli_usbhub_device_class_init(FuVliUsbhubDeviceClass *klass)
 	klass_device->attach = fu_vli_usbhub_device_attach;
 	klass_device->to_string = fu_vli_usbhub_device_to_string;
 	klass_device->ready = fu_vli_usbhub_device_ready;
+	klass_device->set_progress = fu_vli_usbhub_device_set_progress;
 	klass_vli_device->spi_chip_erase = fu_vli_usbhub_device_spi_chip_erase;
 	klass_vli_device->spi_sector_erase = fu_vli_usbhub_device_spi_sector_erase;
 	klass_vli_device->spi_read_data = fu_vli_usbhub_device_spi_read_data;

--- a/plugins/wacom-raw/fu-wacom-device.h
+++ b/plugins/wacom-raw/fu-wacom-device.h
@@ -15,7 +15,10 @@ G_DECLARE_DERIVABLE_TYPE(FuWacomDevice, fu_wacom_device, FU, WACOM_DEVICE, FuUde
 
 struct _FuWacomDeviceClass {
 	FuUdevDeviceClass parent_class;
-	gboolean (*write_firmware)(FuDevice *self, GPtrArray *chunks, GError **error);
+	gboolean (*write_firmware)(FuDevice *self,
+				   GPtrArray *chunks,
+				   FuProgress *progress,
+				   GError **error);
 };
 
 typedef enum {

--- a/plugins/wacom-usb/fu-plugin-wacom-usb.c
+++ b/plugins/wacom-usb/fu-plugin-wacom-usb.c
@@ -25,6 +25,7 @@ gboolean
 fu_plugin_write_firmware(FuPlugin *plugin,
 			 FuDevice *device,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -33,5 +34,5 @@ fu_plugin_write_firmware(FuPlugin *plugin,
 	locker = fu_device_locker_new(parent != NULL ? parent : device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware(device, blob_fw, flags, error);
+	return fu_device_write_firmware(device, blob_fw, progress, flags, error);
 }

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -471,6 +471,7 @@ fu_wac_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_wac_device_write_firmware(FuDevice *device,
 			     FuFirmware *firmware,
+			     FuProgress *progress,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -480,6 +481,14 @@ fu_wac_device_write_firmware(FuDevice *device,
 	g_autofree guint32 *csum_local = NULL;
 	g_autoptr(FuFirmware) img = NULL;
 	g_autoptr(GHashTable) fd_blobs = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 2);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
 
 	/* get current selected device */
 	if (!fu_wac_device_ensure_firmware_index(self, error))
@@ -506,9 +515,9 @@ fu_wac_device_write_firmware(FuDevice *device,
 	/* get the updater protocol version */
 	if (!fu_wac_device_ensure_checksums(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
 	/* clear all checksums of pages */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_ERASE);
 	for (guint16 i = 0; i < self->flash_descriptors->len; i++) {
 		FuWacFlashDescriptor *fd = g_ptr_array_index(self->flash_descriptors, i);
 		if (fu_wav_device_flash_descriptor_is_wp(fd))
@@ -516,6 +525,7 @@ fu_wac_device_write_firmware(FuDevice *device,
 		if (!fu_wac_device_set_checksum_of_block(self, i, 0x0, error))
 			return FALSE;
 	}
+	fu_progress_step_done(progress);
 
 	/* get the blobs for each chunk */
 	fd_blobs = g_hash_table_new_full(g_direct_hash,
@@ -537,10 +547,9 @@ fu_wac_device_write_firmware(FuDevice *device,
 	}
 
 	/* checksum actions post-write */
-	blocks_total = g_hash_table_size(fd_blobs) + 2;
+	blocks_total = g_hash_table_size(fd_blobs);
 
 	/* write the data into the flash page */
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_WRITE);
 	csum_local = g_new0(guint32, self->flash_descriptors->len);
 	for (guint16 i = 0; i < self->flash_descriptors->len; i++) {
 		FuWacFlashDescriptor *fd = g_ptr_array_index(self->flash_descriptors, i);
@@ -559,7 +568,9 @@ fu_wac_device_write_firmware(FuDevice *device,
 		/* ignore empty blocks */
 		if (fu_common_bytes_is_empty(blob_block)) {
 			g_debug("empty block, ignoring");
-			fu_device_set_progress_full(device, blocks_done++, blocks_total);
+			fu_progress_set_percentage_full(fu_progress_get_child(progress),
+							blocks_done++,
+							blocks_total);
 			continue;
 		}
 
@@ -590,8 +601,11 @@ fu_wac_device_write_firmware(FuDevice *device,
 			return FALSE;
 
 		/* update device progress */
-		fu_device_set_progress_full(device, blocks_done++, blocks_total);
+		fu_progress_set_percentage_full(fu_progress_get_child(progress),
+						blocks_done++,
+						blocks_total);
 	}
+	fu_progress_step_done(progress);
 
 	/* check at least one block was written */
 	if (blocks_done == 0) {
@@ -607,9 +621,6 @@ fu_wac_device_write_firmware(FuDevice *device,
 		if (!fu_wac_device_calculate_checksum_of_block(self, i, error))
 			return FALSE;
 	}
-
-	/* update device progress */
-	fu_device_set_progress_full(device, blocks_done++, blocks_total);
 
 	/* read all CRC of all pages and verify with local CRC */
 	if (!fu_wac_device_ensure_checksums(self, error))
@@ -646,16 +657,14 @@ fu_wac_device_write_firmware(FuDevice *device,
 		if (g_getenv("FWUPD_WACOM_USB_VERBOSE") != NULL)
 			g_debug("matched checksum at block %u of 0x%08x", i, csum_rom);
 	}
-
-	/* update device progress */
-	fu_device_set_progress_full(device, blocks_done++, blocks_total);
+	fu_progress_step_done(progress);
 
 	/* store host CRC into flash */
 	if (!fu_wac_device_write_checksum_table(self, error))
 		return FALSE;
+	fu_progress_step_done(progress);
 
-	/* update progress */
-	fu_device_set_progress_full(device, blocks_total, blocks_total);
+	/* success */
 	return TRUE;
 }
 
@@ -861,9 +870,18 @@ fu_wac_device_close(FuDevice *device, GError **error)
 static gboolean
 fu_wac_device_cleanup(FuDevice *device, FwupdInstallFlags flags, GError **error)
 {
-	fu_device_set_status(device, FWUPD_STATUS_DEVICE_RESTART);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return fu_wac_device_update_reset(FU_WAC_DEVICE(device), error);
+}
+
+static void
+fu_wac_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
 }
 
 static void
@@ -904,4 +922,5 @@ fu_wac_device_class_init(FuWacDeviceClass *klass)
 	klass_device->setup = fu_wac_device_setup;
 	klass_device->cleanup = fu_wac_device_cleanup;
 	klass_device->close = fu_wac_device_close;
+	klass_device->set_progress = fu_wac_device_set_progress;
 }

--- a/plugins/wacom-usb/fu-wac-module.h
+++ b/plugins/wacom-usb/fu-wac-module.h
@@ -26,4 +26,8 @@ struct _FuWacModuleClass {
 #define FU_WAC_MODULE_COMMAND_END   0x03
 
 gboolean
-fu_wac_module_set_feature(FuWacModule *self, guint8 command, GBytes *blob, GError **error);
+fu_wac_module_set_feature(FuWacModule *self,
+			  guint8 command,
+			  GBytes *blob,
+			  FuProgress *progress,
+			  GError **error);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -54,6 +54,7 @@
 #include "fu-plugin-list.h"
 #include "fu-plugin-private.h"
 #include "fu-plugin.h"
+#include "fu-progress.h"
 #include "fu-quirks.h"
 #include "fu-remote-list.h"
 #include "fu-security-attr.h"
@@ -202,19 +203,21 @@ fu_engine_set_percentage(FuEngine *self, guint percentage)
 }
 
 static void
-fu_engine_progress_notify_cb(FuDevice *device, GParamSpec *pspec, FuEngine *self)
+fu_engine_progress_percentage_changed_cb(FuProgress *progress, guint percentage, FuEngine *self)
 {
-	if (fu_device_get_status(device) == FWUPD_STATUS_UNKNOWN)
-		return;
-	fu_engine_set_percentage(self, fu_device_get_progress(device));
-	fu_engine_emit_device_changed(self, device);
+	/* this is global for all the tasks and divisions */
+	fu_engine_set_percentage(self, percentage);
 }
 
 static void
-fu_engine_status_notify_cb(FuDevice *device, GParamSpec *pspec, FuEngine *self)
+fu_engine_progress_status_changed_cb(FuProgress *progress, FwupdStatus status, FuEngine *self)
 {
-	fu_engine_set_status(self, fu_device_get_status(device));
-	fu_engine_emit_device_changed(self, device);
+	/* ignore */
+	if (status == FWUPD_STATUS_UNKNOWN)
+		return;
+
+	/* this is global for all the tasks and divisions */
+	fu_engine_set_status(self, status);
 }
 
 static void
@@ -249,19 +252,10 @@ fu_engine_watch_device(FuEngine *self, FuDevice *device)
 {
 	g_autoptr(FuDevice) device_old = fu_device_list_get_old(self->device_list, device);
 	if (device_old != NULL) {
-		g_signal_handlers_disconnect_by_func(device_old,
-						     fu_engine_progress_notify_cb,
-						     self);
-		g_signal_handlers_disconnect_by_func(device_old, fu_engine_status_notify_cb, self);
 		g_signal_handlers_disconnect_by_func(device_old, fu_engine_generic_notify_cb, self);
 		g_signal_handlers_disconnect_by_func(device_old, fu_engine_history_notify_cb, self);
 		g_signal_handlers_disconnect_by_func(device_old, fu_engine_device_request_cb, self);
 	}
-	g_signal_connect(device,
-			 "notify::progress",
-			 G_CALLBACK(fu_engine_progress_notify_cb),
-			 self);
-	g_signal_connect(device, "notify::status", G_CALLBACK(fu_engine_status_notify_cb), self);
 	g_signal_connect(device, "notify::flags", G_CALLBACK(fu_engine_generic_notify_cb), self);
 	g_signal_connect(device,
 			 "notify::update-message",
@@ -847,6 +841,7 @@ fu_engine_verify_update(FuEngine *self, const gchar *device_id, GError **error)
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *localstatedir = NULL;
 	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GFile) file = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderNode) component = NULL;
@@ -858,6 +853,17 @@ fu_engine_verify_update(FuEngine *self, const gchar *device_id, GError **error)
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(device_id != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* progress */
+	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_engine_progress_percentage_changed_cb),
+			 self);
+	g_signal_connect(progress,
+			 "status-changed",
+			 G_CALLBACK(fu_engine_progress_status_changed_cb),
+			 self);
 
 	/* check the devices still exists */
 	device = fu_device_list_get_by_id(self->device_list, device_id, error);
@@ -873,7 +879,11 @@ fu_engine_verify_update(FuEngine *self, const gchar *device_id, GError **error)
 	/* get the checksum */
 	checksums = fu_device_get_checksums(device);
 	if (checksums->len == 0) {
-		if (!fu_plugin_runner_verify(plugin, device, FU_PLUGIN_VERIFY_FLAG_NONE, error))
+		if (!fu_plugin_runner_verify(plugin,
+					     device,
+					     progress,
+					     FU_PLUGIN_VERIFY_FLAG_NONE,
+					     error))
 			return FALSE;
 		fu_engine_emit_device_changed(self, device);
 	}
@@ -1071,6 +1081,7 @@ fu_engine_verify(FuEngine *self, const gchar *device_id, GError **error)
 	FuPlugin *plugin;
 	GPtrArray *checksums;
 	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GString) xpath_csum = g_string_new(NULL);
 	g_autoptr(XbNode) csum = NULL;
@@ -1079,6 +1090,17 @@ fu_engine_verify(FuEngine *self, const gchar *device_id, GError **error)
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(device_id != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* progress */
+	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_engine_progress_percentage_changed_cb),
+			 self);
+	g_signal_connect(progress,
+			 "status-changed",
+			 G_CALLBACK(fu_engine_progress_status_changed_cb),
+			 self);
 
 	/* check the id exists */
 	device = fu_device_list_get_by_id(self->device_list, device_id, error);
@@ -1093,7 +1115,11 @@ fu_engine_verify(FuEngine *self, const gchar *device_id, GError **error)
 
 	/* update the device firmware hashes if possible */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE)) {
-		if (!fu_plugin_runner_verify(plugin, device, FU_PLUGIN_VERIFY_FLAG_NONE, error))
+		if (!fu_plugin_runner_verify(plugin,
+					     device,
+					     progress,
+					     FU_PLUGIN_VERIFY_FLAG_NONE,
+					     error))
 			return FALSE;
 	}
 
@@ -2057,6 +2083,7 @@ fu_engine_install_tasks(FuEngine *self,
 	g_autoptr(FuIdleLocker) locker = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GPtrArray) devices_new = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* do not allow auto-shutdown during this time */
 	locker = fu_idle_locker_new(self->idle, "update");
@@ -2077,9 +2104,25 @@ fu_engine_install_tasks(FuEngine *self,
 	}
 
 	/* all authenticated, so install all the things */
+	fu_progress_set_steps(progress, install_tasks->len);
+	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_engine_progress_percentage_changed_cb),
+			 self);
+	g_signal_connect(progress,
+			 "status-changed",
+			 G_CALLBACK(fu_engine_progress_status_changed_cb),
+			 self);
 	for (guint i = 0; i < install_tasks->len; i++) {
 		FuInstallTask *task = g_ptr_array_index(install_tasks, i);
-		if (!fu_engine_install(self, task, blob_cab, flags, feature_flags, error)) {
+		if (!fu_engine_install(self,
+				       task,
+				       blob_cab,
+				       fu_progress_get_child(progress),
+				       flags,
+				       feature_flags,
+				       error)) {
 			g_autoptr(GError) error_local = NULL;
 			if (!fu_engine_composite_cleanup(self, devices, &error_local)) {
 				g_warning("failed to cleanup failed composite action: %s",
@@ -2087,13 +2130,14 @@ fu_engine_install_tasks(FuEngine *self,
 			}
 			return FALSE;
 		}
+		fu_progress_step_done(progress);
 	}
 
 	/* set all the device statuses back to unknown */
 	for (guint i = 0; i < install_tasks->len; i++) {
 		FuInstallTask *task = g_ptr_array_index(install_tasks, i);
 		FuDevice *device = fu_install_task_get_device(task);
-		fu_device_set_status(device, FWUPD_STATUS_UNKNOWN);
+		fwupd_device_set_status(FWUPD_DEVICE(device), FWUPD_STATUS_UNKNOWN);
 	}
 
 	/* get a new list of devices in case they replugged */
@@ -2120,6 +2164,7 @@ fu_engine_install_tasks(FuEngine *self,
 	}
 
 	/* success */
+	fu_engine_set_status(self, FWUPD_STATUS_IDLE);
 	return TRUE;
 }
 
@@ -2312,7 +2357,6 @@ fu_engine_schedule_update(FuEngine *self,
 	filename = g_build_filename(dirname, tmpname, NULL);
 
 	/* just copy to the temp file */
-	fu_device_set_status(device, FWUPD_STATUS_SCHEDULING);
 	if (!g_file_set_contents(filename,
 				 g_bytes_get_data(blob_cab, NULL),
 				 (gssize)g_bytes_get_size(blob_cab),
@@ -2332,7 +2376,6 @@ fu_engine_schedule_update(FuEngine *self,
 		return FALSE;
 
 	/* next boot we run offline */
-	fu_device_set_progress(device, 100);
 	return fu_engine_offline_setup(error);
 }
 
@@ -2341,6 +2384,7 @@ fu_engine_install_release(FuEngine *self,
 			  FuDevice *device_orig,
 			  XbNode *component,
 			  XbNode *rel,
+			  FuProgress *progress,
 			  FwupdInstallFlags flags,
 			  FwupdFeatureFlags feature_flags,
 			  GError **error)
@@ -2414,8 +2458,13 @@ fu_engine_install_release(FuEngine *self,
 
 	/* install firmware blob */
 	version_orig = g_strdup(fu_device_get_version(device));
-	if (!fu_engine_install_blob(self, device, blob_fw2, flags, feature_flags, &error_local)) {
-		fu_device_set_status(device, FWUPD_STATUS_IDLE);
+	if (!fu_engine_install_blob(self,
+				    device,
+				    blob_fw2,
+				    progress,
+				    flags,
+				    feature_flags,
+				    &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_AC_POWER_REQUIRED) ||
 		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW) ||
 		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NEEDS_USER_ACTION) ||
@@ -2513,6 +2562,7 @@ fu_engine_sort_releases(FuEngine *self, FuDevice *device, GPtrArray *rels, GErro
  * @self: a #FuEngine
  * @task: a #FuInstallTask
  * @blob_cab: the #GBytes of the .cab file
+ * @progress: a #FuProgress
  * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_ALLOW_OLDER
  * @feature_flags: feature flags, e.g. %FWUPD_FEATURE_FLAG_NONE
  * @error: (nullable): optional return location for an error
@@ -2529,6 +2579,7 @@ gboolean
 fu_engine_install(FuEngine *self,
 		  FuInstallTask *task,
 		  GBytes *blob_cab,
+		  FuProgress *progress,
 		  FwupdInstallFlags flags,
 		  FwupdFeatureFlags feature_flags,
 		  GError **error)
@@ -2542,6 +2593,7 @@ fu_engine_install(FuEngine *self,
 #endif
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
+	g_return_val_if_fail(FU_IS_PROGRESS(progress), FALSE);
 	g_return_val_if_fail(XB_IS_NODE(component), FALSE);
 	g_return_val_if_fail(blob_cab != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -2597,6 +2649,7 @@ fu_engine_install(FuEngine *self,
 			if (!fu_plugin_runner_prepare(plugin, device, flags, error))
 				return FALSE;
 		}
+		fu_progress_set_status(progress, FWUPD_STATUS_SCHEDULING);
 		release_tmp = fu_engine_create_release_metadata(self, device, plugin, error);
 		if (release_tmp == NULL)
 			return FALSE;
@@ -2622,22 +2675,26 @@ fu_engine_install(FuEngine *self,
 		}
 		if (!fu_engine_sort_releases(self, device, rels, error))
 			return FALSE;
+		fu_progress_set_steps(progress, rels->len);
 		for (guint i = 0; i < rels->len; i++) {
 			XbNode *rel = g_ptr_array_index(rels, i);
 			if (!fu_engine_install_release(self,
 						       device,
 						       component,
 						       rel,
+						       fu_progress_get_child(progress),
 						       flags,
 						       feature_flags,
 						       error))
 				return FALSE;
+			fu_progress_step_done(progress);
 		}
 	} else {
 		if (!fu_engine_install_release(self,
 					       device,
 					       component,
 					       rel_newest,
+					       progress,
 					       flags,
 					       feature_flags,
 					       error))
@@ -2856,6 +2913,7 @@ fu_engine_cleanup(FuEngine *self, FwupdInstallFlags flags, const gchar *device_i
 static gboolean
 fu_engine_detach(FuEngine *self,
 		 const gchar *device_id,
+		 FuProgress *progress,
 		 FwupdFeatureFlags feature_flags,
 		 GError **error)
 {
@@ -2875,7 +2933,7 @@ fu_engine_detach(FuEngine *self,
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
 		return FALSE;
-	if (!fu_plugin_runner_detach(plugin, device, error))
+	if (!fu_plugin_runner_detach(plugin, device, progress, error))
 		return FALSE;
 
 	/* support older clients without the ability to do immediate requests */
@@ -2903,7 +2961,7 @@ fu_engine_detach(FuEngine *self,
 }
 
 static gboolean
-fu_engine_attach(FuEngine *self, const gchar *device_id, GError **error)
+fu_engine_attach(FuEngine *self, const gchar *device_id, FuProgress *progress, GError **error)
 {
 	FuPlugin *plugin;
 	g_autofree gchar *str = NULL;
@@ -2922,8 +2980,23 @@ fu_engine_attach(FuEngine *self, const gchar *device_id, GError **error)
 	if (plugin == NULL)
 		return FALSE;
 
-	if (!fu_plugin_runner_attach(plugin, device, error))
+	if (!fu_plugin_runner_attach(plugin, device, progress, error))
 		return FALSE;
+	return TRUE;
+}
+
+static gboolean
+fu_engine_set_progress(FuEngine *self, const gchar *device_id, FuProgress *progress, GError **error)
+{
+	g_autoptr(FuDevice) device = NULL;
+
+	/* the device and plugin both may have changed */
+	device = fu_engine_get_device(self, device_id, error);
+	if (device == NULL) {
+		g_prefix_error(error, "failed to get device before setting progress: ");
+		return FALSE;
+	}
+	fu_device_set_progress(device, progress);
 	return TRUE;
 }
 
@@ -2931,12 +3004,24 @@ gboolean
 fu_engine_activate(FuEngine *self, const gchar *device_id, GError **error)
 {
 	FuPlugin *plugin;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuDevice) device = NULL;
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(device_id != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* progress */
+	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
+	g_signal_connect(progress,
+			 "percentage-changed",
+			 G_CALLBACK(fu_engine_progress_percentage_changed_cb),
+			 self);
+	g_signal_connect(progress,
+			 "status-changed",
+			 G_CALLBACK(fu_engine_progress_status_changed_cb),
+			 self);
 
 	/* check the device exists */
 	device = fu_device_list_get_by_id(self->device_list, device_id, error);
@@ -2950,7 +3035,7 @@ fu_engine_activate(FuEngine *self, const gchar *device_id, GError **error)
 		return FALSE;
 	g_debug("Activating %s", fu_device_get_name(device));
 
-	if (!fu_plugin_runner_activate(plugin, device, error))
+	if (!fu_plugin_runner_activate(plugin, device, progress, error))
 		return FALSE;
 
 	fu_engine_emit_device_changed(self, device);
@@ -2995,6 +3080,7 @@ static gboolean
 fu_engine_write_firmware(FuEngine *self,
 			 const gchar *device_id,
 			 GBytes *blob_fw,
+			 FuProgress *progress,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -3020,12 +3106,12 @@ fu_engine_write_firmware(FuEngine *self,
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
 		return FALSE;
-	if (!fu_plugin_runner_write_firmware(plugin, device, blob_fw, flags, error)) {
+	if (!fu_plugin_runner_write_firmware(plugin, device, blob_fw, progress, flags, error)) {
 		g_autoptr(GError) error_attach = NULL;
 		g_autoptr(GError) error_cleanup = NULL;
 
 		/* attack back into runtime then cleanup */
-		if (!fu_plugin_runner_attach(plugin, device, &error_attach)) {
+		if (!fu_plugin_runner_attach(plugin, device, progress, &error_attach)) {
 			g_warning("failed to attach device after failed update: %s",
 				  error_attach->message);
 		}
@@ -3068,7 +3154,11 @@ fu_engine_write_firmware(FuEngine *self,
 }
 
 GBytes *
-fu_engine_firmware_dump(FuEngine *self, FuDevice *device, FwupdInstallFlags flags, GError **error)
+fu_engine_firmware_dump(FuEngine *self,
+			FuDevice *device,
+			FuProgress *progress,
+			FwupdInstallFlags flags,
+			GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
@@ -3078,13 +3168,14 @@ fu_engine_firmware_dump(FuEngine *self, FuDevice *device, FwupdInstallFlags flag
 		g_prefix_error(error, "failed to open device for firmware read: ");
 		return NULL;
 	}
-	return fu_device_dump_firmware(device, error);
+	return fu_device_dump_firmware(device, progress, error);
 }
 
 gboolean
 fu_engine_install_blob(FuEngine *self,
 		       FuDevice *device,
 		       GBytes *blob_fw,
+		       FuProgress *progress,
 		       FwupdInstallFlags flags,
 		       FwupdFeatureFlags feature_flags,
 		       GError **error)
@@ -3124,17 +3215,46 @@ fu_engine_install_blob(FuEngine *self,
 		if (!fu_engine_prepare(self, flags, device_id, error))
 			return FALSE;
 
-		/* detach to bootloader mode */
-		if (!fu_engine_detach(self, device_id, feature_flags, error))
+		/* progress */
+		if (!fu_engine_set_progress(self, device_id, progress, error))
 			return FALSE;
+		if (fu_progress_get_steps(progress) == 0) {
+			fu_progress_set_id(progress, G_STRLOC);
+			fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+			fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* detach */
+			fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);	/* write */
+			fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2); /* attach */
+			fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+		}
+
+		/* detach to bootloader mode */
+		if (!fu_engine_detach(self,
+				      device_id,
+				      fu_progress_get_child(progress),
+				      feature_flags,
+				      error))
+			return FALSE;
+		fu_progress_step_done(progress);
 
 		/* install */
-		if (!fu_engine_write_firmware(self, device_id, blob_fw, flags, error))
+		if (!fu_engine_write_firmware(self,
+					      device_id,
+					      blob_fw,
+					      fu_progress_get_child(progress),
+					      flags,
+					      error))
 			return FALSE;
+		fu_progress_step_done(progress);
 
 		/* attach into runtime mode */
-		if (!fu_engine_attach(self, device_id, error))
+		if (!fu_engine_attach(self, device_id, fu_progress_get_child(progress), error))
 			return FALSE;
+		fu_progress_step_done(progress);
+
+		/* get the new version number */
+		if (!fu_engine_reload(self, device_id, error))
+			return FALSE;
+		fu_progress_step_done(progress);
 
 		/* the device and plugin both may have changed */
 		device_tmp = fu_engine_get_device(self, device_id, error);
@@ -3145,18 +3265,16 @@ fu_engine_install_blob(FuEngine *self,
 		if (!fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED))
 			break;
 
-	} while (TRUE);
+		/* not sure we can do any better than this */
+		fu_progress_reset(progress);
 
-	/* get the new version number */
-	if (!fu_engine_reload(self, device_id, error))
-		return FALSE;
+	} while (TRUE);
 
 	/* signal to all the plugins the update has happened */
 	if (!fu_engine_cleanup(self, flags, device_id, error))
 		return FALSE;
 
 	/* make the UI update */
-	fu_engine_set_status(self, FWUPD_STATUS_IDLE);
 	g_debug("Updating %s took %f seconds",
 		fu_device_get_name(device),
 		g_timer_elapsed(timer, NULL));

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -129,7 +129,11 @@ fu_engine_verify(FuEngine *self, const gchar *device_id, GError **error);
 gboolean
 fu_engine_verify_update(FuEngine *self, const gchar *device_id, GError **error);
 GBytes *
-fu_engine_firmware_dump(FuEngine *self, FuDevice *device, FwupdInstallFlags flags, GError **error);
+fu_engine_firmware_dump(FuEngine *self,
+			FuDevice *device,
+			FuProgress *progress,
+			FwupdInstallFlags flags,
+			GError **error);
 gboolean
 fu_engine_modify_remote(FuEngine *self,
 			const gchar *remote_id,
@@ -150,6 +154,7 @@ gboolean
 fu_engine_install(FuEngine *self,
 		  FuInstallTask *task,
 		  GBytes *blob_cab,
+		  FuProgress *progress,
 		  FwupdInstallFlags flags,
 		  FwupdFeatureFlags feature_flags,
 		  GError **error);
@@ -157,6 +162,7 @@ gboolean
 fu_engine_install_blob(FuEngine *self,
 		       FuDevice *device,
 		       GBytes *blob_fw,
+		       FuProgress *progress,
 		       FwupdInstallFlags flags,
 		       FwupdFeatureFlags feature_flags,
 		       GError **error);


### PR DESCRIPTION
It's actually quite hard to build a front-end for fwupd at the moment
as you're never sure when the progress bar is going to zip back to 0%
and start all over again. Some plugins go 0..100% for write, others
go 0..100% for erase, then again for write, then *again* for verify.

By creating a helper object we can easily split up the progress of the
specific task, e.g. write_firmware().

We can encode at the plugin level "the erase takes 50% of the time, the
write takes 40% and the read takes 10%". This means we can have a
progressbar which goes up just once at a consistent speed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
