### PR TITLE
Converting security attribute into json and write to hsi_history table.

### DIFF
--- a/src/fu-history.h
+++ b/src/fu-history.h
@@ -48,3 +48,8 @@ gboolean
 fu_history_add_blocked_firmware(FuHistory *self, const gchar *checksum, GError **error);
 GPtrArray *
 fu_history_get_blocked_firmware(FuHistory *self, GError **error);
+gboolean
+fu_history_add_security_attribute(FuHistory *self,
+				  const gchar *security_attr_json,
+				  const gchar *hsi_score,
+				  GError **error);

--- a/src/fu-security-attr.h
+++ b/src/fu-security-attr.h
@@ -7,8 +7,15 @@
 #pragma once
 
 #include <fwupd.h>
+#include <json-glib/json-glib.h>
+
+#include "fu-security-attrs-private.h"
 
 gchar *
 fu_security_attr_get_name(FwupdSecurityAttr *attr);
 const gchar *
 fu_security_attr_get_result(FwupdSecurityAttr *attr);
+void
+fu_security_attrs_to_json(FuSecurityAttrs *attrs, JsonBuilder *builder);
+gchar *
+fu_security_attrs_to_json_string(FuSecurityAttrs *attrs, GError **error);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Converting all security attributes to JSON and write them into hsi_security tables to record the changing of HSI valuer.
This commit consists of two-part:
1. Add a hsi_history table and schema.
2. JSON conversion and DB writing.
 