### PR TITLE
Add support for an 'unreachable' device flag

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -197,6 +197,8 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 		return "wildcard-install";
 	if (device_flag == FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE)
 		return "only-version-upgrade";
+	if (device_flag == FWUPD_DEVICE_FLAG_UNREACHABLE)
+		return "unreachable";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -304,6 +306,8 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_WILDCARD_INSTALL;
 	if (g_strcmp0(device_flag, "only-version-upgrade") == 0)
 		return FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE;
+	if (g_strcmp0(device_flag, "unreachable") == 0)
+		return FWUPD_DEVICE_FLAG_UNREACHABLE;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -470,6 +470,15 @@ typedef enum {
  */
 #define FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE (1llu << 43)
 /**
+ * FWUPD_DEVICE_FLAG_UNREACHABLE:
+ *
+ * The device is currently unreachable, perhaps because it is in a lower power state or is out of
+ * wireless range.
+ *
+ * Since 1.7.0
+ */
+#define FWUPD_DEVICE_FLAG_UNREACHABLE (1llu << 44)
+/**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *
  * This flag is not defined, this typically will happen from mismatched

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1187,6 +1187,11 @@ fu_util_device_flag_to_string(guint64 device_flag)
 		 * be downgraded or reinstalled with the existing version */
 		return _("Only version upgrades are allowed");
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_UNREACHABLE) {
+		/* TRANSLATORS: currently unreachable, perhaps because it is in a lower power state
+		 * or is out of wireless range */
+		return _("Device is unreachable");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */
 		return NULL;


### PR DESCRIPTION
This is for devices that are still registered with a receiver but are
no longer in range or in a high power state.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
