### PR TITLE
device-tests: Do not use a deprecated method

### DIFF
--- a/data/device-tests/hardware.py
+++ b/data/device-tests/hardware.py
@@ -93,7 +93,7 @@ class DeviceTest:
         for d in self.client.get_devices(cancellable):
             for guid in self.guids:
                 if d.has_guid(guid):
-                    if self.protocol and self.protocol != d.get_protocol():
+                    if self.protocol and not d.has_protocol(self.protocol):
                         continue
                     return d
         return None


### PR DESCRIPTION
This also fixes the bug where you can't recover a Unifying device stuck
in bootloader mode if the 'default' protocol is not the one that matches.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
