### PR TITLE
Wip/dependancies

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -198,10 +198,12 @@
       <package>pciutils-devel</package>
     </distro>
     <distro id="debian">
+      <control />
       <package variant="x86_64" />
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
       <package variant="x86_64" />
     </distro>
   </dependency>


### PR DESCRIPTION
Add dependencies required for building with flashrom support on debian/ubuntu