### PR TITLE
Show HSiLevel=0 attributes in JSON security output

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -1129,8 +1129,6 @@ fwupd_common_json_add_string(JsonBuilder *builder, const gchar *key, const gchar
 void
 fwupd_common_json_add_int(JsonBuilder *builder, const gchar *key, guint64 value)
 {
-	if (value == 0)
-		return;
 	json_builder_set_member_name(builder, key);
 	json_builder_add_int_value(builder, value);
 }

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -2630,7 +2630,10 @@ fwupd_device_to_json(FwupdDevice *self, JsonBuilder *builder)
 	fwupd_common_json_add_string(builder,
 				     FWUPD_RESULT_KEY_VERSION_FORMAT,
 				     fwupd_version_format_to_string(priv->version_format));
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_FLASHES_LEFT, priv->flashes_left);
+	if (priv->flashes_left > 0)
+		fwupd_common_json_add_int(builder,
+					  FWUPD_RESULT_KEY_FLASHES_LEFT,
+					  priv->flashes_left);
 	if (priv->version_raw > 0)
 		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_VERSION_RAW, priv->version_raw);
 	if (priv->version_lowest_raw > 0)
@@ -2654,13 +2657,21 @@ fwupd_device_to_json(FwupdDevice *self, JsonBuilder *builder)
 		}
 		json_builder_end_array(builder);
 	}
-	fwupd_common_json_add_int(builder,
-				  FWUPD_RESULT_KEY_INSTALL_DURATION,
-				  priv->install_duration);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_CREATED, priv->created);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_MODIFIED, priv->modified);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_UPDATE_STATE, priv->update_state);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_STATUS, priv->status);
+	if (priv->install_duration > 0) {
+		fwupd_common_json_add_int(builder,
+					  FWUPD_RESULT_KEY_INSTALL_DURATION,
+					  priv->install_duration);
+	}
+	if (priv->created > 0)
+		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_CREATED, priv->created);
+	if (priv->modified > 0)
+		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_MODIFIED, priv->modified);
+	if (priv->update_state > 0)
+		fwupd_common_json_add_int(builder,
+					  FWUPD_RESULT_KEY_UPDATE_STATE,
+					  priv->update_state);
+	if (priv->status > 0)
+		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_STATUS, priv->status);
 	fwupd_common_json_add_string(builder, FWUPD_RESULT_KEY_UPDATE_ERROR, priv->update_error);
 	fwupd_common_json_add_string(builder,
 				     FWUPD_RESULT_KEY_UPDATE_MESSAGE,

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -1918,8 +1918,10 @@ fwupd_release_to_json(FwupdRelease *self, JsonBuilder *builder)
 		json_builder_end_array(builder);
 	}
 	fwupd_common_json_add_string(builder, FWUPD_RESULT_KEY_LICENSE, priv->license);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_SIZE, priv->size);
-	fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_CREATED, priv->created);
+	if (priv->size > 0)
+		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_SIZE, priv->size);
+	if (priv->created > 0)
+		fwupd_common_json_add_int(builder, FWUPD_RESULT_KEY_CREATED, priv->created);
 	if (priv->locations->len > 0) {
 		json_builder_set_member_name(builder, FWUPD_RESULT_KEY_LOCATIONS);
 		json_builder_begin_array(builder);
@@ -1949,9 +1951,11 @@ fwupd_release_to_json(FwupdRelease *self, JsonBuilder *builder)
 		}
 		json_builder_end_array(builder);
 	}
-	fwupd_common_json_add_int(builder,
-				  FWUPD_RESULT_KEY_INSTALL_DURATION,
-				  priv->install_duration);
+	if (priv->install_duration > 0) {
+		fwupd_common_json_add_int(builder,
+					  FWUPD_RESULT_KEY_INSTALL_DURATION,
+					  priv->install_duration);
+	}
 	fwupd_common_json_add_string(builder,
 				     FWUPD_RESULT_KEY_DETACH_CAPTION,
 				     priv->detach_caption);


### PR DESCRIPTION
Don't assume zero always means 'skip'.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
