### PR TITLE
plugins/flashrom: Add private flag to reset CMOS

### DIFF
--- a/plugins/flashrom/fu-flashrom-cmos.c
+++ b/plugins/flashrom/fu-flashrom-cmos.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Sean Rhodes <sean@starlabs.systems>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+#include "config.h"
+
+#include <sys/io.h>
+
+#include "fu-flashrom-cmos.h"
+
+static gboolean
+fu_flashrom_cmos_write(guint8 addr, guint8 val)
+{
+	guint8 tmp;
+
+	/* Reject addresses in the second bank */
+	if (addr >= 128)
+		return FALSE;
+
+	/* Write the value to CMOS */
+	outb(addr, RTC_BASE_PORT);
+	outb(val, RTC_BASE_PORT + 1);
+
+	/* Read the value back from CMOS */
+	outb(addr, RTC_BASE_PORT);
+	tmp = inb(RTC_BASE_PORT + 1);
+
+	/* Check the read value against the written */
+	return (tmp == val);
+}
+
+gboolean
+fu_flashrom_cmos_reset(GError **error)
+{
+	/* Call ioperm() to grant us access to ports 0x70 and 0x71 */
+	if (!ioperm(RTC_BASE_PORT, 2, TRUE)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
+				    "failed to gain access to ports 0x70 and 0x71");
+		return FALSE;
+	}
+
+	/* Write a default value to the CMOS checksum */
+	if ((!fu_flashrom_cmos_write(CMOS_CHECKSUM_OFFSET, 0xff)) ||
+	    (!fu_flashrom_cmos_write(CMOS_CHECKSUM_OFFSET + 1, 0xff))) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_READ, "failed to reset CMOS");
+		return FALSE;
+	}
+
+	/* success */
+
+	return TRUE;
+}

--- a/plugins/flashrom/fu-flashrom-cmos.h
+++ b/plugins/flashrom/fu-flashrom-cmos.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 Sean Rhodes <sean@starlabs.systems>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+/* From coreboot's src/include/pc80/mc146818rtc.h file */
+#define RTC_BASE_PORT 0x70
+
+/*
+ * This is the offset of the first of the two checksum bytes
+ * we may want to figure out how we can determine this dynamically
+ * during execution.
+ */
+#define CMOS_CHECKSUM_OFFSET 123
+
+gboolean
+fu_flashrom_cmos_reset(GError **error);

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -11,6 +11,7 @@ shared_module('fu_plugin_flashrom',
     'fu-flashrom-device.c',
     'fu-flashrom-internal-device.c',
     'fu-plugin-flashrom.c',
+    'fu-flashrom-cmos.c',
   ],
   include_directories : [
     root_incdir,


### PR DESCRIPTION
Reset the CMOS based on a private flag. Tested on coreboot using an
offset of 123. Required when a CMOS layout or default option has
changed as the resulting flash will have 0's for the modified option.

