### PR TITLE
uefi-capsule: Add the apply method to the uploaded report

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -221,6 +221,14 @@ fu_uefi_cod_device_write_firmware(FuDevice *device,
 }
 
 static void
+fu_uefi_cod_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
+{
+	/* FuUefiDevice */
+	FU_DEVICE_CLASS(fu_uefi_cod_device_parent_class)->report_metadata_pre(device, metadata);
+	g_hash_table_insert(metadata, g_strdup("CapsuleApplyMethod"), g_strdup("cod"));
+}
+
+static void
 fu_uefi_cod_device_init(FuUefiCodDevice *self)
 {
 }
@@ -231,4 +239,5 @@ fu_uefi_cod_device_class_init(FuUefiCodDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 	klass_device->write_firmware = fu_uefi_cod_device_write_firmware;
 	klass_device->get_results = fu_uefi_cod_device_get_results;
+	klass_device->report_metadata_pre = fu_uefi_cod_device_report_metadata_pre;
 }

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -187,6 +187,14 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 }
 
 static void
+fu_uefi_grub_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
+{
+	/* FuUefiDevice */
+	FU_DEVICE_CLASS(fu_uefi_grub_device_parent_class)->report_metadata_pre(device, metadata);
+	g_hash_table_insert(metadata, g_strdup("CapsuleApplyMethod"), g_strdup("grub"));
+}
+
+static void
 fu_uefi_grub_device_init(FuUefiGrubDevice *self)
 {
 }
@@ -196,4 +204,5 @@ fu_uefi_grub_device_class_init(FuUefiGrubDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 	klass_device->write_firmware = fu_uefi_grub_device_write_firmware;
+	klass_device->report_metadata_pre = fu_uefi_grub_device_report_metadata_pre;
 }

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -119,6 +119,14 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 }
 
 static void
+fu_uefi_nvram_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
+{
+	/* FuUefiDevice */
+	FU_DEVICE_CLASS(fu_uefi_nvram_device_parent_class)->report_metadata_pre(device, metadata);
+	g_hash_table_insert(metadata, g_strdup("CapsuleApplyMethod"), g_strdup("nvram"));
+}
+
+static void
 fu_uefi_nvram_device_init(FuUefiNvramDevice *self)
 {
 }
@@ -129,4 +137,5 @@ fu_uefi_nvram_device_class_init(FuUefiNvramDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 	klass_device->get_results = fu_uefi_nvram_device_get_results;
 	klass_device->write_firmware = fu_uefi_nvram_device_write_firmware;
+	klass_device->report_metadata_pre = fu_uefi_nvram_device_report_metadata_pre;
 }


### PR DESCRIPTION
We want to be able to differenciate failures for a specific update
method, e.g. finding if should be enabling CoD by default or not.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
