### PR TITLE
Allow adding GUIDs to each HSI security attr

### DIFF
--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -148,6 +148,14 @@ void
 fwupd_security_attr_add_obsolete(FwupdSecurityAttr *self, const gchar *appstream_id);
 gboolean
 fwupd_security_attr_has_obsolete(FwupdSecurityAttr *self, const gchar *appstream_id);
+GPtrArray *
+fwupd_security_attr_get_guids(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_add_guid(FwupdSecurityAttr *self, const gchar *guid);
+void
+fwupd_security_attr_add_guids(FwupdSecurityAttr *self, GPtrArray *guids);
+gboolean
+fwupd_security_attr_has_guid(FwupdSecurityAttr *self, const gchar *guid);
 const gchar *
 fwupd_security_attr_get_metadata(FwupdSecurityAttr *self, const gchar *key);
 void

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -700,3 +700,12 @@ LIBFWUPD_1.6.2 {
     fwupd_request_to_variant;
   local: *;
 } LIBFWUPD_1.6.1;
+
+LIBFWUPD_1.7.0 {
+  global:
+    fwupd_security_attr_add_guid;
+    fwupd_security_attr_add_guids;
+    fwupd_security_attr_get_guids;
+    fwupd_security_attr_has_guid;
+  local: *;
+} LIBFWUPD_1.6.2;

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -303,6 +303,7 @@ fu_cpu_device_add_security_attrs_intel_cet_enabled(FuCpuDevice *self, FuSecurity
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_INTEL_CET_ENABLED);
 	fwupd_security_attr_set_plugin(attr, fu_device_get_plugin(FU_DEVICE(self)));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
+	fwupd_security_attr_add_guids(attr, fu_device_get_guids(FU_DEVICE(self)));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check for CET */
@@ -334,6 +335,7 @@ fu_cpu_device_add_security_attrs_intel_cet_active(FuCpuDevice *self, FuSecurityA
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_INTEL_CET_ACTIVE);
 	fwupd_security_attr_set_plugin(attr, fu_device_get_plugin(FU_DEVICE(self)));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_THEORETICAL);
+	fwupd_security_attr_add_guids(attr, fu_device_get_guids(FU_DEVICE(self)));
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append(attrs, attr);
 
@@ -362,6 +364,7 @@ fu_cpu_device_add_security_attrs_intel_tme(FuCpuDevice *self, FuSecurityAttrs *a
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM);
 	fwupd_security_attr_set_plugin(attr, fu_device_get_plugin(FU_DEVICE(self)));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
+	fwupd_security_attr_add_guids(attr, fu_device_get_guids(FU_DEVICE(self)));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check for TME */
@@ -384,6 +387,7 @@ fu_cpu_device_add_security_attrs_intel_smap(FuCpuDevice *self, FuSecurityAttrs *
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_INTEL_SMAP);
 	fwupd_security_attr_set_plugin(attr, fu_device_get_plugin(FU_DEVICE(self)));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
+	fwupd_security_attr_add_guids(attr, fu_device_get_guids(FU_DEVICE(self)));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check for SMEP and SMAP */

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -214,6 +214,7 @@ fu_intel_spi_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_SPI_DESCRIPTOR);
 	fwupd_security_attr_set_plugin(attr, fu_device_get_plugin(FU_DEVICE(self)));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check for read access from other regions */

--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -187,6 +187,7 @@ static void
 fu_plugin_add_security_attr_dci_enabled(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *device = fu_plugin_cache_lookup(plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* this MSR is only valid for a subset of Intel CPUs */
@@ -199,6 +200,8 @@ fu_plugin_add_security_attr_dci_enabled(FuPlugin *plugin, FuSecurityAttrs *attrs
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_INTEL_DCI_ENABLED);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	if (device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check fields */
@@ -216,6 +219,7 @@ static void
 fu_plugin_add_security_attr_dci_locked(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *device = fu_plugin_cache_lookup(plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* this MSR is only valid for a subset of Intel CPUs */
@@ -228,6 +232,8 @@ fu_plugin_add_security_attr_dci_locked(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_INTEL_DCI_LOCKED);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
+	if (device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check fields */
@@ -245,6 +251,7 @@ static void
 fu_plugin_add_security_attr_amd_tsme_enabled(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *device = fu_plugin_cache_lookup(plugin, "cpu");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* this MSR is only valid for a subset of AMD CPUs */
@@ -255,6 +262,8 @@ fu_plugin_add_security_attr_amd_tsme_enabled(FuPlugin *plugin, FuSecurityAttrs *
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
+	if (device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* check fields */

--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -69,12 +69,15 @@ static void
 fu_plugin_add_security_attr_bioswe(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *msf_device = fu_plugin_cache_lookup(plugin, "main-system-firmware");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_SPI_BIOSWE);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	if (msf_device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(msf_device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* no device */
@@ -98,6 +101,7 @@ static void
 fu_plugin_add_security_attr_ble(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *msf_device = fu_plugin_cache_lookup(plugin, "main-system-firmware");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* no device */
@@ -108,6 +112,8 @@ fu_plugin_add_security_attr_ble(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_SPI_BLE);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	if (msf_device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(msf_device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* load file */
@@ -125,6 +131,7 @@ static void
 fu_plugin_add_security_attr_smm_bwp(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *msf_device = fu_plugin_cache_lookup(plugin, "main-system-firmware");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* no device */
@@ -135,6 +142,8 @@ fu_plugin_add_security_attr_smm_bwp(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_SPI_SMM_BWP);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
+	if (msf_device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(msf_device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* load file */

--- a/plugins/uefi-pk/fu-plugin-uefi-pk.c
+++ b/plugins/uefi-pk/fu-plugin-uefi-pk.c
@@ -159,15 +159,25 @@ fu_plugin_init(FuPlugin *plugin)
 }
 
 void
+fu_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
+{
+	if (fu_device_has_instance_id(device, "main-system-firmware"))
+		fu_plugin_cache_add(plugin, "main-system-firmware", device);
+}
+
+void
 fu_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	FuDevice *msf_device = fu_plugin_cache_lookup(plugin, "main-system-firmware");
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
 	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_UEFI_PK);
 	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_CRITICAL);
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
+	if (msf_device != NULL)
+		fwupd_security_attr_add_guids(attr, fu_device_get_guids(msf_device));
 	fu_security_attrs_append(attrs, attr);
 
 	/* test key is not secure */

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -32,6 +32,7 @@
 #include "fu-hwids.h"
 #include "fu-plugin-private.h"
 #include "fu-progressbar.h"
+#include "fu-security-attr.h"
 #include "fu-security-attrs-private.h"
 #include "fu-smbios-private.h"
 #include "fu-util-common.h"
@@ -59,6 +60,7 @@ struct FuUtilPrivate {
 	FuEngine *engine;
 	FuEngineRequest *request;
 	FuProgressbar *progressbar;
+	gboolean as_json;
 	gboolean no_reboot_check;
 	gboolean no_safety_check;
 	gboolean prepare_blob;
@@ -2622,6 +2624,13 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 
 	/* print the "why" */
 	attrs = fu_engine_get_host_security_attrs(priv->engine);
+	if (priv->as_json) {
+		str = fu_security_attrs_to_json_string(attrs, error);
+		if (str == NULL)
+			return FALSE;
+		g_print("%s\n", str);
+		return TRUE;
+	}
 	items = fu_security_attrs_get_all(attrs);
 	str = fu_util_security_attrs_to_string(items, flags);
 	g_print("%s\n", str);
@@ -3040,6 +3049,14 @@ main(int argc, char *argv[])
 	     /* TRANSLATORS: command line option */
 	     _("Filter with a set of device flags using a ~ prefix to "
 	       "exclude, e.g. 'internal,~needs-reboot'"),
+	     NULL},
+	    {"json",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->as_json,
+	     /* TRANSLATORS: command line option */
+	     _("Output in JSON format"),
 	     NULL},
 	    {NULL}};
 


### PR DESCRIPTION
This indicates the GUID in some way contributed to the result decided.

It also allows us to match the submitted HSI results back to a firmware
stream on the LVFS, which allows us to allow vendors to see a subset of
results for uploaded devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
