### PR TITLE
Run self tests as nobody for at least one CI target

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1590,4 +1590,9 @@
       <package>protobuf</package>
     </distro>
   </dependency>
+  <dependency type="build" id="sudo">
+    <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
 </dependencies>

--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -19,9 +19,11 @@ export LDFLAGS
 
 root=$(pwd)
 rm -rf ${root}/build
-meson build -Dman=false -Ddocs=docgen -Dgusb:tests=false -Dplugin_platform_integrity=true --prefix=${root}/dist
+mkdir -p ${root}/build
+chown nobody build ${root}/subprojects
+sudo -u nobody meson build -Dman=false -Ddocs=docgen -Dgusb:tests=false -Dplugin_platform_integrity=true --prefix=${root}/dist
 #build with clang
-ninja -C build test -v
+sudo -u nobody ninja -C ${root}/build test -v
 
 #make docs available outside of docker
-ninja -C build install -v
+ninja -C ${root}/build install -v

--- a/data/tests/efi/efivars/meson.build
+++ b/data/tests/efi/efivars/meson.build
@@ -1,0 +1,9 @@
+configure_file(input: 'BootNext-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+               output: 'BootNext-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+               copy: true)
+configure_file(input: 'fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e-0-0abba7dc-e516-4167-bbf5-4d9d1c739416',
+               output: 'fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e-0-0abba7dc-e516-4167-bbf5-4d9d1c739416',
+               copy: true)
+configure_file(input: 'SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+               output: 'SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+               copy: true)

--- a/data/tests/efi/meson.build
+++ b/data/tests/efi/meson.build
@@ -1,0 +1,1 @@
+subdir('efivars')

--- a/data/tests/meson.build
+++ b/data/tests/meson.build
@@ -1,4 +1,5 @@
 subdir('builder')
 subdir('colorhug')
+subdir('efi')
 subdir('missing-hwid')
 subdir('multiple-rels')

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -316,6 +316,9 @@ fu_smbios_func(void)
 	g_autoptr(FuSmbios) smbios = NULL;
 	g_autoptr(GError) error = NULL;
 
+	/* these tests will not write */
+	g_setenv("FWUPD_SYSFSFWDIR", TESTDATADIR_SRC, TRUE);
+
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup(smbios, &error);
 	g_assert_no_error(error);
@@ -484,6 +487,9 @@ fu_hwids_func(void)
 		     {"HardwareID-1", "b7cceb67-774c-537e-bf8b-22c6107e9a74"},
 		     {"HardwareID-0", "147efce9-f201-5fc8-ab0c-c859751c3440"},
 		     {NULL, NULL}};
+
+	/* these tests will not write */
+	g_setenv("FWUPD_SYSFSFWDIR", TESTDATADIR_SRC, TRUE);
 
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup(smbios, &error);
@@ -2804,6 +2810,9 @@ fu_efivar_func(void)
 	return;
 #endif
 
+	/* these tests will write */
+	g_setenv("FWUPD_SYSFSFWDIR", TESTDATADIR_DST, TRUE);
+
 	/* check supported */
 	ret = fu_efivar_supported(&error);
 	g_assert_no_error(error);
@@ -3382,7 +3391,6 @@ main(int argc, char **argv)
 	g_setenv("FWUPD_DATADIR", TESTDATADIR_SRC, TRUE);
 	g_setenv("FWUPD_PLUGINDIR", TESTDATADIR_SRC, TRUE);
 	g_setenv("FWUPD_SYSCONFDIR", TESTDATADIR_SRC, TRUE);
-	g_setenv("FWUPD_SYSFSFWDIR", TESTDATADIR_SRC, TRUE);
 	g_setenv("FWUPD_OFFLINE_TRIGGER", "/tmp/fwupd-self-test/system-update", TRUE);
 	g_setenv("FWUPD_LOCALSTATEDIR", "/tmp/fwupd-self-test/var", TRUE);
 

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -335,7 +335,6 @@ if get_option('tests')
     c_args : [
       '-DTESTDATADIR_SRC="' + testdatadir_src + '"',
       '-DTESTDATADIR_DST="' + testdatadir_dst + '"',
-      '-DPLUGINBUILDDIR="' + pluginbuilddir + '"',
     ],
   )
   test('fwupdplugin-self-test', e, is_parallel:false, timeout:180)

--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -24,6 +24,10 @@ fu_ata_id_func(void)
 	g_autoptr(FuAtaDevice) dev = NULL;
 	g_autoptr(GError) error = NULL;
 
+	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error(error);
+	g_assert(ret);
+
 	path = g_test_build_filename(G_TEST_DIST, "tests", "StarDrive-SBFM61.2.bin", NULL);
 	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
 		g_test_skip("Missing StarDrive-SBFM61.2.bin");
@@ -54,6 +58,10 @@ fu_ata_oui_func(void)
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuAtaDevice) dev = NULL;
 	g_autoptr(GError) error = NULL;
+
+	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error(error);
+	g_assert(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "Samsung SSD 860 EVO 500GB.bin", NULL);
 	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {

--- a/plugins/nvme/fu-self-test.c
+++ b/plugins/nvme/fu-self-test.c
@@ -24,6 +24,10 @@ fu_nvme_cns_func(void)
 	g_autoptr(FuNvmeDevice) dev = NULL;
 	g_autoptr(GError) error = NULL;
 
+	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error(error);
+	g_assert(ret);
+
 	path = g_test_build_filename(G_TEST_DIST, "tests", "TOSHIBA_THNSN5512GPU7.bin", NULL);
 
 	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {

--- a/plugins/platform-integrity/fu-plugin-platform-integrity.c
+++ b/plugins/platform-integrity/fu-plugin-platform-integrity.c
@@ -15,7 +15,6 @@ struct FuPluginData {
 void
 fu_plugin_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 	fu_plugin_set_build_hash(plugin, FU_BUILD_HASH);
 	fu_plugin_add_udev_subsystem(plugin, "platform-integrity");

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -79,15 +79,17 @@ fu_synaptics_mst_device_finalize(GObject *object)
 static void
 fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 {
+	FuUdevDeviceFlags flags =
+	    FU_UDEV_DEVICE_FLAG_OPEN_READ | FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT;
+	if (fu_udev_device_get_dev(FU_UDEV_DEVICE(self)) != NULL)
+		flags |= FU_UDEV_DEVICE_FLAG_OPEN_WRITE;
+	fu_udev_device_set_flags(FU_UDEV_DEVICE(self), flags);
 	fu_device_add_protocol(FU_DEVICE(self), "com.synaptics.mst");
 	fu_device_set_vendor(FU_DEVICE(self), "Synaptics");
 	fu_device_add_vendor_id(FU_DEVICE(self), "DRM_DP_AUX_DEV:0x06CB");
 	fu_device_set_summary(FU_DEVICE(self), "Multi-stream transport device");
 	fu_device_add_icon(FU_DEVICE(self), "video-display");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_udev_device_set_flags(FU_UDEV_DEVICE(self),
-				 FU_UDEV_DEVICE_FLAG_OPEN_READ | FU_UDEV_DEVICE_FLAG_OPEN_WRITE |
-				     FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
 					"ignore-board-id");


### PR DESCRIPTION
Beyond the failures that happened in ATA and NVME plugins, other parts in the codebase are making writes into `data/tests` or `plugins/synaptics-mst/tests`.  We shouldn't be allowing this at all.  Fix those and then enforce that everything touched is in `build/` or `/tmp` during the run.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
