### PR TITLE
trivial: system firmware may primarily use sha256 bank instead sha1

### DIFF
--- a/plugins/tpm-eventlog/fu-tpm-eventlog-device.c
+++ b/plugins/tpm-eventlog/fu-tpm-eventlog-device.c
@@ -48,7 +48,13 @@ fu_tpm_eventlog_device_report_metadata(FuTpmEventlogDevice *self)
 	for (guint i = 0; i < self->items->len; i++) {
 		FuTpmEventlogItem *item = g_ptr_array_index(self->items, i);
 		g_autofree gchar *blobstr = fu_tpm_eventlog_blobstr(item->blob);
-		g_autofree gchar *checksum = fu_tpm_eventlog_strhex(item->checksum_sha1);
+		g_autofree gchar *checksum = NULL;
+		if (item->checksum_sha1 != NULL)
+			checksum = fu_tpm_eventlog_strhex(item->checksum_sha1);
+		else if (item->checksum_sha256 != NULL)
+			checksum = fu_tpm_eventlog_strhex(item->checksum_sha256);
+		else
+			continue;
 		g_string_append_printf(str, "0x%08x %s", item->kind, checksum);
 		if (blobstr != NULL)
 			g_string_append_printf(str, " [%s]", blobstr);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Fixes:
<img width="469" alt="tpm_evt_log_nulled_sha1" src="https://user-images.githubusercontent.com/30334596/132304043-c20e00a6-e2c0-42eb-b67b-904685500914.png">
