### PR TITLE
Fix a regression in flashing the Dell dock

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -235,6 +235,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "use-parent-for-open";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY)
 		return "use-parent-for-battery";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK)
+		return "use-proxy-fallback";
 	return NULL;
 }
 
@@ -287,6 +289,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_OPEN;
 	if (g_strcmp0(flag, "use-parent-for-battery") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY;
+	if (g_strcmp0(flag, "use-proxy-fallback") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 
@@ -1092,7 +1096,8 @@ fu_device_get_proxy(FuDevice *self)
  * fu_device_get_proxy_with_fallback:
  * @self: a #FuDevice
  *
- * Gets the proxy device, falling back to the device itself.
+ * Gets the proxy device if %FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK is set, falling back to the
+ * device itself.
  *
  * Returns: (transfer none): a device
  *
@@ -1103,7 +1108,8 @@ fu_device_get_proxy_with_fallback(FuDevice *self)
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
-	if (priv->proxy != NULL)
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK) &&
+	    priv->proxy != NULL)
 		return priv->proxy;
 	return self;
 }

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -378,6 +378,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY (1ull << 17)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK:
+ *
+ * Use parent for the battery level and threshold.
+ *
+ * Since: 1.6.4
+ */
+#define FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK (1ull << 18)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1128,6 +1128,7 @@ fu_vli_usbhub_device_init(FuVliUsbhubDevice *self)
 {
 	fu_device_add_icon(FU_DEVICE(self), "audio-card");
 	fu_device_add_protocol(FU_DEVICE(self), "com.vli.usbhub");
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_GPIOB,


### PR DESCRIPTION
This fixes a regression caused by 15b668c, we should have been more careful.

Fixes https://github.com/fwupd/fwupd/issues/3732

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
