### PR TITLE
wacom-usb: Abort on invalid SREC files early to avoid a fuzzing timeout

### DIFF
--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -188,8 +188,12 @@ fu_wac_firmware_parse(FuFirmware *firmware,
 			}
 			g_string_append_printf(image_buffer, "%s\n", lines[i]);
 		} else {
-			g_warning("ignoring invalid srec command %s", cmd);
-			continue;
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "invalid SREC command: %s",
+				    cmd);
+			return FALSE;
 		}
 
 		/* end */


### PR DESCRIPTION
Half a million new-lines was taking a long time to parse.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38381

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
