### PR TITLE
plugins/flashrom: Fix logic in reset cmos

### DIFF
--- a/plugins/flashrom/fu-flashrom-cmos.c
+++ b/plugins/flashrom/fu-flashrom-cmos.c
@@ -34,7 +34,7 @@ gboolean
 fu_flashrom_cmos_reset(GError **error)
 {
 	/* Call ioperm() to grant us access to ports 0x70 and 0x71 */
-	if (!ioperm(RTC_BASE_PORT, 2, TRUE)) {
+	if (ioperm(RTC_BASE_PORT, 2, TRUE) < 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_READ,


### PR DESCRIPTION
ioperm returns -1 for an error and 0 for success
