### PR TITLE
update void linux ci target

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1186,6 +1186,11 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="gi-docgen">
+    <distro id="void">
+      <package />
+    </distro>
+  </dependency>
   <!-- These are needed for gi-docgen -->
   <dependency type="build" id="python3-pygments">
     <distro id="ubuntu">

--- a/contrib/ci/void.sh
+++ b/contrib/ci/void.sh
@@ -12,12 +12,9 @@ xbps-install -Suy python3
 #build
 rm -rf build
 meson build \
- -Dman=false \
- -Ddocs=none \
  -Dgusb:tests=false \
  -Dgcab:docs=false \
  -Dconsolekit=false \
  -Dsystemd=false \
- -Db_lto=false \
  -Delogind=true
 ninja -C build test -v


### PR DESCRIPTION
i tried to update the ci integration for void linux.

the current packaged version is here
https://github.com/void-linux/void-packages/blob/master/srcpkgs/fwupd/template
should you need to correct something

it would be great to run a regular xbps-src build,
which would show cross compilation issues.
