### PR TITLE
Add new API for splitting an untrusted string

### DIFF
--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -344,6 +344,28 @@ void
 fu_common_string_append_kb(GString *str, guint idt, const gchar *key, gboolean value);
 gchar **
 fu_common_strnsplit(const gchar *str, gsize sz, const gchar *delimiter, gint max_tokens);
+
+/**
+ * FuCommonStrsplitFunc:
+ * @token: a #GString
+ * @token_idx: the token number
+ * @user_data: user data
+ * @error: a #GError or NULL
+ *
+ * The fu_common_strnsplit_full() iteration callback.
+ */
+typedef gboolean (*FuCommonStrsplitFunc)(GString *token,
+					 guint token_idx,
+					 gpointer user_data,
+					 GError **error);
+gboolean
+fu_common_strnsplit_full(const gchar *str,
+			 gssize sz,
+			 const gchar *delimiter,
+			 FuCommonStrsplitFunc callback,
+			 gpointer user_data,
+			 GError **error);
+
 gchar *
 fu_common_strsafe(const gchar *str, gsize maxsz);
 gchar *

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -861,6 +861,7 @@ LIBFWUPDPLUGIN_1.6.2 {
 
 LIBFWUPDPLUGIN_1.7.0 {
   global:
+    fu_common_strnsplit_full;
     fu_device_set_progress;
     fu_plugin_runner_attach;
     fu_plugin_runner_cleanup;

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -18,11 +18,233 @@ struct _FuWacFirmware {
 
 G_DEFINE_TYPE(FuWacFirmware, fu_wac_firmware, FU_TYPE_FIRMWARE)
 
+#define FU_WAC_FIRMWARE_TOKENS_MAX 100000 /* lines */
+
 typedef struct {
 	guint32 addr;
 	guint32 sz;
 	guint32 prog_start_addr;
 } FuFirmwareWacHeaderRecord;
+
+typedef struct {
+	FuFirmware *firmware;
+	FwupdInstallFlags flags;
+	GPtrArray *header_infos;
+	GString *image_buffer;
+	guint8 images_cnt;
+} FuWacFirmwareTokenHelper;
+
+static gboolean
+fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data, GError **error)
+{
+	FuWacFirmwareTokenHelper *helper = (FuWacFirmwareTokenHelper *)user_data;
+	g_autofree gchar *cmd = NULL;
+
+	/* sanity check */
+	if (token_idx > FU_WAC_FIRMWARE_TOKENS_MAX) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_INVALID_DATA,
+				    "file has too many lines");
+		return FALSE;
+	}
+
+	/* remove WIN32 line endings */
+	g_strdelimit(token->str, "\r\x1a", '\0');
+	token->len = strlen(token->str);
+
+	/* ignore blank lines */
+	cmd = g_strndup(token->str, 2);
+	if (g_strcmp0(cmd, "") == 0)
+		return TRUE;
+
+	/* Wacom-specific metadata */
+	if (g_strcmp0(cmd, "WA") == 0) {
+		/* header info record */
+		if (token->len > 3 && memcmp(token->str + 2, "COM", 3) == 0) {
+			guint8 header_image_cnt = 0;
+			if (token->len != 40) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "invalid header, got %" G_GSIZE_FORMAT " bytes",
+					    token->len);
+				return FALSE;
+			}
+			if (!fu_firmware_strparse_uint4_safe(token->str,
+							     token->len,
+							     5,
+							     &header_image_cnt,
+							     error))
+				return FALSE;
+			for (guint j = 0; j < header_image_cnt; j++) {
+				g_autofree FuFirmwareWacHeaderRecord *hdr = NULL;
+				hdr = g_new0(FuFirmwareWacHeaderRecord, 1);
+				if (!fu_firmware_strparse_uint32_safe(token->str,
+								      token->len,
+								      (j * 16) + 6,
+								      &hdr->addr,
+								      error))
+					return FALSE;
+				if (!fu_firmware_strparse_uint32_safe(token->str,
+								      token->len,
+								      (j * 16) + 14,
+								      &hdr->sz,
+								      error))
+					return FALSE;
+				g_debug("header_fw%u_addr: 0x%x", j, hdr->addr);
+				g_debug("header_fw%u_sz:   0x%x", j, hdr->sz);
+				g_ptr_array_add(helper->header_infos, g_steal_pointer(&hdr));
+			}
+			return TRUE;
+		}
+
+		/* firmware headline record */
+		if (token->len == 13) {
+			FuFirmwareWacHeaderRecord *hdr;
+			guint8 idx = 0;
+			if (!fu_firmware_strparse_uint4_safe(token->str,
+							     token->len,
+							     2,
+							     &idx,
+							     error))
+				return FALSE;
+			if (idx == 0) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "headline %u invalid",
+					    idx);
+				return FALSE;
+			}
+			if (idx > helper->header_infos->len) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "headline %u exceeds header count %u",
+					    idx,
+					    helper->header_infos->len);
+				return FALSE;
+			}
+			if (idx - 1 != helper->images_cnt) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "headline %u is not in sorted order",
+					    idx);
+				return FALSE;
+			}
+			hdr = g_ptr_array_index(helper->header_infos, idx - 1);
+			if (!fu_firmware_strparse_uint32_safe(token->str,
+							      token->len,
+							      3,
+							      &hdr->prog_start_addr,
+							      error))
+				return FALSE;
+			if (hdr->prog_start_addr != hdr->addr) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "programming address 0x%x != "
+					    "base address 0x%0x for idx %u",
+					    hdr->prog_start_addr,
+					    hdr->addr,
+					    idx);
+				return FALSE;
+			}
+			g_debug("programing-start-address: 0x%x", hdr->prog_start_addr);
+			return TRUE;
+		}
+
+		g_debug("unknown Wacom-specific metadata");
+		return TRUE;
+	}
+
+	/* start */
+	if (g_strcmp0(cmd, "S0") == 0) {
+		if (helper->image_buffer->len > 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "duplicate S0 without S7");
+			return FALSE;
+		}
+		g_string_append_printf(helper->image_buffer, "%s\n", token->str);
+		return TRUE;
+	}
+
+	/* these are things we want to include in the image */
+	if (g_strcmp0(cmd, "S1") == 0 || g_strcmp0(cmd, "S2") == 0 || g_strcmp0(cmd, "S3") == 0 ||
+	    g_strcmp0(cmd, "S5") == 0 || g_strcmp0(cmd, "S7") == 0 || g_strcmp0(cmd, "S8") == 0 ||
+	    g_strcmp0(cmd, "S9") == 0) {
+		if (helper->image_buffer->len == 0) {
+			g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "%s without S0", cmd);
+			return FALSE;
+		}
+		g_string_append_printf(helper->image_buffer, "%s\n", token->str);
+	} else {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "invalid SREC command on line %u: %s",
+			    token_idx + 1,
+			    cmd);
+		return FALSE;
+	}
+
+	/* end */
+	if (g_strcmp0(cmd, "S7") == 0) {
+		g_autoptr(GBytes) blob = NULL;
+		g_autoptr(GBytes) fw_srec = NULL;
+		g_autoptr(FuFirmware) firmware_srec = fu_srec_firmware_new();
+		g_autoptr(FuFirmware) img = fu_firmware_new();
+		FuFirmwareWacHeaderRecord *hdr;
+
+		/* get the correct relocated start address */
+		if (helper->images_cnt >= helper->header_infos->len) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "%s without header",
+				    cmd);
+			return FALSE;
+		}
+		hdr = g_ptr_array_index(helper->header_infos, helper->images_cnt);
+
+		if (helper->image_buffer->len == 0) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "%s with missing image buffer",
+				    cmd);
+			return FALSE;
+		}
+
+		/* parse SREC file and add as image */
+		blob = g_bytes_new(helper->image_buffer->str, helper->image_buffer->len);
+		if (!fu_firmware_parse_full(firmware_srec,
+					    blob,
+					    hdr->addr,
+					    0x0,
+					    helper->flags,
+					    error))
+			return FALSE;
+		fw_srec = fu_firmware_get_bytes(firmware_srec, error);
+		if (fw_srec == NULL)
+			return FALSE;
+		fu_firmware_set_bytes(img, fw_srec);
+		fu_firmware_set_addr(img, fu_firmware_get_addr(firmware_srec));
+		fu_firmware_set_idx(img, helper->images_cnt);
+		fu_firmware_add_image(helper->firmware, img);
+		helper->images_cnt++;
+
+		/* clear the image buffer */
+		g_string_set_size(helper->image_buffer, 0);
+	}
+
+	/* success */
+	return TRUE;
+}
 
 static gboolean
 fu_wac_firmware_parse(FuFirmware *firmware,
@@ -32,16 +254,18 @@ fu_wac_firmware_parse(FuFirmware *firmware,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
-	gsize len;
-	guint8 *data;
-	guint8 images_cnt = 0;
-	g_auto(GStrv) lines = NULL;
+	gsize sz = 0;
+	const gchar *data = g_bytes_get_data(fw, &sz);
 	g_autoptr(GPtrArray) header_infos = g_ptr_array_new_with_free_func(g_free);
-	g_autoptr(GString) image_buffer = NULL;
+	g_autoptr(GString) image_buffer = g_string_new(NULL);
+	FuWacFirmwareTokenHelper helper = {.firmware = firmware,
+					   .flags = flags,
+					   .header_infos = header_infos,
+					   .image_buffer = image_buffer,
+					   .images_cnt = 0};
 
 	/* check the prefix (BE) */
-	data = (guint8 *)g_bytes_get_data(fw, &len);
-	if (len < 5 || memcmp(data, "WACOM", 5) != 0) {
+	if (sz < 5 || memcmp(data, "WACOM", 5) != 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
@@ -49,213 +273,12 @@ fu_wac_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 
-	/* parse each line */
-	lines = fu_common_strnsplit((const gchar *)data, len, "\n", -1);
-	for (guint i = 0; lines[i] != NULL; i++) {
-		g_autofree gchar *cmd = NULL;
-
-		/* remove windows line endings */
-		g_strdelimit(lines[i], "\r", '\0');
-		cmd = g_strndup(lines[i], 2);
-
-		/* ignore blank lines */
-		if (g_strcmp0(cmd, "") == 0)
-			continue;
-
-		/* Wacom-specific metadata */
-		if (g_strcmp0(cmd, "WA") == 0) {
-			gsize cmdlen = strlen(lines[i]);
-
-			/* header info record */
-			if (cmdlen > 3 && memcmp(lines[i] + 2, "COM", 3) == 0) {
-				guint8 header_image_cnt = 0;
-				if (cmdlen != 40) {
-					g_set_error(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "invalid header, got %" G_GSIZE_FORMAT " bytes",
-						    cmdlen);
-					return FALSE;
-				}
-				if (!fu_firmware_strparse_uint4_safe(lines[i],
-								     cmdlen,
-								     5,
-								     &header_image_cnt,
-								     error))
-					return FALSE;
-				for (guint j = 0; j < header_image_cnt; j++) {
-					g_autofree FuFirmwareWacHeaderRecord *hdr = NULL;
-					hdr = g_new0(FuFirmwareWacHeaderRecord, 1);
-					if (!fu_firmware_strparse_uint32_safe(lines[i],
-									      cmdlen,
-									      (j * 16) + 6,
-									      &hdr->addr,
-									      error))
-						return FALSE;
-					if (!fu_firmware_strparse_uint32_safe(lines[i],
-									      cmdlen,
-									      (j * 16) + 14,
-									      &hdr->sz,
-									      error))
-						return FALSE;
-					g_debug("header_fw%u_addr: 0x%x", j, hdr->addr);
-					g_debug("header_fw%u_sz:   0x%x", j, hdr->sz);
-					g_ptr_array_add(header_infos, g_steal_pointer(&hdr));
-				}
-				continue;
-			}
-
-			/* firmware headline record */
-			if (cmdlen == 13) {
-				FuFirmwareWacHeaderRecord *hdr;
-				guint8 idx = 0;
-				if (!fu_firmware_strparse_uint4_safe(lines[i],
-								     cmdlen,
-								     2,
-								     &idx,
-								     error))
-					return FALSE;
-				if (idx == 0) {
-					g_set_error(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "headline %u invalid",
-						    idx);
-					return FALSE;
-				}
-				if (idx > header_infos->len) {
-					g_set_error(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "headline %u exceeds header count %u",
-						    idx,
-						    header_infos->len);
-					return FALSE;
-				}
-				if (idx - 1 != images_cnt) {
-					g_set_error(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "headline %u is not in sorted order",
-						    idx);
-					return FALSE;
-				}
-				hdr = g_ptr_array_index(header_infos, idx - 1);
-				if (!fu_firmware_strparse_uint32_safe(lines[i],
-								      cmdlen,
-								      3,
-								      &hdr->prog_start_addr,
-								      error))
-					return FALSE;
-				if (hdr->prog_start_addr != hdr->addr) {
-					g_set_error(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "programming address 0x%x != "
-						    "base address 0x%0x for idx %u",
-						    hdr->prog_start_addr,
-						    hdr->addr,
-						    idx);
-					return FALSE;
-				}
-				g_debug("programing-start-address: 0x%x", hdr->prog_start_addr);
-				continue;
-			}
-
-			g_debug("unknown Wacom-specific metadata");
-			continue;
-		}
-
-		/* start */
-		if (g_strcmp0(cmd, "S0") == 0) {
-			if (image_buffer != NULL) {
-				g_set_error_literal(error,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_INTERNAL,
-						    "duplicate S0 without S7");
-				return FALSE;
-			}
-			image_buffer = g_string_new(NULL);
-		}
-
-		/* these are things we want to include in the image */
-		if (g_strcmp0(cmd, "S0") == 0 || g_strcmp0(cmd, "S1") == 0 ||
-		    g_strcmp0(cmd, "S2") == 0 || g_strcmp0(cmd, "S3") == 0 ||
-		    g_strcmp0(cmd, "S5") == 0 || g_strcmp0(cmd, "S7") == 0 ||
-		    g_strcmp0(cmd, "S8") == 0 || g_strcmp0(cmd, "S9") == 0) {
-			if (image_buffer == NULL) {
-				g_set_error(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INTERNAL,
-					    "%s without S0",
-					    cmd);
-				return FALSE;
-			}
-			g_string_append_printf(image_buffer, "%s\n", lines[i]);
-		} else {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INTERNAL,
-				    "invalid SREC command on line %u: %s",
-				    i + 1,
-				    cmd);
-			return FALSE;
-		}
-
-		/* end */
-		if (g_strcmp0(cmd, "S7") == 0) {
-			g_autoptr(GBytes) blob = NULL;
-			g_autoptr(GBytes) fw_srec = NULL;
-			g_autoptr(FuFirmware) firmware_srec = fu_srec_firmware_new();
-			g_autoptr(FuFirmware) img = fu_firmware_new();
-			FuFirmwareWacHeaderRecord *hdr;
-
-			/* get the correct relocated start address */
-			if (images_cnt >= header_infos->len) {
-				g_set_error(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INTERNAL,
-					    "%s without header",
-					    cmd);
-				return FALSE;
-			}
-			hdr = g_ptr_array_index(header_infos, images_cnt);
-
-			if (image_buffer == NULL) {
-				g_set_error(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INTERNAL,
-					    "%s with missing image buffer",
-					    cmd);
-				return FALSE;
-			}
-
-			/* parse SREC file and add as image */
-			blob = g_bytes_new(image_buffer->str, image_buffer->len);
-			if (!fu_firmware_parse_full(firmware_srec,
-						    blob,
-						    hdr->addr,
-						    0x0,
-						    flags,
-						    error))
-				return FALSE;
-			fw_srec = fu_firmware_get_bytes(firmware_srec, error);
-			if (fw_srec == NULL)
-				return FALSE;
-			fu_firmware_set_bytes(img, fw_srec);
-			fu_firmware_set_addr(img, fu_firmware_get_addr(firmware_srec));
-			fu_firmware_set_idx(img, images_cnt);
-			fu_firmware_add_image(firmware, img);
-			images_cnt++;
-
-			/* clear the image buffer */
-			g_string_free(image_buffer, TRUE);
-			image_buffer = NULL;
-		}
-	}
+	/* tokenize */
+	if (!fu_common_strnsplit_full(data, sz, "\n", fu_wac_firmware_tokenize_cb, &helper, error))
+		return FALSE;
 
 	/* verify data is complete */
-	if (image_buffer != NULL) {
+	if (helper.image_buffer != NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
@@ -264,12 +287,12 @@ fu_wac_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* ensure this matched the header */
-	if (header_infos->len != images_cnt) {
+	if (helper.header_infos->len != helper.images_cnt) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "not enough images %u for header count %u",
-			    images_cnt,
+			    helper.images_cnt,
 			    header_infos->len);
 		return FALSE;
 	}


### PR DESCRIPTION
Using fu_common_strnsplit() has the drawback that a malicious user (or
a fuzzer!) could create a file with 5,000,000 newlines, and then pass
that into any parser that tokenizes into lines. This causes millions of
tiny allocations and quickly dirties hundreds of megabytes of RSS due
to heap overheads.

Rather than splitting a huge array and then processing each line, set
up a callback to process each line and only allocate the next string if
the token was parsed correctly. This means that we only dup the buffer
just once before we start parsing rather than allocating everything and
then failing at the first hurdle.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=38696

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
