### PR TITLE
pixart-rf: Use the correct method to add an instance ID

### DIFF
--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -758,11 +758,11 @@ fu_pxi_receiver_device_add_peripherals(FuPxiReceiverDevice *device, guint idx, G
 				      model_name);
 	if (model.type == OTA_WIRELESS_MODULE_TYPE_RECEIVER) {
 		fu_device_set_version(FU_DEVICE(device), model_version);
-		fu_device_add_guid(FU_DEVICE(device), instance_id);
+		fu_device_add_instance_id(FU_DEVICE(device), instance_id);
 	} else {
 		g_autoptr(FuPxiWirelessDevice) wireless_device = fu_pxi_wireless_device_new(&model);
 		g_autofree gchar *logical_id = g_strdup_printf("IDX:0x%02x", idx);
-		fu_device_add_guid(FU_DEVICE(wireless_device), instance_id);
+		fu_device_add_instance_id(FU_DEVICE(wireless_device), instance_id);
 		fu_device_set_name(FU_DEVICE(wireless_device), model_name);
 		fu_device_set_version(FU_DEVICE(wireless_device), model_version);
 		fu_device_set_logical_id(FU_DEVICE(wireless_device), logical_id);


### PR DESCRIPTION
We actually check for fu_device_add_guid() not being an actual GUID,
but in the future we'll be warning if we do this magic fallback as it
hides not-quite-GUID typos.

No behaviour change.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
