### PR TITLE
Update the child composite ID if the parent changes

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2229,6 +2229,7 @@ fu_device_set_id(FuDevice *self, const gchar *id)
 	FuDevicePrivate *priv = GET_PRIVATE(self);
 	GPtrArray *children;
 	g_autofree gchar *id_hash = NULL;
+	g_autofree gchar *id_hash_old = g_strdup(fwupd_device_get_id(FWUPD_DEVICE(self)));
 
 	g_return_if_fail(FU_IS_DEVICE(self));
 	g_return_if_fail(id != NULL);
@@ -2248,6 +2249,12 @@ fu_device_set_id(FuDevice *self, const gchar *id)
 	for (guint i = 0; i < children->len; i++) {
 		FuDevice *devtmp = g_ptr_array_index(children, i);
 		fwupd_device_set_parent_id(FWUPD_DEVICE(devtmp), id_hash);
+
+		/* update the composite ID of the child with the new ID if required; this will
+		 * propagate to grandchildren and great-grandchildren as required */
+		if (id_hash_old != NULL &&
+		    g_strcmp0(fu_device_get_composite_id(devtmp), id_hash_old) == 0)
+			fu_device_set_composite_id(devtmp, id_hash);
 	}
 }
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1598,6 +1598,15 @@ fu_device_composite_id_func(void)
 	g_assert_cmpstr(fu_device_get_composite_id(dev4),
 			==,
 			"3b42553c4e3241e8f3f8fbc19a69fa2f95708a9d");
+
+	/* change the parent ID */
+	fu_device_set_id(dev1, "dev1-NEW");
+	g_assert_cmpstr(fu_device_get_composite_id(dev1),
+			==,
+			"a4c8efc6a0a58c2dc14c05fd33186703f7352997");
+	g_assert_cmpstr(fu_device_get_composite_id(dev2),
+			==,
+			"a4c8efc6a0a58c2dc14c05fd33186703f7352997");
 }
 
 static void


### PR DESCRIPTION
Typically, this can be triggered with:

 * create parent
 * set parent physical ID
 * add new child to parent
 * set parent logical ID

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
