### PR TITLE
Improve get-plugins

### DIFF
--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -18,6 +18,15 @@ fu_plugin_init(FuPlugin *plugin)
 }
 
 gboolean
+fu_plugin_startup(FuPlugin *plugin, GError **error)
+{
+	/* are the EFI dirs set up so we can update each device */
+	if (!fu_efivar_supported(error))
+		return FALSE;
+	return TRUE;
+}
+
+gboolean
 fu_plugin_coldplug(FuPlugin *plugin, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -402,7 +402,7 @@ fu_util_get_plugins(FuUtilPrivate *priv, gchar **values, GError **error)
 	GPtrArray *plugins;
 
 	/* load engine */
-	if (!fu_util_start_engine(priv, FU_ENGINE_LOAD_FLAG_NONE, error))
+	if (!fu_util_start_engine(priv, FU_ENGINE_LOAD_FLAG_HWINFO, error))
 		return FALSE;
 
 	/* print */


### PR DESCRIPTION
Some plugins will need to check hardware in `fu_plugin_startup` and `fwupdtool get-plugins` will show invalid output even when run as root.  To fix this, initialize smbios reading for the context.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

CC @therealjuanmartinez
