### PR TITLE
Fix probing the Dell TPM (Fixes: #3759)

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -761,6 +761,7 @@ fu_plugin_dell_detect_tpm(FuPlugin *plugin, GError **error)
 	/* build Standard device nodes */
 	dev = fu_device_new_with_context(ctx);
 	fu_device_set_physical_id(dev, "DEVNAME=/dev/tpm0");
+	fu_device_set_logical_id(dev, "UEFI");
 	fu_device_add_instance_id(dev, tpm_guid_raw);
 	fu_device_add_instance_id(dev, "system-tpm");
 	fu_device_set_vendor(dev, "Dell Inc.");


### PR DESCRIPTION
Since commit 078beaf, device de-duplication between plugins doesn't
work anymore.  Both the TPM and Dell plugin create a device with an
identical physical ID and no logical ID.  This makes the device list
think whichever plugin probes second is just updating the first.

To avoid this problem, set a logical ID in the Dell plugin, ensuring
that the device ID built from physical + logical is different from the
TPM plugin.

The side effect of this is that both devices will export into the device
list, but the TPM plugin's devices will not be upgradable.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
