### PR TITLE
Wip/3mdeb/freebsd ci fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           pkg install -y git python3 glib meson pkgconf gobject-introspection \
             vala gtk-doc json-glib gpgme gnutls sqlite3 curl gcab libarchive \
             libelf libgpg-error gettext-tools gtk-update-icon-cache atk pango \
-            binutils gcc
+            binutils gcc protobuf-c
         sync: rsync
         run: ./contrib/ci/build_freebsd_package.sh
           --GITHUB_SHA=${GITHUB_SHA}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       uses: jimschubert/query-tag-action@v1
     - name: Build
       id: test
-      uses: vmactions/freebsd-vm@v0.1.4
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         usesh: true
         mem: 8192

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,38 @@ jobs:
       with:
         name: artifacts
         path: ./out/artifacts
+
+  build-freebsd:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    name: build-freebsd-package
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Find tag
+      id: tagger
+      uses: jimschubert/query-tag-action@v1
+    - name: Build
+      id: test
+      uses: vmactions/freebsd-vm@v0.1.4
+      with:
+        usesh: true
+        mem: 8192
+        prepare: |
+          pkg install -y git python3 glib meson pkgconf gobject-introspection \
+            vala gtk-doc json-glib gpgme gnutls sqlite3 curl gcab libarchive \
+            libelf libgpg-error gettext-tools gtk-update-icon-cache atk pango \
+            binutils gcc
+        sync: rsync
+        run: ./contrib/ci/build_freebsd_package.sh
+          --GITHUB_SHA=${GITHUB_SHA}
+          --GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}
+          --GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+          --GITHUB_TAG=${{steps.tagger.outputs.tag}}
+    - name: Upload fwupd binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Binary package
+        path: |
+          fwupd*.pkg
+


### PR DESCRIPTION
Fixes FreeBSD CI problem. There is no need to build protobuf-c from the source. The package is installed in the preparation preparation phase. 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
