### PR TITLE
Restore the ABI for fu_device_detach() and provide new symbols

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3640,7 +3640,6 @@ fu_device_dump_firmware(FuDevice *self, FuProgress *progress, GError **error)
 /**
  * fu_device_detach:
  * @self: a #FuDevice
- * @progress: a #FuProgress
  * @error: (nullable): optional return location for an error
  *
  * Detaches a device from the application into bootloader mode.
@@ -3650,7 +3649,26 @@ fu_device_dump_firmware(FuDevice *self, FuProgress *progress, GError **error)
  * Since: 1.0.8
  **/
 gboolean
-fu_device_detach(FuDevice *self, FuProgress *progress, GError **error)
+fu_device_detach(FuDevice *self, GError **error)
+{
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	return fu_device_detach_full(self, progress, error);
+}
+
+/**
+ * fu_device_detach_full:
+ * @self: a #FuDevice
+ * @progress: a #FuProgress
+ * @error: (nullable): optional return location for an error
+ *
+ * Detaches a device from the application into bootloader mode.
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 1.7.0
+ **/
+gboolean
+fu_device_detach_full(FuDevice *self, FuProgress *progress, GError **error)
 {
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
 
@@ -3669,7 +3687,6 @@ fu_device_detach(FuDevice *self, FuProgress *progress, GError **error)
 /**
  * fu_device_attach:
  * @self: a #FuDevice
- * @progress: a #FuProgress
  * @error: (nullable): optional return location for an error
  *
  * Attaches a device from the bootloader into application mode.
@@ -3679,7 +3696,26 @@ fu_device_detach(FuDevice *self, FuProgress *progress, GError **error)
  * Since: 1.0.8
  **/
 gboolean
-fu_device_attach(FuDevice *self, FuProgress *progress, GError **error)
+fu_device_attach(FuDevice *self, GError **error)
+{
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	return fu_device_attach_full(self, progress, error);
+}
+
+/**
+ * fu_device_attach_full:
+ * @self: a #FuDevice
+ * @progress: a #FuProgress
+ * @error: (nullable): optional return location for an error
+ *
+ * Attaches a device from the bootloader into application mode.
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 1.7.0
+ **/
+gboolean
+fu_device_attach_full(FuDevice *self, FuProgress *progress, GError **error)
 {
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -565,9 +565,17 @@ fu_device_dump_firmware(FuDevice *self,
 			FuProgress *progress,
 			GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_device_attach(FuDevice *self, FuProgress *progress, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_device_attach(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_device_detach(FuDevice *self, FuProgress *progress, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_device_detach(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_device_attach_full(FuDevice *self,
+		      FuProgress *progress,
+		      GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_device_detach_full(FuDevice *self,
+		      FuProgress *progress,
+		      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fu_device_reload(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -682,7 +682,7 @@ fu_plugin_device_attach(FuPlugin *self, FuDevice *device, FuProgress *progress, 
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_attach(device, progress, error);
+	return fu_device_attach_full(device, progress, error);
 }
 
 static gboolean
@@ -693,7 +693,7 @@ fu_plugin_device_detach(FuPlugin *self, FuDevice *device, FuProgress *progress, 
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_detach(device, progress, error);
+	return fu_device_detach_full(device, progress, error);
 }
 
 static gboolean
@@ -780,12 +780,12 @@ fu_plugin_device_read_firmware(FuPlugin *self,
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_detach(device, progress, error))
+	if (!fu_device_detach_full(device, progress, error))
 		return FALSE;
 	firmware = fu_device_read_firmware(device, progress, error);
 	if (firmware == NULL) {
 		g_autoptr(GError) error_local = NULL;
-		if (!fu_device_attach(device, progress, &error_local))
+		if (!fu_device_attach_full(device, progress, &error_local))
 			g_debug("ignoring attach failure: %s", error_local->message);
 		g_prefix_error(error, "failed to read firmware: ");
 		return FALSE;
@@ -793,7 +793,7 @@ fu_plugin_device_read_firmware(FuPlugin *self,
 	fw = fu_firmware_write(firmware, error);
 	if (fw == NULL) {
 		g_autoptr(GError) error_local = NULL;
-		if (!fu_device_attach(device, progress, &error_local))
+		if (!fu_device_attach_full(device, progress, &error_local))
 			g_debug("ignoring attach failure: %s", error_local->message);
 		g_prefix_error(error, "failed to write firmware: ");
 		return FALSE;
@@ -803,7 +803,7 @@ fu_plugin_device_read_firmware(FuPlugin *self,
 		hash = g_compute_checksum_for_bytes(checksum_types[i], fw);
 		fu_device_add_checksum(device, hash);
 	}
-	return fu_device_attach(device, progress, error);
+	return fu_device_attach_full(device, progress, error);
 }
 
 /**

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -862,6 +862,8 @@ LIBFWUPDPLUGIN_1.6.2 {
 LIBFWUPDPLUGIN_1.7.0 {
   global:
     fu_common_strnsplit_full;
+    fu_device_attach_full;
+    fu_device_detach_full;
     fu_device_set_progress;
     fu_plugin_runner_attach;
     fu_plugin_runner_cleanup;

--- a/plugins/dfu/fu-dfu-tool.c
+++ b/plugins/dfu/fu-dfu-tool.c
@@ -494,7 +494,7 @@ fu_dfu_tool_read_alt(FuDfuTool *self, gchar **values, GError **error)
 	/* APP -> DFU */
 	if (!fu_device_has_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
 		g_debug("detaching");
-		if (!fu_device_detach(FU_DEVICE(device), progress, error))
+		if (!fu_device_detach_full(FU_DEVICE(device), progress, error))
 			return FALSE;
 		if (!fu_dfu_device_wait_for_replug(self,
 						   device,
@@ -529,7 +529,7 @@ fu_dfu_tool_read_alt(FuDfuTool *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* do host reset */
-	if (!fu_device_attach(FU_DEVICE(device), progress, error))
+	if (!fu_device_attach_full(FU_DEVICE(device), progress, error))
 		return FALSE;
 	if (!fu_dfu_device_wait_for_replug(self,
 					   device,
@@ -583,7 +583,7 @@ fu_dfu_tool_read(FuDfuTool *self, gchar **values, GError **error)
 
 	/* APP -> DFU */
 	if (!fu_device_has_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		if (!fu_device_detach(FU_DEVICE(device), progress, error))
+		if (!fu_device_detach_full(FU_DEVICE(device), progress, error))
 			return FALSE;
 		if (!fu_dfu_device_wait_for_replug(self,
 						   device,
@@ -601,7 +601,7 @@ fu_dfu_tool_read(FuDfuTool *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* do host reset */
-	if (!fu_device_attach(FU_DEVICE(device), progress, error))
+	if (!fu_device_attach_full(FU_DEVICE(device), progress, error))
 		return FALSE;
 	if (!fu_dfu_device_wait_for_replug(self,
 					   device,
@@ -672,7 +672,7 @@ fu_dfu_tool_write_alt(FuDfuTool *self, gchar **values, GError **error)
 	/* APP -> DFU */
 	if (!fu_device_has_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
 		g_debug("detaching");
-		if (!fu_device_detach(FU_DEVICE(device), progress, error))
+		if (!fu_device_detach_full(FU_DEVICE(device), progress, error))
 			return FALSE;
 		if (!fu_dfu_device_wait_for_replug(self, device, 5000, error))
 			return FALSE;
@@ -730,7 +730,7 @@ fu_dfu_tool_write_alt(FuDfuTool *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* do host reset */
-	if (!fu_device_attach(FU_DEVICE(device), progress, error))
+	if (!fu_device_attach_full(FU_DEVICE(device), progress, error))
 		return FALSE;
 	if (!fu_dfu_device_wait_for_replug(self,
 					   device,
@@ -778,7 +778,7 @@ fu_dfu_tool_write(FuDfuTool *self, gchar **values, GError **error)
 
 	/* APP -> DFU */
 	if (!fu_device_has_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		if (!fu_device_detach(FU_DEVICE(device), progress, error))
+		if (!fu_device_detach_full(FU_DEVICE(device), progress, error))
 			return FALSE;
 		if (!fu_dfu_device_wait_for_replug(self,
 						   device,
@@ -800,7 +800,7 @@ fu_dfu_tool_write(FuDfuTool *self, gchar **values, GError **error)
 		return FALSE;
 
 	/* do host reset */
-	if (!fu_device_attach(FU_DEVICE(device), progress, error))
+	if (!fu_device_attach_full(FU_DEVICE(device), progress, error))
 		return FALSE;
 
 	if (fu_dfu_device_has_attribute(device, FU_DFU_DEVICE_ATTR_MANIFEST_TOL)) {

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
@@ -55,7 +55,7 @@ fu_logitech_hidpp_radio_detach(FuDevice *device, FuProgress *progress, GError **
 
 	if (!fu_device_has_flag(parent, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	return fu_device_detach(parent, progress, error);
+	return fu_device_detach_full(parent, progress, error);
 }
 
 static gboolean

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -398,7 +398,7 @@ fu_plugin_detach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GErro
 	}
 
 	/* reset */
-	if (!fu_device_detach(device, progress, error)) {
+	if (!fu_device_detach_full(device, progress, error)) {
 		fu_plugin_mm_uninhibit_device(plugin);
 		return FALSE;
 	}
@@ -435,7 +435,7 @@ fu_plugin_attach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GErro
 	 * so that engine can setup the device "waiting" logic before the actual
 	 * attach procedure happens (which will reset the module if it worked
 	 * properly) */
-	if (!fu_device_attach(device, progress, error))
+	if (!fu_device_attach_full(device, progress, error))
 		return FALSE;
 
 	/* this signal will always be emitted asynchronously */

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -269,14 +269,14 @@ static gboolean
 fu_synaprom_config_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
-	return fu_device_attach(parent, progress, error);
+	return fu_device_attach_full(parent, progress, error);
 }
 
 static gboolean
 fu_synaprom_config_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
-	return fu_device_detach(parent, progress, error);
+	return fu_device_detach_full(parent, progress, error);
 }
 
 static void

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -252,7 +252,7 @@ fu_vli_usbhub_pd_device_attach(FuDevice *device, FuProgress *progress, GError **
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new(parent, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_attach(parent, progress, error);
+	return fu_device_attach_full(parent, progress, error);
 }
 
 static gboolean

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1525,7 +1525,7 @@ fu_util_detach(FuUtilPrivate *priv, gchar **values, GError **error)
 	locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_detach(device, priv->progress, error);
+	return fu_device_detach_full(device, priv->progress, error);
 }
 
 static gboolean
@@ -1622,7 +1622,7 @@ fu_util_attach(FuUtilPrivate *priv, gchar **values, GError **error)
 	locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_attach(device, priv->progress, error);
+	return fu_device_attach_full(device, priv->progress, error);
 }
 
 static gboolean


### PR DESCRIPTION
Quite a few plugins are using a FuDeviceLocker to detach then attach in
the error path, and finding them isn't easy as we explicitly cast to a
FuDeviceLockerFunc.

For sanity, just provide both symbols so we can do the right thing in
both cases. It seems like a sensible thing to allow.

Fixes https://github.com/fwupd/fwupd/issues/3771

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
