### PR TITLE
plugin: fix URL to fu-device-metadata.h

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,6 +23,6 @@ This includes things like one plugin turning on a device, or providing missing
 metadata to another plugin.
 
 The ABI for these interactions is defined in:
-<https://github.com/fwupd/fwupd/blob/master/src/fu-device-metadata.h>
+<https://github.com/fwupd/fwupd/blob/master/libfwupdplugin/fu-device-metadata.h>
 
 All interactions between plugins should have the interface defined in that file.


### PR DESCRIPTION
The commit 6b0e66354b1b7007cb525a3d3c8280bf9001e880 moved the header to
libfwupdplugin.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
