### PR TITLE
Remove support for `--ignore-power` by frontends

### DIFF
--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -58,7 +58,6 @@ _fwupdmgr_opts=(
 	'--filter'
 	'--disable-ssl-strict'
 	'--ipfs'
-	'--ignore-power'
 	'--json'
 )
 

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -58,7 +58,6 @@ _fwupdtool_opts=(
 	'--no-safety-check'
 	'--ignore-checksum'
 	'--ignore-vid-pid'
-	'--ignore-power'
 )
 
 _show_filters()

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -42,3 +42,7 @@ BlockedFirmware=
 #
 # If unset or no schemes are listed, the default will be: file,https,http,ipfs
 UriSchemes=
+
+# Ignore power levels of devices when running updates
+IgnorePower=false
+

--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -9,6 +9,7 @@
 * Remove `fwupd_release_get_uri()` and `fwupd_release_set_uri()`
 * Rename `fwupd_client_install_release2_async()` to `fwupd_client_install_release_async()`
 * Remove fwupd_device_set_protocol() and fwupd_device_get_protocol()
+* Remove deprecated install flag `FWUPD_INSTALL_FLAG_IGNORE_POWER`
 
 ## Migration from Version 0.9.x
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -743,6 +743,7 @@ typedef guint64 FwupdPluginFlags;
  * @FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM:		Ignore firmware CRCs and checksums
  * @FWUPD_INSTALL_FLAG_IGNORE_VID_PID:		Ignore firmware vendor and project checks
  * @FWUPD_INSTALL_FLAG_IGNORE_POWER:		Ignore requirement of external power source
+ *(Deprecated since 1.7.0)
  * @FWUPD_INSTALL_FLAG_NO_SEARCH:		Do not use heuristics when parsing the image
  *
  * Flags to set when performing the firmware update or install.

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -38,3 +38,5 @@ gboolean
 fu_config_get_update_motd(FuConfig *self);
 gboolean
 fu_config_get_enumerate_all_devices(FuConfig *self);
+gboolean
+fu_config_get_ignore_power(FuConfig *self);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -281,6 +281,9 @@ fu_engine_watch_device(FuEngine *self, FuDevice *device)
 static void
 fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 {
+	if (fu_config_get_ignore_power(self->config))
+		return;
+
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC) &&
 	    (fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_DISCHARGING ||
 	     fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_EMPTY)) {
@@ -2811,7 +2814,15 @@ fu_engine_device_check_power(FuEngine *self,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
-	if (flags & FWUPD_INSTALL_FLAG_IGNORE_POWER)
+	if (flags & FWUPD_INSTALL_FLAG_IGNORE_POWER) {
+		g_autofree gchar *configdir = fu_common_get_path(FU_PATH_KIND_SYSCONFDIR_PKG);
+		g_autofree gchar *configfile = g_build_filename(configdir, "daemon.conf", NULL);
+		g_warning("Ignoring deprecated flag provided by client "
+			  "'FWUPD_INSTALL_FLAG_IGNORE_POWER'. To ignore power levels, modify %s",
+			  configfile);
+	}
+
+	if (fu_config_get_ignore_power(self->config))
 		return TRUE;
 
 	/* not charging */

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1570,10 +1570,8 @@ fu_main_daemon_method_call(GDBusConnection *connection,
 			    g_variant_get_boolean(prop_value) == TRUE)
 				helper->flags |= FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
 			if (g_strcmp0(prop_key, "force") == 0 &&
-			    g_variant_get_boolean(prop_value) == TRUE) {
+			    g_variant_get_boolean(prop_value) == TRUE)
 				helper->flags |= FWUPD_INSTALL_FLAG_FORCE;
-				helper->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;
-			}
 			if (g_strcmp0(prop_key, "ignore-power") == 0 &&
 			    g_variant_get_boolean(prop_value) == TRUE)
 				helper->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2899,7 +2899,6 @@ main(int argc, char *argv[])
 	gboolean ret;
 	gboolean version = FALSE;
 	gboolean ignore_checksum = FALSE;
-	gboolean ignore_power = FALSE;
 	gboolean ignore_vid_pid = FALSE;
 	gboolean interactive = isatty(fileno(stdout)) != 0;
 	g_auto(GStrv) plugin_glob = NULL;
@@ -2964,14 +2963,6 @@ main(int argc, char *argv[])
 	     &ignore_vid_pid,
 	     /* TRANSLATORS: command line option */
 	     _("Ignore firmware hardware mismatch failures"),
-	     NULL},
-	    {"ignore-power",
-	     '\0',
-	     0,
-	     G_OPTION_ARG_NONE,
-	     &ignore_power,
-	     /* TRANSLATORS: command line option */
-	     _("Ignore requirement of external power source"),
 	     NULL},
 	    {"no-reboot-check",
 	     '\0',
@@ -3430,16 +3421,12 @@ main(int argc, char *argv[])
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 	if (allow_branch_switch)
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
-	if (force) {
+	if (force)
 		priv->flags |= FWUPD_INSTALL_FLAG_FORCE;
-		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;
-	}
 	if (ignore_checksum)
 		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM;
 	if (ignore_vid_pid)
 		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_VID_PID;
-	if (ignore_power)
-		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;
 
 	/* load engine */
 	priv->engine = fu_engine_new(FU_APP_FLAGS_NO_IDLE_SOURCES);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3338,7 +3338,6 @@ main(int argc, char *argv[])
 	gboolean allow_older = FALSE;
 	gboolean allow_reinstall = FALSE;
 	gboolean enable_ipfs = FALSE;
-	gboolean ignore_power = FALSE;
 	gboolean is_interactive = TRUE;
 	gboolean no_history = FALSE;
 	gboolean offline = FALSE;
@@ -3511,14 +3510,6 @@ main(int argc, char *argv[])
 					 /* TRANSLATORS: command line option */
 					 _("Filter with a set of device flags using a ~ prefix to "
 					   "exclude, e.g. 'internal,~needs-reboot'"),
-					 NULL},
-					{"ignore-power",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &ignore_power,
-					 /* TRANSLATORS: command line option */
-					 _("Ignore requirement of external power source"),
 					 NULL},
 					{"json",
 					 '\0',
@@ -3879,14 +3870,10 @@ main(int argc, char *argv[])
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 	if (allow_branch_switch)
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
-	if (force) {
+	if (force)
 		priv->flags |= FWUPD_INSTALL_FLAG_FORCE;
-		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;
-	}
 	if (no_history)
 		priv->flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
-	if (ignore_power)
-		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_POWER;
 
 	/* use IPFS for metadata and firmware *only* if specified */
 	if (enable_ipfs)


### PR DESCRIPTION
This functionality broke a number of releases ago as part of
implementing device inhibition and was just noticed now.

Instead of fixing it, the preference seems to be to remove the
functionality as it exists today as inhibitions can happen for
a number of reasons.

To still allow people to override these power warnings (such as during
development) add a new daemon configuration item that can be used.

Fixes: #3778

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
