### PR TITLE
Allow installing the LVFS remote, but disabled

### DIFF
--- a/data/remotes.d/lvfs.conf
+++ b/data/remotes.d/lvfs.conf
@@ -1,7 +1,7 @@
 [fwupd Remote]
 
 # this remote provides metadata and firmware marked as 'stable' from the LVFS
-Enabled=true
+Enabled=@enabled@
 Title=Linux Vendor Firmware Service
 MetadataURI=https://cdn.fwupd.org/downloads/firmware.xml.gz
 ReportURI=https://fwupd.org/lvfs/firmware/report

--- a/data/remotes.d/meson.build
+++ b/data/remotes.d/meson.build
@@ -1,9 +1,21 @@
-if build_standalone and get_option('lvfs')
+if build_standalone and get_option('lvfs') != 'false'
   install_data([
-      'lvfs.conf',
       'lvfs-testing.conf',
     ],
     install_dir : join_paths(sysconfdir, 'fwupd', 'remotes.d')
+  )
+  con3 = configuration_data()
+  if get_option('lvfs') == 'disabled'
+    con3.set('enabled', 'false')
+  else
+    con3.set('enabled', 'true')
+  endif
+  configure_file(
+    input : 'lvfs.conf',
+    output : 'lvfs.conf',
+    configuration : con3,
+    install: true,
+    install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
   )
   i18n.merge_file(
     input: 'lvfs.metainfo.xml',

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -179,12 +179,12 @@ fwupd_remote_download_func(void)
 					     "lib",
 					     "fwupd",
 					     "remotes.d",
-					     "lvfs",
+					     "lvfs-testing",
 					     "metadata.xml.gz",
 					     NULL);
 	expected_signature = g_strdup_printf("%s.jcat", expected_metadata);
 	fwupd_remote_set_remotes_dir(remote, directory);
-	fn = g_build_filename(FU_SELF_TEST_REMOTES_DIR, "remotes.d", "lvfs.conf", NULL);
+	fn = g_build_filename(FU_SELF_TEST_REMOTES_DIR, "remotes.d", "lvfs-testing.conf", NULL);
 	ret = fwupd_remote_load_from_filename(remote, fn, NULL, &error);
 	g_assert_no_error(error);
 	g_assert(ret);
@@ -194,10 +194,12 @@ fwupd_remote_download_func(void)
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert(fwupd_remote_get_enabled(remote));
-	g_assert(fwupd_remote_get_metadata_uri(remote) != NULL);
-	g_assert(fwupd_remote_get_metadata_uri_sig(remote) != NULL);
-	g_assert_cmpstr(fwupd_remote_get_title(remote), ==, "Linux Vendor Firmware Service");
+	g_assert_false(fwupd_remote_get_enabled(remote));
+	g_assert_nonnull(fwupd_remote_get_metadata_uri(remote));
+	g_assert_nonnull(fwupd_remote_get_metadata_uri_sig(remote));
+	g_assert_cmpstr(fwupd_remote_get_title(remote),
+			==,
+			"Linux Vendor Firmware Service (testing)");
 	g_assert_cmpstr(fwupd_remote_get_report_uri(remote),
 			==,
 			"https://fwupd.org/lvfs/firmware/report");

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,7 @@ option('consolekit', type : 'boolean', value : true, description : 'enable Conso
 option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
 option('docs', type : 'combo', choices : ['none', 'gtkdoc', 'docgen'], value : 'docgen', description : 'developer documentation type')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
-option('lvfs', type : 'boolean', value : true, description : 'enable LVFS remotes')
+option('lvfs', type : 'combo', choices : ['true', 'false', 'disabled'], value : 'true', description : 'install LVFS remotes')
 option('man', type : 'boolean', value : true, description : 'enable man pages')
 option('libarchive', type : 'boolean', value : true, description : 'enable libarchive support')
 option('gudev', type : 'boolean', value : true, description : 'enable GUdev support')


### PR DESCRIPTION
This is a patch that I have to regenerate almost every rebase. Just
move it upstream as it's probably not RHEL specific.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
