### PR TITLE
superio: Continue to add the SuperIO-IT8587 instance IDs

### DIFF
--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -268,10 +268,13 @@ fu_superio_device_probe(FuDevice *device, GError **error)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE(device);
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
+	g_autofree gchar *devid = NULL;
 	g_autofree gchar *name = NULL;
 
 	/* use the chipset name as the logical ID and for the GUID */
 	fu_device_set_logical_id(device, priv->chipset);
+	devid = g_strdup_printf("SuperIO-%s", priv->chipset);
+	fu_device_add_instance_id(device, devid);
 	name = g_strdup_printf("SuperIO %s", priv->chipset);
 	fu_device_set_name(FU_DEVICE(self), name);
 	return TRUE;


### PR DESCRIPTION
The GUIDs are in use by old firmware, and so of course we have to
continue adding them.

See https://github.com/fwupd/fwupd/pull/3734#issuecomment-919829988

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
