### PR TITLE
synaptics-cape: Add interrupt endpoint support

### DIFF
--- a/plugins/synaptics-cape/README.md
+++ b/plugins/synaptics-cape/README.md
@@ -32,9 +32,10 @@ device will reset when the new firmware has been written.
 
 The vendor ID is set from the USB vendor, in this instance set to `USB:0x1395`
 
-## Quirk Use
+### Plugin-specific flags
 
-This plugin uses no plugin-specific quirks.
+* use-in-report-interrupt: some devices will support IN_REPORT that allow host communicate with
+  device over interrupt instead of control endpoint, since: 1.7.0
 
 ## External Interface Access
 

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -22,7 +22,7 @@ struct _FuSynapticsCapeFirmware {
 	guint16 pid;
 };
 
-/* Firmware update command structure, little endian */
+/* firmware update command structure, little endian */
 typedef struct __attribute__((packed)) {
 	guint32 vid;		/* USB vendor id */
 	guint32 pid;		/* USB product id */

--- a/plugins/synaptics-cape/synaptics-cape.quirk
+++ b/plugins/synaptics-cape/synaptics-cape.quirk
@@ -1,73 +1,94 @@
 # EPOS Raw Plus
 [USB\VID_1395&PID_0280]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0281]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 # RAW Teams
 [USB\VID_1395&PID_0294]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0295]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0296]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0297]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0298]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0299]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0400]
 Guid = SYNAPTICS_CAPE\CX31993
-
+Flags = use-in-report-interrupt
 
 # EPOS Morgan-T
 [USB\VID_1395&PID_0200]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0288]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0289]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028A]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028B]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028C]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028D]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028E]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_028F]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 # EPOS Morgan-V
 [USB\VID_1395&PID_0290]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0291]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0292]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 [USB\VID_1395&PID_0293]
 Guid = SYNAPTICS_CAPE\CX31993
+Flags = use-in-report-interrupt
 
 # USB audio codec Dongle
 [SYNAPTICS_CAPE\CX31993]


### PR DESCRIPTION
Add new option can receive HID report over Interrupt In endpoint
instead of control endpoint. This new option is enabled by default and
can be turned off by setting 'InReportViaInterrupt = off' in quirk file.

This commit also fixes a false error within software reset function.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
