### PR TITLE
trivial: Do not use g_assert() in self test code

### DIFF
--- a/libfwupd/fwupd-context-test.c
+++ b/libfwupd/fwupd-context-test.c
@@ -30,7 +30,7 @@ fwupd_thread_test_thread_cb(gpointer user_data)
 	g_autoptr(GMainContext) context = g_main_context_new();
 	g_autoptr(GMainContextPusher) pusher = g_main_context_pusher_new(context);
 
-	g_assert(pusher != NULL);
+	g_assert_nonnull(pusher);
 	g_message("Calling fwupd_client_get_devices() in thread %p with main context %p",
 		  g_thread_self(),
 		  g_main_context_get_thread_default());
@@ -66,8 +66,8 @@ fwupd_thread_test_notify_cb(GObject *object, GParamSpec *pspec, gpointer user_da
 	g_message("fwupd_thread_test_notify_cb() in thread %p with main context %p",
 		  g_thread_self(),
 		  g_main_context_get_thread_default());
-	g_assert(g_thread_self() == self->main_thread);
-	g_assert(g_main_context_get_thread_default() == NULL);
+	g_assert_true(g_thread_self() == self->main_thread);
+	g_assert_null(g_main_context_get_thread_default());
 }
 
 static gboolean

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -187,7 +187,7 @@ fwupd_remote_download_func(void)
 	fn = g_build_filename(FU_SELF_TEST_REMOTES_DIR, "remotes.d", "lvfs-testing.conf", NULL);
 	ret = fwupd_remote_load_from_filename(remote, fn, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fwupd_remote_setup(remote, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -224,11 +224,11 @@ fwupd_remote_baseuri_func(void)
 	fn = g_build_filename(TESTDATADIR, "tests", "firmware-base-uri.conf", NULL);
 	ret = fwupd_remote_load_from_filename(remote, fn, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert(fwupd_remote_get_enabled(remote));
+	g_assert_true(fwupd_remote_get_enabled(remote));
 	g_assert_cmpstr(fwupd_remote_get_checksum(remote), ==, NULL);
 	g_assert_cmpstr(fwupd_remote_get_metadata_uri(remote),
 			==,
@@ -291,11 +291,11 @@ fwupd_remote_nopath_func(void)
 	fn = g_build_filename(TESTDATADIR, "tests", "firmware-nopath.conf", NULL);
 	ret = fwupd_remote_load_from_filename(remote, fn, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert(fwupd_remote_get_enabled(remote));
+	g_assert_true(fwupd_remote_get_enabled(remote));
 	g_assert_cmpstr(fwupd_remote_get_checksum(remote), ==, NULL);
 	g_assert_cmpstr(fwupd_remote_get_metadata_uri(remote),
 			==,
@@ -322,13 +322,13 @@ fwupd_remote_local_func(void)
 	fn = g_build_filename(FU_LOCAL_REMOTE_DIR, "dell-esrt.conf", NULL);
 	ret = fwupd_remote_load_from_filename(remote, fn, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_LOCAL);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_NONE);
-	g_assert(fwupd_remote_get_enabled(remote));
-	g_assert(fwupd_remote_get_metadata_uri(remote) == NULL);
-	g_assert(fwupd_remote_get_metadata_uri_sig(remote) == NULL);
-	g_assert(fwupd_remote_get_report_uri(remote) == NULL);
+	g_assert_true(fwupd_remote_get_enabled(remote));
+	g_assert_null(fwupd_remote_get_metadata_uri(remote));
+	g_assert_null(fwupd_remote_get_metadata_uri_sig(remote));
+	g_assert_null(fwupd_remote_get_report_uri(remote));
 	g_assert_cmpstr(fwupd_remote_get_title(remote),
 			==,
 			"Enable UEFI capsule updates on Dell systems");
@@ -429,9 +429,9 @@ fwupd_device_func(void)
 	g_print("\n%s", str);
 
 	/* check GUIDs */
-	g_assert(fwupd_device_has_guid(dev, "2082b5e0-7a64-478a-b1b2-e3404fab6dad"));
-	g_assert(fwupd_device_has_guid(dev, "00000000-0000-0000-0000-000000000000"));
-	g_assert(!fwupd_device_has_guid(dev, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"));
+	g_assert_true(fwupd_device_has_guid(dev, "2082b5e0-7a64-478a-b1b2-e3404fab6dad"));
+	g_assert_true(fwupd_device_has_guid(dev, "00000000-0000-0000-0000-000000000000"));
+	g_assert_false(fwupd_device_has_guid(dev, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"));
 
 	/* convert the new non-breaking space back into a normal space:
 	 * https://gitlab.gnome.org/GNOME/glib/commit/76af5dabb4a25956a6c41a75c0c7feeee74496da */
@@ -460,7 +460,7 @@ fwupd_device_func(void)
 				    "  Flags:                trusted-payload\n",
 				    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* export to json */
 	builder = json_builder_new();
@@ -517,7 +517,7 @@ fwupd_device_func(void)
 				    "}",
 				    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -559,12 +559,12 @@ fwupd_client_devices_func(void)
 		return;
 	}
 	g_assert_no_error(error);
-	g_assert(array != NULL);
+	g_assert_nonnull(array);
 	g_assert_cmpint(array->len, >, 0);
 
 	/* check device */
 	dev = g_ptr_array_index(array, 0);
-	g_assert(FWUPD_IS_DEVICE(dev));
+	g_assert_true(FWUPD_IS_DEVICE(dev));
 	g_assert_cmpstr(fwupd_device_get_guid_default(dev), !=, NULL);
 	g_assert_cmpstr(fwupd_device_get_id(dev), !=, NULL);
 }
@@ -611,20 +611,20 @@ fwupd_client_remotes_func(void)
 		return;
 	}
 	g_assert_no_error(error);
-	g_assert(array != NULL);
+	g_assert_nonnull(array);
 	g_assert_cmpint(array->len, >, 0);
 
 	/* check we can find the right thing */
 	remote2 = fwupd_client_get_remote_by_id(client, "lvfs", NULL, &error);
 	g_assert_no_error(error);
-	g_assert(remote2 != NULL);
+	g_assert_nonnull(remote2);
 	g_assert_cmpstr(fwupd_remote_get_id(remote2), ==, "lvfs");
-	g_assert(fwupd_remote_get_metadata_uri(remote2) != NULL);
+	g_assert_nonnull(fwupd_remote_get_metadata_uri(remote2));
 
 	/* check we set an error when unfound */
 	remote3 = fwupd_client_get_remote_by_id(client, "XXXX", NULL, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(remote3 == NULL);
+	g_assert_null(remote3);
 }
 
 static gboolean
@@ -695,15 +695,15 @@ fwupd_common_guid_func(void)
 	g_autoptr(GError) error = NULL;
 
 	/* invalid */
-	g_assert(!fwupd_guid_is_valid(NULL));
-	g_assert(!fwupd_guid_is_valid(""));
-	g_assert(!fwupd_guid_is_valid("1ff60ab2-3905-06a1-b476"));
-	g_assert(!fwupd_guid_is_valid("1ff60ab2-XXXX-XXXX-XXXX-0371f00c9e9b"));
-	g_assert(!fwupd_guid_is_valid(" 1ff60ab2-3905-06a1-b476-0371f00c9e9b"));
-	g_assert(!fwupd_guid_is_valid("00000000-0000-0000-0000-000000000000"));
+	g_assert_false(fwupd_guid_is_valid(NULL));
+	g_assert_false(fwupd_guid_is_valid(""));
+	g_assert_false(fwupd_guid_is_valid("1ff60ab2-3905-06a1-b476"));
+	g_assert_false(fwupd_guid_is_valid("1ff60ab2-XXXX-XXXX-XXXX-0371f00c9e9b"));
+	g_assert_false(fwupd_guid_is_valid(" 1ff60ab2-3905-06a1-b476-0371f00c9e9b"));
+	g_assert_false(fwupd_guid_is_valid("00000000-0000-0000-0000-000000000000"));
 
 	/* valid */
-	g_assert(fwupd_guid_is_valid("1ff60ab2-3905-06a1-b476-0371f00c9e9b"));
+	g_assert_true(fwupd_guid_is_valid("1ff60ab2-3905-06a1-b476-0371f00c9e9b"));
 
 	/* make valid */
 	guid1 = fwupd_guid_hash_string("python.org");
@@ -719,9 +719,11 @@ fwupd_common_guid_func(void)
 				     &error);
 	g_assert_true(ret);
 	g_assert_no_error(error);
-	g_assert(memcmp(buf,
-			"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
-			sizeof(buf)) == 0);
+	g_assert_cmpint(memcmp(buf,
+			       "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
+			       sizeof(buf)),
+			==,
+			0);
 	guid_be = fwupd_guid_to_string((const fwupd_guid_t *)&buf, FWUPD_GUID_FLAG_NONE);
 	g_assert_cmpstr(guid_be, ==, "00112233-4455-6677-8899-aabbccddeeff");
 
@@ -732,9 +734,11 @@ fwupd_common_guid_func(void)
 				     &error);
 	g_assert_true(ret);
 	g_assert_no_error(error);
-	g_assert(memcmp(buf,
-			"\x33\x22\x11\x00\x55\x44\x77\x66\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
-			sizeof(buf)) == 0);
+	g_assert_cmpint(memcmp(buf,
+			       "\x33\x22\x11\x00\x55\x44\x77\x66\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
+			       sizeof(buf)),
+			==,
+			0);
 	guid_me = fwupd_guid_to_string((const fwupd_guid_t *)&buf, FWUPD_GUID_FLAG_MIXED_ENDIAN);
 	g_assert_cmpstr(guid_me, ==, "00112233-4455-6677-8899-aabbccddeeff");
 

--- a/libfwupd/fwupd-thread-test.c
+++ b/libfwupd/fwupd-thread-test.c
@@ -30,7 +30,7 @@ fwupd_thread_test_thread_cb(gpointer user_data)
 	g_autoptr(GMainContext) context = g_main_context_new();
 	g_autoptr(GMainContextPusher) pusher = g_main_context_pusher_new(context);
 
-	g_assert(pusher != NULL);
+	g_assert_nonnull(pusher);
 	g_message("Calling fwupd_client_get_devices() in thread %p with main context %p",
 		  g_thread_self(),
 		  g_main_context_get_thread_default());

--- a/libfwupdplugin/fu-fuzzer-main.c
+++ b/libfwupdplugin/fu-fuzzer-main.c
@@ -14,7 +14,7 @@ LLVMFuzzerInitialize(int *argc, char ***argv);
 int
 main(int argc, char **argv)
 {
-	g_assert(LLVMFuzzerTestOneInput != NULL);
+	g_assert_nonnull(LLVMFuzzerTestOneInput);
 	if (LLVMFuzzerInitialize != NULL)
 		LLVMFuzzerInitialize(&argc, &argv);
 	for (int i = 1; i < argc; i++) {

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -42,8 +42,8 @@ fu_test_hang_check_cb(gpointer user_data)
 static void
 fu_test_loop_run_with_timeout(guint timeout_ms)
 {
-	g_assert(_test_loop_timeout_id == 0);
-	g_assert(_test_loop == NULL);
+	g_assert_cmpint(_test_loop_timeout_id, ==, 0);
+	g_assert_null(_test_loop);
 	_test_loop = g_main_loop_new(NULL, FALSE);
 	_test_loop_timeout_id = g_timeout_add(timeout_ms, fu_test_hang_check_cb, NULL);
 	g_main_loop_run(_test_loop);
@@ -322,7 +322,7 @@ fu_smbios_func(void)
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup(smbios, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	dump = fu_smbios_to_string(smbios);
 	if (g_getenv("FWUPD_VERBOSE") != NULL)
 		g_debug("%s", dump);
@@ -358,7 +358,7 @@ fu_smbios3_func(void)
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup_from_path(smbios, path, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	if (g_getenv("FWUPD_VERBOSE") != NULL) {
 		g_autofree gchar *dump = fu_smbios_to_string(smbios);
 		g_debug("%s", dump);
@@ -383,7 +383,7 @@ fu_smbios_dt_func(void)
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup_from_path(smbios, path, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	if (g_getenv("FWUPD_VERBOSE") != NULL) {
 		g_autofree gchar *dump = fu_smbios_to_string(smbios);
 		g_debug("%s", dump);
@@ -407,7 +407,7 @@ fu_smbios_class_func(void)
 
 	ret = fu_smbios_setup_from_kernel(smbios, path, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	if (g_getenv("FWUPD_VERBOSE") != NULL) {
 		g_autofree gchar *dump = fu_smbios_to_string(smbios);
 		g_debug("%s", dump);
@@ -540,12 +540,12 @@ fu_hwids_func(void)
 	smbios = fu_smbios_new();
 	ret = fu_smbios_setup(smbios, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	hwids = fu_hwids_new();
 	ret = fu_hwids_setup(hwids, smbios, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_assert_cmpstr(fu_hwids_get_value(hwids, FU_HWIDS_KEY_MANUFACTURER), ==, "LENOVO");
 	g_assert_cmpstr(fu_hwids_get_value(hwids, FU_HWIDS_KEY_ENCLOSURE_KIND), ==, "a");
@@ -566,7 +566,7 @@ fu_hwids_func(void)
 		g_assert_cmpstr(guid, ==, guids[i].value);
 	}
 	for (guint i = 0; guids[i].key != NULL; i++)
-		g_assert(fu_hwids_has_guid(hwids, guids[i].value));
+		g_assert_true(fu_hwids_has_guid(hwids, guids[i].value));
 }
 
 static void
@@ -662,7 +662,7 @@ fu_plugin_delay_func(void)
 	device = fu_device_new();
 	fu_device_set_id(device, "testdev");
 	fu_plugin_device_add(plugin, device);
-	g_assert(device_tmp != NULL);
+	g_assert_nonnull(device_tmp);
 	g_assert_cmpstr(fu_device_get_id(device_tmp),
 			==,
 			"b7eccd0059d6d7dc2ef76c35d6de0048cc8c029d");
@@ -670,7 +670,7 @@ fu_plugin_delay_func(void)
 
 	/* remove device */
 	fu_plugin_device_remove(plugin, device);
-	g_assert(device_tmp != NULL);
+	g_assert_nonnull(device_tmp);
 	g_assert_cmpstr(fu_device_get_id(device_tmp),
 			==,
 			"b7eccd0059d6d7dc2ef76c35d6de0048cc8c029d");
@@ -687,7 +687,7 @@ fu_plugin_quirks_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* exact */
 	tmp = fu_context_lookup_quirk_by_id(ctx, "USB\\VID_0A5C&PID_6412", "Flags");
@@ -717,7 +717,7 @@ fu_plugin_quirks_performance_func(void)
 
 	ret = fu_quirks_load(quirks, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* lookup */
 	g_timer_reset(timer);
@@ -743,7 +743,7 @@ fu_plugin_quirks_device_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* use quirk file to set device attributes */
 	fu_device_set_physical_id(device, "usb:00:05");
@@ -758,7 +758,7 @@ fu_plugin_quirks_device_func(void)
 	g_assert_cmpint(children->len, ==, 1);
 	device_tmp = g_ptr_array_index(children, 0);
 	g_assert_cmpstr(fu_device_get_name(device_tmp), ==, "HDMI");
-	g_assert(fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_UPDATABLE));
+	g_assert_true(fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_UPDATABLE));
 }
 
 static void
@@ -803,7 +803,7 @@ fu_common_firmware_builder_func(void)
 	archive_fn = g_build_filename(TESTDATADIR_DST, "builder", "firmware.tar", NULL);
 	archive_blob = fu_common_get_contents_bytes(archive_fn, &error);
 	g_assert_no_error(error);
-	g_assert(archive_blob != NULL);
+	g_assert_nonnull(archive_blob);
 
 	/* generate the firmware */
 	firmware_blob =
@@ -915,7 +915,7 @@ fu_common_spawn_func(void)
 	argv[0] = fn;
 	ret = fu_common_spawn_sync(argv, fu_test_stdout_cb, &lines, 0, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(lines, ==, 6);
 }
 
@@ -937,7 +937,7 @@ fu_common_spawn_timeout_func(void)
 	argv[0] = fn;
 	ret = fu_common_spawn_sync(argv, fu_test_stdout_cb, &lines, 50, NULL, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
-	g_assert(!ret);
+	g_assert_false(ret);
 	g_assert_cmpint(lines, ==, 1);
 }
 
@@ -972,7 +972,7 @@ _build_cab(GCabCompression compression, ...)
 	cabfolder = gcab_folder_new(compression);
 	ret = gcab_cabinet_add_folder(cabinet, cabfolder, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add each file */
 	va_start(args, compression);
@@ -998,7 +998,7 @@ _build_cab(GCabCompression compression, ...)
 		cabfile = gcab_file_new_with_bytes(fn, blob);
 		ret = gcab_folder_add_file(cabfolder, cabfile, FALSE, NULL, &error);
 		g_assert_no_error(error);
-		g_assert(ret);
+		g_assert_true(ret);
 	} while (TRUE);
 	va_end(args);
 
@@ -1006,10 +1006,10 @@ _build_cab(GCabCompression compression, ...)
 	op = g_memory_output_stream_new_resizable();
 	ret = gcab_cabinet_write_simple(cabinet, op, NULL, NULL, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = g_output_stream_close(op, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	return g_memory_output_stream_steal_as_bytes(G_MEMORY_OUTPUT_STREAM(op));
 }
 
@@ -1813,17 +1813,17 @@ fu_device_parent_func(void)
 	fu_device_add_child(parent, child);
 
 	/* check parents */
-	g_assert(fu_device_get_parent(child) == parent);
-	g_assert(fu_device_get_parent(parent) == grandparent);
-	g_assert(fu_device_get_parent(grandparent) == NULL);
+	g_assert_true(fu_device_get_parent(child) == parent);
+	g_assert_true(fu_device_get_parent(parent) == grandparent);
+	g_assert_true(fu_device_get_parent(grandparent) == NULL);
 
 	/* check root */
 	child_root = fu_device_get_root(child);
-	g_assert(child_root == grandparent);
+	g_assert_true(child_root == grandparent);
 	parent_root = fu_device_get_root(parent);
-	g_assert(parent_root == grandparent);
+	g_assert_true(parent_root == grandparent);
 	grandparent_root = fu_device_get_root(child);
-	g_assert(grandparent_root == grandparent);
+	g_assert_true(grandparent_root == grandparent);
 }
 
 static void
@@ -1894,7 +1894,7 @@ fu_backend_func(void)
 
 	dev = fu_backend_lookup_by_id(backend, "dev1");
 	g_assert_nonnull(dev);
-	g_assert(dev == dev1);
+	g_assert_true(dev == dev1);
 
 	/* should have been removed */
 	dev = fu_backend_lookup_by_id(backend, "dev2");
@@ -1906,7 +1906,7 @@ fu_backend_func(void)
 	g_assert_cmpint(devices->len, ==, 1);
 	dev = g_ptr_array_index(devices, 0);
 	g_assert_nonnull(dev);
-	g_assert(dev == dev1);
+	g_assert_true(dev == dev1);
 }
 
 static void
@@ -2289,10 +2289,10 @@ fu_firmware_ihex_func(void)
 	filename_hex = g_build_filename(TESTDATADIR_SRC, "firmware.hex", NULL);
 	data_file = fu_common_get_contents_bytes(filename_hex, &error);
 	g_assert_no_error(error);
-	g_assert(data_file != NULL);
+	g_assert_nonnull(data_file);
 	ret = fu_firmware_parse(firmware, data_file, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	data_fw = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_fw);
@@ -2302,7 +2302,7 @@ fu_firmware_ihex_func(void)
 	filename_ref = g_build_filename(TESTDATADIR_SRC, "firmware.bin", NULL);
 	data_ref = fu_common_get_contents_bytes(filename_ref, &error);
 	g_assert_no_error(error);
-	g_assert(data_ref != NULL);
+	g_assert_nonnull(data_ref);
 	ret = fu_common_bytes_compare(data_fw, data_ref, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -2311,7 +2311,7 @@ fu_firmware_ihex_func(void)
 	 * non-continous regions being expanded */
 	data_hex = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
-	g_assert(data_hex != NULL);
+	g_assert_nonnull(data_hex);
 	data = g_bytes_get_data(data_hex, &len);
 	str = g_strndup((const gchar *)data, len);
 	g_assert_cmpstr(str,
@@ -2345,10 +2345,10 @@ fu_firmware_ihex_signed_func(void)
 	filename_shex = g_build_filename(TESTDATADIR_SRC, "firmware.shex", NULL);
 	data_file = fu_common_get_contents_bytes(filename_shex, &error);
 	g_assert_no_error(error);
-	g_assert(data_file != NULL);
+	g_assert_nonnull(data_file);
 	ret = fu_firmware_parse(firmware, data_file, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	data_fw = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_fw);
@@ -2360,7 +2360,7 @@ fu_firmware_ihex_signed_func(void)
 	g_assert_nonnull(data_sig);
 	data = g_bytes_get_data(data_sig, &len);
 	g_assert_cmpint(len, ==, 8);
-	g_assert(data != NULL);
+	g_assert_nonnull(data);
 	g_assert_cmpint(memcmp(data, "deadbeef", 8), ==, 0);
 }
 
@@ -2384,7 +2384,7 @@ fu_firmware_ihex_offset_func(void)
 	fu_firmware_set_bytes(firmware, data_dummy);
 	data_bin = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
-	g_assert(data_bin != NULL);
+	g_assert_nonnull(data_bin);
 	data = g_bytes_get_data(data_bin, &len);
 	str = g_strndup((const gchar *)data, len);
 	g_assert_cmpstr(str,
@@ -2396,11 +2396,11 @@ fu_firmware_ihex_offset_func(void)
 	/* check we can load it too */
 	ret = fu_firmware_parse(firmware_verify, data_bin, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_firmware_get_addr(firmware_verify), ==, 0x80000000);
 	data_verify = fu_firmware_get_bytes(firmware_verify, &error);
 	g_assert_no_error(error);
-	g_assert(data_verify != NULL);
+	g_assert_nonnull(data_verify);
 	g_assert_cmpint(g_bytes_get_size(data_verify), ==, 0x4);
 }
 
@@ -2419,10 +2419,10 @@ fu_firmware_srec_func(void)
 	filename_srec = g_build_filename(TESTDATADIR_SRC, "firmware.srec", NULL);
 	data_srec = fu_common_get_contents_bytes(filename_srec, &error);
 	g_assert_no_error(error);
-	g_assert(data_srec != NULL);
+	g_assert_nonnull(data_srec);
 	ret = fu_firmware_parse(firmware, data_srec, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	data_bin = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_bin);
@@ -2432,7 +2432,7 @@ fu_firmware_srec_func(void)
 	filename_ref = g_build_filename(TESTDATADIR_SRC, "firmware.bin", NULL);
 	data_ref = fu_common_get_contents_bytes(filename_ref, &error);
 	g_assert_no_error(error);
-	g_assert(data_ref != NULL);
+	g_assert_nonnull(data_ref);
 	ret = fu_common_bytes_compare(data_bin, data_ref, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -2453,10 +2453,10 @@ fu_firmware_srec_tokenization_func(void)
 			   "S70500000000FA\r\n";
 	data_srec = g_bytes_new_static(buf, strlen(buf));
 	g_assert_no_error(error);
-	g_assert(data_srec != NULL);
+	g_assert_nonnull(data_srec);
 	ret = fu_firmware_tokenize(firmware, data_srec, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	records = fu_srec_firmware_get_records(FU_SREC_FIRMWARE(firmware));
 	g_assert_nonnull(records);
@@ -2508,7 +2508,7 @@ fu_firmware_build_func(void)
 	/* parse XML */
 	ret = xb_builder_source_load_bytes(source, blob, XB_BUILDER_SOURCE_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	xb_builder_import_source(builder, source);
 	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
 	g_assert_no_error(error);
@@ -2520,7 +2520,7 @@ fu_firmware_build_func(void)
 	/* build object */
 	ret = fu_firmware_build(firmware, n, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpstr(fu_firmware_get_version(firmware), ==, "1.2.3");
 
 	/* verify image */
@@ -2574,11 +2574,11 @@ fu_firmware_dfuse_func(void)
 
 	/* load a DfuSe firmware */
 	filename = g_build_filename(TESTDATADIR_SRC, "firmware.dfuse", NULL);
-	g_assert(filename != NULL);
+	g_assert_nonnull(filename);
 	roundtrip_orig = fu_common_get_contents_bytes(filename, &error);
 	ret = fu_firmware_parse(firmware, roundtrip_orig, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_dfu_firmware_get_vid(FU_DFU_FIRMWARE(firmware)), ==, 0x1234);
 	g_assert_cmpint(fu_dfu_firmware_get_pid(FU_DFU_FIRMWARE(firmware)), ==, 0x5678);
 	g_assert_cmpint(fu_dfu_firmware_get_release(FU_DFU_FIRMWARE(firmware)), ==, 0x8642);
@@ -2587,7 +2587,7 @@ fu_firmware_dfuse_func(void)
 	/* can we roundtrip without losing data */
 	roundtrip = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
-	g_assert(roundtrip != NULL);
+	g_assert_nonnull(roundtrip);
 	ret = fu_common_bytes_compare(roundtrip, roundtrip_orig, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -2614,11 +2614,11 @@ fu_firmware_fmap_func(void)
 
 	/* load firmware */
 	filename = g_build_filename(TESTDATADIR_SRC, "firmware.fmap", NULL);
-	g_assert(filename != NULL);
+	g_assert_nonnull(filename);
 	roundtrip_orig = fu_common_get_contents_bytes(filename, &error);
 	ret = fu_firmware_parse(firmware, roundtrip_orig, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check image count */
 	images = fu_firmware_get_images(firmware);
@@ -2638,7 +2638,7 @@ fu_firmware_fmap_func(void)
 	/* can we roundtrip without losing data */
 	roundtrip = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
-	g_assert(roundtrip != NULL);
+	g_assert_nonnull(roundtrip);
 	ret = fu_common_bytes_compare(roundtrip, roundtrip_orig, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -2657,7 +2657,7 @@ fu_firmware_new_from_gtypes_func(void)
 	fn = g_build_filename(TESTDATADIR_SRC, "firmware.dfu", NULL);
 	blob = fu_common_get_contents_bytes(fn, &error);
 	g_assert_no_error(error);
-	g_assert(blob != NULL);
+	g_assert_nonnull(blob);
 
 	/* dfu -> FuDfuFirmware */
 	firmware1 = fu_firmware_new_from_gtypes(blob,
@@ -2707,10 +2707,10 @@ fu_firmware_dfu_func(void)
 	filename_dfu = g_build_filename(TESTDATADIR_SRC, "firmware.dfu", NULL);
 	data_dfu = fu_common_get_contents_bytes(filename_dfu, &error);
 	g_assert_no_error(error);
-	g_assert(data_dfu != NULL);
+	g_assert_nonnull(data_dfu);
 	ret = fu_firmware_parse(firmware, data_dfu, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_dfu_firmware_get_vid(FU_DFU_FIRMWARE(firmware)), ==, 0x1234);
 	g_assert_cmpint(fu_dfu_firmware_get_pid(FU_DFU_FIRMWARE(firmware)), ==, 0x4321);
 	g_assert_cmpint(fu_dfu_firmware_get_release(FU_DFU_FIRMWARE(firmware)), ==, 0xdead);
@@ -2723,7 +2723,7 @@ fu_firmware_dfu_func(void)
 	filename_ref = g_build_filename(TESTDATADIR_SRC, "firmware.bin", NULL);
 	data_ref = fu_common_get_contents_bytes(filename_ref, &error);
 	g_assert_no_error(error);
-	g_assert(data_ref != NULL);
+	g_assert_nonnull(data_ref);
 	ret = fu_common_bytes_compare(data_bin, data_ref, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -26,7 +26,7 @@ fu_ata_id_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "StarDrive-SBFM61.2.bin", NULL);
 	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
@@ -35,7 +35,7 @@ fu_ata_id_func(void)
 	}
 	ret = g_file_get_contents(path, &data, &sz, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	dev = fu_ata_device_new_from_blob(ctx, (guint8 *)data, sz, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(dev);
@@ -61,7 +61,7 @@ fu_ata_oui_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "Samsung SSD 860 EVO 500GB.bin", NULL);
 	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
@@ -70,7 +70,7 @@ fu_ata_oui_func(void)
 	}
 	ret = g_file_get_contents(path, &data, &sz, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	dev = fu_ata_device_new_from_blob(ctx, (guint8 *)data, sz, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(dev);

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -104,7 +104,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 				       self->plugin_uefi_capsule);
 	ret = fu_plugin_runner_coldplug(self->plugin_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* inject fake data (no TPM) */
 	tpm_out.ret = -2;
@@ -159,7 +159,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	fu_plugin_dell_inject_fake_data(self->plugin_dell, (guint32 *)&tpm_out, 0, 0, NULL, TRUE);
 	ret = fu_plugin_dell_detect_tpm(self->plugin_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* make sure not allowed to flash 1.2 */
 	device_v12 = _find_device_by_name(devices, "TPM 1.2");
@@ -188,7 +188,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	fu_plugin_dell_inject_fake_data(self->plugin_dell, (guint32 *)&tpm_out, 0, 0, NULL, TRUE);
 	ret = fu_plugin_dell_detect_tpm(self->plugin_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* make sure allowed to flash 1.2 but not 2.0 */
 	device_v12 = _find_device_by_name(devices, "TPM 1.2");
@@ -201,7 +201,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	/* try to unlock 2.0 */
 	ret = fu_plugin_runner_unlock(self->plugin_uefi_capsule, device_v20, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* make sure no longer allowed to flash 1.2 but can flash 2.0 */
 	g_assert_false(fu_device_has_flag(device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
@@ -221,7 +221,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	fu_plugin_dell_inject_fake_data(self->plugin_dell, (guint32 *)&tpm_out, 0, 0, NULL, TRUE);
 	ret = fu_plugin_dell_detect_tpm(self->plugin_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* make sure allowed to flash 2.0 but not 1.2 */
 	device_v20 = _find_device_by_name(devices, "TPM 2.0");
@@ -250,7 +250,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 					      FWUPD_INSTALL_FLAG_FORCE,
 					      &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* all */
 	g_signal_handler_disconnect(self->plugin_uefi_capsule, added_id);
@@ -339,7 +339,7 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 					buf.buf,
 					FALSE);
 	ret = fu_plugin_backend_device_added(self->plugin_dell, FU_DEVICE(fake_usb_device), NULL);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(devices->len, ==, 4);
 	g_ptr_array_set_size(devices, 0);
 	g_free(buf.record);
@@ -375,7 +375,7 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 					buf.buf,
 					FALSE);
 	ret = fu_plugin_backend_device_added(self->plugin_dell, FU_DEVICE(fake_usb_device), NULL);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(devices->len, ==, 3);
 	g_ptr_array_set_size(devices, 0);
 	g_free(buf.record);
@@ -409,7 +409,7 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 					buf.buf,
 					FALSE);
 	ret = fu_plugin_backend_device_added(self->plugin_dell, FU_DEVICE(fake_usb_device), &error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_no_error(error);
 	g_assert_cmpint(devices->len, ==, 3);
 	g_ptr_array_set_size(devices, 0);
@@ -444,7 +444,7 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 					buf.buf,
 					FALSE);
 	ret = fu_plugin_backend_device_added(self->plugin_dell, FU_DEVICE(fake_usb_device), &error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_no_error(error);
 	g_assert_cmpint(devices->len, ==, 2);
 	g_ptr_array_set_size(devices, 0);
@@ -504,20 +504,20 @@ fu_test_self_init(FuTest *self)
 					 NULL);
 	ret = fu_plugin_open(self->plugin_uefi_capsule, pluginfn_uefi, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	self->plugin_dell = fu_plugin_new(ctx);
 	pluginfn_dell =
 	    g_build_filename(PLUGINBUILDDIR, "libfu_plugin_dell." G_MODULE_SUFFIX, NULL);
 	ret = fu_plugin_open(self->plugin_dell, pluginfn_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(self->plugin_dell, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void

--- a/plugins/dfu/fu-dfu-self-test.c
+++ b/plugins/dfu/fu-dfu-self-test.c
@@ -73,7 +73,7 @@ fu_dfu_target_dfuse_func(void)
 	fu_dfu_target_set_device(target, device);
 	ret = fu_dfu_target_parse_sectors(target, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	tmp = fu_dfu_target_sectors_to_string(target);
 	g_assert_cmpstr(tmp, ==, "");
 	g_free(tmp);
@@ -81,7 +81,7 @@ fu_dfu_target_dfuse_func(void)
 	/* no addresses */
 	ret = fu_dfu_target_parse_sectors(target, "@Flash3", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	tmp = fu_dfu_target_sectors_to_string(target);
 	g_assert_cmpstr(tmp, ==, "");
 	g_free(tmp);
@@ -89,20 +89,20 @@ fu_dfu_target_dfuse_func(void)
 	/* one sector, no space */
 	ret = fu_dfu_target_parse_sectors(target, "@Internal Flash /0x08000000/2*001Ka", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	tmp = fu_dfu_target_sectors_to_string(target);
 	ret = fu_test_compare_lines(tmp,
 				    "Zone:0, Sec#:0, Addr:0x08000000, Size:0x0400, Caps:0x1 [R]\n"
 				    "Zone:0, Sec#:0, Addr:0x08000400, Size:0x0400, Caps:0x1 [R]",
 				    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_free(tmp);
 
 	/* multiple sectors */
 	ret = fu_dfu_target_parse_sectors(target, "@Flash1   /0x08000000/2*001Ka,4*001Kg", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	tmp = fu_dfu_target_sectors_to_string(target);
 	ret = fu_test_compare_lines(tmp,
 				    "Zone:0, Sec#:0, Addr:0x08000000, Size:0x0400, Caps:0x1 [R]\n"
@@ -113,7 +113,7 @@ fu_dfu_target_dfuse_func(void)
 				    "Zone:0, Sec#:1, Addr:0x08001400, Size:0x0400, Caps:0x7 [REW]",
 				    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_free(tmp);
 
 	/* non-contiguous */
@@ -121,7 +121,7 @@ fu_dfu_target_dfuse_func(void)
 					  "@Flash2 /0xF000/4*100Ba/0xE000/3*8Kg/0x80000/2*24Kg",
 					  &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	tmp = fu_dfu_target_sectors_to_string(target);
 	ret = fu_test_compare_lines(tmp,
 				    "Zone:0, Sec#:0, Addr:0x0000f000, Size:0x0064, Caps:0x1 [R]\n"
@@ -135,16 +135,16 @@ fu_dfu_target_dfuse_func(void)
 				    "Zone:2, Sec#:0, Addr:0x00086000, Size:0x6000, Caps:0x7 [REW]",
 				    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_free(tmp);
 
 	/* invalid */
 	ret = fu_dfu_target_parse_sectors(target, "Flash", NULL);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_dfu_target_parse_sectors(target, "@Internal Flash /0x08000000", NULL);
-	g_assert(!ret);
+	g_assert_false(ret);
 	ret = fu_dfu_target_parse_sectors(target, "@Internal Flash /0x08000000/12*001a", NULL);
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 int

--- a/plugins/dfu/fu-dfu-target-stm.c
+++ b/plugins/dfu/fu-dfu-target-stm.c
@@ -344,7 +344,14 @@ fu_dfu_target_stm_download_element(FuDfuTarget *target,
 
 		/* for DfuSe devices we need to set the address manually */
 		sector = fu_dfu_target_get_sector_for_addr(target, offset_dev);
-		g_assert(sector != NULL);
+		if (sector == NULL) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "no valid sector for %x",
+				    offset_dev);
+			return FALSE;
+		}
 
 		/* manually set the sector address */
 		if (fu_dfu_sector_get_zone(sector) != zone_last) {

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -779,7 +779,7 @@ fu_dfu_target_download_chunk(FuDfuTarget *self,
 	if (!fu_dfu_target_check_status(self, error))
 		return FALSE;
 
-	g_assert(actual_length == g_bytes_get_size(bytes));
+	g_assert_cmpint(actual_length, ==, g_bytes_get_size(bytes));
 	return TRUE;
 }
 

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -40,7 +40,7 @@ fu_test_self_init(FuTest *self)
 				     FU_QUIRKS_LOAD_FLAG_NO_CACHE | FU_QUIRKS_LOAD_FLAG_NO_VERIFY,
 				     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	self->plugin_uefi_capsule = fu_plugin_new(ctx);
 	pluginfn_uefi = g_build_filename(PLUGINBUILDDIR,
@@ -50,20 +50,20 @@ fu_test_self_init(FuTest *self)
 					 NULL);
 	ret = fu_plugin_open(self->plugin_uefi_capsule, pluginfn_uefi, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	self->plugin_lenovo_thinklmi = fu_plugin_new(ctx);
 	pluginfn_lenovo =
 	    g_build_filename(PLUGINBUILDDIR, "libfu_plugin_lenovo_thinklmi." G_MODULE_SUFFIX, NULL);
 	ret = fu_plugin_open(self->plugin_lenovo_thinklmi, pluginfn_lenovo, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(self->plugin_lenovo_thinklmi, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static FuDevice *
@@ -81,7 +81,7 @@ fu_test_probe_fake_esrt(FuTest *self)
 
 	ret = fu_plugin_runner_coldplug(self->plugin_uefi_capsule, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_nonnull(dev);
 	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE));
 	g_signal_handler_disconnect(self->plugin_uefi_capsule, added_id);

--- a/plugins/nvme/fu-self-test.c
+++ b/plugins/nvme/fu-self-test.c
@@ -26,7 +26,7 @@ fu_nvme_cns_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "TOSHIBA_THNSN5512GPU7.bin", NULL);
 
@@ -36,7 +36,7 @@ fu_nvme_cns_func(void)
 	}
 	ret = g_file_get_contents(path, &data, &sz, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	dev = fu_nvme_device_new_from_blob(ctx, (guint8 *)data, sz, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(dev);

--- a/plugins/optionrom/fu-self-test.c
+++ b/plugins/optionrom/fu-self-test.c
@@ -59,7 +59,7 @@ fu_rom_func(void)
 		g_autoptr(FuRom) rom = NULL;
 		g_autoptr(GFile) file = NULL;
 		rom = fu_rom_new();
-		g_assert(rom != NULL);
+		g_assert_nonnull(rom);
 
 		/* load file */
 		filename = g_test_build_filename(G_TEST_DIST, "tests", data[i].fn, NULL);
@@ -69,7 +69,7 @@ fu_rom_func(void)
 		file = g_file_new_for_path(filename);
 		ret = fu_rom_load_file(rom, file, FU_ROM_LOAD_FLAG_BLANK_PPID, NULL, &error);
 		g_assert_no_error(error);
-		g_assert(ret);
+		g_assert_true(ret);
 		g_assert_cmpstr(fu_rom_get_version(rom), ==, data[i].ver);
 		g_assert_cmpint(fu_rom_get_kind(rom), ==, data[i].kind);
 		g_assert_cmpint(fu_rom_get_vendor(rom), ==, data[i].vendor);

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -33,23 +33,23 @@ fu_test_self_init(FuTest *self)
 				     FU_QUIRKS_LOAD_FLAG_NO_CACHE | FU_QUIRKS_LOAD_FLAG_NO_VERIFY,
 				     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	self->plugin = fu_plugin_new(ctx);
 	pluginfn = g_build_filename(PLUGINBUILDDIR, "libfu_plugin_redfish." G_MODULE_SUFFIX, NULL);
 	ret = fu_plugin_open(self->plugin, pluginfn, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(self->plugin, &error);
 	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE)) {
 		g_test_skip("no redfish.py running");
 		return;
 	}
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_coldplug(self->plugin, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -34,7 +34,7 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	while ((basename = g_dir_read_name(dir)) != NULL) {
 		g_autofree gchar *fn = g_build_filename(path, basename, NULL);
@@ -56,7 +56,7 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 		g_debug("creating drm_dp_aux_dev object backed by %s", fn);
 		ret = fu_plugin_runner_backend_device_added(plugin, FU_DEVICE(dev), &error);
 		g_assert_no_error(error);
-		g_assert(ret);
+		g_assert_true(ret);
 	}
 }
 
@@ -76,7 +76,7 @@ fu_plugin_synaptics_mst_none_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_signal_connect(plugin, "device-added", G_CALLBACK(_plugin_device_added_cb), &devices);
 	pluginfn = g_test_build_filename(G_TEST_BUILT,
@@ -84,14 +84,14 @@ fu_plugin_synaptics_mst_none_func(void)
 					 NULL);
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(plugin, &error);
 	if (!ret && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 		g_test_skip("Skipping tests due to unsupported configuration");
 		return;
 	}
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "no_devices", NULL);
 	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {
@@ -118,7 +118,7 @@ fu_plugin_synaptics_mst_tb16_func(void)
 
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_signal_connect(plugin, "device-added", G_CALLBACK(_plugin_device_added_cb), &devices);
 	pluginfn = g_test_build_filename(G_TEST_BUILT,
@@ -126,14 +126,14 @@ fu_plugin_synaptics_mst_tb16_func(void)
 					 NULL);
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_plugin_runner_startup(plugin, &error);
 	if (!ret && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 		g_test_skip("Skipping tests due to unsupported configuration");
 		return;
 	}
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "tb16_dock", NULL);
 	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -48,8 +48,8 @@ fu_test_hang_check_cb(gpointer user_data)
 static void
 fu_test_loop_run_with_timeout(guint timeout_ms)
 {
-	g_assert(_test_loop_timeout_id == 0);
-	g_assert(_test_loop == NULL);
+	g_assert_cmpint(_test_loop_timeout_id, ==, 0);
+	g_assert_null(_test_loop);
 	_test_loop = g_main_loop_new(NULL, FALSE);
 	_test_loop_timeout_id = g_timeout_add(timeout_ms, fu_test_hang_check_cb, NULL);
 	g_main_loop_run(_test_loop);
@@ -135,14 +135,14 @@ fu_engine_generate_md_func(gconstpointer user_data)
 					   data,
 					   &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* load engine and check the device was found */
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
 			     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.3");
@@ -171,7 +171,7 @@ fu_plugin_hash_func(gconstpointer user_data)
 
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* make sure not tainted */
 	ret = fu_engine_get_tainted(engine);
@@ -221,7 +221,7 @@ fu_engine_requirements_missing_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -255,7 +255,7 @@ fu_engine_requirements_soft_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_FORCE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -286,7 +286,7 @@ fu_engine_requirements_client_fail_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -317,7 +317,7 @@ fu_engine_requirements_client_invalid_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -351,7 +351,7 @@ fu_engine_requirements_client_pass_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -398,8 +398,9 @@ fu_engine_requirements_version_require_func(gconstpointer user_data)
 	task = fu_install_task_new(device, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
-	g_assert(g_str_has_prefix(error->message, "device requires firmware with a version check"));
-	g_assert(!ret);
+	g_assert_true(
+	    g_str_has_prefix(error->message, "device requires firmware with a version check"));
+	g_assert_false(ret);
 }
 
 static void
@@ -433,7 +434,7 @@ fu_engine_requirements_unsupported_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -488,7 +489,7 @@ fu_engine_requirements_child_func(gconstpointer user_data)
 	task = fu_install_task_new(device, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -545,7 +546,7 @@ fu_engine_requirements_child_fail_func(gconstpointer user_data)
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_nonnull(
 	    g_strstr_len(error->message, -1, "Not compatible with child device version"));
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -580,7 +581,7 @@ fu_engine_requirements_func(gconstpointer user_data)
 	task = fu_install_task_new(NULL, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -637,7 +638,7 @@ fu_engine_requirements_device_func(gconstpointer user_data)
 	task = fu_install_task_new(device, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -683,7 +684,7 @@ fu_engine_requirements_device_plain_func(gconstpointer user_data)
 	task = fu_install_task_new(device, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -733,7 +734,7 @@ fu_engine_requirements_version_format_func(gconstpointer user_data)
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_nonnull(
 	    g_strstr_len(error->message, -1, "Firmware version formats were different"));
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -781,7 +782,7 @@ fu_engine_requirements_only_upgrade_func(gconstpointer user_data)
 					   &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_nonnull(g_strstr_len(error->message, -1, "Device only supports version upgrades"));
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -883,7 +884,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	task2 = fu_install_task_new(device1, component);
 	ret = fu_engine_check_requirements(engine, request, task2, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -948,7 +949,7 @@ fu_engine_requirements_other_device_func(gconstpointer user_data)
 	task = fu_install_task_new(device1, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -1033,7 +1034,7 @@ fu_engine_requirements_protocol_check_func(gconstpointer user_data)
 	ret = fu_engine_check_requirements(engine, request, task2, FWUPD_INSTALL_FLAG_NONE, &error);
 
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -1100,7 +1101,7 @@ fu_engine_requirements_parent_device_func(gconstpointer user_data)
 	task = fu_install_task_new(device2, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -1147,8 +1148,8 @@ fu_engine_device_parent_guid_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device3);
 
 	/* verify both children were adopted */
-	g_assert(fu_device_get_parent(device3) == device2);
-	g_assert(fu_device_get_parent(device1) == device2);
+	g_assert_true(fu_device_get_parent(device3) == device2);
+	g_assert_true(fu_device_get_parent(device1) == device2);
 	g_assert_cmpstr(fu_device_get_vendor(device3), ==, "oem");
 
 	/* verify order */
@@ -1221,9 +1222,9 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device4);
 
 	/* verify both children were adopted */
-	g_assert(fu_device_get_parent(device3) == device2);
-	g_assert(fu_device_get_parent(device4) == device2);
-	g_assert(fu_device_get_parent(device1) == device2);
+	g_assert_true(fu_device_get_parent(device3) == device2);
+	g_assert_true(fu_device_get_parent(device4) == device2);
+	g_assert_true(fu_device_get_parent(device1) == device2);
 	g_assert_cmpstr(fu_device_get_vendor(device3), ==, "oem");
 }
 
@@ -1267,33 +1268,33 @@ fu_engine_partial_hash_func(gconstpointer user_data)
 	/* match nothing */
 	ret = fu_engine_unlock(engine, "deadbeef", &error_none);
 	g_assert_error(error_none, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(!ret);
+	g_assert_false(ret);
 
 	/* match both */
 	ret = fu_engine_unlock(engine, "9", &error_both);
 	g_assert_error(error_both, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
-	g_assert(!ret);
+	g_assert_false(ret);
 
 	/* match one exactly */
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_LOCKED);
 	ret = fu_engine_unlock(engine, "934b4162a6daa0b033d649c8d464529cec41d3de", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* match one partially */
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_LOCKED);
 	ret = fu_engine_unlock(engine, "934b", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* match equivalent ID */
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_LOCKED);
 	ret = fu_engine_unlock(engine, "b92f", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -1313,7 +1314,7 @@ fu_engine_device_unlock_func(gconstpointer user_data)
 	/* load engine to get FuConfig set up */
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add the hardcoded 'fwupd' metadata */
 	filename = g_build_filename(TESTDATADIR_SRC, "metadata.xml", NULL);
@@ -1368,13 +1369,13 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	/* load engine to get FuConfig set up */
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* get generated file as a blob */
 	filename = g_build_filename(TESTDATADIR_DST, "missing-hwid", "hwid-1.2.3.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -1401,11 +1402,11 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	task = fu_install_task_new(device, component);
 	ret = fu_engine_check_requirements(engine, request, task, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-	g_assert(error != NULL);
+	g_assert_nonnull(error);
 	g_assert_cmpstr(error->message,
 			==,
 			"no HWIDs matched 9342d47a-1bab-5709-9869-c840b2eac501");
-	g_assert(!ret);
+	g_assert_false(ret);
 }
 
 static void
@@ -1438,7 +1439,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 				  -1,
 				  &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* write the main file */
 	ret = g_file_set_contents(
@@ -1475,7 +1476,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	    -1,
 	    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* write the extra file */
 	ret = g_file_set_contents(
@@ -1512,27 +1513,27 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	    -1,
 	    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
 			     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 	g_test_assert_expected_messages();
 
 	/* return all the remotes, even the broken one */
 	remotes = fu_engine_get_remotes(engine, &error);
 	g_assert_no_error(error);
-	g_assert(remotes != NULL);
+	g_assert_nonnull(remotes);
 	g_assert_cmpint(remotes->len, ==, 4);
 
 	/* ensure there are no devices already */
 	devices_pre = fu_engine_get_devices(engine, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO);
-	g_assert(devices_pre == NULL);
+	g_assert_null(devices_pre);
 	g_clear_error(&error);
 
 	/* add a device so we can get upgrades and downgrades */
@@ -1552,17 +1553,17 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
 #ifdef HAVE_POLKIT
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SUPPORTED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SUPPORTED));
 #endif
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	/* get the releases for one device */
 	releases = fu_engine_get_releases(engine, request, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(releases != NULL);
+	g_assert_nonnull(releases);
 	g_assert_cmpint(releases->len, ==, 4);
 
 	/* no upgrades, as no firmware is approved */
@@ -1578,7 +1579,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	/* upgrades */
 	releases_up = fu_engine_get_upgrades(engine, request, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(releases_up != NULL);
+	g_assert_nonnull(releases_up);
 	g_assert_cmpint(releases_up->len, ==, 2);
 
 	/* ensure the list is sorted */
@@ -1590,7 +1591,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	/* downgrades */
 	releases_dg = fu_engine_get_downgrades(engine, request, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(releases_dg != NULL);
+	g_assert_nonnull(releases_dg);
 	g_assert_cmpint(releases_dg->len, ==, 1);
 	rel = FWUPD_RELEASE(g_ptr_array_index(releases_dg, 0));
 	g_assert_cmpstr(fwupd_release_get_version(rel), ==, "1.2.2");
@@ -1639,14 +1640,14 @@ fu_engine_install_duration_func(gconstpointer user_data)
 	    -1,
 	    &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
 			     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add a device so we can get the install duration */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -1665,15 +1666,15 @@ fu_engine_install_duration_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
 #ifdef HAVE_POLKIT
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SUPPORTED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SUPPORTED));
 #endif
 	/* check the release install duration */
 	releases = fu_engine_get_releases(engine, request, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(releases != NULL);
+	g_assert_nonnull(releases);
 	g_assert_cmpint(releases->len, ==, 1);
 	rel = FWUPD_RELEASE(g_ptr_array_index(releases, 0));
 	g_assert_cmpint(fwupd_release_get_install_duration(rel), ==, 120);
@@ -1715,7 +1716,7 @@ fu_engine_history_func(gconstpointer user_data)
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
@@ -1733,14 +1734,14 @@ fu_engine_history_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	filename = g_build_filename(TESTDATADIR_DST, "missing-hwid", "noreqs-1.2.3.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -1767,7 +1768,7 @@ fu_engine_history_func(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check the write was done more than once */
 	g_assert_cmpint(fu_device_get_metadata_integer(device, "nr-update"), ==, 2);
@@ -1776,7 +1777,7 @@ fu_engine_history_func(gconstpointer user_data)
 	history = fu_history_new();
 	device2 = fu_history_get_device_by_id(history, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(device2 != NULL);
+	g_assert_nonnull(device2);
 	g_assert_cmpint(fu_device_get_update_state(device2), ==, FWUPD_UPDATE_STATE_SUCCESS);
 	g_assert_cmpstr(fu_device_get_update_error(device2), ==, NULL);
 	fu_device_set_modified(device2, 1514338000);
@@ -1802,11 +1803,11 @@ fu_engine_history_func(gconstpointer user_data)
 			    checksum);
 	ret = fu_test_compare_lines(device_str, device_str_expected, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* GetResults() */
 	device3 = fu_engine_get_results(engine, FWUPD_DEVICE_ID_ANY, &error);
-	g_assert(device3 != NULL);
+	g_assert_nonnull(device3);
 	g_assert_cmpstr(fu_device_get_id(device3), ==, "894e8c17a29428b09d10cd90d1db74ea76fbcfe8");
 	g_assert_cmpint(fu_device_get_update_state(device3), ==, FWUPD_UPDATE_STATE_SUCCESS);
 	g_assert_cmpstr(fu_device_get_update_error(device3), ==, NULL);
@@ -1814,11 +1815,11 @@ fu_engine_history_func(gconstpointer user_data)
 	/* ClearResults() */
 	ret = fu_engine_clear_results(engine, FWUPD_DEVICE_ID_ANY, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* GetResults() */
 	device4 = fu_engine_get_results(engine, FWUPD_DEVICE_ID_ANY, &error);
-	g_assert(device4 == NULL);
+	g_assert_null(device4);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO);
 }
 
@@ -1850,7 +1851,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
@@ -1872,7 +1873,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	    g_build_filename(TESTDATADIR_DST, "multiple-rels", "multiple-rels-1.2.4.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -1898,7 +1899,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check we did 1.2.2 -> 1.2.3 -> 1.2.4 */
 	g_assert_cmpint(fu_device_get_metadata_integer(device, "nr-update"), ==, 2);
@@ -1938,7 +1939,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
@@ -1955,14 +1956,14 @@ fu_engine_history_inherit(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	filename = g_build_filename(TESTDATADIR_DST, "missing-hwid", "noreqs-1.2.3.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -1986,7 +1987,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check the device requires an activation */
 	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
@@ -1995,7 +1996,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	/* activate the device */
 	ret = fu_engine_activate(engine, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check the device no longer requires an activation */
 	g_assert_false(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION));
@@ -2013,7 +2014,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_object_unref(engine);
 	g_object_unref(device);
 	engine = fu_engine_new(FU_APP_FLAGS_NONE);
@@ -2075,7 +2076,7 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
@@ -2092,14 +2093,14 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	filename = g_build_filename(TESTDATADIR_DST, "missing-hwid", "noreqs-1.2.3.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -2123,7 +2124,7 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check the device requires reboot */
 	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
@@ -2164,7 +2165,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	g_setenv("CONFIGURATION_DIRECTORY", TESTDATADIR_SRC, TRUE);
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
@@ -2181,15 +2182,15 @@ fu_engine_history_error_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
-	g_assert(devices != NULL);
+	g_assert_nonnull(devices);
 	g_assert_cmpint(devices->len, ==, 1);
-	g_assert(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
+	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REGISTERED));
 
 	/* install the wrong thing */
 	filename = g_build_filename(TESTDATADIR_DST, "missing-hwid", "noreqs-1.2.3.cab", NULL);
 	blob_cab = fu_common_get_contents_bytes(filename, &error);
 	g_assert_no_error(error);
-	g_assert(blob_cab != NULL);
+	g_assert_nonnull(blob_cab);
 	silo = fu_engine_get_silo_from_blob(engine, blob_cab, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(silo);
@@ -2208,15 +2209,14 @@ fu_engine_history_error_func(gconstpointer user_data)
 				FWUPD_FEATURE_FLAG_NONE,
 				&error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
-	g_assert(error != NULL);
 	g_assert_cmpstr(error->message, ==, "device was not in supported mode");
-	g_assert(!ret);
+	g_assert_false(ret);
 
 	/* check the history database */
 	history = fu_history_new();
 	device2 = fu_history_get_device_by_id(history, fu_device_get_id(device), &error2);
 	g_assert_no_error(error2);
-	g_assert(device2 != NULL);
+	g_assert_nonnull(device2);
 	g_assert_cmpint(fu_device_get_update_state(device2), ==, FWUPD_UPDATE_STATE_FAILED);
 	g_assert_cmpstr(fu_device_get_update_error(device2), ==, error->message);
 	g_clear_error(&error);
@@ -2244,7 +2244,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 			    checksum);
 	ret = fu_test_compare_lines(device_str, device_str_expected, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 }
 
 static void
@@ -2390,7 +2390,7 @@ fu_device_list_replug_auto_func(gconstpointer user_data)
 	/* not yet added */
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add device */
 	fu_device_list_add(device_list, device1);
@@ -2398,7 +2398,7 @@ fu_device_list_replug_auto_func(gconstpointer user_data)
 	/* not waiting */
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* waiting */
 	helper.device_old = device1;
@@ -2409,17 +2409,17 @@ fu_device_list_replug_auto_func(gconstpointer user_data)
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_false(fu_device_has_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG));
 
 	/* check device2 now has parent too */
-	g_assert(fu_device_get_parent(device2) == parent);
+	g_assert_true(fu_device_get_parent(device2) == parent);
 
 	/* waiting, failed */
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(!ret);
+	g_assert_false(ret);
 	g_assert_false(fu_device_has_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG));
 }
 
@@ -2455,7 +2455,7 @@ fu_device_list_replug_user_func(gconstpointer user_data)
 	/* not yet added */
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add device */
 	fu_device_list_add(device_list, device1);
@@ -2468,7 +2468,7 @@ fu_device_list_replug_user_func(gconstpointer user_data)
 	/* not waiting */
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* waiting */
 	helper.device_old = device1;
@@ -2479,7 +2479,7 @@ fu_device_list_replug_user_func(gconstpointer user_data)
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	ret = fu_device_list_wait_for_replug(device_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_false(fu_device_has_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG));
 
 	/* should not be possible, but here we are */
@@ -2568,7 +2568,7 @@ fu_device_list_compatible_func(gconstpointer user_data)
 
 	/* verify we can get the old device from the new device */
 	device_old = fu_device_list_get_old(device_list, device2);
-	g_assert(device_old == device1);
+	g_assert_true(device_old == device1);
 }
 
 static void
@@ -2656,7 +2656,7 @@ fu_device_list_func(gconstpointer user_data)
 					  "99249eb1bd9ef0b6e192b271a8cb6a3090cfec7a",
 					  &error);
 	g_assert_no_error(error);
-	g_assert(device != NULL);
+	g_assert_nonnull(device);
 	g_assert_cmpstr(fu_device_get_id(device), ==, "99249eb1bd9ef0b6e192b271a8cb6a3090cfec7a");
 	g_clear_object(&device);
 
@@ -2664,14 +2664,14 @@ fu_device_list_func(gconstpointer user_data)
 	device =
 	    fu_device_list_get_by_guid(device_list, "579a3b1c-d1db-5bdc-b6b9-e2c1b28d5b8a", &error);
 	g_assert_no_error(error);
-	g_assert(device != NULL);
+	g_assert_nonnull(device);
 	g_assert_cmpstr(fu_device_get_id(device), ==, "1a8d0d9a96ad3e67ba76cf3033623625dc6d6882");
 	g_clear_object(&device);
 
 	/* find by missing GUID */
 	device = fu_device_list_get_by_guid(device_list, "notfound", &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(device == NULL);
+	g_assert_null(device);
 
 	/* remove device */
 	added_cnt = removed_cnt = changed_cnt = 0;
@@ -2707,13 +2707,13 @@ fu_plugin_list_func(gconstpointer user_data)
 	/* get a single plugin */
 	plugin = fu_plugin_list_find_by_name(plugin_list, "plugin1", &error);
 	g_assert_no_error(error);
-	g_assert(plugin != NULL);
+	g_assert_nonnull(plugin);
 	g_assert_cmpstr(fu_plugin_get_name(plugin), ==, "plugin1");
 
 	/* does not exist */
 	plugin = fu_plugin_list_find_by_name(plugin_list, "nope", &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(plugin == NULL);
+	g_assert_null(plugin);
 }
 
 static void
@@ -2736,7 +2736,7 @@ fu_plugin_list_depsolve_func(gconstpointer user_data)
 	fu_plugin_add_rule(plugin1, FU_PLUGIN_RULE_RUN_AFTER, "plugin2");
 	ret = fu_plugin_list_depsolve(plugin_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	plugins = fu_plugin_list_get_all(plugin_list);
 	g_assert_cmpint(plugins->len, ==, 2);
 	plugin = g_ptr_array_index(plugins, 0);
@@ -2748,14 +2748,14 @@ fu_plugin_list_depsolve_func(gconstpointer user_data)
 	fu_plugin_add_rule(plugin1, FU_PLUGIN_RULE_CONFLICTS, "plugin2");
 	ret = fu_plugin_list_depsolve(plugin_list, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	plugin = fu_plugin_list_find_by_name(plugin_list, "plugin1", &error);
 	g_assert_no_error(error);
-	g_assert(plugin != NULL);
+	g_assert_nonnull(plugin);
 	g_assert_false(fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED));
 	plugin = fu_plugin_list_find_by_name(plugin_list, "plugin2", &error);
 	g_assert_no_error(error);
-	g_assert(plugin != NULL);
+	g_assert_nonnull(plugin);
 	g_assert_true(fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED));
 }
 
@@ -2776,18 +2776,18 @@ fu_history_migrate_func(gconstpointer user_data)
 	file_dst = g_file_new_for_path("/tmp/fwupd-self-test/var/lib/fwupd/pending.db");
 	ret = g_file_copy(file_src, file_dst, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* create, migrating as required */
 	history = fu_history_new();
-	g_assert(history != NULL);
+	g_assert_nonnull(history);
 
 	/* get device */
 	device = fu_history_get_device_by_id(history,
 					     "2ba16d10df45823dd4494ff10a0bfccfef512c9d",
 					     &error);
 	g_assert_no_error(error);
-	g_assert(device != NULL);
+	g_assert_nonnull(device);
 	g_assert_cmpstr(fu_device_get_id(device), ==, "2ba16d10df45823dd4494ff10a0bfccfef512c9d");
 }
 
@@ -2845,7 +2845,7 @@ fu_plugin_module_func(gconstpointer user_data)
 	g_setenv("FWUPD_PLUGIN_TEST", "registration", TRUE);
 	ret = fu_plugin_runner_startup(self->plugin, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_signal_connect(self->plugin,
 			 "device-added",
 			 G_CALLBACK(_plugin_device_added_cb),
@@ -2856,10 +2856,10 @@ fu_plugin_module_func(gconstpointer user_data)
 			 &device);
 	ret = fu_plugin_runner_coldplug(self->plugin, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* check we did the right thing */
-	g_assert(device != NULL);
+	g_assert_nonnull(device);
 	g_assert_cmpstr(fu_device_get_id(device), ==, "08d460be0f1f9f128413f816022a6439e0078018");
 	g_assert_cmpstr(fu_device_get_version_lowest(device), ==, "1.2.0");
 	g_assert_cmpstr(fu_device_get_version(device), ==, "1.2.2");
@@ -2879,7 +2879,7 @@ fu_plugin_module_func(gconstpointer user_data)
 	mapped_file_fn = g_build_filename(TESTDATADIR_SRC, "colorhug", "firmware.bin", NULL);
 	mapped_file = g_mapped_file_new(mapped_file_fn, FALSE, &error);
 	g_assert_no_error(error);
-	g_assert(mapped_file != NULL);
+	g_assert_nonnull(mapped_file);
 	blob_cab = g_mapped_file_get_bytes(mapped_file);
 	release = fu_device_get_release_default(device);
 	fwupd_release_set_version(release, "1.2.3");
@@ -2890,7 +2890,7 @@ fu_plugin_module_func(gconstpointer user_data)
 					FWUPD_INSTALL_FLAG_NONE,
 					&error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* set on the current device */
 	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
@@ -2899,12 +2899,12 @@ fu_plugin_module_func(gconstpointer user_data)
 	history = fu_history_new();
 	device2 = fu_history_get_device_by_id(history, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(device2 != NULL);
+	g_assert_nonnull(device2);
 	g_assert_cmpint(fu_device_get_update_state(device2), ==, FWUPD_UPDATE_STATE_PENDING);
 	g_assert_cmpstr(fu_device_get_update_error(device2), ==, NULL);
 	g_assert_true(fu_device_has_flag(device2, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
 	release = fu_device_get_release_default(device2);
-	g_assert(release != NULL);
+	g_assert_nonnull(release);
 	g_assert_cmpstr(fwupd_release_get_filename(release), !=, NULL);
 	g_assert_cmpstr(fwupd_release_get_version(release), ==, "1.2.3");
 
@@ -2922,7 +2922,7 @@ fu_plugin_module_func(gconstpointer user_data)
 				     FWUPD_FEATURE_FLAG_NONE,
 				     &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(cnt, ==, 8);
 
 	/* check the new version */
@@ -2932,7 +2932,7 @@ fu_plugin_module_func(gconstpointer user_data)
 	/* lets check the history */
 	device3 = fu_history_get_device_by_id(history, fu_device_get_id(device), &error);
 	g_assert_no_error(error);
-	g_assert(device3 != NULL);
+	g_assert_nonnull(device3);
 	g_assert_cmpint(fu_device_get_update_state(device3), ==, FWUPD_UPDATE_STATE_SUCCESS);
 	g_assert_cmpstr(fu_device_get_update_error(device3), ==, NULL);
 
@@ -2941,14 +2941,14 @@ fu_plugin_module_func(gconstpointer user_data)
 	fu_device_set_id(device_tmp, "FakeDevice");
 	ret = fu_plugin_runner_get_results(self->plugin, device_tmp, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_assert_cmpint(fu_device_get_update_state(device_tmp), ==, FWUPD_UPDATE_STATE_SUCCESS);
 	g_assert_cmpstr(fu_device_get_update_error(device_tmp), ==, NULL);
 
 	/* clear */
 	ret = fu_plugin_runner_clear_results(self->plugin, device_tmp, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	g_object_unref(device_tmp);
 	g_clear_error(&error);
@@ -2977,7 +2977,7 @@ fu_history_func(gconstpointer user_data)
 
 	/* create */
 	history = fu_history_new();
-	g_assert(history != NULL);
+	g_assert_nonnull(history);
 
 	/* delete the database */
 	dirname = fu_common_get_path(FU_PATH_KIND_LOCALSTATEDIR_PKG);
@@ -3005,11 +3005,11 @@ fu_history_func(gconstpointer user_data)
 	fwupd_release_add_metadata_item(release, "FwupdVersion", VERSION);
 	ret = fu_history_add_device(history, device, release, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_object_unref(release);
 
 	/* ensure database was created */
-	g_assert(g_file_test(filename, G_FILE_TEST_EXISTS));
+	g_assert_true(g_file_test(filename, G_FILE_TEST_EXISTS));
 
 	g_object_unref(device);
 
@@ -3018,7 +3018,7 @@ fu_history_func(gconstpointer user_data)
 					     "2ba16d10df45823dd4494ff10a0bfccfef512c9d",
 					     &error);
 	g_assert_no_error(error);
-	g_assert(device != NULL);
+	g_assert_nonnull(device);
 	g_assert_cmpstr(fu_device_get_id(device), ==, "2ba16d10df45823dd4494ff10a0bfccfef512c9d");
 	g_assert_cmpstr(fu_device_get_name(device), ==, "ColorHug");
 	g_assert_cmpstr(fu_device_get_version(device), ==, "3.0.1");
@@ -3033,22 +3033,22 @@ fu_history_func(gconstpointer user_data)
 	g_assert_cmpint(fu_device_get_created(device), ==, 123);
 	g_assert_cmpint(fu_device_get_modified(device), ==, 456);
 	release = fu_device_get_release_default(device);
-	g_assert(release != NULL);
+	g_assert_nonnull(release);
 	g_assert_cmpstr(fwupd_release_get_version(release), ==, "3.0.2");
 	g_assert_cmpstr(fwupd_release_get_filename(release), ==, "/var/lib/dave.cap");
 	g_assert_cmpstr(fwupd_release_get_metadata_item(release, "FwupdVersion"), ==, VERSION);
 	checksums = fwupd_release_get_checksums(release);
-	g_assert(checksums != NULL);
+	g_assert_nonnull(checksums);
 	g_assert_cmpint(checksums->len, ==, 1);
 	g_assert_cmpstr(fwupd_checksum_get_by_kind(checksums, G_CHECKSUM_SHA1), ==, "abcdef");
 	ret = fu_history_add_device(history, device, release, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* get device that does not exist */
 	device_found = fu_history_get_device_by_id(history, "XXXXXXXXXXXXX", &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(device_found == NULL);
+	g_assert_null(device_found);
 	g_clear_error(&error);
 
 	/* get device that does exist */
@@ -3056,13 +3056,13 @@ fu_history_func(gconstpointer user_data)
 						   "2ba16d10df45823dd4494ff10a0bfccfef512c9d",
 						   &error);
 	g_assert_no_error(error);
-	g_assert(device_found != NULL);
+	g_assert_nonnull(device_found);
 	g_object_unref(device_found);
 
 	/* remove device */
 	ret = fu_history_remove_device(history, device, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	g_object_unref(device);
 
 	/* get device that does not exist */
@@ -3070,19 +3070,19 @@ fu_history_func(gconstpointer user_data)
 						   "2ba16d10df45823dd4494ff10a0bfccfef512c9d",
 						   &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert(device_found == NULL);
+	g_assert_null(device_found);
 	g_clear_error(&error);
 
 	/* approved firmware */
 	ret = fu_history_clear_approved_firmware(history, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_history_add_approved_firmware(history, "foo", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = fu_history_add_approved_firmware(history, "bar", &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	approved_firmware = fu_history_get_approved_firmware(history, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(approved_firmware);
@@ -3106,7 +3106,7 @@ _build_cab(GCabCompression compression, ...)
 	cabfolder = gcab_folder_new(compression);
 	ret = gcab_cabinet_add_folder(cabinet, cabfolder, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 
 	/* add each file */
 	va_start(args, compression);
@@ -3132,7 +3132,7 @@ _build_cab(GCabCompression compression, ...)
 		cabfile = gcab_file_new_with_bytes(fn, blob);
 		ret = gcab_folder_add_file(cabfolder, cabfile, FALSE, NULL, &error);
 		g_assert_no_error(error);
-		g_assert(ret);
+		g_assert_true(ret);
 	} while (TRUE);
 	va_end(args);
 
@@ -3140,10 +3140,10 @@ _build_cab(GCabCompression compression, ...)
 	op = g_memory_output_stream_new_resizable();
 	ret = gcab_cabinet_write_simple(cabinet, op, NULL, NULL, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	ret = g_output_stream_close(op, NULL, &error);
 	g_assert_no_error(error);
-	g_assert(ret);
+	g_assert_true(ret);
 	return g_memory_output_stream_steal_as_bytes(G_MEMORY_OUTPUT_STREAM(op));
 }
 
@@ -3339,7 +3339,7 @@ fu_memcpy_func(gconstpointer user_data)
 	ret = fu_memcpy_safe(dst, sizeof(dst), 0x0, src, sizeof(src), 0x0, 4, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert(memcmp(src, dst, 4) == 0);
+	g_assert_cmpint(memcmp(src, dst, 4), ==, 0);
 
 	/* copy first char */
 	ret = fu_memcpy_safe(dst, sizeof(dst), 0x0, src, sizeof(src), 0x0, 1, &error);


### PR DESCRIPTION
Note that g_assert() should not be used in unit tests, since it is a
no-op when compiling with G_DISABLE_ASSERT. Use g_assert() in production
code, and g_assert_true() in unit tests.

See https://github.com/fwupd/fwupd/issues/3790

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
