### PR TITLE
trivial: Export the CFU enum conversion functions

### DIFF
--- a/libfwupdplugin/fu-cfu-common.c
+++ b/libfwupdplugin/fu-cfu-common.c
@@ -6,10 +6,20 @@
 
 #include "config.h"
 
-#include "fu-elanfp-common.h"
+#include "fu-cfu-common.h"
 
+/**
+ * fu_cfu_device_reject_to_string:
+ * @val: a enumerated value, e.g. %FU_CFU_DEVICE_REJECT_OLD_FIRMWARE
+ *
+ * Converts an enumerated reject type to a string.
+ *
+ * Returns: a string, or `unknown` for invalid
+ *
+ * Since: 1.7.0
+ **/
 const gchar *
-fu_elanfp_cfu_device_reject_to_string(guint8 val)
+fu_cfu_device_reject_to_string(guint8 val)
 {
 	if (val == FU_CFU_DEVICE_REJECT_OLD_FIRMWARE)
 		return "old-firmware";
@@ -28,8 +38,18 @@ fu_elanfp_cfu_device_reject_to_string(guint8 val)
 	return "unknown";
 }
 
+/**
+ * fu_cfu_device_offer_to_string:
+ * @val: a enumerated value, e.g. %FU_CFU_DEVICE_OFFER_ACCEPT
+ *
+ * Converts an enumerated offer type to a string.
+ *
+ * Returns: a string, or `unknown` for invalid
+ *
+ * Since: 1.7.0
+ **/
 const gchar *
-fu_elanfp_cfu_device_offer_to_string(guint8 val)
+fu_cfu_device_offer_to_string(guint8 val)
 {
 	if (val == FU_CFU_DEVICE_OFFER_SKIP)
 		return "skip";
@@ -46,8 +66,18 @@ fu_elanfp_cfu_device_offer_to_string(guint8 val)
 	return "unknown";
 }
 
+/**
+ * fu_cfu_device_status_to_string:
+ * @val: a enumerated value, e.g. %FU_CFU_DEVICE_OFFER_ACCEPT
+ *
+ * Converts an enumerated status type to a string.
+ *
+ * Returns: a string, or `unknown` for invalid
+ *
+ * Since: 1.7.0
+ **/
 const gchar *
-fu_elanfp_cfu_device_status_to_string(guint8 val)
+fu_cfu_device_status_to_string(guint8 val)
 {
 	if (val == FU_CFU_DEVICE_STATUS_SUCCESS)
 		return "success";

--- a/libfwupdplugin/fu-cfu-common.h
+++ b/libfwupdplugin/fu-cfu-common.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <fwupdplugin.h>
+#include <gio/gio.h>
 
 #define FU_CFU_DEVICE_OFFER_SKIP	  0x00
 #define FU_CFU_DEVICE_OFFER_ACCEPT	  0x01
@@ -40,8 +40,8 @@
 #define FU_CFU_DEVICE_REJECT_DEBUG_SAME_VERSION 0xE2
 
 const gchar *
-fu_elanfp_cfu_device_reject_to_string(guint8 val);
+fu_cfu_device_reject_to_string(guint8 val);
 const gchar *
-fu_elanfp_cfu_device_status_to_string(guint8 val);
+fu_cfu_device_status_to_string(guint8 val);
 const gchar *
-fu_elanfp_cfu_device_offer_to_string(guint8 val);
+fu_cfu_device_offer_to_string(guint8 val);

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -11,6 +11,7 @@
 #include <libfwupdplugin/fu-archive.h>
 #include <libfwupdplugin/fu-backend.h>
 #include <libfwupdplugin/fu-bluez-device.h>
+#include <libfwupdplugin/fu-cfu-common.h>
 #include <libfwupdplugin/fu-cfu-offer.h>
 #include <libfwupdplugin/fu-cfu-payload.h>
 #include <libfwupdplugin/fu-chunk.h>

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -861,6 +861,9 @@ LIBFWUPDPLUGIN_1.6.2 {
 
 LIBFWUPDPLUGIN_1.7.0 {
   global:
+    fu_cfu_device_offer_to_string;
+    fu_cfu_device_reject_to_string;
+    fu_cfu_device_status_to_string;
     fu_cfu_offer_get_bank;
     fu_cfu_offer_get_component_id;
     fu_cfu_offer_get_force_ignore_version;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -18,6 +18,7 @@ fwupdplugin_src = [
   'fu-device-locker.c',     # fuzzing
   'fu-device.c',            # fuzzing
   'fu-dfu-firmware.c',      # fuzzing
+  'fu-cfu-common.c',        # fuzzing
   'fu-cfu-offer.c',         # fuzzing
   'fu-cfu-payload.c',       # fuzzing
   'fu-volume.c',            # fuzzing
@@ -84,6 +85,7 @@ fwupdplugin_headers = [
   'fu-device-metadata.h',
   'fu-device-locker.h',
   'fu-dfu-firmware.h',
+  'fu-cfu-common.h',
   'fu-cfu-offer.h',
   'fu-cfu-payload.h',
   'fu-efi-common.h',

--- a/plugins/elanfp/fu-elanfp-device.c
+++ b/plugins/elanfp/fu-elanfp-device.c
@@ -6,7 +6,6 @@
 
 #include "config.h"
 
-#include "fu-elanfp-common.h"
 #include "fu-elanfp-device.h"
 #include "fu-elanfp-firmware.h"
 
@@ -339,7 +338,7 @@ fu_elanfp_device_write_payload(FuElanfpDevice *self,
 				    G_IO_ERROR_INVALID_DATA,
 				    "failed to send chunk %u: %s",
 				    i + 1,
-				    fu_elanfp_cfu_device_status_to_string(recvbuf[5]));
+				    fu_cfu_device_status_to_string(recvbuf[5]));
 			return FALSE;
 		}
 		fu_progress_step_done(progress);
@@ -397,8 +396,8 @@ fu_elanfp_device_write_firmware(FuDevice *device,
 		}
 		g_debug("offer-%s status:%s reject:%s",
 			items[i].tag,
-			fu_elanfp_cfu_device_offer_to_string(recvbuf[13]),
-			fu_elanfp_cfu_device_reject_to_string(recvbuf[9]));
+			fu_cfu_device_offer_to_string(recvbuf[13]),
+			fu_cfu_device_reject_to_string(recvbuf[9]));
 		if (recvbuf[13] == FU_CFU_DEVICE_OFFER_ACCEPT)
 			break;
 	}

--- a/plugins/elanfp/meson.build
+++ b/plugins/elanfp/meson.build
@@ -8,7 +8,6 @@ shared_module('fu_plugin_elanfp',
   fu_hash,
   sources : [
     'fu-plugin-elanfp.c',
-    'fu-elanfp-common.c',
     'fu-elanfp-device.c',
     'fu-elanfp-firmware.c'  # fuzzing
   ],


### PR DESCRIPTION
We need these in the CFU plugin too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
