### PR TITLE
flashrom: Ensure internal devices get an assigned context

### DIFF
--- a/plugins/flashrom/fu-flashrom-internal-device.c
+++ b/plugins/flashrom/fu-flashrom-internal-device.c
@@ -195,7 +195,7 @@ fu_flashrom_internal_device_class_init(FuFlashromInternalDeviceClass *klass)
 }
 
 FuDevice *
-fu_flashrom_internal_device_new(void)
+fu_flashrom_internal_device_new(FuContext *ctx)
 {
-	return FU_DEVICE(g_object_new(FU_TYPE_FLASHROM_INTERNAL_DEVICE, NULL));
+	return FU_DEVICE(g_object_new(FU_TYPE_FLASHROM_INTERNAL_DEVICE, "context", ctx, NULL));
 }

--- a/plugins/flashrom/fu-flashrom-internal-device.h
+++ b/plugins/flashrom/fu-flashrom-internal-device.h
@@ -16,4 +16,4 @@ G_DECLARE_FINAL_TYPE(FuFlashromInternalDevice,
 		     FuFlashromDevice)
 
 FuDevice *
-fu_flashrom_internal_device_new(void);
+fu_flashrom_internal_device_new(FuContext *ctx);

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -148,7 +148,7 @@ fu_plugin_coldplug(FuPlugin *plugin, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	const gchar *dmi_vendor;
-	g_autoptr(FuDevice) device = fu_flashrom_internal_device_new();
+	g_autoptr(FuDevice) device = fu_flashrom_internal_device_new(ctx);
 
 	fu_device_set_context(device, ctx);
 	fu_device_set_name(device, fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_PRODUCT_NAME));


### PR DESCRIPTION
This makes the quirks work correctly. Fixes a warning seen in the logs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
