### PR TITLE
Write the BMP image upside down to avoid using a negative bitmap height

### DIFF
--- a/plugins/uefi-capsule/make-images.py
+++ b/plugins/uefi-capsule/make-images.py
@@ -74,7 +74,7 @@ def _cairo_surface_write_to_bmp(img: cairo.ImageSurface) -> bytes:
             54,  # pixel array offset
             40,  # DIB header
             img.get_width(),  # width
-            -img.get_height(),  # height (top down)
+            img.get_height(),  # height
             1,  # planes
             32,  # BPP
             0,  # no compression
@@ -179,7 +179,7 @@ def main(args) -> int:
                 PangoCairo.context_set_font_options(pctx, font_option)
 
                 cctx.set_source_rgb(1, 1, 1)
-                cctx.move_to(x, y)
+                cctx.move_to(x, y - surface_height / 2)
 
                 def do_write(fs, f, data):
                     """write out glyphs"""
@@ -188,6 +188,11 @@ def main(args) -> int:
                         return False
                     PangoCairo.show_glyph_string(cctx, f, gs)
                     return True
+
+                # flip the image to write the bitmap upside-down
+                mat = cairo.Matrix()
+                mat.scale(1, -1)
+                cctx.transform(mat)
 
                 fs.foreach(do_write, None)
                 img.flush()


### PR DESCRIPTION
It would seem that some EFI BMP loaders are unable to flip the image
and hang when trying to load the UX capsule.

This was a real PITA to debug.

Many thanks to Sean Rhodes <sean@starlabs.systems> for all the help.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
