### PR TITLE
fu-engine: Fix typo in the efi-firmware-volume ID

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6725,7 +6725,7 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, GError **error)
 				      "efi-firmware-section",
 				      FU_TYPE_EFI_FIRMWARE_SECTION);
 	fu_context_add_firmware_gtype(self->ctx,
-				      "efi-firmware-colume",
+				      "efi-firmware-volume",
 				      FU_TYPE_EFI_FIRMWARE_VOLUME);
 	fu_context_add_firmware_gtype(self->ctx, "ifd-bios", FU_TYPE_IFD_BIOS);
 	fu_context_add_firmware_gtype(self->ctx, "ifd-firmware", FU_TYPE_IFD_FIRMWARE);


### PR DESCRIPTION
The commit 488f2e1f37b163c5e32ee340d3fad3b7ea79119e has moved some parsers and has created a typo in the `efi-firmware-volume` ID.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
