### PR TITLE
Allow using interrupt transfers for HID devices

### DIFF
--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -29,6 +29,8 @@
 
 typedef struct {
 	guint8 interface;
+	guint8 ep_addr_in;  /* only for _USE_INTERRUPT_TRANSFER */
+	guint8 ep_addr_out; /* only for _USE_INTERRUPT_TRANSFER */
 	gboolean interface_autodetect;
 	FuHidDeviceFlags flags;
 } FuHidDevicePrivate;
@@ -38,6 +40,19 @@ G_DEFINE_TYPE_WITH_PRIVATE(FuHidDevice, fu_hid_device, FU_TYPE_USB_DEVICE)
 enum { PROP_0, PROP_INTERFACE, PROP_LAST };
 
 #define GET_PRIVATE(o) (fu_hid_device_get_instance_private(o))
+
+static void
+fu_hid_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuHidDevice *self = FU_HID_DEVICE(device);
+	FuHidDevicePrivate *priv = GET_PRIVATE(self);
+	fu_common_string_append_kb(str, idt, "InterfaceAutodetect", priv->interface_autodetect);
+	fu_common_string_append_kx(str, idt, "Interface", priv->interface);
+	if (priv->ep_addr_in != 0)
+		fu_common_string_append_kx(str, idt, "EpAddrIn", priv->ep_addr_in);
+	if (priv->ep_addr_out != 0)
+		fu_common_string_append_kx(str, idt, "EpAddrOut", priv->ep_addr_out);
+}
 
 static void
 fu_hid_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
@@ -68,6 +83,44 @@ fu_hid_device_set_property(GObject *object, guint prop_id, const GValue *value, 
 	}
 }
 
+#ifdef HAVE_GUSB
+static gboolean
+fu_hid_device_autodetect_eps(FuHidDevice *self, GUsbInterface *iface, GError **error)
+{
+#if G_USB_CHECK_VERSION(0, 3, 3)
+	FuHidDevicePrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GPtrArray) eps = g_usb_interface_get_endpoints(iface);
+	for (guint i = 0; i < eps->len; i++) {
+		GUsbEndpoint *ep = g_ptr_array_index(eps, i);
+		if (g_usb_endpoint_get_direction(ep) == G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST &&
+		    priv->ep_addr_in == 0) {
+			priv->ep_addr_in = g_usb_endpoint_get_address(ep);
+			continue;
+		}
+		if (g_usb_endpoint_get_direction(ep) == G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE &&
+		    priv->ep_addr_out == 0) {
+			priv->ep_addr_out = g_usb_endpoint_get_address(ep);
+			continue;
+		}
+	}
+	if (priv->ep_addr_in == 0x0 || priv->ep_addr_out == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "could not autodetect EP addresses");
+		return FALSE;
+	}
+	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "this version of GUsb is not supported");
+	return FALSE;
+#endif
+}
+#endif
+
 static gboolean
 fu_hid_device_open(FuDevice *device, GError **error)
 {
@@ -92,6 +145,10 @@ fu_hid_device_open(FuDevice *device, GError **error)
 			if (g_usb_interface_get_class(iface) == G_USB_DEVICE_CLASS_HID) {
 				priv->interface = g_usb_interface_get_number(iface);
 				priv->interface_autodetect = FALSE;
+				if (priv->flags & FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER) {
+					if (!fu_hid_device_autodetect_eps(self, iface, error))
+						return FALSE;
+				}
 				break;
 			}
 		}
@@ -102,7 +159,6 @@ fu_hid_device_open(FuDevice *device, GError **error)
 					    "could not autodetect HID interface");
 			return FALSE;
 		}
-		g_debug("autodetected HID interface of 0x%02x", priv->interface);
 	}
 
 	/* claim */
@@ -222,37 +278,56 @@ fu_hid_device_set_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 {
 #ifdef HAVE_GUSB
 	FuHidDevicePrivate *priv = GET_PRIVATE(self);
-	GUsbDevice *usb_device;
+	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	gsize actual_len = 0;
-	guint16 wvalue = (FU_HID_REPORT_TYPE_OUTPUT << 8) | helper->value;
 
-	/* special case */
-	if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
-		wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
+	/* what method do we use? */
+	if (priv->flags & FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER) {
+		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
+			g_autofree gchar *title = NULL;
+			title = g_strdup_printf("HID::SetReport [EP=0x%02x]", priv->ep_addr_out);
+			fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
+		}
+		if (!g_usb_device_interrupt_transfer(usb_device,
+						     priv->ep_addr_out,
+						     helper->buf,
+						     helper->bufsz,
+						     &actual_len,
+						     helper->timeout,
+						     NULL, /* cancellable */
+						     error)) {
+			return FALSE;
+		}
+	} else {
+		guint16 wvalue = (FU_HID_REPORT_TYPE_OUTPUT << 8) | helper->value;
 
-	if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-		g_autofree gchar *title = NULL;
-		title = g_strdup_printf("HID::SetReport [wValue=0x%04x ,wIndex=%u]",
-					wvalue,
-					priv->interface);
-		fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
-	}
-	usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
-	if (!g_usb_device_control_transfer(usb_device,
-					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
-					   G_USB_DEVICE_REQUEST_TYPE_CLASS,
-					   G_USB_DEVICE_RECIPIENT_INTERFACE,
-					   FU_HID_REPORT_SET,
-					   wvalue,
-					   priv->interface,
-					   helper->buf,
-					   helper->bufsz,
-					   &actual_len,
-					   helper->timeout,
-					   NULL,
-					   error)) {
-		g_prefix_error(error, "failed to SetReport: ");
-		return FALSE;
+		/* special case */
+		if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
+			wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
+
+		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
+			g_autofree gchar *title = NULL;
+			title = g_strdup_printf("HID::SetReport [wValue=0x%04x ,wIndex=%u]",
+						wvalue,
+						priv->interface);
+			fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
+		}
+		if (!g_usb_device_control_transfer(usb_device,
+						   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
+						   G_USB_DEVICE_REQUEST_TYPE_CLASS,
+						   G_USB_DEVICE_RECIPIENT_INTERFACE,
+						   FU_HID_REPORT_SET,
+						   wvalue,
+						   priv->interface,
+						   helper->buf,
+						   helper->bufsz,
+						   &actual_len,
+						   helper->timeout,
+						   NULL,
+						   error)) {
+			g_prefix_error(error, "failed to SetReport: ");
+			return FALSE;
+		}
 	}
 	if ((helper->flags & FU_HID_DEVICE_FLAG_ALLOW_TRUNC) == 0 && actual_len != helper->bufsz) {
 		g_set_error(error,
@@ -278,7 +353,7 @@ fu_hid_device_set_report_internal_cb(FuDevice *device, gpointer user_data, GErro
 /**
  * fu_hid_device_set_report:
  * @self: a #FuHidDevice
- * @value: low byte of wValue
+ * @value: low byte of wValue, but unused when using %FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER
  * @buf: (nullable): a mutable buffer of data to send
  * @bufsz: size of @buf
  * @timeout: timeout in ms
@@ -333,44 +408,63 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 {
 #ifdef HAVE_GUSB
 	FuHidDevicePrivate *priv = GET_PRIVATE(self);
-	GUsbDevice *usb_device;
+	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	gsize actual_len = 0;
-	guint16 wvalue = (FU_HID_REPORT_TYPE_INPUT << 8) | helper->value;
 
-	/* special case */
-	if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
-		wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
+	/* what method do we use? */
+	if (priv->flags & FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER) {
+		if (!g_usb_device_interrupt_transfer(usb_device,
+						     priv->ep_addr_in,
+						     helper->buf,
+						     helper->bufsz,
+						     &actual_len,
+						     helper->timeout,
+						     NULL, /* cancellable */
+						     error)) {
+			return FALSE;
+		}
+		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
+			g_autofree gchar *title = NULL;
+			title = g_strdup_printf("HID::GetReport [EP=0x%02x]", priv->ep_addr_in);
+			fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
+		}
+	} else {
+		guint16 wvalue = (FU_HID_REPORT_TYPE_INPUT << 8) | helper->value;
 
-	if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-		g_autofree gchar *title = NULL;
-		title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
-					wvalue,
-					priv->interface);
-		fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
-	}
-	usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
-	if (!g_usb_device_control_transfer(usb_device,
-					   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
-					   G_USB_DEVICE_REQUEST_TYPE_CLASS,
-					   G_USB_DEVICE_RECIPIENT_INTERFACE,
-					   FU_HID_REPORT_GET,
-					   wvalue,
-					   priv->interface,
-					   helper->buf,
-					   helper->bufsz,
-					   &actual_len, /* actual length */
-					   helper->timeout,
-					   NULL,
-					   error)) {
-		g_prefix_error(error, "failed to GetReport: ");
-		return FALSE;
-	}
-	if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-		g_autofree gchar *title = NULL;
-		title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
-					wvalue,
-					priv->interface);
-		fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
+		/* special case */
+		if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
+			wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
+
+		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
+			g_autofree gchar *title = NULL;
+			title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
+						wvalue,
+						priv->interface);
+			fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
+		}
+		if (!g_usb_device_control_transfer(usb_device,
+						   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
+						   G_USB_DEVICE_REQUEST_TYPE_CLASS,
+						   G_USB_DEVICE_RECIPIENT_INTERFACE,
+						   FU_HID_REPORT_GET,
+						   wvalue,
+						   priv->interface,
+						   helper->buf,
+						   helper->bufsz,
+						   &actual_len, /* actual length */
+						   helper->timeout,
+						   NULL,
+						   error)) {
+			g_prefix_error(error, "failed to GetReport: ");
+			return FALSE;
+		}
+		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
+			g_autofree gchar *title = NULL;
+			title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
+						wvalue,
+						priv->interface);
+			fu_common_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
+		}
 	}
 	if ((helper->flags & FU_HID_DEVICE_FLAG_ALLOW_TRUNC) == 0 && actual_len != helper->bufsz) {
 		g_set_error(error,
@@ -396,7 +490,7 @@ fu_hid_device_get_report_internal_cb(FuDevice *device, gpointer user_data, GErro
 /**
  * fu_hid_device_get_report:
  * @self: a #FuHidDevice
- * @value: low byte of wValue
+ * @value: low byte of wValue, but unused when using %FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER
  * @buf: (nullable): a mutable buffer of data to send
  * @bufsz: size of @buf
  * @timeout: timeout in ms
@@ -482,6 +576,7 @@ fu_hid_device_class_init(FuHidDeviceClass *klass)
 	object_class->set_property = fu_hid_device_set_property;
 	klass_device->open = fu_hid_device_open;
 	klass_device->close = fu_hid_device_close;
+	klass_device->to_string = fu_hid_device_to_string;
 
 	pspec = g_param_spec_uint("interface",
 				  NULL,

--- a/libfwupdplugin/fu-hid-device.h
+++ b/libfwupdplugin/fu-hid-device.h
@@ -26,6 +26,7 @@ struct _FuHidDeviceClass {
  * @FU_HID_DEVICE_FLAG_RETRY_FAILURE:		Retry up to 10 times on failure
  * @FU_HID_DEVICE_FLAG_NO_KERNEL_UNBIND:	Do not unbind the kernel driver on open
  * @FU_HID_DEVICE_FLAG_NO_KERNEL_REBIND:	Do not rebind the kernel driver on close
+ * @FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER:	Use interrupt transfers, not control transfers
  *
  * Flags used when calling fu_hid_device_get_report() and fu_hid_device_set_report().
  **/
@@ -36,6 +37,7 @@ typedef enum {
 	FU_HID_DEVICE_FLAG_RETRY_FAILURE = 1 << 2,
 	FU_HID_DEVICE_FLAG_NO_KERNEL_UNBIND = 1 << 3,
 	FU_HID_DEVICE_FLAG_NO_KERNEL_REBIND = 1 << 4,
+	FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER = 1 << 5,
 	/*< private >*/
 	FU_HID_DEVICE_FLAG_LAST
 } FuHidDeviceFlags;


### PR DESCRIPTION
Also, print the interface number and EP addresses in the ->to_string
handler.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
