### PR TITLE
trivial: Notify when the FuDevice:parent is set

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1034,6 +1034,7 @@ fu_device_set_parent(FuDevice *self, FuDevice *parent)
 	}
 
 	fwupd_device_set_parent(FWUPD_DEVICE(self), FWUPD_DEVICE(parent));
+	g_object_notify(G_OBJECT(self), "parent");
 }
 
 /**


### PR DESCRIPTION
This allows us to perform a callback when the parent instance is set or
changed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
