### PR TITLE
trivial: Use new libgcab API where possible

### DIFF
--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -163,7 +163,11 @@ fu_cabinet_add_file(FuCabinet *self, const gchar *basename, GBytes *data)
 	/* existing file? */
 	gcab_file_old = fu_cabinet_get_file_by_name(self, basename);
 	if (gcab_file_old != NULL) {
+#ifdef HAVE_GCAB_FILE_SET_BYTES
+		gcab_file_set_bytes(gcab_file_old, data);
+#else
 		g_object_set(gcab_file_old, "bytes", data, NULL);
+#endif
 		return;
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -250,6 +250,10 @@ if build_daemon
 endif
 libm = cc.find_library('m', required: false)
 libgcab = dependency('libgcab-1.0', version : '>= 1.0', fallback : ['gcab', 'gcab_dep'])
+if libgcab.type_name() == 'pkgconfig' and cc.has_function('gcab_file_set_bytes', dependencies: libgcab)
+  conf.set('HAVE_GCAB_FILE_SET_BYTES', '1')
+endif
+
 bashcomp = dependency('bash-completion', required: false)
 if host_machine.system() != 'freebsd'
   python3 = find_program('python3')


### PR DESCRIPTION
This is new in version 1.5, but may be backported.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
