### PR TITLE
trivial: Match up the translator comments with the source strings

### DIFF
--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -186,8 +186,8 @@ main(int argc, char *argv[])
 		if (dbxfile != NULL) {
 			dbx = fu_dbxtool_get_siglist_local(dbxfile, &error);
 			if (dbx == NULL) {
-				/* TRANSLATORS: could not read existing system data */
 				g_printerr("%s: %s\n",
+					   /* TRANSLATORS: could not read existing system data */
 					   _("Failed to load local dbx"),
 					   error->message);
 				return EXIT_FAILURE;
@@ -195,8 +195,8 @@ main(int argc, char *argv[])
 		} else {
 			dbx = fu_dbxtool_get_siglist_system(&error);
 			if (dbx == NULL) {
-				/* TRANSLATORS: could not read existing system data */
 				g_printerr("%s: %s\n",
+					   /* TRANSLATORS: could not read existing system data */
 					   _("Failed to load system dbx"),
 					   error->message);
 				return EXIT_FAILURE;
@@ -267,8 +267,8 @@ main(int argc, char *argv[])
 
 		/* check this is a newer dbx update */
 		if (!force && fu_dbxtool_siglist_inclusive(dbx_system, dbx_update)) {
-			/* TRANSLATORS: same or newer update already applied */
 			g_printerr("%s\n",
+				   /* TRANSLATORS: same or newer update already applied */
 				   _("Cannot apply as dbx update has already been applied."));
 			return EXIT_FAILURE;
 		}
@@ -286,9 +286,9 @@ main(int argc, char *argv[])
 			g_print("%s\n", _("Validating ESP contents…"));
 			if (!fu_uefi_dbx_signature_list_validate(FU_EFI_SIGNATURE_LIST(dbx_update),
 								 &error)) {
-				/* TRANSLATORS: something with a blocked hash exists
-				 * in the users ESP -- which would be bad! */
 				g_printerr("%s: %s\n",
+					   /* TRANSLATORS: something with a blocked hash exists
+					    * in the users ESP -- which would be bad! */
 					   _("Failed to validate ESP contents"),
 					   error->message);
 				return EXIT_FAILURE;

--- a/src/fu-offline.c
+++ b/src/fu-offline.c
@@ -253,8 +253,8 @@ main(int argc, char *argv[])
 					      FWUPD_INSTALL_FLAG_OFFLINE,
 					  NULL,
 					  &error)) {
-			/* TRANSLATORS: we could not install for some reason */
 			g_printerr("%s: %s\n",
+				   /* TRANSLATORS: we could not install for some reason */
 				   _("Failed to install firmware update"),
 				   error->message);
 			return EXIT_FAILURE;

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -140,8 +140,8 @@ fu_progressbar_time_remaining_str(FuProgressbar *self)
 		return g_strdup(_("Less than one minute remaining"));
 	}
 
-	/* more than a minute */
 	return g_strdup_printf(
+	    /* TRANSLATORS: more than a minute */
 	    ngettext("%.0f minute remaining", "%.0f minutes remaining", self->last_estimate / 60),
 	    self->last_estimate / 60);
 }

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -591,9 +591,9 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_SUPPORTED)) {
 			if (!no_updates_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available due to missing on LVFS */
 				g_printerr("%s\n",
+					   /* TRANSLATORS: message letting the user know no device
+					    * upgrade available due to missing on LVFS */
 					   _("Devices with no available firmware updates: "));
 				no_updates_header = TRUE;
 			}
@@ -610,10 +610,10 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 					      &error_local);
 		if (rels == NULL) {
 			if (!latest_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available */
 				g_printerr(
 				    "%s\n",
+				    /* TRANSLATORS: message letting the user know no device upgrade
+				     * available */
 				    _("Devices with the latest available firmware version:"));
 				latest_header = TRUE;
 			}
@@ -1304,9 +1304,9 @@ fu_util_update_all(FuUtilPrivate *priv, GError **error)
 			continue;
 		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_SUPPORTED)) {
 			if (!no_updates_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available due to missing on LVFS */
 				g_printerr("%s\n",
+					   /* TRANSLATORS: message letting the user know no device
+					    * upgrade available due to missing on LVFS */
 					   _("Devices with no available firmware updates: "));
 				no_updates_header = TRUE;
 			}
@@ -1320,10 +1320,10 @@ fu_util_update_all(FuUtilPrivate *priv, GError **error)
 		rels = fu_engine_get_upgrades(priv->engine, priv->request, device_id, &error_local);
 		if (rels == NULL) {
 			if (!latest_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available */
 				g_printerr(
 				    "%s\n",
+				    /* TRANSLATORS: message letting the user know no device upgrade
+				     * available */
 				    _("Devices with the latest available firmware version:"));
 				latest_header = TRUE;
 			}
@@ -2631,8 +2631,8 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 				  error))
 		return FALSE;
 
-	/* TRANSLATORS: this is a string like 'HSI:2-U' */
 	g_print("%s \033[1m%s\033[0m\n",
+		/* TRANSLATORS: this is a string like 'HSI:2-U' */
 		_("Host Security ID:"),
 		fu_engine_get_host_security_id(priv->engine));
 
@@ -3410,9 +3410,9 @@ main(int argc, char *argv[])
 		g_autofree gchar *fmt = NULL;
 		/* TRANSLATORS: this is a prefix on the console */
 		fmt = fu_util_term_format(_("WARNING:"), FU_UTIL_TERM_COLOR_RED);
-		/* TRANSLATORS: try to help */
 		g_printerr("%s %s\n",
 			   fmt,
+			   /* TRANSLATORS: try to help */
 			   _("Ignoring SSL strict checks, "
 			     "to do this automatically in the future "
 			     "export DISABLE_SSL_STRICT in your environment"));
@@ -3425,8 +3425,8 @@ main(int argc, char *argv[])
 						&priv->filter_include,
 						&priv->filter_exclude,
 						&error)) {
-			/* TRANSLATORS: the user didn't read the man page */
 			g_print("%s: %s\n",
+				/* TRANSLATORS: the user didn't read the man page */
 				_("Failed to parse flags for --filter"),
 				error->message);
 			return EXIT_FAILURE;
@@ -3482,8 +3482,7 @@ main(int argc, char *argv[])
 	if (!ret) {
 		g_printerr("%s\n", error->message);
 		if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS)) {
-			/* TRANSLATORS: error message explaining command to run to how to get help
-			 */
+			/* TRANSLATORS: error message explaining command on how to get help */
 			g_printerr("\n%s\n", _("Use fwupdtool --help for help"));
 		} else if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
 			g_debug("%s\n", error->message);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -405,28 +405,31 @@ fu_util_prompt_warning(FwupdDevice *device,
 				       fu_device_get_version(device),
 				       fwupd_device_get_version_format(device));
 	if (vercmp < 0) {
-		/* TRANSLATORS: message letting the user know an downgrade is available
-		 * %1 is the device name and %2 and %3 are version strings */
-		g_string_append_printf(title,
-				       _("Downgrade %s from %s to %s?"),
-				       fwupd_device_get_name(device),
-				       fwupd_device_get_version(device),
-				       fwupd_release_get_version(release));
+		g_string_append_printf(
+		    title,
+		    /* TRANSLATORS: message letting the user know an downgrade is available
+		     * %1 is the device name and %2 and %3 are version strings */
+		    _("Downgrade %s from %s to %s?"),
+		    fwupd_device_get_name(device),
+		    fwupd_device_get_version(device),
+		    fwupd_release_get_version(release));
 	} else if (vercmp > 0) {
-		/* TRANSLATORS: message letting the user know an upgrade is available
-		 * %1 is the device name and %2 and %3 are version strings */
-		g_string_append_printf(title,
-				       _("Upgrade %s from %s to %s?"),
-				       fwupd_device_get_name(device),
-				       fwupd_device_get_version(device),
-				       fwupd_release_get_version(release));
+		g_string_append_printf(
+		    title,
+		    /* TRANSLATORS: message letting the user know an upgrade is available
+		     * %1 is the device name and %2 and %3 are version strings */
+		    _("Upgrade %s from %s to %s?"),
+		    fwupd_device_get_name(device),
+		    fwupd_device_get_version(device),
+		    fwupd_release_get_version(release));
 	} else {
-		/* TRANSLATORS: message letting the user know an upgrade is available
-		 * %1 is the device name and %2 is a version string */
-		g_string_append_printf(title,
-				       _("Reinstall %s to %s?"),
-				       fwupd_device_get_name(device),
-				       fwupd_release_get_version(release));
+		g_string_append_printf(
+		    title,
+		    /* TRANSLATORS: message letting the user know an upgrade is available
+		     * %1 is the device name and %2 is a version string */
+		    _("Reinstall %s to %s?"),
+		    fwupd_device_get_name(device),
+		    fwupd_release_get_version(release));
 	}
 
 	/* description is optional */
@@ -443,9 +446,9 @@ fu_util_prompt_warning(FwupdDevice *device,
 		/* device may reboot */
 		if ((flags & FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE) == 0) {
 			g_string_append(str, "\n\n");
-			/* TRANSLATORS: warn the user before updating, %1 is a device name */
 			g_string_append_printf(
 			    str,
+			    /* TRANSLATORS: warn the user before updating, %1 is a device name */
 			    _("%s and all connected devices may not be usable while updating."),
 			    fwupd_device_get_name(device));
 
@@ -454,17 +457,19 @@ fu_util_prompt_warning(FwupdDevice *device,
 			g_string_append(str, "\n\n");
 			/* external device */
 			if ((flags & FWUPD_DEVICE_FLAG_INTERNAL) == 0) {
-				/* TRANSLATORS: warn the user before updating, %1 is a device name
-				 */
 				g_string_append_printf(str,
+						       /* TRANSLATORS: warn the user before
+							* updating, %1 is a device name
+							*/
 						       _("%s must remain connected for the "
 							 "duration of the update to avoid damage."),
 						       fwupd_device_get_name(device));
 			} else if (flags & FWUPD_DEVICE_FLAG_REQUIRE_AC) {
-				/* TRANSLATORS: warn the user before updating, %1 is a machine name
-				 */
 				g_string_append_printf(
 				    str,
+				    /* TRANSLATORS: warn the user before updating, %1 is a machine
+				     * name
+				     */
 				    _("%s must remain plugged into a power source for the duration "
 				      "of the update to avoid damage."),
 				    machine);
@@ -1301,11 +1306,12 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 			g_string_append_printf(verstr, " [%s]", datestr);
 		}
 		if (flags & FWUPD_DEVICE_FLAG_HISTORICAL) {
-			/* TRANSLATORS: version number of previous firmware */
-			fu_common_string_append_kv(str,
-						   idt + 1,
-						   _("Previous version"),
-						   verstr->str);
+			fu_common_string_append_kv(
+			    str,
+			    idt + 1,
+			    /* TRANSLATORS: version number of previous firmware */
+			    _("Previous version"),
+			    verstr->str);
 		} else {
 			/* TRANSLATORS: version number of current firmware */
 			fu_common_string_append_kv(str, idt + 1, _("Current version"), verstr->str);
@@ -1340,11 +1346,12 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 
 	/* branch */
 	if (fwupd_device_get_branch(dev) != NULL) {
-		/* TRANSLATORS: the stream of firmware, e.g. nonfree or open-source */
-		fu_common_string_append_kv(str,
-					   idt + 1,
-					   _("Release Branch"),
-					   fwupd_device_get_branch(dev));
+		fu_common_string_append_kv(
+		    str,
+		    idt + 1,
+		    /* TRANSLATORS: the stream of firmware, e.g. nonfree or open-source */
+		    _("Release Branch"),
+		    fwupd_device_get_branch(dev));
 	}
 
 	/* install duration */
@@ -1365,9 +1372,9 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 	/* update state */
 	state = fwupd_device_get_update_state(dev);
 	if (state != FWUPD_UPDATE_STATE_UNKNOWN) {
-		/* TRANSLATORS: hardware state, e.g. "pending" */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: hardware state, e.g. "pending" */
 					   _("Update State"),
 					   fu_util_update_state_to_string(state));
 
@@ -1376,11 +1383,12 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 			if (tmp != NULL) {
 				g_autofree gchar *color =
 				    fu_util_term_format(tmp, FU_UTIL_TERM_COLOR_BLUE);
-				/* TRANSLATORS: helpful messages from last update */
-				fu_common_string_append_kv(str,
-							   idt + 1,
-							   _("Update Message"),
-							   color);
+				fu_common_string_append_kv(
+				    str,
+				    idt + 1,
+				    /* TRANSLATORS: helpful messages from last update */
+				    _("Update Message"),
+				    color);
 			}
 		}
 	}
@@ -1421,11 +1429,12 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 			guid_src = g_strdup_printf("%s ← %s", guid, instance_id);
 		}
 		if (i == 0) {
-			/* TRANSLATORS: global ID common to all similar hardware */
-			fu_common_string_append_kv(str,
-						   idt + 1,
-						   ngettext("GUID", "GUIDs", guids->len),
-						   guid_src);
+			fu_common_string_append_kv(
+			    str,
+			    idt + 1,
+			    /* TRANSLATORS: global ID common to all similar hardware */
+			    ngettext("GUID", "GUIDs", guids->len),
+			    guid_src);
 		} else {
 			fu_common_string_append_kv(str, idt + 1, "", guid_src);
 		}
@@ -1637,36 +1646,38 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 	fu_common_string_append_kv(str, idt + 1, _("New version"), fwupd_release_get_version(rel));
 
 	if (fwupd_release_get_remote_id(rel) != NULL) {
-		/* TRANSLATORS: the server the file is coming from */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: the server the file is coming from */
 					   _("Remote ID"),
 					   fwupd_release_get_remote_id(rel));
 	}
 	if (fwupd_release_get_branch(rel) != NULL) {
-		/* TRANSLATORS: the stream of firmware, e.g. nonfree or open-source */
-		fu_common_string_append_kv(str,
-					   idt + 1,
-					   _("Branch"),
-					   fwupd_release_get_branch(rel));
+		fu_common_string_append_kv(
+		    str,
+		    idt + 1,
+		    /* TRANSLATORS: the stream of firmware, e.g. nonfree or open-source */
+		    _("Branch"),
+		    fwupd_release_get_branch(rel));
 	}
 	if (fwupd_release_get_summary(rel) != NULL) {
-		/* TRANSLATORS: one line summary of device */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: one line summary of device */
 					   _("Summary"),
 					   fwupd_release_get_summary(rel));
 	}
 	if (fwupd_release_get_name_variant_suffix(rel) != NULL) {
-		/* TRANSLATORS: one line variant of release (e.g. 'Prerelease' or 'China') */
-		fu_common_string_append_kv(str,
-					   idt + 1,
-					   _("Variant"),
-					   fwupd_release_get_name_variant_suffix(rel));
+		fu_common_string_append_kv(
+		    str,
+		    idt + 1,
+		    /* TRANSLATORS: one line variant of release (e.g. 'Prerelease' or 'China') */
+		    _("Variant"),
+		    fwupd_release_get_name_variant_suffix(rel));
 	}
-	/* TRANSLATORS: e.g. GPLv2+, Proprietary etc */
 	fu_common_string_append_kv(str,
 				   idt + 1,
+				   /* TRANSLATORS: e.g. GPLv2+, Proprietary etc */
 				   _("License"),
 				   fu_util_license_to_string(fwupd_release_get_license(rel)));
 	if (fwupd_release_get_size(rel) != 0) {
@@ -1684,30 +1695,30 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 	}
 	if (fwupd_release_get_urgency(rel) != FWUPD_RELEASE_URGENCY_UNKNOWN) {
 		FwupdReleaseUrgency tmp = fwupd_release_get_urgency(rel);
-		/* TRANSLATORS: how important the release is */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: how important the release is */
 					   _("Urgency"),
 					   fu_util_release_urgency_to_string(tmp));
 	}
 	if (fwupd_release_get_details_url(rel) != NULL) {
-		/* TRANSLATORS: more details about the update link */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: more details about the update link */
 					   _("Details"),
 					   fwupd_release_get_details_url(rel));
 	}
 	if (fwupd_release_get_source_url(rel) != NULL) {
-		/* TRANSLATORS: source (as in code) link */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: source (as in code) link */
 					   _("Source"),
 					   fwupd_release_get_source_url(rel));
 	}
 	if (fwupd_release_get_vendor(rel) != NULL) {
-		/* TRANSLATORS: manufacturer of hardware */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: manufacturer of hardware */
 					   _("Vendor"),
 					   fwupd_release_get_vendor(rel));
 	}
@@ -1718,9 +1729,9 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 		fu_common_string_append_kv(str, idt + 1, _("Duration"), tmp);
 	}
 	if (fwupd_release_get_update_message(rel) != NULL) {
-		/* TRANSLATORS: helpful messages for the update */
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: helpful messages for the update */
 					   _("Update Message"),
 					   fwupd_release_get_update_message(rel));
 	}
@@ -1748,11 +1759,12 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 	for (guint i = 0; i < issues->len; i++) {
 		const gchar *issue = g_ptr_array_index(issues, i);
 		if (i == 0) {
-			/* TRANSLATORS: issue fixed with the release, e.g. CVE */
-			fu_common_string_append_kv(str,
-						   idt + 1,
-						   ngettext("Issue", "Issues", issues->len),
-						   issue);
+			fu_common_string_append_kv(
+			    str,
+			    idt + 1,
+			    /* TRANSLATORS: issue fixed with the release, e.g. CVE */
+			    ngettext("Issue", "Issues", issues->len),
+			    issue);
 		} else {
 			fu_common_string_append_kv(str, idt + 1, "", issue);
 		}
@@ -1780,17 +1792,17 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 	/* TRANSLATORS: remote type, e.g. remote or local */
 	fu_common_string_append_kv(str, idt + 1, _("Type"), fwupd_remote_kind_to_string(kind));
 
-	/* TRANSLATORS: keyring type, e.g. GPG or PKCS7 */
 	if (keyring_kind != FWUPD_KEYRING_KIND_UNKNOWN) {
 		fu_common_string_append_kv(str,
 					   idt + 1,
+					   /* TRANSLATORS: keyring type, e.g. GPG or PKCS7 */
 					   _("Keyring"),
 					   fwupd_keyring_kind_to_string(keyring_kind));
 	}
 
-	/* TRANSLATORS: if the remote is enabled */
 	fu_common_string_append_kv(str,
 				   idt + 1,
+				   /* TRANSLATORS: if the remote is enabled */
 				   _("Enabled"),
 				   fwupd_remote_get_enabled(remote) ? "true" : "false");
 
@@ -1878,12 +1890,12 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 	if (tmp != NULL) {
 		/* TRANSLATORS: URI to send success/failure reports */
 		fu_common_string_append_kv(str, idt + 1, _("Report URI"), tmp);
-		/* TRANSLATORS: Boolean value to automatically send reports */
-		fu_common_string_append_kv(str,
-					   idt + 1,
-					   _("Automatic Reporting"),
-					   fwupd_remote_get_automatic_reports(remote) ? "true"
-										      : "false");
+		fu_common_string_append_kv(
+		    str,
+		    idt + 1,
+		    /* TRANSLATORS: Boolean value to automatically send reports */
+		    _("Automatic Reporting"),
+		    fwupd_remote_get_automatic_reports(remote) ? "true" : "false");
 	}
 
 	return g_string_free(str, FALSE);
@@ -2171,15 +2183,16 @@ fu_util_switch_branch_warning(FwupdDevice *dev,
 
 	/* warn the user if the vendor is different */
 	if (g_strcmp0(fwupd_device_get_vendor(dev), fwupd_release_get_vendor(rel)) != 0) {
-		/* TRANSLATORS: %1 is the firmware vendor, %2 is the device vendor name */
-		g_string_append_printf(desc_full,
-				       _("The firmware from %s is not "
-					 "supplied by %s, the hardware vendor."),
-				       fwupd_release_get_vendor(rel),
-				       fwupd_device_get_vendor(dev));
+		g_string_append_printf(
+		    desc_full,
+		    /* TRANSLATORS: %1 is the firmware vendor, %2 is the device vendor name */
+		    _("The firmware from %s is not "
+		      "supplied by %s, the hardware vendor."),
+		    fwupd_release_get_vendor(rel),
+		    fwupd_device_get_vendor(dev));
 		g_string_append(desc_full, "\n\n");
-		/* TRANSLATORS: %1 is the device vendor name */
 		g_string_append_printf(desc_full,
+				       /* TRANSLATORS: %1 is the device vendor name */
 				       _("Your hardware may be damaged using this firmware, "
 					 "and installing this release may void any warranty "
 					 "with %s."),
@@ -2228,9 +2241,9 @@ fu_util_show_unsupported_warn(void)
 		return;
 	/* TRANSLATORS: this is a prefix on the console */
 	fmt = fu_util_term_format(_("WARNING:"), FU_UTIL_TERM_COLOR_YELLOW);
-	/* TRANSLATORS: unsupported build of the package */
 	g_printerr("%s %s\n",
 		   fmt,
+		   /* TRANSLATORS: unsupported build of the package */
 		   _("This package has not been validated, it may not work properly."));
 #endif
 }

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1209,9 +1209,9 @@ fu_util_report_history(FuUtilPrivate *priv, gchar **values, GError **error)
 		}
 	}
 
-	/* TRANSLATORS: success message -- where the user has uploaded
-	 * success and/or failure reports to the remote server */
 	g_string_append_printf(str,
+			       /* TRANSLATORS: success message -- where the user has uploaded
+				* success and/or failure reports to the remote server */
 			       ngettext("Successfully uploaded %u report",
 					"Successfully uploaded %u reports",
 					g_hash_table_size(report_map)),
@@ -1514,8 +1514,8 @@ fu_util_download_metadata(FuUtilPrivate *priv, GError **error)
 	 * about available firmware on the remote server */
 	g_string_append(str, _("Successfully downloaded new metadata: "));
 
-	/* TRANSLATORS: how many local devices can expect updates now */
 	g_string_append_printf(str,
+			       /* TRANSLATORS: how many local devices can expect updates now */
 			       ngettext("%u local device supported",
 					"%u local devices supported",
 					devices_supported_cnt),
@@ -2089,9 +2089,9 @@ fu_util_update_all(FuUtilPrivate *priv, GError **error)
 			continue;
 		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_SUPPORTED)) {
 			if (!no_updates_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available due to missing on LVFS */
 				g_printerr("%s\n",
+					   /* TRANSLATORS: message letting the user know no device
+					    * upgrade available due to missing on LVFS */
 					   _("Devices with no available firmware updates: "));
 				no_updates_header = TRUE;
 			}
@@ -2109,10 +2109,10 @@ fu_util_update_all(FuUtilPrivate *priv, GError **error)
 						 &error_local);
 		if (rels == NULL) {
 			if (!latest_header) {
-				/* TRANSLATORS: message letting the user know no device upgrade
-				 * available */
 				g_printerr(
 				    "%s\n",
+				    /* TRANSLATORS: message letting the user know no device upgrade
+				     * available */
 				    _("Devices with the latest available firmware version:"));
 				latest_header = TRUE;
 			}
@@ -2359,9 +2359,9 @@ fu_util_downgrade(FuUtilPrivate *priv, gchar **values, GError **error)
 	/* get the releases for this device and filter for validity */
 	rels = fwupd_client_get_downgrades(priv->client, fwupd_device_get_id(dev), NULL, error);
 	if (rels == NULL) {
-		/* TRANSLATORS: message letting the user know no device downgrade available
-		 * %1 is the device name */
 		g_autofree gchar *downgrade_str =
+		    /* TRANSLATORS: message letting the user know no device downgrade available
+		     * %1 is the device name */
 		    g_strdup_printf(_("No downgrades for %s"), fwupd_device_get_name(dev));
 		g_prefix_error(error, "%s: ", downgrade_str);
 		return FALSE;
@@ -2649,8 +2649,8 @@ fu_util_activate(FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION))
 			continue;
-		/* TRANSLATORS: shown when shutting down to switch to the new version */
 		g_print("%s %s…\n",
+			/* TRANSLATORS: shown when shutting down to switch to the new version */
 			_("Activating firmware update for"),
 			fwupd_device_get_name(device));
 		if (!fwupd_client_activate(priv->client, NULL, fwupd_device_get_id(device), error))
@@ -2724,10 +2724,10 @@ fu_util_get_approved_firmware(FuUtilPrivate *priv, gchar **values, GError **erro
 		 * the domain administrator */
 		g_print("%s\n", _("There is no approved firmware."));
 	} else {
-		/* TRANSLATORS: approved firmware has been checked by
-		 * the domain administrator */
 		g_print(
 		    "%s\n",
+		    /* TRANSLATORS: approved firmware has been checked by
+		     * the domain administrator */
 		    ngettext("Approved firmware:", "Approved firmware:", g_strv_length(checksums)));
 		for (guint i = 0; checksums[i] != NULL; i++)
 			g_print(" * %s\n", checksums[i]);
@@ -2998,8 +2998,8 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 	if (priv->as_json)
 		return fu_util_security_as_json(priv, attrs, error);
 
-	/* TRANSLATORS: this is a string like 'HSI:2-U' */
 	g_print("%s \033[1m%s\033[0m\n",
+		/* TRANSLATORS: this is a string like 'HSI:2-U' */
 		_("Host Security ID:"),
 		fwupd_client_get_host_security_id(priv->client));
 
@@ -3801,9 +3801,9 @@ main(int argc, char *argv[])
 		g_autofree gchar *fmt = NULL;
 		/* TRANSLATORS: this is a prefix on the console */
 		fmt = fu_util_term_format(_("WARNING:"), FU_UTIL_TERM_COLOR_RED);
-		/* TRANSLATORS: try to help */
 		g_printerr("%s %s\n",
 			   fmt,
+			   /* TRANSLATORS: try to help */
 			   _("Ignoring SSL strict checks, "
 			     "to do this automatically in the future "
 			     "export DISABLE_SSL_STRICT in your environment"));
@@ -3816,9 +3816,9 @@ main(int argc, char *argv[])
 		g_autofree gchar *fmt = NULL;
 		/* TRANSLATORS: this is a prefix on the console */
 		fmt = fu_util_term_format(_("WARNING:"), FU_UTIL_TERM_COLOR_RED);
-		/* TRANSLATORS: try to help */
 		g_printerr("%s %s\n",
 			   fmt,
+			   /* TRANSLATORS: try to help */
 			   _("The system clock has not been set "
 			     "correctly and downloading files may fail."));
 	}
@@ -3840,8 +3840,8 @@ main(int argc, char *argv[])
 						&priv->filter_include,
 						&priv->filter_exclude,
 						&error)) {
-			/* TRANSLATORS: the user didn't read the man page */
 			g_print("%s: %s\n",
+				/* TRANSLATORS: the user didn't read the man page */
 				_("Failed to parse flags for --filter"),
 				error->message);
 			return EXIT_FAILURE;
@@ -3975,8 +3975,7 @@ main(int argc, char *argv[])
 	if (!ret) {
 		g_printerr("%s\n", error->message);
 		if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS)) {
-			/* TRANSLATORS: error message explaining command to run to how to get help
-			 */
+			/* TRANSLATORS: error message explaining command on how to get help */
 			g_printerr("\n%s\n", _("Use fwupdmgr --help for help"));
 		} else if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
 			g_debug("%s\n", error->message);


### PR DESCRIPTION
Doing clang-format on the codebase broke a few of these.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
