### PR TITLE
Mark as SUPPORTED even if on AC power

### DIFF
--- a/src/fu-engine-helper.c
+++ b/src/fu-engine-helper.c
@@ -17,12 +17,13 @@ gboolean
 fu_engine_update_motd(FuEngine *self, GError **error)
 {
 	guint upgrade_count = 0;
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GString) str = NULL;
 	g_autofree gchar *target = NULL;
 
 	/* a subset of what fwupdmgr can do */
+	request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	fu_engine_request_set_feature_flags(request,
 					    FWUPD_FEATURE_FLAG_DETACH_ACTION |
 						FWUPD_FEATURE_FLAG_UPDATE_ACTION);

--- a/src/fu-engine-request.c
+++ b/src/fu-engine-request.c
@@ -12,6 +12,7 @@
 
 struct _FuEngineRequest {
 	GObject parent_instance;
+	FuEngineRequestKind kind;
 	FwupdFeatureFlags feature_flags;
 	FwupdDeviceFlags device_flags;
 };
@@ -23,6 +24,13 @@ fu_engine_request_get_feature_flags(FuEngineRequest *self)
 {
 	g_return_val_if_fail(FU_IS_ENGINE_REQUEST(self), FALSE);
 	return self->feature_flags;
+}
+
+FuEngineRequestKind
+fu_engine_request_get_kind(FuEngineRequest *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE_REQUEST(self), FU_ENGINE_REQUEST_KIND_UNKNOWN);
+	return self->kind;
 }
 
 void
@@ -66,9 +74,10 @@ fu_engine_request_class_init(FuEngineRequestClass *klass)
 }
 
 FuEngineRequest *
-fu_engine_request_new(void)
+fu_engine_request_new(FuEngineRequestKind kind)
 {
 	FuEngineRequest *self;
 	self = g_object_new(FU_TYPE_ENGINE_REQUEST, NULL);
+	self->kind = kind;
 	return FU_ENGINE_REQUEST(self);
 }

--- a/src/fu-engine-request.h
+++ b/src/fu-engine-request.h
@@ -11,8 +11,16 @@
 #define FU_TYPE_ENGINE_REQUEST (fu_engine_request_get_type())
 G_DECLARE_FINAL_TYPE(FuEngineRequest, fu_engine_request, FU, ENGINE_REQUEST, GObject)
 
+typedef enum {
+	FU_ENGINE_REQUEST_KIND_UNKNOWN,
+	FU_ENGINE_REQUEST_KIND_ACTIVE,
+	FU_ENGINE_REQUEST_KIND_ONLY_SUPPORTED,
+} FuEngineRequestKind;
+
 FuEngineRequest *
-fu_engine_request_new(void);
+fu_engine_request_new(FuEngineRequestKind kind);
+FuEngineRequestKind
+fu_engine_request_get_kind(FuEngineRequest *self);
 FwupdFeatureFlags
 fu_engine_request_get_feature_flags(FuEngineRequest *self);
 void

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1755,7 +1755,8 @@ fu_engine_check_requirements(FuEngine *self,
 	g_autoptr(GPtrArray) reqs_soft = NULL;
 
 	/* all install task checks require a device */
-	if (device != NULL) {
+	if (device != NULL &&
+	    fu_engine_request_get_kind(request) == FU_ENGINE_REQUEST_KIND_ACTIVE) {
 		if (!fu_install_task_check_requirements(task, flags, error))
 			return FALSE;
 	}
@@ -3465,9 +3466,10 @@ fu_engine_ensure_device_supported(FuEngine *self, FuDevice *device)
 	gboolean is_supported = FALSE;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) releases = NULL;
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = NULL;
 
 	/* all flags set */
+	request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ONLY_SUPPORTED);
 	fu_engine_request_set_feature_flags(request, ~0);
 
 	/* get all releases that pass the requirements */

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -238,7 +238,7 @@ fu_main_create_request(FuMainPrivate *priv, const gchar *sender, GError **error)
 	FwupdFeatureFlags *feature_flags;
 	FwupdDeviceFlags device_flags = FWUPD_DEVICE_FLAG_NONE;
 	uid_t calling_uid = 0;
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GVariant) value = NULL;
 
 	g_return_val_if_fail(sender != NULL, NULL);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -197,7 +197,7 @@ fu_engine_requirements_missing_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -231,7 +231,7 @@ fu_engine_requirements_soft_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -265,7 +265,7 @@ fu_engine_requirements_client_fail_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -296,7 +296,7 @@ fu_engine_requirements_client_invalid_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -327,7 +327,7 @@ fu_engine_requirements_client_pass_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -361,7 +361,7 @@ fu_engine_requirements_version_require_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -410,7 +410,7 @@ fu_engine_requirements_unsupported_func(gconstpointer user_data)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	const gchar *xml = "<component>"
@@ -445,7 +445,7 @@ fu_engine_requirements_child_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) child = fu_device_new();
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -500,7 +500,7 @@ fu_engine_requirements_child_fail_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) child = fu_device_new();
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -555,7 +555,7 @@ fu_engine_requirements_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
 	g_autoptr(FuInstallTask) task = NULL;
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbSilo) silo = NULL;
@@ -591,7 +591,7 @@ fu_engine_requirements_device_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -648,7 +648,7 @@ fu_engine_requirements_device_plain_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -694,7 +694,7 @@ fu_engine_requirements_version_format_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -744,7 +744,7 @@ fu_engine_requirements_only_upgrade_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -795,7 +795,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	g_autoptr(FuDevice) unrelated_device3 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) parent = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task1 = NULL;
 	g_autoptr(FuInstallTask) task2 = NULL;
 	g_autoptr(GError) error = NULL;
@@ -895,7 +895,7 @@ fu_engine_requirements_other_device_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device1 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) device2 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -959,7 +959,7 @@ fu_engine_requirements_protocol_check_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device1 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) device2 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(FuInstallTask) task1 = NULL;
 	g_autoptr(FuInstallTask) task2 = NULL;
@@ -1045,7 +1045,7 @@ fu_engine_requirements_parent_device_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device1 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuDevice) device2 = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -1349,7 +1349,7 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(GBytes) blob_cab = NULL;
 	g_autoptr(GError) error = NULL;
@@ -1417,7 +1417,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GPtrArray) devices_pre = NULL;
@@ -1605,7 +1605,7 @@ fu_engine_install_duration_func(gconstpointer user_data)
 	gboolean ret;
 	g_autoptr(FuDevice) device = fu_device_new_with_context(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GPtrArray) releases = NULL;
@@ -3161,7 +3161,7 @@ fu_plugin_composite_func(gconstpointer user_data)
 	GError *error = NULL;
 	gboolean ret;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
-	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GPtrArray) components = NULL;
 	g_autoptr(GPtrArray) devices = NULL;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3106,7 +3106,7 @@ main(int argc, char *argv[])
 	priv->loop = g_main_loop_new(priv->main_ctx, FALSE);
 	priv->progressbar = fu_progressbar_new();
 	fu_progressbar_set_main_context(priv->progressbar, priv->main_ctx);
-	priv->request = fu_engine_request_new();
+	priv->request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
 
 	/* when not using the engine */
 	priv->progress = fu_progress_new(G_STRLOC);


### PR DESCRIPTION
This makes the 'Downloaded new metadata: N local devices supported'
message correct when refreshing on battery power.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
