### PR TITLE
redfish: Handle EPERM when testing devices with a IPMI device

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1253,7 +1253,11 @@ fu_udev_device_open(FuDevice *device, GError **error)
 		if (priv->fd < 0) {
 			g_set_error(error,
 				    G_IO_ERROR,
+#ifdef HAVE_ERRNO_H
+				    g_io_error_from_errno(errno),
+#else
 				    G_IO_ERROR_FAILED,
+#endif
 				    "failed to open %s: %s",
 				    priv->device_file,
 				    strerror(errno));

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -71,6 +71,10 @@ fu_test_redfish_ipmi_func(void)
 
 	/* create device */
 	locker = fu_device_locker_new(device, &error);
+	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED)) {
+		g_test_skip("permission denied for access to IPMI hardware");
+		return;
+	}
 	g_assert_no_error(error);
 	g_assert_nonnull(locker);
 	str = fu_device_to_string(FU_DEVICE(device));


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/3849

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
