### PR TITLE
rts54hub: Use demo firmware on the evaluation board for the tests

### DIFF
--- a/data/device-tests/realtek-rts5423.json
+++ b/data/device-tests/realtek-rts5423.json
@@ -3,12 +3,23 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/8568074e0eece0d695d5cb57e951fde848e3e3058b22b061ee4fd5dc7ca6ff23-Realtek-RTS5423-1.19.cab",
+      "url": "https://fwupd.org/downloads/460a18d93f5d6118908d8437009ebbd6eceb3c6a0cdfbaf31f8a96df008564da-Realtek-RTS5423-1.56.cab",
       "components": [
         {
-          "version": "1.19",
+          "version": "1.56",
           "guids": [
-            "42fc03f7-7a2d-5a50-a13b-610f2b7824c1"
+            "b2d2fae3-1546-5d16-a9af-ac117a255a91"
+          ]
+        }
+      ]
+    },
+    {
+      "url": "https://fwupd.org/downloads/3ee3dd129237648a97d7bf7d668184d074be2ac2a5143b3b242b9869dfafc4a9-Realtek-RTS5423-1.57.cab",
+      "components": [
+        {
+          "version": "1.57",
+          "guids": [
+            "b2d2fae3-1546-5d16-a9af-ac117a255a91"
           ]
         }
       ]

--- a/plugins/rts54hub/rts54hub.quirk
+++ b/plugins/rts54hub/rts54hub.quirk
@@ -1,5 +1,5 @@
 # RTS5423 Development Board
-[USB\VID_0BDA&PID_5423]
+[USB\VID_0BDA&PID_5B00]
 Plugin = rts54hub
 GType = FuRts54HubDevice
 FirmwareSizeMin = 0x20000
@@ -18,23 +18,6 @@ Plugin = rts54hub
 Name = HDMI Converter
 Flags = updatable
 FirmwareSize = 0x30000
-Rts54TargetAddr = 0x20
-Rts54I2cSpeed = 0x2
-Rts54RegisterAddrLen = 0x04
-
-# for-testing ID
-[USB\VID_0BDA&PID_5420]
-Plugin = rts54hub
-GType = FuRts54HubDevice
-FirmwareSizeMin = 0x10000
-FirmwareSizeMax = 0x40000
-Children = FuRts54hubRtd21xxBackground|USB\VID_0BDA&PID_5420&I2C_01
-[USB\VID_0BDA&PID_5420&I2C_01]
-Plugin = rts54hub
-Name = Honeybuns Dock
-Flags = updatable
-FirmwareSizeMin = 0x10000
-FirmwareSizeMax = 0x90000
 Rts54TargetAddr = 0x20
 Rts54I2cSpeed = 0x2
 Rts54RegisterAddrLen = 0x04


### PR DESCRIPTION
This avoids clashing with real-world devices that have the same VID/PID.
Many thanks to Ricky WU <ricky_wu@realtek.com> for all the help.

Fixes: https://github.com/fwupd/fwupd/issues/3835

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
