### PR TITLE
Add fu_usb_device_new_with_context() helpers

### DIFF
--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -48,7 +48,9 @@ typedef enum {
 } FuUdevDeviceFlags;
 
 FuUdevDevice *
-fu_udev_device_new(GUdevDevice *udev_device);
+fu_udev_device_new(GUdevDevice *udev_device) G_DEPRECATED_FOR(fu_udev_device_new_with_context);
+FuUdevDevice *
+fu_udev_device_new_with_context(FuContext *ctx, GUdevDevice *udev_device);
 GUdevDevice *
 fu_udev_device_get_dev(FuUdevDevice *self);
 void

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -585,7 +585,7 @@ fu_udev_device_bind_driver(FuDevice *device,
 	dev = fu_usb_device_find_udev_device(self, error);
 	if (dev == NULL)
 		return FALSE;
-	udev_device = fu_udev_device_new(dev);
+	udev_device = fu_udev_device_new_with_context(fu_device_get_context(device), dev);
 	return fu_device_bind_driver(FU_DEVICE(udev_device), subsystem, driver, error);
 }
 
@@ -600,8 +600,25 @@ fu_udev_device_unbind_driver(FuDevice *device, GError **error)
 	dev = fu_usb_device_find_udev_device(self, error);
 	if (dev == NULL)
 		return FALSE;
-	udev_device = fu_udev_device_new(dev);
+	udev_device = fu_udev_device_new_with_context(fu_device_get_context(device), dev);
 	return fu_device_unbind_driver(FU_DEVICE(udev_device), error);
+}
+
+/**
+ * fu_usb_device_new_with_context:
+ * @ctx: (nullable): a #FuContext
+ * @usb_device: a USB device
+ *
+ * Creates a new #FuUsbDevice.
+ *
+ * Returns: (transfer full): a #FuUsbDevice
+ *
+ * Since: 1.7.1
+ **/
+FuUsbDevice *
+fu_usb_device_new_with_context(FuContext *ctx, GUsbDevice *usb_device)
+{
+	return g_object_new(FU_TYPE_USB_DEVICE, "context", ctx, "usb-device", usb_device, NULL);
 }
 
 /**
@@ -617,9 +634,7 @@ fu_udev_device_unbind_driver(FuDevice *device, GError **error)
 FuUsbDevice *
 fu_usb_device_new(GUsbDevice *usb_device)
 {
-	FuUsbDevice *device = g_object_new(FU_TYPE_USB_DEVICE, NULL);
-	fu_usb_device_set_dev(device, usb_device);
-	return FU_USB_DEVICE(device);
+	return fu_usb_device_new_with_context(NULL, usb_device);
 }
 
 #ifdef HAVE_GUSB

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -29,7 +29,9 @@ struct _FuUsbDeviceClass {
 };
 
 FuUsbDevice *
-fu_usb_device_new(GUsbDevice *usb_device);
+fu_usb_device_new(GUsbDevice *usb_device) G_DEPRECATED_FOR(fu_usb_device_new_with_context);
+FuUsbDevice *
+fu_usb_device_new_with_context(FuContext *ctx, GUsbDevice *usb_device);
 guint16
 fu_usb_device_get_vid(FuUsbDevice *self);
 guint16

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -930,5 +930,7 @@ LIBFWUPDPLUGIN_1.7.1 {
     fu_common_check_full_disk_encryption;
     fu_common_mkdir;
     fu_device_add_string;
+    fu_udev_device_new_with_context;
+    fu_usb_device_new_with_context;
   local: *;
 } LIBFWUPDPLUGIN_1.7.0;

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -267,11 +267,12 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 	DOCK_INFO *dock_info;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
-	g_autoptr(FuUsbDevice) fake_usb_device = fu_usb_device_new(NULL);
+	g_autoptr(FuUsbDevice) fake_usb_device = NULL;
 	gulong added_id;
 	gulong register_id;
 
-	fu_device_set_context(FU_DEVICE(fake_usb_device), fu_plugin_get_context(self->plugin_dell));
+	fake_usb_device =
+	    fu_usb_device_new_with_context(fu_plugin_get_context(self->plugin_dell), NULL);
 	devices = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	added_id = g_signal_connect(self->plugin_uefi_capsule,
 				    "device-added",

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -591,13 +591,13 @@ fu_parade_lspcon_device_reload(FuDevice *device, GError **error)
 			    self->aux_device_name);
 		return FALSE;
 	}
-	aux_device = fu_udev_device_new(g_steal_pointer(&aux_devices->data));
+	aux_device = fu_udev_device_new_with_context(fu_device_get_context(device),
+						     g_steal_pointer(&aux_devices->data));
 	g_debug("using aux dev %s", fu_udev_device_get_sysfs_path(aux_device));
 
 	/* the following open() requires the device have IDs set */
 	if (!fu_udev_device_set_physical_id(aux_device, "drm_dp_aux_dev", error))
 		return FALSE;
-	fu_device_set_context(FU_DEVICE(aux_device), fu_device_get_context(device));
 
 	/* open device to read version from DPCD */
 	if ((aux_device_locker = fu_device_locker_new(aux_device, error)) == NULL)

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -181,9 +181,11 @@ fu_realtek_mst_device_use_aux_dev(FuRealtekMstDevice *self, GError **error)
 	 * I2C bus that runs over DPDDC on the port represented by the
 	 * drm_dp_aux_dev */
 	for (GList *element = matches; element != NULL; element = element->next) {
-		g_autoptr(FuUdevDevice) device = fu_udev_device_new(element->data);
+		g_autoptr(FuUdevDevice) device = NULL;
 		g_autoptr(GPtrArray) i2c_devices = NULL;
 
+		device = fu_udev_device_new_with_context(fu_device_get_context(FU_DEVICE(self)),
+							 element->data);
 		if (bus_device != NULL) {
 			g_debug("Ignoring additional aux device %s",
 				fu_udev_device_get_sysfs_path(device));
@@ -221,9 +223,11 @@ fu_realtek_mst_device_use_drm_card(FuRealtekMstDevice *self, GError **error)
 	g_udev_enumerator_add_match_name(enumerator, self->dp_card_kernel_name);
 	drm_devices = g_udev_enumerator_execute(enumerator);
 	for (GList *element = drm_devices; element != NULL; element = element->next) {
-		g_autoptr(FuUdevDevice) drm_device = fu_udev_device_new(element->data);
+		g_autoptr(FuUdevDevice) drm_device = NULL;
 		g_autoptr(GPtrArray) i2c_devices = NULL;
 
+		drm_device = fu_udev_device_new_with_context(fu_device_get_context(FU_DEVICE(self)),
+							     element->data);
 		if (bus_device != NULL) {
 			g_debug("Ignoring additional drm device %s",
 				fu_udev_device_get_sysfs_path(drm_device));

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -25,9 +25,11 @@ G_DEFINE_TYPE(FuUdevBackend, fu_udev_backend, FU_TYPE_BACKEND)
 static void
 fu_udev_backend_device_add(FuUdevBackend *self, GUdevDevice *udev_device)
 {
-	g_autoptr(FuUdevDevice) device = fu_udev_device_new(udev_device);
+	g_autoptr(FuUdevDevice) device = NULL;
 
 	/* success */
+	device =
+	    fu_udev_device_new_with_context(fu_backend_get_context(FU_BACKEND(self)), udev_device);
 	fu_backend_device_added(FU_BACKEND(self), FU_DEVICE(device));
 }
 

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -23,9 +23,10 @@ G_DEFINE_TYPE(FuUsbBackend, fu_usb_backend, FU_TYPE_BACKEND)
 static void
 fu_usb_backend_device_added_cb(GUsbContext *ctx, GUsbDevice *usb_device, FuBackend *backend)
 {
-	g_autoptr(FuUsbDevice) device = fu_usb_device_new(usb_device);
+	g_autoptr(FuUsbDevice) device = NULL;
 
 	/* success */
+	device = fu_usb_device_new_with_context(fu_backend_get_context(backend), usb_device);
 	fu_backend_device_added(backend, FU_DEVICE(device));
 }
 


### PR DESCRIPTION
This means the context is set at construction time, which is much less
fragile than setting the context manually.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
