### PR TITLE
Disallow unsigned firmware by default

### DIFF
--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -29,9 +29,9 @@
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
     <message>Authentication is required to update the firmware on this machine</message>
     <defaults>
-      <allow_any>auth_admin</allow_any>
+      <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin_keep</allow_active>
+      <allow_active>no</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-internal-trusted</annotate>
   </action>
@@ -64,9 +64,9 @@
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
     <message>Authentication is required to update the firmware on a removable device</message>
     <defaults>
-      <allow_any>auth_admin</allow_any>
+      <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin_keep</allow_active>
+      <allow_active>no</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-hotplug-trusted</annotate>
   </action>


### PR DESCRIPTION
Currently if policy kit is enabled it will be used to verify the signature
on firmware archives.  If no signature is present in the archive a PK prompt
will come up to install it.

However if a user runs `sudo fwupdmgr install foo.cab` the PK prompt never comes up and
they might not be aware they have unsigned firmware they are installing.

During development unsigned firmware can still be installed using `fwupdtool`

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
