### PR TITLE
Add the missing PolicyKit actions for (un)trusted downgrade

### DIFF
--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -36,8 +36,8 @@
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-internal-trusted</annotate>
   </action>
 
-  <action id="org.freedesktop.fwupd.downgrade-internal">
-    <description>Install old version of system firmware</description>
+  <action id="org.freedesktop.fwupd.downgrade-internal-trusted">
+    <description>Install old version of signed system firmware</description>
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
     <message>Authentication is required to downgrade the firmware on this machine</message>
     <defaults>
@@ -46,6 +46,18 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-internal</annotate>
+  </action>
+
+  <action id="org.freedesktop.fwupd.downgrade-internal">
+    <description>Install old version of unsigned system firmware</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to downgrade the firmware on this machine</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.downgrade-internal-trusted</annotate>
   </action>
 
   <action id="org.freedesktop.fwupd.update-hotplug-trusted">
@@ -71,6 +83,17 @@
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-hotplug-trusted</annotate>
   </action>
 
+  <action id="org.freedesktop.fwupd.downgrade-hotplug-trusted">
+    <description>Install signed device firmware</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to downgrade the firmware on a removable device</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.freedesktop.fwupd.downgrade-hotplug">
     <description>Install unsigned device firmware</description>
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
@@ -80,7 +103,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.update-hotplug</annotate>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.downgrade-hotplug-trusted</annotate>
   </action>
 
   <action id="org.freedesktop.fwupd.device-unlock">

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -461,16 +461,22 @@ fu_install_task_get_action_id(FuInstallTask *self)
 {
 	/* relax authentication checks for removable devices */
 	if (!fu_device_has_flag(self->device, FWUPD_DEVICE_FLAG_INTERNAL)) {
-		if (self->is_downgrade)
+		if (self->is_downgrade) {
+			if (self->trust_flags & FWUPD_TRUST_FLAG_PAYLOAD)
+				return "org.freedesktop.fwupd.downgrade-hotplug-trusted";
 			return "org.freedesktop.fwupd.downgrade-hotplug";
+		}
 		if (self->trust_flags & FWUPD_TRUST_FLAG_PAYLOAD)
 			return "org.freedesktop.fwupd.update-hotplug-trusted";
 		return "org.freedesktop.fwupd.update-hotplug";
 	}
 
 	/* internal device */
-	if (self->is_downgrade)
+	if (self->is_downgrade) {
+		if (self->trust_flags & FWUPD_TRUST_FLAG_PAYLOAD)
+			return "org.freedesktop.fwupd.downgrade-internal-trusted";
 		return "org.freedesktop.fwupd.downgrade-internal";
+	}
 	if (self->trust_flags & FWUPD_TRUST_FLAG_PAYLOAD)
 		return "org.freedesktop.fwupd.update-internal-trusted";
 	return "org.freedesktop.fwupd.update-internal";


### PR DESCRIPTION
If we want to tighten the allowed actions, we need the actions to be
symmetric.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
