### PR TITLE
Only installing firmwares with signatures by default

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -46,3 +46,6 @@ UriSchemes=
 # Ignore power levels of devices when running updates
 IgnorePower=false
 
+# For systems using polkit for authorization, only support installing firmware
+# signed with a trusted key
+OnlyTrusted=true

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -40,3 +40,5 @@ gboolean
 fu_config_get_enumerate_all_devices(FuConfig *self);
 gboolean
 fu_config_get_ignore_power(FuConfig *self);
+gboolean
+fu_config_get_only_trusted(FuConfig *self);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -211,7 +211,7 @@ fu_engine_add_plugin(FuEngine *self, FuPlugin *plugin);
 void
 fu_engine_add_runtime_version(FuEngine *self, const gchar *component_id, const gchar *version);
 gboolean
-fu_engine_check_trust(FuInstallTask *task, GError **error);
+fu_engine_check_trust(FuEngine *self, FuInstallTask *task, GError **error);
 gboolean
 fu_engine_check_requirements(FuEngine *self,
 			     FuEngineRequest *request,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -874,7 +874,7 @@ fu_main_install_with_helper(FuMainAuthHelper *helper_ref, GError **error)
 				g_ptr_array_add(errors, g_steal_pointer(&error_local));
 				continue;
 			}
-			if (!fu_engine_check_trust(task, &error_local)) {
+			if (!fu_engine_check_trust(priv->engine, task, &error_local)) {
 				g_ptr_array_add(errors, g_steal_pointer(&error_local));
 				continue;
 			}


### PR DESCRIPTION
99.9999% of users are consuming firmware updates from the LVFS or
another trusted remote. It's far to easy to get a user to enter the
password to install an untrusted firmware, where the security
consequences are pretty dire.

Provide an escape-hatch for firmware engineers, but it does mean
editing a file in /etc as root. This seems like an acceptable level of
inconvenience.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
