### PR TITLE
elanfp plugin requires gusb

### DIFF
--- a/plugins/elanfp/meson.build
+++ b/plugins/elanfp/meson.build
@@ -1,3 +1,4 @@
+if get_option('gusb')
 cargs = ['-DG_LOG_DOMAIN="FuPluginElanfp"']
 
 install_data(['elanfp.quirk'],
@@ -27,3 +28,4 @@ shared_module('fu_plugin_elanfp',
     plugin_deps,
   ],
 )
+endif


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Similar fix like commit 9e4d1bc73ba9078654f3a6b0e4669c081ffa1161.

Fixes the following build error when building without gusb:
```
FAILED: plugins/elanfp/libfu_plugin_elanfp.so.p/fu-elanfp-device.c.o
x86_64-pc-linux-gnu-gcc -Iplugins/elanfp/libfu_plugin_elanfp.so.p -Iplugins/elanfp -I../fwupd-1.7.0/plugins/elanfp -I. -I../fwupd-1.7.0 -Ilibfwupd -I../fwupd-1.7.0/libfwupd -Ilibfwupdplugin -I../fwupd-1.7.0/libfwupdplugin -I/usr/include/libxmlb-2 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/lib64/libffi/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -I/usr/include/gudev-1.0 -I/usr/include/json-glib-1.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -Waggregate-return -Wunused -Warray-bounds -Wcast-align -Wclobbered -Wdeclaration-after-statement -Wdiscarded-qualifiers -Wduplicated-branches -Wduplicated-cond -Wempty-body -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-signedness -Wignored-qualifiers -Wimplicit-function-declaration -Winit-self -Wlogical-op -Wmaybe-uninitialized -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-cast-function-type -Wno-address-of-packed-member -Wno-unknown-pragmas -Wno-missing-field-initializers -Wno-strict-aliasing -Wno-suggest-attribute=format -Wno-unused-parameter -Wold-style-definition -Woverride-init -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing -Wstrict-prototypes -Wswitch-default -Wtype-limits -Wundef -Wuninitialized -Wunused-but-set-variable -Wunused-variable -Wvla -Wwrite-strings -fstack-protector-strong -DFWUPD_COMPILATION -D_DEFAULT_SOURCE -DFWUPD_DISABLE_DEPRECATED -D_BSD_SOURCE -D__BSD_VISIBLE -D_XOPEN_SOURCE=700 -D_GNU_SOURCE -O2 -pipe -march=znver2 -mno-clzero -mno-mwaitx -mno-wbnoinvd -frecord-gcc-switches -fPIC -pthread '-DG_LOG_DOMAIN="FuPluginElanfp"' -MD -MQ plugins/elanfp/libfu_plugin_elanfp.so.p/fu-elanfp-device.c.o -MF plugins/elanfp/libfu_plugin_elanfp.so.p/fu-elanfp-device.c.o.d -o plugins/elanfp/libfu_plugin_elanfp.so.p/fu-elanfp-device.c.o -c ../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c: In function ‘fu_elanfp_device_open’:
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:58:14: warning: implicit declaration of function ‘g_usb_device_claim_interface’ [-Wimplicit-function-declaration]
   58 |         if (!g_usb_device_claim_interface(usb_device,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:58:14: warning: nested extern declaration of ‘g_usb_device_claim_interface’ [-Wnested-externs]
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:60:43: error: ‘G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER’ undeclared (first use in this function)
   60 |                                           G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
      |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:60:43: note: each undeclared identifier is reported only once for each function it appears in
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c: In function ‘fu_elanfp_device_close’:
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:75:14: warning: implicit declaration of function ‘g_usb_device_release_interface’ [-Wimplicit-function-declaration]
   75 |         if (!g_usb_device_release_interface(usb_device,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:75:14: warning: nested extern declaration of ‘g_usb_device_release_interface’ [-Wnested-externs]
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:77:45: error: ‘G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER’ undeclared (first use in this function)
   77 |                                             G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c: In function ‘fu_elanfp_iap_send_command’:
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:110:14: warning: implicit declaration of function ‘g_usb_device_control_transfer’ [-Wimplicit-function-declaration]
  110 |         if (!g_usb_device_control_transfer(usb_device,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:110:14: warning: nested extern declaration of ‘g_usb_device_control_transfer’ [-Wnested-externs]
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:111:44: error: ‘G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE’ undeclared (first use in this function)
  111 |                                            G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:112:44: error: ‘G_USB_DEVICE_REQUEST_TYPE_VENDOR’ undeclared (first use in this function)
  112 |                                            G_USB_DEVICE_REQUEST_TYPE_VENDOR,
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:113:44: error: ‘G_USB_DEVICE_RECIPIENT_INTERFACE’ undeclared (first use in this function)
  113 |                                            G_USB_DEVICE_RECIPIENT_INTERFACE,
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c: In function ‘fu_elanfp_iap_recv_status’:
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:145:14: warning: implicit declaration of function ‘g_usb_device_bulk_transfer’ [-Wimplicit-function-declaration]
  145 |         if (!g_usb_device_bulk_transfer(usb_device,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~
../fwupd-1.7.0/plugins/elanfp/fu-elanfp-device.c:145:14: warning: nested extern declaration of ‘g_usb_device_bulk_transfer’ [-Wnested-externs]
```