### PR TITLE
trivial: Fix a fuzzing crash for a corrupt IFD image

### DIFF
--- a/libfwupdplugin/fu-efi-firmware-file.c
+++ b/libfwupdplugin/fu-efi-firmware-file.c
@@ -291,6 +291,16 @@ fu_efi_firmware_file_write_sections(FuFirmware *firmware, GError **error)
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
+	/* sanity check */
+	if (fu_firmware_get_alignment(firmware) > FU_FIRMWARE_ALIGNMENT_1M) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "alignment invalid, got 0x%02x",
+			    fu_firmware_get_alignment(firmware));
+		return NULL;
+	}
+
 	/* no sections defined */
 	if (images->len == 0)
 		return fu_firmware_get_bytes(firmware, error);

--- a/libfwupdplugin/fu-efi-firmware-filesystem.c
+++ b/libfwupdplugin/fu-efi-firmware-filesystem.c
@@ -72,6 +72,16 @@ fu_efi_firmware_filesystem_write(FuFirmware *firmware, GError **error)
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 
+	/* sanity check */
+	if (fu_firmware_get_alignment(firmware) > FU_FIRMWARE_ALIGNMENT_1M) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "alignment invalid, got 0x%02x",
+			    fu_firmware_get_alignment(firmware));
+		return NULL;
+	}
+
 	/* add each file */
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);


### PR DESCRIPTION
Sanity check the alignment so we do not write gigabytes of 0xFF's.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39982

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
