### PR TITLE
Set the verfmt of the returned device when the daemon device is unset

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -52,3 +52,7 @@ void
 fu_device_set_private_flags(FuDevice *self, guint64 flag);
 void
 fu_device_set_progress(FuDevice *self, FuProgress *progress);
+FuDeviceInternalFlags
+fu_device_get_internal_flags(FuDevice *self);
+void
+fu_device_set_internal_flags(FuDevice *self, FuDeviceInternalFlags flag);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -336,6 +336,40 @@ fu_device_has_internal_flag(FuDevice *self, FuDeviceInternalFlags flag)
 	g_return_val_if_fail(FU_IS_DEVICE(self), FALSE);
 	return (priv->internal_flags & flag) > 0;
 }
+/**
+ * fu_device_get_internal_flags:
+ * @self: a #FuDevice
+ *
+ * Gets all the internal flags.
+ *
+ * Returns: flags, e.g. %FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON
+ *
+ * Since: 1.7.1
+ **/
+FuDeviceInternalFlags
+fu_device_get_internal_flags(FuDevice *self)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_UNKNOWN);
+	return priv->internal_flags;
+}
+
+/**
+ * fu_device_set_internal_flags:
+ * @self: a #FuDevice
+ * @flags: internal device flags, e.g. %FU_DEVICE_INTERNAL_FLAG_MD_SET_ICON
+ *
+ * Sets the internal flags.
+ *
+ * Since: 1.7.1
+ **/
+void
+fu_device_set_internal_flags(FuDevice *self, FuDeviceInternalFlags flags)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_DEVICE(self));
+	priv->internal_flags = flags;
+}
 
 /**
  * fu_device_add_private_flag:

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -930,6 +930,8 @@ LIBFWUPDPLUGIN_1.7.1 {
     fu_common_check_full_disk_encryption;
     fu_common_mkdir;
     fu_device_add_string;
+    fu_device_get_internal_flags;
+    fu_device_set_internal_flags;
     fu_udev_device_new_with_context;
     fu_usb_device_new_with_context;
   local: *;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4243,6 +4243,7 @@ fu_engine_get_result_from_component(FuEngine *self,
 		if (device != NULL) {
 			fu_device_set_name(dev, fu_device_get_name(device));
 			fu_device_set_flags(dev, fu_device_get_flags(device));
+			fu_device_set_internal_flags(dev, fu_device_get_internal_flags(device));
 			fu_device_set_id(dev, fu_device_get_id(device));
 			fu_device_set_version_raw(dev, fu_device_get_version_raw(device));
 			fu_device_set_version_format(dev, fu_device_get_version_format(device));


### PR DESCRIPTION
This regressed in 1.5.5 when we migrated FWUPD_DEVICE_FLAG_MD_SET_VERFMT
into FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT and forgot to copy the system
device internal flags.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
