### PR TITLE
Show translated firmware release notes when provided

### DIFF
--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -478,5 +478,7 @@ fwupd_client_upload_bytes_finish(FwupdClient *self,
 				 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fwupd_client_ensure_networking(FwupdClient *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fwupd_client_add_hint(FwupdClient *self, const gchar *key, const gchar *value);
 
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -709,3 +709,9 @@ LIBFWUPD_1.7.0 {
     fwupd_security_attr_has_guid;
   local: *;
 } LIBFWUPD_1.6.2;
+
+LIBFWUPD_1.7.1 {
+  global:
+    fwupd_client_add_hint;
+  local: *;
+} LIBFWUPD_1.7.0;

--- a/src/fu-engine-request.c
+++ b/src/fu-engine-request.c
@@ -15,6 +15,7 @@ struct _FuEngineRequest {
 	FuEngineRequestKind kind;
 	FwupdFeatureFlags feature_flags;
 	FwupdDeviceFlags device_flags;
+	gchar *locale;
 };
 
 G_DEFINE_TYPE(FuEngineRequest, fu_engine_request, G_TYPE_OBJECT)
@@ -24,6 +25,13 @@ fu_engine_request_get_feature_flags(FuEngineRequest *self)
 {
 	g_return_val_if_fail(FU_IS_ENGINE_REQUEST(self), FALSE);
 	return self->feature_flags;
+}
+
+const gchar *
+fu_engine_request_get_locale(FuEngineRequest *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE_REQUEST(self), NULL);
+	return self->locale;
 }
 
 FuEngineRequestKind
@@ -38,6 +46,17 @@ fu_engine_request_set_feature_flags(FuEngineRequest *self, FwupdFeatureFlags fea
 {
 	g_return_if_fail(FU_IS_ENGINE_REQUEST(self));
 	self->feature_flags = feature_flags;
+}
+
+void
+fu_engine_request_set_locale(FuEngineRequest *self, const gchar *locale)
+{
+	g_return_if_fail(FU_IS_ENGINE_REQUEST(self));
+	self->locale = g_strdup(locale);
+
+	/* remove the UTF8 suffix as it is not present in the XML */
+	if (self->locale != NULL)
+		g_strdelimit(self->locale, ".", '\0');
 }
 
 gboolean

--- a/src/fu-engine-request.h
+++ b/src/fu-engine-request.h
@@ -25,6 +25,10 @@ FwupdFeatureFlags
 fu_engine_request_get_feature_flags(FuEngineRequest *self);
 void
 fu_engine_request_set_feature_flags(FuEngineRequest *self, FwupdFeatureFlags feature_flags);
+const gchar *
+fu_engine_request_get_locale(FuEngineRequest *self);
+void
+fu_engine_request_set_locale(FuEngineRequest *self, const gchar *locale);
 gboolean
 fu_engine_request_has_feature_flag(FuEngineRequest *self, FwupdFeatureFlags feature_flag);
 FwupdDeviceFlags

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -308,6 +308,25 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='SetHints'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Sets optional hints from the client that may affect the list of devices.
+            A typical hint might be <doc:tt>locale</doc:tt> and unknown hints should be ignored.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='a{ss}' name='hints' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>An array of string key values.</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='Install'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
Send the users locale to the daemon so that it can be used to prefer
the localized update text over the default en_US version.

    $ LANG=fr_FR.UTF8 fwupdmgr get-details test.cab
    ...
    └─ACME Plan 9:
          Nouvelle version: 0.0.5
          Licence:          Propriétaire
          Urgence:          Faible
          Fournisseur:      ACME Ltd.
          Description:      Cette version stable corrige des bugs.

I decided to send the locale to the daemon rather than change the
`Description` to return GVariant to `a{ss}` as we also probably want
to support things like localized summary and URLs too in the future.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
