### PR TITLE
trivial: move freebsd CI to a nightly build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,40 @@
+name: FreeBSD daily Builds
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build-freebsd:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    name: build-freebsd-package
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Find tag
+      id: tagger
+      uses: jimschubert/query-tag-action@v1
+    - name: Build
+      id: test
+      uses: vmactions/freebsd-vm@v0.1.5
+      with:
+        usesh: true
+        mem: 8192
+        prepare: |
+          pkg install -y git python3 glib meson pkgconf gobject-introspection \
+            vala gtk-doc json-glib gpgme gnutls sqlite3 curl gcab libarchive \
+            libelf libgpg-error gettext-tools gtk-update-icon-cache atk pango \
+            binutils gcc protobuf-c
+        sync: rsync
+        run: ./contrib/ci/build_freebsd_package.sh
+          --GITHUB_SHA=${GITHUB_SHA}
+          --GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}
+          --GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+          --GITHUB_TAG=${{steps.tagger.outputs.tag}}
+    - name: Upload fwupd binary artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Binary package
+        path: |
+          fwupd*.pkg
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,37 +77,3 @@ jobs:
         name: artifacts
         path: ./out/artifacts
 
-  build-freebsd:
-    runs-on: macos-latest
-    timeout-minutes: 20
-    name: build-freebsd-package
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Find tag
-      id: tagger
-      uses: jimschubert/query-tag-action@v1
-    - name: Build
-      id: test
-      uses: vmactions/freebsd-vm@v0.1.5
-      with:
-        usesh: true
-        mem: 8192
-        prepare: |
-          pkg install -y git python3 glib meson pkgconf gobject-introspection \
-            vala gtk-doc json-glib gpgme gnutls sqlite3 curl gcab libarchive \
-            libelf libgpg-error gettext-tools gtk-update-icon-cache atk pango \
-            binutils gcc protobuf-c
-        sync: rsync
-        run: ./contrib/ci/build_freebsd_package.sh
-          --GITHUB_SHA=${GITHUB_SHA}
-          --GITHUB_REPOSITORY_OWNER=${GITHUB_REPOSITORY_OWNER}
-          --GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
-          --GITHUB_TAG=${{steps.tagger.outputs.tag}}
-    - name: Upload fwupd binary artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: Binary package
-        path: |
-          fwupd*.pkg
-


### PR DESCRIPTION
It currently has a timeout of 20 minutes but the job times out constantly.
This is wasting valuable CI minutes.

Move it to 30 minutes and only run it once a day.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
