### PR TITLE
synaptics-rmi: fix meson configure when building tests

### DIFF
--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -39,8 +39,6 @@ shared_module('fu_plugin_synaptics_rmi',
   ],
 )
 
-endif
-
 if get_option('tests')
   install_data(['tests/synaptics-rmi-0x.builder.xml','tests/synaptics-rmi-10.builder.xml'],
     install_dir: join_paths(installed_test_datadir, 'tests'))
@@ -72,4 +70,5 @@ if get_option('tests')
     install_dir : installed_test_bindir,
   )
   test('synaptics-rmi-self-test', e, env : env)
+endif
 endif


### PR DESCRIPTION
if synaptics-rmi is disabled and gnutls is not used, the configure fails

move the synaptics-rmi test check behind the "plugin_synaptics_rmi" option

the issue presents as:
```
plugins/synaptics-rmi/meson.build:44:2: ERROR: Unknown variable "gnutls".
```

Type of pull request:
- [x] Code fix
