### PR TITLE
uefi-recovery: Set the device context to remove a daemon warning

### DIFF
--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -32,7 +32,7 @@ fu_plugin_coldplug(FuPlugin *plugin, GError **error)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	GPtrArray *hwids = fu_context_get_hwid_guids(ctx);
 	const gchar *dmi_vendor;
-	g_autoptr(FuDevice) device = fu_device_new();
+	g_autoptr(FuDevice) device = fu_device_new_with_context(fu_plugin_get_context(plugin));
 	fu_device_set_id(device, "uefi-recovery");
 	fu_device_set_name(device, "System Firmware ESRT Recovery");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
