### PR TITLE
build: check that outb is present in io.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -308,7 +308,7 @@ endif
 if cc.has_header('sys/socket.h')
   conf.set('HAVE_SOCKET_H', '1')
 endif
-if cc.has_header('sys/io.h')
+if cc.has_header('sys/io.h') and cc.has_function('outb', prefix: '#include <sys/io.h>')
   conf.set('HAVE_IO_H', '1')
 endif
 if cc.has_header('linux/ethtool.h')


### PR DESCRIPTION
The flashrom plugin can use inb/outb to do a CMOS reset. The build gates
this on whether io.h exists (since bc43ad), but on musl the io.h header
can exist but inb/outb won't be defined.

Thus, fwupd builds with musl on non-x86 platforms will fail to link. Fix
this by checking for both io.h and that outb() is defined.

Signed-off-by: Ross Burton <ross.burton@arm.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
