### PR TITLE
trivial: remove outdated comment

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -597,7 +597,6 @@ fu_plugin_has_custom_flag(FuPlugin *self, const gchar *flag)
 	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
 	g_return_val_if_fail(flag != NULL, FALSE);
 
-	/* never set up, e.g. in tests */
 	return fu_context_has_hwid_flag(priv->ctx, flag);
 }
 


### PR DESCRIPTION
This comment became outdated with #3940, where the `NULL` check for `priv->ctx` that followed by early return was removed

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
