### PR TITLE
dfu: Fix all devices that rely on use-any-interface

### DIFF
--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -274,8 +274,8 @@ fu_dfu_device_add_targets(FuDfuDevice *self, GError **error)
 		GUsbInterface *iface = g_ptr_array_index(ifaces, i);
 
 		/* some devices don't use the right class and subclass */
-		if (fu_device_has_private_flag(FU_DEVICE(self),
-					       FU_DFU_DEVICE_FLAG_USE_ANY_INTERFACE)) {
+		if (!fu_device_has_private_flag(FU_DEVICE(self),
+						FU_DFU_DEVICE_FLAG_USE_ANY_INTERFACE)) {
 			if (g_usb_interface_get_class(iface) !=
 			    G_USB_DEVICE_CLASS_APPLICATION_SPECIFIC)
 				continue;


### PR DESCRIPTION
This was a regression caused in aaa77c6f513d65c38d70b95447460c8ed220dca5.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
