### PR TITLE
trivial: Use the device GType as the debugging root

### DIFF
--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -2740,20 +2740,18 @@ gchar *
 fwupd_device_to_string(FwupdDevice *self)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	GString *str;
+	GString *str = g_string_new(NULL);
 	g_autoptr(GPtrArray) guid_helpers = NULL;
 
 	g_return_val_if_fail(FWUPD_IS_DEVICE(self), NULL);
 
-	str = g_string_new("");
-	if (priv->name != NULL)
-		g_string_append_printf(str, "%s\n", priv->name);
-	else
-		str = g_string_append(str, "Unknown Device\n");
+	g_string_append_printf(str, "%s:\n", G_OBJECT_TYPE_NAME(self));
 	fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_DEVICE_ID, priv->id);
 	if (g_strcmp0(priv->composite_id, priv->parent_id) != 0)
 		fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_PARENT_DEVICE_ID, priv->parent_id);
 	fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_COMPOSITE_ID, priv->composite_id);
+	if (priv->name != NULL)
+		fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_NAME, priv->name);
 	if (priv->status != FWUPD_STATUS_UNKNOWN) {
 		fwupd_pad_kv_str(str,
 				 FWUPD_RESULT_KEY_STATUS,

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -439,8 +439,9 @@ fwupd_device_func(void)
 	str_ascii = g_string_new(str);
 	_g_string_replace(str_ascii, " ", " ");
 	ret = fu_test_compare_lines(str_ascii->str,
-				    "ColorHug2\n"
+				    "FwupdDevice:\n"
 				    "  DeviceId:             USB:foo\n"
+				    "  Name:                 ColorHug2\n"
 				    "  Guid:                 2082b5e0-7a64-478a-b1b2-e3404fab6dad\n"
 				    "  Guid:                 00000000-0000-0000-0000-000000000000\n"
 				    "  Flags:                updatable|require-ac\n"

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3310,9 +3310,6 @@ fu_device_add_string(FuDevice *self, guint idt, GString *str)
 
 	g_return_if_fail(locker != NULL);
 
-	/* subclassed type */
-	fu_common_string_append_kv(str, idt, G_OBJECT_TYPE_NAME(self), NULL);
-
 	tmp = fwupd_device_to_string(FWUPD_DEVICE(self));
 	if (tmp != NULL && tmp[0] != '\0')
 		g_string_append(str, tmp);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1762,7 +1762,6 @@ fu_device_private_flags_func(void)
 	g_assert_cmpstr(tmp,
 			==,
 			"FuDevice:\n"
-			"Unknown Device\n"
 			"  Flags:                none\n"
 			"  CustomFlags:          baz\n" /* compat */
 			"  PrivateFlags:         foo\n");

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1792,8 +1792,8 @@ fu_engine_history_func(gconstpointer user_data)
 	checksum = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, blob_cab);
 	device_str_expected =
 	    g_strdup_printf("FuDevice:\n"
-			    "Test Device\n"
 			    "  DeviceId:             894e8c17a29428b09d10cd90d1db74ea76fbcfe8\n"
+			    "  Name:                 Test Device\n"
 			    "  Guid:                 12345678-1234-1234-1234-123456789012\n"
 			    "  Plugin:               test\n"
 			    "  Flags:                updatable|historical\n"
@@ -2233,8 +2233,8 @@ fu_engine_history_error_func(gconstpointer user_data)
 	checksum = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, blob_cab);
 	device_str_expected =
 	    g_strdup_printf("FuDevice:\n"
-			    "Test Device\n"
 			    "  DeviceId:             894e8c17a29428b09d10cd90d1db74ea76fbcfe8\n"
+			    "  Name:                 Test Device\n"
 			    "  Guid:                 12345678-1234-1234-1234-123456789012\n"
 			    "  Plugin:               test\n"
 			    "  Flags:                updatable|historical\n"


### PR DESCRIPTION
We never show the fu_device_to_string() output to the user in normal
circumstances, and it's super useful for it to match the FuFirmware
format.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
