### PR TITLE
trivial: Crash the fuzzer on critical warning

### DIFF
--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -12,7 +12,10 @@ LLVMFuzzerTestOneInput (const guint8 *data, gsize size)
 {
 	g_autoptr(FuFirmware) firmware = FU_FIRMWARE (@FIRMWARENEW@ ());
 	g_autoptr(GBytes) fw = g_bytes_new (data, size);
-	gboolean ret = fu_firmware_parse (firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
+	gboolean ret;
+
+	g_setenv("G_DEBUG", "fatal-criticals", FALSE);
+	ret = fu_firmware_parse (firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag (firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		ret = fu_firmware_parse (firmware, fw,
 					 FWUPD_INSTALL_FLAG_NO_SEARCH |


### PR DESCRIPTION
We want to abort early rather than relying on other problems like segfault or OOM.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
