### PR TITLE
Export the component release ID over DBus

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -426,6 +426,10 @@ fwupd_build_history_report_json_device(JsonBuilder *builder, FwupdDevice *dev)
 		json_builder_end_array(builder);
 	}
 
+	/* allow matching the specific component */
+	json_builder_set_member_name(builder, "ReleaseId");
+	json_builder_add_string_value(builder, fwupd_release_get_id(rel));
+
 	/* include the protocol used */
 	if (fwupd_release_get_protocol(rel) != NULL) {
 		json_builder_set_member_name(builder, "Protocol");

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -19,6 +19,14 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_APPSTREAM_ID "AppstreamId"
 /**
+ * FWUPD_RESULT_KEY_RELEASE_ID:
+ *
+ * Result key to represent the release ID.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_RELEASE_ID "ReleaseId"
+/**
  * FWUPD_RESULT_KEY_CHECKSUM:
  *
  * Result key to represent Checksum

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -81,6 +81,10 @@ fwupd_release_get_protocol(FwupdRelease *self);
 void
 fwupd_release_set_protocol(FwupdRelease *self, const gchar *protocol);
 const gchar *
+fwupd_release_get_id(FwupdRelease *self);
+void
+fwupd_release_set_id(FwupdRelease *self, const gchar *id);
+const gchar *
 fwupd_release_get_appstream_id(FwupdRelease *self);
 void
 fwupd_release_set_appstream_id(FwupdRelease *self, const gchar *appstream_id);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -726,3 +726,10 @@ LIBFWUPD_1.7.1 {
     fwupd_security_attr_set_result_fallback;
   local: *;
 } LIBFWUPD_1.7.0;
+
+LIBFWUPD_1.7.2 {
+  global:
+    fwupd_release_get_id;
+    fwupd_release_set_id;
+  local: *;
+} LIBFWUPD_1.7.1;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -503,6 +503,9 @@ fu_engine_set_release_from_appstream(FuEngine *self,
 		return FALSE;
 	fwupd_release_set_version(rel, version_rel);
 
+	/* optional release ID -- currently a integer but maybe namespaced in the future */
+	fwupd_release_set_id(rel, xb_node_get_attr(release, "id"));
+
 	/* find the remote */
 	remote_id = xb_node_query_text(component, "../custom/value[@key='fwupd::RemoteId']", NULL);
 	if (remote_id != NULL) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1661,6 +1661,13 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 					   _("Remote ID"),
 					   fwupd_release_get_remote_id(rel));
 	}
+	if (fwupd_release_get_id(rel) != NULL) {
+		fu_common_string_append_kv(str,
+					   idt + 1,
+					   /* TRANSLATORS: the exact component on the server */
+					   _("Release ID"),
+					   fwupd_release_get_id(rel));
+	}
 	if (fwupd_release_get_branch(rel) != NULL) {
 		fu_common_string_append_kv(
 		    str,


### PR DESCRIPTION
This allows us to map a specific component on the LVFS without guessing
by using the generated checksum.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
