### PR TITLE
trivial: Fix build error with old meson versions

### DIFF
--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -46,7 +46,6 @@ if get_option('tests')
   e = executable(
     'tpm-self-test',
     fu_hash,
-    plugin_tpm,
     sources : [
       'fu-self-test.c',
       'fu-tpm-device.c',


### PR DESCRIPTION
On 0.58.1:

    ERROR: Bad source of type 'SharedModule' in target 'tpm-self-test'.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
