### PR TITLE
intel-spi: Use lowercase flag names

### DIFF
--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -510,8 +510,8 @@ fu_intel_spi_device_init(FuIntelSpiDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_icon(FU_DEVICE(self), "computer");
 	fu_device_set_physical_id(FU_DEVICE(self), "intel_spi");
-	fu_device_register_private_flag(FU_DEVICE(self), FU_INTEL_SPI_DEVICE_FLAG_ICH, "ICH");
-	fu_device_register_private_flag(FU_DEVICE(self), FU_INTEL_SPI_DEVICE_FLAG_PCH, "PCH");
+	fu_device_register_private_flag(FU_DEVICE(self), FU_INTEL_SPI_DEVICE_FLAG_ICH, "ich");
+	fu_device_register_private_flag(FU_DEVICE(self), FU_INTEL_SPI_DEVICE_FLAG_PCH, "pch");
 }
 
 static void

--- a/plugins/intel-spi/generate-quirk.py
+++ b/plugins/intel-spi/generate-quirk.py
@@ -24,15 +24,15 @@ if __name__ == "__main__":
         sys.exit(1)
 
     chipsets = {
-        "apl": Chipset(flags="PCH", bios_cntl=0xDC, spibar_proxy="00:0d.2"),
-        "c620": Chipset(flags="PCH", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
-        "ich0": Chipset(flags="ICH", bios_cntl=0x4E),
-        "ich2345": Chipset(flags="ICH", bios_cntl=0x4E),
-        "ich6": Chipset(flags="ICH", bios_cntl=0xDC),
-        "pch100": Chipset(flags="PCH", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
-        "pch300": Chipset(flags="PCH", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
-        "pch400": Chipset(flags="PCH", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
-        "poulsbo": Chipset(flags="ICH", bios_cntl=0xD8),
+        "apl": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:0d.2"),
+        "c620": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
+        "ich0": Chipset(flags="ich", bios_cntl=0x4E),
+        "ich2345": Chipset(flags="ich", bios_cntl=0x4E),
+        "ich6": Chipset(flags="ich", bios_cntl=0xDC),
+        "pch100": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
+        "pch300": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
+        "pch400": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
+        "poulsbo": Chipset(flags="ich", bios_cntl=0xD8),
     }
 
     devices = {"PCI\VEN_8086&DEV_A0A4": "pch100"}

--- a/plugins/intel-spi/intel-spi.quirk
+++ b/plugins/intel-spi/intel-spi.quirk
@@ -366,45 +366,45 @@ IntelSpiKind = pch300
 [INTEL_SPI_CHIPSET\APL]
 IntelSpiBarProxy = 00:0d.2
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\C620]
 IntelSpiBarProxy = 00:1f.5
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\ICH0]
 IntelSpiBiosCntl = 0x4E
-Flags = ICH
+Flags = ich
 
 [INTEL_SPI_CHIPSET\ICH2345]
 IntelSpiBiosCntl = 0x4E
-Flags = ICH
+Flags = ich
 
 [INTEL_SPI_CHIPSET\ICH6]
 IntelSpiBiosCntl = 0xDC
-Flags = ICH
+Flags = ich
 
 [INTEL_SPI_CHIPSET\PCH100]
 IntelSpiBarProxy = 00:1f.5
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\PCH200]
 IntelSpiBarProxy = 00:1f.5
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\PCH300]
 IntelSpiBarProxy = 00:1f.5
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\PCH400]
 IntelSpiBarProxy = 00:1f.5
 IntelSpiBiosCntl = 0xDC
-Flags = PCH
+Flags = pch
 
 [INTEL_SPI_CHIPSET\POULSBO]
 IntelSpiBiosCntl = 0xD8
-Flags = ICH
+Flags = ich


### PR DESCRIPTION
This was missed in the addition of 40c7f7ba21a58593c74ee5f5e4766e64036a3c4d

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
