### PR TITLE
Fix running the tests when fwupd is not installed

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -613,7 +613,6 @@ fwupd_client_set_hints_cb(GObject *source, GAsyncResult *res, gpointer user_data
 			g_task_return_boolean(task, TRUE);
 			return;
 		}
-		fwupd_client_fixup_dbus_error(error);
 		g_task_return_error(task, g_steal_pointer(&error));
 		return;
 	}

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -535,7 +535,8 @@ fwupd_client_devices_func(void)
 
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect(client, NULL, &error);
-	if (ret == FALSE && g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT)) {
+	if (ret == FALSE && (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))) {
 		g_debug("%s", error->message);
 		g_test_skip("timeout connecting to daemon");
 		return;
@@ -589,7 +590,8 @@ fwupd_client_remotes_func(void)
 
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect(client, NULL, &error);
-	if (ret == FALSE && g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT)) {
+	if (ret == FALSE && (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))) {
 		g_debug("%s", error->message);
 		g_test_skip("timeout connecting to daemon");
 		return;


### PR DESCRIPTION
This probably regressed in 70f9124545e35c1e55915594722f5aa8c7b7edcc as
the callers actually expect an error in the GDBusError domain, rather
than one fixed up in the FwupdError domain.

Fixes https://github.com/fwupd/fwupd/issues/4014

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
