### PR TITLE
Allow an option sync to a known set of firmware versions

### DIFF
--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -30,6 +30,7 @@ _fwupdmgr_cmd_list=(
 	'security'
 	'set-approved-firmware'
 	'switch-branch'
+	'sync-bkc'
 	'unlock'
 	'unblock-firmware'
 	'update'

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -49,6 +49,11 @@ IgnorePower=false
 # Only support installing firmware signed with a trusted key
 OnlyTrusted=true
 
+# A host best known configuration is used when using `fwupdmgr sync` which can
+# downgrade firmware to factory versions or upgrade firmware to a supported
+# config level. e.g. `vendor-factory-2021q1`
+HostBkc=
+
 # these are only required when the SMBIOS or Device Tree data is invalid or missing
 #Manufacturer=
 #ProductName=

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -370,6 +370,8 @@ fwupd_client_get_percentage(FwupdClient *self);
 const gchar *
 fwupd_client_get_daemon_version(FwupdClient *self);
 const gchar *
+fwupd_client_get_host_bkc(FwupdClient *self);
+const gchar *
 fwupd_client_get_host_product(FwupdClient *self);
 const gchar *
 fwupd_client_get_host_machine_id(FwupdClient *self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -736,6 +736,7 @@ LIBFWUPD_1.7.2 {
 
 LIBFWUPD_1.7.3 {
   global:
+    fwupd_client_get_host_bkc;
     fwupd_release_add_tag;
     fwupd_release_get_tags;
     fwupd_release_has_tag;

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -42,3 +42,5 @@ gboolean
 fu_config_get_ignore_power(FuConfig *self);
 gboolean
 fu_config_get_only_trusted(FuConfig *self);
+const gchar *
+fu_config_get_host_bkc(FuConfig *self);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6043,6 +6043,15 @@ fu_engine_get_host_machine_id(FuEngine *self)
 	return self->host_machine_id;
 }
 
+const gchar *
+fu_engine_get_host_bkc(FuEngine *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
+	if (fu_config_get_host_bkc(self->config) == NULL)
+		return "";
+	return fu_config_get_host_bkc(self->config);
+}
+
 #ifdef HAVE_HSI
 static void
 fu_engine_ensure_security_attrs_tainted(FuEngine *self)

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -64,6 +64,8 @@ fu_engine_get_host_product(FuEngine *self);
 const gchar *
 fu_engine_get_host_machine_id(FuEngine *self);
 const gchar *
+fu_engine_get_host_bkc(FuEngine *self);
+const gchar *
 fu_engine_get_host_security_id(FuEngine *self);
 FwupdStatus
 fu_engine_get_status(FuEngine *self);

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1798,6 +1798,9 @@ fu_main_daemon_get_property(GDBusConnection *connection_,
 	if (g_strcmp0(property_name, "DaemonVersion") == 0)
 		return g_variant_new_string(SOURCE_VERSION);
 
+	if (g_strcmp0(property_name, "HostBkc") == 0)
+		return g_variant_new_string(fu_engine_get_host_bkc(priv->engine));
+
 	if (g_strcmp0(property_name, "Tainted") == 0)
 		return g_variant_new_boolean(fu_engine_get_tainted(priv->engine));
 

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -23,6 +23,18 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='HostBkc' type='s' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The optional best known configuration to use when syncing back to a
+            known state, e.g. <doc:tt>vendor-factory-2021q1</doc:tt>.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='HostProduct' type='s' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
Install or downgrade firmware on all devices to make the system match
a well known set. This allows two things:

 * factory recovery where a device in the field has been upgraded
 * ensuring a consistent set of tested firmware for a specific workload

A tag is assigned either during upload or added post-upload on the LVFS
which is included in the metadata. A single firmware can be marked with
multiple tags, and tags can be duplicated for different firmwares.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
