### PR TITLE
Add support for LVFS component tags

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -35,6 +35,14 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_CHECKSUM "Checksum"
 /**
+ * FWUPD_RESULT_KEY_TAGS:
+ *
+ * Result key to represent release tags
+ *
+ * The D-Bus type signature string is 'as' i.e. an array of strings.
+ **/
+#define FWUPD_RESULT_KEY_TAGS "Tags"
+/**
  * FWUPD_RESULT_KEY_CREATED:
  *
  * Result key to represent Created

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -62,6 +62,12 @@ void
 fwupd_release_add_checksum(FwupdRelease *self, const gchar *checksum);
 gboolean
 fwupd_release_has_checksum(FwupdRelease *self, const gchar *checksum);
+GPtrArray *
+fwupd_release_get_tags(FwupdRelease *self);
+void
+fwupd_release_add_tag(FwupdRelease *self, const gchar *tag);
+gboolean
+fwupd_release_has_tag(FwupdRelease *self, const gchar *tag);
 
 GHashTable *
 fwupd_release_get_metadata(FwupdRelease *self);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -424,6 +424,8 @@ fwupd_device_func(void)
 	fwupd_release_set_size(rel, 1024);
 	fwupd_release_add_location(rel, "http://foo.com");
 	fwupd_release_add_location(rel, "ftp://foo.com");
+	fwupd_release_add_tag(rel, "vendor-2021q1");
+	fwupd_release_add_tag(rel, "vendor-2021q2");
 	fwupd_release_set_version(rel, "1.2.3");
 	fwupd_device_add_release(dev, rel);
 	str = fwupd_device_to_string(dev);
@@ -456,6 +458,8 @@ fwupd_device_func(void)
 				    "  Version:              1.2.3\n"
 				    "  Filename:             firmware.bin\n"
 				    "  Checksum:             SHA1(deadbeef)\n"
+				    "  Tags:                 vendor-2021q1\n"
+				    "  Tags:                 vendor-2021q2\n"
 				    "  Size:                 1.0 kB\n"
 				    "  Uri:                  http://foo.com\n"
 				    "  Uri:                  ftp://foo.com\n"
@@ -504,6 +508,10 @@ fwupd_device_func(void)
 				    "      \"Filename\" : \"firmware.bin\",\n"
 				    "      \"Checksum\" : [\n"
 				    "        \"deadbeef\"\n"
+				    "      ],\n"
+				    "      \"Tags\" : [\n"
+				    "        \"vendor-2021q1\",\n"
+				    "        \"vendor-2021q2\"\n"
 				    "      ],\n"
 				    "      \"Size\" : 1024,\n"
 				    "      \"Locations\" : [\n"

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -733,3 +733,11 @@ LIBFWUPD_1.7.2 {
     fwupd_release_set_id;
   local: *;
 } LIBFWUPD_1.7.1;
+
+LIBFWUPD_1.7.3 {
+  global:
+    fwupd_release_add_tag;
+    fwupd_release_get_tags;
+    fwupd_release_has_tag;
+  local: *;
+} LIBFWUPD_1.7.2;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4239,6 +4239,7 @@ fu_engine_get_result_from_component(FuEngine *self,
 	g_autoptr(FwupdRelease) rel = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) provides = NULL;
+	g_autoptr(GPtrArray) tags = NULL;
 	g_autoptr(XbNode) description = NULL;
 	g_autoptr(XbNode) release = NULL;
 #if LIBXMLB_CHECK_VERSION(0, 2, 0)
@@ -4284,6 +4285,15 @@ fu_engine_get_result_from_component(FuEngine *self,
 				    FWUPD_ERROR_INTERNAL,
 				    "component has no GUIDs");
 		return NULL;
+	}
+
+	/* add tags */
+	tags = xb_node_query(component, "tags/tag[@namespace=$'lvfs']", 0, NULL);
+	if (tags != NULL) {
+		for (guint i = 0; i < tags->len; i++) {
+			XbNode *tag = g_ptr_array_index(tags, i);
+			fwupd_release_add_tag(rel, xb_node_get_text(tag));
+		}
 	}
 
 	/* check we can install it */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1643,6 +1643,7 @@ gchar *
 fu_util_release_to_string(FwupdRelease *rel, guint idt)
 {
 	GPtrArray *issues = fwupd_release_get_issues(rel);
+	GPtrArray *tags = fwupd_release_get_tags(rel);
 	GString *str = g_string_new(NULL);
 	guint64 flags = fwupd_release_get_flags(rel);
 	g_autoptr(GString) flags_str = g_string_new(NULL);
@@ -1783,6 +1784,19 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 			    issue);
 		} else {
 			fu_common_string_append_kv(str, idt + 1, "", issue);
+		}
+	}
+	for (guint i = 0; i < tags->len; i++) {
+		const gchar *tag = g_ptr_array_index(tags, i);
+		if (i == 0) {
+			fu_common_string_append_kv(
+			    str,
+			    idt + 1,
+			    /* TRANSLATORS: release tag set for release, e.g. lenovo-2021q3 */
+			    ngettext("Tag", "Tags", tags->len),
+			    tag);
+		} else {
+			fu_common_string_append_kv(str, idt + 1, "", tag);
 		}
 	}
 


### PR DESCRIPTION
These allow us to tag components as being part of a set, e.g. a BKC.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
