### PR TITLE
thunderbolt retimer nvm update in NDA case WIP: thunderbolt: set ports offline on host controller

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -201,7 +201,7 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 		return "unreachable";
 	if (device_flag == FWUPD_DEVICE_FLAG_AFFECTS_FDE)
 		return "affects-fde";
-	if (device_flag == FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP)
+	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)
 		return "requires-wakeup";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
@@ -315,7 +315,7 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 	if (g_strcmp0(device_flag, "affects-fde") == 0)
 		return FWUPD_DEVICE_FLAG_AFFECTS_FDE;
 	if (g_strcmp0(device_flag, "requires-wakeup") == 0)
-		return FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP;
+		return FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -202,7 +202,7 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 	if (device_flag == FWUPD_DEVICE_FLAG_AFFECTS_FDE)
 		return "affects-fde";
 	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)
-		return "requires-wakeup";
+		return "no-auto-remove";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -314,7 +314,7 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_UNREACHABLE;
 	if (g_strcmp0(device_flag, "affects-fde") == 0)
 		return FWUPD_DEVICE_FLAG_AFFECTS_FDE;
-	if (g_strcmp0(device_flag, "requires-wakeup") == 0)
+	if (g_strcmp0(device_flag, "no-auto-remove") == 0)
 		return FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -201,6 +201,8 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 		return "unreachable";
 	if (device_flag == FWUPD_DEVICE_FLAG_AFFECTS_FDE)
 		return "affects-fde";
+	if (device_flag == FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP)
+		return "requires-wakeup";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -312,6 +314,8 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_UNREACHABLE;
 	if (g_strcmp0(device_flag, "affects-fde") == 0)
 		return FWUPD_DEVICE_FLAG_AFFECTS_FDE;
+	if (g_strcmp0(device_flag, "requires-wakeup") == 0)
+		return FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -472,6 +472,7 @@ typedef enum {
  */
 #define FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE (1llu << 43)
 /**
+<<<<<<< HEAD
  * FWUPD_DEVICE_FLAG_UNREACHABLE:
  *
  * The device is currently unreachable, perhaps because it is in a lower power state or is out of
@@ -495,12 +496,16 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_AFFECTS_FDE (1llu << 45)
 /**
  *
- * FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP :
  *
  * The device requires to be woken up to be re-enumerated.
- * Since 1.7.1
+ *
+ * FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE :
+ *
+ * The device requires to be woken up to be re-enumerated.
+ * Since 1.7.2
  */
-#define FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP (1llu << 46)
+
+#define FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE (1llu << 46)
 /**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -472,7 +472,6 @@ typedef enum {
  */
 #define FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE (1llu << 43)
 /**
-<<<<<<< HEAD
  * FWUPD_DEVICE_FLAG_UNREACHABLE:
  *
  * The device is currently unreachable, perhaps because it is in a lower power state or is out of

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -494,17 +494,14 @@ typedef enum {
  */
 #define FWUPD_DEVICE_FLAG_AFFECTS_FDE (1llu << 45)
 /**
- *
- *
- * The device requires to be woken up to be re-enumerated.
- *
- * FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE :
- *
- * The device requires to be woken up to be re-enumerated.
- * Since 1.7.2
- */
-
+*
+* FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE :
+*
+* The device is not auto removed.
+* Since 1.7.2
+*/
 #define FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE (1llu << 46)
+
 /**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -493,6 +493,9 @@ typedef enum {
  * Since: 1.7.1
  */
 #define FWUPD_DEVICE_FLAG_AFFECTS_FDE (1llu << 45)
+*FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP : **The device requires to be woken up to be re -
+    enumerated.**Since 1.6.5 * /
+#define FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP (1llu << 44)
 /**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *
@@ -502,12 +505,12 @@ typedef enum {
  * Since 0.7.3
  */
 #define FWUPD_DEVICE_FLAG_UNKNOWN G_MAXUINT64
-/**
- * FwupdDeviceFlags:
- *
- * Flags used to represent device attributes
- */
-typedef guint64 FwupdDeviceFlags;
+	/**
+	 * FwupdDeviceFlags:
+	 *
+	 * Flags used to represent device attributes
+	 */
+	typedef guint64 FwupdDeviceFlags;
 
 /**
  * FWUPD_RELEASE_FLAG_NONE:

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -493,9 +493,14 @@ typedef enum {
  * Since: 1.7.1
  */
 #define FWUPD_DEVICE_FLAG_AFFECTS_FDE (1llu << 45)
-*FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP : **The device requires to be woken up to be re -
-    enumerated.**Since 1.6.5 * /
-#define FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP (1llu << 44)
+/**
+ *
+ * FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP :
+ *
+ * The device requires to be woken up to be re-enumerated.
+ * Since 1.7.1
+ */
+#define FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP (1llu << 46)
 /**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *
@@ -505,12 +510,12 @@ typedef enum {
  * Since 0.7.3
  */
 #define FWUPD_DEVICE_FLAG_UNKNOWN G_MAXUINT64
-	/**
-	 * FwupdDeviceFlags:
-	 *
-	 * Flags used to represent device attributes
-	 */
-	typedef guint64 FwupdDeviceFlags;
+/**
+ * FwupdDeviceFlags:
+ *
+ * Flags used to represent device attributes
+ */
+typedef guint64 FwupdDeviceFlags;
 
 /**
  * FWUPD_RELEASE_FLAG_NONE:

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -82,7 +82,9 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 			  GError **error)
 {
 	  g_warning("debug from fu_plugin_update_prepare");
-	  return TRUE;
+	  if (device != NULL && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+		  return fu_thunderbolt_device_open(device,error);
+	  }
 }
 
 gboolean
@@ -92,5 +94,8 @@ fu_plugin_update_cleanup (FuPlugin *plugin,
 			  GError **error)
 {
 	g_warning("debug from fu_plugin_update_cleanup");
+	  if (device != NULL && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+		  return fu_thunderbolt_device_close(device, error);
+	  }
 	return TRUE;
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -76,25 +76,30 @@ fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 	vfuncs->device_registered = fu_plugin_thunderbolt_device_registered;
 	vfuncs->device_created = fu_plugin_thunderbolt_device_created;
 gboolean
-fu_plugin_update_prepare (FuPlugin *plugin,
-			  FwupdInstallFlags flags,
-			  FuDevice *device,
-			  GError **error)
+fu_plugin_composite_prepare (FuPlugin *plugin,
+			     GPtrArray *devices,
+			     GError **error)
 {
-	  if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
-		  return fu_thunderbolt_device_open(device,error);
-	  }
-	  return TRUE;
+	for (guint i = 0; i < devices->len; i++) {
+		FuDevice *device = g_ptr_array_index (devices, i);
+		if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+			return fu_thunderbolt_device_open(device,error);
+		}
+	}
+	return TRUE;
 }
 
+
 gboolean
-fu_plugin_update_cleanup (FuPlugin *plugin,
-			  FwupdInstallFlags flags,
-			  FuDevice *device,
-			  GError **error)
+fu_plugin_composite_cleanup	(FuPlugin	*plugin,
+							 GPtrArray	*devices,
+							 GError		**error)
 {
-	  if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
-		  return fu_thunderbolt_device_close(device, error);
-	  }
+	for (guint i = 0; i < devices->len; i++) {
+		FuDevice *device = g_ptr_array_index (devices, i);
+		if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+			return fu_thunderbolt_device_close(device, error);
+		}
+	}
 	return TRUE;
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -75,4 +75,22 @@ fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 	vfuncs->startup = fu_plugin_thunderbolt_startup;
 	vfuncs->device_registered = fu_plugin_thunderbolt_device_registered;
 	vfuncs->device_created = fu_plugin_thunderbolt_device_created;
+gboolean
+fu_plugin_update_prepare (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
+			  FuDevice *device,
+			  GError **error)
+{
+	  g_warning("debug from fu_plugin_update_prepare");
+	  return TRUE;
+}
+
+gboolean
+fu_plugin_update_cleanup (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
+			  FuDevice *device,
+			  GError **error)
+{
+	g_warning("debug from fu_plugin_update_cleanup");
+	return TRUE;
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -75,6 +75,8 @@ fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 	vfuncs->startup = fu_plugin_thunderbolt_startup;
 	vfuncs->device_registered = fu_plugin_thunderbolt_device_registered;
 	vfuncs->device_created = fu_plugin_thunderbolt_device_created;
+}
+
 gboolean
 fu_plugin_composite_prepare (FuPlugin *plugin,
 			     GPtrArray *devices,

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -81,10 +81,10 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 			  FuDevice *device,
 			  GError **error)
 {
-	  g_warning("debug from fu_plugin_update_prepare");
-	  if (device != NULL && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+	  if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
 		  return fu_thunderbolt_device_open(device,error);
 	  }
+	  return TRUE;
 }
 
 gboolean
@@ -93,8 +93,7 @@ fu_plugin_update_cleanup (FuPlugin *plugin,
 			  FuDevice *device,
 			  GError **error)
 {
-	g_warning("debug from fu_plugin_update_cleanup");
-	  if (device != NULL && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+	  if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
 		  return fu_thunderbolt_device_close(device, error);
 	  }
 	return TRUE;

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -61,6 +61,28 @@ udev_mock_add_nvmem(UMockdevTestbed *bed, gboolean active, const char *parent, i
 	return path;
 }
 
+static gchar *
+udev_mock_add_usb4_port(UMockdevTestbed *bed, int id)
+{
+	gchar *path;
+	g_autofree gchar *name = NULL;
+
+	name = g_strdup_printf("usb4_port%d", id);
+	path = umockdev_testbed_add_device(bed,
+					   "thunderbolt",
+					   name,
+					   NULL,
+					   "security",
+					   "secure",
+					   NULL,
+					   "DEVTYPE",
+					   "thunderbolt_usb4_port",
+					   NULL);
+
+	g_assert_nonnull(path);
+	return path;
+}
+
 typedef struct MockDevice MockDevice;
 
 struct MockDevice {
@@ -561,6 +583,7 @@ mock_tree_attach(MockTree *root, UMockdevTestbed *bed, FuPlugin *plugin)
 {
 	root->bed = g_object_ref(bed);
 	root->sysfs_parent = udev_mock_add_domain(bed, root->device->domain_id);
+	root->sysfs_parent = udev_mock_add_usb4_port(bed, 1);
 	g_assert_nonnull(root->sysfs_parent);
 
 	g_timeout_add(root->device->delay_ms, mock_tree_attach_device, root);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -354,16 +354,10 @@ fu_thunderbolt_device_set_port_online(FuDevice *device)
 {
 	FuUdevDevice *udev = FU_UDEV_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
-	g_warning("debug fu_thunderbolt_device_set_port_online");
 
-	if (!fu_udev_device_write_sysfs(udev, "usb4_port1/offline", "0", &error_local)) {
+	if (!fu_udev_device_write_sysfs(udev, "../offline", "0", &error_local)) {
 		g_warning("Setting port online failed: %s", error_local->message);
 	}
-
-	if (!fu_udev_device_write_sysfs(udev, "usb4_port3/offline", "0", &error_local)) {
-		g_warning("Setting port online failed: %s", error_local->message);
-	}
-
 }
 
 gboolean
@@ -373,7 +367,6 @@ fu_thunderbolt_device_open(FuDevice *device, GError **error)
 	GUdevDevice *udev_device = NULL;
 	g_autoptr(GUdevDevice) udev_parent = NULL;
 	g_autoptr(FuUdevDevice) parent = NULL;
-	g_warning("debug from fu_thunderbolt_device_open");
 	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER ||
 	    fu_thunderbolt_device_get_version(self, NULL))
 		return TRUE;
@@ -382,7 +375,6 @@ fu_thunderbolt_device_open(FuDevice *device, GError **error)
 	udev_parent = g_udev_device_get_parent(udev_device);
 	udev_parent = g_udev_device_get_parent(udev_parent);
 	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
-	g_warning("set offline from fu_thunderbolt_device_open");
 	return fu_thunderbolt_device_set_port_offline(parent);
 }
 
@@ -397,10 +389,9 @@ fu_thunderbolt_device_close(FuDevice *device, GError **error)
 		return TRUE;
 
 	udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	udev_parent = g_udev_device_get_parent(udev_device);
-	udev_parent = g_udev_device_get_parent(udev_parent);
-	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
-	g_warning("set online from fu_thunderbolt_device_close");
+	//udev_parent = g_udev_device_get_parent(udev_device);
+	//udev_parent = g_udev_device_get_parent(udev_parent);
+	parent = fu_udev_device_new(g_steal_pointer(&udev_device));
 	fu_thunderbolt_device_set_port_online(parent);
 	return TRUE;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -320,6 +320,71 @@ fu_thunderbolt_device_get_attr_uint16(FuThunderboltDevice *self, const gchar *na
 	return (guint16)val;
 }
 
+static void
+fu_thunderbolt_device_set_port_offline(FuUdevDevice *device)
+{
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_udev_device_write_sysfs(device, "usb4_port3/offline", "1", &error_local)) {
+		g_warning("Setting port offline failed: %s", error_local->message);
+	}
+	error_local = NULL;
+	if (!fu_udev_device_write_sysfs(device, "usb4_port3/rescan", "1", &error_local)) {
+		g_warning("Rescan on port failed: %s", error_local->message);
+	}
+}
+
+static void
+fu_thunderbolt_device_set_port_online(FuDevice *device)
+{
+	FuUdevDevice *udev = FU_UDEV_DEVICE(device);
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_udev_device_write_sysfs(udev, "usb4_port3/offline", "0", &error_local)) {
+		g_warning("Setting port online failed: %s", error_local->message);
+	}
+}
+
+static gboolean
+fu_thunderbolt_device_set_port_online_cb(FuUdevDevice *device)
+{
+	fu_thunderbolt_device_set_port_online(device);
+	return G_SOURCE_REMOVE;
+}
+
+static gboolean
+fu_thunderbolt_device_open(FuDevice *device, GError **error)
+{
+	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
+
+	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER ||
+	    fu_thunderbolt_device_get_version(self, NULL))
+		return TRUE;
+
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	g_autoptr(GUdevDevice) udev_parent = g_udev_device_get_parent(udev_device);
+	udev_parent = g_udev_device_get_parent(udev_parent);
+	g_autoptr(FuUdevDevice) parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
+	fu_thunderbolt_device_set_port_offline(parent);
+	return TRUE;
+}
+
+static gboolean
+fu_thunderbolt_device_close(FuDevice *device, GError **error)
+{
+	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
+
+	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER)
+		return TRUE;
+
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	g_autoptr(GUdevDevice) udev_parent = g_udev_device_get_parent(udev_device);
+	udev_parent = g_udev_device_get_parent(udev_parent);
+	g_autoptr(FuUdevDevice) parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
+	fu_thunderbolt_device_set_port_online(parent);
+	return TRUE;
+}
+
 static gboolean
 fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
 {
@@ -422,6 +487,13 @@ fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
 		fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	}
 
+	if (self->device_type == FU_THUNDERBOLT_DEVICE_TYPE_HOST_CONTROLLER) {
+		fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device));
+		g_timeout_add_seconds(5,
+				      G_SOURCE_FUNC(fu_thunderbolt_device_set_port_online_cb),
+				      FU_UDEV_DEVICE(device));
+	}
+
 	return TRUE;
 }
 
@@ -442,6 +514,7 @@ fu_thunderbolt_device_setup_retimer(FuDevice *device, GError **error)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP);
 	vid = fu_udev_device_get_vendor(FU_UDEV_DEVICE(self));
 	if (vid == 0x0) {
 		g_set_error_literal(error,
@@ -799,6 +872,8 @@ fu_thunderbolt_device_class_init(FuThunderboltDeviceClass *klass)
 	klass_device->activate = fu_thunderbolt_device_activate;
 	klass_device->to_string = fu_thunderbolt_device_to_string;
 	klass_device->setup = fu_thunderbolt_device_setup;
+	klass_device->open = fu_thunderbolt_device_open;
+	klass_device->close = fu_thunderbolt_device_close;
 	klass_device->prepare_firmware = fu_thunderbolt_device_prepare_firmware;
 	klass_device->write_firmware = fu_thunderbolt_device_write_firmware;
 	klass_device->attach = fu_thunderbolt_device_attach;

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -488,7 +488,7 @@ fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
 	}
 
 	if (self->device_type == FU_THUNDERBOLT_DEVICE_TYPE_HOST_CONTROLLER) {
-		if(fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device)))
+		if (fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device)))
 			return TRUE;
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -516,7 +516,9 @@ fu_thunderbolt_device_setup_retimer(FuDevice *device, GError **error)
 	g_autofree gchar *instance = NULL;
 
 	/* as defined in PCIe 4.0 spec */
-	fu_device_set_summary (device, "A physical layer protocol-aware, software-transparent extension device "
+	fu_device_set_summary (
+			device,
+			"A physical layer protocol-aware, software-transparent extension device "
 				        "that forms two separate electrical link segments");
 	fu_device_set_name (device, fu_thunderbolt_device_type_to_string (self));
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -350,12 +350,16 @@ fu_thunderbolt_device_set_port_offline(FuUdevDevice *device)
 }
 
 static void
-fu_thunderbolt_device_set_port_online(FuDevice *device)
+fu_thunderbolt_device_set_port_online(FuUdevDevice *device)
 {
 	FuUdevDevice *udev = FU_UDEV_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
 
-	if (!fu_udev_device_write_sysfs(udev, "../offline", "0", &error_local)) {
+	if (!fu_udev_device_write_sysfs(udev, "usb4_port1/offline", "0", &error_local)) {
+		g_warning("Setting port online failed: %s", error_local->message);
+	}
+
+	if (!fu_udev_device_write_sysfs(udev, "usb4_port3/offline", "0", &error_local)) {
 		g_warning("Setting port online failed: %s", error_local->message);
 	}
 }
@@ -389,9 +393,9 @@ fu_thunderbolt_device_close(FuDevice *device, GError **error)
 		return TRUE;
 
 	udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	//udev_parent = g_udev_device_get_parent(udev_device);
-	//udev_parent = g_udev_device_get_parent(udev_parent);
-	parent = fu_udev_device_new(g_steal_pointer(&udev_device));
+	udev_parent = g_udev_device_get_parent(udev_device);
+	udev_parent = g_udev_device_get_parent(udev_parent);
+	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
 	fu_thunderbolt_device_set_port_online(parent);
 	return TRUE;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -354,16 +354,18 @@ fu_thunderbolt_device_open(FuDevice *device, GError **error)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
 	GUdevDevice *udev_device = NULL;
-	g_autoptr(GUdevDevice) udev_parent = NULL;
+	g_autoptr(GUdevDevice) udev_parent1 = NULL;
+	g_autoptr(GUdevDevice) udev_parent2 = NULL;
 	g_autoptr(FuUdevDevice) parent = NULL;
 	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER ||
 	    fu_thunderbolt_device_get_version(self, NULL))
 		return TRUE;
 
 	udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	udev_parent = g_udev_device_get_parent(udev_device);
-	udev_parent = g_udev_device_get_parent(udev_parent);
-	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
+	udev_parent1 = g_udev_device_get_parent(udev_device);
+	udev_parent2 = g_udev_device_get_parent(udev_parent1);
+	parent = fu_udev_device_new_with_context(fu_device_get_context(FU_DEVICE(self)),
+						 g_steal_pointer(&udev_parent2));
 	return fu_thunderbolt_device_set_port_offline(parent);
 }
 
@@ -372,15 +374,17 @@ fu_thunderbolt_device_close(FuDevice *device, GError **error)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
 	GUdevDevice *udev_device = NULL;
-	g_autoptr(GUdevDevice) udev_parent = NULL;
+	g_autoptr(GUdevDevice) udev_parent1 = NULL;
+	g_autoptr(GUdevDevice) udev_parent2 = NULL;
 	g_autoptr(FuUdevDevice) parent = NULL;
 	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER)
 		return TRUE;
 
 	udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	udev_parent = g_udev_device_get_parent(udev_device);
-	udev_parent = g_udev_device_get_parent(udev_parent);
-	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
+	udev_parent1 = g_udev_device_get_parent(udev_device);
+	udev_parent2 = g_udev_device_get_parent(udev_parent1);
+	parent = fu_udev_device_new_with_context(fu_device_get_context(FU_DEVICE(self)),
+						 g_steal_pointer(&udev_parent2));
 	fu_thunderbolt_device_set_port_online(parent);
 	return TRUE;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -326,8 +326,6 @@ fu_thunderbolt_device_set_port_offline(FuUdevDevice *device)
 	g_autoptr(GError) error_local_offline = NULL;
 	g_autoptr(GError) error_local_rescan = NULL;
 
-	g_warning("debug fu_thunderbolt_device_set_port_offline");
-
 	if (!fu_udev_device_write_sysfs(device, "usb4_port1/offline", "1", &error_local_offline)) {
 		g_warning("Setting port offline failed: %s", error_local_offline->message);
 		return FALSE;
@@ -839,7 +837,7 @@ fu_thunderbolt_device_write_firmware(FuDevice *device,
 	/* whether to wait for a device replug or not */
 	if (fu_device_has_flag (device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
 		fu_device_set_remove_delay (device, FU_PLUGIN_THUNDERBOLT_UPDATE_TIMEOUT);
-		fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
+		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
 		if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER)
 		{
 			fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -337,15 +337,6 @@ fu_thunderbolt_device_set_port_offline(FuUdevDevice *device)
 		return FALSE;
 	}
 
-	if (!fu_udev_device_write_sysfs(device, "usb4_port3/offline", "1", &error_local_offline)) {
-		g_warning("Setting port offline failed: %s", error_local_offline->message);
-		return FALSE;
-	}
-	if (!fu_udev_device_write_sysfs(device, "usb4_port3/rescan", "1", &error_local_rescan)) {
-		g_warning("Rescan on port failed: %s", error_local_rescan->message);
-		return FALSE;
-	}
-
 	return TRUE;
 }
 
@@ -356,10 +347,6 @@ fu_thunderbolt_device_set_port_online(FuUdevDevice *device)
 	g_autoptr(GError) error_local = NULL;
 
 	if (!fu_udev_device_write_sysfs(udev, "usb4_port1/offline", "0", &error_local)) {
-		g_warning("Setting port online failed: %s", error_local->message);
-	}
-
-	if (!fu_udev_device_write_sysfs(udev, "usb4_port3/offline", "0", &error_local)) {
 		g_warning("Setting port online failed: %s", error_local->message);
 	}
 }

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -320,18 +320,21 @@ fu_thunderbolt_device_get_attr_uint16(FuThunderboltDevice *self, const gchar *na
 	return (guint16)val;
 }
 
-static void
+static gboolean
 fu_thunderbolt_device_set_port_offline(FuUdevDevice *device)
 {
 	g_autoptr(GError) error_local_offline = NULL;
 	g_autoptr(GError) error_local_rescan = NULL;
 
-	if (!fu_udev_device_write_sysfs(device, "usb4_port1/offline", "1", &error_local_offline)) {
+	if (!fu_udev_device_write_sysfs(device, "usb4_port3/offline", "1", &error_local_offline)) {
 		g_warning("Setting port offline failed: %s", error_local_offline->message);
+		return FALSE;
 	}
-	if (!fu_udev_device_write_sysfs(device, "usb4_port1/rescan", "1", &error_local_rescan)) {
+	if (!fu_udev_device_write_sysfs(device, "usb4_port3/rescan", "1", &error_local_rescan)) {
 		g_warning("Rescan on port failed: %s", error_local_rescan->message);
+		return FALSE;
 	}
+	return TRUE;
 }
 
 static void
@@ -340,7 +343,7 @@ fu_thunderbolt_device_set_port_online(FuDevice *device)
 	FuUdevDevice *udev = FU_UDEV_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
 
-	if (!fu_udev_device_write_sysfs(udev, "usb4_port1/offline", "0", &error_local)) {
+	if (!fu_udev_device_write_sysfs(udev, "usb4_port3/offline", "0", &error_local)) {
 		g_warning("Setting port online failed: %s", error_local->message);
 	}
 }
@@ -357,8 +360,8 @@ fu_thunderbolt_device_open(FuDevice *device, GError **error)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
 	GUdevDevice *udev_device = NULL;
-	g_autoptr(GUdevDevice) udev_parent;
-	g_autoptr(FuUdevDevice) parent;
+	g_autoptr(GUdevDevice) udev_parent = NULL;
+	g_autoptr(FuUdevDevice) parent = NULL;
 
 	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER ||
 	    fu_thunderbolt_device_get_version(self, NULL))
@@ -368,17 +371,16 @@ fu_thunderbolt_device_open(FuDevice *device, GError **error)
 	udev_parent = g_udev_device_get_parent(udev_device);
 	udev_parent = g_udev_device_get_parent(udev_parent);
 	parent = fu_udev_device_new(g_steal_pointer(&udev_parent));
-	fu_thunderbolt_device_set_port_offline(parent);
-	return TRUE;
+	return fu_thunderbolt_device_set_port_offline(parent);
 }
 
 static gboolean
 fu_thunderbolt_device_close(FuDevice *device, GError **error)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
-	GUdevDevice *udev_device;
-	g_autoptr(GUdevDevice) udev_parent;
-
+	GUdevDevice *udev_device = NULL;
+	g_autoptr(GUdevDevice) udev_parent = NULL;
+	g_autoptr(FuUdevDevice) parent = NULL;
 	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER)
 		return TRUE;
 
@@ -493,8 +495,8 @@ fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
 	}
 
 	if (self->device_type == FU_THUNDERBOLT_DEVICE_TYPE_HOST_CONTROLLER) {
-		fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device));
-		g_timeout_add_seconds(5,
+		if(fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device)))
+			g_timeout_add_seconds(5,
 				      G_SOURCE_FUNC(fu_thunderbolt_device_set_port_online_cb),
 				      FU_UDEV_DEVICE(device));
 	}

--- a/plugins/thunderbolt/fu-thunderbolt-device.h
+++ b/plugins/thunderbolt/fu-thunderbolt-device.h
@@ -15,3 +15,10 @@ G_DECLARE_FINAL_TYPE(FuThunderboltDevice,
 		     FU,
 		     THUNDERBOLT_DEVICE,
 		     FuUdevDevice)
+
+gboolean
+fu_thunderbolt_device_open(FuDevice *device, GError **error);
+
+gboolean
+fu_thunderbolt_device_close(FuDevice *device, GError **error);
+

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -262,7 +262,6 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 				  "battery-system",
 				  "Cannot install update when not on AC power");
 		return;
-	}
 	if (fu_context_get_battery_level(self->ctx) != FU_BATTERY_VALUE_INVALID &&
 	    fu_context_get_battery_threshold(self->ctx) != FU_BATTERY_VALUE_INVALID &&
 	    fu_context_get_battery_level(self->ctx) < fu_context_get_battery_threshold(self->ctx)) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -262,6 +262,7 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 				  "battery-system",
 				  "Cannot install update when not on AC power");
 		return;
+	}
 	if (fu_context_get_battery_level(self->ctx) != FU_BATTERY_VALUE_INVALID &&
 	    fu_context_get_battery_threshold(self->ctx) != FU_BATTERY_VALUE_INVALID &&
 	    fu_context_get_battery_level(self->ctx) < fu_context_get_battery_threshold(self->ctx)) {

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -42,9 +42,10 @@ fu_udev_backend_device_remove(FuUdevBackend *self, GUdevDevice *udev_device)
 	device_tmp =
 	    fu_backend_lookup_by_id(FU_BACKEND(self), g_udev_device_get_sysfs_path(udev_device));
 	if (device_tmp != NULL &&
-	    fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP)) {
-		if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-			g_debug("UDEV %s removed", g_udev_device_get_sysfs_path(udev_device));
+	    fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE)) {
+		if (g_getenv ("FWUPD_PROBE_VERBOSE") != NULL) {
+			g_debug ("UDEV %s removed",
+				 g_udev_device_get_sysfs_path (udev_device));
 		}
 		fu_backend_device_removed(FU_BACKEND(self), device_tmp);
 	}

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -41,7 +41,8 @@ fu_udev_backend_device_remove(FuUdevBackend *self, GUdevDevice *udev_device)
 	/* find the device we enumerated */
 	device_tmp =
 	    fu_backend_lookup_by_id(FU_BACKEND(self), g_udev_device_get_sysfs_path(udev_device));
-	if (device_tmp != NULL) {
+	if (device_tmp != NULL &&
+	    fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP)) {
 		if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
 			g_debug("UDEV %s removed", g_udev_device_get_sysfs_path(udev_device));
 		}

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1216,7 +1216,10 @@ fu_util_device_flag_to_string(guint64 device_flag)
 	if (device_flag == FWUPD_DEVICE_FLAG_AFFECTS_FDE) {
 		/* TRANSLATORS: we might ask the user the recovery key when next booting Windows */
 		return _("Full disk encryption secrets may be invalidated when updating");
-	}
+		if (device_flag == FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP) {
+			/* TRANSLATORS: device needs to be re-enumerated to operate upon */
+			return _("Device needs to be re-enumerated");
+		}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */
 		return NULL;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1216,13 +1216,10 @@ fu_util_device_flag_to_string(guint64 device_flag)
 	if (device_flag == FWUPD_DEVICE_FLAG_AFFECTS_FDE) {
 		/* TRANSLATORS: we might ask the user the recovery key when next booting Windows */
 		return _("Full disk encryption secrets may be invalidated when updating");
-		if (device_flag == FWUPD_DEVICE_FLAG_REQUIRES_WAKEUP) {
-			/* TRANSLATORS: device needs to be re-enumerated to operate upon */
-			return _("Device needs to be re-enumerated");
-		}
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE) {
-		/* TRANSLATORS: device needs to be re-enumerated to operate upon */
-		return _("Device needs to be re-enumerated");
+		/* TRANSLATORS: device no auto remove */
+		return _("Device no auto remove");
 	}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1220,6 +1220,10 @@ fu_util_device_flag_to_string(guint64 device_flag)
 			/* TRANSLATORS: device needs to be re-enumerated to operate upon */
 			return _("Device needs to be re-enumerated");
 		}
+	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_REMOVE) {
+		/* TRANSLATORS: device needs to be re-enumerated to operate upon */
+		return _("Device needs to be re-enumerated");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */
 		return NULL;


### PR DESCRIPTION
This change offline ports in the host controller for 5 seconds to allow
for retimers to enumerate in the NDA case.

BUG=b:187506425
TEST=emerge-volteer fwupd

Change-Id: I1fde5675f27e91e18951b72f24fbec4113410807

Type of pull request:

thunderbolt retimer nvm update in NDA case

