### PR TITLE
thunderbolt: set ports offline on host controller

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -230,6 +230,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "use-parent-for-battery";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK)
 		return "use-proxy-fallback";
+	if (flag == FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE)
+		return "no-auto-remove";
 	return NULL;
 }
 
@@ -284,6 +286,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY;
 	if (g_strcmp0(flag, "use-proxy-fallback") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK;
+	if (g_strcmp0(flag, "no-auto-remove") == 0)
+		return FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -400,6 +400,14 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK (1ull << 18)
 
+/**
+ * FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE :
+ *
+ * The device is not auto removed.
+ * Since 1.7.3
+ */
+#define FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE (1llu << 19)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -61,6 +61,25 @@ udev_mock_add_nvmem(UMockdevTestbed *bed, gboolean active, const char *parent, i
 	return path;
 }
 
+static gchar *
+udev_mock_add_usb4_port(UMockdevTestbed *bed, int id)
+{
+	g_autofree gchar *name = g_strdup_printf("usb4_port%d", id);
+	gchar *path = umockdev_testbed_add_device(bed,
+						  "thunderbolt",
+						  name,
+						  NULL,
+						  "security",
+						  "secure",
+						  NULL,
+						  "DEVTYPE",
+						  "thunderbolt_usb4_port",
+						  NULL);
+
+	g_assert_nonnull(path);
+	return path;
+}
+
 typedef struct MockDevice MockDevice;
 
 struct MockDevice {
@@ -561,6 +580,7 @@ mock_tree_attach(MockTree *root, UMockdevTestbed *bed, FuPlugin *plugin)
 {
 	root->bed = g_object_ref(bed);
 	root->sysfs_parent = udev_mock_add_domain(bed, root->device->domain_id);
+	root->sysfs_parent = udev_mock_add_usb4_port(bed, 1);
 	g_assert_nonnull(root->sysfs_parent);
 
 	g_timeout_add(root->device->delay_ms, mock_tree_attach_device, root);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -319,6 +319,138 @@ fu_thunderbolt_device_get_attr_uint16(FuThunderboltDevice *self, const gchar *na
 	}
 	return (guint16)val;
 }
+static gboolean
+fu_thunderbolt_check_usb4_port_path(FuUdevDevice *device, const gchar *attribute, GError **err)
+{
+	g_autofree const gchar *path =
+	    g_build_filename(fu_udev_device_get_sysfs_path(device), attribute, NULL);
+	g_autofree gchar *fn = g_strdup_printf("%s", path);
+	g_autoptr(GFile) file = g_file_new_for_path(fn);
+	if (!g_file_query_exists(file, NULL)) {
+		g_set_error(err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "failed to find %s", fn);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_thunderbolt_device_set_port_offline(FuUdevDevice *device, GError **error)
+{
+	const gchar *offline = "usb4_port1/offline";
+	const gchar *rescan = "usb4_port1/rescan";
+	g_autoptr(GError) error_offline = NULL;
+	g_autoptr(GError) error_rescan = NULL;
+	if (fu_thunderbolt_check_usb4_port_path(device, offline, &error_offline)) {
+		if (!fu_udev_device_write_sysfs(device, offline, "1", error)) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "Setting usb4 port offline failed");
+			return FALSE;
+		}
+	} else {
+		g_debug("%s", error_offline->message);
+		return TRUE;
+	}
+	if (fu_thunderbolt_check_usb4_port_path(device, rescan, &error_rescan)) {
+		if (!fu_udev_device_write_sysfs(device, rescan, "1", error)) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "Rescan on port failed");
+			return FALSE;
+		}
+	} else {
+		g_debug("%s", error_rescan->message);
+		return TRUE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_thunderbolt_device_set_port_online(FuUdevDevice *device, GError **err)
+{
+	FuUdevDevice *udev = FU_UDEV_DEVICE(device);
+	const gchar *offline = "usb4_port1/offline";
+	g_autoptr(GError) error_offline = NULL;
+
+	if (fu_thunderbolt_check_usb4_port_path(device, offline, &error_offline)) {
+		if (!fu_udev_device_write_sysfs(udev, offline, "0", err)) {
+			g_set_error_literal(err,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "Setting port online failed");
+			return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+static FuUdevDevice *
+fu_thunderbolt_get_udev_parent_device(FuDevice *device, GError **error)
+{
+	g_autoptr(GUdevDevice) udev_parent1 = NULL;
+	g_autoptr(GUdevDevice) udev_parent2 = NULL;
+	GUdevDevice *udev_device = NULL;
+	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
+	if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "not a retimer device");
+		return NULL;
+	}
+	udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	if (udev_device == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to get udev device for retimer");
+		return NULL;
+	}
+	udev_parent1 = g_udev_device_get_parent(udev_device);
+	if (udev_parent1 == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to get parent device for retimer");
+		return NULL;
+	}
+	udev_parent2 = g_udev_device_get_parent(udev_parent1);
+	if (udev_parent2 == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to get host router device for retimer");
+		return NULL;
+	}
+	return fu_udev_device_new_with_context(fu_device_get_context(FU_DEVICE(self)),
+					       g_steal_pointer(&udev_parent2));
+}
+gboolean
+fu_thunderbolt_probe_retimer(FuDevice *device, GError **error)
+{
+	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
+	g_autoptr(FuUdevDevice) parent = NULL;
+	if (device == NULL || self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "fail to probe retimer device");
+		return FALSE;
+	}
+	parent = fu_thunderbolt_get_udev_parent_device(device, error);
+	return fu_thunderbolt_device_set_port_offline(parent, error);
+}
+
+gboolean
+fu_thunderbolt_device_close(FuDevice *device, GError **error)
+{
+	g_autoptr(FuUdevDevice) parent = fu_thunderbolt_get_udev_parent_device(device, error);
+	if (parent == NULL)
+		return FALSE;
+	return fu_thunderbolt_device_set_port_online(parent, error);
+}
 
 static gboolean
 fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
@@ -422,6 +554,11 @@ fu_thunderbolt_device_setup_controller(FuDevice *device, GError **error)
 		fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	}
 
+	if (self->device_type == FU_THUNDERBOLT_DEVICE_TYPE_HOST_CONTROLLER) {
+		if (!fu_thunderbolt_device_set_port_offline(FU_UDEV_DEVICE(device), error))
+			return FALSE;
+	}
+
 	return TRUE;
 }
 
@@ -442,6 +579,8 @@ fu_thunderbolt_device_setup_retimer(FuDevice *device, GError **error)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(device, FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE);
+
 	vid = fu_udev_device_get_vendor(FU_UDEV_DEVICE(self));
 	if (vid == 0x0) {
 		g_set_error_literal(error,
@@ -763,10 +902,11 @@ fu_thunderbolt_device_write_firmware(FuDevice *device,
 	}
 
 	/* whether to wait for a device replug or not */
-	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
-		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
 		fu_device_set_remove_delay(device, FU_PLUGIN_THUNDERBOLT_UPDATE_TIMEOUT);
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
+		if (self->device_type != FU_THUNDERBOLT_DEVICE_TYPE_RETIMER)
+			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	}
 
 	return TRUE;

--- a/plugins/thunderbolt/fu-thunderbolt-device.h
+++ b/plugins/thunderbolt/fu-thunderbolt-device.h
@@ -15,3 +15,9 @@ G_DECLARE_FINAL_TYPE(FuThunderboltDevice,
 		     FU,
 		     THUNDERBOLT_DEVICE,
 		     FuUdevDevice)
+
+gboolean
+fu_thunderbolt_probe_retimer(FuDevice *device, GError **error);
+
+gboolean
+fu_thunderbolt_device_close(FuDevice *device, GError **error);

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -41,7 +41,8 @@ fu_udev_backend_device_remove(FuUdevBackend *self, GUdevDevice *udev_device)
 	/* find the device we enumerated */
 	device_tmp =
 	    fu_backend_lookup_by_id(FU_BACKEND(self), g_udev_device_get_sysfs_path(udev_device));
-	if (device_tmp != NULL) {
+	if (device_tmp != NULL &&
+	    !fu_device_has_flag(device_tmp, FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE)) {
 		if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
 			g_debug("UDEV %s removed", g_udev_device_get_sysfs_path(udev_device));
 		}

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -39,7 +39,8 @@ fu_usb_backend_device_removed_cb(GUsbContext *ctx, GUsbDevice *usb_device, FuBac
 	/* find the device we enumerated */
 	device_tmp =
 	    fu_backend_lookup_by_id(FU_BACKEND(self), g_usb_device_get_platform_id(usb_device));
-	if (device_tmp != NULL)
+	if (device_tmp != NULL &&
+	    !fu_device_has_flag(device_tmp, FWUPD_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE))
 		fu_backend_device_removed(backend, device_tmp);
 }
 


### PR DESCRIPTION
This change offline ports in the host controller
for retimers to enumerate in the NDA case.

-offline and rescan usb4 ports
-this enable enumeration of the retimers
-updates nvm to the enumerated retimers
-online usb4 port this will de-enumerate retimers

BUG=b:187506425
TEST=emerge-volteer fwupd

Change-Id: I1fde5675f27e91e18951b72f24fbec4113410807

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
