### PR TITLE
trivial: Do not check the device superclass when closing

### DIFF
--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -87,8 +87,7 @@ fu_device_locker_close(FuDeviceLocker *self, GError **error)
 		return TRUE;
 	if (!self->close_func(self->device, &error_local)) {
 #ifdef HAVE_GUSB
-		if (G_USB_IS_DEVICE(self->device) &&
-		    g_error_matches(error_local,
+		if (g_error_matches(error_local,
 				    G_USB_DEVICE_ERROR,
 				    G_USB_DEVICE_ERROR_NO_DEVICE)) {
 			g_debug("ignoring: %s", error_local->message);


### PR DESCRIPTION
The things we're closing is probably a FuUsbDevice subclass which has
the GUsbDevice as an instance variable, not a subclass of GUsbDevice.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
