### PR TITLE
Add the CFI JEDEC instance ID if using vendor-extended version

### DIFF
--- a/data/cfi.quirk
+++ b/data/cfi.quirk
@@ -5,7 +5,7 @@ CfiDeviceCmdSectorErase = 0x20
 
 [CFI\FLASHID_1F65]
 Name = AT25F512A/B
-# CfiDeviceCmdReadId = 0x15
+CfiDeviceCmdReadId = 0x15
 CfiDeviceCmdChipErase = 0x62
 CfiDeviceCmdSectorErase = 0x00
 FirmwareSizeMax = 0x10000
@@ -37,19 +37,19 @@ CfiDeviceCmdSectorErase = 0x20
 
 [CFI\FLASHID_00BF]
 Name = PCT/SST25VFxxx/xxxA
-# CfiDeviceCmdReadId = 0x90
+CfiDeviceCmdReadId = 0x90
 CfiDeviceCmdChipErase = 0x60
 CfiDeviceCmdSectorErase = 0x20
 
 [CFI\FLASHID_009D]
 Name = PM25LDxxx
-# CfiDeviceCmdReadId = 0x90
+CfiDeviceCmdReadId = 0x90
 CfiDeviceCmdChipErase = 0xC7
 CfiDeviceCmdSectorErase = 0xD7
 
 [CFI\FLASHID_009D]
 Name = PM25LVxxx
-# CfiDeviceCmdReadId = 0xAB
+CfiDeviceCmdReadId = 0xAB
 CfiDeviceCmdChipErase = 0xC7
 CfiDeviceCmdSectorErase = 0xD7
 

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -249,40 +249,60 @@ fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 {
 	FuCfiDevice *self = FU_CFI_DEVICE(device);
 	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp;
+
 	if (g_strcmp0(key, "CfiDeviceCmdReadId") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_READ_ID] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_READ_ID] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdReadIdSz") == 0) {
-		priv->cmd_read_id_sz = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmd_read_id_sz = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdChipErase") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_CHIP_ERASE] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_CHIP_ERASE] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdSectorErase") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_SECTOR_ERASE] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_SECTOR_ERASE] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdWriteStatus") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_STATUS] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_STATUS] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdPageProg") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_PAGE_PROG] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_PAGE_PROG] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdReadData") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_READ_DATA] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_READ_DATA] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdReadStatus") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_READ_STATUS] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_READ_STATUS] = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CfiDeviceCmdWriteEn") == 0) {
-		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_EN] = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_EN] = tmp;
 		return TRUE;
 	}
 	g_set_error_literal(error,

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -21,6 +21,8 @@
 typedef struct {
 	gchar *flash_id;
 	guint8 cmd_read_id_sz;
+	guint32 page_size;
+	guint32 sector_size;
 	FuCfiDeviceCmd cmds[FU_CFI_DEVICE_CMD_LAST];
 } FuCfiDevicePrivate;
 
@@ -244,6 +246,80 @@ fu_cfi_device_get_cmd(FuCfiDevice *self, FuCfiDeviceCmd cmd, guint8 *value, GErr
 	return TRUE;
 }
 
+/**
+ * fu_cfi_device_get_page_size:
+ * @self: a #FuCfiDevice
+ *
+ * Gets the chip page size. This is typically the largest writable block size.
+ *
+ * This is typically set with the `CfiDevicePageSize` quirk key.
+ *
+ * Returns: page size in bytes, or 0 if unknown
+ *
+ * Since: 1.7.3
+ **/
+guint32
+fu_cfi_device_get_page_size(FuCfiDevice *self)
+{
+	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_CFI_DEVICE(self), G_MAXUINT32);
+	return priv->page_size;
+}
+
+/**
+ * fu_cfi_device_set_page_size:
+ * @self: a #FuCfiDevice
+ * @page_size: page size in bytes, or 0 if unknown
+ *
+ * Sets the chip page size. This is typically the largest writable block size.
+ *
+ * Since: 1.7.3
+ **/
+void
+fu_cfi_device_set_page_size(FuCfiDevice *self, guint32 page_size)
+{
+	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_CFI_DEVICE(self));
+	priv->page_size = page_size;
+}
+
+/**
+ * fu_cfi_device_get_sector_size:
+ * @self: a #FuCfiDevice
+ *
+ * Gets the chip sector size. This is typically the smallest erasable page size.
+ *
+ * This is typically set with the `CfiDeviceSectorSize` quirk key.
+ *
+ * Returns: sector size in bytes, or 0 if unknown
+ *
+ * Since: 1.7.3
+ **/
+guint32
+fu_cfi_device_get_sector_size(FuCfiDevice *self)
+{
+	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_CFI_DEVICE(self), G_MAXUINT32);
+	return priv->sector_size;
+}
+
+/**
+ * fu_cfi_device_set_sector_size:
+ * @self: a #FuCfiDevice
+ * @sector_size: sector size in bytes, or 0 if unknown
+ *
+ * Sets the chip sector size. This is typically the smallest erasable page size.
+ *
+ * Since: 1.7.3
+ **/
+void
+fu_cfi_device_set_sector_size(FuCfiDevice *self, guint32 sector_size)
+{
+	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_CFI_DEVICE(self));
+	priv->sector_size = sector_size;
+}
+
 static gboolean
 fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, GError **error)
 {
@@ -305,6 +381,18 @@ fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_EN] = tmp;
 		return TRUE;
 	}
+	if (g_strcmp0(key, "CfiDevicePageSize") == 0) {
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		priv->page_size = tmp;
+		return TRUE;
+	}
+	if (g_strcmp0(key, "CfiDeviceSectorSize") == 0) {
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		priv->sector_size = tmp;
+		return TRUE;
+	}
 	g_set_error_literal(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
@@ -321,6 +409,10 @@ fu_cfi_device_to_string(FuDevice *device, guint idt, GString *str)
 	for (guint i = 0; i < FU_CFI_DEVICE_CMD_LAST; i++) {
 		fu_common_string_append_kx(str, idt, fu_cfi_device_cmd_to_string(i), priv->cmds[i]);
 	}
+	if (priv->page_size > 0)
+		fu_common_string_append_kx(str, idt, "PageSize", priv->page_size);
+	if (priv->sector_size > 0)
+		fu_common_string_append_kx(str, idt, "SectorSize", priv->sector_size);
 }
 
 static void

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -265,6 +265,26 @@ fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		priv->cmds[FU_CFI_DEVICE_CMD_SECTOR_ERASE] = fu_common_strtoull(value);
 		return TRUE;
 	}
+	if (g_strcmp0(key, "CfiDeviceCmdWriteStatus") == 0) {
+		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_STATUS] = fu_common_strtoull(value);
+		return TRUE;
+	}
+	if (g_strcmp0(key, "CfiDeviceCmdPageProg") == 0) {
+		priv->cmds[FU_CFI_DEVICE_CMD_PAGE_PROG] = fu_common_strtoull(value);
+		return TRUE;
+	}
+	if (g_strcmp0(key, "CfiDeviceCmdReadData") == 0) {
+		priv->cmds[FU_CFI_DEVICE_CMD_READ_DATA] = fu_common_strtoull(value);
+		return TRUE;
+	}
+	if (g_strcmp0(key, "CfiDeviceCmdReadStatus") == 0) {
+		priv->cmds[FU_CFI_DEVICE_CMD_READ_STATUS] = fu_common_strtoull(value);
+		return TRUE;
+	}
+	if (g_strcmp0(key, "CfiDeviceCmdWriteEn") == 0) {
+		priv->cmds[FU_CFI_DEVICE_CMD_WRITE_EN] = fu_common_strtoull(value);
+		return TRUE;
+	}
 	g_set_error_literal(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,

--- a/libfwupdplugin/fu-cfi-device.h
+++ b/libfwupdplugin/fu-cfi-device.h
@@ -54,5 +54,13 @@ guint64
 fu_cfi_device_get_size(FuCfiDevice *self);
 void
 fu_cfi_device_set_size(FuCfiDevice *self, guint64 size);
+guint32
+fu_cfi_device_get_page_size(FuCfiDevice *self);
+void
+fu_cfi_device_set_page_size(FuCfiDevice *self, guint32 block_size);
+guint32
+fu_cfi_device_get_sector_size(FuCfiDevice *self);
+void
+fu_cfi_device_set_sector_size(FuCfiDevice *self, guint32 sector_size);
 gboolean
 fu_cfi_device_get_cmd(FuCfiDevice *self, FuCfiDeviceCmd cmd, guint8 *value, GError **error);

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -211,6 +211,8 @@ GError *
 fu_common_error_array_get_best(GPtrArray *errors);
 guint64
 fu_common_strtoull(const gchar *str);
+gboolean
+fu_common_strtoull_full(const gchar *str, guint64 *value, guint64 min, guint64 max, GError **error);
 gchar *
 fu_common_find_program_in_path(const gchar *basename, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gchar *

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1496,6 +1496,7 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
+	guint64 tmp;
 
 	if (g_strcmp0(key, FU_QUIRKS_PLUGIN) == 0) {
 		fu_device_add_possible_plugin(self, value);
@@ -1564,31 +1565,45 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_FIRMWARE_SIZE_MIN) == 0) {
-		fu_device_set_firmware_size_min(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT64, error))
+			return FALSE;
+		fu_device_set_firmware_size_min(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_FIRMWARE_SIZE_MAX) == 0) {
-		fu_device_set_firmware_size_max(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT64, error))
+			return FALSE;
+		fu_device_set_firmware_size_max(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_FIRMWARE_SIZE) == 0) {
-		fu_device_set_firmware_size(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT64, error))
+			return FALSE;
+		fu_device_set_firmware_size(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_INSTALL_DURATION) == 0) {
-		fu_device_set_install_duration(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, 60 * 60 * 24, error))
+			return FALSE;
+		fu_device_set_install_duration(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_PRIORITY) == 0) {
-		fu_device_set_priority(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		fu_device_set_priority(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_BATTERY_THRESHOLD) == 0) {
-		fu_device_set_battery_threshold(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, 100, error))
+			return FALSE;
+		fu_device_set_battery_threshold(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_REMOVE_DELAY) == 0) {
-		fu_device_set_remove_delay(self, fu_common_strtoull(value));
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT64, error))
+			return FALSE;
+		fu_device_set_remove_delay(self, tmp);
 		return TRUE;
 	}
 	if (g_strcmp0(key, FU_QUIRKS_VERSION_FORMAT) == 0) {

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -586,6 +586,8 @@ fu_quirks_init(FuQuirks *self)
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdReadIdSz");
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdChipErase");
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdSectorErase");
+	fu_quirks_add_possible_key(self, "CfiDevicePageSize");
+	fu_quirks_add_possible_key(self, "CfiDeviceSectorSize");
 }
 
 static void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2111,6 +2111,33 @@ fu_common_version_semver_func(void)
 }
 
 static void
+fu_common_strtoull_func(void)
+{
+	gboolean ret;
+	guint64 val = 0;
+	g_autoptr(GError) error = NULL;
+
+	ret = fu_common_strtoull_full("123", &val, 123, 200, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(val, ==, 123);
+
+	ret = fu_common_strtoull_full("0x123", &val, 0, 0x123, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(val, ==, 0x123);
+
+	ret = fu_common_strtoull_full(NULL, &val, 0, G_MAXUINT32, NULL);
+	g_assert_false(ret);
+	ret = fu_common_strtoull_full("", &val, 120, 123, NULL);
+	g_assert_false(ret);
+	ret = fu_common_strtoull_full("124", &val, 120, 123, NULL);
+	g_assert_false(ret);
+	ret = fu_common_strtoull_full("119", &val, 120, 123, NULL);
+	g_assert_false(ret);
+}
+
+static void
 fu_common_version_func(void)
 {
 	guint i;
@@ -3781,6 +3808,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/common{crc}", fu_common_crc_func);
 	g_test_add_func("/fwupd/common{string-append-kv}", fu_common_string_append_kv_func);
 	g_test_add_func("/fwupd/common{version-guess-format}", fu_common_version_guess_format_func);
+	g_test_add_func("/fwupd/common{strtoull}", fu_common_strtoull_func);
 	g_test_add_func("/fwupd/common{version}", fu_common_version_func);
 	g_test_add_func("/fwupd/common{version-semver}", fu_common_version_semver_func);
 	g_test_add_func("/fwupd/common{vercmp}", fu_common_vercmp_func);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -310,6 +310,8 @@ fu_device_cfi_device_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(cmd, ==, 0xC7);
 	g_assert_cmpint(fu_cfi_device_get_size(cfi_device), ==, 0x10000);
+	g_assert_cmpint(fu_cfi_device_get_page_size(cfi_device), ==, 0x200);
+	g_assert_cmpint(fu_cfi_device_get_sector_size(cfi_device), ==, 0x2000);
 }
 
 static void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -960,6 +960,10 @@ LIBFWUPDPLUGIN_1.7.3 {
   global:
     fu_archive_firmware_get_type;
     fu_archive_firmware_new;
+    fu_cfi_device_get_page_size;
+    fu_cfi_device_get_sector_size;
+    fu_cfi_device_set_page_size;
+    fu_cfi_device_set_sector_size;
     fu_common_strtoull_full;
     fu_common_sum16;
     fu_common_sum16_bytes;

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -960,6 +960,7 @@ LIBFWUPDPLUGIN_1.7.3 {
   global:
     fu_archive_firmware_get_type;
     fu_archive_firmware_new;
+    fu_common_strtoull_full;
     fu_common_sum16;
     fu_common_sum16_bytes;
     fu_common_sum16w;

--- a/libfwupdplugin/tests/quirks.d/tests.quirk
+++ b/libfwupdplugin/tests/quirks.d/tests.quirk
@@ -20,4 +20,6 @@ Flags = updatable,internal
 Name = A25Lxxx
 CfiDeviceCmdChipErase = 0xc7
 CfiDeviceCmdSectorErase = 0x20
+CfiDevicePageSize = 0x200
+CfiDeviceSectorSize = 0x2000
 FirmwareSizeMax = 0x10000

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -823,8 +823,11 @@ static gboolean
 fu_ata_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, GError **error)
 {
 	FuAtaDevice *self = FU_ATA_DEVICE(device);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "AtaTransferMode") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
 		if (tmp != ATA_SUBCMD_MICROCODE_DOWNLOAD_CHUNKS_ACTIVATE &&
 		    tmp != ATA_SUBCMD_MICROCODE_DOWNLOAD_CHUNKS &&
 		    tmp != ATA_SUBCMD_MICROCODE_DOWNLOAD_CHUNK) {
@@ -839,15 +842,8 @@ fu_ata_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		return TRUE;
 	}
 	if (g_strcmp0(key, "AtaTransferBlocks") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "AtaTransferBlocks only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->transfer_blocks = (guint16)tmp;
 		return TRUE;
 	}

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1525,41 +1525,25 @@ fu_ccgx_hpi_device_set_quirk_kv(FuDevice *device,
 				GError **error)
 {
 	FuCcgxHpiDevice *self = FU_CCGX_HPI_DEVICE(device);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "SiliconId") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			self->silicon_id = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid SiliconId");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		self->silicon_id = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "CcgxFlashRowSize") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT32) {
-			self->flash_row_size = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid CcgxFlashRowSize");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->flash_row_size = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "CcgxFlashSize") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT32) {
-			self->flash_size = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid CcgxFlashSize");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->flash_size = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "CcgxImageKind") == 0) {
 		self->fw_image_type = fu_ccgx_fw_image_type_from_string(value);

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -286,7 +286,9 @@ static gboolean
 fu_cpu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, GError **error)
 {
 	if (g_strcmp0(key, "PciBcrAddr") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
 		fu_device_set_metadata_integer(device, "PciBcrAddr", tmp);
 		return TRUE;
 	}

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -152,25 +152,24 @@ fu_dell_dock_hub_set_quirk_kv(FuDevice *device,
 			      GError **error)
 {
 	FuDellDockHub *self = FU_DELL_DOCK_HUB(device);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "DellDockUnlockTarget") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT8) {
-			self->unlock_target = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DellDockUnlockTarget");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->unlock_target = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobMajorOffset") == 0) {
-		self->blob_major_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_major_offset = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobMinorOffset") == 0) {
-		self->blob_minor_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_minor_offset = tmp;
 		return TRUE;
 	}
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -890,30 +890,19 @@ static gboolean
 fu_dell_dock_ec_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, GError **error)
 {
 	FuDellDockEc *self = FU_DELL_DOCK_EC(device);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "DellDockUnlockTarget") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT8) {
-			self->unlock_target = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DellDockUnlockTarget");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->unlock_target = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBoardMin") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT8) {
-			self->board_min = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DellDockBoardMin");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->board_min = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockVersionLowest") == 0) {
 		self->ec_minimum_version = g_strdup(value);
@@ -924,7 +913,9 @@ fu_dell_dock_ec_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *va
 		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobVersionOffset") == 0) {
-		self->blob_version_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_version_offset = tmp;
 		return TRUE;
 	}
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -1098,32 +1098,34 @@ fu_dell_dock_mst_set_quirk_kv(FuDevice *device,
 			      GError **error)
 {
 	FuDellDockMst *self = FU_DELL_DOCK_MST(device);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "DellDockUnlockTarget") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT8) {
-			self->unlock_target = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DellDockUnlockTarget");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->unlock_target = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobMajorOffset") == 0) {
-		self->blob_major_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_major_offset = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobMinorOffset") == 0) {
-		self->blob_minor_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_minor_offset = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "DellDockBlobBuildOffset") == 0) {
-		self->blob_build_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_build_offset = tmp;
 		return TRUE;
 	} else if (g_strcmp0(key, "DellDockInstallDurationI2C") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, 60 * 60 * 24, error))
+			return FALSE;
 		fu_device_set_install_duration(device, tmp);
 		return TRUE;
 	}

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -149,30 +149,30 @@ fu_dell_dock_tbt_set_quirk_kv(FuDevice *device,
 			      GError **error)
 {
 	FuDellDockTbt *self = FU_DELL_DOCK_TBT(device);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "DellDockUnlockTarget") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT8) {
-			self->unlock_target = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DellDockUnlockTarget");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->unlock_target = tmp;
+		return TRUE;
 	} else if (g_strcmp0(key, "DellDockInstallDurationI2C") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, 60 * 60 * 24, error))
+			return FALSE;
 		fu_device_set_install_duration(device, tmp);
 		return TRUE;
 	} else if (g_strcmp0(key, "DellDockHubVersionLowest") == 0) {
 		self->hub_minimum_version = g_strdup(value);
 		return TRUE;
 	} else if (g_strcmp0(key, "DellDockBlobMajorOffset") == 0) {
-		self->blob_major_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_major_offset = tmp;
 		return TRUE;
 	} else if (g_strcmp0(key, "DellDockBlobMinorOffset") == 0) {
-		self->blob_minor_offset = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_minor_offset = tmp;
 		return TRUE;
 	}
 	/* failed */

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -128,7 +128,10 @@ fu_dell_dock_status_set_quirk_kv(FuDevice *device,
 {
 	FuDellDockStatus *self = FU_DELL_DOCK_STATUS(device);
 	if (g_strcmp0(key, "DellDockBlobVersionOffset") == 0) {
-		self->blob_version_offset = fu_common_strtoull(value);
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->blob_version_offset = tmp;
 		return TRUE;
 	}
 

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1777,6 +1777,7 @@ fu_dfu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 {
 	FuDfuDevice *self = FU_DFU_DEVICE(device);
 	FuDfuDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, FU_QUIRKS_DFU_FORCE_VERSION) == 0) {
 		if (value != NULL) {
@@ -1794,28 +1795,16 @@ fu_dfu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		return FALSE;
 	}
 	if (g_strcmp0(key, "DfuForceTimeout") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT) {
-			priv->timeout_ms = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DFU timeout");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT, error))
+			return FALSE;
+		priv->timeout_ms = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DfuForceTransferSize") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			priv->force_transfer_size = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid DFU transfer size");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		priv->force_transfer_size = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "DfuAltName") == 0) {
 		fu_dfu_device_set_chip_id(self, value);

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -563,29 +563,17 @@ fu_elantp_hid_device_set_quirk_kv(FuDevice *device,
 				  GError **error)
 {
 	FuElantpHidDevice *self = FU_ELANTP_HID_DEVICE(device);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "ElantpIcPageCount") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "ElantpIcPageCount only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->ic_page_count = (guint16)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "ElantpIapPassword") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "ElantpIapPassword only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->iap_password = (guint16)tmp;
 		return TRUE;
 	}

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -657,42 +657,23 @@ fu_elantp_i2c_device_set_quirk_kv(FuDevice *device,
 				  GError **error)
 {
 	FuElantpI2cDevice *self = FU_ELANTP_I2C_DEVICE(device);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "ElantpIcPageCount") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "ElantpIcPageCount only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->ic_page_count = (guint16)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "ElantpIapPassword") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "ElantpIapPassword only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->iap_password = (guint16)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "ElantpI2cTargetAddress") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp > 0xffff) {
-			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "ElantpI2cTargetAddress only supports "
-					    "values <= 0xffff");
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
 			return FALSE;
-		}
 		self->i2c_addr = (guint16)tmp;
 		return TRUE;
 	}

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -693,16 +693,11 @@ fu_fastboot_device_set_quirk_kv(FuDevice *device,
 
 	/* load from quirks */
 	if (g_strcmp0(key, "FastbootBlockSize") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp >= 0x40 && tmp < 0x100000) {
-			self->blocksz = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid block size");
-		return FALSE;
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0x40, 0x100000, error))
+			return FALSE;
+		self->blocksz = tmp;
+		return TRUE;
 	}
 
 	/* failed */

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -90,7 +90,9 @@ fu_flashrom_device_set_quirk_kv(FuDevice *device,
 				GError **error)
 {
 	if (g_strcmp0(key, "PciBcrAddr") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
 		fu_device_set_metadata_integer(device, "PciBcrAddr", tmp);
 		return TRUE;
 	}

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -470,7 +470,9 @@ fu_intel_spi_device_set_quirk_kv(FuDevice *device,
 {
 	FuIntelSpiDevice *self = FU_INTEL_SPI_DEVICE(device);
 	if (g_strcmp0(key, "IntelSpiBar") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
 		self->phys_spibar = tmp;
 		return TRUE;
 	}

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -393,7 +393,10 @@ fu_nvme_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 {
 	FuNvmeDevice *self = FU_NVME_DEVICE(device);
 	if (g_strcmp0(key, "NvmeBlockSize") == 0) {
-		self->write_block_size = fu_common_strtoull(value);
+		guint64 tmp = 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->write_block_size = tmp;
 		return TRUE;
 	}
 

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -90,23 +90,39 @@ fu_redfish_device_probe_related_pcie_item(FuRedfishDevice *self, const gchar *ur
 	}
 	if (json_object_has_member(json_obj, "VendorId")) {
 		const gchar *tmp = json_object_get_string_member(json_obj, "VendorId");
-		if (tmp != NULL && tmp[0] != '\0')
-			vendor_id = fu_common_strtoull(tmp);
+		if (tmp != NULL && tmp[0] != '\0') {
+			if (!fu_common_strtoull_full(tmp, &vendor_id, 0, G_MAXUINT16, error))
+				return FALSE;
+		}
 	}
 	if (json_object_has_member(json_obj, "DeviceId")) {
 		const gchar *tmp = json_object_get_string_member(json_obj, "DeviceId");
-		if (tmp != NULL && tmp[0] != '\0')
-			model_id = fu_common_strtoull(tmp);
+		if (tmp != NULL && tmp[0] != '\0') {
+			if (!fu_common_strtoull_full(tmp, &model_id, 0, G_MAXUINT16, error))
+				return FALSE;
+		}
 	}
 	if (json_object_has_member(json_obj, "SubsystemVendorId")) {
 		const gchar *tmp = json_object_get_string_member(json_obj, "SubsystemVendorId");
-		if (tmp != NULL && tmp[0] != '\0')
-			subsystem_vendor_id = fu_common_strtoull(tmp);
+		if (tmp != NULL && tmp[0] != '\0') {
+			if (!fu_common_strtoull_full(tmp,
+						     &subsystem_vendor_id,
+						     0,
+						     G_MAXUINT16,
+						     error))
+				return FALSE;
+		}
 	}
 	if (json_object_has_member(json_obj, "SubsystemId")) {
 		const gchar *tmp = json_object_get_string_member(json_obj, "SubsystemId");
-		if (tmp != NULL && tmp[0] != '\0')
-			subsystem_model_id = fu_common_strtoull(tmp);
+		if (tmp != NULL && tmp[0] != '\0') {
+			if (!fu_common_strtoull_full(tmp,
+						     &subsystem_model_id,
+						     0,
+						     G_MAXUINT16,
+						     error))
+				return FALSE;
+		}
 	}
 
 	/* add vendor ID */

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -158,47 +158,30 @@ fu_rts54hid_module_set_quirk_kv(FuDevice *device,
 				GError **error)
 {
 	FuRts54HidModule *self = FU_RTS54HID_MODULE(device);
+	guint64 tmp = 0;
 
 	/* load target address from quirks */
 	if (g_strcmp0(key, "Rts54TargetAddr") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp <= 0xff) {
-			self->target_addr = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid target address");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->target_addr = tmp;
+		return TRUE;
 	}
 
 	/* load i2c speed from quirks */
 	if (g_strcmp0(key, "Rts54I2cSpeed") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < FU_RTS54HID_I2C_SPEED_LAST) {
-			self->i2c_speed = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid I²C speed");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, FU_RTS54HID_I2C_SPEED_LAST - 1, error))
+			return FALSE;
+		self->i2c_speed = tmp;
+		return TRUE;
 	}
 
 	/* load register address length from quirks */
 	if (g_strcmp0(key, "Rts54RegisterAddrLen") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp <= 0xff) {
-			self->register_addr_len = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid register address length");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		self->register_addr_len = tmp;
+		return TRUE;
 	}
 
 	/* failed */

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
@@ -57,47 +57,30 @@ fu_rts54hub_rtd21xx_device_set_quirk_kv(FuDevice *device,
 {
 	FuRts54hubRtd21xxDevice *self = FU_RTS54HUB_RTD21XX_DEVICE(device);
 	FuRts54hubRtd21xxDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp = 0;
 
 	/* load target address from quirks */
 	if (g_strcmp0(key, "Rts54TargetAddr") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp <= 0xff) {
-			priv->target_addr = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid target address");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->target_addr = tmp;
+		return TRUE;
 	}
 
 	/* load i2c speed from quirks */
 	if (g_strcmp0(key, "Rts54I2cSpeed") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < FU_RTS54HUB_I2C_SPEED_LAST) {
-			priv->i2c_speed = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid I²C speed");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, FU_RTS54HUB_I2C_SPEED_LAST - 1, error))
+			return FALSE;
+		priv->i2c_speed = tmp;
+		return TRUE;
 	}
 
 	/* load register address length from quirks */
 	if (g_strcmp0(key, "Rts54RegisterAddrLen") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp <= 0xff) {
-			priv->register_addr_len = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "invalid register address length");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->register_addr_len = tmp;
+		return TRUE;
 	}
 
 	/* failed */

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -418,53 +418,39 @@ fu_superio_device_set_quirk_kv(FuDevice *device,
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE(device);
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "SuperioAutoloadAction") == 0)
 		return TRUE;
 	if (g_strcmp0(key, "SuperioId") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			priv->id = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid value");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		priv->id = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "SuperioPort") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			priv->port = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid value");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		priv->port = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "SuperioControlPort") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			priv->control_port = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid value");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		priv->control_port = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "SuperioDataPort") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT16) {
-			priv->data_port = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid value");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT16, error))
+			return FALSE;
+		priv->data_port = tmp;
+		return TRUE;
 	}
 	if (g_strcmp0(key, "SuperioTimeout") == 0) {
-		guint64 tmp = fu_common_strtoull(value);
-		if (tmp < G_MAXUINT) {
-			priv->timeout_ms = tmp;
-			return TRUE;
-		}
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid value");
-		return FALSE;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT, error))
+			return FALSE;
+		priv->timeout_ms = tmp;
+		return TRUE;
 	}
 
 	/* failed */

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -807,20 +807,30 @@ fu_synaptics_cxaudio_device_set_quirk_kv(FuDevice *device,
 					 GError **error)
 {
 	FuSynapticsCxaudioDevice *self = FU_SYNAPTICS_CXAUDIO_DEVICE(device);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "CxaudioChipIdBase") == 0) {
-		self->chip_id_base = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->chip_id_base = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CxaudioSoftwareReset") == 0) {
-		self->sw_reset_supported = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->sw_reset_supported = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CxaudioPatch1ValidAddr") == 0) {
-		self->eeprom_patch_valid_addr = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->eeprom_patch_valid_addr = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "CxaudioPatch2ValidAddr") == 0) {
-		self->eeprom_patch2_valid_addr = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		self->eeprom_patch2_valid_addr = tmp;
 		return TRUE;
 	}
 	g_set_error_literal(error,

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -588,12 +588,18 @@ fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 {
 	FuVliDevice *self = FU_VLI_DEVICE(device);
 	FuVliDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "CfiDeviceCmdReadIdSz") == 0) {
-		priv->spi_cmd_read_id_sz = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->spi_cmd_read_id_sz = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "VliSpiAutoDetect") == 0) {
-		priv->spi_auto_detect = fu_common_strtoull(value) > 0;
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT8, error))
+			return FALSE;
+		priv->spi_auto_detect = tmp > 0;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "VliDeviceKind") == 0) {

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -315,16 +315,24 @@ fu_wacom_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *va
 {
 	FuWacomDevice *self = FU_WACOM_DEVICE(device);
 	FuWacomDevicePrivate *priv = GET_PRIVATE(self);
+	guint64 tmp = 0;
+
 	if (g_strcmp0(key, "WacomI2cFlashBlockSize") == 0) {
-		priv->flash_block_size = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXSIZE, error))
+			return FALSE;
+		priv->flash_block_size = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "WacomI2cFlashBaseAddr") == 0) {
-		priv->flash_base_addr = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		priv->flash_base_addr = tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "WacomI2cFlashSize") == 0) {
-		priv->flash_size = fu_common_strtoull(value);
+		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXUINT32, error))
+			return FALSE;
+		priv->flash_size = tmp;
 		return TRUE;
 	}
 	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");


### PR DESCRIPTION
Setting a flash ID of `C84016` would then add `CFI\FLASHID_C84016` and
also `CFI\FLASHID_C840`. This makes it easier to write quirks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
