### PR TITLE
Fixup the GLib error message when inotify/max_user_instances is too low

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -307,6 +307,9 @@ host_cpu = host_machine.cpu_family()
 if cc.has_header('sys/utsname.h')
   conf.set('HAVE_UTSNAME_H', '1')
 endif
+if cc.has_header('sys/inotify.h')
+  conf.set('HAVE_INOTIFY_H', '1')
+endif
 if cc.has_header('sys/ioctl.h')
   conf.set('HAVE_IOCTL_H', '1')
 endif


### PR DESCRIPTION
This can be reproduced using sysctl fs.inotify.max_user_instances=25
and then running the daemon.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
