### PR TITLE
trivial: Add the missing plugin_cpu

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -37,6 +37,7 @@ meson .. \
     -Dplugin_bcm57xx=false \
     -Dplugin_pixart_rf=false \
     -Dplugin_cfu=false \
+    -Dplugin_cpu=false \
     -Dplugin_ep963x=false \
     -Dplugin_tpm=false \
     -Dsystemd=false \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,7 @@ option('plugin_amt', type : 'boolean', value : true, description : 'enable Intel
 option('plugin_acpi_phat', type : 'boolean', value : true, description : 'enable ACPI PHAT support')
 option('plugin_bcm57xx', type : 'boolean', value : true, description : 'enable BCM57xx support')
 option('plugin_cfu', type : 'boolean', value : false, description : 'enable CFU support')
+option('plugin_cpu', type : 'boolean', value : true, description : 'enable CPU support')
 option('plugin_dell', type : 'boolean', value : true, description : 'enable Dell-specific support')
 option('plugin_dummy', type : 'boolean', value : false, description : 'enable the dummy device')
 option('plugin_emmc', type : 'boolean', value : true, description : 'enable eMMC support')

--- a/plugins/cpu/meson.build
+++ b/plugins/cpu/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and get_option('plugin_uefi_pk')
+if get_option('hsi') and get_option('plugin_cpu')
 cargs = ['-DG_LOG_DOMAIN="FuPluginCpu"']
 
 install_data(['cpu.quirk'],


### PR DESCRIPTION
I think using the plugin_uefi_pk option was probably a typo.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
