### PR TITLE
modem-manager: add Quectel EG25-G modem support

### DIFF
--- a/plugins/fastboot/README.md
+++ b/plugins/fastboot/README.md
@@ -47,6 +47,12 @@ Block size to use for transfers.
 
 Since: 1.2.2
 
+### FastbootOperationDelay
+
+Time in ms to delay after a read or write operation.
+
+Since: 1.7.4
+
 ## Vendor ID Security
 
 The vendor ID is set from the USB vendor, for example `USB:0x18D1`

--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -1,3 +1,7 @@
 # All fastboot devices
 [USB\CLASS_FF&SUBCLASS_42&PROT_03]
 Plugin = fastboot
+
+# Quectel EG25-G modem
+[USB\VID_18D1&PID_D00D]
+FastbootBlockSize = 16384

--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -5,3 +5,4 @@ Plugin = fastboot
 # Quectel EG25-G modem
 [USB\VID_18D1&PID_D00D]
 FastbootBlockSize = 16384
+FastbootOperationDelay = 100

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -708,12 +708,6 @@ fu_fastboot_device_set_quirk_kv(FuDevice *device,
 		self->blocksz = tmp;
 		return TRUE;
 	}
-	if (g_strcmp0(key, "FastbootBlockSize") == 0) {
-		if (!fu_common_strtoull_full(value, &tmp, 0x40, 0x100000, error))
-			return FALSE;
-		self->blocksz = tmp;
-		return TRUE;
-	}
 	if (g_strcmp0(key, "FastbootOperationDelay") == 0) {
 		if (!fu_common_strtoull_full(value, &tmp, 0, G_MAXSIZE, error))
 			return FALSE;

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -43,8 +43,10 @@ CounterpartGuid = USB\VID_0489&PID_E0B5
 [USB\VID_2C7C&PID_0125]
 Summary = Quectel EG25-G modem
 CounterpartGuid = USB\VID_18D1&PID_D00D
+Flags = detach-at-fastboot-has-no-response
 
 # Quectel EG25-G in fastboot mode
 [USB\VID_18D1&PID_D00D]
 Summary = Quectel EG25-G modem (fastboot)
 CounterpartGuid = USB\VID_2C7C&PID_0125
+Flags = detach-at-fastboot-has-no-response

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -38,3 +38,13 @@ CounterpartGuid = USB\VID_0489&PID_E0B8
 [USB\VID_0489&PID_E0B8]
 Summary = Foxconn T77w968/eSIM LTE modem (fastboot)
 CounterpartGuid = USB\VID_0489&PID_E0B5
+
+# Quectel EG25-G
+[USB\VID_2C7C&PID_0125]
+Summary = Quectel EG25-G modem
+CounterpartGuid = USB\VID_18D1&PID_D00D
+
+# Quectel EG25-G in fastboot mode
+[USB\VID_18D1&PID_D00D]
+Summary = Quectel EG25-G modem (fastboot)
+CounterpartGuid = USB\VID_2C7C&PID_0125


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

# Description

The Quectel EG25-G modem is used in the [Pine64 PinePhone](https://pine64.org/pinephone) and [PinePhone Pro](https://pine64.org/pinephonepro) .
By default it ships with an old firmware version which can be upgraded to newer versions from Quectel or a more open firmware developed at https://github.com/Biktorgj/pinephone_modem_sdk.
The current `fwupd` version sees the Quectel EG25-G through the `modem-manager` plugin as upgradable using the `fastboot` plugin. However, the Quectel EG25-G fastboot bootloader is picky when you interact with it:

- Blocksize must be `16384` bytes, not a byte more or less. If you still try another size, the next chunk the `fastboot` plugin writes to the modem fails which reboots the bootloader. I discovered this by analyzing the USB traffic of the same payload (once with `fwupd` and once with the original fastboot binary) with Wireshark.
- Writing and reading data cannot happen at `fwupd`'s rate otherwise the fastboot bootloader crashes and reboot, the original fastboot binary seems to have some delay between writes/reads. If you enable the debug prints of the `fastboot` plugin, this is also 'fixed', but I properly fixed it by introducing a new quirk.
- The modem shows up under an entirely different USB vendor and device ID which causes `fwupd` to not see it. Adding the necessary quirks in `modem-manager` fixes it (like done for all other modems there).

# Changes

- Add GUIDs for the Quectel EG25-G modem in fastboot to `modem-manager` plugin's quirks
- Introduce a new quirk `ModemManagerAtHasResponse` to ignore the responses when entering fastboot mode, default: expects a response.
- Add this no response quirk for the Quectel EG25-G modem
- Introduce a delay operations quirk in the `fastboot` plugin to sleep after a read or write operation, default: 0 us.
- Add this delay operations quirk tor the Quectel EG25-G modem

# Test environment

- Pine64 PinePhone with a Quectel EG25-G modem
- Alpine Linux / postmarketOS edge
- musl

# Disclaimer for distros

*These patches are not ready to be shipped to end-users, I kindly ask you to not ship them to any users, even when they are bleeding edge channels of your distro. At all times, I'm not responsible for complains about bricked modems!*

# Related issues

Fixes #3968 