### PR TITLE
Quectel EG25-G: improve upload stability and require AC power

### DIFF
--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -5,4 +5,4 @@ Plugin = fastboot
 # Quectel EG25-G modem
 [USB\VID_18D1&PID_D00D]
 FastbootBlockSize = 16384
-FastbootOperationDelay = 100
+FastbootOperationDelay = 250

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1520,6 +1520,7 @@ fu_mm_device_init(FuMmDevice *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary(FU_DEVICE(self), "Mobile broadband device");


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

With #4076 merged, I have a following up MR:

# Changes

## Improve upload stability

I did more tests with bigger firmware packages and in some rare cases, 100ms between every read/write operation is too low for a stable upgrade process. Increasing this to 250ms improves the upload stability a lot.
Without it, it might be that the upgrade process stalls after ~5-10 minutes as the bootloader doesn't respond anymore.

## Require AC power to upgrade

To improve the safety of upgrades, I added a flag to the `modem-manager` to require AC power before starting the upgrade.
This is more safe as you don't want to brick the modem due to an empty battery on a laptop or in my case a phone.

# Test environment

- Pine64 PinePhone
- Quectel EG25-G modem
- postmarketOS edge
- fwupd 90baeaabbc94589512642fe970eecbd852ae3532

CC: @aleksander0m @ivanmikh 