### PR TITLE
trivial: contrib/setup: if markdown isn't installed don't show an error

### DIFF
--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -31,11 +31,14 @@ def detect_profile():
 
 
 def test_markdown():
-    import markdown
+    try:
+        import markdown
 
-    new_enough = markdown.__version_info__ >= MINIMUM_MARKDOWN
+        new_enough = markdown.__version_info__ >= MINIMUM_MARKDOWN
+    except ModuleNotFoundError:
+        new_enough = False
     if not new_enough:
-        print("python3-markdown must be upgraded")
+        print("python3-markdown must be installed/upgraded")
     sys.exit(not new_enough)
 
 


### PR DESCRIPTION
```
Install developer-friendly **unsafe** PolicyKit rules into /etc/polkit-1/rules.d? (y/N) n
Traceback (most recent call last):
  File "/home/supermario/fwupd/./contrib/ci/fwupd_setup_helpers.py", line 154, in <module>
    test_markdown()
  File "/home/supermario/fwupd/./contrib/ci/fwupd_setup_helpers.py", line 34, in test_markdown
    import markdown
ModuleNotFoundError: No module named 'markdown'
Collecting markdown
  Downloading Markdown-3.3.6-py3-none-any.whl (97 kB)
     |████████████████████████████████| 97 kB 1.1 MB/s
Collecting importlib-metadata>=4.4
  Downloading importlib_metadata-4.8.2-py3-none-any.whl (17 kB)
Collecting zipp>=0.5
  Downloading zipp-3.6.0-py3-none-any.whl (5.3 kB)
Installing collected packages: zipp, importlib-metadata, markdown
Successfully installed importlib-metadata-4.8.2 markdown-3.3.6 zipp-3.6.0
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
