### PR TITLE
plugins/flashrom: Remove number version format for StarLabs

### DIFF
--- a/contrib/ci/Dockerfile-launchpad.in
+++ b/contrib/ci/Dockerfile-launchpad.in
@@ -1,0 +1,8 @@
+FROM %%%ARCH_PREFIX%%%ubuntu:focal
+%%%OS%%%
+ENV CI_NETWORK true
+RUN echo fubar > /etc/machine-id
+%%%ARCH_SPECIFIC_COMMAND%%%
+%%%INSTALL_DEPENDENCIES_COMMAND%%%
+WORKDIR /github/workspace
+CMD ["./contrib/ci/launchpad.sh"]

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -9,6 +9,9 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="bash">
     <distro id="void">
@@ -27,6 +30,10 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="bubblewrap">
     <distro id="debian">
@@ -38,6 +45,9 @@
       <package />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -70,14 +80,23 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="clang">
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="clang-tools">
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -89,6 +108,9 @@
       <package variant="x86_64" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -122,6 +144,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libcairo-gobject2">
     <distro id="centos">
@@ -139,6 +165,15 @@
     <distro id="ubuntu">
       <control />
       <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="libdistro-info-perl">
+    <distro id="launchpad">
+      <control />
     </distro>
   </dependency>
   <dependency type="build" id="libjson-glib-dev">
@@ -168,6 +203,12 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <version>(>= 1.1.1)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libftdi1-dev">
     <distro id="arch">
@@ -184,6 +225,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
+       <control />
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -203,6 +248,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -229,6 +278,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="devscripts">
     <distro id="debian">
@@ -236,6 +289,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -248,6 +304,12 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <version>(>= 12)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <version>(>= 12)</version>
       </control>
@@ -266,6 +328,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -287,10 +352,36 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="intltool">
     <distro id="debian">
       <package variant="s390x" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="libelf-dev">
+    <distro id="centos">
+      <package>elfutils-libelf-devel</package>
+    </distro>
+    <distro id="fedora">
+      <package>elfutils-libelf-devel</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="s390x">libelf-dev:s390x</package>
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
     </distro>
   </dependency>
   <dependency type="build" id="fakeroot">
@@ -299,6 +390,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -319,6 +413,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="fontconfig">
     <distro id="centos">
@@ -336,6 +434,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libflashrom-dev">
     <distro id="fedora">
@@ -349,6 +451,12 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <exclusive>ia64</exclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <exclusive>ia64</exclusive>
       </control>
@@ -375,6 +483,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="gettext">
     <distro id="centos">
@@ -395,6 +507,12 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <version>(>= 0.19.8.1)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <version>(>= 0.19.8.1)</version>
       </control>
@@ -442,6 +560,16 @@
       <package variant="x86_64">gnu-efi</package>
       <package variant="i386">gnu-efi</package>
     </distro>
+    <distro id="launchpad">
+      <control>
+        <inclusive>amd64</inclusive>
+        <inclusive>arm64</inclusive>
+        <inclusive>armhf</inclusive>
+        <inclusive>i386</inclusive>
+      </control>
+      <package variant="x86_64">gnu-efi</package>
+      <package variant="i386">gnu-efi</package>
+    </distro>
   </dependency>
   <dependency type="build" id="git">
     <distro id="arch">
@@ -464,6 +592,9 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libglib2.0-doc">
     <distro id="debian">
@@ -471,6 +602,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -493,6 +627,12 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <version>(>= 2.45.8)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <version>(>= 2.45.8)</version>
       </control>
@@ -526,6 +666,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="gnome-desktop-testing">
     <distro id="fedora">
@@ -536,6 +680,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -556,6 +703,10 @@
       <package variant="i386">libgnutls28-dev</package>
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -580,6 +731,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <!-- TODO: Drop build dependency after switching to gidoc-gen -->
   <dependency type="build" id="gtk-doc-tools">
@@ -598,6 +753,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -639,6 +798,12 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <version>(>= 0.1.13)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libjcat-dev">
     <distro id="fedora">
@@ -651,6 +816,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -672,6 +841,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libarchive-dev">
     <distro id="centos">
@@ -687,6 +860,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -726,6 +903,15 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <inclusive>amd64</inclusive>
+        <inclusive>arm64</inclusive>
+        <inclusive>armhf</inclusive>
+        <inclusive>i386</inclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libefiboot-dev">
     <distro id="debian">
@@ -739,6 +925,15 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <inclusive>amd64</inclusive>
+        <inclusive>arm64</inclusive>
+        <inclusive>armhf</inclusive>
+        <inclusive>i386</inclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <inclusive>amd64</inclusive>
         <inclusive>arm64</inclusive>
@@ -768,6 +963,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
     <distro id="void">
       <package>gcab-devel</package>
     </distro>
@@ -780,6 +979,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -798,6 +1001,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -824,6 +1031,12 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <version>(>= 0.3.5)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <version>(>= 0.3.3)</version>
       </control>
@@ -870,9 +1083,20 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <inclusive>i386</inclusive>
+        <inclusive>amd64</inclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libsoup2.4-dev">
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -903,6 +1127,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libtool-bin">
     <distro id="debian">
@@ -911,6 +1139,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -926,6 +1158,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -954,6 +1189,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="meson">
     <distro id="arch">
@@ -972,6 +1211,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1002,6 +1245,15 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <inclusive>amd64</inclusive>
+        <inclusive>arm64</inclusive>
+        <inclusive>armhf</inclusive>
+        <inclusive>i386</inclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="gir1.2-pango-1.0">
     <distro id="centos">
@@ -1022,6 +1274,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="pkg-config">
     <distro id="debian">
@@ -1030,6 +1286,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1064,6 +1324,12 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <version>(>> 0.105-14)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libmm-glib-dev">
     <distro id="centos">
@@ -1082,6 +1348,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1106,6 +1376,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libmbim-glib-dev">
     <distro id="centos">
@@ -1127,6 +1401,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libpolkit-gobject-1-dev">
     <distro id="centos">
@@ -1145,6 +1423,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1182,6 +1464,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="gi-docgen">
     <distro id="void">
@@ -1194,6 +1480,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="python3-typogrify">
     <distro id="debian">
@@ -1202,6 +1492,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
     <distro id="fedora">
@@ -1220,12 +1513,18 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="python3-markdown">
     <distro id="fedora">
       <package />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -1239,6 +1538,9 @@
       <package />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -1263,6 +1565,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1305,6 +1611,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
     <distro id="void">
       <package>sqlite-devel</package>
     </distro>
@@ -1335,6 +1645,12 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <version>(>= 231)</version>
+      </control>
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libsystemd-dev">
     <distro id="centos">
@@ -1350,6 +1666,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1374,6 +1694,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="texlive-fonts-recommended">
     <distro id="debian">
@@ -1381,6 +1705,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>
@@ -1392,6 +1719,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1412,6 +1743,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1436,6 +1771,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1472,6 +1811,26 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control>
+        <exclusive>ia64</exclusive>
+        <exclusive>riscv64</exclusive>
+        <exclusive>x32</exclusive>
+        <exclusive>mips</exclusive>
+        <exclusive>sparc64</exclusive>
+        <exclusive>sh4</exclusive>
+        <exclusive>ppc64</exclusive>
+        <exclusive>powerpcspe</exclusive>
+        <exclusive>hppa</exclusive>
+        <exclusive>alpha</exclusive>
+        <exclusive>mips64el</exclusive>
+        <exclusive>armhf</exclusive>
+        <exclusive>armel</exclusive>
+        <exclusive>mipsel</exclusive>
+        <exclusive>m68k</exclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control>
         <exclusive>ia64</exclusive>
         <exclusive>riscv64</exclusive>
@@ -1530,6 +1889,15 @@
       </control>
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control>
+        <inclusive>amd64</inclusive>
+        <inclusive>arm64</inclusive>
+        <inclusive>armhf</inclusive>
+        <inclusive>i386</inclusive>
+      </control>
+      <package variant="x86_64" />
+    </distro>
     <distro id="void">
       <package>tpm2-tss-devel</package>
     </distro>
@@ -1541,6 +1909,9 @@
   </dependency>
   <dependency type="build" id="shellcheck">
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
     <distro id="fedora">
@@ -1557,6 +1928,10 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <control />
       <package variant="x86_64" />
     </distro>
@@ -1577,6 +1952,10 @@
       <control />
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <control />
+      <package variant="x86_64" />
+    </distro>
     <distro id="fedora">
       <package />
     </distro>
@@ -1588,6 +1967,9 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="launchpad">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="python3-venv">
     <distro id="debian">
@@ -1595,6 +1977,9 @@
       <package variant="i386" />
     </distro>
     <distro id="ubuntu">
+      <package variant="x86_64" />
+    </distro>
+    <distro id="launchpad">
       <package variant="x86_64" />
     </distro>
   </dependency>

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -56,7 +56,7 @@ with open("Dockerfile", "w") as wfd:
                 wfd.write("RUN dnf --enablerepo=updates-testing -y install \\\n")
             elif OS == "centos":
                 wfd.write("RUN yum -y install \\\n")
-            elif OS == "debian" or OS == "ubuntu":
+            elif OS == "debian" or OS == "ubuntu" or OS == "launchpad":
                 wfd.write("RUN apt update -qq && \\\n")
                 wfd.write(
                     "\tDEBIAN_FRONTEND=noninteractive apt install -yq --no-install-recommends\\\n"

--- a/contrib/ci/launchpad.sh
+++ b/contrib/ci/launchpad.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+set -x
+
+#prepare
+export DEBFULLNAME="Sean Rhodes"
+export DEBEMAIL="sean@starlabs.systems"
+
+MAJOR=`head meson.build | grep ' version :' | cut -d \' -f2`
+if [[ "$MAJOR" == "1.7.0" ]]; then
+	VERSION=`echo 1.7.0.2166+f`
+else
+	VERSION=`echo $MAJOR+f`
+fi
+
+rm -rf build/
+mkdir -p build
+shopt -s extglob
+cp -lR !(build|dist|venv) build/
+pushd build
+mv contrib/debian .
+sed s/quilt/native/ debian/source/format -i
+#generate control file
+./contrib/ci/generate_debian.py
+
+#check if we have all deps available
+#if some are missing, we're going to use subproject instead and
+#packaging CI will fail
+./contrib/ci/generate_dependencies.py  | xargs apt install -y || true
+if ! dpkg-checkbuilddeps; then
+	# sudo add-apt-repository ppa:starlabs/fwupd
+	echo "deb http://ppa.launchpad.net/starlabs/fw/ubuntu focal main" > /etc/apt/sources.list.d/starlabs.list
+	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 17A20BAF70BEC3904545ACFF8F21C26C794386E3
+	apt update
+	./contrib/ci/generate_dependencies.py | xargs apt install -y
+fi
+
+#clone test firmware
+if [ "$CI_NETWORK" = "true" ]; then
+	./contrib/ci/get_test_firmware.sh
+	export G_TEST_SRCDIR=`pwd`/fwupd-test-firmware/installed-tests
+fi
+
+#disable unit tests if fwupd is already installed (may cause problems)
+if [ -x /usr/lib/fwupd/fwupd ]; then
+	export DEB_BUILD_OPTIONS=nocheck
+fi
+#build the package
+EDITOR=/bin/true dch --create --package fwupd --distribution focal -v $VERSION "CI Build"
+
+debuild -S

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -30,17 +30,14 @@ Plugin = flashrom
 # StarLabTop Mk III (coreboot GUID)
 [d33219e2-b84c-53a8-a624-27af9752dba6]
 Branch = coreboot
-VersionFormat = number
 Flags = reset-cmos
 
 # StarLabTop Mk IV (coreboot GUID)
 [0ee5867c-93f0-5fb4-adf1-9d686ea1183a]
 Branch = coreboot
-VersionFormat = number
 Flags = reset-cmos
 
 # StarBook Mk V (coreboot GUID)
 [54c96fef-31e7-5011-a3ff-ea8e855d9acd]
 Branch = coreboot
-VersionFormat = number
 Flags = reset-cmos


### PR DESCRIPTION
Remove "number" version format to allow different versioning

Signed-off-by: Sean Rhodes <sean@starlabs.systems>