### PR TITLE
uefi-capsule: Check for OsIndications before enabling CapsuleOnDisk

### DIFF
--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -678,6 +678,16 @@ fu_plugin_uefi_capsule_check_cod_support(GError **error)
 	guint64 value = 0;
 	g_autofree guint8 *buf = NULL;
 
+	/* we don't care what the data is, but we need it to exist */
+	if (!fu_efivar_get_data(FU_EFIVAR_GUID_EFI_GLOBAL,
+				"OsIndications",
+				NULL,
+				NULL,
+				NULL,
+				error)) {
+		g_prefix_error(error, "failed to read EFI variable: ");
+		return FALSE;
+	}
 	if (!fu_efivar_get_data(FU_EFIVAR_GUID_EFI_GLOBAL,
 				"OsIndicationsSupported",
 				&buf,


### PR DESCRIPTION
It shouldn't be possible to have `FILE_CAPSULE_DELIVERY_SUPPORTED` set
in `OsIndicationsSupported` without a valid `OsIndications`, but here
we are. I suspect Windows 10 is checking in the same way.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
