### PR TITLE
plugins/flashrom: Remove number version format for StarLabs

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -30,17 +30,17 @@ Plugin = flashrom
 # StarLabTop Mk III (coreboot GUID)
 [d33219e2-b84c-53a8-a624-27af9752dba6]
 Branch = coreboot
-VersionFormat = number
+VersionFormat = plain
 Flags = reset-cmos
 
 # StarLabTop Mk IV (coreboot GUID)
 [0ee5867c-93f0-5fb4-adf1-9d686ea1183a]
 Branch = coreboot
-VersionFormat = number
+VersionFormat = plain
 Flags = reset-cmos
 
 # StarBook Mk V (coreboot GUID)
 [54c96fef-31e7-5011-a3ff-ea8e855d9acd]
 Branch = coreboot
-VersionFormat = number
+VersionFormat = plain
 Flags = reset-cmos


### PR DESCRIPTION
Remove "number" version format to allow different versioning (i.e. 7.4 and 8)

Signed-off-by: Sean Rhodes <sean@starlabs.systems>