### PR TITLE
uefi-capsule: clarify UDisks requirement for ESP autodetection

### DIFF
--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -96,11 +96,12 @@ from within the OS by fwupd. This requires compiling with libsmbios support.
 When fwupd has been compiled with this support you will be able to enable UEFI
 support on the device by using the `unlock` command.
 
-## Custom EFI System Partition
+## Custom EFI System Partition (ESP)
 
-Since version 1.1.0 fwupd will autodetect the ESP when it is mounted on
-`/boot/efi`, `/boot`, or `/efi`. A custom EFI system partition location can be
-used by modifying *OverrideESPMountPoint* in `/etc/fwupd/uefi_capsule.conf`.
+Since version 1.1.0 fwupd will autodetect the ESP if it is mounted on
+`/boot/efi`, `/boot`, or `/efi`, and UDisks is available on the system. In
+other cases the mount point of the ESP needs to be manually specified using the
+option *OverrideESPMountPoint* in `/etc/fwupd/uefi_capsule.conf`.
 
 Setting an invalid directory will disable the fwupd plugin.
 

--- a/plugins/uefi-capsule/uefi_capsule.conf
+++ b/plugins/uefi-capsule/uefi_capsule.conf
@@ -7,8 +7,8 @@
 # the fwupd.efi file has been self-signed manually
 #DisableShimForSecureBoot=true
 
-# the EFI system partition path used
-# if this is is not /boot/efi, /boot, or /efi
+# the EFI system partition (ESP) path used if UDisks is not available
+# or if this partition is not mounted at /boot/efi, /boot, or /efi
 #OverrideESPMountPoint=
 
 # amount of free space required on the ESP, for example using 0x2000000 for 32Mb


### PR DESCRIPTION
The ESP is autodetected only if UDisks is available, but this was not explicitly documented so far.

Fixes #4103

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
