### PR TITLE
Modem modemanger udev context

### DIFF
--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -128,6 +128,10 @@ fu_plugin_mm_udev_device_port_added(FuPlugin *plugin,
 		fu_plugin_mm_udev_device_ports_timeout_reset(plugin);
 		return;
 	}
+
+	/* device is being created, update is complete, uninhibit */
+	fu_plugin_mm_uninhibit_device(plugin);
+
 	/* create device and add to cache */
 	dev = fu_mm_device_udev_new(fu_plugin_get_context(plugin), priv->manager, priv->inhibited);
 	fu_mm_device_udev_add_port(dev, subsystem, path, ifnum);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

# Changes

## Pass context with udev based discovery as well

When a modem is discovered through udev after upgrading it, the context was not passed.
This resulted in the following messages in the log:
```
FuDevice             no FuContext assigned for FuMmDevice:
```
Passing the context fixes it.

## Uninhibit modem after upgrading

ModemManager gives all controls to fwupd when upgrading by inhibiting the modem through the modem-manager plugin.
However, after upgrading, the controls should be given back to ModemManager by uninhibiting the modem. That last part was missing in the case of udev discovery. Because of this, ModemManager saw the modem but didn't expose it as it remained inhibited. Restarting ModemManager or rebooting the device worked around the issue, but didn't solve the cause of it.

Therefore, uninhibit as well when a modem is rediscovered through udev and solve a segfault as well in the mean time due to `g_autofree` and `g_steal_pointer`. They stole a pointer which was still necessary for the rest of the uninhibiting part.
I could reproduce this continuously when the method was invoked.

# Issues

Fixes #4110 

# Test environment

- Pine64 PinePhone
- Quectel EG25-G modem
- postmarketOS edge
- fwupd db94a995bd94600af98933eacc957cdbec27bf41