### PR TITLE
modem-manager: log when modem is added

### DIFF
--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -219,6 +219,9 @@ fu_plugin_mm_device_add(FuPlugin *plugin, MMObject *modem)
 	const gchar *object_path = mm_object_get_path(modem);
 	g_autoptr(FuMmDevice) dev = NULL;
 	g_autoptr(GError) error = NULL;
+
+	g_debug("added modem: %s", object_path);
+
 	if (fu_plugin_cache_lookup(plugin, object_path) != NULL) {
 		g_warning("MM device already added, ignoring");
 		return;


### PR DESCRIPTION
Modem removals are logged, but nothing is logged when a modem is added.
Makes it easier for debugging.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
