### PR TITLE
Modem manager branch support

### DIFF
--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -20,6 +20,16 @@ These device use the ModemManager "Firmware Device IDs" as the GUID, e.g.
 * `PCI\VID_1EAC&PID_1002`
 * `PCI\VID_1EAC`
 
+## Quirk Use
+
+This plugin uses the following plugin-specific quirk:
+
+### ModemManagerBranchAtCommand
+
+AT command to execute to determine the firmware branch currently installed on the modem.
+
+Since: 1.7.4
+
 ## Vendor ID Security
 
 The vendor ID is set from the USB or PCI vendor, for example `USB:0x413C` `PCI:0x105B`

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -44,9 +44,11 @@ CounterpartGuid = USB\VID_0489&PID_E0B5
 Summary = Quectel EG25-G modem
 CounterpartGuid = USB\VID_18D1&PID_D00D
 Flags = detach-at-fastboot-has-no-response
+ModemManagerBranchAtCommand = AT+GETFWBRANCH
 
 # Quectel EG25-G in fastboot mode
 [USB\VID_18D1&PID_D00D]
 Summary = Quectel EG25-G modem (fastboot)
 CounterpartGuid = USB\VID_2C7C&PID_0125
 Flags = detach-at-fastboot-has-no-response
+ModemManagerBranchAtCommand = AT+GETFWBRANCH


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation

# Changes

- Add support for setting the firmware branch in `modem-manager` plugin.
- Read firmware branch using a custom AT command from the modem.
- Configure the quirk for the Quectel EG25-G modem to use `AT+GETFWBRANCH` as custom AT command to get the firmware branch

**Alternative firmware running 0.5.1 on branch `FOSS-002`**:
```
└─QUECTEL Mobile Broadband Module:
      Device ID:          976c4a39e87f61e6940ea6a8d39c583cfa99615f
      Summary:            Quectel EG25-G modem
      Current version:    0.5.1
      Vendor:             QUALCOMM INCORPORATED (USB:0x2C7C)
      Release Branch:     FOSS-002
      GUIDs:              db379a33-254f-5140-b37e-d36ae7e5c039
                          1a2996cb-f86e-5583-a464-e1b96e1c6ae9 ← USB\VID_2C7C&PID_0125&REV_0318
                          587bf468-6859-5522-93a7-6cce552a0aa3 ← USB\VID_2C7C&PID_0125
                          22ae45db-f68e-5c55-9c02-4557dca238ec ← USB\VID_2C7C
      Device Flags:       • Updatable
                          • System requires external power source
                          • Supported on remote server
                          • Device supports switching to a different branch of firmware
```

If the AT command fails or is not implemented by the current running firmware, the error generated by it is unset and we consider running the default branch = official Quectel firmware.

# Involved issues

Fixes #4114 

# Environment

- Pine64 PinePhone, Quectel EG25-G
- postmarketOS edge, musl
- fwupd main