### PR TITLE
Do not allow UEFI updates when the lid is closed

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -3950,6 +3950,28 @@ fu_battery_state_to_string(FuBatteryState battery_state)
 }
 
 /**
+ * fu_lid_state_to_string:
+ * @lid_state: a battery state, e.g. %FU_LID_STATE_CLOSED
+ *
+ * Converts an enumerated type to a string.
+ *
+ * Returns: a string, or %NULL for invalid
+ *
+ * Since: 1.7.4
+ **/
+const gchar *
+fu_lid_state_to_string(FuLidState lid_state)
+{
+	if (lid_state == FU_LID_STATE_UNKNOWN)
+		return "unknown";
+	if (lid_state == FU_LID_STATE_OPEN)
+		return "open";
+	if (lid_state == FU_LID_STATE_CLOSED)
+		return "closed";
+	return NULL;
+}
+
+/**
  * fu_bytes_get_data_safe:
  * @bytes: data blob
  * @bufsz: (out) (optional): location to return size of byte data

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -160,6 +160,22 @@ typedef enum {
 } FuBatteryState;
 
 /**
+ * FuLidState:
+ * @FU_LID_STATE_UNKNOWN:		Unknown
+ * @FU_LID_STATE_OPEN:			Charging
+ * @FU_LID_STATE_CLOSED:		Discharging
+ *
+ * The device lid state.
+ **/
+typedef enum {
+	FU_LID_STATE_UNKNOWN,
+	FU_LID_STATE_OPEN,
+	FU_LID_STATE_CLOSED,
+	/*< private >*/
+	FU_LID_STATE_LAST
+} FuLidState;
+
+/**
  * FuOutputHandler:
  * @line: text data
  * @user_data: user data
@@ -469,6 +485,8 @@ gboolean
 fu_common_reset_firmware_search_path(GError **error);
 const gchar *
 fu_battery_state_to_string(FuBatteryState battery_state);
+const gchar *
+fu_lid_state_to_string(FuLidState lid_state);
 
 void
 fu_xmlb_builder_insert_kv(XbBuilderNode *bn, const gchar *key, const gchar *value);

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -73,6 +73,10 @@ FuBatteryState
 fu_context_get_battery_state(FuContext *self);
 void
 fu_context_set_battery_state(FuContext *self, FuBatteryState battery_state);
+FuLidState
+fu_context_get_lid_state(FuContext *self);
+void
+fu_context_set_lid_state(FuContext *self, FuLidState lid_state);
 guint
 fu_context_get_battery_level(FuContext *self);
 void

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -235,6 +235,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "no-auto-remove";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_MD_SET_VENDOR)
 		return "md-set-vendor";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED)
+		return "no-lid-closed";
 	return NULL;
 }
 
@@ -293,6 +295,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE;
 	if (g_strcmp0(flag, "md-set-vendor") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_MD_SET_VENDOR;
+	if (g_strcmp0(flag, "no-lid-closed") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3427,6 +3427,15 @@ fu_device_add_string(FuDevice *self, guint idt, GString *str)
 		tmps = fu_common_strjoin_array(",", tmpv);
 		fu_common_string_append_kv(str, idt + 1, "PrivateFlags", tmps);
 	}
+	if (priv->inhibits != NULL) {
+		g_autoptr(GList) values = g_hash_table_get_values(priv->inhibits);
+		for (GList *l = values; l != NULL; l = l->next) {
+			FuDeviceInhibit *inhibit = (FuDeviceInhibit *)l->data;
+			g_autofree gchar *val =
+			    g_strdup_printf("[%s] %s", inhibit->inhibit_id, inhibit->reason);
+			fu_common_string_append_kv(str, idt + 1, "Inhibit", val);
+		}
+	}
 
 	/* subclassed */
 	if (klass->to_string != NULL)

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -418,6 +418,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_MD_SET_VENDOR (1ull << 20)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED:
+ *
+ * Do not allow updating when the laptop lid is closed.
+ *
+ * Since: 1.7.4
+ */
+#define FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED (1ull << 21)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -983,6 +983,9 @@ LIBFWUPDPLUGIN_1.7.4 {
     fu_cfi_device_get_block_size;
     fu_cfi_device_set_block_size;
     fu_common_get_contents_stream;
+    fu_context_get_lid_state;
+    fu_context_set_lid_state;
+    fu_lid_state_to_string;
     fu_memmem_safe;
     fu_plugin_set_secure_config_value;
   local: *;

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -465,6 +465,8 @@ fu_plugin_uefi_capsule_coldplug_device(FuPlugin *plugin, FuUefiDevice *dev, GErr
 	}
 	if (fu_context_has_hwid_flag(ctx, "no-ux-capsule"))
 		fu_device_add_private_flag(FU_DEVICE(dev), FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE);
+	if (fu_context_has_hwid_flag(ctx, "no-lid-closed"))
+		fu_device_add_internal_flag(FU_DEVICE(dev), FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED);
 
 	/* set fallback name if nothing else is set */
 	device_kind = fu_uefi_device_get_kind(dev);

--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -12,7 +12,7 @@ Flags = uefi-force-enable
 
 # Lenovo
 [6de5d951-d755-576b-bd09-c5cf66b27234]
-Flags = supports-boot-order-lock,use-legacy-bootmgr-desc,no-ux-capsule
+Flags = supports-boot-order-lock,use-legacy-bootmgr-desc,no-ux-capsule,no-lid-closed
 
 # Lenovo ThinkPad X1 Yoga 4th
 [1138930e-8df1-5ae0-b946-7b0d9c9b4a79]


### PR DESCRIPTION
Most vendors do not mirror the firmware update to an external display,
and some don't behave correctly when the lid is shut and the machine is
docked.

Fixes https://github.com/fwupd/firmware-lenovo/issues/181

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
