### PR TITLE
trivial: snap: pull from github instead of gitlab

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,7 +87,7 @@ parts:
   # this is for the library only, we don't care about the daemon "in-snap"
   modemmanager:
     plugin: autotools
-    source: https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
+    source: https://github.com/freedesktop/ModemManager.git
     source-tag: 1.14.0
     # build without these; system daemon needs them
     build-packages:
@@ -110,7 +110,7 @@ parts:
       - -lib/girepository-1.0
   libmbim:
     plugin: autotools
-    source: https://gitlab.freedesktop.org/mobile-broadband/libmbim.git
+    source: https://github.com/freedesktop/libmbim.git
     source-tag: 1.24.0
     after: [modemmanager]
     # build without these; system daemon needs them
@@ -145,7 +145,7 @@ parts:
       - -share
   libqmi:
     plugin: autotools
-    source: https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
+    source: https://github.com/freedesktop/libqmi.git
     source-tag: 1.26.0
     after: [modemmanager, libmbim]
     # build without these; system daemon needs them


### PR DESCRIPTION
Github has a read-only mirror of FDO gitlab which is expected to
be more reliable than FDO gitlab.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
