### PR TITLE
trivial: fix man page sections

### DIFF
--- a/plugins/dfu/dfu-tool.1
+++ b/plugins/dfu/dfu-tool.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "dfu-tool man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "dfu-tool man page"
 .SH NAME
 dfu-tool \- write firmware to DFU devices
 .SH SYNOPSIS

--- a/plugins/uefi-capsule/fwupdate.1
+++ b/plugins/uefi-capsule/fwupdate.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "fwupdate man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "fwupdate man page"
 .SH NAME
 fwupdate \-ddebugging utility for UEFI firmware updates
 .SH SYNOPSIS

--- a/plugins/uefi-dbx/dbxtool.1
+++ b/plugins/uefi-dbx/dbxtool.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "dbxtool man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "dbxtool man page"
 .SH NAME
 dbxtool \- modify the dbx revokation list
 .SH SYNOPSIS

--- a/src/fwupdagent.1
+++ b/src/fwupdagent.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "fwupdagent man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "fwupdagent man page"
 .SH NAME
 fwupdagent \- firmware updating agent
 .SH SYNOPSIS

--- a/src/fwupdmgr.1
+++ b/src/fwupdmgr.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "fwupdmgr man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "fwupdmgr man page"
 .SH NAME
 fwupdmgr \- firmware update manager client utility
 .SH SYNOPSIS

--- a/src/fwupdtool.1
+++ b/src/fwupdtool.1
@@ -1,5 +1,5 @@
 .\" Report problems in https://github.com/fwupd/fwupd
-.TH man 8 "11 April 2021" @PACKAGE_VERSION@ "fwupdtool man page"
+.TH man 1 "11 April 2021" @PACKAGE_VERSION@ "fwupdtool man page"
 .SH NAME
 fwupdtool \- standalone firmware update utility
 .SH SYNOPSIS


### PR DESCRIPTION
They're marked in the man page as section 8 but installed into 1.
They should be installed into 1 as they're not admin tools.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
