### PR TITLE
Add fu_usb_device_add_interface() for plugins to use

### DIFF
--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -46,3 +46,7 @@ gboolean
 fu_usb_device_is_open(FuUsbDevice *device);
 GUdevDevice *
 fu_usb_device_find_udev_device(FuUsbDevice *device, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fu_usb_device_set_configuration(FuUsbDevice *device, gint configuration);
+void
+fu_usb_device_add_interface(FuUsbDevice *device, guint8 number);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -988,5 +988,7 @@ LIBFWUPDPLUGIN_1.7.4 {
     fu_lid_state_to_string;
     fu_memmem_safe;
     fu_plugin_set_secure_config_value;
+    fu_usb_device_add_interface;
+    fu_usb_device_set_configuration;
   local: *;
 } LIBFWUPDPLUGIN_1.7.3;

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -349,29 +349,6 @@ fu_colorhug_device_probe(FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_colorhug_device_open(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_colorhug_device_parent_class)->open(device, error))
-		return FALSE;
-
-	/* got the version using the HID API */
-	if (!g_usb_device_set_configuration(usb_device, CH_USB_CONFIG, error))
-		return FALSE;
-	if (!g_usb_device_claim_interface(usb_device,
-					  CH_USB_INTERFACE,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
 fu_colorhug_device_setup(FuDevice *device, GError **error)
 {
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE(device);
@@ -587,6 +564,8 @@ fu_colorhug_device_init(FuColorhugDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_COLORHUG_DEVICE_FLAG_HALFSIZE,
 					"halfsize");
+	fu_usb_device_set_configuration(FU_USB_DEVICE(self), CH_USB_CONFIG);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), CH_USB_INTERFACE);
 }
 
 static void
@@ -598,7 +577,6 @@ fu_colorhug_device_class_init(FuColorhugDeviceClass *klass)
 	klass_device->detach = fu_colorhug_device_detach;
 	klass_device->reload = fu_colorhug_device_reload;
 	klass_device->setup = fu_colorhug_device_setup;
-	klass_device->open = fu_colorhug_device_open;
 	klass_device->probe = fu_colorhug_device_probe;
 	klass_device->set_progress = fu_colorhug_device_set_progress;
 }

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -319,21 +319,6 @@ fu_goodixmoc_device_attach(FuDevice *device, FuProgress *progress, GError **erro
 }
 
 static gboolean
-fu_goodixmoc_device_open(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_goodixmoc_device_parent_class)->open(device, error))
-		return FALSE;
-
-	return g_usb_device_claim_interface(usb_device,
-					    GX_USB_INTERFACE,
-					    G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					    error);
-}
-
-static gboolean
 fu_goodixmoc_device_setup(FuDevice *device, GError **error)
 {
 	FuGoodixMocDevice *self = FU_GOODIXMOC_DEVICE(device);
@@ -471,6 +456,7 @@ fu_goodixmoc_device_init(FuGoodixMocDevice *self)
 	fu_device_set_install_duration(FU_DEVICE(self), 10);
 	fu_device_set_firmware_size_min(FU_DEVICE(self), 0x20000);
 	fu_device_set_firmware_size_max(FU_DEVICE(self), 0x30000);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), GX_USB_INTERFACE);
 }
 
 static void
@@ -480,6 +466,5 @@ fu_goodixmoc_device_class_init(FuGoodixMocDeviceClass *klass)
 	klass_device->write_firmware = fu_goodixmoc_device_write_firmware;
 	klass_device->setup = fu_goodixmoc_device_setup;
 	klass_device->attach = fu_goodixmoc_device_attach;
-	klass_device->open = fu_goodixmoc_device_open;
 	klass_device->set_progress = fu_goodixmoc_device_set_progress;
 }

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -160,6 +160,8 @@ fu_logitech_bulkcontroller_device_probe(FuDevice *device, GError **error)
 			}
 		}
 	}
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), self->update_iface);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), self->sync_iface);
 	return TRUE;
 #else
 	g_set_error_literal(error,
@@ -869,62 +871,6 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 }
 
 static gboolean
-fu_logitech_bulkcontroller_device_open(FuDevice *device, GError **error)
-{
-	FuLogitechBulkcontrollerDevice *self = FU_LOGITECH_BULKCONTROLLER_DEVICE(device);
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_logitech_bulkcontroller_device_parent_class)->open(device, error))
-		return FALSE;
-
-	/* claim both interfaces */
-	if (!g_usb_device_claim_interface(usb_device,
-					  self->update_iface,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		g_prefix_error(error, "failed to claim update interface: ");
-		return FALSE;
-	}
-	if (!g_usb_device_claim_interface(usb_device,
-					  self->sync_iface,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		g_prefix_error(error, "failed to claim sync interface: ");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
-fu_logitech_bulkcontroller_device_close(FuDevice *device, GError **error)
-{
-	FuLogitechBulkcontrollerDevice *self = FU_LOGITECH_BULKCONTROLLER_DEVICE(device);
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-
-	if (!g_usb_device_release_interface(usb_device,
-					    self->update_iface,
-					    G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					    error)) {
-		g_prefix_error(error, "failed to release update interface: ");
-		return FALSE;
-	}
-	if (!g_usb_device_release_interface(usb_device,
-					    self->sync_iface,
-					    G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					    error)) {
-		g_prefix_error(error, "failed to release sync interface: ");
-		return FALSE;
-	}
-
-	/* FuUsbDevice->close */
-	return FU_DEVICE_CLASS(fu_logitech_bulkcontroller_device_parent_class)
-	    ->close(device, error);
-}
-
-static gboolean
 fu_logitech_bulkcontroller_device_get_handshake_cb(FuDevice *device,
 						   gpointer user_data,
 						   GError **error)
@@ -1203,7 +1149,5 @@ fu_logitech_bulkcontroller_device_class_init(FuLogitechBulkcontrollerDeviceClass
 	klass_device->write_firmware = fu_logitech_bulkcontroller_device_write_firmware;
 	klass_device->probe = fu_logitech_bulkcontroller_device_probe;
 	klass_device->setup = fu_logitech_bulkcontroller_device_setup;
-	klass_device->open = fu_logitech_bulkcontroller_device_open;
-	klass_device->close = fu_logitech_bulkcontroller_device_close;
 	klass_device->set_progress = fu_logitech_bulkcontroller_device_set_progress;
 }

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -15,29 +15,6 @@
 G_DEFINE_TYPE(FuSteelseriesDevice, fu_steelseries_device, FU_TYPE_USB_DEVICE)
 
 static gboolean
-fu_steelseries_device_open(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-	const guint8 iface_idx = 0x00;
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_steelseries_device_parent_class)->open(device, error))
-		return FALSE;
-
-	/* get firmware version on SteelSeries Rival 100 */
-	if (!g_usb_device_claim_interface(usb_device,
-					  iface_idx,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		g_prefix_error(error, "failed to claim interface: ");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
 fu_steelseries_device_setup(FuDevice *device, GError **error)
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
@@ -104,29 +81,11 @@ fu_steelseries_device_setup(FuDevice *device, GError **error)
 	return TRUE;
 }
 
-static gboolean
-fu_steelseries_device_close(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-	const guint8 iface_idx = 0x00;
-
-	/* we're done here */
-	if (!g_usb_device_release_interface(usb_device,
-					    iface_idx,
-					    G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					    error)) {
-		g_prefix_error(error, "failed to release interface: ");
-		return FALSE;
-	}
-
-	/* FuUsbDevice->close */
-	return FU_DEVICE_CLASS(fu_steelseries_device_parent_class)->close(device, error);
-}
-
 static void
-fu_steelseries_device_init(FuSteelseriesDevice *device)
+fu_steelseries_device_init(FuSteelseriesDevice *self)
 {
-	fu_device_set_version_format(FU_DEVICE(device), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0x00);
 }
 
 static void
@@ -134,6 +93,4 @@ fu_steelseries_device_class_init(FuSteelseriesDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 	klass_device->setup = fu_steelseries_device_setup;
-	klass_device->open = fu_steelseries_device_open;
-	klass_device->close = fu_steelseries_device_close;
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -63,24 +63,6 @@ typedef struct __attribute__((packed)) {
 
 G_DEFINE_TYPE(FuSynapromDevice, fu_synaprom_device, FU_TYPE_USB_DEVICE)
 
-static gboolean
-fu_synaprom_device_open(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_synaprom_device_parent_class)->open(device, error))
-		return FALSE;
-
-	if (!g_usb_device_claim_interface(usb_device,
-					  0x0,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		return FALSE;
-	}
-	return TRUE;
-}
-
 gboolean
 fu_synaprom_device_cmd_send(FuSynapromDevice *device,
 			    GByteArray *request,
@@ -534,6 +516,7 @@ fu_synaprom_device_init(FuSynapromDevice *self)
 	fu_device_set_summary(FU_DEVICE(self), "Fingerprint reader");
 	fu_device_set_vendor(FU_DEVICE(self), "Synaptics");
 	fu_device_add_icon(FU_DEVICE(self), "touchpad-disabled");
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0x0);
 }
 
 static void
@@ -546,7 +529,6 @@ fu_synaprom_device_class_init(FuSynapromDeviceClass *klass)
 	klass_device->reload = fu_synaprom_device_setup;
 	klass_device->attach = fu_synaprom_device_attach;
 	klass_device->detach = fu_synaprom_device_detach;
-	klass_device->open = fu_synaprom_device_open;
 	klass_device->set_progress = fu_synaprom_device_set_progress;
 }
 

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -172,45 +172,6 @@ fu_system76_launch_device_detach(FuDevice *device, FuProgress *progress, GError 
 	return TRUE;
 }
 
-static gboolean
-fu_system76_launch_device_open(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-	const guint8 iface_idx = 0x01;
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_system76_launch_device_parent_class)->open(device, error))
-		return FALSE;
-
-	if (!g_usb_device_claim_interface(usb_device,
-					  iface_idx,
-					  G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					  error)) {
-		g_prefix_error(error, "failed to claim interface: ");
-		return FALSE;
-	}
-
-	return TRUE;
-}
-
-static gboolean
-fu_system76_launch_device_close(FuDevice *device, GError **error)
-{
-	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
-	const guint8 iface_idx = 0x01;
-
-	if (!g_usb_device_release_interface(usb_device,
-					    iface_idx,
-					    G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
-					    error)) {
-		g_prefix_error(error, "failed to release interface: ");
-		return FALSE;
-	}
-
-	/* FuUsbDevice->close */
-	return FU_DEVICE_CLASS(fu_system76_launch_device_parent_class)->close(device, error);
-}
-
 static void
 fu_system76_launch_device_set_progress(FuDevice *self, FuProgress *progress)
 {
@@ -231,6 +192,7 @@ fu_system76_launch_device_init(FuSystem76LaunchDevice *self)
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_add_protocol(FU_DEVICE(self), "org.usb.dfu");
 	fu_device_retry_set_delay(FU_DEVICE(self), 100);
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0x01);
 }
 
 static void
@@ -239,7 +201,5 @@ fu_system76_launch_device_class_init(FuSystem76LaunchDeviceClass *klass)
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
 	klass_device->setup = fu_system76_launch_device_setup;
 	klass_device->detach = fu_system76_launch_device_detach;
-	klass_device->open = fu_system76_launch_device_open;
-	klass_device->close = fu_system76_launch_device_close;
 	klass_device->set_progress = fu_system76_launch_device_set_progress;
 }


### PR DESCRIPTION
It's a common action for plugins to call FuUsbDevice->open() then claim
interfaces, and then release them just before FuUsbDevice->close().

It's also something a lot of plugins get wrong, so provide common code
to handle it correctly in one place.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
