### PR TITLE
Increase the chances of success of WAIT_FOR_REPLUG on WIN32

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -104,6 +104,26 @@ fu_backend_device_changed(FuBackend *self, FuDevice *device)
 }
 
 /**
+ * fu_backend_registered:
+ * @self: a #FuBackend
+ * @device: a device
+ *
+ * Calls the ->registered() vfunc for the backend. This allows the backend to perform shared
+ * backend actions on superclassed devices.
+ *
+ * Since: 1.7.4
+ **/
+void
+fu_backend_registered(FuBackend *self, FuDevice *device)
+{
+	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
+	g_return_if_fail(FU_IS_BACKEND(self));
+	g_return_if_fail(FU_IS_DEVICE(device));
+	if (klass->registered != NULL)
+		klass->registered(self, device);
+}
+
+/**
  * fu_backend_setup:
  * @self: a #FuBackend
  * @error: (nullable): optional return location for an error

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -17,8 +17,9 @@ struct _FuBackendClass {
 	/* signals */
 	gboolean (*setup)(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*coldplug)(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+	void (*registered)(FuBackend *self, FuDevice *device);
 	/*< private >*/
-	gpointer padding[29];
+	gpointer padding[28];
 };
 
 const gchar *
@@ -43,3 +44,5 @@ void
 fu_backend_device_removed(FuBackend *self, FuDevice *device);
 void
 fu_backend_device_changed(FuBackend *self, FuDevice *device);
+void
+fu_backend_registered(FuBackend *self, FuDevice *device);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -980,6 +980,7 @@ LIBFWUPDPLUGIN_1.7.3 {
 
 LIBFWUPDPLUGIN_1.7.4 {
   global:
+    fu_backend_registered;
     fu_cfi_device_get_block_size;
     fu_cfi_device_set_block_size;
     fu_common_get_contents_stream;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5619,6 +5619,10 @@ fu_engine_plugin_device_register(FuEngine *self, FuDevice *device)
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
 		fu_plugin_runner_device_register(plugin, device);
 	}
+	for (guint i = 0; i < self->backends->len; i++) {
+		FuBackend *backend = g_ptr_array_index(self->backends, i);
+		fu_backend_registered(backend, device);
+	}
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_REGISTERED);
 }
 

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -20,6 +20,33 @@ struct _FuUsbBackend {
 
 G_DEFINE_TYPE(FuUsbBackend, fu_usb_backend, FU_TYPE_BACKEND)
 
+#define FU_USB_BACKEND_POLL_INTERVAL_DEFAULT	 1000 /* ms */
+#define FU_USB_BACKEND_POLL_INTERVAL_WAIT_REPLUG 5    /* ms */
+
+#ifdef _WIN32
+static void
+fu_usb_backend_device_notify_flags_cb(FuDevice *device, GParamSpec *pspec, FuBackend *backend)
+{
+#if G_USB_CHECK_VERSION(0, 3, 10)
+	FuUsbBackend *self = FU_USB_BACKEND(backend);
+
+	/* if waiting for a disconnect, set win32 to poll insanely fast -- and set it
+	 * back to the default when the device removal was detected */
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG)) {
+		g_debug("setting USB poll interval to %ums to detect replug",
+			(guint)FU_USB_BACKEND_POLL_INTERVAL_WAIT_REPLUG);
+		g_usb_context_set_hotplug_poll_interval(self->usb_ctx,
+							FU_USB_BACKEND_POLL_INTERVAL_WAIT_REPLUG);
+	} else {
+		g_usb_context_set_hotplug_poll_interval(self->usb_ctx,
+							FU_USB_BACKEND_POLL_INTERVAL_DEFAULT);
+	}
+#else
+	g_warning("GUsb >= 0.3.10 may be needed to notice device enumeration");
+#endif
+}
+#endif
+
 static void
 fu_usb_backend_device_added_cb(GUsbContext *ctx, GUsbDevice *usb_device, FuBackend *backend)
 {
@@ -82,6 +109,22 @@ fu_usb_backend_coldplug(FuBackend *backend, GError **error)
 }
 
 static void
+fu_usb_backend_registered(FuBackend *backend, FuDevice *device)
+{
+#ifdef _WIN32
+	/* not required */
+	if (!FU_IS_USB_DEVICE(device))
+		return;
+
+	/* on win32 we need to poll the context faster */
+	g_signal_connect(FU_DEVICE(device),
+			 "notify::flags",
+			 G_CALLBACK(fu_usb_backend_device_notify_flags_cb),
+			 backend);
+#endif
+}
+
+static void
 fu_usb_backend_finalize(GObject *object)
 {
 	FuUsbBackend *self = FU_USB_BACKEND(object);
@@ -108,6 +151,7 @@ fu_usb_backend_class_init(FuUsbBackendClass *klass)
 	object_class->finalize = fu_usb_backend_finalize;
 	klass_backend->setup = fu_usb_backend_setup;
 	klass_backend->coldplug = fu_usb_backend_coldplug;
+	klass_backend->registered = fu_usb_backend_registered;
 }
 
 FuBackend *


### PR DESCRIPTION
Decrease the GUsb polling interval when any of the devices is in
`WAIT_FOR_REPLUG` on when running on Windows. Any device that can
re-enumerate much faster than the default 1000ms may be missed and the
detach may fail.

Linux doesn't have this problem as it has `LIBUSB_CAP_HAS_HOTPLUG`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
