### PR TITLE
trivial: disable logitech bulk controller on ubuntu by default

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -44,6 +44,11 @@ ifneq ($(QUBES_OPTION),)
 	CONFARGS += -Dqubes=true
 endif
 
+#Needs a MIR
+ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu && echo yes))
+       CONFARGS += -Dplugin_logitech_bulkcontroller=false
+endif
+
 CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=false -Ddocs=gtkdoc -Dsupported_build=true
 
 %:


### PR DESCRIPTION
It needs to go through a MIR

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
