### PR TITLE
redfish: Do not autoload ipmi-si to avoid warning on non-server hardware

### DIFF
--- a/plugins/redfish/fwupd-redfish.conf
+++ b/plugins/redfish/fwupd-redfish.conf
@@ -1,2 +1,1 @@
-ipmi-si
 ipmi-devintf


### PR DESCRIPTION
This leads to reports of:

    systemd-modules-load[1710]: Failed to insert 'ipmi_si': No such device
    systemd-modules-load.service: Main process exited, code=exited, status=1/FAILURE

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
