### PR TITLE
trivial: allow multiple GUID or DEVICE-ID to update command

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -609,6 +609,10 @@
     <distro id="fedora">
       <package />
     </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency type="build" id="libxmlb-dev">
     <distro id="arch">

--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -54,7 +54,8 @@ Recommends: python3,
 	    secureboot-db,
 	    udisks2,
 	    fwupd-unsigned,
-	    fwupd-signed
+	    fwupd-signed,
+	    jq
 Suggests: gir1.2-fwupd-2.0
 Provides: fwupdate
 Conflicts: fwupdate-amd64-signed,

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -137,6 +137,7 @@ Provides: fwupdate-efi
 # optional, but a really good idea
 Recommends: udisks2
 Recommends: bluez
+Recommends: jq
 
 %if 0%{?have_modem_manager}
 Recommends: %{name}-plugin-modem-manager

--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -65,7 +65,7 @@ _fwupdmgr_opts=(
 _show_filters()
 {
 	local flags
-	flags="$(command @libexecdir@/fwupdtool get-device-flags 2>/dev/null)"
+	flags="$(command fwupdtool get-device-flags 2>/dev/null)"
 	COMPREPLY+=( $(compgen -W "${flags}" -- "$cur") )
 }
 
@@ -76,12 +76,12 @@ _show_modifiers()
 
 _show_device_ids()
 {
+	if ! command -v jq &> /dev/null; then
+		return 0
+	fi
 	local description
-	OLDIFS=$IFS
-	IFS=$'\n'
-	description="$(command fwupdagent get-devices 2>/dev/null | sed -e 's,"Name" :,,; s,",,g; s,\,,,g; s,[[:space:]]\+,,' | command awk '!/DeviceId/ { line = $0 }; /DeviceId/ { print $3 " { "line" }"}')"
+	description="$(command fwupdmgr get-devices --json 2>/dev/null | jq '.Devices | .[] | .DeviceId')"
 	COMPREPLY+=( $(compgen -W "${description}" -- "$cur") )
-	IFS=$OLDIFS
 }
 
 _show_remotes()
@@ -107,7 +107,7 @@ _fwupdmgr()
 	esac
 
 	case $command in
-	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update|get-updates|switch-branch)
+	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update|get-updates|switch-branch|update|upgrade)
 		if [[ "$prev" = "$command" ]]; then
 			_show_device_ids
 		else

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -64,22 +64,25 @@ _fwupdtool_opts=(
 _show_filters()
 {
 	local flags
-	flags="$(command @libexecdir@/fwupdtool get-device-flags 2>/dev/null)"
+	flags="$(command fwupdtool get-device-flags 2>/dev/null)"
 	COMPREPLY+=( $(compgen -W "${flags}" -- "$cur") )
 }
 
 _show_firmware_types()
 {
 	local firmware_types
-	firmware_types="$(command @libexecdir@/fwupdtool get-firmware-types 2>/dev/null)"
+	firmware_types="$(command fwupdtool get-firmware-types 2>/dev/null)"
 	COMPREPLY+=( $(compgen -W "${firmware_types}" -- "$cur") )
 }
 
 
 _show_plugins()
 {
+	if ! command -v jq &> /dev/null; then
+		return 0
+	fi
 	local plugins
-	plugins="$(command @libexecdir@/fwupdtool get-plugins 2>/dev/null)"
+	plugins="$(command fwupdtool get-plugins --json 2>/dev/null | jq '.Plugins | .[] | .Name')"
 	COMPREPLY+=( $(compgen -W "${plugins}" -- "$cur") )
 }
 

--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -3,27 +3,14 @@ if bashcomp.found()
     define_variable: bashcomp.version().version_compare('>= 2.10') ? ['datadir', datadir] : ['prefix', prefix],
   )
 
-# replace @libexecdir@
-fwupdtool_path = join_paths(libexecdir, 'fwupd')
-con2 = configuration_data()
-con2.set('libexecdir', fwupdtool_path)
-configure_file(
-  input : 'fwupdtool.in',
-  output : 'fwupdtool',
-  configuration : con2,
-  install: true,
-  install_dir: completions_dir)
+  install_data(['fwupdtool'],
+    install_dir : completions_dir,
+  )
 
-if build_daemon
-install_data(['fwupdagent'],
-  install_dir : completions_dir,
-)
-configure_file(
-  input : 'fwupdmgr.in',
-  output : 'fwupdmgr',
-  configuration : con2,
-  install: true,
-  install_dir: completions_dir)
-endif # build_daemon
+  if build_daemon
+    install_data(['fwupdagent', 'fwupdmgr'],
+      install_dir : completions_dir,
+    )
+  endif # build_daemon
 
 endif # bashcomp.found()


### PR DESCRIPTION
Merged fu_util_update_all() and fu_util_update_by_id() to simplify the
maintaince work and streamline the flow for consistent behavior across
a normal update for all updatable devices and a small set of chosen
devices.

This commit also added support for specifying mutliple DEVICE-IDs or
GUIDs in a single run, previously error message 'Invalid Argument' is
seen and soon aborted.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
