### PR TITLE
Show why devices are not marked as updatable

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-common.c
+++ b/plugins/dell-dock/fu-dell-dock-common.c
@@ -59,20 +59,3 @@ fu_dell_dock_will_replug(FuDevice *device)
 	fu_device_set_remove_delay(device, timeout * 1000);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 }
-
-void
-fu_dell_dock_clone_updatable(FuDevice *device)
-{
-	FuDevice *parent;
-	parent = fu_device_get_parent(device);
-	if (parent == NULL)
-		return;
-	if (fu_device_has_flag(parent, FWUPD_DEVICE_FLAG_UPDATABLE)) {
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
-	} else {
-		const gchar *message = fu_device_get_update_error(parent);
-		if (message != NULL)
-			fu_device_set_update_error(device, message);
-		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
-	}
-}

--- a/plugins/dell-dock/fu-dell-dock-common.h
+++ b/plugins/dell-dock/fu-dell-dock-common.h
@@ -49,5 +49,3 @@ gboolean
 fu_dell_dock_set_power(FuDevice *device, guint8 target, gboolean enabled, GError **error);
 void
 fu_dell_dock_will_replug(FuDevice *device);
-void
-fu_dell_dock_clone_updatable(FuDevice *device);

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -197,6 +197,7 @@ fu_dell_dock_hub_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_dell_dock_hub_init(FuDellDockHub *self)
 {
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_retry_set_delay(FU_DEVICE(self), 1000);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE,

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -579,17 +579,16 @@ fu_dell_dock_ec_get_dock_data(FuDevice *device, GError **error)
 	if (self->data->board_id >= self->board_min) {
 		if (status != FW_UPDATE_IN_PROGRESS) {
 			fu_dell_dock_ec_set_board(device);
-			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+			fu_device_uninhibit(device, "update-pending");
 		} else {
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			fu_device_set_update_error(device,
-						   "A pending update will be completed "
-						   "next time the dock is "
-						   "unplugged from your computer");
+			fu_device_inhibit(device,
+					  "update-pending",
+					  "A pending update will be completed next time the dock "
+					  "is unplugged from your computer");
 		}
 	} else {
-		g_warning("This utility does not support this board, disabling updates for %s",
-			  fu_device_get_name(device));
+		fu_device_inhibit(device, "not-supported", "Utility does not support this board");
 	}
 
 	return TRUE;
@@ -1014,6 +1013,8 @@ fu_dell_dock_ec_init(FuDellDockEc *self)
 	self->data = g_new0(FuDellDockDockDataStructure, 1);
 	self->raw_versions = g_new0(FuDellDockDockPackageFWVersion, 1);
 	fu_device_add_protocol(FU_DEVICE(self), "com.dell.dock");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -1153,8 +1153,6 @@ fu_dell_dock_mst_setup(FuDevice *device, GError **error)
 		fu_device_set_version(device, version);
 	}
 
-	fu_dell_dock_clone_updatable(device);
-
 	return TRUE;
 }
 
@@ -1237,6 +1235,7 @@ static void
 fu_dell_dock_mst_init(FuDellDockMst *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.synaptics.mst");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -215,8 +215,6 @@ fu_dell_dock_tbt_setup(FuDevice *device, GError **error)
 		return TRUE;
 	}
 
-	fu_dell_dock_clone_updatable(device);
-
 	return TRUE;
 }
 
@@ -275,6 +273,7 @@ static void
 fu_dell_dock_tbt_init(FuDellDockTbt *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.intel.thunderbolt");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -51,9 +51,6 @@ fu_dell_dock_status_setup(FuDevice *device, GError **error)
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_version(device, dynamic_version);
 	fu_device_set_logical_id(FU_DEVICE(device), "status");
-
-	fu_dell_dock_clone_updatable(device);
-
 	return TRUE;
 }
 
@@ -160,6 +157,7 @@ static void
 fu_dell_dock_status_init(FuDellDockStatus *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.dell.dock");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-usb-usb4.c
+++ b/plugins/dell-dock/fu-dell-dock-usb-usb4.c
@@ -575,9 +575,6 @@ fu_dell_dock_usb4_probe(FuDevice *device, GError **error)
 	self->intf_nr = GR_USB_INTERFACE_NUMBER;
 	self->blocksz = GR_USB_BLOCK_SIZE;
 	fu_device_set_logical_id(FU_DEVICE(device), "usb4");
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 	return TRUE;
 }
 
@@ -591,6 +588,9 @@ static void
 fu_dell_dock_usb4_init(FuDellDockUsb4 *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.intel.thunderbolt");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_INHERIT_ACTIVATION);
 }
 
 static void

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -183,9 +183,6 @@ fu_plugin_dell_dock_backend_device_added(FuPlugin *plugin, FuDevice *device, GEr
 
 	fu_plugin_device_add(plugin, FU_DEVICE(hub));
 
-	/* clear updatable flag if parent doesn't have it */
-	fu_dell_dock_clone_updatable(FU_DEVICE(hub));
-
 	return TRUE;
 }
 
@@ -233,12 +230,6 @@ fu_plugin_dell_dock_device_registered(FuPlugin *plugin, FuDevice *device)
 	if (g_strcmp0(fu_device_get_plugin(device), "dell_dock") == 0 &&
 	    (FU_IS_DELL_DOCK_EC(device) || FU_IS_DELL_DOCK_USB4(device)))
 		fu_plugin_dell_dock_separate_activation(plugin);
-
-	if (g_strcmp0(fu_device_get_plugin(device), "thunderbolt") != 0 ||
-	    fu_device_has_flag(device, FWUPD_DEVICE_FLAG_INTERNAL))
-		return;
-	/* clone updatable flag to leave in needs activation state */
-	fu_dell_dock_clone_updatable(device);
 }
 
 static gboolean

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -637,7 +637,7 @@ fu_plugin_uefi_capsule_unlock(FuPlugin *plugin, FuDevice *device, GError **error
 	/* clone the info from real device but prevent it from being flashed */
 	device_flags_alt = fu_device_get_flags(device_alt);
 	fu_device_set_flags(device, device_flags_alt);
-	fu_device_remove_flag(device_alt, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_inhibit(device_alt, "alt-device", "Preventing upgrades as alternate");
 
 	/* make sure that this unlocked device can be updated */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_QUAD);


### PR DESCRIPTION
At the moment a lot of the failures are only visible when running the
daemon in verbose mode, and the inhibit functionalit provides us a way
to unset FWUPD_DEVICE_FLAG_UPDATABLE from multiple places, as well as
setting the update error for the user to see why.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
