### PR TITLE
Fix the logic for removable fallback path in uefi-capsule

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -304,7 +304,7 @@ fu_uefi_bootmgr_bootnext(FuDevice *device,
 				device,
 				FU_UEFI_DEVICE_FLAG_FALLBACK_TO_REMOVABLE_PATH)) {
 				shim_app =
-				    fu_uefi_get_esp_app_path(device, esp_path, "boot", error);
+				    fu_uefi_get_fallback_app_path(device, esp_path, "boot", error);
 				if (shim_app == NULL)
 					return FALSE;
 			}
@@ -327,11 +327,12 @@ fu_uefi_bootmgr_bootnext(FuDevice *device,
 			}
 			use_fwup_path = FALSE;
 		} else if ((flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB) > 0) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_BROKEN_SYSTEM,
-					    "Secure boot is enabled, but shim isn't installed to "
-					    "the EFI system partition");
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_BROKEN_SYSTEM,
+				    "Secure boot is enabled, but shim isn't installed to "
+				    "%s",
+				    shim_app);
 			return FALSE;
 		}
 	}

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -60,6 +60,21 @@ fu_uefi_bootmgr_get_suffix(GError **error)
 }
 
 gchar *
+fu_uefi_get_fallback_app_path(FuDevice *device,
+			      const gchar *esp_path,
+			      const gchar *cmd,
+			      GError **error)
+{
+	const gchar *suffix = fu_uefi_bootmgr_get_suffix(error);
+	g_autofree gchar *base = NULL;
+	if (suffix == NULL)
+		return NULL;
+
+	base = g_build_filename(esp_path, "EFI", "boot", NULL);
+	return g_strdup_printf("%s/%s%s.efi", base, cmd, suffix);
+}
+
+gchar *
 fu_uefi_get_esp_app_path(FuDevice *device, const gchar *esp_path, const gchar *cmd, GError **error)
 {
 	const gchar *suffix = fu_uefi_bootmgr_get_suffix(error);
@@ -220,12 +235,6 @@ fu_uefi_get_esp_path_for_os(FuDevice *device, const gchar *base)
 				return g_steal_pointer(&id_like_path);
 			}
 		}
-	}
-	/* try to fallback to use UEFI removable path if ID_LIKE path doesn't exist */
-	if (fu_device_has_private_flag(device, FU_UEFI_DEVICE_FLAG_FALLBACK_TO_REMOVABLE_PATH)) {
-		esp_path = g_build_filename(base, "EFI", "boot", NULL);
-		if (!g_file_test(esp_path, G_FILE_TEST_IS_DIR))
-			g_debug("failed to fallback due to missing %s", esp_path);
 	}
 	return g_steal_pointer(&esp_path);
 #else

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -61,6 +61,11 @@ typedef struct __attribute__((__packed__)) {
 #define FU_UEFI_COMMON_REQUIRED_ESP_FREE_SPACE (32 * 1024 * 1024)
 
 gchar *
+fu_uefi_get_fallback_app_path(FuDevice *device,
+			      const gchar *esp_path,
+			      const gchar *cmd,
+			      GError **error);
+gchar *
 fu_uefi_get_esp_app_path(FuDevice *device, const gchar *esp_path, const gchar *cmd, GError **error);
 gchar *
 fu_uefi_get_built_app_path(GError **error);


### PR DESCRIPTION
The logic was built on the presumption of Ubuntu core which doesn't
have /etc/os-release.  Since other distributions do have /etc/os-release
adjust the logic to instead build the path explicitly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
