### PR TITLE
trivial: show uefi_recovery message in get-plugins output

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1490,8 +1490,10 @@ fu_util_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return NULL;
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_USER_WARNING)
 		return NULL;
-	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID)
-		return NULL;
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID) {
+		/* TRANSLATORS: Plugin is active only if hardware is found */
+		return _("Enabled if hardware matches");
+	}
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_NONE) {
 		/* TRANSLATORS: Plugin is active and in use */
 		return _("Enabled");
@@ -1548,9 +1550,9 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_UNKNOWN:
 	case FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE:
 	case FWUPD_PLUGIN_FLAG_USER_WARNING:
-	case FWUPD_PLUGIN_FLAG_REQUIRE_HWID:
 		return NULL;
 	case FWUPD_PLUGIN_FLAG_NONE:
+	case FWUPD_PLUGIN_FLAG_REQUIRE_HWID:
 		return fu_util_term_format(fu_util_plugin_flag_to_string(plugin_flag),
 					   FU_UTIL_TERM_COLOR_GREEN);
 	case FWUPD_PLUGIN_FLAG_DISABLED:


### PR DESCRIPTION
By default it shows just a blank line right now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
