### PR TITLE
trivial: Do not match the legacy bootloader VID/PID

### DIFF
--- a/plugins/ebitdo/ebitdo-legacy.quirk
+++ b/plugins/ebitdo/ebitdo-legacy.quirk
@@ -1,0 +1,9 @@
+# This is the ID assigned to STMicroelectronics, and also seems to be used by other vendors who
+# did not change the default from the devkit. Install this quirk file if your 8bitdo controller
+# uses the legacy bootloader from 2018.
+#
+# See https://github.com/fwupd/fwupd/issues/4180 for more information
+
+[USB\VID_0483&PID_5750]
+Plugin = ebitdo
+Flags = is-bootloader

--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -1,7 +1,4 @@
 # bootloader
-[USB\VID_0483&PID_5750]
-Plugin = ebitdo
-Flags = is-bootloader
 [USB\VID_2DC8&PID_5750]
 Plugin = ebitdo
 Flags = is-bootloader


### PR DESCRIPTION
This is the ID assigned to STMicroelectronics... more specifically for
a mini LED display. It also seems to be used by other vendors who also
did not change the default from the devkit, e.g. the Vaydeer Multimedia
Console.

Fixes https://github.com/fwupd/fwupd/issues/4180

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
