### PR TITLE
modem-manager: Fix a segfault on startup for some MBIM-QDU devices

### DIFF
--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -188,6 +188,15 @@ fu_firehose_validate_rawprogram(GBytes *rawprogram,
 gboolean
 fu_firehose_updater_open(FuFirehoseUpdater *self, GError **error)
 {
+	/* sanity check */
+	if (self->port == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no firehose port provided for filename");
+		return FALSE;
+	}
+
 	g_debug("opening firehose port...");
 	self->io_channel = fu_io_channel_new_file(self->port, error);
 	return (self->io_channel != NULL);

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -551,6 +551,15 @@ fu_mm_device_probe(FuDevice *device, GError **error)
 static gboolean
 fu_mm_device_io_open_qcdm(FuMmDevice *self, GError **error)
 {
+	/* sanity check */
+	if (self->port_qcdm == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no QCDM port provided for filename");
+		return FALSE;
+	}
+
 	/* open device */
 	self->io_channel = fu_io_channel_new_file(self->port_qcdm, error);
 	if (self->io_channel == NULL)
@@ -695,6 +704,15 @@ fu_mm_device_at_cmd(FuMmDevice *self, const gchar *cmd, gboolean has_response, G
 static gboolean
 fu_mm_device_io_open(FuMmDevice *self, GError **error)
 {
+	/* sanity check */
+	if (self->port_at == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no AT port provided for filename");
+		return FALSE;
+	}
+
 	/* open device */
 	self->io_channel = fu_io_channel_new_file(self->port_at, error);
 	if (self->io_channel == NULL)


### PR DESCRIPTION
Works around https://github.com/fwupd/fwupd/issues/4190 although we
still need to find the root cause.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
