### PR TITLE
Raise the required version of libxmlb

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -592,6 +592,9 @@
     <distro id="fedora">
       <package>gtk-doc</package>
     </distro>
+    <distro id="void">
+      <package>gtk-doc</package>
+    </distro>
     <distro id="debian">
       <control />
       <package variant="x86_64" />

--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -1069,11 +1069,7 @@ fu_cabinet_parse(FuCabinet *self, GBytes *data, FuCabinetParseFlags flags, GErro
 	/* prepare query */
 	query = xb_query_new_full(self->silo,
 				  "releases/release",
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 				  XB_QUERY_FLAG_FORCE_NODE_CACHE,
-#else
-				  XB_QUERY_FLAG_NONE,
-#endif
 				  error);
 	if (query == NULL)
 		return FALSE;

--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -321,9 +321,7 @@ fu_chunk_to_string(FuChunk *self)
 	fu_chunk_export(self, FU_FIRMWARE_EXPORT_FLAG_ASCII_DATA, bn);
 	return xb_builder_node_export(bn,
 				      XB_NODE_EXPORT_FLAG_FORMAT_MULTILINE |
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 					  XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY |
-#endif
 					  XB_NODE_EXPORT_FLAG_FORMAT_INDENT,
 				      NULL);
 }
@@ -349,9 +347,7 @@ fu_chunk_array_to_string(GPtrArray *chunks)
 	}
 	return xb_builder_node_export(bn,
 				      XB_NODE_EXPORT_FLAG_FORMAT_MULTILINE |
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 					  XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY |
-#endif
 					  XB_NODE_EXPORT_FLAG_FORMAT_INDENT,
 				      NULL);
 }

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1661,9 +1661,7 @@ fu_firmware_export_to_xml(FuFirmware *self, FuFirmwareExportFlags flags, GError 
 	fu_firmware_export(self, flags, bn);
 	return xb_builder_node_export(bn,
 				      XB_NODE_EXPORT_FLAG_FORMAT_MULTILINE |
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 					  XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY |
-#endif
 					  XB_NODE_EXPORT_FLAG_FORMAT_INDENT,
 				      error);
 }
@@ -1688,9 +1686,7 @@ fu_firmware_to_string(FuFirmware *self)
 			   bn);
 	return xb_builder_node_export(bn,
 				      XB_NODE_EXPORT_FLAG_FORMAT_MULTILINE |
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 					  XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY |
-#endif
 					  XB_NODE_EXPORT_FLAG_FORMAT_INDENT,
 				      NULL);
 }

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -246,19 +246,11 @@ fu_quirks_add_quirks_for_path(FuQuirks *self, XbBuilder *builder, const gchar *p
 		g_autoptr(XbBuilderSource) source = xb_builder_source_new();
 
 		/* load from keyfile */
-#if LIBXMLB_CHECK_VERSION(0, 1, 15)
 		xb_builder_source_add_simple_adapter(source,
 						     "text/plain,.quirk",
 						     fu_quirks_convert_quirk_to_xml_cb,
 						     self,
 						     NULL);
-#else
-		xb_builder_source_add_adapter(source,
-					      "text/plain,.quirk",
-					      fu_quirks_convert_quirk_to_xml_cb,
-					      self,
-					      NULL);
-#endif
 		if (!xb_builder_source_load_file(source,
 						 file,
 						 XB_BUILDER_SOURCE_FLAG_WATCH_FILE |
@@ -387,9 +379,7 @@ fu_quirks_lookup_by_id(FuQuirks *self, const gchar *guid, const gchar *key)
 {
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) n = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 3, 0)
 	g_auto(XbQueryContext) context = XB_QUERY_CONTEXT_INIT();
-#endif
 
 	g_return_val_if_fail(FU_IS_QUIRKS(self), NULL);
 	g_return_val_if_fail(guid != NULL, NULL);
@@ -406,23 +396,10 @@ fu_quirks_lookup_by_id(FuQuirks *self, const gchar *guid, const gchar *key)
 		return NULL;
 
 	/* query */
-#if LIBXMLB_CHECK_VERSION(0, 3, 0)
 	xb_query_context_set_flags(&context, XB_QUERY_FLAG_USE_INDEXES);
 	xb_value_bindings_bind_str(xb_query_context_get_bindings(&context), 0, guid, NULL);
 	xb_value_bindings_bind_str(xb_query_context_get_bindings(&context), 1, key, NULL);
 	n = xb_silo_query_first_with_context(self->silo, self->query_kv, &context, &error);
-#else
-	if (!xb_query_bind_str(self->query_kv, 0, guid, &error)) {
-		g_warning("failed to bind 0: %s", error->message);
-		return NULL;
-	}
-	if (!xb_query_bind_str(self->query_kv, 1, key, &error)) {
-		g_warning("failed to bind 1: %s", error->message);
-		return NULL;
-	}
-	n = xb_silo_query_first_full(self->silo, self->query_kv, &error);
-#endif
-
 	if (n == NULL) {
 		if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
 			return NULL;
@@ -457,9 +434,7 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 {
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) results = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 3, 0)
 	g_auto(XbQueryContext) context = XB_QUERY_CONTEXT_INIT();
-#endif
 
 	g_return_val_if_fail(FU_IS_QUIRKS(self), FALSE);
 	g_return_val_if_fail(guid != NULL, FALSE);
@@ -476,18 +451,9 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 		return FALSE;
 
 	/* query */
-#if LIBXMLB_CHECK_VERSION(0, 3, 0)
 	xb_query_context_set_flags(&context, XB_QUERY_FLAG_USE_INDEXES);
 	xb_value_bindings_bind_str(xb_query_context_get_bindings(&context), 0, guid, NULL);
 	results = xb_silo_query_with_context(self->silo, self->query_vs, &context, &error);
-#else
-	if (!xb_query_bind_str(self->query_vs, 0, guid, &error)) {
-		g_warning("failed to bind 0: %s", error->message);
-		return FALSE;
-	}
-	results = xb_silo_query_full(self->silo, self->query_vs, &error);
-#endif
-
 	if (results == NULL) {
 		if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
 			return FALSE;

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1134,9 +1134,7 @@ fu_common_store_cab_func(void)
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbNode) req = NULL;
 	g_autoptr(XbSilo) silo = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	g_autoptr(XbQuery) query = NULL;
-#endif
 
 	/* create silo */
 	blob = _build_cab(
@@ -1176,7 +1174,6 @@ fu_common_store_cab_func(void)
 				&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(component);
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	query = xb_query_new_full(xb_node_get_silo(component),
 				  "releases/release",
 				  XB_QUERY_FLAG_FORCE_NODE_CACHE,
@@ -1184,9 +1181,6 @@ fu_common_store_cab_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(query);
 	rel = xb_node_query_first_full(component, query, &error);
-#else
-	rel = xb_node_query_first(component, "releases/release", &error);
-#endif
 	g_assert_no_error(error);
 	g_assert_nonnull(rel);
 	g_assert_cmpstr(xb_node_get_attr(rel, "version"), ==, "1.2.3");
@@ -1333,9 +1327,7 @@ fu_common_store_cab_unsigned_func(void)
 	g_autoptr(XbNode) csum = NULL;
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbSilo) silo = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	g_autoptr(XbQuery) query = NULL;
-#endif
 
 	/* create silo */
 	blob = _build_cab(GCAB_COMPRESSION_NONE,
@@ -1360,7 +1352,6 @@ fu_common_store_cab_unsigned_func(void)
 				&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(component);
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	query = xb_query_new_full(xb_node_get_silo(component),
 				  "releases/release",
 				  XB_QUERY_FLAG_FORCE_NODE_CACHE,
@@ -1368,9 +1359,6 @@ fu_common_store_cab_unsigned_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(query);
 	rel = xb_node_query_first_full(component, query, &error);
-#else
-	rel = xb_node_query_first(component, "releases/release", &error);
-#endif
 	g_assert_no_error(error);
 	g_assert_nonnull(rel);
 	g_assert_cmpstr(xb_node_get_attr(rel, "version"), ==, "1.2.3");
@@ -1418,9 +1406,7 @@ fu_common_store_cab_folder_func(void)
 	g_autoptr(XbNode) component = NULL;
 	g_autoptr(XbNode) rel = NULL;
 	g_autoptr(XbSilo) silo = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	g_autoptr(XbQuery) query = NULL;
-#endif
 
 	/* create silo */
 	blob = _build_cab(GCAB_COMPRESSION_NONE,
@@ -1445,7 +1431,6 @@ fu_common_store_cab_folder_func(void)
 				&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(component);
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	query = xb_query_new_full(xb_node_get_silo(component),
 				  "releases/release",
 				  XB_QUERY_FLAG_FORCE_NODE_CACHE,
@@ -1453,9 +1438,6 @@ fu_common_store_cab_folder_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(query);
 	rel = xb_node_query_first_full(component, query, &error);
-#else
-	rel = xb_node_query_first(component, "releases/release", &error);
-#endif
 	g_assert_no_error(error);
 	g_assert_nonnull(rel);
 	g_assert_cmpstr(xb_node_get_attr(rel, "version"), ==, "1.2.3");

--- a/meson.build
+++ b/meson.build
@@ -210,7 +210,7 @@ endif
 if get_option('hsi')
   conf.set('HAVE_HSI', '1')
 endif
-libxmlb = dependency('xmlb', version : '>= 0.1.13', fallback : ['libxmlb', 'libxmlb_dep'])
+libxmlb = dependency('xmlb', version : '>= 0.3.0', fallback : ['libxmlb', 'libxmlb_dep'])
 if get_option('gusb')
   gusb = dependency('gusb', version : '>= 0.3.0', fallback : ['gusb', 'gusb_dep'])
   conf.set('HAVE_GUSB', '1')

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -720,11 +720,7 @@ fu_firehose_updater_run_action(FuFirehoseUpdater *self,
 
 	action = xb_node_get_element(node);
 
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 	cmd_str = xb_node_export(node, XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY, error);
-#else
-	cmd_str = xb_node_export(node, XB_NODE_EXPORT_FLAG_NONE, error);
-#endif
 	if (cmd_str == NULL)
 		return FALSE;
 	cmd_bytearray = g_byte_array_new_take((guint8 *)cmd_str, strlen(cmd_str));

--- a/plugins/vli/fu-vli-usbhub-common.c
+++ b/plugins/vli/fu-vli-usbhub-common.c
@@ -52,9 +52,7 @@ fu_vli_usbhub_header_to_string(FuVliUsbhubHeader *hdr, guint idt, GString *str)
 	fu_vli_usbhub_header_export(hdr, bn);
 	xml = xb_builder_node_export(bn,
 				     XB_NODE_EXPORT_FLAG_FORMAT_MULTILINE |
-#if LIBXMLB_CHECK_VERSION(0, 2, 2)
 					 XB_NODE_EXPORT_FLAG_COLLAPSE_EMPTY |
-#endif
 					 XB_NODE_EXPORT_FLAG_FORMAT_INDENT,
 				     NULL);
 	fu_common_string_append_kv(str, idt, "xml", xml);

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -207,9 +207,7 @@ fu_install_task_check_requirements(FuInstallTask *self, FwupdInstallFlags flags,
 	g_autoptr(GPtrArray) provides = NULL;
 	g_autoptr(GPtrArray) verfmts = NULL;
 	g_autoptr(XbNode) release = NULL;
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	g_autoptr(XbQuery) query = NULL;
-#endif
 
 	g_return_val_if_fail(FU_IS_INSTALL_TASK(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -334,7 +332,6 @@ fu_install_task_check_requirements(FuInstallTask *self, FwupdInstallFlags flags,
 	}
 
 	/* get latest release */
-#if LIBXMLB_CHECK_VERSION(0, 2, 0)
 	query = xb_query_new_full(xb_node_get_silo(self->component),
 				  "releases/release",
 				  XB_QUERY_FLAG_FORCE_NODE_CACHE,
@@ -342,9 +339,6 @@ fu_install_task_check_requirements(FuInstallTask *self, FwupdInstallFlags flags,
 	if (query == NULL)
 		return FALSE;
 	release = xb_node_query_first_full(self->component, query, NULL);
-#else
-	release = xb_node_query_first(self->component, "releases/release", NULL);
-#endif
 	if (release == NULL) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,7 @@ endif
 if build_daemon
 fwupdmgr = executable(
   'fwupdmgr',
+  fu_hash,
   sources : [
     'fu-util.c',
     'fu-history.c',
@@ -114,6 +115,7 @@ endif
 if get_option('systemd') and get_option('offline')
 fwupdoffline = executable(
   'fwupdoffline',
+  fu_hash,
   sources : [
     'fu-history.c',
     'fu-offline.c',


### PR DESCRIPTION
The last 0.2.x release was released in 2020...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
