### PR TITLE
Freebsd CI fix

### DIFF
--- a/contrib/freebsd/Makefile
+++ b/contrib/freebsd/Makefile
@@ -52,6 +52,8 @@ MESON_ARGS=	-Dgudev=false \
 		-Dplugin_realtek_mst=false \
 		-Dplugin_thunderbolt=false \
 		-Dplugin_tpm=false \
+		-Dplugin_bcm57xx=false \
+		-Dplugin_ep963x=false \
 		-Dpolkit=false \
 		-Dsystemd=false \
 		-Doffline=false \

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -9,7 +9,10 @@
 
 #include <fwupdplugin.h>
 
+#ifdef HAVE_EFI_TIME_T
 #include <efivar/efivar.h>
+#endif
+
 #include <glib.h>
 
 #define EFI_CAPSULE_HEADER_FLAGS_PERSIST_ACROSS_RESET  0x00010000


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Fixes the problems with FreeBSD CI. There was a regression related to the following commit: https://github.com/fwupd/fwupd/commit/e74d38bfd3097471fe60dbe843a68c16516a78da
`<efivar/efivar.h>` is wrong path for the FreeBSD efivar library. Also it is not needed in the common header, when there is no  `efi_time_t`.

The second problem was connected to the libxmlb FreeBSD recipe. I fixed it locally at https://github.com/3mdeb/freebsd-ports/tree/fwupd, but we need to refresh this [topic](https://reviews.freebsd.org/D29332). It needs to be merged to make CI maintenance easier.