### PR TITLE
Allow fwupd to operate without a D-Bus daemon

### DIFF
--- a/data/installed-tests/fwupdmgr-p2p.sh
+++ b/data/installed-tests/fwupdmgr-p2p.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# only run as root, possibly only in CI
+if [ "$(id -u)" -ne 0 ]; then exit 0; fi
+
+# ---
+echo "Starting P2P daemon..."
+export FWUPD_DBUS_SOCKET="/var/run/fwupd.sock"
+rm -rf ${FWUPD_DBUS_SOCKET}
+/usr/libexec/fwupd/fwupd --verbose --timed-exit --no-timestamp &
+while [ ! -e ${FWUPD_DBUS_SOCKET} ]; do sleep 1; done
+
+# ---
+echo "Starting P2P client..."
+fwupdmgr get-devices --json
+rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+
+# ---
+echo "Shutting down P2P daemon..."
+gdbus call --system --dest org.freedesktop.fwupd --object-path / --method org.freedesktop.fwupd.Quit
+
+# success!
+exit 0

--- a/data/installed-tests/fwupdmgr-p2p.test.in
+++ b/data/installed-tests/fwupdmgr-p2p.test.in
@@ -1,0 +1,3 @@
+[Test]
+Type=session
+Exec=sh -c "@installedtestsdir@/fwupdmgr-p2p.sh"

--- a/data/installed-tests/meson.build
+++ b/data/installed-tests/meson.build
@@ -13,6 +13,14 @@ configure_file(
 )
 
 configure_file(
+  input : 'fwupdmgr-p2p.test.in',
+  output : 'fwupdmgr-p2p.test',
+  configuration : con2,
+  install: true,
+  install_dir: installed_test_datadir,
+)
+
+configure_file(
   input : 'fwupd.test.in',
   output : 'fwupd.test',
   configuration : con2,
@@ -22,6 +30,7 @@ configure_file(
 
 install_data([
     'fwupdmgr.sh',
+    'fwupdmgr-p2p.sh',
     'fwupd-tests.xml',
   ],
   install_dir : installed_test_datadir,

--- a/docs/env.md
+++ b/docs/env.md
@@ -15,6 +15,7 @@ with a non-standard filesystem layout.
 * `FWUPD_SUPPORTED` overrides the `-Dsupported_build` meson option at runtime
 * `FWUPD_VERBOSE` is set when running `--verbose`
 * `FWUPD_XMLB_VERBOSE` can be set to show Xmlb silo regeneration and quirk matches
+* `FWUPD_DBUS_SOCKET` is used to set the socket filename if running without a dbus-daemon
 * `FWUPD_DOWNLOAD_VERBOSE` can be used to show wget or curl output
 * standard glibc variables like `LANG` are also honored for CLI tools that are translated
 * libcurl respects the session proxy, e.g. `http_proxy`, `all_proxy`, `sftp_proxy` and `no_proxy`


### PR DESCRIPTION
This adds support for optionally using a UNIX domain socket where a
D-Bus daemon may not be running.

To use this, launch the daemon and clients with something like
`FWUPD_DBUS_SOCKET=/var/run/fwupd.sock fwupdmgr get-devices`

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
