### PR TITLE
debian/rules: enable modem-manager plugin support

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -49,7 +49,7 @@ ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu && echo yes))
        CONFARGS += -Dplugin_logitech_bulkcontroller=false
 endif
 
-CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=false -Ddocs=gtkdoc -Dsupported_build=true
+CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=false -Ddocs=gtkdoc -Dsupported_build=true -Dplugin_modem_manager=true
 
 %:
 	dh $@ --with gir


### PR DESCRIPTION
Type of pull request:

This enables the modem-manager plugin support in the debian packaging, creating a new libfu_plugin_modem_manager.so object under fwupd-plugins.
Having this plugin enabled will allow users to update firmwares via modem-manager on modems which are compatible, such as the EG25 from Quectel shipped with the PinePhone.

This is a follow-up of https://salsa.debian.org/efi-team/fwupd/-/merge_requests/8 

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
