### PR TITLE
trivial: Turn off -fanalyzer by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -108,7 +108,7 @@ warning_flags = [
   '-Wvla',
   '-Wwrite-strings'
 ]
-if host_machine.system() != 'windows'
+if get_option('static_analysis') and host_machine.system() != 'windows'
   warning_flags += ['-fanalyzer', '-Wno-analyzer-null-dereference']
 endif
 cc = meson.get_compiler('c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
 option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
+option('static_analysis', type : 'boolean', value : false, description : 'enable GCC static analysis support')
 option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
 option('docs', type : 'combo', choices : ['none', 'gtkdoc', 'docgen'], value : 'docgen', description : 'developer documentation type')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')


### PR DESCRIPTION
This has several false positives in Fedora 36 and also slows down the
build considerably.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
