### PR TITLE
modem-manager: Assign the FuUsbDevice to the FuMmDevice

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -86,6 +86,8 @@ struct _FuMmDevice {
 #if MM_CHECK_VERSION(1, 17, 2)
 	FuFirehoseUpdater *firehose_updater;
 #endif
+	/* for sahara */
+	FuUsbDevice *usb_device;
 
 	/* firmware path */
 	gchar *firmware_path;
@@ -1637,6 +1639,8 @@ static void
 fu_mm_device_finalize(GObject *object)
 {
 	FuMmDevice *self = FU_MM_DEVICE(object);
+	if (self->usb_device != NULL)
+		g_object_unref(self->usb_device);
 	if (self->attach_idle)
 		g_source_remove(self->attach_idle);
 	if (self->qmi_pdc_active_id)
@@ -1734,6 +1738,21 @@ fu_plugin_mm_inhibited_device_info_free(FuPluginMmInhibitedDeviceInfo *info)
 		g_ptr_array_unref(info->guids);
 	g_free(info->detach_fastboot_at);
 	g_free(info);
+}
+
+FuUsbDevice *
+fu_mm_device_get_usb_device(FuMmDevice *self)
+{
+	g_return_val_if_fail(FU_IS_MM_DEVICE(self), NULL);
+	return self->usb_device;
+}
+
+void
+fu_mm_device_set_usb_device(FuMmDevice *self, FuUsbDevice *usb_device)
+{
+	g_return_if_fail(FU_IS_MM_DEVICE(self));
+	g_return_if_fail(FU_IS_USB_DEVICE(usb_device));
+	g_set_object(&self->usb_device, usb_device);
 }
 
 FuMmDevice *

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -17,6 +17,10 @@ G_DECLARE_FINAL_TYPE(FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)
 
 FuMmDevice *
 fu_mm_device_new(FuContext *ctx, MMManager *manager, MMObject *omodem);
+FuUsbDevice *
+fu_mm_device_get_usb_device(FuMmDevice *self);
+void
+fu_mm_device_set_usb_device(FuMmDevice *self, FuUsbDevice *usb_device);
 const gchar *
 fu_mm_device_get_inhibition_uid(FuMmDevice *device);
 const gchar *

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -237,6 +237,7 @@ fu_plugin_mm_device_add(FuPlugin *plugin, MMObject *modem)
 	}
 	fu_plugin_device_add(plugin, FU_DEVICE(dev));
 	fu_plugin_cache_add(plugin, object_path, dev);
+	fu_plugin_cache_add(plugin, fu_device_get_physical_id(FU_DEVICE(dev)), dev);
 }
 
 static void
@@ -450,6 +451,33 @@ fu_plugin_mm_attach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GE
 	return TRUE;
 }
 
+static gboolean
+fu_plugin_mm_backend_device_added(FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	FuDevice *device_tmp;
+	g_autoptr(GUdevDevice) udev_device = NULL;
+
+	/* interesting device? */
+	if (!FU_IS_USB_DEVICE(device))
+		return TRUE;
+
+	/* look up the FuMmDevice for the USB device that just appeared */
+	udev_device = fu_usb_device_find_udev_device(FU_USB_DEVICE(device), error);
+	if (udev_device == NULL)
+		return FALSE;
+	device_tmp = fu_plugin_cache_lookup(plugin, g_udev_device_get_sysfs_path(udev_device));
+	if (device_tmp == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "%s not added by ModemManager",
+			    g_udev_device_get_sysfs_path(udev_device));
+		return FALSE;
+	}
+	fu_mm_device_set_usb_device(FU_MM_DEVICE(device_tmp), FU_USB_DEVICE(device));
+	return TRUE;
+}
+
 void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
@@ -460,4 +488,5 @@ fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 	vfuncs->coldplug = fu_plugin_mm_coldplug;
 	vfuncs->attach = fu_plugin_mm_attach;
 	vfuncs->detach = fu_plugin_mm_detach;
+	vfuncs->backend_device_added = fu_plugin_mm_backend_device_added;
 }

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -45,6 +45,7 @@ Summary = Quectel EG25-G modem
 CounterpartGuid = USB\VID_18D1&PID_D00D
 Flags = detach-at-fastboot-has-no-response
 ModemManagerBranchAtCommand = AT+GETFWBRANCH
+Plugin = modem_manager
 
 # Quectel EG25-G in fastboot mode
 [USB\VID_18D1&PID_D00D]


### PR DESCRIPTION
This allows protocol code like Sahara to use GUsb.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
