### PR TITLE
plugins/flashrom: add quirk for NovaCustom NV4x

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -44,3 +44,11 @@ Flags = reset-cmos
 Branch = coreboot
 VersionFormat = plain
 Flags = reset-cmos
+
+# NovaCustom NV4x (HwId)
+[25b6ea34-8f52-598e-a27a-31e03014dbe3]
+Plugin = flashrom
+
+# NovaCustom NV4x (Dasharo GUID)
+[9a8c30e2-1b7e-5b28-9632-fc2fbf8cd0ba]
+Branch = dasharo


### PR DESCRIPTION
Add a quirk for NovaCustom NV4x devices.
These laptops are running coreboot and are updatable using flashrom.

The HwId GUID matches to both previous Insyde firmware and the current
Dasharo firmware. The Dasharo GUID matches to the devices running
Dasharo firmware. This way the device can be switched from Insyde
to Dasharo using `fwupdmgr switch-branch`.

Homepage: https://configurelaptop.eu/nv40-series/

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
