### PR TITLE
trivial: Remove the unused com.redhat.fwupdate built version

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7491,9 +7491,6 @@ fu_engine_init(FuEngine *self)
 #endif
 
 	g_hash_table_insert(self->compile_versions,
-			    g_strdup("com.redhat.fwupdate"),
-			    g_strdup("12"));
-	g_hash_table_insert(self->compile_versions,
 			    g_strdup("org.freedesktop.fwupd"),
 			    g_strdup(VERSION));
 #ifdef HAVE_GUSB


### PR DESCRIPTION
We've not needed this for several years, and no firmware on the LVFS actually uses this.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
