### PR TITLE
Drop the AMD SME check for security attributes (Fixes: #4176)

### DIFF
--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -291,49 +291,10 @@ fu_plugin_add_security_attr_dci_locked(FuPlugin *plugin, FuSecurityAttrs *attrs)
 }
 
 static void
-fu_plugin_add_security_attr_amd_sme_enabled(FuPlugin *plugin, FuSecurityAttrs *attrs)
-{
-	FuPluginData *priv = fu_plugin_get_data(plugin);
-	FuDevice *device = fu_plugin_cache_lookup(plugin, "cpu");
-	g_autoptr(FwupdSecurityAttr) attr = NULL;
-
-	/* this MSR is only valid for a subset of AMD CPUs */
-	if (fu_common_get_cpu_vendor() != FU_CPU_VENDOR_AMD)
-		return;
-
-	/* create attr */
-	attr = fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_ENCRYPTED_RAM);
-	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
-	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_SYSTEM_PROTECTION);
-	if (device != NULL)
-		fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
-	fu_security_attrs_append(attrs, attr);
-
-	/* check fields */
-	if (!priv->amd64_syscfg_supported) {
-		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);
-		return;
-	}
-	if (!priv->amd64_syscfg.fields.sme_is_enabled) {
-		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
-		return;
-	}
-	if (!priv->amd64_sev.fields.sev_is_enabled) {
-		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENCRYPTED);
-		return;
-	}
-
-	/* success */
-	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_ENCRYPTED);
-}
-
-static void
 fu_plugin_msr_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	fu_plugin_add_security_attr_dci_enabled(plugin, attrs);
 	fu_plugin_add_security_attr_dci_locked(plugin, attrs);
-	fu_plugin_add_security_attr_amd_sme_enabled(plugin, attrs);
 }
 
 void


### PR DESCRIPTION
This method does not indicate whether the kernel has enabled encryption.
That information is only visible from the kernel log at this time.

Continue to read the MSRs though, because if/when we get a method for the
kernel to export it we may use these as a basis of "support" but not a
indication of it being enabled.

encrypted:
```FuPluginMsr          SME/SEV check MSR: eax 01000f, ebx 016f
FuPluginMsr          PCI_MSR_AMD64_SYSCFG: 0f40000, sme_is_enabled=1
FuPluginMsr          PCI_MSR_AMD64_SEV: 00, sev_is_enabled=0
```

not_encrypted:
```
FuPluginMsr          SME/SEV check MSR: eax 01000f, ebx 016f
FuPluginMsr          PCI_MSR_AMD64_SYSCFG: 0f40000, sme_is_enabled=1
FuPluginMsr          PCI_MSR_AMD64_SEV: 00, sev_is_enabled=0
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
