### PR TITLE
trivial: Fix the vendor to battery threshold mapping

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6906,8 +6906,9 @@ fu_engine_context_set_battery_threshold(FuContext *ctx)
 
 	vendor = fu_context_get_hwid_replace_value(ctx, FU_HWIDS_KEY_MANUFACTURER, NULL);
 	if (vendor != NULL) {
+		g_autofree gchar *vendor_guid = fwupd_guid_hash_string(vendor);
 		battery_str = g_strdup(
-		    fu_context_lookup_quirk_by_id(ctx, vendor, FU_QUIRKS_BATTERY_THRESHOLD));
+		    fu_context_lookup_quirk_by_id(ctx, vendor_guid, FU_QUIRKS_BATTERY_THRESHOLD));
 	}
 	if (battery_str == NULL)
 		minimum_battery = MINIMUM_BATTERY_PERCENTAGE_FALLBACK;


### PR DESCRIPTION
I broke this when optimizing fu_context_lookup_quirk_by_id() to only
take a GUID. Mea culpa.

Fixes https://github.com/fwupd/fwupd/issues/4250

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
