### PR TITLE
[thunderbolt] remove the skip-restart flag for retimer

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -147,7 +147,6 @@ fu_thunderbolt_retimer_init(FuThunderboltRetimer *self)
 	    "that forms two separate electrical link segments");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SKIPS_RESTART);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE);
 }
 


### PR DESCRIPTION
-this is indeed needed to reflect the updated version

Signed-off-by: Kranthi Kuntala <kranthi.kuntala@intel.corp-partner.google.com>
Change-Id: Id4751d531528590cc93c08db0d0939a547f4d59f

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
