### PR TITLE
thunderbolt: Set the update timeout if required

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -436,7 +436,7 @@ fu_thunderbolt_device_write_firmware(FuDevice *device,
 	}
 
 	/* whether to wait for a device replug or not */
-	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
+	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
 		fu_device_set_remove_delay(device, FU_PLUGIN_THUNDERBOLT_UPDATE_TIMEOUT);
 		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_RESTART);
 	}


### PR DESCRIPTION
I think this accidentally got inverted during the retimer split.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
