### PR TITLE
tpm: Fix a critical warning when loading an empty TPM eventlog item

### DIFF
--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -259,8 +259,11 @@ fu_plugin_tpm_eventlog_report_metadata(FuPlugin *plugin)
 
 	for (guint i = 0; i < data->ev_items->len; i++) {
 		FuTpmEventlogItem *item = g_ptr_array_index(data->ev_items, i);
-		g_autofree gchar *blobstr = fu_tpm_eventlog_blobstr(item->blob);
+		g_autofree gchar *blobstr = NULL;
 		g_autofree gchar *checksum = NULL;
+
+		if (item->blob == NULL)
+			continue;
 		if (item->checksum_sha1 != NULL)
 			checksum = fu_tpm_eventlog_strhex(item->checksum_sha1);
 		else if (item->checksum_sha256 != NULL)
@@ -268,6 +271,7 @@ fu_plugin_tpm_eventlog_report_metadata(FuPlugin *plugin)
 		else
 			continue;
 		g_string_append_printf(str, "0x%08x %s", item->kind, checksum);
+		blobstr = fu_tpm_eventlog_blobstr(item->blob);
 		if (blobstr != NULL)
 			g_string_append_printf(str, " [%s]", blobstr);
 		g_string_append(str, "\n");

--- a/plugins/tpm/fu-tpm-eventlog-common.c
+++ b/plugins/tpm/fu-tpm-eventlog-common.c
@@ -149,6 +149,9 @@ fu_tpm_eventlog_blobstr(GBytes *blob)
 	const guint8 *buf = g_bytes_get_data(blob, &bufsz);
 	g_autoptr(GString) str = g_string_new(NULL);
 
+	g_return_val_if_fail(blob != NULL, NULL);
+
+	buf = g_bytes_get_data(blob, &bufsz);
 	for (gsize i = 0; i < bufsz; i++) {
 		gchar chr = buf[i];
 		if (g_ascii_isprint(chr)) {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
