### PR TITLE
trivial: don't replug if thunderbolt device supports auth on disconnect

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -310,7 +310,8 @@ fu_thunderbolt_controller_write_firmware(FuDevice *device,
 	if (!FU_DEVICE_CLASS(fu_thunderbolt_controller_parent_class)
 		 ->write_firmware(device, firmware, progress, flags, error))
 		return FALSE;
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE))
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 


### PR DESCRIPTION
Fixes: #4262

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
