### PR TITLE
trivial: Move the date_eol attribute to the component node

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -762,7 +762,7 @@ fu_engine_set_release_from_appstream(FuEngine *self,
 			fwupd_release_set_update_image(rel, tmp);
 		}
 	}
-	if (xb_node_get_attr(release, "date_eol") != NULL)
+	if (xb_node_get_attr(component, "date_eol") != NULL)
 		fu_device_add_flag(dev, FWUPD_DEVICE_FLAG_END_OF_LIFE);
 
 	/* sort the locations by scheme */


### PR DESCRIPTION
The LVFS has been changed to do the same, and no real vendors have
added EOL information yet.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
