### PR TITLE
fall back to signed EFI app as secure boot is off.

### DIFF
--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -53,7 +53,6 @@ Recommends: python3,
 	    dbus,
 	    secureboot-db,
 	    udisks2,
-	    fwupd-unsigned,
 	    fwupd-signed,
 	    jq
 Suggests: gir1.2-fwupd-2.0


### PR DESCRIPTION
Some distribution hopes to not install the not-signed EFI app by default.
However, for the corner case, the user might still want to use not-signed
one (maybe to work around bugs or do testing). This implements
a logic that uses the not-signed EFI app as the secure boot is off, and
if it does not exist, then we fall back to using the signed one.

I have not tested this patch. I think that change looks trivial. I'll try to
test it as soon as I can and update the result here.

I created this PR on a release sooner and earlier basis.

Please kindly share if you think the direction of this change is fine
with you or not.

Type of pull request:

- [V] Feature
