### PR TITLE
[thunderbolt] Add 5 secs delay after nvm update

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -13,6 +13,10 @@
 #include "fu-thunderbolt-firmware.h"
 #include "fu-thunderbolt-retimer.h"
 
+/*5 seconds sleep until retimer is available                                       \
+				     after nvm update*/
+#define FU_THUNDERBOLT_RETIMER_CLEANUP_DELAY 5000000
+
 static gboolean
 fu_plugin_thunderbolt_safe_kernel(FuPlugin *plugin, GError **error)
 {
@@ -89,6 +93,7 @@ fu_plugin_thunderbolt_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GE
 		FuDevice *dev = g_ptr_array_index(devices, i);
 		if ((g_strcmp0(fu_device_get_plugin(dev), "thunderbolt") == 0) &&
 		    fu_device_has_internal_flag(dev, FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE)) {
+			g_usleep(FU_THUNDERBOLT_RETIMER_CLEANUP_DELAY);
 			return fu_thunderbolt_retimer_set_parent_port_online(dev, error);
 		}
 	}


### PR DESCRIPTION
- this is needed for the retimer to be accessible after update
- and to bring the port back to online

Signed-off-by: Kranthi Kuntala <kranthi.kuntala@intel.corp-partner.google.com>
Change-Id: I2234ebe23a55fc03f9ef30c1ea10febfe46a2003

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
