### PR TITLE
tpm: Do not show a warning if the TPM eventlog does not exist

### DIFF
--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -297,6 +297,11 @@ fu_plugin_tpm_coldplug_eventlog(FuPlugin *plugin, GError **error)
 	g_autofree gchar *str = NULL;
 	g_autofree guint8 *buf = NULL;
 
+	/* do not show a warning if no TPM exists, or the kernel is too old */
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
+		g_debug("no %s, so skipping", fn);
+		return TRUE;
+	}
 	if (!g_file_get_contents(fn, (gchar **)&buf, &bufsz, error))
 		return FALSE;
 	if (bufsz == 0) {


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/4290

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
