### PR TITLE
Restore AMD SME check

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -356,6 +356,7 @@ done
 %{_sysconfdir}/pki/fwupd-metadata
 %if 0%{?have_msr}
 /usr/lib/modules-load.d/fwupd-msr.conf
+%config(noreplace)%{_sysconfdir}/fwupd/msr.conf
 %endif
 /usr/lib/modules-load.d/fwupd-redfish.conf
 %{_datadir}/dbus-1/system.d/org.freedesktop.fwupd.conf

--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -11,6 +11,9 @@ install_data(['fwupd-msr.conf'],
 )
 endif
 
+install_data(['msr.conf'],
+  install_dir:  join_paths(sysconfdir, 'fwupd')
+)
 shared_module('fu_plugin_msr',
   fu_hash,
   sources : [

--- a/plugins/msr/msr.conf
+++ b/plugins/msr/msr.conf
@@ -1,0 +1,5 @@
+[msr]
+
+# Minimum kernel version to allow probing for sme flag
+MinimumSmeKernelVersion=5.18.0
+


### PR DESCRIPTION
Starting with linux kernel 5.18 the SME flag will be removed from
/proc/cpuinfo when it's not activated.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?id=08f253ec3767bcfafc5d32617a92cee57c63968e

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
