### PR TITLE
systemd: don't run fwupd/fwupd-refresh in containers

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -3,6 +3,7 @@ Description=Firmware update daemon
 Documentation=https://fwupd.org/
 After=dbus.service
 Before=display-manager.service
+ConditionVirtualization=!container
 
 [Service]
 Type=dbus

--- a/data/motd/fwupd-refresh.timer
+++ b/data/motd/fwupd-refresh.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=Refresh fwupd metadata regularly
+ConditionVirtualization=!container
 
 [Timer]
 OnCalendar=*-*-* 6,18:00


### PR DESCRIPTION
Containers typically don't need to run fwupd as they don't have access to the real hardware.
