### PR TITLE
Sanitize the instance ID parts more carefully

### DIFF
--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -410,6 +410,8 @@ fu_common_strnsplit_full(const gchar *str,
 gchar *
 fu_common_strsafe(const gchar *str, gsize maxsz);
 gchar *
+fu_common_instance_id_strsafe(const gchar *str);
+gchar *
 fu_common_strjoin_array(const gchar *separator, GPtrArray *array);
 gboolean
 fu_common_kernel_locked_down(void);

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -129,11 +129,11 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 	/* i2c devices all expose a name */
 	tmp = g_udev_device_get_sysfs_attr(udev_device, "name");
 	if (tmp != NULL) {
-		g_autofree gchar *devid = NULL;
-		g_autofree gchar *name_safe = g_strdup(tmp);
-		g_strdelimit(name_safe, " /\\\"", '-');
-		devid = g_strdup_printf("I2C\\NAME_%s", name_safe);
-		fu_device_add_instance_id(FU_DEVICE(self), devid);
+		g_autofree gchar *name_safe = fu_common_instance_id_strsafe(tmp);
+		if (name_safe != NULL) {
+			g_autofree gchar *devid = g_strdup_printf("I2C\\NAME_%s", name_safe);
+			fu_device_add_instance_id(FU_DEVICE(self), devid);
+		}
 	}
 
 	/* get bus number out of sysfs path */

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -574,6 +574,8 @@ fu_common_strsafe_func(void)
 		    {"dave\x03\x04XXX", "dave..X"},
 		    {"\x03\x03", NULL},
 		    {NULL, NULL}};
+	g_autofree gchar *id_part = fu_common_instance_id_strsafe("_ _LEN&VO&\\&");
+	g_assert_cmpstr(id_part, ==, "LEN-VO");
 	for (guint i = 0; strs[i].in != NULL; i++) {
 		g_autofree gchar *tmp = fu_common_strsafe(strs[i].in, 7);
 		g_assert_cmpstr(tmp, ==, strs[i].op);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -300,15 +300,15 @@ fu_udev_device_probe_serio(FuUdevDevice *self, GError **error)
 	/* firmware ID */
 	tmp = g_udev_device_get_property(priv->udev_device, "SERIO_FIRMWARE_ID");
 	if (tmp != NULL) {
-		g_autofree gchar *devid = NULL;
 		g_autofree gchar *id_safe = NULL;
 		/* this prefix is not useful */
 		if (g_str_has_prefix(tmp, "PNP: "))
 			tmp += 5;
-		id_safe = g_utf8_strup(tmp, -1);
-		g_strdelimit(id_safe, " /\\\"", '-');
-		devid = g_strdup_printf("SERIO\\FWID_%s", id_safe);
-		fu_device_add_instance_id(FU_DEVICE(self), devid);
+		id_safe = fu_common_instance_id_strsafe(tmp);
+		if (id_safe != NULL) {
+			g_autofree gchar *devid = g_strdup_printf("SERIO\\FWID_%s", id_safe);
+			fu_device_add_instance_id(FU_DEVICE(self), devid);
+		}
 	}
 	return TRUE;
 }

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -998,6 +998,7 @@ LIBFWUPDPLUGIN_1.7.4 {
 
 LIBFWUPDPLUGIN_1.7.6 {
   global:
+    fu_common_instance_id_strsafe;
     fu_common_version_ensure_semver_full;
   local: *;
 } LIBFWUPDPLUGIN_1.7.4;

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -46,11 +46,11 @@ fu_mtd_device_probe(FuDevice *device, GError **error)
 	/* get name */
 	name = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "name", NULL);
 	if (name != NULL) {
-		g_autofree gchar *devid = NULL;
-		g_autofree gchar *name_safe = g_strdup(name);
-		g_strdelimit(name_safe, " /\\\"", '-');
-		devid = g_strdup_printf("MTD\\NAME_%s", name_safe);
-		fu_device_add_instance_id(FU_DEVICE(self), devid);
+		g_autofree gchar *name_safe = fu_common_instance_id_strsafe(name);
+		if (name_safe != NULL) {
+			g_autofree gchar *devid = g_strdup_printf("MTD\\NAME_%s", name_safe);
+			fu_device_add_instance_id(FU_DEVICE(self), devid);
+		}
 		fu_device_set_name(FU_DEVICE(self), name);
 	}
 


### PR DESCRIPTION
The only users of `SERIO\FWID` and `I2C\NAME` are already 'safe' and
the device GUIDs should all be unchanged.

There are no current users of the `MTD\NAME` instance IDs, and these
are the ones that may be more unpredictable and in need of sanity.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
