### PR TITLE
trivial: add allow-stderr to ci autopkgtest

### DIFF
--- a/contrib/debian/tests/control
+++ b/contrib/debian/tests/control
@@ -1,5 +1,5 @@
 Tests: ci
-Restrictions: needs-root
+Restrictions: needs-root, allow-stderr
 
 Tests: libfwupd-dev
 Depends: build-essential, libfwupd-dev, pkg-config


### PR DESCRIPTION
This commit + [87470ea](https://github.com/fwupd/fwupd/commit/87470ea3e010c58d927e0a57be7162c9fc740e73) fix https://github.com/fwupd/fwupd/issues/4299 per my test (against fwupd 1.7.5)

Type of pull request:

- [V] Code fix
