### PR TITLE
trivial: allow fwupd.service to be run in containers for autopkgtest

### DIFF
--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -2,4 +2,8 @@
 set -e
 sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 sed "s,^VerboseDomains=.*,VerboseDomains=*,"  -i /etc/fwupd/daemon.conf
+sed "s,ConditionVirtualization=.*,," 		\
+	/lib/systemd/system/fwupd.service >	\
+	/etc/systemd/system/fwupd.service
+systemctl daemon-reload
 gnome-desktop-testing-runner fwupd


### PR DESCRIPTION
Generally we don't want this - but for the autopkgtest case it's OK.
Fixes: #4299

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
