### PR TITLE
fu-util: prompt devices to stderr

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -207,14 +207,14 @@ fu_util_prompt_for_device(FuUtilPrivate *priv, GPtrArray *devices, GError **erro
 	if (devices_filtered->len == 1) {
 		dev = g_ptr_array_index(devices_filtered, 0);
 		/* TRANSLATORS: Device has been chosen by the daemon for the user */
-		g_print("%s: %s\n", _("Selected device"), fwupd_device_get_name(dev));
+		g_printerr("%s: %s\n", _("Selected device"), fwupd_device_get_name(dev));
 		return g_object_ref(dev);
 	}
 
 	/* TRANSLATORS: get interactive prompt */
-	g_print("%s\n", _("Choose a device:"));
+	g_printerr("%s\n", _("Choose a device:"));
 	/* TRANSLATORS: this is to abort the interactive prompt */
-	g_print("0.\t%s\n", _("Cancel"));
+	g_printerr("0.\t%s\n", _("Cancel"));
 	for (guint i = 0; i < devices_filtered->len; i++) {
 		dev = g_ptr_array_index(devices_filtered, i);
 		g_print("%u.\t%s (%s)\n",


### PR DESCRIPTION
Prompting the devices to stdout breaks the JSON output. Prompts to
stderr instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This intends to fix the command `fwupdmgr get-updates --json b585990a-003e-5270-89d5-3705a17f9a43`.

```
[gportay@archlinux fwupd]$ fwupdmgr get-updates --json b585990a-003e-5270-89d5-3705a17f9a43 | jq .
WARNING: The daemon has loaded 3rd party code and is no longer supported by the upstream developers!
parse error: Invalid numeric literal at line 1, column 9
```

```
[gportay@archlinux fwupd]$ make fixme 
build/src/fwupdmgr get-updates --json b585990a-003e-5270-89d5-3705a17f9a43 | jq .
WARNING: The daemon has loaded 3rd party code and is no longer supported by the upstream developers!
Selected device: Integrated Webcam™
{
  "Devices": []
}
```

It is limited to prompting devices only for now. however, it can be generalized to every other commands.

We should probably discuss if prompting should go to stderr. or make sure there is no path that prompt with `--json` (after `if (priv->as_json) { ... }`