### PR TITLE
vli: Do not assume any VL82x reference firmware has shared PD

### DIFF
--- a/plugins/vli/vli-usbhub.quirk
+++ b/plugins/vli/vli-usbhub.quirk
@@ -62,18 +62,18 @@ Flags = usb2
 [USB\VID_2109&PID_0820]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-shared-spi-pd
+Flags = usb3
 [USB\VID_2109&PID_2820]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb2,has-shared-spi-pd
+Flags = usb2
 
 # VL822
 [USB\VID_2109&PID_0822]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-shared-spi-pd
+Flags = usb3
 [USB\VID_2109&PID_2822]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb2,has-shared-spi-pd
+Flags = usb2


### PR DESCRIPTION
This should be harmless on an actual devboard, and not break products
using the default VID/PID *without* any shared PD chip.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
