### PR TITLE
trivial: Turn off GPIO support by default

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -24,7 +24,7 @@ extraction:
     - "export LD_LIBRARY_PATH=$LGTM_WORKSPACE/installdir/usr/lib:$LD_LIBRARY_PATH"
     configure:
       command:
-      - "meson setup _lgtm_build_dir -Defi_binary=false -Dplugin_uefi_capsule_splash=false -Dplugin_gpio=false -Ddocs=none"
+      - "meson setup _lgtm_build_dir -Defi_binary=false -Dplugin_uefi_capsule_splash=false -Ddocs=none"
     index:
       build_command:
       - "ninja -C _lgtm_build_dir"

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -44,7 +44,6 @@ meson .. \
     -Doffline=false \
     -Dplugin_emmc=false \
     -Dplugin_amt=false \
-    -Dplugin_gpio=false \
     -Dplugin_mtd=false \
     -Dintrospection=false \
     -Dplugin_thunderbolt=false \

--- a/contrib/ci/check-abi
+++ b/contrib/ci/check-abi
@@ -87,7 +87,6 @@ def build_install(revision):
                 "--prefix=/usr",
                 "--libdir=lib",
                 "-Db_coverage=false",
-                "-Dplugin_gpio=false",
                 "-Dgtkdoc=false",
                 "-Ddocs=none",
                 "-Dgusb:docs=false",

--- a/contrib/freebsd/Makefile
+++ b/contrib/freebsd/Makefile
@@ -44,7 +44,6 @@ MESON_ARGS=	-Dgudev=false \
 		-Dplugin_amt=false \
 		-Dplugin_dell=false \
 		-Dplugin_emmc=false \
-		-Dplugin_gpio=false \
 		-Dplugin_nvme=false \
 		-Dplugin_parade_lspcon=false \
 		-Dplugin_redfish=false \

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -256,6 +256,7 @@ fwupd wrapper for Qubes OS
     -Dplugin_uefi_capsule=true \
     -Dplugin_uefi_pk=true \
     -Dplugin_tpm=true \
+    -Dplugin_gpio=true \
     -Defi_binary=false \
 %else
     -Dplugin_uefi_capsule=false \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,7 +24,7 @@ option('plugin_dummy', type : 'boolean', value : false, description : 'enable th
 option('plugin_emmc', type : 'boolean', value : true, description : 'enable eMMC support')
 option('plugin_ep963x', type : 'boolean', value : true, description : 'enable EP963x support')
 option('plugin_fastboot', type : 'boolean', value : true, description : 'enable Fastboot support')
-option('plugin_gpio', type : 'boolean', value : true, description : 'enable GPIO support')
+option('plugin_gpio', type : 'boolean', value : false, description : 'enable GPIO support')
 option('plugin_logitech_bulkcontroller', type : 'boolean', value : true, description : 'enable Logitech bulk controller support')
 option('plugin_parade_lspcon', type : 'boolean', value : true, description : 'enable Parade LSPCON support')
 option('plugin_pixart_rf', type : 'boolean', value : true, description : 'enable PixartRF support')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -191,7 +191,6 @@ parts:
                        -Dman=false,
                        -Dplugin_modem_manager=true,
                        -Dplugin_powerd=false,
-                       -Dplugin_gpio=false,
                        -Dudevdir=$SNAPCRAFT_STAGE/lib/udev,
                        "-Dgusb:tests=false",
                        "-Dgusb:docs=false",


### PR DESCRIPTION
We can swap the default to auto-detection once the auto-features branch
has landed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
