### PR TITLE
uefi-capsule: Add a private flag for devices that never want a capsule header

### DIFF
--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -231,6 +231,11 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 	g_assert_nonnull(device_v12);
 	g_assert_false(fu_device_has_flag(device_v12, FWUPD_DEVICE_FLAG_UPDATABLE));
 
+	/* ensure flags set */
+	ret = fu_device_probe(device_v20, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
 	/* With one flash left we need an override */
 	ret = fu_plugin_runner_write_firmware(self->plugin_uefi_capsule,
 					      device_v20,

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -84,6 +84,12 @@ typedef enum {
  * Do not use RT->SetVariable.
  */
 #define FU_UEFI_DEVICE_FLAG_NO_RT_SET_VARIABLE (1 << 6)
+/**
+ * FU_UEFI_DEVICE_FLAG_NO_CAPSULE_HEADER_FIXUP:
+ *
+ * Do not prepend a plausible missing capsule header.
+ */
+#define FU_UEFI_DEVICE_FLAG_NO_CAPSULE_HEADER_FIXUP (1 << 7)
 
 FuUefiDeviceKind
 fu_uefi_device_kind_from_string(const gchar *kind);


### PR DESCRIPTION
This is to provide an escape hatch for vendors debugging, without having to recompile fwupd from source.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
