### PR TITLE
vli: Skip probing the Dell DA300 device

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -429,6 +429,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED (1ull << 21)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_NO_PROBE:
+ *
+ * Do not probe this device.
+ *
+ * Since: 1.7.6
+ */
+#define FU_DEVICE_INTERNAL_FLAG_NO_PROBE (1ull << 22)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -4,6 +4,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginVliUsbhub"']
 install_data([
   'vli-pd.quirk',
   'vli-usbhub.quirk',
+  'vli-usbhub-dell.quirk',
   'vli-usbhub-lenovo.quirk',
   'vli-usbhub-hyper.quirk',
   'vli-usbhub-bizlink.quirk',

--- a/plugins/vli/vli-usbhub-dell.quirk
+++ b/plugins/vli/vli-usbhub-dell.quirk
@@ -1,0 +1,5 @@
+# Dell DA300
+[USB\VID_2109&PID_0820&REV_3003]
+Flags = no-probe
+[USB\VID_2109&PID_2820&REV_3003]
+Flags = no-probe

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6642,9 +6642,15 @@ fu_engine_backend_device_added_cb(FuBackend *backend, FuDevice *device, FuEngine
 	/* add any extra quirks */
 	fu_device_set_context(device, self->ctx);
 	if (!fu_device_probe(device, &error_local)) {
-		g_warning("failed to probe device %s: %s",
-			  fu_device_get_backend_id(device),
-			  error_local->message);
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+			g_warning("failed to probe device %s: %s",
+				  fu_device_get_backend_id(device),
+				  error_local->message);
+		} else if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
+			g_debug("failed to probe device %s : %s",
+				fu_device_get_backend_id(device),
+				error_local->message);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Although 2109:2820 and 2109:0820, the firmware revision of 3003 is
specific to that hardware.

Fixes https://github.com/fwupd/fwupd/issues/4305

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
