### PR TITLE
Require libjcat 0.1.4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -224,7 +224,7 @@ if get_option('libarchive')
   conf.set('HAVE_LIBARCHIVE', '1')
 endif
 endif
-libjcat = dependency('jcat', version : '>= 0.1.0', fallback : ['libjcat', 'libjcat_dep'])
+libjcat = dependency('jcat', version : '>= 0.1.4', fallback : ['libjcat', 'libjcat_dep'])
 libjsonglib = dependency('json-glib-1.0', version : '>= 1.1.1')
 valgrind = dependency('valgrind', required: false)
 if get_option('curl')

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4123,17 +4123,8 @@ fu_engine_get_newest_signature_jcat_result(GPtrArray *results, GError **error)
 	/* get the first signature, ignoring the checksums */
 	for (guint i = 0; i < results->len; i++) {
 		JcatResult *result = g_ptr_array_index(results, i);
-#if LIBJCAT_CHECK_VERSION(0, 1, 3)
 		if (jcat_result_get_method(result) == JCAT_BLOB_METHOD_SIGNATURE)
 			return g_object_ref(result);
-#else
-		guint verify_kind = 0;
-		g_autoptr(JcatEngine) engine = NULL;
-		g_object_get(result, "engine", &engine, NULL);
-		g_object_get(engine, "verify-kind", &verify_kind, NULL);
-		if (verify_kind == 2) /* SIGNATURE */
-			return g_object_ref(result);
-#endif
 	}
 
 	/* should never happen due to %JCAT_VERIFY_FLAG_REQUIRE_SIGNATURE */


### PR DESCRIPTION
Although we can compile against older versions, we can't actually work
as current firmware.jcat metadata from the LVFS needs these commits:

https://github.com/hughsie/libjcat/commit/109399e1f28cec84b43c355b2be77bac38943df7
https://github.com/hughsie/libjcat/commit/583df67e3ee25201f1e1830ae6d92bf846c082a3

If it helps, 0.1.4 was released in October *2020*.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
