### PR TITLE
Allow devices to build instance IDs more easily

### DIFF
--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -171,24 +171,19 @@ fu_bluez_device_set_modalias(FuBluezDevice *self, const gchar *modalias)
 		fu_firmware_strparse_uint16_safe(modalias, modaliaslen, 21, &rev, NULL);
 	}
 
-	if (vid != 0x0 && pid != 0x0 && rev != 0x0) {
-		g_autofree gchar *devid = NULL;
-		devid = g_strdup_printf("BLUETOOTH\\VID_%04X&PID_%04X&REV_%04X", vid, pid, rev);
-		fu_device_add_instance_id(FU_DEVICE(self), devid);
-	}
-	if (vid != 0x0 && pid != 0x0) {
-		g_autofree gchar *devid = NULL;
-		devid = g_strdup_printf("BLUETOOTH\\VID_%04X&PID_%04X", vid, pid);
-		fu_device_add_instance_id(FU_DEVICE(self), devid);
-	}
+	/* add generated IDs */
+	if (vid != 0x0)
+		fu_device_add_instance_u16(FU_DEVICE(self), "VID", vid);
+	if (pid != 0x0)
+		fu_device_add_instance_u16(FU_DEVICE(self), "PID", pid);
+	fu_device_add_instance_u16(FU_DEVICE(self), "REV", rev);
+	fu_device_build_instance_id_quirk(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", NULL);
+	fu_device_build_instance_id(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", "PID", NULL);
+	fu_device_build_instance_id(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", "PID", "REV", NULL);
+
+	/* set vendor ID */
 	if (vid != 0x0) {
-		g_autofree gchar *devid = NULL;
-		g_autofree gchar *vendor_id = NULL;
-		devid = g_strdup_printf("BLUETOOTH\\VID_%04X", vid);
-		fu_device_add_instance_id_full(FU_DEVICE(self),
-					       devid,
-					       FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
-		vendor_id = g_strdup_printf("BLUETOOTH:%04X", vid);
+		g_autofree gchar *vendor_id = g_strdup_printf("BLUETOOTH:%04X", vid);
 		fu_device_add_vendor_id(FU_DEVICE(self), vendor_id);
 	}
 }

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -699,3 +699,22 @@ gboolean
 fu_device_has_private_flag(FuDevice *self, guint64 flag);
 void
 fu_device_emit_request(FuDevice *self, FwupdRequest *request);
+
+void
+fu_device_add_instance_str(FuDevice *self, const gchar *key, const gchar *value);
+void
+fu_device_add_instance_strsafe(FuDevice *self, const gchar *key, const gchar *value);
+void
+fu_device_add_instance_strup(FuDevice *self, const gchar *key, const gchar *value);
+void
+fu_device_add_instance_u4(FuDevice *self, const gchar *key, guint8 value);
+void
+fu_device_add_instance_u8(FuDevice *self, const gchar *key, guint8 value);
+void
+fu_device_add_instance_u16(FuDevice *self, const gchar *key, guint16 value);
+void
+fu_device_add_instance_u32(FuDevice *self, const gchar *key, guint32 value);
+gboolean
+fu_device_build_instance_id(FuDevice *self, GError **error, const gchar *subsystem, ...);
+gboolean
+fu_device_build_instance_id_quirk(FuDevice *self, GError **error, const gchar *subsystem, ...);

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -128,13 +128,9 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 #ifdef HAVE_GUDEV
 	/* i2c devices all expose a name */
 	tmp = g_udev_device_get_sysfs_attr(udev_device, "name");
-	if (tmp != NULL) {
-		g_autofree gchar *name_safe = fu_common_instance_id_strsafe(tmp);
-		if (name_safe != NULL) {
-			g_autofree gchar *devid = g_strdup_printf("I2C\\NAME_%s", name_safe);
-			fu_device_add_instance_id(FU_DEVICE(self), devid);
-		}
-	}
+	fu_device_add_instance_strsafe(device, "NAME", tmp);
+	if (!fu_device_build_instance_id(device, error, "I2C", "NAME", NULL))
+		return FALSE;
 
 	/* get bus number out of sysfs path */
 	regex = g_regex_new("/i2c-([0-9]+)/", 0, 0, error);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1003,3 +1003,17 @@ LIBFWUPDPLUGIN_1.7.6 {
     fu_udev_device_get_parent_with_subsystem;
   local: *;
 } LIBFWUPDPLUGIN_1.7.4;
+
+LIBFWUPDPLUGIN_1.7.7 {
+  global:
+    fu_device_add_instance_str;
+    fu_device_add_instance_strsafe;
+    fu_device_add_instance_strup;
+    fu_device_add_instance_u16;
+    fu_device_add_instance_u32;
+    fu_device_add_instance_u4;
+    fu_device_add_instance_u8;
+    fu_device_build_instance_id;
+    fu_device_build_instance_id_quirk;
+  local: *;
+} LIBFWUPDPLUGIN_1.7.6;

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -121,9 +121,6 @@ fu_cpu_device_add_instance_ids(FuDevice *device, GError **error)
 	guint32 model_id_ext;
 	guint32 processor_id;
 	guint32 stepping_id;
-	g_autofree gchar *devid1 = NULL;
-	g_autofree gchar *devid2 = NULL;
-	g_autofree gchar *devid3 = NULL;
 
 	/* decode according to https://en.wikipedia.org/wiki/CPUID */
 	if (!fu_common_cpuid(0x1, &eax, NULL, NULL, NULL, error))
@@ -141,17 +138,16 @@ fu_cpu_device_add_instance_ids(FuDevice *device, GError **error)
 	if (family_id == 15)
 		family_id += family_id_ext;
 
-	devid1 = g_strdup_printf("CPUID\\PRO_%01X&FAM_%02X", processor_id, family_id);
-	fu_device_add_instance_id(device, devid1);
-	devid2 =
-	    g_strdup_printf("CPUID\\PRO_%01X&FAM_%02X&MOD_%02X", processor_id, family_id, model_id);
-	fu_device_add_instance_id(device, devid2);
-	devid3 = g_strdup_printf("CPUID\\PRO_%01X&FAM_%02X&MOD_%02X&STP_%01X",
-				 processor_id,
-				 family_id,
-				 model_id,
-				 stepping_id);
-	fu_device_add_instance_id(device, devid3);
+	/* add GUIDs */
+	fu_device_add_instance_u4(device, "PRO", processor_id);
+	fu_device_add_instance_u8(device, "FAM", family_id);
+	fu_device_add_instance_u8(device, "MOD", model_id);
+	fu_device_add_instance_u4(device, "STP", stepping_id);
+	fu_device_build_instance_id(device, NULL, "CPUID", "PRO", "FAM", NULL);
+	fu_device_build_instance_id(device, NULL, "CPUID", "PRO", "FAM", "MOD", NULL);
+	fu_device_build_instance_id(device, NULL, "CPUID", "PRO", "FAM", "MOD", "STP", NULL);
+
+	/* success */
 	return TRUE;
 }
 

--- a/plugins/dfu/fu-dfu-target-avr.c
+++ b/plugins/dfu/fu-dfu-target-avr.c
@@ -531,10 +531,11 @@ fu_dfu_target_avr_setup(FuDfuTarget *target, GError **error)
 	}
 	memcpy(&device_id_be, buf, 4);
 	priv->device_id = GINT32_FROM_BE(device_id_be);
+
 	if (buf[0] == ATMEL_MANUFACTURER_CODE1) {
-		chip_id_guid = g_strdup_printf("DFU_AVR\\CID_0x%08x", (guint)priv->device_id);
+		chip_id_guid = g_strdup_printf("0x%08x", (guint)priv->device_id);
 	} else if (buf[0] == ATMEL_MANUFACTURER_CODE2) {
-		chip_id_guid = g_strdup_printf("DFU_AVR\\CID_0x%06x", (guint)priv->device_id >> 8);
+		chip_id_guid = g_strdup_printf("0x%06x", (guint)priv->device_id >> 8);
 	} else {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -549,7 +550,9 @@ fu_dfu_target_avr_setup(FuDfuTarget *target, GError **error)
 
 	/* set the alt-name using the chip ID via a quirk */
 	device = fu_dfu_target_get_device(target);
-	fu_device_add_instance_id(FU_DEVICE(device), chip_id_guid);
+	fu_device_add_instance_str(FU_DEVICE(device), "CID", chip_id_guid);
+	if (!fu_device_build_instance_id(FU_DEVICE(device), error, "DFU_AVR", "CID", NULL))
+		return FALSE;
 	chip_id = fu_dfu_device_get_chip_id(device);
 	if (chip_id == NULL) {
 		fu_dfu_device_remove_attribute(fu_dfu_target_get_device(target),

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -164,9 +164,7 @@ static gboolean
 fu_fresco_pd_device_setup(FuDevice *device, GError **error)
 {
 	FuFrescoPdDevice *self = FU_FRESCO_PD_DEVICE(device);
-	FuUsbDevice *usb_device = FU_USB_DEVICE(device);
 	guint8 ver[4] = {0x0};
-	g_autofree gchar *instance_id = NULL;
 	g_autofree gchar *version = NULL;
 
 	/* FuUsbDevice->setup */
@@ -185,14 +183,10 @@ fu_fresco_pd_device_setup(FuDevice *device, GError **error)
 
 	/* get customer ID */
 	self->customer_id = ver[1];
-	instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&CID_%02X",
-				      fu_usb_device_get_vid(usb_device),
-				      fu_usb_device_get_pid(usb_device),
-				      self->customer_id);
-	fu_device_add_instance_id(device, instance_id);
 
-	/* success */
-	return TRUE;
+	/* add extra instance ID */
+	fu_device_add_instance_u8(device, "CID", self->customer_id);
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", "CID", NULL);
 }
 
 static FuFirmware *

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1402,8 +1402,6 @@ fu_genesys_scaler_device_probe(FuDevice *device, GError **error)
 	FuGenesysScalerDevice *self = FU_GENESYS_SCALER_DEVICE(device);
 	guint8 buf[7 + 1] = {0};
 	g_autofree gchar *guid = NULL;
-	g_autofree gchar *guid_upper = NULL;
-	g_autofree gchar *instance_id = NULL;
 	g_autofree gchar *version = NULL;
 
 	if (!fu_genesys_scaler_device_get_level(self, &self->level, error))
@@ -1425,9 +1423,12 @@ fu_genesys_scaler_device_probe(FuDevice *device, GError **error)
 	fu_device_set_version(device, version);
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_logical_id(device, "scaler");
-	guid_upper = g_ascii_strup(guid, -1);
-	instance_id = g_strdup_printf("GENESYS_SCALER\\MSTAR_TSUM_G&PUBKEY_%s", guid_upper);
-	fu_device_add_instance_id(device, instance_id);
+
+	/* add instance ID */
+	fu_device_add_instance_str(device, "MSTAR", "TSUM_G");
+	fu_device_add_instance_strup(device, "PUBKEY", guid);
+	fu_device_build_instance_id(device, NULL, "GENESYS_SCALER", "MSTAR", "PUBKEY", NULL);
+
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 
 	self->vc.req_read = GENESYS_SCALER_MSTAR_READ;

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -68,10 +68,12 @@ fu_gpio_device_setup(FuDevice *device, GError **error)
 	/* label is optional, but name is always set */
 	if (info.label[0] != '\0') {
 		g_autofree gchar *logical_id = fu_common_strsafe(info.label, sizeof(info.label));
-		g_autofree gchar *instance_id = NULL;
 		fu_device_set_logical_id(device, logical_id);
-		instance_id = g_strdup_printf("GPIO\\ID_%s", logical_id);
-		fu_device_add_instance_id(device, instance_id);
+
+		/* add instance ID */
+		fu_device_add_instance_strsafe(device, "ID", logical_id);
+		if (!fu_device_build_instance_id(device, error, "GPIO", "ID", NULL))
+			return FALSE;
 	}
 
 	/* success */

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -42,20 +42,13 @@ fu_hailuck_bl_device_attach(FuDevice *device, FuProgress *progress, GError **err
 static gboolean
 fu_hailuck_bl_device_probe(FuDevice *device, GError **error)
 {
-	g_autofree gchar *devid = NULL;
-
 	/* FuUsbDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_hailuck_bl_device_parent_class)->probe(device, error))
 		return FALSE;
 
-	/* add extra keyboard-specific GUID */
-	devid = g_strdup_printf("USB\\VID_%04X&PID_%04X&MODE_KBD",
-				fu_usb_device_get_vid(FU_USB_DEVICE(device)),
-				fu_usb_device_get_pid(FU_USB_DEVICE(device)));
-	fu_device_add_instance_id(device, devid);
-
-	/* success */
-	return TRUE;
+	/* add instance ID */
+	fu_device_add_instance_str(device, "MODE", "KBD");
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", "MODE", NULL);
 }
 
 static gboolean

--- a/plugins/hailuck/fu-hailuck-kbd-device.c
+++ b/plugins/hailuck/fu-hailuck-kbd-device.c
@@ -35,7 +35,6 @@ fu_hailuck_kbd_device_detach(FuDevice *device, FuProgress *progress, GError **er
 static gboolean
 fu_hailuck_kbd_device_probe(FuDevice *device, GError **error)
 {
-	g_autofree gchar *devid = NULL;
 	g_autoptr(FuHailuckTpDevice) tp_device = fu_hailuck_tp_device_new(FU_DEVICE(device));
 
 	/* FuUsbDevice->probe */
@@ -43,10 +42,9 @@ fu_hailuck_kbd_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* add extra keyboard-specific GUID */
-	devid = g_strdup_printf("USB\\VID_%04X&PID_%04X&MODE_KBD",
-				fu_usb_device_get_vid(FU_USB_DEVICE(device)),
-				fu_usb_device_get_pid(FU_USB_DEVICE(device)));
-	fu_device_add_instance_id(device, devid);
+	fu_device_add_instance_str(device, "MODE", "KBD");
+	if (!fu_device_build_instance_id(device, error, "USB", "VID", "PID", "MODE", NULL))
+		return FALSE;
 
 	/* add touchpad */
 	if (!fu_device_probe(FU_DEVICE(tp_device), error))

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -20,20 +20,9 @@ G_DEFINE_TYPE(FuHailuckTpDevice, fu_hailuck_tp_device, FU_TYPE_DEVICE)
 static gboolean
 fu_hailuck_tp_device_probe(FuDevice *device, GError **error)
 {
-	FuDevice *parent = fu_device_get_parent(device);
-	g_autofree gchar *devid1 = NULL;
-	g_autofree gchar *devid2 = NULL;
-
-	devid1 = g_strdup_printf("USB\\VID_%04X&PID_%04X",
-				 fu_usb_device_get_vid(FU_USB_DEVICE(parent)),
-				 fu_usb_device_get_pid(FU_USB_DEVICE(parent)));
-	fu_device_add_instance_id(device, devid1);
-	devid2 = g_strdup_printf("USB\\VID_%04X&PID_%04X&MODE_TP",
-				 fu_usb_device_get_vid(FU_USB_DEVICE(parent)),
-				 fu_usb_device_get_pid(FU_USB_DEVICE(parent)));
-	fu_device_add_instance_id(device, devid2);
-
-	return TRUE;
+	/* add extra touchpad-specific GUID */
+	fu_device_add_instance_str(device, "MODE", "TP");
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", "MODE", NULL);
 }
 
 typedef struct {

--- a/plugins/intel-spi/fu-ifd-device.c
+++ b/plugins/intel-spi/fu-ifd-device.c
@@ -27,14 +27,14 @@ fu_ifd_device_set_region(FuIfdDevice *self, FuIfdRegion region)
 	FuIfdDevicePrivate *priv = GET_PRIVATE(self);
 	const gchar *region_str = fu_ifd_region_to_string(region);
 	g_autofree gchar *instance_id = NULL;
-	g_autofree gchar *region_str_up = NULL;
 
 	priv->region = region;
 	fu_device_set_name(FU_DEVICE(self), fu_ifd_region_to_name(region));
 	fu_device_set_logical_id(FU_DEVICE(self), region_str);
-	region_str_up = g_ascii_strup(region_str, -1);
-	instance_id = g_strdup_printf("IFD\\NAME_%s", region_str_up);
-	fu_device_add_instance_id(FU_DEVICE(self), instance_id);
+
+	/* add instance ID */
+	fu_device_add_instance_strup(FU_DEVICE(self), "NAME", region_str);
+	fu_device_build_instance_id(FU_DEVICE(self), NULL, "IFD", "NAME", NULL);
 }
 
 static void

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -477,8 +477,6 @@ fu_intel_spi_device_set_quirk_kv(FuDevice *device,
 		return TRUE;
 	}
 	if (g_strcmp0(key, "IntelSpiKind") == 0) {
-		g_autofree gchar *instance_id = NULL;
-		g_autofree gchar *kind_up = NULL;
 
 		/* validate */
 		self->kind = fu_intel_spi_kind_from_string(value);
@@ -492,10 +490,8 @@ fu_intel_spi_device_set_quirk_kv(FuDevice *device,
 		}
 
 		/* get things like SPIBAR */
-		kind_up = g_ascii_strup(value, -1);
-		instance_id = g_strdup_printf("INTEL_SPI_CHIPSET\\ID_%s", kind_up);
-		fu_device_add_instance_id(device, instance_id);
-		return TRUE;
+		fu_device_add_instance_strup(device, "ID", value);
+		return fu_device_build_instance_id(device, error, "INTEL_SPI_CHIPSET", "ID", NULL);
 	}
 	if (g_strcmp0(key, "IntelSpiBarProxy") == 0) {
 		self->spibar_proxy = g_strdup(value);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -487,7 +487,6 @@ fu_logitech_hidpp_device_fetch_model_id(FuLogitechHidPpDevice *self, GError **er
 {
 	FuLogitechHidPpDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
-	g_autofree gchar *devid = NULL;
 	g_autoptr(FuLogitechHidPpHidppMsg) msg = fu_logitech_hidpp_msg_new();
 	g_autoptr(GString) str = g_string_new(NULL);
 
@@ -512,11 +511,9 @@ fu_logitech_hidpp_device_fetch_model_id(FuLogitechHidPpDevice *self, GError **er
 	fu_logitech_hidpp_device_set_model_id(self, str->str);
 
 	/* add one more instance ID */
-	devid = g_strdup_printf("HIDRAW\\VEN_%04X&MOD_%s",
-				(guint)FU_UNIFYING_DEVICE_VID,
-				priv->model_id);
-	fu_device_add_instance_id(FU_DEVICE(self), devid);
-	return TRUE;
+	fu_device_add_instance_u16(FU_DEVICE(self), "VEN", FU_UNIFYING_DEVICE_VID);
+	fu_device_add_instance_str(FU_DEVICE(self), "MOD", priv->model_id);
+	return fu_device_build_instance_id(FU_DEVICE(self), error, "HIDRAW", "VEN", "MOD", NULL);
 }
 
 static gboolean

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -359,7 +359,6 @@ fu_logitech_hidpp_runtime_bolt_setup_internal(FuDevice *device, GError **error)
 		guint16 version_raw = 0;
 		g_autofree gchar *version = NULL;
 		g_autoptr(FuLogitechHidPpRadio) radio = NULL;
-		g_autofree gchar *instance_id = NULL;
 		g_autoptr(GString) radio_version = NULL;
 
 		msg->report_id = HIDPP_REPORT_ID_SHORT;
@@ -374,6 +373,7 @@ fu_logitech_hidpp_runtime_bolt_setup_internal(FuDevice *device, GError **error)
 			g_prefix_error(error, "failed to read device config: ");
 			return FALSE;
 		}
+
 		switch (msg->data[0]) {
 		case 0:
 			/* main application */
@@ -409,15 +409,26 @@ fu_logitech_hidpp_runtime_bolt_setup_internal(FuDevice *device, GError **error)
 			/* SoftDevice */
 			radio_version = g_string_new(NULL);
 			radio = fu_logitech_hidpp_radio_new(ctx, i);
+			fu_device_add_instance_u16(
+			    FU_DEVICE(radio),
+			    "VEN",
+			    fu_udev_device_get_vendor(FU_UDEV_DEVICE(device)));
+			fu_device_add_instance_u16(
+			    FU_DEVICE(radio),
+			    "DEV",
+			    fu_udev_device_get_model(FU_UDEV_DEVICE(device)));
+			fu_device_add_instance_u8(FU_DEVICE(radio), "ENT", msg->data[0]);
 			fu_device_set_physical_id(FU_DEVICE(radio),
 						  fu_device_get_physical_id(device));
 			fu_device_set_logical_id(FU_DEVICE(radio), "Receiver_SoftDevice");
-
-			instance_id =
-			    g_strdup_printf("HIDRAW\\VEN_%04X&DEV_%04X&ENT_05",
-					    fu_udev_device_get_vendor(FU_UDEV_DEVICE(device)),
-					    fu_udev_device_get_model(FU_UDEV_DEVICE(device)));
-			fu_device_add_guid(FU_DEVICE(radio), instance_id);
+			if (!fu_device_build_instance_id(FU_DEVICE(radio),
+							 error,
+							 "HIDRAW",
+							 "VEN",
+							 "DEV",
+							 "ENT",
+							 NULL))
+				return FALSE;
 			if (!fu_common_read_uint16_safe(msg->data,
 							sizeof(msg->data),
 							0x03,

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -936,7 +936,6 @@ static gboolean
 fu_nordic_hid_cfg_channel_setup(FuDevice *device, GError **error)
 {
 	FuNordicHidCfgChannel *self = FU_NORDIC_HID_CFG_CHANNEL(device);
-	g_autofree gchar *target_id = NULL;
 
 	/* get the board name */
 	if (!fu_nordic_hid_cfg_channel_get_board_name(self, error))
@@ -965,15 +964,17 @@ fu_nordic_hid_cfg_channel_setup(FuDevice *device, GError **error)
 		fu_device_set_name(device, physical_id);
 	}
 
-	/* additional GUID based on VID/PID and target area to flash
-	 * needed to distinguish images aimed to different bootloaders */
-	target_id = g_strdup_printf("HIDRAW\\VEN_%04X&DEV_%04X&BOARD_%s&BL_%s",
-				    fu_udev_device_get_vendor(FU_UDEV_DEVICE(device)),
-				    fu_udev_device_get_model(FU_UDEV_DEVICE(device)),
-				    self->board_name,
-				    self->bl_name);
-	fu_device_add_guid(device, target_id);
-	return TRUE;
+	/* generate IDs */
+	fu_device_add_instance_strsafe(device, "BOARD", self->board_name);
+	fu_device_add_instance_strsafe(device, "BL", self->bl_name);
+	return fu_device_build_instance_id(device,
+					   error,
+					   "HIDRAW",
+					   "VEN",
+					   "DEV",
+					   "BOARD",
+					   "BL",
+					   NULL);
 }
 
 static void

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -121,19 +121,6 @@ fu_parade_lspcon_device_probe(FuDevice *device, GError **error)
 	FuContext *context = fu_device_get_context(device);
 	FuUdevDevice *udev_device = FU_UDEV_DEVICE(device);
 	const gchar *device_name;
-	g_autofree gchar *instance_id_hwid = NULL;
-	g_autofree gchar *instance_id = NULL;
-
-	/* custom instance IDs to get device quirks */
-	instance_id = g_strdup_printf("PARADE-LSPCON\\NAME_%s",
-				      fu_udev_device_get_sysfs_attr(udev_device, "name", NULL));
-	fu_device_add_instance_id(device, instance_id);
-	instance_id_hwid = g_strdup_printf("%s&FAMILY_%s",
-					   instance_id,
-					   fu_context_get_hwid_value(context, FU_HWIDS_KEY_FAMILY));
-	fu_device_add_instance_id_full(device,
-				       instance_id_hwid,
-				       FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
 
 	device_name = fu_device_get_name(device);
 	if (g_strcmp0(device_name, "PS175") != 0) {
@@ -144,6 +131,17 @@ fu_parade_lspcon_device_probe(FuDevice *device, GError **error)
 			    device_name);
 		return FALSE;
 	}
+
+	/* custom instance IDs to get device quirks */
+	fu_device_add_instance_str(device,
+				   "NAME",
+				   fu_udev_device_get_sysfs_attr(udev_device, "name", NULL));
+	fu_device_add_instance_str(device,
+				   "FAMILY",
+				   fu_context_get_hwid_value(context, FU_HWIDS_KEY_FAMILY));
+	if (!fu_device_build_instance_id(device, error, "PARADE-LSPCON", "NAME", NULL))
+		return FALSE;
+	fu_device_build_instance_id_quirk(device, NULL, "PARADE-LSPCON", "NAME", "FAMILY", NULL);
 
 	/* should know which aux device over which we read DPCD version */
 	if (self->aux_device_name == NULL) {

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -383,22 +383,20 @@ fu_realtek_mst_device_probe(FuDevice *device, GError **error)
 {
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 	FuContext *context = fu_device_get_context(device);
-	const gchar *hardware_family = NULL;
 	const gchar *quirk_name = NULL;
-	g_autofree gchar *family_instance_id = NULL;
-	g_autofree gchar *instance_id = NULL;
 
 	/* set custom instance ID and load matching quirks */
-	instance_id =
-	    g_strdup_printf("REALTEK-MST\\NAME_%s",
-			    fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "name", NULL));
-	fu_device_add_instance_id(device, instance_id);
+	fu_device_add_instance_str(
+	    device,
+	    "NAME",
+	    fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "name", NULL));
+	if (!fu_device_build_instance_id(device, error, "REALTEK-MST", "NAME", NULL))
+		return FALSE;
 
-	hardware_family = fu_context_get_hwid_value(context, FU_HWIDS_KEY_FAMILY);
-	family_instance_id = g_strdup_printf("%s&FAMILY_%s", instance_id, hardware_family);
-	fu_device_add_instance_id_full(device,
-				       family_instance_id,
-				       FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
+	fu_device_add_instance_str(device,
+				   "FAMILY",
+				   fu_context_get_hwid_value(context, FU_HWIDS_KEY_FAMILY));
+	fu_device_build_instance_id_quirk(device, NULL, "REALTEK-MST", "NAME", "FAMILY", NULL);
 
 	/* having loaded quirks, check this device is supported */
 	quirk_name = fu_device_get_name(device);

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -22,7 +22,6 @@ fu_plugin_superio_coldplug_chipset(FuPlugin *plugin, const gchar *guid, GError *
 	const gchar *dmi_vendor;
 	const gchar *chipset;
 	GType custom_gtype;
-	g_autofree gchar *devid = NULL;
 	g_autoptr(FuSuperioDevice) dev = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
@@ -51,8 +50,9 @@ fu_plugin_superio_coldplug_chipset(FuPlugin *plugin, const gchar *guid, GError *
 			   NULL);
 
 	/* add this so we can attach all the other quirks */
-	devid = g_strdup_printf("SUPERIO\\GUID_%s", guid);
-	fu_device_add_instance_id(FU_DEVICE(dev), devid);
+	fu_device_add_instance_str(FU_DEVICE(dev), "GUID", guid);
+	if (!fu_device_build_instance_id(FU_DEVICE(dev), error, "SUPERIO", "GUID", NULL))
+		return FALSE;
 
 	/* set ID and ports via quirks */
 	if (!fu_device_probe(FU_DEVICE(dev), error))

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -412,8 +412,12 @@ fu_synaptics_cxaudio_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 	self->chip_id = self->chip_id_base + chip_id_offset;
-	chip_id = g_strdup_printf("SYNAPTICS_CXAUDIO\\ID_CX%u", self->chip_id);
-	fu_device_add_instance_id_full(device, chip_id, FU_DEVICE_INSTANCE_FLAG_ONLY_QUIRKS);
+
+	/* add instance ID */
+	chip_id = g_strdup_printf("CX%u", self->chip_id);
+	fu_device_add_instance_str(device, "ID", chip_id);
+	if (!fu_device_build_instance_id_quirk(device, error, "SYNAPTICS_CXAUDIO", "ID", NULL))
+		return FALSE;
 
 	/* set summary */
 	summary = g_strdup_printf("CX%u USB audio device", self->chip_id);

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -236,10 +236,6 @@ fu_tpm_v2_device_setup(FuDevice *device, GError **error)
 	guint32 version1 = 0;
 	guint32 version2 = 0;
 	guint64 version_raw;
-	g_autofree gchar *id1 = NULL;
-	g_autofree gchar *id2 = NULL;
-	g_autofree gchar *id3 = NULL;
-	g_autofree gchar *id4 = NULL;
 	g_autofree gchar *manufacturer = NULL;
 	g_autofree gchar *model1 = NULL;
 	g_autofree gchar *model2 = NULL;
@@ -302,14 +298,14 @@ fu_tpm_v2_device_setup(FuDevice *device, GError **error)
 	model = g_strjoin("", model1, model2, model3, model4, NULL);
 
 	/* add GUIDs to daemon */
-	id1 = g_strdup_printf("TPM\\VEN_%s&DEV_%04X", manufacturer, tpm_type);
-	fu_device_add_instance_id(device, id1);
-	id2 = g_strdup_printf("TPM\\VEN_%s&MOD_%s", manufacturer, model);
-	fu_device_add_instance_id(device, id2);
-	id3 = g_strdup_printf("TPM\\VEN_%s&DEV_%04X&VER_%s", manufacturer, tpm_type, family);
-	fu_device_add_instance_id(device, id3);
-	id4 = g_strdup_printf("TPM\\VEN_%s&MOD_%s&VER_%s", manufacturer, model, family);
-	fu_device_add_instance_id(device, id4);
+	fu_device_add_instance_str(device, "VEN", manufacturer);
+	fu_device_add_instance_u16(device, "DEV", tpm_type);
+	fu_device_add_instance_str(device, "MOD", model);
+	fu_device_add_instance_str(device, "VER", family);
+	fu_device_build_instance_id(device, NULL, "TPM", "VEN", "DEV", NULL);
+	fu_device_build_instance_id(device, NULL, "TPM", "VEN", "MOD", NULL);
+	fu_device_build_instance_id(device, NULL, "TPM", "VEN", "DEV", "VER", NULL);
+	fu_device_build_instance_id(device, NULL, "TPM", "VEN", "MOD", "VER", NULL);
 
 	/* enforce vendors can only ship updates for their own hardware */
 	vendor_id = g_strdup_printf("TPM:%s", manufacturer);

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -194,7 +194,6 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 	for (guint i = 0; components[i].name != NULL; i++) {
 		const guint8 *val = outbuf + components[i].offset;
 		g_autofree gchar *version = NULL;
-		g_autofree gchar *instance_id = NULL;
 		g_autoptr(FuDevice) child = NULL;
 
 		child = fu_usi_dock_child_new(fu_device_get_context(FU_DEVICE(self)));
@@ -361,11 +360,15 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 		}
 
 		/* add virtual device */
-		instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&CID_%s",
-					      fu_usb_device_get_vid(FU_USB_DEVICE(self)),
-					      fu_usb_device_get_pid(FU_USB_DEVICE(self)),
-					      components[i].name);
-		fu_device_add_instance_id(child, instance_id);
+		fu_device_add_instance_u16(child,
+					   "VID",
+					   fu_usb_device_get_vid(FU_USB_DEVICE(self)));
+		fu_device_add_instance_u16(child,
+					   "PID",
+					   fu_usb_device_get_pid(FU_USB_DEVICE(self)));
+		fu_device_add_instance_str(child, "CID", components[i].name);
+		if (!fu_device_build_instance_id(child, error, "USB", "VID", "PID", "CID", NULL))
+			return FALSE;
 		if (fu_device_get_name(child) == NULL)
 			fu_device_set_name(child, components[i].name);
 		fu_device_set_logical_id(child, components[i].name);

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -665,23 +665,17 @@ fu_vli_pd_parade_device_dump_firmware(FuDevice *device, FuProgress *progress, GE
 static gboolean
 fu_vli_pd_parade_device_probe(FuDevice *device, GError **error)
 {
-	FuVliPdDevice *parent = FU_VLI_PD_DEVICE(fu_device_get_parent(device));
 	FuVliPdParadeDevice *self = FU_VLI_PD_PARADE_DEVICE(device);
-	g_autofree gchar *instance_id1 = NULL;
 
 	/* get version */
 	if (!fu_vli_pd_parade_device_read_fw_ver(self, error))
 		return FALSE;
 
 	/* use header to populate device info */
-	instance_id1 = g_strdup_printf("USB\\VID_%04X&PID_%04X&I2C_%s",
-				       fu_usb_device_get_vid(FU_USB_DEVICE(parent)),
-				       fu_usb_device_get_pid(FU_USB_DEVICE(parent)),
-				       fu_vli_common_device_kind_to_string(self->device_kind));
-	fu_device_add_instance_id(device, instance_id1);
-
-	/* success */
-	return TRUE;
+	fu_device_add_instance_str(device,
+				   "I2C",
+				   fu_vli_common_device_kind_to_string(self->device_kind));
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", "I2C", NULL);
 }
 
 static void

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -292,19 +292,13 @@ fu_vli_usbhub_msp430_device_probe(FuDevice *device, GError **error)
 {
 	FuVliDeviceKind device_kind = FU_VLI_DEVICE_KIND_MSP430;
 	FuVliUsbhubDevice *parent = FU_VLI_USBHUB_DEVICE(fu_device_get_parent(device));
-	g_autofree gchar *instance_id = NULL;
 
 	fu_device_set_name(device, fu_vli_common_device_kind_to_string(device_kind));
 	fu_device_set_physical_id(device, fu_device_get_physical_id(FU_DEVICE(parent)));
 
 	/* add instance ID */
-	instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&I2C_%s",
-				      fu_usb_device_get_vid(FU_USB_DEVICE(parent)),
-				      fu_usb_device_get_pid(FU_USB_DEVICE(parent)),
-				      fu_vli_common_device_kind_to_string(device_kind));
-	fu_device_add_instance_id(device, instance_id);
-
-	return TRUE;
+	fu_device_add_instance_str(device, "I2C", fu_vli_common_device_kind_to_string(device_kind));
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", NULL);
 }
 
 static void

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -511,18 +511,13 @@ fu_vli_usbhub_rtd21xx_device_probe(FuDevice *device, GError **error)
 {
 	FuVliDeviceKind device_kind = FU_VLI_DEVICE_KIND_RTD21XX;
 	FuVliUsbhubDevice *parent = FU_VLI_USBHUB_DEVICE(fu_device_get_parent(device));
-	g_autofree gchar *instance_id = NULL;
 
 	fu_device_set_name(device, fu_vli_common_device_kind_to_string(device_kind));
 	fu_device_set_physical_id(device, fu_device_get_physical_id(FU_DEVICE(parent)));
 
 	/* add instance ID */
-	instance_id = g_strdup_printf("USB\\VID_%04X&PID_%04X&I2C_%s",
-				      fu_usb_device_get_vid(FU_USB_DEVICE(parent)),
-				      fu_usb_device_get_pid(FU_USB_DEVICE(parent)),
-				      fu_vli_common_device_kind_to_string(device_kind));
-	fu_device_add_instance_id(device, instance_id);
-	return TRUE;
+	fu_device_add_instance_str(device, "I2C", fu_vli_common_device_kind_to_string(device_kind));
+	return fu_device_build_instance_id(device, error, "USB", "VID", "PID", "I2C", NULL);
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -41,8 +41,6 @@ fu_wacom_aes_add_recovery_hwid(FuDevice *device, GError **error)
 	FuWacomRawVerifyResponse rsp = {.report_id = FU_WACOM_RAW_BL_REPORT_ID_GET,
 					.size8 = 0x00,
 					.data = {0x00}};
-	g_autofree gchar *devid1 = NULL;
-	g_autofree gchar *devid2 = NULL;
 	guint16 pid;
 
 	if (!fu_wacom_device_set_feature(FU_WACOM_DEVICE(device),
@@ -77,12 +75,13 @@ fu_wacom_aes_add_recovery_hwid(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	devid1 = g_strdup_printf("HIDRAW\\VEN_2D1F&DEV_%04X", pid);
-	devid2 = g_strdup_printf("HIDRAW\\VEN_056A&DEV_%04X", pid);
-	fu_device_add_instance_id(device, devid1);
-	fu_device_add_instance_id(device, devid2);
-
-	return TRUE;
+	/* add recovery IDs */
+	fu_device_add_instance_u16(device, "VEN", 0x2D1F);
+	fu_device_add_instance_u16(device, "DEV", pid);
+	if (!fu_device_build_instance_id(device, error, "HIDRAW", "VID", "PID", NULL))
+		return FALSE;
+	fu_device_add_instance_u16(device, "VEN", 0x056A);
+	return fu_device_build_instance_id(device, error, "HIDRAW", "VID", "PID", NULL);
 }
 
 static gboolean


### PR DESCRIPTION
Provide a device instance builder that allows plugins to easily
create multiple instance IDs based on parent attributes.

Also fix a lot of the instance ID orders, so that we add more generic
IDs first, and more specific IDs after.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
