### PR TITLE
plugin/flashrom: Add MaxSize quirk for Lite II and III

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -10,10 +10,12 @@ VersionFormat = quad
 # StarLite Mk II (HwId)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
 Plugin = flashrom
+FirmwareSizeMax = 0x800000
 
 # StarLite Mk III (HwId)
 [d5521faa-c50b-5d64-971d-8fd400030c51]
 Plugin = flashrom
+FirmwareSizeMax = 0x800000
 
 # StarLabTop Mk III (HwId)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]


### PR DESCRIPTION
Add FirmwareSizeMax = 0x800000 for StarLite Mk II and Mk III to allow
switching from AMI to coreboot firmware.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>
