### PR TITLE
trivial: Don't leak the string even on critical failure

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -4567,7 +4567,7 @@ fwupd_client_set_user_agent_for_package(FwupdClient *self,
 					const gchar *package_version)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
-	GString *str = g_string_new(NULL);
+	g_autoptr(GString) str = g_string_new(NULL);
 	g_autofree gchar *system = NULL;
 
 	g_return_if_fail(FWUPD_IS_CLIENT(self));
@@ -4588,7 +4588,7 @@ fwupd_client_set_user_agent_for_package(FwupdClient *self,
 
 	/* success */
 	g_free(priv->user_agent);
-	priv->user_agent = g_string_free(str, FALSE);
+	priv->user_agent = g_string_free(g_steal_pointer(&str), FALSE);
 }
 
 #ifdef HAVE_LIBCURL

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -308,7 +308,7 @@ fwupd_build_user_agent_system(void)
 gchar *
 fwupd_build_user_agent(const gchar *package_name, const gchar *package_version)
 {
-	GString *str = g_string_new(NULL);
+	g_autoptr(GString) str = g_string_new(NULL);
 	g_autofree gchar *system = NULL;
 
 	g_return_val_if_fail(package_name != NULL, NULL);
@@ -327,7 +327,7 @@ fwupd_build_user_agent(const gchar *package_name, const gchar *package_version)
 		g_string_append_printf(str, " fwupd/%s", PACKAGE_VERSION);
 
 	/* success */
-	return g_string_free(str, FALSE);
+	return g_string_free(g_steal_pointer(&str), FALSE);
 }
 
 /**

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -2833,7 +2833,7 @@ gchar *
 fwupd_device_to_string(FwupdDevice *self)
 {
 	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	GString *str = g_string_new(NULL);
+	g_autoptr(GString) str = g_string_new(NULL);
 	g_autoptr(GPtrArray) guid_helpers = NULL;
 
 	g_return_val_if_fail(FWUPD_IS_DEVICE(self), NULL);
@@ -2950,7 +2950,7 @@ fwupd_device_to_string(FwupdDevice *self)
 		g_string_append_printf(str, "  \n  [%s]\n%s", FWUPD_RESULT_KEY_RELEASE, tmp);
 	}
 
-	return g_string_free(str, FALSE);
+	return g_string_free(g_steal_pointer(&str), FALSE);
 }
 
 static void


### PR DESCRIPTION
Not totally sure this is worthwhile, but it triggered a failure in the
RHEL tests we do - and it's less work to fix it than argue.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
