### PR TITLE
trivial: Add daemon configuration key 'OnlyTrusted' to dbus Properties

### DIFF
--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -364,6 +364,8 @@ fwupd_client_get_status(FwupdClient *self);
 gboolean
 fwupd_client_get_tainted(FwupdClient *self);
 gboolean
+fwupd_client_get_only_trusted(FwupdClient *self);
+gboolean
 fwupd_client_get_daemon_interactive(FwupdClient *self);
 guint
 fwupd_client_get_percentage(FwupdClient *self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -755,3 +755,9 @@ LIBFWUPD_1.7.6 {
     fwupd_device_get_issues;
   local: *;
 } LIBFWUPD_1.7.4;
+
+LIBFWUPD_1.8.0 {
+  global:
+    fwupd_client_get_only_trusted;
+  local: *;
+} LIBFWUPD_1.7.6;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -110,6 +110,7 @@ struct _FuEngine {
 	FuDeviceList *device_list;
 	FwupdStatus status;
 	gboolean tainted;
+	gboolean only_trusted;
 	gboolean write_history;
 	guint percentage;
 	FuHistory *history;
@@ -6272,6 +6273,13 @@ gboolean
 fu_engine_get_tainted(FuEngine *self)
 {
 	return self->tainted;
+}
+
+gboolean
+fu_engine_get_only_trusted(FuEngine *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
+	return fu_config_get_only_trusted(self->config);
 }
 
 const gchar *

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -59,6 +59,8 @@ gboolean
 fu_engine_load_plugins(FuEngine *self, GError **error);
 gboolean
 fu_engine_get_tainted(FuEngine *self);
+gboolean
+fu_engine_get_only_trusted(FuEngine *self);
 const gchar *
 fu_engine_get_host_product(FuEngine *self);
 const gchar *

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1889,6 +1889,9 @@ fu_main_daemon_get_property(GDBusConnection *connection_,
 	if (g_strcmp0(property_name, "Interactive") == 0)
 		return g_variant_new_boolean(isatty(fileno(stdout)) != 0);
 
+	if (g_strcmp0(property_name, "OnlyTrusted") == 0)
+		return g_variant_new_boolean(fu_engine_get_only_trusted(priv->engine));
+
 	/* return an error */
 	g_set_error(error,
 		    G_DBUS_ERROR,

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -112,6 +112,17 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='OnlyTrusted' type='b' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            If the daemon requires trusted payloads.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <method name='GetDevices'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
