### PR TITLE
trivial: dell-dock: set package version payload as unsigned

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -158,6 +158,7 @@ fu_dell_dock_status_init(FuDellDockStatus *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.dell.dock");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 }
 
 static void


### PR DESCRIPTION
This payload is just 24 bytes with no signature.  It's used as a manifest
to verify that all firmware is installed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
