### PR TITLE
ccgx: Add the correct instance IDs to the HPI device

### DIFF
--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1468,16 +1468,8 @@ fu_ccgx_hpi_device_setup(FuDevice *device, GError **error)
 	}
 
 	/* add extra instance IDs */
-	fu_device_build_instance_id_quirk(device, NULL, "USB", "VID", "PID", "SID", "APP", NULL);
-	fu_device_build_instance_id_quirk(device,
-					  NULL,
-					  "USB",
-					  "VID",
-					  "PID",
-					  "SID",
-					  "APP",
-					  "MODE",
-					  NULL);
+	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "SID", "APP", NULL);
+	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "SID", "APP", "MODE", NULL);
 
 	/* if we are coming back from reset, wait for hardware to settle */
 	if (!fu_ccgx_hpi_device_get_event(self,


### PR DESCRIPTION
A simple copy+paste typo -- these need to be actual IDs for firmware
matching rather than only for quirks.

Fixes https://github.com/fwupd/fwupd/issues/4382

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
