### PR TITLE
Only delay the device removal when waiting for a replug

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -485,7 +485,8 @@ fu_device_list_remove(FuDeviceList *self, FuDevice *device)
 	}
 
 	/* delay the removal and check for replug */
-	if (fu_device_get_remove_delay(item->device) > 0) {
+	if (fu_device_has_flag(item->device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG) &&
+	    fu_device_get_remove_delay(item->device) > 0) {
 		fu_device_list_remove_with_delay(item);
 		return;
 	}


### PR DESCRIPTION
This stops the device showing up in 'fwupdmgr get-devices' with an
inhibit when removed normally, i.e. not during or after a fw update.

Fixes https://github.com/fwupd/fwupd/issues/4382

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
