### PR TITLE
trivial: Actually open the GPIO device before querying the chipinfo

### DIFF
--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -35,6 +35,15 @@ fu_gpio_device_probe(FuDevice *device, GError **error)
 	if (!FU_DEVICE_CLASS(fu_gpio_device_parent_class)->probe(device, error))
 		return FALSE;
 
+	/* no device file */
+	if (fu_udev_device_get_device_file(FU_UDEV_DEVICE(device)) == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no device file");
+		return FALSE;
+	}
+
 	/* set the physical ID */
 	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "gpio", error);
 }

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -190,6 +190,7 @@ fu_gpio_device_assign(FuGpioDevice *self, const gchar *id, gboolean value, GErro
 static void
 fu_gpio_device_init(FuGpioDevice *self)
 {
+	fu_udev_device_set_flags(FU_UDEV_DEVICE(self), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 }
 
 static void


### PR DESCRIPTION
Set the GPIO open flags as without the fd is not opened.

Fixes https://github.com/fwupd/fwupd/issues/4388

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
