### PR TITLE
Allow a plugin to only use the RemoveDelay when waiting for replug

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -242,6 +242,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "no-probe";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED)
 		return "md-set-signed";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY)
+		return "only-wfr-remove-delay";
 	return NULL;
 }
 
@@ -306,6 +308,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_NO_PROBE;
 	if (g_strcmp0(flag, "md-set-signed") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED;
+	if (g_strcmp0(flag, "only-wfr-remove-delay") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -447,6 +447,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED (1ull << 23)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY:
+ *
+ * Only use the device removal delay when waiting for reboot.
+ *
+ * Since: 1.8.0
+ */
+#define FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY (1ull << 24)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -731,6 +731,7 @@ fu_ccgx_dmc_device_init(FuCcgxDmcDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_CCGX_DMC_DEVICE_FLAG_HAS_MANUAL_REPLUG,
 					"has-manual-replug");

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -562,6 +562,7 @@ fu_colorhug_device_init(FuColorhugDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_COLORHUG_DEVICE_FLAG_HALFSIZE,
 					"halfsize");

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -446,6 +446,17 @@ fu_device_list_remove_with_delay(FuDeviceItem *item)
 					item);
 }
 
+static gboolean
+fu_device_list_should_remove_with_delay(FuDevice *device)
+{
+	if (fu_device_get_remove_delay(device) == 0)
+		return FALSE;
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ONLY_WFR_REMOVE_DELAY) &&
+	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG))
+		return FALSE;
+	return TRUE;
+}
+
 /**
  * fu_device_list_remove:
  * @self: a device list
@@ -487,7 +498,7 @@ fu_device_list_remove(FuDeviceList *self, FuDevice *device)
 	}
 
 	/* delay the removal and check for replug */
-	if (fu_device_get_remove_delay(item->device) > 0) {
+	if (fu_device_list_should_remove_with_delay(item->device)) {
 		fu_device_list_remove_with_delay(item);
 		return;
 	}


### PR DESCRIPTION
Only opt-in plugins that have been tested -- unconditionally enabling
this may cause regressions on devices like docks.

Fixes https://github.com/fwupd/fwupd/issues/4378

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
