### PR TITLE
redfish: Don't add the backup BMC device as it shares the same GUIDs

### DIFF
--- a/plugins/redfish/redfish.quirk
+++ b/plugins/redfish/redfish.quirk
@@ -4,7 +4,7 @@ Flags = wildcard-targets,reset-required
 
 [REDFISH\VENDOR_Lenovo&ID_BMC-Backup]
 ParentGuid = REDFISH\VENDOR_Lenovo&ID_BMC-Primary
-Flags = dual-image,is-backup
+Flags = dual-image,is-backup,no-probe
 
 [REDFISH\VENDOR_Lenovo&ID_BMC-Primary]
 ParentGuid = REDFISH\VENDOR_Lenovo&ID_BMC-Primary


### PR DESCRIPTION
This fixes the problem when the UEFI update depends on a specific BMC
version -- including the backup BMC device means we checking that both
the primary and the backup were above a specific version.

I don't think it's ever useful to show the backup BMC device, so just
don't include it as an enumerated device.

Fixes https://github.com/fwupd/fwupd/issues/4404

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
