### PR TITLE
genesys: Identify hp usbhubs with public key

### DIFF
--- a/plugins/genesys/README.md
+++ b/plugins/genesys/README.md
@@ -24,7 +24,7 @@ This plugin supports the following protocol IDs:
 
 These devices use the standard USB DeviceInstanceId values for the USB Hub, e.g.
 
-* HP Mxfd FHD Monitor: `USB\VID_03F0&PID_0610`
+* HP USB-C Controller: `USB\VID_03F0&PID_0610`
 
 These devices also use custom GUID values for the Scaler, e.g.
 

--- a/plugins/genesys/README.md
+++ b/plugins/genesys/README.md
@@ -25,6 +25,8 @@ This plugin supports the following protocol IDs:
 These devices use the standard USB DeviceInstanceId values for the USB Hub, e.g.
 
 * HP USB-C Controller: `USB\VID_03F0&PID_0610`
+* HP M24fd USB-C Controller: `USB\VID_03F0&PID_0610&PUBKEY_B335BDCE-7073-5D0E-9BD3-9B69C1A6899F`
+* HP M27fd USB-C Controller: `USB\VID_03F0&PID_0610&PUBKEY_847A3650-8648-586B-83C8-8B53714F37E3`
 
 These devices also use custom GUID values for the Scaler, e.g.
 

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -34,12 +34,16 @@
  * FU_SCALER_FLAG_PAUSE_R2_CPU:
  *
  * Pause R2 CPU.
+ *
+ * Since 1.7.6
  */
 #define FU_SCALER_FLAG_PAUSE_R2_CPU (1 << 1)
 /**
  * FU_SCALER_FLAG_USE_I2C_CH0:
  *
  * Use I2C ch0.
+ *
+ * Since 1.7.6
  */
 #define FU_SCALER_FLAG_USE_I2C_CH0 (1 << 0)
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -21,6 +21,8 @@
  * FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER:
  *
  * Device has a MStar scaler attached via I2C.
+ *
+ * Since 1.7.6
  */
 #define FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER (1 << 0)
 /**

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -837,7 +837,6 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		} else {
 			self->code_size = self->fw_data_total_count;
 		}
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 		fu_device_set_firmware_size_max(device, 0x8000);
 		break;
 	case ISP_MODEL_HUB_GL3590:
@@ -846,7 +845,6 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		self->fw_bank_addr[0] = 0x0000;
 		self->fw_bank_addr[1] = 0x10000;
 		self->fw_data_total_count = 0x8000;
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 		fu_device_set_firmware_size_max(device, 0x10000);
 		break;
 	default:

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2022 Gaël PORTAY <gael.portay@collabora.com>
  * Copyright (C) 2021 Ricardo Cañuelo <ricardo.canuelo@collabora.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
@@ -115,6 +116,7 @@ struct _FuGenesysUsbhubDevice {
 	gboolean read_first_bank;
 	gboolean write_recovery_bank;
 
+	guint8 public_key[0x212];
 	FuCfiDevice *cfi_device;
 };
 
@@ -691,6 +693,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autofree guint8 *buf = NULL;
+	g_autofree gchar *guid = NULL;
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->setup(device, error)) {
@@ -920,6 +923,21 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		self->write_recovery_bank = address == self->fw_bank_addr[1];
 	}
 
+	/* get public key */
+	if (!fu_memcpy_safe(self->public_key,
+			    sizeof(self->public_key),
+			    0, /* dst */
+			    g_bytes_get_data(blob, NULL),
+			    g_bytes_get_size(blob),
+			    self->fw_data_total_count, /* src */
+			    sizeof(self->public_key),
+			    error))
+		return FALSE;
+	guid =
+	    fwupd_guid_hash_data(self->public_key, sizeof(self->public_key), FWUPD_GUID_FLAG_NONE);
+	fu_device_add_instance_strup(device, "PUBKEY", guid);
+	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "PUBKEY", NULL);
+
 	/* have MStar scaler */
 	if (fu_device_has_private_flag(device, FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER))
 		if (!fu_genesys_usbhub_device_mstar_scaler_setup(self, error))
@@ -963,11 +981,30 @@ fu_genesys_usbhub_device_prepare_firmware(FuDevice *device,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {
+	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
 	g_autoptr(FuFirmware) firmware = fu_genesys_usbhub_firmware_new();
 
 	/* parse firmware */
 	if (!fu_firmware_parse(firmware, fw, flags, error))
 		return NULL;
+
+	/* has public-key */
+	if (g_bytes_get_size(fw) >= fu_firmware_get_size(firmware) + sizeof(self->public_key)) {
+		gsize bufsz = 0;
+		const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+
+		if (g_getenv("FWUPD_GENESYS_USBHUB_VERBOSE") != NULL)
+			fu_common_dump_raw(G_LOG_DOMAIN, "Footer", buf, bufsz);
+		if (memcmp(buf + fu_firmware_get_size(firmware),
+			   self->public_key,
+			   sizeof(self->public_key)) != 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_SIGNATURE_INVALID,
+					    "mismatch public-key");
+			return NULL;
+		}
+	}
 
 	/* check size */
 	if (g_bytes_get_size(fw) > fu_device_get_firmware_size_max(device)) {

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -23,6 +23,14 @@
  * Device has a MStar scaler attached via I2C.
  */
 #define FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER (1 << 0)
+/**
+ * FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY:
+ *
+ * Device has a public-key appended to firmware.
+ *
+ * Since 1.7.7
+ */
+#define FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY (1 << 1)
 
 #define GENESYS_USBHUB_STATIC_TOOL_DESC_IDX_USB_3_0  0x84
 #define GENESYS_USBHUB_DYNAMIC_TOOL_DESC_IDX_USB_3_0 0x85
@@ -614,8 +622,10 @@ static gboolean
 fu_genesys_usbhub_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
-	if (!fu_genesys_usbhub_device_authenticate(self, error))
-		return FALSE;
+	if (fu_device_has_private_flag(device, FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY)) {
+		if (!fu_genesys_usbhub_device_authenticate(self, error))
+			return FALSE;
+	}
 	if (!fu_genesys_usbhub_device_set_isp_mode(self, ISP_ENTER, error))
 		return FALSE;
 
@@ -693,7 +703,6 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autofree guint8 *buf = NULL;
-	g_autofree gchar *guid = NULL;
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->setup(device, error)) {
@@ -809,8 +818,10 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		}
 	}
 
-	if (!fu_genesys_usbhub_device_authenticate(self, error))
-		return FALSE;
+	if (fu_device_has_private_flag(device, FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY)) {
+		if (!fu_genesys_usbhub_device_authenticate(self, error))
+			return FALSE;
+	}
 	if (!fu_genesys_usbhub_device_set_isp_mode(self, ISP_ENTER, error))
 		return FALSE;
 	self->cfi_device = fu_genesys_usbhub_device_cfi_setup(self, error);
@@ -921,19 +932,24 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		self->write_recovery_bank = address == self->fw_bank_addr[1];
 	}
 
-	/* get public key */
-	if (!fu_memcpy_safe(self->public_key,
-			    sizeof(self->public_key),
-			    0, /* dst */
-			    g_bytes_get_data(blob, NULL),
-			    g_bytes_get_size(blob),
-			    self->fw_data_total_count, /* src */
-			    sizeof(self->public_key),
-			    error))
-		return FALSE;
-	guid =
-	    fwupd_guid_hash_data(self->public_key, sizeof(self->public_key), FWUPD_GUID_FLAG_NONE);
-	fu_device_add_instance_strup(device, "PUBKEY", guid);
+	/* has public key */
+	if (fu_device_has_private_flag(device, FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY)) {
+		g_autofree gchar *guid = NULL;
+		if (!fu_memcpy_safe(self->public_key,
+				    sizeof(self->public_key),
+				    0, /* dst */
+				    g_bytes_get_data(blob, NULL),
+				    g_bytes_get_size(blob),
+				    self->fw_data_total_count, /* src */
+				    sizeof(self->public_key),
+				    error))
+			return FALSE;
+		guid = fwupd_guid_hash_data(self->public_key,
+					    sizeof(self->public_key),
+					    FWUPD_GUID_FLAG_NONE);
+		fu_device_add_instance_strup(device, "PUBKEY", guid);
+	}
+
 	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "PUBKEY", NULL);
 
 	/* have MStar scaler */
@@ -1373,6 +1389,9 @@ fu_genesys_usbhub_device_init(FuGenesysUsbhubDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER,
 					"has-mstar-scaler");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY,
+					"has-public-key");
 	self->vcs.req_switch = GENESYS_USBHUB_GL_HUB_SWITCH;
 	self->vcs.req_read = GENESYS_USBHUB_GL_HUB_READ;
 	self->vcs.req_write = GENESYS_USBHUB_GL_HUB_WRITE;

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -153,6 +153,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 	} else {
 		code_size = 0x6000;
 	}
+	fu_firmware_set_size(firmware, code_size);
 
 	/* calculate checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0)

--- a/plugins/genesys/genesys.quirk
+++ b/plugins/genesys/genesys.quirk
@@ -4,7 +4,7 @@
 [USB\VID_03F0&PID_0610]
 Plugin = genesys
 Name = HP USB-C Controller
-Flags = dual-image
+Flags = dual-image,has-public-key
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3
@@ -12,7 +12,7 @@ GenesysUsbhubWriteRequest = 0xA3
 [USB\VID_03F0&PID_0610&PUBKEY_AB859399-95B8-5817-B521-9AD8CC7F5BD6]
 Plugin = genesys
 Name = HP M24fd USB-C Controller
-Flags = dual-image,has-mstar-scaler
+Flags = dual-image,has-public-key,has-mstar-scaler
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3
@@ -20,7 +20,7 @@ GenesysUsbhubWriteRequest = 0xA3
 [USB\VID_03F0&PID_0610&PUBKEY_6BE97D77-C2BA-5AA2-B7DF-B9B318BEC2B5]
 Plugin = genesys
 Name = HP M27fd USB-C Controller
-Flags = dual-image,has-mstar-scaler
+Flags = dual-image,has-public-key,has-mstar-scaler
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3

--- a/plugins/genesys/genesys.quirk
+++ b/plugins/genesys/genesys.quirk
@@ -1,9 +1,24 @@
-# M2xfd
+# HP M2xfd
 
 # usbhub
 [USB\VID_03F0&PID_0610]
 Plugin = genesys
 Name = HP USB-C Controller
+GenesysUsbhubSwitchRequest = 0xA1
+GenesysUsbhubReadRequest = 0xA2
+GenesysUsbhubWriteRequest = 0xA3
+
+[USB\VID_03F0&PID_0610&PUBKEY_AB859399-95B8-5817-B521-9AD8CC7F5BD6]
+Plugin = genesys
+Name = HP M24fd USB-C Controller
+Flags = has-mstar-scaler
+GenesysUsbhubSwitchRequest = 0xA1
+GenesysUsbhubReadRequest = 0xA2
+GenesysUsbhubWriteRequest = 0xA3
+
+[USB\VID_03F0&PID_0610&PUBKEY_6BE97D77-C2BA-5AA2-B7DF-B9B318BEC2B5]
+Plugin = genesys
+Name = HP M27fd USB-C Controller
 Flags = has-mstar-scaler
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2

--- a/plugins/genesys/genesys.quirk
+++ b/plugins/genesys/genesys.quirk
@@ -4,6 +4,7 @@
 [USB\VID_03F0&PID_0610]
 Plugin = genesys
 Name = HP USB-C Controller
+Flags = dual-image
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3
@@ -11,7 +12,7 @@ GenesysUsbhubWriteRequest = 0xA3
 [USB\VID_03F0&PID_0610&PUBKEY_AB859399-95B8-5817-B521-9AD8CC7F5BD6]
 Plugin = genesys
 Name = HP M24fd USB-C Controller
-Flags = has-mstar-scaler
+Flags = dual-image,has-mstar-scaler
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3
@@ -19,7 +20,7 @@ GenesysUsbhubWriteRequest = 0xA3
 [USB\VID_03F0&PID_0610&PUBKEY_6BE97D77-C2BA-5AA2-B7DF-B9B318BEC2B5]
 Plugin = genesys
 Name = HP M27fd USB-C Controller
-Flags = has-mstar-scaler
+Flags = dual-image,has-mstar-scaler
 GenesysUsbhubSwitchRequest = 0xA1
 GenesysUsbhubReadRequest = 0xA2
 GenesysUsbhubWriteRequest = 0xA3


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

The idea behind those changes is to prepare the genesys plugin for upgrading the genuine Genesys Logic Hubs products.

These products uses `USB\VID_05E3&PID_0610` which is not set in the quirk file yet; will be in a dedicated PR, once the support is fully functional.

The support for genuine Genesys Logic Hubs is splited into several PR. This one is the first of the serie.

In short, this PR:
 - Adds add the public key to the instance-id to with precision the HP hub; M24fd and M27fd have different firmwares; public-keys are differents at least.  
 - Adds the private flag `has-public-key` which tells the plugin the device support public-key and do authentication on attach/detach. This feature is specific to HP devices. The Genesys Logic products do not use this feature.
 - Sets the flag `dual-image` in the quirk file instead of hardcoding it in the plugin; the dual bank feature is not necessarily used by the hubs (HP use it).