### PR TITLE
genesys: trivial rework some usbhub errors

### DIFF
--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -747,10 +747,14 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		} else if (memcmp(self->static_ts.mask_project_ic_type, "3590", 4) == 0) {
 			self->isp_model = ISP_MODEL_HUB_GL3590;
 		} else {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INTERNAL,
-					    "Unknown ISP model");
+			g_autofree gchar *ic_type =
+			    fu_common_strsafe((const gchar *)&self->static_ts.mask_project_ic_type,
+					      sizeof(self->static_ts.mask_project_ic_type));
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "IC type %s not supported",
+				    ic_type);
 			return FALSE;
 		}
 		memcpy(rev, &self->static_ts.mask_project_ic_type[4], 2);

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -752,7 +752,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 					      sizeof(self->static_ts.mask_project_ic_type));
 			g_set_error(error,
 				    FWUPD_ERROR,
-				    FWUPD_ERROR_INTERNAL,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "IC type %s not supported",
 				    ic_type);
 			return FALSE;

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -469,8 +469,10 @@ static gboolean
 fu_genesys_usbhub_device_probe(FuDevice *device, GError **error)
 {
 	/* FuUsbDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->probe(device, error))
+	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->probe(device, error)) {
+		g_prefix_error(error, "error probing device: ");
 		return FALSE;
+	}
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

The idea behind those changes is to prepare the genesys plugin for upgrading the genuine Genesys Logic Hubs products.

These products uses `USB\VID_05E3&PID_0610` which is not set in the quirk file yet; will be in a dedicated PR, once the support is fully functional.

The support for genuine Genesys Logic Hubs is splited into several PR. This one is the second of the serie.

In short, this PR:
 - Print the Genesys IC if it is not yet supported by the plugin.
 - Fails silently if the IC is not yet supported.