### PR TITLE
genesys: usbhub: support for gl3590 and other generic case with customized tool string info

### DIFF
--- a/plugins/genesys/README.md
+++ b/plugins/genesys/README.md
@@ -24,7 +24,13 @@ This plugin supports the following protocol IDs:
 
 These devices use the standard USB DeviceInstanceId values for the USB Hub, e.g.
 
+* `USB\VID_05E3&PID_0610`
 * HP USB-C Controller: `USB\VID_03F0&PID_0610`
+
+Additionally, some customized instance IDs are added. e.g.
+
+* `USB\VID_03F0&PID_0610&IC_352330&BONDING_0F`
+* `USB\VID_03F0&PID_0610&VENDOR_GENESYSLOGIC&IC_352330&BONDING_0F&PORTNUM_3233&VENDORSUP_C09B5DD3-1A23-51D2-995A-F7366AAB3CA4`
 * HP M24fd USB-C Controller: `USB\VID_03F0&PID_0610&PUBKEY_B335BDCE-7073-5D0E-9BD3-9B69C1A6899F`
 * HP M27fd USB-C Controller: `USB\VID_03F0&PID_0610&PUBKEY_847A3650-8648-586B-83C8-8B53714F37E3`
 
@@ -44,6 +50,12 @@ This plugin uses the following plugin-specific quirks:
 USB Hub has a MStar Semiconductor Scaler attached via I²C.
 
 Since 1.7.6.
+
+### has-public-key
+
+Device has a public-key appended to firmware.
+
+Since 1.7.7
 
 ### GenesysUsbhubSwitchRequest
 

--- a/plugins/genesys/fu-genesys-common.h
+++ b/plugins/genesys/fu-genesys-common.h
@@ -32,7 +32,7 @@ typedef struct {
 } FuGenesysChip;
 
 typedef struct __attribute__((packed)) {
-	guint8 tool_string_version; /* 0xff = not supported */
+	guint8 tool_string_version;
 
 	/* byte arrays are ASCII encoded and not NUL terminated */
 	guint8 mask_project_code[4];

--- a/plugins/genesys/fu-genesys-common.h
+++ b/plugins/genesys/fu-genesys-common.h
@@ -11,6 +11,26 @@ typedef struct {
 	guint8 expected_val;
 } FuGenesysWaitFlashRegisterHelper;
 
+typedef enum {
+	ISP_MODEL_UNKNOWN,
+
+	/* hub */
+	ISP_MODEL_HUB_GL3510,
+	ISP_MODEL_HUB_GL3521,
+	ISP_MODEL_HUB_GL3523,
+	ISP_MODEL_HUB_GL3590,
+	ISP_MODEL_HUB_GL7000,
+	ISP_MODEL_HUB_GL3525,
+
+	/* pd */
+	ISP_MODEL_PD_GL9510,
+} FuGenesysModel;
+
+typedef struct {
+	FuGenesysModel model;
+	gint32 revision;
+} FuGenesysChip;
+
 typedef struct __attribute__((packed)) {
 	guint8 tool_string_version; /* 0xff = not supported */
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -132,6 +132,11 @@ typedef struct __attribute__((packed)) {
 	guint8 update_fw_time[12]; /* YYYYMMDDhhmm */
 } FuGenesysFirmwareInfoToolString;
 
+typedef struct __attribute__((packed)) {
+	guint8 version[2];
+	guint8 supports[29];
+} FuGenesysVendorSupportToolString;
+
 typedef struct {
 	guint8 req_switch;
 	guint8 req_read;
@@ -143,6 +148,7 @@ struct _FuGenesysUsbhubDevice {
 	FuGenesysStaticToolString static_ts;
 	FuGenesysDynamicToolString dynamic_ts;
 	FuGenesysFirmwareInfoToolString fwinfo_ts;
+	FuGenesysVendorSupportToolString vs_ts;
 	FuGenesysVendorCommandSetting vcs;
 	FuGenesysChip chip;
 	guint32 running_bank;
@@ -763,6 +769,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autofree guint8 *buf = NULL;
+	g_autofree gchar *ic_type = NULL;
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->setup(device, error)) {
@@ -816,9 +823,8 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 	} else if (memcmp(self->static_ts.mask_project_ic_type, "3590", 4) == 0) {
 		self->chip.model = ISP_MODEL_HUB_GL3590;
 	} else {
-		g_autofree gchar *ic_type =
-		    fu_common_strsafe((const gchar *)&self->static_ts.mask_project_ic_type,
-				      sizeof(self->static_ts.mask_project_ic_type));
+		ic_type = fu_common_strsafe((const gchar *)&self->static_ts.mask_project_ic_type,
+					    sizeof(self->static_ts.mask_project_ic_type));
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
@@ -888,6 +894,20 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		if (vendor_buf == NULL) {
 			g_prefix_error(error, "failed to get vendor support info from device: ");
 			return FALSE;
+		}
+		if (!fu_genesys_usbhub_device_get_descriptor_data(
+			vendor_buf,
+			(guint8 *)&self->vs_ts,
+			sizeof(FuGenesysVendorSupportToolString),
+			error)) {
+			g_prefix_error(error, "failed to get vendor support info from device: ");
+			return FALSE;
+		}
+		if (g_getenv("FWUPD_GENESYS_USBHUB_VERBOSE") != NULL) {
+			fu_common_dump_raw(G_LOG_DOMAIN,
+					   "Vendor support",
+					   (guint8 *)&self->vs_ts,
+					   sizeof(FuGenesysVendorSupportToolString));
 		}
 	}
 
@@ -1056,6 +1076,37 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		fu_device_add_instance_strup(device, "PUBKEY", guid);
 	}
 
+	/* add specific product info */
+	ic_type = fu_common_strsafe((const gchar *)self->static_ts.mask_project_ic_type,
+				    sizeof(self->static_ts.mask_project_ic_type));
+	fu_device_add_instance_str(device, "IC", ic_type);
+	fu_device_add_instance_u8(device, "BONDING", self->bonding);
+
+	if (self->running_bank != BANK_MASK_CODE) {
+		const gchar *vendor = fwupd_device_get_vendor(FWUPD_DEVICE(device));
+		guint16 port_num =
+		    (self->dynamic_ts.ss_port_number << 8) + self->dynamic_ts.hs_port_number;
+		g_autofree gchar *guid = NULL;
+		guid = fwupd_guid_hash_data((const guint8 *)&self->vs_ts,
+					    sizeof(self->vs_ts),
+					    FWUPD_GUID_FLAG_NONE);
+		fu_device_add_instance_strup(device, "VENDOR", vendor);
+		fu_device_add_instance_u16(device, "PORTNUM", port_num);
+		fu_device_add_instance_strup(device, "VENDORSUP", guid);
+	}
+
+	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "IC", "BONDING", NULL);
+	fu_device_build_instance_id(device,
+				    NULL,
+				    "USB",
+				    "VID",
+				    "PID",
+				    "VENDOR",
+				    "IC",
+				    "BONDING",
+				    "PORTNUM",
+				    "VENDORSUP",
+				    NULL);
 	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "PUBKEY", NULL);
 
 	/* have MStar scaler */

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -71,21 +71,6 @@ typedef enum {
 	ISP_ENTER,
 } FuGenesysIspMode;
 
-typedef enum {
-	ISP_MODEL_UNKNOWN,
-
-	/* hub */
-	ISP_MODEL_HUB_GL3510,
-	ISP_MODEL_HUB_GL3521,
-	ISP_MODEL_HUB_GL3523,
-	ISP_MODEL_HUB_GL3590,
-	ISP_MODEL_HUB_GL7000,
-	ISP_MODEL_HUB_GL3525,
-
-	/* pd */
-	ISP_MODEL_PD_GL9510,
-} FuGenesysModel;
-
 typedef struct __attribute__((packed)) {
 	guint8 tool_version[6]; /* ISP tool defined by itself */
 	guint8 address_mode;
@@ -104,8 +89,7 @@ struct _FuGenesysUsbhubDevice {
 	FuGenesysStaticToolString static_ts;
 	FuGenesysFirmwareInfoToolString fwinfo_ts;
 	FuGenesysVendorCommandSetting vcs;
-	guint32 isp_model;
-	guint8 isp_revision;
+	FuGenesysChip chip;
 	guint32 flash_erase_delay;
 	guint32 flash_write_delay;
 	guint32 flash_block_size;
@@ -752,9 +736,9 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		gchar rev[3] = {0};
 
 		if (memcmp(self->static_ts.mask_project_ic_type, "3523", 4) == 0) {
-			self->isp_model = ISP_MODEL_HUB_GL3523;
+			self->chip.model = ISP_MODEL_HUB_GL3523;
 		} else if (memcmp(self->static_ts.mask_project_ic_type, "3590", 4) == 0) {
-			self->isp_model = ISP_MODEL_HUB_GL3590;
+			self->chip.model = ISP_MODEL_HUB_GL3590;
 		} else {
 			g_autofree gchar *ic_type =
 			    fu_common_strsafe((const gchar *)&self->static_ts.mask_project_ic_type,
@@ -767,7 +751,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 			return FALSE;
 		}
 		memcpy(rev, &self->static_ts.mask_project_ic_type[4], 2);
-		self->isp_revision = fu_common_strtoull(rev);
+		self->chip.revision = fu_common_strtoull(rev);
 	}
 
 	dynamic_buf =
@@ -835,12 +819,12 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		self->flash_sector_size = sector_size;
 
 	/* setup firmware parameters */
-	switch (self->isp_model) {
+	switch (self->chip.model) {
 	case ISP_MODEL_HUB_GL3523:
 		self->fw_bank_addr[0] = 0x0000;
 		self->fw_bank_addr[1] = 0x8000;
 		self->extend_size = GL3523_PUBLIC_KEY_LEN + GL3523_SIG_LEN;
-		if (self->isp_revision == 50) {
+		if (self->chip.revision == 50) {
 			self->fw_data_total_count = 0x8000;
 			if (!fu_genesys_usbhub_device_get_fw_size(self, 0, error))
 				return FALSE;
@@ -927,7 +911,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		}
 
 		self->read_first_bank =
-		    (self->isp_model == ISP_MODEL_HUB_GL3523) && self->fw_bank_vers[0] != 0;
+		    (self->chip.model == ISP_MODEL_HUB_GL3523) && self->fw_bank_vers[0] != 0;
 		self->write_recovery_bank = address == self->fw_bank_addr[1];
 	}
 

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -166,15 +166,6 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 			    error))
 		return FALSE;
 
-	/* unsupported static tool string */
-	if (self->static_ts.tool_string_version == 0xff) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "Static Tool String not supported");
-		return FALSE;
-	}
-
 	/* deduce code size */
 	switch (self->chip.model) {
 	case ISP_MODEL_HUB_GL3523: {

--- a/plugins/genesys/genesys.quirk
+++ b/plugins/genesys/genesys.quirk
@@ -1,3 +1,8 @@
+# Genesys Logic USB Hubs
+
+[USB\VID_05E3&PID_0610]
+Plugin = genesys
+
 # HP M2xfd
 
 # usbhub


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
---
- There are many bonding types of chip, and a firmware has built for customize request with specific chip. Therefore, we have to create a unique instance-id to avoid updating wrong firmware.
- There is a `bonding` byte in `FuGenesysDynamicToolString`, the byte also indicate current running bank.
- There has a unique public key for HP products; other products do not have a unique key to indicate products.
  - When running mask code bank, the characteristics only
    1.  **chip**, the value in `FuGenesysStaticToolString`, e.g. "352310", "359010".
    2.  **bonding**, the value in `FuGenesysDynamicToolString`, each bonding already defined supporting DFP number.
  - When running bank 1st/2nd, the firmware already customized, obviously characteristics are
    1. `VID`  / `PID` / `VENDOR` from USB descriptor. 'PRODUCT' already replaced by 'NAME', so it cannot be reference I guess.
    2.  **port number** for HS and SS, the values in `FuGenesysDynamicToolString`. Firmware can turn off hub's DFPs, so two products have the same bonding of chip may enable different number of DFPs.
    3.  **vendor supporting** for special function, the value in `FuGenesysVendorSupportToolString`.
    4. Other characteristics are in the firmware configuration, but they may changed due to requests or bug fix.
