### PR TITLE
Take a device inhibit when updating a device

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3075,6 +3075,7 @@ fu_engine_prepare(FuEngine *self, FwupdInstallFlags flags, const gchar *device_i
 
 	/* don't rely on a plugin clearing this */
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+	fu_device_inhibit(device, "update-in-progress", "An update is in progress");
 
 	if (!fu_engine_device_check_power(self, device, flags, error))
 		return FALSE;
@@ -3110,6 +3111,7 @@ fu_engine_cleanup(FuEngine *self, FwupdInstallFlags flags, const gchar *device_i
 		g_prefix_error(error, "failed to get device before update cleanup: ");
 		return FALSE;
 	}
+	fu_device_uninhibit(device, "update-in-progress");
 	str = fu_device_to_string(device);
 	g_debug("cleanup -> %s", str);
 	if (!fu_engine_device_cleanup(self, device, flags, error))

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1819,7 +1819,7 @@ fu_engine_history_func(gconstpointer user_data)
 			    "  Name:                 Test Device\n"
 			    "  Guid:                 12345678-1234-1234-1234-123456789012\n"
 			    "  Plugin:               test\n"
-			    "  Flags:                updatable|historical\n"
+			    "  Flags:                historical\n"
 			    "  Version:              1.2.2\n"
 			    "  Created:              2018-01-07\n"
 			    "  Modified:             2017-12-27\n"


### PR DESCRIPTION
This ensures that two different clients cannot update the same device,
as there's a window where we're waiting for the device to come back in
bootloader mode where we might accept a request from a different client.

As a side effect it also means we no longer store the UPDATABLE flag
in the history database -- which is fine as it's pretty useless anyway;
the device had to have been UPDATABLE to be updated in the first place.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
