### PR TITLE
modem-manager: Remove the cache item and use a shadow device instead

### DIFF
--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -34,30 +34,10 @@ fu_mm_device_get_port_mbim_ifnum(FuMmDevice *device);
 MMModemFirmwareUpdateMethod
 fu_mm_device_get_update_methods(FuMmDevice *device);
 
-/* support for udev-based devices */
-typedef struct {
-	gchar *inhibited_uid;
-	gchar *physical_id;
-	gchar *vendor;
-	gchar *name;
-	gchar *version;
-	GPtrArray *guids;
-	MMModemFirmwareUpdateMethod update_methods;
-	gchar *detach_fastboot_at;
-	gint port_at_ifnum;
-	gint port_qmi_ifnum;
-	gint port_mbim_ifnum;
-} FuPluginMmInhibitedDeviceInfo;
-
-FuPluginMmInhibitedDeviceInfo *
-fu_plugin_mm_inhibited_device_info_new(FuMmDevice *device);
-void
-fu_plugin_mm_inhibited_device_info_free(FuPluginMmInhibitedDeviceInfo *info);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuPluginMmInhibitedDeviceInfo,
-			      fu_plugin_mm_inhibited_device_info_free);
-
 FuMmDevice *
-fu_mm_device_udev_new(FuContext *ctx, MMManager *manager, FuPluginMmInhibitedDeviceInfo *info);
+fu_mm_shadow_device_new(FuMmDevice *device);
+FuMmDevice *
+fu_mm_device_udev_new(FuContext *ctx, MMManager *manager, FuMmDevice *shadow_device);
 void
 fu_mm_device_udev_add_port(FuMmDevice *device,
 			   const gchar *subsystem,


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/4394

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
