### PR TITLE
vli: Do not set the serial number

### DIFF
--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -720,6 +720,7 @@ fu_vli_device_init(FuVliDevice *self)
 	priv->spi_cmd_read_id_sz = 2;
 	priv->spi_auto_detect = TRUE;
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER);
 }
 
 static void


### PR DESCRIPTION
This is always set as '00000000000000000000001' and thus is unhelpful.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
