### PR TITLE
Show the device serial number and instance IDs by default

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -49,6 +49,9 @@ IgnorePower=false
 # Only support installing firmware signed with a trusted key
 OnlyTrusted=true
 
+# Show private data like device serial numbers and instance IDs to clients
+ShowDevicePrivate=true
+
 # A host best known configuration is used when using `fwupdmgr sync` which can
 # downgrade firmware to factory versions or upgrade firmware to a supported
 # config level. e.g. `vendor-factory-2021q1`

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -37,6 +37,7 @@ struct _FuConfig {
 	gboolean enumerate_all_devices;
 	gboolean ignore_power;
 	gboolean only_trusted;
+	gboolean show_device_private;
 };
 
 G_DEFINE_TYPE(FuConfig, fu_config, G_TYPE_OBJECT)
@@ -64,6 +65,7 @@ fu_config_reload(FuConfig *self, GError **error)
 	g_autoptr(GError) error_update_motd = NULL;
 	g_autoptr(GError) error_ignore_power = NULL;
 	g_autoptr(GError) error_only_trusted = NULL;
+	g_autoptr(GError) error_show_device_private = NULL;
 	g_autoptr(GError) error_enumerate_all = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
@@ -221,6 +223,17 @@ fu_config_reload(FuConfig *self, GError **error)
 	if (!self->only_trusted && error_only_trusted != NULL) {
 		g_debug("failed to read OnlyTrusted key: %s", error_only_trusted->message);
 		self->only_trusted = TRUE;
+	}
+
+	/* whether to show private device data, e.g. serial numbers */
+	self->show_device_private = g_key_file_get_boolean(keyfile,
+							   "fwupd",
+							   "ShowDevicePrivate",
+							   &error_show_device_private);
+	if (!self->show_device_private && error_show_device_private != NULL) {
+		g_debug("failed to read ShowDevicePrivate key: %s",
+			error_show_device_private->message);
+		self->show_device_private = TRUE;
 	}
 
 	/* fetch host best known configuration */
@@ -383,6 +396,13 @@ fu_config_get_only_trusted(FuConfig *self)
 {
 	g_return_val_if_fail(FU_IS_CONFIG(self), FALSE);
 	return self->only_trusted;
+}
+
+gboolean
+fu_config_get_show_device_private(FuConfig *self)
+{
+	g_return_val_if_fail(FU_IS_CONFIG(self), FALSE);
+	return self->show_device_private;
 }
 
 gboolean

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -42,5 +42,7 @@ gboolean
 fu_config_get_ignore_power(FuConfig *self);
 gboolean
 fu_config_get_only_trusted(FuConfig *self);
+gboolean
+fu_config_get_show_device_private(FuConfig *self);
 const gchar *
 fu_config_get_host_bkc(FuConfig *self);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5825,6 +5825,13 @@ fu_engine_get_only_trusted(FuEngine *self)
 	return fu_config_get_only_trusted(self->config);
 }
 
+gboolean
+fu_engine_get_show_device_private(FuEngine *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
+	return fu_config_get_show_device_private(self->config);
+}
+
 const gchar *
 fu_engine_get_host_product(FuEngine *self)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -60,6 +60,8 @@ gboolean
 fu_engine_get_tainted(FuEngine *self);
 gboolean
 fu_engine_get_only_trusted(FuEngine *self);
+gboolean
+fu_engine_get_show_device_private(FuEngine *self);
 const gchar *
 fu_engine_get_host_product(FuEngine *self);
 const gchar *

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -286,15 +286,17 @@ fu_main_device_array_to_variant(FuMainPrivate *priv,
 				GError **error)
 {
 	GVariantBuilder builder;
+	FwupdDeviceFlags flags = fu_engine_request_get_device_flags(request);
 
 	g_return_val_if_fail(devices->len > 0, NULL);
 	g_variant_builder_init(&builder, G_VARIANT_TYPE_ARRAY);
 
+	/* override when required */
+	if (fu_engine_get_show_device_private(priv->engine))
+		flags |= FWUPD_DEVICE_FLAG_TRUSTED;
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device = g_ptr_array_index(devices, i);
-		GVariant *tmp =
-		    fwupd_device_to_variant_full(FWUPD_DEVICE(device),
-						 fu_engine_request_get_device_flags(request));
+		GVariant *tmp = fwupd_device_to_variant_full(FWUPD_DEVICE(device), flags);
 		g_variant_builder_add_value(&builder, tmp);
 	}
 	return g_variant_new("(aa{sv})", &builder);


### PR DESCRIPTION
This is a feature that seems useful, but one that no vendor has actually
asked for. It's also of limited use for peripheral devices.

Showing the instance IDs by default is also going to make it much easier
to explain to hardware vendors where the GUIDs come from.

Fixes https://github.com/fwupd/fwupd/issues/4445

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
