### PR TITLE
Add HP Dev One quirk with no-ux-capsule flag

### DIFF
--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -33,3 +33,7 @@ Flags = no-coalesce
 # Dynabook (né Toshiba) X30, X40
 [28108d08-5027-42c2-a5b8-92d6ede9b97b]
 VersionFormat = bcd
+
+# HP Dev One
+[9f7962c7-7d0e-473d-8a01-c168912f1f14]
+Flags = no-ux-capsule


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

The firmware for the HP Dev One (upcoming Linux laptop) does not support a UX capsule.