### PR TITLE
Wip/gportay/genesys add cfi devices

### DIFF
--- a/data/cfi.quirk
+++ b/data/cfi.quirk
@@ -150,6 +150,16 @@ Vendor = GigaDevice
 Name = GD25Qxxx
 CfiDeviceCmdChipErase = 0xC7
 CfiDeviceCmdSectorErase = 0x20
+CfiDeviceCmdBlockErase = 0xd8
+CfiDeviceBlockSize = 0x10000
+CfiDeviceSectorSize = 0x1000
+CfiDevicePageSize = 0x100
+[CFI\FLASHID_C84012]
+Name = GD25Q20C
+FirmwareSizeMax = 0x40000
+[CFI\FLASHID_C84016]
+Name = GD25Q32C
+FirmwareSizeMax = 0x400000
 
 # Nantronics
 [CFI\FLASHID_D5]

--- a/data/cfi.quirk
+++ b/data/cfi.quirk
@@ -106,6 +106,18 @@ Vendor = PMC
 # Fudan
 [CFI\FLASHID_A1]
 Vendor = Fudan
+[CFI\FLASHID_A131]
+Name = FM25xxx
+CfiDeviceBlockSize = 0x10000
+CfiDeviceSectorSize = 0x1000
+CfiDevicePageSize = 0x100
+CfiDeviceCmdBlockErase = 0xd8
+[CFI\FLASHID_A13110]
+Name = FM25W04
+FirmwareSizeMax = 0x80000
+[CFI\FLASHID_A13111]
+Name = FM25F01
+FirmwareSizeMax = 0x20000
 
 # Hyundai
 [CFI\FLASHID_AD]

--- a/data/cfi.quirk
+++ b/data/cfi.quirk
@@ -138,6 +138,16 @@ Vendor = Macronix
 Name = MX25Lxxx/xxxC/xxxE
 CfiDeviceCmdChipErase = 0x60
 CfiDeviceCmdSectorErase = 0x20
+CfiDeviceCmdBlockErase = 0xd8
+CfiDeviceBlockSize = 0x10000
+CfiDeviceSectorSize = 0x1000
+CfiDevicePageSize = 0x100
+[CFI\FLASHID_C22012]
+Name = MX25V2033F
+FirmwareSizeMax = 0x40000
+[CFI\FLASHID_C22016]
+Name = MX25L3236F
+FirmwareSizeMax = 0x400000
 [CFI\FLASHID_C222]
 Name = MX25Lxxx1E
 CfiDeviceCmdChipErase = 0x60


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

This adds several CFI devices used by serveral Genesys Logic based hardwares.