### PR TITLE
genesys: usbhub: Fix typo

### DIFF
--- a/plugins/genesys/README.md
+++ b/plugins/genesys/README.md
@@ -56,7 +56,7 @@ Since 1.7.6.
 
 Device has a public-key appended to firmware.
 
-Since 1.7.7
+Since 1.8.0
 
 ### GenesysUsbhubSwitchRequest
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -30,7 +30,7 @@
  *
  * Device has a public-key appended to firmware.
  *
- * Since 1.7.7
+ * Since 1.8.0
  */
 #define FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY (1 << 1)
 


### PR DESCRIPTION
The private flag has-pubkey will be introduced with version 1.8.0.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

If I am not mistaken, those changes are not back-ported to branch 1.7.y (1.7.7); therefore, the that private is will be available starting by version 1.8.0.