### PR TITLE
Add the fwupd-efi version as a firmware requirement

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3132,6 +3132,10 @@ fu_util_version(FuUtilPrivate *priv, GError **error)
 	g_autoptr(GHashTable) metadata = NULL;
 	g_autofree gchar *str = NULL;
 
+	/* load engine */
+	if (!fu_util_start_engine(priv, FU_ENGINE_LOAD_FLAG_READONLY, error))
+		return FALSE;
+
 	/* get metadata */
 	metadata = fu_engine_get_report_metadata(priv->engine, error);
 	if (metadata == NULL)


### PR DESCRIPTION
If we rely on a fix in fwupd-efi, the firmware may want to depend on it.

Although we're adding a compile time version provide, normally the
fwupd-efi.pc file is actually shipped in the binary package.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
