### PR TITLE
Fix regression in 'fwupdtool install foo.cab'

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1244,8 +1244,14 @@ fu_util_install(FuUtilPrivate *priv, gchar **values, GError **error)
 			/* is this component valid for the device */
 			fu_release_set_device(release, device);
 			fu_release_set_request(release, priv->request);
-			if (!fu_release_load(release, component, NULL, priv->flags, error))
-				return FALSE;
+			if (!fu_release_load(release, component, NULL, priv->flags, &error_local)) {
+				g_debug("loading release failed on %s:%s failed: %s",
+					fu_device_get_id(device),
+					xb_node_query_text(component, "id", NULL),
+					error_local->message);
+				g_ptr_array_add(errors, g_steal_pointer(&error_local));
+				continue;
+			}
 			if (!fu_engine_check_requirements(priv->engine,
 							  release,
 							  priv->flags | FWUPD_INSTALL_FLAG_FORCE,


### PR DESCRIPTION
When using fwupdmgr install we pass all the possible devices and then
loop each one. If loading the requirement failed for a specific one
just continue to the next device rather than aborting too early.

Fixes https://github.com/fwupd/fwupd/issues/4509

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
