### PR TITLE
Feature: Clevo/Tuxedo me unlock

### DIFF
--- a/plugins/flashrom/README.md
+++ b/plugins/flashrom/README.md
@@ -2,7 +2,10 @@
 
 ## Introduction
 
-This plugin uses `flashrom` to update the system firmware.
+This plugin uses `libflashrom` to update the system firmware.  It can be used
+to update BIOS or ME regions of the flash.  Device for ME region is created
+only if "Intel SPI" plugin indicates that such a region exists, which makes
+"Intel SPI" a dependency of this plugin for doing ME updates.
 
 ## Firmware Format
 
@@ -44,6 +47,16 @@ Internal device uses hardware ID values which are derived from SMBIOS.
 
 They should match the values provided by `fwupdtool hwids` or the
 `ComputerHardwareIds.exe` Windows utility.
+
+One more GUID has the following form:
+
+* `FLASHROM\VENDOR_{manufacturer}&PRODUCT_{product}&REGION_{ifd_region_name}`
+
+Its purpose is to target specific regions of the flash as defined by IFD (Intel
+SPI Flash Descriptor), examples:
+
+* `FLASHROM\VENDOR_Notebook&PRODUCT_NS50MU&REGION_BIOS`
+* `FLASHROM\VENDOR_Notebook&PRODUCT_NS50MU&REGION_ME`
 
 ## Update Behavior
 

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -99,3 +99,15 @@ Plugin = flashrom
 [43455705-4c7d-5440-b285-8362b67a5743]
 Branch = dasharo
 VersionFormat = triplet
+
+# Tuxedo InifinityBook S14 Gen6 (HwId)
+[6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+Plugin = flashrom
+[FLASHROM\GUID_6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+Flags = fn-m-me-unlock
+
+# Tuxedo InifinityBook S15 Gen6 (HwId)
+[60f53465-e8fc-5122-b79b-f7b03f063037]
+Plugin = flashrom
+[FLASHROM\GUID_60f53465-e8fc-5122-b79b-f7b03f063037]
+Flags = fn-m-me-unlock

--- a/plugins/flashrom/fu-flashrom-device.h
+++ b/plugins/flashrom/fu-flashrom-device.h
@@ -17,3 +17,6 @@ fu_flashrom_device_new(FuContext *ctx, FuIfdRegion region);
 
 FuIfdRegion
 fu_flashrom_device_get_region(FuFlashromDevice *self);
+
+gboolean
+fu_flashrom_device_unlock(FuFlashromDevice *self, GError **error);

--- a/plugins/flashrom/fu-flashrom-device.h
+++ b/plugins/flashrom/fu-flashrom-device.h
@@ -12,8 +12,10 @@
 #define FU_TYPE_FLASHROM_DEVICE (fu_flashrom_device_get_type())
 G_DECLARE_FINAL_TYPE(FuFlashromDevice, fu_flashrom_device, FU, FLASHROM_DEVICE, FuUdevDevice)
 
+struct flashrom_flashctx;
+
 FuDevice *
-fu_flashrom_device_new(FuContext *ctx, FuIfdRegion region);
+fu_flashrom_device_new(FuContext *ctx, struct flashrom_flashctx *flashctx, FuIfdRegion region);
 
 FuIfdRegion
 fu_flashrom_device_get_region(FuFlashromDevice *self);

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -281,6 +281,12 @@ fu_plugin_flashrom_startup(FuPlugin *plugin, GError **error)
 	return TRUE;
 }
 
+static gboolean
+fu_plugin_flashrom_unlock(FuPlugin *self, FuDevice *device, GError **error)
+{
+	return fu_flashrom_device_unlock(FU_FLASHROM_DEVICE(device), error);
+}
+
 void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
@@ -290,4 +296,5 @@ fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 	vfuncs->device_registered = fu_plugin_flashrom_device_registered;
 	vfuncs->startup = fu_plugin_flashrom_startup;
 	vfuncs->coldplug = fu_plugin_flashrom_coldplug;
+	vfuncs->unlock = fu_plugin_flashrom_unlock;
 }

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -142,15 +142,31 @@ fu_plugin_flashrom_device_set_hwids(FuPlugin *plugin, FuDevice *device)
 	}
 }
 
-static gboolean
-fu_plugin_flashrom_coldplug(FuPlugin *plugin, GError **error)
+static FuDevice *
+fu_plugin_flashrom_add_device(FuPlugin *plugin, FuIfdRegion region, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	const gchar *dmi_vendor;
-	g_autoptr(FuDevice) device = fu_flashrom_device_new(ctx, FU_IFD_REGION_BIOS);
+	const gchar *product = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_PRODUCT_NAME);
+	const gchar *vendor = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_MANUFACTURER);
+	const gchar *region_str = fu_ifd_region_to_string(region);
+	g_autofree gchar *name = g_strdup_printf("%s (%s)", product, region_str);
+	g_autoptr(FuDevice) device = fu_flashrom_device_new(ctx, region);
 
-	fu_device_set_name(device, fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_PRODUCT_NAME));
-	fu_device_set_vendor(device, fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_MANUFACTURER));
+	fu_device_set_name(device, name);
+	fu_device_set_vendor(device, vendor);
+
+	fu_device_add_instance_str(device, "VENDOR", vendor);
+	fu_device_add_instance_str(device, "PRODUCT", product);
+	fu_device_add_instance_strup(device, "REGION", region_str);
+	if (!fu_device_build_instance_id(device,
+					 error,
+					 "FLASHROM",
+					 "VENDOR",
+					 "PRODUCT",
+					 "REGION",
+					 NULL))
+		return NULL;
 
 	/* use same VendorID logic as with UEFI */
 	dmi_vendor = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_BIOS_VENDOR);
@@ -162,17 +178,19 @@ fu_plugin_flashrom_coldplug(FuPlugin *plugin, GError **error)
 	fu_plugin_flashrom_device_set_hwids(plugin, device);
 	fu_plugin_flashrom_device_set_bios_info(plugin, device);
 	if (!fu_device_setup(device, error))
-		return FALSE;
+		return NULL;
 
 	/* success */
 	fu_plugin_device_add(plugin, device);
-	return TRUE;
+
+	g_object_ref(device);
+	return device;
 }
 
 static void
 fu_plugin_flashrom_device_registered(FuPlugin *plugin, FuDevice *device)
 {
-	GPtrArray *our_devices;
+	g_autoptr(FuDevice) me_device = NULL;
 	const gchar *me_region_str = fu_ifd_region_to_string(FU_IFD_REGION_ME);
 
 	/* we're only interested in a device from intel-spi plugin that corresponds to ME
@@ -182,16 +200,21 @@ fu_plugin_flashrom_device_registered(FuPlugin *plugin, FuDevice *device)
 	if (g_strcmp0(fu_device_get_logical_id(device), me_region_str) != 0)
 		return;
 
-	our_devices = fu_plugin_get_devices(plugin);
-	for (guint i = 0; i < our_devices->len; i++) {
-		FuFlashromDevice *our_device =
-		    FU_FLASHROM_DEVICE(g_ptr_array_index(our_devices, i));
-		if (fu_flashrom_device_get_region(our_device) == FU_IFD_REGION_ME) {
-			/* unlock operation requires device to be locked */
-			if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_LOCKED))
-				fu_device_add_flag(FU_DEVICE(our_device), FWUPD_DEVICE_FLAG_LOCKED);
-		}
-	}
+	me_device = fu_plugin_flashrom_add_device(plugin, FU_IFD_REGION_ME, NULL);
+	if (me_device == NULL)
+		return;
+
+	/* unlock operation requires device to be locked */
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_LOCKED))
+		fu_device_add_flag(me_device, FWUPD_DEVICE_FLAG_LOCKED);
+}
+
+static gboolean
+fu_plugin_flashrom_coldplug(FuPlugin *plugin, GError **error)
+{
+	g_autoptr(FuDevice) device =
+	    fu_plugin_flashrom_add_device(plugin, FU_IFD_REGION_BIOS, error);
+	return (device != NULL);
 }
 
 static gboolean


### PR DESCRIPTION
This is follow up on [Enabling support for ME unlock](https://groups.google.com/g/fwupd/c/e6yE6xy5Hjg) discussion on ML.

What it's needed in the end:
 1. Reading lock status from HSFS and sharing it for two use cases:
    1. State verification before unlocking.
    2. State verification before flashing ME firmware.
 2. Ability to unlock ME.
 3. Ability to flash ME firmware.

How it's done in this PR in its WIP state:
 1. Sharing ME lock status via `FuContext`.  Value is set by `intel-spi` plugin.  Consumed in `superio` and `flashrom`.
 2. Via `unlock` command for IT55 `superio` device, because unlocking is done through EC.
 3. Happens in `flashrom` plugin.  Device for ME firmware is added if ME region is unlocked.

Things to consider:
 1. What's the best way of presenting ME flashing to the user?  I guess ideally unlocking and flashing should be done for the same device. I saw that plugins can monitor created devices, but I think they can't invoke code from one another, so not sure how to implement all functionality in one place.
 2. `intel-spi` is re-used to not duplicate neither code nor quirks that are there and also because some kind of sharing would be necessary anyway.

ME device is incomplete at the moment, despite that the changes should capture the end goal relatively well. Please take a look to see if such changes are sane and if there are better ways of going about them.

P.S. First two commits are trivial changes for things I've noticed when going through the code and can be cherry-picked right away.