### PR TITLE
Automatically obsolete negative duplicate attributes

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3297,7 +3297,8 @@ fu_security_attrs_hsi_func(void)
 	g_autofree gchar *hsi6 = NULL;
 	g_autofree gchar *hsi7 = NULL;
 	g_autofree gchar *hsi8 = NULL;
-	g_autofree gchar *expected_hsi8 = NULL;
+	g_autofree gchar *hsi9 = NULL;
+	g_autofree gchar *expected_hsi9 = NULL;
 	g_autoptr(FuSecurityAttrs) attrs = NULL;
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
@@ -3327,6 +3328,18 @@ fu_security_attrs_hsi_func(void)
 	g_assert_cmpstr(hsi3, ==, "HSI:1");
 	g_clear_object(&attr);
 
+	/* add an implicit obsolete via duplication */
+	attr = fwupd_security_attr_new("org.fwupd.hsi.PRX");
+	fwupd_security_attr_set_plugin(attr, "other-plugin");
+	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
+	fwupd_security_attr_set_url(attr, "http://other-plugin");
+	fu_security_attrs_append(attrs, attr);
+	fu_security_attrs_depsolve(attrs);
+	hsi4 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
+	g_assert_cmpstr(hsi4, ==, "HSI:1");
+	g_assert_true(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_OBSOLETED));
+	g_clear_object(&attr);
+
 	/* add attr from HSI:3, obsoleting the failure */
 	attr = fwupd_security_attr_new("org.fwupd.hsi.BIOSGuard");
 	fwupd_security_attr_set_plugin(attr, "test");
@@ -3336,8 +3349,8 @@ fu_security_attrs_hsi_func(void)
 	fwupd_security_attr_set_url(attr, "http://test");
 	fu_security_attrs_append(attrs, attr);
 	fu_security_attrs_depsolve(attrs);
-	hsi4 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr(hsi4, ==, "HSI:3");
+	hsi5 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
+	g_assert_cmpstr(hsi5, ==, "HSI:3");
 	g_clear_object(&attr);
 
 	/* add taint that was fine */
@@ -3347,8 +3360,8 @@ fu_security_attrs_hsi_func(void)
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fwupd_security_attr_set_url(attr, "http://test");
 	fu_security_attrs_append(attrs, attr);
-	hsi5 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr(hsi5, ==, "HSI:3");
+	hsi6 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
+	g_assert_cmpstr(hsi6, ==, "HSI:3");
 	g_clear_object(&attr);
 
 	/* add updates and attestation */
@@ -3357,8 +3370,8 @@ fu_security_attrs_hsi_func(void)
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 	fwupd_security_attr_set_url(attr, "http://test");
 	fu_security_attrs_append(attrs, attr);
-	hsi6 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr(hsi6, ==, "HSI:3");
+	hsi7 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
+	g_assert_cmpstr(hsi7, ==, "HSI:3");
 	g_clear_object(&attr);
 
 	/* add issue that was uncool */
@@ -3367,8 +3380,8 @@ fu_security_attrs_hsi_func(void)
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fwupd_security_attr_set_url(attr, "http://test");
 	fu_security_attrs_append(attrs, attr);
-	hsi7 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
-	g_assert_cmpstr(hsi7, ==, "HSI:3!");
+	hsi8 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_NONE);
+	g_assert_cmpstr(hsi8, ==, "HSI:3!");
 	g_clear_object(&attr);
 
 	/* show version in the attribute */
@@ -3377,12 +3390,12 @@ fu_security_attrs_hsi_func(void)
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fwupd_security_attr_set_url(attr, "http://test");
 	fu_security_attrs_append(attrs, attr);
-	hsi8 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
-	expected_hsi8 = g_strdup_printf("HSI:3! (v%d.%d.%d)",
+	hsi9 = fu_security_attrs_calculate_hsi(attrs, FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
+	expected_hsi9 = g_strdup_printf("HSI:3! (v%d.%d.%d)",
 					FWUPD_MAJOR_VERSION,
 					FWUPD_MINOR_VERSION,
 					FWUPD_MICRO_VERSION);
-	g_assert_cmpstr(hsi8, ==, expected_hsi8);
+	g_assert_cmpstr(hsi9, ==, expected_hsi9);
 	g_clear_object(&attr);
 }
 static void


### PR DESCRIPTION
To a user there is no point to explicitly showing two failures for
encrypted RAM if the system supports SME and TSME both.

To show them a single failure, de-duplicate the attributes by appstream
ID during depsolve.

If the plugin didn't explicitly set obsoletes and two attributes are both
failures and both share the same appstream ID obsolete one of them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
