### PR TITLE
trivial: pci_psp: test an attribute to declare missing data

### DIFF
--- a/plugins/pci-psp/fu-plugin-pci-psp.c
+++ b/plugins/pci-psp/fu-plugin-pci-psp.c
@@ -250,15 +250,18 @@ fu_plugin_pci_psp_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuDevice *psp_device = fu_plugin_cache_lookup(plugin, "pci-psp-device");
 	const gchar *sysfs_path = NULL;
+	g_autofree gchar *test_file = NULL;
 
 	/* only AMD */
 	if (fu_common_get_cpu_vendor() != FU_CPU_VENDOR_AMD)
 		return;
 
 	/* ccp not loaded */
-	if (psp_device)
+	if (psp_device) {
 		sysfs_path = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(psp_device));
-	if (sysfs_path == NULL) {
+		test_file = g_build_filename(sysfs_path, "tsme_status", NULL);
+	}
+	if (sysfs_path == NULL || !g_file_test(test_file, G_FILE_TEST_EXISTS)) {
 		fu_plugin_pci_psp_set_missing_data(attrs);
 		return;
 	}


### PR DESCRIPTION
If the system loads ccp but the ccp driver doesn't export attributes
we should mark the CPU plugin as not supported.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
