### PR TITLE
Add support for a new TrustedUids key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ plugins/tpm-eventlog/tests/
 plugins/uefi-dbx/tests/
 .buildconfig
 .ossfuzz
+*.rej

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -52,6 +52,9 @@ OnlyTrusted=true
 # Show private data like device serial numbers and instance IDs to clients
 ShowDevicePrivate=true
 
+# UIDs that should marked as trusted
+TrustedUids=
+
 # A host best known configuration is used when using `fwupdmgr sync` which can
 # downgrade firmware to factory versions or upgrade firmware to a supported
 # config level. e.g. `vendor-factory-2021q1`

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -28,6 +28,8 @@ GPtrArray *
 fu_config_get_disabled_devices(FuConfig *self);
 GPtrArray *
 fu_config_get_disabled_plugins(FuConfig *self);
+GArray *
+fu_config_get_trusted_uids(FuConfig *self);
 GPtrArray *
 fu_config_get_approved_firmware(FuConfig *self);
 GPtrArray *

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5770,6 +5770,23 @@ fu_engine_add_plugin(FuEngine *self, FuPlugin *plugin)
 	fu_plugin_list_add(self->plugin_list, plugin);
 }
 
+gboolean
+fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid)
+{
+	GArray *trusted;
+
+	/* root is always trusted */
+	if (calling_uid == 0)
+		return TRUE;
+
+	trusted = fu_config_get_trusted_uids(self->config);
+	for (guint i = 0; i < trusted->len; i++) {
+		if (calling_uid == g_array_index(trusted, guint64, i))
+			return TRUE;
+	}
+	return FALSE;
+}
+
 static gboolean
 fu_engine_is_plugin_name_disabled(FuEngine *self, const gchar *name)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -68,6 +68,8 @@ const gchar *
 fu_engine_get_host_machine_id(FuEngine *self);
 const gchar *
 fu_engine_get_host_bkc(FuEngine *self);
+gboolean
+fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid);
 const gchar *
 fu_engine_get_host_security_id(FuEngine *self);
 FwupdStatus

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -284,7 +284,7 @@ fu_main_create_request(FuMainPrivate *priv, const gchar *sender, GError **error)
 		return NULL;
 	}
 	g_variant_get(value, "(u)", &calling_uid);
-	if (calling_uid == 0)
+	if (fu_engine_is_uid_trusted(priv->engine, calling_uid))
 		device_flags |= FWUPD_DEVICE_FLAG_TRUSTED;
 	fu_engine_request_set_device_flags(request, device_flags);
 


### PR DESCRIPTION
This key is used to specify that a dedicated user runs the fwupd
client process and sensitive strings such as the serial number should
be shared with the calling process.

(Fixes: #4524)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
