### PR TITLE
genesys: Fix a potential buffer overread spotted by Coverity

### DIFF
--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1505,7 +1505,7 @@ fu_genesys_scaler_device_get_firmware_packet_version(FuGenesysScalerDevice *self
 		guint8 checksum;
 		guint8 checksum_tmp = 0x0;
 
-		if (len >= sizeof(buf)) {
+		if (len > sizeof(buf) - 3) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,


### PR DESCRIPTION
overrun-buffer-arg: Overrunning array buf of 64 bytes by passing it to
a function which accesses it at byte offset 65 using argument len + 3UL

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
