### PR TITLE
Install D-Bus introspection data even if introspection is disabled

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -58,11 +58,9 @@ if bluez.allowed()
 endif
 
 if build_daemon
-if introspection.allowed()
-  install_data(['org.freedesktop.fwupd.xml'],
-    install_dir : join_paths(datadir, 'dbus-1', 'interfaces')
-  )
-endif
+install_data(['org.freedesktop.fwupd.xml'],
+  install_dir : join_paths(datadir, 'dbus-1', 'interfaces')
+)
 fwupdmgr = executable(
   'fwupdmgr',
   fu_hash,


### PR DESCRIPTION
According to the D-Bus API Design Guidelines, the D-Bus interface files
for public API should be installed so that other services can load them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
