### PR TITLE
Install D-Bus introspection data even if introspection is disabled

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,7 @@ if get_option('tests')
 subdir('tests')
 endif
 
-if build_daemon and get_option('introspection')
+if build_daemon
   install_data(['org.freedesktop.fwupd.xml'],
     install_dir : join_paths(datadir, 'dbus-1', 'interfaces')
   )


### PR DESCRIPTION
According to the D-Bus API Design Guidelines, the D-Bus interface files
for public API should be installed so that other services can load them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Related issue: https://github.com/fwupd/fwupd/issues/4551