### PR TITLE
Adjust handling of fwupd-refresh.service

### DIFF
--- a/contrib/debian/fwupd.postinst
+++ b/contrib/debian/fwupd.postinst
@@ -48,3 +48,10 @@ for dir in /var/cache/fwupdate /var/lib/fwupdate; do
 	        rmdir --ignore-fail-on-non-empty $dir || true
 	fi
 done
+
+#create a user for fwupd-refresh.service/fwupd-refresh.timer
+adduser --quiet --system --group --no-create-home --home /run/systemd \
+    --gecos "fwupd-refresh user" fwupd-refresh
+if [ -d /run/systemd/system ]; then
+    systemctl reload dbus || true
+fi

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -49,7 +49,7 @@ ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu && echo yes))
        CONFARGS += -Dplugin_logitech_bulkcontroller=disabled
 endif
 
-CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=disabled -Ddocs=gtkdoc -Dsupported_build=enabled -Dplugin_modem_manager=enabled
+CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=disabled -Ddocs=gtkdoc -Dsupported_build=enabled -Dplugin_modem_manager=enabled -Dsystemd_unit_user=fwupd-refresh
 
 %:
 	dh $@ --with gir
@@ -75,6 +75,9 @@ override_dh_install:
 	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-*/libfu_plugin_test_ble.so
 	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-*/libfu_plugin_invalid.so
 	rm -f debian/fwupd/etc/fwupd/remotes.d/fwupd-tests.conf
+
+	#enable fwupd-refresh.service by default (we have a dedicated user)
+	rm -f debian/fwupd/lib/systemd/system-preset/fwupd-refresh.preset
 
 override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism -Xfirmware-example.xml.gz

--- a/data/motd/fwupd-refresh.preset
+++ b/data/motd/fwupd-refresh.preset
@@ -1,1 +1,2 @@
 disable fwupd-refresh.service
+disable fwupd-refresh.timer

--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -7,7 +7,7 @@ After=network.target
 Type=oneshot
 CacheDirectory=fwupdmgr
 StandardError=null
-DynamicUser=yes
+@user@
 RestrictAddressFamilies=AF_NETLINK AF_UNIX AF_INET AF_INET6
 SystemCallFilter=~@mount
 ProtectKernelModules=yes

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -14,6 +14,17 @@ con2.set('bindir', bindir)
 con2.set('motd_fullpath', motd_fullpath)
 
 if libsystemd.found()
+  if get_option('systemd_unit_user') == ''
+      con2.set('user', 'DynamicUser=yes')
+  else
+      dynamic_options = [
+                         'ProtectSystem=strict',
+                         'ProtectHome=read-only',
+                         'User=' + get_option('systemd_unit_user')
+                        ]
+      con2.set('user','\n'.join(dynamic_options))
+  endif
+
   configure_file(
     input : 'fwupd-refresh.service.in',
     output : 'fwupd-refresh.service',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -53,6 +53,7 @@ option('plugin_powerd', type : 'feature', description : 'support for powerd', de
 option('qubes', type : 'boolean', value : false, description : 'build packages for Qubes OS')
 option('supported_build', type : 'feature', description: 'distribution package with upstream support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('systemd', type : 'feature', description : 'systemd support', deprecated: {'true': 'enabled', 'false': 'disabled'})
+option('systemd_unit_user', type : 'string', description : 'User account to use for fwupd-refresh.service (empty for DynamicUser)')
 option('systemd_root_prefix', type: 'string', value: '', description: 'Directory to base systemd’s installation directories on')
 option('elogind', type : 'feature', description : 'elogind support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('tests', type : 'boolean', value : true, description : 'enable tests')


### PR DESCRIPTION

This PR does a few things:
* Disable `fwupd-refresh.timer` by default as well.  I think we have too many circumstances this can lead to a failure to make it a default to enabled everywhere.  It should be enabled by packaging until when we have this sorted out.
* Add new configuration option to choose to set a static user by packaging
* Modifications to Debian packaging to create a user by default.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
