### PR TITLE
ccgx: fix wrong failure to replug

### DIFF
--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -631,22 +631,24 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 			if (!fu_ccgx_dmc_device_send_download_trigger(self,
 								      self->trigger_code,
 								      error)) {
-				if (manual_replug)
+				if (manual_replug) {
 					fu_device_remove_flag(device,
 							      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-				else
+				} else {
 					fu_device_remove_flag(device,
 							      FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+				}
 				g_prefix_error(error, "download trigger error: ");
 				return FALSE;
 			}
 		}
 	} else if (self->update_model == DMC_UPDATE_MODEL_PENDING_RESET) {
 		if (!fu_ccgx_dmc_device_send_sort_reset(self, manual_replug, error)) {
-			if (manual_replug)
+			if (manual_replug) {
 				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			else
+			} else {
 				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+			}
 			g_prefix_error(error, "soft reset error: ");
 			return FALSE;
 		}

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -631,14 +631,22 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 			if (!fu_ccgx_dmc_device_send_download_trigger(self,
 								      self->trigger_code,
 								      error)) {
-				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+				if (manual_replug)
+					fu_device_remove_flag(device,
+							      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+				else
+					fu_device_remove_flag(device,
+							      FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 				g_prefix_error(error, "download trigger error: ");
 				return FALSE;
 			}
 		}
 	} else if (self->update_model == DMC_UPDATE_MODEL_PENDING_RESET) {
 		if (!fu_ccgx_dmc_device_send_sort_reset(self, manual_replug, error)) {
-			fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+			if (manual_replug)
+				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+			else
+				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 			g_prefix_error(error, "soft reset error: ");
 			return FALSE;
 		}

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -616,8 +616,15 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 	if (fu_device_get_update_state(self) != FWUPD_UPDATE_STATE_SUCCESS)
 		return TRUE;
 
-	if (manual_replug == FALSE)
+	if (manual_replug) {
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+		fu_device_inhibit(device,
+				  "update-pending",
+				  "A pending update will be completed next time the device "
+				  "is unplugged from your computer");
+	} else {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	}
 
 	if (self->update_model == DMC_UPDATE_MODEL_DOWNLOAD_TRIGGER) {
 		if (self->trigger_code > 0) {
@@ -635,14 +642,6 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 			g_prefix_error(error, "soft reset error: ");
 			return FALSE;
 		}
-	}
-
-	if (manual_replug) {
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-		fu_device_inhibit(device,
-				  "update-pending",
-				  "A pending update will be completed next time the device "
-				  "is unplugged from your computer");
 	}
 
 	return TRUE;

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -631,10 +631,7 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 			if (!fu_ccgx_dmc_device_send_download_trigger(self,
 								      self->trigger_code,
 								      error)) {
-				if (manual_replug) {
-					fu_device_remove_flag(device,
-							      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-				} else {
+				if (manual_replug == FALSE) {
 					fu_device_remove_flag(device,
 							      FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 				}
@@ -644,9 +641,7 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 		}
 	} else if (self->update_model == DMC_UPDATE_MODEL_PENDING_RESET) {
 		if (!fu_ccgx_dmc_device_send_sort_reset(self, manual_replug, error)) {
-			if (manual_replug) {
-				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			} else {
+			if (manual_replug == FALSE) {
 				fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 			}
 			g_prefix_error(error, "soft reset error: ");


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation

Changes 
 1. Fix “failed to get device before update reload: ..." error happens sometimes when it waits for device replug.
  - Set "FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG" flag before sending a trigger code to the device.
  2. Fix  typo of function name.