### PR TITLE
Add plugin quirk keys earlier in the startup process

### DIFF
--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -34,6 +34,8 @@ GHashTable *
 fu_plugin_get_report_metadata(FuPlugin *self);
 gboolean
 fu_plugin_open(FuPlugin *self, const gchar *filename, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fu_plugin_runner_init(FuPlugin *self);
 gboolean
 fu_plugin_runner_startup(FuPlugin *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -368,8 +368,18 @@ typedef struct {
 	 * Since: 1.7.2
 	 **/
 	gboolean (*composite_cleanup)(FuPlugin *self, GPtrArray *devices, GError **error);
+	/**
+	 * load
+	 * @ctx: a #FuContext
+	 *
+	 * Function to register context attributes, run during early startup even on plugins which
+	 * will be later disabled.
+	 *
+	 * Since: 1.8.1
+	 **/
+	void (*load)(FuContext *ctx);
 	/*< private >*/
-	gpointer padding[9];
+	gpointer padding[8];
 } FuPluginVfuncs;
 
 /**

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -572,6 +572,7 @@ fu_quirks_init(FuQuirks *self)
 	fu_quirks_add_possible_key(self, FU_QUIRKS_ICON);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_INHIBIT);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_INSTALL_DURATION);
+	fu_quirks_add_possible_key(self, FU_QUIRKS_ISSUE);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_NAME);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_PARENT_GUID);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_PLUGIN);
@@ -587,6 +588,7 @@ fu_quirks_init(FuQuirks *self)
 	fu_quirks_add_possible_key(self, FU_QUIRKS_VENDOR_ID);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_VERSION);
 	fu_quirks_add_possible_key(self, FU_QUIRKS_VERSION_FORMAT);
+	fu_quirks_add_possible_key(self, "CfiDeviceCmdBlockErase");
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdReadId");
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdReadIdSz");
 	fu_quirks_add_possible_key(self, "CfiDeviceCmdChipErase");

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1037,6 +1037,7 @@ LIBFWUPDPLUGIN_1.8.0 {
 
 LIBFWUPDPLUGIN_1.8.1 {
   global:
+    fu_plugin_runner_init;
     fu_udev_device_ioctl_full;
   local: *;
 } LIBFWUPDPLUGIN_1.8.0;

--- a/plugins/ccgx/fu-plugin-ccgx.c
+++ b/plugins/ccgx/fu-plugin-ccgx.c
@@ -17,12 +17,16 @@
 static void
 fu_plugin_ccgx_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HPI_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_DMC_DEVICE);
+}
+
+static void
+fu_plugin_ccgx_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "CcgxFlashRowSize");
 	fu_context_add_quirk_key(ctx, "CcgxFlashSize");
 	fu_context_add_quirk_key(ctx, "CcgxImageKind");
@@ -33,5 +37,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_ccgx_load;
 	vfuncs->init = fu_plugin_ccgx_init;
 }

--- a/plugins/corsair/fu-plugin-corsair.c
+++ b/plugins/corsair/fu-plugin-corsair.c
@@ -13,8 +13,12 @@
 static void
 fu_plugin_corsair_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CORSAIR_DEVICE);
+}
+
+static void
+fu_plugin_corsair_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "CorsairDeviceKind");
 	fu_context_add_quirk_key(ctx, "CorsairVendorInterfaceId");
 }
@@ -23,5 +27,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_corsair_load;
 	vfuncs->init = fu_plugin_corsair_init;
 }

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -20,10 +20,8 @@
 #include "fu-dell-dock-common.h"
 
 static void
-fu_plugin_dell_dock_init(FuPlugin *plugin)
+fu_plugin_dell_dock_load(FuContext *ctx)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-
 	fu_context_add_quirk_key(ctx, "DellDockBlobBuildOffset");
 	fu_context_add_quirk_key(ctx, "DellDockBlobMajorOffset");
 	fu_context_add_quirk_key(ctx, "DellDockBlobMinorOffset");
@@ -33,7 +31,11 @@ fu_plugin_dell_dock_init(FuPlugin *plugin)
 	fu_context_add_quirk_key(ctx, "DellDockInstallDurationI2C");
 	fu_context_add_quirk_key(ctx, "DellDockUnlockTarget");
 	fu_context_add_quirk_key(ctx, "DellDockVersionLowest");
+}
 
+static void
+fu_plugin_dell_dock_init(FuPlugin *plugin)
+{
 	/* allow these to be built by quirks */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_DOCK_STATUS);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_DOCK_MST);
@@ -341,6 +343,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_dell_dock_load;
 	vfuncs->init = fu_plugin_dell_dock_init;
 	vfuncs->device_registered = fu_plugin_dell_dock_device_registered;
 	vfuncs->backend_device_added = fu_plugin_dell_dock_backend_device_added;

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -857,10 +857,8 @@ fu_plugin_dell_device_registered(FuPlugin *plugin, FuDevice *device)
 }
 
 static void
-fu_plugin_dell_init(FuPlugin *plugin)
+fu_plugin_dell_load(FuContext *ctx)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-	FuPluginData *data = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 	g_autofree gchar *tmp = NULL;
 
 	tmp = g_strdup_printf("%d.%d",
@@ -868,6 +866,12 @@ fu_plugin_dell_init(FuPlugin *plugin)
 			      smbios_get_library_version_minor());
 	fu_context_add_runtime_version(ctx, "com.dell.libsmbios", tmp);
 	g_debug("Using libsmbios %s", tmp);
+}
+
+static void
+fu_plugin_dell_init(FuPlugin *plugin)
+{
+	FuPluginData *data = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 
 	data->smi_obj = g_malloc0(sizeof(FuDellSmiObj));
 	if (g_getenv("FWUPD_DELL_VERBOSE") != NULL)
@@ -959,6 +963,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_dell_load;
 	vfuncs->init = fu_plugin_dell_init;
 	vfuncs->destroy = fu_plugin_dell_destroy;
 	vfuncs->startup = fu_plugin_dell_startup;

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -13,8 +13,12 @@
 static void
 fu_plugin_dfu_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DFU_DEVICE);
+}
+
+static void
+fu_plugin_dfu_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "DfuAltName");
 	fu_context_add_quirk_key(ctx, "DfuForceTimeout");
 	fu_context_add_quirk_key(ctx, "DfuForceVersion");
@@ -24,5 +28,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_dfu_load;
 	vfuncs->init = fu_plugin_dfu_init;
 }

--- a/plugins/elantp/fu-plugin-elantp.c
+++ b/plugins/elantp/fu-plugin-elantp.c
@@ -24,15 +24,19 @@ fu_plugin_elantp_device_created(FuPlugin *plugin, FuDevice *dev, GError **error)
 }
 
 static void
-fu_plugin_elantp_init(FuPlugin *plugin)
+fu_plugin_elantp_load(FuContext *ctx)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-	fu_plugin_add_udev_subsystem(plugin, "i2c-dev");
-	fu_plugin_add_udev_subsystem(plugin, "hidraw");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
 	fu_context_add_quirk_key(ctx, "ElantpI2cTargetAddress");
 	fu_context_add_quirk_key(ctx, "ElantpIapPassword");
 	fu_context_add_quirk_key(ctx, "ElantpIcPageCount");
+}
+
+static void
+fu_plugin_elantp_init(FuPlugin *plugin)
+{
+	fu_plugin_add_udev_subsystem(plugin, "i2c-dev");
+	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_I2C_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_HID_DEVICE);
 }
@@ -41,6 +45,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_elantp_load;
 	vfuncs->init = fu_plugin_elantp_init;
 	vfuncs->device_created = fu_plugin_elantp_device_created;
 }

--- a/plugins/fastboot/fu-plugin-fastboot.c
+++ b/plugins/fastboot/fu-plugin-fastboot.c
@@ -11,6 +11,13 @@
 #include "fu-fastboot-device.h"
 
 static void
+fu_plugin_fastboot_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "FastbootBlockSize");
+	fu_context_add_quirk_key(ctx, "FastbootOperationDelay");
+}
+
+static void
 fu_plugin_fastboot_init(FuPlugin *plugin)
 {
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FASTBOOT_DEVICE);
@@ -20,5 +27,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_fastboot_load;
 	vfuncs->init = fu_plugin_fastboot_init;
 }

--- a/plugins/genesys/fu-plugin-genesys.c
+++ b/plugins/genesys/fu-plugin-genesys.c
@@ -13,12 +13,19 @@
 #include "fu-genesys-usbhub-firmware.h"
 
 static void
-fu_plugin_genesys_init(FuPlugin *plugin)
+fu_plugin_genesys_load(FuContext *ctx)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "GenesysScalerGpioOutputRegister");
 	fu_context_add_quirk_key(ctx, "GenesysScalerGpioEnableRegister");
 	fu_context_add_quirk_key(ctx, "GenesysScalerGpioValue");
+	fu_context_add_quirk_key(ctx, "GenesysUsbhubReadRequest");
+	fu_context_add_quirk_key(ctx, "GenesysUsbhubSwitchRequest");
+	fu_context_add_quirk_key(ctx, "GenesysUsbhubWriteRequest");
+}
+
+static void
+fu_plugin_genesys_init(FuPlugin *plugin)
+{
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_USBHUB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_USBHUB_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_SCALER_FIRMWARE);
@@ -28,5 +35,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_genesys_load;
 	vfuncs->init = fu_plugin_genesys_init;
 }

--- a/plugins/gpio/fu-plugin-gpio.c
+++ b/plugins/gpio/fu-plugin-gpio.c
@@ -15,12 +15,16 @@ struct FuPluginData {
 };
 
 static void
+fu_plugin_gpio_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "GpioForUpdate");
+}
+
+static void
 fu_plugin_gpio_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuPluginData *data = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 	data->current_logical_ids = g_ptr_array_new_with_free_func(g_free);
-	fu_context_add_quirk_key(ctx, "GpioForUpdate");
 	fu_plugin_add_udev_subsystem(plugin, "gpio");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GPIO_DEVICE);
 }
@@ -164,6 +168,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_gpio_load;
 	vfuncs->init = fu_plugin_gpio_init;
 	vfuncs->destroy = fu_plugin_gpio_destroy;
 	vfuncs->prepare = fu_plugin_gpio_prepare;

--- a/plugins/intel-spi/fu-plugin-intel-spi.c
+++ b/plugins/intel-spi/fu-plugin-intel-spi.c
@@ -11,14 +11,18 @@
 #include "fu-intel-spi-device.h"
 
 static void
-fu_plugin_intel_spi_init(FuPlugin *plugin)
+fu_plugin_intel_spi_load(FuContext *ctx)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_context_add_quirk_key(ctx, "IntelSpiKind");
 	fu_context_add_quirk_key(ctx, "IntelSpiBar");
 	fu_context_add_quirk_key(ctx, "IntelSpiBarProxy");
 	fu_context_add_quirk_key(ctx, "IntelSpiBiosCntl");
+}
+
+static void
+fu_plugin_intel_spi_init(FuPlugin *plugin)
+{
+	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_SPI_DEVICE);
 }
 
@@ -39,6 +43,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_intel_spi_load;
 	vfuncs->init = fu_plugin_intel_spi_init;
 	vfuncs->startup = fu_plugin_intel_spi_startup;
 }

--- a/plugins/jabra/fu-plugin-jabra.c
+++ b/plugins/jabra/fu-plugin-jabra.c
@@ -13,8 +13,12 @@
 static void
 fu_plugin_jabra_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_DEVICE);
+}
+
+static void
+fu_plugin_jabra_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "JabraMagic");
 }
 
@@ -59,6 +63,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_jabra_load;
 	vfuncs->init = fu_plugin_jabra_init;
 	vfuncs->cleanup = fu_plugin_jabra_cleanup;
 }

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -32,7 +32,6 @@ fu_plugin_logitech_hidpp_startup(FuPlugin *plugin, GError **error)
 static void
 fu_plugin_logitech_hidpp_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "unifying");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UNIFYING_BOOTLOADER_NORDIC);
@@ -40,6 +39,11 @@ fu_plugin_logitech_hidpp_init(FuPlugin *plugin)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HIDPP_RUNTIME_UNIFYING);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HIDPP_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HIDPP_RUNTIME_BOLT);
+}
+
+static void
+fu_plugin_logitech_hidpp_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "LogitechHidppModelId");
 }
 
@@ -47,6 +51,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_logitech_hidpp_load;
 	vfuncs->init = fu_plugin_logitech_hidpp_init;
 	vfuncs->startup = fu_plugin_logitech_hidpp_startup;
 }

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -35,6 +35,12 @@ struct FuPluginData {
 };
 
 static void
+fu_plugin_mm_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "ModemManagerBranchAtCommand");
+}
+
+static void
 fu_plugin_mm_udev_device_removed(FuPlugin *plugin)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
@@ -534,6 +540,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_mm_load;
 	vfuncs->init = fu_plugin_mm_init;
 	vfuncs->destroy = fu_plugin_mm_destroy;
 	vfuncs->startup = fu_plugin_mm_startup;

--- a/plugins/nordic-hid/fu-plugin-nordic-hid.c
+++ b/plugins/nordic-hid/fu-plugin-nordic-hid.c
@@ -16,13 +16,16 @@
 static void
 fu_plugin_nordic_hid_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NORDIC_HID_CFG_CHANNEL);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_ARCHIVE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_FIRMWARE_B0);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT);
+}
+
+static void
+fu_plugin_nordic_hid_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "NordicHidBootloader");
 }
 
@@ -30,5 +33,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_nordic_hid_load;
 	vfuncs->init = fu_plugin_nordic_hid_init;
 }

--- a/plugins/parade-lspcon/fu-plugin-parade-lspcon.c
+++ b/plugins/parade-lspcon/fu-plugin-parade-lspcon.c
@@ -9,6 +9,12 @@
 #include "fu-parade-lspcon-device.h"
 
 static void
+fu_plugin_parade_lspcon_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "ParadeLspconAuxDeviceName");
+}
+
+static void
 fu_plugin_parade_lspcon_init(FuPlugin *plugin)
 {
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
@@ -19,5 +25,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_parade_lspcon_load;
 	vfuncs->init = fu_plugin_parade_lspcon_init;
 }

--- a/plugins/pci-bcr/fu-plugin-pci-bcr.c
+++ b/plugins/pci-bcr/fu-plugin-pci-bcr.c
@@ -19,12 +19,16 @@ struct FuPluginData {
 #define BCR_SMM_BWP (1 << 5)
 
 static void
+fu_plugin_pci_bcr_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "PciBcrAddr");
+}
+
+static void
 fu_plugin_pci_bcr_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuPluginData *priv = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 	fu_plugin_add_udev_subsystem(plugin, "pci");
-	fu_context_add_quirk_key(ctx, "PciBcrAddr");
 
 	/* this is true except for some Atoms */
 	priv->bcr_addr = 0xdc;
@@ -219,6 +223,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_pci_bcr_load;
 	vfuncs->init = fu_plugin_pci_bcr_init;
 	vfuncs->add_security_attrs = fu_plugin_pci_bcr_add_security_attrs;
 	vfuncs->device_registered = fu_plugin_pci_bcr_device_registered;

--- a/plugins/realtek-mst/fu-plugin-realtek-mst.c
+++ b/plugins/realtek-mst/fu-plugin-realtek-mst.c
@@ -9,12 +9,15 @@
 #include "fu-realtek-mst-device.h"
 
 static void
+fu_plugin_realtek_mst_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "RealtekMstDpAuxName");
+	fu_context_add_quirk_key(ctx, "RealtekMstDrmCardKernelName");
+}
+
+static void
 fu_plugin_realtek_mst_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
-
-	fu_context_add_quirk_key(ctx, "RealtekMstDpAuxName");
-
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_REALTEK_MST_DEVICE);
 }
@@ -23,5 +26,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_realtek_mst_load;
 	vfuncs->init = fu_plugin_realtek_mst_init;
 }

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -507,13 +507,18 @@ fu_plugin_redfish_cleanup(FuPlugin *self,
 }
 
 static void
+fu_plugin_redfish_load(FuContext *ctx)
+{
+	fu_context_add_quirk_key(ctx, "RedfishResetPreDelay");
+	fu_context_add_quirk_key(ctx, "RedfishResetPostDelay");
+}
+
+static void
 fu_plugin_redfish_init(FuPlugin *plugin)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuPluginData *data = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 	data->backend = fu_redfish_backend_new(ctx);
-	fu_context_add_quirk_key(ctx, "RedfishResetPreDelay");
-	fu_context_add_quirk_key(ctx, "RedfishResetPostDelay");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_REDFISH_SMBIOS);
 }
 
@@ -528,6 +533,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_redfish_load;
 	vfuncs->init = fu_plugin_redfish_init;
 	vfuncs->destroy = fu_plugin_redfish_destroy;
 	vfuncs->startup = fu_plugin_redfish_startup;

--- a/plugins/rts54hid/fu-plugin-rts54hid.c
+++ b/plugins/rts54hid/fu-plugin-rts54hid.c
@@ -14,9 +14,13 @@
 static void
 fu_plugin_rts54hid_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HID_MODULE);
+}
+
+static void
+fu_plugin_rts54hid_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "Rts54TargetAddr");
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
@@ -26,5 +30,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_rts54hid_load;
 	vfuncs->init = fu_plugin_rts54hid_init;
 }

--- a/plugins/rts54hub/fu-plugin-rts54hub.c
+++ b/plugins/rts54hub/fu-plugin-rts54hub.c
@@ -15,10 +15,14 @@
 static void
 fu_plugin_rts54hub_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_BACKGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_FOREGROUND);
+}
+
+static void
+fu_plugin_rts54hub_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "Rts54TargetAddr");
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
@@ -28,5 +32,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_rts54hub_load;
 	vfuncs->init = fu_plugin_rts54hub_init;
 }

--- a/plugins/steelseries/fu-plugin-steelseries.c
+++ b/plugins/steelseries/fu-plugin-steelseries.c
@@ -14,9 +14,13 @@
 static void
 fu_plugin_steelseries_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_STEELSERIES_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_STEELSERIES_GAMEPAD);
+}
+
+static void
+fu_plugin_steelseries_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "SteelSeriesDeviceKind");
 }
 
@@ -24,5 +28,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_steelseries_load;
 	vfuncs->init = fu_plugin_steelseries_init;
 }

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -77,11 +77,15 @@ fu_plugin_superio_coldplug_chipset(FuPlugin *plugin, const gchar *guid, GError *
 static void
 fu_plugin_superio_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EC_IT55_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SUPERIO_IT85_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SUPERIO_IT89_DEVICE);
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "linux_lockdown");
+}
+
+static void
+fu_plugin_superio_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "SuperioGType");
 	fu_context_add_quirk_key(ctx, "SuperioId");
 	fu_context_add_quirk_key(ctx, "SuperioPort");
@@ -118,6 +122,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_superio_load;
 	vfuncs->init = fu_plugin_superio_init;
 	vfuncs->coldplug = fu_plugin_superio_coldplug;
 }

--- a/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
+++ b/plugins/synaptics-cxaudio/fu-plugin-synaptics-cxaudio.c
@@ -14,9 +14,13 @@
 static void
 fu_plugin_synaptics_cxaudio_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
+}
+
+static void
+fu_plugin_synaptics_cxaudio_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "CxaudioChipIdBase");
 	fu_context_add_quirk_key(ctx, "CxaudioPatch1ValidAddr");
 	fu_context_add_quirk_key(ctx, "CxaudioPatch2ValidAddr");
@@ -27,5 +31,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_synaptics_cxaudio_load;
 	vfuncs->init = fu_plugin_synaptics_cxaudio_init;
 }

--- a/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
+++ b/plugins/synaptics-mst/fu-plugin-synaptics-mst.c
@@ -136,7 +136,6 @@ fu_plugin_synaptics_mst_write_firmware(FuPlugin *plugin,
 static void
 fu_plugin_synaptics_mst_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuPluginData *priv = fu_plugin_alloc_data(plugin, sizeof(FuPluginData));
 
 	/* devices added by this plugin */
@@ -145,6 +144,11 @@ fu_plugin_synaptics_mst_init(FuPlugin *plugin)
 	fu_plugin_add_udev_subsystem(plugin, "drm"); /* used for uevent only */
 	fu_plugin_add_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
+}
+
+static void
+fu_plugin_synaptics_mst_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "SynapticsMstDeviceKind");
 }
 
@@ -161,6 +165,7 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_synaptics_mst_load;
 	vfuncs->init = fu_plugin_synaptics_mst_init;
 	vfuncs->destroy = fu_plugin_synaptics_mst_destroy;
 	vfuncs->write_firmware = fu_plugin_synaptics_mst_write_firmware;

--- a/plugins/vli/fu-plugin-vli.c
+++ b/plugins/vli/fu-plugin-vli.c
@@ -16,11 +16,15 @@
 static void
 fu_plugin_vli_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_USBHUB_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_PD_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_PD_DEVICE);
+}
+
+static void
+fu_plugin_vli_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "VliDeviceKind");
 	fu_context_add_quirk_key(ctx, "VliSpiAutoDetect");
 }
@@ -29,5 +33,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_vli_load;
 	vfuncs->init = fu_plugin_vli_init;
 }

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -15,10 +15,14 @@
 static void
 fu_plugin_wacom_raw_init(FuPlugin *plugin)
 {
-	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_AES_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_EMR_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+}
+
+static void
+fu_plugin_wacom_raw_load(FuContext *ctx)
+{
 	fu_context_add_quirk_key(ctx, "WacomI2cFlashBlockSize");
 	fu_context_add_quirk_key(ctx, "WacomI2cFlashBaseAddr");
 	fu_context_add_quirk_key(ctx, "WacomI2cFlashSize");
@@ -28,5 +32,6 @@ void
 fu_plugin_init_vfuncs(FuPluginVfuncs *vfuncs)
 {
 	vfuncs->build_hash = FU_BUILD_HASH;
+	vfuncs->load = fu_plugin_wacom_raw_load;
 	vfuncs->init = fu_plugin_wacom_raw_init;
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7223,7 +7223,12 @@ static void
 fu_engine_finalize(GObject *obj)
 {
 	FuEngine *self = FU_ENGINE(obj);
+	GPtrArray *plugins = fu_plugin_list_get_all(self->plugin_list);
 
+	for (guint i = 0; i < plugins->len; i++) {
+		FuPlugin *plugin = g_ptr_array_index(plugins, i);
+		g_signal_handlers_disconnect_by_data(plugin, self);
+	}
 	for (guint i = 0; i < self->local_monitors->len; i++) {
 		GFileMonitor *monitor = g_ptr_array_index(self->local_monitors, i);
 		g_file_monitor_cancel(monitor);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -55,8 +55,6 @@ fu_engine_idle_reset(FuEngine *self);
 gboolean
 fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, GError **error);
 gboolean
-fu_engine_load_plugins(FuEngine *self, GError **error);
-gboolean
 fu_engine_get_tainted(FuEngine *self);
 gboolean
 fu_engine_get_only_trusted(FuEngine *self);

--- a/src/tests/daemon.conf
+++ b/src/tests/daemon.conf
@@ -1,1 +1,2 @@
-../../data/daemon.conf
+[fwupd]
+# nothing to see here


### PR DESCRIPTION
This allows creating the silo when starting the engine with custom
plugin keys such as WacomI2cFlashBaseAddr.

If we move the plugin initialization earlier then we don't get the
HwID matches, so we really do have to split this into a 4-stage startup,
e.g. ->class_init(), ->init(), ->startup() and ->coldplug().

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
