### PR TITLE
trivial: set up win32 build not to take GPG by default

### DIFF
--- a/data/pki/meson.build
+++ b/data/pki/meson.build
@@ -1,13 +1,13 @@
 # only install files that are going to be used
 if libjcat.type_name() != 'internal' and libjcat.version().version_compare('>= 0.1.9')
-  supported_gpg = libjcat.get_variable(pkgconfig : 'supported_gpg')
-  supported_pkcs7 = libjcat.get_variable(pkgconfig : 'supported_pkcs7')
+  supported_gpg = libjcat.get_variable(pkgconfig : 'supported_gpg') == '1'
+  supported_pkcs7 = libjcat.get_variable(pkgconfig : 'supported_pkcs7') == '1'
 else
-  supported_gpg = '1'
-  supported_pkcs7 = '1'
+  supported_gpg = host_machine.system() != 'windows'
+  supported_pkcs7 = true
 endif
 
-if supported_gpg == '1'
+if supported_gpg
 install_data([
     'GPG-KEY-Linux-Foundation-Firmware',
     'GPG-KEY-Linux-Vendor-Firmware-Service',
@@ -22,7 +22,7 @@ install_data([
 )
 endif
 
-if supported_pkcs7 == '1'
+if supported_pkcs7
 install_data([
     'LVFS-CA.pem',
   ],


### PR DESCRIPTION
Unfortunately you can't detect the meson option:
```
../data/pki/meson.build:4:4: ERROR: Having a colon in option name is forbidden, projects are not allowed to directly access options of other subprojects.
```
So hardcode in top level meson.build that Windows doesn't take GPG.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
