### PR TITLE
scsi: Rearchitect the plugin to match a block device

### DIFF
--- a/plugins/scsi/fu-plugin-scsi.c
+++ b/plugins/scsi/fu-plugin-scsi.c
@@ -13,7 +13,7 @@
 static void
 fu_plugin_scsi_init(FuPlugin *plugin)
 {
-	fu_plugin_add_udev_subsystem(plugin, "scsi");
+	fu_plugin_add_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SCSI_DEVICE);
 }
 

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -17,66 +17,56 @@ G_DEFINE_TYPE(FuScsiDevice, fu_scsi_device, FU_TYPE_UDEV_DEVICE)
 static gboolean
 fu_scsi_device_probe(FuDevice *device, GError **error)
 {
-	const gchar *name;
-	const gchar *vendor;
-	const gchar *version;
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	guint64 removable = 0;
 	g_autofree gchar *vendor_id = NULL;
-	g_autofree gchar *vendor_safe = NULL;
-	g_autoptr(GPtrArray) block_devs = NULL;
 
-	/* ignore */
-	if (g_strcmp0(fu_udev_device_get_devtype(FU_UDEV_DEVICE(device)), "scsi_target") == 0) {
+	/* check is valid */
+	if (g_strcmp0(g_udev_device_get_devtype(udev_device), "disk") != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "is not correct devtype=%s, expected disk",
+			    g_udev_device_get_devtype(udev_device));
+		return FALSE;
+	}
+	if (!g_udev_device_get_property_as_boolean(udev_device, "ID_SCSI")) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "targets are not supported");
+				    "has no ID_SCSI");
 		return FALSE;
 	}
 
-	/* vendor */
-	vendor = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "vendor", NULL);
-	if (vendor != NULL)
-		vendor_safe = fu_common_strstrip(vendor);
-	if (vendor_safe == NULL || g_strcmp0(vendor_safe, "ATA") == 0) {
+	/* vendor sanity */
+	if (g_strcmp0(fu_device_get_vendor(device), "ATA") == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no assigned vendor");
 		return FALSE;
 	}
-	fu_device_set_vendor(device, vendor);
-	vendor_id = g_strdup_printf("SCSI:%s", vendor_safe);
+	vendor_id = g_strdup_printf("SCSI:%s", fu_device_get_vendor(device));
 	fu_device_add_vendor_id(device, vendor_id);
 
-	/* name */
-	name = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "model", NULL);
-	fu_device_set_name(device, name);
-
-	/* version */
-	version = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "rev", NULL);
-	fu_device_set_version(device, version);
-
 	/* add GUIDs */
-	fu_device_add_instance_strsafe(device, "VEN", vendor);
-	fu_device_add_instance_strsafe(device, "DEV", name);
-	fu_device_add_instance_strsafe(device, "REV", version);
+	fu_device_add_instance_strsafe(device, "VEN", fu_device_get_vendor(device));
+	fu_device_add_instance_strsafe(device, "DEV", fu_device_get_name(device));
+	fu_device_add_instance_strsafe(device, "REV", fu_device_get_version(device));
 	if (!fu_device_build_instance_id_quirk(device, error, "SCSI", "VEN", NULL))
 		return FALSE;
 	if (!fu_device_build_instance_id(device, error, "SCSI", "VEN", "DEV", NULL))
 		return FALSE;
 	if (!fu_device_build_instance_id(device, error, "SCSI", "VEN", "DEV", "REV", NULL))
 		return FALSE;
-	/* check all block devices, although there should only be one */
-	block_devs = fu_udev_device_get_children_with_subsystem(FU_UDEV_DEVICE(device), "block");
-	for (guint i = 0; i < block_devs->len; i++) {
-		FuUdevDevice *block_dev = g_ptr_array_index(block_devs, i);
-		guint64 value = 0;
-		if (!fu_udev_device_get_sysfs_attr_uint64(block_dev, "removable", &value, NULL))
-			continue;
-		if (value == 0x0) {
+
+	/* is internal? */
+	if (fu_udev_device_get_sysfs_attr_uint64(FU_UDEV_DEVICE(device),
+						 "removable",
+						 &removable,
+						 NULL)) {
+		if (removable == 0x0)
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
-			break;
-		}
 	}
 
 	/* set the physical ID */

--- a/plugins/scsi/scsi.quirk
+++ b/plugins/scsi/scsi.quirk
@@ -1,4 +1,4 @@
-[SCSI]
+[BLOCK]
 Plugin = scsi
 
 [SCSI\VEN_LSI&DEV_VirtualSES]


### PR DESCRIPTION
This makes it match the eMMC and SATA plugins, and means we can more easily
walk up to the parent SCSI controller, rather than trying to find the correct
block child.

No functional changes, other than now we also read the disk serial number, and
use one less udev subsystem match.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
