### PR TITLE
colorhug: Never set a NULL version when the FW inface data is NULL

### DIFF
--- a/plugins/colorhug/colorhug.quirk
+++ b/plugins/colorhug/colorhug.quirk
@@ -8,6 +8,10 @@ FirmwareSizeMax = 0x8000
 CounterpartGuid = USB\VID_273F&PID_1001
 InstallDuration = 8
 
+# ColorHug1: first batch!
+[USB\VID_04D8&PID_F8DA]
+Guid = USB\VID_273F&PID_1000
+
 [USB\VID_273F&PID_1001]
 Plugin = colorhug
 Flags = self-recovery

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -371,8 +371,10 @@ fu_colorhug_device_setup(FuDevice *device, GError **error)
 		/* although guessing is a route to insanity, if the device has
 		 * provided the extra data it's because the BCD type was not
 		 * suitable -- and INTEL_ME is not relevant here */
-		fu_device_set_version_format(device, fu_common_version_guess_format(tmp));
-		fu_device_set_version(device, tmp);
+		if (tmp != NULL) {
+			fu_device_set_version_format(device, fu_common_version_guess_format(tmp));
+			fu_device_set_version(device, tmp);
+		}
 	}
 
 	/* get GUID from the descriptor if set */


### PR DESCRIPTION
This fixes updating from ColorHug(1) devices on old firmware versions,
but doesn't affect ColorHug2.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
