### PR TITLE
Do not install ca-bundle.crt on win32 as it's no longer required

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -129,15 +129,6 @@ find $MINGW32BINDIR \
 	--component-group "CG.fwupd-deps" | \
 	tee $build/contrib/fwupd-deps.wxs
 
-# CA bundle
-echo $CERTDIR/ca-bundle.crt | wixl-heat \
-	-p $CERTDIR/ \
-	--win64 \
-	--directory-ref BINDIR \
-	--var "var.CRTDIR" \
-	--component-group "CG.fwupd-certs" | \
-	tee "$build/contrib/fwupd-certs.wxs"
-
 # no static libraries
 find "$DESTDIR/" -type f -name "*.a" -print0 | xargs rm -f
 
@@ -162,7 +153,6 @@ mkdir -p "$DESTDIR/setup"
 wixl -v \
 	"$build/contrib/fwupd.wxs" \
 	"$build/contrib/fwupd-deps.wxs" \
-	"$build/contrib/fwupd-certs.wxs" \
 	"$build/contrib/fwupd-files.wxs" \
 	-D CRTDIR=$CERTDIR \
 	-D MINGW32BINDIR=$MINGW32BINDIR \

--- a/contrib/fwupd.wxs.in
+++ b/contrib/fwupd.wxs.in
@@ -29,7 +29,6 @@
     </Directory>
     <Feature Id="Complete"  Level="1">
       <ComponentGroupRef Id="CG.fwupd-deps"/>
-      <ComponentGroupRef Id="CG.fwupd-certs"/>
       <ComponentGroupRef Id="CG.fwupd-files"/>
     </Feature>
     <InstallExecuteSequence>


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
