### PR TITLE
Use exe_wrapper = '/usr/bin/wine' when cross-compiling

### DIFF
--- a/contrib/build-windows.sh
+++ b/contrib/build-windows.sh
@@ -14,6 +14,7 @@ fi
 # try to keep this and ../contrib/ci/build_windows.sh in sync as much as makes sense
 meson .. \
     --cross-file=/usr/share/mingw/toolchain-mingw64.meson \
+    --cross-file=../contrib/mingw64.cross \
     --prefix=/ \
     --sysconfdir="etc" \
     --libexecdir="bin" \

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -36,6 +36,7 @@ rm -rf $DESTDIR $build
 mkdir -p $build $DESTDIR && cd $build
 meson .. \
     --cross-file=/usr/share/mingw/toolchain-mingw64.meson \
+    --cross-file=../contrib/mingw64.cross \
     --prefix=/ \
     --sysconfdir="etc" \
     --libexecdir="bin" \

--- a/contrib/mingw64.cross
+++ b/contrib/mingw64.cross
@@ -1,0 +1,2 @@
+[binaries]
+exe_wrapper = '/usr/bin/wine'


### PR DESCRIPTION
This should probably move to /usr/share/mingw/toolchain-mingw64.meson
and this patch can be reverted when that happens.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
