### PR TITLE
Build a dummy event message file for Windows

### DIFF
--- a/contrib/mingw64.cross
+++ b/contrib/mingw64.cross
@@ -1,2 +1,3 @@
 [binaries]
 exe_wrapper = '/usr/bin/wine'
+windmc = '/usr/bin/x86_64-w64-mingw32-windmc'

--- a/src/fwupd-windows.mc
+++ b/src/fwupd-windows.mc
@@ -1,0 +1,11 @@
+MessageId=0x0
+SymbolicName=FWUPD_CATEGORY_GENERIC
+Language=English
+Generic Events
+.
+
+MessageId=0x100
+SymbolicName=FWUPD_MESSAGE_GENERIC
+Language=English
+No specific message -- see the EventData in the Details tab
+.

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,20 @@ if bluez.allowed()
   daemon_src += 'fu-bluez-backend.c'
 endif
 
+# include event message file
+if host_machine.system() == 'windows'
+  windmc = find_program('windmc')
+  fwupd_rc = custom_target('fwupd-rc',
+    input : 'fwupd-windows.mc',
+    output : 'fwupd-windows.rc',
+    command : [
+      windmc, '@INPUT@', '--rcdir', meson.current_build_dir(),
+    ],
+  )
+  windows = import('windows')
+  daemon_src += windows.compile_resources(fwupd_rc)
+endif
+
 if build_daemon
 install_data(['org.freedesktop.fwupd.xml'],
   install_dir : join_paths(datadir, 'dbus-1', 'interfaces')


### PR DESCRIPTION
This means we don't get the 'No description found, please repair'
message when viewing messages in the Windows Event Viewer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
