### PR TITLE
Allow clients to opt-in to showing updates with inhibits

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -608,6 +608,8 @@ fwupd_feature_flag_to_string(FwupdFeatureFlags feature_flag)
 		return "fde-warning";
 	if (feature_flag == FWUPD_FEATURE_FLAG_COMMUNITY_TEXT)
 		return "community-text";
+	if (feature_flag == FWUPD_FEATURE_FLAG_SHOW_PROBLEMS)
+		return "show-problems";
 	return NULL;
 }
 
@@ -640,6 +642,8 @@ fwupd_feature_flag_from_string(const gchar *feature_flag)
 		return FWUPD_FEATURE_FLAG_FDE_WARNING;
 	if (g_strcmp0(feature_flag, "community-text") == 0)
 		return FWUPD_FEATURE_FLAG_COMMUNITY_TEXT;
+	if (g_strcmp0(feature_flag, "show-problems") == 0)
+		return FWUPD_FEATURE_FLAG_SHOW_PROBLEMS;
 	return FWUPD_FEATURE_FLAG_LAST;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -74,6 +74,7 @@ typedef enum {
  * @FWUPD_FEATURE_FLAG_REQUESTS:		Can show interactive requests
  * @FWUPD_FEATURE_FLAG_FDE_WARNING:		Can warn about full disk encryption
  * @FWUPD_FEATURE_FLAG_COMMUNITY_TEXT:		Can show information about community supported
+ * @FWUPD_FEATURE_FLAG_SHOW_PROBLEMS:		Can show problems when getting the update list
  *
  * The flags to the feature capabilities of the front-end client.
  **/
@@ -86,6 +87,7 @@ typedef enum {
 	FWUPD_FEATURE_FLAG_REQUESTS = 1 << 4,	    /* Since: 1.6.2 */
 	FWUPD_FEATURE_FLAG_FDE_WARNING = 1 << 5,    /* Since: 1.7.1 */
 	FWUPD_FEATURE_FLAG_COMMUNITY_TEXT = 1 << 6, /* Since: 1.7.5 */
+	FWUPD_FEATURE_FLAG_SHOW_PROBLEMS = 1 << 7,  /* Since: 1.8.1 */
 	/*< private >*/
 	FWUPD_FEATURE_FLAG_LAST
 } FwupdFeatureFlags;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4853,7 +4853,8 @@ fu_engine_get_releases_for_device(FuEngine *self,
 	}
 
 	/* only show devices that can be updated */
-	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE) &&
+	if (!fu_engine_request_has_feature_flag(request, FWUPD_FEATURE_FLAG_SHOW_PROBLEMS) &&
+	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE) &&
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -262,6 +262,10 @@ fu_engine_watch_device(FuEngine *self, FuDevice *device)
 			 G_CALLBACK(fu_engine_generic_notify_cb),
 			 self);
 	g_signal_connect(FU_DEVICE(device),
+			 "notify::problems",
+			 G_CALLBACK(fu_engine_generic_notify_cb),
+			 self);
+	g_signal_connect(FU_DEVICE(device),
 			 "notify::update-message",
 			 G_CALLBACK(fu_engine_generic_notify_cb),
 			 self);

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -497,7 +497,8 @@ fu_release_check_requirements(FuRelease *self,
 	}
 
 	/* no update abilities */
-	if (!fu_device_has_flag(self->device, FWUPD_DEVICE_FLAG_UPDATABLE)) {
+	if (!fu_engine_request_has_feature_flag(self->request, FWUPD_FEATURE_FLAG_SHOW_PROBLEMS) &&
+	    !fu_device_has_flag(self->device, FWUPD_DEVICE_FLAG_UPDATABLE)) {
 		g_autoptr(GString) str = g_string_new(NULL);
 		g_string_append_printf(str,
 				       "Device %s [%s] does not currently allow updates",

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -614,7 +614,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GNode) root = g_node_new(NULL);
-	g_autoptr(GPtrArray) devices_inhibited = g_ptr_array_new();
 	g_autoptr(GPtrArray) devices_no_support = g_ptr_array_new();
 	g_autoptr(GPtrArray) devices_no_upgrades = g_ptr_array_new();
 
@@ -663,10 +662,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 			g_ptr_array_add(devices_no_support, dev);
 			continue;
 		}
-		if (fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN)) {
-			g_ptr_array_add(devices_inhibited, dev);
-			continue;
-		}
 
 		/* get the releases for this device and filter for validity */
 		rels = fu_engine_get_upgrades(priv->engine,
@@ -703,16 +698,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 		for (guint i = 0; i < devices_no_upgrades->len; i++) {
 			FwupdDevice *dev = g_ptr_array_index(devices_no_upgrades, i);
 			g_printerr(" • %s\n", fwupd_device_get_name(dev));
-		}
-	}
-	if (devices_inhibited->len > 0) {
-		/* TRANSLATORS: the device has a reason it can't update, e.g. laptop lid closed */
-		g_printerr("%s\n", _("Devices not currently updatable:"));
-		for (guint i = 0; i < devices_inhibited->len; i++) {
-			FwupdDevice *dev = g_ptr_array_index(devices_inhibited, i);
-			g_printerr(" • %s — %s\n",
-				   fwupd_device_get_name(dev),
-				   fwupd_device_get_update_error(dev));
 		}
 	}
 
@@ -3743,7 +3728,7 @@ main(int argc, char *argv[])
 		    priv->request,
 		    FWUPD_FEATURE_FLAG_DETACH_ACTION | FWUPD_FEATURE_FLAG_SWITCH_BRANCH |
 			FWUPD_FEATURE_FLAG_FDE_WARNING | FWUPD_FEATURE_FLAG_UPDATE_ACTION |
-			FWUPD_FEATURE_FLAG_COMMUNITY_TEXT);
+			FWUPD_FEATURE_FLAG_COMMUNITY_TEXT | FWUPD_FEATURE_FLAG_SHOW_PROBLEMS);
 	}
 	fu_progressbar_set_interactive(priv->progressbar, priv->interactive);
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1978,7 +1978,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) devices = NULL;
 	gboolean supported = FALSE;
 	g_autoptr(GNode) root = g_node_new(NULL);
-	g_autoptr(GPtrArray) devices_inhibited = g_ptr_array_new();
 	g_autoptr(GPtrArray) devices_no_support = g_ptr_array_new();
 	g_autoptr(GPtrArray) devices_no_upgrades = g_ptr_array_new();
 
@@ -2027,10 +2026,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		}
 		supported = TRUE;
-		if (fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN)) {
-			g_ptr_array_add(devices_inhibited, dev);
-			continue;
-		}
 
 		/* get the releases for this device and filter for validity */
 		rels = fwupd_client_get_upgrades(priv->client,
@@ -2068,16 +2063,6 @@ fu_util_get_updates(FuUtilPrivate *priv, gchar **values, GError **error)
 		for (guint i = 0; i < devices_no_upgrades->len; i++) {
 			FwupdDevice *dev = g_ptr_array_index(devices_no_upgrades, i);
 			g_printerr(" • %s\n", fwupd_device_get_name(dev));
-		}
-	}
-	if (devices_inhibited->len > 0) {
-		/* TRANSLATORS: the device has a reason it can't update, e.g. laptop lid closed */
-		g_printerr("%s\n", _("Devices not currently updatable:"));
-		for (guint i = 0; i < devices_inhibited->len; i++) {
-			FwupdDevice *dev = g_ptr_array_index(devices_inhibited, i);
-			g_printerr(" • %s — %s\n",
-				   fwupd_device_get_name(dev),
-				   fwupd_device_get_update_error(dev));
 		}
 	}
 
@@ -2312,6 +2297,20 @@ fu_util_update_device_with_release(FuUtilPrivate *priv,
 				   FwupdRelease *rel,
 				   GError **error)
 {
+	if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE)) {
+		const gchar *name = fwupd_device_get_name(dev);
+		g_autofree gchar *str = NULL;
+
+		/* TRANSLATORS: the device has a reason it can't update, e.g. laptop lid closed */
+		str = g_strdup_printf(_("%s is not currently updatable"), name);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOTHING_TO_DO,
+			    "%s: %s",
+			    str,
+			    fwupd_device_get_update_error(dev));
+		return FALSE;
+	}
 	if (!priv->no_safety_check && !priv->assume_yes) {
 		const gchar *title = fwupd_client_get_host_product(priv->client);
 		if (!fu_util_prompt_warning(dev, rel, title, error))
@@ -2407,7 +2406,8 @@ fu_util_update(FuUtilPrivate *priv, gchar **values, GError **error)
 		gboolean dev_skip_byid = TRUE;
 
 		/* not going to have results, so save a D-Bus round-trip */
-		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE))
+		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE) &&
+		    !fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN))
 			continue;
 		if (!fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_SUPPORTED)) {
 			if (!no_updates_header) {
@@ -4458,7 +4458,7 @@ main(int argc, char *argv[])
 			FWUPD_FEATURE_FLAG_CAN_REPORT | FWUPD_FEATURE_FLAG_SWITCH_BRANCH |
 			    FWUPD_FEATURE_FLAG_REQUESTS | FWUPD_FEATURE_FLAG_UPDATE_ACTION |
 			    FWUPD_FEATURE_FLAG_FDE_WARNING | FWUPD_FEATURE_FLAG_DETACH_ACTION |
-			    FWUPD_FEATURE_FLAG_COMMUNITY_TEXT,
+			    FWUPD_FEATURE_FLAG_COMMUNITY_TEXT | FWUPD_FEATURE_FLAG_SHOW_PROBLEMS,
 			priv->cancellable,
 			&error)) {
 			g_printerr("Failed to set front-end features: %s\n", error->message);


### PR DESCRIPTION
When typing 'fwupdmgr get-updates' show the updates that *could* be
installed if the inhibit was removed.

Do not unconditionally do this, as some clients such as gnome-software
assume that all updates returned by GetUpdates() are updatable with
Install() -- and in a GUI we only want to show the updates we can apply
*right now*. When the inhibit is removed (e.g. AC power is connected)
the GUI client will notify the user as required, unlike a CLI tool.

Fixes https://github.com/fwupd/fwupd/issues/4629

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
