### PR TITLE
Specify an enumerated kind when inhibiting devices

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5315,6 +5315,18 @@ fwupd_client_set_property(GObject *object, guint prop_id, const GValue *value, G
 	case PROP_BATTERY_THRESHOLD:
 		fwupd_client_set_battery_threshold(self, g_value_get_uint(value));
 		break;
+	case PROP_HOST_BKC:
+		fwupd_client_set_host_bkc(self, g_value_get_string(value));
+		break;
+	case PROP_HOST_PRODUCT:
+		fwupd_client_set_host_product(self, g_value_get_string(value));
+		break;
+	case PROP_HOST_MACHINE_ID:
+		fwupd_client_set_host_machine_id(self, g_value_get_string(value));
+		break;
+	case PROP_HOST_SECURITY_ID:
+		fwupd_client_set_host_security_id(self, g_value_get_string(value));
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -5543,7 +5555,7 @@ fwupd_client_class_init(FwupdClientClass *klass)
 				    NULL,
 				    NULL,
 				    NULL,
-				    G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_HOST_BKC, pspec);
 
 	/**
@@ -5571,7 +5583,7 @@ fwupd_client_class_init(FwupdClientClass *klass)
 				    NULL,
 				    NULL,
 				    NULL,
-				    G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_HOST_PRODUCT, pspec);
 
 	/**
@@ -5585,7 +5597,7 @@ fwupd_client_class_init(FwupdClientClass *klass)
 				    NULL,
 				    NULL,
 				    NULL,
-				    G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_HOST_MACHINE_ID, pspec);
 
 	/**
@@ -5599,7 +5611,7 @@ fwupd_client_class_init(FwupdClientClass *klass)
 				    NULL,
 				    NULL,
 				    NULL,
-				    G_PARAM_READABLE | G_PARAM_STATIC_NAME);
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_HOST_SECURITY_ID, pspec);
 
 	/**

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -136,6 +136,16 @@ fwupd_device_remove_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 gboolean
 fwupd_device_has_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 guint64
+fwupd_device_get_inhibit_kinds(FwupdDevice *self);
+void
+fwupd_device_set_inhibit_kinds(FwupdDevice *self, guint64 inhibit_kinds);
+void
+fwupd_device_add_inhibit_kind(FwupdDevice *self, FwupdDeviceInhibitKind inhibit_kind);
+void
+fwupd_device_remove_inhibit_kind(FwupdDevice *self, FwupdDeviceInhibitKind inhibit_kind);
+gboolean
+fwupd_device_has_inhibit_kind(FwupdDevice *self, FwupdDeviceInhibitKind inhibit_kind);
+guint64
 fwupd_device_get_created(FwupdDevice *self);
 void
 fwupd_device_set_created(FwupdDevice *self, guint64 created);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -363,6 +363,14 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_TRUST_FLAGS "TrustFlags"
 /**
+ * FWUPD_RESULT_KEY_INHIBIT_KINDS:
+ *
+ * Result key to represent inhibit kinds
+ *
+ * The D-Bus type signature string is 't' i.e. a unsigned 64 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_INHIBIT_KINDS "InhibitKinds"
+/**
  * FWUPD_RESULT_KEY_UPDATE_MESSAGE:
  *
  * Result key to represent UpdateMessage

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -328,6 +328,68 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 }
 
 /**
+ * fwupd_device_inhibit_kind_to_string:
+ * @device_inhibit_kind: a device inhibit kind, e.g. %FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW
+ *
+ * Converts a device inhibit kind to a string.
+ *
+ * Returns: identifier string
+ *
+ * Since: 1.8.1
+ **/
+const gchar *
+fwupd_device_inhibit_kind_to_string(FwupdDeviceInhibitKind device_inhibit_kind)
+{
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_NONE)
+		return "none";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW)
+		return "system-power-too-low";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE)
+		return "unreachable";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW)
+		return "power-too-low";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING)
+		return "update-pending";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER)
+		return "require-ac-power";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED)
+		return "lid-is-closed";
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN)
+		return "unknown";
+	return NULL;
+}
+
+/**
+ * fwupd_device_inhibit_kind_from_string:
+ * @device_inhibit_kind: (nullable): a string, e.g. `require-ac`
+ *
+ * Converts a string to a enumerated device inhibit kind.
+ *
+ * Returns: enumerated value
+ *
+ * Since: 1.8.1
+ **/
+FwupdDeviceInhibitKind
+fwupd_device_inhibit_kind_from_string(const gchar *device_inhibit_kind)
+{
+	if (g_strcmp0(device_inhibit_kind, "none") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_NONE;
+	if (g_strcmp0(device_inhibit_kind, "system-power-too-low") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW;
+	if (g_strcmp0(device_inhibit_kind, "unreachable") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE;
+	if (g_strcmp0(device_inhibit_kind, "power-too-low") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW;
+	if (g_strcmp0(device_inhibit_kind, "update-pending") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING;
+	if (g_strcmp0(device_inhibit_kind, "require-ac-power") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER;
+	if (g_strcmp0(device_inhibit_kind, "lid-is-closed") == 0)
+		return FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED;
+	return FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN;
+}
+
+/**
  * fwupd_plugin_flag_to_string:
  * @plugin_flag: plugin flags, e.g. %FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -540,6 +540,78 @@ typedef enum {
 typedef guint64 FwupdDeviceFlags;
 
 /**
+ * FWUPD_DEVICE_INHIBIT_KIND_NONE:
+ *
+ * No inhibits set
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_NONE (0u)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW:
+ *
+ * The system power is too low to perform the update.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW (1u << 0)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE:
+ *
+ * The device is unreachable, or out of wireless range.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE (1u << 1)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW:
+ *
+ * The device battery power is too low.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW (1u << 2)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING:
+ *
+ * The device is waiting for the update to be applied.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING (1u << 3)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER:
+ *
+ * The device requires AC power to be connected.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER (1u << 4)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED:
+ *
+ * The device cannot be used while the laptop lid is closed.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED (1u << 5)
+/**
+ * FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN:
+ *
+ * This inhibit is not defined, this typically will happen from mismatched
+ * fwupd library and clients.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN G_MAXUINT64
+/**
+ * FwupdDeviceInhibitKind:
+ *
+ * Inhibits are reasons why the device is not updatable.
+ */
+typedef guint64 FwupdDeviceInhibitKind;
+
+/**
  * FWUPD_RELEASE_FLAG_NONE:
  *
  * No flags are set.
@@ -931,6 +1003,10 @@ const gchar *
 fwupd_device_flag_to_string(FwupdDeviceFlags device_flag);
 FwupdDeviceFlags
 fwupd_device_flag_from_string(const gchar *device_flag);
+const gchar *
+fwupd_device_inhibit_kind_to_string(FwupdDeviceInhibitKind device_inhibit_kind);
+FwupdDeviceInhibitKind
+fwupd_device_inhibit_kind_from_string(const gchar *device_inhibit_kind);
 const gchar *
 fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag);
 FwupdPluginFlags

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -155,6 +155,12 @@ fwupd_enums_func(void)
 			break;
 		g_assert_cmpint(fwupd_device_flag_from_string(tmp), ==, i);
 	}
+	for (guint64 i = 1; i < FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN; i *= 2) {
+		const gchar *tmp = fwupd_device_inhibit_kind_to_string(i);
+		if (tmp == NULL)
+			break;
+		g_assert_cmpint(fwupd_device_inhibit_kind_from_string(tmp), ==, i);
+	}
 	for (guint64 i = 1; i < FWUPD_PLUGIN_FLAG_UNKNOWN; i *= 2) {
 		const gchar *tmp = fwupd_plugin_flag_to_string(i);
 		if (tmp == NULL)

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -767,9 +767,16 @@ LIBFWUPD_1.8.1 {
   global:
     fwupd_client_get_battery_level;
     fwupd_client_get_battery_threshold;
+    fwupd_device_add_inhibit_kind;
     fwupd_device_get_battery_level;
     fwupd_device_get_battery_threshold;
+    fwupd_device_get_inhibit_kinds;
+    fwupd_device_has_inhibit_kind;
+    fwupd_device_inhibit_kind_from_string;
+    fwupd_device_inhibit_kind_to_string;
+    fwupd_device_remove_inhibit_kind;
     fwupd_device_set_battery_level;
     fwupd_device_set_battery_threshold;
+    fwupd_device_set_inhibit_kinds;
   local: *;
 } LIBFWUPD_1.8.0;

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -83,6 +83,7 @@ typedef struct {
 } FuDeviceRetryRecovery;
 
 typedef struct {
+	FwupdDeviceInhibitKind inhibit_kind;
 	gchar *inhibit_id;
 	gchar *reason;
 } FuDeviceInhibit;
@@ -1262,7 +1263,10 @@ fu_device_add_child(FuDevice *self, FuDevice *child)
 		g_autoptr(GList) values = g_hash_table_get_values(priv->inhibits);
 		for (GList *l = values; l != NULL; l = l->next) {
 			FuDeviceInhibit *inhibit = (FuDeviceInhibit *)l->data;
-			fu_device_inhibit(child, inhibit->inhibit_id, inhibit->reason);
+			fu_device_inhibit_full(child,
+					       inhibit->inhibit_kind,
+					       inhibit->inhibit_id,
+					       inhibit->reason);
 		}
 	}
 
@@ -2635,6 +2639,7 @@ static void
 fu_device_ensure_inhibits(FuDevice *self)
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
+	FwupdDeviceInhibitKind inhibit_kinds = FWUPD_DEVICE_INHIBIT_KIND_NONE;
 	guint nr_inhibits = g_hash_table_size(priv->inhibits);
 
 	/* disable */
@@ -2658,6 +2663,7 @@ fu_device_ensure_inhibits(FuDevice *self)
 		for (GList *l = values; l != NULL; l = l->next) {
 			FuDeviceInhibit *inhibit = (FuDeviceInhibit *)l->data;
 			g_ptr_array_add(reasons, inhibit->reason);
+			inhibit_kinds |= inhibit->inhibit_kind;
 		}
 		reasons_str = fu_common_strjoin_array(", ", reasons);
 		fu_device_set_update_error(self, reasons_str);
@@ -2669,9 +2675,111 @@ fu_device_ensure_inhibits(FuDevice *self)
 		fu_device_set_update_error(self, NULL);
 	}
 
+	/* sync with baseclass */
+	fwupd_device_set_inhibit_kinds(FWUPD_DEVICE(self), inhibit_kinds);
+
 	/* enable */
 	if (priv->notify_flags_handler_id != 0)
 		g_signal_handler_unblock(self, priv->notify_flags_handler_id);
+}
+
+static gchar *
+fu_device_inhibit_kind_to_reason(FuDevice *self, guint64 device_inhibit_kind)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE)
+		return g_strdup("Device is unreachable, or out of wireless range");
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING)
+		return g_strdup("Device is waiting for the update to be applied");
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER)
+		return g_strdup("Device requires AC power to be connected");
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED)
+		return g_strdup("Device cannot be used while the lid is closed");
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW) {
+		if (priv->ctx == NULL)
+			return g_strdup("System power is too low to perform the update");
+		return g_strdup_printf(
+		    "System power is too low to perform the update (%u%%, requires %u%%)",
+		    fu_context_get_battery_level(priv->ctx),
+		    fu_context_get_battery_threshold(priv->ctx));
+	}
+	if (device_inhibit_kind == FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW) {
+		if (fu_device_get_battery_level(self) == FWUPD_BATTERY_LEVEL_INVALID ||
+		    fu_device_get_battery_threshold(self) == FWUPD_BATTERY_LEVEL_INVALID) {
+			return g_strdup_printf("Device battery power is too low");
+		}
+		return g_strdup_printf("Device battery power is too low (%u%%, requires %u%%)",
+				       fu_device_get_battery_level(self),
+				       fu_device_get_battery_threshold(self));
+	}
+	return NULL;
+}
+
+/**
+ * fu_device_inhibit_full:
+ * @self: a #FuDevice
+ * @inhibit_kind: a #FwupdDeviceInhibitKind, e.g. %FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW
+ * @inhibit_id: (nullable): an optional ID used for uninhibiting, e.g. `low-power`
+ * @reason: (nullable): a string, e.g. `Cannot update as foo [bar] needs reboot`
+ *
+ * Prevent the device from being updated, changing it from %FWUPD_DEVICE_FLAG_UPDATABLE
+ * to %FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN if not already inhibited.
+ *
+ * If the device already has an inhibit with the same @inhibit_id then the request
+ * is ignored.
+ *
+ * Since: 1.8.1
+ **/
+void
+fu_device_inhibit_full(FuDevice *self,
+		       FwupdDeviceInhibitKind inhibit_kind,
+		       const gchar *inhibit_id,
+		       const gchar *reason)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	FuDeviceInhibit *inhibit;
+
+	g_return_if_fail(FU_IS_DEVICE(self));
+
+	/* lazy create as most devices will not need this */
+	if (priv->inhibits == NULL) {
+		priv->inhibits = g_hash_table_new_full(g_str_hash,
+						       g_str_equal,
+						       NULL,
+						       (GDestroyNotify)fu_device_inhibit_free);
+	}
+
+	/* can fallback */
+	if (inhibit_id == NULL)
+		inhibit_id = fwupd_device_inhibit_kind_to_string(inhibit_kind);
+
+	/* already exists */
+	inhibit = g_hash_table_lookup(priv->inhibits, inhibit_id);
+	if (inhibit != NULL)
+		return;
+
+	/* create new */
+	inhibit = g_new0(FuDeviceInhibit, 1);
+	inhibit->inhibit_kind = inhibit_kind;
+	inhibit->inhibit_id = g_strdup(inhibit_id);
+	if (reason != NULL) {
+		inhibit->reason = g_strdup(reason);
+	} else {
+		inhibit->reason = fu_device_inhibit_kind_to_reason(self, inhibit_kind);
+	}
+	g_hash_table_insert(priv->inhibits, inhibit->inhibit_id, inhibit);
+
+	/* refresh */
+	fu_device_ensure_inhibits(self);
+
+	/* propagate to children */
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN)) {
+		GPtrArray *children = fu_device_get_children(self);
+		for (guint i = 0; i < children->len; i++) {
+			FuDevice *child = g_ptr_array_index(children, i);
+			fu_device_inhibit(child, inhibit_id, reason);
+		}
+	}
 }
 
 /**
@@ -2691,42 +2799,9 @@ fu_device_ensure_inhibits(FuDevice *self)
 void
 fu_device_inhibit(FuDevice *self, const gchar *inhibit_id, const gchar *reason)
 {
-	FuDevicePrivate *priv = GET_PRIVATE(self);
-	FuDeviceInhibit *inhibit;
-
 	g_return_if_fail(FU_IS_DEVICE(self));
 	g_return_if_fail(inhibit_id != NULL);
-
-	/* lazy create as most devices will not need this */
-	if (priv->inhibits == NULL) {
-		priv->inhibits = g_hash_table_new_full(g_str_hash,
-						       g_str_equal,
-						       NULL,
-						       (GDestroyNotify)fu_device_inhibit_free);
-	}
-
-	/* already exists */
-	inhibit = g_hash_table_lookup(priv->inhibits, inhibit_id);
-	if (inhibit != NULL)
-		return;
-
-	/* create new */
-	inhibit = g_new0(FuDeviceInhibit, 1);
-	inhibit->inhibit_id = g_strdup(inhibit_id);
-	inhibit->reason = g_strdup(reason);
-	g_hash_table_insert(priv->inhibits, inhibit->inhibit_id, inhibit);
-
-	/* refresh */
-	fu_device_ensure_inhibits(self);
-
-	/* propagate to children */
-	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_INHIBIT_CHILDREN)) {
-		GPtrArray *children = fu_device_get_children(self);
-		for (guint i = 0; i < children->len; i++) {
-			FuDevice *child = g_ptr_array_index(children, i);
-			fu_device_inhibit(child, inhibit_id, reason);
-		}
-	}
+	fu_device_inhibit_full(self, FWUPD_DEVICE_INHIBIT_KIND_NONE, inhibit_id, reason);
 }
 
 /**
@@ -2751,6 +2826,48 @@ fu_device_has_inhibit(FuDevice *self, const gchar *inhibit_id)
 	if (priv->inhibits == NULL)
 		return FALSE;
 	return g_hash_table_contains(priv->inhibits, inhibit_id);
+}
+
+/**
+ * fu_device_uninhibit_kind:
+ * @self: a #FuDevice
+ * @inhibit_kind: a #FwupdDeviceInhibitKind, e.g. %FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW
+ *
+ * Allow the device from being updated if there are no other inhibitors,
+ * changing it from %FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN to %FWUPD_DEVICE_FLAG_UPDATABLE.
+ *
+ * If the device already has no inhibit with the @inhibit_id then the request
+ * is ignored.
+ *
+ * Since: 1.8.1
+ **/
+void
+fu_device_uninhibit_kind(FuDevice *self, FwupdDeviceInhibitKind inhibit_kind)
+{
+	g_return_if_fail(FU_IS_DEVICE(self));
+	g_return_if_fail(inhibit_kind != FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN);
+	return fu_device_uninhibit(self, fwupd_device_inhibit_kind_to_string(inhibit_kind));
+}
+
+/**
+ * fu_device_inhibit_kind:
+ * @self: a #FuDevice
+ * @inhibit_kind: a #FwupdDeviceInhibitKind, e.g. %FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW
+ *
+ * Prevent the device from being updated, changing it from %FWUPD_DEVICE_FLAG_UPDATABLE
+ * to %FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN if not already inhibited.
+ *
+ * If the device already has an inhibit with the same @inhibit_kind then the request
+ * is ignored.
+ *
+ * Since: 1.8.1
+ **/
+void
+fu_device_inhibit_kind(FuDevice *self, FwupdDeviceInhibitKind inhibit_kind)
+{
+	g_return_if_fail(FU_IS_DEVICE(self));
+	g_return_if_fail(inhibit_kind != FWUPD_DEVICE_INHIBIT_KIND_UNKNOWN);
+	fu_device_inhibit_full(self, inhibit_kind, NULL, NULL);
 }
 
 /**
@@ -3101,8 +3218,9 @@ fu_device_add_flag(FuDevice *self, FwupdDeviceFlags flag)
 		fu_device_inhibit(self, "needs-activation", "Pending activation");
 
 	/* do not let devices be updated until back in range */
-	if (flag & FWUPD_DEVICE_FLAG_UNREACHABLE)
-		fu_device_inhibit(self, "unreachable", "Device is unreachable");
+	if (flag & FWUPD_DEVICE_FLAG_UNREACHABLE) {
+		fu_device_inhibit_kind(self, FWUPD_DEVICE_INHIBIT_KIND_UNREACHABLE);
+	}
 }
 
 typedef struct {
@@ -3336,10 +3454,10 @@ fu_device_ensure_battery_inhibit(FuDevice *self)
 {
 	if (fu_device_get_battery_level(self) == FWUPD_BATTERY_LEVEL_INVALID ||
 	    fu_device_get_battery_level(self) >= fu_device_get_battery_threshold(self)) {
-		fu_device_uninhibit(self, "battery");
+		fu_device_uninhibit_kind(self, FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW);
 		return;
 	}
-	fu_device_inhibit(self, "battery", "Battery level is too low");
+	fu_device_inhibit_kind(self, FWUPD_DEVICE_INHIBIT_KIND_POWER_TOO_LOW);
 }
 
 /**

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -534,7 +534,16 @@ fu_device_set_version_bootloader(FuDevice *self, const gchar *version);
 void
 fu_device_inhibit(FuDevice *self, const gchar *inhibit_id, const gchar *reason);
 void
+fu_device_inhibit_kind(FuDevice *self, FwupdDeviceInhibitKind inhibit_kind);
+void
+fu_device_inhibit_full(FuDevice *self,
+		       FwupdDeviceInhibitKind inhibit_kind,
+		       const gchar *inhibit_id,
+		       const gchar *reason);
+void
 fu_device_uninhibit(FuDevice *self, const gchar *inhibit_id);
+void
+fu_device_uninhibit_kind(FuDevice *self, FwupdDeviceInhibitKind inhibit_kind);
 gboolean
 fu_device_has_inhibit(FuDevice *self, const gchar *inhibit_id);
 const gchar *

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1037,7 +1037,10 @@ LIBFWUPDPLUGIN_1.8.0 {
 
 LIBFWUPDPLUGIN_1.8.1 {
   global:
+    fu_device_inhibit_kind;
+    fu_device_inhibit_full;
     fu_device_poll_locker_new;
+    fu_device_uninhibit_kind;
     fu_plugin_runner_init;
     fu_udev_device_ioctl_full;
   local: *;

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -618,10 +618,7 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 
 	if (manual_replug) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-		fu_device_inhibit(device,
-				  "update-pending",
-				  "A pending update will be completed next time the device "
-				  "is unplugged from your computer");
+		fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING);
 	} else {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	}

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -582,10 +582,7 @@ fu_dell_dock_ec_get_dock_data(FuDevice *device, GError **error)
 			fu_device_uninhibit(device, "update-pending");
 		} else {
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			fu_device_inhibit(device,
-					  "update-pending",
-					  "A pending update will be completed next time the dock "
-					  "is unplugged from your computer");
+			fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING);
 		}
 	} else {
 		fu_device_inhibit(device, "not-supported", "Utility does not support this board");

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -274,7 +274,7 @@ fu_scsi_device_write_firmware(FuDevice *device,
 	}
 
 	/* success! */
-	fu_device_inhibit(device, "needs-reboot", "Waiting for reboot to apply firmware");
+	fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_UPDATE_PENDING);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	return TRUE;
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -292,10 +292,9 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC) &&
 	    (fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_DISCHARGING ||
 	     fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_EMPTY)) {
-		fu_device_inhibit(device,
-				  "battery-system",
-				  "Cannot install update when not on AC power");
-		return;
+		fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER);
+	} else {
+		fu_device_uninhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_REQUIRE_AC_POWER);
 	}
 	if (fu_context_get_battery_level(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_threshold(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
@@ -304,10 +303,10 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 		reason = g_strdup_printf(
 		    "Cannot install update when system battery is not at least %u%%",
 		    fu_context_get_battery_threshold(self->ctx));
-		fu_device_inhibit(device, "battery-system", reason);
-		return;
+		fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW);
+	} else {
+		fu_device_uninhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_SYSTEM_POWER_TOO_LOW);
 	}
-	fu_device_uninhibit(device, "battery-system");
 }
 
 static void
@@ -315,12 +314,10 @@ fu_engine_ensure_device_lid_inhibit(FuEngine *self, FuDevice *device)
 {
 	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED) &&
 	    fu_context_get_lid_state(self->ctx) == FU_LID_STATE_CLOSED) {
-		fu_device_inhibit(device,
-				  "lid-closed-system",
-				  "Cannot install update when the lid is closed");
+		fu_device_inhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED);
 		return;
 	}
-	fu_device_uninhibit(device, "lid-closed-system");
+	fu_device_uninhibit_kind(device, FWUPD_DEVICE_INHIBIT_KIND_LID_IS_CLOSED);
 }
 
 static void

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -285,7 +285,14 @@ fu_util_start_engine(FuUtilPrivate *priv, FuEngineLoadFlags flags, GError **erro
 	fu_util_show_unsupported_warn();
 
 	/* copy properties from engine to client */
-	g_object_set(priv->client, "host-product", fu_engine_get_host_product(priv->engine), NULL);
+	g_object_set(priv->client,
+		     "host-product",
+		     fu_engine_get_host_product(priv->engine),
+		     "battery-level",
+		     fu_context_get_battery_level(fu_engine_get_context(priv->engine)),
+		     "battery-threshold",
+		     fu_context_get_battery_threshold(fu_engine_get_context(priv->engine)),
+		     NULL);
 
 	/* success */
 	return TRUE;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1961,7 +1961,8 @@ fu_util_self_sign(FuUtilPrivate *priv, gchar **values, GError **error)
 static void
 fu_util_device_added_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
 {
-	g_autofree gchar *tmp = fu_util_device_to_string(device, 0);
+	FuUtilPrivate *priv = (FuUtilPrivate *)user_data;
+	g_autofree gchar *tmp = fu_util_device_to_string(priv->client, device, 0);
 	/* TRANSLATORS: this is when a device is hotplugged */
 	g_print("%s\n%s", _("Device added:"), tmp);
 }
@@ -1969,7 +1970,8 @@ fu_util_device_added_cb(FwupdClient *client, FwupdDevice *device, gpointer user_
 static void
 fu_util_device_removed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
 {
-	g_autofree gchar *tmp = fu_util_device_to_string(device, 0);
+	FuUtilPrivate *priv = (FuUtilPrivate *)user_data;
+	g_autofree gchar *tmp = fu_util_device_to_string(priv->client, device, 0);
 	/* TRANSLATORS: this is when a device is hotplugged */
 	g_print("%s\n%s", _("Device removed:"), tmp);
 }
@@ -1977,7 +1979,8 @@ fu_util_device_removed_cb(FwupdClient *client, FwupdDevice *device, gpointer use
 static void
 fu_util_device_changed_cb(FwupdClient *client, FwupdDevice *device, gpointer user_data)
 {
-	g_autofree gchar *tmp = fu_util_device_to_string(device, 0);
+	FuUtilPrivate *priv = (FuUtilPrivate *)user_data;
+	g_autofree gchar *tmp = fu_util_device_to_string(priv->client, device, 0);
 	/* TRANSLATORS: this is when a device has been updated */
 	g_print("%s\n%s", _("Device changed:"), tmp);
 }

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -168,6 +168,7 @@ fu_util_prompt_for_boolean(gboolean def)
 static gboolean
 fu_util_traverse_tree(GNode *n, gpointer data)
 {
+	FwupdClient *client = FWUPD_CLIENT(data);
 	guint idx = g_node_depth(n) - 1;
 	g_autofree gchar *tmp = NULL;
 	g_auto(GStrv) split = NULL;
@@ -187,7 +188,7 @@ fu_util_traverse_tree(GNode *n, gpointer data)
 
 	/* root node */
 	if (n->data == NULL && g_getenv("FWUPD_VERBOSE") == NULL) {
-		const gchar *str = data;
+		const gchar *str = fwupd_client_get_host_product(client);
 		g_print("%s\n│\n", str != NULL ? str : "○");
 		return FALSE;
 	}
@@ -239,9 +240,9 @@ fu_util_traverse_tree(GNode *n, gpointer data)
 }
 
 void
-fu_util_print_tree(GNode *n, gpointer data)
+fu_util_print_tree(FwupdClient *client, GNode *n)
 {
-	g_node_traverse(n, G_PRE_ORDER, G_TRAVERSE_ALL, -1, fu_util_traverse_tree, data);
+	g_node_traverse(n, G_PRE_ORDER, G_TRAVERSE_ALL, -1, fu_util_traverse_tree, client);
 }
 
 static gboolean

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -176,7 +176,7 @@ fu_util_traverse_tree(GNode *n, gpointer data)
 	/* get split lines */
 	if (FWUPD_IS_DEVICE(n->data)) {
 		FwupdDevice *dev = FWUPD_DEVICE(n->data);
-		tmp = fu_util_device_to_string(dev, idx);
+		tmp = fu_util_device_to_string(client, dev, idx);
 	} else if (FWUPD_IS_REMOTE(n->data)) {
 		FwupdRemote *remote = FWUPD_REMOTE(n->data);
 		tmp = fu_util_remote_to_string(remote, idx);
@@ -1305,7 +1305,7 @@ fu_util_update_state_to_string(FwupdUpdateState update_state)
 }
 
 gchar *
-fu_util_device_to_string(FwupdDevice *dev, guint idt)
+fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 {
 	FwupdUpdateState state;
 	GPtrArray *guids = fwupd_device_get_guids(dev);

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -53,7 +53,7 @@ gboolean
 fu_util_prompt_for_boolean(gboolean def);
 
 void
-fu_util_print_tree(GNode *n, gpointer data);
+fu_util_print_tree(FwupdClient *client, GNode *n);
 gboolean
 fu_util_is_interesting_device(FwupdDevice *dev);
 gchar *

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -112,7 +112,7 @@ gchar *
 fu_util_time_to_str(guint64 tmp);
 
 gchar *
-fu_util_device_to_string(FwupdDevice *dev, guint idt);
+fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt);
 gchar *
 fu_util_plugin_to_string(FwupdPlugin *plugin, guint idt);
 const gchar *

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1753,7 +1753,7 @@ fu_util_get_results(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	if (priv->as_json)
 		return fu_util_get_results_as_json(priv, rel, error);
-	tmp = fu_util_device_to_string(rel, 0);
+	tmp = fu_util_device_to_string(priv->client, rel, 0);
 	g_print("%s", tmp);
 	return TRUE;
 }


### PR DESCRIPTION
This allows us to make smarter policy decisions in the future on when
to show unavailable updates.

Only inhibits the user can "fix" are enumerated. For example, opening
the laptop lid, or charging the device battery.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
