### PR TITLE
Move the battery attributes down into libfwupd

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -26,7 +26,7 @@
 #include "fwupd-common-private.h"
 #include "fwupd-deprecated.h"
 #include "fwupd-device-private.h"
-#include "fwupd-enums.h"
+#include "fwupd-enums-private.h"
 #include "fwupd-error.h"
 #include "fwupd-plugin-private.h"
 #include "fwupd-release-private.h"
@@ -58,6 +58,8 @@ typedef struct {
 	gboolean tainted;
 	gboolean interactive;
 	guint percentage;
+	guint32 battery_level;
+	guint32 battery_threshold;
 	GMutex idle_mutex; /* for @idle_id and @idle_sources */
 	guint idle_id;
 	GPtrArray *idle_sources; /* element-type FwupdClientContextHelper */
@@ -110,6 +112,8 @@ enum {
 	PROP_HOST_BKC,
 	PROP_INTERACTIVE,
 	PROP_ONLY_TRUSTED,
+	PROP_BATTERY_LEVEL,
+	PROP_BATTERY_THRESHOLD,
 	PROP_LAST
 };
 
@@ -356,6 +360,26 @@ fwupd_client_set_percentage(FwupdClient *self, guint percentage)
 }
 
 static void
+fwupd_client_set_battery_level(FwupdClient *self, guint32 battery_level)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	if (priv->battery_level == battery_level)
+		return;
+	priv->battery_level = battery_level;
+	g_object_notify(G_OBJECT(self), "battery-level");
+}
+
+static void
+fwupd_client_set_battery_threshold(FwupdClient *self, guint32 battery_threshold)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	if (priv->battery_threshold == battery_threshold)
+		return;
+	priv->battery_threshold = battery_threshold;
+	g_object_notify(G_OBJECT(self), "battery-threshold");
+}
+
+static void
 fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 				   GVariant *changed_properties,
 				   const GStrv invalidated_properties,
@@ -393,6 +417,18 @@ fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 		val = g_dbus_proxy_get_cached_property(proxy, "Percentage");
 		if (val != NULL)
 			fwupd_client_set_percentage(self, g_variant_get_uint32(val));
+	}
+	if (g_variant_dict_contains(dict, FWUPD_RESULT_KEY_BATTERY_LEVEL)) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property(proxy, FWUPD_RESULT_KEY_BATTERY_LEVEL);
+		if (val != NULL)
+			fwupd_client_set_battery_level(self, g_variant_get_uint32(val));
+	}
+	if (g_variant_dict_contains(dict, FWUPD_RESULT_KEY_BATTERY_THRESHOLD)) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property(proxy, FWUPD_RESULT_KEY_BATTERY_THRESHOLD);
+		if (val != NULL)
+			fwupd_client_set_battery_threshold(self, g_variant_get_uint32(val));
 	}
 	if (g_variant_dict_contains(dict, "DaemonVersion")) {
 		g_autoptr(GVariant) val = NULL;
@@ -3317,6 +3353,43 @@ fwupd_client_get_host_security_id(FwupdClient *self)
 }
 
 /**
+ * fwupd_client_get_battery_level:
+ * @self: a #FwupdClient
+ *
+ * Returns the system battery level.
+ *
+ * Returns: value in percent
+ *
+ * Since: 1.8.1
+ **/
+guint32
+fwupd_client_get_battery_level(FwupdClient *self)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FWUPD_BATTERY_LEVEL_INVALID);
+	return priv->battery_level;
+}
+
+/**
+ * fwupd_client_get_battery_threshold:
+ * @self: a #FwupdClient
+ *
+ * Returns the system battery threshold under which a firmware update cannot be
+ * performed.
+ *
+ * Returns: value in percent
+ *
+ * Since: 1.8.1
+ **/
+guint32
+fwupd_client_get_battery_threshold(FwupdClient *self)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FWUPD_BATTERY_LEVEL_INVALID);
+	return priv->battery_threshold;
+}
+
+/**
  * fwupd_client_get_status:
  * @self: a #FwupdClient
  *
@@ -5211,6 +5284,12 @@ fwupd_client_get_property(GObject *object, guint prop_id, GValue *value, GParamS
 	case PROP_INTERACTIVE:
 		g_value_set_boolean(value, priv->interactive);
 		break;
+	case PROP_BATTERY_LEVEL:
+		g_value_set_uint(value, priv->battery_level);
+		break;
+	case PROP_BATTERY_THRESHOLD:
+		g_value_set_uint(value, priv->battery_threshold);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -5229,6 +5308,12 @@ fwupd_client_set_property(GObject *object, guint prop_id, const GValue *value, G
 		break;
 	case PROP_PERCENTAGE:
 		priv->percentage = g_value_get_uint(value);
+		break;
+	case PROP_BATTERY_LEVEL:
+		fwupd_client_set_battery_level(self, g_value_get_uint(value));
+		break;
+	case PROP_BATTERY_THRESHOLD:
+		fwupd_client_set_battery_threshold(self, g_value_get_uint(value));
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -5530,6 +5615,38 @@ fwupd_client_class_init(FwupdClientClass *klass)
 				     TRUE,
 				     G_PARAM_READABLE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_ONLY_TRUSTED, pspec);
+
+	/**
+	 * FwupdClient:battery-level:
+	 *
+	 * The system battery level in percent.
+	 *
+	 * Since: 1.8.1
+	 */
+	pspec = g_param_spec_uint("battery-level",
+				  NULL,
+				  NULL,
+				  0,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_BATTERY_LEVEL, pspec);
+
+	/**
+	 * FwupdClient:battery-threshold:
+	 *
+	 * The system battery threshold in percent.
+	 *
+	 * Since: 1.8.1
+	 */
+	pspec = g_param_spec_uint("battery-threshold",
+				  NULL,
+				  NULL,
+				  0,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_BATTERY_THRESHOLD, pspec);
 }
 
 static void
@@ -5542,6 +5659,8 @@ fwupd_client_init(FwupdClient *self)
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fwupd_client_context_helper_free);
 	priv->proxy_resolver = g_proxy_resolver_get_default();
 	priv->hints = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	priv->battery_level = FWUPD_BATTERY_LEVEL_INVALID;
+	priv->battery_threshold = FWUPD_BATTERY_LEVEL_INVALID;
 
 	/* we get this one for free */
 	fwupd_client_add_hint(self, "locale", g_getenv("LANG"));

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -381,6 +381,10 @@ const gchar *
 fwupd_client_get_host_machine_id(FwupdClient *self);
 const gchar *
 fwupd_client_get_host_security_id(FwupdClient *self);
+guint32
+fwupd_client_get_battery_level(FwupdClient *self);
+guint32
+fwupd_client_get_battery_threshold(FwupdClient *self);
 
 void
 fwupd_client_get_remotes_async(FwupdClient *self,

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -114,6 +114,14 @@ fwupd_device_get_flashes_left(FwupdDevice *self);
 void
 fwupd_device_set_flashes_left(FwupdDevice *self, guint32 flashes_left);
 guint32
+fwupd_device_get_battery_level(FwupdDevice *self);
+void
+fwupd_device_set_battery_level(FwupdDevice *self, guint32 battery_level);
+guint32
+fwupd_device_get_battery_threshold(FwupdDevice *self);
+void
+fwupd_device_set_battery_threshold(FwupdDevice *self, guint32 battery_threshold);
+guint32
 fwupd_device_get_install_duration(FwupdDevice *self);
 void
 fwupd_device_set_install_duration(FwupdDevice *self, guint32 duration);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -482,5 +482,23 @@ G_BEGIN_DECLS
  * The D-Bus type signature string is 's' i.e. a string.
  **/
 #define FWUPD_RESULT_KEY_VERSION "Version"
+/**
+ * FWUPD_RESULT_KEY_BATTERY_LEVEL:
+ *
+ * Result key to represent the current battery level in percent.
+ * Expressed from 0-100%, or 101 for invalid or unset.
+ *
+ * The D-Bus type signature string is 'u' i.e. a unsigned 32 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_BATTERY_LEVEL "BatteryLevel"
+/**
+ * FWUPD_RESULT_KEY_BATTERY_THRESHOLD:
+ *
+ * Result key to represent the minimum battery level required to perform an update.
+ * Expressed from 0-100%, or 101 for invalid or unset.
+ *
+ * The D-Bus type signature string is 'u' i.e. a unsigned 32 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_BATTERY_THRESHOLD "BatteryThreshold"
 
 G_END_DECLS

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -915,6 +915,14 @@ typedef enum {
 	FWUPD_VERSION_FORMAT_LAST
 } FwupdVersionFormat;
 
+/**
+ * FWUPD_BATTERY_LEVEL_INVALID:
+ *
+ * This value signifies the battery level is either unset, or the value cannot
+ * be discovered.
+ */
+#define FWUPD_BATTERY_LEVEL_INVALID 101
+
 const gchar *
 fwupd_status_to_string(FwupdStatus status);
 FwupdStatus

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -765,6 +765,8 @@ LIBFWUPD_1.8.0 {
 
 LIBFWUPD_1.8.1 {
   global:
+    fwupd_client_get_battery_level;
+    fwupd_client_get_battery_threshold;
     fwupd_device_get_battery_level;
     fwupd_device_get_battery_threshold;
     fwupd_device_set_battery_level;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -762,3 +762,12 @@ LIBFWUPD_1.8.0 {
     fwupd_client_get_only_trusted;
   local: *;
 } LIBFWUPD_1.7.6;
+
+LIBFWUPD_1.8.1 {
+  global:
+    fwupd_device_get_battery_level;
+    fwupd_device_get_battery_threshold;
+    fwupd_device_set_battery_level;
+    fwupd_device_set_battery_threshold;
+  local: *;
+} LIBFWUPD_1.8.0;

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -134,14 +134,6 @@ typedef enum {
 } FuCpuVendor;
 
 /**
- * FU_BATTERY_VALUE_INVALID:
- *
- * This value signifies the battery level is either unset, or the value cannot
- * be discovered.
- */
-#define FU_BATTERY_VALUE_INVALID 101
-
-/**
  * FuBatteryState:
  * @FU_BATTERY_STATE_UNKNOWN:		Unknown
  * @FU_BATTERY_STATE_CHARGING:		Charging

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -674,7 +674,7 @@ fu_context_set_lid_state(FuContext *self, FuLidState lid_state)
  *
  * Gets the system battery level in percent.
  *
- * Returns: percentage value, or %FU_BATTERY_VALUE_INVALID for unknown
+ * Returns: percentage value, or %FWUPD_BATTERY_LEVEL_INVALID for unknown
  *
  * Since: 1.6.0
  **/
@@ -700,7 +700,7 @@ fu_context_set_battery_level(FuContext *self, guint battery_level)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FU_IS_CONTEXT(self));
-	g_return_if_fail(battery_level <= FU_BATTERY_VALUE_INVALID);
+	g_return_if_fail(battery_level <= FWUPD_BATTERY_LEVEL_INVALID);
 	if (priv->battery_level == battery_level)
 		return;
 	priv->battery_level = battery_level;
@@ -714,7 +714,7 @@ fu_context_set_battery_level(FuContext *self, guint battery_level)
  *
  * Gets the system battery threshold in percent.
  *
- * Returns: percentage value, or %FU_BATTERY_VALUE_INVALID for unknown
+ * Returns: percentage value, or %FWUPD_BATTERY_LEVEL_INVALID for unknown
  *
  * Since: 1.6.0
  **/
@@ -740,7 +740,7 @@ fu_context_set_battery_threshold(FuContext *self, guint battery_threshold)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FU_IS_CONTEXT(self));
-	g_return_if_fail(battery_threshold <= FU_BATTERY_VALUE_INVALID);
+	g_return_if_fail(battery_threshold <= FWUPD_BATTERY_LEVEL_INVALID);
 	if (priv->battery_threshold == battery_threshold)
 		return;
 	priv->battery_threshold = battery_threshold;
@@ -867,8 +867,8 @@ fu_context_class_init(FuContextClass *klass)
 				  NULL,
 				  NULL,
 				  0,
-				  FU_BATTERY_VALUE_INVALID,
-				  FU_BATTERY_VALUE_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
 				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_BATTERY_LEVEL, pspec);
 
@@ -883,8 +883,8 @@ fu_context_class_init(FuContextClass *klass)
 				  NULL,
 				  NULL,
 				  0,
-				  FU_BATTERY_VALUE_INVALID,
-				  FU_BATTERY_VALUE_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
+				  FWUPD_BATTERY_LEVEL_INVALID,
 				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_BATTERY_THRESHOLD, pspec);
 
@@ -915,8 +915,8 @@ static void
 fu_context_init(FuContext *self)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
-	priv->battery_level = FU_BATTERY_VALUE_INVALID;
-	priv->battery_threshold = FU_BATTERY_VALUE_INVALID;
+	priv->battery_level = FWUPD_BATTERY_LEVEL_INVALID;
+	priv->battery_threshold = FWUPD_BATTERY_LEVEL_INVALID;
 	priv->smbios = fu_smbios_new();
 	priv->hwids = fu_hwids_new();
 	priv->hwid_flags = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);

--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -76,7 +76,7 @@ fu_plugin_powerd_rescan(FuPlugin *plugin, GVariant *parameters)
 
 	/* checking if percentage is invalid */
 	if (current_level < 1 || current_level > 100)
-		current_level = FU_BATTERY_VALUE_INVALID;
+		current_level = FWUPD_BATTERY_LEVEL_INVALID;
 
 	fu_context_set_battery_state(ctx, current_state);
 	fu_context_set_battery_level(ctx, current_level);

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -1146,6 +1146,6 @@ fu_steelseries_sonic_init(FuSteelseriesSonic *self)
 	fu_device_add_protocol(FU_DEVICE(self), "com.steelseries.sonic");
 	fu_device_set_install_duration(FU_DEVICE(self), 135); /* 2 min 15 s */
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
-	fu_device_set_battery_level(FU_DEVICE(self), FU_BATTERY_VALUE_INVALID);
+	fu_device_set_battery_level(FU_DEVICE(self), FWUPD_BATTERY_LEVEL_INVALID);
 	fu_device_set_battery_threshold(FU_DEVICE(self), 20);
 }

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -53,14 +53,14 @@ fu_plugin_upower_rescan_devices(FuPlugin *plugin)
 	type_val = g_dbus_proxy_get_cached_property(data->proxy, "Type");
 	if (type_val == NULL || g_variant_get_uint32(type_val) == 0) {
 		fu_context_set_battery_state(ctx, FU_BATTERY_STATE_UNKNOWN);
-		fu_context_set_battery_level(ctx, FU_BATTERY_VALUE_INVALID);
+		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 		return;
 	}
 	state_val = g_dbus_proxy_get_cached_property(data->proxy, "State");
 	if (state_val == NULL || g_variant_get_uint32(state_val) == 0) {
 		g_warning("failed to query power state");
 		fu_context_set_battery_state(ctx, FU_BATTERY_STATE_UNKNOWN);
-		fu_context_set_battery_level(ctx, FU_BATTERY_VALUE_INVALID);
+		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 		return;
 	}
 
@@ -89,7 +89,7 @@ fu_plugin_upower_rescan_devices(FuPlugin *plugin)
 	percentage_val = g_dbus_proxy_get_cached_property(data->proxy, "Percentage");
 	if (percentage_val == NULL) {
 		g_warning("failed to query power percentage level");
-		fu_context_set_battery_level(ctx, FU_BATTERY_VALUE_INVALID);
+		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 		return;
 	}
 	fu_context_set_battery_level(ctx, g_variant_get_double(percentage_val));

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -20,6 +20,7 @@
 #include <jcat.h>
 
 #include "fwupd-device-private.h"
+#include "fwupd-enums-private.h"
 #include "fwupd-plugin-private.h"
 #include "fwupd-release-private.h"
 #include "fwupd-remote-private.h"
@@ -1953,6 +1954,16 @@ fu_daemon_daemon_get_property(GDBusConnection *connection_,
 
 	if (g_strcmp0(property_name, "Status") == 0)
 		return g_variant_new_uint32(fu_engine_get_status(self->engine));
+
+	if (g_strcmp0(property_name, FWUPD_RESULT_KEY_BATTERY_LEVEL) == 0) {
+		FuContext *ctx = fu_engine_get_context(self->engine);
+		return g_variant_new_uint32(fu_context_get_battery_level(ctx));
+	}
+
+	if (g_strcmp0(property_name, FWUPD_RESULT_KEY_BATTERY_THRESHOLD) == 0) {
+		FuContext *ctx = fu_engine_get_context(self->engine);
+		return g_variant_new_uint32(fu_context_get_battery_threshold(ctx));
+	}
 
 	if (g_strcmp0(property_name, "HostProduct") == 0)
 		return g_variant_new_string(fu_engine_get_host_product(self->engine));

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -297,8 +297,8 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 				  "Cannot install update when not on AC power");
 		return;
 	}
-	if (fu_context_get_battery_level(self->ctx) != FU_BATTERY_VALUE_INVALID &&
-	    fu_context_get_battery_threshold(self->ctx) != FU_BATTERY_VALUE_INVALID &&
+	if (fu_context_get_battery_level(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
+	    fu_context_get_battery_threshold(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_level(self->ctx) < fu_context_get_battery_threshold(self->ctx)) {
 		g_autofree gchar *reason = NULL;
 		reason = g_strdup_printf(
@@ -2585,8 +2585,8 @@ fu_engine_device_check_power(FuEngine *self,
 	}
 
 	/* not enough just in case */
-	if (fu_context_get_battery_level(self->ctx) != FU_BATTERY_VALUE_INVALID &&
-	    fu_context_get_battery_threshold(self->ctx) != FU_BATTERY_VALUE_INVALID &&
+	if (fu_context_get_battery_level(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
+	    fu_context_get_battery_threshold(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_level(self->ctx) < fu_context_get_battery_threshold(self->ctx)) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1454,6 +1454,25 @@ fu_util_device_to_string(FwupdDevice *dev, guint idt)
 			}
 		}
 	}
+
+	/* battery */
+	if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID &&
+	    fwupd_device_get_battery_threshold(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
+		g_autofree gchar *val = NULL;
+		/* TRANSLATORS: first percentage is current value, 2nd percentage is the lowest
+		 * limit the firmware update is allowed for the update to happen */
+		val = g_strdup_printf(_("%u%% (threshold %u%%)"),
+				      fwupd_device_get_battery_level(dev),
+				      fwupd_device_get_battery_threshold(dev));
+		/* TRANSLATORS: refers to the battery inside the peripheral device, e.g. mouse */
+		fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
+	} else if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
+		g_autofree gchar *val = NULL;
+		val = g_strdup_printf("%u%%", fwupd_device_get_battery_level(dev));
+		/* TRANSLATORS: refers to the battery inside the peripheral device, e.g. mouse */
+		fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
+	}
+
 	tmp = fwupd_device_get_update_error(dev);
 	if (tmp != NULL) {
 		g_autofree gchar *color = fu_util_term_format(tmp, FU_UTIL_TERM_COLOR_RED);

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -112,6 +112,28 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='BatteryLevel' type='u' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Returns the system battery level, or 101 for unknown.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
+    <property name='BatteryThreshold' type='u' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Returns the system battery threshold under which a firmware update cannot be performed.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='OnlyTrusted' type='b' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
This allows us to show the current value and the threshold on the CLI
and in tools like gnome-firmware.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
