### PR TITLE
trivial: Add device-test for Steelseries Rival 3 Wireless

### DIFF
--- a/data/device-tests/steelseries-rival-3-wireless.json
+++ b/data/device-tests/steelseries-rival-3-wireless.json
@@ -1,0 +1,28 @@
+{
+  "name": "Steelseries Rival 3 Wireless",
+  "interactive": true,
+  "steps": [
+    {
+      "url": "https://fwupd.org/downloads/89791626948cb485e15d093ac47c7823d5ad6a7dcbe8b9917a3711f5c8694d52-SteelSeries_Rival_3_Wireless_0.20.cab",
+      "components": [
+        {
+          "version": "0.20",
+          "guids": [
+            "73e6daa7-d5a1-567d-a0ff-01514f8498b1"
+          ]
+        }
+      ]
+    },
+    {
+      "url": "https://fwupd.org/downloads/fe3775d33b41898e69f06698ed03779a158d99b9716a9b1c0ee7e3051ab857c3-SteelSeries_Rival_3_Wireless_1.0.cab",
+      "components": [
+        {
+          "version": "1.0",
+          "guids": [
+            "73e6daa7-d5a1-567d-a0ff-01514f8498b1"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

This adds a Json device-test for the Steelseries Rival 3 Wireless device.