### PR TITLE
debian: debci: load the 'mtdram' module, to make it execute the mtd-self-test

### DIFF
--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -1,5 +1,7 @@
 #!/bin/sh
 set -e
+# try loading the mtdram module to run our mtd tests
+modprobe mtdram || true
 sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 sed "s,^VerboseDomains=.*,VerboseDomains=*,"  -i /etc/fwupd/daemon.conf
 sed "s,ConditionVirtualization=.*,," 		\


### PR DESCRIPTION
debian: debci: load the 'mtdram' module, to make it execute the mtd-self-test

This is related to the discussion (and issue reported) at: https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/1973598

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
