### PR TITLE
debian: debci: don't stderr-fail the autopkgtest on modprobe error

### DIFF
--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 # try loading the mtdram module to run our mtd tests
-modprobe mtdram || true
+modprobe mtdram 2>&1 || true
 sed "s,^DisabledPlugins=.*,DisabledPlugins=," -i /etc/fwupd/daemon.conf
 sed "s,^VerboseDomains=.*,VerboseDomains=*,"  -i /etc/fwupd/daemon.conf
 sed "s,ConditionVirtualization=.*,," 		\


### PR DESCRIPTION
debian: debci: don't stderr-fail the autopkgtest on modprobe error
it's optional as tests can be skipped, if mtdram module isn't there

This is a fixup for the previous PR #4641 and related to https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/1973598

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
