### PR TITLE
Specify an enumerated problem when inhibiting devices

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -136,6 +136,16 @@ fwupd_device_remove_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 gboolean
 fwupd_device_has_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 guint64
+fwupd_device_get_problems(FwupdDevice *self);
+void
+fwupd_device_set_problems(FwupdDevice *self, guint64 problems);
+void
+fwupd_device_add_problem(FwupdDevice *self, FwupdDeviceProblem problem);
+void
+fwupd_device_remove_problem(FwupdDevice *self, FwupdDeviceProblem problem);
+gboolean
+fwupd_device_has_problem(FwupdDevice *self, FwupdDeviceProblem problem);
+guint64
 fwupd_device_get_created(FwupdDevice *self);
 void
 fwupd_device_set_created(FwupdDevice *self, guint64 created);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -363,6 +363,14 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_TRUST_FLAGS "TrustFlags"
 /**
+ * FWUPD_RESULT_KEY_PROBLEMS:
+ *
+ * Result key to represent problems
+ *
+ * The D-Bus type signature string is 't' i.e. a unsigned 64 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_PROBLEMS "Problems"
+/**
  * FWUPD_RESULT_KEY_UPDATE_MESSAGE:
  *
  * Result key to represent UpdateMessage

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -328,6 +328,68 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 }
 
 /**
+ * fwupd_device_problem_to_string:
+ * @device_problem: a device inhibit kind, e.g. %FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW
+ *
+ * Converts a device inhibit kind to a string.
+ *
+ * Returns: identifier string
+ *
+ * Since: 1.8.1
+ **/
+const gchar *
+fwupd_device_problem_to_string(FwupdDeviceProblem device_problem)
+{
+	if (device_problem == FWUPD_DEVICE_PROBLEM_NONE)
+		return "none";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW)
+		return "system-power-too-low";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_UNREACHABLE)
+		return "unreachable";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW)
+		return "power-too-low";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_UPDATE_PENDING)
+		return "update-pending";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER)
+		return "require-ac-power";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED)
+		return "lid-is-closed";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_UNKNOWN)
+		return "unknown";
+	return NULL;
+}
+
+/**
+ * fwupd_device_problem_from_string:
+ * @device_problem: (nullable): a string, e.g. `require-ac`
+ *
+ * Converts a string to a enumerated device inhibit kind.
+ *
+ * Returns: enumerated value
+ *
+ * Since: 1.8.1
+ **/
+FwupdDeviceProblem
+fwupd_device_problem_from_string(const gchar *device_problem)
+{
+	if (g_strcmp0(device_problem, "none") == 0)
+		return FWUPD_DEVICE_PROBLEM_NONE;
+	if (g_strcmp0(device_problem, "system-power-too-low") == 0)
+		return FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW;
+	if (g_strcmp0(device_problem, "unreachable") == 0)
+		return FWUPD_DEVICE_PROBLEM_UNREACHABLE;
+	if (g_strcmp0(device_problem, "power-too-low") == 0)
+		return FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW;
+	if (g_strcmp0(device_problem, "update-pending") == 0)
+		return FWUPD_DEVICE_PROBLEM_UPDATE_PENDING;
+	if (g_strcmp0(device_problem, "require-ac-power") == 0)
+		return FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER;
+	if (g_strcmp0(device_problem, "lid-is-closed") == 0)
+		return FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED;
+	return FWUPD_DEVICE_PROBLEM_UNKNOWN;
+}
+
+/**
  * fwupd_plugin_flag_to_string:
  * @plugin_flag: plugin flags, e.g. %FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -540,6 +540,80 @@ typedef enum {
 typedef guint64 FwupdDeviceFlags;
 
 /**
+ * FWUPD_DEVICE_PROBLEM_NONE:
+ *
+ * No device problems detected.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_NONE (0u)
+/**
+ * FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW:
+ *
+ * The system power is too low to perform the update.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW (1u << 0)
+/**
+ * FWUPD_DEVICE_PROBLEM_UNREACHABLE:
+ *
+ * The device is unreachable, or out of wireless range.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_UNREACHABLE (1u << 1)
+/**
+ * FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW:
+ *
+ * The device battery power is too low.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW (1u << 2)
+/**
+ * FWUPD_DEVICE_PROBLEM_UPDATE_PENDING:
+ *
+ * The device is waiting for the update to be applied.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_UPDATE_PENDING (1u << 3)
+/**
+ * FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER:
+ *
+ * The device requires AC power to be connected.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER (1u << 4)
+/**
+ * FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED:
+ *
+ * The device cannot be used while the laptop lid is closed.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED (1u << 5)
+/**
+ * FWUPD_DEVICE_PROBLEM_UNKNOWN:
+ *
+ * This problem is not defined, this typically will happen from mismatched
+ * fwupd library and clients.
+ *
+ * Since 1.8.1
+ */
+#define FWUPD_DEVICE_PROBLEM_UNKNOWN G_MAXUINT64
+/**
+ * FwupdDeviceProblem:
+ *
+ * Problems are reasons why the device is not updatable.
+ *
+ * All problems have to be fixable by the user, rather than the plugin author.
+ */
+typedef guint64 FwupdDeviceProblem;
+
+/**
  * FWUPD_RELEASE_FLAG_NONE:
  *
  * No flags are set.
@@ -931,6 +1005,10 @@ const gchar *
 fwupd_device_flag_to_string(FwupdDeviceFlags device_flag);
 FwupdDeviceFlags
 fwupd_device_flag_from_string(const gchar *device_flag);
+const gchar *
+fwupd_device_problem_to_string(FwupdDeviceProblem device_problem);
+FwupdDeviceProblem
+fwupd_device_problem_from_string(const gchar *device_problem);
 const gchar *
 fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag);
 FwupdPluginFlags

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -155,6 +155,12 @@ fwupd_enums_func(void)
 			break;
 		g_assert_cmpint(fwupd_device_flag_from_string(tmp), ==, i);
 	}
+	for (guint64 i = 1; i < FWUPD_DEVICE_PROBLEM_UNKNOWN; i *= 2) {
+		const gchar *tmp = fwupd_device_problem_to_string(i);
+		if (tmp == NULL)
+			break;
+		g_assert_cmpint(fwupd_device_problem_from_string(tmp), ==, i);
+	}
 	for (guint64 i = 1; i < FWUPD_PLUGIN_FLAG_UNKNOWN; i *= 2) {
 		const gchar *tmp = fwupd_plugin_flag_to_string(i);
 		if (tmp == NULL)

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -767,9 +767,16 @@ LIBFWUPD_1.8.1 {
   global:
     fwupd_client_get_battery_level;
     fwupd_client_get_battery_threshold;
+    fwupd_device_add_problem;
     fwupd_device_get_battery_level;
     fwupd_device_get_battery_threshold;
+    fwupd_device_get_problems;
+    fwupd_device_has_problem;
+    fwupd_device_problem_from_string;
+    fwupd_device_problem_to_string;
+    fwupd_device_remove_problem;
     fwupd_device_set_battery_level;
     fwupd_device_set_battery_threshold;
+    fwupd_device_set_problems;
   local: *;
 } LIBFWUPD_1.8.0;

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -535,6 +535,10 @@ void
 fu_device_inhibit(FuDevice *self, const gchar *inhibit_id, const gchar *reason);
 void
 fu_device_uninhibit(FuDevice *self, const gchar *inhibit_id);
+void
+fu_device_add_problem(FuDevice *self, FwupdDeviceProblem problem);
+void
+fu_device_remove_problem(FuDevice *self, FwupdDeviceProblem problem);
 gboolean
 fu_device_has_inhibit(FuDevice *self, const gchar *inhibit_id);
 const gchar *

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1037,7 +1037,9 @@ LIBFWUPDPLUGIN_1.8.0 {
 
 LIBFWUPDPLUGIN_1.8.1 {
   global:
+    fu_device_add_problem;
     fu_device_poll_locker_new;
+    fu_device_remove_problem;
     fu_plugin_runner_init;
     fu_udev_device_ioctl_full;
   local: *;

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -618,10 +618,7 @@ fu_ccgx_dmc_device_attach(FuDevice *device, FuProgress *progress, GError **error
 
 	if (manual_replug) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-		fu_device_inhibit(device,
-				  "update-pending",
-				  "A pending update will be completed next time the device "
-				  "is unplugged from your computer");
+		fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_PENDING);
 	} else {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	}

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -582,10 +582,7 @@ fu_dell_dock_ec_get_dock_data(FuDevice *device, GError **error)
 			fu_device_uninhibit(device, "update-pending");
 		} else {
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			fu_device_inhibit(device,
-					  "update-pending",
-					  "A pending update will be completed next time the dock "
-					  "is unplugged from your computer");
+			fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_PENDING);
 		}
 	} else {
 		fu_device_inhibit(device, "not-supported", "Utility does not support this board");

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -274,7 +274,7 @@ fu_scsi_device_write_firmware(FuDevice *device,
 	}
 
 	/* success! */
-	fu_device_inhibit(device, "needs-reboot", "Waiting for reboot to apply firmware");
+	fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_PENDING);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	return TRUE;
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -292,10 +292,9 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC) &&
 	    (fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_DISCHARGING ||
 	     fu_context_get_battery_state(self->ctx) == FU_BATTERY_STATE_EMPTY)) {
-		fu_device_inhibit(device,
-				  "battery-system",
-				  "Cannot install update when not on AC power");
-		return;
+		fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER);
+	} else {
+		fu_device_remove_problem(device, FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER);
 	}
 	if (fu_context_get_battery_level(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_threshold(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
@@ -304,10 +303,10 @@ fu_engine_ensure_device_battery_inhibit(FuEngine *self, FuDevice *device)
 		reason = g_strdup_printf(
 		    "Cannot install update when system battery is not at least %u%%",
 		    fu_context_get_battery_threshold(self->ctx));
-		fu_device_inhibit(device, "battery-system", reason);
-		return;
+		fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW);
+	} else {
+		fu_device_remove_problem(device, FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW);
 	}
-	fu_device_uninhibit(device, "battery-system");
 }
 
 static void
@@ -315,12 +314,10 @@ fu_engine_ensure_device_lid_inhibit(FuEngine *self, FuDevice *device)
 {
 	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_NO_LID_CLOSED) &&
 	    fu_context_get_lid_state(self->ctx) == FU_LID_STATE_CLOSED) {
-		fu_device_inhibit(device,
-				  "lid-closed-system",
-				  "Cannot install update when the lid is closed");
+		fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED);
 		return;
 	}
-	fu_device_uninhibit(device, "lid-closed-system");
+	fu_device_remove_problem(device, FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED);
 }
 
 static void

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -285,7 +285,14 @@ fu_util_start_engine(FuUtilPrivate *priv, FuEngineLoadFlags flags, GError **erro
 	fu_util_show_unsupported_warn();
 
 	/* copy properties from engine to client */
-	g_object_set(priv->client, "host-product", fu_engine_get_host_product(priv->engine), NULL);
+	g_object_set(priv->client,
+		     "host-product",
+		     fu_engine_get_host_product(priv->engine),
+		     "battery-level",
+		     fu_context_get_battery_level(fu_engine_get_context(priv->engine)),
+		     "battery-threshold",
+		     fu_context_get_battery_threshold(fu_engine_get_context(priv->engine)),
+		     NULL);
 
 	/* success */
 	return TRUE;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1304,6 +1304,55 @@ fu_util_update_state_to_string(FwupdUpdateState update_state)
 	return NULL;
 }
 
+static gchar *
+fu_util_device_problem_to_string(FwupdClient *client, FwupdDevice *dev, FwupdDeviceProblem problem)
+{
+	if (problem == FWUPD_DEVICE_PROBLEM_NONE)
+		return NULL;
+	if (problem == FWUPD_DEVICE_PROBLEM_UNKNOWN)
+		return NULL;
+	if (problem == FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW) {
+		if (fwupd_client_get_battery_level(client) == FWUPD_BATTERY_LEVEL_INVALID ||
+		    fwupd_client_get_battery_threshold(client) == FWUPD_BATTERY_LEVEL_INVALID) {
+			/* TRANSLATORS: as in laptop battery power */
+			return g_strdup(_("System power is too low to perform the update"));
+		}
+		return g_strdup_printf(
+		    /* TRANSLATORS: as in laptop battery power */
+		    _("System power is too low to perform the update (%u%%, requires %u%%)"),
+		    fwupd_client_get_battery_level(client),
+		    fwupd_client_get_battery_threshold(client));
+	}
+	if (problem == FWUPD_DEVICE_PROBLEM_UNREACHABLE) {
+		/* TRANSLATORS: for example, a Bluetooth mouse that is in powersave mode */
+		return g_strdup(_("Device is unreachable, or out of wireless range"));
+	}
+	if (problem == FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW) {
+		if (fwupd_device_get_battery_level(dev) == FWUPD_BATTERY_LEVEL_INVALID ||
+		    fwupd_device_get_battery_threshold(dev) == FWUPD_BATTERY_LEVEL_INVALID) {
+			/* TRANSLATORS: for example the batteries *inside* the Bluetooth mouse */
+			return g_strdup_printf(_("Device battery power is too low"));
+		}
+		/* TRANSLATORS: for example the batteries *inside* the Bluetooth mouse */
+		return g_strdup_printf(_("Device battery power is too low (%u%%, requires %u%%)"),
+				       fwupd_device_get_battery_level(dev),
+				       fwupd_device_get_battery_threshold(dev));
+	}
+	if (problem == FWUPD_DEVICE_PROBLEM_UPDATE_PENDING) {
+		/* TRANSLATORS: usually this is when we're waiting for a reboot */
+		return g_strdup(_("Device is waiting for the update to be applied"));
+	}
+	if (problem == FWUPD_DEVICE_PROBLEM_REQUIRE_AC_POWER) {
+		/* TRANSLATORS: as in, wired mains power for a laptop */
+		return g_strdup(_("Device requires AC power to be connected"));
+	}
+	if (problem == FWUPD_DEVICE_PROBLEM_LID_IS_CLOSED) {
+		/* TRANSLATORS: lid means "laptop top cover" */
+		return g_strdup(_("Device cannot be used while the lid is closed"));
+	}
+	return NULL;
+}
+
 gchar *
 fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 {
@@ -1456,29 +1505,53 @@ fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 		}
 	}
 
-	/* battery */
-	if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID &&
-	    fwupd_device_get_battery_threshold(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
-		g_autofree gchar *val = NULL;
-		/* TRANSLATORS: first percentage is current value, 2nd percentage is the lowest
-		 * limit the firmware update is allowed for the update to happen */
-		val = g_strdup_printf(_("%u%% (threshold %u%%)"),
-				      fwupd_device_get_battery_level(dev),
-				      fwupd_device_get_battery_threshold(dev));
-		/* TRANSLATORS: refers to the battery inside the peripheral device, e.g. mouse */
-		fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
-	} else if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
-		g_autofree gchar *val = NULL;
-		val = g_strdup_printf("%u%%", fwupd_device_get_battery_level(dev));
-		/* TRANSLATORS: refers to the battery inside the peripheral device, e.g. mouse */
-		fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
+	/* battery, but only if we're not about to show the same info as an inhibit */
+	if (!fwupd_device_has_problem(dev, FWUPD_DEVICE_PROBLEM_POWER_TOO_LOW)) {
+		if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID &&
+		    fwupd_device_get_battery_threshold(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
+			g_autofree gchar *val = NULL;
+			/* TRANSLATORS: first percentage is current value, 2nd percentage is the
+			 * lowest limit the firmware update is allowed for the update to happen */
+			val = g_strdup_printf(_("%u%% (threshold %u%%)"),
+					      fwupd_device_get_battery_level(dev),
+					      fwupd_device_get_battery_threshold(dev));
+			/* TRANSLATORS: refers to the battery inside the peripheral device */
+			fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
+		} else if (fwupd_device_get_battery_level(dev) != FWUPD_BATTERY_LEVEL_INVALID) {
+			g_autofree gchar *val = NULL;
+			val = g_strdup_printf("%u%%", fwupd_device_get_battery_level(dev));
+			/* TRANSLATORS: refers to the battery inside the peripheral device */
+			fu_common_string_append_kv(str, idt + 1, _("Battery"), val);
+		}
 	}
 
-	tmp = fwupd_device_get_update_error(dev);
-	if (tmp != NULL) {
-		g_autofree gchar *color = fu_util_term_format(tmp, FU_UTIL_TERM_COLOR_RED);
-		/* TRANSLATORS: error message from last update attempt */
-		fu_common_string_append_kv(str, idt + 1, _("Update Error"), color);
+	/* either show enumerated [translated] problems or the synthesized update error */
+	if (fwupd_device_get_problems(dev) == FWUPD_DEVICE_PROBLEM_NONE) {
+		tmp = fwupd_device_get_update_error(dev);
+		if (tmp != NULL) {
+			g_autofree gchar *color = fu_util_term_format(tmp, FU_UTIL_TERM_COLOR_RED);
+			/* TRANSLATORS: error message from last update attempt */
+			fu_common_string_append_kv(str, idt + 1, _("Update Error"), color);
+		}
+	} else {
+		/* TRANSLATORS: reasons the device is not updatable */
+		tmp = _("Problems");
+		for (guint i = 0; i < 64; i++) {
+			FwupdDeviceProblem problem = (guint64)1 << i;
+			g_autofree gchar *bullet = NULL;
+			g_autofree gchar *desc = NULL;
+			g_autofree gchar *color = NULL;
+
+			if (!fwupd_device_has_problem(dev, problem))
+				continue;
+			desc = fu_util_device_problem_to_string(client, dev, problem);
+			if (desc == NULL)
+				continue;
+			bullet = g_strdup_printf("• %s", desc);
+			color = fu_util_term_format(bullet, FU_UTIL_TERM_COLOR_RED);
+			fu_common_string_append_kv(str, idt + 1, tmp, color);
+			tmp = NULL;
+		}
 	}
 
 	/* modified date: for history devices */


### PR DESCRIPTION
This allows us to make smarter policy decisions in the future on when
to show unavailable updates. It also means we can show translated
text in the frond-end clients.

Only problems the user can "fix" are enumerated. For example, opening
the laptop lid, or charging the device battery.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
