### PR TITLE
trivial: don't require libgusb when building as a subproject on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -510,7 +510,7 @@ conf.set_quoted('FWUPD_PLUGINDIR', plugin_dir)
 endif
 
 # sanity check, otherwise there is not point building
-if host_machine.system() == 'windows' and not gusb.found()
+if build_standalone and host_machine.system() == 'windows' and not gusb.found()
   error('gusb feature is required for Windows build')
 endif
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
