### PR TITLE
Store the last-set status in the daemon

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -111,7 +111,6 @@ struct _FuEngine {
 	FuConfig *config;
 	FuRemoteList *remote_list;
 	FuDeviceList *device_list;
-	FwupdStatus status;
 	gboolean tainted;
 	gboolean only_trusted;
 	gboolean write_history;
@@ -194,30 +193,10 @@ fu_engine_get_context(FuEngine *self)
 	return self->ctx;
 }
 
-/**
- * fu_engine_get_status:
- * @self: a #FuEngine
- *
- * Gets the current engine status.
- *
- * Returns: a #FwupdStatus, e.g. %FWUPD_STATUS_DECOMPRESSING
- **/
-FwupdStatus
-fu_engine_get_status(FuEngine *self)
-{
-	g_return_val_if_fail(FU_IS_ENGINE(self), 0);
-	return self->status;
-}
-
 static void
 fu_engine_set_status(FuEngine *self, FwupdStatus status)
 {
-	if (self->status == status)
-		return;
-	self->status = status;
-
 	/* emit changed */
-	g_debug("Emitting PropertyChanged('Status'='%s')", fwupd_status_to_string(status));
 	g_signal_emit(self, signals[SIGNAL_STATUS_CHANGED], 0, status);
 }
 
@@ -7199,7 +7178,6 @@ fu_engine_init(FuEngine *self)
 	g_autofree gchar *pkidir_md = NULL;
 	g_autofree gchar *sysconfdir = NULL;
 	self->percentage = 0;
-	self->status = FWUPD_STATUS_IDLE;
 	self->config = fu_config_new();
 	self->remote_list = fu_remote_list_new();
 	self->device_list = fu_device_list_new();

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -70,8 +70,6 @@ gboolean
 fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid);
 const gchar *
 fu_engine_get_host_security_id(FuEngine *self);
-FwupdStatus
-fu_engine_get_status(FuEngine *self);
 XbSilo *
 fu_engine_get_silo_from_blob(FuEngine *self, GBytes *blob_cab, GError **error);
 guint64

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1667,7 +1667,6 @@ fu_engine_downgrade_func(gconstpointer user_data)
 			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 	g_test_assert_expected_messages();
 
 	/* return all the remotes, even the broken one */
@@ -1863,7 +1862,6 @@ fu_engine_history_func(gconstpointer user_data)
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -2010,7 +2008,6 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -2131,7 +2128,6 @@ fu_engine_history_inherit(gconstpointer user_data)
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -2271,7 +2267,6 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
@@ -2362,7 +2357,6 @@ fu_engine_history_error_func(gconstpointer user_data)
 	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_engine_get_status(engine), ==, FWUPD_STATUS_IDLE);
 
 	/* add a device so we can get upgrade it */
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);


### PR DESCRIPTION
We emit to the client from the daemon, and also proxy the status from
the engine, i.e. we're setting the same property in two places.

When the client requests the last-set status, recover the value sent
from the lowest layer (the daemon) rather than the engine. The former
gets reset back to IDLE automatically, the latter does not.

Fixes https://github.com/fwupd/fwupd/issues/4649

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
