### PR TITLE
Gportay/genesys fix dump firmware behaviour

### DIFF
--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1655,13 +1655,9 @@ static GBytes *
 fu_genesys_scaler_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuGenesysScalerDevice *self = FU_GENESYS_SCALER_DEVICE(device);
-	gsize size = fu_device_get_firmware_size_max(device);
-	guint addr = 0x000000;
+	gsize size = fu_cfi_device_get_size(self->cfi_device);
 	g_autofree guint8 *buf = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
-
-	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE))
-		addr = 0x200000;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -1679,7 +1675,7 @@ fu_genesys_scaler_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 
 	buf = g_malloc0(size);
 	if (!fu_genesys_scaler_device_read_flash(self,
-						 addr,
+						 0,
 						 buf,
 						 size,
 						 fu_progress_get_child(progress),

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -758,13 +758,9 @@ static GBytes *
 fu_genesys_usbhub_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
-	gsize address = self->fw_bank_addr[0];
-	gsize size = self->code_size + self->extend_size;
+	gsize size = fu_cfi_device_get_size(self->cfi_device);
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autofree guint8 *buf = NULL;
-
-	if (self->fw_bank_vers[0] == 0 && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE))
-		address = self->fw_bank_addr[1];
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -782,7 +778,7 @@ fu_genesys_usbhub_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 
 	buf = g_malloc0(size);
 	if (!fu_genesys_usbhub_device_read_flash(self,
-						 address,
+						 0,
 						 buf,
 						 size,
 						 fu_progress_get_child(progress),


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This fixes the `dump_firmware()` behavior by dumping the whole CFI instead of the current bank.