### PR TITLE
trivial: Do not use the unset MSR ucode version

### DIFF
--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -203,7 +203,7 @@ fu_plugin_msr_backend_device_added(FuPlugin *plugin, FuDevice *device, GError **
 						G_LITTLE_ENDIAN,
 						error))
 			return FALSE;
-		if (ver_raw != 0) {
+		if (ver_raw != 0 && ver_raw != G_MAXUINT32) {
 			FwupdVersionFormat verfmt = fu_device_get_version_format(device_cpu);
 			g_autofree gchar *ver_str = NULL;
 			ver_str = fu_common_version_from_uint32(ver_raw, verfmt);


### PR DESCRIPTION
This happens in VirtualBox.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
