### PR TITLE
Add a 'name' attribute to each FuProgress step

### DIFF
--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -610,7 +610,6 @@ fu_progress_finished(FuProgress *self)
 	FuProgressPrivate *priv = GET_PRIVATE(self);
 
 	g_return_if_fail(FU_IS_PROGRESS(self));
-	g_return_if_fail(priv->id != NULL);
 
 	/* is already at 100%? */
 	if (priv->step_now == priv->step_max)

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -71,6 +71,10 @@ fu_progress_get_id(FuProgress *self);
 void
 fu_progress_set_id(FuProgress *self, const gchar *id);
 const gchar *
+fu_progress_get_name(FuProgress *self);
+void
+fu_progress_set_name(FuProgress *self, const gchar *name);
+const gchar *
 fu_progress_flag_to_string(FuProgressFlags flag);
 FuProgressFlags
 fu_progress_flag_from_string(const gchar *flag);
@@ -100,6 +104,8 @@ guint
 fu_progress_get_steps(FuProgress *self);
 void
 fu_progress_add_step(FuProgress *self, FwupdStatus status, guint value);
+void
+fu_progress_add_step_full(FuProgress *self, FwupdStatus status, guint value, const gchar *name);
 void
 fu_progress_finished(FuProgress *self);
 void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1054,3 +1054,11 @@ LIBFWUPDPLUGIN_1.8.1 {
     fu_udev_device_ioctl_full;
   local: *;
 } LIBFWUPDPLUGIN_1.8.0;
+
+LIBFWUPDPLUGIN_1.8.2 {
+  global:
+    fu_progress_add_step_full;
+    fu_progress_get_name;
+    fu_progress_set_name;
+  local: *;
+} LIBFWUPDPLUGIN_1.8.1;

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -260,7 +260,7 @@ fu_analogix_device_write_image(FuAnalogixDevice *self,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* initialization */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "initialization");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
 
 	/* offset into firmware */
@@ -328,10 +328,10 @@ fu_analogix_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 25); /* cus */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 25); /* stx */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 25); /* srx */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 25); /* ocm */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 25, "cus");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 25, "stx");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 25, "srx");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 25, "ocm");
 
 	/* CUSTOM_DEF */
 	fw_cus = fu_firmware_get_image_by_id(firmware, "custom", NULL);

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -503,8 +503,8 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "build-img");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 80, "write-chunks");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 19);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2);
 
@@ -652,10 +652,10 @@ fu_bcm57xx_device_set_progress(FuDevice *self, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* detach */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);	/* write */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0); /* attach */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* reload */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 98, "write");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 2, "reload");
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -655,10 +655,10 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* enable */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 80); /* nvram */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* veraddr */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* version */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "enable");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 80, "nvram");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "veraddr");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "version");
 
 	locker = fu_device_locker_new_full(
 	    self,

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -464,8 +464,8 @@ fu_ccgx_dmc_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "fwct");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 98, "img");
 
 	/* get fwct record */
 	fwct_blob = fu_ccgx_dmc_firmware_get_fwct_record(FU_CCGX_DMC_FIRMWARE(firmware));

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1273,10 +1273,10 @@ fu_ccgx_hpi_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* invalidate metadata */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "invalidate-metadata");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* leave-flash */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "leave-flash");
 
 	/* enter flash mode */
 	locker = fu_device_locker_new_full(self,

--- a/plugins/dfu/fu-dfu-target-avr.c
+++ b/plugins/dfu/fu-dfu-target-avr.c
@@ -112,8 +112,8 @@ fu_dfu_target_avr_attach(FuDfuTarget *target, FuProgress *progress, GError **err
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 50);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 50);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 50, "download-chunk");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 50, "download-zero");
 
 	/* format buffer */
 	buf[0] = DFU_AVR32_GROUP_EXEC;
@@ -363,10 +363,10 @@ fu_dfu_target_avr32_get_chip_signature(FuDfuTarget *target, FuProgress *progress
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 25);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 25);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 25);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 25);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 25, "mem-unit");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 25, "mem-page");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 25, "read-memory");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 25, "upload");
 
 	/* select unit, and request 4 bytes */
 	if (!fu_dfu_target_avr_select_memory_unit(target,
@@ -411,8 +411,8 @@ fu_dfu_target_avr_get_chip_signature_for_addr(FuDfuTarget *target,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 10);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 90);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 10, "req");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 90, "res");
 
 	/* request a single byte */
 	if (!fu_dfu_target_avr_read_command(target,

--- a/plugins/dfu/fu-dfu-target-stm.c
+++ b/plugins/dfu/fu-dfu-target-stm.c
@@ -108,8 +108,8 @@ fu_dfu_target_stm_upload_element(FuDfuTarget *target,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 40);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 40, "set-addr");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "abort");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 58);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
 

--- a/plugins/elanfp/fu-elanfp-device.c
+++ b/plugins/elanfp/fu-elanfp-device.c
@@ -320,8 +320,8 @@ fu_elanfp_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);   /* offer */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98); /* payload */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 2, "offer");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 98, "payload");
 
 	/* send offers */
 	for (i = 0; items[i].tag != NULL; i++) {

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -314,10 +314,10 @@ fu_elantp_hid_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* detach */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "detach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 30);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10); /* reset */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 10, "reset");
 
 	/* simple image */
 	fw = fu_firmware_get_bytes(firmware, error);

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -354,7 +354,7 @@ fu_emmc_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* ffu */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "ffu");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 45);
 

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -241,7 +241,7 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* ICP */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "icp");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95);
 
 	/* get default image */

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -254,10 +254,10 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* enable mtp write */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50);	/* copy-mmio */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 46); /* customize */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2);	/* boot */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 2, "enable-mtp-write");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 50, "copy-mmio");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 46, "customize");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 2, "boot");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 2);
 
 	/* get default blob, which we know is already bigger than FirmwareMin */

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1661,7 +1661,7 @@ fu_genesys_scaler_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* detach */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "detach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 99);
 
 	/* require detach -> attach */

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -764,7 +764,7 @@ fu_genesys_usbhub_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* detach */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "detach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 99);
 
 	/* require detach -> attach */

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -355,7 +355,7 @@ fu_goodixmoc_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* init */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "init");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 99);
 
 	/* get default image */

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -222,7 +222,7 @@ fu_hailuck_bl_device_write_firmware(FuDevice *device,
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1); /* block 0 */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "device-write-blk0");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 9);
 
 	/* get default image */

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -96,9 +96,9 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 85);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* end-program */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "end-program");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 3);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* pass */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "pass");
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -232,13 +232,13 @@ fu_logitech_hidpp_bootloader_nordic_write_firmware(FuDevice *device,
 	if (fu_device_has_private_flag(device, FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED)) {
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 4);
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 13);
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1);  /* block 0 */
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 82); /* reset vector */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "device-write0");
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 82, "reset vector");
 	} else {
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 22);
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 72);
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1); /* block 0 */
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 6); /* reset vector */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "device-write0");
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 6, "reset-vector");
 	}
 
 	/* get default image */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -130,12 +130,12 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 	fu_progress_set_id(progress, G_STRLOC);
 	if (fu_device_has_private_flag(device, FU_LOGITECH_HIDPP_BOOTLOADER_FLAG_IS_SIGNED)) {
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 3);
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1); /* clear */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_ERASE, 1, "clear");
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 18);
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 79);
 	} else {
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 11);
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1); /* clear */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_ERASE, 1, "clear");
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 75);
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 12);
 	}

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -366,7 +366,7 @@ fu_nvme_device_write_firmware(FuDevice *device,
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10); /* commit */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 10, "commit");
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -663,8 +663,8 @@ fu_parade_lspcon_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 5);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 70);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 25);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 3);  /* boot */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 2); /* boot */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 3, "device-write-boot");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 2, "device-verify-boot");
 
 	blob_fw = fu_firmware_get_bytes(firmware, error);
 	if (blob_fw == NULL)

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -650,8 +650,8 @@ fu_pxi_ble_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 9); /* ota-init */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 9, "ota-init");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "check-support-resume");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 1);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1);

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -543,7 +543,7 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 9); /* ota-init */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 9, "ota-init");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 1);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1);

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -577,7 +577,7 @@ fu_pxi_wireless_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 9); /* ota-init */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 9, "ota-init");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 1);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1);

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -767,7 +767,7 @@ fu_realtek_mst_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 70);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 9);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* flag */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "flag");
 
 	if (!mst_ensure_device_address(self, I2C_ADDR_ISP, error))
 		return FALSE;

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -452,11 +452,11 @@ fu_plugin_redfish_cleanup(FuPlugin *self,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 5);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 67);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 18);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 9);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "manager-reboot");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 5, "pre-delay");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 67, "poll-manager");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 18, "post-delay");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 9, "recoldplug");
 
 	/* ask the BMC to reboot */
 	json_builder_begin_object(builder);

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -298,7 +298,7 @@ fu_rts54hid_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 46);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 52);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* reset */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "reset");
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -208,9 +208,9 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* setup */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "setup");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 5); /* exit */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 5, "exit");
 
 	/* open device */
 	locker = fu_device_locker_new(self, error);

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -240,9 +240,9 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* setup */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "setup");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* finish */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "finish");
 
 	/* open device */
 	locker = fu_device_locker_new(self, error);

--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -110,7 +110,7 @@ fu_steelseries_fizz_tunnel_attach(FuDevice *device, FuProgress *progress, GError
 
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 67);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 67, "sleep");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 33);
 
 	if (!fu_steelseries_fizz_reset(parent,

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -610,8 +610,8 @@ fu_steelseries_sonic_attach(FuDevice *device, FuProgress *progress, GError **err
 	g_autofree gchar *msg = NULL;
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 50);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 50);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 50, "mouse");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_RESTART, 50, "holtek");
 
 	/* mouse */
 	chip = STEELSERIES_SONIC_CHIP_MOUSE;
@@ -813,9 +813,9 @@ fu_steelseries_sonic_read_firmware(FuDevice *device, FuProgress *progress, GErro
 		return NULL;
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 18);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 8);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 73);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 18, "nordic");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 8, "holtek");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_READ, 73, "mouse");
 
 	fu_archive_firmware_set_format(FU_ARCHIVE_FIRMWARE(firmware), FU_ARCHIVE_FORMAT_ZIP);
 	fu_archive_firmware_set_compression(FU_ARCHIVE_FIRMWARE(firmware),
@@ -866,12 +866,12 @@ fu_steelseries_sonic_write_firmware(FuDevice *device,
 	SteelseriesSonicChip chip;
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 34);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 30);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 17);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 7);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 8);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 3);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 34, "device-write-mouse");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 30, "device-verify-mouse");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 17, "device-write-nordic");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 7, "device-verify-nordic");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 8, "device-write-holtek");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_VERIFY, 3, "device-verify-holtek");
 
 	/* mouse */
 	chip = STEELSERIES_SONIC_CHIP_MOUSE;

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -343,7 +343,7 @@ fu_superio_it55_device_write_attempt(FuDevice *device,
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 80);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1); /* block 0 */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "device-write-blk0");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 9);
 
 	if (!fu_superio_it55_device_erase(device, error))

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -518,8 +518,8 @@ fu_superio_it89_device_write_chunk(FuSuperioDevice *self,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 1);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 21);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_ERASE, 1, "page-erase");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_ERASE, 21, "check-erase");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 59);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 20);
 
@@ -667,7 +667,7 @@ fu_superio_it89_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5); /* check e-flash */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "check-eflash");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 95);
 
 	/* check JEDEC ID */

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -703,7 +703,7 @@ fu_synaptics_cape_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 2); /* header */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 2, "device-write-hdr");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 69);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 0);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 29);

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -626,11 +626,11 @@ fu_synaptics_cxaudio_device_write_firmware(FuDevice *device,
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 3); /* park */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* init */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 3, "park");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "init");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* invalidate */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1); /* unpark */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "invalidate");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "unpark");
 
 	/* check if a patch file fits completely into the EEPROM */
 	for (guint i = 0; i < records->len; i++) {

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -259,10 +259,10 @@ fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "enter-iep");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "cfg-image");
 
 	/* we should be in bootloader mode now, but check anyway */
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -347,11 +347,11 @@ fu_synaptics_rmi_v7_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "disable-sleep");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 20, "flash-config");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 20, "core-code");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 20, "core-config");
 
 	/* we should be in bootloader mode now, but check anyway */
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -404,9 +404,9 @@ main(int argc, char *argv[])
 		/* progress */
 		fu_progress_set_id(progress, G_STRLOC);
 		fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);   /* prepare */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "prepare");
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98); /* write */
-		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);   /* cleanup */
+		fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "cleanup");
 
 		/* load SMBIOS */
 		if (!fu_context_load_hwinfo(ctx, &error_local)) {

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -558,9 +558,9 @@ fu_usi_dock_mcu_device_write_firmware_with_idx(FuUsiDockMcuDevice *self,
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 6);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 40);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 13);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 42);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 40, "write-external");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 13, "wait-for-checksum");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 42, "internal-flash");
 
 	/* initial external flash */
 	cmd = USBUID_ISP_DEVICE_CMD_FWBUFER_INITIAL;

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -290,7 +290,7 @@ fu_vli_device_spi_write(FuVliDevice *self,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 99);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 1); /* chk0 */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 1, "device-write-chk0");
 
 	/* write SPI data, then CRC bytes last */
 	g_debug("writing 0x%x bytes @0x%x", (guint)bufsz, address);

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -500,9 +500,9 @@ fu_vli_pd_device_write_dual_firmware(FuVliPdDevice *self,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* crc */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 45);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 45);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "crc");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 45, "backup");
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_WRITE, 45, "primary");
 
 	/* check spi fw1 crc16 */
 	spi_fw = fu_vli_device_spi_read(FU_VLI_DEVICE(self),

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1092,7 +1092,7 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 72);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 20);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 8); /* HD2 */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 8, "hd2");
 
 	/* make space */
 	if (!fu_vli_device_spi_erase(FU_VLI_DEVICE(self),

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -322,9 +322,9 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10); /* enable ISP */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "enable-isp");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10); /* restart */
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10);
 
 	/* open device */
 	locker = fu_device_locker_new(parent, error);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2970,9 +2970,9 @@ fu_engine_install_blob(FuEngine *self,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);   /* prepare */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98); /* write */
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1);   /* cleanup */
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "prepare");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98);
+	fu_progress_add_step_full(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "cleanup");
 
 	/* test the firmware is not an empty blob */
 	if (g_bytes_get_size(blob_fw) == 0) {


### PR DESCRIPTION
This allows us to print better warning strings, and in the future
would allow us to profile each operation in a meaningful way.

Also, add context to some of the progress steps as required.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
