### PR TITLE
Add FuProgress to ->startup() and ->coldplug()

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -56,7 +56,7 @@ is taken automatically from the suffix of the `.so` file.
     }
 
     static gboolean
-    fu_plugin_foo_startup(FuPlugin *plugin, GError **error)
+    fu_plugin_foo_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
     {
         FuPluginData *data = fu_plugin_get_data(plugin);
         data->proxy = create_proxy();
@@ -92,7 +92,7 @@ derive the details about the `FuDevice` from the hardware, for example reading
 data from `sysfs` or `/dev`.
 
     static gboolean
-    fu_plugin_foo_coldplug(FuPlugin *plugin, GError **error)
+    fu_plugin_foo_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
     {
         g_autoptr(FuDevice) dev = NULL;
         fu_device_set_id(dev, "dummy-1:2:3");

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -54,3 +54,7 @@ Remember: Plugins should be upstream!
 * `fu_plugin_has_custom_flag()`: Use `fu_plugin_has_private_flag()` instead.
 * `fu_efivar_secure_boot_enabled_full()`: Use `fu_efivar_secure_boot_enabled()` instead -- as the latter always specifies the error.
 * `fu_progress_add_step()`: Add a 4th parameter to the function to specify the nice name for the step, or NULL.
+* `fu_backend_setup()`: Now requires a `FuProgress`, although it can be ignored.
+* `fu_backend_coldplug`: Now requires a `FuProgress`, although it can be ignored.
+* `FuPluginVfuncs->setup`: Now requires a `FuProgress`, although it can be ignored.
+* `FuPluginVfuncs->coldplug`: Now requires a `FuProgress`, although it can be ignored.

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -160,6 +160,7 @@ fu_backend_invalidate(FuBackend *self)
 /**
  * fu_backend_setup:
  * @self: a #FuBackend
+ * @progress: a #FuProgress
  * @error: (nullable): optional return location for an error
  *
  * Sets up the backend ready for use, which typically calls the subclassed setup
@@ -170,7 +171,7 @@ fu_backend_invalidate(FuBackend *self)
  * Since: 1.6.1
  **/
 gboolean
-fu_backend_setup(FuBackend *self, GError **error)
+fu_backend_setup(FuBackend *self, FuProgress *progress, GError **error)
 {
 	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
 	FuBackendPrivate *priv = GET_PRIVATE(self);
@@ -181,7 +182,7 @@ fu_backend_setup(FuBackend *self, GError **error)
 	if (priv->done_setup)
 		return TRUE;
 	if (klass->setup != NULL) {
-		if (!klass->setup(self, error)) {
+		if (!klass->setup(self, progress, error)) {
 			priv->enabled = FALSE;
 			return FALSE;
 		}
@@ -193,6 +194,7 @@ fu_backend_setup(FuBackend *self, GError **error)
 /**
  * fu_backend_coldplug:
  * @self: a #FuBackend
+ * @progress: a #FuProgress
  * @error: (nullable): optional return location for an error
  *
  * Adds devices using the subclassed backend. If fu_backend_setup() has not
@@ -203,16 +205,16 @@ fu_backend_setup(FuBackend *self, GError **error)
  * Since: 1.6.1
  **/
 gboolean
-fu_backend_coldplug(FuBackend *self, GError **error)
+fu_backend_coldplug(FuBackend *self, FuProgress *progress, GError **error)
 {
 	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
 	g_return_val_if_fail(FU_IS_BACKEND(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-	if (!fu_backend_setup(self, error))
+	if (!fu_backend_setup(self, progress, error))
 		return FALSE;
 	if (klass->coldplug == NULL)
 		return TRUE;
-	return klass->coldplug(self, error);
+	return klass->coldplug(self, progress, error);
 }
 
 /**

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -15,8 +15,12 @@ G_DECLARE_DERIVABLE_TYPE(FuBackend, fu_backend, FU, BACKEND, GObject)
 struct _FuBackendClass {
 	GObjectClass parent_class;
 	/* signals */
-	gboolean (*setup)(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
-	gboolean (*coldplug)(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+	gboolean (*setup)(FuBackend *self,
+			  FuProgress *progress,
+			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+	gboolean (*coldplug)(FuBackend *self,
+			     FuProgress *progress,
+			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	void (*registered)(FuBackend *self, FuDevice *device);
 	void (*invalidate)(FuBackend *self);
 	/*< private >*/
@@ -36,9 +40,11 @@ fu_backend_get_devices(FuBackend *self);
 FuDevice *
 fu_backend_lookup_by_id(FuBackend *self, const gchar *device_id);
 gboolean
-fu_backend_setup(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_backend_setup(FuBackend *self, FuProgress *progress, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_backend_coldplug(FuBackend *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_backend_coldplug(FuBackend *self,
+		    FuProgress *progress,
+		    GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_backend_device_added(FuBackend *self, FuDevice *device);
 void

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -37,9 +37,13 @@ fu_plugin_open(FuPlugin *self, const gchar *filename, GError **error) G_GNUC_WAR
 void
 fu_plugin_runner_init(FuPlugin *self);
 gboolean
-fu_plugin_runner_startup(FuPlugin *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_plugin_runner_startup(FuPlugin *self,
+			 FuProgress *progress,
+			 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
-fu_plugin_runner_coldplug(FuPlugin *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_plugin_runner_coldplug(FuPlugin *self,
+			  FuProgress *progress,
+			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fu_plugin_runner_prepare(FuPlugin *self,
 			 FuDevice *device,

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -773,7 +773,7 @@ fu_plugin_device_read_firmware(FuPlugin *self,
  * Since: 0.8.0
  **/
 gboolean
-fu_plugin_runner_startup(FuPlugin *self, GError **error)
+fu_plugin_runner_startup(FuPlugin *self, FuProgress *progress, GError **error)
 {
 	FuPluginPrivate *priv = GET_PRIVATE(self);
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
@@ -794,7 +794,7 @@ fu_plugin_runner_startup(FuPlugin *self, GError **error)
 	if (vfuncs->startup == NULL)
 		return TRUE;
 	g_debug("startup(%s)", fu_plugin_get_name(self));
-	if (!vfuncs->startup(self, &error_local)) {
+	if (!vfuncs->startup(self, progress, &error_local)) {
 		if (error_local == NULL) {
 			g_critical("unset plugin error in startup(%s)", fu_plugin_get_name(self));
 			g_set_error_literal(&error_local,
@@ -1008,6 +1008,7 @@ fu_plugin_runner_device_array_generic(FuPlugin *self,
 /**
  * fu_plugin_runner_coldplug:
  * @self: a #FuPlugin
+ * @progress: a #FuProgress
  * @error: (nullable): optional return location for an error
  *
  * Runs the coldplug routine for the plugin
@@ -1017,7 +1018,7 @@ fu_plugin_runner_device_array_generic(FuPlugin *self,
  * Since: 0.8.0
  **/
 gboolean
-fu_plugin_runner_coldplug(FuPlugin *self, GError **error)
+fu_plugin_runner_coldplug(FuPlugin *self, FuProgress *progress, GError **error)
 {
 	FuPluginPrivate *priv = GET_PRIVATE(self);
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
@@ -1037,7 +1038,7 @@ fu_plugin_runner_coldplug(FuPlugin *self, GError **error)
 	if (vfuncs->coldplug == NULL)
 		return TRUE;
 	g_debug("coldplug(%s)", fu_plugin_get_name(self));
-	if (!vfuncs->coldplug(self, &error_local)) {
+	if (!vfuncs->coldplug(self, progress, &error_local)) {
 		if (error_local == NULL) {
 			g_critical("unset plugin error in coldplug(%s)", fu_plugin_get_name(self));
 			g_set_error_literal(&error_local,

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -110,6 +110,7 @@ typedef struct {
 	/**
 	 * startup:
 	 * @self: a #FuPlugin
+	 * @progress: a #FuProgress
 	 * @error: (nullable): optional return location for an error
 	 *
 	 * Tries to start the plugin.
@@ -121,17 +122,18 @@ typedef struct {
 	 *
 	 * Since: 1.7.2
 	 **/
-	gboolean (*startup)(FuPlugin *self, GError **error);
+	gboolean (*startup)(FuPlugin *self, FuProgress *progress, GError **error);
 	/**
 	 * coldplug:
 	 * @self: a #FuPlugin
+	 * @progress: a #FuProgress
 	 * @error: (nullable): optional return location for an error
 	 *
 	 * Probes for devices.
 	 *
 	 * Since: 1.7.2
 	 **/
-	gboolean (*coldplug)(FuPlugin *self, GError **error);
+	gboolean (*coldplug)(FuPlugin *self, FuProgress *progress, GError **error);
 	/**
 	 * device_created
 	 * @self: a #FuPlugin

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2033,6 +2033,7 @@ fu_backend_func(void)
 	g_autoptr(FuBackend) backend = g_object_new(FU_TYPE_BACKEND, NULL);
 	g_autoptr(FuDevice) dev1 = fu_device_new(NULL);
 	g_autoptr(FuDevice) dev2 = fu_device_new(NULL);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 
@@ -2041,10 +2042,10 @@ fu_backend_func(void)
 	g_assert_true(fu_backend_get_enabled(backend));
 
 	/* load */
-	ret = fu_backend_setup(backend, &error);
+	ret = fu_backend_setup(backend, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_backend_coldplug(backend, &error);
+	ret = fu_backend_coldplug(backend, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3805,6 +3806,7 @@ fu_progress_child_func(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* reset */
+	fu_progress_set_profile(progress, TRUE);
 	fu_progress_set_steps(progress, 2);
 	g_signal_connect(FU_PROGRESS(progress),
 			 "percentage-changed",

--- a/plugins/acpi-phat/fu-plugin-acpi-phat.c
+++ b/plugins/acpi-phat/fu-plugin-acpi-phat.c
@@ -23,7 +23,7 @@ fu_plugin_acpi_phat_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_acpi_phat_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_acpi_phat_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	g_autofree gchar *path = NULL;
 	g_autofree gchar *fn = NULL;

--- a/plugins/bios/fu-plugin-bios.c
+++ b/plugins/bios/fu-plugin-bios.c
@@ -9,7 +9,7 @@
 #include <fwupdplugin.h>
 
 static gboolean
-fu_plugin_bios_startup(FuPlugin *plugin, GError **error)
+fu_plugin_bios_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	const gchar *vendor;
@@ -24,7 +24,7 @@ fu_plugin_bios_startup(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_bios_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_bios_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	g_autofree gchar *sysfsfwdir = NULL;
 	g_autofree gchar *esrt_path = NULL;

--- a/plugins/cpu/fu-plugin-cpu.c
+++ b/plugins/cpu/fu-plugin-cpu.c
@@ -17,14 +17,24 @@ fu_plugin_cpu_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_cpu_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_cpu_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	g_autoptr(FuCpuDevice) dev = fu_cpu_device_new(ctx);
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 99, "probe");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "setup");
+
 	if (!fu_device_probe(FU_DEVICE(dev), error))
 		return FALSE;
+	fu_progress_step_done(progress);
+
 	if (!fu_device_setup(FU_DEVICE(dev), error))
 		return FALSE;
+	fu_progress_step_done(progress);
+
 	fu_plugin_cache_add(plugin, "cpu", dev);
 	fu_plugin_device_add(plugin, FU_DEVICE(dev));
 	return TRUE;

--- a/plugins/dell-esrt/fu-plugin-dell-esrt.c
+++ b/plugins/dell-esrt/fu-plugin-dell-esrt.c
@@ -94,7 +94,7 @@ fu_plugin_dell_esrt_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_dell_esrt_startup(FuPlugin *plugin, GError **error)
+fu_plugin_dell_esrt_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	gboolean capsule_disable = FALSE;
 	g_autofree gchar *sysfsfwdir = NULL;
@@ -155,7 +155,7 @@ fu_plugin_dell_esrt_unlock(FuPlugin *plugin, FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_plugin_dell_esrt_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_dell_esrt_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	g_autoptr(FuDevice) dev = fu_device_new(NULL);
 

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -901,7 +901,7 @@ fu_plugin_dell_destroy(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_dell_startup(FuPlugin *plugin, GError **error)
+fu_plugin_dell_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *sysfsfwdir = NULL;
@@ -951,7 +951,7 @@ fu_plugin_dell_startup(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_dell_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_dell_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	/* look for switchable TPM */
 	if (!fu_plugin_dell_detect_tpm(plugin, error))

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -102,7 +102,7 @@ fu_plugin_dell_tpm_func(gconstpointer user_data)
 				       "device-register",
 				       G_CALLBACK(fu_engine_plugin_device_register_cb),
 				       self->plugin_uefi_capsule);
-	ret = fu_plugin_runner_coldplug(self->plugin_dell, &error);
+	ret = fu_plugin_runner_coldplug(self->plugin_dell, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -506,6 +506,7 @@ fu_test_self_init(FuTest *self)
 {
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *pluginfn_uefi = NULL;
 	g_autofree gchar *pluginfn_dell = NULL;
@@ -524,7 +525,7 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_open(self->plugin_uefi_capsule, pluginfn_uefi, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, &error);
+	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -534,7 +535,7 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_open(self->plugin_dell, pluginfn_dell, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(self->plugin_dell, &error);
+	ret = fu_plugin_runner_startup(self->plugin_dell, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }

--- a/plugins/intel-spi/fu-plugin-intel-spi.c
+++ b/plugins/intel-spi/fu-plugin-intel-spi.c
@@ -27,7 +27,7 @@ fu_plugin_intel_spi_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_intel_spi_startup(FuPlugin *plugin, GError **error)
+fu_plugin_intel_spi_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	if (fu_common_kernel_locked_down()) {
 		g_set_error_literal(error,

--- a/plugins/lenovo-thinklmi/fu-plugin-lenovo-thinklmi.c
+++ b/plugins/lenovo-thinklmi/fu-plugin-lenovo-thinklmi.c
@@ -9,7 +9,7 @@
 #include <fwupdplugin.h>
 
 static gboolean
-fu_plugin_lenovo_thinklmi_startup(FuPlugin *plugin, GError **error)
+fu_plugin_lenovo_thinklmi_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	g_autofree gchar *sysfsfwdir = NULL;
 	g_autofree gchar *thinklmidir = NULL;

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -32,6 +32,7 @@ fu_test_self_init(FuTest *self)
 {
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *pluginfn_uefi = NULL;
 	g_autofree gchar *pluginfn_lenovo = NULL;
@@ -51,7 +52,7 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_open(self->plugin_uefi_capsule, pluginfn_uefi, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, &error);
+	ret = fu_plugin_runner_startup(self->plugin_uefi_capsule, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -62,7 +63,7 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_open(self->plugin_lenovo_thinklmi, pluginfn_lenovo, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(self->plugin_lenovo_thinklmi, &error);
+	ret = fu_plugin_runner_startup(self->plugin_lenovo_thinklmi, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }
@@ -73,6 +74,7 @@ fu_test_probe_fake_esrt(FuTest *self)
 	gboolean ret;
 	gulong added_id;
 	FuDevice *dev = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 
 	added_id = g_signal_connect(FU_PLUGIN(self->plugin_uefi_capsule),
@@ -80,7 +82,7 @@ fu_test_probe_fake_esrt(FuTest *self)
 				    G_CALLBACK(_plugin_device_added_cb),
 				    &dev);
 
-	ret = fu_plugin_runner_coldplug(self->plugin_uefi_capsule, &error);
+	ret = fu_plugin_runner_coldplug(self->plugin_uefi_capsule, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_nonnull(dev);

--- a/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
+++ b/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
@@ -94,7 +94,7 @@ fu_plugin_linux_lockdown_changed_cb(GFileMonitor *monitor,
 }
 
 static gboolean
-fu_plugin_linux_lockdown_startup(FuPlugin *plugin, GError **error)
+fu_plugin_linux_lockdown_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *path = NULL;

--- a/plugins/linux-swap/fu-plugin-linux-swap.c
+++ b/plugins/linux-swap/fu-plugin-linux-swap.c
@@ -46,7 +46,7 @@ fu_plugin_linux_swap_changed_cb(GFileMonitor *monitor,
 }
 
 static gboolean
-fu_plugin_linux_swap_startup(FuPlugin *plugin, GError **error)
+fu_plugin_linux_swap_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *fn = NULL;

--- a/plugins/linux-tainted/fu-plugin-linux-tainted.c
+++ b/plugins/linux-tainted/fu-plugin-linux-tainted.c
@@ -44,7 +44,7 @@ fu_plugin_linux_tainted_changed_cb(GFileMonitor *monitor,
 }
 
 static gboolean
-fu_plugin_linux_tainted_startup(FuPlugin *plugin, GError **error)
+fu_plugin_linux_tainted_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *fn = NULL;

--- a/plugins/logind/fu-plugin-logind.c
+++ b/plugins/logind/fu-plugin-logind.c
@@ -33,7 +33,7 @@ fu_plugin_logind_destroy(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_logind_startup(FuPlugin *plugin, GError **error)
+fu_plugin_logind_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *name_owner = NULL;

--- a/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
+++ b/plugins/logitech-hidpp/fu-plugin-logitech-hidpp.c
@@ -16,7 +16,7 @@
 #include "fu-logitech-hidpp-runtime-unifying.h"
 
 static gboolean
-fu_plugin_logitech_hidpp_startup(FuPlugin *plugin, GError **error)
+fu_plugin_logitech_hidpp_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	/* check the kernel has CONFIG_HIDRAW */
 	if (!g_file_test("/sys/class/hidraw", G_FILE_TEST_IS_DIR)) {

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -368,7 +368,7 @@ fu_plugin_mm_name_owner_updated(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_mm_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_mm_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
 	g_signal_connect_swapped(MM_MANAGER(priv->manager),
@@ -395,7 +395,7 @@ fu_plugin_mm_modem_power_changed_cb(GFileMonitor *monitor,
 }
 
 static gboolean
-fu_plugin_mm_startup(FuPlugin *plugin, GError **error)
+fu_plugin_mm_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
 	g_autoptr(GDBusConnection) connection = NULL;

--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -59,7 +59,7 @@ fu_plugin_msr_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_msr_startup(FuPlugin *plugin, GError **error)
+fu_plugin_msr_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
 	guint eax = 0;

--- a/plugins/mtd/fu-plugin-mtd.c
+++ b/plugins/mtd/fu-plugin-mtd.c
@@ -18,7 +18,7 @@ fu_plugin_mtd_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_mtd_startup(FuPlugin *plugin, GError **error)
+fu_plugin_mtd_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 #ifndef HAVE_MTD_USER_H
 	g_set_error_literal(error,

--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -95,7 +95,7 @@ fu_plugin_powerd_proxy_changed_cb(GDBusProxy *proxy,
 }
 
 static gboolean
-fu_plugin_powerd_startup(FuPlugin *plugin, GError **error)
+fu_plugin_powerd_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *name_owner = NULL;

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -222,7 +222,7 @@ fu_redfish_backend_set_push_uri_path(FuRedfishBackend *self, const gchar *push_u
 }
 
 static gboolean
-fu_redfish_backend_coldplug(FuBackend *backend, GError **error)
+fu_redfish_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuRedfishBackend *self = FU_REDFISH_BACKEND(backend);
 	JsonObject *json_obj;
@@ -303,7 +303,7 @@ fu_redfish_backend_set_update_uri_path(FuRedfishBackend *self, const gchar *upda
 }
 
 static gboolean
-fu_redfish_backend_setup(FuBackend *backend, GError **error)
+fu_redfish_backend_setup(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuRedfishBackend *self = FU_REDFISH_BACKEND(backend);
 	JsonObject *json_obj;

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -35,6 +35,7 @@ fu_test_self_init(FuTest *self)
 {
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *pluginfn = NULL;
 
@@ -59,14 +60,14 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_open(self->plugin, pluginfn, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(self->plugin, &error);
+	ret = fu_plugin_runner_startup(self->plugin, progress, &error);
 	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE)) {
 		g_test_skip("no redfish.py running");
 		return;
 	}
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_coldplug(self->plugin, &error);
+	ret = fu_plugin_runner_coldplug(self->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -96,7 +96,7 @@ fu_plugin_superio_load(FuContext *ctx)
 }
 
 static gboolean
-fu_plugin_superio_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_superio_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	GPtrArray *hwids;

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -68,6 +68,7 @@ fu_plugin_synaptics_mst_none_func(void)
 	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
@@ -88,7 +89,7 @@ fu_plugin_synaptics_mst_none_func(void)
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(plugin, &error);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
 	if (!ret && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 		g_test_skip("Skipping tests due to unsupported configuration");
 		return;
@@ -112,6 +113,7 @@ fu_plugin_synaptics_mst_tb16_func(void)
 	gboolean ret;
 	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices =
@@ -133,7 +135,7 @@ fu_plugin_synaptics_mst_tb16_func(void)
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(plugin, &error);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
 	if (!ret && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 		g_test_skip("Skipping tests due to unsupported configuration");
 		return;

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -63,7 +63,7 @@ fu_plugin_test_load_xml(FuPlugin *plugin, const gchar *xml, GError **error)
 }
 
 static gboolean
-fu_plugin_test_startup(FuPlugin *plugin, GError **error)
+fu_plugin_test_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	const gchar *xml = g_getenv("FWUPD_TEST_PLUGIN_XML");
 	if (xml != NULL) {
@@ -74,7 +74,7 @@ fu_plugin_test_startup(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_test_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_test_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	g_autoptr(FuDevice) device = NULL;

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -69,7 +69,7 @@ fu_plugin_thunderbolt_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_thunderbolt_startup(FuPlugin *plugin, GError **error)
+fu_plugin_thunderbolt_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	return fu_plugin_thunderbolt_safe_kernel(plugin, error);
 }

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -921,6 +921,7 @@ test_set_up(ThunderboltTest *tt, gconstpointer params)
 	g_autofree gchar *pluginfn = NULL;
 	g_autofree gchar *sysfs = NULL;
 	g_autoptr(GError) error = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	const gchar *udev_subsystems[] = {"thunderbolt", NULL};
 
 	tt->ctx = fu_context_new();
@@ -946,7 +947,7 @@ test_set_up(ThunderboltTest *tt, gconstpointer params)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_plugin_runner_startup(tt->plugin, &error);
+	ret = fu_plugin_runner_startup(tt->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -324,7 +324,7 @@ fu_plugin_tpm_coldplug_eventlog(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_tpm_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_tpm_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
 
@@ -337,7 +337,7 @@ fu_plugin_tpm_coldplug(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_tpm_startup(FuPlugin *plugin, GError **error)
+fu_plugin_tpm_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *sysfstpmdir = NULL;

--- a/plugins/tpm/fu-self-test.c
+++ b/plugins/tpm/fu-self-test.c
@@ -25,6 +25,7 @@ fu_tpm_device_1_2_func(void)
 	g_autofree gchar *pluginfn = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
 	g_autoptr(FwupdSecurityAttr) attr0 = NULL;
 	g_autoptr(FwupdSecurityAttr) attr1 = NULL;
@@ -42,7 +43,7 @@ fu_tpm_device_1_2_func(void)
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(plugin, &error);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -195,6 +196,7 @@ fu_tpm_empty_pcr_func(void)
 	g_auto(GStrv) environ_old = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 	g_autoptr(GError) error = NULL;
@@ -214,7 +216,7 @@ fu_tpm_empty_pcr_func(void)
 	ret = fu_plugin_open(plugin, pluginfn, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_plugin_runner_startup(plugin, &error);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -180,6 +180,7 @@ fu_uefi_plugin_func(void)
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuBackend) backend = fu_uefi_backend_new(ctx);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 
@@ -194,7 +195,7 @@ fu_uefi_plugin_func(void)
 	g_assert_true(ret);
 
 	/* add each device */
-	ret = fu_backend_coldplug(backend, &error);
+	ret = fu_backend_coldplug(backend, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	devices = fu_backend_get_devices(backend);
@@ -243,6 +244,7 @@ fu_uefi_update_info_func(void)
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuBackend) backend = fu_uefi_backend_new(ctx);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuUefiUpdateInfo) info = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
@@ -253,7 +255,7 @@ fu_uefi_update_info_func(void)
 #endif
 
 	/* add each device */
-	ret = fu_backend_coldplug(backend, &error);
+	ret = fu_backend_coldplug(backend, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/uefi-capsule/fu-uefi-backend-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-linux.c
@@ -124,7 +124,7 @@ fu_uefi_backend_linux_check_efivarfs(FuUefiBackendLinux *self, GError **error)
 }
 
 static gboolean
-fu_uefi_backend_linux_coldplug(FuBackend *backend, GError **error)
+fu_uefi_backend_linux_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuUefiBackendLinux *self = FU_UEFI_BACKEND_LINUX(backend);
 	const gchar *fn;
@@ -199,7 +199,7 @@ fu_uefi_backend_linux_check_smbios_enabled(FuContext *ctx, GError **error)
 }
 
 static gboolean
-fu_uefi_backend_linux_setup(FuBackend *backend, GError **error)
+fu_uefi_backend_linux_setup(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
 

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -277,6 +277,7 @@ main(int argc, char *argv[])
 	if (action_list || action_supported || action_info) {
 		g_autoptr(FuContext) ctx = fu_context_new();
 		g_autoptr(FuBackend) backend = fu_uefi_backend_new(ctx);
+		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 		g_autoptr(GError) error_local = NULL;
 
 		/* load SMBIOS */
@@ -286,7 +287,7 @@ main(int argc, char *argv[])
 		}
 
 		/* add each device */
-		if (!fu_backend_coldplug(backend, &error_local)) {
+		if (!fu_backend_coldplug(backend, progress, &error_local)) {
 			g_printerr("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}

--- a/plugins/uefi-dbx/fu-plugin-uefi-dbx.c
+++ b/plugins/uefi-dbx/fu-plugin-uefi-dbx.c
@@ -18,14 +18,24 @@ fu_plugin_uefi_dbx_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_uefi_dbx_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_uefi_dbx_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	g_autoptr(FuUefiDbxDevice) device = fu_uefi_dbx_device_new(ctx);
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 99, "probe");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "setup");
+
 	if (!fu_device_probe(FU_DEVICE(device), error))
 		return FALSE;
+	fu_progress_step_done(progress);
+
 	if (!fu_device_setup(FU_DEVICE(device), error))
 		return FALSE;
+	fu_progress_step_done(progress);
+
 	if (fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "no-dbx-updates")) {
 		fu_device_inhibit(FU_DEVICE(device),
 				  "no-dbx",

--- a/plugins/uefi-pk/fu-plugin-uefi-pk.c
+++ b/plugins/uefi-pk/fu-plugin-uefi-pk.c
@@ -116,7 +116,7 @@ fu_plugin_uefi_pk_parse_signature(FuPlugin *plugin, FuEfiSignature *sig, GError 
 }
 
 static gboolean
-fu_plugin_uefi_pk_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_uefi_pk_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
 	g_autoptr(FuFirmware) img = NULL;

--- a/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
+++ b/plugins/uefi-recovery/fu-plugin-uefi-recovery.c
@@ -17,7 +17,7 @@ fu_plugin_uefi_recovery_init(FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_uefi_recovery_startup(FuPlugin *plugin, GError **error)
+fu_plugin_uefi_recovery_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	/* are the EFI dirs set up so we can update each device */
 	if (!fu_efivar_supported(error))
@@ -26,7 +26,7 @@ fu_plugin_uefi_recovery_startup(FuPlugin *plugin, GError **error)
 }
 
 static gboolean
-fu_plugin_uefi_recovery_coldplug(FuPlugin *plugin, GError **error)
+fu_plugin_uefi_recovery_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	GPtrArray *hwids = fu_context_get_hwid_guids(ctx);

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -133,7 +133,7 @@ fu_plugin_upower_proxy_changed_cb(GDBusProxy *proxy,
 }
 
 static gboolean
-fu_plugin_upower_startup(FuPlugin *plugin, GError **error)
+fu_plugin_upower_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data(plugin);
 	g_autofree gchar *name_owner = NULL;

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -156,7 +156,7 @@ fu_bluez_backend_timeout_cb(gpointer user_data)
 }
 
 static gboolean
-fu_bluez_backend_setup(FuBackend *backend, GError **error)
+fu_bluez_backend_setup(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuBluezBackend *self = FU_BLUEZ_BACKEND(backend);
 	g_autoptr(FuBluezBackendHelper) helper = g_new0(FuBluezBackendHelper, 1);
@@ -195,7 +195,7 @@ fu_bluez_backend_setup(FuBackend *backend, GError **error)
 }
 
 static gboolean
-fu_bluez_backend_coldplug(FuBackend *backend, GError **error)
+fu_bluez_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuBluezBackend *self = FU_BLUEZ_BACKEND(backend);
 	g_autolist(GDBusObject) objects = NULL;

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -53,7 +53,7 @@ fu_engine_add_plugin_filter(FuEngine *self, const gchar *plugin_glob);
 void
 fu_engine_idle_reset(FuEngine *self);
 gboolean
-fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, GError **error);
+fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GError **error);
 gboolean
 fu_engine_get_tainted(FuEngine *self);
 gboolean

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -123,6 +123,7 @@ fu_engine_generate_md_func(gconstpointer user_data)
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GBytes) data = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(XbNode) component = NULL;
@@ -142,6 +143,7 @@ fu_engine_generate_md_func(gconstpointer user_data)
 	/* load engine and check the device was found */
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
+			     progress,
 			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -168,10 +170,11 @@ fu_plugin_hash_func(gconstpointer user_data)
 	GError *error = NULL;
 	g_autofree gchar *pluginfn = NULL;
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(NULL);
 	gboolean ret = FALSE;
 
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1446,6 +1449,7 @@ fu_engine_device_unlock_func(gconstpointer user_data)
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GFile) file = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
@@ -1453,7 +1457,7 @@ fu_engine_device_unlock_func(gconstpointer user_data)
 	g_autoptr(XbSilo) silo = NULL;
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1491,6 +1495,7 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(GBytes) blob_cab = NULL;
 	g_autoptr(GError) error = NULL;
@@ -1508,7 +1513,7 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	fu_engine_set_silo(engine, silo_empty);
 
 	/* load engine to get FuConfig set up */
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -1565,6 +1570,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GPtrArray) devices_pre = NULL;
@@ -1664,6 +1670,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
+			     progress,
 			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1752,6 +1759,7 @@ fu_engine_install_duration_func(gconstpointer user_data)
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
 	g_autoptr(FuEngine) engine = fu_engine_new(FU_APP_FLAGS_NONE);
 	g_autoptr(FuEngineRequest) request = fu_engine_request_new(FU_ENGINE_REQUEST_KIND_ACTIVE);
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 	g_autoptr(GPtrArray) releases = NULL;
@@ -1790,6 +1798,7 @@ fu_engine_install_duration_func(gconstpointer user_data)
 
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_NO_CACHE,
+			     progress,
 			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1859,7 +1868,7 @@ fu_engine_history_func(gconstpointer user_data)
 	/* set up dummy plugin */
 	fu_engine_add_plugin(engine, self->plugin);
 
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -2005,7 +2014,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	/* set up dummy plugin */
 	fu_engine_add_plugin(engine, self->plugin);
 
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -2075,6 +2084,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	}
 
 	/* install them */
+	fu_progress_reset(progress);
 	ret = fu_engine_install_releases(engine,
 					 request,
 					 releases,
@@ -2125,7 +2135,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	/* set up dummy plugin */
 	(void)g_setenv("FWUPD_PLUGIN_TEST", "fail", TRUE);
 	fu_engine_add_plugin(engine, self->plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -2264,7 +2274,7 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	/* set up dummy plugin */
 	(void)g_setenv("FWUPD_PLUGIN_TEST", "fail", TRUE);
 	fu_engine_add_plugin(engine, self->plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NONE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NONE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -2354,7 +2364,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	/* set up dummy plugin */
 	(void)g_setenv("FWUPD_PLUGIN_TEST", "fail", TRUE);
 	fu_engine_add_plugin(engine, self->plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, &error);
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3082,7 +3092,7 @@ fu_plugin_module_func(gconstpointer user_data)
 
 	/* create a fake device */
 	(void)g_setenv("FWUPD_PLUGIN_TEST", "registration", TRUE);
-	ret = fu_plugin_runner_startup(self->plugin, &error);
+	ret = fu_plugin_runner_startup(self->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_signal_connect(FU_PLUGIN(self->plugin),
@@ -3093,7 +3103,7 @@ fu_plugin_module_func(gconstpointer user_data)
 			 "device-register",
 			 G_CALLBACK(_plugin_device_register_cb),
 			 &device);
-	ret = fu_plugin_runner_coldplug(self->plugin, &error);
+	ret = fu_plugin_runner_coldplug(self->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3476,7 +3486,7 @@ fu_plugin_composite_func(gconstpointer user_data)
 	(void)g_setenv("FWUPD_PLUGIN_TEST", "composite", TRUE);
 	fu_engine_add_plugin(engine, self->plugin);
 
-	ret = fu_plugin_runner_startup(self->plugin, &error);
+	ret = fu_plugin_runner_startup(self->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	devices = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
@@ -3485,7 +3495,7 @@ fu_plugin_composite_func(gconstpointer user_data)
 			 G_CALLBACK(_plugin_composite_device_added_cb),
 			 devices);
 
-	ret = fu_plugin_runner_coldplug(self->plugin, &error);
+	ret = fu_plugin_runner_coldplug(self->plugin, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -270,7 +270,7 @@ fu_util_start_engine(FuUtilPrivate *priv, FuEngineLoadFlags flags, GError **erro
 			g_debug("Failed to stop daemon: %s", error_local->message);
 	}
 #endif
-	if (!fu_engine_load(priv->engine, flags, error))
+	if (!fu_engine_load(priv->engine, flags, priv->progress, error))
 		return FALSE;
 	if (fu_engine_get_tainted(priv->engine)) {
 		g_autofree gchar *fmt = NULL;
@@ -2109,7 +2109,7 @@ fu_util_get_firmware_types(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) firmware_types = NULL;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	firmware_types = fu_context_get_firmware_gtype_ids(fu_engine_get_context(priv->engine));
@@ -2180,7 +2180,7 @@ fu_util_firmware_parse(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -2234,7 +2234,7 @@ fu_util_firmware_export(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -2291,7 +2291,7 @@ fu_util_firmware_extract(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -2377,7 +2377,7 @@ fu_util_firmware_build(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* parse XML */
@@ -2477,7 +2477,7 @@ fu_util_firmware_convert(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* find the GType to use */
@@ -2606,7 +2606,7 @@ fu_util_firmware_patch(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* load engine */
-	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, error))
+	if (!fu_engine_load(priv->engine, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
 		return FALSE;
 
 	/* find the GType to use */

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -77,7 +77,7 @@ fu_usb_backend_context_finalized_cb(gpointer data, GObject *where_the_object_was
 }
 
 static gboolean
-fu_usb_backend_setup(FuBackend *backend, GError **error)
+fu_usb_backend_setup(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuUsbBackend *self = FU_USB_BACKEND(backend);
 
@@ -100,7 +100,7 @@ fu_usb_backend_setup(FuBackend *backend, GError **error)
 }
 
 static gboolean
-fu_usb_backend_coldplug(FuBackend *backend, GError **error)
+fu_usb_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
 {
 	FuUsbBackend *self = FU_USB_BACKEND(backend);
 	g_usb_context_enumerate(self->usb_ctx);


### PR DESCRIPTION
This allows us to profile the daemon startup so we can find any plugins
taking an inordinate amount of time to start.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
