### PR TITLE
corsair: Flush input endpoint before sending commands

### DIFF
--- a/plugins/corsair/fu-corsair-bp.h
+++ b/plugins/corsair/fu-corsair-bp.h
@@ -17,6 +17,9 @@ struct _FuCorsairBpClass {
 	FuUsbDeviceClass parent_class;
 };
 
+void
+fu_corsair_bp_flush_input_reports(FuCorsairBp *self);
+
 gboolean
 fu_corsair_bp_get_property(FuCorsairBp *self,
 			   FuCorsairBpProperty property,

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -198,6 +198,9 @@ fu_corsair_device_setup(FuDevice *device, GError **error)
 	g_autofree gchar *version = NULL;
 	FuCorsairDevice *self = FU_CORSAIR_DEVICE(device);
 
+	if (!fu_device_has_private_flag(device, FU_CORSAIR_DEVICE_FLAG_IS_SUBDEVICE))
+		fu_corsair_bp_flush_input_reports(self->bp);
+
 	if (!fu_corsair_bp_get_property(self->bp, FU_CORSAIR_BP_PROPERTY_MODE, &mode, error))
 		return FALSE;
 	if (mode == FU_CORSAIR_DEVICE_MODE_BOOTLOADER)


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [*] Code fix
- [ ] Feature
- [ ] Documentation

This fixes cases when a device sends spurious report after the enumeration. Flushing happens in ->setup() before sending commands. Flushing is done by reading data from an endpoint and ignoring it.