### PR TITLE
Add startup profiling functionality

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -17,6 +17,7 @@ with a non-standard filesystem layout.
 * `FWUPD_XMLB_VERBOSE` can be set to show Xmlb silo regeneration and quirk matches
 * `FWUPD_DBUS_SOCKET` is used to set the socket filename if running without a dbus-daemon
 * `FWUPD_DOWNLOAD_VERBOSE` can be used to show wget or curl output
+* `FWUPD_PROFILE` can be used to set the profile traceback threshold value in ms
 * standard glibc variables like `LANG` are also honored for CLI tools that are translated
 * libcurl respects the session proxy, e.g. `http_proxy`, `all_proxy`, `sftp_proxy` and `no_proxy`
 

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -73,6 +73,15 @@ typedef guint64 FuProgressFlags;
  */
 #define FU_PROGRESS_FLAG_CHILD_FINISHED (1ull << 2)
 
+/**
+ * FU_PROGRESS_FLAG_NO_TRACEBACK:
+ *
+ * The steps should not be shown in the traceback.
+ *
+ * Since: 1.8.2
+ */
+#define FU_PROGRESS_FLAG_NO_TRACEBACK (1ull << 3)
+
 FuProgress *
 fu_progress_new(const gchar *id);
 const gchar *
@@ -103,8 +112,12 @@ void
 fu_progress_set_percentage_full(FuProgress *self, gsize progress_done, gsize progress_total);
 guint
 fu_progress_get_percentage(FuProgress *self);
+gdouble
+fu_progress_get_duration(FuProgress *self);
 void
 fu_progress_set_profile(FuProgress *self, gboolean profile);
+gboolean
+fu_progress_get_profile(FuProgress *self);
 void
 fu_progress_reset(FuProgress *self);
 void
@@ -121,3 +134,5 @@ FuProgress *
 fu_progress_get_child(FuProgress *self);
 void
 fu_progress_sleep(FuProgress *self, guint delay_ms);
+gchar *
+fu_progress_traceback(FuProgress *self);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3125,17 +3125,26 @@ fu_progress_func(void)
 			 G_CALLBACK(fu_progress_percentage_changed_cb),
 			 &helper);
 
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_duration(progress), 0.f, 0.001);
+
+	fu_progress_set_profile(progress, TRUE);
 	fu_progress_set_steps(progress, 5);
 	g_assert_cmpint(helper.last_percentage, ==, 0);
 
+	g_usleep(20 * 1000);
 	fu_progress_step_done(progress);
 	g_assert_cmpint(helper.updates, ==, 2);
 	g_assert_cmpint(helper.last_percentage, ==, 20);
 
-	for (guint i = 0; i < 4; i++)
+	for (guint i = 0; i < 4; i++) {
+		g_usleep(20 * 1000);
 		fu_progress_step_done(progress);
+	}
+
 	g_assert_cmpint(helper.last_percentage, ==, 100);
 	g_assert_cmpint(helper.updates, ==, 6);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_duration(progress), 0.1f, 0.01);
+	g_debug("\n%s", fu_progress_traceback(progress));
 }
 
 static void
@@ -3362,6 +3371,7 @@ main(int argc, char **argv)
 	(void)g_setenv("FWUPD_SYSCONFDIR", testdatadir, TRUE);
 	(void)g_setenv("FWUPD_OFFLINE_TRIGGER", "/tmp/fwupd-self-test/system-update", TRUE);
 	(void)g_setenv("FWUPD_LOCALSTATEDIR", "/tmp/fwupd-self-test/var", TRUE);
+	(void)g_setenv("FWUPD_PROFILE", "1", TRUE);
 
 	g_test_add_func("/fwupd/common{strnsplit}", fu_strsplit_func);
 	g_test_add_func("/fwupd/common{memmem}", fu_common_memmem_func);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -969,8 +969,11 @@ LIBFWUPDPLUGIN_1.8.2 {
     fu_path_mkdir_parent;
     fu_path_rmtree;
     fu_progress_add_step;
+    fu_progress_get_duration;
     fu_progress_get_name;
+    fu_progress_get_profile;
     fu_progress_set_name;
+    fu_progress_traceback;
     fu_string_append;
     fu_string_append_kb;
     fu_string_append_ku;

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -2242,6 +2242,13 @@ fu_daemon_setup(FuDaemon *self, const gchar *socket_address, GError **error)
 	}
 	fu_progress_step_done(progress);
 
+	/* a good place to do the traceback */
+	if (fu_progress_get_profile(progress)) {
+		g_autofree gchar *str = fu_progress_traceback(progress);
+		if (str != NULL)
+			g_print("\n%s\n", str);
+	}
+
 	/* success */
 	return TRUE;
 }

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3981,6 +3981,13 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	/* a good place to do the traceback */
+	if (fu_progress_get_profile(priv->progress)) {
+		g_autofree gchar *str = fu_progress_traceback(priv->progress);
+		if (str != NULL)
+			g_print("\n%s\n", str);
+	}
+
 	/* success */
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
With `--verbose` this will print a dump of startup times onto the
console so that we can debug which plugin is slowing down system
startup. For example:

    ../src/fu-engine.c:5409:plugins-coldplug [108.55ms]:
        ../plugins/amt/fu-plugin-amt.c:437:amt [27.14ms]:
            ../plugins/amt/fu-plugin-amt.c:437:create-context [12.66ms]
            ../plugins/amt/fu-plugin-amt.c:437:get-version [8.44ms]
            ../plugins/amt/fu-plugin-amt.c:437:add-device [3.95ms]

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
