### PR TITLE
redfish: Never manually modprobe ipmi-devintf

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -365,7 +365,6 @@ done
 /usr/lib/modules-load.d/fwupd-msr.conf
 %config(noreplace)%{_sysconfdir}/fwupd/msr.conf
 %endif
-/usr/lib/modules-load.d/fwupd-redfish.conf
 %{_datadir}/dbus-1/system.d/org.freedesktop.fwupd.conf
 %{_datadir}/bash-completion/completions/fwupdmgr
 %{_datadir}/bash-completion/completions/fwupdtool

--- a/plugins/redfish/fwupd-redfish.conf
+++ b/plugins/redfish/fwupd-redfish.conf
@@ -1,1 +1,0 @@
-ipmi-devintf

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -11,12 +11,6 @@ if have_linux_ipmi
   ipmi_src += 'fu-ipmi-device.c'
 endif
 
-if libsystemd.found() and have_linux_ipmi
-install_data(['fwupd-redfish.conf'],
-  install_dir: systemd_modules_load_dir,
-)
-endif
-
 shared_module('fu_plugin_redfish',
   fu_hash,
   sources : [


### PR DESCRIPTION
This produces startup failures on images that do not ship that exact
module, e.g. guest-images.

Just rely on the kernel driver to be auto-loaded when required.

Fixes https://github.com/fwupd/fwupd/issues/4550

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
