### PR TITLE
trivial: Remove one layer of indirection when getting config keys

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -303,7 +303,7 @@ fu_daemon_device_array_to_variant(FuDaemon *self,
 	g_variant_builder_init(&builder, G_VARIANT_TYPE_ARRAY);
 
 	/* override when required */
-	if (fu_engine_get_show_device_private(self->engine))
+	if (fu_config_get_show_device_private(fu_engine_get_config(self->engine)))
 		flags |= FWUPD_DEVICE_FLAG_TRUSTED;
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device = g_ptr_array_index(devices, i);
@@ -1858,7 +1858,8 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		/* parse the cab file before authenticating so we can work out
 		 * what action ID to use, for instance, if this is trusted --
 		 * this will also close the fd when done */
-		archive_size_max = fu_engine_get_archive_size_max(self->engine);
+		archive_size_max =
+		    fu_config_get_archive_size_max(fu_engine_get_config(self->engine));
 		helper->blob_cab = fu_common_get_contents_fd(fd, archive_size_max, &error);
 		if (helper->blob_cab == NULL) {
 			g_dbus_method_invocation_return_gerror(invocation, error);
@@ -1997,8 +1998,10 @@ fu_daemon_daemon_get_property(GDBusConnection *connection_,
 	if (g_strcmp0(property_name, "Interactive") == 0)
 		return g_variant_new_boolean(isatty(fileno(stdout)) != 0);
 
-	if (g_strcmp0(property_name, "OnlyTrusted") == 0)
-		return g_variant_new_boolean(fu_engine_get_only_trusted(self->engine));
+	if (g_strcmp0(property_name, "OnlyTrusted") == 0) {
+		return g_variant_new_boolean(
+		    fu_config_get_only_trusted(fu_engine_get_config(self->engine)));
+	}
 
 	/* return an error */
 	g_set_error(error,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -39,7 +39,6 @@
 #include "fu-cfu-payload.h"
 #include "fu-common-cab.h"
 #include "fu-common.h"
-#include "fu-config.h"
 #include "fu-context-private.h"
 #include "fu-coswid-firmware.h"
 #include "fu-debug.h"
@@ -4073,7 +4072,7 @@ fu_engine_get_silo_from_blob(FuEngine *self, GBytes *blob_cab, GError **error)
 
 	/* load file */
 	fu_engine_set_status(self, FWUPD_STATUS_DECOMPRESSING);
-	fu_cabinet_set_size_max(cabinet, fu_engine_get_archive_size_max(self));
+	fu_cabinet_set_size_max(cabinet, fu_config_get_archive_size_max(self->config));
 	fu_cabinet_set_jcat_context(cabinet, self->jcat_context);
 	if (!fu_cabinet_parse(cabinet, blob_cab, FU_CABINET_PARSE_FLAG_NONE, error))
 		return NULL;
@@ -4264,7 +4263,7 @@ fu_engine_get_details(FuEngine *self, FuEngineRequest *request, gint fd, GError 
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* get all components */
-	blob = fu_common_get_contents_fd(fd, fu_engine_get_archive_size_max(self), error);
+	blob = fu_common_get_contents_fd(fd, fu_config_get_archive_size_max(self->config), error);
 	if (blob == NULL)
 		return NULL;
 	silo = fu_engine_get_silo_from_blob(self, blob, error);
@@ -5917,18 +5916,11 @@ fu_engine_get_tainted(FuEngine *self)
 	return self->tainted;
 }
 
-gboolean
-fu_engine_get_only_trusted(FuEngine *self)
+FuConfig *
+fu_engine_get_config(FuEngine *self)
 {
-	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
-	return fu_config_get_only_trusted(self->config);
-}
-
-gboolean
-fu_engine_get_show_device_private(FuEngine *self)
-{
-	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
-	return fu_config_get_show_device_private(self->config);
+	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
+	return self->config;
 }
 
 const gchar *
@@ -6305,12 +6297,6 @@ fu_engine_cleanup_state(GError **error)
 		}
 	}
 	return TRUE;
-}
-
-guint64
-fu_engine_get_archive_size_max(FuEngine *self)
-{
-	return fu_config_get_archive_size_max(self->config);
 }
 
 static void

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -14,6 +14,7 @@
 #include "fwupd-enums.h"
 
 #include "fu-common.h"
+#include "fu-config.h"
 #include "fu-context.h"
 #include "fu-plugin.h"
 #include "fu-release.h"
@@ -56,10 +57,6 @@ gboolean
 fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GError **error);
 gboolean
 fu_engine_get_tainted(FuEngine *self);
-gboolean
-fu_engine_get_only_trusted(FuEngine *self);
-gboolean
-fu_engine_get_show_device_private(FuEngine *self);
 const gchar *
 fu_engine_get_host_product(FuEngine *self);
 const gchar *
@@ -72,8 +69,8 @@ const gchar *
 fu_engine_get_host_security_id(FuEngine *self);
 XbSilo *
 fu_engine_get_silo_from_blob(FuEngine *self, GBytes *blob_cab, GError **error);
-guint64
-fu_engine_get_archive_size_max(FuEngine *self);
+FuConfig *
+fu_engine_get_config(FuEngine *self);
 GPtrArray *
 fu_engine_get_plugins(FuEngine *self);
 GPtrArray *


### PR DESCRIPTION
This makes it much easier to add new config keys in the future.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
