### PR TITLE
Reorder plugins FuDevice->probe() to speed up daemon startup by 100ms

### DIFF
--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -468,10 +468,6 @@ fu_ata_device_probe(FuDevice *device, GError **error)
 	FuAtaDevice *self = FU_ATA_DEVICE(device);
 	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
 
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_ata_device_parent_class)->probe(device, error))
-		return FALSE;
-
 	/* check is valid */
 	if (g_strcmp0(g_udev_device_get_devtype(udev_device), "disk") != 0) {
 		g_set_error(error,
@@ -489,6 +485,10 @@ fu_ata_device_probe(FuDevice *device, GError **error)
 				    "has no ID_ATA_DOWNLOAD_MICROCODE");
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_ata_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* set the physical ID */
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "scsi", error))

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -144,10 +144,6 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 	g_autofree gchar *vendor_id = NULL;
 	g_autoptr(GRegex) dev_regex = NULL;
 
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_emmc_device_parent_class)->probe(device, error))
-		return FALSE;
-
 	udev_parent = g_udev_device_get_parent_with_subsystem(udev_device, "mmc", NULL);
 	if (udev_parent == NULL) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no MMC parent");
@@ -163,6 +159,10 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 			    g_udev_device_get_devtype(udev_device));
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_emmc_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* ignore *rpmb and *boot* mmc block devices */
 	dev_regex = g_regex_new("mmcblk\\d$", 0, 0, NULL);

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -33,10 +33,6 @@ fu_gpio_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_gpio_device_probe(FuDevice *device, GError **error)
 {
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_gpio_device_parent_class)->probe(device, error))
-		return FALSE;
-
 	/* no device file */
 	if (fu_udev_device_get_device_file(FU_UDEV_DEVICE(device)) == NULL) {
 		g_set_error_literal(error,
@@ -45,6 +41,10 @@ fu_gpio_device_probe(FuDevice *device, GError **error)
 				    "no device file");
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_gpio_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* set the physical ID */
 	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "gpio", error);

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -18,13 +18,10 @@ static gboolean
 fu_optionrom_device_probe(FuDevice *device, GError **error)
 {
 	g_autofree gchar *fn = NULL;
-
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_optionrom_device_parent_class)->probe(device, error))
-		return FALSE;
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
 
 	/* does the device even have ROM? */
-	fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "rom", NULL);
+	fn = g_build_filename(g_udev_device_get_sysfs_path(udev_device), "rom", NULL);
 	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -32,6 +29,10 @@ fu_optionrom_device_probe(FuDevice *device, GError **error)
 				    "Unable to read firmware from device");
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_optionrom_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* set the physical ID */
 	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error);

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -48,10 +48,6 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 	g_autoptr(FuUdevDevice) ufshci_parent = NULL;
 	const gchar *subsystem_parents[] = {"pci", "platform", NULL};
 
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_scsi_device_parent_class)->probe(device, error))
-		return FALSE;
-
 	/* check is valid */
 	if (g_strcmp0(g_udev_device_get_devtype(udev_device), "disk") != 0) {
 		g_set_error(error,
@@ -68,6 +64,10 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 				    "has no ID_SCSI");
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_scsi_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* vendor sanity */
 	if (g_strcmp0(fu_device_get_vendor(device), "ATA") == 0) {

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -317,10 +317,6 @@ fu_uf2_device_probe(FuDevice *device, GError **error)
 	guint64 vid = 0;
 	guint64 pid = 0;
 
-	/* FuUdevDevice->probe */
-	if (!FU_DEVICE_CLASS(fu_uf2_device_parent_class)->probe(device, error))
-		return FALSE;
-
 	/* check is valid */
 	tmp = g_udev_device_get_property(udev_device, "ID_BUS");
 	if (g_strcmp0(tmp, "usb") != 0) {
@@ -340,6 +336,10 @@ fu_uf2_device_probe(FuDevice *device, GError **error)
 			    tmp);
 		return FALSE;
 	}
+
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_uf2_device_parent_class)->probe(device, error))
+		return FALSE;
 
 	/* set the physical ID */
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "block", error))


### PR DESCRIPTION
There's no point scanning the baseclass again if we can quickly check
if the device is valid.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
