### PR TITLE
scsi: Use the SCSI target to correctly set the physical ID

### DIFF
--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -100,6 +100,8 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 			/* least significant bit specifies FFU capability */
 			if (ufs_features & 0x1) {
 				fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+				fu_device_add_internal_flag(FU_DEVICE(self),
+							    FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED);
 				fu_device_add_protocol(device, "org.jedec.ufs");
 			}
 			if (!fu_udev_device_get_sysfs_attr_uint64(ufshci_parent,

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -133,7 +133,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* set the physical ID */
-	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "scsi", error);
+	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "scsi:scsi_target", error);
 }
 
 static FuFirmware *


### PR DESCRIPTION
We don't want to include the SCSI LUN in the physical ID, as this is a
logical concept not relating to the hardware device.

Use the UDev devtype to find the 'correct' parent.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
