### PR TITLE
Add a progress flag to indicate for when the child returns early

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -783,6 +783,9 @@ fu_plugin_runner_startup(FuPlugin *self, FuProgress *progress, GError **error)
 
 	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
 
+	/* progress */
+	fu_progress_set_name(progress, fu_plugin_get_name(self));
+
 	/* be helpful for unit tests */
 	fu_plugin_runner_init(self);
 
@@ -1025,6 +1028,9 @@ fu_plugin_runner_coldplug(FuPlugin *self, FuProgress *progress, GError **error)
 	g_autoptr(GError) error_local = NULL;
 
 	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
+
+	/* progress */
+	fu_progress_set_name(progress, fu_plugin_get_name(self));
 
 	/* not enabled */
 	if (fu_plugin_has_flag(self, FWUPD_PLUGIN_FLAG_DISABLED))

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -848,7 +848,7 @@ fu_progress_step_done(FuProgress *self)
 	}
 
 	/* is child not at 100%? */
-	if (priv->child != NULL) {
+	if (!fu_progress_has_flag(self, FU_PROGRESS_FLAG_CHILD_FINISHED) && priv->child != NULL) {
 		FuProgressPrivate *child_priv = GET_PRIVATE(priv->child);
 		if (child_priv->step_now != child_priv->step_max) {
 			g_autoptr(GString) str = g_string_new(NULL);

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -64,6 +64,15 @@ typedef guint64 FuProgressFlags;
  */
 #define FU_PROGRESS_FLAG_NO_PROFILE (1ull << 1)
 
+/**
+ * FU_PROGRESS_FLAG_CHILD_FINISHED:
+ *
+ * The child completed all the expected steps.
+ *
+ * Since: 1.8.2
+ */
+#define FU_PROGRESS_FLAG_CHILD_FINISHED (1ull << 2)
+
 FuProgress *
 fu_progress_new(const gchar *id);
 const gchar *

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3985,6 +3985,25 @@ fu_progress_finish_func(void)
 	fu_progress_step_done(progress);
 }
 
+static void
+fu_progress_child_finished(void)
+{
+	FuProgress *child;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* check straight finish */
+	fu_progress_set_steps(progress, 3);
+
+	child = fu_progress_get_child(progress);
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 3);
+	/* some imaginary igorable error */
+
+	/* parent step done after child finish */
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_CHILD_FINISHED);
+	fu_progress_step_done(progress);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -4008,6 +4027,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/common{memmem}", fu_common_memmem_func);
 	g_test_add_func("/fwupd/progress", fu_progress_func);
 	g_test_add_func("/fwupd/progress{child}", fu_progress_child_func);
+	g_test_add_func("/fwupd/progress{child-finished}", fu_progress_child_finished);
 	g_test_add_func("/fwupd/progress{parent-1-step}", fu_progress_parent_one_step_proxy_func);
 	g_test_add_func("/fwupd/progress{no-equal}", fu_progress_non_equal_steps_func);
 	g_test_add_func("/fwupd/progress{finish}", fu_progress_finish_func);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5383,15 +5383,13 @@ fu_engine_plugins_setup(FuEngine *self, FuProgress *progress)
 	for (guint i = 0; i < plugins->len; i++) {
 		g_autoptr(GError) error = NULL;
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
-		FuProgress *progress_child = fu_progress_get_child(progress);
-		fu_progress_set_name(progress_child, fu_plugin_get_name(plugin));
-		if (!fu_plugin_runner_startup(plugin, progress_child, &error)) {
+		if (!fu_plugin_runner_startup(plugin, fu_progress_get_child(progress), &error)) {
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED);
 			if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 				fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_NO_HARDWARE);
 			}
-			fu_progress_finished(progress_child);
 			g_message("disabling plugin because: %s", error->message);
+			fu_progress_add_flag(progress, FU_PROGRESS_FLAG_CHILD_FINISHED);
 		}
 		fu_progress_step_done(progress);
 	}
@@ -5410,11 +5408,10 @@ fu_engine_plugins_coldplug(FuEngine *self, FuProgress *progress)
 	for (guint i = 0; i < plugins->len; i++) {
 		g_autoptr(GError) error = NULL;
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
-		FuProgress *progress_child = fu_progress_get_child(progress);
-		fu_progress_set_name(progress_child, fu_plugin_get_name(plugin));
-		if (!fu_plugin_runner_coldplug(plugin, progress_child, &error)) {
+		if (!fu_plugin_runner_coldplug(plugin, fu_progress_get_child(progress), &error)) {
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED);
 			g_message("disabling plugin because: %s", error->message);
+			fu_progress_add_flag(progress, FU_PROGRESS_FLAG_CHILD_FINISHED);
 		}
 		fu_progress_step_done(progress);
 	}


### PR DESCRIPTION
Using `fu_progress_finished(fu_progress_get_child(progress))` is IMHO
a hacky workaround.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
