### PR TITLE
plugins/intel-spi: Correct BIOS Control Device

### DIFF
--- a/plugins/intel-spi/generate-quirk.py
+++ b/plugins/intel-spi/generate-quirk.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     chipsets = {
-        "apl": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:0d.2"),
+        "apl": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.0"),
         "c620": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
         "ich0": Chipset(flags="ich", bios_cntl=0x4E),
         "ich2345": Chipset(flags="ich", bios_cntl=0x4E),

--- a/plugins/intel-spi/intel-spi.quirk
+++ b/plugins/intel-spi/intel-spi.quirk
@@ -404,7 +404,7 @@ IntelSpiKind = pch400
 
 
 [INTEL_SPI_CHIPSET\ID_APL]
-IntelSpiBarProxy = 00:0d.2
+IntelSpiBarProxy = 00:1f.0
 IntelSpiBiosCntl = 0xDC
 Flags = pch
 


### PR DESCRIPTION
Correct the BIOS Control Device, which is should be 31.

This can be found on Intel doc numbers:
* 334819 (APL)
* 336561 (GLK)

Signed-off-by: Sean Rhodes <sean@starlabs.systems>

