### PR TITLE
Fix setting version for udev devices

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -397,7 +397,7 @@ fu_udev_device_probe(FuDevice *device, GError **error)
 	/* set the version if the revision has been set */
 	if (fu_device_get_version(device) == NULL &&
 	    fu_device_get_version_format(device) == FWUPD_VERSION_FORMAT_UNKNOWN) {
-		if (priv->revision != 0x00) {
+		if (priv->revision != 0x00 && priv->revision != 0xFF) {
 			g_autofree gchar *version = g_strdup_printf("%02x", priv->revision);
 			fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PLAIN);
 			fu_device_set_version(device, version);


### PR DESCRIPTION
Change-Id: I907bb3958b624ff5f887cbc192f54448354d9d5c

Type of pull request:

- [ ] Code fix
--- Make "unset" check for version simillar to model/device where unset can be 0x00 or 0xFF
