### PR TITLE
trivial: Make meson.build indentation consistent

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -17,7 +17,7 @@ pkgver() {
     cd ${pkgname}
 
     VERSION=$(git describe | sed 's/-/.r/;s/-/./')
-    [ -z $VERSION ] && VERSION=$(head meson.build | grep ' version :' | cut -d \' -f2)
+    [ -z $VERSION ] && VERSION=$(head meson.build | grep ' version:' | cut -d \' -f2)
 
     echo $VERSION
 }

--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -20,7 +20,7 @@ fi
 export DEBFULLNAME="CI Builder"
 export DEBEMAIL="ci@travis-ci.org"
 VERSION=`git describe | sed 's/-/+r/;s/-/+/'`
-[ -z $VERSION ] && VERSION=`head meson.build | grep ' version :' | cut -d \' -f2`
+[ -z $VERSION ] && VERSION=`head meson.build | grep ' version:' | cut -d \' -f2`
 rm -rf build/
 mkdir -p build
 shopt -s extglob

--- a/contrib/ci/out-of-tree-link/meson.build
+++ b/contrib/ci/out-of-tree-link/meson.build
@@ -1,5 +1,5 @@
   project('out-of-tree-link', 'c',
-  license : 'LGPL-2.1+',
+  license: 'LGPL-2.1+',
 )
 fwupd = dependency('fwupd')
 fwupdplugin = dependency('fwupdplugin')
@@ -7,20 +7,20 @@ env = environment()
 env.set('G_DEBUG', 'fatal-criticals')
 e = executable(
   'fwupd',
-  sources : [
+  sources: [
     'fwupd.c'
   ],
-  dependencies : [
+  dependencies: [
     fwupd
   ],
   )
 test('fwupd', e, timeout: 60, env: env)
 e = executable(
   'fwupdplugin',
-  sources : [
+  sources: [
     'fwupdplugin.c'
   ],
-  dependencies : [
+  dependencies: [
     fwupdplugin
   ],
   )

--- a/contrib/ci/qt5-thread-test/meson.build
+++ b/contrib/ci/qt5-thread-test/meson.build
@@ -1,7 +1,7 @@
 project('qt5-thread-test', 'cpp',
-  license : 'LGPL-2.1+',
+  license: 'LGPL-2.1+',
 )
-add_project_arguments('-fPIC', language : 'cpp')
+add_project_arguments('-fPIC', language: 'cpp')
 qt5core = dependency('Qt5Core')
 qt5concurrent = dependency('Qt5Concurrent')
 glib2 = dependency('glib-2.0')
@@ -11,10 +11,10 @@ env = environment()
 env.set('G_DEBUG', 'fatal-criticals')
 e = executable(
   'qt-thread-test',
-  sources : [
+  sources: [
     'qt-thread-test.cpp'
   ],
-  dependencies : [
+  dependencies: [
     qt5core,
     qt5concurrent,
     glib2,

--- a/contrib/firmware_packager/meson.build
+++ b/contrib/firmware_packager/meson.build
@@ -1,16 +1,16 @@
 if get_option('firmware-packager')
   install_data('firmware_packager.py',
-               install_dir : 'share/fwupd')
+               install_dir: 'share/fwupd')
   install_data('add_capsule_header.py',
-               install_dir : 'share/fwupd')
+               install_dir: 'share/fwupd')
   install_data('install_dell_bios_exe.py',
-               install_dir : 'share/fwupd')
+               install_dir: 'share/fwupd')
   con2 = configuration_data()
   con2.set('FWUPD_VERSION', fwupd_version)
   configure_file(
-    input : 'simple_client.py',
-    output : 'simple_client.py',
-    configuration : con2,
+    input: 'simple_client.py',
+    output: 'simple_client.py',
+    configuration: con2,
     install: true,
     install_dir: 'share/fwupd',
   )

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -8,9 +8,9 @@ con2.set('FWUPD_VERSION', fwupd_version)
 con2.set('FWUPD_PLUGINVER', libfwupdplugin_lt_current)
 
 configure_file(
-  input : 'fwupd.spec.in',
-  output : 'fwupd.spec.in',
-  configuration : con2,
+  input: 'fwupd.spec.in',
+  output: 'fwupd.spec.in',
+  configuration: con2,
 )
 
 if host_machine.system() == 'windows'

--- a/contrib/qubes/meson.build
+++ b/contrib/qubes/meson.build
@@ -4,7 +4,7 @@ install_data([
   'src/qubes_fwupd_heads.py',
   'src/qubes_fwupd_update.py',
   ],
-  install_dir : 'share/qubes-fwupd/src',
+  install_dir: 'share/qubes-fwupd/src',
 )
 
 install_data([
@@ -13,7 +13,7 @@ install_data([
   'test/test_qubes_fwupd_heads.py',
   'test/test_qubes_fwupdmgr.py',
   ],
-  install_dir : 'share/qubes-fwupd/test',
+  install_dir: 'share/qubes-fwupd/test',
 )
 
 install_data([
@@ -22,7 +22,7 @@ install_data([
   'test/logs/get_updates.log',
   'test/logs/help.log',
   ],
-  install_dir : 'share/qubes-fwupd/test/logs',
+  install_dir: 'share/qubes-fwupd/test/logs',
 )
 
 install_data([
@@ -30,24 +30,24 @@ install_data([
   'src/vms/fwupd_download_updates.py',
   'src/vms/fwupd_usbvm_validate.py',
   ],
-  install_dir : 'libexec/qubes-fwupd',
-  install_mode : 'rwxrwxr-x',
+  install_dir: 'libexec/qubes-fwupd',
+  install_mode: 'rwxrwxr-x',
 )
 
 install_data([
   'test/logs/metainfo_name/firmware.metainfo.xml',
   ],
-  install_dir : 'share/qubes-fwupd/test/logs/metainfo_name',
+  install_dir: 'share/qubes-fwupd/test/logs/metainfo_name',
 )
 
 install_data(
   'test/logs/metainfo_version/firmware.metainfo.xml',
-  install_dir : 'share/qubes-fwupd/test/logs/metainfo_version',
+  install_dir: 'share/qubes-fwupd/test/logs/metainfo_version',
 )
 
 install_data(
   'src/qubes_fwupdmgr.py',
-  install_dir : 'sbin',
-  rename : 'qubes-fwupdmgr',
-  install_mode : 'rwxrwxr-x',
+  install_dir: 'sbin',
+  rename: 'qubes-fwupdmgr',
+  install_mode: 'rwxrwxr-x',
 )

--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -1,5 +1,5 @@
 if bashcomp.found()
-  completions_dir = bashcomp.get_variable(pkgconfig : 'completionsdir',
+  completions_dir = bashcomp.get_variable(pkgconfig: 'completionsdir',
     pkgconfig_define: bashcomp.version().version_compare('>= 2.10') ? ['datadir', datadir] : ['prefix', prefix],
   )
 
@@ -7,16 +7,16 @@ if bashcomp.found()
   con.set('localstatedir', localstatedir)
 
   configure_file(
-    input : 'fwupdtool',
-    output : 'fwupdtool',
-    configuration : con,
-    install : true,
-    install_dir : completions_dir,
+    input: 'fwupdtool',
+    output: 'fwupdtool',
+    configuration: con,
+    install: true,
+    install_dir: completions_dir,
   )
 
   if build_daemon
     install_data(['fwupdagent', 'fwupdmgr'],
-      install_dir : completions_dir,
+      install_dir: completions_dir,
     )
   endif # build_daemon
 

--- a/data/builder/meson.build
+++ b/data/builder/meson.build
@@ -1,3 +1,3 @@
 install_data('README.md',
-  install_dir : join_paths(datadir, 'doc', 'fwupd', 'builder')
+  install_dir: join_paths(datadir, 'doc', 'fwupd', 'builder')
 )

--- a/data/device-tests/meson.build
+++ b/data/device-tests/meson.build
@@ -45,5 +45,5 @@ install_data([
     'wacom-intuos-bt-m-main.json',
     'wacom-intuos-bt-s.json',
   ],
-  install_dir : join_paths(datadir, 'fwupd', 'device-tests'),
+  install_dir: join_paths(datadir, 'fwupd', 'device-tests'),
 )

--- a/data/fish-completion/meson.build
+++ b/data/fish-completion/meson.build
@@ -1,3 +1,3 @@
 install_data(['fwupdmgr.fish'],
-  install_dir : join_paths(datadir, 'fish', 'vendor_completions.d'),
+  install_dir: join_paths(datadir, 'fish', 'vendor_completions.d'),
 )

--- a/data/installed-tests/meson.build
+++ b/data/installed-tests/meson.build
@@ -6,33 +6,33 @@ con2.set('bindir', bindir)
 con2.set('libexecdir', libexecdir)
 
 configure_file(
-  input : 'fwupdmgr.test.in',
-  output : 'fwupdmgr.test',
-  configuration : con2,
+  input: 'fwupdmgr.test.in',
+  output: 'fwupdmgr.test',
+  configuration: con2,
   install: true,
   install_dir: installed_test_datadir,
 )
 
 configure_file(
-  input : 'fwupdmgr-p2p.test.in',
-  output : 'fwupdmgr-p2p.test',
-  configuration : con2,
+  input: 'fwupdmgr-p2p.test.in',
+  output: 'fwupdmgr-p2p.test',
+  configuration: con2,
   install: true,
   install_dir: installed_test_datadir,
 )
 
 configure_file(
-  input : 'fwupd.test.in',
-  output : 'fwupd.test',
-  configuration : con2,
+  input: 'fwupd.test.in',
+  output: 'fwupd.test',
+  configuration: con2,
   install: true,
   install_dir: installed_test_datadir,
 )
 
 configure_file(
-  input : 'fwupdmgr-p2p.sh',
-  output : 'fwupdmgr-p2p.sh',
-  configuration : con2,
+  input: 'fwupdmgr-p2p.sh',
+  output: 'fwupdmgr-p2p.sh',
+  configuration: con2,
   install: true,
   install_dir: installed_test_datadir,
 )
@@ -41,36 +41,36 @@ install_data([
     'fwupdmgr.sh',
     'fwupd-tests.xml',
   ],
-  install_dir : installed_test_datadir,
+  install_dir: installed_test_datadir,
 )
 
 install_data([
     'fwupd.sh',
   ],
-  install_dir : installed_test_bindir,
+  install_dir: installed_test_bindir,
 )
 
 custom_target('installed-cab123',
-  input : [
+  input: [
     'fakedevice123.bin',
     'fakedevice123.bin.asc',
     'fakedevice123.metainfo.xml',
   ],
-  output : 'fakedevice123.cab',
-  command : [
+  output: 'fakedevice123.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
   install: true,
   install_dir: installed_test_datadir,
 )
 custom_target('installed-cab124',
-  input : [
+  input: [
     'fakedevice124.bin',
     'fakedevice124.bin.asc',
     'fakedevice124.metainfo.xml',
   ],
-  output : 'fakedevice124.cab',
-  command : [
+  output: 'fakedevice124.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
   install: true,
@@ -79,9 +79,9 @@ custom_target('installed-cab124',
 
 # replace @installedtestsdir@
 configure_file(
-  input : 'remote.conf.in',
-  output : 'fwupd-tests.conf',
-  configuration : con2,
+  input: 'remote.conf.in',
+  output: 'fwupd-tests.conf',
+  configuration: con2,
   install: true,
   install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 )

--- a/data/meson.build
+++ b/data/meson.build
@@ -26,7 +26,7 @@ endif
 
 if build_standalone
   install_data(['daemon.conf'],
-    install_dir : join_paths(sysconfdir, 'fwupd')
+    install_dir: join_paths(sysconfdir, 'fwupd')
   )
   install_data(['power.quirk', 'cfi.quirk'],
     install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
@@ -37,18 +37,18 @@ if get_option('metainfo')
     install_dir: join_paths(datadir, 'metainfo')
   )
   install_data(['org.freedesktop.fwupd.svg'],
-    install_dir : join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps')
+    install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps')
   )
 endif
 
 if build_daemon
   install_data(['org.freedesktop.fwupd.conf'],
-    install_dir : join_paths(datadir, 'dbus-1', 'system.d')
+    install_dir: join_paths(datadir, 'dbus-1', 'system.d')
   )
 
   if gudev.found()
     install_data(['90-fwupd-devices.rules'],
-      install_dir : join_paths(udevdir, 'rules.d')
+      install_dir: join_paths(udevdir, 'rules.d')
     )
   endif
 
@@ -92,9 +92,9 @@ if build_daemon
     # replace @bindir@
     if offline.allowed()
       configure_file(
-        input : 'fwupd-offline-update.service.in',
-        output : 'fwupd-offline-update.service',
-        configuration : con2,
+        input: 'fwupd-offline-update.service.in',
+        output: 'fwupd-offline-update.service',
+        configuration: con2,
         install: true,
         install_dir: systemdunitdir,
       )
@@ -102,18 +102,18 @@ if build_daemon
 
     # replace @dynamic_options@
     configure_file(
-      input : 'fwupd.service.in',
-      output : 'fwupd.service',
-      configuration : con2,
+      input: 'fwupd.service.in',
+      output: 'fwupd.service',
+      configuration: con2,
       install: true,
       install_dir: systemdunitdir,
     )
 
     # for activation
     configure_file(
-      input : 'fwupd.shutdown.in',
-      output : 'fwupd.shutdown',
-      configuration : con2,
+      input: 'fwupd.shutdown.in',
+      output: 'fwupd.shutdown',
+      configuration: con2,
       install: true,
       install_dir: systemd_shutdown_dir,
     )
@@ -125,9 +125,9 @@ if build_daemon
 
     # replace @libexecdir@
     configure_file(
-      input : 'org.freedesktop.fwupd.service.in',
-      output : 'org.freedesktop.fwupd.service',
-      configuration : con2,
+      input: 'org.freedesktop.fwupd.service.in',
+      output: 'org.freedesktop.fwupd.service',
+      configuration: con2,
       install: true,
       install_dir: join_paths(datadir,
                               'dbus-1',

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -26,9 +26,9 @@ if libsystemd.found()
   endif
 
   configure_file(
-    input : 'fwupd-refresh.service.in',
-    output : 'fwupd-refresh.service',
-    configuration : con2,
+    input: 'fwupd-refresh.service.in',
+    output: 'fwupd-refresh.service',
+    configuration: con2,
     install: true,
     install_dir: systemdunitdir,
   )
@@ -38,8 +38,8 @@ endif
 # of sourcing /run/motd.d/*
 # See https://bugs.launchpad.net/ubuntu/+source/pam/+bug/399071
 configure_file(
-  input : '85-fwupd.motd.in',
-  output : motd_file,
-  configuration : con2,
+  input: '85-fwupd.motd.in',
+  output: motd_file,
+  configuration: con2,
   install: false,
 )

--- a/data/pki/meson.build
+++ b/data/pki/meson.build
@@ -1,7 +1,7 @@
 # only install files that are going to be used
 if libjcat.type_name() != 'internal' and libjcat.version().version_compare('>= 0.1.9')
-  supported_gpg = libjcat.get_variable(pkgconfig : 'supported_gpg') == '1'
-  supported_pkcs7 = libjcat.get_variable(pkgconfig : 'supported_pkcs7') == '1'
+  supported_gpg = libjcat.get_variable(pkgconfig: 'supported_gpg') == '1'
+  supported_pkcs7 = libjcat.get_variable(pkgconfig: 'supported_pkcs7') == '1'
 else
   supported_gpg = host_machine.system() != 'windows'
   supported_pkcs7 = true
@@ -12,13 +12,13 @@ install_data([
     'GPG-KEY-Linux-Foundation-Firmware',
     'GPG-KEY-Linux-Vendor-Firmware-Service',
   ],
-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
+  install_dir: join_paths(sysconfdir, 'pki', 'fwupd')
 )
 install_data([
     'GPG-KEY-Linux-Foundation-Metadata',
     'GPG-KEY-Linux-Vendor-Firmware-Service',
   ],
-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
+  install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata')
 )
 endif
 
@@ -26,11 +26,11 @@ if supported_pkcs7
 install_data([
     'LVFS-CA.pem',
   ],
-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd')
+  install_dir: join_paths(sysconfdir, 'pki', 'fwupd')
 )
 install_data([
     'LVFS-CA.pem',
   ],
-  install_dir : join_paths(sysconfdir, 'pki', 'fwupd-metadata')
+  install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata')
 )
 endif

--- a/data/remotes.d/meson.build
+++ b/data/remotes.d/meson.build
@@ -2,7 +2,7 @@ if build_standalone and get_option('lvfs') != 'false'
   install_data([
       'lvfs-testing.conf',
     ],
-    install_dir : join_paths(sysconfdir, 'fwupd', 'remotes.d')
+    install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d')
   )
   con3 = configuration_data()
   if get_option('lvfs') == 'disabled'
@@ -11,9 +11,9 @@ if build_standalone and get_option('lvfs') != 'false'
     con3.set('enabled', 'true')
   endif
   configure_file(
-    input : 'lvfs.conf',
-    output : 'lvfs.conf',
-    configuration : con3,
+    input: 'lvfs.conf',
+    output: 'lvfs.conf',
+    configuration: con3,
     install: true,
     install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
   )
@@ -38,23 +38,23 @@ if build_standalone and get_option('lvfs') != 'false'
 endif
 
 install_data('README.md',
-  install_dir : join_paths(datadir, 'fwupd', 'remotes.d', 'vendor', 'firmware')
+  install_dir: join_paths(datadir, 'fwupd', 'remotes.d', 'vendor', 'firmware')
 )
 
 # replace @datadir@
 con2 = configuration_data()
 con2.set('datadir', datadir)
 configure_file(
-  input : 'vendor.conf',
-  output : 'vendor.conf',
-  configuration : con2,
+  input: 'vendor.conf',
+  output: 'vendor.conf',
+  configuration: con2,
   install: true,
   install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 )
 configure_file(
-  input : 'vendor-directory.conf',
-  output : 'vendor-directory.conf',
-  configuration : con2,
+  input: 'vendor-directory.conf',
+  output: 'vendor-directory.conf',
+  configuration: con2,
   install: true,
   install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 )

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -69,9 +69,9 @@ if introspection.allowed() and get_option('docs')
     install_dir: join_paths(datadir, 'doc'),
   )
  install_data(['urlmap_fwupd.js'],
-    install_dir : join_paths(datadir, 'doc', 'libfwupd')
+    install_dir: join_paths(datadir, 'doc', 'libfwupd')
   )
  install_data(['urlmap_fwupdplugin.js'],
-    install_dir : join_paths(datadir, 'doc', 'libfwupdplugin')
+    install_dir: join_paths(datadir, 'doc', 'libfwupdplugin')
   )
 endif

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -1,12 +1,12 @@
 fwupd_version_h = configure_file(
-  input : 'fwupd-version.h.in',
-  output : 'fwupd-version.h',
-  configuration : conf
+  input: 'fwupd-version.h.in',
+  output: 'fwupd-version.h',
+  configuration: conf
 )
 
 install_headers(
   'fwupd.h',
-  subdir : 'fwupd-1',
+  subdir: 'fwupd-1',
 )
 
 install_headers([
@@ -24,7 +24,7 @@ install_headers([
     'fwupd-plugin.h',
     fwupd_version_h,
   ],
-  subdir : 'fwupd-1/libfwupd',
+  subdir: 'fwupd-1/libfwupd',
 )
 
 libfwupd_deps = [
@@ -54,35 +54,35 @@ fwupd_mapfile = 'fwupd.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), fwupd_mapfile)
 fwupd = library(
   'fwupd',
-  sources : libfwupd_src,
-  soversion : libfwupd_lt_current,
-  version : libfwupd_lt_version,
-  dependencies : libfwupd_deps,
-  c_args : [
+  sources: libfwupd_src,
+  soversion: libfwupd_lt_current,
+  version: libfwupd_lt_version,
+  dependencies: libfwupd_deps,
+  c_args: [
       '-DG_LOG_DOMAIN="Fwupd"',
       '-DLOCALSTATEDIR="' + localstatedir + '"',
     ],
-  include_directories : root_incdir,
-  link_args : cc.get_supported_link_arguments([vflag]),
-  link_depends : fwupd_mapfile,
-  install : true
+  include_directories: root_incdir,
+  link_args: cc.get_supported_link_arguments([vflag]),
+  link_depends: fwupd_mapfile,
+  install: true
 )
 
 libfwupd_dep = declare_dependency(
-  link_with : fwupd,
-  include_directories : [root_incdir, include_directories('.')],
-  dependencies : libfwupd_deps
+  link_with: fwupd,
+  include_directories: [root_incdir, include_directories('.')],
+  dependencies: libfwupd_deps
 )
 
 pkgg = import('pkgconfig')
 pkgg.generate(
   fwupd,
-  requires : [ 'gio-2.0' ],
-  subdirs : 'fwupd-1',
-  version : meson.project_version(),
-  name : 'fwupd',
-  filebase : 'fwupd',
-  description : 'fwupd is a system daemon for installing device firmware',
+  requires: [ 'gio-2.0' ],
+  subdirs: 'fwupd-1',
+  version: meson.project_version(),
+  name: 'fwupd',
+  filebase: 'fwupd',
+  description: 'fwupd is a system daemon for installing device firmware',
 )
 
 if introspection.allowed()
@@ -91,7 +91,7 @@ if introspection.allowed()
       libcurl,
   ]
   fwupd_gir = gnome.generate_gir(fwupd,
-    sources : [
+    sources: [
       'fwupd-client.c',
       'fwupd-client.h',
       'fwupd-client-sync.c',
@@ -125,25 +125,25 @@ if introspection.allowed()
       'fwupd-version.c',
       fwupd_version_h,
     ],
-    nsversion : '2.0',
-    namespace : 'Fwupd',
-    symbol_prefix : 'fwupd',
-    identifier_prefix : 'Fwupd',
-    export_packages : 'fwupd',
-    header : 'fwupd.h',
-    dependencies : fwupd_gir_deps,
-    includes : [
+    nsversion: '2.0',
+    namespace: 'Fwupd',
+    symbol_prefix: 'fwupd',
+    identifier_prefix: 'Fwupd',
+    export_packages: 'fwupd',
+    header: 'fwupd.h',
+    dependencies: fwupd_gir_deps,
+    includes: [
       'Gio-2.0',
       'GObject-2.0',
       'Json-1.0',
     ],
-    install : true
+    install: true
   )
 
   gnome.generate_vapi('fwupd',
-    sources : fwupd_gir[0],
-    packages : ['gio-2.0', 'json-glib-1.0'],
-    install : true,
+    sources: fwupd_gir[0],
+    packages: ['gio-2.0', 'json-glib-1.0'],
+    install: true,
   )
 
   # Verify the map file is correct -- note we can't actually use the generated
@@ -166,7 +166,7 @@ if introspection.allowed()
     ],
   )
   test('fwupd-exported-api', diffcmd,
-       args : [
+       args: [
         '-urNp',
         join_paths(meson.current_source_dir(), 'fwupd.map'),
         mapfile_target,
@@ -180,53 +180,53 @@ if get_option('tests')
   env.set('G_TEST_BUILDDIR', meson.current_build_dir())
   e = executable(
     'fwupd-self-test',
-    sources : [
+    sources: [
       'fwupd-self-test.c'
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
     ],
-    dependencies : [
+    dependencies: [
       libfwupd_deps,
     ],
-    link_with : fwupd,
-    c_args : [
+    link_with: fwupd,
+    c_args: [
       '-DG_LOG_DOMAIN="Fwupd"',
       '-DLOCALSTATEDIR="' + localstatedir + '"',
     ],
   )
-  test('fwupd-self-test', e, timeout: 60, env : env)
+  test('fwupd-self-test', e, timeout: 60, env: env)
   if run_sanitize_unsafe_tests and gio.version().version_compare ('>= 2.64.0')
     e = executable(
       'fwupd-thread-test',
-      sources : [
+      sources: [
         'fwupd-thread-test.c'
       ],
-      include_directories : [
+      include_directories: [
         root_incdir,
       ],
-      dependencies : [
+      dependencies: [
         libfwupd_deps,
       ],
-      link_with : fwupd,
-      c_args : [
+      link_with: fwupd,
+      c_args: [
         '-DG_LOG_DOMAIN="Fwupd"',
       ],
     )
     test('fwupd-thread-test', e, timeout: 60)
     e = executable(
       'fwupd-context-test',
-      sources : [
+      sources: [
         'fwupd-context-test.c'
       ],
-      include_directories : [
+      include_directories: [
         root_incdir,
       ],
-      dependencies : [
+      dependencies: [
         libfwupd_deps,
       ],
-      link_with : fwupd,
-      c_args : [
+      link_with: fwupd,
+      c_args: [
         '-DG_LOG_DOMAIN="Fwupd"',
       ],
     )

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -54,7 +54,7 @@ fu_kernel_locked_down(void)
 }
 
 /**
- * fu_kernel_check_version :
+ * fu_kernel_check_version:
  * @minimum_kernel: (not nullable): The minimum kernel version to check against
  * @error: (nullable): optional return location for an error
  *

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -3,9 +3,9 @@ subdir('tests')
 endif
 
 fwupdplugin_version_h = configure_file(
-  input : 'fu-version.h.in',
-  output : 'fu-version.h',
-  configuration : conf
+  input: 'fu-version.h.in',
+  output: 'fu-version.h',
+  configuration: conf
 )
 
 fwupdplugin_src = [
@@ -152,17 +152,17 @@ fwupdplugin_headers = [
 ]
 install_headers(
   'fwupdplugin.h',
-  subdir : 'fwupd-1',
+  subdir: 'fwupd-1',
 )
 install_headers([fwupdplugin_headers, 'fu-plugin-vfuncs.h'],
-  subdir : 'fwupd-1/libfwupdplugin',
+  subdir: 'fwupd-1/libfwupdplugin',
 )
 
 fu_hash = custom_target(
   'fu-hash.h',
-  input : fwupdplugin_src,
-  output : 'fu-hash.h',
-  command : [python3.full_path(),
+  input: fwupdplugin_src,
+  output: 'fu-hash.h',
+  command: [python3.full_path(),
              join_paths(meson.current_source_dir(), 'fu-hash.py'),
              '@OUTPUT@', '@INPUT@']
 )
@@ -217,37 +217,37 @@ fwupdplugin_mapfile = 'fwupdplugin.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), fwupdplugin_mapfile)
 fwupdplugin = library(
   'fwupdplugin',
-  sources : [
+  sources: [
     fwupdplugin_src,
     fwupdplugin_headers,
     fwupdplugin_headers_private,
   ],
-  soversion : libfwupdplugin_lt_current,
-  version : libfwupdplugin_lt_version,
-  include_directories : [
+  soversion: libfwupdplugin_lt_current,
+  version: libfwupdplugin_lt_version,
+  include_directories: [
     root_incdir,
     fwupd_incdir,
   ],
-  dependencies : [
+  dependencies: [
     library_deps
   ],
-  link_with : [
+  link_with: [
     fwupd,
   ],
-  link_args : cc.get_supported_link_arguments([vflag]),
-  link_depends : fwupdplugin_mapfile,
-  install : true
+  link_args: cc.get_supported_link_arguments([vflag]),
+  link_depends: fwupdplugin_mapfile,
+  install: true
 )
 
 fwupdplugin_pkgg = import('pkgconfig')
 fwupdplugin_pkgg.generate(
-  libraries : fwupdplugin,
-  requires : pkgg_requires,
-  subdirs : 'fwupd-1',
-  version : meson.project_version(),
-  name : 'fwupdplugin',
-  filebase : 'fwupdplugin',
-  description : 'library for plugins to use to interact with fwupd daemon',
+  libraries: fwupdplugin,
+  requires: pkgg_requires,
+  subdirs: 'fwupd-1',
+  version: meson.project_version(),
+  name: 'fwupdplugin',
+  filebase: 'fwupdplugin',
+  description: 'library for plugins to use to interact with fwupd daemon',
 )
 
 if introspection.allowed()
@@ -268,35 +268,35 @@ if introspection.allowed()
     girtargets += 'Xmlb-2.0'
   endif
   fwupdplugin_gir = gnome.generate_gir(fwupd,
-    sources : [
+    sources: [
       fwupdplugin_src,
       fwupdplugin_headers,
       fwupdplugin_headers_private,
     ],
-    nsversion : '1.0',
-    namespace : 'FwupdPlugin',
-    symbol_prefix : 'fu',
-    identifier_prefix : 'Fu',
-    export_packages : 'fwupdplugin',
-    extra_args : extra_args,
-    include_directories : [
+    nsversion: '1.0',
+    namespace: 'FwupdPlugin',
+    symbol_prefix: 'fu',
+    identifier_prefix: 'Fu',
+    export_packages: 'fwupdplugin',
+    extra_args: extra_args,
+    include_directories: [
       fwupd_incdir,
     ],
-    header : 'fwupdplugin.h',
-    dependencies : [
+    header: 'fwupdplugin.h',
+    dependencies: [
       gir_dep,
       introspection_deps
     ],
-    link_with : [
+    link_with: [
       fwupdplugin,
     ],
-    includes : [
+    includes: [
       'Gio-2.0',
       'GObject-2.0',
       girtargets,
       fwupd_gir[0],
     ],
-    install : true
+    install: true
   )
 
   # Verify the map file is correct -- note we can't actually use the generated
@@ -322,7 +322,7 @@ if introspection.allowed()
   )
 
   test('fwupdplugin-exported-api', diffcmd,
-       args : [
+       args: [
         '-urNp',
         join_paths(meson.current_source_dir(), 'fwupdplugin.map'),
         fwupdplugin_mapfile_target,
@@ -340,25 +340,25 @@ if get_option('tests')
   e = executable(
     'fwupdplugin-self-test',
     test_deps,
-    sources : [
+    sources: [
       fwupdplugin_src,
       'fu-self-test.c'
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
     ],
-    dependencies : [
+    dependencies: [
       library_deps
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin
     ],
-    c_args : [
+    c_args: [
     ],
   )
-  test('fwupdplugin-self-test', e, is_parallel:false, timeout:180, env : env)
+  test('fwupdplugin-self-test', e, is_parallel: false, timeout: 180, env: env)
 endif
 
 fwupdplugin_incdir = include_directories('.')

--- a/libfwupdplugin/tests/colorhug/meson.build
+++ b/libfwupdplugin/tests/colorhug/meson.build
@@ -1,11 +1,11 @@
 colorhug_test_firmware = custom_target('colorhug-test-firmware',
-  input : [
+  input: [
     'firmware.bin',
     'firmware.bin.asc',
     'firmware.metainfo.xml',
   ],
-  output : 'colorhug-als-3.0.2.cab',
-  command : [
+  output: 'colorhug-als-3.0.2.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
 )

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('fwupd', 'c',
-  version : '1.8.2',
-  license : 'LGPL-2.1+',
-  meson_version : '>=0.60.0',
-  default_options : ['warning_level=2', 'c_std=c99'],
+  version: '1.8.2',
+  license: 'LGPL-2.1+',
+  meson_version: '>=0.60.0',
+  default_options: ['warning_level=2', 'c_std=c99'],
 )
 
 fwupd_version = meson.project_version()
@@ -18,7 +18,7 @@ conf.set('MICRO_VERSION', fwupd_micro_version)
 conf.set_quoted('PACKAGE_VERSION', fwupd_version)
 
 # get source version, falling back to package version
-git = find_program('git', required : false)
+git = find_program('git', required: false)
 tag = false
 if git.found()
   source_version = run_command(git, 'describe').stdout().strip()
@@ -115,10 +115,10 @@ if get_option('static_analysis') and host_machine.system() != 'windows'
   warning_flags += ['-fanalyzer', '-Wno-analyzer-null-dereference']
 endif
 cc = meson.get_compiler('c')
-add_project_arguments(cc.get_supported_arguments(warning_flags), language : 'c')
+add_project_arguments(cc.get_supported_arguments(warning_flags), language: 'c')
 
 if not meson.is_cross_build()
-  add_project_arguments('-fstack-protector-strong', language : 'c')
+  add_project_arguments('-fstack-protector-strong', language: 'c')
 endif
 
 # enable full RELRO where possible
@@ -140,24 +140,24 @@ add_project_link_arguments(
   language: 'c'
 )
 
-add_project_arguments('-DFWUPD_COMPILATION', language : 'c')
+add_project_arguments('-DFWUPD_COMPILATION', language: 'c')
 
 # Needed for realpath(), syscall(), cfmakeraw(), etc.
-add_project_arguments('-D_DEFAULT_SOURCE', language : 'c')
+add_project_arguments('-D_DEFAULT_SOURCE', language: 'c')
 
 # do not use deprecated symbols or defines internally
-add_project_arguments('-DFWUPD_DISABLE_DEPRECATED', language : 'c')
+add_project_arguments('-DFWUPD_DISABLE_DEPRECATED', language: 'c')
 
 # needed for symlink() and BYTE_ORDER
-add_project_arguments('-D_BSD_SOURCE', language : 'c')
-add_project_arguments('-D__BSD_VISIBLE', language : 'c')
-add_project_arguments('-D_XOPEN_SOURCE=700', language : 'c')
+add_project_arguments('-D_BSD_SOURCE', language: 'c')
+add_project_arguments('-D__BSD_VISIBLE', language: 'c')
+add_project_arguments('-D_XOPEN_SOURCE=700', language: 'c')
 
 # needed for memfd_create()
-add_project_arguments('-D_GNU_SOURCE', language : 'c')
+add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
 # needed for memmem()
-add_project_arguments('-D_DARWIN_C_SOURCE=900000', language : 'c')
+add_project_arguments('-D_DARWIN_C_SOURCE=900000', language: 'c')
 
 # sanity check
 if get_option('build') == 'all'
@@ -196,8 +196,8 @@ mandir = join_paths(prefix, get_option('mandir'))
 localedir = join_paths(prefix, get_option('localedir'))
 
 diffcmd = find_program('diff')
-gio = dependency('gio-2.0', version : '>= 2.45.8')
-giounix = dependency('gio-unix-2.0', version : '>= 2.45.8', required: false)
+gio = dependency('gio-2.0', version: '>= 2.45.8')
+giounix = dependency('gio-unix-2.0', version: '>= 2.45.8', required: false)
 if giounix.found()
   conf.set('HAVE_GIO_UNIX', '1')
 endif
@@ -206,7 +206,7 @@ if gio.version().version_compare ('>= 2.55.0')
 endif
 gmodule = dependency('gmodule-2.0')
 if build_standalone
-gudev = dependency('gudev-1.0', version : '>= 232',
+gudev = dependency('gudev-1.0', version: '>= 232',
                     required: get_option('gudev').disable_auto_if(host_machine.system() != 'linux'))
 if gudev.found()
   conf.set('HAVE_GUDEV', '1')
@@ -218,8 +218,8 @@ endif
 if get_option('hsi')
   conf.set('HAVE_HSI', '1')
 endif
-libxmlb = dependency('xmlb', version : '>= 0.1.13', fallback : ['libxmlb', 'libxmlb_dep'])
-gusb = dependency('gusb', version : '>= 0.3.0', fallback : ['gusb', 'gusb_dep'], required: get_option('gusb'))
+libxmlb = dependency('xmlb', version: '>= 0.1.13', fallback: ['libxmlb', 'libxmlb_dep'])
+gusb = dependency('gusb', version: '>= 0.3.0', fallback: ['gusb', 'gusb_dep'], required: get_option('gusb'))
 if gusb.found()
   conf.set('HAVE_GUSB', '1')
 endif
@@ -235,24 +235,24 @@ if libarchive.found()
   endif
 endif
 endif
-libjcat = dependency('jcat', version : '>= 0.1.4', fallback : ['libjcat', 'libjcat_dep'])
-libjsonglib = dependency('json-glib-1.0', version : '>= 1.1.1')
+libjcat = dependency('jcat', version: '>= 0.1.4', fallback: ['libjcat', 'libjcat_dep'])
+libjsonglib = dependency('json-glib-1.0', version: '>= 1.1.1')
 valgrind = dependency('valgrind', required: false)
-libcurl = dependency('libcurl', version : '>= 7.56.0', required: get_option('curl'))
+libcurl = dependency('libcurl', version: '>= 7.56.0', required: get_option('curl'))
 if libcurl.found()
   conf.set('HAVE_LIBCURL', '1')
   if libcurl.version().version_compare('>= 7.62.0')
     conf.set('HAVE_LIBCURL_7_62_0', '1')
   endif
 endif
-polkit = dependency('polkit-gobject-1', version : '>= 0.103',
+polkit = dependency('polkit-gobject-1', version: '>= 0.103',
          required: get_option('polkit').disable_auto_if(host_machine.system() != 'linux'))
 if polkit.found()
   conf.set('HAVE_POLKIT', '1')
   if polkit.version().version_compare('>= 0.114')
     conf.set('HAVE_POLKIT_0_114', '1')
   endif
-  conf.set_quoted ('POLKIT_ACTIONDIR', polkit.get_variable(pkgconfig : 'actiondir'))
+  conf.set_quoted ('POLKIT_ACTIONDIR', polkit.get_variable(pkgconfig: 'actiondir'))
 endif
 if build_daemon
   if not polkit.found()
@@ -261,11 +261,11 @@ if build_daemon
   udevdir = get_option('udevdir')
   if udevdir == '' and host_machine.system() == 'linux'
     udev = dependency('udev')
-    udevdir = udev.get_variable(pkgconfig : 'udevdir')
+    udevdir = udev.get_variable(pkgconfig: 'udevdir')
   endif
 endif
 libm = cc.find_library('m', required: false)
-libgcab = dependency('libgcab-1.0', version : '>= 1.0', fallback : ['gcab', 'gcab_dep'])
+libgcab = dependency('libgcab-1.0', version: '>= 1.0', fallback: ['gcab', 'gcab_dep'])
 if libgcab.type_name() == 'pkgconfig' and cc.has_function('gcab_file_set_bytes', dependencies: libgcab)
   conf.set('HAVE_GCAB_FILE_SET_BYTES', '1')
 endif
@@ -277,7 +277,7 @@ else
   python3 = find_program('python3.8', 'python3', 'python3.9')
 endif
 
-gnutls = dependency('gnutls', version : '>= 3.6.0', required: get_option('gnutls'))
+gnutls = dependency('gnutls', version: '>= 3.6.0', required: get_option('gnutls'))
 if gnutls.found()
   conf.set('HAVE_GNUTLS', '1')
 endif
@@ -287,7 +287,7 @@ if lzma.found()
   conf.set('HAVE_LZMA', '1')
 endif
 
-cbor = dependency('libcbor', version : '>= 0.7.0', required: get_option('cbor'))
+cbor = dependency('libcbor', version: '>= 0.7.0', required: get_option('cbor'))
 if cbor.found()
   conf.set('HAVE_CBOR', '1')
 endif
@@ -395,7 +395,7 @@ endif
 if cc.has_header_symbol('fcntl.h', 'F_OFD_SETLK')
   conf.set('HAVE_OFD', '1')
 endif
-if cc.has_function('pwrite', args : '-D_XOPEN_SOURCE')
+if cc.has_function('pwrite', args: '-D_XOPEN_SOURCE')
   conf.set('HAVE_PWRITE', '1')
 endif
 
@@ -409,7 +409,7 @@ efiboot = dependency('efiboot', required: get_option('plugin_uefi_capsule'))
 efivar = dependency('efivar', required: get_option('plugin_uefi_capsule'))
 if build_standalone and efiboot.found() and efivar.found()
 
-  if cc.has_header_symbol('efivar/efivar-types.h', 'efi_time_t', dependencies : efivar)
+  if cc.has_header_symbol('efivar/efivar-types.h', 'efi_time_t', dependencies: efivar)
     conf.set('HAVE_EFI_TIME_T', '1')
   endif
 
@@ -449,29 +449,29 @@ umockdev = dependency('umockdev-1.0', required: false)
 
 if build_standalone
   libflashrom = dependency('flashrom', 
-                            fallback : ['flashrom', 'flashrom_dep'], 
+                            fallback: ['flashrom', 'flashrom_dep'], 
                             required: get_option('plugin_flashrom').disable_auto_if(host_machine.system() != 'linux'))
 endif
 
 if libsystemd.found()
-  systemd = dependency('systemd', version : '>= 211', required: get_option('systemd'))
+  systemd = dependency('systemd', version: '>= 211', required: get_option('systemd'))
   conf.set('HAVE_SYSTEMD' , '1')
   conf.set('HAVE_LOGIND' , '1')
   systemd_root_prefix = get_option('systemd_root_prefix')
   if systemd_root_prefix == ''
-    systemdunitdir = systemd.get_variable(pkgconfig : 'systemdsystemunitdir')
-    systemdsystempresetdir = systemd.get_variable(pkgconfig : 'systemdsystempresetdir')
-    systemd_shutdown_dir = systemd.get_variable(pkgconfig : 'systemdshutdowndir')
-    systemd_modules_load_dir = systemd.get_variable(pkgconfig : 'modulesloaddir')
+    systemdunitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
+    systemdsystempresetdir = systemd.get_variable(pkgconfig: 'systemdsystempresetdir')
+    systemd_shutdown_dir = systemd.get_variable(pkgconfig: 'systemdshutdowndir')
+    systemd_modules_load_dir = systemd.get_variable(pkgconfig: 'modulesloaddir')
   else
-    systemdunitdir = systemd.get_variable(pkgconfig : 'systemdsystemunitdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
-    systemdsystempresetdir = systemd.get_variable(pkgconfig : 'systemdsystempresetdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
+    systemdunitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
+    systemdsystempresetdir = systemd.get_variable(pkgconfig: 'systemdsystempresetdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
     systemd_root_prefix_varname = 'root_prefix'
     if systemd.version().version_compare('< 246')
       systemd_root_prefix_varname = 'rootprefix'
     endif
-    systemd_shutdown_dir = systemd.get_variable(pkgconfig : 'systemdshutdowndir', pkgconfig_define: [systemd_root_prefix_varname, systemd_root_prefix])
-    systemd_modules_load_dir = systemd.get_variable(pkgconfig : 'modulesloaddir', pkgconfig_define: [systemd_root_prefix_varname, systemd_root_prefix])
+    systemd_shutdown_dir = systemd.get_variable(pkgconfig: 'systemdshutdowndir', pkgconfig_define: [systemd_root_prefix_varname, systemd_root_prefix])
+    systemd_modules_load_dir = systemd.get_variable(pkgconfig: 'modulesloaddir', pkgconfig_define: [systemd_root_prefix_varname, systemd_root_prefix])
   endif
 endif
 
@@ -524,8 +524,8 @@ conf.set_quoted('MOTD_FILE', motd_file)
 conf.set_quoted('MOTD_DIR', motd_dir)
 
 configure_file(
-  output : 'config.h',
-  configuration : conf
+  output: 'config.h',
+  configuration: conf
 )
 
 protobufc = dependency('libprotobuf-c', required: get_option('plugin_logitech_bulkcontroller'))
@@ -560,7 +560,7 @@ if polkit.found()
   subdir('policy')
 endif
 if build_standalone
-  gcab = find_program('gcab', required : get_option('tests'))
+  gcab = find_program('gcab', required: get_option('tests'))
   subdir('data')
   subdir('po')
   subdir('libfwupdplugin')

--- a/plugins/acpi-dmar/meson.build
+++ b/plugins/acpi-dmar/meson.build
@@ -5,23 +5,23 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiDmar"']
 
 shared_module('fu_plugin_acpi_dmar',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-acpi-dmar.c',
     'fu-acpi-dmar.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -33,25 +33,25 @@ if get_option('tests')
   e = executable(
     'acpi-dmar-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-acpi-dmar.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('acpi-dmar-self-test', e, env : env)  # added to installed-tests
+  test('acpi-dmar-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/acpi-facp/meson.build
+++ b/plugins/acpi-facp/meson.build
@@ -3,23 +3,23 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiFacp"']
 
 shared_module('fu_plugin_acpi_facp',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-acpi-facp.c',
     'fu-acpi-facp.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -31,25 +31,25 @@ if get_option('tests')
   e = executable(
     'acpi-facp-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-acpi-facp.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('acpi-facp-self-test', e, env : env)  # added to installed-tests
+  test('acpi-facp-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/acpi-ivrs/meson.build
+++ b/plugins/acpi-ivrs/meson.build
@@ -5,23 +5,23 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiIvrs"']
 
 shared_module('fu_plugin_acpi_ivrs',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-acpi-ivrs.c',
     'fu-acpi-ivrs.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -33,25 +33,25 @@ if get_option('tests')
   e = executable(
     'acpi-ivrs-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-acpi-ivrs.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('acpi-ivrs-self-test', e, env : env)  # added to installed-tests
+  test('acpi-ivrs-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/acpi-phat/meson.build
+++ b/plugins/acpi-phat/meson.build
@@ -3,26 +3,26 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiPhat"']
 
 shared_module('fu_plugin_acpi_phat',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-acpi-phat.c',
     'fu-acpi-phat.c',                 # fuzzing
     'fu-acpi-phat-health-record.c',   # fuzzing
     'fu-acpi-phat-version-element.c', # fuzzing
     'fu-acpi-phat-version-record.c',  # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -34,28 +34,28 @@ if get_option('tests')
   e = executable(
     'acpi-phat-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-acpi-phat.c',
       'fu-acpi-phat-health-record.c',
       'fu-acpi-phat-version-element.c',
       'fu-acpi-phat-version-record.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('acpi-phat-self-test', e, env : env)  # added to installed-tests
+  test('acpi-phat-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/amt/meson.build
+++ b/plugins/amt/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginAmt"']
 
 shared_module('fu_plugin_amt',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-amt.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/analogix/meson.build
+++ b/plugins/analogix/meson.build
@@ -7,25 +7,25 @@ install_data(['analogix.quirk'],
 
 shared_module('fu_plugin_analogix',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-analogix.c',
     'fu-analogix-device.c',
     'fu-analogix-common.c',
     'fu-analogix-firmware.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/ata/meson.build
+++ b/plugins/ata/meson.build
@@ -9,26 +9,26 @@ install_data([
 
 shared_module('fu_plugin_ata',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-ata.c',
     'fu-ata-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -41,25 +41,25 @@ if get_option('tests')
   e = executable(
     'ata-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-ata-device.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('ata-self-test', e, env : env)  # added to installed-tests
+  test('ata-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/bcm57xx/meson.build
+++ b/plugins/bcm57xx/meson.build
@@ -7,7 +7,7 @@ install_data(['bcm57xx.quirk'],
 )
 shared_module('fu_plugin_bcm57xx',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-bcm57xx.c',
     'fu-bcm57xx-common.c',          # fuzzing
     'fu-bcm57xx-device.c',
@@ -17,19 +17,19 @@ shared_module('fu_plugin_bcm57xx',
     'fu-bcm57xx-stage1-image.c',    # fuzzing
     'fu-bcm57xx-stage2-image.c',    # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     valgrind,
   ],
@@ -44,7 +44,7 @@ if get_option('tests')
   e = executable(
     'bcm57xx-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-bcm57xx-common.c',
       'fu-bcm57xx-dict-image.c',
@@ -52,21 +52,21 @@ if get_option('tests')
       'fu-bcm57xx-stage1-image.c',
       'fu-bcm57xx-stage2-image.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('bcm57xx-self-test', e, env : env)
+  test('bcm57xx-self-test', e, env: env)
 endif
 endif

--- a/plugins/bios/meson.build
+++ b/plugins/bios/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginBios"']
 
 shared_module('fu_plugin_bios',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-bios.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/ccgx/meson.build
+++ b/plugins/ccgx/meson.build
@@ -10,7 +10,7 @@ install_data([
 
 shared_module('fu_plugin_ccgx',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-ccgx.c',
     'fu-ccgx-common.c',         # fuzzing
     'fu-ccgx-firmware.c',       # fuzzing
@@ -21,19 +21,19 @@ shared_module('fu_plugin_ccgx',
     'fu-ccgx-dmc-firmware.c',   # fuzzing
     'fu-ccgx-dmc-common.c',     # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     gudev,
   ],
@@ -49,27 +49,27 @@ if get_option('tests')
   e = executable(
     'ccgx-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-ccgx-common.c',
       'fu-ccgx-firmware.c',
       'fu-ccgx-dmc-common.c',
       'fu-ccgx-dmc-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('ccgx-self-test', e, env : env)
+  test('ccgx-self-test', e, env: env)
 endif

--- a/plugins/cfu/meson.build
+++ b/plugins/cfu/meson.build
@@ -10,24 +10,24 @@ install_data([
 
 shared_module('fu_plugin_cfu',
   fu_hash,
-  sources : [
+  sources: [
     'fu-cfu-device.c',
     'fu-cfu-module.c',
     'fu-plugin-cfu.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/ch341a/meson.build
+++ b/plugins/ch341a/meson.build
@@ -9,24 +9,24 @@ install_data([
 
 shared_module('fu_plugin_ch341a',
   fu_hash,
-  sources : [
+  sources: [
     'fu-ch341a-cfi-device.c',
     'fu-ch341a-device.c',
     'fu-plugin-ch341a.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/colorhug/meson.build
+++ b/plugins/colorhug/meson.build
@@ -9,24 +9,24 @@ install_data([
 
 shared_module('fu_plugin_colorhug',
   fu_hash,
-  sources : [
+  sources: [
     'fu-colorhug-common.c',
     'fu-colorhug-device.c',
     'fu-plugin-colorhug.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/corsair/meson.build
+++ b/plugins/corsair/meson.build
@@ -7,25 +7,25 @@ install_data(['corsair.quirk'],
 
 shared_module('fu_plugin_corsair',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-corsair.c',
     'fu-corsair-common.c',
     'fu-corsair-device.c',
     'fu-corsair-bp.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/cpu/meson.build
+++ b/plugins/cpu/meson.build
@@ -8,23 +8,23 @@ install_data(['cpu.quirk'],
 
 shared_module('fu_plugin_cpu',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-cpu.c',
     'fu-cpu-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -39,7 +39,7 @@ static void __attribute__((noinline,noclone)) f(void) {}
 # verify the compiler knows what to do
 if cc.has_argument('-fcf-protection')
   build_fwupdcethelper = cc.compiles(code,
-    name : '__attribute__((noinline,noclone))',
+    name: '__attribute__((noinline,noclone))',
   )
 else
   build_fwupdcethelper = false
@@ -47,30 +47,30 @@ endif
 
 if build_fwupdcethelper
   libfwupdcethelper = static_library('fwupdcethelper',
-    sources : [
+    sources: [
       'fu-cpu-helper-cet-common.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
     ],
-    c_args : ['-fcf-protection=none'],
-    install : false,
+    c_args: ['-fcf-protection=none'],
+    install: false,
   )
 
   executable(
     'fwupd-detect-cet',
-    sources : [
+    sources: [
       'fu-cpu-helper-cet.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
     ],
-    link_with : [
+    link_with: [
       libfwupdcethelper,
     ],
-    c_args : ['-fcf-protection=full'],
-    install : true,
-    install_dir : join_paths(libexecdir, 'fwupd')
+    c_args: ['-fcf-protection=full'],
+    install: true,
+    install_dir: join_paths(libexecdir, 'fwupd')
   )
 endif
 endif

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -7,25 +7,25 @@ install_data(['cros-ec.quirk'],
 
 shared_module('fu_plugin_cros_ec',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-cros-ec.c',
     'fu-cros-ec-usb-device.c',
     'fu-cros-ec-common.c',      # fuzzing
     'fu-cros-ec-firmware.c',    # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/dell-dock/meson.build
+++ b/plugins/dell-dock/meson.build
@@ -7,7 +7,7 @@ install_data(['dell-dock.quirk'],
 
 shared_module('fu_plugin_dell_dock',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-dell-dock.c',
     'fu-dell-dock-common.c',
     'fu-dell-dock-hid.c',
@@ -18,19 +18,19 @@ shared_module('fu_plugin_dell_dock',
     'fu-dell-dock-i2c-mst.c',
     'fu-dell-dock-usb-usb4.c'
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     gudev,
   ],

--- a/plugins/dell-esrt/meson.build
+++ b/plugins/dell-esrt/meson.build
@@ -2,29 +2,29 @@ if libsmbios_c.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginDellEsrt"']
 
 install_data(['metadata.xml'],
-  install_dir : join_paths(datadir, 'fwupd', 'remotes.d', 'dell-esrt')
+  install_dir: join_paths(datadir, 'fwupd', 'remotes.d', 'dell-esrt')
 )
 
 shared_module('fu_plugin_dell_esrt',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-dell-esrt.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     libsmbios_c,
   ],
@@ -34,9 +34,9 @@ shared_module('fu_plugin_dell_esrt',
 con2 = configuration_data()
 con2.set('datadir', datadir)
 configure_file(
-  input : 'dell-esrt.conf',
-  output : 'dell-esrt.conf',
-  configuration : con2,
+  input: 'dell-esrt.conf',
+  output: 'dell-esrt.conf',
+  configuration: con2,
   install: true,
   install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 )

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -1,5 +1,5 @@
-tpm2tss_dell = dependency('tss2-esys', version : '>= 2.0', required: get_option('plugin_dell'))
-libsmbios_c = dependency('libsmbios_c', version : '>= 2.4.0', required: get_option('plugin_dell'))
+tpm2tss_dell = dependency('tss2-esys', version: '>= 2.0', required: get_option('plugin_dell'))
+libsmbios_c = dependency('libsmbios_c', version: '>= 2.4.0', required: get_option('plugin_dell'))
 
 if tpm2tss_dell.found() and libsmbios_c.found() and \
    get_option('plugin_dell').require(get_option('plugin_uefi_capsule').allowed(),
@@ -13,25 +13,25 @@ install_data(['dell.quirk'],
 
 shared_module('fu_plugin_dell',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-dell.c',
     'fu-dell-smi.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     cargs,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     libsmbios_c,
     tpm2tss_dell,
@@ -46,30 +46,30 @@ if get_option('tests')
   e = executable(
     'dell-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-dell-smi.c',
       'fu-plugin-dell.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       libsmbios_c,
       valgrind,
       tpm2tss_dell,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : [
+    c_args: [
       cargs,
     ],
   )
-  test('dell-self-test', e, env : env)
+  test('dell-self-test', e, env: env)
 endif
 endif

--- a/plugins/dfu-csr/meson.build
+++ b/plugins/dfu-csr/meson.build
@@ -7,23 +7,23 @@ install_data(['dfu-csr.quirk'],
 
 shared_module('fu_plugin_dfu_csr',
   fu_hash,
-  sources : [
+  sources: [
     'fu-dfu-csr-device.c',
     'fu-plugin-dfu-csr.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
     plugindfu_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupdplugin,
     dfu,
   ],

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -8,7 +8,7 @@ install_data(['dfu.quirk'],
 dfu = static_library(
   'dfu',
   fu_hash,
-  sources : [
+  sources: [
     'fu-dfu-common.c',
     'fu-dfu-device.c',
     'fu-dfu-sector.c',
@@ -16,16 +16,16 @@ dfu = static_library(
     'fu-dfu-target-stm.c',
     'fu-dfu-target-avr.c',
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     libm,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  include_directories : [
+  c_args: cargs,
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
@@ -34,22 +34,22 @@ dfu = static_library(
 
 shared_module('fu_plugin_dfu',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-dfu.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     libm,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
     dfu,
@@ -60,33 +60,33 @@ if get_option('compat_cli')
 fu_dfu_tool = executable(
   'dfu-tool',
   fu_hash,
-  sources : [
+  sources: [
     'fu-dfu-tool.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     dfu,
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  install : true,
-  install_dir : bindir
+  c_args: cargs,
+  install: true,
+  install_dir: bindir
 )
 endif
 
 if get_option('compat_cli') and get_option('man')
   configure_file(
-    input : 'dfu-tool.1',
-    output : 'dfu-tool.1',
-    configuration : conf,
+    input: 'dfu-tool.1',
+    output: 'dfu-tool.1',
+    configuration: conf,
     install: true,
     install_dir: join_paths(mandir, 'man1'),
   )
@@ -99,27 +99,27 @@ if get_option('tests')
   e = executable(
     'fu-dfu-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-dfu-self-test.c'
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       libm,
     ],
-    link_with : [
+    link_with: [
       dfu,
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('fu-dfu-self-test', e, env : env)  # added to installed-tests
+  test('fu-dfu-self-test', e, env: env)  # added to installed-tests
 endif
 
 plugindfu_incdir = include_directories('.')

--- a/plugins/ebitdo/meson.build
+++ b/plugins/ebitdo/meson.build
@@ -7,25 +7,25 @@ install_data(['ebitdo.quirk'],
 
 shared_module('fu_plugin_ebitdo',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-ebitdo.c',
     'fu-ebitdo-common.c',
     'fu-ebitdo-device.c',
     'fu-ebitdo-firmware.c',     # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/elanfp/meson.build
+++ b/plugins/elanfp/meson.build
@@ -7,24 +7,24 @@ install_data(['elanfp.quirk'],
 
 shared_module('fu_plugin_elanfp',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-elanfp.c',
     'fu-elanfp-device.c',
     'fu-elanfp-firmware.c'  # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/elantp/meson.build
+++ b/plugins/elantp/meson.build
@@ -9,28 +9,28 @@ install_data([
 
 shared_module('fu_plugin_elantp',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-elantp.c',
     'fu-elantp-firmware.c',   # fuzzing
     'fu-elantp-hid-device.c',
     'fu-elantp-i2c-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -45,24 +45,24 @@ if get_option('tests')
   e = executable(
     'elantp-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-elantp-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('elantp-self-test', e, env : env)
+  test('elantp-self-test', e, env: env)
 endif

--- a/plugins/emmc/meson.build
+++ b/plugins/emmc/meson.build
@@ -8,23 +8,23 @@ install_data(['emmc.quirk'],
 )
 shared_module('fu_plugin_emmc',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-emmc.c',
     'fu-emmc-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/ep963x/meson.build
+++ b/plugins/ep963x/meson.build
@@ -9,25 +9,25 @@ install_data([
 
 shared_module('fu_plugin_ep963x',
   fu_hash,
-  sources : [
+  sources: [
     'fu-ep963x-common.c',
     'fu-ep963x-device.c',
     'fu-ep963x-firmware.c',
     'fu-plugin-ep963x.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/fastboot/meson.build
+++ b/plugins/fastboot/meson.build
@@ -8,23 +8,23 @@ install_data(['fastboot.quirk'],
 
 shared_module('fu_plugin_fastboot',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-fastboot.c',
     'fu-fastboot-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -8,27 +8,27 @@ install_data(['flashrom.quirk'],
 
 shared_module('fu_plugin_flashrom',
   fu_hash,
-  sources : [
+  sources: [
     'fu-flashrom-device.c',
     'fu-plugin-flashrom.c',
     'fu-flashrom-cmos.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     libflashrom,
   ],

--- a/plugins/fresco-pd/meson.build
+++ b/plugins/fresco-pd/meson.build
@@ -7,25 +7,25 @@ install_data(['fresco-pd.quirk'],
 
 shared_module('fu_plugin_fresco_pd',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-fresco-pd.c',
     'fu-fresco-pd-common.c',
     'fu-fresco-pd-device.c',
     'fu-fresco-pd-firmware.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/genesys/meson.build
+++ b/plugins/genesys/meson.build
@@ -9,26 +9,26 @@ install_data([
 
 shared_module('fu_plugin_genesys',
   fu_hash,
-  sources : [
+  sources: [
     'fu-genesys-scaler-firmware.c',   # fuzzing
     'fu-genesys-usbhub-firmware.c',   # fuzzing
     'fu-genesys-scaler-device.c',
     'fu-genesys-usbhub-device.c',
     'fu-plugin-genesys.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/goodix-moc/meson.build
+++ b/plugins/goodix-moc/meson.build
@@ -9,23 +9,23 @@ install_data([
 
 shared_module('fu_plugin_goodixmoc',
   fu_hash,
-  sources : [
+  sources: [
     'fu-goodixmoc-device.c',
     'fu-plugin-goodixmoc.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/gpio/meson.build
+++ b/plugins/gpio/meson.build
@@ -11,26 +11,26 @@ install_data([
 
 shared_module('fu_plugin_gpio',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-gpio.c',
     'fu-gpio-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/hailuck/meson.build
+++ b/plugins/hailuck/meson.build
@@ -9,7 +9,7 @@ install_data([
 
 shared_module('fu_plugin_hailuck',
   fu_hash,
-  sources : [
+  sources: [
     'fu-hailuck-common.c',
     'fu-hailuck-bl-device.c',
     'fu-hailuck-kbd-device.c',
@@ -17,19 +17,19 @@ shared_module('fu_plugin_hailuck',
     'fu-hailuck-tp-device.c',
     'fu-plugin-hailuck.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/intel-spi/meson.build
+++ b/plugins/intel-spi/meson.build
@@ -13,26 +13,26 @@ install_data(['intel-spi.quirk'],
 
 shared_module('fu_plugin_intel_spi',
   fu_hash,
-  sources : [
+  sources: [
     'fu-ifd-device.c',
     'fu-intel-spi-common.c',
     'fu-intel-spi-device.c',
     'fu-pci-device.c',
     'fu-plugin-intel-spi.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/iommu/meson.build
+++ b/plugins/iommu/meson.build
@@ -9,22 +9,22 @@ install_data([
 
 shared_module('fu_plugin_iommu',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-iommu.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupdplugin,
     fwupd,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/jabra/meson.build
+++ b/plugins/jabra/meson.build
@@ -7,23 +7,23 @@ install_data(['jabra.quirk'],
 
 shared_module('fu_plugin_jabra',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-jabra.c',
     'fu-jabra-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/lenovo-thinklmi/meson.build
+++ b/plugins/lenovo-thinklmi/meson.build
@@ -4,24 +4,24 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLenovoThinkLmi"']
 
 shared_module('fu_plugin_lenovo_thinklmi',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-lenovo-thinklmi.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -34,25 +34,25 @@ if get_option('tests')
   e = executable(
     'lenovo-thinklmi-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : [
+    c_args: [
       cargs,
     ],
   )
-  test('lenovo-thinklmi-self-test', e, env : env)
+  test('lenovo-thinklmi-self-test', e, env: env)
 endif
 endif

--- a/plugins/linux-lockdown/meson.build
+++ b/plugins/linux-lockdown/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxLockdown"']
 
 shared_module('fu_plugin_linux_lockdown',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-linux-lockdown.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/linux-sleep/meson.build
+++ b/plugins/linux-sleep/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSleep"']
 
 shared_module('fu_plugin_linux_sleep',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-linux-sleep.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/linux-swap/meson.build
+++ b/plugins/linux-swap/meson.build
@@ -3,23 +3,23 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSwap"']
 
 shared_module('fu_plugin_linux_swap',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-linux-swap.c',
     'fu-linux-swap.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -28,24 +28,24 @@ if get_option('tests')
   e = executable(
     'linux-swap-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-linux-swap.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
   test('linux-swap-self-test', e)  # added to installed-tests
 endif

--- a/plugins/linux-tainted/meson.build
+++ b/plugins/linux-tainted/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxTainted"']
 
 shared_module('fu_plugin_linux_tainted',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-linux-tainted.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/logind/meson.build
+++ b/plugins/logind/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginLogind"']
 
 shared_module('fu_plugin_logind',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-logind.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/logitech-bulkcontroller/meson.build
+++ b/plugins/logitech-bulkcontroller/meson.build
@@ -8,25 +8,25 @@ install_data(['logitech-bulkcontroller.quirk'],
 subdir('proto')
 shared_module('fu_plugin_logitech_bulkcontroller',
   fu_hash,
-  sources : [
+  sources: [
     generated,
     'fu-logitech-bulkcontroller-common.c',
     'fu-logitech-bulkcontroller-device.c',
     'fu-plugin-logitech-bulkcontroller.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/logitech-bulkcontroller/proto/meson.build
+++ b/plugins/logitech-bulkcontroller/proto/meson.build
@@ -1,7 +1,7 @@
 
 gen = generator(protoc, \
-  output    : ['@BASENAME@.pb-c.c', '@BASENAME@.pb-c.h'],
-  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--c_out=@BUILD_DIR@', '@INPUT@'])
+  output: ['@BASENAME@.pb-c.c', '@BASENAME@.pb-c.h'],
+  arguments: ['--proto_path=@CURRENT_SOURCE_DIR@', '--c_out=@BUILD_DIR@', '@INPUT@'])
 
 src = [
        'antiflicker.proto',

--- a/plugins/logitech-hidpp/meson.build
+++ b/plugins/logitech-hidpp/meson.build
@@ -10,7 +10,7 @@ install_data([
 
 shared_module('fu_plugin_logitech_hidpp',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-logitech-hidpp.c',
     'fu-logitech-hidpp-bootloader.c',
     'fu-logitech-hidpp-bootloader-nordic.c',
@@ -24,19 +24,19 @@ shared_module('fu_plugin_logitech_hidpp',
     'fu-logitech-hidpp-runtime-bolt.c',
     'fu-logitech-hidpp-radio.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -45,23 +45,23 @@ if get_option('tests')
   e = executable(
     'logitech-hidpp-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-logitech-hidpp-self-test.c',
       'fu-logitech-hidpp-common.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs,
+    c_args: cargs,
   )
   test('logitech-hidpp-self-test', e)
 endif

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -1,6 +1,6 @@
-libmm_glib = dependency('mm-glib', version : '>= 1.10.0', required: get_option('plugin_modem_manager'))
-libqmi_glib = dependency('qmi-glib', version : '>= 1.23.1', required: get_option('plugin_modem_manager'))
-libmbim_glib = dependency('mbim-glib', version : '>= 1.22.0', required: get_option('plugin_modem_manager'))
+libmm_glib = dependency('mm-glib', version: '>= 1.10.0', required: get_option('plugin_modem_manager'))
+libqmi_glib = dependency('qmi-glib', version: '>= 1.23.1', required: get_option('plugin_modem_manager'))
+libmbim_glib = dependency('mbim-glib', version: '>= 1.22.0', required: get_option('plugin_modem_manager'))
 
 if libmm_glib.found() and \
    libqmi_glib.found() and \
@@ -17,7 +17,7 @@ install_data(['modem-manager.quirk'],
 
 shared_module('fu_plugin_modem_manager',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-modem-manager.c',
     'fu-mm-device.c',
     'fu-qmi-pdc-updater.c',
@@ -26,21 +26,21 @@ shared_module('fu_plugin_modem_manager',
     'fu-sahara-loader.c',
     'fu-mm-utils.c'
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     libmm_glib,
     libqmi_glib,

--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -12,26 +12,26 @@ install_data(['fwupd-msr.conf'],
 endif
 
 install_data(['msr.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
+  install_dir: join_paths(sysconfdir, 'fwupd')
 )
 shared_module('fu_plugin_msr',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-msr.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/mtd/meson.build
+++ b/plugins/mtd/meson.build
@@ -9,23 +9,23 @@ install_data([
 
 shared_module('fu_plugin_mtd',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-mtd.c',
     'fu-mtd-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -33,25 +33,25 @@ shared_module('fu_plugin_mtd',
 if get_option('tests')
   e = executable(
     'mtd-self-test',
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-mtd-device.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    c_args : cargs,
-    dependencies : [
+    c_args: cargs,
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
   test('mtd-self-test', e)  # added to installed-tests
 endif

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -7,24 +7,24 @@ install_data(['nitrokey.quirk'],
 
 shared_module('fu_plugin_nitrokey',
   fu_hash,
-  sources : [
+  sources: [
     'fu-nitrokey-device.c',
     'fu-nitrokey-common.c',
     'fu-plugin-nitrokey.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -33,24 +33,24 @@ if get_option('tests')
   e = executable(
     'nitrokey-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-nitrokey-common.c',
       'fu-self-test.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       valgrind,
     ],
-    link_with : [
+    link_with: [
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
   test('nitrokey-self-test', e)  # added to installed-tests
 endif

--- a/plugins/nordic-hid/meson.build
+++ b/plugins/nordic-hid/meson.build
@@ -9,7 +9,7 @@ install_data([
 
 shared_module('fu_plugin_nordic_hid',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-nordic-hid.c',
     'fu-nordic-hid-cfg-channel.c',
     'fu-nordic-hid-firmware.c',
@@ -17,19 +17,19 @@ shared_module('fu_plugin_nordic_hid',
     'fu-nordic-hid-firmware-mcuboot.c',
     'fu-nordic-hid-archive.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -13,27 +13,27 @@ install_data([
 
 shared_module('fu_plugin_nvme',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-nvme.c',
     'fu-nvme-common.c',
     'fu-nvme-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -46,26 +46,26 @@ if get_option('tests')
   e = executable(
     'nvme-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-nvme-common.c',
       'fu-nvme-device.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('nvme-self-test', e, env : env)  # added to installed-tests
+  test('nvme-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/optionrom/meson.build
+++ b/plugins/optionrom/meson.build
@@ -7,23 +7,23 @@ install_data(['optionrom.quirk'],
 
 shared_module('fu_plugin_optionrom',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-optionrom.c',
     'fu-optionrom-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/parade-lspcon/meson.build
+++ b/plugins/parade-lspcon/meson.build
@@ -9,26 +9,26 @@ install_data(['parade-lspcon.quirk'],
 
 shared_module('fu_plugin_parade_lspcon',
   fu_hash,
-  sources : [
+  sources: [
     'fu-parade-lspcon-device.c',
     'fu-plugin-parade-lspcon.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/pci-bcr/meson.build
+++ b/plugins/pci-bcr/meson.build
@@ -7,22 +7,22 @@ install_data(['pci-bcr.quirk'],
 
 shared_module('fu_plugin_pci_bcr',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-pci-bcr.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/pci-mei/meson.build
+++ b/plugins/pci-mei/meson.build
@@ -7,23 +7,23 @@ install_data(['pci-mei.quirk'],
 
 shared_module('fu_plugin_pci_mei',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-pci-mei.c',
     'fu-mei-common.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/pci-psp/meson.build
+++ b/plugins/pci-psp/meson.build
@@ -9,22 +9,22 @@ install_data(['pci-psp.quirk'],
 
 shared_module('fu_plugin_pci_psp',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-pci-psp.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/pixart-rf/meson.build
+++ b/plugins/pixart-rf/meson.build
@@ -7,7 +7,7 @@ install_data(['pixart-rf.quirk'],
 
 shared_module('fu_plugin_pixart_rf',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-pixart-rf.c',
     'fu-pxi-common.c',
     'fu-pxi-ble-device.c',
@@ -15,18 +15,18 @@ shared_module('fu_plugin_pixart_rf',
     'fu-pxi-wireless-device.c',
     'fu-pxi-firmware.c',      # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
@@ -41,25 +41,25 @@ if get_option('tests')
   e = executable(
     'pxi-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-pxi-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('pxi-self-test', e, env : env)
+  test('pxi-self-test', e, env: env)
 endif
 endif

--- a/plugins/powerd/meson.build
+++ b/plugins/powerd/meson.build
@@ -4,22 +4,22 @@ if get_option('plugin_powerd').disable_auto_if(host_machine.system() != 'linux')
 
 shared_module('fu_plugin_powerd',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-powerd.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/realtek-mst/meson.build
+++ b/plugins/realtek-mst/meson.build
@@ -8,26 +8,26 @@ install_data(['realtek-mst.quirk'],
 
 shared_module('fu_plugin_realtek_mst',
   fu_hash,
-  sources : [
+  sources: [
     'fu-realtek-mst-device.c',
     'fu-plugin-realtek-mst.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -13,7 +13,7 @@ endif
 
 shared_module('fu_plugin_redfish',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-redfish.c',
     'fu-redfish-backend.c',
     'fu-redfish-common.c',     # fuzzing
@@ -26,26 +26,26 @@ shared_module('fu_plugin_redfish',
     'fu-redfish-smbios.c',     # fuzzing
     ipmi_src,
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     libcurl,
   ],
 )
 
 install_data(['redfish.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd'),
+  install_dir: join_paths(sysconfdir, 'fwupd'),
 )
 
 if get_option('tests')
@@ -64,7 +64,7 @@ if get_option('tests')
   e = executable(
     'redfish-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-redfish-backend.c',
       'fu-redfish-common.c',
@@ -77,23 +77,23 @@ if get_option('tests')
       'fu-redfish-smbios.c',
       ipmi_src,
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    c_args : cargs,
-    dependencies : [
+    c_args: cargs,
+    dependencies: [
       plugin_deps,
       libcurl,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('redfish-self-test', e, env : env)  # added to installed-tests
+  test('redfish-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/rts54hid/meson.build
+++ b/plugins/rts54hid/meson.build
@@ -9,24 +9,24 @@ install_data([
 
 shared_module('fu_plugin_rts54hid',
   fu_hash,
-  sources : [
+  sources: [
     'fu-rts54hid-device.c',
     'fu-rts54hid-module.c',
     'fu-plugin-rts54hid.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/rts54hub/meson.build
+++ b/plugins/rts54hub/meson.build
@@ -9,26 +9,26 @@ install_data([
 
 shared_module('fu_plugin_rts54hub',
   fu_hash,
-  sources : [
+  sources: [
     'fu-rts54hub-device.c',
     'fu-rts54hub-rtd21xx-device.c',
     'fu-rts54hub-rtd21xx-background.c',
     'fu-rts54hub-rtd21xx-foreground.c',
     'fu-plugin-rts54hub.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/scsi/meson.build
+++ b/plugins/scsi/meson.build
@@ -10,26 +10,26 @@ install_data([
 
 shared_module('fu_plugin_scsi',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-scsi.c',
     'fu-scsi-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/steelseries/meson.build
+++ b/plugins/steelseries/meson.build
@@ -7,7 +7,7 @@ install_data(['steelseries.quirk'],
 
 shared_module('fu_plugin_steelseries',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-steelseries.c',
     'fu-steelseries-device.c',
     'fu-steelseries-firmware.c',
@@ -18,19 +18,19 @@ shared_module('fu_plugin_steelseries',
     'fu-steelseries-gamepad.c',
     'fu-steelseries-sonic.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/superio/meson.build
+++ b/plugins/superio/meson.build
@@ -7,7 +7,7 @@ install_data(['superio.quirk'],
 
 shared_module('fu_plugin_superio',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-superio.c',
     'fu-superio-device.c',
     'fu-superio-it55-device.c',
@@ -15,19 +15,19 @@ shared_module('fu_plugin_superio',
     'fu-superio-it89-device.c',
     'fu-superio-common.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/synaptics-cape/meson.build
+++ b/plugins/synaptics-cape/meson.build
@@ -7,24 +7,24 @@ install_data(['synaptics-cape.quirk'],
 
 shared_module('fu_plugin_synaptics_cape',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-synaptics-cape.c',
     'fu-synaptics-cape-device.c',
     'fu-synaptics-cape-firmware.c', # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/synaptics-cxaudio/meson.build
+++ b/plugins/synaptics-cxaudio/meson.build
@@ -7,24 +7,24 @@ install_data(['synaptics-cxaudio.quirk'],
 
 shared_module('fu_plugin_synaptics_cxaudio',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-synaptics-cxaudio.c',
     'fu-synaptics-cxaudio-device.c',
     'fu-synaptics-cxaudio-firmware.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -8,28 +8,28 @@ install_data(['synaptics-mst.quirk'],
 
 shared_module('fu_plugin_synaptics_mst',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-synaptics-mst.c',
     'fu-synaptics-mst-common.c',
     'fu-synaptics-mst-connection.c',
     'fu-synaptics-mst-device.c',
     'fu-synaptics-mst-firmware.c',      # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : [
+  c_args: [
     cargs,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -45,31 +45,31 @@ if get_option('tests')
   e = executable(
     'synaptics-mst-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-synaptics-mst-common.c',
       'fu-synaptics-mst-connection.c',
       'fu-synaptics-mst-device.c',
       'fu-synaptics-mst-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       valgrind,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : [
+    c_args: [
       cargs,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
   test('synaptics-mst-self-test', e, env: env)
 endif

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -7,26 +7,26 @@ install_data(['synaptics-prometheus.quirk'],
 
 shared_module('fu_plugin_synaptics_prometheus',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-synaptics-prometheus.c',
     'fu-synaprom-common.c',
     'fu-synaprom-config.c',
     'fu-synaprom-device.c',
     'fu-synaprom-firmware.c',       # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -40,29 +40,29 @@ if get_option('tests')
   e = executable(
     'synaptics-prometheus-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-synaprom-common.c',
       'fu-synaprom-config.c',
       'fu-synaprom-device.c',
       'fu-synaprom-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs,
-    install : true,
-    install_dir : installed_test_bindir,
+    c_args: cargs,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('synaptics-prometheus-self-test', e, env : env)  # added to installed-tests
+  test('synaptics-prometheus-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -10,7 +10,7 @@ install_data(['synaptics-rmi.quirk'],
 
 shared_module('fu_plugin_synaptics_rmi',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-synaptics-rmi.c',
     'fu-synaptics-rmi-common.c',      # fuzzing
     'fu-synaptics-rmi-device.c',
@@ -21,18 +21,18 @@ shared_module('fu_plugin_synaptics_rmi',
     'fu-synaptics-rmi-v7-device.c',
     'fu-synaptics-rmi-firmware.c',    # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
@@ -47,26 +47,26 @@ if get_option('tests')
   e = executable(
     'synaptics-rmi-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-synaptics-rmi-common.c',
       'fu-synaptics-rmi-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('synaptics-rmi-self-test', e, env : env)
+  test('synaptics-rmi-self-test', e, env: env)
 endif
 endif

--- a/plugins/system76-launch/meson.build
+++ b/plugins/system76-launch/meson.build
@@ -7,23 +7,23 @@ install_data(['system76-launch.quirk'],
 
 shared_module('fu_plugin_system76_launch',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-system76-launch.c',
     'fu-system76-launch-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/test/meson.build
+++ b/plugins/test/meson.build
@@ -13,43 +13,43 @@ endif
 
 shared_module('fu_plugin_test',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-test.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : install_dummy,
+  install: install_dummy,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
 
 shared_module('fu_plugin_invalid',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-invalid.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : install_dummy,
+  install: install_dummy,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -57,23 +57,23 @@ shared_module('fu_plugin_invalid',
 if bluez.allowed()
 shared_module('fu_plugin_test_ble',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-test-ble.c',
     'fu-test-ble-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : install_dummy,
+  install: install_dummy,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/thelio-io/meson.build
+++ b/plugins/thelio-io/meson.build
@@ -7,23 +7,23 @@ install_data(['thelio-io.quirk'],
 
 shared_module('fu_plugin_thelio_io',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-thelio-io.c',
     'fu-thelio-io-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -8,7 +8,7 @@ install_data([
 )
 fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-thunderbolt.c',
     'fu-thunderbolt-common.c',
     'fu-thunderbolt-device.c',
@@ -17,25 +17,25 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
     'fu-thunderbolt-firmware.c',
     'fu-thunderbolt-firmware-update.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
 
 install_data(['thunderbolt.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
+  install_dir: join_paths(sysconfdir, 'fwupd')
 )
 # we use functions from 2.52 in the tests
 if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gio.version().version_compare('>= 2.52')
@@ -47,7 +47,7 @@ if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gi
   e = executable(
     'thunderbolt-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-plugin-thunderbolt.c',
       'fu-thunderbolt-common.c',
@@ -57,27 +57,27 @@ if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gi
       'fu-thunderbolt-firmware.c',
       'fu-thunderbolt-firmware-update.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       gudev,
       plugin_deps,
       umockdev,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs
+    c_args: cargs
   )
   if get_option('b_sanitize') == 'address'
-    env.prepend('LD_PRELOAD', 'libasan.so.5', 'libumockdev-preload.so.0', separator : ' ')
+    env.prepend('LD_PRELOAD', 'libasan.so.5', 'libumockdev-preload.so.0', separator: ' ')
   else
     env.prepend('LD_PRELOAD', 'libumockdev-preload.so.0')
   endif
-  test('thunderbolt-self-test', e, env: env, timeout : 120)
+  test('thunderbolt-self-test', e, env: env, timeout: 120)
 endif
 endif

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -1,4 +1,4 @@
-tpm2tss_tpm = dependency('tss2-esys', version : '>= 2.0', required: get_option('plugin_tpm'))
+tpm2tss_tpm = dependency('tss2-esys', version: '>= 2.0', required: get_option('plugin_tpm'))
 
 if get_option('hsi') and \
    tpm2tss_tpm.found() and \
@@ -14,7 +14,7 @@ install_data([
 
 plugin_tpm = shared_module('fu_plugin_tpm',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-tpm.c',
     'fu-tpm-device.c',
     'fu-tpm-v1-device.c',
@@ -22,19 +22,19 @@ plugin_tpm = shared_module('fu_plugin_tpm',
     'fu-tpm-eventlog-common.c',
     'fu-tpm-eventlog-parser.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupdplugin,
     fwupd,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     tpm2tss_tpm,
   ],
@@ -48,7 +48,7 @@ if get_option('tests')
   e = executable(
     'tpm-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-tpm-device.c',
       'fu-tpm-v1-device.c',
@@ -56,20 +56,20 @@ if get_option('tests')
       'fu-tpm-eventlog-common.c',
       'fu-tpm-eventlog-parser.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       tpm2tss_tpm,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs
+    c_args: cargs
   )
   test('tpm-self-test', e, env: env)
 endif
@@ -77,21 +77,21 @@ endif
 executable(
   'fwupdtpmevlog',
   fu_hash,
-  sources : [
+  sources: [
     'fu-tpm-eventlog.c',
     'fu-tpm-eventlog-common.c',
     'fu-tpm-eventlog-parser.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
       plugin_deps,
       tpm2tss_tpm,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -17,9 +17,9 @@ if host_machine.system() == 'linux'
   con2 = configuration_data()
   con2.set('localstatedir', localstatedir)
   configure_file(
-    input : 'fwupd.grub.conf.in',
-    output : '35_fwupd',
-    configuration : con2,
+    input: 'fwupd.grub.conf.in',
+    output: '35_fwupd',
+    configuration: con2,
     install: true,
     install_dir: join_paths(sysconfdir, 'grub.d')
   )
@@ -31,7 +31,7 @@ endif
 
 shared_module('fu_plugin_uefi_capsule',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-uefi-capsule.c',
     'fu-uefi-bgrt.c',
     'fu-uefi-bootmgr.c',
@@ -44,19 +44,19 @@ shared_module('fu_plugin_uefi_capsule',
     'fu-uefi-update-info.c',
     backend_srcs,
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
     platform_deps,
     efiboot,
@@ -68,7 +68,7 @@ fwupdate = executable(
   'fwupdate',
   resources_src,
   fu_hash,
-  sources : [
+  sources: [
     'fu-uefi-tool.c',
     'fu-uefi-bgrt.c',
     'fu-uefi-bootmgr.c',
@@ -81,38 +81,38 @@ fwupdate = executable(
     'fu-uefi-update-info.c',
     backend_srcs,
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
     platform_deps,
     efiboot,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  install : true,
-  install_dir : bindir,
-  c_args : cargs,
+  install: true,
+  install_dir: bindir,
+  c_args: cargs,
 )
 endif
 
 if get_option('compat_cli') and get_option('man')
   configure_file(
-    input : 'fwupdate.1',
-    output : 'fwupdate.1',
-    configuration : conf,
+    input: 'fwupdate.1',
+    output: 'fwupdate.1',
+    configuration: conf,
     install: true,
     install_dir: join_paths(mandir, 'man1'),
   )
 endif
 
 install_data(['uefi_capsule.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
+  install_dir: join_paths(sysconfdir, 'fwupd')
 )
 
 # add all the .po files as inputs to watch
@@ -120,20 +120,20 @@ ux_linguas = run_command(
   'cat', files(join_paths(meson.project_source_root(), 'po', 'LINGUAS')),
 ).stdout().strip().split('\n')
 ux_capsule_pofiles = []
-foreach ux_lingua : ux_linguas
+foreach ux_lingua: ux_linguas
   ux_capsule_pofiles += join_paths(meson.project_source_root(), 'po', '@0@.po'.format(ux_lingua))
 endforeach
 
 if get_option('plugin_uefi_capsule_splash')
   # add the archive of pregenerated images
   custom_target('ux-capsule-tar',
-    input : [
+    input: [
       join_paths(meson.project_source_root(), 'po', 'LINGUAS'),
       join_paths(meson.current_source_dir(), 'make-images.py'),
       ux_capsule_pofiles,
     ],
-    output : 'uefi-capsule-ux.tar.xz',
-    command : [
+    output: 'uefi-capsule-ux.tar.xz',
+    command: [
       python3.full_path(),
       join_paths(meson.current_source_dir(), 'make-images.py'),
       '--podir', join_paths(meson.project_source_root(), 'po'),
@@ -153,7 +153,7 @@ if get_option('tests')
   e = executable(
     'uefi-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-uefi-bgrt.c',
       'fu-uefi-bootmgr.c',
@@ -166,21 +166,21 @@ if get_option('tests')
       'fu-uefi-update-info.c',
       backend_srcs,
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
       platform_deps,
       efiboot,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs
+    c_args: cargs
   )
   test('uefi-self-test', e, env: env)
 
@@ -195,12 +195,12 @@ install_data([
     'tests/efi/esrt/entries/entry0/last_attempt_version',
     'tests/efi/esrt/entries/entry0/lowest_supported_fw_version',
   ],
-  install_dir : join_paths(installed_test_datadir, 'efi/esrt/entries/entry0'),
+  install_dir: join_paths(installed_test_datadir, 'efi/esrt/entries/entry0'),
 )
 install_data([
     'tests/efi/efivars/CapsuleMax-39b68c46-f7fb-441b-b6ec-16b0f69821f3',
   ],
-  install_dir : join_paths(installed_test_datadir, 'efi/efivars'),
+  install_dir: join_paths(installed_test_datadir, 'efi/efivars'),
 )
 endif
 

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -7,25 +7,25 @@ install_data(['uefi-dbx.quirk'],
 
 shared_module('fu_plugin_uefi_dbx',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-uefi-dbx.c',
     'fu-uefi-dbx-common.c',
     'fu-uefi-dbx-device.c',
     'fu-efi-image.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -37,60 +37,60 @@ if get_option('tests')
   e = executable(
     'uefi-dbx-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-uefi-dbx-common.c',
       'fu-efi-image.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs,
-    install : true,
-    install_dir : installed_test_bindir,
+    c_args: cargs,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('uefi-dbx-self-test', e, env : env)  # added to installed-tests
+  test('uefi-dbx-self-test', e, env: env)  # added to installed-tests
 endif
 
 dbxtool = executable(
   'dbxtool',
   fu_hash,
-  sources : [
+  sources: [
     'fu-dbxtool.c',
     'fu-uefi-dbx-common.c',
     'fu-efi-image.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  install : true,
-  install_dir : bindir,
-  c_args : cargs,
+  install: true,
+  install_dir: bindir,
+  c_args: cargs,
 )
 
 if get_option('man')
   configure_file(
-    input : 'dbxtool.1',
-    output : 'dbxtool.1',
-    configuration : conf,
+    input: 'dbxtool.1',
+    output: 'dbxtool.1',
+    configuration: conf,
     install: true,
     install_dir: join_paths(mandir, 'man1'),
   )

--- a/plugins/uefi-pk/meson.build
+++ b/plugins/uefi-pk/meson.build
@@ -5,22 +5,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginUefiPk"']
 
 shared_module('fu_plugin_uefi_pk',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-uefi-pk.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/uefi-recovery/meson.build
+++ b/plugins/uefi-recovery/meson.build
@@ -7,24 +7,24 @@ install_data(['uefi-recovery.quirk'],
 
 shared_module('fu_plugin_uefi_recovery',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-uefi-recovery.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     cargs,
   ],
-  dependencies : [
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/uf2/meson.build
+++ b/plugins/uf2/meson.build
@@ -9,23 +9,23 @@ install_data(['uf2.quirk'],
 
 shared_module('fu_plugin_uf2',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-uf2.c',
     'fu-uf2-device.c',
     'fu-uf2-firmware.c',      # fuzzing
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
@@ -40,25 +40,25 @@ if get_option('tests')
   e = executable(
     'uf2-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-uf2-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    install : true,
-    install_dir : installed_test_bindir,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('uf2-self-test', e, env : env)
+  test('uf2-self-test', e, env: env)
 endif
 endif

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -3,22 +3,22 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
 
 shared_module('fu_plugin_upower',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-upower.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/usi-dock/meson.build
+++ b/plugins/usi-dock/meson.build
@@ -7,26 +7,26 @@ install_data(['usi-dock.quirk'],
 
 shared_module('fu_plugin_usi_dock',
   fu_hash,
-  sources : [
+  sources: [
     'fu-usi-dock-common.c',
     'fu-usi-dock-child-device.c',
     'fu-usi-dock-dmc-device.c',
     'fu-usi-dock-mcu-device.c',
     'fu-plugin-usi-dock.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -14,7 +14,7 @@ install_data([
 
 shared_module('fu_plugin_vli',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-vli.c',
     'fu-vli-common.c',
     'fu-vli-device.c',
@@ -30,19 +30,19 @@ shared_module('fu_plugin_vli',
     'fu-vli-usbhub-pd-device.c',
     'fu-vli-usbhub-rtd21xx-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
 )
@@ -51,25 +51,25 @@ if get_option('tests')
   e = executable(
     'vli-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-vli-common.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs,
-    install : true,
-    install_dir : installed_test_bindir,
+    c_args: cargs,
+    install: true,
+    install_dir: installed_test_bindir,
   )
   test('vli-self-test', e)  # added to installed-tests
 endif

--- a/plugins/wacom-raw/meson.build
+++ b/plugins/wacom-raw/meson.build
@@ -7,25 +7,25 @@ install_data(['wacom-raw.quirk'],
 
 shared_module('fu_plugin_wacom_raw',
   fu_hash,
-  sources : [
+  sources: [
     'fu-plugin-wacom-raw.c',
     'fu-wacom-common.c',
     'fu-wacom-device.c',
     'fu-wacom-aes-device.c',
     'fu-wacom-emr-device.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -7,7 +7,7 @@ install_data(['wacom-usb.quirk'],
 
 shared_module('fu_plugin_wacom_usb',
   fu_hash,
-  sources : [
+  sources: [
     'fu-wac-common.c',
     'fu-wac-android-device.c',
     'fu-wac-device.c',
@@ -18,18 +18,18 @@ shared_module('fu_plugin_wacom_usb',
     'fu-wac-module-touch.c',
     'fu-plugin-wacom-usb.c',
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  install : true,
+  install: true,
   install_dir: plugin_dir,
-  c_args : cargs,
-  dependencies : [
+  c_args: cargs,
+  dependencies: [
     plugin_deps,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
@@ -44,27 +44,27 @@ if get_option('tests')
   e = executable(
     'wacom-usb-self-test',
     fu_hash,
-    sources : [
+    sources: [
       'fu-self-test.c',
       'fu-wac-common.c',
       'fu-wac-firmware.c',
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       plugin_deps,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin,
     ],
-    c_args : cargs,
-    install : true,
-    install_dir : installed_test_bindir,
+    c_args: cargs,
+    install: true,
+    install_dir: installed_test_bindir,
   )
-  test('wacom-usb-self-test', e, env : env)  # added to installed-tests
+  test('wacom-usb-self-test', e, env: env)  # added to installed-tests
 endif
 endif

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-  preset : 'glib',
+  preset: 'glib',
   args: [
   '--default-domain=' + meson.project_name(),
   ]

--- a/policy/meson.build
+++ b/policy/meson.build
@@ -1,5 +1,5 @@
 install_data('org.freedesktop.fwupd.rules',
-             install_dir : join_paths(datadir, 'polkit-1', 'rules.d'))
+             install_dir: join_paths(datadir, 'polkit-1', 'rules.d'))
 
 #newer polkit has the ITS rules included
 if polkit.version().version_compare('>0.113')

--- a/src/meson.build
+++ b/src/meson.build
@@ -64,9 +64,9 @@ endif
 if host_machine.system() == 'windows'
   windmc = find_program('windmc')
   fwupd_rc = custom_target('fwupd-rc',
-    input : 'fwupd-windows.mc',
-    output : 'fwupd-windows.rc',
-    command : [
+    input: 'fwupd-windows.mc',
+    output: 'fwupd-windows.rc',
+    command: [
       windmc, '@INPUT@', '--rcdir', meson.current_build_dir(),
     ],
   )
@@ -76,12 +76,12 @@ endif
 
 if build_daemon
 install_data(['org.freedesktop.fwupd.xml'],
-  install_dir : join_paths(datadir, 'dbus-1', 'interfaces')
+  install_dir: join_paths(datadir, 'dbus-1', 'interfaces')
 )
 fwupdmgr = executable(
   'fwupdmgr',
   fu_hash,
-  sources : [
+  sources: [
     'fu-util.c',
     'fu-history.c',
     'fu-progressbar.c',
@@ -90,22 +90,22 @@ fwupdmgr = executable(
     client_src,
     systemd_src
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     libfwupd_deps,
     libxmlb,
     client_dep,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  install : true,
-  install_dir : bindir
+  install: true,
+  install_dir: bindir
 )
 
 # for compatibility
@@ -122,7 +122,7 @@ if offline.allowed()
 fwupdoffline = executable(
   'fwupdoffline',
   fu_hash,
-  sources : [
+  sources: [
     'fu-history.c',
     'fu-offline.c',
     'fu-spawn.c',
@@ -130,49 +130,49 @@ fwupdoffline = executable(
     'fu-util-common.c',
     systemd_src
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     libfwupd_deps,
     client_dep,
     libxmlb,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  install : true,
-  install_dir : join_paths(libexecdir, 'fwupd')
+  install: true,
+  install_dir: join_paths(libexecdir, 'fwupd')
 )
 endif
 
 resources_src = gnome.compile_resources(
   'fwupd-resources',
   'fwupd.gresource.xml',
-  source_dir : '.',
-  c_name : 'fu'
+  source_dir: '.',
+  c_name: 'fu'
 )
 
 fwupdtool = executable(
   'fwupdtool',
   resources_src,
   fu_hash,
-  export_dynamic : true,
-  sources : [
+  export_dynamic: true,
+  sources: [
     'fu-tool.c',
     'fu-progressbar.c',
     'fu-util-common.c',
     daemon_src,
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     libfwupd_deps,
     libxmlb,
     libgcab,
@@ -180,36 +180,36 @@ fwupdtool = executable(
     client_dep,
     valgrind,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin
   ],
-  install : true,
-  install_dir : bindir
+  install: true,
+  install_dir: bindir
 )
 
 if get_option('man')
   if build_daemon
     configure_file(
-      input : 'fwupdmgr.1',
-      output : 'fwupdmgr.1',
-      configuration : conf,
+      input: 'fwupdmgr.1',
+      output: 'fwupdmgr.1',
+      configuration: conf,
       install: true,
       install_dir: join_paths(mandir, 'man1'),
     )
     configure_file(
-      input : 'fwupdagent.1',
-      output : 'fwupdagent.1',
-      configuration : conf,
+      input: 'fwupdagent.1',
+      output: 'fwupdagent.1',
+      configuration: conf,
       install: true,
       install_dir: join_paths(mandir, 'man1'),
     )
   endif
   if build_standalone
     configure_file(
-      input : 'fwupdtool.1',
-      output : 'fwupdtool.1',
-      configuration : conf,
+      input: 'fwupdtool.1',
+      output: 'fwupdtool.1',
+      configuration: conf,
       install: true,
       install_dir: join_paths(mandir, 'man1'),
     )
@@ -229,30 +229,30 @@ executable(
   'fwupd',
   resources_src,
   fu_hash,
-  sources : [
+  sources: [
     daemon_loader_src,
     'fu-daemon.c',
     daemon_src,
   ],
-  include_directories : [
+  include_directories: [
     root_incdir,
     fwupd_incdir,
     fwupdplugin_incdir,
   ],
-  dependencies : [
+  dependencies: [
     valgrind,
     libsystemd,
     daemon_dep,
   ],
-  link_with : [
+  link_with: [
     fwupd,
     fwupdplugin,
   ],
-  c_args : [
+  c_args: [
     '-DFU_OFFLINE_DESTDIR=""',
   ],
-  install : true,
-  install_dir : daemon_dir
+  install: true,
+  install_dir: daemon_dir
 )
 
 endif
@@ -272,26 +272,26 @@ if get_option('tests')
     resources_src,
     test_deps,
     fu_hash,
-    sources : [
+    sources: [
       'fu-progressbar.c',
       'fu-spawn.c',
       'fu-self-test.c',
       daemon_src,
     ],
-    include_directories : [
+    include_directories: [
       root_incdir,
       fwupd_incdir,
       fwupdplugin_incdir,
     ],
-    dependencies : [
+    dependencies: [
       daemon_dep,
     ],
-    link_with : [
+    link_with: [
       fwupd,
       fwupdplugin
     ],
-    c_args : [
+    c_args: [
     ],
   )
-  test('fu-self-test', e, is_parallel:false, timeout:180, env : env)
+  test('fu-self-test', e, is_parallel: false, timeout: 180, env: env)
 endif

--- a/src/tests/builder/meson.build
+++ b/src/tests/builder/meson.build
@@ -1,12 +1,12 @@
 if get_option('tests')
   tar = find_program('gtar', 'tar')
   builder_test_firmware = custom_target('builder-test-firmware',
-    input : [
+    input: [
       'source.bin',
       'startup.sh',
     ],
-    output : 'firmware.tar',
-    command : [
+    output: 'firmware.tar',
+    command: [
       tar, '--xform', 's,.*/,,',
            '--absolute-names', '--create', '--file', '@OUTPUT@', '@INPUT@',
     ],

--- a/src/tests/missing-hwid/meson.build
+++ b/src/tests/missing-hwid/meson.build
@@ -1,20 +1,20 @@
 hwid_test_firmware = custom_target('hwid-test-firmware',
-  input : [
+  input: [
     'firmware.bin',
     'firmware.metainfo.xml',
   ],
-  output : 'hwid-1.2.3.cab',
-  command : [
+  output: 'hwid-1.2.3.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
 )
 noreqs_test_firmware = custom_target('noreqs-test-firmware',
-  input : [
+  input: [
     'firmware.bin',
     'firmware2.metainfo.xml',
   ],
-  output : 'noreqs-1.2.3.cab',
-  command : [
+  output: 'noreqs-1.2.3.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
 )

--- a/src/tests/multiple-rels/meson.build
+++ b/src/tests/multiple-rels/meson.build
@@ -1,11 +1,11 @@
 multiple_rels_test_firmware = custom_target('multiple-rels-test-firmware',
-  input : [
+  input: [
     'firmware-123.bin',
     'firmware-124.bin',
     'firmware.metainfo.xml',
   ],
-  output : 'multiple-rels-1.2.4.cab',
-  command : [
+  output: 'multiple-rels-1.2.4.cab',
+  command: [
     gcab, '--create', '--nopath', '@OUTPUT@', '@INPUT@',
   ],
 )


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

The indentation used for the parameter is not consistent across the `meson.build` files; even in the same files. I picked the most commonly used (aka space, colon, space)  even though it is not the one I prefer.

I can change it if needed. 