### PR TITLE
corsair: remove support for some devices

### DIFF
--- a/plugins/corsair/corsair.quirk
+++ b/plugins/corsair/corsair.quirk
@@ -1,19 +1,3 @@
-# SABRE RGB PRO WIRELESS
-[USB\VID_1B1C&PID_1B98]
-Plugin = corsair
-GType = FuCorsairDevice
-Name = SABRE RGB PRO WIRELESS Gaming Mouse
-Icon = input-mouse
-CorsairDeviceKind = mouse
-
-# SLIPSTREAM WIRELESS USB Receiver
-[USB\VID_1B1C&PID_1BA6]
-Plugin = corsair
-GType = FuCorsairDevice
-Name = SLIPSTREAM WIRELESS USB Receiver
-Icon = usb-receiver
-CorsairDeviceKind = receiver
-
 # KATAR PRO WIRELESS receiver
 [USB\VID_1B1C&PID_1B94]
 Plugin = corsair


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Vendor has decided to remove these devices from the initial supported
device list:
* SABRE RGB PRO WIRELESS Gaming Mouse
* SLIPSTREAM WIRELESS USB Receiver
