### PR TITLE
system76-launch: Wait for device to re-enumerate if unlocked and reset

### DIFF
--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -133,8 +133,10 @@ fu_system76_launch_device_detach(FuDevice *device, FuProgress *progress, GError 
 		return FALSE;
 
 	/* unlikely, but already unlocked */
-	if (rc == 0)
+	if (rc == 0) {
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 		return TRUE;
+	}
 
 	/* generate a message if not already set */
 	if (fu_device_get_update_message(device) == NULL) {


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/4762

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
