### PR TITLE
Fix running fwupdtool security with a plugin allowlist

### DIFF
--- a/plugins/iommu/fu-plugin-iommu.c
+++ b/plugins/iommu/fu-plugin-iommu.c
@@ -46,6 +46,11 @@ fu_plugin_iommu_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	fwupd_security_attr_set_plugin(attr, fu_plugin_get_name(plugin));
 	fu_security_attrs_append(attrs, attr);
 
+	if (!data) {
+		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_MISSING_DATA);
+		return;
+	}
+
 	if (!data->has_iommu) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		return;

--- a/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
+++ b/plugins/linux-lockdown/fu-plugin-linux-lockdown.c
@@ -133,7 +133,7 @@ fu_plugin_linux_lockdown_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *a
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append(attrs, attr);
 
-	if (data->lockdown == FU_PLUGIN_LINUX_LOCKDOWN_UNKNOWN) {
+	if (!data || data->lockdown == FU_PLUGIN_LINUX_LOCKDOWN_UNKNOWN) {
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
 		return;
 	}

--- a/plugins/linux-swap/fu-plugin-linux-swap.c
+++ b/plugins/linux-swap/fu-plugin-linux-swap.c
@@ -82,7 +82,7 @@ fu_plugin_linux_swap_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 	g_autoptr(GError) error_local = NULL;
 
-	if (data->file == NULL)
+	if (!data || data->file == NULL)
 		return;
 
 	/* create attr */

--- a/plugins/linux-tainted/fu-plugin-linux-tainted.c
+++ b/plugins/linux-tainted/fu-plugin-linux-tainted.c
@@ -78,6 +78,11 @@ fu_plugin_linux_tainted_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *at
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 	fu_security_attrs_append(attrs, attr);
 
+	if (!data) {
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
+		return;
+	}
+
 	/* load file */
 	if (!g_file_load_contents(data->file, NULL, &buf, &bufsz, NULL, &error_local)) {
 		g_autofree gchar *fn = g_file_get_path(data->file);

--- a/plugins/msr/fu-plugin-msr.c
+++ b/plugins/msr/fu-plugin-msr.c
@@ -344,6 +344,11 @@ fu_plugin_add_security_attr_amd_sme_enabled(FuPlugin *plugin, FuSecurityAttrs *a
 		fwupd_security_attr_add_guids(attr, fu_device_get_guids(device));
 	fu_security_attrs_append(attrs, attr);
 
+	if (!priv) {
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
+		return;
+	}
+
 	/* check fields */
 	if (!priv->amd64_syscfg_supported) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);

--- a/plugins/uefi-pk/fu-plugin-uefi-pk.c
+++ b/plugins/uefi-pk/fu-plugin-uefi-pk.c
@@ -179,8 +179,8 @@ fu_plugin_uefi_pk_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 		fwupd_security_attr_add_guids(attr, fu_device_get_guids(msf_device));
 	fu_security_attrs_append(attrs, attr);
 
-	/* test key is not secure */
-	if (priv->has_pk_test_key) {
+	/* not enabled or test key is not secure */
+	if (!priv || priv->has_pk_test_key) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}


### PR DESCRIPTION
A number of plugins make assumptions that ->init() was called, but
when an allowlist is used this won't have been called.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
