### PR TITLE
trivial: quiet the modem manager error about unable to probe

### DIFF
--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -99,7 +99,7 @@ fu_plugin_mm_udev_device_ports_timeout(gpointer user_data)
 				     fu_device_get_physical_id(FU_DEVICE(priv->shadow_device)));
 	if (dev != NULL) {
 		if (!fu_device_probe(FU_DEVICE(dev), &error)) {
-			g_warning("failed to probe MM device: %s", error->message);
+			g_debug("failed to probe MM device: %s", error->message);
 		} else {
 			fu_plugin_device_add(plugin, FU_DEVICE(dev));
 		}


### PR DESCRIPTION
We don't show messages in the logs about unable to probe other
device types by default, MM should be no different.
This gets rid of this message coming up every fwupd startup on a
EM05-G:
"failed to probe MM device: modem cannot be put in programming mode"

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
