### PR TITLE
synaptics-cape: Fix a big endian compile warning

### DIFF
--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -27,8 +27,8 @@ _plugin_device_added_cb(FuPlugin *plugin, FuDevice *device, gpointer user_data)
 	*dev = device;
 }
 
-static void
-fu_test_self_init(FuTest *self)
+static gboolean
+fu_test_self_init(FuTest *self, GError **error_global)
 {
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
@@ -49,6 +49,14 @@ fu_test_self_init(FuTest *self)
 					      "uefi-capsule",
 					      "libfu_plugin_uefi_capsule." G_MODULE_SUFFIX,
 					      NULL);
+	if (!g_file_test(pluginfn_uefi, G_FILE_TEST_EXISTS)) {
+		g_set_error(error_global,
+			    G_IO_ERROR,
+			    G_IO_ERROR_NOT_FOUND,
+			    "%s was not found",
+			    pluginfn_uefi);
+		return FALSE;
+	}
 	ret = fu_plugin_open(self->plugin_uefi_capsule, pluginfn_uefi, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -66,6 +74,7 @@ fu_test_self_init(FuTest *self)
 	ret = fu_plugin_runner_startup(self->plugin_lenovo_thinklmi, progress, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	return TRUE;
 }
 
 static FuDevice *
@@ -141,6 +150,7 @@ main(int argc, char **argv)
 	g_autofree gchar *testdatadir = NULL;
 	g_autofree gchar *test_dir = NULL;
 	g_autoptr(FuTest) self = g_new0(FuTest, 1);
+	g_autoptr(GError) error = NULL;
 
 	g_test_init(&argc, &argv, NULL);
 
@@ -164,7 +174,10 @@ main(int argc, char **argv)
 	g_assert_cmpint(g_mkdir_with_parents("/tmp/fwupd-self-test/var/lib/fwupd", 0755), ==, 0);
 
 	/* tests go here */
-	fu_test_self_init(self);
+	if (!fu_test_self_init(self, &error)) {
+		g_test_skip(error->message);
+		return 0;
+	}
 	g_test_add_data_func("/fwupd/plugin{lenovo-think-lmi:bootorder-locked}",
 			     self,
 			     fu_plugin_lenovo_thinklmi_bootorder_locked);

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -250,7 +250,7 @@ fu_synaptics_cape_device_sendcmd_ex(FuSynapticsCapeDevice *self,
 		report.cmd.data_len = GINT16_TO_LE(report.cmd.data_len);
 	}
 
-	report.cmd.cmd_id = GUINT32_TO_LE(report.cmd.cmd_id);
+	report.cmd.cmd_id = GUINT16_TO_LE(report.cmd.cmd_id);
 	report.cmd.module_id = GUINT32_TO_LE(report.cmd.module_id);
 
 	if (!fu_synaptics_cape_device_set_report(self, &report, error)) {
@@ -351,8 +351,8 @@ fu_synaptics_cape_device_sendcmd(FuSynapticsCapeDevice *self,
 
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	cmd.cmd_id = cmd_id;
-	cmd.module_id = module_id;
+	cmd.cmd_id = GUINT16_TO_LE(cmd_id);
+	cmd.module_id = GUINT32_TO_LE(module_id);
 
 	if (data_len != 0 && data != NULL) {
 		cmd.data_len = data_len;
@@ -459,9 +459,9 @@ fu_synaptics_cape_device_setup_version(FuSynapticsCapeDevice *self, GError **err
 	FuCapCmd cmd = {0};
 	g_autofree gchar *version_str = NULL;
 
-	cmd.cmd_id = GUINT32_TO_LE(FU_SYNAPTICS_CMD_GET_VERSION);
-	cmd.module_id = FU_SYNAPTICS_CAPE_CMD_APP_ID_CTRL;
-	cmd.data_len = 4;
+	cmd.cmd_id = GUINT16_TO_LE(FU_SYNAPTICS_CMD_GET_VERSION);
+	cmd.module_id = GUINT32_TO_LE(FU_SYNAPTICS_CAPE_CMD_APP_ID_CTRL);
+	cmd.data_len = GUINT16_TO_LE(4);
 
 	g_return_val_if_fail(FU_IS_SYNAPTICS_CAPE_DEVICE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -10,6 +10,7 @@
 
 #include <gio/gio.h>
 #include <glib/gi18n.h>
+#include <glib/gstdio.h>
 #include <locale.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The cmd_id is 16 bits wide.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
