### PR TITLE
dell-dock: cache hub device and add it until ec is added

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-common.h
+++ b/plugins/dell-dock/fu-dell-dock-common.h
@@ -42,8 +42,9 @@
 #define ATOMIC_HUB1_PID			    0x541A
 #define DELL_VID			    0x413C
 
-#define WD19_BASE   0x04
-#define ATOMIC_BASE 0x05
+#define DOCK_BASE_TYPE_UNKNOWN 0x0
+#define DOCK_BASE_TYPE_SALOMON 0x04
+#define DOCK_BASE_TYPE_ATOMIC  0x05
 
 gboolean
 fu_dell_dock_set_power(FuDevice *device, guint8 target, gboolean enabled, GError **error);

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -29,11 +29,11 @@ struct _FuDellDockHub {
 G_DEFINE_TYPE(FuDellDockHub, fu_dell_dock_hub, FU_TYPE_HID_DEVICE)
 
 void
-fu_dell_dock_hub_add_instance(FuDevice *device, guint8 ec_type)
+fu_dell_dock_hub_add_instance(FuDevice *device, guint8 dock_type)
 {
 	g_autofree gchar *devid = NULL;
 
-	if (ec_type == ATOMIC_BASE) {
+	if (dock_type == DOCK_BASE_TYPE_ATOMIC) {
 		devid = g_strdup_printf("USB\\VID_%04X&PID_%04X&atomic_hub",
 					(guint)fu_usb_device_get_vid(FU_USB_DEVICE(device)),
 					(guint)fu_usb_device_get_pid(FU_USB_DEVICE(device)));

--- a/plugins/dell-dock/fu-dell-dock-hub.h
+++ b/plugins/dell-dock/fu-dell-dock-hub.h
@@ -32,4 +32,4 @@ G_DECLARE_FINAL_TYPE(FuDellDockHub, fu_dell_dock_hub, FU, DELL_DOCK_HUB, FuHidDe
 FuDellDockHub *
 fu_dell_dock_hub_new(FuUsbDevice *device);
 void
-fu_dell_dock_hub_add_instance(FuDevice *device, guint8 ec_type);
+fu_dell_dock_hub_add_instance(FuDevice *device, guint8 dock_type);

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -183,7 +183,7 @@ fu_dell_dock_module_is_usb4(FuDevice *device)
 }
 
 guint8
-fu_dell_dock_get_ec_type(FuDevice *device)
+fu_dell_dock_get_dock_type(FuDevice *device)
 {
 	FuDellDockEc *self = FU_DELL_DOCK_EC(device);
 	return self->base_type;
@@ -347,10 +347,10 @@ fu_dell_dock_is_valid_dock(FuDevice *device, GError **error)
 	self->base_type = result[0];
 
 	/* this will trigger setting up all the quirks */
-	if (self->base_type == WD19_BASE) {
+	if (self->base_type == DOCK_BASE_TYPE_SALOMON) {
 		fu_device_add_instance_id(device, DELL_DOCK_EC_INSTANCE_ID);
 		return TRUE;
-	} else if (self->base_type == ATOMIC_BASE) {
+	} else if (self->base_type == DOCK_BASE_TYPE_ATOMIC) {
 		fu_device_add_instance_id(device, DELL_DOCK_ATOMIC_EC_INSTANCE_ID);
 		return TRUE;
 	}

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.h
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.h
@@ -48,4 +48,4 @@ fu_dell_dock_ec_commit_package(FuDevice *device, GBytes *blob_fw, GError **error
 gboolean
 fu_dell_dock_module_is_usb4(FuDevice *device);
 guint8
-fu_dell_dock_get_ec_type(FuDevice *device);
+fu_dell_dock_get_dock_type(FuDevice *device);


### PR DESCRIPTION
The usb3 hub 413c:b06f may be added to the plugin ahead of ec device
while dock type is yet known at that time. Cache the hub until ec can
tell the instance id, then add it to the plugin.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
