### PR TITLE
Make the FuFirmware->parse() vfunc more helpful

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -93,3 +93,4 @@ Remember: Plugins should be upstream!
 * `fu_common_cab_build_silo()`: You should not be using this.
 * `fu_i2c_device_read_full()`: Use `fu_i2c_device_read` instead.
 * `fu_i2c_device_write_full()`: Use `fu_i2c_device_write` instead.
+* `fu_firmware_parse_full()`: Remove the `addr_end` parameter, and ensure that `offset` is a `gsize`.

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -57,8 +57,7 @@ fu_archive_firmware_parse_cb(FuArchive *self,
 static gboolean
 fu_archive_firmware_parse(FuFirmware *firmware,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -417,8 +417,7 @@ fu_cfu_offer_set_product_id(FuCfuOffer *self, guint16 product_id)
 static gboolean
 fu_cfu_offer_parse(FuFirmware *firmware,
 		   GBytes *fw,
-		   guint64 addr_start,
-		   guint64 addr_end,
+		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -31,12 +31,10 @@ G_DEFINE_TYPE(FuCfuPayload, fu_cfu_payload, FU_TYPE_FIRMWARE)
 static gboolean
 fu_cfu_payload_parse(FuFirmware *firmware,
 		     GBytes *fw,
-		     guint64 addr_start,
-		     guint64 addr_end,
+		     gsize offset,
 		     FwupdInstallFlags flags,
 		     GError **error)
 {
-	guint32 offset = 0;
 	gsize bufsz = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -98,8 +98,7 @@ fu_coswid_firmware_strndup(cbor_item_t *item)
 static gboolean
 fu_coswid_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -286,8 +286,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 static gboolean
 fu_dfu_firmware_parse(FuFirmware *firmware,
 		      GBytes *fw,
-		      guint64 addr_start,
-		      guint64 addr_end,
+		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -150,15 +150,13 @@ fu_dfuse_firmware_image_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offse
 static gboolean
 fu_dfuse_firmware_parse(FuFirmware *firmware,
 			GBytes *fw,
-			guint64 addr_start,
-			guint64 addr_end,
+			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
 	FuDfuFirmware *dfu_firmware = FU_DFU_FIRMWARE(firmware);
 	DfuSeHdr hdr = {0x0};
 	gsize bufsz = 0;
-	gsize offset = 0;
 	const guint8 *buf;
 
 	/* DFU footer first */

--- a/libfwupdplugin/fu-efi-firmware-file.c
+++ b/libfwupdplugin/fu-efi-firmware-file.c
@@ -144,8 +144,7 @@ fu_efi_firmware_file_hdr_checksum8(GBytes *blob)
 static gboolean
 fu_efi_firmware_file_parse(FuFirmware *firmware,
 			   GBytes *fw,
-			   guint64 addr_start,
-			   guint64 addr_end,
+			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {

--- a/libfwupdplugin/fu-efi-firmware-filesystem.c
+++ b/libfwupdplugin/fu-efi-firmware-filesystem.c
@@ -24,12 +24,10 @@ G_DEFINE_TYPE(FuEfiFirmwareFilesystem, fu_efi_firmware_filesystem, FU_TYPE_FIRMW
 static gboolean
 fu_efi_firmware_filesystem_parse(FuFirmware *firmware,
 				 GBytes *fw,
-				 guint64 addr_start,
-				 guint64 addr_end,
+				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
-	gsize offset = 0;
 	gsize bufsz = 0x0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 

--- a/libfwupdplugin/fu-efi-firmware-section.c
+++ b/libfwupdplugin/fu-efi-firmware-section.c
@@ -110,8 +110,7 @@ fu_efi_firmware_section_export(FuFirmware *firmware, FuFirmwareExportFlags flags
 static gboolean
 fu_efi_firmware_section_parse(FuFirmware *firmware,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset_ignored,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/libfwupdplugin/fu-efi-firmware-volume.c
+++ b/libfwupdplugin/fu-efi-firmware-volume.c
@@ -60,8 +60,7 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_efi_firmware_volume_parse(FuFirmware *firmware,
 			     GBytes *fw,
-			     guint64 addr_start,
-			     guint64 addr_end,
+			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -70,7 +69,6 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 	fwupd_guid_t guid = {0x0};
 	gsize blockmap_sz = 0;
 	gsize bufsz = 0;
-	gsize offset = 0;
 	guint16 checksum = 0;
 	guint16 ext_hdr = 0;
 	guint16 hdr_length = 0;

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -204,39 +204,30 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 static gboolean
 fu_efi_signature_list_parse(FuFirmware *firmware,
 			    GBytes *fw,
-			    guint64 addr_start,
-			    guint64 addr_end,
+			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
 	FuEfiSignatureList *self = FU_EFI_SIGNATURE_LIST(firmware);
 	gsize bufsz = 0;
-	gsize offset_fs = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	g_autofree gchar *version_str = NULL;
 
 	/* this allows us to skip the efi permissions uint32_t or even the
 	 * Microsoft PKCS-7 signature */
 	if ((flags & FWUPD_INSTALL_FLAG_NO_SEARCH) == 0) {
-		if (bufsz < 5) {
-			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "signature invalid: 0x%x",
-				    (guint)bufsz);
+		if (!fu_memmem_safe(buf,
+				    bufsz,
+				    (const guint8 *)"\x26\x16\xc4\xc1\x4c",
+				    5,
+				    &offset,
+				    error))
 			return FALSE;
-		}
-		for (gsize i = 0; i < bufsz - 5; i++) {
-			if (memcmp(buf + i, "\x26\x16\xc4\xc1\x4c", 5) == 0) {
-				g_debug("found EFI_SIGNATURE_LIST @0x%x", (guint)i);
-				offset_fs = i;
-				break;
-			}
-		}
+		fu_firmware_set_offset(firmware, offset);
 	}
 
 	/* parse each EFI_SIGNATURE_LIST */
-	for (gsize offset = offset_fs; offset < bufsz;) {
+	while (offset < bufsz) {
 		if (!fu_efi_signature_list_parse_list(self, buf, bufsz, &offset, error))
 			return FALSE;
 	}

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -727,8 +727,7 @@ fu_firmware_tokenize(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GErr
  * fu_firmware_parse_full:
  * @self: a #FuFirmware
  * @fw: firmware blob
- * @addr_start: start address, useful for ignoring a bootloader
- * @addr_end: end address, useful for ignoring config bytes
+ * @offset: start offset, useful for ignoring a bootloader
  * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
@@ -736,13 +735,12 @@ fu_firmware_tokenize(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GErr
  *
  * Returns: %TRUE for success
  *
- * Since: 1.3.1
+ * Since: 1.8.2
  **/
 gboolean
 fu_firmware_parse_full(FuFirmware *self,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
@@ -779,7 +777,7 @@ fu_firmware_parse_full(FuFirmware *self,
 			return FALSE;
 	}
 	if (klass->parse != NULL)
-		return klass->parse(self, fw, addr_start, addr_end, flags, error);
+		return klass->parse(self, fw, offset, flags, error);
 
 	/* verify alignment */
 	if (g_bytes_get_size(fw) % (1ull << priv->alignment) != 0) {
@@ -816,7 +814,7 @@ fu_firmware_parse_full(FuFirmware *self,
 gboolean
 fu_firmware_parse(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GError **error)
 {
-	return fu_firmware_parse_full(self, fw, 0x0, 0x0, flags, error);
+	return fu_firmware_parse_full(self, fw, 0x0, flags, error);
 }
 
 /**

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -51,8 +51,7 @@ struct _FuFirmwareClass {
 	GObjectClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	GBytes *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
@@ -268,8 +267,7 @@ fu_firmware_parse_file(FuFirmware *self, GFile *file, FwupdInstallFlags flags, G
 gboolean
 fu_firmware_parse_full(FuFirmware *self,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error) G_GNUC_WARN_UNUSED_RESULT;
 GBytes *

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -28,15 +28,13 @@ G_DEFINE_TYPE(FuFmapFirmware, fu_fmap_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_fmap_firmware_parse(FuFirmware *firmware,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
 	FuFmapFirmwareClass *klass_firmware = FU_FMAP_FIRMWARE_GET_CLASS(firmware);
 	gsize bufsz;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
-	gsize offset = 0;
 	FuFmap fmap;
 
 	/* corrupt */
@@ -130,7 +128,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 
 	/* subclassed */
 	if (klass_firmware->parse != NULL) {
-		if (!klass_firmware->parse(firmware, fw, addr_start, addr_end, flags, error))
+		if (!klass_firmware->parse(firmware, fw, offset, flags, error))
 			return FALSE;
 	}
 

--- a/libfwupdplugin/fu-fmap-firmware.h
+++ b/libfwupdplugin/fu-fmap-firmware.h
@@ -18,8 +18,7 @@ struct _FuFmapFirmwareClass {
 	FuFirmwareClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error);
 	/*< private >*/

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -28,13 +28,11 @@ G_DEFINE_TYPE(FuIfdBios, fu_ifd_bios, FU_TYPE_IFD_IMAGE)
 static gboolean
 fu_ifd_bios_parse(FuFirmware *firmware,
 		  GBytes *fw,
-		  guint64 addr_start,
-		  guint64 addr_end,
+		  gsize offset,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
 	gsize bufsz = 0;
-	gsize offset = 0x0;
 	guint32 sig;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -100,8 +100,7 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_ifd_firmware_parse(FuFirmware *firmware,
 		      GBytes *fw,
-		      guint64 addr_start,
-		      guint64 addr_end,
+		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -245,8 +245,7 @@ fu_ihex_firmware_tokenize(FuFirmware *firmware, GBytes *fw, FwupdInstallFlags fl
 static gboolean
 fu_ihex_firmware_parse(FuFirmware *firmware,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -494,9 +494,9 @@ fu_smbios_encode_byte_from_kernel(FuSmbios *self,
  * the textual version of the field back into the raw SMBIOS table
  * representation.
  */
-#define SYSFS_DMI_FIELD(_name, _type, _offset, kind)                                               \
+#define SYSFS_DMI_FIELD(_name, _type, offset_ignored, kind)                                        \
 	{                                                                                          \
-		.name = _name, .type = _type, .offset = _offset,                                   \
+		.name = _name, .type = _type, .offset = offset_ignored,                            \
 		.encode = fu_smbios_encode_##kind##_from_kernel                                    \
 	}
 const struct kernel_dmi_field {
@@ -753,8 +753,7 @@ fu_smbios_setup_from_path_dmi(FuSmbios *self, const gchar *path, GError **error)
 static gboolean
 fu_smbios_parse(FuFirmware *firmware,
 		GBytes *fw,
-		guint64 addr_start,
-		guint64 addr_end,
+		gsize offset,
 		FwupdInstallFlags flags,
 		GError **error)
 {

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -354,8 +354,7 @@ fu_srec_firmware_tokenize(FuFirmware *firmware, GBytes *fw, FwupdInstallFlags fl
 static gboolean
 fu_srec_firmware_parse(FuFirmware *firmware,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
@@ -440,11 +439,11 @@ fu_srec_firmware_parse(FuFirmware *firmware,
 					    rcd->ln);
 				return FALSE;
 			}
-			if (rcd->addr < addr_start) {
+			if (rcd->addr < offset) {
 				g_debug(
 				    "ignoring data at 0x%x as before start address 0x%x at line %u",
 				    (guint)rcd->addr,
-				    (guint)addr_start,
+				    (guint)offset,
 				    rcd->ln);
 			} else {
 				guint32 len_hole = rcd->addr - addr32_last;

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -66,8 +66,7 @@ fu_uswid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 static gboolean
 fu_uswid_firmware_parse(FuFirmware *firmware,
 			GBytes *fw,
-			guint64 addr_start,
-			guint64 addr_end,
+			gsize offset_ignored,
 			FwupdInstallFlags flags,
 			GError **error)
 {

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -303,7 +303,6 @@ LIBFWUPDPLUGIN_1.3.1 {
     fu_firmware_new;
     fu_firmware_new_from_bytes;
     fu_firmware_parse;
-    fu_firmware_parse_full;
     fu_firmware_to_string;
     fu_firmware_write;
     fu_ihex_firmware_get_type;
@@ -933,6 +932,7 @@ LIBFWUPDPLUGIN_1.8.2 {
     fu_dump_full;
     fu_dump_raw;
     fu_efivar_secure_boot_enabled;
+    fu_firmware_parse_full;
     fu_i2c_device_read;
     fu_i2c_device_write;
     fu_kernel_check_version;

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -39,8 +39,7 @@ fu_acpi_phat_health_record_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 				 GBytes *fw,
-				 guint64 addr_start,
-				 guint64 addr_end,
+				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -35,8 +35,7 @@ fu_acpi_phat_version_element_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 				   GBytes *fw,
-				   guint64 addr_start,
-				   guint64 addr_end,
+				   gsize offset,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -23,13 +23,11 @@ G_DEFINE_TYPE(FuAcpiPhatVersionRecord, fu_acpi_phat_version_record, FU_TYPE_FIRM
 static gboolean
 fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 				  GBytes *fw,
-				  guint64 addr_start,
-				  guint64 addr_end,
+				  gsize offset,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
 	gsize bufsz = 0;
-	gsize offset = 0;
 	guint32 record_count = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -18,8 +18,7 @@ G_DEFINE_TYPE(FuAnalogixFirmware, fu_analogix_firmware, FU_TYPE_IHEX_FIRMWARE)
 static gboolean
 fu_analogix_firmware_parse(FuFirmware *firmware,
 			   GBytes *fw,
-			   guint64 addr_start,
-			   guint64 addr_end,
+			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
@@ -38,7 +37,7 @@ fu_analogix_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) blob_stx = NULL;
 
 	/* convert to binary with FuIhexFirmware->parse */
-	if (!klass->parse(firmware, fw, addr_start, addr_end, flags, error))
+	if (!klass->parse(firmware, fw, offset, flags, error))
 		return FALSE;
 	blob = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (blob == NULL)

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -32,8 +32,7 @@ fu_bcm57xx_dict_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 			    GBytes *fw,
-			    guint64 addr_start,
-			    guint64 addr_end,
+			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -304,8 +304,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 static gboolean
 fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -20,8 +20,7 @@ G_DEFINE_TYPE(FuBcm57xxStage1Image, fu_bcm57xx_stage1_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -20,8 +20,7 @@ G_DEFINE_TYPE(FuBcm57xxStage2Image, fu_bcm57xx_stage2_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage2_image_parse(FuFirmware *image,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx/fu-ccgx-dmc-firmware.c
@@ -275,8 +275,7 @@ fu_ccgx_dmc_firmware_parse_image(FuFirmware *firmware,
 static gboolean
 fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 			   GBytes *fw,
-			   guint64 addr_start,
-			   guint64 addr_end,
+			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -355,8 +355,7 @@ fu_ccgx_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_ccgx_firmware_parse(FuFirmware *firmware,
 		       GBytes *fw,
-		       guint64 addr_start,
-		       guint64 addr_end,
+		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -76,8 +76,7 @@ fu_cros_ec_firmware_get_needed_sections(FuCrosEcFirmware *self, GError **error)
 static gboolean
 fu_cros_ec_firmware_parse(FuFirmware *firmware,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -27,8 +27,7 @@ typedef struct __attribute__((packed)) {
 static gboolean
 fu_ebitdo_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -42,8 +42,7 @@ fu_elanfp_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 static gboolean
 fu_elanfp_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -51,7 +50,6 @@ fu_elanfp_firmware_parse(FuFirmware *firmware,
 	const guint8 *buf;
 	gsize bufsz;
 	guint32 tag = 0;
-	gsize offset = 0x00;
 	guint img_cnt = 0;
 
 	/* check the tag */

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -49,8 +49,7 @@ fu_elantp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 static gboolean
 fu_elantp_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset_ignored,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -22,8 +22,7 @@ G_DEFINE_TYPE(FuEp963xFirmware, fu_ep963x_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_ep963x_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/fresco-pd/fu-fresco-pd-firmware.c
+++ b/plugins/fresco-pd/fu-fresco-pd-firmware.c
@@ -33,8 +33,7 @@ fu_fresco_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_fresco_pd_firmware_parse(FuFirmware *firmware,
 			    GBytes *fw,
-			    guint64 addr_start,
-			    guint64 addr_end,
+			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -20,8 +20,7 @@ G_DEFINE_TYPE(FuGenesysScalerFirmware, fu_genesys_scaler_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 				 GBytes *fw,
-				 guint64 addr_start,
-				 guint64 addr_end,
+				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -111,8 +111,7 @@ fu_genesys_usbhub_firmware_verify(const guint8 *buf, gsize bufsz, guint16 code_s
 static gboolean
 fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 				 GBytes *fw,
-				 guint64 addr_start,
-				 guint64 addr_end,
+				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/hailuck/fu-hailuck-kbd-firmware.c
+++ b/plugins/hailuck/fu-hailuck-kbd-firmware.c
@@ -19,8 +19,7 @@ G_DEFINE_TYPE(FuHailuckKbdFirmware, fu_hailuck_kbd_firmware, FU_TYPE_IHEX_FIRMWA
 static gboolean
 fu_hailuck_kbd_firmware_parse(FuFirmware *firmware,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -23,8 +23,7 @@ G_DEFINE_TYPE(FuNordicHidArchive, fu_nordic_hid_archive, FU_TYPE_FIRMWARE)
 static gboolean
 fu_nordic_hid_archive_parse(FuFirmware *firmware,
 			    GBytes *fw,
-			    guint64 addr_start,
-			    guint64 addr_end,
+			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -117,8 +117,7 @@ fu_nordic_hid_firmware_b0_read_fwinfo(FuFirmware *firmware,
 static gboolean
 fu_nordic_hid_firmware_b0_parse(FuFirmware *firmware,
 				GBytes *fw,
-				guint64 addr_start,
-				guint64 addr_end,
+				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {
@@ -126,7 +125,7 @@ fu_nordic_hid_firmware_b0_parse(FuFirmware *firmware,
 	gsize bufsz = 0;
 
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_b0_parent_class)
-		 ->parse(firmware, fw, addr_start, addr_end, flags, error))
+		 ->parse(firmware, fw, offset, flags, error))
 		return FALSE;
 
 	buf = g_bytes_get_data(fw, &bufsz);

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -128,8 +128,7 @@ fu_nordic_hid_firmware_mcuboot_validate(FuFirmware *firmware,
 static gboolean
 fu_nordic_hid_firmware_mcuboot_parse(FuFirmware *firmware,
 				     GBytes *fw,
-				     guint64 addr_start,
-				     guint64 addr_end,
+				     gsize offset,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {
@@ -137,7 +136,7 @@ fu_nordic_hid_firmware_mcuboot_parse(FuFirmware *firmware,
 	gsize bufsz = 0;
 
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_mcuboot_parent_class)
-		 ->parse(firmware, fw, addr_start, addr_end, flags, error))
+		 ->parse(firmware, fw, offset, flags, error))
 		return FALSE;
 
 	buf = g_bytes_get_data(fw, &bufsz);

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -53,8 +53,7 @@ fu_nordic_hid_firmware_crc32(const guint8 *buf, gsize bufsz)
 static gboolean
 fu_nordic_hid_firmware_parse(FuFirmware *firmware,
 			     GBytes *fw,
-			     guint64 addr_start,
-			     guint64 addr_end,
+			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -37,8 +37,7 @@ fu_pxi_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_pxi_firmware_parse(FuFirmware *firmware,
 		      GBytes *fw,
-		      guint64 addr_start,
-		      guint64 addr_end,
+		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -302,14 +302,12 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self, GBytes *fw, gsize offset,
 static gboolean
 fu_redfish_smbios_parse(FuFirmware *firmware,
 			GBytes *fw,
-			guint64 addr_start,
-			guint64 addr_end,
+			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);
 	gsize bufsz = 0;
-	gsize offset = 0;
 	guint8 protocol_rcds = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -20,8 +20,7 @@ G_DEFINE_TYPE(FuSteelseriesFirmware, fu_steelseries_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_steelseries_firmware_parse(FuFirmware *firmware,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -157,8 +157,7 @@ fu_synaptics_cape_firmware_parse_header(FuSynapticsCapeFirmware *self,
 static gboolean
 fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 				 GBytes *fw,
-				 guint64 addr_start,
-				 guint64 addr_end,
+				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -146,8 +146,7 @@ fu_synaptics_cxaudio_firmware_avoid_badblocks(GPtrArray *badblocks, GPtrArray *r
 static gboolean
 fu_synaptics_cxaudio_firmware_parse(FuFirmware *firmware,
 				    GBytes *fw,
-				    guint64 addr_start,
-				    guint64 addr_end,
+				    gsize offset,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -37,8 +37,7 @@ fu_synaptics_mst_firmware_export(FuFirmware *firmware,
 static gboolean
 fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 				GBytes *fw,
-				guint64 addr_start,
-				guint64 addr_end,
+				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -60,14 +60,12 @@ fu_synaprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 static gboolean
 fu_synaprom_firmware_parse(FuFirmware *firmware,
 			   GBytes *fw,
-			   guint64 addr_start,
-			   guint64 addr_end,
+			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	const guint8 *buf;
 	gsize bufsz = 0;
-	gsize offset = 0;
 	guint img_cnt = 0;
 
 	g_return_val_if_fail(fw != NULL, FALSE);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -445,8 +445,7 @@ fu_synaptics_rmi_firmware_parse_v0x(FuFirmware *firmware, GBytes *fw, GError **e
 static gboolean
 fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 				GBytes *fw,
-				guint64 addr_start,
-				guint64 addr_end,
+				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/thunderbolt/fu-thunderbolt-firmware-update.c
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware-update.c
@@ -81,8 +81,7 @@ fu_thunderbolt_firmware_read_farb_pointer(FuThunderboltFirmwareUpdate *self, GEr
 static gboolean
 fu_thunderbolt_firmware_update_parse(FuFirmware *firmware,
 				     GBytes *fw,
-				     guint64 addr_start,
-				     guint64 addr_end,
+				     gsize offset_ignored,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {

--- a/plugins/thunderbolt/fu-thunderbolt-firmware.c
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware.c
@@ -367,8 +367,7 @@ fu_thunderbolt_firmware_set_digital(FuThunderboltFirmware *self, guint32 offset)
 static gboolean
 fu_thunderbolt_firmware_parse(FuFirmware *firmware,
 			      GBytes *fw,
-			      guint64 addr_start,
-			      guint64 addr_end,
+			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {
@@ -406,7 +405,7 @@ fu_thunderbolt_firmware_parse(FuFirmware *firmware,
 
 	/* subclassed */
 	if (klass_firmware->parse != NULL) {
-		if (!klass_firmware->parse(firmware, fw, addr_start, addr_end, flags, error))
+		if (!klass_firmware->parse(firmware, fw, offset, flags, error))
 			return FALSE;
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-firmware.h
+++ b/plugins/thunderbolt/fu-thunderbolt-firmware.h
@@ -39,8 +39,7 @@ struct _FuThunderboltFirmwareClass {
 	FuFirmwareClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
 			  GBytes *fw,
-			  guint64 addr_start,
-			  guint64 addr_end,
+			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error);
 	/*< private >*/

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -232,8 +232,7 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 static gboolean
 fu_uf2_firmware_parse(FuFirmware *firmware,
 		      GBytes *fw,
-		      guint64 addr_start,
-		      guint64 addr_end,
+		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -69,8 +69,7 @@ fu_vli_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 static gboolean
 fu_vli_pd_firmware_parse(FuFirmware *firmware,
 			 GBytes *fw,
-			 guint64 addr_start,
-			 guint64 addr_end,
+			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -46,8 +46,7 @@ fu_vli_usbhub_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags,
 static gboolean
 fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 			     GBytes *fw,
-			     guint64 addr_start,
-			     guint64 addr_end,
+			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -233,12 +233,7 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 
 		/* parse SREC file and add as image */
 		blob = g_bytes_new(helper->image_buffer->str, helper->image_buffer->len);
-		if (!fu_firmware_parse_full(firmware_srec,
-					    blob,
-					    hdr->addr,
-					    0x0,
-					    helper->flags,
-					    error))
+		if (!fu_firmware_parse_full(firmware_srec, blob, hdr->addr, helper->flags, error))
 			return FALSE;
 		fw_srec = fu_firmware_get_bytes(firmware_srec, error);
 		if (fw_srec == NULL)
@@ -260,8 +255,7 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 static gboolean
 fu_wac_firmware_parse(FuFirmware *firmware,
 		      GBytes *fw,
-		      guint64 addr_start,
-		      guint64 addr_end,
+		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {


### PR DESCRIPTION
This removes the 100% unused addr_end parameter and explicitly makes
the addr_start into the start offset in more cases.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
