### PR TITLE
dfu: Add Force-Detach to bypass audio/video streaming check

### DIFF
--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -340,10 +340,10 @@ Plugin = dfu
 DfuForceVersion = 011a
 DfuForceTimeout = 5000
 
-# Poly Studio
+# Poly Studio USB
 [USB\VID_095D&PID_9217]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout,signed-payload
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 60000
 [USB\VID_095D&PID_9218]
 Plugin = dfu
@@ -363,7 +363,7 @@ RemoveDelay = 30000
 # Poly Studio P15
 [USB\VID_095D&PID_9290]
 Plugin = dfu
-Flags = manifest-poll,allow-zero-polltimeout,signed-payload
+Flags = manifest-poll,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 60000
 [USB\VID_095D&PID_9291]
 Plugin = dfu
@@ -373,7 +373,7 @@ RemoveDelay = 60000
 # Poly ULCC
 [USB\VID_095D&PID_9160]
 Plugin = dfu
-Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout,signed-payload
+Flags = manifest-poll,no-bus-reset-attach,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 60000
 [USB\VID_095D&PID_927B]
 Plugin = dfu
@@ -393,11 +393,15 @@ RemoveDelay = 9000
 # Poly Studio R30
 [USB\VID_095D&PID_92B2]
 Plugin = dfu
-Flags = manifest-poll,allow-zero-polltimeout,signed-payload
+Flags = manifest-poll,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 60000
 [USB\VID_095D&PID_92B3]
 Plugin = dfu
 Flags = manifest-poll,allow-zero-polltimeout,signed-payload
+RemoveDelay = 60000
+[USB\VID_095D&PID_92B4]
+Plugin = dfu
+Flags = manifest-poll,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 60000
 
 # Poly Studio P5
@@ -413,7 +417,7 @@ RemoveDelay = 9000
 # Poly Studio E70
 [USB\VID_095D&PID_92A1]
 Plugin = dfu
-Flags = manifest-poll,allow-zero-polltimeout,signed-payload
+Flags = manifest-poll,allow-zero-polltimeout,signed-payload,index-force-detach
 RemoveDelay = 90000
 [USB\VID_095D&PID_92A2]
 Plugin = dfu

--- a/plugins/dfu/fu-dfu-common.h
+++ b/plugins/dfu/fu-dfu-common.h
@@ -254,6 +254,12 @@ typedef enum {
  * Allows the zero bwPollTimeout from GetStatus in dfuDNLOAD-SYNC state.
  */
 #define FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT (1ull << (8 + 18))
+/**
+ * FU_DFU_DEVICE_FLAG_INDEX_FORCE_DETACH:
+ *
+ * Requires Force Detach in wIndex to bypass status checking.
+ */
+#define FU_DFU_DEVICE_FLAG_INDEX_FORCE_DETACH (1ull << (8 + 19))
 
 const gchar *
 fu_dfu_state_to_string(FuDfuState state);

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -804,7 +804,11 @@ fu_dfu_device_request_detach(FuDfuDevice *self, FuProgress *progress, GError **e
 	FuDfuDevicePrivate *priv = GET_PRIVATE(self);
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	const guint16 timeout_reset_ms = 1000;
+	guint16 ctrl_setup_index = priv->iface_number;
 	g_autoptr(GError) error_local = NULL;
+
+	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_INDEX_FORCE_DETACH))
+		ctrl_setup_index |= 0x01u << 8;
 
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
@@ -812,7 +816,7 @@ fu_dfu_device_request_detach(FuDfuDevice *self, FuProgress *progress, GError **e
 					   G_USB_DEVICE_RECIPIENT_INTERFACE,
 					   FU_DFU_REQUEST_DETACH,
 					   timeout_reset_ms,
-					   priv->iface_number,
+					   ctrl_setup_index,
 					   NULL,
 					   0,
 					   NULL,
@@ -1759,4 +1763,7 @@ fu_dfu_device_init(FuDfuDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_DFU_DEVICE_FLAG_ALLOW_ZERO_POLLTIMEOUT,
 					"allow-zero-polltimeout");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_DFU_DEVICE_FLAG_INDEX_FORCE_DETACH,
+					"index-force-detach");
 }


### PR DESCRIPTION
Some Poly usb devices will STALL the dfu detach request if the
audio/video is streaming. By setting the high byte of wIndex
in detach control request to 1, it could bypass the streaming
status check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
