### PR TITLE
Add fu_firmware_get_parent() for future use

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -256,6 +256,10 @@ void
 fu_firmware_add_chunk(FuFirmware *self, FuChunk *chk);
 GPtrArray *
 fu_firmware_get_chunks(FuFirmware *self, GError **error);
+FuFirmware *
+fu_firmware_get_parent(FuFirmware *self);
+void
+fu_firmware_set_parent(FuFirmware *self, FuFirmware *parent);
 
 gboolean
 fu_firmware_tokenize(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GError **error)

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2607,6 +2607,7 @@ fu_firmware_dedupe_func(void)
 	fu_firmware_set_idx(img1_old, 13);
 	fu_firmware_set_id(img1_old, "DAVE");
 	fu_firmware_add_image(firmware, img1_old);
+	g_assert_true(fu_firmware_get_parent(img1_old) == firmware);
 
 	fu_firmware_set_idx(img1, 13);
 	fu_firmware_set_id(img1, "primary");

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -932,7 +932,9 @@ LIBFWUPDPLUGIN_1.8.2 {
     fu_dump_full;
     fu_dump_raw;
     fu_efivar_secure_boot_enabled;
+    fu_firmware_get_parent;
     fu_firmware_parse_full;
+    fu_firmware_set_parent;
     fu_i2c_device_read;
     fu_i2c_device_write;
     fu_ifwi_cpd_firmware_get_type;


### PR DESCRIPTION
Some firmware stacks images hierarchically, and it's useful to be able
to get the parent when unrolling them out into a linear format.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
