### PR TITLE
 trivial: don't show devices with inhibit id: hidden

### DIFF
--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -255,7 +255,7 @@ fu_plugin_dell_dock_device_registered(FuPlugin *plugin, FuDevice *device)
 		g_autofree gchar *msg = NULL;
 		msg = g_strdup_printf("firmware update inhibited by [%s] plugin",
 				      fu_plugin_get_name(plugin));
-		fu_device_inhibit(device, "usb4-blocked", msg);
+		fu_device_inhibit(device, "hidden", msg);
 		return;
 	}
 

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -215,6 +215,8 @@ fu_device_list_get_active(FuDeviceList *self)
 		FuDeviceItem *item = g_ptr_array_index(self->devices, i);
 		if (fu_device_has_inhibit(item->device, "unconnected"))
 			continue;
+		if (fu_device_has_inhibit(item->device, "hidden"))
+			continue;
 		g_ptr_array_add(devices, g_object_ref(item->device));
 	}
 	g_rw_lock_reader_unlock(&self->devices_mutex);


### PR DESCRIPTION
 dell-dock: don't show thunderbolt's usb4 device, if inhibited

Some users might be confused by the inhibited message,
they might think the upgrade failed,
so the idea is to hide the inhibited device with a "hidden" inhibit id. 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
