### PR TITLE
trivial: rename thunderbolt to linux-thunderbolt

### DIFF
--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -24,7 +24,6 @@ meson .. \
     -Dplugin_dummy=true \
     -Dplugin_flashrom=enabled \
     -Dplugin_modem_manager=disabled \
-    -Dplugin_thunderbolt=enabled \
     -Dplugin_uefi_capsule=enabled \
     -Dplugin_dell=enabled \
     -Dplugin_synaptics_mst=enabled $@

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -257,7 +257,6 @@ fwupd wrapper for Qubes OS
 %else
     -Dplugin_msr=disabled \
 %endif
-    -Dplugin_thunderbolt=enabled \
 %if 0%{?have_uefi}
     -Dplugin_uefi_capsule=enabled \
     -Dplugin_uefi_pk=enabled \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,7 +35,6 @@ option('plugin_synaptics_mst', type: 'feature', description : 'Synaptics MST hub
 option('plugin_synaptics_rmi', type: 'feature', description : 'Synaptics RMI support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('plugin_scsi', type: 'feature', description : 'SCSI support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('plugin_tpm', type : 'feature', description : 'TPM support', deprecated: {'true': 'enabled', 'false': 'disabled'})
-option('plugin_thunderbolt', type : 'feature', description : 'Thunderbolt support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('plugin_redfish', type : 'feature' , description : 'Redfish support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('plugin_uefi_capsule', type : 'feature', description : 'UEFI capsule support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('plugin_uefi_capsule_splash', type : 'boolean', value : true, description : 'enable UEFI capsule splash support')

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -1,5 +1,4 @@
-if get_option('plugin_thunderbolt').require(gudev.found(),
-    error_message: 'gudev is needed for plugin_thunderbolt').allowed()
+if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginThunderbolt"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'thunderbolt.quirk')


### PR DESCRIPTION
This plugin relies on a linux only interface. There isn't a good reason to keep
a separate configuration option as we have meson tri-state features for gudev.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
