### PR TITLE
Handle ENOTTY with the correct error code for ioctl calls

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1534,11 +1534,19 @@ fu_udev_device_ioctl(FuUdevDevice *self,
 					    "permission denied");
 			return FALSE;
 		}
+		if (errno == ENOTTY) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "permission denied");
+			return FALSE;
+		}
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
-			    "ioctl error: %s",
-			    strerror(errno));
+			    "ioctl error: %s [%i]",
+			    strerror(errno),
+			    errno);
 #else
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unspecified ioctl error");
 #endif


### PR DESCRIPTION
Fixes half of https://github.com/fwupd/fwupd/discussions/4810

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
