### PR TITLE
Do not make failing to parse the i2c bus number fatal

### DIFF
--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -132,9 +132,12 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 	devname = g_path_get_basename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)));
 	if (g_str_has_prefix(devname, "i2c-")) {
 		guint64 tmp64 = 0;
-		if (!fu_strtoull(devname + 4, &tmp64, 0, G_MAXUINT, error))
-			return FALSE;
-		priv->bus_number = tmp64;
+		g_autoptr(GError) error_local = NULL;
+		if (!fu_strtoull(devname + 4, &tmp64, 0, G_MAXUINT, &error_local)) {
+			g_debug("ignoring i2c devname bus number: %s", error_local->message);
+		} else {
+			priv->bus_number = tmp64;
+		}
 	}
 #endif
 


### PR DESCRIPTION
This acccidentally become more strict in bb548f15f0 and means there
should be no more false-positive daemon warnings at startup.

Fixes the 2nd half of https://github.com/fwupd/fwupd/discussions/4810

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
