### PR TITLE
Enable protobuf-c (and relevant plugins) based on them in Ubuntu

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -44,11 +44,6 @@ ifneq ($(QUBES_OPTION),)
 	CONFARGS += -Dqubes=true
 endif
 
-#Needs a MIR
-ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu && echo yes))
-       CONFARGS += -Dplugin_logitech_bulkcontroller=disabled
-endif
-
 CONFARGS += -Dplugin_dummy=true -Dplugin_powerd=disabled -Dsupported_build=enabled -Dplugin_modem_manager=enabled -Dsystemd_unit_user=fwupd-refresh
 
 %:


### PR DESCRIPTION
an MIR has been completed in Ubuntu for this.

https://bugs.launchpad.net/ubuntu/+source/protobuf-c/+bug/1956617

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
