### PR TITLE
plugins/intel-spi: (nit) Change APL from pch to ich

### DIFF
--- a/plugins/intel-spi/generate-quirk.py
+++ b/plugins/intel-spi/generate-quirk.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     chipsets = {
-        "apl": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.0"),
+        "apl": Chipset(flags="ich", bios_cntl=0xDC, spibar_proxy="00:1f.0"),
         "c620": Chipset(flags="pch", bios_cntl=0xDC, spibar_proxy="00:1f.5"),
         "ich0": Chipset(flags="ich", bios_cntl=0x4E),
         "ich2345": Chipset(flags="ich", bios_cntl=0x4E),

--- a/plugins/intel-spi/intel-spi.quirk
+++ b/plugins/intel-spi/intel-spi.quirk
@@ -406,7 +406,7 @@ IntelSpiKind = pch400
 [INTEL_SPI_CHIPSET\ID_APL]
 IntelSpiBarProxy = 00:1f.0
 IntelSpiBiosCntl = 0xDC
-Flags = pch
+Flags = ich
 
 [INTEL_SPI_CHIPSET\ID_C620]
 IntelSpiBarProxy = 00:1f.5


### PR DESCRIPTION
APL doesn't have a PCH so change it to ich. This change makes no
difference, and is just for correctness.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>

