### PR TITLE
Allow loading in test HSI profiles for debugging

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -414,6 +414,7 @@ done
 %{_datadir}/fwupd/quirks.d/*.quirk
 %{_datadir}/doc/fwupd/builder/README.md
 %{_datadir}/doc/fwupd/*.html
+%{_datadir}/fwupd/test-profile.d/*.json.gz
 %if 0%{?have_uefi}
 %{_sysconfdir}/grub.d/35_fwupd
 %endif

--- a/contrib/minimize-test-profile.py
+++ b/contrib/minimize-test-profile.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+# pylint: disable=invalid-name,missing-docstring
+
+import json
+import sys
+
+from typing import Dict, List, Any
+
+if len(sys.argv) < 2:
+    print("specify filenames")
+    sys.exit(1)
+
+for fn in sys.argv[1:]:
+    with open(fn, "rb") as f:
+        attrs = json.loads(f.read().decode())
+    new_attrs: List[Dict[str, Any]] = []
+    for attr in attrs["SecurityAttributes"]:
+        new_attr: Dict[str, Any] = {}
+        for key in attr:
+            if key in ["AppstreamId", "HsiResult", "HsiLevel", "Flags", "Plugin"]:
+                new_attr[key] = attr[key]
+        new_attrs.append(new_attr)
+    with open(fn, "wb") as f:
+        f.write(
+            json.dumps(
+                {"SecurityAttributes": new_attrs}, indent=2, separators=(",", " : ")
+            ).encode()
+        )

--- a/docs/env.md
+++ b/docs/env.md
@@ -24,6 +24,7 @@ with a non-standard filesystem layout.
 ## daemon
 
 * `FWUPD_MACHINE_KIND` can be used to override the detected machine type, e.g. `physical`, `virtual`, or `container`
+* `FWUPD_TEST_PROFILE` can be used to load test data from `/usr/share/fwupd/test-profile.d`, e.g. `thinkpad-p1-no-iommu.json.gz`
 
 ## Self Tests
 

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -76,6 +76,8 @@ fwupd_security_attr_flag_to_string(FwupdSecurityAttrFlags flag)
 		return "action-config-fw";
 	if (flag == FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS)
 		return "action-config-os";
+	if (flag == FWUPD_SECURITY_ATTR_FLAG_EMULATED)
+		return "emulated";
 	return NULL;
 }
 
@@ -110,6 +112,8 @@ fwupd_security_attr_flag_from_string(const gchar *flag)
 		return FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW;
 	if (g_strcmp0(flag, "action-config-os") == 0)
 		return FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS;
+	if (g_strcmp0(flag, "emulated") == 0)
+		return FWUPD_SECURITY_ATTR_FLAG_EMULATED;
 	return FWUPD_SECURITY_ATTR_FLAG_NONE;
 }
 

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -39,6 +39,8 @@ struct _FwupdSecurityAttrClass {
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM:	Contact the firmware vendor for a update
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW:		Failure may be fixed by changing FW config
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS:		Failure may be fixed by changing OS config
+ * @FWUPD_SECURITY_ATTR_FLAG_EMULATED			This attribute has been emulated for
+ *simulating GUI behavior
  *
  * The flags available for HSI attributes.
  **/
@@ -53,6 +55,7 @@ typedef enum {
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM = 1 << 11,
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW = 1 << 12,
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS = 1 << 13,
+	FWUPD_SECURITY_ATTR_FLAG_EMULATED = 1 << 14,
 } FwupdSecurityAttrFlags;
 
 /**

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3251,7 +3251,7 @@ fu_util_security_as_json(FuUtilPrivate *priv,
 	json_builder_begin_object(builder);
 
 	/* attrs */
-	json_builder_set_member_name(builder, "HostSecurityAttributes");
+	json_builder_set_member_name(builder, "SecurityAttributes");
 	json_builder_begin_array(builder);
 	for (guint i = 0; i < attrs->len; i++) {
 		FwupdSecurityAttr *attr = g_ptr_array_index(attrs, i);
@@ -3263,7 +3263,7 @@ fu_util_security_as_json(FuUtilPrivate *priv,
 
 	/* events */
 	if (events != NULL && events->len > 0) {
-		json_builder_set_member_name(builder, "HostSecurityEvents");
+		json_builder_set_member_name(builder, "SecurityEvents");
 		json_builder_begin_array(builder);
 		for (guint i = 0; i < attrs->len; i++) {
 			FwupdSecurityAttr *attr = g_ptr_array_index(attrs, i);

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,3 +1,4 @@
 subdir('missing-hwid')
 subdir('multiple-rels')
 subdir('builder')
+subdir('test-profile')

--- a/src/tests/test-profile/meson.build
+++ b/src/tests/test-profile/meson.build
@@ -1,0 +1,16 @@
+if build_standalone
+  gzip = find_program('gzip')
+  foreach input_file : [
+    'thinkpad-p1-no-iommu.json',
+    'thinkpad-p1-iommu.json',
+  ]
+    custom_target(input_file,
+      input: input_file,
+      output: '@0@.gz'.format(input_file),
+      capture: true,
+      command: [gzip, '--keep', '--stdout', '@INPUT@'],
+      install: true,
+      install_dir: join_paths(datadir, 'fwupd', 'test-profile.d'),
+    )
+  endforeach
+endif

--- a/src/tests/test-profile/thinkpad-p1-iommu.json
+++ b/src/tests/test-profile/thinkpad-p1-iommu.json
@@ -1,0 +1,275 @@
+{
+  "SecurityAttributes" : [
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Tainted",
+      "HsiLevel" : 0,
+      "HsiResult" : "not-tainted",
+      "Plugin" : "linux_tainted",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Lockdown",
+      "HsiLevel" : 0,
+      "HsiResult" : "enabled",
+      "Plugin" : "linux_lockdown",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Swap",
+      "HsiLevel" : 0,
+      "HsiResult" : "encrypted",
+      "Plugin" : "linux_swap",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Uefi.SecureBoot",
+      "HsiLevel" : 0,
+      "HsiResult" : "enabled",
+      "Plugin" : "uefi_capsule",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Fwupd.Plugins",
+      "HsiLevel" : 0,
+      "HsiResult" : "not-tainted",
+      "Plugin" : "core",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.ManufacturingMode",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.OverrideStrap",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.Version",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PlatformDebugEnabled",
+      "HsiLevel" : 1,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "msr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.SmmBwp",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.Ble",
+      "HsiLevel" : 1,
+      "HsiResult" : "enabled",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.Bioswe",
+      "HsiLevel" : 1,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SupportedCpu",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "cpu",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.EmptyPcr",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.Version20",
+      "HsiLevel" : 1,
+      "HsiResult" : "found",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Uefi.Pk",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "uefi_pk",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Enabled",
+      "HsiLevel" : 2,
+      "HsiResult" : "enabled",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Acm",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Otp",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Verified",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PlatformDebugLocked",
+      "HsiLevel" : 2,
+      "HsiResult" : "locked",
+      "Plugin" : "msr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.ReconstructionPcr0",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Iommu",
+      "HsiLevel" : 2,
+      "HsiResult" : "found",
+      "Plugin" : "iommu",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Policy",
+      "HsiLevel" : 3,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelCet.Enabled",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-supported",
+      "Plugin" : "cpu"
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PrebootDma",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "acpi_dmar",
+      "Flags" : [
+        "action-contact-oem",
+        "action-config-fw"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SuspendToIdle",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "acpi_facp",
+      "Flags" : [
+        "action-config-fw",
+        "action-config-os"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SuspendToRam",
+      "HsiLevel" : 3,
+      "HsiResult" : "enabled",
+      "Plugin" : "linux_sleep",
+      "Flags" : [
+        "action-config-fw",
+        "action-config-os"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelSmap",
+      "HsiLevel" : 4,
+      "HsiResult" : "enabled",
+      "Plugin" : "cpu",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.EncryptedRam",
+      "HsiLevel" : 4,
+      "HsiResult" : "not-supported",
+      "Plugin" : "cpu"
+    }
+  ]
+}

--- a/src/tests/test-profile/thinkpad-p1-no-iommu.json
+++ b/src/tests/test-profile/thinkpad-p1-no-iommu.json
@@ -1,0 +1,272 @@
+{
+  "SecurityAttributes" : [
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Tainted",
+      "HsiLevel" : 0,
+      "HsiResult" : "not-tainted",
+      "Plugin" : "linux_tainted",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Lockdown",
+      "HsiLevel" : 0,
+      "HsiResult" : "enabled",
+      "Plugin" : "linux_lockdown",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Kernel.Swap",
+      "HsiLevel" : 0,
+      "HsiResult" : "encrypted",
+      "Plugin" : "linux_swap",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Uefi.SecureBoot",
+      "HsiLevel" : 0,
+      "HsiResult" : "enabled",
+      "Plugin" : "uefi_capsule",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Fwupd.Plugins",
+      "HsiLevel" : 0,
+      "HsiResult" : "not-tainted",
+      "Plugin" : "core",
+      "Flags" : [
+        "success",
+        "runtime-issue"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.ManufacturingMode",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.OverrideStrap",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Mei.Version",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PlatformDebugEnabled",
+      "HsiLevel" : 1,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "msr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.SmmBwp",
+      "HsiLevel" : 1,
+      "HsiResult" : "locked",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.Ble",
+      "HsiLevel" : 1,
+      "HsiResult" : "enabled",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Spi.Bioswe",
+      "HsiLevel" : 1,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "pci_bcr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SupportedCpu",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "cpu",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.EmptyPcr",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.Version20",
+      "HsiLevel" : 1,
+      "HsiResult" : "found",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Uefi.Pk",
+      "HsiLevel" : 1,
+      "HsiResult" : "valid",
+      "Plugin" : "uefi_pk",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Enabled",
+      "HsiLevel" : 2,
+      "HsiResult" : "enabled",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Acm",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Otp",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Verified",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PlatformDebugLocked",
+      "HsiLevel" : 2,
+      "HsiResult" : "locked",
+      "Plugin" : "msr",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Tpm.ReconstructionPcr0",
+      "HsiLevel" : 2,
+      "HsiResult" : "valid",
+      "Plugin" : "tpm",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.Iommu",
+      "HsiLevel" : 2,
+      "HsiResult" : "not-found",
+      "Plugin" : "iommu"
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelBootguard.Policy",
+      "HsiLevel" : 3,
+      "HsiResult" : "valid",
+      "Plugin" : "pci_mei",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelCet.Enabled",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-supported",
+      "Plugin" : "cpu"
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.PrebootDma",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "acpi_dmar",
+      "Flags" : [
+        "action-contact-oem",
+        "action-config-fw"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SuspendToIdle",
+      "HsiLevel" : 3,
+      "HsiResult" : "not-enabled",
+      "Plugin" : "acpi_facp",
+      "Flags" : [
+        "action-config-fw",
+        "action-config-os"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.SuspendToRam",
+      "HsiLevel" : 3,
+      "HsiResult" : "enabled",
+      "Plugin" : "linux_sleep",
+      "Flags" : [
+        "action-config-fw",
+        "action-config-os"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.IntelSmap",
+      "HsiLevel" : 4,
+      "HsiResult" : "enabled",
+      "Plugin" : "cpu",
+      "Flags" : [
+        "success"
+      ]
+    },
+    {
+      "AppstreamId" : "org.fwupd.hsi.EncryptedRam",
+      "HsiLevel" : 4,
+      "HsiResult" : "not-supported",
+      "Plugin" : "cpu"
+    }
+  ]
+}


### PR DESCRIPTION
This allows us to load sets of different host security attributes
for testing the various front end tools we have now. e.g.

    sudo FWUPD_TEST_PROFILE=thinkpad-p1-iommu.json.gz fwupd

or, using a non-compressed absolute path:

    sudo FWUPD_TEST_PROFILE=/tmp/test/thinkpad-p1-iommu.json fwupd

Test profiles can be created with `fwupdmgr security --json` and
manually modified if required.

See https://github.com/fwupd/fwupd/discussions/4832

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
