### PR TITLE
trivial: fix URLs for SteelSeries Aerox3 device test

### DIFF
--- a/data/device-tests/steelseries-aerox-3-wireless.json
+++ b/data/device-tests/steelseries-aerox-3-wireless.json
@@ -3,7 +3,7 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/e22dd276f649d895ffd484e14bfbbb394c82eee368f75c76c642b5f8d51e0e24-SteelSeries_Aerox_3_Wireless_Dongle_1.2.17.cab",
+      "url": "https://fwupd.org/downloads/dee6986d0faf769bf57869ee2b61118c8142e4a0017dbfc3bb0da24fb6dcfb06-SteelSeries_Aerox_3_Wireless_Dongle_1.2.17.cab",
       "components": [
         {
           "version": "1.2.17",
@@ -15,7 +15,7 @@
       ]
     },
     {
-      "url": "https://fwupd.org/downloads/7cd77f93b72507beeb0bf75f43bb9acc12e37088f3e9e1decaa84d1a696fd7df-SteelSeries_Aerox_3_Wireless_Mouse_1.8.1.cab",
+      "url": "https://fwupd.org/downloads/35883a1f60f9a171451ccd8ca9e3d89cfaedd99cc1325410465e30d180bcb47a-SteelSeries_Aerox_3_Wireless_Mouse_1.8.1.cab",
       "components": [
         {
           "version": "1.8.1",
@@ -28,7 +28,7 @@
       ]
     },
     {
-      "url": "https://fwupd.org/downloads/89fcc9ae1e7bd9d9f86aa029463fb25e21352a9490fad671a3e409b77da0200c-SteelSeries_Aerox_3_Wireless_Dongle_1.3.1.cab",
+      "url": "https://fwupd.org/downloads/fb8e8253a6c4426233ff88a58ae9323f1a7b9002fe6f68541c2e886cded04d38-SteelSeries_Aerox_3_Wireless_Dongle_1.3.1.cab",
       "components": [
         {
           "version": "1.3.1",
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "url": "https://fwupd.org/downloads/1a15d0bac6fdd76d10bb0ae5ce3899e0a68e7b9a7761ffb009c8449d157dbd32-SteelSeries_Aerox_3_Wireless_Mouse_1.9.3.cab",
+      "url": "https://fwupd.org/downloads/60627b15b7c1499fcd6a882ef02743f358812fcfc9ed3d1b200f55b91c554796-SteelSeries_Aerox_3_Wireless_Mouse_1.9.3.cab",
       "components": [
         {
           "version": "1.9.3",


### PR DESCRIPTION
Some of URLs disappeared. Marked all versions from the
commit as persistent on LVFS to avoid CABs loss.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
