### PR TITLE
Wait for the system to acquiesce after doing each update

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -235,6 +235,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "auto-pause-polling";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_ONLY_WAIT_FOR_REPLUG)
 		return "only-wait-for-replug";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_REQUIRES_ACQUIESCE)
+		return "requires-acquiesce";
 	return NULL;
 }
 
@@ -303,6 +305,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_AUTO_PAUSE_POLLING;
 	if (g_strcmp0(flag, "only-wait-for-replug") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_ONLY_WAIT_FOR_REPLUG;
+	if (g_strcmp0(flag, "requires-acquiesce") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_REQUIRES_ACQUIESCE;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -466,6 +466,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_ONLY_WAIT_FOR_REPLUG (1ull << 25)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_REQUIRES_ACQUIESCE:
+ *
+ * Wait for the system to return to idle with no hotplug events pending.
+ *
+ * Since: 1.8.3
+ */
+#define FU_DEVICE_INTERNAL_FLAG_REQUIRES_ACQUIESCE (1ull << 26)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -89,6 +89,7 @@ fu_usb_device_init(FuUsbDevice *device)
 {
 	FuUsbDevicePrivate *priv = GET_PRIVATE(device);
 	priv->configuration = -1;
+	fu_device_add_internal_flag(FU_DEVICE(device), FU_DEVICE_INTERNAL_FLAG_REQUIRES_ACQUIESCE);
 #ifdef HAVE_GUSB
 	fu_device_retry_add_recovery(FU_DEVICE(device),
 				     G_USB_DEVICE_ERROR,

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -213,6 +213,8 @@ fu_engine_get_releases_for_device(FuEngine *self,
 
 /* for the self tests */
 void
+fu_engine_set_system_acquiesce_delay(FuEngine *self, guint system_acquiesce_delay);
+void
 fu_engine_add_device(FuEngine *self, FuDevice *device);
 void
 fu_engine_add_plugin(FuEngine *self, FuPlugin *plugin);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2194,6 +2194,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 
 	/* install them */
 	fu_progress_reset(progress);
+	fu_engine_set_system_acquiesce_delay(engine, 0);
 	ret = fu_engine_install_releases(engine,
 					 request,
 					 releases,
@@ -3658,6 +3659,7 @@ fu_plugin_composite_func(gconstpointer user_data)
 	g_assert_cmpint(releases->len, ==, 3);
 
 	/* install the cab */
+	fu_engine_set_system_acquiesce_delay(engine, 0);
 	ret = fu_engine_install_releases(engine,
 					 request,
 					 releases,


### PR DESCRIPTION
We want to allow all the device hotplug events to be processed before
marking the update as completed. Otherwise, we might have a situation
where we have a child device attached to a parent, where we want to
update the parent, then the child. e.g.

 1. Add parent
 2. Add child
 3. Update parent
 4. Attach parent
 5. Wait for parent

...some time passes...

 6. Parent re-appears
 7. Update finishes, client indicates success

...child update is scheduled...
...which returns with failure as it does not exist...

 8. Add child

The child should have been added *before* the update completed to avoid
the caller from needing an unspecified delay as a *workaround*.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
