### PR TITLE
fu-smbios: Fix parsing smbios data

### DIFF
--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -869,7 +869,8 @@ fu_smbios_setup(FuSmbios *self, GError **error)
 				return FALSE;
 			}
 			g_debug("ignoring %s", error_local->message);
-		}
+		} else
+			return TRUE;
 	}
 
 	/* the values the kernel parsed; these are world-readable */


### PR DESCRIPTION
When support was added for falling back to SMBIOS data from the kernel
in /sys/class/dmi, we inadvertently stopped caring about the data parsed
directly from DMI tables as first priority.  This caused a regression in
hwids from some OEMs that relied upon IDs that could only be properly built
from DMI tables, not the kernel /sys/class/dmi interface.

Link: https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/1982103
Fixes: 464425fb5 ("SMBIOS: try reading from /sys/class/dmi if direct access fails")
Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
