### PR TITLE
trivial: fixup setup helpers to install right version of meson

### DIFF
--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -58,9 +58,20 @@ def test_markdown(debug):
 
 
 def test_meson(debug):
-    from importlib.metadata import version
+    from importlib.metadata import version, PackageNotFoundError
 
-    new_enough = version("meson") >= MINIMUM_MESON
+    try:
+        new_enough = version("meson") >= MINIMUM_MESON
+    except PackageNotFoundError:
+        import subprocess
+
+        try:
+            ver = (
+                subprocess.check_output(["meson", "--version"]).strip().decode("utf-8")
+            )
+            new_enough = ver >= MINIMUM_MESON
+        except FileNotFoundError:
+            new_enough = False
     if not new_enough:
         print("meson must be installed/upgraded")
         pip_install_package(debug, "meson")

--- a/contrib/setup
+++ b/contrib/setup
@@ -158,12 +158,6 @@ detect_os "$@"
 
 detect_selinux
 
-#always setup pre-commit
-setup_precommit
-
-#always setup git environment
-setup_git
-
 #if interactive install build deps and prepare environment
 if [ -t 2 ]; then
     case $OS in
@@ -176,9 +170,15 @@ if [ -t 2 ]; then
             ;;
     esac
     setup_unsafe_polkit_rules
-    check_markdown
-    check_meson
-    setup_vscode
     rename_branch
+fi
+check_markdown
+setup_vscode
+setup_git
+check_meson
+setup_precommit
+
+#needs to be after pre-commit is sourced
+if [ -t 2 ]; then
     setup_prepush
 fi


### PR DESCRIPTION
if meson wasn't installed by pip it won't have a version string

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
