### PR TITLE
Make host-emulate/meson.build compatible with Busybox

### DIFF
--- a/src/tests/host-emulate/meson.build
+++ b/src/tests/host-emulate/meson.build
@@ -7,7 +7,7 @@ if build_standalone
       input: input_file,
       output: '@0@.gz'.format(input_file),
       capture: true,
-      command: [gzip, '--keep', '--stdout', '@INPUT@'],
+      command: [gzip, '-k', '--stdout', '@INPUT@'],
       install: true,
       install_dir: join_paths(datadir, 'fwupd', 'host-emulate.d'),
     )


### PR DESCRIPTION
Busybox only supports the short option '-k'. (#4866)

Using this instead of '--keep' allows fwupd to be built on systems like Alpine Linux where /bin/gzip is supplied by Busybox.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
