### PR TITLE
trivial: Reduce the debug output when fuzzing

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -18,6 +18,7 @@ with a non-standard filesystem layout.
 * `FWUPD_DBUS_SOCKET` is used to set the socket filename if running without a dbus-daemon
 * `FWUPD_DOWNLOAD_VERBOSE` can be used to show wget or curl output
 * `FWUPD_PROFILE` can be used to set the profile traceback threshold value in ms
+* `FWUPD_FUZZER_RUNNING` if the firmware format is being fuzzed
 * standard glibc variables like `LANG` are also honored for CLI tools that are translated
 * libcurl respects the session proxy, e.g. `http_proxy`, `all_proxy`, `sftp_proxy` and `no_proxy`
 

--- a/libfwupdplugin/fu-efi-firmware-file.c
+++ b/libfwupdplugin/fu-efi-firmware-file.c
@@ -230,9 +230,13 @@ fu_efi_firmware_file_parse(FuFirmware *firmware,
 
 	/* verify header checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
-		g_autoptr(GBytes) hdr_blob =
-		    g_bytes_new_from_bytes(fw, 0x0, FU_EFI_FIRMWARE_FILE_SIZE);
-		guint8 hdr_checksum_verify = fu_efi_firmware_file_hdr_checksum8(hdr_blob);
+		guint8 hdr_checksum_verify;
+		g_autoptr(GBytes) hdr_blob = NULL;
+
+		hdr_blob = fu_bytes_new_offset(fw, 0x0, FU_EFI_FIRMWARE_FILE_SIZE, error);
+		if (hdr_blob == NULL)
+			return FALSE;
+		hdr_checksum_verify = fu_efi_firmware_file_hdr_checksum8(hdr_blob);
 		if (hdr_checksum_verify != hdr_checksum) {
 			g_set_error(error,
 				    FWUPD_ERROR,

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -28,11 +28,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 					NULL);
 	}
 	if (ret) {
-		g_autofree gchar *str = fu_firmware_to_string(firmware);
 		g_autoptr(GBytes) fw2 = fu_firmware_write(firmware, NULL);
-		g_print("%s", str);
-		if (fw2 != NULL)
-			g_print("[%" G_GSIZE_FORMAT " bytes]\n", g_bytes_get_size(fw2));
 	}
 	return 0;
 }

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -15,7 +15,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 	g_autoptr(GBytes) fw = g_bytes_new(data, size);
 	gboolean ret;
 
-	(void)g_setenv("G_DEBUG", "fatal-criticals", FALSE);
+	(void)g_setenv("G_DEBUG", "fatal-criticals", TRUE);
 	(void)g_setenv("FWUPD_FUZZER_RUNNING", "1", TRUE);
 	ret = fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -16,6 +16,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 	gboolean ret;
 
 	(void)g_setenv("G_DEBUG", "fatal-criticals", FALSE);
+	(void)g_setenv("FWUPD_FUZZER_RUNNING", "1", TRUE);
 	ret = fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		g_clear_object(&firmware);

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -117,7 +117,8 @@ fu_bcm57xx_dict_image_ensure_id(FuBcm57xxDictImage *self)
 		}
 	}
 	id = g_strdup_printf("dict-%02x-%02x", self->target, self->kind);
-	g_warning("falling back to %s, please report", id);
+	if (g_getenv("FWUPD_FUZZER_RUNNING") == NULL)
+		g_warning("falling back to %s, please report", id);
 	fu_firmware_set_id(FU_FIRMWARE(self), id);
 }
 

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -553,8 +553,9 @@ fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 	if (self->active_partition == 1)
 		offset = bufsz / 2;
 
-	new_fw = g_bytes_new_from_bytes(fw, offset, bufsz / 2);
-
+	new_fw = fu_bytes_new_offset(fw, offset, bufsz / 2, error);
+	if (new_fw == NULL)
+		return NULL;
 	if (!fu_firmware_parse(firmware, new_fw, flags, error))
 		return NULL;
 

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -184,11 +184,15 @@ fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 
-	fw_header = g_bytes_new_from_bytes(fw, 0x0, headsz);
+	fw_header = fu_bytes_new_offset(fw, 0x0, headsz, error);
+	if (fw_header == NULL)
+		return FALSE;
 	if (!fu_synaptics_cape_firmware_parse_header(self, firmware, fw_header, error))
 		return FALSE;
 
-	fw_body = g_bytes_new_from_bytes(fw, headsz, bufsz - headsz);
+	fw_body = fu_bytes_new_offset(fw, headsz, bufsz - headsz, error);
+	if (fw_body == NULL)
+		return FALSE;
 	fu_firmware_set_id(firmware, FU_FIRMWARE_ID_PAYLOAD);
 	fu_firmware_set_bytes(firmware, fw_body);
 	return TRUE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -317,7 +317,9 @@ fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* verify signature if set */
-	firmware_bin = g_bytes_new_from_bytes(bytes_bin, 0, firmware_length);
+	firmware_bin = fu_bytes_new_offset(bytes_bin, 0, firmware_length, error);
+	if (firmware_bin == NULL)
+		return FALSE;
 	signature_bin = fu_firmware_get_image_by_id_bytes(firmware, "sig", NULL);
 	if (signature_bin != NULL) {
 		if (!fu_synaptics_rmi_v5_device_secure_check(device,

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -198,7 +198,8 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 					return FALSE;
 				fu_firmware_set_id(FU_FIRMWARE(self), utf8buf);
 			} else {
-				g_warning("unknown tag 0x%06x", tag);
+				if (g_getenv("FWUPD_FUZZER_RUNNING") == NULL)
+					g_warning("unknown tag 0x%06x", tag);
 			}
 
 			/* next! */


### PR DESCRIPTION
At the moment the log is ~150,000 lines, and quite a bit of CPU time is
being spent just generating ignored XML for successful runs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X ] Code fix
- [ ] Feature
- [ ] Documentation
