### PR TITLE
Add support to map BIOS attributes to Security Attributes

### DIFF
--- a/libfwupd/fwupd-bios-attr.h
+++ b/libfwupd/fwupd-bios-attr.h
@@ -108,4 +108,13 @@ fwupd_bios_attr_get_current_value(FwupdBiosAttr *self);
 void
 fwupd_bios_attr_set_current_value(FwupdBiosAttr *self, const gchar *value);
 
+const gchar *
+fwupd_bios_attr_get_id(FwupdBiosAttr *self);
+void
+fwupd_bios_attr_set_id(FwupdBiosAttr *self, const gchar *id);
+
+const gchar *
+fwupd_bios_attr_get_preferred_value(FwupdBiosAttr *self);
+void
+fwupd_bios_attr_set_preferred_value(FwupdBiosAttr *self, const gchar *value);
 G_END_DECLS

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -509,10 +509,25 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_BATTERY_THRESHOLD "BatteryThreshold"
 /**
+ * FWUPD_RESULT_KEY_BIOS_ATTR_ID:
+ *
+ * Result key to represent the unique identifier of the BIOS attribute.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_ATTR_ID "BiosAttrId"
+/**
+ * FWUPD_RESULT_KEY_BIOS_ATTR_PREFERRED_VALUE:
+ *
+ * Result key to represent the value that would enable this attribute.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_ATTR_PREFERRED_VALUE "BiosAttrPreferredValue"
+/**
  * FWUPD_RESULT_KEY_BIOS_ATTR_CURRENT_VALUE:
  *
- * Result key to represent the type of BIOS attribute.
- * 0 is invalid, 1+ represent an attribute type
+ * Result key to represent the current value of BIOS attribute.
  *
  * The D-Bus type signature string is 's' i.e. a string.
  **/
@@ -567,4 +582,5 @@ G_BEGIN_DECLS
  * The D-Bus type signature string is 'b' i.e. a boolean.
  **/
 #define FWUPD_RESULT_KEY_BIOS_ATTR_READ_ONLY "BiosAttrReadOnly"
+
 G_END_DECLS

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -127,6 +127,11 @@ gchar *
 fwupd_security_attr_to_string(FwupdSecurityAttr *self);
 
 const gchar *
+fwupd_security_attr_get_bios_id(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_set_bios_attr_id(FwupdSecurityAttr *self, const gchar *id);
+
+const gchar *
 fwupd_security_attr_get_appstream_id(FwupdSecurityAttr *self);
 void
 fwupd_security_attr_set_appstream_id(FwupdSecurityAttr *self, const gchar *appstream_id);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -842,5 +842,7 @@ LIBFWUPD_1.8.4 {
     fwupd_client_modify_bios_attr;
     fwupd_client_modify_bios_attr_async;
     fwupd_client_modify_bios_attr_finish;
+    fwupd_security_attr_get_bios_id;
+    fwupd_security_attr_set_bios_attr_id;
   local: *;
 } LIBFWUPD_1.8.3;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -809,11 +809,13 @@ LIBFWUPD_1.8.4 {
     fwupd_bios_attr_from_variant;
     fwupd_bios_attr_get_current_value;
     fwupd_bios_attr_get_description;
+    fwupd_bios_attr_get_id;
     fwupd_bios_attr_get_kind;
     fwupd_bios_attr_get_lower_bound;
     fwupd_bios_attr_get_name;
     fwupd_bios_attr_get_path;
     fwupd_bios_attr_get_possible_values;
+    fwupd_bios_attr_get_preferred_value;
     fwupd_bios_attr_get_read_only;
     fwupd_bios_attr_get_scalar_increment;
     fwupd_bios_attr_get_type;
@@ -822,10 +824,12 @@ LIBFWUPD_1.8.4 {
     fwupd_bios_attr_new;
     fwupd_bios_attr_set_current_value;
     fwupd_bios_attr_set_description;
+    fwupd_bios_attr_set_id;
     fwupd_bios_attr_set_kind;
     fwupd_bios_attr_set_lower_bound;
     fwupd_bios_attr_set_name;
     fwupd_bios_attr_set_path;
+    fwupd_bios_attr_set_preferred_value;
     fwupd_bios_attr_set_read_only;
     fwupd_bios_attr_set_scalar_increment;
     fwupd_bios_attr_set_upper_bound;

--- a/libfwupdplugin/fu-bios-attrs.h
+++ b/libfwupdplugin/fu-bios-attrs.h
@@ -18,4 +18,6 @@ fu_bios_attrs_new(void);
 gboolean
 fu_bios_attrs_get_pending_reboot(FuBiosAttrs *self, gboolean *result, GError **error);
 FwupdBiosAttr *
-fu_bios_attrs_get_attr(FuBiosAttrs *self, const gchar *name);
+fu_bios_attrs_get_attr(FuBiosAttrs *self, const gchar *val);
+void
+fu_bios_attr_set_preferred_value(FwupdBiosAttr *attr, const gchar *needle);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2948,7 +2948,7 @@ fu_bios_attrs_load_func(void)
 	g_assert_false(ret);
 
 	/* check an attribute reads from kernel as expected by fwupd today */
-	attr = fu_context_get_bios_attr(ctx, "AMDMemoryGuard");
+	attr = fu_context_get_bios_attr(ctx, "com.thinklmi.AMDMemoryGuard");
 	g_assert_nonnull(attr);
 	tmp = fwupd_bios_attr_get_name(attr);
 	g_assert_cmpstr(tmp, ==, "AMDMemoryGuard");
@@ -2968,7 +2968,7 @@ fu_bios_attrs_load_func(void)
 	/* try to read an attribute known to have ][Status] to make sure we worked
 	 * around the thinklmi bug sufficiently
 	 */
-	attr = fu_context_get_bios_attr(ctx, "StartupSequence");
+	attr = fu_context_get_bios_attr(ctx, "com.thinklmi.StartupSequence");
 	g_assert_nonnull(attr);
 	tmp = fwupd_bios_attr_get_current_value(attr);
 	g_assert_cmpstr(tmp, ==, "Primary");
@@ -3008,7 +3008,7 @@ fu_bios_attrs_load_func(void)
 	g_assert_true(ret);
 
 	/* look for an enumeration attribute with a space */
-	attr = fu_context_get_bios_attr(ctx, "SleepState");
+	attr = fu_context_get_bios_attr(ctx, "com.thinklmi.SleepState");
 	g_assert_nonnull(attr);
 	tmp = fwupd_bios_attr_get_name(attr);
 	g_assert_cmpstr(tmp, ==, "SleepState");
@@ -3042,7 +3042,7 @@ fu_bios_attrs_load_func(void)
 	g_assert_null(attr);
 
 	/* look at a integer attribute */
-	attr = fu_context_get_bios_attr(ctx, "CustomChargeStop");
+	attr = fu_context_get_bios_attr(ctx, "com.dell-wmi-sysman.CustomChargeStop");
 	g_assert_nonnull(attr);
 	kind = fwupd_bios_attr_get_kind(attr);
 	g_assert_cmpint(kind, ==, FWUPD_BIOS_ATTR_KIND_INTEGER);
@@ -3054,7 +3054,7 @@ fu_bios_attrs_load_func(void)
 	g_assert_cmpint(integer, ==, 1);
 
 	/* look at a string attribute */
-	attr = fu_context_get_bios_attr(ctx, "Asset");
+	attr = fu_context_get_bios_attr(ctx, "com.dell-wmi-sysman.Asset");
 	g_assert_nonnull(attr);
 	integer = fwupd_bios_attr_get_lower_bound(attr);
 	g_assert_cmpint(integer, ==, 1);
@@ -3064,7 +3064,7 @@ fu_bios_attrs_load_func(void)
 	g_assert_cmpstr(tmp, ==, "Asset Tag");
 
 	/* look at a enumeration attribute */
-	attr = fu_context_get_bios_attr(ctx, "BiosRcvrFrmHdd");
+	attr = fu_context_get_bios_attr(ctx, "com.dell-wmi-sysman.BiosRcvrFrmHdd");
 	g_assert_nonnull(attr);
 	kind = fwupd_bios_attr_get_kind(attr);
 	g_assert_cmpint(kind, ==, FWUPD_BIOS_ATTR_KIND_ENUMERATION);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1071,6 +1071,7 @@ LIBFWUPDPLUGIN_1.8.3 {
 LIBFWUPDPLUGIN_1.8.4 {
   global:
     fu_backend_add_string;
+    fu_bios_attr_set_preferred_value;
     fu_bios_attrs_get_all;
     fu_bios_attrs_get_attr;
     fu_bios_attrs_get_pending_reboot;

--- a/plugins/acpi-facp/fu-plugin-acpi-facp.c
+++ b/plugins/acpi-facp/fu-plugin-acpi-facp.c
@@ -13,6 +13,7 @@
 static void
 fu_plugin_acpi_facp_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
+	FwupdBiosAttr *bios_attr;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *path = NULL;
 	g_autoptr(FuAcpiFacp) facp = NULL;
@@ -40,6 +41,16 @@ fu_plugin_acpi_facp_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 		return;
 	}
+
+	/* BIOS knob used on Lenovo systems */
+	bios_attr =
+	    fu_context_get_bios_attr(fu_plugin_get_context(plugin), "com.thinklmi.SleepState");
+	if (bios_attr != NULL) {
+		fwupd_security_attr_set_bios_attr_id(attr, fwupd_bios_attr_get_id(bios_attr));
+		/* options are usually "Linux" (S3) or "Windows" (s2idle) */
+		fu_bios_attr_set_preferred_value(bios_attr, "windows");
+	}
+
 	if (!fu_acpi_facp_get_s2i(facp)) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);

--- a/plugins/iommu/fu-plugin-iommu.c
+++ b/plugins/iommu/fu-plugin-iommu.c
@@ -45,6 +45,7 @@ static void
 fu_plugin_iommu_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuPluginData *priv = fu_plugin_get_data(plugin);
+	const gchar *iommu_attributes[] = {"AmdVt", "IOMMU", "VtForDirectIo", NULL};
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
 
 	/* create attr */
@@ -55,6 +56,17 @@ fu_plugin_iommu_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (priv == NULL) {
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
 		return;
+	}
+
+	for (guint i = 0; iommu_attributes[i] != NULL; i++) {
+		FwupdBiosAttr *bios_attr =
+		    fu_context_get_bios_attr(fu_plugin_get_context(plugin), iommu_attributes[i]);
+		if (bios_attr != NULL) {
+			fwupd_security_attr_set_bios_attr_id(attr,
+							     fwupd_bios_attr_get_id(bios_attr));
+			fu_bios_attr_set_preferred_value(bios_attr, "enable");
+			break;
+		}
 	}
 	if (!priv->has_iommu) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);

--- a/plugins/lenovo-thinklmi/fu-plugin-lenovo-thinklmi.c
+++ b/plugins/lenovo-thinklmi/fu-plugin-lenovo-thinklmi.c
@@ -8,7 +8,7 @@
 
 #include <fwupdplugin.h>
 
-#define BOOT_ORDER_LOCK "BootOrderLock"
+#define BOOT_ORDER_LOCK "com.thinklmi.BootOrderLock"
 
 static gboolean
 fu_plugin_lenovo_thinklmi_startup(FuPlugin *plugin, FuProgress *progress, GError **error)

--- a/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
+++ b/plugins/uefi-capsule/fu-plugin-uefi-capsule.c
@@ -187,10 +187,15 @@ fu_plugin_uefi_capsule_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *att
 
 	/* SB not available or disabled */
 	if (!fu_efivar_secure_boot_enabled(&error)) {
+		FwupdBiosAttr *bios_attr;
 		if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 			return;
 		}
+		bios_attr = fu_context_get_bios_attr(fu_plugin_get_context(plugin), "SecureBoot");
+		if (bios_attr != NULL)
+			fwupd_security_attr_set_bios_attr_id(attr,
+							     fwupd_bios_attr_get_id(bios_attr));
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE);
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4537,7 +4537,8 @@ fu_engine_modify_bios_attrs_func(void)
 	g_assert_cmpint(items->len, ==, 4);
 
 	/* enumeration */
-	attr1 = fu_context_get_bios_attr(fu_engine_get_context(engine), "Absolute");
+	attr1 =
+	    fu_context_get_bios_attr(fu_engine_get_context(engine), "com.fwupd-internal.Absolute");
 	g_assert_nonnull(attr1);
 
 	current = fwupd_bios_attr_get_current_value(attr1);
@@ -4552,12 +4553,13 @@ fu_engine_modify_bios_attrs_func(void)
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
-	ret = fu_engine_modify_bios_attr(engine, "Absolute", current, &error);
+	/* use BiosAttrId instead */
+	ret = fu_engine_modify_bios_attr(engine, "com.fwupd-internal.Absolute", current, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	/* string */
-	attr2 = fu_context_get_bios_attr(fu_engine_get_context(engine), "Asset");
+	attr2 = fu_context_get_bios_attr(fu_engine_get_context(engine), "com.fwupd-internal.Asset");
 	g_assert_nonnull(attr2);
 
 	current = fwupd_bios_attr_get_current_value(attr2);
@@ -4577,7 +4579,8 @@ fu_engine_modify_bios_attrs_func(void)
 	g_clear_error(&error);
 
 	/* integer */
-	attr3 = fu_context_get_bios_attr(fu_engine_get_context(engine), "CustomChargeStop");
+	attr3 = fu_context_get_bios_attr(fu_engine_get_context(engine),
+					 "com.fwupd-internal.CustomChargeStop");
 	g_assert_nonnull(attr3);
 
 	current = fwupd_bios_attr_get_current_value(attr3);
@@ -4601,7 +4604,8 @@ fu_engine_modify_bios_attrs_func(void)
 	g_assert_no_error(error);
 
 	/* Read Only */
-	attr4 = fu_context_get_bios_attr(fu_engine_get_context(engine), "pending_reboot");
+	attr4 = fu_context_get_bios_attr(fu_engine_get_context(engine),
+					 "com.fwupd-internal.pending_reboot");
 	g_assert_nonnull(attr4);
 
 	current = fwupd_bios_attr_get_current_value(attr4);


### PR DESCRIPTION
This will allow clients to be able to suggest to users to change BIOS settings to try to fix security problems.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
