### PR TITLE
Use -Db_sanitize=address,undefined in Fedora CI

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1741,6 +1741,18 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="libasan">
+    <distro id="fedora">
+      <!-- for running with -Db_sanitize=address -->
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
+  <dependency type="build" id="libubsan">
+    <distro id="fedora">
+      <!-- for running with -Db_sanitize=undefined -->
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="wine">
     <distro id="fedora">
       <!-- for running the self tests -->

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -20,6 +20,7 @@ meson .. \
     -Ddocs=disabled \
     -Dman=true \
     -Dtests=true \
+    -Db_sanitize=address,undefined \
     -Dgusb:tests=false \
     -Dplugin_dummy=true \
     -Dplugin_flashrom=enabled \


### PR DESCRIPTION
This would have caught the recent memory corruption automatically.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
