### PR TITLE
plugins/flashrom: Skip BC check for coreboot devices

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -39,11 +39,13 @@ Plugin = flashrom
 [d33219e2-b84c-53a8-a624-27af9752dba6]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # StarLite Mk II (coreboot GUID)
 [2993474c-b4c4-5b7c-b2e1-a471d8d328a5]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # StarLite Mk II (AMI GUID)
 [0676539d-150f-5f07-89b9-fe0afd98c44e]
@@ -53,6 +55,7 @@ FirmwareSizeMax = 0x800000
 [3d2f164a-8818-58fd-a082-6c60a67e21a6]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # StarLite Mk III (AMI GUID)
 [ec375a72-9ed9-5a21-b1da-5e7f00dcada1]
@@ -62,6 +65,7 @@ FirmwareSizeMax = 0x800000
 [5dc1dd5b-761e-5146-8ac2-1fdd8445f2ff]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # StarLite Mk IV (AMI GUID)
 [32edd806-13a0-5b0f-a8e9-656a0e147369]
@@ -71,11 +75,13 @@ FirmwareSizeMax = 0x800000
 [0ee5867c-93f0-5fb4-adf1-9d686ea1183a]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # StarBook Mk V (coreboot GUID)
 [54c96fef-31e7-5011-a3ff-ea8e855d9acd]
 Branch = coreboot
 Flags = reset-cmos
+PciBcrAddr = 0x0
 
 # NovaCustom NV4x (HwId)
 [25b6ea34-8f52-598e-a27a-31e03014dbe3]


### PR DESCRIPTION
Set BcrAddr to 0x0 for all coreboot devices, so that the check of
BIOS Control is skipped as coreboot won't forcibly set this.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>

