### PR TITLE
Store the current BIOS value in a security attribute

### DIFF
--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -131,9 +131,13 @@ fwupd_security_attr_get_bios_attr_id(FwupdSecurityAttr *self);
 void
 fwupd_security_attr_set_bios_attr_id(FwupdSecurityAttr *self, const gchar *id);
 const gchar *
-fwupd_security_attr_get_bios_attr_value(FwupdSecurityAttr *self);
+fwupd_security_attr_get_bios_attr_target_value(FwupdSecurityAttr *self);
 void
-fwupd_security_attr_set_bios_attr_value(FwupdSecurityAttr *self, const gchar *value);
+fwupd_security_attr_set_bios_attr_target_value(FwupdSecurityAttr *self, const gchar *value);
+const gchar *
+fwupd_security_attr_get_bios_attr_current_value(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_set_bios_attr_current_value(FwupdSecurityAttr *self, const gchar *value);
 
 const gchar *
 fwupd_security_attr_get_appstream_id(FwupdSecurityAttr *self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -840,9 +840,11 @@ LIBFWUPD_1.8.4 {
     fwupd_client_modify_bios_attr;
     fwupd_client_modify_bios_attr_async;
     fwupd_client_modify_bios_attr_finish;
+    fwupd_security_attr_get_bios_attr_current_value;
     fwupd_security_attr_get_bios_attr_id;
-    fwupd_security_attr_get_bios_attr_value;
+    fwupd_security_attr_get_bios_attr_target_value;
+    fwupd_security_attr_set_bios_attr_current_value;
     fwupd_security_attr_set_bios_attr_id;
-    fwupd_security_attr_set_bios_attr_value;
+    fwupd_security_attr_set_bios_attr_target_value;
   local: *;
 } LIBFWUPD_1.8.3;

--- a/libfwupdplugin/fu-security-attr.c
+++ b/libfwupdplugin/fu-security-attr.c
@@ -44,6 +44,9 @@ fu_security_attr_add_bios_target_value(FwupdSecurityAttr *attr,
 	if (bios_attr == NULL)
 		return;
 	fwupd_security_attr_set_bios_attr_id(attr, fwupd_bios_attr_get_id(bios_attr));
+	fwupd_security_attr_set_bios_attr_current_value(
+	    attr,
+	    fwupd_bios_attr_get_current_value(bios_attr));
 	if (fwupd_bios_attr_get_kind(bios_attr) != FWUPD_BIOS_ATTR_KIND_ENUMERATION)
 		return;
 	values = fwupd_bios_attr_get_possible_values(bios_attr);
@@ -51,7 +54,7 @@ fu_security_attr_add_bios_target_value(FwupdSecurityAttr *attr,
 		const gchar *possible = g_ptr_array_index(values, i);
 		g_autofree gchar *lower = g_utf8_strdown(possible, -1);
 		if (g_strrstr(lower, needle)) {
-			fwupd_security_attr_set_bios_attr_value(attr, possible);
+			fwupd_security_attr_set_bios_attr_target_value(attr, possible);
 			return;
 		}
 	}


### PR DESCRIPTION
We can't very-well ask the user to 'change it back' if we do not tell
them what it is set to already.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
