### PR TITLE
trivial: don't let people try to turn off UEFI secure boot

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3023,6 +3023,12 @@ fu_bios_attrs_load_func(void)
 			g_assert_cmpstr(possible, ==, "Windows 10");
 	}
 
+	/* make sure we defaulted UEFI Secure boot to read only if enabled */
+	attr = fu_context_get_bios_attr(ctx, "com.thinklmi.SecureBoot");
+	g_assert_nonnull(attr);
+	ret = fwupd_bios_attr_get_read_only(attr);
+	g_assert_true(ret);
+
 	g_free(test_dir);
 
 	/* load attrs from a Dell XPS 9310 */
@@ -3076,6 +3082,12 @@ fu_bios_attrs_load_func(void)
 		if (i == 1)
 			g_assert_cmpstr(possible, ==, "Enabled");
 	}
+
+	/* make sure we defaulted UEFI Secure boot to read only if enabled */
+	attr = fu_context_get_bios_attr(ctx, "com.dell-wmi-sysman.SecureBoot");
+	g_assert_nonnull(attr);
+	ret = fwupd_bios_attr_get_read_only(attr);
+	g_assert_true(ret);
 }
 
 static void

--- a/libfwupdplugin/tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/SecureBoot/current_value
+++ b/libfwupdplugin/tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/SecureBoot/current_value
@@ -1,1 +1,1 @@
-Disabled
+Enabled

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p14s-gen1/thinklmi/attributes/SecureBoot/current_value
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p14s-gen1/thinklmi/attributes/SecureBoot/current_value
@@ -1,1 +1,1 @@
-Disable
+Enable


### PR DESCRIPTION
The firmware from both Dell and Lenovo actually blocks this, but the
error message is pretty confusing.

```
$ sudo fwupdtool set-bios-setting SecureBoot Disable
17:39:40:0249 FuBiosAttrs          KERNEL BUG: thinklmi doesn't export a 'type' attribute
Loading…                 [-                                      ]
failed to write 7 bytes to 17: Invalid argument
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
