### PR TITLE
fu-engine: Evalute HSI number when FWUPD_HOST_EMULATE is set in the VM

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6344,6 +6344,11 @@ fu_engine_attrs_calculate_hsi_for_chassis(FuEngine *self)
 	guint val =
 	    fu_context_get_smbios_integer(self->ctx, FU_SMBIOS_STRUCTURE_TYPE_CHASSIS, 0x05);
 
+	if (g_getenv("FWUPD_HOST_EMULATE") != NULL) {
+		return fu_security_attrs_calculate_hsi(self->host_security_attrs,
+						       FU_SECURITY_ATTRS_FLAG_ADD_VERSION);
+	}
+
 	switch (val) {
 	case FU_SMBIOS_CHASSIS_KIND_DESKTOP:
 	case FU_SMBIOS_CHASSIS_KIND_LOW_PROFILE_DESKTOP:


### PR DESCRIPTION
When fwupd runs in VM with FWUPD_MACHINE_KIND and FWUPD_HOST_EMULATE set,
the HSI value will not be computed since the FU_SMBIOS_CHASSIS_KIND is
OTHER. Consequence, a "HSI-INVALID:chassis[0x01]" is returned through
dbus. This should ensure when fwupd runs in a VM with FWUPD_HOST_EMULATE,
the HSI value can be properly returned according to the mockup data.

Signed-off-by: Kate Hsuan <hpa@redhat.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
