### PR TITLE
trivial: don't set target BIOS attribute for read only attributes

### DIFF
--- a/libfwupdplugin/fu-security-attr.c
+++ b/libfwupdplugin/fu-security-attr.c
@@ -48,6 +48,8 @@ fu_security_attr_add_bios_target_value(FwupdSecurityAttr *attr,
 	    fwupd_bios_attr_get_current_value(bios_attr));
 	if (fwupd_bios_attr_get_kind(bios_attr) != FWUPD_BIOS_ATTR_KIND_ENUMERATION)
 		return;
+	if (fwupd_bios_attr_get_read_only(bios_attr))
+		return;
 	values = fwupd_bios_attr_get_possible_values(bios_attr);
 	for (guint i = 0; i < values->len; i++) {
 		const gchar *possible = g_ptr_array_index(values, i);


### PR DESCRIPTION
If an attribute is read only, then we'll have a failure trying to
set it.  So don't offer a target value so clients won't try to set
an attribute.x

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
