### PR TITLE
trivial: ci: debian: Use helper script to install dependencies instead.

### DIFF
--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -4,5 +4,6 @@ ENV CI_NETWORK true
 RUN echo fubar > /etc/machine-id
 %%%ARCH_SPECIFIC_COMMAND%%%
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
+RUN apt install -yq --no-install-recommends python3-apt
 WORKDIR /github/workspace
 CMD ["./contrib/ci/debian.sh"]

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -71,7 +71,7 @@ with open("Dockerfile", "w") as wfd:
                 if i < len(deps) - 1:
                     wfd.write("\t%s \\\n" % deps[i])
                 else:
-                    wfd.write("\t%s \n" % deps[i])
+                    wfd.write("\t%s || true\n" % deps[i])
         elif line == "%%%ARCH_SPECIFIC_COMMAND%%%\n":
             if OS == "debian" and SUBOS == "s390x":
                 # add sources

--- a/contrib/debian/fwupd-doc.install
+++ b/contrib/debian/fwupd-doc.install
@@ -1,1 +1,0 @@
-usr/share/*doc

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -63,6 +63,10 @@ override_dh_install:
 	#install MSR conf if needed (depending on distro)
 	[ ! -d debian/tmp/usr/lib/modules-load.d ] || dh_install -pfwupd usr/lib/modules-load.d
 	[ ! -d debian/tmp/lib/modules-load.d ] || dh_install -pfwupd lib/modules-load.d
+
+	#install docs (maybe)
+	[ -d debian/usr/share/doc ] || dh_install -pfwupd-doc usr/share/doc
+
 	dh_missing -a --fail-missing
 
 	#this is placed in fwupd-tests


### PR DESCRIPTION
Should fix building Debian stable containers
Fixes: #4901

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
