### PR TITLE
trivial: map common positive or negative keys to possible enumeration…

### DIFF
--- a/libfwupd/fwupd-bios-attr.h
+++ b/libfwupd/fwupd-bios-attr.h
@@ -91,6 +91,8 @@ const gchar *
 fwupd_bios_attr_get_path(FwupdBiosAttr *self);
 const gchar *
 fwupd_bios_attr_get_description(FwupdBiosAttr *self);
+const gchar *
+fwupd_bios_attr_map_possible_value(FwupdBiosAttr *self, const gchar *key, GError **error);
 gboolean
 fwupd_bios_attr_has_possible_value(FwupdBiosAttr *self, const gchar *val);
 void

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -820,6 +820,7 @@ LIBFWUPD_1.8.4 {
     fwupd_bios_attr_get_type;
     fwupd_bios_attr_get_upper_bound;
     fwupd_bios_attr_has_possible_value;
+    fwupd_bios_attr_map_possible_value;
     fwupd_bios_attr_new;
     fwupd_bios_attr_set_current_value;
     fwupd_bios_attr_set_description;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4512,7 +4512,11 @@ fu_engine_modify_bios_attrs_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_engine_modify_bios_attr(engine, "Absolute", "Disable", &error);
+	ret = fu_engine_modify_bios_attr(engine, "Absolute", "off", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_engine_modify_bios_attr(engine, "Absolute", "FOO", &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3236,13 +3236,15 @@ fu_util_set_bios_attr(FuUtilPrivate *priv, gchar **values, GError **error)
 				  error))
 		return FALSE;
 
-	if (!fu_engine_modify_bios_attr(priv->engine, values[0], values[1], error))
+	if (!fu_engine_modify_bios_attr(priv->engine, values[0], values[1], error)) {
+		g_prefix_error(error, "failed to set '%s' using '%s': ", values[0], values[1]);
 		return FALSE;
+	}
 
 	if (!priv->as_json) {
-		g_autofree gchar *msg =
-		    g_strdup_printf(_("Set BIOS attribute '%s' to '%s'."), values[0], values[1]);
 		/* TRANSLATORS: Configured a BIOS setting to a value */
+		g_autofree gchar *msg =
+		    g_strdup_printf(_("Set BIOS attribute '%s' using '%s'."), values[0], values[1]);
 		g_print("\n%s\n", msg);
 	}
 	priv->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_REBOOT;

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3809,13 +3809,15 @@ fu_util_set_bios_attr(FuUtilPrivate *priv, gchar **values, GError **error)
 					   values[0],
 					   values[1],
 					   priv->cancellable,
-					   error))
+					   error)) {
+		g_prefix_error(error, "failed to set '%s' using '%s': ", values[0], values[1]);
 		return FALSE;
+	}
 
 	if (!priv->as_json) {
-		g_autofree gchar *msg =
-		    g_strdup_printf(_("Set BIOS attribute '%s' to '%s'."), values[0], values[1]);
 		/* TRANSLATORS: Configured a BIOS setting to a value */
+		g_autofree gchar *msg =
+		    g_strdup_printf(_("Set BIOS attribute '%s' using '%s'."), values[0], values[1]);
 		g_print("\n%s\n", msg);
 	}
 	priv->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_REBOOT;


### PR DESCRIPTION
… values

Dell and Lenovo use Enable or Enabled and Disable or Disabled which is confusing
to an end user.

Set up some heuristics to map positive values and negative values when passed
into the client.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
