### PR TITLE
trivial: fix a docs directory check inversion

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -65,7 +65,7 @@ override_dh_install:
 	[ ! -d debian/tmp/lib/modules-load.d ] || dh_install -pfwupd lib/modules-load.d
 
 	#install docs (maybe)
-	[ -d debian/usr/share/doc ] || dh_install -pfwupd-doc usr/share/doc
+	[ ! -d debian/tmp/usr/share/doc ] || dh_install -pfwupd-doc usr/share/doc
 
 	dh_missing -a --fail-missing
 


### PR DESCRIPTION
Fixes: a19b6f23e ("trivial: ci: debian: Use helper script to install dependencies instead. (#4906)")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
