### PR TITLE
Allow running get-bios-settings without root or PK

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -63,6 +63,27 @@ _fwupdmgr_opts=(
 	'--json'
 )
 
+bios_get_opts=(
+	'--no-authenticate'
+	'--json'
+	'--verbose'
+)
+
+bios_set_opts=(
+	'--no-reboot-check'
+	'--verbose'
+)
+
+_show_bios_get_modifiers()
+{
+	COMPREPLY+=( $(compgen -W '${bios_get_opts[@]}' -- "$cur") )
+}
+
+_show_bios_set_modifiers()
+{
+	COMPREPLY+=( $(compgen -W '${bios_set_opts[@]}' -- "$cur") )
+}
+
 _show_filters()
 {
 	local flags
@@ -73,6 +94,26 @@ _show_filters()
 _show_modifiers()
 {
 	COMPREPLY+=( $(compgen -W '${_fwupdmgr_opts[@]}' -- "$cur") )
+}
+
+_show_bios_attrs()
+{
+	if ! command -v jq &> /dev/null; then
+		return 0
+	fi
+	local attr
+	attr="$(command fwupdmgr get-bios-setting --json --no-authenticate 2>/dev/null | jq '.BiosAttributes | .[] | .Name')"
+	COMPREPLY+=( $(compgen -W "${attr}" -- "$cur") )
+}
+
+_show_bios_attrs_possible()
+{
+	if ! command -v jq &> /dev/null; then
+		return 0
+	fi
+	local attr
+	attr="$(command fwupdmgr get-bios-setting "$1" --json --no-authenticate 2>/dev/null | jq '.BiosAttributes | .[] | .BiosAttrPossibleValues | .[]')"
+	COMPREPLY+=( $(compgen -W "${attr}" -- "$cur") )
 }
 
 _show_device_ids()
@@ -123,6 +164,25 @@ _fwupdmgr()
 		if [[ "$args" = "2" ]]; then
 			_show_device_ids
 		fi
+		;;
+	get-bios-settings|get-bios-setting)
+		#bios attrs (no limit)
+		_show_bios_attrs
+		_show_bios_get_modifiers
+		return 0
+		;;
+	set-bios-setting)
+		#allow setting a single bios attr at a time
+		if [[ "$args" = "2" ]]; then
+			_show_bios_attrs
+		fi
+		#possible values (only works for enumeration though)
+		if [[ "$args" = "3" ]]; then
+			_show_bios_attrs_possible "$prev"
+			return 0
+		fi
+		_show_bios_set_modifiers
+		return 0
 		;;
 	get-details)
 		#find files

--- a/libfwupd/fwupd-bios-attr-private.h
+++ b/libfwupd/fwupd-bios-attr-private.h
@@ -11,7 +11,7 @@
 #pragma once
 
 GVariant *
-fwupd_bios_attr_to_variant(FwupdBiosAttr *self);
+fwupd_bios_attr_to_variant(FwupdBiosAttr *self, gboolean trusted);
 void
 fwupd_bios_attr_to_json(FwupdBiosAttr *self, JsonBuilder *builder);
 gboolean

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -618,6 +618,8 @@ fwupd_feature_flag_to_string(FwupdFeatureFlags feature_flag)
 		return "community-text";
 	if (feature_flag == FWUPD_FEATURE_FLAG_SHOW_PROBLEMS)
 		return "show-problems";
+	if (feature_flag == FWUPD_FEATURE_FLAG_ALLOW_AUTHENTICATION)
+		return "allow-authentication";
 	return NULL;
 }
 
@@ -652,6 +654,8 @@ fwupd_feature_flag_from_string(const gchar *feature_flag)
 		return FWUPD_FEATURE_FLAG_COMMUNITY_TEXT;
 	if (g_strcmp0(feature_flag, "show-problems") == 0)
 		return FWUPD_FEATURE_FLAG_SHOW_PROBLEMS;
+	if (g_strcmp0(feature_flag, "allow-authentication") == 0)
+		return FWUPD_FEATURE_FLAG_ALLOW_AUTHENTICATION;
 	return FWUPD_FEATURE_FLAG_LAST;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -75,19 +75,21 @@ typedef enum {
  * @FWUPD_FEATURE_FLAG_FDE_WARNING:		Can warn about full disk encryption
  * @FWUPD_FEATURE_FLAG_COMMUNITY_TEXT:		Can show information about community supported
  * @FWUPD_FEATURE_FLAG_SHOW_PROBLEMS:		Can show problems when getting the update list
+ * @FWUPD_FEATURE_FLAG_ALLOW_AUTHENTICATION:	Can authenticate with PolicyKit for requests
  *
  * The flags to the feature capabilities of the front-end client.
  **/
 typedef enum {
-	FWUPD_FEATURE_FLAG_NONE = 0,		    /* Since: 1.4.5 */
-	FWUPD_FEATURE_FLAG_CAN_REPORT = 1 << 0,	    /* Since: 1.4.5 */
-	FWUPD_FEATURE_FLAG_DETACH_ACTION = 1 << 1,  /* Since: 1.4.5 */
-	FWUPD_FEATURE_FLAG_UPDATE_ACTION = 1 << 2,  /* Since: 1.4.5 */
-	FWUPD_FEATURE_FLAG_SWITCH_BRANCH = 1 << 3,  /* Since: 1.5.0 */
-	FWUPD_FEATURE_FLAG_REQUESTS = 1 << 4,	    /* Since: 1.6.2 */
-	FWUPD_FEATURE_FLAG_FDE_WARNING = 1 << 5,    /* Since: 1.7.1 */
-	FWUPD_FEATURE_FLAG_COMMUNITY_TEXT = 1 << 6, /* Since: 1.7.5 */
-	FWUPD_FEATURE_FLAG_SHOW_PROBLEMS = 1 << 7,  /* Since: 1.8.1 */
+	FWUPD_FEATURE_FLAG_NONE = 0,			  /* Since: 1.4.5 */
+	FWUPD_FEATURE_FLAG_CAN_REPORT = 1 << 0,		  /* Since: 1.4.5 */
+	FWUPD_FEATURE_FLAG_DETACH_ACTION = 1 << 1,	  /* Since: 1.4.5 */
+	FWUPD_FEATURE_FLAG_UPDATE_ACTION = 1 << 2,	  /* Since: 1.4.5 */
+	FWUPD_FEATURE_FLAG_SWITCH_BRANCH = 1 << 3,	  /* Since: 1.5.0 */
+	FWUPD_FEATURE_FLAG_REQUESTS = 1 << 4,		  /* Since: 1.6.2 */
+	FWUPD_FEATURE_FLAG_FDE_WARNING = 1 << 5,	  /* Since: 1.7.1 */
+	FWUPD_FEATURE_FLAG_COMMUNITY_TEXT = 1 << 6,	  /* Since: 1.7.5 */
+	FWUPD_FEATURE_FLAG_SHOW_PROBLEMS = 1 << 7,	  /* Since: 1.8.1 */
+	FWUPD_FEATURE_FLAG_ALLOW_AUTHENTICATION = 1 << 8, /* Since: 1.8.4 */
 	/*< private >*/
 	FWUPD_FEATURE_FLAG_LAST
 } FwupdFeatureFlags;

--- a/libfwupdplugin/fu-bios-attrs-private.h
+++ b/libfwupdplugin/fu-bios-attrs-private.h
@@ -17,6 +17,6 @@ GPtrArray *
 fu_bios_attrs_get_all(FuBiosAttrs *self);
 
 GVariant *
-fu_bios_attrs_to_variant(FuBiosAttrs *self);
+fu_bios_attrs_to_variant(FuBiosAttrs *self, gboolean trusted);
 gboolean
 fu_bios_attrs_from_json(FuBiosAttrs *self, JsonNode *json_node, GError **error);

--- a/libfwupdplugin/fu-bios-attrs.c
+++ b/libfwupdplugin/fu-bios-attrs.c
@@ -526,6 +526,7 @@ fu_bios_attrs_get_pending_reboot(FuBiosAttrs *self, gboolean *result, GError **e
 /**
  * fu_bios_attrs_to_variant:
  * @self: a #FuBiosAttrs
+ * @trusted: whether the caller should receive trusted values
  *
  * Serializes the #FwupdBiosAttr objects.
  *
@@ -534,7 +535,7 @@ fu_bios_attrs_get_pending_reboot(FuBiosAttrs *self, gboolean *result, GError **e
  * Since: 1.8.4
  **/
 GVariant *
-fu_bios_attrs_to_variant(FuBiosAttrs *self)
+fu_bios_attrs_to_variant(FuBiosAttrs *self, gboolean trusted)
 {
 	GVariantBuilder builder;
 
@@ -543,8 +544,8 @@ fu_bios_attrs_to_variant(FuBiosAttrs *self)
 	g_variant_builder_init(&builder, G_VARIANT_TYPE("aa{sv}"));
 	for (guint i = 0; i < self->attrs->len; i++) {
 		FwupdBiosAttr *bios_attr = g_ptr_array_index(self->attrs, i);
-		GVariant *tmp = fwupd_bios_attr_to_variant(bios_attr);
-		g_variant_builder_add_value(&builder, tmp);
+		g_variant_builder_add_value(&builder,
+					    fwupd_bios_attr_to_variant(bios_attr, trusted));
 	}
 	return g_variant_new("(aa{sv})", &builder);
 }

--- a/src/fu-util-bios-attr.c
+++ b/src/fu-util-bios-attr.c
@@ -107,6 +107,7 @@ fu_util_bios_attr_to_string(FwupdBiosAttr *attr, guint idt)
 {
 	const gchar *tmp;
 	FwupdBiosAttrKind type;
+	g_autofree gchar *current_value = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
 
@@ -128,9 +129,13 @@ fu_util_bios_attr_to_string(FwupdBiosAttr *attr, guint idt)
 
 	tmp = fwupd_bios_attr_get_current_value(attr);
 	if (tmp != NULL) {
-		/* TRANSLATORS: current value of a BIOS setting */
-		fu_string_append(str, idt + 1, _("Current Value"), tmp);
+		current_value = g_strdup(tmp);
+	} else {
+		/* TRANSLATORS: tell a user how to get information */
+		current_value = g_strdup_printf(_("Run without '%s' to see"), "--no-authenticate");
 	}
+	/* TRANSLATORS: current value of a BIOS setting */
+	fu_string_append(str, idt + 1, _("Current Value"), current_value);
 
 	fu_util_bios_attr_update_description(attr);
 	tmp = fwupd_bios_attr_get_description(attr);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3908,6 +3908,7 @@ main(int argc, char *argv[])
 	gboolean enable_ipfs = FALSE;
 	gboolean is_interactive = FALSE;
 	gboolean no_history = FALSE;
+	gboolean no_authenticate = FALSE;
 	gboolean offline = FALSE;
 	gboolean ret;
 	gboolean verbose = FALSE;
@@ -3919,184 +3920,193 @@ main(int argc, char *argv[])
 	g_autoptr(GPtrArray) cmd_array = fu_util_cmd_array_new();
 	g_autofree gchar *cmd_descriptions = NULL;
 	g_autofree gchar *filter = NULL;
-	const GOptionEntry options[] = {{"verbose",
-					 'v',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &verbose,
-					 /* TRANSLATORS: command line option */
-					 N_("Show extra debugging information"),
-					 NULL},
-					{"version",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &version,
-					 /* TRANSLATORS: command line option */
-					 N_("Show client and daemon versions"),
-					 NULL},
-					{"offline",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &offline,
-					 /* TRANSLATORS: command line option */
-					 N_("Schedule installation for next reboot when possible"),
-					 NULL},
-					{"allow-reinstall",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &allow_reinstall,
-					 /* TRANSLATORS: command line option */
-					 N_("Allow reinstalling existing firmware versions"),
-					 NULL},
-					{"allow-older",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &allow_older,
-					 /* TRANSLATORS: command line option */
-					 N_("Allow downgrading firmware versions"),
-					 NULL},
-					{"allow-branch-switch",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &allow_branch_switch,
-					 /* TRANSLATORS: command line option */
-					 N_("Allow switching firmware branch"),
-					 NULL},
-					{"force",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &force,
-					 /* TRANSLATORS: command line option */
-					 N_("Force the action by relaxing some runtime checks"),
-					 NULL},
-					{"assume-yes",
-					 'y',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->assume_yes,
-					 /* TRANSLATORS: command line option */
-					 N_("Answer yes to all questions"),
-					 NULL},
-					{"sign",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->sign,
-					 /* TRANSLATORS: command line option */
-					 N_("Sign the uploaded data with the client certificate"),
-					 NULL},
-					{"no-unreported-check",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_unreported_check,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not check for unreported history"),
-					 NULL},
-					{"no-metadata-check",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_metadata_check,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not check for old metadata"),
-					 NULL},
-					{"no-remote-check",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_remote_check,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not check if download remotes should be enabled"),
-					 NULL},
-					{"no-reboot-check",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_reboot_check,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not check or prompt for reboot after update"),
-					 NULL},
-					{"no-safety-check",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_safety_check,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not perform device safety checks"),
-					 NULL},
-					{"no-device-prompt",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->no_device_prompt,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not prompt for devices"),
-					 NULL},
-					{"no-history",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &no_history,
-					 /* TRANSLATORS: command line option */
-					 N_("Do not write to the history database"),
-					 NULL},
-					{"show-all",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->show_all,
-					 /* TRANSLATORS: command line option */
-					 N_("Show all results"),
-					 NULL},
-					{"show-all-devices",
-					 '\0',
-					 G_OPTION_FLAG_HIDDEN,
-					 G_OPTION_ARG_NONE,
-					 &priv->show_all,
-					 /* TRANSLATORS: command line option */
-					 N_("Show devices that are not updatable"),
-					 NULL},
-					{"disable-ssl-strict",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->disable_ssl_strict,
-					 /* TRANSLATORS: command line option */
-					 N_("Ignore SSL strict checks when downloading files"),
-					 NULL},
-					{"ipfs",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &enable_ipfs,
-					 /* TRANSLATORS: command line option */
-					 N_("Only use IPFS when downloading files"),
-					 NULL},
-					{"filter",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_STRING,
-					 &filter,
-					 /* TRANSLATORS: command line option */
-					 N_("Filter with a set of device flags using a ~ prefix to "
-					    "exclude, e.g. 'internal,~needs-reboot'"),
-					 NULL},
-					{"json",
-					 '\0',
-					 0,
-					 G_OPTION_ARG_NONE,
-					 &priv->as_json,
-					 /* TRANSLATORS: command line option */
-					 N_("Output in JSON format"),
-					 NULL},
-					{NULL}};
+	const GOptionEntry options[] = {
+	    {"verbose",
+	     'v',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &verbose,
+	     /* TRANSLATORS: command line option */
+	     N_("Show extra debugging information"),
+	     NULL},
+	    {"version",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &version,
+	     /* TRANSLATORS: command line option */
+	     N_("Show client and daemon versions"),
+	     NULL},
+	    {"offline",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &offline,
+	     /* TRANSLATORS: command line option */
+	     N_("Schedule installation for next reboot when possible"),
+	     NULL},
+	    {"allow-reinstall",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &allow_reinstall,
+	     /* TRANSLATORS: command line option */
+	     N_("Allow reinstalling existing firmware versions"),
+	     NULL},
+	    {"allow-older",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &allow_older,
+	     /* TRANSLATORS: command line option */
+	     N_("Allow downgrading firmware versions"),
+	     NULL},
+	    {"allow-branch-switch",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &allow_branch_switch,
+	     /* TRANSLATORS: command line option */
+	     N_("Allow switching firmware branch"),
+	     NULL},
+	    {"force",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &force,
+	     /* TRANSLATORS: command line option */
+	     N_("Force the action by relaxing some runtime checks"),
+	     NULL},
+	    {"assume-yes",
+	     'y',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->assume_yes,
+	     /* TRANSLATORS: command line option */
+	     N_("Answer yes to all questions"),
+	     NULL},
+	    {"sign",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->sign,
+	     /* TRANSLATORS: command line option */
+	     N_("Sign the uploaded data with the client certificate"),
+	     NULL},
+	    {"no-unreported-check",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_unreported_check,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not check for unreported history"),
+	     NULL},
+	    {"no-metadata-check",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_metadata_check,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not check for old metadata"),
+	     NULL},
+	    {"no-remote-check",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_remote_check,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not check if download remotes should be enabled"),
+	     NULL},
+	    {"no-reboot-check",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_reboot_check,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not check or prompt for reboot after update"),
+	     NULL},
+	    {"no-safety-check",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_safety_check,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not perform device safety checks"),
+	     NULL},
+	    {"no-device-prompt",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->no_device_prompt,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not prompt for devices"),
+	     NULL},
+	    {"no-history",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &no_history,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not write to the history database"),
+	     NULL},
+	    {"show-all",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->show_all,
+	     /* TRANSLATORS: command line option */
+	     N_("Show all results"),
+	     NULL},
+	    {"show-all-devices",
+	     '\0',
+	     G_OPTION_FLAG_HIDDEN,
+	     G_OPTION_ARG_NONE,
+	     &priv->show_all,
+	     /* TRANSLATORS: command line option */
+	     N_("Show devices that are not updatable"),
+	     NULL},
+	    {"disable-ssl-strict",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->disable_ssl_strict,
+	     /* TRANSLATORS: command line option */
+	     N_("Ignore SSL strict checks when downloading files"),
+	     NULL},
+	    {"ipfs",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &enable_ipfs,
+	     /* TRANSLATORS: command line option */
+	     N_("Only use IPFS when downloading files"),
+	     NULL},
+	    {"filter",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_STRING,
+	     &filter,
+	     /* TRANSLATORS: command line option */
+	     N_("Filter with a set of device flags using a ~ prefix to "
+		"exclude, e.g. 'internal,~needs-reboot'"),
+	     NULL},
+	    {"json",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &priv->as_json,
+	     /* TRANSLATORS: command line option */
+	     N_("Output in JSON format"),
+	     NULL},
+	    {"no-authenticate",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &no_authenticate,
+	     /* TRANSLATORS: command line option */
+	     N_("Don't prompt for authentication (less details may be shown)"),
+	     NULL},
+	    {NULL}};
 
 #ifdef _WIN32
 	/* workaround Windows setting the codepage to 1252 */
@@ -4360,7 +4370,7 @@ main(int argc, char *argv[])
 	    cmd_array,
 	    "get-bios-settings,get-bios-setting",
 	    /* TRANSLATORS: command argument: uppercase, spaces->dashes */
-	    _("[SETTING1] [SETTING2]"),
+	    _("[SETTING1] [SETTING2] [--no-authenticate]"),
 	    /* TRANSLATORS: command description */
 	    _("Retrieve BIOS settings.  If no arguments are passed all settings are returned"),
 	    fu_util_get_bios_attr);
@@ -4570,14 +4580,17 @@ main(int argc, char *argv[])
 
 	/* send our implemented feature set */
 	if (is_interactive) {
-		if (!fwupd_client_set_feature_flags(
-			priv->client,
-			FWUPD_FEATURE_FLAG_CAN_REPORT | FWUPD_FEATURE_FLAG_SWITCH_BRANCH |
-			    FWUPD_FEATURE_FLAG_REQUESTS | FWUPD_FEATURE_FLAG_UPDATE_ACTION |
-			    FWUPD_FEATURE_FLAG_FDE_WARNING | FWUPD_FEATURE_FLAG_DETACH_ACTION |
-			    FWUPD_FEATURE_FLAG_COMMUNITY_TEXT | FWUPD_FEATURE_FLAG_SHOW_PROBLEMS,
-			priv->cancellable,
-			&error)) {
+		FwupdFeatureFlags flags =
+		    FWUPD_FEATURE_FLAG_CAN_REPORT | FWUPD_FEATURE_FLAG_SWITCH_BRANCH |
+		    FWUPD_FEATURE_FLAG_REQUESTS | FWUPD_FEATURE_FLAG_UPDATE_ACTION |
+		    FWUPD_FEATURE_FLAG_FDE_WARNING | FWUPD_FEATURE_FLAG_DETACH_ACTION |
+		    FWUPD_FEATURE_FLAG_COMMUNITY_TEXT | FWUPD_FEATURE_FLAG_SHOW_PROBLEMS;
+		if (!no_authenticate)
+			flags |= FWUPD_FEATURE_FLAG_ALLOW_AUTHENTICATION;
+		if (!fwupd_client_set_feature_flags(priv->client,
+						    flags,
+						    priv->cancellable,
+						    &error)) {
 			g_printerr("Failed to set front-end features: %s\n", error->message);
 			return EXIT_FAILURE;
 		}


### PR DESCRIPTION
The only information that is secret is the `current_value`.
Augment the d-bus call to determine whether the caller needs this
information.

* If `fwupdmgr` is launched as root it will be provided.
* If `fwupdmgr` is launched with `--authenticate` it will be requested
  and PK will be engaged.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
