### PR TITLE
Add instance IDs that include the kernel driver

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -517,6 +517,12 @@ fu_udev_device_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_str(device, "DRIVER", priv->driver);
 	fu_device_build_instance_id_quirk(device, NULL, subsystem, "DRIVER", NULL);
 
+	/* add the modalias */
+	fu_device_add_instance_strsafe(device,
+				       "MODALIAS",
+				       g_udev_device_get_property(priv->udev_device, "MODALIAS"));
+	fu_device_build_instance_id_quirk(device, NULL, subsystem, "MODALIAS", NULL);
+
 	/* add subsystem to match in plugins */
 	if (subsystem != NULL) {
 		fu_device_add_instance_id_full(device,

--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -26,6 +26,16 @@ Flags = elantp-recovery
 [513cde3d-d939-59bd-a634-5c1645ebb93b]
 Flags = elantp-recovery
 
+[I2C\MODALIAS_acpi:ELAN0000:]
+Plugin = elantp
+GType = FuElantpI2cDevice
+ElantpI2cTargetAddress = 0x15
+
+[I2C\MODALIAS_of:NtrackpadT(null)Celan,ekth3000]
+Plugin = elantp
+GType = FuElantpI2cDevice
+ElantpI2cTargetAddress = 0x15
+
 # recovery device
 [I2C\NAME_Synopsys-DesignWare-I2C-adapter]
 Plugin = elantp


### PR DESCRIPTION
Some interesting i2c devices have a generic name, e.g. 'Synopsys'.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
