### PR TITLE
plugins/{superio,flashrom}: Add LabTop Mk III HwId

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -23,8 +23,12 @@ Plugin = flashrom
 [0fc25c8c-ffa8-54ad-a216-d13cfe75bee4]
 Plugin = flashrom
 
-# StarLabTop Mk III (HwId)
+# StarLabTop Mk III (HwId - AMI)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
+Plugin = flashrom
+
+# StarLabTop Mk III (HwId - coreboot)
+[8f8ca82b-30e1-5907-bc9d-4257a49898d4]
 Plugin = flashrom
 
 # StarLabTop Mk IV (HwId)

--- a/plugins/superio/superio.quirk
+++ b/plugins/superio/superio.quirk
@@ -12,10 +12,19 @@ SuperioGType = FuSuperioIt85Device
 SuperioId = 0x8587
 SuperioPort = 0x2e
 
-# Star LabTop Mk III (HwId)
+# Star LabTop Mk III (HwId - AMI)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
 SuperioGType = FuSuperioIt89Device
 [SUPERIO\GUID_013b60e5-1023-5bee-8ae5-14cae21377b7]
+SuperioId = 0x8987
+SuperioPort = 0x4e
+InstallDuration = 20
+Flags = unsigned-payload
+
+# Star LabTop MK III (HwId - coreboot)
+[8f8ca82b-30e1-5907-bc9d-4257a49898d4]
+SuperioGType = FuSuperioIt89Device
+[SUPERIO\GUID_8f8ca82b-30e1-5907-bc9d-4257a49898d4]
 SuperioId = 0x8987
 SuperioPort = 0x4e
 InstallDuration = 20


### PR DESCRIPTION
Add the HwId for the Star LabTop Mk III when using coreboot firmware,
as this differs to AMI.

Signed-off-by: Sean Rhodes <sean@starlabs.systems>
