### PR TITLE
trivial: Make BIOS setting parsing errors less verbose by default

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -41,6 +41,7 @@ with a non-standard filesystem layout.
 * `FU_USB_DEVICE_DEBUG` shows more information about USB devices
 * `FWUPD_DEVICE_LIST_VERBOSE` display devices being added and removed from the list
 * `FWUPD_PROBE_VERBOSE` dump the detected devices to the console, even if not supported by fwupd
+* `FWUPD_BIOS_SETTING_VERBOSE` be verbose while parsing BIOS settings
 
 ## Plugins
 

--- a/libfwupdplugin/fu-bios-attrs.c
+++ b/libfwupdplugin/fu-bios-attrs.c
@@ -388,6 +388,7 @@ fu_bios_attrs_populate_attribute(FuBiosAttrs *self,
 gboolean
 fu_bios_attrs_setup(FuBiosAttrs *self, GError **error)
 {
+	guint count = 0;
 	g_autofree gchar *sysfsfwdir = NULL;
 	g_autoptr(GDir) class_dir = NULL;
 
@@ -438,8 +439,9 @@ fu_bios_attrs_setup(FuBiosAttrs *self, GError **error)
 				g_propagate_error(error, g_steal_pointer(&error_local));
 				return FALSE;
 			}
-		} while (TRUE);
+		} while (++count);
 	} while (TRUE);
+	g_debug("loaded %u BIOS settings", count);
 
 	return TRUE;
 }


### PR DESCRIPTION
The `--verbose` output for getting BIOS setting info is very noisy
on Lenovo systems due to a mismatch for the driver behavior and
kernel API.

Hide most of it behind an optional environment variable
`FWUPD_BIOS_SETTING_VERBOSE`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
