### PR TITLE
Add support to set BIOS settings using a JSON payload

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -71,8 +71,16 @@ bios_get_opts=(
 
 bios_set_opts=(
 	'--no-reboot-check'
+	'--json'
 	'--verbose'
 )
+
+_show_file_in_dir()
+{
+	local files
+	files="$(ls 2>/dev/null)"
+	COMPREPLY+=( $(compgen -W "${files}" -- "$cur") )
+}
 
 _show_bios_get_modifiers()
 {
@@ -172,12 +180,17 @@ _fwupdmgr()
 		return 0
 		;;
 	set-bios-setting)
+		if [[ "$prev" = "--json" ]]; then
+			_show_file_in_dir "$prev"
+			return 0
+		fi
+		count=$(($((args)) % 2))
 		#allow setting a single bios attr at a time
-		if [[ "$args" = "2" ]]; then
+		if [[ $count == 0 ]]; then
 			_show_bios_attrs
 		fi
 		#possible values (only works for enumeration though)
-		if [[ "$args" = "3" ]]; then
+		if [[ $count == 1 ]]; then
 			_show_bios_attrs_possible "$prev"
 			return 0
 		fi

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -899,8 +899,7 @@ fwupd_client_modify_bios_attr_cb(GObject *source, GAsyncResult *res, gpointer us
 /**
  * fwupd_client_modify_bios_attr
  * @self: a #FwupdClient
- * @key: the name of the BIOS attribute, e.g. `SleepMode`
- * @value: the value to set, e.g. 'S3'
+ * @settings: (transfer container): BIOS settings
  * @cancellable: (nullable): optional #GCancellable
  * @error: (nullable): optional return location for an error
  *
@@ -913,16 +912,14 @@ fwupd_client_modify_bios_attr_cb(GObject *source, GAsyncResult *res, gpointer us
  **/
 gboolean
 fwupd_client_modify_bios_attr(FwupdClient *self,
-			      const gchar *key,
-			      const gchar *value,
+			      GHashTable *settings,
 			      GCancellable *cancellable,
 			      GError **error)
 {
 	g_autoptr(FwupdClientHelper) helper = NULL;
 
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
-	g_return_val_if_fail(key != NULL, FALSE);
-	g_return_val_if_fail(value != NULL, FALSE);
+	g_return_val_if_fail(settings != NULL, FALSE);
 	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -933,8 +930,7 @@ fwupd_client_modify_bios_attr(FwupdClient *self,
 	/* call async version and run loop until complete */
 	helper = fwupd_client_helper_new(self);
 	fwupd_client_modify_bios_attr_async(self,
-					    key,
-					    value,
+					    settings,
 					    cancellable,
 					    fwupd_client_modify_bios_attr_cb,
 					    helper);

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -89,8 +89,7 @@ fwupd_client_get_results(FwupdClient *self,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fwupd_client_modify_bios_attr(FwupdClient *self,
-			      const gchar *key,
-			      const gchar *value,
+			      GHashTable *settings,
 			      GCancellable *cancellable,
 			      GError **error);
 GPtrArray *

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -221,8 +221,7 @@ fwupd_client_get_results_finish(FwupdClient *self,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fwupd_client_modify_bios_attr_async(FwupdClient *self,
-				    const gchar *key,
-				    const gchar *value,
+				    GHashTable *settings,
 				    GCancellable *cancellable,
 				    GAsyncReadyCallback callback,
 				    gpointer callback_data);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -244,4 +244,4 @@ fu_engine_schedule_update(FuEngine *self,
 GError *
 fu_engine_error_array_get_best(GPtrArray *errors);
 gboolean
-fu_engine_modify_bios_attr(FuEngine *self, const gchar *key, const gchar *value, GError **error);
+fu_engine_modify_bios_attrs(FuEngine *self, GHashTable *settings, GError **error);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "fwupd-bios-attr-private.h"
 #include "fwupd-security-attr-private.h"
 
 #include "fu-bios-attrs-private.h"
@@ -4487,6 +4488,8 @@ fu_engine_modify_bios_attrs_func(void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuBiosAttrs) attrs = NULL;
 	g_autoptr(GPtrArray) items = NULL;
+	g_autoptr(GHashTable) bios_settings =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
 	/* Load contrived attributes */
 	test_dir = g_test_build_filename(G_TEST_DIST, "tests", "bios-attrs", NULL);
@@ -4508,21 +4511,30 @@ fu_engine_modify_bios_attrs_func(void)
 	current = fwupd_bios_attr_get_current_value(attr1);
 	g_assert_nonnull(current);
 
-	ret = fu_engine_modify_bios_attr(engine, "Absolute", "Disabled", &error);
+	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("Disabled"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_engine_modify_bios_attr(engine, "Absolute", "off", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("off"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_engine_modify_bios_attr(engine, "Absolute", "FOO", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("FOO"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
 	/* use BiosAttrId instead */
-	ret = fu_engine_modify_bios_attr(engine, "com.fwupd-internal.Absolute", current, &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings,
+			    g_strdup("com.fwupd-internal.Absolute"),
+			    g_strdup(current));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -4533,15 +4545,18 @@ fu_engine_modify_bios_attrs_func(void)
 	current = fwupd_bios_attr_get_current_value(attr2);
 	g_assert_nonnull(current);
 
-	ret = fu_engine_modify_bios_attr(engine, "Asset", "1", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("Asset"), g_strdup("1"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_engine_modify_bios_attr(
-	    engine,
-	    "Absolute",
-	    "1234567891123456789112345678911234567891123456789112345678911111",
-	    &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(
+	    bios_settings,
+	    g_strdup("Absolute"),
+	    g_strdup("1234567891123456789112345678911234567891123456789112345678911111"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
@@ -4554,20 +4569,28 @@ fu_engine_modify_bios_attrs_func(void)
 	current = fwupd_bios_attr_get_current_value(attr3);
 	g_assert_nonnull(current);
 
-	ret = fu_engine_modify_bios_attr(engine, "CustomChargeStop", "70", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("70"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_true(ret);
 
-	ret = fu_engine_modify_bios_attr(engine, "CustomChargeStop", "110", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("110"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
-	ret = fu_engine_modify_bios_attr(engine, "CustomChargeStop", "1", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("1"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
-	ret = fu_engine_modify_bios_attr(engine, "CustomChargeStop", current, &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup(current));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_true(ret);
 	g_assert_no_error(error);
 
@@ -4579,9 +4602,12 @@ fu_engine_modify_bios_attrs_func(void)
 	current = fwupd_bios_attr_get_current_value(attr4);
 	g_assert_nonnull(current);
 
-	ret = fu_engine_modify_bios_attr(engine, "pending_reboot", "foo", &error);
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("pending_reboot"), g_strdup("foo"));
+	ret = fu_engine_modify_bios_attrs(engine, bios_settings, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_clear_error(&error);
 }
 
 int

--- a/src/fu-util-bios-attr.h
+++ b/src/fu-util-bios-attr.h
@@ -16,3 +16,5 @@ gboolean
 fu_util_bios_attr_matches_args(FwupdBiosAttr *attr, gchar **values);
 gboolean
 fu_util_get_bios_attr_as_json(gchar **values, GPtrArray *attrs, GError **error);
+GHashTable *
+fu_util_bios_attrs_parse_argv(gchar **input, GError **error);

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -866,7 +866,7 @@
     </method>
 
     <!--***********************************************************-->
-    <method name='SetBiosAttr'>
+    <method name='SetBiosAttrs'>
       <doc:doc>
         <doc:description>
           <doc:para>
@@ -874,21 +874,10 @@
           </doc:para>
         </doc:description>
       </doc:doc>
-      <arg type='s' name='key' direction='in'>
+      <arg type='a{ss}' name='settings' direction='in'>
         <doc:doc>
           <doc:summary>
-            <doc:para>
-              The BIOS attribute, e.g. 'CustomChargeStop'.
-            </doc:para>
-          </doc:summary>
-        </doc:doc>
-      </arg>
-      <arg type='s' name='value' direction='in'>
-        <doc:doc>
-          <doc:summary>
-            <doc:para>
-              The value to set the BIOS attribute to
-            </doc:para>
+            <doc:para>An array of BIOS attributes and their new values.</doc:para>
           </doc:summary>
         </doc:doc>
       </arg>


### PR DESCRIPTION
The JSON payload is ideally generated from `fwupdmgr get-bios-settings --json`
with all attributes expected to be included as additional arguments.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
