### PR TITLE
Convert HSI into a meson tristate-feature

### DIFF
--- a/contrib/build-openbmc.sh
+++ b/contrib/build-openbmc.sh
@@ -6,7 +6,7 @@ meson ../ \
     -Dcompat_cli=false \
     -Dfish_completion=false \
     -Dfirmware-packager=false \
-    -Dhsi=false \
+    -Dhsi=disabled \
     -Dman=false \
     -Dmetainfo=false \
     -Dtests=false \

--- a/contrib/build-windows.sh
+++ b/contrib/build-windows.sh
@@ -20,7 +20,6 @@ meson .. \
     --libexecdir="bin" \
     --bindir="bin" \
     -Dbuild=all \
-    -Dhsi=false \
     -Dman=false \
     -Dfish_completion=false \
     -Dbash_completion=false \

--- a/contrib/ci/build_macos.sh
+++ b/contrib/ci/build_macos.sh
@@ -5,7 +5,6 @@ set -x
 mkdir -p build-macos && cd build-macos
 meson .. \
     -Dbuild=standalone \
-    -Dhsi=false \
     -Dsoup_session_compat=false \
     -Dgusb:docs=false \
     -Dlibjcat:gpg=false \

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -41,7 +41,6 @@ meson .. \
     --libexecdir="bin" \
     --bindir="bin" \
     -Dbuild=all \
-    -Dhsi=false \
     -Dman=false \
     -Dfish_completion=false \
     -Dbash_completion=false \

--- a/meson.build
+++ b/meson.build
@@ -215,7 +215,9 @@ bluez = get_option('bluez').disable_auto_if(host_machine.system() != 'linux')
 if bluez.allowed()
   conf.set('HAVE_BLUEZ', '1')
 endif
-if get_option('hsi')
+host_cpu = host_machine.cpu_family()
+hsi = get_option('hsi').disable_auto_if(host_machine.system() != 'linux').disable_auto_if(host_cpu != 'x86' and host_cpu != 'x86_64').allowed()
+if hsi
   conf.set('HAVE_HSI', '1')
 endif
 libxmlb = dependency('xmlb', version: '>= 0.1.13', fallback: ['libxmlb', 'libxmlb_dep'])
@@ -313,8 +315,6 @@ offline = get_option('offline').require(libsystemd.found(),
 if offline.allowed()
   conf.set('HAVE_FWUPDOFFLINE', '1')
 endif
-
-host_cpu = host_machine.cpu_family()
 
 if cc.has_header('sys/utsname.h')
   conf.set('HAVE_UTSNAME_H', '1')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,4 +67,4 @@ option('bash_completion', type: 'boolean', value : true, description : 'enable b
 option('fish_completion', type: 'boolean', value : true, description : 'enable fish completion')
 option('offline', type: 'feature', description : 'Allow installing firmware using a pre-boot systemd target', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('compat_cli', type: 'boolean', value : true, description : 'enable legacy commands: fwupdagent,dfu-tool,fwupdate')
-option('hsi', type: 'boolean', value : true, description : 'enable plugins used just for HSI')
+option('hsi', type: 'feature', description : ' Host Security Information', deprecated: {'true': 'enabled', 'false': 'disabled'})

--- a/plugins/acpi-dmar/meson.build
+++ b/plugins/acpi-dmar/meson.build
@@ -1,6 +1,4 @@
-if get_option('hsi') and \
-   host_machine.system() == 'linux' and \
-   (host_cpu == 'x86' or host_cpu == 'x86_64')
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiDmar"']
 
 shared_module('fu_plugin_acpi_dmar',

--- a/plugins/acpi-facp/meson.build
+++ b/plugins/acpi-facp/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiFacp"']
 
 shared_module('fu_plugin_acpi_facp',

--- a/plugins/acpi-ivrs/meson.build
+++ b/plugins/acpi-ivrs/meson.build
@@ -1,6 +1,4 @@
-if get_option('hsi') and \
-   host_machine.system() == 'linux' and \
-   (host_cpu == 'x86' or host_cpu == 'x86_64')
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiIvrs"']
 
 shared_module('fu_plugin_acpi_ivrs',

--- a/plugins/cpu/meson.build
+++ b/plugins/cpu/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_cpu').disable_auto_if(host_machine.system() != 'linux').require(get_option('hsi'),
+if get_option('plugin_cpu').disable_auto_if(host_machine.system() != 'linux').require(hsi,
     error_message: 'plugin_cpu needs hsi to be set').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCpu"']
 

--- a/plugins/iommu/meson.build
+++ b/plugins/iommu/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginIommu"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'iommu.quirk')

--- a/plugins/linux-lockdown/meson.build
+++ b/plugins/linux-lockdown/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxLockdown"']
 
 shared_module('fu_plugin_linux_lockdown',

--- a/plugins/linux-sleep/meson.build
+++ b/plugins/linux-sleep/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSleep"']
 
 shared_module('fu_plugin_linux_sleep',

--- a/plugins/linux-swap/meson.build
+++ b/plugins/linux-swap/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxSwap"']
 
 shared_module('fu_plugin_linux_swap',

--- a/plugins/linux-tainted/meson.build
+++ b/plugins/linux-tainted/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi
 cargs = ['-DG_LOG_DOMAIN="FuPluginLinuxTainted"']
 
 shared_module('fu_plugin_linux_tainted',

--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and has_cpuid
+if hsi and has_cpuid
 cargs = ['-DG_LOG_DOMAIN="FuPluginMsr"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'msr.quirk')

--- a/plugins/pci-bcr/meson.build
+++ b/plugins/pci-bcr/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi
 cargs = ['-DG_LOG_DOMAIN="FuPluginPciBcr"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'pci-bcr.quirk')

--- a/plugins/pci-mei/meson.build
+++ b/plugins/pci-mei/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and host_machine.system() == 'linux'
+if hsi
 cargs = ['-DG_LOG_DOMAIN="FuPluginPciMei"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'pci-mei.quirk')

--- a/plugins/pci-psp/meson.build
+++ b/plugins/pci-psp/meson.build
@@ -1,6 +1,4 @@
-if get_option('hsi') and \
-  host_machine.system() == 'linux' and \
-  host_cpu == 'x86_64'
+if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginPciPsp"']
 
 plugin_quirks += join_paths(meson.current_source_dir(), 'pci-psp.quirk')

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -1,6 +1,6 @@
 tpm2tss_tpm = dependency('tss2-esys', version: '>= 2.0', required: get_option('plugin_tpm'))
 
-if get_option('hsi') and \
+if hsi and \
    tpm2tss_tpm.found() and \
    get_option('plugin_tpm').require(gudev.found(),
     error_message: 'gudev is needed for plugin_tpm').allowed()

--- a/plugins/uefi-pk/meson.build
+++ b/plugins/uefi-pk/meson.build
@@ -1,4 +1,4 @@
-if get_option('hsi') and \
+if hsi and \
    get_option('plugin_uefi_pk').require(gnutls.found(),
    error_message: 'gnutls is needed for plugin_uefi_pk').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefiPk"']


### PR DESCRIPTION
This allows us to disable it automatically on architectures that
aren't supported and OSes that aren't supported.

Link: https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/1987067

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
