### PR TITLE
HSI emulation profile for machine_kind and chassis_type

### DIFF
--- a/contrib/generate-emulation.py
+++ b/contrib/generate-emulation.py
@@ -8,6 +8,7 @@
 
 import json
 import sys
+import argparse
 
 from typing import Dict, List, Any
 
@@ -20,8 +21,46 @@ gi.require_version("Json", "1.0")
 from gi.repository import Fwupd  # pylint: disable=wrong-import-position
 from gi.repository import Json  # pylint: disable=wrong-import-position
 
+fu_chassis_kind = {
+    "FU_SMBIOS_CHASSIS_KIND_OTHER": 0x01,
+    "FU_SMBIOS_CHASSIS_KIND_UNKNOWN": 0x02,
+    "FU_SMBIOS_CHASSIS_KIND_DESKTOP": 0x03,
+    "FU_SMBIOS_CHASSIS_KIND_LOW_PROFILE_DESKTOP": 0x04,
+    "FU_SMBIOS_CHASSIS_KIND_PIZZA_BOX": 0x05,
+    "FU_SMBIOS_CHASSIS_KIND_MINI_TOWER": 0x06,
+    "FU_SMBIOS_CHASSIS_KIND_TOWER": 0x07,
+    "FU_SMBIOS_CHASSIS_KIND_PORTABLE": 0x08,
+    "FU_SMBIOS_CHASSIS_KIND_LAPTOP": 0x09,
+    "FU_SMBIOS_CHASSIS_KIND_NOTEBOOK": 0x0A,
+    "FU_SMBIOS_CHASSIS_KIND_HAND_HELD": 0x0B,
+    "FU_SMBIOS_CHASSIS_KIND_DOCKING_STATION": 0x0C,
+    "FU_SMBIOS_CHASSIS_KIND_ALL_IN_ONE": 0x0D,
+    "FU_SMBIOS_CHASSIS_KIND_SUB_NOTEBOOK": 0x0E,
+    "FU_SMBIOS_CHASSIS_KIND_SPACE_SAVING": 0x0F,
+    "FU_SMBIOS_CHASSIS_KIND_LUNCH_BOX": 0x10,
+    "FU_SMBIOS_CHASSIS_KIND_MAIN_SERVER": 0x11,
+    "FU_SMBIOS_CHASSIS_KIND_EXPANSION": 0x12,
+    "FU_SMBIOS_CHASSIS_KIND_SUBCHASSIS": 0x13,
+    "FU_SMBIOS_CHASSIS_KIND_BUS_EXPANSION": 0x14,
+    "FU_SMBIOS_CHASSIS_KIND_PERIPHERAL": 0x15,
+    "FU_SMBIOS_CHASSIS_KIND_RAID": 0x16,
+    "FU_SMBIOS_CHASSIS_KIND_RACK_MOUNT": 0x17,
+    "FU_SMBIOS_CHASSIS_KIND_SEALED_CASE_PC": 0x18,
+    "FU_SMBIOS_CHASSIS_KIND_MULTI_SYSTEM": 0x19,
+    "FU_SMBIOS_CHASSIS_KIND_COMPACT_PCI": 0x1A,
+    "FU_SMBIOS_CHASSIS_KIND_ADVANCED_TCA": 0x1B,
+    "FU_SMBIOS_CHASSIS_KIND_BLADE": 0x1C,
+    "FU_SMBIOS_CHASSIS_KIND_TABLET": 0x1E,
+    "FU_SMBIOS_CHASSIS_KIND_CONVERTIBLE": 0x1F,
+    "FU_SMBIOS_CHASSIS_KIND_DETACHABLE": 0x20,
+    "FU_SMBIOS_CHASSIS_KIND_IOT_GATEWAY": 0x21,
+    "FU_SMBIOS_CHASSIS_KIND_EMBEDDED_PC": 0x22,
+    "FU_SMBIOS_CHASSIS_KIND_MINI_PC": 0x23,
+    "FU_SMBIOS_CHASSIS_KIND_STICK_PC": 0x24,
+}
 
-def _minimize_json(json_str: str) -> str:
+
+def _minimize_json(json_str: str, machine_kind="physical", chassis_type=0x09) -> str:
     nodes = json.loads(json_str)
     new_attrs: List[Dict[str, Any]] = []
     new_devices: List[Dict[str, Any]] = []
@@ -55,6 +94,8 @@ def _minimize_json(json_str: str) -> str:
         pass
     return json.dumps(
         {
+            "MachineKind": machine_kind,
+            "ChassisType": chassis_type,
             "SecurityAttributes": new_attrs,
             "Devices": new_devices,
             "BiosAttributes": new_bios_attrs,
@@ -121,16 +162,45 @@ def _get_host_devices_and_attrs() -> str:
     return generator.to_data()[0]
 
 
-if len(sys.argv) < 2:
-    sys.stdout.write(_minimize_json(sys.stdin.read()))
-else:
-    for fn in sys.argv[1:]:
+def main():
+    if len(sys.argv) < 2:
+        sys.stdout.write(_minimize_json(sys.stdin.read()))
+    else:
+        parser = argparse.ArgumentParser(description="Generate HSI emulation json.")
+        parser.add_argument(
+            "json_file_list",
+            metavar="json_file_list",
+            type=str,
+            nargs="+",
+            help="An list of HSI emulation json file.",
+        )
+        parser.add_argument(
+            "--machine", default="physical", help="Machines kind (default: physical)"
+        )
+        parser.add_argument(
+            "--chassis",
+            default="laptop",
+            help="Chassis type (laptop and desktop. default: physical)",
+        )
+        args = parser.parse_args()
+        chassis_type = ""
+        if args.chassis == "laptop":
+            chassis_type = fu_chassis_kind["FU_SMBIOS_CHASSIS_KIND_LAPTOP"]
+        elif args.chassis == "desktop":
+            chassis_type = fu_chassis_kind["FU_SMBIOS_CHASSIS_KIND_DESKTOP"]
+        else:
+            chassis_type = fu_chassis_kind["FU_SMBIOS_CHASSIS_KIND_OTHER"]
 
-        try:
-            with open(fn, "rb") as f_in:
-                json_in = f_in.read().decode()
-        except FileNotFoundError:
-            json_in = _get_host_devices_and_attrs()
-        json_out = _minimize_json(json_in).encode()
-        with open(fn, "wb") as f_out:
-            f_out.write(json_out)
+        for fn in args.json_file_list:
+            try:
+                with open(fn, "rb") as f_in:
+                    json_in = f_in.read().decode()
+            except FileNotFoundError:
+                json_in = _get_host_devices_and_attrs()
+            json_out = _minimize_json(json_in, args.machine, chassis_type).encode()
+            with open(fn, "wb") as f_out:
+                f_out.write(json_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1478,6 +1478,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		return;
 	}
 	if (g_strcmp0(method_name, "GetHostSecurityAttrs") == 0) {
+		FuDaemonMachineKind kind;
 		g_autoptr(FuSecurityAttrs) attrs = NULL;
 		g_debug("Called %s()", method_name);
 #ifndef HAVE_HSI
@@ -1486,7 +1487,13 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 							      FWUPD_ERROR_NOT_SUPPORTED,
 							      "HSI support not enabled");
 #else
-		if (self->machine_kind != FU_DAEMON_MACHINE_KIND_PHYSICAL) {
+		kind = self->machine_kind;
+		if (g_getenv("FWUPD_HOST_EMULATE") != NULL) {
+			kind = fu_daemon_machine_kind_from_string(
+			    fu_engine_get_mockup_machine_kind(self->engine));
+		}
+
+		if (kind != FU_DAEMON_MACHINE_KIND_PHYSICAL) {
 			g_dbus_method_invocation_return_error_literal(
 			    invocation,
 			    FWUPD_ERROR,

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -245,3 +245,6 @@ GError *
 fu_engine_error_array_get_best(GPtrArray *errors);
 gboolean
 fu_engine_modify_bios_attr(FuEngine *self, const gchar *key, const gchar *value, GError **error);
+
+gchar *
+fu_engine_get_mockup_machine_kind(FuEngine *self);


### PR DESCRIPTION
When fwupd runs in VM with FWUPD_MACHINE_KIND and FWUPD_HOST_EMULATE set,
the HSI value will not be computed since the FU_SMBIOS_CHASSIS_KIND is
OTHER. Consequence, a "HSI-INVALID:chassis[0x01]" is returned through
dbus. If both machine_kind and chassis_type are not properly set, the HSI
result and security attribute can't be evaluated and presented.

Two JSON items- MachineKind and ChassisType were introduced to set the
mockup values. Therefore, fwupd can get these values from a single JSON
file to evaluate the HSI value.

Related to #4904 

Signed-off-by: Kate Hsuan <hpa@redhat.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
