### PR TITLE
ELANTP: Added support for absolute reporting (non-HID) devices

### DIFF
--- a/plugins/elantp/README.md
+++ b/plugins/elantp/README.md
@@ -3,7 +3,8 @@
 ## Introduction
 
 This plugin allows updating Touchpad devices from Elan. Devices are enumerated
-using HID and raw I²C nodes. The I²C mode is used for firmware recovery.
+using HID and raw I²C nodes. The I²C mode is used for ABS devices and firmware
+recovery of HID devices.
 
 ## Firmware Format
 
@@ -32,16 +33,24 @@ These devices also use custom GUID values for the IC configuration, e.g.
 
 * `ELANTP\ICTYPE_09&MOD_1234`
 
+ Additionally another instance ID is added which corresponds to the IC Type & module ID and Driver in order to distinguish HID/ABS devices:
+
+* `ELANTP\ICTYPE_09&MOD_1234&DRIVER_HID` -> HID Device
+* `ELANTP\ICTYPE_09&MOD_1234&DRIVER_ELAN_I2C` -> ABS Device
+
 ## Update Behavior
 
-The device usually presents in HID mode, and the firmware is written to the
+The device usually presents in HID/ABS mode, and the firmware is written to the
 device by switching to a IAP mode where the touchpad is nonfunctional.
 Once complete the device is reset to get out of IAP mode and to load the new
 firmware version.
 
-On flash failure the device is nonfunctional, but is recoverable by writing
-to the i2c device. This is typically much slower than updating the device
-using HID and also requires a model-specific HWID quirk to match.
+For HID devices, on flash failure the device is nonfunctional, but is recoverable
+by writing to the i2c device. This is typically much slower than updating the
+device using HID and also requires a model-specific HWID quirk to match.
+
+For ABS devices, on flash failure the device is nonfunctional, but it could be
+recovered by the same i2c device.
 
 ## Vendor ID Security
 

--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -26,15 +26,19 @@ Flags = elantp-recovery
 [513cde3d-d939-59bd-a634-5c1645ebb93b]
 Flags = elantp-recovery
 
+# absolute report device on ACPI
 [I2C\MODALIAS_acpi:ELAN0000:]
 Plugin = elantp
 GType = FuElantpI2cDevice
 ElantpI2cTargetAddress = 0x15
+Flags = elantp-absolute
 
+# absolute report device on Device Tree
 [I2C\MODALIAS_of:NtrackpadT(null)Celan,ekth3000]
 Plugin = elantp
 GType = FuElantpI2cDevice
 ElantpI2cTargetAddress = 0x15
+Flags = elantp-absolute
 
 # recovery device
 [I2C\NAME_Synopsys-DesignWare-I2C-adapter]

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -247,10 +247,12 @@ fu_elantp_hid_device_setup(FuDevice *device, GError **error)
 		ic_type = (tmp >> 8) & 0xFF;
 	}
 
-	/* define the extra instance IDs (ic_type + module_id) */
+	/* define the extra instance IDs (ic_type + module_id + driver) */
 	fu_device_add_instance_u8(device, "ICTYPE", ic_type);
 	fu_device_build_instance_id(device, NULL, "ELANTP", "ICTYPE", NULL);
 	fu_device_build_instance_id(device, NULL, "ELANTP", "ICTYPE", "MOD", NULL);
+	fu_device_add_instance_str(device, "DRIVER", "HID");
+	fu_device_build_instance_id(device, NULL, "ELANTP", "ICTYPE", "MOD", "DRIVER", NULL);
 
 	/* no quirk entry */
 	if (self->ic_page_count == 0x0) {

--- a/plugins/elantp/fu-elantp-i2c-device.h
+++ b/plugins/elantp/fu-elantp-i2c-device.h
@@ -8,5 +8,7 @@
 
 #include <fwupdplugin.h>
 
+#define FU_ELANTP_I2C_DEVICE_ABSOLUTE (1 << 0)
+
 #define FU_TYPE_ELANTP_I2C_DEVICE (fu_elantp_i2c_device_get_type())
 G_DECLARE_FINAL_TYPE(FuElantpI2cDevice, fu_elantp_i2c_device, FU, ELANTP_I2C_DEVICE, FuUdevDevice)

--- a/plugins/elantp/fu-plugin-elantp.c
+++ b/plugins/elantp/fu-plugin-elantp.c
@@ -16,7 +16,8 @@ static gboolean
 fu_plugin_elantp_device_created(FuPlugin *plugin, FuDevice *dev, GError **error)
 {
 	if (fu_device_get_specialized_gtype(dev) == FU_TYPE_ELANTP_I2C_DEVICE &&
-	    !fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "elantp-recovery")) {
+	    !fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "elantp-recovery") &&
+	    !fu_device_has_private_flag(dev, FU_ELANTP_I2C_DEVICE_ABSOLUTE)) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not required");
 		return FALSE;
 	}
@@ -34,6 +35,7 @@ fu_plugin_elantp_load(FuContext *ctx)
 static void
 fu_plugin_elantp_init(FuPlugin *plugin)
 {
+	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_udev_subsystem(plugin, "i2c-dev");
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);


### PR DESCRIPTION
These non-HID devices are bind with the elan_i2c driver, and quirks uses ACPI/DeviceTree information for matching, same as the driver method.
After the firmware update, it needs to switch back to absolute report mode and rebind the driver to update the information.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation