### PR TITLE
Only show *changed* events in the fwupdmgr security output

### DIFF
--- a/libfwupd/fwupd-security-attr-private.h
+++ b/libfwupd/fwupd-security-attr-private.h
@@ -342,9 +342,5 @@ gboolean
 fwupd_security_attr_from_json(FwupdSecurityAttr *self, JsonNode *json_node, GError **error);
 FwupdSecurityAttr *
 fwupd_security_attr_copy(FwupdSecurityAttr *self);
-FwupdSecurityAttrResult
-fwupd_security_attr_get_result_fallback(FwupdSecurityAttr *self);
-void
-fwupd_security_attr_set_result_fallback(FwupdSecurityAttr *self, FwupdSecurityAttrResult result);
 
 G_END_DECLS

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -151,6 +151,10 @@ FwupdSecurityAttrResult
 fwupd_security_attr_get_result(FwupdSecurityAttr *self);
 void
 fwupd_security_attr_set_result(FwupdSecurityAttr *self, FwupdSecurityAttrResult result);
+FwupdSecurityAttrResult
+fwupd_security_attr_get_result_fallback(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_set_result_fallback(FwupdSecurityAttr *self, FwupdSecurityAttrResult result);
 const gchar *
 fwupd_security_attr_get_name(FwupdSecurityAttr *self);
 void

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2377,6 +2377,12 @@ fu_util_security_events_to_string(GPtrArray *events, FuSecurityAttrToStringFlags
 		g_autofree gchar *check = NULL;
 		g_autofree gchar *eventstr = NULL;
 
+		/* skip events that have either been added or removed with no prior value */
+		if (fwupd_security_attr_get_result(attr) == FWUPD_SECURITY_ATTR_RESULT_UNKNOWN ||
+		    fwupd_security_attr_get_result_fallback(attr) ==
+			FWUPD_SECURITY_ATTR_RESULT_UNKNOWN)
+			continue;
+
 		date = g_date_time_new_from_unix_utc((gint64)fwupd_security_attr_get_created(attr));
 		dtstr = g_date_time_format(date, "%F %T");
 		eventstr = fu_util_security_event_to_string(attr);


### PR DESCRIPTION
We do not want to show added or removed HSI tests in this UI.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
