### PR TITLE
Add support for default BIOS settings policy

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -358,6 +358,8 @@ done
 %{_bindir}/fwupdtool
 %{_bindir}/fwupdagent
 %dir %{_sysconfdir}/fwupd
+%dir %{_sysconfdir}/fwupd/bios-settings.d
+%config%(noreplace)%{_sysconfdir}/fwupd/bios-settings.d/README.md
 %dir %{_sysconfdir}/fwupd/remotes.d
 %if 0%{?have_dell}
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/dell-esrt.conf

--- a/data/bios-settings.d/README.md
+++ b/data/bios-settings.d/README.md
@@ -1,0 +1,25 @@
+# BIOS Settings
+
+On supported machines fwupd can enforce BIOS settings policy so that a user's desired settings are configured at bootup
+and prevent fwupd clients from changing them.
+
+## JSON policies
+
+A policy file can be created using `fwupdmgr`.  First determine what settings you want to enforce by running:
+
+```shell
+# fwupdmgr get-bios-settings
+```
+
+After you have identified settings, create a JSON payload by listing them on the command line.  Any number of attributes can
+be listed.
+For example for the BIOS setting `WindowsUEFIFirmwareUpdate` you would create a policy file like this:
+
+```shell
+# fwupdmgr get-bios-settings --json WindowsUEFIFirmwareUpdate > ~/foo.json
+```
+
+Now examine `~/foo.json` and modify the `BiosSettingCurrentValue` key to your desired value.
+
+Lastly place this policy file into `/etc/fwupd/bios-settings.d`.  Any number of policies is supported, and they will be examined
+in alphabetical order.  The next time that fwupd is started it will load this policy and ensure that no fwupd clients change it.

--- a/data/bios-settings.d/meson.build
+++ b/data/bios-settings.d/meson.build
@@ -1,0 +1,5 @@
+if build_standalone and host_machine.system() == 'linux'
+install_data('README.md',
+  install_dir: join_paths(sysconfdir, 'fwupd', 'bios-settings.d')
+)
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,4 @@
+subdir('bios-settings.d')
 subdir('pki')
 subdir('remotes.d')
 

--- a/libfwupdplugin/fu-bios-settings-private.h
+++ b/libfwupdplugin/fu-bios-settings-private.h
@@ -20,3 +20,7 @@ GVariant *
 fu_bios_settings_to_variant(FuBiosSettings *self, gboolean trusted);
 gboolean
 fu_bios_settings_from_json(FuBiosSettings *self, JsonNode *json_node, GError **error);
+gboolean
+fu_bios_settings_from_json_file(FuBiosSettings *self, const gchar *fn, GError **error);
+GHashTable *
+fu_bios_settings_to_hash_kv(FuBiosSettings *self);

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -508,7 +508,7 @@ gboolean
 fu_bios_settings_get_pending_reboot(FuBiosSettings *self, gboolean *result, GError **error)
 {
 	FwupdBiosSetting *attr;
-	const gchar *data;
+	g_autofree gchar *data = NULL;
 	guint64 val = 0;
 
 	g_return_val_if_fail(result != NULL, FALSE);
@@ -532,7 +532,10 @@ fu_bios_settings_get_pending_reboot(FuBiosSettings *self, gboolean *result, GErr
 		return FALSE;
 	}
 
-	data = fwupd_bios_setting_get_current_value(attr);
+	/* refresh/re-read */
+	if (!fu_bios_setting_get_key(attr, NULL, &data, error))
+		return FALSE;
+	fwupd_bios_setting_set_current_value(attr, data);
 	if (!fu_strtoull(data, &val, 0, G_MAXUINT32, error))
 		return FALSE;
 

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1072,12 +1072,14 @@ LIBFWUPDPLUGIN_1.8.4 {
   global:
     fu_backend_add_string;
     fu_bios_settings_from_json;
+    fu_bios_settings_from_json_file;
     fu_bios_settings_get_all;
     fu_bios_settings_get_attr;
     fu_bios_settings_get_pending_reboot;
     fu_bios_settings_get_type;
     fu_bios_settings_new;
     fu_bios_settings_setup;
+    fu_bios_settings_to_hash_kv;
     fu_bios_settings_to_variant;
     fu_context_get_bios_setting;
     fu_context_get_bios_setting_pending_reboot;

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -557,7 +557,10 @@ fu_daemon_authorize_set_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 #endif /* HAVE_POLKIT */
 
 	/* authenticated */
-	if (!fu_engine_modify_bios_settings(helper->self->engine, helper->bios_settings, &error)) {
+	if (!fu_engine_modify_bios_settings(helper->self->engine,
+					    helper->bios_settings,
+					    FALSE,
+					    &error)) {
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -892,7 +892,7 @@ fu_engine_modify_single_bios_setting(FuEngine *self,
 gboolean
 fu_engine_modify_bios_settings(FuEngine *self, GHashTable *settings, GError **error)
 {
-	FwupdBiosSetting *pending;
+	g_autoptr(FuBiosSettings) bios_settings = fu_context_get_bios_settings(self->ctx);
 	gboolean changed = FALSE;
 	GHashTableIter iter;
 	gpointer key, value;
@@ -931,16 +931,9 @@ fu_engine_modify_bios_settings(FuEngine *self, GHashTable *settings, GError **er
 		return FALSE;
 	}
 
-	pending = fu_context_get_bios_setting(self->ctx, FWUPD_BIOS_SETTING_PENDING_REBOOT);
-	if (pending == NULL) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_FOUND,
-			    "attribute %s not found",
-			    FWUPD_BIOS_SETTING_PENDING_REBOOT);
+	if (!fu_bios_settings_get_pending_reboot(bios_settings, &changed, error))
 		return FALSE;
-	}
-	fwupd_bios_setting_set_current_value(pending, "1");
+	g_debug("pending_reboot is now %d", changed);
 	return TRUE;
 }
 

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -244,4 +244,7 @@ fu_engine_schedule_update(FuEngine *self,
 GError *
 fu_engine_error_array_get_best(GPtrArray *errors);
 gboolean
-fu_engine_modify_bios_settings(FuEngine *self, GHashTable *settings, GError **error);
+fu_engine_modify_bios_settings(FuEngine *self,
+			       GHashTable *settings,
+			       gboolean force_ro,
+			       GError **error);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4512,26 +4512,26 @@ fu_engine_modify_bios_settings_func(void)
 	g_assert_nonnull(current);
 
 	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("Disabled"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO);
 	g_assert_false(ret);
 	g_clear_error(&error);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("Enabled"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("off"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("Absolute"), g_strdup("FOO"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
@@ -4539,7 +4539,7 @@ fu_engine_modify_bios_settings_func(void)
 	/* use BiosSettingId instead */
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("com.fwupd-internal.Absolute"), g_strdup("on"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -4547,7 +4547,7 @@ fu_engine_modify_bios_settings_func(void)
 	g_hash_table_insert(bios_settings,
 			    g_strdup("com.fwupd-internal.Absolute"),
 			    g_strdup("off"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -4561,13 +4561,13 @@ fu_engine_modify_bios_settings_func(void)
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("Asset"), g_strdup("0"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("Asset"), g_strdup("1"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -4576,7 +4576,7 @@ fu_engine_modify_bios_settings_func(void)
 	    bios_settings,
 	    g_strdup("Absolute"),
 	    g_strdup("1234567891123456789112345678911234567891123456789112345678911111"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
@@ -4591,26 +4591,27 @@ fu_engine_modify_bios_settings_func(void)
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("75"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_true(ret);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("110"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("1"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);
 
+	/* force it to read only */
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("70"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, TRUE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -4624,7 +4625,14 @@ fu_engine_modify_bios_settings_func(void)
 
 	g_hash_table_remove_all(bios_settings);
 	g_hash_table_insert(bios_settings, g_strdup("pending_reboot"), g_strdup("foo"));
-	ret = fu_engine_modify_bios_settings(engine, bios_settings, &error);
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_clear_error(&error);
+
+	g_hash_table_remove_all(bios_settings);
+	g_hash_table_insert(bios_settings, g_strdup("CustomChargeStop"), g_strdup("80"));
+	ret = fu_engine_modify_bios_settings(engine, bios_settings, FALSE, &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_clear_error(&error);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3237,7 +3237,7 @@ fu_util_set_bios_setting(FuUtilPrivate *priv, gchar **input, GError **error)
 				  error))
 		return FALSE;
 
-	if (!fu_engine_modify_bios_settings(priv->engine, settings, error)) {
+	if (!fu_engine_modify_bios_settings(priv->engine, settings, FALSE, error)) {
 		if (!g_error_matches(*error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
 			g_prefix_error(error, "failed to set BIOS setting: ");
 		return FALSE;


### PR DESCRIPTION
With this change, system administrators can place JSON files in `/etc/fwupd/bios-settings.d` which will set up fwupd to enforce their BIOS settings policy.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Some open discussion questions:

1. Should settings modified this way also be marked "read only"?
2. Should the default directory be created at fwupd startup?
3. Should the empty directory be shipped with packages?
4. Should an empty JSON file be shipped?
5. Should we make a wiki page for how to use BIOS settings (they're getting a lot more complex!), or `fwupd.github.io` page for it?