### PR TITLE
fu-engine: HSI prefix fixing for invalid chassis

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6402,7 +6402,7 @@ fu_engine_attrs_calculate_hsi_for_chassis(FuEngine *self)
 		break;
 	}
 
-	return g_strdup_printf("HSI-INVALID:chassis[0x%02x]", val);
+	return g_strdup_printf("HSI:INVALID:chassis[0x%02x]", val);
 }
 
 static gboolean


### PR DESCRIPTION
The invalid HSI prefix should be "HSI:INVALID" not "HSI-INVALID".

After fixing, the HSI for invalid chassis is shown as follows.
![截圖 2022-08-24 下午11 14 37](https://user-images.githubusercontent.com/1192641/186456075-79f540c3-7b77-49ea-9996-1685723c5b89.png)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
