### PR TITLE
Add a read-only view of BIOS authentication settings

### DIFF
--- a/docs/bios-settings.md
+++ b/docs/bios-settings.md
@@ -162,7 +162,7 @@ An important return code to know for programmatic usage is that *2* means nothin
 
 `fwupd` has the ability to enforce the BIOS settings policy of a system administrator.  To use this feature, create a json payload using `fwupdmgr get-bios-setting --json` that reflects the settings you would like to see enforced.
 
-Then copy this payload into `/etc/fwupd/bios-settings.d`.  The next time that the fwupd daemon is started (such as a system bootup) it will ensure that all BIOS settings are programed to your desired values.  It will also mark those settings as read-only so no fwupd clients will be able to modify them.
+Then copy this payload into `/etc/fwupd/bios-settings.d` with a filename ending in `.json`.  The next time that the fwupd daemon is started (such as a system bootup) it will ensure that all BIOS settings are programed to your desired values.  It will also mark those settings as read-only so no fwupd clients will be able to modify them.
 
 This *does not* stop the kernel firmware-attributes API from working.  So a determined user with appropriate permissions would be able to modify settings from the kernel API directly, but they would be changed again on fwupd daemon startup.
 

--- a/libfwupd/fwupd-bios-setting.h
+++ b/libfwupd/fwupd-bios-setting.h
@@ -35,10 +35,10 @@ struct _FwupdBiosSettingClass {
 /**
  * FwupdBiosSettingKind:
  * @FWUPD_BIOS_SETTING_KIND_UNKNOWN:		BIOS setting type is unknown
- * @FWUPD_BIOS_SETTING_KIND_ENUMERATION:		BIOS setting that has enumerated possible
- *values
+ * @FWUPD_BIOS_SETTING_KIND_ENUMERATION:	BIOS setting that has enumerated possible values
  * @FWUPD_BIOS_SETTING_KIND_INTEGER:		BIOS setting that is an integer
  * @FWUPD_BIOS_SETTING_KIND_STRING:		BIOS setting that accepts a string
+ * @FWUPD_BIOS_SETTING_KIND_AUTH:		BIOS setting used for managing authentication
  *
  * The type of BIOS setting.
  **/
@@ -47,9 +47,48 @@ typedef enum {
 	FWUPD_BIOS_SETTING_KIND_ENUMERATION = 1, /* Since: 1.8.4 */
 	FWUPD_BIOS_SETTING_KIND_INTEGER = 2,	 /* Since: 1.8.4 */
 	FWUPD_BIOS_SETTING_KIND_STRING = 3,	 /* Since: 1.8.4 */
+	FWUPD_BIOS_SETTING_KIND_AUTH = 4,	 /* Since: 1.8.4 */
 	/*< private >*/
-	FWUPD_BIOS_SETTING_KIND_LAST = 4 /* perhaps increased in the future */
+	FWUPD_BIOS_SETTING_KIND_LAST = 5 /* perhaps increased in the future */
 } FwupdBiosSettingKind;
+
+/**
+ * FwupdBiosAuthRole:
+ * @FWUPD_BIOS_AUTH_ROLE_UNKNOWN:	BIOS authentication role is unknown
+ * @FWUPD_BIOS_AUTH_ROLE_POWER_ON:	BIOS authentication role is power-on
+ * @FWUPD_BIOS_AUTH_ROLE_SYSTEM:	BIOS authentication role is system
+ * @FWUPD_BIOS_AUTH_ROLE_BIOS_ADMIN:	BIOS authentication role is bios-admin
+ * @FWUPD_BIOS_AUTH_ROLE_NVME:		BIOS authentication role is nvme
+ * @FWUPD_BIOS_AUTH_ROLE_HDD:		BIOS authentication role is hdd
+ *
+ * The role of BIOS authentication.
+ **/
+typedef enum {
+	FWUPD_BIOS_AUTH_ROLE_UNKNOWN = 0,    /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_ROLE_POWER_ON = 1,   /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_ROLE_SYSTEM = 2,     /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_ROLE_BIOS_ADMIN = 3, /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_ROLE_NVME = 4,	     /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_ROLE_HDD = 5,	     /* Since: 1.8.4 */
+	/*< private >*/
+	FWUPD_BIOS_AUTH_ROLE_LAST = 6 /* perhaps increased in the future */
+} FwupdBiosAuthRole;
+
+/**
+ * FwupdBiosAuthMechanism:
+ * @FWUPD_BIOS_AUTH_MECHANISM_UNKNOWN:	Unknown how BIOS authentication is performed
+ * @FWUPD_BIOS_AUTH_MECHANISM_PASSWORD:	BIOS authentication is performed with password
+ * @FWUPD_BIOS_AUTH_MECHANISM_CERTIFICATE:	BIOS authentication is performed with certificate
+ *
+ * How BIOS authentication is performed
+ **/
+typedef enum {
+	FWUPD_BIOS_AUTH_MECHANISM_UNKNOWN = 0,	   /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_MECHANISM_PASSWORD = 1,	   /* Since: 1.8.4 */
+	FWUPD_BIOS_AUTH_MECHANISM_CERTIFICATE = 2, /* Since: 1.8.4 */
+	/*< private >*/
+	FWUPD_BIOS_AUTH_MECHANISM_LAST = 3 /* perhaps increased in the future */
+} FwupdBiosAuthMechanism;
 
 FwupdBiosSetting *
 fwupd_bios_setting_new(const gchar *name, const gchar *path);
@@ -115,5 +154,18 @@ const gchar *
 fwupd_bios_setting_get_id(FwupdBiosSetting *self);
 void
 fwupd_bios_setting_set_id(FwupdBiosSetting *self, const gchar *id);
+
+FwupdBiosAuthRole
+fwupd_bios_setting_get_auth_role(FwupdBiosSetting *self);
+void
+fwupd_bios_setting_set_auth_role(FwupdBiosSetting *self, FwupdBiosAuthRole role);
+gboolean
+fwupd_bios_setting_get_auth_enabled(FwupdBiosSetting *self);
+void
+fwupd_bios_setting_set_auth_enabled(FwupdBiosSetting *self, gboolean auth_enabled);
+FwupdBiosAuthMechanism
+fwupd_bios_setting_get_auth_mechanism(FwupdBiosSetting *self);
+void
+fwupd_bios_setting_set_auth_mechanism(FwupdBiosSetting *self, FwupdBiosAuthMechanism mechanism);
 
 G_END_DECLS

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -582,5 +582,31 @@ G_BEGIN_DECLS
  * The D-Bus type signature string is 'b' i.e. a boolean.
  **/
 #define FWUPD_RESULT_KEY_BIOS_SETTING_READ_ONLY "BiosSettingReadOnly"
+/**
+ * FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_ENABLED:
+ *
+ * Result key to represent whether BIOS authentication setting is in use.
+ *
+ * The D-Bus type signature string is 'b' i.e. a boolean.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_ENABLED "BiosSettingAuthEnabled"
+/**
+ * FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_MECHANISM:
+ *
+ * Result key to represent the BIOS authentication setting authorization
+ * mechanism.
+ *
+ * The D-Bus type signature string is 't' i.e. a unsigned 64 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_MECHANISM "BiosSettingAuthMechanism"
+/**
+ * FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_ROLE:
+ *
+ * Result key to represent the BIOS authentication setting role, describing
+ * how the authentication is used.
+ *
+ * The D-Bus type signature string is 't' i.e. a unsigned 64 bit integer.
+ **/
+#define FWUPD_RESULT_KEY_BIOS_SETTING_AUTH_ROLE "BiosSettingAuthRole"
 
 G_END_DECLS

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -1383,10 +1383,12 @@ fwupd_bios_settings_func(void)
 	g_autofree gchar *str1 = NULL;
 	g_autofree gchar *str2 = NULL;
 	g_autofree gchar *str3 = NULL;
+	g_autofree gchar *str4 = NULL;
 	g_autofree gchar *json1 = NULL;
 	g_autofree gchar *json2 = NULL;
 	g_autoptr(FwupdBiosSetting) attr1 = fwupd_bios_setting_new("foo", "/path/to/bar");
 	g_autoptr(FwupdBiosSetting) attr2 = NULL;
+	g_autoptr(FwupdBiosSetting) attr3 = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GVariant) data1 = NULL;
 	g_autoptr(GVariant) data2 = NULL;
@@ -1425,11 +1427,31 @@ fwupd_bios_settings_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	/* roundtrip GVariant */
-	data1 = fwupd_bios_setting_to_variant(attr1, TRUE);
-	attr2 = fwupd_bios_setting_from_variant(data1);
+	attr2 = fwupd_bios_setting_new("Admin", "/path/to/Admin");
+	fwupd_bios_setting_set_name(attr2, "Admin");
+	fwupd_bios_setting_set_kind(attr2, FWUPD_BIOS_SETTING_KIND_AUTH);
+	fwupd_bios_setting_set_auth_mechanism(attr2, FWUPD_BIOS_AUTH_MECHANISM_PASSWORD);
+	fwupd_bios_setting_set_auth_role(attr2, FWUPD_BIOS_AUTH_ROLE_BIOS_ADMIN);
+	fwupd_bios_setting_set_auth_enabled(attr2, TRUE);
+	g_assert_cmpint(fwupd_bios_setting_get_kind(attr2), ==, FWUPD_BIOS_SETTING_KIND_AUTH);
 	str2 = fwupd_bios_setting_to_string(attr2);
 	ret = fu_test_compare_lines(str2,
+				    "  Name:                 Admin\n"
+				    "  Filename:             /path/to/Admin\n"
+				    "  BiosSettingType:      4\n"
+				    "  BiosSettingReadOnly:  False\n"
+				    "  BiosSettingAuthEnabled: True\n"
+				    "  BiosSettingAuthMechanism: 1\n"
+				    "  BiosSettingAuthRole:  3\n",
+				    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* roundtrip GVariant */
+	data1 = fwupd_bios_setting_to_variant(attr1, TRUE);
+	attr3 = fwupd_bios_setting_from_variant(data1);
+	str3 = fwupd_bios_setting_to_string(attr3);
+	ret = fu_test_compare_lines(str3,
 				    "  Name:                 UEFISecureBoot\n"
 				    "  Description:          Controls Secure boot\n"
 				    "  Filename:             /path/to/bar\n"
@@ -1475,8 +1497,8 @@ fwupd_bios_settings_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	str3 = fwupd_bios_setting_to_string(attr2);
-	ret = fu_test_compare_lines(str3, str1, &error);
+	str4 = fwupd_bios_setting_to_string(attr2);
+	ret = fu_test_compare_lines(str4, str1, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -807,6 +807,9 @@ LIBFWUPD_1.8.4 {
     fwupd_bios_setting_array_from_variant;
     fwupd_bios_setting_from_json;
     fwupd_bios_setting_from_variant;
+    fwupd_bios_setting_get_auth_enabled;
+    fwupd_bios_setting_get_auth_mechanism;
+    fwupd_bios_setting_get_auth_role;
     fwupd_bios_setting_get_current_value;
     fwupd_bios_setting_get_description;
     fwupd_bios_setting_get_id;
@@ -822,6 +825,9 @@ LIBFWUPD_1.8.4 {
     fwupd_bios_setting_has_possible_value;
     fwupd_bios_setting_map_possible_value;
     fwupd_bios_setting_new;
+    fwupd_bios_setting_set_auth_enabled;
+    fwupd_bios_setting_set_auth_mechanism;
+    fwupd_bios_setting_set_auth_role;
     fwupd_bios_setting_set_current_value;
     fwupd_bios_setting_set_description;
     fwupd_bios_setting_set_id;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6906,7 +6906,7 @@ fu_engine_apply_default_bios_settings_policy(FuEngine *self, GError **error)
 	dir = g_dir_open(dirname, 0, error);
 	while ((tmp = g_dir_read_name(dir)) != NULL) {
 		g_autofree gchar *fn = NULL;
-		if (g_strcmp0(tmp, "README.md") == 0)
+		if (!g_str_has_suffix(tmp, ".json"))
 			continue;
 		fn = g_build_filename(dirname, tmp, NULL);
 		g_debug("Loading default BIOS settings policy from %s", fn);


### PR DESCRIPTION
This isn't incredibly useful right now for anything other than a building block to design how to interact with these settings.

By design the kernel will not let you read the current password for anything.
This means that the password (or certificate) would need to be stored somewhere to be used.  By reading these other attributes we can discover whether a password is needed and at least prevent fwupd from trying to set an attribute in this case.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

If we ignore certificate authentication for now and focus on password, my big open question is where/how to get the password into the daemon (for another PR).  Here's the ideas i've come up with.
1. Pass it over dbus from the client.  I'm not personally crazy about it going in clear text.
2. Require a user to populate in clear text in a file `/etc/fwupd/bios-settings.d/bios_settings.conf` only accessible by root.
3. Use the client to encrypt the password, pass it over dbus.
4. Attempt to store and fetch it from the TPM.

My current leaning is conffile.  If a user went out of their way to set a BIOS setting let them populate that file.  When the daemon detects the need to set a password (from `is_enabled` attribute in `bios-admin` type) then it would use the value fetched from that file.