### PR TITLE
Move BIOS Settings descriptions database into the daemon

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,5 +1,6 @@
 data/remotes.d/lvfs.metainfo.xml
 data/remotes.d/lvfs-testing.metainfo.xml
+libfwupdplugin/fu-bios-settings.c
 libfwupdplugin/tests/bios-attrs/dell-xps13-9310/strings.txt
 policy/org.freedesktop.fwupd.policy.in
 plugins/dfu/fu-dfu-tool.c

--- a/src/fu-util-bios-setting.c
+++ b/src/fu-util-bios-setting.c
@@ -14,33 +14,13 @@
 #include "fu-util-bios-setting.h"
 #include "fu-util-common.h"
 
-static gboolean
-fu_util_bios_setting_dup_fields(const gchar *name, const gchar *desc)
-{
-	return g_strcmp0(name, desc) == 0;
-}
-
 static void
 fu_util_bios_setting_update_description(FwupdBiosSetting *setting)
 {
-	const gchar *name = fwupd_bios_setting_get_name(setting);
-	const gchar *old = fwupd_bios_setting_get_description(setting);
 	const gchar *new = NULL;
 
-	if (g_strcmp0(name, FWUPD_BIOS_SETTING_PENDING_REBOOT) == 0) {
-		/* TRANSLATORS: Settings refers to BIOS settings in this context */
-		new = _("Settings will apply after system reboots");
-	}
-	/* For providing a better description on a number of Lenovo systems */
-	if (fu_util_bios_setting_dup_fields(name, old)) {
-		if (g_strcmp0(old, "WindowsUEFIFirmwareUpdate") == 0) {
-			/* TRANSLATORS: description of a BIOS setting */
-			new = _("BIOS updates delivered via LVFS or Windows Update");
-		}
-	} else {
-		/* try to look it up from translations */
-		new = gettext(old);
-	}
+	/* try to look it up from translations */
+	new = gettext(fwupd_bios_setting_get_description(setting));
 	if (new != NULL)
 		fwupd_bios_setting_set_description(setting, new);
 }


### PR DESCRIPTION
We'll want all clients to be able to get translations from updated descriptions.  So move this into the daemon so at least the right English string is set by default.

Clients can then look up from there.

While making this change, also prepare for better lookups for read-only as well.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
