### PR TITLE
trivial: bios-settings: don't show error for nothing to do

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6942,7 +6942,11 @@ fu_engine_check_firmware_attributes(FuEngine *self, FuDevice *device)
 			return;
 		}
 		if (!fu_engine_apply_default_bios_settings_policy(self, &error)) {
-			g_warning("Failed to apply BIOS settings policy: %s", error->message);
+			if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
+				g_debug("%s", error->message);
+			else
+				g_warning("Failed to apply BIOS settings policy: %s",
+					  error->message);
 			return;
 		}
 	}


### PR DESCRIPTION
After policy applies for the first time, you don't want to show
messaging to users that the policy can't apply the next time.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
