### PR TITLE
Fix applying the latest DBX update on machines with 20200729.x64 installed

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -190,7 +190,36 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 	const gchar *ignored_guids[] = {FU_EFI_SIGNATURE_GUID_OVMF,
 					FU_EFI_SIGNATURE_GUID_OVMF_LEGACY,
 					NULL};
+	g_autofree gchar *checksum_last = NULL;
 	g_autoptr(GPtrArray) sigs = NULL;
+	struct {
+		const gchar *checksum;
+		guint version;
+	} known_checksums[] = {
+	    /* DBXUpdate-20100307.x64.bin */
+	    {"5391c3a2fb112102a6aa1edc25ae77e19f5d6f09cd09eeb2509922bfcd5992ea", 9},
+	    /* DBXUpdate-20140413.x64.bin */
+	    {"90fbe70e69d633408d3e170c6832dbb2d209e0272527dfb63d49d29572a6f44c", 13},
+	    /* DBXUpdate-20160809.x64.bin */
+	    {"45c7c8ae750acfbb48fc37527d6412dd644daed8913ccd8a24c94d856967df8e", 77},
+	    /* DBXUpdate-20200729.x64.bin */
+	    {"540801dd345dc1c33ef431b35bf4c0e68bd319b577b9abe1a9cff1cbc39f548f", 190},
+	    /* DBXUpdate-20200729.aa64.bin */
+	    {"8c8183ad9b96fe1f3c74dedb8087469227b642afe2e80f8fd22e0137c11c7d90", 19},
+	    /* DBXUpdate-20200729.ia32.bin */
+	    {"a7dfcc3a8d6ab30f93f31748dbc8ea38415cf52bb9ad8085672cd9ab8938d5de", 41},
+	    /* DBXUpdate-20210429.x64.bin */
+	    {"af79b14064601bc0987d4747af1e914a228c05d622ceda03b7a4f67014fee767", 211},
+	    /* DBXUpdate-20210429.aa64.bin */
+	    {"b133de42a37376f5d91439af3d61d38201f10377c36dacd9c2610f52aa124a91", 21},
+	    /* DBXUpdate-20210429.ia32.bin */
+	    {"a8a3300e33a0a2692839ccba84803c5e742d12501b6d58c46eb87f32017f2cff", 55},
+	    /* DBXUpdate-20220812.x64.bin */
+	    {"90aec5c4995674a849c1d1384463f3b02b5aa625a5c320fc4fe7d9bb58a62398", 217},
+	    /* DBXUpdate-20220812.aa64.bin - only X509 certificates removed */
+	    /* DBXUpdate-20220812.ia32.bin - only X509 certificates removed */
+	    {NULL, 0}};
+
 	sigs = fu_firmware_get_images(FU_FIRMWARE(self));
 	for (guint i = 0; i < sigs->len; i++) {
 		FuEfiSignature *sig = g_ptr_array_index(sigs, i);
@@ -198,8 +227,56 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 			continue;
 		if (g_strv_contains(ignored_guids, fu_efi_signature_get_owner(sig)))
 			continue;
+
+		/* save the last hash in the list */
+		if (i == sigs->len - 1) {
+			g_autoptr(GError) error_local = NULL;
+			checksum_last = fu_firmware_get_checksum(FU_FIRMWARE(sig),
+								 G_CHECKSUM_SHA256,
+								 &error_local);
+			if (checksum_last == NULL) {
+				g_warning("failed to get checksum for signature %u: %s",
+					  i,
+					  error_local->message);
+			}
+		}
+
 		csum_cnt++;
 	}
+
+	/*
+	 * Microsoft seems to actually remove checksums in UEFI dbx updates, which I'm guessing is
+	 * a result from OEM pressure about SPI usage -- but local dbx updates are append-only.
+	 *
+	 * That means that if you remove hashes then you can have a different set of dbx checksums
+	 * on your machine depending on whether you went A->B->C->D or A->D...
+	 *
+	 * If we use the metric of "count the number of SHA256 checksums from MS" then we might
+	 * overcount (due to the now-removed entries) -- in some cases enough to not actually apply
+	 * the new update at all.
+	 *
+	 * In these cases look at the *last* dbx checksum and compare to the set we know to see if
+	 * we need to artificially lower the reported version. This isn't helped by having *zero*
+	 * visibility in the reason that entries were removed or added.
+	 *
+	 * This also fixes the DBX update 20200729 which added 4 duplicate entries, which should be
+	 * rectified during the SetVariable(), so they're only really a problem for transactional
+	 * size limits. But we all noticed that load-bearing *should* word there, didn't we.
+	 */
+	for (guint i = 0; checksum_last != NULL && known_checksums[i].checksum != NULL; i++) {
+		if (g_strcmp0(checksum_last, known_checksums[i].checksum) == 0) {
+			if (csum_cnt != known_checksums[i].version) {
+				g_debug("fixing signature list version from %u to %u as "
+					"last dbx checksum was %s",
+					csum_cnt,
+					known_checksums[i].version,
+					checksum_last);
+				csum_cnt = known_checksums[i].version;
+			}
+			break;
+		}
+	}
+
 	return g_strdup_printf("%u", csum_cnt);
 }
 

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -219,6 +219,7 @@ main(int argc, char *argv[])
 				fu_efi_signature_kind_to_string(fu_efi_signature_get_kind(sig)),
 				checksum);
 		}
+		g_debug("version: %s", fu_firmware_get_version(FU_FIRMWARE(dbx)));
 		return EXIT_SUCCESS;
 	}
 


### PR DESCRIPTION
Use a hardcoded list of last-set dbx checksums to fix the reported version
when required.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
