### PR TITLE
tpm: Don't require uefi capsule updates for checking TPM PCR0

### DIFF
--- a/plugins/tpm/fu-plugin-tpm.c
+++ b/plugins/tpm/fu-plugin-tpm.c
@@ -159,7 +159,7 @@ fu_plugin_tpm_add_security_attr_eventlog(FuPlugin *plugin, FuSecurityAttrs *attr
 	fu_security_attrs_append(attrs, attr);
 
 	/* check reconstructed to PCR0 */
-	if (priv->ev_items == NULL || priv->bios_device == NULL) {
+	if (priv->ev_items == NULL) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		return;
 	}


### PR DESCRIPTION
There isn't any reason that we need to have a system advertising a
GUID with `main-system-firmware` in order to check that PCR0 reconstruction
matches what the TPM actually has.

Fixes: #4961

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
