### PR TITLE
Correctly detect CET IBT

### DIFF
--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -250,8 +250,9 @@ fu_cpu_device_probe_extended_features(FuDevice *device, GError **error)
 	FuCpuDevice *self = FU_CPU_DEVICE(device);
 	guint32 ebx = 0;
 	guint32 ecx = 0;
+	guint32 edx = 0;
 
-	if (!fu_cpuid(0x7, NULL, &ebx, &ecx, NULL, error))
+	if (!fu_cpuid(0x7, NULL, &ebx, &ecx, &edx, error))
 		return FALSE;
 	if ((ebx >> 20) & 0x1)
 		self->flags |= FU_CPU_DEVICE_FLAG_SMAP;
@@ -259,7 +260,7 @@ fu_cpu_device_probe_extended_features(FuDevice *device, GError **error)
 		self->flags |= FU_CPU_DEVICE_FLAG_SHSTK;
 	if ((ecx >> 13) & 0x1)
 		self->flags |= FU_CPU_DEVICE_FLAG_TME;
-	if ((ecx >> 20) & 0x1)
+	if ((edx >> 20) & 0x1)
 		self->flags |= FU_CPU_DEVICE_FLAG_IBT;
 	return TRUE;
 }


### PR DESCRIPTION
According to Intel, EDX[bit 20] corresponds to IBT feature, *not* ECX.

Fixes half of https://github.com/fwupd/fwupd/issues/4960

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
