### PR TITLE
trivial: disable `security` arg when HSI disabled

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -68,13 +68,15 @@ if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() 
     install: true,
     install_dir: join_paths(datadir, 'doc', 'fwupd'),
   )
- install_data(['index.html', 'hsi.html'],
-    install_dir : join_paths(datadir, 'doc', 'fwupd')
-  )
- install_data(['urlmap_fwupd.js'],
+  if hsi
+    install_data(['index.html', 'hsi.html'],
+      install_dir : join_paths(datadir, 'doc', 'fwupd')
+    )
+  endif
+  install_data(['urlmap_fwupd.js'],
     install_dir: join_paths(datadir, 'doc', 'fwupd', 'libfwupd')
   )
- install_data(['urlmap_fwupdplugin.js'],
+  install_data(['urlmap_fwupdplugin.js'],
     install_dir: join_paths(datadir, 'doc', 'fwupd', 'libfwupdplugin')
   )
   #make devhelp work

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2910,6 +2910,15 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GPtrArray) events_array = NULL;
 	g_autofree gchar *str = NULL;
 
+#ifndef HAVE_HSI
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    /* TRANSLATORS: error message for unsupported feature */
+		    _("Host Security ID (HSI) is not supported"));
+	return FALSE;
+#endif /* HAVE_HSI */
+
 	if (!fu_util_start_engine(priv,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_HWINFO |
 				      FU_ENGINE_LOAD_FLAG_REMOTES,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3449,6 +3449,15 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(GError) error_local = NULL;
 	g_autofree gchar *str = NULL;
 
+#ifndef HAVE_HSI
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    /* TRANSLATORS: error message for unsupported feature */
+		    _("Host Security ID (HSI) is not supported"));
+	return FALSE;
+#endif /* HAVE_HSI */
+
 	/* the "why" */
 	attrs = fwupd_client_get_host_security_attrs(priv->client, priv->cancellable, error);
 	if (attrs == NULL)


### PR DESCRIPTION
There is no point to offering the security argument to the tools if HSI was disabled
at compile time.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
