### PR TITLE
Add a Service for Windows

### DIFF
--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -146,6 +146,12 @@ find "$DESTDIR" | \
 	--component-group "CG.fwupd-files" | \
 	tee "$build/contrib/fwupd-files.wxs"
 
+#add service install key
+sed -i "$build/contrib/fwupd-files.wxs" -f - << EOF
+s,fwupd.exe"/>,fwupd.exe"/>\\
+          <ServiceInstall Id="FwupdServiceInstaller" Interactive="no" ErrorControl="normal" Name="fwupd" DisplayName="fwupd" Description="fwupd" Start="auto" Type="ownProcess" Arguments=""/>,
+EOF
+
 MSI_FILENAME="$DESTDIR/setup/fwupd-$VERSION-setup-x86_64.msi"
 mkdir -p "$DESTDIR/setup"
 wixl -v \

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -518,7 +518,7 @@ fwupd_client_get_details(FwupdClient *self,
 	g_set_error_literal(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "Not supported as <glib-unix.h> is unavailable");
+			    "Get Details only supported on Linux");
 	return NULL;
 #endif
 }
@@ -1272,7 +1272,7 @@ fwupd_client_install(FwupdClient *self,
 	g_set_error_literal(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "Not supported as <glib-unix.h> is unavailable");
+			    "Install CAB only supported on Linux");
 	return FALSE;
 #endif
 }
@@ -1514,7 +1514,7 @@ fwupd_client_update_metadata(FwupdClient *self,
 	g_set_error_literal(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "Not supported as <glib-unix.h> is unavailable");
+			    "Update metadata only supported on Linux");
 	return FALSE;
 #endif
 }

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -2856,7 +2856,7 @@ fwupd_client_install_bytes_async(FwupdClient *self,
 	g_task_return_new_error(task,
 				FWUPD_ERROR,
 				FWUPD_ERROR_NOT_SUPPORTED,
-				"Not supported as <glib-unix.h> is unavailable");
+				"Install CAB only supported on Linux");
 #endif
 }
 
@@ -2941,7 +2941,7 @@ fwupd_client_install_async(FwupdClient *self,
 	g_task_return_new_error(task,
 				FWUPD_ERROR,
 				FWUPD_ERROR_NOT_SUPPORTED,
-				"Not supported as <glib-unix.h> is unavailable");
+				"Install CAB async only supported on Linux");
 #endif
 }
 
@@ -3415,7 +3415,7 @@ fwupd_client_get_details_bytes_async(FwupdClient *self,
 	g_task_return_new_error(task,
 				FWUPD_ERROR,
 				FWUPD_ERROR_NOT_SUPPORTED,
-				"Not supported as <glib-unix.h> is unavailable");
+				"Get Details only supported on Linux");
 #endif
 }
 
@@ -3815,7 +3815,7 @@ fwupd_client_update_metadata_bytes_async(FwupdClient *self,
 	g_task_return_new_error(task,
 				FWUPD_ERROR,
 				FWUPD_ERROR_NOT_SUPPORTED,
-				"Not supported as <glib-unix.h> is unavailable");
+				"Update metadata only supported on Linux");
 #endif
 }
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4604,7 +4604,13 @@ main(int argc, char *argv[])
 
 	/* show a warning if the daemon is tainted */
 	if (!fwupd_client_connect(priv->client, priv->cancellable, &error)) {
+#ifdef _WIN32
+		/* TRANSLATORS: error message for Windows */
+		g_printerr(_("Failed to connect to Windows service, please ensure it's running."));
+		g_debug("%s", error->message);
+#else
 		g_printerr("Failed to connect to daemon: %s\n", error->message);
+#endif
 		return EXIT_FAILURE;
 	}
 	if (fwupd_client_get_tainted(priv->client)) {


### PR DESCRIPTION
This makes `fwupdmgr.exe` "work".  We still don't have the ability to pass CAB files or metadata between client and daemon, but it's a step in that direction.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
