### PR TITLE
Install the symlink the other way around

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - "dist/share/doc/fwupd"
+            - "dist/share/doc"
 
   build-windows:
     docker:
@@ -80,7 +80,7 @@ jobs:
             git config user.email "info@fwupd.org"
             git config user.name "Documentation deployment Bot"
             rm -rf *
-            cp  ../libfwupd* ../*html . -R
+            cp  ../libfwupd* ../fwupd/*html . -R
             git add .
             git commit -a --allow-empty -m "Trigger deployment"
             git push git@github.com:fwupd/fwupd.github.io.git

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -40,7 +40,7 @@ if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() 
     ],
     build_by_default: true,
     install: true,
-    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+    install_dir: join_paths(datadir, 'doc'),
   )
 
   custom_target('doc-fwupdplugin',
@@ -66,7 +66,7 @@ if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() 
     ],
     build_by_default: true,
     install: true,
-    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+    install_dir: join_paths(datadir, 'doc'),
   )
   if hsi
     install_data(['index.html', 'hsi.html'],
@@ -74,18 +74,18 @@ if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() 
     )
   endif
   install_data(['urlmap_fwupd.js'],
-    install_dir: join_paths(datadir, 'doc', 'fwupd', 'libfwupd')
+    install_dir: join_paths(datadir, 'doc', 'libfwupd')
   )
   install_data(['urlmap_fwupdplugin.js'],
-    install_dir: join_paths(datadir, 'doc', 'fwupd', 'libfwupdplugin')
+    install_dir: join_paths(datadir, 'doc', 'libfwupdplugin')
   )
   #make devhelp work
   install_symlink('libfwupd',
-    install_dir: join_paths(datadir, 'doc',),
-    pointing_to: join_paths('fwupd', 'libfwupd'),
+    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+    pointing_to: join_paths(datadir, 'doc', 'libfwupd'),
   )
   install_symlink('libfwupdplugin',
-    install_dir: join_paths(datadir, 'doc',),
-    pointing_to: join_paths('fwupd', 'libfwupdplugin'),
+    install_dir: join_paths(datadir, 'doc', 'fwupd'),
+    pointing_to: join_paths(datadir, 'doc', 'libfwupdplugin'),
   )
 endif


### PR DESCRIPTION
RPM based distros cannot replace a directory with a symlink without a giant hack.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
