### PR TITLE
trivial: Only build CI for macos-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,10 +72,7 @@ jobs:
           docker run --privileged -e CI=true -t -v $GITHUB_WORKSPACE:/github/workspace docker.pkg.github.com/fwupd/fwupd/fwupd-${{matrix.os}}:latest
 
   macos:
-    strategy:
-      matrix:
-        os: [ macos-10.15, macos-11 ]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-11
     steps:
     - name: install dependencies
       run: brew install meson gcab libusb gobject-introspection sqlite libarchive json-glib curl gnutls protobuf-c vala


### PR DESCRIPTION
We've never found a different in compilation between 10.15 and 11.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
