### PR TITLE
trivial: update golang container for msi publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
 
   publish-github-exe-release:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.17.5
     steps:
       - attach_workspace:
           at: .


### PR DESCRIPTION
The deploy job failed at 1.8.4 release, move up to a current version
of golang instead to fix this.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
