### PR TITLE
trivial: show a better error why docs fails if markdown not installed

### DIFF
--- a/docs/test-deps.py
+++ b/docs/test-deps.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import sys
-import markdown
+
+try:
+    import markdown
+except ImportError:
+    print("Missing 'markdown' python module")
+    sys.exit(1)
 
 try:
     from packaging.version import Version


### PR DESCRIPTION
We require at least 3.3.3, but if they don't have anything at least show a message.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
