### PR TITLE
Ensure the context is set for all backends

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -55,8 +55,8 @@ fu_backend_device_added(FuBackend *self, FuDevice *device)
 	g_return_if_fail(FU_IS_DEVICE(device));
 	g_return_if_fail(priv->thread_init == g_thread_self());
 
-	/* assign context if unset */
-	if (fu_device_get_context(device) == NULL)
+	/* assign context if set */
+	if (priv->ctx != NULL)
 		fu_device_set_context(device, priv->ctx);
 
 	/* add */

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3814,12 +3814,6 @@ fu_device_set_context(FuDevice *self, FuContext *ctx)
 			   fu_device_get_id(self));
 		return;
 	}
-	if (priv->ctx != NULL && priv->ctx == ctx) {
-		g_critical("re-setting device context for %s [%s]",
-			   fu_device_get_name(self),
-			   fu_device_get_id(self));
-		return;
-	}
 #endif
 
 	if (g_set_object(&priv->ctx, ctx))

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -237,7 +237,8 @@ fu_bluez_backend_class_init(FuBluezBackendClass *klass)
 }
 
 FuBackend *
-fu_bluez_backend_new(void)
+fu_bluez_backend_new(FuContext *ctx)
 {
-	return FU_BACKEND(g_object_new(FU_TYPE_BLUEZ_BACKEND, "name", "bluez", NULL));
+	return FU_BACKEND(
+	    g_object_new(FU_TYPE_BLUEZ_BACKEND, "name", "bluez", "context", ctx, NULL));
 }

--- a/src/fu-bluez-backend.h
+++ b/src/fu-bluez-backend.h
@@ -12,4 +12,4 @@
 G_DECLARE_FINAL_TYPE(FuBluezBackend, fu_bluez_backend, FU, BLUEZ_BACKEND, FuBackend)
 
 FuBackend *
-fu_bluez_backend_new(void);
+fu_bluez_backend_new(FuContext *ctx);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8095,14 +8095,13 @@ fu_engine_init(FuEngine *self)
 
 	/* backends */
 #ifdef HAVE_GUSB
-	g_ptr_array_add(self->backends, fu_usb_backend_new());
+	g_ptr_array_add(self->backends, fu_usb_backend_new(self->ctx));
 #endif
 #ifdef HAVE_GUDEV
-	g_ptr_array_add(self->backends,
-			fu_udev_backend_new(fu_context_get_udev_subsystems(self->ctx)));
+	g_ptr_array_add(self->backends, fu_udev_backend_new(self->ctx));
 #endif
 #ifdef HAVE_BLUEZ
-	g_ptr_array_add(self->backends, fu_bluez_backend_new());
+	g_ptr_array_add(self->backends, fu_bluez_backend_new(self->ctx));
 #endif
 
 	/* setup Jcat context */

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -12,6 +12,7 @@
 
 #include <gudev/gudev.h>
 
+#include "fu-context-private.h"
 #include "fu-udev-backend.h"
 
 struct _FuUdevBackend {
@@ -238,10 +239,12 @@ fu_udev_backend_class_init(FuUdevBackendClass *klass)
 }
 
 FuBackend *
-fu_udev_backend_new(GPtrArray *subsystems)
+fu_udev_backend_new(FuContext *ctx)
 {
 	FuUdevBackend *self;
-	self = FU_UDEV_BACKEND(g_object_new(FU_TYPE_UDEV_BACKEND, "name", "udev", NULL));
+	GPtrArray *subsystems = fu_context_get_udev_subsystems(ctx);
+	self = FU_UDEV_BACKEND(
+	    g_object_new(FU_TYPE_UDEV_BACKEND, "name", "udev", "context", ctx, NULL));
 	if (subsystems != NULL)
 		self->subsystems = g_ptr_array_ref(subsystems);
 	return FU_BACKEND(self);

--- a/src/fu-udev-backend.h
+++ b/src/fu-udev-backend.h
@@ -12,4 +12,4 @@
 G_DECLARE_FINAL_TYPE(FuUdevBackend, fu_udev_backend, FU, UDEV_BACKEND, FuBackend)
 
 FuBackend *
-fu_udev_backend_new(GPtrArray *subsystems);
+fu_udev_backend_new(FuContext *ctx);

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -195,7 +195,7 @@ fu_usb_backend_class_init(FuUsbBackendClass *klass)
 }
 
 FuBackend *
-fu_usb_backend_new(void)
+fu_usb_backend_new(FuContext *ctx)
 {
-	return FU_BACKEND(g_object_new(FU_TYPE_USB_BACKEND, "name", "usb", NULL));
+	return FU_BACKEND(g_object_new(FU_TYPE_USB_BACKEND, "name", "usb", "context", ctx, NULL));
 }

--- a/src/fu-usb-backend.h
+++ b/src/fu-usb-backend.h
@@ -12,4 +12,4 @@
 G_DECLARE_FINAL_TYPE(FuUsbBackend, fu_usb_backend, FU, USB_BACKEND, FuBackend)
 
 FuBackend *
-fu_usb_backend_new(void);
+fu_usb_backend_new(FuContext *ctx);


### PR DESCRIPTION
This isn't required right now, but new functionality is much easier to add if
we know the context has always been set.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
