### PR TITLE
trivial: Fix a tiny memory leak when loading BIOS settings

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6936,7 +6936,8 @@ fu_engine_check_firmware_attributes(FuEngine *self, FuDevice *device, gboolean a
 	if (g_strcmp0(subsystem, "firmware-attributes") == 0) {
 		g_autoptr(GError) error = NULL;
 		if (added) {
-			FuBiosSettings *settings = fu_context_get_bios_settings(self->ctx);
+			g_autoptr(FuBiosSettings) settings =
+			    fu_context_get_bios_settings(self->ctx);
 			g_autoptr(GPtrArray) items = fu_bios_settings_get_all(settings);
 
 			if (items->len > 0) {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
