### PR TITLE
Fixes for debian/control

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -190,6 +190,7 @@
       <package variant="aarch64">libftdi-devel</package>
     </distro>
     <distro id="debian">
+      <control />
       <package variant="x86_64" />
       <package variant="i386" />
     </distro>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -494,15 +494,6 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency id="libglib2.0-doc">
-    <distro id="debian">
-      <package variant="x86_64" />
-      <package variant="i386" />
-    </distro>
-    <distro id="ubuntu">
-      <package variant="x86_64" />
-    </distro>
-  </dependency>
   <dependency id="libglib2.0-dev">
     <distro id="centos">
       <package variant="x86_64">glib2-devel</package>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -972,6 +972,7 @@
     </distro>
   </dependency>
   <dependency id="libumockdev-dev">
+    <control />
     <distro id="debian">
       <package variant="x86_64" />
       <package variant="i386" />

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -97,6 +97,8 @@ def parse_dependencies(OS, variant, add_control):
             if add_control:
                 inclusive = []
                 exclusive = []
+                if not distro.findall("control"):
+                    continue
                 for control_parent in distro.findall("control"):
                     for obj in control_parent.findall("inclusive"):
                         inclusive.append(obj.text)


### PR DESCRIPTION
Recently noticed that a bunch of weird architectures are failing in Debian because they happen to not have `clang-format`.  That's fine if they want to build, but make sure the dependencies that we use for our CI environment don't leak into `debian/control`.  This should help avoid those failures.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
