### PR TITLE
Try harder to make sure mtdram env setup

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1222,7 +1222,7 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 			g_set_error_literal(error,
 					    G_IO_ERROR,
 					    G_IO_ERROR_NOT_FOUND,
-					    "failed to find DEVPATH");
+					    "failed to find DEVNAME");
 			return FALSE;
 		}
 		physical_id = g_strdup_printf("DEVNAME=%s", tmp);

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -39,6 +39,15 @@ fu_test_mtd_device_func(void)
 		g_test_skip("could not find mtdram device");
 		return;
 	}
+	dev_name = g_udev_device_get_property(udev_device, "DEVNAME");
+	if (g_strcmp0(dev_name, "/dev/mtd0") != 0) {
+		g_test_skip("DEVNAME not /dev/mtd0");
+		return;
+	}
+	if (!g_file_test(dev_name, G_FILE_TEST_EXISTS)) {
+		g_test_skip("/dev/mtd0 doesn't exist");
+		return;
+	}
 
 	/* create device */
 	device = g_object_new(FU_TYPE_MTD_DEVICE, "context", ctx, "udev-device", udev_device, NULL);


### PR DESCRIPTION
The autopkgtest environment in Ubuntu seems to not be preparing the mtdram device properly. Sometimes the udev node "exists" but the /dev/mtd0 does not exist.
    
Look for this explicitly and skip the test if it happens.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
