### PR TITLE
trivial: Export fu_device_set_quirk_kv() for future use

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -56,3 +56,5 @@ FuDeviceInternalFlags
 fu_device_get_internal_flags(FuDevice *self);
 void
 fu_device_set_internal_flags(FuDevice *self, FuDeviceInternalFlags flags);
+gboolean
+fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GError **error);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1619,12 +1619,30 @@ fu_device_set_quirk_inhibit_section(FuDevice *self, const gchar *value, GError *
 	return TRUE;
 }
 
-static gboolean
+/**
+ * fu_device_set_quirk_kv:
+ * @self: a #FuDevice
+ * @key: a string key
+ * @value: a string value
+ * @error: (nullable): optional return location for an error
+ *
+ * Sets a specific quirk on the device.
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 1.8.5
+ **/
+gboolean
 fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GError **error)
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
 	guint64 tmp;
+
+	g_return_val_if_fail(FU_IS_DEVICE(self), FALSE);
+	g_return_val_if_fail(key != NULL, FALSE);
+	g_return_val_if_fail(value != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (g_strcmp0(key, FU_QUIRKS_PLUGIN) == 0) {
 		g_auto(GStrv) sections = g_strsplit(value, ",", -1);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1098,6 +1098,7 @@ LIBFWUPDPLUGIN_1.8.4 {
 
 LIBFWUPDPLUGIN_1.8.5 {
   global:
+    fu_device_set_quirk_kv;
     fu_intel_thunderbolt_firmware_get_type;
     fu_intel_thunderbolt_firmware_new;
     fu_intel_thunderbolt_nvm_get_device_id;


### PR DESCRIPTION
This seems like a useful thing regardless.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
