### PR TITLE
ccgx: Write all the metadata block as intended

### DIFF
--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1218,7 +1218,7 @@ fu_ccgx_hpi_load_metadata(FuCcgxHpiDevice *self,
 			      buf,
 			      self->flash_row_size,
 			      md_offset,
-			      sizeof(metadata),
+			      sizeof(*metadata),
 			      error);
 }
 
@@ -1247,7 +1247,7 @@ fu_ccgx_hpi_save_metadata(FuCcgxHpiDevice *self,
 			    (guint8 *)metadata,
 			    sizeof(*metadata),
 			    0x0,
-			    sizeof(metadata),
+			    sizeof(*metadata),
 			    error))
 		return FALSE;
 	if (!fu_ccgx_hpi_write_flash(self, addr, buf, self->flash_row_size, error)) {


### PR DESCRIPTION
PVS: It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'metadata' class object.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
