### PR TITLE
vbe: Fix a crash when dumping firmware

### DIFF
--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -388,7 +388,7 @@ fu_vbe_simple_device_upload(FuDevice *device, FuProgress *progress, GError **err
 {
 	FuVbeSimpleDevice *self = FU_VBE_SIMPLE_DEVICE(device);
 	gssize rc;
-	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GPtrArray) chunks = NULL;
 
 	/* notify UI */


### PR DESCRIPTION
PVS: The null pointer is passed into 'g_byte_array_append' function.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
