### PR TITLE
mtd: expose Pine64 PinePhone Pro MTD as Tow-Boot

### DIFF
--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -1,2 +1,6 @@
 [MTD]
 Plugin = mtd
+
+[MTD\VENDOR_PINE64&PRODUCT_PinePhone-Pro&NAME_spi1.0]
+Name = Tow-Boot platform firmware
+FirmwareGType = FuUswidFirmware


### PR DESCRIPTION
Pine64 PinePhone Pro has an SPI device which is handled by the MTD plugin and comes with Tow-Boot pre-installed from the factory. Expose it as Tow-Boot and mark the firmware type with uSWID for version extraction. However, it does not provide uSWID data so users have to manually upgrade to a Tow-Boot version with uSWID data support first.

Depends on a fix for #5021 first, fix available in #5023

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
