### PR TITLE
fwupd: Drop unsupported xml_declaration parameter

### DIFF
--- a/contrib/generate-gresource-xml.py
+++ b/contrib/generate-gresource-xml.py
@@ -23,6 +23,6 @@ for fn in sorted(sys.argv[2:]):
         n_file.set("preprocess", "xml-stripblanks")
     n_file.set("alias", os.path.basename(fn))
 with open(sys.argv[1], "wb") as f:
-    f.write(ET.tostring(root, "utf-8", xml_declaration=True))
+    f.write(ET.tostring(root, "utf-8"))
 
 sys.exit(0)


### PR DESCRIPTION
This is not needed on Python3.7

Fixes
wupd-1.8.4/contrib/generate-gresource-xml.py", line 26, in <module>
    f.write(ET.tostring(root, "utf-8", xml_declaration=True))
TypeError: tostring() got an unexpected keyword argument 'xml_declaration'

Signed-off-by: Khem Raj <raj.khem@gmail.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
