### PR TITLE
trivial: fu-util-common: RO devices w/ FW versions are interesting

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -264,6 +264,8 @@ fu_util_is_interesting_device(FwupdDevice *dev)
 		return TRUE;
 	if (fwupd_device_get_update_error(dev) != NULL)
 		return TRUE;
+	if (fwupd_device_get_version(dev) != NULL)
+		return TRUE;
 	/* device not plugged in, get-details */
 	if (fwupd_device_get_flags(dev) == 0)
 		return TRUE;


### PR DESCRIPTION
Sometimes even if fwupd can't upgrade these devices they're interesting to end users because they may show information that can otherwise only be obtained by tearing apart firmware or using extra arguments.

Amend the default behavior to let these show up.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
