### PR TITLE
pixart-rf: Fix the endianness of the magic

### DIFF
--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -47,7 +47,7 @@ fu_pxi_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GErr
 				    g_bytes_get_size(fw) - PIXART_RF_FW_HEADER_SIZE +
 					PIXART_RF_FW_HEADER_TAG_OFFSET,
 				    &magic,
-				    G_LITTLE_ENDIAN,
+				    G_BIG_ENDIAN,
 				    error)) {
 		g_prefix_error(error, "failed to read magic: ");
 		return FALSE;

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -21,6 +21,8 @@ fu_pxi_firmware_xml_func(void)
 	g_autofree gchar *xml_src = NULL;
 	g_autoptr(FuFirmware) firmware1 = fu_pxi_firmware_new();
 	g_autoptr(FuFirmware) firmware2 = fu_pxi_firmware_new();
+	g_autoptr(FuFirmware) firmware3 = fu_pxi_firmware_new();
+	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -31,9 +33,17 @@ fu_pxi_firmware_xml_func(void)
 	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	fw = fu_firmware_write(firmware1, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(fw);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+
+	/* ensure we can parse */
+	ret = fu_firmware_parse(firmware3, fw, FWUPD_INSTALL_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);


### PR DESCRIPTION
This was probably broken in https://github.com/fwupd/fwupd/commit/0c51630991725d29255a4e4774f92185f6a24aaa

Mea culpa.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
