### PR TITLE
android-boot: support eMMC boot partitions

### DIFF
--- a/plugins/android-boot/README.md
+++ b/plugins/android-boot/README.md
@@ -24,6 +24,12 @@ when using an Android A/B partitioning scheme, e.g.
 * `DRIVE\UUID_c49183ed-aaec-9bf5-760a-66330fbcffc1&LABEL_label`
 * `DRIVE\UUID_c49183ed-aaec-9bf5-760a-66330fbcffc1`
 
+For some devices with eMMC boot partitions, we cannot use UUIDs or labels as they do not contain a partition
+table since the firmware is flashed already at offset 0 of the block device.
+To support such devices, a combination of the block device name, path, hardware name is used:
+
+* `DRIVE\DEVNAME_dev-mmcblk2boot0&ID_PATH=platform-1c11000_mmc&ID_NAME_DA4032`
+
 ## Update Behavior
 
 The block device is erased in chunks, written and then read back to verify.

--- a/plugins/android-boot/android-boot.quirk
+++ b/plugins/android-boot/android-boot.quirk
@@ -14,3 +14,13 @@ Flags = updatable,signed-payload
 Vendor = SHIFT GmbH
 VendorId = eco.shift
 AndroidBootVersionProperty = androidboot.abl.revision
+
+# Pine64 PinePhone eMMC boot partition 0
+[DRIVE\DEVNAME_dev-mmcblk2boot0&ID_PATH_platform-1c11000.mmc&ID_NAME_DA4032]
+Name = Tow-Boot platform firmware
+Summary = Tow-Boot platform firmware
+Flags = updatable
+Vendor = Tow-Boot
+VendorId = org.tow-boot
+FirmwareGType = FuUswidFirmware
+AndroidBootPartitionMaxSize = 1000000

--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -4,3 +4,5 @@ Plugin = mtd
 [MTD\VENDOR_PINE64&PRODUCT_PinePhone-Pro&NAME_spi1.0]
 Name = Tow-Boot platform firmware
 FirmwareGType = FuUswidFirmware
+Vendor = Tow-Boot
+VendorId = org.tow-boot


### PR DESCRIPTION
eMMC boot partitions are commonly found in eMMCs to write platform firmware on like Tow-Boot.
This way, users can install their distro without having to deal with bootloaders embedded into the distro image.

- These partitions do not contain a partition table so we need to identify them differently, added a new GUID for this.
- Such partitions can only be written if `force_ro` is set to 0 in sysfs, do this when flashing firmware.
- Tow-Boot leverages uSWID for version information, add version extraction for this to the plugin based upon the MTD plugin.

Would be great to have this in before the next release so it lands before the freeze of the next Alpine stable.

```
pine64-pinephone:~$ fwupdmgr get-devices
WARNING: This package has not been validated, it may not work properly.
pine64 Pine64 PinePhone (1.2)
│
├─QUECTEL Mobile Broadband Module:
│     Device ID:          976c4a39e87f61e6940ea6a8d39c583cfa99615f
│     Summary:            Quectel EG25-G modem
│     Current version:    0.6.8
│     Vendor:             Qualcomm (USB:0x2C7C)
│     Release Branch:     community
│     GUIDs:              db379a33-254f-5140-b37e-d36ae7e5c039
│                         d18f31f1-a3fa-55a2-b4ed-decfbc1e004d ← USB\VID_2C7C&PID_0125&REV_0318&NAME_EG25GGB
│                         1a2996cb-f86e-5583-a464-e1b96e1c6ae9 ← USB\VID_2C7C&PID_0125&REV_0318
│                         587bf468-6859-5522-93a7-6cce552a0aa3 ← USB\VID_2C7C&PID_0125
│                         22ae45db-f68e-5c55-9c02-4557dca238ec ← USB\VID_2C7C
│     Device Flags:       • Updatable
│                         • System requires external power source
│   
└─Tow-Boot platform firmware:
      Device ID:          10dd409c2799697c90ebca1a12c460ad0cbbf1eb
      Summary:            Tow-Boot platform firmware
      Current version:    2021.10-005
      Vendor:             Tow-Boot (org.tow-boot)
      GUID:               c96f594a-8b9e-5ee8-bae2-74c1b1355877 ← DRIVE\DEVNAME_dev-mmcblk2boot0&ID_PATH_platform-1c11000.mmc&ID_NAME_DA4032
      Device Flags:       • Internal device
                          • Updatable
                          • System requires external power source
                          • Needs a reboot after installation
                          • Cryptographic hash verification is available
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
