### PR TITLE
Add functionality to finalize Wacom EMR devices

### DIFF
--- a/plugins/wacom-raw/fu-wacom-device.h
+++ b/plugins/wacom-raw/fu-wacom-device.h
@@ -19,6 +19,7 @@ struct _FuWacomDeviceClass {
 				   GPtrArray *chunks,
 				   FuProgress *progress,
 				   GError **error);
+	gboolean (*attach)(FuDevice *self, GError **error);
 };
 
 typedef enum {

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -136,6 +136,25 @@ fu_wacom_device_w9021_erase_all(FuWacomEmrDevice *self, GError **error)
 }
 
 static gboolean
+fu_wacom_emr_device_attach(FuDevice *device, GError **error)
+{
+	FuWacomDevice *self = FU_WACOM_DEVICE(device);
+	FuWacomRawRequest req = {.report_id = FU_WACOM_RAW_BL_REPORT_ID_SET,
+				 .cmd = FU_WACOM_RAW_BL_CMD_ATTACH,
+				 .echo = FU_WACOM_RAW_ECHO_DEFAULT,
+				 0x00};
+
+	if (!fu_wacom_device_set_feature(self, (const guint8 *)&req, sizeof(req), error)) {
+		g_prefix_error(error, "failed to switch to runtime mode: ");
+		return FALSE;
+	}
+
+	fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+
+	return TRUE;
+}
+
+static gboolean
 fu_wacom_emr_device_write_block(FuWacomEmrDevice *self,
 				guint32 idx,
 				guint32 address,
@@ -258,6 +277,7 @@ fu_wacom_emr_device_class_init(FuWacomEmrDeviceClass *klass)
 	FuWacomDeviceClass *klass_wac_device = FU_WACOM_DEVICE_CLASS(klass);
 	klass_device->setup = fu_wacom_emr_device_setup;
 	klass_wac_device->write_firmware = fu_wacom_emr_device_write_firmware;
+	klass_wac_device->attach = fu_wacom_emr_device_attach;
 }
 
 FuWacomEmrDevice *


### PR DESCRIPTION
This change is required for Wacom EMR devices
to be flashed properly.

Signed-off-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>
Tested-by: Tatsunosuke Tobita <tatsunosuke.tobita@wacom.com>

*This is the related feature for the commit, "G14t compatibility #5033".

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
