### PR TITLE
redfish: Set the permissions of redfish.conf at install time

### DIFF
--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -44,6 +44,7 @@ shared_module('fu_plugin_redfish',
 
 install_data(['redfish.conf'],
   install_dir: join_paths(sysconfdir, 'fwupd'),
+  install_mode: 'rw-r-----',
 )
 
 if get_option('tests')


### PR DESCRIPTION
Although typically we set the password using fu_plugin_set_secure_config_value() or something like Ansible or Puppet -- the user could just edit the file with vim and we still want the permissions set correctly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
