### PR TITLE
Move the getting the ESP to the context

### DIFF
--- a/contrib/ci/check-headers.py
+++ b/contrib/ci/check-headers.py
@@ -66,7 +66,7 @@ def test_files() -> int:
         if (
             fn.startswith("plugins")
             and not fn.endswith("self-test.c")
-            and not fn.endswith("-tool.c")
+            and not fn.endswith("tool.c")
         ):
             for include in includes:
                 # check for using private header use in plugins

--- a/contrib/migrate.py
+++ b/contrib/migrate.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
             "fu_common_get_volume_by_device": "fu_volume_new_by_device",
             "fu_common_get_volume_by_devnum": "fu_volume_new_by_devnum",
             "fu_common_get_esp_for_path": "fu_volume_new_esp_for_path",
-            "fu_common_get_esp_default": "fu_volume_new_esp_default",
+            "fu_common_get_esp_default": "fu_context_get_esp_volumes",
             "fu_smbios_to_string": "fu_firmware_to_string",
             "fu_i2c_device_read_full": "fu_i2c_device_read",
             "fu_i2c_device_write_full": "fu_i2c_device_write",

--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -60,6 +60,10 @@ TrustedUids=
 # config level. e.g. `vendor-factory-2021q1`
 HostBkc=
 
+# The EFI system partition (ESP) path used if UDisks is not available
+# or if this partition is not mounted at /boot/efi, /boot, or /efi
+#EspLocation=
+
 # these are only required when the SMBIOS or Device Tree data is invalid or missing
 #Manufacturer=
 #ProductName=

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -94,3 +94,7 @@ Remember: Plugins should be upstream!
 * `fu_i2c_device_read_full()`: Use `fu_i2c_device_read` instead.
 * `fu_i2c_device_write_full()`: Use `fu_i2c_device_write` instead.
 * `fu_firmware_parse_full()`: Remove the `addr_end` parameter, and ensure that `offset` is a `gsize`.
+
+## 1.8.5
+
+* `fu_volume_new_esp_default()`: Use `fu_context_get_esp_volumes()` instead.

--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -9,6 +9,7 @@
 #include "fu-context.h"
 #include "fu-hwids.h"
 #include "fu-quirks.h"
+#include "fu-volume.h"
 
 FuContext *
 fu_context_new(void);
@@ -32,3 +33,5 @@ void
 fu_context_add_udev_subsystem(FuContext *self, const gchar *subsystem);
 GPtrArray *
 fu_context_get_udev_subsystems(FuContext *self);
+void
+fu_context_add_esp_volume(FuContext *self, FuVolume *volume);

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -123,3 +123,6 @@ gboolean
 fu_context_get_bios_setting_pending_reboot(FuContext *self);
 FwupdBiosSetting *
 fu_context_get_bios_setting(FuContext *self, const gchar *name);
+
+GPtrArray *
+fu_context_get_esp_volumes(FuContext *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -60,7 +60,7 @@ FuVolume *
 fu_volume_new_by_devnum(guint32 devnum, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 FuVolume *
 fu_volume_new_esp_for_path(const gchar *esp_path, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+G_DEPRECATED_FOR(fu_context_get_esp_volumes)
 FuVolume *
 fu_volume_new_esp_default(GError **error) G_GNUC_WARN_UNUSED_RESULT;
-GPtrArray *
-fu_volume_new_by_esp(GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1100,7 +1100,9 @@ LIBFWUPDPLUGIN_1.8.5 {
   global:
     fu_backend_load;
     fu_backend_save;
+    fu_context_add_esp_volume;
     fu_context_add_flag;
+    fu_context_get_esp_volumes;
     fu_context_has_flag;
     fu_device_add_backend_tag;
     fu_device_get_backend_tags;
@@ -1125,6 +1127,5 @@ LIBFWUPDPLUGIN_1.8.5 {
     fu_usb_device_fw_ds20_new;
     fu_usb_device_ms_ds20_get_type;
     fu_usb_device_ms_ds20_new;
-    fu_volume_new_by_esp;
   local: *;
 } LIBFWUPDPLUGIN_1.8.4;

--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -106,7 +106,7 @@ support on the device by using the `unlock` command.
 Since version 1.1.0 fwupd will autodetect the ESP if it is mounted on
 `/boot/efi`, `/boot`, or `/efi`, and UDisks is available on the system. In
 other cases the mount point of the ESP needs to be manually specified using the
-option *OverrideESPMountPoint* in `/etc/fwupd/uefi_capsule.conf`.
+option *EspLocation* in `/etc/fwupd/daemon.conf`.
 
 Setting an invalid directory will disable the fwupd plugin.
 

--- a/plugins/uefi-capsule/uefi_capsule.conf
+++ b/plugins/uefi-capsule/uefi_capsule.conf
@@ -7,10 +7,6 @@
 # the fwupd.efi file has been self-signed manually
 #DisableShimForSecureBoot=true
 
-# the EFI system partition (ESP) path used if UDisks is not available
-# or if this partition is not mounted at /boot/efi, /boot, or /efi
-#OverrideESPMountPoint=
-
 # amount of free space required on the ESP, for example using 0x2000000 for 32Mb
 #RequireESPFreeSpace=
 

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.c
@@ -80,10 +80,10 @@ fu_uefi_dbx_signature_list_validate_volume(FuEfiSignatureList *siglist,
 }
 
 gboolean
-fu_uefi_dbx_signature_list_validate(FuEfiSignatureList *siglist, GError **error)
+fu_uefi_dbx_signature_list_validate(FuContext *ctx, FuEfiSignatureList *siglist, GError **error)
 {
 	g_autoptr(GPtrArray) volumes = NULL;
-	volumes = fu_volume_new_by_esp(error);
+	volumes = fu_context_get_esp_volumes(ctx, error);
 	if (volumes == NULL)
 		return FALSE;
 	for (guint i = 0; i < volumes->len; i++) {

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.h
@@ -11,4 +11,4 @@
 gchar *
 fu_uefi_dbx_get_authenticode_hash(const gchar *fn, GError **error);
 gboolean
-fu_uefi_dbx_signature_list_validate(FuEfiSignatureList *siglist, GError **error);
+fu_uefi_dbx_signature_list_validate(FuContext *ctx, FuEfiSignatureList *siglist, GError **error);

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -73,6 +73,7 @@ fu_uefi_dbx_device_set_version_number(FuDevice *device, GError **error)
 static FuFirmware *
 fu_uefi_dbx_prepare_firmware(FuDevice *device, GBytes *fw, FwupdInstallFlags flags, GError **error)
 {
+	FuContext *ctx = fu_device_get_context(device);
 	g_autoptr(FuFirmware) siglist = fu_efi_signature_list_new();
 
 	/* parse dbx */
@@ -82,7 +83,9 @@ fu_uefi_dbx_prepare_firmware(FuDevice *device, GBytes *fw, FwupdInstallFlags fla
 	/* validate this is safe to apply */
 	if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		//		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
-		if (!fu_uefi_dbx_signature_list_validate(FU_EFI_SIGNATURE_LIST(siglist), error)) {
+		if (!fu_uefi_dbx_signature_list_validate(ctx,
+							 FU_EFI_SIGNATURE_LIST(siglist),
+							 error)) {
 			g_prefix_error(error,
 				       "Blocked executable in the ESP, "
 				       "ensure grub and shim are up to date: ");

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -32,6 +32,7 @@ struct _FuConfig {
 	guint64 archive_size_max;
 	guint idle_timeout;
 	gchar *host_bkc;
+	gchar *esp_location;
 	gboolean update_motd;
 	gboolean enumerate_all_devices;
 	gboolean ignore_power;
@@ -61,6 +62,7 @@ fu_config_reload(FuConfig *self, GError **error)
 	g_auto(GStrv) plugins = NULL;
 	g_autofree gchar *domains = NULL;
 	g_autofree gchar *host_bkc = NULL;
+	g_autofree gchar *esp_location = NULL;
 	g_autoptr(GKeyFile) keyfile = g_key_file_new();
 	g_autoptr(GError) error_update_motd = NULL;
 	g_autoptr(GError) error_ignore_power = NULL;
@@ -240,6 +242,11 @@ fu_config_reload(FuConfig *self, GError **error)
 	host_bkc = g_key_file_get_string(keyfile, "fwupd", "HostBkc", NULL);
 	if (host_bkc != NULL && host_bkc[0] != '\0')
 		self->host_bkc = g_steal_pointer(&host_bkc);
+
+	/* fetch hardcoded ESP mountpoint */
+	esp_location = g_key_file_get_string(keyfile, "fwupd", "EspLocation", NULL);
+	if (esp_location != NULL && esp_location[0] != '\0')
+		self->esp_location = g_steal_pointer(&esp_location);
 
 	/* get trusted uids */
 	g_array_set_size(self->trusted_uids, 0);
@@ -444,6 +451,13 @@ fu_config_get_host_bkc(FuConfig *self)
 	return self->host_bkc;
 }
 
+const gchar *
+fu_config_get_esp_location(FuConfig *self)
+{
+	g_return_val_if_fail(FU_IS_CONFIG(self), NULL);
+	return self->esp_location;
+}
+
 static void
 fu_config_class_init(FuConfigClass *klass)
 {
@@ -499,6 +513,7 @@ fu_config_finalize(GObject *obj)
 	g_ptr_array_unref(self->uri_schemes);
 	g_array_unref(self->trusted_uids);
 	g_free(self->host_bkc);
+	g_free(self->esp_location);
 
 	G_OBJECT_CLASS(fu_config_parent_class)->finalize(obj);
 }

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -46,3 +46,5 @@ gboolean
 fu_config_get_show_device_private(FuConfig *self);
 const gchar *
 fu_config_get_host_bkc(FuConfig *self);
+const gchar *
+fu_config_get_esp_location(FuConfig *self);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2996,14 +2996,15 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 }
 
 static FuVolume *
-fu_util_prompt_for_volume(GError **error)
+fu_util_prompt_for_volume(FuUtilPrivate *priv, GError **error)
 {
+	FuContext *ctx = fu_engine_get_context(priv->engine);
 	FuVolume *volume;
 	guint idx;
 	g_autoptr(GPtrArray) volumes = NULL;
 
 	/* exactly one */
-	volumes = fu_volume_new_by_esp(error);
+	volumes = fu_context_get_esp_volumes(ctx, error);
 	if (volumes == NULL)
 		return NULL;
 	if (volumes->len == 1) {
@@ -3037,7 +3038,7 @@ static gboolean
 fu_util_esp_mount(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FuVolume) volume = NULL;
-	volume = fu_util_prompt_for_volume(error);
+	volume = fu_util_prompt_for_volume(priv, error);
 	if (volume == NULL)
 		return FALSE;
 	return fu_volume_mount(volume, error);
@@ -3047,7 +3048,7 @@ static gboolean
 fu_util_esp_unmount(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FuVolume) volume = NULL;
-	volume = fu_util_prompt_for_volume(error);
+	volume = fu_util_prompt_for_volume(priv, error);
 	if (volume == NULL)
 		return FALSE;
 	return fu_volume_unmount(volume, error);
@@ -3061,7 +3062,7 @@ fu_util_esp_list(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuVolume) volume = NULL;
 	g_autoptr(GPtrArray) files = NULL;
 
-	volume = fu_util_prompt_for_volume(error);
+	volume = fu_util_prompt_for_volume(priv, error);
 	if (volume == NULL)
 		return FALSE;
 	locker = fu_volume_locker(volume, error);


### PR DESCRIPTION
We now have two plugins getting the ESP values, and we only allow hardcoding the ESP in uefi_capsule.conf. We also have *another* override in the `FWUPD_UEFI_ESP_PATH` environment variable.

Make all this a lot simpler by moving the ESP+BDP code to `FuContext`, which also means we can handle the override (via the config file) in the engine, and the override (in the command line tools) using the same mechanism.

Also, automate the migration of the `OverrideESPMountPoint` -> `EspLocation` when loading the engine.

Fixes https://github.com/fwupd/fwupd/issues/5042

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
