### PR TITLE
redfish: Only create users using IPMI when we know it's going to work

### DIFF
--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -436,6 +436,14 @@ fu_plugin_redfish_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 #ifdef HAVE_LINUX_IPMI_H
 	/* we got neither a type 42 entry or config value, lets try IPMI */
 	if (fu_redfish_backend_get_username(priv->backend) == NULL) {
+		if (!fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "ipmi-create-user")) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "no username and password specified, "
+					    "and no vendor quirk for 'ipmi-create-user'");
+			return FALSE;
+		}
 		if (!fu_plugin_get_config_value_boolean(plugin, "IpmiDisableCreateUser")) {
 			g_debug("attempting to create user using IPMI");
 			if (!fu_redfish_plugin_ipmi_create_user(plugin, error))

--- a/plugins/redfish/redfish.quirk
+++ b/plugins/redfish/redfish.quirk
@@ -1,6 +1,6 @@
 # Lenovo ThinkSystem
 [42f00735-c9ab-5374-bd63-a5deee5881e0]
-Flags = wildcard-targets,reset-required
+Flags = wildcard-targets,reset-required,ipmi-create-user
 
 [REDFISH\VENDOR_Lenovo&ID_BMC-Backup]
 ParentGuid = REDFISH\VENDOR_Lenovo&ID_BMC-Primary


### PR DESCRIPTION
Make the IPMI auto-account feature allow-listed on specific vendors as some IPMI implementations are not specification compliant and do entirely the wrong thing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
