### PR TITLE
trivial: Install the devhelp symlinks relative

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -82,10 +82,10 @@ if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() 
   #make devhelp work
   install_symlink('libfwupd',
     install_dir: join_paths(datadir, 'doc', 'fwupd'),
-    pointing_to: join_paths(datadir, 'doc', 'libfwupd'),
+    pointing_to: join_paths('..', 'libfwupd'),
   )
   install_symlink('libfwupdplugin',
     install_dir: join_paths(datadir, 'doc', 'fwupd'),
-    pointing_to: join_paths(datadir, 'doc', 'libfwupdplugin'),
+    pointing_to: join_paths('..', 'libfwupdplugin'),
   )
 endif


### PR DESCRIPTION
We want /usr/share/docs/fwupd/libfwupd for the docs that can be referenced from index.html, and a symlink of /usr/share/docs/libfwupd for devhelp.

This fixes the rpmbuild warning:

    # absolute symlink: /usr/share/doc/fwupd/libfwupd -> /usr/share/doc/libfwupd
    # absolute symlink: /usr/share/doc/fwupd/libfwupdplugin -> /usr/share/doc/libfwupdplugin

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
