### PR TITLE
trivial: skip self tests for fwupd_client_remotes_func if G_DBUS_ERRO…

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -983,6 +983,7 @@ fwupd_client_devices_func(void)
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect(client, NULL, &error);
 	if (ret == FALSE && (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER) ||
 			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))) {
 		g_debug("%s", error->message);
 		g_test_skip("timeout connecting to daemon");
@@ -1038,6 +1039,7 @@ fwupd_client_remotes_func(void)
 	/* only run if running fwupd is new enough */
 	ret = fwupd_client_connect(client, NULL, &error);
 	if (ret == FALSE && (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_TIMED_OUT) ||
+			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER) ||
 			     g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN))) {
 		g_debug("%s", error->message);
 		g_test_skip("timeout connecting to daemon");


### PR DESCRIPTION
…R_NAME_HAS_NO_OWNER

Fixes: #5073

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
