### PR TITLE
android-boot: set default version format

### DIFF
--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -358,6 +358,7 @@ fu_android_boot_device_init(FuAndroidBootDevice *self)
 	 * will disappear. If version reporting is available, the reported version is set.
 	 */
 	fu_device_set_version(FU_DEVICE(self), ANDROID_BOOT_UNKNOWN_VERSION);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 }
 
 static void


### PR DESCRIPTION
In case no version is found, android-boot plugin uses a fall back version (0.0.0) but no version format is set. Therefore, fwupd uses format 'plain' as default which is not correct as 0.0.0 is a triplet.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
