### PR TITLE
trivial: Always use g_assert_no_error() first

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -1178,8 +1178,8 @@ fwupd_common_guid_func(void)
 				     &buf,
 				     FWUPD_GUID_FLAG_NONE,
 				     &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	g_assert_cmpint(memcmp(buf,
 			       "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
 			       sizeof(buf)),
@@ -1193,8 +1193,8 @@ fwupd_common_guid_func(void)
 				     &buf,
 				     FWUPD_GUID_FLAG_MIXED_ENDIAN,
 				     &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	g_assert_cmpint(memcmp(buf,
 			       "\x33\x22\x11\x00\x55\x44\x77\x66\x88\x99\xaa\xbb\xcc\xdd\xee\xff",
 			       sizeof(buf)),

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -425,8 +425,8 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 	ret = fu_plugin_dell_backend_device_added(self->plugin_dell,
 						  FU_DEVICE(fake_usb_device),
 						  &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	g_assert_cmpint(devices->len, ==, 3);
 	g_ptr_array_set_size(devices, 0);
 	g_free(buf.record);
@@ -462,8 +462,8 @@ fu_plugin_dell_dock_func(gconstpointer user_data)
 	ret = fu_plugin_dell_backend_device_added(self->plugin_dell,
 						  FU_DEVICE(fake_usb_device),
 						  &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	g_assert_cmpint(devices->len, ==, 2);
 	g_ptr_array_set_size(devices, 0);
 	g_free(buf.record);

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -50,8 +50,8 @@ fu_test_self_init(FuTest *self, GError **error_global)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	ret = fu_context_reload_bios_settings(ctx, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	g_test_assert_expected_messages();
 
 	self->plugin_uefi_capsule = fu_plugin_new(ctx);
@@ -124,8 +124,8 @@ fu_plugin_lenovo_thinklmi_bootorder_locked(gconstpointer user_data)
 	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 
 	ret = fu_context_reload_bios_settings(self->ctx, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	dev = fu_test_probe_fake_esrt(self);
 	fu_plugin_runner_device_register(self->plugin_lenovo_thinklmi, dev);
@@ -144,8 +144,8 @@ fu_plugin_lenovo_thinklmi_bootorder_unlocked(gconstpointer user_data)
 	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 
 	ret = fu_context_reload_bios_settings(self->ctx, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	dev = fu_test_probe_fake_esrt(self);
 	fu_plugin_runner_device_register(self->plugin_lenovo_thinklmi, dev);
 	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE));
@@ -166,8 +166,8 @@ fu_plugin_lenovo_thinklmi_reboot_pending(gconstpointer user_data)
 	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 
 	ret = fu_context_reload_bios_settings(self->ctx, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 	dev = fu_test_probe_fake_esrt(self);
 	fu_plugin_runner_device_register(self->plugin_lenovo_thinklmi, dev);
 	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE_HIDDEN));

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1078,8 +1078,8 @@ test_image_validation(ThunderboltTest *tt, gconstpointer user_data)
 
 	/* parse controller image */
 	ret = fu_firmware_parse(firmware_ctl, ctl_data, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* valid firmware update image */
 	fwi_path = g_test_build_filename(G_TEST_DIST, "tests", "minimal-fw.bin", NULL);
@@ -1092,8 +1092,8 @@ test_image_validation(ThunderboltTest *tt, gconstpointer user_data)
 
 	/* parse */
 	ret = fu_firmware_parse(firmware_fwi, fwi_data, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* a wrong/bad firmware update image */
 	bad_path = g_test_build_filename(G_TEST_DIST, "tests", "colorhug.bin", NULL);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -193,8 +193,8 @@ fu_plugin_hash_func(gconstpointer user_data)
 					 "libfu_plugin_invalid." G_MODULE_SUFFIX,
 					 NULL);
 	ret = fu_plugin_open(plugin, pluginfn, &error);
-	g_assert_true(ret);
 	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* make sure it tainted now */
 	g_test_expect_message("FuEngine", G_LOG_LEVEL_WARNING, "* has incorrect built version*");


### PR DESCRIPTION
It's way more helpful to print the GError message than just an boolean failure.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
