### PR TITLE
trivial: Speed up the build by about 9%

### DIFF
--- a/libfwupdplugin/fu-common-private.h
+++ b/libfwupdplugin/fu-common-private.h
@@ -17,7 +17,3 @@ GPtrArray *
 fu_common_get_block_devices(GError **error);
 guint64
 fu_common_get_memory_size_impl(void);
-
-/* for self tests */
-const gchar *
-fu_common_convert_to_gpt_type(const gchar *type);

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -141,26 +141,6 @@ fu_common_get_memory_size(void)
 	return fu_common_get_memory_size_impl();
 }
 
-const gchar *
-fu_common_convert_to_gpt_type(const gchar *type)
-{
-	struct {
-		const gchar *gpt;
-		const gchar *mbrs[6];
-	} typeguids[] = {{"c12a7328-f81f-11d2-ba4b-00a0c93ec93b", /* esp */
-			  {"0xef", "efi", NULL}},
-			 {"ebd0a0a2-b9e5-4433-87c0-68b6b72699c7", /* fat32 */
-			  {"0x0b", "0x06", "vfat", "fat32", "fat32lba", NULL}},
-			 {NULL, {NULL}}};
-	for (guint i = 0; typeguids[i].gpt != NULL; i++) {
-		for (guint j = 0; typeguids[i].mbrs[j] != NULL; j++) {
-			if (g_strcmp0(type, typeguids[i].mbrs[j]) == 0)
-				return typeguids[i].gpt;
-		}
-	}
-	return type;
-}
-
 /**
  * fu_common_check_full_disk_encryption:
  * @error: (nullable): optional return location for an error

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -130,18 +130,18 @@ fu_archive_cab_func(void)
 }
 
 static void
-fu_common_gpt_type_func(void)
+fu_volume_gpt_type_func(void)
 {
-	g_assert_cmpstr(fu_common_convert_to_gpt_type("0xef"),
+	g_assert_cmpstr(fu_volume_kind_convert_to_gpt("0xef"),
 			==,
 			"c12a7328-f81f-11d2-ba4b-00a0c93ec93b");
-	g_assert_cmpstr(fu_common_convert_to_gpt_type("0x0b"),
+	g_assert_cmpstr(fu_volume_kind_convert_to_gpt("0x0b"),
 			==,
 			"ebd0a0a2-b9e5-4433-87c0-68b6b72699c7");
-	g_assert_cmpstr(fu_common_convert_to_gpt_type("fat32lba"),
+	g_assert_cmpstr(fu_volume_kind_convert_to_gpt("fat32lba"),
 			==,
 			"ebd0a0a2-b9e5-4433-87c0-68b6b72699c7");
-	g_assert_cmpstr(fu_common_convert_to_gpt_type("0x00"), ==, "0x00");
+	g_assert_cmpstr(fu_volume_kind_convert_to_gpt("0x00"), ==, "0x00");
 }
 
 static void
@@ -3666,7 +3666,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/backend", fu_backend_func);
 	g_test_add_func("/fwupd/chunk", fu_chunk_func);
 	g_test_add_func("/fwupd/common{align-up}", fu_common_align_up_func);
-	g_test_add_func("/fwupd/common{gpt-type}", fu_common_gpt_type_func);
+	g_test_add_func("/fwupd/volume{gpt-type}", fu_volume_gpt_type_func);
 	g_test_add_func("/fwupd/common{byte-array}", fu_common_byte_array_func);
 	g_test_add_func("/fwupd/common{crc}", fu_common_crc_func);
 	g_test_add_func("/fwupd/common{string-append-kv}", fu_string_append_func);

--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -60,3 +60,5 @@ FuVolume *
 fu_volume_new_by_devnum(guint32 devnum, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 FuVolume *
 fu_volume_new_esp_for_path(const gchar *esp_path, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+const gchar *
+fu_volume_kind_convert_to_gpt(const gchar *kind);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1132,5 +1132,6 @@ LIBFWUPDPLUGIN_1.8.6 {
   global:
     fu_plugin_new_from_gtype;
     fu_plugin_set_context;
+    fu_volume_kind_convert_to_gpt;
   local: *;
 } LIBFWUPDPLUGIN_1.8.5;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -354,7 +354,6 @@ if get_option('tests')
     'fwupdplugin-self-test',
     test_deps,
     sources: [
-      fwupdplugin_src,
       'fu-self-test.c'
     ],
     include_directories: [


### PR DESCRIPTION
Only build libfwupdplugin source files once; we were only using one non-exported symbol and so move that to the exported map so we can just link the library in the self tests.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
