### PR TITLE
Only include the last 5 releases in the installed metainfo file

### DIFF
--- a/contrib/generate-metainfo.py
+++ b/contrib/generate-metainfo.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+# pylint: disable=invalid-name,missing-docstring
+#
+# Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+
+import argparse
+import xml.etree.ElementTree as ET
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r",
+        "--releases",
+        type=int,
+        default=5,
+    )
+    parser.add_argument(
+        "filename_src", action="store", type=str, help="metainfo source"
+    )
+    parser.add_argument(
+        "filename_dst", action="store", type=str, help="metainfo destination"
+    )
+    args = parser.parse_args()
+
+    tree = ET.parse(args.filename_src)
+    root = tree.getroot().findall("releases")[0]
+    for release in root.findall("release")[args.releases :]:
+        root.remove(release)
+
+    with open(args.filename_dst, "wb") as f:
+        tree.write(f, encoding="UTF-8", xml_declaration=True)

--- a/data/meson.build
+++ b/data/meson.build
@@ -35,8 +35,17 @@ if build_standalone
 endif
 
 if get_option('metainfo')
-  install_data(['org.freedesktop.fwupd.metainfo.xml'],
-    install_dir: join_paths(datadir, 'metainfo')
+  custom_target('metainfo',
+    input: 'org.freedesktop.fwupd.metainfo.xml',
+    output: 'org.freedesktop.fwupd.metainfo.xml',
+    command: [
+      python3,
+      join_paths(meson.project_source_root(), 'contrib', 'generate-metainfo.py'),
+      '@INPUT@',
+      '@OUTPUT@',
+    ],
+    install: true,
+    install_dir: join_paths(datadir, 'metainfo'),
   )
   install_data(['org.freedesktop.fwupd.svg'],
     install_dir: join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps')


### PR DESCRIPTION
We have to include the entire history in git, and also to generate the NEWS file, but this reduces the size of the on-disk file by 116Kb.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
