### PR TITLE
Use a higher compression preset for the UEFI splash images

### DIFF
--- a/plugins/uefi-capsule/make-images.py
+++ b/plugins/uefi-capsule/make-images.py
@@ -91,7 +91,7 @@ def _cairo_surface_write_to_bmp(img: cairo.ImageSurface) -> bytes:
 def main(args) -> int:
 
     # open output archive
-    with tarfile.open(args.out, "w:xz") as tar:
+    with tarfile.open(args.out, "w:xz", preset=8) as tar:
 
         for lang in languages(args.podir):
             # these are the 1.6:1 of some common(ish) screen widths


### PR DESCRIPTION
This reduces the size of the archive by ~500Kb at the expense of taking a few seconds more to compress.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
