### PR TITLE
Support an enumerated release action for the post-update warning

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -746,6 +746,10 @@ fwupd_release_flag_to_string(FwupdReleaseFlags release_flag)
 		return "is-alternate-branch";
 	if (release_flag == FWUPD_RELEASE_FLAG_IS_COMMUNITY)
 		return "is-community";
+	if (release_flag == FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER)
+		return "do-not-unplug-power";
+	if (release_flag == FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG)
+		return "remove-replug";
 	return NULL;
 }
 
@@ -778,6 +782,10 @@ fwupd_release_flag_from_string(const gchar *release_flag)
 		return FWUPD_RELEASE_FLAG_IS_ALTERNATE_BRANCH;
 	if (g_strcmp0(release_flag, "is-community") == 0)
 		return FWUPD_RELEASE_FLAG_IS_COMMUNITY;
+	if (g_strcmp0(release_flag, "do-not-unplug-power") == 0)
+		return FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER;
+	if (g_strcmp0(release_flag, "remove-replug") == 0)
+		return FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG;
 	return FWUPD_RELEASE_FLAG_NONE;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -698,6 +698,26 @@ typedef guint64 FwupdDeviceProblem;
  */
 #define FWUPD_RELEASE_FLAG_IS_COMMUNITY (1u << 7)
 /**
+ * FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER:
+ *
+ * Show the user a message not to unplug the machine from the AC power, e.g.
+ *
+ * "Do not turn off your computer or remove the AC adaptor while the update is in progress."
+ *
+ * Since: 1.8.6
+ */
+#define FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER (1u << 8)
+/**
+ * FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG:
+ *
+ * Show the user a message to replug the USB cable, e.g.
+ *
+ * "The update will continue when the device USB cable is unplugged and then re-inserted."
+ *
+ * Since: 1.8.6
+ */
+#define FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG (1u << 9)
+/**
  * FWUPD_RELEASE_FLAG_UNKNOWN:
  *
  * The release flag is unknown, typically caused by using mismatched client and daemon.

--- a/libfwupd/fwupd-request.c
+++ b/libfwupd/fwupd-request.c
@@ -21,13 +21,23 @@
 typedef struct {
 	gchar *id;
 	FwupdRequestKind kind;
+	FwupdRequestFlags flags;
 	guint64 created;
 	gchar *device_id;
 	gchar *message;
 	gchar *image;
 } FwupdRequestPrivate;
 
-enum { PROP_0, PROP_ID, PROP_KIND, PROP_MESSAGE, PROP_IMAGE, PROP_DEVICE_ID, PROP_LAST };
+enum {
+	PROP_0,
+	PROP_ID,
+	PROP_KIND,
+	PROP_FLAGS,
+	PROP_MESSAGE,
+	PROP_IMAGE,
+	PROP_DEVICE_ID,
+	PROP_LAST
+};
 
 G_DEFINE_TYPE_WITH_PRIVATE(FwupdRequest, fwupd_request, G_TYPE_OBJECT)
 #define GET_PRIVATE(o) (fwupd_request_get_instance_private(o))
@@ -74,6 +84,44 @@ fwupd_request_kind_from_string(const gchar *kind)
 	if (g_strcmp0(kind, "immediate") == 0)
 		return FWUPD_REQUEST_KIND_IMMEDIATE;
 	return FWUPD_REQUEST_KIND_LAST;
+}
+
+/**
+ * fwupd_request_flag_to_string:
+ * @flag: a request flag, e.g. %FWUPD_REQUEST_FLAG_FORCE_GENERIC
+ *
+ * Converts an enumerated request flag to a string.
+ *
+ * Returns: identifier string
+ *
+ * Since: 1.8.6
+ **/
+const gchar *
+fwupd_request_flag_to_string(FwupdRequestFlags flag)
+{
+	if (flag == FWUPD_REQUEST_FLAG_NONE)
+		return "none";
+	if (flag == FWUPD_REQUEST_FLAG_FORCE_GENERIC)
+		return "force-generic";
+	return NULL;
+}
+
+/**
+ * fwupd_request_flag_from_string:
+ * @flag: (nullable): a string, e.g. `force-generic`
+ *
+ * Converts a string to an enumerated request flag.
+ *
+ * Returns: enumerated value
+ *
+ * Since: 1.8.6
+ **/
+FwupdRequestFlags
+fwupd_request_flag_from_string(const gchar *flag)
+{
+	if (g_strcmp0(flag, "force-generic") == 0)
+		return FWUPD_REQUEST_FLAG_FORCE_GENERIC;
+	return FWUPD_REQUEST_FLAG_NONE;
 }
 
 /**
@@ -249,6 +297,12 @@ fwupd_request_to_variant(FwupdRequest *self)
 				      FWUPD_RESULT_KEY_REQUEST_KIND,
 				      g_variant_new_uint32(priv->kind));
 	}
+	if (priv->flags != FWUPD_REQUEST_FLAG_NONE) {
+		g_variant_builder_add(&builder,
+				      "{sv}",
+				      FWUPD_RESULT_KEY_FLAGS,
+				      g_variant_new_uint64(priv->flags));
+	}
 	return g_variant_new("a{sv}", &builder);
 }
 
@@ -277,6 +331,10 @@ fwupd_request_from_key_value(FwupdRequest *self, const gchar *key, GVariant *val
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_REQUEST_KIND) == 0) {
 		fwupd_request_set_kind(self, g_variant_get_uint32(value));
+		return;
+	}
+	if (g_strcmp0(key, FWUPD_RESULT_KEY_FLAGS) == 0) {
+		fwupd_request_set_flags(self, g_variant_get_uint64(value));
 		return;
 	}
 }
@@ -404,6 +462,100 @@ fwupd_request_set_kind(FwupdRequest *self, FwupdRequestKind kind)
 }
 
 /**
+ * fwupd_request_get_flags:
+ * @self: a #FwupdRequest
+ *
+ * Gets the request flags.
+ *
+ * Returns: request flags, or 0 if unset
+ *
+ * Since: 1.8.6
+ **/
+FwupdRequestFlags
+fwupd_request_get_flags(FwupdRequest *self)
+{
+	FwupdRequestPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_REQUEST(self), 0);
+	return priv->flags;
+}
+
+/**
+ * fwupd_request_set_flags:
+ * @self: a #FwupdRequest
+ * @flags: request flags, e.g. %FWUPD_REQUEST_FLAG_FORCE_GENERIC
+ *
+ * Sets the request flags.
+ *
+ * Since: 1.8.6
+ **/
+void
+fwupd_request_set_flags(FwupdRequest *self, FwupdRequestFlags flags)
+{
+	FwupdRequestPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FWUPD_IS_REQUEST(self));
+
+	/* not changed */
+	if (priv->flags == flags)
+		return;
+
+	priv->flags = flags;
+	g_object_notify(G_OBJECT(self), "flags");
+}
+
+/**
+ * fwupd_request_add_flag:
+ * @self: a #FwupdRequest
+ * @flag: the #FwupdRequestFlags
+ *
+ * Adds a specific flag to the request.
+ *
+ * Since: 1.8.6
+ **/
+void
+fwupd_request_add_flag(FwupdRequest *self, FwupdRequestFlags flag)
+{
+	FwupdRequestPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FWUPD_IS_REQUEST(self));
+	priv->flags |= flag;
+}
+
+/**
+ * fwupd_request_remove_flag:
+ * @self: a #FwupdRequest
+ * @flag: the #FwupdRequestFlags
+ *
+ * Removes a specific flag from the request.
+ *
+ * Since: 1.8.6
+ **/
+void
+fwupd_request_remove_flag(FwupdRequest *self, FwupdRequestFlags flag)
+{
+	FwupdRequestPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FWUPD_IS_REQUEST(self));
+	priv->flags &= ~flag;
+}
+
+/**
+ * fwupd_request_has_flag:
+ * @self: a #FwupdRequest
+ * @flag: the #FwupdRequestFlags
+ *
+ * Finds if the request has a specific flag.
+ *
+ * Returns: %TRUE if the flag is set
+ *
+ * Since: 1.8.6
+ **/
+gboolean
+fwupd_request_has_flag(FwupdRequest *self, FwupdRequestFlags flag)
+{
+	FwupdRequestPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_REQUEST(self), FALSE);
+	return (priv->flags & flag) > 0;
+}
+
+/**
  * fwupd_request_to_string:
  * @self: a #FwupdRequest
  *
@@ -427,6 +579,7 @@ fwupd_request_to_string(FwupdRequest *self)
 				 FWUPD_RESULT_KEY_REQUEST_KIND,
 				 fwupd_request_kind_to_string(priv->kind));
 	}
+	fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_FLAGS, fwupd_request_flag_to_string(priv->flags));
 	fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_DEVICE_ID, priv->device_id);
 	fwupd_pad_kv_unx(str, FWUPD_RESULT_KEY_CREATED, priv->created);
 	fwupd_pad_kv_str(str, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->message);
@@ -455,6 +608,9 @@ fwupd_request_get_property(GObject *object, guint prop_id, GValue *value, GParam
 	case PROP_KIND:
 		g_value_set_uint(value, priv->kind);
 		break;
+	case PROP_FLAGS:
+		g_value_set_uint64(value, priv->flags);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -480,6 +636,9 @@ fwupd_request_set_property(GObject *object, guint prop_id, const GValue *value, 
 		break;
 	case PROP_KIND:
 		fwupd_request_set_kind(self, g_value_get_uint(value));
+		break;
+	case PROP_FLAGS:
+		fwupd_request_set_flags(self, g_value_get_uint64(value));
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -544,6 +703,22 @@ fwupd_request_class_init(FwupdRequestClass *klass)
 				  FWUPD_REQUEST_KIND_UNKNOWN,
 				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_KIND, pspec);
+
+	/**
+	 * FwupdRequest:flags:
+	 *
+	 * The flags for the request.
+	 *
+	 * Since: 1.8.6
+	 */
+	pspec = g_param_spec_uint64("flags",
+				    NULL,
+				    NULL,
+				    FWUPD_REQUEST_FLAG_NONE,
+				    FWUPD_REQUEST_FLAG_UNKNOWN,
+				    FWUPD_REQUEST_FLAG_UNKNOWN,
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_FLAGS, pspec);
 
 	/**
 	 * FwupdRequest:message:

--- a/libfwupd/fwupd-request.h
+++ b/libfwupd/fwupd-request.h
@@ -59,10 +59,59 @@ typedef enum {
  */
 #define FWUPD_REQUEST_ID_PRESS_UNLOCK "org.freedesktop.fwupd.request.press-unlock"
 
+/**
+ * FWUPD_REQUEST_ID_PRESS_DO_NOT_UNPLUG_POWER:
+ *
+ * Show the user a message not to unplug the machine from the AC power, e.g.
+ * "Do not turn off your computer or remove the AC adaptor while the update is in progress."
+ *
+ * Since 1.6.2
+ */
+#define FWUPD_REQUEST_ID_DO_NOT_UNPLUG_POWER "org.freedesktop.fwupd.request.do-not-unplug-power"
+
+/**
+ * FWUPD_REQUEST_FLAG_NONE:
+ *
+ * No flags are set.
+ *
+ * Since: 1.8.6
+ */
+#define FWUPD_REQUEST_FLAG_NONE (0u)
+
+/**
+ * FWUPD_REQUEST_FLAG_FORCE_GENERIC:
+ *
+ * The payload binary is trusted.
+ *
+ * Since: 1.8.6
+ */
+#define FWUPD_REQUEST_FLAG_FORCE_GENERIC (1u << 0)
+
+/**
+ * FWUPD_REQUEST_FLAG_UNKNOWN:
+ *
+ * The request flag is unknown, typically caused by using mismatched client and daemon.
+ *
+ * Since: 1.8.6
+ */
+#define FWUPD_REQUEST_FLAG_UNKNOWN G_MAXUINT64
+
+/**
+ * FwupdRequestFlags:
+ *
+ * Flags used to represent request attributes
+ */
+typedef guint64 FwupdRequestFlags;
+
 const gchar *
 fwupd_request_kind_to_string(FwupdRequestKind kind);
 FwupdRequestKind
 fwupd_request_kind_from_string(const gchar *kind);
+
+const gchar *
+fwupd_request_flag_to_string(FwupdRequestFlags flag);
+FwupdRequestFlags
+fwupd_request_flag_from_string(const gchar *flag);
 
 FwupdRequest *
 fwupd_request_new(void);
@@ -93,6 +142,17 @@ FwupdRequestKind
 fwupd_request_get_kind(FwupdRequest *self);
 void
 fwupd_request_set_kind(FwupdRequest *self, FwupdRequestKind kind);
+
+FwupdRequestFlags
+fwupd_request_get_flags(FwupdRequest *self);
+void
+fwupd_request_set_flags(FwupdRequest *self, FwupdRequestFlags flags);
+void
+fwupd_request_add_flag(FwupdRequest *self, FwupdRequestFlags flag);
+void
+fwupd_request_remove_flag(FwupdRequest *self, FwupdRequestFlags flag);
+gboolean
+fwupd_request_has_flag(FwupdRequest *self, FwupdRequestFlags flag);
 
 FwupdRequest *
 fwupd_request_from_variant(GVariant *value);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -191,7 +191,7 @@ fwupd_enums_func(void)
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_feature_flag_from_string(tmp), ==, i);
 	}
-	for (guint64 i = 1; i <= FWUPD_RELEASE_FLAG_IS_COMMUNITY; i *= 2) {
+	for (guint64 i = 1; i <= FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG; i *= 2) {
 		const gchar *tmp = fwupd_release_flag_to_string(i);
 		if (tmp == NULL)
 			g_warning("missing release flag 0x%x", (guint)i);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -849,3 +849,15 @@ LIBFWUPD_1.8.4 {
     fwupd_security_attr_set_bios_setting_target_value;
   local: *;
 } LIBFWUPD_1.8.3;
+
+LIBFWUPD_1.8.6 {
+  global:
+    fwupd_request_add_flag;
+    fwupd_request_flag_from_string;
+    fwupd_request_flag_to_string;
+    fwupd_request_get_flags;
+    fwupd_request_has_flag;
+    fwupd_request_remove_flag;
+    fwupd_request_set_flags;
+  local: *;
+} LIBFWUPD_1.8.4;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2745,6 +2745,26 @@ fu_engine_install_release(FuEngine *self,
 			return FALSE;
 	}
 
+	/* warnings specified in the metainfo file */
+	if (fu_release_has_flag(release, FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG)) {
+		g_autoptr(FwupdRequest) req = fwupd_request_new();
+		fwupd_request_set_kind(req, FWUPD_REQUEST_KIND_POST);
+		fwupd_request_add_flag(req, FWUPD_REQUEST_FLAG_FORCE_GENERIC);
+		fwupd_request_set_id(req, FWUPD_REQUEST_ID_REMOVE_REPLUG);
+		fwupd_request_set_message(req, fu_release_get_update_message(release));
+		fwupd_request_set_image(req, fu_release_get_update_image(release));
+		fu_device_emit_request(device, req);
+	}
+	if (fu_release_has_flag(release, FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER)) {
+		g_autoptr(FwupdRequest) req = fwupd_request_new();
+		fwupd_request_set_kind(req, FWUPD_REQUEST_KIND_POST);
+		fwupd_request_add_flag(req, FWUPD_REQUEST_FLAG_FORCE_GENERIC);
+		fwupd_request_set_id(req, FWUPD_REQUEST_ID_DO_NOT_UNPLUG_POWER);
+		fwupd_request_set_message(req, fu_release_get_update_message(release));
+		fwupd_request_set_image(req, fu_release_get_update_image(release));
+		fu_device_emit_request(device, req);
+	}
+
 	/* install firmware blob */
 	version_orig = g_strdup(fu_device_get_version(device));
 	if (!fu_engine_install_blob(self,

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -861,6 +861,17 @@ fu_release_load(FuRelease *self,
 	tmp = xb_node_query_text(component, "custom/value[@key='LVFS::UpdateMessage']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_update_message(FWUPD_RELEASE(self), tmp);
+	tmp = xb_node_query_text(component, "custom/value[@key='LVFS::UpdateAction']", NULL);
+	if (tmp != NULL) {
+		if (g_strcmp0(tmp, "do-not-unplug-power") == 0) {
+			fwupd_release_add_flag(
+			    FWUPD_RELEASE(self),
+			    FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER);
+		} else if (g_strcmp0(tmp, "remove-replug") == 0) {
+			fwupd_release_add_flag(FWUPD_RELEASE(self),
+					       FWUPD_RELEASE_FLAG_UPDATE_ACTION_REMOVE_REPLUG);
+		}
+	}
 	tmp = xb_node_query_text(component, "custom/value[@key='LVFS::UpdateImage']", NULL);
 	if (tmp != NULL) {
 		if (self->remote != NULL) {

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -18,9 +18,12 @@ FuRelease *
 fu_release_new(void);
 
 #define fu_release_get_version(r)     fwupd_release_get_version(FWUPD_RELEASE(r))
+#define fu_release_get_update_message(r) fwupd_release_get_update_message(FWUPD_RELEASE(r))
+#define fu_release_get_update_image(r)	 fwupd_release_get_update_image(FWUPD_RELEASE(r))
 #define fu_release_get_branch(r)      fwupd_release_get_branch(FWUPD_RELEASE(r))
 #define fu_release_get_checksums(r)   fwupd_release_get_checksums(FWUPD_RELEASE(r))
 #define fu_release_add_flag(r, v)     fwupd_release_add_flag(FWUPD_RELEASE(r), v)
+#define fu_release_has_flag(r, v)	 fwupd_release_has_flag(FWUPD_RELEASE(r), v)
 #define fu_release_add_tag(r, v)      fwupd_release_add_tag(FWUPD_RELEASE(r), v)
 #define fu_release_add_metadata(r, v) fwupd_release_add_metadata(FWUPD_RELEASE(r), v)
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -878,7 +878,7 @@ fu_util_display_current_message(FuUtilPrivate *priv)
 	/* print all POST requests */
 	for (guint i = 0; i < priv->post_requests->len; i++) {
 		FwupdRequest *request = g_ptr_array_index(priv->post_requests, i);
-		g_print("%s\n", fwupd_request_get_message(request));
+		g_print("%s\n", fu_util_request_get_message(request));
 	}
 }
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1867,6 +1867,42 @@ fu_util_release_flag_to_string(FwupdReleaseFlags release_flag)
 	return fwupd_release_flag_to_string(release_flag);
 }
 
+const gchar *
+fu_util_request_get_message(FwupdRequest *req)
+{
+	if (fwupd_request_has_flag(req, FWUPD_REQUEST_FLAG_FORCE_GENERIC)) {
+		if (g_strcmp0(fwupd_request_get_id(req), FWUPD_REQUEST_ID_REMOVE_REPLUG) == 0) {
+			/* TRANSLATORS: warning message shown after update has been scheduled */
+			return _("The update will continue when the device USB cable is unplugged "
+				 "and then re-inserted.");
+		}
+		if (g_strcmp0(fwupd_request_get_id(req), FWUPD_REQUEST_ID_PRESS_UNLOCK) == 0) {
+			/* TRANSLATORS: warning message shown after update has been scheduled */
+			return _("Press unlock on the device to continue the update process.");
+		}
+		if (g_strcmp0(fwupd_request_get_id(req), FWUPD_REQUEST_ID_DO_NOT_UNPLUG_POWER) ==
+		    0) {
+			/* TRANSLATORS: warning message shown after update has been scheduled */
+			return _("Do not turn off your computer or remove the AC adaptor while the "
+				 "update is in progress.");
+		}
+	}
+	return fwupd_request_get_message(req);
+}
+
+static const gchar *
+fu_util_release_get_update_message(FwupdRelease *rel)
+{
+	if (fwupd_release_has_flag(rel, FWUPD_RELEASE_FLAG_UPDATE_ACTION_DO_NOT_UNPLUG_POWER))
+		return NULL;
+	if (fwupd_release_has_flag(rel, FWUPD_REQUEST_ID_REMOVE_REPLUG)) {
+		/* TRANSLATORS: warning message shown after update has been scheduled */
+		return _("The update will require the device USB cable to be unplugged and then "
+			 "re-inserted after the update has completed.");
+	}
+	return fwupd_release_get_update_message(rel);
+}
+
 gchar *
 fu_util_release_to_string(FwupdRelease *rel, guint idt)
 {
@@ -1980,7 +2016,7 @@ fu_util_release_to_string(FwupdRelease *rel, guint idt)
 				 idt + 1,
 				 /* TRANSLATORS: helpful messages for the update */
 				 _("Update Message"),
-				 fwupd_release_get_update_message(rel));
+				 fu_util_release_get_update_message(rel));
 	}
 	if (fwupd_release_get_update_image(rel) != NULL) {
 		fu_string_append(str,

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -96,6 +96,8 @@ gchar *
 fu_util_release_get_name(FwupdRelease *release);
 const gchar *
 fu_util_branch_for_display(const gchar *branch);
+const gchar *
+fu_util_request_get_message(FwupdRequest *req);
 
 const gchar *
 fu_util_get_systemd_unit(void);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -678,7 +678,7 @@ fu_util_display_current_message(FuUtilPrivate *priv)
 	/* print all POST requests */
 	for (guint i = 0; i < priv->post_requests->len; i++) {
 		FwupdRequest *request = g_ptr_array_index(priv->post_requests, i);
-		g_print("%s\n", fwupd_request_get_message(request));
+		g_print("%s\n", fu_util_request_get_message(request));
 	}
 }
 


### PR DESCRIPTION
The hardware OEMs have chosen all very different and difficult to understand post-install warnings -- it was perhaps a mistake to allow freeform text. Additionally these warnings are important, and not translated, and so many users are going to be blindly clicking 'Ok' to make the dialog they can't understand go away.

After analysing a few dozens of the warnings on the public LVFS firmwares we can see there's only really two different cases we need to support -- and one already has a FwupdRequest ID.

Add an enumerated type that can be set by the LVFS so that we can translate the user-visible message text. The LVFS will continue to set the fallback text and image and so this is forwards and backwards compatible.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
