### PR TITLE
uefi-capsule: Try harder when trying to find the default ESP

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -14,7 +14,7 @@
 #include "fu-uefi-common.h"
 #include "fu-uefi-device.h"
 
-static const gchar *
+const gchar *
 fu_uefi_bootmgr_get_suffix(GError **error)
 {
 	guint64 firmware_bits;

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -89,3 +89,5 @@ gboolean
 fu_uefi_cmp_asset(const gchar *source, const gchar *target);
 gboolean
 fu_uefi_copy_asset(const gchar *source, const gchar *target, GError **error);
+const gchar *
+fu_uefi_bootmgr_get_suffix(GError **error);


### PR DESCRIPTION
Look for a plausible path existing, still continuing to the first entry on failure as before. This makes it "work" for more people out-of-the-box.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
