### PR TITLE
Add some more profiling to debug custom device GType creation

### DIFF
--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -79,6 +79,7 @@ fu_plugin_runner_reload(FuPlugin *self, FuDevice *device, GError **error) G_GNUC
 gboolean
 fu_plugin_runner_backend_device_added(FuPlugin *self,
 				      FuDevice *device,
+				      FuProgress *progress,
 				      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fu_plugin_runner_backend_device_changed(FuPlugin *self,

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -40,6 +40,7 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 
 	while ((basename = g_dir_read_name(dir)) != NULL) {
 		g_autofree gchar *fn = g_build_filename(path, basename, NULL);
+		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 		g_autoptr(FuUdevDevice) dev = NULL;
 		if (!g_str_has_prefix(basename, "drm_dp_aux"))
 			continue;
@@ -56,7 +57,8 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 				   fn,
 				   NULL);
 		g_debug("creating drm_dp_aux_dev object backed by %s", fn);
-		ret = fu_plugin_runner_backend_device_added(plugin, FU_DEVICE(dev), &error);
+		ret =
+		    fu_plugin_runner_backend_device_added(plugin, FU_DEVICE(dev), progress, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
 	}

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -887,6 +887,7 @@ fu_thunderbolt_gudev_uevent_cb(GUdevClient *gudev_client,
 	if (g_strcmp0(action, "add") == 0) {
 		g_autoptr(FuUdevDevice) device = NULL;
 		g_autoptr(GError) error_local = NULL;
+		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 		device = fu_udev_device_new(tt->ctx, udev_device);
 		if (!fu_device_probe(FU_DEVICE(device), &error_local)) {
@@ -895,6 +896,7 @@ fu_thunderbolt_gudev_uevent_cb(GUdevClient *gudev_client,
 		}
 		if (!fu_plugin_runner_backend_device_added(tt->plugin,
 							   FU_DEVICE(device),
+							   progress,
 							   &error_local))
 			g_debug("failed to add: %s", error_local->message);
 		return;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7034,7 +7034,7 @@ fu_engine_backend_device_added_run_plugin(FuEngine *self,
 		return FALSE;
 
 	/* run the ->probe() then ->setup() vfuncs */
-	if (!fu_plugin_runner_backend_device_added(plugin, device, error)) {
+	if (!fu_plugin_runner_backend_device_added(plugin, device, progress, error)) {
 #ifdef SUPPORTED_BUILD
 		/* sanity check */
 		if (*error == NULL) {


### PR DESCRIPTION
It turns out using tss2_esys is slow (200ms) -- and now we know.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
