### PR TITLE
vli: Remove the incorrect ParentGuid to prevent confusion

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1211,6 +1211,7 @@ fu_vli_usbhub_device_init(FuVliUsbhubDevice *self)
 	fu_device_add_icon(FU_DEVICE(self), "usb-hub");
 	fu_device_add_protocol(FU_DEVICE(self), "com.vli.usbhub");
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_GPIOB,

--- a/plugins/vli/vli-goodway.quirk
+++ b/plugins/vli/vli-goodway.quirk
@@ -4,7 +4,6 @@ Plugin = vli
 GType = FuVliUsbhubDevice
 Flags = usb3
 CounterpartGuid = USB\VID_065F&PID_F816
-ParentGuid = USB\VID_1F29&PID_7518
 [USB\VID_065F&PID_F816]
 Plugin = vli
 GType = FuVliUsbhubDevice


### PR DESCRIPTION
The daemon wants to auto-add the parent relationship from the analogix device to the VLI device automatically, which is arguably more correct anyway.

No behaviour change, but the tree output in fwupdmgr will be reversed now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
