### PR TITLE
wacom_usb: Update quirks with new PID for v2 of 2nd-gen Intuos Pro Small

### DIFF
--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -81,3 +81,9 @@ Flags = use-runtime-version,no-serial-number
 [USB\VID_2D1F&PID_03C7]
 Plugin = wacom_usb
 GType = FuWacAndroidDevice
+
+# Intuos Pro Small (2nd-gen USB v2) [PTH-460]
+[USB\VID_056A&PID_03DC]
+GType = FuWacDevice
+Plugin = wacom_usb
+Flags = use-runtime-version


### PR DESCRIPTION
Wacom has added a new PID for a change in the second gen IPS

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ x] Feature
- [ ] Documentation
