### PR TITLE
Use EFI-style GUIDs when connecting the MEI interface

### DIFF
--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -144,7 +144,7 @@ fu_mei_device_connect(FuMeiDevice *self,
 	g_return_val_if_fail(guid != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (!fwupd_guid_from_string(guid, &guid_le, FWUPD_GUID_FLAG_NONE, error))
+	if (!fwupd_guid_from_string(guid, &guid_le, FWUPD_GUID_FLAG_MIXED_ENDIAN, error))
 		return FALSE;
 	memcpy(&data.in_client_uuid, &guid_le, sizeof(guid_le));
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),

--- a/libfwupdplugin/fu-mei-device.h
+++ b/libfwupdplugin/fu-mei-device.h
@@ -16,6 +16,48 @@ struct _FuMeiDeviceClass {
 	gpointer __reserved[31];
 };
 
+/**
+ * FU_MEI_DEVICE_HECI_AMTHI_GUID:
+ *
+ * GUID used to connect to the PTHI client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_AMTHI_GUID "12f80028-b4b7-4b2d-aca8-46e0ff65814c"
+
+/**
+ * FU_MEI_DEVICE_HECI_WATCHDOG_GUID:
+ *
+ * GUID used to connect to the Watchdog client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_WATCHDOG_GUID "05b79a6f-4628-4d7f-899d-a91514cb32ab"
+
+/**
+ * FU_MEI_DEVICE_HECI_FWUPDATE_GUID:
+ *
+ * GUID used to connect to the FWUpdate client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_FWUPDATE_GUID "309dcde8-ccb1-4062-8f78-600115a34327"
+
+/**
+ * FU_MEI_DEVICE_HECI_MKHI_GUID:
+ *
+ * GUID used to connect to the MKHI client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_MKHI_GUID "8e6a6715-9abc-4043-88ef-9e39c6f63e0f"
+
+/**
+ * FU_MEI_DEVICE_HECI_UPI_GUID:
+ *
+ * GUID used to connect to the Unique Platform ID client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_UPI_GUID "92136c79-5fea-4cfd-980e-23be07fa5e9f"
+
+/**
+ * FU_MEI_DEVICE_HECI_PSR_GUID:
+ *
+ * GUID used to connect to the Platform Service Record client (via the HECI device).
+ */
+#define FU_MEI_DEVICE_HECI_PSR_GUID "ed6703fa-d312-4e8b-9ddd-2155bb2dee65"
+
 gboolean
 fu_mei_device_connect(FuMeiDevice *self,
 		      const gchar *guid,

--- a/plugins/amt/fu-amt-device.c
+++ b/plugins/amt/fu-amt-device.c
@@ -16,7 +16,7 @@ struct _FuAmtDevice {
 
 G_DEFINE_TYPE(FuAmtDevice, fu_amt_device, FU_TYPE_MEI_DEVICE)
 
-#define FU_AMT_DEVICE_MEI_IAMTHIF "2800f812-b7b4-2d4b-aca8-46e0ff65814c"
+#define FU_AMT_DEVICE_MEI_IAMTHIF "12f80028-b4b7-4b2d-aca8-46e0ff65814c"
 
 #define AMT_MAJOR_VERSION 1
 #define AMT_MINOR_VERSION 1

--- a/plugins/amt/fu-amt-device.c
+++ b/plugins/amt/fu-amt-device.c
@@ -16,8 +16,6 @@ struct _FuAmtDevice {
 
 G_DEFINE_TYPE(FuAmtDevice, fu_amt_device, FU_TYPE_MEI_DEVICE)
 
-#define FU_AMT_DEVICE_MEI_IAMTHIF "12f80028-b4b7-4b2d-aca8-46e0ff65814c"
-
 #define AMT_MAJOR_VERSION 1
 #define AMT_MINOR_VERSION 1
 
@@ -275,7 +273,10 @@ fu_amt_device_open(FuDevice *device, GError **error)
 	/* open then create context */
 	if (!FU_DEVICE_CLASS(fu_amt_device_parent_class)->open(device, error))
 		return FALSE;
-	return fu_mei_device_connect(FU_MEI_DEVICE(device), FU_AMT_DEVICE_MEI_IAMTHIF, 0, error);
+	return fu_mei_device_connect(FU_MEI_DEVICE(device),
+				     FU_MEI_DEVICE_HECI_AMTHI_GUID,
+				     0,
+				     error);
 }
 
 static gboolean
@@ -324,7 +325,7 @@ fu_amt_device_setup(FuDevice *device, GError **error)
 	}
 
 	/* add guid */
-	fu_device_add_guid(device, FU_AMT_DEVICE_MEI_IAMTHIF);
+	fu_device_add_guid(device, FU_MEI_DEVICE_HECI_AMTHI_GUID);
 	fu_device_add_parent_guid(device, "main-system-firmware");
 
 	/* get version numbers */


### PR DESCRIPTION
This means the GUID matches what the kernel exports in sysfs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
