### PR TITLE
Do not use GKeyFile to parse quirk files

### DIFF
--- a/libfwupdplugin/tests/quirks.d/tests.quirk
+++ b/libfwupdplugin/tests/quirks.d/tests.quirk
@@ -24,3 +24,9 @@ CfiDevicePageSize = 0x200
 CfiDeviceSectorSize = 0x2000
 CfiDeviceBlockSize = 0x8000
 FirmwareSizeMax = 0x10000
+
+[MEI]
+Plugin = one
+
+[MEI]
+Plugin = two


### PR DESCRIPTION
There are two reasons for this. First is that GKeyFile is quite inefficient, using a large amount of heap memory when loading. Given we don't actually use the merge and replace functionality of GKeyFile and we only need line-by-line access we can parse this ourselves and reduce the peak RSS considerably.

This also accidentally fixes another bug. Moving from multiple quirk files to a single builtin.quirk meant that multiple subsystem plugins were deduped -- which isn't really what we wanted. For example, this now works:

    [MEI]
    Plugin = one
    [MEI]
    Plugin = two

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
