### PR TITLE
Only count the Microsoft hashes when getting the dbx version

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -43,6 +43,7 @@ with a non-standard filesystem layout.
 * `FWUPD_DEVICE_LIST_VERBOSE` display devices being added and removed from the list
 * `FWUPD_PROBE_VERBOSE` dump the detected devices to the console, even if not supported by fwupd
 * `FWUPD_BIOS_SETTING_VERBOSE` be verbose while parsing BIOS settings
+* `FWUPD_EFI_SIGNATURE_VERBOSE` be verbose while parsing EFI signatures
 
 ## Plugins
 


### PR DESCRIPTION
HP include extra keys that means the version is higher than expected.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
