### PR TITLE
Allow parsing metadata more than 1MB in size

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -84,6 +84,9 @@
 
 #define MINIMUM_BATTERY_PERCENTAGE_FALLBACK 10
 
+#define FU_ENGINE_MAX_METADATA_SIZE  0x2000000 /* 32MB */
+#define FU_ENGINE_MAX_SIGNATURE_SIZE 0x100000  /* 1MB */
+
 static void
 fu_engine_finalize(GObject *obj);
 static void
@@ -4427,12 +4430,12 @@ fu_engine_update_metadata(FuEngine *self,
 	stream_sig = g_unix_input_stream_new(fd_sig, TRUE);
 
 	/* read the entire file into memory */
-	bytes_raw = g_input_stream_read_bytes(stream_fd, 0x100000, NULL, error);
+	bytes_raw = fu_bytes_get_contents_stream(stream_fd, FU_ENGINE_MAX_METADATA_SIZE, error);
 	if (bytes_raw == NULL)
 		return FALSE;
 
 	/* read signature */
-	bytes_sig = g_input_stream_read_bytes(stream_sig, 0x100000, NULL, error);
+	bytes_sig = fu_bytes_get_contents_stream(stream_sig, FU_ENGINE_MAX_SIGNATURE_SIZE, error);
 	if (bytes_sig == NULL)
 		return FALSE;
 


### PR DESCRIPTION
The LVFS crept over this limit yesterday. I've put some emergency commits in place that take it back down to 800KB, and I'll focus next week on getting it much lower than that.

The real problem is that we thought that g_input_stream_read_bytes() was using `count` as the chunk size, not the total size. Raise the total size to 32MB and chunk in 32kB blocks to reduce the RSS peak when loading metadata.

Fixes https://github.com/fwupd/fwupd/issues/5173

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
