### PR TITLE
elantp: solve the problem that I2C device cannot be matched

### DIFF
--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -118,6 +118,10 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 	g_autoptr(GUdevDevice) udev_parent = NULL;
 #endif
 
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_i2c_device_parent_class)->probe(device, error))
+		return FALSE;
+
 	/* set physical ID */
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "i2c", error))
 		return FALSE;

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -110,6 +110,10 @@ fu_elantp_i2c_device_probe(FuDevice *device, GError **error)
 {
 	FuElantpI2cDevice *self = FU_ELANTP_I2C_DEVICE(device);
 
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_elantp_i2c_device_parent_class)->probe(device, error))
+		return FALSE;
+
 	/* check is valid */
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "i2c") == 0) {
 		g_autoptr(GPtrArray) i2c_buses = NULL;


### PR DESCRIPTION
revert some files of faa7871

After fu-i2c-device.c is reverted, I2C\MODALIAS_* of elantp.quirk can be matched.
After fu-elantp-i2c-device.c is reverted, the elantp plugin can correctly read the value of the "ElantpI2cTargetAddress" key.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
