### PR TITLE
Add two Godzilla Creek docks to ccgx

### DIFF
--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -132,3 +132,12 @@ Summary = Dock Management Controller Device
 CcgxDmcTriggerCode = 0x01
 CcgxImageKind = dmc-composite
 RemoveDelay = 732000
+
+# Anker Thunderbolt4 Mini Dock
+[USB\VID_291A&PID_8398]
+Plugin = ccgx
+GType = FuCcgxDmcDevice
+Summary = Dock Management Controller Device
+CcgxDmcTriggerCode = 0x01
+CcgxImageKind = dmc-composite
+RemoveDelay = 732000

--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -123,3 +123,12 @@ CcgxDmcTriggerCode = 0x01
 CcgxImageKind = dmc-composite
 InstallDuration = 898
 RemoveDelay = 732000
+
+# Quanta Storage Inc. QSI Thunderbolt4 Godzilla Hub
+[USB\VID_2BEF&PID_9065]
+Plugin = ccgx
+GType = FuCcgxDmcDevice
+Summary = Dock Management Controller Device
+CcgxDmcTriggerCode = 0x01
+CcgxImageKind = dmc-composite
+RemoveDelay = 732000


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

QSI's original Godzilla Creek reference, and one variant I just happen to have, the Anker Thunderbolt 4 Mini.