### PR TITLE
elantp: Derive from FuI2cDevice to allow a I2C\NAME_ quirk match

### DIFF
--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -16,7 +16,7 @@
 #include "fu-elantp-i2c-device.h"
 
 struct _FuElantpI2cDevice {
-	FuUdevDevice parent_instance;
+	FuI2cDevice parent_instance;
 	guint16 i2c_addr;
 	guint16 ic_page_count;
 	guint16 iap_type;
@@ -29,7 +29,7 @@ struct _FuElantpI2cDevice {
 	gchar *bind_id;
 };
 
-G_DEFINE_TYPE(FuElantpI2cDevice, fu_elantp_i2c_device, FU_TYPE_UDEV_DEVICE)
+G_DEFINE_TYPE(FuElantpI2cDevice, fu_elantp_i2c_device, FU_TYPE_I2C_DEVICE)
 
 #define FU_ELANTP_DEVICE_IOCTL_TIMEOUT 5000 /* ms */
 

--- a/plugins/elantp/fu-elantp-i2c-device.h
+++ b/plugins/elantp/fu-elantp-i2c-device.h
@@ -11,4 +11,4 @@
 #define FU_ELANTP_I2C_DEVICE_ABSOLUTE (1 << 0)
 
 #define FU_TYPE_ELANTP_I2C_DEVICE (fu_elantp_i2c_device_get_type())
-G_DECLARE_FINAL_TYPE(FuElantpI2cDevice, fu_elantp_i2c_device, FU, ELANTP_I2C_DEVICE, FuUdevDevice)
+G_DECLARE_FINAL_TYPE(FuElantpI2cDevice, fu_elantp_i2c_device, FU, ELANTP_I2C_DEVICE, FuI2cDevice)


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
