### PR TITLE
trivial: add missing log domain for efi signature list

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#define G_LOG_DOMAIN "FuEfiSignatureList"
+
 #include "config.h"
 
 #include <fwupd.h>


### PR DESCRIPTION
Noticed this missing in https://github.com/fwupd/fwupd/issues/5211

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
