### PR TITLE
elantp: Updating the quirks of the ABS touchpad of Chromebook

### DIFF
--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -27,14 +27,14 @@ Flags = elantp-recovery
 Flags = elantp-recovery
 
 # absolute report device on ACPI
-[I2C\MODALIAS_acpi:ELAN0000:]
+[I2C\NAME_ELAN0000:00]
 Plugin = elantp
 GType = FuElantpI2cDevice
 ElantpI2cTargetAddress = 0x15
 Flags = elantp-absolute
 
 # absolute report device on Device Tree
-[I2C\MODALIAS_of:NtrackpadT(null)Celan,ekth3000]
+[I2C\NAME_ekth3000]
 Plugin = elantp
 GType = FuElantpI2cDevice
 ElantpI2cTargetAddress = 0x15


### PR DESCRIPTION
Modify the matching method from `I2C\MODALIAS_` to `I2C\NAME_`

It depends on #5212 and has been tested to work.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
