### PR TITLE
Fix a regression when using fwuptool install-blob with FMAP firmware

### DIFF
--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -60,6 +60,7 @@ _fwupdtool_opts=(
 	'--method'
 	'--disable-ssl-strict'
 	'--no-safety-check'
+	'--no-search'
 	'--ignore-checksum'
 	'--ignore-vid-pid'
 	'--save-backends'

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3401,6 +3401,7 @@ main(int argc, char *argv[])
 	gboolean allow_older = FALSE;
 	gboolean allow_reinstall = FALSE;
 	gboolean force = FALSE;
+	gboolean no_search = FALSE;
 	gboolean ret;
 	gboolean version = FALSE;
 	gboolean ignore_checksum = FALSE;
@@ -3477,6 +3478,14 @@ main(int argc, char *argv[])
 	     &priv->no_reboot_check,
 	     /* TRANSLATORS: command line option */
 	     N_("Do not check or prompt for reboot after update"),
+	     NULL},
+	    {"no-search",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &no_search,
+	     /* TRANSLATORS: command line option */
+	     N_("Do not search the firmware when parsing"),
 	     NULL},
 	    {"no-safety-check",
 	     '\0',
@@ -3995,7 +4004,7 @@ main(int argc, char *argv[])
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
 	if (force)
 		priv->flags |= FWUPD_INSTALL_FLAG_FORCE;
-	else
+	if (no_search)
 		priv->flags |= FWUPD_INSTALL_FLAG_NO_SEARCH;
 	if (ignore_checksum)
 		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM;


### PR DESCRIPTION
Only set _NO_SEARCH when specified, and do not piggy-back on the --force command line option.

Fixes https://github.com/fwupd/fwupd/issues/5227

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
