### PR TITLE
wacom-usb: remove the use-runtime-version flag from IPS

### DIFF
--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -86,4 +86,3 @@ GType = FuWacAndroidDevice
 [USB\VID_056A&PID_03DC]
 GType = FuWacDevice
 Plugin = wacom_usb
-Flags = use-runtime-version


### PR DESCRIPTION
The use-runtime-version flag was initially used with the Intuos Pro Small (2nd-gen USB v2) to force the use of the legacy code path. The legacy code path was required because of a bug in the identification of the Bluetooth (I6) firmware.

It has been decided that the bug will be fixed before any fimware changes are released, removing the need to use the legacy code path.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
