### PR TITLE
Add Goodix GF3258WNC support

### DIFF
--- a/plugins/goodix-moc/goodixmoc.quirk
+++ b/plugins/goodix-moc/goodixmoc.quirk
@@ -11,3 +11,5 @@ Plugin = goodixmoc
 Plugin = goodixmoc
 [USB\VID_27C6&PID_6496]
 Plugin = goodixmoc
+[USB\VID_27C6&PID_659A]
+Plugin = goodixmoc


### PR DESCRIPTION
Add support for the coming GF3258WNC(MOC) fingerprint device. 
