### PR TITLE
build: Do not check markdown version for gi-docgen 2022

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,4 +1,4 @@
-if gidocgen_dep.found() and docs_python_deps.allowed() and gidocgen_app.found() and introspection.allowed()
+if build_docs and introspection.allowed()
   toml_conf = configuration_data()
   docgen_version = source_version
   if git.found() and source_version != fwupd_version

--- a/meson.build
+++ b/meson.build
@@ -537,18 +537,24 @@ fwupd_gir = []
 gir_dep = dependency('gobject-introspection-1.0', required: get_option('introspection'))
 introspection = get_option('introspection').disable_auto_if(host_machine.system() != 'linux').disable_auto_if(not gir_dep.found())
 
-markdown_version = run_command(
-  python3, '-c', 'import markdown; print(markdown.__version__)'
-).stdout().strip()
-docs_python_deps = get_option('docs').require(markdown_version.version_compare('>=3.2'),
-						error_message: 'docs=enabled requires at least markdown >= 3.2')
 gidocgen_dep = dependency('gi-docgen',
   version: '>= 2021.1',
   native: true,
   fallback: ['gi-docgen', 'dummy_dep'],
-  required: docs_python_deps,
+  required: get_option('docs'),
 )
-gidocgen_app = find_program('gi-docgen', required: docs_python_deps)
+gidocgen_app = find_program('gi-docgen', required: gidocgen_dep.found())
+build_docs = gidocgen_dep.found() and gidocgen_app.found()
+
+if build_docs and gidocgen_dep.version().version_compare('< 2022.2')
+  markdown_version = run_command(
+    python3, '-c', 'import markdown; print(markdown.__version__)'
+  ).stdout().strip()
+  build_docs = get_option('docs').require(
+    markdown_version.version_compare('>=3.2'),
+    error_message: 'docs=enabled requires at least markdown >= 3.2'
+  ).allowed()
+endif
 
 # using "meson configure -Db_sanitize=address,undefined" is super useful in finding corruption,
 # but it does not work with our GMainContext-abuse tests...


### PR DESCRIPTION
There is no guarantee that Python environment used for the build contains the same `markdown` version as the one used for running `gi-docgen`. For example, Nixpkgs uses a self-contained Python environment for the latter, so `markdown` package is not even available in fwupd build environment. Fortunately, gi-docgen 2022.2 already checks for `markdown` version so we can omit our own check for newer gi-docgen versions.

cc @eli-schwartz who added the check to gi-docgen.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
