### PR TITLE
Do not query PolicyKit when requester is trusted

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -455,7 +455,8 @@ fu_daemon_authorization_is_valid(PolkitAuthorizationResult *auth, GError **error
 	/* success */
 	return TRUE;
 }
-#else
+#endif /* HAVE_POLKIT */
+
 static gboolean
 fu_daemon_authorization_is_trusted(FuEngineRequest *request, GError **error)
 {
@@ -469,28 +470,27 @@ fu_daemon_authorization_is_trusted(FuEngineRequest *request, GError **error)
 	}
 	return TRUE;
 }
-#endif /* HAVE_POLKIT */
 
 static void
 fu_daemon_authorize_unlock_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* authenticated */
 	if (!fu_engine_unlock(helper->self->engine, helper->device_id, &error)) {
@@ -510,21 +510,21 @@ fu_daemon_authorize_get_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 	g_autoptr(FuBiosSettings) attrs = NULL;
 	FuContext *ctx;
 	GVariant *val = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* authenticated */
 	ctx = fu_engine_get_context(helper->self->engine);
@@ -538,21 +538,21 @@ fu_daemon_authorize_set_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* authenticated */
 	if (!fu_engine_modify_bios_settings(helper->self->engine,
@@ -571,21 +571,21 @@ fu_daemon_authorize_set_approved_firmware_cb(GObject *source, GAsyncResult *res,
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* success */
 	for (guint i = 0; i < helper->checksums->len; i++) {
@@ -600,21 +600,21 @@ fu_daemon_authorize_set_blocked_firmware_cb(GObject *source, GAsyncResult *res, 
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* success */
 	if (!fu_engine_set_blocked_firmware(helper->self->engine, helper->checksums, &error)) {
@@ -630,21 +630,21 @@ fu_daemon_authorize_self_sign_cb(GObject *source, GAsyncResult *res, gpointer us
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autofree gchar *sig = NULL;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* authenticated */
 	sig = fu_engine_self_sign(helper->self->engine, helper->value, helper->flags, &error);
@@ -662,21 +662,21 @@ fu_daemon_modify_config_cb(GObject *source, GAsyncResult *res, gpointer user_dat
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	if (!fu_engine_modify_config(helper->self->engine, helper->key, helper->value, &error)) {
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
@@ -711,16 +711,21 @@ fu_daemon_authorize_activate_cb(GObject *source, GAsyncResult *res, gpointer use
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
 #ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
 
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* progress */
 	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
@@ -749,21 +754,21 @@ fu_daemon_authorize_verify_update_cb(GObject *source, GAsyncResult *res, gpointe
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* progress */
 	fu_progress_set_profile(progress, g_getenv("FWUPD_VERBOSE") != NULL);
@@ -791,21 +796,21 @@ fu_daemon_authorize_modify_remote_cb(GObject *source, GAsyncResult *res, gpointe
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
-#ifdef HAVE_POLKIT
-	g_autoptr(PolkitAuthorizationResult) auth = NULL;
-
-	/* get result */
-	auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
-	if (!fu_daemon_authorization_is_valid(auth, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
-		return;
-	}
-#else
 	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
+#ifdef HAVE_POLKIT
+		g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+		/* get result */
+		auth = polkit_authority_check_authorization_finish(POLKIT_AUTHORITY(source), res, &error);
+		if (!fu_daemon_authorization_is_valid(auth, &error)) {
+			g_dbus_method_invocation_return_gerror(helper->invocation, error);
+			return;
+		}
+#else
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
-	}
 #endif /* HAVE_POLKIT */
+	}
 
 	/* authenticated */
 	if (!fu_engine_modify_remote(helper->self->engine,
@@ -855,21 +860,23 @@ fu_daemon_authorize_install_queue(FuMainAuthHelper *helper_ref)
 	gboolean ret;
 
 #ifdef HAVE_POLKIT
+	if (!fu_daemon_authorization_is_trusted(helper->request, &error)) {
 	/* still more things to to authenticate */
-	if (helper->action_ids->len > 0) {
-		g_autofree gchar *action_id = g_strdup(g_ptr_array_index(helper->action_ids, 0));
-		g_autoptr(PolkitSubject) subject = g_object_ref(helper->subject);
-		g_ptr_array_remove_index(helper->action_ids, 0);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    action_id,
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_install_cb,
-		    g_steal_pointer(&helper));
-		return;
+		if (helper->action_ids->len > 0) {
+			g_autofree gchar *action_id = g_strdup(g_ptr_array_index(helper->action_ids, 0));
+			g_autoptr(PolkitSubject) subject = g_object_ref(helper->subject);
+			g_ptr_array_remove_index(helper->action_ids, 0);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    action_id,
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_install_cb,
+			    g_steal_pointer(&helper));
+			return;
+		}
 	}
 #endif /* HAVE_POLKIT */
 
@@ -1290,8 +1297,6 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		checksums_str = g_strjoinv(",", checksums);
 		g_debug("Called %s(%s)", method_name, checksums_str);
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->flags = FWUPD_INSTALL_FLAG_NO_SEARCH;
@@ -1301,16 +1306,20 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		for (guint i = 0; checksums[i] != NULL; i++)
 			g_ptr_array_add(helper->checksums, g_strdup(checksums[i]));
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.set-approved-firmware",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_set_approved_firmware_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.set-approved-firmware",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_set_approved_firmware_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_set_approved_firmware_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1327,8 +1336,6 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		checksums_str = g_strjoinv(",", checksums);
 		g_debug("Called %s(%s)", method_name, checksums_str);
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->request = g_steal_pointer(&request);
@@ -1337,16 +1344,20 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		for (guint i = 0; checksums[i] != NULL; i++)
 			g_ptr_array_add(helper->checksums, g_strdup(checksums[i]));
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.set-approved-firmware",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_set_blocked_firmware_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.set-approved-firmware",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_set_blocked_firmware_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_set_blocked_firmware_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1390,23 +1401,25 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 			g_variant_unref(prop_value);
 		}
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper->self = self;
 		helper->value = g_steal_pointer(&value);
 		helper->request = g_steal_pointer(&request);
 		helper->invocation = g_object_ref(invocation);
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.self-sign",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_self_sign_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.self-sign",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_self_sign_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_self_sign_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1620,24 +1633,26 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 			return;
 		}
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->request = g_steal_pointer(&request);
 		helper->invocation = g_object_ref(invocation);
 		helper->device_id = g_strdup(device_id);
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.device-unlock",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_unlock_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.device-unlock",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_unlock_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_unlock_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1656,24 +1671,26 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 			return;
 		}
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->request = g_steal_pointer(&request);
 		helper->invocation = g_object_ref(invocation);
 		helper->device_id = g_strdup(device_id);
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.device-activate",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_activate_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.device-activate",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_activate_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_activate_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1697,16 +1714,18 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		helper->request = g_steal_pointer(&request);
 		helper->invocation = g_object_ref(invocation);
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.modify-config",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_modify_config_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.modify-config",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_modify_config_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_modify_config_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1733,19 +1752,21 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		helper->value = g_strdup(value);
 		helper->self = self;
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.modify-remote",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_modify_remote_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.modify-remote",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_modify_remote_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_modify_remote_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -1773,19 +1794,21 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		helper->device_id = g_strdup(device_id);
 		helper->self = self;
 
-		/* authenticate */
 #ifdef HAVE_POLKIT
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.verify-update",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_verify_update_cb,
-		    g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.verify-update",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_verify_update_cb,
+			    g_steal_pointer(&helper));
+		} else
 #else
 		fu_daemon_authorize_verify_update_cb(NULL, NULL, g_steal_pointer(&helper));
 #endif /* HAVE_POLKIT */
@@ -2009,28 +2032,29 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 #ifdef HAVE_POLKIT
 			g_autoptr(PolkitSubject) subject = NULL;
 #endif
-			/* authenticate */
-			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 			helper = g_new0(FuMainAuthHelper, 1);
 			helper->self = self;
 			helper->request = g_steal_pointer(&request);
 			helper->invocation = g_object_ref(invocation);
 #ifdef HAVE_POLKIT
-			subject = polkit_system_bus_name_new(sender);
-			polkit_authority_check_authorization(
-			    self->authority,
-			    subject,
-			    "org.freedesktop.fwupd.get-bios-settings",
-			    NULL,
-			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-			    NULL,
-			    fu_daemon_authorize_get_bios_settings_cb,
-			    g_steal_pointer(&helper));
-#else
+			if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+				/* authenticate */
+				fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+				subject = polkit_system_bus_name_new(sender);
+				polkit_authority_check_authorization(
+				    self->authority,
+				    subject,
+				    "org.freedesktop.fwupd.get-bios-settings",
+				    NULL,
+				    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+				    NULL,
+				    fu_daemon_authorize_get_bios_settings_cb,
+				    g_steal_pointer(&helper));
+			} else
+#endif /* HAVE_POLKIT */
 			fu_daemon_authorize_get_bios_settings_cb(NULL,
 								 NULL,
 								 g_steal_pointer(&helper));
-#endif /* HAVE_POLKIT */
 		}
 		return;
 	}
@@ -2046,8 +2070,6 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(a{ss})", &iter);
 		g_debug("Called %s()", method_name);
 
-		/* authenticate */
-		fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
 		helper = g_new0(FuMainAuthHelper, 1);
 		helper->self = self;
 		helper->request = g_steal_pointer(&request);
@@ -2059,19 +2081,22 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 			g_hash_table_insert(helper->bios_settings, g_strdup(key), g_strdup(value));
 		}
 #ifdef HAVE_POLKIT
-		subject = polkit_system_bus_name_new(sender);
-		polkit_authority_check_authorization(
-		    self->authority,
-		    subject,
-		    "org.freedesktop.fwupd.set-bios-settings",
-		    NULL,
-		    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
-		    NULL,
-		    fu_daemon_authorize_set_bios_settings_cb,
-		    g_steal_pointer(&helper));
-#else
-		fu_daemon_authorize_set_bios_settings_cb(NULL, NULL, g_steal_pointer(&helper));
+		if (!fu_daemon_authorization_is_trusted(helper->request, NULL)) {
+			/* authenticate */
+			fu_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+			subject = polkit_system_bus_name_new(sender);
+			polkit_authority_check_authorization(
+			    self->authority,
+			    subject,
+			    "org.freedesktop.fwupd.set-bios-settings",
+			    NULL,
+			    POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+			    NULL,
+			    fu_daemon_authorize_set_bios_settings_cb,
+			    g_steal_pointer(&helper));
+		} else
 #endif /* HAVE_POLKIT */
+		fu_daemon_authorize_set_bios_settings_cb(NULL, NULL, g_steal_pointer(&helper));
 
 		return;
 	}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6310,9 +6310,11 @@ fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid)
 {
 	GArray *trusted;
 
+#ifndef HAVE_POLKIT
 	/* root is always trusted */
 	if (calling_uid == 0)
 		return TRUE;
+#endif
 
 	trusted = fu_config_get_trusted_uids(self->config);
 	for (guint i = 0; i < trusted->len; i++) {


### PR DESCRIPTION
In the context of snap, we want to be able to distribute the same build of fwupd for both desktop and IoT. However IoT images do not typically run PolicyKit.

So if we detect requested in trusted, we skip using PolicyKit.

When compiled against polkit we also make 0 (root) untrusted by default so that the new behavior of not using polkit is only used when 0 is explictly added to `TrustedUids`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
