### PR TITLE
goodix-moc: Add quirk for GF5288WNC used on Framework

### DIFF
--- a/plugins/goodix-moc/goodixmoc.quirk
+++ b/plugins/goodix-moc/goodixmoc.quirk
@@ -13,3 +13,5 @@ Plugin = goodixmoc
 Plugin = goodixmoc
 [USB\VID_27C6&PID_659A]
 Plugin = goodixmoc
+[USB\VID_27C6&PID_609C]
+Plugin = goodixmoc


### PR DESCRIPTION
Framework Laptops use this device.

Output from `fwupdtool get-devices`:

```
├─Fingerprint Sensor:
│     Device ID:          4295296d98b3ba38c72f6baa33d24f03a1d428f6
│     Summary:            Match-On-Chip fingerprint sensor
│     Current version:    01000252
│     Vendor:             Goodix (USB:0x27C6)
│     Install Duration:   10 seconds
│     Serial Number:      UID2E43190D_XXXX_MOC_B0
│     GUIDs:              1e8c8470-a49c-571a-82fd-19c9fa32b8c3 ← USB\VID_27C6&PID_609C
│                         34def4c7-9461-5a32-a945-5dde0ca57d88 ← USB\VID_27C6&PID_609C&REV_0100
│     Device Flags:       • Updatable
│                         • Device can recover flash failures
│                         • Signed Payload
```

Signed-off-by: Daniel Schaefer <dhs@frame.work>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
