### PR TITLE
synaptics-cape: add the PID 0x0286

### DIFF
--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -463,7 +463,8 @@ fu_synaptics_cape_device_setup_version(FuSynapticsCapeDevice *self, GError **err
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* gets version number from device */
-	fu_synaptics_cape_device_sendcmd_ex(self, &cmd, 0, error);
+	if (!fu_synaptics_cape_device_sendcmd_ex(self, &cmd, 0, error))
+		return FALSE;
 
 	/* the version number are stored in lowest byte of a sequence of returned data */
 	version_raw =

--- a/plugins/synaptics-cape/synaptics-cape.quirk
+++ b/plugins/synaptics-cape/synaptics-cape.quirk
@@ -24,6 +24,12 @@ Flags = use-in-report-interrupt
 Guid = SYNAPTICS_CAPE\CX31993
 Flags = use-in-report-interrupt
 
+# This is the outdated PID for 0x0298
+[USB\VID_1395&PID_0286]
+Guid = SYNAPTICS_CAPE\CX31993
+Flags = add-counterpart-guids
+CounterpartGuid = USB\VID_1395&PID_0298
+
 [USB\VID_1395&PID_0298]
 Guid = SYNAPTICS_CAPE\CX31993
 Flags = use-in-report-interrupt


### PR DESCRIPTION
The device with PID=0x00298 has PID=0x0286 with the outdated FWre. This change allows to recognize and update devices in the field to the recent FWre version.
See: Google tracker issue 257197851

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
