### PR TITLE
elantp: Include 04F3:0400 (bootloader) as a valid i2c-hid touchpad

### DIFF
--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -53,7 +53,7 @@ fu_elantp_hid_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_elantp_hid_device_probe(FuDevice *device, GError **error)
 {
-	guint16 did;
+	guint16 device_id = fu_udev_device_get_model(FU_UDEV_DEVICE(device));
 
 	/* check is valid */
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "hidraw") != 0) {
@@ -65,10 +65,8 @@ fu_elantp_hid_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
-	did = fu_udev_device_get_model(FU_UDEV_DEVICE(device));
-
 	/* i2c-hid */
-	if (did != 0x400 && (did < 0x3000 || did >= 0x4000)) {
+	if (device_id != 0x400 && (device_id < 0x3000 || device_id >= 0x4000)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -53,6 +53,8 @@ fu_elantp_hid_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_elantp_hid_device_probe(FuDevice *device, GError **error)
 {
+	guint16 did;
+
 	/* check is valid */
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "hidraw") != 0) {
 		g_set_error(error,
@@ -63,9 +65,10 @@ fu_elantp_hid_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
+	did = fu_udev_device_get_model(FU_UDEV_DEVICE(device));
+
 	/* i2c-hid */
-	if (fu_udev_device_get_model(FU_UDEV_DEVICE(device)) < 0x400 ||
-	    fu_udev_device_get_model(FU_UDEV_DEVICE(device)) >= 0x4000) {
+	if (did != 0x400 && (did < 0x3000 || did >= 0x4000)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -64,7 +64,7 @@ fu_elantp_hid_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* i2c-hid */
-	if (fu_udev_device_get_model(FU_UDEV_DEVICE(device)) < 0x3000 ||
+	if (fu_udev_device_get_model(FU_UDEV_DEVICE(device)) < 0x400 ||
 	    fu_udev_device_get_model(FU_UDEV_DEVICE(device)) >= 0x4000) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,


### PR DESCRIPTION
ELAN Touchpads with product ids between 0x3000 and 0x4000 can sometimes end up in bootloader mode (due to not having a valid firmware, for example)

The bootloader has a product id outside of the range checked by fu_elantp_hid_device_probe, resulting in the device disappearing from get-devices when it's in that mode, which makes it seem dead.

This expands the range of that check to include 0x400 so that it is possible to upload a valid firmware to it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

----

As requested by this comment https://github.com/fwupd/fwupd/issues/5281#issuecomment-1327298367

(We could alternatively keep it as `< 0x3000` and add another condition to allow `0x400` only)

Fixes: https://github.com/fwupd/fwupd/issues/5281

See also: https://github.com/fwupd/fwupd/issues/2926

