### PR TITLE
Add more metadata to the report attributes

### DIFF
--- a/contrib/codespell.cfg
+++ b/contrib/codespell.cfg
@@ -1,4 +1,4 @@
 [codespell]
 builtin = clear,informal,en-GB_to_en-US
 skip = *.po,*.csv,*.svg,*.p7c,subprojects,.git,pcrs,build*,.ossfuzz,*/tests/*
-ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre
+ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname


### PR DESCRIPTION
This can be used in gnome-control-center when building the security report.

Fixes https://github.com/fwupd/fwupd/discussions/5262

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
