### PR TITLE
remove errant % in spec file

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -359,7 +359,7 @@ done
 %{_bindir}/fwupdagent
 %dir %{_sysconfdir}/fwupd
 %dir %{_sysconfdir}/fwupd/bios-settings.d
-%config%(noreplace)%{_sysconfdir}/fwupd/bios-settings.d/README.md
+%{_sysconfdir}/fwupd/bios-settings.d/README.md
 %dir %{_sysconfdir}/fwupd/remotes.d
 %if 0%{?have_dell}
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/dell-esrt.conf


### PR DESCRIPTION
addresses the build error "sh: line 1: noreplace: command not found"

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation




When performing a source build on rpm based systems, one may get messages of the form:
   `sh: line 1: noreplace: command not found`
(seen in fedora koji build logs such as: https://kojipkgs.fedoraproject.org//packages/fwupd/1.8.7/3.fc38/data/logs/x86_64/build.log )

line 362 of fwupd.spec.in file is
   ` %config%(noreplace).....`
which appears to be an error, and should be
    `%config(noreplace).....`
as elsewhere in the spec.
