### PR TITLE
build: don't record timestamp in builtin.quirk.gz

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -604,7 +604,7 @@ custom_target('builtin-quirk-gz',
   input: builtin_quirk,
   output: 'builtin.quirk.gz',
   capture: true,
-  command: [gzip, '-k', '--stdout', '@INPUT@'],
+  command: [gzip, '-n', '-k', '--stdout', '@INPUT@'],
   install: true,
   install_dir: join_paths(datadir, 'fwupd', 'quirks.d'),
 )


### PR DESCRIPTION
On Arch Linux fwupd is almost reproducible except for the timestamp recorded in the generated gzip file.

Type of pull request:

- [x] Code fix

This can be observed in this [diffoscope report](https://reproducible.archlinux.org/api/v0/builds/371445/diffoscope). Arch Linux differs from other distributions in reproducibility in that it does not strip non-determinism during it's build (like for example Debian).