### PR TITLE
Add the fwupd version to the HSI result if the chassis is invalid

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6533,7 +6533,11 @@ fu_engine_attrs_calculate_hsi_for_chassis(FuEngine *self)
 		break;
 	}
 
-	return g_strdup_printf("HSI:INVALID:chassis[0x%02x]", val);
+	return g_strdup_printf("HSI:INVALID:chassis[0x%02x] (v%d.%d.%d)",
+			       val,
+			       FWUPD_MAJOR_VERSION,
+			       FWUPD_MINOR_VERSION,
+			       FWUPD_MICRO_VERSION);
 }
 
 static gboolean


### PR DESCRIPTION
If the user uploads a report to the LVFS we don't currently get the fwupd version data in this case. And it makes the LVFS unhappy.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
