### PR TITLE
trivial: uefi-capsule: decrease warning about missing header to debug

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -427,7 +427,7 @@ fu_uefi_device_fixup_firmware(FuUefiDevice *self, GBytes *fw, GError **error)
 		efi_capsule_header_t header = {0x0};
 		g_autoptr(GByteArray) buf_hdr = g_byte_array_new();
 
-		g_warning("missing or invalid embedded capsule header");
+		g_debug("missing or invalid embedded capsule header");
 		priv->missing_header = TRUE;
 
 		/* create a fake header with plausible contents */


### PR DESCRIPTION
Plenty of vendors rely upon this behavior, so we don't need to be making noise in logs for them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
