### PR TITLE
trivial: fix autopkgtest failure

### DIFF
--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -28,6 +28,10 @@ fu_test_mtd_device_func(void)
 	g_autoptr(GUdevDevice) udev_device = NULL;
 	const gchar *dev_name;
 
+	ret = fu_context_load_hwinfo(ctx, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
 	/* do not save silo */
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);


### PR DESCRIPTION
Explicitly load_hwinfo at start of mtd self test
```
.# Start of mtd tests
.# GLib-GIO-DEBUG: _g_io_module_get_default: Found default implementation local (GLocalVfs) for ?gio-vfs?
.# XbSilo-DEBUG: attempting to load /tmp/.E94WW1
.# XbSilo-DEBUG: failed to load silo: blob too small
Bail out! FuContext-FATAL-CRITICAL: cannot use HWIDs before calling ->load_hwinfo()

(/usr/libexec/installed-tests/fwupd/mtd-self-test:1758): FuContext-CRITICAL **: 23:27:43.095: cannot use HWIDs before calling ->load_hwinfo()
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
