### PR TITLE
Qubes fixes

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -477,7 +477,8 @@ done
 
 %files qubes-dom0
 %{_datadir}/qubes-fwupd/src/fwupd_receive_updates.py
-/usr/sbin/qubes-fwupdmgr
+%{_sbindir}/qubes_fwupdmgr
+%{_datadir}/qubes-fwupd/src/qubes_fwupdmgr.py
 %{_datadir}/qubes-fwupd/src/qubes_fwupd_heads.py
 %{_datadir}/qubes-fwupd/src/qubes_fwupd_update.py
 %{_datadir}/qubes-fwupd/src/__init__.py

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -217,6 +217,7 @@ Summary: fwupd wrapper for Qubes OS - dom0 scripts
 Requires:   gcab
 Requires:   fwupd >= 1.5.7
 Requires:   libjcat >= 0.1.6
+Requires:   python3-packaging
 
 %description qubes-dom0
 fwupd wrapper for Qubes OS
@@ -226,6 +227,7 @@ Summary: fwupd wrapper for Qubes OS - VM scripts
 Requires:   gcab
 Requires:   fwupd >= 1.5.7
 Requires:   libjcat >= 0.1.6
+Requires:   python3-packaging
 
 %description qubes-vm
 fwupd wrapper for Qubes OS
@@ -472,7 +474,6 @@ done
 %files qubes-vm
 %{_libexecdir}/qubes-fwupd/fwupd_common_vm.py
 %{_libexecdir}/qubes-fwupd/fwupd_download_updates.py
-%{_libexecdir}/qubes-fwupd/fwupd_usbvm_validate.py
 
 %files qubes-dom0
 %{_datadir}/qubes-fwupd/src/fwupd_receive_updates.py

--- a/contrib/qubes/meson.build
+++ b/contrib/qubes/meson.build
@@ -3,6 +3,7 @@ install_data([
   'src/fwupd_receive_updates.py',
   'src/qubes_fwupd_heads.py',
   'src/qubes_fwupd_update.py',
+  'src/qubes_fwupdmgr.py',
   ],
   install_dir: 'share/qubes-fwupd/src',
 )
@@ -44,9 +45,8 @@ install_data(
   install_dir: 'share/qubes-fwupd/test/logs/metainfo_version',
 )
 
-install_data(
-  'src/qubes_fwupdmgr.py',
-  install_dir: 'sbin',
-  rename: 'qubes-fwupdmgr',
-  install_mode: 'rwxrwxr-x',
+install_symlink(
+  'qubes_fwupdmgr',
+  pointing_to: '/usr/share/qubes-fwupd/src/qubes_fwupdmgr.py',
+  install_dir: '/usr/sbin',
 )

--- a/contrib/qubes/src/qubes_fwupd_update.py
+++ b/contrib/qubes/src/qubes_fwupd_update.py
@@ -93,8 +93,8 @@ class FwupdUpdate:
 
     def _encrypt_update_url(self, url):
         self.enc_url = url
-        self.arch_path = os.path.join(FWUPD_DOM0_UPDATES_DIR, self.arch_name)
         self.arch_name = "untrusted.cab"
+        self.arch_path = os.path.join(FWUPD_DOM0_UPDATES_DIR, self.arch_name)
 
     def download_metadata(self, whonix=False, metadata_url=None):
         """Initialize downloading metadata files.
@@ -115,7 +115,7 @@ class FwupdUpdate:
         if metadata_url:
             cmd_metadata.append("--url=" + metadata_url)
         try:
-            run_in_tty(updatevm, cmd_metadata)
+            run_in_tty(self.updatevm, cmd_metadata)
         except subprocess.CalledProcessError:
             raise Exception("Metadata download failed.")
 

--- a/contrib/qubes/src/qubes_fwupd_update.py
+++ b/contrib/qubes/src/qubes_fwupd_update.py
@@ -10,6 +10,7 @@
 import grp
 import os
 import re
+import shlex
 import subprocess
 
 FWUPD_DOM0_DIR = "/var/cache/fwupd"

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -507,6 +507,14 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         """Prints help information"""
         self._output_crawler(HELP, 0, help_f=True)
 
+    def check_vms(self):
+        """Checks which VMs are running"""
+        cmd_xl_list = ["xl", "list"]
+        p = subprocess.Popen(cmd_xl_list, stdout=subprocess.PIPE)
+        self.vm_list = p.communicate()[0].decode()
+        if p.returncode != 0:
+            raise Exception("fwupd-qubes: Listing VMs failed")
+
     def trusted_cleanup(self):
         """Deletes trusted directory."""
         trusted_path = os.path.join(FWUPD_DOM0_UPDATES_DIR, "trusted.cab")

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -107,7 +107,6 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             self.metadata_file = os.path.join(FWUPD_DOM0_METADATA_DIR, metadata_name)
             self.metadata_file_jcat = self.metadata_file + ".jcat"
             self.lvfs = "lvfs-testing"
-            self._enable_lvfs_testing_dom0()
         else:
             self.metadata_file = FWUPD_DOM0_METADATA_FILE
             self.metadata_file_jcat = FWUPD_DOM0_METADATA_JCAT

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -46,6 +46,7 @@ FWUPD_DOM0_METADATA_JCAT = os.path.join(FWUPD_DOM0_METADATA_DIR, "firmware.xml.g
 FWUPD_DOWNLOAD_PREFIX = "https://fwupd.org/downloads/"
 
 FWUPDMGR = "/bin/fwupdmgr"
+FWUPDAGENT = "/bin/fwupdagent"
 
 BIOS_UPDATE_FLAG = os.path.join(FWUPD_DOM0_DIR, "bios_update")
 LVFS_TESTING_DOM0_FLAG = os.path.join(FWUPD_DOM0_DIR, "lvfs_testing")
@@ -129,7 +130,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
 
     def _get_dom0_updates(self):
         """Gathers infromations about available updates."""
-        cmd_get_dom0_updates = [FWUPDMGR, "--json", "get-updates"]
+        cmd_get_dom0_updates = [FWUPDAGENT, "get-updates"]
         p = subprocess.Popen(cmd_get_dom0_updates, stdout=subprocess.PIPE)
         self.dom0_updates_info = p.communicate()[0].decode()
         if p.returncode != 0 and p.returncode != 2:
@@ -301,7 +302,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
 
     def _get_dom0_devices(self):
         """Gathers information about devices connected in dom0."""
-        cmd_get_dom0_devices = [FWUPDMGR, "--json", "get-devices"]
+        cmd_get_dom0_devices = [FWUPDAGENT, "get-devices"]
         p = subprocess.Popen(cmd_get_dom0_devices, stdout=subprocess.PIPE)
         self.dom0_devices_info = p.communicate()[0].decode()
         if p.returncode != 0:

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -58,7 +58,8 @@ def check_whonix_updatevm():
     if "qubes" not in platform.release():
         return False
     q = qfwupd.QubesFwupdmgr()
-    return "sys-whonix" in q.output
+    q.check_vms()
+    return "sys-whonix" in q.vm_list
 
 
 class TestQubesFwupdmgr(unittest.TestCase):
@@ -353,11 +354,9 @@ class TestQubesFwupdmgr(unittest.TestCase):
         user_input = ["1", "6", "sth", "2.2.1", "", " ", "\0", "2"]
         with patch("builtins.input", side_effect=user_input):
             downgrade_list = self.q._parse_downgrades(GET_DEVICES)
-            downgrade_dict = {"dom0": downgrade_list}
-            key, device_choice, downgrade_choice = self.q._user_input(
-                downgrade_dict, downgrade=True
+            device_choice, downgrade_choice = self.q._user_input(
+                downgrade_list, downgrade=True
             )
-        self.assertEqual(key, "dom0")
         self.assertEqual(device_choice, 0)
         self.assertEqual(downgrade_choice, 1)
 

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -396,13 +396,6 @@ class TestQubesFwupdmgr(unittest.TestCase):
             self.fail("Test device not found")
         self.assertLess(Version(old_version), Version(new_version))
 
-    @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
-    def test_enable_lvfs_testing_dom0(self):
-        if os.path.exists(LVFS_TESTING_DOM0_FLAG):
-            os.remove(LVFS_TESTING_DOM0_FLAG)
-        self.q._enable_lvfs_testing_dom0()
-        self.assertTrue(os.path.exists(LVFS_TESTING_DOM0_FLAG))
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Some of the fixes needed to make fwupd Qubes wrapper work after merged changes to https://github.com/fwupd/fwupd/pull/5260 (@DemiMarie).

I fixed package building, and dropped some files that were related to usbvm support.

I reversed the change from fwupdmgr --json to fwupdagent. This broke the wrapper's compatibility with older versions of fwupd. I wasn't able to install fwupd 1.8.7 on fc32, which is used as the dom0 vm in Qubes R4.1. As far as I know, we want to support Qubes R4.1 with these changes (@DemiMarie please correct me if I'm wrong). Unless we drop fwupdagent from the fwupd package in the near future, I don't see any gain from this change.

The rest of the changes are minor fixes to get the tests running. Currently, the wrapper code is still broken. @DemiMarie something is wrong with the communication between, dom0 and update vm via qvm-run. I did not get any debug output. Using `run_in_tty` in `qubes_fwupd_update.py` just freezes the code.
