### PR TITLE
Remove data only useful for ->probe() when the device has been added

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -241,6 +241,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "only-wait-for-replug";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_IGNORE_SYSTEM_POWER)
 		return "ignore-system-power";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE)
+		return "no-probe-complete";
 	return NULL;
 }
 
@@ -311,6 +313,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_ONLY_WAIT_FOR_REPLUG;
 	if (g_strcmp0(flag, "ignore-system-power") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_IGNORE_SYSTEM_POWER;
+	if (g_strcmp0(flag, "no-probe-complete") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 
@@ -4742,6 +4746,28 @@ fu_device_probe(FuDevice *self, GError **error)
 	/* success */
 	priv->done_probe = TRUE;
 	return TRUE;
+}
+
+/**
+ * fu_device_probe_complete:
+ * @self: a #FuDevice
+ *
+ * Tell the device that all probing has finished. This allows it to release any resources that are
+ * only valid during coldplug or hotplug.
+ *
+ * Since: 1.8.12
+ **/
+void
+fu_device_probe_complete(FuDevice *self)
+{
+	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
+
+	g_return_if_fail(FU_IS_DEVICE(self));
+
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE))
+		return;
+	if (klass->probe_complete != NULL)
+		klass->probe_complete(self);
 }
 
 /**

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -50,6 +50,7 @@ struct _FuDeviceClass {
 				 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*setup)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	void (*incorporate)(FuDevice *self, FuDevice *donor);
+	void (*probe_complete)(FuDevice *self);
 	gboolean (*poll)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*activate)(FuDevice *self,
 			     FuProgress *progress,
@@ -480,6 +481,18 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_IGNORE_SYSTEM_POWER (1ull << 26)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE:
+ *
+ * Do not deallocate resources typically only required during `->probe`.
+ *
+ * Note: the daemon will not actually free or unref device resources, but the plugin should
+ * still use this flag. After a a few releases and a lot of testing we'll actually flip the switch.
+ *
+ * Since: 1.8.12
+ */
+#define FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE (1ull << 27)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);
@@ -704,6 +717,8 @@ gboolean
 fu_device_activate(FuDevice *self, FuProgress *progress, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_device_probe_invalidate(FuDevice *self);
+void
+fu_device_probe_complete(FuDevice *self);
 gboolean
 fu_device_poll(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1179,3 +1179,9 @@ LIBFWUPDPLUGIN_1.8.11 {
     fu_udev_device_is_pci_base_cls;
   local: *;
 } LIBFWUPDPLUGIN_1.8.10;
+
+LIBFWUPDPLUGIN_1.8.12 {
+  global:
+    fu_device_probe_complete;
+  local: *;
+} LIBFWUPDPLUGIN_1.8.11;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -282,8 +282,7 @@ fu_logitech_hidpp_device_open(FuDevice *device, GError **error)
 {
 	FuLogitechHidPpDevice *self = FU_HIDPP_DEVICE(device);
 	FuLogitechHidPpDevicePrivate *priv = GET_PRIVATE(self);
-	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	const gchar *devpath = g_udev_device_get_device_file(udev_device);
+	const gchar *devpath = fu_udev_device_get_device_file(FU_UDEV_DEVICE(device));
 
 	/* open */
 	priv->io_channel = fu_io_channel_new_file(devpath, error);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -153,8 +153,7 @@ fu_logitech_hidpp_runtime_open(FuDevice *device, GError **error)
 {
 	FuLogitechHidPpRuntime *self = FU_HIDPP_RUNTIME(device);
 	FuLogitechHidPpRuntimePrivate *priv = GET_PRIVATE(self);
-	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-	const gchar *devpath = g_udev_device_get_device_file(udev_device);
+	const gchar *devpath = fu_udev_device_get_device_file(FU_UDEV_DEVICE(device));
 
 	/* open, but don't block */
 	priv->io_channel = fu_io_channel_new_file(devpath, error);

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -18,10 +18,9 @@ static gboolean
 fu_optionrom_device_probe(FuDevice *device, GError **error)
 {
 	g_autofree gchar *fn = NULL;
-	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
 
 	/* does the device even have ROM? */
-	fn = g_build_filename(g_udev_device_get_sysfs_path(udev_device), "rom", NULL);
+	fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "rom", NULL);
 	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -96,6 +96,7 @@ fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
 					"ignore-board-id");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
 }
 
 static void

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -570,6 +570,7 @@ fu_synaptics_rmi_hid_device_init(FuSynapticsRmiHidDevice *self)
 {
 	fu_device_set_name(FU_DEVICE(self), "Touchpad");
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
 	fu_synaptics_rmi_device_set_max_page(FU_SYNAPTICS_RMI_DEVICE(self), 0xff);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6917,6 +6917,9 @@ fu_engine_add_device(FuEngine *self, FuDevice *device)
 	/* create new device */
 	fu_device_list_add(self->device_list, device);
 
+	/* clean up any state only valid for ->probe */
+	fu_device_probe_complete(device);
+
 	/* fix order */
 	fu_device_list_depsolve_order(self->device_list, device);
 


### PR DESCRIPTION
This might include snapshot data like GUdevDevice that is only very rarely useful after ->probe has been completed.

This reduces the idle RSS by ~200kB on my laptop.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
