### PR TITLE
Remove HSI-5 as a level

### DIFF
--- a/docs/hsi.md.in
+++ b/docs/hsi.md.in
@@ -107,14 +107,8 @@ This security level corresponds to out-of-band protection of the system firmware
 
 The system is in a robust secure state.
 
-The system is corresponding several kind of encryption and execution protection for the system firmware.
-
-<a id="hsi-level5"></a>
-
-### [HSI:5 (Secure Proven State)](#hsi-level5)
-
-This security level corresponds to out-of-band attestation of the system firmware.
-There are currently no tests implemented for HSI:5 and so this security level cannot yet be obtained.
+The system is corresponding several kind of encryption and execution protection for the system
+firmware, perhaps even including out-of-band attestation of the system firmware.
 
 <a id="runtime-bang"></a>
 


### PR DESCRIPTION
We have no tools for detecting out-of-band attestation, and no tests that would fit a higher level than 4. It's easier to explain as a '5 level scale' that is logically numbered from 0 to 4.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
