### PR TITLE
ti-tps6598x: remove the delay on write

### DIFF
--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -617,7 +617,6 @@ fu_ti_tps6598x_device_write_chunks(FuTiTps6598xDevice *self,
 		}
 
 		/* update progress */
-		g_usleep(100 * 1000);
 		fu_progress_step_done(progress);
 	}
 


### PR DESCRIPTION
Speed up the write by removing the delay after SFWd write:
- 100ms (current): 3m 16s
- no delays: 1m 45s

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
