### PR TITLE
ti-tps6598x: Use the TX identity to set the PD VID&PID to the correct…

### DIFF
--- a/plugins/ti-tps6598x/README.md
+++ b/plugins/ti-tps6598x/README.md
@@ -23,11 +23,10 @@ These devices use the standard USB DeviceInstanceId values, e.g.
 * `USB\VID_0451&PID_ACE1`
 * `USB\VID_0451`
 
-Devices also have additional instance IDs which corresponds to the UID, oUID and OTP config, e.g.
+Child devices also have an additional instance IDs which corresponds to the index, e.g.
 
-* `USB\VID_0451&PID_ACE1&UID_50bf5616c608a6b98b4169b220d9a5b8`
-* `USB\VID_0451&PID_ACE1&OUID_2200000000000000`
-* `USB\VID_0451&PID_0451&CONFIG_00000000A206000030000000`
+* `USB\VID_2188&PID_5988&REV_0714&PD_00
+* `USB\VID_2188&PID_5988&PD_00
 
 ## Update Behavior
 

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-common.h
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-common.h
@@ -27,6 +27,7 @@
 #define TI_TPS6598X_REGISTER_OTP_CONFIG	      0x2D /* ro, 12 bytes */
 #define TI_TPS6598X_REGISTER_BUILD_IDENTIFIER 0x2E /* ro, 64 bytes */
 #define TI_TPS6598X_REGISTER_DEVICE_INFO      0x2F /* ro, 47 bytes */
+#define TI_TPS6598X_REGISTER_TX_IDENTITY      0x47 /* rw, 49 bytes */
 
 #define TI_TPS6598X_SFWI_SUCCESS		    0x0
 #define TI_TPS6598X_SFWI_FAIL_FLASH_ERROR_OR_BUSY   0x4

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -14,6 +14,8 @@
 
 struct _FuTiTps6598xDevice {
 	FuUsbDevice parent_instance;
+	gchar *uid;
+	gchar *ouid;
 };
 
 G_DEFINE_TYPE(FuTiTps6598xDevice, fu_ti_tps6598x_device, FU_TYPE_USB_DEVICE)
@@ -24,6 +26,14 @@ G_DEFINE_TYPE(FuTiTps6598xDevice, fu_ti_tps6598x_device, FU_TYPE_USB_DEVICE)
 #define TI_TPS6598X_USB_REQUEST_WRITE 0xFD
 #define TI_TPS6598X_USB_REQUEST_READ  0xFE
 #define TI_TPS6598X_USB_BUFFER_SIZE   8 /* bytes */
+
+static void
+fu_ti_tps6598x_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuTiTps6598xDevice *self = FU_TI_TPS6598X_DEVICE(device);
+	fu_string_append(str, idt, "UID", self->uid);
+	fu_string_append(str, idt, "oUID", self->ouid);
+}
 
 /* read @length bytes from address @addr */
 static GByteArray *
@@ -465,61 +475,25 @@ fu_ti_tps6598x_device_ensure_mode(FuTiTps6598xDevice *self, GError **error)
 static gboolean
 fu_ti_tps6598x_device_ensure_uid(FuTiTps6598xDevice *self, GError **error)
 {
-	g_autofree gchar *str = NULL;
-	g_autoptr(GByteArray) buf = NULL;
-
-	buf = fu_ti_tps6598x_device_usbep_read(self, TI_TPS6598X_REGISTER_UID, 16, error);
+	g_autoptr(GByteArray) buf =
+	    fu_ti_tps6598x_device_usbep_read(self, TI_TPS6598X_REGISTER_UID, 16, error);
 	if (buf == NULL)
 		return FALSE;
-	str = fu_byte_array_to_string(buf);
-	fu_device_add_instance_str(FU_DEVICE(self), "UID", str);
-	return fu_device_build_instance_id(FU_DEVICE(self),
-					   error,
-					   "USB",
-					   "VID",
-					   "PID",
-					   "UID",
-					   NULL);
+	g_free(self->uid);
+	self->uid = fu_byte_array_to_string(buf);
+	return TRUE;
 }
 
 static gboolean
 fu_ti_tps6598x_device_ensure_ouid(FuTiTps6598xDevice *self, GError **error)
 {
-	g_autofree gchar *str = NULL;
-	g_autoptr(GByteArray) buf = NULL;
-
-	buf = fu_ti_tps6598x_device_usbep_read(self, TI_TPS6598X_REGISTER_OUID, 8, error);
+	g_autoptr(GByteArray) buf =
+	    fu_ti_tps6598x_device_usbep_read(self, TI_TPS6598X_REGISTER_OUID, 8, error);
 	if (buf == NULL)
 		return FALSE;
-	str = fu_byte_array_to_string(buf);
-	fu_device_add_instance_str(FU_DEVICE(self), "OUID", str);
-	return fu_device_build_instance_id(FU_DEVICE(self),
-					   error,
-					   "USB",
-					   "VID",
-					   "PID",
-					   "OUID",
-					   NULL);
-}
-
-static gboolean
-fu_ti_tps6598x_device_ensure_config(FuTiTps6598xDevice *self, GError **error)
-{
-	g_autofree gchar *str = NULL;
-	g_autoptr(GByteArray) buf = NULL;
-
-	buf = fu_ti_tps6598x_device_usbep_read(self, TI_TPS6598X_REGISTER_OTP_CONFIG, 12, error);
-	if (buf == NULL)
-		return FALSE;
-	str = fu_byte_array_to_string(buf);
-	fu_device_add_instance_strup(FU_DEVICE(self), "CONFIG", str);
-	return fu_device_build_instance_id(FU_DEVICE(self),
-					   error,
-					   "USB",
-					   "VID",
-					   "PID",
-					   "CONFIG",
-					   NULL);
+	g_free(self->ouid);
+	self->ouid = fu_byte_array_to_string(buf);
+	return TRUE;
 }
 
 static gboolean
@@ -556,10 +530,6 @@ fu_ti_tps6598x_device_setup(FuDevice *device, GError **error)
 	}
 	if (!fu_ti_tps6598x_device_ensure_ouid(self, error)) {
 		g_prefix_error(error, "failed to read oUID: ");
-		return FALSE;
-	}
-	if (!fu_ti_tps6598x_device_ensure_config(self, error)) {
-		g_prefix_error(error, "failed to read OTP config: ");
 		return FALSE;
 	}
 
@@ -788,9 +758,21 @@ fu_ti_tps6598x_device_init(FuTiTps6598xDevice *self)
 }
 
 static void
+fu_ti_tps6598x_device_finalize(GObject *object)
+{
+	FuTiTps6598xDevice *self = FU_TI_TPS6598X_DEVICE(object);
+	g_free(self->uid);
+	g_free(self->ouid);
+	G_OBJECT_CLASS(fu_ti_tps6598x_device_parent_class)->finalize(object);
+}
+
+static void
 fu_ti_tps6598x_device_class_init(FuTiTps6598xDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_ti_tps6598x_device_finalize;
+	klass_device->to_string = fu_ti_tps6598x_device_to_string;
 	klass_device->write_firmware = fu_ti_tps6598x_device_write_firmware;
 	klass_device->attach = fu_ti_tps6598x_device_attach;
 	klass_device->setup = fu_ti_tps6598x_device_setup;


### PR DESCRIPTION
… values

This allows us to match the firmware stream to the dock model perfectly, without relying on the oUID and CONFIG being set to specific OEM values.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
