### PR TITLE
Add fu_archive_firmware_get_image_fnmatch() for future use

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -459,6 +459,7 @@ done
 %{_datadir}/installed-tests/fwupd/*.test
 %{_datadir}/installed-tests/fwupd/*.cab
 %{_datadir}/installed-tests/fwupd/*.sh
+%{_datadir}/installed-tests/fwupd/*.zip
 %if 0%{?have_uefi}
 %{_datadir}/installed-tests/fwupd/efi
 %endif

--- a/libfwupdplugin/fu-archive-firmware.h
+++ b/libfwupdplugin/fu-archive-firmware.h
@@ -28,3 +28,7 @@ FuArchiveCompression
 fu_archive_firmware_get_compression(FuArchiveFirmware *self);
 void
 fu_archive_firmware_set_compression(FuArchiveFirmware *self, FuArchiveCompression compression);
+FuFirmware *
+fu_archive_firmware_get_image_fnmatch(FuArchiveFirmware *self,
+				      const gchar *pattern,
+				      GError **error);

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1143,6 +1143,7 @@ LIBFWUPDPLUGIN_1.8.7 {
 
 LIBFWUPDPLUGIN_1.8.9 {
   global:
+    fu_archive_firmware_get_image_fnmatch;
     fu_byte_array_to_string;
     fu_version_from_uint24;
   local: *;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -340,6 +340,7 @@ if get_option('tests')
   env.set('G_TEST_BUILDDIR', meson.current_build_dir())
   e = executable(
     'fwupdplugin-self-test',
+    installed_firmware_zip,
     sources: [
       'fu-self-test.c'
     ],

--- a/libfwupdplugin/tests/meson.build
+++ b/libfwupdplugin/tests/meson.build
@@ -1,2 +1,15 @@
 subdir('colorhug')
 subdir('efi')
+
+installed_firmware_zip = custom_target('installed-firmware-zip',
+  input: [
+    'colorhug/firmware.bin',
+    'colorhug/firmware.bin.asc',
+  ],
+  output: 'firmware.zip',
+  command: [
+    python3, '-m', 'zipfile', '-c', '@OUTPUT@', '@INPUT@',
+  ],
+  install: true,
+  install_dir: installed_test_datadir,
+)


### PR DESCRIPTION
It's useful to get images from archives by a specific filename extension.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
