### PR TITLE
Make no-conffile behavior more expected

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -60,11 +60,16 @@ TrustedUids=
 # config level. e.g. `vendor-factory-2021q1`
 HostBkc=
 
-# The EFI system partition (ESP) path used if UDisks is not available
-# or if this partition is not mounted at /boot/efi, /boot, or /efi
-#EspLocation=
+# Override the location used for the EFI system partition (ESP) path.
+# This is typically used if UDisks is not available, or was not able to
+# automatically identify the location for any reason.
+EspLocation=
 
-# these are only required when the SMBIOS or Device Tree data is invalid or missing
+# Override values for SMBIOS / Device Tree data on a system.
+# These are only required when the SMBIOS or Device Tree data is invalid,
+# missing, or to simulate running on another system.
+# * Uncomment them to populate blank entries
+# * Uncomment them and add values to populate specific entries
 #Manufacturer=
 #ProductName=
 #ProductSku=

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -192,7 +192,7 @@ fu_config_reload(FuConfig *self, GError **error)
 	}
 
 	/* get idle timeout */
-	idle_timeout = g_key_file_get_int64(keyfile, "fwupd", "IdleTimeout", &error_timeout);
+	idle_timeout = g_key_file_get_uint64(keyfile, "fwupd", "IdleTimeout", &error_timeout);
 	if (idle_timeout > 0)
 		self->idle_timeout = idle_timeout;
 	else if (error_timeout != NULL)

--- a/src/tests/daemon.conf
+++ b/src/tests/daemon.conf
@@ -1,2 +1,2 @@
 [fwupd]
-# nothing to see here
+DisabledPlugins=


### PR DESCRIPTION
Right now when someone removes the `daemon.conf` conffile for whatever reason, we end up with the test and test_ble plugins enabled and also some defaults don't match.

Adjust the handling of this file such that:

    1) All keys are configured with their default value.
    2) Commenting out a key should keep the default value.
    3) Modifying a key sets a new value.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
