### PR TITLE
Add device ID and support for Quectel RM520 

### DIFF
--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -30,6 +30,12 @@ AT command to execute to determine the firmware branch currently installed on th
 
 Since: 1.7.4
 
+### ModemManagerFirehoseProgFile
+
+Firehose program file to use during the switch to EDL (Emergency Download) mode.
+
+Since: 1.8.10
+
 ## Vendor ID Security
 
 The vendor ID is set from the USB or PCI vendor, for example `USB:0x413C` `PCI:0x105B`

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -68,3 +68,8 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
 [PCI\VID_1EAC&PID_1002]
 Summary = Quectel EM160 firehose prog file
 ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
+
+# Quectel RM520 firehose prog file
+[PCI\VID_1EAC&PID_1004]
+Summary = Quectel RM520 firehose prog file
+ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -58,3 +58,13 @@ ModemManagerBranchAtCommand = AT+GETFWBRANCH
 [USB\VID_05C6&PID_9008]
 Summary = Qualcomm based modems in EDL (sahara)
 Plugin = modem_manager
+
+# Quectel EM120 firehose prog file
+[PCI\VID_1EAC&PID_1001]
+Summary = Quectel EM120 firehose prog file
+ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
+
+# Quectel EM160 firehose prog file
+[PCI\VID_1EAC&PID_1002]
+Summary = Quectel EM160 firehose prog file
+ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn


### PR DESCRIPTION
Hi,

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

New Quectel RM520 PCIe modem is based on Qualcomm SDX6x and requires a different firehose binary for the update process.
RM520 differs from other Quectel PCIe modems only by PID, so this merge request adds device ID to the FuMmDevice structure and uses it to select the correct binary in `fu_mm_copy_firehose_prog` 

Thanks and happy holidays!