### PR TITLE
Do not allow LZX compressed cabinet archives

### DIFF
--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -69,6 +69,10 @@ fu_cabinet_init(FuCabinet *self)
 {
 	self->size_max = 1024 * 1024 * 100;
 	self->gcab_cabinet = gcab_cabinet_new();
+#ifdef HAVE_GCAB_CABINET_ADD_ALLOWED_COMPRESSION
+	gcab_cabinet_add_allowed_compression(self->gcab_cabinet, GCAB_COMPRESSION_NONE);
+	gcab_cabinet_add_allowed_compression(self->gcab_cabinet, GCAB_COMPRESSION_MSZIP);
+#endif
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();
 	self->jcat_context = jcat_context_new();

--- a/meson.build
+++ b/meson.build
@@ -267,8 +267,13 @@ if build_daemon
 endif
 libm = cc.find_library('m', required: false)
 libgcab = dependency('libgcab-1.0', version: '>= 1.0', fallback: ['gcab', 'gcab_dep'])
-if libgcab.type_name() == 'pkgconfig' and cc.has_function('gcab_file_set_bytes', dependencies: libgcab)
-  conf.set('HAVE_GCAB_FILE_SET_BYTES', '1')
+if libgcab.type_name() == 'pkgconfig'
+  if cc.has_function('gcab_file_set_bytes', dependencies: libgcab)
+    conf.set('HAVE_GCAB_FILE_SET_BYTES', '1')
+  endif
+  if cc.has_function('gcab_cabinet_add_allowed_compression', dependencies: libgcab)
+    conf.set('HAVE_GCAB_CABINET_ADD_ALLOWED_COMPRESSION', '1')
+  endif
 endif
 
 bashcomp = dependency('bash-completion', required: false)


### PR DESCRIPTION
The GCab decompression code is *scary* low level C that has not had any security auditing other than by the fuzzer (which found plenty of memory-safety bugs).

Supporting LZX is useless at best, and could be a security exploit at worst.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
