### PR TITLE
emmc: Add back a legacy GUID to fix a regression

### DIFF
--- a/plugins/emmc/README.md
+++ b/plugins/emmc/README.md
@@ -13,12 +13,16 @@ eMMC devices support the `org.jedec.mmc` protocol.
 
 These devices use the following instance values:
 
-* `EMMC\%NAME%`
-* `EMMC\%NAME%&%REV%`
-* `EMMC\%MANFID%&%OEMID%`
-* `EMMC\%MANFID%&%OEMID%&%NAME%`
-* `EMMC\%MANFID%&%NAME%&%REV%`
-* `EMMC\%MANFID%&%OEMID%&%NAME%&%REV%`
+* `EMMC\NAME_%name%`
+* `EMMC\NAME_%name%&REV_%rev%`
+* `EMMC\MAN_%manfid%&OEM_%oemid%`
+* `EMMC\MAN_%manfid%&OEM_%oemid%&NAME_%name%`
+* `EMMC\MAN_%manfid%&NAME_%name%&REV_%rev%`
+* `EMMC\MAN_%manfid%&OEM_%oemid%&NAME_%name%&REV_%rev%`
+
+One deprecated instance ID is also added; new firmware should not use this.
+
+* `EMMC\%manfid%&%oemid%&%name%`
 
 ## Update Behavior
 

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -136,6 +136,7 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 	guint64 manfid = 0;
 	const gchar *tmp;
 	g_autoptr(GUdevDevice) udev_parent = NULL;
+	g_autofree gchar *man_oem_name = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autoptr(GRegex) dev_regex = NULL;
 
@@ -220,6 +221,13 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 	fu_device_build_instance_id(device, NULL, "EMMC", "MAN", "OEM", "NAME", NULL);
 	fu_device_build_instance_id(device, NULL, "EMMC", "MAN", "NAME", "REV", NULL);
 	fu_device_build_instance_id(device, NULL, "EMMC", "MAN", "OEM", "NAME", "REV", NULL);
+
+	/* this is a (invalid!) instance ID added for legacy compatibility */
+	man_oem_name = g_strdup_printf("EMMC\\%04x&%04x&%s",
+				       (guint)manfid,
+				       (guint)oemid,
+				       fu_device_get_name(device));
+	fu_device_add_instance_id(device, man_oem_name);
 
 	/* set the vendor */
 	tmp = g_udev_device_get_sysfs_attr(udev_parent, "manfid");


### PR DESCRIPTION
I had no idea anyone was using this, so apologies. The instance ID is completely wrong, but it is effectively D-Bus ABI and we need to support old firmware in the field.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
