### PR TITLE
trivial: Set the backend ID when added

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -59,6 +59,10 @@ fu_backend_device_added(FuBackend *self, FuDevice *device)
 	if (priv->ctx != NULL)
 		fu_device_set_context(device, priv->ctx);
 
+	/* set backend ID if required */
+	if (fu_device_get_backend_id(device) == NULL)
+		fu_device_set_backend_id(device, priv->name);
+
 	/* add */
 	g_hash_table_insert(priv->devices,
 			    g_strdup(fu_device_get_backend_id(device)),


### PR DESCRIPTION
This matches what the plugin does and means there's no critical warning when adding to the hash table.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
