### PR TITLE
trivial: Reduce runtime RSS requirement for each device subclass

### DIFF
--- a/libfwupdplugin/fu-bluez-device.h
+++ b/libfwupdplugin/fu-bluez-device.h
@@ -13,7 +13,6 @@ G_DECLARE_DERIVABLE_TYPE(FuBluezDevice, fu_bluez_device, FU, BLUEZ_DEVICE, FuDev
 
 struct _FuBluezDeviceClass {
 	FuDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 GByteArray *

--- a/libfwupdplugin/fu-cfi-device.h
+++ b/libfwupdplugin/fu-cfi-device.h
@@ -14,7 +14,6 @@ G_DECLARE_DERIVABLE_TYPE(FuCfiDevice, fu_cfi_device, FU, CFI_DEVICE, FuDevice)
 struct _FuCfiDeviceClass {
 	FuDeviceClass parent_class;
 	gboolean (*chip_select)(FuCfiDevice *self, gboolean value, GError **error);
-	gpointer __reserved[30];
 };
 
 /**

--- a/libfwupdplugin/fu-hid-device.h
+++ b/libfwupdplugin/fu-hid-device.h
@@ -13,7 +13,6 @@ G_DECLARE_DERIVABLE_TYPE(FuHidDevice, fu_hid_device, FU, HID_DEVICE, FuUsbDevice
 
 struct _FuHidDeviceClass {
 	FuUsbDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 /**

--- a/libfwupdplugin/fu-i2c-device.h
+++ b/libfwupdplugin/fu-i2c-device.h
@@ -13,7 +13,6 @@ G_DECLARE_DERIVABLE_TYPE(FuI2cDevice, fu_i2c_device, FU, I2C_DEVICE, FuUdevDevic
 
 struct _FuI2cDeviceClass {
 	FuUdevDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 guint

--- a/libfwupdplugin/fu-mei-device.h
+++ b/libfwupdplugin/fu-mei-device.h
@@ -13,7 +13,6 @@ G_DECLARE_DERIVABLE_TYPE(FuMeiDevice, fu_mei_device, FU, MEI_DEVICE, FuUdevDevic
 
 struct _FuMeiDeviceClass {
 	FuUdevDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 gboolean

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -27,7 +27,6 @@ G_DECLARE_DERIVABLE_TYPE(FuUdevDevice, fu_udev_device, FU, UDEV_DEVICE, FuDevice
 
 struct _FuUdevDeviceClass {
 	FuDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 /**

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -24,7 +24,6 @@ G_DECLARE_DERIVABLE_TYPE(FuUsbDevice, fu_usb_device, FU, USB_DEVICE, FuDevice)
 
 struct _FuUsbDeviceClass {
 	FuDeviceClass parent_class;
-	gpointer __reserved[31];
 };
 
 FuUsbDevice *


### PR DESCRIPTION
Remove the FuDeviceClass padding, as this library now loaded using an rpath rather than a shared library with a static API. This matches what we did for the FuFirmwareClass objects a while ago.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
