### PR TITLE
Add a Flat Device Tree backend

### DIFF
--- a/plugins/vbe/fu-vbe-plugin.c
+++ b/plugins/vbe/fu-vbe-plugin.c
@@ -13,14 +13,12 @@
 
 struct _FuVbePlugin {
 	FuPlugin parent_instance;
-	FuFirmware *fdt;
-	gchar *vbe_dir;
 };
 
 G_DEFINE_TYPE(FuVbePlugin, fu_vbe_plugin, FU_TYPE_PLUGIN)
 
 static gboolean
-fu_vbe_plugin_coldplug_img(FuPlugin *plugin,
+fu_vbe_plugin_coldplug_img(FuVbePlugin *self,
 			   FuFdtImage *fdt_root,
 			   FuFdtImage *fdt_node,
 			   GError **error)
@@ -79,33 +77,41 @@ fu_vbe_plugin_coldplug_img(FuPlugin *plugin,
 	/* success */
 	dev = g_object_new(device_gtype,
 			   "context",
-			   fu_plugin_get_context(plugin),
+			   fu_plugin_get_context(FU_PLUGIN(self)),
 			   "fdt-root",
 			   fdt_root,
 			   "fdt-node",
 			   fdt_node,
 			   NULL);
-	fu_plugin_device_add(plugin, dev);
+	fu_plugin_device_add(FU_PLUGIN(self), dev);
 	return TRUE;
 }
 
 static gboolean
-fu_vbe_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+fu_vbe_plugin_backend_device_added(FuPlugin *plugin, FuDevice *device, GError **error)
 {
 	FuVbePlugin *self = FU_VBE_PLUGIN(plugin);
+	g_autoptr(FuFirmware) fdt = NULL;
 	g_autoptr(FuFdtImage) fdt_root = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GPtrArray) fdt_imgs = NULL;
 
+	/* not interesting */
+	if (g_strcmp0(fu_device_get_backend_id(device), "fdt") != 0)
+		return TRUE;
+
 	/* get compatible from root node */
-	fdt_root =
-	    fu_fdt_firmware_get_image_by_path(FU_FDT_FIRMWARE(self->fdt), "/chosen/fwupd", error);
+	fdt = fu_device_read_firmware(device, progress, error);
+	if (fdt == NULL)
+		return FALSE;
+	fdt_root = fu_fdt_firmware_get_image_by_path(FU_FDT_FIRMWARE(fdt), "/chosen/fwupd", error);
 	if (fdt_root == NULL)
 		return FALSE;
 	fdt_imgs = fu_firmware_get_images(FU_FIRMWARE(fdt_root));
 	for (guint i = 0; i < fdt_imgs->len; i++) {
 		FuFdtImage *fdt_node = g_ptr_array_index(fdt_imgs, i);
 		g_autoptr(GError) error_local = NULL;
-		if (!fu_vbe_plugin_coldplug_img(plugin, fdt_root, fdt_node, &error_local)) {
+		if (!fu_vbe_plugin_coldplug_img(self, fdt_root, fdt_node, &error_local)) {
 			g_warning("%s", error_local->message);
 			continue;
 		}
@@ -124,77 +130,14 @@ fu_vbe_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 	return TRUE;
 }
 
-static GFile *
-fu_vbe_plugin_get_bfname(FuPlugin *plugin)
-{
-	FuVbePlugin *self = FU_VBE_PLUGIN(plugin);
-	g_autofree gchar *bfname_local = NULL;
-	g_autofree gchar *bfname_sys = NULL;
-	g_autofree gchar *sysfsdir = NULL;
-
-	/* look for override first, fall back to system value */
-	bfname_local = g_build_filename(self->vbe_dir, "system.dtb", NULL);
-	if (g_file_test(bfname_local, G_FILE_TEST_EXISTS))
-		return g_file_new_for_path(bfname_local);
-
-	/* actual hardware value */
-	sysfsdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW);
-	bfname_sys = g_build_filename(sysfsdir, "fdt", NULL);
-	return g_file_new_for_path(bfname_sys);
-}
-
-static gboolean
-fu_vbe_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
-{
-	FuVbePlugin *self = FU_VBE_PLUGIN(plugin);
-	g_autoptr(GFile) file = NULL;
-
-	/* look for override first, fall back to system value */
-	file = fu_vbe_plugin_get_bfname(plugin);
-	if (!fu_firmware_parse_file(self->fdt, file, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
-		g_prefix_error(error, "failed to parse FDT: ");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static void
-fu_vbe_plugin_to_string(FuPlugin *plugin, guint idt, GString *str)
-{
-	FuVbePlugin *self = FU_VBE_PLUGIN(plugin);
-	fu_string_append(str, idt, "VbeDir", self->vbe_dir);
-}
-
 static void
 fu_vbe_plugin_init(FuVbePlugin *self)
 {
-	g_autofree gchar *localstatedir_pkg = NULL;
-
-	/* where we can store the override and also image state */
-	localstatedir_pkg = fu_path_from_kind(FU_PATH_KIND_LOCALSTATEDIR_PKG);
-	self->vbe_dir = g_build_filename(localstatedir_pkg, "vbe", NULL);
-	self->fdt = fu_fdt_firmware_new();
-}
-
-static void
-fu_vbe_finalize(GObject *obj)
-{
-	FuVbePlugin *self = FU_VBE_PLUGIN(obj);
-	g_free(self->vbe_dir);
-	g_object_unref(self->fdt);
-	G_OBJECT_CLASS(fu_vbe_plugin_parent_class)->finalize(obj);
 }
 
 static void
 fu_vbe_plugin_class_init(FuVbePluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->finalize = fu_vbe_finalize;
-	plugin_class->to_string = fu_vbe_plugin_to_string;
-	plugin_class->startup = fu_vbe_plugin_startup;
-	plugin_class->coldplug = fu_vbe_plugin_coldplug;
+	plugin_class->backend_device_added = fu_vbe_plugin_backend_device_added;
 }

--- a/plugins/vbe/meson.build
+++ b/plugins/vbe/meson.build
@@ -1,5 +1,6 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginVbe"']
 
+plugin_quirks += files('vbe.quirk')
 plugin_builtins += static_library('fu_plugin_vbe',
   sources : [
     'fu-vbe-plugin.c',

--- a/plugins/vbe/vbe.quirk
+++ b/plugins/vbe/vbe.quirk
@@ -1,0 +1,2 @@
+[FDT]
+Plugin = vbe

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -48,6 +48,7 @@
 #include "fu-engine-helper.h"
 #include "fu-engine-request.h"
 #include "fu-engine.h"
+#include "fu-fdt-backend.h"
 #include "fu-history.h"
 #include "fu-idle.h"
 #include "fu-kenv.h"
@@ -8396,6 +8397,7 @@ fu_engine_init(FuEngine *self)
 			 self);
 
 	/* backends */
+	g_ptr_array_add(self->backends, fu_fdt_backend_new(self->ctx));
 #ifdef HAVE_GUSB
 	g_ptr_array_add(self->backends, fu_usb_backend_new(self->ctx));
 #endif

--- a/src/fu-fdt-backend.c
+++ b/src/fu-fdt-backend.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuBackend"
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-fdt-backend.h"
+#include "fu-fdt-device.h"
+
+struct _FuFdtBackend {
+	FuBackend parent_instance;
+};
+
+G_DEFINE_TYPE(FuFdtBackend, fu_fdt_backend, FU_TYPE_BACKEND)
+
+static GFile *
+fu_fdt_backend_get_bfname(FuFdtBackend *self, GError **error)
+{
+	g_autofree gchar *bfname_local = NULL;
+	g_autofree gchar *bfname_sys = NULL;
+	g_autofree gchar *localstatedir_pkg = fu_path_from_kind(FU_PATH_KIND_LOCALSTATEDIR_PKG);
+	g_autofree gchar *sysfsdir = NULL;
+
+	/* look for override first, fall back to system value */
+	bfname_local = g_build_filename(localstatedir_pkg, "vbe", "system.dtb", NULL);
+	if (g_file_test(bfname_local, G_FILE_TEST_EXISTS))
+		return g_file_new_for_path(bfname_local);
+
+	/* actual hardware value */
+	sysfsdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW);
+	bfname_sys = g_build_filename(sysfsdir, "fdt", NULL);
+	if (g_file_test(bfname_sys, G_FILE_TEST_EXISTS))
+		return g_file_new_for_path(bfname_sys);
+
+	/* failed */
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "cannot find %s or override %s",
+		    bfname_sys,
+		    bfname_local);
+	return NULL;
+}
+
+static gboolean
+fu_fdt_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **error)
+{
+	FuFdtBackend *self = FU_FDT_BACKEND(backend);
+	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuFirmware) fdt_firmware = fu_fdt_firmware_new();
+	g_autoptr(GFile) file = NULL;
+
+	/* look for override first, fall back to system value */
+	file = fu_fdt_backend_get_bfname(self, error);
+	if (file == NULL)
+		return FALSE;
+	if (!fu_firmware_parse_file(fdt_firmware, file, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
+		g_prefix_error(error, "failed to parse FDT: ");
+		return FALSE;
+	}
+
+	/* add device */
+	device = g_object_new(FU_TYPE_FDT_DEVICE, "fdt-firmware", fdt_firmware, NULL);
+	fu_backend_device_added(backend, device);
+	return TRUE;
+}
+
+static void
+fu_fdt_backend_init(FuFdtBackend *self)
+{
+}
+
+static void
+fu_fdt_backend_class_init(FuFdtBackendClass *klass)
+{
+	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
+	klass_backend->coldplug = fu_fdt_backend_coldplug;
+}
+
+FuBackend *
+fu_fdt_backend_new(FuContext *ctx)
+{
+	FuFdtBackend *self;
+	self =
+	    FU_FDT_BACKEND(g_object_new(FU_TYPE_FDT_BACKEND, "name", "fdt", "context", ctx, NULL));
+	return FU_BACKEND(self);
+}

--- a/src/fu-fdt-backend.h
+++ b/src/fu-fdt-backend.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-backend.h"
+
+#define FU_TYPE_FDT_BACKEND (fu_fdt_backend_get_type())
+G_DECLARE_FINAL_TYPE(FuFdtBackend, fu_fdt_backend, FU, FDT_BACKEND, FuBackend)
+
+FuBackend *
+fu_fdt_backend_new(FuContext *ctx);

--- a/src/fu-fdt-device.c
+++ b/src/fu-fdt-device.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuFdtDevice"
+
+#include "config.h"
+
+#include "fu-fdt-device.h"
+#include "fu-fdt-firmware.h"
+
+typedef struct {
+	FuFirmware *fdt_firmware;
+} FuFdtDevicePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(FuFdtDevice, fu_fdt_device, FU_TYPE_DEVICE)
+
+enum { PROP_0, PROP_FDT_FIRMWARE, PROP_LAST };
+
+#define GET_PRIVATE(o) (fu_fdt_device_get_instance_private(o))
+
+static gboolean
+fu_fdt_device_probe(FuDevice *device, GError **error)
+{
+	FuFdtDevice *self = FU_FDT_DEVICE(device);
+	FuFdtDevicePrivate *priv = GET_PRIVATE(self);
+	g_autoptr(FuFirmware) fdt_root = NULL;
+	g_autofree gchar *compatible = NULL;
+
+	/* set instance ID on device from root "compatible" */
+	fdt_root = fu_firmware_get_image_by_id(priv->fdt_firmware, NULL, error);
+	if (fdt_root == NULL)
+		return FALSE;
+	if (!fu_fdt_image_get_attr_str(FU_FDT_IMAGE(fdt_root), "compatible", &compatible, error))
+		return FALSE;
+	fu_device_add_instance_strsafe(device, "COMPATIBLE", compatible);
+	if (!fu_device_build_instance_id_quirk(device, error, "FDT", NULL))
+		return FALSE;
+	return fu_device_build_instance_id(device, error, "FDT", "COMPATIBLE", NULL);
+}
+
+static FuFirmware *
+fu_fdt_device_read_firmware(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuFdtDevice *self = FU_FDT_DEVICE(device);
+	FuFdtDevicePrivate *priv = GET_PRIVATE(self);
+	return g_object_ref(priv->fdt_firmware);
+}
+
+static void
+fu_fdt_device_get_property(GObject *obj, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	FuFdtDevice *self = FU_FDT_DEVICE(obj);
+	FuFdtDevicePrivate *priv = GET_PRIVATE(self);
+	switch (prop_id) {
+	case PROP_FDT_FIRMWARE:
+		g_value_set_object(value, priv->fdt_firmware);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+fu_fdt_device_set_property(GObject *obj, guint prop_id, const GValue *value, GParamSpec *pspec)
+{
+	FuFdtDevice *self = FU_FDT_DEVICE(obj);
+	FuFdtDevicePrivate *priv = GET_PRIVATE(self);
+	switch (prop_id) {
+	case PROP_FDT_FIRMWARE:
+		g_set_object(&priv->fdt_firmware, g_value_get_object(value));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(obj, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+fu_fdt_device_finalize(GObject *object)
+{
+	FuFdtDevice *self = FU_FDT_DEVICE(object);
+	FuFdtDevicePrivate *priv = GET_PRIVATE(self);
+	if (priv->fdt_firmware != NULL)
+		g_object_unref(priv->fdt_firmware);
+	G_OBJECT_CLASS(fu_fdt_device_parent_class)->finalize(object);
+}
+
+static void
+fu_fdt_device_init(FuFdtDevice *self)
+{
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+}
+
+static void
+fu_fdt_device_class_init(FuFdtDeviceClass *klass)
+{
+	GParamSpec *pspec;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	object_class->finalize = fu_fdt_device_finalize;
+	object_class->get_property = fu_fdt_device_get_property;
+	object_class->set_property = fu_fdt_device_set_property;
+
+	device_class->probe = fu_fdt_device_probe;
+	device_class->read_firmware = fu_fdt_device_read_firmware;
+
+	pspec =
+	    g_param_spec_object("fdt-firmware",
+				NULL,
+				NULL,
+				FU_TYPE_FDT_FIRMWARE,
+				G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_FDT_FIRMWARE, pspec);
+}

--- a/src/fu-fdt-device.h
+++ b/src/fu-fdt-device.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-device.h"
+
+#define FU_TYPE_FDT_DEVICE (fu_fdt_device_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuFdtDevice, fu_fdt_device, FU, FDT_DEVICE, FuDevice)
+
+struct _FuFdtDeviceClass {
+	FuDeviceClass parent_class;
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,8 @@ fwupd_engine_src = [
   'fu-engine.c',
   'fu-engine-helper.c',
   'fu-engine-request.c',
+  'fu-fdt-backend.c',
+  'fu-fdt-device.c',
   'fu-history.c',
   'fu-idle.c',
   'fu-polkit-authority.c',


### PR DESCRIPTION
This is needed because multiple plugins will soon be consuming the system FDT, and we don't want to either parse this multiple times, or duplicate the loading logic.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
