### PR TITLE
Respect user requested paths for ESP even if they aren't volumes

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -725,6 +725,10 @@ fu_volume_new_esp_for_path(const gchar *esp_path, GError **error)
 		if (g_strcmp0(basename, vol_basename) == 0)
 			return g_object_ref(vol);
 	}
+	if (g_file_test(esp_path, G_FILE_TEST_IS_DIR)) {
+		g_debug("Using user requested path %s for ESP", esp_path);
+		return fu_volume_new_from_mount_path(esp_path);
+	}
 	g_set_error(error,
 		    G_IO_ERROR,
 		    G_IO_ERROR_INVALID_FILENAME,


### PR DESCRIPTION
These paths may be used for bind mounts, which we can't accurately discover. Leave a message in the logs accordingly, but allow these paths.

fixes: #5185

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
