### PR TITLE
uefi-capsule: Do not call grub2-probe without arguments

### DIFF
--- a/plugins/uefi-capsule/fwupd.grub.conf.in
+++ b/plugins/uefi-capsule/fwupd.grub.conf.in
@@ -14,8 +14,8 @@ if [ -f @localstatedir@/lib/fwupd/uefi_capsule.conf ] &&
 cat << EOF
 menuentry 'Linux Firmware Updater' \$menuentry_id_option 'fwupd' {
 EOF
-      ${grub_probe:?}
-      prepare_grub_to_access_device '`${grub_probe} --target=device \${ESP}` | sed -e "s/^/\t/"'
+      ${grub_probe:?} --version > /dev/null
+      prepare_grub_to_access_device "$(${grub_probe} --target=device ${ESP})" | sed -e "s/^/\t/"
 cat << EOF
 	chainloader ${EFI_PATH}
 }


### PR DESCRIPTION
commit 684bc0381 ("trivial: fix various shellcheck warnings") adds call to ${grub_probe} without any argument which causes grub2-probe to return an error, and generating grub configuration fails.

Add --version argument to avoid the error, and redierct the output to /dev/null so that it's not included in the grub configuration file.

The commit also adds superfluous single quotes causing another error:

/usr/sbin/grub2-probe: error: cannot find a GRUB drive for `${grub_probe} --target=device \${ESP}` | sed -e "s/^/\t/".  Check your device.map.

Remove the single quotes again.

Fixes: #5424
Fixes: 684bc0381 ("trivial: fix various shellcheck warnings")
Signed-off-by: Michal Suchanek <msuchanek@suse.de>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
