### PR TITLE
Allow desktop software to inhibit devices to prevent updates

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -20,6 +20,8 @@ _fwupdmgr_cmd_list=(
 	'get-updates'
 	'get-upgrades'
 	'get-plugins'
+	'inhibit'
+	'uninhibit'
 	'install'
 	'local-install'
 	'modify-config'

--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -64,6 +64,8 @@ complete -c fwupdmgr -n '__fish_use_subcommand' -x -a unlock -d 'Unlocks the dev
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a update -d 'Updates all firmware to latest versions available'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify -d 'Checks cryptographic hash matches firmware'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a verify-update -d 'Update the stored cryptographic hash with current ROM contents'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a inhibit -d 'Inhibit the system to prevent upgrades'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a uninhibit -d 'Uninhibit the system to allow upgrades'
 
 # commands exclusively consuming device IDs
 set -l deviceid_consumers activate clear-results downgrade get-releases get-results get-updates reinstall switch-branch unlock update verify verify-update

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -66,6 +66,16 @@ fwupd_client_unlock(FwupdClient *self,
 		    const gchar *device_id,
 		    GCancellable *cancellable,
 		    GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gchar *
+fwupd_client_inhibit(FwupdClient *self,
+		     const gchar *reason,
+		     GCancellable *cancellable,
+		     GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fwupd_client_uninhibit(FwupdClient *self,
+		       const gchar *inhibit_id,
+		       GCancellable *cancellable,
+		       GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
 fwupd_client_modify_config(FwupdClient *self,
 			   const gchar *key,

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5390,6 +5390,168 @@ fwupd_client_upload_bytes_finish(FwupdClient *self, GAsyncResult *res, GError **
 	return g_task_propagate_pointer(G_TASK(res), error);
 }
 
+static void
+fwupd_client_inhibit_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autofree gchar *inhibit_id = NULL;
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_variant_get(val, "(s)", &inhibit_id);
+	g_task_return_pointer(task, g_steal_pointer(&inhibit_id), g_free);
+}
+
+/**
+ * fwupd_client_inhibit_async:
+ * @self: a #FwupdClient
+ * @reason: (not nullable): the inhibit reason, e.g. `user active`
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Marks all devices as unavailable for update. Update is only available if there is no other
+ * inhibit imposed by other applications or by the system (e.g. low power state).
+ *
+ * The same application can inhibit the system multiple times.
+ *
+ * Since: 1.8.11
+ **/
+void
+fwupd_client_inhibit_async(FwupdClient *self,
+			   const gchar *reason,
+			   GCancellable *cancellable,
+			   GAsyncReadyCallback callback,
+			   gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(reason != NULL);
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+	g_dbus_proxy_call(priv->proxy,
+			  "Inhibit",
+			  g_variant_new("(s)", reason),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_inhibit_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_inhibit_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.inhibit_async].
+ *
+ * Returns: (transfer full): a string to use for [method@FwupdClient.uninhibit_async],
+ * or %NULL for failure
+ *
+ * Since: 1.8.11
+ **/
+gchar *
+fwupd_client_inhibit_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
+	g_return_val_if_fail(g_task_is_valid(res, self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+	return g_task_propagate_pointer(G_TASK(res), error);
+}
+
+static void
+fwupd_client_uninhibit_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_task_return_boolean(task, TRUE);
+}
+
+/**
+ * fwupd_client_uninhibit_async:
+ * @self: a #FwupdClient
+ * @uninhibit_id: (not nullable): the inhibit ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Removes the inhibit token added by the application.
+ *
+ * Since: 1.8.11
+ **/
+void
+fwupd_client_uninhibit_async(FwupdClient *self,
+			     const gchar *inhibit_id,
+			     GCancellable *cancellable,
+			     GAsyncReadyCallback callback,
+			     gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(inhibit_id != NULL);
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+	g_dbus_proxy_call(priv->proxy,
+			  "Uninhibit",
+			  g_variant_new("(s)", inhibit_id),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_uninhibit_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_uninhibit_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.uninhibit_async].
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.8.11
+ **/
+gboolean
+fwupd_client_uninhibit_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(g_task_is_valid(res, self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	return g_task_propagate_boolean(G_TASK(res), error);
+}
+
 /**
  * fwupd_client_add_hint:
  * @self: a #FwupdClient

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -376,6 +376,26 @@ GHashTable *
 fwupd_client_get_report_metadata_finish(FwupdClient *self,
 					GAsyncResult *res,
 					GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fwupd_client_inhibit_async(FwupdClient *self,
+			   const gchar *reason,
+			   GCancellable *cancellable,
+			   GAsyncReadyCallback callback,
+			   gpointer callback_data);
+gchar *
+fwupd_client_inhibit_finish(FwupdClient *self,
+			    GAsyncResult *res,
+			    GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fwupd_client_uninhibit_async(FwupdClient *self,
+			     const gchar *inhibit_id,
+			     GCancellable *cancellable,
+			     GAsyncReadyCallback callback,
+			     gpointer callback_data);
+gboolean
+fwupd_client_uninhibit_finish(FwupdClient *self,
+			      GAsyncResult *res,
+			      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 
 FwupdStatus
 fwupd_client_get_status(FwupdClient *self);

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -362,6 +362,8 @@ fwupd_device_problem_to_string(FwupdDeviceProblem device_problem)
 		return "is-emulated";
 	if (device_problem == FWUPD_DEVICE_PROBLEM_MISSING_LICENSE)
 		return "missing-license";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT)
+		return "system-inhibit";
 	if (device_problem == FWUPD_DEVICE_PROBLEM_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -398,6 +400,8 @@ fwupd_device_problem_from_string(const gchar *device_problem)
 		return FWUPD_DEVICE_PROBLEM_IS_EMULATED;
 	if (g_strcmp0(device_problem, "missing-license") == 0)
 		return FWUPD_DEVICE_PROBLEM_MISSING_LICENSE;
+	if (g_strcmp0(device_problem, "system-inhibit") == 0)
+		return FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT;
 	return FWUPD_DEVICE_PROBLEM_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -616,6 +616,14 @@ typedef guint64 FwupdDeviceFlags;
  */
 #define FWUPD_DEVICE_PROBLEM_MISSING_LICENSE (1u << 7)
 /**
+ * FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT:
+ *
+ * The device cannot be updated due to a system-wide inhibit.
+ *
+ * Since 1.8.10
+ */
+#define FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT (1u << 8)
+/**
  * FWUPD_DEVICE_PROBLEM_UNKNOWN:
  *
  * This problem is not defined, this typically will happen from mismatched

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -164,7 +164,7 @@ fwupd_enums_func(void)
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_device_flag_from_string(tmp), ==, i);
 	}
-	for (guint64 i = 1; i <= FWUPD_DEVICE_PROBLEM_IS_EMULATED; i *= 2) {
+	for (guint64 i = 1; i <= FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT; i *= 2) {
 		const gchar *tmp = fwupd_device_problem_to_string(i);
 		if (tmp == NULL)
 			g_warning("missing device problem 0x%x", (guint)i);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -901,3 +901,14 @@ LIBFWUPD_1.8.8 {
     fwupd_report_to_variant;
   local: *;
 } LIBFWUPD_1.8.7;
+
+LIBFWUPD_1.8.11 {
+  global:
+    fwupd_client_inhibit;
+    fwupd_client_inhibit_async;
+    fwupd_client_inhibit_finish;
+    fwupd_client_uninhibit;
+    fwupd_client_uninhibit_async;
+    fwupd_client_uninhibit_finish;
+  local: *;
+} LIBFWUPD_1.8.8;

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -55,6 +55,15 @@ typedef void (*FuContextLookupIter)(FuContext *self,
 #define FU_CONTEXT_FLAG_SAVE_EVENTS (1u << 0)
 
 /**
+ * FU_CONTEXT_FLAG_SYSTEM_INHIBIT:
+ *
+ * All devices are not updatable due to a system-wide inhibit.
+ *
+ * Since: 1.8.10
+ **/
+#define FU_CONTEXT_FLAG_SYSTEM_INHIBIT (1u << 1)
+
+/**
  * FuContextFlags:
  *
  * The context flags.

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1402,6 +1402,10 @@ fu_util_device_problem_to_string(FwupdClient *client, FwupdDevice *dev, FwupdDev
 		/* TRANSLATORS: The device cannot be updated due to missing vendor's license." */
 		return g_strdup(_("Device requires a software license to update"));
 	}
+	if (problem == FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT) {
+		/* TRANSLATORS: an application is preventing system updates */
+		return g_strdup(_("All devices are prevented from update by system inhibit"));
+	}
 	return NULL;
 }
 

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -901,6 +901,52 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='Inhibit'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Marks the system as unavailable for update.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='reason' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              A reason, e.g. <doc:tt>device is being used to capture content</doc:tt>.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg type='s' name='inhibit_id' direction='out'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>The token that was used for inhibiting.</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
+    <method name='Uninhibit'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Removes the inhibit token added by the application, but only if there is no other
+            inhibit imposed by other applications or by the system (e.g. low power state).
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='inhibit_id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>The token to use for uninhibiting.</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='Quit'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
On edge hardware a process may want to disable firmware updates as it might be a bad time to allow an upgrade.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
