### PR TITLE
modem-manager: remove improper use of assert

### DIFF
--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -206,7 +206,8 @@ fu_sahara_loader_close(FuSaharaLoader *self, GError **error)
 gboolean
 fu_sahara_loader_qdl_is_open(FuSaharaLoader *self)
 {
-	g_return_val_if_fail(self != NULL, FALSE);
+	if (self == NULL)
+		return FALSE;
 
 	return fu_usb_device_is_open(self->usb_device);
 }


### PR DESCRIPTION
FuSaharaLoader being NULL is a normal case for devices that only support Firehose and don't use Sahara QDL port.
Therefore assert should not be used.

Reported here #5428 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
