### PR TITLE
Remove duplicate calls to fu_device_list_wait_for_replug()

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3153,11 +3153,6 @@ fu_engine_prepare(FuEngine *self,
 			return FALSE;
 	}
 
-	/* wait for device to disconnect and reconnect */
-	if (!fu_device_list_wait_for_replug(self->device_list, error)) {
-		g_prefix_error(error, "failed to wait for prepare replug: ");
-		return FALSE;
-	}
 	return TRUE;
 }
 
@@ -3189,11 +3184,6 @@ fu_engine_cleanup(FuEngine *self,
 			return FALSE;
 	}
 
-	/* wait for device to disconnect and reconnect */
-	if (!fu_device_list_wait_for_replug(self->device_list, error)) {
-		g_prefix_error(error, "failed to wait for cleanup replug: ");
-		return FALSE;
-	}
 	return TRUE;
 }
 


### PR DESCRIPTION
The fu_engine_get_device() function is called at the start of each phase. Duplicate calls are at best confusing, and at worst could cause a 'device failed to come back' failure.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
