### PR TITLE
Add a device problem for 'update-in-progress'

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -368,6 +368,8 @@ fwupd_device_problem_to_string(FwupdDeviceProblem device_problem)
 		return "missing-license";
 	if (device_problem == FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT)
 		return "system-inhibit";
+	if (device_problem == FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS)
+		return "update-in-process";
 	if (device_problem == FWUPD_DEVICE_PROBLEM_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -406,6 +408,8 @@ fwupd_device_problem_from_string(const gchar *device_problem)
 		return FWUPD_DEVICE_PROBLEM_MISSING_LICENSE;
 	if (g_strcmp0(device_problem, "system-inhibit") == 0)
 		return FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT;
+	if (g_strcmp0(device_problem, "update-in-process") == 0)
+		return FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS;
 	return FWUPD_DEVICE_PROBLEM_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -632,6 +632,14 @@ typedef guint64 FwupdDeviceFlags;
  */
 #define FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT (1llu << 8)
 /**
+ * FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS:
+ *
+ * The device cannot be updated as it is already being updated.
+ *
+ * Since 1.8.11
+ */
+#define FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS (1llu << 9)
+/**
  * FWUPD_DEVICE_PROBLEM_UNKNOWN:
  *
  * This problem is not defined, this typically will happen from mismatched

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -164,7 +164,7 @@ fwupd_enums_func(void)
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_device_flag_from_string(tmp), ==, i);
 	}
-	for (guint64 i = 1; i <= FWUPD_DEVICE_PROBLEM_SYSTEM_INHIBIT; i *= 2) {
+	for (guint64 i = 1; i <= FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS; i *= 2) {
 		const gchar *tmp = fwupd_device_problem_to_string(i);
 		if (tmp == NULL)
 			g_warning("missing device problem 0x%x", (guint)i);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2926,6 +2926,8 @@ fu_device_problem_to_inhibit_reason(FuDevice *self, guint64 device_problem)
 		return g_strdup("Device cannot be used while the lid is closed");
 	if (device_problem == FWUPD_DEVICE_PROBLEM_IS_EMULATED)
 		return g_strdup("Device is emulated");
+	if (device_problem == FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS)
+		return g_strdup("An update is in progress");
 	if (device_problem == FWUPD_DEVICE_PROBLEM_MISSING_LICENSE)
 		return g_strdup("Device does not have the necessary license installed");
 	if (device_problem == FWUPD_DEVICE_PROBLEM_SYSTEM_POWER_TOO_LOW) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3138,7 +3138,7 @@ fu_engine_prepare(FuEngine *self,
 		g_prefix_error(error, "failed to get device before update prepare: ");
 		return FALSE;
 	}
-	fu_device_inhibit(device, "update-in-progress", "An update is in progress");
+	fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
 
 	if (!fu_engine_device_check_power(self, device, flags, error))
 		return FALSE;
@@ -3178,7 +3178,7 @@ fu_engine_cleanup(FuEngine *self,
 		g_prefix_error(error, "failed to get device before update cleanup: ");
 		return FALSE;
 	}
-	fu_device_uninhibit(device, "update-in-progress");
+	fu_device_remove_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
 	str = fu_device_to_string(device);
 	g_debug("cleanup -> %s", str);
 	if (!fu_engine_device_cleanup(self, device, progress, flags, error))

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1410,6 +1410,10 @@ fu_util_device_problem_to_string(FwupdClient *client, FwupdDevice *dev, FwupdDev
 		/* TRANSLATORS: an application is preventing system updates */
 		return g_strdup(_("All devices are prevented from update by system inhibit"));
 	}
+	if (problem == FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS) {
+		/* TRANSLATORS: another application is updating the device already */
+		return g_strdup(_("An update is in progress"));
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
We already had this as an inhibit, but this was not translated client-side.

We also need to propagate the problem to the bootloader device if the device replugs during firmware update.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
