### PR TITLE
trivial: update fwupd-efi to 1.4

### DIFF
--- a/subprojects/fwupd-efi.wrap
+++ b/subprojects/fwupd-efi.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = fwupd-efi
 url = https://github.com/fwupd/fwupd-efi
-revision = 1.2
+revision = 1.4


### PR DESCRIPTION
fwupd-efi 1.4 enforces that NX bit is set by default. This won't affect most users, it should only affect those that compile by hand and don't have fwupd-efi installed already.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
