### PR TITLE
trivial: Remove duplicate call to fu_engine_ensure_device_supported()

### DIFF
--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -8,6 +8,7 @@
 
 #include "fu-context.h"
 #include "fu-hwids.h"
+#include "fu-progress.h"
 #include "fu-quirks.h"
 #include "fu-volume.h"
 
@@ -26,7 +27,10 @@ fu_context_new(void);
 gboolean
 fu_context_reload_bios_settings(FuContext *self, GError **error);
 gboolean
-fu_context_load_hwinfo(FuContext *self, FuContextHwidFlags flags, GError **error);
+fu_context_load_hwinfo(FuContext *self,
+		       FuProgress *progress,
+		       FuContextHwidFlags flags,
+		       GError **error);
 gboolean
 fu_context_load_quirks(FuContext *self, FuQuirksLoadFlags flags, GError **error);
 void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -435,10 +435,11 @@ static void
 fu_context_hwids_dmi_func(void)
 {
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
 
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_DMI, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_LOAD_DMI, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	if (g_getenv("FWUPD_VERBOSE") != NULL) {
@@ -559,6 +560,7 @@ fu_hwids_func(void)
 {
 	g_autofree gchar *testdatadir = NULL;
 	g_autoptr(FuContext) context = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
 
@@ -593,7 +595,7 @@ fu_hwids_func(void)
 	(void)g_setenv("FWUPD_SYSFSFWDIR", testdatadir, TRUE);
 
 	context = fu_context_new();
-	ret = fu_context_load_hwinfo(context, FU_CONTEXT_HWID_FLAG_LOAD_SMBIOS, &error);
+	ret = fu_context_load_hwinfo(context, progress, FU_CONTEXT_HWID_FLAG_LOAD_SMBIOS, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -46,7 +46,7 @@ fu_test_self_init(FuTest *self, GError **error_global)
 				     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_CONFIG, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_LOAD_CONFIG, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	ret = fu_context_reload_bios_settings(ctx, &error);

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -32,7 +32,7 @@ fu_test_mtd_device_func(void)
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_SMBIOS, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_LOAD_SMBIOS, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -29,6 +29,7 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 	const gchar *basename;
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GDir) dir = g_dir_open(path, 0, &error);
 	g_assert_no_error(error);
@@ -37,13 +38,13 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_NONE, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	while ((basename = g_dir_read_name(dir)) != NULL) {
 		g_autofree gchar *fn = g_build_filename(path, basename, NULL);
-		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+		g_autoptr(FuProgress) progress_local = fu_progress_new(G_STRLOC);
 		g_autoptr(FuUdevDevice) dev = NULL;
 		if (!g_str_has_prefix(basename, "drm_dp_aux"))
 			continue;
@@ -60,8 +61,10 @@ _test_add_fake_devices_from_dir(FuPlugin *plugin, const gchar *path)
 				   fn,
 				   NULL);
 		g_debug("creating drm_dp_aux_dev object backed by %s", fn);
-		ret =
-		    fu_plugin_runner_backend_device_added(plugin, FU_DEVICE(dev), progress, &error);
+		ret = fu_plugin_runner_backend_device_added(plugin,
+							    FU_DEVICE(dev),
+							    progress_local,
+							    &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
 	}
@@ -84,7 +87,7 @@ fu_plugin_synaptics_mst_none_func(void)
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_NONE, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -127,7 +130,7 @@ fu_plugin_synaptics_mst_tb16_func(void)
 	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_NONE, &error);
+	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -336,7 +336,10 @@ main(int argc, char *argv[])
 		g_autoptr(GError) error_local = NULL;
 
 		/* load SMBIOS */
-		if (!fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_ALL, &error_local)) {
+		if (!fu_context_load_hwinfo(ctx,
+					    progress,
+					    FU_CONTEXT_HWID_FLAG_LOAD_ALL,
+					    &error_local)) {
 			g_printerr("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}
@@ -459,15 +462,20 @@ main(int argc, char *argv[])
 		/* progress */
 		fu_progress_set_id(progress, G_STRLOC);
 		fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);
+		fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "hwinfo");
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "prepare");
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98, NULL);
 		fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "cleanup");
 
 		/* load SMBIOS */
-		if (!fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_ALL, &error_local)) {
+		if (!fu_context_load_hwinfo(ctx,
+					    fu_progress_get_child(progress),
+					    FU_CONTEXT_HWID_FLAG_LOAD_ALL,
+					    &error_local)) {
 			g_printerr("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}
+		fu_progress_step_done(progress);
 
 		/* type is specified, otherwise use default */
 		if (type != NULL) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6421,9 +6421,6 @@ fu_engine_add_device(FuEngine *self, FuDevice *device)
 	if (component != NULL)
 		fu_engine_md_refresh_device_from_component(self, device, component);
 
-	/* match the metadata so clients can tell if the device is worthy */
-	fu_engine_ensure_device_supported(self, device);
-
 	fu_engine_emit_changed(self);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8036,7 +8036,10 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 
 	/* load SMBIOS and the hwids */
 	if (flags & FU_ENGINE_LOAD_FLAG_HWINFO) {
-		if (!fu_context_load_hwinfo(self->ctx, FU_CONTEXT_HWID_FLAG_LOAD_ALL, error))
+		if (!fu_context_load_hwinfo(self->ctx,
+					    fu_progress_get_child(progress),
+					    FU_CONTEXT_HWID_FLAG_LOAD_ALL,
+					    error))
 			return FALSE;
 		self->has_hwinfo = TRUE;
 	}

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1988,7 +1988,7 @@ fu_util_export_hwids(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* setup default hwids */
-	if (!fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_ALL, error))
+	if (!fu_context_load_hwinfo(ctx, priv->progress, FU_CONTEXT_HWID_FLAG_LOAD_ALL, error))
 		return FALSE;
 
 	/* save all keys */
@@ -2022,7 +2022,7 @@ fu_util_hwids(FuUtilPrivate *priv, gchar **values, GError **error)
 			fu_hwids_add_value(hwids, hwid_key, tmp);
 		}
 	}
-	if (!fu_context_load_hwinfo(ctx, FU_CONTEXT_HWID_FLAG_LOAD_ALL, error))
+	if (!fu_context_load_hwinfo(ctx, priv->progress, FU_CONTEXT_HWID_FLAG_LOAD_ALL, error))
 		return FALSE;
 
 	/* show debug output */


### PR DESCRIPTION
This is moderately expensive to call as it processes each requirement on each release on each device, so the last thing we want to do is call it *twice*.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
