### PR TITLE
Use indexes when building the quirk prepared queries

### DIFF
--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -427,6 +427,10 @@ fu_quirks_check_silo(FuQuirks *self, GError **error)
 		g_prefix_error(error, "failed to prepare query: ");
 		return FALSE;
 	}
+	if (!xb_silo_query_build_index(self->silo, "quirk/device", "id", error))
+		return FALSE;
+	if (!xb_silo_query_build_index(self->silo, "quirk/device/value", "key", error))
+		return FALSE;
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
This can save 250us on each query (of which we do a *lot*), and reduces the number of queries by about half if the user is using a libxmlb version that can convert from `_BOUND_TEXT` to `_BOUND_INDEX_TEXT`.

The more devices detected, the bigger the difference, and without this patch fixing libxmlb would break fwupd as we'e been searching with an index, but not actually providing one.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
