### PR TITLE
Remove unused API for setting backend tags

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -83,7 +83,6 @@ typedef struct {
 	gchar *custom_flags;
 	gulong notify_flags_handler_id;
 	GHashTable *instance_hash;
-	GPtrArray *backend_tags; /* of utf-8 */
 } FuDevicePrivate;
 
 typedef struct {
@@ -106,7 +105,6 @@ enum {
 	PROP_CONTEXT,
 	PROP_PROXY,
 	PROP_PARENT,
-	PROP_BACKEND_TAGS,
 	PROP_LAST
 };
 
@@ -140,9 +138,6 @@ fu_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec
 		break;
 	case PROP_PARENT:
 		g_value_set_object(value, fu_device_get_parent(self));
-		break;
-	case PROP_BACKEND_TAGS:
-		g_value_set_boxed(value, priv->backend_tags);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -1275,104 +1270,6 @@ fu_device_get_children(FuDevice *self)
 {
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
 	return fwupd_device_get_children(FWUPD_DEVICE(self));
-}
-
-/**
- * fu_device_get_backend_tags:
- * @self: a #FuDevice
- *
- * Gets any backend tags.
- *
- * Returns: (transfer none) (element-type utf8): string tags
- *
- * Since: 1.8.5
- **/
-GPtrArray *
-fu_device_get_backend_tags(FuDevice *self)
-{
-	FuDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
-	return priv->backend_tags;
-}
-
-/**
- * fu_device_add_backend_tag:
- * @self: a #FuDevice
- * @backend_tag: a tag, for example `bootloader` or `runtime-reload`
- *
- * Adds a backend tag, which allows the backend to identify the specific device for a specific
- * phase. For instance, there might be a pre-update runtime, a bootloader and a post-update runtime
- * and allowing tags to be saved to the backend object allows us to identify each version of
- * the same physical device.
- *
- * Since: 1.8.5
- **/
-void
-fu_device_add_backend_tag(FuDevice *self, const gchar *backend_tag)
-{
-	FuDevicePrivate *priv = GET_PRIVATE(self);
-	FuDevice *parent = fu_device_get_parent(self);
-	g_return_if_fail(FU_IS_DEVICE(self));
-	g_return_if_fail(backend_tag != NULL);
-	if (fu_device_has_backend_tag(self, backend_tag))
-		return;
-	g_ptr_array_add(priv->backend_tags, g_strdup(backend_tag));
-	g_object_notify(G_OBJECT(self), "backend-tags");
-
-	if (parent != NULL)
-		fu_device_add_backend_tag(parent, backend_tag);
-}
-
-/**
- * fu_device_remove_backend_tag:
- * @self: a #FuDevice
- * @backend_tag: a tag, for example `bootloader` or `runtime-reload`
- *
- * Removes a backend tag, which allows the backend to identify the specific device for a specific
- * phase.
- *
- * Since: 1.8.11
- **/
-void
-fu_device_remove_backend_tag(FuDevice *self, const gchar *backend_tag)
-{
-	FuDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FU_IS_DEVICE(self));
-	g_return_if_fail(backend_tag != NULL);
-
-	for (guint i = 0; i < priv->backend_tags->len; i++) {
-		const gchar *backend_tag_tmp = g_ptr_array_index(priv->backend_tags, i);
-		if (g_strcmp0(backend_tag_tmp, backend_tag) == 0) {
-			g_ptr_array_remove_index(priv->backend_tags, i);
-			g_object_notify(G_OBJECT(self), "backend-tags");
-			break;
-		}
-	}
-}
-
-/**
- * fu_device_has_backend_tag:
- * @self: a #FuDevice
- * @backend_tag: a tag, for example `bootloader` or `runtime-reload`
- *
- * Finds if the backend tag already exists.
- *
- * Returns: %TRUE if the backend tag exists
- *
- * Since: 1.8.5
- **/
-gboolean
-fu_device_has_backend_tag(FuDevice *self, const gchar *backend_tag)
-{
-	FuDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FU_IS_DEVICE(self), FALSE);
-	g_return_val_if_fail(backend_tag != NULL, FALSE);
-	for (guint i = 0; i < priv->backend_tags->len; i++) {
-		const gchar *backend_tag_tmp = g_ptr_array_index(priv->backend_tags, i);
-		if (g_strcmp0(backend_tag_tmp, backend_tag) == 0)
-			return TRUE;
-	}
-	return FALSE;
 }
 
 /**
@@ -5856,20 +5753,6 @@ fu_device_class_init(FuDeviceClass *klass)
 				    FU_TYPE_DEVICE,
 				    G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_PARENT, pspec);
-
-	/**
-	 * FuDevice:backend-tags:
-	 *
-	 * The device tags used for backend identification.
-	 *
-	 * Since: 1.5.8
-	 */
-	pspec = g_param_spec_boxed("backend-tags",
-				   NULL,
-				   NULL,
-				   G_TYPE_PTR_ARRAY,
-				   G_PARAM_READABLE | G_PARAM_STATIC_NAME);
-	g_object_class_install_property(object_class, PROP_BACKEND_TAGS, pspec);
 }
 
 static void
@@ -5882,7 +5765,6 @@ fu_device_init(FuDevice *self)
 	priv->instance_id_quirks = g_ptr_array_new_with_free_func(g_free);
 	priv->retry_recs = g_ptr_array_new_with_free_func(g_free);
 	priv->instance_hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-	priv->backend_tags = g_ptr_array_new_with_free_func(g_free);
 	priv->acquiesce_delay = 50; /* ms */
 	priv->notify_flags_handler_id = g_signal_connect(FWUPD_DEVICE(self),
 							 "notify::flags",
@@ -5916,7 +5798,6 @@ fu_device_finalize(GObject *object)
 	g_ptr_array_unref(priv->possible_plugins);
 	g_ptr_array_unref(priv->instance_id_quirks);
 	g_ptr_array_unref(priv->retry_recs);
-	g_ptr_array_unref(priv->backend_tags);
 	g_free(priv->alternate_id);
 	g_free(priv->equivalent_id);
 	g_free(priv->physical_id);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -546,14 +546,6 @@ fu_device_set_version_from_uint32(FuDevice *self, guint32 version_raw);
 void
 fu_device_set_version_from_uint64(FuDevice *self, guint64 version_raw);
 void
-fu_device_add_backend_tag(FuDevice *self, const gchar *backend_tag);
-void
-fu_device_remove_backend_tag(FuDevice *self, const gchar *backend_tag);
-gboolean
-fu_device_has_backend_tag(FuDevice *self, const gchar *backend_tag);
-GPtrArray *
-fu_device_get_backend_tags(FuDevice *self);
-void
 fu_device_inhibit(FuDevice *self, const gchar *inhibit_id, const gchar *reason);
 void
 fu_device_uninhibit(FuDevice *self, const gchar *inhibit_id);

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -1267,7 +1267,6 @@ fu_plugin_runner_prepare(FuPlugin *self,
 			 GError **error)
 {
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
-	fu_device_add_backend_tag(device, "prepare");
 	return fu_plugin_runner_flagged_device_generic(self,
 						       device,
 						       progress,
@@ -1299,7 +1298,6 @@ fu_plugin_runner_cleanup(FuPlugin *self,
 			 GError **error)
 {
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
-	fu_device_add_backend_tag(device, "cleanup");
 	return fu_plugin_runner_flagged_device_generic(self,
 						       device,
 						       progress,
@@ -1326,7 +1324,6 @@ gboolean
 fu_plugin_runner_attach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
-	fu_device_add_backend_tag(device, "attach");
 	return fu_plugin_runner_device_generic_progress(
 	    self,
 	    device,
@@ -1353,7 +1350,6 @@ gboolean
 fu_plugin_runner_detach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
-	fu_device_add_backend_tag(device, "detach");
 	return fu_plugin_runner_device_generic_progress(
 	    self,
 	    device,
@@ -1389,7 +1385,6 @@ fu_plugin_runner_reload(FuPlugin *self, FuDevice *device, GError **error)
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
 		return FALSE;
-	fu_device_add_backend_tag(device, "reload");
 	return fu_device_reload(device, error);
 }
 
@@ -1984,7 +1979,6 @@ fu_plugin_runner_activate(FuPlugin *self, FuDevice *device, FuProgress *progress
 	}
 
 	/* run vfunc */
-	fu_device_add_backend_tag(device, "activate");
 	if (!fu_plugin_runner_device_generic_progress(
 		self,
 		device,
@@ -2034,7 +2028,6 @@ fu_plugin_runner_unlock(FuPlugin *self, FuDevice *device, GError **error)
 	}
 
 	/* run vfunc */
-	fu_device_add_backend_tag(device, "unlock");
 	if (!fu_plugin_runner_device_generic(self,
 					     device,
 					     "fu_plugin_unlock",
@@ -2084,7 +2077,6 @@ fu_plugin_runner_write_firmware(FuPlugin *self,
 		g_debug("plugin not enabled, skipping");
 		return TRUE;
 	}
-	fu_device_add_backend_tag(device, "write-firmware");
 
 	/* optional */
 	if (vfuncs->write_firmware == NULL) {

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1210,15 +1210,6 @@ fu_device_func(void)
 	fu_device_add_possible_plugin(device, "test");
 	possible_plugins = fu_device_get_possible_plugins(device);
 	g_assert_cmpint(possible_plugins->len, ==, 1);
-
-	g_assert_cmpint(fu_device_get_backend_tags(device)->len, ==, 0);
-	fu_device_add_backend_tag(device, "foo");
-	fu_device_add_backend_tag(device, "bar");
-	g_assert_cmpint(fu_device_get_backend_tags(device)->len, ==, 2);
-	g_assert_true(fu_device_has_backend_tag(device, "foo"));
-	g_assert_false(fu_device_has_backend_tag(device, "bazbazbazbazbaz"));
-	fu_device_remove_backend_tag(device, "foo");
-	g_assert_false(fu_device_has_backend_tag(device, "foo"));
 }
 
 static void

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -86,27 +86,6 @@ fu_usb_device_finalize(GObject *object)
 	G_OBJECT_CLASS(fu_usb_device_parent_class)->finalize(object);
 }
 
-#if G_USB_CHECK_VERSION(0, 4, 4)
-static void
-fu_usb_device_backend_tags_notify_cb(GObject *object, GParamSpec *pspec, FuUsbDevice *device)
-{
-	FuUsbDevicePrivate *priv = GET_PRIVATE(device);
-	GPtrArray *backend_tags = fu_device_get_backend_tags(FU_DEVICE(device));
-	g_autoptr(GPtrArray) usb_device_tags = g_usb_device_get_tags(priv->usb_device);
-
-	for (guint i = 0; i < usb_device_tags->len; i++) {
-		const gchar *tag = g_ptr_array_index(usb_device_tags, i);
-		if (!fu_device_has_backend_tag(FU_DEVICE(device), tag))
-			g_usb_device_remove_tag(priv->usb_device, tag);
-	}
-	for (guint i = 0; i < backend_tags->len; i++) {
-		const gchar *tag = g_ptr_array_index(backend_tags, i);
-		if (!g_usb_device_has_tag(priv->usb_device, tag))
-			g_usb_device_add_tag(priv->usb_device, tag);
-	}
-}
-#endif
-
 static void
 fu_usb_device_init(FuUsbDevice *device)
 {
@@ -122,14 +101,6 @@ fu_usb_device_init(FuUsbDevice *device)
 				     G_USB_DEVICE_ERROR,
 				     G_USB_DEVICE_ERROR_PERMISSION_DENIED,
 				     NULL);
-#endif
-
-#if G_USB_CHECK_VERSION(0, 4, 4)
-	/* copy this to the GUsbDevice */
-	g_signal_connect(FU_DEVICE(device),
-			 "notify::backend-tags",
-			 G_CALLBACK(fu_usb_device_backend_tags_notify_cb),
-			 device);
 #endif
 }
 

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1090,9 +1090,6 @@ LIBFWUPDPLUGIN_1.8.5 {
     fu_context_add_flag;
     fu_context_get_esp_volumes;
     fu_context_has_flag;
-    fu_device_add_backend_tag;
-    fu_device_get_backend_tags;
-    fu_device_has_backend_tag;
     fu_device_set_quirk_kv;
     fu_intel_thunderbolt_firmware_get_type;
     fu_intel_thunderbolt_firmware_new;
@@ -1166,6 +1163,5 @@ LIBFWUPDPLUGIN_1.8.10 {
 LIBFWUPDPLUGIN_1.8.11 {
   global:
     fu_device_has_problem;
-    fu_device_remove_backend_tag;
   local: *;
 } LIBFWUPDPLUGIN_1.8.10;


### PR DESCRIPTION
It turns out we do not want to know the current phase of the device, and we can achieve the same thing tagging the GUsbDevice manually and clearing the events at exactly the correct time.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
