### PR TITLE
Do not invalidate the probe for emulated devices

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -664,7 +664,8 @@ fu_usb_device_set_dev(FuUsbDevice *device, GUsbDevice *usb_device)
 	g_return_if_fail(FU_IS_USB_DEVICE(device));
 
 	/* need to re-probe hardware */
-	fu_device_probe_invalidate(FU_DEVICE(device));
+	if (!fu_device_has_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_EMULATED))
+		fu_device_probe_invalidate(FU_DEVICE(device));
 
 	/* allow replacement */
 	g_set_object(&priv->usb_device, usb_device);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7480,7 +7480,8 @@ fu_engine_backend_device_changed_cb(FuBackend *backend, FuDevice *device, FuEngi
 			continue;
 		if (g_strcmp0(fu_usb_device_get_platform_id(FU_USB_DEVICE(device_tmp)),
 			      fu_usb_device_get_platform_id(FU_USB_DEVICE(device))) == 0) {
-			g_debug("incorporating new GUsbDevice for %s", fu_device_get_id(device));
+			g_debug("incorporating new GUsbDevice for %s",
+				fu_device_get_id(device_tmp));
 			fu_device_incorporate(device_tmp, device);
 		}
 	}


### PR DESCRIPTION
If the device does not replug, and we change the GUsbDevice because the phase changed we don't want reprobe the hardware.

If we reprobe then the emulated device will request extra data compared to the real device, which will cause emulation to fail.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
