### PR TITLE
Add API to wait for a device

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -711,6 +711,10 @@ fu_device_retry_full(FuDevice *self,
 		     guint delay,
 		     gpointer user_data,
 		     GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fu_device_sleep(FuDevice *self, guint delay_ms);
+void
+fu_device_sleep_full(FuDevice *self, guint delay_ms, FuProgress *progress);
 gboolean
 fu_device_bind_driver(FuDevice *self, const gchar *subsystem, const gchar *driver, GError **error)
     G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -903,6 +903,8 @@ fu_progress_step_done(FuProgress *self)
  *
  * Sleeps, setting the device progress from 0..100% as time continues.
  *
+ * NOTE: You should try to avoid calling this function for emulated devices.
+ *
  * Since: 1.7.0
  **/
 void

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1163,5 +1163,7 @@ LIBFWUPDPLUGIN_1.8.10 {
 LIBFWUPDPLUGIN_1.8.11 {
   global:
     fu_device_has_problem;
+    fu_device_sleep;
+    fu_device_sleep_full;
   local: *;
 } LIBFWUPDPLUGIN_1.8.10;

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -139,8 +139,7 @@ fu_analogix_device_get_update_status(FuAnalogixDevice *self,
 				*status = status_tmp;
 			return TRUE;
 		}
-		/* wait 1ms */
-		g_usleep(1000);
+		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 	}
 	g_set_error_literal(error,
 			    FWUPD_ERROR,

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -77,7 +77,7 @@ fu_bcm57xx_device_probe(FuDevice *device, GError **error)
 	fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "net", NULL);
 	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_debug("waiting for net devices to appear");
-		g_usleep(50 * 1000);
+		fu_device_sleep(device, 50); /* ms */
 	}
 	ifaces = fu_path_glob(fn, "en*", NULL);
 	if (ifaces == NULL || ifaces->len == 0) {
@@ -325,7 +325,7 @@ fu_bcm57xx_device_activate(FuDevice *device, FuProgress *progress, GError **erro
 
 	/* wait for the device to restart before calling reload() */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
-	fu_progress_sleep(progress, 5000);
+	fu_device_sleep_full(device, 5000, progress); /* ms */
 	return TRUE;
 }
 

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -349,7 +349,7 @@ fu_ccgx_dmc_get_image_write_status_cb(FuDevice *device, gpointer user_data, GErr
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "invalid dmc intr req data in image write status = %d",
 			    dmc_int_req.data[0]);
-		g_usleep(DMC_FW_WRITE_STATUS_RETRY_DELAY_MS * 1000);
+		fu_device_sleep(device, DMC_FW_WRITE_STATUS_RETRY_DELAY_MS);
 		return FALSE;
 	}
 	return TRUE;

--- a/plugins/ccgx/fu-ccgx-hpi-common.h
+++ b/plugins/ccgx/fu-ccgx-hpi-common.h
@@ -8,7 +8,7 @@
 
 #include <glib.h>
 
-#define I2C_READ_WRITE_DELAY_US 10000 /* 10 msec */
+#define I2C_READ_WRITE_DELAY_MS 10 /* ms */
 
 #define CY_SCB_INDEX_POS	      15
 #define CY_I2C_WRITE_COMMAND_POS      3

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -45,13 +45,13 @@ struct _FuCcgxHpiDevice {
 
 G_DEFINE_TYPE(FuCcgxHpiDevice, fu_ccgx_hpi_device, FU_TYPE_USB_DEVICE)
 
-#define HPI_CMD_REG_READ_WRITE_DELAY_US		 10000
-#define HPI_CMD_ENTER_FLASH_MODE_DELAY_US	 20000
+#define HPI_CMD_REG_READ_WRITE_DELAY_MS		 10
+#define HPI_CMD_ENTER_FLASH_MODE_DELAY_MS	 20
 #define HPI_CMD_SETUP_EVENT_WAIT_TIME_MS	 200
 #define HPI_CMD_SETUP_EVENT_CLEAR_TIME_MS	 150
 #define HPI_CMD_COMMAND_RESPONSE_TIME_MS	 500
 #define HPI_CMD_COMMAND_CLEAR_EVENT_TIME_MS	 30
-#define HPI_CMD_RESET_COMPLETE_DELAY_US		 150000
+#define HPI_CMD_RESET_COMPLETE_DELAY_MS		 150
 #define HPI_CMD_RETRY_DELAY			 30 /* ms */
 #define HPI_CMD_RESET_RETRY_CNT			 3
 #define HPI_CMD_ENTER_LEAVE_FLASH_MODE_RETRY_CNT 3
@@ -322,7 +322,7 @@ fu_ccgx_hpi_device_i2c_read(FuCcgxHpiDevice *self,
 	}
 
 	/* 10 msec delay */
-	g_usleep(I2C_READ_WRITE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), I2C_READ_WRITE_DELAY_MS);
 	if (!fu_ccgx_hpi_device_wait_for_notify(self, NULL, error)) {
 		g_prefix_error(error, "i2c read error: ");
 		return FALSE;
@@ -374,7 +374,7 @@ fu_ccgx_hpi_device_i2c_write(FuCcgxHpiDevice *self,
 	}
 
 	/* 10 msec delay */
-	g_usleep(I2C_READ_WRITE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), I2C_READ_WRITE_DELAY_MS);
 	if (!fu_ccgx_hpi_device_wait_for_notify(self, NULL, error)) {
 		g_prefix_error(error, "i2c wait for notification error: ");
 		return FALSE;
@@ -454,7 +454,7 @@ fu_ccgx_hpi_device_reg_read_cb(FuDevice *device, gpointer user_data, GError **er
 		g_prefix_error(error, "read error: ");
 		return FALSE;
 	}
-	g_usleep(HPI_CMD_REG_READ_WRITE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), HPI_CMD_REG_READ_WRITE_DELAY_MS);
 	return TRUE;
 }
 
@@ -496,7 +496,7 @@ fu_ccgx_hpi_device_reg_write_cb(FuDevice *device, gpointer user_data, GError **e
 		g_prefix_error(error, "reg write error: ");
 		return FALSE;
 	}
-	g_usleep(HPI_CMD_REG_READ_WRITE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), HPI_CMD_REG_READ_WRITE_DELAY_MS);
 	return TRUE;
 }
 
@@ -539,7 +539,7 @@ fu_ccgx_hpi_device_reg_write_no_resp(FuCcgxHpiDevice *self,
 		g_prefix_error(error, "reg write no-resp error: ");
 		return FALSE;
 	}
-	g_usleep(HPI_CMD_REG_READ_WRITE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), HPI_CMD_REG_READ_WRITE_DELAY_MS);
 	return TRUE;
 }
 
@@ -826,7 +826,7 @@ fu_ccgx_hpi_enter_flash_mode_cb(FuDevice *device, gpointer user_data, GError **e
 	}
 
 	/* wait 10 msec */
-	g_usleep(HPI_CMD_ENTER_FLASH_MODE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), HPI_CMD_ENTER_FLASH_MODE_DELAY_MS);
 	return TRUE;
 }
 
@@ -877,7 +877,7 @@ fu_ccgx_hpi_leave_flash_mode_cb(FuDevice *device, gpointer user_data, GError **e
 	}
 
 	/* wait 10 msec */
-	g_usleep(HPI_CMD_ENTER_FLASH_MODE_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), HPI_CMD_ENTER_FLASH_MODE_DELAY_MS);
 	return TRUE;
 }
 
@@ -1483,7 +1483,7 @@ fu_ccgx_hpi_device_setup(FuDevice *device, GError **error)
 		}
 	} else {
 		if (hpi_event == CY_PD_RESP_RESET_COMPLETE)
-			g_usleep(HPI_CMD_RESET_COMPLETE_DELAY_US);
+			fu_device_sleep(FU_DEVICE(self), HPI_CMD_RESET_COMPLETE_DELAY_MS);
 	}
 
 	/* start with no events in the queue */

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -16,10 +16,10 @@
 
 #define CORSAIR_TRANSACTION_TIMEOUT	    4000
 #define CORSAIR_SUBDEVICE_POLL_PERIOD	    30000
-#define CORSAIR_SUBDEVICE_REBOOT_DELAY	    (4 * G_USEC_PER_SEC)
+#define CORSAIR_SUBDEVICE_REBOOT_DELAY	    4000 /* ms */
 #define CORSAIR_SUBDEVICE_RECONNECT_RETRIES 30
 #define CORSAIR_SUBDEVICE_RECONNECT_PERIOD  1000
-#define CORSAIR_SUBDEVICE_FIRST_POLL_DELAY  (2 * G_USEC_PER_SEC)
+#define CORSAIR_SUBDEVICE_FIRST_POLL_DELAY  2000 /* ms */
 
 struct _FuCorsairDevice {
 	FuUsbDevice parent_instance;
@@ -244,7 +244,7 @@ fu_corsair_device_setup(FuDevice *device, GError **error)
 		/* Give some time to a subdevice to get connected to the receiver.
 		 * Without this delay a subdevice may be not present even if it is
 		 * turned on. */
-		g_usleep(CORSAIR_SUBDEVICE_FIRST_POLL_DELAY);
+		fu_device_sleep(device, CORSAIR_SUBDEVICE_FIRST_POLL_DELAY);
 		if (!fu_corsair_poll_subdevice(device, &subdevice_added, &local_error)) {
 			g_warning("error polling subdevice: %s", local_error->message);
 		} else {
@@ -300,7 +300,7 @@ fu_corsair_reconnect_subdevice(FuDevice *device, GError **error)
 	}
 
 	/* Wait some time to make sure that a subdevice was disconnected. */
-	g_usleep(CORSAIR_SUBDEVICE_REBOOT_DELAY);
+	fu_device_sleep(device, CORSAIR_SUBDEVICE_REBOOT_DELAY);
 
 	if (!fu_device_retry_full(parent,
 				  fu_corsair_is_subdevice_connected_cb,

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -457,7 +457,7 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 
 	cmd_buffer.tbt_command = GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE_STATUS);
 	/* needs at least 2 seconds */
-	g_usleep(2000000);
+	fu_device_sleep(self, 2000);
 	for (gint i = 1; i <= TBT_MAX_RETRIES; i++) {
 		if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
 			g_prefix_error(error, "failed to set check authentication: ");
@@ -474,7 +474,7 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 			i,
 			TBT_MAX_RETRIES,
 			result);
-		g_usleep(500000);
+		fu_device_sleep(self, 500); /* ms */
 	}
 	if (result != 0) {
 		g_set_error(error,

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -932,7 +932,7 @@ fu_dell_dock_ec_setup(FuDevice *device, GError **error)
 	if (!fu_dell_dock_ec_query(device, &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_SIGNATURE_INVALID)) {
 			g_warning("%s", error_local->message);
-			g_usleep(2 * G_USEC_PER_SEC);
+			fu_device_sleep(device, 2000); /* ms */
 			if (!fu_dell_dock_ec_query(device, error))
 				return FALSE;
 		} else {

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -326,7 +326,7 @@ fu_dell_dock_trigger_rc_command(FuDevice *device, GError **error)
 			tmp = result[3];
 			break;
 		}
-		g_usleep(2000);
+		fu_device_sleep(FU_DEVICE(self), 2); /* ms */
 	}
 	switch (tmp) {
 	/* need to enable remote control */
@@ -611,7 +611,7 @@ fu_dell_dock_mst_erase_panamera_bank(FuDevice *device, MSTBank bank, GError **er
 		}
 	}
 	g_debug("MST: Waiting for flash clear to settle");
-	g_usleep(5000000);
+	fu_device_sleep(device, 5000); /* ms */
 
 	return TRUE;
 }
@@ -634,7 +634,7 @@ fu_dell_dock_mst_erase_cayenne(FuDevice *device, GError **error)
 		}
 	}
 	g_debug("MST: Waiting for flash clear to settle");
-	g_usleep(5000000);
+	fu_device_sleep(device, 5000);
 
 	return TRUE;
 }
@@ -697,7 +697,7 @@ fu_dell_dock_mst_stop_esm(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* waiting for ESM exit */
-	g_usleep(200);
+	fu_device_sleep(device, 1);
 
 	/* disable QUAD mode */
 	if (!fu_dell_dock_mst_rc_command(device,

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -105,7 +105,7 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 	g_debug("waking Thunderbolt controller");
 	if (!fu_dell_dock_hid_tbt_wake(fu_device_get_proxy(device), &tbt_base_settings, error))
 		return FALSE;
-	g_usleep(2000000);
+	fu_device_sleep(device, 2000);
 
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i < image_size; i += HIDI2C_MAX_WRITE, buffer += HIDI2C_MAX_WRITE) {

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -315,7 +315,7 @@ fu_dfu_csr_device_download_chunk(FuDfuCsrDevice *self, guint16 idx, GBytes *chun
 	/* wait for hardware */
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_CSR_DEVICE_FLAG_REQUIRE_DELAY)) {
 		g_debug("sleeping for %ums", self->dnload_timeout);
-		g_usleep(self->dnload_timeout * 1000);
+		fu_device_sleep(FU_DEVICE(self), self->dnload_timeout);
 	}
 
 	/* get status */
@@ -325,7 +325,7 @@ fu_dfu_csr_device_download_chunk(FuDfuCsrDevice *self, guint16 idx, GBytes *chun
 	/* is still busy */
 	if (self->dfu_state == FU_DFU_STATE_DFU_DNBUSY) {
 		g_debug("busy, so sleeping a bit longer");
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(FU_DEVICE(self), 1000);
 		if (!fu_dfu_csr_device_get_status(self, error))
 			return FALSE;
 	}

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1174,10 +1174,8 @@ fu_dfu_device_probe(FuDevice *device, GError **error)
 
 	/* hardware from Jabra literally reboots if you try to retry a failed
 	 * write -- there's no way to avoid blocking the daemon like this... */
-	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_ATTACH_EXTRA_RESET)) {
-		g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
-		fu_progress_sleep(progress, 10000);
-	}
+	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_ATTACH_EXTRA_RESET))
+		fu_device_sleep(device, 10000);
 
 	/* success */
 	return TRUE;

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -424,7 +424,8 @@ fu_dfu_target_manifest_wait(FuDfuTarget *self, GError **error)
 			return FALSE;
 		}
 
-		g_usleep((fu_dfu_device_get_download_timeout(device) + 1000) * 1000);
+		fu_device_sleep(FU_DEVICE(device),
+				fu_dfu_device_get_download_timeout(device) + 1000);
 		if (!fu_dfu_device_refresh(device, error))
 			return FALSE;
 	}
@@ -456,7 +457,7 @@ fu_dfu_target_check_status(FuDfuTarget *self, GError **error)
 	/* wait for dfuDNBUSY to not be set */
 	while (fu_dfu_device_get_state(device) == FU_DFU_STATE_DFU_DNBUSY) {
 		g_debug("waiting for FU_DFU_STATE_DFU_DNBUSY to clear");
-		g_usleep(fu_dfu_device_get_download_timeout(device) * 1000);
+		fu_device_sleep(FU_DEVICE(device), fu_dfu_device_get_download_timeout(device));
 		if (!fu_dfu_device_refresh(device, error))
 			return FALSE;
 		/* this is a really long time to save fwupd in case
@@ -730,7 +731,7 @@ fu_dfu_target_download_chunk(FuDfuTarget *self,
 		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
 	if (fu_dfu_device_get_download_timeout(device) > 0) {
 		g_debug("sleeping for %ums…", fu_dfu_device_get_download_timeout(device));
-		g_usleep(fu_dfu_device_get_download_timeout(device) * 1000);
+		fu_device_sleep(FU_DEVICE(device), fu_dfu_device_get_download_timeout(device));
 	}
 
 	/* find out if the write was successful, waiting for BUSY to clear */

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -693,8 +693,9 @@ fu_elantp_hid_device_write_firmware(FuDevice *device,
 		fu_memwrite_uint16(blk + fu_chunk_get_data_sz(chk) + 1, csum_tmp, G_LITTLE_ENDIAN);
 		if (!fu_elantp_hid_device_send_cmd(self, blk, blksz, NULL, 0, error))
 			return FALSE;
-		g_usleep(self->fw_page_size == 512 ? ELANTP_DELAY_WRITE_BLOCK_512 * 1000
-						   : ELANTP_DELAY_WRITE_BLOCK * 1000);
+		fu_device_sleep(device,
+				self->fw_page_size == 512 ? ELANTP_DELAY_WRITE_BLOCK_512
+							  : ELANTP_DELAY_WRITE_BLOCK);
 
 		if (!fu_elantp_hid_device_ensure_iap_ctrl(self, error))
 			return FALSE;
@@ -741,7 +742,9 @@ fu_elantp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* wait for a reset */
-	fu_progress_sleep(fu_progress_get_child(progress), ELANTP_DELAY_COMPLETE);
+	fu_device_sleep_full(device,
+			     ELANTP_DELAY_COMPLETE,
+			     fu_progress_get_child(progress)); /* ms */
 	fu_progress_step_done(progress);
 	return TRUE;
 }
@@ -763,7 +766,7 @@ fu_elantp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **err
 						    ETP_I2C_IAP_RESET,
 						    error))
 			return FALSE;
-		g_usleep(ELANTP_DELAY_RESET * 1000);
+		fu_device_sleep(FU_DEVICE(self), ELANTP_DELAY_RESET);
 	}
 
 	/* get OSM version */
@@ -844,7 +847,7 @@ fu_elantp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **err
 		return FALSE;
 	if (!fu_elantp_hid_device_write_cmd(self, ETP_CMD_I2C_IAP, self->iap_password, error))
 		return FALSE;
-	g_usleep(ELANTP_DELAY_UNLOCK * 1000);
+	fu_device_sleep(FU_DEVICE(self), ELANTP_DELAY_UNLOCK);
 	if (!fu_elantp_hid_device_ensure_iap_ctrl(self, error))
 		return FALSE;
 	if ((self->iap_ctrl & ETP_FW_IAP_CHECK_PW) == 0) {
@@ -873,7 +876,7 @@ fu_elantp_hid_device_attach(FuDevice *device, FuProgress *progress, GError **err
 	/* reset back to runtime */
 	if (!fu_elantp_hid_device_write_cmd(self, ETP_CMD_I2C_IAP_RESET, ETP_I2C_IAP_RESET, error))
 		return FALSE;
-	g_usleep(ELANTP_DELAY_RESET * 1000);
+	fu_device_sleep(FU_DEVICE(self), ELANTP_DELAY_RESET);
 	if (!fu_elantp_hid_device_write_cmd(self,
 					    ETP_CMD_I2C_IAP_RESET,
 					    ETP_I2C_ENABLE_REPORT,

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -259,7 +259,7 @@ fu_elantp_hid_haptic_device_get_version(FuDevice *parent,
 		g_prefix_error(error, "failed to write haptic version cmd: ");
 		return FALSE;
 	}
-	g_usleep(ELANTP_DELAY_RESET * 1000);
+	fu_device_sleep(FU_DEVICE(self), ELANTP_DELAY_RESET);
 
 	if (!fu_elantp_hid_haptic_device_read_cmd(parent, 0x0321, buf, sizeof(buf), error)) {
 		g_prefix_error(error, "failed to read haptic version cmd: ");
@@ -276,7 +276,7 @@ fu_elantp_hid_haptic_device_get_version(FuDevice *parent,
 		g_prefix_error(error, "failed to write haptic iap version cmd: ");
 		return FALSE;
 	}
-	g_usleep(ELANTP_DELAY_RESET * 1000);
+	fu_device_sleep(FU_DEVICE(self), ELANTP_DELAY_RESET);
 
 	if (!fu_elantp_hid_haptic_device_read_cmd(parent, 0x0321, buf, sizeof(buf), error)) {
 		g_prefix_error(error, "failed to read haptic iap version cmd: ");
@@ -732,8 +732,9 @@ fu_elantp_hid_haptic_device_write_chunks_cb(FuDevice *device, gpointer user_data
 							  error))
 			return FALSE;
 
-		g_usleep(self->fw_page_size == 512 ? ELANTP_DELAY_WRITE_BLOCK_512 * 1000
-						   : ELANTP_DELAY_WRITE_BLOCK * 1000);
+		fu_device_sleep(device,
+				self->fw_page_size == 512 ? ELANTP_DELAY_WRITE_BLOCK_512
+							  : ELANTP_DELAY_WRITE_BLOCK);
 
 		if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
 							   ETP_CMD_I2C_SET_EEPROM_CTRL,
@@ -828,7 +829,7 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 		g_prefix_error(error, "cannot leave EEPROM IAP: ");
 		return FALSE;
 	}
-	g_usleep(ELANTP_DELAY_RESET * 1000);
+	fu_device_sleep(device, ELANTP_DELAY_RESET);
 	if (!fu_elantp_hid_haptic_device_get_checksum(FU_DEVICE(parent), &checksum_device, error)) {
 		g_prefix_error(error, "read device checksum fail: ");
 		return FALSE;
@@ -1044,7 +1045,7 @@ fu_elantp_hid_haptic_device_attach(FuDevice *device, FuProgress *progress, GErro
 		g_prefix_error(error, "cannot reset TP: ");
 		return FALSE;
 	}
-	g_usleep(ELANTP_DELAY_RESET * 1000);
+	fu_device_sleep(device, ELANTP_DELAY_RESET);
 	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
 						   ETP_CMD_I2C_IAP_RESET,
 						   ETP_I2C_ENABLE_REPORT,

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -54,7 +54,7 @@ fu_ep963x_device_write(FuEp963xDevice *self,
 		return FALSE;
 
 	/* wait for hardware */
-	g_usleep(100 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 100);
 	return TRUE;
 }
 
@@ -99,7 +99,7 @@ fu_ep963x_device_write_icp(FuEp963xDevice *self,
 			}
 			return TRUE;
 		}
-		g_usleep(100 * 1000);
+		fu_device_sleep(FU_DEVICE(self), 100);
 	}
 
 	/* failed */

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -18,7 +18,6 @@
 #define FASTBOOT_EP_IN			   0x81
 #define FASTBOOT_EP_OUT			   0x01
 #define FASTBOOT_CMD_BUFSZ		   64 /* bytes */
-#define FASTBOOT_US_TO_MS		   1000
 
 struct _FuFastbootDevice {
 	FuUsbDevice parent_instance;
@@ -91,7 +90,7 @@ fu_fastboot_device_write(FuDevice *device, const guint8 *buf, gsize buflen, GErr
 					 error);
 
 	/* give device some time to handle action */
-	g_usleep(self->operation_delay * FASTBOOT_US_TO_MS);
+	fu_device_sleep(device, self->operation_delay);
 
 	if (!ret) {
 		g_prefix_error(error, "failed to do bulk transfer: ");
@@ -159,7 +158,7 @@ fu_fastboot_device_read(FuDevice *device,
 						 NULL,
 						 &error_local);
 		/* give device some time to handle action */
-		g_usleep(self->operation_delay * FASTBOOT_US_TO_MS);
+		fu_device_sleep(device, self->operation_delay);
 
 		if (!ret) {
 			if (g_error_matches(error_local,

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -482,7 +482,7 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	}
 	if (!fu_focalfp_hid_device_erase_flash(self, error))
 		return FALSE;
-	g_usleep(1000 * 1000);
+	fu_device_sleep(device, 1000);
 	if (!fu_focalfp_hid_device_wait_for_upgrade_ready(self, 20, error))
 		return FALSE;
 	fu_progress_step_done(progress);
@@ -497,7 +497,7 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write flash end and check ready (fw calculate checksum) */
-	g_usleep(50 * 1000);
+	fu_device_sleep(device, 50);
 	if (!fu_focalfp_hid_device_wait_for_upgrade_ready(self, 5, error))
 		return FALSE;
 	fu_progress_step_done(progress);
@@ -506,7 +506,7 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	if (!fu_focalfp_hid_device_checksum_upgrade(self, &checksum, error))
 		return FALSE;
 	if (checksum != fu_focalfp_firmware_get_checksum(FU_FOCALFP_FIRMWARE(firmware))) {
-		g_usleep(500 * 1000);
+		fu_device_sleep(device, 500);
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_INVALID_DATA,
@@ -528,7 +528,7 @@ fu_focalfp_hid_device_reload(FuDevice *device, GError **error)
 	FuFocalfpHidDevice *self = FU_FOCALFP_HID_DEVICE(device);
 	guint8 idbuf[2] = {0x0};
 
-	g_usleep(500 * 1000);
+	fu_device_sleep(device, 500);
 	if (!fu_focalfp_hid_device_read_reg(self, 0x9F, &idbuf[0], error))
 		return FALSE;
 	if (!fu_focalfp_hid_device_read_reg(self, 0xA3, &idbuf[1], error))
@@ -592,7 +592,7 @@ fu_focalfp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **er
 		g_prefix_error(error, "failed to CMD_ENTER_UPGRADE_MODE: ");
 		return FALSE;
 	}
-	g_usleep(200 * 1000);
+	fu_device_sleep(device, 200);
 
 	/* second command : bootloader normal mode --> bootloader upgrade mode */
 	if (!fu_device_retry_full(device,
@@ -604,7 +604,7 @@ fu_focalfp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **er
 		return FALSE;
 
 	/* success */
-	g_usleep(200 * 1000);
+	fu_device_sleep(device, 200);
 	return TRUE;
 }
 
@@ -624,7 +624,7 @@ fu_focalfp_hid_device_attach(FuDevice *device, FuProgress *progress, GError **er
 		return FALSE;
 
 	/* success */
-	g_usleep(500 * 1000);
+	fu_device_sleep(device, 500);
 	return TRUE;
 }
 

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -102,7 +102,7 @@ fu_genesys_scaler_device_enter_serial_debug_mode(FuGenesysScalerDevice *self, GE
 		return FALSE;
 	}
 
-	g_usleep(1000); /* 1ms */
+	fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 
 	/* success */
 	return TRUE;
@@ -605,7 +605,7 @@ fu_genesys_scaler_device_pause_r2_cpu(FuGenesysScalerDevice *self, GError **erro
 		return FALSE;
 	}
 
-	g_usleep(200000); /* 200ms */
+	fu_device_sleep(FU_DEVICE(self), 200); /* ms */
 
 	/* success */
 	return TRUE;
@@ -634,8 +634,7 @@ fu_genesys_scaler_device_set_isp_mode(FuDevice *device, gpointer user_data, GErr
 					   error)) {
 		return FALSE;
 	}
-
-	g_usleep(1000); /* 1ms */
+	fu_device_sleep(device, 1); /* ms */
 
 	/* success */
 	return TRUE;
@@ -780,8 +779,7 @@ fu_genesys_scaler_device_get_level(FuGenesysScalerDevice *self, guint8 *level, G
 		g_prefix_error(error, "error getting level: ");
 		return FALSE;
 	}
-
-	g_usleep(100000); /* 100ms */
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 
 	/* success */
 	return TRUE;
@@ -813,7 +811,7 @@ fu_genesys_scaler_device_get_version(FuGenesysScalerDevice *self,
 		return FALSE;
 	}
 
-	g_usleep(100000); /* 100ms */
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 
 	/* success */
 	return TRUE;
@@ -851,7 +849,7 @@ fu_genesys_scaler_device_get_public_key(FuGenesysScalerDevice *self,
 			return FALSE;
 		}
 
-		g_usleep(100000); /* 100ms */
+		fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 	}
 
 	/* success */
@@ -1464,7 +1462,7 @@ fu_genesys_scaler_device_get_ddcci_data(FuGenesysScalerDevice *self,
 		return FALSE;
 	}
 
-	g_usleep(100000); /* 100ms */
+	fu_device_sleep(FU_DEVICE(self), 100); /* 1ms */
 
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
@@ -1483,7 +1481,7 @@ fu_genesys_scaler_device_get_ddcci_data(FuGenesysScalerDevice *self,
 		return FALSE;
 	}
 
-	g_usleep(100000); /* 100ms */
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 
 	/* success */
 	return TRUE;

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -94,7 +94,7 @@ fu_hailuck_bl_device_read_block(FuHailuckBlDevice *self,
 		return FALSE;
 
 	/* success */
-	g_usleep(10000);
+	fu_device_sleep(FU_DEVICE(self), 10);
 	return TRUE;
 }
 
@@ -145,7 +145,7 @@ fu_hailuck_bl_device_erase(FuHailuckBlDevice *self, FuProgress *progress, GError
 				      FU_HID_DEVICE_FLAG_IS_FEATURE,
 				      error))
 		return FALSE;
-	fu_progress_sleep(progress, 2000);
+	fu_device_sleep_full(FU_DEVICE(self), 2000, progress);
 	return TRUE;
 }
 
@@ -196,7 +196,7 @@ fu_hailuck_bl_device_write_block(FuHailuckBlDevice *self,
 		return FALSE;
 
 	/* success */
-	g_usleep(10000);
+	fu_device_sleep(FU_DEVICE(self), 10);
 	return TRUE;
 }
 

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -111,7 +111,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to erase: ");
 		return FALSE;
 	}
-	g_usleep(10000);
+	fu_device_sleep(device, 10);
 	fu_progress_step_done(progress);
 
 	/* write */
@@ -151,7 +151,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 			g_prefix_error(error, "failed to write block 0x%x: ", i);
 			return FALSE;
 		}
-		g_usleep(150 * 1000);
+		fu_device_sleep(device, 150);
 
 		/* verify block */
 		req.type = FU_HAILUCK_CMD_I2C_VERIFY_BLOCK;
@@ -165,7 +165,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 						i + 1,
 						chunks->len);
 	}
-	g_usleep(50 * 1000);
+	fu_device_sleep(device, 50);
 	fu_progress_step_done(progress);
 
 	/* end-program */
@@ -174,7 +174,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to end program: ");
 		return FALSE;
 	}
-	g_usleep(50 * 1000);
+	fu_device_sleep(device, 50);
 	fu_progress_step_done(progress);
 
 	/* verify checksum */
@@ -183,7 +183,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to verify: ");
 		return FALSE;
 	}
-	g_usleep(50 * 1000);
+	fu_device_sleep(device, 50);
 	fu_progress_step_done(progress);
 
 	/* signal that programming has completed */

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -619,7 +619,7 @@ fu_igsc_device_wait_for_reset(FuIgscDevice *self, GError **error)
 						    sizeof(fw_code_version),
 						    NULL))
 			return TRUE;
-		g_usleep(1000 * 100);
+		fu_device_sleep(FU_DEVICE(self), 100);
 	}
 	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "device did not reset");
 	return FALSE;

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -276,7 +276,7 @@ fu_intel_usb4_device_operation(FuDevice *device, guint16 opcode, guint8 *metadat
 						   g_steal_pointer(&error_local),
 						   "maximum tries exceeded: ");
 		}
-		g_usleep((gulong)10000);
+		fu_device_sleep(device, 10); /* ms */
 	}
 	return FALSE;
 }

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -818,7 +818,7 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 	 *  Upload finished: kUpdateStateUpdating->kUpdateStateCurrent (~5minutes)
 	 *  After upload is finished, device reboots itself
 	 */
-	g_usleep(G_TIME_SPAN_SECOND);
+	fu_device_sleep(device, 1000); /* ms */
 	/* save the current firmware version for troubleshooting purpose */
 	old_firmware_version = g_strdup(fu_device_get_version(device));
 	do {
@@ -830,7 +830,7 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 		} else {
 			query_device = (no_response_count == 0) ? FALSE : TRUE;
 		}
-		g_usleep(500 * G_TIME_SPAN_MILLISECOND);
+		fu_device_sleep(device, 500);
 
 		/* lost Success/Failure message, device rebooting */
 		if (no_response_count == max_no_response_count) {
@@ -879,7 +879,7 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 			 * device no longer broadcast fu related events, need to query device
 			 * explicitly now
 			 */
-			g_usleep(G_USEC_PER_SEC);
+			fu_device_sleep(device, 1000); /* ms */
 			fu_progress_reset(fu_progress_get_child(progress));
 			continue;
 		}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -748,7 +748,7 @@ fu_logitech_hidpp_device_setup(FuDevice *device, GError **error)
 		 * BLE devices might not be ready for ping right after
 		 * they come up -> wait a bit before pinging.
 		 */
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(device, 1000); /* ms */
 	}
 	if (fu_device_has_private_flag(device, FU_LOGITECH_HIDPP_DEVICE_FLAG_FORCE_RECEIVER_ID))
 		priv->device_idx = HIDPP_DEVICE_IDX_RECEIVER;
@@ -963,7 +963,7 @@ fu_logitech_hidpp_device_detach(FuDevice *device, FuProgress *progress, GError *
 			g_prefix_error(error, "failed to put device into DFU mode: ");
 			return FALSE;
 		}
-		g_usleep(200 * 1000);
+		fu_device_sleep(device, 200); /* ms */
 		return fu_logitech_hidpp_device_setup(FU_DEVICE(self), error);
 	}
 
@@ -1276,7 +1276,7 @@ fu_logitech_hidpp_device_attach(FuLogitechHidPpDevice *self,
 		 * Possible race condition: after the device is reset, Linux might enumerate it as
 		 * a different hidraw device depending on timing.
 		 */
-		fu_progress_sleep(progress, 1000); /* ms */
+		fu_device_sleep_full(FU_DEVICE(self), 1000, progress); /* ms */
 	} else {
 		/* device file hasn't been unbound/re-bound, just probe again */
 		if (!fu_device_retry(device, fu_logitech_hidpp_device_reprobe_cb, 10, NULL, error))

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -463,7 +463,7 @@ fu_logitech_hidpp_runtime_bolt_setup(FuDevice *device, GError **error)
 		/* HID++1.0 devices have to sleep to allow Solaar to talk to
 		 * the device first -- we can't use the SwID as this is a
 		 * HID++2.0 feature */
-		g_usleep(200 * 1000);
+		fu_device_sleep(device, 200); /* ms */
 		if (fu_logitech_hidpp_runtime_bolt_setup_internal(device, &error_local))
 			return TRUE;
 		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_DATA)) {

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -141,7 +141,7 @@ fu_logitech_hidpp_runtime_unifying_setup(FuDevice *device, GError **error)
 		/* HID++1.0 devices have to sleep to allow Solaar to talk to
 		 * the device first -- we can't use the SwID as this is a
 		 * HID++2.0 feature */
-		g_usleep(200 * 1000);
+		fu_device_sleep(device, 200); /* ms */
 		if (fu_logitech_hidpp_runtime_unifying_setup_internal(device, &error_local))
 			return TRUE;
 		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_DATA)) {

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -199,7 +199,7 @@ fu_nordic_hid_cfg_channel_receive(FuNordicHidCfgChannel *self,
 		    (recv_msg->recipient | recv_msg->event_id | recv_msg->status |
 		     recv_msg->data_len))
 			break;
-		g_usleep(i * 50);
+		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 	}
 	if (!fu_memcpy_safe(buf,
 			    bufsz,
@@ -780,7 +780,7 @@ fu_nordic_hid_cfg_channel_dfu_sync_cb(FuDevice *device, gpointer user_data, GErr
 			return FALSE;
 
 		recv_msg->report_id = HID_REPORT_ID;
-		g_usleep(i * 5000);
+		fu_device_sleep(device, 2); /* ms */
 		if (!fu_nordic_hid_cfg_channel_receive(self,
 						       (guint8 *)recv_msg,
 						       sizeof(*recv_msg),

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -391,7 +391,7 @@ fu_parade_lspcon_flash_wait_ready(FuParadeLspconDevice *self, GError **error)
 
 		/* flash operations generally take between 1ms and 4s; polling
 		 * at 1000 Hz is still quite responsive and not overly slow */
-		g_usleep(G_TIME_SPAN_MILLISECOND);
+		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 	} while (g_timer_elapsed(timer, NULL) <= 10.0);
 
 	g_set_error_literal(error,
@@ -431,7 +431,7 @@ fu_parade_lspcon_flash_write(FuParadeLspconDevice *self,
 	/* reset clt2SPI, required before write */
 	if (!fu_parade_lspcon_write_register(self, REG_ADDR_CLT2SPI, 0x20, error))
 		return FALSE;
-	g_usleep(100 * G_TIME_SPAN_MILLISECOND);
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 	if (!fu_parade_lspcon_write_register(self, REG_ADDR_CLT2SPI, 0, error))
 		return FALSE;
 

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -554,7 +554,7 @@ fu_pxi_ble_device_fw_ota_init_new(FuPxiBleDevice *self, gsize bufsz, GError **er
 		return FALSE;
 
 	/* delay for BLE device read command */
-	g_usleep(10 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 
 	/* read fw ota init new command */
 	res[0] = PXI_HID_DEV_OTA_FEATURE_REPORT_ID;
@@ -731,7 +731,7 @@ fu_pxi_ble_device_fw_get_info(FuPxiBleDevice *self, GError **error)
 		return FALSE;
 
 	/* delay for BLE device read command */
-	g_usleep(10 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 
 	res[0] = PXI_HID_DEV_OTA_FEATURE_REPORT_ID;
 	res[1] = FU_PXI_DEVICE_CMD_FW_GET_INFO;
@@ -775,7 +775,7 @@ fu_pxi_ble_device_get_model_info(FuPxiBleDevice *self, GError **error)
 		return FALSE;
 
 	/* delay for BLE device read command */
-	g_usleep(10 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 
 	res[0] = PXI_HID_DEV_OTA_FEATURE_REPORT_ID;
 	if (!fu_pxi_ble_device_get_feature(self, res, sizeof(res), error))

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -168,7 +168,7 @@ fu_pxi_receiver_device_fw_ota_ini_new_check(FuPxiReceiverDevice *device, GError 
 		return FALSE;
 
 	/* delay for wireless module device read command */
-	g_usleep(5 * 1000);
+	fu_device_sleep(FU_DEVICE(device), 5); /* ms */
 	buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 	if (!fu_pxi_receiver_device_get_feature(self, buf, sizeof(buf), error))
 		return FALSE;
@@ -189,7 +189,7 @@ fu_pxi_receiver_device_get_cmd_response(FuPxiReceiverDevice *device,
 		memset(buf, 0, bufsz);
 		buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 
-		g_usleep(5 * 1000);
+		fu_device_sleep(FU_DEVICE(device), 5); /* ms */
 
 		if (!fu_pxi_receiver_device_get_feature(device, buf, bufsz, error))
 			return FALSE;
@@ -483,7 +483,7 @@ fu_pxi_receiver_device_fw_upgrade(FuDevice *device,
 		return FALSE;
 
 	/* delay for wireless module device read command */
-	g_usleep(5 * 1000);
+	fu_device_sleep(device, 5); /* ms */
 
 	if (!fu_pxi_receiver_device_get_cmd_response(self, res, sizeof(res), error))
 		return FALSE;
@@ -592,7 +592,7 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* delay for wireless module device read command */
-	g_usleep(5 * 1000);
+	fu_device_sleep(device, 5); /* ms */
 
 	/* send device reset command */
 	if (!fu_pxi_receiver_device_reset(device, error))
@@ -630,7 +630,7 @@ fu_pxi_receiver_device_get_peripheral_info(FuPxiReceiverDevice *device,
 						error))
 		return FALSE;
 
-	g_usleep(5 * 1000);
+	fu_device_sleep(FU_DEVICE(device), 5); /* ms */
 	buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 
 	if (!fu_pxi_receiver_device_get_feature(device, buf, sizeof(buf), error))
@@ -711,7 +711,7 @@ fu_pxi_receiver_device_get_peripheral_num(FuPxiReceiverDevice *device,
 						error))
 		return FALSE;
 
-	g_usleep(5 * 1000);
+	fu_device_sleep(FU_DEVICE(device), 5); /* ms */
 
 	buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 	if (!fu_pxi_receiver_device_get_feature(device, buf, sizeof(buf), error))

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -18,7 +18,7 @@
 #include "fu-pxi-receiver-device.h"
 #include "fu-pxi-wireless-device.h"
 
-#define FU_PXI_WIRELESS_DEV_DELAY_US 50000
+#define FU_PXI_WIRELESS_DEV_DELAY_MS 50
 
 struct _FuPxiWirelessDevice {
 	FuDevice parent_instance;
@@ -114,7 +114,7 @@ fu_pxi_wireless_device_get_cmd_response(FuPxiWirelessDevice *device,
 		memset(buf, 0, bufsz);
 		buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 
-		g_usleep(5 * 1000);
+		fu_device_sleep(FU_DEVICE(device), 5); /* ms */
 
 		if (!fu_pxi_wireless_device_get_feature(FU_DEVICE(parent), buf, bufsz, error))
 			return FALSE;
@@ -253,7 +253,7 @@ fu_pxi_wireless_device_fw_object_create(FuDevice *device, FuChunk *chk, GError *
 		return FALSE;
 
 	/* delay for wireless module device get command response*/
-	g_usleep(FU_PXI_WIRELESS_DEV_DELAY_US);
+	fu_device_sleep(FU_DEVICE(self), FU_PXI_WIRELESS_DEV_DELAY_MS);
 
 	return fu_pxi_wireless_device_set_feature(FU_DEVICE(parent),
 						  receiver_cmd->data,
@@ -300,7 +300,7 @@ fu_pxi_wireless_device_write_payload(FuDevice *device, FuChunk *chk, GError **er
 		return FALSE;
 
 	/* delay for wireless module device get command response*/
-	g_usleep(FU_PXI_WIRELESS_DEV_DELAY_US);
+	fu_device_sleep(device, FU_PXI_WIRELESS_DEV_DELAY_MS);
 
 	if (!fu_pxi_wireless_device_get_cmd_response(self, buf, sizeof(buf), error))
 		return FALSE;
@@ -437,7 +437,7 @@ fu_pxi_wireless_device_fw_ota_ini_new_check(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* delay for wireless module device get command response*/
-	g_usleep(FU_PXI_WIRELESS_DEV_DELAY_US);
+	fu_device_sleep(device, FU_PXI_WIRELESS_DEV_DELAY_MS);
 
 	if (!fu_pxi_wireless_device_get_cmd_response(self, buf, sizeof(buf), error))
 		return FALSE;
@@ -624,7 +624,7 @@ fu_pxi_wireless_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send device reset command */
-	g_usleep(FU_PXI_WIRELESS_DEV_DELAY_US);
+	fu_device_sleep(device, FU_PXI_WIRELESS_DEV_DELAY_MS);
 	if (!fu_pxi_wireless_device_reset(device, error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -340,7 +340,7 @@ mst_poll_register(FuRealtekMstDevice *self,
 	if (!mst_read_register(self, address, &value, error))
 		return FALSE;
 	while ((value & mask) != expected && g_timer_elapsed(timer, NULL) <= timeout_seconds) {
-		g_usleep(G_TIME_SPAN_MILLISECOND);
+		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 		if (!mst_read_register(self, address, &value, error))
 			return FALSE;
 	}
@@ -435,7 +435,7 @@ fu_realtek_mst_device_get_dual_bank_info(FuRealtekMstDevice *self,
 		return FALSE;
 
 	/* wait for mode switch to complete */
-	g_usleep(200 * G_TIME_SPAN_MILLISECOND);
+	fu_device_sleep(FU_DEVICE(self), 200); /* ms */
 
 	/* request dual bank state and read back */
 	if (!fu_i2c_device_write(FU_I2C_DEVICE(self), request, sizeof(request), error))
@@ -886,7 +886,7 @@ fu_realtek_mst_device_attach(FuDevice *device, FuProgress *progress, GError **er
 		}
 
 		/* allow device some time to reset */
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(device, 1000); /* ms */
 
 		/* verify device has exited programming mode and actually reset */
 		if (!mst_read_register(self, REG_MCU_MODE, &value, error))

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -751,7 +751,7 @@ fu_redfish_device_poll_task(FuRedfishDevice *self,
 
 	/* sleep and then reprobe hardware */
 	do {
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(FU_DEVICE(self), 1000); /* ms */
 		if (!fu_redfish_device_poll_task_once(self, ctx, error))
 			return FALSE;
 		if (ctx->completed)

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -538,10 +538,9 @@ fu_redfish_plugin_cleanup(FuPlugin *plugin,
 
 	/* work around manager bugs... */
 	fu_backend_invalidate(FU_BACKEND(self->backend));
-	if (fu_redfish_device_get_reset_pre_delay(FU_REDFISH_DEVICE(device)) > 0) {
-		fu_progress_sleep(fu_progress_get_child(progress),
-				  fu_redfish_device_get_reset_pre_delay(FU_REDFISH_DEVICE(device)));
-	}
+	fu_device_sleep_full(device,
+			     fu_redfish_device_get_reset_pre_delay(FU_REDFISH_DEVICE(device)),
+			     fu_progress_get_child(progress));
 	fu_progress_step_done(progress);
 
 	/* read the config file to work out how long to wait */
@@ -566,11 +565,9 @@ fu_redfish_plugin_cleanup(FuPlugin *plugin,
 	fu_progress_step_done(progress);
 
 	/* work around manager bugs... */
-	if (fu_redfish_device_get_reset_post_delay(FU_REDFISH_DEVICE(device)) > 0) {
-		fu_progress_sleep(
-		    fu_progress_get_child(progress),
-		    fu_redfish_device_get_reset_post_delay(FU_REDFISH_DEVICE(device)));
-	}
+	fu_device_sleep_full(device,
+			     fu_redfish_device_get_reset_post_delay(FU_REDFISH_DEVICE(device)),
+			     fu_progress_get_child(progress));
 	fu_progress_step_done(progress);
 
 	/* get the new list of devices */

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -182,7 +182,7 @@ fu_rts54hid_device_verify_update_fw(FuRts54HidDevice *self, FuProgress *progress
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error))
 		return FALSE;
-	fu_progress_sleep(progress, 4000);
+	fu_device_sleep_full(FU_DEVICE(self), 4000, progress); /* ms */
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      0x0,
 				      buf,

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -51,7 +51,7 @@ fu_rts54hub_rtd21xx_ensure_version_unlocked(FuRts54hubRtd21xxBackground *self, G
 	}
 
 	/* wait for device ready */
-	g_usleep(300000);
+	fu_device_sleep(FU_DEVICE(self), 300); /* ms */
 	if (!fu_rts54hub_rtd21xx_device_i2c_read(FU_RTS54HUB_RTD21XX_DEVICE(self),
 						 UC_ISP_TARGET_ADDR,
 						 0x00,
@@ -84,7 +84,7 @@ fu_rts54hub_rtd21xx_background_detach_raw(FuRts54hubRtd21xxBackground *self, GEr
 	}
 
 	/* wait for device ready */
-	g_usleep(300000);
+	fu_device_sleep(FU_DEVICE(self), 300); /* ms */
 	return TRUE;
 }
 
@@ -147,7 +147,7 @@ fu_rts54hub_rtd21xx_background_attach(FuDevice *device, FuProgress *progress, GE
 		g_prefix_error(error, "failed to attach: ");
 		return FALSE;
 	}
-	fu_progress_sleep(progress, 1000);
+	fu_device_sleep_full(device, 1000, progress); /* ms */
 
 	/* success */
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
@@ -236,7 +236,7 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	}
 
 	/* read back 6 bytes data */
-	g_usleep(I2C_DELAY_AFTER_SEND * 40);
+	fu_device_sleep(device, I2C_DELAY_AFTER_SEND * 40);
 	if (!fu_rts54hub_rtd21xx_device_i2c_read(FU_RTS54HUB_RTD21XX_DEVICE(self),
 						 UC_ISP_TARGET_ADDR,
 						 0x00,

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
@@ -118,7 +118,7 @@ fu_rts54hub_rtd21xx_device_i2c_write(FuRts54hubRtd21xxDevice *self,
 		g_prefix_error(error, "failed to write I2C @0x%02x:%02x: ", target_addr, sub_addr);
 		return FALSE;
 	}
-	g_usleep(I2C_DELAY_AFTER_SEND);
+	fu_device_sleep(FU_DEVICE(self), I2C_DELAY_AFTER_SEND);
 	return TRUE;
 }
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.h
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.h
@@ -20,7 +20,7 @@ struct _FuRts54hubRtd21xxDeviceClass {
 	FuDeviceClass parent_class;
 };
 
-#define I2C_DELAY_AFTER_SEND 5000 /* us */
+#define I2C_DELAY_AFTER_SEND 5 /* ms */
 
 #define UC_ISP_TARGET_ADDR	      0x3A
 #define UC_FOREGROUND_STATUS	      0x31

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -53,7 +53,7 @@ fu_rts54hub_rtd21xx_ensure_version_unlocked(FuRts54hubRtd21xxForeground *self, G
 	}
 
 	/* wait for device ready */
-	g_usleep(300000);
+	fu_device_sleep(FU_DEVICE(self), 300); /* ms */
 	if (!fu_rts54hub_rtd21xx_device_i2c_read(FU_RTS54HUB_RTD21XX_DEVICE(self),
 						 UC_ISP_TARGET_ADDR,
 						 0x00,
@@ -83,7 +83,7 @@ fu_rts54hub_rtd21xx_foreground_detach_raw(FuRts54hubRtd21xxForeground *self, GEr
 		return FALSE;
 	}
 	/* wait for device ready */
-	g_usleep(300000);
+	fu_device_sleep(FU_DEVICE(self), 300); /* ms */
 	return TRUE;
 }
 
@@ -153,7 +153,7 @@ fu_rts54hub_rtd21xx_foreground_attach(FuDevice *device, FuProgress *progress, GE
 
 	/* the device needs some time to restart with the new firmware before
 	 * it can be queried again */
-	fu_progress_sleep(progress, 60000);
+	fu_device_sleep_full(device, 60000, progress); /* ms */
 
 	/* success */
 	return TRUE;
@@ -283,7 +283,7 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	}
 
 	/* read back 6 bytes data */
-	g_usleep(I2C_DELAY_AFTER_SEND * 40);
+	fu_device_sleep(FU_DEVICE(self), I2C_DELAY_AFTER_SEND * 40);
 	if (!fu_rts54hub_rtd21xx_device_i2c_read(FU_RTS54HUB_RTD21XX_DEVICE(self),
 						 UC_ISP_TARGET_ADDR,
 						 UC_FOREGROUND_STATUS,

--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -121,7 +121,7 @@ fu_steelseries_fizz_tunnel_attach(FuDevice *device, FuProgress *progress, GError
 	fu_progress_step_done(progress);
 
 	/* wait for receiver to reset the connection status to 0 */
-	fu_progress_sleep(fu_progress_get_child(progress), 2000); /* 2 s */
+	fu_device_sleep_full(device, 2000, fu_progress_get_child(progress)); /* ms */
 	remove_delay -= 2000;
 	fu_progress_step_done(progress);
 

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -43,7 +43,7 @@ fu_steelseries_gamepad_cmd_erase(FuDevice *device, GError **error)
 	}
 
 	/* timeout to give some time to erase */
-	g_usleep(20000);
+	fu_device_sleep(device, 20); /* ms */
 
 	return TRUE;
 }
@@ -183,7 +183,7 @@ fu_steelseries_gamepad_write_firmware_chunks(FuDevice *device,
 			return FALSE;
 		}
 		/* timeout to give some time to flash the block on device */
-		g_usleep(10000);
+		fu_device_sleep(device, 10); /* ms */
 		fu_progress_step_done(progress);
 	}
 

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -307,7 +307,7 @@ fu_steelseries_sonic_read_from_flash(FuDevice *device,
 			fu_dump_raw(G_LOG_DOMAIN, "ReadFromFlash", data, sizeof(data));
 
 		/* timeout to give some time to read from flash to ram */
-		g_usleep(15000); /* 15 ms */
+		fu_device_sleep(device, 15); /* ms */
 
 		if (!fu_steelseries_sonic_read_from_ram(device,
 							chip,
@@ -317,7 +317,6 @@ fu_steelseries_sonic_read_from_flash(FuDevice *device,
 							fu_progress_get_child(progress),
 							error))
 			return FALSE;
-
 		fu_progress_step_done(progress);
 	}
 
@@ -391,8 +390,7 @@ fu_steelseries_sonic_write_to_ram(FuDevice *device,
 			return FALSE;
 
 		/* timeout to give some time to write to ram */
-		g_usleep(15000); /* 15 ms */
-
+		fu_device_sleep(device, 15); /* ms */
 		fu_progress_step_done(progress);
 	}
 
@@ -474,8 +472,7 @@ fu_steelseries_sonic_write_to_flash(FuDevice *device,
 			return FALSE;
 
 		/* timeout to give some time to write from ram to flash */
-		g_usleep(15000); /* 15 ms */
-
+		fu_device_sleep(device, 15); /* ms */
 		fu_progress_step_done(progress);
 	}
 
@@ -523,8 +520,7 @@ fu_steelseries_sonic_erase(FuDevice *device,
 		return FALSE;
 
 	/* timeout to give some time to erase flash */
-	fu_progress_sleep(fu_progress_get_child(progress), 1000); /* 1 s */
-
+	fu_device_sleep_full(device, 1000, fu_progress_get_child(progress)); /* ms */
 	fu_progress_step_done(progress);
 
 	/* success */
@@ -562,8 +558,7 @@ fu_steelseries_sonic_restart(FuDevice *device,
 		return FALSE;
 
 	/* timeout to give some time to restart chip */
-	fu_progress_sleep(progress, 3000); /* 3 s */
-
+	fu_device_sleep_full(device, 3000, progress); /* ms */
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -320,10 +320,10 @@ fu_superio_it55_device_erase(FuDevice *device, GError **error)
 		    !fu_superio_device_ec_write_cmd(self, 0x00, error))
 			return FALSE;
 
-		g_usleep(1000);
+		fu_device_sleep(device, 1); /* ms */
 	}
 
-	g_usleep(100000);
+	fu_device_sleep(device, 100); /* ms */
 	return TRUE;
 }
 
@@ -417,7 +417,7 @@ fu_superio_it55_device_write_attempt(FuDevice *device,
 			return FALSE;
 	fu_progress_step_done(progress);
 
-	g_usleep(1000);
+	fu_device_sleep(device, 1); /* ms */
 
 	written_fw =
 	    fu_superio_it55_device_get_firmware(device, fu_progress_get_child(progress), error);

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -657,7 +657,7 @@ fu_synaptics_cxaudio_device_write_firmware(FuDevice *device,
 		7,
 		error))
 		return FALSE;
-	g_usleep(10 * 1000);
+	fu_device_sleep(device, 10); /* ms */
 	fu_progress_step_done(progress);
 
 	/* initialize layout signature and version to 0 if transitioning from

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -40,7 +40,7 @@
 #define REG_QUAD_DISABLE       0x200fc0
 #define REG_HDCP22_DISABLE     0x200f90
 
-#define FLASH_SETTLE_TIME 5000000 /* us */
+#define FLASH_SETTLE_TIME 5000 /* ms */
 
 #define CAYENNE_FIRMWARE_SIZE 0x50000 /* bytes */
 
@@ -344,7 +344,7 @@ fu_synaptics_mst_device_update_esm(FuSynapticsMstDevice *self,
 		}
 
 		g_debug("Waiting for flash clear to settle");
-		g_usleep(FLASH_SETTLE_TIME);
+		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		/* write firmware */
 		fu_progress_set_id(progress, G_STRLOC);
@@ -425,7 +425,7 @@ fu_synaptics_mst_device_update_tesla_leaf_firmware(FuSynapticsMstDevice *self,
 		if (!fu_synaptics_mst_device_set_flash_sector_erase(self, 0xffff, 0, error))
 			return FALSE;
 		g_debug("Waiting for flash clear to settle");
-		g_usleep(FLASH_SETTLE_TIME);
+		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		fu_progress_set_steps(progress, write_loops);
 		for (guint32 i = 0; i < write_loops; i++) {
@@ -582,7 +582,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 								    error))
 			return FALSE;
 		g_debug("Waiting for flash clear to settle");
-		g_usleep(FLASH_SETTLE_TIME);
+		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		/* write */
 		write_idx = 0;
@@ -622,7 +622,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 		/* verify CRC */
 		checksum = fu_synaptics_mst_device_get_crc(0, 16, fw_size, payload_data);
 		for (guint32 i = 0; i < 4; i++) {
-			g_usleep(1000); /* wait crc calculation */
+			fu_device_sleep(FU_DEVICE(self), 1); /* wait crc calculation */
 			if (!fu_synaptics_mst_connection_rc_special_get_command(
 				connection,
 				UPDC_CAL_EEPROM_CHECK_CRC16,
@@ -645,7 +645,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 					    "firmware update fail");
 			return FALSE;
 		}
-		g_usleep(2000);
+		fu_device_sleep(FU_DEVICE(self), 2);
 	}
 
 	/* set tag valid */
@@ -683,7 +683,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 			g_prefix_error(error, "failed to write tag: ");
 			return FALSE;
 		}
-		g_usleep(200);
+		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 		if (!fu_synaptics_mst_connection_rc_get_command(
 			connection,
 			UPDC_READ_FROM_EEPROM,
@@ -801,7 +801,7 @@ fu_synaptics_mst_device_panamera_prepare_write(FuSynapticsMstDevice *self, GErro
 	}
 
 	/* wait for ESM exit */
-	g_usleep(200);
+	fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 
 	/* disable QUAD mode */
 	if (!fu_synaptics_mst_connection_rc_get_command(connection,
@@ -889,7 +889,7 @@ fu_synaptics_mst_device_update_cayenne_firmware(FuSynapticsMstDevice *self,
 		if (!fu_synaptics_mst_device_set_flash_sector_erase(self, 0xffff, 0, error))
 			return FALSE;
 		g_debug("Waiting for flash clear to settle");
-		g_usleep(FLASH_SETTLE_TIME);
+		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		fu_progress_set_steps(progress, write_loops);
 		for (guint32 i = 0; i < write_loops; i++) {
@@ -1134,7 +1134,7 @@ fu_synaptics_mst_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* wait for flash clear to settle */
-	fu_progress_sleep(fu_progress_get_child(progress), 2000);
+	fu_device_sleep_full(device, 2000, fu_progress_get_child(progress)); /* ms */
 	fu_progress_step_done(progress);
 	return TRUE;
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -209,7 +209,7 @@ fu_synaptics_rmi_device_reset(FuSynapticsRmiDevice *self, GError **error)
 					   FU_SYNAPTICS_RMI_DEVICE_FLAG_ALLOW_FAILURE,
 					   error))
 		return FALSE;
-	g_usleep(1000 * RMI_F01_DEFAULT_RESET_DELAY_MS);
+	fu_device_sleep(FU_DEVICE(self), RMI_F01_DEFAULT_RESET_DELAY_MS);
 	return TRUE;
 }
 
@@ -641,7 +641,7 @@ fu_synaptics_rmi_device_poll_wait(FuSynapticsRmiDevice *self, GError **error)
 
 	/* try to poll every 20ms for up to 400ms */
 	for (guint i = 0; i < 20; i++) {
-		g_usleep(1000 * 20);
+		fu_device_sleep(FU_DEVICE(self), 20);
 		g_clear_error(&error_local);
 		if (fu_synaptics_rmi_device_poll(self, &error_local))
 			return TRUE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -117,7 +117,7 @@ fu_synaptics_rmi_ps2_device_read_ack(FuSynapticsRmiPs2Device *self, guint8 *pbuf
 					    &error_local)) {
 			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
 				g_warning("read timed out: %u", i);
-				g_usleep(30);
+				fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 				continue;
 			}
 			g_propagate_error(error, g_steal_pointer(&error_local));
@@ -188,17 +188,17 @@ fu_synaptics_rmi_ps2_device_write_byte(FuSynapticsRmiPs2Device *self,
 			if (res == edpsResend) {
 				do_write = TRUE;
 				g_debug("resend");
-				g_usleep(G_USEC_PER_SEC);
+				fu_device_sleep(FU_DEVICE(self), 1000); /* ms */
 				break;
 			}
 			if (res == edpsError) {
 				do_write = TRUE;
 				g_debug("error");
-				g_usleep(1000 * 10);
+				fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 				break;
 			}
 			g_debug("other response: 0x%x", res);
-			g_usleep(1000 * 10);
+			fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 		}
 		if (i >= 3) {
 			if (flags & FU_SYNAPTICS_RMI_DEVICE_FLAG_ALLOW_FAILURE) {
@@ -503,7 +503,7 @@ fu_synaptics_rmi_ps2_device_write_rmi_register(FuSynapticsRmiPs2Device *self,
 	}
 
 	/* success */
-	g_usleep(1000 * 20);
+	fu_device_sleep(FU_DEVICE(self), 20); /* ms */
 	return TRUE;
 }
 
@@ -563,7 +563,7 @@ fu_synaptics_rmi_ps2_device_read_rmi_register(FuSynapticsRmiPs2Device *self,
 	}
 
 	/* success */
-	g_usleep(1000 * 20);
+	fu_device_sleep(FU_DEVICE(self), 20); /* ms */
 	return TRUE;
 }
 
@@ -611,7 +611,7 @@ fu_synaptics_rmi_ps2_device_read_rmi_packet_register(FuSynapticsRmiPs2Device *se
 		fu_byte_array_append_uint8(buf, tmp);
 	}
 
-	g_usleep(1000 * 20);
+	fu_device_sleep(FU_DEVICE(self), 20); /* ms */
 	return g_steal_pointer(&buf);
 }
 
@@ -950,7 +950,7 @@ fu_synaptics_rmi_ps2_device_attach(FuDevice *device, FuProgress *progress, GErro
 	fu_synaptics_rmi_device_set_iepmode(rmi_device, FALSE);
 
 	/* delay after writing */
-	fu_progress_sleep(progress, 2000);
+	fu_device_sleep_full(device, 2000, progress); /* ms */
 
 	/* reset device */
 	if (!fu_synaptics_rmi_device_enter_iep_mode(rmi_device,
@@ -961,9 +961,7 @@ fu_synaptics_rmi_ps2_device_attach(FuDevice *device, FuProgress *progress, GErro
 		g_prefix_error(error, "failed to reset device: ");
 		return FALSE;
 	}
-
-	/* delay after reset */
-	fu_progress_sleep(progress, 5000);
+	fu_device_sleep_full(device, 5000, progress); /* ms */
 
 	/* back to psmouse */
 	if (!fu_udev_device_write_sysfs(FU_UDEV_DEVICE(device), "drvctl", "psmouse", error)) {
@@ -993,7 +991,7 @@ fu_synaptics_rmi_ps2_device_wait_for_attr(FuSynapticsRmiDevice *rmi_device,
 					  guint timeout_ms,
 					  GError **error)
 {
-	g_usleep(1000 * timeout_ms);
+	fu_device_sleep(FU_DEVICE(rmi_device), timeout_ms);
 	return TRUE;
 }
 

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -60,7 +60,7 @@ fu_synaptics_rmi_v5_device_detach(FuDevice *device, FuProgress *progress, GError
 		return FALSE;
 	}
 
-	g_usleep(1000 * RMI_F34_ENABLE_WAIT_MS);
+	fu_device_sleep(device, RMI_F34_ENABLE_WAIT_MS);
 	return TRUE;
 }
 
@@ -86,7 +86,7 @@ fu_synaptics_rmi_v5_device_erase_all(FuSynapticsRmiDevice *self, GError **error)
 		g_prefix_error(error, "failed to erase core config: ");
 		return FALSE;
 	}
-	g_usleep(1000 * RMI_F34_ERASE_WAIT_MS);
+	fu_device_sleep(FU_DEVICE(self), RMI_F34_ERASE_WAIT_MS);
 	fu_synaptics_rmi_device_set_iepmode(self, FALSE);
 	if (!fu_synaptics_rmi_device_enter_iep_mode(self,
 						    FU_SYNAPTICS_RMI_DEVICE_FLAG_FORCE,
@@ -429,7 +429,7 @@ fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 			}
 			fu_progress_step_done(progress_child);
 		}
-		g_usleep(1000 * 1000);
+		fu_device_sleep(device, 1000); /* ms */
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -119,7 +119,7 @@ fu_synaptics_rmi_v7_device_detach(FuDevice *device, FuProgress *progress, GError
 		return FALSE;
 	if (!fu_synaptics_rmi_device_poll_wait(self, error))
 		return FALSE;
-	g_usleep(1000 * RMI_F34_ENABLE_WAIT_MS);
+	fu_device_sleep(device, RMI_F34_ENABLE_WAIT_MS);
 	return TRUE;
 }
 
@@ -143,7 +143,7 @@ fu_synaptics_rmi_v7_device_erase_partition(FuSynapticsRmiDevice *self,
 	fu_byte_array_append_uint8(erase_cmd, flash->bootloader_id[0]);
 	fu_byte_array_append_uint8(erase_cmd, flash->bootloader_id[1]);
 
-	g_usleep(1000 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 1000); /* ms */
 	if (!fu_synaptics_rmi_device_write(self,
 					   f34->data_base + 1,
 					   erase_cmd,
@@ -152,7 +152,7 @@ fu_synaptics_rmi_v7_device_erase_partition(FuSynapticsRmiDevice *self,
 		g_prefix_error(error, "failed to unlock erasing: ");
 		return FALSE;
 	}
-	g_usleep(1000 * 100);
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 
 	/* wait for ATTN */
 	if (!fu_synaptics_rmi_device_wait_for_idle(self,
@@ -196,7 +196,7 @@ fu_synaptics_rmi_v7_device_erase_all(FuSynapticsRmiDevice *self, GError **error)
 	/* for BL8 device, we need hold 1 seconds after querying F34 status to
 	 * avoid not get attention by following giving erase command */
 	if (flash->bootloader_id[1] >= 8)
-		g_usleep(1000 * 1000);
+		fu_device_sleep(FU_DEVICE(self), 1000); /* ms */
 	if (!fu_synaptics_rmi_device_write(self,
 					   f34->data_base + 1,
 					   erase_cmd,
@@ -205,7 +205,7 @@ fu_synaptics_rmi_v7_device_erase_all(FuSynapticsRmiDevice *self, GError **error)
 		g_prefix_error(error, "failed to unlock erasing: ");
 		return FALSE;
 	}
-	g_usleep(1000 * 100);
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 	if (flash->bootloader_id[1] >= 8) {
 		/* wait for ATTN */
 		if (!fu_synaptics_rmi_device_wait_for_idle(self,
@@ -229,7 +229,7 @@ fu_synaptics_rmi_v7_device_erase_all(FuSynapticsRmiDevice *self, GError **error)
 		fu_byte_array_append_uint32(erase_config_cmd, 0x0, G_LITTLE_ENDIAN);
 		fu_byte_array_append_uint8(erase_config_cmd, RMI_FLASH_CMD_ERASE);
 
-		g_usleep(1000 * 100);
+		fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 		if (!fu_synaptics_rmi_device_write(self,
 						   f34->data_base + 1,
 						   erase_config_cmd,
@@ -240,7 +240,7 @@ fu_synaptics_rmi_v7_device_erase_all(FuSynapticsRmiDevice *self, GError **error)
 		}
 
 		/* wait for ATTN */
-		g_usleep(1000 * 100);
+		fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 		if (!fu_synaptics_rmi_device_wait_for_idle(
 			self,
 			RMI_F34_ERASE_WAIT_MS,

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -166,7 +166,7 @@ fu_system76_launch_device_detach(FuDevice *device, FuProgress *progress, GError 
 
 	/* poll for the user-unlock */
 	do {
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(device, 1000); /* ms */
 		if (!fu_system76_launch_device_reset(device, &rc, error))
 			return FALSE;
 	} while (rc != 0 &&

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -222,17 +222,17 @@ fu_test_plugin_write_firmware(FuPlugin *plugin,
 	}
 	fu_progress_set_status(progress, FWUPD_STATUS_DECOMPRESSING);
 	for (guint i = 0; i <= self->delay_decompress_ms; i++) {
-		g_usleep(1000);
+		fu_device_sleep(device, 1);
 		fu_progress_set_percentage_full(progress, i, self->delay_decompress_ms);
 	}
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 0; i <= self->delay_write_ms; i++) {
-		g_usleep(1000);
+		fu_device_sleep(device, 1);
 		fu_progress_set_percentage_full(progress, i, self->delay_write_ms);
 	}
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
 	for (guint i = 0; i <= self->delay_verify_ms; i++) {
-		g_usleep(1000);
+		fu_device_sleep(device, 1);
 		fu_progress_set_percentage_full(progress, i, self->delay_verify_ms);
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -125,7 +125,7 @@ fu_thunderbolt_device_get_version(FuThunderboltDevice *self, GError **error)
 		if (g_file_get_contents(safe_path, &version_raw, NULL, &error_local))
 			break;
 		g_debug("Attempt %u: Failed to read NVM version", i);
-		g_usleep(TBT_NVM_RETRY_TIMEOUT * 1000);
+		fu_device_sleep(FU_DEVICE(self), TBT_NVM_RETRY_TIMEOUT);
 		/* safe mode probably */
 		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
 			break;

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -149,7 +149,7 @@ fu_vli_device_spi_wait_finish(FuVliDevice *self, GError **error)
 		} else {
 			cnt = 0;
 		}
-		g_usleep(500 * 1000);
+		fu_device_sleep(FU_DEVICE(self), 500); /* ms */
 	}
 	g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed to wait for SPI");
 	return FALSE;
@@ -267,7 +267,7 @@ fu_vli_device_spi_write_block(FuVliDevice *self,
 		g_prefix_error(error, "SPI data write failed: ");
 		return FALSE;
 	}
-	g_usleep(800);
+	fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 
 	/* verify */
 	if (!fu_vli_device_spi_read_block(self, address, buf_tmp, bufsz, error)) {
@@ -349,7 +349,7 @@ fu_vli_device_spi_erase_all(FuVliDevice *self, FuProgress *progress, GError **er
 		return FALSE;
 	if (!fu_vli_device_spi_chip_erase(self, error))
 		return FALSE;
-	fu_progress_sleep(fu_progress_get_child(progress), 4000);
+	fu_device_sleep_full(FU_DEVICE(self), 4000, fu_progress_get_child(progress)); /* ms */
 	fu_progress_step_done(progress);
 
 	/* verify chip was erased */

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -172,7 +172,7 @@ fu_vli_pd_device_spi_write_status(FuVliDevice *self, guint8 status, GError **err
 	}
 
 	/* Fix_For_GD_&_EN_SPI_Flash */
-	g_usleep(100 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 	return TRUE;
 }
 

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -151,7 +151,7 @@ fu_vli_pd_parade_device_read_fw_ver(FuVliPdParadeDevice *self, GError **error)
 		return FALSE;
 	if (!fu_vli_pd_parade_device_set_offset(self, 0x0, error))
 		return FALSE;
-	g_usleep(1000 * 10);
+	fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 	if (!fu_vli_pd_parade_device_i2c_read(self, self->page7, 0x02, buf, 0x1, error))
 		return FALSE;
 	if (buf[0] != 0x01 && buf[0] != 0x02) {
@@ -518,7 +518,7 @@ fu_vli_pd_parade_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (!fu_vli_pd_parade_device_i2c_write(self, self->page2, 0x82, 0x20, error))
 		return FALSE; /* Reset_CLT2SPI_Interface */
-	g_usleep(1000 * 100);
+	fu_device_sleep(device, 100); /* ms */
 	if (!fu_vli_pd_parade_device_i2c_write(self, self->page2, 0x82, 0x00, error))
 		return FALSE;
 

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -240,7 +240,7 @@ fu_vli_usbhub_device_spi_write_status(FuVliDevice *self, guint8 status, GError *
 	}
 
 	/* Fix_For_GD_&_EN_SPI_Flash */
-	g_usleep(100 * 1000);
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 	return TRUE;
 }
 

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -157,7 +157,7 @@ fu_vli_usbhub_msp430_device_detach(FuDevice *device, FuProgress *progress, GErro
 		return FALSE;
 
 	/* avoid power instability by waiting T1 */
-	fu_progress_sleep(progress, 1000);
+	fu_device_sleep_full(device, 1000, progress); /* ms */
 
 	/* check the device came back */
 	if (!fu_vli_usbhub_device_i2c_read_status(parent, &status, error)) {
@@ -181,7 +181,7 @@ fu_vli_usbhub_msp430_device_write_firmware_cb(FuDevice *device, gpointer user_da
 	FuVliUsbhubDevice *parent = FU_VLI_USBHUB_DEVICE(fu_device_get_parent(device));
 	FuVliUsbhubI2cStatus status = 0xff;
 
-	g_usleep(5 * 1000);
+	fu_device_sleep(device, 5); /* ms */
 	if (fu_usb_device_get_spec(FU_USB_DEVICE(parent)) >= 0x0300 || req->bufsz <= 32) {
 		if (!fu_vli_usbhub_device_i2c_write_data(parent, 0, 0, req->buf, req->bufsz, error))
 			return FALSE;
@@ -203,7 +203,7 @@ fu_vli_usbhub_msp430_device_write_firmware_cb(FuDevice *device, gpointer user_da
 		return TRUE;
 
 	/* read data to check status */
-	g_usleep(5 * 1000);
+	fu_device_sleep(device, 5); /* ms */
 	if (!fu_vli_usbhub_device_i2c_read_status(parent, &status, error))
 		return FALSE;
 	return fu_vli_usbhub_i2c_check_status(status, error);

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -21,7 +21,7 @@ G_DEFINE_TYPE(FuVliUsbhubRtd21xxDevice, fu_vli_usbhub_rtd21xx_device, FU_TYPE_DE
 #define I2C_WRITE_REQUEST 0xB2
 #define I2C_READ_REQUEST  0xA5
 
-#define I2C_DELAY_AFTER_SEND 5000 /* us */
+#define I2C_DELAY_AFTER_SEND 5 /* ms */
 
 #define UC_FOREGROUND_TARGET_ADDR     0x3A
 #define UC_FOREGROUND_STATUS	      0x31
@@ -89,7 +89,7 @@ fu_vli_usbhub_device_i2c_write(FuVliUsbhubDevice *self,
 		g_prefix_error(error, "failed to write I2C @0x%02x:%02x: ", target_addr, sub_addr);
 		return FALSE;
 	}
-	g_usleep(I2C_DELAY_AFTER_SEND);
+	fu_device_sleep(FU_DEVICE(self), I2C_DELAY_AFTER_SEND);
 	return TRUE;
 }
 
@@ -187,7 +187,7 @@ fu_vli_usbhub_rtd21xx_ensure_version_unlocked(FuVliUsbhubRtd21xxDevice *self, GE
 	}
 
 	/* wait for device ready */
-	g_usleep(300000);
+	fu_device_sleep(FU_DEVICE(self), 300);
 	if (!fu_vli_usbhub_device_i2c_read(parent,
 					   UC_FOREGROUND_TARGET_ADDR,
 					   0x00,
@@ -365,7 +365,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	}
 
 	/* read back 6 bytes data */
-	g_usleep(I2C_DELAY_AFTER_SEND * 40);
+	fu_device_sleep(device, I2C_DELAY_AFTER_SEND * 40);
 	if (!fu_vli_usbhub_device_i2c_read(parent,
 					   UC_FOREGROUND_TARGET_ADDR,
 					   UC_FOREGROUND_STATUS,
@@ -486,7 +486,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 
 	/* the device needs some time to restart with the new firmware before
 	 * it can be queried again */
-	fu_progress_sleep(progress, 20000);
+	fu_device_sleep_full(device, 20000, progress); /* ms */
 
 	/* success */
 	fu_progress_step_done(progress);

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -167,7 +167,7 @@ fu_wacom_aes_device_attach(FuDevice *device, FuProgress *progress, GError **erro
 	}
 
 	/* wait for device back to runtime mode */
-	g_usleep(500 * 1000);
+	fu_device_sleep(device, 500); /* ms */
 	fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	return TRUE;
 }
@@ -182,13 +182,13 @@ fu_wacom_aes_device_erase_all(FuWacomAesDevice *self, FuProgress *progress, GErr
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 2000 * 1000, /* this takes a long time */
+				 2000, /* this takes a long time */
 				 FU_WACOM_DEVICE_CMD_FLAG_POLL_ON_WAITING,
 				 error)) {
 		g_prefix_error(error, "failed to send eraseall command: ");
 		return FALSE;
 	}
-	fu_progress_sleep(progress, 2000);
+	fu_device_sleep_full(FU_DEVICE(self), 2000, progress);
 	return TRUE;
 }
 
@@ -234,7 +234,7 @@ fu_wacom_aes_device_write_block(FuWacomAesDevice *self,
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 1000,
+				 1, /* ms */
 				 FU_WACOM_DEVICE_CMD_FLAG_NONE,
 				 error)) {
 		g_prefix_error(error, "failed to write block %u: ", idx);

--- a/plugins/wacom-raw/fu-wacom-device.h
+++ b/plugins/wacom-raw/fu-wacom-device.h
@@ -35,7 +35,7 @@ gboolean
 fu_wacom_device_cmd(FuWacomDevice *self,
 		    FuWacomRawRequest *req,
 		    FuWacomRawResponse *rsp,
-		    gulong delay_us,
+		    guint delay_ms,
 		    FuWacomDeviceCmdFlags flags,
 		    GError **error);
 gboolean

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -71,7 +71,7 @@ fu_wacom_emr_device_w9013_erase_data(FuWacomEmrDevice *self, GError **error)
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 50,
+				 1, /* ms */
 				 FU_WACOM_DEVICE_CMD_FLAG_POLL_ON_WAITING,
 				 error)) {
 		g_prefix_error(error, "failed to erase datamem: ");
@@ -96,7 +96,7 @@ fu_wacom_emr_device_w9013_erase_code(FuWacomEmrDevice *self,
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 50,
+				 1, /* ms */
 				 FU_WACOM_DEVICE_CMD_FLAG_POLL_ON_WAITING,
 				 error)) {
 		g_prefix_error(error, "failed to erase codemem: ");
@@ -118,7 +118,7 @@ fu_wacom_device_w9021_erase_all(FuWacomEmrDevice *self, GError **error)
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 2000 * 1000, /* this takes a long time */
+				 2000, /* this takes a long time */
 				 FU_WACOM_DEVICE_CMD_FLAG_POLL_ON_WAITING,
 				 error)) {
 		g_prefix_error(error, "failed to send eraseall command: ");
@@ -201,7 +201,7 @@ fu_wacom_emr_device_write_block(FuWacomEmrDevice *self,
 	if (!fu_wacom_device_cmd(FU_WACOM_DEVICE(self),
 				 &req,
 				 &rsp,
-				 50,
+				 1,
 				 FU_WACOM_DEVICE_CMD_FLAG_NONE,
 				 error)) {
 		g_prefix_error(error, "failed to write at 0x%x: ", address);

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -694,7 +694,7 @@ fu_wac_device_add_modules_bluetooth(FuWacDevice *self, GError **error)
 			return FALSE;
 		if (fw_ver != 0)
 			break;
-		g_usleep(G_USEC_PER_SEC);
+		fu_device_sleep(FU_DEVICE(self), 1000); /* ms */
 	}
 
 	/* Success! But legacy bluetooth can't tell us which module the device needs.
@@ -880,7 +880,7 @@ fu_wac_device_close(FuDevice *device, GError **error)
 	 * we take the lock, then cancel the work item which needs to take the
 	 * lock too. This needs to be fixed in the kernel, but for the moment
 	 * this should let the kernel unstick itself. */
-	g_usleep(20 * 1000);
+	fu_device_sleep(device, 20); /* ms */
 
 	/* FuUsbDevice->close */
 	return FU_DEVICE_CLASS(fu_wac_device_parent_class)->close(device, error);

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -228,7 +228,7 @@ fu_wac_module_set_feature(FuWacModule *self,
 		if (!fu_wac_module_refresh(self, error))
 			return FALSE;
 		if (priv->status == FU_WAC_MODULE_STATUS_BUSY) {
-			g_usleep(10000); /* 10ms */
+			fu_device_sleep(FU_DEVICE(self), 10); /* ms */
 			continue;
 		}
 		if (priv->status == FU_WAC_MODULE_STATUS_OK)


### PR DESCRIPTION
This allows us to ignore all the delays when the device is emulated, with the idea being to do dozens of device emulations in the CI tests.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
