### PR TITLE
trivial: use github mirror for gcab

### DIFF
--- a/contrib/mingw64.cross
+++ b/contrib/mingw64.cross
@@ -1,2 +1,3 @@
 [binaries]
 windmc = '/usr/bin/x86_64-w64-mingw32-windmc'
+exe_wrapper = 'wine'

--- a/meson.build
+++ b/meson.build
@@ -574,7 +574,7 @@ if polkit.found()
 endif
 if build_standalone
   plugin_quirks = []
-  gcab = find_program('gcab', required: get_option('tests'))
+  gcab = find_program('gcab', native: true, required: get_option('tests'))
   subdir('data')
   subdir('po')
   subdir('libfwupdplugin')

--- a/meson.build
+++ b/meson.build
@@ -574,7 +574,7 @@ if polkit.found()
 endif
 if build_standalone
   plugin_quirks = []
-  gcab = find_program('gcab', native: true, required: get_option('tests'))
+  gcab = find_program('/usr/bin/gcab', 'gcab', native: true, required: get_option('tests'))
   subdir('data')
   subdir('po')
   subdir('libfwupdplugin')

--- a/subprojects/gcab.wrap
+++ b/subprojects/gcab.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = gcab
-url = https://gitlab.gnome.org/GNOME/gcab.git
-revision = b55268ac1020cd6c033acb52f2e6ae984bf5c9fd
+url = https://github.com/gnome/gcab
+revision = v1.5
 
 # disabled until we depend on a meson including https://github.com/mesonbuild/meson/pull/10291
 # and https://gitlab.gnome.org/GNOME/gcab/-/merge_requests/10 is merged

--- a/subprojects/gcab.wrap
+++ b/subprojects/gcab.wrap
@@ -3,7 +3,5 @@ directory = gcab
 url = https://github.com/gnome/gcab
 revision = v1.5
 
-# disabled until we depend on a meson including https://github.com/mesonbuild/meson/pull/10291
-# and https://gitlab.gnome.org/GNOME/gcab/-/merge_requests/10 is merged
-# [provide]
-# program_names = gcab
+[provide]
+program_names = gcab


### PR DESCRIPTION
[GNOME git](https://gitlab.gnome.org/GNOME/gcab.git) seems to be down a few days. As this breaks Windows CI for us and we run fwupd on Github let's use the Github mirror instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
