### PR TITLE
trivial: Fix clang-format of JSON files for newer versions of clang

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,6 +36,9 @@ PenaltyBreakBeforeFirstCallParameter: '15'
 ---
 Language: 'Proto'
 ---
+Language: 'Json'
+BasedOnStyle: llvm
+---
 Language: 'Cpp'
 IncludeCategories:
   - Regex:           '^"config.h"$'


### PR DESCRIPTION
This explains why Mario and I had different precommit settings.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
