### PR TITLE
Use the correct range check when parsing SMBIOS

### DIFF
--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -325,7 +325,7 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 	dmi_fn = g_build_filename(path, "DMI", NULL);
 	if (!g_file_get_contents(dmi_fn, &dmi_raw, &sz, error))
 		return FALSE;
-	if (sz != self->structure_table_len) {
+	if (sz > self->structure_table_len) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,


### PR DESCRIPTION
The SMBIOS specification says:

    Maximum size of SMBIOS Structure Table, pointed to by the
    Structure Table Address, in bytes. The actual size is guaranteed
    to be less or equal to the maximum size.

So, the firmware is actually allowed to return a DMI blob smaller than the specified size.

Fixes https://github.com/fwupd/fwupd/issues/5486

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
