### PR TITLE
analogix: Do not check the endpoints before selecting an interface

### DIFF
--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -208,11 +208,6 @@ fu_analogix_device_find_interface(FuUsbDevice *device, GError **error)
 		if (g_usb_interface_get_class(intf) == BILLBOARD_CLASS &&
 		    g_usb_interface_get_subclass(intf) == BILLBOARD_SUBCLASS &&
 		    g_usb_interface_get_protocol(intf) == BILLBOARD_PROTOCOL) {
-			g_autoptr(GPtrArray) endpoints = NULL;
-
-			endpoints = g_usb_interface_get_endpoints(intf);
-			if (endpoints == NULL)
-				continue;
 			fu_usb_device_add_interface(FU_USB_DEVICE(self),
 						    g_usb_interface_get_number(intf));
 			return TRUE;


### PR DESCRIPTION
My Analogix USB device has a Billboard interface, with bNumEndpoints=0.

When emulating the interface is NULL, and in runtime the array can *never* be NULL, so I think this check was added in error.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
