### PR TITLE
Print errors as JSON objects when using --json

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5526,7 +5526,6 @@ fu_engine_get_releases_for_device(FuEngine *self,
 {
 	GPtrArray *device_guids;
 	const gchar *version;
-	g_autoptr(GError) error_all = NULL;
 	g_autoptr(GPtrArray) branches = NULL;
 	g_autoptr(GPtrArray) releases = NULL;
 
@@ -5581,11 +5580,7 @@ fu_engine_get_releases_for_device(FuEngine *self,
 
 		/* nothing found */
 		if (components == NULL) {
-			if (error_all == NULL) {
-				error_all = g_steal_pointer(&error_local);
-				continue;
-			}
-			g_prefix_error(&error_all, "%s, ", error_local->message);
+			g_debug("%s", error_local->message);
 			continue;
 		}
 
@@ -5599,13 +5594,8 @@ fu_engine_get_releases_for_device(FuEngine *self,
 									 component,
 									 releases,
 									 &error_tmp)) {
-				if (error_all == NULL) {
-					error_all = g_steal_pointer(&error_tmp);
-					continue;
-				}
-
-				/* assume the domain and code is the same */
-				g_prefix_error(&error_all, "%s, ", error_tmp->message);
+				g_debug("%s", error_tmp->message);
+				continue;
 			}
 		}
 	}
@@ -5629,14 +5619,6 @@ fu_engine_get_releases_for_device(FuEngine *self,
 
 	/* return the compound error */
 	if (releases->len == 0) {
-		if (error_all != NULL) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOTHING_TO_DO,
-				    "No releases found: %s",
-				    error_all->message);
-			return NULL;
-		}
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO, "No releases found");
 		return NULL;
 	}

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3455,6 +3455,16 @@ fu_util_backends_save(FuUtilPrivate *priv, const gchar *fn, GError **error)
 	return g_file_set_contents(fn, data, -1, error);
 }
 
+static void
+fu_util_print_error(FuUtilPrivate *priv, const GError *error)
+{
+	if (priv->as_json) {
+		fu_util_print_error_as_json(error);
+		return;
+	}
+	g_printerr("%s\n", error->message);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -4054,10 +4064,9 @@ main(int argc, char *argv[])
 						&priv->filter_include,
 						&priv->filter_exclude,
 						&error)) {
-			g_print("%s: %s\n",
-				/* TRANSLATORS: the user didn't read the man page */
-				_("Failed to parse flags for --filter"),
-				error->message);
+			/* TRANSLATORS: the user didn't read the man page */
+			g_prefix_error(&error, "%s: ", _("Failed to parse flags for --filter"));
+			fu_util_print_error(priv, error);
 			return EXIT_FAILURE;
 		}
 	}
@@ -4104,7 +4113,7 @@ main(int argc, char *argv[])
 	/* just show versions and exit */
 	if (version) {
 		if (!fu_util_version(priv, &error)) {
-			g_printerr("%s\n", error->message);
+			fu_util_print_error(priv, error);
 			return EXIT_FAILURE;
 		}
 		return EXIT_SUCCESS;
@@ -4124,7 +4133,7 @@ main(int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 #endif
-		g_printerr("%s\n", error->message);
+		fu_util_print_error(priv, error);
 		if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_ARGS)) {
 			/* TRANSLATORS: error message explaining command on how to get help */
 			g_printerr("\n%s\n", _("Use fwupdtool --help for help"));

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -3031,6 +3031,24 @@ fu_util_print_builder(JsonBuilder *builder, GError **error)
 	return TRUE;
 }
 
+void
+fu_util_print_error_as_json(const GError *error)
+{
+	g_autoptr(JsonBuilder) builder = json_builder_new();
+	json_builder_begin_object(builder);
+	json_builder_set_member_name(builder, "Error");
+	json_builder_begin_object(builder);
+	json_builder_set_member_name(builder, "Domain");
+	json_builder_add_string_value(builder, g_quark_to_string(error->domain));
+	json_builder_set_member_name(builder, "Code");
+	json_builder_add_int_value(builder, error->code);
+	json_builder_set_member_name(builder, "Message");
+	json_builder_add_string_value(builder, error->message);
+	json_builder_end_object(builder);
+	json_builder_end_object(builder);
+	fu_util_print_builder(builder, NULL);
+}
+
 typedef enum {
 	FU_UTIL_DEPENDENCY_KIND_UNKNOWN,
 	FU_UTIL_DEPENDENCY_KIND_RUNTIME,

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -157,6 +157,8 @@ gboolean
 fu_util_setup_interactive_console(GError **error);
 gboolean
 fu_util_print_builder(JsonBuilder *builder, GError **error);
+void
+fu_util_print_error_as_json(const GError *error);
 gchar *
 fu_util_project_versions_to_string(GHashTable *metadata);
 gboolean


### PR DESCRIPTION
For example:

	$ fwupdmgr local-install --json foo.zip
	{
	  "Error" : {
	    "Domain" : "FwupdError",
	    "Code" : 7,
	    "Message" : "failed to open foo.zip"
	  }
	}

Fixes https://github.com/fwupd/fwupd/issues/5499

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
