### PR TITLE
snap: read the host os-release instead of base snap

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -80,6 +80,7 @@ for details.
 * `FWUPD_DATADIR_QUIRKS`
 * `FWUPD_EFIAPPDIR`
 * `FWUPD_FIRMWARESEARCH`
+* `FWUPD_HOSTDIR` looks for host OS `os-release` in this sysroot, default is /
 * `FWUPD_LIBDIR_PKG`
 * `FWUPD_LOCALSTATEDIR`
 * `FWUPD_LOCALSTATEDIR_QUIRKS`

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -144,23 +144,27 @@ static gchar *
 fwupd_get_os_release_filename(void)
 {
 #ifndef _WIN32
+	const gchar *hostdir = g_getenv("FWUPD_HOSTDIR");
 	const gchar *sysconfdir = g_getenv("FWUPD_SYSCONFDIR");
 	g_autofree gchar *fn1 = NULL;
 
+	if (hostdir == NULL)
+		hostdir = "/";
+
 	/* override */
 	if (sysconfdir != NULL) {
-		g_autofree gchar *fn2 = g_build_filename(sysconfdir, "os-release", NULL);
+		g_autofree gchar *fn2 = g_build_filename(hostdir, sysconfdir, "os-release", NULL);
 		if (g_file_test(fn2, G_FILE_TEST_EXISTS))
 			return g_steal_pointer(&fn2);
 	}
 
 	/* host locations */
 	if (g_strcmp0(sysconfdir, "/etc") != 0) {
-		g_autofree gchar *fn2 = g_strdup("/etc/os-release");
+		g_autofree gchar *fn2 = g_build_filename(hostdir, "/etc/os-release", NULL);
 		if (g_file_test(fn2, G_FILE_TEST_EXISTS))
 			return g_steal_pointer(&fn2);
 	}
-	fn1 = g_strdup("/usr/lib/os-release");
+	fn1 = g_build_filename(hostdir, "/usr/lib/os-release", NULL);
 	if (g_file_test(fn1, G_FILE_TEST_EXISTS))
 		return g_steal_pointer(&fn1);
 #endif

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,6 +40,8 @@ apps:
     slots: [fwupd]
     completer:
       share/bash-completion/completions/fwupdtool
+    environment:
+      FWUPD_HOSTDIR: /var/lib/snapd/hostfs
   fwupd:
     command: fwupd.wrapper
     daemon: dbus
@@ -48,6 +50,8 @@ apps:
     daemon-scope: system
     activates-on:
       - fwupd-dbus
+    environment:
+      FWUPD_HOSTDIR: /var/lib/snapd/hostfs
   fwupdmgr:
     command: fwupdmgr.wrapper
     plugs: [fwupdmgr, network, polkit]


### PR DESCRIPTION
This should fix #5485. Depends on https://github.com/snapcore/snapd/pull/12545

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
