### PR TITLE
Ensure composite devices all share the same acquiesce delay

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1378,6 +1378,12 @@ fu_device_add_child(FuDevice *self, FuDevice *child)
 		}
 	}
 
+	/* ensure child has the parent acquiesce delay */
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *child_tmp = g_ptr_array_index(children, i);
+		fu_device_set_acquiesce_delay(child_tmp, priv->acquiesce_delay);
+	}
+
 	/* copy from main device if unset */
 	if (fu_device_get_physical_id(child) == NULL && fu_device_get_physical_id(self) != NULL)
 		fu_device_set_physical_id(child, fu_device_get_physical_id(self));


### PR DESCRIPTION
We go to great pains to set the parent to the MAX of the child delays, but we don't actually set the children to have the new parent value.

This means if you update the child device without the parent in the transaction we don't always wait for all the USB devices to come back -- which is what the acquiesce delay is designed to do.

Fixes an intermittant device test for the Wacom USB tablet.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
