### PR TITLE
snap: allow fwupdmgr to shutdown

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ apps:
       FWUPD_HOSTDIR: /var/lib/snapd/hostfs
   fwupdmgr:
     command: fwupdmgr.wrapper
-    plugs: [fwupdmgr, network, polkit]
+    plugs: [fwupdmgr, network, polkit, shutdown]
     completer:
       share/bash-completion/completions/fwupdmgr
   fwupdagent:


### PR DESCRIPTION
When installing a capsule, optional reboot is done by fwupdmgr instead of fwupd. This means fwupdmgr needs the permission to do that.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
