### PR TITLE
ccgx: Auto-set the remove-delay now we parse the devx components

### DIFF
--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -148,6 +148,5 @@ Plugin = ccgx
 GType = FuCcgxDmcDevice
 CcgxDmcTriggerCode = 0x01
 CcgxImageKind = dmc-composite
-RemoveDelay = 732000
 [USB\VID_2188&PID_0035&CID_05&VER_3.3.1.69]
 CcgxDmcCompositeVersion = 15

--- a/plugins/ccgx/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-devx-device.c
@@ -206,6 +206,24 @@ fu_ccgx_dmc_devx_device_type_to_name(DmcDevxDeviceType device_type)
 	return "Unknown";
 }
 
+guint
+fu_ccgx_dmc_devx_device_get_remove_delay(FuCcgxDmcDevxDevice *self)
+{
+	guint remove_delay = 0;
+
+	g_return_val_if_fail(FU_IS_CCGX_DMC_DEVX_DEVICE(self), G_MAXUINT);
+
+	switch (self->status.device_type) {
+	case DMC_DEVX_DEVICE_TYPE_DMC:
+		remove_delay = 40 * 1000;
+		break;
+	default:
+		remove_delay = 30 * 1000;
+		break;
+	}
+	return remove_delay;
+}
+
 static gboolean
 fu_ccgx_dmc_devx_device_probe(FuDevice *device, GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-dmc-devx-device.h
+++ b/plugins/ccgx/fu-ccgx-dmc-devx-device.h
@@ -20,3 +20,5 @@ G_DECLARE_FINAL_TYPE(FuCcgxDmcDevxDevice,
 
 FuCcgxDmcDevxDevice *
 fu_ccgx_dmc_devx_device_new(FuDevice *proxy, DmcDevxStatus *status);
+guint
+fu_ccgx_dmc_devx_device_get_remove_delay(FuCcgxDmcDevxDevice *self);


### PR DESCRIPTION
This is one less thing for vendors to work out.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
