### PR TITLE
ccgx: Make the default image type for FuCcgxDmcDevice to be DMC_COMPOSITE

### DIFF
--- a/plugins/ccgx/ccgx-noinst.quirk
+++ b/plugins/ccgx/ccgx-noinst.quirk
@@ -3,7 +3,6 @@
 Plugin = ccgx
 GType = FuCcgxDmcDevice
 CcgxDmcTriggerCode = 1
-CcgxImageKind = dmc-composite
 RemoveDelay = 732000
 
 # Any EVB board that uses CYUSB4357
@@ -11,5 +10,4 @@ RemoveDelay = 732000
 Plugin = ccgx
 GType = FuCcgxDmcDevice
 CcgxDmcTriggerCode = 1
-CcgxImageKind = dmc-composite
 RemoveDelay = 732000

--- a/plugins/ccgx/ccgx.quirk
+++ b/plugins/ccgx/ccgx.quirk
@@ -60,7 +60,6 @@ ParentGuid = USB\VID_17EF&PID_30AF
 Name = ThinkPad Universal USB-C Dock
 Flags = has-manual-replug
 CcgxDmcTriggerCode = 0x02
-CcgxImageKind = dmc-composite
 InstallDuration = 60
 
 [USB\VID_17EF&PID_3105]
@@ -71,7 +70,6 @@ ParentGuid = USB\VID_17EF&PID_30AF
 Name = ThinkPad Universal USB-C Dock
 Flags = has-manual-replug
 CcgxDmcTriggerCode = 0x02
-CcgxImageKind = dmc-composite
 InstallDuration = 60
 
 # HP USB-C Dock G5
@@ -83,7 +81,6 @@ ParentGuid = USB\VID_03F0&PID_0363
 Vendor = HP
 Name = USB-C Dock G5
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 InstallDuration = 233
 RemoveDelay = 203000
 
@@ -96,7 +93,6 @@ ParentGuid = USB\VID_03F0&PID_096B
 Vendor = HP
 Name = USB-C/A Universal Dock G2
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 InstallDuration = 180
 RemoveDelay = 162000
 
@@ -120,7 +116,6 @@ ParentGuid = USB\VID_03F0&PID_2488
 Vendor = HP
 Name = Thunderbolt Dock G4
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 InstallDuration = 898
 RemoveDelay = 732000
 
@@ -130,7 +125,6 @@ Plugin = ccgx
 GType = FuCcgxDmcDevice
 Summary = Dock Management Controller Device
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 RemoveDelay = 732000
 
 # Anker Thunderbolt4 Mini Dock
@@ -139,7 +133,6 @@ Plugin = ccgx
 GType = FuCcgxDmcDevice
 Summary = Dock Management Controller Device
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 RemoveDelay = 732000
 
 # Caldigit ElementHub
@@ -147,6 +140,5 @@ RemoveDelay = 732000
 Plugin = ccgx
 GType = FuCcgxDmcDevice
 CcgxDmcTriggerCode = 0x01
-CcgxImageKind = dmc-composite
 [USB\VID_2188&PID_0035&CID_05&VER_3.3.1.69]
 CcgxDmcCompositeVersion = 15

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -768,6 +768,7 @@ fu_ccgx_dmc_device_init(FuCcgxDmcDevice *self)
 {
 	self->ep_intr_in = DMC_INTERRUPT_PIPE_ID;
 	self->ep_bulk_out = DMC_BULK_PIPE_ID;
+	self->fw_image_type = FW_IMAGE_TYPE_DMC_COMPOSITE;
 	fu_device_add_protocol(FU_DEVICE(self), "com.cypress.ccgx.dmc");
 	fu_device_add_protocol(FU_DEVICE(self), "com.infineon.ccgx.dmc");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);


### PR DESCRIPTION
This means most devices do not need to specify additional quirks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
