### PR TITLE
trivial: logitech-hidpp: move the check for CONFIG_HIDRAW into probe

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -683,6 +683,15 @@ fu_logitech_hidpp_device_probe(FuDevice *device, GError **error)
 	FuLogitechHidPpDevice *self = FU_HIDPP_DEVICE(device);
 	FuLogitechHidPpDevicePrivate *priv = GET_PRIVATE(self);
 
+	/* check the kernel has CONFIG_HIDRAW */
+	if (!g_file_test("/sys/class/hidraw", G_FILE_TEST_IS_DIR)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no kernel support for CONFIG_HIDRAW");
+		return FALSE;
+	}
+
 	/* set the physical ID */
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "hid", error))
 		return FALSE;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -20,20 +20,6 @@ struct _FuLogitechHidppPlugin {
 
 G_DEFINE_TYPE(FuLogitechHidppPlugin, fu_logitech_hidpp_plugin, FU_TYPE_PLUGIN)
 
-static gboolean
-fu_logitech_hidpp_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
-{
-	/* check the kernel has CONFIG_HIDRAW */
-	if (!g_file_test("/sys/class/hidraw", G_FILE_TEST_IS_DIR)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "no kernel support for CONFIG_HIDRAW");
-		return FALSE;
-	}
-	return TRUE;
-}
-
 static void
 fu_logitech_hidpp_plugin_init(FuLogitechHidppPlugin *self)
 {
@@ -57,8 +43,6 @@ fu_logitech_hidpp_plugin_constructed(GObject *obj)
 static void
 fu_logitech_hidpp_plugin_class_init(FuLogitechHidppPluginClass *klass)
 {
-	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->constructed = fu_logitech_hidpp_plugin_constructed;
-	plugin_class->startup = fu_logitech_hidpp_plugin_startup;
 }


### PR DESCRIPTION
The kernel should have loaded hidraw support by the time that we probe
a device.  This fixes logitech devices not showing up after startup
if they weren't plugged in initially.

Fixes: #5525

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
