### PR TITLE
Use a predefined message when emulating

### DIFF
--- a/libfwupd/fwupd-request.h
+++ b/libfwupd/fwupd-request.h
@@ -93,6 +93,16 @@ typedef enum {
 #define FWUPD_REQUEST_ID_DO_NOT_POWER_OFF "org.freedesktop.fwupd.request.do-not-power-off"
 
 /**
+ * FWUPD_REQUEST_ID_REPLUG_INSTALL:
+ *
+ * Show the user a message to replug the device and then install the firmware, e.g.
+ * "Unplug and replug the device, then install the firmware."
+ *
+ * Since 1.8.11
+ */
+#define FWUPD_REQUEST_ID_REPLUG_INSTALL "org.freedesktop.fwupd.replug-install"
+
+/**
  * FWUPD_REQUEST_FLAG_NONE:
  *
  * No flags are set.

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1114,6 +1114,19 @@ fu_engine_remove_device_flag(FuEngine *self,
 	return FALSE;
 }
 
+static void
+fu_engine_emit_device_request_replug_and_install(FuEngine *self, FuDevice *device)
+{
+	g_autoptr(FwupdRequest) request = fwupd_request_new();
+	fwupd_request_set_id(request, FWUPD_REQUEST_ID_REPLUG_INSTALL);
+	fwupd_request_set_device_id(request, fu_device_get_id(device));
+	fwupd_request_set_kind(request, FWUPD_REQUEST_KIND_IMMEDIATE);
+	fwupd_request_add_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
+	fwupd_request_set_message(request,
+				  "Unplug and replug the device, then install the firmware.");
+	g_signal_emit(self, signals[SIGNAL_DEVICE_REQUEST], 0, request);
+}
+
 static gboolean
 fu_engine_add_device_flag(FuEngine *self,
 			  const gchar *device_id,
@@ -1147,6 +1160,7 @@ fu_engine_add_device_flag(FuEngine *self,
 		g_hash_table_insert(self->emulation_backend_ids,
 				    g_strdup(fu_device_get_backend_id(device)),
 				    GUINT_TO_POINTER(1));
+		fu_engine_emit_device_request_replug_and_install(self, device);
 		return TRUE;
 	}
 	g_set_error_literal(error,

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2300,6 +2300,10 @@ fu_util_request_get_message(FwupdRequest *req)
 			return _("Do not turn off your computer or remove the AC adaptor "
 				 "while the update is in progress.");
 		}
+		if (g_strcmp0(fwupd_request_get_id(req), FWUPD_REQUEST_ID_REPLUG_INSTALL) == 0) {
+			/* TRANSLATORS: message shown after device has been marked for emulation */
+			return _("Unplug and replug the device, then install the firmware.");
+		}
 	}
 	return fwupd_request_get_message(req);
 }

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -95,10 +95,6 @@ fu_util_client_notify_cb(GObject *object, GParamSpec *pspec, FuUtilPrivate *priv
 static void
 fu_util_update_device_request_cb(FwupdClient *client, FwupdRequest *request, FuUtilPrivate *priv)
 {
-	/* action has not been assigned yet */
-	if (priv->current_operation == FU_UTIL_OPERATION_UNKNOWN)
-		return;
-
 	/* nothing sensible to show */
 	if (fwupd_request_get_message(request) == NULL)
 		return;
@@ -4077,25 +4073,17 @@ static gboolean
 fu_util_emulation_tag(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FwupdDevice) dev = NULL;
-	g_autofree gchar *cmd = g_strdup_printf("%s emulation-save", g_get_prgname());
 
 	/* set the flag */
 	dev = fu_util_get_device_or_prompt(priv, values, error);
 	if (dev == NULL)
 		return FALSE;
-	if (!fwupd_client_modify_device(priv->client,
-					fwupd_device_get_id(dev),
-					"Flags",
-					"emulation-tag",
-					priv->cancellable,
-					error))
-		return FALSE;
-
-	/* TRANSLATORS: these are instructions on how to generate the data, and the %1 is a command
-	 * like 'fwupdmgr emulation-save' */
-	g_print(_("Now unplug and replug the device, install the firmware, and then run %s"), cmd);
-	g_print("\n");
-	return TRUE;
+	return fwupd_client_modify_device(priv->client,
+					  fwupd_device_get_id(dev),
+					  "Flags",
+					  "emulation-tag",
+					  priv->cancellable,
+					  error);
 }
 
 static gboolean


### PR DESCRIPTION
This allow us to guide the user through emulation in gnome-firmware.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
