### PR TITLE
Fetch vbios version from sysfs

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -87,6 +87,23 @@ fu_udev_device_emit_changed(FuUdevDevice *self)
 }
 
 #ifdef HAVE_GUDEV
+static guint32
+fu_udev_device_get_sysfs_attr_as_uint32(GUdevDevice *udev_device, const gchar *name)
+{
+	const gchar *tmp;
+	guint64 tmp64 = 0;
+	g_autoptr(GError) error_local = NULL;
+
+	tmp = g_udev_device_get_sysfs_attr(udev_device, name);
+	if (tmp == NULL)
+		return 0x0;
+	if (!fu_strtoull(tmp, &tmp64, 0, G_MAXUINT32 - 1, &error_local)) {
+		g_warning("reading %s for %s was invalid: %s", name, tmp, error_local->message);
+		return 0x0;
+	}
+	return tmp64;
+}
+
 static guint16
 fu_udev_device_get_sysfs_attr_as_uint16(GUdevDevice *udev_device, const gchar *name)
 {

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -36,6 +36,7 @@
 
 typedef struct {
 	GUdevDevice *udev_device;
+	guint32 class;
 	guint16 vendor;
 	guint16 model;
 	guint16 subsystem_vendor;
@@ -178,6 +179,8 @@ fu_udev_device_to_string(FuDevice *device, guint idt, GString *str)
 		fu_string_append_kx(str, idt, "SubsystemVendor", priv->subsystem_vendor);
 		fu_string_append_kx(str, idt, "SubsystemModel", priv->subsystem_model);
 	}
+	if (priv->class != 0x0)
+		fu_string_append_kx(str, idt, "Class", priv->class);
 	if (priv->revision != 0x0)
 		fu_string_append_kx(str, idt, "Revision", priv->revision);
 	if (priv->subsystem != NULL)
@@ -373,6 +376,7 @@ fu_udev_device_set_vendor_from_udev_device(FuUdevDevice *self, GUdevDevice *udev
 	priv->vendor = fu_udev_device_get_sysfs_attr_as_uint16(udev_device, "vendor");
 	priv->model = fu_udev_device_get_sysfs_attr_as_uint16(udev_device, "device");
 	priv->revision = fu_udev_device_get_sysfs_attr_as_uint8(udev_device, "revision");
+	priv->class = fu_udev_device_get_sysfs_attr_as_uint32(udev_device, "class");
 	priv->subsystem_vendor =
 	    fu_udev_device_get_sysfs_attr_as_uint16(udev_device, "subsystem_vendor");
 	priv->subsystem_model =

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -55,6 +55,56 @@ typedef enum {
 	FU_UDEV_DEVICE_FLAG_LAST
 } FuUdevDeviceFlags;
 
+/**
+ * FuPciBaseCls:
+ * @FU_PCI_BASE_CLS_OLD: Device from before classes were defined
+ * @FU_PCI_BASE_CLS_MASS_STORAGE: Mass Storage Controller
+ * @FU_PCI_BASE_CLS_NETWORK: Network controller
+ * @FU_PCI_BASE_CLS_DISPLAY: Display controller
+ * @FU_PCI_BASE_CLS_MULTIMEDIA: Multimedia controller
+ * @FU_PCI_BASE_CLS_MEMORY: Memory controller
+ * @FU_PCI_BASE_CLS_BRIDGE: Bridge
+ * @FU_PCI_BASE_CLS_SIMPLE_COMMUNICATION: Simple communications controller
+ * @FU_PCI_BASE_CLS_BASE: Base system peripheral
+ * @FU_PCI_BASE_CLS_INPUT: Input device
+ * @FU_PCI_BASE_CLS_DOCKING: Docking station
+ * @FU_PCI_BASE_CLS_PROCESSORS: Processor
+ * @FU_PCI_BASE_CLS_SERIAL_BUS: Serial bus controller
+ * @FU_PCI_BASE_CLS_WIRELESS: Wireless controller
+ * @FU_PCI_BASE_CLS_INTELLIGENT_IO: Intelligent IO controller
+ * @FU_PCI_BASE_CLS_SATELLITE: Satellite controller
+ * @FU_PCI_BASE_CLS_ENCRYPTION: Encryption/Decryption controller
+ * @FU_PCI_BASE_CLS_SIGNAL_PROCESSING: Data acquisition and signal processing controller
+ * @FU_PCI_BASE_CLS_ACCELERATOR: Processing accelerator
+ * @FU_PCI_BASE_CLS_NON_ESSENTIAL: Non-essential instrumentation
+ * @FU_PCI_BASE_CLS_UNDEFINED: Device doesn't fit any defined class
+ *
+ * PCI base class types returned by fu_udev_device_get_cls().
+ **/
+typedef enum {
+	FU_PCI_BASE_CLS_OLD,
+	FU_PCI_BASE_CLS_MASS_STORAGE,
+	FU_PCI_BASE_CLS_NETWORK,
+	FU_PCI_BASE_CLS_DISPLAY,
+	FU_PCI_BASE_CLS_MULTIMEDIA,
+	FU_PCI_BASE_CLS_MEMORY,
+	FU_PCI_BASE_CLS_BRIDGE,
+	FU_PCI_BASE_CLS_SIMPLE_COMMUNICATION,
+	FU_PCI_BASE_CLS_BASE,
+	FU_PCI_BASE_CLS_INPUT,
+	FU_PCI_BASE_CLS_DOCKING,
+	FU_PCI_BASE_CLS_PROCESSORS,
+	FU_PCI_BASE_CLS_SERIAL_BUS,
+	FU_PCI_BASE_CLS_WIRELESS,
+	FU_PCI_BASE_CLS_INTELLIGENT_IO,
+	FU_PCI_BASE_CLS_SATELLITE,
+	FU_PCI_BASE_CLS_ENCRYPTION,
+	FU_PCI_BASE_CLS_SIGNAL_PROCESSING,
+	FU_PCI_BASE_CLS_ACCELERATOR,
+	FU_PCI_BASE_CLS_NON_ESSENTIAL,
+	FU_PCI_BASE_CLS_UNDEFINED = 0xff
+} FuPciBaseCls;
+
 FuUdevDevice *
 fu_udev_device_new(FuContext *ctx, GUdevDevice *udev_device);
 GUdevDevice *
@@ -75,6 +125,10 @@ void
 fu_udev_device_set_bind_id(FuUdevDevice *self, const gchar *bind_id);
 const gchar *
 fu_udev_device_get_driver(FuUdevDevice *self);
+gboolean
+fu_udev_device_is_pci_base_cls(FuUdevDevice *self, FuPciBaseCls cls);
+guint32
+fu_udev_device_get_cls(FuUdevDevice *self);
 guint16
 fu_udev_device_get_vendor(FuUdevDevice *self);
 guint16

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1168,5 +1168,7 @@ LIBFWUPDPLUGIN_1.8.11 {
     fu_device_sleep;
     fu_device_sleep_full;
     fu_strdup;
+    fu_udev_device_get_cls;
+    fu_udev_device_is_pci_base_cls;
   local: *;
 } LIBFWUPDPLUGIN_1.8.10;

--- a/plugins/amd-gpu/README.md
+++ b/plugins/amd-gpu/README.md
@@ -1,0 +1,11 @@
+---
+title: Plugin: AMDGPU
+---
+
+## Introduction
+
+This plugin reports the vbios version of APU devices supported by amdgpu.
+
+## External Interface Access
+
+This plugin requires read only access to attributes located within `/sys/bus/pci/drivers/*/amdgpu`.

--- a/plugins/amd-gpu/amd-gpu.quirk
+++ b/plugins/amd-gpu/amd-gpu.quirk
@@ -1,2 +1,2 @@
 [PCI\DRIVER_amdgpu]
-Plugin = amdgpu
+Plugin = amd_gpu

--- a/plugins/amd-gpu/amd-gpu.quirk
+++ b/plugins/amd-gpu/amd-gpu.quirk
@@ -1,0 +1,2 @@
+[PCI\DRIVER_amdgpu]
+Plugin = amdgpu

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Advanced Micro Devices Inc.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-amd-gpu-device.h"
+struct _FuAmdGpuDevice {
+	FuUdevDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuAmdGpuDevice, fu_amd_gpu_device, FU_TYPE_UDEV_DEVICE)
+
+static gboolean
+fu_amd_gpu_device_probe(FuDevice *device, GError **error)
+{
+	const gchar *base;
+	g_autofree gchar *rom = NULL;
+
+	/* heuristic to detect !APU since we don't have sysfs file to indicate IS_APU */
+	base = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
+	rom = g_build_filename(base, "rom", NULL);
+	if (g_file_test(rom, G_FILE_TEST_EXISTS)) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "only for APU");
+		return FALSE;
+	}
+	fu_device_add_parent_guid(device, "cpu");
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error);
+}
+
+static void
+fu_amd_gpu_device_init(FuAmdGpuDevice *self)
+{
+	fu_device_set_name(FU_DEVICE(self), "Graphics Processing Unit (GPU)");
+}
+
+static void
+fu_amd_gpu_device_class_init(FuAmdGpuDeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	klass_device->probe = fu_amd_gpu_device_probe;
+}

--- a/plugins/amd-gpu/fu-amd-gpu-device.h
+++ b/plugins/amd-gpu/fu-amd-gpu-device.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2023 Advanced Micro Devices Inc.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_AMDGPU_DEVICE (fu_amd_gpu_device_get_type())
+G_DECLARE_FINAL_TYPE(FuAmdGpuDevice, fu_amd_gpu_device, FU, AMDGPU_DEVICE, FuUdevDevice)

--- a/plugins/amd-gpu/fu-amd-gpu-plugin.c
+++ b/plugins/amd-gpu/fu-amd-gpu-plugin.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Advanced Micro Devices Inc.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-amd-gpu-device.h"
+#include "fu-amd-gpu-plugin.h"
+
+struct _FuAmdGpuPlugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuAmdGpuPlugin, fu_amd_gpu_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_amd_gpu_plugin_init(FuAmdGpuPlugin *self)
+{
+}
+
+static void
+fu_amd_gpu_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "pci");
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMDGPU_DEVICE);
+}
+
+static void
+fu_amd_gpu_plugin_class_init(FuAmdGpuPluginClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->constructed = fu_amd_gpu_plugin_constructed;
+}

--- a/plugins/amd-gpu/fu-amd-gpu-plugin.h
+++ b/plugins/amd-gpu/fu-amd-gpu-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 Advanced Micro Devices Inc.
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuAmdGpuPlugin, fu_amd_gpu_plugin, FU, AMDGPU_PLUGIN, FuPlugin)

--- a/plugins/amd-gpu/meson.build
+++ b/plugins/amd-gpu/meson.build
@@ -1,0 +1,15 @@
+if gudev.found()
+cargs = ['-DG_LOG_DOMAIN="FuPluginAmdGpu"']
+
+plugin_quirks += files('amd-gpu.quirk')
+plugin_builtins += static_library('fu_plugin_amd_gpu',
+  sources: [
+    'fu-amd-gpu-plugin.c',
+    'fu-amd-gpu-device.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+endif

--- a/plugins/amd-pmc/fu-amd-pmc-device.c
+++ b/plugins/amd-pmc/fu-amd-pmc-device.c
@@ -59,7 +59,7 @@ fu_amd_pmc_device_init(FuAmdPmcDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon(FU_DEVICE(self), "computer");
 	fu_device_add_parent_guid(FU_DEVICE(self), "cpu");
-	fu_device_set_vendor(FU_DEVICE(self), "AMD");
+	fu_device_set_vendor(FU_DEVICE(self), "Advanced Micro Devices, Inc.");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_physical_id(FU_DEVICE(self), "amd-pmc");
 }

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -51,7 +51,7 @@ fu_cpu_device_convert_vendor(const gchar *vendor)
 	if (g_strcmp0(vendor, "GenuineIntel") == 0)
 		return "Intel";
 	if (g_strcmp0(vendor, "AuthenticAMD") == 0 || g_strcmp0(vendor, "AMDisbetter!") == 0)
-		return "AMD";
+		return "Advanced Micro Devices, Inc.";
 	if (g_strcmp0(vendor, "CentaurHauls") == 0)
 		return "IDT";
 	if (g_strcmp0(vendor, "CyrixInstead") == 0)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -19,6 +19,7 @@ plugins = [
   'acpi-ivrs',
   'acpi-phat',
   'amd-pmc',
+  'amd-gpu',
   'analogix',
   'android-boot',
   'ata',

--- a/plugins/pci-psp/fu-pci-psp-device.c
+++ b/plugins/pci-psp/fu-pci-psp-device.c
@@ -275,7 +275,7 @@ fu_pci_psp_device_init(FuPciPspDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon(FU_DEVICE(self), "computer");
 	fu_device_add_parent_guid(FU_DEVICE(self), "cpu");
-	fu_device_set_vendor(FU_DEVICE(self), "AMD");
+	fu_device_set_vendor(FU_DEVICE(self), "Advanced Micro Devices, Inc.");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_set_physical_id(FU_DEVICE(self), "pci-psp");
 }

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -103,7 +103,7 @@ static const gchar *
 fu_tpm_v2_device_convert_manufacturer(const gchar *manufacturer)
 {
 	if (g_strcmp0(manufacturer, "AMD") == 0)
-		return "AMD";
+		return "Advanced Micro Devices, Inc.";
 	if (g_strcmp0(manufacturer, "ATML") == 0)
 		return "Atmel";
 	if (g_strcmp0(manufacturer, "BRCM") == 0)


### PR DESCRIPTION
For dGPUs this adds the VBIOS version into the device created by the optionrom plugin.
For APUs this adds the VBIOS version into a device that hangs off the APU.

For example on APU:

```
└─Ryzen 5 PRO 6650U with Radeon Graphics:
  │   Device ID:          4bde70ba4e39b28f9eab1628f9dd6e6244c03027
  │   Vendor:             AMD
  │   GUIDs:              b9a2dd81-159e-5537-a7db-e7101d164d3f ← cpu
  │                       22f9ecf4-588d-5c0a-8326-6ebff3655c6d ← CPUID\PRO_0&FAM_19
  │                       52f8f9af-1ca9-5352-bef4-ceb232c888a5 ← CPUID\PRO_0&FAM_19&MOD_44
  │                       e94372a3-3ffb-5d1c-a579-c415b7313e52 ← CPUID\PRO_0&FAM_19&MOD_44&STP_1
  │   Device Flags:       • Internal device
  │
  ├─Graphics Processing Unit (GPU):
  │     Device ID:        2287ee908298807e95f89a9b7c1a435c1a634e33
  │     Current version:  113-REMBRANDT-X37
  │     Vendor:           Advanced Micro Devices, Inc. [AMD/ATI] (PCI:0x1002)
  │     GUIDs:            817e27b3-d1bb-591a-a1cc-e039d0a60be6 ← PCI\VEN_1002&DEV_1681
  │                       a57d78cd-3738-5c25-9bae-60208129eae4 ← PCI\VEN_1002&DEV_1681&REV_D2
  │                       9b7d6019-9008-55ab-8512-0e2851542b8a ← PCI\VEN_1002&DEV_1681&SUBSYS_17AA22F1
  │                       5c1de11d-7e81-5e75-b8f8-0c5102c64756 ← PCI\VEN_1002&DEV_1681&SUBSYS_17AA22F1&REV_D2
  │     Device Flags:     • Internal device
  │
  └─System Management Unit (SMU):
        Device ID:        db0330716216c629bb2c07256e5d018f499eb6ce
        Summary:          Microcontroller used within CPU/APU program 4
        Current version:  69.55.0
        Vendor:           AMD
        GUID:             79307ae6-a2ea-52e1-bf56-6abbaf3547ad ← /sys/devices/platform/AMDI0007:00
        Device Flags:     • Internal device
```

```
Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
