### PR TITLE
redfish: Only offset the IPMI user_id when using XCC

### DIFF
--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -16,6 +16,12 @@ G_DECLARE_FINAL_TYPE(FuRedfishBackend, fu_redfish_backend, FU, REDFISH_BACKEND, 
 
 FuRedfishBackend *
 fu_redfish_backend_new(FuContext *ctx);
+const gchar *
+fu_redfish_backend_get_vendor(FuRedfishBackend *self);
+const gchar *
+fu_redfish_backend_get_version(FuRedfishBackend *self);
+const gchar *
+fu_redfish_backend_get_uuid(FuRedfishBackend *self);
 void
 fu_redfish_backend_set_hostname(FuRedfishBackend *self, const gchar *hostname);
 void


### PR DESCRIPTION
Both iDRAC and SuperMicro do the sensible thing.

Fixes https://github.com/fwupd/fwupd/issues/5129

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
