### PR TITLE
Allow enabling low-level debugging of fwupdx64.efi from uefi_capsule.…

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -437,6 +437,7 @@ static void
 fu_uefi_capsule_plugin_load_config(FuPlugin *plugin, FuDevice *device)
 {
 	gboolean disable_shim;
+	gboolean enable_efi_debugging;
 	guint64 sz_reqd = 0;
 	g_autofree gchar *require_esp_free_space = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -454,6 +455,11 @@ fu_uefi_capsule_plugin_load_config(FuPlugin *plugin, FuDevice *device)
 	disable_shim = fu_plugin_get_config_value_boolean(plugin, "DisableShimForSecureBoot");
 	if (!disable_shim)
 		fu_device_add_private_flag(device, FU_UEFI_DEVICE_FLAG_USE_SHIM_FOR_SB);
+
+	/* enable the fwupd.efi debug log? */
+	enable_efi_debugging = fu_plugin_get_config_value_boolean(plugin, "EnableEfiDebugging");
+	if (enable_efi_debugging)
+		fu_device_add_private_flag(device, FU_UEFI_DEVICE_FLAG_ENABLE_EFI_DEBUGGING);
 }
 
 static gboolean

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -84,6 +84,12 @@ typedef enum {
  * Do not prepend a plausible missing capsule header.
  */
 #define FU_UEFI_DEVICE_FLAG_NO_CAPSULE_HEADER_FIXUP (1 << 7)
+/**
+ * FU_UEFI_DEVICE_FLAG_ENABLE_EFI_DEBUGGING:
+ *
+ * Enable debugging the EFI binary.
+ */
+#define FU_UEFI_DEVICE_FLAG_ENABLE_EFI_DEBUGGING (1 << 8)
 
 FuUefiDeviceKind
 fu_uefi_device_kind_from_string(const gchar *kind);
@@ -130,3 +136,5 @@ void
 fu_uefi_device_set_status(FuUefiDevice *self, FuUefiDeviceStatus status);
 void
 fu_uefi_device_set_require_esp_free_space(FuUefiDevice *self, gsize require_esp_free_space);
+gboolean
+fu_uefi_device_perhaps_enable_debugging(FuUefiDevice *self, GError **error);

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -155,11 +155,11 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 	if (g_getenv("FWUPD_UEFI_TEST") != NULL)
 		return TRUE;
 
-	/* delete the logs to save space; use fwupdate to debug the EFI binary */
-	if (fu_efivar_exists(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_VERBOSE")) {
-		if (!fu_efivar_delete(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_VERBOSE", error))
-			return FALSE;
-	}
+	/* enable debugging in the EFI binary */
+	if (!fu_uefi_device_perhaps_enable_debugging(self, error))
+		return FALSE;
+
+	/* delete the old log to save space */
 	if (fu_efivar_exists(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_DEBUG_LOG")) {
 		if (!fu_efivar_delete(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_DEBUG_LOG", error))
 			return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -89,11 +89,11 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 	if (!fu_bytes_set_contents(fn, fixed_fw, error))
 		return FALSE;
 
-	/* delete the logs to save space; use fwupdate to debug the EFI binary */
-	if (fu_efivar_exists(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_VERBOSE")) {
-		if (!fu_efivar_delete(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_VERBOSE", error))
-			return FALSE;
-	}
+	/* enable debugging in the EFI binary */
+	if (!fu_uefi_device_perhaps_enable_debugging(self, error))
+		return FALSE;
+
+	/* delete the old log to save space */
 	if (fu_efivar_exists(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_DEBUG_LOG")) {
 		if (!fu_efivar_delete(FU_EFIVAR_GUID_FWUPDATE, "FWUPDATE_DEBUG_LOG", error))
 			return FALSE;

--- a/plugins/uefi-capsule/uefi_capsule.conf
+++ b/plugins/uefi-capsule/uefi_capsule.conf
@@ -12,3 +12,12 @@
 
 # allow ignoring the CapsuleOnDisk support advertised by the firmware
 #DisableCapsuleUpdateOnDisk=true
+
+# enable the low-level debugging of fwupdx64.efi to the FWUPDATE_DEBUG_LOG EFI variable
+#
+# Note: enabling this option is going to fill up the NVRAM store much more quickly and
+# should only be enabled when debugging an issue with the EFI binary
+#
+# This value also has no affect when using Capsule-on-Disk as the EFI helper binary is
+# not being used
+#EnableEfiDebugging=false


### PR DESCRIPTION
…conf

Short-to-medium-term we want to stop installing fwupdate and this was the last useful part we never migrated.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
