### PR TITLE
Stop shipping compat_cli by default

### DIFF
--- a/contrib/ci/void.sh
+++ b/contrib/ci/void.sh
@@ -17,5 +17,6 @@ meson build \
  -Dconsolekit=disabled \
  -Dsystemd=disabled \
  -Doffline=disabled \
+ -Dcompat_cli=true \
  -Delogind=enabled
 ninja -C build test -v

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -348,15 +348,10 @@ done
 %endif
 %{_libexecdir}/fwupd/fwupdoffline
 %if 0%{?have_uefi}
-%{_bindir}/fwupdate
-%endif
-%{_bindir}/dfu-tool
-%if 0%{?have_uefi}
 %{_bindir}/dbxtool
 %endif
 %{_bindir}/fwupdmgr
 %{_bindir}/fwupdtool
-%{_bindir}/fwupdagent
 %dir %{_sysconfdir}/fwupd
 %dir %{_sysconfdir}/fwupd/bios-settings.d
 %{_sysconfdir}/fwupd/bios-settings.d/README.md
@@ -377,7 +372,6 @@ done
 %{_datadir}/dbus-1/system.d/org.freedesktop.fwupd.conf
 %{_datadir}/bash-completion/completions/fwupdmgr
 %{_datadir}/bash-completion/completions/fwupdtool
-%{_datadir}/bash-completion/completions/fwupdagent
 %{_datadir}/fish/vendor_completions.d/fwupdmgr.fish
 %{_datadir}/fwupd/metainfo/org.freedesktop.fwupd*.metainfo.xml
 %if 0%{?have_dell}
@@ -389,15 +383,10 @@ done
 %{_datadir}/polkit-1/rules.d/org.freedesktop.fwupd.rules
 %{_datadir}/dbus-1/system-services/org.freedesktop.fwupd.service
 %{_mandir}/man1/fwupdtool.1*
-%{_mandir}/man1/fwupdagent.1*
-%{_mandir}/man1/dfu-tool.1*
 %if 0%{?have_uefi}
 %{_mandir}/man1/dbxtool.*
 %endif
 %{_mandir}/man1/fwupdmgr.1*
-%if 0%{?have_uefi}
-%{_mandir}/man1/fwupdate.1*
-%endif
 %{_datadir}/metainfo/org.freedesktop.fwupd.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/org.freedesktop.fwupd.svg
 %{_datadir}/fwupd/firmware_packager.py

--- a/contrib/snap/dfu-tool.wrapper
+++ b/contrib/snap/dfu-tool.wrapper
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "$SNAP/fwupd-command" $SNAP/bin/dfu-tool $@

--- a/contrib/snap/fwupdagent.wrapper
+++ b/contrib/snap/fwupdagent.wrapper
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "$SNAP/fwupd-command" $SNAP/bin/fwupdagent $@

--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -15,7 +15,11 @@ if bashcomp.found()
   )
 
   if build_daemon
-    install_data(['fwupdagent', 'fwupdmgr'],
+    binaries = ['fwupdmgr']
+    if get_option('compat_cli')
+      binaries += ['fwupdagent']
+    endif
+    install_data(binaries,
       install_dir: completions_dir,
     )
   endif # build_daemon

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,5 +67,5 @@ option('metainfo', type: 'boolean', value : true, description : 'install the pro
 option('bash_completion', type: 'boolean', value : true, description : 'enable bash completion')
 option('fish_completion', type: 'boolean', value : true, description : 'enable fish completion')
 option('offline', type: 'feature', description : 'Allow installing firmware using a pre-boot systemd target', deprecated: {'true': 'enabled', 'false': 'disabled'})
-option('compat_cli', type: 'boolean', value : true, description : 'enable legacy commands: fwupdagent,dfu-tool,fwupdate')
+option('compat_cli', type: 'boolean', value : false, description : 'enable legacy commands: fwupdagent,dfu-tool,fwupdate')
 option('hsi', type: 'feature', description : ' Host Security Information', deprecated: {'true': 'enabled', 'false': 'disabled'})

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,9 +28,6 @@ plugs:
     action-prefix: org.freedesktop.fwupd
 
 apps:
-  dfu-tool:
-    command: dfu-tool.wrapper
-    plugs: [fwupdmgr, network]
   dbxtool:
     command: dbxtool.wrapper
     plugs: [fwupdmgr, network]
@@ -57,9 +54,6 @@ apps:
     plugs: [fwupdmgr, network, polkit, shutdown]
     completer:
       share/bash-completion/completions/fwupdmgr
-  fwupdagent:
-    command: fwupdagent.wrapper
-    plugs: [fwupdmgr, network]
 
 parts:
   #needed for UEFI plugin to build UX labels
@@ -293,13 +287,11 @@ parts:
     plugin: dump
     source: contrib/snap
     stage:
-    - dfu-tool.wrapper
     - dbxtool.wrapper
     - fwupd-command
     - fwupdtool.wrapper
     - fwupd.wrapper
     - fwupdmgr.wrapper
-    - fwupdagent.wrapper
 
   policy:
     plugin: nil

--- a/src/meson.build
+++ b/src/meson.build
@@ -254,13 +254,15 @@ if get_option('man')
       install: true,
       install_dir: join_paths(mandir, 'man1'),
     )
-    configure_file(
-      input: 'fwupdagent.1',
-      output: 'fwupdagent.1',
-      configuration: conf,
-      install: true,
-      install_dir: join_paths(mandir, 'man1'),
-    )
+    if get_option('compat_cli')
+      configure_file(
+        input: 'fwupdagent.1',
+        output: 'fwupdagent.1',
+        configuration: conf,
+        install: true,
+        install_dir: join_paths(mandir, 'man1'),
+      )
+    endif
   endif
   if build_standalone
     configure_file(


### PR DESCRIPTION
This just flips the default.  Distros that need it for real compatibility reason (like RHEL?) could still -`Dcompat_cli=true`

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
