### PR TITLE
Fix a critical warning when parsing an empty kernel cmdline

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -116,7 +116,7 @@ fu_common_is_live_media(void)
 		return TRUE;
 	if (!g_file_get_contents("/proc/cmdline", &buf, &bufsz, NULL))
 		return FALSE;
-	if (bufsz == 0)
+	if (bufsz <= 1)
 		return FALSE;
 	tokens = fu_strsplit(buf, bufsz - 1, " ", -1);
 	for (guint i = 0; args[i] != NULL; i++) {


### PR DESCRIPTION
Fix the bounds check so we never pass a bufsz of zero to fu_strsplit().

Resolves: https://github.com/fwupd/fwupd/issues/5575

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
