### PR TITLE
Do not check for at least one loaded backend

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -33,8 +33,7 @@ jobs:
           python3 -m pip install --user "meson >= 0.60.0"
       - name: Build
         run: |
-          ./contrib/build-openbmc.sh
-          ninja -C ..
+          ./contrib/build-openbmc.sh --prefix=/home/runner/.root
 
   macos:
     runs-on: macos-12

--- a/contrib/build-openbmc.sh
+++ b/contrib/build-openbmc.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-meson setup ../ \
+rm -rf build
+
+meson setup build \
     -Dauto_features=disabled \
+    -Ddocs=disabled \
     -Dbash_completion=false \
     -Dcompat_cli=false \
     -Dfish_completion=false \
@@ -13,3 +16,7 @@ meson setup ../ \
     -Dudevdir=/tmp \
     -Dsystemd_root_prefix=/tmp \
     $@
+
+ninja install -C build
+build/src/fwupdtool get-devices --verbose
+test $? -eq 2 || exit 1


### PR DESCRIPTION
If we're building for OpenBMC then we might not have USB -- and it's perfectly valid to just use plugin methods and not backends.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
