### PR TITLE
trivial: snap: only copy /etc and /var for tools that run as root

### DIFF
--- a/contrib/snap/fwupd-command
+++ b/contrib/snap/fwupd-command
@@ -18,10 +18,6 @@ else
   ARCH="$SNAP_ARCH-linux-gnu"
 fi
 
-# don't update between versions, we want to preserve previous data
-[ ! -d "$SNAP_USER_DATA/etc" ] && [ -d "$SNAP/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
-[ ! -d "$SNAP_USER_DATA/var" ] && [ -d "$SNAP/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
-
 # re-generate gio modules in local cache
 needs_update=true
 if [ -f $SNAP_USER_DATA/.last_revision ]; then

--- a/contrib/snap/fwupd.wrapper
+++ b/contrib/snap/fwupd.wrapper
@@ -1,2 +1,5 @@
 #!/bin/sh
+# don't update between versions, we want to preserve previous data
+[ ! -d "$SNAP_USER_DATA/etc" ] && [ -d "$SNAP/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
+[ ! -d "$SNAP_USER_DATA/var" ] && [ -d "$SNAP/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
 exec "$SNAP/fwupd-command" $SNAP/libexec/fwupd/fwupd $@

--- a/contrib/snap/fwupdtool.wrapper
+++ b/contrib/snap/fwupdtool.wrapper
@@ -1,2 +1,5 @@
 #!/bin/sh
+# don't update between versions, we want to preserve previous data
+[ ! -d "$SNAP_USER_DATA/etc" ] && [ -d "$SNAP/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
+[ ! -d "$SNAP_USER_DATA/var" ] && [ -d "$SNAP/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
 exec "$SNAP/fwupd-command" $SNAP/bin/fwupdtool $@


### PR DESCRIPTION
we don't need to make a copy of /etc in ~ for fwupdmgr

fixes: #5579

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
