### PR TITLE
fixed translation spacing

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -845,7 +845,7 @@ msgstr "Els dispositius que no s'han actualitzat correctament:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Dispositius sense actualitzacions de microprogramari disponibles:"
+msgstr "Dispositius sense actualitzacions de microprogramari disponibles: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -2577,7 +2577,7 @@ msgstr "El remot s'ha inhabilitat correctament"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "S'han baixat les metadades noves amb èxit:"
+msgstr "S'han baixat les metadades noves amb èxit: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/cs.po
+++ b/po/cs.po
@@ -801,7 +801,7 @@ msgstr "Zařízení, která nebyla úspěšně aktualizována:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Zařízení, pro která nejsou k dispozici aktualizace firmware:"
+msgstr "Zařízení, pro která nejsou k dispozici aktualizace firmware: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -2016,7 +2016,7 @@ msgstr "Než budete pokračovat, zajistěte si, abyste měli k dispozici záchra
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Zadejte prosím číslo od 0 do %u:"
+msgstr "Zadejte prosím číslo od 0 do %u: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"
@@ -2490,7 +2490,7 @@ msgstr "Vzdálený zdroj úspěšně zakázán"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Nová metadata úspěšně stažena:"
+msgstr "Nová metadata úspěšně stažena: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/fi.po
+++ b/po/fi.po
@@ -674,7 +674,7 @@ msgstr "Laitteet, joita ei päivitetty oikein:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Laitteet, joille ei ole saatavilla laiteohjelmiston päivityksiä:"
+msgstr "Laitteet, joille ei ole saatavilla laiteohjelmiston päivityksiä: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -1670,7 +1670,7 @@ msgstr "Varmista, että sinulla on aseman palautusavain ennen kuin jatkat."
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Anna numero 0 -%u"
+msgstr "Anna numero 0 - %u: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"

--- a/po/fr.po
+++ b/po/fr.po
@@ -692,7 +692,7 @@ msgstr "Effectuer l'opération ?"
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Veuillez saisir un nombre de 0 à %u :"
+msgstr "Veuillez saisir un nombre de 0 à %u: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"

--- a/po/fur.po
+++ b/po/fur.po
@@ -365,7 +365,7 @@ msgstr "Dispositîfs che no son stâts inzornâts ben:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Dispositîfs cence inzornaments firmware disponibii:"
+msgstr "Dispositîfs cence inzornaments firmware disponibii: "
 
 #. TRANSLATORS: Suffix: the HSI result
 #. TRANSLATORS: Plugin is inactive and not used
@@ -1422,7 +1422,7 @@ msgstr "Sorzint esterne disabilitade cun sucès"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Gnûf metadât discjariât cun sucès:"
+msgstr "Gnûf metadât discjariât cun sucès: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/he.po
+++ b/po/he.po
@@ -474,7 +474,7 @@ msgstr "התקנים שלא עודכנו כראוי:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "התקנים ללא עדכוני קושחה זמינים:"
+msgstr "התקנים ללא עדכוני קושחה זמינים: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -1139,7 +1139,7 @@ msgstr "לבצע פעולה?"
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "נא למלא מספר מ־0 עד %u:"
+msgstr "נא למלא מספר מ־0 עד %u: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"
@@ -1393,7 +1393,7 @@ msgstr "כל ההתקנים הופעלו בהצלחה"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "נתוני על חדשים התקבלו בהצלחה:"
+msgstr "נתוני על חדשים התקבלו בהצלחה: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled remote"

--- a/po/hu.po
+++ b/po/hu.po
@@ -826,7 +826,7 @@ msgstr "Százalék kész"
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Adjon meg egy számot 0 és %u között:"
+msgstr "Adjon meg egy számot 0 és %u között: "
 
 #. TRANSLATORS: version number of previous firmware
 msgid "Previous version"
@@ -1051,7 +1051,7 @@ msgstr "Távoli tároló sikeresen letiltva"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Új metaadatok sikeresen letöltve:"
+msgstr "Új metaadatok sikeresen letöltve: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled remote"

--- a/po/it.po
+++ b/po/it.po
@@ -736,7 +736,7 @@ msgstr "Dispositivi non aggiornati correttamente:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Dispositivi senza aggiornamenti firmware:"
+msgstr "Dispositivi senza aggiornamenti firmware: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -1738,7 +1738,7 @@ msgstr "Assicurarsi di avere la chiave di ripristino prima di continuare."
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Inserire un numero tra 0 e %u:"
+msgstr "Inserire un numero tra 0 e %u: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"
@@ -2172,7 +2172,7 @@ msgstr "Remoto disabilitato con successo"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Nuovi metadati scaricati con successo:"
+msgstr "Nuovi metadati scaricati con successo: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/ko.po
+++ b/po/ko.po
@@ -349,7 +349,7 @@ msgstr "펌웨어 업데이트 활성화 중"
 
 #. TRANSLATORS: shown when shutting down to switch to the new version
 msgid "Activating firmware update for"
-msgstr "다음 장치의 펌웨어 업데이트 활성화 중:"
+msgstr "다음 장치의 펌웨어 업데이트 활성화 중: "
 
 #. TRANSLATORS: the age of the metadata
 msgid "Age"
@@ -795,7 +795,7 @@ msgstr "올바르게 업데이트되지 않은 장치:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "펌웨어 업데이트를 사용할 수 없는 장치:"
+msgstr "펌웨어 업데이트를 사용할 수 없는 장치: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -2005,7 +2005,7 @@ msgstr "계속하시 전 볼륨 복원 키가 있는지 확인하십시오."
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "0에서 %u까지의 숫자 중 하나를 입력하십시오:"
+msgstr "0에서 %u까지의 숫자 중 하나를 입력하십시오: "
 
 #. TRANSLATORS: Failed to open plugin, hey Arch users
 msgid "Plugin dependencies missing"
@@ -2479,7 +2479,7 @@ msgstr "원격 저장소를 비활성화함"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "새 메타데이터를 다운로드함:"
+msgstr "새 메타데이터를 다운로드함: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -664,7 +664,7 @@ msgstr "Dispositivos que não foram atualizados com sucesso:"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Dispositivos com nenhuma atualização de firmware disponível:"
+msgstr "Dispositivos com nenhuma atualização de firmware disponível: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -2009,7 +2009,7 @@ msgstr "Remoto desabilitado com sucesso"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Baixados com sucesso novos metadados:"
+msgstr "Baixados com sucesso novos metadados: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/ru.po
+++ b/po/ru.po
@@ -513,7 +513,7 @@ msgstr "Устройства, которые не были правильно о
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Устройства без доступных обновлений прошивки:"
+msgstr "Устройства без доступных обновлений прошивки: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -1248,7 +1248,7 @@ msgstr "Прежде чем продолжить, убедитесь, что у 
 #. TRANSLATORS: the user isn't reading the question
 #, c-format
 msgid "Please enter a number from 0 to %u: "
-msgstr "Пожалуйста, введите число от 0 до %u:"
+msgstr "Пожалуйста, введите число от 0 до %u: "
 
 #. TRANSLATORS: Possible values for a bios setting
 msgid "Possible Values"
@@ -1575,7 +1575,7 @@ msgstr "Удалённый репозиторий успешно отключе�
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Успешно загружены новые метаданные:"
+msgstr "Успешно загружены новые метаданные: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"

--- a/po/tr.po
+++ b/po/tr.po
@@ -378,7 +378,7 @@ msgstr "Aygıt, kurulumdan önce donanım yazılımını yedekleyecek"
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Donanım yazılımı güncellemesi olmayan aygıtlar:"
+msgstr "Donanım yazılımı güncellemesi olmayan aygıtlar: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -1181,7 +1181,7 @@ msgstr "Tüm aygıtlar başarıyla etkinleştirildi"
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Yeni üst veri başarıyla indirildi:"
+msgstr "Yeni üst veri başarıyla indirildi: "
 
 #. TRANSLATORS: success message
 msgid "Successfully installed firmware"

--- a/po/uk.po
+++ b/po/uk.po
@@ -862,7 +862,7 @@ msgstr "Пристрої, для яких не вдалося оновити д�
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
 msgid "Devices with no available firmware updates: "
-msgstr "Пристрої, для яких немає оновлень мікропрограми:"
+msgstr "Пристрої, для яких немає оновлень мікропрограми: "
 
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device upgrade
@@ -2600,7 +2600,7 @@ msgstr "Успішно вимкнено запис віддаленого схо
 #. TRANSLATORS: success message -- where 'metadata' is information
 #. * about available firmware on the remote server
 msgid "Successfully downloaded new metadata: "
-msgstr "Успішно отримано нові метадані:"
+msgstr "Успішно отримано нові метадані: "
 
 #. TRANSLATORS: success message
 msgid "Successfully enabled and refreshed remote"


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

Fixes how some translations in different languages were sometimes missing a space after a colon.

example:
`title:content` would have been shown to the user instead of `title: content`.

real-world example:
![immagine](https://user-images.githubusercontent.com/84153269/221316189-ff83b767-589e-414b-a711-abcaaec7114b.png)

Should be safely mergable