### PR TITLE
Don't mask autopkgtest failures

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1408,8 +1408,8 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		data = g_variant_get_data_as_bytes(g_variant_get_child_value(parameters, 0));
 		if (!fu_engine_emulation_load(self->engine, data, &error)) {
 			g_dbus_method_invocation_return_error(invocation,
-							      FWUPD_ERROR,
-							      FWUPD_ERROR_NOT_SUPPORTED,
+							      error->domain,
+							      error->code,
 							      "failed to load emulation data: %s",
 							      error->message);
 			return;

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -63,6 +63,7 @@ struct FuUtilPrivate {
 	gboolean no_unreported_check;
 	gboolean no_safety_check;
 	gboolean no_device_prompt;
+	gboolean no_emulation_check;
 	gboolean assume_yes;
 	gboolean sign;
 	gboolean show_all;
@@ -839,7 +840,8 @@ fu_util_emulation_load_with_fallback(FuUtilPrivate *priv, GBytes *emulation_data
 					 emulation_data,
 					 priv->cancellable,
 					 &error_local)) {
-		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
+		    priv->no_emulation_check) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
@@ -4855,6 +4857,7 @@ main(int argc, char *argv[])
 		priv->no_safety_check = TRUE;
 		priv->no_remote_check = TRUE;
 		priv->no_device_prompt = TRUE;
+		priv->no_emulation_check = TRUE;
 	} else {
 		is_interactive = TRUE;
 	}


### PR DESCRIPTION
autopkgtest is failing with 1.8.12.  I don't think it's a config problem (we set it in `contrib/debian/tests/ci`) but rather getting masked.  This should help get the correct error passed up.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
