### PR TITLE
Fix the debci failure

### DIFF
--- a/contrib/debian/fwupd-tests.install
+++ b/contrib/debian/fwupd-tests.install
@@ -3,7 +3,6 @@
 #find them. for more information see:
 #https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872458
 usr/share/installed-tests/*
-usr/share/fwupd/device-tests/*.json
 usr/libexec/installed-tests/fwupd/fwupd.sh
 usr/libexec/installed-tests/fwupd/*-self-test
 debian/lintian/fwupd-tests usr/share/lintian/overrides

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -72,6 +72,9 @@ override_dh_install:
 	#install docs (maybe)
 	[ ! -d debian/tmp/usr/share/doc ] || dh_install -pfwupd-doc usr/share/doc
 
+	#install devices-tests (maybe)
+	[ ! -d debian/tmp/usr/share/fwupd/device-tests/ ] || dh_install -pfwupd-tests usr/share/fwupd/device-tests
+
 	dh_missing -a --fail-missing
 
 	#this is placed in fwupd-tests

--- a/data/device-tests/meson.build
+++ b/data/device-tests/meson.build
@@ -1,3 +1,4 @@
+if gusb.version().version_compare ('>= 0.4.5')
 install_data([
     '8bitdo-nes30pro.json',
     '8bitdo-sf30pro.json',
@@ -45,3 +46,5 @@ install_data([
   ],
   install_dir: join_paths(datadir, 'fwupd', 'device-tests'),
 )
+endif
+

--- a/data/installed-tests/fwupd.sh
+++ b/data/installed-tests/fwupd.sh
@@ -10,6 +10,19 @@ run_test()
         fi
 }
 
+run_device_tests()
+{
+	if [ -d @devicetestdir@ ]; then
+		# grab device tests from the CDN to avoid incrementing the download counter
+		export FWUPD_DEVICE_TESTS_BASE_URI=http://cdn.fwupd.org/downloads
+		for f in `grep --files-with-matches -r emulation-url @devicetestdir@`; do
+		        echo "Emulating for $f"
+		        fwupdmgr device-emulate --no-unreported-check --no-remote-check --no-metadata-check "$f"
+		        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+		done
+	fi
+}
+
 run_test acpi-dmar-self-test
 run_test acpi-facp-self-test
 run_test acpi-phat-self-test
@@ -25,14 +38,7 @@ run_test uefi-dbx-self-test
 run_test synaptics-prometheus-self-test
 run_test dfu-self-test
 run_test mtd-self-test
-
-# grab device tests from the CDN to avoid incrementing the download counter
-export FWUPD_DEVICE_TESTS_BASE_URI=http://cdn.fwupd.org/downloads
-for f in `grep --files-with-matches -r emulation-url @devicetestdir@`; do
-        echo "Emulating for $f"
-        fwupdmgr device-emulate --no-unreported-check --no-remote-check --no-metadata-check "$f"
-        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
-done
+run_device_tests
 
 # success!
 exit 0


### PR DESCRIPTION
Here is the error that was being masked:
```
Emulating for /usr/share/fwupd/device-tests/hughski-colorhug2.json
failed to load emulation data: GUsb version too old to load backends
FAIL: fwupd/fwupd.test (Child process exited with code 1)
```

To make the build more flexible, don't set up this device test unless we know we were compiled against a new enough gusb.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
