### PR TITLE
trivial: use `Wants=` in fwupd-refresh unit

### DIFF
--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Refresh fwupd metadata and update motd
 Documentation=man:fwupdmgr(1)
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
systemd documentation indicates to use this for units starting after network is up. Whether that fixes the problem at hand I don't know but we should at least match the suggestion.

Link: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
Link: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2008699

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
