### PR TITLE
Actually use GLib logging correctly

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -14,10 +14,8 @@ with a non-standard filesystem layout.
 * `FWUPD_DEVICE_TESTS_BASE_URI` sets the base URI when downloading firmware for the device-tests
 * `FWUPD_SUPPORTED` overrides the `-Dsupported_build` meson option at runtime
 * `FWUPD_VERBOSE` is set when running `--verbose`
-* `FWUPD_BACKEND_VERBOSE` can be used to show detailed plugin and backend debugging
 * `FWUPD_XMLB_VERBOSE` can be set to show Xmlb silo regeneration and quirk matches
 * `FWUPD_DBUS_SOCKET` is used to set the socket filename if running without a dbus-daemon
-* `FWUPD_DOWNLOAD_VERBOSE` can be used to show wget or curl output
 * `FWUPD_PROFILE` can be used to set the profile traceback threshold value in ms
 * `FWUPD_FUZZER_RUNNING` if the firmware format is being fuzzed
 * `FWUPD_POLKIT_NOCHECK` if we should not check for polkit policies to be installed
@@ -34,25 +32,6 @@ with a non-standard filesystem layout.
 * `CI_NETWORK` if CI is running with network access
 * `TPM_SERVER_RUNNING` if an emulated TPM is running
 
-## Shared libfwupdplugin
-
-* `FU_HID_DEVICE_VERBOSE` shows HID traffic
-* `FU_SREC_FIRMWARE_VERBOSE` shows more information about parsing Motorola S-record files
-* `FU_IHEX_FIRMWARE_VERBOSE` shows more information about parsing Intel hex files
-* `FU_UDEV_DEVICE_DEBUG` shows more information about UDEV devices, including parents
-* `FU_USB_DEVICE_DEBUG` shows more information about USB devices
-* `FU_MEI_DEVICE_DEBUG` shows MEI reads and writes
-* `FWUPD_DEVICE_LIST_VERBOSE` display devices being added and removed from the list
-* `FWUPD_PROBE_VERBOSE` dump the detected devices to the console, even if not supported by fwupd
-* `FWUPD_BIOS_SETTING_VERBOSE` be verbose while parsing BIOS settings
-* `FWUPD_EFI_SIGNATURE_VERBOSE` be verbose while parsing EFI signatures
-
-## Plugins
-
-Most plugins read a plugin-specific runtime key to increase verbosity more than the usual `VERBOSE`.
-This can be also used when using fwupdtool e.g. using `--plugin-verbose=dell` will set the
-environment variable of `FWUPD_DELL_VERBOSE` automatically.
-
 Other variables, include:
 
 * `FWUPD_DELL_FAKE_SMBIOS` if set, use fake SMBIOS information for tests
@@ -66,7 +45,6 @@ Other variables, include:
 * `FWUPD_TEST_PLUGIN_XML` used by the test plugin to load XML state out-of-band before startup
 * `FWUPD_UEFI_CAPSULE_RECREATE_COD_DATA` if set, write the files in the example COD tree in srcdir
 * `FWUPD_UEFI_TEST` used by the UEFI plugins to disable specific sanity checks during self tests
-* `FWUPD_WAC_EMULATE` emulates a fake device for testing
 
 ## File system overrides
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -803,12 +803,8 @@ device will only be updatable when all of them are removed.
 
 ## Debugging tips
 
-The most important rule when debugging is using the `--verbose` flag
-when running fwupd or fwupdtool. Besides that, there are many
-environment variables that allow some debug traces to be printed
-conditionally, for example: `FWUPD_PROBE_VERBOSE`,
-`FU_HID_DEVICE_VERBOSE`, `FWUPD_DEVICE_LIST_VERBOSE` and many other
-plugin-specific envvars.
+The most important rule when debugging is using the `--verbose` and
+duplicate `--verbose` flag when running fwupd or fwupdtool.
 
 ### Adding debug messages
 

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -1172,7 +1172,7 @@ fwupd_remote_load_signature_jcat(FwupdRemote *self, JcatFile *jcat_file, GError 
 	baseuri = g_path_get_dirname(priv->metadata_uri);
 	metadata_uri = g_build_path("/", baseuri, id, NULL);
 	if (g_strcmp0(metadata_uri, priv->metadata_uri) != 0) {
-		g_debug("changing metadata URI from %s to %s", priv->metadata_uri, metadata_uri);
+		g_info("changing metadata URI from %s to %s", priv->metadata_uri, metadata_uri);
 		g_free(priv->metadata_uri);
 		priv->metadata_uri = g_steal_pointer(&metadata_uri);
 	}

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -195,11 +195,10 @@ fu_bios_setting_fixup_lenovo_thinklmi_bug(FwupdBiosSetting *attr, GError **error
 	g_autoptr(GString) right_str = NULL;
 	g_auto(GStrv) vals = NULL;
 
-	if (g_getenv("FWUPD_BIOS_SETTING_VERBOSE") != NULL) {
-		g_debug("Processing %s: (%s)",
-			fwupd_bios_setting_get_name(attr),
-			fwupd_bios_setting_get_current_value(attr));
-	}
+	/* debug */
+	g_debug("processing %s: (%s)",
+		fwupd_bios_setting_get_name(attr),
+		fwupd_bios_setting_get_current_value(attr));
 
 	/* We have read only */
 	tmp = g_strrstr(current_value, LENOVO_READ_ONLY_NEEDLE);
@@ -286,21 +285,14 @@ fu_bios_setting_set_type(FuBiosSettings *self, FwupdBiosSetting *attr, GError **
 	}
 
 	if (g_strcmp0(data, "enumeration") == 0 || kernel_bug) {
-		if (!fu_bios_setting_set_enumeration_attrs(attr, &error_local)) {
-			if (g_getenv("FWUPD_BIOS_SETTING_VERBOSE") != NULL)
-				g_debug("failed to add enumeration attrs: %s",
-					error_local->message);
-		}
+		if (!fu_bios_setting_set_enumeration_attrs(attr, &error_local))
+			g_debug("failed to add enumeration attrs: %s", error_local->message);
 	} else if (g_strcmp0(data, "integer") == 0) {
-		if (!fu_bios_setting_set_integer_attrs(attr, &error_local)) {
-			if (g_getenv("FWUPD_BIOS_SETTING_VERBOSE") != NULL)
-				g_debug("failed to add integer attrs: %s", error_local->message);
-		}
+		if (!fu_bios_setting_set_integer_attrs(attr, &error_local))
+			g_debug("failed to add integer attrs: %s", error_local->message);
 	} else if (g_strcmp0(data, "string") == 0) {
-		if (!fu_bios_setting_set_string_attrs(attr, &error_local)) {
-			if (g_getenv("FWUPD_BIOS_SETTING_VERBOSE") != NULL)
-				g_debug("failed to add string attrs: %s", error_local->message);
-		}
+		if (!fu_bios_setting_set_string_attrs(attr, &error_local))
+			g_debug("failed to add string attrs: %s", error_local->message);
 	}
 	return TRUE;
 }
@@ -419,10 +411,10 @@ fu_bios_settings_combination_fixups(FuBiosSettings *self)
 	if (thinklmi_sb != NULL && thinklmi_3rd != NULL) {
 		const gchar *val = fwupd_bios_setting_get_current_value(thinklmi_3rd);
 		if (g_strcmp0(val, "Disable") == 0) {
-			g_debug("Disabling changing %s since %s is %s",
-				fwupd_bios_setting_get_name(thinklmi_sb),
-				fwupd_bios_setting_get_name(thinklmi_3rd),
-				val);
+			g_info("Disabling changing %s since %s is %s",
+			       fwupd_bios_setting_get_name(thinklmi_sb),
+			       fwupd_bios_setting_get_name(thinklmi_3rd),
+			       val);
 			fwupd_bios_setting_set_read_only(thinklmi_sb, TRUE);
 		}
 	}
@@ -499,7 +491,7 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 			}
 		} while (++count);
 	} while (TRUE);
-	g_debug("loaded %u BIOS settings", count);
+	g_info("loaded %u BIOS settings", count);
 
 	fu_bios_settings_combination_fixups(self);
 

--- a/libfwupdplugin/fu-cabinet.c
+++ b/libfwupdplugin/fu-cabinet.c
@@ -350,9 +350,9 @@ fu_cabinet_parse_release(FuCabinet *self, XbNode *release, GError **error)
 						       JCAT_VERIFY_FLAG_REQUIRE_SIGNATURE,
 						   &error_local);
 		if (results == NULL) {
-			g_debug("failed to verify payload %s: %s", basename, error_local->message);
+			g_info("failed to verify payload %s: %s", basename, error_local->message);
 		} else {
-			g_debug("verified payload %s: %u", basename, results->len);
+			g_info("verified payload %s: %u", basename, results->len);
 			release_flags |= FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD;
 		}
 
@@ -383,11 +383,11 @@ fu_cabinet_parse_release(FuCabinet *self, XbNode *release, GError **error)
 							       JCAT_VERIFY_FLAG_REQUIRE_SIGNATURE,
 							       &error_local);
 			if (jcat_result == NULL) {
-				g_debug("failed to verify payload %s using detached: %s",
-					basename,
-					error_local->message);
+				g_info("failed to verify payload %s using detached: %s",
+				       basename,
+				       error_local->message);
 			} else {
-				g_debug("verified payload %s using detached", basename);
+				g_info("verified payload %s using detached", basename);
 				release_flags |= FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD;
 			}
 		}
@@ -602,7 +602,7 @@ fu_cabinet_build_silo_metainfo(FuCabinet *self, GCabFile *cabfile, GError **erro
 	/* validate against the Jcat file */
 	item = jcat_file_get_item_by_id(self->jcat_file, fn, NULL);
 	if (item == NULL) {
-		g_debug("failed to verify %s: no JcatItem", fn);
+		g_info("failed to verify %s: no JcatItem", fn);
 	} else {
 		g_autoptr(GError) error_local = NULL;
 		g_autoptr(GPtrArray) results = NULL;
@@ -613,15 +613,15 @@ fu_cabinet_build_silo_metainfo(FuCabinet *self, GCabFile *cabfile, GError **erro
 						       JCAT_VERIFY_FLAG_REQUIRE_SIGNATURE,
 						   &error_local);
 		if (results == NULL) {
-			g_debug("failed to verify %s: %s", fn, error_local->message);
+			g_info("failed to verify %s: %s", fn, error_local->message);
 		} else {
-			g_debug("verified metadata %s: %u", fn, results->len);
+			g_info("verified metadata %s: %u", fn, results->len);
 			release_flags |= FWUPD_RELEASE_FLAG_TRUSTED_METADATA;
 		}
 	}
 
 	/* actually parse the XML now */
-	g_debug("processing file: %s", fn);
+	g_info("processing file: %s", fn);
 	if (!fu_cabinet_build_silo_file(self, cabfile, release_flags, error)) {
 		g_prefix_error(error,
 			       "%s could not be loaded: ",
@@ -1127,7 +1127,7 @@ fu_cabinet_parse(FuCabinet *self, GBytes *data, FuCabinetParseFlags flags, GErro
 		}
 		for (guint j = 0; j < releases->len; j++) {
 			XbNode *rel = g_ptr_array_index(releases, j);
-			g_debug("processing release: %s", xb_node_get_attr(rel, "version"));
+			g_info("processing release: %s", xb_node_get_attr(rel, "version"));
 			if (!fu_cabinet_parse_release(self, rel, error))
 				return FALSE;
 		}

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -577,7 +577,7 @@ fu_context_add_udev_subsystem(FuContext *self, const gchar *subsystem)
 		if (g_strcmp0(subsystem_tmp, subsystem) == 0)
 			return;
 	}
-	g_debug("added udev subsystem watch of %s", subsystem);
+	g_info("added udev subsystem watch of %s", subsystem);
 	g_ptr_array_add(priv->udev_subsystems, g_strdup(subsystem));
 }
 
@@ -818,9 +818,9 @@ fu_context_load_hwinfo(FuContext *self,
 		if ((flags & hwids_setup_map[i].flag) > 0) {
 			g_autoptr(GError) error_local = NULL;
 			if (!hwids_setup_map[i].func(self, priv->hwids, &error_local)) {
-				g_debug("failed to load %s: %s",
-					hwids_setup_map[i].name,
-					error_local->message);
+				g_info("failed to load %s: %s",
+				       hwids_setup_map[i].name,
+				       error_local->message);
 				continue;
 			}
 		}
@@ -941,7 +941,7 @@ fu_context_set_power_state(FuContext *self, FuPowerState power_state)
 	if (priv->power_state == power_state)
 		return;
 	priv->power_state = power_state;
-	g_debug("power state now %s", fu_power_state_to_string(power_state));
+	g_info("power state now %s", fu_power_state_to_string(power_state));
 	g_object_notify(G_OBJECT(self), "power-state");
 }
 
@@ -980,7 +980,7 @@ fu_context_set_lid_state(FuContext *self, FuLidState lid_state)
 	if (priv->lid_state == lid_state)
 		return;
 	priv->lid_state = lid_state;
-	g_debug("lid state now %s", fu_lid_state_to_string(lid_state));
+	g_info("lid state now %s", fu_lid_state_to_string(lid_state));
 	g_object_notify(G_OBJECT(self), "lid-state");
 }
 
@@ -1020,7 +1020,7 @@ fu_context_set_battery_level(FuContext *self, guint battery_level)
 	if (priv->battery_level == battery_level)
 		return;
 	priv->battery_level = battery_level;
-	g_debug("battery level now %u", battery_level);
+	g_info("battery level now %u", battery_level);
 	g_object_notify(G_OBJECT(self), "battery-level");
 }
 
@@ -1060,7 +1060,7 @@ fu_context_set_battery_threshold(FuContext *self, guint battery_threshold)
 	if (priv->battery_threshold == battery_threshold)
 		return;
 	priv->battery_threshold = battery_threshold;
-	g_debug("battery threshold now %u", battery_threshold);
+	g_info("battery threshold now %u", battery_threshold);
 	g_object_notify(G_OBJECT(self), "battery-threshold");
 }
 

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -670,7 +670,7 @@ fu_device_retry_full(FuDevice *self,
 
 		/* show recoverable error on the console */
 		if (priv->retry_recs->len == 0) {
-			g_debug("failed on try %u of %u: %s", i + 1, count, error_local->message);
+			g_info("failed on try %u of %u: %s", i + 1, count, error_local->message);
 			continue;
 		}
 
@@ -1178,11 +1178,11 @@ fu_device_set_parent(FuDevice *self, FuDevice *parent)
 
 	/* debug */
 	if (parent != NULL) {
-		g_debug("setting parent of %s [%s] to be %s [%s]",
-			fu_device_get_name(self),
-			fu_device_get_id(self),
-			fu_device_get_name(parent),
-			fu_device_get_id(parent));
+		g_info("setting parent of %s [%s] to be %s [%s]",
+		       fu_device_get_name(self),
+		       fu_device_get_id(self),
+		       fu_device_get_name(parent),
+		       fu_device_get_id(parent));
 	}
 
 	/* set the composite ID on the children and grandchildren */
@@ -4158,7 +4158,7 @@ fu_device_write_firmware(FuDevice *self,
 	if (firmware == NULL)
 		return FALSE;
 	str = fu_firmware_to_string(firmware);
-	g_debug("installing onto %s:\n%s", fu_device_get_id(self), str);
+	g_info("installing onto %s:\n%s", fu_device_get_id(self), str);
 
 	/* call vfunc */
 	if (!klass->write_firmware(self, firmware, progress, flags, error))
@@ -5309,9 +5309,9 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request)
 
 	/* ignore */
 	if (fu_device_has_flag(self, FWUPD_DEVICE_FLAG_EMULATED)) {
-		g_debug("ignoring device %s request of %s as emulated",
-			fu_device_get_id(self),
-			fwupd_request_get_id(request));
+		g_info("ignoring device %s request of %s as emulated",
+		       fu_device_get_id(self),
+		       fwupd_request_get_id(request));
 		return;
 	}
 

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -224,15 +224,12 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 	for (guint i = 0; i < sigs->len; i++) {
 		FuEfiSignature *sig = g_ptr_array_index(sigs, i);
 		if (fu_efi_signature_get_kind(sig) != FU_EFI_SIGNATURE_KIND_SHA256) {
-			if (g_getenv("FWUPD_EFI_SIGNATURE_VERBOSE") != NULL)
-				g_debug("ignoring dbx certificate");
+			g_debug("ignoring dbx certificate in position %u", i);
 			continue;
 		}
 		if (!g_strv_contains(valid_owners, fu_efi_signature_get_owner(sig))) {
-			if (g_getenv("FWUPD_EFI_SIGNATURE_VERBOSE") != NULL) {
-				g_debug("ignoring non-Microsoft dbx hash: %s",
-					fu_efi_signature_get_owner(sig));
-			}
+			g_debug("ignoring non-Microsoft dbx hash: %s",
+				fu_efi_signature_get_owner(sig));
 			continue;
 		}
 
@@ -274,11 +271,11 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 	for (guint i = 0; checksum_last != NULL && known_checksums[i].checksum != NULL; i++) {
 		if (g_strcmp0(checksum_last, known_checksums[i].checksum) == 0) {
 			if (csum_cnt != known_checksums[i].version) {
-				g_debug("fixing signature list version from %u to %u as "
-					"last dbx checksum was %s",
-					csum_cnt,
-					known_checksums[i].version,
-					checksum_last);
+				g_info("fixing signature list version from %u to %u as "
+				       "last dbx checksum was %s",
+				       csum_cnt,
+				       known_checksums[i].version,
+				       checksum_last);
 				csum_cnt = known_checksums[i].version;
 			}
 			break;

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -179,8 +179,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GBytes *strtab,
 	g_autoptr(FuFirmware) firmware_current = g_object_ref(FU_FIRMWARE(self));
 
 	/* debug */
-	if (g_getenv("FU_FDT_FIRMWARE_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "dt_struct", fw);
+	fu_dump_bytes(G_LOG_DOMAIN, "dt_struct", fw);
 
 	/* parse */
 	while (offset < bufsz) {
@@ -190,8 +189,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GBytes *strtab,
 		offset = fu_common_align_up(offset, FU_FIRMWARE_ALIGNMENT_4);
 		if (!fu_memread_uint32_safe(buf, bufsz, offset, &token, G_BIG_ENDIAN, error))
 			return FALSE;
-		if (g_getenv("FU_FDT_FIRMWARE_VERBOSE") != NULL)
-			g_debug("token: 0x%x", token);
+		g_debug("token: 0x%x", token);
 		offset += sizeof(guint32);
 
 		/* nothing to do */
@@ -352,8 +350,7 @@ fu_fdt_firmware_parse_mem_rsvmap(FuFdtFirmware *self,
 					    G_BIG_ENDIAN,
 					    error))
 			return FALSE;
-		if (g_getenv("FU_FDT_FIRMWARE_VERBOSE") != NULL)
-			g_debug("mem_rsvmap: 0x%x, 0x%x", (guint)address, (guint)size);
+		g_debug("mem_rsvmap: 0x%x, 0x%x", (guint)address, (guint)size);
 		if (address == 0x0 && size == 0x0)
 			break;
 	}
@@ -540,8 +537,7 @@ fu_fdt_firmware_append_to_strtab(FuFdtFirmwareBuildHelper *helper, const gchar *
 	if (g_hash_table_lookup_extended(helper->strtab, key, NULL, &tmp))
 		return GPOINTER_TO_UINT(tmp);
 
-	if (g_getenv("FU_FDT_FIRMWARE_VERBOSE") != NULL)
-		g_debug("adding strtab: %s", key);
+	g_debug("adding strtab: %s", key);
 	offset = helper->dt_strings->len;
 	g_byte_array_append(helper->dt_strings, (const guint8 *)key, strlen(key));
 	fu_byte_array_append_uint8(helper->dt_strings, 0x0);

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -241,8 +241,7 @@ fu_fit_firmware_verify_image(FuFirmware *firmware,
 		if (blob == NULL)
 			return FALSE;
 	}
-	if (g_getenv("FU_FDT_FIRMWARE_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "data", blob);
+	fu_dump_bytes(G_LOG_DOMAIN, "data", blob);
 
 	/* verify any hashes we recognize */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -285,11 +285,9 @@ fu_hid_device_set_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 
 	/* what method do we use? */
 	if (priv->flags & FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER) {
-		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-			g_autofree gchar *title = NULL;
-			title = g_strdup_printf("HID::SetReport [EP=0x%02x]", priv->ep_addr_out);
-			fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
-		}
+		g_autofree gchar *title =
+		    g_strdup_printf("HID::SetReport [EP=0x%02x]", priv->ep_addr_out);
+		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
 		if (!g_usb_device_interrupt_transfer(usb_device,
 						     priv->ep_addr_out,
 						     helper->buf,
@@ -302,18 +300,16 @@ fu_hid_device_set_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 		}
 	} else {
 		guint16 wvalue = (FU_HID_REPORT_TYPE_OUTPUT << 8) | helper->value;
+		g_autofree gchar *title = NULL;
 
 		/* special case */
 		if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
 			wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
 
-		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-			g_autofree gchar *title = NULL;
-			title = g_strdup_printf("HID::SetReport [wValue=0x%04x, wIndex=%u]",
-						wvalue,
-						priv->interface);
-			fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
-		}
+		title = g_strdup_printf("HID::SetReport [wValue=0x%04x, wIndex=%u]",
+					wvalue,
+					priv->interface);
+		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
 		if (!g_usb_device_control_transfer(usb_device,
 						   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 						   G_USB_DEVICE_REQUEST_TYPE_CLASS,
@@ -415,6 +411,7 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 
 	/* what method do we use? */
 	if (priv->flags & FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER) {
+		g_autofree gchar *title = NULL;
 		if (!g_usb_device_interrupt_transfer(usb_device,
 						     priv->ep_addr_in,
 						     helper->buf,
@@ -425,25 +422,20 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 						     error)) {
 			return FALSE;
 		}
-		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-			g_autofree gchar *title = NULL;
-			title = g_strdup_printf("HID::GetReport [EP=0x%02x]", priv->ep_addr_in);
-			fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
-		}
+		title = g_strdup_printf("HID::GetReport [EP=0x%02x]", priv->ep_addr_in);
+		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
 	} else {
 		guint16 wvalue = (FU_HID_REPORT_TYPE_INPUT << 8) | helper->value;
+		g_autofree gchar *title = NULL;
 
 		/* special case */
 		if (helper->flags & FU_HID_DEVICE_FLAG_IS_FEATURE)
 			wvalue = (FU_HID_REPORT_TYPE_FEATURE << 8) | helper->value;
 
-		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-			g_autofree gchar *title = NULL;
-			title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
-						wvalue,
-						priv->interface);
-			fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
-		}
+		title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
+					wvalue,
+					priv->interface);
+		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
 		if (!g_usb_device_control_transfer(usb_device,
 						   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
 						   G_USB_DEVICE_REQUEST_TYPE_CLASS,
@@ -460,13 +452,7 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 			g_prefix_error(error, "failed to GetReport: ");
 			return FALSE;
 		}
-		if (g_getenv("FU_HID_DEVICE_VERBOSE") != NULL) {
-			g_autofree gchar *title = NULL;
-			title = g_strdup_printf("HID::GetReport [wValue=0x%04x, wIndex=%u]",
-						wvalue,
-						priv->interface);
-			fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
-		}
+		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, actual_len);
 	}
 	if ((helper->flags & FU_HID_DEVICE_FLAG_ALLOW_TRUNC) == 0 && actual_len != helper->bufsz) {
 		g_set_error(error,

--- a/libfwupdplugin/fu-hwids-config.c
+++ b/libfwupdplugin/fu-hwids-config.c
@@ -27,7 +27,7 @@ fu_hwids_config_setup(FuContext *ctx, FuHwids *self, GError **error)
 	for (guint i = 0; i < fns->len; i++) {
 		const gchar *fn = g_ptr_array_index(fns, i);
 		if (g_file_test(fn, G_FILE_TEST_EXISTS)) {
-			g_debug("loading HwId overrides from %s", fn);
+			g_info("loading HwId overrides from %s", fn);
 			if (!g_key_file_load_from_file(kf, fn, G_KEY_FILE_NONE, error))
 				return FALSE;
 		} else {

--- a/libfwupdplugin/fu-hwids-smbios.c
+++ b/libfwupdplugin/fu-hwids-smbios.c
@@ -132,7 +132,7 @@ fu_hwids_smbios_setup(FuContext *ctx, FuHwids *self, GError **error)
 			g_debug("ignoring %s: %s", map[i].key, error_local->message);
 			continue;
 		}
-		g_debug("smbios property %s=%s", map[i].key, contents);
+		g_info("SMBIOS %s=%s", map[i].key, contents);
 
 		/* weirdly, remove leading zeros */
 		contents_hdr = contents;

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -257,7 +257,6 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 	guint32 addr_last = 0x0;
 	guint32 img_addr = G_MAXUINT32;
 	guint32 seg_addr = 0x0;
-	gboolean is_debug = g_getenv("FU_IHEX_FIRMWARE_VERBOSE") != NULL;
 	g_autoptr(GBytes) img_bytes = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
@@ -269,11 +268,9 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 		guint32 len_hole;
 
 		/* debug */
-		if (is_debug) {
-			g_debug("%s:", fu_ihex_firmware_record_type_to_string(rcd->record_type));
-			g_debug("  length:\t0x%02x", rcd->data->len);
-			g_debug("  addr:\t0x%08x", addr);
-		}
+		g_debug("%s:", fu_ihex_firmware_record_type_to_string(rcd->record_type));
+		g_debug("length:\t0x%02x", rcd->data->len);
+		g_debug("addr:\t0x%08x", addr);
 
 		/* sanity check */
 		if (rcd->record_type != FU_IHEX_FIRMWARE_RECORD_TYPE_EOF && rcd->data->len == 0) {
@@ -374,8 +371,7 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 						    error))
 				return FALSE;
 			abs_addr = (guint32)addr16 << 16;
-			if (is_debug)
-				g_debug("  abs_addr:\t0x%02x on line %u", abs_addr, rcd->ln);
+			g_debug("abs_addr:\t0x%02x on line %u", abs_addr, rcd->ln);
 			break;
 		case FU_IHEX_FIRMWARE_RECORD_TYPE_START_LINEAR:
 			if (!fu_memread_uint32_safe(rcd->data->data,
@@ -385,8 +381,7 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 						    G_BIG_ENDIAN,
 						    error))
 				return FALSE;
-			if (is_debug)
-				g_debug("  abs_addr:\t0x%08x on line %u", abs_addr, rcd->ln);
+			g_debug("abs_addr:\t0x%08x on line %u", abs_addr, rcd->ln);
 			break;
 		case FU_IHEX_FIRMWARE_RECORD_TYPE_EXTENDED_SEGMENT:
 			if (!fu_memread_uint16_safe(rcd->data->data,
@@ -398,8 +393,7 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 				return FALSE;
 			/* segment base address, so ~1Mb addressable */
 			seg_addr = (guint32)addr16 * 16;
-			if (is_debug)
-				g_debug("  seg_addr:\t0x%08x on line %u", seg_addr, rcd->ln);
+			g_debug("seg_addr:\t0x%08x on line %u", seg_addr, rcd->ln);
 			break;
 		case FU_IHEX_FIRMWARE_RECORD_TYPE_START_SEGMENT:
 			/* initial content of the CS:IP registers */
@@ -410,8 +404,7 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 						    G_BIG_ENDIAN,
 						    error))
 				return FALSE;
-			if (is_debug)
-				g_debug("  seg_addr:\t0x%02x on line %u", seg_addr, rcd->ln);
+			g_debug("seg_addr:\t0x%02x on line %u", seg_addr, rcd->ln);
 			break;
 		case FU_IHEX_FIRMWARE_RECORD_TYPE_SIGNATURE:
 			if (got_sig) {

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -304,8 +304,7 @@ fu_mei_device_connect(FuMeiDevice *self, guchar req_protocol_version, GError **e
 
 	if (!fwupd_guid_from_string(priv->uuid, &guid_le, FWUPD_GUID_FLAG_MIXED_ENDIAN, error))
 		return FALSE;
-	if (g_getenv("FU_MEI_DEVICE_DEBUG") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "guid_le", (guint8 *)&guid_le, sizeof(guid_le));
+	fu_dump_raw(G_LOG_DOMAIN, "guid_le", (guint8 *)&guid_le, sizeof(guid_le));
 	memcpy(&data.in_client_uuid, &guid_le, sizeof(guid_le));
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  IOCTL_MEI_CONNECT_CLIENT,
@@ -377,8 +376,7 @@ fu_mei_device_read(FuMeiDevice *self,
 			    strerror(errno));
 		return FALSE;
 	}
-	if (g_getenv("FU_MEI_DEVICE_DEBUG") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "read", buf, rc);
+	fu_dump_raw(G_LOG_DOMAIN, "read", buf, rc);
 	if (bytes_read != NULL)
 		*bytes_read = (gsize)rc;
 	return TRUE;
@@ -419,8 +417,7 @@ fu_mei_device_write(FuMeiDevice *self,
 	tv.tv_sec = timeout_ms / 1000;
 	tv.tv_usec = (timeout_ms % 1000) * 1000000;
 
-	if (g_getenv("FU_MEI_DEVICE_DEBUG") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
 	written = write(fd, buf, bufsz);
 	if (written < 0) {
 		g_set_error(error,

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -904,9 +904,9 @@ fu_plugin_runner_startup(FuPlugin *self, FuProgress *progress, GError **error)
 			}
 			st.st_mode &= 0777;
 			if (st.st_mode != FU_PLUGIN_FILE_MODE_SECURE) {
-				g_debug("mode was 0%o, and needs to be 0%o",
-					st.st_mode,
-					(guint)FU_PLUGIN_FILE_MODE_SECURE);
+				g_info("mode was 0%o, and needs to be 0%o",
+				       st.st_mode,
+				       (guint)FU_PLUGIN_FILE_MODE_SECURE);
 				rc = g_chmod(config_filename, FU_PLUGIN_FILE_MODE_SECURE);
 				if (rc != 0) {
 					g_set_error(error,
@@ -1597,7 +1597,7 @@ fu_plugin_backend_device_added(FuPlugin *self,
 		fu_device_convert_instance_ids(dev);
 		if (!fu_plugin_check_supported_device(self, dev)) {
 			g_autofree gchar *guids = fu_device_get_guids_as_str(dev);
-			g_debug("%s has no updates, so ignoring device", guids);
+			g_info("%s has no updates, so ignoring device", guids);
 			fu_progress_finished(progress);
 			return TRUE;
 		}

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -281,8 +281,7 @@ fu_quirks_add_quirks_for_path(FuQuirks *self, XbBuilder *builder, const gchar *p
 	g_autoptr(GDir) dir = NULL;
 	g_autoptr(GPtrArray) filenames = g_ptr_array_new_with_free_func(g_free);
 
-	if (g_getenv("FWUPD_VERBOSE") != NULL)
-		g_debug("loading quirks from %s", path);
+	g_info("loading quirks from %s", path);
 
 	/* add valid files to the array */
 	if (!g_file_test(path, G_FILE_TEST_EXISTS))
@@ -399,7 +398,7 @@ fu_quirks_check_silo(FuQuirks *self, GError **error)
 		g_autofree gchar *str = NULL;
 		g_ptr_array_sort(self->invalid_keys, fu_quirks_strcasecmp_cb);
 		str = fu_strjoin(",", self->invalid_keys);
-		g_debug("invalid key names: %s", str);
+		g_info("invalid key names: %s", str);
 	}
 
 	/* check if there is any quirk data to load, as older libxmlb versions will not be able to

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -370,8 +370,7 @@ fu_smbios_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	dump = fu_firmware_to_string(FU_FIRMWARE(smbios));
-	if (g_getenv("FWUPD_VERBOSE") != NULL)
-		g_debug("%s", dump);
+	g_debug("%s", dump);
 
 	/* test for missing table */
 	str = fu_smbios_get_string(smbios, 0xff, 0, &error);
@@ -396,6 +395,7 @@ fu_smbios3_func(void)
 {
 	const gchar *str;
 	gboolean ret;
+	g_autofree gchar *dump = NULL;
 	g_autofree gchar *path = NULL;
 	g_autoptr(FuSmbios) smbios = NULL;
 	g_autoptr(GError) error = NULL;
@@ -405,10 +405,8 @@ fu_smbios3_func(void)
 	ret = fu_smbios_setup_from_path(smbios, path, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	if (g_getenv("FWUPD_VERBOSE") != NULL) {
-		g_autofree gchar *dump = fu_firmware_to_string(FU_FIRMWARE(smbios));
-		g_debug("%s", dump);
-	}
+	dump = fu_firmware_to_string(FU_FIRMWARE(smbios));
+	g_debug("%s", dump);
 
 	/* get vendor */
 	str = fu_smbios_get_string(smbios, FU_SMBIOS_STRUCTURE_TYPE_BIOS, 0x04, &error);
@@ -435,6 +433,7 @@ fu_context_flags_func(void)
 static void
 fu_context_hwids_dmi_func(void)
 {
+	g_autofree gchar *dump = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
@@ -443,11 +442,8 @@ fu_context_hwids_dmi_func(void)
 	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_LOAD_DMI, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	if (g_getenv("FWUPD_VERBOSE") != NULL) {
-		g_autofree gchar *dump =
-		    fu_firmware_to_string(FU_FIRMWARE(fu_context_get_smbios(ctx)));
-		g_debug("%s", dump);
-	}
+	dump = fu_firmware_to_string(FU_FIRMWARE(fu_context_get_smbios(ctx)));
+	g_debug("%s", dump);
 
 	g_assert_cmpstr(fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_MANUFACTURER), ==, "FwupdTest");
 	g_assert_cmpuint(fu_context_get_chassis_kind(ctx), ==, 16);

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -301,13 +301,11 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 	default:
 		g_assert_not_reached();
 	}
-	if (g_getenv("FU_SREC_FIRMWARE_VERBOSE") != NULL) {
-		g_debug("line %03u S%u addr:0x%04x datalen:0x%02x",
-			token_idx + 1,
-			rec_kind,
-			rec_addr32,
-			(guint)rec_count - addrsz - 1);
-	}
+	g_debug("line %03u S%u addr:0x%04x datalen:0x%02x",
+		token_idx + 1,
+		rec_kind,
+		rec_addr32,
+		(guint)rec_count - addrsz - 1);
 	if (require_data && rec_count == addrsz) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -143,27 +143,6 @@ fu_udev_device_get_sysfs_attr_as_uint8(GUdevDevice *udev_device, const gchar *na
 	return tmp64;
 }
 
-static void
-fu_udev_device_to_string_raw(GUdevDevice *udev_device, guint idt, GString *str)
-{
-	const gchar *const *keys;
-	if (udev_device == NULL)
-		return;
-	keys = g_udev_device_get_property_keys(udev_device);
-	for (guint i = 0; keys[i] != NULL; i++) {
-		fu_string_append(str,
-				 idt,
-				 keys[i],
-				 g_udev_device_get_property(udev_device, keys[i]));
-	}
-	keys = g_udev_device_get_sysfs_attr_keys(udev_device);
-	for (guint i = 0; keys[i] != NULL; i++) {
-		fu_string_append(str,
-				 idt,
-				 keys[i],
-				 g_udev_device_get_sysfs_attr(udev_device, keys[i]));
-	}
-}
 #endif
 
 static void
@@ -197,15 +176,6 @@ fu_udev_device_to_string(FuDevice *device, guint idt, GString *str)
 				 idt,
 				 "SysfsPath",
 				 g_udev_device_get_sysfs_path(priv->udev_device));
-	}
-	if (g_getenv("FU_UDEV_DEVICE_DEBUG") != NULL) {
-		g_autoptr(GUdevDevice) udev_parent = NULL;
-		fu_udev_device_to_string_raw(priv->udev_device, idt, str);
-		udev_parent = g_udev_device_get_parent(priv->udev_device);
-		if (udev_parent != NULL) {
-			fu_string_append(str, idt, "Parent", NULL);
-			fu_udev_device_to_string_raw(udev_parent, idt + 1, str);
-		}
 	}
 #endif
 }

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-#define G_LOG_DOMAIN "FuFirmware"
+#define G_LOG_DOMAIN "FuUsbDeviceDs20"
 
 #include "config.h"
 
@@ -109,8 +109,7 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 	}
 
 	/* debug */
-	if (g_getenv("FWUPD_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "PlatformCapabilityOs20", buf, actual_length);
+	fu_dump_raw(G_LOG_DOMAIN, "PlatformCapabilityOs20", buf, actual_length);
 
 	/* FuUsbDeviceDs20->parse */
 	blob = g_bytes_new_take(g_steal_pointer(&buf), actual_length);

--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#define G_LOG_DOMAIN "FuUsbDeviceDs20"
+
 #include "config.h"
 
 #include "fu-device-private.h"

--- a/libfwupdplugin/fu-usb-device-ms-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ms-ds20.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#define G_LOG_DOMAIN "FuUsbDeviceDs20"
+
 #include "config.h"
 
 #include "fu-mem.h"

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -226,8 +226,7 @@ fu_usb_device_query_hub(FuUsbDevice *self, GError **error)
 		g_prefix_error(error, "failed to get USB descriptor: ");
 		return FALSE;
 	}
-	if (g_getenv("FU_USB_DEVICE_DEBUG") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "HUB_DT", data, sz);
+	fu_dump_raw(G_LOG_DOMAIN, "HUB_DT", data, sz);
 
 	/* for USB 3: size is fixed as max ports is 15,
 	 * for USB 2: size is variable as max ports is 255 */
@@ -386,6 +385,7 @@ fu_usb_device_setup(FuDevice *device, GError **error)
 		if (g_usb_bos_descriptor_get_capability(bos) == 0x5 &&
 		    g_bytes_get_size(extra) > 0) {
 			g_autoptr(FuFirmware) ds20 = NULL;
+			g_autofree gchar *str = NULL;
 			g_autoptr(GError) error_ds20 = NULL;
 
 			ds20 = fu_firmware_new_from_gtypes(extra,
@@ -405,10 +405,8 @@ fu_usb_device_setup(FuDevice *device, GError **error)
 				g_warning("failed to get DS20 data: %s", error_ds20->message);
 				continue;
 			}
-			if (g_getenv("FU_USB_DEVICE_DEBUG") != NULL) {
-				g_autofree gchar *str = fu_firmware_to_string(ds20);
-				g_debug("DS20: %s", str);
-			}
+			str = fu_firmware_to_string(ds20);
+			g_debug("DS20: %s", str);
 		}
 	}
 #endif

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -524,6 +524,7 @@ fu_volume_new_by_kind(const gchar *kind, GError **error)
 	for (guint i = 0; i < devices->len; i++) {
 		GDBusProxy *proxy_blk = g_ptr_array_index(devices, i);
 		const gchar *type_str;
+		g_autofree gchar *id_type = NULL;
 		g_autoptr(FuVolume) vol = NULL;
 		g_autoptr(GDBusProxy) proxy_part = NULL;
 		g_autoptr(GDBusProxy) proxy_fs = NULL;
@@ -572,14 +573,12 @@ fu_volume_new_by_kind(const gchar *kind, GError **error)
 
 		/* convert reported type to GPT type */
 		type_str = fu_volume_kind_convert_to_gpt(type_str);
-		if (g_getenv("FWUPD_VERBOSE") != NULL) {
-			g_autofree gchar *id_type = fu_volume_get_id_type(vol);
-			g_debug("device %s, type: %s, internal: %d, fs: %s",
-				g_dbus_proxy_get_object_path(proxy_blk),
-				type_str,
-				fu_volume_is_internal(vol),
-				id_type);
-		}
+		id_type = fu_volume_get_id_type(vol);
+		g_debug("device %s, type: %s, internal: %d, fs: %s",
+			g_dbus_proxy_get_object_path(proxy_blk),
+			type_str,
+			fu_volume_is_internal(vol),
+			id_type);
 		if (g_strcmp0(type_str, kind) != 0)
 			continue;
 		g_ptr_array_add(volumes, g_steal_pointer(&vol));
@@ -726,7 +725,7 @@ fu_volume_new_esp_for_path(const gchar *esp_path, GError **error)
 			return g_object_ref(vol);
 	}
 	if (g_file_test(esp_path, G_FILE_TEST_IS_DIR)) {
-		g_debug("Using user requested path %s for ESP", esp_path);
+		g_info("using user requested path %s for ESP", esp_path);
 		return fu_volume_new_from_mount_path(esp_path);
 	}
 	g_set_error(error,

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -200,8 +200,7 @@ fu_android_boot_device_erase(FuAndroidBootDevice *self, FuProgress *progress, GE
 
 	chunks = fu_chunk_array_new(buf, bufsz, 0x0, 0x0, 10 * 1024);
 
-	if (g_getenv("FWUPD_ANDROID_BOOT_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "erase", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "erase", buf, bufsz);
 
 	if (!fu_android_boot_device_write(self, chunks, progress, error))
 		return FALSE;
@@ -263,9 +262,7 @@ fu_android_boot_device_write_firmware(FuDevice *device,
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
-
-	if (g_getenv("FWUPD_ANDROID_BOOT_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "write", fw);
+	fu_dump_bytes(G_LOG_DOMAIN, "write", fw);
 
 	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, 10 * 1024);
 

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -548,12 +548,9 @@ fu_ata_device_command(FuAtaDevice *self,
 	cdb[7] = tf->lbah;
 	cdb[8] = tf->dev;
 	cdb[9] = tf->command;
-	if (g_getenv("FWUPD_ATA_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "CDB", cdb, sizeof(cdb));
-		if (dxfer_direction == SG_DXFER_TO_DEV && dxferp != NULL) {
-			fu_dump_raw(G_LOG_DOMAIN, "outgoing_data", dxferp, dxfer_len);
-		}
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "CDB", cdb, sizeof(cdb));
+	if (dxfer_direction == SG_DXFER_TO_DEV && dxferp != NULL)
+		fu_dump_raw(G_LOG_DOMAIN, "outgoing_data", dxferp, dxfer_len);
 
 	/* hit hardware */
 	io_hdr.interface_id = 'S';
@@ -573,14 +570,12 @@ fu_ata_device_command(FuAtaDevice *self,
 				  FU_ATA_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-	if (g_getenv("FWUPD_ATA_VERBOSE") != NULL) {
-		g_debug("ATA_%u status=0x%x, host_status=0x%x, driver_status=0x%x",
-			io_hdr.cmd_len,
-			io_hdr.status,
-			io_hdr.host_status,
-			io_hdr.driver_status);
-		fu_dump_raw(G_LOG_DOMAIN, "SB", sb, sizeof(sb));
-	}
+	g_debug("ATA_%u status=0x%x, host_status=0x%x, driver_status=0x%x",
+		io_hdr.cmd_len,
+		io_hdr.status,
+		io_hdr.host_status,
+		io_hdr.driver_status);
+	fu_dump_raw(G_LOG_DOMAIN, "SB", sb, sizeof(sb));
 
 	/* error check */
 	if (io_hdr.status && io_hdr.status != SG_CHECK_CONDITION) {
@@ -616,18 +611,16 @@ fu_ata_device_command(FuAtaDevice *self,
 	tf->lbah = sb[8 + 11];
 	tf->dev = sb[8 + 12];
 	tf->status = sb[8 + 13];
-	if (g_getenv("FWUPD_ATA_VERBOSE") != NULL) {
-		g_debug("ATA_%u stat=%02x err=%02x nsect=%02x lbal=%02x "
-			"lbam=%02x lbah=%02x dev=%02x",
-			io_hdr.cmd_len,
-			tf->status,
-			tf->error,
-			tf->nsect,
-			tf->lbal,
-			tf->lbam,
-			tf->lbah,
-			tf->dev);
-	}
+	g_debug("ATA_%u stat=%02x err=%02x nsect=%02x lbal=%02x "
+		"lbam=%02x lbah=%02x dev=%02x",
+		io_hdr.cmd_len,
+		tf->status,
+		tf->error,
+		tf->nsect,
+		tf->lbal,
+		tf->lbam,
+		tf->lbah,
+		tf->dev);
 
 	/* io error */
 	if (tf->status & (ATA_STAT_ERR | ATA_STAT_DRQ)) {
@@ -660,8 +653,7 @@ fu_ata_device_setup(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to IDENTIFY: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_ATA_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "IDENTIFY", id, sizeof(id));
+	fu_dump_raw(G_LOG_DOMAIN, "IDENTIFY", id, sizeof(id));
 	if (!fu_ata_device_parse_id(self, id, sizeof(id), error))
 		return FALSE;
 

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -386,6 +386,8 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 				   GError **error)
 {
 	guint dict_cnt = 0;
+	g_autofree gchar *str_existing = NULL;
+	g_autofree gchar *str_proposed = NULL;
 	g_autoptr(GBytes) fw_old = NULL;
 	g_autoptr(FuFirmware) firmware = fu_bcm57xx_firmware_new();
 	g_autoptr(FuFirmware) firmware_tmp = fu_bcm57xx_firmware_new();
@@ -429,10 +431,8 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to parse existing firmware: ");
 		return NULL;
 	}
-	if (g_getenv("FWUPD_BCM57XX_VERBOSE") != NULL) {
-		g_autofree gchar *str = fu_firmware_to_string(firmware);
-		g_debug("existing device firmware: %s", str);
-	}
+	str_existing = fu_firmware_to_string(firmware);
+	g_info("existing device firmware: %s", str_existing);
 
 	/* merge in all the provided images into the existing firmware */
 	img_stage1 = fu_firmware_get_image_by_id(firmware_tmp, "stage1", NULL);
@@ -454,10 +454,8 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 			dict_cnt++;
 		}
 	}
-	if (g_getenv("FWUPD_BCM57XX_VERBOSE") != NULL) {
-		g_autofree gchar *str = fu_firmware_to_string(firmware);
-		g_debug("proposed device firmware: %s", str);
-	}
+	str_proposed = fu_firmware_to_string(firmware);
+	g_info("proposed device firmware: %s", str_proposed);
 
 	/* success */
 	return g_steal_pointer(&firmware);
@@ -543,7 +541,7 @@ fu_bcm57xx_device_setup(FuDevice *device, GError **error)
 	/* device is in recovery mode */
 	if (self->ethtool_iface == NULL) {
 		g_autoptr(FuDeviceLocker) locker = NULL;
-		g_debug("device in recovery mode, use alternate device");
+		g_info("device in recovery mode, use alternate device");
 		locker = fu_device_locker_new(FU_DEVICE(self->recovery), error);
 		if (locker == NULL)
 			return FALSE;

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -782,8 +782,7 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 		}
 
 		/* mmap */
-		if (g_getenv("FWUPD_BCM57XX_VERBOSE") != NULL)
-			g_debug("mapping BAR[%u] %s for 0x%x bytes", i, fn, (guint)st.st_size);
+		g_debug("mapping BAR[%u] %s for 0x%x bytes", i, fn, (guint)st.st_size);
 		self->bar[i].buf =
 		    (guint8 *)mmap(0, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0);
 		self->bar[i].bufsz = st.st_size;
@@ -820,8 +819,7 @@ fu_bcm57xx_recovery_device_close(FuDevice *device, GError **error)
 	for (guint i = 0; i < FU_BCM57XX_BAR_MAX; i++) {
 		if (self->bar[i].buf == NULL)
 			continue;
-		if (g_getenv("FWUPD_BCM57XX_VERBOSE") != NULL)
-			g_debug("unmapping BAR[%u]", i);
+		g_debug("unmapping BAR[%u]", i);
 		munmap(self->bar[i].buf, self->bar[i].bufsz);
 		self->bar[i].buf = NULL;
 		self->bar[i].bufsz = 0;

--- a/plugins/ccgx/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx/fu-ccgx-dmc-device.c
@@ -101,12 +101,10 @@ fu_ccgx_dmc_device_ensure_status(FuCcgxDmcDevice *self, GError **error)
 			return FALSE;
 		}
 	}
-	if (g_getenv("FWUPD_CCGX_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN,
-			    "DmcDockStatus",
-			    (const guint8 *)&self->dock_status,
-			    sizeof(self->dock_status));
-	}
+	fu_dump_raw(G_LOG_DOMAIN,
+		    "DmcDockStatus",
+		    (const guint8 *)&self->dock_status,
+		    sizeof(self->dock_status));
 
 	/* add devx children */
 	for (guint i = 0; i < self->dock_status.device_count; i++) {
@@ -686,7 +684,7 @@ fu_ccgx_dmc_device_ensure_factory_version(FuCcgxDmcDevice *self)
 		guint64 fwver_img1 = fu_memread_uint64(status->fw_version + 0x08, G_LITTLE_ENDIAN);
 		guint64 fwver_img2 = fu_memread_uint64(status->fw_version + 0x10, G_LITTLE_ENDIAN);
 		if (status->device_type == 0x2 && fwver_img1 == fwver_img2 && fwver_img1 != 0) {
-			g_debug("overriding version as device is in factory mode");
+			g_info("overriding version as device is in factory mode");
 			fu_device_set_version_from_uint32(FU_DEVICE(self), 0x1);
 			return;
 		}

--- a/plugins/ch341a/fu-ch341a-device.c
+++ b/plugins/ch341a/fu-ch341a-device.c
@@ -98,9 +98,7 @@ fu_ch341a_device_write(FuCh341aDevice *self, guint8 *buf, gsize bufsz, GError **
 	gsize actual_length = 0;
 
 	/* debug */
-	if (g_getenv("FWUPD_CH341A_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
-
+	fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
 	if (!g_usb_device_bulk_transfer(usb_device,
 					CH341A_EP_OUT,
 					buf,
@@ -154,8 +152,7 @@ fu_ch341a_device_read(FuCh341aDevice *self, guint8 *buf, gsize bufsz, GError **e
 	}
 
 	/* debug */
-	if (g_getenv("FWUPD_CH341A_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "read", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "read", buf, bufsz);
 
 	/* success */
 	return TRUE;
@@ -204,8 +201,7 @@ fu_ch341a_device_spi_transfer(FuCh341aDevice *self, guint8 *buf, gsize bufsz, GE
 		buf2[i + 1] = fu_ch341a_reverse_uint8(buf[i]);
 
 	/* debug */
-	if (g_getenv("FWUPD_CH341A_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SPIwrite", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "SPIwrite", buf, bufsz);
 	if (!fu_ch341a_device_write(self, buf2, buf2sz, error))
 		return FALSE;
 
@@ -217,8 +213,7 @@ fu_ch341a_device_spi_transfer(FuCh341aDevice *self, guint8 *buf, gsize bufsz, GE
 		buf[i] = fu_ch341a_reverse_uint8(buf[i]);
 
 	/* debug */
-	if (g_getenv("FWUPD_CH341A_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SPIread", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "SPIread", buf, bufsz);
 
 	/* success */
 	return TRUE;

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -96,8 +96,7 @@ fu_colorhug_device_msg(FuColorhugDevice *self,
 	}
 
 	/* request */
-	if (g_getenv("FWUPD_COLORHUG_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "REQ", buf, ibufsz + 1);
+	fu_dump_raw(G_LOG_DOMAIN, "REQ", buf, ibufsz + 1);
 	if (!g_usb_device_interrupt_transfer(usb_device,
 					     CH_USB_HID_EP_OUT,
 					     buf,
@@ -146,8 +145,7 @@ fu_colorhug_device_msg(FuColorhugDevice *self,
 					   "failed to get reply: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_COLORHUG_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "RES", buf, actual_length);
+	fu_dump_raw(G_LOG_DOMAIN, "RES", buf, actual_length);
 
 	/* old bootloaders do not return the full block */
 	if (actual_length != CH_USB_HID_EP_SIZE && actual_length != 2 &&

--- a/plugins/dell-dock/fu-dell-dock-common.c
+++ b/plugins/dell-dock/fu-dell-dock-common.c
@@ -53,9 +53,9 @@ fu_dell_dock_will_replug(FuDevice *device)
 
 	g_return_if_fail(FU_IS_DEVICE(device));
 
-	g_debug("Activated %" G_GUINT64_FORMAT "s replug delay for %s",
-		timeout,
-		fu_device_get_name(device));
+	g_info("activated %" G_GUINT64_FORMAT "s replug delay for %s",
+	       timeout,
+	       fu_device_get_name(device));
 	fu_device_set_remove_delay(device, timeout * 1000);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 }

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -90,7 +90,7 @@ fu_dell_dock_hub_write_fw(FuDevice *device,
 	dynamic_version = g_strdup_printf("%02x.%02x",
 					  data[self->blob_major_offset],
 					  data[self->blob_minor_offset]);
-	g_debug("writing hub firmware version %s", dynamic_version);
+	g_info("writing hub firmware version %s", dynamic_version);
 
 	if (!fu_dell_dock_set_power(device, self->unlock_target, TRUE, error))
 		return FALSE;

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -225,7 +225,7 @@ fu_dell_dock_ec_needs_tbt(FuDevice *device)
 	if (self->data->module_type != MODULE_TYPE_130_TBT &&
 	    self->data->module_type != MODULE_TYPE_45_TBT)
 		return FALSE;
-	g_debug("found thunderbolt dock, port mode: %d", port0_tbt_mode);
+	g_info("found thunderbolt dock, port mode: %d", port0_tbt_mode);
 
 	return !port0_tbt_mode;
 }
@@ -409,10 +409,10 @@ fu_dell_dock_ec_get_dock_info(FuDevice *device, GError **error)
 			    "No bridge devices detected, dock may be booting up");
 		return FALSE;
 	}
-	g_debug("%u devices [%u->%u]",
-		header->total_devices,
-		header->first_index,
-		header->last_index);
+	g_info("%u devices [%u->%u]",
+	       header->total_devices,
+	       header->first_index,
+	       header->last_index);
 	device_entry =
 	    (FuDellDockEcQueryEntry *)((guint8 *)header + sizeof(FuDellDockDockInfoHeader));
 	for (guint i = 0; i < header->total_devices; i++) {
@@ -689,9 +689,9 @@ fu_dell_dock_ec_reboot_dock(FuDevice *device, GError **error)
 
 	g_return_val_if_fail(device != NULL, FALSE);
 
-	g_debug("activating passive flow (%x) for %s",
-		self->passive_flow,
-		fu_device_get_name(device));
+	g_info("activating passive flow (%x) for %s",
+	       self->passive_flow,
+	       fu_device_get_name(device));
 	return fu_dell_dock_ec_write(device, 3, (guint8 *)&cmd, error);
 }
 
@@ -814,7 +814,7 @@ fu_dell_dock_ec_write_fw(FuDevice *device,
 	data = g_bytes_get_data(fw, &fw_size);
 	write_size = (fw_size / HIDI2C_MAX_WRITE) >= 1 ? HIDI2C_MAX_WRITE : fw_size;
 	dynamic_version = g_strndup((gchar *)data + self->blob_version_offset, 11);
-	g_debug("writing EC firmware version %s", dynamic_version);
+	g_info("writing EC firmware version %s", dynamic_version);
 
 	/* meet the minimum EC version */
 	if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0 &&
@@ -830,7 +830,7 @@ fu_dell_dock_ec_write_fw(FuDevice *device,
 		return FALSE;
 	}
 
-	g_debug("writing EC firmware version %s", dynamic_version);
+	g_info("writing EC firmware version %s", dynamic_version);
 	if (!fu_dell_dock_ec_modify_lock(device, self->unlock_target, TRUE, error))
 		return FALSE;
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -1063,7 +1063,7 @@ fu_dell_dock_mst_write_fw(FuDevice *device,
 					  data[self->blob_major_offset],
 					  data[self->blob_minor_offset],
 					  data[self->blob_build_offset]);
-	g_debug("writing MST firmware version %s", dynamic_version);
+	g_info("writing MST firmware version %s", dynamic_version);
 
 	/* enable remote control */
 	if (!fu_dell_dock_mst_enable_remote_control(device, error))

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -75,7 +75,7 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 	dynamic_version = g_strdup_printf("%02x.%02x",
 					  buffer[self->blob_major_offset],
 					  buffer[self->blob_minor_offset]);
-	g_debug("writing Thunderbolt firmware version %s", dynamic_version);
+	g_info("writing Thunderbolt firmware version %s", dynamic_version);
 	g_debug("Total Image size: %" G_GSIZE_FORMAT, image_size);
 
 	memcpy(&start_offset, buffer, sizeof(guint32));
@@ -127,7 +127,7 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
 
 	if (fu_dell_dock_ec_tbt_passive(fu_device_get_parent(device))) {
-		g_debug("using passive flow for Thunderbolt");
+		g_info("using passive flow for Thunderbolt");
 	} else if (!fu_dell_dock_hid_tbt_authenticate(fu_device_get_proxy(device),
 						      &tbt_base_settings,
 						      error)) {

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -188,9 +188,9 @@ fu_dell_dock_plugin_separate_activation(FuPlugin *plugin)
 		    fu_device_has_flag(device_ec, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 			fu_device_remove_flag(FU_DEVICE(device_ec),
 					      FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-			g_debug("activate for %s is inhibited by %s",
-				fu_device_get_name(device_ec),
-				fu_device_get_name(device_usb4));
+			g_info("activate for %s is inhibited by %s",
+			       fu_device_get_name(device_ec),
+			       fu_device_get_name(device_usb4));
 		}
 	}
 }

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -87,7 +87,7 @@ fu_dell_dock_status_write(FuDevice *device,
 			    error))
 		return FALSE;
 	dynamic_version = fu_dell_dock_status_ver_string(status_version);
-	g_debug("writing status firmware version %s", dynamic_version);
+	g_info("writing status firmware version %s", dynamic_version);
 
 	parent = fu_device_get_parent(device);
 	if (!fu_dell_dock_ec_commit_package(parent, fw, error))

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -380,14 +380,12 @@ fu_dell_plugin_backend_device_added(FuPlugin *plugin,
 
 	dock_info = &buf.record->dock_info;
 
-	if (g_getenv("FWUPD_DELL_VERBOSE") != NULL) {
-		g_debug("Dock description: %s", dock_info->dock_description);
-		/* Note: fw package version is deprecated, look at components instead */
-		g_debug("Dock flash pkg ver: 0x%x", dock_info->flash_pkg_version);
-		g_debug("Dock cable type: %" G_GUINT32_FORMAT, dock_info->cable_type);
-		g_debug("Dock location: %d", dock_info->location);
-		g_debug("Dock component count: %d", dock_info->component_count);
-	}
+	g_debug("Dock description: %s", dock_info->dock_description);
+	/* Note: fw package version is deprecated, look at components instead */
+	g_debug("Dock flash pkg ver: 0x%x", dock_info->flash_pkg_version);
+	g_debug("Dock cable type: %" G_GUINT32_FORMAT, dock_info->cable_type);
+	g_debug("Dock location: %d", dock_info->location);
+	g_debug("Dock component count: %d", dock_info->component_count);
 	if (dock_info->flash_pkg_version == 0x00ffffff)
 		g_debug("WARNING: dock flash package version invalid");
 

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -308,14 +308,14 @@ fu_dfu_device_add_targets(FuDfuDevice *self, GError **error)
 			priv->version = priv->force_version;
 		if (priv->version == FU_DFU_FIRMARE_VERSION_DFU_1_0 ||
 		    priv->version == FU_DFU_FIRMARE_VERSION_DFU_1_1) {
-			g_debug("DFU v1.1");
+			g_info("DFU v1.1");
 		} else if (priv->version == FU_DFU_FIRMARE_VERSION_ATMEL_AVR) {
-			g_debug("AVR-DFU support");
+			g_info("AVR-DFU support");
 			priv->version = FU_DFU_FIRMARE_VERSION_ATMEL_AVR;
 		} else if (priv->version == FU_DFU_FIRMARE_VERSION_DFUSE) {
-			g_debug("STM-DFU support");
+			g_info("STM-DFU support");
 		} else if (priv->version == 0x0101) {
-			g_debug("DFU v1.1 assumed");
+			g_info("DFU v1.1 assumed");
 			priv->version = FU_DFU_FIRMARE_VERSION_DFU_1_1;
 		} else {
 			g_warning("DFU version 0x%04x invalid, v1.1 assumed", priv->version);
@@ -780,7 +780,7 @@ fu_dfu_device_refresh(FuDfuDevice *self, GError **error)
 	/* some devices use the wrong state value */
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_FORCE_DFU_MODE) &&
 	    fu_dfu_device_get_state(self) != FU_DFU_STATE_DFU_IDLE) {
-		g_debug("quirking device into DFU mode");
+		g_info("quirking device into DFU mode");
 		fu_dfu_device_set_state(self, FU_DFU_STATE_DFU_IDLE);
 	} else {
 		fu_dfu_device_set_state(self, buf[4]);
@@ -888,7 +888,7 @@ fu_dfu_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 
 	/* do a host reset */
 	if (!fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_WILL_DETACH)) {
-		g_debug("doing device reset as host will not self-reset");
+		g_info("doing device reset as host will not self-reset");
 		if (!fu_dfu_device_reset(self, progress, error))
 			return FALSE;
 	}
@@ -1075,8 +1075,7 @@ fu_dfu_device_open(FuDevice *device, GError **error)
 		    g_usb_device_get_string_descriptor_bytes(usb_device, idx, langid, error);
 		if (serial_blob == NULL)
 			return FALSE;
-		if (g_getenv("FWUPD_DFU_VERBOSE") != NULL)
-			fu_dump_bytes(G_LOG_DOMAIN, "GD32 serial", serial_blob);
+		fu_dump_bytes(G_LOG_DOMAIN, "GD32 serial", serial_blob);
 		buf = g_bytes_get_data(serial_blob, &bufsz);
 		if (bufsz < 2) {
 			g_set_error_literal(error,
@@ -1167,9 +1166,9 @@ fu_dfu_device_probe(FuDevice *device, GError **error)
 
 	/* check capabilities */
 	if (!fu_device_has_private_flag(device, FU_DFU_DEVICE_FLAG_CAN_DOWNLOAD)) {
-		g_debug("%04x:%04x is missing download capability",
-			g_usb_device_get_vid(usb_device),
-			g_usb_device_get_pid(usb_device));
+		g_info("%04x:%04x is missing download capability",
+		       g_usb_device_get_vid(usb_device),
+		       g_usb_device_get_pid(usb_device));
 	}
 
 	/* hardware from Jabra literally reboots if you try to retry a failed
@@ -1250,7 +1249,7 @@ fu_dfu_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 	/* normal DFU mode just needs a bus reset */
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_NO_BUS_RESET_ATTACH) &&
 	    fu_device_has_private_flag(FU_DEVICE(self), FU_DFU_DEVICE_FLAG_WILL_DETACH)) {
-		g_debug("Bus reset is not required. Device will reboot to normal");
+		g_info("bus reset is not required; device will reboot to normal");
 	} else if (!fu_dfu_target_attach(target, progress, error)) {
 		g_prefix_error(error, "failed to attach target: ");
 		return FALSE;

--- a/plugins/dfu/fu-dfu-target-avr.c
+++ b/plugins/dfu/fu-dfu-target-avr.c
@@ -504,8 +504,7 @@ fu_dfu_target_avr_setup(FuDfuTarget *target, GError **error)
 
 	/* get data back */
 	buf = g_bytes_get_data(chunk_sig, &sz);
-	if (g_getenv("FWUPD_DFU_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "AVR:CID", chunk_sig);
+	fu_dump_bytes(G_LOG_DOMAIN, "AVR:CID", chunk_sig);
 	if (sz != 4) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -694,9 +694,7 @@ fu_dfu_target_download_chunk(FuDfuTarget *self,
 	gsize actual_length;
 
 	/* low level packet debugging */
-	if (g_getenv("FWUPD_DFU_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "Message", bytes);
-
+	fu_dump_bytes(G_LOG_DOMAIN, "Message", bytes);
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_CLASS,
@@ -786,8 +784,7 @@ fu_dfu_target_upload_chunk(FuDfuTarget *self,
 	}
 
 	/* low level packet debugging */
-	if (g_getenv("FWUPD_DFU_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Message", buf, actual_length);
+	fu_dump_raw(G_LOG_DOMAIN, "Message", buf, actual_length);
 
 	return g_bytes_new_take(buf, actual_length);
 }

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -73,10 +73,8 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 	}
 
 	/* debug */
-	if (g_getenv("FWUPD_EBITDO_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "->DEVICE", packet, (gsize)hdr->pkt_len + 1);
-		fu_ebitdo_dump_pkt(hdr);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "->DEVICE", packet, (gsize)hdr->pkt_len + 1);
+	fu_ebitdo_dump_pkt(hdr);
 
 	/* get data from device */
 	if (!g_usb_device_interrupt_transfer(usb_device,
@@ -131,10 +129,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 	}
 
 	/* debug */
-	if (g_getenv("FWUPD_EBITDO_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "<-DEVICE", packet, actual_length);
-		fu_ebitdo_dump_pkt(hdr);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "<-DEVICE", packet, actual_length);
+	fu_ebitdo_dump_pkt(hdr);
 
 	/* get-version (bootloader) */
 	if (hdr->type == FU_EBITDO_PKT_TYPE_USER_CMD &&
@@ -525,12 +521,10 @@ fu_ebitdo_device_write_firmware(FuDevice *device,
 	chunks = fu_chunk_array_new_from_bytes(fw_payload, 0x0, 0x0, 32);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
-		if (g_getenv("FWUPD_EBITDO_VERBOSE") != NULL) {
-			g_debug("writing %u bytes to 0x%04x of 0x%04x",
-				fu_chunk_get_data_sz(chk),
-				fu_chunk_get_address(chk),
-				fu_chunk_get_data_sz(chk));
-		}
+		g_debug("writing %u bytes to 0x%04x of 0x%04x",
+			fu_chunk_get_data_sz(chk),
+			fu_chunk_get_address(chk),
+			fu_chunk_get_data_sz(chk));
 		if (!fu_ebitdo_device_send(self,
 					   FU_EBITDO_PKT_TYPE_USER_CMD,
 					   FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA,

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -89,8 +89,7 @@ fu_elantp_hid_device_send_cmd(FuElantpHidDevice *self,
 	g_autofree guint8 *buf = NULL;
 	gsize bufsz = rxsz + 3;
 
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetReport", tx, txsz);
+	fu_dump_raw(G_LOG_DOMAIN, "SetReport", tx, txsz);
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  HIDIOCSFEATURE(txsz),
 				  tx,
@@ -111,8 +110,7 @@ fu_elantp_hid_device_send_cmd(FuElantpHidDevice *self,
 				  FU_ELANTP_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, bufsz);
 
 	/* success */
 	return fu_memcpy_safe(rx,
@@ -760,7 +758,7 @@ fu_elantp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **err
 
 	/* sanity check */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		g_debug("in bootloader mode, reset IC");
+		g_info("in bootloader mode, reset IC");
 		if (!fu_elantp_hid_device_write_cmd(self,
 						    ETP_CMD_I2C_IAP_RESET,
 						    ETP_I2C_IAP_RESET,

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -82,9 +82,7 @@ fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
 	g_autofree guint8 *buf = NULL;
 	gsize bufsz = rxsz + 3;
 
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetReport", tx, txsz);
-
+	fu_dump_raw(G_LOG_DOMAIN, "SetReport", tx, txsz);
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  HIDIOCSFEATURE(txsz),
 				  (guint8 *)tx,
@@ -106,9 +104,7 @@ fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
 				  FU_ELANTP_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, bufsz);
 
 	/* success */
 	return fu_memcpy_safe(rx,

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -134,7 +134,7 @@ fu_elantp_i2c_device_probe(FuDevice *device, GError **error)
 				return FALSE;
 			}
 
-			g_debug("Found I2C bus at %s, using this device",
+			g_debug("found I2C bus at %s, using this device",
 				fu_udev_device_get_sysfs_path(bus_device));
 			self->bind_path =
 			    g_build_filename("/sys/bus/i2c/drivers",
@@ -175,16 +175,14 @@ fu_elantp_i2c_device_send_cmd(FuElantpI2cDevice *self,
 			      gssize rxsz,
 			      GError **error)
 {
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Write", tx, txsz);
+	fu_dump_raw(G_LOG_DOMAIN, "Write", tx, txsz);
 	if (!fu_udev_device_pwrite(FU_UDEV_DEVICE(self), 0, tx, txsz, error))
 		return FALSE;
 	if (rxsz == 0)
 		return TRUE;
 	if (!fu_udev_device_pread(FU_UDEV_DEVICE(self), 0, rx, rxsz, error))
 		return FALSE;
-	if (g_getenv("FWUPD_ELANTP_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Read", rx, rxsz);
+	fu_dump_raw(G_LOG_DOMAIN, "Read", rx, rxsz);
 	return TRUE;
 }
 
@@ -585,7 +583,7 @@ fu_elantp_i2c_device_detach(FuDevice *device, FuProgress *progress, GError **err
 
 	/* sanity check */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		g_debug("in bootloader mode, reset IC");
+		g_info("in bootloader mode, reset IC");
 		if (!fu_elantp_i2c_device_write_cmd(self,
 						    ETP_CMD_I2C_IAP_RESET,
 						    ETP_I2C_IAP_RESET,

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -233,7 +233,7 @@ fu_flashrom_device_write_firmware(FuDevice *device,
 
 	/* Check if CMOS needs a reset */
 	if (fu_device_has_private_flag(device, FU_FLASHROM_DEVICE_FLAG_RESET_CMOS)) {
-		g_debug("Attempting CMOS Reset");
+		g_debug("attempting CMOS reset");
 		if (!fu_flashrom_cmos_reset(error)) {
 			g_prefix_error(error, "failed CMOS reset: ");
 			return FALSE;

--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -49,12 +49,11 @@ fu_flashrom_plugin_debug_cb(enum flashrom_log_level lvl, const char *fmt, va_lis
 		g_warning("%s", str);
 		break;
 	case FLASHROM_MSG_INFO:
-		g_debug("%s", str);
+		g_info("%s", str);
 		break;
 	case FLASHROM_MSG_DEBUG:
 	case FLASHROM_MSG_DEBUG2:
-		if (g_getenv("FWUPD_FLASHROM_VERBOSE") != NULL)
-			g_debug("%s", str);
+		g_debug("%s", str);
 		break;
 	case FLASHROM_MSG_SPEW:
 	default:

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -98,8 +98,7 @@ fu_focalfp_hid_device_io(FuFocalfpHidDevice *self,
 		if (!fu_memcpy_safe(buf, sizeof(buf), 0x04, wbuf, wbufsz, 0x00, wbufsz, error))
 			return FALSE;
 		buf[cmdlen] = fu_focaltp_buffer_generate_checksum(&buf[1], cmdlen - 1);
-		if (g_getenv("FWUPD_FOCALFP_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "SetReport", buf, sizeof(buf));
+		fu_dump_raw(G_LOG_DOMAIN, "SetReport", buf, sizeof(buf));
 		if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 					  HIDIOCSFEATURE(cmdlen + 1),
 					  buf,
@@ -121,8 +120,7 @@ fu_focalfp_hid_device_io(FuFocalfpHidDevice *self,
 					  error)) {
 			return FALSE;
 		}
-		if (g_getenv("FWUPD_FOCALFP_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, sizeof(buf));
+		fu_dump_raw(G_LOG_DOMAIN, "GetReport", buf, sizeof(buf));
 		if (!fu_memcpy_safe(rbuf, rbufsz, 0x0, buf, sizeof(buf), 0x00, rbufsz, error))
 			return FALSE;
 	}

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -39,8 +39,7 @@ fu_fresco_pd_device_transfer_read(FuFrescoPdDevice *self,
 	g_return_val_if_fail(bufsz != 0, FALSE);
 
 	/* to device */
-	if (g_getenv("FWUPD_FRESCO_PD_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "read", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "read", buf, bufsz);
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -85,8 +84,7 @@ fu_fresco_pd_device_transfer_write(FuFrescoPdDevice *self,
 	g_return_val_if_fail(bufsz != 0, FALSE);
 
 	/* to device */
-	if (g_getenv("FWUPD_FRESCO_PD_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1564,12 +1564,10 @@ fu_genesys_scaler_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	if (memcmp(self->public_key.N, "N = ", 4) != 0 ||
 	    memcmp(self->public_key.E, "E = ", 4) != 0) {
-		if (g_getenv("FWUPD_GENESYS_SCALER_VERBOSE") != NULL) {
-			fu_dump_raw(G_LOG_DOMAIN,
-				    "PublicKey",
-				    (const guint8 *)&self->public_key,
-				    sizeof(self->public_key));
-		}
+		fu_dump_raw(G_LOG_DOMAIN,
+			    "PublicKey",
+			    (const guint8 *)&self->public_key,
+			    sizeof(self->public_key));
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_SIGNATURE_INVALID,
@@ -1715,12 +1713,10 @@ fu_genesys_scaler_device_prepare_firmware(FuDevice *device,
 	    fu_firmware_get_image_by_id_bytes(firmware, FU_FIRMWARE_ID_SIGNATURE, error);
 	if (blob_public_key == NULL)
 		return NULL;
-	if (g_getenv("FWUPD_GENESYS_SCALER_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN,
-			    "PublicKey",
-			    g_bytes_get_data(blob_public_key, NULL),
-			    g_bytes_get_size(blob_public_key));
-	}
+	fu_dump_raw(G_LOG_DOMAIN,
+		    "PublicKey",
+		    g_bytes_get_data(blob_public_key, NULL),
+		    g_bytes_get_size(blob_public_key));
 	if (memcmp(g_bytes_get_data(blob_public_key, NULL),
 		   &self->public_key,
 		   sizeof(self->public_key)) != 0 &&

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -66,14 +66,7 @@ goodixmoc_device_cmd_send(FuGoodixMocDevice *self,
 		g_prefix_error(error, "failed to req: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_GOODIXFP_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "REQST",
-			     buf->data,
-			     buf->len,
-			     16,
-			     FU_DUMP_FLAGS_SHOW_ADDRESSES);
-	}
+	fu_dump_full(G_LOG_DOMAIN, "REQST", buf->data, buf->len, 16, FU_DUMP_FLAGS_SHOW_ADDRESSES);
 
 	/* send data */
 	if (!g_usb_device_bulk_transfer(usb_device,
@@ -134,14 +127,12 @@ goodixmoc_device_cmd_recv(FuGoodixMocDevice *self,
 		/* receive zero length package */
 		if (actual_len == 0)
 			continue;
-		if (g_getenv("FWUPD_GOODIXFP_VERBOSE") != NULL) {
-			fu_dump_full(G_LOG_DOMAIN,
-				     "REPLY",
-				     reply->data,
-				     actual_len,
-				     16,
-				     FU_DUMP_FLAGS_SHOW_ADDRESSES);
-		}
+		fu_dump_full(G_LOG_DOMAIN,
+			     "REPLY",
+			     reply->data,
+			     actual_len,
+			     16,
+			     FU_DUMP_FLAGS_SHOW_ADDRESSES);
 
 		/* parse package header */
 		if (!fu_memread_uint8_safe(reply->data, reply->len, 0x0, &header_cmd0, error))

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -93,7 +93,7 @@ fu_gpio_device_unassign(FuGpioDevice *self, GError **error)
 {
 	if (self->fd < 0)
 		return TRUE;
-	g_debug("unsetting %s", fu_device_get_logical_id(FU_DEVICE(self)));
+	g_info("unsetting %s", fu_device_get_logical_id(FU_DEVICE(self)));
 	if (!g_close(self->fd, error))
 		return FALSE;
 	self->fd = -1;
@@ -125,10 +125,10 @@ fu_gpio_device_assign_full(FuGpioDevice *self, guint64 line, gboolean value, GEr
 		return FALSE;
 
 	/* slightly weird API, but roll with it */
-	g_debug("setting %s:0x%02x → %i",
-		fu_device_get_logical_id(FU_DEVICE(self)),
-		(guint)line,
-		value);
+	g_info("setting %s:0x%02x → %i",
+	       fu_device_get_logical_id(FU_DEVICE(self)),
+	       (guint)line,
+	       value);
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  GPIO_V2_GET_LINE_IOCTL,
 				  (guint8 *)&req,

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -311,11 +311,9 @@ fu_intel_spi_device_setup(FuDevice *device, GError **error)
 			      : PCH100_REG_FPR0;
 
 	/* dump everything */
-	if (g_getenv("FWUPD_INTEL_SPI_VERBOSE") != NULL) {
-		for (guint i = 0; i < 0xff; i += 4) {
-			guint32 tmp = fu_mmio_read32(self->spibar, i);
-			g_print("SPIBAR[0x%02x] = 0x%x\n", i, tmp);
-		}
+	for (guint i = 0; i < 0xff; i += 4) {
+		guint32 tmp = fu_mmio_read32(self->spibar, i);
+		g_print("SPIBAR[0x%02x] = 0x%x\n", i, tmp);
 	}
 
 	/* read from descriptor */

--- a/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
+++ b/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
@@ -42,7 +42,7 @@ fu_lenovo_thinklmi_plugin_cpu_registered(FuContext *ctx, FuDevice *device)
 		FwupdBiosSetting *attr = fu_context_get_bios_setting(ctx, BIOS_SETTING_SLEEP_MODE);
 
 		if (attr != NULL) {
-			g_debug("Setting %s to read-only", fwupd_bios_setting_get_name(attr));
+			g_debug("setting %s to read-only", fwupd_bios_setting_get_name(attr));
 			fwupd_bios_setting_set_read_only(attr, TRUE);
 		}
 	}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -218,11 +218,7 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 		if ((payload->addr + 0x10) % 0x80 == 0 &&
 		    req->cmd != FU_UNIFYING_BOOTLOADER_CMD_WRITE_SIGNATURE) {
 			guint16 addr_start = payload->addr - (7 * 0x10);
-			if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL) {
-				g_debug("addr flush @ 0x%04x for 0x%04x",
-					payload->addr,
-					addr_start);
-			}
+			g_debug("addr flush @ 0x%04x for 0x%04x", payload->addr, addr_start);
 			if (!fu_logitech_hidpp_bootloader_texas_flash_ram_buffer(self,
 										 addr_start,
 										 error)) {

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -327,9 +327,7 @@ fu_logitech_hidpp_bootloader_request(FuLogitechHidPpBootloader *self,
 		return FALSE;
 
 	/* send request */
-	if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "host->device", buf_request, sizeof(buf_request));
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "host->device", buf_request, sizeof(buf_request));
 	if (usb_device != NULL) {
 		if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 					      0x0,
@@ -356,12 +354,7 @@ fu_logitech_hidpp_bootloader_request(FuLogitechHidPpBootloader *self,
 						     &error_ignore)) {
 			g_debug("ignoring: %s", error_ignore->message);
 		} else {
-			if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL) {
-				fu_dump_raw(G_LOG_DOMAIN,
-					    "device->host",
-					    buf_response,
-					    actual_length);
-			}
+			fu_dump_raw(G_LOG_DOMAIN, "device->host", buf_response, actual_length);
 		}
 		return TRUE;
 	}
@@ -394,9 +387,7 @@ fu_logitech_hidpp_bootloader_request(FuLogitechHidPpBootloader *self,
 		}
 		actual_length = sizeof(buf_response);
 	}
-	if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "device->host", buf_response, actual_length);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "device->host", buf_response, actual_length);
 
 	/* parse response */
 	if ((buf_response[0x00] & 0xf0) != req->cmd) {

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -204,7 +204,7 @@ fu_logitech_hidpp_device_ping(FuLogitechHidPpDevice *self, GError **error)
 	if (priv->device_idx == HIDPP_DEVICE_IDX_UNSET &&
 	    msg->device_id != HIDPP_DEVICE_IDX_UNSET) {
 		priv->device_idx = msg->device_id;
-		g_debug("Device index is %02x", priv->device_idx);
+		g_debug("device index is %02x", priv->device_idx);
 	}
 
 	/* format version in BCD format */
@@ -852,7 +852,7 @@ fu_logitech_hidpp_device_setup(FuDevice *device, GError **error)
 	if (idx != 0x00) {
 		fu_device_add_flag(FU_DEVICE(device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		if (fu_device_get_version(device) == NULL) {
-			g_debug("repairing device in bootloader mode");
+			g_info("repairing device in bootloader mode");
 			fu_device_set_version(FU_DEVICE(device), "MPK00.00_B0000");
 		}
 		/* we do not actually know which protocol when in recovery mode,
@@ -1128,8 +1128,7 @@ fu_logitech_hidpp_device_write_firmware_pkt(FuLogitechHidPpDevice *self,
 				    G_BIG_ENDIAN,
 				    error))
 		return FALSE;
-	if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL)
-		g_debug("packet_cnt=0x%04x", packet_cnt);
+	g_debug("packet_cnt=0x%04x", packet_cnt);
 	if (fu_logitech_hidpp_device_check_status(msg->data[4], &error_local))
 		return TRUE;
 
@@ -1201,8 +1200,7 @@ fu_logitech_hidpp_device_write_firmware(FuDevice *device,
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	for (gsize i = 0; i < sz / 16; i++) {
 		/* send packet and wait for reply */
-		if (g_getenv("FWUPD_LOGITECH_HIDPP_VERBOSE") != NULL)
-			g_debug("send data at addr=0x%04x", (guint)i * 16);
+		g_debug("send data at addr=0x%04x", (guint)i * 16);
 		if (!fu_logitech_hidpp_device_write_firmware_pkt(self,
 								 idx,
 								 cmd,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -187,7 +187,7 @@ fu_logitech_hidpp_runtime_bolt_poll_peripherals(FuDevice *device)
 
 		name = fu_logitech_hidpp_runtime_bolt_query_device_name(self, i, &error_local);
 		if (name == NULL) {
-			g_debug("Can't query paired device name for slot %u", i);
+			g_debug("cannot query paired device name for slot %u", i);
 			continue;
 		}
 

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -243,11 +243,9 @@ fu_logitech_scribe_device_query_data_size(FuLogitechScribeDevice *self,
 	size_query.size = kDefaultUvcGetLenQueryControlSize;
 	size_query.data = size_data;
 
-	if (g_getenv("FWUPD_LOGITECH_SCRIBE_VERBOSE") != NULL) {
-		g_debug("data size query request, unit: 0x%x selector: 0x%x",
-			(guchar)unit_id,
-			(guchar)control_selector);
-	}
+	g_debug("data size query request, unit: 0x%x selector: 0x%x",
+		(guchar)unit_id,
+		(guchar)control_selector);
 
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  UVCIOC_CTRL_QUERY,
@@ -258,16 +256,11 @@ fu_logitech_scribe_device_query_data_size(FuLogitechScribeDevice *self,
 		return FALSE;
 	/* convert the data byte to int */
 	*data_size = size_data[1] << 8 | size_data[0];
-	if (g_getenv("FWUPD_LOGITECH_SCRIBE_VERBOSE") != NULL) {
-		g_debug("data size query response, size: %u unit: 0x%x selector: 0x%x",
-			*data_size,
-			(guchar)unit_id,
-			(guchar)control_selector);
-		fu_dump_raw(G_LOG_DOMAIN,
-			    "UVC_GET_LEN",
-			    size_data,
-			    kDefaultUvcGetLenQueryControlSize);
-	}
+	g_debug("data size query response, size: %u unit: 0x%x selector: 0x%x",
+		*data_size,
+		(guchar)unit_id,
+		(guchar)control_selector);
+	fu_dump_raw(G_LOG_DOMAIN, "UVC_GET_LEN", size_data, kDefaultUvcGetLenQueryControlSize);
 
 	/* success */
 	return TRUE;
@@ -283,13 +276,10 @@ fu_logitech_scribe_device_get_xu_control(FuLogitechScribeDevice *self,
 {
 	struct uvc_xu_control_query control_query;
 
-	if (g_getenv("FWUPD_LOGITECH_SCRIBE_VERBOSE") != NULL) {
-		g_debug("get xu control request, size: %" G_GUINT16_FORMAT
-			" unit: 0x%x selector: 0x%x",
-			data_size,
-			(guchar)unit_id,
-			(guchar)control_selector);
-	}
+	g_debug("get xu control request, size: %" G_GUINT16_FORMAT " unit: 0x%x selector: 0x%x",
+		data_size,
+		(guchar)unit_id,
+		(guchar)control_selector);
 	control_query.unit = unit_id;
 	control_query.selector = control_selector;
 	control_query.query = UVC_GET_CUR;
@@ -302,13 +292,12 @@ fu_logitech_scribe_device_get_xu_control(FuLogitechScribeDevice *self,
 				  FU_LOGITECH_SCRIBE_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-	if (g_getenv("FWUPD_LOGITECH_SCRIBE_VERBOSE") != NULL) {
-		g_debug("received get xu control response, size: %u unit: 0x%x selector: 0x%x",
-			data_size,
-			(guchar)unit_id,
-			(guchar)control_selector);
-		fu_dump_raw(G_LOG_DOMAIN, "UVC_GET_CUR", data, data_size);
-	}
+	g_debug("received get xu control response, size: %u unit: 0x%x selector: 0x%x",
+		data_size,
+		(guchar)unit_id,
+		(guchar)control_selector);
+	fu_dump_raw(G_LOG_DOMAIN, "UVC_GET_CUR", data, data_size);
+
 	/* success */
 	return TRUE;
 }

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -65,15 +65,11 @@ fu_firehose_updater_log_message(const gchar *action, GBytes *msg)
 	gsize msg_size;
 	g_autofree gchar *msg_strsafe = NULL;
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") == NULL)
-		return;
-
 	msg_data = (const gchar *)g_bytes_get_data(msg, &msg_size);
 	if (msg_size > G_MAXINT)
 		return;
 
 	msg_strsafe = fu_strsafe(msg_data, msg_size);
-
 	g_debug("%s: %.*s", action, (gint)msg_size, msg_strsafe);
 }
 

--- a/plugins/modem-manager/fu-mbim-qdu-updater.c
+++ b/plugins/modem-manager/fu-mbim-qdu-updater.c
@@ -54,7 +54,7 @@ fu_mbim_qdu_updater_mbim_device_open_ready(GObject *mbim_device,
 		}
 
 		/* retry */
-		g_debug("error: couldn't open mbim device: %s", ctx->error->message);
+		g_debug("couldn't open mbim device: %s", ctx->error->message);
 		g_clear_error(&ctx->error);
 		fu_mbim_qdu_updater_mbim_device_open_attempt(ctx);
 		return;
@@ -189,7 +189,7 @@ fu_mbim_qdu_updater_caps_query_ready(MbimDevice *device, GAsyncResult *res, gpoi
 	if (!response || !mbim_message_response_get_result(response,
 							   MBIM_MESSAGE_TYPE_COMMAND_DONE,
 							   &ctx->error)) {
-		g_debug("error: operation failed: %s", ctx->error->message);
+		g_debug("operation failed: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
@@ -208,7 +208,7 @@ fu_mbim_qdu_updater_caps_query_ready(MbimDevice *device, GAsyncResult *res, gpoi
 						     &firmware_version,
 						     NULL,
 						     &ctx->error)) {
-		g_debug("error: couldn't parse response message: %s", ctx->error->message);
+		g_debug("couldn't parse response message: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
@@ -280,14 +280,14 @@ fu_mbim_qdu_updater_file_write_ready(MbimDevice *device, GAsyncResult *res, gpoi
 	if (!response || !mbim_message_response_get_result(response,
 							   MBIM_MESSAGE_TYPE_COMMAND_DONE,
 							   &ctx->error)) {
-		g_debug("error: operation failed: %s", ctx->error->message);
+		g_debug("operation failed: %s", ctx->error->message);
 		g_ptr_array_unref(ctx->chunks);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
 
 	if (!mbim_message_qdu_file_write_response_parse(response, &ctx->error)) {
-		g_debug("error: couldn't parse response message: %s", ctx->error->message);
+		g_debug("couldn't parse response message: %s", ctx->error->message);
 		g_ptr_array_unref(ctx->chunks);
 		g_main_loop_quit(ctx->mainloop);
 		return;
@@ -329,7 +329,7 @@ fu_mbim_qdu_updater_file_open_ready(MbimDevice *device, GAsyncResult *res, gpoin
 	if (!response || !mbim_message_response_get_result(response,
 							   MBIM_MESSAGE_TYPE_COMMAND_DONE,
 							   &ctx->error)) {
-		g_debug("error: operation failed: %s", ctx->error->message);
+		g_debug("operation failed: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
@@ -338,7 +338,7 @@ fu_mbim_qdu_updater_file_open_ready(MbimDevice *device, GAsyncResult *res, gpoin
 						       &out_max_transfer_size,
 						       NULL,
 						       &ctx->error)) {
-		g_debug("error: couldn't parse response message: %s", ctx->error->message);
+		g_debug("couldn't parse response message: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
@@ -370,7 +370,7 @@ fu_mbim_qdu_updater_session_ready(MbimDevice *device, GAsyncResult *res, gpointe
 	if (!response || !mbim_message_response_get_result(response,
 							   MBIM_MESSAGE_TYPE_COMMAND_DONE,
 							   &ctx->error)) {
-		g_debug("error: operation failed: %s", ctx->error->message);
+		g_debug("operation failed: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}
@@ -383,7 +383,7 @@ fu_mbim_qdu_updater_session_ready(MbimDevice *device, GAsyncResult *res, gpointe
 							    NULL,
 							    NULL,
 							    &ctx->error)) {
-		g_debug("error: couldn't parse response message: %s", ctx->error->message);
+		g_debug("couldn't parse response message: %s", ctx->error->message);
 		g_main_loop_quit(ctx->mainloop);
 		return;
 	}

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -185,7 +185,7 @@ validate_firmware_update_method(MMModemFirmwareUpdateMethod methods, GError **er
 	methods_str = mm_modem_firmware_update_method_build_string_from_mask(methods);
 	for (guint i = 0; i < G_N_ELEMENTS(supported_combinations); i++) {
 		if (supported_combinations[i] == methods) {
-			g_debug("valid firmware update combination: %s", methods_str);
+			g_info("valid firmware update combination: %s", methods_str);
 			return TRUE;
 		}
 	}
@@ -596,8 +596,7 @@ fu_mm_device_qcdm_cmd(FuMmDevice *self, const guint8 *cmd, gsize cmd_len, GError
 
 	/* command */
 	qcdm_req = g_bytes_new(cmd, cmd_len);
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "writing", qcdm_req);
+	fu_dump_bytes(G_LOG_DOMAIN, "writing", qcdm_req);
 	if (!fu_io_channel_write_bytes(self->io_channel,
 				       qcdm_req,
 				       1500,
@@ -617,8 +616,7 @@ fu_mm_device_qcdm_cmd(FuMmDevice *self, const guint8 *cmd, gsize cmd_len, GError
 		g_prefix_error(error, "failed to read qcdm response: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "read", qcdm_res);
+	fu_dump_bytes(G_LOG_DOMAIN, "read", qcdm_res);
 
 	/* command == response */
 	if (g_bytes_compare(qcdm_res, qcdm_req) != 0) {
@@ -651,8 +649,7 @@ fu_mm_device_at_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 
 	/* command */
 	at_req = g_bytes_new(cmd_cr, strlen(cmd_cr));
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "writing", at_req);
+	fu_dump_bytes(G_LOG_DOMAIN, "writing", at_req);
 	if (!fu_io_channel_write_bytes(self->io_channel,
 				       at_req,
 				       1500,
@@ -664,7 +661,7 @@ fu_mm_device_at_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 
 	/* AT command has no response, return TRUE */
 	if (!helper->has_response) {
-		g_debug("No response expected for AT command: '%s', assuming succeed", helper->cmd);
+		g_debug("no response expected for AT command: '%s', assuming succeed", helper->cmd);
 		return TRUE;
 	}
 
@@ -678,8 +675,7 @@ fu_mm_device_at_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 		g_prefix_error(error, "failed to read response for %s: ", helper->cmd);
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "read", at_res);
+	fu_dump_bytes(G_LOG_DOMAIN, "read", at_res);
 	buf = g_bytes_get_data(at_res, &bufsz);
 	if (bufsz < 6) {
 		g_set_error(error,
@@ -718,7 +714,7 @@ fu_mm_device_at_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 			if (g_strcmp0(parts[j], "") != 0 && g_strcmp0(parts[j], "OK") != 0) {
 				/* Set branch */
 				fu_device_set_branch(FU_DEVICE(self), parts[j]);
-				g_debug("Firmware branch reported as '%s'", parts[j]);
+				g_info("firmware branch reported as '%s'", parts[j]);
 				break;
 			}
 		}
@@ -1800,9 +1796,9 @@ fu_mm_device_setup_branch_at(FuMmDevice *self, GError **error)
 		return FALSE;
 
 	if (fu_device_get_branch(self) != NULL)
-		g_debug("using firmware branch: %s", fu_device_get_branch(self));
+		g_info("using firmware branch: %s", fu_device_get_branch(self));
 	else
-		g_debug("using firmware branch: default");
+		g_info("using firmware branch: default");
 
 	return TRUE;
 }

--- a/plugins/modem-manager/fu-mm-plugin.c
+++ b/plugins/modem-manager/fu-mm-plugin.c
@@ -344,7 +344,7 @@ fu_mm_plugin_setup_manager(FuPlugin *plugin)
 		return;
 	}
 
-	g_debug("ModemManager %s is available", version);
+	g_info("ModemManager %s is available", version);
 
 	g_signal_connect(G_DBUS_OBJECT_MANAGER(self->manager),
 			 "object-added",

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -233,9 +233,7 @@ fu_sahara_loader_qdl_read(FuSaharaLoader *self, GError **error)
 	}
 
 	g_byte_array_set_size(buf, actual_len);
-
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		g_debug("received %" G_GSIZE_FORMAT " bytes", actual_len);
+	g_debug("received %" G_GSIZE_FORMAT " bytes", actual_len);
 
 	return g_steal_pointer(&buf);
 #else
@@ -321,12 +319,10 @@ fu_sahara_loader_write_prog(FuSaharaLoader *self,
 
 	g_return_val_if_fail(offset + length <= sz, FALSE);
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL) {
-		g_debug("SENDING --> RAW_DATA: %u bytes (offset = %u, total = %" G_GSIZE_FORMAT ")",
-			length,
-			offset,
-			sz);
-	}
+	g_debug("SENDING --> RAW_DATA: %u bytes (offset = %u, total = %" G_GSIZE_FORMAT ")",
+		length,
+		offset,
+		sz);
 	return fu_sahara_loader_qdl_write(self, &data[offset], length, error);
 }
 
@@ -338,8 +334,7 @@ fu_sahara_loader_send_packet(FuSaharaLoader *self, GByteArray *pkt, GError **err
 
 	g_return_val_if_fail(pkt != NULL, FALSE);
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "tx packet", pkt->data, pkt->len);
+	fu_dump_raw(G_LOG_DOMAIN, "tx packet", pkt->data, pkt->len);
 	return fu_sahara_loader_qdl_write(self, data, sz, error);
 }
 
@@ -429,8 +424,7 @@ fu_sahara_loader_send_reset_packet(FuSaharaLoader *self, GError **error)
 		return FALSE;
 	}
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		g_debug("reset succeeded");
+	g_debug("reset succeeded");
 	return TRUE;
 }
 
@@ -451,8 +445,7 @@ fu_sahara_loader_wait_hello_rsp(FuSaharaLoader *self, GError **error)
 
 	g_return_val_if_fail(rx_packet != NULL, FALSE);
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "rx packet", rx_packet->data, rx_packet->len);
+	fu_dump_raw(G_LOG_DOMAIN, "rx packet", rx_packet->data, rx_packet->len);
 
 	if (sahara_packet_get_command_id(rx_packet) != SAHARA_HELLO_ID) {
 		g_set_error(error,
@@ -474,8 +467,7 @@ fu_sahara_loader_run(FuSaharaLoader *self, GBytes *prog, GError **error)
 {
 	g_return_val_if_fail(prog != NULL, FALSE);
 
-	if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-		g_debug("STATE -- SAHARA_WAIT_HELLO");
+	g_debug("STATE -- SAHARA_WAIT_HELLO");
 	if (!fu_sahara_loader_wait_hello_rsp(self, error))
 		return FALSE;
 
@@ -486,8 +478,7 @@ fu_sahara_loader_run(FuSaharaLoader *self, GBytes *prog, GError **error)
 		g_autoptr(GByteArray) tx_packet = NULL;
 		g_autoptr(GError) error_local = NULL;
 
-		if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
-			g_debug("STATE -- SAHARA_WAIT_COMMAND");
+		g_debug("STATE -- SAHARA_WAIT_COMMAND");
 		rx_packet = fu_sahara_loader_qdl_read(self, error);
 		if (rx_packet == NULL)
 			break;
@@ -498,10 +489,7 @@ fu_sahara_loader_run(FuSaharaLoader *self, GBytes *prog, GError **error)
 				    "Received packet length is not matching");
 			break;
 		}
-
-		if (g_getenv("FWUPD_MODEM_MANAGER_VERBOSE") != NULL) {
-			fu_dump_raw(G_LOG_DOMAIN, "rx_packet", rx_packet->data, rx_packet->len);
-		}
+		fu_dump_raw(G_LOG_DOMAIN, "rx_packet", rx_packet->data, rx_packet->len);
 
 		command_id = sahara_packet_get_command_id(rx_packet);
 		pkt = (struct sahara_packet *)(rx_packet->data);

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -415,7 +415,7 @@ fu_msr_plugin_safe_kernel_for_sme(FuPlugin *plugin, GError **error)
 	g_autofree gchar *min = fu_plugin_get_config_value(plugin, "MinimumSmeKernelVersion");
 
 	if (min == NULL) {
-		g_debug("Ignoring kernel safety checks");
+		g_debug("ignoring kernel safety checks");
 		return TRUE;
 	}
 	return fu_kernel_check_version(min, error);
@@ -475,7 +475,7 @@ fu_plugin_add_security_attr_amd_sme_enabled(FuPlugin *plugin, FuSecurityAttrs *a
 	}
 
 	if (!fu_msr_plugin_safe_kernel_for_sme(plugin, &error_local)) {
-		g_debug("Unable to properly detect SME: %s", error_local->message);
+		g_debug("unable to properly detect SME: %s", error_local->message);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_UNKNOWN);
 		return;
 	}

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -133,8 +133,7 @@ fu_nitrokey_device_setup(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to do get firmware version: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_NITROKEY_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "payload", buf_reply, sizeof(buf_reply));
+	fu_dump_raw(G_LOG_DOMAIN, "payload", buf_reply, sizeof(buf_reply));
 	memcpy(&payload, buf_reply, sizeof(payload));
 	version = g_strdup_printf("%u.%u", payload.VersionMajor, payload.VersionMinor);
 	fu_device_set_version(FU_DEVICE(device), version);

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -154,8 +154,7 @@ fu_nordic_hid_cfg_channel_send(FuNordicHidCfgChannel *self,
 	FuUdevDevice *udev_device = fu_nordic_hid_cfg_channel_get_udev_device(self, error);
 	if (udev_device == NULL)
 		return FALSE;
-	if (g_getenv("FWUPD_NORDIC_HID_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Sent", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "Sent", buf, bufsz);
 	if (!fu_udev_device_ioctl(udev_device,
 				  HIDIOCSFEATURE(bufsz),
 				  buf,
@@ -212,8 +211,7 @@ fu_nordic_hid_cfg_channel_receive(FuNordicHidCfgChannel *self,
 		return FALSE;
 	}
 
-	if (g_getenv("FWUPD_NORDIC_HID_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Received", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "Received", buf, bufsz);
 	/*
 	 * [TODO]: Possibly add the report-id fix for Bluez versions < 5.56:
 	 * https://github.com/bluez/bluez/commit/35a2c50437cca4d26ac6537ce3a964bb509c9b62
@@ -460,8 +458,7 @@ fu_nordic_hid_cfg_channel_add_peers(FuNordicHidCfgChannel *self, GError **error)
 		if (res->data[8] == INVALID_PEER_ID)
 			return TRUE;
 
-		if (g_getenv("FWUPD_NORDIC_HID_VERBOSE") != NULL)
-			g_debug("detected peer: 0x%02x", res->data[8]);
+		g_debug("detected peer: 0x%02x", res->data[8]);
 
 		peer = fu_nordic_hid_cfg_channel_new(res->data[8]);
 		/* prohibit to close parent's communication descriptor */
@@ -528,8 +525,8 @@ fu_nordic_hid_cfg_channel_get_bl_name(FuNordicHidCfgChannel *self, GError **erro
 			return FALSE;
 		}
 		self->bl_name = fu_strsafe((const gchar *)res->data, res->data_len);
-	} else if (g_getenv("FWUPD_NORDIC_HID_VERBOSE") != NULL) {
-		g_debug("the board have no support of bootloader runtime detection");
+	} else {
+		g_debug("the board has no support of bootloader runtime detection");
 	}
 
 	if (self->bl_name == NULL) {

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -235,8 +235,7 @@ fu_nvme_device_parse_cns(FuNvmeDevice *self, const guint8 *buf, gsize sz, GError
 	fawr = (buf[260] & 0x10) >> 4;
 	nfws = (buf[260] & 0x0e) >> 1;
 	s1ro = buf[260] & 0x01;
-	if (g_getenv("FWUPD_NVME_VERBOSE") != NULL)
-		g_debug("fawr: %u, nr fw slots: %u, slot1 r/o: %u", fawr, nfws, s1ro);
+	g_debug("fawr: %u, nr fw slots: %u, slot1 r/o: %u", fawr, nfws, s1ro);
 
 	/* FRU globally unique identifier (FGUID) */
 	gu = fu_nvme_device_get_guid_safe(buf, 127);
@@ -254,20 +253,6 @@ fu_nvme_device_parse_cns(FuNvmeDevice *self, const guint8 *buf, gsize sz, GError
 		fu_device_add_instance_id(FU_DEVICE(self), mn);
 	}
 	return TRUE;
-}
-
-static void
-fu_nvme_device_dump(const gchar *title, const guint8 *buf, gsize sz)
-{
-	if (g_getenv("FWUPD_NVME_VERBOSE") == NULL)
-		return;
-	g_print("%s (%" G_GSIZE_FORMAT "):", title, sz);
-	for (gsize i = 0; i < sz; i++) {
-		if (i % 64 == 0)
-			g_print("\naddr 0x%04x: ", (guint)i);
-		g_print("%02x", buf[i]);
-	}
-	g_print("\n");
 }
 
 /*
@@ -344,7 +329,7 @@ fu_nvme_device_setup(FuDevice *device, GError **error)
 			       fu_device_get_physical_id(FU_DEVICE(self)));
 		return FALSE;
 	}
-	fu_nvme_device_dump("CNS", buf, sizeof(buf));
+	fu_dump_raw(G_LOG_DOMAIN, "CNS", buf, sizeof(buf));
 	if (!fu_nvme_device_parse_cns(self, buf, sizeof(buf), error))
 		return FALSE;
 

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -542,7 +542,7 @@ fu_parade_lspcon_device_reload(FuDevice *device, GError **error)
 	/* determine active partition for flashing later */
 	if (!fu_parade_lspcon_probe_active_flash_partition(self, &self->active_partition, error))
 		return FALSE;
-	g_debug("device reports running from partition %d", self->active_partition);
+	g_info("device reports running from partition %d", self->active_partition);
 	if (self->active_partition < 1 || self->active_partition > 3) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/pci-bcr/fu-pci-bcr-plugin.c
+++ b/plugins/pci-bcr/fu-pci-bcr-plugin.c
@@ -49,7 +49,7 @@ fu_pci_bcr_plugin_device_registered(FuPlugin *plugin, FuDevice *dev)
 	    g_strcmp0(fu_device_get_plugin(dev), "flashrom") == 0) {
 		guint tmp = fu_device_get_metadata_integer(dev, "PciBcrAddr");
 		if (tmp != G_MAXUINT && self->bcr_addr != tmp) {
-			g_debug("overriding BCR addr from 0x%02x to 0x%02x", self->bcr_addr, tmp);
+			g_info("overriding BCR addr from 0x%02x to 0x%02x", self->bcr_addr, tmp);
 			self->bcr_addr = tmp;
 		}
 	}

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -147,13 +147,11 @@ fu_mei_parse_fwvers(FuPlugin *plugin, const gchar *fwvers, GError **error)
 		self->issue = fu_mei_common_is_txe_vulnerable(&self->vers);
 	else if (self->family == FU_MEI_FAMILY_SPS)
 		self->issue = fu_mei_common_is_sps_vulnerable(&self->vers);
-	if (g_getenv("FWUPD_MEI_VERBOSE") != NULL) {
-		g_debug("%s version parsed as %u.%u.%u",
-			fu_mei_common_family_to_string(self->family),
-			self->vers.major,
-			self->vers.minor,
-			self->vers.hotfix);
-	}
+	g_debug("%s version parsed as %u.%u.%u",
+		fu_mei_common_family_to_string(self->family),
+		self->vers.major,
+		self->vers.minor,
+		self->vers.hotfix);
 	return TRUE;
 }
 

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -137,9 +137,7 @@ static gboolean
 fu_pxi_ble_device_set_feature(FuPxiBleDevice *self, GByteArray *req, GError **error)
 {
 #ifdef HAVE_HIDRAW_H
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "SetFeature", req->data, req->len);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "SetFeature", req->data, req->len);
 	return fu_device_retry(FU_DEVICE(self),
 			       fu_pxi_ble_device_set_feature_cb,
 			       FU_PXI_BLE_DEVICE_SET_REPORT_RETRIES,
@@ -166,8 +164,7 @@ fu_pxi_ble_device_get_feature(FuPxiBleDevice *self, guint8 *buf, guint bufsz, GE
 				  error)) {
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
 
 	/* prepend the report-id and cmd for versions of bluez that do not have
 	 * https://github.com/bluez/bluez/commit/35a2c50437cca4d26ac6537ce3a964bb509c9b62 */
@@ -196,9 +193,7 @@ fu_pxi_ble_device_search_hid_usage_page(guint8 *report_descriptor,
 {
 	gint pos = 0;
 
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "target usage_page", usage_page, usage_page_sz);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "target usage_page", usage_page, usage_page_sz);
 
 	while (pos < size) {
 		/* HID info define by HID specification */
@@ -216,11 +211,9 @@ fu_pxi_ble_device_search_hid_usage_page(guint8 *report_descriptor,
 
 		memmove(usage_page_tmp, &report_descriptor[pos + 1], report_size);
 		if (memcmp(usage_page, usage_page_tmp, usage_page_sz) == 0) {
-			if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-				g_debug("hit item: %x  ", item);
-				fu_dump_raw(G_LOG_DOMAIN, "usage_page", usage_page, report_size);
-				g_debug("hit pos %d", pos);
-			}
+			g_debug("hit item: %x  ", item);
+			fu_dump_raw(G_LOG_DOMAIN, "usage_page", usage_page, report_size);
+			g_debug("hit pos %d", pos);
 			return TRUE; /* finished processing */
 		}
 		pos += report_size + 1;
@@ -255,8 +248,7 @@ fu_pxi_ble_device_check_support_report_id(FuPxiBleDevice *self, GError **error)
 				  FU_PXI_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "HID descriptor", rpt_desc.value, rpt_desc.size);
+	fu_dump_raw(G_LOG_DOMAIN, "HID descriptor", rpt_desc.value, rpt_desc.size);
 
 	/* check ota retransmit feature report usage page exist or not */
 	fu_byte_array_append_uint16(req, PXI_HID_DEV_OTA_RETRANSMIT_USAGE_PAGE, G_LITTLE_ENDIAN);
@@ -616,8 +608,7 @@ fu_pxi_ble_device_fw_upgrade(FuPxiBleDevice *self,
 	if (!fu_pxi_ble_device_set_feature(self, req, error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "fw upgrade", req->data, req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "fw upgrade", req->data, req->len);
 
 	/* wait fw upgrade command result */
 	if (!fu_pxi_ble_device_wait_notify(self, 0x1, &opcode, NULL, error)) {

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -94,9 +94,7 @@ fu_pxi_firmware_parse(FuFirmware *firmware,
 		g_prefix_error(error, "failed to read fw header: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "fw header", fw_header, sizeof(fw_header));
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "fw header", fw_header, sizeof(fw_header));
 
 	/* set fw version */
 	version_raw = (((guint32)(fw_header[0] - '0')) << 16) +

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -61,8 +61,7 @@ fu_pxi_receiver_device_set_feature(FuPxiReceiverDevice *self,
 				   GError **error)
 {
 #ifdef HAVE_HIDRAW_H
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetFeature", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "SetFeature", buf, bufsz);
 	return fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				    HIDIOCSFEATURE(bufsz),
 				    (guint8 *)buf,
@@ -93,8 +92,7 @@ fu_pxi_receiver_device_get_feature(FuPxiReceiverDevice *self,
 				  error)) {
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
 	return TRUE;
 #else
 	g_set_error_literal(error,
@@ -461,8 +459,7 @@ fu_pxi_receiver_device_fw_upgrade(FuDevice *device,
 		return FALSE;
 
 	g_byte_array_append(ota_cmd, fw_version, sizeof(fw_version));
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "ota_cmd ", ota_cmd->data, ota_cmd->len);
+	fu_dump_raw(G_LOG_DOMAIN, "ota_cmd ", ota_cmd->data, ota_cmd->len);
 	self->sn++;
 
 	/* get pixart wireless module ota command */
@@ -610,6 +607,7 @@ fu_pxi_receiver_device_get_peripheral_info(FuPxiReceiverDevice *device,
 {
 	guint8 buf[FU_PXI_RECEIVER_DEVICE_OTA_BUF_SZ] = {0x0};
 	guint16 checksum = 0;
+	g_autofree gchar *version_str = NULL;
 	g_autoptr(GByteArray) ota_cmd = g_byte_array_new();
 	g_autoptr(GByteArray) receiver_device_cmd = g_byte_array_new();
 
@@ -636,8 +634,7 @@ fu_pxi_receiver_device_get_peripheral_info(FuPxiReceiverDevice *device,
 	if (!fu_pxi_receiver_device_get_feature(device, buf, sizeof(buf), error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "model_info", buf, sizeof(buf));
+	fu_dump_raw(G_LOG_DOMAIN, "model_info", buf, sizeof(buf));
 
 	if (!fu_memread_uint8_safe(buf, sizeof(buf), 0x9, &model->status, error))
 		return FALSE;
@@ -668,16 +665,13 @@ fu_pxi_receiver_device_get_peripheral_info(FuPxiReceiverDevice *device,
 		return FALSE;
 
 	if (!fu_memread_uint16_safe(buf, sizeof(buf), 0x1D, &checksum, G_LITTLE_ENDIAN, error))
-
 		return FALSE;
 
 	/* set current version and model name */
 	model->checksum = checksum;
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-		g_autofree gchar *version_str = g_strndup((gchar *)model->version, 5);
-		g_debug("checksum %x", model->checksum);
-		g_debug("version_str %s", version_str);
-	}
+	g_debug("checksum %x", model->checksum);
+	version_str = g_strndup((gchar *)model->version, 5);
+	g_debug("version_str %s", version_str);
 
 	return TRUE;
 }
@@ -716,9 +710,7 @@ fu_pxi_receiver_device_get_peripheral_num(FuPxiReceiverDevice *device,
 	buf[0] = PXI_HID_WIRELESS_DEV_OTA_REPORT_ID;
 	if (!fu_pxi_receiver_device_get_feature(device, buf, sizeof(buf), error))
 		return FALSE;
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL) {
-		fu_dump_raw(G_LOG_DOMAIN, "buf from get model num", buf, sizeof(buf));
-	}
+	fu_dump_raw(G_LOG_DOMAIN, "buf from get model num", buf, sizeof(buf));
 	if (!fu_memread_uint8_safe(buf, sizeof(buf), 0xA, num_of_models, error))
 		return FALSE;
 
@@ -823,8 +815,7 @@ fu_pxi_receiver_device_check_peripherals(FuPxiReceiverDevice *device, GError **e
 	/* add wireless peripherals */
 	if (!fu_pxi_receiver_device_get_peripheral_num(device, &num, error))
 		return FALSE;
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		g_debug("peripheral num: %u", num);
+	g_debug("peripheral num: %u", num);
 	for (guint8 idx = 0; idx < num; idx++) {
 		if (!fu_pxi_receiver_device_add_peripherals(device, idx, error))
 			return FALSE;

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -43,8 +43,7 @@ static gboolean
 fu_pxi_wireless_device_set_feature(FuDevice *self, const guint8 *buf, guint bufsz, GError **error)
 {
 #ifdef HAVE_HIDRAW_H
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetFeature", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "SetFeature", buf, bufsz);
 	return fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				    HIDIOCSFEATURE(bufsz),
 				    (guint8 *)buf,
@@ -72,8 +71,7 @@ fu_pxi_wireless_device_get_feature(FuDevice *self, guint8 *buf, guint bufsz, GEr
 				  error)) {
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "GetFeature", buf, bufsz);
 	return TRUE;
 #else
 	g_set_error_literal(error,
@@ -187,8 +185,7 @@ fu_pxi_wireless_device_check_crc(FuDevice *device, guint16 checksum, GError **er
 	if (!fu_pxi_wireless_device_get_cmd_response(self, buf, sizeof(buf), error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_PIXART_RF_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "crc buf", buf, sizeof(buf));
+	fu_dump_raw(G_LOG_DOMAIN, "crc buf", buf, sizeof(buf));
 
 	if (!fu_memread_uint8_safe(buf, sizeof(buf), 0x5, &status, error))
 		return FALSE;

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -159,7 +159,7 @@ locate_i2c_bus(const GPtrArray *i2c_devices)
 		}
 
 		bus_device = g_object_ref(g_ptr_array_index(i2c_buses, 0));
-		g_debug("Found I2C bus at %s, using this device",
+		g_debug("found I2C bus at %s, using this device",
 			fu_udev_device_get_sysfs_path(bus_device));
 		return bus_device;
 	}
@@ -188,7 +188,7 @@ fu_realtek_mst_device_use_aux_dev(FuRealtekMstDevice *self, GError **error)
 
 		device = fu_udev_device_new(fu_device_get_context(FU_DEVICE(self)), element->data);
 		if (bus_device != NULL) {
-			g_debug("Ignoring additional aux device %s",
+			g_debug("ignoring additional aux device %s",
 				fu_udev_device_get_sysfs_path(device));
 			continue;
 		}
@@ -230,7 +230,7 @@ fu_realtek_mst_device_use_drm_card(FuRealtekMstDevice *self, GError **error)
 		drm_device =
 		    fu_udev_device_new(fu_device_get_context(FU_DEVICE(self)), element->data);
 		if (bus_device != NULL) {
-			g_debug("Ignoring additional drm device %s",
+			g_debug("ignoring additional drm device %s",
 				fu_udev_device_get_sysfs_path(drm_device));
 			continue;
 		}
@@ -510,15 +510,15 @@ fu_realtek_mst_device_probe_version(FuDevice *device, GError **error)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_uninhibit(device, "dual-bank");
 
-	g_debug("device is currently running from bank %u", info.active_bank);
+	g_info("device is currently running from bank %u", info.active_bank);
 	g_return_val_if_fail(info.active_bank <= FLASH_BANK_MAX_VALUE, FALSE);
 	self->active_bank = info.active_bank;
 
-	g_debug("firmware version reports user1 %d.%d, user2 %d.%d",
-		info.user1_version[0],
-		info.user1_version[1],
-		info.user2_version[0],
-		info.user2_version[1]);
+	g_info("firmware version reports user1 %d.%d, user2 %d.%d",
+	       info.user1_version[0],
+	       info.user1_version[1],
+	       info.user2_version[0],
+	       info.user2_version[1]);
 	if (info.active_bank == FLASH_BANK_USER1)
 		active_version = info.user1_version;
 	else if (info.active_bank == FLASH_BANK_USER2)

--- a/plugins/redfish/fu-ipmi-device.c
+++ b/plugins/redfish/fu-ipmi-device.c
@@ -100,8 +100,7 @@ fu_ipmi_device_send(FuIpmiDevice *self,
 	    .msg.netfn = netfn,
 	    .msg.cmd = cmd,
 	};
-	if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL && buf2 != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "ipmi-send", buf2, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "ipmi-send", buf2, bufsz);
 	return fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				    IPMICTL_SEND_COMMAND,
 				    (guint8 *)&req,
@@ -134,8 +133,7 @@ fu_ipmi_device_recv(FuIpmiDevice *self,
 				  FU_IPMI_DEVICE_IOCTL_TIMEOUT,
 				  error))
 		return FALSE;
-	if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL && buf != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "ipmi-recv", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "ipmi-recv", buf, bufsz);
 	if (netfn != NULL)
 		*netfn = recv.msg.netfn;
 	if (cmd != NULL)
@@ -373,13 +371,11 @@ fu_ipmi_device_transaction_cb(FuDevice *device, gpointer user_data, GError **err
 			}
 			if (helper->resp_len != NULL)
 				*helper->resp_len = resp_len2 - 1;
-			if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL) {
-				g_debug("IPMI netfn: %02x->%02x, cmd: %02x->%02x",
-					helper->netfn,
-					resp_netfn,
-					helper->cmd,
-					resp_cmd);
-			}
+			g_debug("IPMI netfn: %02x->%02x, cmd: %02x->%02x",
+				helper->netfn,
+				resp_netfn,
+				helper->cmd,
+				resp_cmd);
 			break;
 		}
 	}

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -82,8 +82,7 @@ fu_redfish_multipart_device_write_firmware(FuDevice *device,
 	curl_mime_name(part, "UpdateParameters");
 	(void)curl_mime_type(part, "application/json");
 	(void)curl_mime_data(part, params->str, CURL_ZERO_TERMINATED);
-	if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL)
-		g_debug("request: %s", params->str);
+	g_debug("request: %s", params->str);
 
 	part = curl_mime_addpart(mime);
 	curl_mime_name(part, "UpdateFile");

--- a/plugins/redfish/fu-redfish-network-device.c
+++ b/plugins/redfish/fu-redfish-network-device.c
@@ -121,12 +121,10 @@ fu_redfish_network_device_connect(FuRedfishNetworkDevice *self, GError **error)
 		FuRedfishNetworkDeviceState state = FU_REDFISH_NETWORK_DEVICE_STATE_UNKNOWN;
 		if (!fu_redfish_network_device_get_state(self, &state, error))
 			return FALSE;
-		if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL) {
-			g_debug("%s device state is now %s [%u]",
-				self->object_path,
-				fu_redfish_network_device_state_to_string(state),
-				state);
-		}
+		g_debug("%s device state is now %s [%u]",
+			self->object_path,
+			fu_redfish_network_device_state_to_string(state),
+			state);
 		if (state == FU_REDFISH_NETWORK_DEVICE_STATE_ACTIVATED)
 			return TRUE;
 		g_usleep(50 * 1000);

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -49,8 +49,7 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 		mac_addr = g_variant_get_string(hw_address, NULL);
 
 		/* verify */
-		if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL)
-			g_debug("mac_addr=%s", mac_addr);
+		g_debug("mac_addr=%s", mac_addr);
 		if (g_strcmp0(mac_addr, helper->mac_addr) == 0)
 			helper->device = fu_redfish_network_device_new(object_path);
 	}
@@ -84,8 +83,7 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 			pid = g_ascii_strtoull(tmp, NULL, 16);
 
 		/* verify */
-		if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL)
-			g_debug("%s: 0x%04x, 0x%04x", sysfs_path, vid, pid);
+		g_debug("%s: 0x%04x, 0x%04x", sysfs_path, vid, pid);
 		if (vid == helper->vid && pid == helper->pid)
 			helper->device = fu_redfish_network_device_new(object_path);
 #else
@@ -157,8 +155,7 @@ fu_redfish_network_device_match(FuRedfishNetworkMatchHelper *helper, GError **er
 	/* look at each device */
 	g_variant_get(devices, "(^ao)", &paths);
 	for (guint i = 0; paths[i] != NULL; i++) {
-		if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL)
-			g_debug("device %u: %s", i, paths[i]);
+		g_debug("device %u: %s", i, paths[i]);
 		if (!fu_redfish_network_device_match_device(helper, paths[i], error))
 			return FALSE;
 		if (helper->device != NULL)

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -263,11 +263,9 @@ fu_redfish_plugin_autoconnect_network_device(FuRedfishPlugin *self, GError **err
 		FuRedfishNetworkDeviceState state = FU_REDFISH_NETWORK_DEVICE_STATE_UNKNOWN;
 		if (!fu_redfish_network_device_get_state(device, &state, error))
 			return FALSE;
-		if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL) {
-			g_debug("device state is now %s [%u]",
-				fu_redfish_network_device_state_to_string(state),
-				state);
-		}
+		g_info("device state is now %s [%u]",
+		       fu_redfish_network_device_state_to_string(state),
+		       state);
 		if (state == FU_REDFISH_NETWORK_DEVICE_STATE_DISCONNECTED) {
 			if (!fu_redfish_network_device_connect(device, error))
 				return FALSE;
@@ -463,7 +461,7 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 			return FALSE;
 		}
 		if (!fu_plugin_get_config_value_boolean(plugin, "IpmiDisableCreateUser")) {
-			g_debug("attempting to create user using IPMI");
+			g_info("attempting to create user using IPMI");
 			if (!fu_redfish_plugin_ipmi_create_user(plugin, error))
 				return FALSE;
 		}

--- a/plugins/redfish/fu-redfish-smc-device.c
+++ b/plugins/redfish/fu-redfish-smc-device.c
@@ -165,8 +165,7 @@ fu_redfish_smc_device_write_firmware(FuDevice *device,
 	curl_mime_name(part, "UpdateParameters");
 	(void)curl_mime_type(part, "application/json");
 	(void)curl_mime_data(part, params->str, CURL_ZERO_TERMINATED);
-	if (g_getenv("FWUPD_REDFISH_VERBOSE") != NULL)
-		g_debug("request: %s", params->str);
+	g_debug("request: %s", params->str);
 
 	part = curl_mime_addpart(mime);
 	curl_mime_name(part, "UpdateFile");

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -86,8 +86,8 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 		guint64 ufs_features = 0;
 
 		/* check if this is a UFS device */
-		g_debug("found ufshci controller at %s",
-			fu_udev_device_get_sysfs_path(ufshci_parent));
+		g_info("found ufshci controller at %s",
+		       fu_udev_device_get_sysfs_path(ufshci_parent));
 		if (fu_udev_device_get_sysfs_attr_uint64(ufshci_parent,
 							 "device_descriptor/ufs_features",
 							 &ufs_features,
@@ -205,8 +205,7 @@ fu_scsi_device_send_scsi_cmd_v3(FuScsiDevice *self,
 	io_hdr.sbp = sense_buffer;
 	io_hdr.timeout = 60000; /* ms */
 
-	if (g_getenv("FWUPD_SCSI_VERBOSE") != NULL)
-		g_debug("cmd=0x%x len=0x%x", cdb[0], (guint)bufsz);
+	g_debug("cmd=0x%x len=0x%x", cdb[0], (guint)bufsz);
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				  SG_IO,
 				  (guint8 *)&io_hdr,

--- a/plugins/steelseries/fu-steelseries-fizz-hid.c
+++ b/plugins/steelseries/fu-steelseries-fizz-hid.c
@@ -77,12 +77,10 @@ fu_steelseries_fizz_hid_get_version(FuDevice *device, GError **error)
 				    error))
 		return NULL;
 
-	if (g_getenv("FWUPD_STEELSERIES_HID_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
 	if (!fu_steelseries_fizz_hid_command(device, data, sizeof(data), error))
 		return NULL;
-	if (g_getenv("FWUPD_STEELSERIES_HID_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
 
 	/* success */
 	return fu_strsafe((const gchar *)&data[1], sizeof(data) - 1);

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -206,16 +206,14 @@ fu_steelseries_fizz_get_version(FuDevice *device, gboolean tunnel, GError **erro
 				    error))
 		return NULL;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
 				       TRUE,
 				       error))
 		return NULL;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Version", data, sizeof(data));
 
 	/* success */
 	return fu_strsafe((const gchar *)data, sizeof(data));
@@ -293,12 +291,10 @@ fu_steelseries_fizz_write_fs(FuDevice *device,
 				    error))
 			return FALSE;
 
-		if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
 		if (!fu_steelseries_fizz_command_and_check_error(device, data, sizeof(data), error))
 			return FALSE;
-		if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
 
 		fu_progress_step_done(progress);
 	}
@@ -341,12 +337,10 @@ fu_steelseries_fizz_erase_fs(FuDevice *device,
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "EraseFile", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "EraseFile", data, sizeof(data));
 	if (!fu_steelseries_fizz_command_and_check_error(device, data, sizeof(data), error))
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "EraseFile", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "EraseFile", data, sizeof(data));
 
 	/* success */
 	return TRUE;
@@ -375,8 +369,7 @@ fu_steelseries_fizz_reset(FuDevice *device, gboolean tunnel, guint8 mode, GError
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Reset", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Reset", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
@@ -425,12 +418,10 @@ fu_steelseries_fizz_get_crc32_fs(FuDevice *device,
 
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "FileCRC32", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "FileCRC32", data, sizeof(data));
 	if (!fu_steelseries_fizz_command_and_check_error(device, data, sizeof(data), error))
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "FileCRC32", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "FileCRC32", data, sizeof(data));
 
 	if (!fu_memread_uint32_safe(data,
 				    sizeof(data),
@@ -515,12 +506,10 @@ fu_steelseries_fizz_read_fs(FuDevice *device,
 					     error))
 			return FALSE;
 
-		if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
 		if (!fu_steelseries_fizz_command_and_check_error(device, data, sizeof(data), error))
 			return FALSE;
-		if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "AccessFile", data, sizeof(data));
 
 		if (!fu_memcpy_safe(fu_chunk_get_data_out(chk),
 				    fu_chunk_get_data_sz(chk),
@@ -558,16 +547,14 @@ fu_steelseries_fizz_get_battery_level(FuDevice *device,
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "BatteryLevel", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "BatteryLevel", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
 				       TRUE,
 				       error))
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "BatteryLevel", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "BatteryLevel", data, sizeof(data));
 
 	if (!fu_memread_uint8_safe(data,
 				   sizeof(data),
@@ -593,16 +580,14 @@ fu_steelseries_fizz_get_paired_status(FuDevice *device, guint8 *status, GError *
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "PairedStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "PairedStatus", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
 				       TRUE,
 				       error))
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "PairedStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "PairedStatus", data, sizeof(data));
 
 	if (!fu_memread_uint8_safe(data,
 				   sizeof(data),
@@ -628,16 +613,14 @@ fu_steelseries_fizz_get_connection_status(FuDevice *device, guint8 *status, GErr
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "ConnectionStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "ConnectionStatus", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
 				       TRUE,
 				       error))
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "ConnectionStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "ConnectionStatus", data, sizeof(data));
 
 	if (!fu_memread_uint8_safe(data,
 				   sizeof(data),
@@ -774,8 +757,7 @@ fu_steelseries_fizz_write_firmware_fs(FuDevice *device,
 	buf = fu_bytes_get_data_safe(blob, &bufsz, error);
 	if (buf == NULL)
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "File", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "File", buf, bufsz);
 	if (!fu_steelseries_fizz_erase_fs(device, tunnel, fs, id, error)) {
 		g_prefix_error(error, "failed to erase FS 0x%02x ID 0x%02x: ", fs, id);
 		return FALSE;
@@ -880,8 +862,7 @@ fu_steelseries_fizz_read_firmware_fs(FuDevice *device,
 	}
 	fu_progress_step_done(progress);
 
-	if (g_getenv("FWUPD_STEELSERIES_FIZZ_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Firmware", buf, size);
+	fu_dump_raw(G_LOG_DOMAIN, "Firmware", buf, size);
 	blob = g_bytes_new_take(g_steal_pointer(&buf), size);
 	if (!fu_firmware_parse(firmware, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return NULL;

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -100,8 +100,7 @@ fu_steelseries_sonic_wireless_status(FuDevice *device,
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "WirelessStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "WirelessStatus", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
@@ -109,8 +108,7 @@ fu_steelseries_sonic_wireless_status(FuDevice *device,
 				       error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "WirelessStatus", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "WirelessStatus", data, sizeof(data));
 	if (!fu_memread_uint8_safe(data,
 				   sizeof(data),
 				   STEELSERIES_SONIC_WIRELESS_STATUS_VALUE_OFFSET,
@@ -144,8 +142,7 @@ fu_steelseries_sonic_battery_state(FuDevice *device, guint16 *value, GError **er
 				    error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "BatteryState", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "BatteryState", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
@@ -153,8 +150,7 @@ fu_steelseries_sonic_battery_state(FuDevice *device, guint16 *value, GError **er
 				       error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "BatteryState", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "BatteryState", data, sizeof(data));
 	if (!fu_memread_uint16_safe(data,
 				    sizeof(data),
 				    STEELSERIES_SONIC_BATTERY_VALUE_OFFSET,
@@ -219,8 +215,7 @@ fu_steelseries_sonic_read_from_ram(FuDevice *device,
 					       TRUE,
 					       error))
 			return FALSE;
-		if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "ReadFromRAM", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "ReadFromRAM", data, sizeof(data));
 
 		if (!fu_memcpy_safe(fu_chunk_get_data_out(chk),
 				    fu_chunk_get_data_sz(chk),
@@ -303,8 +298,7 @@ fu_steelseries_sonic_read_from_flash(FuDevice *device,
 					       FALSE,
 					       error))
 			return FALSE;
-		if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "ReadFromFlash", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "ReadFromFlash", data, sizeof(data));
 
 		/* timeout to give some time to read from flash to ram */
 		fu_device_sleep(device, 15); /* ms */
@@ -380,8 +374,7 @@ fu_steelseries_sonic_write_to_ram(FuDevice *device,
 				    error))
 			return FALSE;
 
-		if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "WriteToRAM", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "WriteToRAM", data, sizeof(data));
 		if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 					       data,
 					       sizeof(data),
@@ -462,8 +455,7 @@ fu_steelseries_sonic_write_to_flash(FuDevice *device,
 					     error))
 			return FALSE;
 
-		if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-			fu_dump_raw(G_LOG_DOMAIN, "WriteToFlash", data, sizeof(data));
+		fu_dump_raw(G_LOG_DOMAIN, "WriteToFlash", data, sizeof(data));
 		if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 					       data,
 					       sizeof(data),
@@ -510,8 +502,7 @@ fu_steelseries_sonic_erase(FuDevice *device,
 				     error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Erase", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Erase", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
@@ -548,8 +539,7 @@ fu_steelseries_sonic_restart(FuDevice *device,
 				     error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "Restart", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "Restart", data, sizeof(data));
 	if (!fu_steelseries_device_cmd(FU_STEELSERIES_DEVICE(device),
 				       data,
 				       sizeof(data),
@@ -729,8 +719,7 @@ fu_steelseries_sonic_write_chip(FuDevice *device,
 	buf = fu_bytes_get_data_safe(blob, &bufsz, error);
 	if (buf == NULL)
 		return FALSE;
-	if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, STEELSERIES_SONIC_FIRMWARE_ID[chip], buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, STEELSERIES_SONIC_FIRMWARE_ID[chip], buf, bufsz);
 	if (!fu_steelseries_sonic_erase(device, chip, fu_progress_get_child(progress), error)) {
 		g_prefix_error(error, "failed to erase chip %u: ", chip);
 		return FALSE;
@@ -814,12 +803,10 @@ fu_steelseries_sonic_verify_chip(FuDevice *device,
 	if (blob_tmp == NULL)
 		return FALSE;
 	if (!fu_bytes_compare(blob_tmp, blob, error)) {
-		if (g_getenv("FWUPD_STEELSERIES_SONIC_VERBOSE") != NULL) {
-			fu_dump_raw(G_LOG_DOMAIN,
-				    "Verify",
-				    g_bytes_get_data(blob_tmp, NULL),
-				    g_bytes_get_size(blob_tmp));
-		}
+		fu_dump_raw(G_LOG_DOMAIN,
+			    "Verify",
+			    g_bytes_get_data(blob_tmp, NULL),
+			    g_bytes_get_size(blob_tmp));
 		return FALSE;
 	}
 	fu_progress_step_done(progress);

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -110,8 +110,7 @@ fu_superio_device_regdump(FuSuperioDevice *self, guint8 ldn, GError **error)
 		g_string_append_printf(str, "IOBAD1:0x%04x ", iobad1);
 	if (ldnstr != NULL)
 		g_string_append_printf(str, "(%s)", ldnstr);
-	if (g_getenv("FWUPD_SUPERIO_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, str->str, buf, sizeof(buf));
+	fu_dump_raw(G_LOG_DOMAIN, str->str, buf, sizeof(buf));
 	return TRUE;
 }
 

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -564,7 +564,7 @@ fu_superio_it55_device_prepare_firmware(FuDevice *device,
 	if (date == NULL)
 		date = g_strdup("(unknown build date)");
 
-	g_debug("New firmware: %s %s built on %s", prj_name, version, date);
+	g_debug("new firmware: %s %s built on %s", prj_name, version, date);
 	if (g_strcmp0(prj_name, self->prj_name) != 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -95,8 +95,7 @@ fu_synaptics_cape_device_set_report(FuSynapticsCapeDevice *self,
 	g_return_val_if_fail(data != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (g_getenv("FWUPD_SYNAPTICS_CAPE_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetReport", (guint8 *)data, sizeof(*data));
+	fu_dump_raw(G_LOG_DOMAIN, "SetReport", (guint8 *)data, sizeof(*data));
 
 	return fu_hid_device_set_report(FU_HID_DEVICE(self),
 					FU_SYNAPTICS_CAPE_DEVICE_GOLEM_REPORT_ID,
@@ -126,8 +125,7 @@ fu_synaptics_cape_device_get_report(FuSynapticsCapeDevice *self,
 				      error))
 		return FALSE;
 
-	if (g_getenv("FWUPD_SYNAPTICS_CAPE_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetReport", (guint8 *)data, sizeof(*data));
+	fu_dump_raw(G_LOG_DOMAIN, "GetReport", (guint8 *)data, sizeof(*data));
 
 	/* success */
 	return TRUE;
@@ -156,8 +154,7 @@ fu_synaptics_cape_device_get_report_intr(FuSynapticsCapeDevice *self,
 		return FALSE;
 	}
 
-	if (g_getenv("FWUPD_SYNAPTICS_CAPE_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "GetReport", (guint8 *)data, sizeof(*data));
+	fu_dump_raw(G_LOG_DOMAIN, "GetReport", (guint8 *)data, sizeof(*data));
 
 	/* success */
 	return TRUE;

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -344,7 +344,7 @@ fu_synaptics_mst_device_update_esm(FuSynapticsMstDevice *self,
 			}
 		}
 
-		g_debug("Waiting for flash clear to settle");
+		g_debug("waiting for flash clear to settle");
 		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		/* write firmware */
@@ -425,7 +425,7 @@ fu_synaptics_mst_device_update_tesla_leaf_firmware(FuSynapticsMstDevice *self,
 
 		if (!fu_synaptics_mst_device_set_flash_sector_erase(self, 0xffff, 0, error))
 			return FALSE;
-		g_debug("Waiting for flash clear to settle");
+		g_debug("waiting for flash clear to settle");
 		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		fu_progress_set_steps(progress, write_loops);
@@ -556,7 +556,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 	/* Current max firmware size is 104K */
 	if (fw_size < payload_len)
 		fw_size = 104 * 1024;
-	g_debug("Calculated fw size as %u", fw_size);
+	g_debug("Ccalculated fw size as %u", fw_size);
 
 	/* Update firmware */
 	write_loops = fw_size / unit_sz;
@@ -582,7 +582,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 								    erase_offset,
 								    error))
 			return FALSE;
-		g_debug("Waiting for flash clear to settle");
+		g_debug("waiting for flash clear to settle");
 		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		/* write */
@@ -889,7 +889,7 @@ fu_synaptics_mst_device_update_cayenne_firmware(FuSynapticsMstDevice *self,
 
 		if (!fu_synaptics_mst_device_set_flash_sector_erase(self, 0xffff, 0, error))
 			return FALSE;
-		g_debug("Waiting for flash clear to settle");
+		g_debug("waiting for flash clear to settle");
 		fu_device_sleep(FU_DEVICE(self), FLASH_SETTLE_TIME);
 
 		fu_progress_set_steps(progress, write_loops);

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -81,14 +81,12 @@ fu_synaprom_device_cmd_send(FuSynapromDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 25, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 75, NULL);
 
-	if (g_getenv("FWUPD_SYNAPROM_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "REQST",
-			     request->data,
-			     request->len,
-			     16,
-			     FU_DUMP_FLAGS_SHOW_ADDRESSES);
-	}
+	fu_dump_full(G_LOG_DOMAIN,
+		     "REQST",
+		     request->data,
+		     request->len,
+		     16,
+		     FU_DUMP_FLAGS_SHOW_ADDRESSES);
 	ret = g_usb_device_bulk_transfer(usb_device,
 					 FU_SYNAPROM_USB_REQUEST_EP,
 					 request->data,
@@ -124,14 +122,12 @@ fu_synaprom_device_cmd_send(FuSynapromDevice *device,
 		g_prefix_error(error, "failed to reply: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_SYNAPROM_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "REPLY",
-			     reply->data,
-			     actual_len,
-			     16,
-			     FU_DUMP_FLAGS_SHOW_ADDRESSES);
-	}
+	fu_dump_full(G_LOG_DOMAIN,
+		     "REPLY",
+		     reply->data,
+		     actual_len,
+		     16,
+		     FU_DUMP_FLAGS_SHOW_ADDRESSES);
 	fu_progress_step_done(progress);
 
 	/* parse as FuSynapromReplyGeneric */
@@ -201,12 +197,12 @@ fu_synaprom_device_setup(FuDevice *device, GError **error)
 	}
 	memcpy(&pkt, reply->data, sizeof(pkt));
 	product = GUINT32_FROM_LE(pkt.product);
-	g_debug("product ID is %u, version=%u.%u, buildnum=%u prod=%i",
-		product,
-		pkt.vmajor,
-		pkt.vminor,
-		GUINT32_FROM_LE(pkt.buildnum),
-		pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR);
+	g_info("product ID is %u, version=%u.%u, buildnum=%u prod=%i",
+	       product,
+	       pkt.vmajor,
+	       pkt.vminor,
+	       GUINT32_FROM_LE(pkt.buildnum),
+	       pkt.security[1] & FU_SYNAPROM_SECURITY1_PROD_SENSOR);
 	fu_synaprom_device_set_version(self, pkt.vmajor, pkt.vminor, GUINT32_FROM_LE(pkt.buildnum));
 
 	/* get serial number */

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -265,21 +265,19 @@ fu_synaptics_rmi_device_scan_pdt(FuSynapticsRmiDevice *self, GError **error)
 	}
 
 	/* for debug */
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		for (guint i = 0; i < priv->functions->len; i++) {
-			FuSynapticsRmiFunction *func = g_ptr_array_index(priv->functions, i);
-			g_debug("PDT-%02u fn:0x%02x vr:%d sc:%d ms:0x%x "
-				"db:0x%02x cb:0x%02x cm:0x%02x qb:0x%02x",
-				i,
-				func->function_number,
-				func->function_version,
-				func->interrupt_source_count,
-				func->interrupt_mask,
-				func->data_base,
-				func->control_base,
-				func->command_base,
-				func->query_base);
-		}
+	for (guint i = 0; i < priv->functions->len; i++) {
+		FuSynapticsRmiFunction *func = g_ptr_array_index(priv->functions, i);
+		g_debug("PDT-%02u fn:0x%02x vr:%d sc:%d ms:0x%x "
+			"db:0x%02x cb:0x%02x cm:0x%02x qb:0x%02x",
+			i,
+			func->function_number,
+			func->function_version,
+			func->interrupt_source_count,
+			func->interrupt_mask,
+			func->data_base,
+			func->control_base,
+			func->command_base,
+			func->query_base);
 	}
 
 	/* success */

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -93,14 +93,7 @@ fu_synaptics_rmi_hid_device_read(FuSynapticsRmiDevice *rmi_device,
 	/* request */
 	for (guint j = req->len; j < 21; j++)
 		fu_byte_array_append_uint8(req, 0x0);
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "ReportWrite",
-			     req->data,
-			     req->len,
-			     80,
-			     FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, "ReportWrite", req->data, req->len, 80, FU_DUMP_FLAGS_NONE);
 	if (!fu_io_channel_write_byte_array(self->io_channel,
 					    req,
 					    RMI_DEVICE_DEFAULT_TIMEOUT,
@@ -127,14 +120,12 @@ fu_synaptics_rmi_hid_device_read(FuSynapticsRmiDevice *rmi_device,
 					    "response zero sized");
 			return NULL;
 		}
-		if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-			fu_dump_full(G_LOG_DOMAIN,
-				     "ReportRead",
-				     res->data,
-				     res->len,
-				     80,
-				     FU_DUMP_FLAGS_NONE);
-		}
+		fu_dump_full(G_LOG_DOMAIN,
+			     "ReportRead",
+			     res->data,
+			     res->len,
+			     80,
+			     FU_DUMP_FLAGS_NONE);
 
 		/* ignore non data report events */
 		if (res->data[HID_RMI4_REPORT_ID] != RMI_READ_DATA_REPORT_ID) {
@@ -168,14 +159,7 @@ fu_synaptics_rmi_hid_device_read(FuSynapticsRmiDevice *rmi_device,
 		}
 		g_byte_array_append(buf, res->data + HID_RMI4_READ_INPUT_DATA, input_count_sz);
 	}
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "DeviceRead",
-			     buf->data,
-			     buf->len,
-			     80,
-			     FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, "DeviceRead", buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
 
 	return g_steal_pointer(&buf);
 }
@@ -228,14 +212,7 @@ fu_synaptics_rmi_hid_device_write(FuSynapticsRmiDevice *rmi_device,
 	/* pad out to 21 bytes for some reason */
 	for (guint i = buf->len; i < 21; i++)
 		fu_byte_array_append_uint8(buf, 0x0);
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "DeviceWrite",
-			     buf->data,
-			     buf->len,
-			     80,
-			     FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, "DeviceWrite", buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
 
 	return fu_io_channel_write_byte_array(self->io_channel,
 					      buf,
@@ -271,14 +248,12 @@ fu_synaptics_rmi_hid_device_wait_for_attr(FuSynapticsRmiDevice *rmi_device,
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
-		if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-			fu_dump_full(G_LOG_DOMAIN,
-				     "ReportRead",
-				     res->data,
-				     res->len,
-				     80,
-				     FU_DUMP_FLAGS_NONE);
-		}
+		fu_dump_full(G_LOG_DOMAIN,
+			     "ReportRead",
+			     res->data,
+			     res->len,
+			     80,
+			     FU_DUMP_FLAGS_NONE);
 		if (res->len < HID_RMI4_ATTN_INTERRUPT_SOURCES + 1) {
 			g_debug("attr: ignoring small read of %u", res->len);
 			continue;
@@ -318,8 +293,7 @@ fu_synaptics_rmi_hid_device_set_mode(FuSynapticsRmiHidDevice *self,
 				     GError **error)
 {
 	const guint8 data[] = {0x0f, mode};
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SetMode", data, sizeof(data));
+	fu_dump_raw(G_LOG_DOMAIN, "SetMode", data, sizeof(data));
 	return fu_udev_device_ioctl(FU_UDEV_DEVICE(self),
 				    HIDIOCSFEATURE(sizeof(data)),
 				    (guint8 *)data,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -699,9 +699,7 @@ fu_synaptics_rmi_ps2_device_read(FuSynapticsRmiDevice *rmi_device,
 		break;
 	}
 	dump = g_strdup_printf("R %x", addr);
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN, dump, buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, dump, buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
 	return g_steal_pointer(&buf);
 }
 
@@ -713,6 +711,7 @@ fu_synaptics_rmi_ps2_device_read_packet_register(FuSynapticsRmiDevice *rmi_devic
 {
 	FuSynapticsRmiPs2Device *self = FU_SYNAPTICS_RMI_PS2_DEVICE(rmi_device);
 	g_autoptr(GByteArray) buf = NULL;
+	g_autofree gchar *dump = g_strdup_printf("R %x", addr);
 
 	if (!fu_synaptics_rmi_device_set_page(rmi_device, addr >> 8, error)) {
 		g_prefix_error(error, "failed to set RMI page: ");
@@ -725,10 +724,7 @@ fu_synaptics_rmi_ps2_device_read_packet_register(FuSynapticsRmiDevice *rmi_devic
 		return NULL;
 	}
 
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		g_autofree gchar *dump = g_strdup_printf("R %x", addr);
-		fu_dump_full(G_LOG_DOMAIN, dump, buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, dump, buf->data, buf->len, 80, FU_DUMP_FLAGS_NONE);
 	return g_steal_pointer(&buf);
 }
 
@@ -740,6 +736,8 @@ fu_synaptics_rmi_ps2_device_write(FuSynapticsRmiDevice *rmi_device,
 				  GError **error)
 {
 	FuSynapticsRmiPs2Device *self = FU_SYNAPTICS_RMI_PS2_DEVICE(rmi_device);
+	g_autofree gchar *str = g_strdup_printf("W %x", addr);
+
 	if (!fu_synaptics_rmi_device_set_page(rmi_device, addr >> 8, error)) {
 		g_prefix_error(error, "failed to set RMI page: ");
 		return FALSE;
@@ -754,10 +752,7 @@ fu_synaptics_rmi_ps2_device_write(FuSynapticsRmiDevice *rmi_device,
 		g_prefix_error(error, "failed to write register %x: ", addr);
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		g_autofree gchar *str = g_strdup_printf("W %x", addr);
-		fu_dump_full(G_LOG_DOMAIN, str, req->data, req->len, 80, FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, str, req->data, req->len, 80, FU_DUMP_FLAGS_NONE);
 	return TRUE;
 }
 

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -146,8 +146,7 @@ fu_synaptics_rmi_v5_device_secure_check(FuDevice *device,
 	g_autoptr(GByteArray) pubkey_buf = g_byte_array_new();
 	g_autoptr(GBytes) pubkey = NULL;
 
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL)
-		fu_dump_bytes(G_LOG_DOMAIN, "Signature", signature);
+	fu_dump_bytes(G_LOG_DOMAIN, "Signature", signature);
 
 	f34 = fu_synaptics_rmi_device_get_function(self, 0x34, error);
 	if (f34 == NULL)
@@ -211,14 +210,12 @@ fu_synaptics_rmi_v5_device_secure_check(FuDevice *device,
 		/* success */
 		break;
 	}
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "RSA public key",
-			     pubkey_buf->data,
-			     pubkey_buf->len,
-			     16,
-			     FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN,
+		     "RSA public key",
+		     pubkey_buf->data,
+		     pubkey_buf->len,
+		     16,
+		     FU_DUMP_FLAGS_NONE);
 
 	/* sanity check size */
 	if (rsa_pubkey_len != pubkey_buf->len) {

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -329,8 +329,8 @@ fu_synaptics_rmi_v7_device_write_partition_signature(FuSynapticsRmiDevice *self,
 	}
 
 	/* write partition signature */
-	g_debug("writing partition signature %s…",
-		rmi_firmware_partition_id_to_string(partition_id));
+	g_info("writing partition signature %s…",
+	       rmi_firmware_partition_id_to_string(partition_id));
 
 	fu_byte_array_append_uint16(req_offset, 0x0, G_LITTLE_ENDIAN);
 	if (!fu_synaptics_rmi_device_write(self,
@@ -402,7 +402,7 @@ fu_synaptics_rmi_v7_device_write_partition(FuSynapticsRmiDevice *self,
 		return FALSE;
 
 	/* write partition id */
-	g_debug("writing partition %s…", rmi_firmware_partition_id_to_string(partition_id));
+	g_info("writing partition %s…", rmi_firmware_partition_id_to_string(partition_id));
 	fu_byte_array_append_uint8(req_partition_id, partition_id);
 	if (!fu_synaptics_rmi_device_write(self,
 					   f34->data_base + 0x1,
@@ -594,7 +594,7 @@ fu_synaptics_rmi_v7_device_secure_check(FuSynapticsRmiDevice *self,
 			g_prefix_error(error, "%s secure check failed: ", id);
 			return FALSE;
 		}
-		g_debug("%s signature verified successfully", id);
+		g_info("%s signature verified successfully", id);
 	}
 	return TRUE;
 }
@@ -887,14 +887,7 @@ fu_synaptics_rmi_device_read_flash_config_v7(FuSynapticsRmiDevice *self, GError 
 	}
 
 	/* debugging */
-	if (g_getenv("FWUPD_SYNAPTICS_RMI_VERBOSE") != NULL) {
-		fu_dump_full(G_LOG_DOMAIN,
-			     "FlashConfig",
-			     res->data,
-			     res->len,
-			     80,
-			     FU_DUMP_FLAGS_NONE);
-	}
+	fu_dump_full(G_LOG_DOMAIN, "FlashConfig", res->data, res->len, 80, FU_DUMP_FLAGS_NONE);
 
 	if ((res->data[0] & 0x0f) == 1)
 		partition_size = sizeof(RmiPartitionTbl) + 2;

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -224,7 +224,7 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 	self->gen =
 	    fu_thunderbolt_udev_get_attr_uint16(FU_UDEV_DEVICE(self), "generation", &error_gen);
 	if (self->gen == 0)
-		g_debug("Unable to read generation: %s", error_gen->message);
+		g_debug("unable to read generation: %s", error_gen->message);
 
 	if (self->controller_kind == FU_THUNDERBOLT_CONTROLLER_KIND_HOST) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -124,7 +124,7 @@ fu_thunderbolt_device_get_version(FuThunderboltDevice *self, GError **error)
 		 * kernel only returns -ENODATA or -EAGAIN */
 		if (g_file_get_contents(safe_path, &version_raw, NULL, &error_local))
 			break;
-		g_debug("Attempt %u: Failed to read NVM version", i);
+		g_debug("attempt %u: failed to read NVM version", i);
 		fu_device_sleep(FU_DEVICE(self), TBT_NVM_RETRY_TIMEOUT);
 		/* safe mode probably */
 		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
@@ -373,7 +373,7 @@ fu_thunderbolt_device_write_firmware(FuDevice *device,
 
 	/* using an active delayed activation flow later (either shutdown or another plugin) */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_SKIPS_RESTART)) {
-		g_debug("Skipping Thunderbolt reset per quirk request");
+		g_debug("skipping Thunderbolt reset per quirk request");
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 		return TRUE;
 	}

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -28,7 +28,7 @@ fu_thunderbolt_plugin_safe_kernel(FuPlugin *plugin, GError **error)
 
 	minimum_kernel = fu_plugin_get_config_value(plugin, "MinimumKernelVersion");
 	if (minimum_kernel == NULL) {
-		g_debug("Ignoring kernel safety checks");
+		g_debug("ignoring kernel safety checks");
 		return TRUE;
 	}
 	return fu_kernel_check_version(minimum_kernel, error);
@@ -54,7 +54,7 @@ fu_thunderbolt_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 	/* Operating system will handle finishing updates later */
 	if (fu_plugin_get_config_value_boolean(plugin, "DelayedActivation") &&
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE)) {
-		g_debug("Turning on delayed activation for %s", fu_device_get_name(device));
+		g_info("turning on delayed activation for %s", fu_device_get_name(device));
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_SKIPS_RESTART);
 		fu_device_remove_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -44,6 +44,7 @@ fu_ti_tps6598x_device_usbep_read_raw(FuTiTps6598xDevice *self,
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	gsize actual_length = 0;
+	g_autofree gchar *title = g_strdup_printf("read@0x%x", addr);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
 	/* first byte is length */
@@ -65,10 +66,7 @@ fu_ti_tps6598x_device_usbep_read_raw(FuTiTps6598xDevice *self,
 		g_prefix_error(error, "failed to contact device: ");
 		return NULL;
 	}
-	if (g_getenv("FWUPD_TI_TPS6598X_VERBOSE") != NULL) {
-		g_autofree gchar *title = g_strdup_printf("read@0x%x", addr);
-		fu_dump_raw(G_LOG_DOMAIN, title, buf->data, buf->len);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, title, buf->data, buf->len);
 	if (actual_length != buf->len) {
 		g_set_error(error,
 			    G_IO_ERROR,
@@ -121,11 +119,9 @@ fu_ti_tps6598x_device_usbep_write(FuTiTps6598xDevice *self,
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	g_autoptr(GPtrArray) chunks = NULL;
+	g_autofree gchar *title = g_strdup_printf("write@0x%x", addr);
 
-	if (g_getenv("FWUPD_TI_TPS6598X_VERBOSE") != NULL) {
-		g_autofree gchar *title = g_strdup_printf("write@0x%x", addr);
-		fu_dump_raw(G_LOG_DOMAIN, title, buf->data, buf->len);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, title, buf->data, buf->len);
 	chunks =
 	    fu_chunk_array_mutable_new(buf->data, buf->len, 0x0, 0x0, TI_TPS6598X_USB_BUFFER_SIZE);
 	for (guint i = 0; i < chunks->len; i++) {
@@ -315,11 +311,9 @@ fu_ti_tps6598x_device_sfwi(FuTiTps6598xDevice *self, GError **error)
 	}
 
 	/* success */
-	if (g_getenv("FWUPD_TI_TPS6598X_VERBOSE") != NULL) {
-		g_debug("prod-key-present: %u", (guint)(buf->data[2] & 0b00010) >> 1);
-		g_debug("engr-key-present: %u", (guint)(buf->data[2] & 0b00100) >> 2);
-		g_debug("new-flash-region: %u", (guint)(buf->data[2] & 0b11000) >> 3);
-	}
+	g_debug("prod-key-present: %u", (guint)(buf->data[2] & 0b00010) >> 1);
+	g_debug("engr-key-present: %u", (guint)(buf->data[2] & 0b00100) >> 2);
+	g_debug("new-flash-region: %u", (guint)(buf->data[2] & 0b11000) >> 3);
 	return TRUE;
 }
 
@@ -349,8 +343,7 @@ fu_ti_tps6598x_device_sfwd(FuTiTps6598xDevice *self, GByteArray *data, GError **
 	}
 
 	/* success */
-	if (g_getenv("FWUPD_TI_TPS6598X_VERBOSE") != NULL)
-		g_debug("more-data-expected: %i", (buf->data[0] & 0x80) > 0);
+	g_debug("more-data-expected: %i", (buf->data[0] & 0x80) > 0);
 	return TRUE;
 }
 
@@ -380,14 +373,12 @@ fu_ti_tps6598x_device_sfws(FuTiTps6598xDevice *self, GByteArray *data, GError **
 	}
 
 	/* success */
-	if (g_getenv("FWUPD_TI_TPS6598X_VERBOSE") != NULL) {
-		g_debug("more-data-expected: %i", (buf->data[0] & 0x80) > 0);
-		g_debug("signature-data-block: %u", (guint)buf->data[1]);
-		g_debug("prod-key-present: %u", (guint)(buf->data[2] & 0b00010) >> 1);
-		g_debug("engr-key-present: %u", (guint)(buf->data[2] & 0b00100) >> 2);
-		g_debug("new-flash-region: %u", (guint)(buf->data[2] & 0b11000) >> 3);
-		g_debug("hash-match: %u", (guint)(buf->data[2] & 0b1100000) >> 5);
-	}
+	g_debug("more-data-expected: %i", (buf->data[0] & 0x80) > 0);
+	g_debug("signature-data-block: %u", (guint)buf->data[1]);
+	g_debug("prod-key-present: %u", (guint)(buf->data[2] & 0b00010) >> 1);
+	g_debug("engr-key-present: %u", (guint)(buf->data[2] & 0b00100) >> 2);
+	g_debug("new-flash-region: %u", (guint)(buf->data[2] & 0b11000) >> 3);
+	g_debug("hash-match: %u", (guint)(buf->data[2] & 0b1100000) >> 5);
 	return TRUE;
 }
 

--- a/plugins/tpm/fu-tpm-eventlog-parser.c
+++ b/plugins/tpm/fu-tpm-eventlog-parser.c
@@ -219,8 +219,7 @@ fu_tpm_eventlog_parser_parse_blob_v2(const guint8 *buf,
 						    error))
 					return NULL;
 				item->blob = g_bytes_new_take(g_steal_pointer(&data), datasz);
-				if (g_getenv("FWUPD_TPM_EVENTLOG_VERBOSE") != NULL)
-					fu_dump_bytes(G_LOG_DOMAIN, "TpmEvent", item->blob);
+				fu_dump_bytes(G_LOG_DOMAIN, "TpmEvent", item->blob);
 			}
 			g_ptr_array_add(items, g_steal_pointer(&item));
 		}
@@ -323,8 +322,7 @@ fu_tpm_eventlog_parser_new(const guint8 *buf,
 						    error))
 					return NULL;
 				item->blob = g_bytes_new_take(g_steal_pointer(&data), datasz);
-				if (g_getenv("FWUPD_TPM_EVENTLOG_VERBOSE") != NULL)
-					fu_dump_bytes(G_LOG_DOMAIN, "TpmEvent", item->blob);
+				fu_dump_bytes(G_LOG_DOMAIN, "TpmEvent", item->blob);
 			}
 			g_ptr_array_add(items, g_steal_pointer(&item));
 		}

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -334,7 +334,7 @@ fu_uefi_capsule_plugin_update_splash(FuPlugin *plugin, FuDevice *device, GError 
 
 	/* no UX capsule support, so deleting var if it exists */
 	if (fu_device_has_private_flag(device, FU_UEFI_DEVICE_FLAG_NO_UX_CAPSULE)) {
-		g_debug("not providing UX capsule");
+		g_info("not providing UX capsule");
 		return fu_efivar_delete(FU_EFIVAR_GUID_FWUPDATE, "fwupd-ux-capsule", error);
 	}
 
@@ -426,9 +426,8 @@ fu_uefi_capsule_plugin_write_firmware(FuPlugin *plugin,
 
 	/* perform the update */
 	fu_progress_set_status(progress, FWUPD_STATUS_SCHEDULING);
-	if (!fu_uefi_capsule_plugin_update_splash(plugin, device, &error_splash)) {
-		g_debug("failed to upload UEFI UX capsule text: %s", error_splash->message);
-	}
+	if (!fu_uefi_capsule_plugin_update_splash(plugin, device, &error_splash))
+		g_info("failed to upload UEFI UX capsule text: %s", error_splash->message);
 
 	return fu_device_write_firmware(device, blob_fw, progress, flags, error);
 }
@@ -488,7 +487,7 @@ fu_uefi_capsule_plugin_is_esp_linux(FuVolume *esp, GError **error)
 		g_autofree gchar *basename = g_path_get_basename(fn);
 		g_autofree gchar *basename_lower = g_utf8_strdown(basename, -1);
 		if (g_strv_contains((const gchar *const *)basenames, basename_lower)) {
-			g_debug("found %s which indicates a Linux ESP, using %s", fn, mount_point);
+			g_info("found %s which indicates a Linux ESP, using %s", fn, mount_point);
 			return TRUE;
 		}
 	}
@@ -521,7 +520,7 @@ fu_uefi_capsule_plugin_get_default_esp(FuPlugin *plugin, GError **error)
 				g_string_append_c(str, ',');
 			g_string_append(str, fu_volume_get_id(vol));
 		}
-		g_debug("more than one ESP possible: %s", str->str);
+		g_info("more than one ESP possible: %s", str->str);
 	}
 
 	/* we found more than one: lets look for something plausible */
@@ -768,7 +767,7 @@ fu_uefi_capsule_plugin_unlock(FuPlugin *plugin, FuDevice *device, GError **error
 	}
 
 	/* for unlocking TPM1.2 <-> TPM2.0 switching */
-	g_debug("Unlocking upgrades for: %s (%s)",
+	g_debug("unlocking upgrades for: %s (%s)",
 		fu_device_get_name(device),
 		fu_device_get_id(device));
 	device_alt = fu_device_get_alternate(device);
@@ -780,7 +779,7 @@ fu_uefi_capsule_plugin_unlock(FuPlugin *plugin, FuDevice *device, GError **error
 			    fu_device_get_name(device));
 		return FALSE;
 	}
-	g_debug("Preventing upgrades for: %s (%s)",
+	g_debug("preventing upgrades for: %s (%s)",
 		fu_device_get_name(device_alt),
 		fu_device_get_id(device_alt));
 
@@ -986,7 +985,7 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 	if (!fu_uefi_bgrt_setup(self->bgrt, &error_local))
 		g_debug("BGRT setup failed: %s", error_local->message);
 	str = fu_uefi_bgrt_get_supported(self->bgrt) ? "Enabled" : "Disabled";
-	g_debug("UX Capsule support : %s", str);
+	g_info("UX capsule support : %s", str);
 	fu_plugin_add_report_metadata(plugin, "UEFIUXCapsule", str);
 	fu_progress_step_done(progress);
 

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -266,7 +266,7 @@ fu_uefi_get_esp_path_for_os(FuDevice *device, const gchar *base)
 			g_autofree gchar *id_like_path =
 			    g_build_filename(base, "EFI", split[i], NULL);
 			if (g_file_test(id_like_path, G_FILE_TEST_IS_DIR)) {
-				g_debug("Using ID_LIKE key from os-release");
+				g_debug("using ID_LIKE key from os-release");
 				return g_steal_pointer(&id_like_path);
 			}
 		}

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -435,7 +435,7 @@ fu_uefi_device_fixup_firmware(FuUefiDevice *self, GBytes *fw, GError **error)
 	}
 
 	/* create a fake header with plausible contents */
-	g_debug("missing or invalid embedded capsule header");
+	g_info("missing or invalid embedded capsule header");
 	priv->missing_header = TRUE;
 	header.flags = priv->capsule_flags;
 	header.header_size = hdrsize;
@@ -746,8 +746,8 @@ fu_uefi_device_prepare_firmware(FuDevice *device,
 
 	/* check there is enough space in the ESP */
 	if (sz_reqd == 0) {
-		g_debug("required ESP free space is not configured, using 2 x %uMB + 20MB",
-			(guint)g_bytes_get_size(fw) / (1024 * 1024));
+		g_info("required ESP free space is not configured, using 2 x %uMB + 20MB",
+		       (guint)g_bytes_get_size(fw) / (1024 * 1024));
 		sz_reqd = g_bytes_get_size(fw) * 2 + (20u * 1024 * 1024);
 	}
 	if (!fu_volume_check_free_space(priv->esp, sz_reqd, error))

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -89,8 +89,7 @@ fu_uefi_grub_device_mkconfig(FuDevice *device,
 			  NULL,
 			  error))
 		return FALSE;
-	if (g_getenv("FWUPD_UPDATE_CAPSULE_VERBOSE") != NULL)
-		g_debug("%s", output);
+	g_debug("%s", output);
 
 	/* make fwupd default */
 	argv_reboot[0] = grub_reboot;

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -243,7 +243,7 @@ main(int argc, char *argv[])
 				fu_efi_signature_kind_to_string(fu_efi_signature_get_kind(sig)),
 				checksum);
 		}
-		g_debug("version: %s", fu_firmware_get_version(FU_FIRMWARE(dbx)));
+		g_info("version: %s", fu_firmware_get_version(FU_FIRMWARE(dbx)));
 		return EXIT_SUCCESS;
 	}
 

--- a/plugins/uefi-pk/fu-uefi-pk-device.c
+++ b/plugins/uefi-pk/fu-uefi-pk-device.c
@@ -55,7 +55,7 @@ fu_uefi_pk_device_parse_buf(FuUefiPkDevice *self, const gchar *buf, gsize bufsz,
 	/* look for things that should not exist */
 	for (guint i = 0; needles[i] != NULL; i++) {
 		if (g_strstr_len(buf, bufsz, needles[i]) != NULL) {
-			g_debug("got %s, marking unsafe", buf);
+			g_info("got %s, marking unsafe", buf);
 			self->has_pk_test_key = TRUE;
 			break;
 		}
@@ -124,8 +124,7 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 
 	/* look in issuer */
 	if (gnutls_x509_crt_get_issuer_dn(crt, buf, &bufsz) == GNUTLS_E_SUCCESS) {
-		if (g_getenv("FWUPD_UEFI_PK_VERBOSE") != NULL)
-			g_debug("PK issuer: %s", buf);
+		g_debug("PK issuer: %s", buf);
 		if (!fu_uefi_pk_device_parse_buf(self, buf, bufsz, error))
 			return FALSE;
 	}
@@ -134,8 +133,7 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 	subject = (gnutls_datum_t *)gnutls_malloc(sizeof(gnutls_datum_t));
 	if (gnutls_x509_crt_get_subject(crt, &dn) == GNUTLS_E_SUCCESS) {
 		gnutls_x509_dn_get_str(dn, subject);
-		if (g_getenv("FWUPD_UEFI_PK_VERBOSE") != NULL)
-			g_debug("PK subject: %s", subject->data);
+		g_debug("PK subject: %s", subject->data);
 		if (!fu_uefi_pk_device_parse_buf(self,
 						 (const gchar *)subject->data,
 						 subject->size,

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -219,12 +219,10 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	}
 
 	/* dump */
-	if (g_getenv("FWUPD_U2F_VERBOSE") != NULL) {
-		g_debug("block: 0x%x/0x%x @0x%x", blockcnt, blocktotal - 1, addr);
-		g_debug("family_id: 0x%x", family_id);
-		g_debug("flags: 0x%x", flags);
-		g_debug("datasz: 0x%x", datasz);
-	}
+	g_debug("block: 0x%x/0x%x @0x%x", blockcnt, blocktotal - 1, addr);
+	g_debug("family_id: 0x%x", family_id);
+	g_debug("flags: 0x%x", flags);
+	g_debug("datasz: 0x%x", datasz);
 
 	/* success */
 	return TRUE;

--- a/plugins/usi-dock/fu-usi-dock-dmc-device.c
+++ b/plugins/usi-dock/fu-usi-dock-dmc-device.c
@@ -22,7 +22,7 @@ fu_usi_dock_dmc_device_parent_notify_cb(FuDevice *device, GParamSpec *pspec, gpo
 		g_autoptr(GError) error = NULL;
 
 		/* slightly odd: the MCU device uses the DMC version number */
-		g_debug("absorbing DMC version into MCU");
+		g_info("absorbing DMC version into MCU");
 		fu_device_set_version_format(parent, fu_device_get_version_format(device));
 		fu_device_set_version(parent, fu_device_get_version(device));
 		fu_device_set_serial(parent, fu_device_get_serial(device));

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -257,8 +257,7 @@ fu_vli_device_spi_write_block(FuVliDevice *self,
 	}
 
 	/* write */
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		g_debug("writing 0x%x block @0x%x", (guint)bufsz, address);
+	g_debug("writing 0x%x block @0x%x", (guint)bufsz, address);
 	if (!fu_vli_device_spi_write_enable(self, error)) {
 		g_prefix_error(error, "enabling SPI write failed: ");
 		return FALSE;
@@ -390,8 +389,7 @@ fu_vli_device_spi_erase(FuVliDevice *self,
 	fu_progress_set_steps(progress, chunks->len);
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
-		if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-			g_debug("erasing @0x%x", fu_chunk_get_address(chk));
+		g_debug("erasing @0x%x", fu_chunk_get_address(chk));
 		if (!fu_vli_device_spi_erase_sector(FU_VLI_DEVICE(self),
 						    fu_chunk_get_address(chk),
 						    error)) {
@@ -560,8 +558,7 @@ fu_vli_device_spi_read_flash_id(FuVliDevice *self, GError **error)
 		g_prefix_error(error, "failed to read chip ID: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "SpiCmdReadId", buf, sizeof(buf));
+	fu_dump_raw(G_LOG_DOMAIN, "SpiCmdReadId", buf, sizeof(buf));
 	if (priv->spi_cmd_read_id_sz == 4) {
 		if (!fu_memread_uint32_safe(buf,
 					    sizeof(buf),

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -33,6 +33,7 @@ fu_vli_pd_device_read_regs(FuVliPdDevice *self,
 			   gsize bufsz,
 			   GError **error)
 {
+	g_autofree gchar *title = g_strdup_printf("ReadRegs@0x%x", addr);
 	if (!g_usb_device_control_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(self)),
 					   G_USB_DEVICE_DIRECTION_DEVICE_TO_HOST,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -49,10 +50,7 @@ fu_vli_pd_device_read_regs(FuVliPdDevice *self,
 		g_prefix_error(error, "failed to write register @0x%x: ", addr);
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL) {
-		g_autofree gchar *title = g_strdup_printf("ReadRegs@0x%x", addr);
-		fu_dump_raw(G_LOG_DOMAIN, title, buf, bufsz);
-	}
+	fu_dump_raw(G_LOG_DOMAIN, title, buf, bufsz);
 	return TRUE;
 }
 
@@ -65,10 +63,8 @@ fu_vli_pd_device_read_reg(FuVliPdDevice *self, guint16 addr, guint8 *value, GErr
 static gboolean
 fu_vli_pd_device_write_reg(FuVliPdDevice *self, guint16 addr, guint8 value, GError **error)
 {
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL) {
-		g_autofree gchar *title = g_strdup_printf("WriteReg@0x%x", addr);
-		fu_dump_raw(G_LOG_DOMAIN, title, &value, sizeof(value));
-	}
+	g_autofree gchar *title = g_strdup_printf("WriteReg@0x%x", addr);
+	fu_dump_raw(G_LOG_DOMAIN, title, &value, sizeof(value));
 	if (!g_usb_device_control_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(self)),
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -378,7 +378,7 @@ fu_vli_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **err
 		guint8 tmp = 0x0;
 
 		/* set GPIOB output enable */
-		g_debug("using GPIO reset for %s", fu_device_get_id(device));
+		g_info("using GPIO reset for %s", fu_device_get_id(device));
 		if (!fu_vli_usbhub_device_read_reg(FU_VLI_USBHUB_DEVICE(proxy),
 						   VL817_ADDR_GPIO_OUTPUT_ENABLE,
 						   &tmp,
@@ -492,44 +492,42 @@ fu_vli_usbhub_device_guess_kind(FuVliUsbhubDevice *self, GError **error)
 		g_prefix_error(error, "Read_ChipVer failed: ");
 		return FALSE;
 	}
+	g_debug("chipver = 0x%02x", chipver);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf63f, &chipver2, error)) {
 		g_prefix_error(error, "Read_ChipVer2 failed: ");
 		return FALSE;
 	}
+	g_debug("chipver2 = 0x%02x", chipver2);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf800, &b811P812, error)) {
 		g_prefix_error(error, "Read_811P812 failed: ");
 		return FALSE;
 	}
+	g_debug("b811P812 = 0x%02x", b811P812);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf88e, &chipid1, error)) {
 		g_prefix_error(error, "Read_ChipID1 failed: ");
 		return FALSE;
 	}
+	g_debug("chipid1 = 0x%02x", chipid1);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf88f, &chipid2, error)) {
 		g_prefix_error(error, "Read_ChipID2 failed: ");
 		return FALSE;
 	}
+	g_debug("chipid2 = 0x%02x", chipid2);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf64e, &chipid12, error)) {
 		g_prefix_error(error, "Read_ChipID12 failed: ");
 		return FALSE;
 	}
+	g_debug("chipid12 = 0x%02x", chipid12);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf64f, &chipid22, error)) {
 		g_prefix_error(error, "Read_ChipID22 failed: ");
 		return FALSE;
 	}
+	g_debug("chipid22 = 0x%02x", chipid22);
 	if (!fu_vli_usbhub_device_read_reg(self, 0xf651, &pkgtype, error)) {
 		g_prefix_error(error, "Read_820Q7Q8 failed: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL) {
-		g_debug("chipver = 0x%02x", chipver);
-		g_debug("chipver2 = 0x%02x", chipver2);
-		g_debug("b811P812 = 0x%02x", b811P812);
-		g_debug("chipid1 = 0x%02x", chipid1);
-		g_debug("chipid2 = 0x%02x", chipid2);
-		g_debug("chipid12 = 0x%02x", chipid12);
-		g_debug("chipid22 = 0x%02x", chipid22);
-		g_debug("pkgtype = 0x%02x", pkgtype);
-	}
+	g_debug("pkgtype = 0x%02x", pkgtype);
 
 	if (chipid2 == 0x35 && chipid1 == 0x07) {
 		fu_vli_device_set_kind(FU_VLI_DEVICE(self), FU_VLI_DEVICE_KIND_VL210);
@@ -853,7 +851,7 @@ fu_vli_usbhub_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* we could check this against flags */
-	g_debug("parsed version: %s", fu_firmware_get_version(firmware));
+	g_info("parsed version: %s", fu_firmware_get_version(firmware));
 	return g_steal_pointer(&firmware);
 }
 
@@ -1043,7 +1041,7 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
 
 		/* copy the header from the backup zone */
 	} else {
-		g_debug("HD1 was invalid, reading backup");
+		g_info("HD1 was invalid, reading backup");
 		if (!fu_vli_device_spi_read_block(FU_VLI_DEVICE(self),
 						  VLI_USBHUB_FLASHMAP_ADDR_HD1_BACKUP,
 						  (guint8 *)&self->hd1_hdr,
@@ -1055,7 +1053,7 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
 			return FALSE;
 		}
 		if (!fu_vli_usbhub_device_hd1_is_valid(&self->hd1_hdr)) {
-			g_debug("backup header is also invalid, starting recovery");
+			g_info("backup header is also invalid, starting recovery");
 			return fu_vli_usbhub_device_update_v2_recovery(self, fw, progress, error);
 		}
 		if (!fu_vli_usbhub_device_hd1_recover(self, &self->hd1_hdr, progress, error)) {

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -57,8 +57,7 @@ fu_vli_usbhub_device_i2c_read(FuVliUsbhubDevice *self,
 		g_prefix_error(error, "failed to read I2C: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "I2cReadData", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "I2cReadData", buf, bufsz);
 	return TRUE;
 }
 
@@ -85,8 +84,7 @@ fu_vli_usbhub_device_i2c_write_data(FuVliUsbhubDevice *self,
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	guint16 value = (((guint16)disable_start_bit) << 8) | disable_end_bit;
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "I2cWriteData", buf, bufsz);
+	fu_dump_raw(G_LOG_DOMAIN, "I2cWriteData", buf, bufsz);
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -156,7 +156,7 @@ fu_vli_usbhub_pd_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* we could check this against flags */
-	g_debug("parsed version: %s", fu_firmware_get_version(firmware));
+	g_info("parsed version: %s", fu_firmware_get_version(firmware));
 	return g_steal_pointer(&firmware);
 }
 

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -70,8 +70,7 @@ fu_vli_usbhub_device_i2c_write(FuVliUsbhubDevice *self,
 			    datasz,
 			    error))
 		return FALSE;
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "I2cWriteData", buf, datasz + 2);
+	fu_dump_raw(G_LOG_DOMAIN, "I2cWriteData", buf, datasz + 2);
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -117,8 +116,7 @@ fu_vli_usbhub_device_i2c_read(FuVliUsbhubDevice *self,
 		g_prefix_error(error, "failed to read I2C: ");
 		return FALSE;
 	}
-	if (g_getenv("FWUPD_VLI_USBHUB_VERBOSE") != NULL)
-		fu_dump_raw(G_LOG_DOMAIN, "I2cReadData", data, datasz);
+	fu_dump_raw(G_LOG_DOMAIN, "I2cReadData", data, datasz);
 	return TRUE;
 }
 

--- a/plugins/wacom-usb/fu-wac-common.c
+++ b/plugins/wacom-usb/fu-wac-common.c
@@ -58,8 +58,6 @@ void
 fu_wac_buffer_dump(const gchar *title, guint8 cmd, const guint8 *buf, gsize sz)
 {
 	g_autofree gchar *tmp = NULL;
-	if (g_getenv("FWUPD_WACOM_USB_VERBOSE") == NULL)
-		return;
 	tmp = g_strdup_printf("%s %s (%" G_GSIZE_FORMAT ")",
 			      title,
 			      fu_wac_report_id_to_string(cmd),

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -123,13 +123,11 @@ fu_wac_device_to_string(FuDevice *device, guint idt, GString *str)
 		g_autofree gchar *tmp = g_strdup_printf("0x%04x", (guint)self->configuration);
 		fu_string_append(str, idt, "Configuration", tmp);
 	}
-	if (g_getenv("FWUPD_WACOM_USB_VERBOSE") != NULL) {
-		for (guint i = 0; i < self->flash_descriptors->len; i++) {
-			FuWacFlashDescriptor *fd = g_ptr_array_index(self->flash_descriptors, i);
-			g_autofree gchar *title = g_strdup_printf("FlashDescriptor%02u", i);
-			fu_string_append(str, idt, title, NULL);
-			fu_wac_device_flash_descriptor_to_string(fd, idt + 1, str);
-		}
+	for (guint i = 0; i < self->flash_descriptors->len; i++) {
+		FuWacFlashDescriptor *fd = g_ptr_array_index(self->flash_descriptors, i);
+		g_autofree gchar *title = g_strdup_printf("FlashDescriptor%02u", i);
+		fu_string_append(str, idt, title, NULL);
+		fu_wac_device_flash_descriptor_to_string(fd, idt + 1, str);
 	}
 	status_str = fu_wac_device_status_to_string(self->status_word);
 	fu_string_append(str, idt, "Status", status_str->str);
@@ -237,7 +235,7 @@ fu_wac_device_ensure_flash_descriptors(FuWacDevice *self, GError **error)
 		return FALSE;
 	}
 
-	g_debug("added %u flash descriptors", self->flash_descriptors->len);
+	g_info("added %u flash descriptors", self->flash_descriptors->len);
 	return TRUE;
 }
 
@@ -278,14 +276,13 @@ fu_wac_device_ensure_checksums(FuWacDevice *self, GError **error)
 
 	/* parse */
 	updater_version = fu_memread_uint32(buf + 1, G_LITTLE_ENDIAN);
-	g_debug("updater-version: %" G_GUINT32_FORMAT, updater_version);
+	g_info("updater-version: %" G_GUINT32_FORMAT, updater_version);
 
 	/* get block checksums */
 	g_array_set_size(self->checksums, 0);
 	for (guint i = 0; i < self->nr_flash_blocks; i++) {
 		guint32 csum = fu_memread_uint32(buf + 5 + (i * 4), G_LITTLE_ENDIAN);
-		if (g_getenv("FWUPD_WACOM_USB_VERBOSE") != NULL)
-			g_debug("checksum block %02u: 0x%08x", i, (guint)csum);
+		g_debug("checksum block %02u: 0x%08x", i, (guint)csum);
 		g_array_append_val(self->checksums, csum);
 	}
 	g_debug("added %u checksums", self->flash_descriptors->len);
@@ -592,8 +589,7 @@ fu_wac_device_write_firmware(FuDevice *device,
 
 		/* calculate expected checksum and save to device RAM */
 		csum_local[i] = GUINT32_TO_LE(fu_sum32w_bytes(blob_block, G_LITTLE_ENDIAN));
-		if (g_getenv("FWUPD_WACOM_USB_VERBOSE") != NULL)
-			g_debug("block checksum %02u: 0x%08x", i, csum_local[i]);
+		g_debug("block checksum %02u: 0x%08x", i, csum_local[i]);
 		if (!fu_wac_device_set_checksum_of_block(self, i, csum_local[i], error))
 			return FALSE;
 
@@ -651,8 +647,7 @@ fu_wac_device_write_firmware(FuDevice *device,
 				    (guint)csum_local[i]);
 			return FALSE;
 		}
-		if (g_getenv("FWUPD_WACOM_USB_VERBOSE") != NULL)
-			g_debug("matched checksum at block %u of 0x%08x", i, csum_rom);
+		g_debug("matched checksum at block %u of 0x%08x", i, csum_rom);
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -148,11 +148,9 @@ fu_wac_module_refresh(FuWacModule *self, GError **error)
 	if (priv->command != buf[2] || priv->status != buf[3]) {
 		priv->command = buf[2];
 		priv->status = buf[3];
-		if (g_getenv("FWUPD_WACOM_VERBOSE") != NULL) {
-			g_debug("command: %s, status: %s",
-				fu_wac_module_command_to_string(priv->command),
-				fu_wac_module_status_to_string(priv->status));
-		}
+		g_debug("command: %s, status: %s",
+			fu_wac_module_command_to_string(priv->command),
+			fu_wac_module_status_to_string(priv->status));
 	}
 
 	/* success */

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -649,6 +649,7 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 	guint16 usb_pid = 0x0;
 	guint16 usb_vid = 0x0;
 	guint32 version_raw = 0;
+	guint8 device_cnt = 0x0;
 	guint8 update_state = 0x0;
 	guint8 buf[FU_WISTRON_DOCK_WDIT_SIZE + 1] = {FU_WISTRON_DOCK_ID_DOCK_WDIT};
 
@@ -759,22 +760,19 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 	fu_device_set_version_from_uint32(FU_DEVICE(self), version_raw);
 
 	/* for debugging only */
-	if (g_getenv("FWUPD_WISTRON_DOCK_VERBOSE") != NULL) {
-		guint8 device_cnt = 0x0;
-		if (!fu_memread_uint8_safe(buf,
-					   sizeof(buf),
-					   G_STRUCT_OFFSET(FuWistronDockWdit, device_cnt),
-					   &device_cnt,
-					   error))
-			return FALSE;
-		if (!fu_wistron_dock_device_parse_wdit_img(self,
-							   buf,
-							   sizeof(buf),
-							   MIN(device_cnt, 32),
-							   error)) {
-			g_prefix_error(error, "failed to parse imgs: ");
-			return FALSE;
-		}
+	if (!fu_memread_uint8_safe(buf,
+				   sizeof(buf),
+				   G_STRUCT_OFFSET(FuWistronDockWdit, device_cnt),
+				   &device_cnt,
+				   error))
+		return FALSE;
+	if (!fu_wistron_dock_device_parse_wdit_img(self,
+						   buf,
+						   sizeof(buf),
+						   MIN(device_cnt, 32),
+						   error)) {
+		g_prefix_error(error, "failed to parse imgs: ");
+		return FALSE;
 	}
 
 	/* adding the MCU while flashing the device, ignore until it comes back in runtime mode */

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -64,7 +64,7 @@ fu_bluez_backend_object_properties_changed(FuBluezBackend *self, GDBusProxy *pro
 			   "proxy",
 			   proxy,
 			   NULL);
-	g_debug("adding suitable BlueZ device: %s", path);
+	g_info("adding suitable BlueZ device: %s", path);
 	fu_backend_device_added(FU_BACKEND(self), FU_DEVICE(dev));
 }
 
@@ -111,7 +111,7 @@ fu_bluez_backend_object_removed_cb(GDBusObjectManager *manager,
 	device_tmp = fu_backend_lookup_by_id(FU_BACKEND(self), path);
 	if (device_tmp == NULL)
 		return;
-	g_debug("removing BlueZ device: %s", path);
+	g_info("removing BlueZ device: %s", path);
 	fu_backend_device_removed(FU_BACKEND(self), device_tmp);
 }
 

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -298,7 +298,7 @@ fu_config_monitor_changed_cb(GFileMonitor *monitor,
 	FuConfig *self = FU_CONFIG(user_data);
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *fn = g_file_get_path(file);
-	g_debug("%s changed, reloading all configs", fn);
+	g_info("%s changed, reloading all configs", fn);
 	if (!fu_config_reload(self, &error))
 		g_warning("failed to rescan daemon config: %s", error->message);
 	fu_config_emit_changed(self);

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -996,7 +996,7 @@ fu_daemon_schedule_process_quit_cb(gpointer user_data)
 {
 	FuDaemon *self = FU_DAEMON(user_data);
 
-	g_debug("daemon asked to quit, shutting down");
+	g_info("daemon asked to quit, shutting down");
 	self->process_quit_id = 0;
 	g_main_loop_quit(self->loop);
 	return G_SOURCE_REMOVE;
@@ -2130,7 +2130,7 @@ fu_daemon_dbus_connection_closed_cb(GDBusConnection *connection,
 				    gpointer user_data)
 {
 	FuDaemon *self = FU_DAEMON(user_data);
-	g_debug("client connection closed: %s", error != NULL ? error->message : "unknown");
+	g_info("client connection closed: %s", error != NULL ? error->message : "unknown");
 	g_clear_object(&self->connection);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -174,7 +174,7 @@ fu_engine_update_motd_timeout_cb(gpointer user_data)
 
 	/* update now */
 	if (!fu_engine_update_motd(self, &error_local))
-		g_debug("failed to update MOTD: %s", error_local->message);
+		g_info("failed to update MOTD: %s", error_local->message);
 	self->update_motd_id = 0;
 	return G_SOURCE_REMOVE;
 }
@@ -182,7 +182,7 @@ fu_engine_update_motd_timeout_cb(gpointer user_data)
 static void
 fu_engine_update_motd_reset(FuEngine *self)
 {
-	g_debug("resetting update motd timeout");
+	g_info("resetting update motd timeout");
 	if (self->update_motd_id != 0)
 		g_source_remove(self->update_motd_id);
 	self->update_motd_id = g_timeout_add_seconds(FU_ENGINE_UPDATE_MOTD_DELAY,
@@ -208,7 +208,7 @@ fu_engine_emit_changed(FuEngine *self)
 
 	/* update the list of devices */
 	if (!fu_engine_update_devices_file(self, &error))
-		g_debug("failed to update list of devices: %s", error->message);
+		g_info("failed to update list of devices: %s", error->message);
 }
 
 static void
@@ -372,7 +372,7 @@ fu_engine_history_notify_cb(FuDevice *device, GParamSpec *pspec, FuEngine *self)
 static void
 fu_engine_device_request_cb(FuDevice *device, FwupdRequest *request, FuEngine *self)
 {
-	g_debug("Emitting DeviceRequest('Message'='%s')", fwupd_request_get_message(request));
+	g_info("Emitting DeviceRequest('Message'='%s')", fwupd_request_get_message(request));
 	g_signal_emit(self, signals[SIGNAL_DEVICE_REQUEST], 0, request);
 }
 
@@ -399,7 +399,7 @@ fu_engine_install_phase_to_string(FuEngineInstallPhase phase)
 static void
 fu_engine_set_install_phase(FuEngine *self, FuEngineInstallPhase install_phase)
 {
-	g_debug("install phase now %s", fu_engine_install_phase_to_string(install_phase));
+	g_info("install phase now %s", fu_engine_install_phase_to_string(install_phase));
 	self->install_phase = install_phase;
 }
 
@@ -489,7 +489,7 @@ static gboolean
 fu_engine_acquiesce_timeout_cb(gpointer user_data)
 {
 	FuEngine *self = FU_ENGINE(user_data);
-	g_debug("system acquiesced after %ums", self->acquiesce_delay);
+	g_info("system acquiesced after %ums", self->acquiesce_delay);
 	g_main_loop_quit(self->acquiesce_loop);
 	self->acquiesce_id = 0;
 	return G_SOURCE_REMOVE;
@@ -500,7 +500,7 @@ fu_engine_acquiesce_reset(FuEngine *self)
 {
 	if (!g_main_loop_is_running(self->acquiesce_loop))
 		return;
-	g_debug("resetting system acquiesce timeout");
+	g_info("resetting system acquiesce timeout");
 	if (self->acquiesce_id != 0)
 		g_source_remove(self->acquiesce_id);
 	self->acquiesce_id =
@@ -900,7 +900,6 @@ fu_engine_update_bios_setting(FwupdBiosSetting *attr,
 				     error))
 		return FALSE;
 	fwupd_bios_setting_set_current_value(attr, value);
-
 	g_debug("set %s to %s", fwupd_bios_setting_get_id(attr), value);
 
 	return TRUE;
@@ -1075,7 +1074,7 @@ fu_engine_modify_bios_settings(FuEngine *self,
 
 	if (!fu_bios_settings_get_pending_reboot(bios_settings, &changed, error))
 		return FALSE;
-	g_debug("pending_reboot is now %d", changed);
+	g_info("pending_reboot is now %d", changed);
 	return TRUE;
 }
 
@@ -2184,8 +2183,8 @@ fu_engine_check_soft_requirement(FuEngine *self,
 	g_autoptr(GError) error_local = NULL;
 	if (!fu_engine_check_requirement(self, release, req, flags, &error_local)) {
 		if (flags & FWUPD_INSTALL_FLAG_FORCE) {
-			g_debug("ignoring soft-requirement due to --force: %s",
-				error_local->message);
+			g_info("ignoring soft-requirement due to --force: %s",
+			       error_local->message);
 			return TRUE;
 		}
 		g_propagate_error(error, g_steal_pointer(&error_local));
@@ -2256,11 +2255,11 @@ fu_engine_get_report_metadata_cpu_device(FuEngine *self, GHashTable *hash)
 
 	device = fu_device_list_get_by_guid(self->device_list, guid, &error_local);
 	if (device == NULL) {
-		g_debug("failed to find CPU device: %s", error_local->message);
+		g_info("failed to find CPU device: %s", error_local->message);
 		return;
 	}
 	if (fu_device_get_vendor(device) == NULL || fu_device_get_name(device) == NULL) {
-		g_debug("not enough data to include CpuModel");
+		g_info("not enough data to include CpuModel");
 		return;
 	}
 	g_hash_table_insert(
@@ -2640,9 +2639,9 @@ fu_engine_install_releases(FuEngine *self,
 	devices = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	for (guint i = 0; i < releases->len; i++) {
 		FuRelease *release = g_ptr_array_index(releases, i);
-		g_debug("composite update %u: %s",
-			i + 1,
-			fu_device_get_id(fu_release_get_device(release)));
+		g_info("composite update %u: %s",
+		       i + 1,
+		       fu_device_get_id(fu_release_get_device(release)));
 		g_ptr_array_add(devices, g_object_ref(fu_release_get_device(release)));
 	}
 	if (!fu_engine_composite_prepare(self, devices, error)) {
@@ -2689,7 +2688,7 @@ fu_engine_install_releases(FuEngine *self,
 						      fu_device_get_id(device),
 						      &error_local);
 		if (device_new == NULL) {
-			g_debug("failed to find new device: %s", error_local->message);
+			g_info("failed to find new device: %s", error_local->message);
 			continue;
 		}
 		g_ptr_array_add(devices_new, g_steal_pointer(&device_new));
@@ -2832,7 +2831,7 @@ fu_engine_offline_setup(GError **error)
 	/* does already exist */
 	filename = fu_realpath(trigger, NULL);
 	if (g_strcmp0(filename, symlink_target) == 0) {
-		g_debug("%s already points to %s, skipping creation", trigger, symlink_target);
+		g_info("%s already points to %s, skipping creation", trigger, symlink_target);
 		return TRUE;
 	}
 
@@ -2957,9 +2956,9 @@ fu_engine_schedule_update(FuEngine *self,
 		return FALSE;
 
 	/* schedule for next boot */
-	g_debug("schedule %s to be installed to %s on next boot",
-		filename,
-		fu_device_get_id(device));
+	g_info("schedule %s to be installed to %s on next boot",
+	       filename,
+	       fu_device_get_id(device));
 	fwupd_release_set_filename(release, filename);
 
 	/* add to database */
@@ -3210,8 +3209,7 @@ fu_engine_emulation_load_phase(FuEngine *self, FuEngineInstallPhase phase, GErro
 	const gchar *json = g_hash_table_lookup(self->emulation_phases, GINT_TO_POINTER(phase));
 	if (json == NULL)
 		return TRUE;
-	if (g_getenv("FWUPD_BACKEND_VERBOSE") != NULL)
-		g_debug("loading phase %s: %s", fu_engine_install_phase_to_string(phase), json);
+	g_info("loading phase %s: %s", fu_engine_install_phase_to_string(phase), json);
 	return fu_engine_emulation_load_json(self, json, error);
 }
 
@@ -3257,7 +3255,7 @@ fu_engine_emulation_load(FuEngine *self, GBytes *data, GError **error)
 			continue;
 		json_safe = g_strndup(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));
 		got_json = TRUE;
-		g_debug("got emulation for phase %s", fu_engine_install_phase_to_string(phase));
+		g_info("got emulation for phase %s", fu_engine_install_phase_to_string(phase));
 		if (phase == FU_ENGINE_INSTALL_PHASE_SETUP) {
 			if (!fu_engine_emulation_load_json(self, json_safe, error))
 				return FALSE;
@@ -3338,6 +3336,7 @@ fu_engine_backends_save_phase(FuEngine *self, GError **error)
 {
 	const gchar *data_old;
 	g_autofree gchar *data_new = NULL;
+	g_autofree gchar *data_new_safe = NULL;
 	g_autoptr(JsonBuilder) json_builder = json_builder_new();
 	g_autoptr(JsonGenerator) json_generator = NULL;
 	g_autoptr(JsonNode) json_root = NULL;
@@ -3361,22 +3360,20 @@ fu_engine_backends_save_phase(FuEngine *self, GError **error)
 	    g_hash_table_lookup(self->emulation_phases, GINT_TO_POINTER(self->install_phase));
 	data_new = json_generator_to_data(json_generator, NULL);
 	if (g_strcmp0(data_new, "") == 0) {
-		g_debug("no data for phase %s",
-			fu_engine_install_phase_to_string(self->install_phase));
+		g_info("no data for phase %s",
+		       fu_engine_install_phase_to_string(self->install_phase));
 		return TRUE;
 	}
 	if (g_strcmp0(data_old, data_new) == 0) {
-		g_debug("JSON unchanged for phase %s",
-			fu_engine_install_phase_to_string(self->install_phase));
+		g_info("JSON unchanged for phase %s",
+		       fu_engine_install_phase_to_string(self->install_phase));
 		return TRUE;
 	}
-	if (g_getenv("FWUPD_BACKEND_VERBOSE") != NULL) {
-		g_autofree gchar *data_new_safe = g_strndup(data_new, 8000);
-		g_debug("JSON %s for phase %s: %s...",
-			data_old == NULL ? "added" : "changed",
-			fu_engine_install_phase_to_string(self->install_phase),
-			data_new_safe);
-	}
+	data_new_safe = g_strndup(data_new, 8000);
+	g_info("JSON %s for phase %s: %s...",
+	       data_old == NULL ? "added" : "changed",
+	       fu_engine_install_phase_to_string(self->install_phase),
+	       data_new_safe);
 	g_hash_table_insert(self->emulation_phases,
 			    GINT_TO_POINTER(self->install_phase),
 			    g_steal_pointer(&data_new));
@@ -3465,7 +3462,7 @@ fu_engine_device_cleanup(FuEngine *self,
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
-		g_debug("skipping device cleanup due to will-disappear flag");
+		g_info("skipping device cleanup due to will-disappear flag");
 		return TRUE;
 	}
 
@@ -3546,7 +3543,7 @@ fu_engine_prepare(FuEngine *self,
 		return FALSE;
 
 	str = fu_device_to_string(device);
-	g_debug("prepare -> %s", str);
+	g_info("prepare -> %s", str);
 	if (!fu_engine_device_prepare(self, device, progress, flags, error))
 		return FALSE;
 	for (guint j = 0; j < plugins->len; j++) {
@@ -3583,7 +3580,7 @@ fu_engine_cleanup(FuEngine *self,
 	}
 	fu_device_remove_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
 	str = fu_device_to_string(device);
-	g_debug("cleanup -> %s", str);
+	g_info("cleanup -> %s", str);
 	if (!fu_engine_device_cleanup(self, device, progress, flags, error))
 		return FALSE;
 	for (guint j = 0; j < plugins->len; j++) {
@@ -3626,7 +3623,7 @@ fu_engine_detach(FuEngine *self,
 		return FALSE;
 
 	str = fu_device_to_string(device);
-	g_debug("detach -> %s", str);
+	g_info("detach -> %s", str);
 	plugin =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
@@ -3680,7 +3677,7 @@ fu_engine_attach(FuEngine *self, const gchar *device_id, FuProgress *progress, G
 		return FALSE;
 	}
 	str = fu_device_to_string(device);
-	g_debug("attach -> %s", str);
+	g_info("attach -> %s", str);
 	plugin =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
@@ -3735,13 +3732,11 @@ fu_engine_activate(FuEngine *self, const gchar *device_id, FuProgress *progress,
 	if (device == NULL)
 		return FALSE;
 	str = fu_device_to_string(device);
-	g_debug("activate -> %s", str);
+	g_info("activate -> %s", str);
 	plugin =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
 		return FALSE;
-	g_debug("Activating %s", fu_device_get_name(device));
-
 	if (!fu_plugin_runner_activate(plugin, device, progress, error))
 		return FALSE;
 
@@ -3765,14 +3760,14 @@ fu_engine_reload(FuEngine *self, const gchar *device_id, GError **error)
 		return FALSE;
 	}
 	str = fu_device_to_string(device);
-	g_debug("reload -> %s", str);
+	g_info("reload -> %s", str);
 	plugin =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
 		return FALSE;
 
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
-		g_debug("skipping reload due to will-disappear flag");
+		g_info("skipping reload due to will-disappear flag");
 		return TRUE;
 	}
 
@@ -3824,7 +3819,7 @@ fu_engine_write_firmware(FuEngine *self,
 
 	device_pending = fu_history_get_device_by_id(self->history, device_id, NULL);
 	str = fu_device_to_string(device);
-	g_debug("update -> %s", str);
+	g_info("update -> %s", str);
 	plugin =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), error);
 	if (plugin == NULL)
@@ -4071,9 +4066,9 @@ fu_engine_install_blob(FuEngine *self,
 
 	/* make the UI update */
 	fu_engine_emit_device_changed(self, device_id);
-	g_debug("Updating %s took %f seconds",
-		fu_device_get_name(device),
-		g_timer_elapsed(timer, NULL));
+	g_info("Updating %s took %f seconds",
+	       fu_device_get_name(device),
+	       g_timer_elapsed(timer, NULL));
 	return TRUE;
 }
 
@@ -4145,7 +4140,7 @@ fu_engine_create_silo_index(FuEngine *self, GError **error)
 	components = xb_silo_query(self->silo, "components/component[@type='firmware']", 0, NULL);
 	if (components == NULL)
 		return TRUE;
-	g_debug("%u components now in silo", components->len);
+	g_info("%u components now in silo", components->len);
 
 	/* clear old prepared queries */
 	g_clear_object(&self->query_component_by_guid);
@@ -4274,7 +4269,7 @@ fu_engine_create_metadata_builder_source(FuEngine *self, const gchar *fn, GError
 	g_autoptr(GFile) file = g_file_new_for_path(fn);
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
 
-	g_debug("using %s as metadata source", fn);
+	g_info("using %s as metadata source", fn);
 	xb_builder_source_add_simple_adapter(source,
 					     "application/vnd.ms-cab-compressed",
 					     fu_engine_builder_cabinet_adapter_cb,
@@ -4316,7 +4311,7 @@ fu_engine_create_metadata(FuEngine *self, XbBuilder *builder, FwupdRemote *remot
 
 		/* check is cab file */
 		if (!g_str_has_suffix(fn_lowercase, ".cab")) {
-			g_debug("ignoring: %s", fn);
+			g_info("ignoring: %s", fn);
 			continue;
 		}
 
@@ -4553,7 +4548,7 @@ fu_engine_md_refresh_device_name_category(FuEngine *self, FuDevice *device, XbNo
 			}
 		}
 		if (is_battery) {
-			g_debug("ignoring system power for %s battery", fu_device_get_id(device));
+			g_info("ignoring system power for %s battery", fu_device_get_id(device));
 			fu_device_add_internal_flag(device,
 						    FU_DEVICE_INTERNAL_FLAG_IGNORE_SYSTEM_POWER);
 		}
@@ -4670,14 +4665,14 @@ fu_engine_load_metadata_store_local(FuEngine *self,
 
 	metadata_fns = fu_path_glob(metadata_path, "*.xml", &error_local);
 	if (metadata_fns == NULL) {
-		g_debug("ignoring: %s", error_local->message);
+		g_info("ignoring: %s", error_local->message);
 		return TRUE;
 	}
 	for (guint i = 0; i < metadata_fns->len; i++) {
 		const gchar *path = g_ptr_array_index(metadata_fns, i);
 		g_autoptr(XbBuilderSource) source = xb_builder_source_new();
 		g_autoptr(GFile) file = g_file_new_for_path(path);
-		g_debug("loading local metadata: %s", path);
+		g_info("loading local metadata: %s", path);
 		if (!xb_builder_source_load_file(source,
 						 file,
 						 XB_BUILDER_SOURCE_FLAG_NONE,
@@ -4729,7 +4724,7 @@ fu_engine_load_metadata_store(FuEngine *self, FuEngineLoadFlags flags, GError **
 
 		/* generate all metadata on demand */
 		if (fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_DIRECTORY) {
-			g_debug("loading metadata for remote '%s'", fwupd_remote_get_id(remote));
+			g_info("loading metadata for remote '%s'", fwupd_remote_get_id(remote));
 			if (!fu_engine_create_metadata(self, builder, remote, &error_local)) {
 				g_warning("failed to generate remote %s: %s",
 					  fwupd_remote_get_id(remote),
@@ -4949,7 +4944,7 @@ fu_engine_validate_result_timestamp(JcatResult *jcat_result,
 		return FALSE;
 	}
 	if (delta > 0)
-		g_debug("timestamp increased, so no rollback");
+		g_info("timestamp increased, so no rollback");
 	return TRUE;
 }
 
@@ -5058,7 +5053,7 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 		jcat_result_old = fu_engine_get_system_jcat_result(self, remote, &error_local);
 		if (jcat_result_old == NULL) {
 			if (g_error_matches(error_local, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
-				g_debug("no existing valid keyrings: %s", error_local->message);
+				g_info("no existing valid keyrings: %s", error_local->message);
 			} else {
 				g_warning("could not get existing keyring result: %s",
 					  error_local->message);
@@ -5420,12 +5415,12 @@ fu_engine_get_details_for_bytes(FuEngine *self,
 						    NULL,
 						    install_flags,
 						    &error_req)) {
-				g_debug("%s failed requirement checks: %s",
-					fu_device_get_id(dev),
-					error_req->message);
+				g_info("%s failed requirement checks: %s",
+				       fu_device_get_id(dev),
+				       error_req->message);
 				fu_device_inhibit(dev, "failed-reqs", error_req->message);
 			} else {
-				g_debug("%s passed requirement checks", fu_device_get_id(dev));
+				g_info("%s passed requirement checks", fu_device_get_id(dev));
 				fu_device_uninhibit(dev, "failed-reqs");
 			}
 		}
@@ -5787,7 +5782,7 @@ fu_engine_check_release_is_approved(FuEngine *self, FwupdRelease *rel)
 		return FALSE;
 	for (guint i = 0; i < csums->len; i++) {
 		const gchar *csum = g_ptr_array_index(csums, i);
-		g_debug("checking %s against approved list", csum);
+		g_info("checking %s against approved list", csum);
 		if (g_hash_table_lookup(self->approved_firmware, csum) != NULL)
 			return TRUE;
 	}
@@ -5884,9 +5879,9 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 		/* different branch */
 		if (g_strcmp0(fu_release_get_branch(release), fu_device_get_branch(device)) != 0) {
 			if ((feature_flags & FWUPD_FEATURE_FLAG_SWITCH_BRANCH) == 0) {
-				g_debug("client does not understand branches, skipping %s:%s",
-					fu_release_get_branch(release),
-					fu_release_get_version(release));
+				g_info("client does not understand branches, skipping %s:%s",
+				       fu_release_get_branch(release),
+				       fu_release_get_version(release));
 				continue;
 			}
 			fu_release_add_flag(release, FWUPD_RELEASE_FLAG_IS_ALTERNATE_BRANCH);
@@ -6190,10 +6185,10 @@ fu_engine_get_downgrades(FuEngine *self,
 
 		/* different branch */
 		if (fwupd_release_has_flag(rel_tmp, FWUPD_RELEASE_FLAG_IS_ALTERNATE_BRANCH)) {
-			g_debug("ignoring release %s as branch %s, and device is %s",
-				fwupd_release_get_version(rel_tmp),
-				fwupd_release_get_branch(rel_tmp),
-				fu_device_get_branch(device));
+			g_info("ignoring release %s as branch %s, and device is %s",
+			       fwupd_release_get_version(rel_tmp),
+			       fwupd_release_get_branch(rel_tmp),
+			       fu_device_get_branch(device));
 			continue;
 		}
 
@@ -6413,10 +6408,10 @@ fu_engine_get_upgrades(FuEngine *self,
 
 		/* different branch */
 		if (fwupd_release_has_flag(rel_tmp, FWUPD_RELEASE_FLAG_IS_ALTERNATE_BRANCH)) {
-			g_debug("ignoring release %s as branch %s, and device is %s",
-				fwupd_release_get_version(rel_tmp),
-				fwupd_release_get_branch(rel_tmp),
-				fu_device_get_branch(device));
+			g_info("ignoring release %s as branch %s, and device is %s",
+			       fwupd_release_get_version(rel_tmp),
+			       fwupd_release_get_branch(rel_tmp),
+			       fu_device_get_branch(device));
 			continue;
 		}
 
@@ -6549,7 +6544,7 @@ fu_engine_plugins_startup(FuEngine *self, FuProgress *progress)
 			if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 				fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_NO_HARDWARE);
 			}
-			g_message("disabling plugin because: %s", error->message);
+			g_info("disabling plugin because: %s", error->message);
 			fu_progress_add_flag(progress, FU_PROGRESS_FLAG_CHILD_FINISHED);
 		}
 		fu_progress_step_done(progress);
@@ -6571,7 +6566,7 @@ fu_engine_plugins_coldplug(FuEngine *self, FuProgress *progress)
 		FuPlugin *plugin = g_ptr_array_index(plugins, i);
 		if (!fu_plugin_runner_coldplug(plugin, fu_progress_get_child(progress), &error)) {
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED);
-			g_message("disabling plugin because: %s", error->message);
+			g_info("disabling plugin because: %s", error->message);
 			fu_progress_add_flag(progress, FU_PROGRESS_FLAG_CHILD_FINISHED);
 		}
 		fu_progress_step_done(progress);
@@ -6586,7 +6581,7 @@ fu_engine_plugins_coldplug(FuEngine *self, FuProgress *progress)
 	}
 	if (str->len > 2) {
 		g_string_truncate(str, str->len - 2);
-		g_debug("using plugins: %s", str->str);
+		g_info("using plugins: %s", str->str);
 	}
 }
 
@@ -6624,9 +6619,9 @@ fu_engine_plugin_device_added_cb(FuPlugin *plugin, FuDevice *device, gpointer us
 
 	/* plugin has prio and device not already set from quirk */
 	if (fu_plugin_get_priority(plugin) > 0 && fu_device_get_priority(device) == 0) {
-		g_debug("auto-setting %s priority to %u",
-			fu_device_get_id(device),
-			fu_plugin_get_priority(plugin));
+		g_info("auto-setting %s priority to %u",
+		       fu_device_get_id(device),
+		       fu_plugin_get_priority(plugin));
 		fu_device_set_priority(device, fu_plugin_get_priority(plugin));
 	}
 
@@ -6715,10 +6710,10 @@ fu_engine_set_proxy_device(FuEngine *self, FuDevice *device)
 	proxy =
 	    fu_device_list_get_by_guid(self->device_list, fu_device_get_proxy_guid(device), NULL);
 	if (proxy != NULL) {
-		g_debug("setting proxy of %s to %s for %s",
-			fu_device_get_id(proxy),
-			fu_device_get_id(device),
-			fu_device_get_proxy_guid(device));
+		g_info("setting proxy of %s to %s for %s",
+		       fu_device_get_id(proxy),
+		       fu_device_get_id(device),
+		       fu_device_get_proxy_guid(device));
 		fu_device_set_proxy(device, proxy);
 		return;
 	}
@@ -6731,10 +6726,10 @@ fu_engine_set_proxy_device(FuEngine *self, FuDevice *device)
 		for (guint i = 0; i < devices->len; i++) {
 			FuDevice *device_tmp = g_ptr_array_index(devices, i);
 			if (g_strcmp0(fu_device_get_proxy_guid(device_tmp), guid) == 0) {
-				g_debug("adding proxy of %s to %s for %s",
-					fu_device_get_id(device),
-					fu_device_get_id(device_tmp),
-					guid);
+				g_info("adding proxy of %s to %s for %s",
+				       fu_device_get_id(device),
+				       fu_device_get_id(device_tmp),
+				       guid);
 				fu_device_set_proxy(device_tmp, device);
 				return;
 			}
@@ -6768,10 +6763,10 @@ fu_engine_device_inherit_history(FuEngine *self, FuDevice *device)
 		if (fu_version_compare(fu_device_get_version(device),
 				       fwupd_release_get_version(release),
 				       fu_device_get_version_format(device)) != 0) {
-			g_debug("inheriting needs-activation for %s as version %s != %s",
-				fu_device_get_name(device),
-				fu_device_get_version(device),
-				fwupd_release_get_version(release));
+			g_info("inheriting needs-activation for %s as version %s != %s",
+			       fu_device_get_name(device),
+			       fu_device_get_version(device),
+			       fwupd_release_get_version(release));
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 		}
 	}
@@ -6791,7 +6786,7 @@ fu_engine_ensure_device_emulation_tag(FuEngine *self, FuDevice *device)
 		return;
 
 	/* success */
-	g_debug("adding emulation-tag to %s", fu_device_get_backend_id(device));
+	g_info("adding emulation-tag to %s", fu_device_get_backend_id(device));
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_EMULATION_TAG);
 	fu_engine_check_context_flag_save_events(self);
 }
@@ -6819,11 +6814,11 @@ fu_engine_add_device(FuEngine *self, FuDevice *device)
 		for (guint j = 0; j < device_guids->len; j++) {
 			const gchar *device_guid = g_ptr_array_index(device_guids, j);
 			if (g_strcmp0(disabled_guid, device_guid) == 0) {
-				g_debug("%s [%s] is disabled [%s], ignoring from %s",
-					fu_device_get_name(device),
-					fu_device_get_id(device),
-					device_guid,
-					fu_device_get_plugin(device));
+				g_info("%s [%s] is disabled [%s], ignoring from %s",
+				       fu_device_get_name(device),
+				       fu_device_get_id(device),
+				       device_guid,
+				       fu_device_get_plugin(device));
 				return;
 			}
 		}
@@ -6983,7 +6978,7 @@ fu_engine_plugin_device_removed_cb(FuPlugin *plugin, FuDevice *device, gpointer 
 
 	device_tmp = fu_device_list_get_by_id(self->device_list, fu_device_get_id(device), &error);
 	if (device_tmp == NULL) {
-		g_debug("failed to find device %s: %s", fu_device_get_id(device), error->message);
+		g_info("failed to find device %s: %s", fu_device_get_id(device), error->message);
 		return;
 	}
 
@@ -6991,15 +6986,15 @@ fu_engine_plugin_device_removed_cb(FuPlugin *plugin, FuDevice *device, gpointer 
 	plugin_old =
 	    fu_plugin_list_find_by_name(self->plugin_list, fu_device_get_plugin(device), &error);
 	if (plugin_old == NULL) {
-		g_debug("failed to find plugin %s: %s",
-			fu_device_get_plugin(device),
-			error->message);
+		g_info("failed to find plugin %s: %s",
+		       fu_device_get_plugin(device),
+		       error->message);
 		return;
 	}
 
 	/* check this came from the same plugin */
 	if (g_strcmp0(fu_plugin_get_name(plugin), fu_plugin_get_name(plugin_old)) != 0) {
-		g_debug("ignoring duplicate removal from %s", fu_plugin_get_name(plugin));
+		g_info("ignoring duplicate removal from %s", fu_plugin_get_name(plugin));
 		return;
 	}
 
@@ -7166,7 +7161,7 @@ fu_engine_attrs_calculate_hsi_for_chassis(FuEngine *self)
 	/* if emulating, force the chassis type to be valid */
 	if (self->host_emulation && (chassis_kind == FU_SMBIOS_CHASSIS_KIND_OTHER ||
 				     chassis_kind == FU_SMBIOS_CHASSIS_KIND_UNKNOWN)) {
-		g_debug("forcing chassis kind [0x%x] to be valid", chassis_kind);
+		g_info("forcing chassis kind [0x%x] to be valid", chassis_kind);
 		chassis_kind = FU_SMBIOS_CHASSIS_KIND_DESKTOP;
 	}
 
@@ -7225,7 +7220,7 @@ fu_engine_record_security_attrs(FuEngine *self, GError **error)
 	if (attrs_array->len > 0) {
 		FuSecurityAttrs *attrs_tmp = g_ptr_array_index(attrs_array, 0);
 		if (fu_security_attrs_equal(attrs_tmp, self->host_security_attrs)) {
-			g_debug("skipping writing HSI attrs to database as unchanged");
+			g_info("skipping writing HSI attrs to database as unchanged");
 			return TRUE;
 		}
 	}
@@ -7652,13 +7647,13 @@ fu_engine_plugins_init(FuEngine *self, FuProgress *progress, GError **error)
 		g_autofree gchar *str = NULL;
 		g_ptr_array_add(plugins_disabled, NULL);
 		str = g_strjoinv(", ", (gchar **)plugins_disabled->pdata);
-		g_debug("plugins disabled: %s", str);
+		g_info("plugins disabled: %s", str);
 	}
 	if (plugins_disabled_rt->len > 0) {
 		g_autofree gchar *str = NULL;
 		g_ptr_array_add(plugins_disabled_rt, NULL);
 		str = g_strjoinv(", ", (gchar **)plugins_disabled_rt->pdata);
-		g_debug("plugins runtime-disabled: %s", str);
+		g_info("plugins runtime-disabled: %s", str);
 	}
 
 	/* depsolve into the correct order */
@@ -7706,7 +7701,7 @@ fu_engine_apply_default_bios_settings_policy(FuEngine *self, GError **error)
 		if (!g_str_has_suffix(tmp, ".json"))
 			continue;
 		fn = g_build_filename(dirname, tmp, NULL);
-		g_debug("Loading default BIOS settings policy from %s", fn);
+		g_info("loading default BIOS settings policy from %s", fn);
 		if (!fu_bios_settings_from_json_file(new_bios_settings, fn, error))
 			return FALSE;
 	}
@@ -7744,7 +7739,7 @@ fu_engine_check_firmware_attributes(FuEngine *self, FuDevice *device, gboolean a
 			if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO))
 				g_debug("%s", error->message);
 			else
-				g_warning("Failed to apply BIOS settings policy: %s",
+				g_warning("failed to apply BIOS settings policy: %s",
 					  error->message);
 			return;
 		}
@@ -7760,11 +7755,7 @@ fu_engine_backend_device_removed_cb(FuBackend *backend, FuDevice *device, FuEngi
 	fu_engine_check_firmware_attributes(self, device, FALSE);
 
 	/* debug */
-	if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-		g_debug("%s removed %s",
-			fu_backend_get_name(backend),
-			fu_device_get_backend_id(device));
-	}
+	g_debug("%s removed %s", fu_backend_get_name(backend), fu_device_get_backend_id(device));
 
 	/* go through each device and remove any that match */
 	devices = fu_device_list_get_all(self->device_list);
@@ -7774,14 +7765,14 @@ fu_engine_backend_device_removed_cb(FuBackend *backend, FuDevice *device, FuEngi
 			      fu_device_get_backend_id(device)) == 0) {
 			if (fu_device_has_internal_flag(device_tmp,
 							FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE)) {
-				g_debug("not auto-removing backend device %s [%s] due to flags",
-					fu_device_get_name(device_tmp),
-					fu_device_get_id(device_tmp));
+				g_info("not auto-removing backend device %s [%s] due to flags",
+				       fu_device_get_name(device_tmp),
+				       fu_device_get_id(device_tmp));
 				continue;
 			}
-			g_debug("auto-removing backend device %s [%s]",
-				fu_device_get_name(device_tmp),
-				fu_device_get_id(device_tmp));
+			g_info("auto-removing backend device %s [%s]",
+			       fu_device_get_name(device_tmp),
+			       fu_device_get_id(device_tmp));
 			fu_device_list_remove(self->device_list, device_tmp);
 			fu_engine_emit_changed(self);
 		}
@@ -7840,11 +7831,7 @@ fu_engine_backend_device_added_run_plugins(FuEngine *self, FuDevice *device, FuP
 							       fu_progress_get_child(progress),
 							       &error_local)) {
 			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
-				if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-					g_debug("%s ignoring: %s",
-						plugin_name,
-						error_local->message);
-				}
+				g_debug("%s ignoring: %s", plugin_name, error_local->message);
 			} else {
 				g_warning("failed to add device %s: %s",
 					  fu_device_get_backend_id(device),
@@ -7861,6 +7848,8 @@ fu_engine_backend_device_added_run_plugins(FuEngine *self, FuDevice *device, FuP
 static void
 fu_engine_backend_device_added(FuEngine *self, FuDevice *device, FuProgress *progress)
 {
+	g_autofree gchar *str1 = NULL;
+	g_autofree gchar *str2 = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* progress */
@@ -7871,10 +7860,8 @@ fu_engine_backend_device_added(FuEngine *self, FuDevice *device, FuProgress *pro
 	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 50, "query-possible-plugins");
 
 	/* super useful for plugin development */
-	if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-		g_autofree gchar *str = fu_device_to_string(FU_DEVICE(device));
-		g_debug("%s added %s", fu_device_get_backend_id(device), str);
-	}
+	str1 = fu_device_to_string(FU_DEVICE(device));
+	g_debug("%s added %s", fu_device_get_backend_id(device), str1);
 
 	/* add any extra quirks */
 	fu_device_set_context(device, self->ctx);
@@ -7883,7 +7870,7 @@ fu_engine_backend_device_added(FuEngine *self, FuDevice *device, FuProgress *pro
 			g_warning("failed to probe device %s: %s",
 				  fu_device_get_backend_id(device),
 				  error_local->message);
-		} else if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
+		} else {
 			g_debug("failed to probe device %s : %s",
 				fu_device_get_backend_id(device),
 				error_local->message);
@@ -7897,10 +7884,8 @@ fu_engine_backend_device_added(FuEngine *self, FuDevice *device, FuProgress *pro
 	fu_engine_ensure_device_emulation_tag(self, device);
 
 	/* super useful for plugin development */
-	if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-		g_autofree gchar *str = fu_device_to_string(FU_DEVICE(device));
-		g_debug("%s added %s", fu_device_get_backend_id(device), str);
-	}
+	str2 = fu_device_to_string(FU_DEVICE(device));
+	g_debug("%s added %s", fu_device_get_backend_id(device), str2);
 
 	/* if this is for firmware attributes, reload that part of the daemon */
 	fu_engine_check_firmware_attributes(self, device, TRUE);
@@ -7924,11 +7909,7 @@ fu_engine_backend_device_changed_cb(FuBackend *backend, FuDevice *device, FuEngi
 	g_autoptr(GPtrArray) devices = NULL;
 
 	/* debug */
-	if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-		g_debug("%s changed %s",
-			fu_backend_get_name(backend),
-			fu_device_get_physical_id(device));
-	}
+	g_debug("%s changed %s", fu_backend_get_name(backend), fu_device_get_physical_id(device));
 
 	/* emit changed on any that match */
 	devices = fu_device_list_get_all(self->device_list);
@@ -8001,13 +7982,13 @@ fu_engine_load_quirks_for_hwid(FuEngine *self, const gchar *hwid)
 		g_autoptr(GError) error_local = NULL;
 		plugin = fu_plugin_list_find_by_name(self->plugin_list, plugins[i], &error_local);
 		if (plugin == NULL) {
-			g_debug("no %s plugin for HwId %s: %s",
-				plugins[i],
-				hwid,
-				error_local->message);
+			g_info("no %s plugin for HwId %s: %s",
+			       plugins[i],
+			       hwid,
+			       error_local->message);
 			continue;
 		}
-		g_debug("enabling %s due to HwId %s", plugins[i], hwid);
+		g_info("enabling %s due to HwId %s", plugins[i], hwid);
 		fu_plugin_remove_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
 	}
 }
@@ -8041,11 +8022,11 @@ fu_engine_update_history_device(FuEngine *self, FuDevice *dev_history, GError **
 	 * i.e. has fwupd been restarted before we rebooted */
 	btime = fu_engine_get_boot_time();
 	if (g_strcmp0(fwupd_release_get_metadata_item(rel_history, "BootTime"), btime) == 0) {
-		g_debug("service restarted, but no reboot has taken place");
+		g_info("service restarted, but no reboot has taken place");
 
 		/* if it needed reboot then, it also needs it now... */
 		if (fu_device_get_update_state(dev_history) == FWUPD_UPDATE_STATE_NEEDS_REBOOT) {
-			g_debug("inheriting needs-reboot for %s", fu_device_get_name(dev));
+			g_info("inheriting needs-reboot for %s", fu_device_get_name(dev));
 			fu_device_set_update_state(dev, FWUPD_UPDATE_STATE_NEEDS_REBOOT);
 		}
 		return TRUE;
@@ -8076,9 +8057,9 @@ fu_engine_update_history_device(FuEngine *self, FuDevice *dev_history, GError **
 			       fwupd_release_get_version(rel_history),
 			       fu_device_get_version_format(dev)) == 0) {
 		GPtrArray *checksums;
-		g_debug("installed version %s matching history %s",
-			fu_device_get_version(dev),
-			fwupd_release_get_version(rel_history));
+		g_info("installed version %s matching history %s",
+		       fu_device_get_version(dev),
+		       fwupd_release_get_version(rel_history));
 
 		/* copy over runtime checksums if set from probe() */
 		checksums = fu_device_get_checksums(dev);
@@ -8103,7 +8084,7 @@ fu_engine_update_history_device(FuEngine *self, FuDevice *dev_history, GError **
 	/* the plugin either can't tell us the error, or doesn't know itself */
 	if (fu_device_get_update_state(dev) != FWUPD_UPDATE_STATE_FAILED &&
 	    fu_device_get_update_state(dev) != FWUPD_UPDATE_STATE_FAILED_TRANSIENT) {
-		g_debug("falling back to generic failure");
+		g_info("falling back to generic failure");
 		fu_device_set_update_state(dev_history, FWUPD_UPDATE_STATE_FAILED);
 		fu_device_set_update_error(dev_history, "failed to run update on reboot");
 	} else {
@@ -8158,13 +8139,13 @@ fu_engine_ensure_client_certificate(FuEngine *self)
 	jcat_sig = jcat_engine_self_sign(jcat_engine, blob, JCAT_SIGN_FLAG_NONE, &error);
 	if (jcat_sig == NULL) {
 		if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT)) {
-			g_debug("client certificate now exists: %s", error->message);
+			g_info("client certificate now exists: %s", error->message);
 			return;
 		}
 		g_message("failed to sign using keyring: %s", error->message);
 		return;
 	}
-	g_debug("client certificate exists and working");
+	g_info("client certificate exists and working");
 }
 
 static void
@@ -8357,11 +8338,9 @@ fu_engine_backends_coldplug(FuEngine *self, FuProgress *progress)
 			if (g_error_matches(error_backend,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED)) {
-				if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-					g_debug("ignoring coldplug failure %s: %s",
-						fu_backend_get_name(backend),
-						error_backend->message);
-				}
+				g_debug("ignoring coldplug failure %s: %s",
+					fu_backend_get_name(backend),
+					error_backend->message);
 			} else {
 				g_warning("failed to coldplug backend %s: %s",
 					  fu_backend_get_name(backend),
@@ -8389,12 +8368,14 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 {
 	FuPlugin *plugin_uefi;
 	FuQuirksLoadFlags quirks_flags = FU_QUIRKS_LOAD_FLAG_NONE;
+	GPtrArray *plugins = fu_plugin_list_get_all(self->plugin_list);
 	const gchar *host_emulate = g_getenv("FWUPD_HOST_EMULATE");
 	g_autoptr(GPtrArray) checksums_approved = NULL;
 	g_autoptr(GPtrArray) checksums_blocked = NULL;
 	g_autoptr(GError) error_quirks = NULL;
 	g_autoptr(GError) error_json_devices = NULL;
 	g_autoptr(GError) error_local = NULL;
+	g_autoptr(GString) str = g_string_new(NULL);
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -8453,7 +8434,7 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	self->host_machine_id = fwupd_build_machine_id("fwupd", &error_local);
 #endif
 	if (self->host_machine_id == NULL)
-		g_debug("failed to build machine-id: %s", error_local->message);
+		g_info("failed to build machine-id: %s", error_local->message);
 
 	/* ensure these exist before starting */
 	if (!fu_engine_ensure_paths_exist(error))
@@ -8645,9 +8626,9 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 			if (!fu_backend_setup(backend,
 					      fu_progress_get_child(progress),
 					      &error_backend)) {
-				g_debug("failed to setup backend %s: %s",
-					fu_backend_get_name(backend),
-					error_backend->message);
+				g_info("failed to setup backend %s: %s",
+				       fu_backend_get_name(backend),
+				       error_backend->message);
 				continue;
 			}
 		}
@@ -8713,23 +8694,17 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	fu_progress_step_done(progress);
 
 	/* dump plugin information to the console */
-	if (g_getenv("FWUPD_BACKEND_VERBOSE") != NULL) {
-		GPtrArray *plugins = fu_plugin_list_get_all(self->plugin_list);
-		g_autoptr(GString) str = g_string_new(NULL);
-		for (guint i = 0; i < self->backends->len; i++) {
-			FuBackend *backend = g_ptr_array_index(self->backends, i);
-			fu_backend_add_string(backend, 0, str);
-		}
-		if (str->len > 0)
-			g_string_append_c(str, '\n');
-		for (guint i = 0; i < plugins->len; i++) {
-			FuPlugin *plugin = g_ptr_array_index(plugins, i);
-			if (fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
-				continue;
-			fu_plugin_add_string(plugin, 0, str);
-		}
-		g_debug("\n%s", str->str);
+	for (guint i = 0; i < self->backends->len; i++) {
+		FuBackend *backend = g_ptr_array_index(self->backends, i);
+		fu_backend_add_string(backend, 0, str);
 	}
+	for (guint i = 0; i < plugins->len; i++) {
+		FuPlugin *plugin = g_ptr_array_index(plugins, i);
+		if (fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED))
+			continue;
+		fu_plugin_add_string(plugin, 0, str);
+	}
+	g_info("%s", str->str);
 
 	/* update the db for devices that were updated during the reboot */
 	if (!fu_engine_update_history_database(self, error))
@@ -8738,7 +8713,7 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 
 	/* update the devices JSON file */
 	if (!fu_engine_update_devices_file(self, &error_json_devices))
-		g_debug("failed to update list of devices: %s", error_json_devices->message);
+		g_info("failed to update list of devices: %s", error_json_devices->message);
 
 	fu_engine_set_status(self, FWUPD_STATUS_IDLE);
 	self->loaded = TRUE;

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -218,7 +218,7 @@ fu_history_migrate_database_v1(FuHistory *self, GError **error)
 {
 	gint rc;
 
-	g_debug("migrating v1 database by recreating table");
+	g_info("migrating v1 database by recreating table");
 	/* rename the table to something out the way */
 	rc = sqlite3_exec(self->db, "ALTER TABLE history RENAME TO history_old;", NULL, NULL, NULL);
 	if (rc != SQLITE_OK) {
@@ -386,9 +386,9 @@ fu_history_create_or_migrate(FuHistory *self, guint schema_ver, GError **error)
 	g_autoptr(sqlite3_stmt) stmt = NULL;
 
 	if (schema_ver == 0)
-		g_debug("building initial database");
+		g_info("building initial database");
 	else if (schema_ver > 1)
-		g_debug("migrating v%u database by altering", schema_ver);
+		g_info("migrating v%u database by altering", schema_ver);
 
 	switch (schema_ver) {
 	/* create initial up-to-date database or migrate */

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -54,7 +54,7 @@ fu_main_argv_changed_cb(GFileMonitor *monitor,
 			gpointer user_data)
 {
 	FuDaemon *daemon = FU_DAEMON(user_data);
-	g_debug("binary changed, shutting down");
+	g_info("binary changed, shutting down");
 	fu_daemon_stop(daemon);
 }
 
@@ -64,7 +64,7 @@ fu_main_memory_monitor_warning_cb(GMemoryMonitor *memory_monitor,
 				  GMemoryMonitorWarningLevel level,
 				  FuDaemon *daemon)
 {
-	g_debug("OOM event, shutting down");
+	g_info("OOM event, shutting down");
 	fu_daemon_stop(daemon);
 }
 #endif

--- a/src/fu-plugin-list.c
+++ b/src/fu-plugin-list.c
@@ -63,9 +63,9 @@ fu_plugin_list_rules_changed_cb(FuPlugin *plugin, gpointer user_data)
 			continue;
 		if (fu_plugin_has_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED))
 			continue;
-		g_debug("late disabling %s as conflicts with %s",
-			fu_plugin_get_name(dep),
-			fu_plugin_get_name(plugin));
+		g_info("late disabling %s as conflicts with %s",
+		       fu_plugin_get_name(dep),
+		       fu_plugin_get_name(plugin));
 		fu_plugin_add_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED);
 	}
 }
@@ -176,10 +176,10 @@ fu_plugin_list_depsolve(FuPluginList *self, GError **error)
 				const gchar *plugin_name = g_ptr_array_index(deps, j);
 				dep = fu_plugin_list_find_by_name(self, plugin_name, NULL);
 				if (dep == NULL) {
-					g_debug("cannot find plugin '%s' "
-						"requested by '%s'",
-						plugin_name,
-						fu_plugin_get_name(plugin));
+					g_info("cannot find plugin '%s' "
+					       "requested by '%s'",
+					       plugin_name,
+					       fu_plugin_get_name(plugin));
 					continue;
 				}
 				if (fu_plugin_has_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED))
@@ -206,10 +206,10 @@ fu_plugin_list_depsolve(FuPluginList *self, GError **error)
 				const gchar *plugin_name = g_ptr_array_index(deps, j);
 				dep = fu_plugin_list_find_by_name(self, plugin_name, NULL);
 				if (dep == NULL) {
-					g_debug("cannot find plugin '%s' "
-						"requested by '%s'",
-						plugin_name,
-						fu_plugin_get_name(plugin));
+					g_info("cannot find plugin '%s' "
+					       "requested by '%s'",
+					       plugin_name,
+					       fu_plugin_get_name(plugin));
 					continue;
 				}
 				if (fu_plugin_has_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED))
@@ -238,10 +238,10 @@ fu_plugin_list_depsolve(FuPluginList *self, GError **error)
 				const gchar *plugin_name = g_ptr_array_index(deps, j);
 				dep = fu_plugin_list_find_by_name(self, plugin_name, NULL);
 				if (dep == NULL) {
-					g_debug("cannot find plugin '%s' "
-						"referenced by '%s'",
-						plugin_name,
-						fu_plugin_get_name(plugin));
+					g_info("cannot find plugin '%s' "
+					       "referenced by '%s'",
+					       plugin_name,
+					       fu_plugin_get_name(plugin));
 					continue;
 				}
 				if (fu_plugin_has_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED))
@@ -286,9 +286,9 @@ fu_plugin_list_depsolve(FuPluginList *self, GError **error)
 				continue;
 			if (fu_plugin_has_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED))
 				continue;
-			g_debug("disabling %s as conflicts with %s",
-				fu_plugin_get_name(dep),
-				fu_plugin_get_name(plugin));
+			g_info("disabling %s as conflicts with %s",
+			       fu_plugin_get_name(dep),
+			       fu_plugin_get_name(plugin));
 			fu_plugin_add_flag(dep, FWUPD_PLUGIN_FLAG_DISABLED);
 		}
 	}

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4864,7 +4864,6 @@ main(int argc, char **argv)
 	/* only critical and error are fatal */
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
-	(void)g_setenv("FWUPD_DEVICE_LIST_VERBOSE", "1", TRUE);
 	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
 	(void)g_setenv("FWUPD_DATADIR", testdatadir, TRUE);
 	(void)g_setenv("FWUPD_LIBDIR_PKG", testdatadir, TRUE);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -215,11 +215,11 @@ fu_util_start_engine(FuUtilPrivate *priv,
 	}
 #ifdef HAVE_SYSTEMD
 	if (getuid() != 0 || geteuid() != 0) {
-		g_debug("not attempting to stop daemon when running as user");
+		g_info("not attempting to stop daemon when running as user");
 	} else {
 		g_autoptr(GError) error_local = NULL;
 		if (!fu_systemd_unit_stop(fu_util_get_systemd_unit(), &error_local))
-			g_debug("Failed to stop daemon: %s", error_local->message);
+			g_info("failed to stop daemon: %s", error_local->message);
 	}
 #endif
 	flags |= FU_ENGINE_LOAD_FLAG_NO_IDLE_SOURCES;
@@ -292,7 +292,7 @@ static gboolean
 fu_util_sigint_cb(gpointer user_data)
 {
 	FuUtilPrivate *priv = (FuUtilPrivate *)user_data;
-	g_debug("Handling SIGINT");
+	g_info("handling SIGINT");
 	g_cancellable_cancel(priv->cancellable);
 	return FALSE;
 }
@@ -2946,7 +2946,7 @@ fu_util_refresh_remote(FuUtilPrivate *priv, FwupdRemote *remote, GError **error)
 		return FALSE;
 
 	/* send to daemon */
-	g_debug("updating %s", fwupd_remote_get_id(remote));
+	g_info("updating %s", fwupd_remote_get_id(remote));
 	return fu_engine_update_metadata_bytes(priv->engine,
 					       fwupd_remote_get_id(remote),
 					       bytes_raw,
@@ -4014,7 +4014,7 @@ main(int argc, char *argv[])
 
 	/* non-TTY consoles cannot answer questions */
 	if (!fu_util_setup_interactive(priv, &error_console)) {
-		g_debug("failed to initialize interactive console: %s", error_console->message);
+		g_info("failed to initialize interactive console: %s", error_console->message);
 		priv->no_reboot_check = TRUE;
 		priv->no_safety_check = TRUE;
 		priv->no_device_prompt = TRUE;
@@ -4144,7 +4144,7 @@ main(int argc, char *argv[])
 						 /* TRANSLATORS: explain how to get help */
 						 _("Use fwupdtool --help for help"));
 		} else if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
-			g_debug("%s\n", error->message);
+			g_info("%s\n", error->message);
 			return EXIT_NOTHING_TO_DO;
 		}
 #ifdef HAVE_GETUID

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -65,9 +65,7 @@ fu_udev_backend_device_remove(FuUdevBackend *self, GUdevDevice *udev_device)
 	device_tmp =
 	    fu_backend_lookup_by_id(FU_BACKEND(self), g_udev_device_get_sysfs_path(udev_device));
 	if (device_tmp != NULL) {
-		if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL) {
-			g_debug("UDEV %s removed", g_udev_device_get_sysfs_path(udev_device));
-		}
+		g_debug("UDEV %s removed", g_udev_device_get_sysfs_path(udev_device));
 		fu_backend_device_removed(FU_BACKEND(self), device_tmp);
 	}
 }
@@ -159,8 +157,7 @@ fu_udev_backend_coldplug_subsystem(FuUdevBackend *self,
 	g_autolist(GObject) devices = NULL;
 
 	devices = g_udev_client_query_by_subsystem(self->gudev_client, subsystem);
-	if (g_getenv("FWUPD_PROBE_VERBOSE") != NULL)
-		g_debug("%u devices with subsystem %s", g_list_length(devices), subsystem);
+	g_debug("%u devices with subsystem %s", g_list_length(devices), subsystem);
 
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_name(progress, subsystem);

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -75,9 +75,7 @@ fu_usb_backend_context_flags_check(FuUsbBackend *self)
 {
 #if G_USB_CHECK_VERSION(0, 4, 5)
 	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
-	GUsbContextFlags usb_flags = G_USB_CONTEXT_FLAGS_NONE;
-	if (g_getenv("FWUPD_BACKEND_VERBOSE") != NULL)
-		usb_flags |= G_USB_CONTEXT_FLAGS_DEBUG;
+	GUsbContextFlags usb_flags = G_USB_CONTEXT_FLAGS_DEBUG;
 	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_SAVE_EVENTS)) {
 		g_debug("saving FuUsbBackend events");
 		usb_flags |= G_USB_CONTEXT_FLAGS_SAVE_EVENTS;
@@ -205,9 +203,9 @@ fu_usb_backend_save(FuBackend *backend,
 		GUsbDevice *usb_device = g_ptr_array_index(devices, i);
 		g_autoptr(GPtrArray) usb_events = g_usb_device_get_events(usb_device);
 		if (usb_events->len > 0 || g_usb_device_has_tag(usb_device, tag)) {
-			g_debug("%u USB events to save for %s",
-				usb_events->len,
-				g_usb_device_get_platform_id(usb_device));
+			g_info("%u USB events to save for %s",
+			       usb_events->len,
+			       g_usb_device_get_platform_id(usb_device));
 		}
 		usb_events_cnt += usb_events->len;
 	}

--- a/src/fu-util-bios-setting.c
+++ b/src/fu-util-bios-setting.c
@@ -91,15 +91,12 @@ fu_util_bios_setting_to_string(FwupdBiosSetting *setting, guint idt)
 {
 	const gchar *tmp;
 	FwupdBiosSettingKind type;
+	g_autofree gchar *debug_str = NULL;
 	g_autofree gchar *current_value = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
 
-	if (g_getenv("FWUPD_VERBOSE") != NULL) {
-		g_autofree gchar *debug_str = NULL;
-		debug_str = fwupd_bios_setting_to_string(setting);
-		g_debug("%s", debug_str);
-		return NULL;
-	}
+	debug_str = fwupd_bios_setting_to_string(setting);
+	g_debug("%s", debug_str);
 	tmp = fwupd_bios_setting_get_name(setting);
 	fu_string_append(str, idt, tmp, NULL);
 

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -73,11 +73,11 @@ fu_util_using_correct_daemon(GError **error)
 
 	default_target = fu_systemd_get_default_target(&error_local);
 	if (default_target == NULL) {
-		g_debug("Systemd isn't accessible: %s\n", error_local->message);
+		g_info("systemd is not accessible: %s", error_local->message);
 		return TRUE;
 	}
 	if (!fu_systemd_unit_check_exists(target, &error_local)) {
-		g_debug("wrong target: %s\n", error_local->message);
+		g_info("wrong target: %s", error_local->message);
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_ARGS,
@@ -113,7 +113,7 @@ fu_util_traverse_tree(GNode *n, gpointer data)
 	} else if (FWUPD_IS_RELEASE(n->data)) {
 		FwupdRelease *release = FWUPD_RELEASE(n->data);
 		tmp = fu_util_release_to_string(release, idx);
-		g_debug("%s", tmp);
+		g_info("%s", tmp);
 	}
 
 	/* root node */
@@ -1265,7 +1265,7 @@ fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 	if (g_getenv("FWUPD_VERBOSE") != NULL) {
 		g_autofree gchar *debug_str = NULL;
 		debug_str = fwupd_device_to_string(dev);
-		g_debug("%s", debug_str);
+		g_info("%s", debug_str);
 		return NULL;
 	}
 
@@ -2348,7 +2348,7 @@ fu_util_security_events_to_string(GPtrArray *events, FuSecurityAttrToStringFlags
 		for (guint i = 0; i < events->len; i++) {
 			FwupdSecurityAttr *attr = g_ptr_array_index(events, i);
 			g_autofree gchar *tmp = fwupd_security_attr_to_string(attr);
-			g_debug("%s", tmp);
+			g_info("%s", tmp);
 		}
 	}
 
@@ -2595,7 +2595,7 @@ fu_util_send_report(FwupdClient *client,
 
 	/* server wanted us to see the message */
 	if (server_msg != NULL) {
-		g_debug("server message: %s", server_msg);
+		g_info("server message: %s", server_msg);
 		if (g_strstr_len(server_msg, -1, "known issue") != NULL &&
 		    json_object_has_member(json_object, "uri")) {
 			if (uri != NULL)

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1647,7 +1647,7 @@ fu_util_get_device_or_prompt(FuUtilPrivate *priv, gchar **values, GError **error
 	if (g_strv_length(values) >= 1) {
 		if (g_strv_length(values) > 1) {
 			for (guint i = 1; i < g_strv_length(values); i++)
-				g_debug("Ignoring extra input %s", values[i]);
+				g_debug("ignoring extra input %s", values[i]);
 		}
 		return fu_util_get_device_by_id(priv, values[0], error);
 	}
@@ -4850,7 +4850,7 @@ main(int argc, char *argv[])
 
 	/* non-TTY consoles cannot answer questions */
 	if (!fu_util_setup_interactive(priv, &error_console)) {
-		g_debug("failed to initialize interactive console: %s", error_console->message);
+		g_info("failed to initialize interactive console: %s", error_console->message);
 		priv->no_unreported_check = TRUE;
 		priv->no_metadata_check = TRUE;
 		priv->no_reboot_check = TRUE;


### PR DESCRIPTION
In the old code we only used `g_warning()`, `g_critical()` and then `g_debug()` -- where the latter level was then filtered by a range of per-log-domain, per-plugin and other tangentially related environment variables.

Knowing how to make each debug line actually show up meant either knowing the secret incantation, or looking up and pasting from `docs/env.md` and adding enough keys until the line actually showed up. This made debugging with end users frustrating.

Rather than using env variables to filter debug, show messages and warnings by default, using `--verbose` to enable info messages, and then using `--verbose` **again** to enable all verbose debugging. Also promote useful messages to the INFO level so they show in the single `-v` output.

Additionally, filtering on the log domain with `--daemon-verbose` still works when you know exactly what you're looking for.
