### PR TITLE
Optionally retain firmware in a backup remote

### DIFF
--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -19,6 +19,15 @@ fwupd_remote_load_from_filename(FwupdRemote *self,
 				const gchar *filename,
 				GCancellable *cancellable,
 				GError **error);
+gboolean
+fwupd_remote_save_to_filename(FwupdRemote *self,
+			      const gchar *filename,
+			      GCancellable *cancellable,
+			      GError **error);
+void
+fwupd_remote_set_enabled(FwupdRemote *self, gboolean enabled);
+void
+fwupd_remote_set_title(FwupdRemote *self, const gchar *title);
 void
 fwupd_remote_set_priority(FwupdRemote *self, gint priority);
 void
@@ -27,6 +36,8 @@ void
 fwupd_remote_set_checksum(FwupdRemote *self, const gchar *checksum);
 void
 fwupd_remote_set_filename_cache(FwupdRemote *self, const gchar *filename);
+void
+fwupd_remote_set_metadata_uri(FwupdRemote *self, const gchar *metadata_uri);
 void
 fwupd_remote_set_mtime(FwupdRemote *self, guint64 mtime);
 gchar **

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -924,3 +924,12 @@ LIBFWUPD_1.8.11 {
     fwupd_device_set_percentage;
   local: *;
 } LIBFWUPD_1.8.8;
+
+LIBFWUPD_1.8.13 {
+  global:
+    fwupd_remote_save_to_filename;
+    fwupd_remote_set_enabled;
+    fwupd_remote_set_metadata_uri;
+    fwupd_remote_set_title;
+  local: *;
+} LIBFWUPD_1.8.11;

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -243,6 +243,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "ignore-system-power";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE)
 		return "no-probe-complete";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE)
+		return "save-into-backup-remote";
 	return NULL;
 }
 
@@ -315,6 +317,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_IGNORE_SYSTEM_POWER;
 	if (g_strcmp0(flag, "no-probe-complete") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE;
+	if (g_strcmp0(flag, "save-into-backup-remote") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -493,6 +493,20 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE (1ull << 27)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE:
+ *
+ * Save the cabinet archive to persistent storage remote before starting the update process.
+ *
+ * This is useful when the network device is being updated, and different blobs inside the archive
+ * could be required in different scenarios. For instance, if the user installs a firmware update
+ * for a specific network device and then changes the SIM -- it might be they need the archive
+ * again and have no internet access.
+ *
+ * Since: 1.8.13
+ */
+#define FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE (1ull << 28)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);


### PR DESCRIPTION
This allows the device to set the flag and then 'fwupdmgr reinstall' works correctly without internet access. This is probably a good idea for network devices that have different loadable firmwares depending on configuration, e.g. inserted SIM card.

Fixes https://github.com/fwupd/fwupd/discussions/5592

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
