### PR TITLE
Accept application/octet-stream when the mime database is missing

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4368,7 +4368,8 @@ fu_engine_create_metadata_builder_source(FuEngine *self, const gchar *fn, GError
 
 	g_info("using %s as metadata source", fn);
 	xb_builder_source_add_simple_adapter(source,
-					     "application/vnd.ms-cab-compressed",
+					     "application/vnd.ms-cab-compressed,"
+					     "application/octet-stream",
 					     fu_engine_builder_cabinet_adapter_cb,
 					     self,
 					     NULL);


### PR DESCRIPTION
This fixes vendor directory remotes on ChromeOS.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
