### PR TITLE
elantp: Set the i2c name properly

### DIFF
--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -802,7 +802,7 @@ fu_elantp_i2c_device_init(FuElantpI2cDevice *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_set_summary(FU_DEVICE(self), "Touchpad (I²C)");
+	fu_device_set_name(FU_DEVICE(self), "Touchpad");
 	fu_device_add_icon(FU_DEVICE(self), "input-touchpad");
 	fu_device_add_protocol(FU_DEVICE(self), "tw.com.emc.elantp");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);


### PR DESCRIPTION
The FuElantpI2cDevice does not call the FuI2cDevice->probe() function and so the name does not get automatically set.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
