### PR TITLE
Add the latest dbx version version fixups

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -218,6 +218,12 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 	    {"90aec5c4995674a849c1d1384463f3b02b5aa625a5c320fc4fe7d9bb58a62398", 217},
 	    /* DBXUpdate-20220812.aa64.bin - only X509 certificates removed */
 	    /* DBXUpdate-20220812.ia32.bin - only X509 certificates removed */
+	    /* DBXUpdate-20230314.aa64.bin */
+	    {"f4dc5a40d2a9dbdab210bae0c508e053ae986c4da42d68760a1655d6fbaec051", 22},
+	    /* DBXUpdate-20230314.ia32.bin */
+	    {"c4ebdc43048c43f5f11c59ead051a3585a07fafce985cfed8b27b73a5492f9b2", 57},
+	    /* DBXUpdate-20230314.x64.bin */
+	    {"6a0e824654b7479152058cf738a378e629483874b6dbd67e0d8c3327b2fcac64", 220},
 	    {NULL, 0}};
 
 	sigs = fu_firmware_get_images(FU_FIRMWARE(self));


### PR DESCRIPTION
This is required because again Microsoft removed hashes in the x64 DBXUpdate 20230314 update.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
