### PR TITLE
trivial: Move Fedora CI container from 37 to 39

### DIFF
--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:39
 %%%OS%%%
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/subprojects/fwupd-efi.wrap
+++ b/subprojects/fwupd-efi.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = fwupd-efi
 url = https://github.com/fwupd/fwupd-efi
-revision = 1.4
+revision = 189f7637f423cb2983aec9bdebd9e9a20765ab85


### PR DESCRIPTION
Needed for https://github.com/fwupd/fwupd-efi/pull/40

Will trigger a build before merging this to make sure that works rather than waiting 24 hours.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
