### PR TITLE
Generate packed struct getters and setters like protobuf

### DIFF
--- a/libfwupdplugin/fu-acpi-table.struct
+++ b/libfwupdplugin/fu-acpi-table.struct
@@ -1,0 +1,11 @@
+struct AcpiTable {
+    signature: 4s
+    length: u32le
+    revision: u8
+    checksum: u8
+    oem_id: 6s
+    oem_table_id: 8s
+    oem_revision: u32be
+    _asl_compiler_id: 4s
+    _asl_compiler_revision: u32le
+}

--- a/libfwupdplugin/fu-cfu.struct
+++ b/libfwupdplugin/fu-cfu.struct
@@ -1,0 +1,15 @@
+struct CfuPayload {
+    addr: u32le
+    size: u8
+}
+struct CfuOffer {
+    segment_number: u8
+    flags1: u8
+    component_id: u8
+    token: u8
+    version_raw: u32le
+    hw_variant: u32le
+    flags2: u8
+    flags3: u8
+    product_id: u16le
+}

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -15,7 +15,7 @@
 #include "fu-common.h"
 #include "fu-crc.h"
 #include "fu-dfu-firmware-private.h"
-#include "fu-mem.h"
+#include "fu-dfu-struct.h"
 
 /**
  * FuDfuFirmware:
@@ -196,41 +196,13 @@ fu_dfu_firmware_set_version(FuDfuFirmware *self, guint16 version)
 	priv->dfu_version = version;
 }
 
-typedef struct __attribute__((packed)) {
-	guint16 release;
-	guint16 pid;
-	guint16 vid;
-	guint16 ver;
-	guint8 sig[3];
-	guint8 len;
-	guint32 crc;
-} FuDfuFirmwareFooter;
-
 static gboolean
 fu_dfu_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	guint8 magic[3] = {0x0};
-
-	/* is a footer */
-	if (!fu_memcpy_safe(magic,
-			    sizeof(magic),
-			    0x0, /* dst */
-			    g_bytes_get_data(fw, NULL),
-			    g_bytes_get_size(fw),
-			    g_bytes_get_size(fw) - G_STRUCT_OFFSET(FuDfuFirmwareFooter, sig),
-			    sizeof(magic),
-			    error))
-		return FALSE;
-	if (memcmp(magic, "UFD", sizeof(magic)) != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "no DFU signature");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
+	return fu_struct_dfu_ftr_validate(g_bytes_get_data(fw, NULL),
+					  g_bytes_get_size(fw),
+					  g_bytes_get_size(fw) - FU_STRUCT_DFU_FTR_SIZE,
+					  error);
 }
 
 gboolean
@@ -240,53 +212,42 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 			     GError **error)
 {
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
-	FuDfuFirmwareFooter ftr;
-	gsize len;
-	guint32 crc;
-	guint32 crc_new;
-	const guint8 *data = g_bytes_get_data(fw, &len);
+	gsize bufsz;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autoptr(GByteArray) st = NULL;
+
+	/* parse */
+	st = fu_struct_dfu_ftr_parse(buf, bufsz, bufsz - FU_STRUCT_DFU_FTR_SIZE, error);
+	if (st == NULL)
+		return FALSE;
+	priv->vid = fu_struct_dfu_ftr_get_vid(st);
+	priv->pid = fu_struct_dfu_ftr_get_pid(st);
+	priv->release = fu_struct_dfu_ftr_get_release(st);
+	priv->dfu_version = fu_struct_dfu_ftr_get_ver(st);
+	priv->footer_len = fu_struct_dfu_ftr_get_len(st);
 
 	/* verify the checksum */
-	if (!fu_memcpy_safe((guint8 *)&ftr,
-			    sizeof(FuDfuFirmwareFooter),
-			    0x0, /* dst */
-			    data,
-			    len,
-			    len - sizeof(FuDfuFirmwareFooter), /* src */
-			    sizeof(FuDfuFirmwareFooter),
-			    error)) {
-		g_prefix_error(error, "failed to read magic: ");
-		return FALSE;
-	}
-	crc = GUINT32_FROM_LE(ftr.crc);
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
-		crc_new = ~fu_crc32(data, len - 4);
-		if (crc != crc_new) {
+		guint32 crc_new = ~fu_crc32(buf, bufsz - 4);
+		if (fu_struct_dfu_ftr_get_crc(st) != crc_new) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
-				    "CRC failed, expected %04x, got %04x",
+				    "CRC failed, expected 0x%04x, got 0x%04x",
 				    crc_new,
-				    GUINT32_FROM_LE(ftr.crc));
+				    fu_struct_dfu_ftr_get_crc(st));
 			return FALSE;
 		}
 	}
 
-	/* set from footer */
-	priv->vid = GUINT16_FROM_LE(ftr.vid);
-	priv->pid = GUINT16_FROM_LE(ftr.pid);
-	priv->release = GUINT16_FROM_LE(ftr.release);
-	priv->dfu_version = GUINT16_FROM_LE(ftr.ver);
-	priv->footer_len = ftr.len;
-
 	/* check reported length */
-	if (priv->footer_len > len) {
+	if (priv->footer_len > bufsz) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
-			    "reported footer size %04x larger than file %04x",
+			    "reported footer size 0x%04x larger than file 0x%04x",
 			    (guint)priv->footer_len,
-			    (guint)len);
+			    (guint)bufsz);
 		return FALSE;
 	}
 
@@ -322,23 +283,18 @@ GBytes *
 fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **error)
 {
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
-	GByteArray *buf = g_byte_array_new();
-	const guint8 *blob;
-	gsize blobsz = 0;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) st = fu_struct_dfu_ftr_new();
 
-	/* add the raw firmware data */
-	blob = g_bytes_get_data(contents, &blobsz);
-	g_byte_array_append(buf, blob, blobsz);
-
-	/* append footer */
-	fu_byte_array_append_uint16(buf, priv->release, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, priv->pid, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, priv->vid, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, priv->dfu_version, G_LITTLE_ENDIAN);
-	g_byte_array_append(buf, (const guint8 *)"UFD", 3);
-	fu_byte_array_append_uint8(buf, sizeof(FuDfuFirmwareFooter));
+	/* add the raw firmware data, the footer-less-CRC, and only then the CRC */
+	fu_byte_array_append_bytes(buf, contents);
+	fu_struct_dfu_ftr_set_release(st, priv->release);
+	fu_struct_dfu_ftr_set_pid(st, priv->pid);
+	fu_struct_dfu_ftr_set_vid(st, priv->vid);
+	fu_struct_dfu_ftr_set_ver(st, priv->dfu_version);
+	g_byte_array_append(buf, st->data, st->len - sizeof(guint32));
 	fu_byte_array_append_uint32(buf, ~fu_crc32(buf->data, buf->len), G_LITTLE_ENDIAN);
-	return g_byte_array_free_to_bytes(buf);
+	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
 }
 
 static GBytes *

--- a/libfwupdplugin/fu-dfu.struct
+++ b/libfwupdplugin/fu-dfu.struct
@@ -1,0 +1,27 @@
+struct DfuFtr {
+    release: u16le
+    pid: u16le
+    vid: u16le
+    ver: u16le
+    sig: 3s:: UFD
+    len: u8: $struct_size
+    crc: u32le
+}
+struct DfuseHdr {
+    sig: 5s:: DfuSe
+    ver: u8:: 0x01
+    image_size: u32le
+    targets: u8
+}
+struct DfuseImage {
+    sig: 6s:: Target
+    alt_setting: u8
+    target_named: u32le
+    target_name: 255s
+    target_size: u32le
+    chunks: u32le
+}
+struct DfuseElement {
+    address: u32le
+    size: u32le
+}

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -15,8 +15,8 @@
 #include "fu-chunk-private.h"
 #include "fu-common.h"
 #include "fu-dfu-firmware-private.h"
+#include "fu-dfu-struct.h"
 #include "fu-dfuse-firmware.h"
-#include "fu-mem.h"
 
 /**
  * FuDfuseFirmware:
@@ -28,62 +28,26 @@
 
 G_DEFINE_TYPE(FuDfuseFirmware, fu_dfuse_firmware, FU_TYPE_DFU_FIRMWARE)
 
-/* firmware: LE */
-typedef struct __attribute__((packed)) {
-	guint8 sig[5];
-	guint8 ver;
-	guint32 image_size;
-	guint8 targets;
-} DfuSeHdr;
-
-/* image: LE */
-typedef struct __attribute__((packed)) {
-	guint8 sig[6];
-	guint8 alt_setting;
-	guint32 target_named;
-	gchar target_name[255];
-	guint32 target_size;
-	guint32 chunks;
-} DfuSeImageHdr;
-
-/* element: LE */
-typedef struct __attribute__((packed)) {
-	guint32 address;
-	guint32 size;
-} DfuSeElementHdr;
-
-G_STATIC_ASSERT(sizeof(DfuSeHdr) == 11);
-G_STATIC_ASSERT(sizeof(DfuSeImageHdr) == 274);
-G_STATIC_ASSERT(sizeof(DfuSeElementHdr) == 8);
-
 static FuChunk *
 fu_firmware_image_chunk_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offset, GError **error)
 {
-	DfuSeElementHdr hdr = {0x0};
 	gsize bufsz = 0;
 	gsize ftrlen = fu_dfu_firmware_get_footer_len(FU_DFU_FIRMWARE(self));
 	const guint8 *buf = g_bytes_get_data(bytes, &bufsz);
 	g_autoptr(FuChunk) chk = NULL;
+	g_autoptr(GByteArray) st_ele = NULL;
 	g_autoptr(GBytes) blob = NULL;
 
-	/* check size */
-	if (!fu_memcpy_safe((guint8 *)&hdr,
-			    sizeof(hdr),
-			    0x0, /* dst */
-			    buf,
-			    bufsz - ftrlen,
-			    *offset, /* src */
-			    sizeof(hdr),
-			    error))
-		return NULL;
-
 	/* create new chunk */
-	*offset += sizeof(hdr);
-	blob = fu_bytes_new_offset(bytes, *offset, GUINT32_FROM_LE(hdr.size), error);
+	st_ele = fu_struct_dfuse_element_parse(buf, bufsz - ftrlen, *offset, error);
+	if (st_ele == NULL)
+		return NULL;
+	*offset += st_ele->len;
+	blob = fu_bytes_new_offset(bytes, *offset, fu_struct_dfuse_element_get_size(st_ele), error);
 	if (blob == NULL)
 		return NULL;
 	chk = fu_chunk_bytes_new(blob);
-	fu_chunk_set_address(chk, GUINT32_FROM_LE(hdr.address));
+	fu_chunk_set_address(chk, fu_struct_dfuse_element_get_address(st_ele));
 	*offset += fu_chunk_get_data_sz(chk);
 
 	/* success */
@@ -93,39 +57,27 @@ fu_firmware_image_chunk_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offse
 static FuFirmware *
 fu_dfuse_firmware_image_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offset, GError **error)
 {
-	DfuSeImageHdr hdr = {0x0};
 	gsize bufsz = 0;
+	guint chunks;
 	const guint8 *buf = g_bytes_get_data(bytes, &bufsz);
 	g_autoptr(FuFirmware) image = fu_firmware_new();
+	g_autoptr(GByteArray) st_img = NULL;
 
 	/* verify image signature */
-	if (!fu_memcpy_safe((guint8 *)&hdr,
-			    sizeof(hdr),
-			    0x0, /* dst */
-			    buf,
-			    bufsz,
-			    *offset, /* src */
-			    sizeof(hdr),
-			    error))
+	st_img = fu_struct_dfuse_image_parse(buf, bufsz, *offset, error);
+	if (st_img == NULL)
 		return NULL;
-	if (memcmp(hdr.sig, "Target", sizeof(hdr.sig)) != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid DfuSe target signature");
-		return NULL;
-	}
 
 	/* set properties */
-	fu_firmware_set_idx(image, hdr.alt_setting);
-	if (GUINT32_FROM_LE(hdr.target_named) == 0x01) {
-		g_autofree gchar *img_id = NULL;
-		img_id = g_strndup(hdr.target_name, sizeof(hdr.target_name));
-		fu_firmware_set_id(image, img_id);
+	fu_firmware_set_idx(image, fu_struct_dfuse_image_get_alt_setting(st_img));
+	if (fu_struct_dfuse_image_get_target_named(st_img) == 0x01) {
+		g_autofree gchar *target_name = fu_struct_dfuse_image_get_target_name(st_img);
+		fu_firmware_set_id(image, target_name);
 	}
 
 	/* no chunks */
-	if (hdr.chunks == 0) {
+	chunks = fu_struct_dfuse_image_get_chunks(st_img);
+	if (chunks == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
@@ -134,8 +86,8 @@ fu_dfuse_firmware_image_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offse
 	}
 
 	/* parse chunks */
-	*offset += sizeof(hdr);
-	for (guint j = 0; j < GUINT32_FROM_LE(hdr.chunks); j++) {
+	*offset += st_img->len;
+	for (guint j = 0; j < chunks; j++) {
 		g_autoptr(FuChunk) chk = NULL;
 		chk = fu_firmware_image_chunk_parse(self, bytes, offset, error);
 		if (chk == NULL)
@@ -150,29 +102,10 @@ fu_dfuse_firmware_image_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offse
 static gboolean
 fu_dfuse_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	guint8 magic[5] = {0x0};
-
-	if (!fu_memcpy_safe(magic,
-			    sizeof(magic),
-			    0x0, /* dst */
-			    g_bytes_get_data(fw, NULL),
-			    g_bytes_get_size(fw),
-			    offset, /* src */
-			    sizeof(magic),
-			    error)) {
-		g_prefix_error(error, "failed to read magic: ");
-		return FALSE;
-	}
-	if (memcmp(magic, "DfuSe", sizeof(magic)) != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid DfuSe prefix");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
+	return fu_struct_dfuse_hdr_validate(g_bytes_get_data(fw, NULL),
+					    g_bytes_get_size(fw),
+					    offset,
+					    error);
 }
 
 static gboolean
@@ -184,59 +117,36 @@ fu_dfuse_firmware_parse(FuFirmware *firmware,
 {
 	FuDfuFirmware *dfu_firmware = FU_DFU_FIRMWARE(firmware);
 	gsize bufsz = 0;
-	guint32 image_size = 0;
 	guint8 targets = 0;
-	guint8 ver = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* DFU footer first */
 	if (!fu_dfu_firmware_parse_footer(dfu_firmware, fw, flags, error))
 		return FALSE;
 
-	/* check the version */
-	if (!fu_memread_uint8_safe(buf,
-				   bufsz,
-				   offset + G_STRUCT_OFFSET(DfuSeHdr, ver),
-				   &ver,
-				   error))
+	/* parse */
+	st_hdr = fu_struct_dfuse_hdr_parse(buf, bufsz, offset, error);
+	if (st_hdr == NULL)
 		return FALSE;
-	if (ver != 0x01) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INTERNAL,
-			    "invalid DfuSe version, got %02x",
-			    ver);
-		return FALSE;
-	}
 
 	/* check image size */
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(DfuSeHdr, image_size),
-				    &image_size,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (image_size != bufsz - fu_dfu_firmware_get_footer_len(dfu_firmware)) {
+	if (fu_struct_dfuse_hdr_get_image_size(st_hdr) !=
+	    bufsz - fu_dfu_firmware_get_footer_len(dfu_firmware)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "invalid DfuSe image size, "
 			    "got %" G_GUINT32_FORMAT ", "
 			    "expected %" G_GSIZE_FORMAT,
-			    image_size,
+			    fu_struct_dfuse_hdr_get_image_size(st_hdr),
 			    bufsz - fu_dfu_firmware_get_footer_len(dfu_firmware));
 		return FALSE;
 	}
 
 	/* parse the image targets */
-	if (!fu_memread_uint8_safe(buf,
-				   bufsz,
-				   offset + G_STRUCT_OFFSET(DfuSeHdr, targets),
-				   &targets,
-				   error))
-		return FALSE;
-	offset += sizeof(DfuSeHdr);
+	targets = fu_struct_dfuse_hdr_get_targets(st_hdr);
+	offset += st_hdr->len;
 	for (guint i = 0; i < targets; i++) {
 		g_autoptr(FuFirmware) image = NULL;
 		image =
@@ -249,27 +159,20 @@ fu_dfuse_firmware_parse(FuFirmware *firmware,
 }
 
 static GBytes *
-fu_firmware_chunk_write(FuChunk *chk)
+fu_firmware_chunk_write(FuDfuseFirmware *self, FuChunk *chk)
 {
-	DfuSeElementHdr hdr = {0x0};
-	const guint8 *data = fu_chunk_get_data(chk);
-	gsize length = fu_chunk_get_data_sz(chk);
-	g_autoptr(GByteArray) buf = NULL;
-
-	buf = g_byte_array_sized_new(sizeof(DfuSeElementHdr) + length);
-	hdr.address = GUINT32_TO_LE(fu_chunk_get_address(chk));
-	hdr.size = GUINT32_TO_LE(length);
-	g_byte_array_append(buf, (const guint8 *)&hdr, sizeof(hdr));
-	g_byte_array_append(buf, data, length);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	g_autoptr(GByteArray) st_ele = fu_struct_dfuse_element_new();
+	fu_struct_dfuse_element_set_address(st_ele, fu_chunk_get_address(chk));
+	fu_struct_dfuse_element_set_size(st_ele, fu_chunk_get_data_sz(chk));
+	g_byte_array_append(st_ele, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
+	return g_byte_array_free_to_bytes(g_steal_pointer(&st_ele));
 }
 
 static GBytes *
-fu_dfuse_firmware_write_image(FuFirmware *image, GError **error)
+fu_dfuse_firmware_write_image(FuDfuseFirmware *self, FuFirmware *image, GError **error)
 {
-	DfuSeImageHdr hdr = {0x0};
 	gsize totalsz = 0;
-	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GByteArray) st_img = fu_struct_dfuse_image_new();
 	g_autoptr(GPtrArray) blobs = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
 
@@ -280,41 +183,37 @@ fu_dfuse_firmware_write_image(FuFirmware *image, GError **error)
 		return NULL;
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
-		GBytes *bytes = fu_firmware_chunk_write(chk);
+		GBytes *bytes = fu_firmware_chunk_write(self, chk);
 		g_ptr_array_add(blobs, bytes);
 		totalsz += g_bytes_get_size(bytes);
 	}
 
-	/* mutable output buffer */
-	buf = g_byte_array_sized_new(sizeof(DfuSeImageHdr) + totalsz);
-
 	/* add prefix */
-	memcpy(hdr.sig, "Target", 6);
-	hdr.alt_setting = fu_firmware_get_idx(image);
+	fu_struct_dfuse_image_set_alt_setting(st_img, fu_firmware_get_idx(image));
 	if (fu_firmware_get_id(image) != NULL) {
-		hdr.target_named = GUINT32_TO_LE(0x01);
-		(void)g_strlcpy((gchar *)&hdr.target_name,
-				fu_firmware_get_id(image),
-				sizeof(hdr.target_name));
+		fu_struct_dfuse_image_set_target_named(st_img, 0x01);
+		if (!fu_struct_dfuse_image_set_target_name(st_img,
+							   fu_firmware_get_id(image),
+							   error))
+			return NULL;
 	}
-	hdr.target_size = GUINT32_TO_LE(totalsz);
-	hdr.chunks = GUINT32_TO_LE(chunks->len);
-	g_byte_array_append(buf, (const guint8 *)&hdr, sizeof(hdr));
+	fu_struct_dfuse_image_set_target_size(st_img, totalsz);
+	fu_struct_dfuse_image_set_chunks(st_img, chunks->len);
 
 	/* copy data */
 	for (guint i = 0; i < blobs->len; i++) {
 		GBytes *blob = g_ptr_array_index(blobs, i);
-		fu_byte_array_append_bytes(buf, blob);
+		fu_byte_array_append_bytes(st_img, blob);
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_byte_array_free_to_bytes(g_steal_pointer(&st_img));
 }
 
 static GBytes *
 fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 {
-	DfuSeHdr hdr = {0x0};
+	FuDfuseFirmware *self = FU_DFUSE_FIRMWARE(firmware);
 	gsize totalsz = 0;
-	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GByteArray) st_hdr = fu_struct_dfuse_hdr_new();
 	g_autoptr(GBytes) blob_noftr = NULL;
 	g_autoptr(GPtrArray) blobs = NULL;
 	g_autoptr(GPtrArray) images = NULL;
@@ -325,18 +224,15 @@ fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GBytes) blob = NULL;
-		blob = fu_dfuse_firmware_write_image(img, error);
+		blob = fu_dfuse_firmware_write_image(self, img, error);
 		if (blob == NULL)
 			return NULL;
 		totalsz += g_bytes_get_size(blob);
 		g_ptr_array_add(blobs, g_steal_pointer(&blob));
 	}
-	buf = g_byte_array_sized_new(sizeof(DfuSeHdr) + totalsz);
 
 	/* DfuSe header */
-	memcpy(hdr.sig, "DfuSe", 5);
-	hdr.ver = 0x01;
-	hdr.image_size = GUINT32_TO_LE(sizeof(hdr) + totalsz);
+	fu_struct_dfuse_hdr_set_image_size(st_hdr, st_hdr->len + totalsz);
 	if (images->len > G_MAXUINT8) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -345,17 +241,16 @@ fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 			    images->len);
 		return NULL;
 	}
-	hdr.targets = (guint8)images->len;
-	g_byte_array_append(buf, (const guint8 *)&hdr, sizeof(hdr));
+	fu_struct_dfuse_hdr_set_targets(st_hdr, (guint8)images->len);
 
 	/* copy images */
 	for (guint i = 0; i < blobs->len; i++) {
 		GBytes *blob = g_ptr_array_index(blobs, i);
-		fu_byte_array_append_bytes(buf, blob);
+		fu_byte_array_append_bytes(st_hdr, blob);
 	}
 
 	/* return blob */
-	blob_noftr = g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	blob_noftr = g_byte_array_free_to_bytes(g_steal_pointer(&st_hdr));
 	return fu_dfu_firmware_append_footer(FU_DFU_FIRMWARE(firmware), blob_noftr, error);
 }
 

--- a/libfwupdplugin/fu-efi-firmware-volume.c
+++ b/libfwupdplugin/fu-efi-firmware-volume.c
@@ -11,7 +11,8 @@
 #include "fu-efi-common.h"
 #include "fu-efi-firmware-filesystem.h"
 #include "fu-efi-firmware-volume.h"
-#include "fu-mem.h"
+#include "fu-efi-struct.h"
+#include "fu-sum.h"
 
 /**
  * FuEfiFirmwareVolume:
@@ -27,22 +28,6 @@ typedef struct {
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuEfiFirmwareVolume, fu_efi_firmware_volume, FU_TYPE_FIRMWARE)
 #define GET_PRIVATE(o) (fu_efi_firmware_volume_get_instance_private(o))
-
-#define FU_EFI_FIRMWARE_VOLUME_SIGNATURE 0x4856465F
-#define FU_EFI_FIRMWARE_VOLUME_REVISION	 0x02
-
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_ZERO_VECTOR 0x00
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_GUID	  0x10
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_LENGTH	  0x20
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_SIGNATURE	  0x28
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_ATTRS	  0x2C
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_HDR_LEN	  0x30
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_CHECKSUM	  0x32
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_EXT_HDR	  0x34
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_RESERVED	  0x36
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_REVISION	  0x37
-#define FU_EFI_FIRMWARE_VOLUME_OFFSET_BLOCK_MAP	  0x38
-#define FU_EFI_FIRMWARE_VOLUME_SIZE		  0x40
 
 static void
 fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
@@ -60,29 +45,10 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_efi_firmware_volume_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	guint32 magic = 0;
-
-	if (!fu_memread_uint32_safe(g_bytes_get_data(fw, NULL),
-				    g_bytes_get_size(fw),
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_SIGNATURE,
-				    &magic,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read magic: ");
-		return FALSE;
-	}
-	if (magic != FU_EFI_FIRMWARE_VOLUME_SIGNATURE) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_FILE,
-			    "EFI FV signature invalid, got 0x%x, expected 0x%x",
-			    magic,
-			    (guint)FU_EFI_FIRMWARE_VOLUME_SIGNATURE);
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
+	return fu_struct_efi_volume_validate(g_bytes_get_data(fw, NULL),
+					     g_bytes_get_size(fw),
+					     offset,
+					     error);
 }
 
 static gboolean
@@ -94,45 +60,29 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 {
 	FuEfiFirmwareVolume *self = FU_EFI_FIRMWARE_VOLUME(firmware);
 	FuEfiFirmwareVolumePrivate *priv = GET_PRIVATE(self);
-	fwupd_guid_t guid = {0x0};
 	gsize blockmap_sz = 0;
 	gsize bufsz = 0;
-	guint16 checksum = 0;
-	guint16 ext_hdr = 0;
 	guint16 hdr_length = 0;
 	guint32 attrs = 0;
 	guint64 fv_length = 0;
 	guint8 alignment;
-	guint8 revision = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	g_autofree gchar *guid_str = NULL;
 	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GByteArray) st_hdr = NULL;
+
+	/* parse */
+	st_hdr = fu_struct_efi_volume_parse(buf, bufsz, offset, error);
+	if (st_hdr == NULL)
+		return FALSE;
 
 	/* guid */
-	if (!fu_memcpy_safe((guint8 *)&guid,
-			    sizeof(guid),
-			    0x0, /* dst */
-			    buf,
-			    bufsz,
-			    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_GUID, /* src */
-			    sizeof(guid),
-			    error)) {
-		g_prefix_error(error, "failed to read GUID: ");
-		return FALSE;
-	}
-	guid_str = fwupd_guid_to_string(&guid, FWUPD_GUID_FLAG_MIXED_ENDIAN);
+	guid_str = fwupd_guid_to_string(fu_struct_efi_volume_get_guid(st_hdr),
+					FWUPD_GUID_FLAG_MIXED_ENDIAN);
 	g_debug("volume GUID: %s [%s]", guid_str, fu_efi_guid_to_name(guid_str));
 
 	/* length */
-	if (!fu_memread_uint64_safe(buf,
-				    bufsz,
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_LENGTH,
-				    &fv_length,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read length: ");
-		return FALSE;
-	}
+	fv_length = fu_struct_efi_volume_get_length(st_hdr);
 	if (fv_length == 0x0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -141,15 +91,7 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 	fu_firmware_set_size(firmware, fv_length);
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_ATTRS,
-				    &attrs,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read attrs: ");
-		return FALSE;
-	}
+	attrs = fu_struct_efi_volume_get_attrs(st_hdr);
 	alignment = (attrs & 0x00ff0000) >> 16;
 	if (alignment > FU_FIRMWARE_ALIGNMENT_2G) {
 		g_set_error(error,
@@ -162,79 +104,25 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 	}
 	fu_firmware_set_alignment(firmware, alignment);
 	priv->attrs = attrs & 0xffff;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_HDR_LEN,
-				    &hdr_length,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read hdr_length: ");
-		return FALSE;
-	}
-	if (hdr_length < FU_EFI_FIRMWARE_VOLUME_SIZE || hdr_length > fv_length) {
+	hdr_length = fu_struct_efi_volume_get_hdr_len(st_hdr);
+	if (hdr_length < st_hdr->len || hdr_length > fv_length || hdr_length > bufsz) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
 				    "invalid volume header length");
 		return FALSE;
 	}
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_CHECKSUM,
-				    &checksum,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read checksum: ");
-		return FALSE;
-	}
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_EXT_HDR,
-				    &ext_hdr,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read ext_hdr: ");
-		return FALSE;
-	}
-	if (!fu_memread_uint8_safe(buf,
-				   bufsz,
-				   offset + FU_EFI_FIRMWARE_VOLUME_OFFSET_REVISION,
-				   &revision,
-				   error))
-		return FALSE;
-	if (revision != FU_EFI_FIRMWARE_VOLUME_REVISION) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INTERNAL,
-			    "revision invalid, got 0x%x, expected 0x%x",
-			    revision,
-			    (guint)FU_EFI_FIRMWARE_VOLUME_REVISION);
-		return FALSE;
-	}
 
 	/* verify checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
-		guint16 checksum_verify = 0;
-		for (guint j = 0; j < hdr_length; j += sizeof(guint16)) {
-			guint16 checksum_tmp = 0;
-			if (!fu_memread_uint16_safe(buf,
-						    bufsz,
-						    offset + j,
-						    &checksum_tmp,
-						    G_LITTLE_ENDIAN,
-						    error)) {
-				g_prefix_error(error, "failed to hdr checksum 0x%x: ", j);
-				return FALSE;
-			}
-			checksum_verify += checksum_tmp;
-		}
+		guint16 checksum_verify = fu_sum16w(buf, hdr_length, G_LITTLE_ENDIAN);
 		if (checksum_verify != 0) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
 				    "checksum invalid, got %02x, expected %02x",
 				    checksum_verify,
-				    checksum);
+				    fu_struct_efi_volume_get_checksum(st_hdr));
 			return FALSE;
 		}
 	}
@@ -259,25 +147,17 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 	}
 
 	/* skip the blockmap */
-	offset += FU_EFI_FIRMWARE_VOLUME_OFFSET_BLOCK_MAP;
+	offset += st_hdr->len;
 	while (offset < bufsz) {
-		guint32 num_blocks = 0;
-		guint32 length = 0;
-		if (!fu_memread_uint32_safe(buf,
-					    bufsz,
-					    offset,
-					    &num_blocks,
-					    G_LITTLE_ENDIAN,
-					    error))
+		guint32 num_blocks;
+		guint32 length;
+		g_autoptr(GByteArray) st_blk = NULL;
+		st_blk = fu_struct_efi_volume_block_map_parse(buf, bufsz, offset, error);
+		if (st_blk == NULL)
 			return FALSE;
-		if (!fu_memread_uint32_safe(buf,
-					    bufsz,
-					    offset + sizeof(guint32),
-					    &length,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return FALSE;
-		offset += 2 * sizeof(guint32);
+		num_blocks = fu_struct_efi_volume_block_map_get_num_blocks(st_blk);
+		length = fu_struct_efi_volume_block_map_get_length(st_blk);
+		offset += st_blk->len;
 		if (num_blocks == 0x0 && length == 0x0)
 			break;
 		blockmap_sz += (gsize)num_blocks * (gsize)length;
@@ -299,9 +179,9 @@ fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiFirmwareVolume *self = FU_EFI_FIRMWARE_VOLUME(firmware);
 	FuEfiFirmwareVolumePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) buf = fu_struct_efi_volume_new();
+	g_autoptr(GByteArray) st_blk = fu_struct_efi_volume_block_map_new();
 	fwupd_guid_t guid = {0x0};
-	guint16 checksum = 0;
 	guint32 hdr_length = 0x48;
 	guint64 fv_length;
 	g_autoptr(GBytes) img_blob = NULL;
@@ -317,10 +197,6 @@ fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	}
 
-	/* zero vector */
-	for (guint i = 0; i < 0x10; i++)
-		fu_byte_array_append_uint8(buf, 0x0);
-
 	/* GUID */
 	if (fu_firmware_get_id(firmware) == NULL) {
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no GUID set for EFI FV");
@@ -331,7 +207,6 @@ fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 				    FWUPD_GUID_FLAG_MIXED_ENDIAN,
 				    error))
 		return NULL;
-	g_byte_array_append(buf, (const guint8 *)&guid, sizeof(guid));
 
 	/* length */
 	img = fu_firmware_get_image_by_id(firmware, NULL, NULL);
@@ -348,59 +223,29 @@ fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 			return NULL;
 		}
 	}
+
+	/* pack */
+	fu_struct_efi_volume_set_guid(buf, &guid);
 	fv_length = fu_common_align_up(hdr_length + g_bytes_get_size(img_blob),
 				       fu_firmware_get_alignment(firmware));
-	fu_byte_array_append_uint64(buf, fv_length, G_LITTLE_ENDIAN);
-
-	/* signature */
-	fu_byte_array_append_uint32(buf, FU_EFI_FIRMWARE_VOLUME_SIGNATURE, G_LITTLE_ENDIAN);
-
-	/* attributes */
-	fu_byte_array_append_uint32(buf,
-				    priv->attrs |
-					((guint32)fu_firmware_get_alignment(firmware) << 16),
-				    G_LITTLE_ENDIAN);
-
-	/* header length */
-	fu_byte_array_append_uint16(buf, hdr_length, G_LITTLE_ENDIAN);
-
-	/* checksum (will fixup) */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN);
-
-	/* ext header offset */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN);
-
-	/* reserved */
-	fu_byte_array_append_uint8(buf, 0x0);
-
-	/* revision */
-	fu_byte_array_append_uint8(buf, FU_EFI_FIRMWARE_VOLUME_REVISION);
+	fu_struct_efi_volume_set_length(buf, fv_length);
+	fu_struct_efi_volume_set_attrs(buf,
+				       priv->attrs |
+					   ((guint32)fu_firmware_get_alignment(firmware) << 16));
+	fu_struct_efi_volume_set_hdr_len(buf, hdr_length);
 
 	/* blockmap */
-	fu_byte_array_append_uint32(buf, fv_length, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, 0x1, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);
+	fu_struct_efi_volume_block_map_set_num_blocks(st_blk, fv_length);
+	fu_struct_efi_volume_block_map_set_length(st_blk, 0x1);
+	g_byte_array_append(buf, st_blk->data, st_blk->len);
+	fu_struct_efi_volume_block_map_set_num_blocks(st_blk, 0x0);
+	fu_struct_efi_volume_block_map_set_length(st_blk, 0x0);
+	g_byte_array_append(buf, st_blk->data, st_blk->len);
 
 	/* fix up checksum */
-	for (guint j = buf->len - hdr_length; j < buf->len; j += sizeof(guint16)) {
-		guint16 checksum_tmp = 0;
-		if (!fu_memread_uint16_safe(buf->data,
-					    buf->len,
-					    j,
-					    &checksum_tmp,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return NULL;
-		checksum += checksum_tmp;
-	}
-	if (!fu_memwrite_uint16_safe(buf->data,
-				     buf->len,
-				     buf->len - 0x16,
-				     0x10000 - checksum,
-				     G_LITTLE_ENDIAN,
-				     error))
-		return NULL;
+	fu_struct_efi_volume_set_checksum(buf,
+					  0x10000 -
+					      fu_sum16w(buf->data, buf->len, G_LITTLE_ENDIAN));
 
 	/* pad contents to alignment */
 	fu_byte_array_append_bytes(buf, img_blob);

--- a/libfwupdplugin/fu-efi.struct
+++ b/libfwupdplugin/fu-efi.struct
@@ -1,0 +1,35 @@
+struct EfiFile {
+    name: guid
+    hdr_checksum: u8
+    data_checksum: u8
+    type: u8
+    attrs: u8
+    size: u24le
+    state: u8:: 0xF8
+}
+struct EfiSection {
+    size: u24le
+    type: u8
+}
+struct EfiVolume {
+    zero_vector: guid
+    guid: guid
+    length: u64le
+    signature: u32le:: 0x4856465F
+    attrs: u32le
+    hdr_len: u16le
+    checksum: u16le
+    ext_hdr: u16le
+    reserved: u8
+    revision: u8:: 0x02
+}
+struct EfiVolumeBlockMap {
+    num_blocks: u32le
+    length: u32le
+}
+struct EfiSignatureList {
+    type: guid
+    list_size: u32le
+    header_size: u32le
+    size: u32le
+}

--- a/libfwupdplugin/fu-fdt.struct
+++ b/libfwupdplugin/fu-fdt.struct
@@ -1,0 +1,20 @@
+struct Fdt {
+    magic: u32be:: 0xD00DFEED
+    totalsize: u32be
+    off_dt_struct: u32be
+    off_dt_strings: u32be
+    off_mem_rsvmap: u32be
+    version: u32be
+    last_comp_version: u32be: 2
+    boot_cpuid_phys: u32be
+    size_dt_strings: u32be
+    size_dt_struct: u32be
+}
+struct FdtReserveEntry {
+    address: u64be
+    size: u64be
+}
+struct FdtProp {
+    len: u32be
+    nameoff: u32be
+}

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -27,7 +27,7 @@
 typedef struct {
 	FuFirmwareFlags flags;
 	FuFirmware *parent; /* noref */
-	GPtrArray *images; /* FuFirmware */
+	GPtrArray *images;  /* FuFirmware */
 	gchar *version;
 	guint64 version_raw;
 	GBytes *bytes;

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -10,7 +10,7 @@
 #include "fu-bytes.h"
 #include "fu-common.h"
 #include "fu-fmap-firmware.h"
-#include "fu-mem.h"
+#include "fu-fmap-struct.h"
 
 /**
  * FuFmapFirmware:
@@ -20,37 +20,17 @@
  * See also: [class@FuFirmware]
  */
 
-#define FMAP_SIGNATURE "__FMAP__"
-#define FMAP_AREANAME  "FMAP"
+#define FMAP_AREANAME "FMAP"
 
 G_DEFINE_TYPE(FuFmapFirmware, fu_fmap_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
 fu_fmap_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	guint8 magic[8] = {0x0};
-
-	if (!fu_memcpy_safe(magic,
-			    sizeof(magic),
-			    0, /* dst */
-			    g_bytes_get_data(fw, NULL),
-			    g_bytes_get_size(fw),
-			    offset,
-			    sizeof(magic),
-			    error)) {
-		g_prefix_error(error, "failed to read magic: ");
-		return FALSE;
-	}
-	if (memcmp(magic, FMAP_SIGNATURE, sizeof(magic)) != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid magic for file");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
+	return fu_struct_fmap_validate(g_bytes_get_data(fw, NULL),
+				       g_bytes_get_size(fw),
+				       offset,
+				       error);
 }
 
 static gboolean
@@ -62,89 +42,68 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 {
 	FuFmapFirmwareClass *klass_firmware = FU_FMAP_FIRMWARE_GET_CLASS(firmware);
 	gsize bufsz;
+	guint32 nareas;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
-	FuFmap fmap;
+	g_autoptr(GByteArray) st_hdr = NULL;
 
-	/* corrupt */
-	if (g_bytes_get_size(fw) < sizeof(FuFmap)) {
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "firmware too small for fmap");
+	/* parse */
+	st_hdr = fu_struct_fmap_parse(buf, bufsz, offset, error);
+	if (st_hdr == NULL)
 		return FALSE;
-	}
+	fu_firmware_set_addr(firmware, fu_struct_fmap_get_base(st_hdr));
 
-	/* load header */
-	if (!fu_memcpy_safe((guint8 *)&fmap,
-			    sizeof(fmap),
-			    0x0, /* dst */
-			    buf,
-			    bufsz,
-			    offset, /* src */
-			    sizeof(fmap),
-			    error))
-		return FALSE;
-	fu_firmware_set_addr(firmware, GUINT64_FROM_LE(fmap.base));
-
-	if (GUINT32_FROM_LE(fmap.size) != bufsz) {
+	if (fu_struct_fmap_get_size(st_hdr) != bufsz) {
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_INVALID_DATA,
 			    "file size incorrect, expected 0x%04x got 0x%04x",
-			    (guint)fmap.size,
+			    fu_struct_fmap_get_size(st_hdr),
 			    (guint)bufsz);
 		return FALSE;
 	}
-	if (GUINT16_FROM_LE(fmap.nareas) < 1) {
-		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
-			    "number of areas too small, got %" G_GUINT16_FORMAT,
-			    GUINT16_FROM_LE(fmap.nareas));
+	nareas = fu_struct_fmap_get_nareas(st_hdr);
+	if (nareas < 1) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_INVALID_DATA,
+				    "number of areas invalid");
 		return FALSE;
 	}
-	offset += sizeof(fmap);
-
-	for (gsize i = 0; i < GUINT16_FROM_LE(fmap.nareas); i++) {
-		FuFmapArea area;
-		g_autoptr(FuFirmware) img = NULL;
-		g_autoptr(GBytes) bytes = NULL;
+	offset += st_hdr->len;
+	for (gsize i = 0; i < nareas; i++) {
+		guint32 area_offset;
+		guint32 area_size;
 		g_autofree gchar *area_name = NULL;
+		g_autoptr(FuFirmware) img = NULL;
+		g_autoptr(GByteArray) st_area = NULL;
+		g_autoptr(GBytes) bytes = NULL;
 
 		/* load area */
-		if (!fu_memcpy_safe((guint8 *)&area,
-				    sizeof(area),
-				    0x0, /* dst */
-				    buf,
-				    bufsz,
-				    offset, /* src */
-				    sizeof(area),
-				    error))
+		st_area = fu_struct_fmap_area_parse(buf, bufsz, offset, error);
+		if (st_area == NULL)
 			return FALSE;
-
-		/* skip */
-		if (area.size == 0)
+		area_size = fu_struct_fmap_area_get_size(st_area);
+		if (area_size == 0)
 			continue;
-
-		bytes = fu_bytes_new_offset(fw,
-					    (gsize)GUINT32_FROM_LE(area.offset),
-					    (gsize)GUINT32_FROM_LE(area.size),
-					    error);
+		area_offset = fu_struct_fmap_area_get_offset(st_area);
+		bytes = fu_bytes_new_offset(fw, (gsize)area_offset, (gsize)area_size, error);
 		if (bytes == NULL)
 			return FALSE;
-		area_name = g_strndup((const gchar *)area.name, FU_FMAP_FIRMWARE_STRLEN);
+		area_name = fu_struct_fmap_area_get_name(st_area);
 		img = fu_firmware_new_from_bytes(bytes);
 		fu_firmware_set_id(img, area_name);
 		fu_firmware_set_idx(img, i + 1);
-		fu_firmware_set_addr(img, GUINT32_FROM_LE(area.offset));
+		fu_firmware_set_addr(img, area_offset);
 		fu_firmware_add_image(firmware, img);
 
 		if (g_strcmp0(area_name, FMAP_AREANAME) == 0) {
 			g_autofree gchar *version = NULL;
-			version = g_strdup_printf("%d.%d", fmap.ver_major, fmap.ver_minor);
+			version = g_strdup_printf("%d.%d",
+						  fu_struct_fmap_get_ver_major(st_hdr),
+						  fu_struct_fmap_get_ver_minor(st_hdr));
 			fu_firmware_set_version(img, version);
 		}
-		offset += sizeof(area);
+		offset += st_area->len;
 	}
 
 	/* subclassed */
@@ -164,22 +123,14 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	gsize offset;
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	FuFmap hdr = {
-	    .signature = {FMAP_SIGNATURE},
-	    .ver_major = 0x1,
-	    .ver_minor = 0x1,
-	    .base = GUINT64_TO_LE(fu_firmware_get_addr(firmware)),
-	    .size = 0x0,
-	    .name = "",
-	    .nareas = GUINT16_TO_LE(images->len),
-	};
+	g_autoptr(GByteArray) st_hdr = fu_struct_fmap_new();
 
 	/* pad to offset */
 	if (fu_firmware_get_offset(firmware) > 0)
 		fu_byte_array_set_size(buf, fu_firmware_get_offset(firmware), 0x00);
 
 	/* add header */
-	total_sz = offset = sizeof(hdr) + (sizeof(FuFmapArea) * images->len);
+	total_sz = offset = st_hdr->len + (FU_STRUCT_FMAP_AREA_SIZE * images->len);
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GBytes) fw = fu_firmware_get_bytes_with_patches(img, error);
@@ -187,23 +138,25 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 			return NULL;
 		total_sz += g_bytes_get_size(fw);
 	}
-	hdr.size = GUINT32_TO_LE(fu_firmware_get_offset(firmware) + total_sz);
-	g_byte_array_append(buf, (const guint8 *)&hdr, sizeof(hdr));
+
+	/* header */
+	fu_struct_fmap_set_base(st_hdr, fu_firmware_get_addr(firmware));
+	fu_struct_fmap_set_nareas(st_hdr, images->len);
+	fu_struct_fmap_set_size(st_hdr, fu_firmware_get_offset(firmware) + total_sz);
+	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
 
 	/* add each area */
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
-		const gchar *id = fu_firmware_get_id(img);
 		g_autoptr(GBytes) fw = fu_firmware_get_bytes_with_patches(img, NULL);
-		FuFmapArea area = {
-		    .offset = GUINT32_TO_LE(fu_firmware_get_offset(firmware) + offset),
-		    .size = GUINT32_TO_LE(g_bytes_get_size(fw)),
-		    .name = {""},
-		    .flags = 0x0,
-		};
-		if (id != NULL)
-			strncpy((gchar *)area.name, id, sizeof(area.name) - 1);
-		g_byte_array_append(buf, (const guint8 *)&area, sizeof(area));
+		g_autoptr(GByteArray) st_area = fu_struct_fmap_area_new();
+		fu_struct_fmap_area_set_offset(st_area, fu_firmware_get_offset(firmware) + offset);
+		fu_struct_fmap_area_set_size(st_area, g_bytes_get_size(fw));
+		if (fu_firmware_get_id(img) != NULL) {
+			if (!fu_struct_fmap_area_set_name(st_area, fu_firmware_get_id(img), error))
+				return NULL;
+		}
+		g_byte_array_append(buf, st_area->data, st_area->len);
 		offset += g_bytes_get_size(fw);
 	}
 

--- a/libfwupdplugin/fu-fmap-firmware.h
+++ b/libfwupdplugin/fu-fmap-firmware.h
@@ -23,34 +23,5 @@ struct _FuFmapFirmwareClass {
 			  GError **error);
 };
 
-/**
- * FuFmapArea:
- *
- * Specific area of volatile and static regions in firmware binary.
- **/
-typedef struct __attribute__((packed)) {
-	guint32 offset;			      /* offset relative to base */
-	guint32 size;			      /* size in bytes */
-	guint8 name[FU_FMAP_FIRMWARE_STRLEN]; /* descriptive name */
-	guint16 flags;			      /* flags for this area */
-} FuFmapArea;
-
-/**
- * FuFmap:
- *
- * Mapping of volatile and static regions in firmware binary.
- **/
-typedef struct __attribute__((packed)) {
-	guint8 signature[8];		      /* "__FMAP__" (0x5F5F464D41505F5F) */
-	guint8 ver_major;		      /* major version */
-	guint8 ver_minor;		      /* minor version */
-	guint64 base;			      /* address of the firmware binary */
-	guint32 size;			      /* size of firmware binary in bytes */
-	guint8 name[FU_FMAP_FIRMWARE_STRLEN]; /* name of this firmware binary */
-	guint16 nareas;			      /* number of areas described by
-						 areas[] below */
-	FuFmapArea areas[];
-} FuFmap;
-
 FuFirmware *
 fu_fmap_firmware_new(void);

--- a/libfwupdplugin/fu-fmap.struct
+++ b/libfwupdplugin/fu-fmap.struct
@@ -1,0 +1,15 @@
+struct Fmap {
+    signature: 8s:: __FMAP__
+    ver_major: u8: 0x1
+    ver_minor: u8: 0x1
+    base: u64le			// address of the firmware binary
+    size: u32le			// bytes
+    name: 32s
+    nareas: u16le		// number of areas
+}
+struct FmapArea {		// area of volatile and static regions
+    offset: u32le		// offset relative to base
+    size: u32le			// bytes
+    name: 32s			// descriptive name
+    flags: u16le
+}

--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -32,10 +32,10 @@
 
 struct _FuHwids {
 	GObject parent_instance;
-	GHashTable *hash_values;	  /* BiosVersion->"1.2.3 " */
-	GHashTable *hash_values_display;  /* BiosVersion->"1.2.3" */
-	GHashTable *hash_guid;		  /* a-c-b-d->1 */
-	GPtrArray *array_guids;		  /* a-c-b-d */
+	GHashTable *hash_values;	 /* BiosVersion->"1.2.3 " */
+	GHashTable *hash_values_display; /* BiosVersion->"1.2.3" */
+	GHashTable *hash_guid;		 /* a-c-b-d->1 */
+	GPtrArray *array_guids;		 /* a-c-b-d */
 };
 
 G_DEFINE_TYPE(FuHwids, fu_hwids, G_TYPE_OBJECT)

--- a/libfwupdplugin/fu-ifwi.struct
+++ b/libfwupdplugin/fu-ifwi.struct
@@ -1,0 +1,57 @@
+struct IfwiCpd {
+    header_marker: u32le:: 0x44504324
+    num_of_entries: u32le
+    header_version: u8
+    entry_version: u8
+    header_length: u8: $struct_size
+    checksum: u8
+    partition_name: u32le
+    crc32: u32le
+}
+struct IfwiCpdEntry {
+    name: 12s
+    offset: u32le
+    length: u32le
+    _reserved1: 4u8
+}
+struct IfwiCpdManifest {
+    header_type: u32le
+    header_length: u32le		// dwords
+    header_version: u32le
+    flags: u32le
+    vendor: u32le
+    date: u32le
+    size: u32le				// dwords
+    id: u32le
+    rsvd: u32le
+    version: u64le
+    svn: u32le
+}
+struct IfwiCpdManifestExt {
+    extension_type: u32le
+    extension_length: u32le
+}
+struct IfwiFpt {
+    header_marker: u32le:: 0x54504624
+    num_of_entries: u32le
+    header_version: u8: 0x20
+    entry_version: u8:: 0x10
+    header_length: u8: $struct_size
+    flags: u8
+    ticks_to_add: u16le
+    tokens_to_add: u16le
+    uma_size: u32le
+    crc32: u32le
+    fitc_major: u16le
+    fitc_minor: u16le
+    fitc_hotfix: u16le
+    fitc_build: u16le
+}
+struct IfwiFptEntry {
+    partition_name: u32le
+    _reserved1: 4u8
+    offset: u32le
+    length: u32le		// bytes
+    _reserved2: 12u8
+    partition_type: u32le	// 0 for code, 1 for data, 2 for GLUT
+}

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -14,8 +14,8 @@
 #include "fu-byte-array.h"
 #include "fu-bytes.h"
 #include "fu-ifwi-cpd-firmware.h"
-#include "fu-mem.h"
 #include "fu-oprom-firmware.h"
+#include "fu-oprom-struct.h"
 #include "fu-string.h"
 
 /**
@@ -35,40 +35,8 @@ typedef struct {
 G_DEFINE_TYPE_WITH_PRIVATE(FuOpromFirmware, fu_oprom_firmware, FU_TYPE_FIRMWARE)
 #define GET_PRIVATE(o) (fu_oprom_firmware_get_instance_private(o))
 
-#define FU_OPROM_HEADER_SIGNATURE		   0xAA55
-#define FU_OPROM_FIRMWARE_PCI_DATA_SIGNATURE	   0x52494350 /* "PCIR" */
 #define FU_OPROM_FIRMWARE_ALIGN_LEN		   512u
 #define FU_OPROM_FIRMWARE_LAST_IMAGE_INDICATOR_BIT (1u << 7)
-
-typedef struct __attribute__((packed)) {
-	guint16 signature;
-	guint16 image_size; /* of 512 bytes */
-	guint32 init_func_entry_point;
-	guint16 subsystem;
-	guint16 machine_type;
-	guint16 compression_type;
-	guint8 reserved[8];
-	guint16 efi_image_offset;
-	guint16 pci_header_offset;
-	guint16 expansion_header_offset;
-} FuOpromFirmwareHeader2;
-
-typedef struct __attribute__((packed)) {
-	guint32 signature;
-	guint16 vendor_id;
-	guint16 device_id;
-	guint16 device_list_pointer;
-	guint16 structure_length;
-	guint8 structure_revision;
-	guint8 class_code[3];
-	guint16 image_length; /* of 512 bytes */
-	guint16 image_revision;
-	guint8 code_type;
-	guint8 indicator;
-	guint16 max_runtime_image_length;
-	guint16 conf_util_code_header_pointer;
-	guint16 dmtf_clp_entry_point_pointer;
-} FuOpromFirmwarePciData;
 
 /**
  * fu_oprom_firmware_get_machine_type:
@@ -137,31 +105,10 @@ fu_oprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 static gboolean
 fu_oprom_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	gsize bufsz = 0;
-	guint16 signature = 0;
-	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
-
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuOpromFirmwareHeader2, signature),
-				    &signature,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read magic: ");
-		return FALSE;
-	}
-	if (signature != FU_OPROM_HEADER_SIGNATURE) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_FILE,
-			    "invalid ROM signature, got 0x%x, expected 0x%x",
-			    signature,
-			    (guint)FU_OPROM_HEADER_SIGNATURE);
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
+	return fu_struct_oprom_validate(g_bytes_get_data(fw, NULL),
+					g_bytes_get_size(fw),
+					offset,
+					error);
 }
 
 static gboolean
@@ -174,46 +121,23 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	FuOpromFirmware *self = FU_OPROM_FIRMWARE(firmware);
 	FuOpromFirmwarePrivate *priv = GET_PRIVATE(self);
 	guint16 expansion_header_offset = 0;
-	guint16 pci_header_offset = 0;
+	guint16 pci_header_offset;
 	gsize bufsz = 0;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	guint16 image_length = 0;
-	guint32 pci_signature = 0;
-	guint8 code_type = 0;
+	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(GByteArray) st_pci = NULL;
 
 	/* parse header */
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuOpromFirmwareHeader2, subsystem),
-				    &priv->subsystem,
-				    G_LITTLE_ENDIAN,
-				    error))
+	st_hdr = fu_struct_oprom_parse(buf, bufsz, offset, error);
+	if (st_hdr == NULL)
 		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset +
-					G_STRUCT_OFFSET(FuOpromFirmwareHeader2, compression_type),
-				    &priv->compression_type,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuOpromFirmwareHeader2, machine_type),
-				    &priv->machine_type,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
+	priv->subsystem = fu_struct_oprom_get_subsystem(st_hdr);
+	priv->compression_type = fu_struct_oprom_get_compression_type(st_hdr);
+	priv->machine_type = fu_struct_oprom_get_machine_type(st_hdr);
 
 	/* get PCI offset */
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset +
-					G_STRUCT_OFFSET(FuOpromFirmwareHeader2, pci_header_offset),
-				    &pci_header_offset,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
+	pci_header_offset = fu_struct_oprom_get_pci_header_offset(st_hdr);
 	if (pci_header_offset == 0x0) {
 		g_set_error(error,
 			    G_IO_ERROR,
@@ -223,56 +147,21 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* verify signature */
-	offset += pci_header_offset;
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuOpromFirmwarePciData, signature),
-				    &pci_signature,
-				    G_LITTLE_ENDIAN,
-				    error))
+	st_pci = fu_struct_oprom_pci_parse(buf, bufsz, offset + pci_header_offset, error);
+	if (st_pci == NULL)
 		return FALSE;
-	if (pci_signature != FU_OPROM_FIRMWARE_PCI_DATA_SIGNATURE) {
-		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
-			    "invalid PCI signature, got 0x%x, expected 0x%x",
-			    pci_signature,
-			    (guint)FU_OPROM_FIRMWARE_PCI_DATA_SIGNATURE);
-		return FALSE;
-	}
 
 	/* get length */
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuOpromFirmwarePciData, image_length),
-				    &image_length,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
+	image_length = fu_struct_oprom_pci_get_image_length(st_pci);
 	if (image_length == 0x0) {
 		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid image length");
 		return FALSE;
 	}
 	fu_firmware_set_size(firmware, image_length * FU_OPROM_FIRMWARE_ALIGN_LEN);
-
-	/* get code type */
-	if (!fu_memread_uint8_safe(buf,
-				   bufsz,
-				   offset + G_STRUCT_OFFSET(FuOpromFirmwarePciData, code_type),
-				   &code_type,
-				   error))
-		return FALSE;
-	fu_firmware_set_idx(firmware, code_type);
+	fu_firmware_set_idx(firmware, fu_struct_oprom_pci_get_code_type(st_pci));
 
 	/* get CPD offset */
-	if (!fu_memread_uint16_safe(
-		buf,
-		bufsz,
-		G_STRUCT_OFFSET(FuOpromFirmwareHeader2, expansion_header_offset),
-		&expansion_header_offset,
-		G_LITTLE_ENDIAN,
-		error))
-		return FALSE;
+	expansion_header_offset = fu_struct_oprom_get_expansion_header_offset(st_hdr);
 	if (expansion_header_offset != 0x0) {
 		g_autoptr(FuFirmware) img = NULL;
 		g_autoptr(GBytes) blob = NULL;
@@ -312,10 +201,12 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	FuOpromFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize image_size = 0;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) st_hdr = fu_struct_oprom_new();
+	g_autoptr(GByteArray) st_pci = fu_struct_oprom_pci_new();
 	g_autoptr(GBytes) blob_cpd = NULL;
 
 	/* the smallest each image (and header) can be is 512 bytes */
-	image_size += fu_common_align_up(sizeof(FuOpromFirmwareHeader2), FU_FIRMWARE_ALIGNMENT_512);
+	image_size += fu_common_align_up(st_hdr->len, FU_FIRMWARE_ALIGNMENT_512);
 	blob_cpd = fu_firmware_get_image_by_id_bytes(firmware, "cpd", NULL);
 	if (blob_cpd != NULL) {
 		image_size +=
@@ -323,37 +214,23 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* write the header */
-	fu_byte_array_append_uint16(buf, FU_OPROM_HEADER_SIGNATURE, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, image_size / FU_OPROM_FIRMWARE_ALIGN_LEN, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN); /* init_func_entry_point */
-	fu_byte_array_append_uint16(buf, priv->subsystem, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, priv->machine_type, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, priv->compression_type, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint64(buf, 0x0, G_LITTLE_ENDIAN); /* reserved */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN); /* efi_image_offset */
-	fu_byte_array_append_uint16(buf,
-				    sizeof(FuOpromFirmwareHeader2),
-				    G_LITTLE_ENDIAN); /* pci_header_offset */
-	fu_byte_array_append_uint16(buf,
-				    blob_cpd != NULL ? image_size - FU_OPROM_FIRMWARE_ALIGN_LEN
-						     : 0x0,
-				    G_LITTLE_ENDIAN); /* expansion_header_offset */
-	g_assert(buf->len == sizeof(FuOpromFirmwareHeader2));
+	fu_struct_oprom_set_image_size(st_hdr, image_size / FU_OPROM_FIRMWARE_ALIGN_LEN);
+	fu_struct_oprom_set_subsystem(st_hdr, priv->subsystem);
+	fu_struct_oprom_set_machine_type(st_hdr, priv->machine_type);
+	fu_struct_oprom_set_compression_type(st_hdr, priv->compression_type);
+	if (blob_cpd != NULL) {
+		fu_struct_oprom_set_expansion_header_offset(st_hdr,
+							    image_size -
+								FU_OPROM_FIRMWARE_ALIGN_LEN);
+	}
+	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
 
 	/* add PCI section */
-	fu_byte_array_append_uint32(buf, FU_OPROM_FIRMWARE_PCI_DATA_SIGNATURE, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, 0x8086, G_LITTLE_ENDIAN); /* vendor_id */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN);	   /* device_id */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN);	   /* device_list_pointer */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN);	   /* structure_length */
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);	   /* structure_revision */
-	fu_byte_array_append_uint16(buf, image_size / FU_OPROM_FIRMWARE_ALIGN_LEN, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN); /* image_revision */
-	fu_byte_array_append_uint8(buf, fu_firmware_get_idx(firmware));
-	fu_byte_array_append_uint8(buf, FU_OPROM_FIRMWARE_LAST_IMAGE_INDICATOR_BIT);
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN); /* max_runtime_image_length */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN); /* conf_util_code_header_pointer */
-	fu_byte_array_append_uint16(buf, 0x0, G_LITTLE_ENDIAN); /* dmtf_clp_entry_point_pointer */
+	fu_struct_oprom_pci_set_vendor_id(st_pci, 0x8086);
+	fu_struct_oprom_pci_set_image_length(st_pci, image_size / FU_OPROM_FIRMWARE_ALIGN_LEN);
+	fu_struct_oprom_pci_set_code_type(st_pci, fu_firmware_get_idx(firmware));
+	fu_struct_oprom_pci_set_indicator(st_pci, FU_OPROM_FIRMWARE_LAST_IMAGE_INDICATOR_BIT);
+	g_byte_array_append(buf, st_pci->data, st_pci->len);
 	fu_byte_array_align_up(buf, FU_FIRMWARE_ALIGNMENT_512, 0xFF);
 
 	/* add CPD */

--- a/libfwupdplugin/fu-oprom.struct
+++ b/libfwupdplugin/fu-oprom.struct
@@ -1,0 +1,28 @@
+struct Oprom {
+    signature: u16le:: 0xAA55
+    image_size: u16le		// of 512 bytes
+    init_func_entry_point: u32le
+    subsystem: u16le
+    machine_type: u16le
+    compression_type: u16le
+    _reserved: 8u8
+    efi_image_offset: u16le
+    pci_header_offset: u16le: $struct_size
+    expansion_header_offset: u16le
+}
+struct OpromPci {
+    signature: u32le:: 0x52494350
+    vendor_id: u16le
+    device_id: u16le
+    device_list_pointer: u16le
+    structure_length: u16le
+    structure_revision: u8
+    class_code: u24
+    image_length: u16le		// of 512 bytes
+    image_revision: u16le
+    code_type: u8
+    indicator: u8
+    max_runtime_image_length: u16le
+    conf_util_code_header_pointer: u16le
+    dmtf_clp_entry_point_pointer: u16le
+}

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -47,8 +47,8 @@ typedef struct {
 	GHashTable *runtime_versions;
 	GHashTable *compile_versions;
 	FuContext *ctx;
-	GArray *device_gtypes; /* (nullable): of #GType */
-	GHashTable *cache;     /* (nullable): platform_id:GObject */
+	GArray *device_gtypes;	     /* (nullable): of #GType */
+	GHashTable *cache;	     /* (nullable): platform_id:GObject */
 	GHashTable *report_metadata; /* (nullable): key:value */
 	GFileMonitor *config_monitor;
 	FuPluginData *data;

--- a/libfwupdplugin/fu-self-test.struct
+++ b/libfwupdplugin/fu-self-test.struct
@@ -1,0 +1,11 @@
+struct SelfTest {
+    signature: u32be:: 0x12345678
+    length: u32le: $struct_size			// bytes
+    revision: u8
+    owner: guid
+    oem_id: 6s:: ABCDEF
+    oem_table_id: 8s
+    oem_revision: u32le
+    asl_compiler_id: 4s
+    asl_compiler_revision: u32le
+}

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -20,9 +20,9 @@
 
 #include "fu-byte-array.h"
 #include "fu-common.h"
-#include "fu-mem.h"
 #include "fu-path.h"
 #include "fu-smbios-private.h"
+#include "fu-smbios-struct.h"
 #include "fu-string.h"
 
 /**
@@ -39,38 +39,6 @@ struct _FuSmbios {
 	GPtrArray *items;
 };
 
-/* little endian */
-typedef struct __attribute__((packed)) {
-	gchar anchor_str[4];
-	guint8 entry_point_csum;
-	guint8 entry_point_len;
-	guint8 smbios_major_ver;
-	guint8 smbios_minor_ver;
-	guint16 max_structure_sz;
-	guint8 entry_point_rev;
-	guint8 formatted_area[5];
-	gchar intermediate_anchor_str[5];
-	guint8 intermediate_csum;
-	guint16 structure_table_len;
-	guint32 structure_table_addr;
-	guint16 number_smbios_structs;
-	guint8 smbios_bcd_rev;
-} FuSmbiosStructureEntryPoint32;
-
-/* little endian */
-typedef struct __attribute__((packed)) {
-	gchar anchor_str[5];
-	guint8 entry_point_csum;
-	guint8 entry_point_len;
-	guint8 smbios_major_ver;
-	guint8 smbios_minor_ver;
-	guint8 smbios_docrev;
-	guint8 entry_point_rev;
-	guint8 reserved0;
-	guint32 structure_table_len;
-	guint64 structure_table_addr;
-} FuSmbiosStructureEntryPoint64;
-
 typedef struct {
 	guint8 type;
 	guint16 handle;
@@ -81,25 +49,20 @@ typedef struct {
 G_DEFINE_TYPE(FuSmbios, fu_smbios, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize sz, GError **error)
+fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **error)
 {
 	/* go through each structure */
-	for (gsize i = 0; i < sz; i++) {
+	for (gsize i = 0; i < bufsz; i++) {
 		FuSmbiosItem *item;
-		guint16 str_handle = 0;
-		guint8 str_len = 0;
-		guint8 str_type = 0;
-
-		/* le */
-		if (!fu_memread_uint8_safe(buf, sz, i + 0x0, &str_type, error))
-			return FALSE;
-		if (!fu_memread_uint8_safe(buf, sz, i + 0x1, &str_len, error))
-			return FALSE;
-		if (!fu_memread_uint16_safe(buf, sz, i + 0x2, &str_handle, G_LITTLE_ENDIAN, error))
-			return FALSE;
+		guint8 length;
+		g_autoptr(GByteArray) st_str = NULL;
 
 		/* sanity check */
-		if (str_len < 4) {
+		st_str = fu_struct_smbios_structure_parse(buf, bufsz, i, error);
+		if (st_str == NULL)
+			return FALSE;
+		length = fu_struct_smbios_structure_get_length(st_str);
+		if (length < st_str->len) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
@@ -107,7 +70,7 @@ fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize sz, GError **
 				    (guint)i);
 			return FALSE;
 		}
-		if (i + str_len >= sz) {
+		if (i + length >= bufsz) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
@@ -118,18 +81,18 @@ fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize sz, GError **
 
 		/* create a new result */
 		item = g_new0(FuSmbiosItem, 1);
-		item->type = str_type;
-		item->handle = GUINT16_FROM_LE(str_handle);
-		item->buf = g_byte_array_sized_new(str_len);
+		item->type = fu_struct_smbios_structure_get_type(st_str);
+		item->handle = fu_struct_smbios_structure_get_handle(st_str);
+		item->buf = g_byte_array_sized_new(length);
 		item->strings = g_ptr_array_new_with_free_func(g_free);
-		g_byte_array_append(item->buf, buf + i, str_len);
+		g_byte_array_append(item->buf, buf + i, length);
 		g_ptr_array_add(self->items, item);
 
 		/* jump to the end of the formatted area of the struct */
-		i += str_len;
+		i += length;
 
 		/* add strings from table */
-		while (i < sz) {
+		while (i < bufsz) {
 			GString *str;
 
 			/* end of string section */
@@ -137,7 +100,7 @@ fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize sz, GError **
 				break;
 
 			/* copy into string table */
-			str = fu_strdup((const gchar *)buf, sz, i);
+			str = fu_strdup((const gchar *)buf, bufsz, i);
 			i += str->len + 1;
 			g_ptr_array_add(item->strings, g_string_free(str, FALSE));
 		}
@@ -174,26 +137,18 @@ fu_smbios_setup_from_file(FuSmbios *self, const gchar *filename, GError **error)
 }
 
 static gboolean
-fu_smbios_parse_ep32(FuSmbios *self, const gchar *buf, gsize sz, GError **error)
+fu_smbios_parse_ep32(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **error)
 {
-	FuSmbiosStructureEntryPoint32 *ep;
 	guint8 csum = 0;
 	g_autofree gchar *version_str = NULL;
-
-	/* verify size */
-	if (sz != sizeof(FuSmbiosStructureEntryPoint32)) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_FILE,
-			    "invalid smbios entry point got %" G_GSIZE_FORMAT
-			    " bytes, expected %" G_GSIZE_FORMAT,
-			    sz,
-			    sizeof(FuSmbiosStructureEntryPoint32));
-		return FALSE;
-	}
+	g_autofree gchar *intermediate_anchor_str = NULL;
+	g_autoptr(GByteArray) st_ep32 = NULL;
 
 	/* verify checksum */
-	for (guint i = 0; i < sz; i++)
+	st_ep32 = fu_struct_smbios_ep32_parse(buf, bufsz, 0x0, error);
+	if (st_ep32 == NULL)
+		return FALSE;
+	for (guint i = 0; i < bufsz; i++)
 		csum += buf[i];
 	if (csum != 0x00) {
 		g_set_error_literal(error,
@@ -204,17 +159,16 @@ fu_smbios_parse_ep32(FuSmbios *self, const gchar *buf, gsize sz, GError **error)
 	}
 
 	/* verify intermediate section */
-	ep = (FuSmbiosStructureEntryPoint32 *)buf;
-	if (memcmp(ep->intermediate_anchor_str, "_DMI_", 5) != 0) {
-		g_autofree gchar *tmp = g_strndup(ep->intermediate_anchor_str, 5);
+	intermediate_anchor_str = fu_struct_smbios_ep32_get_intermediate_anchor_str(st_ep32);
+	if (g_strcmp0(intermediate_anchor_str, "_DMI_") != 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "intermediate anchor signature invalid, got %s",
-			    tmp);
+			    intermediate_anchor_str);
 		return FALSE;
 	}
-	for (guint i = 10; i < sz; i++)
+	for (guint i = 10; i < bufsz; i++)
 		csum += buf[i];
 	if (csum != 0x00) {
 		g_set_error_literal(error,
@@ -223,35 +177,30 @@ fu_smbios_parse_ep32(FuSmbios *self, const gchar *buf, gsize sz, GError **error)
 				    "intermediate checksum invalid");
 		return FALSE;
 	}
-	self->structure_table_len = GUINT16_FROM_LE(ep->structure_table_len);
-	version_str = g_strdup_printf("%u.%u", ep->smbios_major_ver, ep->smbios_minor_ver);
+	self->structure_table_len = fu_struct_smbios_ep32_get_structure_table_len(st_ep32);
+	version_str = g_strdup_printf("%u.%u",
+				      fu_struct_smbios_ep32_get_smbios_major_ver(st_ep32),
+				      fu_struct_smbios_ep32_get_smbios_minor_ver(st_ep32));
 	fu_firmware_set_version(FU_FIRMWARE(self), version_str);
-	fu_firmware_set_version_raw(FU_FIRMWARE(self),
-				    (((guint16)ep->smbios_major_ver) << 8) + ep->smbios_minor_ver);
+	fu_firmware_set_version_raw(
+	    FU_FIRMWARE(self),
+	    (((guint16)fu_struct_smbios_ep32_get_smbios_major_ver(st_ep32)) << 8) +
+		fu_struct_smbios_ep32_get_smbios_minor_ver(st_ep32));
 	return TRUE;
 }
 
 static gboolean
-fu_smbios_parse_ep64(FuSmbios *self, const gchar *buf, gsize sz, GError **error)
+fu_smbios_parse_ep64(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **error)
 {
-	FuSmbiosStructureEntryPoint64 *ep;
 	guint8 csum = 0;
 	g_autofree gchar *version_str = NULL;
-
-	/* verify size */
-	if (sz != sizeof(FuSmbiosStructureEntryPoint64)) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_FILE,
-			    "invalid smbios3 entry point got %" G_GSIZE_FORMAT
-			    " bytes, expected %" G_GSIZE_FORMAT,
-			    sz,
-			    sizeof(FuSmbiosStructureEntryPoint32));
-		return FALSE;
-	}
+	g_autoptr(GByteArray) st_ep64 = NULL;
 
 	/* verify checksum */
-	for (guint i = 0; i < sz; i++)
+	st_ep64 = fu_struct_smbios_ep64_parse(buf, bufsz, 0x0, error);
+	if (st_ep64 == NULL)
+		return FALSE;
+	for (guint i = 0; i < bufsz; i++)
 		csum += buf[i];
 	if (csum != 0x00) {
 		g_set_error_literal(error,
@@ -260,9 +209,10 @@ fu_smbios_parse_ep64(FuSmbios *self, const gchar *buf, gsize sz, GError **error)
 				    "entry point checksum invalid");
 		return FALSE;
 	}
-	ep = (FuSmbiosStructureEntryPoint64 *)buf;
-	self->structure_table_len = GUINT32_FROM_LE(ep->structure_table_len);
-	version_str = g_strdup_printf("%u.%u", ep->smbios_major_ver, ep->smbios_minor_ver);
+	self->structure_table_len = fu_struct_smbios_ep64_get_structure_table_len(st_ep64);
+	version_str = g_strdup_printf("%u.%u",
+				      fu_struct_smbios_ep64_get_smbios_major_ver(st_ep64),
+				      fu_struct_smbios_ep64_get_smbios_minor_ver(st_ep64));
 	fu_firmware_set_version(FU_FIRMWARE(self), version_str);
 	return TRUE;
 }
@@ -302,20 +252,19 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
-			    "invalid smbios entry point got %" G_GSIZE_FORMAT
-			    " bytes, expected %" G_GSIZE_FORMAT " or %" G_GSIZE_FORMAT,
-			    sz,
-			    sizeof(FuSmbiosStructureEntryPoint32),
-			    sizeof(FuSmbiosStructureEntryPoint64));
+			    "invalid smbios entry point got 0x%x bytes, expected 0x%x or 0x%x",
+			    (guint)sz,
+			    (guint)FU_STRUCT_SMBIOS_EP32_SIZE,
+			    (guint)FU_STRUCT_SMBIOS_EP64_SIZE);
 		return FALSE;
 	}
 
 	/* parse 32 bit structure */
 	if (memcmp(ep_raw, "_SM_", 4) == 0) {
-		if (!fu_smbios_parse_ep32(self, ep_raw, sz, error))
+		if (!fu_smbios_parse_ep32(self, (const guint8 *)ep_raw, sz, error))
 			return FALSE;
 	} else if (memcmp(ep_raw, "_SM3_", 5) == 0) {
-		if (!fu_smbios_parse_ep64(self, ep_raw, sz, error))
+		if (!fu_smbios_parse_ep64(self, (const guint8 *)ep_raw, sz, error))
 			return FALSE;
 	} else {
 		g_autofree gchar *tmp = g_strndup(ep_raw, 4);

--- a/libfwupdplugin/fu-smbios.struct
+++ b/libfwupdplugin/fu-smbios.struct
@@ -1,0 +1,33 @@
+struct SmbiosEp32 {
+    anchor_str: 4s
+    entry_point_csum: u8
+    entry_point_len: u8
+    smbios_major_ver: u8
+    smbios_minor_ver: u8
+    max_structure_sz: u16le
+    entry_point_rev: u8
+    _formatted_area: 5u8
+    intermediate_anchor_str: 5s
+    intermediate_csum: u8
+    structure_table_len: u16le
+    structure_table_addr: u32le
+    number_smbios_structs: u16le
+    smbios_bcd_rev: u8
+}
+struct SmbiosEp64 {
+    anchor_str: 5s
+    entry_point_csum: u8
+    entry_point_len: u8
+    smbios_major_ver: u8
+    smbios_minor_ver: u8
+    smbios_docrev: u8
+    entry_point_rev: u8
+    reserved0: u8
+    structure_table_len: u32le
+    structure_table_addr: u64le
+}
+struct SmbiosStructure {
+    type: u8
+    length: u8
+    handle: u16le
+}

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -11,7 +11,7 @@
 #include "fu-byte-array.h"
 #include "fu-bytes.h"
 #include "fu-dump.h"
-#include "fu-mem.h"
+#include "fu-usb-device-ds20-struct.h"
 #include "fu-usb-device-ds20.h"
 
 /**
@@ -29,7 +29,7 @@ typedef struct {
 G_DEFINE_TYPE_WITH_PRIVATE(FuUsbDeviceDs20, fu_usb_device_ds20, FU_TYPE_FIRMWARE)
 #define GET_PRIVATE(o) (fu_usb_device_ds20_get_instance_private(o))
 
-typedef struct __attribute__((packed)) {
+typedef struct {
 	guint32 platform_ver;
 	guint16 total_length;
 	guint8 vendor_code;
@@ -126,22 +126,14 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 static gboolean
 fu_usb_device_ds20_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	fwupd_guid_t guid = {0x0};
+	g_autoptr(GByteArray) st = NULL;
 	g_autofree gchar *guid_str = NULL;
 
-	/* parse GUID */
-	if (!fu_memcpy_safe((guint8 *)&guid,
-			    sizeof(guid),
-			    0x0, /* dst */
-			    g_bytes_get_data(fw, NULL),
-			    g_bytes_get_size(fw),
-			    offset + 0x1, /* src */
-			    sizeof(guid),
-			    error))
-		return FALSE;
-
 	/* matches the correct UUID */
-	guid_str = fwupd_guid_to_string(&guid, FWUPD_GUID_FLAG_MIXED_ENDIAN);
+	st = fu_struct_ds20_parse(g_bytes_get_data(fw, NULL), g_bytes_get_size(fw), offset, error);
+	if (st == NULL)
+		return FALSE;
+	guid_str = fwupd_guid_to_string(fu_struct_ds20_get_guid(st), FWUPD_GUID_FLAG_MIXED_ENDIAN);
 	if (g_strcmp0(guid_str, fu_firmware_get_id(firmware)) != 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -176,62 +168,30 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 {
 	FuUsbDeviceDs20 *self = FU_USB_DEVICE_DS20(firmware);
 	FuUsbDeviceDs20Private *priv = GET_PRIVATE(self);
-	const guint8 *buf;
 	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	guint version_lowest = fu_firmware_get_version_raw(firmware);
-	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GPtrArray) dsinfos = g_ptr_array_new_with_free_func(g_free);
 
-	/* cut out the data */
-	blob = fu_bytes_new_offset(fw,
-				   1 + sizeof(fwupd_guid_t),
-				   g_bytes_get_size(fw) - (1 + sizeof(fwupd_guid_t)),
-				   error);
-	if (blob == NULL)
-		return FALSE;
-	buf = g_bytes_get_data(blob, &bufsz);
-	for (gsize off = 0; off < bufsz; off += sizeof(FuUsbDeviceDs20Item)) {
-		FuUsbDeviceDs20Item *dsinfo = g_new0(FuUsbDeviceDs20Item, 1);
-		guint16 total_length = 0;
-		guint32 platform_ver = 0;
+	for (gsize off = 0; off < bufsz; off += FU_STRUCT_DS20_SIZE) {
+		g_autofree FuUsbDeviceDs20Item *dsinfo = g_new0(FuUsbDeviceDs20Item, 1);
+		g_autoptr(GByteArray) st = NULL;
 
-		g_ptr_array_add(dsinfos, dsinfo);
-		if (!fu_memread_uint32_safe(buf,
-					    bufsz,
-					    off +
-						G_STRUCT_OFFSET(FuUsbDeviceDs20Item, platform_ver),
-					    &platform_ver,
-					    G_LITTLE_ENDIAN,
-					    error))
+		/* parse */
+		st = fu_struct_ds20_parse(buf, bufsz, off, error);
+		if (st == NULL)
 			return FALSE;
-		if (!fu_memread_uint16_safe(buf,
-					    bufsz,
-					    off +
-						G_STRUCT_OFFSET(FuUsbDeviceDs20Item, total_length),
-					    &total_length,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return FALSE;
-		if (!fu_memread_uint8_safe(buf,
-					   bufsz,
-					   off + G_STRUCT_OFFSET(FuUsbDeviceDs20Item, vendor_code),
-					   &dsinfo->vendor_code,
-					   error))
-			return FALSE;
-		if (!fu_memread_uint8_safe(buf,
-					   bufsz,
-					   off + G_STRUCT_OFFSET(FuUsbDeviceDs20Item, alt_code),
-					   &dsinfo->alt_code,
-					   error))
-			return FALSE;
-		dsinfo->platform_ver = platform_ver;
-		dsinfo->total_length = total_length;
+		dsinfo->platform_ver = fu_struct_ds20_get_platform_ver(st);
+		dsinfo->total_length = fu_struct_ds20_get_total_length(st);
+		dsinfo->vendor_code = fu_struct_ds20_get_vendor_code(st);
+		dsinfo->alt_code = fu_struct_ds20_get_alt_code(st);
 		g_debug("PlatformVersion=0x%08x, TotalLength=0x%04x, VendorCode=0x%02x, "
 			"AltCode=0x%02x",
 			dsinfo->platform_ver,
 			dsinfo->total_length,
 			dsinfo->vendor_code,
 			dsinfo->alt_code);
+		g_ptr_array_add(dsinfos, g_steal_pointer(&dsinfo));
 	}
 
 	/* sort by platform_ver, highest first */
@@ -276,28 +236,20 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 static GBytes *
 fu_usb_device_ds20_write(FuFirmware *firmware, GError **error)
 {
+	g_autoptr(GByteArray) st = fu_struct_ds20_new();
 	fwupd_guid_t guid = {0x0};
-	g_autoptr(GByteArray) buf = g_byte_array_new();
 
-	/* bReserved */
-	fu_byte_array_append_uint8(buf, 0x0);
-
-	/* PlatformCapabilityUUID */
+	/* pack */
 	if (!fwupd_guid_from_string(fu_firmware_get_id(firmware),
 				    &guid,
 				    FWUPD_GUID_FLAG_MIXED_ENDIAN,
 				    error))
 		return NULL;
-	g_byte_array_append(buf, (const guint8 *)&guid, sizeof(guid));
-
-	/* CapabilityData */
-	fu_byte_array_append_uint32(buf, fu_firmware_get_version_raw(firmware), G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint16(buf, fu_firmware_get_size(firmware), G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint8(buf, fu_firmware_get_idx(firmware));
-	fu_byte_array_append_uint8(buf, 0x0); /* AltCode */
-
-	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	fu_struct_ds20_set_guid(st, &guid);
+	fu_struct_ds20_set_platform_ver(st, fu_firmware_get_version_raw(firmware));
+	fu_struct_ds20_set_total_length(st, fu_firmware_get_size(firmware));
+	fu_struct_ds20_set_vendor_code(st, fu_firmware_get_idx(firmware));
+	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
 }
 
 static void

--- a/libfwupdplugin/fu-usb-device-ds20.struct
+++ b/libfwupdplugin/fu-usb-device-ds20.struct
@@ -1,0 +1,12 @@
+struct Ds20 {
+    _reserved: u8
+    guid: guid
+    platform_ver: u32le
+    total_length: u16le
+    vendor_code: u8
+    alt_code: u8
+}
+struct MsDs20 {
+    size: u16le
+    type: u16le
+}

--- a/libfwupdplugin/fu-usb-device-ms-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ms-ds20.c
@@ -8,7 +8,7 @@
 
 #include "config.h"
 
-#include "fu-mem.h"
+#include "fu-usb-device-ds20-struct.h"
 #include "fu-usb-device-ms-ds20.h"
 
 struct _FuUsbDeviceMsDs20 {
@@ -62,24 +62,17 @@ fu_usb_device_ms_ds20_parse(FuUsbDeviceDs20 *self,
 
 	/* get length and type only */
 	for (gsize offset = 0; offset < bufsz;) {
-		guint16 desc_sz = 0;
-		guint16 desc_type = 0;
-		if (!fu_memread_uint16_safe(buf,
-					    bufsz,
-					    offset + 0x0,
-					    &desc_sz,
-					    G_LITTLE_ENDIAN,
-					    error))
+		guint16 desc_sz;
+		guint16 desc_type;
+		g_autoptr(GByteArray) st = NULL;
+
+		st = fu_struct_ms_ds20_parse(buf, bufsz, offset, error);
+		if (st == NULL)
 			return FALSE;
+		desc_sz = fu_struct_ms_ds20_get_size(st);
 		if (desc_sz == 0)
 			break;
-		if (!fu_memread_uint16_safe(buf,
-					    bufsz,
-					    offset + 0x2,
-					    &desc_type,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return FALSE;
+		desc_type = fu_struct_ms_ds20_get_type(st);
 		g_debug("USB OS descriptor type 0x%04x [%s], length 0x%04x",
 			desc_type,
 			fu_usb_device_os20_type_to_string(desc_type),

--- a/libfwupdplugin/fu-uswid.struct
+++ b/libfwupdplugin/fu-uswid.struct
@@ -1,0 +1,7 @@
+struct Uswid {
+    magic: guid:: 0x53424F4DD6BA2EACA3E67A52AAEE3BAF
+    hdrver: u8
+    hdrsz: u16le: $struct_size
+    payloadsz: u32le
+    flags: u8
+}

--- a/libfwupdplugin/generate-struct.py
+++ b/libfwupdplugin/generate-struct.py
@@ -1,0 +1,594 @@
+#!/usr/bin/python3
+# pylint: disable=invalid-name,missing-docstring
+#
+# Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+import sys
+import argparse
+
+from enum import Enum
+from typing import Optional, List, Tuple
+
+# This script builds source files that describe a structure.
+#
+# This is a very smart structure that supports endian conversion, arrays, GUIDs, strings, default
+# and constant data of variable size.
+#
+# In most cases the smart structure will be defined in a `.struct` file:
+#
+#    struct UswidHdr {
+#        magic: guid
+#        hdrver: u8
+#        hdrsz: u16le: $struct_size
+#        payloadsz: u32le
+#        flags: u8
+#    }
+#
+# The types currently supported are:
+#
+# - `u8`: a #guint8
+# - `u16`: a #guint16
+# - `u24`: a 24 bit number represented as a #guint32
+# - `u32`:  #guint32
+# - `u64`:  #guint64
+# - `s`: a string
+# - `guid`: a packed GUID
+#
+# Additionally, default values can be auto-populated:
+#
+# - `$struct_size`: the struct size, e.g. the value of `fu_struct_size()`
+# - `$struct_offset`: the internal offset in the struct
+# - string values
+# - integer values, specified with a `0x` prefix for base-16 and with no prefix for base-10
+#
+# Any default value prefixed with an additional `:` is set as the default, and is **also**
+# verified during unpacking.
+# This is suitable for constant signature fields where there is no other valid value.
+
+
+class Endian(Enum):
+    NATIVE = "native"
+    LITTLE = "le"
+    BIG = "be"
+
+
+class Type(Enum):
+    U8 = "u8"
+    U16 = "u16"
+    U24 = "u24"
+    U32 = "u32"
+    U64 = "u64"
+    STRING = "s"
+    GUID = "guid"
+
+
+class Item:
+    def __init__(self):
+        self.element_id: str = ""
+        self.type: Type = Type.U8
+        self.default: Optional[str] = None
+        self.constant: Optional[str] = None
+        self.endian: Endian = Endian.NATIVE
+        self.multiplier: int = 0
+        self.offset: int = 0
+
+    @property
+    def size(self) -> int:
+        multiplier = self.multiplier
+        if not multiplier:
+            multiplier = 1
+        if self.type in [Type.U8, Type.STRING, Type.GUID]:
+            return multiplier
+        if self.type == Type.U16:
+            return multiplier * 2
+        if self.type == Type.U24:
+            return multiplier * 3
+        if self.type == Type.U32:
+            return multiplier * 4
+        if self.type == Type.U64:
+            return multiplier * 8
+        return 0
+
+    @property
+    def enabled(self) -> bool:
+        if self.element_id.startswith("_"):
+            return False
+        if self.element_id == "reserved":
+            return False
+        return True
+
+    @property
+    def endian_glib(self) -> str:
+        if self.endian == Endian.LITTLE:
+            return "G_LITTLE_ENDIAN"
+        if self.endian == Endian.BIG:
+            return "G_BIG_ENDIAN"
+        return "G_BYTE_ORDER"
+
+    @property
+    def type_glib(self) -> str:
+        if self.type == Type.U8:
+            return "guint8"
+        elif self.type == Type.U16:
+            return "guint16"
+        elif self.type == Type.U24:
+            return "guint32"
+        elif self.type == Type.U32:
+            return "guint32"
+        elif self.type == Type.U64:
+            return "guint64"
+        elif self.type == Type.STRING:
+            return "gchar"
+        if self.type == Type.GUID:
+            return "fwupd_guid_t"
+        return "void"
+
+    @property
+    def type_mem(self) -> str:
+        if self.type == Type.U16:
+            return "uint16"
+        elif self.type == Type.U24:
+            return "uint24"
+        elif self.type == Type.U32:
+            return "uint32"
+        elif self.type == Type.U64:
+            return "uint64"
+        return ""
+
+    def generate_h_glib(self, name_snake: str) -> str:
+
+        # constants do not need getters and setters as they're, well, constant
+        if self.constant:
+            return ""
+
+        # string
+        if self.type == Type.STRING:
+            return f"""
+gchar *{name_snake}_get_{self.element_id}(GByteArray *st);
+gboolean {name_snake}_set_{self.element_id}(GByteArray *st, const gchar *value, GError **error);
+"""
+
+        # data blob
+        if self.type == Type.U8 and self.multiplier:
+            return f"""
+const guint8 *{name_snake}_get_{self.element_id}(GByteArray *st, gsize *bufsz);
+gboolean {name_snake}_set_{self.element_id}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error);
+"""
+
+        # GUID
+        if self.type == Type.GUID:
+            return f"""
+const fwupd_guid_t *{name_snake}_get_{self.element_id}(GByteArray *st);
+void {name_snake}_set_{self.element_id}(GByteArray *st, const fwupd_guid_t *value);
+"""
+
+        # uint
+        if not self.multiplier and self.type in [
+            Type.U8,
+            Type.U16,
+            Type.U24,
+            Type.U32,
+            Type.U64,
+        ]:
+            return f"""
+{self.type_glib} {name_snake}_get_{self.element_id}(GByteArray *st);
+void {name_snake}_set_{self.element_id}(GByteArray *st, {self.type_glib} value);
+"""
+
+        # fallback
+        return ""
+
+    def generate_c_glib(self, name_snake: str) -> str:
+
+        # string
+        if self.type == Type.STRING:
+            return f"""
+{"G_GNUC_UNUSED static " if self.constant else ""}gchar *
+{name_snake}_get_{self.element_id}(GByteArray *st)
+{{
+    g_return_val_if_fail(st != NULL, NULL);
+    return fu_strsafe((const gchar *) (st->data + {self.offset}), {self.size});
+}}
+{"static " if self.constant else ""}gboolean
+{name_snake}_set_{self.element_id}(GByteArray *st, const gchar *value, GError **error)
+{{
+    gsize len = strlen(value);
+    g_return_val_if_fail(st != NULL, FALSE);
+    return fu_memcpy_safe(st->data, st->len, {self.offset}, (const guint8 *)value, len, 0x0, len, error);
+}}
+"""
+
+        # data blob
+        if self.type == Type.U8 and self.multiplier:
+            return f"""
+{"static " if self.constant else ""}const guint8 *
+{name_snake}_get_{self.element_id}(GByteArray *st, gsize *bufsz)
+{{
+    g_return_val_if_fail(st != NULL, NULL);
+    if (bufsz != NULL)
+        *bufsz = st->len;
+    return st->data + {self.offset};
+}}
+{"static " if self.constant else ""}gboolean
+{name_snake}_set_{self.element_id}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error)
+{{
+    g_return_val_if_fail(st != NULL, FALSE);
+    g_return_val_if_fail(buf != NULL, FALSE);
+    return fu_memcpy_safe(st->data, st->len, {self.offset}, buf, bufsz, 0x0, bufsz, error);
+}}
+"""
+
+        # GUID
+        if self.type == Type.GUID:
+            return f"""
+{"static " if self.constant else ""}const fwupd_guid_t *
+{name_snake}_get_{self.element_id}(GByteArray *st)
+{{
+    g_return_val_if_fail(st != NULL, NULL);
+    return (const fwupd_guid_t *) (st->data + {self.offset});
+}}
+{"static " if self.constant else ""}void
+{name_snake}_set_{self.element_id}(GByteArray *st, const fwupd_guid_t *value)
+{{
+    g_return_if_fail(st != NULL);
+    g_return_if_fail(value != NULL);
+    memcpy(st->data + {self.offset}, value, sizeof(*value));
+}}
+"""
+
+        # U8
+        if self.type == Type.U8:
+            return f"""
+{"static " if self.constant else ""}guint8
+{name_snake}_get_{self.element_id}(GByteArray *st)
+{{
+    g_return_val_if_fail(st != NULL, 0x0);
+    return st->data[{self.offset}];
+}}
+{"static " if self.constant else ""}void
+{name_snake}_set_{self.element_id}(GByteArray *st, guint8 value)
+{{
+    g_return_if_fail(st != NULL);
+    st->data[{self.offset}] = value;
+}}
+"""
+        # uint
+        if not self.multiplier and self.type in [
+            Type.U16,
+            Type.U24,
+            Type.U32,
+            Type.U64,
+        ]:
+            return f"""
+{"static " if self.constant else ""}{self.type_glib}
+{name_snake}_get_{self.element_id}(GByteArray *st)
+{{
+    g_return_val_if_fail(st != NULL, 0x0);
+    return fu_memread_{self.type_mem}(st->data + {self.offset}, {self.endian_glib});
+}}
+{"static " if self.constant else ""}void
+{name_snake}_set_{self.element_id}(GByteArray *st, {self.type_glib} value)
+{{
+    g_return_if_fail(st != NULL);
+    fu_memwrite_{self.type_mem}(st->data + {self.offset}, value, {self.endian_glib});
+}}
+"""
+
+        # fallback
+        return ""
+
+    def _parse_default(self, val: str) -> str:
+
+        if self.type == Type.STRING:
+            return val
+        if self.type == Type.GUID or (self.type == Type.U8 and self.multiplier):
+            if not val.startswith("0x"):
+                raise ValueError(f"0x prefix for hex number expected, got: {val}")
+            if len(val) != (self.size * 2) + 2:
+                raise ValueError(f"data has to be {self.size} bytes exactly")
+            val_hex = ""
+            for idx in range(2, len(val), 2):
+                val_hex += f"\\x{val[idx:idx+2]}"
+            return val_hex
+        if self.type in [
+            Type.U8,
+            Type.U16,
+            Type.U24,
+            Type.U32,
+            Type.U64,
+        ]:
+            return val.replace("$struct_offset", str(self.offset))
+        raise ValueError(f"do not know how to parse value for type: {self.type}")
+
+    def parse_default(self, val: str) -> None:
+
+        self.default = self._parse_default(val)
+
+    def parse_constant(self, val: str) -> None:
+
+        self.default = self._parse_default(val)
+        self.constant = self.default
+
+    def parse_type(self, val: str) -> None:
+
+        # get the integer multiplier
+        split_index = 0
+        for char in val:
+            if not char.isnumeric():
+                break
+            split_index += 1
+        if split_index:
+            self.multiplier = int(val[:split_index])
+
+        # find the type
+        try:
+            val2 = val[split_index:]
+            if val2.endswith("be"):
+                self.endian = Endian.BIG
+                val2 = val2[:-2]
+            elif val2.endswith("le"):
+                self.endian = Endian.LITTLE
+                val2 = val2[:-2]
+            self.type = Type(val2)
+            if self.type == Type.GUID:
+                self.multiplier = 16
+        except ValueError as e:
+            raise ValueError(f"invalid type: {val2}") from e
+
+    def __str__(self) -> str:
+        tmp = f"{self.element_id}: "
+        if self.multiplier:
+            tmp += str(self.multiplier)
+        tmp += str(self.type)
+        if self.endian != Endian.NATIVE:
+            tmp += str(self.endian)
+        if self.default:
+            tmp += f": {self.default}"
+        elif self.constant:
+            tmp += f":: {self.constant}"
+        return tmp
+
+
+# convert a CamelCase name into snake_case
+def _camel_to_snake(name: str) -> str:
+
+    name_snake: str = ""
+    for char in name:
+        if char.islower() or char.isnumeric():
+            name_snake += char
+            continue
+        if name_snake:
+            name_snake += "_"
+        name_snake += char.lower()
+    return name_snake
+
+
+class Generator:
+    def __init__(self, basename):
+        self.basename: str = basename
+
+    def _process_items(self, name: str, items: List[Item]) -> Tuple[str, str]:
+
+        # useful constants
+        name_snake = f"fu_struct_{_camel_to_snake(name)}"
+        size: int = 0
+        for item in items:
+            size += item.size
+        has_constant: bool = False
+        for item in items:
+            if item.constant:
+                has_constant = True
+                break
+
+        # header
+        str_h = ""
+        str_h += f"GByteArray* {name_snake}_new(void);\n"
+        str_h += f"GByteArray* {name_snake}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error);\n"
+        str_h += f"gboolean {name_snake}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error);\n"
+        for item in items:
+            if not item.enabled:
+                continue
+            str_h += item.generate_h_glib(name_snake)
+        for item in items:
+            str_h += f"#define {name_snake.upper()}_OFFSET_{item.element_id.upper()} 0x{item.offset:x}\n"
+        str_h += f"#define {name_snake.upper()}_SIZE 0x{size:x}\n"
+        # print(str_h)
+
+        # code
+        str_c = ""
+        for item in items:
+            if not item.enabled:
+                continue
+            str_c += item.generate_c_glib(name_snake)
+
+        # _new()
+        str_c += f"GByteArray *\n"
+        str_c += f"{name_snake}_new(void)\n"
+        str_c += f"{{\n"
+        str_c += f"    GByteArray *st = g_byte_array_new();\n"
+        str_c += f"    fu_byte_array_set_size(st, {size}, 0x0);\n"
+        for item in items:
+            if not item.default:
+                continue
+            if item.type == Type.STRING:
+                str_c += f'    {name_snake}_set_{item.element_id}(st, "{item.default}", NULL);\n'
+            elif item.type == Type.GUID:
+                str_c += f'    {name_snake}_set_{item.element_id}(st, (fwupd_guid_t *) "{item.default}");\n'
+            else:
+                str_c += (
+                    f"    {name_snake}_set_{item.element_id}(st, {item.default});\n"
+                )
+        str_c += f"    return st;\n"
+        str_c += f"}}\n"
+
+        # _parse()
+        str_c += f"GByteArray *\n"
+        str_c += f"{name_snake}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error)\n"
+        str_c += f"{{\n"
+        str_c += f"    g_autoptr(GByteArray) st = g_byte_array_new();\n"
+        str_c += f"    g_return_val_if_fail(buf != NULL, NULL);\n"
+        str_c += f"    g_return_val_if_fail(error == NULL || *error == NULL, NULL);\n"
+        str_c += f"    if (offset + {size} > bufsz) {{\n"
+        str_c += f"            g_set_error(error,\n"
+        str_c += f"                        G_IO_ERROR,\n"
+        str_c += f"                        G_IO_ERROR_INVALID_DATA,\n"
+        str_c += f'                        "cannot parse buffer of size 0x%x at offset 0x%x for struct {name} of size 0x%x",\n'
+        str_c += f"                        (guint) bufsz,\n"
+        str_c += f"                        (guint) offset,\n"
+        str_c += f"                        (guint) {size});\n"
+        str_c += f"            return NULL;\n"
+        str_c += f"    }}\n"
+        str_c += f"    g_byte_array_append(st, buf + offset, {size});\n"
+        for item in items:
+            if item.constant:
+                if item.type == Type.STRING:
+                    str_c += f'    if (strncmp((const gchar *) (st->data + {item.offset}), "{item.constant}", {item.size}) != 0) {{\n'
+                elif item.type == Type.GUID:
+                    str_c += f'    if (memcmp(st->data + {item.offset}, "{item.constant}", {item.size}) != 0) {{\n'
+                else:
+                    str_c += f"    if ({name_snake}_get_{item.element_id}(st) != {item.constant}) {{\n"
+                str_c += "            g_set_error_literal(error,\n"
+                str_c += "                                G_IO_ERROR,\n"
+                str_c += "                                G_IO_ERROR_INVALID_DATA,\n"
+                str_c += f'                                "constant {name}.{item.element_id} was not valid, expected {item.constant}");\n'
+                str_c += "            return NULL;\n"
+                str_c += "    }\n"
+        str_c += "    return g_steal_pointer(&st);\n"
+        str_c += "}\n"
+
+        # _validate()
+        if has_constant:
+            str_c += f"gboolean\n"
+            str_c += f"{name_snake}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error)\n"
+            str_c += f"{{\n"
+            str_c += f"    GByteArray st = {{.data = (guint8 *) buf + offset, .len = bufsz - offset, }};\n"
+            str_c += f"    g_return_val_if_fail(buf != NULL, FALSE);\n"
+            str_c += (
+                f"    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);\n"
+            )
+            str_c += f"    if (offset + {size} > bufsz) {{\n"
+            str_c += f"            g_set_error(error,\n"
+            str_c += f"                        G_IO_ERROR,\n"
+            str_c += f"                        G_IO_ERROR_INVALID_DATA,\n"
+            str_c += f'                        "cannot parse buffer of size 0x%x at offset 0x%x for struct {name} of size 0x%x",\n'
+            str_c += f"                        (guint) bufsz,\n"
+            str_c += f"                        (guint) offset,\n"
+            str_c += f"                        (guint) {size});\n"
+            str_c += f"            return FALSE;\n"
+            str_c += f"    }}\n"
+            for item in items:
+                if not item.constant:
+                    continue
+                if item.type == Type.STRING:
+                    str_c += f'    if (strncmp((const gchar *) (st.data + {item.offset}), "{item.constant}", {item.size}) != 0) {{\n'
+                elif item.type == Type.GUID or (
+                    item.type == Type.U8 and item.multiplier
+                ):
+                    str_c += f'    if (memcmp({name_snake}_get_{item.element_id}(&st), "{item.constant}", {item.size}) != 0) {{\n'
+                else:
+                    str_c += f"    if ({name_snake}_get_{item.element_id}(&st) != {item.constant}) {{\n"
+                str_c += f"            g_set_error_literal(error,\n"
+                str_c += f"                                G_IO_ERROR,\n"
+                str_c += f"                                G_IO_ERROR_INVALID_DATA,\n"
+                str_c += f'                                "constant {name}.{item.element_id} was not valid");\n'
+                str_c += f"            return FALSE;\n"
+                str_c += f"    }}\n"
+            str_c += f"    return TRUE;\n"
+            str_c += f"}}\n"
+
+        # success
+        return str_c, str_h
+
+    def process_input(self, contents: str) -> Tuple[str, str]:
+        name = None
+        items: List[Item] = []
+        offset: int = 0
+
+        # header
+        dst_h = """/* auto-generated, do not modify */
+#pragma once
+#include <glib.h>
+typedef guint8 fwupd_guid_t[16];
+"""
+
+        # body
+        dst_c = f"""/* auto-generated, do not modify */
+#include "{self.basename}"
+#include "fu-byte-array.h"
+#include "fu-mem.h"
+#include "fu-string.h"
+"""
+
+        for line in contents.split("\n"):
+
+            # remove comments and indent
+            line = line.split("//")[0].strip()
+            if not line:
+                continue
+
+            # start of structure
+            if line.startswith("struct ") and line.endswith("{"):
+                name = line[6:-1].strip()
+                continue
+
+            # not in the structure
+            if not name:
+                continue
+
+            # end of structure
+            if line.startswith("}"):
+                for item in items:
+                    if item.default == "$struct_size":
+                        item.default = str(offset)
+                    if item.constant == "$struct_size":
+                        item.constant = str(offset)
+                str_c, str_h = self._process_items(name, items)
+                dst_c += str_c
+                dst_h += str_h
+                name = None
+                items = []
+                offset = 0
+                continue
+
+            # split into sections
+            parts = line.replace(" ", "").split(":")
+            if len(parts) == 1:
+                raise ValueError(f"invalid struct line: {line}")
+
+            # parse one element
+            item = Item()
+            item.offset = offset
+            item.element_id = parts[0]
+            item.parse_type(parts[1])
+            if len(parts) >= 3 and parts[2]:
+                item.parse_default(parts[2])
+            if len(parts) >= 4 and parts[3]:
+                item.parse_constant(parts[3])
+            offset += item.size
+            items.append(item)
+
+        # success
+        return dst_c, dst_h
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("src", action="store", type=str, help="source")
+    parser.add_argument("dst_c", action="store", type=str, help="destination .c")
+    parser.add_argument("dst_h", action="store", type=str, help="destination .h")
+    args = parser.parse_args()
+
+    g = Generator(basename=os.path.basename(args.dst_h))
+    with open(args.src, "rb") as f:
+        try:
+            dst_c, dst_h = g.process_input(f.read().decode())
+        except ValueError as e:
+            sys.exit(f"cannot process {args.src}: {str(e)}")
+    with open(args.dst_c, "wb") as f:  # type: ignore
+        f.write(dst_c.encode())
+    with open(args.dst_h, "wb") as f:  # type: ignore
+        f.write(dst_h.encode())

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -8,6 +8,20 @@ fwupdplugin_version_h = configure_file(
   configuration: conf
 )
 
+fwupdplugin_structs = structgen.process(
+  'fu-acpi-table.struct',   # fuzzing
+  'fu-cfu.struct',          # fuzzing
+  'fu-dfu.struct',          # fuzzing
+  'fu-efi.struct',          # fuzzing
+  'fu-fdt.struct',          # fuzzing
+  'fu-fmap.struct',         # fuzzing
+  'fu-ifwi.struct',         # fuzzing
+  'fu-oprom.struct',        # fuzzing
+  'fu-smbios.struct',       # fuzzing
+  'fu-usb-device-ds20.struct', # fuzzing
+  'fu-uswid.struct',        # fuzzing
+)
+
 fwupdplugin_src = [
   'fu-acpi-table.c',        # fuzzing
   'fu-archive.c',
@@ -243,6 +257,7 @@ fwupdplugin_mapfile = 'fwupdplugin.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), fwupdplugin_mapfile)
 fwupdplugin = library(
   'fwupdplugin',
+  fwupdplugin_structs,
   sources: [
     fwupdplugin_src,
     fwupdplugin_headers,
@@ -351,6 +366,7 @@ if get_option('tests')
   e = executable(
     'fwupdplugin-self-test',
     installed_firmware_zip,
+    structgen.process('fu-self-test.struct'),
     sources: [
       'fu-self-test.c'
     ],

--- a/meson.build
+++ b/meson.build
@@ -565,6 +565,13 @@ else
   run_sanitize_unsafe_tests = true
 endif
 
+# take foo.struct and generate foo-struct.c and foo-struct.h files like protobuf_c
+structgenpy = find_program(join_paths(meson.project_source_root(), 'libfwupdplugin', 'generate-struct.py'))
+structgen = generator(structgenpy,
+  output  : ['@BASENAME@-struct.c', '@BASENAME@-struct.h'],
+  arguments : ['@INPUT@', '@OUTPUT0@', '@OUTPUT1@'],
+)
+
 subdir('libfwupd')
 if polkit.found()
   subdir('policy')

--- a/plugins/acpi-phat/fu-acpi-phat.struct
+++ b/plugins/acpi-phat/fu-acpi-phat.struct
@@ -1,0 +1,21 @@
+struct AcpiPhatHealthRecord {
+    signature: u16le: 0x1
+    rcdlen: u16le
+    version: u8
+    reserved: 2u8
+    flags: u8
+    device_signature: guid
+    device_specific_data: u32le
+}
+struct AcpiPhatVersionElement {
+    component_id: guid
+    version_value: u64le
+    producer_id: 4s
+}
+struct AcpiPhatVersionRecord {
+    signature: u16le: 0x0
+    rcdlen: u16le
+    version: u8
+    reserved: 3u8
+    record_count: u32le
+}

--- a/plugins/acpi-phat/meson.build
+++ b/plugins/acpi-phat/meson.build
@@ -2,6 +2,9 @@ if get_option('plugin_acpi_phat').disable_auto_if(host_machine.system() != 'linu
 cargs = ['-DG_LOG_DOMAIN="FuPluginAcpiPhat"']
 
 plugin_builtin_acpi_phat = static_library('fu_plugin_acpi_phat',
+  structgen.process(
+    'fu-acpi-phat.struct',            # fuzzing
+  ),
   sources: [
     'fu-acpi-phat-plugin.c',
     'fu-acpi-phat.c',                 # fuzzing

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -9,20 +9,13 @@
 #include <fwupdplugin.h>
 
 #include "fu-ebitdo-firmware.h"
+#include "fu-ebitdo-struct.h"
 
 struct _FuEbitdoFirmware {
 	FuFirmwareClass parent_instance;
 };
 
 G_DEFINE_TYPE(FuEbitdoFirmware, fu_ebitdo_firmware, FU_TYPE_FIRMWARE)
-
-/* little endian */
-typedef struct __attribute__((packed)) {
-	guint32 version;
-	guint32 destination_addr;
-	guint32 destination_len;
-	guint32 reserved[4];
-} FuEbitdoFirmwareHeader;
 
 static gboolean
 fu_ebitdo_firmware_parse(FuFirmware *firmware,
@@ -31,55 +24,39 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
-	FuEbitdoFirmwareHeader *hdr;
 	guint32 payload_len;
-	g_autofree gchar *version = NULL;
+	gsize bufsz = 0;
+	guint32 version;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autofree gchar *version_str = NULL;
 	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
+	g_autoptr(GByteArray) st = NULL;
 	g_autoptr(GBytes) fw_hdr = NULL;
 	g_autoptr(GBytes) fw_payload = NULL;
 
-	/* corrupt */
-	if (g_bytes_get_size(fw) < sizeof(FuEbitdoFirmwareHeader)) {
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "firmware too small for header");
-		return FALSE;
-	}
-
 	/* check the file size */
-	hdr = (FuEbitdoFirmwareHeader *)g_bytes_get_data(fw, NULL);
-	payload_len = (guint32)(g_bytes_get_size(fw) - sizeof(FuEbitdoFirmwareHeader));
-	if (payload_len != GUINT32_FROM_LE(hdr->destination_len)) {
+	st = fu_struct_ebitdo_hdr_parse(buf, bufsz, offset, error);
+	if (st == NULL)
+		return FALSE;
+	payload_len = (guint32)(g_bytes_get_size(fw) - st->len);
+	if (payload_len != fu_struct_ebitdo_hdr_get_destination_len(st)) {
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_INVALID_DATA,
 			    "file size incorrect, expected 0x%04x got 0x%04x",
-			    (guint)GUINT32_FROM_LE(hdr->destination_len),
+			    (guint)fu_struct_ebitdo_hdr_get_destination_len(st),
 			    (guint)payload_len);
 		return FALSE;
 	}
 
-	/* check if this is firmware */
-	for (guint i = 0; i < 4; i++) {
-		if (hdr->reserved[i] != 0x0) {
-			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "data invalid, reserved[%u] = 0x%04x",
-				    i,
-				    hdr->reserved[i]);
-			return FALSE;
-		}
-	}
-
 	/* parse version */
-	version = g_strdup_printf("%.2f", GUINT32_FROM_LE(hdr->version) / 100.f);
-	fu_firmware_set_version(firmware, version);
-	fu_firmware_set_version_raw(firmware, GUINT32_FROM_LE(hdr->version));
+	version = fu_struct_ebitdo_hdr_get_version(st);
+	version_str = g_strdup_printf("%.2f", version / 100.f);
+	fu_firmware_set_version(firmware, version_str);
+	fu_firmware_set_version_raw(firmware, version);
 
 	/* add header */
-	fw_hdr = fu_bytes_new_offset(fw, 0x0, sizeof(FuEbitdoFirmwareHeader), error);
+	fw_hdr = fu_bytes_new_offset(fw, 0x0, st->len, error);
 	if (fw_hdr == NULL)
 		return FALSE;
 	fu_firmware_set_id(img_hdr, FU_FIRMWARE_ID_HEADER);
@@ -87,11 +64,11 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	fu_firmware_add_image(firmware, img_hdr);
 
 	/* add payload */
-	fw_payload = fu_bytes_new_offset(fw, sizeof(FuEbitdoFirmwareHeader), payload_len, error);
+	fw_payload = fu_bytes_new_offset(fw, st->len, payload_len, error);
 	if (fw_payload == NULL)
 		return FALSE;
 	fu_firmware_set_id(firmware, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_set_addr(firmware, GUINT32_FROM_LE(hdr->destination_addr));
+	fu_firmware_set_addr(firmware, fu_struct_ebitdo_hdr_get_destination_addr(st));
 	fu_firmware_set_bytes(firmware, fw_payload);
 	return TRUE;
 }
@@ -99,20 +76,18 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 static GBytes *
 fu_ebitdo_firmware_write(FuFirmware *firmware, GError **error)
 {
-	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) st = fu_struct_ebitdo_hdr_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	/* header then payload */
 	blob = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (blob == NULL)
 		return NULL;
-	fu_byte_array_append_uint32(buf, fu_firmware_get_version_raw(firmware), G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, fu_firmware_get_addr(firmware), G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, g_bytes_get_size(blob), G_LITTLE_ENDIAN);
-	for (guint i = 0; i < 4; i++)
-		fu_byte_array_append_uint32(buf, 0, G_LITTLE_ENDIAN);
-	fu_byte_array_append_bytes(buf, blob);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	fu_struct_ebitdo_hdr_set_version(st, fu_firmware_get_version_raw(firmware));
+	fu_struct_ebitdo_hdr_set_destination_addr(st, fu_firmware_get_addr(firmware));
+	fu_struct_ebitdo_hdr_set_destination_len(st, g_bytes_get_size(blob));
+	fu_byte_array_append_bytes(st, blob);
+	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
 }
 
 static void

--- a/plugins/ebitdo/fu-ebitdo.struct
+++ b/plugins/ebitdo/fu-ebitdo.struct
@@ -1,0 +1,6 @@
+struct EbitdoHdr {
+    version: u32le
+    destination_addr: u32le
+    destination_len: u32le
+    reserved: 4u32le
+}

--- a/plugins/ebitdo/meson.build
+++ b/plugins/ebitdo/meson.build
@@ -3,6 +3,9 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginEbitdo"']
 
 plugin_quirks += files('ebitdo.quirk')
 plugin_builtins += static_library('fu_plugin_ebitdo',
+  structgen.process(
+    'fu-ebitdo.struct',         # fuzzing
+  ),
   sources: [
     'fu-ebitdo-plugin.c',
     'fu-ebitdo-common.c',

--- a/plugins/intel-gsc/fu-igsc.struct
+++ b/plugins/intel-gsc/fu-igsc.struct
@@ -1,0 +1,16 @@
+struct IgscOpromVersion {
+    major: u16le
+    minor: u16le
+    hotfix: u16le
+    build: u16le
+}
+struct IgscOpromSubsystemDeviceId {
+    subsys_vendor_id: u16le
+    subsys_device_id: u16le
+}
+struct IgscOpromSubsystemDevice4Id {
+    vendor_id: u16le
+    device_id: u16le
+    subsys_vendor_id: u16le
+    subsys_device_id: u16le
+}

--- a/plugins/intel-gsc/meson.build
+++ b/plugins/intel-gsc/meson.build
@@ -5,7 +5,8 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginIgsc"']
 
 plugin_quirks += files('igsc.quirk')
 plugin_builtins += static_library('fu_plugin_igsc',
-  sources : [
+  structgen.process('fu-igsc.struct'),
+  sources: [
     'fu-igsc-plugin.c',
     'fu-igsc-device.c',
     'fu-igsc-code-firmware.c',

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -114,9 +114,9 @@ fu_pxi_receiver_device_fw_ota_init_new(FuPxiReceiverDevice *device, gsize bufsz,
 	fu_byte_array_append_uint8(ota_cmd, 0X06); /* ota init new command length */
 	fu_byte_array_append_uint8(ota_cmd,
 				   FU_PXI_DEVICE_CMD_FW_OTA_INIT_NEW); /* ota init new op code */
-	fu_byte_array_append_uint32(ota_cmd, bufsz, G_LITTLE_ENDIAN); /* fw size */
-	fu_byte_array_append_uint8(ota_cmd, 0x0);		      /* ota setting */
-	g_byte_array_append(ota_cmd, fw_version, sizeof(fw_version)); /* ota version */
+	fu_byte_array_append_uint32(ota_cmd, bufsz, G_LITTLE_ENDIAN);  /* fw size */
+	fu_byte_array_append_uint8(ota_cmd, 0x0);		       /* ota setting */
+	g_byte_array_append(ota_cmd, fw_version, sizeof(fw_version));  /* ota version */
 
 	self->sn++;
 	if (!fu_pxi_composite_receiver_cmd(FU_PXI_DEVICE_CMD_FW_OTA_INIT_NEW,

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -377,9 +377,9 @@ fu_pxi_wireless_device_fw_ota_init_new(FuDevice *device, gsize bufsz, GError **e
 	fu_byte_array_append_uint8(ota_cmd, 0X06); /* ota init new command length */
 	fu_byte_array_append_uint8(ota_cmd,
 				   FU_PXI_DEVICE_CMD_FW_OTA_INIT_NEW); /* ota init new op code */
-	fu_byte_array_append_uint32(ota_cmd, bufsz, G_LITTLE_ENDIAN); /* fw size */
-	fu_byte_array_append_uint8(ota_cmd, 0x0);		      /* ota setting */
-	g_byte_array_append(ota_cmd, fw_version, sizeof(fw_version)); /* ota version */
+	fu_byte_array_append_uint32(ota_cmd, bufsz, G_LITTLE_ENDIAN);  /* fw size */
+	fu_byte_array_append_uint8(ota_cmd, 0x0);		       /* ota setting */
+	g_byte_array_append(ota_cmd, fw_version, sizeof(fw_version));  /* ota version */
 
 	/* increase the serial number */
 	self->sn++;

--- a/plugins/redfish/fu-redfish-smbios.struct
+++ b/plugins/redfish/fu-redfish-smbios.struct
@@ -1,0 +1,15 @@
+struct RedfishProtocolOverIp {
+    service_uuid: guid
+    host_ip_assignment_type: u8
+    host_ip_address_format: u8
+    host_ip_address: 16u8
+    host_ip_mask: 16u8
+    service_ip_assignment_type: u8
+    service_ip_address_format: u8
+    service_ip_address: 16u8
+    service_ip_mask: 16u8
+    service_ip_port: u16le
+    service_ip_vlan_id: u32le
+    service_hostname_len: u8
+// optional service_hostname goes here
+}

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -10,6 +10,9 @@ if have_linux_ipmi
 endif
 
 plugin_builtin_redfish = static_library('fu_plugin_redfish',
+  structgen.process(
+    'fu-redfish-smbios.struct', # fuzzing
+  ),
   sources: [
     'fu-redfish-plugin.c',
     'fu-redfish-backend.c',

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -531,15 +531,6 @@ fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 		return NULL;
 	}
 
-	/* checks file size */
-	if (bufsz < FW_CAPE_HID_HEADER_SIZE * 2) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "file size is too small");
-		return NULL;
-	}
-
 	/* uses second partition if active partition is 1 */
 	if (self->active_partition == 1)
 		offset = bufsz / 2;

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -11,34 +11,13 @@
 #include <string.h>
 
 #include "fu-synaptics-cape-firmware.h"
-
-typedef struct __attribute__((packed)) {
-	guint32 data[8];
-} FuCapeHidFwCmdUpdateWritePar;
+#include "fu-synaptics-cape-struct.h"
 
 struct _FuSynapticsCapeFirmware {
 	FuFirmware parent_instance;
 	guint16 vid;
 	guint16 pid;
 };
-
-/* firmware update command structure, little endian */
-typedef struct __attribute__((packed)) {
-	guint32 vid;		/* USB vendor id */
-	guint32 pid;		/* USB product id */
-	guint32 fw_update_type; /* firmware update type */
-	guint32 fw_signature;	/* firmware identifier */
-	guint32 crc_value;	/* used to detect accidental changes to fw data */
-} FuCapeHidFwCmdUpdateStartPar;
-
-typedef struct __attribute__((packed)) {
-	FuCapeHidFwCmdUpdateStartPar par;
-	guint16 version_w; /* firmware version is four parts number "z.y.x.w", this is last part */
-	guint16 version_x; /* firmware version, third part */
-	guint16 version_y; /* firmware version, second part */
-	guint16 version_z; /* firmware version, first part */
-	guint32 reserved3;
-} FuCapeHidFileHeader;
 
 G_DEFINE_TYPE(FuSynapticsCapeFirmware, fu_synaptics_cape_firmware, FU_TYPE_FIRMWARE)
 
@@ -67,94 +46,6 @@ fu_synaptics_cape_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_synaptics_cape_firmware_parse_header(FuSynapticsCapeFirmware *self,
-					FuFirmware *firmware,
-					GBytes *fw,
-					GError **error)
-{
-	gsize bufsz = 0x0;
-	guint16 version_w = 0;
-	guint16 version_x = 0;
-	guint16 version_y = 0;
-	guint16 version_z = 0;
-	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
-	g_autofree gchar *version_str = NULL;
-	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
-	g_autoptr(GBytes) fw_hdr = NULL;
-
-	g_return_val_if_fail(FU_IS_SYNAPTICS_CAPE_FIRMWARE(self), FALSE);
-	g_return_val_if_fail(fw != NULL, FALSE);
-	g_return_val_if_fail(firmware != NULL, FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	/* the input fw image size should be the same as header size */
-	if (bufsz < sizeof(FuCapeHidFileHeader)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "not enough data to parse header");
-		return FALSE;
-	}
-
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_VID,
-				    &self->vid,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_PID,
-				    &self->pid,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_VER_W,
-				    &version_w,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_VER_X,
-				    &version_x,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_VER_Y,
-				    &version_y,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    FW_CAPE_HID_HEADER_OFFSET_VER_Z,
-				    &version_z,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-
-	version_str = g_strdup_printf("%u.%u.%u.%u", version_z, version_y, version_x, version_w);
-	fu_firmware_set_version(FU_FIRMWARE(self), version_str);
-
-	fw_hdr = fu_bytes_new_offset(fw, 0, sizeof(FuCapeHidFwCmdUpdateStartPar), error);
-	if (fw_hdr == NULL)
-		return FALSE;
-
-	fu_firmware_set_id(img_hdr, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_set_bytes(img_hdr, fw_hdr);
-	fu_firmware_add_image(firmware, img_hdr);
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
 fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 				 GBytes *fw,
 				 gsize offset,
@@ -162,20 +53,15 @@ fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 				 GError **error)
 {
 	FuSynapticsCapeFirmware *self = FU_SYNAPTICS_CAPE_FIRMWARE(firmware);
-	const gsize bufsz = g_bytes_get_size(fw);
-	const gsize headsz = sizeof(FuCapeHidFileHeader);
-	g_autoptr(GBytes) fw_header = NULL;
+	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autofree gchar *version_str = NULL;
+	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
+	g_autoptr(GByteArray) st = NULL;
 	g_autoptr(GBytes) fw_body = NULL;
+	g_autoptr(GBytes) fw_hdr = NULL;
 
-	/* check minimum size */
-	if (bufsz < sizeof(FuCapeHidFileHeader)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "not enough data to parse header, size ");
-		return FALSE;
-	}
-
+	/* sanity check */
 	if ((guint32)bufsz % 4 != 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -184,13 +70,29 @@ fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 
-	fw_header = fu_bytes_new_offset(fw, 0x0, headsz, error);
-	if (fw_header == NULL)
+	/* unpack */
+	st = fu_struct_synaptics_cape_file_hdr_parse(buf, bufsz, offset, error);
+	if (st == NULL)
 		return FALSE;
-	if (!fu_synaptics_cape_firmware_parse_header(self, firmware, fw_header, error))
-		return FALSE;
+	self->vid = fu_struct_synaptics_cape_file_hdr_get_vid(st);
+	self->pid = fu_struct_synaptics_cape_file_hdr_get_pid(st);
+	version_str = g_strdup_printf("%u.%u.%u.%u",
+				      fu_struct_synaptics_cape_file_hdr_get_ver_z(st),
+				      fu_struct_synaptics_cape_file_hdr_get_ver_y(st),
+				      fu_struct_synaptics_cape_file_hdr_get_ver_x(st),
+				      fu_struct_synaptics_cape_file_hdr_get_ver_w(st));
+	fu_firmware_set_version(FU_FIRMWARE(self), version_str);
 
-	fw_body = fu_bytes_new_offset(fw, headsz, bufsz - headsz, error);
+	/* top-most part of header */
+	fw_hdr = fu_bytes_new_offset(fw, 0, FU_STRUCT_SYNAPTICS_CAPE_FILE_HDR_OFFSET_VER_W, error);
+	if (fw_hdr == NULL)
+		return FALSE;
+	fu_firmware_set_id(img_hdr, FU_FIRMWARE_ID_HEADER);
+	fu_firmware_set_bytes(img_hdr, fw_hdr);
+	fu_firmware_add_image(firmware, img_hdr);
+
+	/* body */
+	fw_body = fu_bytes_new_offset(fw, st->len, bufsz - st->len, error);
 	if (fw_body == NULL)
 		return FALSE;
 	fu_firmware_set_id(firmware, FU_FIRMWARE_ID_PAYLOAD);
@@ -203,20 +105,17 @@ fu_synaptics_cape_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsCapeFirmware *self = FU_SYNAPTICS_CAPE_FIRMWARE(firmware);
 	guint64 ver = fu_firmware_get_version_raw(firmware);
-	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) buf = fu_struct_synaptics_cape_file_hdr_new();
 	g_autoptr(GBytes) payload = NULL;
 
-	/* header */
-	fu_byte_array_append_uint32(buf, self->vid, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, self->pid, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);	      /* update type */
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);	      /* identifier */
-	fu_byte_array_append_uint32(buf, 0xffff, G_LITTLE_ENDIAN);    /* crc_value */
-	fu_byte_array_append_uint16(buf, ver >> 0, G_LITTLE_ENDIAN);  /* version w */
-	fu_byte_array_append_uint16(buf, ver >> 16, G_LITTLE_ENDIAN); /* version x */
-	fu_byte_array_append_uint16(buf, ver >> 32, G_LITTLE_ENDIAN); /* version y */
-	fu_byte_array_append_uint16(buf, ver >> 48, G_LITTLE_ENDIAN); /* version z */
-	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);	      /* reserved */
+	/* pack */
+	fu_struct_synaptics_cape_file_hdr_set_vid(buf, self->vid);
+	fu_struct_synaptics_cape_file_hdr_set_pid(buf, self->pid);
+	fu_struct_synaptics_cape_file_hdr_set_crc(buf, 0xFFFF);
+	fu_struct_synaptics_cape_file_hdr_set_ver_w(buf, ver >> 0);
+	fu_struct_synaptics_cape_file_hdr_set_ver_x(buf, ver >> 16);
+	fu_struct_synaptics_cape_file_hdr_set_ver_y(buf, ver >> 32);
+	fu_struct_synaptics_cape_file_hdr_set_ver_z(buf, ver >> 48);
 
 	/* payload */
 	payload = fu_firmware_get_bytes_with_patches(firmware, error);

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.h
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.h
@@ -18,21 +18,7 @@ G_DECLARE_FINAL_TYPE(FuSynapticsCapeFirmware,
 
 FuFirmware *
 fu_synaptics_cape_firmware_new(void);
-
 guint16
 fu_synaptics_cape_firmware_get_vid(FuSynapticsCapeFirmware *self);
-
 guint16
 fu_synaptics_cape_firmware_get_pid(FuSynapticsCapeFirmware *self);
-
-#define FW_CAPE_HID_HEADER_OFFSET_VID	      0x0
-#define FW_CAPE_HID_HEADER_OFFSET_PID	      0x4
-#define FW_CAPE_HID_HEADER_OFFSET_UPDATE_TYPE 0x8
-#define FW_CAPE_HID_HEADER_OFFSET_SIGNATURE   0xc
-#define FW_CAPE_HID_HEADER_OFFSET_CRC	      0x10
-#define FW_CAPE_HID_HEADER_OFFSET_VER_W	      0x14
-#define FW_CAPE_HID_HEADER_OFFSET_VER_X	      0x16
-#define FW_CAPE_HID_HEADER_OFFSET_VER_Y	      0x18
-#define FW_CAPE_HID_HEADER_OFFSET_VER_Z	      0x1A
-
-#define FW_CAPE_HID_HEADER_SIZE 32 /* =sizeof(FuCapeHidFileHeader) */

--- a/plugins/synaptics-cape/fu-synaptics-cape.struct
+++ b/plugins/synaptics-cape/fu-synaptics-cape.struct
@@ -1,0 +1,13 @@
+struct SynapticsCapeFileHdr {
+    vid: u32le
+    pid: u32le
+    update_type: u32le
+    signature: u32le
+    crc: u32le
+    ver_w: u16le
+    ver_x: u16le
+    ver_y: u16le
+    ver_z: u16le
+    reserved: u32le
+}
+

--- a/plugins/synaptics-cape/meson.build
+++ b/plugins/synaptics-cape/meson.build
@@ -3,6 +3,9 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsCape"']
 
 plugin_quirks += files('synaptics-cape.quirk')
 plugin_builtins += static_library('fu_plugin_synaptics_cape',
+  structgen.process(
+    'fu-synaptics-cape.struct',     # fuzzing
+  ),
   sources: [
     'fu-synaptics-cape-plugin.c',
     'fu-synaptics-cape-device.c',

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "fu-synaprom-firmware.h"
+#include "fu-synaprom-struct.h"
 
 struct _FuSynapromFirmware {
 	FuFirmware parent_instance;
@@ -24,11 +25,6 @@ G_DEFINE_TYPE(FuSynapromFirmware, fu_synaprom_firmware, FU_TYPE_FIRMWARE)
 #define FU_SYNAPROM_FIRMWARE_TAG_MFW_PAYLOAD 0x0002
 #define FU_SYNAPROM_FIRMWARE_TAG_CFG_HEADER  0x0003
 #define FU_SYNAPROM_FIRMWARE_TAG_CFG_PAYLOAD 0x0004
-
-typedef struct __attribute__((packed)) {
-	guint16 tag;
-	guint32 bufsz;
-} FuSynapromFirmwareHdr;
 
 /* use only first 12 bit of 16 bits as tag value */
 #define FU_SYNAPROM_FIRMWARE_TAG_MAX 0xfff0
@@ -50,6 +46,13 @@ fu_synaprom_firmware_tag_to_string(guint16 tag)
 	return NULL;
 }
 
+guint32
+fu_synaprom_firmware_get_product_id(FuSynapromFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_SYNAPROM_FIRMWARE(self), 0x0);
+	return self->product_id;
+}
+
 static void
 fu_synaprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
 {
@@ -64,16 +67,13 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
-	const guint8 *buf;
+	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);
 	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	guint img_cnt = 0;
 
-	g_return_val_if_fail(fw != NULL, FALSE);
-
-	buf = g_bytes_get_data(fw, &bufsz);
-
 	/* 256 byte signature as footer */
-	if (bufsz < FU_SYNAPROM_FIRMWARE_SIGSIZE + sizeof(FuSynapromFirmwareHdr)) {
+	if (bufsz < FU_SYNAPROM_FIRMWARE_SIGSIZE + FU_STRUCT_SYNAPROM_HDR_SIZE) {
 		g_set_error_literal(error,
 				    G_IO_ERROR,
 				    G_IO_ERROR_INVALID_DATA,
@@ -83,16 +83,18 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 	bufsz -= FU_SYNAPROM_FIRMWARE_SIGSIZE;
 
 	/* parse each chunk */
-	while (offset != bufsz) {
-		FuSynapromFirmwareHdr header;
+	while (offset < bufsz) {
 		guint32 hdrsz;
 		guint32 tag;
-		g_autoptr(GBytes) bytes = NULL;
 		g_autoptr(FuFirmware) img = NULL;
+		g_autoptr(GByteArray) st_hdr = NULL;
+		g_autoptr(GBytes) bytes = NULL;
 
 		/* verify item header */
-		memcpy(&header, buf, sizeof(header));
-		tag = GUINT16_FROM_LE(header.tag);
+		st_hdr = fu_struct_synaprom_hdr_parse(buf, bufsz, offset, error);
+		if (st_hdr == NULL)
+			return FALSE;
+		tag = fu_struct_synaprom_hdr_get_tag(st_hdr);
 		if (tag >= FU_SYNAPROM_FIRMWARE_TAG_MAX) {
 			g_set_error(error,
 				    G_IO_ERROR,
@@ -112,7 +114,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 				    tag);
 			return FALSE;
 		}
-		hdrsz = GUINT32_FROM_LE(header.bufsz);
+		hdrsz = fu_struct_synaprom_hdr_get_bufsz(st_hdr);
 		if (hdrsz == 0) {
 			g_set_error(error,
 				    G_IO_ERROR,
@@ -121,20 +123,10 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 				    tag);
 			return FALSE;
 		}
-		offset += sizeof(header) + hdrsz;
-		if (offset > bufsz) {
-			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
-				    "data is corrupted 0x%04x > 0x%04x",
-				    (guint)offset,
-				    (guint)bufsz);
+		offset += st_hdr->len;
+		bytes = fu_bytes_new_offset(fw, offset, hdrsz, error);
+		if (bytes == NULL)
 			return FALSE;
-		}
-
-		/* move pointer to data */
-		buf += sizeof(header);
-		bytes = g_bytes_new(buf, hdrsz);
 		g_debug("adding 0x%04x (%s) with size 0x%04x",
 			tag,
 			fu_synaprom_firmware_tag_to_string(tag),
@@ -143,6 +135,20 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		fu_firmware_set_idx(img, tag);
 		fu_firmware_set_id(img, fu_synaprom_firmware_tag_to_string(tag));
 		fu_firmware_add_image(firmware, img);
+
+		/* metadata */
+		if (tag == FU_SYNAPROM_FIRMWARE_TAG_MFW_HEADER) {
+			g_autofree gchar *version = NULL;
+			g_autoptr(GByteArray) st_mfw = NULL;
+			st_mfw = fu_struct_synaprom_mfw_hdr_parse(buf, bufsz, offset, error);
+			if (st_mfw == NULL)
+				return FALSE;
+			self->product_id = fu_struct_synaprom_mfw_hdr_get_product(st_mfw);
+			version = g_strdup_printf("%u.%u",
+						  fu_struct_synaprom_mfw_hdr_get_vmajor(st_mfw),
+						  fu_struct_synaprom_mfw_hdr_get_vminor(st_mfw));
+			fu_firmware_set_version(firmware, version);
+		}
 
 		/* sanity check */
 		if (img_cnt++ > FU_SYNAPROM_FIRMWARE_COUNT_MAX) {
@@ -156,7 +162,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		}
 
 		/* next item */
-		buf += hdrsz;
+		offset += hdrsz;
 	}
 	return TRUE;
 }
@@ -165,34 +171,31 @@ static GBytes *
 fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);
-	GByteArray *blob = g_byte_array_new();
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GByteArray) st_hdr = fu_struct_synaprom_hdr_new();
+	g_autoptr(GByteArray) st_mfw = fu_struct_synaprom_mfw_hdr_new();
 	g_autoptr(GBytes) payload = NULL;
-	FuSynapromFirmwareMfwHeader hdr = {
-	    .product = GUINT32_TO_LE(self->product_id),
-	    .id = GUINT32_TO_LE(0xff),
-	    .buildtime = GUINT32_TO_LE(0xff),
-	    .buildnum = GUINT32_TO_LE(0xff),
-	    .vmajor = 10,
-	    .vminor = 1,
-	};
 
 	/* add header */
-	fu_byte_array_append_uint16(blob, FU_SYNAPROM_FIRMWARE_TAG_MFW_HEADER, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(blob, sizeof(hdr), G_LITTLE_ENDIAN);
-	g_byte_array_append(blob, (const guint8 *)&hdr, sizeof(hdr));
+	fu_struct_synaprom_hdr_set_tag(st_hdr, FU_SYNAPROM_FIRMWARE_TAG_MFW_HEADER);
+	fu_struct_synaprom_hdr_set_bufsz(st_hdr, st_mfw->len);
+	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
+	fu_struct_synaprom_mfw_hdr_set_product(st_mfw, self->product_id);
+	g_byte_array_append(buf, st_mfw->data, st_mfw->len);
 
 	/* add payload */
 	payload = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (payload == NULL)
 		return NULL;
-	fu_byte_array_append_uint16(blob, FU_SYNAPROM_FIRMWARE_TAG_MFW_PAYLOAD, G_LITTLE_ENDIAN);
-	fu_byte_array_append_uint32(blob, g_bytes_get_size(payload), G_LITTLE_ENDIAN);
-	fu_byte_array_append_bytes(blob, payload);
+	fu_struct_synaprom_hdr_set_tag(st_hdr, FU_SYNAPROM_FIRMWARE_TAG_MFW_PAYLOAD);
+	fu_struct_synaprom_hdr_set_bufsz(st_hdr, g_bytes_get_size(payload));
+	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
+	fu_byte_array_append_bytes(buf, payload);
 
 	/* add signature */
 	for (guint i = 0; i < FU_SYNAPROM_FIRMWARE_SIGSIZE; i++)
-		fu_byte_array_append_uint8(blob, 0xff);
-	return g_byte_array_free_to_bytes(blob);
+		fu_byte_array_append_uint8(buf, 0xff);
+	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
 }
 
 static gboolean

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.h
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.h
@@ -12,16 +12,7 @@
 #define FU_TYPE_SYNAPROM_FIRMWARE (fu_synaprom_firmware_get_type())
 G_DECLARE_FINAL_TYPE(FuSynapromFirmware, fu_synaprom_firmware, FU, SYNAPROM_FIRMWARE, FuFirmware)
 
-/* le */
-typedef struct __attribute__((packed)) {
-	guint32 product;
-	guint32 id;	   /* MFW unique id used for compat verification */
-	guint32 buildtime; /* unix-style build time */
-	guint32 buildnum;  /* build number */
-	guint8 vmajor;	   /* major version */
-	guint8 vminor;	   /* minor version */
-	guint8 unused[6];
-} FuSynapromFirmwareMfwHeader;
-
 FuFirmware *
 fu_synaprom_firmware_new(void);
+guint32
+fu_synaprom_firmware_get_product_id(FuSynapromFirmware *self);

--- a/plugins/synaptics-prometheus/fu-synaprom.struct
+++ b/plugins/synaptics-prometheus/fu-synaprom.struct
@@ -1,0 +1,13 @@
+struct SynapromMfwHdr {
+    product: u32le
+    id: u32le: 0xFF		// MFW unique id used for compat verification
+    buildtime: u32le: 0xFF	// unix-style
+    buildnum: u32le: 0xFF
+    vmajor: u8: 10		// major version
+    vminor: u8: 1		// minor version
+    unused: 6u8
+}
+struct SynapromHdr {
+    tag: u16le
+    bufsz: u32le
+}

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -3,6 +3,9 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsPrometheus"']
 
 plugin_quirks += files('synaptics-prometheus.quirk')
 plugin_builtin_synaprom = static_library('fu_plugin_synaprom',
+  structgen.process(
+    'fu-synaprom.struct',           # fuzzing
+  ),
   sources: [
     'fu-synaprom-plugin.c',
     'fu-synaprom-common.c',

--- a/plugins/tpm/fu-tpm.struct
+++ b/plugins/tpm/fu-tpm.struct
@@ -1,0 +1,5 @@
+struct TpmEventLog2 {
+    pcr: u32le
+    type: u32le
+    digest_count: u32le
+}

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -9,6 +9,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginTpm"']
 plugin_quirks += files('tpm.quirk')
 
 plugin_builtin_tpm = static_library('fu_plugin_tpm',
+  structgen.process('fu-tpm.struct'),
   sources: [
     'fu-tpm-plugin.c',
     'fu-tpm-device.c',

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include "fu-acpi-uefi-struct.h"
 #include "fu-acpi-uefi.h"
 
 #define FU_EFI_INSYDE_GUID	 "9d4bf935-a674-4710-ba02-bf0aa1758c7b"
@@ -17,12 +18,6 @@ struct _FuAcpiUefi {
 	gboolean is_insyde;
 	gchar *guid;
 };
-
-typedef struct __attribute__((packed)) {
-	gchar signature[6];
-	guint32 size;  /* le */
-	guint32 flags; /* le */
-} FuAcpiInsydeQuirkSection;
 
 G_DEFINE_TYPE(FuAcpiUefi, fu_acpi_uefi, FU_TYPE_ACPI_TABLE)
 
@@ -48,8 +43,7 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self,
 {
 	const gchar *needle = "$QUIRK";
 	gsize data_offset = 0;
-	guint32 flags = 0;
-	guint32 size = 0;
+	g_autoptr(GByteArray) st_qrk = NULL;
 
 	if (!fu_memmem_safe(buf,
 			    bufsz,
@@ -61,28 +55,20 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self,
 		return FALSE;
 	}
 	offset += data_offset;
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuAcpiInsydeQuirkSection, size),
-				    &size,
-				    G_LITTLE_ENDIAN,
-				    error))
+
+	/* parse */
+	st_qrk = fu_struct_acpi_insyde_quirk_parse(buf, bufsz, offset, error);
+	if (st_qrk == NULL)
 		return FALSE;
-	if (size < sizeof(FuAcpiInsydeQuirkSection)) {
+	if (fu_struct_acpi_insyde_quirk_get_size(st_qrk) < st_qrk->len) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_READ,
 				    "$QUIRK structure is too small");
 		return FALSE;
 	}
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    offset + G_STRUCT_OFFSET(FuAcpiInsydeQuirkSection, flags),
-				    &flags,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	self->insyde_cod_status = flags & INSYDE_QUIRK_COD_WORKING;
+	self->insyde_cod_status =
+	    fu_struct_acpi_insyde_quirk_get_flags(st_qrk) & INSYDE_QUIRK_COD_WORKING;
 	return TRUE;
 }
 

--- a/plugins/uefi-capsule/fu-acpi-uefi.struct
+++ b/plugins/uefi-capsule/fu-acpi-uefi.struct
@@ -1,0 +1,5 @@
+struct AcpiInsydeQuirk {
+    signature: 6s
+    size: u32le
+    flags: u32le
+}

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -29,6 +29,7 @@ else
 endif
 
 plugin_builtin_uefi_capsule = static_library('fu_plugin_uefi_capsule',
+  structgen.process('fu-acpi-uefi.struct'),
   sources: [
     'fu-uefi-capsule-plugin.c',
     'fu-uefi-bgrt.c',
@@ -57,6 +58,7 @@ plugin_builtins += plugin_builtin_uefi_capsule
 if get_option('compat_cli')
 fwupdate = executable(
   'fwupdate',
+  structgen.process('fu-acpi-uefi.struct'),
   sources: [
     'fu-uefi-tool.c',
   ],

--- a/plugins/uefi-dbx/fu-efi-image.c
+++ b/plugins/uefi-dbx/fu-efi-image.c
@@ -8,6 +8,7 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-efi-image-struct.h"
 #include "fu-efi-image.h"
 
 struct _FuEfiImage {
@@ -20,11 +21,6 @@ typedef struct {
 	gsize size;
 	gchar *name;
 } FuEfiImageRegion;
-
-typedef struct __attribute__((packed)) {
-	guint32 addr;
-	guint32 size;
-} FuEfiImageDataDirEntry;
 
 G_DEFINE_TYPE(FuEfiImage, fu_efi_image, G_TYPE_OBJECT)
 
@@ -268,12 +264,12 @@ fu_efi_image_new(GBytes *data, GError **error)
 				    "cksum->datadir[DEBUG]",
 				    checksum_offset + sizeof(guint32),
 				    data_dir_debug_offset);
-	image_bytes += r->size + sizeof(FuEfiImageDataDirEntry);
+	image_bytes += r->size + FU_STRUCT_EFI_IMAGE_DATA_DIR_ENTRY_SIZE;
 
 	/* third region: end of checksum_offset to end of headers */
 	r = fu_efi_image_add_region(checksum_regions,
 				    "datadir[DEBUG]->headers",
-				    data_dir_debug_offset + sizeof(FuEfiImageDataDirEntry),
+				    data_dir_debug_offset + FU_STRUCT_EFI_IMAGE_DATA_DIR_ENTRY_SIZE,
 				    header_size);
 	image_bytes += r->size;
 

--- a/plugins/uefi-dbx/fu-efi-image.struct
+++ b/plugins/uefi-dbx/fu-efi-image.struct
@@ -1,0 +1,4 @@
+struct EfiImageDataDirEntry {
+    addr: u32le
+    size: u32le
+}

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -3,6 +3,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginUefiDbx"']
 
 plugin_quirks += files('uefi-dbx.quirk')
 plugin_builtin_uefi_dbx = static_library('fu_plugin_uefi_dbx',
+  structgen.process('fu-efi-image.struct'),
   sources: [
     'fu-uefi-dbx-plugin.c',
     'fu-uefi-dbx-common.c',

--- a/plugins/uf2/fu-uf2.struct
+++ b/plugins/uf2/fu-uf2.struct
@@ -1,0 +1,12 @@
+struct Uf2 {
+    magic0: u32le:: 0x0A324655
+    magic1: u32le:: 0x9E5D5157
+    flags: u32le
+    target_addr: u32le
+    payload_size: u32le
+    block_no: u32le
+    num_blocks: u32le
+    family_id: u32le
+    data: 476u8
+    magic_end: u32le:: 0x0AB16F30
+}

--- a/plugins/uf2/meson.build
+++ b/plugins/uf2/meson.build
@@ -5,6 +5,9 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginUf2"']
 
 plugin_quirks += files('uf2.quirk')
 plugin_builtin_uf2 = static_library('fu_plugin_uf2',
+  structgen.process(
+    'fu-uf2.struct',          # fuzzing
+  ),
   sources: [
     'fu-uf2-plugin.c',
     'fu-uf2-device.c',

--- a/plugins/vli/fu-vli-pd-common.h
+++ b/plugins/vli/fu-vli-pd-common.h
@@ -11,12 +11,6 @@
 
 #include "fu-vli-common.h"
 
-typedef struct __attribute__((packed)) {
-	guint32 fwver; /* BE */
-	guint16 vid;   /* LE */
-	guint16 pid;   /* LE */
-} FuVliPdHdr;
-
 #define VLI_USBHUB_PD_FLASHMAP_ADDR_LEGACY 0x4000
 #define VLI_USBHUB_PD_FLASHMAP_ADDR	   0x1003
 

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -517,7 +517,7 @@ fu_vli_pd_parade_device_write_firmware(FuDevice *device,
 	if (!fu_vli_pd_parade_device_enable_mapping(self, error))
 		return FALSE;
 	if (!fu_vli_pd_parade_device_i2c_write(self, self->page2, 0x82, 0x20, error))
-		return FALSE; /* Reset_CLT2SPI_Interface */
+		return FALSE;	      /* Reset_CLT2SPI_Interface */
 	fu_device_sleep(device, 100); /* ms */
 	if (!fu_vli_pd_parade_device_i2c_write(self, self->page2, 0x82, 0x00, error))
 		return FALSE;

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -11,6 +11,7 @@
 
 #include "fu-vli-pd-common.h"
 #include "fu-vli-pd-firmware.h"
+#include "fu-vli-struct.h"
 #include "fu-vli-usbhub-common.h"
 #include "fu-vli-usbhub-pd-device.h"
 
@@ -42,45 +43,54 @@ fu_vli_usbhub_pd_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_vli_usbhub_pd_device_setup(FuDevice *device, GError **error)
 {
-	FuVliPdHdr hdr = {0x0};
 	FuVliUsbhubPdDevice *self = FU_VLI_USBHUB_PD_DEVICE(device);
 	FuVliUsbhubDevice *parent = FU_VLI_USBHUB_DEVICE(fu_device_get_parent(device));
 	const gchar *name;
 	guint32 fwver;
+	gsize bufsz = FU_STRUCT_VLI_PD_HDR_SIZE;
+	g_autofree guint8 *buf = g_malloc0(bufsz);
+	g_autoptr(GByteArray) st = NULL;
 
 	/* legacy location */
 	if (!fu_vli_device_spi_read_block(FU_VLI_DEVICE(parent),
 					  VLI_USBHUB_FLASHMAP_ADDR_PD_LEGACY +
 					      VLI_USBHUB_PD_FLASHMAP_ADDR_LEGACY,
-					  (guint8 *)&hdr,
-					  sizeof(hdr),
+					  buf,
+					  bufsz,
 					  error)) {
 		g_prefix_error(error, "failed to read legacy PD header: ");
 		return FALSE;
 	}
+	st = fu_struct_vli_pd_hdr_parse(buf, bufsz, 0x0, error);
+	if (st == NULL)
+		return FALSE;
 
 	/* new location */
-	if (GUINT16_FROM_LE(hdr.vid) != 0x2109) {
-		g_debug("PD VID was 0x%04x trying new location", GUINT16_FROM_LE(hdr.vid));
+	if (fu_struct_vli_pd_hdr_get_vid(st) != 0x2109) {
+		g_debug("PD VID was 0x%04x trying new location", fu_struct_vli_pd_hdr_get_vid(st));
 		if (!fu_vli_device_spi_read_block(FU_VLI_DEVICE(parent),
 						  VLI_USBHUB_FLASHMAP_ADDR_PD +
 						      VLI_USBHUB_PD_FLASHMAP_ADDR,
-						  (guint8 *)&hdr,
-						  sizeof(hdr),
+						  buf,
+						  bufsz,
 						  error)) {
 			g_prefix_error(error, "failed to read PD header: ");
 			return FALSE;
 		}
+		g_byte_array_unref(st);
+		st = fu_struct_vli_pd_hdr_parse(buf, bufsz, 0x0, error);
+		if (st == NULL)
+			return FALSE;
 	}
 
 	/* just empty space */
-	if (hdr.fwver == G_MAXUINT32) {
+	fwver = fu_struct_vli_pd_hdr_get_fwver(st);
+	if (fwver == G_MAXUINT32) {
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no PD device header found");
 		return FALSE;
 	}
 
 	/* get version */
-	fwver = GUINT32_FROM_BE(hdr.fwver);
 	self->device_kind = fu_vli_pd_common_guess_device_kind(fwver);
 	if (self->device_kind == FU_VLI_DEVICE_KIND_UNKNOWN) {
 		g_set_error(error,
@@ -97,8 +107,8 @@ fu_vli_usbhub_pd_device_setup(FuDevice *device, GError **error)
 	fu_device_set_version_from_uint32(device, fwver);
 
 	/* add standard GUIDs in order of priority */
-	fu_device_add_instance_u16(device, "VID", GUINT16_FROM_LE(hdr.vid));
-	fu_device_add_instance_u16(device, "PID", GUINT16_FROM_LE(hdr.pid));
+	fu_device_add_instance_u16(device, "VID", fu_struct_vli_pd_hdr_get_vid(st));
+	fu_device_add_instance_u16(device, "PID", fu_struct_vli_pd_hdr_get_pid(st));
 	fu_device_add_instance_u8(device, "APP", fwver & 0xff);
 	fu_device_add_instance_str(device, "DEV", name);
 	if (!fu_device_build_instance_id_quirk(device, error, "USB", "VID", NULL))

--- a/plugins/vli/fu-vli.struct
+++ b/plugins/vli/fu-vli.struct
@@ -1,0 +1,5 @@
+struct VliPdHdr {
+    fwver: u32be
+    vid: u16le
+    pid: u16le
+}

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -10,6 +10,7 @@ plugin_quirks += files([
   'vli-samsung.quirk',
   ])
 plugin_builtin_vli = static_library('fu_plugin_vli',
+  structgen.process('fu-vli.struct'),
   sources: [
     'fu-vli-plugin.c',
     'fu-vli-common.c',

--- a/plugins/wistron-dock/fu-wistron-dock.struct
+++ b/plugins/wistron-dock/fu-wistron-dock.struct
@@ -1,0 +1,22 @@
+struct WistronDockWdit {
+    hid_id: u8
+    tag_id: u16be
+    vid: u16le
+    pid: u16le
+    imgmode: u8
+    update_state: u8
+    status_code: u8
+    composite_version: u32be
+    device_cnt: u8
+    reserved: u8
+}
+struct WistronDockWditImg {
+    comp_id: u8
+    mode: u8   // 0=single, 1=dual-s, 2=dual-a
+    status: u8 // 0=unknown, 1=valid, 2=invalid
+    reserved: u8
+    version_build: u32be
+    version1: u32be
+    version2: u32be
+    name: 32s
+}

--- a/plugins/wistron-dock/meson.build
+++ b/plugins/wistron-dock/meson.build
@@ -3,6 +3,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginWistronDock"']
 
 plugin_quirks += files('wistron-dock.quirk')
 plugin_builtins += static_library('fu_plugin_wistron_dock',
+  structgen.process('fu-wistron-dock.struct'),
   sources: [
     'fu-wistron-dock-common.c',
     'fu-wistron-dock-device.c',


### PR DESCRIPTION
At the moment we use two styles, both broken in subtly ways:

 * `memcpy()` a packed struct, then `GUINTXX_TO_LE` and `GUINTXX_FROM_LE`
 * `fu_memread_uintXX` and `fu_memwrite_uintXX` from known buffer offsets

In some cases, both were being used in the same plugin. Using the same method to parse and write the structure makes it much easier to read and write plugins whilst still being memory safe.

The actual struct definition is taken from the source file itself, and the code generated with the correct types and checks.

We didn't use protobuf for this for a few reasons:

 * No support for default or constant values
 * Clucky to use from GLib-style parsers and writers
 * No support for uint24 or GUID types
 * Needing to wrap the protobuf_c generated class in a GByteArray wrapper
 * The protobuf_c library is not a hard dep and not available in RHEL

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
