### PR TITLE
trivial: Fallback to the current source directory in the self tests

### DIFF
--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -1637,6 +1637,7 @@ int
 main(int argc, char **argv)
 {
 	setlocale(LC_ALL, "");
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -206,6 +206,7 @@ if get_option('tests')
     link_with: fwupd,
     c_args: [
       '-DG_LOG_DOMAIN="Fwupd"',
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
       '-DLOCALSTATEDIR="' + localstatedir + '"',
     ],
   )

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3772,6 +3772,7 @@ main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_type_ensure(FU_TYPE_IFD_BIOS);
 

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -366,6 +366,7 @@ if get_option('tests')
       fwupdplugin
     ],
     c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
     ],
   )
   test('fwupdplugin-self-test', e, is_parallel: false, timeout: 180, env: env)

--- a/plugins/acpi-dmar/fu-self-test.c
+++ b/plugins/acpi-dmar/fu-self-test.c
@@ -59,6 +59,7 @@ fu_acpi_dmar_opt_out_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/acpi-dmar/meson.build
+++ b/plugins/acpi-dmar/meson.build
@@ -31,6 +31,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('acpi-dmar-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/acpi-facp/fu-self-test.c
+++ b/plugins/acpi-facp/fu-self-test.c
@@ -59,6 +59,7 @@ fu_acpi_facp_s2i_enabled_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/acpi-facp/meson.build
+++ b/plugins/acpi-facp/meson.build
@@ -31,6 +31,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('acpi-facp-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/acpi-ivrs/fu-self-test.c
+++ b/plugins/acpi-ivrs/fu-self-test.c
@@ -60,6 +60,7 @@ fu_acpi_ivrs_no_dma_remap_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/acpi-ivrs/meson.build
+++ b/plugins/acpi-ivrs/meson.build
@@ -31,6 +31,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('acpi-ivrs-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/acpi-phat/fu-self-test.c
+++ b/plugins/acpi-phat/fu-self-test.c
@@ -41,6 +41,7 @@ fu_acpi_phat_parse_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/acpi-phat/meson.build
+++ b/plugins/acpi-phat/meson.build
@@ -34,6 +34,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('acpi-phat-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -88,6 +88,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/ata/meson.build
+++ b/plugins/ata/meson.build
@@ -36,6 +36,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('ata-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/bcm57xx/fu-self-test.c
+++ b/plugins/bcm57xx/fu-self-test.c
@@ -129,6 +129,7 @@ fu_bcm57xx_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_type_ensure(FU_TYPE_BCM57XX_STAGE1_IMAGE);
 	g_type_ensure(FU_TYPE_BCM57XX_STAGE2_IMAGE);

--- a/plugins/bcm57xx/meson.build
+++ b/plugins/bcm57xx/meson.build
@@ -44,6 +44,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('bcm57xx-self-test', e, env: env)
 endif

--- a/plugins/ccgx/fu-self-test.c
+++ b/plugins/ccgx/fu-self-test.c
@@ -84,6 +84,7 @@ fu_ccgx_dmc_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/ccgx/meson.build
+++ b/plugins/ccgx/meson.build
@@ -48,6 +48,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('ccgx-self-test', e, env: env)
 endif

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -560,6 +560,7 @@ main(int argc, char **argv)
 	g_autofree gchar *testdatadir = NULL;
 	g_autoptr(FuTest) self = g_new0(FuTest, 1);
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* change path */

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -52,6 +52,9 @@ if get_option('tests')
     c_args: [
       cargs,
     ],
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('dell-self-test', e, env: env)
 endif

--- a/plugins/dfu/fu-dfu-self-test.c
+++ b/plugins/dfu/fu-dfu-self-test.c
@@ -154,6 +154,7 @@ main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -73,6 +73,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('fu-dfu-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/elantp/fu-self-test.c
+++ b/plugins/elantp/fu-self-test.c
@@ -48,6 +48,7 @@ fu_elantp_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/elantp/meson.build
+++ b/plugins/elantp/meson.build
@@ -41,6 +41,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('elantp-self-test', e, env: env)
 endif

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -193,6 +193,7 @@ main(int argc, char **argv)
 	g_autoptr(FuTest) self = g_new0(FuTest, 1);
 	g_autoptr(GError) error = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* starting thinklmi dir to make startup pass */

--- a/plugins/lenovo-thinklmi/meson.build
+++ b/plugins/lenovo-thinklmi/meson.build
@@ -35,6 +35,7 @@ if get_option('tests') and efiboot.found() and efivar.found()
     ],
     c_args: [
       cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
     ],
   )
   test('lenovo-thinklmi-self-test', e, env: env)

--- a/plugins/linux-swap/fu-self-test.c
+++ b/plugins/linux-swap/fu-self-test.c
@@ -78,6 +78,7 @@ fu_linux_swap_encrypted_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/linux-swap/meson.build
+++ b/plugins/linux-swap/meson.build
@@ -31,6 +31,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('linux-swap-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-self-test.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-self-test.c
@@ -29,6 +29,7 @@ fu_logitech_hidpp_common(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/logitech-hidpp/meson.build
+++ b/plugins/logitech-hidpp/meson.build
@@ -39,7 +39,10 @@ if get_option('tests')
       plugin_libs,
       plugin_builtin_logitech_hidpp,
     ],
-    c_args: cargs,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('logitech-hidpp-self-test', e, env: env)
 endif

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -100,6 +100,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	(void)g_setenv("FWUPD_MTD_VERBOSE", "1", TRUE);
 	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);

--- a/plugins/mtd/meson.build
+++ b/plugins/mtd/meson.build
@@ -33,6 +33,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('mtd-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/nitrokey/fu-self-test.c
+++ b/plugins/nitrokey/fu-self-test.c
@@ -91,6 +91,7 @@ fu_nitrokey_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -36,6 +36,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('nitrokey-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/nvme/fu-self-test.c
+++ b/plugins/nvme/fu-self-test.c
@@ -91,6 +91,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -41,6 +41,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('nvme-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -58,6 +58,7 @@ fu_pxi_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/pixart-rf/meson.build
+++ b/plugins/pixart-rf/meson.build
@@ -38,6 +38,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('pxi-self-test', e, env: env)
 endif

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -486,6 +486,7 @@ main(int argc, char **argv)
 	g_autofree gchar *smbios_data_fn = NULL;
 	g_autofree gchar *testdatadir = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	(void)g_setenv("FWUPD_REDFISH_VERBOSE", "1", TRUE);

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -73,6 +73,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('redfish-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -201,6 +201,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/synaptics-mst/meson.build
+++ b/plugins/synaptics-mst/meson.build
@@ -50,6 +50,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('synaptics-mst-self-test', e, env: env)
 endif

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -116,6 +116,7 @@ fu_synaprom_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 	g_test_add_func("/synaprom/firmware", fu_test_synaprom_firmware_func);

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -38,6 +38,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('synaptics-prometheus-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/synaptics-rmi/fu-self-test.c
+++ b/plugins/synaptics-rmi/fu-self-test.c
@@ -85,6 +85,7 @@ fu_synaptics_rmi_firmware_10_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -44,6 +44,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('synaptics-rmi-self-test', e, env: env)
 endif

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1329,6 +1329,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -44,7 +44,10 @@ if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gi
       fwupdplugin,
       plugin_builtin_thunderbolt,
     ],
-    c_args: cargs
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   if get_option('b_sanitize') == 'address'
     env.prepend('LD_PRELOAD', 'libasan.so.5', 'libumockdev-preload.so.0', separator: ' ')

--- a/plugins/tpm/fu-self-test.c
+++ b/plugins/tpm/fu-self-test.c
@@ -238,6 +238,7 @@ main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -50,7 +50,10 @@ if get_option('tests')
       fwupdplugin,
       plugin_builtin_tpm,
     ],
-    c_args: cargs
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('tpm-self-test', e, env: env)
 endif

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -286,6 +286,7 @@ main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -143,7 +143,10 @@ if get_option('tests')
       fwupdplugin,
       plugin_builtin_uefi_capsule,
     ],
-    c_args: cargs
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('uefi-self-test', e, env: env)
 

--- a/plugins/uefi-dbx/fu-self-test.c
+++ b/plugins/uefi-dbx/fu-self-test.c
@@ -43,6 +43,7 @@ fu_efi_image_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -31,10 +31,13 @@ if get_option('tests')
       plugin_libs,
       plugin_builtin_uefi_dbx,
     ],
-    c_args: cargs,
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('uefi-dbx-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/uf2/fu-self-test.c
+++ b/plugins/uf2/fu-self-test.c
@@ -48,6 +48,7 @@ fu_uf2_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/plugins/uf2/meson.build
+++ b/plugins/uf2/meson.build
@@ -37,6 +37,9 @@ if get_option('tests')
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('uf2-self-test', e, env: env)
 endif

--- a/plugins/vli/fu-self-test.c
+++ b/plugins/vli/fu-self-test.c
@@ -24,6 +24,7 @@ fu_test_common_device_kind_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 	g_test_add_func("/vli/common{device-kind}", fu_test_common_device_kind_func);

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -48,10 +48,13 @@ if get_option('tests')
       plugin_libs,
       plugin_builtin_vli,
     ],
-    c_args: cargs,
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('vli-self-test', e, env: env)  # added to installed-tests
 endif

--- a/plugins/wacom-usb/fu-self-test.c
+++ b/plugins/wacom-usb/fu-self-test.c
@@ -90,6 +90,7 @@ fu_wac_firmware_xml_func(void)
 int
 main(int argc, char **argv)
 {
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_type_ensure(FU_TYPE_SREC_FIRMWARE);
 

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -39,10 +39,13 @@ if get_option('tests')
       plugin_libs,
       plugin_builtin_wac,
     ],
-    c_args: cargs,
     install: true,
     install_rpath: libdir_pkg,
     install_dir: installed_test_bindir,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
   )
   test('wacom-usb-self-test', e, env: env)  # added to installed-tests
 endif

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4859,6 +4859,7 @@ main(int argc, char **argv)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(FuTest) self = g_new0(FuTest, 1);
 
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
 	/* only critical and error are fatal */

--- a/src/meson.build
+++ b/src/meson.build
@@ -346,6 +346,7 @@ if get_option('tests')
       plugin_libs,
     ],
     c_args: [
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
     ],
   )
   test('fu-self-test', e, is_parallel: false, timeout: 180, env: env)


### PR DESCRIPTION
This allows us to run fu-self-test in the common case of `checkoutdir/builddir` without always setting G_TEST_SRCDIR.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
