### PR TITLE
ch347: Add support for the CH347 SPI programmer

### DIFF
--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -8,7 +8,11 @@
 
 #include "config.h"
 
+#include "fu-byte-array.h"
+#include "fu-bytes.h"
 #include "fu-cfi-device.h"
+#include "fu-dump.h"
+#include "fu-mem.h"
 #include "fu-quirks.h"
 #include "fu-string.h"
 
@@ -181,12 +185,124 @@ fu_cfi_device_finalize(GObject *object)
 	G_OBJECT_CLASS(fu_cfi_device_parent_class)->finalize(object);
 }
 
+typedef struct {
+	guint8 mask;
+	guint8 value;
+} FuCfiDeviceHelper;
+
+static gboolean
+fu_cfi_device_wait_for_status_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuCfiDeviceHelper *helper = (FuCfiDeviceHelper *)user_data;
+	FuCfiDevice *self = FU_CFI_DEVICE(device);
+	guint8 buf[2] = {0x0};
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* enable chip */
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+	if (!fu_cfi_device_get_cmd(self, FU_CFI_DEVICE_CMD_READ_STATUS, &buf[0], error))
+		return FALSE;
+	if (!fu_cfi_device_send_command(self,
+					buf,
+					sizeof(buf),
+					buf,
+					sizeof(buf),
+					progress,
+					error)) {
+		g_prefix_error(error, "failed to want to status: ");
+		return FALSE;
+	}
+	if ((buf[0x1] & helper->mask) != helper->value) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "wanted 0x%x, got 0x%x",
+			    helper->value,
+			    buf[0x1] & helper->mask);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cfi_device_wait_for_status(FuCfiDevice *self,
+			      guint8 mask,
+			      guint8 value,
+			      guint count,
+			      guint delay,
+			      GError **error)
+{
+	FuCfiDeviceHelper helper = {.mask = mask, .value = value};
+	return fu_device_retry_full(FU_DEVICE(self),
+				    fu_cfi_device_wait_for_status_cb,
+				    count,
+				    delay,
+				    &helper,
+				    error);
+}
+
+static gboolean
+fu_cfi_device_read_jedec(FuCfiDevice *self, GError **error)
+{
+	guint8 buf_res[] = {0x9F};
+	guint8 buf_req[3] = {0x0};
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GString) flash_id = g_string_new(NULL);
+
+	/* enable chip */
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+
+	/* read JEDEC ID */
+	if (!fu_cfi_device_send_command(self,
+					buf_res,
+					sizeof(buf_res),
+					buf_req,
+					sizeof(buf_req),
+					progress,
+					error)) {
+		g_prefix_error(error, "failed to request JEDEC ID: ");
+		return FALSE;
+	}
+	if ((buf_req[0] == 0x0 && buf_req[1] == 0x0 && buf_req[2] == 0x0) ||
+	    (buf_req[0] == 0xFF && buf_req[1] == 0xFF && buf_req[2] == 0xFF)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "device not detected, flash ID 0x%02X%02X%02X",
+			    buf_req[0],
+			    buf_req[1],
+			    buf_req[2]);
+		return FALSE;
+	}
+	g_string_append_printf(flash_id, "%02X", buf_req[0]);
+	g_string_append_printf(flash_id, "%02X", buf_req[1]);
+	g_string_append_printf(flash_id, "%02X", buf_req[2]);
+	fu_cfi_device_set_flash_id(self, flash_id->str);
+
+	/* success */
+	return TRUE;
+}
+
 static gboolean
 fu_cfi_device_setup(FuDevice *device, GError **error)
 {
 	gsize flash_idsz = 0;
 	FuCfiDevice *self = FU_CFI_DEVICE(device);
 	FuCfiDevicePrivate *priv = GET_PRIVATE(self);
+
+	/* setup SPI chip */
+	if (priv->flash_id == NULL) {
+		if (!fu_cfi_device_read_jedec(self, error))
+			return FALSE;
+	}
 
 	/* sanity check */
 	if (priv->flash_id != NULL)
@@ -470,6 +586,51 @@ fu_cfi_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 /**
+ * fu_cfi_device_send_command:
+ * @self: a #FuCfiDevice
+ * @wbuf: buffer
+ * @wbufsz: size of @wbuf, possibly zero
+ * @rbuf: buffer
+ * @rbufsz: size of @rbuf, possibly zero
+ * @progress: a #FuProgress
+ * @error: (nullable): optional return location for an error
+ *
+ * Sends an unspecified command stream to the CFI device.
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 1.8.13
+ **/
+gboolean
+fu_cfi_device_send_command(FuCfiDevice *self,
+			   const guint8 *wbuf,
+			   gsize wbufsz,
+			   guint8 *rbuf,
+			   gsize rbufsz,
+			   FuProgress *progress,
+			   GError **error)
+{
+	FuCfiDeviceClass *klass = FU_CFI_DEVICE_GET_CLASS(self);
+	g_return_val_if_fail(FU_IS_CFI_DEVICE(self), FALSE);
+	g_return_val_if_fail(FU_IS_PROGRESS(progress), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	if (klass->send_command == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "send_command is not implemented on this device");
+		return FALSE;
+	}
+	if (wbufsz > 0)
+		fu_dump_raw(G_LOG_DOMAIN, "SPI write", wbuf, wbufsz);
+	if (!klass->send_command(self, wbuf, wbufsz, rbuf, rbufsz, progress, error))
+		return FALSE;
+	if (rbufsz > 0)
+		fu_dump_raw(G_LOG_DOMAIN, "SPI read", rbuf, rbufsz);
+	return TRUE;
+}
+
+/**
  * fu_cfi_device_chip_select:
  * @self: a #FuCfiDevice
  * @value: boolean
@@ -530,6 +691,247 @@ fu_cfi_device_chip_select_locker_new(FuCfiDevice *self, GError **error)
 					 error);
 }
 
+static gboolean
+fu_cfi_device_write_enable(FuCfiDevice *self, GError **error)
+{
+	guint8 buf[1] = {0x0};
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* write enable */
+	if (!fu_cfi_device_get_cmd(self, FU_CFI_DEVICE_CMD_WRITE_EN, &buf[0], error))
+		return FALSE;
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+	if (!fu_cfi_device_send_command(self, buf, sizeof(buf), NULL, 0, progress, error))
+		return FALSE;
+	if (!fu_device_locker_close(cslocker, error))
+		return FALSE;
+
+	/* check that WEL is now set */
+	return fu_cfi_device_wait_for_status(self, 0b10, 0b10, 10, 5, error);
+}
+
+static gboolean
+fu_cfi_device_chip_erase(FuCfiDevice *self, GError **error)
+{
+	guint8 buf[] = {0x0};
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* enable chip */
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+
+	/* erase */
+	if (!fu_cfi_device_get_cmd(self, FU_CFI_DEVICE_CMD_CHIP_ERASE, &buf[0], error))
+		return FALSE;
+	if (!fu_cfi_device_send_command(self, buf, sizeof(buf), NULL, 0, progress, error))
+		return FALSE;
+	if (!fu_device_locker_close(cslocker, error))
+		return FALSE;
+
+	/* poll Read Status register BUSY */
+	return fu_cfi_device_wait_for_status(self, 0b1, 0b0, 100, 500, error);
+}
+
+static gboolean
+fu_cfi_device_write_page(FuCfiDevice *self, FuChunk *page, FuProgress *progress, GError **error)
+{
+	guint8 cmd = 0x0;
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+
+	if (!fu_cfi_device_write_enable(self, error))
+		return FALSE;
+
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+
+	/* cmd, 24 bit starting address, then data */
+	if (!fu_cfi_device_get_cmd(self, FU_CFI_DEVICE_CMD_PAGE_PROG, &cmd, error))
+		return FALSE;
+	fu_byte_array_append_uint8(buf, cmd);
+	fu_byte_array_append_uint24(buf, fu_chunk_get_address(page), G_BIG_ENDIAN);
+	g_byte_array_append(buf, fu_chunk_get_data(page), fu_chunk_get_data_sz(page));
+	g_debug("writing page at 0x%x", (guint)fu_chunk_get_address(page));
+	if (!fu_cfi_device_send_command(self, buf->data, buf->len, NULL, 0, progress, error))
+		return FALSE;
+	if (!fu_device_locker_close(cslocker, error))
+		return FALSE;
+
+	/* poll Read Status register BUSY */
+	return fu_cfi_device_wait_for_status(self, 0b1, 0b0, 100, 50, error);
+}
+
+static gboolean
+fu_cfi_device_write_pages(FuCfiDevice *self, GPtrArray *pages, FuProgress *progress, GError **error)
+{
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, pages->len);
+	for (guint i = 0; i < pages->len; i++) {
+		FuChunk *page = g_ptr_array_index(pages, i);
+		if (!fu_cfi_device_write_page(self, page, fu_progress_get_child(progress), error))
+			return FALSE;
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_cfi_device_read_block(FuCfiDevice *self, FuChunk *block, FuProgress *progress, GError **error)
+{
+	guint8 buf_req[4] = {0x0}; /* cmd, then 24 bit starting address */
+	g_autoptr(FuDeviceLocker) cslocker = NULL;
+
+	/* enable chip */
+	cslocker = fu_cfi_device_chip_select_locker_new(self, error);
+	if (cslocker == NULL)
+		return FALSE;
+	if (!fu_cfi_device_get_cmd(self, FU_CFI_DEVICE_CMD_READ_DATA, &buf_req[0], error))
+		return FALSE;
+	fu_memwrite_uint24(buf_req + 0x1, fu_chunk_get_address(block), G_BIG_ENDIAN);
+	return fu_cfi_device_send_command(self,
+					  buf_req,
+					  sizeof(buf_req),
+					  fu_chunk_get_data_out(block),
+					  fu_chunk_get_data_sz(block),
+					  progress,
+					  error);
+}
+
+static GBytes *
+fu_cfi_device_read_firmware(FuCfiDevice *self, gsize bufsz, FuProgress *progress, GError **error)
+{
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GPtrArray) pages = NULL;
+
+	/* progress */
+	fu_byte_array_set_size(buf, bufsz, 0x0);
+	pages = fu_chunk_array_mutable_new(buf->data,
+					   buf->len,
+					   0x0,
+					   0x0,
+					   fu_cfi_device_get_block_size(self));
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, pages->len);
+	for (guint i = 0; i < pages->len; i++) {
+		FuChunk *block = g_ptr_array_index(pages, i);
+		if (!fu_cfi_device_read_block(self, block, fu_progress_get_child(progress), error))
+			return NULL;
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+}
+
+static GBytes *
+fu_cfi_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuCfiDevice *self = FU_CFI_DEVICE(device);
+	gsize bufsz = fu_device_get_firmware_size_max(device);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* open programmer */
+	locker = fu_device_locker_new(device, error);
+	if (locker == NULL)
+		return NULL;
+
+	/* sanity check */
+	if (bufsz == 0x0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
+				    "device firmware size not set");
+		return NULL;
+	}
+	return fu_cfi_device_read_firmware(self, bufsz, progress, error);
+}
+
+static gboolean
+fu_cfi_device_write_firmware(FuDevice *device,
+			     FuFirmware *firmware,
+			     FuProgress *progress,
+			     FwupdInstallFlags flags,
+			     GError **error)
+{
+	FuCfiDevice *self = FU_CFI_DEVICE(device);
+	g_autoptr(GBytes) fw = NULL;
+	g_autoptr(GBytes) fw_verify = NULL;
+	g_autoptr(GPtrArray) pages = NULL;
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* open programmer */
+	locker = fu_device_locker_new(device, error);
+	if (locker == NULL)
+		return FALSE;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 10, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 85, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 5, NULL);
+
+	/* get default image */
+	fw = fu_firmware_get_bytes(firmware, error);
+	if (fw == NULL)
+		return FALSE;
+
+	/* erase */
+	if (!fu_cfi_device_write_enable(self, error)) {
+		g_prefix_error(error, "failed to enable writes: ");
+		return FALSE;
+	}
+	if (!fu_cfi_device_chip_erase(self, error)) {
+		g_prefix_error(error, "failed to erase: ");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* write each block */
+	pages = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, fu_cfi_device_get_page_size(self));
+	if (!fu_cfi_device_write_pages(self, pages, fu_progress_get_child(progress), error)) {
+		g_prefix_error(error, "failed to write pages: ");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* verify each block */
+	fw_verify = fu_cfi_device_read_firmware(self,
+						g_bytes_get_size(fw),
+						fu_progress_get_child(progress),
+						error);
+	if (fw_verify == NULL) {
+		g_prefix_error(error, "failed to verify blocks: ");
+		return FALSE;
+	}
+	if (!fu_bytes_compare(fw_verify, fw, error)) {
+		g_prefix_error(error, "verify failed: ");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success! */
+	return TRUE;
+}
+
+static void
+fu_cfi_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 100, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "reload");
+}
+
 static void
 fu_cfi_device_init(FuCfiDevice *self)
 {
@@ -545,7 +947,20 @@ fu_cfi_device_init(FuCfiDevice *self)
 	priv->cmds[FU_CFI_DEVICE_CMD_SECTOR_ERASE] = 0x20;
 	priv->cmds[FU_CFI_DEVICE_CMD_CHIP_ERASE] = 0x60;
 	priv->cmds[FU_CFI_DEVICE_CMD_READ_ID] = 0x9f;
+	fu_device_add_protocol(FU_DEVICE(self), "org.jedec.cfi");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_OPEN);
+	fu_device_add_vendor_id(FU_DEVICE(self), "SPI:*");
 	fu_device_set_summary(FU_DEVICE(self), "CFI flash chip");
+}
+
+static void
+fu_cfi_device_constructed(GObject *obj)
+{
+	FuCfiDevice *self = FU_CFI_DEVICE(obj);
+	fu_device_add_instance_id(FU_DEVICE(self), "SPI");
 }
 
 static void
@@ -558,9 +973,13 @@ fu_cfi_device_class_init(FuCfiDeviceClass *klass)
 	object_class->finalize = fu_cfi_device_finalize;
 	object_class->get_property = fu_cfi_device_get_property;
 	object_class->set_property = fu_cfi_device_set_property;
+	object_class->constructed = fu_cfi_device_constructed;
 	klass_device->setup = fu_cfi_device_setup;
 	klass_device->to_string = fu_cfi_device_to_string;
 	klass_device->set_quirk_kv = fu_cfi_device_set_quirk_kv;
+	klass_device->write_firmware = fu_cfi_device_write_firmware;
+	klass_device->dump_firmware = fu_cfi_device_dump_firmware;
+	klass_device->set_progress = fu_cfi_device_set_progress;
 
 	/**
 	 * FuCfiDevice:flash-id:

--- a/libfwupdplugin/fu-cfi-device.h
+++ b/libfwupdplugin/fu-cfi-device.h
@@ -14,6 +14,13 @@ G_DECLARE_DERIVABLE_TYPE(FuCfiDevice, fu_cfi_device, FU, CFI_DEVICE, FuDevice)
 struct _FuCfiDeviceClass {
 	FuDeviceClass parent_class;
 	gboolean (*chip_select)(FuCfiDevice *self, gboolean value, GError **error);
+	gboolean (*send_command)(FuCfiDevice *self,
+				 const guint8 *wbuf,
+				 gsize wbufsz,
+				 guint8 *rbuf,
+				 gsize rbufsz,
+				 FuProgress *progress,
+				 GError **error);
 };
 
 /**
@@ -69,6 +76,14 @@ fu_cfi_device_set_block_size(FuCfiDevice *self, guint32 block_size);
 gboolean
 fu_cfi_device_get_cmd(FuCfiDevice *self, FuCfiDeviceCmd cmd, guint8 *value, GError **error);
 
+gboolean
+fu_cfi_device_send_command(FuCfiDevice *self,
+			   const guint8 *wbuf,
+			   gsize wbufsz,
+			   guint8 *rbuf,
+			   gsize rbufsz,
+			   FuProgress *progress,
+			   GError **error);
 gboolean
 fu_cfi_device_chip_select(FuCfiDevice *self, gboolean value, GError **error);
 FuDeviceLocker *

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1189,6 +1189,7 @@ LIBFWUPDPLUGIN_1.8.12 {
 LIBFWUPDPLUGIN_1.8.13 {
   global:
     fu_byte_array_append_uint24;
+    fu_cfi_device_send_command;
     fu_device_ensure_from_component;
     fu_volume_get_partition_kind;
   local: *;

--- a/plugins/ch347/README.md
+++ b/plugins/ch347/README.md
@@ -1,0 +1,37 @@
+---
+title: Plugin: CH347
+---
+
+## Introduction
+
+The CH347 is an affordable SPI programmer.
+
+## Firmware Format
+
+The daemon will decompress the cabinet archive and extract a firmware blob of unspecified format.
+
+This plugin supports the following protocol ID:
+
+- `org.jedec.cfi`
+
+## GUID Generation
+
+These devices use the standard USB DeviceInstanceId values, e.g.
+
+- `USB\VID_1A86&PID_55DB&REV_0304`
+- `USB\VID_1A86&PID_55DB`
+
+## Update Behavior
+
+The device programs devices in raw mode, and can best be used with `fwupdtool`.
+
+To write an image, use `sudo fwupdtool --plugins ch347 install-blob firmware.bin` and to backup
+the contents of a SPI device use `sudo fwupdtool --plugins ch347 firmware-dump backup.bin`
+
+## Vendor ID Security
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x1A86`
+
+## External Interface Access
+
+This plugin requires read/write access to `/dev/bus/usb`.

--- a/plugins/ch347/ch347.quirk
+++ b/plugins/ch347/ch347.quirk
@@ -1,0 +1,2 @@
+[USB\VID_1A86&PID_55DB]
+Plugin = ch347

--- a/plugins/ch347/fu-ch347-cfi-device.c
+++ b/plugins/ch347/fu-ch347-cfi-device.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-ch347-cfi-device.h"
+#include "fu-ch347-device.h"
+
+struct _FuCh347CfiDevice {
+	FuCfiDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuCh347CfiDevice, fu_ch347_cfi_device, FU_TYPE_CFI_DEVICE)
+
+static gboolean
+fu_ch347_cfi_device_chip_select(FuCfiDevice *self, gboolean value, GError **error)
+{
+	FuCh347Device *proxy = FU_CH347_DEVICE(fu_device_get_proxy(FU_DEVICE(self)));
+	return fu_ch347_device_chip_select(proxy, value, error);
+}
+
+static gboolean
+fu_ch347_cfi_device_send_command(FuCfiDevice *self,
+				 const guint8 *wbuf,
+				 gsize wbufsz,
+				 guint8 *rbuf,
+				 gsize rbufsz,
+				 FuProgress *progress,
+				 GError **error)
+{
+	FuCh347Device *proxy = FU_CH347_DEVICE(fu_device_get_proxy(FU_DEVICE(self)));
+	return fu_ch347_device_send_command(proxy, wbuf, wbufsz, rbuf, rbufsz, progress, error);
+}
+
+static void
+fu_ch347_cfi_device_init(FuCh347CfiDevice *self)
+{
+}
+
+static void
+fu_ch347_cfi_device_class_init(FuCh347CfiDeviceClass *klass)
+{
+	FuCfiDeviceClass *klass_cfi = FU_CFI_DEVICE_CLASS(klass);
+	klass_cfi->chip_select = fu_ch347_cfi_device_chip_select;
+	klass_cfi->send_command = fu_ch347_cfi_device_send_command;
+}

--- a/plugins/ch347/fu-ch347-cfi-device.h
+++ b/plugins/ch347/fu-ch347-cfi-device.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_CH347_CFI_DEVICE (fu_ch347_cfi_device_get_type())
+G_DECLARE_FINAL_TYPE(FuCh347CfiDevice, fu_ch347_cfi_device, FU, CH347_CFI_DEVICE, FuCfiDevice)

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-ch347-cfi-device.h"
+#include "fu-ch347-device.h"
+
+struct _FuCh347Device {
+	FuUsbDevice parent_instance;
+	guint8 divisor;
+};
+
+G_DEFINE_TYPE(FuCh347Device, fu_ch347_device, FU_TYPE_USB_DEVICE)
+
+#define FU_CH347_USB_TIMEOUT 1000
+
+#define FU_CH347_CMD_SPI_SET_CFG 0xC0
+#define FU_CH347_CMD_SPI_CS_CTRL 0xC1
+#define FU_CH347_CMD_SPI_OUT_IN	 0xC2
+#define FU_CH347_CMD_SPI_IN	 0xC3
+#define FU_CH347_CMD_SPI_OUT	 0xC4
+#define FU_CH347_CMD_SPI_GET_CFG 0xCA
+
+#define FU_CH347_CS_ASSERT   0x00
+#define FU_CH347_CS_DEASSERT 0x40
+#define FU_CH347_CS_CHANGE   0x80
+#define FU_CH347_CS_IGNORE   0x00
+
+#define FU_CH347_EP_OUT 0x06
+#define FU_CH347_EP_IN	0x86
+
+#define FU_CH347_MODE1_IFACE 0x2
+#define FU_CH347_MODE2_IFACE 0x1
+
+#define FU_CH347_PACKET_SIZE  510
+#define FU_CH347_PAYLOAD_SIZE (FU_CH347_PACKET_SIZE - 3)
+
+static void
+fu_ch347_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuCh347Device *self = FU_CH347_DEVICE(device);
+
+	/* FuUsbDevice->to_string */
+	FU_DEVICE_CLASS(fu_ch347_device_parent_class)->to_string(device, idt, str);
+
+	fu_string_append_kx(str, idt, "Divisor", self->divisor);
+}
+
+static gboolean
+fu_ch347_device_write(FuCh347Device *self,
+		      guint8 cmd,
+		      const guint8 *buf,
+		      gsize bufsz,
+		      GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
+	gsize actual_length = 0;
+	g_autoptr(GByteArray) cmdbuf = g_byte_array_new();
+
+	/* pack */
+	fu_byte_array_append_uint8(cmdbuf, cmd);
+	fu_byte_array_append_uint16(cmdbuf, bufsz, G_LITTLE_ENDIAN);
+	if (bufsz > 0)
+		g_byte_array_append(cmdbuf, buf, bufsz);
+
+	/* debug */
+	fu_dump_raw(G_LOG_DOMAIN, "write", cmdbuf->data, cmdbuf->len);
+	if (!g_usb_device_bulk_transfer(usb_device,
+					FU_CH347_EP_OUT,
+					cmdbuf->data,
+					cmdbuf->len,
+					&actual_length,
+					FU_CH347_USB_TIMEOUT,
+					NULL,
+					error)) {
+		g_prefix_error(error, "failed to write 0x%x bytes: ", (guint)bufsz);
+		return FALSE;
+	}
+	if (cmdbuf->len != actual_length) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "only wrote 0x%x of 0x%x",
+			    (guint)actual_length,
+			    (guint)cmdbuf->len);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_ch347_device_read(FuCh347Device *self, guint8 cmd, guint8 *buf, gsize bufsz, GError **error)
+{
+	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
+	gsize actual_length = 0;
+	guint8 cmd_rsp;
+	guint16 size_rsp;
+	g_autoptr(GByteArray) cmdbuf = g_byte_array_new();
+
+	/* pack */
+	fu_byte_array_append_uint8(cmdbuf, cmd);
+	fu_byte_array_append_uint16(cmdbuf, sizeof(guint32), G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(cmdbuf, bufsz, G_LITTLE_ENDIAN);
+	fu_byte_array_set_size(cmdbuf, FU_CH347_PACKET_SIZE, 0x0);
+
+	if (!g_usb_device_bulk_transfer(usb_device,
+					FU_CH347_EP_IN,
+					cmdbuf->data,
+					cmdbuf->len,
+					&actual_length,
+					FU_CH347_USB_TIMEOUT,
+					NULL,
+					error)) {
+		g_prefix_error(error, "failed to read 0x%x bytes: ", (guint)bufsz);
+		return FALSE;
+	}
+	fu_dump_raw(G_LOG_DOMAIN, "read", cmdbuf->data, actual_length);
+	if (actual_length == 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "returned 0 bytes");
+		return FALSE;
+	}
+
+	/* debug */
+	cmd_rsp = cmdbuf->data[0];
+	if (cmd_rsp != cmd) {
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_FAILED,
+			    "invalid cmd, got 0x%02x, expected 0x%02x",
+			    cmd_rsp,
+			    cmd);
+		return FALSE;
+	}
+	size_rsp = fu_memread_uint16(cmdbuf->data + 0x1, G_LITTLE_ENDIAN);
+	if (size_rsp != bufsz) {
+		g_set_error(error,
+			    G_IO_ERROR,
+			    G_IO_ERROR_FAILED,
+			    "size invalid, got 0x%04x, expected 0x04%x",
+			    size_rsp,
+			    (guint)bufsz);
+		return FALSE;
+	}
+
+	/* success */
+	memcpy(buf, cmdbuf->data + 0x3, size_rsp);
+	return TRUE;
+}
+
+gboolean
+fu_ch347_device_send_command(FuCh347Device *self,
+			     const guint8 *wbuf,
+			     gsize wbufsz,
+			     guint8 *rbuf,
+			     gsize rbufsz,
+			     FuProgress *progress,
+			     GError **error)
+{
+	/* write */
+	if (wbufsz > 0) {
+		g_autoptr(GPtrArray) chunks =
+		    fu_chunk_array_new(wbuf, wbufsz, 0x0, 0x0, FU_CH347_PAYLOAD_SIZE);
+		for (guint i = 0; i < chunks->len; i++) {
+			FuChunk *chk = g_ptr_array_index(chunks, i);
+			guint8 buf[1] = {0x0};
+			if (!fu_ch347_device_write(self,
+						   FU_CH347_CMD_SPI_OUT,
+						   fu_chunk_get_data(chk),
+						   fu_chunk_get_data_sz(chk),
+						   error))
+				return FALSE;
+			if (!fu_ch347_device_read(self,
+						  FU_CH347_CMD_SPI_OUT,
+						  buf,
+						  sizeof(buf),
+						  error))
+				return FALSE;
+		}
+	}
+
+	/* read */
+	if (rbufsz > 0) {
+		g_autoptr(GPtrArray) chunks =
+		    fu_chunk_array_mutable_new(rbuf, rbufsz, 0x0, 0x0, FU_CH347_PAYLOAD_SIZE);
+		g_autoptr(GByteArray) cmdbuf = g_byte_array_new();
+		fu_byte_array_append_uint32(cmdbuf, rbufsz, G_LITTLE_ENDIAN);
+		if (!fu_ch347_device_write(self,
+					   FU_CH347_CMD_SPI_IN,
+					   cmdbuf->data,
+					   cmdbuf->len,
+					   error))
+			return FALSE;
+		fu_progress_set_id(progress, G_STRLOC);
+		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
+		fu_progress_set_steps(progress, chunks->len);
+		for (guint i = 0; i < chunks->len; i++) {
+			FuChunk *chk = g_ptr_array_index(chunks, i);
+			if (!fu_ch347_device_read(self,
+						  FU_CH347_CMD_SPI_IN,
+						  fu_chunk_get_data_out(chk),
+						  fu_chunk_get_data_sz(chk),
+						  error))
+				return FALSE;
+			fu_progress_step_done(progress);
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_ch347_device_configure_stream(FuCh347Device *self, GError **error)
+{
+	guint8 data[26] = {[2] = 4,			      /* ?? */
+			   [3] = 1,			      /* ?? */
+			   [6] = 0,			      /* clock polarity: bit 1 */
+			   [8] = 0,			      /* clock phase: bit 0 */
+			   [11] = 2,			      /* ?? */
+			   [12] = (self->divisor & 0x7) << 3, /* clock divisor: bits 5:3 */
+			   [14] = 0,			      /* bit order: bit 7, 0=MSB */
+			   [16] = 7,			      /* ?? */
+			   [21] = 0}; /* CS polarity: bit 7 CS2, bit 6 CS1. 0 = active low */
+	if (!fu_ch347_device_write(self, FU_CH347_CMD_SPI_SET_CFG, data, sizeof(data), error)) {
+		g_prefix_error(error, "failed to configure stream: ");
+		return FALSE;
+	}
+	if (!fu_ch347_device_read(self, FU_CH347_CMD_SPI_SET_CFG, data, 1, error)) {
+		g_prefix_error(error, "failed to confirm configure stream: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_ch347_device_chip_select(FuCh347Device *self, gboolean val, GError **error)
+{
+	guint8 buf[10] = {
+	    [0] = val ? FU_CH347_CS_ASSERT | FU_CH347_CS_CHANGE
+		      : FU_CH347_CS_DEASSERT | FU_CH347_CS_CHANGE,
+	    [5] = FU_CH347_CS_IGNORE /* CS2 */
+	};
+	return fu_ch347_device_write(self, FU_CH347_CMD_SPI_CS_CTRL, buf, sizeof(buf), error);
+}
+
+static gboolean
+fu_ch347_device_setup(FuDevice *device, GError **error)
+{
+	FuCh347Device *self = FU_CH347_DEVICE(device);
+	g_autoptr(FuCh347CfiDevice) cfi_device = NULL;
+
+	/* FuUsbDevice->setup */
+	if (!FU_DEVICE_CLASS(fu_ch347_device_parent_class)->setup(device, error))
+		return FALSE;
+
+	/* set divisor */
+	if (!fu_ch347_device_configure_stream(self, error))
+		return FALSE;
+
+	/* setup SPI chip */
+	cfi_device = g_object_new(FU_TYPE_CH347_CFI_DEVICE,
+				  "context",
+				  fu_device_get_context(device),
+				  "proxy",
+				  device,
+				  "parent",
+				  device,
+				  "logical-id",
+				  "SPI",
+				  NULL);
+	if (!fu_device_setup(FU_DEVICE(cfi_device), error))
+		return FALSE;
+	fu_device_add_child(device, FU_DEVICE(cfi_device));
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_ch347_device_init(FuCh347Device *self)
+{
+	self->divisor = 0b10;
+	fu_usb_device_add_interface(FU_USB_DEVICE(self), FU_CH347_MODE1_IFACE);
+	fu_device_set_name(FU_DEVICE(self), "CH347");
+	fu_device_set_vendor(FU_DEVICE(self), "WinChipHead");
+}
+
+static void
+fu_ch347_device_class_init(FuCh347DeviceClass *klass)
+{
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	klass_device->setup = fu_ch347_device_setup;
+	klass_device->to_string = fu_ch347_device_to_string;
+}

--- a/plugins/ch347/fu-ch347-device.h
+++ b/plugins/ch347/fu-ch347-device.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_CH347_DEVICE (fu_ch347_device_get_type())
+G_DECLARE_FINAL_TYPE(FuCh347Device, fu_ch347_device, FU, CH347_DEVICE, FuUsbDevice)
+
+gboolean
+fu_ch347_device_chip_select(FuCh347Device *self, gboolean val, GError **error);
+gboolean
+fu_ch347_device_send_command(FuCh347Device *self,
+			     const guint8 *wbuf,
+			     gsize wbufsz,
+			     guint8 *rbuf,
+			     gsize rbufsz,
+			     FuProgress *progress,
+			     GError **error);

--- a/plugins/ch347/fu-ch347-plugin.c
+++ b/plugins/ch347/fu-ch347-plugin.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-ch347-device.h"
+#include "fu-ch347-plugin.h"
+
+struct _FuCh347Plugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuCh347Plugin, fu_ch347_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_ch347_plugin_init(FuCh347Plugin *self)
+{
+}
+
+static void
+fu_ch347_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_CH347_DEVICE);
+}
+
+static void
+fu_ch347_plugin_class_init(FuCh347PluginClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->constructed = fu_ch347_plugin_constructed;
+}

--- a/plugins/ch347/fu-ch347-plugin.h
+++ b/plugins/ch347/fu-ch347-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuCh347Plugin, fu_ch347_plugin, FU, CH347_PLUGIN, FuPlugin)

--- a/plugins/ch347/meson.build
+++ b/plugins/ch347/meson.build
@@ -1,0 +1,16 @@
+if gusb.found()
+cargs = ['-DG_LOG_DOMAIN="FuPluginCh347"']
+
+plugin_quirks += files('ch347.quirk')
+plugin_builtins += static_library('fu_plugin_ch347',
+  sources: [
+    'fu-ch347-cfi-device.c',
+    'fu-ch347-device.c',
+    'fu-ch347-plugin.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -28,6 +28,7 @@ plugins = [
   'ccgx',
   'cfu',
   'ch341a',
+  'ch347',
   'colorhug',
   'corsair',
   'cpu',


### PR DESCRIPTION
Move the generic SPI functionality from the CH341a plugin to libfwupdplugin.

The ->send_command() vfunc is inspired by flashrom, and it seems to be most suitable for USB programmers with odd quirks.

NOTE: I've not switched the CH341a plugin to use the generic command as there are two quirks (JEDEC 4 byte read, junk in initial read buffer) which need further reverse engineering to unpuzzle.

Type of pull request:

- [X] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
