### PR TITLE
Adjust thinklmi handling

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3146,11 +3146,10 @@ fu_bios_settings_load_func(void)
 	test_dir = g_test_build_filename(G_TEST_DIST, "tests", "bios-attrs", "lenovo-p620", NULL);
 	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 
-	g_test_expect_message("FuBiosSettings", G_LOG_LEVEL_WARNING, "*BUG*");
 	ret = fu_context_reload_bios_settings(ctx, &error);
+#ifdef FU_THINKLMI_COMPAT
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_test_assert_expected_messages();
 
 	p620_settings = fu_context_get_bios_settings(ctx);
 	p620_items = fu_bios_settings_get_all(p620_settings);
@@ -3201,6 +3200,13 @@ fu_bios_settings_load_func(void)
 		g_debug("%s", tmp);
 		g_assert_null(g_strrstr(tmp, "[Status"));
 	}
+#else
+	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
+	g_assert_false(ret);
+	g_clear_error(&error);
+#endif
+	g_free(test_dir);
+
 
 	g_free(test_dir);
 
@@ -3209,6 +3215,7 @@ fu_bios_settings_load_func(void)
 	    g_test_build_filename(G_TEST_DIST, "tests", "bios-attrs", "lenovo-p14s-gen1", NULL);
 	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 	ret = fu_context_reload_bios_settings(ctx, &error);
+#ifdef FU_THINKLMI_COMPAT
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3241,7 +3248,11 @@ fu_bios_settings_load_func(void)
 	g_assert_nonnull(setting);
 	ret = fwupd_bios_setting_get_read_only(setting);
 	g_assert_true(ret);
-
+#else
+	g_assert_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT);
+	g_assert_false(ret);
+	g_clear_error(&error);
+#endif
 	g_free(test_dir);
 
 	/* load BIOS settings from a Dell XPS 9310 */

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/current_value
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/current_value
@@ -1,0 +1,1 @@
+../../../../lenovo-p14s-gen1/thinklmi/attributes/UserDefinedAlarmMonday/current_value

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/display_name
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/display_name
@@ -1,0 +1,1 @@
+../../../../lenovo-p620/thinklmi/attributes/AMDMemoryGuard/display_name

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/possible_values
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/possible_values
@@ -1,0 +1,1 @@
+Disable;Enable

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/type
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AMDMemoryGuard/type
@@ -1,0 +1,1 @@
+../../../../dell-xps13-9310/dell-wmi-sysman/attributes/KeyboardIllumination/type

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/current_value
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/current_value
@@ -1,0 +1,1 @@
+[01/01/2019][Status:ShowOnly]

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/display_name
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/display_name
@@ -1,0 +1,1 @@
+AlarmDate

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/type
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/AlarmDate/type
@@ -1,0 +1,1 @@
+../../../../dell-xps13-9310/dell-wmi-sysman/attributes/SvcTag/type

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/current_value
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/current_value
@@ -1,0 +1,1 @@
+Primary

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/display_name
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/display_name
@@ -1,0 +1,1 @@
+../../../../lenovo-p620/thinklmi/attributes/StartupSequence/display_name

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/possible_values
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/possible_values
@@ -1,0 +1,1 @@
+Primary;Automatic

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/type
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/StartupSequence/type
@@ -1,0 +1,1 @@
+../../../../dell-xps13-9310/dell-wmi-sysman/attributes/KeyboardIllumination/type

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/current_value
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/current_value
@@ -1,0 +1,1 @@
+../../../../lenovo-p14s-gen1/thinklmi/attributes/LidSensor/current_value

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/display_name
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/display_name
@@ -1,0 +1,1 @@
+../../../../lenovo-p14s-gen1/thinklmi/attributes/WindowsUEFIFirmwareUpdate/display_name

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/possible_values
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/possible_values
@@ -1,0 +1,1 @@
+../AMDMemoryGuard/possible_values

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/type
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/WindowsUEFIFirmwareUpdate/type
@@ -1,0 +1,1 @@
+../../../../dell-xps13-9310/dell-wmi-sysman/attributes/KeyboardIllumination/type

--- a/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/pending_reboot
+++ b/libfwupdplugin/tests/bios-attrs/lenovo-p620-6.3/thinklmi/attributes/pending_reboot
@@ -1,0 +1,1 @@
+../../../lenovo-p620/thinklmi/attributes/pending_reboot

--- a/meson.build
+++ b/meson.build
@@ -488,6 +488,11 @@ if get_option('supported_build').disable_auto_if(not tag).allowed()
     conf.set('SUPPORTED_BUILD', '1')
 endif
 
+# compatibility with behavior in < kernel 6.3
+if get_option('thinklmi_compat')
+  conf.set('FU_THINKLMI_COMPAT', '1')
+endif
+
 gnome = import('gnome')
 i18n = import('i18n')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -70,3 +70,4 @@ option('fish_completion', type: 'boolean', value : true, description : 'enable f
 option('offline', type: 'feature', description : 'Allow installing firmware using a pre-boot systemd target', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('compat_cli', type: 'boolean', value : false, description : 'enable legacy commands: fwupdagent,dfu-tool,fwupdate')
 option('hsi', type: 'feature', description : ' Host Security Information', deprecated: {'true': 'enabled', 'false': 'disabled'})
+option('thinklmi_compat', type: 'boolean', description : 'Include workaround for thinklmi kernel bugs')

--- a/plugins/lenovo-thinklmi/tests/firmware-attributes/locked/thinklmi/attributes/BootOrderLock/display_name
+++ b/plugins/lenovo-thinklmi/tests/firmware-attributes/locked/thinklmi/attributes/BootOrderLock/display_name
@@ -1,0 +1,1 @@
+BootOrderLock

--- a/plugins/lenovo-thinklmi/tests/firmware-attributes/reboot-pending/thinklmi/attributes/BootOrderLock/display_name
+++ b/plugins/lenovo-thinklmi/tests/firmware-attributes/reboot-pending/thinklmi/attributes/BootOrderLock/display_name
@@ -1,0 +1,1 @@
+BootOrderLock

--- a/plugins/lenovo-thinklmi/tests/firmware-attributes/unlocked/thinklmi/attributes/BootOrderLock/display_name
+++ b/plugins/lenovo-thinklmi/tests/firmware-attributes/unlocked/thinklmi/attributes/BootOrderLock/display_name
@@ -1,0 +1,1 @@
+BootOrderLock


### PR DESCRIPTION
The plan for this is that we offer a compile option to turn on compatibility with older kernels.
Proposal:
* In ~March 2024 we'll change default for this option to false.
* In ~September 2024 we'll drop all the compatibility code

This PR is currently marked draft because it's pending one more kernel fix to adjust the `current_value` sysfs file to behave properly.  It will be adjusted and marked ready after that is landed in mainline.

@mrhpearson  FYI.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
