### PR TITLE
uefi-capsule: Fix possible crash when getting UEFI report metadata

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -162,7 +162,7 @@ fu_uefi_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 			    g_strdup(priv->missing_header ? "True" : "False"));
 
 	/* where and how the ESP was mounted during installation */
-	g_hash_table_insert(metadata, g_strdup("EspPath"), mount_point);
+	g_hash_table_insert(metadata, g_strdup("EspPath"), g_steal_pointer(&mount_point));
 	if (fu_volume_get_partition_kind(priv->esp) != NULL) {
 		g_hash_table_insert(metadata,
 				    g_strdup("EspKind"),


### PR DESCRIPTION
The fix of 0eec0c4a66a5e8a5957172e34fb675cfce646617 was incorrect as the hash table takes allocated strings, and mount_point is g_autofree.

Fixes https://github.com/fwupd/fwupd/issues/5656

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
