### PR TITLE
synaptics-cxaudio: Convert to FuStruct which makes the code a lot less magic

### DIFF
--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-common.h
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-common.h
@@ -40,6 +40,7 @@ typedef enum {
 
 /* EEPROM */
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_VALIDITY_SIGNATURE_OFFSET  0x0000
+#define FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_OFFSET	       0x0014
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_CUSTOM_INFO_OFFSET	       0x0020
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_CPX_PATCH_VERSION_ADDRESS  0x0022
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_CPX_PATCH2_VERSION_ADDRESS 0x0176
@@ -47,65 +48,9 @@ typedef enum {
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_STORAGE_PADDING_SIZE       0x4 /* bytes */
 
 #define FU_SYNAPTICS_CXAUDIO_DEVICE_CAPABILITIES_STRIDX 50
-#define FU_SYNAPTICS_CXAUDIO_DEVICE_CAPABILITIES_BYTE	0x03
-#define FU_SYNAPTICS_CXAUDIO_MAGIC_BYTE			'L'
 #define FU_SYNAPTICS_CXAUDIO_SIGNATURE_BYTE		'S'
 #define FU_SYNAPTICS_CXAUDIO_SIGNATURE_PATCH_BYTE	'P'
 #define FU_SYNAPTICS_CXAUDIO_REG_FIRMWARE_PARK_ADDR	0x1000
 #define FU_SYNAPTICS_CXAUDIO_REG_FIRMWARE_VERSION_ADDR	0x1001
 #define FU_SYNAPTICS_CXAUDIO_REG_RESET_ADDR		0x0400
 #define FU_SYNAPTICS_CXAUDIO_EEPROM_SHADOW_SIZE		(8 * 1024)
-
-typedef guint16 FuSynapticsCxaudioEepromPtr;
-typedef struct __attribute__((packed)) {
-	FuSynapticsCxaudioEepromPtr PatchVersionStringAddress;
-	guint8 CpxPatchVersion[3];
-	guint8 SpxPatchVersion[4];
-	guint8 LayoutSignature;
-	guint8 LayoutVersion;
-	guint8 ApplicationStatus;
-	guint16 VendorID;
-	guint16 ProductID;
-	guint16 RevisionID;
-	FuSynapticsCxaudioEepromPtr LanguageStringAddress;
-	FuSynapticsCxaudioEepromPtr ManufacturerStringAddress;
-	FuSynapticsCxaudioEepromPtr ProductStringAddress;
-	FuSynapticsCxaudioEepromPtr SerialNumberStringAddress;
-} FuSynapticsCxaudioEepromCustomInfo;
-
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_APP_STATUS_ADDRESS                                             \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_CUSTOM_INFO_OFFSET +                                          \
-	 G_STRUCT_OFFSET(FuSynapticsCxaudioEepromCustomInfo, ApplicationStatus))
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_LAYOUT_SIGNATURE_ADDRESS                                       \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_CUSTOM_INFO_OFFSET +                                          \
-	 G_STRUCT_OFFSET(FuSynapticsCxaudioEepromCustomInfo, LayoutSignature))
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_LAYOUT_VERSION_ADDRESS                                         \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_CUSTOM_INFO_OFFSET +                                          \
-	 G_STRUCT_OFFSET(FuSynapticsCxaudioEepromCustomInfo, LayoutVersion))
-
-typedef struct __attribute__((packed)) {
-	guint8 Length;
-	guint8 Type;
-} FuSynapticsCxaudioEepromStringHeader;
-
-typedef struct __attribute__((packed)) {
-	guint8 PatchSignature;
-	FuSynapticsCxaudioEepromPtr PatchAddress;
-} FuSynapticsCxaudioEepromPatchInfo;
-
-typedef struct __attribute__((packed)) {
-	guint8 MagicByte;
-	guint8 EeepromSizeCode;
-} FuSynapticsCxaudioEepromValiditySignature;
-
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_OFFSET 0x0014
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_SIZE   (sizeof(FuSynapticsCxaudioEepromPatchInfo))
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_SIGNATURE_ADDRESS                                        \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_OFFSET +                                           \
-	 G_STRUCT_OFFSET(FuSynapticsCxaudioEepromPatchInfo, PatchSignature))
-#define FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_PTR_ADDRESS                                              \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_OFFSET +                                           \
-	 G_STRUCT_OFFSET(FuSynapticsCxaudioEepromPatchInfo, PatchAddress))
-#define FU_SYNAPTICS_CXAUDIO_FIRMWARE_SIGNATURE_OFFSET                                             \
-	(FU_SYNAPTICS_CXAUDIO_EEPROM_VALIDITY_SIGNATURE_OFFSET +                                   \
-	 sizeof(FuSynapticsCxaudioEepromValiditySignature))

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio.struct
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio.struct
@@ -1,0 +1,27 @@
+struct SynapticsCxaudioCustomInfo {
+	patch_version_string_address: u16le
+	cpx_patch_version: 3u8
+	spx_patch_version: 4u8
+	layout_signature: u8
+	layout_version: u8
+	application_status: u8
+	vendor_id: u16le
+	product_id: u16le
+	revision_id: u16le
+	language_string_address: u16le
+	manufacturer_string_address: u16le
+	product_string_address: u16le
+	serial_number_string_address: u16le
+}
+struct SynapticsCxaudioStringHeader {
+	length: u8
+	type: u8:: 0x03
+}
+struct SynapticsCxaudioValiditySignature {
+	magic_byte: u8: 0x4C	// 'L'
+	eeprom_size_code: u8
+}
+struct SynapticsCxaudioPatchInfo {
+	patch_signature: u8
+	patch_address: u16le
+}

--- a/plugins/synaptics-cxaudio/meson.build
+++ b/plugins/synaptics-cxaudio/meson.build
@@ -3,6 +3,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsCxaudio"']
 
 plugin_quirks += files('synaptics-cxaudio.quirk')
 plugin_builtins += static_library('fu_plugin_synaptics_cxaudio',
+  structgen.process('fu-synaptics-cxaudio.struct'),
   sources: [
     'fu-synaptics-cxaudio-plugin.c',
     'fu-synaptics-cxaudio-device.c',


### PR DESCRIPTION
This also makes it endian-clean.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
