### PR TITLE
Reduce the amount of debugging when using --plugins

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -134,7 +134,20 @@ fu_plugin_get_name(FuPlugin *self)
 void
 fu_plugin_set_name(FuPlugin *self, const gchar *name)
 {
+	FuPluginPrivate *priv = GET_PRIVATE(self);
+
 	g_return_if_fail(FU_IS_PLUGIN(self));
+	g_return_if_fail(!priv->done_init);
+
+	if (g_strcmp0(name, fwupd_plugin_get_name(FWUPD_PLUGIN(self))) == 0) {
+		g_critical("plugin name set to original value: %s", name);
+		return;
+	}
+	if (fwupd_plugin_get_name(FWUPD_PLUGIN(self)) != NULL) {
+		g_debug("overwriting plugin name %s -> %s",
+			fwupd_plugin_get_name(FWUPD_PLUGIN(self)),
+			name);
+	}
 	fwupd_plugin_set_name(FWUPD_PLUGIN(self), name);
 }
 

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -58,8 +58,6 @@ static void
 fu_acpi_phat_plugin_class_init(FuAcpiPhatPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_acpi_phat_plugin_constructed;
+	plugin_class->constructed = fu_acpi_phat_plugin_constructed;
 	plugin_class->coldplug = fu_acpi_phat_plugin_coldplug;
 }

--- a/plugins/amd-gpu/fu-amd-gpu-plugin.c
+++ b/plugins/amd-gpu/fu-amd-gpu-plugin.c
@@ -31,6 +31,6 @@ fu_amd_gpu_plugin_constructed(GObject *obj)
 static void
 fu_amd_gpu_plugin_class_init(FuAmdGpuPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_amd_gpu_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_amd_gpu_plugin_constructed;
 }

--- a/plugins/amd-pmc/fu-amd-pmc-plugin.c
+++ b/plugins/amd-pmc/fu-amd-pmc-plugin.c
@@ -31,6 +31,6 @@ fu_amd_pmc_plugin_constructed(GObject *obj)
 static void
 fu_amd_pmc_plugin_class_init(FuAmdPmcPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_amd_pmc_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_amd_pmc_plugin_constructed;
 }

--- a/plugins/analogix/fu-analogix-plugin.c
+++ b/plugins/analogix/fu-analogix-plugin.c
@@ -32,6 +32,6 @@ fu_analogix_plugin_constructed(GObject *obj)
 static void
 fu_analogix_plugin_class_init(FuAnalogixPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_analogix_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_analogix_plugin_constructed;
 }

--- a/plugins/android-boot/fu-android-boot-plugin.c
+++ b/plugins/android-boot/fu-android-boot-plugin.c
@@ -31,6 +31,6 @@ fu_android_boot_plugin_constructed(GObject *obj)
 static void
 fu_android_boot_plugin_class_init(FuAndroidBootPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_android_boot_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_android_boot_plugin_constructed;
 }

--- a/plugins/ata/fu-ata-plugin.c
+++ b/plugins/ata/fu-ata-plugin.c
@@ -31,6 +31,6 @@ fu_ata_plugin_constructed(GObject *obj)
 static void
 fu_ata_plugin_class_init(FuAtaPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ata_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_ata_plugin_constructed;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-plugin.c
+++ b/plugins/bcm57xx/fu-bcm57xx-plugin.c
@@ -25,10 +25,16 @@ fu_bcm57xx_plugin_init(FuBcm57XxPlugin *self)
 }
 
 static void
-fu_bcm57xx_plugin_constructed(GObject *obj)
+fu_bcm57xx_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "bcm57xx");
+}
+
+static void
+fu_bcm57xx_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
@@ -41,6 +47,8 @@ fu_bcm57xx_plugin_constructed(GObject *obj)
 static void
 fu_bcm57xx_plugin_class_init(FuBcm57XxPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_bcm57xx_plugin_constructed;
+	object_class->constructed = fu_bcm57xx_plugin_object_constructed;
+	plugin_class->constructed = fu_bcm57xx_plugin_constructed;
 }

--- a/plugins/ccgx/fu-ccgx-plugin.c
+++ b/plugins/ccgx/fu-ccgx-plugin.c
@@ -43,6 +43,6 @@ fu_ccgx_plugin_constructed(GObject *obj)
 static void
 fu_ccgx_plugin_class_init(FuCcgxPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ccgx_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_ccgx_plugin_constructed;
 }

--- a/plugins/cfu/fu-cfu-plugin.c
+++ b/plugins/cfu/fu-cfu-plugin.c
@@ -30,6 +30,6 @@ fu_cfu_plugin_constructed(GObject *obj)
 static void
 fu_cfu_plugin_class_init(FuCfuPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_cfu_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_cfu_plugin_constructed;
 }

--- a/plugins/ch341a/fu-ch341a-plugin.c
+++ b/plugins/ch341a/fu-ch341a-plugin.c
@@ -21,16 +21,24 @@ fu_ch341a_plugin_init(FuCh341APlugin *self)
 }
 
 static void
-fu_ch341a_plugin_constructed(GObject *obj)
+fu_ch341a_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "ch341a");
+}
+
+static void
+fu_ch341a_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CH341A_DEVICE);
 }
 
 static void
 fu_ch341a_plugin_class_init(FuCh341APluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ch341a_plugin_constructed;
+	object_class->constructed = fu_ch341a_plugin_object_constructed;
+	plugin_class->constructed = fu_ch341a_plugin_constructed;
 }

--- a/plugins/ch347/fu-ch347-plugin.c
+++ b/plugins/ch347/fu-ch347-plugin.c
@@ -30,6 +30,6 @@ fu_ch347_plugin_constructed(GObject *obj)
 static void
 fu_ch347_plugin_class_init(FuCh347PluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ch347_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_ch347_plugin_constructed;
 }

--- a/plugins/colorhug/fu-colorhug-plugin.c
+++ b/plugins/colorhug/fu-colorhug-plugin.c
@@ -30,6 +30,6 @@ fu_colorhug_plugin_constructed(GObject *obj)
 static void
 fu_colorhug_plugin_class_init(FuColorhugPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_colorhug_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_colorhug_plugin_constructed;
 }

--- a/plugins/corsair/fu-corsair-plugin.c
+++ b/plugins/corsair/fu-corsair-plugin.c
@@ -35,6 +35,6 @@ fu_corsair_plugin_constructed(GObject *obj)
 static void
 fu_corsair_plugin_class_init(FuCorsairPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_corsair_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_corsair_plugin_constructed;
 }

--- a/plugins/cpu/fu-cpu-plugin.c
+++ b/plugins/cpu/fu-cpu-plugin.c
@@ -55,7 +55,6 @@ static void
 fu_cpu_plugin_class_init(FuCpuPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_cpu_plugin_constructed;
+	plugin_class->constructed = fu_cpu_plugin_constructed;
 	plugin_class->coldplug = fu_cpu_plugin_coldplug;
 }

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -32,6 +32,6 @@ fu_cros_ec_plugin_constructed(GObject *obj)
 static void
 fu_cros_ec_plugin_class_init(FuCrosEcPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_cros_ec_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_cros_ec_plugin_constructed;
 }

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -346,8 +346,7 @@ static void
 fu_dell_dock_plugin_class_init(FuDellDockPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_dell_dock_plugin_constructed;
+	plugin_class->constructed = fu_dell_dock_plugin_constructed;
 	plugin_class->device_registered = fu_dell_dock_plugin_device_registered;
 	plugin_class->backend_device_added = fu_dell_dock_plugin_backend_device_added;
 	plugin_class->backend_device_removed = fu_dell_dock_plugin_backend_device_removed;

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -1042,8 +1042,8 @@ fu_dell_plugin_class_init(FuDellPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_dell_plugin_constructed;
 	object_class->finalize = fu_dell_finalize;
+	plugin_class->constructed = fu_dell_plugin_constructed;
 	plugin_class->to_string = fu_dell_plugin_to_string;
 	plugin_class->startup = fu_dell_plugin_startup;
 	plugin_class->coldplug = fu_dell_plugin_coldplug;

--- a/plugins/dfu-csr/fu-dfu-csr-plugin.c
+++ b/plugins/dfu-csr/fu-dfu-csr-plugin.c
@@ -30,6 +30,6 @@ fu_dfu_csr_plugin_constructed(GObject *obj)
 static void
 fu_dfu_csr_plugin_class_init(FuDfuCsrPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_dfu_csr_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_dfu_csr_plugin_constructed;
 }

--- a/plugins/dfu/fu-dfu-plugin.c
+++ b/plugins/dfu/fu-dfu-plugin.c
@@ -34,6 +34,6 @@ fu_dfu_plugin_constructed(GObject *obj)
 static void
 fu_dfu_plugin_class_init(FuDfuPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_dfu_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_dfu_plugin_constructed;
 }

--- a/plugins/ebitdo/fu-ebitdo-plugin.c
+++ b/plugins/ebitdo/fu-ebitdo-plugin.c
@@ -32,6 +32,6 @@ fu_ebitdo_plugin_constructed(GObject *obj)
 static void
 fu_ebitdo_plugin_class_init(FuEbitdoPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ebitdo_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_ebitdo_plugin_constructed;
 }

--- a/plugins/elanfp/fu-elanfp-plugin.c
+++ b/plugins/elanfp/fu-elanfp-plugin.c
@@ -32,6 +32,6 @@ fu_elanfp_plugin_constructed(GObject *obj)
 static void
 fu_elanfp_plugin_class_init(FuElanfpPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_elanfp_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_elanfp_plugin_constructed;
 }

--- a/plugins/elantp/fu-elantp-plugin.c
+++ b/plugins/elantp/fu-elantp-plugin.c
@@ -54,7 +54,6 @@ static void
 fu_elantp_plugin_class_init(FuElantpPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_elantp_plugin_constructed;
+	plugin_class->constructed = fu_elantp_plugin_constructed;
 	plugin_class->device_created = fu_elantp_plugin_device_created;
 }

--- a/plugins/emmc/fu-emmc-plugin.c
+++ b/plugins/emmc/fu-emmc-plugin.c
@@ -31,6 +31,6 @@ fu_emmc_plugin_constructed(GObject *obj)
 static void
 fu_emmc_plugin_class_init(FuEmmcPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_emmc_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_emmc_plugin_constructed;
 }

--- a/plugins/ep963x/fu-ep963x-plugin.c
+++ b/plugins/ep963x/fu-ep963x-plugin.c
@@ -22,10 +22,16 @@ fu_ep963x_plugin_init(FuEp963XPlugin *self)
 }
 
 static void
-fu_ep963x_plugin_constructed(GObject *obj)
+fu_ep963x_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "ep963x");
+}
+
+static void
+fu_ep963x_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EP963X_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EP963X_FIRMWARE);
 }
@@ -33,6 +39,8 @@ fu_ep963x_plugin_constructed(GObject *obj)
 static void
 fu_ep963x_plugin_class_init(FuEp963XPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ep963x_plugin_constructed;
+	object_class->constructed = fu_ep963x_plugin_object_constructed;
+	plugin_class->constructed = fu_ep963x_plugin_constructed;
 }

--- a/plugins/fastboot/fu-fastboot-plugin.c
+++ b/plugins/fastboot/fu-fastboot-plugin.c
@@ -33,6 +33,6 @@ fu_fastboot_plugin_constructed(GObject *obj)
 static void
 fu_fastboot_plugin_class_init(FuFastbootPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_fastboot_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_fastboot_plugin_constructed;
 }

--- a/plugins/focalfp/fu-focalfp-plugin.c
+++ b/plugins/focalfp/fu-focalfp-plugin.c
@@ -33,6 +33,6 @@ fu_focalfp_plugin_constructed(GObject *obj)
 static void
 fu_focalfp_plugin_class_init(FuFocalfpPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_focalfp_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_focalfp_plugin_constructed;
 }

--- a/plugins/fpc/fu-fpc-plugin.c
+++ b/plugins/fpc/fu-fpc-plugin.c
@@ -30,6 +30,6 @@ fu_fpc_constructed(GObject *obj)
 static void
 fu_fpc_plugin_class_init(FuFpcPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_fpc_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_fpc_constructed;
 }

--- a/plugins/fresco-pd/fu-fresco-pd-plugin.c
+++ b/plugins/fresco-pd/fu-fresco-pd-plugin.c
@@ -32,6 +32,6 @@ fu_fresco_pd_plugin_constructed(GObject *obj)
 static void
 fu_fresco_pd_plugin_class_init(FuFrescoPdPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_fresco_pd_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_fresco_pd_plugin_constructed;
 }

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -42,6 +42,6 @@ fu_genesys_plugin_constructed(GObject *obj)
 static void
 fu_genesys_plugin_class_init(FuGenesysPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_genesys_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_genesys_plugin_constructed;
 }

--- a/plugins/goodix-moc/fu-goodixmoc-plugin.c
+++ b/plugins/goodix-moc/fu-goodixmoc-plugin.c
@@ -22,16 +22,24 @@ fu_goodixmoc_plugin_init(FuGoodixMocPlugin *self)
 }
 
 static void
-fu_goodixmoc_plugin_constructed(GObject *obj)
+fu_goodixmoc_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "goodixmoc");
+}
+
+static void
+fu_goodixmoc_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GOODIXMOC_DEVICE);
 }
 
 static void
 fu_goodixmoc_plugin_class_init(FuGoodixMocPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_goodixmoc_plugin_constructed;
+	object_class->constructed = fu_goodixmoc_plugin_object_constructed;
+	plugin_class->constructed = fu_goodixmoc_plugin_constructed;
 }

--- a/plugins/gpio/fu-gpio-plugin.c
+++ b/plugins/gpio/fu-gpio-plugin.c
@@ -185,8 +185,8 @@ fu_gpio_plugin_class_init(FuGpioPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_gpio_plugin_constructed;
 	object_class->finalize = fu_gpio_finalize;
+	plugin_class->constructed = fu_gpio_plugin_constructed;
 	plugin_class->to_string = fu_gpio_plugin_to_string;
 	plugin_class->prepare = fu_gpio_plugin_prepare;
 	plugin_class->cleanup = fu_gpio_plugin_cleanup;

--- a/plugins/hailuck/fu-hailuck-plugin.c
+++ b/plugins/hailuck/fu-hailuck-plugin.c
@@ -34,6 +34,6 @@ fu_hailuck_plugin_constructed(GObject *obj)
 static void
 fu_hailuck_plugin_class_init(FuHailuckPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_hailuck_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_hailuck_plugin_constructed;
 }

--- a/plugins/intel-gsc/fu-igsc-plugin.c
+++ b/plugins/intel-gsc/fu-igsc-plugin.c
@@ -37,6 +37,6 @@ fu_igsc_constructed(GObject *obj)
 static void
 fu_igsc_plugin_class_init(FuIgscPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_igsc_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_igsc_constructed;
 }

--- a/plugins/intel-me/fu-intel-me-plugin.c
+++ b/plugins/intel-me/fu-intel-me-plugin.c
@@ -35,6 +35,6 @@ fu_intel_me_plugin_constructed(GObject *obj)
 static void
 fu_intel_me_plugin_class_init(FuIntelMePluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_intel_me_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_intel_me_plugin_constructed;
 }

--- a/plugins/intel-spi/fu-intel-spi-plugin.c
+++ b/plugins/intel-spi/fu-intel-spi-plugin.c
@@ -50,8 +50,6 @@ static void
 fu_intel_spi_plugin_class_init(FuIntelSpiPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_intel_spi_plugin_constructed;
+	plugin_class->constructed = fu_intel_spi_plugin_constructed;
 	plugin_class->startup = fu_intel_spi_plugin_startup;
 }

--- a/plugins/intel-usb4/fu-intel-usb4-plugin.c
+++ b/plugins/intel-usb4/fu-intel-usb4-plugin.c
@@ -62,7 +62,6 @@ static void
 fu_intel_usb4_plugin_class_init(FuIntelUsb4PluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_intel_usb4_plugin_constructed;
+	plugin_class->constructed = fu_intel_usb4_plugin_constructed;
 	plugin_class->device_registered = fu_intel_usb4_plugin_device_registered;
 }

--- a/plugins/iommu/fu-iommu-plugin.c
+++ b/plugins/iommu/fu-iommu-plugin.c
@@ -92,9 +92,7 @@ static void
 fu_iommu_plugin_class_init(FuIommuPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_iommu_plugin_constructed;
+	plugin_class->constructed = fu_iommu_plugin_constructed;
 	plugin_class->to_string = fu_iommu_plugin_to_string;
 	plugin_class->backend_device_added = fu_iommu_plugin_backend_device_added;
 	plugin_class->add_security_attrs = fu_iommu_plugin_add_security_attrs;

--- a/plugins/jabra/fu-jabra-plugin.c
+++ b/plugins/jabra/fu-jabra-plugin.c
@@ -70,7 +70,6 @@ static void
 fu_jabra_plugin_class_init(FuJabraPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_jabra_plugin_constructed;
+	plugin_class->constructed = fu_jabra_plugin_constructed;
 	plugin_class->cleanup = fu_jabra_plugin_cleanup;
 }

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
@@ -30,6 +30,6 @@ fu_logitech_bulkcontroller_plugin_constructed(GObject *obj)
 static void
 fu_logitech_bulkcontroller_plugin_class_init(FuLogitechBulkcontrollerPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_logitech_bulkcontroller_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_logitech_bulkcontroller_plugin_constructed;
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -43,6 +43,6 @@ fu_logitech_hidpp_plugin_constructed(GObject *obj)
 static void
 fu_logitech_hidpp_plugin_class_init(FuLogitechHidppPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_logitech_hidpp_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_logitech_hidpp_plugin_constructed;
 }

--- a/plugins/logitech-scribe/fu-logitech-scribe-plugin.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-plugin.c
@@ -31,6 +31,6 @@ fu_logitech_scribe_plugin_constructed(GObject *obj)
 static void
 fu_logitech_scribe_plugin_class_init(FuLogitechScribePluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_logitech_scribe_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_logitech_scribe_plugin_constructed;
 }

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -518,9 +518,7 @@ static void
 fu_msr_plugin_class_init(FuMsrPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_msr_plugin_constructed;
+	plugin_class->constructed = fu_msr_plugin_constructed;
 	plugin_class->to_string = fu_msr_plugin_to_string;
 	plugin_class->startup = fu_msr_plugin_startup;
 	plugin_class->backend_device_added = fu_msr_plugin_backend_device_added;

--- a/plugins/mtd/fu-mtd-plugin.c
+++ b/plugins/mtd/fu-mtd-plugin.c
@@ -45,7 +45,6 @@ static void
 fu_mtd_plugin_class_init(FuMtdPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_mtd_plugin_constructed;
+	plugin_class->constructed = fu_mtd_plugin_constructed;
 	plugin_class->startup = fu_mtd_plugin_startup;
 }

--- a/plugins/nitrokey/fu-nitrokey-plugin.c
+++ b/plugins/nitrokey/fu-nitrokey-plugin.c
@@ -30,6 +30,6 @@ fu_nitrokey_plugin_constructed(GObject *obj)
 static void
 fu_nitrokey_plugin_class_init(FuNitrokeyPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_nitrokey_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_nitrokey_plugin_constructed;
 }

--- a/plugins/nordic-hid/fu-nordic-hid-plugin.c
+++ b/plugins/nordic-hid/fu-nordic-hid-plugin.c
@@ -39,6 +39,6 @@ fu_nordic_hid_plugin_constructed(GObject *obj)
 static void
 fu_nordic_hid_plugin_class_init(FuNordicHidPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_nordic_hid_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_nordic_hid_plugin_constructed;
 }

--- a/plugins/nvme/fu-nvme-plugin.c
+++ b/plugins/nvme/fu-nvme-plugin.c
@@ -31,6 +31,6 @@ fu_nvme_plugin_constructed(GObject *obj)
 static void
 fu_nvme_plugin_class_init(FuNvmePluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_nvme_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_nvme_plugin_constructed;
 }

--- a/plugins/optionrom/fu-optionrom-plugin.c
+++ b/plugins/optionrom/fu-optionrom-plugin.c
@@ -32,6 +32,6 @@ fu_optionrom_plugin_constructed(GObject *obj)
 static void
 fu_optionrom_plugin_class_init(FuOptionromPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_optionrom_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_optionrom_plugin_constructed;
 }

--- a/plugins/parade-lspcon/fu-parade-lspcon-plugin.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-plugin.c
@@ -33,6 +33,6 @@ fu_parade_lspcon_plugin_constructed(GObject *obj)
 static void
 fu_parade_lspcon_plugin_class_init(FuParadeLspconPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_parade_lspcon_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_parade_lspcon_plugin_constructed;
 }

--- a/plugins/pci-bcr/fu-pci-bcr-plugin.c
+++ b/plugins/pci-bcr/fu-pci-bcr-plugin.c
@@ -237,8 +237,7 @@ static void
 fu_pci_bcr_plugin_class_init(FuPciBcrPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_pci_bcr_plugin_constructed;
+	plugin_class->constructed = fu_pci_bcr_plugin_constructed;
 	plugin_class->to_string = fu_pci_bcr_plugin_to_string;
 	plugin_class->add_security_attrs = fu_pci_bcr_plugin_add_security_attrs;
 	plugin_class->device_registered = fu_pci_bcr_plugin_device_registered;

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -577,8 +577,8 @@ fu_pci_mei_plugin_class_init(FuPciMeiPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_pci_mei_plugin_constructed;
 	object_class->finalize = fu_pci_mei_finalize;
+	plugin_class->constructed = fu_pci_mei_plugin_constructed;
 	plugin_class->to_string = fu_pci_mei_plugin_to_string;
 	plugin_class->add_security_attrs = fu_pci_mei_plugin_add_security_attrs;
 	plugin_class->backend_device_added = fu_pci_mei_plugin_backend_device_added;

--- a/plugins/pci-psp/fu-pci-psp-plugin.c
+++ b/plugins/pci-psp/fu-pci-psp-plugin.c
@@ -31,6 +31,6 @@ fu_pci_psp_plugin_constructed(GObject *obj)
 static void
 fu_pci_psp_plugin_class_init(FuPciPspPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_pci_psp_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_pci_psp_plugin_constructed;
 }

--- a/plugins/pixart-rf/fu-pxi-plugin.c
+++ b/plugins/pixart-rf/fu-pxi-plugin.c
@@ -23,10 +23,16 @@ fu_pxi_plugin_init(FuPxiPlugin *self)
 }
 
 static void
-fu_pxi_plugin_constructed(GObject *obj)
+fu_pxi_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "pixart_rf");
+}
+
+static void
+fu_pxi_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PXI_BLE_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PXI_RECEIVER_DEVICE);
@@ -36,6 +42,8 @@ fu_pxi_plugin_constructed(GObject *obj)
 static void
 fu_pxi_plugin_class_init(FuPxiPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_pxi_plugin_constructed;
+	object_class->constructed = fu_pxi_plugin_object_constructed;
+	plugin_class->constructed = fu_pxi_plugin_constructed;
 }

--- a/plugins/qsi-dock/fu-qsi-dock-plugin.c
+++ b/plugins/qsi-dock/fu-qsi-dock-plugin.c
@@ -31,6 +31,6 @@ fu_qsi_dock_plugin_constructed(GObject *obj)
 static void
 fu_qsi_dock_plugin_class_init(FuQsiDockPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_qsi_dock_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_qsi_dock_plugin_constructed;
 }

--- a/plugins/realtek-mst/fu-realtek-mst-plugin.c
+++ b/plugins/realtek-mst/fu-realtek-mst-plugin.c
@@ -34,6 +34,6 @@ fu_realtek_mst_plugin_constructed(GObject *obj)
 static void
 fu_realtek_mst_plugin_class_init(FuRealtekMstPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_realtek_mst_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_realtek_mst_plugin_constructed;
 }

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -616,7 +616,8 @@ fu_redfish_finalize(GObject *obj)
 	FuRedfishPlugin *self = FU_REDFISH_PLUGIN(obj);
 	if (self->smbios != NULL)
 		g_object_unref(self->smbios);
-	g_object_unref(self->backend);
+	if (self->backend != NULL)
+		g_object_unref(self->backend);
 	G_OBJECT_CLASS(fu_redfish_plugin_parent_class)->finalize(obj);
 }
 
@@ -626,8 +627,8 @@ fu_redfish_plugin_class_init(FuRedfishPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_redfish_plugin_constructed;
 	object_class->finalize = fu_redfish_finalize;
+	plugin_class->constructed = fu_redfish_plugin_constructed;
 	plugin_class->to_string = fu_redfish_plugin_to_string;
 	plugin_class->startup = fu_redfish_plugin_startup;
 	plugin_class->coldplug = fu_redfish_plugin_coldplug;

--- a/plugins/rts54hid/fu-rts54hid-plugin.c
+++ b/plugins/rts54hid/fu-rts54hid-plugin.c
@@ -22,6 +22,13 @@ fu_rts54hid_plugin_init(FuRts54HidPlugin *self)
 }
 
 static void
+fu_rts54hid_plugin_object_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_set_name(plugin, "rts54hid");
+}
+
+static void
 fu_rts54hid_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
@@ -29,7 +36,6 @@ fu_rts54hid_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "Rts54TargetAddr");
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
-	fu_plugin_set_name(plugin, "rts54hid");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HID_MODULE);
 }
@@ -37,6 +43,8 @@ fu_rts54hid_plugin_constructed(GObject *obj)
 static void
 fu_rts54hid_plugin_class_init(FuRts54HidPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_rts54hid_plugin_constructed;
+	object_class->constructed = fu_rts54hid_plugin_object_constructed;
+	plugin_class->constructed = fu_rts54hid_plugin_constructed;
 }

--- a/plugins/rts54hub/fu-rts54hub-plugin.c
+++ b/plugins/rts54hub/fu-rts54hub-plugin.c
@@ -23,6 +23,13 @@ fu_rts54hub_plugin_init(FuRts54HubPlugin *self)
 }
 
 static void
+fu_rts54hub_plugin_object_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_set_name(plugin, "rts54hub");
+}
+
+static void
 fu_rts54hub_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
@@ -30,7 +37,6 @@ fu_rts54hub_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "Rts54TargetAddr");
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
-	fu_plugin_set_name(plugin, "rts54hub");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_BACKGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_FOREGROUND);
@@ -39,6 +45,8 @@ fu_rts54hub_plugin_constructed(GObject *obj)
 static void
 fu_rts54hub_plugin_class_init(FuRts54HubPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_rts54hub_plugin_constructed;
+	object_class->constructed = fu_rts54hub_plugin_object_constructed;
+	plugin_class->constructed = fu_rts54hub_plugin_constructed;
 }

--- a/plugins/scsi/fu-scsi-plugin.c
+++ b/plugins/scsi/fu-scsi-plugin.c
@@ -31,6 +31,6 @@ fu_scsi_plugin_constructed(GObject *obj)
 static void
 fu_scsi_plugin_class_init(FuScsiPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_scsi_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_scsi_plugin_constructed;
 }

--- a/plugins/steelseries/fu-steelseries-plugin.c
+++ b/plugins/steelseries/fu-steelseries-plugin.c
@@ -42,6 +42,6 @@ fu_steelseries_plugin_constructed(GObject *obj)
 static void
 fu_steelseries_plugin_class_init(FuSteelseriesPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_steelseries_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_steelseries_plugin_constructed;
 }

--- a/plugins/superio/fu-superio-plugin.c
+++ b/plugins/superio/fu-superio-plugin.c
@@ -129,8 +129,6 @@ static void
 fu_superio_plugin_class_init(FuSuperioPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_superio_plugin_constructed;
+	plugin_class->constructed = fu_superio_plugin_constructed;
 	plugin_class->coldplug = fu_superio_plugin_coldplug;
 }

--- a/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
@@ -32,6 +32,6 @@ fu_synaptics_cape_plugin_constructed(GObject *obj)
 static void
 fu_synaptics_cape_plugin_class_init(FuSynapticsCapePluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_synaptics_cape_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_synaptics_cape_plugin_constructed;
 }

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
@@ -37,6 +37,6 @@ fu_synaptics_cxaudio_plugin_constructed(GObject *obj)
 static void
 fu_synaptics_cxaudio_plugin_class_init(FuSynapticsCxaudioPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_synaptics_cxaudio_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_synaptics_cxaudio_plugin_constructed;
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -177,8 +177,8 @@ fu_synaptics_mst_plugin_class_init(FuSynapticsMstPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_synaptics_mst_plugin_constructed;
 	object_class->finalize = fu_synaptics_mst_finalize;
+	plugin_class->constructed = fu_synaptics_mst_plugin_constructed;
 	plugin_class->write_firmware = fu_synaptics_mst_plugin_write_firmware;
 	plugin_class->backend_device_added = fu_synaptics_mst_plugin_backend_device_added;
 	plugin_class->backend_device_changed = fu_synaptics_mst_plugin_backend_device_changed;

--- a/plugins/synaptics-prometheus/fu-synaprom-plugin.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-plugin.c
@@ -22,10 +22,16 @@ fu_synaprom_plugin_init(FuSynapromPlugin *self)
 }
 
 static void
-fu_synaprom_plugin_constructed(GObject *obj)
+fu_synaprom_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "synaptics_prometheus");
+}
+
+static void
+fu_synaprom_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPROM_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPROM_FIRMWARE);
 }
@@ -33,6 +39,8 @@ fu_synaprom_plugin_constructed(GObject *obj)
 static void
 fu_synaprom_plugin_class_init(FuSynapromPluginClass *klass)
 {
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_synaprom_plugin_constructed;
+	object_class->constructed = fu_synaprom_plugin_object_constructed;
+	plugin_class->constructed = fu_synaprom_plugin_constructed;
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
@@ -36,6 +36,6 @@ fu_synaptics_rmi_plugin_constructed(GObject *obj)
 static void
 fu_synaptics_rmi_plugin_class_init(FuSynapticsRmiPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_synaptics_rmi_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_synaptics_rmi_plugin_constructed;
 }

--- a/plugins/system76-launch/fu-system76-launch-plugin.c
+++ b/plugins/system76-launch/fu-system76-launch-plugin.c
@@ -31,6 +31,6 @@ fu_system76_launch_plugin_constructed(GObject *obj)
 static void
 fu_system76_launch_plugin_class_init(FuSystem76LaunchPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_system76_launch_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_system76_launch_plugin_constructed;
 }

--- a/plugins/test/fu-test-ble-plugin.c
+++ b/plugins/test/fu-test-ble-plugin.c
@@ -30,6 +30,6 @@ fu_test_ble_plugin_constructed(GObject *obj)
 static void
 fu_test_ble_plugin_class_init(FuTestBlePluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_test_ble_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_test_ble_plugin_constructed;
 }

--- a/plugins/thelio-io/fu-thelio-io-plugin.c
+++ b/plugins/thelio-io/fu-thelio-io-plugin.c
@@ -31,6 +31,6 @@ fu_thelio_io_plugin_constructed(GObject *obj)
 static void
 fu_thelio_io_plugin_class_init(FuThelioIoPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_thelio_io_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_thelio_io_plugin_constructed;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -114,9 +114,7 @@ static void
 fu_thunderbolt_plugin_class_init(FuThunderboltPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_thunderbolt_plugin_constructed;
+	plugin_class->constructed = fu_thunderbolt_plugin_constructed;
 	plugin_class->startup = fu_thunderbolt_plugin_startup;
 	plugin_class->device_registered = fu_thunderbolt_plugin_device_registered;
 	plugin_class->device_created = fu_thunderbolt_plugin_device_created;

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
@@ -33,6 +33,6 @@ fu_ti_tps6598x_plugin_constructed(GObject *obj)
 static void
 fu_ti_tps6598x_plugin_class_init(FuTiTps6598xPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_ti_tps6598x_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_ti_tps6598x_plugin_constructed;
 }

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -388,8 +388,8 @@ fu_tpm_plugin_class_init(FuTpmPluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_tpm_plugin_constructed;
 	object_class->finalize = fu_tpm_finalize;
+	plugin_class->constructed = fu_tpm_plugin_constructed;
 	plugin_class->to_string = fu_tpm_plugin_to_string;
 	plugin_class->startup = fu_tpm_plugin_startup;
 	plugin_class->coldplug = fu_tpm_plugin_coldplug;

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1033,8 +1033,10 @@ fu_uefi_capsule_finalize(GObject *obj)
 		g_file_monitor_cancel(self->fwupd_efi_monitor);
 		g_object_unref(self->fwupd_efi_monitor);
 	}
-	g_object_unref(self->backend);
-	g_object_unref(self->bgrt);
+	if (self->backend != NULL)
+		g_object_unref(self->backend);
+	if (self->bgrt != NULL)
+		g_object_unref(self->bgrt);
 	G_OBJECT_CLASS(fu_uefi_capsule_plugin_parent_class)->finalize(obj);
 }
 
@@ -1044,8 +1046,8 @@ fu_uefi_capsule_plugin_class_init(FuUefiCapsulePluginClass *klass)
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	object_class->constructed = fu_uefi_capsule_plugin_constructed;
 	object_class->finalize = fu_uefi_capsule_finalize;
+	plugin_class->constructed = fu_uefi_capsule_plugin_constructed;
 	plugin_class->to_string = fu_uefi_capsule_plugin_to_string;
 	plugin_class->clear_results = fu_uefi_capsule_plugin_clear_results;
 	plugin_class->add_security_attrs = fu_uefi_capsule_plugin_add_security_attrs;

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -60,8 +60,6 @@ static void
 fu_uefi_dbx_plugin_class_init(FuUefiDbxPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_uefi_dbx_plugin_constructed;
+	plugin_class->constructed = fu_uefi_dbx_plugin_constructed;
 	plugin_class->coldplug = fu_uefi_dbx_plugin_coldplug;
 }

--- a/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
+++ b/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
@@ -72,9 +72,8 @@ fu_uefi_recovery_plugin_init(FuUefiRecoveryPlugin *self)
 static void
 fu_uefi_recovery_plugin_class_init(FuUefiRecoveryPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	object_class->constructed = fu_uefi_recovery_plugin_constructed;
+	plugin_class->constructed = fu_uefi_recovery_plugin_constructed;
 	plugin_class->coldplug = fu_uefi_recovery_plugin_coldplug;
 	plugin_class->startup = fu_uefi_recovery_plugin_startup;
 }

--- a/plugins/uf2/fu-uf2-plugin.c
+++ b/plugins/uf2/fu-uf2-plugin.c
@@ -33,6 +33,6 @@ fu_uf2_plugin_constructed(GObject *obj)
 static void
 fu_uf2_plugin_class_init(FuUf2PluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_uf2_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_uf2_plugin_constructed;
 }

--- a/plugins/usi-dock/fu-usi-dock-plugin.c
+++ b/plugins/usi-dock/fu-usi-dock-plugin.c
@@ -49,7 +49,6 @@ static void
 fu_usi_dock_plugin_class_init(FuUsiDockPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_usi_dock_plugin_constructed;
+	plugin_class->constructed = fu_usi_dock_plugin_constructed;
 	plugin_class->device_registered = fu_usi_dock_plugin_dmc_registered;
 }

--- a/plugins/vendor-example/fu-vendor-example-plugin.c.in
+++ b/plugins/vendor-example/fu-vendor-example-plugin.c.in
@@ -34,6 +34,6 @@ fu_{{vendor}}_{{example}}_plugin_constructed(GObject *obj)
 static void
 fu_{{vendor}}_{{example}}_plugin_class_init(Fu{{Vendor}}{{Example}}PluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_{{vendor}}_{{example}}_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_{{vendor}}_{{example}}_plugin_constructed;
 }

--- a/plugins/vli/fu-vli-plugin.c
+++ b/plugins/vli/fu-vli-plugin.c
@@ -39,6 +39,6 @@ fu_vli_plugin_constructed(GObject *obj)
 static void
 fu_vli_plugin_class_init(FuVliPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_vli_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_vli_plugin_constructed;
 }

--- a/plugins/wacom-raw/fu-wacom-raw-plugin.c
+++ b/plugins/wacom-raw/fu-wacom-raw-plugin.c
@@ -38,6 +38,6 @@ fu_wacom_raw_plugin_constructed(GObject *obj)
 static void
 fu_wacom_raw_plugin_class_init(FuWacomRawPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_wacom_raw_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_wacom_raw_plugin_constructed;
 }

--- a/plugins/wacom-usb/fu-wac-plugin.c
+++ b/plugins/wacom-usb/fu-wac-plugin.c
@@ -39,10 +39,16 @@ fu_wac_plugin_init(FuWacPlugin *self)
 }
 
 static void
-fu_wac_plugin_constructed(GObject *obj)
+fu_wac_plugin_object_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_name(plugin, "wacom_usb");
+}
+
+static void
+fu_wac_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_ANDROID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, "wacom", FU_TYPE_WAC_FIRMWARE);
@@ -53,7 +59,7 @@ fu_wac_plugin_class_init(FuWacPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-
-	object_class->constructed = fu_wac_plugin_constructed;
+	object_class->constructed = fu_wac_plugin_object_constructed;
+	plugin_class->constructed = fu_wac_plugin_constructed;
 	plugin_class->write_firmware = fu_wac_plugin_write_firmware;
 }

--- a/plugins/wistron-dock/fu-wistron-dock-plugin.c
+++ b/plugins/wistron-dock/fu-wistron-dock-plugin.c
@@ -30,6 +30,6 @@ fu_wistron_dock_plugin_constructed(GObject *obj)
 static void
 fu_wistron_dock_plugin_class_init(FuWistronDockPluginClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_wistron_dock_plugin_constructed;
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_wistron_dock_plugin_constructed;
 }


### PR DESCRIPTION
When we switched all the plugins to GObjectClass->constructed this meant that they all added firwmare GTypes and udev subsystems unconditionally, rather than only when the plugin is enabled. Switch to the almost-identical FuPluginClass->constructed vfunc which is only called if the plugin is enabled.

This makes debugging way easier as there's less debug output.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
