### PR TITLE
Tag releases with an extra flag if they have a report we trust

### DIFF
--- a/data/daemon.conf
+++ b/data/daemon.conf
@@ -58,6 +58,23 @@ AllowEmulation=false
 # UIDs that should marked as trusted
 TrustedUids=
 
+# Vendor reports matching these globs will have releases marked as `trusted-report`, e.g.
+#
+# * `DistroId=chromeos`
+# * `DistroId=fedora&VendorId=19`
+# * `DistroId=fedora&VendorId=$OEM`
+# * `DistroId=fedora;DistroId=rhel&DistroVersion=9`
+#
+# NOTE: a `VendorId` of `$OEM` represents the OEM vendor ID of the vendor that owns the firmware,
+# for example, where Lenovo QA has generated a signed report for a Lenovo laptop.
+#
+# There are also three os-release values available, `$ID`, `$VERSION_ID` and `$VARIANT_ID`, which
+# allow globs like:
+#
+# * `DistroId=$ID`
+# * `DistroId=$ID,DistroVersion=$VERSION_ID`
+TrustedReports=VendorId=$OEM
+
 # A host best known configuration is used when using `fwupdmgr sync` which can
 # downgrade firmware to factory versions or upgrade firmware to a supported
 # config level. e.g. `vendor-factory-2021q1`

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -770,6 +770,8 @@ fwupd_release_flag_to_string(FwupdReleaseFlags release_flag)
 		return "is-alternate-branch";
 	if (release_flag == FWUPD_RELEASE_FLAG_IS_COMMUNITY)
 		return "is-community";
+	if (release_flag == FWUPD_RELEASE_FLAG_TRUSTED_REPORT)
+		return "trusted-report";
 	return NULL;
 }
 
@@ -802,6 +804,8 @@ fwupd_release_flag_from_string(const gchar *release_flag)
 		return FWUPD_RELEASE_FLAG_IS_ALTERNATE_BRANCH;
 	if (g_strcmp0(release_flag, "is-community") == 0)
 		return FWUPD_RELEASE_FLAG_IS_COMMUNITY;
+	if (g_strcmp0(release_flag, "trusted-report") == 0)
+		return FWUPD_RELEASE_FLAG_TRUSTED_REPORT;
 	return FWUPD_RELEASE_FLAG_NONE;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -738,6 +738,14 @@ typedef guint64 FwupdDeviceProblem;
  */
 #define FWUPD_RELEASE_FLAG_IS_COMMUNITY (1llu << 7)
 /**
+ * FWUPD_RELEASE_FLAG_TRUSTED_REPORT:
+ *
+ * The payload has been tested by a report we trust.
+ *
+ * Since: 1.9.1
+ */
+#define FWUPD_RELEASE_FLAG_TRUSTED_REPORT (1llu << 8)
+/**
  * FWUPD_RELEASE_FLAG_UNKNOWN:
  *
  * The release flag is unknown, typically caused by using mismatched client and daemon.

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -192,7 +192,7 @@ fwupd_enums_func(void)
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_feature_flag_from_string(tmp), ==, i);
 	}
-	for (guint64 i = 1; i <= FWUPD_RELEASE_FLAG_IS_COMMUNITY; i *= 2) {
+	for (guint64 i = 1; i <= FWUPD_RELEASE_FLAG_TRUSTED_REPORT; i *= 2) {
 		const gchar *tmp = fwupd_release_flag_to_string(i);
 		if (tmp == NULL)
 			g_warning("missing release flag 0x%x", (guint)i);

--- a/src/fu-config.h
+++ b/src/fu-config.h
@@ -29,6 +29,8 @@ fu_config_get_disabled_plugins(FuConfig *self);
 GArray *
 fu_config_get_trusted_uids(FuConfig *self);
 GPtrArray *
+fu_config_get_trusted_reports(FuConfig *self);
+GPtrArray *
 fu_config_get_approved_firmware(FuConfig *self);
 GPtrArray *
 fu_config_get_blocked_firmware(FuConfig *self);

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -17,9 +17,11 @@ G_DECLARE_FINAL_TYPE(FuRelease, fu_release, FU, RELEASE, FwupdRelease)
 FuRelease *
 fu_release_new(void);
 
+#define fu_release_get_appstream_id(r) fwupd_release_get_appstream_id(FWUPD_RELEASE(r))
 #define fu_release_get_version(r)     fwupd_release_get_version(FWUPD_RELEASE(r))
 #define fu_release_get_branch(r)      fwupd_release_get_branch(FWUPD_RELEASE(r))
 #define fu_release_get_checksums(r)   fwupd_release_get_checksums(FWUPD_RELEASE(r))
+#define fu_release_get_reports(r)      fwupd_release_get_reports(FWUPD_RELEASE(r))
 #define fu_release_get_flags(r)	      fwupd_release_get_flags(FWUPD_RELEASE(r))
 #define fu_release_add_flag(r, v)     fwupd_release_add_flag(FWUPD_RELEASE(r), v)
 #define fu_release_has_flag(r, v)     fwupd_release_has_flag(FWUPD_RELEASE(r), v)

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1413,6 +1413,7 @@ static void
 fu_engine_device_unlock_func(gconstpointer user_data)
 {
 	FuTest *self = (FuTest *)user_data;
+	FwupdRelease *rel;
 	gboolean ret;
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
@@ -1451,7 +1452,9 @@ fu_engine_device_unlock_func(gconstpointer user_data)
 	fu_engine_add_device(engine, device);
 
 	/* ensure the metainfo was matched */
-	g_assert_nonnull(fwupd_device_get_release_default(FWUPD_DEVICE(device)));
+	rel = fwupd_device_get_release_default(FWUPD_DEVICE(device));
+	g_assert_nonnull(rel);
+	g_assert_false(fwupd_release_has_flag(rel, FWUPD_RELEASE_FLAG_TRUSTED_REPORT));
 }
 
 static void
@@ -4393,6 +4396,116 @@ fu_release_uri_scheme_func(void)
 }
 
 static void
+fu_release_trusted_report_func(gconstpointer user_data)
+{
+	FuTest *self = (FuTest *)user_data;
+	FwupdRelease *rel;
+	gboolean ret;
+	g_autofree gchar *filename = NULL;
+	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
+	g_autoptr(FuEngine) engine = fu_engine_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GFile) file = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new();
+	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(GPtrArray) releases = NULL;
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+
+	/* load engine to get FuConfig set up */
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* metadata with vendor id=123 */
+	filename = g_test_build_filename(G_TEST_DIST, "tests", "metadata-report1.xml", NULL);
+	file = g_file_new_for_path(filename);
+	ret = xb_builder_source_load_file(source, file, XB_BUILDER_SOURCE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	xb_builder_import_source(builder, source);
+	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+	fu_engine_set_silo(engine, silo);
+
+	/* add a dummy device */
+	fu_device_set_id(device, "dummy");
+	fu_device_set_version(device, "1.2.2");
+	fu_device_add_vendor_id(device, "USB:FFFF");
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_protocol(device, "com.acme");
+	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_engine_add_device(engine, device);
+
+	/* ensure we set this as trusted */
+	releases = fu_engine_get_releases_for_device(engine, request, device, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(releases);
+	g_assert_cmpint(releases->len, ==, 1);
+	rel = g_ptr_array_index(releases, 0);
+	g_assert_true(fwupd_release_has_flag(rel, FWUPD_RELEASE_FLAG_TRUSTED_REPORT));
+}
+
+static void
+fu_release_trusted_report_oem_func(gconstpointer user_data)
+{
+	FuTest *self = (FuTest *)user_data;
+	FwupdRelease *rel;
+	gboolean ret;
+	g_autofree gchar *filename = NULL;
+	g_autoptr(FuDevice) device = fu_device_new(self->ctx);
+	g_autoptr(FuEngine) engine = fu_engine_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GFile) file = NULL;
+	g_autoptr(XbBuilder) builder = xb_builder_new();
+	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(GPtrArray) releases = NULL;
+	g_autoptr(FuEngineRequest) request = fu_engine_request_new();
+
+	/* load engine to get FuConfig set up */
+	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* metadata with FromOEM */
+	filename = g_test_build_filename(G_TEST_DIST, "tests", "metadata-report2.xml", NULL);
+	file = g_file_new_for_path(filename);
+	ret = xb_builder_source_load_file(source, file, XB_BUILDER_SOURCE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	xb_builder_import_source(builder, source);
+	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(silo);
+	fu_engine_set_silo(engine, silo);
+
+	/* add a dummy device */
+	fu_device_set_id(device, "dummy");
+	fu_device_set_version(device, "1.2.2");
+	fu_device_add_vendor_id(device, "USB:FFFF");
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_protocol(device, "com.acme");
+	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_engine_add_device(engine, device);
+
+	/* ensure we set this as trusted */
+	releases = fu_engine_get_releases_for_device(engine, request, device, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(releases);
+	g_assert_cmpint(releases->len, ==, 1);
+	rel = g_ptr_array_index(releases, 0);
+	g_assert_true(fwupd_release_has_flag(rel, FWUPD_RELEASE_FLAG_TRUSTED_REPORT));
+}
+
+static void
 fu_common_store_cab_func(void)
 {
 	GBytes *blob_tmp;
@@ -5070,6 +5183,12 @@ main(int argc, char **argv)
 			     fu_device_list_remove_chain_func);
 	g_test_add_data_func("/fwupd/release{compare}", self, fu_release_compare_func);
 	g_test_add_func("/fwupd/release{uri-scheme}", fu_release_uri_scheme_func);
+	g_test_add_data_func("/fwupd/release{trusted-report}",
+			     self,
+			     fu_release_trusted_report_func);
+	g_test_add_data_func("/fwupd/release{trusted-report-oem}",
+			     self,
+			     fu_release_trusted_report_oem_func);
 	g_test_add_data_func("/fwupd/engine{get-details-added}",
 			     self,
 			     fu_engine_get_details_added_func);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1745,6 +1745,10 @@ fu_util_release_flag_to_string(FwupdReleaseFlags release_flag)
 		/* TRANSLATORS: is not supported by the vendor */
 		return _("Community supported");
 	}
+	if (release_flag == FWUPD_RELEASE_FLAG_TRUSTED_REPORT) {
+		/* TRANSLATORS: someone we trust has tested this */
+		return _("Tested by trusted vendor");
+	}
 
 	/* fall back for unknown types */
 	return fwupd_release_flag_to_string(release_flag);

--- a/src/tests/daemon.conf
+++ b/src/tests/daemon.conf
@@ -1,2 +1,3 @@
 [fwupd]
 DisabledPlugins=
+TrustedReports=VendorId=123&DistroId=fedora&DistroVariant=workstation;VendorId=$OEM&DistroId=chromeos

--- a/src/tests/metadata-report1.xml
+++ b/src/tests/metadata-report1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<components version="0.9" origin="fwupd">
+  <component type="firmware">
+    <id>org.fwupd.something.device</id>
+    <provides>
+      <firmware type="flashed">2d47f29b-83a2-4f31-a2e8-63474f4d4c2e</firmware>
+    </provides>
+    <releases>
+      <release version="1.2.3">
+        <description><p>Applying will enable UEFI firmware reporting</p></description>
+        <artifacts>
+          <artifact type="binary">
+            <location>https://fwupd.org/something.cab</location>
+            <checksum type="sha256">0628376cb0583335a7ff5875dd2d4b09fc5653057f644783a477553ca9981dcd</checksum>
+            <testing>
+              <test_result date="2021-07-15">
+                <vendor_name id="123">Hughski</vendor_name>
+                <device>LENOVO ThinkPad X1 Carbon 7th</device>
+                <os version="34" variant="workstation">fedora</os>
+                <previous_version>1.2.6</previous_version>
+                <custom>
+                  <value key="RuntimeVersion(org.freedesktop.fwupd)">1.6.2</value>
+                </custom>
+              </test_result>
+            </testing>
+          </artifact>
+        </artifacts>
+      </release>
+    </releases>
+  </component>
+</components>

--- a/src/tests/metadata-report2.xml
+++ b/src/tests/metadata-report2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<components version="0.9" origin="fwupd">
+  <component type="firmware">
+    <id>org.fwupd.something.device</id>
+    <provides>
+      <firmware type="flashed">2d47f29b-83a2-4f31-a2e8-63474f4d4c2e</firmware>
+    </provides>
+    <releases>
+      <release version="1.2.3">
+        <description><p>Applying will enable UEFI firmware reporting</p></description>
+        <artifacts>
+          <artifact type="binary">
+            <location>https://fwupd.org/something.cab</location>
+            <checksum type="sha256">0628376cb0583335a7ff5875dd2d4b09fc5653057f644783a477553ca9981dcd</checksum>
+            <testing>
+              <test_result date="2021-07-15">
+                <vendor_name id="9999">Google</vendor_name>
+                <device>ChromeBook</device>
+                <os version="102">chromeos</os>
+                <custom>
+                  <value key="RuntimeVersion(org.freedesktop.fwupd)">1.9.1</value>
+                  <value key="FromOEM" />
+                </custom>
+              </test_result>
+            </testing>
+          </artifact>
+        </artifacts>
+      </release>
+    </releases>
+  </component>
+</components>


### PR DESCRIPTION
For instance, this could be used to only show a desktop notification if the report has been verified to work on ChromeOS, or to only auto-install the update on an automotive system if tested by Red Hat QA.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
