### PR TITLE
Allow setting device flags in the metadata

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -245,6 +245,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "no-probe-complete";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE)
 		return "save-into-backup-remote";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS)
+		return "md-set-flags";
 	return NULL;
 }
 
@@ -319,6 +321,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE;
 	if (g_strcmp0(flag, "save-into-backup-remote") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE;
+	if (g_strcmp0(flag, "md-set-flags") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 
@@ -5348,6 +5352,17 @@ fu_device_ensure_from_component_icon(FuDevice *self, XbNode *component)
 	}
 }
 
+static void
+fu_device_ensure_from_component_flags(FuDevice *self, XbNode *component)
+{
+	const gchar *tmp =
+	    xb_node_query_text(component, "custom/value[@key='LVFS::DeviceFlags']", NULL);
+	if (tmp != NULL) {
+		fu_device_set_custom_flag(self, tmp);
+		fu_device_remove_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS);
+	}
+}
+
 static const gchar *
 fu_device_category_to_name(const gchar *cat)
 {
@@ -5519,6 +5534,8 @@ fu_device_ensure_from_component(FuDevice *self, XbNode *component)
 		fu_device_ensure_from_component_signed(self, component);
 	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT))
 		fu_device_ensure_from_component_verfmt(self, component);
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS))
+		fu_device_ensure_from_component_flags(self, component);
 }
 
 /**

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -507,6 +507,18 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_SAVE_INTO_BACKUP_REMOTE (1ull << 28)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS:
+ *
+ * Set the device flags from the metadata if available.
+ *
+ * NOTE: These flags should only affect device update, and should never be used to affect
+ * enumeration.
+ *
+ * Since: 1.9.1
+ */
+#define FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS (1ull << 29)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -1083,6 +1083,13 @@ fu_release_ensure_trust_flags(FuRelease *self, XbNode *rel, GError **error)
 	g_return_val_if_fail(FU_IS_RELEASE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	/* in the self tests */
+	if (g_getenv("FWUPD_SELF_TEST") != NULL) {
+		fu_release_add_flag(self, FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD);
+		fu_release_add_flag(self, FWUPD_RELEASE_FLAG_TRUSTED_METADATA);
+		return TRUE;
+	}
+
 	/* populated from an actual cab archive */
 	blob = g_object_get_data(G_OBJECT(rel), "fwupd::ReleaseFlags");
 	if (blob != NULL) {


### PR DESCRIPTION
NOTE: This can only be used to affect device write, not device enumeration.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
