### PR TITLE
fix uefi-capsule build with compat_cli enabled

### DIFF
--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -58,7 +58,7 @@ plugin_builtins += plugin_builtin_uefi_capsule
 if get_option('compat_cli')
 fwupdate = executable(
   'fwupdate',
-  structgen.process('fu-acpi-uefi.struct'),
+  structgen.process('fu-uefi.struct'),
   sources: [
     'fu-uefi-tool.c',
   ],


### PR DESCRIPTION
Current build with `compat_cli` enabled failed:
```
../plugins/uefi-capsule/meson.build:59:0: ERROR: File fu-acpi-uefi.struct does not exist.
```

`fu-acpi-uefi.struct` has been replaced by `fu-uefi.struct` in 7f99954c

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
