### PR TITLE
trivial: contrib/pcap2emulation: Fix supplementary phase file format

### DIFF
--- a/contrib/pcap2emulation.py
+++ b/contrib/pcap2emulation.py
@@ -103,7 +103,7 @@ class Pcap2Emulation:
             phase_path = "{}-{}.json".format(path, phase)
             with open(phase_path, "w") as dump_file:
                 json.dump(
-                    {"UsbDevices": [self.phases[phase]]},
+                    self.phases[phase],
                     dump_file,
                     indent=2,
                     separators=(",", " : "),


### PR DESCRIPTION
"UsbDevices" is already part of self.phases[n]

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
