### PR TITLE
dell-dock: trigger passive flow for usb4 from intel-usb4 plugin

### DIFF
--- a/plugins/dell-dock/dell-dock.quirk
+++ b/plugins/dell-dock/dell-dock.quirk
@@ -210,6 +210,6 @@ VendorId = TBT:0x00D4
 ParentGuid = USB\VID_413C&PID_B06E&hub&embedded
 FirmwareSizeMin = 0x40000
 FirmwareSizeMax = 0x80000
-Flags = skips-restart,dual-image
+Flags = skips-restart,dual-image,usable-during-update
 Icon = thunderbolt
 InstallDuration = 46

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -276,6 +276,7 @@ fu_dell_dock_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GErr
 	for (guint i = 0; i < devices->len; i++) {
 		dev = g_ptr_array_index(devices, i);
 		if ((g_strcmp0(fu_device_get_plugin(dev), "thunderbolt") == 0 ||
+		     g_strcmp0(fu_device_get_plugin(dev), "intel_usb4") == 0 ||
 		     g_strcmp0(fu_device_get_plugin(dev), "dell_dock") == 0) &&
 		    fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
 			/* the kernel and/or thunderbolt plugin have been configured to let HW


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

The USB4 dock requires `usable-during-update` flag to enable updating the NVM firmware in a cycle of the Type-C cable is disconnected and re-connected.
