### PR TITLE
Move the expected default plugin config value to the code

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -104,3 +104,8 @@ Remember: Plugins should be upstream!
 
 * `fu_mei_device_connect()`: Drop the explicit GUID parameter and match in the quirk file instead.
 * `fu_context_get_smbios_data()`: Add a `GError`
+
+## 1.9.1
+
+* `fu_plugin_get_config_value()`: Add the default value as the last parameter
+* `fu_plugin_get_config_value_boolean()`: Add the default value as the last parameter

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2411,22 +2411,27 @@ fu_plugin_get_report_metadata(FuPlugin *self)
  * fu_plugin_get_config_value:
  * @self: a #FuPlugin
  * @key: a settings key
+ * @value_default: the default value of the key if not found
  *
- * Return the value of a key if it's been configured
+ * Return the value of a key, falling back to the default value.
  *
  * Since: 1.0.6
  **/
 gchar *
-fu_plugin_get_config_value(FuPlugin *self, const gchar *key)
+fu_plugin_get_config_value(FuPlugin *self, const gchar *key, const gchar *value_default)
 {
 	g_autofree gchar *conf_path = fu_plugin_get_config_filename(self);
+	g_autofree gchar *value = NULL;
 	g_autoptr(GKeyFile) keyfile = NULL;
 	if (!g_file_test(conf_path, G_FILE_TEST_IS_REGULAR))
-		return NULL;
+		return g_strdup(value_default);
 	keyfile = g_key_file_new();
 	if (!g_key_file_load_from_file(keyfile, conf_path, G_KEY_FILE_NONE, NULL))
-		return NULL;
-	return g_key_file_get_string(keyfile, fu_plugin_get_name(self), key, NULL);
+		return g_strdup(value_default);
+	value = g_key_file_get_string(keyfile, fu_plugin_get_name(self), key, NULL);
+	if (value == NULL)
+		return g_strdup(value_default);
+	return g_steal_pointer(&value);
 }
 
 /**
@@ -2565,6 +2570,7 @@ fu_plugin_set_config_value(FuPlugin *self, const gchar *key, const gchar *value,
  * fu_plugin_get_config_value_boolean:
  * @self: a #FuPlugin
  * @key: a settings key
+ * @value_default: the default value of the key if not found
  *
  * Return the boolean value of a key if it's been configured
  *
@@ -2573,11 +2579,11 @@ fu_plugin_set_config_value(FuPlugin *self, const gchar *key, const gchar *value,
  * Since: 1.4.0
  **/
 gboolean
-fu_plugin_get_config_value_boolean(FuPlugin *self, const gchar *key)
+fu_plugin_get_config_value_boolean(FuPlugin *self, const gchar *key, gboolean value_default)
 {
-	g_autofree gchar *tmp = fu_plugin_get_config_value(self, key);
+	g_autofree gchar *tmp = fu_plugin_get_config_value(self, key, NULL);
 	if (tmp == NULL)
-		return FALSE;
+		return value_default;
 	return g_ascii_strcasecmp(tmp, "true") == 0;
 }
 

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -448,9 +448,9 @@ fu_plugin_add_rule(FuPlugin *self, FuPluginRule rule, const gchar *name);
 void
 fu_plugin_add_report_metadata(FuPlugin *self, const gchar *key, const gchar *value);
 gchar *
-fu_plugin_get_config_value(FuPlugin *self, const gchar *key);
+fu_plugin_get_config_value(FuPlugin *self, const gchar *key, const gchar *value_default);
 gboolean
-fu_plugin_get_config_value_boolean(FuPlugin *self, const gchar *key);
+fu_plugin_get_config_value_boolean(FuPlugin *self, const gchar *key, gboolean value_default);
 gboolean
 fu_plugin_set_config_value(FuPlugin *self, const gchar *key, const gchar *value, GError **error);
 FwupdSecurityAttr *

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -649,6 +649,7 @@ fu_plugin_config_func(void)
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *testdatadir = NULL;
 	g_autofree gchar *value = NULL;
+	g_autofree gchar *value_missing = NULL;
 	g_autoptr(FuPlugin) plugin = fu_plugin_new(NULL);
 	g_autoptr(GError) error = NULL;
 
@@ -681,9 +682,11 @@ fu_plugin_config_func(void)
 	g_assert_cmpint(statbuf.st_mode & 0777, ==, 0644);
 
 	/* read back the value */
-	value = fu_plugin_get_config_value(plugin, "Key");
+	value_missing = fu_plugin_get_config_value(plugin, "NotGoingToExist", "Foo");
+	g_assert_cmpstr(value_missing, ==, "Foo");
+	value = fu_plugin_get_config_value(plugin, "Key", "Foo");
 	g_assert_cmpstr(value, ==, "True");
-	g_assert_true(fu_plugin_get_config_value_boolean(plugin, "Key"));
+	g_assert_true(fu_plugin_get_config_value_boolean(plugin, "Key", FALSE));
 
 	/* write it private, i.e. only readable by the user/group */
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_SECURE_CONFIG);

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -412,12 +412,8 @@ fu_plugin_add_security_attr_dci_locked(FuPlugin *plugin, FuSecurityAttrs *attrs)
 static gboolean
 fu_msr_plugin_safe_kernel_for_sme(FuPlugin *plugin, GError **error)
 {
-	g_autofree gchar *min = fu_plugin_get_config_value(plugin, "MinimumSmeKernelVersion");
-
-	if (min == NULL) {
-		g_debug("ignoring kernel safety checks");
-		return TRUE;
-	}
+	g_autofree gchar *min =
+	    fu_plugin_get_config_value(plugin, "MinimumSmeKernelVersion", "5.18.0");
 	return fu_kernel_check_version(min, error);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8355,7 +8355,8 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	/* migrate per-plugin settings into daemon.conf */
 	plugin_uefi = fu_plugin_list_find_by_name(self->plugin_list, "uefi_capsule", NULL);
 	if (plugin_uefi != NULL) {
-		const gchar *tmp = fu_plugin_get_config_value(plugin_uefi, "OverrideESPMountPoint");
+		const gchar *tmp =
+		    fu_plugin_get_config_value(plugin_uefi, "OverrideESPMountPoint", NULL);
 		if (tmp != NULL && g_strcmp0(tmp, fu_config_get_esp_location(self->config)) != 0) {
 			g_info("migrating OverrideESPMountPoint=%s to EspLocation", tmp);
 			if (!fu_config_set_key_value(self->config, "EspLocation", tmp, error))


### PR DESCRIPTION
This means we can ship a fwupd without any config files at all, and reduces the mental gymnastics when reading empty integer values.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
