### PR TITLE
mtd: Allow specifying the metadata offset and size

### DIFF
--- a/libfwupdplugin/fu-bytes.h
+++ b/libfwupdplugin/fu-bytes.h
@@ -19,6 +19,9 @@ fu_bytes_get_contents_stream(GInputStream *stream,
 			     gsize count,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
 GBytes *
+fu_bytes_get_contents_stream_full(GInputStream *stream, gsize offset, gsize count, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT;
+GBytes *
 fu_bytes_get_contents_fd(gint fd, gsize count, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 GBytes *
 fu_bytes_align(GBytes *bytes, gsize blksz, gchar padval);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -47,8 +47,6 @@ G_DEFINE_TYPE_WITH_PRIVATE(FuFirmware, fu_firmware, G_TYPE_OBJECT)
 
 enum { PROP_0, PROP_PARENT, PROP_LAST };
 
-#define FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX (32 * 1024 * 1024)
-
 /**
  * fu_firmware_flag_to_string:
  * @flag: a #FuFirmwareFlags, e.g. %FU_FIRMWARE_FLAG_DEDUPE_ID

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -202,6 +202,8 @@ typedef guint64 FuFirmwareFlags;
 #define FU_FIRMWARE_ALIGNMENT_2G   0x1F
 #define FU_FIRMWARE_ALIGNMENT_4G   0x20
 
+#define FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX (32 * 1024 * 1024)
+
 const gchar *
 fu_firmware_flag_to_string(FuFirmwareFlags flag);
 FuFirmwareFlags

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1196,6 +1196,7 @@ LIBFWUPDPLUGIN_1.8.13 {
 
 LIBFWUPDPLUGIN_1.9.1 {
   global:
+    fu_bytes_get_contents_stream_full;
     fu_cfi_device_send_command;
     fu_context_get_firmware_gtypes;
     fu_memchk_read;

--- a/plugins/mtd/README.md
+++ b/plugins/mtd/README.md
@@ -45,6 +45,25 @@ This would allow fwupd to read the MTD image data, look for a [uSWID](https://gi
 data section and then parse the metadata from that. Any of the firmware formats supported by
 `fwupdtool get-firmware-gtypes` that can provide a version can be used.
 
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### MtdMetadataOffset
+
+The offset to start searching within the MTD partition when using `FirmwareGType`. This is provided
+to avoid dumping a huge amount of MTD data to access a tiny chunk of data that will not be before a
+known offset.
+
+Since: 1.9.1
+
+### MtdMetadataSize
+
+The size of data to read from the MTD partition when using `FirmwareGType`. This is provided to
+avoid dumping a huge amount of MTD data to access a tiny chunk of data.
+
+Since: 1.9.1
+
 ## Vendor ID Security
 
 The vendor ID is set from the system vendor, for example `DMI:LENOVO`

--- a/plugins/mtd/fu-mtd-plugin.c
+++ b/plugins/mtd/fu-mtd-plugin.c
@@ -31,6 +31,9 @@ fu_mtd_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 static void
 fu_mtd_plugin_init(FuMtdPlugin *self)
 {
+	FuContext *ctx = fu_plugin_get_context(FU_PLUGIN(self));
+	fu_context_add_quirk_key(ctx, "MtdMetadataOffset");
+	fu_context_add_quirk_key(ctx, "MtdMetadataSize");
 }
 
 static void


### PR DESCRIPTION
Some MTD partitions are huge, and take a long time to dump. If we know the offset the metadata is going to be located at, allow it to be specified in the quirk file.

This speeds up reading uSWID metadata for the BMC partition by several orders of magnitude.

Also, don't fail to add the MTD device if the metdata is not found.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
