### PR TITLE
trivial: Fix ModifyDaemonConfig not accessible

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1571,7 +1571,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 					  g_steal_pointer(&helper));
 		return;
 	}
-	if (g_strcmp0(method_name, "ModifyDaemonConfig") == 0) {
+	if (g_strcmp0(method_name, "ModifyConfig") == 0) {
 		g_autofree gchar *key = NULL;
 		g_autofree gchar *value = NULL;
 		g_autoptr(FuMainAuthHelper) helper = NULL;


### PR DESCRIPTION
The method change name from ModifyConfig to ModifyDaemonConfig in 7fa422744

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
