### PR TITLE
Have fwupd-refresh.timer trigger once per hour on average

### DIFF
--- a/data/motd/fwupd-refresh.timer
+++ b/data/motd/fwupd-refresh.timer
@@ -3,8 +3,8 @@ Description=Refresh fwupd metadata regularly
 ConditionVirtualization=!container
 
 [Timer]
-OnCalendar=*-*-* 6,18:00
-RandomizedDelaySec=12h
+OnCalendar=*-*-* *:00:00
+RandomizedDelaySec=1h
 Persistent=true
 
 [Install]


### PR DESCRIPTION
Due to systemd timers applying RandomizedDelaySec upon reboot, the previous 12h maximum delay meant that the timer would rarely trigger on devices that reboot often (systemd/systemd#21166). We set the timer to trigger with a randomised delay of up to 1h, every hour.

Fixes #5731.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
