### PR TITLE
Add a new device-wait command to fwupdmgr

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -5,6 +5,7 @@ _fwupdmgr_cmd_list=(
 	'disable-remote'
 	'device-test'
 	'device-emulate'
+	'device-wait'
 	'downgrade'
 	'download'
 	'enable-remote'

--- a/data/fish-completion/fwupdmgr.fish
+++ b/data/fish-completion/fwupdmgr.fish
@@ -38,6 +38,7 @@ complete -c fwupdmgr -n '__fish_use_subcommand' -x -a block-firmware -d 'Blocks 
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a clear-results -d 'Clears the results from the last update'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a disable-remote -d 'Disables a given remote'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a downgrade -d 'Downgrades the firmware on a device'
+complete -c fwupdmgr -n '__fish_use_subcommand' -x -a device-wait -d 'Wait for a device to appear'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a enable-remote -d 'Enables a given remote'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-approved-firmware -d 'Gets the list of approved firmware'
 complete -c fwupdmgr -n '__fish_use_subcommand' -x -a get-blocked-firmware -d 'Gets the list of blocked firmware'

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -47,8 +47,9 @@
 #include "fu-systemd.h"
 #endif
 
-/* custom return code */
+/* custom return codes */
 #define EXIT_NOTHING_TO_DO 2
+#define EXIT_NOT_FOUND	   3
 
 typedef enum {
 	FU_UTIL_OPERATION_UNKNOWN,
@@ -4232,6 +4233,9 @@ main(int argc, char *argv[])
 		} else if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
 			g_info("%s\n", error->message);
 			return EXIT_NOTHING_TO_DO;
+		} else if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
+			g_info("%s\n", error->message);
+			return EXIT_NOT_FOUND;
 		}
 #ifdef HAVE_GETUID
 		/* if not root, then notify users on the error path */

--- a/src/fwupdmgr.md
+++ b/src/fwupdmgr.md
@@ -26,8 +26,11 @@ Run **fwupdmgr \-\-help** for the full list.
 EXIT STATUS
 ===========
 
-Commands that successfully execute will return "0", but commands that have no
-actions but successfully execute will return "2".
+Commands that successfully execute will return "0", with generic failure as "1".
+
+There are also several other exit codes used:
+A return code of "2" is used for commands that have no actions but were successfully executed,
+and "3" is used when a resource was not found.
 
 BUGS
 ====

--- a/src/fwupdtool.md
+++ b/src/fwupdtool.md
@@ -31,8 +31,11 @@ Note that some runtimes failures can be ignored using **\-\-force**.
 EXIT STATUS
 ===========
 
-Commands that successfully execute will return "0", but commands that have no
-actions but successfully execute will return "2".
+Commands that successfully execute will return "0", with generic failure as "1".
+
+There are also several other exit codes used:
+A return code of "2" is used for commands that have no actions but were successfully executed,
+and "3" is used when a resource was not found.
 
 BUGS
 ====


### PR DESCRIPTION
This waits for a specific device to appear. Additionally, a new return code is returned when a specific resource (typically a device) does not exist.

Fixes https://github.com/fwupd/fwupd/issues/5740

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
