### PR TITLE
Use traits to define what GLib helpers get built

### DIFF
--- a/contrib/ci/check-unused.py
+++ b/contrib/ci/check-unused.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: LGPL-2.1+
 
 import glob
+import fnmatch
 import sys
 import subprocess
 
@@ -44,11 +45,11 @@ def test_files() -> int:
             continue
         if symb.endswith("_get_type"):
             continue
-        if symb.startswith("fu_struct_"):
+        if fnmatch.fnmatch(symb, "fu_struct_*_set_*"):
             continue
-        if symb.endswith("_to_string"):
+        if fnmatch.fnmatch(symb, "fu_struct_*_get_*"):
             continue
-        if symb.endswith("_from_string"):
+        if fnmatch.fnmatch(symb, "fu_struct_*_to_string"):
             continue
         if symb.find("__proto__") != -1:
             continue

--- a/libfwupdplugin/fu-acpi-table.rs
+++ b/libfwupdplugin/fu-acpi-table.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct AcpiTable {
     signature: 4s
     length: u32le

--- a/libfwupdplugin/fu-cfu.rs
+++ b/libfwupdplugin/fu-cfu.rs
@@ -1,7 +1,9 @@
+#[derive(New, Validate, Parse)]
 struct CfuPayload {
     addr: u32le
     size: u8
 }
+#[derive(New, Validate, Parse)]
 struct CfuOffer {
     segment_number: u8
     flags1: u8

--- a/libfwupdplugin/fu-dfu.rs
+++ b/libfwupdplugin/fu-dfu.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct DfuFtr {
     release: u16le
     pid: u16le
@@ -7,12 +8,14 @@ struct DfuFtr {
     len: u8: default=$struct_size
     crc: u32le
 }
+#[derive(New, Validate, Parse)]
 struct DfuseHdr {
     sig: 5s: const=DfuSe
     ver: u8: const=0x01
     image_size: u32le
     targets: u8
 }
+#[derive(New, Validate, Parse)]
 struct DfuseImage {
     sig: 6s: const=Target
     alt_setting: u8
@@ -21,6 +24,7 @@ struct DfuseImage {
     target_size: u32le
     chunks: u32le
 }
+#[derive(New, Validate, Parse)]
 struct DfuseElement {
     address: u32le
     size: u32le

--- a/libfwupdplugin/fu-efi.rs
+++ b/libfwupdplugin/fu-efi.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct EfiFile {
     name: guid
     hdr_checksum: u8
@@ -7,15 +8,18 @@ struct EfiFile {
     size: u24le
     state: u8: const=0xF8
 }
+#[derive(New, Validate, Parse)]
 struct EfiSection {
     size: u24le
     type: u8
 }
+#[derive(New, Validate, Parse)]
 struct EfiSectionGuidDefined {
     name: guid
     offset: u16le
     attr: u16le
 }
+#[derive(New, Validate, Parse)]
 struct EfiVolume {
     zero_vector: guid
     guid: guid
@@ -28,10 +32,12 @@ struct EfiVolume {
     reserved: u8
     revision: u8: const=0x02
 }
+#[derive(New, Validate, Parse)]
 struct EfiVolumeBlockMap {
     num_blocks: u32le
     length: u32le
 }
+#[derive(New, Validate, Parse)]
 struct EfiSignatureList {
     type: guid
     list_size: u32le

--- a/libfwupdplugin/fu-fdt.rs
+++ b/libfwupdplugin/fu-fdt.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct Fdt {
     magic: u32be: const=0xD00DFEED
     totalsize: u32be
@@ -10,10 +11,12 @@ struct Fdt {
     size_dt_strings: u32be
     size_dt_struct: u32be
 }
+#[derive(New, Validate, Parse)]
 struct FdtReserveEntry {
     address: u64be
     size: u64be
 }
+#[derive(New, Validate, Parse)]
 struct FdtProp {
     len: u32be
     nameoff: u32be

--- a/libfwupdplugin/fu-fmap.rs
+++ b/libfwupdplugin/fu-fmap.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct Fmap {
     signature: 8s: const=__FMAP__
     ver_major: u8: default=0x1
@@ -7,6 +8,7 @@ struct Fmap {
     name: 32s
     nareas: u16le		// number of areas
 }
+#[derive(New, Validate, Parse)]
 struct FmapArea {		// area of volatile and static regions
     offset: u32le		// offset relative to base
     size: u32le			// bytes

--- a/libfwupdplugin/fu-ifwi.rs
+++ b/libfwupdplugin/fu-ifwi.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct IfwiCpd {
     header_marker: u32le: const=0x44504324
     num_of_entries: u32le
@@ -8,12 +9,14 @@ struct IfwiCpd {
     partition_name: u32le
     crc32: u32le
 }
+#[derive(New, Validate, Parse)]
 struct IfwiCpdEntry {
     name: 12s
     offset: u32le
     length: u32le
     _reserved1: 4u8
 }
+#[derive(New, Validate, Parse)]
 struct IfwiCpdManifest {
     header_type: u32le
     header_length: u32le		// dwords
@@ -27,10 +30,12 @@ struct IfwiCpdManifest {
     version: u64le
     svn: u32le
 }
+#[derive(New, Validate, Parse)]
 struct IfwiCpdManifestExt {
     extension_type: u32le
     extension_length: u32le
 }
+#[derive(New, Validate, Parse)]
 struct IfwiFpt {
     header_marker: u32le: const=0x54504624
     num_of_entries: u32le
@@ -47,6 +52,7 @@ struct IfwiFpt {
     fitc_hotfix: u16le
     fitc_build: u16le
 }
+#[derive(New, Validate, Parse)]
 struct IfwiFptEntry {
     partition_name: u32le
     _reserved1: 4u8

--- a/libfwupdplugin/fu-oprom.rs
+++ b/libfwupdplugin/fu-oprom.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct Oprom {
     signature: u16le: const=0xAA55
     image_size: u16le		// of 512 bytes
@@ -10,6 +11,7 @@ struct Oprom {
     pci_header_offset: u16le: default=$struct_size
     expansion_header_offset: u16le
 }
+#[derive(New, Validate, Parse)]
 struct OpromPci {
     signature: u32le: const=0x52494350
     vendor_id: u16le

--- a/libfwupdplugin/fu-rustgen-enum.c.in
+++ b/libfwupdplugin/fu-rustgen-enum.c.in
@@ -1,3 +1,4 @@
+{%- if 'ToString' in derives %}
 const gchar *
 {{name_snake}}_to_string({{name}} val)
 {
@@ -7,7 +8,9 @@ const gchar *
 {%- endfor %}
     return NULL;
 }
+{%- endif %}
 
+{%- if 'FromString' in derives %}
 {{name}}
 {{name_snake}}_from_string(const gchar *val)
 {
@@ -17,3 +20,4 @@ const gchar *
 {%- endfor %}
     return {{items[0].c_define(name)}};
 }
+{%- endif %}

--- a/libfwupdplugin/fu-rustgen-enum.h.in
+++ b/libfwupdplugin/fu-rustgen-enum.h.in
@@ -7,5 +7,9 @@ typedef enum {
 {%- endif %}
 {%- endfor %}
 } {{name}};
+{%- if 'ToString' in derives %}
 const gchar *{{name_snake}}_to_string({{name}} val);
+{%- endif %}
+{%- if 'FromString' in derives %}
 {{name}} {{name_snake}}_from_string(const gchar *val);
+{%- endif %}

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -1,3 +1,5 @@
+/* getters */
+{%- if 'Getters' in derives %}
 {%- for item in items | selectattr('enabled') %}
 {%- if item.type == Type.STRING %}
 {{"G_GNUC_UNUSED static " if item.constant else ""}}gchar *
@@ -6,6 +8,44 @@
     g_return_val_if_fail(st != NULL, NULL);
     return fu_strsafe((const gchar *) (st->data + {{item.offset}}), {{item.size}});
 }
+{%- elif item.type == Type.U8 and item.multiplier %}
+{{"static " if item.constant else ""}}const guint8 *
+{{name_snake}}_get_{{item.element_id}}(GByteArray *st, gsize *bufsz)
+{
+    g_return_val_if_fail(st != NULL, NULL);
+    if (bufsz != NULL)
+        *bufsz = {{item.size}};
+    return st->data + {{item.offset}};
+}
+{%- elif item.type == Type.GUID %}
+{{"static " if item.constant else ""}}const fwupd_guid_t *
+{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{
+    g_return_val_if_fail(st != NULL, NULL);
+    return (const fwupd_guid_t *) (st->data + {{item.offset}});
+}
+{%- elif item.type == Type.U8 %}
+{{"static " if item.constant else ""}}guint8
+{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{
+    g_return_val_if_fail(st != NULL, 0x0);
+    return st->data[{{item.offset}}];
+}
+{%- elif not item.multiplier and item.type in [Type.U16, Type.U24, Type.U32, Type.U64] %}
+{{"static " if item.constant else ""}}{{item.type_glib}}
+{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{
+    g_return_val_if_fail(st != NULL, 0x0);
+    return fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
+}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+
+/* setters */
+{%- for item in items | selectattr('enabled') %}
+{%- if 'Setters' in derives or ('New' in derives and item.default) %}
+{%- if item.type == Type.STRING %}
 {{"static " if item.constant else ""}}gboolean
 {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const gchar *value, GError **error)
 {
@@ -19,16 +59,7 @@
     len = strlen(value);
     return fu_memcpy_safe(st->data, st->len, {{item.offset}}, (const guint8 *)value, len, 0x0, len, error);
 }
-
 {%- elif item.type == Type.U8 and item.multiplier %}
-{{"static " if item.constant else ""}}const guint8 *
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st, gsize *bufsz)
-{
-    g_return_val_if_fail(st != NULL, NULL);
-    if (bufsz != NULL)
-        *bufsz = {{item.size}};
-    return st->data + {{item.offset}};
-}
 {{"static " if item.constant else ""}}gboolean
 {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error)
 {
@@ -37,14 +68,7 @@
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     return fu_memcpy_safe(st->data, st->len, {{item.offset}}, buf, bufsz, 0x0, bufsz, error);
 }
-
 {%- elif item.type == Type.GUID %}
-{{"static " if item.constant else ""}}const fwupd_guid_t *
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
-{
-    g_return_val_if_fail(st != NULL, NULL);
-    return (const fwupd_guid_t *) (st->data + {{item.offset}});
-}
 {{"static " if item.constant else ""}}void
 {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const fwupd_guid_t *value)
 {
@@ -52,28 +76,14 @@
     g_return_if_fail(value != NULL);
     memcpy(st->data + {{item.offset}}, value, sizeof(*value));
 }
-
 {%- elif item.type == Type.U8 %}
-{{"static " if item.constant else ""}}guint8
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
-{
-    g_return_val_if_fail(st != NULL, 0x0);
-    return st->data[{{item.offset}}];
-}
 {{"static " if item.constant else ""}}void
 {{name_snake}}_set_{{item.element_id}}(GByteArray *st, guint8 value)
 {
     g_return_if_fail(st != NULL);
     st->data[{{item.offset}}] = value;
 }
-
 {%- elif not item.multiplier and item.type in [Type.U16, Type.U24, Type.U32, Type.U64] %}
-{{"static " if item.constant else ""}}{{item.type_glib}}
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
-{
-    g_return_val_if_fail(st != NULL, 0x0);
-    return fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
-}
 {{"static " if item.constant else ""}}void
 {{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value)
 {
@@ -81,8 +91,10 @@
     fu_memwrite_{{item.type_mem}}(st->data + {{item.offset}}, value, {{item.endian_glib}});
 }
 {%- endif %}
+{%- endif %}
 {%- endfor %}
 
+{%- if 'New' in derives %}
 GByteArray *
 {{name_snake}}_new(void)
 {
@@ -102,6 +114,7 @@ GByteArray *
 {%- endfor %}
     return st;
 }
+{%- endif %}
 
 gchar *
 {{name_snake}}_to_string(GByteArray *st)
@@ -137,6 +150,7 @@ gchar *
     return g_string_free(g_steal_pointer(&str), FALSE);
 }
 
+{%- if 'Parse' in derives %}
 GByteArray *
 {{name_snake}}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
@@ -168,12 +182,15 @@ GByteArray *
     g_debug("%s", str);
     return g_steal_pointer(&st);
 }
+{%- endif %}
 
-{%- if has_constant %}
+{%- if 'Validate' in derives %}
 gboolean
 {{name_snake}}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
+{%- if has_constant %}
     GByteArray st = {.data = (guint8 *) buf + offset, .len = bufsz - offset, };
+{%- endif %}
     g_return_val_if_fail(buf != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     if (!fu_memchk_read(bufsz, offset, {{size}}, error)) {

--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -1,25 +1,41 @@
+{%- if 'New' in derives %}
 GByteArray *{{name_snake}}_new(void);
+{%- endif %}
+{%- if 'Parse' in derives %}
 GByteArray *{{name_snake}}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
+{%- endif %}
+{%- if 'Validate' in derives %}
 gboolean {{name_snake}}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
+{%- endif %}
 gchar *{{name_snake}}_to_string(GByteArray *st);
 
-{%- for item in items %}
-{%- if item.enabled and not item.constant %}
+{%- if 'Getters' in derives %}
+{%- for item in items | selectattr('enabled') | rejectattr('constant') %}
 {%- if item.type == Type.STRING %}
 gchar *{{name_snake}}_get_{{item.element_id}}(GByteArray *st);
-gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const gchar *value, GError **error);
 {%- elif item.type == Type.U8 and item.multiplier %}
 const guint8 *{{name_snake}}_get_{{item.element_id}}(GByteArray *st, gsize *bufsz);
-gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error);
 {%- elif item.type == Type.GUID %}
 const fwupd_guid_t *{{name_snake}}_get_{{item.element_id}}(GByteArray *st);
-void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const fwupd_guid_t *value);
 {%- elif not item.multiplier and item.type in [Type.U8, Type.U16, Type.U24, Type.U32, Type.U64] %}
 {{item.type_glib}} {{name_snake}}_get_{{item.element_id}}(GByteArray *st);
-void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value);
-{%- endif %}
 {%- endif %}
 {%- endfor %}
+{%- endif %}
+
+{%- if 'Setters' in derives %}
+{%- for item in items | selectattr('enabled') | rejectattr('constant') %}
+{%- if item.type == Type.STRING %}
+gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const gchar *value, GError **error);
+{%- elif item.type == Type.U8 and item.multiplier %}
+gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error);
+{%- elif item.type == Type.GUID %}
+void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const fwupd_guid_t *value);
+{%- elif not item.multiplier and item.type in [Type.U8, Type.U16, Type.U24, Type.U32, Type.U64] %}
+void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value);
+{%- endif %}
+{%- endfor %}
+{%- endif %}
 
 {%- for item in items | selectattr('enabled') %}
 #define {{name_snake.upper()}}_OFFSET_{{item.element_id.upper()}} 0x{{'{:x}'.format(item.offset)}}

--- a/libfwupdplugin/fu-self-test.rs
+++ b/libfwupdplugin/fu-self-test.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct SelfTest {
     signature: u32be: const=0x12345678
     length: u32le: default=$struct_size // bytes

--- a/libfwupdplugin/fu-smbios.rs
+++ b/libfwupdplugin/fu-smbios.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct SmbiosEp32 {
     anchor_str: 4s
     entry_point_csum: u8
@@ -14,6 +15,7 @@ struct SmbiosEp32 {
     number_smbios_structs: u16le
     smbios_bcd_rev: u8
 }
+#[derive(New, Validate, Parse)]
 struct SmbiosEp64 {
     anchor_str: 5s
     entry_point_csum: u8
@@ -26,6 +28,7 @@ struct SmbiosEp64 {
     structure_table_len: u32le
     structure_table_addr: u64le
 }
+#[derive(New, Validate, Parse)]
 struct SmbiosStructure {
     type: u8
     length: u8

--- a/libfwupdplugin/fu-usb-device-ds20.rs
+++ b/libfwupdplugin/fu-usb-device-ds20.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct Ds20 {
     _reserved: u8
     guid: guid
@@ -6,6 +7,7 @@ struct Ds20 {
     vendor_code: u8
     alt_code: u8
 }
+#[derive(New, Validate, Parse)]
 struct MsDs20 {
     size: u16le
     type: u16le

--- a/libfwupdplugin/fu-uswid.rs
+++ b/libfwupdplugin/fu-uswid.rs
@@ -1,3 +1,4 @@
+#[derive(New, Validate, Parse)]
 struct Uswid {
     magic: guid: const=0x53424F4DD6BA2EACA3E67A52AAEE3BAF
     hdrver: u8

--- a/plugins/acpi-phat/fu-acpi-phat.rs
+++ b/plugins/acpi-phat/fu-acpi-phat.rs
@@ -1,3 +1,4 @@
+#[derive(New, Parse)]
 struct AcpiPhatHealthRecord {
     signature: u16le: default=0x1
     rcdlen: u16le
@@ -7,11 +8,13 @@ struct AcpiPhatHealthRecord {
     device_signature: guid
     device_specific_data: u32le
 }
+#[derive(New, Parse)]
 struct AcpiPhatVersionElement {
     component_id: guid
     version_value: u64le
     producer_id: 4s
 }
+#[derive(New, Parse)]
 struct AcpiPhatVersionRecord {
     signature: u16le: default=0x0
     rcdlen: u16le

--- a/plugins/analogix/fu-analogix.rs
+++ b/plugins/analogix/fu-analogix.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum AnalogixUpdateStatus {
     Invalid,
     Start,

--- a/plugins/ccgx/fu-ccgx.rs
+++ b/plugins/ccgx/fu-ccgx.rs
@@ -1,3 +1,4 @@
+#[derive(ToString, FromString)]
 enum CcgxImageType {
     Unknown,
     Single,
@@ -6,6 +7,7 @@ enum CcgxImageType {
     DualAsymmetricVariable, // A=bootloader (variable) B=runtime
     DmcComposite,           // composite firmware image for dmc
 }
+#[derive(ToString)]
 enum CcgxFwMode {
     Boot,
     Fw1,

--- a/plugins/cfu/fu-cfu.rs
+++ b/plugins/cfu/fu-cfu.rs
@@ -1,14 +1,17 @@
+#[derive(New, Validate, Parse)]
 struct CfuRspGetFirmwareVersion {
     component_cnt: u8
     _reserved: u16le
     flags: u8
 }
+#[derive(New, Validate, Parse)]
 struct CfuRspGetFirmwareVersionComponent {
     fw_version: u32le
     flags: u8
     component_id: u8
     _vendor_specific: u16le
 }
+#[derive(Parse)]
 struct CfuRspFirmwareUpdateOffer {
     _reserved1: 3u8
     token: u8
@@ -18,12 +21,14 @@ struct CfuRspFirmwareUpdateOffer {
     status: u8
     _reserved3: 3u8
 }
+#[derive(New, Getters)]
 struct CfuReqFirmwareUpdateContent {
     flags: u8
     data_length: u8
     seq_number: u16le
     address: u32le
 }
+#[derive(New, Getters)]
 struct CfuRspFirmwareUpdateContent {
     seq_number: u16le
     _reserved1: u16le

--- a/plugins/corsair/fu-corsair.rs
+++ b/plugins/corsair/fu-corsair.rs
@@ -1,3 +1,4 @@
+#[derive(ToString, FromString)]
 enum CorsairDeviceKind {
     Unknown,
     Mouse,

--- a/plugins/ebitdo/fu-ebitdo.rs
+++ b/plugins/ebitdo/fu-ebitdo.rs
@@ -1,14 +1,17 @@
+#[derive(New, Parse)]
 struct EbitdoHdr {
     version: u32le
     destination_addr: u32le
     destination_len: u32le
     reserved: 4u32le
 }
+#[derive(ToString)]
 enum EbitdoPktType {
     UserCmd = 0x00,
     UserData = 0x01,
     MidCmd = 0x02,
 }
+#[derive(ToString)]
 enum EbitdoPktCmd {
     FwUpdateData       = 0x00, // update firmware data
     FwUpdateHeader     = 0x01, // update firmware header

--- a/plugins/hailuck/fu-hailuck.rs
+++ b/plugins/hailuck/fu-hailuck.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum HailuckCmd {
     Erase             = 0x45,
     ReadBlockStart    = 0x52,

--- a/plugins/intel-gsc/fu-igsc.rs
+++ b/plugins/intel-gsc/fu-igsc.rs
@@ -1,25 +1,30 @@
+#[derive(Parse)]
 struct IgscOpromVersion {
     major: u16le
     minor: u16le
     hotfix: u16le
     build: u16le
 }
+#[derive(Parse)]
 struct IgscOpromSubsystemDeviceId {
     subsys_vendor_id: u16le
     subsys_device_id: u16le
 }
+#[derive(Parse)]
 struct IgscOpromSubsystemDevice4Id {
     vendor_id: u16le
     device_id: u16le
     subsys_vendor_id: u16le
     subsys_device_id: u16le
 }
+#[derive(Parse)]
 struct IgscFwuGwsImageInfo {
     format_version: u32le: const=0x1
     instance_id: u32le
     _reserved: 14u32
 }
 /* represents a GSC FW sub-partition such as FTPR, RBEP */
+#[derive(Getters)]
 struct IgscFwuFwImageData {
     version_major: u16le
     version_minor: u16le
@@ -32,6 +37,7 @@ struct IgscFwuFwImageData {
     tcb_svn: u32le
     vcn: u32le
 }
+#[derive(Getters)]
 struct IgscFwuIupData {
     iup_name: u32le
     flags: u16le
@@ -39,9 +45,11 @@ struct IgscFwuIupData {
     svn: u32le
     vcn: u32le
 }
+#[derive(Getters)]
 struct IgscFwuHeciImageMetadata {
     version_format: u32le: default=0x1
 }
+#[derive(Parse)]
 struct IgscFwuImageMetadataV1 {
     version_format: u32le: default=0x1  // struct IgscFwuHeciImageMetadata
     project: 4s

--- a/plugins/intel-spi/fu-intel-spi.rs
+++ b/plugins/intel-spi/fu-intel-spi.rs
@@ -1,3 +1,4 @@
+#[derive(ToString, FromString)]
 enum IntelSpiKind {
     Unknown,
     Apl,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp.rs
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum LogitechHidppFeature {
     Root                  = 0x0000,
     IFeatureSet           = 0x0001,

--- a/plugins/pci-mei/fu-mei.rs
+++ b/plugins/pci-mei/fu-mei.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum MeiFamily {
     Unknown,
     Sps,
@@ -7,6 +8,7 @@ enum MeiFamily {
 }
 
 # HFS1[3:0] Current Working State Values
+#[derive(ToString)]
 enum MeHfsCws {
     Reset,
     Initializing,
@@ -20,6 +22,7 @@ enum MeHfsCws {
 }
 
 # HFS1[8:6] Current Operation State Values
+#[derive(ToString)]
 enum MeHfsState {
     Preboot,
     M0WithUma = 1,
@@ -30,6 +33,7 @@ enum MeHfsState {
 }
 
 # HFS[19:16] Current Operation Mode Values
+#[derive(ToString)]
 enum MeHfsMode {
     Normal,
     Debug = 2,
@@ -41,6 +45,7 @@ enum MeHfsMode {
 }
 
 # HFS[15:12] Error Code Values
+#[derive(ToString)]
 enum MeHfsError {
     NoError,
     UncategorizedFailure,

--- a/plugins/redfish/fu-redfish.rs
+++ b/plugins/redfish/fu-redfish.rs
@@ -1,3 +1,4 @@
+#[derive(New, Parse)]
 struct RedfishProtocolOverIp {
     service_uuid: guid
     host_ip_assignment_type: u8
@@ -13,6 +14,7 @@ struct RedfishProtocolOverIp {
     service_hostname_len: u8
 // optional service_hostname goes here
 }
+#[derive(ToString)]
 enum RedfishNetworkDeviceState {
     Unknown = 0,
     Unmanaged = 10,

--- a/plugins/scsi/fu-scsi.rs
+++ b/plugins/scsi/fu-scsi.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum ScsiSenseKey {
     NoSense = 0x00,
     RecoveredError = 0x01,

--- a/plugins/synaptics-cape/fu-synaptics-cape.rs
+++ b/plugins/synaptics-cape/fu-synaptics-cape.rs
@@ -1,3 +1,4 @@
+#[derive(New, Parse)]
 struct SynapticsCapeFileHdr {
     vid: u32le
     pid: u32le

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio.rs
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio.rs
@@ -1,3 +1,4 @@
+#[derive(Parse)]
 struct SynapticsCxaudioCustomInfo {
 	patch_version_string_address: u16le
 	cpx_patch_version: 3u8
@@ -13,14 +14,17 @@ struct SynapticsCxaudioCustomInfo {
 	product_string_address: u16le
 	serial_number_string_address: u16le
 }
+#[derive(Parse)]
 struct SynapticsCxaudioStringHeader {
 	length: u8
 	type: u8: const=0x03
 }
+#[derive(Parse)]
 struct SynapticsCxaudioValiditySignature {
 	magic_byte: u8: default=0x4C	// 'L'
 	eeprom_size_code: u8
 }
+#[derive(Parse, Setters)]
 struct SynapticsCxaudioPatchInfo {
 	patch_signature: u8
 	patch_address: u16le

--- a/plugins/synaptics-mst/fu-synaptics-mst.rs
+++ b/plugins/synaptics-mst/fu-synaptics-mst.rs
@@ -1,8 +1,10 @@
+#[derive(ToString)]
 enum SynapticsMstMode {
     Unknown,
     Direct,
     Remote,
 }
+#[derive(ToString)]
 enum SynapticsMstFamily {
     Unknown,
     Tesla,

--- a/plugins/synaptics-prometheus/fu-synaprom.rs
+++ b/plugins/synaptics-prometheus/fu-synaprom.rs
@@ -1,3 +1,4 @@
+#[derive(New, Parse)]
 struct SynapromMfwHdr {
     product: u32le
     id: u32le: default=0xFF		// MFW unique id used for compat verification
@@ -7,10 +8,12 @@ struct SynapromMfwHdr {
     vminor: u8: default=1		// minor version
     unused: 6u8
 }
+#[derive(New, Parse)]
 struct SynapromHdr {
     tag: u16le
     bufsz: u32le
 }
+#[derive(Parse)]
 struct SynapromCfgHdr {
     product: u32le: default=65 // Prometheus (b1422)
     id1: u32le
@@ -18,12 +21,14 @@ struct SynapromCfgHdr {
     version: u16le
     _unused: 2u8
 }
+#[derive(Parse)]
 struct SynapromIotaConfigVersion {
     config_id1: u32le // YYMMDD
     config_id2: u32le // HHMMSS
     version: u16le
     _unused: 3u16
 }
+#[derive(Parse)]
 struct SynapromReplyIotaFindHdr {
     status: u16le
     fullsize: u32le
@@ -32,6 +37,7 @@ struct SynapromReplyIotaFindHdr {
 }
 // Iotas can exceed the size of available RAM in the part: to allow the host to read them the
 // IOTA_FIND command supports transferring iotas with multiple commands
+#[derive(New, Getters)]
 struct SynapromCmdIotaFind {
     itype: u16le    // type of iotas to find
     flags: u16le
@@ -41,6 +47,7 @@ struct SynapromCmdIotaFind {
     offset: u32le   // byte offset of data to return
     nbytes: u32le   // maximum number of bytes to return
 }
+#[derive(ToString)]
 enum SynapromFirmwareTag {
     MfwUpdateHeader  = 0x0001,
     MfwUpdatePayload = 0x0002,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi.rs
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi.rs
@@ -1,12 +1,14 @@
+#[derive(Parse)]
 struct RmiPartitionTbl {
     partition_id: u16le
     partition_len: u16le
     partition_addr: u16le
     partition_prop: u16le
 }
+#[derive(New, Parse)]
 struct RmiImg {
     checksum: u32le
-    reserved1: 2u8
+    _reserved1: 2u8
     io_offset: u8
     bootloader_version: u8
     image_size: u32le
@@ -14,10 +16,11 @@ struct RmiImg {
     product_id: 10s
     package_id: u32le
     product_info: u32le
-    reserved3: 46u8
+    _reserved3: 46u8
     fw_build_id: u32le
     signature_size: u32le
 }
+#[derive(New, Parse)]
 struct RmiContainerDescriptor {
     content_checksum: u32le
     container_id: u16le
@@ -30,6 +33,7 @@ struct RmiContainerDescriptor {
     content_length: u32le
     content_address: u32le
 }
+#[derive(ToString)]
 enum RmiPartitionId {
     None = 0x00,
     Bootloader = 0x01,
@@ -47,6 +51,7 @@ enum RmiPartitionId {
     Pubkey,
     FixedLocationData = 0x0E,
 }
+#[derive(ToString)]
 enum RmiContainerId {
     TopLevel,
     Ui,

--- a/plugins/tpm/fu-tpm.rs
+++ b/plugins/tpm/fu-tpm.rs
@@ -1,12 +1,15 @@
+#[derive(Parse)]
 struct TpmEventLog2 {
     pcr: u32le
     type: u32le
     digest_count: u32le
 }
+#[derive(Parse)]
 struct TpmEfiStartupLocalityEvent {
     signature: 16s: const=StartupLocality
     locality: u8    // from which TPM2_Startup() was issued -- which is the initial value of PCR0
 }
+#[derive(ToString)]
 enum TpmEventlogItemKind {
     EV_PREBOOT_CERT = 0x00000000,
     EV_POST_CODE = 0x00000001,

--- a/plugins/uefi-capsule/fu-uefi.rs
+++ b/plugins/uefi-capsule/fu-uefi.rs
@@ -1,3 +1,4 @@
+#[derive(New, Getters)]
 struct EfiUxCapsuleHeader {
     version: u8: const=0x01
     checksum: u8
@@ -7,12 +8,14 @@ struct EfiUxCapsuleHeader {
     x_offset: u32le
     y_offset: u32le
 }
+#[derive(New, Getters)]
 struct EfiCapsuleHeader {
     guid: guid
     header_size: u32le: default=$struct_size
     flags: u32le
     image_size: u32le
 }
+#[derive(New, Parse)]
 struct EfiUpdateInfo {
     version: u32le: default=0x7
     guid: guid
@@ -22,16 +25,19 @@ struct EfiUpdateInfo {
     status: u32le
     // EFI_DEVICE_PATH goes here
 }
+#[derive(Parse)]
 struct AcpiInsydeQuirk {
     signature: 6s
     size: u32le
     flags: u32le
 }
+#[derive(ToString)]
 enum UefiUpdateInfoStatus {
     Unknown,
     AttemptUpdate,
     Attempted,
 }
+#[derive(ToString, FromString)]
 enum UefiDeviceKind {
     Unknown,
     SystemFirmware,
@@ -41,6 +47,7 @@ enum UefiDeviceKind {
     DellTpmFirmware,
     Last,
 }
+#[derive(ToString)]
 enum UefiDeviceStatus {
     Success = 0x00,
     ErrorUnsuccessful = 0x01,

--- a/plugins/uefi-dbx/fu-efi-image.rs
+++ b/plugins/uefi-dbx/fu-efi-image.rs
@@ -1,3 +1,4 @@
+#[derive(Getters)]
 struct EfiImageDataDirEntry {
     addr: u32le
     size: u32le

--- a/plugins/uf2/fu-uf2.rs
+++ b/plugins/uf2/fu-uf2.rs
@@ -1,3 +1,4 @@
+#[derive(New, Parse)]
 struct Uf2 {
     magic0: u32le: const=0x0A324655
     magic1: u32le: const=0x9E5D5157

--- a/plugins/usi-dock/fu-usi-dock.rs
+++ b/plugins/usi-dock/fu-usi-dock.rs
@@ -1,3 +1,4 @@
+#[derive(ToString)]
 enum UsiDockSpiState {
     None,
     SwitchSuccess,

--- a/plugins/vendor-example/fu-vendor-example.rs
+++ b/plugins/vendor-example/fu-vendor-example.rs
@@ -1,7 +1,9 @@
+#[derive(New, Validate, Parse)]
 struct {{Vendor}}{{Example}} {
     signature: u8: const=0xDE
     address: u16le
 }
+#[derive(ToString)]
 enum {{Vendor}}{{Example}}Status {
     Unknown,
     Failed,

--- a/plugins/vli/fu-vli.rs
+++ b/plugins/vli/fu-vli.rs
@@ -1,8 +1,10 @@
+#[derive(Parse)]
 struct VliPdHdr {
     fwver: u32be
     vid: u16le
     pid: u16le
 }
+#[derive(New, Parse)]
 struct VliUsbhubHdr {
     dev_id: u16be
     strapping1: u8
@@ -21,6 +23,7 @@ struct VliUsbhubHdr {
     variant: u8
     checksum: u8
 }
+#[derive(ToString, FromString)]
 enum VliDeviceKind {
     Unknown = 0x0,
     Vl100 = 0x0100,

--- a/plugins/wacom-usb/fu-wac.rs
+++ b/plugins/wacom-usb/fu-wac.rs
@@ -1,7 +1,9 @@
+#[derive(Parse)]
 struct WtaBlockHeader {
     block_start: u32le
     block_size: u32le
 }
+#[derive(ToString)]
 enum WacReportId {
     FwDescriptor              = 0xCB, // GET_FEATURE
     SwitchToFlashLoader       = 0xCC, // SET_FEATURE
@@ -22,6 +24,7 @@ enum WacReportId {
     GetCurrentFirmwareIdx     = 0xE2, // GET_FEATURE
     Module                    = 0xE4,
 }
+#[derive(ToString)]
 enum WacModuleFwType {
     Touch         = 0x00,
     Bluetooth     = 0x01,
@@ -32,11 +35,13 @@ enum WacModuleFwType {
     TouchId7      = 0x07,
     Main          = 0x3F,
 }
+#[derive(ToString)]
 enum WacModuleCommand {
     Start = 0x01,
     Data  = 0x02,
     End   = 0x03,
 }
+#[derive(ToString)]
 enum WacModuleStatus {
     Ok,
     Busy,

--- a/plugins/wistron-dock/fu-wistron-dock.rs
+++ b/plugins/wistron-dock/fu-wistron-dock.rs
@@ -1,3 +1,4 @@
+#[derive(Parse)]
 struct WistronDockWdit {
     hid_id: u8
     tag_id: u16be
@@ -10,6 +11,7 @@ struct WistronDockWdit {
     device_cnt: u8
     reserved: u8
 }
+#[derive(Parse)]
 struct WistronDockWditImg {
     comp_id: u8
     mode: u8   // 0=single, 1=dual-s, 2=dual-a
@@ -20,16 +22,19 @@ struct WistronDockWditImg {
     version2: u32be
     name: 32s
 }
+#[derive(ToString)]
 enum WistronDockUpdatePhase {
     Download = 0x1,
     Deploy = 0x2,
 }
+#[derive(ToString)]
 enum WistronDockStatusCode {
     Enter = 0x1,
     Prepare = 0x2,
     Updating = 0x3,
     Complete = 0x4, // unplug cable to trigger update
 }
+#[derive(ToString)]
 enum WistronDockComponentIdx {
     Mcu   = 0x0,
     Pd    = 0x1,


### PR DESCRIPTION
Although the compiler does a very good job to eliminate symbols we're not using it's better not to build them in the first place if we know they're not needed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
