### PR TITLE
Enable the retimer offline mode depending on HWIDs

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -258,10 +258,6 @@ The `[thunderbolt]` section can contain the following parameters:
 
   Forces delaying activation until shutdown/logout/reboot.
 
-**RetimerOfflineMode={{FU_THUNDERBOLT_CONFIG_DEFAULT_RETIMER_OFFLINE_MODE}}**
-
-  Uses offline mode interface to update retimers.
-
 NOTES
 -----
 

--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -102,6 +102,16 @@ DROM and exposed in the relevant sysfs attributes.
 If the controller is in native enumeration mode, the string "-native" is added
 at the end so the format is "TBT-vvvvdddd-native".
 
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### Flags=retimer-offline-mode
+
+Use offline mode interface to update retimers.
+
+Since: 1.9.1
+
 ## External Interface Access
 
 This plugin requires read/write access to `/sys/bus/thunderbolt`.

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -23,7 +23,6 @@ G_DEFINE_TYPE(FuThunderboltPlugin, fu_thunderbolt_plugin, FU_TYPE_PLUGIN)
 /* defaults changed here will also be reflected in the fwupd.conf man page */
 #define FU_THUNDERBOLT_CONFIG_DEFAULT_MINIMUM_KERNEL_VERSION "4.13.0"
 #define FU_THUNDERBOLT_CONFIG_DEFAULT_DELAYED_ACTIVATION     FALSE
-#define FU_THUNDERBOLT_CONFIG_DEFAULT_RETIMER_OFFLINE_MODE   FALSE
 
 static gboolean
 fu_thunderbolt_plugin_safe_kernel(FuPlugin *plugin, GError **error)
@@ -38,12 +37,11 @@ fu_thunderbolt_plugin_safe_kernel(FuPlugin *plugin, GError **error)
 static gboolean
 fu_thunderbolt_plugin_device_created(FuPlugin *plugin, FuDevice *dev, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_rule(plugin,
 			   FU_PLUGIN_RULE_INHIBITS_IDLE,
 			   "thunderbolt requires device wakeup");
-	if (fu_plugin_get_config_value_boolean(plugin,
-					       "RetimerOfflineMode",
-					       FU_THUNDERBOLT_CONFIG_DEFAULT_RETIMER_OFFLINE_MODE))
+	if (fu_context_has_hwid_flag(ctx, "retimer-offline-mode"))
 		fu_device_add_private_flag(dev, FU_THUNDERBOLT_DEVICE_FLAG_FORCE_ENUMERATION);
 	return TRUE;
 }

--- a/plugins/thunderbolt/thunderbolt.quirk
+++ b/plugins/thunderbolt/thunderbolt.quirk
@@ -5,3 +5,11 @@ GType = FuThunderboltController
 [THUNDERBOLT\TYPE_THUNDERBOLT_RETIMER]
 Plugin = thunderbolt
 GType = FuThunderboltRetimer
+
+# Google Redrix
+[​af1d04d1-fbe9-5197-973d-fdc9310a33bd]
+Flags = retimer-offline-mode
+
+# Google Rex
+[​​fe682559-28dc-58b3-bf61-aa8414d9f363]
+Flags = retimer-offline-mode


### PR DESCRIPTION
One config value is not granular enough; for the same build of fwupd on RHEL or ChromeOS we only want to target the hardware where the EC is going to actually do what we tell it to -- rather than crash...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
