### PR TITLE
Invalidate the XMLb cache when installing new fwupd versions

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4614,6 +4614,9 @@ fu_engine_load_metadata_store(FuEngine *self, FuEngineLoadFlags flags, GError **
 	/* clear existing silo */
 	g_clear_object(&self->silo);
 
+	/* invalidate the cache if the fwupd version changes */
+	xb_builder_append_guid(builder, SOURCE_VERSION);
+
 	/* verbose profiling */
 	if (g_getenv("FWUPD_XMLB_VERBOSE") != NULL) {
 		xb_builder_set_profile_flags(builder,


### PR DESCRIPTION
We might be fixing a bug related to metadata cache generation.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
