### PR TITLE
plugins: nordic-hid: Add MCUboot direct-xip mode support

### DIFF
--- a/plugins/nordic-hid/README.md
+++ b/plugins/nordic-hid/README.md
@@ -53,7 +53,7 @@ This plugin uses the following plugin-specific quirks:
 
 ### NordicHidBootloader
 
-Explicitly set the expected bootloader type: "B0" or "MCUBOOT"
+Explicitly set the expected bootloader type: "B0", "MCUBOOT" or "MCUBOOT+XIP".
 This quirk must be set for devices without support of `bootloader variant` DFU option.
 
 ### NordicHidGeneration

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -125,6 +125,9 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 		} else if (json_object_has_member(obj, "version_MCUBOOT")) {
 			bootloader_name = "MCUBOOT";
 			image = g_object_new(FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT, NULL);
+		} else if (json_object_has_member(obj, "version_MCUBOOT+XIP")) {
+			bootloader_name = "MCUBOOT+XIP";
+			image = g_object_new(FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT, NULL);
 		} else {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
@@ -149,10 +152,10 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 					    "manifest invalid as has no target board information");
 			return FALSE;
 		}
-		/* images for B0 bootloader are listed in strict order:
+		/* The images for B0 or MCUboot+XIP bootloader are listed in strict order:
 		 * this is guaranteed by producer set the id format as
 		 * <board>_<bl>_<bank>N, i.e "nrf52840dk_B0_bank0".
-		 * For MCUBoot bootloader only the single image is available */
+		 * For MCUBoot bootloader that swaps images, only a single image is available */
 		image_id = g_strdup_printf("%s_%s_bank%01u", board_split[0], bootloader_name, i);
 		if (!fu_firmware_parse(image, blob, flags | FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 			return FALSE;

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -767,7 +767,7 @@ fu_nordic_hid_cfg_channel_dfu_fwinfo(FuNordicHidCfgChannel *self, GError **error
 	}
 	/* set the target flash ID area */
 	self->flash_area_id = res->data[0] ^ 1;
-	/* always use the bank 0 for MCUBOOT bootloader */
+	/* always use the bank 0 for MCUBOOT bootloader that swaps images */
 	if (g_strcmp0(self->bl_name, "MCUBOOT") == 0)
 		self->flash_area_id = 0;
 
@@ -1276,11 +1276,13 @@ fu_nordic_hid_cfg_channel_set_quirk_kv(FuDevice *device,
 			self->bl_name = g_strdup("B0");
 		else if (g_strcmp0(value, "MCUBOOT") == 0)
 			self->bl_name = g_strdup("MCUBOOT");
+		else if (g_strcmp0(value, "MCUBOOT+XIP") == 0)
+			self->bl_name = g_strdup("MCUBOOT+XIP");
 		else {
 			g_set_error_literal(error,
 					    G_IO_ERROR,
 					    G_IO_ERROR_INVALID_DATA,
-					    "must be 'B0' or 'MCUBOOT'");
+					    "must be 'B0', 'MCUBOOT' or 'MCUBOOT+XIP'");
 			return FALSE;
 		}
 		return TRUE;


### PR DESCRIPTION
Change introduces support for MCUboot bootloader built in direct-xip mode.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation