### PR TITLE
Remove the FuPlugin::config-changed signal

### DIFF
--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -62,7 +62,6 @@ struct _FuPluginClass {
 	void (*_device_register)(FuPlugin *self, FuDevice *device);
 	gboolean (*_check_supported)(FuPlugin *self, const gchar *guid);
 	void (*_rules_changed)(FuPlugin *self);
-	void (*_config_changed)(FuPlugin *self);
 
 	/* vfuncs */
 	/**

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6852,14 +6852,6 @@ fu_engine_plugin_rules_changed_cb(FuPlugin *plugin, gpointer user_data)
 }
 
 static void
-fu_engine_plugin_config_changed_cb(FuPlugin *plugin, gpointer user_data)
-{
-	FuEngine *self = FU_ENGINE(user_data);
-	g_info("config file for %s changed, sending SHUTDOWN", fu_plugin_get_name(plugin));
-	fu_engine_set_status(self, FWUPD_STATUS_SHUTDOWN);
-}
-
-static void
 fu_engine_context_security_changed_cb(FuContext *ctx, gpointer user_data)
 {
 	FuEngine *self = FU_ENGINE(user_data);
@@ -7528,10 +7520,6 @@ fu_engine_plugins_init(FuEngine *self, FuProgress *progress, GError **error)
 		g_signal_connect(FU_PLUGIN(plugin),
 				 "rules-changed",
 				 G_CALLBACK(fu_engine_plugin_rules_changed_cb),
-				 self);
-		g_signal_connect(FU_PLUGIN(plugin),
-				 "config-changed",
-				 G_CALLBACK(fu_engine_plugin_config_changed_cb),
 				 self);
 		fu_progress_step_done(progress);
 	}


### PR DESCRIPTION
It's no longer required as we use fwupd.conf for everything.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
