### PR TITLE
wacom-usb: Allow the firmware time to process commands to avoid a device crash

### DIFF
--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
@@ -25,6 +25,8 @@ G_DEFINE_TYPE(FuWacModuleBluetoothId6, fu_wac_module_bluetooth_id6, FU_TYPE_WAC_
 #define FU_WAC_MODULE_BLUETOOTH_ID6_START_NORMAL    0x00
 #define FU_WAC_MODULE_BLUETOOTH_ID6_START_FULLERASE 0xFE
 
+#define FU_WAC_MODULE_BLUETOOTH_ID6_WRITE_TIMEOUT 8000 /* ms */
+
 static guint8
 fu_wac_module_bluetooth_id6_reverse_bits(guint8 value)
 {
@@ -75,7 +77,7 @@ fu_wac_module_bluetooth_id6_write_blob(FuWacModule *self,
 					       FU_WAC_MODULE_COMMAND_DATA,
 					       blob_chunk,
 					       fu_progress_get_child(progress),
-					       FU_WAC_MODULE_WRITE_TIMEOUT,
+					       FU_WAC_MODULE_BLUETOOTH_ID6_WRITE_TIMEOUT,
 					       error)) {
 			g_prefix_error(error, "failed to write block %u of %u: ", i, chunks->len);
 			return FALSE;


### PR DESCRIPTION
In some cases fwupd polling the device so quickly after setting the feature report can cause the device firmware to return junk, or self-reset. Add a small delay as a pragmatic fix -- which doesn't actually slow down the firmware deploy as it's normally when 'busy' is returned.

Also, increase the maximum allowed time for an ID6 write as in some rare circumstances it can take more than the maximum 2000ms.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
