### PR TITLE
logitech-hidpp: Add support for more TI Unifying receiver variants

### DIFF
--- a/plugins/logitech-hidpp/logitech-hidpp.quirk
+++ b/plugins/logitech-hidpp/logitech-hidpp.quirk
@@ -60,6 +60,23 @@ FirmwareSizeMin = 0x4000
 CounterpartGuid = HIDRAW\VEN_046D&DEV_C52B
 InstallDuration = 18
 
+# Texas Pico (another variant) / C-U0016
+[USB\VID_046D&PID_AAE5]
+Plugin = logitech_hidpp
+GType = FuLogitechHidPpBootloaderTexas
+FirmwareSizeMin = 0x4000
+CounterpartGuid = HIDRAW\VEN_046D&DEV_C52B
+InstallDuration = 18
+
+# Texas Unknown
+# https://github.com/Logitech/fw_updates/blob/1ddde61310573ecea54c4204b401393a90f4bbae/RQR24/RQR24.11/RQR24.11_B0036.txt#L22
+[USB\VID_046D&PID_AAF8]
+Plugin = logitech_hidpp
+GType = FuLogitechHidPpBootloaderTexas
+FirmwareSizeMin = 0x4000
+CounterpartGuid = HIDRAW\VEN_046D&DEV_C52B
+InstallDuration = 18
+
 # K780 (through Unifying receiver)
 [HIDRAW\VEN_046D&DEV_405B]
 Plugin = logitech_hidpp


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

The patch enables fwupd to work with two new variants of Logitech Unifying receiver (TI).
I have tested the patch on my `C-U0012` Pico receiver and it works totally fine. Differing from previous `C-U0012`s whose PID in DFU mode is `AAAD`, mine is `AAE5`.
There is another variant get supported in this patch, whose PID in DFU mode is `AAF8`. I do not have such a receiver and the PID is documented in https://github.com/Logitech/fw_updates/blob/1ddde61310573ecea54c4204b401393a90f4bbae/RQR24/RQR24.11/RQR24.11_B0036.txt#L22. I guess it is `C-U0016`, a signal-enhanced Unifying receiver bundled with `K600` (ref: https://post.smzdm.com/p/aqnlx78p), which is known to be driven by a TI CC2544 (ref: https://fccid.io/JNZCU0016/Internal-Photos/Internal-Photos-3182497.pdf). I've managed to buy one. Once I receive it, I will update more information here.

See also https://github.com/fwupd/fwupd/issues/4259#issuecomment-1537361667

Note: I did not update macros in `plugins/logitech-hidpp/fu-logitech-hidpp-common.h` as no C code needs to reference the new PIDs.