### PR TITLE
Fix behavior of EspLocation if UDisks is not available

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -757,11 +757,12 @@ fu_volume_new_esp_for_path(const gchar *esp_path, GError **error)
 	g_return_val_if_fail(esp_path != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
+	/* check if it's a valid directory already */
+	if (g_file_test(esp_path, G_FILE_TEST_IS_DIR))
+		return fu_volume_new_from_mount_path(esp_path);
+
 	volumes = fu_volume_new_by_kind(FU_VOLUME_KIND_ESP, &error_local);
 	if (volumes == NULL) {
-		/* check if it's a valid directory already */
-		if (g_file_test(esp_path, G_FILE_TEST_IS_DIR))
-			return fu_volume_new_from_mount_path(esp_path);
 		g_propagate_error(error, g_steal_pointer(&error_local));
 		return NULL;
 	}


### PR DESCRIPTION
When an ESP mount path is set in the daemon config via the `EspLocation` setting, UDisks should not be required for finding the ESP path. In `fu_volume_new_esp_for_path`, move up the check of `esp_path` so that it returns that mount immediately if it's a valid directory. This needs to happen _before_ the call to `fu_volume_new_by_kind`, as that function requires UDisks to be available.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
