### PR TITLE
Fix fwupd.conf(5) man page to use [fwupd] section

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -42,7 +42,7 @@ Case is not significant in boolean values, but is preserved in string values.
 DAEMON PARAMETERS
 -----------------
 
-The `[daemon]` section can contain the following parameters:
+The `[fwupd]` section can contain the following parameters:
 
 **DisabledDevices=**
 


### PR DESCRIPTION
I believe this man page needs to be updated to use `[fwupd]` as the section (consistent with the provided default fwupd.conf and with what I can see in the current source).

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
