### PR TITLE
trivial: Do not use 'const gpointer' to fix clang-tidy misc-misplaced-const

### DIFF
--- a/plugins/synaptics-prometheus/fu-synaprom-common.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-common.c
@@ -28,12 +28,12 @@ enum {
 };
 
 GByteArray *
-fu_synaprom_request_new(guint8 cmd, const gpointer data, gsize len)
+fu_synaprom_request_new(guint8 cmd, const guint8 *buf, gsize bufsz)
 {
 	GByteArray *blob = g_byte_array_new();
 	fu_byte_array_append_uint8(blob, cmd);
-	if (data != NULL)
-		g_byte_array_append(blob, data, len);
+	if (buf != NULL)
+		g_byte_array_append(blob, buf, bufsz);
 	return blob;
 }
 

--- a/plugins/synaptics-prometheus/fu-synaprom-common.h
+++ b/plugins/synaptics-prometheus/fu-synaprom-common.h
@@ -10,7 +10,7 @@
 #include <glib.h>
 
 GByteArray *
-fu_synaprom_request_new(guint8 cmd, const gpointer data, gsize len);
+fu_synaprom_request_new(guint8 cmd, const guint8 *buf, gsize bufsz);
 GByteArray *
 fu_synaprom_reply_new(gsize cmdlen);
 gboolean


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
