### PR TITLE
Do not use g_byte_array_free_to_bytes()

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -24,7 +24,10 @@ def test_files() -> int:
             continue
         with open(fn, "rb") as f:
             src = f.read().decode()
-        for token, msg in {"g_error(": "Use GError instead"}.items():
+        for token, msg in {
+            "g_error(": "Use GError instead",
+            "g_byte_array_free_to_bytes(": "Use g_bytes_new() instead",
+        }.items():
             if src.find(token) != -1:
                 print(f"{fn} contains blocked token {token}: {msg}")
                 rc = 1

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5221,7 +5221,7 @@ fwupd_client_download_http(FwupdClient *self, CURL *curl, const gchar *url, GErr
 		return NULL;
 	}
 
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static void
@@ -5411,7 +5411,7 @@ fwupd_client_upload_bytes_thread_cb(GTask *task,
 		return;
 	}
 	g_task_return_pointer(task,
-			      g_byte_array_free_to_bytes(g_steal_pointer(&buf)),
+			      g_bytes_new(buf->data, buf->len),
 			      (GDestroyNotify)g_bytes_unref);
 }
 #endif

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -192,7 +192,7 @@ fu_archive_firmware_get_image_fnmatch(FuArchiveFirmware *self, const gchar *patt
 	return g_steal_pointer(&img_match);
 }
 
-static GBytes *
+static GByteArray *
 fu_archive_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuArchiveFirmware *self = FU_ARCHIVE_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-archive.c
+++ b/libfwupdplugin/fu-archive.c
@@ -574,7 +574,7 @@ fu_archive_write_cb(struct archive *arch, void *user_data, const void *buf, gsiz
  *
  * Since: 1.8.1
  **/
-GBytes *
+GByteArray *
 fu_archive_write(FuArchive *self,
 		 FuArchiveFormat format,
 		 FuArchiveCompression compression,
@@ -674,7 +674,7 @@ fu_archive_write(FuArchive *self,
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&blob));
+	return g_steal_pointer(&blob);
 #else
 	g_set_error_literal(error,
 			    FWUPD_ERROR,

--- a/libfwupdplugin/fu-archive.h
+++ b/libfwupdplugin/fu-archive.h
@@ -135,7 +135,7 @@ void
 fu_archive_add_entry(FuArchive *self, const gchar *fn, GBytes *blob);
 GBytes *
 fu_archive_lookup_by_fn(FuArchive *self, const gchar *fn, GError **error) G_GNUC_WARN_UNUSED_RESULT;
-GBytes *
+GByteArray *
 fu_archive_write(FuArchive *self,
 		 FuArchiveFormat format,
 		 FuArchiveCompression compression,

--- a/libfwupdplugin/fu-bytes.c
+++ b/libfwupdplugin/fu-bytes.c
@@ -170,7 +170,7 @@ fu_bytes_get_contents_stream(GInputStream *stream, gsize count, GError **error)
 			return NULL;
 		}
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 /**
@@ -237,7 +237,7 @@ fu_bytes_get_contents_stream_full(GInputStream *stream, gsize offset, gsize coun
 		if (buf->len >= count)
 			break;
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 /**

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -829,7 +829,7 @@ fu_cfi_device_read_firmware(FuCfiDevice *self, gsize bufsz, FuProgress *progress
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static GBytes *

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -458,7 +458,7 @@ fu_cfu_offer_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_cfu_offer_write(FuFirmware *firmware, GError **error)
 {
 	FuCfuOffer *self = FU_CFU_OFFER(firmware);
@@ -483,7 +483,7 @@ fu_cfu_offer_write(FuFirmware *firmware, GError **error)
 	fu_struct_cfu_offer_set_product_id(st, priv->product_id);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -65,7 +65,7 @@ fu_cfu_payload_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_cfu_payload_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -82,7 +82,7 @@ fu_cfu_payload_write(FuFirmware *firmware, GError **error)
 		g_byte_array_append(buf, st->data, st->len);
 		g_byte_array_append(buf, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -298,7 +298,7 @@ fu_coswid_firmware_write_tag_item(cbor_item_t *root, FuCoswidTag tag, cbor_item_
 }
 #endif
 
-static GBytes *
+static GByteArray *
 fu_coswid_firmware_write(FuFirmware *firmware, GError **error)
 {
 #ifdef HAVE_CBOR
@@ -405,7 +405,7 @@ fu_coswid_firmware_write(FuFirmware *firmware, GError **error)
 				    "CBOR allocation failure");
 		return NULL;
 	}
-	return g_bytes_new(buf, buflen);
+	return g_byte_array_new_take(g_steal_pointer(&buf), buflen);
 #else
 	g_set_error_literal(error,
 			    G_IO_ERROR,

--- a/libfwupdplugin/fu-dfu-firmware-private.h
+++ b/libfwupdplugin/fu-dfu-firmware-private.h
@@ -10,7 +10,7 @@
 
 guint8
 fu_dfu_firmware_get_footer_len(FuDfuFirmware *self);
-GBytes *
+GByteArray *
 fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **error);
 gboolean
 fu_dfu_firmware_parse_footer(FuDfuFirmware *self,

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -279,7 +279,7 @@ fu_dfu_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-GBytes *
+GByteArray *
 fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **error)
 {
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -294,10 +294,10 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
 	fu_struct_dfu_ftr_set_ver(st, priv->dfu_version);
 	g_byte_array_append(buf, st->data, st->len - sizeof(guint32));
 	fu_byte_array_append_uint32(buf, ~fu_crc32(buf->data, buf->len), G_LITTLE_ENDIAN);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
-static GBytes *
+static GByteArray *
 fu_dfu_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuDfuFirmware *self = FU_DFU_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -165,7 +165,7 @@ fu_firmware_chunk_write(FuDfuseFirmware *self, FuChunk *chk)
 	fu_struct_dfuse_element_set_address(st_ele, fu_chunk_get_address(chk));
 	fu_struct_dfuse_element_set_size(st_ele, fu_chunk_get_data_sz(chk));
 	g_byte_array_append(st_ele, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st_ele));
+	return g_bytes_new(st_ele->data, st_ele->len);
 }
 
 static GBytes *
@@ -205,10 +205,10 @@ fu_dfuse_firmware_write_image(FuDfuseFirmware *self, FuFirmware *image, GError *
 		GBytes *blob = g_ptr_array_index(blobs, i);
 		fu_byte_array_append_bytes(st_img, blob);
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st_img));
+	return g_bytes_new(st_img->data, st_img->len);
 }
 
-static GBytes *
+static GByteArray *
 fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuDfuseFirmware *self = FU_DFUSE_FIRMWARE(firmware);
@@ -250,7 +250,7 @@ fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* return blob */
-	blob_noftr = g_byte_array_free_to_bytes(g_steal_pointer(&st_hdr));
+	blob_noftr = g_bytes_new(st_hdr->data, st_hdr->len);
 	return fu_dfu_firmware_append_footer(FU_DFU_FIRMWARE(firmware), blob_noftr, error);
 }
 

--- a/libfwupdplugin/fu-efi-firmware-common.c
+++ b/libfwupdplugin/fu-efi-firmware-common.c
@@ -123,7 +123,7 @@ fu_efi_firmware_decompress_lzma(GBytes *blob, GError **error)
 			    rc);
 		return NULL;
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 #else
 	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "missing lzma support");
 	return NULL;

--- a/libfwupdplugin/fu-efi-firmware-file.c
+++ b/libfwupdplugin/fu-efi-firmware-file.c
@@ -256,10 +256,10 @@ fu_efi_firmware_file_write_sections(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
-static GBytes *
+static GByteArray *
 fu_efi_firmware_file_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiFirmwareFile *self = FU_EFI_FIRMWARE_FILE(firmware);
@@ -291,7 +291,7 @@ fu_efi_firmware_file_write(FuFirmware *firmware, GError **error)
 
 	/* success */
 	fu_byte_array_append_bytes(st, blob);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-firmware-filesystem.c
+++ b/libfwupdplugin/fu-efi-firmware-filesystem.c
@@ -64,7 +64,7 @@ fu_efi_firmware_filesystem_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_efi_firmware_filesystem_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -93,7 +93,7 @@ fu_efi_firmware_filesystem_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-firmware-section.c
+++ b/libfwupdplugin/fu-efi-firmware-section.c
@@ -184,7 +184,7 @@ fu_efi_firmware_section_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_efi_firmware_section_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiFirmwareSection *self = FU_EFI_FIRMWARE_SECTION(firmware);
@@ -215,7 +215,7 @@ fu_efi_firmware_section_write(FuFirmware *firmware, GError **error)
 
 	/* blob */
 	fu_byte_array_append_bytes(buf, blob);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-firmware-volume.c
+++ b/libfwupdplugin/fu-efi-firmware-volume.c
@@ -176,7 +176,7 @@ fu_efi_firmware_volume_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiFirmwareVolume *self = FU_EFI_FIRMWARE_VOLUME(firmware);
@@ -254,7 +254,7 @@ fu_efi_firmware_volume_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_set_size(buf, fv_length, 0xFF);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -247,7 +247,7 @@ fu_efi_signature_list_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_efi_signature_list_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = fu_struct_efi_signature_list_new();
@@ -263,7 +263,7 @@ fu_efi_signature_list_write(FuFirmware *firmware, GError **error)
 	for (guint i = 0; i < 16; i++)
 		fu_byte_array_append_uint8(buf, '2');
 
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 /**

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -490,7 +490,7 @@ fu_fdt_firmware_write_image(FuFdtFirmware *self,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuFdtFirmware *self = FU_FDT_FIRMWARE(firmware);
@@ -554,7 +554,7 @@ fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_align_up(st_hdr, FU_FIRMWARE_ALIGNMENT_4, 0x0);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st_hdr));
+	return g_steal_pointer(&st_hdr);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -598,7 +598,7 @@ fu_firmware_get_bytes_with_patches(FuFirmware *self, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 /**
@@ -1261,8 +1261,12 @@ fu_firmware_write(FuFirmware *self, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* subclassed */
-	if (klass->write != NULL)
-		return klass->write(self, error);
+	if (klass->write != NULL) {
+		g_autoptr(GByteArray) buf = klass->write(self, error);
+		if (buf == NULL)
+			return NULL;
+		return g_bytes_new(buf->data, buf->len);
+	}
 
 	/* just add default blob */
 	return fu_firmware_get_bytes_with_patches(self, error);

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -54,7 +54,7 @@ struct _FuFirmwareClass {
 			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
-	GBytes *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
+	GByteArray *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	void (*export)(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode *bn);
 	gboolean (*tokenize)(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GError **error)
 	    G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -116,7 +116,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 {
 	gsize total_sz;
@@ -168,7 +168,7 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -287,7 +287,7 @@ fu_ifd_firmware_check_jedec_cmd(FuIfdFirmware *self, guint8 cmd)
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuIfdFirmware *self = FU_IFD_FIRMWARE(firmware);
@@ -305,7 +305,7 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 		fu_byte_array_set_size(buf_desc, FU_IFD_SIZE, 0x00);
 
 		/* success */
-		blob_desc = g_byte_array_free_to_bytes(g_steal_pointer(&buf_desc));
+		blob_desc = g_bytes_new(buf_desc->data, buf_desc->len);
 		img_desc = fu_firmware_new_from_bytes(blob_desc);
 		fu_firmware_set_addr(img_desc, 0x0);
 		fu_firmware_set_idx(img_desc, FU_IFD_REGION_DESC);
@@ -427,7 +427,7 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-ifd-image.c
+++ b/libfwupdplugin/fu-ifd-image.c
@@ -76,7 +76,7 @@ fu_ifd_image_get_access(FuIfdImage *self, FuIfdRegion region)
 	return priv->access[region];
 }
 
-static GBytes *
+static GByteArray *
 fu_ifd_image_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -115,7 +115,7 @@ fu_ifd_image_write(FuFirmware *firmware, GError **error)
 			       0x00);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -214,7 +214,7 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ifwi_cpd_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuIfwiCpdFirmware *self = FU_IFWI_CPD_FIRMWARE(firmware);
@@ -279,7 +279,7 @@ fu_ifwi_cpd_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -122,7 +122,7 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ifwi_fpt_firmware_write(FuFirmware *firmware, GError **error)
 {
 	gsize offset = 0;
@@ -168,7 +168,7 @@ fu_ifwi_fpt_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -512,9 +512,10 @@ fu_ihex_firmware_image_to_string(GBytes *bytes,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ihex_firmware_write(FuFirmware *firmware, GError **error)
 {
+	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(FuFirmware) img_sig = NULL;
 	g_autoptr(GString) str = g_string_new("");
@@ -546,7 +547,8 @@ fu_ihex_firmware_write(FuFirmware *firmware, GError **error)
 
 	/* add EOF */
 	fu_ihex_firmware_emit_chunk(str, 0x0, FU_IHEX_FIRMWARE_RECORD_TYPE_EOF, NULL, 0);
-	return g_bytes_new(str->str, str->len);
+	g_byte_array_append(buf, (const guint8 *)str->str, str->len);
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-intel-thunderbolt-firmware.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-firmware.c
@@ -74,11 +74,11 @@ fu_intel_thunderbolt_firmware_parse(FuFirmware *firmware,
 	    ->parse(firmware, fw, offset + farb_pointer, flags, error);
 }
 
-static GBytes *
+static GByteArray *
 fu_intel_thunderbolt_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GByteArray) buf_nvm = NULL;
 
 	/* sanity check */
 	if (fu_firmware_get_offset(firmware) < 0x08) {
@@ -94,12 +94,14 @@ fu_intel_thunderbolt_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_set_size(buf, fu_firmware_get_offset(firmware), 0x00);
 
 	/* FuIntelThunderboltNvm->write */
-	blob =
+	buf_nvm =
 	    FU_FIRMWARE_CLASS(fu_intel_thunderbolt_firmware_parent_class)->write(firmware, error);
-	fu_byte_array_append_bytes(buf, blob);
+	if (buf_nvm == NULL)
+		return NULL;
+	g_byte_array_append(buf, buf_nvm->data, buf_nvm->len);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -712,7 +712,7 @@ fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 }
 
 /* can only write version 3 NVM */
-static GBytes *
+static GByteArray *
 fu_intel_thunderbolt_nvm_write(FuFirmware *firmware, GError **error)
 {
 	FuIntelThunderboltNvm *self = FU_INTEL_THUNDERBOLT_NVM(firmware);
@@ -815,7 +815,7 @@ fu_intel_thunderbolt_nvm_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -275,10 +275,11 @@ fu_io_channel_read_bytes(FuIOChannel *self,
 			 FuIOChannelFlags flags,
 			 GError **error)
 {
-	GByteArray *buf = fu_io_channel_read_byte_array(self, max_size, timeout_ms, flags, error);
+	g_autoptr(GByteArray) buf =
+	    fu_io_channel_read_byte_array(self, max_size, timeout_ms, flags, error);
 	if (buf == NULL)
 		return NULL;
-	return g_byte_array_free_to_bytes(buf);
+	return g_bytes_new(buf->data, buf->len);
 }
 
 /**

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -113,7 +113,7 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_linear_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -131,7 +131,7 @@ fu_linear_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -194,7 +194,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuOpromFirmware *self = FU_OPROM_FIRMWARE(firmware);
@@ -240,7 +240,7 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -545,9 +545,10 @@ fu_srec_firmware_write_line(GString *str,
 	g_string_append_printf(str, "%02X\n", csum);
 }
 
-static GBytes *
+static GByteArray *
 fu_srec_firmware_write(FuFirmware *firmware, GError **error)
 {
+	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GString) str = g_string_new(NULL);
 	g_autoptr(GBytes) buf_blob = NULL;
 	const gchar *id = fu_firmware_get_id(firmware);
@@ -602,7 +603,8 @@ fu_srec_firmware_write(FuFirmware *firmware, GError **error)
 	fu_srec_firmware_write_line(str, kind_term, 0x0, NULL, 0);
 
 	/* success */
-	return g_string_free_to_bytes(g_steal_pointer(&str));
+	g_byte_array_append(buf, (const guint8 *)str->str, str->len);
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -233,7 +233,7 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 	return FALSE;
 }
 
-static GBytes *
+static GByteArray *
 fu_usb_device_ds20_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) st = fu_struct_ds20_new();
@@ -249,7 +249,7 @@ fu_usb_device_ds20_write(FuFirmware *firmware, GError **error)
 	fu_struct_ds20_set_platform_ver(st, fu_firmware_get_version_raw(firmware));
 	fu_struct_ds20_set_total_length(st, fu_firmware_get_size(firmware));
 	fu_struct_ds20_set_vendor_code(st, fu_firmware_get_idx(firmware));
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static void

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -156,7 +156,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuUswidFirmware *self = FU_USWID_FIRMWARE(firmware);
@@ -188,7 +188,7 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 		if (payload_blob == NULL)
 			return NULL;
 	} else {
-		payload_blob = g_byte_array_free_to_bytes(g_steal_pointer(&payload));
+		payload_blob = g_bytes_new(payload->data, payload->len);
 	}
 
 	/* pack */
@@ -206,7 +206,7 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(buf, payload_blob);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -116,7 +116,7 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 {
 	FuAcpiPhatHealthRecord *self = FU_ACPI_PHAT_HEALTH_RECORD(firmware);
@@ -149,7 +149,7 @@ fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 		g_byte_array_append(st, (const guint8 *)device_path_utf16, device_path_utf16sz);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -56,7 +56,7 @@ fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_acpi_phat_version_element_write(FuFirmware *firmware, GError **error)
 {
 	FuAcpiPhatVersionElement *self = FU_ACPI_PHAT_VERSION_ELEMENT(firmware);
@@ -76,7 +76,7 @@ fu_acpi_phat_version_element_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -54,7 +54,7 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_acpi_phat_version_record_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf2 = g_byte_array_new();
@@ -77,7 +77,7 @@ fu_acpi_phat_version_record_write(FuFirmware *firmware, GError **error)
 
 	/* element data */
 	g_byte_array_append(st, buf2->data, buf2->len);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -222,7 +222,7 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_acpi_phat_write(FuFirmware *firmware, GError **error)
 {
 	FuAcpiPhat *self = FU_ACPI_PHAT(firmware);
@@ -285,7 +285,7 @@ fu_acpi_phat_write(FuFirmware *firmware, GError **error)
 	buf->data[9] = 0xFF - fu_sum8(buf->data, buf->len);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -48,7 +48,7 @@ fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_bcm57xx_dict_image_write(FuFirmware *firmware, GError **error)
 {
 	const guint8 *buf;
@@ -70,7 +70,7 @@ fu_bcm57xx_dict_image_write(FuFirmware *firmware, GError **error)
 	/* add CRC */
 	crc = fu_bcm57xx_nvram_crc(buf, bufsz);
 	fu_byte_array_append_uint32(blob, crc, G_LITTLE_ENDIAN);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&blob));
+	return g_steal_pointer(&blob);
 }
 
 static gboolean

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -458,10 +458,10 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 static GBytes *
 _g_bytes_new_sized(gsize sz)
 {
-	GByteArray *tmp = g_byte_array_sized_new(sz);
+	g_autoptr(GByteArray) tmp = g_byte_array_sized_new(sz);
 	for (gsize i = 0; i < sz; i++)
 		fu_byte_array_append_uint8(tmp, 0x0);
-	return g_byte_array_free_to_bytes(tmp);
+	return g_bytes_new(tmp->data, tmp->len);
 }
 
 static gboolean
@@ -482,7 +482,7 @@ fu_bcm57xx_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_bcm57xx_firmware_write(FuFirmware *firmware, GError **error)
 {
 	gsize off = BCM_NVRAM_STAGE1_BASE;
@@ -571,12 +571,12 @@ fu_bcm57xx_firmware_write(FuFirmware *firmware, GError **error)
 		if (blob_info == NULL)
 			return NULL;
 	} else {
-		GByteArray *tmp = g_byte_array_sized_new(BCM_NVRAM_INFO_SZ);
+		g_autoptr(GByteArray) tmp = g_byte_array_sized_new(BCM_NVRAM_INFO_SZ);
 		for (gsize i = 0; i < BCM_NVRAM_INFO_SZ; i++)
 			fu_byte_array_append_uint8(tmp, 0x0);
 		fu_memwrite_uint16(tmp->data + BCM_NVRAM_INFO_VENDOR, self->vendor, G_BIG_ENDIAN);
 		fu_memwrite_uint16(tmp->data + BCM_NVRAM_INFO_DEVICE, self->model, G_BIG_ENDIAN);
-		blob_info = g_byte_array_free_to_bytes(tmp);
+		blob_info = g_bytes_new(tmp->data, tmp->len);
 	}
 	fu_byte_array_append_bytes(buf, blob_info);
 
@@ -617,7 +617,7 @@ fu_bcm57xx_firmware_write(FuFirmware *firmware, GError **error)
 		fu_byte_array_append_uint8(buf, self->source_padchar);
 
 	/* add EOF */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 guint16

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -93,7 +93,7 @@ fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_bcm57xx_stage1_image_write(FuFirmware *firmware, GError **error)
 {
 	guint32 crc;
@@ -140,7 +140,7 @@ fu_bcm57xx_stage1_image_write(FuFirmware *firmware, GError **error)
 	/* add CRC */
 	crc = fu_bcm57xx_nvram_crc(buf->data, buf->len);
 	fu_byte_array_append_uint32(buf, crc, G_LITTLE_ENDIAN);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -36,7 +36,7 @@ fu_bcm57xx_stage2_image_parse(FuFirmware *image,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_bcm57xx_stage2_image_write(FuFirmware *image, GError **error)
 {
 	const guint8 *buf;
@@ -60,7 +60,7 @@ fu_bcm57xx_stage2_image_write(FuFirmware *image, GError **error)
 
 	/* add CRC */
 	fu_byte_array_append_uint32(blob, fu_bcm57xx_nvram_crc(buf, bufsz), G_LITTLE_ENDIAN);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&blob));
+	return g_steal_pointer(&blob);
 }
 
 static void

--- a/plugins/ccgx/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx/fu-ccgx-dmc-firmware.c
@@ -391,7 +391,7 @@ fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -497,7 +497,7 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 			return NULL;
 	}
 
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -124,7 +124,7 @@ fu_ccgx_firmware_add_record(FuCcgxFirmware *self,
 		fu_byte_array_append_uint8(data, tmp);
 		checksum_calc += tmp;
 	}
-	rcd->data = g_byte_array_free_to_bytes(g_steal_pointer(&data));
+	rcd->data = g_bytes_new(data->data, data->len);
 
 	/* verify 2s complement checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
@@ -417,7 +417,7 @@ fu_ccgx_firmware_write_record(GString *str,
 			       (guint)((guint8)~checksum_calc));
 }
 
-static GBytes *
+static GByteArray *
 fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuCcgxFirmware *self = FU_CCGX_FIRMWARE(firmware);
@@ -425,6 +425,7 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	gsize fwbufsz = 0;
 	guint8 checksum_img = 0xff;
 	const guint8 *fwbuf;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GByteArray) mdbuf = g_byte_array_new();
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
@@ -480,7 +481,9 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 				      mdbuf->data,
 				      mdbuf->len);
 
-	return g_string_free_to_bytes(g_steal_pointer(&str));
+	/* success */
+	g_byte_array_append(buf, (const guint8 *)str->str, str->len);
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/ch341a/fu-ch341a-cfi-device.c
+++ b/plugins/ch341a/fu-ch341a-cfi-device.c
@@ -313,7 +313,7 @@ fu_ch341a_cfi_device_read_firmware(FuCh341aCfiDevice *self,
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&blob));
+	return g_bytes_new(blob->data, blob->len);
 }
 
 static gboolean

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -73,7 +73,7 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ebitdo_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) st = fu_struct_ebitdo_hdr_new();
@@ -87,7 +87,7 @@ fu_ebitdo_firmware_write(FuFirmware *firmware, GError **error)
 	fu_struct_ebitdo_hdr_set_destination_addr(st, fu_firmware_get_addr(firmware));
 	fu_struct_ebitdo_hdr_set_destination_len(st, g_bytes_get_size(blob));
 	fu_byte_array_append_bytes(st, blob);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st));
+	return g_steal_pointer(&st);
 }
 
 static void

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -183,7 +183,7 @@ fu_elanfp_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_elanfp_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuElanfpFirmware *self = FU_ELANFP_FIRMWARE(firmware);
@@ -227,7 +227,7 @@ fu_elanfp_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -250,7 +250,7 @@ fu_elantp_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_elantp_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuElantpFirmware *self = FU_ELANTP_FIRMWARE(firmware);
@@ -295,7 +295,7 @@ fu_elantp_firmware_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	fu_byte_array_append_bytes(buf, blob);
 	g_byte_array_append(buf, elantp_signature, sizeof(elantp_signature));
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -120,7 +120,7 @@ fu_genesys_scaler_firmware_build(FuFirmware *firmware, XbNode *n, GError **error
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_genesys_scaler_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuGenesysScalerFirmware *self = FU_GENESYS_SCALER_FIRMWARE(firmware);
@@ -137,7 +137,7 @@ fu_genesys_scaler_firmware_write(FuFirmware *firmware, GError **error)
 	g_byte_array_append(buf, (const guint8 *)&self->public_key, sizeof(self->public_key));
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -242,7 +242,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_genesys_usbhub_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuGenesysUsbhubFirmware *self = FU_GENESYS_USBHUB_FIRMWARE(firmware);
@@ -295,7 +295,7 @@ fu_genesys_usbhub_firmware_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gchar *

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -128,7 +128,7 @@ fu_hailuck_bl_device_dump_firmware(FuDevice *device, FuProgress *progress, GErro
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&fwbuf));
+	return g_bytes_new(fwbuf->data, fwbuf->len);
 }
 
 static gboolean

--- a/plugins/hailuck/fu-hailuck-kbd-firmware.c
+++ b/plugins/hailuck/fu-hailuck-kbd-firmware.c
@@ -79,7 +79,7 @@ fu_hailuck_kbd_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* whole image */
-	fw_new = g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	fw_new = g_bytes_new(buf->data, buf->len);
 	fu_firmware_set_bytes(firmware, fw_new);
 	return TRUE;
 }

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -248,11 +248,11 @@ fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_igsc_aux_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/intel-spi/fu-intel-spi-device.c
+++ b/plugins/intel-spi/fu-intel-spi-device.c
@@ -439,7 +439,7 @@ fu_intel_spi_device_dump(FuIntelSpiDevice *self,
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static GBytes *

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -78,7 +78,7 @@ fu_firehose_read(FuFirehoseUpdater *self, guint timeout_ms, FuIOChannelFlags fla
 {
 	if (self->sahara != NULL) {
 		GByteArray *bytearr = fu_sahara_loader_qdl_read(self->sahara, error);
-		return bytearr == NULL ? NULL : g_byte_array_free_to_bytes(bytearr);
+		return bytearr == NULL ? NULL : g_bytes_new(bytearr->data, bytearr->len);
 	}
 
 	return fu_io_channel_read_bytes(self->io_channel, -1, timeout_ms, flags, error);
@@ -331,7 +331,7 @@ fu_firehose_updater_send_and_receive(FuFirehoseUpdater *self,
 		g_byte_array_append(take_cmd_bytearray,
 				    (const guint8 *)cmd_trailer,
 				    strlen(cmd_trailer));
-		cmd_bytes = g_byte_array_free_to_bytes(take_cmd_bytearray);
+		cmd_bytes = g_bytes_new(take_cmd_bytearray->data, take_cmd_bytearray->len);
 
 		fu_firehose_updater_log_message("writing", cmd_bytes);
 		if (!fu_firehose_write(self,

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -74,7 +74,7 @@ fu_test_mtd_device_func(void)
 	/* create a random payload exactly the same size */
 	for (gsize i = 0; i < bufsz; i++)
 		fu_byte_array_append_uint8(buf, g_rand_int_range(rand, 0x00, 0xFF));
-	fw = g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	fw = g_bytes_new(buf->data, buf->len);
 
 	/* write with a verify */
 	ret = fu_device_write_firmware(device, fw, progress, FWUPD_INSTALL_FLAG_NONE, &error);

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -19,7 +19,7 @@ struct _FuNordicHidFirmwareB0 {
 
 G_DEFINE_TYPE(FuNordicHidFirmwareB0, fu_nordic_hid_firmware_b0, FU_TYPE_NORDIC_HID_FIRMWARE)
 
-static GBytes *
+static GByteArray *
 fu_nordic_hid_firmware_b0_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -35,7 +35,7 @@ fu_nordic_hid_firmware_b0_write(FuFirmware *firmware, GError **error)
 	if (blob == NULL)
 		return NULL;
 	fu_byte_array_append_bytes(buf, blob);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuNordicHidFirmwareMcuboot,
 	      fu_nordic_hid_firmware_mcuboot,
 	      FU_TYPE_NORDIC_HID_FIRMWARE)
 
-static GBytes *
+static GByteArray *
 fu_nordic_hid_firmware_mcuboot_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -55,7 +55,7 @@ fu_nordic_hid_firmware_mcuboot_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_uint16(buf, IMAGE_TLV_INFO_MAGIC, G_LITTLE_ENDIAN);
 	fu_byte_array_append_uint16(buf, 0x00, G_LITTLE_ENDIAN);
 
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 /* simple validation of the image */

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -110,7 +110,7 @@ fu_optionrom_device_dump_firmware(FuDevice *device, FuProgress *progress, GError
 			    buf->len);
 		return NULL;
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static void

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -136,7 +136,7 @@ fu_pxi_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_pxi_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuPxiFirmware *self = FU_PXI_FIRMWARE(firmware);
@@ -202,7 +202,7 @@ fu_pxi_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	g_byte_array_append(buf, fw_header, sizeof(fw_header));
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -336,7 +336,7 @@ fu_redfish_smbios_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_redfish_smbios_write(FuFirmware *firmware, GError **error)
 {
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);
@@ -377,7 +377,7 @@ fu_redfish_smbios_write(FuFirmware *firmware, GError **error)
 	g_byte_array_append(buf, st->data, st->len);
 	if (hostname_sz > 0)
 		g_byte_array_append(buf, (guint8 *)self->hostname, hostname_sz);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -100,7 +100,7 @@ fu_synaptics_cape_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_synaptics_cape_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsCapeFirmware *self = FU_SYNAPTICS_CAPE_FIRMWARE(firmware);
@@ -124,7 +124,7 @@ fu_synaptics_cape_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(buf, payload);
 	fu_byte_array_align_up(buf, FU_FIRMWARE_ALIGNMENT_32, 0xFF);
 
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -57,7 +57,7 @@ fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_synaptics_mst_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -80,7 +80,7 @@ fu_synaptics_mst_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(buf, blob);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -148,7 +148,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);
@@ -176,7 +176,7 @@ fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 	/* add signature */
 	for (guint i = 0; i < FU_SYNAPROM_FIRMWARE_SIGSIZE; i++)
 		fu_byte_array_append_uint8(buf, 0xff);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -469,7 +469,7 @@ fu_synaptics_rmi_firmware_get_sig_size(FuSynapticsRmiFirmware *self)
 	return self->sig_size;
 }
 
-static GBytes *
+static GByteArray *
 fu_synaptics_rmi_firmware_write_v0x(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);
@@ -510,10 +510,10 @@ fu_synaptics_rmi_firmware_write_v0x(FuFirmware *firmware, GError **error)
 	fu_memwrite_uint32(buf->data + FU_STRUCT_RMI_IMG_OFFSET_CHECKSUM, csum, G_LITTLE_ENDIAN);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
-static GBytes *
+static GByteArray *
 fu_synaptics_rmi_firmware_write_v10(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);
@@ -594,7 +594,7 @@ fu_synaptics_rmi_firmware_write_v10(FuFirmware *firmware, GError **error)
 	fu_memwrite_uint32(buf->data + FU_STRUCT_RMI_IMG_OFFSET_CHECKSUM, csum, G_LITTLE_ENDIAN);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static gboolean
@@ -630,7 +630,7 @@ fu_synaptics_rmi_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_synaptics_rmi_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -495,7 +495,7 @@ fu_synaptics_rmi_v7_device_get_pubkey(FuSynapticsRmiDevice *self, GError **error
 		fu_byte_array_append_uint8(pubkey, res->data[res->len - i - 1]);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&pubkey));
+	return g_bytes_new(pubkey->data, pubkey->len);
 }
 
 static gboolean

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -106,7 +106,7 @@ fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_ti_tps6598x_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
@@ -136,7 +136,7 @@ fu_ti_tps6598x_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(buf, blob_payload);
 
 	/* add EOF */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -510,7 +510,7 @@ fu_tpm_v2_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static gboolean

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -410,7 +410,7 @@ fu_uefi_device_fixup_firmware(FuUefiDevice *self, GBytes *fw, GError **error)
 	/* pad to the headersize then add the payload */
 	fu_byte_array_set_size(st_cap, hdrsize, 0x00);
 	g_byte_array_append(st_cap, buf, bufsz);
-	return g_byte_array_free_to_bytes(g_steal_pointer(&st_cap));
+	return g_bytes_new(st_cap->data, st_cap->len);
 }
 
 gboolean

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -190,7 +190,7 @@ fu_uf2_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* success */
-	blob = g_byte_array_free_to_bytes(g_steal_pointer(&tmp));
+	blob = g_bytes_new(tmp->data, tmp->len);
 	fu_firmware_set_bytes(firmware, blob);
 	return TRUE;
 }
@@ -223,7 +223,7 @@ fu_uf2_firmware_write_chunk(FuUf2Firmware *self, FuChunk *chk, guint chk_len, GE
 	return g_steal_pointer(&st);
 }
 
-static GBytes *
+static GByteArray *
 fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuUf2Firmware *self = FU_UF2_FIRMWARE(firmware);
@@ -248,7 +248,7 @@ fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -439,7 +439,7 @@ fu_vbe_simple_device_upload(FuDevice *device, FuProgress *progress, GError **err
 	}
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static void

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -58,7 +58,7 @@ fu_{{vendor}}_{{example}}_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 }
 
-static GBytes *
+static GByteArray *
 fu_{{vendor}}_{{example}}_firmware_write(FuFirmware *firmware, GError **error)
 {
 	Fu{{Vendor}}{{Example}}Firmware *self = FU_{{VENDOR}}_{{EXAMPLE}}_FIRMWARE(firmware);
@@ -75,7 +75,7 @@ fu_{{vendor}}_{{example}}_firmware_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(buf, fw);
 
 	/* success */
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_steal_pointer(&buf);
 }
 
 guint16

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -557,7 +557,7 @@ fu_vli_pd_parade_device_write_firmware(FuDevice *device,
 						i + 1,
 						blocks->len);
 	}
-	fw_verify = g_byte_array_free_to_bytes(g_steal_pointer(&buf_verify));
+	fw_verify = g_bytes_new(buf_verify->data, buf_verify->len);
 	if (!fu_bytes_compare(fw, fw_verify, error))
 		return FALSE;
 	fu_progress_step_done(progress);
@@ -663,7 +663,7 @@ fu_vli_pd_parade_device_dump_firmware(FuDevice *device, FuProgress *progress, GE
 			return NULL;
 		fu_progress_step_done(progress);
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&fw));
+	return g_bytes_new(fw->data, fw->len);
 }
 
 static gboolean

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -340,11 +340,12 @@ fu_wac_firmware_calc_checksum(GByteArray *buf)
 	return fu_sum8(buf->data, buf->len) ^ 0xFF;
 }
 
-static GBytes *
+static GByteArray *
 fu_wac_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(GString) str = g_string_new(NULL);
+	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GByteArray) buf_hdr = g_byte_array_new();
 
 	/* fw header */
@@ -388,7 +389,8 @@ fu_wac_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* success */
-	return g_string_free_to_bytes(g_steal_pointer(&str));
+	g_byte_array_append(buf, (const guint8 *)str->str, str->len);
+	return g_steal_pointer(&buf);
 }
 
 static void

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3448,7 +3448,7 @@ GBytes *
 fu_engine_emulation_save(FuEngine *self, GError **error)
 {
 	gboolean got_json = FALSE;
-	g_autoptr(GBytes) bytes = NULL;
+	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(FuArchive) archive = fu_archive_new(NULL, FU_ARCHIVE_FLAG_NONE, NULL);
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
@@ -3488,14 +3488,13 @@ fu_engine_emulation_save(FuEngine *self, GError **error)
 	}
 
 	/* write  */
-	bytes =
-	    fu_archive_write(archive, FU_ARCHIVE_FORMAT_ZIP, FU_ARCHIVE_COMPRESSION_GZIP, error);
-	if (bytes == NULL)
+	buf = fu_archive_write(archive, FU_ARCHIVE_FORMAT_ZIP, FU_ARCHIVE_COMPRESSION_GZIP, error);
+	if (buf == NULL)
 		return NULL;
 
 	/* success */
 	g_hash_table_remove_all(self->emulation_phases);
-	return g_steal_pointer(&bytes);
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static gboolean

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2697,7 +2697,7 @@ fu_util_hex_string_to_bytes(const gchar *val, GError **error)
 			return NULL;
 		fu_byte_array_append_uint8(buf, tmp);
 	}
-	return g_byte_array_free_to_bytes(g_steal_pointer(&buf));
+	return g_bytes_new(buf->data, buf->len);
 }
 
 static gboolean


### PR DESCRIPTION
The g_byte_array_free_to_bytes() function that g_byte_array_free_to_bytes() uses contains a huge foot-gun of 'data may be NULL if size is 0' which is really not what all the callers are expecting.

Rather than do mental gymnastics when stealing, just return GByteArray from `FuFirmware->write()` -- all but 4 of the subclasses already build the binary blob in this way already.
