### PR TITLE
trivial: Fix a meson warning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -561,6 +561,7 @@ endif
 
 jinja2 = run_command(
   [python3, '-c', 'import jinja2; print(jinja2.__version__)'],
+  check: true,
 )
 if jinja2.stderr().strip() != ''
   error('Python module jinja2 not found')


### PR DESCRIPTION
Fixes:

	WARNING: You should add the boolean check kwarg to the run_command call.
	 It currently defaults to false,
	 but it will default to true in future releases of meson.
	 See also: https://github.com/mesonbuild/meson/issues/9300

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
