### PR TITLE
Allow using enum types in rustgen structs

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -872,12 +872,17 @@ rustc*, so small differences may be noticeable.
     }
 
     #[derive(ToString, FromString)]
+    #[repr(u8)] // optional, and only required if using the enum as a struct item type
     enum ExampleFamily {
         Unknown,
         Sps,
         Txe = 0x5,
         Me,
         Csme,
+    }
+    struct ExamplePacket {
+        family: ExampleFamily,
+        data: [u8; 254],
     }
 
 The struct types currently supported are:

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -25,7 +25,7 @@
     return (const fwupd_guid_t *) (st->data + {{item.offset}});
 }
 {%- elif item.type == Type.U8 %}
-{{"static " if item.constant else ""}}guint8
+{{"static " if item.constant else ""}}{{item.type_glib}}
 {{name_snake}}_get_{{item.element_id}}(GByteArray *st)
 {
     g_return_val_if_fail(st != NULL, 0x0);
@@ -78,7 +78,7 @@
 }
 {%- elif item.type == Type.U8 %}
 {{"static " if item.constant else ""}}void
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, guint8 value)
+{{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value)
 {
     g_return_if_fail(st != NULL);
     st->data[{{item.offset}}] = value;

--- a/plugins/ebitdo/fu-ebitdo.rs
+++ b/plugins/ebitdo/fu-ebitdo.rs
@@ -8,21 +8,14 @@ struct EbitdoHdr {
     destination_len: u32le,
     reserved: [u32le; 4],
 }
-#[derive(New, Parse)]
-struct EbitdoPkt {
-    pkt_len: u8,
-    type: u8,       // FuEbitdoPktType
-    subtype: u8,    // FuEbitdoPktCmd
-    cmd_len: u16le,
-    cmd: u8,        // FuEbitdoPktCmd
-    payload_len: u16le, // optional
-}
+#[repr(u8)]
 enum EbitdoPktType {
     UserCmd = 0x00,
     UserData = 0x01,
     MidCmd = 0x02,
 }
 #[derive(ToString)]
+#[repr(u8)]
 enum EbitdoPktCmd {
     FwUpdateData       = 0x00, // update firmware data
     FwUpdateHeader     = 0x01, // update firmware header
@@ -42,4 +35,13 @@ enum EbitdoPktCmd {
     TransferTimeout    = 0x1d, // send or receive data timeout
     GetVersion         = 0x21, // get fw ver joystick mode
     GetVersionResponse = 0x22, // get fw version response
+}
+#[derive(New, Parse)]
+struct EbitdoPkt {
+    pkt_len: u8,
+    type: EbitdoPktType,
+    subtype: u8,
+    cmd_len: u16le,
+    cmd: EbitdoPktCmd,
+    payload_len: u16le, // optional
 }

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -36,8 +36,6 @@
 #define FPC_DEVICE_NORMAL_MODE_CLASS 0xFF
 #define FPC_DEVICE_NORMAL_MODE_PORT  0xFF
 
-#define FPC_DFU_DNBUSY 0x04
-
 /**
  * FU_FPC_DEVICE_FLAG_MOH_DEVICE:
  *
@@ -276,7 +274,7 @@ fu_fpc_device_check_dfu_status_cb(FuDevice *device, gpointer user_data, GError *
 	}
 
 	if (fu_struct_fpc_dfu_get_status(dfu_status) != 0 ||
-	    fu_struct_fpc_dfu_get_state(dfu_status) == FPC_DFU_DNBUSY) {
+	    fu_struct_fpc_dfu_get_state(dfu_status) == FU_FPC_DFU_STATE_DNBUSY) {
 		/* device is not in correct status/state */
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/fpc/fu-fpc.rs
+++ b/plugins/fpc/fu-fpc.rs
@@ -1,11 +1,16 @@
 // Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1+
 
+#[repr(u8)]
+enum FpcDfuState {
+    Dnbusy = 0x04,
+}
+
 #[derive(New, Getters)]
 struct FpcDfu {
     status: u8,
     max_payload_size: u8,
     _reserved: [u8; 2],
-    state: u8,
+    state: FpcDfuState,
     _reserved2: u8,
 }

--- a/plugins/intel-usb4/fu-intel-usb4.rs
+++ b/plugins/intel-usb4/fu-intel-usb4.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-2.1+
 
 // hub operation
+#[repr(u16le)]
 enum IntelUsb4Opcode {
     NVM_WRITE       = 0x20,
     NVM_AUTH_WRITE  = 0x21,
@@ -12,7 +13,7 @@ enum IntelUsb4Opcode {
 
 #[derive(New, Parse)]
 struct IntelUsb4Mbox {
-    opcode: u16le,
+    opcode: IntelUsb4Opcode,
     _rsvd: u8,
     status: u8,
 }

--- a/plugins/synaptics-prometheus/fu-synaprom.rs
+++ b/plugins/synaptics-prometheus/fu-synaprom.rs
@@ -11,11 +11,22 @@ struct SynapromMfwHdr {
     vminor: u8: default=1,			// minor version
     unused: [u8; 6],
 }
+
+#[derive(ToString)]
+#[repr(u16le)]
+enum SynapromFirmwareTag {
+    MfwUpdateHeader  = 0x0001,
+    MfwUpdatePayload = 0x0002,
+    CfgUpdateHeader  = 0x0003,
+    CfgUpdatePayload = 0x0004,
+}
+
 #[derive(New, Parse)]
 struct SynapromHdr {
-    tag: u16le,
+    tag: SynapromFirmwareTag,
     bufsz: u32le,
 }
+
 #[derive(Parse)]
 struct SynapromCfgHdr {
     product: u32le: default=65, // Prometheus (b1422)
@@ -49,11 +60,4 @@ struct SynapromCmdIotaFind {
     _dummy: [u8; 2],
     offset: u32le,   // byte offset of data to return
     nbytes: u32le,   // maximum number of bytes to return
-}
-#[derive(ToString)]
-enum SynapromFirmwareTag {
-    MfwUpdateHeader  = 0x0001,
-    MfwUpdatePayload = 0x0002,
-    CfgUpdateHeader  = 0x0003,
-    CfgUpdatePayload = 0x0004,
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi.rs
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi.rs
@@ -1,9 +1,29 @@
 // Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1+
 
+#[derive(ToString)]
+#[repr(u16le)]
+enum RmiPartitionId {
+    None = 0x00,
+    Bootloader = 0x01,
+    DeviceConfig,
+    FlashConfig,
+    ManufacturingBlock,
+    GuestSerialization,
+    GlobalParameters,
+    CoreCode,
+    CoreConfig,
+    GuestCode,
+    DisplayConfig,
+    ExternalTouchAfeConfig,
+    UtilityParameter,
+    Pubkey,
+    FixedLocationData = 0x0E,
+}
+
 #[derive(Parse)]
 struct RmiPartitionTbl {
-    partition_id: u16le,
+    partition_id: RmiPartitionId,
     partition_len: u16le,
     partition_addr: u16le,
     partition_prop: u16le,
@@ -23,38 +43,9 @@ struct RmiImg {
     fw_build_id: u32le,
     signature_size: u32le,
 }
-#[derive(New, Parse)]
-struct RmiContainerDescriptor {
-    content_checksum: u32le,
-    container_id: u16le,
-    minor_version: u8,
-    major_version: u8,
-    signature_size: u32le,
-    container_option_flags: u32le,
-    content_options_length: u32le,
-    content_options_address: u32le,
-    content_length: u32le,
-    content_address: u32le,
-}
+
 #[derive(ToString)]
-enum RmiPartitionId {
-    None = 0x00,
-    Bootloader = 0x01,
-    DeviceConfig,
-    FlashConfig,
-    ManufacturingBlock,
-    GuestSerialization,
-    GlobalParameters,
-    CoreCode,
-    CoreConfig,
-    GuestCode,
-    DisplayConfig,
-    ExternalTouchAfeConfig,
-    UtilityParameter,
-    Pubkey,
-    FixedLocationData = 0x0E,
-}
-#[derive(ToString)]
+#[repr(u16le)]
 enum RmiContainerId {
     TopLevel,
     Ui,
@@ -81,4 +72,18 @@ enum RmiContainerId {
     Utility,
     UtilityParameter,
     FixedLocationData = 27,
+}
+
+#[derive(New, Parse)]
+struct RmiContainerDescriptor {
+    content_checksum: u32le,
+    container_id: RmiContainerId,
+    minor_version: u8,
+    major_version: u8,
+    signature_size: u32le,
+    container_option_flags: u32le,
+    content_options_length: u32le,
+    content_options_address: u32le,
+    content_length: u32le,
+    content_address: u32le,
 }

--- a/plugins/tpm/fu-tpm.rs
+++ b/plugins/tpm/fu-tpm.rs
@@ -1,18 +1,8 @@
 // Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1+
 
-#[derive(Parse)]
-struct TpmEventLog2 {
-    pcr: u32le,
-    type: u32le,
-    digest_count: u32le,
-}
-#[derive(Parse)]
-struct TpmEfiStartupLocalityEvent {
-    signature: [char; 16]: const="StartupLocality",
-    locality: u8,    // from which TPM2_Startup() was issued -- which is the initial value of PCR0
-}
 #[derive(ToString)]
+#[repr(u32le)]
 enum TpmEventlogItemKind {
     EV_PREBOOT_CERT = 0x00000000,
     EV_POST_CODE = 0x00000001,
@@ -42,4 +32,17 @@ enum TpmEventlogItemKind {
     EV_EFI_HANDOFF_TABLES = 0x80000009,
     EV_EFI_HCRTM_EVENT = 0x80000010,
     EV_EFI_VARIABLE_AUTHORITY = 0x800000e0,
+}
+
+#[derive(Parse)]
+struct TpmEventLog2 {
+    pcr: u32le,
+    type: TpmEventlogItemKind,
+    digest_count: u32le,
+}
+
+#[derive(Parse)]
+struct TpmEfiStartupLocalityEvent {
+    signature: [char; 16]: const="StartupLocality",
+    locality: u8,    // from which TPM2_Startup() was issued -- which is the initial value of PCR0
 }

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -287,7 +287,7 @@ fu_uefi_device_clear_status(FuUefiDevice *self, GError **error)
 	}
 
 	/* just copy the new EfiUpdateInfo and save it back */
-	fu_struct_efi_update_info_set_status(st_inf, FU_UEFI_DEVICE_STATUS_SUCCESS);
+	fu_struct_efi_update_info_set_status(st_inf, FU_UEFI_UPDATE_INFO_STATUS_UNKNOWN);
 	memcpy(data, st_inf->data, st_inf->len);
 	return fu_efivar_set_data(FU_EFIVAR_GUID_FWUPDATE,
 				  varname,

--- a/plugins/uefi-capsule/fu-uefi.rs
+++ b/plugins/uefi-capsule/fu-uefi.rs
@@ -18,6 +18,15 @@ struct EfiCapsuleHeader {
     flags: u32le,
     image_size: u32le,
 }
+
+#[derive(ToString)]
+#[repr(u32le)]
+enum UefiUpdateInfoStatus {
+    Unknown,
+    AttemptUpdate,
+    Attempted,
+}
+
 #[derive(New, Parse)]
 struct EfiUpdateInfo {
     version: u32le: default=0x7,
@@ -25,7 +34,7 @@ struct EfiUpdateInfo {
     flags: u32le,
     hw_inst: u64le,
     time_attempted: [u8; 16], // a EFI_TIME_T
-    status: u32le,
+    status: UefiUpdateInfoStatus,
     // EFI_DEVICE_PATH goes here
 }
 #[derive(Parse)]
@@ -33,12 +42,6 @@ struct AcpiInsydeQuirk {
     signature: [char; 6],
     size: u32le,
     flags: u32le,
-}
-#[derive(ToString)]
-enum UefiUpdateInfoStatus {
-    Unknown,
-    AttemptUpdate,
-    Attempted,
 }
 #[derive(ToString, FromString)]
 enum UefiDeviceKind {

--- a/plugins/usi-dock/fu-usi-dock-common.h
+++ b/plugins/usi-dock/fu-usi-dock-common.h
@@ -37,15 +37,6 @@
 #define USBUID_ISP_INTERNAL_FW_CMD_ISP_END	   0x0D
 #define USBUID_ISP_CMD_ALL			   0xFF
 
-#define TAG_TAG2_ISP_BOOT      0    /* before Common CMD for bootload, with TAG0, TAG1, CMD */
-#define TAG_TAG2_ISP	       0x5a /* before Common, with TAG0, TAG1, CMD */
-#define TAG_TAG2_CMD_MCU       0x6a /* USB->MCU(Common-cmd mode), with TAG0, TAG1, CMD */
-#define TAG_TAG2_CMD_SPI       0x7a /* USB->MCU->SPI(Common-cmd mode), with TAG0, TAG1, CMD */
-#define TAG_TAG2_CMD_I2C       0x8a /* USB->MCU->I2C(Mass data transmission) */
-#define TAG_TAG2_MASS_DATA_MCU 0x6b /* MASS data transfer for MCU 0xA0 */
-#define TAG_TAG2_MASS_DATA_SPI 0x7b /* MASS data transfer for External flash 0xA1 */
-#define TAG_TAG2_MASS_DATA_I2C 0x8b /* MASS data transfer for TBT flash */
-
 #define DP_VERSION_FROM_MCU  0x01 /* if in use */
 #define NIC_VERSION_FROM_MCU 0x2  /* if in use */
 

--- a/plugins/usi-dock/fu-usi-dock.rs
+++ b/plugins/usi-dock/fu-usi-dock.rs
@@ -29,6 +29,18 @@ enum UsiDockFirmwareIdx {
     Mcu   = 0x80,
 }
 
+#[repr(u8)]
+enum UsiDockTag2 {
+    IspBoot     = 0,    // before Common CMD for bootload, with TAG0, TAG1, CMD
+    Isp         = 0x5A, // before Common, with TAG0, TAG1, CMD
+    CmdMcu      = 0x6A, // USB->MCU(Common-cmd mode), with TAG0, TAG1, CMD
+    CmdSpi      = 0x7A, // USB->MCU->SPI(Common-cmd mode), with TAG0, TAG1, CMD
+    CmdI2c      = 0x8A, // USB->MCU->I2C(Mass data transmission)
+    MassDataMcu = 0x6B, // MASS data transfer for MCU 0xA0
+    MassDataSpi = 0x7B, // MASS data transfer for External flash 0xA1
+    MassDataI2c = 0x8B, // MASS data transfer for TBT flash
+}
+
 #[derive(New)]
 struct UsiDockSetReportBuf {
     id: u8: const=2,
@@ -36,7 +48,7 @@ struct UsiDockSetReportBuf {
     mcutag1: u8: const=0xFE,
     mcutag2: u8: const=0xFF,
     inbuf: [u8; 59],
-    mcutag3: u8,
+    mcutag3: UsiDockTag2,
 }
 
 struct UsiDockIspVersion {

--- a/plugins/wistron-dock/fu-wistron-dock.rs
+++ b/plugins/wistron-dock/fu-wistron-dock.rs
@@ -1,6 +1,15 @@
 // Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1+
 
+#[derive(ToString)]
+#[repr(u8)]
+enum WistronDockStatusCode {
+    Enter = 0x1,
+    Prepare = 0x2,
+    Updating = 0x3,
+    Complete = 0x4, // unplug cable to trigger update
+}
+
 #[derive(Parse)]
 struct WistronDockWdit {
     hid_id: u8,
@@ -9,14 +18,27 @@ struct WistronDockWdit {
     pid: u16le,
     imgmode: u8,
     update_state: u8,
-    status_code: u8,
+    status_code: WistronDockStatusCode,
     composite_version: u32be,
     device_cnt: u8,
     reserved: u8,
 }
+
+#[derive(ToString)]
+#[repr(u8)]
+enum WistronDockComponentIdx {
+    Mcu   = 0x0,
+    Pd    = 0x1,
+    Audio = 0x2,
+    Usb   = 0x3,
+    Mst   = 0x4,
+    Spi   = 0xA,
+    Dock  = 0xF,
+}
+
 #[derive(Parse)]
 struct WistronDockWditImg {
-    comp_id: u8,
+    comp_id: WistronDockComponentIdx,
     mode: u8,   // 0=single, 1=dual-s, 2=dual-a
     status: u8, // 0=unknown, 1=valid, 2=invalid
     reserved: u8,
@@ -29,21 +51,4 @@ struct WistronDockWditImg {
 enum WistronDockUpdatePhase {
     Download = 0x1,
     Deploy = 0x2,
-}
-#[derive(ToString)]
-enum WistronDockStatusCode {
-    Enter = 0x1,
-    Prepare = 0x2,
-    Updating = 0x3,
-    Complete = 0x4, // unplug cable to trigger update
-}
-#[derive(ToString)]
-enum WistronDockComponentIdx {
-    Mcu   = 0x0,
-    Pd    = 0x1,
-    Audio = 0x2,
-    Usb   = 0x3,
-    Mst   = 0x4,
-    Spi   = 0xA,
-    Dock  = 0xF,
 }


### PR DESCRIPTION
This allows us to pick up problems using `-Wenum-conversion` -- but means we have to define the enums before the structs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
