### PR TITLE
The security hardening for the given security attribute through fwupdmgr

### DIFF
--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -2709,3 +2709,56 @@ fwupd_client_emulation_save(FwupdClient *self, GCancellable *cancellable, GError
 	}
 	return g_steal_pointer(&helper->bytes);
 }
+
+static void
+fwupd_client_security_harden_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
+	helper->ret =
+	    fwupd_client_security_harden_finish(FWUPD_CLIENT(source), res, &helper->error);
+	g_main_loop_quit(helper->loop);
+}
+
+/**
+ * fwupd_client_security_harden:
+ * @self: a #FwupdClient
+ * @appstream_id: the AppStream_id
+ * @enable: TRUE to enable hardening, FALSE to disable
+ * @cancellable: (nullable): optional #GCancellable
+ * @error: (nullable): optional return location for an error
+ *
+ * Harden the security attributes.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_security_harden(FwupdClient *self,
+			     const gchar *appstream_id,
+			     gboolean enable,
+			     GCancellable *cancellable,
+			     GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(appstream_id != NULL, FALSE);
+	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* call async version and run loop until complete */
+	helper = fwupd_client_helper_new(self);
+	fwupd_client_security_harden_async(self,
+					   appstream_id,
+					   enable,
+					   cancellable,
+					   fwupd_client_security_harden_cb,
+					   helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -270,4 +270,11 @@ fwupd_client_emulation_save(FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error) G_GNUC_WARN_UNUSED_RESULT;
 
+gboolean
+fwupd_client_security_harden(FwupdClient *self,
+			     const gchar *appstream_id,
+			     gboolean enable,
+			     GCancellable *cancellable,
+			     GError **error);
+
 G_END_DECLS

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5962,6 +5962,87 @@ fwupd_client_emulation_save_finish(FwupdClient *self, GAsyncResult *res, GError 
 }
 
 static void
+fwupd_client_security_harden_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_task_return_boolean(task, TRUE);
+}
+
+/**
+ * fwupd_client_security_harden_async:
+ * @self: a #FwupdClient
+ * @appstream_id: AppStreamID
+ * @action: action
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: (scope async) (closure callback_data): the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Harden the security attribute with blocking.
+ *
+ * Since: 1.9.6
+ **/
+void
+fwupd_client_security_harden_async(FwupdClient *self,
+				   const gchar *appstream_id,
+				   gboolean action,
+				   GCancellable *cancellable,
+				   GAsyncReadyCallback callback,
+				   gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(appstream_id != NULL);
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+
+	g_dbus_proxy_call(priv->proxy,
+			  "SecurityHarden",
+			  g_variant_new("(sb)", appstream_id, action),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_security_harden_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_security_harden_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.security_harden_async].
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_security_harden_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(g_task_is_valid(res, self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	return g_task_propagate_boolean(G_TASK(res), error);
+}
+
+static void
 fwupd_client_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	FwupdClient *self = FWUPD_CLIENT(object);

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -441,6 +441,17 @@ fwupd_client_emulation_save_finish(FwupdClient *self,
 				   GAsyncResult *res,
 				   GError **error) G_GNUC_WARN_UNUSED_RESULT;
 
+void
+fwupd_client_security_harden_async(FwupdClient *self,
+				   const gchar *appstream_id,
+				   gboolean action,
+				   GCancellable *cancellable,
+				   GAsyncReadyCallback callback,
+				   gpointer callback_data);
+
+gboolean
+fwupd_client_security_harden_finish(FwupdClient *self, GAsyncResult *res, GError **error);
+
 FwupdStatus
 fwupd_client_get_status(FwupdClient *self);
 gboolean

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -978,3 +978,11 @@ LIBFWUPD_1.9.4 {
     fwupd_remote_set_flags;
   local: *;
 } LIBFWUPD_1.9.3;
+
+LIBFWUPD_1.9.6 {
+  global:
+    fwupd_client_security_harden;
+    fwupd_client_security_harden_async;
+    fwupd_client_security_harden_finish;
+  local: *;
+} LIBFWUPD_1.9.4;

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -305,3 +305,96 @@ fu_kernel_get_cmdline(GError **error)
 	return NULL;
 #endif
 }
+
+static gboolean
+fu_kernel_set_commandline(const gchar *grubby_path,
+			  gboolean set_unset,
+			  const gchar *arg,
+			  GError **error)
+{
+	g_autofree gchar *output = NULL;
+	g_autofree gchar *arg_string = NULL;
+	const gchar *argv_grubby[] = {"", "--update-kernel=DEFAULT", "", NULL};
+
+	if (grubby_path == NULL) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "grubby path can't be NULL.");
+		return FALSE;
+	}
+
+	argv_grubby[0] = grubby_path;
+
+	if (set_unset)
+		arg_string = g_strdup_printf("--args=%s", arg);
+	else
+		arg_string = g_strdup_printf("--remove-args=%s", arg);
+
+	argv_grubby[2] = arg_string;
+
+	if (!g_spawn_sync(NULL,
+			  (gchar **)argv_grubby,
+			  NULL,
+			  G_SPAWN_DEFAULT,
+			  NULL,
+			  NULL,
+			  &output,
+			  NULL,
+			  NULL,
+			  error))
+		return FALSE;
+
+	return TRUE;
+}
+
+/**
+ * fu_kernel_add_cmdline_arg:
+ * @arg: (not nullable): key to set
+ * @error: (nullable): optional return location for an error
+ *
+ * Add kernel parameters through grubby
+ *
+ * Returns: %TRUE if successful
+ *
+ * Since: 1.9.5
+ **/
+gboolean
+fu_kernel_add_cmdline_arg(const gchar *grubby_path, const gchar *arg, GError **error)
+{
+	return fu_kernel_set_commandline(grubby_path, TRUE, arg, error);
+}
+
+/**
+ * fu_kernel_remove_cmdline_arg:
+ * @arg: (not nullable): key to set
+ * @error: (nullable): optional return location for an error
+ *
+ * Remove kernel parameters through grubby
+ *
+ * Returns: %TRUE if successful
+ *
+ * Since: 1.9.5
+ **/
+gboolean
+fu_kernel_remove_cmdline_arg(const gchar *grubby_path, const gchar *arg, GError **error)
+{
+	return fu_kernel_set_commandline(grubby_path, FALSE, arg, error);
+}
+
+/**
+ * fu_kernel_get_grubby_path:
+ * @error: (nullable): optional return location for an error
+ *
+ * Set kernel parameters through grubby
+ *
+ * Returns: a pointer of gchar array
+ *
+ * Since: 1.9.5
+ **/
+gchar *
+fu_kernel_get_grubby_path(GError **error)
+{
+	g_autofree gchar *grubby_path = NULL;
+	grubby_path = fu_path_find_program("grubby", error);
+	if (grubby_path == NULL)
+		return NULL;
+	return g_strdup(grubby_path);
+}

--- a/libfwupdplugin/fu-kernel.h
+++ b/libfwupdplugin/fu-kernel.h
@@ -22,3 +22,9 @@ GHashTable *
 fu_kernel_get_cmdline(GError **error);
 GHashTable *
 fu_kernel_parse_cmdline(const gchar *buf, gsize bufsz);
+gboolean
+fu_kernel_add_cmdline_arg(const gchar *grubby_path, const gchar *arg, GError **error);
+gboolean
+fu_kernel_remove_cmdline_arg(const gchar *grubby_path, const gchar *arg, GError **error);
+gchar *
+fu_kernel_get_grubby_path(GError **error);

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -124,6 +124,14 @@ gboolean
 fu_plugin_runner_get_results(FuPlugin *self,
 			     FuDevice *device,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_plugin_runner_security_fix(FuPlugin *self,
+			      FwupdSecurityAttr *attr,
+			      GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_plugin_runner_security_unfix(FuPlugin *self,
+				FwupdSecurityAttr *attr,
+				GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_plugin_runner_add_security_attrs(FuPlugin *self, FuSecurityAttrs *attrs);
 gint

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2238,6 +2238,81 @@ fu_plugin_runner_get_results(FuPlugin *self, FuDevice *device, GError **error)
 	return TRUE;
 }
 
+static gboolean
+fu_plugin_runner_security(FuPlugin *self, gboolean do_fix, FwupdSecurityAttr *attr, GError **error)
+{
+	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
+
+	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	switch (do_fix) {
+	case TRUE:
+		if (vfuncs->security_hardening_fix == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "Hardening fix is not supported");
+			return FALSE;
+		}
+		return vfuncs->security_hardening_fix(self, attr, error);
+		break;
+	case FALSE:
+		if (vfuncs->security_hardening_unfix == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "Unfix hardening is not supported");
+			return FALSE;
+		}
+		return vfuncs->security_hardening_unfix(self, attr, error);
+		break;
+	default:
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "Unknown security hardening action");
+	}
+
+	return FALSE;
+}
+
+/**
+ * fu_plugin_runner_security_fix:
+ * @self: a #FuPlugin
+ * @attr: (nullable): a security attribute
+ * @error: (nullable): optional return location for an error
+ *
+ * Fix the security issue of given security attribute.
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.5
+ **/
+gboolean
+fu_plugin_runner_security_fix(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	return fu_plugin_runner_security(self, TRUE, attr, error);
+}
+
+/**
+ * fu_plugin_runner_security_unfix:
+ * @self: a #FuPlugin
+ * @attr: (nullable): a security attribute
+ * @error: (nullable): optional return location for an error
+ *
+ * Fix the security issue of given security attribute.
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.5
+ **/
+gboolean
+fu_plugin_runner_security_unfix(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	return fu_plugin_runner_security(self, FALSE, attr, error);
+}
+
 /**
  * fu_plugin_get_order:
  * @self: a #FuPlugin

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -389,6 +389,30 @@ struct _FuPluginClass {
 	 * Since: 1.8.4
 	 **/
 	void (*to_string)(FuPlugin *self, guint idt, GString *str);
+	/**
+	 * security_hardening_fix:
+	 * @self: a #FuPlugin
+	 * @attr: security attr
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Unfix the security issue for the plugin.
+	 *
+	 * since: 1.9.5
+	 **/
+	gboolean (*security_hardening_fix)(FuPlugin *self, FwupdSecurityAttr *attr, GError **error);
+	/**
+	 * security_hardening_unfix:
+	 * @self: a #FuPlugin
+	 * @attr: security attr
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Fix security issue for the plugin.
+	 *
+	 * since: 1.9.5
+	 **/
+	gboolean (*security_hardening_unfix)(FuPlugin *self,
+					     FwupdSecurityAttr *attr,
+					     GError **error);
 };
 
 /**

--- a/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
+++ b/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
@@ -111,6 +111,45 @@ fu_lenovo_thinklmi_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }
 
+static gboolean
+fu_lenovo_thinklmi_security_hardening_fix(FuPlugin *plugin, FwupdSecurityAttr *attr, GError **error)
+{
+	FwupdBiosSetting *bios_attr;
+	FuContext *ctx = fu_plugin_get_context(plugin);
+
+	bios_attr = fu_context_get_bios_setting(ctx, BIOS_SETTING_SECURE_ROLLBACK);
+	if (bios_attr == NULL) {
+		g_debug("failed to find %s in cache", BIOS_SETTING_SECURE_ROLLBACK);
+		return FALSE;
+	}
+
+	return fwupd_bios_setting_write_value(
+	    bios_attr,
+	    fwupd_security_attr_get_bios_setting_target_value(attr),
+	    error);
+}
+
+static gboolean
+fu_lenovo_thinklmi_security_hardening_unfix(FuPlugin *plugin,
+					    FwupdSecurityAttr *attr,
+					    GError **error)
+{
+	FwupdBiosSetting *bios_attr;
+	FuContext *ctx = fu_plugin_get_context(plugin);
+
+	g_return_val_if_fail(attr != NULL, FALSE);
+	bios_attr = fu_context_get_bios_setting(ctx, BIOS_SETTING_SECURE_ROLLBACK);
+	if (bios_attr == NULL) {
+		g_debug("failed to find %s in cache", BIOS_SETTING_SECURE_ROLLBACK);
+		return FALSE;
+	}
+
+	return fwupd_bios_setting_write_value(
+	    bios_attr,
+	    fwupd_security_attr_get_bios_setting_current_value(attr),
+	    error);
+}
+
 static void
 fu_lenovo_thinklmi_plugin_init(FuLenovoThinklmiPlugin *self)
 {
@@ -123,4 +162,6 @@ fu_lenovo_thinklmi_plugin_class_init(FuLenovoThinklmiPluginClass *klass)
 	plugin_class->startup = fu_lenovo_thinklmi_plugin_startup;
 	plugin_class->device_registered = fu_lenovo_thinklmi_plugin_device_registered;
 	plugin_class->add_security_attrs = fu_lenovo_thinklmi_plugin_add_security_attrs;
+	plugin_class->security_hardening_fix = fu_lenovo_thinklmi_security_hardening_fix;
+	plugin_class->security_hardening_unfix = fu_lenovo_thinklmi_security_hardening_unfix;
 }

--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -207,4 +207,25 @@
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.get-bios-settings</annotate>
   </action>
 
+  <action id="org.freedesktop.fwupd.security-harden-fix">
+    <description>Security hardening for HSI</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to fix the security issue</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+    <action id="org.freedesktop.fwupd.security-harden-unfix">
+    <description>Security hardening for HSI</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to unfix the security issue</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
 </policyconfig>

--- a/src/fu-engine-security.c
+++ b/src/fu-engine-security.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 Kate Hsuan <hpa@redhat.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuEngine"
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include <fcntl.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+#ifdef HAVE_GIO_UNIX
+#include <gio/gunixfdlist.h>
+#include <glib-unix.h>
+#endif
+#include <locale.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "fu-console.h"
+#include "fu-engine-security.h"
+#include "fu-engine.h"
+#include "fu-plugin-private.h"
+#include "fu-security-attr-common.h"
+#include "fu-security-attrs-private.h"
+#include "fu-util-common.h"
+
+static gboolean
+fu_engine_security_fix(FuEngine *engine,
+		       FuSecurityAttrs *attrs,
+		       const gchar *appstream_id,
+		       gboolean do_fix,
+		       GError **error)
+{
+	FuPlugin *plugin;
+	gboolean ret = FALSE;
+	FwupdSecurityAttr *attr;
+	g_autoptr(GHashTable) settings =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+	attr = fu_security_attrs_get_by_appstream_id(attrs, appstream_id);
+	if (attr == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "Attribute was not found");
+		return FALSE;
+	}
+
+	plugin = fu_engine_get_plugin_by_name(engine, fwupd_security_attr_get_plugin(attr), error);
+	if (plugin) {
+		if (!do_fix && fwupd_security_attr_get_bios_setting_id(attr) != NULL) {
+			attr = fu_engine_get_previous_bios_security_attr(
+			    engine,
+			    appstream_id,
+			    fwupd_security_attr_get_bios_setting_current_value(attr),
+			    error);
+		}
+		if (do_fix)
+			ret = fu_plugin_runner_security_fix(plugin, attr, error);
+		else
+			ret = fu_plugin_runner_security_unfix(plugin, attr, error);
+	}
+
+	if (ret) {
+		return TRUE;
+	} else if (g_error_matches(*error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+		g_clear_error(error);
+	} else {
+		return FALSE;
+	}
+
+	g_set_error_literal(error,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR_NOTHING_TO_DO,
+			    "Repair item is not supported.");
+	return FALSE;
+}
+
+/**
+ * fu_engine_security_harden:
+ * @self: a #FuEngine
+ * @appstream_id: the Appstream ID.
+ * @do_fix: fix or unfix the security issue.
+ * @error: (nullable): optional return location for an error
+ *
+ * This function is used to enable or disable the security fix.
+ *
+ * Returns: %TRUE for success
+ **/
+gboolean
+fu_engine_security_harden(FuEngine *engine,
+			  const gchar *appstream_id,
+			  gboolean do_fix,
+			  GError **error)
+{
+	g_autoptr(GPtrArray) attrs_array = NULL;
+	FuSecurityAttrs *attrs;
+
+	/* for those BIOS fixes and unsupported items */
+	attrs = fu_engine_get_host_security_attrs(engine);
+	if (attrs == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "Fail on getting security attributes.");
+		return FALSE;
+	}
+
+	attrs_array = fu_security_attrs_get_all(attrs);
+
+	for (guint i = 0; i < attrs_array->len; i++) {
+		FwupdSecurityAttr *attr = g_ptr_array_index(attrs_array, i);
+		const gchar *appstream_tmp = fwupd_security_attr_get_appstream_id(attr);
+		if (!g_strcmp0(appstream_id, appstream_tmp)) {
+			return fu_engine_security_fix(engine, attrs, appstream_id, do_fix, error);
+		}
+	}
+
+	/* for unknown Appstream IDs */
+	g_set_error_literal(error,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR_NOTHING_TO_DO,
+			    "Repair item is not found.");
+	return FALSE;
+}

--- a/src/fu-engine-security.h
+++ b/src/fu-engine-security.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2017 Kate Hsuan <hpa@redhat.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include "fwupd-security-attr-private.h"
+
+#include "fu-engine.h"
+
+gboolean
+fu_engine_security_harden(FuEngine *self,
+			  const gchar *appstream_id,
+			  gboolean do_fix,
+			  GError **error);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -71,6 +71,8 @@ FuEngineConfig *
 fu_engine_get_config(FuEngine *self);
 GPtrArray *
 fu_engine_get_plugins(FuEngine *self);
+FuPlugin *
+fu_engine_get_plugin_by_name(FuEngine *self, const gchar *plugin_name, GError **error);
 GPtrArray *
 fu_engine_get_devices(FuEngine *self, GError **error);
 FuDevice *
@@ -253,3 +255,9 @@ gboolean
 fu_engine_emulation_load(FuEngine *self, GBytes *data, GError **error);
 GBytes *
 fu_engine_emulation_save(FuEngine *self, GError **error);
+
+FwupdSecurityAttr *
+fu_engine_get_previous_bios_security_attr(FuEngine *self,
+					  const gchar *appstream_id,
+					  const gchar *current_setting,
+					  GError **error);

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,7 @@ fwupd_engine_src = [
   'fu-engine-config.c',
   'fu-engine-helper.c',
   'fu-engine-request.c',
+  'fu-engine-security.c',
   'fu-history.c',
   'fu-idle.c',
   'fu-polkit-authority.c',

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -827,6 +827,35 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='SecurityHarden'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Security hardening for HSI.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='appstream_id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              The fwupd AppStream ID, e.g. 'org.fwupd.hsi.Kernel.Lockdown'.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg type='b' name='action' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              The action, e.g. True for fix and False for unfix.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='SelfSign'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

After the security testing, fwupd gives the user a list of passed and failed items. For those failed items, the users have to fix them as soon as possible to maintain the security level of their system. Some of the items should be fixed through firmware updating or hardware upgrading but for those software settings issues can be fixed through a command line.

The proposed feature enables the fwupd is able to fix the setting issues, such as enabling IOMMU and kernel lockdown. The `fwupd security-harden AppStreamID` can be used to fix a specific issue and the command `fwupd security-harden AppStreamID unfix` reverts the fix. Through this feature, users can fix their system without any system configuration or OS knowledge. Moreover, it also benefits the automation frameworks, such as Ansible and poppet. The developer calls the repair functions with only one command line.
