### PR TITLE
Make using the device-list simpler

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -41,6 +41,8 @@ fu_device_ensure_id(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_device_incorporate_from_component(FuDevice *self, XbNode *component);
 void
+fu_device_replace(FuDevice *self, FuDevice *donor);
+void
 fu_device_ensure_from_component(FuDevice *self, XbNode *component);
 void
 fu_device_convert_instance_ids(FuDevice *self);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -5309,6 +5309,30 @@ fu_device_incorporate(FuDevice *self, FuDevice *donor)
 }
 
 /**
+ * fu_device_replace:
+ * @self: a #FuDevice
+ * @donor: the old #FuDevice
+ *
+ * Copy properties from the old (no-longer-connected) device to the new (connected) device.
+ *
+ * This is typcically called from the daemon device list and should not be called from plugin code.
+ *
+ * Since: 1.9.2
+ **/
+void
+fu_device_replace(FuDevice *self, FuDevice *donor)
+{
+	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
+
+	g_return_if_fail(FU_IS_DEVICE(self));
+	g_return_if_fail(FU_IS_DEVICE(donor));
+
+	/* optional subclass */
+	if (klass->replace != NULL)
+		klass->replace(self, donor);
+}
+
+/**
  * fu_device_incorporate_flag:
  * @self: a #FuDevice
  * @donor: another device

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -50,6 +50,7 @@ struct _FuDeviceClass {
 				 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*setup)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	void (*incorporate)(FuDevice *self, FuDevice *donor);
+	void (*replace)(FuDevice *self, FuDevice *donor);
 	void (*probe_complete)(FuDevice *self);
 	gboolean (*poll)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*activate)(FuDevice *self,

--- a/libfwupdplugin/fwupdplugin.map
+++ b/libfwupdplugin/fwupdplugin.map
@@ -1219,3 +1219,9 @@ LIBFWUPDPLUGIN_1.9.1 {
     fu_memchk_write;
   local: *;
 } LIBFWUPDPLUGIN_1.8.15;
+
+LIBFWUPDPLUGIN_1.9.2 {
+  global:
+    fu_device_replace;
+  local: *;
+} LIBFWUPDPLUGIN_1.9.1;


### PR DESCRIPTION
Make the code match the comment; 'same object' in this sense means the same pointer address -- not just the same device ID.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
