### PR TITLE
Print the enum type when parsing rustgen structs

### DIFF
--- a/libfwupdplugin/fu-rustgen-enum.c.in
+++ b/libfwupdplugin/fu-rustgen-enum.c.in
@@ -1,23 +1,26 @@
-{%- if 'ToString' in derives %}
-const gchar *
-{{name_snake}}_to_string({{name}} val)
+
+{%- set export = obj.export('ToString') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}const gchar *
+{{obj.c_method('ToString')}}({{obj.c_type}} val)
 {
-{%- for item in items %}
-    if (val == {{item.c_define(name)}})
+{%- for item in obj.items %}
+    if (val == {{item.c_define}})
         return "{{item.value}}";
 {%- endfor %}
     return NULL;
 }
 {%- endif %}
 
-{%- if 'FromString' in derives %}
-{{name}}
-{{name_snake}}_from_string(const gchar *val)
+{%- set export = obj.export('FromString') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}{{obj.c_type}}
+{{obj.c_method('FromString')}}(const gchar *val)
 {
-{%- for item in items %}
+{%- for item in obj.items %}
     if (g_strcmp0(val, "{{item.value}}") == 0)
-        return {{item.c_define(name)}};
+        return {{item.c_define}};
 {%- endfor %}
-    return {{items[0].c_define(name)}};
+    return {{obj.items[0].c_define}};
 }
 {%- endif %}

--- a/libfwupdplugin/fu-rustgen-enum.h.in
+++ b/libfwupdplugin/fu-rustgen-enum.h.in
@@ -1,15 +1,16 @@
 typedef enum {
-{%- for item in items %}
+{%- for item in obj.items %}
 {%- if item.default %}
-    {{item.c_define(name)}} = {{item.default}},
+    {{item.c_define}} = {{item.default}},
 {%- else %}
-    {{item.c_define(name)}},
+    {{item.c_define}},
 {%- endif %}
 {%- endfor %}
-} {{name}};
-{%- if 'ToString' in derives %}
-const gchar *{{name_snake}}_to_string({{name}} val);
+} {{obj.c_type}};
+
+{%- if obj.export('ToString') == Export.PUBLIC %}
+const gchar *{{obj.c_method('ToString')}}({{obj.c_type}} val);
 {%- endif %}
-{%- if 'FromString' in derives %}
-{{name}} {{name_snake}}_from_string(const gchar *val);
+{%- if obj.export('FromString') == Export.PUBLIC %}
+{{obj.c_type}} {{obj.c_method('FromString')}}(const gchar *val);
 {%- endif %}

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -1,16 +1,17 @@
 /* getters */
-{%- if 'Getters' in derives %}
-{%- for item in items | selectattr('enabled') %}
+{%- for item in obj.items | selectattr('enabled') %}
+{%- set export = item.export('Getters') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
 {%- if item.type == Type.STRING %}
-{{"G_GNUC_UNUSED static " if item.constant else ""}}gchar *
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{{export.value}}gchar *
+{{item.c_getter}}(GByteArray *st)
 {
     g_return_val_if_fail(st != NULL, NULL);
     return fu_strsafe((const gchar *) (st->data + {{item.offset}}), {{item.size}});
 }
 {%- elif item.type == Type.U8 and item.multiplier %}
-{{"static " if item.constant else ""}}const guint8 *
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st, gsize *bufsz)
+{{export.value}}const guint8 *
+{{item.c_getter}}(GByteArray *st, gsize *bufsz)
 {
     g_return_val_if_fail(st != NULL, NULL);
     if (bufsz != NULL)
@@ -18,36 +19,37 @@
     return st->data + {{item.offset}};
 }
 {%- elif item.type == Type.GUID %}
-{{"static " if item.constant else ""}}const fwupd_guid_t *
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{{export.value}}const fwupd_guid_t *
+{{item.c_getter}}(GByteArray *st)
 {
     g_return_val_if_fail(st != NULL, NULL);
     return (const fwupd_guid_t *) (st->data + {{item.offset}});
 }
 {%- elif item.type == Type.U8 %}
-{{"static " if item.constant else ""}}{{item.type_glib}}
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{{export.value}}{{item.type_glib}}
+{{item.c_getter}}(GByteArray *st)
 {
     g_return_val_if_fail(st != NULL, 0x0);
     return st->data[{{item.offset}}];
 }
 {%- elif not item.multiplier and item.type in [Type.U16, Type.U24, Type.U32, Type.U64] %}
-{{"static " if item.constant else ""}}{{item.type_glib}}
-{{name_snake}}_get_{{item.element_id}}(GByteArray *st)
+{{export.value}}{{item.type_glib}}
+{{item.c_getter}}(GByteArray *st)
 {
     g_return_val_if_fail(st != NULL, 0x0);
     return fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
 }
 {%- endif %}
-{%- endfor %}
 {%- endif %}
+{%- endfor %}
 
 /* setters */
-{%- for item in items | selectattr('enabled') %}
-{%- if ('Setters' in derives and not item.constant) or ('New' in derives and item.default) %}
+{%- for item in obj.items | selectattr('enabled') %}
+{%- set export = item.export('Setters') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
 {%- if item.type == Type.STRING %}
-{{"static " if item.constant else ""}}gboolean
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, const gchar *value, GError **error)
+{{export.value}}gboolean
+{{item.c_setter}}(GByteArray *st, const gchar *value, GError **error)
 {
     gsize len;
     g_return_val_if_fail(st != NULL, FALSE);
@@ -60,8 +62,8 @@
     return fu_memcpy_safe(st->data, st->len, {{item.offset}}, (const guint8 *)value, len, 0x0, len, error);
 }
 {%- elif item.type == Type.U8 and item.multiplier %}
-{{"static " if item.constant else ""}}gboolean
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error)
+{{export.value}}gboolean
+{{item.c_setter}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error)
 {
     g_return_val_if_fail(st != NULL, FALSE);
     g_return_val_if_fail(buf != NULL, FALSE);
@@ -69,23 +71,23 @@
     return fu_memcpy_safe(st->data, st->len, {{item.offset}}, buf, bufsz, 0x0, bufsz, error);
 }
 {%- elif item.type == Type.GUID %}
-{{"static " if item.constant else ""}}void
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, const fwupd_guid_t *value)
+{{export.value}}void
+{{item.c_setter}}(GByteArray *st, const fwupd_guid_t *value)
 {
     g_return_if_fail(st != NULL);
     g_return_if_fail(value != NULL);
     memcpy(st->data + {{item.offset}}, value, sizeof(*value));
 }
 {%- elif item.type == Type.U8 %}
-{{"static " if item.constant else ""}}void
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value)
+{{export.value}}void
+{{item.c_setter}}(GByteArray *st, {{item.type_glib}} value)
 {
     g_return_if_fail(st != NULL);
     st->data[{{item.offset}}] = value;
 }
 {%- elif not item.multiplier and item.type in [Type.U16, Type.U24, Type.U32, Type.U64] %}
-{{"static " if item.constant else ""}}void
-{{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value)
+{{export.value}}void
+{{item.c_setter}}(GByteArray *st, {{item.type_glib}} value)
 {
     g_return_if_fail(st != NULL);
     fu_memwrite_{{item.type_mem}}(st->data + {{item.offset}}, value, {{item.endian_glib}});
@@ -94,51 +96,60 @@
 {%- endif %}
 {%- endfor %}
 
-{%- if 'New' in derives %}
-GByteArray *
-{{name_snake}}_new(void)
+{%- set export = obj.export('New') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}GByteArray *
+{{obj.c_method('New')}}(void)
 {
     GByteArray *st = g_byte_array_new();
-    fu_byte_array_set_size(st, {{size}}, 0x0);
-{%- for item in items | selectattr('padding') %}
+    fu_byte_array_set_size(st, {{obj.size}}, 0x0);
+{%- for item in obj.items | selectattr('padding') %}
     memset(st->data + {{item.offset}}, {{item.padding}}, {{item.size}});
 {%- endfor %}
-{%- for item in items | selectattr('default') %}
+{%- for item in obj.items | selectattr('default') %}
 {%- if item.type == Type.STRING %}
-    {{name_snake}}_set_{{item.element_id}}(st, "{{item.default}}", NULL);
+    {{item.c_setter}}(st, "{{item.default}}", NULL);
 {%- elif item.type == Type.GUID %}
-    {{name_snake}}_set_{{item.element_id}}(st, (fwupd_guid_t *) "{{item.default}}");
+    {{item.c_setter}}(st, (fwupd_guid_t *) "{{item.default}}");
 {%- else %}
-    {{name_snake}}_set_{{item.element_id}}(st, {{item.default}});
+    {{item.c_setter}}(st, {{item.default}});
 {%- endif %}
 {%- endfor %}
     return st;
 }
 {%- endif %}
 
-{%- if derives %}
-gchar *
-{{name_snake}}_to_string(GByteArray *st)
+{%- set export = obj.export('ToString') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}gchar *
+{{obj.c_method('ToString')}}(GByteArray *st)
 {
-    g_autoptr(GString) str = g_string_new("{{name}}:\n");
+    g_autoptr(GString) str = g_string_new("{{obj.name}}:\n");
     g_return_val_if_fail(st != NULL, NULL);
-{%- for item in items | selectattr('enabled') %}
+{%- for item in obj.items | selectattr('enabled') | rejectattr('constant') %}
 {%- if not item.multiplier and item.type in [Type.U8, Type.U16, Type.U24, Type.U32, Type.U64] %}
-    g_string_append_printf(str, "  {{item.element_id}}: 0x%x\n", (guint) {{name_snake}}_get_{{item.element_id}}(st));
+{%- if item.enum_obj %}
+    g_string_append_printf(str, "  {{item.element_id}}: 0x%x [%s]\n",
+                           (guint) {{item.c_getter}}(st),
+                           {{item.enum_obj.c_method('ToString')}}({{item.c_getter}}(st)));
+{%- else %}
+    g_string_append_printf(str, "  {{item.element_id}}: 0x%x\n",
+                           (guint) {{item.c_getter}}(st));
+{%- endif %}
 {%- elif item.type == Type.GUID %}
     {
-        g_autofree gchar *tmp = fwupd_guid_to_string({{name_snake}}_get_{{item.element_id}}(st), FWUPD_GUID_FLAG_MIXED_ENDIAN);
+        g_autofree gchar *tmp = fwupd_guid_to_string({{item.c_getter}}(st), FWUPD_GUID_FLAG_MIXED_ENDIAN);
         g_string_append_printf(str, "  {{item.element_id}}: %s\n", tmp);
     }
 {%- elif item.type == Type.STRING %}
     {
-        g_autofree gchar *tmp = {{name_snake}}_get_{{item.element_id}}(st);
+        g_autofree gchar *tmp = {{item.c_getter}}(st);
         g_string_append_printf(str, "  {{item.element_id}}: %s\n", tmp);
     }
 {%- else %}
     {
         gsize bufsz = 0;
-        const guint8 *buf = {{name_snake}}_get_{{item.element_id}}(st, &bufsz);
+        const guint8 *buf = {{item.c_getter}}(st, &bufsz);
         g_autoptr(GString) tmp = g_string_new(NULL);
         for (gsize i = 0; i < bufsz; i++)
             g_string_append_printf(tmp, "%02X", buf[i]);
@@ -152,65 +163,67 @@ gchar *
 }
 {%- endif %}
 
-{%- if 'Parse' in derives %}
-GByteArray *
-{{name_snake}}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
+{%- set export = obj.export('Parse') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}GByteArray *
+{{obj.c_method('Parse')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
     g_autoptr(GByteArray) st = g_byte_array_new();
     g_autofree gchar *str = NULL;
     g_return_val_if_fail(buf != NULL, NULL);
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-    if (!fu_memchk_read(bufsz, offset, {{size}}, error)) {
-        g_prefix_error(error, "invalid struct {{name}}: ");
+    if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
+        g_prefix_error(error, "invalid struct {{obj.name}}: ");
         return NULL;
     }
-    g_byte_array_append(st, buf + offset, {{size}});
-{%- for item in items | selectattr('constant') %}
+    g_byte_array_append(st, buf + offset, {{obj.size}});
+{%- for item in obj.items | selectattr('constant') %}
 {%- if item.type == Type.STRING %}
     if (strncmp((const gchar *) (st->data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
 {%- elif item.type == Type.GUID %}
     if (memcmp(st->data + {{item.offset}}, "{{item.constant}}", {{item.size}}) != 0) {
 {%- else %}
-    if ({{name_snake}}_get_{{item.element_id}}(st) != {{item.constant}}) {
+    if ({{item.c_getter}}(st) != {{item.constant}}) {
 {%- endif %}
         g_set_error_literal(error,
                             G_IO_ERROR,
                             G_IO_ERROR_INVALID_DATA,
-                            "constant {{name}}.{{item.element_id}} was not valid, expected {{item.constant}}");
+                            "constant {{obj.name}}.{{item.element_id}} was not valid, expected {{item.constant}}");
         return NULL;
     }
 {%- endfor %}
-    str = {{name_snake}}_to_string(st);
+    str = {{obj.c_method('ToString')}}(st);
     g_debug("%s", str);
     return g_steal_pointer(&st);
 }
 {%- endif %}
 
-{%- if 'Validate' in derives %}
-gboolean
-{{name_snake}}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
+{%- set export = obj.export('Validate') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}gboolean
+{{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
-{%- if has_constant %}
+{%- if obj.has_constant %}
     GByteArray st = {.data = (guint8 *) buf + offset, .len = bufsz - offset, };
 {%- endif %}
     g_return_val_if_fail(buf != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-    if (!fu_memchk_read(bufsz, offset, {{size}}, error)) {
-        g_prefix_error(error, "invalid struct {{name}}: ");
+    if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
+        g_prefix_error(error, "invalid struct {{obj.name}}: ");
         return FALSE;
     }
-{%- for item in items | selectattr('constant') %}
+{%- for item in obj.items | selectattr('constant') %}
 {%- if item.type == Type.STRING %}
     if (strncmp((const gchar *) (st.data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
 {%- elif item.type == Type.GUID or (item.type == Type.U8 and item.multiplier) %}
-    if (memcmp({{name_snake}}_get_{{item.element_id}}(&st), "{{item.constant}}", {{item.size}}) != 0) {
+    if (memcmp({{item.c_getter}}(&st), "{{item.constant}}", {{item.size}}) != 0) {
 {%- else %}
-    if ({{name_snake}}_get_{{item.element_id}}(&st) != {{item.constant}}) {
+    if ({{item.c_getter}}(&st) != {{item.constant}}) {
 {%- endif %}
         g_set_error_literal(error,
                             G_IO_ERROR,
                             G_IO_ERROR_INVALID_DATA,
-                            "constant {{name}}.{{item.element_id}} was not valid");
+                            "constant {{obj.name}}.{{item.element_id}} was not valid");
         return FALSE;
     }
 {%- endfor %}

--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -1,57 +1,57 @@
-{%- if 'New' in derives %}
-GByteArray *{{name_snake}}_new(void);
+{%- if obj.export('New') == Export.PUBLIC %}
+GByteArray *{{obj.c_method('New')}}(void);
 {%- endif %}
-{%- if 'Parse' in derives %}
-GByteArray *{{name_snake}}_parse(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
+{%- if obj.export('Parse') == Export.PUBLIC %}
+GByteArray *{{obj.c_method('Parse')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
 {%- endif %}
-{%- if 'Validate' in derives %}
-gboolean {{name_snake}}_validate(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
+{%- if obj.export('Validate') == Export.PUBLIC %}
+gboolean {{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error);
 {%- endif %}
-{%- if derives %}
-gchar *{{name_snake}}_to_string(GByteArray *st);
+{%- if obj.export('ToString') == Export.PUBLIC %}
+gchar *{{obj.c_method('ToString')}}(GByteArray *st);
 {%- endif %}
 
-{%- if 'Getters' in derives %}
-{%- for item in items | selectattr('enabled') | rejectattr('constant') %}
+{%- for item in obj.items | selectattr('enabled') %}
+{%- if item.export('Getters') == Export.PUBLIC %}
 {%- if item.type == Type.STRING %}
-gchar *{{name_snake}}_get_{{item.element_id}}(GByteArray *st);
+gchar *{{item.c_getter}}(GByteArray *st);
 {%- elif item.type == Type.U8 and item.multiplier %}
-const guint8 *{{name_snake}}_get_{{item.element_id}}(GByteArray *st, gsize *bufsz);
+const guint8 *{{item.c_getter}}(GByteArray *st, gsize *bufsz);
 {%- elif item.type == Type.GUID %}
-const fwupd_guid_t *{{name_snake}}_get_{{item.element_id}}(GByteArray *st);
+const fwupd_guid_t *{{item.c_getter}}(GByteArray *st);
 {%- elif not item.multiplier and item.type in [Type.U8, Type.U16, Type.U24, Type.U32, Type.U64] %}
-{{item.type_glib}} {{name_snake}}_get_{{item.element_id}}(GByteArray *st);
+{{item.type_glib}} {{item.c_getter}}(GByteArray *st);
+{%- endif %}
 {%- endif %}
 {%- endfor %}
-{%- endif %}
 
-{%- if 'Setters' in derives %}
-{%- for item in items | selectattr('enabled') | rejectattr('constant') %}
+{%- for item in obj.items | selectattr('enabled') %}
+{%- if item.export('Setters') == Export.PUBLIC %}
 {%- if item.type == Type.STRING %}
-gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const gchar *value, GError **error);
+gboolean {{item.c_setter}}(GByteArray *st, const gchar *value, GError **error);
 {%- elif item.type == Type.U8 and item.multiplier %}
-gboolean {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error);
+gboolean {{item.c_setter}}(GByteArray *st, const guint8 *buf, gsize bufsz, GError **error);
 {%- elif item.type == Type.GUID %}
-void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, const fwupd_guid_t *value);
+void {{item.c_setter}}(GByteArray *st, const fwupd_guid_t *value);
 {%- elif not item.multiplier and item.type in [Type.U8, Type.U16, Type.U24, Type.U32, Type.U64] %}
-void {{name_snake}}_set_{{item.element_id}}(GByteArray *st, {{item.type_glib}} value);
+void {{item.c_setter}}(GByteArray *st, {{item.type_glib}} value);
+{%- endif %}
 {%- endif %}
 {%- endfor %}
-{%- endif %}
 
-{%- for item in items | selectattr('enabled') %}
-#define {{name_snake.upper()}}_OFFSET_{{item.element_id.upper()}} 0x{{'{:x}'.format(item.offset)}}
+{%- for item in obj.items | selectattr('enabled') %}
+#define {{item.c_define('OFFSET')}} 0x{{'{:X}'.format(item.offset)}}
 {%- endfor %}
 
-{%- for item in items | selectattr('enabled') | selectattr('multiplier') %}
-#define {{name_snake.upper()}}_SIZE_{{item.element_id.upper()}} 0x{{'{:x}'.format(item.size)}}
+{%- for item in obj.items | selectattr('enabled') | selectattr('multiplier') %}
+#define {{item.c_define('SIZE')}} 0x{{'{:X}'.format(item.size)}}
 {%- endfor %}
-#define {{name_snake.upper()}}_SIZE 0x{{'{:x}'.format(size)}}
+#define {{obj.c_define('SIZE')}} 0x{{'{:X}'.format(obj.size)}}
 
-{%- for item in items | selectattr('enabled') | selectattr('default') | rejectattr('constant') %}
+{%- for item in obj.items | selectattr('enabled') | selectattr('default') | rejectattr('constant') %}
 {%- if item.type == Type.STRING %}
-#define {{name_snake.upper()}}_DEFAULT_{{item.element_id.upper()}} "{{item.default}}"
+#define {{item.c_define('DEFAULT')}} "{{item.default}}"
 {%- else %}
-#define {{name_snake.upper()}}_DEFAULT_{{item.element_id.upper()}} {{item.default}}
+#define {{item.c_define('DEFAULT')}} {{item.default}}
 {%- endif %}
 {%- endfor %}

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3885,6 +3885,7 @@ fu_plugin_struct_func(void)
 	g_autoptr(GByteArray) st3 = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *str1 = NULL;
+	g_autofree gchar *str2 = NULL;
 	g_autofree gchar *oem_table_id = NULL;
 
 	/* size */
@@ -3914,6 +3915,19 @@ fu_plugin_struct_func(void)
 	g_assert_cmpint(fu_struct_self_test_get_length(st2), ==, 0xDEAD);
 	oem_table_id = fu_struct_self_test_get_oem_table_id(st2);
 	g_assert_cmpstr(oem_table_id, ==, "X");
+
+	/* to string */
+	str2 = fu_struct_self_test_to_string(st);
+	g_assert_cmpstr(str2,
+			==,
+			"SelfTest:\n"
+			"  length: 0xdead\n"
+			"  revision: 0xff [all]\n"
+			"  owner: 00000000-0000-0000-0000-000000000000\n"
+			"  oem_table_id: X\n"
+			"  oem_revision: 0x0\n"
+			"  asl_compiler_id: 0xDFDFDFDF\n"
+			"  asl_compiler_revision: 0x0");
 
 	/* parse failing signature */
 	st->data[0] = 0xFF;

--- a/libfwupdplugin/fu-self-test.rs
+++ b/libfwupdplugin/fu-self-test.rs
@@ -1,11 +1,17 @@
 // Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1+
 
-#[derive(New, Validate, Parse)]
+#[repr(u8)]
+enum SelfTestRevision {
+    None = 0x0,
+    All = 0xFF,
+}
+
+#[derive(New, Validate, Parse, ToString)]
 struct SelfTest {
     signature: u32be: const=0x12345678,
     length: u32le: default=$struct_size, // bytes
-    revision: u8,
+    revision: SelfTestRevision,
     owner: Guid,
     oem_id: [char; 6]: const="ABCDEF",
     oem_table_id: [char; 8],

--- a/plugins/vli/fu-vli.rs
+++ b/plugins/vli/fu-vli.rs
@@ -7,7 +7,7 @@ struct VliPdHdr {
     vid: u16le,
     pid: u16le,
 }
-#[derive(New, Parse)]
+#[derive(New, Parse, ToString)]
 struct VliUsbhubHdr {
     dev_id: u16be,
     strapping1: u8,


### PR DESCRIPTION
This turned into a bit of a rewrite; we now parse the .rs file and then generate the c and h files, rather than doing it inline.

This allows us to resolve enums in the struct generator. It also will allow us to nest structs in the future too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
