### PR TITLE
plugins: nordic-hid: Update quirk content

### DIFF
--- a/plugins/nordic-hid/README.md
+++ b/plugins/nordic-hid/README.md
@@ -53,7 +53,9 @@ This plugin uses the following plugin-specific quirks:
 
 ### NordicHidBootloader
 
-Explicitly set the expected bootloader type: "B0", "MCUBOOT" or "MCUBOOT+XIP".
+Explicitly set the expected bootloader type.
+Only the `B0` bootloader can be set by the quirk file.
+Other values can only be provided by device.
 This quirk must be set for devices without support of `bootloader variant` DFU option.
 
 ### NordicHidGeneration

--- a/plugins/nordic-hid/nordic-hid.quirk
+++ b/plugins/nordic-hid/nordic-hid.quirk
@@ -1,19 +1,5 @@
-# Nordic Semiconductor ASA Mouse nRF52 Desktop
-[HIDRAW\VEN_1915&DEV_52DE]
-Plugin = nordic_hid
-GType = FuNordicHidCfgChannel
-#NordicHidBootloader = B0
-#NordicHidBootloader = MCUBOOT
-NordicHidGeneration = default
-
-# Nordic Semiconductor ASA Keyboard nRF52 Desktop
-[HIDRAW\VEN_1915&DEV_52DD]
-Plugin = nordic_hid
-GType = FuNordicHidCfgChannel
-NordicHidGeneration = default
-
-# Nordic Semiconductor ASA Dongle nRF52 Desktop
-[HIDRAW\VEN_1915&DEV_52DC]
+# Nordic Semiconductor ASA HID Devices
+[HIDRAW\VEN_1915]
 Plugin = nordic_hid
 GType = FuNordicHidCfgChannel
 NordicHidBootloader = B0


### PR DESCRIPTION
Allow to use the plugin with any Nordic HID device that supports the configuration channel (check only Vendor ID).

Define common default values of generation and bootloader in quirk. The values are used for all of the Nordic HID devices. Values other than "B0" bootloader and "default" generation must be explicitly reported by device. This is needed to apply the quirk content to peripherals connected via dongle (in this scenario we do not know Product ID in advance).

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
