### PR TITLE
genesys: usbhub: Supporting device-bridge and PD firmware update

### DIFF
--- a/plugins/genesys/fu-genesys-common.h
+++ b/plugins/genesys/fu-genesys-common.h
@@ -20,15 +20,6 @@ typedef struct {
 } FuGenesysWaitFlashRegisterHelper;
 
 typedef enum {
-	FW_TYPE_HUB,
-	FW_TYPE_INT_PD,
-	FW_TYPE_EXT_PD,
-	FW_TYPE_DEVICE_BRIDGE,
-
-	FW_TYPE_COUNT
-} FuGenesysFw;
-
-typedef enum {
 	ISP_MODEL_UNKNOWN,
 
 	/* hub */
@@ -48,10 +39,12 @@ typedef struct {
 	gint32 revision;
 } FuGenesysChip;
 
-#define GENESYS_USBHUB_FW_SIG_OFFSET	    0xFC
-#define GENESYS_USBHUB_FW_SIG_LEN	    4
-#define GENESYS_USBHUB_FW_SIG_TEXT_HUB	    "XROM"
-#define GENESYS_USBHUB_FW_SIG_TEXT_HUB_SIGN "SROM"
+#define GENESYS_USBHUB_FW_SIG_OFFSET	      0xFC
+#define GENESYS_USBHUB_FW_SIG_LEN	      4
+#define GENESYS_USBHUB_FW_SIG_TEXT_HUB	      "XROM"
+#define GENESYS_USBHUB_FW_SIG_TEXT_HUB_SIGN   "SROM" // not formal usage
+#define GENESYS_USBHUB_FW_SIG_TEXT_DEV_BRIDGE "HOST"
+#define GENESYS_USBHUB_FW_SIG_TEXT_PD	      "PRDY"
 
 #define GENESYS_USBHUB_FW_CONFIGURATION_OFFSET	       0x100
 #define GENESYS_USBHUB_FW_CONFIGURATION_WITHOUT_SERIAL 0x55

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-genesys-common.h"
+#include "fu-genesys-usbhub-codesign-firmware.h"
+#include "fu-genesys-usbhub-struct.h"
+
+struct _FuGenesysUsbhubCodesignFirmware {
+	FuFirmwareClass parent_instance;
+	FuGenesysFwCodesign codesign;
+};
+
+G_DEFINE_TYPE(FuGenesysUsbhubCodesignFirmware,
+	      fu_genesys_usbhub_codesign_firmware,
+	      FU_TYPE_FIRMWARE)
+
+gint
+fu_genesys_usbhub_codesign_firmware_get_codesign(FuGenesysUsbhubCodesignFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_GENESYS_USBHUB_CODESIGN_FIRMWARE(self), 0);
+	return self->codesign;
+}
+
+static gboolean
+fu_genesys_usbhub_codesign_firmware_check_magic(FuFirmware *firmware,
+						GBytes *fw,
+						gsize offset,
+						GError **error)
+{
+	gsize code_size = g_bytes_get_size(fw) - offset;
+
+	if (code_size != FU_STRUCT_GENESYS_FW_CODESIGN_INFO_RSA_SIZE &&
+	    code_size != FU_STRUCT_GENESYS_FW_CODESIGN_INFO_ECDSA_SIZE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "unknown codesign format");
+		return FALSE;
+	}
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
+					  GBytes *fw,
+					  gsize offset,
+					  FwupdInstallFlags flags,
+					  GError **error)
+{
+	FuGenesysUsbhubCodesignFirmware *self = FU_GENESYS_USBHUB_CODESIGN_FIRMWARE(firmware);
+	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	gsize code_size = bufsz - offset;
+
+	if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_RSA_SIZE) {
+		if (!fu_struct_genesys_fw_codesign_info_rsa_validate(buf, bufsz, offset, error)) {
+			g_prefix_error(error, "not valid for codesign: ");
+			return FALSE;
+		}
+		self->codesign = FU_GENESYS_FW_CODESIGN_RSA;
+	} else if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_ECDSA_SIZE) {
+		if (!fu_struct_genesys_fw_codesign_info_ecdsa_validate(buf, bufsz, offset, error)) {
+			g_prefix_error(error, "not valid for codesign: ");
+			return FALSE;
+		}
+		self->codesign = FU_GENESYS_FW_CODESIGN_ECDSA;
+	} else {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "unknown file format at %#lx:%#lx",
+			    offset,
+			    bufsz);
+		return FALSE;
+	}
+
+	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_CODESIGN));
+	fu_firmware_set_idx(firmware, FU_GENESYS_FW_TYPE_CODESIGN);
+	fu_firmware_set_size(firmware, code_size);
+
+	return TRUE;
+}
+
+static void
+fu_genesys_usbhub_codesign_firmware_export(FuFirmware *firmware,
+					   FuFirmwareExportFlags flags,
+					   XbBuilderNode *bn)
+{
+	FuGenesysUsbhubCodesignFirmware *self = FU_GENESYS_USBHUB_CODESIGN_FIRMWARE(firmware);
+	fu_xmlb_builder_insert_kv(bn, "codesign", fu_genesys_fw_codesign_to_string(self->codesign));
+}
+
+static void
+fu_genesys_usbhub_codesign_firmware_init(FuGenesysUsbhubCodesignFirmware *self)
+{
+}
+
+static void
+fu_genesys_usbhub_codesign_firmware_class_init(FuGenesysUsbhubCodesignFirmwareClass *klass)
+{
+	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	klass_firmware->check_magic = fu_genesys_usbhub_codesign_firmware_check_magic;
+	klass_firmware->parse = fu_genesys_usbhub_codesign_firmware_parse;
+	klass_firmware->export = fu_genesys_usbhub_codesign_firmware_export;
+}
+
+FuFirmware *
+fu_genesys_usbhub_codesign_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_GENESYS_USBHUB_CODESIGN_FIRMWARE, NULL));
+}

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_GENESYS_USBHUB_CODESIGN_FIRMWARE (fu_genesys_usbhub_codesign_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuGenesysUsbhubCodesignFirmware,
+		     fu_genesys_usbhub_codesign_firmware,
+		     FU,
+		     GENESYS_USBHUB_CODESIGN_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_genesys_usbhub_codesign_firmware_new(void);
+gint
+fu_genesys_usbhub_codesign_firmware_get_codesign(FuGenesysUsbhubCodesignFirmware *self);

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-genesys-common.h"
+#include "fu-genesys-usbhub-dev-firmware.h"
+#include "fu-genesys-usbhub-firmware.h"
+#include "fu-genesys-usbhub-struct.h"
+
+struct _FuGenesysUsbhubDevFirmware {
+	FuFirmwareClass parent_instance;
+};
+
+G_DEFINE_TYPE(FuGenesysUsbhubDevFirmware, fu_genesys_usbhub_dev_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_genesys_usbhub_dev_firmware_check_magic(FuFirmware *firmware,
+					   GBytes *fw,
+					   gsize offset,
+					   GError **error)
+{
+	guint8 magic[GENESYS_USBHUB_FW_SIG_LEN] = {0x0};
+
+	if (!fu_memcpy_safe(magic,
+			    sizeof(magic),
+			    0, /* dst */
+			    g_bytes_get_data(fw, NULL),
+			    g_bytes_get_size(fw),
+			    offset + GENESYS_USBHUB_FW_SIG_OFFSET,
+			    sizeof(magic),
+			    error)) {
+		g_prefix_error(error, "failed to read magic: ");
+		return FALSE;
+	}
+	if (memcmp(magic, GENESYS_USBHUB_FW_SIG_TEXT_DEV_BRIDGE, sizeof(magic)) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "signature not supported");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
+				     GBytes *fw,
+				     gsize offset,
+				     FwupdInstallFlags flags,
+				     GError **error)
+{
+	guint32 code_size = 0;
+
+	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_DEV_BRIDGE));
+	fu_firmware_set_idx(firmware, FU_GENESYS_FW_TYPE_DEV_BRIDGE);
+	fu_firmware_set_alignment(firmware, FU_FIRMWARE_ALIGNMENT_1K);
+
+	/* deduce code size */
+	if (!fu_genesys_usbhub_firmware_query_codesize(firmware, fw, offset, error)) {
+		g_prefix_error(error, "not valid for dev: ");
+		return FALSE;
+	}
+	code_size = fu_firmware_get_size(firmware);
+
+	/* calculate checksum */
+	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+		if (!fu_genesys_usbhub_firmware_verify(fw, offset, code_size, error)) {
+			g_prefix_error(error, "not valid for dev: ");
+			return FALSE;
+		}
+	}
+
+	/* get firmware version */
+	if (!fu_genesys_usbhub_firmware_query_version(firmware, fw, offset, error)) {
+		g_prefix_error(error, "not valid for dev: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_genesys_usbhub_dev_firmware_init(FuGenesysUsbhubDevFirmware *self)
+{
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+}
+
+static void
+fu_genesys_usbhub_dev_firmware_class_init(FuGenesysUsbhubDevFirmwareClass *klass)
+{
+	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	klass_firmware->check_magic = fu_genesys_usbhub_dev_firmware_check_magic;
+	klass_firmware->parse = fu_genesys_usbhub_dev_firmware_parse;
+}
+
+FuFirmware *
+fu_genesys_usbhub_dev_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_GENESYS_USBHUB_DEV_FIRMWARE, NULL));
+}

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_GENESYS_USBHUB_DEV_FIRMWARE (fu_genesys_usbhub_dev_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuGenesysUsbhubDevFirmware,
+		     fu_genesys_usbhub_dev_firmware,
+		     FU,
+		     GENESYS_USBHUB_DEV_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_genesys_usbhub_dev_firmware_new(void);

--- a/plugins/genesys/fu-genesys-usbhub-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.h
@@ -17,3 +17,15 @@ G_DECLARE_FINAL_TYPE(FuGenesysUsbhubFirmware,
 
 FuFirmware *
 fu_genesys_usbhub_firmware_new(void);
+gboolean
+fu_genesys_usbhub_firmware_verify(GBytes *fw, gsize offset, gsize code_size, GError **error);
+gboolean
+fu_genesys_usbhub_firmware_query_codesize(FuFirmware *firmware,
+					  GBytes *fw,
+					  gsize offset,
+					  GError **error);
+gboolean
+fu_genesys_usbhub_firmware_query_version(FuFirmware *firmware,
+					 GBytes *fw,
+					 gsize offset,
+					 GError **error);

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-genesys-common.h"
+#include "fu-genesys-usbhub-firmware.h"
+#include "fu-genesys-usbhub-pd-firmware.h"
+#include "fu-genesys-usbhub-struct.h"
+
+struct _FuGenesysUsbhubPdFirmware {
+	FuFirmwareClass parent_instance;
+};
+
+G_DEFINE_TYPE(FuGenesysUsbhubPdFirmware, fu_genesys_usbhub_pd_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_genesys_usbhub_pd_firmware_check_magic(FuFirmware *firmware,
+					  GBytes *fw,
+					  gsize offset,
+					  GError **error)
+{
+	guint8 magic[GENESYS_USBHUB_FW_SIG_LEN] = {0x0};
+
+	if (!fu_memcpy_safe(magic,
+			    sizeof(magic),
+			    0, /* dst */
+			    g_bytes_get_data(fw, NULL),
+			    g_bytes_get_size(fw),
+			    offset + GENESYS_USBHUB_FW_SIG_OFFSET,
+			    sizeof(magic),
+			    error)) {
+		g_prefix_error(error, "failed to read magic: ");
+		return FALSE;
+	}
+	if (memcmp(magic, GENESYS_USBHUB_FW_SIG_TEXT_PD, sizeof(magic)) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "signature not supported");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
+				    GBytes *fw,
+				    gsize offset,
+				    FwupdInstallFlags flags,
+				    GError **error)
+{
+	guint32 code_size = 0;
+
+	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_PD));
+	fu_firmware_set_idx(firmware, FU_GENESYS_FW_TYPE_PD);
+	fu_firmware_set_alignment(firmware, FU_FIRMWARE_ALIGNMENT_1K);
+
+	/* deduce code size */
+	if (!fu_genesys_usbhub_firmware_query_codesize(firmware, fw, offset, error)) {
+		g_prefix_error(error, "not valid for pd: ");
+		return FALSE;
+	}
+	code_size = fu_firmware_get_size(firmware);
+
+	/* calculate checksum */
+	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+		if (!fu_genesys_usbhub_firmware_verify(fw, offset, code_size, error)) {
+			g_prefix_error(error, "not valid for pd: ");
+			return FALSE;
+		}
+	}
+
+	/* get firmware version */
+	if (!fu_genesys_usbhub_firmware_query_version(firmware, fw, offset, error)) {
+		g_prefix_error(error, "not valid for pd: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_genesys_usbhub_pd_firmware_init(FuGenesysUsbhubPdFirmware *self)
+{
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+}
+
+static void
+fu_genesys_usbhub_pd_firmware_class_init(FuGenesysUsbhubPdFirmwareClass *klass)
+{
+	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	klass_firmware->check_magic = fu_genesys_usbhub_pd_firmware_check_magic;
+	klass_firmware->parse = fu_genesys_usbhub_pd_firmware_parse;
+}
+
+FuFirmware *
+fu_genesys_usbhub_pd_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_GENESYS_USBHUB_PD_FIRMWARE, NULL));
+}

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Adam.Chen <Adam.Chen@genesyslogic.com.tw>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_GENESYS_USBHUB_PD_FIRMWARE (fu_genesys_usbhub_pd_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuGenesysUsbhubPdFirmware,
+		     fu_genesys_usbhub_pd_firmware,
+		     FU,
+		     GENESYS_USBHUB_PD_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_genesys_usbhub_pd_firmware_new(void);

--- a/plugins/genesys/fu-genesys-usbhub.rs
+++ b/plugins/genesys/fu-genesys-usbhub.rs
@@ -155,3 +155,55 @@ struct GenesysTsVendorSupport {
     version: [char; 2],
     supports: [char; 29],
 }
+
+// Firmware info
+#[derive(ToString)]
+enum GenesysFwCodesign {
+    None,
+    Rsa,
+    Ecdsa,
+}
+
+#[derive(Getters, Validate)]
+struct GenesysFwCodesignInfoRsa {
+    tag_n: u32be: const=0x4E203D20, // 'N = '
+    text_n: [char; 512],
+    end_n: u16be: const=0x0D0A,
+    tag_e: u32be: const=0x45203D20, // 'E = '
+    text_e: [char; 6],
+    end_e: u16be: const=0x0D0A,
+    signature: [u8; 256],
+}
+#[derive(Parse, Validate)]
+struct GenesysFwRsaPublicKeyText {
+    tag_n: u32be: const=0x4E203D20, // 'N = '
+    text_n: [char; 512],
+    end_n: u16be: const=0x0D0A,
+    tag_e: u32be: const=0x45203D20, // 'E = '
+    text_e: [char; 6],
+    end_e: u16be: const=0x0D0A,
+}
+
+#[derive(Getters, Validate)]
+struct GenesysFwCodesignInfoEcdsa {
+    hash: [u8; 32],
+    key: [u8; 64],
+    signature: [u8; 64],
+}
+#[derive(Parse, Validate)]
+struct GenesysFwEcdsaPublicKey {
+    key: [u8; 64],
+}
+
+#[derive(ToString)]
+enum GenesysFwType {
+    Hub, // inside hub start
+    DevBridge,
+    Pd,
+    Codesign, // inside hub end
+    InsideHubCount,
+
+    Scaler, // vendor support start
+
+    Unknown = 0xff,
+}

--- a/plugins/genesys/fu-genesys-usbhub.rs
+++ b/plugins/genesys/fu-genesys-usbhub.rs
@@ -90,6 +90,7 @@ struct GenesysTsDynamicGl3590 {
     bonding: u8,
 }
 
+#[derive(ToString)]
 #[repr(u8)]
 enum GenesysFwStatus {
     Mask = 0x30,

--- a/plugins/genesys/meson.build
+++ b/plugins/genesys/meson.build
@@ -9,6 +9,9 @@ plugin_builtins += static_library('fu_plugin_genesys',
   sources: [
     'fu-genesys-scaler-firmware.c',   # fuzzing
     'fu-genesys-usbhub-firmware.c',   # fuzzing
+    'fu-genesys-usbhub-dev-firmware.c',
+    'fu-genesys-usbhub-pd-firmware.c',
+    'fu-genesys-usbhub-codesign-firmware.c',
     'fu-genesys-scaler-device.c',
     'fu-genesys-usbhub-device.c',
     'fu-genesys-plugin.c',


### PR DESCRIPTION
To parse device-bridge and PD firmware then record them. Also records codesign info. 

Add `vfunc->prepare()` to collect information before `vfunc->prepare_firmware()`. 
   - check fw bank is valid.
   - get fw bank version.
   - move from `_setup()`, it can reduce reading flash to improve running time. 

Refactor  `_write_firmware()` with specific address. 
   - rename `_write_recovery()` to `_backup_hub_fw_bank1_to_bank2()` and refactor to use saved bank1 data and key.
   - add `_update_firmware()` to update each FuFirmware.
   - add `_compare_flash_blank()` to check erasing flash succeeded.
   - add `_compare_flash_data()` to sequential check each read chunk.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
