### PR TITLE
trivial: Don't run emulation tests without CI_NETWORK set

### DIFF
--- a/data/installed-tests/fwupd.sh
+++ b/data/installed-tests/fwupd.sh
@@ -12,7 +12,7 @@ run_test()
 
 run_device_tests()
 {
-	if [ -d @devicetestdir@ ]; then
+	if [ -n "$CI_NETWORK" ] && [ -d @devicetestdir@ ]; then
 		# grab device tests from the CDN to avoid incrementing the download counter
 		export FWUPD_DEVICE_TESTS_BASE_URI=http://cdn.fwupd.org/downloads
 		for f in `grep --files-with-matches -r emulation-url @devicetestdir@`; do


### PR DESCRIPTION
autopkgtest in Ubuntu has a proxy configuration issue on some autopkgtest hosts that is causing it to sometimes fail.

This needs to get fixed on the server end but it's actually surprising it was being run in the first place because we snuck tests in with new artifacts that depended on LVFS now.

We should gate this running behind CI_NETWORK, just like we do for other test data.

Link: https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/2021908

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
