### PR TITLE
ccgx-dmc: Default to TriggerCode of 0x1

### DIFF
--- a/plugins/ccgx-dmc/ccgx-dmc-noinst.quirk
+++ b/plugins/ccgx-dmc/ccgx-dmc-noinst.quirk
@@ -1,11 +1,9 @@
 # Any EVB board that uses CY7C65219
 [USB\VID_04B4&PID_5220]
 Plugin = ccgx_dmc
-CcgxDmcTriggerCode = 1
 RemoveDelay = 732000
 
 # Any EVB board that uses CYUSB4357
 [USB\VID_04B4&PID_521B]
 Plugin = ccgx_dmc
-CcgxDmcTriggerCode = 1
 RemoveDelay = 732000

--- a/plugins/ccgx-dmc/ccgx-dmc.quirk
+++ b/plugins/ccgx-dmc/ccgx-dmc.quirk
@@ -24,7 +24,6 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_0363
 Vendor = HP
 Name = USB-C Dock G5
-CcgxDmcTriggerCode = 0x01
 InstallDuration = 233
 RemoveDelay = 203000
 
@@ -35,7 +34,6 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_096B
 Vendor = HP
 Name = USB-C/A Universal Dock G2
-CcgxDmcTriggerCode = 0x01
 InstallDuration = 180
 RemoveDelay = 162000
 
@@ -57,7 +55,6 @@ Summary = Dock Management Controller Device
 ParentGuid = USB\VID_03F0&PID_2488
 Vendor = HP
 Name = Thunderbolt Dock G4
-CcgxDmcTriggerCode = 0x01
 InstallDuration = 898
 RemoveDelay = 732000
 
@@ -65,19 +62,16 @@ RemoveDelay = 732000
 [USB\VID_2BEF&PID_9065]
 Plugin = ccgx_dmc
 Summary = Dock Management Controller Device
-CcgxDmcTriggerCode = 0x01
 RemoveDelay = 732000
 
 # Anker Thunderbolt4 Mini Dock
 [USB\VID_291A&PID_8398]
 Plugin = ccgx_dmc
 Summary = Dock Management Controller Device
-CcgxDmcTriggerCode = 0x01
 RemoveDelay = 732000
 
 # Caldigit ElementHub
 [USB\VID_2188&PID_0035]
 Plugin = ccgx_dmc
-CcgxDmcTriggerCode = 0x01
 [USB\VID_2188&PID_0035&CID_05&VER_3.3.1.69]
 CcgxDmcCompositeVersion = 15

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -800,6 +800,7 @@ fu_ccgx_dmc_device_init(FuCcgxDmcDevice *self)
 {
 	self->ep_intr_in = DMC_INTERRUPT_PIPE_ID;
 	self->ep_bulk_out = DMC_BULK_PIPE_ID;
+	self->trigger_code = 0x1;
 	fu_device_add_protocol(FU_DEVICE(self), "com.cypress.ccgx.dmc");
 	fu_device_add_protocol(FU_DEVICE(self), "com.infineon.ccgx.dmc");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);


### PR DESCRIPTION
The trigger code is only used when `CcgxDmcUpdateModel` is `DownloadTrigger`.

This is on advice of Infineon.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
