### PR TITLE
vli: add fujitsu

### DIFF
--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -38,6 +38,8 @@ fu_vli_pd_firmware_validate_header(FuVliPdFirmware *self)
 		return TRUE;
 	if (self->vid == 0x06C4)
 		return TRUE;
+	if (self->vid == 0x0BF8)
+		return TRUE;
 	return FALSE;
 }
 

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -4,6 +4,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginVliUsbhub"']
 plugin_quirks += files([
   'vli-bizlink.quirk',
   'vli-dell.quirk',
+  'vli-fujitsu.quirk',
   'vli-goodway.quirk',
   'vli-hyper.quirk',
   'vli-lenovo.quirk',

--- a/plugins/vli/vli-fujitsu.quirk
+++ b/plugins/vli/vli-fujitsu.quirk
@@ -1,0 +1,39 @@
+# Fujitsu B2711 Hub
+[USB\VID_0BF8&PID_105F]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb3
+CounterpartGuid = USB\VID_0BF8&PID_105E
+[USB\VID_0BF8&PID_105E]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2
+ParentGuid = USB\VID_0BF8&PID_105F
+
+# Fujitsu P2711 Multi-Hub
+[USB\VID_0BF8&PID_1051]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb3,has-shared-spi-pd
+CounterpartGuid = USB\VID_0BF8&PID_1052
+[USB\VID_0BF8&PID_1052]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2
+ParentGuid = USB\VID_0BF8&PID_1051
+[USB\VID_0BF8&PID_1054]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb3
+ParentGuid = USB\VID_0BF8&PID_1051
+CounterpartGuid = USB\VID_0BF8&PID_1055
+[USB\VID_0BF8&PID_1055]
+Plugin = vli
+GType = FuVliUsbhubDevice
+Flags = usb2
+ParentGuid = USB\VID_0BF8&PID_1051
+
+# Fujitsu
+[USB\VID_0BF8&PID_103C]
+Plugin = vli
+GType = FuVliPDDevice


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Why howdy! It's **us**, unruly characters. 

On behalf of Fujitsu Siemens Computer Monitors, we're adding their information into vli's plugin. No rush, please review at your most, convenient, leisure. Much obliged. 

Minor aside, we're delighted by all the QoL changes, you guys have worked hard. 