### PR TITLE
Show the user a warning when the ESP may not be valid

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -452,6 +452,8 @@ fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return "efivar-not-mounted";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND)
 		return "esp-not-found";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_ESP_NOT_VALID)
+		return "esp-not-valid";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_LEGACY_BIOS)
 		return "legacy-bios";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_FAILED_OPEN)
@@ -504,6 +506,8 @@ fwupd_plugin_flag_from_string(const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED;
 	if (g_strcmp0(plugin_flag, "esp-not-found") == 0)
 		return FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND;
+	if (g_strcmp0(plugin_flag, "esp-not-valid") == 0)
+		return FWUPD_PLUGIN_FLAG_ESP_NOT_VALID;
 	if (g_strcmp0(plugin_flag, "legacy-bios") == 0)
 		return FWUPD_PLUGIN_FLAG_LEGACY_BIOS;
 	if (g_strcmp0(plugin_flag, "failed-open") == 0)

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -936,6 +936,15 @@ typedef enum {
  */
 #define FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY (1llu << 15)
 /**
+ * FWUPD_PLUGIN_FLAG_ESP_NOT_VALID:
+ *
+ * The plugins discovered that the EFI system partition may not be valid.
+ * Supported clients will display this information to a user.
+ *
+ * Since: 1.9.3
+ */
+#define FWUPD_PLUGIN_FLAG_ESP_NOT_VALID (1llu << 16)
+/**
  * FWUPD_PLUGIN_FLAG_UNKNOWN:
  *
  * The plugin flag is Unknown.

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -943,6 +943,10 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE);
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_USER_WARNING);
 			g_warning("cannot find default ESP: %s", error_udisks2->message);
+		} else if (g_strcmp0(fu_volume_get_partition_kind(self->esp), FU_VOLUME_KIND_ESP) !=
+			   0) {
+			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_ESP_NOT_VALID);
+			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_USER_WARNING);
 		}
 	}
 	fu_progress_step_done(progress);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -121,6 +121,7 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
 	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
+	flags &= ~FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;
 
 	/* print */
 	for (guint i = 0; i < 64; i++) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1589,6 +1589,10 @@ fu_util_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		/* TRANSLATORS: partition refers to something on disk, again, hey Arch users */
 		return _("UEFI ESP partition not detected or configured");
 	}
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_ESP_NOT_VALID) {
+		/* TRANSLATORS: partition refers to something on disk, again, hey Arch users */
+		return _("UEFI ESP partition may not be set up correctly");
+	}
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_FAILED_OPEN) {
 		/* TRANSLATORS: Failed to open plugin, hey Arch users */
 		return _("Plugin dependencies missing");
@@ -1627,6 +1631,7 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_AUTH_REQUIRED:
 	case FWUPD_PLUGIN_FLAG_EFIVAR_NOT_MOUNTED:
 	case FWUPD_PLUGIN_FLAG_ESP_NOT_FOUND:
+	case FWUPD_PLUGIN_FLAG_ESP_NOT_VALID:
 	case FWUPD_PLUGIN_FLAG_KERNEL_TOO_OLD:
 		return fu_console_color_format(fu_util_plugin_flag_to_string(plugin_flag),
 					       FU_CONSOLE_COLOR_RED);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4146,6 +4146,7 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
 	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
+	flags &= ~FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;
 
 	/* print */
 	for (guint i = 0; i < 64; i++) {


### PR DESCRIPTION
UEFI capsules require a valid ESP -- and although firmware may work using a BDP [FAT32] partition -- this is not always true.

Most installers create a valid ESP, but users creating a FAT32 partition by hand will have the wrong flags set. Fixing is as easy as:

    parted /dev/nvmeXnY set 1 esp on

...but isn't something we should do automatically.

Show users a wiki link explaining the problem on the console.

Fixes https://github.com/fwupd/fwupd/issues/5906

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
