### PR TITLE
Allow devices to only accept explicitly specified release versions

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -213,6 +213,8 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 		return "emulated";
 	if (device_flag == FWUPD_DEVICE_FLAG_EMULATION_TAG)
 		return "emulation-tag";
+	if (device_flag == FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES)
+		return "only-explicit-updates";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -336,6 +338,8 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_EMULATED;
 	if (g_strcmp0(device_flag, "emulation-tag") == 0)
 		return FWUPD_DEVICE_FLAG_EMULATION_TAG;
+	if (g_strcmp0(device_flag, "only-explicit-updates") == 0)
+		return FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -544,6 +544,16 @@ typedef enum {
  */
 #define FWUPD_DEVICE_FLAG_EMULATION_TAG (1llu << 50)
 /**
+ * FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES:
+ *
+ * The device should stay on one firmware version unless the new version is explicitly specified.
+ *
+ * This can either be done using `fwupdmgr install`, using GNOME Firmware, or using a BKC config.
+ *
+ * Since: 1.9.3
+ */
+#define FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES (1llu << 51)
+/**
  * FWUPD_DEVICE_FLAG_UNKNOWN:
  *
  * This flag is not defined, this typically will happen from mismatched

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6238,6 +6238,15 @@ fu_engine_get_upgrades(FuEngine *self,
 		return NULL;
 	}
 
+	/* stay on one firmware version unless the new version is explicitly specified */
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOTHING_TO_DO,
+				    "Installing a specific release is explicitly required");
+		return NULL;
+	}
+
 	/* don't show upgrades again until we reboot */
 	if (fu_device_get_update_state(device) == FWUPD_UPDATE_STATE_NEEDS_REBOOT) {
 		g_set_error_literal(error,

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1721,6 +1721,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	g_autoptr(GPtrArray) releases_dg = NULL;
 	g_autoptr(GPtrArray) releases = NULL;
 	g_autoptr(GPtrArray) releases_up = NULL;
+	g_autoptr(GPtrArray) releases_up2 = NULL;
 	g_autoptr(GPtrArray) remotes = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
 
@@ -1888,6 +1889,12 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	g_assert_cmpint(releases_dg->len, ==, 1);
 	rel = FWUPD_RELEASE(g_ptr_array_index(releases_dg, 0));
 	g_assert_cmpstr(fwupd_release_get_version(rel), ==, "1.2.2");
+
+	/* enforce that updates have to be explicit */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES);
+	releases_up2 = fu_engine_get_upgrades(engine, request, fu_device_get_id(device), &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO);
+	g_assert_null(releases_up2);
 }
 
 static void

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1150,6 +1150,11 @@ fu_util_device_flag_to_string(guint64 device_flag)
 		/* TRANSLATORS: we're saving all USB events for emulation */
 		return _("Tagged for emulation");
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES) {
+		/* TRANSLATORS: stay on one firmware version unless the new version is explicitly
+		 * specified */
+		return _("Installing a specific release is explicitly required");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_SKIPS_RESTART) {
 		/* skip */
 		return NULL;


### PR DESCRIPTION
For some devices, a 'newer' release may be no better than the version they have right now, or is may be unexpected or disallowed to update the firmware automatically.

In other cases it might be that per-device user-set presets would be cleared on update, or that only Best Known Configuration is allowed for regulatory reasons.

Provide a per-device flag that allows the explicit install action, but hides the device from the 'simple' GetUpgrades API call.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
