### PR TITLE
Document which Jabra devices are supported

### DIFF
--- a/data/org.freedesktop.fwupd.metainfo.xml
+++ b/data/org.freedesktop.fwupd.metainfo.xml
@@ -63,7 +63,7 @@
           <li>AVer FONE540</li>
           <li>Genesys GL3525 USB hubs</li>
           <li>Goodix Touch controllers</li>
-          <li>Jabra Evolve, Evolve2, Speak2 and Link devices</li>
+	  <li>Jabra Evolve 65e/t and SE, Evolve2, Speak2 and Link devices</li>
         </ul>
       </description>
     </release>

--- a/plugins/jabra-gnp/README.md
+++ b/plugins/jabra-gnp/README.md
@@ -2,7 +2,11 @@
 
 ## Introduction
 
-This plugin is used to firmware update some Jabra devices.
+This plugin is used to firmware update for some Jabra devices
+(refer to the `jabra-gnp.quirk` file for more information).
+Notably this excludes devices supported by the `jabra` plugin,
+as well as 1st edition Jabra Evolve (non-SE) devices and the
+corresponding Jabra Link connectors.
 
 ## GUID Generation
 

--- a/plugins/jabra/README.md
+++ b/plugins/jabra/README.md
@@ -4,7 +4,7 @@ title: Plugin: Jabra
 
 ## Introduction
 
-This plugin is used to detach the Jabra device to DFU mode.
+This plugin is used to detach Jabra Speak Gen 1 devices to DFU mode.
 
 ## GUID Generation
 


### PR DESCRIPTION
Addresses confusions in #5907 regarding the newly supported devices from #5638.

The mentioned PR adds support for Jabra Evolve and Evolve2 devices, including Jabra Evolve 65e/t and SE (second generation) devices, but excluding first generation devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation


I'm not sure whether this can be phrased better, but I think it'd be helpful to document that in the READMEs & Changelog instead of being buried in the GitHub issue.  Feedback welcome :)