### PR TITLE
Add json_object_get_*_member_with_default() helpers and fix build for GLib 2.64.0

### DIFF
--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -10,6 +10,7 @@
 #include "fwupd-common-private.h"
 #include "fwupd-enums-private.h"
 #include "fwupd-error.h"
+#include "fwupd-json-common.h"
 
 /**
  * FwupdBiosSetting:

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -13,6 +13,7 @@
 #include "fwupd-device-private.h"
 #include "fwupd-enums-private.h"
 #include "fwupd-error.h"
+#include "fwupd-json-common.h"
 #include "fwupd-release-private.h"
 
 /**

--- a/libfwupd/fwupd-json-common.c
+++ b/libfwupd/fwupd-json-common.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2023 Collabora Ltd.
+ *    @author Frédéric Danis <frederic.danis@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fwupd-json-common.h"
+
+#if !JSON_CHECK_VERSION(1, 6, 0)
+const char *
+json_object_get_string_member_with_default(JsonObject *json_object,
+					   const char *member_name,
+					   const char *default_value)
+{
+	if (!json_object_has_member(json_object, member_name))
+		return default_value;
+	return json_object_get_string_member(json_object, member_name);
+}
+
+gint64
+json_object_get_int_member_with_default(JsonObject *json_object,
+					const char *member_name,
+					gint64 default_value)
+{
+	if (!json_object_has_member(json_object, member_name))
+		return default_value;
+	return json_object_get_int_member(json_object, member_name);
+}
+
+gboolean
+json_object_get_boolean_member_with_default(JsonObject *json_object,
+					    const char *member_name,
+					    gboolean default_value)
+{
+	if (!json_object_has_member(json_object, member_name))
+		return default_value;
+	return json_object_get_boolean_member(json_object, member_name);
+}
+
+#endif

--- a/libfwupd/fwupd-json-common.h
+++ b/libfwupd/fwupd-json-common.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2023 Collabora Ltd.
+ *    @author Frédéric Danis <frederic.danis@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <json-glib/json-glib.h>
+
+G_BEGIN_DECLS
+
+#if !JSON_CHECK_VERSION(1, 6, 0)
+const char *
+json_object_get_string_member_with_default(JsonObject *json_object,
+					   const char *member_name,
+					   const char *default_value);
+gint64
+json_object_get_int_member_with_default(JsonObject *json_object,
+					const char *member_name,
+					gint64 default_value);
+gboolean
+json_object_get_boolean_member_with_default(JsonObject *json_object,
+					    const char *member_name,
+					    gboolean default_value);
+#endif
+
+G_END_DECLS

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -12,6 +12,7 @@
 #include "fwupd-common-private.h"
 #include "fwupd-enums-private.h"
 #include "fwupd-error.h"
+#include "fwupd-json-common.h"
 #include "fwupd-security-attr-private.h"
 
 /**

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -55,6 +55,7 @@ libfwupd_src = [
   'fwupd-report.c',         # fuzzing
   'fwupd-request.c',        # fuzzing
   'fwupd-version.c',
+  'fwupd-json-common.c',
 ]
 
 fwupd_mapfile = 'fwupd.map'

--- a/meson.build
+++ b/meson.build
@@ -231,7 +231,7 @@ if libarchive.found()
 endif
 endif
 libjcat = dependency('jcat', version: '>= 0.1.4', fallback: ['libjcat', 'libjcat_dep'])
-libjsonglib = dependency('json-glib-1.0', version: '>= 1.6.0')
+libjsonglib = dependency('json-glib-1.0', version: '>= 1.4.4')
 valgrind = dependency('valgrind', required: false)
 libcurl = dependency('libcurl', version: '>= 7.62.0', required: get_option('curl'))
 if libcurl.found()


### PR DESCRIPTION
json library previous to version 1.6.0 doesn't provide the `json_object_get_*_member_with_default()` functions.

Fix `fu_string_replace()` with GLib 2.64.0 by reverting part of change af3422cd as `g_string_replace()` replace only appears in GLib 2.68.0

Ubuntu 20.04 provides `GLib` 2.64.0 and `json-glib` 1.4.4

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
