### PR TITLE
Update TUXEDO quirks

### DIFF
--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -133,14 +133,16 @@ Plugin = flashrom
 Branch = dasharo
 VersionFormat = triplet
 
-# Tuxedo InfinityBook S14 Gen6 (HwId)
-[6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+# TUXEDO InfinityBook S 14 Gen6 (HwId)
+[9366407e-433e-51e9-bd79-a517e3f31536]
 Plugin = flashrom
-[FLASHROM\GUID_6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+[FLASHROM\GUID_9366407e-433e-51e9-bd79-a517e3f31536]
 Flags = fn-m-me-unlock
+FirmwareSizeMax = 0x1000000
 
-# Tuxedo InfinityBook S15 Gen6 (HwId)
-[60f53465-e8fc-5122-b79b-f7b03f063037]
+# TUXEDO InfinityBook S 15 Gen6 (HwId)
+[16cabee1-8d79-5164-9400-346dddbfe2c5]
 Plugin = flashrom
-[FLASHROM\GUID_60f53465-e8fc-5122-b79b-f7b03f063037]
+[FLASHROM\GUID_16cabee1-8d79-5164-9400-346dddbfe2c5]
 Flags = fn-m-me-unlock
+FirmwareSizeMax = 0x1000000

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -146,3 +146,10 @@ Plugin = flashrom
 [FLASHROM\GUID_16cabee1-8d79-5164-9400-346dddbfe2c5]
 Flags = fn-m-me-unlock
 FirmwareSizeMax = 0x1000000
+
+# TUXEDO InfinityBook Pro 13 v3 (HwId)
+[caaa8a77-aca3-595b-92fa-4e6fb7bccc82]
+Plugin = flashrom
+[FLASHROM\GUID_caaa8a77-aca3-595b-92fa-4e6fb7bccc82]
+Flags = fn-m-me-unlock
+FirmwareSizeMax = 0x800000

--- a/plugins/superio/superio.quirk
+++ b/plugins/superio/superio.quirk
@@ -92,20 +92,20 @@ SuperioPort = 0x4e
 InstallDuration = 20
 Flags = signed-payload
 
-# Tuxedo InfinityBook S14 Gen6
-[6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+# TUXEDO InfinityBook S 14 Gen6 (HwId)
+[9366407e-433e-51e9-bd79-a517e3f31536]
 SuperioGType = FuEcIt55Device
-[SUPERIO\GUID_6c80d85b-d0b6-5ee2-99d4-ec28dd32febd]
+[SUPERIO\GUID_9366407e-433e-51e9-bd79-a517e3f31536]
 SuperioId = 0x5570
 SuperioControlPort = 0x66
 SuperioDataPort = 0x62
 SuperioAutoloadAction = disable
 SuperioTimeout = 650
 
-# Tuxedo InfinityBook S15 Gen6
-[60f53465-e8fc-5122-b79b-f7b03f063037]
+# TUXEDO InfinityBook S 15 Gen6 (HwId)
+[16cabee1-8d79-5164-9400-346dddbfe2c5]
 SuperioGType = FuEcIt55Device
-[SUPERIO\GUID_60f53465-e8fc-5122-b79b-f7b03f063037]
+[SUPERIO\GUID_16cabee1-8d79-5164-9400-346dddbfe2c5]
 SuperioId = 0x5570
 SuperioControlPort = 0x66
 SuperioDataPort = 0x62


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Updating quirks for TUXEDO devices:
- TUXEDO InfinityBook S 14/15 Gen6 GUID where based on older DMI strings that didn't actually ship
- New GUIDs for TUXEDO InfinityBook Pro 13 v3 (only for BIOS/flashrom plugin as EC/superio plugin is not yet tested on this device

I noticed that the fn-m-me-unlock flag doesn't actually do anything? At least from the command line. Is the promt to reboot with FN+M pressed only for GUI or am I encountering a bug?