### PR TITLE
Fix oss-fuzz by providing a dummy efivar implementation

### DIFF
--- a/libfwupdplugin/fu-efivar-impl.c
+++ b/libfwupdplugin/fu-efivar-impl.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fwupd-error.h"
+
+#include "fu-efivar-impl.h"
+
+gboolean
+fu_efivar_supported_impl(GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return FALSE;
+}
+
+gboolean
+fu_efivar_delete_impl(const gchar *guid, const gchar *name, GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return FALSE;
+}
+
+gboolean
+fu_efivar_delete_with_glob_impl(const gchar *guid, const gchar *name_glob, GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return FALSE;
+}
+
+gboolean
+fu_efivar_exists_impl(const gchar *guid, const gchar *name)
+{
+	return FALSE;
+}
+
+gboolean
+fu_efivar_get_data_impl(const gchar *guid,
+			const gchar *name,
+			guint8 **data,
+			gsize *data_sz,
+			guint32 *attr,
+			GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return FALSE;
+}
+
+GPtrArray *
+fu_efivar_get_names_impl(const gchar *guid, GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return NULL;
+}
+
+GFileMonitor *
+fu_efivar_get_monitor_impl(const gchar *guid, const gchar *name, GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return NULL;
+}
+
+guint64
+fu_efivar_space_used_impl(GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return G_MAXUINT64;
+}
+
+gboolean
+fu_efivar_set_data_impl(const gchar *guid,
+			const gchar *name,
+			const guint8 *data,
+			gsize sz,
+			guint32 attr,
+			GError **error)
+{
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+	return FALSE;
+}

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -124,12 +124,12 @@ elif host_machine.system() == 'freebsd'
   fwupdplugin_src += 'fu-efivar-freebsd.c'
 elif host_machine.system() == 'windows'
   fwupdplugin_src += 'fu-common-windows.c'
-  fwupdplugin_src += 'fu-efivar-windows.c'  # fuzzing
+  fwupdplugin_src += 'fu-efivar-windows.c'
 elif host_machine.system() == 'darwin'
   fwupdplugin_src += 'fu-common-darwin.c'
   fwupdplugin_src += 'fu-efivar-darwin.c'
 else
-  error('no OS support for @0@'.format(host_machine.system()))
+  fwupdplugin_src += 'fu-efivar-impl.c' # fuzzing
 endif
 
 fwupdplugin_headers = [


### PR DESCRIPTION
We used to use the Windows one for this, but now it's actually implemented.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
