### PR TITLE
uefi-dbx: Check only the efi executables from boot menu

### DIFF
--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -308,6 +308,7 @@ main(int argc, char *argv[])
 			g_print("%s\n", _("Validating ESP contents…"));
 			if (!fu_uefi_dbx_signature_list_validate(ctx,
 								 FU_EFI_SIGNATURE_LIST(dbx_update),
+								 FWUPD_INSTALL_FLAG_NONE,
 								 &error)) {
 				g_printerr("%s: %s\n",
 					   /* TRANSLATORS: something with a blocked hash exists

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.c
@@ -29,13 +29,86 @@ fu_uefi_dbx_get_authenticode_hash(const gchar *fn, GError **error)
 	return g_strdup(fu_efi_image_get_checksum(img));
 }
 
+static GPtrArray *
+fu_uefi_dbx_get_basenames_bootxxxx(void)
+{
+	g_autoptr(GPtrArray) files = g_ptr_array_new_with_free_func(g_free);
+
+	/* hardcoded, as we chainload from shim to these */
+	g_ptr_array_add(files, g_strdup_printf("fwupd%s.efi", EFI_MACHINE_TYPE_NAME));
+	g_ptr_array_add(files, g_strdup_printf("grub%s.efi", EFI_MACHINE_TYPE_NAME));
+
+	for (guint i = 0; i <= G_MAXUINT16; i++) {
+		g_autofree gchar *basename = NULL;
+		g_autofree gchar *basename_down = NULL;
+		g_autofree gchar *fullpath = NULL;
+		g_autofree gchar *name = g_strdup_printf("Boot%04X", i);
+		g_autoptr(FuEfiLoadOption) loadopt = NULL;
+		g_autoptr(FuFirmware) dp_buf = NULL;
+		g_autoptr(FuFirmware) dp_file = NULL;
+		g_autoptr(GBytes) blob = NULL;
+		g_autoptr(GError) error_local = NULL;
+
+		/* load EFI load option */
+		blob = fu_efivar_get_data_bytes(FU_EFIVAR_GUID_EFI_GLOBAL, name, NULL, NULL);
+		if (blob == NULL)
+			continue;
+		loadopt = fu_efi_load_option_new();
+		if (!fu_firmware_parse(FU_FIRMWARE(loadopt),
+				       blob,
+				       FWUPD_INSTALL_FLAG_NONE,
+				       &error_local)) {
+			g_warning("failed to parse %s: %s", name, error_local->message);
+			continue;
+		}
+
+		/* get EfiFilePath from the list of DEVICE PATHs */
+		dp_buf = fu_firmware_get_image_by_gtype(FU_FIRMWARE(loadopt),
+							FU_TYPE_EFI_DEVICE_PATH_LIST,
+							&error_local);
+		if (dp_buf == NULL) {
+			g_warning("no DP list for %s: %s", name, error_local->message);
+			continue;
+		}
+		dp_file = fu_firmware_get_image_by_gtype(dp_buf,
+							 FU_TYPE_EFI_FILE_PATH_DEVICE_PATH,
+							 &error_local);
+		if (dp_file == NULL) {
+			g_debug("no EfiFilePathDevicePath list for %s: %s",
+				name,
+				error_local->message);
+			continue;
+		}
+		fullpath =
+		    fu_efi_file_path_device_path_get_name(FU_EFI_FILE_PATH_DEVICE_PATH(dp_file),
+							  &error_local);
+		if (fullpath == NULL) {
+			g_warning("no EfiFilePathDevicePath name for %s: %s",
+				  name,
+				  error_local->message);
+			continue;
+		}
+		g_debug("found %s from %s", fullpath, name);
+
+		/* add lowercase basename if not already present */
+		basename = g_path_get_basename(fullpath);
+		basename_down = g_utf8_strdown(basename, -1);
+		if (g_ptr_array_find_with_equal_func(files, basename_down, g_str_equal, NULL))
+			continue;
+		g_ptr_array_add(files, g_steal_pointer(&basename_down));
+	}
+	return g_steal_pointer(&files);
+}
+
 static gboolean
 fu_uefi_dbx_signature_list_validate_volume(FuEfiSignatureList *siglist,
 					   FuVolume *esp,
+					   FwupdInstallFlags flags,
 					   GError **error)
 {
 	g_autofree gchar *esp_path = NULL;
 	g_autoptr(GPtrArray) files = NULL;
+	g_autoptr(GPtrArray) basenames = NULL;
 
 	/* get list of files contained in the ESP */
 	esp_path = fu_volume_get_mount_point(esp);
@@ -45,12 +118,34 @@ fu_uefi_dbx_signature_list_validate_volume(FuEfiSignatureList *siglist,
 	if (files == NULL)
 		return FALSE;
 
+	/* filter the list of possible names from BootXXXX */
+	if (flags & FWUPD_INSTALL_FLAG_FORCE) {
+		basenames = fu_uefi_dbx_get_basenames_bootxxxx();
+		if (basenames->len > 0) {
+			g_autofree gchar *str = fu_strjoin(",", basenames);
+			g_info("EFI binaries to check: %s", str);
+		}
+	}
+
 	/* verify each file does not exist in the ESP */
 	for (guint i = 0; i < files->len; i++) {
 		const gchar *fn = g_ptr_array_index(files, i);
 		g_autofree gchar *checksum = NULL;
 		g_autoptr(FuFirmware) img = NULL;
 		g_autoptr(GError) error_local = NULL;
+
+		/* is listed in the BootXXXX variables */
+		if (basenames != NULL && basenames->len > 0) {
+			g_autofree gchar *basename = g_path_get_basename(fn);
+			g_autofree gchar *basename_down = g_utf8_strdown(basename, -1);
+			if (!g_ptr_array_find_with_equal_func(files,
+							      basename_down,
+							      g_str_equal,
+							      NULL)) {
+				g_debug("%s was not in a BootXXXX variable", fn);
+				continue;
+			}
+		}
 
 		/* get checksum of file */
 		checksum = fu_uefi_dbx_get_authenticode_hash(fn, &error_local);
@@ -78,7 +173,10 @@ fu_uefi_dbx_signature_list_validate_volume(FuEfiSignatureList *siglist,
 }
 
 gboolean
-fu_uefi_dbx_signature_list_validate(FuContext *ctx, FuEfiSignatureList *siglist, GError **error)
+fu_uefi_dbx_signature_list_validate(FuContext *ctx,
+				    FuEfiSignatureList *siglist,
+				    FwupdInstallFlags flags,
+				    GError **error)
 {
 	g_autoptr(GPtrArray) volumes = NULL;
 	volumes = fu_context_get_esp_volumes(ctx, error);
@@ -97,7 +195,7 @@ fu_uefi_dbx_signature_list_validate(FuContext *ctx, FuEfiSignatureList *siglist,
 			g_debug("failed to mount ESP: %s", error_local->message);
 			continue;
 		}
-		if (!fu_uefi_dbx_signature_list_validate_volume(siglist, esp, error))
+		if (!fu_uefi_dbx_signature_list_validate_volume(siglist, esp, flags, error))
 			return FALSE;
 	}
 	return TRUE;

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.h
@@ -9,4 +9,7 @@
 #include <fwupdplugin.h>
 
 gboolean
-fu_uefi_dbx_signature_list_validate(FuContext *ctx, FuEfiSignatureList *siglist, GError **error);
+fu_uefi_dbx_signature_list_validate(FuContext *ctx,
+				    FuEfiSignatureList *siglist,
+				    FwupdInstallFlags flags,
+				    GError **error);

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -100,6 +100,7 @@ fu_uefi_dbx_prepare_firmware(FuDevice *device, GBytes *fw, FwupdInstallFlags fla
 		//		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
 		if (!fu_uefi_dbx_signature_list_validate(ctx,
 							 FU_EFI_SIGNATURE_LIST(siglist),
+							 flags,
 							 error)) {
 			g_prefix_error(error,
 				       "Blocked executable in the ESP, "


### PR DESCRIPTION
Inspired from a patch by Crag Wang <crag.wang@dell.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
