### PR TITLE
Only add the little-used _REV instance IDs by request

### DIFF
--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -180,7 +180,16 @@ fu_bluez_device_set_modalias(FuBluezDevice *self, const gchar *modalias)
 	fu_device_add_instance_u16(FU_DEVICE(self), "REV", rev);
 	fu_device_build_instance_id_quirk(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", NULL);
 	fu_device_build_instance_id(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", "PID", NULL);
-	fu_device_build_instance_id(FU_DEVICE(self), NULL, "BLUETOOTH", "VID", "PID", "REV", NULL);
+	if (fu_device_has_internal_flag(FU_DEVICE(self),
+					FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV)) {
+		fu_device_build_instance_id(FU_DEVICE(self),
+					    NULL,
+					    "BLUETOOTH",
+					    "VID",
+					    "PID",
+					    "REV",
+					    NULL);
+	}
 
 	/* set vendor ID */
 	if (vid != 0x0) {

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -272,6 +272,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "md-set-version";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_MD_ONLY_CHECKSUM)
 		return "md-only-checksum";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV)
+		return "add-instance-id-rev";
 	return NULL;
 }
 
@@ -352,6 +354,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_MD_SET_VERSION;
 	if (g_strcmp0(flag, "md-only-checksum") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_MD_ONLY_CHECKSUM;
+	if (g_strcmp0(flag, "add-instance-id-rev") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV;
 	return FU_DEVICE_INTERNAL_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -538,6 +538,15 @@ typedef guint64 FuDeviceInternalFlags;
  */
 #define FU_DEVICE_INTERNAL_FLAG_MD_ONLY_CHECKSUM (1ull << 31)
 
+/**
+ * FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV:
+ *
+ * Add the `_REV` instance ID suffix.
+ *
+ * Since: 1.9.3
+ */
+#define FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV (1ull << 32)
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -531,14 +531,26 @@ fu_udev_device_probe(FuDevice *device, GError **error)
 		    g_strdup_printf("%04X%04X", priv->subsystem_vendor, priv->subsystem_model);
 		fu_device_add_instance_str(device, "SUBSYS", subsys);
 	}
-	if (priv->revision != 0xFF)
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV) &&
+	    priv->revision != 0xFF) {
 		fu_device_add_instance_u8(device, "REV", priv->revision);
+	}
 
 	fu_device_build_instance_id_quirk(device, NULL, subsystem, "VEN", NULL);
 	fu_device_build_instance_id(device, NULL, subsystem, "VEN", "DEV", NULL);
-	fu_device_build_instance_id(device, NULL, subsystem, "VEN", "DEV", "REV", NULL);
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV))
+		fu_device_build_instance_id(device, NULL, subsystem, "VEN", "DEV", "REV", NULL);
 	fu_device_build_instance_id(device, NULL, subsystem, "VEN", "DEV", "SUBSYS", NULL);
-	fu_device_build_instance_id(device, NULL, subsystem, "VEN", "DEV", "SUBSYS", "REV", NULL);
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV)) {
+		fu_device_build_instance_id(device,
+					    NULL,
+					    subsystem,
+					    "VEN",
+					    "DEV",
+					    "SUBSYS",
+					    "REV",
+					    NULL);
+	}
 
 	/* add device class */
 	tmp = g_udev_device_get_sysfs_attr(priv->udev_device, "class");

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -535,7 +535,8 @@ fu_usb_device_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_u16(device, "REV", release);
 	fu_device_build_instance_id_quirk(device, NULL, "USB", "VID", NULL);
 	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", NULL);
-	fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "REV", NULL);
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV))
+		fu_device_build_instance_id(device, NULL, "USB", "VID", "PID", "REV", NULL);
 
 	/* add the interface GUIDs */
 	intfs = g_usb_device_get_interfaces(priv->usb_device, error);

--- a/plugins/ch341a/README.md
+++ b/plugins/ch341a/README.md
@@ -40,7 +40,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-- `USB\VID_1A86&PID_5512&REV_0304`
 - `USB\VID_1A86&PID_5512`
 
 ## Update Behavior

--- a/plugins/ch347/README.md
+++ b/plugins/ch347/README.md
@@ -18,7 +18,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-- `USB\VID_1A86&PID_55DB&REV_0304`
 - `USB\VID_1A86&PID_55DB`
 
 ## Update Behavior

--- a/plugins/colorhug/README.md
+++ b/plugins/colorhug/README.md
@@ -24,7 +24,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_273F&PID_1001&REV_0001`
 * `USB\VID_273F&PID_1001`
 * `USB\VID_273F`
 

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -433,6 +433,7 @@ fu_dfu_csr_device_init(FuDfuCsrDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_DFU_FIRMWARE);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_DFU_CSR_DEVICE_FLAG_REQUIRE_DELAY,

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1684,6 +1684,7 @@ fu_dfu_device_init(FuDfuDevice *self)
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 
 	fu_device_register_private_flag(FU_DEVICE(self),

--- a/plugins/ebitdo/README.md
+++ b/plugins/ebitdo/README.md
@@ -26,7 +26,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_2DC8&PID_AB11&REV_0001`
 * `USB\VID_2DC8&PID_AB11`
 * `USB\VID_2DC8`
 

--- a/plugins/elanfp/README.md
+++ b/plugins/elanfp/README.md
@@ -19,7 +19,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_04F3&PID_0C7E&REV_0304`
 * `USB\VID_04F3&PID_0C7E`
 * `USB\VID_04F3`
 

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -206,7 +206,8 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 		fu_device_set_version(device, tmp);
 	}
 	fu_device_add_instance_strsafe(device, "REV", tmp);
-	fu_device_build_instance_id(device, NULL, "EMMC", "NAME", "REV", NULL);
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV))
+		fu_device_build_instance_id(device, NULL, "EMMC", "NAME", "REV", NULL);
 
 	/* manfid + oemid, manfid + oemid + name */
 	if (!fu_emmc_device_get_sysattr_guint64(udev_parent, "manfid", &manfid, error))

--- a/plugins/ep963x/README.md
+++ b/plugins/ep963x/README.md
@@ -19,7 +19,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_17EF&PID_7226&REV_0001`
 * `USB\VID_17EF&PID_7226`
 * `USB\VID_17EF`
 

--- a/plugins/fastboot/README.md
+++ b/plugins/fastboot/README.md
@@ -25,7 +25,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_18D1&PID_4EE0&REV_0001`
 * `USB\VID_18D1&PID_4EE0`
 * `USB\VID_18D1`
 

--- a/plugins/fpc/README.md
+++ b/plugins/fpc/README.md
@@ -19,7 +19,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_10A5&PID_FFE0&REV_0001`
 * `USB\VID_10A5&PID_FFE0`
 * `USB\VID_10A5`
 

--- a/plugins/fresco-pd/README.md
+++ b/plugins/fresco-pd/README.md
@@ -19,7 +19,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_1D5C&PID_7102&REV_0001`
 * `USB\VID_1D5C&PID_7102`
 * `USB\VID_1D5C`
 

--- a/plugins/goodix-moc/README.md
+++ b/plugins/goodix-moc/README.md
@@ -19,7 +19,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_27C6&PID_6001&REV_0001`
 * `USB\VID_27C6&PID_6001`
 * `USB\VID_27C6`
 

--- a/plugins/logitech-hidpp/README.md
+++ b/plugins/logitech-hidpp/README.md
@@ -36,7 +36,6 @@ This plugin supports the following protocol IDs:
 The Unifying receivers and peripherals use the standard USB
 DeviceInstanceId values when in DFU mode:
 
-* `USB\VID_046D&PID_AAAA&REV_0001`
 * `USB\VID_046D&PID_AAAA`
 * `USB\VID_046D`
 

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1861,6 +1861,7 @@ fu_mm_device_init(FuMmDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary(FU_DEVICE(self), "Mobile broadband device");

--- a/plugins/nitrokey/README.md
+++ b/plugins/nitrokey/README.md
@@ -15,7 +15,6 @@ is entered into the nitrokey-app tool. This cannot be automated.
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_20A0&PID_4109&REV_0001`
 * `USB\VID_20A0&PID_4109`
 * `USB\VID_20A0`
 

--- a/plugins/nvme/README.md
+++ b/plugins/nvme/README.md
@@ -24,7 +24,6 @@ This plugin supports the following protocol ID:
 
 These device use the NVMe DeviceInstanceId values, e.g.
 
-* `NVME\VEN_1179&DEV_010F&REV_01`
 * `NVME\VEN_1179&DEV_010F`
 * `NVME\VEN_1179`
 

--- a/plugins/qsi-dock/README.md
+++ b/plugins/qsi-dock/README.md
@@ -15,7 +15,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_047D&PID_808D&REV_0001`
 * `USB\VID_047D&PID_808D`
 * `USB\VID_047D`
 

--- a/plugins/rts54hid/README.md
+++ b/plugins/rts54hid/README.md
@@ -23,7 +23,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_0BDA&PID_1100&REV_0001`
 * `USB\VID_0BDA&PID_1100`
 * `USB\VID_0BDA`
 

--- a/plugins/rts54hub/README.md
+++ b/plugins/rts54hub/README.md
@@ -24,7 +24,6 @@ This plugin supports the following protocol IDs:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_0BDA&PID_5423&REV_0001`
 * `USB\VID_0BDA&PID_5423`
 * `USB\VID_0BDA`
 

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -269,6 +269,7 @@ fu_scsi_device_init(FuScsiDevice *self)
 	fu_device_add_icon(FU_DEVICE(self), "drive-harddisk");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary(FU_DEVICE(self), "SCSI device");
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_udev_device_set_flags(FU_UDEV_DEVICE(self),
 				 FU_UDEV_DEVICE_FLAG_OPEN_READ | FU_UDEV_DEVICE_FLAG_OPEN_SYNC |
 				     FU_UDEV_DEVICE_FLAG_IOCTL_RETRY);

--- a/plugins/steelseries/README.md
+++ b/plugins/steelseries/README.md
@@ -26,7 +26,6 @@ This plugin supports the following protocol IDs:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_1038&PID_1702&REV_0001`
 * `USB\VID_1038&PID_1702`
 * `USB\VID_1038`
 

--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -157,14 +157,16 @@ fu_steelseries_fizz_tunnel_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_u16(device, "REV", release);
 	fu_device_build_instance_id_quirk(device, NULL, "STEELSERIES", "VID", "PROTOCOL", NULL);
 	fu_device_build_instance_id(device, NULL, "STEELSERIES", "VID", "PID", "PROTOCOL", NULL);
-	fu_device_build_instance_id(device,
-				    NULL,
-				    "STEELSERIES",
-				    "VID",
-				    "PID",
-				    "REV",
-				    "PROTOCOL",
-				    NULL);
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV)) {
+		fu_device_build_instance_id(device,
+					    NULL,
+					    "STEELSERIES",
+					    "VID",
+					    "PID",
+					    "REV",
+					    "PROTOCOL",
+					    NULL);
+	}
 
 	/* success */
 	return TRUE;

--- a/plugins/synaptics-cxaudio/README.md
+++ b/plugins/synaptics-cxaudio/README.md
@@ -20,7 +20,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_17EF&PID_3083&REV_0001`
 * `USB\VID_17EF&PID_3083`
 * `USB\VID_17EF`
 

--- a/plugins/synaptics-prometheus/README.md
+++ b/plugins/synaptics-prometheus/README.md
@@ -20,7 +20,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_06CB&PID_00A9&REV_0001`
 * `USB\VID_06CB&PID_00A9`
 * `USB\VID_06CB&PID_00A9-cfg`
 * `USB\VID_06CB&PID_00A9&CFG1_3483&CFG2_500`

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -202,6 +202,7 @@ fu_system76_launch_device_init(FuSystem76LaunchDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_add_protocol(FU_DEVICE(self), "org.usb.dfu");
 	fu_device_retry_set_delay(FU_DEVICE(self), 100);

--- a/plugins/test/fu-test-ble-device.c
+++ b/plugins/test/fu-test-ble-device.c
@@ -20,6 +20,7 @@ fu_test_ble_device_init(FuTestBleDevice *self)
 	fu_device_add_protocol(FU_DEVICE(self), "org.test.testble");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 }
 
 static void

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -112,6 +112,7 @@ fu_thelio_io_device_init(FuThelioIoDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_REPLUG_MATCH_GUID);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_protocol(FU_DEVICE(self), "org.usb.dfu");

--- a/plugins/ti-tps6598x/README.md
+++ b/plugins/ti-tps6598x/README.md
@@ -21,7 +21,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_0451&PID_ACE1&REV_0001`
 * `USB\VID_0451&PID_ACE1`
 * `USB\VID_0451`
 

--- a/plugins/usi-dock/README.md
+++ b/plugins/usi-dock/README.md
@@ -15,7 +15,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_17EF&PID_7226&REV_0001`
 * `USB\VID_17EF&PID_7226`
 * `USB\VID_17EF`
 

--- a/plugins/vendor-example/README.md.in
+++ b/plugins/vendor-example/README.md.in
@@ -21,7 +21,6 @@ This plugin supports the following protocol ID:
 These devices use the standard USB DeviceInstanceId values, e.g.
 
 * `USB\ID_XXX`
-* `USB\VID_273F&PID_1001&REV_0001`
 * `USB\VID_273F&PID_1001`
 * `USB\VID_273F`
 {%- else -%}

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -718,6 +718,7 @@ fu_vli_device_init(FuVliDevice *self)
 	priv->spi_auto_detect = TRUE;
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_SERIAL_NUMBER);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_ADD_INSTANCE_ID_REV);
 }
 
 static void

--- a/plugins/wacom-usb/README.md
+++ b/plugins/wacom-usb/README.md
@@ -34,7 +34,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_056A&PID_0378&REV_0001`
 * `USB\VID_056A&PID_0378`
 * `USB\VID_056A`
 

--- a/plugins/wistron-dock/README.md
+++ b/plugins/wistron-dock/README.md
@@ -24,7 +24,6 @@ This plugin supports the following protocol ID:
 
 These devices use the standard USB DeviceInstanceId values, e.g.
 
-* `USB\VID_0FB8&PID_0010&REV_0001`
 * `USB\VID_0FB8&PID_0010`
 * `USB\VID_0FB8`
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -3537,7 +3537,7 @@ fu_backend_usb_func(gconstpointer user_data)
 
 	/* check the device was processed correctly by FuUsbDevice */
 	g_assert_cmpstr(fu_device_get_name(device_tmp), ==, "ColorHug2");
-	g_assert_true(fu_device_has_instance_id(device_tmp, "USB\\VID_273F&PID_1004&REV_0002"));
+	g_assert_true(fu_device_has_instance_id(device_tmp, "USB\\VID_273F&PID_1004"));
 	g_assert_true(fu_device_has_vendor_id(device_tmp, "USB:0x273F"));
 
 	/* check the fwupd DS20 descriptor was parsed */
@@ -3623,7 +3623,7 @@ fu_backend_usb_invalid_func(gconstpointer user_data)
 
 	/* check the device was processed correctly by FuUsbDevice */
 	g_assert_cmpstr(fu_device_get_name(device_tmp), ==, "ColorHug2");
-	g_assert_true(fu_device_has_instance_id(device_tmp, "USB\\VID_273F&PID_1004&REV_0002"));
+	g_assert_true(fu_device_has_instance_id(device_tmp, "USB\\VID_273F&PID_1004"));
 	g_assert_true(fu_device_has_vendor_id(device_tmp, "USB:0x273F"));
 
 	/* check the fwupd DS20 descriptor was *not* parsed */


### PR DESCRIPTION
This reduces the number of calls to fu_quirks_lookup_by_id_iter() by 15% and speeds up engine coldplug by about the same amount.

Add the flag to anything we know depends on the _REV GUIDs, and now we can add flags from LVFS metadata we worry less if we miss one device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
