### PR TITLE
Do not use quirk lookups to match udev subsystems to plugins

### DIFF
--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -47,9 +47,13 @@ fu_context_get_firmware_gtypes(FuContext *self);
 GType
 fu_context_get_firmware_gtype_by_id(FuContext *self, const gchar *id);
 void
-fu_context_add_udev_subsystem(FuContext *self, const gchar *subsystem);
+fu_context_add_udev_subsystem(FuContext *self, const gchar *subsystem, const gchar *plugin_name);
 GPtrArray *
 fu_context_get_udev_subsystems(FuContext *self);
+GPtrArray *
+fu_context_get_plugin_names_for_udev_subsystem(FuContext *self,
+					       const gchar *subsystem,
+					       GError **error);
 void
 fu_context_add_esp_volume(FuContext *self, FuVolume *volume);
 FuSmbios *

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -433,6 +433,8 @@ fu_plugin_add_device_gtype(FuPlugin *self, GType device_gtype);
 void
 fu_plugin_add_firmware_gtype(FuPlugin *self, const gchar *id, GType gtype);
 void
+fu_plugin_add_device_udev_subsystem(FuPlugin *self, const gchar *subsystem);
+void
 fu_plugin_add_udev_subsystem(FuPlugin *self, const gchar *subsystem);
 gpointer
 fu_plugin_cache_lookup(FuPlugin *self, const gchar *id);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -573,10 +573,6 @@ fu_udev_device_probe(FuDevice *device, GError **error)
 				       g_udev_device_get_property(priv->udev_device, "MODALIAS"));
 	fu_device_build_instance_id_quirk(device, NULL, subsystem, "MODALIAS", NULL);
 
-	/* add subsystem to match in plugins */
-	if (subsystem != NULL)
-		fu_device_add_instance_id_full(device, subsystem, FU_DEVICE_INSTANCE_FLAG_QUIRKS);
-
 	/* add firmware_id */
 	if (g_strcmp0(g_udev_device_get_subsystem(priv->udev_device), "serio") == 0) {
 		if (!fu_udev_device_probe_serio(self, error))

--- a/plugins/ata/ata.quirk
+++ b/plugins/ata/ata.quirk
@@ -1,7 +1,3 @@
-# match all devices with this udev subsystem
-[BLOCK]
-Plugin = ata
-
 [ThinkSystem M.2 VD]
 Flags = ~updatable
 

--- a/plugins/ata/fu-ata-plugin.c
+++ b/plugins/ata/fu-ata-plugin.c
@@ -24,7 +24,7 @@ static void
 fu_ata_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "block");
+	fu_plugin_add_device_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ATA_DEVICE);
 }
 

--- a/plugins/emmc/emmc.quirk
+++ b/plugins/emmc/emmc.quirk
@@ -1,3 +1,0 @@
-# match all devices with this udev subsystem
-[BLOCK]
-Plugin = emmc

--- a/plugins/emmc/fu-emmc-plugin.c
+++ b/plugins/emmc/fu-emmc-plugin.c
@@ -24,7 +24,7 @@ static void
 fu_emmc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "block");
+	fu_plugin_add_device_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EMMC_DEVICE);
 }
 

--- a/plugins/emmc/meson.build
+++ b/plugins/emmc/meson.build
@@ -3,7 +3,6 @@ if get_option('plugin_emmc').require(gudev.found(),
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginEmmc"']
 
-plugin_quirks += files('emmc.quirk')
 plugin_builtins += static_library('fu_plugin_emmc',
   sources: [
     'fu-emmc-plugin.c',

--- a/plugins/gpio/fu-gpio-plugin.c
+++ b/plugins/gpio/fu-gpio-plugin.c
@@ -167,7 +167,7 @@ fu_gpio_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "GpioForUpdate");
-	fu_plugin_add_udev_subsystem(plugin, "gpio");
+	fu_plugin_add_device_udev_subsystem(plugin, "gpio");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GPIO_DEVICE);
 }
 

--- a/plugins/gpio/gpio.quirk
+++ b/plugins/gpio/gpio.quirk
@@ -1,7 +1,3 @@
-# match all devices with this udev subsystem
-[GPIO]
-Plugin = gpio
-
 [GPIO\ID_AMDI0030:00]
 Name = GPIO controller
 ParentGuid = cpu

--- a/plugins/iommu/fu-iommu-plugin.c
+++ b/plugins/iommu/fu-iommu-plugin.c
@@ -85,7 +85,7 @@ static void
 fu_iommu_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "iommu");
+	fu_plugin_add_device_udev_subsystem(plugin, "iommu");
 }
 
 static void

--- a/plugins/iommu/iommu.quirk
+++ b/plugins/iommu/iommu.quirk
@@ -1,3 +1,0 @@
-# match all devices with this udev subsystem
-[IOMMU]
-Plugin = iommu

--- a/plugins/iommu/meson.build
+++ b/plugins/iommu/meson.build
@@ -1,7 +1,6 @@
 if hsi and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginIommu"']
 
-plugin_quirks += files('iommu.quirk')
 plugin_builtins += static_library('fu_plugin_iommu',
   sources: [
     'fu-iommu-plugin.c',

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -512,7 +512,7 @@ static void
 fu_msr_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "msr");
+	fu_plugin_add_device_udev_subsystem(plugin, "msr");
 }
 
 static void

--- a/plugins/msr/meson.build
+++ b/plugins/msr/meson.build
@@ -1,8 +1,6 @@
 if hsi and has_cpuid
 cargs = ['-DG_LOG_DOMAIN="FuPluginMsr"']
 
-plugin_quirks += files('msr.quirk')
-
 if libsystemd.found()
 install_data(['fwupd-msr.conf'],
   install_dir: systemd_modules_load_dir,

--- a/plugins/msr/msr.quirk
+++ b/plugins/msr/msr.quirk
@@ -1,3 +1,0 @@
-# match all devices with this udev subsystem
-[MSR]
-Plugin = msr

--- a/plugins/mtd/fu-mtd-plugin.c
+++ b/plugins/mtd/fu-mtd-plugin.c
@@ -40,7 +40,7 @@ fu_mtd_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "MtdMetadataOffset");
 	fu_context_add_quirk_key(ctx, "MtdMetadataSize");
-	fu_plugin_add_udev_subsystem(plugin, "mtd");
+	fu_plugin_add_device_udev_subsystem(plugin, "mtd");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MTD_DEVICE);
 }
 

--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -1,6 +1,3 @@
-[MTD]
-Plugin = mtd
-
 [MTD\VENDOR_PINE64&PRODUCT_PinePhone-Pro&NAME_spi1.0]
 Name = Tow-Boot platform firmware
 FirmwareGType = FuUswidFirmware

--- a/plugins/nvme/fu-nvme-plugin.c
+++ b/plugins/nvme/fu-nvme-plugin.c
@@ -26,7 +26,7 @@ fu_nvme_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "NvmeBlockSize");
-	fu_plugin_add_udev_subsystem(plugin, "nvme");
+	fu_plugin_add_device_udev_subsystem(plugin, "nvme");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NVME_DEVICE);
 }
 

--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -1,7 +1,3 @@
-# match all devices with this udev subsystem
-[NVME]
-Plugin = nvme
-
 # Phison
 [NVME\VEN_1987]
 Flags = force-align,needs-shutdown

--- a/plugins/optionrom/fu-optionrom-plugin.c
+++ b/plugins/optionrom/fu-optionrom-plugin.c
@@ -24,7 +24,7 @@ static void
 fu_optionrom_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "pci");
+	fu_plugin_add_device_udev_subsystem(plugin, "pci");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "udev");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_OPTIONROM_DEVICE);
 }

--- a/plugins/optionrom/meson.build
+++ b/plugins/optionrom/meson.build
@@ -1,7 +1,6 @@
 if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginOptionrom"']
 
-plugin_quirks += files('optionrom.quirk')
 plugin_builtins += static_library('fu_plugin_optionrom',
   sources: [
     'fu-optionrom-plugin.c',

--- a/plugins/optionrom/optionrom.quirk
+++ b/plugins/optionrom/optionrom.quirk
@@ -1,3 +1,0 @@
-# match all devices with this udev subsystem
-[PCI]
-Plugin = optionrom

--- a/plugins/scsi/fu-scsi-plugin.c
+++ b/plugins/scsi/fu-scsi-plugin.c
@@ -24,7 +24,7 @@ static void
 fu_scsi_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_udev_subsystem(plugin, "block");
+	fu_plugin_add_device_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SCSI_DEVICE);
 }
 

--- a/plugins/scsi/scsi.quirk
+++ b/plugins/scsi/scsi.quirk
@@ -1,6 +1,3 @@
-[BLOCK]
-Plugin = scsi
-
 [SCSI\VEN_LSI&DEV_VirtualSES]
 Flags = no-probe
 [SCSI\VEN_Marvell&DEV_Console]

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -157,7 +157,7 @@ fu_synaptics_mst_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "SynapticsMstDeviceKind");
 	fu_plugin_add_udev_subsystem(plugin, "drm"); /* used for uevent only */
-	fu_plugin_add_udev_subsystem(plugin, "drm_dp_aux_dev");
+	fu_plugin_add_device_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
 }
 

--- a/plugins/synaptics-mst/synaptics-mst.quirk
+++ b/plugins/synaptics-mst/synaptics-mst.quirk
@@ -1,7 +1,3 @@
-# match all devices with this udev subsystem
-[DRM_DP_AUX_DEV]
-Plugin = synaptics_mst
-
 # GUID generation for Synaptics MST plugin
 #
 # SYNAPTICSMST\BID is the 16 bit board ID which contains:

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -365,7 +365,7 @@ fu_tpm_plugin_constructed(GObject *obj)
 
 	/* old name */
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "tpm_eventlog");
-	fu_plugin_add_udev_subsystem(plugin, "tpm");
+	fu_plugin_add_device_udev_subsystem(plugin, "tpm");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TPM_V2_DEVICE);
 }
 

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -6,8 +6,6 @@ if hsi and \
     error_message: 'gudev is needed for plugin_tpm').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginTpm"']
 
-plugin_quirks += files('tpm.quirk')
-
 plugin_builtin_tpm = static_library('fu_plugin_tpm',
   rustgen.process('fu-tpm.rs'),
   sources: [

--- a/plugins/tpm/tpm.quirk
+++ b/plugins/tpm/tpm.quirk
@@ -1,2 +1,0 @@
-[TPM]
-Plugin = tpm

--- a/plugins/uf2/fu-uf2-plugin.c
+++ b/plugins/uf2/fu-uf2-plugin.c
@@ -27,7 +27,7 @@ fu_uf2_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UF2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, "uf2", FU_TYPE_UF2_FIRMWARE);
-	fu_plugin_add_udev_subsystem(plugin, "block");
+	fu_plugin_add_device_udev_subsystem(plugin, "block");
 }
 
 static void

--- a/plugins/uf2/uf2.quirk
+++ b/plugins/uf2/uf2.quirk
@@ -1,7 +1,3 @@
-# match all devices with this udev subsystem
-[BLOCK]
-Plugin = uf2
-
 # Raspberry Pi RP2 [no CURRENT.UF2]
 [USB\VID_2E8A&PID_0003]
 Guid = UF2\FAMILY_E48BFF56


### PR DESCRIPTION
This speeds up the engine startup by another 35%. We only need to track what plugin wants what udev subsystem and we can avoid 91 lookups for `BLOCK`, 65 for `PCI`, 57 for `PLATFORM`, 26 for `MEI` etc.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
