### PR TITLE
Fix the replug error "failed to get device before update reload: fail…

### DIFF
--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -527,7 +527,7 @@ fu_fpc_device_init(FuFpcDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
-	fu_device_set_remove_delay(FU_DEVICE(self), 5000);
+	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
 	fu_device_add_protocol(FU_DEVICE(self), "com.fingerprints.dfupc");
 	fu_device_set_summary(FU_DEVICE(self), "FPC fingerprint sensor");
 	fu_device_set_install_duration(FU_DEVICE(self), 15);

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -916,7 +916,7 @@ fu_device_list_wait_for_replug(FuDeviceList *self, GError **error)
 		g_main_context_iteration(NULL, FALSE);
 		devices_wfr_tmp = fu_device_list_get_wait_for_replug(self);
 		if (devices_wfr_tmp->len == 0)
-			break;
+			continue;
 	} while (g_timer_elapsed(timer, NULL) * 1000.f < remove_delay);
 
 	/* check that no other devices are still waiting for replug */


### PR DESCRIPTION
…ed to wait for detach replug"

There is some chances for 10a5:9800 show replug error for firmware upgrading nearly being finished.
Just wait for enough time to wait for the USB device replug.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
