### PR TITLE
Load PE/COFF long section names from string table

### DIFF
--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -10,9 +10,9 @@
 
 #include "fu-bytes.h"
 #include "fu-coswid-firmware.h"
-#include "fu-dump.h"
 #include "fu-mem.h"
 #include "fu-pefile-firmware.h"
+#include "fu-pefile-struct.h"
 #include "fu-string.h"
 
 /**
@@ -30,27 +30,75 @@ G_DEFINE_TYPE(FuPefileFirmware, fu_pefile_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_pefile_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
-	guint16 magic = 0x0;
+	return fu_struct_pe_dos_header_validate(g_bytes_get_data(fw, NULL),
+						g_bytes_get_size(fw),
+						offset,
+						error);
+}
 
-	if (!fu_memread_uint16_safe(g_bytes_get_data(fw, NULL),
-				    g_bytes_get_size(fw),
-				    offset,
-				    &magic,
-				    G_LITTLE_ENDIAN,
-				    error)) {
-		g_prefix_error(error, "failed to read magic: ");
+static gboolean
+fu_pefile_firmware_parse_section(FuFirmware *firmware,
+				 GBytes *fw,
+				 gsize hdr_offset,
+				 gsize strtab_offset,
+				 FwupdInstallFlags flags,
+				 GError **error)
+{
+	gsize bufsz = 0;
+	guint32 sect_offset;
+	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autofree gchar *sect_id = NULL;
+	g_autofree gchar *sect_id_tmp = NULL;
+	g_autoptr(FuFirmware) img = NULL;
+	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(GBytes) blob = NULL;
+
+	st = fu_struct_pe_coff_section_parse(buf, bufsz, hdr_offset, error);
+	if (st == NULL)
 		return FALSE;
-	}
-	if (magic != 0x5A4D) {
+	sect_id_tmp = fu_struct_pe_coff_section_get_name(st);
+	if (sect_id_tmp == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid magic for file");
+				    "invalid section name");
 		return FALSE;
 	}
+	if (sect_id_tmp[0] == '/') {
+		guint64 str_idx = 0x0;
+		if (!fu_strtoull(sect_id_tmp + 1, &str_idx, 0, G_MAXUINT32, error))
+			return FALSE;
+		sect_id = fu_memstrsafe(buf, bufsz, strtab_offset + str_idx, 16, error);
+		if (sect_id == NULL) {
+			g_prefix_error(error, "no section name: ");
+			return FALSE;
+		}
+	} else {
+		sect_id = g_steal_pointer(&sect_id_tmp);
+	}
 
-	/* success */
-	return TRUE;
+	/* create new firmware */
+	if (g_strcmp0(sect_id, ".sbom") == 0) {
+		img = fu_coswid_firmware_new();
+	} else {
+		img = fu_firmware_new();
+	}
+	fu_firmware_set_id(img, sect_id);
+
+	/* add data */
+	sect_offset = fu_struct_pe_coff_section_get_pointer_to_raw_data(st);
+	fu_firmware_set_offset(img, sect_offset);
+	blob = fu_bytes_new_offset(fw,
+				   sect_offset,
+				   fu_struct_pe_coff_section_get_size_of_raw_data(st),
+				   error);
+	if (blob == NULL) {
+		g_prefix_error(error, "failed to get raw data for %s: ", sect_id);
+		return FALSE;
+	}
+	if (!fu_firmware_parse(img, blob, flags, error))
+		return FALSE;
+	return fu_firmware_add_image_full(firmware, img, error);
 }
 
 static gboolean
@@ -61,41 +109,33 @@ fu_pefile_firmware_parse(FuFirmware *firmware,
 			 GError **error)
 {
 	gsize bufsz = 0;
-	gsize hdr_offset = offset;
-	guint16 opt_hdrsz = 0x0;
-	guint32 nr_sections = 0x0;
-	guint32 offset_sig = 0x0;
-	guint32 signature = 0x0;
+	gsize strtab_offset;
+	guint32 nr_sections;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
+	g_autoptr(GByteArray) st_coff = NULL;
+	g_autoptr(GByteArray) st_doshdr = NULL;
 
-	/* we already checked the MS-DOS magic, check the signature now */
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    hdr_offset + 0x3C,
-				    &offset_sig,
-				    G_LITTLE_ENDIAN,
-				    error))
+	/* parse the DOS header to get the COFF header */
+	st_doshdr = fu_struct_pe_dos_header_parse(buf, bufsz, offset, error);
+	if (st_doshdr == NULL)
 		return FALSE;
-	hdr_offset += offset_sig;
-	if (!fu_memread_uint32_safe(buf, bufsz, hdr_offset, &signature, G_LITTLE_ENDIAN, error))
+	offset += fu_struct_pe_dos_header_get_lfanew(st_doshdr);
+	st_coff = fu_struct_pe_coff_file_header_parse(buf, bufsz, offset, error);
+	if (st_coff == NULL)
 		return FALSE;
-	if (signature != 0x4550) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid signature for file");
-		return FALSE;
+	offset += st_coff->len;
+
+	/* verify optional extra header */
+	if (fu_struct_pe_coff_file_header_get_size_of_optional_header(st_coff) > 0) {
+		g_autoptr(GByteArray) st_opt =
+		    fu_struct_pe_coff_optional_header64_parse(buf, bufsz, offset, error);
+		if (st_opt == NULL)
+			return FALSE;
+		offset += fu_struct_pe_coff_file_header_get_size_of_optional_header(st_coff);
 	}
-	hdr_offset += 4;
 
 	/* read number of sections */
-	if (!fu_memread_uint32_safe(buf,
-				    bufsz,
-				    hdr_offset + 0x02,
-				    &nr_sections,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
+	nr_sections = fu_struct_pe_coff_file_header_get_number_of_sections(st_coff);
 	if (nr_sections == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -103,83 +143,20 @@ fu_pefile_firmware_parse(FuFirmware *firmware,
 				    "invalid number of sections");
 		return FALSE;
 	}
+	strtab_offset = fu_struct_pe_coff_file_header_get_pointer_to_symbol_table(st_coff) +
+			fu_struct_pe_coff_file_header_get_number_of_symbols(st_coff) *
+			    FU_STRUCT_PE_COFF_SYMBOL_SIZE;
 
-	/* read optional extra header size  */
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    hdr_offset + 0x10,
-				    &opt_hdrsz,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	hdr_offset += 0x14 + opt_hdrsz;
-
-	/* read out COFF header */
+	/* read out each section */
 	for (guint idx = 0; idx < nr_sections; idx++) {
-		guint32 sect_length = 0x0;
-		guint32 sect_offset = 0x0;
-		guint8 name[8] = {0x0};
-		g_autofree gchar *sect_id = NULL;
-		g_autoptr(FuFirmware) fw_sect = NULL;
-		g_autoptr(GBytes) sect_blob = NULL;
-
-		/* read the section name */
-		if (!fu_memcpy_safe(name,
-				    sizeof(name),
-				    0x0,
-				    buf,
-				    bufsz,
-				    hdr_offset,
-				    sizeof(name),
-				    error))
+		if (!fu_pefile_firmware_parse_section(firmware,
+						      fw,
+						      offset,
+						      strtab_offset,
+						      flags,
+						      error))
 			return FALSE;
-		sect_id = fu_strsafe((const gchar *)name, sizeof(name));
-		if (sect_id == NULL) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INVALID_FILE,
-					    "no section name");
-			return FALSE;
-		}
-
-		/* create new firmware */
-		if (g_strcmp0(sect_id, ".sbom") == 0) {
-			fw_sect = fu_coswid_firmware_new();
-		} else {
-			fw_sect = fu_firmware_new();
-		}
-		fu_firmware_set_idx(fw_sect, idx);
-		fu_firmware_set_id(fw_sect, sect_id);
-
-		/* add data */
-		if (!fu_memread_uint32_safe(buf,
-					    bufsz,
-					    hdr_offset + 0x08,
-					    &sect_length,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return FALSE;
-		fu_firmware_set_size(fw_sect, sect_length);
-		if (!fu_memread_uint32_safe(buf,
-					    bufsz,
-					    hdr_offset + 0x14,
-					    &sect_offset,
-					    G_LITTLE_ENDIAN,
-					    error))
-			return FALSE;
-		fu_firmware_set_offset(fw_sect, sect_offset);
-		sect_blob = fu_bytes_new_offset(fw, sect_offset, sect_length, error);
-		if (sect_blob == NULL) {
-			g_prefix_error(error, "failed to get raw data for %s: ", sect_id);
-			return FALSE;
-		}
-		if (!fu_firmware_parse(fw_sect, sect_blob, flags, error))
-			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, fw_sect, error))
-			return FALSE;
-
-		/* next! */
-		hdr_offset += 0x28;
+		offset += FU_STRUCT_PE_COFF_SECTION_SIZE;
 	}
 
 	/* success */

--- a/libfwupdplugin/fu-pefile.rs
+++ b/libfwupdplugin/fu-pefile.rs
@@ -1,0 +1,151 @@
+// Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1+
+
+#[derive(Parse, Validate)]
+struct PeDosHeader {
+    magic: u16le: const=0x5A4D,
+    _cblp: u16le: default=0x90,
+    _cp: u16le: default=0x3,
+    _crlc: u16le: default=0x0,
+    _cparhdr: u16le: default=0x4,
+    _minalloc: u16le: default=0x0,
+    _maxalloc: u16le: default=0xFFFF,
+    _ss: u16le: default=0x0,
+    _sp: u16le: default=0xB8,
+    _csum: u16le: default=0x0,
+    _ip: u16le: default=0x0,
+    _cs: u16le: default=0x0,
+    _lfarlc: u16le: default=0x40,
+    _ovno: u16le: default=0x0,
+    _res: [u8; 8]: default=0x0000000000000000,
+    _oemid: u16le: default=0x0,
+    _oeminfo: u16le: default=0x0,
+    _res2: [u8; 20]: default=0x0000000000000000000000000000000000000000,
+    lfanew: u32le: default=0x80,
+}
+
+#[repr(u16le)]
+enum PeCoffMachine {
+    Unknown = 0x0,
+    Alpha = 0x184,
+    Alpha64 = 0x284,
+    Am33 = 0x1d3,
+    Amd64 = 0x8664,
+    Arm = 0x1c0,
+    Arm64 = 0xaa64,
+    Armnt = 0x1c4,
+    Axp64 = 0x284,
+    Ebc = 0xebc,
+    I386 = 0x14c,
+    Ia64 = 0x200,
+    Loongarch32 = 0x6232,
+    Loongarch64 = 0x6264,
+    M32r = 0x9041,
+    Mips16 = 0x266,
+    Mipsfpu = 0x366,
+    Mipsfpu16 = 0x466,
+    Powerpc = 0x1f0,
+    Powerpcfp = 0x1f1,
+    R4000 = 0x166,
+    Riscv32 = 0x5032,
+    Riscv64 = 0x5064,
+    Riscv128 = 0x5128,
+    Sh3 = 0x1a2,
+    Sh3dsp = 0x1a3,
+    Sh4 = 0x1a6,
+    Sh5 = 0x1a8,
+    Thumb = 0x1c2,
+    Wcemipsv2 = 0x169,
+}
+
+#[repr(u16le)]
+enum PeCoffMagic {
+    Pe32 = 0x10b,
+    Pe32Plus = 0x20b,
+}
+
+#[repr(u16le)]
+enum FuCoffSubsystem {
+    Unknown = 0,
+    Native = 1,
+    WindowsGui = 2,
+    WindowsCui = 3,
+    Os2Cui = 5,
+    PosixCui = 7,
+    NativeWindows = 8,
+    WindowsCeGui = 9,
+    EfiApplication = 10,
+    EfiBootServiceDriver = 11,
+    EfiRuntimeDriver = 12,
+    EfiRom = 13,
+    Xbox = 14,
+    WindowsBootApplication = 16,
+}
+
+#[derive(Parse)]
+struct PeCoffFileHeader {
+    signature: u32le: const=0x4550, // "PE\0\0"
+    machine: PeCoffMachine: default=0x8664,
+    number_of_sections: u16le: default=0,
+    _time_date_stamp: u32le: default=0,
+    pointer_to_symbol_table: u32le: default=0,
+    number_of_symbols: u32le: default=0,
+    size_of_optional_header: u16le: default=0xf0,
+    characteristics: u16le: default=0x2022,
+}
+
+#[derive(Parse)]
+struct PeCoffOptionalHeader64 {
+    magic: PeCoffMagic: default=0x020b,
+    _major_linker_version: u8: default=0x0e,
+    _minor_linker_version: u8: default=0x0e,
+    size_of_code: u32le: default=0x0,
+    size_of_initialized_data: u32le: default=0x0,
+    size_of_uninitialized_data: u32le: default=0x0,
+    addressofentrypoint: u32le: default=0x0,
+    base_of_code: u32le: default=0x0,
+    image_base: u64le: default=0x0,
+    section_alignment: u32le: default=0x200,
+    file_alignment: u32le: default=0x200,
+    _major_operating_system_version: u16le: default=0x0,
+    _minor_operating_system_version: u16le: default=0x0,
+    _major_image_version: u16le: default=0x0,
+    _minor_image_version: u16le: default=0x0,
+    _major_subsystem_version: u16le: default=0x0,
+    _minor_subsystem_version: u16le: default=0x0,
+    _win32_versionvalue: u32le: default=0x0,
+    size_of_image: u32le: default=0x0,
+    size_of_headers: u32le: default=0x0,
+    check_sum: u32le: default=0x0,
+    subsystem: FuCoffSubsystem: default=0xa,
+    _dll_characteristics: u16le: default=0x0,
+    _size_of_stackreserve: u64le: default=0x0,
+    _size_of_stack_commit: u64le: default=0x0,
+    _size_of_heap_reserve: u64le: default=0x0,
+    _size_of_heap_commit: u64le: default=0x0,
+    loader_flags: u32le: default=0x0,
+    number_of_rva_and_sizes: u32le: default=0x0,
+}
+
+struct PeCoffSymbol {
+    name: [char; 8],
+    value: u32le,
+    section_number: u16le,
+    type: u16le,
+    storage_class: u8,
+    number_of_aux_symbols: u8,
+}
+
+#[derive(Parse)]
+struct PeCoffSection {
+    name: [char; 8],
+    virtual_size: u32le: default=0x0,
+    virtual_address: u32le: default=0x0,
+    size_of_raw_data: u32le: default=0x0,
+    pointer_to_raw_data: u32le: default=0x0,
+    _pointer_to_relocations: u32le: default=0x0,
+    _pointer_to_linenumbers: u32le: default=0x0,
+    _number_of_relocations: u16le: default=0x0,
+    _number_of_linenumbers: u16le: default=0x0,
+    characteristics: u32le: default=0x0,
+}

--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -54,7 +54,7 @@ void {{item.c_setter}}(GByteArray *st, {{item.type_glib}} value);
 #define {{obj.c_define('SIZE')}} 0x{{'{:X}'.format(obj.size)}}
 
 {%- for item in obj.items | selectattr('enabled') | selectattr('default') %}
-{%- if item.type == Type.STRING %}
+{%- if item.type == Type.STRING or item.multiplier %}
 #define {{item.c_define('DEFAULT')}} "{{item.default}}"
 {%- else %}
 #define {{item.c_define('DEFAULT')}} {{item.default}}

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -19,6 +19,7 @@ fwupdplugin_structs = rustgen.process(
   'fu-ifwi.rs', # fuzzing
   'fu-intel-thunderbolt.rs', # fuzzing
   'fu-oprom.rs', # fuzzing
+  'fu-pefile.rs', # fuzzing
   'fu-smbios.rs', # fuzzing
   'fu-usb-device-ds20.rs', # fuzzing
   'fu-uswid.rs', # fuzzing


### PR DESCRIPTION
Also, use rustgen to validate PE files.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
