### PR TITLE
genesys-gl32xx: Add an extra GUID to differentiate firmware streams

### DIFF
--- a/plugins/genesys-gl32xx/README.md
+++ b/plugins/genesys-gl32xx/README.md
@@ -16,7 +16,11 @@ This plugin supports the following protocol ID:
 
 These devices use the standard UDEV DeviceInstanceId values, e.g.
 
-* `[BLOCK\VEN_05E3&DEV_XXXX]`
+* `BLOCK\VEN_05E3&DEV_XXXX`
+
+These devices also use custom GUID values, e.g.
+
+* `BLOCK\VEN_05E3&DEV_XXXX&VER_YY`
 
 ## Update Behavior
 


### PR DESCRIPTION

    └─GL323x SD reader [0x0764]:
          Device ID:          268092d4100a2a2e4ffe010ce476db434a0dbf47
          Current version:    2960
          Vendor:             Genesys (BLOCK:0x05E3)
          GUIDs:              9125a0e3-fc06-5648-8044-021842ff3eed ← BLOCK\VEN_05E3&DEV_0764
                              ce88d98c-d36c-5b55-bac4-f07af9e0c022 ← BLOCK\VEN_05E3&DEV_0764&VER_29
          Device Flags:       • Updatable
                              • Cryptographic hash verification is available
                              • Unsigned Payload

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
