### PR TITLE
Do not misuse the offset as an address in the SREC parser

### DIFF
--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -26,6 +26,8 @@
 
 typedef struct {
 	GPtrArray *records;
+	guint32 addr_min;
+	guint32 addr_max;
 } FuSrecFirmwarePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuSrecFirmware, fu_srec_firmware, FU_TYPE_FIRMWARE)
@@ -52,6 +54,40 @@ fu_srec_firmware_get_records(FuSrecFirmware *self)
 	FuSrecFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_SREC_FIRMWARE(self), NULL);
 	return priv->records;
+}
+
+/**
+ * fu_srec_firmware_set_addr_min:
+ * @self: A #FuSrecFirmware
+ * @addr_min: address, or 0x0 to disable
+ *
+ * Sets the minimum address allowed. This may be useful to ignore a bootloader section.
+ *
+ * Since: 1.9.3
+ **/
+void
+fu_srec_firmware_set_addr_min(FuSrecFirmware *self, guint32 addr_min)
+{
+	FuSrecFirmwarePrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_SREC_FIRMWARE(self));
+	priv->addr_min = addr_min;
+}
+
+/**
+ * fu_srec_firmware_set_addr_max:
+ * @self: A #FuSrecFirmware
+ * @addr_max: address, or 0x0 to disable
+ *
+ * Sets the maximum address allowed. This may be useful to ignore a signature.
+ *
+ * Since: 1.9.3
+ **/
+void
+fu_srec_firmware_set_addr_max(FuSrecFirmware *self, guint32 addr_max)
+{
+	FuSrecFirmwarePrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_SREC_FIRMWARE(self));
+	priv->addr_max = addr_max;
 }
 
 static void
@@ -447,11 +483,17 @@ fu_srec_firmware_parse(FuFirmware *firmware,
 					    rcd->ln);
 				return FALSE;
 			}
-			if (rcd->addr < offset) {
+			if (rcd->addr < priv->addr_min) {
 				g_debug(
 				    "ignoring data at 0x%x as before start address 0x%x at line %u",
 				    (guint)rcd->addr,
-				    (guint)offset,
+				    priv->addr_min,
+				    rcd->ln);
+			} else if (priv->addr_max > 0 && rcd->addr < priv->addr_max) {
+				g_debug(
+				    "ignoring data at 0x%x as after end address 0x%x at line %u",
+				    (guint)rcd->addr,
+				    priv->addr_max,
 				    rcd->ln);
 			} else {
 				guint32 len_hole = rcd->addr - addr32_last;

--- a/libfwupdplugin/fu-srec-firmware.h
+++ b/libfwupdplugin/fu-srec-firmware.h
@@ -60,6 +60,10 @@ typedef struct {
 
 FuFirmware *
 fu_srec_firmware_new(void);
+void
+fu_srec_firmware_set_addr_min(FuSrecFirmware *self, guint32 addr_min);
+void
+fu_srec_firmware_set_addr_max(FuSrecFirmware *self, guint32 addr_max);
 GPtrArray *
 fu_srec_firmware_get_records(FuSrecFirmware *self);
 GType

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -231,9 +231,10 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 
 		/* parse SREC file and add as image */
 		blob = g_bytes_new(helper->image_buffer->str, helper->image_buffer->len);
+		fu_srec_firmware_set_addr_min(FU_SREC_FIRMWARE(firmware_srec), hdr->addr);
 		if (!fu_firmware_parse_full(firmware_srec,
 					    blob,
-					    hdr->addr,
+					    0x0,
 					    helper->flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
 					    error))
 			return FALSE;


### PR DESCRIPTION
This regressed in https://github.com/fwupd/fwupd/commit/5ad1462de2d7d2b93376c9f55fe061b5b01d0f0b.

Fixes https://github.com/fwupd/fwupd/issues/5971

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
