### PR TITLE
trivial: Fix self test failure on s390x

### DIFF
--- a/libfwupdplugin/fu-efi-file-path-device-path.c
+++ b/libfwupdplugin/fu-efi-file-path-device-path.c
@@ -49,7 +49,7 @@ fu_efi_file_path_device_path_get_name(FuEfiFilePathDevicePath *self, GError **er
 	blob = fu_firmware_get_bytes(FU_FIRMWARE(self), error);
 	if (blob == NULL)
 		return NULL;
-	name = fu_utf16_to_utf8_bytes(blob, error);
+	name = fu_utf16_to_utf8_bytes(blob, G_LITTLE_ENDIAN, error);
 	if (name == NULL)
 		return NULL;
 	g_strdelimit(name, "\\", '/');
@@ -81,7 +81,10 @@ fu_efi_file_path_device_path_set_name(FuEfiFilePathDevicePath *self,
 		g_autofree gchar *name_bs = g_strdup(name);
 		g_autoptr(GByteArray) buf = NULL;
 		g_strdelimit(name_bs, "/", '\\');
-		buf = fu_utf8_to_utf16_byte_array(name_bs, FU_UTF_CONVERT_FLAG_APPEND_NUL, error);
+		buf = fu_utf8_to_utf16_byte_array(name_bs,
+						  G_LITTLE_ENDIAN,
+						  FU_UTF_CONVERT_FLAG_APPEND_NUL,
+						  error);
 		if (buf == NULL)
 			return FALSE;
 		blob = g_bytes_new(buf->data, buf->len);

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -90,7 +90,10 @@ fu_efi_load_option_set_optional_path(FuEfiLoadOption *self,
 	/* is required if a path */
 	if (!g_str_has_prefix(str->str, "\\"))
 		g_string_prepend(str, "\\");
-	opt_blob = fu_utf8_to_utf16_bytes(str->str, FU_UTF_CONVERT_FLAG_APPEND_NUL, error);
+	opt_blob = fu_utf8_to_utf16_bytes(str->str,
+					  G_LITTLE_ENDIAN,
+					  FU_UTF_CONVERT_FLAG_APPEND_NUL,
+					  error);
 	if (opt_blob == NULL)
 		return FALSE;
 	fu_efi_load_option_set_optional_data(self, opt_blob);
@@ -138,7 +141,7 @@ fu_efi_load_option_parse(FuFirmware *firmware,
 			break;
 		fu_byte_array_append_uint16(buf_utf16, tmp, G_LITTLE_ENDIAN);
 	}
-	id = fu_utf16_to_utf8_byte_array(buf_utf16, error);
+	id = fu_utf16_to_utf8_byte_array(buf_utf16, G_LITTLE_ENDIAN, error);
 	if (id == NULL)
 		return FALSE;
 	fu_firmware_set_id(firmware, id);
@@ -183,6 +186,7 @@ fu_efi_load_option_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	}
 	buf_utf16 = fu_utf8_to_utf16_byte_array(fu_firmware_get_id(firmware),
+						G_LITTLE_ENDIAN,
 						FU_UTF_CONVERT_FLAG_APPEND_NUL,
 						error);
 	if (buf_utf16 == NULL)

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -355,7 +355,10 @@ fu_string_utf16_func(void)
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GError) error = NULL;
 
-	buf = fu_utf8_to_utf16_byte_array("hello world", FU_UTF_CONVERT_FLAG_APPEND_NUL, &error);
+	buf = fu_utf8_to_utf16_byte_array("hello world",
+					  G_LITTLE_ENDIAN,
+					  FU_UTF_CONVERT_FLAG_APPEND_NUL,
+					  &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(buf);
 	g_assert_cmpint(buf->len, ==, 24);
@@ -363,13 +366,13 @@ fu_string_utf16_func(void)
 	g_assert_cmpint(buf->data[1], ==, '\0');
 	g_assert_cmpint(buf->data[2], ==, 'e');
 	g_assert_cmpint(buf->data[3], ==, '\0');
-	str1 = fu_utf16_to_utf8_byte_array(buf, &error);
+	str1 = fu_utf16_to_utf8_byte_array(buf, G_LITTLE_ENDIAN, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(str1, ==, "hello world");
 
 	/* failure */
 	g_byte_array_set_size(buf, buf->len - 1);
-	str2 = fu_utf16_to_utf8_byte_array(buf, &error);
+	str2 = fu_utf16_to_utf8_byte_array(buf, G_LITTLE_ENDIAN, &error);
 	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
 	g_assert_cmpstr(str2, ==, NULL);
 }

--- a/libfwupdplugin/fu-string.h
+++ b/libfwupdplugin/fu-string.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <gio/gio.h>
+#include "fu-common.h"
 
 void
 fu_string_append(GString *str, guint idt, const gchar *key, const gchar *value);
@@ -68,10 +68,16 @@ typedef enum {
 } FuUtfConvertFlags;
 
 gchar *
-fu_utf16_to_utf8_byte_array(GByteArray *array, GError **error);
+fu_utf16_to_utf8_byte_array(GByteArray *array, FuEndianType endian, GError **error);
 GByteArray *
-fu_utf8_to_utf16_byte_array(const gchar *str, FuUtfConvertFlags flags, GError **error);
+fu_utf8_to_utf16_byte_array(const gchar *str,
+			    FuEndianType endian,
+			    FuUtfConvertFlags flags,
+			    GError **error);
 gchar *
-fu_utf16_to_utf8_bytes(GBytes *bytes, GError **error);
+fu_utf16_to_utf8_bytes(GBytes *bytes, FuEndianType endian, GError **error);
 GBytes *
-fu_utf8_to_utf16_bytes(const gchar *str, FuUtfConvertFlags flags, GError **error);
+fu_utf8_to_utf16_bytes(const gchar *str,
+		       FuEndianType endian,
+		       FuUtfConvertFlags flags,
+		       GError **error);

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -90,7 +90,7 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 		ubuf = fu_bytes_new_offset(fw, 28, ubufsz, error);
 		if (ubuf == NULL)
 			return FALSE;
-		self->device_path = fu_utf16_to_utf8_bytes(ubuf, error);
+		self->device_path = fu_utf16_to_utf8_bytes(ubuf, G_LITTLE_ENDIAN, error);
 		if (self->device_path == NULL)
 			return FALSE;
 	}
@@ -107,8 +107,10 @@ fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 
 	/* convert device path ahead of time */
 	if (self->device_path != NULL) {
-		g_autoptr(GByteArray) buf =
-		    fu_utf8_to_utf16_byte_array(self->device_path, FU_UTF_CONVERT_FLAG_NONE, error);
+		g_autoptr(GByteArray) buf = fu_utf8_to_utf16_byte_array(self->device_path,
+									G_LITTLE_ENDIAN,
+									FU_UTF_CONVERT_FLAG_NONE,
+									error);
 		if (buf == NULL)
 			return NULL;
 		g_byte_array_append(st, buf->data, buf->len);

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -81,7 +81,7 @@ fu_uefi_capsule_plugin_fwupd_efi_parse(FuUefiCapsulePlugin *self, GError **error
 		return FALSE;
 
 	/* convert to UTF-8 */
-	version = fu_utf16_to_utf8_bytes(ubuf, error);
+	version = fu_utf16_to_utf8_bytes(ubuf, G_LITTLE_ENDIAN, error);
 	if (version == NULL) {
 		g_prefix_error(error, "converting %s: ", fn);
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -93,7 +93,7 @@ fu_uefi_cod_device_get_variable_idx(const gchar *name, guint *value, GError **er
 	buf = fu_efivar_get_data_bytes(FU_EFIVAR_GUID_EFI_CAPSULE_REPORT, name, NULL, error);
 	if (buf == NULL)
 		return FALSE;
-	str = fu_utf16_to_utf8_bytes(buf, error);
+	str = fu_utf16_to_utf8_bytes(buf, G_LITTLE_ENDIAN, error);
 	if (str == NULL)
 		return FALSE;
 	if (!g_str_has_prefix(str, "Capsule")) {

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -577,7 +577,7 @@ fu_uefi_device_capture_efi_debugging(FuDevice *device)
 	}
 
 	/* convert from UCS-2 to UTF-8 */
-	str = fu_utf16_to_utf8_bytes(buf, &error_local);
+	str = fu_utf16_to_utf8_bytes(buf, G_LITTLE_ENDIAN, &error_local);
 	if (str == NULL) {
 		fu_device_set_update_error(device, error_local->message);
 		return;

--- a/plugins/uefi-capsule/fu-uefi-tool.c
+++ b/plugins/uefi-capsule/fu-uefi-tool.c
@@ -316,7 +316,7 @@ main(int argc, char *argv[])
 			g_printerr("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}
-		str = fu_utf16_to_utf8_bytes(buf, &error_local);
+		str = fu_utf16_to_utf8_bytes(buf, G_LITTLE_ENDIAN, &error_local);
 		if (str == NULL) {
 			g_printerr("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;


### PR DESCRIPTION
I forgot that UTF-16 is usually written in host-native endian -- which isn't what the firmware is expecting.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
