### PR TITLE
genesys-gl32xx: add GUIDs based of customer ID

### DIFF
--- a/plugins/genesys-gl32xx/README.md
+++ b/plugins/genesys-gl32xx/README.md
@@ -22,6 +22,11 @@ These devices also use custom GUID values, e.g.
 
 * `BLOCK\VEN_05E3&DEV_XXXX&VER_YY`
 
+Additional GUID values based on customer ID read from the device, e.g.
+
+* `BLOCK\VEN_05E3&DEV_XXXX&CID_ZZZZZZZZ`
+* `BLOCK\VEN_05E3&DEV_XXXX&VER_YY&CID_ZZZZZZZZ`
+
 ## Update Behavior
 
 The device is switched to ROM mode for the update and the device must be reset

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -457,6 +457,63 @@ fu_genesys_gl32xx_device_verify_chip_id(FuGenesysGl32xxDevice *self, GError **er
 }
 
 static gboolean
+fu_genesys_gl32xx_device_ensure_cid(FuGenesysGl32xxDevice *self, GError **error)
+{
+	const guint8 cmd_gl3224_cid[] = {0xE4, 0x01, 0xBF, 0x80, 0x04, 0x00};
+	const guint8 cmd_gl323x_cid[] = {0xE4, 0x01, 0x35, 0x00, 0x04, 0x00};
+	const guint8 *cmd = NULL;
+	const guint16 model = fu_udev_device_get_model(FU_UDEV_DEVICE(self));
+	guint8 data[4] = {0};
+	guint32 cid = 0;
+
+	switch (model) {
+	case 0x0749:
+		cmd = cmd_gl3224_cid;
+		break;
+	case 0x0764:
+		cmd = cmd_gl323x_cid;
+		break;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "unsupported model [0x%04X]",
+			    model);
+		return FALSE;
+	}
+
+	if (!fu_genesys_gl32xx_device_cmd_in(self,
+					     cmd,
+					     sizeof(cmd_gl323x_cid),
+					     data,
+					     sizeof(data),
+					     error))
+		return FALSE;
+
+	cid = fu_memread_uint32(data, G_BIG_ENDIAN);
+	fu_device_add_instance_u32(FU_DEVICE(self), "CID", cid);
+
+	/* additional GUIDs with customer ID suffix */
+	if (!fu_device_build_instance_id(FU_DEVICE(self),
+					 error,
+					 "BLOCK",
+					 "VEN",
+					 "DEV",
+					 "CID",
+					 NULL))
+		return FALSE;
+
+	return fu_device_build_instance_id(FU_DEVICE(self),
+					   error,
+					   "BLOCK",
+					   "VEN",
+					   "DEV",
+					   "VER",
+					   "CID",
+					   NULL);
+}
+
+static gboolean
 fu_genesys_gl32xx_device_get_usb_mode(FuGenesysGl32xxDevice *self, GError **error)
 {
 	guint8 mode = 0;
@@ -606,6 +663,9 @@ fu_genesys_gl32xx_device_setup(FuDevice *device, GError **error)
 			       self->chip_name,
 			       fu_udev_device_get_model(FU_UDEV_DEVICE(device)));
 	fu_device_set_name(device, name);
+
+	if (!fu_genesys_gl32xx_device_ensure_cid(self, error))
+		return FALSE;
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Added GUIDs with customer ID "CID" key:

```
├─GL3224 SD reader [0x0749]:
│     Device ID:          df55aa7088230719e6511a287c130e79cb203efc
│     Current version:    1539
│     Vendor:             Genesys (BLOCK:0x05E3)
│     Serial Number:      000000001539
│     GUIDs:              33bf0d51-f87e-54a0-bbfc-efb323601e31 ← BLOCK\VEN_05E3&DEV_0749
│                         94299e46-f54f-540a-a670-d075b82a477a ← BLOCK\VEN_05E3&DEV_0749&VER_15
│                         0ab7a3da-cb81-5e60-9f2d-863e6de4c0de ← BLOCK\VEN_05E3&DEV_0749&CID_FFFFFFFF
│                         388208e0-add9-5b77-b9c9-f854a2b30f3e ← BLOCK\VEN_05E3&DEV_0749&VER_15&CID_FFFFFFFF
│     Device Flags:       • Updatable
│                         • Cryptographic hash verification is available
│                         • Unsigned Payload
│   
└─GL323x SD reader [0x0764]:
      Device ID:          a4a75bcfbcc3a928b1dfd786d258ab0b7ac8ef08
      Current version:    2960
      Vendor:             Genesys (BLOCK:0x05E3)
      Serial Number:      000000002960
      GUIDs:              9125a0e3-fc06-5648-8044-021842ff3eed ← BLOCK\VEN_05E3&DEV_0764
                          ce88d98c-d36c-5b55-bac4-f07af9e0c022 ← BLOCK\VEN_05E3&DEV_0764&VER_29
                          5ea97736-fd84-547a-8f94-3282bff97819 ← BLOCK\VEN_05E3&DEV_0764&CID_22FFFFFF
                          525be421-10e1-5211-a1f0-1723c14340da ← BLOCK\VEN_05E3&DEV_0764&VER_29&CID_22FFFFFF
      Device Flags:       • Updatable
                          • Cryptographic hash verification is available
                          • Unsigned Payload
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation
