### PR TITLE
trivial: Convert 0b literals to 0x to fix a warning in gi-docgen

### DIFF
--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -112,6 +112,8 @@ class EnumItem:
     def parse_default(self, val: str) -> None:
         if val.startswith("0x") or val.startswith("0b"):
             val = val.replace("_", "")
+        if val.startswith("0b"):
+            val = hex(int(val[2:], 2))
         self.default = val
 
     @property


### PR DESCRIPTION
Fixes warnings like:

    unexpected identifier in '    FU_HID_ITEM_TAG_UNKNOWN = 0b0,' at 'b0'

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
