### PR TITLE
Allow configuring the refresh interval per-remote

### DIFF
--- a/docs/fwupd-remotes.d.md
+++ b/docs/fwupd-remotes.d.md
@@ -119,6 +119,11 @@ The `[fwupd Remote]` section can contain the following parameters:
   The password (although, in practice this will be a user *token*) to use for BASIC authentication
   when downloading both metadata and firmware from this remote, and for uploading success reports.
 
+**RefreshInterval={{FWUPD_REMOTE_CONFIG_DEFAULT_REFRESH_INTERVAL}}**
+
+  The time in seconds after which the front end tools should re-download the metadata signature,
+  or `0` to re-download every time.
+
 NOTES
 -----
 

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -40,6 +40,7 @@ if build_standalone and get_option('man')
       '--replace', 'PACKAGE_VERSION', fwupd_version,
       '--replace', 'SYSCONFDIR', sysconfdir,
       '--replace', 'LOCALSTATEDIR', localstatedir,
+      '--defines', join_paths(meson.project_source_root(), 'libfwupd', 'fwupd-remote.c'),
     ],
     install: true,
     install_dir: join_paths(mandir, 'man5'),

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -90,6 +90,10 @@ gboolean
 fwupd_remote_get_automatic_reports(FwupdRemote *self);
 gboolean
 fwupd_remote_get_automatic_security_reports(FwupdRemote *self);
+guint64
+fwupd_remote_get_refresh_interval(FwupdRemote *self);
+gboolean
+fwupd_remote_needs_refresh(FwupdRemote *self);
 gint
 fwupd_remote_get_priority(FwupdRemote *self);
 guint64

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -358,7 +358,8 @@ fwupd_remote_auth_func(void)
 	    "  \"AutomaticReports\" : \"false\",\n"
 	    "  \"AutomaticSecurityReports\" : \"true\",\n"
 	    "  \"Priority\" : 999,\n"
-	    "  \"Mtime\" : 0\n"
+	    "  \"Mtime\" : 0,\n"
+	    "  \"RefreshInterval\" : 86400\n"
 	    "}",
 	    &error);
 	g_assert_no_error(error);
@@ -487,7 +488,8 @@ fwupd_remote_local_func(void)
 	    "  \"AutomaticReports\" : \"false\",\n"
 	    "  \"AutomaticSecurityReports\" : \"false\",\n"
 	    "  \"Priority\" : 0,\n"
-	    "  \"Mtime\" : 0\n"
+	    "  \"Mtime\" : 0,\n"
+	    "  \"RefreshInterval\" : 0\n"
 	    "}",
 	    &error);
 	g_assert_no_error(error);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -960,3 +960,10 @@ LIBFWUPD_1.9.3 {
     fwupd_security_attr_set_result_success;
   local: *;
 } LIBFWUPD_1.9.1;
+
+LIBFWUPD_1.9.4 {
+  global:
+    fwupd_remote_get_refresh_interval;
+    fwupd_remote_needs_refresh;
+  local: *;
+} LIBFWUPD_1.9.3;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2101,28 +2101,15 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 	/* optional parameters */
 	if (kind == FWUPD_REMOTE_KIND_DOWNLOAD && fwupd_remote_get_age(remote) > 0 &&
 	    fwupd_remote_get_age(remote) != G_MAXUINT64) {
-		const gchar *unit = "s";
-		gdouble age = fwupd_remote_get_age(remote);
-		g_autofree gchar *age_str = NULL;
-		if (age > 60) {
-			age /= 60.f;
-			unit = "m";
-		}
-		if (age > 60) {
-			age /= 60.f;
-			unit = "h";
-		}
-		if (age > 24) {
-			age /= 24.f;
-			unit = "d";
-		}
-		if (age > 7) {
-			age /= 7.f;
-			unit = "w";
-		}
-		age_str = g_strdup_printf("%.2f%s", age, unit);
+		g_autofree gchar *age_str = fu_util_time_to_str(fwupd_remote_get_age(remote));
 		/* TRANSLATORS: the age of the metadata */
 		fu_string_append(str, idt + 1, _("Age"), age_str);
+	}
+	if (kind == FWUPD_REMOTE_KIND_DOWNLOAD && fwupd_remote_get_refresh_interval(remote) > 0) {
+		g_autofree gchar *age_str =
+		    fu_util_time_to_str(fwupd_remote_get_refresh_interval(remote));
+		/* TRANSLATORS: how often we should refresh the metadata */
+		fu_string_append(str, idt + 1, _("Refresh Interval"), age_str);
 	}
 	priority = fwupd_remote_get_priority(remote);
 	if (priority != 0) {


### PR DESCRIPTION
Using 24h is suitable for the LVFS that changes ~4 times per day, but other remotes may want a much smaller or much larger interval.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
