### PR TITLE
uefi-capsule: Do not assume the logical block size is always 0x200

### DIFF
--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -42,6 +42,8 @@ gboolean
 fu_volume_is_encrypted(FuVolume *self);
 guint64
 fu_volume_get_size(FuVolume *self);
+gsize
+fu_volume_get_block_size(FuVolume *self, GError **error);
 gchar *
 fu_volume_get_partition_kind(FuVolume *self);
 guint64

--- a/meson.build
+++ b/meson.build
@@ -395,6 +395,9 @@ endif
 if cc.has_function('pwrite', args: '-D_XOPEN_SOURCE')
   conf.set('HAVE_PWRITE', '1')
 endif
+if cc.has_header_symbol('sys/mount.h', 'BLKSSZGET')
+  conf.set('HAVE_BLKSSZGET', '1')
+endif
 
 if host_machine.system() == 'freebsd'
   if cc.has_type('struct efi_esrt_entry_v1', prefix: '#include <sys/types.h>\n#include <sys/efiio.h>')


### PR DESCRIPTION
Unfortunately, UDisks does not provide us this in a nice-to-read D-Bus property, so do things the old way with a ioctl. This makes it Linux/BSD specific so also fallback to 0x200 as before.

Fixes https://github.com/fwupd/fwupd/issues/6023

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
