### PR TITLE
trivial: debian: avoid shipping an empty systemd dir

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -78,6 +78,8 @@ override_dh_install:
 
 	#enable fwupd-refresh.service by default (we have a dedicated user)
 	rm -f debian/fwupd/lib/systemd/system-preset/fwupd-refresh.preset
+	# avoid shipping an empty directory
+	find debian/fwupd/lib/systemd -type d -empty -delete
 
 override_dh_strip_nondeterminism:
 	dh_strip_nondeterminism -Xfirmware-example.xml.gz


### PR DESCRIPTION
Thanks to Helmut Grohne <helmut@subdivi.de> for this patch
Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1041752

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
