### PR TITLE
Add support for Passim

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,8 @@ Important things to note:
       ODM -. "fw.cab" .-> LVFS
       IBV(BIOS Vendor) -- "fw.bin" --> ODM
       ISV(Silicon Vendor) -- "fw.bin" --> ODM
+      User -. "md.xml 🔒" .-> User2(Other LAN Users)
+      User -. "fw.cab 🔒" .-> User2
       LVFS -- "FwHunt|Yara" --> SecAlert(Security Researchers)
 ```
 
@@ -107,8 +109,12 @@ Important things to note:
       subgraph User
         fwupdmgr((fwupdmgr\ngnome-software))
       end
+      subgraph Local Network User
+        fwupdmgr2((fwupdmgr\ngnome-software))
+      end
       subgraph Privileged
         fwupd((fwupd\ndaemon))
+        passim((passimd))
         fwupdengine(FuEngine)
         fwupdtool(fwupdtool\ndebug\ntool)
         fwupd-efi(fwupd capsule loader)
@@ -161,6 +167,8 @@ Important things to note:
       fwupdmgr -. "report.json" .-> LVFS
       fwupdmgr -. "report.json 🔒" .-> LVFS
       State <-- "fw.cab 🔒" --> fwupd
+      passim -. "md.md|fw.cab 🔒\nmDNS with TLS" .-> fwupdmgr2
+      fwupd -. "md.md|fw.cab 🔒🚏" .-> passim
       User ~~~~ Privileged
       Internet ~~~~~ User
       Vendor ~~~~~ Internet

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -945,6 +945,23 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <!-- for passim -->
+  <dependency id="libsoup3.0-dev">
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="fedora">
+      <package variant="x86_64">libsoup3-devel</package>
+      <package variant="aarch64">libsoup3-devel</package>
+    </distro>
+    <distro id="arch">
+      <package variant="x86_64">libsoup3</package>
+    </distro>
+    <distro id="void">
+      <package variant="x86_64">libsoup3-devel</package>
+    </distro>
+  </dependency>
   <dependency id="libtool-bin">
     <distro id="debian">
       <control />

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -60,6 +60,10 @@ if [ -n "$CI" ]; then
 	sed -i "s,enable_ci 0,enable_ci 1,;" build/fwupd.spec
 fi
 
+# until we've done a package review
+dnf install -y dnf-plugins-core
+dnf copr enable rhughes/fwupd fedora-38-x86_64 -y && dnf install -y passim-devel passim
+
 #build RPM packages
 rpmbuild -ba "${QUBES_MACRO[@]}" build/fwupd.spec
 

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -75,6 +75,7 @@ BuildRequires: systemd >= %{systemd_version}
 BuildRequires: systemd-devel
 BuildRequires: libarchive-devel
 BuildRequires: libcbor-devel
+BuildRequires: passim-devel
 BuildRequires: gobject-introspection-devel
 BuildRequires: gcab
 %ifarch %{valgrind_arches}
@@ -142,6 +143,7 @@ Provides: fwupdate-efi
 Recommends: udisks2
 Recommends: bluez
 Recommends: jq
+Recommends: passim
 
 %if 0%{?have_modem_manager}
 Recommends: %{name}-plugin-modem-manager

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -187,6 +187,22 @@ The `[fwupd]` section can contain the following parameters:
 
 * `DistroId=$ID,DistroVersion=$VERSION_ID`
 
+**P2pPolicy={{FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY}}**
+
+  This tells the daemon what peer-to-peer policy to use. For instance, using Passim, an optional
+  local caching service. Using peer-to-peer data might reduce the amount of bandwidth used on your
+  network considerably.
+
+  There are three possible values:
+
+* `none`: Do not publish any files
+
+* `metadata`: Only publish shared metadata that is common to each machine.
+
+* `firmware`: Only publish firmware archives **after the next reboot** of the machine.
+
+  At some point in the future fwupd will change the default to `metadata,firmware`.
+
 {% if plugin_uefi_capsule %}
 UEFI_CAPSULE PARAMETERS
 -----------------------

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -102,6 +102,10 @@ fwupd_remote_flag_to_string(FwupdRemoteFlags flag)
 		return "automatic-reports";
 	if (flag == FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS)
 		return "automatic-security-reports";
+	if (flag == FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA)
+		return "allow-p2p-metadata";
+	if (flag == FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE)
+		return "allow-p2p-firmware";
 	return NULL;
 }
 
@@ -126,6 +130,10 @@ fwupd_remote_flag_from_string(const gchar *flag)
 		return FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS;
 	if (g_strcmp0(flag, "automatic-security-reports") == 0)
 		return FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS;
+	if (g_strcmp0(flag, "allow-p2p-metadata") == 0)
+		return FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA;
+	if (g_strcmp0(flag, "allow-p2p-firmware") == 0)
+		return FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE;
 	return FWUPD_REMOTE_FLAG_NONE;
 }
 

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -52,6 +52,8 @@ typedef enum {
  * @FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED:		Requires approval for each firmware
  * @FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS:		Send firmware reports automatically
  * @FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS:	Send security reports automatically
+ * @FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA:		Use peer-to-peer locations for metadata
+ * @FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE:		Use peer-to-peer locations for firmware
  *
  * The flags available for the remote.
  **/
@@ -61,6 +63,8 @@ typedef enum {
 	FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED = 1 << 1,	       /* Since: 1.9.4 */
 	FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS = 1 << 2,	       /* Since: 1.9.4 */
 	FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS = 1 << 3, /* Since: 1.9.4 */
+	FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA = 1 << 4,	       /* Since: 1.9.5 */
+	FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE = 1 << 5,	       /* Since: 1.9.5 */
 } FwupdRemoteFlags;
 
 FwupdRemoteKind

--- a/meson.build
+++ b/meson.build
@@ -222,6 +222,10 @@ sqlite = dependency('sqlite3', required: get_option('sqlite'))
 if sqlite.found()
   conf.set('HAVE_SQLITE', '1')
 endif
+passim = dependency('passim', required: get_option('passim'), fallback: ['passim', 'passim_dep'])
+if passim.found()
+  conf.set('HAVE_PASSIM', '1')
+endif
 libarchive = dependency('libarchive', required: get_option('libarchive'))
 if libarchive.found()
   conf.set('HAVE_LIBARCHIVE', '1')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,6 +13,7 @@ option('bluez', type : 'feature', description : 'BlueZ support', deprecated: {'t
 option('polkit', type: 'feature', description : 'PolKit support in daemon', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('gnutls', type: 'feature', description : 'GnuTLS support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('sqlite', type: 'feature', description : 'sqlite support', deprecated: {'true': 'enabled', 'false': 'disabled'})
+option('passim', type: 'feature', description : 'Passim support')
 option('lzma', type: 'feature', description : 'LZMA support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('cbor', type: 'feature', description : 'CBOR support for coSWID and uSWID')
 option('plugin_acpi_phat', type : 'feature', description : 'ACPI PHAT support', deprecated: {'true': 'enabled', 'false': 'disabled'})

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -43,6 +43,7 @@ G_DEFINE_TYPE(FuEngineConfig, fu_engine_config, FU_TYPE_CONFIG)
 #define FU_DAEMON_CONFIG_DEFAULT_TRUSTED_REPORTS       "VendorId=$OEM"
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_DEDUPE	       TRUE
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_PRIORITY      "local"
+#define FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY	       "metadata"
 
 static FwupdReport *
 fu_engine_config_report_from_spec(FuEngineConfig *self, const gchar *report_spec, GError **error)
@@ -355,6 +356,20 @@ fu_engine_config_get_release_priority(FuEngineConfig *self)
 						    "ReleasePriority",
 						    FU_DAEMON_CONFIG_DEFAULT_RELEASE_PRIORITY);
 	return fu_release_priority_from_string(tmp);
+}
+
+FuP2pPolicy
+fu_engine_config_get_p2p_policy(FuEngineConfig *self)
+{
+	FuP2pPolicy p2p_policy = FU_P2P_POLICY_NOTHING;
+	g_autofree gchar *tmp = fu_config_get_value(FU_CONFIG(self),
+						    "fwupd",
+						    "P2pPolicy",
+						    FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY);
+	g_auto(GStrv) split = g_strsplit(tmp, ",", -1);
+	for (guint i = 0; split[i] != NULL; i++)
+		p2p_policy |= fu_p2p_policy_from_string(split[i]);
+	return p2p_policy;
 }
 
 gboolean

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -49,6 +49,8 @@ gboolean
 fu_engine_config_get_release_dedupe(FuEngineConfig *self);
 FuReleasePriority
 fu_engine_config_get_release_priority(FuEngineConfig *self);
+FuP2pPolicy
+fu_engine_config_get_p2p_policy(FuEngineConfig *self);
 const gchar *
 fu_engine_config_get_host_bkc(FuEngineConfig *self);
 const gchar *

--- a/src/fu-engine.rs
+++ b/src/fu-engine.rs
@@ -7,3 +7,10 @@ enum ReleasePriority {
     Local,
     Remote,
 }
+
+#[derive(FromString)]
+enum P2pPolicy {
+    Nothing = 0x00,
+    Metadata = 0x01,
+    Firmware = 0x02,
+}

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -18,6 +18,7 @@ FuRelease *
 fu_release_new(void);
 
 #define fu_release_get_appstream_id(r) fwupd_release_get_appstream_id(FWUPD_RELEASE(r))
+#define fu_release_get_filename(r)     fwupd_release_get_filename(FWUPD_RELEASE(r))
 #define fu_release_get_version(r)     fwupd_release_get_version(FWUPD_RELEASE(r))
 #define fu_release_get_branch(r)      fwupd_release_get_branch(FWUPD_RELEASE(r))
 #define fu_release_get_remote_id(r)    fwupd_release_get_remote_id(FWUPD_RELEASE(r))

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2102,6 +2102,22 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 			 _("Enabled"),
 			 fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED) ? "true"
 										  : "false");
+	if (fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_DOWNLOAD) {
+		fu_string_append(str,
+				 idt + 1,
+				 /* TRANSLATORS: if we can get metadata from peer-to-peer clients */
+				 _("P2P Metadata"),
+				 fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA)
+				     ? "true"
+				     : "false");
+		fu_string_append(str,
+				 idt + 1,
+				 /* TRANSLATORS: if we can get metadata from peer-to-peer clients */
+				 _("P2P Firmware"),
+				 fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE)
+				     ? "true"
+				     : "false");
+	}
 
 	tmp = fwupd_remote_get_checksum(remote);
 	if (tmp != NULL) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,10 @@ engine_dep = [
   cbor,
 ]
 
+if get_option('passim').allowed()
+  engine_dep += passim
+endif
+
 client_dep = [
   gudev,
   gusb,

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -5,3 +5,4 @@ flashrom
 libjcat
 libxmlb
 fwupd-efi
+passim

--- a/subprojects/passim.wrap
+++ b/subprojects/passim.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+directory = passim
+url = https://github.com/hughsie/passim.git
+revision = 0.1.0


### PR DESCRIPTION
Using the Passim project allows fwupd to download metadata from other machines on your local network using the SHA-256 hash.

Using Passim should reduce the bandwidth needed by fwupd from offices and homes considerably.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
