### PR TITLE
Update BIOS setting through notifying fu-engine

### DIFF
--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -27,6 +27,7 @@ typedef struct {
 	gchar *description;
 	gchar *path;
 	gchar *current_value;
+	gchar *unsettled_value;
 	guint64 lower_bound;
 	guint64 upper_bound;
 	guint64 scalar_increment;
@@ -584,6 +585,52 @@ fwupd_bios_setting_set_current_value(FwupdBiosSetting *self, const gchar *value)
 
 	g_free(priv->current_value);
 	priv->current_value = g_strdup(value);
+}
+
+/**
+ * fwupd_bios_setting_get_unsettled_value:
+ * @self: a #FwupdBiosSetting
+ *
+ * Get a unsettled BIOS unsettled value from the cache. This value is not
+ * applied to the BIOS.
+ *
+ * Returns: the unsettled value of the attribute.
+ *
+ * Since: 1.9.4
+ **/
+const gchar *
+fwupd_bios_setting_get_unsettled_value(FwupdBiosSetting *self)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_BIOS_SETTING(self), NULL);
+	return priv->unsettled_value;
+}
+
+/**
+ * fwupd_bios_setting_set_unsettled_value:
+ * @self: a #FwupdBiosSetting
+ * @value: (nullable): The BIOS setting value to set
+ *
+ * Sets the BIOS setting value stored in an attribute. The value is cached and
+ * will be applied when the BIOS setting is triggered.
+ *
+ * Since: 1.9.4
+ **/
+void
+fwupd_bios_setting_set_unsettled_value(FwupdBiosSetting *self, const gchar *value)
+{
+	FwupdBiosSettingPrivate *priv = GET_PRIVATE(self);
+
+	/* not changed */
+	if (g_strcmp0(priv->unsettled_value, value) == 0)
+		return;
+
+	g_free(priv->unsettled_value);
+
+	if (value == NULL)
+		priv->unsettled_value = NULL;
+	else
+		priv->unsettled_value = g_strdup(value);
 }
 
 static gboolean

--- a/libfwupd/fwupd-bios-setting.h
+++ b/libfwupd/fwupd-bios-setting.h
@@ -93,6 +93,10 @@ fwupd_bios_setting_get_path(FwupdBiosSetting *self);
 const gchar *
 fwupd_bios_setting_get_description(FwupdBiosSetting *self);
 const gchar *
+fwupd_bios_setting_get_unsettled_value(FwupdBiosSetting *self);
+void
+fwupd_bios_setting_set_unsettled_value(FwupdBiosSetting *self, const gchar *value);
+const gchar *
 fwupd_bios_setting_map_possible_value(FwupdBiosSetting *self, const gchar *key, GError **error);
 gboolean
 fwupd_bios_setting_has_possible_value(FwupdBiosSetting *self, const gchar *val);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -963,6 +963,8 @@ LIBFWUPD_1.9.3 {
 
 LIBFWUPD_1.9.4 {
   global:
+    fwupd_bios_setting_get_unsettled_value;
+    fwupd_bios_setting_set_unsettled_value;
     fwupd_client_refresh_remote2;
     fwupd_client_refresh_remote2_async;
     fwupd_remote_add_flag;

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -556,6 +556,33 @@ fu_bios_settings_get_all(FuBiosSettings *self)
 }
 
 /**
+ * fu_bios_settings_get_unsettled_values:
+ * @self: a #FuBiosSettings
+ *
+ * ets all BIOS unsettled values.
+ *
+ * Returns: (transfer container) (element-type FwupdBiosSetting): attributes
+ *
+ * Since: 1.9.4
+ **/
+GPtrArray *
+fu_bios_settings_get_unsettled_values(FuBiosSettings *self)
+{
+	GPtrArray *result = NULL;
+	g_return_val_if_fail(FU_IS_BIOS_SETTINGS(self), NULL);
+
+	result = g_ptr_array_new();
+
+	for (guint i = 0; i < self->attrs->len; i++) {
+		FwupdBiosSetting *attr = g_ptr_array_index(self->attrs, i);
+		if (fwupd_bios_setting_get_unsettled_value(attr))
+			g_ptr_array_add(result, g_object_ref(attr));
+	}
+
+	return g_ptr_array_ref(self->attrs);
+}
+
+/**
  * fu_bios_settings_get_pending_reboot:
  * @self: a #FuBiosSettings
  * @result: (out): Whether a reboot is pending

--- a/libfwupdplugin/fu-bios-settings.h
+++ b/libfwupdplugin/fu-bios-settings.h
@@ -16,5 +16,7 @@ FuBiosSettings *
 fu_bios_settings_new(void);
 gboolean
 fu_bios_settings_get_pending_reboot(FuBiosSettings *self, gboolean *result, GError **error);
+GPtrArray *
+fu_bios_settings_get_unsettled_values(FuBiosSettings *self);
 FwupdBiosSetting *
 fu_bios_settings_get_attr(FuBiosSettings *self, const gchar *val);

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1557,6 +1557,22 @@ fu_context_class_init(FuContextClass *klass)
 	g_object_class_install_property(object_class, PROP_FLAGS, pspec);
 
 	/**
+	 * FuContext:bios-set:
+	 *
+	 * The property for signaling bios updating.
+	 *
+	 * Since: 1.9.4
+	 */
+	pspec = g_param_spec_uint64("bios-set",
+				    NULL,
+				    NULL,
+				    FU_CONTEXT_FLAG_NONE,
+				    G_MAXUINT64,
+				    FU_CONTEXT_FLAG_NONE,
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_FLAGS, pspec);
+
+	/**
 	 * FuContext::security-changed:
 	 * @self: the #FuContext instance that emitted the signal
 	 *

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -77,6 +77,11 @@ fu_context_remove_flag(FuContext *context, FuContextFlags flag);
 gboolean
 fu_context_has_flag(FuContext *context, FuContextFlags flag);
 
+gboolean
+fu_context_get_bios_setting_unsettled_value(FuContext *self,
+					    const gchar *id,
+					    const gchar *value,
+					    GError **error);
 const gchar *
 fu_context_get_smbios_string(FuContext *self, guint8 structure_type, guint8 offset, GError **error);
 guint

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -465,10 +465,10 @@ fu_daemon_authorize_set_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 	}
 
 	/* authenticated */
-	if (!fu_engine_modify_bios_settings(helper->self->engine,
-					    helper->bios_settings,
-					    FALSE,
-					    &error)) {
+	if (!fu_engine_update_bios_unsettled_settings(helper->self->engine,
+						      helper->bios_settings,
+						      FALSE,
+						      &error)) {
 		g_dbus_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -250,6 +250,11 @@ fu_engine_modify_bios_settings(FuEngine *self,
 			       gboolean force_ro,
 			       GError **error);
 gboolean
+fu_engine_update_bios_unsettled_settings(FuEngine *self,
+					 GHashTable *settings,
+					 gboolean force_ro,
+					 GError **error);
+gboolean
 fu_engine_emulation_load(FuEngine *self, GBytes *data, GError **error);
 GBytes *
 fu_engine_emulation_save(FuEngine *self, GError **error);


### PR DESCRIPTION
The original way to update BIOS settings is to call an updating function which was placed in fu-engine. That increased the complexity when the other components need to update the BIOS. The fu-engine should be passed to the objects and then this object can use the services from fu-engine. That leads the code much more complicated and difficult to manage.

In this work, we would keep every low-level task in fu-engine. If any components would like to update the BIOS, it can put the pending values into the corresponding data structure and then notifies the fu-engine to process the corresponding task. The components, for example, just only update the BIOS setting pending value and then notify the engine to finish the request. It keeps the code become simpler and clean and also keeps its architecture.


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
