### PR TITLE
  Add Pixart-HPAC plugin.

### DIFF
--- a/plugins/pixart-rf/fu-pxi-common.h
+++ b/plugins/pixart-rf/fu-pxi-common.h
@@ -9,6 +9,8 @@
 
 #include <fwupdplugin.h>
 
+#define FU_PXI_DEVICE_FLAG_IS_HPAC (1 << 0)
+
 #define PXI_HID_WIRELESS_DEV_OTA_REPORT_ID 0x03
 
 #define FU_PXI_DEVICE_CMD_FW_OTA_INIT		   0x10u

--- a/plugins/pixart-rf/fu-pxi-firmware.h
+++ b/plugins/pixart-rf/fu-pxi-firmware.h
@@ -17,3 +17,6 @@ FuFirmware *
 fu_pxi_firmware_new(void);
 const gchar *
 fu_pxi_firmware_get_model_name(FuPxiFirmware *self);
+
+gboolean
+fu_pxi_firmware_is_hpac(FuPxiFirmware *self);

--- a/plugins/pixart-rf/pixart-rf.quirk
+++ b/plugins/pixart-rf/pixart-rf.quirk
@@ -187,3 +187,9 @@ GType = FuPxiBleDevice
 [HIDRAW\VEN_093A&DEV_2852]
 Plugin = pixart_rf
 GType = FuPxiBleDevice
+
+# HP 430
+[HIDRAW\VEN_03F0&DEV_114C]
+Plugin = pixart_rf
+GType = FuPxiBleDevice
+Flags = is-hpac


### PR DESCRIPTION
    - HPAC BLE devices OTA implement.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

**Checklist**
- [X]     Fill out README.md with update protocol
- [X]     Fill out README.md with any custom quirks and flags
- [X]     Fill out README.md with the vendor ID security value
- [X]     Implement FuFirmware->write() and include at least one fuzzer testcase in src/fuzzing/firmware for any custom FuFirmware subclass
- [x]     CI run of the plugin for at least one target
- [x]     Document targets CI isn't currently run and the reasons (i.e. minimum versions needed or distribution limitations etc).

Tested on "Ubuntu 20.04.5 LTS" . And It works well.
