### PR TITLE
Convert 4 binary FwupdRemote values to a bitfield

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -13,6 +13,10 @@
 * Rename `fwupd_remote_set_checksum()` to `fwupd_remote_set_checksum_sig()`
 * Remove the deprecated flag `FWUPD_CLIENT_DOWNLOAD_FLAG_ONLY_IPFS`
 * Rename `fwupd_client_refresh_remote2_async()` to `fwupd_client_refresh_remote_async()`
+* Remove the deprecated method `fwupd_remote_get_enabled()`
+* Remove the deprecated method `fwupd_remote_get_approval_required()`
+* Remove the deprecated method `fwupd_remote_get_automatic_reports()`
+* Remove the deprecated method `fwupd_remote_get_automatic_security_reports()`
 
 ## Migration from Version 0.9.x
 

--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -25,7 +25,8 @@ fwupd_remote_save_to_filename(FwupdRemote *self,
 			      GCancellable *cancellable,
 			      GError **error);
 void
-fwupd_remote_set_enabled(FwupdRemote *self, gboolean enabled);
+fwupd_remote_set_enabled(FwupdRemote *self, gboolean enabled)
+    G_DEPRECATED_FOR(fwupd_remote_add_flag);
 void
 fwupd_remote_set_id(FwupdRemote *self, const gchar *id);
 void

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -45,10 +45,32 @@ typedef enum {
 	FWUPD_REMOTE_KIND_LAST
 } FwupdRemoteKind;
 
+/**
+ * FwupdRemoteFlags:
+ * @FWUPD_REMOTE_FLAG_NONE:				No flags set
+ * @FWUPD_REMOTE_FLAG_ENABLED:				Is enabled
+ * @FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED:		Requires approval for each firmware
+ * @FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS:		Send firmware reports automatically
+ * @FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS:	Send security reports automatically
+ *
+ * The flags available for the remote.
+ **/
+typedef enum {
+	FWUPD_REMOTE_FLAG_NONE = 0,			       /* Since: 1.9.4 */
+	FWUPD_REMOTE_FLAG_ENABLED = 1 << 0,		       /* Since: 1.9.4 */
+	FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED = 1 << 1,	       /* Since: 1.9.4 */
+	FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS = 1 << 2,	       /* Since: 1.9.4 */
+	FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS = 1 << 3, /* Since: 1.9.4 */
+} FwupdRemoteFlags;
+
 FwupdRemoteKind
 fwupd_remote_kind_from_string(const gchar *kind);
 const gchar *
 fwupd_remote_kind_to_string(FwupdRemoteKind kind);
+const gchar *
+fwupd_remote_flag_to_string(FwupdRemoteFlags flag);
+FwupdRemoteFlags
+fwupd_remote_flag_from_string(const gchar *flag);
 
 FwupdRemote *
 fwupd_remote_new(void);
@@ -85,15 +107,28 @@ fwupd_remote_get_metadata_uri(FwupdRemote *self);
 const gchar *
 fwupd_remote_get_metadata_uri_sig(FwupdRemote *self);
 gboolean
-fwupd_remote_get_enabled(FwupdRemote *self);
+fwupd_remote_get_enabled(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
 gboolean
-fwupd_remote_get_approval_required(FwupdRemote *self);
+fwupd_remote_get_approval_required(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
 gboolean
-fwupd_remote_get_automatic_reports(FwupdRemote *self);
+fwupd_remote_get_automatic_reports(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
 gboolean
-fwupd_remote_get_automatic_security_reports(FwupdRemote *self);
+fwupd_remote_get_automatic_security_reports(FwupdRemote *self)
+    G_DEPRECATED_FOR(fwupd_remote_has_flag);
 guint64
 fwupd_remote_get_refresh_interval(FwupdRemote *self);
+
+FwupdRemoteFlags
+fwupd_remote_get_flags(FwupdRemote *self);
+void
+fwupd_remote_set_flags(FwupdRemote *self, FwupdRemoteFlags flags);
+void
+fwupd_remote_add_flag(FwupdRemote *self, FwupdRemoteFlags flag);
+void
+fwupd_remote_remove_flag(FwupdRemote *self, FwupdRemoteFlags flag);
+gboolean
+fwupd_remote_has_flag(FwupdRemote *self, FwupdRemoteFlags flag);
+
 gboolean
 fwupd_remote_needs_refresh(FwupdRemote *self);
 gint

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -185,7 +185,7 @@ fwupd_remote_download_func(void)
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert_false(fwupd_remote_get_enabled(remote));
+	g_assert_false(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
 	g_assert_nonnull(fwupd_remote_get_metadata_uri(remote));
 	g_assert_nonnull(fwupd_remote_get_metadata_uri_sig(remote));
 	g_assert_cmpstr(fwupd_remote_get_title(remote),
@@ -219,7 +219,7 @@ fwupd_remote_baseuri_func(void)
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert_true(fwupd_remote_get_enabled(remote));
+	g_assert_true(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
 	g_assert_cmpstr(fwupd_remote_get_firmware_base_uri(remote), ==, "https://my.fancy.cdn/");
 	g_assert_cmpstr(fwupd_remote_get_agreement(remote), ==, NULL);
 	g_assert_cmpstr(fwupd_remote_get_checksum(remote), ==, NULL);
@@ -285,9 +285,9 @@ fwupd_remote_auth_func(void)
 	g_assert_cmpstr(fwupd_remote_get_security_report_uri(remote),
 			==,
 			"https://fwupd.org/lvfs/hsireports/upload");
-	g_assert_false(fwupd_remote_get_approval_required(remote));
-	g_assert_false(fwupd_remote_get_automatic_reports(remote));
-	g_assert_true(fwupd_remote_get_automatic_security_reports(remote));
+	g_assert_false(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED));
+	g_assert_false(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS));
+	g_assert_true(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS));
 
 	g_assert_true(
 	    g_str_has_suffix(fwupd_remote_get_filename_source(remote), "tests/auth.conf"));
@@ -353,6 +353,7 @@ fwupd_remote_auth_func(void)
 	    "\"dd1b4fd2a59bb0e4d9ea760c658ac3cf9336c7b6729357bab443485b5cf071b2\",\n"
 	    "  \"FilenameCache\" : \"./libfwupd/tests/auth/metadata.xml.gz\",\n"
 	    "  \"FilenameCacheSig\" : \"./libfwupd/tests/auth/metadata.xml.gz.jcat\",\n"
+	    "  \"Flags\" : 9,\n"
 	    "  \"Enabled\" : \"true\",\n"
 	    "  \"ApprovalRequired\" : \"false\",\n"
 	    "  \"AutomaticReports\" : \"false\",\n"
@@ -389,7 +390,7 @@ fwupd_remote_duplicate_func(void)
 	ret = fwupd_remote_setup(remote, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_false(fwupd_remote_get_enabled(remote));
+	g_assert_false(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_NONE);
 	g_assert_cmpstr(fwupd_remote_get_username(remote), ==, NULL);
 	g_assert_cmpstr(fwupd_remote_get_password(remote), ==, "");
@@ -419,7 +420,7 @@ fwupd_remote_nopath_func(void)
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_JCAT);
 	g_assert_cmpint(fwupd_remote_get_priority(remote), ==, 0);
-	g_assert_true(fwupd_remote_get_enabled(remote));
+	g_assert_true(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
 	g_assert_cmpstr(fwupd_remote_get_checksum(remote), ==, NULL);
 	g_assert_cmpstr(fwupd_remote_get_metadata_uri(remote),
 			==,
@@ -452,7 +453,7 @@ fwupd_remote_local_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_LOCAL);
 	g_assert_cmpint(fwupd_remote_get_keyring_kind(remote), ==, FWUPD_KEYRING_KIND_NONE);
-	g_assert_true(fwupd_remote_get_enabled(remote));
+	g_assert_true(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
 	g_assert_null(fwupd_remote_get_metadata_uri(remote));
 	g_assert_null(fwupd_remote_get_metadata_uri_sig(remote));
 	g_assert_null(fwupd_remote_get_report_uri(remote));
@@ -483,6 +484,7 @@ fwupd_remote_local_func(void)
 	    "  \"KeyringKind\" : \"none\",\n"
 	    "  \"Title\" : \"Enable UEFI capsule updates on Dell systems\",\n"
 	    "  \"FilenameCache\" : \"@datadir@/fwupd/remotes.d/dell-esrt/metadata.xml\",\n"
+	    "  \"Flags\" : 1,\n"
 	    "  \"Enabled\" : \"true\",\n"
 	    "  \"ApprovalRequired\" : \"false\",\n"
 	    "  \"AutomaticReports\" : \"false\",\n"

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -965,8 +965,15 @@ LIBFWUPD_1.9.4 {
   global:
     fwupd_client_refresh_remote2;
     fwupd_client_refresh_remote2_async;
+    fwupd_remote_add_flag;
+    fwupd_remote_flag_from_string;
+    fwupd_remote_flag_to_string;
     fwupd_remote_get_checksum_metadata;
+    fwupd_remote_get_flags;
     fwupd_remote_get_refresh_interval;
+    fwupd_remote_has_flag;
     fwupd_remote_needs_refresh;
+    fwupd_remote_remove_flag;
+    fwupd_remote_set_flags;
   local: *;
 } LIBFWUPD_1.9.3;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3070,19 +3070,19 @@ fu_engine_save_into_backup_remote(FuEngine *self, GBytes *fw, GError **error)
 	}
 
 	/* already exists as an enabled remote */
-	if (remote_tmp != NULL && fwupd_remote_get_enabled(remote_tmp))
+	if (remote_tmp != NULL && fwupd_remote_has_flag(remote_tmp, FWUPD_REMOTE_FLAG_ENABLED))
 		return TRUE;
 
 	/* just enable */
 	if (remote_tmp != NULL) {
 		g_info("enabling remote %s", fwupd_remote_get_id(remote_tmp));
-		fwupd_remote_set_enabled(remote_tmp, TRUE);
+		fwupd_remote_add_flag(remote_tmp, FWUPD_REMOTE_FLAG_ENABLED);
 		return fwupd_remote_save_to_filename(remote_tmp, remotes_fn, NULL, error);
 	}
 
 	/* create a new remote we can use for re-installing */
 	g_info("creating new backup remote");
-	fwupd_remote_set_enabled(remote, TRUE);
+	fwupd_remote_add_flag(remote, FWUPD_REMOTE_FLAG_ENABLED);
 	fwupd_remote_set_keyring_kind(remote, FWUPD_KEYRING_KIND_NONE);
 	fwupd_remote_set_title(remote, "Backup");
 	fwupd_remote_set_metadata_uri(remote, backupdir_uri);
@@ -4603,7 +4603,7 @@ fu_engine_load_metadata_store(FuEngine *self, FuEngineLoadFlags flags, GError **
 		g_autoptr(XbBuilderSource) source = xb_builder_source_new();
 
 		FwupdRemote *remote = g_ptr_array_index(remotes, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		path = fwupd_remote_get_filename_cache(remote);
 		if (!g_file_test(path, G_FILE_TEST_EXISTS))
@@ -4892,7 +4892,7 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 			    remote_id);
 		return FALSE;
 	}
-	if (!fwupd_remote_get_enabled(remote)) {
+	if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
@@ -5782,7 +5782,8 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 		remote_id = fwupd_release_get_remote_id(FWUPD_RELEASE(release));
 		if (remote_id != NULL) {
 			FwupdRemote *remote = fu_engine_get_remote_by_id(self, remote_id, NULL);
-			if (remote != NULL && fwupd_remote_get_approval_required(remote) &&
+			if (remote != NULL &&
+			    fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED) &&
 			    !fu_engine_check_release_is_approved(self, FWUPD_RELEASE(release))) {
 				fu_release_add_flag(release, FWUPD_RELEASE_FLAG_BLOCKED_APPROVAL);
 			}

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -271,7 +271,7 @@ fu_remote_list_add_for_file(FuRemoteList *self,
 	}
 
 	/* delete the obsolete .gz files if the remote is now set up to use .xz */
-	if (fwupd_remote_get_enabled(remote) &&
+	if (fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED) &&
 	    fwupd_remote_get_kind(remote) == FWUPD_REMOTE_KIND_DOWNLOAD) {
 		if (!fu_remote_list_cleanup_remote(remote, error))
 			return FALSE;
@@ -519,7 +519,7 @@ fu_remote_list_reload(FuRemoteList *self, GError **error)
 	/* print to the console */
 	for (guint i = 0; i < self->array->len; i++) {
 		FwupdRemote *remote = g_ptr_array_index(self->array, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		if (str->len > 0)
 			g_string_append(str, ", ");

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3051,7 +3051,7 @@ fu_util_refresh(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 	for (guint i = 0; i < remotes->len; i++) {
 		FwupdRemote *remote = g_ptr_array_index(remotes, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		if (fwupd_remote_get_kind(remote) != FWUPD_REMOTE_KIND_DOWNLOAD)
 			continue;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2090,7 +2090,8 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 			 idt + 1,
 			 /* TRANSLATORS: if the remote is enabled */
 			 _("Enabled"),
-			 fwupd_remote_get_enabled(remote) ? "true" : "false");
+			 fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED) ? "true"
+										  : "false");
 
 	tmp = fwupd_remote_get_checksum(remote);
 	if (tmp != NULL) {
@@ -2167,7 +2168,9 @@ fu_util_remote_to_string(FwupdRemote *remote, guint idt)
 				 idt + 1,
 				 /* TRANSLATORS: Boolean value to automatically send reports */
 				 _("Automatic Reporting"),
-				 fwupd_remote_get_automatic_reports(remote) ? "true" : "false");
+				 fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS)
+				     ? "true"
+				     : "false");
 	}
 
 	return g_string_free(g_steal_pointer(&str), FALSE);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -277,7 +277,8 @@ fu_util_perhaps_show_unreported(FuUtilPrivate *priv, GError **error)
 		g_hash_table_insert(remote_id_uri_map,
 				    (gpointer)fwupd_remote_get_id(remote),
 				    (gpointer)fwupd_remote_get_report_uri(remote));
-		remote_automatic = fwupd_remote_get_automatic_reports(remote);
+		remote_automatic =
+		    fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS);
 		g_debug("%s is %d", fwupd_remote_get_title(remote), remote_automatic);
 		if (remote_automatic && !all_automatic)
 			all_automatic = TRUE;
@@ -429,7 +430,8 @@ fu_util_perhaps_show_unreported(FuUtilPrivate *priv, GError **error)
 				const gchar *remote_id = fwupd_remote_get_id(remote);
 				if (fwupd_remote_get_report_uri(remote) == NULL)
 					continue;
-				if (fwupd_remote_get_automatic_reports(remote))
+				if (fwupd_remote_has_flag(remote,
+							  FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS))
 					continue;
 				if (!fwupd_client_modify_remote(priv->client,
 								remote_id,
@@ -1468,7 +1470,8 @@ fu_util_report_history_for_remote(FuUtilPrivate *priv,
 	report_uri = fwupd_remote_build_report_uri(remote, error);
 	if (report_uri == NULL)
 		return FALSE;
-	if (!priv->assume_yes && !fwupd_remote_get_automatic_reports(remote)) {
+	if (!priv->assume_yes &&
+	    !fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS)) {
 		fu_console_print_kv(priv->console, _("Target"), report_uri);
 		fu_console_print_kv(priv->console, _("Payload"), data);
 		if (sig != NULL)
@@ -1867,7 +1870,7 @@ fu_util_check_oldest_remote(FuUtilPrivate *priv, guint64 *age_oldest, GError **e
 		return FALSE;
 	for (guint i = 0; i < remotes->len; i++) {
 		FwupdRemote *remote = g_ptr_array_index(remotes, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		if (fwupd_remote_get_kind(remote) != FWUPD_REMOTE_KIND_DOWNLOAD)
 			continue;
@@ -1926,7 +1929,7 @@ fu_util_download_metadata(FuUtilPrivate *priv, GError **error)
 		return FALSE;
 	for (guint i = 0; i < remotes->len; i++) {
 		FwupdRemote *remote = g_ptr_array_index(remotes, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		if (fwupd_remote_get_kind(remote) != FWUPD_REMOTE_KIND_DOWNLOAD)
 			continue;
@@ -2673,7 +2676,7 @@ fu_util_maybe_send_reports(FuUtilPrivate *priv, FwupdRelease *rel, GError **erro
 					       error);
 	if (remote == NULL)
 		return FALSE;
-	if (fwupd_remote_get_automatic_reports(remote)) {
+	if (fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_REPORTS)) {
 		if (!fu_util_report_history(priv, NULL, &error_local))
 			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED))
 				g_warning("%s", error_local->message);
@@ -3416,7 +3419,7 @@ fu_util_get_remote_with_security_report_uri(FuUtilPrivate *priv, GError **error)
 
 	for (guint i = 0; i < remotes->len; i++) {
 		FwupdRemote *remote = g_ptr_array_index(remotes, i);
-		if (!fwupd_remote_get_enabled(remote))
+		if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED))
 			continue;
 		if (fwupd_remote_get_security_report_uri(remote) != NULL)
 			return g_object_ref(remote);
@@ -3452,7 +3455,8 @@ fu_util_upload_security(FuUtilPrivate *priv, GPtrArray *attrs, GError **error)
 		g_debug("failed to find suitable remote: %s", error_local->message);
 		return TRUE;
 	}
-	if (!priv->assume_yes && !fwupd_remote_get_automatic_security_reports(remote)) {
+	if (!priv->assume_yes &&
+	    !fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS)) {
 		if (!fu_console_input_bool(priv->console,
 					   FALSE,
 					   /* TRANSLATORS: ask the user to share, %s is something
@@ -3541,7 +3545,8 @@ fu_util_upload_security(FuUtilPrivate *priv, GPtrArray *attrs, GError **error)
 	}
 
 	/* ask for permission */
-	if (!priv->assume_yes && !fwupd_remote_get_automatic_security_reports(remote)) {
+	if (!priv->assume_yes &&
+	    !fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS)) {
 		fu_console_print_kv(priv->console,
 				    _("Target"),
 				    fwupd_remote_get_security_report_uri(remote));
@@ -3573,7 +3578,7 @@ fu_util_upload_security(FuUtilPrivate *priv, GPtrArray *attrs, GError **error)
 				 _("Host Security ID attributes uploaded successfully, thanks!"));
 
 	/* as this worked, ask if the user want to do this every time */
-	if (!fwupd_remote_get_automatic_security_reports(remote)) {
+	if (!fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_AUTOMATIC_SECURITY_REPORTS)) {
 		if (fu_console_input_bool(priv->console,
 					  FALSE,
 					  "%s",


### PR DESCRIPTION
We've about to add 2 more booleans, and this should have been a bitfield like the other objects all along. The sooner we convert it the less compat code we need.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
