### PR TITLE
genesys: revert using g_prefix_error_literal()

### DIFF
--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -93,7 +93,7 @@ fu_genesys_scaler_device_enter_serial_debug_mode(FuGenesysScalerDevice *self, GE
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error entering Serial Debug Mode: ");
+		g_prefix_error(error, "error entering Serial Debug Mode: ");
 		return FALSE;
 	}
 
@@ -123,7 +123,7 @@ fu_genesys_scaler_device_exit_serial_debug_mode(FuGenesysScalerDevice *self, GEr
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error exiting Serial Debug Mode: ");
+		g_prefix_error(error, "error exiting Serial Debug Mode: ");
 		return FALSE;
 	}
 
@@ -152,7 +152,7 @@ fu_genesys_scaler_device_enter_single_step_mode(FuGenesysScalerDevice *self, GEr
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error entering Single Step Mode: ");
+		g_prefix_error(error, "error entering Single Step Mode: ");
 		return FALSE;
 	}
 
@@ -169,7 +169,7 @@ fu_genesys_scaler_device_enter_single_step_mode(FuGenesysScalerDevice *self, GEr
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error entering Single Step Mode: ");
+		g_prefix_error(error, "error entering Single Step Mode: ");
 		return FALSE;
 	}
 
@@ -197,7 +197,7 @@ fu_genesys_scaler_device_exit_single_step_mode(FuGenesysScalerDevice *self, GErr
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error exiting Single Step Mode: ");
+		g_prefix_error(error, "error exiting Single Step Mode: ");
 		return FALSE;
 	}
 
@@ -225,7 +225,7 @@ fu_genesys_scaler_device_enter_debug_mode(FuGenesysScalerDevice *self, GError **
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error entering Debug Mode: ");
+		g_prefix_error(error, "error entering Debug Mode: ");
 		return FALSE;
 	}
 
@@ -651,7 +651,7 @@ fu_genesys_scaler_device_enter_isp_mode(FuGenesysScalerDevice *self, GError **er
 				  1000 /* 1ms */,
 				  self,
 				  error)) {
-		g_prefix_error_literal(error, "error entering ISP mode: ");
+		g_prefix_error(error, "error entering ISP mode: ");
 		return FALSE;
 	}
 
@@ -679,7 +679,7 @@ fu_genesys_scaler_device_exit_isp_mode(FuGenesysScalerDevice *self, GError **err
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error exiting ISP mode: ");
+		g_prefix_error(error, "error exiting ISP mode: ");
 		return FALSE;
 	}
 
@@ -771,7 +771,7 @@ fu_genesys_scaler_device_get_level(FuGenesysScalerDevice *self, guint8 *level, G
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error getting level: ");
+		g_prefix_error(error, "error getting level: ");
 		return FALSE;
 	}
 	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
@@ -802,7 +802,7 @@ fu_genesys_scaler_device_get_version(FuGenesysScalerDevice *self,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error getting version: ");
+		g_prefix_error(error, "error getting version: ");
 		return FALSE;
 	}
 
@@ -840,7 +840,7 @@ fu_genesys_scaler_device_get_public_key(FuGenesysScalerDevice *self,
 						   GENESYS_SCALER_USB_TIMEOUT,
 						   NULL,
 						   error)) {
-			g_prefix_error_literal(error, "error getting public key: ");
+			g_prefix_error(error, "error getting public key: ");
 			return FALSE;
 		}
 
@@ -985,7 +985,7 @@ fu_genesys_scaler_device_wait_flash_control_register_cb(FuDevice *dev,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error reading flash control register: ");
+		g_prefix_error(error, "error reading flash control register: ");
 		return FALSE;
 	}
 
@@ -1030,7 +1030,7 @@ fu_genesys_scaler_device_flash_control_write_enable(FuGenesysScalerDevice *self,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error sending flash control write enable: ");
+		g_prefix_error(error, "error sending flash control write enable: ");
 		return FALSE;
 	}
 
@@ -1047,7 +1047,7 @@ fu_genesys_scaler_device_flash_control_write_enable(FuGenesysScalerDevice *self,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error sending flash control write enable: ");
+		g_prefix_error(error, "error sending flash control write enable: ");
 		return FALSE;
 	}
 
@@ -1162,8 +1162,7 @@ fu_genesys_scaler_device_flash_control_sector_erase(FuGenesysScalerDevice *self,
 				  50, /* 50ms */
 				  &helper,
 				  error)) {
-		g_prefix_error_literal(error,
-				       "error waiting for flash control read status register: ");
+		g_prefix_error(error, "error waiting for flash control read status register: ");
 		return FALSE;
 	}
 
@@ -1215,8 +1214,7 @@ fu_genesys_scaler_device_flash_control_sector_erase(FuGenesysScalerDevice *self,
 				  50, /* 50ms */
 				  &helper,
 				  error)) {
-		g_prefix_error_literal(error,
-				       "error waiting for flash control read status register: ");
+		g_prefix_error(error, "error waiting for flash control read status register: ");
 		return FALSE;
 	}
 
@@ -1348,8 +1346,7 @@ fu_genesys_scaler_device_flash_control_page_program(FuGenesysScalerDevice *self,
 			     20,
 			     &helper,
 			     error)) {
-		g_prefix_error_literal(error,
-				       "error waiting for flash control read status register: ");
+		g_prefix_error(error, "error waiting for flash control read status register: ");
 		return FALSE;
 	}
 
@@ -1456,7 +1453,7 @@ fu_genesys_scaler_device_get_ddcci_data(FuGenesysScalerDevice *self,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error setting dddci data: ");
+		g_prefix_error(error, "error setting dddci data: ");
 		return FALSE;
 	}
 
@@ -1475,7 +1472,7 @@ fu_genesys_scaler_device_get_ddcci_data(FuGenesysScalerDevice *self,
 					   GENESYS_SCALER_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error getting dddci data: ");
+		g_prefix_error(error, "error getting dddci data: ");
 		return FALSE;
 	}
 

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -60,13 +60,13 @@ fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
 
 	if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_RSA_SIZE) {
 		if (!fu_struct_genesys_fw_codesign_info_rsa_validate(buf, bufsz, offset, error)) {
-			g_prefix_error_literal(error, "not valid for codesign: ");
+			g_prefix_error(error, "not valid for codesign: ");
 			return FALSE;
 		}
 		self->codesign = FU_GENESYS_FW_CODESIGN_RSA;
 	} else if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_ECDSA_SIZE) {
 		if (!fu_struct_genesys_fw_codesign_info_ecdsa_validate(buf, bufsz, offset, error)) {
-			g_prefix_error_literal(error, "not valid for codesign: ");
+			g_prefix_error(error, "not valid for codesign: ");
 			return FALSE;
 		}
 		self->codesign = FU_GENESYS_FW_CODESIGN_ECDSA;

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -50,7 +50,7 @@ fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 
 	/* truncate to correct size */
 	if (!fu_genesys_usbhub_firmware_calculate_size(fw, offset, &code_size, error)) {
-		g_prefix_error_literal(error, "not valid for dev: ");
+		g_prefix_error(error, "not valid for dev: ");
 		return FALSE;
 	}
 	fw_trunc = fu_bytes_new_offset(fw, offset, code_size, error);
@@ -61,14 +61,14 @@ fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 	/* calculate checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_genesys_usbhub_firmware_verify_checksum(fw_trunc, error)) {
-			g_prefix_error_literal(error, "not valid for dev: ");
+			g_prefix_error(error, "not valid for dev: ");
 			return FALSE;
 		}
 	}
 
 	/* get firmware version */
 	if (!fu_genesys_usbhub_firmware_ensure_version(firmware, error)) {
-		g_prefix_error_literal(error, "not valid for dev: ");
+		g_prefix_error(error, "not valid for dev: ");
 		return FALSE;
 	}
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -348,7 +348,7 @@ fu_genesys_usbhub_device_reset(FuGenesysUsbhubDevice *self, GError **error)
 					   GENESYS_USBHUB_USB_TIMEOUT,
 					   NULL,
 					   error)) {
-		g_prefix_error_literal(error, "error resetting device: ");
+		g_prefix_error(error, "error resetting device: ");
 		return FALSE;
 	}
 
@@ -387,7 +387,7 @@ fu_genesys_usbhub_device_cfi_setup(FuGenesysUsbhubDevice *self, GError **error)
 						   GENESYS_USBHUB_USB_TIMEOUT,
 						   NULL,
 						   error)) {
-			g_prefix_error_literal(error, "error reading flash chip: ");
+			g_prefix_error(error, "error reading flash chip: ");
 			return NULL;
 		}
 
@@ -498,7 +498,7 @@ fu_genesys_usbhub_device_set_isp_mode(FuGenesysUsbhubDevice *self,
 				     5,
 				     &helper,
 				     error)) {
-			g_prefix_error_literal(error, "error setting isp mode: ");
+			g_prefix_error(error, "error setting isp mode: ");
 			return FALSE;
 		}
 	}
@@ -598,7 +598,7 @@ fu_genesys_usbhub_device_authenticate(FuGenesysUsbhubDevice *self, GError **erro
 							     offset_end,
 							     temp_byte,
 							     error)) {
-		g_prefix_error_literal(error, "error authenticating device: ");
+		g_prefix_error(error, "error authenticating device: ");
 		return FALSE;
 	}
 
@@ -759,7 +759,7 @@ fu_genesys_usbhub_device_get_fw_bank_code_size(FuGenesysUsbhubDevice *self,
 						 1,
 						 NULL,
 						 error)) {
-		g_prefix_error_literal(error, "error getting fw size from device: ");
+		g_prefix_error(error, "error getting fw size from device: ");
 		return FALSE;
 	}
 	self->fw_bank_code_sizes[bank_num][fw_type] = 1024 * kbs;
@@ -835,7 +835,7 @@ fu_genesys_usbhub_device_get_fw_bank_version(FuGenesysUsbhubDevice *self,
 				    &self->fw_bank_vers[bank_num][fw_type],
 				    G_LITTLE_ENDIAN,
 				    error)) {
-		g_prefix_error_literal(error, "failed to get version: ");
+		g_prefix_error(error, "failed to get version: ");
 		return FALSE;
 	}
 
@@ -875,7 +875,7 @@ fu_genesys_usbhub_device_get_public_key(FuGenesysUsbhubDevice *self, int bank_nu
 		bufsz,
 		NULL,
 		error)) {
-		g_prefix_error_literal(error, "error getting public-key from device: ");
+		g_prefix_error(error, "error getting public-key from device: ");
 		return FALSE;
 	}
 
@@ -926,7 +926,7 @@ fu_genesys_usbhub_device_get_info_from_static_ts(FuGenesysUsbhubDevice *self,
 
 	self->st_static_ts = fu_struct_genesys_ts_static_parse(buf, bufsz, 0, error);
 	if (self->st_static_ts == NULL) {
-		g_prefix_error_literal(error, "failed to parse static tool info: ");
+		g_prefix_error(error, "failed to parse static tool info: ");
 		return FALSE;
 	}
 
@@ -1065,7 +1065,7 @@ fu_genesys_usbhub_device_get_info_from_dynamic_ts(FuGenesysUsbhubDevice *self,
 		self->st_dynamic_ts =
 		    fu_struct_genesys_ts_dynamic_gl3523_parse(buf, bufsz, 0, error);
 		if (self->st_dynamic_ts == NULL) {
-			g_prefix_error_literal(error, "failed to parse dynamic tool info: ");
+			g_prefix_error(error, "failed to parse dynamic tool info: ");
 			return FALSE;
 		}
 
@@ -1085,8 +1085,7 @@ fu_genesys_usbhub_device_get_info_from_dynamic_ts(FuGenesysUsbhubDevice *self,
 			self->st_dynamic_ts =
 			    fu_struct_genesys_ts_dynamic_gl359030_parse(buf, bufsz, 0, error);
 			if (self->st_dynamic_ts == NULL) {
-				g_prefix_error_literal(error,
-						       "failed to parse dynamic tool info: ");
+				g_prefix_error(error, "failed to parse dynamic tool info: ");
 				return FALSE;
 			}
 
@@ -1105,8 +1104,7 @@ fu_genesys_usbhub_device_get_info_from_dynamic_ts(FuGenesysUsbhubDevice *self,
 			self->st_dynamic_ts =
 			    fu_struct_genesys_ts_dynamic_gl3590_parse(buf, bufsz, 0, error);
 			if (self->st_dynamic_ts == NULL) {
-				g_prefix_error_literal(error,
-						       "failed to parse dynamic tool info: ");
+				g_prefix_error(error, "failed to parse dynamic tool info: ");
 				return FALSE;
 			}
 
@@ -1127,7 +1125,7 @@ fu_genesys_usbhub_device_get_info_from_dynamic_ts(FuGenesysUsbhubDevice *self,
 		self->st_dynamic_ts =
 		    fu_struct_genesys_ts_dynamic_gl3525_parse(buf, bufsz, 0, error);
 		if (self->st_dynamic_ts == NULL) {
-			g_prefix_error_literal(error, "failed to parse dynamic tool info: ");
+			g_prefix_error(error, "failed to parse dynamic tool info: ");
 			return FALSE;
 		}
 
@@ -1241,7 +1239,7 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->setup(device, error)) {
-		g_prefix_error_literal(error, "error setuping device: ");
+		g_prefix_error(error, "error setuping device: ");
 		return FALSE;
 	}
 
@@ -1272,11 +1270,11 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 							  64,
 							  error);
 	if (static_buf == NULL) {
-		g_prefix_error_literal(error, "failed to get static tool info from device: ");
+		g_prefix_error(error, "failed to get static tool info from device: ");
 		return FALSE;
 	}
 	if (!fu_genesys_usbhub_device_get_descriptor_data(static_buf, buf, bufsz, error)) {
-		g_prefix_error_literal(error, "failed to get static tool info from device: ");
+		g_prefix_error(error, "failed to get static tool info from device: ");
 		return FALSE;
 	}
 	if (!fu_genesys_usbhub_device_get_info_from_static_ts(self, buf, bufsz, error))
@@ -1290,11 +1288,11 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 							  64,
 							  error);
 	if (dynamic_buf == NULL) {
-		g_prefix_error_literal(error, "failed to get dynamic tool info from device: ");
+		g_prefix_error(error, "failed to get dynamic tool info from device: ");
 		return FALSE;
 	}
 	if (!fu_genesys_usbhub_device_get_descriptor_data(dynamic_buf, buf, bufsz, error)) {
-		g_prefix_error_literal(error, "failed to get dynamic tool info from device: ");
+		g_prefix_error(error, "failed to get dynamic tool info from device: ");
 		return FALSE;
 	}
 	if (!fu_genesys_usbhub_device_get_info_from_dynamic_ts(self, buf, bufsz, error))
@@ -1308,16 +1306,16 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 							  64,
 							  error);
 	if (fw_buf == NULL) {
-		g_prefix_error_literal(error, "failed to get firmware tool info from device: ");
+		g_prefix_error(error, "failed to get firmware tool info from device: ");
 		return FALSE;
 	}
 	if (!fu_genesys_usbhub_device_get_descriptor_data(fw_buf, buf, bufsz, error)) {
-		g_prefix_error_literal(error, "failed to get firmware tool info from device: ");
+		g_prefix_error(error, "failed to get firmware tool info from device: ");
 		return FALSE;
 	}
 	self->st_fwinfo_ts = fu_struct_genesys_ts_firmware_info_parse(buf, bufsz, 0, error);
 	if (self->st_fwinfo_ts == NULL) {
-		g_prefix_error_literal(error, "failed to parse firmware tool info: ");
+		g_prefix_error(error, "failed to parse firmware tool info: ");
 		return FALSE;
 	}
 
@@ -1330,21 +1328,19 @@ fu_genesys_usbhub_device_setup(FuDevice *device, GError **error)
 		    64,
 		    error);
 		if (vendor_buf == NULL) {
-			g_prefix_error_literal(
-			    error,
-			    "failed to get vendor support tool info from device: ");
+			g_prefix_error(error,
+				       "failed to get vendor support tool info from device: ");
 			return FALSE;
 		}
 		if (!fu_genesys_usbhub_device_get_descriptor_data(vendor_buf, buf, bufsz, error)) {
-			g_prefix_error_literal(
-			    error,
-			    "failed to get vendor support tool info from device: ");
+			g_prefix_error(error,
+				       "failed to get vendor support tool info from device: ");
 			return FALSE;
 		}
 		self->st_vendor_ts =
 		    fu_struct_genesys_ts_vendor_support_parse(buf, bufsz, 0, error);
 		if (self->st_vendor_ts == NULL) {
-			g_prefix_error_literal(error, "failed to parse vendor support tool info: ");
+			g_prefix_error(error, "failed to parse vendor support tool info: ");
 			return FALSE;
 		}
 	} else {
@@ -1669,7 +1665,7 @@ fu_genesys_usbhub_device_compare_fw_public_key(FuGenesysUsbhubDevice *self,
 				    0,
 				    FU_STRUCT_GENESYS_FW_RSA_PUBLIC_KEY_TEXT_SIZE_TEXT_N,
 				    error)) {
-			g_prefix_error_literal(error, "mismatch public-keyN: ");
+			g_prefix_error(error, "mismatch public-keyN: ");
 			return FALSE;
 		}
 
@@ -1683,7 +1679,7 @@ fu_genesys_usbhub_device_compare_fw_public_key(FuGenesysUsbhubDevice *self,
 				    0,
 				    FU_STRUCT_GENESYS_FW_RSA_PUBLIC_KEY_TEXT_SIZE_TEXT_E,
 				    error)) {
-			g_prefix_error_literal(error, "mismatch public-keyE: ");
+			g_prefix_error(error, "mismatch public-keyE: ");
 			return FALSE;
 		}
 		break;
@@ -1721,7 +1717,7 @@ fu_genesys_usbhub_device_compare_fw_public_key(FuGenesysUsbhubDevice *self,
 				    0,
 				    FU_STRUCT_GENESYS_FW_ECDSA_PUBLIC_KEY_SIZE,
 				    error)) {
-			g_prefix_error_literal(error, "mismatch public-key: ");
+			g_prefix_error(error, "mismatch public-key: ");
 			fu_dump_raw(G_LOG_DOMAIN, "PublicKey", fw_key, fw_keysz);
 			return FALSE;
 		}
@@ -1907,7 +1903,7 @@ fu_genesys_usbhub_device_erase_flash(FuGenesysUsbhubDevice *self,
 				     self->flash_erase_delay / 30,
 				     &helper,
 				     error)) {
-			g_prefix_error_literal(error, "error erasing flash: ");
+			g_prefix_error(error, "error erasing flash: ");
 			return FALSE;
 		}
 		fu_progress_step_done(progress);
@@ -1968,7 +1964,7 @@ fu_genesys_usbhub_device_write_flash(FuGenesysUsbhubDevice *self,
 				     self->flash_write_delay / 30,
 				     &helper,
 				     error)) {
-			g_prefix_error_literal(error, "error writing flash: ");
+			g_prefix_error(error, "error writing flash: ");
 			return FALSE;
 		}
 		fu_progress_step_done(progress);

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -128,7 +128,7 @@ fu_genesys_usbhub_firmware_verify_checksum(GBytes *fw, GError **error)
 				    &fw_checksum,
 				    G_BIG_ENDIAN,
 				    error)) {
-		g_prefix_error_literal(error, "failed to get checksum: ");
+		g_prefix_error(error, "failed to get checksum: ");
 		return FALSE;
 	}
 
@@ -156,7 +156,7 @@ fu_genesys_usbhub_firmware_calculate_size(GBytes *fw, gsize offset, gsize *size,
 				   offset + GENESYS_USBHUB_CODE_SIZE_OFFSET,
 				   &kbs,
 				   error)) {
-		g_prefix_error_literal(error, "failed to get codesize: ");
+		g_prefix_error(error, "failed to get codesize: ");
 		return FALSE;
 	}
 	if (kbs == 0) {
@@ -184,7 +184,7 @@ fu_genesys_usbhub_firmware_ensure_version(FuFirmware *firmware, GError **error)
 				    &version_raw,
 				    G_LITTLE_ENDIAN,
 				    error)) {
-		g_prefix_error_literal(error, "failed to get version: ");
+		g_prefix_error(error, "failed to get version: ");
 		return FALSE;
 	}
 	fu_firmware_set_version_raw(firmware, version_raw);
@@ -229,7 +229,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 
 	/* get chip */
 	if (!fu_genesys_usbhub_firmware_get_chip(self, buf, bufsz, offset, error)) {
-		g_prefix_error_literal(error, "failed to get chip: ");
+		g_prefix_error(error, "failed to get chip: ");
 		return FALSE;
 	}
 	fu_firmware_set_id(firmware, fu_genesys_fw_type_to_string(FU_GENESYS_FW_TYPE_HUB));
@@ -323,7 +323,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 							   FU_TYPE_GENESYS_USBHUB_CODESIGN_FIRMWARE,
 							   G_TYPE_INVALID);
 		if (firmware_sub == NULL) {
-			g_prefix_error_literal(error, "fw bytes have dual hub firmware: ");
+			g_prefix_error(error, "fw bytes have dual hub firmware: ");
 			return FALSE;
 		}
 		fu_firmware_set_offset(firmware_sub, offset);

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -50,7 +50,7 @@ fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 
 	/* truncate to correct size */
 	if (!fu_genesys_usbhub_firmware_calculate_size(fw, offset, &code_size, error)) {
-		g_prefix_error_literal(error, "not valid for pd: ");
+		g_prefix_error(error, "not valid for pd: ");
 		return FALSE;
 	}
 	fw_trunc = fu_bytes_new_offset(fw, offset, code_size, error);
@@ -61,14 +61,14 @@ fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 	/* calculate checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_genesys_usbhub_firmware_verify_checksum(fw_trunc, error)) {
-			g_prefix_error_literal(error, "not valid for pd: ");
+			g_prefix_error(error, "not valid for pd: ");
 			return FALSE;
 		}
 	}
 
 	/* get firmware version */
 	if (!fu_genesys_usbhub_firmware_ensure_version(firmware, error)) {
-		g_prefix_error_literal(error, "not valid for pd: ");
+		g_prefix_error(error, "not valid for pd: ");
 		return FALSE;
 	}
 


### PR DESCRIPTION
because current fwupd only depend on glib 2.68.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
