### PR TITLE
wacom-usb: Define quirks for new Wacom One tablets (CTC4110WL, CTC6110WL)

### DIFF
--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -101,3 +101,25 @@ GType = FuWacDevice
 [USB\VID_056A&PID_03CE]
 Plugin = wacom_usb
 GType = FuWacDevice
+
+# Wacom One Pen tablet small (USB) [CTC4110WL]
+[USB\VID_0531&PID_0100]
+Plugin = wacom_usb
+GType = FuWacDevice
+Flags = no-serial-number
+
+# Wacom One Pen tablet small (USB) [CTC4110WL - Android Mode]
+[USB\VID_0531&PID_0104]
+Plugin = wacom_usb
+GType = FuWacDevice
+
+# Wacom One Pen tablet medium (USB) [CTC6110WL]
+[USB\VID_0531&PID_0102]
+Plugin = wacom_usb
+GType = FuWacDevice
+Flags = no-serial-number
+
+# Wacom One Pen tablet medium (USB) [CTC6110WL - Android Mode]
+[USB\VID_0531&PID_0105]
+Plugin = wacom_usb
+GType = FuWacDevice


### PR DESCRIPTION
Define quirks to recognize the Wacom's two newly-announced "Wacom One" devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
