### PR TITLE
Add device ID and support for Quectel RM520

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -73,3 +73,8 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
 [PCI\VID_1EAC&PID_1004]
 Summary = Quectel RM520 firehose prog file
 ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf
+
+# Quectel RM520 firehose prog file
+[PCI\VID_1EAC&PID_1007]
+Summary = Quectel RM520 firehose prog file
+ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf


### PR DESCRIPTION
Hi，

Type of pull request:

[ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
[ ] Code fix
[*] Feature
[ ] Documentation

The Quectel new RM520N-GL product works with the Quectel's existing RM520N-GL modem settings.
But this one is designed for lenovo laptop usecase, hence Quectel got a new PID.

Thanks and happy holidays!
