### PR TITLE
Allow writing BIOS settings from plugin code

### DIFF
--- a/libfwupd/fwupd-bios-setting.h
+++ b/libfwupd/fwupd-bios-setting.h
@@ -17,8 +17,8 @@ G_DECLARE_DERIVABLE_TYPE(FwupdBiosSetting, fwupd_bios_setting, FWUPD, BIOS_SETTI
 
 struct _FwupdBiosSettingClass {
 	GObjectClass parent_class;
+	gboolean (*write_value)(FwupdBiosSetting *self, const gchar *value, GError **error);
 	/*< private >*/
-	void (*_fwupd_reserved1)(void);
 	void (*_fwupd_reserved2)(void);
 	void (*_fwupd_reserved3)(void);
 	void (*_fwupd_reserved4)(void);
@@ -110,6 +110,9 @@ const gchar *
 fwupd_bios_setting_get_current_value(FwupdBiosSetting *self);
 void
 fwupd_bios_setting_set_current_value(FwupdBiosSetting *self, const gchar *value);
+
+gboolean
+fwupd_bios_setting_write_value(FwupdBiosSetting *self, const gchar *value, GError **error);
 
 const gchar *
 fwupd_bios_setting_get_id(FwupdBiosSetting *self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -963,6 +963,7 @@ LIBFWUPD_1.9.3 {
 
 LIBFWUPD_1.9.4 {
   global:
+    fwupd_bios_setting_write_value;
     fwupd_client_refresh_remote2;
     fwupd_client_refresh_remote2_async;
     fwupd_remote_add_flag;

--- a/libfwupdplugin/fu-bios-setting.c
+++ b/libfwupdplugin/fu-bios-setting.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuBiosSettings"
+
+#include "config.h"
+
+#include <fcntl.h>
+
+#include "fu-bios-setting.h"
+#include "fu-io-channel.h"
+
+struct _FuBiosSetting {
+	FwupdBiosSetting parent_instance;
+};
+
+G_DEFINE_TYPE(FuBiosSetting, fu_bios_setting, FWUPD_TYPE_BIOS_SETTING)
+
+static gboolean
+fu_bios_setting_write_value(FwupdBiosSetting *self, const gchar *value, GError **error)
+{
+	int fd;
+	g_autofree gchar *fn =
+	    g_build_filename(fwupd_bios_setting_get_path(self), "current_value", NULL);
+	g_autoptr(FuIOChannel) io = NULL;
+
+	fd = open(fn, O_WRONLY);
+	if (fd < 0) {
+		g_set_error(error,
+			    G_IO_ERROR,
+#ifdef HAVE_ERRNO_H
+			    g_io_error_from_errno(errno),
+#else
+			    G_IO_ERROR_FAILED,
+#endif
+			    "could not open %s: %s",
+			    fn,
+			    g_strerror(errno));
+		return FALSE;
+	}
+	io = fu_io_channel_unix_new(fd);
+	if (!fu_io_channel_write_raw(io,
+				     (const guint8 *)value,
+				     strlen(value),
+				     1000,
+				     FU_IO_CHANNEL_FLAG_NONE,
+				     error))
+		return FALSE;
+
+	/* success */
+	fwupd_bios_setting_set_current_value(self, value);
+	g_debug("set %s to %s", fwupd_bios_setting_get_id(self), value);
+	return TRUE;
+}
+
+static void
+fu_bios_setting_class_init(FuBiosSettingClass *klass)
+{
+	FwupdBiosSettingClass *bios_setting_class = FWUPD_BIOS_SETTING_CLASS(klass);
+	bios_setting_class->write_value = fu_bios_setting_write_value;
+}
+
+static void
+fu_bios_setting_init(FuBiosSetting *self)
+{
+}
+
+FwupdBiosSetting *
+fu_bios_setting_new(void)
+{
+	return g_object_new(FU_TYPE_BIOS_SETTING, NULL);
+}

--- a/libfwupdplugin/fu-bios-setting.h
+++ b/libfwupdplugin/fu-bios-setting.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupd.h>
+
+#define FU_TYPE_BIOS_SETTING (fu_bios_setting_get_type())
+
+G_DECLARE_FINAL_TYPE(FuBiosSetting, fu_bios_setting, FU, BIOS_SETTING, FwupdBiosSetting)
+
+FwupdBiosSetting *
+fu_bios_setting_new(void);

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -13,6 +13,7 @@
 #include "fwupd-bios-setting-private.h"
 #include "fwupd-error.h"
 
+#include "fu-bios-setting.h"
 #include "fu-bios-settings-private.h"
 #include "fu-path.h"
 #include "fu-string.h"
@@ -362,9 +363,11 @@ fu_bios_settings_populate_attribute(FuBiosSettings *self,
 	g_return_val_if_fail(path != NULL, FALSE);
 	g_return_val_if_fail(driver != NULL, FALSE);
 
-	attr = fwupd_bios_setting_new(name, path);
+	attr = fu_bios_setting_new();
 
 	id = g_strdup_printf("com.%s.%s", driver, name);
+	fwupd_bios_setting_set_name(attr, name);
+	fwupd_bios_setting_set_path(attr, path);
 	fwupd_bios_setting_set_id(attr, id);
 
 	if (g_file_test(path, G_FILE_TEST_IS_DIR)) {

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -51,6 +51,7 @@ fwupdplugin_src = [
   'fu-archive.c',
   'fu-archive-firmware.c',
   'fu-backend.c',
+  'fu-bios-setting.c', # fuzzing
   'fu-bios-settings.c', # fuzzing
   'fu-bluez-device.c',
   'fu-byte-array.c', # fuzzing

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -910,149 +910,6 @@ fu_engine_modify_remote(FuEngine *self,
 }
 
 static gboolean
-fu_engine_update_bios_setting(FwupdBiosSetting *attr,
-			      const gchar *value,
-			      gboolean force_ro,
-			      GError **error)
-{
-	int fd;
-	g_autofree gchar *fn =
-	    g_build_filename(fwupd_bios_setting_get_path(attr), "current_value", NULL);
-	g_autoptr(FuIOChannel) io = NULL;
-
-	if (force_ro)
-		fwupd_bios_setting_set_read_only(attr, TRUE);
-
-	if (g_strcmp0(fwupd_bios_setting_get_current_value(attr), value) == 0) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOTHING_TO_DO,
-			    "%s is already set to %s",
-			    fwupd_bios_setting_get_id(attr),
-			    value);
-		return FALSE;
-	}
-
-	fd = open(fn, O_WRONLY);
-	if (fd < 0) {
-		g_set_error(error,
-			    G_IO_ERROR,
-#ifdef HAVE_ERRNO_H
-			    g_io_error_from_errno(errno),
-#else
-			    G_IO_ERROR_FAILED,
-#endif
-			    "could not open %s: %s",
-			    fn,
-			    g_strerror(errno));
-		return FALSE;
-	}
-	io = fu_io_channel_unix_new(fd);
-	if (!fu_io_channel_write_raw(io,
-				     (const guint8 *)value,
-				     strlen(value),
-				     1000,
-				     FU_IO_CHANNEL_FLAG_NONE,
-				     error))
-		return FALSE;
-	fwupd_bios_setting_set_current_value(attr, value);
-	g_debug("set %s to %s", fwupd_bios_setting_get_id(attr), value);
-
-	return TRUE;
-}
-
-/*
- * This is also done by the kernel or firmware, doing it here too allows for cleaner
- * error messages
- */
-static gboolean
-fu_engine_validate_bios_setting_input(FwupdBiosSetting *attr, const gchar **value, GError **error)
-{
-	guint64 tmp = 0;
-
-	g_return_val_if_fail(*value != NULL, FALSE);
-	g_return_val_if_fail(value != NULL, FALSE);
-
-	if (attr == NULL) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_FOUND,
-				    "attribute not found");
-		return FALSE;
-	}
-	if (fwupd_bios_setting_get_read_only(attr)) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "%s is read only",
-			    fwupd_bios_setting_get_name(attr));
-		return FALSE;
-	}
-	if (fwupd_bios_setting_get_kind(attr) == FWUPD_BIOS_SETTING_KIND_INTEGER) {
-		if (!fu_strtoull(*value, &tmp, 0, G_MAXUINT64, error))
-			return FALSE;
-		if (tmp < fwupd_bios_setting_get_lower_bound(attr)) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "%s is too small (%" G_GUINT64_FORMAT
-				    "); expected at least %" G_GUINT64_FORMAT,
-				    *value,
-				    tmp,
-				    fwupd_bios_setting_get_lower_bound(attr));
-			return FALSE;
-		}
-		if (tmp > fwupd_bios_setting_get_upper_bound(attr)) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "%s is too big (%" G_GUINT64_FORMAT
-				    "); expected no more than %" G_GUINT64_FORMAT,
-				    *value,
-				    tmp,
-				    fwupd_bios_setting_get_upper_bound(attr));
-			return FALSE;
-		}
-	} else if (fwupd_bios_setting_get_kind(attr) == FWUPD_BIOS_SETTING_KIND_STRING) {
-		tmp = strlen(*value);
-		if (tmp < fwupd_bios_setting_get_lower_bound(attr)) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "%s is too short (%" G_GUINT64_FORMAT
-				    "); expected at least %" G_GUINT64_FORMAT,
-				    *value,
-				    tmp,
-				    fwupd_bios_setting_get_lower_bound(attr));
-			return FALSE;
-		}
-		if (tmp > fwupd_bios_setting_get_upper_bound(attr)) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "%s is too long (%" G_GUINT64_FORMAT
-				    "); expected no more than %" G_GUINT64_FORMAT,
-				    *value,
-				    tmp,
-				    fwupd_bios_setting_get_upper_bound(attr));
-			return FALSE;
-		}
-	} else if (fwupd_bios_setting_get_kind(attr) == FWUPD_BIOS_SETTING_KIND_ENUMERATION) {
-		const gchar *result = fwupd_bios_setting_map_possible_value(attr, *value, error);
-		if (result == NULL)
-			return FALSE;
-		*value = result;
-	} else {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "unknown attribute type");
-		return FALSE;
-	}
-	return TRUE;
-}
-
-static gboolean
 fu_engine_modify_single_bios_setting(FuEngine *self,
 				     const gchar *key,
 				     const gchar *value,
@@ -1060,12 +917,18 @@ fu_engine_modify_single_bios_setting(FuEngine *self,
 				     GError **error)
 {
 	FwupdBiosSetting *attr = fu_context_get_bios_setting(self->ctx, key);
-	const gchar *tmp = value;
-
-	if (!fu_engine_validate_bios_setting_input(attr, &tmp, error))
+	if (attr == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "attribute not found");
 		return FALSE;
-
-	return fu_engine_update_bios_setting(attr, tmp, force_ro, error);
+	}
+	if (!fwupd_bios_setting_write_value(attr, value, error))
+		return FALSE;
+	if (force_ro)
+		fwupd_bios_setting_set_read_only(attr, TRUE);
+	return TRUE;
 }
 
 /**


### PR DESCRIPTION
This moves the actual writing to sysfs to a new FuBiosSetting superclass in libfwupdplugin (which is now created from FuBiosSettings) to avoid leaking low level unix stuff into libfwupd.

This also allows us to move the value validation code into libfwupd which is a much better location and makes the engine smaller.

Based on a patch by Kate Hsuan <hpa@redhat.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
