### PR TITLE
wacom-usb: Correct flash errors with ID9 module

### DIFF
--- a/plugins/wacom-usb/fu-wac.rs
+++ b/plugins/wacom-usb/fu-wac.rs
@@ -76,14 +76,14 @@ enum WacDeviceStatus {
 
 #[derive(New)]
 struct Id9UnknownCmd {
-    unknown1: u16be: const=0x7050,
-    unknown2: u32be: const=0,
+    unknown1: u16be == 0x7050,
+    unknown2: u32be == 0,
     size: u16be,                  // Size of payload to be transferred
 }
 #[derive(New)]
 struct Id9SpiCmd {
-    command: u8: const=0x91,
-    start_addr: u32be: const=0,
+    command: u8 == 0x91,
+    start_addr: u32be == 0,
     size: u16be,                  // sizeof(data) + size of payload
     data: Id9UnknownCmd,
 }


### PR DESCRIPTION
The recently-added ID9 module is failing to flash properly due to an oversight that occurred while merging. This pull request fixes the issue and also updates the plugin to waste less time trying to recover from unrecoverable states.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation