### PR TITLE
intel-me: Only query one set of FILE_IDs

### DIFF
--- a/plugins/intel-me/fu-intel-me.rs
+++ b/plugins/intel-me/fu-intel-me.rs
@@ -1,9 +1,0 @@
-// Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
-// SPDX-License-Identifier: LGPL-2.1+
-
-#[derive(ToString)]
-enum IntelMeMcaSection {
-    Me = 0x00,
-    Uep = 0x04,
-    Fpf = 0x08,
-}

--- a/plugins/intel-me/meson.build
+++ b/plugins/intel-me/meson.build
@@ -3,7 +3,6 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginIntelMe"']
 
 plugin_quirks += files('intel-me.quirk')
 plugin_builtins += static_library('fu_plugin_intel_me',
-  rustgen.process('fu-intel-me.rs'),
   sources: [
     'fu-intel-me-common.c',
     'fu-intel-me-plugin.c',


### PR DESCRIPTION
According to Intel sections 0x4 and 0x8 are only used for development testing. Using 0x0 is sufficient to get the value from either the FPF *or* NVRAM.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
