### PR TITLE
modem_manager: Fix transaction timed out issue for T99W373 qdu device

### DIFF
--- a/plugins/modem-manager/fu-mbim-qdu-updater.c
+++ b/plugins/modem-manager/fu-mbim-qdu-updater.c
@@ -305,7 +305,7 @@ fu_mbim_qdu_updater_file_write_ready(MbimDevice *device, GAsyncResult *res, gpoi
 							NULL);
 		mbim_device_command(ctx->mbim_device,
 				    request,
-				    10,
+				    20,
 				    NULL,
 				    (GAsyncReadyCallback)fu_mbim_qdu_updater_file_write_ready,
 				    ctx);

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -32,7 +32,7 @@
  * modem boots without SIM card inserted (and therefore the initialization
  * may be very slow) and also where carrier config switching is explicitly
  * required (e.g. if switching from the default (DF) to generic (GC).*/
-#define FU_MM_DEVICE_REMOVE_DELAY_REPROBE 120000 /* ms */
+#define FU_MM_DEVICE_REMOVE_DELAY_REPROBE 180000 /* ms */
 
 #define FU_MM_DEVICE_AT_RETRIES 3
 #define FU_MM_DEVICE_AT_DELAY	3000 /* ms */


### PR DESCRIPTION
T99W373 is a modem device based on mbim qdu. This device needs about 12-16s to response last write mbim qdu message. So we need to increase the default timeout 10 to 20. Besides that, this device needs reboot twice to uprgade FW successfully.So we need to increase the replug time from 120s to 180s in case another timed out issue.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
