### PR TITLE
trivial: Fix the refresh logic in fwupdmgr

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1027,10 +1027,8 @@ fu_util_convert_description(const gchar *xml, GError **error)
  * Converts a timestamp to a 'pretty' translated string
  *
  * Returns: (transfer full): A string
- *
- * Since: 1.3.7
  **/
-gchar *
+static gchar *
 fu_util_time_to_str(guint64 tmp)
 {
 	g_return_val_if_fail(tmp != 0, NULL);

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -98,8 +98,6 @@ fu_util_parse_filter_release_flags(const gchar *filter,
 				   GError **error);
 gchar *
 fu_util_convert_description(const gchar *xml, GError **error);
-gchar *
-fu_util_time_to_str(guint64 tmp);
 
 gchar *
 fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt);


### PR DESCRIPTION
The logic was all backwards; the refresh loop is already using _needs_refresh() which works per-remote now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
