### PR TITLE
Added support for Fibocom 0x2cb7, and fixes for two issues

### DIFF
--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -6,3 +6,9 @@ Plugin = fastboot
 [USB\VID_18D1&PID_D00D]
 FastbootBlockSize = 16384
 FastbootOperationDelay = 250
+
+# Fibocom FM101 in fastboot mode
+[USB\VID_2CB7&PID_D00D]
+FastbootBlockSize = 16384
+FastbootOperationDelay = 0
+

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1893,6 +1893,9 @@ fu_mm_device_init(FuMmDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE,
 					"detach-at-fastboot-has-no-response");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT,
+					"uninhibit-modemmanager-after-fastboot-reboot");
 }
 
 static void

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -12,6 +12,15 @@
 
 #include <libmm-glib.h>
 
+/*
+ * FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT
+ *
+ * after entering the fastboot state, the modem cannot execute the attach method
+ * in the MM plugin plugin plugin. shadow_device needs to be used to uninhibit the modem
+ * when fu_mm_plugin_udev_uevent_cb detects it.
+ */
+#define FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT (1 << 1)
+
 #define FU_TYPE_MM_DEVICE (fu_mm_device_get_type())
 G_DECLARE_FINAL_TYPE(FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)
 

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -78,3 +78,15 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf
 [PCI\VID_1EAC&PID_1007]
 Summary = Quectel RM520 firehose prog file
 ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf
+
+# Fibocom FM101
+[USB\VID_2CB7&PID_01A2]
+Summary = Fibocom FM101-GL Module
+Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
+CounterpartGuid = USB\VID_2CB7&PID_D00D
+
+# Fibocom FM101 in fastboot mode
+[USB\VID_2CB7&PID_D00D]
+Summary = Fibocom FM101 Modem
+CounterpartGuid = USB\VID_2CB7&PID_01A2
+


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation

FM101 device-related parameters were added to quirk files of MM and fastboot plugins.

AT command receiving problem when modem opens echo in MM plug-in.

A flag is added in the MM plug-in, so that the ModemManager can uninhibit after the fastboot flash ends, so that the modem can be found again.