### PR TITLE
Remove fwupd-refresh.preset & contrib/fwupd.spec.in: Follow presets for fwupd-refresh.timer

### DIFF
--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -13,7 +13,6 @@ usr/share/metainfo/*
 usr/libexec/fwupd/*
 usr/share/man/*
 lib/systemd/system/*
-lib/systemd/system-preset/*
 lib/systemd/system-shutdown/*
 lib/udev/rules.d/*
 data/fwupd.conf etc/fwupd

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -76,8 +76,6 @@ override_dh_install:
 	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-*/libfu_plugin_test_ble.so
 	rm -f debian/fwupd/etc/fwupd/remotes.d/fwupd-tests.conf
 
-	#enable fwupd-refresh.service by default (we have a dedicated user)
-	rm -f debian/fwupd/lib/systemd/system-preset/fwupd-refresh.preset
 	# avoid shipping an empty directory
 	find debian/fwupd/lib/systemd -type d -empty -delete
 

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -386,7 +386,6 @@ done
 %{_unitdir}/fwupd.service
 %{_unitdir}/fwupd-refresh.service
 %{_unitdir}/fwupd-refresh.timer
-%{_presetdir}/fwupd-refresh.preset
 %{_unitdir}/system-update.target.wants/
 %dir %{_localstatedir}/lib/fwupd
 %dir %{_localstatedir}/cache/fwupd

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -314,7 +314,7 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/cache/fwupd
 %find_lang %{name}
 
 %post
-%systemd_post fwupd.service
+%systemd_post fwupd.service fwupd-refresh.timer
 
 # change vendor-installed remotes to use the default keyring type
 for fn in /etc/fwupd/remotes.d/*.conf; do
@@ -324,10 +324,10 @@ for fn in /etc/fwupd/remotes.d/*.conf; do
 done
 
 %preun
-%systemd_preun fwupd.service
+%systemd_preun fwupd.service fwupd-refresh.timer
 
 %postun
-%systemd_postun_with_restart fwupd.service
+%systemd_postun_with_restart fwupd.service fwupd-refresh.timer
 
 %files -f %{name}.lang
 %doc README.md

--- a/data/motd/fwupd-refresh.preset
+++ b/data/motd/fwupd-refresh.preset
@@ -1,2 +1,0 @@
-disable fwupd-refresh.service
-disable fwupd-refresh.timer

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -2,8 +2,6 @@
 if libsystemd.found()
   install_data(['fwupd-refresh.timer'],
     install_dir: systemdunitdir)
-  install_data(['fwupd-refresh.preset'],
-    install_dir: systemdsystempresetdir)
   motd_fullpath = join_paths ('/run', motd_dir, motd_file)
 else
   motd_fullpath = join_paths (localstatedir, motd_dir, motd_file)

--- a/meson.build
+++ b/meson.build
@@ -447,12 +447,10 @@ if libsystemd.found()
   systemd_root_prefix = get_option('systemd_root_prefix')
   if systemd_root_prefix == ''
     systemdunitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')
-    systemdsystempresetdir = systemd.get_variable(pkgconfig: 'systemdsystempresetdir')
     systemd_shutdown_dir = systemd.get_variable(pkgconfig: 'systemdshutdowndir')
     systemd_modules_load_dir = systemd.get_variable(pkgconfig: 'modulesloaddir')
   else
     systemdunitdir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
-    systemdsystempresetdir = systemd.get_variable(pkgconfig: 'systemdsystempresetdir', pkgconfig_define: ['rootprefix', systemd_root_prefix])
     systemd_root_prefix_varname = 'root_prefix'
     if systemd.version().version_compare('< 246')
       systemd_root_prefix_varname = 'rootprefix'


### PR DESCRIPTION
contrib/fwupd.spec.in: Follow presets for fwupd-refresh.timer

Ensure that the fwupd-refresh.timer unit is enabled/disabled on
install/update/removal according to the global systemd presets.

See: https://src.fedoraproject.org/rpms/fedora-release/pull-request/279
See: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_systemd

---

Remove fwupd-refresh.preset

Fedora, CentOS Stream, openSUSE and Debian remove or wants to remove
this preset as it either enabled by default or managed somewhere else.

For example, Fedora disables all units, that have not been explicitly
enabled, by default in [1] which is part of the fedora-release package
[2].

Thus we don't need to explicitly disable those units here.

This is potentially an important change as it will enable those units on
systems that do not explcitely disable "all not explicitly enabled
units" like Fedora, etc. does.

[1] /usr/lib/systemd/system-preset/99-default-disable.preset
[2] https://src.fedoraproject.org/rpms/fedora-release/blob/rawhide/f/99-default-disable.preset

Fixes: https://github.com/fwupd/fwupd/issues/6115
See: https://src.fedoraproject.org/rpms/fwupd/pull-request/9
Fixes: https://github.com/fwupd/fwupd/pull/1491
Related to: https://src.fedoraproject.org/rpms/fedora-release/pull-request/279