### PR TITLE
add supporting flash in cfi.quirk

### DIFF
--- a/data/cfi.quirk
+++ b/data/cfi.quirk
@@ -84,9 +84,6 @@ Vendor = Sanyo
 # AMIC
 [CFI\FLASHID_7F]
 Vendor = AMIC
-[CFI\FLASHID_7F9D21]
-Name = PM25LD010
-FirmwareSizeMax = 0x20000
 
 [CFI\FLASHID_89]
 Vendor = Intel
@@ -102,6 +99,12 @@ Vendor = Texas Instruments
 # PMC
 [CFI\FLASHID_9D]
 Vendor = PMC
+[CFI\FLASHID_7F9D20]
+Name = PM25Lx512x
+FirmwareSizeMax = 0x10000
+[CFI\FLASHID_7F9D21]
+Name = PM25LD010
+FirmwareSizeMax = 0x20000
 
 # Fudan
 [CFI\FLASHID_A1]
@@ -155,6 +158,9 @@ FirmwareSizeMax = 0x400000
 Name = MX25Lxxx1E
 CfiDeviceCmdChipErase = 0x60
 CfiDeviceCmdSectorErase = 0x20
+[CFI\FLASHID_C22312]
+Name = MX25V2035F
+FirmwareSizeMax = 0x40000
 
 # GigaDevice
 [CFI\FLASHID_C8]
@@ -197,6 +203,9 @@ FirmwareSizeMax = 0x10000
 [CFI\FLASHID_EF3011]
 Name = W25X10CL
 FirmwareSizeMax = 0x20000
+[CFI\FLASHID_EF3012]
+Name = W25X20X
+FirmwareSizeMax = 0x40000
 [CFI\FLASHID_EF4018]
 Name = W25Q128
 FirmwareSizeMax = 0x1000000


### PR DESCRIPTION
1. rearrange PM25LD010 to correct .
2. add PM25Lx512x / MX25V2035F / W25X20.X

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
