### PR TITLE
modem_manager: continue fix timed out for T99W373 mbim-qdu device

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1222,7 +1222,7 @@ fu_mm_device_write_firmware_mbim_qdu(FuDevice *device,
 	fu_mm_utils_get_port_info(self->port_mbim, NULL, &device_sysfs_path, NULL, NULL);
 	autosuspend_delay_filename =
 	    g_build_filename(device_sysfs_path, "/power/autosuspend_delay_ms", NULL);
-	if (!fu_mm_device_writeln(autosuspend_delay_filename, "10000", error))
+	if (!fu_mm_device_writeln(autosuspend_delay_filename, "20000", error))
 		return FALSE;
 
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);


### PR DESCRIPTION
The transaction timed out issue cause by the value of "/power/autosuspend_delay_ms" not enough. For last fu_mbim_qdu_updater_file_write_ready, we needs 12~16s to get the response. Once we send last MBIM write request, device may enter into suspend state after 10000 ms which was set in fu_mm_device_write_firmware_mbim_qdu(). This would block the response to return. So we need to increase the  delay time from 10000ms to 20000ms to sync with the time out of MBIM command.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
