### PR TITLE
synaptics-cape: add delay for header write

### DIFF
--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -18,6 +18,7 @@
 #define FU_SYNAPTICS_CAPE_DEVICE_USB_CMD_RETRY_TIMEOUT	300  /* ms */
 #define FU_SYNAPTICS_CAPE_DEVICE_USB_CMD_INTR_TIMEOUT	5000 /* ms */
 #define FU_SYNAPTICS_CAPE_DEVICE_USB_RESET_DELAY_MS	5000 /* ms */
+#define FU_SYNAPTICS_CAPE_DEVICE_HDR_WRITE_DELAY_MS	150  /* ms */
 
 /* defines CAPE command constant values and macro */
 #define FU_SYNAPTICS_CAPE_DEVICE_GOLEM_REPORT_ID 1 /* HID report id */
@@ -659,7 +660,7 @@ fu_synaptics_cape_device_write_firmware_header(FuSynapticsCapeDevice *self,
 						FU_SYNAPTICS_CMD_FW_UPDATE_START,
 						buf32,
 						bufsz / sizeof(guint32),
-						0,
+						FU_SYNAPTICS_CAPE_DEVICE_HDR_WRITE_DELAY_MS,
 						error);
 }
 


### PR DESCRIPTION
For factory firmware (v8.41.16.0) EPOS ADAPT 1x5 requires the delay about 140ms to get report after sending the firmware header to the device. Having no delay at all preventing new devices to update with error "failed to get GET_REPORT: failed to GetReport: transfer timed out".
Adding 150ms delay (+30ms for GET_REPORT) for the command should give enough time for the device to be prepared for firmware writing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
