### PR TITLE
Allow specifying the path to python during configure

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -272,7 +272,12 @@ if libgcab.type_name() == 'pkgconfig'
 endif
 
 bashcomp = dependency('bash-completion', required: false)
-python3 = import('python').find_installation('python3')
+python3path = get_option('python')
+if python3path == ''
+  python3 = import('python').find_installation('python3')
+else
+  python3 = find_program(python3path)
+endif
 
 gnutls = dependency('gnutls', version: '>= 3.6.0', required: get_option('gnutls'))
 if gnutls.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -72,3 +72,4 @@ option('offline', type: 'feature', description : 'Allow installing firmware usin
 option('compat_cli', type: 'boolean', value : false, description : 'enable legacy commands: fwupdagent,dfu-tool,fwupdate')
 option('hsi', type: 'feature', description : ' Host Security Information', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('thinklmi_compat', type: 'boolean', description : 'Include workaround for thinklmi kernel bugs')
+option('python', type: 'string', description : 'the absolute path of the python3 binary')


### PR DESCRIPTION
I've had to patch this for RHEL 8 and now also Homebrew, so lets just provide an escape hatch.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
