### PR TITLE
Add -Ddbus_p2p=true to always use a D-Bus TCP socket

### DIFF
--- a/contrib/build-windows.sh
+++ b/contrib/build-windows.sh
@@ -20,6 +20,7 @@ meson setup .. \
     --libexecdir="bin" \
     --bindir="bin" \
     -Dbuild=all \
+    -Ddbus_p2p=true \
     -Dman=false \
     -Dfish_completion=false \
     -Dbash_completion=false \

--- a/contrib/ci/build_windows.sh
+++ b/contrib/ci/build_windows.sh
@@ -48,6 +48,7 @@ meson setup .. \
     --bindir="bin" \
     -Dbuild=all \
     -Dman=false \
+    -Ddbus_p2p=true \
     -Dfish_completion=false \
     -Dbash_completion=false \
     -Dfirmware-packager=false \

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -908,6 +908,12 @@ fwupd_client_connect_async(FwupdClient *self,
 		return;
 	}
 
+#ifdef FWUPD_ALWAYS_USE_DBUS_P2P
+	/* this is set for macOS and Windows */
+	if (socket_filename == NULL)
+		socket_filename = g_strdup(FWUPD_DBUS_P2P_SOCKET_ADDRESS);
+#endif
+
 	/* convert from filename to address, if required */
 	if (socket_filename != NULL) {
 		if (g_strrstr(socket_filename, "=") == NULL) {
@@ -915,10 +921,6 @@ fwupd_client_connect_async(FwupdClient *self,
 		} else {
 			socket_address = g_strdup(socket_filename);
 		}
-	} else {
-#ifdef _WIN32
-		socket_address = g_strdup(FWUPD_DBUS_P2P_SOCKET_ADDRESS);
-#endif
 	}
 
 	/* use peer-to-peer only if the env variable is set */

--- a/meson.build
+++ b/meson.build
@@ -508,6 +508,10 @@ conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 conf.set_quoted('PACKAGE_NAME', meson.project_name())
 conf.set_quoted('VERSION', meson.project_version())
 
+if get_option('dbus_p2p')
+  conf.set('FWUPD_ALWAYS_USE_DBUS_P2P', '1')
+endif
+
 motd_file = '85-fwupd'
 motd_dir = 'motd.d'
 conf.set_quoted('MOTD_FILE', motd_file)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('build', type : 'combo', choices : ['all', 'standalone', 'library'], value : 'all', description : 'build type')
 option('consolekit', type : 'feature', description : 'ConsoleKit support', deprecated: {'true': 'enabled', 'false': 'disabled'})
 option('static_analysis', type : 'boolean', value : false, description : 'enable GCC static analysis support')
+option('dbus_p2p', type : 'boolean', value : false, description : 'always use D-Bus in p2p mode')
 option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
 option('docs', type : 'feature', description : 'Build developer documentation', deprecated: {'docgen': 'enabled', 'none': 'disabled'})
 option('introspection', type : 'feature', description : 'generate GObject Introspection data', deprecated: {'true': 'enabled', 'false': 'disabled'})

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -150,6 +150,12 @@ main(int argc, char *argv[])
 		fu_daemon_set_machine_kind(daemon, FU_DAEMON_MACHINE_KIND_PHYSICAL);
 	}
 
+#ifdef FWUPD_ALWAYS_USE_DBUS_P2P
+	/* this is set for macOS and Windows */
+	if (socket_filename == NULL)
+		socket_filename = g_strdup(FWUPD_DBUS_P2P_SOCKET_ADDRESS);
+#endif
+
 	/* convert from filename to address, if required */
 	if (socket_filename != NULL) {
 		if (g_strrstr(socket_filename, "=") == NULL) {


### PR DESCRIPTION
We need this on Windows and macOS -- although both platforms might have a system bus in the future.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
