### PR TITLE
trivial: Require GUdev for logitech-scribe and logitech-tap

### DIFF
--- a/plugins/logitech-scribe/meson.build
+++ b/plugins/logitech-scribe/meson.build
@@ -1,5 +1,5 @@
-if get_option('plugin_logitech_scribe').require(gusb.found(),
-    error_message: 'usb is needed for plugin_logitech_scribe').disable_auto_if(host_machine.system() != 'linux').allowed()    
+if get_option('plugin_logitech_scribe').require(gusb.found() and gudev.found(),
+    error_message: 'usb and udev are needed for plugin_logitech_scribe').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechScribe"']
 
 plugin_quirks += files('logitech-scribe.quirk')

--- a/plugins/logitech-tap/meson.build
+++ b/plugins/logitech-tap/meson.build
@@ -1,5 +1,5 @@
-if get_option('plugin_logitech_tap').require(gusb.found(),
-    error_message: 'usb is needed for plugin_logitech_tap').disable_auto_if(host_machine.system() != 'linux').allowed()    
+if get_option('plugin_logitech_tap').require(gusb.found() and gudev.found(),
+    error_message: 'usb and udev are needed for plugin_logitech_tap').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechTap"']
 
 plugin_quirks += files('logitech-tap.quirk')


### PR DESCRIPTION
This fixes a compile error when compiling with -Dgudev=disabled.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
