### PR TITLE
quectel:Add device ID and support for EM160 module

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -69,6 +69,11 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
 Summary = Quectel EM160 firehose prog file
 ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
 
+# Quectel EM160 firehose prog file
+[PCI\VID_1EAC&PID_100D]
+Summary = Quectel EM160 firehose prog file
+ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
+
 # Quectel RM520 firehose prog file
 [PCI\VID_1EAC&PID_1004]
 Summary = Quectel RM520 firehose prog file


### PR DESCRIPTION
Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation


quectel's new EM160 module PCIe ID joins fwupd