### PR TITLE
Reduce the maximum size of archive loaded into memory

### DIFF
--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -275,7 +275,7 @@ guint64
 fu_engine_config_get_archive_size_max(FuEngineConfig *self)
 {
 	guint64 memory_size = fu_common_get_memory_size();
-	guint64 value_default = memory_size > 0 ? MIN(memory_size / 4, G_MAXUINT32)
+	guint64 value_default = memory_size > 0 ? MIN(memory_size / 10, G_MAXUINT32)
 						: 512 * 0x100000;
 	return fu_config_get_value_u64(FU_CONFIG(self), "fwupd", "ArchiveSizeMax", value_default);
 }


### PR DESCRIPTION
To support the existing large archives, and to support larger still (!) firmware payloads, write the fd handle to localstatedir and open it as a mmap'd file.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
