### PR TITLE
Delete BootNext as a post-reboot action

### DIFF
--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -50,6 +50,7 @@ _fwupdtool_cmd_list=(
 	'unbind-driver'
 	'bind-driver'
 	'export-hwids'
+	'reboot-cleanup'
 )
 
 _fwupdtool_opts=(

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -235,6 +235,13 @@ The `[uefi_capsule]` section can contain the following parameters:
 
   This value also has no affect when using Capsule-on-Disk as the EFI helper binary is
   not being used.
+
+**RebootCleanup={{FU_UEFI_CAPSULE_CONFIG_DEFAULT_REBOOT_CLEANUP}}**
+
+  Delete any capsule files copy to the ESP, and remove any EFI variables set for the update.
+
+  **NOTE:** disabling this option is only required when debugging the flash process and normal
+  users should not need to change this setting.
 {% endif %}
 
 {% if plugin_msr %}

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -132,6 +132,10 @@ gboolean
 fu_plugin_runner_undo_host_security_attr(FuPlugin *self,
 					 FwupdSecurityAttr *attr,
 					 GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_plugin_runner_reboot_cleanup(FuPlugin *self,
+				FuDevice *device,
+				GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_plugin_runner_add_security_attrs(FuPlugin *self, FuSecurityAttrs *attrs);
 gint

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -1379,6 +1379,32 @@ fu_plugin_runner_reload(FuPlugin *self, FuDevice *device, GError **error)
 }
 
 /**
+ * fu_plugin_runner_reboot_cleanup:
+ * @self: a #FuPlugin
+ * @device: a device
+ * @error: (nullable): optional return location for an error
+ *
+ * Performs cleanup actions after the reboot has been performed.
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.7
+ **/
+gboolean
+fu_plugin_runner_reboot_cleanup(FuPlugin *self, FuDevice *device, GError **error)
+{
+	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
+
+	/* optional */
+	if (fu_plugin_has_flag(self, FWUPD_PLUGIN_FLAG_DISABLED))
+		return TRUE;
+	if (vfuncs->reboot_cleanup == NULL)
+		return TRUE;
+	g_debug("reboot_cleanup(%s)", fu_plugin_get_name(self));
+	return vfuncs->reboot_cleanup(self, device, error);
+}
+
+/**
  * fu_plugin_runner_add_security_attrs:
  * @self: a #FuPlugin
  * @attrs: a security attribute

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -413,6 +413,17 @@ struct _FuPluginClass {
 	gboolean (*undo_host_security_attr)(FuPlugin *self,
 					    FwupdSecurityAttr *attr,
 					    GError **error);
+	/**
+	 * reboot_cleanup:
+	 * @self: a #FuPlugin
+	 * @device: a device
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Performs cleanup actions after the reboot has been performed.
+	 *
+	 * Since: 1.9.7
+	 **/
+	gboolean (*reboot_cleanup)(FuPlugin *self, FuDevice *device, GError **error);
 };
 
 /**

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3156,6 +3156,25 @@ fu_engine_get_plugins(FuEngine *self)
 	return fu_plugin_list_get_all(self->plugin_list);
 }
 
+/**
+ * fu_engine_get_plugin_by_name:
+ * @self: a #FuPluginList
+ * @name: a plugin name, e.g. `dfu`
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets a specific plugin.
+ *
+ * Returns: (transfer none): a plugin, or %NULL
+ *
+ * Since: 1.9.6
+ **/
+FuPlugin *
+fu_engine_get_plugin_by_name(FuEngine *self, const gchar *name, GError **error)
+{
+	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
+	return fu_plugin_list_find_by_name(self->plugin_list, name, error);
+}
+
 static gboolean
 fu_engine_emulation_load_json(FuEngine *self, const gchar *json, GError **error)
 {
@@ -8115,6 +8134,12 @@ fu_engine_update_history_device(FuEngine *self, FuDevice *dev_history, GError **
 		return FALSE;
 	if (fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY))
 		fu_engine_update_release_integrity(self, rel_history, "SystemIntegrityNew");
+
+	/* do any late-cleanup actions */
+	if (!fu_plugin_runner_reboot_cleanup(plugin, dev, error)) {
+		g_prefix_error(error, "failed to do post-reboot cleanup: ");
+		return FALSE;
+	}
 
 	/* the system is running with the new firmware version */
 	if (fu_version_compare(fu_device_get_version(dev),

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -71,6 +71,8 @@ FuEngineConfig *
 fu_engine_get_config(FuEngine *self);
 GPtrArray *
 fu_engine_get_plugins(FuEngine *self);
+FuPlugin *
+fu_engine_get_plugin_by_name(FuEngine *self, const gchar *name, GError **error);
 GPtrArray *
 fu_engine_get_devices(FuEngine *self, GError **error);
 FuDevice *


### PR DESCRIPTION
This should not be required, but then some firmware is broken.

Fixes https://github.com/fwupd/fwupd/issues/5938

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
