### PR TITLE
elantp: Fix an unset i2c device name

### DIFF
--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -433,6 +433,11 @@ fu_elantp_hid_device_setup(FuDevice *device, GError **error)
 		g_autoptr(FuElantpHidHapticDevice) cfg = fu_elantp_haptic_device_new(device);
 		fu_device_add_child(FU_DEVICE(device), FU_DEVICE(cfg));
 	}
+
+	/* fix an unsuitable i²c name, e.g. `VEN 04F3:00 04F3:3XXX` */
+	if (g_str_has_prefix(fu_device_get_name(device), "VEN 04F3:00 04F3:3"))
+		fu_device_set_name(device, "Touchpad");
+
 	/* success */
 	return TRUE;
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2238139

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
