### PR TITLE
genesys-gl32xx: set physical id based on USB subsystem

### DIFF
--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -632,7 +632,6 @@ static gboolean
 fu_genesys_gl32xx_device_probe(FuDevice *device, GError **error)
 {
 	FuUdevDevice *udev_device = FU_UDEV_DEVICE(device);
-	const gchar *device_bus = NULL;
 
 	/* UdevDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_genesys_gl32xx_device_parent_class)->probe(device, error))
@@ -648,8 +647,7 @@ fu_genesys_gl32xx_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* success */
-	device_bus = fu_udev_device_get_subsystem(udev_device);
-	return fu_udev_device_set_physical_id(udev_device, device_bus, error);
+	return fu_udev_device_set_physical_id(udev_device, "usb", error);
 }
 
 static gboolean


### PR DESCRIPTION
Genesys GL32XX devices are USB card readers, so using the deepest "usb" node in the udev tree effectively allows to register multi-LUN devices.
Still need to check the partitions to avoid the device de-registration in case if user remove the SD-card.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation
