### PR TITLE
Reduce the amount of memory used when chunking large firmware

### DIFF
--- a/libfwupdplugin/fu-chunk-array.c
+++ b/libfwupdplugin/fu-chunk-array.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#define G_LOG_DOMAIN "FuChunkArray"
+
+#include "config.h"
+
+#include "fu-chunk-array.h"
+
+/**
+ * FuChunkArray:
+ *
+ * Create chunked data with address and index as required.
+ *
+ * NOTE: If you need a page size, either use fu_chunk_array_new() or use two #FuChunkArray's --
+ * e.g. once to split to page size, and once to split to packet size.
+ */
+
+struct _FuChunkArray {
+	GObject parent_instance;
+	GBytes *blob;
+	guint32 addr_start;
+	guint32 packet_sz;
+	guint total_chunks;
+};
+
+G_DEFINE_TYPE(FuChunkArray, fu_chunk_array, G_TYPE_OBJECT)
+
+/**
+ * fu_chunk_array_length:
+ * @self: a #FuChunkArray
+ *
+ * Gets the number of chunks.
+ *
+ * Returns: integer
+ *
+ * Since: 1.9.6
+ **/
+guint
+fu_chunk_array_length(FuChunkArray *self)
+{
+	g_return_val_if_fail(FU_IS_CHUNK_ARRAY(self), G_MAXUINT);
+	return self->total_chunks;
+}
+
+/**
+ * fu_chunk_array_index:
+ * @self: a #FuChunkArray
+ * @idx: the chunk index
+ *
+ * Gets the next chunk.
+ *
+ * Returns: (transfer full): a #FuChunk or %NULL if not valid
+ *
+ * Since: 1.9.6
+ **/
+FuChunk *
+fu_chunk_array_index(FuChunkArray *self, guint idx)
+{
+	gsize length;
+	gsize offset;
+	g_autoptr(FuChunk) chk = NULL;
+	g_autoptr(GBytes) blob_chk = NULL;
+
+	g_return_val_if_fail(FU_IS_CHUNK_ARRAY(self), NULL);
+
+	/* calculate offset and length */
+	offset = (gsize)idx * (gsize)self->packet_sz;
+	if (offset >= g_bytes_get_size(self->blob))
+		return NULL;
+	length = MIN(self->packet_sz, g_bytes_get_size(self->blob) - offset);
+	if (length == 0)
+		return NULL;
+
+	/* create new chunk */
+	blob_chk = g_bytes_new_from_bytes(self->blob, offset, length);
+	chk = fu_chunk_bytes_new(blob_chk);
+	fu_chunk_set_idx(chk, idx);
+	fu_chunk_set_address(chk, self->addr_start + offset);
+	return g_steal_pointer(&chk);
+}
+
+/**
+ * fu_chunk_array_new_from_bytes:
+ * @blob: data
+ * @addr_start: the hardware address offset, or 0x0
+ * @packet_sz: the packet size, or 0x0
+ *
+ * Chunks a linear blob of memory into packets, ensuring each packet is less that a specific
+ * transfer size.
+ *
+ * Returns: (transfer full): a #FuChunkArray
+ *
+ * Since: 1.9.6
+ **/
+FuChunkArray *
+fu_chunk_array_new_from_bytes(GBytes *blob, guint32 addr_start, guint32 packet_sz)
+{
+	g_autoptr(FuChunkArray) self = g_object_new(FU_TYPE_CHUNK_ARRAY, NULL);
+
+	g_return_val_if_fail(blob != NULL, NULL);
+
+	self->addr_start = addr_start;
+	self->packet_sz = packet_sz;
+	self->blob = g_bytes_ref(blob);
+	self->total_chunks = g_bytes_get_size(self->blob) / self->packet_sz;
+	if (g_bytes_get_size(self->blob) % self->packet_sz != 0)
+		self->total_chunks++;
+	return g_steal_pointer(&self);
+}
+
+static void
+fu_chunk_array_finalize(GObject *object)
+{
+	FuChunkArray *self = FU_CHUNK_ARRAY(object);
+	if (self->blob != NULL)
+		g_bytes_unref(self->blob);
+	G_OBJECT_CLASS(fu_chunk_array_parent_class)->finalize(object);
+}
+
+static void
+fu_chunk_array_class_init(FuChunkArrayClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_chunk_array_finalize;
+}
+
+static void
+fu_chunk_array_init(FuChunkArray *self)
+{
+}

--- a/libfwupdplugin/fu-chunk-array.h
+++ b/libfwupdplugin/fu-chunk-array.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include "fu-chunk.h"
+
+#define FU_TYPE_CHUNK_ARRAY (fu_chunk_array_get_type())
+
+G_DECLARE_FINAL_TYPE(FuChunkArray, fu_chunk_array, FU, CHUNK_ARRAY, GObject)
+
+FuChunkArray *
+fu_chunk_array_new_from_bytes(GBytes *blob, guint32 addr_start, guint32 packet_sz);
+guint
+fu_chunk_array_length(FuChunkArray *self);
+FuChunk *
+fu_chunk_array_index(FuChunkArray *self, guint idx);

--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -475,35 +475,15 @@ fu_chunk_array_new(const guint8 *data,
 					     data_offset,
 					     data_sz - last_flush));
 	}
-	return chunks;
-}
 
-/**
- * fu_chunk_array_new_from_bytes:
- * @blob: data
- * @addr_start: the hardware address offset, or 0
- * @page_sz: the hardware page size, or 0
- * @packet_sz: the transfer size, or 0
- *
- * Chunks a linear blob of memory into packets, ensuring each packet does not
- * cross a package boundary and is less that a specific transfer size.
- *
- * Returns: (transfer container) (element-type FuChunk): array of packets
- *
- * Since: 1.1.2
- **/
-GPtrArray *
-fu_chunk_array_new_from_bytes(GBytes *blob, guint32 addr_start, guint32 page_sz, guint32 packet_sz)
-{
-	GPtrArray *chunks;
-	gsize sz;
-	const guint8 *data = g_bytes_get_data(blob, &sz);
-
-	chunks = fu_chunk_array_new(data, (guint32)sz, addr_start, page_sz, packet_sz);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
-		chk->bytes = fu_bytes_new_offset(blob, chk->data - data, chk->data_sz, NULL);
+#ifndef SUPPORTED_BUILD
+	/* show the programmer a warning */
+	if (page_sz == 0x0 && chunks->len > 10000) {
+		g_warning("fu_chunk_array_new() generated a lot of chunks (%u), "
+			  "maybe use FuChunkArray instead?",
+			  chunks->len);
 	}
+#endif
 	return chunks;
 }
 

--- a/libfwupdplugin/fu-chunk.h
+++ b/libfwupdplugin/fu-chunk.h
@@ -56,5 +56,3 @@ fu_chunk_array_mutable_new(guint8 *data,
 			   guint32 addr_start,
 			   guint32 page_sz,
 			   guint32 packet_sz);
-GPtrArray *
-fu_chunk_array_new_from_bytes(GBytes *blob, guint32 addr_start, guint32 page_sz, guint32 packet_sz);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1689,6 +1689,45 @@ fu_backend_func(void)
 }
 
 static void
+fu_chunk_array_func(void)
+{
+	g_autoptr(FuChunk) chk1 = NULL;
+	g_autoptr(FuChunk) chk2 = NULL;
+	g_autoptr(FuChunk) chk3 = NULL;
+	g_autoptr(FuChunk) chk4 = NULL;
+	g_autoptr(GBytes) fw = g_bytes_new_static("hello world", 11);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 100, 5);
+
+	g_assert_cmpint(fu_chunk_array_length(chunks), ==, 3);
+
+	chk1 = fu_chunk_array_index(chunks, 0);
+	g_assert_nonnull(chk1);
+	g_assert_cmpint(fu_chunk_get_idx(chk1), ==, 0x0);
+	g_assert_cmpint(fu_chunk_get_address(chk1), ==, 100);
+	g_assert_cmpint(fu_chunk_get_data_sz(chk1), ==, 0x5);
+	g_assert_cmpint(strncmp((const gchar *)fu_chunk_get_data(chk1), "hello", 5), ==, 0);
+
+	chk2 = fu_chunk_array_index(chunks, 1);
+	g_assert_nonnull(chk2);
+	g_assert_cmpint(fu_chunk_get_idx(chk2), ==, 0x1);
+	g_assert_cmpint(fu_chunk_get_address(chk2), ==, 105);
+	g_assert_cmpint(fu_chunk_get_data_sz(chk2), ==, 0x5);
+	g_assert_cmpint(strncmp((const gchar *)fu_chunk_get_data(chk2), " world", 5), ==, 0);
+
+	chk3 = fu_chunk_array_index(chunks, 2);
+	g_assert_nonnull(chk3);
+	g_assert_cmpint(fu_chunk_get_idx(chk3), ==, 0x2);
+	g_assert_cmpint(fu_chunk_get_address(chk3), ==, 110);
+	g_assert_cmpint(fu_chunk_get_data_sz(chk3), ==, 0x1);
+	g_assert_cmpint(strncmp((const gchar *)fu_chunk_get_data(chk3), "d", 1), ==, 0);
+
+	chk4 = fu_chunk_array_index(chunks, 3);
+	g_assert_null(chk4);
+	chk4 = fu_chunk_array_index(chunks, 1024);
+	g_assert_null(chk4);
+}
+
+static void
 fu_chunk_func(void)
 {
 	g_autofree gchar *chunked1_str = NULL;
@@ -4382,6 +4421,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/plugin{quirks-device}", fu_plugin_quirks_device_func);
 	g_test_add_func("/fwupd/backend", fu_backend_func);
 	g_test_add_func("/fwupd/chunk", fu_chunk_func);
+	g_test_add_func("/fwupd/chunks", fu_chunk_array_func);
 	g_test_add_func("/fwupd/common{align-up}", fu_common_align_up_func);
 	g_test_add_func("/fwupd/volume{gpt-type}", fu_volume_gpt_type_func);
 	g_test_add_func("/fwupd/common{byte-array}", fu_common_byte_array_func);

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -20,6 +20,7 @@
 #include <libfwupdplugin/fu-cfi-device.h>
 #include <libfwupdplugin/fu-cfu-offer.h>
 #include <libfwupdplugin/fu-cfu-payload.h>
+#include <libfwupdplugin/fu-chunk-array.h>
 #include <libfwupdplugin/fu-chunk.h>
 #include <libfwupdplugin/fu-common-guid.h>
 #include <libfwupdplugin/fu-common.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -61,6 +61,7 @@ fwupdplugin_src = [
   'fu-cfu-offer.c', # fuzzing
   'fu-cfu-payload.c', # fuzzing
   'fu-chunk.c', # fuzzing
+  'fu-chunk-array.c', # fuzzing
   'fu-common.c', # fuzzing
   'fu-common-guid.c',
   'fu-config.c', # fuzzing
@@ -179,6 +180,7 @@ fwupdplugin_headers = [
   'fu-cfu-offer.h',
   'fu-cfu-payload.h',
   'fu-chunk.h',
+  'fu-chunk-array.h',
   'fu-common-guid.h',
   'fu-common.h',
   'fu-config.h',

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -233,17 +233,17 @@ fu_analogix_device_probe(FuDevice *device, GError **error)
 
 static gboolean
 fu_analogix_device_write_chunks(FuAnalogixDevice *self,
-				GPtrArray *chunks,
+				FuChunkArray *chunks,
 				guint16 req_val,
 				FuProgress *progress,
 				GError **error)
 {
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		FuAnalogixUpdateStatus status = FU_ANALOGIX_UPDATE_STATUS_INVALID;
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_analogix_device_send(self,
 					     ANX_BB_RQT_SEND_UPDATE_DATA,
 					     req_val,
@@ -275,7 +275,7 @@ fu_analogix_device_write_image(FuAnalogixDevice *self,
 	FuAnalogixUpdateStatus status = FU_ANALOGIX_UPDATE_STATUS_INVALID;
 	guint8 buf_init[4] = {0x0};
 	g_autoptr(GBytes) block_bytes = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -304,7 +304,7 @@ fu_analogix_device_write_image(FuAnalogixDevice *self,
 	fu_progress_step_done(progress);
 
 	/* write data */
-	chunks = fu_chunk_array_new_from_bytes(block_bytes, 0x00, 0x00, BILLBOARD_MAX_PACKET_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(block_bytes, 0x00, BILLBOARD_MAX_PACKET_SIZE);
 	if (!fu_analogix_device_write_chunks(self,
 					     chunks,
 					     req_val,

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -774,7 +774,7 @@ fu_ata_device_write_firmware(FuDevice *device,
 	guint32 chunksz = (guint32)self->transfer_blocks * FU_ATA_BLOCK_SIZE;
 	guint max_size = 0xffff * FU_ATA_BLOCK_SIZE;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -805,11 +805,11 @@ fu_ata_device_write_firmware(FuDevice *device,
 
 	/* write each block */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, 0x00, chunksz);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, chunksz);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_ata_device_fw_download(self,
 					       fu_chunk_get_idx(chk),
 					       fu_chunk_get_address(chk),

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -468,14 +468,14 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 
 static gboolean
 fu_bcm57xx_device_write_chunks(FuBcm57xxDevice *self,
-			       GPtrArray *chunks,
+			       FuChunkArray *chunks,
 			       FuProgress *progress,
 			       GError **error)
 {
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_bcm57xx_device_nvram_write(self,
 						   fu_chunk_get_address(chk),
 						   fu_chunk_get_data(chk),
@@ -497,7 +497,7 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GBytes) blob_verify = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -514,7 +514,7 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* hit hardware */
-	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 0x0, FU_BCM57XX_BLOCK_SZ);
+	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, FU_BCM57XX_BLOCK_SZ);
 	if (!fu_bcm57xx_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -385,13 +385,14 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GByteArray) st_info = fu_struct_ccgx_dmc_fwct_segmentation_info_new();
-		g_autoptr(GPtrArray) chunks = NULL;
+		g_autoptr(FuChunkArray) chunks = NULL;
 		g_autoptr(GBytes) img_bytes = fu_firmware_get_bytes(img, error);
 		if (img_bytes == NULL)
 			return NULL;
-		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 0x0, 64);
-		fu_struct_ccgx_dmc_fwct_segmentation_info_set_num_rows(st_info,
-								       MAX(chunks->len, 1));
+		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 64);
+		fu_struct_ccgx_dmc_fwct_segmentation_info_set_num_rows(
+		    st_info,
+		    MAX(fu_chunk_array_length(chunks), 1));
 		g_byte_array_append(buf, st_info->data, st_info->len);
 	}
 
@@ -409,13 +410,13 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 		g_autoptr(GChecksum) csum = g_checksum_new(G_CHECKSUM_SHA256);
 		g_autoptr(GBytes) img_bytes = NULL;
 		g_autoptr(GBytes) img_padded = NULL;
-		g_autoptr(GPtrArray) chunks = NULL;
+		g_autoptr(FuChunkArray) chunks = NULL;
 
 		img_bytes = fu_firmware_get_bytes(img, error);
 		if (img_bytes == NULL)
 			return NULL;
-		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 0x0, 64);
-		img_padded = fu_bytes_pad(img_bytes, MAX(chunks->len, 1) * 64);
+		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 64);
+		img_padded = fu_bytes_pad(img_bytes, MAX(fu_chunk_array_length(chunks), 1) * 64);
 		fu_byte_array_append_bytes(buf, img_padded);
 		g_checksum_update(csum,
 				  (const guchar *)g_bytes_get_data(img_padded, NULL),

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -421,7 +421,7 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	g_autoptr(GByteArray) mdbuf = g_byte_array_new();
 	g_autoptr(GByteArray) st_metadata = fu_struct_ccgx_metadata_hdr_new();
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
 
 	/* header record */
@@ -436,9 +436,9 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	fw = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (fw == NULL)
 		return NULL;
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, 0x100);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x100);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		fu_ccgx_firmware_write_record(str,
 					      0x0,
 					      i,

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -164,11 +164,12 @@ fu_ch347_device_send_command(FuCh347Device *self,
 {
 	/* write */
 	if (wbufsz > 0) {
-		g_autoptr(GPtrArray) chunks =
-		    fu_chunk_array_new(wbuf, wbufsz, 0x0, 0x0, FU_CH347_PAYLOAD_SIZE);
-		for (guint i = 0; i < chunks->len; i++) {
-			FuChunk *chk = g_ptr_array_index(chunks, i);
+		g_autoptr(GBytes) wblob = g_bytes_new_static(wbuf, wbufsz);
+		g_autoptr(FuChunkArray) chunks =
+		    fu_chunk_array_new_from_bytes(wblob, 0x0, FU_CH347_PAYLOAD_SIZE);
+		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			guint8 buf[1] = {0x0};
+			g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 			if (!fu_ch347_device_write(self,
 						   FU_CH347_CMD_SPI_OUT,
 						   fu_chunk_get_data(chk),

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -465,7 +465,7 @@ fu_ebitdo_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) fw_hdr = NULL;
 	g_autoptr(GBytes) fw_payload = NULL;
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 	const guint32 app_key_index[16] = {0x186976e5,
 					   0xcac67acd,
 					   0x38f27fee,
@@ -525,9 +525,9 @@ fu_ebitdo_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* flash the firmware in 32 byte blocks */
-	chunks = fu_chunk_array_new_from_bytes(fw_payload, 0x0, 0x0, 32);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw_payload, 0x0, 32);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		g_debug("writing %u bytes to 0x%04x of 0x%04x",
 			fu_chunk_get_data_sz(chk),
 			fu_chunk_get_address(chk),
@@ -552,7 +552,7 @@ fu_ebitdo_device_write_firmware(FuDevice *device,
 		}
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						i + 1,
-						chunks->len);
+						fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -400,20 +400,20 @@ fu_focalfp_hid_device_setup(FuDevice *device, GError **error)
 
 static gboolean
 fu_focalfp_hid_device_write_chunks(FuFocalfpHidDevice *self,
-				   GPtrArray *chunks,
+				   FuChunkArray *chunks,
 				   FuProgress *progress,
 				   GError **error)
 {
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		guint8 uc_packet_type = MID_PACKET;
 
 		if (i == 0)
 			uc_packet_type = FIRST_PACKET;
-		else if (i == chunks->len - 1)
+		else if (i == fu_chunk_array_length(chunks) - 1)
 			uc_packet_type = END_PACKET;
 
 		if (!fu_focalfp_hid_device_send_data(self,
@@ -447,7 +447,7 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	guint16 us_ic_id = 0;
 	guint32 checksum = 0;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -484,7 +484,7 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send packet data */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, MAX_USB_PACKET_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, MAX_USB_PACKET_SIZE);
 	if (!fu_focalfp_hid_device_write_chunks(self,
 						chunks,
 						fu_progress_get_child(progress),

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -417,13 +417,13 @@ fu_goodixtp_brlb_device_write_image(FuGoodixtpBrlbDevice *self,
 				    GError **error)
 {
 	g_autoptr(GBytes) blob = fu_firmware_get_bytes(img, NULL);
-	g_autoptr(GPtrArray) chunks =
-	    fu_chunk_array_new_from_bytes(blob, fu_firmware_get_addr(img), 0x0, RAM_BUFFER_SIZE);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(blob, fu_firmware_get_addr(img), RAM_BUFFER_SIZE);
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_goodixtp_brlb_device_update_process(self, chk, error))
 			return FALSE;
 		fu_device_sleep(FU_DEVICE(self), 20);

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -463,13 +463,13 @@ fu_goodixtp_gtx8_device_write_image(FuGoodixtpGtx8Device *self,
 				    GError **error)
 {
 	g_autoptr(GBytes) blob = fu_firmware_get_bytes(img, NULL);
-	g_autoptr(GPtrArray) chunks =
-	    fu_chunk_array_new_from_bytes(blob, fu_firmware_get_addr(img), 0x0, RAM_BUFFER_SIZE);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(blob, fu_firmware_get_addr(img), RAM_BUFFER_SIZE);
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_goodixtp_gtx8_device_update_process(self, chk, error))
 			return FALSE;
 		fu_device_sleep(FU_DEVICE(self), 20);

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -84,7 +84,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 	FuDevice *parent = fu_device_get_parent(device);
 	const guint block_size = 1024;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 	FuHailuckTpDeviceReq req = {
 	    .type = 0xff,
 	    .success = 0xff,
@@ -114,9 +114,9 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, block_size);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, block_size);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		g_autoptr(GByteArray) buf = g_byte_array_new();
 
 		/* write block */
@@ -162,7 +162,7 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						i + 1,
-						chunks->len);
+						fu_chunk_array_length(chunks));
 	}
 	fu_device_sleep(device, 50);
 	fu_progress_step_done(progress);

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -577,14 +577,14 @@ fu_igsc_device_no_update(FuIgscDevice *self, GError **error)
 
 static gboolean
 fu_igsc_device_write_chunks(FuIgscDevice *self,
-			    GPtrArray *chunks,
+			    FuChunkArray *chunks,
 			    FuProgress *progress,
 			    GError **error)
 {
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_igsc_device_update_data(self,
 						fu_chunk_get_data(chk),
 						fu_chunk_get_data_sz(chk),
@@ -636,7 +636,7 @@ fu_igsc_device_write_blob(FuIgscDevice *self,
 	guint32 sts5 = 0;
 	gsize payloadsz = fu_mei_device_get_max_msg_length(FU_MEI_DEVICE(self)) -
 			  sizeof(struct gsc_fwu_heci_data_req);
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	if (payload_type == GSC_FWU_HECI_PAYLOAD_TYPE_GFX_FW) {
@@ -671,7 +671,7 @@ fu_igsc_device_write_blob(FuIgscDevice *self,
 	fu_progress_step_done(progress);
 
 	/* data */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, payloadsz);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, payloadsz);
 	if (!fu_igsc_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -362,7 +362,7 @@ fu_intel_usb4_device_nvm_write(FuDevice *device,
 			       GError **error)
 {
 	guint8 metadata[4];
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	if (nvm_addr % 4 != 0) {
 		g_set_error(error,
@@ -392,12 +392,12 @@ fu_intel_usb4_device_nvm_write(FuDevice *device,
 	}
 
 	/* write data in 64 byte blocks */
-	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 0x0, 64);
+	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 64);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
 		/* write data to mbox data regs */
 		if (!fu_intel_usb4_device_mbox_data_write(device,

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -687,13 +687,11 @@ fu_logitech_bulkcontroller_device_write_fw(FuLogitechBulkcontrollerDevice *self,
 					   FuProgress *progress,
 					   GError **error)
 {
-	g_autoptr(GPtrArray) chunks = NULL;
-
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, PAYLOAD_SIZE);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 0x0, PAYLOAD_SIZE);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		g_autoptr(GByteArray) data_pkt = g_byte_array_new();
 		g_byte_array_append(data_pkt, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 		if (!fu_logitech_bulkcontroller_device_send_upd_cmd(self,

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -365,13 +365,11 @@ fu_logitech_scribe_device_write_fw(FuLogitechScribeDevice *self,
 				   FuProgress *progress,
 				   GError **error)
 {
-	g_autoptr(GPtrArray) chunks = NULL;
-
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, PAYLOAD_SIZE);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 0x0, PAYLOAD_SIZE);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		g_autoptr(GByteArray) data_pkt = g_byte_array_new();
 		g_byte_array_append(data_pkt, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 		if (!fu_logitech_scribe_device_send_upd_cmd(self,

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -283,7 +283,7 @@ fu_logitech_tap_hdmi_device_ait_finalize_update(FuLogitechTapHdmiDevice *self, G
 
 static gboolean
 fu_logitech_tap_hdmi_device_write_fw(FuLogitechTapHdmiDevice *self,
-				     GPtrArray *chunks,
+				     FuChunkArray *chunks,
 				     FuProgress *progress,
 				     GError **error)
 {
@@ -293,9 +293,9 @@ fu_logitech_tap_hdmi_device_write_fw(FuLogitechTapHdmiDevice *self,
 
 	/* write */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		/* if needed, pad the last block to kLogiDefaultImageBlockSize size,
 		 * so that device always gets each block of kLogiDefaultImageBlockSize */
 		g_autofree guint8 *data_pkt = g_malloc0(kLogiDefaultImageBlockSize);
@@ -338,7 +338,7 @@ fu_logitech_tap_hdmi_device_write_firmware(FuDevice *device,
 	FuLogitechTapHdmiDevice *self = FU_LOGITECH_TAP_HDMI_DEVICE(device);
 	g_autofree gchar *old_firmware_version = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* for troubleshooting purpose */
 	old_firmware_version = g_strdup(fu_device_get_version(device));
@@ -355,7 +355,7 @@ fu_logitech_tap_hdmi_device_write_firmware(FuDevice *device,
 
 	/* write */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, kLogiDefaultImageBlockSize);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, kLogiDefaultImageBlockSize);
 	if (!fu_logitech_tap_hdmi_device_write_fw(self,
 						  chunks,
 						  fu_progress_get_child(progress),

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -1507,18 +1507,18 @@ fu_nordic_hid_cfg_channel_write_firmware_blob(FuNordicHidCfgChannel *self,
 					      GError **error)
 {
 	g_autoptr(FuNordicCfgChannelDfuInfo) dfu_info = g_new0(FuNordicCfgChannelDfuInfo, 1);
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	if (!fu_nordic_hid_cfg_channel_dfu_sync(self, dfu_info, DFU_STATE_ACTIVE, error))
 		return FALSE;
 
-	chunks = fu_chunk_array_new_from_bytes(blob, 0, 0, dfu_info->sync_buffer_size);
+	chunks = fu_chunk_array_new_from_bytes(blob, 0, dfu_info->sync_buffer_size);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
-		gboolean is_last = (i == chunks->len - 1);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
+		gboolean is_last = (i == fu_chunk_array_length(chunks) - 1);
 		if (!fu_nordic_hid_cfg_channel_write_firmware_chunk(self, chk, is_last, error)) {
 			g_prefix_error(error, "chunk %u: ", fu_chunk_get_idx(chk));
 			return FALSE;

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -411,7 +411,7 @@ fu_parade_lspcon_flash_write(FuParadeLspconDevice *self,
 	FuI2cDevice *i2c_device = FU_I2C_DEVICE(self);
 	const guint8 unlock_writes[] = {0xaa, 0x55, 0x50, 0x41, 0x52, 0x44};
 	gsize data_len = g_bytes_get_size(data);
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* address must be 256-byte aligned */
 	g_return_val_if_fail((base_address & 0xFF) == 0, FALSE);
@@ -435,9 +435,9 @@ fu_parade_lspcon_flash_write(FuParadeLspconDevice *self,
 	if (!fu_parade_lspcon_write_register(self, REG_ADDR_CLT2SPI, 0, error))
 		return FALSE;
 
-	chunks = fu_chunk_array_new_from_bytes(data, base_address, 0, 256);
-	for (gsize i = 0; i < chunks->len; i++) {
-		FuChunk *chunk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(data, base_address, 256);
+	for (gsize i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chunk = fu_chunk_array_index(chunks, i);
 		guint32 address = fu_chunk_get_address(chunk);
 		guint32 chunk_size = fu_chunk_get_data_sz(chunk);
 		guint8 write_data[257] = {0x0};

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -374,30 +374,29 @@ fu_pxi_receiver_device_write_chunk(FuDevice *device, FuChunk *chk, GError **erro
 	FuPxiReceiverDevice *self = FU_PXI_RECEIVER_DEVICE(device);
 	guint32 prn = 0;
 	guint16 checksum;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
+	g_autoptr(GBytes) chk_bytes = fu_chunk_get_bytes(chk);
 
 	/* send create fw object command */
 	if (!fu_pxi_receiver_device_fw_object_create(device, chk, error))
 		return FALSE;
 
 	/* write payload */
-	chunks = fu_chunk_array_new(fu_chunk_get_data(chk),
-				    fu_chunk_get_data_sz(chk),
-				    fu_chunk_get_address(chk),
-				    0x0,
-				    self->fwstate.mtu_size);
+	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
+					       fu_chunk_get_address(chk),
+					       self->fwstate.mtu_size);
 
 	/* the checksum of chunk */
 	checksum = fu_sum16(fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 	self->fwstate.checksum += checksum;
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk2 = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk2 = fu_chunk_array_index(chunks, i);
 		if (!fu_pxi_receiver_device_write_payload(device, chk2, error))
 			return FALSE;
 		prn++;
 		/* check crc at fw when PRN over threshold write or
 		 * offset reach max object sz or write offset reach fw length */
-		if (prn >= self->fwstate.prn_threshold || i == chunks->len - 1) {
+		if (prn >= self->fwstate.prn_threshold || i == fu_chunk_array_length(chunks) - 1) {
 			if (!fu_pxi_receiver_device_check_crc(device,
 							      self->fwstate.checksum,
 							      error))
@@ -541,7 +540,7 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 {
 	FuPxiReceiverDevice *self = FU_PXI_RECEIVER_DEVICE(device);
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -563,19 +562,19 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
 	/* prepare write fw into device */
 	self->fwstate.offset = 0;
 	self->fwstate.checksum = 0;
 
 	/* write fw into device */
-	for (guint i = self->fwstate.offset; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	for (guint i = self->fwstate.offset; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_pxi_receiver_device_write_chunk(device, chk, error))
 			return FALSE;
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + self->fwstate.offset + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -641,11 +641,11 @@ flash_iface_write(FuRealtekMstDevice *self,
 		  GError **error)
 {
 	gsize total_size = g_bytes_get_size(data);
-	g_autoptr(GPtrArray) chunks = fu_chunk_array_new_from_bytes(data, address, 0, 256);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(data, address, 256);
 
 	g_debug("write %#" G_GSIZE_MODIFIER "x bytes at %#08x", total_size, address);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chunk = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chunk = fu_chunk_array_index(chunks, i);
 		guint32 chunk_address = fu_chunk_get_address(chunk);
 		guint32 chunk_size = fu_chunk_get_data_sz(chunk);
 
@@ -691,7 +691,7 @@ flash_iface_write(FuRealtekMstDevice *self,
 				       address);
 			return FALSE;
 		}
-		fu_progress_set_percentage_full(progress, i + 1, chunks->len);
+		fu_progress_set_percentage_full(progress, i + 1, fu_chunk_array_length(chunks));
 	}
 
 	return TRUE;

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -338,7 +338,7 @@ fu_rts54hid_device_write_firmware(FuDevice *device,
 {
 	FuRts54HidDevice *self = FU_RTS54HID_DEVICE(device);
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -362,12 +362,9 @@ fu_rts54hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       0x00, /* start addr */
-					       0x00, /* page_sz */
-					       FU_RTS54HID_TRANSFER_BLOCK_SIZE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, FU_RTS54HID_TRANSFER_BLOCK_SIZE);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		/* write chunk */
 		if (!fu_rts54hid_device_write_flash(self,
 						    fu_chunk_get_address(chk),
@@ -379,7 +376,7 @@ fu_rts54hid_device_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -431,7 +431,7 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 {
 	FuRts54HubDevice *self = FU_RTS54HUB_DEVICE(device);
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -472,12 +472,9 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 	}
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       0x00, /* start addr */
-					       0x00, /* page_sz */
-					       FU_RTS54HUB_DEVICE_BLOCK_SIZE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, FU_RTS54HUB_DEVICE_BLOCK_SIZE);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
 		/* write chunk */
 		if (!fu_rts54hub_device_write_flash(self,
@@ -490,7 +487,7 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -201,7 +201,7 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	guint8 write_buf[ISP_PACKET_SIZE] = {0x0};
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -295,12 +295,9 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       0x00, /* start addr */
-					       0x00, /* page_sz */
-					       ISP_DATA_BLOCKSIZE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, ISP_DATA_BLOCKSIZE);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_rts54hub_rtd21xx_device_read_status(FU_RTS54HUB_RTD21XX_DEVICE(self),
 							    NULL,
 							    error))
@@ -320,7 +317,7 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -233,7 +233,7 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	guint8 write_buf[ISP_PACKET_SIZE] = {0x0};
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -342,12 +342,9 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       0x00, /* start addr */
-					       0x00, /* page_sz */
-					       ISP_DATA_BLOCKSIZE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, ISP_DATA_BLOCKSIZE);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_rts54hub_rtd21xx_device_read_status(FU_RTS54HUB_RTD21XX_DEVICE(self),
 							    NULL,
 							    error))
@@ -367,7 +364,7 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -206,7 +206,7 @@ fu_scsi_device_write_firmware(FuDevice *device,
 	guint32 chunksz = 0x1000;
 	guint32 offset = 0;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* get default image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -214,14 +214,14 @@ fu_scsi_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* prepare chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, 0x00, chunksz);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, chunksz);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	fu_progress_set_steps(progress, chunks->len);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 
 	/* write each block */
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		guint8 cdb[WRITE_BUF_CMDLEN] = {WRITE_BUFFER_CMD,
 						BUFFER_FFU_MODE,
 						0x0 /* buf_id */};

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -335,7 +335,7 @@ fu_superio_it55_device_write_attempt(FuDevice *device,
 	const guint8 *fw_data = NULL;
 	g_autoptr(GBytes) erased_fw = NULL;
 	g_autoptr(GBytes) written_fw = NULL;
-	g_autoptr(GPtrArray) blocks = NULL;
+	g_autoptr(FuChunkArray) blocks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -364,9 +364,9 @@ fu_superio_it55_device_write_attempt(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write everything but the first kilobyte */
-	blocks = fu_chunk_array_new_from_bytes(firmware, 0x00, 0x00, BLOCK_SIZE);
-	for (guint i = 0; i < blocks->len; ++i) {
-		FuChunk *block = g_ptr_array_index(blocks, i);
+	blocks = fu_chunk_array_new_from_bytes(firmware, 0x00, BLOCK_SIZE);
+	for (guint i = 0; i < fu_chunk_array_length(blocks); ++i) {
+		g_autoptr(FuChunk) block = fu_chunk_array_index(blocks, i);
 		gboolean first = (i == 0);
 		guint32 offset = 0;
 		guint32 bytes_left = fu_chunk_get_data_sz(block);
@@ -402,7 +402,7 @@ fu_superio_it55_device_write_attempt(FuDevice *device,
 		}
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)blocks->len);
+						(gsize)fu_chunk_array_length(blocks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -617,15 +617,15 @@ fu_superio_it89_device_get_jedec_id(FuSuperioDevice *self, guint8 *id, GError **
 
 static gboolean
 fu_superio_it89_device_write_chunks(FuSuperioDevice *self,
-				    GPtrArray *chunks,
+				    FuChunkArray *chunks,
 				    FuProgress *progress,
 				    GError **error)
 {
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len - 1);
-	for (guint i = 0; i < chunks->len - 1; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks) - 1);
+	for (guint i = 0; i < fu_chunk_array_length(chunks) - 1; i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
 		/* try this many times; the failure-to-flash case leaves you
 		 * without a keyboard and future boot may completely fail */
@@ -663,7 +663,7 @@ fu_superio_it89_device_write_firmware(FuDevice *device,
 	guint8 id[4] = {0x0};
 	g_autoptr(GBytes) fw_fixed = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -708,7 +708,7 @@ fu_superio_it89_device_write_firmware(FuDevice *device,
 	}
 
 	/* chunks of 1kB, skipping the final chunk */
-	chunks = fu_chunk_array_new_from_bytes(fw_fixed, 0x00, 0x00, 0x400);
+	chunks = fu_chunk_array_new_from_bytes(fw_fixed, 0x00, 0x400);
 	if (!fu_superio_it89_device_write_chunks(self,
 						 chunks,
 						 fu_progress_get_child(progress),

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -671,7 +671,7 @@ fu_synaptics_cape_device_write_firmware_image(FuSynapticsCapeDevice *self,
 					      FuProgress *progress,
 					      GError **error)
 {
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	g_return_val_if_fail(FU_IS_SYNAPTICS_CAPE_DEVICE(self), FALSE);
 	g_return_val_if_fail(fw != NULL, FALSE);
@@ -680,13 +680,12 @@ fu_synaptics_cape_device_write_firmware_image(FuSynapticsCapeDevice *self,
 	chunks =
 	    fu_chunk_array_new_from_bytes(fw,
 					  0x00,
-					  0x00,
 					  sizeof(guint32) * FU_SYNAPTICS_CAPE_CMD_WRITE_DATAL_LEN);
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		gsize bufsz = fu_chunk_get_data_sz(chk);
 		g_autofree guint32 *buf32 = NULL;
 

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -365,13 +365,13 @@ fu_tpm_v2_device_upgrade_data(FuTpmV2Device *self, GBytes *fw, FuProgress *progr
 	TPMT_HA *first_digest;
 	TPMT_HA *next_digest;
 	TSS2_RC rc;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, TPM2_MAX_DIGEST_BUFFER);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, TPM2_MAX_DIGEST_BUFFER);
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		TPM2B_MAX_BUFFER data = {.size = g_bytes_get_size(fw)};
 		if (!fu_memcpy_safe((guint8 *)data.buffer,
 				    sizeof(data.buffer),

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -177,12 +177,12 @@ fu_uf2_firmware_parse(FuFirmware *firmware,
 	FuUf2Firmware *self = FU_UF2_FIRMWARE(firmware);
 	g_autoptr(GByteArray) tmp = g_byte_array_new();
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* read in fixed sized chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x0, 512);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 512);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_uf2_firmware_parse_chunk(self, chk, tmp, error))
 			return FALSE;
 	}
@@ -227,7 +227,7 @@ fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 	FuUf2Firmware *self = FU_UF2_FIRMWARE(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* data first */
 	fw = fu_firmware_get_bytes_with_patches(firmware, error);
@@ -235,11 +235,11 @@ fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* write in chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw, fu_firmware_get_addr(firmware), 0x0, 256);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, fu_firmware_get_addr(firmware), 256);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		g_autoptr(GByteArray) tmp = NULL;
-		tmp = fu_uf2_firmware_write_chunk(self, chk, chunks->len, error);
+		tmp = fu_uf2_firmware_write_chunk(self, chk, fu_chunk_array_length(chunks), error);
 		if (tmp == NULL)
 			return NULL;
 		g_byte_array_append(buf, tmp->data, tmp->len);

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -176,15 +176,15 @@ fu_{{vendor}}_{{example}}_device_prepare_firmware(FuDevice *device,
 
 static gboolean
 fu_{{vendor}}_{{example}}_device_write_blocks(Fu{{Vendor}}{{Example}}Device *self,
-				      GPtrArray *chunks,
+				      FuChunkArray *chunks,
 				      FuProgress *progress,
 				      GError **error)
 {
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
 		/* TODO: send to hardware */
 		g_assert(chk != NULL);
@@ -239,7 +239,7 @@ fu_{{vendor}}_{{example}}_device_write_firmware(FuDevice *device,
 {
 	Fu{{Vendor}}{{Example}}Device *self = FU_{{VENDOR}}_{{EXAMPLE}}_DEVICE(device);
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -253,10 +253,7 @@ fu_{{vendor}}_{{example}}_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       self->start_addr,
-					       0x00, /* page_sz */
-					       64 /* block_size */);
+	chunks = fu_chunk_array_new_from_bytes(fw, self->start_addr, 64 /* block_size */);
 	if (!fu_{{vendor}}_{{example}}_device_write_blocks(self,
 						   chunks,
 						   fu_progress_get_child(progress),

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -313,7 +313,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	guint8 write_buf[ISP_PACKET_SIZE] = {0};
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -424,12 +424,9 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       0x00, /* start addr */
-					       0x00, /* page_sz */
-					       ISP_DATA_BLOCKSIZE);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, ISP_DATA_BLOCKSIZE);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_vli_usbhub_device_rtd21xx_read_status(self, NULL, error))
 			return FALSE;
 		if (!fu_vli_usbhub_device_i2c_write(parent,
@@ -447,7 +444,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 		/* update progress */
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -243,7 +243,7 @@ fu_wacom_aes_device_write_block(FuWacomAesDevice *self,
 
 static gboolean
 fu_wacom_aes_device_write_firmware(FuDevice *device,
-				   GPtrArray *chunks,
+				   FuChunkArray *chunks,
 				   FuProgress *progress,
 				   GError **error)
 {
@@ -261,8 +261,8 @@ fu_wacom_aes_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write */
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (!fu_wacom_aes_device_write_block(self,
 						     fu_chunk_get_idx(chk),
 						     fu_chunk_get_address(chk),
@@ -272,7 +272,7 @@ fu_wacom_aes_device_write_firmware(FuDevice *device,
 			return FALSE;
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 	return TRUE;

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -175,7 +175,7 @@ fu_wacom_device_write_firmware(FuDevice *device,
 	FuWacomDevicePrivate *priv = GET_PRIVATE(self);
 	FuWacomDeviceClass *klass = FU_WACOM_DEVICE_GET_CLASS(device);
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* use the correct image from the firmware */
 	g_debug("using element at addr 0x%0x", (guint)fu_firmware_get_addr(firmware));
@@ -208,10 +208,7 @@ fu_wacom_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* flash chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw,
-					       priv->flash_base_addr,
-					       0x00, /* page_sz */
-					       priv->flash_block_size);
+	chunks = fu_chunk_array_new_from_bytes(fw, priv->flash_base_addr, priv->flash_block_size);
 	return klass->write_firmware(device, chunks, progress, error);
 }
 

--- a/plugins/wacom-raw/fu-wacom-device.h
+++ b/plugins/wacom-raw/fu-wacom-device.h
@@ -16,7 +16,7 @@ G_DECLARE_DERIVABLE_TYPE(FuWacomDevice, fu_wacom_device, FU, WACOM_DEVICE, FuUde
 struct _FuWacomDeviceClass {
 	FuUdevDeviceClass parent_class;
 	gboolean (*write_firmware)(FuDevice *self,
-				   GPtrArray *chunks,
+				   FuChunkArray *chunks,
 				   FuProgress *progress,
 				   GError **error);
 };

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -210,7 +210,7 @@ fu_wacom_emr_device_write_block(FuWacomEmrDevice *self,
 
 static gboolean
 fu_wacom_emr_device_write_firmware(FuDevice *device,
-				   GPtrArray *chunks,
+				   FuChunkArray *chunks,
 				   FuProgress *progress,
 				   GError **error)
 {
@@ -241,8 +241,8 @@ fu_wacom_emr_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write */
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 		if (fu_wacom_common_block_is_empty(fu_chunk_get_data(chk),
 						   fu_chunk_get_data_sz(chk)))
 			continue;
@@ -255,7 +255,7 @@ fu_wacom_emr_device_write_firmware(FuDevice *device,
 			return FALSE;
 		fu_progress_set_percentage_full(fu_progress_get_child(progress),
 						(gsize)i + 1,
-						(gsize)chunks->len);
+						(gsize)fu_chunk_array_length(chunks));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -517,7 +517,7 @@ fu_wac_device_write_firmware(FuDevice *device,
 	for (guint i = 0; i < self->flash_descriptors->len; i++) {
 		FuWacFlashDescriptor *fd = g_ptr_array_index(self->flash_descriptors, i);
 		GBytes *blob_block;
-		g_autoptr(GPtrArray) chunks = NULL;
+		g_autoptr(FuChunkArray) chunks = NULL;
 
 		/* if page is protected */
 		if (fu_wav_device_flash_descriptor_is_wp(fd))
@@ -542,12 +542,10 @@ fu_wac_device_write_firmware(FuDevice *device,
 			return FALSE;
 
 		/* write block in chunks */
-		chunks = fu_chunk_array_new_from_bytes(blob_block,
-						       fd->start_addr,
-						       0, /* page_sz */
-						       self->write_block_sz);
-		for (guint j = 0; j < chunks->len; j++) {
-			FuChunk *chk = g_ptr_array_index(chunks, j);
+		chunks =
+		    fu_chunk_array_new_from_bytes(blob_block, fd->start_addr, self->write_block_sz);
+		for (guint j = 0; j < fu_chunk_array_length(chunks); j++) {
+			g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 			g_autoptr(GBytes) blob_chunk = fu_chunk_get_bytes(chk);
 			if (!fu_wac_device_write_block(self,
 						       fu_chunk_get_address(chk),

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -95,16 +95,13 @@ fu_wac_module_bluetooth_id9_write_blocks(FuWacModule *self,
 					 FuProgress *progress,
 					 GError **error)
 {
-	g_autoptr(GPtrArray) chunks = fu_chunk_array_new_from_bytes(data, 0, 0, block_len);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(data, 0, block_len);
 
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		if (!fu_wac_module_bluetooth_id9_write_block(self,
-							     phase,
-							     g_ptr_array_index(chunks, i),
-							     progress,
-							     error))
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
+		if (!fu_wac_module_bluetooth_id9_write_block(self, phase, chk, progress, error))
 			return FALSE;
 
 		fu_progress_step_done(progress);

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -291,15 +291,15 @@ fu_wistron_dock_device_write_img_data(FuWistronDockDevice *self,
 
 static gboolean
 fu_wistron_dock_device_write_blocks(FuWistronDockDevice *self,
-				    GPtrArray *chunks,
+				    FuChunkArray *chunks,
 				    FuProgress *progress,
 				    GError **error)
 {
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_set_steps(progress, chunks->len);
-	for (guint i = 0; i < chunks->len; i++) {
-		FuChunk *chk = g_ptr_array_index(chunks, i);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
 		/* set address */
 		if (!fu_wistron_dock_device_set_img_address(self,
@@ -400,7 +400,7 @@ fu_wistron_dock_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) fw_cbin = NULL;
 	g_autoptr(GBytes) fw_wdfl = NULL;
 	g_autoptr(GBytes) fw_wsig = NULL;
-	g_autoptr(GPtrArray) chunks = NULL;
+	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -438,10 +438,7 @@ fu_wistron_dock_device_write_firmware(FuDevice *device,
 	fw_cbin = fu_firmware_get_image_by_id_bytes(firmware, FU_FIRMWARE_ID_PAYLOAD, error);
 	if (fw_cbin == NULL)
 		return FALSE;
-	chunks = fu_chunk_array_new_from_bytes(fw_cbin,
-					       0x0,
-					       0x0, /* page_sz */
-					       FU_WISTRON_DOCK_TRANSFER_BLOCK_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw_cbin, 0x0, FU_WISTRON_DOCK_TRANSFER_BLOCK_SIZE);
 	if (!fu_wistron_dock_device_write_blocks(self,
 						 chunks,
 						 fu_progress_get_child(progress),


### PR DESCRIPTION
When chunking a 1GiB firmware into 32 byte blocks an additional 1.3GiB was being used for the overhead for the FuChunk GObjects. We only need the blocks one at a time, and so only allocate them as required.

Create a new `FuChunkArray` object which can be used in preference to fu_chunk_array_new() when the page size is zero.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
