### PR TITLE
Add a FuPlugin->ready() function to be called when coldplug has compl…

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -476,6 +476,8 @@ fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return "modular";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY)
 		return "measure-system-integrity";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_READY)
+		return "ready";
 	return NULL;
 }
 
@@ -528,6 +530,8 @@ fwupd_plugin_flag_from_string(const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_MODULAR;
 	if (g_strcmp0(plugin_flag, "measure-system-integrity") == 0)
 		return FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;
+	if (g_strcmp0(plugin_flag, "ready") == 0)
+		return FWUPD_PLUGIN_FLAG_READY;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -955,6 +955,14 @@ typedef enum {
  */
 #define FWUPD_PLUGIN_FLAG_ESP_NOT_VALID (1llu << 16)
 /**
+ * FWUPD_PLUGIN_FLAG_READY:
+ *
+ * The plugin is ready for use and all devices have been coldplugged.
+ *
+ * Since: 1.9.6
+ */
+#define FWUPD_PLUGIN_FLAG_READY (1llu << 17)
+/**
  * FWUPD_PLUGIN_FLAG_UNKNOWN:
  *
  * The plugin flag is Unknown.

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -45,6 +45,10 @@ fu_plugin_runner_startup(FuPlugin *self,
 			 FuProgress *progress,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 gboolean
+fu_plugin_runner_ready(FuPlugin *self,
+		       FuProgress *progress,
+		       GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
 fu_plugin_runner_coldplug(FuPlugin *self,
 			  FuProgress *progress,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -897,6 +897,54 @@ fu_plugin_runner_startup(FuPlugin *self, FuProgress *progress, GError **error)
 }
 
 /**
+ * fu_plugin_runner_ready:
+ * @self: a #FuPlugin
+ * @error: (nullable): optional return location for an error
+ *
+ * Runs the ready routine for the plugin
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fu_plugin_runner_ready(FuPlugin *self, FuProgress *progress, GError **error)
+{
+	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
+	g_autoptr(GError) error_local = NULL;
+
+	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
+
+	/* progress */
+	fu_progress_set_name(progress, fu_plugin_get_name(self));
+	if (fu_plugin_has_flag(self, FWUPD_PLUGIN_FLAG_DISABLED))
+		return TRUE;
+	fu_plugin_add_flag(self, FWUPD_PLUGIN_FLAG_READY);
+	if (vfuncs->ready == NULL)
+		return TRUE;
+
+	/* optional */
+	g_debug("ready(%s)", fu_plugin_get_name(self));
+	if (!vfuncs->ready(self, progress, &error_local)) {
+		if (error_local == NULL) {
+			g_critical("unset plugin error in ready(%s)", fu_plugin_get_name(self));
+			g_set_error_literal(&error_local,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
+					    "unspecified error");
+		}
+		g_propagate_prefixed_error(error,
+					   g_steal_pointer(&error_local),
+					   "failed to ready using %s: ",
+					   fu_plugin_get_name(self));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+/**
  * fu_plugin_runner_init:
  * @self: a #FuPlugin
  *

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -101,6 +101,23 @@ struct _FuPluginClass {
 	 **/
 	gboolean (*startup)(FuPlugin *self, FuProgress *progress, GError **error);
 	/**
+	 * ready:
+	 * @self: a #FuPlugin
+	 * @progress: a #FuProgress
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Tells the plugin that all devices have been coldplugged and the plugin is
+	 * ready to be used.
+	 *
+	 * Returns: TRUE for success or FALSE for failure.
+	 *
+	 * NOTE: Any plugins not intended for the system or that have failure communicating
+	 * with the device should return %FALSE and set @error.
+	 *
+	 * Since: 1.9.6
+	 **/
+	gboolean (*ready)(FuPlugin *self, FuProgress *progress, GError **error);
+	/**
 	 * coldplug:
 	 * @self: a #FuPlugin
 	 * @progress: a #FuProgress

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1613,6 +1613,8 @@ fu_util_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return NULL;
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_USER_WARNING)
 		return NULL;
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_READY)
+		return NULL;
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_REQUIRE_HWID) {
 		/* TRANSLATORS: Plugin is active only if hardware is found */
 		return _("Enabled if hardware matches");
@@ -1689,6 +1691,7 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_UNKNOWN:
 	case FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE:
 	case FWUPD_PLUGIN_FLAG_USER_WARNING:
+	case FWUPD_PLUGIN_FLAG_READY:
 		return NULL;
 	case FWUPD_PLUGIN_FLAG_NONE:
 	case FWUPD_PLUGIN_FLAG_REQUIRE_HWID:


### PR DESCRIPTION
…eted

This allows plugin-specific functionality to be run only when all the plugins and backends have been coldplugged.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
