### PR TITLE
trivial: Make usable under Visual Studio

### DIFF
--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -143,13 +143,14 @@ fwupd_client_install_bytes(FwupdClient *self,
 			   FwupdInstallFlags install_flags,
 			   GCancellable *cancellable,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT;
+G_DEPRECATED_FOR(fwupd_client_install_release2)
 gboolean
 fwupd_client_install_release(FwupdClient *self,
 			     FwupdDevice *device,
 			     FwupdRelease *release,
 			     FwupdInstallFlags install_flags,
 			     GCancellable *cancellable,
-			     GError **error) G_DEPRECATED_FOR(fwupd_client_install_release2);
+			     GError **error);
 gboolean
 fwupd_client_install_release2(FwupdClient *self,
 			      FwupdDevice *device,
@@ -172,11 +173,12 @@ fwupd_client_update_metadata_bytes(FwupdClient *self,
 				   GBytes *signature,
 				   GCancellable *cancellable,
 				   GError **error) G_GNUC_WARN_UNUSED_RESULT;
+G_DEPRECATED_FOR(fwupd_client_refresh_remote2)
 gboolean
 fwupd_client_refresh_remote(FwupdClient *self,
 			    FwupdRemote *remote,
 			    GCancellable *cancellable,
-			    GError **error) G_DEPRECATED_FOR(fwupd_client_refresh_remote2);
+			    GError **error);
 gboolean
 fwupd_client_refresh_remote2(FwupdClient *self,
 			     FwupdRemote *remote,

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -318,6 +318,7 @@ gboolean
 fwupd_client_install_bytes_finish(FwupdClient *self,
 				  GAsyncResult *res,
 				  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+G_DEPRECATED_FOR(fwupd_client_install_release2_async)
 void
 fwupd_client_install_release_async(FwupdClient *self,
 				   FwupdDevice *device,
@@ -325,8 +326,7 @@ fwupd_client_install_release_async(FwupdClient *self,
 				   FwupdInstallFlags install_flags,
 				   GCancellable *cancellable,
 				   GAsyncReadyCallback callback,
-				   gpointer callback_data)
-    G_DEPRECATED_FOR(fwupd_client_install_release2_async);
+				   gpointer callback_data);
 void
 fwupd_client_install_release2_async(FwupdClient *self,
 				    FwupdDevice *device,
@@ -352,13 +352,13 @@ gboolean
 fwupd_client_update_metadata_bytes_finish(FwupdClient *self,
 					  GAsyncResult *res,
 					  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+G_DEPRECATED_FOR(fwupd_client_refresh_remote2_async)
 void
 fwupd_client_refresh_remote_async(FwupdClient *self,
 				  FwupdRemote *remote,
 				  GCancellable *cancellable,
 				  GAsyncReadyCallback callback,
-				  gpointer callback_data)
-    G_DEPRECATED_FOR(fwupd_client_refresh_remote2_async);
+				  gpointer callback_data);
 void
 fwupd_client_refresh_remote2_async(FwupdClient *self,
 				   FwupdRemote *remote,

--- a/libfwupd/fwupd-common.h
+++ b/libfwupd/fwupd-common.h
@@ -75,9 +75,10 @@ GChecksumType
 fwupd_checksum_guess_kind(const gchar *checksum);
 gchar *
 fwupd_checksum_format_for_display(const gchar *checksum);
+
+G_DEPRECATED_FOR(fwupd_client_set_user_agent_for_package)
 gchar *
-fwupd_build_user_agent(const gchar *package_name, const gchar *package_version)
-    G_DEPRECATED_FOR(fwupd_client_set_user_agent_for_package);
+fwupd_build_user_agent(const gchar *package_name, const gchar *package_version);
 gchar *
 fwupd_build_machine_id(const gchar *salt, GError **error);
 GHashTable *

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -153,11 +153,12 @@ const gchar *
 fwupd_release_get_license(FwupdRelease *self);
 void
 fwupd_release_set_license(FwupdRelease *self, const gchar *license);
+G_DEPRECATED_FOR(fwupd_release_get_flags)
 FwupdTrustFlags
-fwupd_release_get_trust_flags(FwupdRelease *self) G_DEPRECATED_FOR(fwupd_release_get_flags);
+fwupd_release_get_trust_flags(FwupdRelease *self);
+G_DEPRECATED_FOR(fwupd_release_set_flags)
 void
-fwupd_release_set_trust_flags(FwupdRelease *self, FwupdTrustFlags trust_flags)
-    G_DEPRECATED_FOR(fwupd_release_set_flags);
+fwupd_release_set_trust_flags(FwupdRelease *self, FwupdTrustFlags trust_flags);
 FwupdReleaseFlags
 fwupd_release_get_flags(FwupdRelease *self);
 void

--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -24,9 +24,9 @@ fwupd_remote_save_to_filename(FwupdRemote *self,
 			      const gchar *filename,
 			      GCancellable *cancellable,
 			      GError **error);
+G_DEPRECATED_FOR(fwupd_remote_add_flag)
 void
-fwupd_remote_set_enabled(FwupdRemote *self, gboolean enabled)
-    G_DEPRECATED_FOR(fwupd_remote_add_flag);
+fwupd_remote_set_enabled(FwupdRemote *self, gboolean enabled);
 void
 fwupd_remote_set_id(FwupdRemote *self, const gchar *id);
 void

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -110,15 +110,18 @@ const gchar *
 fwupd_remote_get_metadata_uri(FwupdRemote *self);
 const gchar *
 fwupd_remote_get_metadata_uri_sig(FwupdRemote *self);
+G_DEPRECATED_FOR(fwupd_remote_has_flag)
 gboolean
-fwupd_remote_get_enabled(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
+fwupd_remote_get_enabled(FwupdRemote *self);
+G_DEPRECATED_FOR(fwupd_remote_has_flag)
 gboolean
-fwupd_remote_get_approval_required(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
+fwupd_remote_get_approval_required(FwupdRemote *self);
+G_DEPRECATED_FOR(fwupd_remote_has_flag)
 gboolean
-fwupd_remote_get_automatic_reports(FwupdRemote *self) G_DEPRECATED_FOR(fwupd_remote_has_flag);
+fwupd_remote_get_automatic_reports(FwupdRemote *self);
+G_DEPRECATED_FOR(fwupd_remote_has_flag)
 gboolean
-fwupd_remote_get_automatic_security_reports(FwupdRemote *self)
-    G_DEPRECATED_FOR(fwupd_remote_has_flag);
+fwupd_remote_get_automatic_security_reports(FwupdRemote *self);
 guint64
 fwupd_remote_get_refresh_interval(FwupdRemote *self);
 


### PR DESCRIPTION
Even the docs say `G_DEPRECATED_FOR(...)` must be before the return type.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
