### PR TITLE
Add functionality to fix specific host security attributes

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -37,6 +37,8 @@ _fwupdmgr_cmd_list=(
 	'refresh'
 	'report-history'
 	'security'
+	'security-fix'
+	'security-undo'
 	'set-approved-firmware'
 	'set-bios-setting'
 	'switch-branch'

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -34,6 +34,8 @@ _fwupdtool_cmd_list=(
 	'monitor'
 	'reinstall'
 	'security'
+	'security-fix'
+	'security-undo'
 	'set-bios-setting'
 	'switch-branch'
 	'self-sign'

--- a/libfwupd/fwupd-client-sync.c
+++ b/libfwupd/fwupd-client-sync.c
@@ -2709,3 +2709,103 @@ fwupd_client_emulation_save(FwupdClient *self, GCancellable *cancellable, GError
 	}
 	return g_steal_pointer(&helper->bytes);
 }
+
+static void
+fwupd_client_fix_host_security_attr_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
+	helper->ret =
+	    fwupd_client_fix_host_security_attr_finish(FWUPD_CLIENT(source), res, &helper->error);
+	g_main_loop_quit(helper->loop);
+}
+
+/**
+ * fwupd_client_fix_host_security_attr:
+ * @self: a #FwupdClient
+ * @appstream_id: the HSI AppStream ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @error: (nullable): optional return location for an error
+ *
+ * Fix one specific security attribute.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_fix_host_security_attr(FwupdClient *self,
+				    const gchar *appstream_id,
+				    GCancellable *cancellable,
+				    GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(appstream_id != NULL, FALSE);
+	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* call async version and run loop until complete */
+	helper = fwupd_client_helper_new(self);
+	fwupd_client_fix_host_security_attr_async(self,
+						  appstream_id,
+						  cancellable,
+						  fwupd_client_fix_host_security_attr_cb,
+						  helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static void
+fwupd_client_undo_host_security_attr_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	FwupdClientHelper *helper = (FwupdClientHelper *)user_data;
+	helper->ret =
+	    fwupd_client_undo_host_security_attr_finish(FWUPD_CLIENT(source), res, &helper->error);
+	g_main_loop_quit(helper->loop);
+}
+
+/**
+ * fwupd_client_undo_host_security_attr:
+ * @self: a #FwupdClient
+ * @appstream_id: the HSI AppStream ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @error: (nullable): optional return location for an error
+ *
+ * Revert the fix to one specific security attribute.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_undo_host_security_attr(FwupdClient *self,
+				     const gchar *appstream_id,
+				     GCancellable *cancellable,
+				     GError **error)
+{
+	g_autoptr(FwupdClientHelper) helper = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(appstream_id != NULL, FALSE);
+	g_return_val_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* call async version and run loop until complete */
+	helper = fwupd_client_helper_new(self);
+	fwupd_client_undo_host_security_attr_async(self,
+						   appstream_id,
+						   cancellable,
+						   fwupd_client_undo_host_security_attr_cb,
+						   helper);
+	g_main_loop_run(helper->loop);
+	if (!helper->ret) {
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return FALSE;
+	}
+	return TRUE;
+}

--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -271,5 +271,15 @@ GBytes *
 fwupd_client_emulation_save(FwupdClient *self,
 			    GCancellable *cancellable,
 			    GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fwupd_client_fix_host_security_attr(FwupdClient *self,
+				    const gchar *appstream_id,
+				    GCancellable *cancellable,
+				    GError **error);
+gboolean
+fwupd_client_undo_host_security_attr(FwupdClient *self,
+				     const gchar *appstream_id,
+				     GCancellable *cancellable,
+				     GError **error);
 
 G_END_DECLS

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5962,6 +5962,162 @@ fwupd_client_emulation_save_finish(FwupdClient *self, GAsyncResult *res, GError 
 }
 
 static void
+fwupd_client_fix_host_security_attr_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_task_return_boolean(task, TRUE);
+}
+
+/**
+ * fwupd_client_fix_host_security_attr_async:
+ * @self: a #FwupdClient
+ * @appstream_id: HSI AppStream ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: (scope async) (closure callback_data): the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Fix one specific security attribute.
+ *
+ * Since: 1.9.6
+ **/
+void
+fwupd_client_fix_host_security_attr_async(FwupdClient *self,
+					  const gchar *appstream_id,
+					  GCancellable *cancellable,
+					  GAsyncReadyCallback callback,
+					  gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(appstream_id != NULL);
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+	g_dbus_proxy_call(priv->proxy,
+			  "FixHostSecurityAttr",
+			  g_variant_new("(s)", appstream_id),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_fix_host_security_attr_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_fix_host_security_attr_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.fix_host_security_attr_async].
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_fix_host_security_attr_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(g_task_is_valid(res, self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	return g_task_propagate_boolean(G_TASK(res), error);
+}
+
+static void
+fwupd_client_undo_host_security_attr_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_task_return_boolean(task, TRUE);
+}
+
+/**
+ * fwupd_client_undo_host_security_attr_async:
+ * @self: a #FwupdClient
+ * @appstream_id: HSI AppStream ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: (scope async) (closure callback_data): the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Reverts the fix to one specific security attribute.
+ *
+ * Since: 1.9.6
+ **/
+void
+fwupd_client_undo_host_security_attr_async(FwupdClient *self,
+					   const gchar *appstream_id,
+					   GCancellable *cancellable,
+					   GAsyncReadyCallback callback,
+					   gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(appstream_id != NULL);
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+	g_dbus_proxy_call(priv->proxy,
+			  "UndoHostSecurityAttr",
+			  g_variant_new("(s)", appstream_id),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_undo_host_security_attr_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_undo_host_security_attr_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.undo_host_security_attr_async].
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fwupd_client_undo_host_security_attr_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FALSE);
+	g_return_val_if_fail(g_task_is_valid(res, self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+	return g_task_propagate_boolean(G_TASK(res), error);
+}
+
+static void
 fwupd_client_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	FwupdClient *self = FWUPD_CLIENT(object);

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -440,6 +440,22 @@ GBytes *
 fwupd_client_emulation_save_finish(FwupdClient *self,
 				   GAsyncResult *res,
 				   GError **error) G_GNUC_WARN_UNUSED_RESULT;
+void
+fwupd_client_fix_host_security_attr_async(FwupdClient *self,
+					  const gchar *appstream_id,
+					  GCancellable *cancellable,
+					  GAsyncReadyCallback callback,
+					  gpointer callback_data);
+gboolean
+fwupd_client_fix_host_security_attr_finish(FwupdClient *self, GAsyncResult *res, GError **error);
+void
+fwupd_client_undo_host_security_attr_async(FwupdClient *self,
+					   const gchar *appstream_id,
+					   GCancellable *cancellable,
+					   GAsyncReadyCallback callback,
+					   gpointer callback_data);
+gboolean
+fwupd_client_undo_host_security_attr_finish(FwupdClient *self, GAsyncResult *res, GError **error);
 
 FwupdStatus
 fwupd_client_get_status(FwupdClient *self);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -607,6 +607,22 @@ G_BEGIN_DECLS
  **/
 #define FWUPD_RESULT_KEY_BIOS_SETTING_READ_ONLY "BiosSettingReadOnly"
 /**
+ * FWUPD_RESULT_KEY_KERNEL_CURRENT_VALUE:
+ *
+ * Result key to represent the current kernel setting.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_KERNEL_CURRENT_VALUE "KernelCurrentValue"
+/**
+ * FWUPD_RESULT_KEY_KERNEL_TARGET_VALUE:
+ *
+ * Result key to represent the target kernel setting.
+ *
+ * The D-Bus type signature string is 's' i.e. a string.
+ **/
+#define FWUPD_RESULT_KEY_KERNEL_TARGET_VALUE "KernelTargetValue"
+/**
  * FWUPD_RESULT_KEY_DISTRO_ID:
  *
  * Result key to represent the distribution ID.

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -39,6 +39,8 @@ struct _FwupdSecurityAttrClass {
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM:	Contact the firmware vendor for a update
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW:		Failure may be fixed by changing FW config
  * @FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS:		Failure may be fixed by changing OS config
+ * @FWUPD_SECURITY_ATTR_FLAG_CAN_FIX:			The failure can be automatically fixed
+ * @FWUPD_SECURITY_ATTR_FLAG_CAN_UNDO:			The fix can be automatically reverted
  *
  * The flags available for HSI attributes.
  **/
@@ -53,6 +55,8 @@ typedef enum {
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM = 1 << 11,
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW = 1 << 12,
 	FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS = 1 << 13,
+	FWUPD_SECURITY_ATTR_FLAG_CAN_FIX = 1 << 14,
+	FWUPD_SECURITY_ATTR_FLAG_CAN_UNDO = 1 << 15,
 } FwupdSecurityAttrFlags;
 
 /**
@@ -138,6 +142,14 @@ const gchar *
 fwupd_security_attr_get_bios_setting_current_value(FwupdSecurityAttr *self);
 void
 fwupd_security_attr_set_bios_setting_current_value(FwupdSecurityAttr *self, const gchar *value);
+const gchar *
+fwupd_security_attr_get_kernel_current_value(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_set_kernel_current_value(FwupdSecurityAttr *self, const gchar *value);
+const gchar *
+fwupd_security_attr_get_kernel_target_value(FwupdSecurityAttr *self);
+void
+fwupd_security_attr_set_kernel_target_value(FwupdSecurityAttr *self, const gchar *value);
 
 const gchar *
 fwupd_security_attr_get_appstream_id(FwupdSecurityAttr *self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -982,5 +982,15 @@ LIBFWUPD_1.9.4 {
 LIBFWUPD_1.9.6 {
   global:
     fwupd_checksum_type_to_string_display;
+    fwupd_client_fix_host_security_attr;
+    fwupd_client_fix_host_security_attr_async;
+    fwupd_client_fix_host_security_attr_finish;
+    fwupd_client_undo_host_security_attr;
+    fwupd_client_undo_host_security_attr_async;
+    fwupd_client_undo_host_security_attr_finish;
+    fwupd_security_attr_get_kernel_current_value;
+    fwupd_security_attr_get_kernel_target_value;
+    fwupd_security_attr_set_kernel_current_value;
+    fwupd_security_attr_set_kernel_target_value;
   local: *;
 } LIBFWUPD_1.9.4;

--- a/libfwupdplugin/fu-kernel.h
+++ b/libfwupdplugin/fu-kernel.h
@@ -26,3 +26,9 @@ GHashTable *
 fu_kernel_get_cmdline(GError **error);
 GHashTable *
 fu_kernel_parse_cmdline(const gchar *buf, gsize bufsz);
+gboolean
+fu_kernel_check_cmdline_mutable(GError **error);
+gboolean
+fu_kernel_add_cmdline_arg(const gchar *arg, GError **error);
+gboolean
+fu_kernel_remove_cmdline_arg(const gchar *arg, GError **error);

--- a/libfwupdplugin/fu-plugin-private.h
+++ b/libfwupdplugin/fu-plugin-private.h
@@ -124,6 +124,14 @@ gboolean
 fu_plugin_runner_get_results(FuPlugin *self,
 			     FuDevice *device,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_plugin_runner_fix_host_security_attr(FuPlugin *self,
+					FwupdSecurityAttr *attr,
+					GError **error) G_GNUC_WARN_UNUSED_RESULT;
+gboolean
+fu_plugin_runner_undo_host_security_attr(FuPlugin *self,
+					 FwupdSecurityAttr *attr,
+					 GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_plugin_runner_add_security_attrs(FuPlugin *self, FuSecurityAttrs *attrs);
 gint

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2239,6 +2239,66 @@ fu_plugin_runner_get_results(FuPlugin *self, FuDevice *device, GError **error)
 }
 
 /**
+ * fu_plugin_runner_fix_host_security_attr:
+ * @self: a #FuPlugin
+ * @attr: (nullable): a security attribute
+ * @error: (nullable): optional return location for an error
+ *
+ * Fix the specific security attribute.
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fu_plugin_runner_fix_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
+
+	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (vfuncs->fix_host_security_attr == NULL) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_NOT_SUPPORTED,
+				    "fix is not supported");
+		return FALSE;
+	}
+	return vfuncs->fix_host_security_attr(self, attr, error);
+}
+
+/**
+ * fu_plugin_runner_undo_host_security_attr:
+ * @self: a #FuPlugin
+ * @attr: (nullable): a security attribute
+ * @error: (nullable): optional return location for an error
+ *
+ * Fix the security issue of given security attribute.
+ *
+ * Returns: #TRUE for success, #FALSE for failure
+ *
+ * Since: 1.9.6
+ **/
+gboolean
+fu_plugin_runner_undo_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	FuPluginVfuncs *vfuncs = fu_plugin_get_vfuncs(self);
+
+	g_return_val_if_fail(FU_IS_PLUGIN(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (vfuncs->undo_host_security_attr == NULL) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_NOT_SUPPORTED,
+				    "undo is not supported");
+		return FALSE;
+	}
+	return vfuncs->undo_host_security_attr(self, attr, error);
+}
+
+/**
  * fu_plugin_get_order:
  * @self: a #FuPlugin
  *

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -389,6 +389,30 @@ struct _FuPluginClass {
 	 * Since: 1.8.4
 	 **/
 	void (*to_string)(FuPlugin *self, guint idt, GString *str);
+	/**
+	 * fix_host_security_attr:
+	 * @self: a #FuPlugin
+	 * @attr: a #FwupdSecurityAttr
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Fix a host security issue.
+	 *
+	 * Since: 1.9.6
+	 **/
+	gboolean (*fix_host_security_attr)(FuPlugin *self, FwupdSecurityAttr *attr, GError **error);
+	/**
+	 * undo_host_security_attr:
+	 * @self: a #FuPlugin
+	 * @attr: a #FwupdSecurityAttr
+	 * @error: (nullable): optional return location for an error
+	 *
+	 * Undo the fix for a host security issue.
+	 *
+	 * Since: 1.9.6
+	 **/
+	gboolean (*undo_host_security_attr)(FuPlugin *self,
+					    FwupdSecurityAttr *attr,
+					    GError **error);
 };
 
 /**

--- a/libfwupdplugin/fu-security-attr.c
+++ b/libfwupdplugin/fu-security-attr.c
@@ -56,6 +56,9 @@ fu_security_attr_add_bios_target_value(FwupdSecurityAttr *attr,
 		g_autofree gchar *lower = g_utf8_strdown(possible, -1);
 		if (g_strrstr(lower, needle)) {
 			fwupd_security_attr_set_bios_setting_target_value(attr, possible);
+			/* this is built-in to the engine */
+			fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_CAN_FIX);
+			fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_CAN_UNDO);
 			return;
 		}
 	}

--- a/plugins/iommu/fu-iommu-plugin.c
+++ b/plugins/iommu/fu-iommu-plugin.c
@@ -45,11 +45,32 @@ fu_iommu_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
 	FuIommuPlugin *self = FU_IOMMU_PLUGIN(plugin);
 	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autoptr(GHashTable) cmdline = NULL;
 
 	/* create attr */
 	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_IOMMU);
 	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_ENABLED);
 	fu_security_attrs_append(attrs, attr);
+
+	/* we might be able to fix this */
+	cmdline = fu_kernel_get_cmdline(&error_local);
+	if (cmdline == NULL) {
+		g_warning("failed to get kernel cmdline: %s", error_local->message);
+	} else if (fu_kernel_check_cmdline_mutable(NULL)) {
+		const gchar *value = g_hash_table_lookup(cmdline, "iommu");
+		fwupd_security_attr_set_kernel_current_value(attr, value);
+		if (!g_hash_table_contains(cmdline, "iommu") &&
+		    !g_hash_table_contains(cmdline, "intel_iommu") &&
+		    !g_hash_table_contains(cmdline, "amd_iommu")) {
+			fwupd_security_attr_set_kernel_target_value(attr, "iommu=force");
+			fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_CAN_FIX);
+		}
+		if (g_strcmp0(value, "force") == 0) {
+			fwupd_security_attr_set_kernel_target_value(attr, NULL);
+			fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_CAN_UNDO);
+		}
+	}
 
 	fu_security_attr_add_bios_target_value(attr, "AmdVt", "enable");
 	fu_security_attr_add_bios_target_value(attr, "IOMMU", "enable");
@@ -68,6 +89,7 @@ fu_iommu_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!self->has_iommu) {
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_FOUND);
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS);
 		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_FW);
 		return;
 	}
@@ -88,6 +110,18 @@ fu_iommu_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_udev_subsystem(plugin, "iommu");
 }
 
+static gboolean
+fu_iommu_fix_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	return fu_kernel_add_cmdline_arg("iommu=force", error);
+}
+
+static gboolean
+fu_iommu_undo_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr, GError **error)
+{
+	return fu_kernel_remove_cmdline_arg("iommu=force", error);
+}
+
 static void
 fu_iommu_plugin_class_init(FuIommuPluginClass *klass)
 {
@@ -96,4 +130,6 @@ fu_iommu_plugin_class_init(FuIommuPluginClass *klass)
 	plugin_class->to_string = fu_iommu_plugin_to_string;
 	plugin_class->backend_device_added = fu_iommu_plugin_backend_device_added;
 	plugin_class->add_security_attrs = fu_iommu_plugin_add_security_attrs;
+	plugin_class->fix_host_security_attr = fu_iommu_fix_host_security_attr;
+	plugin_class->undo_host_security_attr = fu_iommu_undo_host_security_attr;
 }

--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -207,4 +207,25 @@
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.get-bios-settings</annotate>
   </action>
 
+  <action id="org.freedesktop.fwupd.fix-host-security-attr">
+    <description>Security hardening for HSI</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to fix a host security issue</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+    <action id="org.freedesktop.fwupd.undo-host-security-attr">
+    <description>Security hardening for HSI</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to undo the fix for a host security issue</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
 </policyconfig>

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -253,3 +253,7 @@ gboolean
 fu_engine_emulation_load(FuEngine *self, GBytes *data, GError **error);
 GBytes *
 fu_engine_emulation_save(FuEngine *self, GError **error);
+gboolean
+fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GError **error);
+gboolean
+fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GError **error);

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -827,6 +827,46 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='FixHostSecurityAttr'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Fix a specific HSI attribute.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='appstream_id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              The fwupd AppStream ID, e.g. 'org.fwupd.hsi.Kernel.Lockdown'.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
+    <method name='UndoHostSecurityAttr'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Revert the fix for a specific HSI attribute.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='appstream_id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              The fwupd AppStream ID, e.g. 'org.fwupd.hsi.Kernel.Lockdown'.
+            </doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='SelfSign'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
The idea here is that rather than limiting ourselves to setting BIOS values to fix HSI attributes, we can do per-plugin actions such as setting kernel command line options.

Add two new:

 * flags for FwupdSecurityAttr
 * client helpers
 * PolicyKit rules
 * D-Bus methods and plugin vfuncs

Then teach the iommu and linux-lockdown plugins how to set kernel arguments.

This also benefits automation frameworks such as Ansible and puppet; the framework can call the repair functions with just the AppStream ID.

Heavily based on patches by Kate Hsuan <hpa@redhat.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation
