### PR TITLE
trivial: Bump minimum passim version to 0.1.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -226,7 +226,7 @@ sqlite = dependency('sqlite3', required: get_option('sqlite'))
 if sqlite.found()
   conf.set('HAVE_SQLITE', '1')
 endif
-passim = dependency('passim', required: get_option('passim'), fallback: ['passim', 'passim_dep'])
+passim = dependency('passim', version: '>= 0.1.2', required: get_option('passim'), fallback: ['passim', 'passim_dep'])
 if passim.found()
   conf.set('HAVE_PASSIM', '1')
 endif

--- a/subprojects/passim.wrap
+++ b/subprojects/passim.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = passim
 url = https://github.com/hughsie/passim.git
-revision = 0.1.0
+revision = 0.1.2


### PR DESCRIPTION
This improves the experience of using passim with fwupd. We want to make sure that it's only used with a new enough stack. Link: https://github.com/fwupd/fwupd/issues/6022

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
