### PR TITLE
modem_manager: add T99W373 need to restore defult configuration of autosuspend_delay_ms

### DIFF
--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -40,4 +40,10 @@ fu_mm_device_udev_new(FuContext *ctx, MMManager *manager, FuMmDevice *shadow_dev
 void
 fu_mm_device_udev_add_port(FuMmDevice *self, const gchar *subsystem, const gchar *path, gint ifnum);
 
+gboolean
+fu_mm_device_write_suspend_ms(FuDevice *device, const gchar *buf, GError **error);
+
+gboolean
+fu_mm_device_get_device_info(FuDevice *device, GError **error);
+
 #endif /* __FU_MM_DEVICE_H */

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -39,6 +39,72 @@ CounterpartGuid = USB\VID_0489&PID_E0B8
 Summary = Foxconn T77w968/eSIM LTE modem (fastboot)
 CounterpartGuid = USB\VID_0489&PID_E0B5
 
+# T99W265 with MBIM only
+[USB\VID_0489&PID_E0DA]
+Summary = Foxconn T99W265 LTE modem with MBIM only
+CounterpartGuid = USB\VID_0489&PID_E0DA
+ModemManagerFoxconnDeviceFlag = SDX12
+
+# T99W265 with MBIM and Serial port
+[USB\VID_0489&PID_E0DB]
+Summary = Foxconn T99W265 LTE modem with MBIM and Serial
+CounterpartGuid = USB\VID_0489&PID_E0DB
+ModemManagerFoxconnDeviceFlag = SDX12
+
+# T99W175 based on QC LE1.2
+[PCI\VID_105B&PID_E0AB]
+Summary = Foxconn T99W175 5G modem
+CounterpartGuid = PCI\VID_105B&PID_E0AB
+ModemManagerFoxconnDeviceFlag = SDX55
+
+# T99W175(DW5930e with eSIM)
+[PCI\VID_105B&PID_E0B0]
+Summary = Foxconn T99W175 5G modem with eSIM for DW5930e
+CounterpartGuid = PCI\VID_105B&PID_E0B0
+ModemManagerFoxconnDeviceFlag = SDX55
+
+# T99W175(DW5930e without eSIM)
+[PCI\VID_105B&PID_E0B1]
+Summary = Foxconn T99W175 5G modem without eSIM for DW5930e
+CounterpartGuid = PCI\VID_105B&PID_E0B1
+ModemManagerFoxconnDeviceFlag = SDX55
+
+# T99W175 based on QC LE1.4
+[PCI\VID_105B&PID_E0BF]
+Summary = Foxconn T99W175 5G modem
+CounterpartGuid = PCI\VID_105B&PID_E0BF
+ModemManagerFoxconnDeviceFlag = SDX55
+
+# T99W175 variant
+[PCI\VID_105B&PID_E0C3]
+Summary = Foxconn T99W175 5G modem
+CounterpartGuid = PCI\VID_105B&PID_E0C3
+ModemManagerFoxconnDeviceFlag = SDX55
+
+# T99W368 Foxconn variant based on SDX65
+[PCI\VID_105B&PID_E0D8]
+Summary = Foxconn T99W368 5G modem
+CounterpartGuid = PCI\VID_105B&PID_E0D8
+ModemManagerFoxconnDeviceFlag = SDX6X
+
+# T99W373 Foxconn variant based on SDX62
+[PCI\VID_105B&PID_E0D9]
+Summary = Foxconn T99W373 5G modem
+CounterpartGuid = PCI\VID_105B&PID_E0D9
+ModemManagerFoxconnDeviceFlag = SDX6X
+
+# T99W373(DW5932e with eSIM) based on SDX62
+[PCI\VID_105B&PID_E0F5]
+Summary = Foxconn T99W373 5G modem with eSIM for DW5932e
+CounterpartGuid = PCI\VID_105B&PID_E0F5
+ModemManagerFoxconnDeviceFlag = SDX6X
+
+# T99W373 (DW5932e without eSIM) based on SDX62
+[PCI\VID_105B&PID_E0F9]
+Summary = Foxconn T99W373 5G modem without eSIM for DW5932e
+CounterpartGuid = PCI\VID_105B&PID_E0F9
+ModemManagerFoxconnDeviceFlag = SDX6X
+
 # Quectel EG25-G
 [USB\VID_2C7C&PID_0125]
 Summary = Quectel EG25-G modem


### PR DESCRIPTION
…tosuspend_delay_ms

1.Add device ID and support Foxconn mbim_qdu upgrade devices. 2:After mbim_qdu fw update successfully, Some devices(T99W265/T99W175/T99W368/T99W373)
  need restore defult configuration of autosuspend_delay_ms:2000ms, we define
  fu_mm_device_get_device_info to distinguish different devices.
3:Due to different MCP configurations, the time of FU_MM_DEVICE_REMOVE_DELAY_REPROBE
  need to increase 180000ms to 210000ms.
4:Need to synchronize MAX_WAIT_TIME_SECS 150s->240s for the time of
  FU_MM_DEVICE_REMOVE_DELAY_REPROBE.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
