### PR TITLE
vli: add private flag, still testing

### DIFF
--- a/plugins/vli/README.md
+++ b/plugins/vli/README.md
@@ -90,6 +90,34 @@ the other flash chip parameters. For example:
     CfiDeviceCmdChipErase = 0xc7
     CfiDeviceCmdSectorErase = 0x20
 
+### Flags:attach-with-gpiob
+
+This flag is used if device needs GPIO-B to reset the device.
+
+### Flags:unlock-legacy813
+
+This flag is used for unlocking VL813 with a custom VDR request.
+
+### Flags:has-shared-spi-pd
+
+This flag is used for devices that share SPI with the PD device.
+
+### Flags:has-msp430
+
+This flag is used if device has a MSP430 attached via I²C.
+
+### Flags:has-rtd21xx
+
+This flag is used if device has a RTD21XX attached via I²C.
+
+### Flags:has-i2c-ps186
+
+This flag is used if device has a PS186 attached via I²C.
+
+### Flags:skips-rom
+
+This flag handles cases to update in firmware mode, skips ROM mode entirely.
+
 ## External Interface Access
 
 This plugin requires read/write access to `/dev/bus/usb`.

--- a/plugins/vli/vli-luxshare.quirk
+++ b/plugins/vli/vli-luxshare.quirk
@@ -13,4 +13,5 @@ Flags = usb2
 [USB\VID_208E&PID_0105]
 Plugin = vli
 GType = FuVliPdDevice
+Flags = skips-rom
 VliDeviceKind = vl105


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

We would like to add a private flag for PDs to skip ROM mode in the detach function. Testing in progress. Thanks!
