### PR TITLE
wacom: Only enter flash loader mode once per composite update

### DIFF
--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -356,7 +356,7 @@ fu_wac_device_erase_block(FuWacDevice *self, guint32 addr, GError **error)
 						error);
 }
 
-static gboolean
+gboolean
 fu_wac_device_update_reset(FuWacDevice *self, GError **error)
 {
 	guint8 buf[] = {[0] = FU_WAC_REPORT_ID_UPDATE_RESET, [1 ... 4] = 0xff};
@@ -418,7 +418,7 @@ fu_wac_device_write_checksum_table(FuWacDevice *self, GError **error)
 						error);
 }
 
-static gboolean
+gboolean
 fu_wac_device_switch_to_flash_loader(FuWacDevice *self, GError **error)
 {
 	guint8 buf[] = {[0] = FU_WAC_REPORT_ID_SWITCH_TO_FLASH_LOADER, [1] = 0x05, [2] = 0x6a};
@@ -462,10 +462,6 @@ fu_wac_device_write_firmware(FuDevice *device,
 	if (img == NULL)
 		return FALSE;
 	g_debug("using image at addr 0x%0x", (guint)fu_firmware_get_addr(img));
-
-	/* enter flash mode */
-	if (!fu_wac_device_switch_to_flash_loader(self, error))
-		return FALSE;
 
 	/* get firmware parameters (page sz and transfer sz) */
 	if (!fu_wac_device_ensure_parameters(self, error))
@@ -856,16 +852,6 @@ fu_wac_device_close(FuDevice *device, GError **error)
 	return FU_DEVICE_CLASS(fu_wac_device_parent_class)->close(device, error);
 }
 
-static gboolean
-fu_wac_device_cleanup(FuDevice *device,
-		      FuProgress *progress,
-		      FwupdInstallFlags flags,
-		      GError **error)
-{
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	return fu_wac_device_update_reset(FU_WAC_DEVICE(device), error);
-}
-
 static void
 fu_wac_device_set_progress(FuDevice *self, FuProgress *progress)
 {
@@ -914,7 +900,6 @@ fu_wac_device_class_init(FuWacDeviceClass *klass)
 	klass_device->write_firmware = fu_wac_device_write_firmware;
 	klass_device->to_string = fu_wac_device_to_string;
 	klass_device->setup = fu_wac_device_setup;
-	klass_device->cleanup = fu_wac_device_cleanup;
 	klass_device->close = fu_wac_device_close;
 	klass_device->set_progress = fu_wac_device_set_progress;
 }

--- a/plugins/wacom-usb/fu-wac-device.h
+++ b/plugins/wacom-usb/fu-wac-device.h
@@ -23,3 +23,7 @@ fu_wac_device_set_feature_report(FuWacDevice *self,
 				 gsize bufsz,
 				 FuHidDeviceFlags flags,
 				 GError **error);
+gboolean
+fu_wac_device_switch_to_flash_loader(FuWacDevice *self, GError **error);
+gboolean
+fu_wac_device_update_reset(FuWacDevice *self, GError **error);

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
@@ -152,7 +152,6 @@ fu_wac_module_bluetooth_id6_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* success */
-	fu_device_add_flag(fu_device_get_proxy(device), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2577,6 +2577,12 @@ fu_engine_install_releases(FuEngine *self,
 		return FALSE;
 	}
 
+	/* wait for any device to disconnect and reconnect */
+	if (!fu_device_list_wait_for_replug(self->device_list, error)) {
+		g_prefix_error(error, "failed to wait for device: ");
+		return FALSE;
+	}
+
 	/* success */
 	return TRUE;
 }


### PR DESCRIPTION
This might improve reliability, and it certainly quicker as the device only has to re-enumerate once.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
