### PR TITLE
Revert "thunderbolt: disable retimer offline mode for rex"

### DIFF
--- a/plugins/thunderbolt/thunderbolt.quirk
+++ b/plugins/thunderbolt/thunderbolt.quirk
@@ -11,5 +11,5 @@ GType = FuThunderboltRetimer
 Flags = retimer-offline-mode
 
 # Google Rex
-#[​​fe682559-28dc-58b3-bf61-aa8414d9f363]
-#Flags = retimer-offline-mode
+[​​fe682559-28dc-58b3-bf61-aa8414d9f363]
+Flags = retimer-offline-mode


### PR DESCRIPTION
This reverts commit 96012791a26f5694627f11a2fda08b9a2e3dd0b0.

-enable thunderbolt retimer offline mode for rex

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ x] Feature
- [ ] Documentation
