### PR TITLE
trivial: Explicitly look for `AMDGPU_INFO_VBIOS_INFO` to enable amd-gpu plugin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -537,7 +537,7 @@ configure_file(
   configuration: conf
 )
 
-amdgpu = cc.has_header('drm/amdgpu_drm.h', required: get_option('plugin_amdgpu'))
+amdgpu = cc.has_header_symbol('drm/amdgpu_drm.h', 'AMDGPU_INFO_VBIOS_INFO', required: get_option('plugin_amdgpu'))
 protobufc = dependency('libprotobuf-c', required: get_option('plugin_logitech_bulkcontroller'))
 protoc = find_program('protoc', 'protoc-c', required: get_option('plugin_logitech_bulkcontroller'))
 

--- a/plugins/amd-gpu/meson.build
+++ b/plugins/amd-gpu/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_amdgpu').disable_auto_if(not gudev.found()).allowed()
+if get_option('plugin_amdgpu').disable_auto_if(not gudev.found() or not amdgpu).allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginAmdGpu"']
 
 plugin_quirks += files('amd-gpu.quirk')


### PR DESCRIPTION
Fixes: https://github.com/fwupd/fwupd/issues/6246

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
