### PR TITLE
fu-engine: Recalculate FWUPD_DEVICE_FLAG_SUPPORTED after adopting child

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6424,6 +6424,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 				device,
 				fu_device_get_physical_id(device_tmp))) {
 				fu_device_set_parent(device, device_tmp);
+				fu_engine_ensure_device_supported(self, device_tmp);
 				break;
 			}
 		}
@@ -6436,6 +6437,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 				FuDevice *device_tmp = g_ptr_array_index(devices, i);
 				if (fu_device_has_guid(device_tmp, guid)) {
 					fu_device_set_parent(device, device_tmp);
+					fu_engine_ensure_device_supported(self, device_tmp);
 					break;
 				}
 			}


### PR DESCRIPTION
The current code failed to detect firmware updates coming from a vendor directory if the update was not for the top-level device but for a child device.

In the specific case a Thunderbolt dock had the following guid:

- 8d30b09f-bcc5-5379-bc65-9ccceeece1f4 ← USB\VID_17EF&PID_30B4
- 275e4695-9b4e-5263-835e-8681bec8cd1a ← USB\VID_17EF&PID_30B4&CID_40B0
- 57e1b971-662a-5c9d-b500-69ce8ee3ad99

and the update was available for 275e4695-9b4e-5263-835e-8681bec8cd1a.

The method GetUpgrade returned the firmware update but the flag FWUPD_DEVICE_FLAG_SUPPORTED was not set for the device.

The tool "fwupdmgr get-updates" checks he FWUPD_DEVICE_FLAG_SUPPORTED flag before even considering calling GetUpgrades for any device. So it failed to output the available update even though the fwupd itself updated /var/cache/fwupd/motd.d to inform about one available update.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

In our use case we do not have a network connection and must be able to provide updates to our customer via the vendor directory mechanism.