### PR TITLE
vli: Do not treat an immutable buffer as a mutable one

### DIFF
--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -264,6 +264,8 @@ fu_vli_pd_device_spi_write_data(FuVliDevice *self,
 	guint8 spi_cmd = 0x0;
 	guint16 value;
 	guint16 index;
+	g_autofree guint8 *buf_mut = NULL;
+
 	if (!fu_cfi_device_get_cmd(fu_vli_device_get_cfi_device(self),
 				   FU_CFI_DEVICE_CMD_PAGE_PROG,
 				   &spi_cmd,
@@ -271,6 +273,10 @@ fu_vli_pd_device_spi_write_data(FuVliDevice *self,
 		return FALSE;
 	value = ((addr << 8) & 0xff00) | spi_cmd;
 	index = addr >> 8;
+
+	buf_mut = fu_memdup_safe(buf, bufsz, error);
+	if (buf_mut == NULL)
+		return FALSE;
 	if (!g_usb_device_control_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(self)),
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -278,7 +284,7 @@ fu_vli_pd_device_spi_write_data(FuVliDevice *self,
 					   0xdc,
 					   value,
 					   index,
-					   (guint8 *)buf,
+					   buf_mut,
 					   bufsz,
 					   NULL,
 					   FU_VLI_DEVICE_TIMEOUT,

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -343,6 +343,8 @@ fu_vli_usbhub_device_spi_write_data(FuVliDevice *self,
 	guint8 spi_cmd = 0x0;
 	guint16 value;
 	guint16 index;
+	g_autofree guint8 *buf_mut = NULL;
+
 	if (!fu_cfi_device_get_cmd(fu_vli_device_get_cfi_device(self),
 				   FU_CFI_DEVICE_CMD_PAGE_PROG,
 				   &spi_cmd,
@@ -350,6 +352,9 @@ fu_vli_usbhub_device_spi_write_data(FuVliDevice *self,
 		return FALSE;
 	value = ((addr >> 8) & 0xff00) | spi_cmd;
 	index = ((addr << 8) & 0xff00) | ((addr >> 8) & 0x00ff);
+	buf_mut = fu_memdup_safe(buf, bufsz, error);
+	if (buf_mut == NULL)
+		return FALSE;
 	if (!g_usb_device_control_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(self)),
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -357,7 +362,7 @@ fu_vli_usbhub_device_spi_write_data(FuVliDevice *self,
 					   0xd4,
 					   value,
 					   index,
-					   (guint8 *)buf,
+					   buf_mut,
 					   bufsz,
 					   NULL,
 					   FU_VLI_DEVICE_TIMEOUT,

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -83,7 +83,12 @@ fu_vli_usbhub_device_i2c_write_data(FuVliUsbhubDevice *self,
 {
 	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(self));
 	guint16 value = (((guint16)disable_start_bit) << 8) | disable_end_bit;
+	g_autofree guint8 *buf_mut = NULL;
+
 	fu_dump_raw(G_LOG_DOMAIN, "I2cWriteData", buf, bufsz);
+	buf_mut = fu_memdup_safe(buf, bufsz, error);
+	if (buf_mut == NULL)
+		return FALSE;
 	if (!g_usb_device_control_transfer(usb_device,
 					   G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 					   G_USB_DEVICE_REQUEST_TYPE_VENDOR,
@@ -91,7 +96,7 @@ fu_vli_usbhub_device_i2c_write_data(FuVliUsbhubDevice *self,
 					   I2C_W_VDR,
 					   value,
 					   0x0,
-					   (guint8 *)buf,
+					   buf_mut,
 					   bufsz,
 					   NULL,
 					   FU_VLI_DEVICE_TIMEOUT,


### PR DESCRIPTION
If we're loading using mmap() then the process will crash if the buffer is modified as it really is read-only.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
