### PR TITLE
wacom-raw: Add the PNP ID as a additional instance ID

### DIFF
--- a/plugins/wacom-raw/README.md
+++ b/plugins/wacom-raw/README.md
@@ -11,6 +11,9 @@ connected using I²C and not USB.
 
 The HID DeviceInstanceId values are used, e.g. `HIDRAW\VEN_056A&DEV_4875`.
 
+To recover panels that have been flashed with the wrong firmware version, the panel may have a
+parent device with GUID constructed from the EDID, e.g. `DRM\VEN_BOE&DEV_086E`.
+
 ## Firmware Format
 
 The daemon will decompress the cabinet archive and extract a firmware blob in

--- a/plugins/wacom-raw/fu-wacom-raw-plugin.c
+++ b/plugins/wacom-raw/fu-wacom-raw-plugin.c
@@ -18,6 +18,29 @@ struct _FuWacomRawPlugin {
 G_DEFINE_TYPE(FuWacomRawPlugin, fu_wacom_raw_plugin, FU_TYPE_PLUGIN)
 
 static void
+fu_wacom_raw_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
+{
+	/* is internal DRM device */
+	if (FU_IS_DRM_DEVICE(device) && fu_device_has_flag(device, FWUPD_DEVICE_FLAG_INTERNAL)) {
+		GPtrArray *devices = fu_plugin_get_devices(plugin);
+		for (guint i = 0; i < devices->len; i++) {
+			FuDevice *device_tmp = g_ptr_array_index(devices, i);
+			fu_device_add_child(device, device_tmp);
+		}
+		fu_plugin_cache_add(plugin, "drm", device);
+	}
+}
+
+static gboolean
+fu_wacom_raw_plugin_device_created(FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	FuDevice *drm_device = fu_plugin_cache_lookup(plugin, "drm");
+	if (drm_device != NULL)
+		fu_device_add_child(drm_device, device);
+	return TRUE;
+}
+
+static void
 fu_wacom_raw_plugin_init(FuWacomRawPlugin *self)
 {
 }
@@ -32,7 +55,7 @@ fu_wacom_raw_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "WacomI2cFlashSize");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_AES_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_EMR_DEVICE);
-	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+	fu_plugin_add_device_udev_subsystem(plugin, "hidraw");
 }
 
 static void
@@ -40,4 +63,6 @@ fu_wacom_raw_plugin_class_init(FuWacomRawPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	plugin_class->constructed = fu_wacom_raw_plugin_constructed;
+	plugin_class->device_created = fu_wacom_raw_plugin_device_created;
+	plugin_class->device_registered = fu_wacom_raw_plugin_device_registered;
 }


### PR DESCRIPTION
This allows us to recover some panels that have accidentally may been flashed with the wrong firmware that changed the device DEV number. Using the three digit `PNP_ID` (which is constructed from the 2-byte manufacturer name) means we can get the user back to the correct firmware stream.

It's not ideal that we can't go from the sysfs hidraw node to the drm device with the EDID, but we do know there is only going to be one "internal" panel.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
