### PR TITLE
trivial: Cache the DRM properties at ->probe()

### DIFF
--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -20,19 +20,36 @@
  * See also: #FuUdevDevice
  */
 
-G_DEFINE_TYPE(FuDrmDevice, fu_drm_device, FU_TYPE_UDEV_DEVICE)
+typedef struct {
+	gchar *connector_id;
+	gboolean enabled;
+	FuDisplayState display_state;
+	FuEdid *edid;
+} FuDrmDevicePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(FuDrmDevice, fu_drm_device, FU_TYPE_UDEV_DEVICE)
+
+#define GET_PRIVATE(o) (fu_drm_device_get_instance_private(o))
+
+static FuDisplayState
+fu_display_state_from_string(const gchar *display_state)
+{
+	if (g_strcmp0(display_state, "connected") == 0)
+		return FU_DISPLAY_STATE_CONNECTED;
+	if (g_strcmp0(display_state, "disconnected") == 0)
+		return FU_DISPLAY_STATE_DISCONNECTED;
+	return FU_DISPLAY_STATE_UNKNOWN;
+}
 
 static void
 fu_drm_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuDrmDevice *self = FU_DRM_DEVICE(device);
-	if (fu_drm_device_get_connector_id(self) != NULL)
-		fu_string_append(str, idt, "ConnectorId", fu_drm_device_get_connector_id(self));
-	fu_string_append_kb(str, idt, "Enabled", fu_drm_device_get_enabled(self));
-	fu_string_append(str,
-			 idt,
-			 "Status",
-			 fu_display_state_to_string(fu_drm_device_get_state(self)));
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
+	if (priv->connector_id != NULL)
+		fu_string_append(str, idt, "ConnectorId", priv->connector_id);
+	fu_string_append_kb(str, idt, "Enabled", priv->enabled);
+	fu_string_append(str, idt, "State", fu_display_state_to_string(priv->display_state));
 }
 
 /**
@@ -48,14 +65,9 @@ fu_drm_device_to_string(FuDevice *device, guint idt, GString *str)
 FuDisplayState
 fu_drm_device_get_state(FuDrmDevice *self)
 {
-	const gchar *tmp;
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_DRM_DEVICE(self), FU_DISPLAY_STATE_UNKNOWN);
-	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "status", NULL);
-	if (g_strcmp0(tmp, "connected") == 0)
-		return FU_DISPLAY_STATE_CONNECTED;
-	if (g_strcmp0(tmp, "disconnected") == 0)
-		return FU_DISPLAY_STATE_DISCONNECTED;
-	return FU_DISPLAY_STATE_UNKNOWN;
+	return priv->display_state;
 }
 
 /**
@@ -71,10 +83,9 @@ fu_drm_device_get_state(FuDrmDevice *self)
 gboolean
 fu_drm_device_get_enabled(FuDrmDevice *self)
 {
-	const gchar *tmp;
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_DRM_DEVICE(self), FALSE);
-	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "enabled", NULL);
-	return g_strcmp0(tmp, "enabled") == 0;
+	return priv->enabled;
 }
 
 /**
@@ -90,56 +101,50 @@ fu_drm_device_get_enabled(FuDrmDevice *self)
 const gchar *
 fu_drm_device_get_connector_id(FuDrmDevice *self)
 {
-	const gchar *tmp;
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_DRM_DEVICE(self), NULL);
-	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "connector_id", NULL);
-	if (tmp == NULL || tmp[0] == '\0')
-		return NULL;
-	return tmp;
+	return priv->connector_id;
 }
 
 /**
- * fu_drm_device_read_edid:
+ * fu_drm_device_get_edid:
  * @self: a #FuDrmDevice
- * @error: (nullable): optional return location for an error
  *
- * Read the EDID from the DRM device.
+ * Returns the cached EDID from the DRM device.
  *
- * Returns: (transfer full): a #FuEdid, or %NULL
+ * Returns: (transfer none): a #FuEdid, or %NULL
  *
  * Since: 1.9.7
  **/
 FuEdid *
-fu_drm_device_read_edid(FuDrmDevice *self, GError **error)
+fu_drm_device_get_edid(FuDrmDevice *self)
 {
-	const gchar *sysfs_path;
-	g_autofree gchar *edid_path = NULL;
-	g_autoptr(FuEdid) edid = fu_edid_new();
-	g_autoptr(GBytes) blob = NULL;
-
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_DRM_DEVICE(self), NULL);
-	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-	/* read blob and parse it */
-	sysfs_path = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(self));
-	edid_path = g_build_filename(sysfs_path, "edid", NULL);
-	blob = fu_bytes_get_contents(edid_path, error);
-	if (blob == NULL)
-		return NULL;
-	if (!fu_firmware_parse(FU_FIRMWARE(edid), blob, FWUPD_INSTALL_FLAG_NONE, error))
-		return NULL;
-	return g_steal_pointer(&edid);
+	return priv->edid;
 }
 
 static gboolean
 fu_drm_device_probe(FuDevice *device, GError **error)
 {
+	FuDrmDevice *self = FU_DRM_DEVICE(device);
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	const gchar *sysfs_path = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
+	const gchar *tmp;
 	g_autofree gchar *physical_id = g_path_get_basename(sysfs_path);
 
 	/* FuUdevDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_drm_device_parent_class)->probe(device, error))
 		return FALSE;
+
+	/* basic properties */
+	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "enabled", NULL);
+	priv->enabled = g_strcmp0(tmp, "enabled") == 0;
+	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "status", NULL);
+	priv->display_state = fu_display_state_from_string(tmp);
+	tmp = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(self), "connector_id", NULL);
+	if (tmp != NULL && tmp[0] != '\0')
+		priv->connector_id = g_strdup(tmp);
 
 	/* this is a heuristic */
 	if (physical_id != NULL) {
@@ -148,6 +153,32 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 			if (g_strcmp0(parts[i], "eDP") == 0)
 				fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
 		}
+		fu_device_set_physical_id(device, physical_id);
+	}
+
+	/* read EDID and parse it */
+	if (priv->display_state == FU_DISPLAY_STATE_CONNECTED) {
+		g_autofree gchar *edid_path = g_build_filename(sysfs_path, "edid", NULL);
+		g_autoptr(FuEdid) edid = fu_edid_new();
+		g_autoptr(GBytes) edid_blob = NULL;
+
+		edid_blob = fu_bytes_get_contents(edid_path, error);
+		if (edid_blob == NULL)
+			return FALSE;
+		if (!fu_firmware_parse(FU_FIRMWARE(edid),
+				       edid_blob,
+				       FWUPD_INSTALL_FLAG_NONE,
+				       error))
+			return FALSE;
+		g_set_object(&priv->edid, edid);
+
+		/* add instance ID */
+		fu_device_add_instance_str(device, "VEN", fu_edid_get_pnp_id(edid));
+		fu_device_add_instance_u16(device, "DEV", fu_edid_get_product_code(edid));
+		if (!fu_device_build_instance_id(device, error, "EDID", "VEN", "DEV", NULL))
+			return FALSE;
+		if (fu_edid_get_eisa_id(edid) != NULL)
+			fu_device_set_name(device, fu_edid_get_eisa_id(edid));
 	}
 
 	/* success */
@@ -160,9 +191,24 @@ fu_drm_device_init(FuDrmDevice *self)
 }
 
 static void
+fu_drm_device_finalize(GObject *object)
+{
+	FuDrmDevice *self = FU_DRM_DEVICE(object);
+	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
+
+	g_free(priv->connector_id);
+	if (priv->edid != NULL)
+		g_object_unref(priv->edid);
+
+	G_OBJECT_CLASS(fu_drm_device_parent_class)->finalize(object);
+}
+
+static void
 fu_drm_device_class_init(FuDrmDeviceClass *klass)
 {
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_drm_device_finalize;
 	klass_device->probe = fu_drm_device_probe;
 	klass_device->to_string = fu_drm_device_to_string;
 }

--- a/libfwupdplugin/fu-drm-device.h
+++ b/libfwupdplugin/fu-drm-device.h
@@ -23,4 +23,4 @@ fu_drm_device_get_state(FuDrmDevice *self);
 const gchar *
 fu_drm_device_get_connector_id(FuDrmDevice *self);
 FuEdid *
-fu_drm_device_read_edid(FuDrmDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_drm_device_get_edid(FuDrmDevice *self);


### PR DESCRIPTION
Also, construct plausible GUIDs using the EDID if connected and enabled.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
