### PR TITLE
trivial: thunderbolt: stop creating integrated devices

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -284,8 +284,11 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 				return FALSE;
 
 		} else {
-			device_id = g_strdup("TBT-fixed");
-			fu_device_add_parent_guid(device, "cpu");
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "updates are distributed as part of the platform");
+			return FALSE;
 		}
 		fu_device_add_instance_id(device, device_id);
 		if (domain_id != NULL)


### PR DESCRIPTION
When the thunderbolt or USB4 controller is integrated into the SoC
upgrades for applicable firmware are distributed as part of the platform.

The kernel doesn't export any type of version string in this instance so
there isn't really any reason for fwupd to both creating a device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
