### PR TITLE
trivial: discover libdrm, and ensure it has amdgpu support using pkgconfig

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -11,7 +11,7 @@ license=('GPL2')
 depends=('libgusb' 'modemmanager' 'tpm2-tss')
 makedepends=('meson' 'valgrind' 'gobject-introspection' 'gi-docgen' 'git'
              'python-cairo' 'noto-fonts' 'noto-fonts-cjk' 'python-gobject' 'vala'
-             'linux-headers' 'curl' 'polkit' 'gcab' 'xz')
+             'libdrm' 'curl' 'polkit' 'gcab' 'xz')
 
 pkgver() {
     cd ${pkgname}
@@ -30,7 +30,6 @@ build() {
     arch-meson -D b_lto=false $CI ../build \
         -Dplugin_intel_spi=true \
         -Dplugin_powerd=disabled \
-        -Dplugin_amdgpu=disabled \
         -Dlaunchd=disabled \
         -Ddocs=enabled \
         -Defi_binary=false \

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -148,6 +148,20 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency id="libdrm-dev">
+    <distro id="fedora">
+      <package variant="x86_64">libdrm-devel</package>
+      <package variant="aarch64">libdrm-devel</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency id="libjson-glib-dev">
     <distro id="arch">
       <package variant="x86_64">json-glib</package>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -149,6 +149,9 @@
     </distro>
   </dependency>
   <dependency id="libdrm-dev">
+    <distro id="arch">
+      <package variant="x86_64">libdrm</package>
+    </distro>
     <distro id="fedora">
       <package variant="x86_64">libdrm-devel</package>
       <package variant="aarch64">libdrm-devel</package>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -87,7 +87,6 @@ BuildRequires: json-glib-devel >= %{json_glib_version}
 BuildRequires: vala
 BuildRequires: bash-completion
 BuildRequires: git-core
-BuildRequires: kernel-headers
 %if 0%{?have_flashrom}
 BuildRequires: flashrom-devel >= 1.2-2
 %endif

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -91,6 +91,7 @@ BuildRequires: kernel-headers
 %if 0%{?have_flashrom}
 BuildRequires: flashrom-devel >= 1.2-2
 %endif
+BuildRequires: libdrm-devel
 
 %if 0%{?have_modem_manager}
 BuildRequires: ModemManager-glib-devel >= 1.10.0

--- a/meson.build
+++ b/meson.build
@@ -537,7 +537,9 @@ configure_file(
   configuration: conf
 )
 
-amdgpu = cc.has_header_symbol('drm/amdgpu_drm.h', 'AMDGPU_INFO_VBIOS_INFO', required: get_option('plugin_amdgpu'))
+libdrm_amdgpu = dependency('libdrm_amdgpu',
+                           version: '>= 2.4.113',
+                           required: get_option('plugin_amdgpu'))
 protobufc = dependency('libprotobuf-c', required: get_option('plugin_logitech_bulkcontroller'))
 protoc = find_program('protoc', 'protoc-c', required: get_option('plugin_logitech_bulkcontroller'))
 

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -11,9 +11,9 @@
 
 #include "config.h"
 
-#include <drm/amdgpu_drm.h>
 #include <fcntl.h>
 #include <glib/gstdio.h>
+#include <libdrm/amdgpu_drm.h>
 
 #include "fu-amd-gpu-atom-firmware.h"
 #include "fu-amd-gpu-device.h"

--- a/plugins/amd-gpu/meson.build
+++ b/plugins/amd-gpu/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_amdgpu').disable_auto_if(not gudev.found() or not amdgpu).allowed()
+if gudev.found() and libdrm_amdgpu.found() and get_option('plugin_amdgpu').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginAmdGpu"']
 
 plugin_quirks += files('amd-gpu.quirk')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -9,6 +9,7 @@ plugin_deps = [
   libarchive,
   libjsonglib,
   libxmlb,
+  libdrm_amdgpu,
   protobufc,
   fwupdplugin_rs_dep,
 ]


### PR DESCRIPTION
I think this is the cleaner solution - it means we never need to be updating the header copy locally if we keep using future ioctls.

Fixes: #6266

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
