### PR TITLE
trivial: Adjust AMD rollback protection to be consistent

### DIFF
--- a/docs/hsi-tests.d/meson.build
+++ b/docs/hsi-tests.d/meson.build
@@ -1,5 +1,5 @@
 hsi_test_jsons = files([
-  'org.fwupd.hsi.Amd.PlatformRollbackProtection.json',
+  'org.fwupd.hsi.Amd.RollbackProtection.json',
   'org.fwupd.hsi.Amd.SpiReplayProtection.json',
   'org.fwupd.hsi.Amd.SpiWriteProtection.json',
   'org.fwupd.hsi.EncryptedRam.json',

--- a/docs/hsi-tests.d/org.fwupd.hsi.Amd.RollbackProtection.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Amd.RollbackProtection.json
@@ -1,5 +1,5 @@
 {
-  "id": "org.fwupd.hsi.Amd.PlatformRollbackProtection",
+  "id": "org.fwupd.hsi.Amd.RollbackProtection",
   "name": "AMD Secure Processor Rollback protection",
   "description": [
     "AMD SOCs include the ability to prevent a rollback attack by a rollback protection feature on the secure processor.",


### PR DESCRIPTION
The documentation didn't match the #define.  Adjust documentation to match.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
