### PR TITLE
Add plugin boilerplate to indicate the plugin owner

### DIFF
--- a/plugins/amd-gpu/README.md
+++ b/plugins/amd-gpu/README.md
@@ -63,3 +63,10 @@ interfaces with the hardware.
       PSP ~~~ kernel
       kernel ~~~ fwupdengine
 ```
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Mario Limonciello: @superm1

--- a/plugins/amd-pmc/README.md
+++ b/plugins/amd-pmc/README.md
@@ -14,3 +14,10 @@ This plugin requires read only access to attributes located within `/sys/bus/pla
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.5`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Mario Limonciello: @superm1

--- a/plugins/analogix/README.md
+++ b/plugins/analogix/README.md
@@ -51,3 +51,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.6.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Analogix: @xtcui

--- a/plugins/android-boot/README.md
+++ b/plugins/android-boot/README.md
@@ -57,3 +57,10 @@ This plugin requires read/write access to `/dev/block`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.5`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Dylan Van Assche: @DylanVanAssche

--- a/plugins/aver-hid/README.md
+++ b/plugins/aver-hid/README.md
@@ -49,3 +49,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.9.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Pierce Wang: @PierceWangAVer

--- a/plugins/bcm57xx/README.md
+++ b/plugins/bcm57xx/README.md
@@ -42,3 +42,10 @@ This plugin requires the `SIOCETHTOOL` ioctl interface.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Evan Lojewski: @meklort

--- a/plugins/ccgx-dmc/README.md
+++ b/plugins/ccgx-dmc/README.md
@@ -97,3 +97,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Ryan Lee: @chlee75

--- a/plugins/ccgx/README.md
+++ b/plugins/ccgx/README.md
@@ -117,3 +117,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.4.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Ryan Lee: @chlee75

--- a/plugins/colorhug/README.md
+++ b/plugins/colorhug/README.md
@@ -47,3 +47,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `0.8.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Richard Hughes: @hughsie

--- a/plugins/corsair/README.md
+++ b/plugins/corsair/README.md
@@ -64,3 +64,10 @@ This flag tells device that it is a child device. All subdevice behavior tweaks 
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Andrii Dushko: @dushko-devx

--- a/plugins/cros-ec/README.md
+++ b/plugins/cros-ec/README.md
@@ -52,3 +52,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Benson Leung: @bleungatchromium

--- a/plugins/dell-dock/README.md
+++ b/plugins/dell-dock/README.md
@@ -192,3 +192,11 @@ This plugin has been available since fwupd version `1.2.0`.
       I2C~~~USB1
       I2C~~~USB2
 ```
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Crag Wang: @CragW
+* Mario Limonciello: @superm1

--- a/plugins/dell/README.md
+++ b/plugins/dell/README.md
@@ -51,3 +51,10 @@ This plugin requires read/write access to `/dev/wmi/dell-smbios` and `/sys/bus/p
 ## Version Considerations
 
 This plugin has been available since fwupd version `0.8.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Mario Limonciello: @superm1

--- a/plugins/elanfp/README.md
+++ b/plugins/elanfp/README.md
@@ -29,3 +29,10 @@ The vendor ID is set from the USB vendor, in this instance set to `USB:0x04F3`
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Michael Cheng: @MichaelCheng04

--- a/plugins/elantp/README.md
+++ b/plugins/elantp/README.md
@@ -81,3 +81,11 @@ This plugin requires ioctl access to `HIDIOCSFEATURE` and `HIDIOCGFEATURE`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jingle Wu: @jinglewu
+* Josh Chen: @josh-chen-elan

--- a/plugins/focalfp/README.md
+++ b/plugins/focalfp/README.md
@@ -48,3 +48,10 @@ This plugin requires ioctl access to `HIDIOCSFEATURE` and `HIDIOCGFEATURE`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Wayne Huang: @waynehuang2022

--- a/plugins/fpc/README.md
+++ b/plugins/fpc/README.md
@@ -38,3 +38,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jim Zhang: @jimzhang2

--- a/plugins/genesys/README.md
+++ b/plugins/genesys/README.md
@@ -170,3 +170,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Adam Chen: @adamgene

--- a/plugins/goodix-moc/README.md
+++ b/plugins/goodix-moc/README.md
@@ -38,3 +38,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Boger Wang: @boger047

--- a/plugins/goodix-tp/README.md
+++ b/plugins/goodix-tp/README.md
@@ -39,3 +39,10 @@ This plugin requires ioctl access to `HIDIOCSFEATURE` and `HIDIOCGFEATURE`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.9.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Goodix: @xulinkun

--- a/plugins/intel-gsc/README.md
+++ b/plugins/intel-gsc/README.md
@@ -41,3 +41,10 @@ This plugin requires read/write access to `/dev/mei*`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.7`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Vitaly Lubart: @vlubart

--- a/plugins/jabra-gnp/README.md
+++ b/plugins/jabra-gnp/README.md
@@ -29,3 +29,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.9.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Gianmarco: @gdpcastro

--- a/plugins/logitech-bulkcontroller/README.md
+++ b/plugins/logitech-bulkcontroller/README.md
@@ -91,3 +91,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Sanjay Sheth: @vcdmp

--- a/plugins/logitech-scribe/README.md
+++ b/plugins/logitech-scribe/README.md
@@ -45,3 +45,10 @@ This plugin requires the `UVCIOC_CTRL_QUERY` ioctl interface.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.8`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Sanjay Sheth: @vcdmp

--- a/plugins/logitech-tap/README.md
+++ b/plugins/logitech-tap/README.md
@@ -46,3 +46,10 @@ This plugin requires the ioctl interfaces: `UVCIOC_CTRL_QUERY`, `HIDIOCGFEATURE`
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.9.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Sanjay Sheth: @vcdmp

--- a/plugins/mediatek-scaler/README.md
+++ b/plugins/mediatek-scaler/README.md
@@ -55,3 +55,10 @@ the device number changes in various situations.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.9.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Crag Wang: @CragW

--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -98,3 +98,10 @@ This plugin requires read/write access to `/dev/bus/usb` and `/dev/bus/pci`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Aleksander Morgado: @aleksander0m

--- a/plugins/nitrokey/README.md
+++ b/plugins/nitrokey/README.md
@@ -41,3 +41,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.0.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Szczepan Zalega: @szszszsz

--- a/plugins/nordic-hid/README.md
+++ b/plugins/nordic-hid/README.md
@@ -82,3 +82,10 @@ This plugin requires ioctl `HIDIOCSFEATURE` and `HIDIOCGFEATURE` access.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.3`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Marek Pieta: @MarekPieta

--- a/plugins/parade-lspcon/README.md
+++ b/plugins/parade-lspcon/README.md
@@ -56,3 +56,10 @@ as `/dev/drm_dp_aux0` as well as the i2c bus attached to the device, such as
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.6.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Peter Marheine: @tari

--- a/plugins/pci-psp/README.md
+++ b/plugins/pci-psp/README.md
@@ -20,3 +20,10 @@ This plugin requires read only access to attributes located within `/sys/bus/pci
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Mario Limonciello: @superm1

--- a/plugins/pixart-rf/README.md
+++ b/plugins/pixart-rf/README.md
@@ -44,3 +44,10 @@ This plugin requires ioctl `HIDIOCSFEATURE` and `HIDIOCGFEATURE` access.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.5`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Sam Chen: @sam412081go

--- a/plugins/qsi-dock/README.md
+++ b/plugins/qsi-dock/README.md
@@ -35,3 +35,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.8`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Kevin Chen: @hssinf

--- a/plugins/realtek-mst/README.md
+++ b/plugins/realtek-mst/README.md
@@ -57,3 +57,10 @@ DisplayPort aux channel, usually `/dev/i2c-5` or similar.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.6.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Peter Marheine: @tari

--- a/plugins/rts54hid/README.md
+++ b/plugins/rts54hid/README.md
@@ -68,3 +68,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Ricky Wu: @AnyProblem

--- a/plugins/rts54hub/README.md
+++ b/plugins/rts54hub/README.md
@@ -43,3 +43,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Ricky Wu: @AnyProblem

--- a/plugins/synaptics-cape/README.md
+++ b/plugins/synaptics-cape/README.md
@@ -46,3 +46,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Simon Ho: @CNXT-Simon

--- a/plugins/synaptics-mst/README.md
+++ b/plugins/synaptics-mst/README.md
@@ -117,3 +117,10 @@ This plugin has been available since fwupd version `1.3.6`.
       gpu<--DDC/I2C-->MST
       MST---SPI
 ```
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Apollo Ling: @ApolloLing

--- a/plugins/synaptics-prometheus/README.md
+++ b/plugins/synaptics-prometheus/README.md
@@ -41,3 +41,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.9`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Vincent Huang: @synavincent

--- a/plugins/synaptics-rmi/README.md
+++ b/plugins/synaptics-rmi/README.md
@@ -42,3 +42,11 @@ This plugin requires ioctl access to `HIDIOCSFEATURE` and `HIDIOCGFEATURE`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.3.3`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* David Chiu: @blueue
+* Vincent Huang: @vhuag

--- a/plugins/system76-launch/README.md
+++ b/plugins/system76-launch/README.md
@@ -43,3 +43,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.5.6`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jeremy Soller: @jackpot51

--- a/plugins/thelio-io/README.md
+++ b/plugins/thelio-io/README.md
@@ -37,3 +37,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.3.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jeremy Soller: @jackpot51

--- a/plugins/usi-dock/README.md
+++ b/plugins/usi-dock/README.md
@@ -57,3 +57,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.7.4`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Victor Cheng: @victor-cheng

--- a/plugins/vbe/README.md
+++ b/plugins/vbe/README.md
@@ -269,3 +269,10 @@ the update.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Simon Glass: @sjg20

--- a/plugins/vendor-example/README.md.in
+++ b/plugins/vendor-example/README.md.in
@@ -62,3 +62,10 @@ This plugin requires read/write access to `TODO`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `SET_VERSION_HERE`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* {{Vendor}}: @github-username

--- a/plugins/vli/README.md
+++ b/plugins/vli/README.md
@@ -125,3 +125,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.3.3`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Emily Miller: @memily

--- a/plugins/wacom-raw/README.md
+++ b/plugins/wacom-raw/README.md
@@ -65,3 +65,10 @@ This plugin requires ioctl `HIDIOCSFEATURE` access.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.4`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Tatsunosuke Tobita: @flying-elephant

--- a/plugins/wacom-usb/README.md
+++ b/plugins/wacom-usb/README.md
@@ -53,3 +53,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.2.2`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jason Gerecke: @jigpu

--- a/plugins/wistron-dock/README.md
+++ b/plugins/wistron-dock/README.md
@@ -48,3 +48,10 @@ This plugin requires read/write access to `/dev/bus/usb`.
 ## Version Considerations
 
 This plugin has been available since fwupd version `1.8.9`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Felix Chen: @a999153


### PR DESCRIPTION
A frequent anxiety heard from new vendors is that anybody can edit any plugin as the code is "open source". To allay that fear add an 'Owners' section in each plugin README.md to specify people that should be consulted for specific reviews or compliance or functional testing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [X] Documentation
