### PR TITLE
eMMC plugin changes - v3

### DIFF
--- a/plugins/emmc/README.md
+++ b/plugins/emmc/README.md
@@ -31,6 +31,16 @@ One deprecated instance ID is also added; new firmware should not use this.
 The firmware is deployed when the device is in normal runtime mode, but it is
 only activated when the device is rebooted.
 
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### EmmcBlockSize
+
+The block size used for Emmc  writes
+
+Since: 1.9.7
+
 ## Vendor ID Security
 
 The vendor ID is set from the EMMC vendor, for example set to `EMMC:{$manfid}`

--- a/plugins/emmc/emmc.quirk
+++ b/plugins/emmc/emmc.quirk
@@ -1,0 +1,9 @@
+#Western Digital
+[EMMC\NAME_DI4064]
+EmmcBlockSize = 0x1000
+[EMMC\NAME_DI4128]
+EmmcBlockSize = 0x1000
+[EMMC\NAME_DJ4008]
+EmmcBlockSize = 0x1000
+[EMMC\NAME_DJ4016]
+EmmcBlockSize = 0x1000

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -348,9 +348,9 @@ fu_emmc_device_write_firmware(FuDevice *device,
 {
 	FuEmmcDevice *self = FU_EMMC_DEVICE(device);
 	gsize fw_size = 0;
-	gsize total_done;
 	guint32 arg;
 	guint32 sect_done = 0;
+	gboolean check_sect_done = FALSE;
 	guint8 ext_csd[512];
 	guint failure_cnt = 0;
 	g_autofree struct mmc_ioc_multi_cmd *multi_cmd = NULL;
@@ -371,6 +371,9 @@ fu_emmc_device_write_firmware(FuDevice *device,
 	if (fw == NULL)
 		return FALSE;
 	fw_size = g_bytes_get_size(fw);
+
+	/*  mode operation codes are supported */
+	check_sect_done = (ext_csd[EXT_CSD_FFU_FEATURES] & 1) > 0;
 
 	/* set CMD ARG */
 	arg = ext_csd[EXT_CSD_FFU_ARG_0] | ext_csd[EXT_CSD_FFU_ARG_1] << 8 |
@@ -405,7 +408,7 @@ fu_emmc_device_write_firmware(FuDevice *device,
 
 	/* build packets */
 	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, self->sect_size);
-	while (sect_done == 0) {
+	while (failure_cnt < 3) {
 		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
 
@@ -431,50 +434,51 @@ fu_emmc_device_write_firmware(FuDevice *device,
 				return FALSE;
 			}
 
-			if (!fu_emmc_read_extcsd(self, ext_csd, sizeof(ext_csd), error))
-				return FALSE;
-
-			/* if we need to restart the download */
-			sect_done = ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_0] |
-				    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_1] << 8 |
-				    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_2] << 16 |
-				    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_3] << 24;
-			if (sect_done == 0) {
-				if (failure_cnt >= 3) {
-					g_set_error_literal(error,
-							    G_IO_ERROR,
-							    G_IO_ERROR_FAILED,
-							    "programming failed");
-					return FALSE;
-				}
-				failure_cnt++;
-				g_debug("programming failed: retrying (%u)", failure_cnt);
-				break;
-			}
-
 			/* update progress */
 			fu_progress_set_percentage_full(fu_progress_get_child(progress),
 							(gsize)i + 1,
 							(gsize)fu_chunk_array_length(chunks));
 		}
+
+		if (!check_sect_done)
+			break;
+
+		if (!fu_emmc_read_extcsd(self, ext_csd, sizeof(ext_csd), error))
+			return FALSE;
+
+		sect_done = ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_0] |
+			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_1] << 8 |
+			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_2] << 16 |
+			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_3] << 24;
+
+		if (sect_done != 0)
+			break;
+
+		failure_cnt++;
+		g_debug("programming failed: retrying (%u)", failure_cnt);
+		fu_progress_step_done(progress);
 	}
+
 	fu_progress_step_done(progress);
 
 	/* sanity check */
-	total_done = (gsize)sect_done * (gsize)self->sect_size;
-	if (total_done != fw_size) {
-		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "firmware size and number of sectors written "
-			    "mismatch (%" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT "):",
-			    total_done,
-			    fw_size);
-		return FALSE;
+	if (check_sect_done) {
+		gsize total_done = (gsize)sect_done * (gsize)self->sect_size;
+
+		if (total_done != fw_size) {
+			g_set_error(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_FAILED,
+				    "firmware size and number of sectors written "
+				    "mismatch (%" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT "):",
+				    total_done,
+				    fw_size);
+			return FALSE;
+		}
 	}
 
 	/* check mode operation for ffu install*/
-	if (!ext_csd[EXT_CSD_FFU_FEATURES]) {
+	if (!check_sect_done) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	} else {
 		/* re-enter ffu mode and install the firmware */

--- a/plugins/emmc/fu-emmc-plugin.c
+++ b/plugins/emmc/fu-emmc-plugin.c
@@ -24,6 +24,9 @@ static void
 fu_emmc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	FuContext *ctx = fu_plugin_get_context(plugin);
+
+	fu_context_add_quirk_key(ctx, "EmmcBlockSize");
 	fu_plugin_add_device_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EMMC_DEVICE);
 }

--- a/plugins/emmc/meson.build
+++ b/plugins/emmc/meson.build
@@ -3,6 +3,7 @@ if get_option('plugin_emmc').require(gudev.found(),
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginEmmc"']
 
+plugin_quirks += files('emmc.quirk')
 plugin_builtins += static_library('fu_plugin_emmc',
   sources: [
     'fu-emmc-plugin.c',


### PR DESCRIPTION
Here is v3 of this change.  This pull request contains few code fixes:

emmc: Check ffu features support: Only devices that support EXT_CSD_FFU_FEATURES should be checked for sectors done.
emmc: let FFU use close-ended mode - use the much-more efficient close-ended mode instead of open-ended.
emmc: Add emmc quirk - Allow to use different chunk size, and add some wdc devices that needs it.

Thanks,
Avri
