### PR TITLE
trivial: Avoid absolute buildtime paths in generated headers

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -202,7 +202,7 @@ plugins_hdr = custom_target('fwupd-generate-plugins-header',
   command : [
     generate_plugins_header,
     '@OUTPUT@',
-    meson.project_source_root(),
+    '.',
     ','.join(plugin_names),
   ],
 )


### PR DESCRIPTION
Using meson.project_source_root() means the path emitted to include .h files are absolute, which is not going to work if the -src package was used to re-build fwupd in a different build path.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
