### PR TITLE
Drop `HSI:INVALID:missing-data`

### DIFF
--- a/docs/hsi.md.in
+++ b/docs/hsi.md.in
@@ -140,16 +140,6 @@ A safe baseline for security should be HSI-1. If your system isn't at least meet
 
 The command line tool `fwupdmgr security` included with fwupd 1.8.4 or later will make individual recommendations on what you can do for individual test failures.  GUI tools built against `libfwupd` 1.8.4 or later may also make these recommendation as well.
 
-<a id="not-enough-info"></a>
-
-## [Not enough information](#not-enough-info)
-
-HSI calculations require that the SOC, firmware, and kernel provide enough data to the fwupd daemon about the state of the system.  If any HSI test that runs on the system declares it's *missing data* then the client will show a message like this:
-
-**Not enough data was provided to make an HSI calculation.**
-
-The HSI level will also be set to `INVALID` indicating this.
-
 <a id="tests"></a>
 
 ## [Tests included in fwupd](#tests)

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -258,8 +258,6 @@ fu_security_attrs_calculate_hsi(FuSecurityAttrs *self, FuSecurityAttrsFlags flag
 		if (fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_RUNTIME_ISSUE) &&
 		    fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
 			continue;
-		if (fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA))
-			return g_strdup("HSI:INVALID:missing-data");
 
 		attr_flags |= fwupd_security_attr_get_flags(attr);
 	}

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -412,14 +412,9 @@ fu_cpu_device_add_supported_cpu_attribute(FuCpuDevice *self, FuSecurityAttrs *at
 
 	attr = fu_device_security_attr_new(FU_DEVICE(self), FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
 	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
-	switch (fu_cpu_get_vendor()) {
-	case FU_CPU_VENDOR_INTEL:
-	case FU_CPU_VENDOR_AMD:
-		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-		break;
-	default:
-		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
-	}
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
+	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 	fu_security_attrs_append(attrs, attr);
 }
 

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -536,9 +536,17 @@ fu_plugin_add_security_attrs_mei_version(FuPlugin *plugin, FuSecurityAttrs *attr
 static void
 fu_pci_mei_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 {
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+
 	/* only Intel */
 	if (fu_cpu_get_vendor() != FU_CPU_VENDOR_INTEL)
 		return;
+
+	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
+	fwupd_security_attr_add_obsolete(attr, "cpu");
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
+	fu_security_attrs_append(attrs, attr);
 
 	fu_plugin_add_security_attrs_manufacturing_mode(plugin, attrs);
 	fu_plugin_add_security_attrs_override_strap(plugin, attrs);

--- a/plugins/pci-psp/fu-pci-psp-device.c
+++ b/plugins/pci-psp/fu-pci-psp-device.c
@@ -324,7 +324,7 @@ fu_pci_psp_device_init(FuPciPspDevice *self)
 	fu_device_add_icon(FU_DEVICE(self), "computer");
 	fu_device_add_parent_guid(FU_DEVICE(self), "cpu");
 	fu_device_set_vendor(FU_DEVICE(self), "Advanced Micro Devices, Inc.");
-	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_physical_id(FU_DEVICE(self), "pci-psp");
 }
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3172,24 +3172,6 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 
 	attrs = fu_engine_get_host_security_attrs(priv->engine);
 	items = fu_security_attrs_get_all(attrs);
-	for (guint j = 0; j < items->len; j++) {
-		FwupdSecurityAttr *attr = g_ptr_array_index(items, j);
-		g_autofree gchar *err_str = NULL;
-
-		if (!fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA))
-			continue;
-#ifndef SUPPORTED_BUILD
-		if (priv->flags & FWUPD_INSTALL_FLAG_FORCE)
-			continue;
-#endif
-		err_str = g_strdup_printf(
-		    "\n%s\n » %s",
-		    /* TRANSLATORS: error message to tell someone they can't use this feature */
-		    _("Not enough data was provided by the platform to make an HSI calculation."),
-		    "https://fwupd.github.io/hsi.html#not-enough-info");
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, err_str);
-		return FALSE;
-	}
 
 	/* print the "why" */
 	if (priv->as_json) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2324,7 +2324,7 @@ fu_security_attr_get_result(FwupdSecurityAttr *attr)
 	}
 
 	/* TRANSLATORS: Suffix: the fallback HSI result */
-	return _("Failed");
+	return _("Unknown");
 }
 
 static void

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2644,6 +2644,8 @@ fu_util_security_attrs_to_string(GPtrArray *attrs, FuSecurityAttrToStringFlags s
 			fu_security_attr_append_str(attr, str, strflags);
 			/* make sure they have at least HSI-1 */
 			if (j < FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT &&
+			    !fwupd_security_attr_has_flag(attr,
+							  FWUPD_SECURITY_ATTR_FLAG_OBSOLETED) &&
 			    !fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS))
 				low_help = TRUE;
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3911,25 +3911,6 @@ fu_util_security(FuUtilPrivate *priv, gchar **values, GError **error)
 	if (attrs == NULL)
 		return FALSE;
 
-	for (guint j = 0; j < attrs->len; j++) {
-		FwupdSecurityAttr *attr = g_ptr_array_index(attrs, j);
-		g_autofree gchar *err_str = NULL;
-
-		if (!fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA))
-			continue;
-#ifndef SUPPORTED_BUILD
-		if (priv->flags & FWUPD_INSTALL_FLAG_FORCE)
-			continue;
-#endif
-		err_str = g_strdup_printf(
-		    "\n%s\n » %s",
-		    /* TRANSLATORS: error message to tell someone they can't use this feature */
-		    _("Not enough data was provided by the platform to make an HSI calculation."),
-		    "https://fwupd.github.io/hsi.html#not-enough-info");
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, err_str);
-		return FALSE;
-	}
-
 	/* the "when" */
 	events = fwupd_client_get_host_security_events(priv->client,
 						       10,


### PR DESCRIPTION
This is a follow up from the various bugs that complain about unable to discover security attributes.  It flips the way that the CPU attribute works so that if PCI-PSP is missing it will continue to show all the attributes but with `Failed` instead of `HSI:INVALID:missing-data`

 Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
