### PR TITLE
Do not require a IEEE OUI to set up a DP AUX device

### DIFF
--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -88,10 +88,6 @@ fu_dpaux_device_setup(FuDevice *device, GError **error)
 	if (st == NULL)
 		return FALSE;
 	priv->dpcd_ieee_oui = fu_struct_dpaux_dpcd_get_ieee_oui(st);
-	if (priv->dpcd_ieee_oui == 0x0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no IEEE OUI set");
-		return FALSE;
-	}
 	priv->dpcd_hw_rev = fu_struct_dpaux_dpcd_get_hw_rev(st);
 	priv->dpcd_dev_id = fu_struct_dpaux_dpcd_get_dev_id(st);
 	fu_device_set_version_from_uint24(device, fu_struct_dpaux_dpcd_get_fw_ver(st));

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1266,6 +1266,12 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 	if (!FU_DEVICE_CLASS(fu_synaptics_mst_device_parent_class)->setup(device, error))
 		return FALSE;
 
+	/* sanity check */
+	if (fu_dpaux_device_get_dpcd_ieee_oui(FU_DPAUX_DEVICE(device)) == 0x0) {
+		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no IEEE OUI set");
+		return FALSE;
+	}
+
 	/* read vendor ID */
 	if (!fu_dpaux_device_read(FU_DPAUX_DEVICE(device),
 				  REG_RC_CAP,


### PR DESCRIPTION
This fixes a regression in mediatek_scaler which does not implement OUI data. The Synaptics MST plugin already checks for a specific OUI value anyway.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
