### PR TITLE
genesys-gl32xx: remove GUID based on CID only

### DIFF
--- a/plugins/genesys-gl32xx/README.md
+++ b/plugins/genesys-gl32xx/README.md
@@ -22,9 +22,8 @@ These devices also use custom GUID values, e.g.
 
 * `BLOCK\VEN_05E3&DEV_XXXX&VER_YY` (quirk-only)
 
-Additional GUID values based on customer ID read from the device, e.g.
+Additional GUID value based on firmware version stream and customer ID read from the device, e.g.
 
-* `BLOCK\VEN_05E3&DEV_XXXX&CID_ZZZZZZZZ`
 * `BLOCK\VEN_05E3&DEV_XXXX&VER_YY&CID_ZZZZZZZZ`
 
 ## Update Behavior

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -493,16 +493,7 @@ fu_genesys_gl32xx_device_ensure_cid(FuGenesysGl32xxDevice *self, GError **error)
 	cid = fu_memread_uint32(data, G_BIG_ENDIAN);
 	fu_device_add_instance_u32(FU_DEVICE(self), "CID", cid);
 
-	/* additional GUIDs with customer ID suffix */
-	if (!fu_device_build_instance_id(FU_DEVICE(self),
-					 error,
-					 "BLOCK",
-					 "VEN",
-					 "DEV",
-					 "CID",
-					 NULL))
-		return FALSE;
-
+	/* valid GUID with the pair of FW version stream and customer ID */
 	return fu_device_build_instance_id(FU_DEVICE(self),
 					   error,
 					   "BLOCK",


### PR DESCRIPTION
To identify customer device the pair VER and CID must be used. The GUID based on CID only is redundant and dangerous, so removing it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
