### PR TITLE
plugins: nordic-hid: Do not display GUID for "HIDRAW\VEN_1915"

### DIFF
--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -460,7 +460,9 @@ fu_nordic_hid_cfg_channel_add_peer(FuNordicHidCfgChannel *self, guint8 peer_id)
 	peer = fu_nordic_hid_cfg_channel_new(peer_id, self);
 
 	/* ensure that the general quirk content for Nordic HID devices is applied */
-	fu_device_add_instance_id(FU_DEVICE(peer), "HIDRAW\\VEN_1915");
+	fu_device_add_instance_id_full(FU_DEVICE(peer),
+				       "HIDRAW\\VEN_1915",
+				       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
 
 	if (!fu_device_setup(FU_DEVICE(peer), &error_local)) {
 		g_debug("failed to discover peer 0x%02x: %s", peer_id, error_local->message);


### PR DESCRIPTION
The GUID for "HIDRAW\VEN_1915" is added to HID peripherals connected through a dongle only to apply quirks. Do not display it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
