### PR TITLE
Rename `fwupdmgr sync-bkc` to `fwupdmgr sync` and also consider the b…

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -42,7 +42,7 @@ _fwupdmgr_cmd_list=(
 	'set-approved-firmware'
 	'set-bios-setting'
 	'switch-branch'
-	'sync-bkc'
+	'sync'
 	'unlock'
 	'unblock-firmware'
 	'update'

--- a/docs/best-known-configuration.md
+++ b/docs/best-known-configuration.md
@@ -32,12 +32,15 @@ let us know by [opening an issue](https://gitlab.com/fwupd/lvfs-website/-/issues
 
 When provisioning the client machine, we can set the BKC by setting `HostBkc=vendor-2021q1` in
 `/etc/fwupd/fwupd.conf`.
-Then any invocation of `fwupdmgr sync-bkc` will install or downgrade firmware on all compatible
-devices (UEFI, RAID, network adapter, & SAS HBA etc.) to make the system match a compatible set.
 
-Updating or downgrading firmware away from the *Best Known Configuration* is allowed, but the UI
-shows a warning.
-Using `fwupdmgr sync-bkc` will undo any manual changes and bring the machine back to the BKC.
+Any invocation of `fwupdmgr sync` will install or downgrade firmware on all compatible devices
+(e.g. UEFI, RAID, network adapter, & SAS HBA) to make the system match a compatible set.
+The `fwupdmgr sync` command will also ensure that firmware is installed that matches the device
+branch, if the device has one assigned.
+
+Updating or downgrading firmware away from the *Best Known Configuration* or to different branches
+is allowed, but the UI shows a warning.
+Using `fwupdmgr sync` will undo any manual changes and bring the machine back to the BKC.
 
 ## Local metadata
 
@@ -95,7 +98,7 @@ This then appears when getting the releases for that specific GUID:
 
 ..and can be synced on the command line:
 
-    $ fwupdmgr sync-bkc
+    $ fwupdmgr sync
     ╔══════════════════════════════════════════════════════════════════════════════╗
     ║ Downgrade System Firmware from 225.52.1521 to 225.53.1649?                   ║
     ╠══════════════════════════════════════════════════════════════════════════════╣

--- a/src/fu-engine-helper.c
+++ b/src/fu-engine-helper.c
@@ -126,7 +126,7 @@ fu_engine_update_motd(FuEngine *self, GError **error)
 		g_string_append_printf(str,
 				       "\n%s\n\n",
 				       /* TRANSLATORS: this is shown in the MOTD */
-				       _("Run `fwupdmgr sync-bkc` to complete this action."));
+				       _("Run `fwupdmgr sync` to complete this action."));
 	} else if (upgrade_count > 0) {
 		g_string_append(str, "\n");
 		g_string_append_printf(str,


### PR DESCRIPTION
…ranch

This allows the device to set a branch (e.g. the modem carrier configuration) and for the client to be able to *downgrade* the firmware version to make the device work.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
