### PR TITLE
trivial: amd-gpu: don't allow PCI generic GUIDs

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -101,8 +101,6 @@ fu_amd_gpu_device_probe(FuDevice *device, GError **error)
 		fu_device_add_protocol(device, "com.amd.pspvbflash");
 	}
 
-	fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN);
-
 	return TRUE;
 }
 
@@ -266,6 +264,8 @@ fu_amd_gpu_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_amd_gpu_device_init(FuAmdGpuDevice *self)
 {
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_AUTO_PARENT_CHILDREN);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_GENERIC_GUIDS);
 }
 
 static void


### PR DESCRIPTION
The intent should be to match to board IDs that were probed from the driver.

This doesn't actually work though for udev devices AFAICT; it seems like it's because the IDs were already added before the derived plugin runs.  I'd think this problem actually affects all the udev based  #plugins.

Here's a log of `sudo fwupdtool get-devices --plugins amd-gpu -vv` on a system:
https://dpaste.com/7Y8JP349J

@hughsie feel free to add commits to the branch to fix the underlying issue.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
