### PR TITLE
trivial: amd-gpu: move name to description field

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -117,6 +117,7 @@ fu_amd_gpu_device_setup(FuDevice *device, GError **error)
 	};
 	g_autofree gchar *part = NULL;
 	g_autofree gchar *ver = NULL;
+	g_autofree gchar *model = NULL;
 
 	if (!fu_udev_device_ioctl(FU_UDEV_DEVICE(device),
 				  DRM_IOCTL_AMDGPU_INFO,
@@ -132,12 +133,8 @@ fu_amd_gpu_device_setup(FuDevice *device, GError **error)
 	fu_device_set_version_raw(device, vbios_info.version);
 	ver = fu_strsafe((const gchar *)vbios_info.vbios_ver_str, sizeof(vbios_info.vbios_ver_str));
 	fu_device_set_version(device, ver);
-
-	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_INTERNAL)) {
-		g_autofree gchar *model = NULL;
-		model = fu_strsafe((const gchar *)vbios_info.name, sizeof(vbios_info.name));
-		fu_device_set_name(device, model);
-	}
+	model = fu_strsafe((const gchar *)vbios_info.name, sizeof(vbios_info.name));
+	fu_device_set_summary(device, model);
 
 	return TRUE;
 }


### PR DESCRIPTION
The model name on some dGPUs isn't really user friendly, it's better to default to the udev database for the name and instead show the description with model name info.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
