### PR TITLE
redfish: Parse all the type 42 SMBIOS tables

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -117,4 +117,5 @@ Remember: Plugins should be upstream!
 ## 1.9.8
 
 * `fu_device_build_instance_id_quirk": rename to`fu_device_build_instance_id_full()`
+* `fu_smbios_get_data()`: Now returns a array of `GByte`s
 * `fu_udev_device_get_fd()`: Use `fu_udev_device_get_io_channel()` instead

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -222,17 +222,16 @@ fu_context_get_smbios_string(FuContext *self, guint8 structure_type, guint8 offs
  * @structure_type: a SMBIOS structure type, e.g. %FU_SMBIOS_STRUCTURE_TYPE_BIOS
  * @error: (nullable): optional return location for an error
  *
- * Gets a hardware SMBIOS data.
+ * Gets all hardware SMBIOS data for a specific type.
  *
- * Returns: (transfer full): a #GBytes, or %NULL
+ * Returns: (transfer container) (element-type GBytes): a #GBytes, or %NULL if not found
  *
- * Since: 1.6.0
+ * Since: 1.9.8
  **/
-GBytes *
+GPtrArray *
 fu_context_get_smbios_data(FuContext *self, guint8 structure_type, GError **error)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GBytes) blob = NULL;
 
 	g_return_val_if_fail(FU_IS_CONTEXT(self), NULL);
 
@@ -242,14 +241,7 @@ fu_context_get_smbios_data(FuContext *self, guint8 structure_type, GError **erro
 		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED, "no data");
 		return NULL;
 	}
-	blob = fu_smbios_get_data(priv->smbios, structure_type, error);
-	if (blob == NULL)
-		return NULL;
-	if (g_bytes_get_size(blob) == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "no data");
-		return NULL;
-	}
-	return g_steal_pointer(&blob);
+	return fu_smbios_get_data(priv->smbios, structure_type, error);
 }
 
 /**

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -81,7 +81,7 @@ const gchar *
 fu_context_get_smbios_string(FuContext *self, guint8 structure_type, guint8 offset, GError **error);
 guint
 fu_context_get_smbios_integer(FuContext *self, guint8 type, guint8 offset, GError **error);
-GBytes *
+GPtrArray *
 fu_context_get_smbios_data(FuContext *self, guint8 structure_type, GError **error);
 gboolean
 fu_context_has_hwid_guid(FuContext *self, const gchar *guid);

--- a/libfwupdplugin/fu-smbios.h
+++ b/libfwupdplugin/fu-smbios.h
@@ -105,5 +105,5 @@ const gchar *
 fu_smbios_get_string(FuSmbios *self, guint8 type, guint8 offset, GError **error);
 guint
 fu_smbios_get_integer(FuSmbios *self, guint8 type, guint8 offset, GError **error);
-GBytes *
+GPtrArray *
 fu_smbios_get_data(FuSmbios *self, guint8 type, GError **error);

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -70,17 +70,20 @@ fu_dell_supported(FuPlugin *plugin, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuSmbiosChassisKind chassis_kind = fu_context_get_chassis_kind(ctx);
-	g_autoptr(GBytes) de_table = NULL;
-	g_autoptr(GBytes) da_table = NULL;
+	GBytes *de_blob = NULL;
+	GBytes *da_blob = NULL;
+	g_autoptr(GPtrArray) de_tables = NULL;
+	g_autoptr(GPtrArray) da_tables = NULL;
 	guint8 value = 0;
 	struct da_structure da_values = {0x0};
 
 	/* make sure that Dell SMBIOS methods are available */
-	de_table = fu_context_get_smbios_data(ctx, 0xDE, error);
-	if (de_table == NULL)
+	de_tables = fu_context_get_smbios_data(ctx, 0xDE, error);
+	if (de_tables == NULL)
 		return FALSE;
-	if (!fu_memread_uint8_safe(g_bytes_get_data(de_table, NULL),
-				   g_bytes_get_size(de_table),
+	de_blob = g_ptr_array_index(de_tables, 0);
+	if (!fu_memread_uint8_safe(g_bytes_get_data(de_blob, NULL),
+				   g_bytes_get_size(de_blob),
 				   0x0,
 				   &value,
 				   error)) {
@@ -92,14 +95,15 @@ fu_dell_supported(FuPlugin *plugin, GError **error)
 		return FALSE;
 	}
 
-	da_table = fu_context_get_smbios_data(ctx, 0xDA, error);
-	if (da_table == NULL)
+	da_tables = fu_context_get_smbios_data(ctx, 0xDA, error);
+	if (da_tables == NULL)
 		return FALSE;
+	da_blob = g_ptr_array_index(da_tables, 0);
 	if (!fu_memcpy_safe((guint8 *)&da_values,
 			    sizeof(da_values),
 			    0x0, /* dst */
-			    g_bytes_get_data(da_table, NULL),
-			    g_bytes_get_size(da_table),
+			    g_bytes_get_data(da_blob, NULL),
+			    g_bytes_get_size(da_blob),
 			    0x0, /* src */
 			    sizeof(da_values),
 			    error)) {

--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -96,18 +96,20 @@ static gboolean
 fu_flashrom_plugin_device_set_bios_info(FuPlugin *plugin, FuDevice *device, GError **error)
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
+	GBytes *bios_blob;
 	const guint8 *buf;
 	gsize bufsz;
 	guint32 bios_char = 0x0;
-	g_autoptr(GBytes) bios_table = NULL;
+	g_autoptr(GPtrArray) bios_tables = NULL;
 
 	/* get SMBIOS info */
-	bios_table = fu_context_get_smbios_data(ctx, FU_SMBIOS_STRUCTURE_TYPE_BIOS, error);
-	if (bios_table == NULL)
+	bios_tables = fu_context_get_smbios_data(ctx, FU_SMBIOS_STRUCTURE_TYPE_BIOS, error);
+	if (bios_tables == NULL)
 		return FALSE;
 
 	/* ROM size if not already been quirked */
-	buf = g_bytes_get_data(bios_table, &bufsz);
+	bios_blob = g_ptr_array_index(bios_tables, 0);
+	buf = g_bytes_get_data(bios_blob, &bufsz);
 	if (fu_device_get_firmware_size_max(device) == 0) {
 		guint8 bios_sz = 0x0;
 		if (fu_memread_uint8_safe(buf, bufsz, 0x9, &bios_sz, NULL)) {

--- a/plugins/redfish/fu-redfish-smbios.h
+++ b/plugins/redfish/fu-redfish-smbios.h
@@ -8,12 +8,16 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-redfish-struct.h"
+
 #define FU_TYPE_REDFISH_SMBIOS (fu_redfish_smbios_get_type())
 G_DECLARE_FINAL_TYPE(FuRedfishSmbios, fu_redfish_smbios, FU, REDFISH_SMBIOS, FuFirmware)
 
 FuRedfishSmbios *
 fu_redfish_smbios_new(void);
 
+FuRedfishSmbiosInterfaceType
+fu_redfish_smbios_get_interface_type(FuRedfishSmbios *self);
 guint16
 fu_redfish_smbios_get_port(FuRedfishSmbios *self);
 guint16

--- a/plugins/redfish/fu-redfish.rs
+++ b/plugins/redfish/fu-redfish.rs
@@ -40,8 +40,19 @@ enum RedfishIpAddressFormat {
 }
 
 #[repr(u8)]
-enum RedfishControllerInterfaceType {
-    NetworkHost = 0x40,
+#[derive(ToString)]
+enum RedfishSmbiosInterfaceType {
+    Unknown = 0x00,
+    Kcs = 0x02,
+    8250Uart = 0x03,
+    16450Uart = 0x04,
+    16550Uart = 0x05,
+    16650Uart = 0x06,
+    16750Uart = 0x07,
+    16850Uart = 0x08,
+    Mctp = 0x3F,
+    Network = 0x40,
+    Oem = 0xF0,
 }
 
 #[derive(ParseBytes)]
@@ -49,7 +60,7 @@ struct RedfishSmbiosType42 {
     type: u8 == 42,
     length: u8,
     handle: u16le,
-    interface_type: RedfishControllerInterfaceType == NetworkHost,
+    interface_type: RedfishSmbiosInterfaceType = Network,
     data_length: u8,
     // data: [u8; data_length],
     // protocol_cnt: u8,

--- a/plugins/uefi-capsule/fu-uefi-backend-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-linux.c
@@ -150,10 +150,12 @@ fu_uefi_backend_linux_coldplug(FuBackend *backend, FuProgress *progress, GError 
 static gboolean
 fu_uefi_backend_linux_check_smbios_enabled(FuContext *ctx, GError **error)
 {
+	GBytes *bios_blob;
 	const guint8 *data;
 	gsize sz;
-	g_autoptr(GBytes) bios_information = fu_context_get_smbios_data(ctx, 0, NULL);
-	if (bios_information == NULL) {
+	g_autoptr(GPtrArray) bios_tables = fu_context_get_smbios_data(ctx, 0, NULL);
+
+	if (bios_tables == NULL) {
 		const gchar *tmp = g_getenv("FWUPD_DELL_FAKE_SMBIOS");
 		if (tmp != NULL)
 			return TRUE;
@@ -163,7 +165,8 @@ fu_uefi_backend_linux_check_smbios_enabled(FuContext *ctx, GError **error)
 				    "SMBIOS not supported");
 		return FALSE;
 	}
-	data = g_bytes_get_data(bios_information, &sz);
+	bios_blob = g_ptr_array_index(bios_tables, 0);
+	data = g_bytes_get_data(bios_blob, &sz);
 	if (sz < 0x14) {
 		g_set_error(error,
 			    FWUPD_ERROR,


### PR DESCRIPTION
The reason we did not do this before is that the libfwupdplugin API only gave us the first entry. As it's perfect valid to have more than one table with the same structure type, return a list and allow the caller to filter them.

Fixes https://github.com/fwupd/fwupd/issues/6348

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
