### PR TITLE
Fix editing fwupd.conf when ProtectSystem=full and not using a prefix…

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -74,6 +74,11 @@ if build_daemon
       rw_directories += ['-/boot/efi', '-/efi/EFI', '-/boot/EFI', '-/boot/grub']
     endif
 
+    # not using ConfigurationDirectory further down
+    if get_option('prefix') != '/usr'
+      rw_directories += join_paths(sysconfdir, 'fwupd')
+    endif
+
     dynamic_options = []
     if systemd.version().version_compare('>= 232')
       dynamic_options += 'ProtectControlGroups=yes'


### PR DESCRIPTION
… of /usr

Add the sysconfdir to ReadWritePaths if not using ConfigurationDirectory.

Fixes https://github.com/fwupd/fwupd/issues/6370

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
