### PR TITLE
Remove timestamp from gzip to achieve reproducible build

### DIFF
--- a/generate-build/generate-quirk-builtin.py
+++ b/generate-build/generate-quirk-builtin.py
@@ -25,5 +25,5 @@ if __name__ == "__main__":
                 if line.startswith("#"):
                     continue
                 lines.append(line)
-    with gzip.open(args.output, "wb") as f:
+    with gzip.GzipFile(args.output, "wb", mtime=0) as f:
         f.write("\n".join(lines).encode())


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Python script `generate-build/generate-quirk-builtin.py` uses `gzip` to generate the `builtin.quirk.gz` artifact during building. A timestamp is appended to the file, making fwupd unreproducible as can be seen by the diffoscope log here:

https://reproducible.archlinux.org/api/v0/builds/534033/diffoscope

Until `gzip.open()` supports `mtime` (see python/cpython#91372), I suggest using `gzip.GZipFile()` instead with `mtime=0`. This generates the same file without embedding a timestamp, making the fwupd reproducible (at least in Arch Linux).


