### PR TITLE
Add re-plug flag

### DIFF
--- a/generate-build/generate-quirk-builtin.py
+++ b/generate-build/generate-quirk-builtin.py
@@ -25,5 +25,5 @@ if __name__ == "__main__":
                 if line.startswith("#"):
                     continue
                 lines.append(line)
-    with gzip.open(args.output, "wb") as f:
+    with gzip.GzipFile(args.output, "wb", mtime=0) as f:
         f.write("\n".join(lines).encode())

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -69,6 +69,18 @@ G_DEFINE_TYPE(FuVliUsbhubDevice, fu_vli_usbhub_device, FU_TYPE_VLI_DEVICE)
  * Device has a RTD21XX attached via I²C.
  */
 #define FU_VLI_USBHUB_DEVICE_FLAG_HAS_RTD21XX (1 << 6)
+/**
+ * FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_USB_CABLE:
+ *
+ * Unplug & re-plug USB cable to reset the device.
+ */
+#define FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_USB_CABLE (1 << 7)
+/**
+ * FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_POWER_CORD:
+ *
+ * Unplug & re-plug power cord to reset the device.
+ */
+#define FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_POWER_CORD (1 << 8)
 
 static void
 fu_vli_usbhub_device_to_string(FuDevice *device, guint idt, GString *str)
@@ -412,6 +424,42 @@ fu_vli_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **err
 						    tmp ^ (1 << 1),
 						    error))
 			return FALSE;
+	} else if (fu_device_has_private_flag(device,
+					      FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_USB_CABLE)) {
+		g_autoptr(FwupdRequest) request = fwupd_request_new();
+
+		/* the user has to do something */
+		fwupd_request_set_kind(request, FWUPD_REQUEST_KIND_IMMEDIATE);
+		fwupd_request_set_id(request, FWUPD_REQUEST_ID_REMOVE_REPLUG);
+		fwupd_request_add_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
+		fwupd_request_set_message(
+		    request,
+		    "The update will continue when the device USB cable has been "
+		    "unplugged and then re-inserted.");
+		if (!fu_device_emit_request(device, request, progress, error))
+			return FALSE;
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+
+		/* success */
+		return TRUE;
+	} else if (fu_device_has_private_flag(device,
+					      FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_POWER_CORD)) {
+		g_autoptr(FwupdRequest) request = fwupd_request_new();
+
+		/* the user has to do something */
+		fwupd_request_set_kind(request, FWUPD_REQUEST_KIND_IMMEDIATE);
+		fwupd_request_set_id(request, FWUPD_REQUEST_ID_REMOVE_REPLUG);
+		fwupd_request_add_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
+		fwupd_request_set_message(
+		    request,
+		    "The update will continue when the device power cord has been "
+		    "unplugged and then re-inserted.");
+		if (!fu_device_emit_request(device, request, progress, error))
+			return FALSE;
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+
+		/* success */
+		return TRUE;
 	} else {
 		/* replug, and ignore the device going away */
 		if (!g_usb_device_control_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(proxy)),
@@ -1406,6 +1454,12 @@ fu_vli_usbhub_device_init(FuVliUsbhubDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_VLI_USBHUB_DEVICE_FLAG_HAS_RTD21XX,
 					"has-rtd21xx");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_USB_CABLE,
+					"attach-with-usb");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_VLI_USBHUB_DEVICE_FLAG_ATTACH_WITH_POWER_CORD,
+					"attach-with-power");
 }
 
 static void

--- a/plugins/vli/vli-luxshare.quirk
+++ b/plugins/vli/vli-luxshare.quirk
@@ -2,7 +2,7 @@
 [USB\VID_208E&PID_0830]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3
+Flags = usb3,attach-with-power
 CounterpartGuid = USB\VID_208E&PID_2830
 [USB\VID_208E&PID_2830]
 Plugin = vli


### PR DESCRIPTION
Python script generate-build/generate-quirk-builtin.py uses gzip to generate the builtin.quirk.gz artifact during building. A timestamp is appended to the file, making fwupd unreproducible as can be seen by the diffoscope log here:

https://reproducible.archlinux.org/api/v0/builds/534033/diffoscope

Until gzip.open() supports mtime (see python/cpython#91372), I suggest using gzip.GZipFile() instead and passing mtime=0. This generates the same file without embedding a timestamp.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [x] Documentation
add "attach-with-usb" flag for dongle devices, unplug & re-plug usb cable to reboot
add "attach-with-power" flag for dock devices, unplug & re-plug power cord to reboot
