### PR TITLE
synaptics-mst: Disable scanning for cascade devices

### DIFF
--- a/plugins/synaptics-mst/README.md
+++ b/plugins/synaptics-mst/README.md
@@ -38,6 +38,18 @@ MST device may not enumerate if there is no monitor actually plugged in.
 
 The vendor ID is set from the PCI vendor, for example set to `DRM_DP_AUX_DEV:0x$(vid)`
 
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### Flags:ignore-board-id
+
+Ignore board ID firmware mismatch.
+
+### Flags:scan-cascade
+
+Scan MST controllers for remote cascade devices.
+
 ## Requirements
 
 ### (Kernel) DP Aux Interface

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -53,6 +53,13 @@
  */
 #define FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID (1 << 0)
 
+/**
+ * FU_SYNAPTICS_MST_DEVICE_FLAG_SCAN_CASCADE:
+ *
+ * Scan MST controllers for cascade devices.
+ */
+#define FU_SYNAPTICS_MST_DEVICE_FLAG_SCAN_CASCADE (1 << 1)
+
 struct _FuSynapticsMstDevice {
 	FuDpauxDevice parent_instance;
 	gchar *device_kind;
@@ -110,6 +117,9 @@ fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
 					"ignore-board-id");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_SYNAPTICS_MST_DEVICE_FLAG_SCAN_CASCADE,
+					"scan-cascade");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
 
@@ -1405,7 +1415,8 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to close parent: ");
 		return FALSE;
 	}
-	if (!fu_synaptics_mst_device_scan_cascade(self, 0, error))
+	if (fu_device_has_private_flag(device, FU_SYNAPTICS_MST_DEVICE_FLAG_SCAN_CASCADE) &&
+	    !fu_synaptics_mst_device_scan_cascade(self, 0, error))
 		return FALSE;
 
 	/* set up the device name and kind via quirks */


### PR DESCRIPTION
This is super slow -- the synaptics MST probes are the slowest thing in fwupd startup -- and we have to probe four relative adresses on each disovered layer. The real problem is we have never actually used the discovered remote devices!

Add a flag to stop the cascade scanning until we can rework the plugin to actually add them as child devices. I'm working with Synaptics to actually do that, although it's going to take a bit longer to complete.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
