### PR TITLE
trivial: Allow using `-` in `DisabledPlugins`

### DIFF
--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -128,8 +128,13 @@ fu_engine_config_reload(FuEngineConfig *self)
 					   "DisabledPlugins",
 					   FU_DAEMON_CONFIG_DEFAULT_DISABLED_PLUGINS);
 	if (plugins != NULL) {
-		for (guint i = 0; plugins[i] != NULL; i++)
-			g_ptr_array_add(self->disabled_plugins, g_strdup(plugins[i]));
+		for (guint i = 0; plugins[i] != NULL; i++) {
+			g_autofree gchar *plugin_name = fu_strstrip(plugins[i]);
+			if (plugin_name == NULL || plugin_name[0] == '\0')
+				continue;
+			g_strdelimit(plugin_name, "-", '_');
+			g_ptr_array_add(self->disabled_plugins, g_steal_pointer(&plugin_name));
+		}
 	}
 
 	/* get approved firmware */


### PR DESCRIPTION
If a plugin is specified using a `-` character replace it inline with `_` so that users can disable plugins that match the name of the directory instead of needing to know the project internally uses `_`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
