### PR TITLE
trivial: Use G_GNUC_WARN_UNUSED_RESULT when using _has_

### DIFF
--- a/libfwupd/fwupd-bios-setting.h
+++ b/libfwupd/fwupd-bios-setting.h
@@ -95,7 +95,8 @@ fwupd_bios_setting_get_description(FwupdBiosSetting *self);
 const gchar *
 fwupd_bios_setting_map_possible_value(FwupdBiosSetting *self, const gchar *key, GError **error);
 gboolean
-fwupd_bios_setting_has_possible_value(FwupdBiosSetting *self, const gchar *val);
+fwupd_bios_setting_has_possible_value(FwupdBiosSetting *self,
+				      const gchar *val) G_GNUC_WARN_UNUSED_RESULT;
 void
 fwupd_bios_setting_add_possible_value(FwupdBiosSetting *self, const gchar *possible_value);
 GPtrArray *

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -134,7 +134,7 @@ fwupd_device_add_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 void
 fwupd_device_remove_flag(FwupdDevice *self, FwupdDeviceFlags flag);
 gboolean
-fwupd_device_has_flag(FwupdDevice *self, FwupdDeviceFlags flag);
+fwupd_device_has_flag(FwupdDevice *self, FwupdDeviceFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 guint64
 fwupd_device_get_problems(FwupdDevice *self);
 void
@@ -144,7 +144,7 @@ fwupd_device_add_problem(FwupdDevice *self, FwupdDeviceProblem problem);
 void
 fwupd_device_remove_problem(FwupdDevice *self, FwupdDeviceProblem problem);
 gboolean
-fwupd_device_has_problem(FwupdDevice *self, FwupdDeviceProblem problem);
+fwupd_device_has_problem(FwupdDevice *self, FwupdDeviceProblem problem) G_GNUC_WARN_UNUSED_RESULT;
 guint64
 fwupd_device_get_created(FwupdDevice *self);
 void
@@ -158,7 +158,7 @@ fwupd_device_get_checksums(FwupdDevice *self);
 void
 fwupd_device_add_checksum(FwupdDevice *self, const gchar *checksum);
 gboolean
-fwupd_device_has_checksum(FwupdDevice *self, const gchar *checksum);
+fwupd_device_has_checksum(FwupdDevice *self, const gchar *checksum) G_GNUC_WARN_UNUSED_RESULT;
 const gchar *
 fwupd_device_get_plugin(FwupdDevice *self);
 void
@@ -172,7 +172,7 @@ fwupd_device_set_protocol(FwupdDevice *self, const gchar *protocol);
 void
 fwupd_device_add_protocol(FwupdDevice *self, const gchar *protocol);
 gboolean
-fwupd_device_has_protocol(FwupdDevice *self, const gchar *protocol);
+fwupd_device_has_protocol(FwupdDevice *self, const gchar *protocol) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_device_get_protocols(FwupdDevice *self);
 const gchar *
@@ -188,13 +188,13 @@ fwupd_device_set_vendor_id(FwupdDevice *self, const gchar *vendor_id);
 void
 fwupd_device_add_vendor_id(FwupdDevice *self, const gchar *vendor_id);
 gboolean
-fwupd_device_has_vendor_id(FwupdDevice *self, const gchar *vendor_id);
+fwupd_device_has_vendor_id(FwupdDevice *self, const gchar *vendor_id) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_device_get_vendor_ids(FwupdDevice *self);
 void
 fwupd_device_add_guid(FwupdDevice *self, const gchar *guid);
 gboolean
-fwupd_device_has_guid(FwupdDevice *self, const gchar *guid);
+fwupd_device_has_guid(FwupdDevice *self, const gchar *guid) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_device_get_guids(FwupdDevice *self);
 const gchar *
@@ -202,13 +202,13 @@ fwupd_device_get_guid_default(FwupdDevice *self);
 void
 fwupd_device_add_instance_id(FwupdDevice *self, const gchar *instance_id);
 gboolean
-fwupd_device_has_instance_id(FwupdDevice *self, const gchar *instance_id);
+fwupd_device_has_instance_id(FwupdDevice *self, const gchar *instance_id) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_device_get_instance_ids(FwupdDevice *self);
 void
 fwupd_device_add_icon(FwupdDevice *self, const gchar *icon);
 gboolean
-fwupd_device_has_icon(FwupdDevice *self, const gchar *icon);
+fwupd_device_has_icon(FwupdDevice *self, const gchar *icon) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_device_get_icons(FwupdDevice *self);
 GPtrArray *

--- a/libfwupd/fwupd-plugin.h
+++ b/libfwupd/fwupd-plugin.h
@@ -45,7 +45,7 @@ fwupd_plugin_add_flag(FwupdPlugin *self, FwupdPluginFlags flag);
 void
 fwupd_plugin_remove_flag(FwupdPlugin *self, FwupdPluginFlags flag);
 gboolean
-fwupd_plugin_has_flag(FwupdPlugin *self, FwupdPluginFlags flag);
+fwupd_plugin_has_flag(FwupdPlugin *self, FwupdPluginFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 
 FwupdPlugin *
 fwupd_plugin_from_variant(GVariant *value);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -54,19 +54,19 @@ fwupd_release_get_categories(FwupdRelease *self);
 void
 fwupd_release_add_category(FwupdRelease *self, const gchar *category);
 gboolean
-fwupd_release_has_category(FwupdRelease *self, const gchar *category);
+fwupd_release_has_category(FwupdRelease *self, const gchar *category) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_release_get_checksums(FwupdRelease *self);
 void
 fwupd_release_add_checksum(FwupdRelease *self, const gchar *checksum);
 gboolean
-fwupd_release_has_checksum(FwupdRelease *self, const gchar *checksum);
+fwupd_release_has_checksum(FwupdRelease *self, const gchar *checksum) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_release_get_tags(FwupdRelease *self);
 void
 fwupd_release_add_tag(FwupdRelease *self, const gchar *tag);
 gboolean
-fwupd_release_has_tag(FwupdRelease *self, const gchar *tag);
+fwupd_release_has_tag(FwupdRelease *self, const gchar *tag) G_GNUC_WARN_UNUSED_RESULT;
 
 GHashTable *
 fwupd_release_get_metadata(FwupdRelease *self);
@@ -168,7 +168,7 @@ fwupd_release_add_flag(FwupdRelease *self, FwupdReleaseFlags flag);
 void
 fwupd_release_remove_flag(FwupdRelease *self, FwupdReleaseFlags flag);
 gboolean
-fwupd_release_has_flag(FwupdRelease *self, FwupdReleaseFlags flag);
+fwupd_release_has_flag(FwupdRelease *self, FwupdReleaseFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 FwupdReleaseUrgency
 fwupd_release_get_urgency(FwupdRelease *self);
 void

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -134,7 +134,7 @@ fwupd_remote_add_flag(FwupdRemote *self, FwupdRemoteFlags flag);
 void
 fwupd_remote_remove_flag(FwupdRemote *self, FwupdRemoteFlags flag);
 gboolean
-fwupd_remote_has_flag(FwupdRemote *self, FwupdRemoteFlags flag);
+fwupd_remote_has_flag(FwupdRemote *self, FwupdRemoteFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 
 gboolean
 fwupd_remote_needs_refresh(FwupdRemote *self);

--- a/libfwupd/fwupd-report.h
+++ b/libfwupd/fwupd-report.h
@@ -124,7 +124,7 @@ fwupd_report_add_flag(FwupdReport *self, FwupdReportFlags flag);
 void
 fwupd_report_remove_flag(FwupdReport *self, FwupdReportFlags flag);
 gboolean
-fwupd_report_has_flag(FwupdReport *self, FwupdReportFlags flag);
+fwupd_report_has_flag(FwupdReport *self, FwupdReportFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 
 const gchar *
 fwupd_report_flag_to_string(FwupdReportFlags report_flag);

--- a/libfwupd/fwupd-request.h
+++ b/libfwupd/fwupd-request.h
@@ -194,7 +194,7 @@ fwupd_request_add_flag(FwupdRequest *self, FwupdRequestFlags flag);
 void
 fwupd_request_remove_flag(FwupdRequest *self, FwupdRequestFlags flag);
 gboolean
-fwupd_request_has_flag(FwupdRequest *self, FwupdRequestFlags flag);
+fwupd_request_has_flag(FwupdRequest *self, FwupdRequestFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 
 FwupdRequest *
 fwupd_request_from_variant(GVariant *value);

--- a/libfwupd/fwupd-security-attr.h
+++ b/libfwupd/fwupd-security-attr.h
@@ -200,7 +200,8 @@ fwupd_security_attr_get_obsoletes(FwupdSecurityAttr *self);
 void
 fwupd_security_attr_add_obsolete(FwupdSecurityAttr *self, const gchar *appstream_id);
 gboolean
-fwupd_security_attr_has_obsolete(FwupdSecurityAttr *self, const gchar *appstream_id);
+fwupd_security_attr_has_obsolete(FwupdSecurityAttr *self,
+				 const gchar *appstream_id) G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray *
 fwupd_security_attr_get_guids(FwupdSecurityAttr *self);
 void
@@ -208,7 +209,7 @@ fwupd_security_attr_add_guid(FwupdSecurityAttr *self, const gchar *guid);
 void
 fwupd_security_attr_add_guids(FwupdSecurityAttr *self, GPtrArray *guids);
 gboolean
-fwupd_security_attr_has_guid(FwupdSecurityAttr *self, const gchar *guid);
+fwupd_security_attr_has_guid(FwupdSecurityAttr *self, const gchar *guid) G_GNUC_WARN_UNUSED_RESULT;
 const gchar *
 fwupd_security_attr_get_metadata(FwupdSecurityAttr *self, const gchar *key);
 void
@@ -222,7 +223,8 @@ fwupd_security_attr_add_flag(FwupdSecurityAttr *self, FwupdSecurityAttrFlags fla
 void
 fwupd_security_attr_remove_flag(FwupdSecurityAttr *self, FwupdSecurityAttrFlags flag);
 gboolean
-fwupd_security_attr_has_flag(FwupdSecurityAttr *self, FwupdSecurityAttrFlags flag);
+fwupd_security_attr_has_flag(FwupdSecurityAttr *self,
+			     FwupdSecurityAttrFlags flag) G_GNUC_WARN_UNUSED_RESULT;
 const gchar *
 fwupd_security_attr_flag_to_string(FwupdSecurityAttrFlags flag);
 FwupdSecurityAttrFlags


### PR DESCRIPTION
This means we get a compile warning when typoing fwupd_device_has_flag() instead of fwupd_device_add_flag().

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
