### PR TITLE
trivial: Fix a tiny memory leak when using fwupdtool get-devices

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -212,7 +212,7 @@ fwupd_client_context_helper(FwupdClient *self, FwupdClientContextHelper *helper)
 	if (priv->idle_id == 0) {
 		g_autoptr(GSource) source = g_idle_source_new();
 		g_source_set_callback(source, fwupd_client_context_idle_cb, self, NULL);
-		priv->idle_id = g_source_attach(g_steal_pointer(&source), priv->main_ctx);
+		priv->idle_id = g_source_attach(source, priv->main_ctx);
 	}
 
 	/* run in the correct GMainContext and thread */


### PR DESCRIPTION
The GSource is ref'd in g_source_attach_unlocked().

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
