### PR TITLE
Only use the USB open-retry behaviour when required

### DIFF
--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -46,3 +46,7 @@ void
 fu_usb_device_set_configuration(FuUsbDevice *device, gint configuration);
 void
 fu_usb_device_add_interface(FuUsbDevice *device, guint8 number);
+void
+fu_usb_device_set_open_retry_count(FuUsbDevice *self, guint open_retry_count);
+guint
+fu_usb_device_get_open_retry_count(FuUsbDevice *self);

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -1289,6 +1289,7 @@ fu_logitech_bulkcontroller_device_init(FuLogitechBulkcontrollerDevice *self)
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_usb_device_set_open_retry_count(FU_USB_DEVICE(self), 5);
 	fu_device_retry_set_delay(FU_DEVICE(self), 1000);
 	fu_device_set_remove_delay(FU_DEVICE(self), 10 * 60 * 1000); /* >1 min to finish init */
 	fu_device_register_private_flag(FU_DEVICE(self),


### PR DESCRIPTION
This regressed the Hughski ColorHug plus test in 94eea8.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
