### PR TITLE
trivial: Handle G_DBUS_ERROR_NAME_HAS_NO_OWNER in the self tests

### DIFF
--- a/plugins/linux-swap/fu-self-test.c
+++ b/plugins/linux-swap/fu-self-test.c
@@ -32,18 +32,13 @@ fu_linux_swap_plain_func(void)
 			      "/dev/nvme0n1p4                          partition\t5962748\t0\t-2\n",
 			      0,
 			      &error);
-	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
-	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY) ||
+	if (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER) ||
+	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
 	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_EXEC_FAILED) ||
-	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT)) {
-		g_test_skip(error->message);
-		return;
-	}
-	if (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN)) {
-		g_test_skip(error->message);
-		return;
-	}
-	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED)) {
+	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED) ||
+	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT) ||
+	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY) ||
+	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
 		g_test_skip(error->message);
 		return;
 	}

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -136,7 +136,8 @@ fu_redfish_network_device_match(FuRedfishNetworkMatchHelper *helper, GError **er
 					 NULL,
 					 &error_local);
 	if (devices == NULL) {
-		if (g_error_matches(error_local, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN)) {
+		if (g_error_matches(error_local, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
+		    g_error_matches(error_local, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER)) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
Fixes some of https://github.com/fwupd/fwupd/issues/6418

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
