### PR TITLE
trivial: Fix incorrect usage of `strerror`

### DIFF
--- a/src/fu-polkit-agent.c
+++ b/src/fu-polkit-agent.c
@@ -192,7 +192,7 @@ fu_polkit_agent_open(GError **error)
 			    G_IO_ERROR,
 			    G_IO_ERROR_FAILED,
 			    "failed to create pipe: %s",
-			    strerror(-errno));
+			    strerror(errno));
 		return FALSE;
 	}
 


### PR DESCRIPTION
`strerror` takes the `errno` directly as its argument, negating it will result in an "Unknown error".

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
