### PR TITLE
chore: update to mordern meson build

### DIFF
--- a/data/pki/meson.build
+++ b/data/pki/meson.build
@@ -1,7 +1,8 @@
 # only install files that are going to be used
-if libjcat.type_name() != 'internal' and libjcat.version().version_compare('>= 0.1.9')
-  supported_gpg = libjcat.get_variable(pkgconfig: 'supported_gpg') == '1'
-  supported_pkcs7 = libjcat.get_variable(pkgconfig: 'supported_pkcs7') == '1'
+libjcat_dep = dependency('jcat', version: '>= 0.1.9', required: false)
+if libjcat_dep.found()
+  supported_gpg = libjcat_dep.get_variable(pkgconfig: 'supported_gpg', default_value: '0') == '1'
+  supported_pkcs7 = libjcat_dep.get_variable(pkgconfig: 'supported_pkcs7', default_value: '0') == '1'
 else
   supported_gpg = host_machine.system() != 'windows'
   supported_pkcs7 = true


### PR DESCRIPTION
fix the following build error

```
data/pki/meson.build:3:26: ERROR: Could not get pkg-config variable and no default provided for <PkgConfigDependency jcat: True ['>= 0.1.4']>
```

fixes #6432

relates to Homebrew/homebrew-core#154947

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
