### PR TITLE
Do not send requests when the sender is no longer alive

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -5909,6 +5909,15 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 		return FALSE;
 	}
 
+	/* already cancelled */
+	if (progress != NULL && fu_progress_has_flag(progress, FU_PROGRESS_FLAG_NO_SENDER)) {
+		g_set_error_literal(error,
+				    G_IO_ERROR,
+				    G_IO_ERROR_CANCELLED,
+				    "no sender, and so cannot process request");
+		return FALSE;
+	}
+
 	/* ignore */
 	if (fu_device_has_flag(self, FWUPD_DEVICE_FLAG_EMULATED)) {
 		g_info("ignoring device %s request of %s as emulated",

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -61,7 +61,7 @@ struct _FuProgress {
 	GObject parent_instance;
 	gchar *id;
 	gchar *name;
-	FuProgressFlags flags;
+	FuProgressFlag flags;
 	guint percentage;
 	FwupdStatus status;
 	GPtrArray *children; /* of FuProgress */
@@ -192,54 +192,6 @@ fu_progress_get_status(FuProgress *self)
 }
 
 /**
- * fu_progress_flag_to_string:
- * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
- *
- * Converts an progress flag to a string.
- *
- * Returns: identifier string
- *
- * Since: 1.7.0
- **/
-const gchar *
-fu_progress_flag_to_string(FuProgressFlags flag)
-{
-	if (flag == FU_PROGRESS_FLAG_GUESSED)
-		return "guessed";
-	if (flag == FU_PROGRESS_FLAG_NO_PROFILE)
-		return "no-profile";
-	if (flag == FU_PROGRESS_FLAG_NO_TRACEBACK)
-		return "no-traceback";
-	if (flag == FU_PROGRESS_FLAG_NO_SENDER)
-		return "no-sender";
-	return NULL;
-}
-
-/**
- * fu_progress_flag_from_string:
- * @flag: a string, e.g. `guessed`
- *
- * Converts a string to an progress flag.
- *
- * Returns: enumerated value
- *
- * Since: 1.7.0
- **/
-FuProgressFlags
-fu_progress_flag_from_string(const gchar *flag)
-{
-	if (g_strcmp0(flag, "guessed") == 0)
-		return FU_PROGRESS_FLAG_GUESSED;
-	if (g_strcmp0(flag, "no-profile") == 0)
-		return FU_PROGRESS_FLAG_NO_PROFILE;
-	if (g_strcmp0(flag, "no-traceback") == 0)
-		return FU_PROGRESS_FLAG_NO_TRACEBACK;
-	if (g_strcmp0(flag, "no-sender") == 0)
-		return FU_PROGRESS_FLAG_NO_SENDER;
-	return FU_PROGRESS_FLAG_UNKNOWN;
-}
-
-/**
  * fu_progress_add_flag:
  * @self: a #FuProgress
  * @flag: an internal progress flag, e.g. %FU_PROGRESS_FLAG_GUESSED
@@ -249,7 +201,7 @@ fu_progress_flag_from_string(const gchar *flag)
  * Since: 1.7.0
  **/
 void
-fu_progress_add_flag(FuProgress *self, FuProgressFlags flag)
+fu_progress_add_flag(FuProgress *self, FuProgressFlag flag)
 {
 	g_return_if_fail(FU_IS_PROGRESS(self));
 	self->flags |= flag;
@@ -265,7 +217,7 @@ fu_progress_add_flag(FuProgress *self, FuProgressFlags flag)
  * Since: 1.7.0
  **/
 void
-fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag)
+fu_progress_remove_flag(FuProgress *self, FuProgressFlag flag)
 {
 	g_return_if_fail(FU_IS_PROGRESS(self));
 	self->flags &= ~flag;
@@ -281,7 +233,7 @@ fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag)
  * Since: 1.7.0
  **/
 gboolean
-fu_progress_has_flag(FuProgress *self, FuProgressFlags flag)
+fu_progress_has_flag(FuProgress *self, FuProgressFlag flag)
 {
 	g_return_val_if_fail(FU_IS_PROGRESS(self), FALSE);
 	return (self->flags & flag) > 0;

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -210,6 +210,8 @@ fu_progress_flag_to_string(FuProgressFlags flag)
 		return "no-profile";
 	if (flag == FU_PROGRESS_FLAG_NO_TRACEBACK)
 		return "no-traceback";
+	if (flag == FU_PROGRESS_FLAG_NO_SENDER)
+		return "no-sender";
 	return NULL;
 }
 
@@ -232,6 +234,8 @@ fu_progress_flag_from_string(const gchar *flag)
 		return FU_PROGRESS_FLAG_NO_PROFILE;
 	if (g_strcmp0(flag, "no-traceback") == 0)
 		return FU_PROGRESS_FLAG_NO_TRACEBACK;
+	if (g_strcmp0(flag, "no-sender") == 0)
+		return FU_PROGRESS_FLAG_NO_SENDER;
 	return FU_PROGRESS_FLAG_UNKNOWN;
 }
 

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -9,78 +9,10 @@
 #include <fwupd.h>
 #include <gio/gio.h>
 
+#include "fu-progress-struct.h"
+
 #define FU_TYPE_PROGRESS (fu_progress_get_type())
 G_DECLARE_FINAL_TYPE(FuProgress, fu_progress, FU, PROGRESS, GObject)
-
-/**
- * FuProgressFlags:
- *
- * The progress internal flags.
- **/
-typedef guint64 FuProgressFlags;
-
-/**
- * FU_PROGRESS_FLAG_NONE:
- *
- * No flags set.
- *
- * Since: 1.7.0
- */
-#define FU_PROGRESS_FLAG_NONE (0)
-
-/**
- * FU_PROGRESS_FLAG_UNKNOWN:
- *
- * Unknown flag value.
- *
- * Since: 1.7.0
- */
-#define FU_PROGRESS_FLAG_UNKNOWN G_MAXUINT64
-
-/**
- * FU_PROGRESS_FLAG_GUESSED:
- *
- * The steps have not been measured on real hardware and have been guessed.
- *
- * Since: 1.7.0
- */
-#define FU_PROGRESS_FLAG_GUESSED (1ull << 0)
-
-/**
- * FU_PROGRESS_FLAG_NO_PROFILE:
- *
- * The steps cannot be accurate enough for a profile result.
- *
- * Since: 1.7.0
- */
-#define FU_PROGRESS_FLAG_NO_PROFILE (1ull << 1)
-
-/**
- * FU_PROGRESS_FLAG_CHILD_FINISHED:
- *
- * The child completed all the expected steps.
- *
- * Since: 1.8.2
- */
-#define FU_PROGRESS_FLAG_CHILD_FINISHED (1ull << 2)
-
-/**
- * FU_PROGRESS_FLAG_NO_TRACEBACK:
- *
- * The steps should not be shown in the traceback.
- *
- * Since: 1.8.2
- */
-#define FU_PROGRESS_FLAG_NO_TRACEBACK (1ull << 3)
-
-/**
- * FU_PROGRESS_FLAG_NO_SENDER:
- *
- * The task has no sender and is no longer able to perform requests.
- *
- * Since: 1.9.10
- */
-#define FU_PROGRESS_FLAG_NO_SENDER (1ull << 4)
 
 FuProgress *
 fu_progress_new(const gchar *id);
@@ -92,16 +24,12 @@ const gchar *
 fu_progress_get_name(FuProgress *self);
 void
 fu_progress_set_name(FuProgress *self, const gchar *name);
-const gchar *
-fu_progress_flag_to_string(FuProgressFlags flag);
-FuProgressFlags
-fu_progress_flag_from_string(const gchar *flag);
 void
-fu_progress_add_flag(FuProgress *self, FuProgressFlags flag);
+fu_progress_add_flag(FuProgress *self, FuProgressFlag flag);
 void
-fu_progress_remove_flag(FuProgress *self, FuProgressFlags flag);
+fu_progress_remove_flag(FuProgress *self, FuProgressFlag flag);
 gboolean
-fu_progress_has_flag(FuProgress *self, FuProgressFlags flag);
+fu_progress_has_flag(FuProgress *self, FuProgressFlag flag);
 FwupdStatus
 fu_progress_get_status(FuProgress *self);
 void

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -73,6 +73,15 @@ typedef guint64 FuProgressFlags;
  */
 #define FU_PROGRESS_FLAG_NO_TRACEBACK (1ull << 3)
 
+/**
+ * FU_PROGRESS_FLAG_NO_SENDER:
+ *
+ * The task has no sender and is no longer able to perform requests.
+ *
+ * Since: 1.9.10
+ */
+#define FU_PROGRESS_FLAG_NO_SENDER (1ull << 4)
+
 FuProgress *
 fu_progress_new(const gchar *id);
 const gchar *

--- a/libfwupdplugin/fu-progress.rs
+++ b/libfwupdplugin/fu-progress.rs
@@ -1,0 +1,12 @@
+// Copyright (C) 2023 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1+
+
+enum ProgressFlag {
+    None            = 0,        // Since: 1.7.0
+    Guessed         = 1 << 0,   // Since: 1.7.0
+    NoProfile       = 1 << 1,   // Since: 1.7.0
+    ChildFinished   = 1 << 2,   // Since: 1.8.2
+    NoTraceback     = 1 << 3,   // Since: 1.8.2
+    NoSender        = 1 << 4,   // Since: 1.9.10
+    Unknown         = u64::MAX, // Since: 1.7.0
+}

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -22,6 +22,7 @@ fwupdplugin_structs = [
   'fu-intel-thunderbolt.rs', # fuzzing
   'fu-oprom.rs', # fuzzing
   'fu-pefile.rs', # fuzzing
+  'fu-progress.rs', # fuzzing
   'fu-sbatlevel-section.rs', # fuzzing
   'fu-smbios.rs', # fuzzing
   'fu-usb-device-ds20.rs', # fuzzing

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -110,6 +110,13 @@ class EnumItem:
         return f"FU_{name_snake.upper()}_{_camel_to_snake(self.name).replace('-', '_').upper()}"
 
     def parse_default(self, val: str) -> None:
+
+        val = {
+            "u64::MAX": "G_MAXUINT64",
+            "u32::MAX": "G_MAXUINT32",
+            "u16::MAX": "G_MAXUINT16",
+            "u8::MAX": "G_MAXUINT8",
+        }.get(val, val)
         if val.startswith("0x") or val.startswith("0b"):
             val = val.replace("_", "")
         if val.startswith("0b"):


### PR DESCRIPTION
If the frontend quits or crashes then there is nothing that is able to handle the interactive request. This means that fwupd would wait for potentially a few minutes blocking all other requests until timing out.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
