### PR TITLE
amd-gpu: Fix probing mistake

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -111,7 +111,7 @@ fu_amd_gpu_device_setup(FuDevice *device, GError **error)
 	struct drm_amdgpu_info_vbios vbios_info;
 	struct drm_amdgpu_info request = {
 	    .query = AMDGPU_INFO_VBIOS,
-	    .return_pointer = GPOINTER_TO_UINT(&vbios_info),
+	    .return_pointer = GPOINTER_TO_SIZE(&vbios_info),
 	    .return_size = sizeof(struct drm_amdgpu_info_vbios),
 	    .vbios_info.type = AMDGPU_INFO_VBIOS_INFO,
 	};


### PR DESCRIPTION
While trying to fix a casting error, I accidentally broke 64 bit return addresses entirely.

Fixes: 5bb7ab869 ("trivial: amd-gpu: fix a casting error on 32 bit x86")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
