### PR TITLE
vli:7-in-1 dongle

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -382,6 +382,9 @@ fu_vli_usbhub_device_spi_write_data(FuVliDevice *self,
 					   error)) {
 		return FALSE;
 	}
+
+	/* patch for PUYA flash write data command */
+	fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 	return TRUE;
 }
 
@@ -772,6 +775,9 @@ fu_vli_usbhub_device_ready(FuDevice *device, GError **error)
 	/* FuUsbDevice->ready */
 	if (!FU_DEVICE_CLASS(fu_vli_usbhub_device_parent_class)->ready(device, error))
 		return FALSE;
+
+	/* to expose U3 hub, wait until fw is stable before sending VDR */
+	fu_device_sleep(FU_DEVICE(self), 100); /* ms */
 
 	/* try to read a block of data which will fail for 813-type devices */
 	if (fu_device_has_private_flag(device, FU_VLI_USBHUB_DEVICE_FLAG_UNLOCK_LEGACY813) &&


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [X] Documentation
Added a 1 ms delay to wait for the completion of PUYA SPI flash writing data.
To patch firmware issue exposing the USB3 hub, need to wait for some time for the firmware stable before sending vendor-commands.