### PR TITLE
Fix the warning 'already registered private FuMmDevice flag with value'

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -34,21 +34,6 @@
 /* Amount of time for the modem to get firmware version */
 #define MAX_WAIT_TIME_SECS 240 /* s */
 
-/**
- * FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE
- *
- * If no AT response is expected when entering fastboot mode.
- */
-#define FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE (1 << 0)
-
-/**
- * FU_MM_DEVICE_FLAG_USE_BRANCH
- *
- * Use the carrier (e.g. `VODAFONE`) as the device branch name so that `fwupdmgr sync` can
- * upgrade or downgrade the firmware as required.
- */
-#define FU_MM_DEVICE_FLAG_USE_BRANCH (1 << 1)
-
 struct _FuMmDevice {
 	FuDevice parent_instance;
 	MMManager *manager;

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -13,6 +13,13 @@
 #include <libmm-glib.h>
 
 /*
+ * FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE
+ *
+ * If no AT response is expected when entering fastboot mode.
+ */
+#define FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE (1 << 0)
+
+/*
  * FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT
  *
  * after entering the fastboot state, the modem cannot execute the attach method
@@ -20,6 +27,14 @@
  * when fu_mm_plugin_udev_uevent_cb detects it.
  */
 #define FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT (1 << 1)
+
+/*
+ * FU_MM_DEVICE_FLAG_USE_BRANCH
+ *
+ * Use the carrier (e.g. `VODAFONE`) as the device branch name so that `fwupdmgr sync` can
+ * upgrade or downgrade the firmware as required.
+ */
+#define FU_MM_DEVICE_FLAG_USE_BRANCH (1 << 2)
 
 #define FU_TYPE_MM_DEVICE (fu_mm_device_get_type())
 G_DECLARE_FINAL_TYPE(FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)


### PR DESCRIPTION
The private flags `uninhibit-modemmanager-after-fastboot-reboot` and `use-branch` had the same bitfield value!

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
