### PR TITLE
colorhug: Fix updating the first batch of ColorHug1

### DIFF
--- a/plugins/colorhug/colorhug.quirk
+++ b/plugins/colorhug/colorhug.quirk
@@ -10,7 +10,7 @@ InstallDuration = 8
 
 # ColorHug1: first batch!
 [USB\VID_04D8&PID_F8DA]
-Guid = USB\VID_273F&PID_1000
+Flags = legacy-vidpid
 
 [USB\VID_273F&PID_1001]
 Plugin = colorhug

--- a/plugins/colorhug/colorhug.quirk
+++ b/plugins/colorhug/colorhug.quirk
@@ -10,6 +10,7 @@ InstallDuration = 8
 
 # ColorHug1: first batch!
 [USB\VID_04D8&PID_F8DA]
+Plugin = colorhug
 Flags = legacy-vidpid
 
 [USB\VID_273F&PID_1001]

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -357,14 +357,10 @@ fu_colorhug_device_version_notify_cb(FuDevice *device, GParamSpec *pspec, gpoint
 		return;
 	if (fu_device_has_private_flag(device, FU_COLORHUG_DEVICE_FLAG_LEGACY_VIDPID)) {
 		if (g_str_has_prefix(version, "0.")) {
-			fu_device_add_instance_id_full(device,
-						       "USB\\VID_273F&PID_1000",
-						       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+			fu_device_add_instance_id(device, "USB\\VID_273F&PID_1000");
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		} else {
-			fu_device_add_instance_id_full(device,
-						       "USB\\VID_273F&PID_1001",
-						       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+			fu_device_add_instance_id(device, "USB\\VID_273F&PID_1001");
 			fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 		}
 	}

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -349,6 +349,27 @@ fu_colorhug_device_probe(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+static void
+fu_colorhug_device_version_notify_cb(FuDevice *device, GParamSpec *pspec, gpointer user_data)
+{
+	const gchar *version = fu_device_get_version(device);
+	if (version == NULL || fu_device_get_version_format(device) != FWUPD_VERSION_FORMAT_TRIPLET)
+		return;
+	if (fu_device_has_private_flag(device, FU_COLORHUG_DEVICE_FLAG_LEGACY_VIDPID)) {
+		if (g_str_has_prefix(version, "0.")) {
+			fu_device_add_instance_id_full(device,
+						       "USB\\VID_273F&PID_1000",
+						       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+		} else {
+			fu_device_add_instance_id_full(device,
+						       "USB\\VID_273F&PID_1001",
+						       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+			fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+		}
+	}
+}
+
 static gboolean
 fu_colorhug_device_setup(FuDevice *device, GError **error)
 {
@@ -397,25 +418,8 @@ fu_colorhug_device_setup(FuDevice *device, GError **error)
 		version = fu_colorhug_device_get_version(self, &error_local);
 		if (version != NULL) {
 			g_debug("obtained fwver using API '%s'", version);
-			fu_device_set_version(device, version);
 			fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
-			if (fu_device_has_private_flag(device,
-						       FU_COLORHUG_DEVICE_FLAG_LEGACY_VIDPID)) {
-				if (g_str_has_prefix(version, "0.")) {
-					fu_device_add_instance_id_full(
-					    device,
-					    "USB\\VID_273F&PID_1000",
-					    FU_DEVICE_INSTANCE_FLAG_QUIRKS);
-					fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-				} else {
-					fu_device_add_instance_id_full(
-					    device,
-					    "USB\\VID_273F&PID_1001",
-					    FU_DEVICE_INSTANCE_FLAG_QUIRKS);
-					fu_device_remove_flag(device,
-							      FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
-				}
-			}
+			fu_device_set_version(device, version);
 		} else {
 			g_warning("failed to get firmware version: %s", error_local->message);
 		}
@@ -616,6 +620,10 @@ fu_colorhug_device_init(FuColorhugDevice *self)
 					"legacy-vidpid");
 	fu_usb_device_set_configuration(FU_USB_DEVICE(self), CH_USB_CONFIG);
 	fu_usb_device_add_interface(FU_USB_DEVICE(self), CH_USB_INTERFACE);
+	g_signal_connect(FWUPD_DEVICE(self),
+			 "notify::version",
+			 G_CALLBACK(fu_colorhug_device_version_notify_cb),
+			 NULL);
 }
 
 static void


### PR DESCRIPTION
Use the version number prefix to set the bootloader mode in this case.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
