### PR TITLE
Never show a HSI index that is impossible

### DIFF
--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -248,10 +248,8 @@ fu_security_attrs_calculate_hsi(FuSecurityAttrs *self, FuSecurityAttrsFlags flag
 		}
 
 		/* abort */
-		if (failure_cnt > 0) {
-			hsi_number = j - 1;
+		if (failure_cnt > 0)
 			break;
-		}
 
 		/* we matched at least one thing on this level */
 		if (success_cnt > 0)


### PR DESCRIPTION
We already start the HSI level at zero, and set it on success -- just abort on failure.

Fixes some of https://github.com/fwupd/fwupd/issues/6454

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
