### PR TITLE
trivial: create HTML docs for device emulation

### DIFF
--- a/docs/fwupdplugin.toml.in
+++ b/docs/fwupdplugin.toml.in
@@ -45,6 +45,7 @@ content_files = [
   "env.md",
   "tutorial.md",
   "hsi.md",
+  "device-emulation.md",
   "ds20.md",
   "hwids.md",
   "bios-settings.md",


### PR DESCRIPTION
This looks like a miss from before when it was introduced and fixes a 404 on fwupd.github.io.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
