### PR TITLE
Never obsolete the wrong HSI attribute

### DIFF
--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -412,19 +412,6 @@ fu_cpu_device_add_security_attrs_intel_smap(FuCpuDevice *self, FuSecurityAttrs *
 }
 
 static void
-fu_cpu_device_add_supported_cpu_attribute(FuCpuDevice *self, FuSecurityAttrs *attrs)
-{
-	g_autoptr(FwupdSecurityAttr) attr = NULL;
-
-	attr = fu_device_security_attr_new(FU_DEVICE(self), FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
-	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
-	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
-	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
-	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
-	fu_security_attrs_append(attrs, attr);
-}
-
-static void
 fu_cpu_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
 {
 	FuCpuDevice *self = FU_CPU_DEVICE(device);
@@ -436,8 +423,6 @@ fu_cpu_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
 		fu_cpu_device_add_security_attrs_intel_tme(self, attrs);
 		fu_cpu_device_add_security_attrs_intel_smap(self, attrs);
 	}
-
-	fu_cpu_device_add_supported_cpu_attribute(self, attrs);
 }
 
 static void

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -542,11 +542,12 @@ fu_pci_mei_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (fu_cpu_get_vendor() != FU_CPU_VENDOR_INTEL)
 		return;
 
-	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
-	fwupd_security_attr_add_obsolete(attr, "cpu");
-	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
-	fu_security_attrs_append(attrs, attr);
+	/* CPU supported */
+	attr = fu_security_attrs_get_by_appstream_id(attrs,
+						     FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU,
+						     NULL);
+	if (attr != NULL)
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 
 	fu_plugin_add_security_attrs_manufacturing_mode(plugin, attrs);
 	fu_plugin_add_security_attrs_override_strap(plugin, attrs);

--- a/plugins/pci-psp/fu-pci-psp-device.c
+++ b/plugins/pci-psp/fu-pci-psp-device.c
@@ -78,12 +78,13 @@ fu_pci_psp_device_set_valid_data(FuDevice *device, FuSecurityAttrs *attrs)
 	if (self->supported)
 		return;
 
-	attr = fu_device_security_attr_new(device, FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
-	fwupd_security_attr_add_obsolete(attr, "cpu");
-	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
-	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
-	fu_security_attrs_append(attrs, attr);
+	/* CPU supported */
 	self->supported = TRUE;
+	attr = fu_security_attrs_get_by_appstream_id(attrs,
+						     FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU,
+						     NULL);
+	if (attr != NULL)
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 }
 
 static void

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6428,6 +6428,20 @@ fu_engine_get_host_bkc(FuEngine *self)
 
 #ifdef HAVE_HSI
 static void
+fu_engine_ensure_security_attrs_supported_cpu(FuEngine *self)
+{
+	g_autoptr(FwupdSecurityAttr) attr =
+	    fwupd_security_attr_new(FWUPD_SECURITY_ATTR_ID_SUPPORTED_CPU);
+	fwupd_security_attr_set_plugin(attr, "core");
+
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
+	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
+	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
+	fu_security_attrs_append(self->host_security_attrs, attr);
+}
+
+static void
 fu_engine_ensure_security_attrs_tainted(FuEngine *self)
 {
 	gboolean disabled_plugins = FALSE;
@@ -6906,6 +6920,7 @@ fu_engine_ensure_security_attrs(FuEngine *self)
 	fu_security_attrs_remove_all(self->host_security_attrs);
 
 	/* built in */
+	fu_engine_ensure_security_attrs_supported_cpu(self);
 	fu_engine_ensure_security_attrs_tainted(self);
 
 	/* call into devices */


### PR DESCRIPTION
Add the org.fwupd.hsi.SupportedCpu HSI attr early in the engine -- it's always needed and we can just find it then set 'success' in each plugin.

This means we don't have to do complicated rebasing of obsoleted attributes.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
