### PR TITLE
vli:reset_timeout

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -469,6 +469,9 @@ fu_vli_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **err
 					    G_USB_DEVICE_ERROR_NO_DEVICE) ||
 			    g_error_matches(error_local,
 					    G_USB_DEVICE_ERROR,
+					    G_USB_DEVICE_ERROR_TIMED_OUT) ||
+			    g_error_matches(error_local,
+					    G_USB_DEVICE_ERROR,
 					    G_USB_DEVICE_ERROR_FAILED)) {
 				g_debug("ignoring %s", error_local->message);
 			} else {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [X] Documentation
When VLI hub receives a reset command, it immediately resets itself without completing the control transfer command. So this timeout error is possible and we should ignore it.