### PR TITLE
trivial: debian: drop udev rules line in fwupd.install

### DIFF
--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -13,7 +13,6 @@ usr/share/metainfo/*
 usr/libexec/fwupd/*
 usr/lib/sysusers.d/*
 usr/share/man/*
-lib/udev/rules.d/*
 data/fwupd.conf etc/fwupd
 debian/fwupd.pkla /var/lib/polkit-1/localauthority/10-vendor.d
 usr/lib/*/fwupd-*/*.so


### PR DESCRIPTION
This is already handled by debian/rules.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057241

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
