### PR TITLE
trivial: Only define G_GNUC_NON_NULL for non-SUPPORTED builds

### DIFF
--- a/libfwupd/fwupd-build.h
+++ b/libfwupd/fwupd-build.h
@@ -10,7 +10,8 @@
 
 /* see https://bugzilla.gnome.org/show_bug.cgi?id=113075 */
 #ifndef G_GNUC_NON_NULL
-#if !defined(_WIN32) && (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)
+#if !defined(SUPPORTED_BUILD) && !defined(_WIN32) && (__GNUC__ > 3) ||                             \
+    (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)
 #define G_GNUC_NON_NULL(params...) __attribute__((nonnull(params)))
 #else
 #define G_GNUC_NON_NULL(params...)


### PR DESCRIPTION
If we've been over-eager we don't want the release builds to explode.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
