### PR TITLE
trivial: Add a GError to fu_cabinet_get_silo()

### DIFF
--- a/src/fu-cabinet-common.c
+++ b/src/fu-cabinet-common.c
@@ -34,5 +34,5 @@ fu_cabinet_build_silo(GBytes *blob, guint64 size_max, GError **error)
 	fu_firmware_set_size_max(FU_FIRMWARE(cabinet), size_max);
 	if (!fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
-	return fu_cabinet_get_silo(cabinet);
+	return fu_cabinet_get_silo(cabinet, error);
 }

--- a/src/fu-cabinet.h
+++ b/src/fu-cabinet.h
@@ -42,4 +42,4 @@ fu_cabinet_add_file(FuCabinet *self, const gchar *basename, GBytes *data);
 GBytes *
 fu_cabinet_get_file(FuCabinet *self, const gchar *basename, GError **error);
 XbSilo *
-fu_cabinet_get_silo(FuCabinet *self);
+fu_cabinet_get_silo(FuCabinet *self, GError **error);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4358,7 +4358,7 @@ fu_engine_get_silo_from_blob(FuEngine *self, GBytes *blob_cab, GError **error)
 	fu_cabinet_set_jcat_context(cabinet, self->jcat_context);
 	if (!fu_firmware_parse(FU_FIRMWARE(cabinet), blob_cab, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
-	return fu_cabinet_get_silo(cabinet);
+	return fu_cabinet_get_silo(cabinet, error);
 }
 
 static FuDevice *


### PR DESCRIPTION
It can fail if the archive is not loaded, so set an error.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
