### PR TITLE
trivial: Always seek to the correct offset in fu_bytes_get_contents_s…

### DIFF
--- a/libfwupdplugin/fu-bytes.c
+++ b/libfwupdplugin/fu-bytes.c
@@ -221,18 +221,16 @@ fu_bytes_get_contents_stream_full(GInputStream *stream, gsize offset, gsize coun
 		return NULL;
 	}
 
-	/* seek */
-	if (offset > 0) {
-		if (!g_seekable_can_seek(G_SEEKABLE(stream))) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_NOT_SUPPORTED,
-					    "input stream is not seekable");
-			return NULL;
-		}
-		if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error))
-			return NULL;
+	/* seek back to start */
+	if (!g_seekable_can_seek(G_SEEKABLE(stream))) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "input stream is not seekable");
+		return NULL;
 	}
+	if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error))
+		return NULL;
 
 	/* read from stream in 32kB chunks */
 	while (TRUE) {


### PR DESCRIPTION
…tream_full()

If we seeked to some other offset we need to reset it back to zero.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
