### PR TITLE
trivial: Always use project version for docgen

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -49,10 +49,7 @@ endif
 
 if build_docs and introspection.allowed()
   toml_conf = configuration_data()
-  docgen_version = source_version
-  if git.found() and source_version != fwupd_version
-    docgen_version = run_command([git, 'branch', '--show-current'], check: true).stdout().strip()
-  endif
+  docgen_version = meson.project_version()
   toml_conf.set('version', docgen_version)
   toml_conf.set('plugin_readme_outputs', ','.join(plugin_readme_outputs))
 


### PR DESCRIPTION
Fixes a series of warnings:
```
WARNING: Section aliases raised Invalid version: 'main'
WARNING: Section bitfields raised Invalid version: 'main'
WARNING: Section enums raised Invalid version: 'main'
WARNING: Section functions raised Invalid version: 'main'
WARNING: Section domains raised Invalid version: 'main'
WARNING: Section function_macros raised Invalid version: 'main'
WARNING: Section constants raised Invalid version: 'main'
WARNING: Section classes raised Invalid version: 'main'
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
