### PR TITLE
Fail the update if version doesn't match expected

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2416,12 +2416,14 @@ fu_engine_install_release(FuEngine *self,
 	if (version_rel != NULL && fu_version_compare(version_orig, version_rel, fmt) != 0 &&
 	    fu_version_compare(version_orig, fu_device_get_version(device), fmt) == 0 &&
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)) {
-		g_autofree gchar *str = NULL;
 		fu_device_set_update_state(device, FWUPD_UPDATE_STATE_FAILED);
-		str = g_strdup_printf("device version not updated on success, %s != %s",
-				      version_rel,
-				      fu_device_get_version(device));
-		fu_device_set_update_error(device, str);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "device version not updated on success, %s != %s",
+			    version_rel,
+			    fu_device_get_version(device));
+		return FALSE;
 	}
 
 	/* mark success unless needs a reboot */


### PR DESCRIPTION
If the flashed version doesn't match version read from the CAB file, the upgrade must fail.
Fixes https://github.com/fwupd/fwupd/issues/6513


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
