### PR TITLE
trivial: Correctly validate structures of structures in all cases

### DIFF
--- a/libfwupdplugin/fu-dfu-firmware.rs
+++ b/libfwupdplugin/fu-dfu-firmware.rs
@@ -27,7 +27,7 @@ struct DfuseImage {
     target_size: u32le,
     chunks: u32le,
 }
-#[derive(New, Validate, Parse)]
+#[derive(New, Parse)]
 struct DfuseElement {
     address: u32le,
     size: u32le,

--- a/libfwupdplugin/fu-efi.rs
+++ b/libfwupdplugin/fu-efi.rs
@@ -71,12 +71,12 @@ enum EfiSectionType {
     MmDepex = 0x1C,
 }
 
-#[derive(New, Validate, ParseBytes)]
+#[derive(New, ParseBytes)]
 struct EfiSection {
     size: u24le,
     type: EfiSectionType,
 }
-#[derive(New, Validate, ParseBytes)]
+#[derive(New, ParseBytes)]
 struct EfiSectionGuidDefined {
     name: Guid,
     offset: u16le,
@@ -95,12 +95,12 @@ struct EfiVolume {
     reserved: u8,
     revision: u8 == 0x02,
 }
-#[derive(New, Validate, ParseBytes)]
+#[derive(New, ParseBytes)]
 struct EfiVolumeBlockMap {
     num_blocks: u32le,
     length: u32le,
 }
-#[derive(New, Validate, Parse)]
+#[derive(New, Parse)]
 struct EfiSignatureList {
     type: Guid,
     list_size: u32le,

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -211,109 +211,6 @@
 }
 {%- endif %}
 
-{%- set export = obj.export('ParseInternal') %}
-{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
-{{export.value}}gboolean
-{{obj.c_method('ParseInternal')}}(GByteArray *st, GError **error)
-{
-    g_autofree gchar *str = NULL;
-{%- for item in obj.items | selectattr('struct_obj') %}
-    if (!{{item.struct_obj.c_method('Validate')}}(st->data, st->len, {{item.c_define('OFFSET')}}, error))
-        return FALSE;
-{%- endfor %}
-{%- for item in obj.items | selectattr('constant') %}
-{%- if item.type == Type.STRING %}
-    if (strncmp((const gchar *) (st->data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
-{%- elif item.type == Type.GUID or (item.type == Type.U8 and item.multiplier) %}
-    if (memcmp(st->data + {{item.offset}}, "{{item.constant}}", {{item.size}}) != 0) {
-{%- else %}
-    if ({{item.c_getter}}(st) != {{item.constant}}) {
-{%- endif %}
-        g_set_error_literal(error,
-                            G_IO_ERROR,
-                            G_IO_ERROR_INVALID_DATA,
-                            "constant {{obj.name}}.{{item.element_id}} was not valid, expected {{item.constant}}");
-        return FALSE;
-    }
-{%- endfor %}
-    str = {{obj.c_method('ToString')}}(st);
-    g_debug("%s", str);
-    return TRUE;
-}
-{%- endif %}
-
-{%- set export = obj.export('Parse') %}
-{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
-
-/**
- * {{obj.c_method('Parse')}}: (skip):
- **/
-{{export.value}}GByteArray *
-{{obj.c_method('Parse')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
-{
-    g_autoptr(GByteArray) st = g_byte_array_new();
-    g_return_val_if_fail(buf != NULL, NULL);
-    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-    if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
-        g_prefix_error(error, "invalid struct {{obj.name}}: ");
-        return NULL;
-    }
-    g_byte_array_append(st, buf + offset, {{obj.size}});
-    if (!{{obj.c_method('ParseInternal')}}(st, error))
-        return NULL;
-    return g_steal_pointer(&st);
-}
-{%- endif %}
-
-{%- set export = obj.export('ParseBytes') %}
-{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
-/**
- * {{obj.c_method('ParseBytes')}}: (skip):
- **/
-{{export.value}}GByteArray *
-{{obj.c_method('ParseBytes')}}(GBytes *blob, gsize offset, GError **error)
-{
-    gsize bufsz = 0;
-    const guint8 *buf = g_bytes_get_data(blob, &bufsz);
-    return {{obj.c_method('Parse')}}(buf, bufsz, offset, error);
-}
-{%- endif %}
-
-{%- set export = obj.export('ParseStream') %}
-{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
-/**
- * {{obj.c_method('ParseStream')}}: (skip):
- **/
-{{export.value}}GByteArray *
-{{obj.c_method('ParseStream')}}(GInputStream *stream, gsize offset, GError **error)
-{
-    gssize rc;
-    g_autoptr(GByteArray) st = g_byte_array_new();
-    if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error)) {
-        g_prefix_error(error, "{{obj.name}} failed seek to 0x%x: ", (guint) offset);
-        return NULL;
-    }
-    g_byte_array_set_size(st, {{obj.size}});
-    rc = g_input_stream_read(stream, st->data, st->len, NULL, error);
-    if (rc == -1) {
-        g_prefix_error(error, "{{obj.name}} failed read of 0x%x: ", (guint) st->len);
-        return NULL;
-    }
-    if (rc != st->len) {
-        g_set_error(error,
-                    G_IO_ERROR,
-                    G_IO_ERROR_PARTIAL_INPUT,
-                    "{{obj.name}} requested 0x%x and got 0x%x",
-                    (guint) st->len,
-                    (guint) rc);
-        return NULL;
-    }
-    if (!{{obj.c_method('ParseInternal')}}(st, error))
-        return NULL;
-    return g_steal_pointer(&st);
-}
-{%- endif %}
-
 {%- set export = obj.export('ValidateInternal') %}
 {%- if export in [Export.PUBLIC, Export.PRIVATE] %}
 {{export.value}}gboolean
@@ -322,8 +219,10 @@
 {%- for item in obj.items | selectattr('constant') %}
 {%- if item.type == Type.STRING %}
     if (strncmp((const gchar *) (st->data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
-{%- elif item.type == Type.GUID or (item.type == Type.U8 and item.multiplier) %}
+{%- elif item.type == Type.GUID %}
     if (memcmp({{item.c_getter}}(st), "{{item.constant}}", {{item.size}}) != 0) {
+{%- elif item.type == Type.U8 and item.multiplier %}
+    if (memcmp(st->data + {{item.offset}}, "{{item.constant}}", {{item.size}}) != 0) {
 {%- else %}
     if ({{item.c_getter}}(st) != {{item.constant}}) {
 {%- endif %}
@@ -401,10 +300,6 @@
                     (guint) rc);
         return FALSE;
     }
-{%- for item in obj.items | selectattr('struct_obj') %}
-    if (!{{item.struct_obj.c_method('ValidateStream')}}(stream, offset + {{item.c_define('OFFSET')}}, error))
-        return FALSE;
-{%- endfor %}
     return {{obj.c_method('ValidateInternal')}}(st, error);
 }
 {%- endif %}
@@ -420,5 +315,91 @@
     gsize bufsz = 0;
     const guint8 *buf = g_bytes_get_data(blob, &bufsz);
     return {{obj.c_method('Validate')}}(buf, bufsz, offset, error);
+}
+{%- endif %}
+
+{%- set export = obj.export('ParseInternal') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+{{export.value}}gboolean
+{{obj.c_method('ParseInternal')}}(GByteArray *st, GError **error)
+{
+    g_autofree gchar *str = NULL;
+    if (!{{obj.c_method('ValidateInternal')}}(st, error))
+        return FALSE;
+    str = {{obj.c_method('ToString')}}(st);
+    g_debug("%s", str);
+    return TRUE;
+}
+{%- endif %}
+
+{%- set export = obj.export('Parse') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+
+/**
+ * {{obj.c_method('Parse')}}: (skip):
+ **/
+{{export.value}}GByteArray *
+{{obj.c_method('Parse')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
+{
+    g_autoptr(GByteArray) st = g_byte_array_new();
+    g_return_val_if_fail(buf != NULL, NULL);
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+    if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
+        g_prefix_error(error, "invalid struct {{obj.name}}: ");
+        return NULL;
+    }
+    g_byte_array_append(st, buf + offset, {{obj.size}});
+    if (!{{obj.c_method('ParseInternal')}}(st, error))
+        return NULL;
+    return g_steal_pointer(&st);
+}
+{%- endif %}
+
+{%- set export = obj.export('ParseBytes') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+/**
+ * {{obj.c_method('ParseBytes')}}: (skip):
+ **/
+{{export.value}}GByteArray *
+{{obj.c_method('ParseBytes')}}(GBytes *blob, gsize offset, GError **error)
+{
+    gsize bufsz = 0;
+    const guint8 *buf = g_bytes_get_data(blob, &bufsz);
+    return {{obj.c_method('Parse')}}(buf, bufsz, offset, error);
+}
+{%- endif %}
+
+{%- set export = obj.export('ParseStream') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+/**
+ * {{obj.c_method('ParseStream')}}: (skip):
+ **/
+{{export.value}}GByteArray *
+{{obj.c_method('ParseStream')}}(GInputStream *stream, gsize offset, GError **error)
+{
+    gssize rc;
+    g_autoptr(GByteArray) st = g_byte_array_new();
+    if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error)) {
+        g_prefix_error(error, "{{obj.name}} failed seek to 0x%x: ", (guint) offset);
+        return NULL;
+    }
+    g_byte_array_set_size(st, {{obj.size}});
+    rc = g_input_stream_read(stream, st->data, st->len, NULL, error);
+    if (rc == -1) {
+        g_prefix_error(error, "{{obj.name}} failed read of 0x%x: ", (guint) st->len);
+        return NULL;
+    }
+    if (rc != st->len) {
+        g_set_error(error,
+                    G_IO_ERROR,
+                    G_IO_ERROR_PARTIAL_INPUT,
+                    "{{obj.name}} requested 0x%x and got 0x%x",
+                    (guint) st->len,
+                    (guint) rc);
+        return NULL;
+    }
+    if (!{{obj.c_method('ParseInternal')}}(st, error))
+        return NULL;
+    return g_steal_pointer(&st);
 }
 {%- endif %}

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -334,6 +334,16 @@
         return FALSE;
     }
 {%- endfor %}
+{%- for item in obj.items | selectattr('struct_obj') %}
+    {
+        GByteArray st_tmp = {
+            .data = (guint8*) st->data + {{item.c_define('OFFSET')}},
+            .len = {{item.size}},
+        };
+        if (!{{item.struct_obj.c_method('ValidateInternal')}}(&st_tmp, error))
+            return FALSE;
+    }
+{%- endfor %}
     return TRUE;
 }
 
@@ -347,24 +357,16 @@
 {{export.value}}gboolean
 {{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
-{%- if obj.has_constant %}
     GByteArray st = {.data = (guint8 *) buf + offset, .len = bufsz - offset, };
-{%- endif %}
     g_return_val_if_fail(buf != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
         g_prefix_error(error, "invalid struct {{obj.name}}: ");
         return FALSE;
     }
-{%- for item in obj.items | selectattr('struct_obj') %}
-    if (!{{item.struct_obj.c_method('Validate')}}(buf, bufsz, offset + {{item.c_define('OFFSET')}}, error))
+    if (!{{obj.c_method('ValidateInternal')}}(&st, error))
         return FALSE;
-{%- endfor %}
-{%- if obj.has_constant %}
-    return {{obj.c_method('ValidateInternal')}}(&st, error);
-{%- else %}
     return TRUE;
-{%- endif %}
 }
 {%- endif %}
 
@@ -376,13 +378,10 @@
 {{export.value}}gboolean
 {{obj.c_method('ValidateStream')}}(GInputStream *stream, gsize offset, GError **error)
 {
-{%- if obj.has_constant %}
     gssize rc;
     g_autoptr(GByteArray) st = g_byte_array_new();
-{%- endif %}
     g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-{%- if obj.has_constant %}
     if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error)) {
         g_prefix_error(error, "{{obj.name}} failed seek to 0x%x: ", (guint) offset);
         return FALSE;
@@ -402,8 +401,6 @@
                     (guint) rc);
         return FALSE;
     }
-{%- endif %}
-
 {%- for item in obj.items | selectattr('struct_obj') %}
     if (!{{item.struct_obj.c_method('ValidateStream')}}(stream, offset + {{item.c_define('OFFSET')}}, error))
         return FALSE;

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -200,6 +200,7 @@ class StructObj:
             self.add_private_export("Parse")
         elif derive == "ParseInternal":
             self.add_private_export("ToString")
+            self.add_private_export("ValidateInternal")
             for item in self.items:
                 if (
                     item.constant
@@ -208,7 +209,7 @@ class StructObj:
                 ):
                     item.add_private_export("Getters")
                 if item.struct_obj:
-                    item.struct_obj.add_private_export("Validate")
+                    item.struct_obj.add_private_export("ValidateInternal")
         elif derive == "New":
             for item in self.items:
                 if item.constant and not (item.type == Type.U8 and item.multiplier):

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -173,6 +173,12 @@ class StructObj:
             return
         self._exports[derive] = Export.PRIVATE
         if derive == "Validate":
+            self.add_private_export("ValidateInternal")
+        elif derive == "ValidateStream":
+            self.add_private_export("ValidateInternal")
+        elif derive == "ValidateBytes":
+            self.add_private_export("Validate")
+        elif derive == "ValidateInternal":
             for item in self.items:
                 if (
                     item.constant
@@ -181,13 +187,7 @@ class StructObj:
                 ):
                     item.add_private_export("Getters")
                 if item.struct_obj:
-                    item.struct_obj.add_private_export("Validate")
-            if self.has_constant:
-                self.add_private_export("ValidateInternal")
-        elif derive == "ValidateStream":
-            self.add_private_export("ValidateInternal")
-        elif derive == "ValidateBytes":
-            self.add_private_export("Validate")
+                    item.struct_obj.add_private_export("ValidateInternal")
         elif derive == "ToString":
             for item in self.items:
                 if item.enum_obj and not item.constant:


### PR DESCRIPTION
Also, in some cases plugins were using validate to check for buffer correctness, so don't optimize that away even if there are no constants to check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
