### PR TITLE
Fix miscalculation `fu_mei_device_write` timeout

### DIFF
--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -417,7 +417,7 @@ fu_mei_device_write(FuMeiDevice *self,
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	tv.tv_sec = timeout_ms / 1000;
-	tv.tv_usec = (timeout_ms % 1000) * 1000000;
+	tv.tv_usec = (timeout_ms % 1000) * 1000;
 
 	fu_dump_raw(G_LOG_DOMAIN, "write", buf, bufsz);
 	written = write(fd, buf, bufsz);


### PR DESCRIPTION
It appears the `fu_mei_device_write` function intends to have a 200ms timeout. However, it actually ends up with a 200s timeout because of a miscalculation on timing. (1 millisecond = 1000 microseconds, not 100000 microseconds).

With this miscalcuation, `fwupd` hangs when running. This makes all `fwupdmgr` commands fail as they have a 25 second timeout.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
