### PR TITLE
trivial: Rename FuFirmwareClass->check_magic to ->validate

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -458,7 +458,7 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 }
 
 static gboolean
-fu_cab_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_cab_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_cab_header_validate_bytes(fw, offset, error);
 }
@@ -837,7 +837,7 @@ static void
 fu_cab_firmware_class_init(FuCabFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_cab_firmware_check_magic;
+	klass_firmware->validate = fu_cab_firmware_validate;
 	klass_firmware->parse = fu_cab_firmware_parse;
 	klass_firmware->write = fu_cab_firmware_write;
 	klass_firmware->build = fu_cab_firmware_build;

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -197,7 +197,7 @@ fu_dfu_firmware_set_version(FuDfuFirmware *self, guint16 version)
 }
 
 static gboolean
-fu_dfu_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_dfu_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_dfu_ftr_validate_bytes(fw,
 						g_bytes_get_size(fw) - FU_STRUCT_DFU_FTR_SIZE,
@@ -360,7 +360,7 @@ static void
 fu_dfu_firmware_class_init(FuDfuFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_dfu_firmware_check_magic;
+	klass_firmware->validate = fu_dfu_firmware_validate;
 	klass_firmware->export = fu_dfu_firmware_export;
 	klass_firmware->parse = fu_dfu_firmware_parse;
 	klass_firmware->write = fu_dfu_firmware_write;

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -98,7 +98,7 @@ fu_dfuse_firmware_image_parse(FuDfuseFirmware *self, GBytes *bytes, gsize *offse
 }
 
 static gboolean
-fu_dfuse_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_dfuse_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_dfuse_hdr_validate_bytes(fw, offset, error);
 }
@@ -260,7 +260,7 @@ static void
 fu_dfuse_firmware_class_init(FuDfuseFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_dfuse_firmware_check_magic;
+	klass_firmware->validate = fu_dfuse_firmware_validate;
 	klass_firmware->parse = fu_dfuse_firmware_parse;
 	klass_firmware->write = fu_dfuse_firmware_write;
 }

--- a/libfwupdplugin/fu-efi-firmware-volume.c
+++ b/libfwupdplugin/fu-efi-firmware-volume.c
@@ -45,7 +45,7 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 }
 
 static gboolean
-fu_efi_firmware_volume_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_efi_firmware_volume_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_efi_volume_validate_bytes(fw, offset, error);
 }
@@ -267,7 +267,7 @@ static void
 fu_efi_firmware_volume_class_init(FuEfiFirmwareVolumeClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_efi_firmware_volume_check_magic;
+	klass_firmware->validate = fu_efi_firmware_volume_validate;
 	klass_firmware->parse = fu_efi_firmware_volume_parse;
 	klass_firmware->write = fu_efi_firmware_volume_write;
 	klass_firmware->export = fu_ifd_firmware_export;

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -188,7 +188,7 @@ fu_efi_signature_list_get_version(FuEfiSignatureList *self)
 }
 
 static gboolean
-fu_efi_signature_list_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_efi_signature_list_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	fwupd_guid_t guid = {0x0};
 	g_autofree gchar *sig_type = NULL;
@@ -282,7 +282,7 @@ static void
 fu_efi_signature_list_class_init(FuEfiSignatureListClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_efi_signature_list_check_magic;
+	klass_firmware->validate = fu_efi_signature_list_validate;
 	klass_firmware->parse = fu_efi_signature_list_parse;
 	klass_firmware->write = fu_efi_signature_list_write;
 }

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -26,7 +26,7 @@
 G_DEFINE_TYPE(FuElfFirmware, fu_elf_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_elf_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_elf_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_elf_file_header64le_validate_bytes(fw, offset, error);
 }
@@ -141,7 +141,7 @@ static void
 fu_elf_firmware_class_init(FuElfFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_elf_firmware_check_magic;
+	klass_firmware->validate = fu_elf_firmware_validate;
 	klass_firmware->parse = fu_elf_firmware_parse;
 }
 

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -318,7 +318,7 @@ fu_fdt_firmware_parse_mem_rsvmap(FuFdtFirmware *self, GBytes *fw, gsize offset, 
 }
 
 static gboolean
-fu_fdt_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_fdt_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_fdt_validate_bytes(fw, offset, error);
 }
@@ -573,7 +573,7 @@ static void
 fu_fdt_firmware_class_init(FuFdtFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_fdt_firmware_check_magic;
+	klass_firmware->validate = fu_fdt_firmware_validate;
 	klass_firmware->export = fu_fdt_firmware_export;
 	klass_firmware->parse = fu_fdt_firmware_parse;
 	klass_firmware->write = fu_fdt_firmware_write;

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -67,7 +67,7 @@ struct _FuFirmwareClass {
 	gchar *(*get_checksum)(FuFirmware *self,
 			       GChecksumType csum_kind,
 			       GError **error)G_GNUC_WARN_UNUSED_RESULT;
-	gboolean (*check_magic)(FuFirmware *self, GBytes *fw, gsize offset, GError **error);
+	gboolean (*validate)(FuFirmware *self, GBytes *fw, gsize offset, GError **error);
 	gboolean (*validate_stream)(FuFirmware *self,
 				    GInputStream *stream,
 				    gsize offset,

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -25,7 +25,7 @@
 G_DEFINE_TYPE(FuFmapFirmware, fu_fmap_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_fmap_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_fmap_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_fmap_validate_bytes(fw, offset, error);
 }
@@ -178,7 +178,7 @@ static void
 fu_fmap_firmware_class_init(FuFmapFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_fmap_firmware_check_magic;
+	klass_firmware->validate = fu_fmap_firmware_validate;
 	klass_firmware->parse = fu_fmap_firmware_parse;
 	klass_firmware->write = fu_fmap_firmware_write;
 }

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -90,7 +90,7 @@ fu_ifd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 }
 
 static gboolean
-fu_ifd_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ifd_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_ifd_fdbar_validate_bytes(fw, offset, error);
 }
@@ -439,7 +439,7 @@ fu_ifd_firmware_class_init(FuIfdFirmwareClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ifd_firmware_finalize;
-	klass_firmware->check_magic = fu_ifd_firmware_check_magic;
+	klass_firmware->validate = fu_ifd_firmware_validate;
 	klass_firmware->export = fu_ifd_firmware_export;
 	klass_firmware->parse = fu_ifd_firmware_parse;
 	klass_firmware->write = fu_ifd_firmware_write;

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -124,7 +124,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware, GBytes *fw, GError **e
 }
 
 static gboolean
-fu_ifwi_cpd_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ifwi_cpd_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_ifwi_cpd_validate_bytes(fw, offset, error);
 }
@@ -315,7 +315,7 @@ static void
 fu_ifwi_cpd_firmware_class_init(FuIfwiCpdFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_ifwi_cpd_firmware_check_magic;
+	klass_firmware->validate = fu_ifwi_cpd_firmware_validate;
 	klass_firmware->export = fu_ifwi_cpd_firmware_export;
 	klass_firmware->parse = fu_ifwi_cpd_firmware_parse;
 	klass_firmware->write = fu_ifwi_cpd_firmware_write;

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -34,7 +34,7 @@ G_DEFINE_TYPE(FuIfwiFptFirmware, fu_ifwi_fpt_firmware, FU_TYPE_FIRMWARE)
 #define FU_IFWI_FPT_MAX_ENTRIES	   56
 
 static gboolean
-fu_ifwi_fpt_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ifwi_fpt_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_ifwi_fpt_validate_bytes(fw, offset, error);
 }
@@ -176,7 +176,7 @@ static void
 fu_ifwi_fpt_firmware_class_init(FuIfwiFptFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_ifwi_fpt_firmware_check_magic;
+	klass_firmware->validate = fu_ifwi_fpt_firmware_validate;
 	klass_firmware->parse = fu_ifwi_fpt_firmware_parse;
 	klass_firmware->write = fu_ifwi_fpt_firmware_write;
 }

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -107,7 +107,7 @@ fu_oprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 }
 
 static gboolean
-fu_oprom_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_oprom_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_oprom_validate_bytes(fw, offset, error);
 }
@@ -294,7 +294,7 @@ static void
 fu_oprom_firmware_class_init(FuOpromFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_oprom_firmware_check_magic;
+	klass_firmware->validate = fu_oprom_firmware_validate;
 	klass_firmware->export = fu_oprom_firmware_export;
 	klass_firmware->parse = fu_oprom_firmware_parse;
 	klass_firmware->write = fu_oprom_firmware_write;

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -30,7 +30,7 @@
 G_DEFINE_TYPE(FuPefileFirmware, fu_pefile_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_pefile_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_pefile_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_pe_dos_header_validate_bytes(fw, offset, error);
 }
@@ -182,7 +182,7 @@ static void
 fu_pefile_firmware_class_init(FuPefileFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_pefile_firmware_check_magic;
+	klass_firmware->validate = fu_pefile_firmware_validate;
 	klass_firmware->parse = fu_pefile_firmware_parse;
 }
 

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -124,7 +124,7 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 }
 
 static gboolean
-fu_usb_device_ds20_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_usb_device_ds20_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	g_autoptr(GByteArray) st = NULL;
 	g_autofree gchar *guid_str = NULL;
@@ -260,7 +260,7 @@ static void
 fu_usb_device_ds20_class_init(FuUsbDeviceDs20Class *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_usb_device_ds20_check_magic;
+	klass_firmware->validate = fu_usb_device_ds20_validate;
 	klass_firmware->parse = fu_usb_device_ds20_parse;
 	klass_firmware->write = fu_usb_device_ds20_write;
 }

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -51,7 +51,7 @@ fu_uswid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBu
 }
 
 static gboolean
-fu_uswid_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_uswid_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_uswid_validate_bytes(fw, offset, error);
 }
@@ -303,7 +303,7 @@ static void
 fu_uswid_firmware_class_init(FuUswidFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_uswid_firmware_check_magic;
+	klass_firmware->validate = fu_uswid_firmware_validate;
 	klass_firmware->parse = fu_uswid_firmware_parse;
 	klass_firmware->write = fu_uswid_firmware_write;
 	klass_firmware->build = fu_uswid_firmware_build;

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -96,7 +96,7 @@ fu_acpi_phat_set_oem_id(FuAcpiPhat *self, const gchar *oem_id)
 }
 
 static gboolean
-fu_acpi_phat_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_acpi_phat_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	const guint8 magic[4] = "PHAT";
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -336,7 +336,7 @@ fu_acpi_phat_class_init(FuAcpiPhatClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_phat_finalize;
-	klass_firmware->check_magic = fu_acpi_phat_check_magic;
+	klass_firmware->validate = fu_acpi_phat_validate;
 	klass_firmware->parse = fu_acpi_phat_parse;
 	klass_firmware->write = fu_acpi_phat_write;
 	klass_firmware->export = fu_acpi_phat_export;

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -62,7 +62,7 @@ fu_amd_gpu_atom_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_amd_gpu_atom_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_amd_gpu_atom_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	g_autoptr(GByteArray) atom = NULL;
 
@@ -329,7 +329,7 @@ fu_amd_gpu_atom_firmware_class_init(FuAmdGpuAtomFirmwareClass *klass)
 	object_class->finalize = fu_amd_gpu_atom_firmware_finalize;
 	klass_firmware->parse = fu_amd_gpu_atom_firmware_parse;
 	klass_firmware->export = fu_amd_gpu_atom_firmware_export;
-	klass_firmware->check_magic = fu_amd_gpu_atom_firmware_check_magic;
+	klass_firmware->validate = fu_amd_gpu_atom_firmware_validate;
 }
 
 FuFirmware *

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -47,7 +47,7 @@ fu_amd_gpu_psp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags
 }
 
 static gboolean
-fu_amd_gpu_psp_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_amd_gpu_psp_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	g_autoptr(GByteArray) efs = NULL;
 
@@ -204,7 +204,7 @@ static void
 fu_amd_gpu_psp_firmware_class_init(FuAmdGpuPspFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_amd_gpu_psp_firmware_check_magic;
+	klass_firmware->validate = fu_amd_gpu_psp_firmware_validate;
 	klass_firmware->parse = fu_amd_gpu_psp_firmware_parse;
 	klass_firmware->export = fu_amd_gpu_psp_firmware_export;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -300,7 +300,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 }
 
 static gboolean
-fu_bcm57xx_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_bcm57xx_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint32 magic = 0;
 
@@ -651,7 +651,7 @@ static void
 fu_bcm57xx_firmware_class_init(FuBcm57xxFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_bcm57xx_firmware_check_magic;
+	klass_firmware->validate = fu_bcm57xx_firmware_validate;
 	klass_firmware->parse = fu_bcm57xx_firmware_parse;
 	klass_firmware->export = fu_bcm57xx_firmware_export;
 	klass_firmware->write = fu_bcm57xx_firmware_write;

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -259,7 +259,7 @@ fu_ccgx_dmc_firmware_parse_image(FuFirmware *firmware,
 }
 
 static gboolean
-fu_ccgx_dmc_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ccgx_dmc_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_ccgx_dmc_fwct_info_validate_bytes(fw, offset, error);
 }
@@ -465,7 +465,7 @@ fu_ccgx_dmc_firmware_class_init(FuCcgxDmcFirmwareClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ccgx_dmc_firmware_finalize;
-	klass_firmware->check_magic = fu_ccgx_dmc_firmware_check_magic;
+	klass_firmware->validate = fu_ccgx_dmc_firmware_validate;
 	klass_firmware->parse = fu_ccgx_dmc_firmware_parse;
 	klass_firmware->write = fu_ccgx_dmc_firmware_write;
 	klass_firmware->export = fu_ccgx_dmc_firmware_export;

--- a/plugins/dfu-csr/fu-dfu-csr-firmware.c
+++ b/plugins/dfu-csr/fu-dfu-csr-firmware.c
@@ -26,7 +26,7 @@ fu_dfu_csr_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, Xb
 }
 
 static gboolean
-fu_dfu_csr_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_dfu_csr_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	return fu_struct_dfu_csr_file_validate_bytes(fw, offset, error);
 }
@@ -67,7 +67,7 @@ static void
 fu_dfu_csr_firmware_class_init(FuDfuCsrFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_dfu_csr_firmware_check_magic;
+	klass_firmware->validate = fu_dfu_csr_firmware_validate;
 	klass_firmware->parse = fu_dfu_csr_firmware_parse;
 	klass_firmware->export = fu_dfu_csr_firmware_export;
 }

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -40,7 +40,7 @@ fu_elanfp_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 }
 
 static gboolean
-fu_elanfp_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_elanfp_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint32 magic = 0;
 
@@ -229,7 +229,7 @@ static void
 fu_elanfp_firmware_class_init(FuElanfpFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_elanfp_firmware_check_magic;
+	klass_firmware->validate = fu_elanfp_firmware_validate;
 	klass_firmware->parse = fu_elanfp_firmware_parse;
 	klass_firmware->write = fu_elanfp_firmware_write;
 	klass_firmware->export = fu_elanfp_firmware_export;

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -73,7 +73,7 @@ fu_elantp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 }
 
 static gboolean
-fu_elantp_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_elantp_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	FuElantpFirmware *self = FU_ELANTP_FIRMWARE(firmware);
 	gsize bufsz = g_bytes_get_size(fw);
@@ -305,7 +305,7 @@ static void
 fu_elantp_firmware_class_init(FuElantpFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_elantp_firmware_check_magic;
+	klass_firmware->validate = fu_elantp_firmware_validate;
 	klass_firmware->parse = fu_elantp_firmware_parse;
 	klass_firmware->build = fu_elantp_firmware_build;
 	klass_firmware->write = fu_elantp_firmware_write;

--- a/plugins/elantp/fu-elantp-haptic-firmware.c
+++ b/plugins/elantp/fu-elantp-haptic-firmware.c
@@ -35,10 +35,7 @@ fu_elantp_haptic_firmware_export(FuFirmware *firmware,
 }
 
 static gboolean
-fu_elantp_haptic_firmware_check_magic(FuFirmware *firmware,
-				      GBytes *fw,
-				      gsize offset,
-				      GError **error)
+fu_elantp_haptic_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	gsize bufsz = g_bytes_get_size(fw);
 	const guint8 *buf = g_bytes_get_data(fw, NULL);
@@ -117,7 +114,7 @@ static void
 fu_elantp_haptic_firmware_class_init(FuElantpHapticFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_elantp_haptic_firmware_check_magic;
+	klass_firmware->validate = fu_elantp_haptic_firmware_validate;
 	klass_firmware->parse = fu_elantp_haptic_firmware_parse;
 	klass_firmware->export = fu_elantp_haptic_firmware_export;
 }

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -18,7 +18,7 @@ struct _FuEp963xFirmware {
 G_DEFINE_TYPE(FuEp963xFirmware, fu_ep963x_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_ep963x_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ep963x_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint8 magic[5] = "EP963";
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -64,6 +64,6 @@ static void
 fu_ep963x_firmware_class_init(FuEp963xFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_ep963x_firmware_check_magic;
+	klass_firmware->validate = fu_ep963x_firmware_validate;
 	klass_firmware->parse = fu_ep963x_firmware_parse;
 }

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -27,10 +27,10 @@ fu_genesys_usbhub_codesign_firmware_get_codesign(FuGenesysUsbhubCodesignFirmware
 }
 
 static gboolean
-fu_genesys_usbhub_codesign_firmware_check_magic(FuFirmware *firmware,
-						GBytes *fw,
-						gsize offset,
-						GError **error)
+fu_genesys_usbhub_codesign_firmware_validate(FuFirmware *firmware,
+					     GBytes *fw,
+					     gsize offset,
+					     GError **error)
 {
 	gsize code_size = g_bytes_get_size(fw) - offset;
 
@@ -104,7 +104,7 @@ static void
 fu_genesys_usbhub_codesign_firmware_class_init(FuGenesysUsbhubCodesignFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_genesys_usbhub_codesign_firmware_check_magic;
+	klass_firmware->validate = fu_genesys_usbhub_codesign_firmware_validate;
 	klass_firmware->parse = fu_genesys_usbhub_codesign_firmware_parse;
 	klass_firmware->export = fu_genesys_usbhub_codesign_firmware_export;
 }

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -18,10 +18,10 @@ struct _FuGenesysUsbhubDevFirmware {
 G_DEFINE_TYPE(FuGenesysUsbhubDevFirmware, fu_genesys_usbhub_dev_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_genesys_usbhub_dev_firmware_check_magic(FuFirmware *firmware,
-					   GBytes *fw,
-					   gsize offset,
-					   GError **error)
+fu_genesys_usbhub_dev_firmware_validate(FuFirmware *firmware,
+					GBytes *fw,
+					gsize offset,
+					GError **error)
 {
 	guint8 magic[4] = GENESYS_USBHUB_FW_SIG_TEXT_DEV_BRIDGE;
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -86,6 +86,6 @@ static void
 fu_genesys_usbhub_dev_firmware_class_init(FuGenesysUsbhubDevFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_genesys_usbhub_dev_firmware_check_magic;
+	klass_firmware->validate = fu_genesys_usbhub_dev_firmware_validate;
 	klass_firmware->parse = fu_genesys_usbhub_dev_firmware_parse;
 }

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -197,10 +197,7 @@ fu_genesys_usbhub_firmware_ensure_version(FuFirmware *firmware, GError **error)
 }
 
 static gboolean
-fu_genesys_usbhub_firmware_check_magic(FuFirmware *firmware,
-				       GBytes *fw,
-				       gsize offset,
-				       GError **error)
+fu_genesys_usbhub_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint8 magic[4] = GENESYS_USBHUB_FW_SIG_TEXT_HUB;
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -520,7 +517,7 @@ fu_genesys_usbhub_firmware_class_init(FuGenesysUsbhubFirmwareClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_genesys_usbhub_firmware_finalize;
-	klass_firmware->check_magic = fu_genesys_usbhub_firmware_check_magic;
+	klass_firmware->validate = fu_genesys_usbhub_firmware_validate;
 	klass_firmware->parse = fu_genesys_usbhub_firmware_parse;
 	klass_firmware->export = fu_genesys_usbhub_firmware_export;
 	klass_firmware->build = fu_genesys_usbhub_firmware_build;

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -18,10 +18,10 @@ struct _FuGenesysUsbhubPdFirmware {
 G_DEFINE_TYPE(FuGenesysUsbhubPdFirmware, fu_genesys_usbhub_pd_firmware, FU_TYPE_FIRMWARE)
 
 static gboolean
-fu_genesys_usbhub_pd_firmware_check_magic(FuFirmware *firmware,
-					  GBytes *fw,
-					  gsize offset,
-					  GError **error)
+fu_genesys_usbhub_pd_firmware_validate(FuFirmware *firmware,
+				       GBytes *fw,
+				       gsize offset,
+				       GError **error)
 {
 	guint8 magic[4] = GENESYS_USBHUB_FW_SIG_TEXT_PD;
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -86,6 +86,6 @@ static void
 fu_genesys_usbhub_pd_firmware_class_init(FuGenesysUsbhubPdFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_genesys_usbhub_pd_firmware_check_magic;
+	klass_firmware->validate = fu_genesys_usbhub_pd_firmware_validate;
 	klass_firmware->parse = fu_genesys_usbhub_pd_firmware_parse;
 }

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -40,7 +40,7 @@ fu_pxi_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 }
 
 static gboolean
-fu_pxi_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_pxi_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint64 magic = 0;
 	FuPxiFirmware *self = FU_PXI_FIRMWARE(firmware);
@@ -281,7 +281,7 @@ fu_pxi_firmware_class_init(FuPxiFirmwareClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_pxi_firmware_finalize;
-	klass_firmware->check_magic = fu_pxi_firmware_check_magic;
+	klass_firmware->validate = fu_pxi_firmware_validate;
 	klass_firmware->parse = fu_pxi_firmware_parse;
 	klass_firmware->build = fu_pxi_firmware_build;
 	klass_firmware->write = fu_pxi_firmware_write;

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuTiTps6598xFirmware, fu_ti_tps6598x_firmware, FU_TYPE_FIRMWARE)
 #define FU_TI_TPS6598X_FIRMWARE_PUBKEY_SIZE 0x180 /* bytes */
 
 static gboolean
-fu_ti_tps6598x_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_ti_tps6598x_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint32 magic = 0;
 
@@ -149,7 +149,7 @@ static void
 fu_ti_tps6598x_firmware_class_init(FuTiTps6598xFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_ti_tps6598x_firmware_check_magic;
+	klass_firmware->validate = fu_ti_tps6598x_firmware_validate;
 	klass_firmware->parse = fu_ti_tps6598x_firmware_parse;
 	klass_firmware->write = fu_ti_tps6598x_firmware_write;
 }

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -43,7 +43,7 @@ fu_{{vendor}}_{{example}}_firmware_build(FuFirmware *firmware, XbNode *n, GError
 }
 
 static gboolean
-fu_{{vendor}}_{{example}}_check_magic(FuFirmware *firmware,
+fu_{{vendor}}_{{example}}_validate(FuFirmware *firmware,
 					GBytes *fw,
 					gsize offset,
 					GError **error)
@@ -123,7 +123,7 @@ static void
 fu_{{vendor}}_{{example}}_firmware_class_init(Fu{{Vendor}}{{Example}}FirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_{{vendor}}_{{example}}_check_magic;
+	klass_firmware->validate = fu_{{vendor}}_{{example}}_validate;
 	klass_firmware->parse = fu_{{vendor}}_{{example}}_firmware_parse;
 	klass_firmware->write = fu_{{vendor}}_{{example}}_firmware_write;
 	klass_firmware->build = fu_{{vendor}}_{{example}}_firmware_build;

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -257,7 +257,7 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 }
 
 static gboolean
-fu_wac_firmware_check_magic(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
+fu_wac_firmware_validate(FuFirmware *firmware, GBytes *fw, gsize offset, GError **error)
 {
 	guint8 magic[5] = "WACOM";
 	return fu_memcmp_safe(g_bytes_get_data(fw, NULL),
@@ -389,7 +389,7 @@ static void
 fu_wac_firmware_class_init(FuWacFirmwareClass *klass)
 {
 	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->check_magic = fu_wac_firmware_check_magic;
+	klass_firmware->validate = fu_wac_firmware_validate;
 	klass_firmware->parse = fu_wac_firmware_parse;
 	klass_firmware->write = fu_wac_firmware_write;
 }


### PR DESCRIPTION
Most implementations actually validate the entire header, rather than just checking the magic bytes.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
