### PR TITLE
redfish: Do not request the Advantech BMC to reboot

### DIFF
--- a/plugins/redfish/README.md
+++ b/plugins/redfish/README.md
@@ -57,6 +57,13 @@ default 0ms.
 
 Since: 1.8.0
 
+### Flags=no-manager-reset-request
+
+The BMC device will auto-reboot and so fwupd should not explicitly call
+`/redfish/v1/Managers/1/Actions/Manager.Reset`.
+
+Since: 1.9.11
+
 ## Setting Service IP Manually
 
 The service IP may not be automatically discoverable due to the absence of

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -877,6 +877,9 @@ fu_redfish_device_init(FuRedfishDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_REDFISH_DEVICE_FLAG_MANAGER_RESET,
 					"manager-reset");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_REDFISH_DEVICE_FLAG_NO_MANAGER_RESET_REQUEST,
+					"no-manager-reset-request");
 }
 
 static void

--- a/plugins/redfish/fu-redfish-device.h
+++ b/plugins/redfish/fu-redfish-device.h
@@ -49,6 +49,14 @@ struct _FuRedfishDeviceClass {
  */
 #define FU_REDFISH_DEVICE_FLAG_WILDCARD_TARGETS (1 << 3)
 
+/**
+ * FU_REDFISH_DEVICE_FLAG_NO_MANAGER_RESET_REQUEST:
+ *
+ * The BMC device will auto-reboot and so fwupd should not explicitly call
+ * `/redfish/v1/Managers/1/Actions/Manager.Reset`.
+ */
+#define FU_REDFISH_DEVICE_FLAG_NO_MANAGER_RESET_REQUEST (1 << 4)
+
 FuRedfishBackend *
 fu_redfish_device_get_backend(FuRedfishDevice *self);
 gboolean

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -562,7 +562,6 @@ fu_redfish_plugin_cleanup(FuPlugin *plugin,
 	guint64 reset_timeout = 0;
 	g_autofree gchar *restart_timeout_str = NULL;
 	g_autoptr(FuRedfishRequest) request = fu_redfish_backend_request_new(self->backend);
-	g_autoptr(JsonBuilder) builder = json_builder_new();
 	g_autoptr(GPtrArray) devices = NULL;
 
 	/* nothing to do */
@@ -578,18 +577,21 @@ fu_redfish_plugin_cleanup(FuPlugin *plugin,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 9, "recoldplug");
 
 	/* ask the BMC to reboot */
-	json_builder_begin_object(builder);
-	json_builder_set_member_name(builder, "ResetType");
-	json_builder_add_string_value(builder, "ForceRestart");
-	json_builder_end_object(builder);
-	if (!fu_redfish_request_perform_full(request,
-					     "/redfish/v1/Managers/1/Actions/Manager.Reset",
-					     "POST",
-					     builder,
-					     FU_REDFISH_REQUEST_PERFORM_FLAG_NONE,
-					     error)) {
-		g_prefix_error(error, "failed to reset manager: ");
-		return FALSE;
+	if (!fu_device_has_private_flag(device, FU_REDFISH_DEVICE_FLAG_NO_MANAGER_RESET_REQUEST)) {
+		g_autoptr(JsonBuilder) builder = json_builder_new();
+		json_builder_begin_object(builder);
+		json_builder_set_member_name(builder, "ResetType");
+		json_builder_add_string_value(builder, "ForceRestart");
+		json_builder_end_object(builder);
+		if (!fu_redfish_request_perform_full(request,
+						     "/redfish/v1/Managers/1/Actions/Manager.Reset",
+						     "POST",
+						     builder,
+						     FU_REDFISH_REQUEST_PERFORM_FLAG_NONE,
+						     error)) {
+			g_prefix_error(error, "failed to reset manager: ");
+			return FALSE;
+		}
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/redfish/redfish.quirk
+++ b/plugins/redfish/redfish.quirk
@@ -26,3 +26,7 @@ Flags = is-backup,no-probe
 # Advantech
 [18789130-a714-53c0-b025-fa93801d3995]
 Flags = wildcard-targets,ipmi-create-user
+
+[REDFISH\VENDOR_Advantech&ID_BMC]
+Flags = manager-reset,no-manager-reset-request
+RedfishResetPreDelay = 100000


### PR DESCRIPTION
It reboots automatically.

Based on a patch by Vincent Tang <vincent.tang@advantech.com.tw>, many thanks.

Fixes https://github.com/fwupd/fwupd/issues/6536

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
