### PR TITLE
Add missing build dependency to fwupdplugin-self-test

### DIFF
--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -426,7 +426,8 @@ if get_option('tests')
       fwupd_incdir,
     ],
     dependencies: [
-      library_deps
+      library_deps,
+      fwupdplugin_rs_dep,
     ],
     link_with: [
       fwupd,


### PR DESCRIPTION
Parallel builds sometimes fail due to a header not having been generated yet. Fix by adding fwupdplugin_rs_dep to the deps for fwupdplugin-self-test.

The build error can be reliably reproduced like so:

```
$ meson setup build
$ cd build
$ ninja libfwupdplugin/fwupdplugin-self-test.p/fu-self-test.c.o
[...snip...]
In file included from ../libfwupdplugin/fu-archive-firmware.h:10,
                 from ../libfwupdplugin/fwupdplugin.h:13,
                 from ../libfwupdplugin/fu-self-test.c:11:
../libfwupdplugin/fu-archive.h:12:10: fatal error: fu-archive-struct.h: No such file or directory
   12 | #include "fu-archive-struct.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
ninja: build stopped: subcommand failed.
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
