### PR TITLE
synaptics-mst: Add support for the Luxshare Quad USB4 Dock

### DIFF
--- a/plugins/synaptics-mst/README.md
+++ b/plugins/synaptics-mst/README.md
@@ -42,6 +42,10 @@ The vendor ID is set from the PCI vendor, for example set to `DRM_DP_AUX_DEV:0x$
 
 This plugin uses the following plugin-specific quirks:
 
+### Flags:manual-restart-required
+
+The device must be restarted manually after the update has completed.
+
 ### Flags:ignore-board-id
 
 Ignore board ID firmware mismatch.

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -64,6 +64,13 @@
  */
 #define FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID (1 << 0)
 
+/**
+ * FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED:
+ *
+ * The device must be restarted manually after the update has completed.
+ */
+#define FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED (1 << 1)
+
 struct _FuSynapticsMstDevice {
 	FuDpauxDevice parent_instance;
 	gchar *device_kind;
@@ -118,8 +125,12 @@ fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
 					"ignore-board-id");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED,
+					"manual-restart-required");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
+	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 
 	/* this is set from ->incorporate() */
 	g_signal_connect(FU_UDEV_DEVICE(self),
@@ -1366,6 +1377,25 @@ fu_synaptics_mst_device_prepare_firmware(FuDevice *device,
 }
 
 static gboolean
+fu_synaptics_mst_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	/* some devices do not use a GPIO to reset the chip */
+	if (fu_device_has_private_flag(device,
+				       FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED)) {
+		g_autoptr(FwupdRequest) request = fwupd_request_new();
+		fwupd_request_set_kind(request, FWUPD_REQUEST_KIND_IMMEDIATE);
+		fwupd_request_set_id(request, FWUPD_REQUEST_ID_REPLUG_POWER);
+		fwupd_request_add_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
+		if (!fu_device_emit_request(device, request, progress, error))
+			return FALSE;
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_synaptics_mst_device_write_firmware(FuDevice *device,
 				       FuFirmware *firmware,
 				       FuProgress *progress,
@@ -1674,6 +1704,12 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 	guid0 = g_strdup_printf("MST-%u", self->board_id);
 	fu_device_add_instance_id(FU_DEVICE(self), guid0);
 
+	/* requires user to do something */
+	if (fu_device_has_private_flag(device,
+				       FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED)) {
+		fu_device_set_remove_delay(device, FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
+	}
+
 	/* this is a host system, use system ID */
 	name_family = fu_synaptics_mst_family_to_string(self->family);
 	if (g_strcmp0(self->device_kind, "system") == 0) {
@@ -1776,6 +1812,7 @@ fu_synaptics_mst_device_class_init(FuSynapticsMstDeviceClass *klass)
 	klass_device->set_quirk_kv = fu_synaptics_mst_device_set_quirk_kv;
 	klass_device->setup = fu_synaptics_mst_device_setup;
 	klass_device->write_firmware = fu_synaptics_mst_device_write_firmware;
+	klass_device->attach = fu_synaptics_mst_device_attach;
 	klass_device->prepare_firmware = fu_synaptics_mst_device_prepare_firmware;
 	klass_device->set_progress = fu_synaptics_mst_device_set_progress;
 }

--- a/plugins/synaptics-mst/synaptics-mst.quirk
+++ b/plugins/synaptics-mst/synaptics-mst.quirk
@@ -15,6 +15,11 @@
 # To override this behavior add FWUPD_DEVICE_FLAG_SKIPS_RESTART
 #
 
+[MST-162]
+Name = Luxshare Quad USB4 Dock
+SynapticsMstDeviceKind = dock
+Flags = manual-restart-required
+
 [MST-272]
 Name = Dell X6 Platform
 SynapticsMstDeviceKind = system


### PR DESCRIPTION
Require a manual restart.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
