### PR TITLE
trivial: set fingerprint reader in Framework laptops as will-disappear

### DIFF
--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -391,6 +391,13 @@ fu_goodixmoc_device_write_firmware(FuDevice *device,
 						  &rsp,
 						  wait_data_reply,
 						  &error_block)) {
+			if (wait_data_reply == TRUE &&
+			    fu_device_has_flag(device, FWUPD_DEVICE_FLAG_WILL_DISAPPEAR)) {
+				fu_device_set_remove_delay(device, 0);
+				g_debug("%s", error_block->message);
+				break;
+			}
+
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_WRITE,

--- a/plugins/goodix-moc/goodixmoc.quirk
+++ b/plugins/goodix-moc/goodixmoc.quirk
@@ -22,4 +22,4 @@ Plugin = goodixmoc
 Flags = enforce-requires
 [USB\VID_27C6&PID_609C]
 Plugin = goodixmoc
-Flags = enforce-requires
+Flags = enforce-requires,will-disappear,needs-reboot


### PR DESCRIPTION
The factory firmware for the goodixmoc fingerprint readers appears to have a bug that it doesn't come back after an update even when succesful.

As this is "expected" behavior set the will-disappear and needs-reboot flags so this isn't flagged as a failure.

Link: https://community.frame.work/t/beta-lvfs-fingerprint-reader-firmware-for-framework-laptop-13-13th-gen-intel-core-amd-7040-series-fingerprint-reader-on-fedora-39-and-ubuntu-22-04/41898

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
