### PR TITLE
bcm57xx: Never use /dev/mem when not in recovery mode

### DIFF
--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -34,12 +34,13 @@
 
 struct _FuBcm57xxDevice {
 	FuUdevDevice parent_instance;
-	FuBcm57xxRecoveryDevice *recovery;
 	gchar *ethtool_iface;
 	int ethtool_fd;
 };
 
 G_DEFINE_TYPE(FuBcm57xxDevice, fu_bcm57xx_device, FU_TYPE_UDEV_DEVICE)
+
+enum { PROP_0, PROP_IFACE, PROP_LAST };
 
 static void
 fu_bcm57xx_device_to_string(FuDevice *device, guint idt, GString *str)
@@ -52,39 +53,6 @@ fu_bcm57xx_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_bcm57xx_device_probe(FuDevice *device, GError **error)
 {
-	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
-	g_autofree gchar *fn = NULL;
-	g_autoptr(GPtrArray) ifaces = NULL;
-
-	/* only enumerate number 0 */
-	if (fu_udev_device_get_number(FU_UDEV_DEVICE(device)) != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "only device 0 supported on multi-device card");
-		return FALSE;
-	}
-
-	/* we need this even for non-recovery to reset APE */
-	fu_device_set_context(FU_DEVICE(self->recovery), fu_device_get_context(FU_DEVICE(self)));
-	fu_device_incorporate(FU_DEVICE(self->recovery), FU_DEVICE(self));
-	if (!fu_device_probe(FU_DEVICE(self->recovery), error))
-		return FALSE;
-
-	/* only if has an interface */
-	fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "net", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
-		g_debug("waiting for net devices to appear");
-		fu_device_sleep(device, 50); /* ms */
-	}
-	ifaces = fu_path_glob(fn, "en*", NULL);
-	if (ifaces == NULL || ifaces->len == 0) {
-		fu_device_add_child(FU_DEVICE(self), FU_DEVICE(self->recovery));
-	} else {
-		self->ethtool_iface = g_path_get_basename(g_ptr_array_index(ifaces, 0));
-	}
-
-	/* success */
 	return fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error);
 }
 
@@ -298,40 +266,6 @@ fu_bcm57xx_device_nvram_check(FuBcm57xxDevice *self, GError **error)
 		    "Not supported as <linux/ethtool.h> not found");
 	return FALSE;
 #endif
-}
-
-static gboolean
-fu_bcm57xx_device_activate(FuDevice *device, FuProgress *progress, GError **error)
-{
-	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
-	g_autoptr(FuDeviceLocker) locker1 = NULL;
-	g_autoptr(FuDeviceLocker) locker2 = NULL;
-
-	/* the only way to do this is using the mmap method */
-	locker2 = fu_device_locker_new_full(FU_DEVICE(self->recovery),
-					    (FuDeviceLockerFunc)fu_device_detach,
-					    (FuDeviceLockerFunc)fu_device_attach,
-					    error);
-	if (locker2 == NULL)
-		return FALSE;
-
-	/* open */
-	locker1 = fu_device_locker_new(FU_DEVICE(self->recovery), error);
-	if (locker1 == NULL)
-		return FALSE;
-
-	/* activate, causing APE reset, then close, then attach */
-	if (!fu_device_activate(FU_DEVICE(self->recovery), progress, error))
-		return FALSE;
-
-	/* ensure we attach before we close */
-	if (!fu_device_locker_close(locker2, error))
-		return FALSE;
-
-	/* wait for the device to restart before calling reload() */
-	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_BUSY);
-	fu_device_sleep_full(device, 5000, progress); /* ms */
-	return TRUE;
 }
 
 static GBytes *
@@ -548,16 +482,6 @@ fu_bcm57xx_device_setup(FuDevice *device, GError **error)
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
 	guint32 fwversion = 0;
 
-	/* device is in recovery mode */
-	if (self->ethtool_iface == NULL) {
-		g_autoptr(FuDeviceLocker) locker = NULL;
-		g_info("device in recovery mode, use alternate device");
-		locker = fu_device_locker_new(FU_DEVICE(self->recovery), error);
-		if (locker == NULL)
-			return FALSE;
-		return fu_device_setup(FU_DEVICE(self->recovery), error);
-	}
-
 	/* check the EEPROM size */
 	if (!fu_bcm57xx_device_nvram_check(self, error))
 		return FALSE;
@@ -658,6 +582,38 @@ fu_bcm57xx_device_set_progress(FuDevice *self, FuProgress *progress)
 }
 
 static void
+fu_bcm57xx_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(object);
+	switch (prop_id) {
+	case PROP_IFACE:
+		g_value_set_string(value, self->ethtool_iface);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+fu_bcm57xx_device_set_property(GObject *object,
+			       guint prop_id,
+			       const GValue *value,
+			       GParamSpec *pspec)
+{
+	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(object);
+	switch (prop_id) {
+	case PROP_IFACE:
+		g_free(self->ethtool_iface);
+		self->ethtool_iface = g_value_dup_string(value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
 fu_bcm57xx_device_init(FuBcm57xxDevice *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -666,9 +622,6 @@ fu_bcm57xx_device_init(FuBcm57xxDevice *self)
 
 	/* other values are set from a quirk */
 	fu_device_set_firmware_size(FU_DEVICE(self), BCM_FIRMWARE_SIZE);
-
-	/* used for recovery in case of ethtool failure and for APE reset */
-	self->recovery = fu_bcm57xx_recovery_device_new();
 }
 
 static void
@@ -683,18 +636,29 @@ static void
 fu_bcm57xx_device_class_init(FuBcm57xxDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	GParamSpec *pspec;
+
 	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	object_class->get_property = fu_bcm57xx_device_get_property;
+	object_class->set_property = fu_bcm57xx_device_set_property;
 	object_class->finalize = fu_bcm57xx_device_finalize;
 	klass_device->prepare_firmware = fu_bcm57xx_device_prepare_firmware;
 	klass_device->setup = fu_bcm57xx_device_setup;
 	klass_device->reload = fu_bcm57xx_device_setup;
 	klass_device->open = fu_bcm57xx_device_open;
 	klass_device->close = fu_bcm57xx_device_close;
-	klass_device->activate = fu_bcm57xx_device_activate;
 	klass_device->write_firmware = fu_bcm57xx_device_write_firmware;
 	klass_device->read_firmware = fu_bcm57xx_device_read_firmware;
 	klass_device->dump_firmware = fu_bcm57xx_device_dump_firmware;
 	klass_device->probe = fu_bcm57xx_device_probe;
 	klass_device->to_string = fu_bcm57xx_device_to_string;
 	klass_device->set_progress = fu_bcm57xx_device_set_progress;
+
+	pspec =
+	    g_param_spec_string("iface",
+				NULL,
+				NULL,
+				NULL,
+				G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_IFACE, pspec);
 }

--- a/plugins/bcm57xx/fu-bcm57xx-plugin.c
+++ b/plugins/bcm57xx/fu-bcm57xx-plugin.c
@@ -10,6 +10,7 @@
 #include "fu-bcm57xx-dict-image.h"
 #include "fu-bcm57xx-firmware.h"
 #include "fu-bcm57xx-plugin.h"
+#include "fu-bcm57xx-recovery-device.h"
 #include "fu-bcm57xx-stage1-image.h"
 #include "fu-bcm57xx-stage2-image.h"
 
@@ -18,6 +19,47 @@ struct _FuBcm57XxPlugin {
 };
 
 G_DEFINE_TYPE(FuBcm57XxPlugin, fu_bcm57xx_plugin, FU_TYPE_PLUGIN)
+
+static gboolean
+fu_bcm57xx_plugin_backend_device_added(FuPlugin *plugin,
+				       FuDevice *device,
+				       FuProgress *progress,
+				       GError **error)
+{
+	g_autofree gchar *fn = NULL;
+	g_autoptr(GPtrArray) ifaces = NULL;
+	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* only enumerate number 0 */
+	if (fu_udev_device_get_number(FU_UDEV_DEVICE(device)) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "only device 0 supported on multi-device card");
+		return FALSE;
+	}
+
+	/* is in recovery mode if has no ethtool interface */
+	fn = g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "net", NULL);
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
+		g_debug("waiting for net devices to appear");
+		fu_device_sleep(device, 50); /* ms */
+	}
+	ifaces = fu_path_glob(fn, "en*", NULL);
+	if (ifaces == NULL || ifaces->len == 0) {
+		dev = g_object_new(FU_TYPE_BCM57XX_RECOVERY_DEVICE, NULL);
+	} else {
+		g_autofree gchar *ethtool_iface = g_path_get_basename(g_ptr_array_index(ifaces, 0));
+		dev = g_object_new(FU_TYPE_BCM57XX_DEVICE, "iface", ethtool_iface, NULL);
+	}
+	fu_device_incorporate(dev, device);
+	locker = fu_device_locker_new(dev, error);
+	if (locker == NULL)
+		return FALSE;
+	fu_plugin_device_add(plugin, dev);
+	return TRUE;
+}
 
 static void
 fu_bcm57xx_plugin_init(FuBcm57XxPlugin *self)
@@ -37,6 +79,7 @@ fu_bcm57xx_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_RECOVERY_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_DICT_IMAGE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_STAGE1_IMAGE);
@@ -51,4 +94,5 @@ fu_bcm57xx_plugin_class_init(FuBcm57XxPluginClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->constructed = fu_bcm57xx_plugin_object_constructed;
 	plugin_class->constructed = fu_bcm57xx_plugin_constructed;
+	plugin_class->backend_device_added = fu_bcm57xx_plugin_backend_device_added;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -891,10 +891,3 @@ fu_bcm57xx_recovery_device_class_init(FuBcm57xxRecoveryDeviceClass *klass)
 	klass_device->probe = fu_bcm57xx_recovery_device_probe;
 	klass_device->set_progress = fu_bcm57xx_recovery_device_set_progress;
 }
-
-FuBcm57xxRecoveryDevice *
-fu_bcm57xx_recovery_device_new(void)
-{
-	FuUdevDevice *self = g_object_new(FU_TYPE_BCM57XX_RECOVERY_DEVICE, NULL);
-	return FU_BCM57XX_RECOVERY_DEVICE(self);
-}

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.h
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.h
@@ -14,6 +14,3 @@ G_DECLARE_FINAL_TYPE(FuBcm57xxRecoveryDevice,
 		     FU,
 		     BCM57XX_RECOVERY_DEVICE,
 		     FuUdevDevice)
-
-FuBcm57xxRecoveryDevice *
-fu_bcm57xx_recovery_device_new(void);


### PR DESCRIPTION
In most cases mmap is blocked by the CONFIG_IO_STRICT_DEVMEM config option.

This means we now need a system reboot for updates to take effect.

Fixes https://github.com/fwupd/fwupd/issues/6243

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
