### PR TITLE
trivial: fwupdtool: Start engine for esp-list command

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -204,7 +204,7 @@ fu_volume_get_id(FuVolume *self)
 		return g_dbus_proxy_get_object_path(self->proxy_blk);
 	if (self->proxy_part != NULL)
 		return g_dbus_proxy_get_object_path(self->proxy_part);
-	return NULL;
+	return self->mount_path;
 }
 
 /**

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3288,6 +3288,9 @@ fu_util_esp_list(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FuVolume) volume = NULL;
 	g_autoptr(GPtrArray) files = NULL;
 
+	if (!fu_util_start_engine(priv, FU_ENGINE_LOAD_FLAG_READONLY, priv->progress, error))
+		return FALSE;
+
 	volume = fu_util_prompt_for_volume(priv, error);
 	if (volume == NULL)
 		return FALSE;


### PR DESCRIPTION
The `esp-list` command normally fetches data using udisks2, but if the user has set up `EspLocation` in `/etc/fwupd/fwupd.conf` it isn't used. Start the engine so that the conffile is parsed and used as well.

Fixes: https://github.com/fwupd/fwupd/issues/6565

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
