### PR TITLE
Fix a segfault when using zlib-ng instead of zlib

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -470,6 +470,8 @@ fu_cab_firmware_parse_helper_new(GBytes *fw, FwupdInstallFlags flags, GError **e
 	g_autoptr(FuCabFirmwareParseHelper) helper = g_new0(FuCabFirmwareParseHelper, 1);
 
 	/* zlib */
+	helper->zstrm.zalloc = zalloc;
+	helper->zstrm.zfree = zfree;
 	zret = inflateInit2(&helper->zstrm, -MAX_WBITS);
 	if (zret != Z_OK) {
 		g_set_error(error,
@@ -479,8 +481,6 @@ fu_cab_firmware_parse_helper_new(GBytes *fw, FwupdInstallFlags flags, GError **e
 			    zError(zret));
 		return NULL;
 	}
-	helper->zstrm.zalloc = zalloc;
-	helper->zstrm.zfree = zfree;
 
 	helper->fw = g_bytes_ref(fw);
 	helper->install_flags = flags;


### PR DESCRIPTION
See https://github.com/zlib-ng/zlib-ng/issues/1624

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
