### PR TITLE
synaptics-mst: Add board ID firmware offset for Cayenne and Spyder

### DIFF
--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -116,6 +116,7 @@ fu_synaptics_mst_device_udev_device_notify_cb(FuUdevDevice *udev_device,
 static void
 fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 {
+	self->family = FU_SYNAPTICS_MST_FAMILY_UNKNOWN;
 	fu_device_add_protocol(FU_DEVICE(self), "com.synaptics.mst");
 	fu_device_set_vendor(FU_DEVICE(self), "Synaptics");
 	fu_device_add_vendor_id(FU_DEVICE(self), "DRM_DP_AUX_DEV:0x06CB");
@@ -1355,6 +1356,9 @@ fu_synaptics_mst_device_prepare_firmware(FuDevice *device,
 {
 	FuSynapticsMstDevice *self = FU_SYNAPTICS_MST_DEVICE(device);
 	g_autoptr(FuFirmware) firmware = fu_synaptics_mst_firmware_new();
+
+	/* set chip family to use correct board ID offset */
+	fu_synaptics_mst_firmware_set_family(FU_SYNAPTICS_MST_FIRMWARE(firmware), self->family);
 
 	/* check firmware and board ID match */
 	if (!fu_firmware_parse(firmware, fw, flags, error))

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -6,22 +6,34 @@
 
 #include "config.h"
 
+#include "fu-synaptics-mst-common.h"
 #include "fu-synaptics-mst-firmware.h"
 
 struct _FuSynapticsMstFirmware {
 	FuFirmwareClass parent_instance;
 	guint16 board_id;
+	FuSynapticsMstFamily family;
 };
 
 G_DEFINE_TYPE(FuSynapticsMstFirmware, fu_synaptics_mst_firmware, FU_TYPE_FIRMWARE)
 
-#define ADDR_CUSTOMER_ID 0x10E
+#define ADDR_CUSTOMER_ID_CAYENNE 0x20E
+#define ADDR_CUSTOMER_ID_TESLA	 0x10E
+#define ADDR_CONFIG_CAYENNE	 0x200
+#define ADDR_CONFIG_TESLA	 0x100
 
 guint16
 fu_synaptics_mst_firmware_get_board_id(FuSynapticsMstFirmware *self)
 {
 	g_return_val_if_fail(FU_IS_SYNAPTICS_MST_FIRMWARE(self), 0);
 	return self->board_id;
+}
+
+void
+fu_synaptics_mst_firmware_set_family(FuSynapticsMstFirmware *self, FuSynapticsMstFamily family)
+{
+	g_return_if_fail(FU_IS_SYNAPTICS_MST_FIRMWARE(self));
+	self->family = family;
 }
 
 static void
@@ -31,6 +43,29 @@ fu_synaptics_mst_firmware_export(FuFirmware *firmware,
 {
 	FuSynapticsMstFirmware *self = FU_SYNAPTICS_MST_FIRMWARE(firmware);
 	fu_xmlb_builder_insert_kx(bn, "board_id", self->board_id);
+	fu_xmlb_builder_insert_kv(bn, "family", fu_synaptics_mst_family_to_string(self->family));
+}
+
+static gboolean
+fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self, GBytes *fw, GError **error)
+{
+	guint16 addrs[] = {ADDR_CONFIG_TESLA, ADDR_CONFIG_CAYENNE};
+	for (guint i = 0; i < G_N_ELEMENTS(addrs); i++) {
+		g_autoptr(GByteArray) st = NULL;
+		st = fu_struct_synaptics_firmware_config_parse_bytes(fw, addrs[i], error);
+		if (st == NULL)
+			return FALSE;
+		if ((fu_struct_synaptics_firmware_config_get_magic1(st) & 0x80) &&
+		    (fu_struct_synaptics_firmware_config_get_magic2(st) & 0x80)) {
+			self->family = fu_struct_synaptics_firmware_config_get_version(st) >> 4;
+			return TRUE;
+		}
+	}
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "unable to autodetect chip family");
+	return FALSE;
 }
 
 static gboolean
@@ -43,13 +78,34 @@ fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 	FuSynapticsMstFirmware *self = FU_SYNAPTICS_MST_FIRMWARE(firmware);
 	const guint8 *buf;
 	gsize bufsz;
+	guint16 addr;
+
+	/* if device family not specified by caller, try to get from firmware file */
+	if (self->family == FU_SYNAPTICS_MST_FAMILY_UNKNOWN) {
+		if (!fu_synaptics_mst_firmware_detect_family(self, fw, error))
+			return FALSE;
+	}
+
+	switch (self->family) {
+	case FU_SYNAPTICS_MST_FAMILY_TESLA:
+	case FU_SYNAPTICS_MST_FAMILY_LEAF:
+	case FU_SYNAPTICS_MST_FAMILY_PANAMERA:
+		addr = ADDR_CUSTOMER_ID_TESLA;
+		break;
+	case FU_SYNAPTICS_MST_FAMILY_CAYENNE:
+	case FU_SYNAPTICS_MST_FAMILY_SPYDER:
+		addr = ADDR_CUSTOMER_ID_CAYENNE;
+		break;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "unsupported chip family %s",
+			    fu_synaptics_mst_family_to_string(self->family));
+		return FALSE;
+	}
 	buf = g_bytes_get_data(fw, &bufsz);
-	if (!fu_memread_uint16_safe(buf,
-				    bufsz,
-				    ADDR_CUSTOMER_ID,
-				    &self->board_id,
-				    G_BIG_ENDIAN,
-				    error))
+	if (!fu_memread_uint16_safe(buf, bufsz, addr, &self->board_id, G_BIG_ENDIAN, error))
 		return FALSE;
 
 	/* success */
@@ -59,14 +115,33 @@ fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 static GByteArray *
 fu_synaptics_mst_firmware_write(FuFirmware *firmware, GError **error)
 {
+	FuSynapticsMstFirmware *self = FU_SYNAPTICS_MST_FIRMWARE(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GBytes) blob = NULL;
+	guint16 addr;
 
+	switch (self->family) {
+	case FU_SYNAPTICS_MST_FAMILY_TESLA:
+	case FU_SYNAPTICS_MST_FAMILY_LEAF:
+	case FU_SYNAPTICS_MST_FAMILY_PANAMERA:
+		addr = ADDR_CUSTOMER_ID_TESLA;
+		break;
+	case FU_SYNAPTICS_MST_FAMILY_CAYENNE:
+	case FU_SYNAPTICS_MST_FAMILY_SPYDER:
+		addr = ADDR_CUSTOMER_ID_CAYENNE;
+		break;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "unsupported chip family");
+		return NULL;
+	}
 	/* assumed header */
-	fu_byte_array_set_size(buf, ADDR_CUSTOMER_ID + sizeof(guint16), 0x00);
+	fu_byte_array_set_size(buf, addr + sizeof(guint16), 0x00);
 	if (!fu_memwrite_uint16_safe(buf->data,
 				     buf->len,
-				     ADDR_CUSTOMER_ID,
+				     addr,
 				     fu_firmware_get_idx(firmware),
 				     G_BIG_ENDIAN,
 				     error))
@@ -100,6 +175,7 @@ fu_synaptics_rmi_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 static void
 fu_synaptics_mst_firmware_init(FuSynapticsMstFirmware *self)
 {
+	self->family = FU_SYNAPTICS_MST_FAMILY_UNKNOWN;
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
 }
 

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.h
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.h
@@ -19,3 +19,5 @@ FuFirmware *
 fu_synaptics_mst_firmware_new(void);
 guint16
 fu_synaptics_mst_firmware_get_board_id(FuSynapticsMstFirmware *self);
+void
+fu_synaptics_mst_firmware_set_family(FuSynapticsMstFirmware *self, FuSynapticsMstFamily family);

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+#include "fu-synaptics-mst-common.h"
 #include "fu-synaptics-mst-device.h"
 #include "fu-synaptics-mst-firmware.h"
 #include "fu-synaptics-mst-plugin.h"

--- a/plugins/synaptics-mst/fu-synaptics-mst.rs
+++ b/plugins/synaptics-mst/fu-synaptics-mst.rs
@@ -3,12 +3,12 @@
 
 #[derive(ToString)]
 enum SynapticsMstFamily {
-    Unknown,
-    Tesla,
-    Leaf,
-    Panamera,
-    Cayenne,
-    Spyder,
+    Unknown = 0xFF,
+    Tesla = 0,
+    Leaf = 1,
+    Panamera = 2,
+    Cayenne = 3,
+    Spyder = 4,
 }
 
 #[derive(ToString)]
@@ -58,4 +58,12 @@ enum SynapticsMstRegRc {
     Len    = 0x4B8,
     Offset = 0x4BC,
     Data   = 0x4C0,
+}
+
+#[derive(ParseBytes)]
+struct SynapticsFirmwareConfig {
+    version: u8,
+    reserved: u8,
+    magic1: u8,
+    magic2: u8,
 }


### PR DESCRIPTION
Get the device family from firmware file, using the hardware if possible.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
