### PR TITLE
trivial: Set a maximum size for a HID descriptor

### DIFF
--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -286,6 +286,7 @@ static void
 fu_hid_descriptor_init(FuHidDescriptor *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
+	fu_firmware_set_size_max(FU_FIRMWARE(self), 64 * 1024);
 	fu_firmware_set_images_max(FU_FIRMWARE(self),
 				   g_getenv("FWUPD_FUZZER_RUNNING") != NULL ? 10 : 1024);
 	g_type_ensure(FU_TYPE_HID_REPORT);


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65454

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
