### PR TITLE
LoongArch: Replace __loongarch64 with __loongarch_lp64

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -22,7 +22,7 @@ fu_uefi_bootmgr_get_suffix(GError **error)
 		{64, "x64"},
 #elif defined(__aarch64__)
 		{64, "aa64"},
-#elif defined(__loongarch64)
+#elif defined(__loongarch_lp64)
 		{64, "loongarch64"},
 #endif
 #if defined(__x86_64__) || defined(__i386__) || defined(__i686__)


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

`__loongarch64` is no longer used for historical reasons and should be replaced by `__loongarch_lp64` in new code.

https://loongson.github.io/LoongArch-Documentation/LoongArch-toolchain-conventions-EN.html#_cc_preprocessor_built_in_macro_definitions