### PR TITLE
Do not ever require plugins to call parent->to_string()

### DIFF
--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -43,7 +43,6 @@ fu_dpaux_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuDpauxDevice *self = FU_DPAUX_DEVICE(device);
 	FuDpauxDevicePrivate *priv = GET_PRIVATE(self);
-	FU_DEVICE_CLASS(fu_dpaux_device_parent_class)->to_string(device, idt, str);
 	if (priv->dpcd_ieee_oui != 0)
 		fu_string_append_kx(str, idt, "DpcdIeeeOui", priv->dpcd_ieee_oui);
 	if (priv->dpcd_hw_rev != 0)

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -58,7 +58,6 @@ fu_mei_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuMeiDevice *self = FU_MEI_DEVICE(device);
 	FuMeiDevicePrivate *priv = GET_PRIVATE(self);
-	FU_DEVICE_CLASS(fu_mei_device_parent_class)->to_string(device, idt, str);
 	fu_string_append(str, idt, "Uuid", priv->uuid);
 	fu_string_append(str, idt, "ParentDeviceFile", priv->parent_device_file);
 	if (priv->max_msg_length > 0x0)

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -111,7 +111,6 @@ static void
 fu_ata_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuAtaDevice *self = FU_ATA_DEVICE(device);
-	FU_DEVICE_CLASS(fu_ata_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_kx(str, idt, "TransferMode", self->transfer_mode);
 	fu_string_append_kx(str, idt, "TransferBlocks", self->transfer_blocks);
 	if (self->oui != 0x0)

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -46,7 +46,6 @@ static void
 fu_bcm57xx_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
-	FU_DEVICE_CLASS(fu_bcm57xx_device_parent_class)->to_string(device, idt, str);
 	fu_string_append(str, idt, "EthtoolIface", self->ethtool_iface);
 }
 

--- a/plugins/cfu/fu-cfu-device.c
+++ b/plugins/cfu/fu-cfu-device.c
@@ -47,10 +47,6 @@ static void
 fu_cfu_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCfuDevice *self = FU_CFU_DEVICE(device);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_cfu_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "ProtocolVersion", self->protocol_version);
 	fu_cfu_device_map_to_string(str, idt, &self->version_get_report, "VersionGetReport");
 	fu_cfu_device_map_to_string(str, idt, &self->offer_set_report, "OfferSetReport");

--- a/plugins/ch341a/fu-ch341a-device.c
+++ b/plugins/ch341a/fu-ch341a-device.c
@@ -82,10 +82,6 @@ static void
 fu_ch341a_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCh341aDevice *self = FU_CH341A_DEVICE(device);
-
-	/* FuUsbDevice->to_string */
-	FU_DEVICE_CLASS(fu_ch341a_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "Speed", fu_ch341a_device_speed_to_string(self->speed));
 }
 

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -43,10 +43,6 @@ static void
 fu_ch347_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCh347Device *self = FU_CH347_DEVICE(device);
-
-	/* FuUsbDevice->to_string */
-	FU_DEVICE_CLASS(fu_ch347_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "Divisor", self->divisor);
 }
 

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -431,9 +431,6 @@ static void
 fu_corsair_bp_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCorsairBp *self = FU_CORSAIR_BP(device);
-
-	FU_DEVICE_CLASS(fu_corsair_bp_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "InEndpoint", self->epin);
 	fu_string_append_kx(str, idt, "OutEndpoint", self->epout);
 }

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -422,9 +422,6 @@ static void
 fu_corsair_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuCorsairDevice *self = FU_CORSAIR_DEVICE(device);
-
-	FU_DEVICE_CLASS(fu_corsair_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str,
 			 idt,
 			 "DeviceKind",

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -78,7 +78,6 @@ static void
 fu_emmc_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuEmmcDevice *self = FU_EMMC_DEVICE(device);
-	FU_DEVICE_CLASS(fu_emmc_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_ku(str, idt, "SectorSize", self->sect_size);
 }
 

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -601,8 +601,6 @@ static void
 fu_genesys_gl32xx_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuGenesysGl32xxDevice *self = FU_GENESYS_GL32XX_DEVICE(device);
-
-	FU_DEVICE_CLASS(fu_genesys_gl32xx_device_parent_class)->to_string(device, idt, str);
 	fu_string_append(str, idt, "ChipName", self->chip_name);
 	fu_string_append_kx(str, idt, "BlockTransferSize", self->packetsz);
 	fu_string_append_kx(str, idt, "CustomerId", self->customer_id);

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -25,7 +25,6 @@ static void
 fu_gpio_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuGpioDevice *self = FU_GPIO_DEVICE(device);
-	FU_DEVICE_CLASS(fu_gpio_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_ku(str, idt, "NumLines", self->num_lines);
 	fu_string_append_kb(str, idt, "FdOpen", self->fd > 0);
 }

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -44,7 +44,6 @@ static void
 fu_igsc_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuIgscDevice *self = FU_IGSC_DEVICE(device);
-	FU_DEVICE_CLASS(fu_igsc_device_parent_class)->to_string(device, idt, str);
 	fu_string_append(str, idt, "Project", self->project);
 	fu_string_append_kx(str, idt, "HwSku", self->hw_sku);
 	fu_string_append_kx(str, idt, "SubsystemVendor", self->subsystem_vendor);

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -34,10 +34,6 @@ static void
 fu_kinetic_dp_puma_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuKineticDpPumaDevice *self = FU_KINETIC_DP_PUMA_DEVICE(device);
-
-	/* FuKineticDpDevice->to_string */
-	FU_DEVICE_CLASS(fu_kinetic_dp_puma_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "ReadFlashProgTime", self->read_flash_prog_time);
 	fu_string_append_kx(str, idt, "FlashId", self->flash_id);
 	fu_string_append_kx(str, idt, "FlashSize", self->flash_size);

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -47,10 +47,6 @@ static void
 fu_kinetic_dp_secure_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuKineticDpSecureDevice *self = FU_KINETIC_DP_SECURE_DEVICE(device);
-
-	/* FuKineticDpDevice->to_string */
-	FU_DEVICE_CLASS(fu_kinetic_dp_secure_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "ReadFlashProgTime", self->read_flash_prog_time);
 	fu_string_append_kx(str, idt, "FlashId", self->flash_id);
 	fu_string_append_kx(str, idt, "FlashSize", self->flash_size);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -275,10 +275,6 @@ fu_logitech_hidpp_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuLogitechHidppDevice *self = FU_HIDPP_DEVICE(device);
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_logitech_hidpp_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_ku(str, idt, "HidppVersion", priv->hidpp_version);
 	fu_string_append_ku(str, idt, "HidppPid", priv->hidpp_pid);
 	fu_string_append_kx(str, idt, "DeviceIdx", priv->device_idx);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -57,8 +57,6 @@ static void
 fu_logitech_hidpp_runtime_bolt_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuLogitechHidppRuntimeBolt *self = FU_HIDPP_RUNTIME_BOLT(device);
-
-	FU_DEVICE_CLASS(fu_logitech_hidpp_runtime_bolt_parent_class)->to_string(device, idt, str);
 	fu_string_append_ku(str, idt, "PairingSlots", self->pairing_slots);
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -40,12 +40,6 @@ fu_logitech_hidpp_runtime_get_version_bl_major(FuLogitechHidppRuntime *self)
 	return priv->version_bl_major;
 }
 
-static void
-fu_logitech_hidpp_runtime_to_string(FuDevice *device, guint idt, GString *str)
-{
-	FU_DEVICE_CLASS(fu_logitech_hidpp_runtime_parent_class)->to_string(device, idt, str);
-}
-
 gboolean
 fu_logitech_hidpp_runtime_enable_notifications(FuLogitechHidppRuntime *self, GError **error)
 {
@@ -249,7 +243,6 @@ fu_logitech_hidpp_runtime_class_init(FuLogitechHidppRuntimeClass *klass)
 	klass_device->probe = fu_logitech_hidpp_runtime_probe;
 	klass_device->close = fu_logitech_hidpp_runtime_close;
 	klass_device->poll = fu_logitech_hidpp_runtime_poll;
-	klass_device->to_string = fu_logitech_hidpp_runtime_to_string;
 }
 
 static void

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -54,10 +54,6 @@ static void
 fu_mediatek_scaler_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuMediatekScalerDevice *self = FU_MEDIATEK_SCALER_DEVICE(device);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_mediatek_scaler_device_parent_class)->to_string(device, idt, str);
-
 	if (self->i2c_dev != NULL) {
 		fu_string_append(str,
 				 idt,

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -47,7 +47,6 @@ static void
 fu_nvme_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuNvmeDevice *self = FU_NVME_DEVICE(device);
-	FU_DEVICE_CLASS(fu_nvme_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_ku(str, idt, "PciDepth", self->pci_depth);
 }
 

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -74,10 +74,6 @@ static void
 fu_pxi_ble_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuPxiBleDevice *self = FU_PXI_BLE_DEVICE(device);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_pxi_ble_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "ModelName", self->model_name);
 	fu_pxi_ota_fw_state_to_string(&self->fwstate, idt, str);
 	fu_string_append_kx(str, idt, "RetransmitID", self->retransmit_id);

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -35,7 +35,6 @@ static void
 fu_scsi_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuScsiDevice *self = FU_SCSI_DEVICE(device);
-	FU_DEVICE_CLASS(fu_scsi_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_kx(str, idt, "FfuTimeout", self->ffu_timeout);
 }
 

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -158,9 +158,6 @@ fu_steelseries_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuSteelseriesDevice *self = FU_STEELSERIES_DEVICE(device);
 	FuSteelseriesDevicePrivate *priv = GET_PRIVATE(self);
-
-	FU_DEVICE_CLASS(fu_steelseries_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "Interface", priv->iface_idx);
 	fu_string_append_kx(str, idt, "Endpoint", priv->ep);
 }

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -119,10 +119,6 @@ fu_superio_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE(device);
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_superio_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "Chipset", priv->chipset);
 	fu_string_append_kx(str, idt, "Id", priv->id);
 	fu_string_append_kx(str, idt, "Port", priv->port);

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -53,10 +53,6 @@ static void
 fu_superio_it55_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuEcIt55Device *self = FU_SUPERIO_IT55_DEVICE(device);
-
-	/* FuSuperioDevice->to_string */
-	FU_DEVICE_CLASS(fu_superio_it55_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "PrjName", self->prj_name);
 	fu_string_append_kx(str, idt, "AutoloadAction", self->autoload_action);
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -138,10 +138,6 @@ static void
 fu_synaptics_mst_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuSynapticsMstDevice *self = FU_SYNAPTICS_MST_DEVICE(device);
-
-	/* FuDpauxDevice->to_string */
-	FU_DEVICE_CLASS(fu_synaptics_mst_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "DeviceKind", self->device_kind);
 	if (self->family == FU_SYNAPTICS_MST_FAMILY_PANAMERA)
 		fu_string_append_kx(str, idt, "ActiveBank", self->active_bank);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -86,10 +86,6 @@ fu_synaptics_rmi_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE(device);
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_synaptics_rmi_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "CurrentPage", priv->current_page);
 	fu_string_append_kx(str, idt, "InIepMode", priv->in_iep_mode);
 	fu_string_append_kx(str, idt, "MaxPage", priv->max_page);

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -67,10 +67,6 @@ static void
 fu_thunderbolt_controller_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuThunderboltController *self = FU_THUNDERBOLT_CONTROLLER(device);
-
-	/* FuThunderboltDevice->to_string */
-	FU_DEVICE_CLASS(fu_thunderbolt_controller_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "DeviceType", fu_thunderbolt_controller_kind_to_string(self));
 	fu_string_append_kb(str, idt, "SafeMode", self->safe_mode);
 	fu_string_append_kb(str, idt, "NativeMode", self->is_native);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -155,10 +155,6 @@ fu_thunderbolt_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
 	FuThunderboltDevicePrivate *priv = GET_PRIVATE(self);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_thunderbolt_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str, idt, "AuthMethod", priv->auth_method);
 }
 

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -408,7 +408,6 @@ static void
 fu_uf2_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuUf2Device *self = FU_UF2_DEVICE(device);
-	FU_DEVICE_CLASS(fu_uf2_device_parent_class)->to_string(device, idt, str);
 	if (self->family_id > 0)
 		fu_string_append_kx(str, idt, "FamilyId", self->family_id);
 }

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -39,10 +39,6 @@ static void
 fu_vbe_simple_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuVbeSimpleDevice *self = FU_VBE_SIMPLE_DEVICE(device);
-
-	/* FuVbeDevice->to_string */
-	FU_DEVICE_CLASS(fu_vbe_simple_device_parent_class)->to_string(device, idt, str);
-
 	if (self->storage != NULL)
 		fu_string_append(str, idt, "Storage", self->storage);
 	if (self->devname != NULL)

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -25,7 +25,6 @@ static void
 fu_{{vendor}}_{{example}}_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	Fu{{Vendor}}{{Example}}Device *self = FU_{{VENDOR}}_{{EXAMPLE}}_DEVICE(device);
-	FU_DEVICE_CLASS(fu_{{vendor}}_{{example}}_device_parent_class)->to_string(device, idt, str);
 	fu_string_append_kx(str, idt, "StartAddr", self->start_addr);
 }
 

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -521,12 +521,8 @@ fu_vli_device_to_string(FuDevice *device, guint idt, GString *str)
 	FuVliDevice *self = FU_VLI_DEVICE(device);
 	FuVliDevicePrivate *priv = GET_PRIVATE(self);
 
-	/* parent */
-	FU_DEVICE_CLASS(fu_vli_device_parent_class)->to_string(device, idt, str);
-
-	if (priv->kind != FU_VLI_DEVICE_KIND_UNKNOWN) {
+	if (priv->kind != FU_VLI_DEVICE_KIND_UNKNOWN)
 		fu_string_append(str, idt, "DeviceKind", fu_vli_device_kind_to_string(priv->kind));
-	}
 	fu_string_append_kb(str, idt, "SpiAutoDetect", priv->spi_auto_detect);
 	if (priv->flash_id != 0x0) {
 		g_autofree gchar *tmp = fu_vli_device_get_flash_id_str(self);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -86,10 +86,6 @@ static void
 fu_vli_usbhub_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE(device);
-
-	/* parent */
-	FU_DEVICE_CLASS(fu_vli_usbhub_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kb(str, idt, "DisablePowersave", self->disable_powersave);
 	fu_string_append_kx(str, idt, "UpdateProtocol", self->update_protocol);
 	if (self->update_protocol >= 0x2) {

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -29,10 +29,6 @@ fu_wacom_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuWacomDevice *self = FU_WACOM_DEVICE(device);
 	FuWacomDevicePrivate *priv = GET_PRIVATE(self);
-
-	/* FuUdevDevice->to_string */
-	FU_DEVICE_CLASS(fu_wacom_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append_kx(str, idt, "FlashBlockSize", priv->flash_block_size);
 	fu_string_append_kx(str, idt, "FlashBaseAddr", priv->flash_base_addr);
 	fu_string_append_kx(str, idt, "FlashSize", priv->flash_size);

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -42,10 +42,6 @@ static void
 fu_wistron_dock_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuWistronDockDevice *self = FU_WISTRON_DOCK_DEVICE(device);
-
-	/* FuHidDevice->to_string */
-	FU_DEVICE_CLASS(fu_wistron_dock_device_parent_class)->to_string(device, idt, str);
-
 	fu_string_append(str,
 			 idt,
 			 "ComponentIdx",


### PR DESCRIPTION
The rule for whether this was required was overly complicated -- "if deriving from something other then FuDevice that does implement to_string() then yes, otherwise no" -- and the result is that a lot of the plugin code wasn't doing the right thing.

Move all the complexity into `fu_device_add_string()` and run every unique `->to_string()` in each subclass on the logic we never want to 'replace' the subclass implementation like we might with `->probe()`, `->setup()` etc.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
