### PR TITLE
trivial: Set flags for MST plugins in setup() instead of init()

### DIFF
--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -472,6 +472,18 @@ fu_mediatek_scaler_device_setup(FuDevice *device, GError **error)
 	if (!fu_mediatek_scaler_device_ensure_firmware_version(self, error))
 		return FALSE;
 
+	/* set flags */
+	fu_device_set_name(device, "Display Controller");
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_set_vendor(device, "Mediatek");
+	fu_device_add_protocol(device, "com.mediatek.scaler");
+	fu_device_add_icon(device, "video-display");
+	fu_device_set_firmware_size_max(device, FU_MEDIATEK_SCALER_FW_SIZE_MAX);
+
 	/* success */
 	return TRUE;
 }
@@ -966,16 +978,6 @@ fu_mediatek_scaler_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_mediatek_scaler_device_init(FuMediatekScalerDevice *self)
 {
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_set_vendor(FU_DEVICE(self), "Mediatek");
-	fu_device_add_protocol(FU_DEVICE(self), "com.mediatek.scaler");
-	fu_device_set_name(FU_DEVICE(self), "Display Controller");
-	fu_device_add_icon(FU_DEVICE(self), "video-display");
-	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_MEDIATEK_SCALER_FW_SIZE_MAX);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_MEDIATEK_SCALER_DEVICE_FLAG_PROBE_VCP,
 					"probe-vcp");

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -494,6 +494,18 @@ fu_realtek_mst_device_probe_version(FuDevice *device, GError **error)
 	guint8 *active_version;
 	g_autofree gchar *version_str = NULL;
 
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_protocol(device, "com.realtek.rtd2142");
+	fu_device_set_vendor(device, "Realtek");
+	fu_device_add_vendor_id(device, "PCI:0x10EC");
+	fu_device_set_summary(device, "DisplayPort MST hub");
+	fu_device_add_icon(device, "video-display");
+	fu_device_set_firmware_size(device, FLASH_USER_SIZE);
+
 	/* ensure probed state is cleared in case of error */
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	self->active_bank = FLASH_BANK_INVALID;
@@ -935,19 +947,7 @@ static void
 fu_realtek_mst_device_init(FuRealtekMstDevice *self)
 {
 	self->active_bank = FLASH_BANK_INVALID;
-
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_GENERIC_GUIDS);
-	fu_device_add_protocol(FU_DEVICE(self), "com.realtek.rtd2142");
-	fu_device_set_vendor(FU_DEVICE(self), "Realtek");
-	fu_device_add_vendor_id(FU_DEVICE(self), "PCI:0x10EC");
-	fu_device_set_summary(FU_DEVICE(self), "DisplayPort MST hub");
-	fu_device_add_icon(FU_DEVICE(self), "video-display");
-	fu_device_set_firmware_size(FU_DEVICE(self), FLASH_USER_SIZE);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -110,21 +110,12 @@ fu_synaptics_mst_device_udev_device_notify_cb(FuUdevDevice *udev_device,
 static void
 fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 {
-	self->family = FU_SYNAPTICS_MST_FAMILY_UNKNOWN;
-	fu_device_add_protocol(FU_DEVICE(self), "com.synaptics.mst");
-	fu_device_set_vendor(FU_DEVICE(self), "Synaptics");
-	fu_device_add_vendor_id(FU_DEVICE(self), "DRM_DP_AUX_DEV:0x06CB");
-	fu_device_set_summary(FU_DEVICE(self), "Multi-stream transport device");
-	fu_device_add_icon(FU_DEVICE(self), "video-display");
-	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID,
 					"ignore-board-id");
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_MANUAL_RESTART_REQUIRED,
 					"manual-restart-required");
-	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
 	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 
 	/* this is set from ->incorporate() */
@@ -1591,6 +1582,16 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 	g_autofree gchar *version = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GError) error_local = NULL;
+
+	self->family = FU_SYNAPTICS_MST_FAMILY_UNKNOWN;
+	fu_device_add_protocol(device, "com.synaptics.mst");
+	fu_device_set_vendor(device, "Synaptics");
+	fu_device_add_vendor_id(device, "DRM_DP_AUX_DEV:0x06CB");
+	fu_device_set_summary(device, "Multi-stream transport device");
+	fu_device_add_icon(device, "video-display");
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_NO_PROBE_COMPLETE);
 
 	/* not a correct device */
 	if (fu_dpaux_device_get_dpcd_ieee_oui(FU_DPAUX_DEVICE(device)) != SYNAPTICS_IEEE_OUI) {


### PR DESCRIPTION
This avoids one plugin's values overriding another plugin that doesn't set them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
