### PR TITLE
trivial: Fix an off-by-one error when using old GLib versions

### DIFF
--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -58,7 +58,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (length < 0)
 		length = strlen(contents);
 	fd = g_open(filename, O_CREAT, mode);
-	if (fd <= 0) {
+	if (fd < 0) {
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_FAILED,

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2571,7 +2571,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (length < 0)
 		length = strlen(contents);
 	fd = g_open(filename, O_CREAT, mode);
-	if (fd <= 0) {
+	if (fd < 0) {
 		g_set_error(error,
 			    G_IO_ERROR,
 			    G_IO_ERROR_FAILED,


### PR DESCRIPTION
Spotted by Coverity, although impossible to hit in practice.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
