### PR TITLE
Correctly mark the CPU as supported, harder

### DIFF
--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -923,6 +923,7 @@ fwupd_security_attr_ensure_result(FwupdSecurityAttr *self)
 {
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE(self);
 	if (fwupd_security_attr_has_flag(self, FWUPD_SECURITY_ATTR_FLAG_SUCCESS) &&
+	    priv->result == FWUPD_SECURITY_ATTR_RESULT_UNKNOWN &&
 	    priv->result_success != FWUPD_SECURITY_ATTR_RESULT_UNKNOWN) {
 		g_debug("auto-setting %s result %s",
 			priv->appstream_id,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6469,7 +6469,6 @@ fu_engine_ensure_security_attrs_supported_cpu(FuEngine *self)
 
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_MISSING_DATA);
-	fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);
 	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_VALID);
 	fu_security_attrs_append(self->host_security_attrs, attr);
 }


### PR DESCRIPTION
This essentially reverts commit fa97f360e0a478344d5acf1728d2338b6f420cfa, and for an unsupported CPU we now show a failure of "Unknown".

Fixes https://github.com/fwupd/fwupd/issues/6603

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
