### PR TITLE
trivial: linux-swap: don't ever auto-set swap to encrypted

### DIFF
--- a/plugins/linux-swap/fu-linux-swap-plugin.c
+++ b/plugins/linux-swap/fu-linux-swap-plugin.c
@@ -92,8 +92,8 @@ fu_linux_swap_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs
 
 	/* none configured */
 	if (!fu_linux_swap_get_enabled(swap)) {
-		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
 		return;
 	}
 


### PR DESCRIPTION
Adding the success flag will cause `fwupd_security_attr_ensure_result()` to be called which will potentially set the value to an incorrect value momentarily and can look like a mistake in debug logs.

Change the call order to ensure that `FWUPD_SECURITY_ATTR_FLAG_SUCCESS` is only added after result and result success are declared.

Fixes: https://github.com/fwupd/fwupd/issues/6603

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
