### PR TITLE
trivial: add a meson warning for DynamicUser

### DIFF
--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -16,6 +16,7 @@ con2.set('systemd_unit_user', get_option('systemd_unit_user'))
 if libsystemd.found()
   if get_option('systemd_unit_user') == ''
       con2.set('user', 'DynamicUser=yes')
+      warning('Using systemd DynamicUser for fwupd-refresh.service. See https://github.com/systemd/systemd/issues/22737 for possible implications')
   else
       dynamic_options = [
                          'ProtectSystem=strict',


### PR DESCRIPTION
This should help point out possible pitfalls for the systemd bug.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
