### PR TITLE
vli: Fix a regression when calculating the PD firmware CRC

### DIFF
--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -74,6 +74,11 @@ fu_input_stream_compute_sum16(GInputStream *stream,
 			      guint16 *value,
 			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
+fu_input_stream_compute_crc16(GInputStream *stream,
+			      guint16 *crc,
+			      guint16 polynomial,
+			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+gboolean
 fu_input_stream_compute_crc32(GInputStream *stream,
 			      guint32 *crc,
 			      guint32 polynomial,


### PR DESCRIPTION
This regressed in 62f6f19d.

Found by Comic Cho, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
