### PR TITLE
Avoid crashing the daemon if not using udisks to check for size

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -440,7 +440,14 @@ fu_volume_get_block_size(FuVolume *self, GError **error)
 	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail(FU_IS_VOLUME(self), 0);
-	g_return_val_if_fail(G_IS_DBUS_PROXY(self->proxy_blk), 0);
+
+	if (self->proxy_blk == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no udisks proxy");
+		return 0;
+	}
 
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "Device");
 	if (val == NULL) {


### PR DESCRIPTION
The caller in `fu_efi_hard_drive_device_path_new_from_volume()` will fall back to `BLOCK_SIZE_FALLBACK` and show a warning.  If a way to get the block size for a random path is introduced later we can clean up that warning at that point.

Fixes: https://github.com/fwupd/fwupd/issues/6638

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
