### PR TITLE
trivial: snap: Promote 1.9.x release to the 1.9.x channel

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -19,9 +19,9 @@ jobs:
     - id: channel
       run: |
         if git describe --exact-match; then
-          echo "::set-output name=channel::candidate"
+          echo "::set-output name=channel::1.9.x/candidate"
         else
-          echo "::set-output name=channel::edge"
+          echo "::set-output name=channel::1.9.x/edge"
         fi
     - id: prep
       run: |
@@ -34,3 +34,18 @@ jobs:
         name: snap
         path: ${{ steps.snapcraft.outputs.snap }}
 
+  deploy-store:
+    needs: build-snap
+    runs-on: ubuntu-latest
+    if: ${{ inputs.deploy }}
+    steps:
+    - uses: actions/download-artifact@v3
+      id: download
+      with:
+        name: snap
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ needs.build-snap.outputs.snap_name }}
+        release: ${{ needs.build-snap.outputs.channel }}


### PR DESCRIPTION
1.9.x releases will be on 1.9.x track, 2.0 will be on latest track.  When we start a 2_0_X branch and main moves to 2.1.x we'll open a 2.0.x track at that time too.

This reverts commit d1e895dc94c45dbe17901ac33c89d709770e900c. 
Fixes: https://github.com/fwupd/fwupd/issues/5804

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
