### PR TITLE
Allow UEFI updates to work from venv

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -9,3 +9,17 @@ if [ ! -d ${BUILD} ]; then
         meson setup ${BUILD} --prefix=${DIST} -Dsystemd=disabled -Dudevdir=${DIST} $@
 fi
 ninja -C ${BUILD} install
+
+# check whether we have an existing fwupd EFI binary in the host system to use
+EFI_PREFIX=$(pkg-config fwupd-efi --variable=prefix 2>/dev/null || echo "/usr")
+EFI_DIR=libexec/fwupd/efi
+BINARIES=$(find "${EFI_PREFIX}/${EFI_DIR}" -name "*.efi*" -type f -print)
+if [ -n "${BINARIES}" ]; then
+        mkdir -p ${DIST}/${EFI_DIR}
+        for i in ${BINARIES}; do
+                if [ -f "${DIST}/${EFI_DIR}/$(basename $i)" ]; then
+                        continue
+                fi
+                ln -s $i "${DIST}/${EFI_DIR}/$(basename $i)"
+        done
+fi

--- a/contrib/setup
+++ b/contrib/setup
@@ -6,6 +6,10 @@ cd "$(dirname "$0")/.."
 HELPER=./contrib/ci/fwupd_setup_helpers.py
 HELPER_ARGS="-y"
 
+if [ "$(id -u)" != "0" ]; then
+       SUDO=$(which sudo)
+fi
+
 rename_branch()
 {
     OLD=master
@@ -27,7 +31,7 @@ setup_deps()
 {
     read -p "Install build dependencies? (y/N) " question
     if [ "$question" = "y" ]; then
-        $(which sudo) python3 $HELPER install-dependencies $HELPER_ARGS -y
+        $SUDO python3 $HELPER install-dependencies $HELPER_ARGS -y
     fi
 }
 
@@ -76,7 +80,7 @@ install_pip()
     package=$1
     args=$2
     if ! python3 -m pip install $package $args; then
-        $(which sudo) python3 $HELPER install-pip $HELPER_ARGS -y
+        $SUDO python3 $HELPER install-pip $HELPER_ARGS -y
     fi
     #try once more
     python3 -m pip install $package
@@ -192,6 +196,12 @@ if [ -f venv/bin/build-fwupd ]; then
     echo "$0 has already been run"
     howto
     exit 0
+fi
+
+PYTHON_VERSION=$(python3 --version 2>/dev/null)
+if [ -z "$PYTHON_VERSION" ]; then
+    echo "Install python3 to run this script" >&2
+    exit 1
 fi
 
 #needed for arguments for some commands


### PR DESCRIPTION
If the host OS has EFI binaries, try to symlink them into the fwupd dev venv environment.  This should let updates with secure boot work.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
