### PR TITLE
Add a device problem when the device needs a reboot

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -4064,6 +4064,11 @@ fu_device_set_update_state(FuDevice *self, FwupdUpdateState update_state)
 	    update_state == FWUPD_UPDATE_STATE_PENDING ||
 	    update_state == FWUPD_UPDATE_STATE_NEEDS_REBOOT)
 		fu_device_set_update_error(self, NULL);
+	if (update_state == FWUPD_UPDATE_STATE_NEEDS_REBOOT) {
+		fu_device_add_problem(self, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
+	} else {
+		fu_device_remove_problem(self, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
+	}
 	fwupd_device_set_update_state(FWUPD_DEVICE(self), update_state);
 }
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2496,7 +2496,7 @@ fu_engine_history_func(gconstpointer user_data)
 			    "  Name:                 Test Device\n"
 			    "  Guid:                 12345678-1234-1234-1234-123456789012\n"
 			    "  Plugin:               test\n"
-			    "  Flags:                historical|updatable-hidden|unsigned-payload\n"
+			    "  Flags:                updatable|historical|unsigned-payload\n"
 			    "  Version:              1.2.2\n"
 			    "  Created:              2018-01-07\n"
 			    "  Modified:             2017-12-27\n"


### PR DESCRIPTION
This ensures that the update does not show up in any program that just gets the device list and checks for the updatable flag.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
