### PR TITLE
Don't require systemd for `modify-config`

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -1007,6 +1007,8 @@ fwupd_client_disconnect(FwupdClient *self, GError **error)
 static void
 fwupd_client_quit_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 {
+	FwupdClient *self = FWUPD_CLIENT(g_task_get_source_object(G_TASK(user_data)));
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GTask) task = G_TASK(user_data);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GVariant) val = NULL;
@@ -1019,6 +1021,7 @@ fwupd_client_quit_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 	}
 
 	/* success */
+	g_clear_object(&priv->proxy);
 	g_task_return_boolean(task, TRUE);
 }
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3672,10 +3672,12 @@ fu_util_modify_config(FuUtilPrivate *priv, gchar **values, GError **error)
 					   _("Restart the daemon to make the change effective?")))
 			return TRUE;
 	}
-#ifdef HAVE_SYSTEMD
-	if (!fu_systemd_unit_stop(fu_util_get_systemd_unit(), error))
+
+	if (!fu_util_quit(priv, NULL, error))
 		return FALSE;
-#endif
+	if (!fwupd_client_connect(priv->client, priv->cancellable, error))
+		return FALSE;
+
 	/* TRANSLATORS: success message -- a per-system setting value */
 	fu_console_print_literal(priv->console, _("Successfully modified configuration value"));
 	return TRUE;


### PR DESCRIPTION
fwupdmgr has the ability to restart the daemon itself by using `fu_util_quit` to stop it and dbus activation to start it again.

Use that instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
