### PR TITLE
trivial: don't show `HSI attribute %s (from %s) had unknown result` t…

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7030,9 +7030,15 @@ fu_engine_ensure_security_attrs(FuEngine *self)
 	for (guint i = 0; i < vals->len; i++) {
 		FwupdSecurityAttr *attr = g_ptr_array_index(vals, i);
 		if (fwupd_security_attr_get_result(attr) == FWUPD_SECURITY_ATTR_RESULT_UNKNOWN) {
+#ifdef SUPPORTED_BUILD
+			g_debug("HSI attribute %s (from %s) had unknown result",
+				fwupd_security_attr_get_appstream_id(attr),
+				fwupd_security_attr_get_plugin(attr));
+#else
 			g_warning("HSI attribute %s (from %s) had unknown result",
 				  fwupd_security_attr_get_appstream_id(attr),
 				  fwupd_security_attr_get_plugin(attr));
+#endif
 		}
 	}
 


### PR DESCRIPTION
…o users

This typically happens on systems that don't have CPU support, but there is nothing that a user or software can do about it.  It will just litter the journal with warnings on every boot.

Downgrade the message to debug on supported builds so we can still dig into it if there is an actual solvable problem.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
