### PR TITLE
trivial: drop systemd unit detection

### DIFF
--- a/src/fu-systemd.c
+++ b/src/fu-systemd.c
@@ -136,18 +136,3 @@ fu_systemd_unit_stop(const gchar *unit, GError **error)
 				     error);
 	return val != NULL;
 }
-
-gboolean
-fu_systemd_unit_check_exists(const gchar *unit, GError **error)
-{
-	g_autoptr(GDBusProxy) proxy_manager = NULL;
-	g_autofree gchar *path = NULL;
-
-	g_return_val_if_fail(unit != NULL, FALSE);
-
-	proxy_manager = fu_systemd_get_manager(error);
-	if (proxy_manager == NULL)
-		return FALSE;
-	path = fu_systemd_unit_get_path(proxy_manager, unit, error);
-	return path != NULL;
-}

--- a/src/fu-systemd.h
+++ b/src/fu-systemd.h
@@ -9,8 +9,6 @@
 #include <glib.h>
 
 gboolean
-fu_systemd_unit_check_exists(const gchar *unit, GError **error);
-gboolean
 fu_systemd_unit_stop(const gchar *unit, GError **error);
 gchar *
 fu_systemd_get_default_target(GError **error);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -48,6 +48,8 @@
 
 #ifdef HAVE_SYSTEMD
 #include "fu-systemd.h"
+#define SYSTEMD_FWUPD_UNIT	"fwupd.service"
+#define SYSTEMD_SNAP_FWUPD_UNIT "snap.fwupd.fwupd.service"
 #endif
 
 /* custom return codes */
@@ -207,6 +209,16 @@ fu_util_lock(FuUtilPrivate *priv, GError **error)
 #endif
 	return TRUE;
 }
+
+#ifdef HAVE_SYSTEMD
+static const gchar *
+fu_util_get_systemd_unit(void)
+{
+	if (g_getenv("SNAP") != NULL)
+		return SYSTEMD_SNAP_FWUPD_UNIT;
+	return SYSTEMD_FWUPD_UNIT;
+}
+#endif
 
 static gboolean
 fu_util_start_engine(FuUtilPrivate *priv,

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -24,25 +24,10 @@
 #include "fu-device-private.h"
 #include "fu-util-common.h"
 
-#ifdef HAVE_SYSTEMD
-#include "fu-systemd.h"
-#endif
-
-#define SYSTEMD_FWUPD_UNIT	"fwupd.service"
-#define SYSTEMD_SNAP_FWUPD_UNIT "snap.fwupd.fwupd.service"
-
 static gchar *
 fu_util_remote_to_string(FwupdRemote *remote, guint idt);
 static gchar *
 fu_util_release_to_string(FwupdRelease *rel, guint idt);
-
-const gchar *
-fu_util_get_systemd_unit(void)
-{
-	if (g_getenv("SNAP") != NULL)
-		return SYSTEMD_SNAP_FWUPD_UNIT;
-	return SYSTEMD_FWUPD_UNIT;
-}
 
 gchar *
 fu_console_color_format(const gchar *text, FuConsoleColor fg_color)
@@ -50,48 +35,6 @@ fu_console_color_format(const gchar *text, FuConsoleColor fg_color)
 	if (g_getenv("NO_COLOR") != NULL)
 		return g_strdup(text);
 	return g_strdup_printf("\033[%um\033[1m%s\033[0m", fg_color, text);
-}
-
-#ifdef HAVE_SYSTEMD
-static const gchar *
-fu_util_get_expected_command(const gchar *target)
-{
-	if (g_strcmp0(target, SYSTEMD_SNAP_FWUPD_UNIT) == 0)
-		return "fwupd.fwupdmgr";
-	return "fwupdmgr";
-}
-#endif
-
-gboolean
-fu_util_using_correct_daemon(GError **error)
-{
-#ifdef HAVE_SYSTEMD
-	g_autofree gchar *default_target = NULL;
-	g_autoptr(GError) error_local = NULL;
-	const gchar *target;
-
-	if (g_getenv("FWUPD_DBUS_SOCKET") != NULL)
-		return TRUE;
-
-	target = fu_util_get_systemd_unit();
-
-	default_target = fu_systemd_get_default_target(&error_local);
-	if (default_target == NULL) {
-		g_info("systemd is not accessible: %s", error_local->message);
-		return TRUE;
-	}
-	if (!fu_systemd_unit_check_exists(target, &error_local)) {
-		g_info("wrong target: %s", error_local->message);
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INVALID_ARGS,
-			    /* TRANSLATORS: error message */
-			    _("Mismatched daemon and client, use %s instead"),
-			    fu_util_get_expected_command(target));
-		return FALSE;
-	}
-#endif
-	return TRUE;
 }
 
 typedef struct {

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -81,11 +81,6 @@ fu_util_branch_for_display(const gchar *branch);
 const gchar *
 fu_util_request_get_message(FwupdRequest *req);
 
-const gchar *
-fu_util_get_systemd_unit(void);
-gboolean
-fu_util_using_correct_daemon(GError **error);
-
 gboolean
 fu_util_parse_filter_device_flags(const gchar *filter,
 				  FwupdDeviceFlags *include,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -5583,16 +5583,6 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-#ifdef HAVE_SYSTEMD
-	/* make sure the correct daemon is in use */
-	if ((priv->flags & FWUPD_INSTALL_FLAG_FORCE) == 0 &&
-	    !fwupd_client_get_daemon_interactive(priv->client) &&
-	    !fu_util_using_correct_daemon(&error)) {
-		fu_util_print_error(priv, error);
-		return EXIT_FAILURE;
-	}
-#endif
-
 	/* make sure polkit actions were installed */
 	if (!fu_util_check_polkit_actions(&error)) {
 		fu_util_print_error(priv, error);


### PR DESCRIPTION
The purpose of all of this code was to make sure that the correct unit was launched when the snap was installed.  There are two issues:

1. The confined snap isn't allowed to access this information so it's dead code now.
2. The snap daemon will prevent starting the snap version if a host version is already installed with this message: "snap.fwupd.fwupd.service: Two services allocated for the same bus name org.freedesktop.fwupd, refusing operation."

Drop the dead code.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
