### PR TITLE
Some snap improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ plugins/uefi-dbx/tests/
 .buildconfig
 .ossfuzz
 *.rej
+/snap

--- a/contrib/snap/fwupd-command
+++ b/contrib/snap/fwupd-command
@@ -38,4 +38,31 @@ if [ $needs_update = true ]; then
   echo "SNAP_DESKTOP_LAST_REVISION=$SNAP_REVISION" > $SNAP_USER_DATA/.last_revision
 fi
 
+# Setup directory structures if command was run as root
+if [ "$(id -u)" = "0" ]; then
+  CONF_DIR="${SNAP_COMMON}/var/etc/fwupd"
+  REMOTE_DIR="${SNAP_COMMON}/var/lib/fwupd/remotes.d"
+  SHARE_DIR="${SNAP_COMMON}/share/fwupd/remotes.d/vendor/firmware"
+  mkdir -p ${CONF_DIR} ${REMOTE_DIR} ${SHARE_DIR}
+
+  # copy a writable fwupd.conf for users to use
+  if [ ! -f "${CONF_DIR}/fwupd.conf" ]; then
+    cp "$SNAP/etc/fwupd/fwupd.conf" "${CONF_DIR}/fwupd.conf"
+  fi
+
+  # Migrate remotes from "old" snap guidance and from immutable directory
+  for BASE in "${SNAP}/etc/fwupd/remotes.d" "${SNAP_USER_DATA}/etc/fwupd/remotes.d/"; do
+    for P in ${BASE}/*.conf; do
+      REMOTE=$(basename $P)
+      # vendor.conf doesn't make sense in snap
+      if [ "${REMOTE}" = "vendor.conf" ]; then
+          continue
+      fi
+      if [ ! -f "${REMOTE_DIR}/${REMOTE}" ]; then
+          cp ${P} "${REMOTE_DIR}"
+      fi
+    done
+  done
+fi
+
 exec "$@"

--- a/contrib/snap/fwupd.wrapper
+++ b/contrib/snap/fwupd.wrapper
@@ -1,5 +1,2 @@
 #!/bin/sh
-# don't update between versions, we want to preserve previous data
-[ ! -d "$SNAP_USER_DATA/etc" ] && [ -d "$SNAP/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
-[ ! -d "$SNAP_USER_DATA/var" ] && [ -d "$SNAP/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
 exec "$SNAP/fwupd-command" $SNAP/libexec/fwupd/fwupd $@

--- a/contrib/snap/fwupdmgr.wrapper
+++ b/contrib/snap/fwupdmgr.wrapper
@@ -1,3 +1,2 @@
 #!/bin/sh
-export FWUPD_POLKIT_NOCHECK=1
 exec "$SNAP/fwupd-command" $SNAP/bin/fwupdmgr $@

--- a/contrib/snap/fwupdtool.wrapper
+++ b/contrib/snap/fwupdtool.wrapper
@@ -1,5 +1,2 @@
 #!/bin/sh
-# don't update between versions, we want to preserve previous data
-[ ! -d "$SNAP_USER_DATA/etc" ] && [ -d "$SNAP/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
-[ ! -d "$SNAP_USER_DATA/var" ] && [ -d "$SNAP/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
 exec "$SNAP/fwupd-command" $SNAP/bin/fwupdtool $@

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -120,7 +120,7 @@ parts:
               ${CRAFT_PART_INSTALL}/share/dbus-1/system-services/org.freedesktop.fwupd.service
       cp -R /usr/libexec/fwupd/efi ${CRAFT_PART_INSTALL}/libexec/fwupd
       cp /usr/lib/shim/shimx64.efi.signed ${CRAFT_PART_INSTALL}/libexec/fwupd/efi/
-      sed -i 's,^MetadataURI=.*$,MetadataURI=file:///var/snap/fwupd/common,' "${CRAFT_PART_INSTALL}/etc/fwupd/remotes.d/vendor-directory.conf"
+      sed -i 's,^MetadataURI=.*$,MetadataURI=file:///var/snap/fwupd/common/share/fwupd/remotes.d/vendor/firmware,' "${CRAFT_PART_INSTALL}/etc/fwupd/remotes.d/vendor-directory.conf"
     override-pull: |
       craftctl default
       craftctl set version=$(git describe HEAD --always)

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -210,6 +210,13 @@ parts:
       # this will cause gpgme to error finding it
       # but that also avoids trying to use nonexistent
       # /usr/bin/gpg2
+      - -etc/dconf/db
+      - -etc/grub.d
+      - -etc/fwupd/remotes.d/vendor.conf
+      - -etc/systemd/system
+      - -share/fwupd/*.py
+      - -share/fish
+      - -root
       - -usr/bin
       - -usr/sbin
       - -usr/libexec
@@ -234,6 +241,7 @@ parts:
       - -usr/share/upstart
       - -usr/share/X11
       - -include
+      - -lib/systemd
       - -lib/udev
       - -lib/*/pkgconfig
       - -usr/share/lintian

--- a/libfwupdplugin/fu-path.c
+++ b/libfwupdplugin/fu-path.c
@@ -257,7 +257,7 @@ fu_path_from_kind(FuPathKind path_kind)
 					FWUPD_LOCALSTATEDIR,
 					NULL);
 #else
-		tmp = g_getenv("SNAP_USER_DATA");
+		tmp = g_getenv("SNAP_COMMON");
 		if (tmp != NULL)
 			return g_build_filename(tmp, FWUPD_LOCALSTATEDIR, NULL);
 		return g_build_filename(FWUPD_LOCALSTATEDIR, NULL);
@@ -315,7 +315,7 @@ fu_path_from_kind(FuPathKind path_kind)
 		tmp = g_getenv("FWUPD_SYSCONFDIR");
 		if (tmp != NULL)
 			return g_strdup(tmp);
-		tmp = g_getenv("SNAP_USER_DATA");
+		tmp = g_getenv("SNAP");
 		if (tmp != NULL)
 			return g_build_filename(tmp, FWUPD_SYSCONFDIR, NULL);
 		basedir = fu_path_get_win32_basedir();

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8726,6 +8726,13 @@ fu_engine_constructed(GObject *obj)
 							    XMLB_MICRO_VERSION);
 		fu_context_add_compile_version(self->ctx, "com.hughsie.libxmlb", version);
 	}
+
+	/* add optional snap version */
+	if (g_getenv("SNAP_REVISION") != NULL) {
+		fu_context_add_compile_version(self->ctx,
+					       "io.snapcraft.fwupd",
+					       g_getenv("SNAP_REVISION"));
+	}
 }
 
 static void


### PR DESCRIPTION
Hodge podge of snap related improvements to shrink size, and to set up directory structure to carry info from one snap to another.

Some of these should have done when first confined, but better now than never.

Also the directory remote is now accessible from host at `/var/snap/fwupd/share/fwupd/remotes.d/vendor/firmware`

CC @CragW 
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
