### PR TITLE
trivial: disable thinklmi compat by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -510,6 +510,7 @@ option('hsi',
 )
 option('thinklmi_compat',
   type: 'boolean',
+  value: false,
   description: 'Include workaround for thinklmi kernel bugs',
 )
 option('python',


### PR DESCRIPTION
In commit 17037db4017920edda6c0917ffa881704a992205 we said that we would turn it off in about a year.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
