### PR TITLE
Disable the vendor remote by default

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -336,7 +336,6 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %dir %{_sysconfdir}/fwupd/remotes.d
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/lvfs.conf
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/lvfs-testing.conf
-%config(noreplace)%{_sysconfdir}/fwupd/remotes.d/vendor.conf
 %config(noreplace)%{_sysconfdir}/fwupd/remotes.d/vendor-directory.conf
 %config(noreplace)%{_sysconfdir}/pki/fwupd
 %{_sysconfdir}/pki/fwupd-metadata

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -212,7 +212,6 @@ parts:
       # /usr/bin/gpg2
       - -etc/dconf/db
       - -etc/grub.d
-      - -etc/fwupd/remotes.d/vendor.conf
       - -etc/systemd/system
       - -share/fwupd/*.py
       - -share/fish

--- a/data/remotes.d/README.md
+++ b/data/remotes.d/README.md
@@ -4,6 +4,7 @@
 
 These are the steps to add vendor firmware that is installed as part of an embedded image such as an OSTree or ChromeOS image:
 
+* Compile with `-Dvendor_metadata=true` to install `/etc/fwupd/remotes.d/vendor.conf`
 * Change `/etc/fwupd/remotes.d/vendor.conf` to have `Enabled=true`
 * Change `/etc/fwupd/remotes.d/vendor.conf` to have the correct `Title`
 * Deploy the firmware to `/usr/share/fwupd/remotes.d/vendor/firmware`

--- a/data/remotes.d/meson.build
+++ b/data/remotes.d/meson.build
@@ -55,7 +55,7 @@ configure_file(
   input: 'vendor.conf',
   output: 'vendor.conf',
   configuration: con2,
-  install: true,
+  install: get_option('vendor_metadata'),
   install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 )
 configure_file(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -468,6 +468,11 @@ option('udevdir',
   value: '',
   description: 'Directory for udev rules',
 )
+option('vendor_metadata',
+  type: 'boolean',
+  value: false,
+  description: 'install OS vendor provided metadata',
+)
 option('efi_os_dir',
   type: 'string',
   description: 'the hardcoded name of OS directory in ESP, e.g. fedora',


### PR DESCRIPTION
This is useful for OStree or ChromeOS, but not for all other Linux. Add a meson option for it, but disable it by default.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
