### PR TITLE
trivial: add FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE to uefi-capsule…

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -868,6 +868,7 @@ fu_uefi_capsule_plugin_coldplug_device(FuPlugin *plugin, FuUefiDevice *dev, GErr
 			fu_device_add_vendor_id(FU_DEVICE(dev), vendor_id);
 		}
 	}
+	fu_device_add_request_flag(FU_DEVICE(dev), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
… devices

These will emit FWUPD_REQUEST_ID_DO_NOT_POWER_OFF

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
