### PR TITLE
Run ALL installed-tests in the snap

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -38,10 +38,6 @@ jobs:
     needs: build-snap
     runs-on: ubuntu-latest
     steps:
-    - id: checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - uses: actions/download-artifact@v4
       id: download
       with:
@@ -51,15 +47,12 @@ jobs:
         sudo snap install --dangerous ${{ needs.build-snap.outputs.snap_name }}
         sudo snap connect fwupd:polkit :polkit
         sudo fwupd.fwupdtool modify-config DisabledPlugins ""
-    - id: build-cab
-      run: |
-        fwupd.fwupdtool build-cabinet fakedevice123.cab data/installed-tests/fakedevice123.*
-        sudo mkdir -p /var/snap/fwupd/common/share/fwupd/remotes.d/vendor/firmware
-        sudo cp fakedevice123.cab /var/snap/fwupd/common/share/fwupd/remotes.d/vendor/firmware
-    - id: update-fake-device
-      run: |
-        sudo fwupd.fwupdmgr update
-        fwupd.fwupdmgr get-updates || [ "$?" = "2" ]
+    - name: Run fwupdmgr tests
+      run: sudo /snap/fwupd/current/share/installed-tests/fwupd/fwupdmgr.sh
+    - name: Run fwupd tests
+      run: sudo /snap/fwupd/current/share/installed-tests/fwupd/fwupd.sh
+    - name: Run fwupdtool tests
+      run: sudo /snap/fwupd/current/share/installed-tests/fwupd/fwupdtool.sh
 
   deploy-store:
     needs: [build-snap, test-snap]

--- a/contrib/debian/fwupd-tests.install
+++ b/contrib/debian/fwupd-tests.install
@@ -3,7 +3,6 @@
 #find them. for more information see:
 #https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872458
 usr/share/installed-tests/*
-usr/libexec/installed-tests/fwupd/fwupd.sh
 usr/libexec/installed-tests/fwupd/*-self-test
 debian/lintian/fwupd-tests usr/share/lintian/overrides
 etc/fwupd/remotes.d/fwupd-tests.conf

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -414,6 +414,9 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %{_datadir}/installed-tests/fwupd/fwupd-tests.xml
 %{_datadir}/installed-tests/fwupd/*.test
 %{_datadir}/installed-tests/fwupd/*.cab
+%{_datadir}/installed-tests/fwupd/fakedevice124.jcat
+%{_datadir}/installed-tests/fwupd/fakedevice124.bin
+%{_datadir}/installed-tests/fwupd/fakedevice124.metainfo.xml
 %{_datadir}/installed-tests/fwupd/*.sh
 %{_datadir}/installed-tests/fwupd/*.zip
 %if 0%{?have_uefi}

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -120,6 +120,8 @@ parts:
               ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/*.sh
       sed -i "s,\(/share\),/snap/fwupd/current/\1," \
               ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/fwupdtool.sh
+      sed -i "s,\(/libexec\),/snap/fwupd/current/\1," \
+              ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/fwupd.sh
       sed -i 's,^MetadataURI=.*$,MetadataURI=file:///snap/fwupd/current/share/installed-tests/fwupd/fwupd-tests.xml,' "${CRAFT_PART_INSTALL}/etc/fwupd/remotes.d/fwupd-tests.conf"
       # fixes up dbus service for classic snap
       sed -i 's!SystemdService=\(.*\)!SystemdService=snap.fwupd.fwupd.service!' \
@@ -219,6 +221,7 @@ parts:
       - -etc/dconf/db
       - -etc/grub.d
       - -etc/systemd/system
+      - -libexec/installed-tests
       - -share/fwupd/*.py
       - -share/fish
       - -root

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -83,7 +83,6 @@ parts:
     meson-parameters: [--prefix=/,
                        -Defi_binary=false,
                        -Ddocs=disabled,
-                       -Dtests=false,
                        -Dbuild=all,
                        -Dintrospection=disabled,
                        -Dman=false,
@@ -115,6 +114,13 @@ parts:
               s,\(command.*\)\(fwupdtool\),\1fwupd.\2,;                         \
               s,\(command.*\)\(fwupdmgr\),\1fwupd.\2,"                          \
               ${CRAFT_PART_INSTALL}/share/bash-completion/completions/*
+      # make installed tests runnable
+      sed -i "s,\(fwupdmgr\),fwupd.\1,; \
+              s,\(fwupdtool\),fwupd.\1," \
+              ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/*.sh
+      sed -i "s,\(/share\),/snap/fwupd/current/\1," \
+              ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/fwupdtool.sh
+      sed -i 's,^MetadataURI=.*$,MetadataURI=file:///snap/fwupd/current/share/installed-tests/fwupd/fwupd-tests.xml,' "${CRAFT_PART_INSTALL}/etc/fwupd/remotes.d/fwupd-tests.conf"
       # fixes up dbus service for classic snap
       sed -i 's!SystemdService=\(.*\)!SystemdService=snap.fwupd.fwupd.service!' \
               ${CRAFT_PART_INSTALL}/share/dbus-1/system-services/org.freedesktop.fwupd.service
@@ -245,7 +251,6 @@ parts:
       - -lib/*/pkgconfig
       - -usr/share/lintian
       - -usr/share/pkgconfig
-      - -usr/share/installed-tests
       - -usr/share/polkit-1
       - -usr/share/vala
       - -usr/share/doc

--- a/data/installed-tests/fwupd.test.in
+++ b/data/installed-tests/fwupd.test.in
@@ -1,3 +1,3 @@
 [Test]
 Type=session
-Exec=sh -c "G_TEST_SRCDIR=@installedtestsdatadir@ G_TEST_BUILDDIR=@installedtestsdatadir@ @installedtestsbindir@/fwupd.sh"
+Exec=sh -c "G_TEST_SRCDIR=@installedtestsdatadir@ G_TEST_BUILDDIR=@installedtestsdatadir@ @installedtestsdir@/fwupd.sh"

--- a/data/installed-tests/fwupdtool.sh
+++ b/data/installed-tests/fwupdtool.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+exec 2>&1
+
+CAB=fakedevice124.cab
+INPUT="@installedtestsdir@/fakedevice124.bin \
+       @installedtestsdir@/fakedevice124.jcat \
+       @installedtestsdir@/fakedevice124.metainfo.xml"
+
+# ---
+echo "Building ${CAB}..."
+fwupdtool build-cabinet ${CAB} ${INPUT}
+rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+
+# ---
+echo "Installing ${CAB} cabinet..."
+fwupdtool install ${CAB}
+rc=$?; if [ $rc != 0 ]; then exit $rc; fi

--- a/data/installed-tests/fwupdtool.test.in
+++ b/data/installed-tests/fwupdtool.test.in
@@ -1,0 +1,3 @@
+[Test]
+Type=session
+Exec=sh -c "@installedtestsdir@/fwupdtool.sh"

--- a/data/installed-tests/meson.build
+++ b/data/installed-tests/meson.build
@@ -69,7 +69,7 @@ configure_file(
   output: 'fwupd.sh',
   configuration: con2,
   install: true,
-  install_dir: installed_test_bindir,
+  install_dir: installed_test_datadir,
 )
 
 custom_target('installed-cab123',

--- a/data/installed-tests/meson.build
+++ b/data/installed-tests/meson.build
@@ -23,6 +23,14 @@ configure_file(
 )
 
 configure_file(
+  input: 'fwupdtool.test.in',
+  output: 'fwupdtool.test',
+  configuration: con2,
+  install: true,
+  install_dir: installed_test_datadir,
+)
+
+configure_file(
   input: 'fwupd.test.in',
   output: 'fwupd.test',
   configuration: con2,
@@ -39,9 +47,20 @@ configure_file(
 )
 
 install_data([
+    'fakedevice124.bin',
+    'fakedevice124.jcat',
+    'fakedevice124.metainfo.xml',
     'fwupdmgr.sh',
     'fwupd-tests.xml',
   ],
+  install_dir: installed_test_datadir,
+)
+
+configure_file(
+  input: 'fwupdtool.sh',
+  output: 'fwupdtool.sh',
+  configuration: con2,
+  install: true,
   install_dir: installed_test_datadir,
 )
 


### PR DESCRIPTION
This also moves the snap CI to use `modify-config` to change plugins and adds a separate installed test for building and using a CAB file.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
