### PR TITLE
Add a concept of "Test Mode"

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo snap install --dangerous ${{ needs.build-snap.outputs.snap_name }}
         sudo snap connect fwupd:polkit :polkit
-        sudo fwupd.fwupdtool modify-config DisabledPlugins ""
+        sudo fwupd.fwupdtool enable-test-devices
     - name: Run fwupdmgr tests
       run: sudo /snap/fwupd/current/share/installed-tests/fwupd/fwupdmgr.sh
     - name: Run fwupd tests

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -73,8 +73,7 @@ mkdir -p dist
 cp $HOME/rpmbuild/RPMS/*/*.rpm dist
 
 if [ "$CI" = "true" ]; then
-	fwupdtool modify-config DisabledPlugins ""
-	fwupdtool modify-config AllowEmulation true
+	fwupdtool enable-test-devices
 
 	# set up enough PolicyKit and D-Bus to run the daemon
 	mkdir -p /run/dbus

--- a/contrib/debian/fwupd-tests.install
+++ b/contrib/debian/fwupd-tests.install
@@ -5,4 +5,4 @@
 usr/share/installed-tests/*
 usr/libexec/installed-tests/fwupd/*-self-test
 debian/lintian/fwupd-tests usr/share/lintian/overrides
-etc/fwupd/remotes.d/fwupd-tests.conf
+usr/share/fwupd/remotes.d/fwupd-tests.conf

--- a/contrib/debian/fwupd-tests.postinst
+++ b/contrib/debian/fwupd-tests.postinst
@@ -5,19 +5,9 @@ set -e
 
 #only enable on installation not upgrade
 if [ "$1" = configure ] && [ -z "$2" ]; then
-	if [ -f /etc/fwupd/fwupd.conf ]; then
-		if [ "$CI" = "true" ]; then
-			fwupdtool modify-config DisabledPlugins ""
-			fwupdtool modify-config AllowEmulation true
-		else
-			echo "To enable test suite, modify /etc/fwupd/fwupd.conf"
-		fi
-	fi
-	if [ -f /etc/fwupd/remotes.d/fwupd-tests.conf ]; then
-		if [ "$CI" = "true" ]; then
-			fwupdtool enable-remote fwupd-tests
-		else
-			echo "To enable test suite, enable fwupd-tests remote"
-		fi
+	if [ "$CI" = "true" ]; then
+		fwupdtool enable-test-devices
+	else
+		echo "To enable test suite, run `fwupdtool enable-test-devices`"
 	fi
 fi

--- a/contrib/debian/fwupd-tests.postrm
+++ b/contrib/debian/fwupd-tests.postrm
@@ -5,19 +5,9 @@ set -e
 
 # don't run on purge; the commands might be missing
 if [ "$1" = remove ]; then
-	if [ -f /etc/fwupd/fwupd.conf ]; then
-		if [ "$CI" = "true" ]; then
-			fwupdtool modify-config DisabledPlugins "test;test_ble"
-			fwupdtool modify-config AllowEmulation false
-		else
-			echo "To disable test suite, modify /etc/fwupd/fwupd.conf"
-		fi
-	fi
-	if [ -f /etc/fwupd/remotes.d/fwupd-tests.conf ]; then
-		if [ "$CI" = "true" ]; then
-			fwupdtool disable-remote fwupd-tests
-		else
-			echo "To enable test suite, enable fwupd-tests remote"
-		fi
+	if [ "$CI" = "true" ]; then
+		fwupdtool disable-test-devices
+	else
+		echo "To disable test suite, run `fwupdtool disable-test-devices`"
 	fi
 fi

--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -4,7 +4,7 @@ usr/share/bash-completion
 usr/share/fish/vendor_completions.d
 usr/share/fwupd/*.*
 usr/share/fwupd/metainfo/*
-usr/share/fwupd/remotes.d/*
+usr/share/fwupd/remotes.d/vendor/*
 usr/share/dbus-1/*
 usr/share/icons/*
 usr/share/polkit-1/*

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -72,9 +72,7 @@ override_dh_install:
 	dh_missing -a --fail-missing
 
 	#this is placed in fwupd-tests
-	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-*/libfu_plugin_test.so
-	rm -f debian/fwupd/usr/lib/*/fwupd-plugins-*/libfu_plugin_test_ble.so
-	rm -f debian/fwupd/etc/fwupd/remotes.d/fwupd-tests.conf
+	rm -f debian/fwupd/usr/share/fwupd/remotes.d/fwupd-tests.conf
 
 	# avoid shipping an empty directory
 	[ ! -d debian/fwupd/lib/systemd ] || find debian/fwupd/lib/systemd -type d -empty -delete

--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -2,8 +2,7 @@
 set -e
 # try loading the mtdram module to run our mtd tests
 modprobe mtdram 2>&1 || true
-fwupdtool modify-config DisabledPlugins ""
-fwupdtool modify-config AllowEmulation true
+fwupdtool enable-test-devices
 fwupdtool modify-config VerboseDomains "*"
 sed "s,ConditionVirtualization=.*,," 		\
 	/lib/systemd/system/fwupd.service >	\

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -428,8 +428,7 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %{_datadir}/fwupd/device-tests/*.json
 %endif
 %{_libexecdir}/installed-tests/fwupd/*
-%dir %{_sysconfdir}/fwupd/remotes.d
-%config(noreplace)%{_sysconfdir}/fwupd/remotes.d/fwupd-tests.conf
+%{_datadir}/fwupd/remotes.d/fwupd-tests.conf
 %endif
 
 %if 0%{?qubes_packages}

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -119,7 +119,7 @@ parts:
               ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/fwupdtool.sh
       sed -i "s,\(/libexec\),/snap/fwupd/current/\1," \
               ${CRAFT_PART_INSTALL}/share/installed-tests/fwupd/fwupd.sh
-      sed -i 's,^MetadataURI=.*$,MetadataURI=file:///snap/fwupd/current/share/installed-tests/fwupd/fwupd-tests.xml,' "${CRAFT_PART_INSTALL}/etc/fwupd/remotes.d/fwupd-tests.conf"
+      sed -i 's,^MetadataURI=.*$,MetadataURI=file:///snap/fwupd/current/share/installed-tests/fwupd/fwupd-tests.xml,' "${CRAFT_PART_INSTALL}/share/fwupd/remotes.d/fwupd-tests.conf"
       # fixes up dbus service for classic snap
       sed -i 's!SystemdService=\(.*\)!SystemdService=snap.fwupd.fwupd.service!' \
               ${CRAFT_PART_INSTALL}/share/dbus-1/system-services/org.freedesktop.fwupd.service

--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -107,6 +107,7 @@ modify_config_opts=(
 	'ReleaseDedupe'
 	'ReleasePriority'
 	'ShowDevicePrivate'
+	'TestDevices'
 	'TrustedReports'
 	'TrustedUids'
 	'UpdateMotd'
@@ -314,7 +315,7 @@ _fwupdmgr()
 			return 0
 		elif [[ "$args" = "3" ]]; then
 			case $prev in
-			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe)
+			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
 				COMPREPLY=( $(compgen -W "True False" -- "$cur") )
 				;;
 			ReleasePriority)

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -3,8 +3,10 @@ _fwupdtool_cmd_list=(
 	'build-cabinet'
 	'clear-history'
 	'disable-remote'
+	'disable-test-devices'
 	'efivar-list'
 	'enable-remote'
+	'enable-test-devices'
 	'esp-list'
 	'esp-mount'
 	'esp-unmount'
@@ -96,6 +98,7 @@ modify_config_opts=(
 	'ReleaseDedupe'
 	'ReleasePriority'
 	'ShowDevicePrivate'
+	'TestDevices'
 	'TrustedReports'
 	'TrustedUids'
 	'UpdateMotd'
@@ -242,7 +245,7 @@ _fwupdtool()
 			return 0
 		elif [[ "$args" = "3" ]]; then
 			case $prev in
-			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe)
+			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
 				COMPREPLY=( $(compgen -W "True False" -- "$cur") )
 				;;
 			ReleasePriority)

--- a/data/fwupd.conf
+++ b/data/fwupd.conf
@@ -1,5 +1,2 @@
-# use `man 5 fwupd.conf` for documentation
 [fwupd]
-DisabledPlugins=test;test_ble
-OnlyTrusted=true
-AllowEmulation=false
+# use `man 5 fwupd.conf` for documentation

--- a/data/installed-tests/README.md
+++ b/data/installed-tests/README.md
@@ -14,17 +14,9 @@ By default this test suite is disabled.
 
 To enable the test suite:
 
-1. Modify `/etc/fwupd/fwupd.conf` to remove the `test` plugin from `DisabledPlugins`
-
-   ```shell
-   # sed "s,^Enabled=false,Enabled=true," -i /etc/fwupd/remotes.d/fwupd-tests.conf
-   ```
-
-2. Enable the `fwupd-tests` remote for local CAB files.
-
-   ```shell
-   # fwupdmgr enable-remote fwupd-tests
-   ```
+```shell
+fwupdtool enable-test-devices
+```
 
 ## Using test suite
 

--- a/data/installed-tests/fwupd.sh
+++ b/data/installed-tests/fwupd.sh
@@ -13,6 +13,7 @@ run_test()
 run_device_tests()
 {
 	if [ -n "$CI_NETWORK" ] && [ -d @devicetestdir@ ]; then
+		fwupdmgr modify-config AllowEmulation true -y
 		# grab device tests from the CDN to avoid incrementing the download counter
 		export FWUPD_DEVICE_TESTS_BASE_URI=http://cdn.fwupd.org/downloads
 		for f in `grep --files-with-matches -r emulation-url @devicetestdir@`; do

--- a/data/installed-tests/fwupdmgr.sh
+++ b/data/installed-tests/fwupdmgr.sh
@@ -16,11 +16,6 @@ fwupdmgr get-remotes
 rc=$?; if [ $rc != 0 ]; then error $rc; fi
 
 # ---
-echo "Enabling fwupd-tests remote..."
-fwupdmgr enable-remote fwupd-tests
-rc=$?; if [ $rc != 0 ]; then error $rc; fi
-
-# ---
 echo "Update the device hash database..."
 fwupdmgr verify-update $device
 rc=$?; if [ $rc != 0 ]; then error $rc; fi

--- a/data/installed-tests/meson.build
+++ b/data/installed-tests/meson.build
@@ -105,5 +105,5 @@ configure_file(
   output: 'fwupd-tests.conf',
   configuration: con2,
   install: true,
-  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
+  install_dir: join_paths(datadir, 'fwupd', 'remotes.d'),
 )

--- a/data/installed-tests/remote.conf.in
+++ b/data/installed-tests/remote.conf.in
@@ -2,8 +2,9 @@
 # This is a local fwupd remote that is used only for installed tests
 # either from continuous integration or for fake devices from fwupd
 # frontends
+# It will only be loaded when the daemon configuration has `TestDevices=true`
 
-Enabled=false
+Enabled=true
 Title=fwupd test suite
 Keyring=none
 MetadataURI=file://@installedtestsdir@/fwupd-tests.xml

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -202,6 +202,11 @@ The `[fwupd]` section can contain the following parameters:
 
   At some point in the future fwupd will change the default to `metadata,firmware`.
 
+**TestDevices={{FU_DAEMON_CONFIG_DEFAULT_TEST_DEVICES}}**
+
+  Create virtual test devices and remote for validating daemon flows.
+  This is only intended for CI testing and development purposes.
+
 {% if plugin_uefi_capsule %}
 
 ## UEFI_CAPSULE PARAMETERS

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -454,6 +454,8 @@ fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return "measure-system-integrity";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_READY)
 		return "ready";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_TEST_ONLY)
+		return "test-only";
 	return NULL;
 }
 
@@ -508,6 +510,8 @@ fwupd_plugin_flag_from_string(const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;
 	if (g_strcmp0(plugin_flag, "ready") == 0)
 		return FWUPD_PLUGIN_FLAG_READY;
+	if (g_strcmp0(plugin_flag, "test-only") == 0)
+		return FWUPD_PLUGIN_FLAG_TEST_ONLY;
 	return FWUPD_PLUGIN_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -914,6 +914,14 @@ typedef enum {
 	 *
 	 * Since: 1.5.0
 	 */
+	FWUPD_PLUGIN_FLAG_TEST_ONLY = 1ull << 18,
+	/**
+	 * FWUPD_PLUGIN_FLAG_TEST_ONLY:
+	 *
+	 * The plugin is used for virtual devices that exercising daemon flows.
+	 *
+	 * Since: 2.0.0
+	 */
 	FWUPD_PLUGIN_FLAG_UNKNOWN = G_MAXUINT64
 } FwupdPluginFlags;
 

--- a/plugins/test/fu-test-ble-plugin.c
+++ b/plugins/test/fu-test-ble-plugin.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE(FuTestBlePlugin, fu_test_ble_plugin, FU_TYPE_PLUGIN)
 static void
 fu_test_ble_plugin_init(FuTestBlePlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_TEST_ONLY);
 }
 
 static void

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -361,7 +361,7 @@ fu_test_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GError **
 static void
 fu_test_plugin_init(FuTestPlugin *self)
 {
-	g_debug("init");
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_TEST_ONLY);
 	self->delay_request_ms = 10;
 }
 

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -30,7 +30,7 @@ struct _FuEngineConfig {
 G_DEFINE_TYPE(FuEngineConfig, fu_engine_config, FU_TYPE_CONFIG)
 
 /* defaults changed here will also be reflected in the fwupd.conf man page */
-#define FU_DAEMON_CONFIG_DEFAULT_DISABLED_PLUGINS      "test;test_ble"
+#define FU_DAEMON_CONFIG_DEFAULT_DISABLED_PLUGINS      ""
 #define FU_DAEMON_CONFIG_DEFAULT_URI_SCHEMES	       "file;https;http;ipfs"
 #define FU_DAEMON_CONFIG_DEFAULT_UPDATE_MOTD	       TRUE
 #define FU_DAEMON_CONFIG_DEFAULT_IGNORE_POWER	       FALSE
@@ -44,6 +44,7 @@ G_DEFINE_TYPE(FuEngineConfig, fu_engine_config, FU_TYPE_CONFIG)
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_DEDUPE	       TRUE
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_PRIORITY      "local"
 #define FU_DAEMON_CONFIG_DEFAULT_IDLE_TIMEOUT	       7200
+#define FU_DAEMON_CONFIG_DEFAULT_TEST_DEVICES	       FALSE
 
 static FwupdReport *
 fu_engine_config_report_from_spec(FuEngineConfig *self, const gchar *report_spec, GError **error)
@@ -336,6 +337,15 @@ fu_engine_config_get_show_device_private(FuEngineConfig *self)
 					"fwupd",
 					"ShowDevicePrivate",
 					FU_DAEMON_CONFIG_DEFAULT_SHOW_DEVICE_PRIVATE);
+}
+
+gboolean
+fu_engine_config_get_test_devices(FuEngineConfig *self)
+{
+	return fu_config_get_value_bool(FU_CONFIG(self),
+					"fwupd",
+					"TestDevices",
+					FU_DAEMON_CONFIG_DEFAULT_TEST_DEVICES);
 }
 
 gboolean

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -44,6 +44,8 @@ fu_engine_config_get_only_trusted(FuEngineConfig *self);
 gboolean
 fu_engine_config_get_show_device_private(FuEngineConfig *self);
 gboolean
+fu_engine_config_get_test_devices(FuEngineConfig *self);
+gboolean
 fu_engine_config_get_allow_emulation(FuEngineConfig *self);
 gboolean
 fu_engine_config_get_release_dedupe(FuEngineConfig *self);

--- a/src/fu-remote-list.h
+++ b/src/fu-remote-list.h
@@ -16,6 +16,7 @@ G_DECLARE_FINAL_TYPE(FuRemoteList, fu_remote_list, FU, REMOTE_LIST, GObject)
  * @FU_REMOTE_LIST_LOAD_FLAG_NONE:		No flags set
  * @FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS:	Ignore readonly filesystem errors
  * @FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE:		Do not save persistent xmlb silos
+ * @FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE:		Enable test mode remotes
  *
  * The flags to use when loading a remote_listuration file.
  **/
@@ -23,6 +24,7 @@ typedef enum {
 	FU_REMOTE_LIST_LOAD_FLAG_NONE = 0,
 	FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS = 1 << 0,
 	FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE = 1 << 1,
+	FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE = 1 << 2,
 	/*< private >*/
 	FU_REMOTE_LIST_LOAD_FLAG_LAST
 } FuRemoteListLoadFlags;

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2053,6 +2053,37 @@ fu_util_remote_enable(FuUtilPrivate *priv, gchar **values, GError **error)
 }
 
 static gboolean
+fu_util_toggle_test_devices(FuUtilPrivate *priv, gboolean enable, GError **error)
+{
+	if (!fu_util_start_engine(priv, FU_ENGINE_LOAD_FLAG_NONE, priv->progress, error))
+		return FALSE;
+
+	if (!fu_engine_modify_config(priv->engine, "TestDevices", enable ? "true" : "false", error))
+		return FALSE;
+
+	if (enable) {
+		/* TRANSLATORS: comment explaining result of command */
+		fu_console_print_literal(priv->console, _("Successfully enabled test devices"));
+	} else {
+		/* TRANSLATORS: comment explaining result of command */
+		fu_console_print_literal(priv->console, _("Successfully disabled test devices"));
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_util_disable_test_devices(FuUtilPrivate *priv, gchar **values, GError **error)
+{
+	return fu_util_toggle_test_devices(priv, FALSE, error);
+}
+
+static gboolean
+fu_util_enable_test_devices(FuUtilPrivate *priv, gchar **values, GError **error)
+{
+	return fu_util_toggle_test_devices(priv, TRUE, error);
+}
+
+static gboolean
 fu_util_check_activation_needed(FuUtilPrivate *priv, GError **error)
 {
 	gboolean has_pending = FALSE;
@@ -4513,6 +4544,18 @@ main(int argc, char *argv[])
 			      /* TRANSLATORS: command description */
 			      _("Disables a given remote"),
 			      fu_util_remote_disable);
+	fu_util_cmd_array_add(cmd_array,
+			      "enable-test-devices",
+			      NULL,
+			      /* TRANSLATORS: command description */
+			      _("Enables virtual testing devices"),
+			      fu_util_enable_test_devices);
+	fu_util_cmd_array_add(cmd_array,
+			      "disable-test-devices",
+			      NULL,
+			      /* TRANSLATORS: command description */
+			      _("Disables virtual testing devices"),
+			      fu_util_disable_test_devices);
 
 	/* do stuff on ctrl+c */
 	priv->cancellable = g_cancellable_new();

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1674,6 +1674,10 @@ fu_util_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		/* TRANSLATORS: The kernel does not support this plugin */
 		return _("Running kernel is too old");
 	}
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_TEST_ONLY) {
+		/* TRANSLATORS: The plugin is only for testing */
+		return _("Plugin is only for testing");
+	}
 
 	/* fall back for unknown types */
 	return fwupd_plugin_flag_to_string(plugin_flag);
@@ -1697,6 +1701,7 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 					       FU_CONSOLE_COLOR_GREEN);
 	case FWUPD_PLUGIN_FLAG_DISABLED:
 	case FWUPD_PLUGIN_FLAG_NO_HARDWARE:
+	case FWUPD_PLUGIN_FLAG_TEST_ONLY:
 		return fu_console_color_format(fu_util_plugin_flag_to_string(plugin_flag),
 					       FU_CONSOLE_COLOR_BLACK);
 	case FWUPD_PLUGIN_FLAG_LEGACY_BIOS:

--- a/src/tests/fwupd.conf
+++ b/src/tests/fwupd.conf
@@ -1,4 +1,4 @@
 [fwupd]
-DisabledPlugins=
 TrustedReports=VendorId=123&DistroId=fedora&RemoteId=lvfs&DistroVariant=workstation;VendorId=$OEM&DistroId=chromeos
 Manufacturer=ACME
+TestDevices=true


### PR DESCRIPTION
Rather than plugins being disabled via the `DisabledPlugins` key
treat the `test` and `test_ble` plugins as special plugins that
are only enabled in test mode.

When the `TestMode` key is set in `/etc/fwupd/fwupd.conf` then these
plugins will be allowed to load.

Furthermore there is a remote loaded on all systems called "fwupd-tests"
which is only used for the test suite.

When `TestMode` key is set then it will be allowed to be used.

Also introduce and use helper args for fwupdtool to turn on/off test
mode.  These helper args are:

`fwupdtool enable-test-mode` and `fwupdtool disable-test-mode`.

When called, 3 things will happen:
    * Allow using the fwupd-tests remote
    * Allow the test plugins to load
    * Allow emulation by default (overrides `AllowEmulation` key)

With all of these changes in place fwupd.conf can be populated
ENTIRELY EMPTY!


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
