### PR TITLE
Make the default p2p policy configurable by a meson option

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -186,7 +186,7 @@ The `[fwupd]` section can contain the following parameters:
 
 * `DistroId=$ID,DistroVersion=$VERSION_ID`
 
-**P2pPolicy={{FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY}}**
+**P2pPolicy={{FU_DEFAULT_P2P_POLICY}}**
 
   This tells the daemon what peer-to-peer policy to use. For instance, using Passim, an optional
   local caching service. Using peer-to-peer data might reduce the amount of bandwidth used on your

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -29,6 +29,7 @@ if build_standalone
         '--defines', join_paths(meson.project_source_root(), 'plugins', 'thunderbolt', 'fu-thunderbolt-plugin.c'),
         '--defines', join_paths(meson.project_source_root(), 'plugins', 'uefi-capsule', 'fu-uefi-capsule-plugin.c'),
         '--defines', join_paths(meson.project_source_root(), 'src', 'fu-engine-config.c'),
+        '--defines', join_paths(meson.project_build_root(), 'config.h'),
       ],
       install: true,
       install_dir: join_paths(mandir, 'man5'),

--- a/meson.build
+++ b/meson.build
@@ -535,6 +535,8 @@ motd_dir = 'motd.d'
 conf.set_quoted('MOTD_FILE', motd_file)
 conf.set_quoted('MOTD_DIR', motd_dir)
 
+conf.set_quoted('FU_DEFAULT_P2P_POLICY', get_option('p2p_policy'))
+
 configure_file(
   output: 'config.h',
   configuration: conf

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -122,6 +122,17 @@ option('passim',
   type: 'feature',
   description: 'Passim support',
 )
+option('p2p_policy',
+  type: 'combo',
+  choices: [
+    'none',
+    'metadata',
+    'firmware',
+    'metadata,firmware',
+  ],
+  value: 'metadata',
+  description: 'Default P2P sharing policy',
+)
 option('lzma',
   type: 'feature',
   description: 'LZMA support',

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -43,7 +43,6 @@ G_DEFINE_TYPE(FuEngineConfig, fu_engine_config, FU_TYPE_CONFIG)
 #define FU_DAEMON_CONFIG_DEFAULT_TRUSTED_REPORTS       "VendorId=$OEM"
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_DEDUPE	       TRUE
 #define FU_DAEMON_CONFIG_DEFAULT_RELEASE_PRIORITY      "local"
-#define FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY	       "metadata"
 #define FU_DAEMON_CONFIG_DEFAULT_IDLE_TIMEOUT	       7200
 
 static FwupdReport *
@@ -371,10 +370,8 @@ FuP2pPolicy
 fu_engine_config_get_p2p_policy(FuEngineConfig *self)
 {
 	FuP2pPolicy p2p_policy = FU_P2P_POLICY_NOTHING;
-	g_autofree gchar *tmp = fu_config_get_value(FU_CONFIG(self),
-						    "fwupd",
-						    "P2pPolicy",
-						    FU_DAEMON_CONFIG_DEFAULT_P2P_POLICY);
+	g_autofree gchar *tmp =
+	    fu_config_get_value(FU_CONFIG(self), "fwupd", "P2pPolicy", FU_DEFAULT_P2P_POLICY);
 	g_auto(GStrv) split = g_strsplit(tmp, ",", -1);
 	for (guint i = 0; split[i] != NULL; i++)
 		p2p_policy |= fu_p2p_policy_from_string(split[i]);


### PR DESCRIPTION
Distributions and packagers that want to offer the feature but turn it off by default can do so.

This will also then be a one line change to change the upstream default if we flip to *metadata,firmware* in the future. 
Link: https://github.com/fwupd/fwupd/issues/6721

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
