### PR TITLE
Use the history-provided verfmt in more cases

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6172,8 +6172,7 @@ fu_engine_device_inherit_history(FuEngine *self, FuDevice *device)
 	/* in an offline environment we may have used the .cab file to find the version-format
 	 * to use for the device -- so when we reboot use the database as the archive data is no
 	 * longer available */
-	if (fu_device_get_version_format(device) == FWUPD_VERSION_FORMAT_UNKNOWN &&
-	    fu_device_get_version_format(device_history) != FWUPD_VERSION_FORMAT_UNKNOWN) {
+	if (fu_device_get_version_format(device_history) != FWUPD_VERSION_FORMAT_UNKNOWN) {
 		g_debug(
 		    "absorbing version format %s into %s from history database",
 		    fwupd_version_format_to_string(fu_device_get_version_format(device_history)),

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2555,6 +2555,7 @@ fu_engine_history_verfmt_func(gconstpointer user_data)
 
 	/* absorb version format from the database */
 	fu_device_set_version_raw(device, 65563);
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_NUMBER);
 	fu_device_set_id(device, "test_device");
 	fu_device_add_vendor_id(device, "USB:FFFF");
 	fu_device_add_protocol(device, "com.acme");


### PR DESCRIPTION
The UEFI capsule plugin actually sets the default to be `NUMBER` rather than `UNKNOWN`. We check for the 'same' value in fu_device_set_version_format() and so there's no penalty in always setting it to the current value.

Even if a newly-updated fwupd package changed the verfmt for the device, we'd still want to use the 'historical' verfmt when working out if the update was a success.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
