### PR TITLE
Store the version format in the history database

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2860,6 +2860,8 @@ fu_device_set_id(FuDevice *self, const gchar *id)
 void
 fu_device_set_version_format(FuDevice *self, FwupdVersionFormat fmt)
 {
+	FuDeviceClass *klass = FU_DEVICE_GET_CLASS(self);
+
 	/* same */
 	if (fu_device_get_version_format(self) == fmt)
 		return;
@@ -2870,6 +2872,14 @@ fu_device_set_version_format(FuDevice *self, FwupdVersionFormat fmt)
 			fwupd_version_format_to_string(fmt));
 	}
 	fwupd_device_set_version_format(FWUPD_DEVICE(self), fmt);
+
+	/* convert this, now we know */
+	if (klass->convert_version != NULL && fu_device_get_version(self) != NULL &&
+	    fu_device_get_version_raw(self) != 0) {
+		g_autofree gchar *version =
+		    klass->convert_version(self, fu_device_get_version_raw(self));
+		fu_device_set_version(self, version);
+	}
 }
 
 /**

--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -128,7 +128,7 @@ fu_dpaux_device_setup(FuDevice *device, GError **error)
 	priv->dpcd_ieee_oui = fu_struct_dpaux_dpcd_get_ieee_oui(st);
 	priv->dpcd_hw_rev = fu_struct_dpaux_dpcd_get_hw_rev(st);
 	priv->dpcd_dev_id = fu_struct_dpaux_dpcd_get_dev_id(st);
-	fu_device_set_version_u24(device, fu_struct_dpaux_dpcd_get_fw_ver(st));
+	fu_device_set_version_raw(device, fu_struct_dpaux_dpcd_get_fw_ver(st));
 	return TRUE;
 }
 
@@ -377,6 +377,12 @@ fu_dpaux_device_incorporate(FuDevice *device, FuDevice *donor)
 					fu_dpaux_device_get_dpcd_dev_id(FU_DPAUX_DEVICE(donor)));
 }
 
+static gchar *
+fu_dpaux_device_convert_version(FuDevice *device, guint64 version_raw)
+{
+	return fu_version_from_uint24(version_raw, fu_device_get_version_format(device));
+}
+
 static void
 fu_dpaux_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
@@ -440,6 +446,7 @@ fu_dpaux_device_class_init(FuDpauxDeviceClass *klass)
 	klass_device->invalidate = fu_dpaux_device_invalidate;
 	klass_device->to_string = fu_dpaux_device_to_string;
 	klass_device->incorporate = fu_dpaux_device_incorporate;
+	klass_device->convert_version = fu_dpaux_device_convert_version;
 
 	/**
 	 * FuDpauxDevice:dpcd-ieee-oui:

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -502,7 +502,7 @@ fu_uefi_device_probe(FuDevice *device, GError **error)
 	fu_device_add_guid(device, priv->fw_class);
 
 	/* set versions */
-	fu_device_set_version_u32(device, priv->fw_version);
+	fu_device_set_version_raw(device, priv->fw_version);
 	if (priv->fw_version_lowest != 0) {
 		g_autofree gchar *version_lowest =
 		    fu_version_from_uint32(priv->fw_version_lowest,
@@ -736,6 +736,12 @@ fu_uefi_device_finalize(GObject *object)
 	G_OBJECT_CLASS(fu_uefi_device_parent_class)->finalize(object);
 }
 
+static gchar *
+fu_uefi_device_convert_version(FuDevice *device, guint64 version_raw)
+{
+	return fu_version_from_uint32(version_raw, fu_device_get_version_format(device));
+}
+
 static void
 fu_uefi_device_class_init(FuUefiDeviceClass *klass)
 {
@@ -754,6 +760,7 @@ fu_uefi_device_class_init(FuUefiDeviceClass *klass)
 	klass_device->report_metadata_post = fu_uefi_device_report_metadata_post;
 	klass_device->get_results = fu_uefi_device_get_results;
 	klass_device->set_progress = fu_uefi_device_set_progress;
+	klass_device->convert_version = fu_uefi_device_convert_version;
 
 	/**
 	 * FuUefiDevice:fw-class:

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6128,6 +6128,17 @@ fu_engine_device_inherit_history(FuEngine *self, FuDevice *device)
 	if (device_history == NULL)
 		return;
 
+	/* in an offline environment we may have used the .cab file to find the version-format
+	 * to use for the device -- so when we reboot use the database as the archive data is no
+	 * longer available */
+	if (fu_device_get_version_format(device_history) != FWUPD_VERSION_FORMAT_UNKNOWN) {
+		g_debug(
+		    "absorbing version format %s into %s from history database",
+		    fwupd_version_format_to_string(fu_device_get_version_format(device_history)),
+		    fu_device_get_id(device));
+		fu_device_set_version_format(device, fu_device_get_version_format(device_history));
+	}
+
 	/* the device is still running the old firmware version and so if it
 	 * required activation before, it still requires it now -- note:
 	 * we can't just check for version_new=version to allow for re-installs */


### PR DESCRIPTION
If we're 100% offline, we get the version format from the cab archive -- but when we reboot and check the 'new version' the verfmt is not available.

To do this, re-set the version string when the version format changes, and use FuDeviceClass->convert_version() in more places.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
