### PR TITLE
debian/tests/ci: Put all stderr into stdout. fwupdtool is pretty verbose with messages that happen to go to stderr but aren't errors.

### DIFF
--- a/contrib/debian/tests/ci
+++ b/contrib/debian/tests/ci
@@ -1,11 +1,12 @@
-#!/bin/sh
-set -e
+#!/bin/sh -e
+exec 2>&1
 # try loading the mtdram module to run our mtd tests
-modprobe mtdram 2>&1 || true
+modprobe mtdram || true
 fwupdtool enable-test-devices
 fwupdtool modify-config VerboseDomains "*"
 sed "s,ConditionVirtualization=.*,," 		\
 	/lib/systemd/system/fwupd.service >	\
 	/etc/systemd/system/fwupd.service
 systemctl daemon-reload
+# run the tests
 gnome-desktop-testing-runner fwupd


### PR DESCRIPTION
…


Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
