### PR TITLE
trivial: Do not parse the IFD MTD partition at startup

### DIFF
--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -15,4 +15,4 @@ Flags = no-probe
 # Intel SPI Controller
 [MTD\NAME_BIOS]
 Name = Internal SPI Controller
-FirmwareGType = FuIfdFirmware
+#FirmwareGType = FuIfdFirmware


### PR DESCRIPTION
It's too slow -- we need a lzma streaming parser to make this efficient.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
