### PR TITLE
Split up the Inhibit idle types

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -171,7 +171,7 @@ fu_engine_update_motd_timeout_cb(gpointer user_data)
 	g_autoptr(GError) error_local = NULL;
 
 	/* busy */
-	if (fu_idle_has_inhibit(self->idle, "update"))
+	if (fu_idle_has_inhibit(self->idle, FU_IDLE_INHIBIT_SIGNALS))
 		return G_SOURCE_CONTINUE;
 
 	/* update now */
@@ -257,7 +257,7 @@ fu_engine_set_status(FuEngine *self, FwupdStatus status)
 static void
 fu_engine_generic_notify_cb(FuDevice *device, GParamSpec *pspec, FuEngine *self)
 {
-	if (fu_idle_get_status(self->idle) == FU_IDLE_STATUS_BUSY &&
+	if (fu_idle_has_inhibit(self->idle, FU_IDLE_INHIBIT_SIGNALS) &&
 	    !g_hash_table_contains(self->device_changed_allowlist, fu_device_get_id(device))) {
 		g_debug("suppressing notification from %s as transaction is in progress",
 			fu_device_get_id(device));
@@ -1871,7 +1871,9 @@ fu_engine_install_releases(FuEngine *self,
 	g_autoptr(GPtrArray) devices_new = NULL;
 
 	/* do not allow auto-shutdown during this time */
-	locker = fu_idle_locker_new(self->idle, "update");
+	locker = fu_idle_locker_new(self->idle,
+				    FU_IDLE_INHIBIT_TIMEOUT | FU_IDLE_INHIBIT_SIGNALS,
+				    "update");
 	g_assert(locker != NULL);
 
 	/* use an allow-list for device-changed signals -- only allow any of the composite update
@@ -6370,7 +6372,7 @@ fu_engine_plugin_rules_changed_cb(FuPlugin *plugin, gpointer user_data)
 		return;
 	for (guint j = 0; j < rules->len; j++) {
 		const gchar *tmp = g_ptr_array_index(rules, j);
-		fu_idle_inhibit(self->idle, tmp);
+		fu_idle_inhibit(self->idle, FU_IDLE_INHIBIT_TIMEOUT, tmp);
 	}
 }
 
@@ -8588,7 +8590,7 @@ fu_engine_context_power_changed(FuEngine *self)
 static void
 fu_engine_context_power_changed_cb(FuContext *ctx, GParamSpec *pspec, FuEngine *self)
 {
-	if (fu_idle_get_status(self->idle) == FU_IDLE_STATUS_BUSY) {
+	if (fu_idle_has_inhibit(self->idle, FU_IDLE_INHIBIT_SIGNALS)) {
 		g_debug("suppressing ::power-changed as transaction is in progress");
 		return;
 	}
@@ -8596,10 +8598,15 @@ fu_engine_context_power_changed_cb(FuContext *ctx, GParamSpec *pspec, FuEngine *
 }
 
 static void
-fu_engine_idle_status_notify_cb(FuIdle *idle, GParamSpec *pspec, FuEngine *self)
+fu_engine_idle_timeout_cb(FuIdle *idle, FuEngine *self)
 {
-	FuIdleStatus status = fu_idle_get_status(idle);
-	if (status == FU_IDLE_STATUS_IDLE &&
+	fu_engine_set_status(self, FWUPD_STATUS_SHUTDOWN);
+}
+
+static void
+fu_engine_idle_inhibit_changed_cb(FuIdle *idle, GParamSpec *pspec, FuEngine *self)
+{
+	if (!fu_idle_has_inhibit(idle, FU_IDLE_INHIBIT_SIGNALS) &&
 	    g_hash_table_size(self->device_changed_allowlist) > 0) {
 		g_debug("clearing device-changed allowlist as transaction done");
 		g_hash_table_remove_all(self->device_changed_allowlist);
@@ -8608,8 +8615,6 @@ fu_engine_idle_status_notify_cb(FuIdle *idle, GParamSpec *pspec, FuEngine *self)
 		 * inhibits are being set up correctly */
 		fu_engine_context_power_changed(self);
 	}
-	if (status == FU_IDLE_STATUS_TIMEOUT)
-		fu_engine_set_status(self, FWUPD_STATUS_SHUTDOWN);
 }
 
 static void
@@ -8669,8 +8674,12 @@ fu_engine_constructed(GObject *obj)
 			 self);
 
 	g_signal_connect(FU_IDLE(self->idle),
-			 "notify::status",
-			 G_CALLBACK(fu_engine_idle_status_notify_cb),
+			 "inhibit-changed",
+			 G_CALLBACK(fu_engine_idle_inhibit_changed_cb),
+			 self);
+	g_signal_connect(FU_IDLE(self->idle),
+			 "timeout",
+			 G_CALLBACK(fu_engine_idle_timeout_cb),
 			 self);
 
 	/* backends */

--- a/src/fu-engine.rs
+++ b/src/fu-engine.rs
@@ -35,3 +35,10 @@ enum EngineRequestFlag {
     NoRequirements = 1 << 0,
     AnyRelease = 1 << 1,
 }
+
+#[derive(ToBitString)]
+enum IdleInhibit {
+    None = 0,
+    Timeout = 1 << 0,
+    Signals = 1 << 1,
+}

--- a/src/fu-idle.c
+++ b/src/fu-idle.c
@@ -19,78 +19,26 @@ struct _FuIdle {
 	GRWLock items_mutex;
 	guint idle_id;
 	guint timeout;
-	FuIdleStatus status;
+	FuIdleInhibit inhibit_old;
 };
 
-enum { PROP_0, PROP_STATUS, PROP_LAST };
+enum { SIGNAL_INHIBIT_CHANGED, SIGNAL_TIMEOUT, SIGNAL_LAST };
 
-static const gchar *
-fu_idle_status_to_string(FuIdleStatus status)
-{
-	if (status == FU_IDLE_STATUS_UNKNOWN)
-		return "unknown";
-	if (status == FU_IDLE_STATUS_IDLE)
-		return "idle";
-	if (status == FU_IDLE_STATUS_BUSY)
-		return "busy";
-	if (status == FU_IDLE_STATUS_TIMEOUT)
-		return "timeout";
-	return NULL;
-}
-
-static void
-fu_idle_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
-{
-	FuIdle *self = FU_IDLE(object);
-	switch (prop_id) {
-	case PROP_STATUS:
-		g_value_set_uint(value, self->status);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-		break;
-	}
-}
-
-static void
-fu_idle_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
-{
-	switch (prop_id) {
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-		break;
-	}
-}
+static guint signals[SIGNAL_LAST] = {0};
 
 typedef struct {
+	FuIdleInhibit inhibit;
 	gchar *reason;
 	guint32 token;
 } FuIdleItem;
 
 G_DEFINE_TYPE(FuIdle, fu_idle, G_TYPE_OBJECT)
 
-FuIdleStatus
-fu_idle_get_status(FuIdle *self)
-{
-	g_return_val_if_fail(FU_IS_IDLE(self), FU_IDLE_STATUS_UNKNOWN);
-	return self->status;
-}
-
-static void
-fu_idle_set_status(FuIdle *self, FuIdleStatus status)
-{
-	if (self->status == status)
-		return;
-	self->status = status;
-	g_debug("status now %s", fu_idle_status_to_string(status));
-	g_object_notify(G_OBJECT(self), "status");
-}
-
 static gboolean
 fu_idle_check_cb(gpointer user_data)
 {
 	FuIdle *self = FU_IDLE(user_data);
-	fu_idle_set_status(self, FU_IDLE_STATUS_TIMEOUT);
+	g_signal_emit(self, signals[SIGNAL_TIMEOUT], 0);
 	return G_SOURCE_CONTINUE;
 }
 
@@ -113,17 +61,31 @@ fu_idle_stop(FuIdle *self)
 	self->idle_id = 0;
 }
 
+static void
+fu_idle_emit_inhibit_changed(FuIdle *self)
+{
+	FuIdleInhibit inhibit_global = FU_IDLE_INHIBIT_NONE;
+
+	fu_idle_reset(self);
+	for (guint i = 0; i < self->items->len; i++) {
+		FuIdleItem *item = g_ptr_array_index(self->items, i);
+		inhibit_global |= item->inhibit;
+	}
+	if (self->inhibit_old != inhibit_global) {
+		g_autofree gchar *inhibit_str = fu_idle_inhibit_to_string(inhibit_global);
+		g_debug("now inhibited: %s", inhibit_str);
+		g_signal_emit(self, signals[SIGNAL_INHIBIT_CHANGED], 0, inhibit_global);
+		self->inhibit_old = inhibit_global;
+	}
+}
+
 void
 fu_idle_reset(FuIdle *self)
 {
 	g_return_if_fail(FU_IS_IDLE(self));
 	fu_idle_stop(self);
-	if (self->items->len == 0) {
+	if (!fu_idle_has_inhibit(self, FU_IDLE_INHIBIT_TIMEOUT))
 		fu_idle_start(self);
-		fu_idle_set_status(self, FU_IDLE_STATUS_IDLE);
-	} else {
-		fu_idle_set_status(self, FU_IDLE_STATUS_BUSY);
-	}
 }
 
 void
@@ -138,45 +100,52 @@ fu_idle_uninhibit(FuIdle *self, guint32 token)
 	for (guint i = 0; i < self->items->len; i++) {
 		FuIdleItem *item = g_ptr_array_index(self->items, i);
 		if (item->token == token) {
-			g_debug("uninhibiting: %s", item->reason);
+			g_autofree gchar *inhibit_str = fu_idle_inhibit_to_string(item->inhibit);
+			g_debug("uninhibiting: %s by %s", inhibit_str, item->reason);
 			g_ptr_array_remove_index(self->items, i);
 			break;
 		}
 	}
-	fu_idle_reset(self);
+
+	g_clear_pointer(&locker, g_rw_lock_writer_locker_free);
+	fu_idle_emit_inhibit_changed(self);
 }
 
 guint32
-fu_idle_inhibit(FuIdle *self, const gchar *reason)
+fu_idle_inhibit(FuIdle *self, FuIdleInhibit inhibit, const gchar *reason)
 {
 	FuIdleItem *item;
+	g_autofree gchar *inhibit_str = fu_idle_inhibit_to_string(inhibit);
 	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_writer_locker_new(&self->items_mutex);
 
 	g_return_val_if_fail(FU_IS_IDLE(self), 0);
-	g_return_val_if_fail(reason != NULL, 0);
+	g_return_val_if_fail(inhibit != FU_IDLE_INHIBIT_NONE, 0);
 	g_return_val_if_fail(locker != NULL, 0);
 
-	g_debug("inhibiting: %s", reason);
+	g_debug("inhibiting: %s by %s", inhibit_str, reason);
 	item = g_new0(FuIdleItem, 1);
+	item->inhibit = inhibit;
 	item->reason = g_strdup(reason);
 	item->token = g_random_int_range(1, G_MAXINT);
 	g_ptr_array_add(self->items, item);
-	fu_idle_reset(self);
+
+	g_clear_pointer(&locker, g_rw_lock_writer_locker_free);
+	fu_idle_emit_inhibit_changed(self);
 	return item->token;
 }
 
 gboolean
-fu_idle_has_inhibit(FuIdle *self, const gchar *reason)
+fu_idle_has_inhibit(FuIdle *self, FuIdleInhibit inhibit)
 {
 	g_autoptr(GRWLockWriterLocker) locker = g_rw_lock_reader_locker_new(&self->items_mutex);
 
 	g_return_val_if_fail(FU_IS_IDLE(self), FALSE);
-	g_return_val_if_fail(reason != NULL, FALSE);
+	g_return_val_if_fail(inhibit != FU_IDLE_INHIBIT_NONE, FALSE);
 	g_return_val_if_fail(locker != NULL, FALSE);
 
 	for (guint i = 0; i < self->items->len; i++) {
 		FuIdleItem *item = g_ptr_array_index(self->items, i);
-		if (g_strcmp0(item->reason, reason) == 0)
+		if (item->inhibit & inhibit)
 			return TRUE;
 	}
 	return FALSE;
@@ -199,11 +168,11 @@ fu_idle_item_free(FuIdleItem *item)
 }
 
 FuIdleLocker *
-fu_idle_locker_new(FuIdle *self, const gchar *reason)
+fu_idle_locker_new(FuIdle *self, FuIdleInhibit inhibit, const gchar *reason)
 {
 	FuIdleLocker *locker = g_new0(FuIdleLocker, 1);
 	locker->idle = g_object_ref(self);
-	locker->token = fu_idle_inhibit(self, reason);
+	locker->token = fu_idle_inhibit(self, inhibit, reason);
 	return locker;
 }
 
@@ -221,31 +190,33 @@ static void
 fu_idle_class_init(FuIdleClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GParamSpec *pspec;
 
 	object_class->finalize = fu_idle_finalize;
-	object_class->get_property = fu_idle_get_property;
-	object_class->set_property = fu_idle_set_property;
 
-	/**
-	 * FuIdle:status:
-	 *
-	 * The status of the idle monitor.
-	 */
-	pspec = g_param_spec_uint("status",
-				  NULL,
-				  NULL,
-				  FU_IDLE_STATUS_UNKNOWN,
-				  FU_IDLE_STATUS_LAST,
-				  FU_IDLE_STATUS_UNKNOWN,
-				  G_PARAM_READABLE | G_PARAM_STATIC_NAME);
-	g_object_class_install_property(object_class, PROP_STATUS, pspec);
+	signals[SIGNAL_INHIBIT_CHANGED] = g_signal_new("inhibit-changed",
+						       G_TYPE_FROM_CLASS(object_class),
+						       G_SIGNAL_RUN_LAST,
+						       0,
+						       NULL,
+						       NULL,
+						       g_cclosure_marshal_VOID__UINT,
+						       G_TYPE_NONE,
+						       1,
+						       G_TYPE_UINT);
+	signals[SIGNAL_TIMEOUT] = g_signal_new("timeout",
+					       G_TYPE_FROM_CLASS(object_class),
+					       G_SIGNAL_RUN_LAST,
+					       0,
+					       NULL,
+					       NULL,
+					       g_cclosure_marshal_VOID__VOID,
+					       G_TYPE_NONE,
+					       0);
 }
 
 static void
 fu_idle_init(FuIdle *self)
 {
-	self->status = FU_IDLE_STATUS_IDLE;
 	self->items = g_ptr_array_new_with_free_func((GDestroyNotify)fu_idle_item_free);
 	g_rw_lock_init(&self->items_mutex);
 }

--- a/src/fu-idle.h
+++ b/src/fu-idle.h
@@ -8,31 +8,23 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-engine-struct.h"
+
 #define FU_TYPE_IDLE (fu_idle_get_type())
 G_DECLARE_FINAL_TYPE(FuIdle, fu_idle, FU, IDLE, GObject)
-
-typedef enum {
-	FU_IDLE_STATUS_UNKNOWN,
-	FU_IDLE_STATUS_IDLE,
-	FU_IDLE_STATUS_BUSY,
-	FU_IDLE_STATUS_TIMEOUT,
-	FU_IDLE_STATUS_LAST,
-} FuIdleStatus;
 
 FuIdle *
 fu_idle_new(void);
 guint32
-fu_idle_inhibit(FuIdle *self, const gchar *reason);
+fu_idle_inhibit(FuIdle *self, FuIdleInhibit inhibit, const gchar *reason);
 void
 fu_idle_uninhibit(FuIdle *self, guint32 token);
 gboolean
-fu_idle_has_inhibit(FuIdle *self, const gchar *reason);
+fu_idle_has_inhibit(FuIdle *self, FuIdleInhibit inhibit);
 void
 fu_idle_set_timeout(FuIdle *self, guint timeout);
 void
 fu_idle_reset(FuIdle *self);
-FuIdleStatus
-fu_idle_get_status(FuIdle *self);
 
 /**
  * FuIdleLocker:
@@ -47,7 +39,7 @@ typedef struct {
 } FuIdleLocker;
 
 FuIdleLocker *
-fu_idle_locker_new(FuIdle *self, const gchar *reason);
+fu_idle_locker_new(FuIdle *self, FuIdleInhibit inhibit, const gchar *reason);
 void
 fu_idle_locker_free(FuIdleLocker *locker);
 


### PR DESCRIPTION
Devices that take a long time inhibit the daemon from auto-quitting on idle.

We were using that same idle for supressing the power notifications during the update -- which doesn't make sense. Split the idle inhibitor types into a bitfield to restore sanity.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
