### PR TITLE
Add a timer inhibit if the daemon took a long time to startup

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -61,6 +61,11 @@ The `[fwupd]` section can contain the following parameters:
 
   **NOTE:** some plugins might inhibit the auto-shutdown, for instance thunderbolt.
 
+**IdleInhibitStartupThreshold={{IdleInhibitStartupThreshold}}**
+
+  If the daemon takes more than this time to startup (in milliseconds) then inhibit the idle
+  shutdown timer. A value of **0** specifies "never".
+
 **VerboseDomains={{VerboseDomains}}**
 
   Comma separated list of domains to log in verbose mode.

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -217,6 +217,7 @@ fu_config_migrate_keyfile(FuConfig *self)
 			  {"fwupd", "EnumerateAllDevices", NULL},
 			  {"fwupd", "EspLocation", NULL},
 			  {"fwupd", "HostBkc", NULL},
+			  {"fwupd", "IdleTimeout", "7200"},
 			  {"fwupd", "IdleTimeout", NULL},
 			  {"fwupd", "IgnorePower", NULL},
 			  {"fwupd", "ShowDevicePrivate", NULL},

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -2297,8 +2297,10 @@ gboolean
 fu_daemon_setup(FuDaemon *self, const gchar *socket_address, GError **error)
 {
 	const gchar *machine_kind = g_getenv("FWUPD_MACHINE_KIND");
+	guint timer_max_ms;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GTimer) timer = g_timer_new();
 
 	g_return_val_if_fail(FU_IS_DAEMON(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -2408,6 +2410,19 @@ fu_daemon_setup(FuDaemon *self, const gchar *socket_address, GError **error)
 						NULL);
 	}
 	fu_progress_step_done(progress);
+
+	/* how did we do */
+	timer_max_ms = fu_config_get_value_u64(FU_CONFIG(fu_engine_get_config(self->engine)),
+					       "fwupd",
+					       "IdleInhibitStartupThreshold");
+	if (timer_max_ms > 0) {
+		guint timer_ms = g_timer_elapsed(timer, NULL) * 1000.f;
+		if (timer_ms > timer_max_ms) {
+			g_autofree gchar *reason =
+			    g_strdup_printf("daemon-startup-%ums-max-%ums", timer_ms, timer_max_ms);
+			fu_engine_idle_inhibit(self->engine, FU_IDLE_INHIBIT_TIMEOUT, reason);
+		}
+	}
 
 	/* a good place to do the traceback */
 	if (fu_progress_get_profile(progress)) {

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -385,7 +385,8 @@ fu_engine_config_init(FuEngineConfig *self)
 	fu_engine_set_config_default(self, "EnumerateAllDevices", "false");
 	fu_engine_set_config_default(self, "EspLocation", NULL);
 	fu_engine_set_config_default(self, "HostBkc", NULL);
-	fu_engine_set_config_default(self, "IdleTimeout", "7200");
+	fu_engine_set_config_default(self, "IdleTimeout", "300");	     /* s */
+	fu_engine_set_config_default(self, "IdleInhibitStartupThreshold", "500"); /* ms */
 	fu_engine_set_config_default(self, "IgnorePower", "false");
 	fu_engine_set_config_default(self, "OnlyTrusted", "true");
 	fu_engine_set_config_default(self, "P2pPolicy", FU_DEFAULT_P2P_POLICY);


### PR DESCRIPTION
This also allows us to decrease the value of the idle timer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
