### PR TITLE
trivial: Use xxxx_class for device and plugin subclasses

### DIFF
--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -194,10 +194,10 @@ static void
 fu_acpi_table_class_init(FuAcpiTableClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_table_finalize;
-	klass_firmware->parse = fu_acpi_table_parse;
-	klass_firmware->export = fu_acpi_table_export;
+	firmware_class->parse = fu_acpi_table_parse;
+	firmware_class->export = fu_acpi_table_export;
 }
 
 /**

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -282,11 +282,11 @@ fu_archive_firmware_init(FuArchiveFirmware *self)
 static void
 fu_archive_firmware_class_init(FuArchiveFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_archive_firmware_parse;
-	klass_firmware->write = fu_archive_firmware_write;
-	klass_firmware->build = fu_archive_firmware_build;
-	klass_firmware->export = fu_archive_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_archive_firmware_parse;
+	firmware_class->write = fu_archive_firmware_write;
+	firmware_class->build = fu_archive_firmware_build;
+	firmware_class->export = fu_archive_firmware_export;
 }
 
 /**

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -854,12 +854,12 @@ fu_cab_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static void
 fu_cab_firmware_class_init(FuCabFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_cab_firmware_validate;
-	klass_firmware->parse = fu_cab_firmware_parse;
-	klass_firmware->write = fu_cab_firmware_write;
-	klass_firmware->build = fu_cab_firmware_build;
-	klass_firmware->export = fu_cab_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_cab_firmware_validate;
+	firmware_class->parse = fu_cab_firmware_parse;
+	firmware_class->write = fu_cab_firmware_write;
+	firmware_class->build = fu_cab_firmware_build;
+	firmware_class->export = fu_cab_firmware_export;
 }
 
 static void

--- a/libfwupdplugin/fu-cab-image.c
+++ b/libfwupdplugin/fu-cab-image.c
@@ -154,11 +154,11 @@ fu_cab_image_finalize(GObject *object)
 static void
 fu_cab_image_class_init(FuCabImageClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_cab_image_finalize;
-	klass_firmware->build = fu_cab_image_build;
-	klass_firmware->export = fu_cab_image_export;
+	firmware_class->build = fu_cab_image_build;
+	firmware_class->export = fu_cab_image_export;
 }
 
 static void

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -982,19 +982,19 @@ static void
 fu_cfi_device_class_init(FuCfiDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GParamSpec *pspec;
 
 	object_class->finalize = fu_cfi_device_finalize;
 	object_class->get_property = fu_cfi_device_get_property;
 	object_class->set_property = fu_cfi_device_set_property;
 	object_class->constructed = fu_cfi_device_constructed;
-	klass_device->setup = fu_cfi_device_setup;
-	klass_device->to_string = fu_cfi_device_to_string;
-	klass_device->set_quirk_kv = fu_cfi_device_set_quirk_kv;
-	klass_device->write_firmware = fu_cfi_device_write_firmware;
-	klass_device->dump_firmware = fu_cfi_device_dump_firmware;
-	klass_device->set_progress = fu_cfi_device_set_progress;
+	device_class->setup = fu_cfi_device_setup;
+	device_class->to_string = fu_cfi_device_to_string;
+	device_class->set_quirk_kv = fu_cfi_device_set_quirk_kv;
+	device_class->write_firmware = fu_cfi_device_write_firmware;
+	device_class->dump_firmware = fu_cfi_device_dump_firmware;
+	device_class->set_progress = fu_cfi_device_set_progress;
 
 	/**
 	 * FuCfiDevice:flash-id:

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -549,11 +549,11 @@ fu_cfu_offer_init(FuCfuOffer *self)
 static void
 fu_cfu_offer_class_init(FuCfuOfferClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_cfu_offer_export;
-	klass_firmware->parse = fu_cfu_offer_parse;
-	klass_firmware->write = fu_cfu_offer_write;
-	klass_firmware->build = fu_cfu_offer_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_cfu_offer_export;
+	firmware_class->parse = fu_cfu_offer_parse;
+	firmware_class->write = fu_cfu_offer_write;
+	firmware_class->build = fu_cfu_offer_build;
 }
 
 /**

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -102,9 +102,9 @@ fu_cfu_payload_init(FuCfuPayload *self)
 static void
 fu_cfu_payload_class_init(FuCfuPayloadClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_cfu_payload_parse;
-	klass_firmware->write = fu_cfu_payload_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_cfu_payload_parse;
+	firmware_class->write = fu_cfu_payload_write;
 }
 
 /**

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -1170,13 +1170,13 @@ static void
 fu_coswid_firmware_class_init(FuCoswidFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_coswid_firmware_finalize;
-	klass_firmware->parse = fu_coswid_firmware_parse;
-	klass_firmware->write = fu_coswid_firmware_write;
-	klass_firmware->build = fu_coswid_firmware_build;
-	klass_firmware->export = fu_coswid_firmware_export;
-	klass_firmware->get_checksum = fu_coswid_firmware_get_checksum;
+	firmware_class->parse = fu_coswid_firmware_parse;
+	firmware_class->write = fu_coswid_firmware_write;
+	firmware_class->build = fu_coswid_firmware_build;
+	firmware_class->export = fu_coswid_firmware_export;
+	firmware_class->get_checksum = fu_coswid_firmware_get_checksum;
 }
 
 /**

--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -248,13 +248,13 @@ fu_csv_entry_finalize(GObject *object)
 static void
 fu_csv_entry_class_init(FuCsvEntryClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_csv_entry_finalize;
-	klass_firmware->parse = fu_csv_entry_parse;
-	klass_firmware->write = fu_csv_entry_write;
-	klass_firmware->build = fu_archive_firmware_build;
-	klass_firmware->export = fu_ifd_firmware_export;
+	firmware_class->parse = fu_csv_entry_parse;
+	firmware_class->write = fu_csv_entry_write;
+	firmware_class->build = fu_archive_firmware_build;
+	firmware_class->export = fu_ifd_firmware_export;
 }
 
 /**

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -199,11 +199,11 @@ fu_csv_firmware_finalize(GObject *object)
 static void
 fu_csv_firmware_class_init(FuCsvFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_csv_firmware_finalize;
-	klass_firmware->parse = fu_csv_firmware_parse;
-	klass_firmware->write = fu_csv_firmware_write;
+	firmware_class->parse = fu_csv_firmware_parse;
+	firmware_class->write = fu_csv_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -369,12 +369,12 @@ fu_dfu_firmware_init(FuDfuFirmware *self)
 static void
 fu_dfu_firmware_class_init(FuDfuFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_dfu_firmware_validate;
-	klass_firmware->export = fu_dfu_firmware_export;
-	klass_firmware->parse = fu_dfu_firmware_parse;
-	klass_firmware->write = fu_dfu_firmware_write;
-	klass_firmware->build = fu_dfu_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_dfu_firmware_validate;
+	firmware_class->export = fu_dfu_firmware_export;
+	firmware_class->parse = fu_dfu_firmware_parse;
+	firmware_class->write = fu_dfu_firmware_write;
+	firmware_class->build = fu_dfu_firmware_build;
 }
 
 /**

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -270,10 +270,10 @@ fu_dfuse_firmware_init(FuDfuseFirmware *self)
 static void
 fu_dfuse_firmware_class_init(FuDfuseFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_dfuse_firmware_validate;
-	klass_firmware->parse = fu_dfuse_firmware_parse;
-	klass_firmware->write = fu_dfuse_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_dfuse_firmware_validate;
+	firmware_class->parse = fu_dfuse_firmware_parse;
+	firmware_class->write = fu_dfuse_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -433,19 +433,19 @@ fu_dpaux_device_finalize(GObject *object)
 static void
 fu_dpaux_device_class_init(FuDpauxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
 	object_class->finalize = fu_dpaux_device_finalize;
 	object_class->get_property = fu_dpaux_device_get_property;
 	object_class->set_property = fu_dpaux_device_set_property;
-	klass_device->probe = fu_dpaux_device_probe;
-	klass_device->setup = fu_dpaux_device_setup;
-	klass_device->invalidate = fu_dpaux_device_invalidate;
-	klass_device->to_string = fu_dpaux_device_to_string;
-	klass_device->incorporate = fu_dpaux_device_incorporate;
-	klass_device->convert_version = fu_dpaux_device_convert_version;
+	device_class->probe = fu_dpaux_device_probe;
+	device_class->setup = fu_dpaux_device_setup;
+	device_class->invalidate = fu_dpaux_device_invalidate;
+	device_class->to_string = fu_dpaux_device_to_string;
+	device_class->incorporate = fu_dpaux_device_incorporate;
+	device_class->convert_version = fu_dpaux_device_convert_version;
 
 	/**
 	 * FuDpauxDevice:dpcd-ieee-oui:

--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -219,9 +219,9 @@ fu_drm_device_finalize(GObject *object)
 static void
 fu_drm_device_class_init(FuDrmDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_drm_device_finalize;
-	klass_device->probe = fu_drm_device_probe;
-	klass_device->to_string = fu_drm_device_to_string;
+	device_class->probe = fu_drm_device_probe;
+	device_class->to_string = fu_drm_device_to_string;
 }

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -413,12 +413,12 @@ static void
 fu_edid_class_init(FuEdidClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_edid_finalize;
-	klass_firmware->parse = fu_edid_parse;
-	klass_firmware->write = fu_edid_write;
-	klass_firmware->build = fu_edid_build;
-	klass_firmware->export = fu_edid_export;
+	firmware_class->parse = fu_edid_parse;
+	firmware_class->write = fu_edid_write;
+	firmware_class->build = fu_edid_build;
+	firmware_class->export = fu_edid_export;
 }
 
 static void

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -96,9 +96,9 @@ fu_efi_device_path_list_write(FuFirmware *firmware, GError **error)
 static void
 fu_efi_device_path_list_class_init(FuEfiDevicePathListClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_efi_device_path_list_parse;
-	klass_firmware->write = fu_efi_device_path_list_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_efi_device_path_list_parse;
+	firmware_class->write = fu_efi_device_path_list_write;
 }
 
 static void

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -165,11 +165,11 @@ fu_efi_device_path_init(FuEfiDevicePath *self)
 static void
 fu_efi_device_path_class_init(FuEfiDevicePathClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_efi_device_path_export;
-	klass_firmware->parse = fu_efi_device_path_parse;
-	klass_firmware->write = fu_efi_device_path_write;
-	klass_firmware->build = fu_efi_device_path_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_efi_device_path_export;
+	firmware_class->parse = fu_efi_device_path_parse;
+	firmware_class->write = fu_efi_device_path_write;
+	firmware_class->build = fu_efi_device_path_build;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-file-path-device-path.c
+++ b/libfwupdplugin/fu-efi-file-path-device-path.c
@@ -133,9 +133,9 @@ fu_efi_file_path_device_path_init(FuEfiFilePathDevicePath *self)
 static void
 fu_efi_file_path_device_path_class_init(FuEfiFilePathDevicePathClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_efi_file_path_device_path_export;
-	klass_firmware->build = fu_efi_file_path_device_path_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_efi_file_path_device_path_export;
+	firmware_class->build = fu_efi_file_path_device_path_build;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -291,11 +291,11 @@ fu_efi_file_init(FuEfiFile *self)
 static void
 fu_efi_file_class_init(FuEfiFileClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_efi_file_parse;
-	klass_firmware->write = fu_efi_file_write;
-	klass_firmware->build = fu_efi_file_build;
-	klass_firmware->export = fu_efi_file_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_efi_file_parse;
+	firmware_class->write = fu_efi_file_write;
+	firmware_class->build = fu_efi_file_build;
+	firmware_class->export = fu_efi_file_export;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -135,9 +135,9 @@ fu_efi_filesystem_init(FuEfiFilesystem *self)
 static void
 fu_efi_filesystem_class_init(FuEfiFilesystemClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_efi_filesystem_parse;
-	klass_firmware->write = fu_efi_filesystem_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_efi_filesystem_parse;
+	firmware_class->write = fu_efi_filesystem_write;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -165,11 +165,11 @@ fu_efi_hard_drive_device_path_init(FuEfiHardDriveDevicePath *self)
 static void
 fu_efi_hard_drive_device_path_class_init(FuEfiHardDriveDevicePathClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_efi_hard_drive_device_path_export;
-	klass_firmware->parse = fu_efi_hard_drive_device_path_parse;
-	klass_firmware->write = fu_efi_hard_drive_device_path_write;
-	klass_firmware->build = fu_efi_hard_drive_device_path_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_efi_hard_drive_device_path_export;
+	firmware_class->parse = fu_efi_hard_drive_device_path_parse;
+	firmware_class->write = fu_efi_hard_drive_device_path_write;
+	firmware_class->build = fu_efi_hard_drive_device_path_build;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -267,12 +267,12 @@ static void
 fu_efi_load_option_class_init(FuEfiLoadOptionClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_efi_load_option_finalize;
-	klass_firmware->parse = fu_efi_load_option_parse;
-	klass_firmware->write = fu_efi_load_option_write;
-	klass_firmware->build = fu_efi_load_option_build;
-	klass_firmware->export = fu_efi_load_option_export;
+	firmware_class->parse = fu_efi_load_option_parse;
+	firmware_class->write = fu_efi_load_option_write;
+	firmware_class->build = fu_efi_load_option_build;
+	firmware_class->export = fu_efi_load_option_export;
 }
 
 static void

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -678,8 +678,8 @@ fu_efi_lz77_decompressor_init(FuEfiLz77Decompressor *self)
 static void
 fu_efi_lz77_decompressor_class_init(FuEfiLz77DecompressorClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_efi_lz77_decompressor_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_efi_lz77_decompressor_parse;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -463,13 +463,13 @@ fu_efi_section_finalize(GObject *object)
 static void
 fu_efi_section_class_init(FuEfiSectionClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_efi_section_finalize;
-	klass_firmware->parse = fu_efi_section_parse;
-	klass_firmware->write = fu_efi_section_write;
-	klass_firmware->build = fu_efi_section_build;
-	klass_firmware->export = fu_efi_section_export;
+	firmware_class->parse = fu_efi_section_parse;
+	firmware_class->write = fu_efi_section_write;
+	firmware_class->build = fu_efi_section_build;
+	firmware_class->export = fu_efi_section_export;
 }
 
 /**

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -272,10 +272,10 @@ fu_efi_signature_list_new(void)
 static void
 fu_efi_signature_list_class_init(FuEfiSignatureListClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_efi_signature_list_validate;
-	klass_firmware->parse = fu_efi_signature_list_parse;
-	klass_firmware->write = fu_efi_signature_list_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_efi_signature_list_validate;
+	firmware_class->parse = fu_efi_signature_list_parse;
+	firmware_class->write = fu_efi_signature_list_write;
 }
 
 static void

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -316,11 +316,11 @@ fu_efi_volume_init(FuEfiVolume *self)
 static void
 fu_efi_volume_class_init(FuEfiVolumeClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_efi_volume_validate;
-	klass_firmware->parse = fu_efi_volume_parse;
-	klass_firmware->write = fu_efi_volume_write;
-	klass_firmware->export = fu_ifd_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_efi_volume_validate;
+	firmware_class->parse = fu_efi_volume_parse;
+	firmware_class->write = fu_efi_volume_write;
+	firmware_class->export = fu_ifd_firmware_export;
 }
 
 /**

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -141,9 +141,9 @@ fu_elf_firmware_init(FuElfFirmware *self)
 static void
 fu_elf_firmware_class_init(FuElfFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_elf_firmware_validate;
-	klass_firmware->parse = fu_elf_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_elf_firmware_validate;
+	firmware_class->parse = fu_elf_firmware_parse;
 }
 
 /**

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -591,12 +591,12 @@ fu_fdt_firmware_init(FuFdtFirmware *self)
 static void
 fu_fdt_firmware_class_init(FuFdtFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_fdt_firmware_validate;
-	klass_firmware->export = fu_fdt_firmware_export;
-	klass_firmware->parse = fu_fdt_firmware_parse;
-	klass_firmware->write = fu_fdt_firmware_write;
-	klass_firmware->build = fu_fdt_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_fdt_firmware_validate;
+	firmware_class->export = fu_fdt_firmware_export;
+	firmware_class->parse = fu_fdt_firmware_parse;
+	firmware_class->write = fu_fdt_firmware_write;
+	firmware_class->build = fu_fdt_firmware_build;
 }
 
 /**

--- a/libfwupdplugin/fu-fdt-image.c
+++ b/libfwupdplugin/fu-fdt-image.c
@@ -642,11 +642,11 @@ fu_fdt_image_finalize(GObject *object)
 static void
 fu_fdt_image_class_init(FuFdtImageClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_fdt_image_finalize;
-	klass_firmware->export = fu_fdt_image_export;
-	klass_firmware->build = fu_fdt_image_build;
+	firmware_class->export = fu_fdt_image_export;
+	firmware_class->build = fu_fdt_image_build;
 }
 
 /**

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -351,8 +351,8 @@ fu_fit_firmware_init(FuFitFirmware *self)
 static void
 fu_fit_firmware_class_init(FuFitFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_fit_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_fit_firmware_parse;
 }
 
 /**

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -39,7 +39,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
-	FuFmapFirmwareClass *klass_firmware = FU_FMAP_FIRMWARE_GET_CLASS(firmware);
+	FuFmapFirmwareClass *firmware_class = FU_FMAP_FIRMWARE_GET_CLASS(firmware);
 	gsize streamsz = 0;
 	guint32 nareas;
 	g_autoptr(GByteArray) st_hdr = NULL;
@@ -108,8 +108,8 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* subclassed */
-	if (klass_firmware->parse != NULL) {
-		if (!klass_firmware->parse(firmware, stream, offset, flags, error))
+	if (firmware_class->parse != NULL) {
+		if (!firmware_class->parse(firmware, stream, offset, flags, error))
 			return FALSE;
 	}
 
@@ -183,10 +183,10 @@ fu_fmap_firmware_init(FuFmapFirmware *self)
 static void
 fu_fmap_firmware_class_init(FuFmapFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_fmap_firmware_validate;
-	klass_firmware->parse = fu_fmap_firmware_parse;
-	klass_firmware->write = fu_fmap_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_fmap_firmware_validate;
+	firmware_class->parse = fu_fmap_firmware_parse;
+	firmware_class->write = fu_fmap_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -300,9 +300,9 @@ fu_hid_descriptor_init(FuHidDescriptor *self)
 static void
 fu_hid_descriptor_class_init(FuHidDescriptorClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_hid_descriptor_parse;
-	klass_firmware->write = fu_hid_descriptor_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_hid_descriptor_parse;
+	firmware_class->write = fu_hid_descriptor_write;
 }
 
 /**

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -684,15 +684,15 @@ fu_hid_device_new(GUsbDevice *usb_device)
 static void
 fu_hid_device_class_init(FuHidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
 	object_class->get_property = fu_hid_device_get_property;
 	object_class->set_property = fu_hid_device_set_property;
-	klass_device->open = fu_hid_device_open;
-	klass_device->close = fu_hid_device_close;
-	klass_device->to_string = fu_hid_device_to_string;
+	device_class->open = fu_hid_device_open;
+	device_class->close = fu_hid_device_close;
+	device_class->to_string = fu_hid_device_to_string;
 
 	/**
 	 * FuHidDevice:interface:

--- a/libfwupdplugin/fu-hid-report-item.c
+++ b/libfwupdplugin/fu-hid-report-item.c
@@ -188,11 +188,11 @@ fu_hid_report_item_init(FuHidReportItem *self)
 static void
 fu_hid_report_item_class_init(FuHidReportItemClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_hid_report_item_export;
-	klass_firmware->parse = fu_hid_report_item_parse;
-	klass_firmware->write = fu_hid_report_item_write;
-	klass_firmware->build = fu_hid_report_item_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_hid_report_item_export;
+	firmware_class->parse = fu_hid_report_item_parse;
+	firmware_class->write = fu_hid_report_item_write;
+	firmware_class->build = fu_hid_report_item_build;
 }
 
 /**

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -257,16 +257,16 @@ fu_i2c_device_init(FuI2cDevice *self)
 static void
 fu_i2c_device_class_init(FuI2cDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
 	object_class->get_property = fu_i2c_device_get_property;
 	object_class->set_property = fu_i2c_device_set_property;
-	klass_device->open = fu_i2c_device_open;
-	klass_device->probe = fu_i2c_device_probe;
-	klass_device->to_string = fu_i2c_device_to_string;
-	klass_device->incorporate = fu_i2c_device_incorporate;
+	device_class->open = fu_i2c_device_open;
+	device_class->probe = fu_i2c_device_probe;
+	device_class->to_string = fu_i2c_device_to_string;
+	device_class->incorporate = fu_i2c_device_incorporate;
 
 	/**
 	 * FuI2cDevice:bus-number:

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -87,8 +87,8 @@ fu_ifd_bios_init(FuIfdBios *self)
 static void
 fu_ifd_bios_class_init(FuIfdBiosClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_ifd_bios_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_ifd_bios_parse;
 }
 
 /**

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -439,13 +439,13 @@ static void
 fu_ifd_firmware_class_init(FuIfdFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ifd_firmware_finalize;
-	klass_firmware->validate = fu_ifd_firmware_validate;
-	klass_firmware->export = fu_ifd_firmware_export;
-	klass_firmware->parse = fu_ifd_firmware_parse;
-	klass_firmware->write = fu_ifd_firmware_write;
-	klass_firmware->build = fu_ifd_firmware_build;
+	firmware_class->validate = fu_ifd_firmware_validate;
+	firmware_class->export = fu_ifd_firmware_export;
+	firmware_class->parse = fu_ifd_firmware_parse;
+	firmware_class->write = fu_ifd_firmware_write;
+	firmware_class->build = fu_ifd_firmware_build;
 }
 
 /**

--- a/libfwupdplugin/fu-ifd-image.c
+++ b/libfwupdplugin/fu-ifd-image.c
@@ -131,9 +131,9 @@ fu_ifd_image_init(FuIfdImage *self)
 static void
 fu_ifd_image_class_init(FuIfdImageClass *klass)
 {
-	FuFirmwareClass *klass_image = FU_FIRMWARE_CLASS(klass);
-	klass_image->export = fu_ifd_image_export;
-	klass_image->write = fu_ifd_image_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_ifd_image_export;
+	firmware_class->write = fu_ifd_image_write;
 }
 
 /**

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -323,12 +323,12 @@ fu_ifwi_cpd_firmware_init(FuIfwiCpdFirmware *self)
 static void
 fu_ifwi_cpd_firmware_class_init(FuIfwiCpdFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_ifwi_cpd_firmware_validate;
-	klass_firmware->export = fu_ifwi_cpd_firmware_export;
-	klass_firmware->parse = fu_ifwi_cpd_firmware_parse;
-	klass_firmware->write = fu_ifwi_cpd_firmware_write;
-	klass_firmware->build = fu_ifwi_cpd_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_ifwi_cpd_firmware_validate;
+	firmware_class->export = fu_ifwi_cpd_firmware_export;
+	firmware_class->parse = fu_ifwi_cpd_firmware_parse;
+	firmware_class->write = fu_ifwi_cpd_firmware_write;
+	firmware_class->build = fu_ifwi_cpd_firmware_build;
 }
 
 /**

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -179,10 +179,10 @@ fu_ifwi_fpt_firmware_init(FuIfwiFptFirmware *self)
 static void
 fu_ifwi_fpt_firmware_class_init(FuIfwiFptFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_ifwi_fpt_firmware_validate;
-	klass_firmware->parse = fu_ifwi_fpt_firmware_parse;
-	klass_firmware->write = fu_ifwi_fpt_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_ifwi_fpt_firmware_validate;
+	firmware_class->parse = fu_ifwi_fpt_firmware_parse;
+	firmware_class->write = fu_ifwi_fpt_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -579,11 +579,11 @@ static void
 fu_ihex_firmware_class_init(FuIhexFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ihex_firmware_finalize;
-	klass_firmware->parse = fu_ihex_firmware_parse;
-	klass_firmware->tokenize = fu_ihex_firmware_tokenize;
-	klass_firmware->write = fu_ihex_firmware_write;
+	firmware_class->parse = fu_ihex_firmware_parse;
+	firmware_class->tokenize = fu_ihex_firmware_tokenize;
+	firmware_class->write = fu_ihex_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-intel-thunderbolt-firmware.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-firmware.c
@@ -112,9 +112,9 @@ fu_intel_thunderbolt_firmware_init(FuIntelThunderboltFirmware *self)
 static void
 fu_intel_thunderbolt_firmware_class_init(FuIntelThunderboltFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_intel_thunderbolt_firmware_parse;
-	klass_firmware->write = fu_intel_thunderbolt_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_intel_thunderbolt_firmware_parse;
+	firmware_class->write = fu_intel_thunderbolt_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -893,12 +893,12 @@ fu_intel_thunderbolt_nvm_init(FuIntelThunderboltNvm *self)
 static void
 fu_intel_thunderbolt_nvm_class_init(FuIntelThunderboltNvmClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_intel_thunderbolt_nvm_export;
-	klass_firmware->parse = fu_intel_thunderbolt_nvm_parse;
-	klass_firmware->write = fu_intel_thunderbolt_nvm_write;
-	klass_firmware->build = fu_intel_thunderbolt_nvm_build;
-	klass_firmware->check_compatible = fu_intel_thunderbolt_nvm_check_compatible;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_intel_thunderbolt_nvm_export;
+	firmware_class->parse = fu_intel_thunderbolt_nvm_parse;
+	firmware_class->write = fu_intel_thunderbolt_nvm_write;
+	firmware_class->build = fu_intel_thunderbolt_nvm_build;
+	firmware_class->check_compatible = fu_intel_thunderbolt_nvm_check_compatible;
 }
 
 /**

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -183,16 +183,16 @@ fu_linear_firmware_init(FuLinearFirmware *self)
 static void
 fu_linear_firmware_class_init(FuLinearFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
 	object_class->get_property = fu_linear_firmware_get_property;
 	object_class->set_property = fu_linear_firmware_set_property;
-	klass_firmware->parse = fu_linear_firmware_parse;
-	klass_firmware->write = fu_linear_firmware_write;
-	klass_firmware->export = fu_linear_firmware_export;
-	klass_firmware->build = fu_linear_firmware_build;
+	firmware_class->parse = fu_linear_firmware_parse;
+	firmware_class->write = fu_linear_firmware_write;
+	firmware_class->export = fu_linear_firmware_export;
+	firmware_class->build = fu_linear_firmware_build;
 
 	/**
 	 * FuLinearFirmware:image-gtype:

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -515,10 +515,10 @@ fu_mei_device_finalize(GObject *object)
 static void
 fu_mei_device_class_init(FuMeiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_mei_device_finalize;
-	klass_device->probe = fu_mei_device_probe;
-	klass_device->to_string = fu_mei_device_to_string;
-	klass_device->incorporate = fu_mei_device_incorporate;
+	device_class->probe = fu_mei_device_probe;
+	device_class->to_string = fu_mei_device_to_string;
+	device_class->incorporate = fu_mei_device_incorporate;
 }

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -292,12 +292,12 @@ fu_oprom_firmware_init(FuOpromFirmware *self)
 static void
 fu_oprom_firmware_class_init(FuOpromFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_oprom_firmware_validate;
-	klass_firmware->export = fu_oprom_firmware_export;
-	klass_firmware->parse = fu_oprom_firmware_parse;
-	klass_firmware->write = fu_oprom_firmware_write;
-	klass_firmware->build = fu_oprom_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_oprom_firmware_validate;
+	firmware_class->export = fu_oprom_firmware_export;
+	firmware_class->parse = fu_oprom_firmware_parse;
+	firmware_class->write = fu_oprom_firmware_write;
+	firmware_class->build = fu_oprom_firmware_build;
 }
 
 /**

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -193,9 +193,9 @@ fu_pefile_firmware_init(FuPefileFirmware *self)
 static void
 fu_pefile_firmware_class_init(FuPefileFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_pefile_firmware_validate;
-	klass_firmware->parse = fu_pefile_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_pefile_firmware_validate;
+	firmware_class->parse = fu_pefile_firmware_parse;
 }
 
 /**

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -691,9 +691,9 @@ static gboolean
 fu_plugin_device_attach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy_with_fallback(device);
-	FuDeviceClass *proxy_klass = FU_DEVICE_GET_CLASS(proxy);
+	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(proxy);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	if (proxy_klass->attach == NULL)
+	if (device_class->attach == NULL)
 		return TRUE;
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
@@ -705,9 +705,9 @@ static gboolean
 fu_plugin_device_detach(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy_with_fallback(device);
-	FuDeviceClass *proxy_klass = FU_DEVICE_GET_CLASS(proxy);
+	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(proxy);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	if (proxy_klass->detach == NULL)
+	if (device_class->detach == NULL)
 		return TRUE;
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
@@ -719,9 +719,9 @@ static gboolean
 fu_plugin_device_activate(FuPlugin *self, FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy_with_fallback(device);
-	FuDeviceClass *proxy_klass = FU_DEVICE_GET_CLASS(proxy);
+	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(proxy);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	if (proxy_klass->activate == NULL)
+	if (device_class->activate == NULL)
 		return TRUE;
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -115,9 +115,9 @@ fu_sbatlevel_section_init(FuSbatlevelSection *self)
 static void
 fu_sbatlevel_section_class_init(FuSbatlevelSectionClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 
-	klass_firmware->parse = fu_sbatlevel_section_parse;
+	firmware_class->parse = fu_sbatlevel_section_parse;
 }
 
 FuFirmware *

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -612,10 +612,10 @@ static void
 fu_smbios_class_init(FuSmbiosClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_smbios_finalize;
-	klass_firmware->parse = fu_smbios_parse;
-	klass_firmware->export = fu_smbios_export;
+	firmware_class->parse = fu_smbios_parse;
+	firmware_class->export = fu_smbios_export;
 }
 
 static void

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -672,11 +672,11 @@ static void
 fu_srec_firmware_class_init(FuSrecFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_srec_firmware_finalize;
-	klass_firmware->parse = fu_srec_firmware_parse;
-	klass_firmware->tokenize = fu_srec_firmware_tokenize;
-	klass_firmware->write = fu_srec_firmware_write;
+	firmware_class->parse = fu_srec_firmware_parse;
+	firmware_class->tokenize = fu_srec_firmware_tokenize;
+	firmware_class->write = fu_srec_firmware_write;
 }
 
 /**

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -266,8 +266,8 @@ fu_usb_device_ds20_init(FuUsbDeviceDs20 *self)
 static void
 fu_usb_device_ds20_class_init(FuUsbDeviceDs20Class *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_usb_device_ds20_validate;
-	klass_firmware->parse = fu_usb_device_ds20_parse;
-	klass_firmware->write = fu_usb_device_ds20_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_usb_device_ds20_validate;
+	firmware_class->parse = fu_usb_device_ds20_parse;
+	firmware_class->write = fu_usb_device_ds20_write;
 }

--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -104,8 +104,8 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 static void
 fu_usb_device_fw_ds20_class_init(FuUsbDeviceFwDs20Class *klass)
 {
-	FuUsbDeviceDs20Class *usb_device_ds20_klass = FU_USB_DEVICE_DS20_CLASS(klass);
-	usb_device_ds20_klass->parse = fu_usb_device_fw_ds20_parse;
+	FuUsbDeviceDs20Class *usb_device_ds20_class = FU_USB_DEVICE_DS20_CLASS(klass);
+	usb_device_ds20_class->parse = fu_usb_device_fw_ds20_parse;
 }
 
 static void

--- a/libfwupdplugin/fu-usb-device-ms-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ms-ds20.c
@@ -89,8 +89,8 @@ fu_usb_device_ms_ds20_parse(FuUsbDeviceDs20 *self,
 static void
 fu_usb_device_ms_ds20_class_init(FuUsbDeviceMsDs20Class *klass)
 {
-	FuUsbDeviceDs20Class *usb_device_ds20_klass = FU_USB_DEVICE_DS20_CLASS(klass);
-	usb_device_ds20_klass->parse = fu_usb_device_ms_ds20_parse;
+	FuUsbDeviceDs20Class *usb_device_ds20_class = FU_USB_DEVICE_DS20_CLASS(klass);
+	usb_device_ds20_class->parse = fu_usb_device_ms_ds20_parse;
 }
 
 static void

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -298,12 +298,12 @@ fu_uswid_firmware_init(FuUswidFirmware *self)
 static void
 fu_uswid_firmware_class_init(FuUswidFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_uswid_firmware_validate;
-	klass_firmware->parse = fu_uswid_firmware_parse;
-	klass_firmware->write = fu_uswid_firmware_write;
-	klass_firmware->build = fu_uswid_firmware_build;
-	klass_firmware->export = fu_uswid_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_uswid_firmware_validate;
+	firmware_class->parse = fu_uswid_firmware_parse;
+	firmware_class->write = fu_uswid_firmware_write;
+	firmware_class->build = fu_uswid_firmware_build;
+	firmware_class->export = fu_uswid_firmware_export;
 }
 
 /**

--- a/plugins/acpi-dmar/fu-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar.c
@@ -64,8 +64,8 @@ fu_acpi_dmar_get_opt_in(FuAcpiDmar *self)
 static void
 fu_acpi_dmar_class_init(FuAcpiDmarClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_acpi_dmar_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_acpi_dmar_parse;
 }
 
 static void

--- a/plugins/acpi-ivrs/fu-acpi-ivrs.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs.c
@@ -66,8 +66,8 @@ fu_acpi_ivrs_get_dma_remap(FuAcpiIvrs *self)
 static void
 fu_acpi_ivrs_class_init(FuAcpiIvrsClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_acpi_ivrs_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_acpi_ivrs_parse;
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -195,12 +195,12 @@ static void
 fu_acpi_phat_health_record_class_init(FuAcpiPhatHealthRecordClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_phat_health_record_finalize;
-	klass_firmware->parse = fu_acpi_phat_health_record_parse;
-	klass_firmware->write = fu_acpi_phat_health_record_write;
-	klass_firmware->export = fu_acpi_phat_health_record_export;
-	klass_firmware->build = fu_acpi_phat_health_record_build;
+	firmware_class->parse = fu_acpi_phat_health_record_parse;
+	firmware_class->write = fu_acpi_phat_health_record_write;
+	firmware_class->export = fu_acpi_phat_health_record_export;
+	firmware_class->build = fu_acpi_phat_health_record_build;
 }
 
 FuFirmware *

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -128,12 +128,12 @@ static void
 fu_acpi_phat_version_element_class_init(FuAcpiPhatVersionElementClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_phat_version_element_finalize;
-	klass_firmware->parse = fu_acpi_phat_version_element_parse;
-	klass_firmware->write = fu_acpi_phat_version_element_write;
-	klass_firmware->export = fu_acpi_phat_version_element_export;
-	klass_firmware->build = fu_acpi_phat_version_element_build;
+	firmware_class->parse = fu_acpi_phat_version_element_parse;
+	firmware_class->write = fu_acpi_phat_version_element_write;
+	firmware_class->export = fu_acpi_phat_version_element_export;
+	firmware_class->build = fu_acpi_phat_version_element_build;
 }
 
 FuFirmware *

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -87,9 +87,9 @@ fu_acpi_phat_version_record_init(FuAcpiPhatVersionRecord *self)
 static void
 fu_acpi_phat_version_record_class_init(FuAcpiPhatVersionRecordClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_acpi_phat_version_record_parse;
-	klass_firmware->write = fu_acpi_phat_version_record_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_acpi_phat_version_record_parse;
+	firmware_class->write = fu_acpi_phat_version_record_write;
 }
 
 FuFirmware *

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -320,13 +320,13 @@ static void
 fu_acpi_phat_class_init(FuAcpiPhatClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_phat_finalize;
-	klass_firmware->validate = fu_acpi_phat_validate;
-	klass_firmware->parse = fu_acpi_phat_parse;
-	klass_firmware->write = fu_acpi_phat_write;
-	klass_firmware->export = fu_acpi_phat_export;
-	klass_firmware->build = fu_acpi_phat_build;
+	firmware_class->validate = fu_acpi_phat_validate;
+	firmware_class->parse = fu_acpi_phat_parse;
+	firmware_class->write = fu_acpi_phat_write;
+	firmware_class->export = fu_acpi_phat_export;
+	firmware_class->build = fu_acpi_phat_build;
 }
 
 FuFirmware *

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -533,8 +533,8 @@ fu_algoltek_usb_device_init(FuAlgoltekUsbDevice *self)
 static void
 fu_algoltek_usb_device_class_init(FuAlgoltekUsbDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_algoltek_usb_device_setup;
-	klass_device->write_firmware = fu_algoltek_usb_device_write_firmware;
-	klass_device->set_progress = fu_algoltek_usb_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_algoltek_usb_device_setup;
+	device_class->write_firmware = fu_algoltek_usb_device_write_firmware;
+	device_class->set_progress = fu_algoltek_usb_device_set_progress;
 }

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -96,8 +96,8 @@ fu_algoltek_usb_firmware_init(FuAlgoltekUsbFirmware *self)
 static void
 fu_algoltek_usb_firmware_class_init(FuAlgoltekUsbFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_algoltek_usb_firmware_validate;
-	klass_firmware->parse = fu_algoltek_usb_firmware_parse;
-	klass_firmware->write = fu_algoltek_usb_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_algoltek_usb_firmware_validate;
+	firmware_class->parse = fu_algoltek_usb_firmware_parse;
+	firmware_class->write = fu_algoltek_usb_firmware_write;
 }

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -333,11 +333,11 @@ static void
 fu_amd_gpu_atom_firmware_class_init(FuAmdGpuAtomFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_amd_gpu_atom_firmware_finalize;
-	klass_firmware->parse = fu_amd_gpu_atom_firmware_parse;
-	klass_firmware->export = fu_amd_gpu_atom_firmware_export;
-	klass_firmware->validate = fu_amd_gpu_atom_firmware_validate;
+	firmware_class->parse = fu_amd_gpu_atom_firmware_parse;
+	firmware_class->export = fu_amd_gpu_atom_firmware_export;
+	firmware_class->validate = fu_amd_gpu_atom_firmware_validate;
 }
 
 FuFirmware *

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -309,12 +309,12 @@ static void
 fu_amd_gpu_device_class_init(FuAmdGpuDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_amd_gpu_device_finalize;
-	klass_device->probe = fu_amd_gpu_device_probe;
-	klass_device->setup = fu_amd_gpu_device_setup;
-	klass_device->set_progress = fu_amd_gpu_device_set_progress;
-	klass_device->write_firmware = fu_amd_gpu_device_write_firmware;
-	klass_device->prepare_firmware = fu_amd_gpu_device_prepare_firmware;
-	klass_device->to_string = fu_amd_gpu_device_to_string;
+	device_class->probe = fu_amd_gpu_device_probe;
+	device_class->setup = fu_amd_gpu_device_setup;
+	device_class->set_progress = fu_amd_gpu_device_set_progress;
+	device_class->write_firmware = fu_amd_gpu_device_write_firmware;
+	device_class->prepare_firmware = fu_amd_gpu_device_prepare_firmware;
+	device_class->to_string = fu_amd_gpu_device_to_string;
 }

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -219,10 +219,10 @@ fu_amd_gpu_psp_firmware_init(FuAmdGpuPspFirmware *self)
 static void
 fu_amd_gpu_psp_firmware_class_init(FuAmdGpuPspFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_amd_gpu_psp_firmware_validate;
-	klass_firmware->parse = fu_amd_gpu_psp_firmware_parse;
-	klass_firmware->export = fu_amd_gpu_psp_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_amd_gpu_psp_firmware_validate;
+	firmware_class->parse = fu_amd_gpu_psp_firmware_parse;
+	firmware_class->export = fu_amd_gpu_psp_firmware_export;
 }
 
 /**

--- a/plugins/amd-pmc/fu-amd-pmc-device.c
+++ b/plugins/amd-pmc/fu-amd-pmc-device.c
@@ -70,6 +70,6 @@ fu_amd_pmc_device_init(FuAmdPmcDevice *self)
 static void
 fu_amd_pmc_device_class_init(FuAmdPmcDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_amd_pmc_device_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_amd_pmc_device_probe;
 }

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -488,11 +488,11 @@ fu_analogix_device_init(FuAnalogixDevice *self)
 static void
 fu_analogix_device_class_init(FuAnalogixDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_analogix_device_to_string;
-	klass_device->write_firmware = fu_analogix_device_write_firmware;
-	klass_device->attach = fu_analogix_device_attach;
-	klass_device->setup = fu_analogix_device_setup;
-	klass_device->probe = fu_analogix_device_probe;
-	klass_device->set_progress = fu_analogix_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_analogix_device_to_string;
+	device_class->write_firmware = fu_analogix_device_write_firmware;
+	device_class->attach = fu_analogix_device_attach;
+	device_class->setup = fu_analogix_device_setup;
+	device_class->probe = fu_analogix_device_probe;
+	device_class->set_progress = fu_analogix_device_set_progress;
 }

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -119,6 +119,6 @@ fu_analogix_firmware_init(FuAnalogixFirmware *self)
 static void
 fu_analogix_firmware_class_init(FuAnalogixFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_analogix_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_analogix_firmware_parse;
 }

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -366,13 +366,13 @@ fu_android_boot_device_init(FuAndroidBootDevice *self)
 static void
 fu_android_boot_device_class_init(FuAndroidBootDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	GObjectClass *klass_object = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	klass_object->finalize = fu_android_boot_device_finalize;
-	klass_device->probe = fu_android_boot_device_probe;
-	klass_device->open = fu_android_boot_device_open;
-	klass_device->write_firmware = fu_android_boot_device_write_firmware;
-	klass_device->to_string = fu_android_boot_device_to_string;
-	klass_device->set_quirk_kv = fu_android_boot_device_set_quirk_kv;
+	object_class->finalize = fu_android_boot_device_finalize;
+	device_class->probe = fu_android_boot_device_probe;
+	device_class->open = fu_android_boot_device_open;
+	device_class->write_firmware = fu_android_boot_device_write_firmware;
+	device_class->to_string = fu_android_boot_device_to_string;
+	device_class->set_quirk_kv = fu_android_boot_device_set_quirk_kv;
 }

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -908,15 +908,15 @@ static void
 fu_ata_device_class_init(FuAtaDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_ata_device_finalize;
-	klass_device->to_string = fu_ata_device_to_string;
-	klass_device->set_quirk_kv = fu_ata_device_set_quirk_kv;
-	klass_device->setup = fu_ata_device_setup;
-	klass_device->activate = fu_ata_device_activate;
-	klass_device->write_firmware = fu_ata_device_write_firmware;
-	klass_device->probe = fu_ata_device_probe;
-	klass_device->set_progress = fu_ata_device_set_progress;
+	device_class->to_string = fu_ata_device_to_string;
+	device_class->set_quirk_kv = fu_ata_device_set_quirk_kv;
+	device_class->setup = fu_ata_device_setup;
+	device_class->activate = fu_ata_device_activate;
+	device_class->write_firmware = fu_ata_device_write_firmware;
+	device_class->probe = fu_ata_device_probe;
+	device_class->set_progress = fu_ata_device_set_progress;
 }
 
 FuAtaDevice *

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -515,10 +515,10 @@ fu_aver_hid_device_init(FuAverHidDevice *self)
 static void
 fu_aver_hid_device_class_init(FuAverHidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->poll = fu_aver_hid_device_poll;
-	klass_device->setup = fu_aver_hid_device_setup;
-	klass_device->prepare_firmware = fu_aver_hid_device_prepare_firmware;
-	klass_device->write_firmware = fu_aver_hid_device_write_firmware;
-	klass_device->set_progress = fu_aver_hid_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->poll = fu_aver_hid_device_poll;
+	device_class->setup = fu_aver_hid_device_setup;
+	device_class->prepare_firmware = fu_aver_hid_device_prepare_firmware;
+	device_class->write_firmware = fu_aver_hid_device_write_firmware;
+	device_class->set_progress = fu_aver_hid_device_set_progress;
 }

--- a/plugins/aver-hid/fu-aver-hid-firmware.c
+++ b/plugins/aver-hid/fu-aver-hid-firmware.c
@@ -54,8 +54,8 @@ fu_aver_hid_firmware_init(FuAverHidFirmware *self)
 static void
 fu_aver_hid_firmware_class_init(FuAverHidFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_aver_hid_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_aver_hid_firmware_parse;
 }
 
 FuFirmware *

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -416,8 +416,8 @@ fu_aver_safeisp_device_init(FuAverSafeispDevice *self)
 static void
 fu_aver_safeisp_device_class_init(FuAverSafeispDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_aver_safeisp_device_setup;
-	klass_device->write_firmware = fu_aver_safeisp_device_write_firmware;
-	klass_device->set_progress = fu_aver_safeisp_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_aver_safeisp_device_setup;
+	device_class->write_firmware = fu_aver_safeisp_device_write_firmware;
+	device_class->set_progress = fu_aver_safeisp_device_set_progress;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -657,23 +657,23 @@ fu_bcm57xx_device_class_init(FuBcm57xxDeviceClass *klass)
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->get_property = fu_bcm57xx_device_get_property;
 	object_class->set_property = fu_bcm57xx_device_set_property;
 	object_class->finalize = fu_bcm57xx_device_finalize;
-	klass_device->prepare_firmware = fu_bcm57xx_device_prepare_firmware;
-	klass_device->setup = fu_bcm57xx_device_setup;
-	klass_device->reload = fu_bcm57xx_device_setup;
-	klass_device->open = fu_bcm57xx_device_open;
-	klass_device->close = fu_bcm57xx_device_close;
-	klass_device->write_firmware = fu_bcm57xx_device_write_firmware;
-	klass_device->attach = fu_bcm57xx_device_attach;
-	klass_device->read_firmware = fu_bcm57xx_device_read_firmware;
-	klass_device->dump_firmware = fu_bcm57xx_device_dump_firmware;
-	klass_device->probe = fu_bcm57xx_device_probe;
-	klass_device->to_string = fu_bcm57xx_device_to_string;
-	klass_device->set_progress = fu_bcm57xx_device_set_progress;
-	klass_device->convert_version = fu_bcm57xx_device_convert_version;
+	device_class->prepare_firmware = fu_bcm57xx_device_prepare_firmware;
+	device_class->setup = fu_bcm57xx_device_setup;
+	device_class->reload = fu_bcm57xx_device_setup;
+	device_class->open = fu_bcm57xx_device_open;
+	device_class->close = fu_bcm57xx_device_close;
+	device_class->write_firmware = fu_bcm57xx_device_write_firmware;
+	device_class->attach = fu_bcm57xx_device_attach;
+	device_class->read_firmware = fu_bcm57xx_device_read_firmware;
+	device_class->dump_firmware = fu_bcm57xx_device_dump_firmware;
+	device_class->probe = fu_bcm57xx_device_probe;
+	device_class->to_string = fu_bcm57xx_device_to_string;
+	device_class->set_progress = fu_bcm57xx_device_set_progress;
+	device_class->convert_version = fu_bcm57xx_device_convert_version;
 
 	pspec =
 	    g_param_spec_string("iface",

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -164,11 +164,11 @@ fu_bcm57xx_dict_image_init(FuBcm57xxDictImage *self)
 static void
 fu_bcm57xx_dict_image_class_init(FuBcm57xxDictImageClass *klass)
 {
-	FuFirmwareClass *klass_image = FU_FIRMWARE_CLASS(klass);
-	klass_image->parse = fu_bcm57xx_dict_image_parse;
-	klass_image->write = fu_bcm57xx_dict_image_write;
-	klass_image->build = fu_bcm57xx_dict_image_build;
-	klass_image->export = fu_bcm57xx_dict_image_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_bcm57xx_dict_image_parse;
+	firmware_class->write = fu_bcm57xx_dict_image_write;
+	firmware_class->build = fu_bcm57xx_dict_image_build;
+	firmware_class->export = fu_bcm57xx_dict_image_export;
 }
 
 FuFirmware *

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -648,12 +648,12 @@ fu_bcm57xx_firmware_init(FuBcm57xxFirmware *self)
 static void
 fu_bcm57xx_firmware_class_init(FuBcm57xxFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_bcm57xx_firmware_validate;
-	klass_firmware->parse = fu_bcm57xx_firmware_parse;
-	klass_firmware->export = fu_bcm57xx_firmware_export;
-	klass_firmware->write = fu_bcm57xx_firmware_write;
-	klass_firmware->build = fu_bcm57xx_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_bcm57xx_firmware_validate;
+	firmware_class->parse = fu_bcm57xx_firmware_parse;
+	firmware_class->export = fu_bcm57xx_firmware_export;
+	firmware_class->write = fu_bcm57xx_firmware_write;
+	firmware_class->build = fu_bcm57xx_firmware_build;
 }
 
 FuFirmware *

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -883,18 +883,18 @@ fu_bcm57xx_recovery_device_probe(FuDevice *device, GError **error)
 static void
 fu_bcm57xx_recovery_device_class_init(FuBcm57xxRecoveryDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->activate = fu_bcm57xx_recovery_device_activate;
-	klass_device->prepare_firmware = fu_bcm57xx_recovery_device_prepare_firmware;
-	klass_device->setup = fu_bcm57xx_recovery_device_setup;
-	klass_device->reload = fu_bcm57xx_recovery_device_setup;
-	klass_device->open = fu_bcm57xx_recovery_device_open;
-	klass_device->close = fu_bcm57xx_recovery_device_close;
-	klass_device->write_firmware = fu_bcm57xx_recovery_device_write_firmware;
-	klass_device->dump_firmware = fu_bcm57xx_recovery_device_dump_firmware;
-	klass_device->attach = fu_bcm57xx_recovery_device_attach;
-	klass_device->detach = fu_bcm57xx_recovery_device_detach;
-	klass_device->probe = fu_bcm57xx_recovery_device_probe;
-	klass_device->set_progress = fu_bcm57xx_recovery_device_set_progress;
-	klass_device->convert_version = fu_bcm57xx_recovery_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->activate = fu_bcm57xx_recovery_device_activate;
+	device_class->prepare_firmware = fu_bcm57xx_recovery_device_prepare_firmware;
+	device_class->setup = fu_bcm57xx_recovery_device_setup;
+	device_class->reload = fu_bcm57xx_recovery_device_setup;
+	device_class->open = fu_bcm57xx_recovery_device_open;
+	device_class->close = fu_bcm57xx_recovery_device_close;
+	device_class->write_firmware = fu_bcm57xx_recovery_device_write_firmware;
+	device_class->dump_firmware = fu_bcm57xx_recovery_device_dump_firmware;
+	device_class->attach = fu_bcm57xx_recovery_device_attach;
+	device_class->detach = fu_bcm57xx_recovery_device_detach;
+	device_class->probe = fu_bcm57xx_recovery_device_probe;
+	device_class->set_progress = fu_bcm57xx_recovery_device_set_progress;
+	device_class->convert_version = fu_bcm57xx_recovery_device_convert_version;
 }

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -152,9 +152,9 @@ fu_bcm57xx_stage1_image_init(FuBcm57xxStage1Image *self)
 static void
 fu_bcm57xx_stage1_image_class_init(FuBcm57xxStage1ImageClass *klass)
 {
-	FuFirmwareClass *klass_image = FU_FIRMWARE_CLASS(klass);
-	klass_image->parse = fu_bcm57xx_stage1_image_parse;
-	klass_image->write = fu_bcm57xx_stage1_image_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_bcm57xx_stage1_image_parse;
+	firmware_class->write = fu_bcm57xx_stage1_image_write;
 }
 
 FuFirmware *

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -76,9 +76,9 @@ fu_bcm57xx_stage2_image_init(FuBcm57xxStage2Image *self)
 static void
 fu_bcm57xx_stage2_image_class_init(FuBcm57xxStage2ImageClass *klass)
 {
-	FuFirmwareClass *klass_image = FU_FIRMWARE_CLASS(klass);
-	klass_image->parse = fu_bcm57xx_stage2_image_parse;
-	klass_image->write = fu_bcm57xx_stage2_image_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_bcm57xx_stage2_image_parse;
+	firmware_class->write = fu_bcm57xx_stage2_image_write;
 }
 
 FuFirmware *

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -822,13 +822,13 @@ fu_ccgx_dmc_device_init(FuCcgxDmcDevice *self)
 static void
 fu_ccgx_dmc_device_class_init(FuCcgxDmcDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_ccgx_dmc_device_to_string;
-	klass_device->write_firmware = fu_ccgx_dmc_write_firmware;
-	klass_device->prepare_firmware = fu_ccgx_dmc_device_prepare_firmware;
-	klass_device->attach = fu_ccgx_dmc_device_attach;
-	klass_device->setup = fu_ccgx_dmc_device_setup;
-	klass_device->set_quirk_kv = fu_ccgx_dmc_device_set_quirk_kv;
-	klass_device->set_progress = fu_ccgx_dmc_device_set_progress;
-	klass_device->convert_version = fu_ccgx_dmc_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_ccgx_dmc_device_to_string;
+	device_class->write_firmware = fu_ccgx_dmc_write_firmware;
+	device_class->prepare_firmware = fu_ccgx_dmc_device_prepare_firmware;
+	device_class->attach = fu_ccgx_dmc_device_attach;
+	device_class->setup = fu_ccgx_dmc_device_setup;
+	device_class->set_quirk_kv = fu_ccgx_dmc_device_set_quirk_kv;
+	device_class->set_progress = fu_ccgx_dmc_device_set_progress;
+	device_class->convert_version = fu_ccgx_dmc_device_convert_version;
 }

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -330,13 +330,13 @@ fu_ccgx_dmc_devx_device_finalize(GObject *object)
 static void
 fu_ccgx_dmc_devx_device_class_init(FuCcgxDmcDevxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_ccgx_dmc_devx_device_finalize;
-	klass_device->probe = fu_ccgx_dmc_devx_device_probe;
-	klass_device->to_string = fu_ccgx_dmc_devx_device_to_string;
-	klass_device->set_quirk_kv = fu_ccgx_dmc_devx_device_set_quirk_kv;
-	klass_device->convert_version = fu_ccgx_dmc_devx_device_convert_version;
+	device_class->probe = fu_ccgx_dmc_devx_device_probe;
+	device_class->to_string = fu_ccgx_dmc_devx_device_to_string;
+	device_class->set_quirk_kv = fu_ccgx_dmc_devx_device_set_quirk_kv;
+	device_class->convert_version = fu_ccgx_dmc_devx_device_convert_version;
 }
 
 FuCcgxDmcDevxDevice *

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -451,12 +451,12 @@ static void
 fu_ccgx_dmc_firmware_class_init(FuCcgxDmcFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ccgx_dmc_firmware_finalize;
-	klass_firmware->validate = fu_ccgx_dmc_firmware_validate;
-	klass_firmware->parse = fu_ccgx_dmc_firmware_parse;
-	klass_firmware->write = fu_ccgx_dmc_firmware_write;
-	klass_firmware->export = fu_ccgx_dmc_firmware_export;
+	firmware_class->validate = fu_ccgx_dmc_firmware_validate;
+	firmware_class->parse = fu_ccgx_dmc_firmware_parse;
+	firmware_class->write = fu_ccgx_dmc_firmware_write;
+	firmware_class->export = fu_ccgx_dmc_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -513,12 +513,12 @@ static void
 fu_ccgx_firmware_class_init(FuCcgxFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_ccgx_firmware_finalize;
-	klass_firmware->parse = fu_ccgx_firmware_parse;
-	klass_firmware->write = fu_ccgx_firmware_write;
-	klass_firmware->build = fu_ccgx_firmware_build;
-	klass_firmware->export = fu_ccgx_firmware_export;
+	firmware_class->parse = fu_ccgx_firmware_parse;
+	firmware_class->write = fu_ccgx_firmware_write;
+	firmware_class->build = fu_ccgx_firmware_build;
+	firmware_class->export = fu_ccgx_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/ccgx/fu-ccgx-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-hid-device.c
@@ -102,8 +102,8 @@ fu_ccgx_hid_device_init(FuCcgxHidDevice *self)
 static void
 fu_ccgx_hid_device_class_init(FuCcgxHidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->detach = fu_ccgx_hid_device_detach;
-	klass_device->setup = fu_ccgx_hid_device_setup;
-	klass_device->set_progress = fu_ccgx_hid_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->detach = fu_ccgx_hid_device_detach;
+	device_class->setup = fu_ccgx_hid_device_setup;
+	device_class->set_progress = fu_ccgx_hid_device_set_progress;
 }

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1618,15 +1618,15 @@ fu_ccgx_hpi_device_init(FuCcgxHpiDevice *self)
 static void
 fu_ccgx_hpi_device_class_init(FuCcgxHpiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_ccgx_hpi_device_to_string;
-	klass_device->write_firmware = fu_ccgx_hpi_write_firmware;
-	klass_device->prepare_firmware = fu_ccgx_hpi_device_prepare_firmware;
-	klass_device->detach = fu_ccgx_hpi_device_detach;
-	klass_device->attach = fu_ccgx_hpi_device_attach;
-	klass_device->setup = fu_ccgx_hpi_device_setup;
-	klass_device->set_quirk_kv = fu_ccgx_hpi_device_set_quirk_kv;
-	klass_device->close = fu_ccgx_hpi_device_close;
-	klass_device->set_progress = fu_ccgx_hpi_device_set_progress;
-	klass_device->convert_version = fu_ccgx_hpi_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_ccgx_hpi_device_to_string;
+	device_class->write_firmware = fu_ccgx_hpi_write_firmware;
+	device_class->prepare_firmware = fu_ccgx_hpi_device_prepare_firmware;
+	device_class->detach = fu_ccgx_hpi_device_detach;
+	device_class->attach = fu_ccgx_hpi_device_attach;
+	device_class->setup = fu_ccgx_hpi_device_setup;
+	device_class->set_quirk_kv = fu_ccgx_hpi_device_set_quirk_kv;
+	device_class->close = fu_ccgx_hpi_device_close;
+	device_class->set_progress = fu_ccgx_hpi_device_set_progress;
+	device_class->convert_version = fu_ccgx_hpi_device_convert_version;
 }

--- a/plugins/cfu/fu-cfu-device.c
+++ b/plugins/cfu/fu-cfu-device.c
@@ -570,9 +570,9 @@ fu_cfu_device_init(FuCfuDevice *self)
 static void
 fu_cfu_device_class_init(FuCfuDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_cfu_device_setup;
-	klass_device->to_string = fu_cfu_device_to_string;
-	klass_device->write_firmware = fu_cfu_device_write_firmware;
-	klass_device->set_quirk_kv = fu_cfu_device_set_quirk_kv;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_cfu_device_setup;
+	device_class->to_string = fu_cfu_device_to_string;
+	device_class->write_firmware = fu_cfu_device_write_firmware;
+	device_class->set_quirk_kv = fu_cfu_device_set_quirk_kv;
 }

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -139,7 +139,7 @@ fu_cfu_module_write_firmware(FuDevice *device,
 			     GError **error)
 {
 	FuDevice *proxy;
-	FuDeviceClass *klass_proxy;
+	FuDeviceClass *device_class;
 
 	/* process by the parent */
 	proxy = fu_device_get_proxy(device);
@@ -150,8 +150,8 @@ fu_cfu_module_write_firmware(FuDevice *device,
 			    "no proxy device assigned");
 		return FALSE;
 	}
-	klass_proxy = FU_DEVICE_GET_CLASS(proxy);
-	return klass_proxy->write_firmware(proxy, firmware, progress, flags, error);
+	device_class = FU_DEVICE_GET_CLASS(proxy);
+	return device_class->write_firmware(proxy, firmware, progress, flags, error);
 }
 
 static void
@@ -186,12 +186,12 @@ fu_cfu_module_init(FuCfuModule *self)
 static void
 fu_cfu_module_class_init(FuCfuModuleClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_cfu_module_to_string;
-	klass_device->prepare_firmware = fu_cfu_module_prepare_firmware;
-	klass_device->write_firmware = fu_cfu_module_write_firmware;
-	klass_device->set_progress = fu_cfu_module_set_progress;
-	klass_device->convert_version = fu_cfu_module_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_cfu_module_to_string;
+	device_class->prepare_firmware = fu_cfu_module_prepare_firmware;
+	device_class->write_firmware = fu_cfu_module_write_firmware;
+	device_class->set_progress = fu_cfu_module_set_progress;
+	device_class->convert_version = fu_cfu_module_convert_version;
 }
 
 FuCfuModule *

--- a/plugins/ch341a/fu-ch341a-cfi-device.c
+++ b/plugins/ch341a/fu-ch341a-cfi-device.c
@@ -436,13 +436,13 @@ fu_ch341a_cfi_device_init(FuCh341aCfiDevice *self)
 static void
 fu_ch341a_cfi_device_class_init(FuCh341aCfiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuCfiDeviceClass *klass_cfi = FU_CFI_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuCfiDeviceClass *cfi_class = FU_CFI_DEVICE_CLASS(klass);
 
-	klass_cfi->chip_select = fu_ch341a_cfi_device_chip_select;
+	cfi_class->chip_select = fu_ch341a_cfi_device_chip_select;
 
-	klass_device->setup = fu_ch341a_cfi_device_setup;
-	klass_device->write_firmware = fu_ch341a_cfi_device_write_firmware;
-	klass_device->dump_firmware = fu_ch341a_cfi_device_dump_firmware;
-	klass_device->set_progress = fu_ch341a_cfi_device_set_progress;
+	device_class->setup = fu_ch341a_cfi_device_setup;
+	device_class->write_firmware = fu_ch341a_cfi_device_write_firmware;
+	device_class->dump_firmware = fu_ch341a_cfi_device_dump_firmware;
+	device_class->set_progress = fu_ch341a_cfi_device_set_progress;
 }

--- a/plugins/ch341a/fu-ch341a-device.c
+++ b/plugins/ch341a/fu-ch341a-device.c
@@ -283,7 +283,7 @@ fu_ch341a_device_init(FuCh341aDevice *self)
 static void
 fu_ch341a_device_class_init(FuCh341aDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_ch341a_device_setup;
-	klass_device->to_string = fu_ch341a_device_to_string;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_ch341a_device_setup;
+	device_class->to_string = fu_ch341a_device_to_string;
 }

--- a/plugins/ch347/fu-ch347-cfi-device.c
+++ b/plugins/ch347/fu-ch347-cfi-device.c
@@ -43,7 +43,7 @@ fu_ch347_cfi_device_init(FuCh347CfiDevice *self)
 static void
 fu_ch347_cfi_device_class_init(FuCh347CfiDeviceClass *klass)
 {
-	FuCfiDeviceClass *klass_cfi = FU_CFI_DEVICE_CLASS(klass);
-	klass_cfi->chip_select = fu_ch347_cfi_device_chip_select;
-	klass_cfi->send_command = fu_ch347_cfi_device_send_command;
+	FuCfiDeviceClass *cfi_class = FU_CFI_DEVICE_CLASS(klass);
+	cfi_class->chip_select = fu_ch347_cfi_device_chip_select;
+	cfi_class->send_command = fu_ch347_cfi_device_send_command;
 }

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -298,7 +298,7 @@ fu_ch347_device_init(FuCh347Device *self)
 static void
 fu_ch347_device_class_init(FuCh347DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_ch347_device_setup;
-	klass_device->to_string = fu_ch347_device_to_string;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_ch347_device_setup;
+	device_class->to_string = fu_ch347_device_to_string;
 }

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -610,12 +610,12 @@ fu_colorhug_device_init(FuColorhugDevice *self)
 static void
 fu_colorhug_device_class_init(FuColorhugDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_colorhug_device_write_firmware;
-	klass_device->attach = fu_colorhug_device_attach;
-	klass_device->detach = fu_colorhug_device_detach;
-	klass_device->reload = fu_colorhug_device_reload;
-	klass_device->setup = fu_colorhug_device_setup;
-	klass_device->probe = fu_colorhug_device_probe;
-	klass_device->set_progress = fu_colorhug_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_colorhug_device_write_firmware;
+	device_class->attach = fu_colorhug_device_attach;
+	device_class->detach = fu_colorhug_device_detach;
+	device_class->reload = fu_colorhug_device_reload;
+	device_class->setup = fu_colorhug_device_setup;
+	device_class->probe = fu_colorhug_device_probe;
+	device_class->set_progress = fu_colorhug_device_set_progress;
 }

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -438,13 +438,13 @@ fu_corsair_bp_to_string(FuDevice *device, guint idt, GString *str)
 static void
 fu_corsair_bp_class_init(FuCorsairBpClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->incorporate = fu_corsair_bp_incorporate;
-	klass_device->write_firmware = fu_corsair_bp_write_firmware;
-	klass_device->attach = fu_corsair_bp_attach;
-	klass_device->detach = fu_corsair_bp_detach;
-	klass_device->to_string = fu_corsair_bp_to_string;
+	device_class->incorporate = fu_corsair_bp_incorporate;
+	device_class->write_firmware = fu_corsair_bp_write_firmware;
+	device_class->attach = fu_corsair_bp_attach;
+	device_class->detach = fu_corsair_bp_detach;
+	device_class->to_string = fu_corsair_bp_to_string;
 }
 
 FuCorsairBp *

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -517,19 +517,19 @@ fu_corsair_device_finalize(GObject *object)
 static void
 fu_corsair_device_class_init(FuCorsairDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	klass_device->poll = fu_corsair_device_poll;
-	klass_device->probe = fu_corsair_device_probe;
-	klass_device->set_quirk_kv = fu_corsair_set_quirk_kv;
-	klass_device->setup = fu_corsair_device_setup;
-	klass_device->reload = fu_corsair_device_reload;
-	klass_device->attach = fu_corsair_device_attach;
-	klass_device->detach = fu_corsair_device_detach;
-	klass_device->write_firmware = fu_corsair_device_write_firmware;
-	klass_device->to_string = fu_corsair_device_to_string;
-	klass_device->set_progress = fu_corsair_device_set_progress;
+	device_class->poll = fu_corsair_device_poll;
+	device_class->probe = fu_corsair_device_probe;
+	device_class->set_quirk_kv = fu_corsair_set_quirk_kv;
+	device_class->setup = fu_corsair_device_setup;
+	device_class->reload = fu_corsair_device_reload;
+	device_class->attach = fu_corsair_device_attach;
+	device_class->detach = fu_corsair_device_detach;
+	device_class->write_firmware = fu_corsair_device_write_firmware;
+	device_class->to_string = fu_corsair_device_to_string;
+	device_class->set_progress = fu_corsair_device_set_progress;
 
 	object_class->finalize = fu_corsair_device_finalize;
 }

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -472,12 +472,12 @@ fu_cpu_device_convert_version(FuDevice *device, guint64 version_raw)
 static void
 fu_cpu_device_class_init(FuCpuDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_cpu_device_to_string;
-	klass_device->probe = fu_cpu_device_probe;
-	klass_device->set_quirk_kv = fu_cpu_device_set_quirk_kv;
-	klass_device->add_security_attrs = fu_cpu_device_add_security_attrs;
-	klass_device->convert_version = fu_cpu_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_cpu_device_to_string;
+	device_class->probe = fu_cpu_device_probe;
+	device_class->set_quirk_kv = fu_cpu_device_set_quirk_kv;
+	device_class->add_security_attrs = fu_cpu_device_add_security_attrs;
+	device_class->convert_version = fu_cpu_device_convert_version;
 }
 
 FuCpuDevice *

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -192,8 +192,8 @@ static void
 fu_cros_ec_firmware_class_init(FuCrosEcFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFmapFirmwareClass *klass_firmware = FU_FMAP_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_cros_ec_firmware_parse;
+	FuFmapFirmwareClass *firmware_class = FU_FMAP_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_cros_ec_firmware_parse;
 	object_class->finalize = fu_cros_ec_firmware_finalize;
 }
 

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -1032,14 +1032,14 @@ fu_cros_ec_usb_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_cros_ec_usb_device_class_init(FuCrosEcUsbDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->attach = fu_cros_ec_usb_device_attach;
-	klass_device->detach = fu_cros_ec_usb_device_detach;
-	klass_device->prepare_firmware = fu_cros_ec_usb_device_prepare_firmware;
-	klass_device->setup = fu_cros_ec_usb_device_setup;
-	klass_device->to_string = fu_cros_ec_usb_device_to_string;
-	klass_device->write_firmware = fu_cros_ec_usb_device_write_firmware;
-	klass_device->probe = fu_cros_ec_usb_device_probe;
-	klass_device->set_progress = fu_cros_ec_usb_device_set_progress;
-	klass_device->reload = fu_cros_ec_usb_device_reload;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->attach = fu_cros_ec_usb_device_attach;
+	device_class->detach = fu_cros_ec_usb_device_detach;
+	device_class->prepare_firmware = fu_cros_ec_usb_device_prepare_firmware;
+	device_class->setup = fu_cros_ec_usb_device_setup;
+	device_class->to_string = fu_cros_ec_usb_device_to_string;
+	device_class->write_firmware = fu_cros_ec_usb_device_write_firmware;
+	device_class->probe = fu_cros_ec_usb_device_probe;
+	device_class->set_progress = fu_cros_ec_usb_device_set_progress;
+	device_class->reload = fu_cros_ec_usb_device_reload;
 }

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -207,13 +207,13 @@ static void
 fu_dell_dock_hub_class_init(FuDellDockHubClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_dell_dock_hub_finalize;
-	klass_device->setup = fu_dell_dock_hub_setup;
-	klass_device->probe = fu_dell_dock_hub_probe;
-	klass_device->write_firmware = fu_dell_dock_hub_write_fw;
-	klass_device->set_quirk_kv = fu_dell_dock_hub_set_quirk_kv;
-	klass_device->set_progress = fu_dell_dock_hub_set_progress;
+	device_class->setup = fu_dell_dock_hub_setup;
+	device_class->probe = fu_dell_dock_hub_probe;
+	device_class->write_firmware = fu_dell_dock_hub_write_fw;
+	device_class->set_quirk_kv = fu_dell_dock_hub_set_quirk_kv;
+	device_class->set_progress = fu_dell_dock_hub_set_progress;
 }
 
 FuDellDockHub *

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -1010,16 +1010,16 @@ static void
 fu_dell_dock_ec_class_init(FuDellDockEcClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_dell_dock_ec_finalize;
-	klass_device->activate = fu_dell_dock_ec_activate;
-	klass_device->to_string = fu_dell_dock_ec_to_string;
-	klass_device->setup = fu_dell_dock_ec_setup;
-	klass_device->open = fu_dell_dock_ec_open;
-	klass_device->close = fu_dell_dock_ec_close;
-	klass_device->write_firmware = fu_dell_dock_ec_write_fw;
-	klass_device->set_quirk_kv = fu_dell_dock_ec_set_quirk_kv;
-	klass_device->set_progress = fu_dell_dock_ec_set_progress;
+	device_class->activate = fu_dell_dock_ec_activate;
+	device_class->to_string = fu_dell_dock_ec_to_string;
+	device_class->setup = fu_dell_dock_ec_setup;
+	device_class->open = fu_dell_dock_ec_open;
+	device_class->close = fu_dell_dock_ec_close;
+	device_class->write_firmware = fu_dell_dock_ec_write_fw;
+	device_class->set_quirk_kv = fu_dell_dock_ec_set_quirk_kv;
+	device_class->set_progress = fu_dell_dock_ec_set_progress;
 }
 
 FuDellDockEc *

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -1240,14 +1240,14 @@ fu_dell_dock_mst_init(FuDellDockMst *self)
 static void
 fu_dell_dock_mst_class_init(FuDellDockMstClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_dell_dock_mst_probe;
-	klass_device->open = fu_dell_dock_mst_open;
-	klass_device->close = fu_dell_dock_mst_close;
-	klass_device->setup = fu_dell_dock_mst_setup;
-	klass_device->write_firmware = fu_dell_dock_mst_write_fw;
-	klass_device->set_quirk_kv = fu_dell_dock_mst_set_quirk_kv;
-	klass_device->set_progress = fu_dell_dock_mst_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_dell_dock_mst_probe;
+	device_class->open = fu_dell_dock_mst_open;
+	device_class->close = fu_dell_dock_mst_close;
+	device_class->setup = fu_dell_dock_mst_setup;
+	device_class->write_firmware = fu_dell_dock_mst_write_fw;
+	device_class->set_quirk_kv = fu_dell_dock_mst_set_quirk_kv;
+	device_class->set_progress = fu_dell_dock_mst_set_progress;
 }
 
 FuDellDockMst *

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -283,14 +283,14 @@ static void
 fu_dell_dock_tbt_class_init(FuDellDockTbtClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_dell_dock_tbt_finalize;
-	klass_device->probe = fu_dell_dock_tbt_probe;
-	klass_device->setup = fu_dell_dock_tbt_setup;
-	klass_device->open = fu_dell_dock_tbt_open;
-	klass_device->close = fu_dell_dock_tbt_close;
-	klass_device->write_firmware = fu_dell_dock_tbt_write_fw;
-	klass_device->set_quirk_kv = fu_dell_dock_tbt_set_quirk_kv;
+	device_class->probe = fu_dell_dock_tbt_probe;
+	device_class->setup = fu_dell_dock_tbt_setup;
+	device_class->open = fu_dell_dock_tbt_open;
+	device_class->close = fu_dell_dock_tbt_close;
+	device_class->write_firmware = fu_dell_dock_tbt_write_fw;
+	device_class->set_quirk_kv = fu_dell_dock_tbt_set_quirk_kv;
 }
 
 FuDellDockTbt *

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -165,14 +165,14 @@ static void
 fu_dell_dock_status_class_init(FuDellDockStatusClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_dell_dock_status_finalize;
-	klass_device->write_firmware = fu_dell_dock_status_write;
-	klass_device->setup = fu_dell_dock_status_setup;
-	klass_device->open = fu_dell_dock_status_open;
-	klass_device->close = fu_dell_dock_status_close;
-	klass_device->set_quirk_kv = fu_dell_dock_status_set_quirk_kv;
-	klass_device->set_progress = fu_dell_dock_status_set_progress;
+	device_class->write_firmware = fu_dell_dock_status_write;
+	device_class->setup = fu_dell_dock_status_setup;
+	device_class->open = fu_dell_dock_status_open;
+	device_class->close = fu_dell_dock_status_close;
+	device_class->set_quirk_kv = fu_dell_dock_status_set_quirk_kv;
+	device_class->set_progress = fu_dell_dock_status_set_progress;
 }
 
 FuDellDockStatus *

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -380,11 +380,11 @@ fu_dfu_csr_device_init(FuDfuCsrDevice *self)
 static void
 fu_dfu_csr_device_class_init(FuDfuCsrDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_dfu_csr_device_to_string;
-	klass_device->write_firmware = fu_dfu_csr_device_download;
-	klass_device->dump_firmware = fu_dfu_csr_device_upload;
-	klass_device->attach = fu_dfu_csr_device_attach;
-	klass_device->setup = fu_dfu_csr_device_setup;
-	klass_device->set_progress = fu_dfu_csr_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_dfu_csr_device_to_string;
+	device_class->write_firmware = fu_dfu_csr_device_download;
+	device_class->dump_firmware = fu_dfu_csr_device_upload;
+	device_class->attach = fu_dfu_csr_device_attach;
+	device_class->setup = fu_dfu_csr_device_setup;
+	device_class->set_progress = fu_dfu_csr_device_set_progress;
 }

--- a/plugins/dfu-csr/fu-dfu-csr-firmware.c
+++ b/plugins/dfu-csr/fu-dfu-csr-firmware.c
@@ -68,10 +68,10 @@ fu_dfu_csr_firmware_init(FuDfuCsrFirmware *self)
 static void
 fu_dfu_csr_firmware_class_init(FuDfuCsrFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_dfu_csr_firmware_validate;
-	klass_firmware->parse = fu_dfu_csr_firmware_parse;
-	klass_firmware->export = fu_dfu_csr_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_dfu_csr_firmware_validate;
+	firmware_class->parse = fu_dfu_csr_firmware_parse;
+	firmware_class->export = fu_dfu_csr_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1530,19 +1530,19 @@ static void
 fu_dfu_device_class_init(FuDfuDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->set_quirk_kv = fu_dfu_device_set_quirk_kv;
-	klass_device->to_string = fu_dfu_device_to_string;
-	klass_device->dump_firmware = fu_dfu_device_dump_firmware;
-	klass_device->write_firmware = fu_dfu_device_write_firmware;
-	klass_device->prepare_firmware = fu_dfu_device_prepare_firmware;
-	klass_device->attach = fu_dfu_device_attach;
-	klass_device->detach = fu_dfu_device_detach;
-	klass_device->reload = fu_dfu_device_reload;
-	klass_device->open = fu_dfu_device_open;
-	klass_device->close = fu_dfu_device_close;
-	klass_device->probe = fu_dfu_device_probe;
-	klass_device->set_progress = fu_dfu_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->set_quirk_kv = fu_dfu_device_set_quirk_kv;
+	device_class->to_string = fu_dfu_device_to_string;
+	device_class->dump_firmware = fu_dfu_device_dump_firmware;
+	device_class->write_firmware = fu_dfu_device_write_firmware;
+	device_class->prepare_firmware = fu_dfu_device_prepare_firmware;
+	device_class->attach = fu_dfu_device_attach;
+	device_class->detach = fu_dfu_device_detach;
+	device_class->reload = fu_dfu_device_reload;
+	device_class->open = fu_dfu_device_open;
+	device_class->close = fu_dfu_device_close;
+	device_class->probe = fu_dfu_device_probe;
+	device_class->set_progress = fu_dfu_device_set_progress;
 	object_class->finalize = fu_dfu_device_finalize;
 }
 

--- a/plugins/dfu/fu-dfu-target-avr.c
+++ b/plugins/dfu/fu-dfu-target-avr.c
@@ -922,12 +922,12 @@ fu_dfu_target_avr_init(FuDfuTargetAvr *self)
 static void
 fu_dfu_target_avr_class_init(FuDfuTargetAvrClass *klass)
 {
-	FuDfuTargetClass *klass_target = FU_DFU_TARGET_CLASS(klass);
-	klass_target->setup = fu_dfu_target_avr_setup;
-	klass_target->attach = fu_dfu_target_avr_attach;
-	klass_target->mass_erase = fu_dfu_target_avr_mass_erase;
-	klass_target->upload_element = fu_dfu_target_avr_upload_element;
-	klass_target->download_element = fu_dfu_target_avr_download_element;
+	FuDfuTargetClass *target_class = FU_DFU_TARGET_CLASS(klass);
+	target_class->setup = fu_dfu_target_avr_setup;
+	target_class->attach = fu_dfu_target_avr_attach;
+	target_class->mass_erase = fu_dfu_target_avr_mass_erase;
+	target_class->upload_element = fu_dfu_target_avr_upload_element;
+	target_class->download_element = fu_dfu_target_avr_download_element;
 }
 
 FuDfuTarget *

--- a/plugins/dfu/fu-dfu-target-stm.c
+++ b/plugins/dfu/fu-dfu-target-stm.c
@@ -468,11 +468,11 @@ fu_dfu_target_stm_init(FuDfuTargetStm *self)
 static void
 fu_dfu_target_stm_class_init(FuDfuTargetStmClass *klass)
 {
-	FuDfuTargetClass *klass_target = FU_DFU_TARGET_CLASS(klass);
-	klass_target->attach = fu_dfu_target_stm_attach;
-	klass_target->mass_erase = fu_dfu_target_stm_mass_erase;
-	klass_target->upload_element = fu_dfu_target_stm_upload_element;
-	klass_target->download_element = fu_dfu_target_stm_download_element;
+	FuDfuTargetClass *target_class = FU_DFU_TARGET_CLASS(klass);
+	target_class->attach = fu_dfu_target_stm_attach;
+	target_class->mass_erase = fu_dfu_target_stm_mass_erase;
+	target_class->upload_element = fu_dfu_target_stm_upload_element;
+	target_class->download_element = fu_dfu_target_stm_download_element;
 }
 
 FuDfuTarget *

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -1267,7 +1267,7 @@ static void
 fu_dfu_target_class_init(FuDfuTargetClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_dfu_target_to_string;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_dfu_target_to_string;
 	object_class->finalize = fu_dfu_target_finalize;
 }

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -678,13 +678,13 @@ fu_ebitdo_device_init(FuEbitdoDevice *self)
 static void
 fu_ebitdo_device_class_init(FuEbitdoDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_ebitdo_device_write_firmware;
-	klass_device->setup = fu_ebitdo_device_setup;
-	klass_device->detach = fu_ebitdo_device_detach;
-	klass_device->attach = fu_ebitdo_device_attach;
-	klass_device->open = fu_ebitdo_device_open;
-	klass_device->probe = fu_ebitdo_device_probe;
-	klass_device->set_progress = fu_ebitdo_set_progress;
-	klass_device->convert_version = fu_ebitdo_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_ebitdo_device_write_firmware;
+	device_class->setup = fu_ebitdo_device_setup;
+	device_class->detach = fu_ebitdo_device_detach;
+	device_class->attach = fu_ebitdo_device_attach;
+	device_class->open = fu_ebitdo_device_open;
+	device_class->probe = fu_ebitdo_device_probe;
+	device_class->set_progress = fu_ebitdo_set_progress;
+	device_class->convert_version = fu_ebitdo_device_convert_version;
 }

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -95,7 +95,7 @@ fu_ebitdo_firmware_init(FuEbitdoFirmware *self)
 static void
 fu_ebitdo_firmware_class_init(FuEbitdoFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_ebitdo_firmware_parse;
-	klass_firmware->write = fu_ebitdo_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_ebitdo_firmware_parse;
+	firmware_class->write = fu_ebitdo_firmware_write;
 }

--- a/plugins/elanfp/fu-elanfp-device.c
+++ b/plugins/elanfp/fu-elanfp-device.c
@@ -455,8 +455,8 @@ fu_elanfp_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_elanfp_device_class_init(FuElanfpDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_elanfp_device_setup;
-	klass_device->write_firmware = fu_elanfp_device_write_firmware;
-	klass_device->set_progress = fu_elanfp_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_elanfp_device_setup;
+	device_class->write_firmware = fu_elanfp_device_write_firmware;
+	device_class->set_progress = fu_elanfp_device_set_progress;
 }

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -204,10 +204,10 @@ fu_elanfp_firmware_init(FuElanfpFirmware *self)
 static void
 fu_elanfp_firmware_class_init(FuElanfpFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_elanfp_firmware_validate;
-	klass_firmware->parse = fu_elanfp_firmware_parse;
-	klass_firmware->write = fu_elanfp_firmware_write;
-	klass_firmware->export = fu_elanfp_firmware_export;
-	klass_firmware->build = fu_elanfp_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_elanfp_firmware_validate;
+	firmware_class->parse = fu_elanfp_firmware_parse;
+	firmware_class->write = fu_elanfp_firmware_write;
+	firmware_class->export = fu_elanfp_firmware_export;
+	firmware_class->build = fu_elanfp_firmware_build;
 }

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -271,12 +271,12 @@ fu_elantp_firmware_init(FuElantpFirmware *self)
 static void
 fu_elantp_firmware_class_init(FuElantpFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_elantp_firmware_validate;
-	klass_firmware->parse = fu_elantp_firmware_parse;
-	klass_firmware->build = fu_elantp_firmware_build;
-	klass_firmware->write = fu_elantp_firmware_write;
-	klass_firmware->export = fu_elantp_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_elantp_firmware_validate;
+	firmware_class->parse = fu_elantp_firmware_parse;
+	firmware_class->build = fu_elantp_firmware_build;
+	firmware_class->write = fu_elantp_firmware_write;
+	firmware_class->export = fu_elantp_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/elantp/fu-elantp-haptic-firmware.c
+++ b/plugins/elantp/fu-elantp-haptic-firmware.c
@@ -93,10 +93,10 @@ fu_elantp_haptic_firmware_init(FuElantpHapticFirmware *self)
 static void
 fu_elantp_haptic_firmware_class_init(FuElantpHapticFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_elantp_haptic_firmware_validate;
-	klass_firmware->parse = fu_elantp_haptic_firmware_parse;
-	klass_firmware->export = fu_elantp_haptic_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_elantp_haptic_firmware_validate;
+	firmware_class->parse = fu_elantp_haptic_firmware_parse;
+	firmware_class->export = fu_elantp_haptic_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -969,16 +969,16 @@ static void
 fu_elantp_hid_device_class_init(FuElantpHidDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_elantp_hid_device_finalize;
-	klass_device->to_string = fu_elantp_hid_device_to_string;
-	klass_device->attach = fu_elantp_hid_device_attach;
-	klass_device->set_quirk_kv = fu_elantp_hid_device_set_quirk_kv;
-	klass_device->setup = fu_elantp_hid_device_setup;
-	klass_device->reload = fu_elantp_hid_device_setup;
-	klass_device->write_firmware = fu_elantp_hid_device_write_firmware;
-	klass_device->prepare_firmware = fu_elantp_hid_device_prepare_firmware;
-	klass_device->probe = fu_elantp_hid_device_probe;
-	klass_device->set_progress = fu_elantp_hid_device_set_progress;
-	klass_device->convert_version = fu_elantp_hid_device_convert_version;
+	device_class->to_string = fu_elantp_hid_device_to_string;
+	device_class->attach = fu_elantp_hid_device_attach;
+	device_class->set_quirk_kv = fu_elantp_hid_device_set_quirk_kv;
+	device_class->setup = fu_elantp_hid_device_setup;
+	device_class->reload = fu_elantp_hid_device_setup;
+	device_class->write_firmware = fu_elantp_hid_device_write_firmware;
+	device_class->prepare_firmware = fu_elantp_hid_device_prepare_firmware;
+	device_class->probe = fu_elantp_hid_device_probe;
+	device_class->set_progress = fu_elantp_hid_device_set_progress;
+	device_class->convert_version = fu_elantp_hid_device_convert_version;
 }

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -1123,16 +1123,16 @@ fu_elantp_hid_haptic_device_init(FuElantpHidHapticDevice *self)
 static void
 fu_elantp_hid_haptic_device_class_init(FuElantpHidHapticDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_elantp_hid_haptic_device_to_string;
-	klass_device->attach = fu_elantp_hid_haptic_device_attach;
-	klass_device->set_quirk_kv = fu_elantp_hid_haptic_device_set_quirk_kv;
-	klass_device->setup = fu_elantp_hid_haptic_device_setup;
-	klass_device->reload = fu_elantp_hid_haptic_device_setup;
-	klass_device->write_firmware = fu_elantp_hid_haptic_device_write_firmware;
-	klass_device->prepare_firmware = fu_elantp_hid_haptic_device_prepare_firmware;
-	klass_device->probe = fu_elantp_hid_haptic_device_probe;
-	klass_device->set_progress = fu_elantp_hid_haptic_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_elantp_hid_haptic_device_to_string;
+	device_class->attach = fu_elantp_hid_haptic_device_attach;
+	device_class->set_quirk_kv = fu_elantp_hid_haptic_device_set_quirk_kv;
+	device_class->setup = fu_elantp_hid_haptic_device_setup;
+	device_class->reload = fu_elantp_hid_haptic_device_setup;
+	device_class->write_firmware = fu_elantp_hid_haptic_device_write_firmware;
+	device_class->prepare_firmware = fu_elantp_hid_haptic_device_prepare_firmware;
+	device_class->probe = fu_elantp_hid_haptic_device_probe;
+	device_class->set_progress = fu_elantp_hid_haptic_device_set_progress;
 }
 
 FuElantpHidHapticDevice *

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -839,17 +839,17 @@ static void
 fu_elantp_i2c_device_class_init(FuElantpI2cDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_elantp_i2c_device_finalize;
-	klass_device->to_string = fu_elantp_i2c_device_to_string;
-	klass_device->attach = fu_elantp_i2c_device_attach;
-	klass_device->set_quirk_kv = fu_elantp_i2c_device_set_quirk_kv;
-	klass_device->setup = fu_elantp_i2c_device_setup;
-	klass_device->reload = fu_elantp_i2c_device_setup;
-	klass_device->write_firmware = fu_elantp_i2c_device_write_firmware;
-	klass_device->prepare_firmware = fu_elantp_i2c_device_prepare_firmware;
-	klass_device->probe = fu_elantp_i2c_device_probe;
-	klass_device->open = fu_elantp_i2c_device_open;
-	klass_device->set_progress = fu_elantp_i2c_device_set_progress;
-	klass_device->convert_version = fu_elantp_i2c_device_convert_version;
+	device_class->to_string = fu_elantp_i2c_device_to_string;
+	device_class->attach = fu_elantp_i2c_device_attach;
+	device_class->set_quirk_kv = fu_elantp_i2c_device_set_quirk_kv;
+	device_class->setup = fu_elantp_i2c_device_setup;
+	device_class->reload = fu_elantp_i2c_device_setup;
+	device_class->write_firmware = fu_elantp_i2c_device_write_firmware;
+	device_class->prepare_firmware = fu_elantp_i2c_device_prepare_firmware;
+	device_class->probe = fu_elantp_i2c_device_probe;
+	device_class->open = fu_elantp_i2c_device_open;
+	device_class->set_progress = fu_elantp_i2c_device_set_progress;
+	device_class->convert_version = fu_elantp_i2c_device_convert_version;
 }

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -604,13 +604,13 @@ static void
 fu_emmc_device_class_init(FuEmmcDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_emmc_device_finalize;
-	klass_device->set_quirk_kv = fu_emmc_device_set_quirk_kv;
-	klass_device->setup = fu_emmc_device_setup;
-	klass_device->to_string = fu_emmc_device_to_string;
-	klass_device->prepare_firmware = fu_emmc_device_prepare_firmware;
-	klass_device->probe = fu_emmc_device_probe;
-	klass_device->write_firmware = fu_emmc_device_write_firmware;
-	klass_device->set_progress = fu_emmc_device_set_progress;
+	device_class->set_quirk_kv = fu_emmc_device_set_quirk_kv;
+	device_class->setup = fu_emmc_device_setup;
+	device_class->to_string = fu_emmc_device_to_string;
+	device_class->prepare_firmware = fu_emmc_device_prepare_firmware;
+	device_class->probe = fu_emmc_device_probe;
+	device_class->write_firmware = fu_emmc_device_write_firmware;
+	device_class->set_progress = fu_emmc_device_set_progress;
 }

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -382,10 +382,10 @@ fu_ep963x_device_init(FuEp963xDevice *self)
 static void
 fu_ep963x_device_class_init(FuEp963xDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_ep963x_device_write_firmware;
-	klass_device->attach = fu_ep963x_device_attach;
-	klass_device->detach = fu_ep963x_device_detach;
-	klass_device->setup = fu_ep963x_device_setup;
-	klass_device->set_progress = fu_ep963x_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_ep963x_device_write_firmware;
+	device_class->attach = fu_ep963x_device_attach;
+	device_class->detach = fu_ep963x_device_detach;
+	device_class->setup = fu_ep963x_device_setup;
+	device_class->set_progress = fu_ep963x_device_set_progress;
 }

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -61,7 +61,7 @@ fu_ep963x_firmware_init(FuEp963xFirmware *self)
 static void
 fu_ep963x_firmware_class_init(FuEp963xFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_ep963x_firmware_validate;
-	klass_firmware->parse = fu_ep963x_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_ep963x_firmware_validate;
+	firmware_class->parse = fu_ep963x_firmware_parse;
 }

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -708,12 +708,12 @@ fu_fastboot_device_init(FuFastbootDevice *self)
 static void
 fu_fastboot_device_class_init(FuFastbootDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_fastboot_device_probe;
-	klass_device->setup = fu_fastboot_device_setup;
-	klass_device->write_firmware = fu_fastboot_device_write_firmware;
-	klass_device->attach = fu_fastboot_device_attach;
-	klass_device->to_string = fu_fastboot_device_to_string;
-	klass_device->set_quirk_kv = fu_fastboot_device_set_quirk_kv;
-	klass_device->set_progress = fu_fastboot_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_fastboot_device_probe;
+	device_class->setup = fu_fastboot_device_setup;
+	device_class->write_firmware = fu_fastboot_device_write_firmware;
+	device_class->attach = fu_fastboot_device_attach;
+	device_class->to_string = fu_fastboot_device_to_string;
+	device_class->set_quirk_kv = fu_fastboot_device_set_quirk_kv;
+	device_class->set_progress = fu_fastboot_device_set_progress;
 }

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -332,7 +332,7 @@ fu_flashrom_device_class_init(FuFlashromDeviceClass *klass)
 {
 	GParamSpec *pspec;
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->get_property = fu_flashrom_device_get_property;
 	object_class->set_property = fu_flashrom_device_set_property;
@@ -364,14 +364,14 @@ fu_flashrom_device_class_init(FuFlashromDeviceClass *klass)
 	g_object_class_install_property(object_class, PROP_FLASHCTX, pspec);
 
 	object_class->finalize = fu_flashrom_device_finalize;
-	klass_device->set_quirk_kv = fu_flashrom_device_set_quirk_kv;
-	klass_device->probe = fu_flashrom_device_probe;
-	klass_device->open = fu_flashrom_device_open;
-	klass_device->close = fu_flashrom_device_close;
-	klass_device->set_progress = fu_flashrom_device_set_progress;
-	klass_device->prepare = fu_flashrom_device_prepare;
-	klass_device->dump_firmware = fu_flashrom_device_dump_firmware;
-	klass_device->write_firmware = fu_flashrom_device_write_firmware;
+	device_class->set_quirk_kv = fu_flashrom_device_set_quirk_kv;
+	device_class->probe = fu_flashrom_device_probe;
+	device_class->open = fu_flashrom_device_open;
+	device_class->close = fu_flashrom_device_close;
+	device_class->set_progress = fu_flashrom_device_set_progress;
+	device_class->prepare = fu_flashrom_device_prepare;
+	device_class->dump_firmware = fu_flashrom_device_dump_firmware;
+	device_class->write_firmware = fu_flashrom_device_write_firmware;
 }
 
 FuDevice *

--- a/plugins/focalfp/fu-focalfp-firmware.c
+++ b/plugins/focalfp/fu-focalfp-firmware.c
@@ -98,7 +98,7 @@ fu_focalfp_firmware_init(FuFocalfpFirmware *self)
 static void
 fu_focalfp_firmware_class_init(FuFocalfpFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_focalfp_firmware_parse;
-	klass_firmware->export = fu_focalfp_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_focalfp_firmware_parse;
+	firmware_class->export = fu_focalfp_firmware_export;
 }

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -667,13 +667,13 @@ fu_focalfp_hid_device_init(FuFocalfpHidDevice *self)
 static void
 fu_focalfp_hid_device_class_init(FuFocalfpHidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->attach = fu_focalfp_hid_device_attach;
-	klass_device->detach = fu_focalfp_hid_device_detach;
-	klass_device->setup = fu_focalfp_hid_device_setup;
-	klass_device->reload = fu_focalfp_hid_device_reload;
-	klass_device->write_firmware = fu_focalfp_hid_device_write_firmware;
-	klass_device->probe = fu_focalfp_hid_device_probe;
-	klass_device->set_progress = fu_focalfp_hid_device_set_progress;
-	klass_device->convert_version = fu_focalfp_hid_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->attach = fu_focalfp_hid_device_attach;
+	device_class->detach = fu_focalfp_hid_device_detach;
+	device_class->setup = fu_focalfp_hid_device_setup;
+	device_class->reload = fu_focalfp_hid_device_reload;
+	device_class->write_firmware = fu_focalfp_hid_device_write_firmware;
+	device_class->probe = fu_focalfp_hid_device_probe;
+	device_class->set_progress = fu_focalfp_hid_device_set_progress;
+	device_class->convert_version = fu_focalfp_hid_device_convert_version;
 }

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -568,13 +568,13 @@ fu_fpc_device_init(FuFpcDevice *self)
 static void
 fu_fpc_device_class_init(FuFpcDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_fpc_device_to_string;
-	klass_device->write_firmware = fu_fpc_device_write_firmware;
-	klass_device->setup = fu_fpc_device_setup;
-	klass_device->reload = fu_fpc_device_setup;
-	klass_device->attach = fu_fpc_device_attach;
-	klass_device->detach = fu_fpc_device_detach;
-	klass_device->set_progress = fu_fpc_device_set_progress;
-	klass_device->convert_version = fu_fpc_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_fpc_device_to_string;
+	device_class->write_firmware = fu_fpc_device_write_firmware;
+	device_class->setup = fu_fpc_device_setup;
+	device_class->reload = fu_fpc_device_setup;
+	device_class->attach = fu_fpc_device_attach;
+	device_class->detach = fu_fpc_device_detach;
+	device_class->set_progress = fu_fpc_device_set_progress;
+	device_class->convert_version = fu_fpc_device_convert_version;
 }

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -428,10 +428,10 @@ fu_fresco_pd_device_init(FuFrescoPdDevice *self)
 static void
 fu_fresco_pd_device_class_init(FuFrescoPdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_fresco_pd_device_to_string;
-	klass_device->setup = fu_fresco_pd_device_setup;
-	klass_device->write_firmware = fu_fresco_pd_device_write_firmware;
-	klass_device->prepare_firmware = fu_fresco_pd_device_prepare_firmware;
-	klass_device->set_progress = fu_fresco_pd_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_fresco_pd_device_to_string;
+	device_class->setup = fu_fresco_pd_device_setup;
+	device_class->write_firmware = fu_fresco_pd_device_write_firmware;
+	device_class->prepare_firmware = fu_fresco_pd_device_prepare_firmware;
+	device_class->set_progress = fu_fresco_pd_device_set_progress;
 }

--- a/plugins/fresco-pd/fu-fresco-pd-firmware.c
+++ b/plugins/fresco-pd/fu-fresco-pd-firmware.c
@@ -69,9 +69,9 @@ fu_fresco_pd_firmware_init(FuFrescoPdFirmware *self)
 static void
 fu_fresco_pd_firmware_class_init(FuFrescoPdFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_fresco_pd_firmware_parse;
-	klass_firmware->export = fu_fresco_pd_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_fresco_pd_firmware_parse;
+	firmware_class->export = fu_fresco_pd_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -942,16 +942,16 @@ static void
 fu_genesys_gl32xx_device_class_init(FuGenesysGl32xxDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_genesys_gl32xx_device_finalize;
-	klass_device->to_string = fu_genesys_gl32xx_device_to_string;
-	klass_device->probe = fu_genesys_gl32xx_device_probe;
-	klass_device->setup = fu_genesys_gl32xx_device_setup;
-	klass_device->detach = fu_genesys_gl32xx_device_detach;
-	klass_device->attach = fu_genesys_gl32xx_device_attach;
-	klass_device->dump_firmware = fu_genesys_gl32xx_device_dump_firmware;
-	klass_device->write_firmware = fu_genesys_gl32xx_device_write_firmware;
-	klass_device->read_firmware = fu_genesys_gl32xx_device_read_firmware;
-	klass_device->prepare_firmware = fu_genesys_gl32xx_device_prepare_firmware;
-	klass_device->set_progress = fu_genesys_gl32xx_device_set_progress;
+	device_class->to_string = fu_genesys_gl32xx_device_to_string;
+	device_class->probe = fu_genesys_gl32xx_device_probe;
+	device_class->setup = fu_genesys_gl32xx_device_setup;
+	device_class->detach = fu_genesys_gl32xx_device_detach;
+	device_class->attach = fu_genesys_gl32xx_device_attach;
+	device_class->dump_firmware = fu_genesys_gl32xx_device_dump_firmware;
+	device_class->write_firmware = fu_genesys_gl32xx_device_write_firmware;
+	device_class->read_firmware = fu_genesys_gl32xx_device_read_firmware;
+	device_class->prepare_firmware = fu_genesys_gl32xx_device_prepare_firmware;
+	device_class->set_progress = fu_genesys_gl32xx_device_set_progress;
 }

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
@@ -86,8 +86,8 @@ fu_genesys_gl32xx_firmware_init(FuGenesysGl32xxFirmware *self)
 static void
 fu_genesys_gl32xx_firmware_class_init(FuGenesysGl32xxFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_genesys_gl32xx_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_genesys_gl32xx_firmware_parse;
 }
 
 FuFirmware *

--- a/plugins/genesys/fu-genesys-hubhid-device.c
+++ b/plugins/genesys/fu-genesys-hubhid-device.c
@@ -393,7 +393,7 @@ fu_genesys_hubhid_device_init(FuGenesysHubhidDevice *self)
 static void
 fu_genesys_hubhid_device_class_init(FuGenesysHubhidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_genesys_hubhid_device_probe;
-	klass_device->setup = fu_genesys_hubhid_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_genesys_hubhid_device_probe;
+	device_class->setup = fu_genesys_hubhid_device_setup;
 }

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1959,18 +1959,18 @@ static void
 fu_genesys_scaler_device_class_init(FuGenesysScalerDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_genesys_scaler_device_finalize;
-	klass_device->probe = fu_genesys_scaler_device_probe;
-	klass_device->setup = fu_genesys_scaler_device_setup;
-	klass_device->dump_firmware = fu_genesys_scaler_device_dump_firmware;
-	klass_device->prepare_firmware = fu_genesys_scaler_device_prepare_firmware;
-	klass_device->write_firmware = fu_genesys_scaler_device_write_firmware;
-	klass_device->set_progress = fu_genesys_scaler_device_set_progress;
-	klass_device->detach = fu_genesys_scaler_device_detach;
-	klass_device->attach = fu_genesys_scaler_device_attach;
-	klass_device->to_string = fu_genesys_scaler_device_to_string;
-	klass_device->set_quirk_kv = fu_genesys_scaler_device_set_quirk_kv;
+	device_class->probe = fu_genesys_scaler_device_probe;
+	device_class->setup = fu_genesys_scaler_device_setup;
+	device_class->dump_firmware = fu_genesys_scaler_device_dump_firmware;
+	device_class->prepare_firmware = fu_genesys_scaler_device_prepare_firmware;
+	device_class->write_firmware = fu_genesys_scaler_device_write_firmware;
+	device_class->set_progress = fu_genesys_scaler_device_set_progress;
+	device_class->detach = fu_genesys_scaler_device_detach;
+	device_class->attach = fu_genesys_scaler_device_attach;
+	device_class->to_string = fu_genesys_scaler_device_to_string;
+	device_class->set_quirk_kv = fu_genesys_scaler_device_set_quirk_kv;
 }
 
 FuGenesysScalerDevice *

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -156,11 +156,11 @@ fu_genesys_scaler_firmware_init(FuGenesysScalerFirmware *self)
 static void
 fu_genesys_scaler_firmware_class_init(FuGenesysScalerFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_genesys_scaler_firmware_parse;
-	klass_firmware->export = fu_genesys_scaler_firmware_export;
-	klass_firmware->build = fu_genesys_scaler_firmware_build;
-	klass_firmware->write = fu_genesys_scaler_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_genesys_scaler_firmware_parse;
+	firmware_class->export = fu_genesys_scaler_firmware_export;
+	firmware_class->build = fu_genesys_scaler_firmware_build;
+	firmware_class->write = fu_genesys_scaler_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -111,8 +111,8 @@ fu_genesys_usbhub_codesign_firmware_init(FuGenesysUsbhubCodesignFirmware *self)
 static void
 fu_genesys_usbhub_codesign_firmware_class_init(FuGenesysUsbhubCodesignFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_genesys_usbhub_codesign_firmware_validate;
-	klass_firmware->parse = fu_genesys_usbhub_codesign_firmware_parse;
-	klass_firmware->export = fu_genesys_usbhub_codesign_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_genesys_usbhub_codesign_firmware_validate;
+	firmware_class->parse = fu_genesys_usbhub_codesign_firmware_parse;
+	firmware_class->export = fu_genesys_usbhub_codesign_firmware_export;
 }

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -76,7 +76,7 @@ fu_genesys_usbhub_dev_firmware_init(FuGenesysUsbhubDevFirmware *self)
 static void
 fu_genesys_usbhub_dev_firmware_class_init(FuGenesysUsbhubDevFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_genesys_usbhub_dev_firmware_validate;
-	klass_firmware->parse = fu_genesys_usbhub_dev_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_genesys_usbhub_dev_firmware_validate;
+	firmware_class->parse = fu_genesys_usbhub_dev_firmware_parse;
 }

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -3115,19 +3115,19 @@ static void
 fu_genesys_usbhub_device_class_init(FuGenesysUsbhubDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_genesys_usbhub_device_finalize;
-	klass_device->probe = fu_genesys_usbhub_device_probe;
-	klass_device->open = fu_genesys_usbhub_device_open;
-	klass_device->close = fu_genesys_usbhub_device_close;
-	klass_device->setup = fu_genesys_usbhub_device_setup;
-	klass_device->dump_firmware = fu_genesys_usbhub_device_dump_firmware;
-	klass_device->prepare = fu_genesys_usbhub_device_prepare;
-	klass_device->prepare_firmware = fu_genesys_usbhub_device_prepare_firmware;
-	klass_device->write_firmware = fu_genesys_usbhub_device_write_firmware;
-	klass_device->set_progress = fu_genesys_usbhub_device_set_progress;
-	klass_device->detach = fu_genesys_usbhub_device_detach;
-	klass_device->attach = fu_genesys_usbhub_device_attach;
-	klass_device->to_string = fu_genesys_usbhub_device_to_string;
-	klass_device->set_quirk_kv = fu_genesys_usbhub_device_set_quirk_kv;
+	device_class->probe = fu_genesys_usbhub_device_probe;
+	device_class->open = fu_genesys_usbhub_device_open;
+	device_class->close = fu_genesys_usbhub_device_close;
+	device_class->setup = fu_genesys_usbhub_device_setup;
+	device_class->dump_firmware = fu_genesys_usbhub_device_dump_firmware;
+	device_class->prepare = fu_genesys_usbhub_device_prepare;
+	device_class->prepare_firmware = fu_genesys_usbhub_device_prepare_firmware;
+	device_class->write_firmware = fu_genesys_usbhub_device_write_firmware;
+	device_class->set_progress = fu_genesys_usbhub_device_set_progress;
+	device_class->detach = fu_genesys_usbhub_device_detach;
+	device_class->attach = fu_genesys_usbhub_device_attach;
+	device_class->to_string = fu_genesys_usbhub_device_to_string;
+	device_class->set_quirk_kv = fu_genesys_usbhub_device_set_quirk_kv;
 }

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -514,13 +514,13 @@ static void
 fu_genesys_usbhub_firmware_class_init(FuGenesysUsbhubFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_genesys_usbhub_firmware_finalize;
-	klass_firmware->validate = fu_genesys_usbhub_firmware_validate;
-	klass_firmware->parse = fu_genesys_usbhub_firmware_parse;
-	klass_firmware->export = fu_genesys_usbhub_firmware_export;
-	klass_firmware->build = fu_genesys_usbhub_firmware_build;
-	klass_firmware->write = fu_genesys_usbhub_firmware_write;
+	firmware_class->validate = fu_genesys_usbhub_firmware_validate;
+	firmware_class->parse = fu_genesys_usbhub_firmware_parse;
+	firmware_class->export = fu_genesys_usbhub_firmware_export;
+	firmware_class->build = fu_genesys_usbhub_firmware_build;
+	firmware_class->write = fu_genesys_usbhub_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -76,7 +76,7 @@ fu_genesys_usbhub_pd_firmware_init(FuGenesysUsbhubPdFirmware *self)
 static void
 fu_genesys_usbhub_pd_firmware_class_init(FuGenesysUsbhubPdFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_genesys_usbhub_pd_firmware_validate;
-	klass_firmware->parse = fu_genesys_usbhub_pd_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_genesys_usbhub_pd_firmware_validate;
+	firmware_class->parse = fu_genesys_usbhub_pd_firmware_parse;
 }

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -460,9 +460,9 @@ fu_goodixmoc_device_init(FuGoodixMocDevice *self)
 static void
 fu_goodixmoc_device_class_init(FuGoodixMocDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_goodixmoc_device_write_firmware;
-	klass_device->setup = fu_goodixmoc_device_setup;
-	klass_device->attach = fu_goodixmoc_device_attach;
-	klass_device->set_progress = fu_goodixmoc_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_goodixmoc_device_write_firmware;
+	device_class->setup = fu_goodixmoc_device_setup;
+	device_class->attach = fu_goodixmoc_device_attach;
+	device_class->set_progress = fu_goodixmoc_device_set_progress;
 }

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -516,9 +516,9 @@ fu_goodixtp_brlb_device_init(FuGoodixtpBrlbDevice *self)
 static void
 fu_goodixtp_brlb_device_class_init(FuGoodixtpBrlbDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_goodixtp_brlb_device_setup;
-	klass_device->reload = fu_goodixtp_brlb_device_setup;
-	klass_device->prepare_firmware = fu_goodixtp_brlb_device_prepare_firmware;
-	klass_device->write_firmware = fu_goodixtp_brlb_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_goodixtp_brlb_device_setup;
+	device_class->reload = fu_goodixtp_brlb_device_setup;
+	device_class->prepare_firmware = fu_goodixtp_brlb_device_prepare_firmware;
+	device_class->write_firmware = fu_goodixtp_brlb_device_write_firmware;
 }

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -566,10 +566,10 @@ fu_goodixtp_gtx8_device_init(FuGoodixtpGtx8Device *self)
 static void
 fu_goodixtp_gtx8_device_class_init(FuGoodixtpGtx8DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->setup = fu_goodixtp_gtx8_device_setup;
-	klass_device->reload = fu_goodixtp_gtx8_device_setup;
-	klass_device->prepare_firmware = fu_goodixtp_gtx8_device_prepare_firmware;
-	klass_device->write_firmware = fu_goodixtp_gtx8_device_write_firmware;
+	device_class->setup = fu_goodixtp_gtx8_device_setup;
+	device_class->reload = fu_goodixtp_gtx8_device_setup;
+	device_class->prepare_firmware = fu_goodixtp_gtx8_device_prepare_firmware;
+	device_class->write_firmware = fu_goodixtp_gtx8_device_write_firmware;
 }

--- a/plugins/goodix-tp/fu-goodixtp-hid-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-hid-device.c
@@ -205,11 +205,11 @@ static void
 fu_goodixtp_hid_device_class_init(FuGoodixtpHidDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->finalize = fu_goodixtp_hid_device_finalize;
-	klass_device->to_string = fu_goodixtp_hid_device_to_string;
-	klass_device->probe = fu_goodixtp_hid_device_probe;
-	klass_device->set_progress = fu_goodixtp_hid_device_set_progress;
-	klass_device->convert_version = fu_goodixtp_hid_device_convert_version;
+	device_class->to_string = fu_goodixtp_hid_device_to_string;
+	device_class->probe = fu_goodixtp_hid_device_probe;
+	device_class->set_progress = fu_goodixtp_hid_device_set_progress;
+	device_class->convert_version = fu_goodixtp_hid_device_convert_version;
 }

--- a/plugins/gpio/fu-gpio-device.c
+++ b/plugins/gpio/fu-gpio-device.c
@@ -216,9 +216,9 @@ static void
 fu_gpio_device_class_init(FuGpioDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_gpio_device_finalize;
-	klass_device->to_string = fu_gpio_device_to_string;
-	klass_device->setup = fu_gpio_device_setup;
-	klass_device->probe = fu_gpio_device_probe;
+	device_class->to_string = fu_gpio_device_to_string;
+	device_class->setup = fu_gpio_device_setup;
+	device_class->probe = fu_gpio_device_probe;
 }

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -304,9 +304,9 @@ fu_hailuck_bl_device_init(FuHailuckBlDevice *self)
 static void
 fu_hailuck_bl_device_class_init(FuHailuckBlDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->dump_firmware = fu_hailuck_bl_device_dump_firmware;
-	klass_device->write_firmware = fu_hailuck_bl_device_write_firmware;
-	klass_device->attach = fu_hailuck_bl_device_attach;
-	klass_device->probe = fu_hailuck_bl_device_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->dump_firmware = fu_hailuck_bl_device_dump_firmware;
+	device_class->write_firmware = fu_hailuck_bl_device_write_firmware;
+	device_class->attach = fu_hailuck_bl_device_attach;
+	device_class->probe = fu_hailuck_bl_device_probe;
 }

--- a/plugins/hailuck/fu-hailuck-kbd-device.c
+++ b/plugins/hailuck/fu-hailuck-kbd-device.c
@@ -84,8 +84,8 @@ fu_hailuck_kbd_device_init(FuHailuckKbdDevice *self)
 static void
 fu_hailuck_kbd_device_class_init(FuHailuckKbdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->detach = fu_hailuck_kbd_device_detach;
-	klass_device->probe = fu_hailuck_kbd_device_probe;
-	klass_device->set_progress = fu_hailuck_kbd_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->detach = fu_hailuck_kbd_device_detach;
+	device_class->probe = fu_hailuck_kbd_device_probe;
+	device_class->set_progress = fu_hailuck_kbd_device_set_progress;
 }

--- a/plugins/hailuck/fu-hailuck-kbd-firmware.c
+++ b/plugins/hailuck/fu-hailuck-kbd-firmware.c
@@ -91,6 +91,6 @@ fu_hailuck_kbd_firmware_init(FuHailuckKbdFirmware *self)
 static void
 fu_hailuck_kbd_firmware_class_init(FuHailuckKbdFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_hailuck_kbd_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_hailuck_kbd_firmware_parse;
 }

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -235,10 +235,10 @@ fu_hailuck_tp_device_init(FuHailuckTpDevice *self)
 static void
 fu_hailuck_tp_device_class_init(FuHailuckTpDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_hailuck_tp_device_write_firmware;
-	klass_device->probe = fu_hailuck_tp_device_probe;
-	klass_device->set_progress = fu_hailuck_tp_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_hailuck_tp_device_write_firmware;
+	device_class->probe = fu_hailuck_tp_device_probe;
+	device_class->set_progress = fu_hailuck_tp_device_set_progress;
 }
 
 FuHailuckTpDevice *

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -198,14 +198,14 @@ fu_igsc_aux_device_init(FuIgscAuxDevice *self)
 static void
 fu_igsc_aux_device_class_init(FuIgscAuxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_igsc_aux_device_to_string;
-	klass_device->probe = fu_igsc_aux_device_probe;
-	klass_device->setup = fu_igsc_aux_device_setup;
-	klass_device->prepare_firmware = fu_igsc_aux_device_prepare_firmware;
-	klass_device->write_firmware = fu_igsc_aux_device_write_firmware;
-	klass_device->prepare = fu_igsc_aux_device_prepare;
-	klass_device->cleanup = fu_igsc_aux_device_cleanup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_igsc_aux_device_to_string;
+	device_class->probe = fu_igsc_aux_device_probe;
+	device_class->setup = fu_igsc_aux_device_setup;
+	device_class->prepare_firmware = fu_igsc_aux_device_prepare_firmware;
+	device_class->write_firmware = fu_igsc_aux_device_write_firmware;
+	device_class->prepare = fu_igsc_aux_device_prepare;
+	device_class->cleanup = fu_igsc_aux_device_cleanup;
 }
 
 FuIgscAuxDevice *

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -305,13 +305,13 @@ fu_igsc_aux_firmware_finalize(GObject *object)
 static void
 fu_igsc_aux_firmware_class_init(FuIgscAuxFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_igsc_aux_firmware_finalize;
-	klass_firmware->parse = fu_igsc_aux_firmware_parse;
-	klass_firmware->write = fu_igsc_aux_firmware_write;
-	klass_firmware->build = fu_igsc_aux_firmware_build;
-	klass_firmware->export = fu_igsc_aux_firmware_export;
+	firmware_class->parse = fu_igsc_aux_firmware_parse;
+	firmware_class->write = fu_igsc_aux_firmware_write;
+	firmware_class->build = fu_igsc_aux_firmware_build;
+	firmware_class->export = fu_igsc_aux_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/intel-gsc/fu-igsc-code-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-code-firmware.c
@@ -128,9 +128,9 @@ fu_igsc_code_firmware_init(FuIgscCodeFirmware *self)
 static void
 fu_igsc_code_firmware_class_init(FuIgscCodeFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_igsc_code_firmware_parse;
-	klass_firmware->export = fu_igsc_code_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_igsc_code_firmware_parse;
+	firmware_class->export = fu_igsc_code_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -832,16 +832,16 @@ fu_igsc_device_finalize(GObject *object)
 static void
 fu_igsc_device_class_init(FuIgscDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_igsc_device_finalize;
-	klass_device->set_progress = fu_igsc_device_set_progress;
-	klass_device->to_string = fu_igsc_device_to_string;
-	klass_device->open = fu_igsc_device_open;
-	klass_device->setup = fu_igsc_device_setup;
-	klass_device->probe = fu_igsc_device_probe;
-	klass_device->prepare = fu_igsc_device_prepare;
-	klass_device->cleanup = fu_igsc_device_cleanup;
-	klass_device->prepare_firmware = fu_igsc_device_prepare_firmware;
-	klass_device->write_firmware = fu_igsc_device_write_firmware;
+	device_class->set_progress = fu_igsc_device_set_progress;
+	device_class->to_string = fu_igsc_device_to_string;
+	device_class->open = fu_igsc_device_open;
+	device_class->setup = fu_igsc_device_setup;
+	device_class->probe = fu_igsc_device_probe;
+	device_class->prepare = fu_igsc_device_prepare;
+	device_class->cleanup = fu_igsc_device_cleanup;
+	device_class->prepare_firmware = fu_igsc_device_prepare_firmware;
+	device_class->write_firmware = fu_igsc_device_write_firmware;
 }

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -258,14 +258,14 @@ fu_igsc_oprom_device_init(FuIgscOpromDevice *self)
 static void
 fu_igsc_oprom_device_class_init(FuIgscOpromDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_igsc_oprom_device_to_string;
-	klass_device->probe = fu_igsc_oprom_device_probe;
-	klass_device->setup = fu_igsc_oprom_device_setup;
-	klass_device->prepare_firmware = fu_igsc_oprom_device_prepare_firmware;
-	klass_device->write_firmware = fu_igsc_oprom_device_write_firmware;
-	klass_device->prepare = fu_igsc_aux_device_prepare;
-	klass_device->cleanup = fu_igsc_aux_device_cleanup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_igsc_oprom_device_to_string;
+	device_class->probe = fu_igsc_oprom_device_probe;
+	device_class->setup = fu_igsc_oprom_device_setup;
+	device_class->prepare_firmware = fu_igsc_oprom_device_prepare_firmware;
+	device_class->write_firmware = fu_igsc_oprom_device_write_firmware;
+	device_class->prepare = fu_igsc_aux_device_prepare;
+	device_class->cleanup = fu_igsc_aux_device_cleanup;
 }
 
 FuIgscOpromDevice *

--- a/plugins/intel-gsc/fu-igsc-oprom-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-firmware.c
@@ -233,9 +233,9 @@ fu_igsc_oprom_firmware_finalize(GObject *object)
 static void
 fu_igsc_oprom_firmware_class_init(FuIgscOpromFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_igsc_oprom_firmware_finalize;
-	klass_firmware->parse = fu_igsc_oprom_firmware_parse;
-	klass_firmware->export = fu_igsc_oprom_firmware_export;
+	firmware_class->parse = fu_igsc_oprom_firmware_parse;
+	firmware_class->export = fu_igsc_oprom_firmware_export;
 }

--- a/plugins/intel-me/fu-intel-me-amt-device.c
+++ b/plugins/intel-me/fu-intel-me-amt-device.c
@@ -368,7 +368,7 @@ fu_intel_me_amt_device_init(FuIntelMeAmtDevice *self)
 static void
 fu_intel_me_amt_device_class_init(FuIntelMeAmtDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->open = fu_intel_me_amt_device_open;
-	klass_device->setup = fu_intel_me_amt_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->open = fu_intel_me_amt_device_open;
+	device_class->setup = fu_intel_me_amt_device_setup;
 }

--- a/plugins/intel-me/fu-intel-me-heci-device.c
+++ b/plugins/intel-me/fu-intel-me-heci-device.c
@@ -198,6 +198,6 @@ fu_intel_me_heci_device_init(FuIntelMeHeciDevice *self)
 static void
 fu_intel_me_heci_device_class_init(FuIntelMeHeciDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->open = fu_intel_me_heci_device_open;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->open = fu_intel_me_heci_device_open;
 }

--- a/plugins/intel-me/fu-intel-me-mca-device.c
+++ b/plugins/intel-me/fu-intel-me-mca-device.c
@@ -127,7 +127,7 @@ fu_intel_me_mca_device_init(FuIntelMeMcaDevice *self)
 static void
 fu_intel_me_mca_device_class_init(FuIntelMeMcaDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_intel_me_mca_device_setup;
-	klass_device->add_security_attrs = fu_intel_me_mca_device_add_security_attrs;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_intel_me_mca_device_setup;
+	device_class->add_security_attrs = fu_intel_me_mca_device_add_security_attrs;
 }

--- a/plugins/intel-me/fu-intel-me-mkhi-device.c
+++ b/plugins/intel-me/fu-intel-me-mkhi-device.c
@@ -86,6 +86,6 @@ fu_intel_me_mkhi_device_init(FuIntelMeMkhiDevice *self)
 static void
 fu_intel_me_mkhi_device_class_init(FuIntelMeMkhiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_intel_me_mkhi_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_intel_me_mkhi_device_setup;
 }

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -603,11 +603,11 @@ fu_intel_usb4_device_init(FuIntelUsb4Device *self)
 static void
 fu_intel_usb4_device_class_init(FuIntelUsb4DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_intel_usb4_device_to_string;
-	klass_device->setup = fu_intel_usb4_device_setup;
-	klass_device->prepare_firmware = fu_intel_usb4_device_prepare_firmware;
-	klass_device->write_firmware = fu_intel_usb4_device_write_firmware;
-	klass_device->activate = fu_intel_usb4_device_activate;
-	klass_device->set_progress = fu_thunderbolt_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_intel_usb4_device_to_string;
+	device_class->setup = fu_intel_usb4_device_setup;
+	device_class->prepare_firmware = fu_intel_usb4_device_prepare_firmware;
+	device_class->write_firmware = fu_intel_usb4_device_write_firmware;
+	device_class->activate = fu_intel_usb4_device_activate;
+	device_class->set_progress = fu_thunderbolt_device_set_progress;
 }

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -753,11 +753,11 @@ fu_jabra_gnp_device_init(FuJabraGnpDevice *self)
 static void
 fu_jabra_gnp_device_class_init(FuJabraGnpDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_jabra_gnp_device_to_string;
-	klass_device->prepare_firmware = fu_jabra_gnp_device_prepare_firmware;
-	klass_device->probe = fu_jabra_gnp_device_probe;
-	klass_device->setup = fu_jabra_gnp_device_setup;
-	klass_device->write_firmware = fu_jabra_gnp_device_write_firmware;
-	klass_device->set_progress = fu_colorhug_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_jabra_gnp_device_to_string;
+	device_class->prepare_firmware = fu_jabra_gnp_device_prepare_firmware;
+	device_class->probe = fu_jabra_gnp_device_probe;
+	device_class->setup = fu_jabra_gnp_device_setup;
+	device_class->write_firmware = fu_jabra_gnp_device_write_firmware;
+	device_class->set_progress = fu_colorhug_device_set_progress;
 }

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -180,9 +180,9 @@ fu_jabra_gnp_firmware_init(FuJabraGnpFirmware *self)
 static void
 fu_jabra_gnp_firmware_class_init(FuJabraGnpFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_jabra_gnp_firmware_parse;
-	klass_firmware->export = fu_jabra_gnp_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_jabra_gnp_firmware_parse;
+	firmware_class->export = fu_jabra_gnp_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/jabra-gnp/fu-jabra-gnp-image.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-image.c
@@ -130,8 +130,8 @@ fu_jabra_gnp_image_init(FuJabraGnpImage *self)
 static void
 fu_jabra_gnp_image_class_init(FuJabraGnpImageClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_jabra_gnp_image_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_jabra_gnp_image_export;
 }
 
 FuJabraGnpImage *

--- a/plugins/jabra/fu-jabra-device.c
+++ b/plugins/jabra/fu-jabra-device.c
@@ -160,9 +160,9 @@ static void
 fu_jabra_device_class_init(FuJabraDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_jabra_device_finalize;
-	klass_device->to_string = fu_jabra_device_to_string;
-	klass_device->prepare = fu_jabra_device_prepare;
-	klass_device->set_quirk_kv = fu_jabra_device_set_quirk_kv;
+	device_class->to_string = fu_jabra_device_to_string;
+	device_class->prepare = fu_jabra_device_prepare;
+	device_class->set_quirk_kv = fu_jabra_device_set_quirk_kv;
 }

--- a/plugins/kinetic-dp/fu-kinetic-dp-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-device.c
@@ -230,9 +230,9 @@ fu_kinetic_dp_device_setup(FuDevice *device, GError **error)
 static void
 fu_kinetic_dp_device_class_init(FuKineticDpDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_kinetic_dp_device_setup;
-	klass_device->to_string = fu_kinetic_dp_device_to_string;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_kinetic_dp_device_setup;
+	device_class->to_string = fu_kinetic_dp_device_to_string;
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -560,11 +560,11 @@ fu_kinetic_dp_puma_device_init(FuKineticDpPumaDevice *self)
 static void
 fu_kinetic_dp_puma_device_class_init(FuKineticDpPumaDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_kinetic_dp_puma_device_to_string;
-	klass_device->setup = fu_kinetic_dp_puma_device_setup;
-	klass_device->prepare = fu_kinetic_dp_puma_device_prepare;
-	klass_device->cleanup = fu_kinetic_dp_puma_device_cleanup;
-	klass_device->write_firmware = fu_kinetic_dp_puma_device_write_firmware;
-	klass_device->set_progress = fu_kinetic_dp_puma_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_kinetic_dp_puma_device_to_string;
+	device_class->setup = fu_kinetic_dp_puma_device_setup;
+	device_class->prepare = fu_kinetic_dp_puma_device_prepare;
+	device_class->cleanup = fu_kinetic_dp_puma_device_cleanup;
+	device_class->write_firmware = fu_kinetic_dp_puma_device_write_firmware;
+	device_class->set_progress = fu_kinetic_dp_puma_device_set_progress;
 }

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -282,7 +282,7 @@ fu_kinetic_dp_puma_firmware_init(FuKineticDpPumaFirmware *self)
 static void
 fu_kinetic_dp_puma_firmware_class_init(FuKineticDpPumaFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_kinetic_dp_puma_firmware_parse;
-	klass_firmware->export = fu_kinetic_dp_puma_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_kinetic_dp_puma_firmware_parse;
+	firmware_class->export = fu_kinetic_dp_puma_firmware_export;
 }

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -1021,12 +1021,12 @@ fu_kinetic_dp_secure_device_init(FuKineticDpSecureDevice *self)
 static void
 fu_kinetic_dp_secure_device_class_init(FuKineticDpSecureDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_kinetic_dp_secure_device_to_string;
-	klass_device->prepare = fu_kinetic_dp_secure_device_prepare;
-	klass_device->cleanup = fu_kinetic_dp_secure_device_cleanup;
-	klass_device->setup = fu_kinetic_dp_secure_device_setup;
-	klass_device->write_firmware = fu_kinetic_dp_secure_device_write_firmware;
-	klass_device->set_progress = fu_kinetic_dp_secure_device_set_progress;
-	klass_device->convert_version = fu_kinetic_dp_secure_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_kinetic_dp_secure_device_to_string;
+	device_class->prepare = fu_kinetic_dp_secure_device_prepare;
+	device_class->cleanup = fu_kinetic_dp_secure_device_cleanup;
+	device_class->setup = fu_kinetic_dp_secure_device_setup;
+	device_class->write_firmware = fu_kinetic_dp_secure_device_write_firmware;
+	device_class->set_progress = fu_kinetic_dp_secure_device_set_progress;
+	device_class->convert_version = fu_kinetic_dp_secure_device_convert_version;
 }

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -253,7 +253,7 @@ fu_kinetic_dp_secure_firmware_init(FuKineticDpSecureFirmware *self)
 static void
 fu_kinetic_dp_secure_firmware_class_init(FuKineticDpSecureFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_kinetic_dp_secure_firmware_parse;
-	klass_firmware->export = fu_kinetic_dp_secure_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_kinetic_dp_secure_firmware_parse;
+	firmware_class->export = fu_kinetic_dp_secure_firmware_export;
 }

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -1353,12 +1353,12 @@ fu_logitech_bulkcontroller_device_finalize(GObject *object)
 static void
 fu_logitech_bulkcontroller_device_class_init(FuLogitechBulkcontrollerDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_logitech_bulkcontroller_device_finalize;
-	klass_device->to_string = fu_logitech_bulkcontroller_device_to_string;
-	klass_device->write_firmware = fu_logitech_bulkcontroller_device_write_firmware;
-	klass_device->probe = fu_logitech_bulkcontroller_device_probe;
-	klass_device->setup = fu_logitech_bulkcontroller_device_setup;
-	klass_device->set_progress = fu_logitech_bulkcontroller_device_set_progress;
+	device_class->to_string = fu_logitech_bulkcontroller_device_to_string;
+	device_class->write_firmware = fu_logitech_bulkcontroller_device_write_firmware;
+	device_class->probe = fu_logitech_bulkcontroller_device_probe;
+	device_class->setup = fu_logitech_bulkcontroller_device_setup;
+	device_class->set_progress = fu_logitech_bulkcontroller_device_set_progress;
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -308,9 +308,9 @@ fu_logitech_hidpp_bootloader_nordic_write_firmware(FuDevice *device,
 static void
 fu_logitech_hidpp_bootloader_nordic_class_init(FuLogitechHidppBootloaderNordicClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_logitech_hidpp_bootloader_nordic_write_firmware;
-	klass_device->setup = fu_logitech_hidpp_bootloader_nordic_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_logitech_hidpp_bootloader_nordic_write_firmware;
+	device_class->setup = fu_logitech_hidpp_bootloader_nordic_setup;
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -257,9 +257,9 @@ fu_logitech_hidpp_bootloader_texas_setup(FuDevice *device, GError **error)
 static void
 fu_logitech_hidpp_bootloader_texas_class_init(FuLogitechHidppBootloaderTexasClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_logitech_hidpp_bootloader_texas_write_firmware;
-	klass_device->setup = fu_logitech_hidpp_bootloader_texas_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_logitech_hidpp_bootloader_texas_write_firmware;
+	device_class->setup = fu_logitech_hidpp_bootloader_texas_setup;
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -435,8 +435,8 @@ fu_logitech_hidpp_bootloader_init(FuLogitechHidppBootloader *self)
 static void
 fu_logitech_hidpp_bootloader_class_init(FuLogitechHidppBootloaderClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_logitech_hidpp_bootloader_to_string;
-	klass_device->attach = fu_logitech_hidpp_bootloader_attach;
-	klass_device->setup = fu_logitech_hidpp_bootloader_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_logitech_hidpp_bootloader_to_string;
+	device_class->attach = fu_logitech_hidpp_bootloader_attach;
+	device_class->setup = fu_logitech_hidpp_bootloader_setup;
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -1332,22 +1332,22 @@ fu_logitech_hidpp_device_cleanup(FuDevice *device,
 static void
 fu_logitech_hidpp_device_class_init(FuLogitechHidppDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
 	object_class->finalize = fu_logitech_hidpp_device_finalize;
-	klass_device->setup = fu_logitech_hidpp_device_setup;
-	klass_device->open = fu_logitech_hidpp_device_open;
-	klass_device->close = fu_logitech_hidpp_device_close;
-	klass_device->write_firmware = fu_logitech_hidpp_device_write_firmware;
-	klass_device->attach = fu_logitech_hidpp_device_attach_cached;
-	klass_device->detach = fu_logitech_hidpp_device_detach;
-	klass_device->poll = fu_logitech_hidpp_device_poll;
-	klass_device->to_string = fu_logitech_hidpp_device_to_string;
-	klass_device->probe = fu_logitech_hidpp_device_probe;
-	klass_device->set_quirk_kv = fu_logitech_hidpp_device_set_quirk_kv;
-	klass_device->cleanup = fu_logitech_hidpp_device_cleanup;
-	klass_device->set_progress = fu_logitech_hidpp_device_set_progress;
+	device_class->setup = fu_logitech_hidpp_device_setup;
+	device_class->open = fu_logitech_hidpp_device_open;
+	device_class->close = fu_logitech_hidpp_device_close;
+	device_class->write_firmware = fu_logitech_hidpp_device_write_firmware;
+	device_class->attach = fu_logitech_hidpp_device_attach_cached;
+	device_class->detach = fu_logitech_hidpp_device_detach;
+	device_class->poll = fu_logitech_hidpp_device_poll;
+	device_class->to_string = fu_logitech_hidpp_device_to_string;
+	device_class->probe = fu_logitech_hidpp_device_probe;
+	device_class->set_quirk_kv = fu_logitech_hidpp_device_set_quirk_kv;
+	device_class->cleanup = fu_logitech_hidpp_device_cleanup;
+	device_class->set_progress = fu_logitech_hidpp_device_set_progress;
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
@@ -108,13 +108,13 @@ fu_logitech_hidpp_radio_init(FuLogitechHidppRadio *self)
 static void
 fu_logitech_hidpp_radio_class_init(FuLogitechHidppRadioClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->detach = fu_logitech_hidpp_radio_detach;
-	klass_device->attach = fu_logitech_hidpp_radio_attach;
-	klass_device->write_firmware = fu_logitech_hidpp_radio_write_firmware;
-	klass_device->to_string = fu_logitech_hidpp_radio_to_string;
-	klass_device->set_progress = fu_logitech_hidpp_radio_set_progress;
+	device_class->detach = fu_logitech_hidpp_radio_detach;
+	device_class->attach = fu_logitech_hidpp_radio_attach;
+	device_class->write_firmware = fu_logitech_hidpp_radio_write_firmware;
+	device_class->to_string = fu_logitech_hidpp_radio_to_string;
+	device_class->set_progress = fu_logitech_hidpp_radio_set_progress;
 }
 
 FuLogitechHidppRadio *

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -477,12 +477,12 @@ fu_logitech_hidpp_runtime_bolt_setup(FuDevice *device, GError **error)
 static void
 fu_logitech_hidpp_runtime_bolt_class_init(FuLogitechHidppRuntimeBoltClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->detach = fu_logitech_hidpp_runtime_bolt_detach;
-	klass_device->setup = fu_logitech_hidpp_runtime_bolt_setup;
-	klass_device->poll = fu_logitech_hidpp_runtime_bolt_poll;
-	klass_device->to_string = fu_logitech_hidpp_runtime_bolt_to_string;
+	device_class->detach = fu_logitech_hidpp_runtime_bolt_detach;
+	device_class->setup = fu_logitech_hidpp_runtime_bolt_setup;
+	device_class->poll = fu_logitech_hidpp_runtime_bolt_poll;
+	device_class->to_string = fu_logitech_hidpp_runtime_bolt_to_string;
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -167,11 +167,11 @@ fu_logitech_hidpp_runtime_unifying_set_progress(FuDevice *self, FuProgress *prog
 static void
 fu_logitech_hidpp_runtime_unifying_class_init(FuLogitechHidppRuntimeUnifyingClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->detach = fu_logitech_hidpp_runtime_unifying_detach;
-	klass_device->setup = fu_logitech_hidpp_runtime_unifying_setup;
-	klass_device->set_progress = fu_logitech_hidpp_runtime_unifying_set_progress;
+	device_class->detach = fu_logitech_hidpp_runtime_unifying_detach;
+	device_class->setup = fu_logitech_hidpp_runtime_unifying_setup;
+	device_class->set_progress = fu_logitech_hidpp_runtime_unifying_set_progress;
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -235,14 +235,14 @@ fu_logitech_hidpp_runtime_finalize(GObject *object)
 static void
 fu_logitech_hidpp_runtime_class_init(FuLogitechHidppRuntimeClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
 	object_class->finalize = fu_logitech_hidpp_runtime_finalize;
-	klass_device->open = fu_logitech_hidpp_runtime_open;
-	klass_device->probe = fu_logitech_hidpp_runtime_probe;
-	klass_device->close = fu_logitech_hidpp_runtime_close;
-	klass_device->poll = fu_logitech_hidpp_runtime_poll;
+	device_class->open = fu_logitech_hidpp_runtime_open;
+	device_class->probe = fu_logitech_hidpp_runtime_probe;
+	device_class->close = fu_logitech_hidpp_runtime_close;
+	device_class->poll = fu_logitech_hidpp_runtime_poll;
 }
 
 static void

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -212,9 +212,9 @@ fu_logitech_rallysystem_audio_device_init(FuLogitechRallysystemAudioDevice *self
 static void
 fu_logitech_rallysystem_audio_device_class_init(FuLogitechRallysystemAudioDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_logitech_rallysystem_audio_device_probe;
-	klass_device->setup = fu_logitech_rallysystem_audio_device_setup;
-	klass_device->set_progress = fu_logitech_rallysystem_audio_device_set_progress;
-	klass_device->convert_version = fu_logitech_rallysystem_audio_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_logitech_rallysystem_audio_device_probe;
+	device_class->setup = fu_logitech_rallysystem_audio_device_setup;
+	device_class->set_progress = fu_logitech_rallysystem_audio_device_set_progress;
+	device_class->convert_version = fu_logitech_rallysystem_audio_device_convert_version;
 }

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -392,10 +392,10 @@ fu_logitech_rallysystem_tablehub_device_init(FuLogitechRallysystemTablehubDevice
 static void
 fu_logitech_rallysystem_tablehub_device_class_init(FuLogitechRallysystemTablehubDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_logitech_rallysystem_tablehub_device_to_string;
-	klass_device->write_firmware = fu_logitech_rallysystem_tablehub_device_write_firmware;
-	klass_device->probe = fu_logitech_rallysystem_tablehub_device_probe;
-	klass_device->setup = fu_logitech_rallysystem_tablehub_device_setup;
-	klass_device->set_progress = fu_logitech_rallysystem_tablehub_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_logitech_rallysystem_tablehub_device_to_string;
+	device_class->write_firmware = fu_logitech_rallysystem_tablehub_device_write_firmware;
+	device_class->probe = fu_logitech_rallysystem_tablehub_device_probe;
+	device_class->setup = fu_logitech_rallysystem_tablehub_device_setup;
+	device_class->set_progress = fu_logitech_rallysystem_tablehub_device_set_progress;
 }

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -649,12 +649,12 @@ static void
 fu_logitech_scribe_device_class_init(FuLogitechScribeDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_logitech_scribe_device_finalize;
-	klass_device->to_string = fu_logitech_scribe_device_to_string;
-	klass_device->write_firmware = fu_logitech_scribe_device_write_firmware;
-	klass_device->probe = fu_logitech_scribe_device_probe;
-	klass_device->setup = fu_logitech_scribe_device_setup;
-	klass_device->set_progress = fu_logitech_scribe_device_set_progress;
-	klass_device->convert_version = fu_logitech_scribe_device_convert_version;
+	device_class->to_string = fu_logitech_scribe_device_to_string;
+	device_class->write_firmware = fu_logitech_scribe_device_write_firmware;
+	device_class->probe = fu_logitech_scribe_device_probe;
+	device_class->setup = fu_logitech_scribe_device_setup;
+	device_class->set_progress = fu_logitech_scribe_device_set_progress;
+	device_class->convert_version = fu_logitech_scribe_device_convert_version;
 }

--- a/plugins/logitech-tap/fu-logitech-tap-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-device.c
@@ -43,7 +43,7 @@ static void
 fu_logitech_tap_device_class_init(FuLogitechTapDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_logitech_tap_device_finalize;
-	klass_device->set_progress = fu_logitech_tap_device_set_progress;
+	device_class->set_progress = fu_logitech_tap_device_set_progress;
 }

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -505,9 +505,9 @@ fu_logitech_tap_hdmi_device_init(FuLogitechTapHdmiDevice *self)
 static void
 fu_logitech_tap_hdmi_device_class_init(FuLogitechTapHdmiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_logitech_tap_hdmi_device_probe;
-	klass_device->setup = fu_logitech_tap_hdmi_device_setup;
-	klass_device->set_progress = fu_logitech_tap_hdmi_device_set_progress;
-	klass_device->write_firmware = fu_logitech_tap_hdmi_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_logitech_tap_hdmi_device_probe;
+	device_class->setup = fu_logitech_tap_hdmi_device_setup;
+	device_class->set_progress = fu_logitech_tap_hdmi_device_set_progress;
+	device_class->write_firmware = fu_logitech_tap_hdmi_device_write_firmware;
 }

--- a/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
@@ -358,9 +358,9 @@ fu_logitech_tap_sensor_device_init(FuLogitechTapSensorDevice *self)
 static void
 fu_logitech_tap_sensor_device_class_init(FuLogitechTapSensorDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_logitech_tap_sensor_device_probe;
-	klass_device->setup = fu_logitech_tap_sensor_device_setup;
-	klass_device->set_progress = fu_logitech_tap_sensor_device_set_progress;
-	klass_device->convert_version = fu_logitech_tap_sensor_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_logitech_tap_sensor_device_probe;
+	device_class->setup = fu_logitech_tap_sensor_device_setup;
+	device_class->set_progress = fu_logitech_tap_sensor_device_set_progress;
+	device_class->convert_version = fu_logitech_tap_sensor_device_convert_version;
 }

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -986,16 +986,16 @@ fu_mediatek_scaler_device_init(FuMediatekScalerDevice *self)
 static void
 fu_mediatek_scaler_device_class_init(FuMediatekScalerDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_mediatek_scaler_device_to_string;
-	klass_device->convert_version = fu_mediatek_scaler_device_convert_version;
-	klass_device->probe = fu_mediatek_scaler_device_probe;
-	klass_device->setup = fu_mediatek_scaler_device_setup;
-	klass_device->open = fu_mediatek_scaler_device_open;
-	klass_device->close = fu_mediatek_scaler_device_close;
-	klass_device->prepare_firmware = fu_mediatek_scaler_device_prepare_firmware;
-	klass_device->write_firmware = fu_mediatek_scaler_device_write_firmware;
-	klass_device->attach = fu_mediatek_scaler_device_attach;
-	klass_device->reload = fu_mediatek_scaler_device_setup;
-	klass_device->set_progress = fu_mediatek_scaler_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_mediatek_scaler_device_to_string;
+	device_class->convert_version = fu_mediatek_scaler_device_convert_version;
+	device_class->probe = fu_mediatek_scaler_device_probe;
+	device_class->setup = fu_mediatek_scaler_device_setup;
+	device_class->open = fu_mediatek_scaler_device_open;
+	device_class->close = fu_mediatek_scaler_device_close;
+	device_class->prepare_firmware = fu_mediatek_scaler_device_prepare_firmware;
+	device_class->write_firmware = fu_mediatek_scaler_device_write_firmware;
+	device_class->attach = fu_mediatek_scaler_device_attach;
+	device_class->reload = fu_mediatek_scaler_device_setup;
+	device_class->set_progress = fu_mediatek_scaler_device_set_progress;
 }

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
@@ -78,8 +78,8 @@ fu_mediatek_scaler_firmware_init(FuMediatekScalerFirmware *self)
 static void
 fu_mediatek_scaler_firmware_class_init(FuMediatekScalerFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_mediatek_scaler_firmware_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_mediatek_scaler_firmware_parse;
 }
 
 FuFirmware *

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1989,19 +1989,19 @@ static void
 fu_mm_device_class_init(FuMmDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_mm_device_finalize;
-	klass_device->setup = fu_mm_device_setup;
-	klass_device->reload = fu_mm_device_setup;
-	klass_device->to_string = fu_mm_device_to_string;
-	klass_device->set_quirk_kv = fu_mm_device_set_quirk_kv;
-	klass_device->probe = fu_mm_device_probe;
-	klass_device->detach = fu_mm_device_detach;
-	klass_device->write_firmware = fu_mm_device_write_firmware;
-	klass_device->attach = fu_mm_device_attach;
-	klass_device->cleanup = fu_mm_device_cleanup;
-	klass_device->set_progress = fu_mm_device_set_progress;
-	klass_device->incorporate = fu_mm_device_incorporate;
+	device_class->setup = fu_mm_device_setup;
+	device_class->reload = fu_mm_device_setup;
+	device_class->to_string = fu_mm_device_to_string;
+	device_class->set_quirk_kv = fu_mm_device_set_quirk_kv;
+	device_class->probe = fu_mm_device_probe;
+	device_class->detach = fu_mm_device_detach;
+	device_class->write_firmware = fu_mm_device_write_firmware;
+	device_class->attach = fu_mm_device_attach;
+	device_class->cleanup = fu_mm_device_cleanup;
+	device_class->set_progress = fu_mm_device_set_progress;
+	device_class->incorporate = fu_mm_device_incorporate;
 
 	/**
 	 * FuMmDevice::attach-finished:

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -545,13 +545,13 @@ fu_mtd_device_init(FuMtdDevice *self)
 static void
 fu_mtd_device_class_init(FuMtdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->open = fu_mtd_device_open;
-	klass_device->probe = fu_mtd_device_probe;
-	klass_device->setup = fu_mtd_device_setup;
-	klass_device->to_string = fu_mtd_device_to_string;
-	klass_device->dump_firmware = fu_mtd_device_dump_firmware;
-	klass_device->read_firmware = fu_mtd_device_read_firmware;
-	klass_device->write_firmware = fu_mtd_device_write_firmware;
-	klass_device->set_quirk_kv = fu_mtd_device_set_quirk_kv;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->open = fu_mtd_device_open;
+	device_class->probe = fu_mtd_device_probe;
+	device_class->setup = fu_mtd_device_setup;
+	device_class->to_string = fu_mtd_device_to_string;
+	device_class->dump_firmware = fu_mtd_device_dump_firmware;
+	device_class->read_firmware = fu_mtd_device_read_firmware;
+	device_class->write_firmware = fu_mtd_device_write_firmware;
+	device_class->set_quirk_kv = fu_mtd_device_set_quirk_kv;
 }

--- a/plugins/mtd/fu-mtd-ifd-device.c
+++ b/plugins/mtd/fu-mtd-ifd-device.c
@@ -84,9 +84,9 @@ fu_mtd_ifd_device_init(FuMtdIfdDevice *self)
 static void
 fu_mtd_ifd_device_class_init(FuMtdIfdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_mtd_ifd_device_probe;
-	klass_device->add_security_attrs = fu_mtd_ifd_device_add_security_attrs;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_mtd_ifd_device_probe;
+	device_class->add_security_attrs = fu_mtd_ifd_device_add_security_attrs;
 }
 
 FuMtdIfdDevice *

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -158,6 +158,6 @@ fu_nitrokey_device_init(FuNitrokeyDevice *self)
 static void
 fu_nitrokey_device_class_init(FuNitrokeyDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_nitrokey_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_nitrokey_device_setup;
 }

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -183,6 +183,6 @@ fu_nordic_hid_archive_init(FuNordicHidArchive *self)
 static void
 fu_nordic_hid_archive_class_init(FuNordicHidArchiveClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_nordic_hid_archive_parse;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_nordic_hid_archive_parse;
 }

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -1682,16 +1682,16 @@ fu_nordic_hid_cfg_channel_finalize(GObject *object)
 static void
 fu_nordic_hid_cfg_channel_class_init(FuNordicHidCfgChannelClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	klass_device->probe = fu_nordic_hid_cfg_channel_probe;
-	klass_device->set_progress = fu_nordic_hid_cfg_channel_set_progress;
-	klass_device->set_quirk_kv = fu_nordic_hid_cfg_channel_set_quirk_kv;
-	klass_device->setup = fu_nordic_hid_cfg_channel_setup;
-	klass_device->poll = fu_nordic_hid_cfg_channel_poll_peers;
-	klass_device->to_string = fu_nordic_hid_cfg_channel_to_string;
-	klass_device->write_firmware = fu_nordic_hid_cfg_channel_write_firmware;
+	device_class->probe = fu_nordic_hid_cfg_channel_probe;
+	device_class->set_progress = fu_nordic_hid_cfg_channel_set_progress;
+	device_class->set_quirk_kv = fu_nordic_hid_cfg_channel_set_quirk_kv;
+	device_class->setup = fu_nordic_hid_cfg_channel_setup;
+	device_class->poll = fu_nordic_hid_cfg_channel_poll_peers;
+	device_class->to_string = fu_nordic_hid_cfg_channel_to_string;
+	device_class->write_firmware = fu_nordic_hid_cfg_channel_write_firmware;
 	object_class->finalize = fu_nordic_hid_cfg_channel_finalize;
 }
 

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -128,7 +128,7 @@ fu_nordic_hid_firmware_b0_init(FuNordicHidFirmwareB0 *self)
 static void
 fu_nordic_hid_firmware_b0_class_init(FuNordicHidFirmwareB0Class *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_nordic_hid_firmware_b0_parse;
-	klass_firmware->write = fu_nordic_hid_firmware_b0_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_nordic_hid_firmware_b0_parse;
+	firmware_class->write = fu_nordic_hid_firmware_b0_write;
 }

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -142,7 +142,7 @@ fu_nordic_hid_firmware_mcuboot_init(FuNordicHidFirmwareMcuboot *self)
 static void
 fu_nordic_hid_firmware_mcuboot_class_init(FuNordicHidFirmwareMcubootClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_nordic_hid_firmware_mcuboot_parse;
-	klass_firmware->write = fu_nordic_hid_firmware_mcuboot_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_nordic_hid_firmware_mcuboot_parse;
+	firmware_class->write = fu_nordic_hid_firmware_mcuboot_write;
 }

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -65,9 +65,9 @@ fu_nordic_hid_firmware_init(FuNordicHidFirmware *self)
 static void
 fu_nordic_hid_firmware_class_init(FuNordicHidFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 
-	klass_firmware->export = fu_nordic_hid_firmware_export;
-	klass_firmware->get_checksum = fu_nordic_hid_firmware_get_checksum;
-	klass_firmware->parse = fu_nordic_hid_firmware_parse;
+	firmware_class->export = fu_nordic_hid_firmware_export;
+	firmware_class->get_checksum = fu_nordic_hid_firmware_get_checksum;
+	firmware_class->parse = fu_nordic_hid_firmware_parse;
 }

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -488,14 +488,14 @@ static void
 fu_nvme_device_class_init(FuNvmeDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_nvme_device_finalize;
-	klass_device->to_string = fu_nvme_device_to_string;
-	klass_device->set_quirk_kv = fu_nvme_device_set_quirk_kv;
-	klass_device->setup = fu_nvme_device_setup;
-	klass_device->write_firmware = fu_nvme_device_write_firmware;
-	klass_device->probe = fu_nvme_device_probe;
-	klass_device->set_progress = fu_nvme_device_set_progress;
+	device_class->to_string = fu_nvme_device_to_string;
+	device_class->set_quirk_kv = fu_nvme_device_set_quirk_kv;
+	device_class->setup = fu_nvme_device_setup;
+	device_class->write_firmware = fu_nvme_device_write_firmware;
+	device_class->probe = fu_nvme_device_probe;
+	device_class->set_progress = fu_nvme_device_set_progress;
 }
 
 FuNvmeDevice *

--- a/plugins/optionrom/fu-optionrom-device.c
+++ b/plugins/optionrom/fu-optionrom-device.c
@@ -78,8 +78,8 @@ static void
 fu_optionrom_device_class_init(FuOptionromDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_optionrom_device_finalize;
-	klass_device->dump_firmware = fu_optionrom_device_dump_firmware;
-	klass_device->probe = fu_optionrom_device_probe;
+	device_class->dump_firmware = fu_optionrom_device_dump_firmware;
+	device_class->probe = fu_optionrom_device_probe;
 }

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -840,18 +840,18 @@ fu_parade_lspcon_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_parade_lspcon_device_class_init(FuParadeLspconDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	GObjectClass *klass_object = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	klass_object->finalize = fu_parade_lspcon_device_finalize;
-	klass_device->set_quirk_kv = fu_parade_lspcon_device_set_quirk_kv;
-	klass_device->probe = fu_parade_lspcon_device_probe;
-	klass_device->setup = fu_parade_lspcon_device_reload;
-	klass_device->open = fu_parade_lspcon_device_open;
-	klass_device->reload = fu_parade_lspcon_device_reload;
-	klass_device->detach = fu_parade_lspcon_device_detach;
-	klass_device->write_firmware = fu_parade_lspcon_device_write_firmware;
-	klass_device->attach = fu_parade_lspcon_device_attach;
-	klass_device->dump_firmware = fu_parade_lspcon_device_dump_firmware;
-	klass_device->set_progress = fu_parade_lspcon_device_set_progress;
+	object_class->finalize = fu_parade_lspcon_device_finalize;
+	device_class->set_quirk_kv = fu_parade_lspcon_device_set_quirk_kv;
+	device_class->probe = fu_parade_lspcon_device_probe;
+	device_class->setup = fu_parade_lspcon_device_reload;
+	device_class->open = fu_parade_lspcon_device_open;
+	device_class->reload = fu_parade_lspcon_device_reload;
+	device_class->detach = fu_parade_lspcon_device_detach;
+	device_class->write_firmware = fu_parade_lspcon_device_write_firmware;
+	device_class->attach = fu_parade_lspcon_device_attach;
+	device_class->dump_firmware = fu_parade_lspcon_device_dump_firmware;
+	device_class->set_progress = fu_parade_lspcon_device_set_progress;
 }

--- a/plugins/pci-psp/fu-pci-psp-device.c
+++ b/plugins/pci-psp/fu-pci-psp-device.c
@@ -385,7 +385,7 @@ fu_pci_psp_device_init(FuPciPspDevice *self)
 static void
 fu_pci_psp_device_class_init(FuPciPspDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_pci_psp_device_probe;
-	klass_device->add_security_attrs = fu_pci_psp_device_add_security_attrs;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_pci_psp_device_probe;
+	device_class->add_security_attrs = fu_pci_psp_device_add_security_attrs;
 }

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -1022,12 +1022,12 @@ static void
 fu_pxi_ble_device_class_init(FuPxiBleDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_pxi_ble_device_finalize;
-	klass_device->probe = fu_pxi_ble_device_probe;
-	klass_device->setup = fu_pxi_ble_device_setup;
-	klass_device->to_string = fu_pxi_ble_device_to_string;
-	klass_device->write_firmware = fu_pxi_ble_device_write_firmware;
-	klass_device->prepare_firmware = fu_pxi_ble_device_prepare_firmware;
-	klass_device->set_progress = fu_pxi_ble_device_set_progress;
+	device_class->probe = fu_pxi_ble_device_probe;
+	device_class->setup = fu_pxi_ble_device_setup;
+	device_class->to_string = fu_pxi_ble_device_to_string;
+	device_class->write_firmware = fu_pxi_ble_device_write_firmware;
+	device_class->prepare_firmware = fu_pxi_ble_device_prepare_firmware;
+	device_class->set_progress = fu_pxi_ble_device_set_progress;
 }

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -291,13 +291,13 @@ static void
 fu_pxi_firmware_class_init(FuPxiFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_pxi_firmware_finalize;
-	klass_firmware->validate = fu_pxi_firmware_validate;
-	klass_firmware->parse = fu_pxi_firmware_parse;
-	klass_firmware->build = fu_pxi_firmware_build;
-	klass_firmware->write = fu_pxi_firmware_write;
-	klass_firmware->export = fu_pxi_firmware_export;
+	firmware_class->validate = fu_pxi_firmware_validate;
+	firmware_class->parse = fu_pxi_firmware_parse;
+	firmware_class->build = fu_pxi_firmware_build;
+	firmware_class->write = fu_pxi_firmware_write;
+	firmware_class->export = fu_pxi_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -924,11 +924,11 @@ fu_pxi_receiver_device_init(FuPxiReceiverDevice *self)
 static void
 fu_pxi_receiver_device_class_init(FuPxiReceiverDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_pxi_receiver_device_to_string;
-	klass_device->setup = fu_pxi_receiver_device_setup;
-	klass_device->probe = fu_pxi_receiver_device_probe;
-	klass_device->write_firmware = fu_pxi_receiver_device_write_firmware;
-	klass_device->prepare_firmware = fu_pxi_receiver_device_prepare_firmware;
-	klass_device->set_progress = fu_pxi_receiver_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_pxi_receiver_device_to_string;
+	device_class->setup = fu_pxi_receiver_device_setup;
+	device_class->probe = fu_pxi_receiver_device_probe;
+	device_class->write_firmware = fu_pxi_receiver_device_write_firmware;
+	device_class->prepare_firmware = fu_pxi_receiver_device_prepare_firmware;
+	device_class->set_progress = fu_pxi_receiver_device_set_progress;
 }

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -787,11 +787,11 @@ fu_pxi_wireless_device_init(FuPxiWirelessDevice *self)
 static void
 fu_pxi_wireless_device_class_init(FuPxiWirelessDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_pxi_wireless_device_write_firmware;
-	klass_device->to_string = fu_pxi_wireless_device_to_string;
-	klass_device->prepare_firmware = fu_pxi_wireless_device_prepare_firmware;
-	klass_device->set_progress = fu_pxi_wireless_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_pxi_wireless_device_write_firmware;
+	device_class->to_string = fu_pxi_wireless_device_to_string;
+	device_class->prepare_firmware = fu_pxi_wireless_device_prepare_firmware;
+	device_class->set_progress = fu_pxi_wireless_device_set_progress;
 }
 
 FuPxiWirelessDevice *

--- a/plugins/qsi-dock/fu-qsi-dock-child-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-child-device.c
@@ -75,10 +75,10 @@ fu_qsi_dock_child_device_init(FuQsiDockChildDevice *self)
 static void
 fu_qsi_dock_child_device_class_init(FuQsiDockChildDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_qsi_dock_child_device_to_string;
-	klass_device->prepare_firmware = fu_qsi_dock_mcu_device_prepare_firmware;
-	klass_device->write_firmware = fu_qsi_dock_mcu_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_qsi_dock_child_device_to_string;
+	device_class->prepare_firmware = fu_qsi_dock_mcu_device_prepare_firmware;
+	device_class->write_firmware = fu_qsi_dock_mcu_device_write_firmware;
 }
 
 FuDevice *

--- a/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
@@ -581,10 +581,10 @@ fu_qsi_dock_mcu_device_init(FuQsiDockMcuDevice *self)
 static void
 fu_qsi_dock_mcu_device_class_init(FuQsiDockMcuDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->setup = fu_qsi_dock_mcu_device_setup;
-	klass_device->attach = fu_qsi_dock_mcu_device_attach;
-	klass_device->set_progress = fu_qsi_dock_mcu_device_set_progress;
-	klass_device->write_firmware = fu_qsi_dock_mcu_device_write_firmware;
+	device_class->setup = fu_qsi_dock_mcu_device_setup;
+	device_class->attach = fu_qsi_dock_mcu_device_attach;
+	device_class->set_progress = fu_qsi_dock_mcu_device_set_progress;
+	device_class->write_firmware = fu_qsi_dock_mcu_device_write_firmware;
 }

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -957,20 +957,20 @@ fu_realtek_mst_device_finalize(GObject *object)
 static void
 fu_realtek_mst_device_class_init(FuRealtekMstDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	GObjectClass *klass_object = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
-	klass_object->finalize = fu_realtek_mst_device_finalize;
-	klass_device->probe = fu_realtek_mst_device_probe;
-	klass_device->set_quirk_kv = fu_realtek_mst_device_set_quirk_kv;
-	klass_device->setup = fu_realtek_mst_device_probe_version;
-	klass_device->detach = fu_realtek_mst_device_detach;
-	klass_device->attach = fu_realtek_mst_device_attach;
-	klass_device->write_firmware = fu_realtek_mst_device_write_firmware;
-	klass_device->reload = fu_realtek_mst_device_probe_version;
+	object_class->finalize = fu_realtek_mst_device_finalize;
+	device_class->probe = fu_realtek_mst_device_probe;
+	device_class->set_quirk_kv = fu_realtek_mst_device_set_quirk_kv;
+	device_class->setup = fu_realtek_mst_device_probe_version;
+	device_class->detach = fu_realtek_mst_device_detach;
+	device_class->attach = fu_realtek_mst_device_attach;
+	device_class->write_firmware = fu_realtek_mst_device_write_firmware;
+	device_class->reload = fu_realtek_mst_device_probe_version;
 	/* read active image */
-	klass_device->read_firmware = fu_realtek_mst_device_read_firmware;
+	device_class->read_firmware = fu_realtek_mst_device_read_firmware;
 	/* dump whole flash */
-	klass_device->dump_firmware = fu_realtek_mst_device_dump_firmware;
-	klass_device->set_progress = fu_realtek_mst_device_set_progress;
+	device_class->dump_firmware = fu_realtek_mst_device_dump_firmware;
+	device_class->set_progress = fu_realtek_mst_device_set_progress;
 }

--- a/plugins/redfish/fu-ipmi-device.c
+++ b/plugins/redfish/fu-ipmi-device.c
@@ -729,10 +729,10 @@ fu_ipmi_device_init(FuIpmiDevice *self)
 static void
 fu_ipmi_device_class_init(FuIpmiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_ipmi_device_probe;
-	klass_device->setup = fu_ipmi_device_setup;
-	klass_device->to_string = fu_ipmi_device_to_string;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_ipmi_device_probe;
+	device_class->setup = fu_ipmi_device_setup;
+	device_class->to_string = fu_ipmi_device_to_string;
 }
 
 FuIpmiDevice *

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -503,11 +503,11 @@ static void
 fu_redfish_backend_class_init(FuRedfishBackendClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
-	klass_backend->coldplug = fu_redfish_backend_coldplug;
-	klass_backend->setup = fu_redfish_backend_setup;
-	klass_backend->invalidate = fu_redfish_backend_invalidate;
-	klass_backend->to_string = fu_redfish_backend_to_string;
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
+	backend_class->coldplug = fu_redfish_backend_coldplug;
+	backend_class->setup = fu_redfish_backend_setup;
+	backend_class->invalidate = fu_redfish_backend_invalidate;
+	backend_class->to_string = fu_redfish_backend_to_string;
 	object_class->finalize = fu_redfish_backend_finalize;
 }
 

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -900,15 +900,15 @@ fu_redfish_device_class_init(FuRedfishDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->get_property = fu_redfish_device_get_property;
 	object_class->set_property = fu_redfish_device_set_property;
 	object_class->finalize = fu_redfish_device_finalize;
 
-	klass_device->to_string = fu_redfish_device_to_string;
-	klass_device->probe = fu_redfish_device_probe;
-	klass_device->set_quirk_kv = fu_redfish_device_set_quirk_kv;
+	device_class->to_string = fu_redfish_device_to_string;
+	device_class->probe = fu_redfish_device_probe;
+	device_class->set_quirk_kv = fu_redfish_device_set_quirk_kv;
 
 	/**
 	 * FuRedfishDevice:backend:

--- a/plugins/redfish/fu-redfish-legacy-device.c
+++ b/plugins/redfish/fu-redfish-legacy-device.c
@@ -138,9 +138,9 @@ fu_redfish_legacy_device_init(FuRedfishLegacyDevice *self)
 static void
 fu_redfish_legacy_device_class_init(FuRedfishLegacyDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->attach = fu_redfish_legacy_device_attach;
-	klass_device->detach = fu_redfish_legacy_device_detach;
-	klass_device->write_firmware = fu_redfish_legacy_device_write_firmware;
-	klass_device->set_progress = fu_redfish_legacy_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->attach = fu_redfish_legacy_device_attach;
+	device_class->detach = fu_redfish_legacy_device_detach;
+	device_class->write_firmware = fu_redfish_legacy_device_write_firmware;
+	device_class->set_progress = fu_redfish_legacy_device_set_progress;
 }

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -144,7 +144,7 @@ fu_redfish_multipart_device_init(FuRedfishMultipartDevice *self)
 static void
 fu_redfish_multipart_device_class_init(FuRedfishMultipartDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_redfish_multipart_device_write_firmware;
-	klass_device->set_progress = fu_redfish_multipart_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_redfish_multipart_device_write_firmware;
+	device_class->set_progress = fu_redfish_multipart_device_set_progress;
 }

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -406,12 +406,12 @@ static void
 fu_redfish_smbios_class_init(FuRedfishSmbiosClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_redfish_smbios_finalize;
-	klass_firmware->parse = fu_redfish_smbios_parse;
-	klass_firmware->write = fu_redfish_smbios_write;
-	klass_firmware->build = fu_redfish_smbios_build;
-	klass_firmware->export = fu_redfish_smbios_export;
+	firmware_class->parse = fu_redfish_smbios_parse;
+	firmware_class->write = fu_redfish_smbios_write;
+	firmware_class->build = fu_redfish_smbios_build;
+	firmware_class->export = fu_redfish_smbios_export;
 }
 
 FuRedfishSmbios *

--- a/plugins/redfish/fu-redfish-smc-device.c
+++ b/plugins/redfish/fu-redfish-smc-device.c
@@ -235,7 +235,7 @@ fu_redfish_smc_device_init(FuRedfishSmcDevice *self)
 static void
 fu_redfish_smc_device_class_init(FuRedfishSmcDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_redfish_smc_device_write_firmware;
-	klass_device->set_progress = fu_redfish_smc_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_redfish_smc_device_write_firmware;
+	device_class->set_progress = fu_redfish_smc_device_set_progress;
 }

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -425,10 +425,10 @@ fu_rts54hid_device_init(FuRts54HidDevice *self)
 static void
 fu_rts54hid_device_class_init(FuRts54HidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_rts54hid_device_write_firmware;
-	klass_device->to_string = fu_rts54hid_device_to_string;
-	klass_device->setup = fu_rts54hid_device_setup;
-	klass_device->close = fu_rts54hid_device_close;
-	klass_device->set_progress = fu_rts54hid_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_rts54hid_device_write_firmware;
+	device_class->to_string = fu_rts54hid_device_to_string;
+	device_class->setup = fu_rts54hid_device_setup;
+	device_class->close = fu_rts54hid_device_close;
+	device_class->set_progress = fu_rts54hid_device_set_progress;
 }

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -266,8 +266,8 @@ fu_rts54hid_module_init(FuRts54HidModule *self)
 static void
 fu_rts54hid_module_class_init(FuRts54HidModuleClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_rts54hid_module_write_firmware;
-	klass_device->to_string = fu_rts54hid_module_to_string;
-	klass_device->set_quirk_kv = fu_rts54hid_module_set_quirk_kv;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_rts54hid_module_write_firmware;
+	device_class->to_string = fu_rts54hid_module_to_string;
+	device_class->set_quirk_kv = fu_rts54hid_module_set_quirk_kv;
 }

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -560,11 +560,11 @@ fu_rts54hub_device_init(FuRts54HubDevice *self)
 static void
 fu_rts54hub_device_class_init(FuRts54HubDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_rts54hub_device_write_firmware;
-	klass_device->setup = fu_rts54hub_device_setup;
-	klass_device->to_string = fu_rts54hub_device_to_string;
-	klass_device->prepare_firmware = fu_rts54hub_device_prepare_firmware;
-	klass_device->close = fu_rts54hub_device_close;
-	klass_device->set_progress = fu_rts54hub_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_rts54hub_device_write_firmware;
+	device_class->setup = fu_rts54hub_device_setup;
+	device_class->to_string = fu_rts54hub_device_to_string;
+	device_class->prepare_firmware = fu_rts54hub_device_prepare_firmware;
+	device_class->close = fu_rts54hub_device_close;
+	device_class->set_progress = fu_rts54hub_device_set_progress;
 }

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -356,10 +356,10 @@ fu_rts54hub_rtd21xx_background_init(FuRts54hubRtd21xxBackground *self)
 static void
 fu_rts54hub_rtd21xx_background_class_init(FuRts54hubRtd21xxBackgroundClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_rts54hub_rtd21xx_background_setup;
-	klass_device->reload = fu_rts54hub_rtd21xx_background_reload;
-	klass_device->attach = fu_rts54hub_rtd21xx_background_attach;
-	klass_device->detach = fu_rts54hub_rtd21xx_background_detach;
-	klass_device->write_firmware = fu_rts54hub_rtd21xx_background_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_rts54hub_rtd21xx_background_setup;
+	device_class->reload = fu_rts54hub_rtd21xx_background_reload;
+	device_class->attach = fu_rts54hub_rtd21xx_background_attach;
+	device_class->detach = fu_rts54hub_rtd21xx_background_detach;
+	device_class->write_firmware = fu_rts54hub_rtd21xx_background_write_firmware;
 }

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
@@ -214,7 +214,7 @@ fu_rts54hub_rtd21xx_device_init(FuRts54hubRtd21xxDevice *self)
 static void
 fu_rts54hub_rtd21xx_device_class_init(FuRts54hubRtd21xxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_rts54hub_rtd21xx_device_to_string;
-	klass_device->set_quirk_kv = fu_rts54hub_rtd21xx_device_set_quirk_kv;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_rts54hub_rtd21xx_device_to_string;
+	device_class->set_quirk_kv = fu_rts54hub_rtd21xx_device_set_quirk_kv;
 }

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -398,10 +398,10 @@ fu_rts54hub_rtd21xx_foreground_init(FuRts54hubRtd21xxForeground *self)
 static void
 fu_rts54hub_rtd21xx_foreground_class_init(FuRts54hubRtd21xxForegroundClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_rts54hub_rtd21xx_foreground_setup;
-	klass_device->reload = fu_rts54hub_rtd21xx_foreground_reload;
-	klass_device->attach = fu_rts54hub_rtd21xx_foreground_attach;
-	klass_device->detach = fu_rts54hub_rtd21xx_foreground_detach;
-	klass_device->write_firmware = fu_rts54hub_rtd21xx_foreground_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_rts54hub_rtd21xx_foreground_setup;
+	device_class->reload = fu_rts54hub_rtd21xx_foreground_reload;
+	device_class->attach = fu_rts54hub_rtd21xx_foreground_attach;
+	device_class->detach = fu_rts54hub_rtd21xx_foreground_detach;
+	device_class->write_firmware = fu_rts54hub_rtd21xx_foreground_write_firmware;
 }

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -288,10 +288,10 @@ fu_scsi_device_init(FuScsiDevice *self)
 static void
 fu_scsi_device_class_init(FuScsiDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_scsi_device_to_string;
-	klass_device->probe = fu_scsi_device_probe;
-	klass_device->prepare_firmware = fu_scsi_device_prepare_firmware;
-	klass_device->write_firmware = fu_scsi_device_write_firmware;
-	klass_device->set_progress = fu_scsi_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_scsi_device_to_string;
+	device_class->probe = fu_scsi_device_probe;
+	device_class->prepare_firmware = fu_scsi_device_prepare_firmware;
+	device_class->write_firmware = fu_scsi_device_write_firmware;
+	device_class->set_progress = fu_scsi_device_set_progress;
 }

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -173,7 +173,7 @@ fu_steelseries_device_init(FuSteelseriesDevice *self)
 static void
 fu_steelseries_device_class_init(FuSteelseriesDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_steelseries_device_to_string;
-	klass_device->probe = fu_steelseries_device_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_steelseries_device_to_string;
+	device_class->probe = fu_steelseries_device_probe;
 }

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -85,9 +85,9 @@ fu_steelseries_firmware_init(FuSteelseriesFirmware *self)
 static void
 fu_steelseries_firmware_class_init(FuSteelseriesFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_steelseries_firmware_parse;
-	klass_firmware->export = fu_steelseries_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_steelseries_firmware_parse;
+	firmware_class->export = fu_steelseries_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/steelseries/fu-steelseries-fizz-hid.c
+++ b/plugins/steelseries/fu-steelseries-fizz-hid.c
@@ -195,10 +195,10 @@ fu_steelseries_fizz_hid_setup(FuDevice *device, GError **error)
 static void
 fu_steelseries_fizz_hid_class_init(FuSteelseriesFizzHidClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->setup = fu_steelseries_fizz_hid_setup;
-	klass_device->detach = fu_steelseries_fizz_hid_detach;
+	device_class->setup = fu_steelseries_fizz_hid_setup;
+	device_class->detach = fu_steelseries_fizz_hid_detach;
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -378,16 +378,16 @@ fu_steelseries_fizz_tunnel_convert_version(FuDevice *device, guint64 version_raw
 static void
 fu_steelseries_fizz_tunnel_class_init(FuSteelseriesFizzTunnelClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->attach = fu_steelseries_fizz_tunnel_attach;
-	klass_device->probe = fu_steelseries_fizz_tunnel_probe;
-	klass_device->setup = fu_steelseries_fizz_tunnel_setup;
-	klass_device->poll = fu_steelseries_fizz_tunnel_poll;
-	klass_device->write_firmware = fu_steelseries_fizz_tunnel_write_firmware;
-	klass_device->read_firmware = fu_steelseries_fizz_tunnel_read_firmware;
-	klass_device->set_progress = fu_steelseries_fizz_tunnel_set_progress;
-	klass_device->convert_version = fu_steelseries_fizz_tunnel_convert_version;
+	device_class->attach = fu_steelseries_fizz_tunnel_attach;
+	device_class->probe = fu_steelseries_fizz_tunnel_probe;
+	device_class->setup = fu_steelseries_fizz_tunnel_setup;
+	device_class->poll = fu_steelseries_fizz_tunnel_poll;
+	device_class->write_firmware = fu_steelseries_fizz_tunnel_write_firmware;
+	device_class->read_firmware = fu_steelseries_fizz_tunnel_read_firmware;
+	device_class->set_progress = fu_steelseries_fizz_tunnel_set_progress;
+	device_class->convert_version = fu_steelseries_fizz_tunnel_convert_version;
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -916,13 +916,13 @@ fu_steelseries_fizz_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_steelseries_fizz_class_init(FuSteelseriesFizzClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->attach = fu_steelseries_fizz_attach;
-	klass_device->setup = fu_steelseries_fizz_setup;
-	klass_device->write_firmware = fu_steelseries_fizz_write_firmware;
-	klass_device->read_firmware = fu_steelseries_fizz_read_firmware;
-	klass_device->set_progress = fu_steelseries_fizz_set_progress;
+	device_class->attach = fu_steelseries_fizz_attach;
+	device_class->setup = fu_steelseries_fizz_setup;
+	device_class->write_firmware = fu_steelseries_fizz_write_firmware;
+	device_class->read_firmware = fu_steelseries_fizz_read_firmware;
+	device_class->set_progress = fu_steelseries_fizz_set_progress;
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -298,14 +298,14 @@ fu_steelseries_gamepad_convert_version(FuDevice *device, guint64 version_raw)
 static void
 fu_steelseries_gamepad_class_init(FuSteelseriesGamepadClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->setup = fu_steelseries_gamepad_setup;
-	klass_device->attach = fu_steelseries_gamepad_attach;
-	klass_device->detach = fu_steelseries_gamepad_detach;
-	klass_device->write_firmware = fu_steelseries_gamepad_write_firmware;
-	klass_device->set_progress = fu_steelseries_gamepad_set_progress;
-	klass_device->convert_version = fu_steelseries_gamepad_convert_version;
+	device_class->setup = fu_steelseries_gamepad_setup;
+	device_class->attach = fu_steelseries_gamepad_attach;
+	device_class->detach = fu_steelseries_gamepad_detach;
+	device_class->write_firmware = fu_steelseries_gamepad_write_firmware;
+	device_class->set_progress = fu_steelseries_gamepad_set_progress;
+	device_class->convert_version = fu_steelseries_gamepad_convert_version;
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-mouse.c
+++ b/plugins/steelseries/fu-steelseries-mouse.c
@@ -95,6 +95,6 @@ fu_steelseries_mouse_init(FuSteelseriesMouse *self)
 static void
 fu_steelseries_mouse_class_init(FuSteelseriesMouseClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_steelseries_mouse_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_steelseries_mouse_setup;
 }

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -1061,14 +1061,14 @@ fu_steelseries_sonic_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_steelseries_sonic_class_init(FuSteelseriesSonicClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->attach = fu_steelseries_sonic_attach;
-	klass_device->prepare = fu_steelseries_sonic_prepare;
-	klass_device->read_firmware = fu_steelseries_sonic_read_firmware;
-	klass_device->write_firmware = fu_steelseries_sonic_write_firmware;
-	klass_device->prepare_firmware = fu_steelseries_sonic_prepare_firmware;
-	klass_device->set_progress = fu_steelseries_sonic_set_progress;
+	device_class->attach = fu_steelseries_sonic_attach;
+	device_class->prepare = fu_steelseries_sonic_prepare;
+	device_class->read_firmware = fu_steelseries_sonic_read_firmware;
+	device_class->write_firmware = fu_steelseries_sonic_write_firmware;
+	device_class->prepare_firmware = fu_steelseries_sonic_prepare_firmware;
+	device_class->set_progress = fu_steelseries_sonic_set_progress;
 }
 
 static void

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -509,7 +509,7 @@ fu_superio_device_class_init(FuSuperioDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	/* properties */
 	object_class->get_property = fu_superio_device_get_property;
@@ -529,10 +529,10 @@ fu_superio_device_class_init(FuSuperioDeviceClass *klass)
 	g_object_class_install_property(object_class, PROP_CHIPSET, pspec);
 
 	object_class->finalize = fu_superio_device_finalize;
-	klass_device->to_string = fu_superio_device_to_string;
-	klass_device->set_quirk_kv = fu_superio_device_set_quirk_kv;
-	klass_device->probe = fu_superio_device_probe;
-	klass_device->setup = fu_superio_device_setup;
-	klass_device->prepare_firmware = fu_superio_device_prepare_firmware;
-	klass_device->set_progress = fu_superio_device_set_progress;
+	device_class->to_string = fu_superio_device_to_string;
+	device_class->set_quirk_kv = fu_superio_device_set_quirk_kv;
+	device_class->probe = fu_superio_device_probe;
+	device_class->setup = fu_superio_device_setup;
+	device_class->prepare_firmware = fu_superio_device_prepare_firmware;
+	device_class->set_progress = fu_superio_device_set_progress;
 }

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -644,14 +644,14 @@ fu_superio_it55_device_finalize(GObject *obj)
 static void
 fu_superio_it55_device_class_init(FuEcIt55DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	G_OBJECT_CLASS(klass)->finalize = fu_superio_it55_device_finalize;
-	klass_device->to_string = fu_superio_it55_device_to_string;
-	klass_device->attach = fu_superio_it55_device_attach;
-	klass_device->detach = fu_superio_it55_device_detach;
-	klass_device->dump_firmware = fu_superio_it55_device_dump_firmware;
-	klass_device->write_firmware = fu_superio_it55_device_write_firmware;
-	klass_device->setup = fu_superio_it55_device_setup;
-	klass_device->prepare_firmware = fu_superio_it55_device_prepare_firmware;
-	klass_device->set_quirk_kv = fu_superio_it55_device_set_quirk_kv;
+	device_class->to_string = fu_superio_it55_device_to_string;
+	device_class->attach = fu_superio_it55_device_attach;
+	device_class->detach = fu_superio_it55_device_detach;
+	device_class->dump_firmware = fu_superio_it55_device_dump_firmware;
+	device_class->write_firmware = fu_superio_it55_device_write_firmware;
+	device_class->setup = fu_superio_it55_device_setup;
+	device_class->prepare_firmware = fu_superio_it55_device_prepare_firmware;
+	device_class->set_quirk_kv = fu_superio_it55_device_set_quirk_kv;
 }

--- a/plugins/superio/fu-superio-it85-device.c
+++ b/plugins/superio/fu-superio-it85-device.c
@@ -75,6 +75,6 @@ fu_superio_it85_device_init(FuSuperioIt85Device *self)
 static void
 fu_superio_it85_device_class_init(FuSuperioIt85DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_superio_it85_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_superio_it85_device_setup;
 }

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -738,11 +738,11 @@ fu_superio_it89_device_init(FuSuperioIt89Device *self)
 static void
 fu_superio_it89_device_class_init(FuSuperioIt89DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->attach = fu_superio_it89_device_attach;
-	klass_device->detach = fu_superio_it89_device_detach;
-	klass_device->read_firmware = fu_superio_it89_device_read_firmware;
-	klass_device->dump_firmware = fu_superio_it89_device_dump_firmware;
-	klass_device->write_firmware = fu_superio_it89_device_write_firmware;
-	klass_device->setup = fu_superio_it89_device_setup;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->attach = fu_superio_it89_device_attach;
+	device_class->detach = fu_superio_it89_device_detach;
+	device_class->read_firmware = fu_superio_it89_device_read_firmware;
+	device_class->dump_firmware = fu_superio_it89_device_dump_firmware;
+	device_class->write_firmware = fu_superio_it89_device_write_firmware;
+	device_class->setup = fu_superio_it89_device_setup;
 }

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -818,11 +818,11 @@ fu_synaptics_cape_device_init(FuSynapticsCapeDevice *self)
 static void
 fu_synaptics_cape_device_class_init(FuSynapticsCapeDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_synaptics_cape_device_to_string;
-	klass_device->setup = fu_synaptics_cape_device_setup;
-	klass_device->write_firmware = fu_synaptics_cape_device_write_firmware;
-	klass_device->prepare_firmware = fu_synaptics_cape_device_prepare_firmware;
-	klass_device->set_progress = fu_synaptics_cape_device_set_progress;
-	klass_device->convert_version = fu_synaptics_cape_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_synaptics_cape_device_to_string;
+	device_class->setup = fu_synaptics_cape_device_setup;
+	device_class->write_firmware = fu_synaptics_cape_device_write_firmware;
+	device_class->prepare_firmware = fu_synaptics_cape_device_prepare_firmware;
+	device_class->set_progress = fu_synaptics_cape_device_set_progress;
+	device_class->convert_version = fu_synaptics_cape_device_convert_version;
 }

--- a/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-firmware.c
@@ -88,7 +88,7 @@ fu_synaptics_cape_firmware_init(FuSynapticsCapeFirmware *self)
 static void
 fu_synaptics_cape_firmware_class_init(FuSynapticsCapeFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->export = fu_synaptics_cape_firmware_export;
-	klass_firmware->build = fu_synaptics_cape_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->export = fu_synaptics_cape_firmware_export;
+	firmware_class->build = fu_synaptics_cape_firmware_build;
 }

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -115,9 +115,9 @@ fu_synaptics_cape_hid_firmware_init(FuSynapticsCapeHidFirmware *self)
 static void
 fu_synaptics_cape_hid_firmware_class_init(FuSynapticsCapeHidFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_synaptics_cape_hid_firmware_parse;
-	klass_firmware->write = fu_synaptics_cape_hid_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_synaptics_cape_hid_firmware_parse;
+	firmware_class->write = fu_synaptics_cape_hid_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -130,7 +130,7 @@ fu_synaptics_cape_sngl_firmware_init(FuSynapticsCapeSnglFirmware *self)
 static void
 fu_synaptics_cape_sngl_firmware_class_init(FuSynapticsCapeSnglFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_synaptics_cape_sngl_firmware_parse;
-	klass_firmware->write = fu_synaptics_cape_sngl_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_synaptics_cape_sngl_firmware_parse;
+	firmware_class->write = fu_synaptics_cape_sngl_firmware_write;
 }

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -890,12 +890,12 @@ fu_synaptics_cxaudio_device_init(FuSynapticsCxaudioDevice *self)
 static void
 fu_synaptics_cxaudio_device_class_init(FuSynapticsCxaudioDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_synaptics_cxaudio_device_to_string;
-	klass_device->set_quirk_kv = fu_synaptics_cxaudio_device_set_quirk_kv;
-	klass_device->setup = fu_synaptics_cxaudio_device_setup;
-	klass_device->write_firmware = fu_synaptics_cxaudio_device_write_firmware;
-	klass_device->attach = fu_synaptics_cxaudio_device_attach;
-	klass_device->prepare_firmware = fu_synaptics_cxaudio_device_prepare_firmware;
-	klass_device->set_progress = fu_synaptics_cxaudio_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_synaptics_cxaudio_device_to_string;
+	device_class->set_quirk_kv = fu_synaptics_cxaudio_device_set_quirk_kv;
+	device_class->setup = fu_synaptics_cxaudio_device_setup;
+	device_class->write_firmware = fu_synaptics_cxaudio_device_write_firmware;
+	device_class->attach = fu_synaptics_cxaudio_device_attach;
+	device_class->prepare_firmware = fu_synaptics_cxaudio_device_prepare_firmware;
+	device_class->set_progress = fu_synaptics_cxaudio_device_set_progress;
 }

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -360,9 +360,9 @@ fu_synaptics_cxaudio_firmware_init(FuSynapticsCxaudioFirmware *self)
 static void
 fu_synaptics_cxaudio_firmware_class_init(FuSynapticsCxaudioFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_synaptics_cxaudio_firmware_parse;
-	klass_firmware->export = fu_synaptics_cxaudio_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_synaptics_cxaudio_firmware_parse;
+	firmware_class->export = fu_synaptics_cxaudio_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1808,13 +1808,13 @@ static void
 fu_synaptics_mst_device_class_init(FuSynapticsMstDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_synaptics_mst_device_finalize;
-	klass_device->to_string = fu_synaptics_mst_device_to_string;
-	klass_device->set_quirk_kv = fu_synaptics_mst_device_set_quirk_kv;
-	klass_device->setup = fu_synaptics_mst_device_setup;
-	klass_device->write_firmware = fu_synaptics_mst_device_write_firmware;
-	klass_device->attach = fu_synaptics_mst_device_attach;
-	klass_device->prepare_firmware = fu_synaptics_mst_device_prepare_firmware;
-	klass_device->set_progress = fu_synaptics_mst_device_set_progress;
+	device_class->to_string = fu_synaptics_mst_device_to_string;
+	device_class->set_quirk_kv = fu_synaptics_mst_device_set_quirk_kv;
+	device_class->setup = fu_synaptics_mst_device_setup;
+	device_class->write_firmware = fu_synaptics_mst_device_write_firmware;
+	device_class->attach = fu_synaptics_mst_device_attach;
+	device_class->prepare_firmware = fu_synaptics_mst_device_prepare_firmware;
+	device_class->set_progress = fu_synaptics_mst_device_set_progress;
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -184,11 +184,11 @@ fu_synaptics_mst_firmware_init(FuSynapticsMstFirmware *self)
 static void
 fu_synaptics_mst_firmware_class_init(FuSynapticsMstFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_synaptics_mst_firmware_parse;
-	klass_firmware->export = fu_synaptics_mst_firmware_export;
-	klass_firmware->write = fu_synaptics_mst_firmware_write;
-	klass_firmware->build = fu_synaptics_rmi_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_synaptics_mst_firmware_parse;
+	firmware_class->export = fu_synaptics_mst_firmware_export;
+	firmware_class->write = fu_synaptics_mst_firmware_write;
+	firmware_class->build = fu_synaptics_rmi_firmware_build;
 }
 
 FuFirmware *

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -251,15 +251,15 @@ fu_synaprom_config_detach(FuDevice *device, FuProgress *progress, GError **error
 static void
 fu_synaprom_config_class_init(FuSynapromConfigClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->constructed = fu_synaprom_config_constructed;
-	klass_device->write_firmware = fu_synaprom_config_write_firmware;
-	klass_device->prepare_firmware = fu_synaprom_config_prepare_firmware;
-	klass_device->setup = fu_synaprom_config_setup;
-	klass_device->reload = fu_synaprom_config_setup;
-	klass_device->attach = fu_synaprom_config_attach;
-	klass_device->detach = fu_synaprom_config_detach;
+	device_class->write_firmware = fu_synaprom_config_write_firmware;
+	device_class->prepare_firmware = fu_synaprom_config_prepare_firmware;
+	device_class->setup = fu_synaprom_config_setup;
+	device_class->reload = fu_synaprom_config_setup;
+	device_class->attach = fu_synaprom_config_attach;
+	device_class->detach = fu_synaprom_config_detach;
 }
 
 FuSynapromConfig *

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -526,14 +526,14 @@ fu_synaprom_device_init(FuSynapromDevice *self)
 static void
 fu_synaprom_device_class_init(FuSynapromDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_synaprom_device_write_firmware;
-	klass_device->prepare_firmware = fu_synaprom_device_prepare_firmware;
-	klass_device->setup = fu_synaprom_device_setup;
-	klass_device->reload = fu_synaprom_device_setup;
-	klass_device->attach = fu_synaprom_device_attach;
-	klass_device->detach = fu_synaprom_device_detach;
-	klass_device->set_progress = fu_synaprom_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_synaprom_device_write_firmware;
+	device_class->prepare_firmware = fu_synaprom_device_prepare_firmware;
+	device_class->setup = fu_synaprom_device_setup;
+	device_class->reload = fu_synaprom_device_setup;
+	device_class->attach = fu_synaprom_device_attach;
+	device_class->detach = fu_synaprom_device_detach;
+	device_class->set_progress = fu_synaprom_device_set_progress;
 }
 
 FuSynapromDevice *

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -200,11 +200,11 @@ fu_synaprom_firmware_init(FuSynapromFirmware *self)
 static void
 fu_synaprom_firmware_class_init(FuSynapromFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_synaprom_firmware_parse;
-	klass_firmware->write = fu_synaprom_firmware_write;
-	klass_firmware->export = fu_synaprom_firmware_export;
-	klass_firmware->build = fu_synaprom_firmware_build;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_synaprom_firmware_parse;
+	firmware_class->write = fu_synaprom_firmware_write;
+	firmware_class->export = fu_synaprom_firmware_export;
+	firmware_class->build = fu_synaprom_firmware_build;
 }
 
 FuFirmware *

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -125,8 +125,8 @@ fu_synaptics_rmi_device_get_function(FuSynapticsRmiDevice *self,
 GByteArray *
 fu_synaptics_rmi_device_read(FuSynapticsRmiDevice *self, guint16 addr, gsize req_sz, GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	return klass_rmi->read(self, addr, req_sz, error);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	return rmi_class->read(self, addr, req_sz, error);
 }
 
 GByteArray *
@@ -135,15 +135,15 @@ fu_synaptics_rmi_device_read_packet_register(FuSynapticsRmiDevice *self,
 					     gsize req_sz,
 					     GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	if (klass_rmi->read_packet_register == NULL) {
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	if (rmi_class->read_packet_register == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "packet register reads not supported");
 		return NULL;
 	}
-	return klass_rmi->read_packet_register(self, addr, req_sz, error);
+	return rmi_class->read_packet_register(self, addr, req_sz, error);
 }
 
 gboolean
@@ -153,18 +153,18 @@ fu_synaptics_rmi_device_write(FuSynapticsRmiDevice *self,
 			      FuSynapticsRmiDeviceFlags flags,
 			      GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	return klass_rmi->write(self, addr, req, flags, error);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	return rmi_class->write(self, addr, req, flags, error);
 }
 
 gboolean
 fu_synaptics_rmi_device_set_page(FuSynapticsRmiDevice *self, guint8 page, GError **error)
 {
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
 	if (priv->current_page == page)
 		return TRUE;
-	if (!klass_rmi->set_page(self, page, error))
+	if (!rmi_class->set_page(self, page, error))
 		return FALSE;
 	priv->current_page = page;
 	return TRUE;
@@ -180,10 +180,10 @@ fu_synaptics_rmi_device_set_iepmode(FuSynapticsRmiDevice *self, gboolean iepmode
 gboolean
 fu_synaptics_rmi_device_write_bus_select(FuSynapticsRmiDevice *self, guint8 bus, GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	if (klass_rmi->write_bus_select == NULL)
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	if (rmi_class->write_bus_select == NULL)
 		return TRUE;
-	return klass_rmi->write_bus_select(self, bus, error);
+	return rmi_class->write_bus_select(self, bus, error);
 }
 
 gboolean
@@ -316,8 +316,8 @@ fu_synaptics_rmi_device_set_product_id(FuSynapticsRmiDevice *self, const gchar *
 static gboolean
 fu_synaptics_rmi_device_query_status(FuSynapticsRmiDevice *self, GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	return klass_rmi->query_status(self, error);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	return rmi_class->query_status(self, error);
 }
 
 static gboolean
@@ -325,10 +325,10 @@ fu_synaptics_rmi_device_query_build_id(FuSynapticsRmiDevice *self,
 				       guint32 *build_id,
 				       GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	if (klass_rmi->query_build_id == NULL)
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	if (rmi_class->query_build_id == NULL)
 		return TRUE;
-	return klass_rmi->query_build_id(self, build_id, error);
+	return rmi_class->query_build_id(self, build_id, error);
 }
 
 static gboolean
@@ -336,10 +336,10 @@ fu_synaptics_rmi_device_query_product_sub_id(FuSynapticsRmiDevice *self,
 					     guint8 *product_sub_id,
 					     GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	if (klass_rmi->query_product_sub_id == NULL)
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	if (rmi_class->query_product_sub_id == NULL)
 		return TRUE;
-	return klass_rmi->query_product_sub_id(self, product_sub_id, error);
+	return rmi_class->query_product_sub_id(self, product_sub_id, error);
 }
 
 static gboolean
@@ -640,8 +640,8 @@ fu_synaptics_rmi_device_wait_for_attr(FuSynapticsRmiDevice *self,
 				      guint timeout_ms,
 				      GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	return klass_rmi->wait_for_attr(self, source_mask, timeout_ms, error);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	return rmi_class->wait_for_attr(self, source_mask, timeout_ms, error);
 }
 
 gboolean
@@ -649,15 +649,15 @@ fu_synaptics_rmi_device_enter_iep_mode(FuSynapticsRmiDevice *self,
 				       FuSynapticsRmiDeviceFlags flags,
 				       GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
 	FuSynapticsRmiDevicePrivate *priv = GET_PRIVATE(self);
 
 	/* already set */
 	if ((flags & FU_SYNAPTICS_RMI_DEVICE_FLAG_FORCE) == 0 && priv->in_iep_mode)
 		return TRUE;
-	if (klass_rmi->enter_iep_mode != NULL) {
+	if (rmi_class->enter_iep_mode != NULL) {
 		g_debug("enabling RMI iep_mode");
-		if (!klass_rmi->enter_iep_mode(self, error)) {
+		if (!rmi_class->enter_iep_mode(self, error)) {
 			g_prefix_error(error, "failed to enable RMI iep_mode: ");
 			return FALSE;
 		}
@@ -749,10 +749,10 @@ fu_synaptics_rmi_device_wait_for_idle(FuSynapticsRmiDevice *self,
 gboolean
 fu_synaptics_rmi_device_disable_sleep(FuSynapticsRmiDevice *self, GError **error)
 {
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
-	if (klass_rmi->disable_sleep == NULL)
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_GET_CLASS(self);
+	if (rmi_class->disable_sleep == NULL)
 		return TRUE;
-	return klass_rmi->disable_sleep(self, error);
+	return rmi_class->disable_sleep(self, error);
 }
 
 gboolean
@@ -857,10 +857,10 @@ static void
 fu_synaptics_rmi_device_class_init(FuSynapticsRmiDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_synaptics_rmi_device_finalize;
-	klass_device->to_string = fu_synaptics_rmi_device_to_string;
-	klass_device->prepare_firmware = fu_synaptics_rmi_device_prepare_firmware;
-	klass_device->setup = fu_synaptics_rmi_device_setup;
-	klass_device->write_firmware = fu_synaptics_rmi_device_write_firmware;
+	device_class->to_string = fu_synaptics_rmi_device_to_string;
+	device_class->prepare_firmware = fu_synaptics_rmi_device_prepare_firmware;
+	device_class->setup = fu_synaptics_rmi_device_setup;
+	device_class->write_firmware = fu_synaptics_rmi_device_write_firmware;
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -677,12 +677,12 @@ static void
 fu_synaptics_rmi_firmware_class_init(FuSynapticsRmiFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_synaptics_rmi_firmware_finalize;
-	klass_firmware->parse = fu_synaptics_rmi_firmware_parse;
-	klass_firmware->export = fu_synaptics_rmi_firmware_export;
-	klass_firmware->build = fu_synaptics_rmi_firmware_build;
-	klass_firmware->write = fu_synaptics_rmi_firmware_write;
+	firmware_class->parse = fu_synaptics_rmi_firmware_parse;
+	firmware_class->export = fu_synaptics_rmi_firmware_export;
+	firmware_class->build = fu_synaptics_rmi_firmware_build;
+	firmware_class->write = fu_synaptics_rmi_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -547,19 +547,19 @@ fu_synaptics_rmi_hid_device_init(FuSynapticsRmiHidDevice *self)
 static void
 fu_synaptics_rmi_hid_device_class_init(FuSynapticsRmiHidDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_CLASS(klass);
-	klass_device->attach = fu_synaptics_rmi_hid_device_attach;
-	klass_device->detach = fu_synaptics_rmi_hid_device_detach;
-	klass_device->probe = fu_synaptics_rmi_hid_device_probe;
-	klass_device->open = fu_synaptics_rmi_hid_device_open;
-	klass_device->close = fu_synaptics_rmi_hid_device_close;
-	klass_device->set_progress = fu_synaptics_rmi_hid_device_set_progress;
-	klass_rmi->write = fu_synaptics_rmi_hid_device_write;
-	klass_rmi->read = fu_synaptics_rmi_hid_device_read;
-	klass_rmi->wait_for_attr = fu_synaptics_rmi_hid_device_wait_for_attr;
-	klass_rmi->set_page = fu_synaptics_rmi_hid_device_set_page;
-	klass_rmi->query_status = fu_synaptics_rmi_hid_device_query_status;
-	klass_rmi->read_packet_register = fu_synaptics_rmi_hid_device_read_packet_register;
-	klass_rmi->disable_sleep = fu_synaptics_rmi_hid_device_disable_sleep;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_CLASS(klass);
+	device_class->attach = fu_synaptics_rmi_hid_device_attach;
+	device_class->detach = fu_synaptics_rmi_hid_device_detach;
+	device_class->probe = fu_synaptics_rmi_hid_device_probe;
+	device_class->open = fu_synaptics_rmi_hid_device_open;
+	device_class->close = fu_synaptics_rmi_hid_device_close;
+	device_class->set_progress = fu_synaptics_rmi_hid_device_set_progress;
+	rmi_class->write = fu_synaptics_rmi_hid_device_write;
+	rmi_class->read = fu_synaptics_rmi_hid_device_read;
+	rmi_class->wait_for_attr = fu_synaptics_rmi_hid_device_wait_for_attr;
+	rmi_class->set_page = fu_synaptics_rmi_hid_device_set_page;
+	rmi_class->query_status = fu_synaptics_rmi_hid_device_query_status;
+	rmi_class->read_packet_register = fu_synaptics_rmi_hid_device_read_packet_register;
+	rmi_class->disable_sleep = fu_synaptics_rmi_hid_device_disable_sleep;
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -979,21 +979,21 @@ fu_synaptics_rmi_ps2_device_wait_for_attr(FuSynapticsRmiDevice *rmi_device,
 static void
 fu_synaptics_rmi_ps2_device_class_init(FuSynapticsRmiPs2DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuSynapticsRmiDeviceClass *klass_rmi = FU_SYNAPTICS_RMI_DEVICE_CLASS(klass);
-	klass_device->attach = fu_synaptics_rmi_ps2_device_attach;
-	klass_device->detach = fu_synaptics_rmi_ps2_device_detach;
-	klass_device->setup = fu_synaptics_rmi_ps2_device_setup;
-	klass_device->probe = fu_synaptics_rmi_ps2_device_probe;
-	klass_device->open = fu_synaptics_rmi_ps2_device_open;
-	klass_rmi->read = fu_synaptics_rmi_ps2_device_read;
-	klass_rmi->write = fu_synaptics_rmi_ps2_device_write;
-	klass_rmi->set_page = fu_synaptics_rmi_ps2_device_set_page;
-	klass_rmi->query_status = fu_synaptics_rmi_ps2_device_query_status;
-	klass_rmi->query_build_id = fu_synaptics_rmi_ps2_device_query_build_id;
-	klass_rmi->query_product_sub_id = fu_synaptics_rmi_ps2_device_query_product_sub_id;
-	klass_rmi->wait_for_attr = fu_synaptics_rmi_ps2_device_wait_for_attr;
-	klass_rmi->enter_iep_mode = fu_synaptics_rmi_ps2_device_enter_iep_mode;
-	klass_rmi->write_bus_select = fu_synaptics_rmi_ps2_device_write_bus_select;
-	klass_rmi->read_packet_register = fu_synaptics_rmi_ps2_device_read_packet_register;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuSynapticsRmiDeviceClass *rmi_class = FU_SYNAPTICS_RMI_DEVICE_CLASS(klass);
+	device_class->attach = fu_synaptics_rmi_ps2_device_attach;
+	device_class->detach = fu_synaptics_rmi_ps2_device_detach;
+	device_class->setup = fu_synaptics_rmi_ps2_device_setup;
+	device_class->probe = fu_synaptics_rmi_ps2_device_probe;
+	device_class->open = fu_synaptics_rmi_ps2_device_open;
+	rmi_class->read = fu_synaptics_rmi_ps2_device_read;
+	rmi_class->write = fu_synaptics_rmi_ps2_device_write;
+	rmi_class->set_page = fu_synaptics_rmi_ps2_device_set_page;
+	rmi_class->query_status = fu_synaptics_rmi_ps2_device_query_status;
+	rmi_class->query_build_id = fu_synaptics_rmi_ps2_device_query_build_id;
+	rmi_class->query_product_sub_id = fu_synaptics_rmi_ps2_device_query_product_sub_id;
+	rmi_class->wait_for_attr = fu_synaptics_rmi_ps2_device_wait_for_attr;
+	rmi_class->enter_iep_mode = fu_synaptics_rmi_ps2_device_enter_iep_mode;
+	rmi_class->write_bus_select = fu_synaptics_rmi_ps2_device_write_bus_select;
+	rmi_class->read_packet_register = fu_synaptics_rmi_ps2_device_read_packet_register;
 }

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -270,8 +270,8 @@ fu_system76_launch_device_init(FuSystem76LaunchDevice *self)
 static void
 fu_system76_launch_device_class_init(FuSystem76LaunchDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_system76_launch_device_setup;
-	klass_device->detach = fu_system76_launch_device_detach;
-	klass_device->set_progress = fu_system76_launch_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_system76_launch_device_setup;
+	device_class->detach = fu_system76_launch_device_detach;
+	device_class->set_progress = fu_system76_launch_device_set_progress;
 }

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -121,8 +121,8 @@ fu_thelio_io_device_init(FuThelioIoDevice *self)
 static void
 fu_thelio_io_device_class_init(FuThelioIoDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_thelio_io_device_probe;
-	klass_device->detach = fu_thelio_io_device_detach;
-	klass_device->set_progress = fu_thelio_io_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_thelio_io_device_probe;
+	device_class->detach = fu_thelio_io_device_detach;
+	device_class->set_progress = fu_thelio_io_device_set_progress;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -359,10 +359,10 @@ static void
 fu_thunderbolt_controller_class_init(FuThunderboltControllerClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_thunderbolt_controller_finalize;
-	klass_device->setup = fu_thunderbolt_controller_setup;
-	klass_device->probe = fu_thunderbolt_controller_probe;
-	klass_device->to_string = fu_thunderbolt_controller_to_string;
-	klass_device->write_firmware = fu_thunderbolt_controller_write_firmware;
+	device_class->setup = fu_thunderbolt_controller_setup;
+	device_class->probe = fu_thunderbolt_controller_probe;
+	device_class->to_string = fu_thunderbolt_controller_to_string;
+	device_class->write_firmware = fu_thunderbolt_controller_write_firmware;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -431,13 +431,13 @@ fu_thunderbolt_device_init(FuThunderboltDevice *self)
 static void
 fu_thunderbolt_device_class_init(FuThunderboltDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->activate = fu_thunderbolt_device_activate;
-	klass_device->to_string = fu_thunderbolt_device_to_string;
-	klass_device->probe = fu_thunderbolt_device_probe;
-	klass_device->prepare_firmware = fu_thunderbolt_device_prepare_firmware;
-	klass_device->write_firmware = fu_thunderbolt_device_write_firmware;
-	klass_device->attach = fu_thunderbolt_device_attach;
-	klass_device->rescan = fu_thunderbolt_device_rescan;
-	klass_device->set_progress = fu_thunderbolt_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->activate = fu_thunderbolt_device_activate;
+	device_class->to_string = fu_thunderbolt_device_to_string;
+	device_class->probe = fu_thunderbolt_device_probe;
+	device_class->prepare_firmware = fu_thunderbolt_device_prepare_firmware;
+	device_class->write_firmware = fu_thunderbolt_device_write_firmware;
+	device_class->attach = fu_thunderbolt_device_attach;
+	device_class->rescan = fu_thunderbolt_device_rescan;
+	device_class->set_progress = fu_thunderbolt_device_set_progress;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -148,7 +148,7 @@ fu_thunderbolt_retimer_init(FuThunderboltRetimer *self)
 static void
 fu_thunderbolt_retimer_class_init(FuThunderboltRetimerClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_thunderbolt_retimer_setup;
-	klass_device->probe = fu_thunderbolt_retimer_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_thunderbolt_retimer_setup;
+	device_class->probe = fu_thunderbolt_retimer_probe;
 }

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -770,13 +770,13 @@ fu_ti_tps6598x_device_finalize(GObject *object)
 static void
 fu_ti_tps6598x_device_class_init(FuTiTps6598xDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_ti_tps6598x_device_finalize;
-	klass_device->to_string = fu_ti_tps6598x_device_to_string;
-	klass_device->write_firmware = fu_ti_tps6598x_device_write_firmware;
-	klass_device->attach = fu_ti_tps6598x_device_attach;
-	klass_device->setup = fu_ti_tps6598x_device_setup;
-	klass_device->report_metadata_pre = fu_ti_tps6598x_device_report_metadata_pre;
-	klass_device->set_progress = fu_ti_tps6598x_device_set_progress;
+	device_class->to_string = fu_ti_tps6598x_device_to_string;
+	device_class->write_firmware = fu_ti_tps6598x_device_write_firmware;
+	device_class->attach = fu_ti_tps6598x_device_attach;
+	device_class->setup = fu_ti_tps6598x_device_setup;
+	device_class->report_metadata_pre = fu_ti_tps6598x_device_report_metadata_pre;
+	device_class->set_progress = fu_ti_tps6598x_device_set_progress;
 }

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -132,8 +132,8 @@ fu_ti_tps6598x_firmware_init(FuTiTps6598xFirmware *self)
 static void
 fu_ti_tps6598x_firmware_class_init(FuTiTps6598xFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_ti_tps6598x_firmware_validate;
-	klass_firmware->parse = fu_ti_tps6598x_firmware_parse;
-	klass_firmware->write = fu_ti_tps6598x_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_ti_tps6598x_firmware_validate;
+	firmware_class->parse = fu_ti_tps6598x_firmware_parse;
+	firmware_class->write = fu_ti_tps6598x_firmware_write;
 }

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-pd-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-pd-device.c
@@ -191,13 +191,13 @@ fu_ti_tps6598x_pd_device_init(FuTiTps6598xPdDevice *self)
 static void
 fu_ti_tps6598x_pd_device_class_init(FuTiTps6598xPdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_ti_tps6598x_pd_device_write_firmware;
-	klass_device->attach = fu_ti_tps6598x_pd_device_attach;
-	klass_device->setup = fu_ti_tps6598x_pd_device_setup;
-	klass_device->probe = fu_ti_tps6598x_pd_device_probe;
-	klass_device->report_metadata_pre = fu_ti_tps6598x_pd_device_report_metadata_pre;
-	klass_device->set_progress = fu_ti_tps6598x_pd_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_ti_tps6598x_pd_device_write_firmware;
+	device_class->attach = fu_ti_tps6598x_pd_device_attach;
+	device_class->setup = fu_ti_tps6598x_pd_device_setup;
+	device_class->probe = fu_ti_tps6598x_pd_device_probe;
+	device_class->report_metadata_pre = fu_ti_tps6598x_pd_device_report_metadata_pre;
+	device_class->set_progress = fu_ti_tps6598x_pd_device_set_progress;
 }
 
 FuDevice *

--- a/plugins/tpm/fu-tpm-device.c
+++ b/plugins/tpm/fu-tpm-device.c
@@ -113,8 +113,8 @@ static void
 fu_tpm_device_class_init(FuTpmDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->finalize = fu_tpm_device_finalize;
-	klass_device->to_string = fu_tpm_device_to_string;
+	device_class->to_string = fu_tpm_device_to_string;
 }

--- a/plugins/tpm/fu-tpm-v1-device.c
+++ b/plugins/tpm/fu-tpm-v1-device.c
@@ -92,8 +92,8 @@ fu_tpm_v1_device_init(FuTpmV1Device *self)
 static void
 fu_tpm_v1_device_class_init(FuTpmV1DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_tpm_v1_device_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_tpm_v1_device_probe;
 }
 
 FuTpmDevice *

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -575,14 +575,14 @@ fu_tpm_v2_device_init(FuTpmV2Device *self)
 static void
 fu_tpm_v2_device_class_init(FuTpmV2DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->setup = fu_tpm_v2_device_setup;
-	klass_device->probe = fu_tpm_v2_device_probe;
-	klass_device->open = fu_tpm_v2_device_open;
-	klass_device->close = fu_tpm_v2_device_close;
-	klass_device->write_firmware = fu_tpm_v2_device_write_firmware;
-	klass_device->dump_firmware = fu_tpm_v2_device_dump_firmware;
-	klass_device->convert_version = fu_tpm_v2_device_convert_version;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_tpm_v2_device_setup;
+	device_class->probe = fu_tpm_v2_device_probe;
+	device_class->open = fu_tpm_v2_device_open;
+	device_class->close = fu_tpm_v2_device_close;
+	device_class->write_firmware = fu_tpm_v2_device_write_firmware;
+	device_class->dump_firmware = fu_tpm_v2_device_dump_firmware;
+	device_class->convert_version = fu_tpm_v2_device_convert_version;
 }
 
 FuTpmDevice *

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -136,10 +136,10 @@ static void
 fu_acpi_uefi_class_init(FuAcpiUefiClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_acpi_uefi_finalize;
-	klass_firmware->parse = fu_acpi_uefi_parse;
-	klass_firmware->export = fu_acpi_uefi_export;
+	firmware_class->parse = fu_acpi_uefi_parse;
+	firmware_class->export = fu_acpi_uefi_export;
 }
 
 FuFirmware *

--- a/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-freebsd.c
@@ -183,9 +183,9 @@ fu_uefi_backend_freebsd_init(FuUefiBackendFreebsd *self)
 static void
 fu_uefi_backend_freebsd_class_init(FuUefiBackendFreebsdClass *klass)
 {
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
-	klass_backend->setup = fu_uefi_backend_freebsd_setup;
-	klass_backend->coldplug = fu_uefi_backend_freebsd_coldplug;
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
+	backend_class->setup = fu_uefi_backend_freebsd_setup;
+	backend_class->coldplug = fu_uefi_backend_freebsd_coldplug;
 }
 
 FuBackend *

--- a/plugins/uefi-capsule/fu-uefi-backend-linux.c
+++ b/plugins/uefi-capsule/fu-uefi-backend-linux.c
@@ -228,9 +228,9 @@ fu_uefi_backend_linux_init(FuUefiBackendLinux *self)
 static void
 fu_uefi_backend_linux_class_init(FuUefiBackendLinuxClass *klass)
 {
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
-	klass_backend->coldplug = fu_uefi_backend_linux_coldplug;
-	klass_backend->setup = fu_uefi_backend_linux_setup;
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
+	backend_class->coldplug = fu_uefi_backend_linux_coldplug;
+	backend_class->setup = fu_uefi_backend_linux_setup;
 }
 
 FuBackend *

--- a/plugins/uefi-capsule/fu-uefi-backend.c
+++ b/plugins/uefi-capsule/fu-uefi-backend.c
@@ -75,6 +75,6 @@ fu_uefi_backend_init(FuUefiBackend *self)
 static void
 fu_uefi_backend_class_init(FuUefiBackendClass *klass)
 {
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
-	klass_backend->to_string = fu_uefi_backend_to_string;
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
+	backend_class->to_string = fu_uefi_backend_to_string;
 }

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -263,8 +263,8 @@ fu_uefi_cod_device_init(FuUefiCodDevice *self)
 static void
 fu_uefi_cod_device_class_init(FuUefiCodDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_uefi_cod_device_write_firmware;
-	klass_device->get_results = fu_uefi_cod_device_get_results;
-	klass_device->report_metadata_pre = fu_uefi_cod_device_report_metadata_pre;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_uefi_cod_device_write_firmware;
+	device_class->get_results = fu_uefi_cod_device_get_results;
+	device_class->report_metadata_pre = fu_uefi_cod_device_report_metadata_pre;
 }

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -750,20 +750,20 @@ fu_uefi_device_class_init(FuUefiDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->set_property = fu_uefi_device_set_property;
 	object_class->finalize = fu_uefi_device_finalize;
-	klass_device->to_string = fu_uefi_device_to_string;
-	klass_device->probe = fu_uefi_device_probe;
-	klass_device->prepare_firmware = fu_uefi_device_prepare_firmware;
-	klass_device->prepare = fu_uefi_device_prepare;
-	klass_device->cleanup = fu_uefi_device_cleanup;
-	klass_device->report_metadata_pre = fu_uefi_device_report_metadata_pre;
-	klass_device->report_metadata_post = fu_uefi_device_report_metadata_post;
-	klass_device->get_results = fu_uefi_device_get_results;
-	klass_device->set_progress = fu_uefi_device_set_progress;
-	klass_device->convert_version = fu_uefi_device_convert_version;
+	device_class->to_string = fu_uefi_device_to_string;
+	device_class->probe = fu_uefi_device_probe;
+	device_class->prepare_firmware = fu_uefi_device_prepare_firmware;
+	device_class->prepare = fu_uefi_device_prepare;
+	device_class->cleanup = fu_uefi_device_cleanup;
+	device_class->report_metadata_pre = fu_uefi_device_report_metadata_pre;
+	device_class->report_metadata_post = fu_uefi_device_report_metadata_post;
+	device_class->get_results = fu_uefi_device_get_results;
+	device_class->set_progress = fu_uefi_device_set_progress;
+	device_class->convert_version = fu_uefi_device_convert_version;
 
 	/**
 	 * FuUefiDevice:fw-class:

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -203,7 +203,7 @@ fu_uefi_grub_device_init(FuUefiGrubDevice *self)
 static void
 fu_uefi_grub_device_class_init(FuUefiGrubDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_uefi_grub_device_write_firmware;
-	klass_device->report_metadata_pre = fu_uefi_grub_device_report_metadata_pre;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_uefi_grub_device_write_firmware;
+	device_class->report_metadata_pre = fu_uefi_grub_device_report_metadata_pre;
 }

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -138,8 +138,8 @@ fu_uefi_nvram_device_init(FuUefiNvramDevice *self)
 static void
 fu_uefi_nvram_device_class_init(FuUefiNvramDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->get_results = fu_uefi_nvram_device_get_results;
-	klass_device->write_firmware = fu_uefi_nvram_device_write_firmware;
-	klass_device->report_metadata_pre = fu_uefi_nvram_device_report_metadata_pre;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->get_results = fu_uefi_nvram_device_get_results;
+	device_class->write_firmware = fu_uefi_nvram_device_write_firmware;
+	device_class->report_metadata_pre = fu_uefi_nvram_device_report_metadata_pre;
 }

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -131,10 +131,10 @@ fu_uefi_update_info_finalize(GObject *object)
 static void
 fu_uefi_update_info_class_init(FuUefiUpdateInfoClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	klass_firmware->parse = fu_uefi_update_info_parse;
-	klass_firmware->export = fu_uefi_update_info_export;
+	firmware_class->parse = fu_uefi_update_info_parse;
+	firmware_class->export = fu_uefi_update_info_export;
 	object_class->finalize = fu_uefi_update_info_finalize;
 }
 

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -205,12 +205,12 @@ fu_uefi_dbx_device_init(FuUefiDbxDevice *self)
 static void
 fu_uefi_dbx_device_class_init(FuUefiDbxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_uefi_dbx_device_probe;
-	klass_device->write_firmware = fu_uefi_dbx_device_write_firmware;
-	klass_device->prepare_firmware = fu_uefi_dbx_prepare_firmware;
-	klass_device->set_progress = fu_uefi_dbx_device_set_progress;
-	klass_device->report_metadata_pre = fu_uefi_dbx_device_report_metadata_pre;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_uefi_dbx_device_probe;
+	device_class->write_firmware = fu_uefi_dbx_device_write_firmware;
+	device_class->prepare_firmware = fu_uefi_dbx_prepare_firmware;
+	device_class->set_progress = fu_uefi_dbx_device_set_progress;
+	device_class->report_metadata_pre = fu_uefi_dbx_device_report_metadata_pre;
 }
 
 FuUefiDbxDevice *

--- a/plugins/uefi-pk/fu-uefi-pk-device.c
+++ b/plugins/uefi-pk/fu-uefi-pk-device.c
@@ -233,10 +233,10 @@ fu_uefi_pk_device_init(FuUefiPkDevice *self)
 static void
 fu_uefi_pk_device_class_init(FuUefiPkDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_uefi_pk_device_to_string;
-	klass_device->add_security_attrs = fu_uefi_pk_device_add_security_attrs;
-	klass_device->probe = fu_uefi_pk_device_probe;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_uefi_pk_device_to_string;
+	device_class->add_security_attrs = fu_uefi_pk_device_add_security_attrs;
+	device_class->probe = fu_uefi_pk_device_probe;
 }
 
 FuUefiPkDevice *

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -437,17 +437,17 @@ fu_uf2_device_finalize(GObject *obj)
 static void
 fu_uf2_device_class_init(FuUf2DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	GObjectClass *klass_object = G_OBJECT_CLASS(klass);
-	klass_object->finalize = fu_uf2_device_finalize;
-	klass_device->to_string = fu_uf2_device_to_string;
-	klass_device->probe = fu_uf2_device_probe;
-	klass_device->setup = fu_uf2_device_setup;
-	klass_device->open = fu_uf2_device_open;
-	klass_device->close = fu_uf2_device_close;
-	klass_device->prepare_firmware = fu_uf2_device_prepare_firmware;
-	klass_device->set_progress = fu_uf2_device_set_progress;
-	klass_device->read_firmware = fu_uf2_device_read_firmware;
-	klass_device->write_firmware = fu_block_device_write_firmware;
-	klass_device->dump_firmware = fu_block_device_dump_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_uf2_device_finalize;
+	device_class->to_string = fu_uf2_device_to_string;
+	device_class->probe = fu_uf2_device_probe;
+	device_class->setup = fu_uf2_device_setup;
+	device_class->open = fu_uf2_device_open;
+	device_class->close = fu_uf2_device_close;
+	device_class->prepare_firmware = fu_uf2_device_prepare_firmware;
+	device_class->set_progress = fu_uf2_device_set_progress;
+	device_class->read_firmware = fu_uf2_device_read_firmware;
+	device_class->write_firmware = fu_block_device_write_firmware;
+	device_class->dump_firmware = fu_block_device_dump_firmware;
 }

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -271,9 +271,9 @@ fu_uf2_firmware_init(FuUf2Firmware *self)
 static void
 fu_uf2_firmware_class_init(FuUf2FirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_uf2_firmware_parse;
-	klass_firmware->write = fu_uf2_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_uf2_firmware_parse;
+	firmware_class->write = fu_uf2_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -75,10 +75,10 @@ fu_usi_dock_child_device_init(FuUsiDockChildDevice *self)
 static void
 fu_usi_dock_child_device_class_init(FuUsiDockChildDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_usi_dock_child_device_to_string;
-	klass_device->prepare_firmware = fu_usi_dock_mcu_device_prepare_firmware;
-	klass_device->write_firmware = fu_usi_dock_mcu_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_usi_dock_child_device_to_string;
+	device_class->prepare_firmware = fu_usi_dock_mcu_device_prepare_firmware;
+	device_class->write_firmware = fu_usi_dock_mcu_device_write_firmware;
 }
 
 FuDevice *

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -824,13 +824,13 @@ fu_usi_dock_mcu_device_init(FuUsiDockMcuDevice *self)
 static void
 fu_usi_dock_mcu_device_class_init(FuUsiDockMcuDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
-	klass_device->write_firmware = fu_usi_dock_mcu_device_write_firmware;
-	klass_device->attach = fu_usi_dock_mcu_device_attach;
-	klass_device->setup = fu_usi_dock_mcu_device_setup;
-	klass_device->set_progress = fu_usi_dock_mcu_device_set_progress;
-	klass_device->cleanup = fu_usi_dock_mcu_device_cleanup;
-	klass_device->reload = fu_usi_dock_mcu_device_reload;
-	klass_device->replace = fu_usi_dock_mcu_device_replace;
+	device_class->write_firmware = fu_usi_dock_mcu_device_write_firmware;
+	device_class->attach = fu_usi_dock_mcu_device_attach;
+	device_class->setup = fu_usi_dock_mcu_device_setup;
+	device_class->set_progress = fu_usi_dock_mcu_device_set_progress;
+	device_class->cleanup = fu_usi_dock_mcu_device_cleanup;
+	device_class->reload = fu_usi_dock_mcu_device_reload;
+	device_class->replace = fu_usi_dock_mcu_device_replace;
 }

--- a/plugins/vbe/fu-vbe-device.c
+++ b/plugins/vbe/fu-vbe-device.c
@@ -149,7 +149,7 @@ fu_vbe_device_class_init(FuVbeDeviceClass *klass)
 {
 	GParamSpec *pspec;
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	object_class->get_property = fu_vbe_device_get_property;
 	object_class->set_property = fu_vbe_device_set_property;
@@ -171,6 +171,6 @@ fu_vbe_device_class_init(FuVbeDeviceClass *klass)
 	g_object_class_install_property(object_class, PROP_FDT_NODE, pspec);
 
 	object_class->finalize = fu_vbe_device_finalize;
-	klass_device->to_string = fu_vbe_device_to_string;
-	klass_device->probe = fu_vbe_device_probe;
+	device_class->to_string = fu_vbe_device_to_string;
+	device_class->probe = fu_vbe_device_probe;
 }

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -478,15 +478,15 @@ static void
 fu_vbe_simple_device_class_init(FuVbeSimpleDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->constructed = fu_vbe_simple_device_constructed;
 	object_class->finalize = fu_vbe_simple_device_finalize;
-	klass_device->to_string = fu_vbe_simple_device_to_string;
-	klass_device->probe = fu_vbe_simple_device_probe;
-	klass_device->open = fu_vbe_simple_device_open;
-	klass_device->close = fu_vbe_simple_device_close;
-	klass_device->set_progress = fu_vbe_simple_device_set_progress;
-	klass_device->prepare_firmware = fu_vbe_simple_device_prepare_firmware;
-	klass_device->write_firmware = fu_vbe_simple_device_write_firmware;
-	klass_device->dump_firmware = fu_vbe_simple_device_upload;
+	device_class->to_string = fu_vbe_simple_device_to_string;
+	device_class->probe = fu_vbe_simple_device_probe;
+	device_class->open = fu_vbe_simple_device_open;
+	device_class->close = fu_vbe_simple_device_close;
+	device_class->set_progress = fu_vbe_simple_device_set_progress;
+	device_class->prepare_firmware = fu_vbe_simple_device_prepare_firmware;
+	device_class->write_firmware = fu_vbe_simple_device_write_firmware;
+	device_class->dump_firmware = fu_vbe_simple_device_upload;
 }

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -342,18 +342,18 @@ static void
 fu_{{vendor}}_{{example}}_device_class_init(Fu{{Vendor}}{{Example}}DeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_{{vendor}}_{{example}}_device_finalize;
-	klass_device->to_string = fu_{{vendor}}_{{example}}_device_to_string;
-	klass_device->probe = fu_{{vendor}}_{{example}}_device_probe;
-	klass_device->setup = fu_{{vendor}}_{{example}}_device_setup;
-	klass_device->reload = fu_{{vendor}}_{{example}}_device_reload;
-	klass_device->prepare = fu_{{vendor}}_{{example}}_device_prepare;
-	klass_device->cleanup = fu_{{vendor}}_{{example}}_device_cleanup;
-	klass_device->attach = fu_{{vendor}}_{{example}}_device_attach;
-	klass_device->detach = fu_{{vendor}}_{{example}}_device_detach;
-	klass_device->prepare_firmware = fu_{{vendor}}_{{example}}_device_prepare_firmware;
-	klass_device->write_firmware = fu_{{vendor}}_{{example}}_device_write_firmware;
-	klass_device->set_quirk_kv = fu_{{vendor}}_{{example}}_device_set_quirk_kv;
-	klass_device->set_progress = fu_{{vendor}}_{{example}}_device_set_progress;
+	device_class->to_string = fu_{{vendor}}_{{example}}_device_to_string;
+	device_class->probe = fu_{{vendor}}_{{example}}_device_probe;
+	device_class->setup = fu_{{vendor}}_{{example}}_device_setup;
+	device_class->reload = fu_{{vendor}}_{{example}}_device_reload;
+	device_class->prepare = fu_{{vendor}}_{{example}}_device_prepare;
+	device_class->cleanup = fu_{{vendor}}_{{example}}_device_cleanup;
+	device_class->attach = fu_{{vendor}}_{{example}}_device_attach;
+	device_class->detach = fu_{{vendor}}_{{example}}_device_detach;
+	device_class->prepare_firmware = fu_{{vendor}}_{{example}}_device_prepare_firmware;
+	device_class->write_firmware = fu_{{vendor}}_{{example}}_device_write_firmware;
+	device_class->set_quirk_kv = fu_{{vendor}}_{{example}}_device_set_quirk_kv;
+	device_class->set_progress = fu_{{vendor}}_{{example}}_device_set_progress;
 }

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -111,12 +111,12 @@ fu_{{vendor}}_{{example}}_firmware_init(Fu{{Vendor}}{{Example}}Firmware *self)
 static void
 fu_{{vendor}}_{{example}}_firmware_class_init(Fu{{Vendor}}{{Example}}FirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_{{vendor}}_{{example}}_validate;
-	klass_firmware->parse = fu_{{vendor}}_{{example}}_firmware_parse;
-	klass_firmware->write = fu_{{vendor}}_{{example}}_firmware_write;
-	klass_firmware->build = fu_{{vendor}}_{{example}}_firmware_build;
-	klass_firmware->export = fu_{{vendor}}_{{example}}_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_{{vendor}}_{{example}}_validate;
+	firmware_class->parse = fu_{{vendor}}_{{example}}_firmware_parse;
+	firmware_class->write = fu_{{vendor}}_{{example}}_firmware_write;
+	firmware_class->build = fu_{{vendor}}_{{example}}_firmware_build;
+	firmware_class->export = fu_{{vendor}}_{{example}}_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -736,7 +736,7 @@ fu_vli_device_finalize(GObject *obj)
 static void
 fu_vli_device_class_init(FuVliDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
 
@@ -760,8 +760,8 @@ fu_vli_device_class_init(FuVliDeviceClass *klass)
 				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_KIND, pspec);
 
-	klass_device->to_string = fu_vli_device_to_string;
-	klass_device->set_quirk_kv = fu_vli_device_set_quirk_kv;
-	klass_device->setup = fu_vli_device_setup;
-	klass_device->report_metadata_pre = fu_vli_device_report_metadata_pre;
+	device_class->to_string = fu_vli_device_to_string;
+	device_class->set_quirk_kv = fu_vli_device_set_quirk_kv;
+	device_class->setup = fu_vli_device_setup;
+	device_class->report_metadata_pre = fu_vli_device_report_metadata_pre;
 }

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -931,21 +931,21 @@ fu_vli_pd_device_init(FuVliPdDevice *self)
 static void
 fu_vli_pd_device_class_init(FuVliPdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuVliDeviceClass *klass_vli_device = FU_VLI_DEVICE_CLASS(klass);
-	klass_device->dump_firmware = fu_vli_pd_device_dump_firmware;
-	klass_device->write_firmware = fu_vli_pd_device_write_firmware;
-	klass_device->prepare_firmware = fu_vli_pd_device_prepare_firmware;
-	klass_device->attach = fu_vli_pd_device_attach;
-	klass_device->detach = fu_vli_pd_device_detach;
-	klass_device->setup = fu_vli_pd_device_setup;
-	klass_device->set_progress = fu_vli_pd_device_set_progress;
-	klass_device->convert_version = fu_vli_pd_device_convert_version;
-	klass_vli_device->spi_chip_erase = fu_vli_pd_device_spi_chip_erase;
-	klass_vli_device->spi_sector_erase = fu_vli_pd_device_spi_sector_erase;
-	klass_vli_device->spi_read_data = fu_vli_pd_device_spi_read_data;
-	klass_vli_device->spi_read_status = fu_vli_pd_device_spi_read_status;
-	klass_vli_device->spi_write_data = fu_vli_pd_device_spi_write_data;
-	klass_vli_device->spi_write_enable = fu_vli_pd_device_spi_write_enable;
-	klass_vli_device->spi_write_status = fu_vli_pd_device_spi_write_status;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuVliDeviceClass *vli_device_class = FU_VLI_DEVICE_CLASS(klass);
+	device_class->dump_firmware = fu_vli_pd_device_dump_firmware;
+	device_class->write_firmware = fu_vli_pd_device_write_firmware;
+	device_class->prepare_firmware = fu_vli_pd_device_prepare_firmware;
+	device_class->attach = fu_vli_pd_device_attach;
+	device_class->detach = fu_vli_pd_device_detach;
+	device_class->setup = fu_vli_pd_device_setup;
+	device_class->set_progress = fu_vli_pd_device_set_progress;
+	device_class->convert_version = fu_vli_pd_device_convert_version;
+	vli_device_class->spi_chip_erase = fu_vli_pd_device_spi_chip_erase;
+	vli_device_class->spi_sector_erase = fu_vli_pd_device_spi_sector_erase;
+	vli_device_class->spi_read_data = fu_vli_pd_device_spi_read_data;
+	vli_device_class->spi_read_status = fu_vli_pd_device_spi_read_status;
+	vli_device_class->spi_write_data = fu_vli_pd_device_spi_write_data;
+	vli_device_class->spi_write_enable = fu_vli_pd_device_spi_write_enable;
+	vli_device_class->spi_write_status = fu_vli_pd_device_spi_write_status;
 }

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -168,9 +168,9 @@ fu_vli_pd_firmware_init(FuVliPdFirmware *self)
 static void
 fu_vli_pd_firmware_class_init(FuVliPdFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_vli_pd_firmware_parse;
-	klass_firmware->export = fu_vli_pd_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_vli_pd_firmware_parse;
+	firmware_class->export = fu_vli_pd_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -719,12 +719,12 @@ fu_vli_pd_parade_device_init(FuVliPdParadeDevice *self)
 static void
 fu_vli_pd_parade_device_class_init(FuVliPdParadeDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_vli_pd_parade_device_to_string;
-	klass_device->probe = fu_vli_pd_parade_device_probe;
-	klass_device->dump_firmware = fu_vli_pd_parade_device_dump_firmware;
-	klass_device->write_firmware = fu_vli_pd_parade_device_write_firmware;
-	klass_device->set_progress = fu_vli_pd_parade_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_vli_pd_parade_device_to_string;
+	device_class->probe = fu_vli_pd_parade_device_probe;
+	device_class->dump_firmware = fu_vli_pd_parade_device_dump_firmware;
+	device_class->write_firmware = fu_vli_pd_parade_device_write_firmware;
+	device_class->set_progress = fu_vli_pd_parade_device_set_progress;
 }
 
 FuDevice *

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1475,22 +1475,22 @@ static void
 fu_vli_usbhub_device_class_init(FuVliUsbhubDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuVliDeviceClass *klass_vli_device = FU_VLI_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuVliDeviceClass *vli_device_class = FU_VLI_DEVICE_CLASS(klass);
 	object_class->finalize = fu_vli_usbhub_device_finalize;
-	klass_device->probe = fu_vli_usbhub_device_probe;
-	klass_device->dump_firmware = fu_vli_usbhub_device_dump_firmware;
-	klass_device->write_firmware = fu_vli_usbhub_device_write_firmware;
-	klass_device->prepare_firmware = fu_vli_usbhub_device_prepare_firmware;
-	klass_device->attach = fu_vli_usbhub_device_attach;
-	klass_device->to_string = fu_vli_usbhub_device_to_string;
-	klass_device->ready = fu_vli_usbhub_device_ready;
-	klass_device->set_progress = fu_vli_usbhub_device_set_progress;
-	klass_vli_device->spi_chip_erase = fu_vli_usbhub_device_spi_chip_erase;
-	klass_vli_device->spi_sector_erase = fu_vli_usbhub_device_spi_sector_erase;
-	klass_vli_device->spi_read_data = fu_vli_usbhub_device_spi_read_data;
-	klass_vli_device->spi_read_status = fu_vli_usbhub_device_spi_read_status;
-	klass_vli_device->spi_write_data = fu_vli_usbhub_device_spi_write_data;
-	klass_vli_device->spi_write_enable = fu_vli_usbhub_device_spi_write_enable;
-	klass_vli_device->spi_write_status = fu_vli_usbhub_device_spi_write_status;
+	device_class->probe = fu_vli_usbhub_device_probe;
+	device_class->dump_firmware = fu_vli_usbhub_device_dump_firmware;
+	device_class->write_firmware = fu_vli_usbhub_device_write_firmware;
+	device_class->prepare_firmware = fu_vli_usbhub_device_prepare_firmware;
+	device_class->attach = fu_vli_usbhub_device_attach;
+	device_class->to_string = fu_vli_usbhub_device_to_string;
+	device_class->ready = fu_vli_usbhub_device_ready;
+	device_class->set_progress = fu_vli_usbhub_device_set_progress;
+	vli_device_class->spi_chip_erase = fu_vli_usbhub_device_spi_chip_erase;
+	vli_device_class->spi_sector_erase = fu_vli_usbhub_device_spi_sector_erase;
+	vli_device_class->spi_read_data = fu_vli_usbhub_device_spi_read_data;
+	vli_device_class->spi_read_status = fu_vli_usbhub_device_spi_read_status;
+	vli_device_class->spi_write_data = fu_vli_usbhub_device_spi_write_data;
+	vli_device_class->spi_write_enable = fu_vli_usbhub_device_spi_write_enable;
+	vli_device_class->spi_write_status = fu_vli_usbhub_device_spi_write_status;
 }

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -327,9 +327,9 @@ fu_vli_usbhub_firmware_init(FuVliUsbhubFirmware *self)
 static void
 fu_vli_usbhub_firmware_class_init(FuVliUsbhubFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->parse = fu_vli_usbhub_firmware_parse;
-	klass_firmware->export = fu_vli_usbhub_firmware_export;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_vli_usbhub_firmware_parse;
+	firmware_class->export = fu_vli_usbhub_firmware_export;
 }
 
 FuFirmware *

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -333,12 +333,12 @@ fu_vli_usbhub_msp430_device_init(FuVliUsbhubMsp430Device *self)
 static void
 fu_vli_usbhub_msp430_device_class_init(FuVliUsbhubMsp430DeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_vli_usbhub_msp430_device_probe;
-	klass_device->setup = fu_vli_usbhub_msp430_device_setup;
-	klass_device->detach = fu_vli_usbhub_msp430_device_detach;
-	klass_device->write_firmware = fu_vli_usbhub_msp430_device_write_firmware;
-	klass_device->set_progress = fu_vli_usbhub_msp430_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_vli_usbhub_msp430_device_probe;
+	device_class->setup = fu_vli_usbhub_msp430_device_setup;
+	device_class->detach = fu_vli_usbhub_msp430_device_detach;
+	device_class->write_firmware = fu_vli_usbhub_msp430_device_write_firmware;
+	device_class->set_progress = fu_vli_usbhub_msp430_device_set_progress;
 }
 
 FuDevice *

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -298,17 +298,17 @@ fu_vli_usbhub_pd_device_init(FuVliUsbhubPdDevice *self)
 static void
 fu_vli_usbhub_pd_device_class_init(FuVliUsbhubPdDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_vli_usbhub_pd_device_to_string;
-	klass_device->probe = fu_vli_usbhub_pd_device_probe;
-	klass_device->setup = fu_vli_usbhub_pd_device_setup;
-	klass_device->reload = fu_vli_usbhub_pd_device_reload;
-	klass_device->attach = fu_vli_usbhub_pd_device_attach;
-	klass_device->dump_firmware = fu_vli_usbhub_pd_device_dump_firmware;
-	klass_device->write_firmware = fu_vli_usbhub_pd_device_write_firmware;
-	klass_device->prepare_firmware = fu_vli_usbhub_pd_device_prepare_firmware;
-	klass_device->convert_version = fu_vli_usbhub_pd_device_convert_version;
-	klass_device->set_progress = fu_vli_usbhub_pd_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_vli_usbhub_pd_device_to_string;
+	device_class->probe = fu_vli_usbhub_pd_device_probe;
+	device_class->setup = fu_vli_usbhub_pd_device_setup;
+	device_class->reload = fu_vli_usbhub_pd_device_reload;
+	device_class->attach = fu_vli_usbhub_pd_device_attach;
+	device_class->dump_firmware = fu_vli_usbhub_pd_device_dump_firmware;
+	device_class->write_firmware = fu_vli_usbhub_pd_device_write_firmware;
+	device_class->prepare_firmware = fu_vli_usbhub_pd_device_prepare_firmware;
+	device_class->convert_version = fu_vli_usbhub_pd_device_convert_version;
+	device_class->set_progress = fu_vli_usbhub_pd_device_set_progress;
 }
 
 FuDevice *

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -543,14 +543,14 @@ fu_vli_usbhub_rtd21xx_device_init(FuVliUsbhubRtd21xxDevice *self)
 static void
 fu_vli_usbhub_rtd21xx_device_class_init(FuVliUsbhubRtd21xxDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->probe = fu_vli_usbhub_rtd21xx_device_probe;
-	klass_device->setup = fu_vli_usbhub_rtd21xx_device_setup;
-	klass_device->reload = fu_vli_usbhub_rtd21xx_device_reload;
-	klass_device->attach = fu_vli_usbhub_rtd21xx_device_attach;
-	klass_device->detach = fu_vli_usbhub_rtd21xx_device_detach;
-	klass_device->write_firmware = fu_vli_usbhub_rtd21xx_device_write_firmware;
-	klass_device->set_progress = fu_vli_usbhub_rtd21xx_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_vli_usbhub_rtd21xx_device_probe;
+	device_class->setup = fu_vli_usbhub_rtd21xx_device_setup;
+	device_class->reload = fu_vli_usbhub_rtd21xx_device_reload;
+	device_class->attach = fu_vli_usbhub_rtd21xx_device_attach;
+	device_class->detach = fu_vli_usbhub_rtd21xx_device_detach;
+	device_class->write_firmware = fu_vli_usbhub_rtd21xx_device_write_firmware;
+	device_class->set_progress = fu_vli_usbhub_rtd21xx_device_set_progress;
 }
 
 FuDevice *

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -293,9 +293,9 @@ fu_wacom_aes_device_init(FuWacomAesDevice *self)
 static void
 fu_wacom_aes_device_class_init(FuWacomAesDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuWacomDeviceClass *klass_wac_device = FU_WACOM_DEVICE_CLASS(klass);
-	klass_device->setup = fu_wacom_aes_device_setup;
-	klass_device->attach = fu_wacom_aes_device_attach;
-	klass_wac_device->write_firmware = fu_wacom_aes_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuWacomDeviceClass *wac_device_class = FU_WACOM_DEVICE_CLASS(klass);
+	device_class->setup = fu_wacom_aes_device_setup;
+	device_class->attach = fu_wacom_aes_device_attach;
+	wac_device_class->write_firmware = fu_wacom_aes_device_write_firmware;
 }

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -330,11 +330,11 @@ fu_wacom_device_init(FuWacomDevice *self)
 static void
 fu_wacom_device_class_init(FuWacomDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->to_string = fu_wacom_device_to_string;
-	klass_device->write_firmware = fu_wacom_device_write_firmware;
-	klass_device->detach = fu_wacom_device_detach;
-	klass_device->set_quirk_kv = fu_wacom_device_set_quirk_kv;
-	klass_device->probe = fu_wacom_device_probe;
-	klass_device->set_progress = fu_wacom_device_set_progress;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_wacom_device_to_string;
+	device_class->write_firmware = fu_wacom_device_write_firmware;
+	device_class->detach = fu_wacom_device_detach;
+	device_class->set_quirk_kv = fu_wacom_device_set_quirk_kv;
+	device_class->probe = fu_wacom_device_probe;
+	device_class->set_progress = fu_wacom_device_set_progress;
 }

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -283,10 +283,10 @@ fu_wacom_emr_device_init(FuWacomEmrDevice *self)
 static void
 fu_wacom_emr_device_class_init(FuWacomEmrDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	FuWacomDeviceClass *klass_wac_device = FU_WACOM_DEVICE_CLASS(klass);
-	klass_device->setup = fu_wacom_emr_device_setup;
-	klass_device->attach = fu_wacom_emr_device_attach;
-	klass_device->convert_version = fu_wacom_emr_device_convert_version;
-	klass_wac_device->write_firmware = fu_wacom_emr_device_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	FuWacomDeviceClass *wac_device_class = FU_WACOM_DEVICE_CLASS(klass);
+	device_class->setup = fu_wacom_emr_device_setup;
+	device_class->attach = fu_wacom_emr_device_attach;
+	device_class->convert_version = fu_wacom_emr_device_convert_version;
+	wac_device_class->write_firmware = fu_wacom_emr_device_write_firmware;
 }

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -907,12 +907,12 @@ static void
 fu_wac_device_class_init(FuWacDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_wac_device_finalize;
-	klass_device->write_firmware = fu_wac_device_write_firmware;
-	klass_device->to_string = fu_wac_device_to_string;
-	klass_device->setup = fu_wac_device_setup;
-	klass_device->close = fu_wac_device_close;
-	klass_device->set_progress = fu_wac_device_set_progress;
-	klass_device->convert_version = fu_wac_device_convert_version;
+	device_class->write_firmware = fu_wac_device_write_firmware;
+	device_class->to_string = fu_wac_device_to_string;
+	device_class->setup = fu_wac_device_setup;
+	device_class->close = fu_wac_device_close;
+	device_class->set_progress = fu_wac_device_set_progress;
+	device_class->convert_version = fu_wac_device_convert_version;
 }

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -374,10 +374,10 @@ fu_wac_firmware_init(FuWacFirmware *self)
 static void
 fu_wac_firmware_class_init(FuWacFirmwareClass *klass)
 {
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
-	klass_firmware->validate = fu_wac_firmware_validate;
-	klass_firmware->parse = fu_wac_firmware_parse;
-	klass_firmware->write = fu_wac_firmware_write;
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->validate = fu_wac_firmware_validate;
+	firmware_class->parse = fu_wac_firmware_parse;
+	firmware_class->write = fu_wac_firmware_write;
 }
 
 FuFirmware *

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
@@ -180,8 +180,8 @@ fu_wac_module_bluetooth_id6_init(FuWacModuleBluetoothId6 *self)
 static void
 fu_wac_module_bluetooth_id6_class_init(FuWacModuleBluetoothId6Class *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_bluetooth_id6_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_bluetooth_id6_write_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -286,9 +286,9 @@ fu_wac_module_bluetooth_id9_init(FuWacModuleBluetoothId9 *self)
 static void
 fu_wac_module_bluetooth_id9_class_init(FuWacModuleBluetoothId9Class *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_bluetooth_id9_write_firmware;
-	klass_device->prepare_firmware = fu_wac_module_bluetooth_id9_prepare_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_bluetooth_id9_write_firmware;
+	device_class->prepare_firmware = fu_wac_module_bluetooth_id9_prepare_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module-bluetooth.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth.c
@@ -219,8 +219,8 @@ fu_wac_module_bluetooth_init(FuWacModuleBluetooth *self)
 static void
 fu_wac_module_bluetooth_class_init(FuWacModuleBluetoothClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_bluetooth_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_bluetooth_write_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module-scaler.c
+++ b/plugins/wacom-usb/fu-wac-module-scaler.c
@@ -169,8 +169,8 @@ fu_wac_module_scaler_init(FuWacModuleScaler *self)
 static void
 fu_wac_module_scaler_class_init(FuWacModuleScalerClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_scaler_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_scaler_write_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module-touch-id7.c
+++ b/plugins/wacom-usb/fu-wac-module-touch-id7.c
@@ -383,8 +383,8 @@ fu_wac_module_touch_id7_init(FuWacModuleTouchId7 *self)
 static void
 fu_wac_module_touch_id7_class_init(FuWacModuleTouchId7Class *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_touch_id7_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_touch_id7_write_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module-touch.c
+++ b/plugins/wacom-usb/fu-wac-module-touch.c
@@ -136,8 +136,8 @@ fu_wac_module_touch_init(FuWacModuleTouch *self)
 static void
 fu_wac_module_touch_class_init(FuWacModuleTouchClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
-	klass_device->write_firmware = fu_wac_module_touch_write_firmware;
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->write_firmware = fu_wac_module_touch_write_firmware;
 }
 
 FuWacModule *

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -298,7 +298,7 @@ fu_wac_module_class_init(FuWacModuleClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	GParamSpec *pspec;
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 
 	/* properties */
 	object_class->get_property = fu_wac_module_get_property;
@@ -319,7 +319,7 @@ fu_wac_module_class_init(FuWacModuleClass *klass)
 	g_object_class_install_property(object_class, PROP_FW_TYPE, pspec);
 
 	object_class->constructed = fu_wac_module_constructed;
-	klass_device->to_string = fu_wac_module_to_string;
-	klass_device->cleanup = fu_wac_module_cleanup;
-	klass_device->set_progress = fu_wac_module_set_progress;
+	device_class->to_string = fu_wac_module_to_string;
+	device_class->cleanup = fu_wac_module_cleanup;
+	device_class->set_progress = fu_wac_module_set_progress;
 }

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -833,16 +833,16 @@ fu_wistron_dock_device_finalize(GObject *object)
 static void
 fu_wistron_dock_device_class_init(FuWistronDockDeviceClass *klass)
 {
-	FuDeviceClass *klass_device = FU_DEVICE_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	object_class->finalize = fu_wistron_dock_device_finalize;
-	klass_device->to_string = fu_wistron_dock_device_to_string;
-	klass_device->prepare_firmware = fu_wistron_dock_device_prepare_firmware;
-	klass_device->write_firmware = fu_wistron_dock_device_write_firmware;
-	klass_device->attach = fu_wistron_dock_device_attach;
-	klass_device->detach = fu_wistron_dock_device_detach;
-	klass_device->setup = fu_wistron_dock_device_setup;
-	klass_device->cleanup = fu_wistron_dock_device_cleanup;
-	klass_device->set_progress = fu_wistron_dock_device_set_progress;
-	klass_device->convert_version = fu_wistron_dock_device_convert_version;
+	device_class->to_string = fu_wistron_dock_device_to_string;
+	device_class->prepare_firmware = fu_wistron_dock_device_prepare_firmware;
+	device_class->write_firmware = fu_wistron_dock_device_write_firmware;
+	device_class->attach = fu_wistron_dock_device_attach;
+	device_class->detach = fu_wistron_dock_device_detach;
+	device_class->setup = fu_wistron_dock_device_setup;
+	device_class->cleanup = fu_wistron_dock_device_cleanup;
+	device_class->set_progress = fu_wistron_dock_device_set_progress;
+	device_class->convert_version = fu_wistron_dock_device_convert_version;
 }

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -229,11 +229,11 @@ static void
 fu_bluez_backend_class_init(FuBluezBackendClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
 
 	object_class->finalize = fu_bluez_backend_finalize;
-	klass_backend->setup = fu_bluez_backend_setup;
-	klass_backend->coldplug = fu_bluez_backend_coldplug;
+	backend_class->setup = fu_bluez_backend_setup;
+	backend_class->coldplug = fu_bluez_backend_coldplug;
 }
 
 FuBackend *

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -1006,9 +1006,9 @@ static void
 fu_cabinet_class_init(FuCabinetClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
 	object_class->finalize = fu_cabinet_finalize;
-	klass_firmware->parse = fu_cabinet_parse;
+	firmware_class->parse = fu_cabinet_parse;
 }
 
 /**

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -342,9 +342,9 @@ static void
 fu_udev_backend_class_init(FuUdevBackendClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
 	object_class->finalize = fu_udev_backend_finalize;
-	klass_backend->coldplug = fu_udev_backend_coldplug;
+	backend_class->coldplug = fu_udev_backend_coldplug;
 }
 
 FuBackend *

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -267,13 +267,13 @@ static void
 fu_usb_backend_class_init(FuUsbBackendClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuBackendClass *klass_backend = FU_BACKEND_CLASS(klass);
+	FuBackendClass *backend_class = FU_BACKEND_CLASS(klass);
 	object_class->finalize = fu_usb_backend_finalize;
-	klass_backend->setup = fu_usb_backend_setup;
-	klass_backend->coldplug = fu_usb_backend_coldplug;
-	klass_backend->load = fu_usb_backend_load;
-	klass_backend->save = fu_usb_backend_save;
-	klass_backend->registered = fu_usb_backend_registered;
+	backend_class->setup = fu_usb_backend_setup;
+	backend_class->coldplug = fu_usb_backend_coldplug;
+	backend_class->load = fu_usb_backend_load;
+	backend_class->save = fu_usb_backend_save;
+	backend_class->registered = fu_usb_backend_registered;
 }
 
 FuBackend *


### PR DESCRIPTION
Only `class` is a reserved word, and the project was using about half a dozen different styles.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
