### PR TITLE
plugins/flashrom: Don't check the quirk for coreboot firmware

### DIFF
--- a/0001-flashrom-Always-load-the-plugin-when-using-coreboot.patch
+++ b/0001-flashrom-Always-load-the-plugin-when-using-coreboot.patch
@@ -1,0 +1,36 @@
+From 36c374e9a846b1a06b80084f3de4a4036730dc7b Mon Sep 17 00:00:00 2001
+From: Richard Hughes <richard@hughsie.com>
+Date: Wed, 14 Feb 2024 22:00:51 +0000
+Subject: [PATCH] flashrom: Always load the plugin when using coreboot
+
+Based on a patch by Sean Rhodes <sean@starlabs.systems>, many thanks.
+---
+ plugins/flashrom/fu-flashrom-plugin.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/flashrom/fu-flashrom-plugin.c b/plugins/flashrom/fu-flashrom-plugin.c
+index 1875149d8..0b11af931 100644
+--- a/plugins/flashrom/fu-flashrom-plugin.c
++++ b/plugins/flashrom/fu-flashrom-plugin.c
+@@ -245,6 +245,10 @@ fu_flashrom_plugin_find_guid(FuPlugin *plugin, GError **error)
+ 	FuContext *ctx = fu_plugin_get_context(plugin);
+ 	GPtrArray *hwids = fu_context_get_hwid_guids(ctx);
+ 
++	/* any coreboot */
++	if (g_strcmp0(fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_BIOS_VENDOR), "coreboot") == 0)
++		return g_strdup(FWUPD_DEVICE_ID_ANY);
++
+ 	for (guint i = 0; i < hwids->len; i++) {
+ 		const gchar *guid = g_ptr_array_index(hwids, i);
+ 		const gchar *plugin_name =
+@@ -336,7 +340,6 @@ fu_flashrom_plugin_constructed(GObject *obj)
+ 	(void)fu_plugin_alloc_data(plugin, sizeof(FuFlashromPlugin));
+ 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "linux_lockdown");
+ 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "coreboot"); /* obsoleted */
+-	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
+ 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY);
+ }
+ 
+-- 
+2.40.1
+

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -1,7 +1,3 @@
-# Purism
-[a0ce5085-2dea-5086-ae72-45810a186ad0]
-Plugin = flashrom
-
 # Libretrend
 [52b68c34-6b31-5ecc-8a5c-de37e666ccd5]
 Plugin = flashrom
@@ -11,48 +7,8 @@ VersionFormat = quad
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
 Plugin = flashrom
 
-# StarLite Mk II (HwId - coreboot)
-[0130a1a1-f888-5977-820a-6214bf1d6ab2]
-Plugin = flashrom
-
-# StarLite Mk III (HwId)
-[d5521faa-c50b-5d64-971d-8fd400030c51]
-Plugin = flashrom
-
-# StarLite Mk IV (HwId)
-[0fc25c8c-ffa8-54ad-a216-d13cfe75bee4]
-Plugin = flashrom
-
 # StarLabTop Mk III (HwId - AMI)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
-Plugin = flashrom
-
-# StarLabTop Mk III (HwId - coreboot)
-[8f8ca82b-30e1-5907-bc9d-4257a49898d4]
-Plugin = flashrom
-
-# StarLabTop Mk IV (HwId)
-[baf1d04e-fd16-5e6a-93cc-1c23d171f879]
-Plugin = flashrom
-
-# StarBookMk V (HwId)
-[85aba599-addd-5985-a2e8-eddb41c61ba3]
-Plugin = flashrom
-
-# StarBook Mk VI - Intel (HwId)
-[5c917039-d938-5c9a-b22a-9c392b1534f3]
-Plugin = flashrom
-
-# StarBook Mk VI - AMD (HwId)
-[b39593ad-7522-52a5-a4ab-1b2ca2153956]
-Plugin = flashrom
-
-# StarBook Mk VIr2 - Intel (HwId)
-[12122d1c-c383-5583-9cb7-3ba8d220913d]
-Plugin = flashrom
-
-# Byte Mk I - AMD (HwId)
-[79a64046-5643-59c4-91d0-e68b33db5829]
 Plugin = flashrom
 
 # StarLabTop Mk III (coreboot GUID)

--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -245,6 +245,10 @@ fu_flashrom_plugin_find_guid(FuPlugin *plugin, GError **error)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	GPtrArray *hwids = fu_context_get_hwid_guids(ctx);
 
+	/* any coreboot */
+	if (g_strcmp0(fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_BIOS_VENDOR), "coreboot") == 0)
+		return g_strdup(FWUPD_DEVICE_ID_ANY);
+
 	for (guint i = 0; i < hwids->len; i++) {
 		const gchar *guid = g_ptr_array_index(hwids, i);
 		const gchar *plugin_name =
@@ -336,7 +340,6 @@ fu_flashrom_plugin_constructed(GObject *obj)
 	(void)fu_plugin_alloc_data(plugin, sizeof(FuFlashromPlugin));
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "linux_lockdown");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "coreboot"); /* obsoleted */
-	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY);
 }
 


### PR DESCRIPTION
coreboot can only be updated by flashrom, so don't check the quirk if the device is running coreboot.
