### PR TITLE
flashrom: Always load the plugin when using coreboot

### DIFF
--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -467,6 +467,9 @@ fu_hwids_init(FuHwids *self)
 	fu_hwids_add_chid(self, "HardwareID-14", "Manufacturer");
 
 	/* used by the flashrom plugin */
+	fu_hwids_add_chid(self,
+			  "fwupd-04",
+			  "Manufacturer&Family&ProductName&ProductSku&BiosVendor");
 	fu_hwids_add_chid(self, "fwupd-05", "Manufacturer&Family&ProductName&BiosVendor");
 	fu_hwids_add_chid(self, "fwupd-14", "Manufacturer&BiosVendor");
 }

--- a/plugins/flashrom/flashrom.quirk
+++ b/plugins/flashrom/flashrom.quirk
@@ -7,6 +7,10 @@ Plugin = flashrom
 Plugin = flashrom
 VersionFormat = quad
 
+# Star Labs generic (HwId - coreboot)
+[b8cf5af6-8a46-5deb-ac01-a35b1ea5fb48]
+Plugin = flashrom
+
 # StarLite Mk II (HwId - AMI)
 [013b60e5-1023-5bee-8ae5-14cae21377b7]
 Plugin = flashrom


### PR DESCRIPTION
Based on a patch by Sean Rhodes <sean@starlabs.systems>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
