### PR TITLE
Limit the maximum depth of child firmware

### DIFF
--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -304,6 +304,8 @@ void
 fu_firmware_set_images_max(FuFirmware *self, guint images_max) G_GNUC_NON_NULL(1);
 guint
 fu_firmware_get_images_max(FuFirmware *self) G_GNUC_NON_NULL(1);
+guint
+fu_firmware_get_depth(FuFirmware *self) G_GNUC_NON_NULL(1);
 guint64
 fu_firmware_get_idx(FuFirmware *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3288,6 +3288,11 @@ fu_firmware_func(void)
 	fu_firmware_set_id(img2, "secondary");
 	fu_firmware_add_image(firmware, img2);
 
+	/* check depth */
+	g_assert_cmpint(fu_firmware_get_depth(firmware), ==, 0);
+	g_assert_cmpint(fu_firmware_get_depth(img1), ==, 1);
+	g_assert_cmpint(fu_firmware_get_depth(img2), ==, 1);
+
 	img_id = fu_firmware_get_image_by_id(firmware, "NotGoingToExist", &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
 	g_assert_null(img_id);


### PR DESCRIPTION
This should prevent invalid firmware from deeply nesting.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
