### PR TITLE
trivial: Fix an infinite loop when parsing invalid EFI firmware

### DIFF
--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -253,6 +253,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 {
 	FuEfiSection *self = FU_EFI_SECTION(firmware);
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
+	gsize streamsz = 0;
 	guint32 size;
 	g_autoptr(GByteArray) st = NULL;
 	g_autoptr(GInputStream) partial_stream = NULL;
@@ -278,6 +279,19 @@ fu_efi_section_parse(FuFirmware *firmware,
 			    FWUPD_ERROR_INTERNAL,
 			    "invalid section size, got 0x%x",
 			    (guint)size);
+		return FALSE;
+	}
+
+	/* sanity check */
+	if (!fu_input_stream_size(stream, &streamsz, error))
+		return FALSE;
+	if (size > streamsz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "invalid section size, got 0x%x from stream of size 0x%x",
+			    (guint)size,
+			    (guint)streamsz);
 		return FALSE;
 	}
 


### PR DESCRIPTION
This was caused by stream underflow, and was found using oss-fuzz, many thanks.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66717

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
