### PR TITLE
Only recover the version format for specific devices

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -275,7 +275,7 @@ typedef enum {
 	/**
 	 * FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT:
 	 *
-	 * Set the device version format from the metadata if available.
+	 * Set the device version format from the metadata or history database if available.
 	 *
 	 * Since: 1.5.5
 	 */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6157,7 +6157,8 @@ fu_engine_device_inherit_history(FuEngine *self, FuDevice *device)
 	/* in an offline environment we may have used the .cab file to find the version-format
 	 * to use for the device -- so when we reboot use the database as the archive data is no
 	 * longer available */
-	if (fu_device_get_version_format(device_history) != FWUPD_VERSION_FORMAT_UNKNOWN) {
+	if (fu_device_has_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT) &&
+	    fu_device_get_version_format(device_history) != FWUPD_VERSION_FORMAT_UNKNOWN) {
 		g_debug(
 		    "absorbing version format %s into %s from history database",
 		    fwupd_version_format_to_string(fu_device_get_version_format(device_history)),

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2644,6 +2644,7 @@ fu_engine_history_verfmt_func(gconstpointer user_data)
 	fu_device_add_checksum(device, "0123456789abcdef0123456789abcdef01234567");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT);
 	fu_device_set_created(device, 1515338000);
 	fu_engine_add_device(engine, device);
 	g_assert_cmpint(fu_device_get_version_format(device), ==, FWUPD_VERSION_FORMAT_TRIPLET);


### PR DESCRIPTION
Use the md-set-verfmt flag to mean that the plugin has set something as a best guess, but that the metadata (or history database) should fix it up to reality.

Also, apologies to Mario, who in the original pull request said that this might be a problem.

Fixes https://github.com/fwupd/fwupd/issues/6832

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
