### PR TITLE
trivial: Fix the error message when comparing the ESRT version_lowest

### DIFF
--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -683,7 +683,7 @@ fu_release_check_requirements(FuRelease *self,
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Specified firmware is older than the minimum "
 			    "required version '%s < %s'",
-			    version,
+			    fu_release_get_version(self),
 			    version_lowest);
 		return FALSE;
 	}


### PR DESCRIPTION
We want to show the thing that we compared, i.e. the new release version against the ESRT lowest version.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
