### PR TITLE
trivial: uefi-capsule: Correct the CoD capsule path

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -141,7 +141,7 @@ fu_uefi_cod_device_get_indexed_filename(FuUefiDevice *self, GError **error)
 	for (guint i = 0; i < 0xFFFF; i++) {
 		g_autofree gchar *basename = g_strdup_printf("CapsuleUpdateFile%04X.bin", i);
 		g_autofree gchar *cod_path =
-		    g_build_filename(esp_path, "EFI", "UpdateCapsule", basename, NULL);
+		    g_build_filename(esp_path, "EFIUpdateCapsule", basename, NULL);
 		if (!g_file_test(cod_path, G_FILE_TEST_EXISTS))
 			return g_steal_pointer(&cod_path);
 	}
@@ -164,7 +164,7 @@ fu_uefi_cod_device_get_filename(FuUefiDevice *self, GError **error)
 
 	/* fallback */
 	basename = g_strdup_printf("fwupd-%s.cap", fu_uefi_device_get_guid(self));
-	return g_build_filename(esp_path, "EFI", "UpdateCapsule", basename, NULL);
+	return g_build_filename(esp_path, "EFIUpdateCapsule", basename, NULL);
 }
 
 static gboolean


### PR DESCRIPTION
Per the spec the path is not `${ESP}\EFI\UpdateCapsule` but rather it is `${ESP}\EFIUpdateCapsule`.

Adjust the path used to match this.

Link: https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html#delivery-of-capsules-via-file-on-mass-storage-device

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
