### PR TITLE
Allow plugins to opt-into a default device GType

### DIFF
--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -52,6 +52,38 @@ typedef enum {
 	FU_PLUGIN_VERIFY_FLAG_LAST
 } FuPluginVerifyFlags;
 
+/**
+ * FuPluginInternalFlags:
+ *
+ * The plugin internal flags, not exported over D-Bus.
+ **/
+typedef enum {
+	/**
+	 * FU_PLUGIN_INTERNAL_FLAG_NONE:
+	 *
+	 * No flags set.
+	 *
+	 * Since: 1.9.14
+	 */
+	FU_PLUGIN_INTERNAL_FLAG_NONE = 0,
+	/**
+	 * FU_PLUGIN_INTERNAL_FLAG_DEFAULT_DEVICE_GTYPE:
+	 *
+	 * Use the first-added plugin GType when there are multiple to choose from.
+	 *
+	 * Since: 1.9.14
+	 */
+	FU_PLUGIN_INTERNAL_FLAG_DEFAULT_DEVICE_GTYPE = 1ull << 0,
+	/**
+	 * FU_PLUGIN_INTERNAL_FLAG_UNKNOWN:
+	 *
+	 * Unknown flag value.
+	 *
+	 * Since: 1.9.14
+	 */
+	FU_PLUGIN_INTERNAL_FLAG_UNKNOWN = G_MAXUINT64,
+} FuPluginInternalFlags;
+
 struct _FuPluginClass {
 	FwupdPluginClass parent_class;
 	/* signals */
@@ -513,3 +545,9 @@ fu_plugin_set_config_value(FuPlugin *self, const gchar *key, const gchar *value,
     G_GNUC_NON_NULL(1, 2);
 FwupdSecurityAttr *
 fu_plugin_security_attr_new(FuPlugin *self, const gchar *appstream_id) G_GNUC_NON_NULL(1, 2);
+void
+fu_plugin_add_internal_flag(FuPlugin *self, FuPluginInternalFlags flag) G_GNUC_NON_NULL(1);
+void
+fu_plugin_remove_internal_flag(FuPlugin *self, FuPluginInternalFlags flag) G_GNUC_NON_NULL(1);
+gboolean
+fu_plugin_has_internal_flag(FuPlugin *self, FuPluginInternalFlags flag) G_GNUC_NON_NULL(1);

--- a/plugins/wacom-usb/fu-wac-plugin.c
+++ b/plugins/wacom-usb/fu-wac-plugin.c
@@ -86,6 +86,7 @@ fu_wac_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_ANDROID_DEVICE);
+	fu_plugin_add_internal_flag(plugin, FU_PLUGIN_INTERNAL_FLAG_DEFAULT_DEVICE_GTYPE);
 	fu_plugin_add_firmware_gtype(plugin, "wacom", FU_TYPE_WAC_FIRMWARE);
 }
 

--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -2,19 +2,16 @@
 # Intuos Pro medium (2nd-gen USB) [PTH-660]
 [USB\VID_056A&PID_0357]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version
 
 # Intuos Pro large (2nd-gen USB) [PTH-860]
 [USB\VID_056A&PID_0358]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version
 
 # Intuos S 3rd-gen (USB) [CTL-4100]
 [USB\VID_056A&PID_0374]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos S 3rd-gen (USB) [CTL-4100 - Android Mode]
@@ -25,7 +22,6 @@ GType = FuWacAndroidDevice
 # Intuos M 3rd-gen (USB) [CTL-6100]
 [USB\VID_056A&PID_0375]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos M 3rd-gen (USB) [CTL-6100 - Android Mode]
@@ -36,7 +32,6 @@ GType = FuWacAndroidDevice
 # Intuos BT S 3rd-gen (USB) [CTL-4100WL]
 [USB\VID_056A&PID_0376]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT S 3rd-gen (USB) [CTL-4100WL - Android Mode]
@@ -47,7 +42,6 @@ GType = FuWacAndroidDevice
 # Intuos BT M 3rd-gen (USB) [CTL-6100WL]
 [USB\VID_056A&PID_0378]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT M 3rd-gen (USB) [CTL-6100WL - Android Mode]
@@ -57,13 +51,11 @@ GType = FuWacAndroidDevice
 
 # Intuos Pro Small (2nd-gen USB) [PTH-460]
 [USB\VID_056A&PID_0392]
-GType = FuWacDevice
 Plugin = wacom_usb
 
 # Intuos BT S 3rd-gen, Rev 2 (USB) [CTL-4100WL]
 [USB\VID_056A&PID_03C5]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT S 3rd-gen, Rev 2 (USB) [CTL-4100WL - Android Mode]
@@ -74,7 +66,6 @@ GType = FuWacAndroidDevice
 # Intuos BT M 3rd-gen, Rev 2 (USB) [CTL-6100WL]
 [USB\VID_056A&PID_03C7]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT M 3rd-gen, Rev 2 (USB) [CTL-6100WL - Android Mode]
@@ -84,62 +75,50 @@ GType = FuWacAndroidDevice
 
 # Intuos Pro Small (2nd-gen USB v2) [PTH-460]
 [USB\VID_056A&PID_03DC]
-GType = FuWacDevice
 Plugin = wacom_usb
 
 # Cintiq Pro 27 (USB) [DTH271]
 [USB\VID_056A&PID_03C0]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One 13 (USB) [DTH-134]
 [USB\VID_056A&PID_03CB]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One 12 (USB) [DTC-121]
 [USB\VID_056A&PID_03CE]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # DTH134 (USB) [DTH-134]
 [USB\VID_056A&PID_03EC]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # DTC121 (USB) [DTC-121]
 [USB\VID_056A&PID_03ED]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One Pen tablet small (USB) [CTC4110WL]
 [USB\VID_0531&PID_0100]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = no-serial-number
 
 # Wacom One Pen tablet small (USB) [CTC4110WL - Android Mode]
 [USB\VID_0531&PID_0104]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One Pen tablet medium (USB) [CTC6110WL]
 [USB\VID_0531&PID_0102]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = no-serial-number
 
 # Wacom One Pen tablet medium (USB) [CTC6110WL - Android Mode]
 [USB\VID_0531&PID_0105]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Cintiq Pro 17 (USB) [DTH172]
 [USB\VID_056A&PID_03C4]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Cintiq Pro 22 (USB) [DTH227]
 [USB\VID_056A&PID_03D0]
 Plugin = wacom_usb
-GType = FuWacDevice


### PR DESCRIPTION
If a vendor is using a DS-20 BOS descriptor this allows the embedded quirk to be much smaller, maybe just a single line.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
