### PR TITLE
Add some basic umockdev tests

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -11,7 +11,7 @@ license=('GPL2')
 depends=('libgusb' 'modemmanager' 'tpm2-tss')
 makedepends=('meson' 'valgrind' 'gobject-introspection' 'gi-docgen' 'git'
              'python-cairo' 'noto-fonts' 'noto-fonts-cjk' 'python-gobject' 'vala'
-             'libdrm' 'curl' 'polkit' 'xz')
+             'python-dbusmock' 'libdrm' 'curl' 'polkit' 'xz')
 
 pkgver() {
     cd ${pkgname}

--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -36,7 +36,7 @@ tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 export TPM_SERVER_RUNNING=1
 
 # build the package
-sudo -E -u nobody PKGEXT='.pkg.tar' makepkg -e --noconfirm
+sudo -E -u nobody PKGEXT='.pkg.tar' makepkg -e --noconfirm --nocheck
 
 # move the package to artifact dir
 mkdir -p ../dist

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -424,6 +424,7 @@ systemctl --no-reload preset fwupd-refresh.timer &>/dev/null || :
 %{_datadir}/installed-tests/fwupd/fakedevice124.bin
 %{_datadir}/installed-tests/fwupd/fakedevice124.metainfo.xml
 %{_datadir}/installed-tests/fwupd/*.sh
+%{_datadir}/installed-tests/fwupd/*.py
 %if 0%{?have_uefi}
 %{_datadir}/installed-tests/fwupd/efi
 %endif

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -168,9 +168,11 @@ parts:
       - python3-cairo
       - python3-gi
       - python3-jinja2
+      - python3-dbusmock
       - protobuf-c-compiler
       - shim-signed
       - systemd
+      - umockdev
       - uuid-dev
     stage-packages:
       - libnghttp2-14

--- a/data/installed-tests/fwupd.sh
+++ b/data/installed-tests/fwupd.sh
@@ -22,6 +22,19 @@ run_device_tests()
 	fi
 }
 
+run_umockdev_test()
+{
+	INSPECTOR=@installedtestsdatadir@/unittest_inspector.py
+	ARG=@installedtestsdatadir@/$1
+	if [ -f ${INSPECTOR} ] && [ -f ${ARG} ]; then
+		TESTS=`${INSPECTOR} ${ARG}`
+		for test in ${TESTS}; do
+			${ARG} ${test} --verbose
+			rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+		done
+	fi
+}
+
 run_test acpi-dmar-self-test
 run_test acpi-facp-self-test
 run_test acpi-phat-self-test
@@ -40,6 +53,9 @@ run_test dfu-self-test
 run_test mtd-self-test
 run_test vli-self-test
 run_device_tests
+run_umockdev_test fwupd_test.py
+run_umockdev_test amd_pmc_test.py
+run_umockdev_test pci_psp_test.py
 
 # success!
 exit 0

--- a/docs/env.md
+++ b/docs/env.md
@@ -30,6 +30,7 @@ with a non-standard filesystem layout.
 
 * `CI_NETWORK` if CI is running with network access
 * `TPM_SERVER_RUNNING` if an emulated TPM is running
+* `UMOCKDEV_DIR` if set, running under umockdev
 
 Other variables, include:
 

--- a/generate-build/meson.build
+++ b/generate-build/meson.build
@@ -6,3 +6,7 @@ generate_dbus_interface = [python3, files('generate-dbus-interface.py')]
 generate_man = [python3, files('generate-man.py')]
 generate_index = [python3, files('generate-index.py')]
 fix_translations = [python3, files('fix_translations.py')]
+if umockdev_integration_tests.allowed()
+    unittest_inspector = [python3, files('unittest_inspector.py')]
+    install_data(files('unittest_inspector.py'), install_dir: installed_test_datadir)
+endif

--- a/generate-build/unittest_inspector.py
+++ b/generate-build/unittest_inspector.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1+
+#
+# Copyright © 2020, Canonical Ltd
+#
+# Authors:
+#       Marco Trevisan <marco.trevisan@canonical.com>
+
+import argparse
+import importlib.util
+import inspect
+import os
+import unittest
+
+
+def list_tests(module):
+    tests = []
+    for name, obj in inspect.getmembers(module):
+        if inspect.isclass(obj) and issubclass(obj, unittest.TestCase):
+            cases = unittest.defaultTestLoader.getTestCaseNames(obj)
+            tests += [(obj, "{}.{}".format(name, t)) for t in cases]
+    return tests
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("unittest_source", type=argparse.FileType("r"))
+
+    args = parser.parse_args()
+    source_path = args.unittest_source.name
+    spec = importlib.util.spec_from_file_location(
+        os.path.basename(source_path), source_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    for machine, human in list_tests(module):
+        print(human)

--- a/meson.build
+++ b/meson.build
@@ -449,8 +449,6 @@ if build_standalone
   conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
 endif
 
-umockdev = dependency('umockdev-1.0', required: false)
-
 if build_standalone
   libflashrom = dependency('flashrom', 
                             fallback: ['flashrom', 'flashrom_dep'], 
@@ -604,6 +602,21 @@ rustgen = generator(python3,
   ],
 )
 
+dbusmock = run_command(
+  [python3, '-c', 'import dbusmock; print(dbusmock.__version__)'],
+  check: false,
+)
+
+umockdev_integration_tests = get_option('umockdev_tests')                     \
+                              .disable_auto_if(not get_option('tests'))       \
+                              .disable_auto_if(not introspection.allowed())   \
+                              .disable_auto_if(dbusmock.returncode() != 0)
+umockdev = dependency('umockdev-1.0', required: get_option('umockdev_tests'))
+
+if dbusmock.returncode() != 0 and get_option('umockdev_tests').allowed()
+  warning('python dbusmock not found, umockdev tests will be disabled')
+endif
+
 allow_uefi_capsule = get_option('plugin_uefi_capsule').disable_auto_if(host_machine.system() not in ['linux', 'freebsd']).allowed()
 
 subdir('generate-build')
@@ -686,6 +699,7 @@ summary({
   'supported_build': supported_build,
   'static_analysis': static_analysis,
   'tests': get_option('tests'),
+  'umockdev_tests': umockdev_integration_tests.allowed(),
 }, section: 'project features')
 
 if build_daemon

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -466,6 +466,10 @@ option('tests',
   value: true,
   description: 'enable tests',
 )
+option('umockdev_tests',
+  type: 'feature',
+  description: 'umockdev tests',
+)
 option('curl',
   type: 'feature',
   description: 'libcurl support',

--- a/plugins/amd-pmc/amd_pmc_test.py
+++ b/plugins/amd-pmc/amd_pmc_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1+
+
+import os
+import sys
+import unittest
+from fwupd_test import FwupdTest, override_gi_search_path
+import gi
+
+try:
+    override_gi_search_path()
+    gi.require_version("Fwupd", "2.0")
+    from gi.repository import Fwupd  # pylint: disable=wrong-import-position
+except ValueError:
+    # when called from unittest-inspector this might not pass, we'll fail later
+    # anyway in actual use
+    pass
+
+
+class AmdPmcTest(FwupdTest):
+    def test_amd_pmc_device(self):
+        """Verify the AMD PMC device is detected correctly"""
+
+        self.testbed.add_from_string(
+            """P: /devices/platform/AMDI0009:00
+E: DRIVER=amd_pmc
+E: ID_PATH=platform-AMDI0009:00
+E: ID_PATH_TAG=platform-AMDI0009_00
+E: ID_VENDOR_FROM_DATABASE=Amdek Corporation
+E: MODALIAS=acpi:AMDI0009:PNP0D80:
+E: SUBSYSTEM=platform
+L: driver=../../../bus/platform/drivers/amd_pmc
+A: driver_override=(null)
+L: firmware_node=../../LNXSYSTM:00/LNXSYBUS:00/AMDI0009:00
+A: modalias=acpi:AMDI0009:PNP0D80:
+A: power/control=auto
+A: power/runtime_active_time=0
+A: power/runtime_status=unsupported
+A: power/runtime_suspended_time=0
+A: smu_fw_version=76.78.0
+A: smu_program=0
+"""
+        )
+
+        self.start_daemon()
+        devices = Fwupd.Client().get_devices()
+        count = 0
+        for dev in devices:
+            if dev.get_plugin() != "amd_pmc":
+                continue
+            self.assertEqual(dev.get_name(), "System Management Unit (SMU)")
+            self.assertEqual(dev.get_vendor(), "Advanced Micro Devices, Inc.")
+            self.assertEqual(dev.get_version(), "76.78.0")
+            count += 1
+        self.assertEqual(count, 1)
+
+    def test_amd_pmc_old_kernel(self):
+        """Verify the behavior of amd-pmc plugin with an older kernel"""
+
+        self.testbed.add_from_string(
+            """P: /devices/platform/AMDI0009:00
+E: DRIVER=amd_pmc
+E: ID_PATH=platform-AMDI0009:00
+E: ID_PATH_TAG=platform-AMDI0009_00
+E: ID_VENDOR_FROM_DATABASE=Amdek Corporation
+E: MODALIAS=acpi:AMDI0009:PNP0D80:
+E: SUBSYSTEM=platform
+L: driver=../../../bus/platform/drivers/amd_pmc
+A: driver_override=(null)
+L: firmware_node=../../LNXSYSTM:00/LNXSYBUS:00/AMDI0009:00
+A: modalias=acpi:AMDI0009:PNP0D80:
+A: power/control=auto
+A: power/runtime_active_time=0
+A: power/runtime_status=unsupported
+A: power/runtime_suspended_time=0
+"""
+        )
+        self.start_daemon()
+        devices = Fwupd.Client().get_devices()
+        for dev in devices:
+            self.assertNotEqual(dev.get_plugin(), "amd_pmc")
+
+    def test_amd_pmc_broken_kernel(self):
+        """Verify the behavior of amd-pmc plugin with a kernel that advertises SMU FW version but not program"""
+
+        self.testbed.add_from_string(
+            """P: /devices/platform/AMDI0009:00
+E: DRIVER=amd_pmc
+E: ID_PATH=platform-AMDI0009:00
+E: ID_PATH_TAG=platform-AMDI0009_00
+E: ID_VENDOR_FROM_DATABASE=Amdek Corporation
+E: MODALIAS=acpi:AMDI0009:PNP0D80:
+E: SUBSYSTEM=platform
+L: driver=../../../bus/platform/drivers/amd_pmc
+A: driver_override=(null)
+L: firmware_node=../../LNXSYSTM:00/LNXSYBUS:00/AMDI0009:00
+A: modalias=acpi:AMDI0009:PNP0D80:
+A: power/control=auto
+A: power/runtime_active_time=0
+A: power/runtime_status=unsupported
+A: power/runtime_suspended_time=0
+A: smu_fw_version=76.78.0
+"""
+        )
+        self.start_daemon()
+        devices = Fwupd.Client().get_devices()
+        for dev in devices:
+            self.assertNotEqual(dev.get_plugin(), "amd_pmc")
+
+
+if __name__ == "__main__":
+    # run ourselves under umockdev
+    if "umockdev" not in os.environ.get("LD_PRELOAD", ""):
+        os.execvp("umockdev-wrapper", ["umockdev-wrapper", sys.executable] + sys.argv)
+
+    prog = unittest.main(exit=False)
+    if prog.result.errors or prog.result.failures:
+        sys.exit(1)
+
+    # Translate to skip error
+    if prog.result.testsRun == len(prog.result.skipped):
+        sys.exit(77)

--- a/plugins/amd-pmc/meson.build
+++ b/plugins/amd-pmc/meson.build
@@ -13,4 +13,5 @@ plugin_builtins += static_library('fu_plugin_amd_pmc',
   c_args: cargs,
   dependencies: plugin_deps,
 )
+umockdev_tests += files('amd_pmc_test.py')
 endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -128,6 +128,29 @@ if get_option('plugin_vendor_example')
   plugins += {'vendor-example': false}
 endif
 
+umockdev_tests = []
 foreach plugin, enabled: plugins
   subdir(plugin)
 endforeach
+
+if umockdev_integration_tests.allowed()
+  envs = environment()
+  envs.set('DAEMON_BUILDDIR', join_paths(meson.project_build_root(), 'src'))
+  envs.set('LIBFWUPD_BUILD_DIR', join_paths(meson.project_build_root(), 'libfwupd'))
+  envs.set('PYTHONPATH', join_paths(meson.project_source_root(), 'src'))
+  envs.set('FWUPD_DATADIR_QUIRKS', join_paths(meson.project_build_root()))
+  envs.set('STATE_DIRECTORY', join_paths(meson.project_build_root(), 'state'))
+  envs.set('CACHE_DIRECTORY', join_paths(meson.project_build_root(), 'cache'))
+
+  foreach suite: umockdev_tests
+    r = run_command(unittest_inspector, suite,
+                    check: true, env: envs)
+    unit_tests = r.stdout().strip().split('\n')
+    foreach ut: unit_tests
+        test(ut, python3, args: [suite, ut], is_parallel: false, env: envs)
+    endforeach
+    install_data(suite,
+      install_dir: installed_test_datadir,
+    )
+  endforeach
+endif

--- a/plugins/pci-psp/meson.build
+++ b/plugins/pci-psp/meson.build
@@ -13,4 +13,5 @@ plugin_builtins += static_library('fu_plugin_pci_psp',
   c_args: cargs,
   dependencies: plugin_deps,
 )
+umockdev_tests += files('pci_psp_test.py')
 endif

--- a/plugins/pci-psp/pci_psp_test.py
+++ b/plugins/pci-psp/pci_psp_test.py
@@ -1,0 +1,423 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1+
+
+import gi
+import os
+import sys
+import unittest
+from fwupd_test import FwupdTest, override_gi_search_path
+
+try:
+    override_gi_search_path()
+    gi.require_version("Fwupd", "2.0")
+    from gi.repository import Fwupd  # pylint: disable=wrong-import-position
+except ValueError:
+    # when called from unittest-inspector this might not pass, we'll fail later
+    # anyway in actual use
+    pass
+
+
+class PciPspNoHsi(FwupdTest):
+    """A system that doesn't support exporting any HSI attributes or versions"""
+
+    def setUp(self):
+        super().setUp()
+        self.testbed.add_from_string(
+            """P: /devices/pci0000:20/0000:20:08.1/0000:23:00.1
+E: DRIVER=ccp
+E: PCI_CLASS=108000
+E: PCI_ID=1022:1486
+E: PCI_SUBSYS_ID=17AA:1046
+E: PCI_SLOT_NAME=0000:23:00.1
+E: MODALIAS=pci:v00001022d00001486sv000017AAsd00001046bc10sc80i00
+E: SUBSYSTEM=pci
+E: ID_PCI_CLASS_FROM_DATABASE=Encryption controller
+E: ID_PCI_SUBCLASS_FROM_DATABASE=Encryption controller
+E: ID_VENDOR_FROM_DATABASE=Advanced Micro Devices, Inc. [AMD]
+E: ID_MODEL_FROM_DATABASE=Starship/Matisse Cryptographic Coprocessor PSPCPP
+A: aer_dev_correctable=RxErr 0BadTLP 0BadDLLP 0Rollover 0Timeout 0NonFatalErr 0CorrIntErr 0HeaderOF 0TOTAL_ERR_COR 0
+A: aer_dev_fatal=Undefined 0DLP 0SDES 0TLP 0FCP 0CmpltTO 0CmpltAbrt 0UnxCmplt 0RxOF 0MalfTLP 0ECRC 0UnsupReq 0ACSViol 0UncorrIntErr 0BlockedTLP 0AtomicOpBlocked 0TLPBlockedErr 0PoisonTLPBlocked 0TOTAL_ERR_FATAL 0
+A: aer_dev_nonfatal=Undefined 0DLP 0SDES 0TLP 0FCP 0CmpltTO 0CmpltAbrt 0UnxCmplt 0RxOF 0MalfTLP 0ECRC 0UnsupReq 0ACSViol 0UncorrIntErr 0BlockedTLP 0AtomicOpBlocked 0TLPBlockedErr 0PoisonTLPBlocked 0TOTAL_ERR_NONFATAL 0
+A: ari_enabled=0
+A: broken_parity_status=0
+A: class=0x108000
+H: config=2210861406041000000080101000800000000000000000000000D0C300000000000000000000E0C300000000AA174610000000004800000000000000FF010000
+A: consistent_dma_mask_bits=48
+A: current_link_speed=16.0 GT/s PCIe
+A: current_link_width=16
+A: d3cold_allowed=1
+A: device=0x1486
+A: dma_mask_bits=48
+L: driver=../../../../bus/pci/drivers/ccp
+A: driver_override=(null)
+A: enable=1
+L: firmware_node=../../../LNXSYSTM:00/LNXSYBUS:00/PNP0A08:02/device:8f/device:91
+L: iommu=../../0000:20:00.2/iommu/ivhd2
+L: iommu_group=../../../../kernel/iommu_groups/37
+A: irq=256
+A: link/l0s_aspm=0
+A: link/l1_aspm=0
+A: local_cpulist=0-23
+A: local_cpus=00000000,00000000,00000000,00ffffff
+A: max_link_speed=16.0 GT/s PCIe
+A: max_link_width=16
+A: modalias=pci:v00001022d00001486sv000017AAsd00001046bc10sc80i00
+A: msi_bus=1
+A: msi_irqs/257=msix
+A: msi_irqs/258=msix
+A: numa_node=-1
+A: pools=poolinfo - 0.1ccp-1_q4            0    0   64  0ccp-1_q3            0    0   64  0ccp-1_q2            0    0   64  0
+A: power/control=on
+A: power/runtime_active_time=2767353428
+A: power/runtime_status=active
+A: power/runtime_suspended_time=0
+A: power/wakeup=disabled
+A: power/wakeup_abort_count=
+A: power/wakeup_active=
+A: power/wakeup_active_count=
+A: power/wakeup_count=
+A: power/wakeup_expire_count=
+A: power/wakeup_last_time_ms=
+A: power/wakeup_max_time_ms=
+A: power/wakeup_total_time_ms=
+A: power_state=D0
+A: reset_method=flr
+A: resource=0x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x00000000c3d00000 0x00000000c3dfffff 0x00000000000402000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x00000000c3e00000 0x00000000c3e01fff 0x00000000000402000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x0000000000000000
+A: revision=0x00
+A: subsystem_device=0x1046
+A: subsystem_vendor=0x17aa
+A: vendor=0x1022
+"""
+        )
+        self.testbed.add_from_string(
+            """P: /devices/pci0000:20/0000:20:08.1
+E: DRIVER=pcieport
+E: PCI_CLASS=60400
+E: PCI_ID=1022:1484
+E: PCI_SUBSYS_ID=1046:17AA
+E: PCI_SLOT_NAME=0000:20:08.1
+E: MODALIAS=pci:v00001022d00001484sv00001046sd000017AAbc06sc04i00
+E: SUBSYSTEM=pci
+E: ID_PCI_CLASS_FROM_DATABASE=Bridge
+E: ID_PCI_SUBCLASS_FROM_DATABASE=PCI bridge
+E: ID_PCI_INTERFACE_FROM_DATABASE=Normal decode
+E: ID_VENDOR_FROM_DATABASE=Advanced Micro Devices, Inc. [AMD]
+E: ID_MODEL_FROM_DATABASE=Starship/Matisse Internal PCIe GPP Bridge 0 to bus[E:B]
+A: aer_dev_correctable=RxErr 0BadTLP 0BadDLLP 0Rollover 0Timeout 0NonFatalErr 0CorrIntErr 0HeaderOF 0TOTAL_ERR_COR 0
+A: aer_dev_fatal=Undefined 0DLP 0SDES 0TLP 0FCP 0CmpltTO 0CmpltAbrt 0UnxCmplt 0RxOF 0MalfTLP 0ECRC 0UnsupReq 0ACSViol 0UncorrIntErr 0BlockedTLP 0AtomicOpBlocked 0TLPBlockedErr 0PoisonTLPBlocked 0TOTAL_ERR_FATAL 0
+A: aer_dev_nonfatal=Undefined 0DLP 0SDES 0TLP 0FCP 0CmpltTO 0CmpltAbrt 0UnxCmplt 0RxOF 0MalfTLP 0ECRC 0UnsupReq 0ACSViol 0UncorrIntErr 0BlockedTLP 0AtomicOpBlocked 0TLPBlockedErr 0PoisonTLPBlocked 0TOTAL_ERR_NONFATAL 0
+A: aer_rootport_total_err_cor=0
+A: aer_rootport_total_err_fatal=0
+A: aer_rootport_total_err_nonfatal=0
+A: ari_enabled=0
+A: broken_parity_status=0
+A: class=0x060400
+H: config=22108414070410000000040610000100000000000000000020232300F1010000C0C3E0C3F1FF01000000000000000000000000005000000000000000FF011200
+A: consistent_dma_mask_bits=32
+A: current_link_speed=16.0 GT/s PCIe
+A: current_link_width=16
+A: d3cold_allowed=1
+A: device=0x1484
+A: dma_mask_bits=32
+L: driver=../../../bus/pci/drivers/pcieport
+A: driver_override=(null)
+A: enable=2
+L: firmware_node=../../LNXSYSTM:00/LNXSYBUS:00/PNP0A08:02/device:8f
+L: iommu=../0000:20:00.2/iommu/ivhd2
+L: iommu_group=../../../kernel/iommu_groups/33
+A: irq=43
+A: local_cpulist=0-23
+A: local_cpus=00000000,00000000,00000000,00ffffff
+A: max_link_speed=16.0 GT/s PCIe
+A: max_link_width=16
+A: modalias=pci:v00001022d00001484sv00001046sd000017AAbc06sc04i00
+A: msi_bus=1
+A: msi_irqs/43=msi
+A: numa_node=-1
+A: power/autosuspend_delay_ms=100
+A: power/control=auto
+A: power/runtime_active_time=2767353433
+A: power/runtime_status=active
+A: power/runtime_suspended_time=0
+A: power/wakeup=enabled
+A: power/wakeup_abort_count=0
+A: power/wakeup_active=0
+A: power/wakeup_active_count=0
+A: power/wakeup_count=0
+A: power/wakeup_expire_count=0
+A: power/wakeup_last_time_ms=0
+A: power/wakeup_max_time_ms=0
+A: power/wakeup_total_time_ms=0
+A: power_state=D0
+A: reset_method=pm
+A: resource=0x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x00000000c3c00000 0x00000000c3efffff 0x00000000000002000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x0000000000000000
+A: revision=0x00
+A: secondary_bus_number=35
+A: subordinate_bus_number=35
+A: subsystem_device=0x17aa
+A: subsystem_vendor=0x1046
+A: vendor=0x1022
+"""
+        )
+
+    def test_pci_psp_device(self):
+        """Verify the PCI PSP device is detected correctly"""
+        self.start_daemon()
+        devices = Fwupd.Client().get_devices()
+
+        count = 0
+        for dev in devices:
+            if dev.get_plugin() != "pci_psp":
+                continue
+            self.assertEqual(dev.get_name(), "Secure Processor")
+            self.assertEqual(dev.get_vendor(), "Advanced Micro Devices, Inc.")
+            self.assertEqual(dev.get_version(), None)
+            self.assertEqual(dev.get_version_bootloader(), None)
+            count += 1
+        self.assertEqual(count, 1)
+
+    def test_pci_psp_hsi(self):
+        """Verify the PCI PSP HSI attributes are detected correctly"""
+        self.start_daemon()
+        attrs = Fwupd.Client().get_host_security_attrs()
+        for attr in attrs:
+            if attr.get_plugin() != "pci_psp":
+                continue
+            if attr.get_appstream_id() == "org.fwupd.hsi.PlatformFused":
+                self.assertEqual(attr.get_name(), "Fused platform")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 1)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.EncryptedRam":
+                self.assertEqual(attr.get_name(), "Encrypted RAM")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 4)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.RollbackProtection":
+                self.assertEqual(attr.get_name(), "Processor rollback protection")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 4)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.SpiReplayProtection":
+                self.assertEqual(attr.get_name(), "SPI replay protection")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 3)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.PlatformDebugLocked":
+                self.assertEqual(attr.get_name(), "Platform debugging")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 2)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.SpiWriteProtection":
+                self.assertEqual(attr.get_name(), "SPI write protection")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.UNKNOWN)
+                self.assertEqual(attr.get_level(), 2)
+
+
+class PciPspWithHsi(FwupdTest):
+    """A system that can export both HSI attributes and versions"""
+
+    def setUp(self):
+        super().setUp()
+        self.testbed.add_from_string(
+            """P: /devices/pci0000:00/0000:00:08.1/0000:c1:00.2
+E: DRIVER=ccp
+E: ID_MODEL_FROM_DATABASE=Family 19h (Model 74h) CCP/PSP 3.0 Device
+E: ID_PATH=pci-0000:c1:00.2
+E: ID_PATH_TAG=pci-0000_c1_00_2
+E: ID_PCI_CLASS_FROM_DATABASE=Encryption controller
+E: ID_PCI_SUBCLASS_FROM_DATABASE=Encryption controller
+E: ID_VENDOR_FROM_DATABASE=Advanced Micro Devices, Inc. [AMD]
+E: MODALIAS=pci:v00001022d000015C7sv0000F111sd00000006bc10sc80i00
+E: PCI_CLASS=108000
+E: PCI_ID=1022:15C7
+E: PCI_SLOT_NAME=0000:c1:00.2
+E: PCI_SUBSYS_ID=F111:0006
+E: SUBSYSTEM=pci
+A: anti_rollback_status=0
+A: ari_enabled=0
+A: bootloader_version=00.2d.00.78
+A: broken_parity_status=0
+A: class=0x108000
+H: config=2210C715070410000000801010008000000000000000000000004090000000000000000000C05C900000000011F10600000000004800000000000000FF030000
+A: consistent_dma_mask_bits=48
+A: current_link_speed=16.0 GT/s PCIe
+A: current_link_width=16
+A: d3cold_allowed=1
+A: debug_lock_on=1
+A: device=0x15c7
+A: dma_mask_bits=48
+L: driver=../../../../bus/pci/drivers/ccp
+A: driver_override=(null)
+A: enable=1
+L: firmware_node=../../../LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:16/device:18
+A: fused_part=1
+A: hsp_tpm_available=0
+L: iommu=../../0000:00:00.2/iommu/ivhd0
+L: iommu_group=../../../../kernel/iommu_groups/16
+A: irq=109
+A: link/l0s_aspm=0
+A: link/l1_aspm=0
+A: local_cpulist=0-11
+A: local_cpus=0fff
+A: max_link_speed=16.0 GT/s PCIe
+A: max_link_width=16
+A: modalias=pci:v00001022d000015C7sv0000F111sd00000006bc10sc80i00
+A: msi_bus=1
+A: msi_irqs/110=msix
+A: msi_irqs/111=msix
+A: numa_node=-1
+A: power/control=on
+A: power/runtime_active_time=17568317
+A: power/runtime_status=active
+A: power/runtime_suspended_time=0
+A: power/wakeup=disabled
+A: power/wakeup_abort_count=
+A: power/wakeup_active=
+A: power/wakeup_active_count=
+A: power/wakeup_count=
+A: power/wakeup_expire_count=
+A: power/wakeup_last_time_ms=
+A: power/wakeup_max_time_ms=
+A: power/wakeup_total_time_ms=
+A: power_state=D0
+A: resource=0x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000090400000 0x00000000904fffff 0x00000000000402000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x00000000905cc000 0x00000000905cdfff 0x00000000000402000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x0000000000000000
+A: revision=0x00
+A: rom_armor_enforced=1
+A: rpmc_production_enabled=0
+A: rpmc_spirom_available=1
+A: subsystem_device=0x0006
+A: subsystem_vendor=0xf111
+A: tee_version=00.2d.00.78
+A: tsme_status=0
+A: vendor=0x1022
+"""
+        )
+        self.testbed.add_from_string(
+            """P: /devices/pci0000:00/0000:00:08.1
+E: DRIVER=pcieport
+E: ID_PATH=pci-0000:00:08.1
+E: ID_PATH_TAG=pci-0000_00_08_1
+E: ID_PCI_CLASS_FROM_DATABASE=Bridge
+E: ID_PCI_INTERFACE_FROM_DATABASE=Normal decode
+E: ID_PCI_SUBCLASS_FROM_DATABASE=PCI bridge
+E: ID_VENDOR_FROM_DATABASE=Advanced Micro Devices, Inc. [AMD]
+E: MODALIAS=pci:v00001022d000014EBsv00000006sd0000F111bc06sc04i00
+E: PCI_CLASS=60400
+E: PCI_ID=1022:14EB
+E: PCI_SLOT_NAME=0000:00:08.1
+E: PCI_SUBSYS_ID=0006:F111
+E: SUBSYSTEM=pci
+A: ari_enabled=0
+A: broken_parity_status=0
+A: class=0x060400
+H: config=2210EB14070410000000040610008100000000000000000000C1C1001111000000905090010071107800000078000000000000005000000000000000FF010200
+A: consistent_dma_mask_bits=32
+A: current_link_speed=16.0 GT/s PCIe
+A: current_link_width=16
+A: d3cold_allowed=1
+A: device=0x14eb
+A: dma_mask_bits=32
+L: driver=../../../bus/pci/drivers/pcieport
+A: driver_override=(null)
+A: enable=2
+L: firmware_node=../../LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:16
+L: iommu=../0000:00:00.2/iommu/ivhd0
+L: iommu_group=../../../kernel/iommu_groups/7
+A: irq=42
+A: local_cpulist=0-11
+A: local_cpus=0fff
+A: max_link_speed=16.0 GT/s PCIe
+A: max_link_width=16
+A: modalias=pci:v00001022d000014EBsv00000006sd0000F111bc06sc04i00
+A: msi_bus=1
+A: msi_irqs/42=msi
+A: numa_node=-1
+A: power/autosuspend_delay_ms=100
+A: power/control=auto
+A: power/runtime_active_time=17568337
+A: power/runtime_status=active
+A: power/runtime_suspended_time=0
+A: power/wakeup=disabled
+A: power/wakeup_abort_count=
+A: power/wakeup_active=
+A: power/wakeup_active_count=
+A: power/wakeup_count=
+A: power/wakeup_expire_count=
+A: power/wakeup_last_time_ms=
+A: power/wakeup_max_time_ms=
+A: power/wakeup_total_time_ms=
+A: power_state=D0
+A: reset_method=pm
+A: resource=0x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000000000 0x0000000000000000 0x00000000000000000x0000000000001000 0x0000000000001fff 0x00000000000001010x0000000090000000 0x00000000905fffff 0x00000000000002000x0000007800000000 0x00000078107fffff 0x00000000001022010x0000000000000000 0x0000000000000000 0x0000000000000000
+A: revision=0x00
+A: secondary_bus_number=193
+A: subordinate_bus_number=193
+A: subsystem_device=0xf111
+A: subsystem_vendor=0x0006
+A: vendor=0x1022
+"""
+        )
+
+    def test_pci_psp_device(self):
+        """Verify the PCI PSP device is detected correctly"""
+        self.start_daemon()
+        devices = Fwupd.Client().get_devices()
+
+        count = 0
+        for dev in devices:
+            if dev.get_plugin() != "pci_psp":
+                continue
+            self.assertEqual(dev.get_name(), "Secure Processor")
+            self.assertEqual(dev.get_vendor(), "Advanced Micro Devices, Inc.")
+            self.assertEqual(dev.get_version(), "00.2d.00.78")
+            self.assertEqual(dev.get_version_bootloader(), "00.2d.00.78")
+            count += 1
+        self.assertEqual(count, 1)
+
+    def test_pci_psp_hsi(self):
+        """Verify the PCI PSP HSI attributes are detected correctly"""
+        self.start_daemon()
+        attrs = Fwupd.Client().get_host_security_attrs()
+        for attr in attrs:
+            if attr.get_plugin() != "pci_psp":
+                continue
+            if attr.get_appstream_id() == "org.fwupd.hsi.PlatformFused":
+                self.assertEqual(attr.get_name(), "Fused platform")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.LOCKED)
+                self.assertEqual(attr.get_level(), 1)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.EncryptedRam":
+                self.assertEqual(attr.get_name(), "Encrypted RAM")
+                self.assertEqual(
+                    attr.get_result(), Fwupd.SecurityAttrResult.NOT_SUPPORTED
+                )
+                self.assertEqual(attr.get_level(), 4)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.RollbackProtection":
+                self.assertEqual(attr.get_name(), "Processor rollback protection")
+                self.assertEqual(
+                    attr.get_result(), Fwupd.SecurityAttrResult.NOT_ENABLED
+                )
+                self.assertEqual(attr.get_level(), 4)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.SpiReplayProtection":
+                self.assertEqual(attr.get_name(), "SPI replay protection")
+                self.assertEqual(
+                    attr.get_result(), Fwupd.SecurityAttrResult.NOT_ENABLED
+                )
+                self.assertEqual(attr.get_level(), 3)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.PlatformDebugLocked":
+                self.assertEqual(attr.get_name(), "Platform debugging")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.LOCKED)
+                self.assertEqual(attr.get_level(), 2)
+            elif attr.get_appstream_id() == "org.fwupd.hsi.Amd.SpiWriteProtection":
+                self.assertEqual(attr.get_name(), "SPI write protection")
+                self.assertEqual(attr.get_result(), Fwupd.SecurityAttrResult.ENABLED)
+                self.assertEqual(attr.get_level(), 2)
+
+
+if __name__ == "__main__":
+    # run ourselves under umockdev
+    if "umockdev" not in os.environ.get("LD_PRELOAD", ""):
+        os.execvp("umockdev-wrapper", ["umockdev-wrapper", sys.executable] + sys.argv)
+
+    prog = unittest.main(exit=False)
+    if prog.result.errors or prog.result.failures:
+        sys.exit(1)
+
+    # Translate to skip error
+    if prog.result.testsRun == len(prog.result.skipped):
+        sys.exit(77)

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1407,7 +1407,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 							      "HSI support not enabled");
 #else
 		if (self->machine_kind != FU_DAEMON_MACHINE_KIND_PHYSICAL &&
-		    !g_getenv("UMOCKDEV_DIR")) {
+		    g_getenv("UMOCKDEV_DIR") == NULL) {
 			g_dbus_method_invocation_return_error_literal(
 			    invocation,
 			    FWUPD_ERROR,

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1406,7 +1406,8 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 							      FWUPD_ERROR_NOT_SUPPORTED,
 							      "HSI support not enabled");
 #else
-		if (self->machine_kind != FU_DAEMON_MACHINE_KIND_PHYSICAL) {
+		if (self->machine_kind != FU_DAEMON_MACHINE_KIND_PHYSICAL &&
+		    !g_getenv("UMOCKDEV_DIR")) {
 			g_dbus_method_invocation_return_error_literal(
 			    invocation,
 			    FWUPD_ERROR,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7194,8 +7194,11 @@ fu_engine_load_plugins_builtins(FuEngine *self, FuProgress *progress)
 	}
 }
 
-static void
-fu_engine_load_plugins(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress)
+static gboolean
+fu_engine_load_plugins(FuEngine *self,
+		       FuEngineLoadFlags flags,
+		       FuProgress *progress,
+		       GError **error)
 {
 	g_autofree gchar *plugin_path = NULL;
 	g_autoptr(GPtrArray) filenames = NULL;
@@ -7224,6 +7227,9 @@ fu_engine_load_plugins(FuEngine *self, FuEngineLoadFlags flags, FuProgress *prog
 	if (flags & FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS)
 		fu_engine_load_plugins_builtins(self, fu_progress_get_child(progress));
 	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
 }
 
 static gboolean
@@ -8155,7 +8161,10 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	fu_progress_step_done(progress);
 
 	/* load plugins early, as we have to call ->load() *before* building quirk silo */
-	fu_engine_load_plugins(self, flags, fu_progress_get_child(progress));
+	if (!fu_engine_load_plugins(self, flags, fu_progress_get_child(progress), error)) {
+		g_prefix_error(error, "failed to load plugins: ");
+		return FALSE;
+	}
 	fu_progress_step_done(progress);
 
 	/* migrate per-plugin settings into fwupd.conf */

--- a/src/fwupd_test.py
+++ b/src/fwupd_test.py
@@ -1,0 +1,346 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1+
+
+# to record a string for a device use
+# umockdev-record $PATH
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import dbusmock
+
+import gi
+from gi.repository import GLib
+from gi.repository import Gio
+
+gi.require_version("UMockdev", "1.0")
+from gi.repository import UMockdev
+
+
+def override_gi_search_path():
+    if "LIBFWUPD_BUILD_DIR" in os.environ:
+        gi.require_version("GIRepository", "2.0")
+        from gi.repository import GIRepository
+
+        GIRepository.Repository.prepend_search_path(
+            os.path.join(os.environ["LIBFWUPD_BUILD_DIR"])
+        )
+        GIRepository.Repository.prepend_library_path(
+            os.path.join(os.environ["LIBFWUPD_BUILD_DIR"])
+        )
+
+
+class FwupdTest(dbusmock.DBusTestCase):
+    DBUS_NAME = "org.freedesktop.fwupd"
+    DBUS_PATH = "/"
+    DBUS_INTERFACE = "org.freedesktop.fwupd"
+
+    @classmethod
+    def setUpClass(cls):
+        if "DAEMON_BUILDDIR" in os.environ:
+            libexecdir = os.environ["DAEMON_BUILDDIR"]
+        else:
+            libexecdir = "@LIBEXECDIR@"
+        cls.daemon_path = os.path.join(libexecdir, "fwupd")
+        for dir in ["STATE_DIRECTORY", "CACHE_DIRECTORY"]:
+            if dir in os.environ:
+                os.makedirs(os.environ[dir], exist_ok=True)
+        os.environ["G_DEBUG"] = "fatal_warnings"
+        GLib.log_set_always_fatal(
+            GLib.LogLevelFlags.LEVEL_WARNING
+            | GLib.LogLevelFlags.LEVEL_ERROR
+            | GLib.LogLevelFlags.LEVEL_CRITICAL
+        )
+        # set up a fake system D-BUS
+        cls.test_bus = Gio.TestDBus.new(Gio.TestDBusFlags.NONE)
+        cls.test_bus.up()
+        try:
+            del os.environ["DBUS_SESSION_BUS_ADDRESS"]
+        except KeyError:
+            pass
+        os.environ["DBUS_SYSTEM_BUS_ADDRESS"] = cls.test_bus.get_bus_address()
+
+        cls.dbus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        cls.dbus_con = cls.get_dbus(True)
+
+        override_gi_search_path()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.test_bus.down()
+        dbusmock.DBusTestCase.tearDownClass()
+
+    def setUp(self):
+        self.testbed = UMockdev.Testbed.new()
+        self.polkitd, self.obj_polkit = self.spawn_server_template(
+            "polkitd", {}, stdout=subprocess.PIPE
+        )
+        self.obj_polkit.SetAllowed(
+            [
+                "org.freedesktop.fwupd.update-internal",
+                "org.freedesktop.fwupd.update-internal-trusted",
+                "org.freedesktop.fwupd.downgrade-internal-trusted",
+                "org.freedesktop.fwupd.downgrade-internal",
+                "org.freedesktop.fwupd.update-hotplug-trusted",
+                "org.freedesktop.fwupd.update-hotplug",
+                "org.freedesktop.fwupd.downgrade-hotplug-trusted",
+                "org.freedesktop.fwupd.downgrade-hotplug",
+                "org.freedesktop.fwupd.device-unlock",
+                "org.freedesktop.fwupd.modify-config",
+                "org.freedesktop.fwupd.device-activate",
+                "org.freedesktop.fwupd.verify-update",
+                "org.freedesktop.fwupd.modify-remote",
+                "org.freedesktop.fwupd.set-approved-firmware",
+                "org.freedesktop.fwupd.self-sign",
+                "org.freedesktop.fwupd.get-bios-settings",
+                "org.freedesktop.fwupd.set-bios-settings",
+                "org.freedesktop.fwupd.fix-host-security-attr",
+                "org.freedesktop.fwupd.undo-host-security-attr",
+            ]
+        )
+
+        self.proxy = None
+        self.props_proxy = None
+        self.daemon_log = None
+        self.daemon = None
+        self.changed_properties = {}
+
+    def run(self, result=None):
+        super().run(result)
+        if not result or not self.daemon_log:
+            return
+        if len(result.errors) + len(result.failures) or os.getenv("VERBOSE"):
+            with open(self.daemon_log.name, encoding="utf-8") as tmpf:
+                sys.stderr.write("\nDAEMON log:\n")
+                sys.stderr.write(tmpf.read())
+                sys.stderr.write("\n")
+
+    def tearDown(self):
+        del self.testbed
+        self.stop_daemon()
+
+        if self.polkitd:
+            self.polkitd.stdout.close()
+            try:
+                self.polkitd.kill()
+            except OSError:
+                pass
+            self.polkitd.wait()
+
+        self.obj_polkit = None
+
+    #
+    # Daemon control and D-BUS I/O
+    #
+
+    def start_daemon(self):
+        """Start daemon and create DBus proxy.
+
+        When done, this sets self.proxy as the Gio.DBusProxy for power-profiles-daemon.
+        """
+        env = os.environ.copy()
+        env["G_DEBUG"] = "fatal-criticals"
+        env["G_MESSAGES_DEBUG"] = "all"
+        # note: Python doesn't propagate the setenv from Testbed.new(), so we
+        # have to do that ourselves
+        env["UMOCKDEV_DIR"] = self.testbed.get_root_dir()
+        self.daemon_log = (
+            tempfile.NamedTemporaryFile()
+        )  # pylint: disable=consider-using-with
+        daemon_path = [self.daemon_path, "-vv"]
+
+        # pylint: disable=consider-using-with
+        self.daemon = subprocess.Popen(
+            daemon_path, env=env, stdout=self.daemon_log, stderr=subprocess.STDOUT
+        )
+        self.addCleanup(self.daemon.kill)
+
+        def on_proxy_connected(_, res):
+            try:
+                self.proxy = Gio.DBusProxy.new_finish(res)
+            except GLib.Error as exc:
+                self.fail(exc)
+
+        cancellable = Gio.Cancellable()
+        self.addCleanup(cancellable.cancel)
+        Gio.DBusProxy.new(
+            self.dbus,
+            Gio.DBusProxyFlags.DO_NOT_AUTO_START,
+            None,
+            self.DBUS_NAME,
+            self.DBUS_PATH,
+            self.DBUS_INTERFACE,
+            cancellable,
+            on_proxy_connected,
+        )
+
+        # wait until the daemon gets online
+        wait_time = 60 if "valgrind" in daemon_path[0] else 5
+        self.assert_eventually(
+            lambda: self.proxy and self.proxy.get_name_owner(),
+            timeout=wait_time * 1000,
+            message=f"daemon did not start in {wait_time} seconds",
+        )
+
+        def properties_changed_cb(_, changed_properties, invalidated):
+            self.changed_properties.update(changed_properties.unpack())
+
+        self.addCleanup(
+            self.proxy.disconnect,
+            self.proxy.connect("g-properties-changed", properties_changed_cb),
+        )
+
+        self.assertEqual(self.daemon.poll(), None, "daemon crashed")
+
+    def stop_daemon(self):
+        """Stop the daemon if it is running."""
+
+        if self.daemon:
+            try:
+                self.daemon.terminate()
+            except OSError:
+                pass
+            self.assertEqual(self.daemon.wait(timeout=3000), 0)
+
+        self.daemon = None
+        self.proxy = None
+
+    def assert_eventually(self, condition, message=None, timeout=5000):
+        """Assert that condition function eventually returns True.
+
+        Timeout is in milliseconds, defaulting to 5000 (5 seconds). message is
+        printed on failure.
+        """
+        if condition():
+            return
+
+        done = False
+
+        def on_timeout_reached():
+            nonlocal done
+            done = True
+
+        source = GLib.timeout_add(timeout, on_timeout_reached)
+        while not done:
+            if condition():
+                GLib.source_remove(source)
+                return
+            GLib.MainContext.default().iteration(False)
+
+        self.fail(message or "timed out waiting for " + str(condition))
+
+    def assert_dbus_property_eventually_is(self, prop, value, timeout=1200):
+        """Asserts that a dbus property eventually is what expected"""
+        return self.assert_eventually(
+            lambda: self.get_dbus_property(prop) == value,
+            timeout=timeout,
+            message=f"property '{prop}' is not '{value}', but "
+            + f"'{self.get_dbus_property(prop)}'",
+        )
+
+    def ensure_dbus_properties_proxies(self):
+        self.props_proxy = Gio.DBusProxy.new_sync(
+            self.dbus,
+            Gio.DBusProxyFlags.DO_NOT_AUTO_START
+            | Gio.DBusProxyFlags.DO_NOT_AUTO_START_AT_CONSTRUCTION
+            | Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES
+            | Gio.DBusProxyFlags.DO_NOT_CONNECT_SIGNALS,
+            None,
+            self.DBUS_NAME,
+            self.DBUS_PATH,
+            "org.freedesktop.DBus.Properties",
+            None,
+        )
+
+    def get_dbus_property(self, name):
+        """Get property value from daemon D-Bus interface."""
+        self.ensure_dbus_properties_proxies()
+        return self.props_proxy.Get("(ss)", self.DBUS_NAME, name)
+
+    def start_upower(self, on_battery):
+        """Start the upower service with the given on_battery state"""
+
+        sys_bat = self.testbed.add_device(
+            "power_supply",
+            "fakeBAT0",
+            None,
+            [
+                "type",
+                "Battery",
+                "present",
+                "1",
+                "status",
+                "Discharging",
+                "energy_full",
+                "60000000",
+                "energy_full_design",
+                "80000000",
+                "energy_now",
+                "48000000",
+                "voltage_now",
+                "12000000",
+            ],
+            ["POWER_SUPPLY_ONLINE", "1"],
+        )
+
+        self.upowerd, obj_upower = self.spawn_server_template(
+            "upower",
+            {"DaemonVersion": "0.99", "OnBattery": on_battery},
+            stdout=subprocess.PIPE,
+        )
+
+    def stop_upower(self):
+        """Stop the upower service"""
+        self.upowerd.terminate()
+        self.upowerd.wait()
+
+
+class VeryBasicTest(FwupdTest):
+    """Test the basic properties of the daemon."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        gi.require_version("Fwupd", "2.0")
+        from gi.repository import Fwupd  # pylint: disable=wrong-import-position
+
+        cls.client = Fwupd.Client()
+
+    def test_properties(self):
+        """Test the properties of the daemon without a client."""
+        self.start_daemon()
+
+        self.assertEqual(self.get_dbus_property("Interactive"), False)
+        self.assertEqual(self.get_dbus_property("OnlyTrusted"), True)
+        self.assertEqual(self.get_dbus_property("Tainted"), False)
+        self.assertEqual(self.get_dbus_property("HostBkc"), "")
+        self.assertEqual(self.get_dbus_property("HostProduct"), "Unknown Product")
+        self.assertEqual(self.get_dbus_property("HostVendor"), "Unknown Vendor")
+        self.assertEqual(self.get_dbus_property("Percentage"), 0)
+        self.assertEqual(self.get_dbus_property("Status"), 1)
+        self.assertEqual(self.get_dbus_property("BatteryLevel"), 101)
+
+    def test_get_devices(self):
+        """Test the libfwupd client get-devices interface."""
+        self.start_daemon()
+
+        devices = self.client.get_devices()
+        # Should be at least the CPU test is running on
+        self.assertGreater(len(devices), 0)
+
+
+if __name__ == "__main__":
+    # run ourselves under umockdev
+    if "umockdev" not in os.environ.get("LD_PRELOAD", ""):
+        os.execvp("umockdev-wrapper", ["umockdev-wrapper", sys.executable] + sys.argv)
+
+    prog = unittest.main(exit=False)
+    if prog.result.errors or prog.result.failures:
+        sys.exit(1)
+
+    # Translate to skip error
+    if prog.result.testsRun == len(prog.result.skipped):
+        sys.exit(77)

--- a/src/meson.build
+++ b/src/meson.build
@@ -407,4 +407,28 @@ if get_option('tests')
     ],
   )
   test('fu-self-test', e, is_parallel: false, timeout: 180, env: env)
+
+  if umockdev_integration_tests.allowed()
+    fwupd_mockdev_tests = files('fwupd_test.py')
+    r = run_command(unittest_inspector, fwupd_mockdev_tests, check: true)
+    unit_tests = r.stdout().strip().split('\n')
+    foreach ut: unit_tests
+        test(ut, python3, args: [fwupd_mockdev_tests, ut], is_parallel: false,
+            env: {
+              'DAEMON_BUILDDIR': meson.current_build_dir(),
+              'LIBFWUPD_BUILD_DIR': join_paths(meson.project_build_root(), 'libfwupd'),
+              'STATE_DIRECTORY': join_paths(meson.project_build_root(), 'state'),
+              'CACHE_DIRECTORY': join_paths(meson.project_build_root(), 'cache'),
+            },
+            )
+    endforeach
+    configure_file(
+      input: fwupd_mockdev_tests,
+      output: 'fwupd_test.py',
+      configuration: {
+        'LIBEXECDIR': daemon_dir,
+      },
+      install_dir: installed_test_datadir
+    )
+  endif
 endif


### PR DESCRIPTION
This allows relatively easily to mock Linux devices as the plugins will detect them.  Most immediately it allows to enumerate mocked devices in plugins, but umockdev also allows to do things like spawn other daemons and intercept ioctl calls.

I think we'll be able to add significantly more coverage by building on this, but this lays the immediate ground work with some very trivial tests.

This is done in python because it's a lot easier to have high level libraries like json to verify the data passed back from daemon to client.  My hope is we can start using this for any non-USB plugins in the future to add test infra.

A lot of this this  is leveraged from the power-profiles-daemon project but modified to fit fwupd.

It's too early for documentation on how to use this, but at a very high level `umockdev-record $PATH` will allow you to get a list of strings that can be passed into umockdev to emulate a device.  I've done two sample plugins this way.  There is definitely some extraneous data the plugins don't care about but I think it's better to encode it all in case we do depend on something later as it represents what a real system has.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
