### PR TITLE
Allow plugins to opt-into a default device GType

### DIFF
--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -47,6 +47,7 @@ typedef struct {
 	GHashTable *compile_versions;
 	FuContext *ctx;
 	GArray *device_gtypes;	     /* (nullable): of #GType */
+	GType device_gtype_default;
 	GHashTable *cache;	     /* (nullable): platform_id:GObject */
 	GHashTable *report_metadata; /* (nullable): key:value */
 	GFileMonitor *config_monitor;
@@ -408,6 +409,12 @@ fu_plugin_add_string(FuPlugin *self, guint idt, GString *str)
 		fu_string_append_ku(str, idt + 1, "Order", priv->order);
 	if (priv->priority != 0)
 		fu_string_append_ku(str, idt + 1, "Priority", priv->priority);
+	if (priv->device_gtype_default != G_TYPE_INVALID) {
+		fu_string_append(str,
+				 idt,
+				 "DeviceGTypeDefault",
+				 g_type_name(priv->device_gtype_default));
+	}
 
 	/* optional */
 	if (vfuncs->to_string != NULL)
@@ -1437,6 +1444,8 @@ fu_plugin_runner_add_security_attrs(FuPlugin *self, FuSecurityAttrs *attrs)
  *
  * Plugins can use this method only in fu_plugin_init()
  *
+ * See also: fu_plugin_set_device_gtype_default()
+ *
  * Since: 1.6.0
  **/
 void
@@ -1444,13 +1453,73 @@ fu_plugin_add_device_gtype(FuPlugin *self, GType device_gtype)
 {
 	FuPluginPrivate *priv = GET_PRIVATE(self);
 
+	g_return_if_fail(FU_IS_PLUGIN(self));
+
 	/* create as required */
 	if (priv->device_gtypes == NULL)
 		priv->device_gtypes = g_array_new(FALSE, FALSE, sizeof(GType));
 
+	/* check for duplicates */
+	for (guint i = 0; i < priv->device_gtypes->len; i++) {
+		GType device_gtype_tmp = g_array_index(priv->device_gtypes, GType, i);
+		if (device_gtype == device_gtype_tmp)
+			return;
+	}
+
 	/* ensure (to allow quirks to use it) then add */
 	g_type_ensure(device_gtype);
 	g_array_append_val(priv->device_gtypes, device_gtype);
+}
+
+/**
+ * fu_plugin_get_device_gtype_default:
+ * @self: a #FuPlugin
+ *
+ * Gets the default device #GType.
+ *
+ * If there is only one possible #GType added from fu_plugin_add_device_gtype() it will also be
+ * returned here.
+ *
+ * Returns: a #GType, or %G_TYPE_INVALID on error
+ *
+ * Since: 1.9.14
+ **/
+GType
+fu_plugin_get_device_gtype_default(FuPlugin *self)
+{
+	FuPluginPrivate *priv = GET_PRIVATE(self);
+
+	g_return_val_if_fail(FU_IS_PLUGIN(self), G_TYPE_INVALID);
+
+	if (priv->device_gtype_default != G_TYPE_INVALID)
+		return priv->device_gtype_default;
+	if (priv->device_gtypes->len == 1)
+		return g_array_index(priv->device_gtypes, GType, 0);
+	return G_TYPE_INVALID;
+}
+
+/**
+ * fu_plugin_set_device_gtype_default:
+ * @self: a #FuPlugin
+ * @device_gtype: a #GType, e.g. `FU_TYPE_DEVICE`
+ *
+ * Sets the default device #GType.
+ *
+ * This will also add the device #GType using fu_plugin_add_device_gtype().
+ *
+ * Plugins can use this method only in fu_plugin_init()
+ *
+ * Since: 1.9.14
+ **/
+void
+fu_plugin_set_device_gtype_default(FuPlugin *self, GType device_gtype)
+{
+	FuPluginPrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FU_IS_PLUGIN(self));
+
+	fu_plugin_add_device_gtype(self, device_gtype);
+	priv->device_gtype_default = device_gtype;
 }
 
 static gchar *
@@ -1614,6 +1683,8 @@ fu_plugin_backend_device_added(FuPlugin *self,
 	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 48, "add");
 
 	/* fall back to plugin default */
+	if (device_gtype == G_TYPE_INVALID)
+		device_gtype = fu_plugin_get_device_gtype_default(self);
 	if (device_gtype == G_TYPE_INVALID) {
 		if (priv->device_gtypes->len > 1) {
 			g_autoptr(GString) str = g_string_new(NULL);
@@ -1630,7 +1701,11 @@ fu_plugin_backend_device_added(FuPlugin *self,
 				    str->str);
 			return FALSE;
 		}
-		device_gtype = g_array_index(priv->device_gtypes, GType, 0);
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "no possible device GTypes");
+		return FALSE;
 	}
 
 	/* create new device and incorporate existing properties */
@@ -2862,6 +2937,8 @@ fu_plugin_class_init(FuPluginClass *klass)
 static void
 fu_plugin_init(FuPlugin *self)
 {
+	FuPluginPrivate *priv = GET_PRIVATE(self);
+	priv->device_gtype_default = G_TYPE_INVALID;
 }
 
 static void

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -482,6 +482,10 @@ void
 fu_plugin_device_register(FuPlugin *self, FuDevice *device) G_GNUC_NON_NULL(1, 2);
 void
 fu_plugin_add_device_gtype(FuPlugin *self, GType device_gtype) G_GNUC_NON_NULL(1);
+GType
+fu_plugin_get_device_gtype_default(FuPlugin *self) G_GNUC_NON_NULL(1);
+void
+fu_plugin_set_device_gtype_default(FuPlugin *self, GType device_gtype) G_GNUC_NON_NULL(1);
 void
 fu_plugin_add_firmware_gtype(FuPlugin *self, const gchar *id, GType gtype) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1267,6 +1267,26 @@ fu_plugin_func(void)
 }
 
 static void
+fu_plugin_device_gtype_func(void)
+{
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+
+	/* add the same gtype multiple times */
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_DEVICE);
+	g_assert_cmpint(fu_plugin_get_device_gtype_default(plugin), ==, FU_TYPE_DEVICE);
+
+	/* now there's no explicit default */
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_USB_DEVICE);
+	g_assert_cmpint(fu_plugin_get_device_gtype_default(plugin), ==, G_TYPE_INVALID);
+
+	/* make it explicit */
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_USB_DEVICE);
+	g_assert_cmpint(fu_plugin_get_device_gtype_default(plugin), ==, FU_TYPE_USB_DEVICE);
+}
+
+static void
 fu_plugin_backend_device_func(void)
 {
 	gboolean ret;
@@ -5333,6 +5353,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/security-attrs{compare}", fu_security_attrs_compare_func);
 	g_test_add_func("/fwupd/config", fu_config_func);
 	g_test_add_func("/fwupd/plugin", fu_plugin_func);
+	g_test_add_func("/fwupd/plugin{device-gtype}", fu_plugin_device_gtype_func);
 	g_test_add_func("/fwupd/plugin{backend-device}", fu_plugin_backend_device_func);
 	g_test_add_func("/fwupd/plugin{config}", fu_plugin_config_func);
 	g_test_add_func("/fwupd/plugin{devices}", fu_plugin_devices_func);

--- a/plugins/wacom-usb/fu-wac-plugin.c
+++ b/plugins/wacom-usb/fu-wac-plugin.c
@@ -84,7 +84,7 @@ static void
 fu_wac_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_DEVICE);
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_WAC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_ANDROID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, "wacom", FU_TYPE_WAC_FIRMWARE);
 }

--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -2,19 +2,16 @@
 # Intuos Pro medium (2nd-gen USB) [PTH-660]
 [USB\VID_056A&PID_0357]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version
 
 # Intuos Pro large (2nd-gen USB) [PTH-860]
 [USB\VID_056A&PID_0358]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version
 
 # Intuos S 3rd-gen (USB) [CTL-4100]
 [USB\VID_056A&PID_0374]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos S 3rd-gen (USB) [CTL-4100 - Android Mode]
@@ -25,7 +22,6 @@ GType = FuWacAndroidDevice
 # Intuos M 3rd-gen (USB) [CTL-6100]
 [USB\VID_056A&PID_0375]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos M 3rd-gen (USB) [CTL-6100 - Android Mode]
@@ -36,7 +32,6 @@ GType = FuWacAndroidDevice
 # Intuos BT S 3rd-gen (USB) [CTL-4100WL]
 [USB\VID_056A&PID_0376]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT S 3rd-gen (USB) [CTL-4100WL - Android Mode]
@@ -47,7 +42,6 @@ GType = FuWacAndroidDevice
 # Intuos BT M 3rd-gen (USB) [CTL-6100WL]
 [USB\VID_056A&PID_0378]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT M 3rd-gen (USB) [CTL-6100WL - Android Mode]
@@ -57,13 +51,11 @@ GType = FuWacAndroidDevice
 
 # Intuos Pro Small (2nd-gen USB) [PTH-460]
 [USB\VID_056A&PID_0392]
-GType = FuWacDevice
 Plugin = wacom_usb
 
 # Intuos BT S 3rd-gen, Rev 2 (USB) [CTL-4100WL]
 [USB\VID_056A&PID_03C5]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT S 3rd-gen, Rev 2 (USB) [CTL-4100WL - Android Mode]
@@ -74,7 +66,6 @@ GType = FuWacAndroidDevice
 # Intuos BT M 3rd-gen, Rev 2 (USB) [CTL-6100WL]
 [USB\VID_056A&PID_03C7]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = use-runtime-version,no-serial-number
 
 # Intuos BT M 3rd-gen, Rev 2 (USB) [CTL-6100WL - Android Mode]
@@ -84,62 +75,50 @@ GType = FuWacAndroidDevice
 
 # Intuos Pro Small (2nd-gen USB v2) [PTH-460]
 [USB\VID_056A&PID_03DC]
-GType = FuWacDevice
 Plugin = wacom_usb
 
 # Cintiq Pro 27 (USB) [DTH271]
 [USB\VID_056A&PID_03C0]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One 13 (USB) [DTH-134]
 [USB\VID_056A&PID_03CB]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One 12 (USB) [DTC-121]
 [USB\VID_056A&PID_03CE]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # DTH134 (USB) [DTH-134]
 [USB\VID_056A&PID_03EC]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # DTC121 (USB) [DTC-121]
 [USB\VID_056A&PID_03ED]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One Pen tablet small (USB) [CTC4110WL]
 [USB\VID_0531&PID_0100]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = no-serial-number
 
 # Wacom One Pen tablet small (USB) [CTC4110WL - Android Mode]
 [USB\VID_0531&PID_0104]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Wacom One Pen tablet medium (USB) [CTC6110WL]
 [USB\VID_0531&PID_0102]
 Plugin = wacom_usb
-GType = FuWacDevice
 Flags = no-serial-number
 
 # Wacom One Pen tablet medium (USB) [CTC6110WL - Android Mode]
 [USB\VID_0531&PID_0105]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Cintiq Pro 17 (USB) [DTH172]
 [USB\VID_056A&PID_03C4]
 Plugin = wacom_usb
-GType = FuWacDevice
 
 # Cintiq Pro 22 (USB) [DTH227]
 [USB\VID_056A&PID_03D0]
 Plugin = wacom_usb
-GType = FuWacDevice


### PR DESCRIPTION
If a vendor is using a DS-20 BOS descriptor this allows the embedded quirk to be much smaller, maybe just a single line.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
