### PR TITLE
Make fu-powerd-plugin respect suspend_announced

### DIFF
--- a/plugins/powerd/README.md
+++ b/plugins/powerd/README.md
@@ -5,7 +5,8 @@ title: Plugin: Powerd
 ## Introduction
 
 This plugin is used to ensure that some updates are not done on battery power
-and that there is sufficient battery power for certain updates that are.
+and that there is sufficient battery power for certain updates that are. It
+also provides mutual exclusion between updates and suspend.
 
 ## Vendor ID Security
 
@@ -14,6 +15,10 @@ This protocol does not create a device and thus requires no vendor ID set.
 ## External interface access
 
 This plugin requires access to the `org.chromium.PowerManager` DBus interface.
+
+It provides mutual exclusion between updates and suspend by creating a lockfile
+in `${FWUPD_LOCKDIR}/power_override/fwupd.lock`, and checking for the existince
+of the file `/run/power_manager/power/suspend_announced`.
 
 ## Version Considerations
 


### PR DESCRIPTION
The ChromeOS daemon `powerd` will create a `suspend_announced` file when it begins suspending the system. Although the fu-powerd-plugin creates a lockfile to keep powerd from initiating suspend, it doesn't stop what it's doing if powerd has already started the suspend.

This patch checks for the `suspend_announced` file after creating its lockfile. If the `suspend_announced` file exists, clean up the lockfile, wait until the suspend is finished, and then proceed.

I've tested this like so:
1. Obtained a Coral Robo360 Chromebook (Lenovo 500e, Intel APL)
2. Applied this patch on top of Chrome OS around 15795.0.0
3. Built a test image and deployed it to my device.
4. Logged in and disabled rootfs verification with
```
for p in 2 4; do /usr/share/vboot/bin/make_dev_ssd.sh --remove_rootfs_verification --partitions $p; done
```
5. Modified `/etc/init/fwupd.conf` to mount `/run/power_manager/power` within the minijail chroot:
```
    exec syslog-cat --identifier="${UPSTART_JOB}" --severity_stderr=info \
     -- minijail0 --uts -l -p -N \
     -v -P /mnt/empty -b / -b /proc -t -r -b /dev,,1 -b /sys,,1 \
     -k /var,/var,tmpfs -b /var/cache/fwupd,,1 -b /var/lib/fwupd,,1 \
     -k run,/run,tmpfs -b /run/dbus -b /run/lock,,1 -b /run/shill \
     -b /run/dns-proxy -b /run/udev/data,,1 -b /var/lib/timezone \
+    -b /run/power_manager/power/ \
     ${efi_mounts} \
     -u fwupd -g fwupd \
     -G -c cap_sys_rawio+e \
     -- /usr/libexec/fwupd/fwupd --verbose --no-timestamp
```
6. Created the file `/run/power_manager/power/suspend_announced`
7. Started watching `fwupd.log` with `tail -f /var/log/fwupd.log &`
8. Started the Chrome OS test `firmware.FwupdPowerdUpdateCheck.ac_powerpresent`
   (https://chromium.googlesource.com/chromiumos/platform/tast-tests/+/f7c6b869b79515cb4e01bad80be8c895770a796a/src/go.chromium.org/tast-tests/cros/local/bundles/cros/firmware/fwupd_powerd_update_check.go)
9. Watched for the following logline in `fwupd.conf` and saw the update pause:
```
   "FuPluginPowerd       waiting due to presence of /run/power_manager/power/suspend_announced"
```
10. Deleted `/run/power_manager/power/suspend_announced`
11. Watched the update immediately continue:
```
   "FuPluginPowerd       suspend blocked"
```
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [X] Documentation
