### PR TITLE
Only create GErrors with our own error GQuark domain

### DIFF
--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -599,7 +599,7 @@ _fu_strtoull_simple(const gchar *str, guint64 *value, GError **error)
 	}
 	*value = g_ascii_strtoull(str, &endptr, base);
 	if ((gsize)(endptr - str) != strlen(str) && *endptr != '\n') {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "cannot parse %s", str);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "cannot parse %s", str);
 		return FALSE;
 	}
 	return TRUE;
@@ -914,7 +914,10 @@ fwupd_bios_setting_from_json(FwupdBiosSetting *self, JsonNode *json_node, GError
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 	obj = json_node_get_object(json_node);

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -752,24 +752,24 @@ fwupd_guid_from_string(const gchar *guidstr,
 	/* split into sections */
 	if (strlen(guidstr) != 36) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "GUID is not valid format");
 		return FALSE;
 	}
 	split = g_strsplit(guidstr, "-", 5);
 	if (g_strv_length(split) != 5) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "GUID is not valid format, no dashes");
 		return FALSE;
 	}
 	if (strlen(split[0]) != 8 && strlen(split[1]) != 4 && strlen(split[2]) != 4 &&
 	    strlen(split[3]) != 4 && strlen(split[4]) != 12) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "GUID is not valid format, not GUID");
 		return FALSE;
 	}

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -3128,7 +3128,10 @@ fwupd_device_from_json(FwupdDevice *self, JsonNode *json_node, GError **error)
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 	obj = json_node_get_object(json_node);
@@ -3136,8 +3139,8 @@ fwupd_device_from_json(FwupdDevice *self, JsonNode *json_node, GError **error)
 	/* this has to exist */
 	if (!json_object_has_member(obj, FWUPD_RESULT_KEY_DEVICE_ID)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "no %s property in object",
 			    FWUPD_RESULT_KEY_DEVICE_ID);
 		return FALSE;

--- a/libfwupd/fwupd-error.h
+++ b/libfwupd/fwupd-error.h
@@ -32,6 +32,9 @@ G_BEGIN_DECLS
  * @FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW:		The system battery level is too low
  * @FWUPD_ERROR_NEEDS_USER_ACTION:		User needs to do an action to complete the update
  * @FWUPD_ERROR_AUTH_EXPIRED:			Failed to get auth as credentials have expired
+ * @FWUPD_ERROR_INVALID_DATA:			Invalid data
+ * @FWUPD_ERROR_TIMED_OUT:			The request timed out
+ * @FWUPD_ERROR_BUSY:				The device is busy
  *
  * The error code.
  **/
@@ -54,6 +57,9 @@ typedef enum {
 	FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW, /* Since: 1.2.10 */
 	FWUPD_ERROR_NEEDS_USER_ACTION,	   /* Since: 1.3.3 */
 	FWUPD_ERROR_AUTH_EXPIRED,	   /* Since: 1.7.5 */
+	FWUPD_ERROR_INVALID_DATA,	   /* Since: 2.0.0 */
+	FWUPD_ERROR_TIMED_OUT,		   /* Since: 2.0.0 */
+	FWUPD_ERROR_BUSY,		   /* Since: 2.0.0 */
 	/*< private >*/
 	FWUPD_ERROR_LAST
 } FwupdError;
@@ -64,5 +70,7 @@ const gchar *
 fwupd_error_to_string(FwupdError error);
 FwupdError
 fwupd_error_from_string(const gchar *error);
+void
+fwupd_error_convert(GError **perror);
 
 G_END_DECLS

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -1561,8 +1561,10 @@ fwupd_remote_load_signature(FwupdRemote *self, const gchar *filename, GError **e
 
 	/* load JCat file */
 	gfile = g_file_new_for_path(filename);
-	if (!jcat_file_import_file(jcat_file, gfile, JCAT_IMPORT_FLAG_NONE, NULL, error))
+	if (!jcat_file_import_file(jcat_file, gfile, JCAT_IMPORT_FLAG_NONE, NULL, error)) {
+		fwupd_error_convert(error);
 		return FALSE;
+	}
 	return fwupd_remote_load_signature_jcat(self, jcat_file, error);
 }
 

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -1471,7 +1471,10 @@ fwupd_security_attr_from_json(FwupdSecurityAttr *self, JsonNode *json_node, GErr
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 	obj = json_node_get_object(json_node);
@@ -1479,8 +1482,8 @@ fwupd_security_attr_from_json(FwupdSecurityAttr *self, JsonNode *json_node, GErr
 	/* this has to exist */
 	if (!json_object_has_member(obj, FWUPD_RESULT_KEY_APPSTREAM_ID)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "no %s property in object",
 			    FWUPD_RESULT_KEY_APPSTREAM_ID);
 		return FALSE;

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -987,6 +987,7 @@ LIBFWUPD_2.0.0 {
     fwupd_client_modify_config_finish;
     fwupd_client_refresh_remote;
     fwupd_client_refresh_remote_async;
+    fwupd_error_convert;
     fwupd_remote_set_checksum_sig;
     fwupd_remote_set_firmware_base_uri;
     fwupd_remote_set_kind;

--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -144,8 +144,8 @@ fu_acpi_table_parse(FuFirmware *firmware,
 		return FALSE;
 	if (length > streamsz || length < st->len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "table length not valid: got 0x%x but expected 0x%x",
 			    (guint)streamsz,
 			    (guint)length);

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -171,8 +171,8 @@ fu_archive_firmware_get_image_fnmatch(FuArchiveFirmware *self, const gchar *patt
 			continue;
 		if (img_match != NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "multiple images matched %s",
 				    pattern);
 			return NULL;
@@ -181,8 +181,8 @@ fu_archive_firmware_get_image_fnmatch(FuArchiveFirmware *self, const gchar *patt
 	}
 	if (img_match == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "no image matched %s",
 			    pattern);
 		return NULL;

--- a/libfwupdplugin/fu-archive.c
+++ b/libfwupdplugin/fu-archive.c
@@ -100,7 +100,8 @@ fu_archive_lookup_by_fn(FuArchive *self, const gchar *fn, GError **error)
 
 	bytes = g_hash_table_lookup(self->entries, fn);
 	if (bytes == NULL) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no blob for %s", fn);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no blob for %s", fn);
+		return NULL;
 	}
 	return bytes;
 }
@@ -252,8 +253,8 @@ fu_archive_load(FuArchive *self, GBytes *blob, FuArchiveFlags flags, GError **er
 	arch = archive_read_new();
 	if (arch == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "libarchive startup failed");
 		return FALSE;
 	}
@@ -264,8 +265,8 @@ fu_archive_load(FuArchive *self, GBytes *blob, FuArchiveFlags flags, GError **er
 				     (size_t)g_bytes_get_size(blob));
 	if (r != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot open: %s",
 			    archive_error_string(arch));
 		return FALSE;
@@ -284,8 +285,8 @@ fu_archive_load(FuArchive *self, GBytes *blob, FuArchiveFlags flags, GError **er
 			break;
 		if (r != ARCHIVE_OK) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "cannot read header: %s",
 				    archive_error_string(arch));
 			return FALSE;
@@ -298,8 +299,8 @@ fu_archive_load(FuArchive *self, GBytes *blob, FuArchiveFlags flags, GError **er
 		bufsz = archive_entry_size(entry);
 		if (bufsz > 1024 * 1024 * 1024) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "cannot read huge files");
 			return FALSE;
 		}
@@ -307,16 +308,16 @@ fu_archive_load(FuArchive *self, GBytes *blob, FuArchiveFlags flags, GError **er
 		rc = archive_read_data(arch, buf, (gsize)bufsz);
 		if (rc < 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "cannot read data: %s",
 				    archive_error_string(arch));
 			return FALSE;
 		}
 		if (rc != bufsz) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "read %" G_GSSIZE_FORMAT " of %" G_GINT64_FORMAT,
 				    rc,
 				    bufsz);
@@ -437,8 +438,8 @@ fu_archive_write(FuArchive *self,
 #ifndef HAVE_LIBARCHIVE_WRITE_ADD_COMPRESSION_ZSTD
 	if (compression == FU_ARCHIVE_COMPRESSION_ZSTD) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "archive_write_add_filter_zstd() not supported");
 		return NULL;
 	}
@@ -448,8 +449,8 @@ fu_archive_write(FuArchive *self,
 	arch = archive_write_new();
 	if (arch == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "libarchive startup failed");
 		return NULL;
 	}
@@ -463,8 +464,8 @@ fu_archive_write(FuArchive *self,
 	r = archive_write_open(arch, blob, NULL, fu_archive_write_cb, NULL);
 	if (r != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot open: %s",
 			    archive_error_string(arch));
 		return NULL;
@@ -486,8 +487,8 @@ fu_archive_write(FuArchive *self,
 		r = archive_write_header(arch, entry);
 		if (r != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "cannot write header: %s",
 				    archive_error_string(arch));
 			return NULL;
@@ -497,8 +498,8 @@ fu_archive_write(FuArchive *self,
 					g_bytes_get_size(bytes));
 		if (rc < 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
 				    "cannot write data: %s",
 				    archive_error_string(arch));
 			return NULL;
@@ -508,8 +509,8 @@ fu_archive_write(FuArchive *self,
 	r = archive_write_close(arch);
 	if (r != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot close: %s",
 			    archive_error_string(arch));
 		return NULL;

--- a/libfwupdplugin/fu-bios-setting.c
+++ b/libfwupdplugin/fu-bios-setting.c
@@ -34,11 +34,12 @@ fu_bios_setting_write_value(FwupdBiosSetting *self, const gchar *value, GError *
 #ifdef HAVE_ERRNO_H
 			    g_io_error_from_errno(errno),
 #else
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 			    "could not open %s: %s",
 			    fn,
 			    g_strerror(errno));
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	io = fu_io_channel_unix_new(fd);

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -588,8 +588,8 @@ fu_bios_settings_get_pending_reboot(FuBiosSettings *self, gboolean *result, GErr
 	}
 	if (attr == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "failed to find pending reboot attribute");
 		return FALSE;
 	}
@@ -653,7 +653,10 @@ fu_bios_settings_from_json(FuBiosSettings *self, JsonNode *json_node, GError **e
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 	obj = json_node_get_object(json_node);
@@ -661,8 +664,8 @@ fu_bios_settings_from_json(FuBiosSettings *self, JsonNode *json_node, GError **e
 	/* this has to exist */
 	if (!json_object_has_member(obj, "BiosSettings")) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no BiosSettings property in object");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -74,8 +74,8 @@ fu_bluez_device_get_uuid_helper(FuBluezDevice *self, const gchar *uuid, GError *
 	uuid_helper = g_hash_table_lookup(priv->uuids, uuid);
 	if (uuid_helper == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "UUID %s not supported",
 			    uuid);
 		return NULL;
@@ -124,8 +124,8 @@ fu_bluez_device_ensure_uuid_helper_proxy(FuBluezDeviceUuidHelper *uuid_helper, G
 						  uuid_helper);
 	if (uuid_helper->signal_id <= 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot connect to signal of UUID %s",
 			    uuid_helper->uuid);
 		return FALSE;
@@ -363,8 +363,8 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 	val_address = g_dbus_proxy_get_cached_property(priv->proxy, "Address");
 	if (val_address == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "No required BLE address");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-bytes.c
+++ b/libfwupdplugin/fu-bytes.c
@@ -239,8 +239,8 @@ fu_bytes_new_offset(GBytes *bytes, gsize offset, gsize length, GError **error)
 	/* sanity check */
 	if (offset + length < length || offset + length > g_bytes_get_size(bytes)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot create bytes @0x%02x for 0x%02x "
 			    "as buffer only 0x%04x bytes in size",
 			    (guint)offset,
@@ -274,7 +274,7 @@ fu_bytes_get_data_safe(GBytes *bytes, gsize *bufsz, GError **error)
 {
 	const guint8 *buf = g_bytes_get_data(bytes, bufsz);
 	if (buf == NULL) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid data");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "invalid data");
 		return NULL;
 	}
 	return buf;

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -204,8 +204,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 	blob_uncomp = fu_struct_cab_data_get_uncomp(st);
 	if (helper->compression == FU_CAB_COMPRESSION_NONE && blob_comp != blob_uncomp) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "mismatched compressed data");
 		return FALSE;
 	}
@@ -214,8 +214,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 		g_autofree gchar *sz_val = g_format_size(helper->size_total);
 		g_autofree gchar *sz_max = g_format_size(size_max);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "uncompressed data too large (%s, limit %s)",
 			    sz_val,
 			    sz_max);
@@ -246,8 +246,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 				return FALSE;
 			if (checksum_actual != checksum) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "invalid checksum at 0x%x, expected 0x%x, got 0x%x",
 					    (guint)*offset,
 					    checksum,
@@ -280,8 +280,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 			return FALSE;
 		if (g_strcmp0(kind, "CK") != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "compressed header invalid: %s",
 				    kind);
 			return FALSE;
@@ -297,8 +297,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 			g_byte_array_append(buf, tmp, sizeof(tmp) - helper->zstrm.avail_out);
 			if (zret != Z_OK) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "inflate error @0x%x: %s",
 					    (guint)*offset,
 					    zError(zret));
@@ -308,8 +308,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 		zret = inflateReset(&helper->zstrm);
 		if (zret != Z_OK) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to reset inflate: %s",
 				    zError(zret));
 			return FALSE;
@@ -317,8 +317,8 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 		zret = inflateSetDictionary(&helper->zstrm, buf->data, buf->len);
 		if (zret != Z_OK) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to set inflate dictionary: %s",
 				    zError(zret));
 			return FALSE;
@@ -357,8 +357,8 @@ fu_cab_firmware_parse_folder(FuCabFirmware *self,
 	/* sanity check */
 	if (fu_struct_cab_folder_get_ndatab(st) == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no CFDATA blocks");
 		return FALSE;
 	}
@@ -368,8 +368,8 @@ fu_cab_firmware_parse_folder(FuCabFirmware *self,
 	if (helper->compression != FU_CAB_COMPRESSION_NONE &&
 	    helper->compression != FU_CAB_COMPRESSION_MSZIP) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "compression %s not supported",
 			    fu_cab_compression_to_string(helper->compression));
 		return FALSE;
@@ -416,8 +416,8 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 	index = fu_struct_cab_file_get_index(st);
 	if (index >= helper->folder_data->len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to get folder data for 0x%x",
 			    index);
 		return FALSE;
@@ -488,8 +488,8 @@ fu_cab_firmware_parse_helper_new(GInputStream *stream, FwupdInstallFlags flags, 
 	zret = inflateInit2(&helper->zstrm, -MAX_WBITS);
 	if (zret != Z_OK) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to initialize inflate: %s",
 			    zError(zret));
 		return NULL;
@@ -526,8 +526,8 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 	/* sanity checks */
 	if (fu_struct_cab_header_get_size(st) < streamsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "buffer size 0x%x is less than stream size 0x%x",
 			    (guint)streamsz,
 			    fu_struct_cab_header_get_size(st));
@@ -535,23 +535,23 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 	}
 	if (fu_struct_cab_header_get_idx_cabinet(st) != 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "chained archive not supported");
 		return FALSE;
 	}
 	if (fu_struct_cab_header_get_nr_folders(st) == 0 ||
 	    fu_struct_cab_header_get_nr_files(st) == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "archive is empty");
 		return FALSE;
 	}
 	if (fu_struct_cab_header_get_nr_folders(st) > FU_CAB_FIRMWARE_MAX_FOLDERS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "too many CFFOLDERS, parsed %u and limit was %u",
 			    fu_struct_cab_header_get_nr_folders(st),
 			    (guint)FU_CAB_FIRMWARE_MAX_FOLDERS);
@@ -559,8 +559,8 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 	}
 	if (fu_struct_cab_header_get_nr_files(st) > FU_CAB_FIRMWARE_MAX_FILES) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "too many CFFILES, parsed %u and limit was %u",
 			    fu_struct_cab_header_get_nr_files(st),
 			    (guint)FU_CAB_FIRMWARE_MAX_FILES);
@@ -569,8 +569,8 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 	off_cffile = fu_struct_cab_header_get_off_cffile(st);
 	if (off_cffile > streamsz) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "archive is corrupt");
 		return FALSE;
 	}
@@ -602,8 +602,8 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		if (streamsz == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "no folder data");
 			return FALSE;
 		}
@@ -646,8 +646,8 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 
 		if (filename_win32 == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "no image filename");
 			return NULL;
 		}
@@ -660,8 +660,8 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 	/* chunkify and compress with a fixed size */
 	if (cfdata_linear->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no data to compress");
 		return NULL;
 	}
@@ -697,8 +697,8 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 					    Z_DEFAULT_STRATEGY);
 			if (zret != Z_OK) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "failed to initialize deflate: %s",
 					    zError(zret));
 				return NULL;
@@ -706,8 +706,8 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 			zret = deflate(zstrm_deflater, Z_FINISH);
 			if (zret != Z_OK && zret != Z_STREAM_END) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "zlib deflate failed: %s",
 					    zError(zret));
 				return NULL;

--- a/libfwupdplugin/fu-cab-image.c
+++ b/libfwupdplugin/fu-cab-image.c
@@ -117,8 +117,8 @@ fu_cab_image_build(FuFirmware *firmware, XbNode *n, GError **error)
 		g_autoptr(GDateTime) created = g_date_time_new_from_iso8601(tmp, NULL);
 		if (created == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "not iso8601: %s",
 				    tmp);
 			return FALSE;

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -310,8 +310,8 @@ fu_cfi_device_setup(FuDevice *device, GError **error)
 		flash_idsz = strlen(priv->flash_id);
 	if (flash_idsz == 0 || flash_idsz % 2 != 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "not a valid flash-id");
 		return FALSE;
 	}
@@ -356,13 +356,16 @@ fu_cfi_device_get_cmd(FuCfiDevice *self, FuCfiDeviceCmd cmd, guint8 *value, GErr
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (cmd >= FU_CFI_DEVICE_CMD_LAST) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "CFI cmd invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "CFI cmd invalid");
 		return FALSE;
 	}
 	if (priv->cmds[cmd] == 0x0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "No defined CFI cmd for %s",
 			    fu_cfi_device_cmd_to_string(cmd));
 		return FALSE;

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -54,8 +54,8 @@ fu_cfu_payload_parse(FuFirmware *firmware,
 		chunk_size = fu_struct_cfu_payload_get_size(st);
 		if (chunk_size == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "payload size was invalid");
 			return FALSE;
 		}

--- a/libfwupdplugin/fu-chunk-array.c
+++ b/libfwupdplugin/fu-chunk-array.c
@@ -74,12 +74,12 @@ fu_chunk_array_index(FuChunkArray *self, guint idx, GError **error)
 	/* calculate offset and length */
 	offset = (gsize)idx * (gsize)self->packet_sz;
 	if (offset >= self->total_size) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "idx %u invalid", idx);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "idx %u invalid", idx);
 		return NULL;
 	}
 	length = MIN(self->packet_sz, self->total_size - offset);
 	if (length == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "idx %u zero sized", idx);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "idx %u zero sized", idx);
 		return NULL;
 	}
 

--- a/libfwupdplugin/fu-common-darwin.c
+++ b/libfwupdplugin/fu-common-darwin.c
@@ -15,10 +15,10 @@
 GPtrArray *
 fu_common_get_block_devices(GError **error)
 {
-	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
-		    "getting block devices is not supported on Darwin");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "getting block devices is not supported on Darwin");
 	return NULL;
 }
 
@@ -44,9 +44,9 @@ fu_common_get_kernel_cmdline_impl(GError **error)
 gchar *
 fu_common_get_olson_timezone_id_impl(GError **error)
 {
-	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
-		    "getting the Olson timezone ID is not supported on Darwin");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "getting the Olson timezone ID is not supported on Darwin");
 	return NULL;
 }

--- a/libfwupdplugin/fu-common-linux.c
+++ b/libfwupdplugin/fu-common-linux.c
@@ -217,8 +217,8 @@ fu_common_get_olson_timezone_id_impl(GError **error)
 			guint sections_len = g_strv_length(sections);
 			if (sections_len < 2) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_FILENAME,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "invalid symlink target: %s",
 					    target);
 				return NULL;
@@ -231,8 +231,8 @@ fu_common_get_olson_timezone_id_impl(GError **error)
 
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no timezone or localtime is available");
 	return NULL;
 }

--- a/libfwupdplugin/fu-common-windows.c
+++ b/libfwupdplugin/fu-common-windows.c
@@ -18,10 +18,10 @@
 GPtrArray *
 fu_common_get_block_devices(GError **error)
 {
-	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
-		    "getting block devices is not supported on Windows");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "getting block devices is not supported on Windows");
 	return NULL;
 }
 
@@ -191,8 +191,8 @@ fu_common_convert_tzinfo_to_olson_id(const gchar *tzinfo, GError **error)
 			return g_strdup(map[i].olson_id);
 	}
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "cannot map tzinfo '%s' to Olson ID",
 		    tzinfo);
 	return NULL;
@@ -209,8 +209,8 @@ fu_common_get_olson_timezone_id_impl(GError **error)
 	rc = GetTimeZoneInformation(&tzinfo);
 	if (rc == TIME_ZONE_ID_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot get timezone information [%u]",
 			    (guint)GetLastError());
 		return NULL;

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -54,7 +54,7 @@ fu_cpuid(guint32 leaf, guint32 *eax, guint32 *ebx, guint32 *ecx, guint32 *edx, G
 		*edx = edx_tmp;
 	return TRUE;
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no <cpuid.h> support");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no <cpuid.h> support");
 	return FALSE;
 #endif
 }
@@ -186,8 +186,8 @@ fu_common_check_full_disk_encryption(GError **error)
 			continue;
 		if (g_strcmp0(g_variant_get_string(id_type, NULL), "BitLocker") == 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_WOULD_BLOCK,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_AUTH_EXPIRED,
 				    "%s device %s is encrypted",
 				    g_variant_get_string(id_type, NULL),
 				    g_variant_get_bytestring(device));

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -146,8 +146,8 @@ fu_composite_input_stream_get_item_for_offset(FuCompositeInputStream *self,
 			return item;
 	}
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_DATA,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "offset is 0x%x out of range",
 		    (guint)offset);
 	return NULL;
@@ -192,8 +192,8 @@ fu_composite_input_stream_truncate(GSeekable *seekable,
 				   GError **error)
 {
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot truncate FuCompositeInputStream");
 	return FALSE;
 }

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -63,7 +63,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (fd < 0) {
 		g_set_error(error,
 			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 			    "could not open %s file",
 			    filename);
 		return FALSE;
@@ -72,7 +72,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (wrote != length) {
 		g_set_error(error,
 			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 			    "did not write %s file",
 			    filename);
 		g_close(fd, NULL);
@@ -420,8 +420,8 @@ fu_config_reload(FuConfig *self, GError **error)
 			g_info("renaming legacy config file %s to %s", fn_old, fn_new);
 			if (g_rename(fn_old, fn_new) != 0) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_FILE,
 					    "failed to change rename %s to %s",
 					    fn_old,
 					    fn_new);
@@ -499,7 +499,7 @@ fu_config_save(FuConfig *self, GError **error)
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED, "no writable config");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no writable config");
 	return FALSE;
 }
 
@@ -533,7 +533,7 @@ fu_config_set_value(FuConfig *self,
 
 	/* sanity check */
 	if (priv->items->len == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED, "no config to load");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no config to load");
 		return FALSE;
 	}
 

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -239,7 +239,7 @@ fu_context_get_smbios_data(FuContext *self, guint8 structure_type, GError **erro
 	/* must be valid and non-zero length */
 	if (!fu_context_has_flag(self, FU_CONTEXT_FLAG_LOADED_HWINFO)) {
 		g_critical("cannot use SMBIOS before calling ->load_hwinfo()");
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED, "no data");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no data");
 		return NULL;
 	}
 	return fu_smbios_get_data(priv->smbios, structure_type, error);
@@ -478,7 +478,7 @@ fu_context_get_hwid_replace_value(FuContext *self, const gchar *keys, GError **e
 
 	if (!fu_context_has_flag(self, FU_CONTEXT_FLAG_LOADED_HWINFO)) {
 		g_critical("cannot use HWIDs before calling ->load_hwinfo()");
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED, "no data");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no data");
 		return NULL;
 	}
 	return fu_hwids_get_replace_values(priv->hwids, keys, error);
@@ -675,8 +675,8 @@ fu_context_get_plugin_names_for_udev_subsystem(FuContext *self,
 	plugin_names = g_hash_table_lookup(priv->udev_subsystems, subsystem);
 	if (plugin_names == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "no plugins registered for %s",
 			    subsystem);
 		return NULL;
@@ -1479,16 +1479,16 @@ fu_context_get_esp_volumes(FuContext *self, GError **error)
 		devices = fu_common_get_block_devices(NULL);
 		if (devices != NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "No ESP or BDP found");
 			return NULL;
 		}
 		base = fu_path_from_kind(FU_PATH_KIND_SYSCONFDIR_PKG);
 		path = g_build_filename(base, "fwupd.conf", NULL);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "No valid 'EspLocation' specified in %s",
 			    path);
 		return NULL;

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -148,7 +148,10 @@ fu_coswid_firmware_parse_one_or_many(FuCoswidFirmware *self,
 	}
 
 	/* not sure what to do */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "neither an array or map");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "neither an array or map");
 	return FALSE;
 }
 
@@ -223,8 +226,8 @@ fu_coswid_firmware_parse_hash(FuCoswidFirmware *self,
 	/* sanity check */
 	if (hash_item_alg_id == NULL || hash_item_value == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid hash item");
 		return FALSE;
 	}
@@ -290,8 +293,8 @@ fu_coswid_firmware_parse_file(FuCoswidFirmware *self,
 				}
 			} else {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "hashes neither an array or array of array");
 				return FALSE;
 			}
@@ -424,8 +427,8 @@ fu_coswid_firmware_parse_entity(FuCoswidFirmware *self,
 				FuCoswidEntityRole role = cbor_get_uint8(value);
 				if (entity_role_cnt >= G_N_ELEMENTS(entity->roles)) {
 					g_set_error_literal(error,
-							    G_IO_ERROR,
-							    G_IO_ERROR_INVALID_DATA,
+							    FWUPD_ERROR,
+							    FWUPD_ERROR_INVALID_DATA,
 							    "too many roles");
 					return FALSE;
 				}
@@ -483,8 +486,8 @@ fu_coswid_firmware_parse(FuFirmware *firmware,
 	/* sanity check */
 	if (!cbor_isa_map(item)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "root item is not a map");
 		return FALSE;
 	}
@@ -551,8 +554,8 @@ fu_coswid_firmware_parse(FuFirmware *firmware,
 	if (fu_firmware_get_id(firmware) == NULL && fu_firmware_get_version(firmware) == NULL &&
 	    priv->product == NULL && priv->entities->len == 0 && priv->links->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "not enough SBoM data");
 		return FALSE;
 	}
@@ -561,8 +564,8 @@ fu_coswid_firmware_parse(FuFirmware *firmware,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "not compiled with CBOR support");
 	return FALSE;
 #endif
@@ -591,8 +594,8 @@ fu_coswid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kind, G
 	}
 	if (alg_id == FU_COSWID_HASH_ALG_UNKNOWN) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot convert %s",
 			    fwupd_checksum_type_to_string_display(csum_kind));
 		return NULL;
@@ -608,8 +611,8 @@ fu_coswid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kind, G
 		}
 	}
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "no hash kind %s",
 		    fwupd_checksum_type_to_string_display(csum_kind));
 	return NULL;
@@ -852,16 +855,16 @@ fu_coswid_firmware_write(FuFirmware *firmware, GError **error)
 	buflen = cbor_serialize_alloc(root, &buf, &bufsz);
 	if (buflen > bufsz) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "CBOR allocation failure");
 		return NULL;
 	}
 	return g_byte_array_new_take(g_steal_pointer(&buf), buflen);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "not compiled with CBOR support");
 	return NULL;
 #endif
@@ -896,16 +899,16 @@ fu_coswid_firmware_build_entity(FuCoswidFirmware *self, XbNode *n, GError **erro
 			role = fu_coswid_entity_role_from_string(tmp);
 			if (role == FU_COSWID_ENTITY_ROLE_UNKNOWN) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "failed to parse entity role %s",
 					    tmp);
 				return FALSE;
 			}
 			if (entity_role_cnt >= G_N_ELEMENTS(entity->roles)) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "too many roles");
 				return FALSE;
 			}
@@ -937,8 +940,8 @@ fu_coswid_firmware_build_link(FuCoswidFirmware *self, XbNode *n, GError **error)
 		link->rel = fu_coswid_link_rel_from_string(tmp);
 		if (link->rel == FU_COSWID_LINK_REL_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to parse link rel %s",
 				    tmp);
 			return FALSE;
@@ -973,8 +976,8 @@ fu_coswid_firmware_build_hash(FuCoswidFirmware *self,
 		hash->alg_id = fu_coswid_hash_alg_from_string(tmp);
 		if (hash->alg_id == FU_COSWID_HASH_ALG_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to parse alg_id %s",
 				    tmp);
 			return FALSE;
@@ -1044,8 +1047,8 @@ fu_coswid_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 		priv->version_scheme = fu_coswid_version_scheme_from_string(tmp);
 		if (priv->version_scheme == FU_COSWID_VERSION_SCHEME_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to parse version_scheme %s",
 				    tmp);
 			return FALSE;

--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -157,8 +157,8 @@ fu_csv_entry_parse_token_cb(GString *token, guint token_idx, gpointer user_data,
 	/* sanity check */
 	if (token_idx > FU_CSV_ENTRY_COLUMNS_MAX) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "too many columns, limit is %u",
 			    FU_CSV_ENTRY_COLUMNS_MAX);
 		return FALSE;

--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -149,8 +149,8 @@ fu_device_locker_new(gpointer device, GError **error)
 						 error);
 	}
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "device object type not supported");
 	return NULL;
 }

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -768,8 +768,8 @@ fu_device_retry_full(FuDevice *self,
 		/* sanity check */
 		if (error_local == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "exec failed but no error set!");
 			return FALSE;
 		}
@@ -1761,8 +1761,8 @@ fu_device_add_child_by_kv(FuDevice *self, const gchar *str, GError **error)
 		GType devtype = g_type_from_name(split[0]);
 		if (devtype == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "no GType registered");
 			return FALSE;
 		}
@@ -1771,8 +1771,8 @@ fu_device_add_child_by_kv(FuDevice *self, const gchar *str, GError **error)
 
 	/* more than one '|' */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "unable to add parse child section");
 	return FALSE;
 }
@@ -1788,8 +1788,8 @@ fu_device_set_quirk_inhibit_section(FuDevice *self, const gchar *value, GError *
 	sections = g_strsplit(value, ":", -1);
 	if (g_strv_length(sections) != 2) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "quirk key not supported, expected k1:v1[,k2:v2][,k3:]");
 		return FALSE;
 	}
@@ -1989,8 +1989,8 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 		priv->specialized_gtype = g_type_from_name(value);
 		if (priv->specialized_gtype == G_TYPE_INVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "unknown GType name %s",
 				    value);
 			return FALSE;
@@ -2007,8 +2007,8 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 		priv->firmware_gtype = g_type_from_name(value);
 		if (priv->firmware_gtype == G_TYPE_INVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "unknown GType name %s",
 				    value);
 			return FALSE;
@@ -2029,7 +2029,10 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 		return device_class->set_quirk_kv(self, key, value, error);
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 
@@ -2108,9 +2111,8 @@ fu_device_quirks_iter_cb(FuContext *ctx, const gchar *key, const gchar *value, g
 	FuDevice *self = FU_DEVICE(user_data);
 	g_autoptr(GError) error = NULL;
 	if (!fu_device_set_quirk_kv(self, key, value, &error)) {
-		if (!g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+		if (!g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED))
 			g_warning("failed to set quirk key %s=%s: %s", key, value, error->message);
-		}
 	}
 }
 
@@ -3269,7 +3271,11 @@ fu_device_ensure_id(FuDevice *self, GError **error)
 	/* nothing we can do! */
 	if (priv->physical_id == NULL) {
 		g_autofree gchar *tmp = fu_device_to_string(self);
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "cannot ensure ID: %s", tmp);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot ensure ID: %s",
+			    tmp);
 		return FALSE;
 	}
 
@@ -5783,8 +5789,8 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 	if (fwupd_request_has_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE) &&
 	    !fu_device_has_request_flag(self, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "request %s emitted but device %s [%s] does not set "
 			    "FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE",
 			    fwupd_request_get_id(request),
@@ -5795,8 +5801,8 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 	if (!fwupd_request_has_flag(request, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE) &&
 	    !fu_device_has_request_flag(self, FWUPD_REQUEST_FLAG_NON_GENERIC_MESSAGE)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "request %s is not a GENERIC_MESSAGE and device %s [%s] does not set "
 			    "FWUPD_REQUEST_FLAG_NON_GENERIC_MESSAGE",
 			    fwupd_request_get_id(request),
@@ -5809,22 +5815,22 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 	/* sanity check */
 	if (fwupd_request_get_kind(request) == FWUPD_REQUEST_KIND_UNKNOWN) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "a request must have an assigned kind");
 		return FALSE;
 	}
 	if (fwupd_request_get_id(request) == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "a request must have an assigned ID");
 		return FALSE;
 	}
 	if (fwupd_request_get_kind(request) >= FWUPD_REQUEST_KIND_LAST) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "invalid request kind");
 		return FALSE;
 	}
@@ -5832,8 +5838,8 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 	/* already cancelled */
 	if (progress != NULL && fu_progress_has_flag(progress, FU_PROGRESS_FLAG_NO_SENDER)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_CANCELLED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no sender, and so cannot process request");
 		return FALSE;
 	}
@@ -5862,7 +5868,7 @@ fu_device_emit_request(FuDevice *self, FwupdRequest *request, FuProgress *progre
 		g_debug("using fallback progress");
 		fu_progress_set_status(priv->progress, FWUPD_STATUS_WAITING_FOR_USER);
 	} else {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no progress");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no progress");
 		return FALSE;
 	}
 	g_signal_emit(self, signals[SIGNAL_REQUEST], 0, request);
@@ -6117,8 +6123,8 @@ fu_device_build_instance_id(FuDevice *self, GError **error, const gchar *subsyst
 			value = fu_device_get_instance_str(priv->proxy, key);
 		if (value == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no value for %s",
 				    key);
 			ret = FALSE;
@@ -6177,8 +6183,8 @@ fu_device_build_instance_id_full(FuDevice *self,
 		value = g_hash_table_lookup(priv->instance_hash, key);
 		if (value == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no value for %s",
 				    key);
 			ret = FALSE;

--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -103,8 +103,8 @@ fu_dpaux_device_setup(FuDevice *device, GError **error)
 	    g_str_has_prefix(fu_device_get_name(device), "AMDGPU DM") &&
 	    fu_context_has_hwid_guid(ctx, "32d49d99-414b-55d5-813b-12aaf0335b58")) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "reading %s DPCD is broken on this hardware, "
 			    "you need to update the system BIOS",
 			    fu_device_get_name(device));
@@ -272,10 +272,7 @@ fu_dpaux_device_write(FuDpauxDevice *self,
 
 	/* sanity check */
 	if (io_channel == NULL) {
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_INITIALIZED,
-				    "device is not open");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "device is not open");
 		return FALSE;
 	}
 
@@ -283,8 +280,8 @@ fu_dpaux_device_write(FuDpauxDevice *self,
 	fu_dump_raw(G_LOG_DOMAIN, title, buf, bufsz);
 	if (lseek(fu_io_channel_unix_get_fd(io_channel), offset, SEEK_SET) != offset) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to lseek to 0x%x",
 			    (guint)offset);
 		return FALSE;
@@ -327,17 +324,14 @@ fu_dpaux_device_read(FuDpauxDevice *self,
 
 	/* sanity check */
 	if (io_channel == NULL) {
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_INITIALIZED,
-				    "device is not open");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "device is not open");
 		return FALSE;
 	}
 	/* seek, then read */
 	if (lseek(fu_io_channel_unix_get_fd(io_channel), offset, SEEK_SET) != offset) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to lseek to 0x%x",
 			    (guint)offset);
 		return FALSE;

--- a/libfwupdplugin/fu-efi-common.c
+++ b/libfwupdplugin/fu-efi-common.c
@@ -111,8 +111,8 @@ fu_efi_parse_sections(FuFirmware *firmware,
 		/* invalid */
 		if (fu_firmware_get_size(img) == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "section had zero size");
 			return FALSE;
 		}

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -90,8 +90,8 @@ fu_efi_device_path_parse(FuFirmware *firmware,
 		return FALSE;
 	if (fu_struct_efi_device_path_get_length(st) < FU_STRUCT_EFI_DEVICE_PATH_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "EFI DEVICE_PATH length invalid: 0x%x",
 			    fu_struct_efi_device_path_get_length(st));
 		return FALSE;

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -226,16 +226,16 @@ fu_efi_hard_drive_device_path_new_from_volume(FuVolume *volume, GError **error)
 	partition_kind = fu_volume_get_partition_kind(volume);
 	if (partition_kind == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "partition kind required");
 		return NULL;
 	}
 	partition_uuid = fu_volume_get_partition_uuid(volume);
 	if (partition_uuid == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "partition UUID required");
 		return NULL;
 	}
@@ -271,8 +271,8 @@ fu_efi_hard_drive_device_path_new_from_volume(FuVolume *volume, GError **error)
 		self->signature_type = FU_EFI_HARD_DRIVE_DEVICE_PATH_SIGNATURE_TYPE_ADDR1B8;
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "partition kind %s not supported",
 			    partition_kind);
 		return NULL;

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -131,8 +131,8 @@ fu_efi_load_option_parse(FuFirmware *firmware,
 		guint16 tmp = 0;
 		if (buf_utf16->len > FU_EFI_LOAD_OPTION_DESCRIPTION_SIZE_MAX) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "description was too long, limit is 0x%x chars",
 				    FU_EFI_LOAD_OPTION_DESCRIPTION_SIZE_MAX / 2);
 			return FALSE;
@@ -183,8 +183,8 @@ fu_efi_load_option_write(FuFirmware *firmware, GError **error)
 	/* label */
 	if (fu_firmware_get_id(firmware) == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware ID required");
 		return NULL;
 	}

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -156,13 +156,16 @@ fu_efi_lz77_decompressor_make_huffman_table(FuEfiLz77DecompressHelper *helper,
 
 	/* the maximum mapping table width supported by this internal working function is 16 */
 	if (mapping_table_bits >= (sizeof(count) / sizeof(guint16))) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "bad table");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bad table");
 		return FALSE;
 	}
 
 	for (index = 0; index < number_of_symbols; index++) {
 		if (code_length_array[index] > 16) {
-			g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "bad table");
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
+					    "bad table");
 			return FALSE;
 		}
 		count[code_length_array[index]]++;
@@ -176,7 +179,7 @@ fu_efi_lz77_decompressor_make_huffman_table(FuEfiLz77DecompressHelper *helper,
 
 	if (start[17] != 0) {
 		/*(1U << 16)*/
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "bad table");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bad table");
 		return FALSE;
 	}
 
@@ -217,8 +220,8 @@ fu_efi_lz77_decompressor_make_huffman_table(FuEfiLz77DecompressHelper *helper,
 			for (index = start[len]; index < next_code; index++) {
 				if (index >= max_table_length) {
 					g_set_error_literal(error,
-							    G_IO_ERROR,
-							    G_IO_ERROR_FAILED,
+							    FWUPD_ERROR,
+							    FWUPD_ERROR_INVALID_DATA,
 							    "bad table");
 					return FALSE;
 				}
@@ -305,7 +308,7 @@ fu_efi_lz77_decompressor_read_pt_len(FuEfiLz77DecompressHelper *helper,
 
 	/* fail if number or number_of_symbols is greater than size of pt_len */
 	if ((number > sizeof(helper->pt_len)) || (number_of_symbols > sizeof(helper->pt_len))) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "bad table");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bad table");
 		return FALSE;
 	}
 	if (number == 0) {
@@ -516,8 +519,8 @@ fu_efi_lz77_decompressor_internal(FuEfiLz77DecompressHelper *helper,
 		break;
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "unknown version 0x%x",
 			    version);
 		return FALSE;
@@ -553,15 +556,15 @@ fu_efi_lz77_decompressor_internal(FuEfiLz77DecompressHelper *helper,
 			while ((gint16)(bytes_remaining) >= 0) {
 				if (dst_offset >= helper->dst->len) {
 					g_set_error_literal(error,
-							    G_IO_ERROR,
-							    G_IO_ERROR_FAILED,
+							    FWUPD_ERROR,
+							    FWUPD_ERROR_INVALID_DATA,
 							    "bad pointer offset");
 					return FALSE;
 				}
 				if (data_offset >= helper->dst->len) {
 					g_set_error_literal(error,
-							    G_IO_ERROR,
-							    G_IO_ERROR_FAILED,
+							    FWUPD_ERROR,
+							    FWUPD_ERROR_INVALID_DATA,
 							    "bad table");
 					return FALSE;
 				}
@@ -602,16 +605,16 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 	src_bufsz = fu_struct_efi_lz77_decompressor_header_get_src_size(st);
 	if (streamsz - offset < src_bufsz + st->len) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "source buffer is truncated");
 		return FALSE;
 	}
 	dst_bufsz = fu_struct_efi_lz77_decompressor_header_get_dst_size(st);
 	if (dst_bufsz == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "destination size is zero");
 		return FALSE;
 	}
@@ -619,8 +622,8 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 		g_autofree gchar *sz_val = g_format_size(dst_bufsz);
 		g_autofree gchar *sz_max = g_format_size(fu_firmware_get_size_max(firmware));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "destination size is too large (%s, limit %s)",
 			    sz_val,
 			    sz_max);

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -51,8 +51,8 @@ fu_efi_signature_list_parse_item(FuEfiSignatureList *self,
 	/* allocate data buf */
 	if (size <= sizeof(fwupd_guid_t)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SignatureSize invalid: 0x%x",
 			    (guint)size);
 		return FALSE;
@@ -113,8 +113,8 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 	list_size = fu_struct_efi_signature_list_get_list_size(st);
 	if (list_size < 0x1c || list_size > 1024 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SignatureListSize invalid: 0x%x",
 			    list_size);
 		return FALSE;
@@ -122,8 +122,8 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 	header_size = fu_struct_efi_signature_list_get_header_size(st);
 	if (header_size > 1024 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SignatureHeaderSize invalid: 0x%x",
 			    header_size);
 		return FALSE;
@@ -131,8 +131,8 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 	size = fu_struct_efi_signature_list_get_size(st);
 	if (size < sizeof(fwupd_guid_t) || size > 1024 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SignatureSize invalid: 0x%x",
 			    size);
 		return FALSE;
@@ -266,8 +266,8 @@ fu_efi_signature_list_write(FuFirmware *firmware, GError **error)
 			return NULL;
 		if (g_bytes_get_size(img_blob) != 16 + 32) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "expected SHA256 hash as signature data");
 			return NULL;
 		}

--- a/libfwupdplugin/fu-efi-signature.c
+++ b/libfwupdplugin/fu-efi-signature.c
@@ -128,8 +128,8 @@ fu_efi_signature_build(FuFirmware *firmware, XbNode *n, GError **error)
 		self->kind = fu_efi_signature_kind_from_string(tmp);
 		if (self->kind == FU_EFI_SIGNATURE_KIND_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid kind: %s",
 				    tmp);
 			return FALSE;

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -97,8 +97,8 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	alignment = (attrs & 0x00ff0000) >> 16;
 	if (alignment > FU_FIRMWARE_ALIGNMENT_2G) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "0x%x invalid, maximum is 0x%x",
 			    (guint)alignment,
 			    (guint)FU_FIRMWARE_ALIGNMENT_2G);
@@ -154,8 +154,8 @@ fu_efi_volume_parse(FuFirmware *firmware,
 				return FALSE;
 			if (fu_struct_efi_volume_ext_entry_get_size(st_ext_entry) == 0x0) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "EFI_VOLUME_EXT_ENTRY invalid size");
 				return FALSE;
 			}

--- a/libfwupdplugin/fu-efivar-freebsd.c
+++ b/libfwupdplugin/fu-efivar-freebsd.c
@@ -38,7 +38,11 @@ fu_efivar_delete_impl(const gchar *guid, const gchar *name, GError **error)
 	if (efi_del_variable(guidt, name) == 0)
 		return TRUE;
 
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "failed to delete efivar %s", name);
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
+		    "failed to delete efivar %s",
+		    name);
 	return FALSE;
 }
 
@@ -121,7 +125,11 @@ fu_efivar_get_names_impl(const gchar *guid, GError **error)
 
 	/* nothing found */
 	if (names->len == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no names for GUID %s", guid);
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "no names for GUID %s",
+				    guid);
 		return NULL;
 	}
 
@@ -150,8 +158,8 @@ fu_efivar_space_used_impl(GError **error)
 		size_t size = 0;
 		if (efi_get_variable_size(*guidt, name, &size) < 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to get efivar size");
 			return G_MAXUINT64;
 		}
@@ -175,8 +183,8 @@ fu_efivar_set_data_impl(const gchar *guid,
 
 	if (efi_set_variable(guidt, name, (guint8 *)data, sz, attr) != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to write data to efivar %s",
 			    name);
 		return FALSE;

--- a/libfwupdplugin/fu-efivar-windows.c
+++ b/libfwupdplugin/fu-efivar-windows.c
@@ -66,7 +66,7 @@ fu_efivar_delete_with_glob_impl(const gchar *guid, const gchar *name_glob, GErro
 
 	names = fu_efivar_get_names_impl(guid, &error_local);
 	if (names == NULL) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND))
 			return TRUE;
 		g_propagate_error(error, g_steal_pointer(&error_local));
 		return FALSE;
@@ -114,8 +114,8 @@ fu_efivar_get_data_impl(const gchar *guid,
 	/* unimplemented function KERNEL32.dll.GetFirmwareEnvironmentVariableExA on wine */
 	if (fu_efivar_is_running_under_wine()) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "GetFirmwareEnvironmentVariableExA is not implemented");
 		return FALSE;
 	}
@@ -143,8 +143,8 @@ fu_efivar_get_data_impl(const gchar *guid,
 
 	/* failed */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "failed to get get variable [%u]",
 		    (guint)GetLastError());
 	return FALSE;
@@ -229,7 +229,11 @@ fu_efivar_get_names_impl(const gchar *guid, GError **error)
 
 	/* nothing found */
 	if (names->len == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no names for GUID %s", guid);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "no names for GUID %s",
+			    guid);
 		return NULL;
 	}
 
@@ -270,15 +274,15 @@ fu_efivar_set_data_impl(const gchar *guid,
 	/* unimplemented function KERNEL32.dll.SetFirmwareEnvironmentVariableExA on wine */
 	if (fu_efivar_is_running_under_wine()) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "SetFirmwareEnvironmentVariableExA is not implemented");
 		return FALSE;
 	}
 	if (!SetFirmwareEnvironmentVariableExA(name, guid_win32, (PVOID)data, sz, attr)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to get set variable [%u]",
 			    (guint)GetLastError());
 		return FALSE;

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -114,8 +114,8 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 			continue;
 		if (sh_name > shstrndx_bufsz) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "offset into shstrndx invalid for section 0x%x",
 				    i);
 			return FALSE;

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -56,8 +56,8 @@ fu_string_new_safe(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 		g_string_append_c(str, (gchar)buf[i]);
 	}
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "buffer not NULL terminated");
 	return NULL;
 }
@@ -178,8 +178,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 		if (token == FDT_END) {
 			if (firmware_current != FU_FIRMWARE(self)) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "got END with unclosed node");
 				return FALSE;
 			}
@@ -195,8 +195,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 			/* sanity check */
 			if (depth++ > FDT_DEPTH_MAX) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "node depth exceeded maximum: 0x%x",
 					    (guint)FDT_DEPTH_MAX);
 				return FALSE;
@@ -220,8 +220,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 		if (token == FDT_END_NODE) {
 			if (firmware_current == FU_FIRMWARE(self)) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "got END NODE with no node to end");
 				return FALSE;
 			}
@@ -242,8 +242,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 			/* sanity check */
 			if (firmware_current == FU_FIRMWARE(self)) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "got PROP with unopen node");
 				return FALSE;
 			}
@@ -272,8 +272,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 
 		/* unknown token */
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid token 0x%x @0%x",
 			    token,
 			    (guint)offset);
@@ -283,8 +283,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 	/* did not see FDT_END */
 	if (!has_end) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "did not see FDT_END");
 		return FALSE;
 	}
@@ -351,8 +351,8 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 	totalsize = fu_struct_fdt_get_totalsize(st_hdr);
 	if (totalsize > streamsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "truncated image, got 0x%x, expected >= 0x%x",
 			    (guint)streamsz,
 			    (guint)totalsize);
@@ -369,8 +369,8 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 	}
 	if (fu_struct_fdt_get_last_comp_version(st_hdr) < FDT_LAST_COMP_VERSION) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid header version, got 0x%x, expected >= 0x%x",
 			    (guint)fu_struct_fdt_get_last_comp_version(st_hdr),
 			    (guint)FDT_LAST_COMP_VERSION);
@@ -400,8 +400,8 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		if (dt_struct->len != fu_struct_fdt_get_size_dt_struct(st_hdr)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid firmware -- dt_struct invalid");
 			return FALSE;
 		}
@@ -453,8 +453,8 @@ fu_fdt_firmware_write_image(FuFdtFirmware *self,
 	/* sanity check */
 	if (depth > 0 && id == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "child FuFdtImage requires ID");
 		return FALSE;
 	}
@@ -527,7 +527,7 @@ fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 
 	/* only one root node supported */
 	if (images->len != 1) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "no root node");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "no root node");
 		return NULL;
 	}
 	if (!fu_fdt_firmware_write_image(self,

--- a/libfwupdplugin/fu-fdt-image.c
+++ b/libfwupdplugin/fu-fdt-image.c
@@ -181,7 +181,7 @@ fu_fdt_image_get_attr(FuFdtImage *self, const gchar *key, GError **error)
 
 	blob = g_hash_table_lookup(priv->hash_attrs, key);
 	if (blob == NULL) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no data for %s", key);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no data for %s", key);
 		return NULL;
 	}
 
@@ -216,8 +216,8 @@ fu_fdt_image_get_attr_u32(FuFdtImage *self, const gchar *key, guint32 *val, GErr
 		return FALSE;
 	if (g_bytes_get_size(blob) != sizeof(guint32)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid data size for %s, got 0x%x, expected 0x%x",
 			    key,
 			    (guint)g_bytes_get_size(blob),
@@ -256,8 +256,8 @@ fu_fdt_image_get_attr_u64(FuFdtImage *self, const gchar *key, guint64 *val, GErr
 		return FALSE;
 	if (g_bytes_get_size(blob) != sizeof(guint64)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid data size for %s, got 0x%x, expected 0x%x",
 			    key,
 			    (guint)g_bytes_get_size(blob),
@@ -298,8 +298,8 @@ fu_fdt_image_get_attr_strlist(FuFdtImage *self, const gchar *key, gchar ***val, 
 		return FALSE;
 	if (g_bytes_get_size(blob) == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid data size for %s, got 0x%x",
 			    key,
 			    (guint)g_bytes_get_size(blob));
@@ -311,8 +311,8 @@ fu_fdt_image_get_attr_strlist(FuFdtImage *self, const gchar *key, gchar ***val, 
 	for (gsize i = 0; i < bufsz; i++) {
 		if (buf[i] != 0x0 && !g_ascii_isprint((gchar)buf[i])) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "nonprintable character 0x%02x at offset 0x%x in %s",
 				    buf[i],
 				    (guint)i,
@@ -356,8 +356,8 @@ fu_fdt_image_get_attr_str(FuFdtImage *self, const gchar *key, gchar **val, GErro
 		return FALSE;
 	if (g_bytes_get_size(blob) == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid data size for %s, got 0x%x",
 			    key,
 			    (guint)g_bytes_get_size(blob));
@@ -369,8 +369,8 @@ fu_fdt_image_get_attr_str(FuFdtImage *self, const gchar *key, gchar **val, GErro
 	for (gsize i = 0; i < bufsz; i++) {
 		if (buf[i] != 0x0 && !g_ascii_isprint((gchar)buf[i])) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "nonprintable character 0x%02x at offset 0x%x in %s",
 				    buf[i],
 				    (guint)i,
@@ -526,14 +526,14 @@ fu_fdt_image_build_metadata_node(FuFdtImage *self, XbNode *n, GError **error)
 
 	key = xb_node_get_attr(n, "key");
 	if (key == NULL) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "key invalid");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "key invalid");
 		return FALSE;
 	}
 	format = xb_node_get_attr(n, "format");
 	if (format == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "format unspecified for %s, expected uint64|uint32|str|strlist|data",
 			    key);
 		return FALSE;
@@ -593,8 +593,8 @@ fu_fdt_image_build_metadata_node(FuFdtImage *self, XbNode *n, GError **error)
 
 	/* failed */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_DATA,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "format for %s invalid, expected uint64|uint32|str|strlist|data",
 		    key);
 	return FALSE;

--- a/libfwupdplugin/fu-firmware-common.c
+++ b/libfwupdplugin/fu-firmware-common.c
@@ -53,8 +53,8 @@ fu_firmware_strparse_uint4_safe(const gchar *data,
 	if (endptr - buffer != sizeof(buffer) - 1) {
 		g_autofree gchar *str = fu_strsafe(buffer, sizeof(buffer));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as hex",
 			    str);
 		return FALSE;
@@ -102,8 +102,8 @@ fu_firmware_strparse_uint8_safe(const gchar *data,
 	if (endptr - buffer != sizeof(buffer) - 1) {
 		g_autofree gchar *str = fu_strsafe(buffer, sizeof(buffer));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as hex",
 			    str);
 		return FALSE;
@@ -151,8 +151,8 @@ fu_firmware_strparse_uint16_safe(const gchar *data,
 	if (endptr - buffer != sizeof(buffer) - 1) {
 		g_autofree gchar *str = fu_strsafe(buffer, sizeof(buffer));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as hex",
 			    str);
 		return FALSE;
@@ -200,8 +200,8 @@ fu_firmware_strparse_uint24_safe(const gchar *data,
 	if (endptr - buffer != sizeof(buffer) - 1) {
 		g_autofree gchar *str = fu_strsafe(buffer, sizeof(buffer));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as hex",
 			    str);
 		return FALSE;
@@ -249,8 +249,8 @@ fu_firmware_strparse_uint32_safe(const gchar *data,
 	if (endptr - buffer != sizeof(buffer) - 1) {
 		g_autofree gchar *str = fu_strsafe(buffer, sizeof(buffer));
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as hex",
 			    str);
 		return FALSE;

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -604,8 +604,8 @@ fu_firmware_get_bytes(FuFirmware *self, GError **error)
 	if (priv->stream != NULL) {
 		if (priv->streamsz == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "stream size unknown");
 			return NULL;
 		}
@@ -1235,8 +1235,8 @@ fu_firmware_build(FuFirmware *self, XbNode *n, GError **error)
 	if (tmpval != G_MAXUINT64) {
 		if (tmpval > FU_FIRMWARE_ALIGNMENT_2G) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "0x%x invalid, maximum is 0x%x",
 				    (guint)tmpval,
 				    (guint)FU_FIRMWARE_ALIGNMENT_2G);
@@ -1301,8 +1301,8 @@ fu_firmware_build(FuFirmware *self, XbNode *n, GError **error)
 				GType gtype = g_type_from_name(tmp);
 				if (gtype == G_TYPE_INVALID) {
 					g_set_error(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_NOT_FOUND,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_NOT_FOUND,
 						    "GType %s not registered",
 						    tmp);
 					return FALSE;
@@ -1663,8 +1663,8 @@ fu_firmware_add_image_full(FuFirmware *self, FuFirmware *img, GError **error)
 	/* check depth */
 	if (priv->depth > FU_FIRMWARE_IMAGE_DEPTH_MAX) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "images are nested too deep, limit is %u",
 			    (guint)FU_FIRMWARE_IMAGE_DEPTH_MAX);
 		return FALSE;
@@ -1690,8 +1690,8 @@ fu_firmware_add_image_full(FuFirmware *self, FuFirmware *img, GError **error)
 	/* sanity check */
 	if (priv->images_max > 0 && priv->images->len >= priv->images_max) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "too many images, limit is %u",
 			    priv->images_max);
 		return FALSE;
@@ -2427,8 +2427,8 @@ fu_firmware_new_from_gtypes(GInputStream *stream,
 	/* invalid */
 	if (gtypes->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOTHING_TO_DO,
 				    "no GTypes specified");
 		return NULL;
 	}

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -103,8 +103,8 @@ fu_fit_firmware_verify_crc32(FuFirmware *firmware,
 	value_calc = fu_crc32(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));
 	if (value_calc != value) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "%s CRC did not match, got 0x%x, expected 0x%x",
 			    fu_firmware_get_id(img),
 			    value,
@@ -137,8 +137,8 @@ fu_fit_firmware_verify_checksum(FuFirmware *firmware,
 		return FALSE;
 	if (g_bytes_get_size(value) != digest_len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "%s invalid hash value size, got 0x%x, expected 0x%x",
 			    fu_firmware_get_id(img),
 			    (guint)g_bytes_get_size(value),
@@ -251,8 +251,8 @@ fu_fit_firmware_verify_image(FuFirmware *firmware,
 			FuFirmware *img_hash = g_ptr_array_index(img_hashes, i);
 			if (fu_firmware_get_id(img_hash) == NULL) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "no ID for image hash");
 				return FALSE;
 			}

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -54,8 +54,8 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (fu_struct_fmap_get_size(st_hdr) != streamsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "file size incorrect, expected 0x%04x got 0x%04x",
 			    fu_struct_fmap_get_size(st_hdr),
 			    (guint)streamsz);
@@ -64,8 +64,8 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 	nareas = fu_struct_fmap_get_nareas(st_hdr);
 	if (nareas < 1) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "number of areas invalid");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -70,16 +70,16 @@ fu_hid_descriptor_parse(FuFirmware *firmware,
 		/* sanity check */
 		if (table_state->len > FU_HID_DESCRIPTOR_TABLE_GLOBAL_SIZE_MAX) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "HID table state too large, limit is %u",
 				    (guint)FU_HID_DESCRIPTOR_TABLE_GLOBAL_SIZE_MAX);
 			return FALSE;
 		}
 		if (table_local->len > FU_HID_DESCRIPTOR_TABLE_LOCAL_SIZE_MAX) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "HID table state too large, limit is %u",
 				    (guint)FU_HID_DESCRIPTOR_TABLE_LOCAL_SIZE_MAX);
 			return FALSE;
@@ -99,8 +99,8 @@ fu_hid_descriptor_parse(FuFirmware *firmware,
 			    FU_HID_DESCRIPTOR_TABLE_GLOBAL_DUPES_MAX) {
 				g_set_error(
 				    error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "table invalid @0x%x, too many duplicate global %s tokens",
 				    (guint)offset,
 				    fu_firmware_get_id(FU_FIRMWARE(item)));
@@ -113,8 +113,8 @@ fu_hid_descriptor_parse(FuFirmware *firmware,
 			    FU_HID_DESCRIPTOR_TABLE_LOCAL_DUPES_MAX) {
 				g_set_error(
 				    error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "table invalid @0x%x, too many duplicate %s %s:0x%x tokens",
 				    (guint)offset,
 				    fu_hid_item_kind_to_string(fu_hid_report_item_get_kind(item)),
@@ -282,7 +282,7 @@ fu_hid_descriptor_find_report(FuHidDescriptor *self, GError **error, ...)
 		if (matched)
 			return g_object_ref(report);
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no report found");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no report found");
 	return NULL;
 }
 

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -122,8 +122,8 @@ fu_hid_device_parse_descriptors(FuHidDevice *self, GError **error)
 	return g_steal_pointer(&descriptors);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "only supported in libgusb >= 0.4.7");
 	return NULL;
 #endif
@@ -404,8 +404,8 @@ fu_hid_device_set_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 		fu_dump_raw(G_LOG_DOMAIN, title, helper->buf, helper->bufsz);
 		if (priv->ep_addr_out == 0x0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "no EpAddrOut set");
 			return FALSE;
 		}
@@ -450,8 +450,8 @@ fu_hid_device_set_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 	}
 	if ((helper->flags & FU_HID_DEVICE_FLAG_ALLOW_TRUNC) == 0 && actual_len != helper->bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wrote %" G_GSIZE_FORMAT ", requested %" G_GSIZE_FORMAT " bytes",
 			    actual_len,
 			    helper->bufsz);
@@ -535,8 +535,8 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 		g_autofree gchar *title = NULL;
 		if (priv->ep_addr_in == 0x0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "no EpAddrIn set");
 			return FALSE;
 		}
@@ -584,8 +584,8 @@ fu_hid_device_get_report_internal(FuHidDevice *self, FuHidDeviceRetryHelper *hel
 	}
 	if ((helper->flags & FU_HID_DEVICE_FLAG_ALLOW_TRUNC) == 0 && actual_len != helper->bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "read %" G_GSIZE_FORMAT ", requested %" G_GSIZE_FORMAT " bytes",
 			    actual_len,
 			    helper->bufsz);

--- a/libfwupdplugin/fu-hid-report-item.c
+++ b/libfwupdplugin/fu-hid-report-item.c
@@ -79,8 +79,8 @@ fu_hid_report_item_parse(FuFirmware *firmware,
 			return FALSE;
 		if (offset + 1 >= streamsz) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "not enough data to read long tag");
 			return FALSE;
 		}

--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -300,8 +300,8 @@ fu_hwids_get_replace_values(FuHwids *self, const gchar *keys, GError **error)
 		const gchar *tmp = g_hash_table_lookup(self->hash_values, split[j]);
 		if (tmp == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "not available as '%s' unknown",
 				    split[j]);
 			return NULL;

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -94,10 +94,11 @@ fu_i2c_device_open(FuDevice *device, GError **error)
 #ifdef HAVE_ERRNO_H
 			    g_io_error_from_errno(errno),
 #else
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 			    "failed to open %s read-write",
 			    bus_path);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	io_channel = fu_io_channel_unix_new(bus_fd);

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -70,8 +70,8 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware, GInputStream *stream, 
 	size = fu_struct_ifwi_cpd_manifest_get_size(st_mhd);
 	if (size * 4 != streamsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid manifest invalid length, got 0x%x, expected 0x%x",
 			    size * 4,
 			    (guint)streamsz);
@@ -102,8 +102,8 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware, GInputStream *stream, 
 			break;
 		if (extension_length < st_mex->len) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid manifest extension header length 0x%x",
 				    (guint)extension_length);
 			return FALSE;
@@ -162,8 +162,8 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 	num_of_entries = fu_struct_ifwi_cpd_get_num_of_entries(st_hdr);
 	if (num_of_entries > FU_IFWI_CPD_FIRMWARE_ENTRIES_MAX) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "too many entries 0x%x, expected <= 0x%x",
 			    num_of_entries,
 			    (guint)FU_IFWI_CPD_FIRMWARE_ENTRIES_MAX);
@@ -260,8 +260,8 @@ fu_ifwi_cpd_firmware_write(FuFirmware *firmware, GError **error)
 		/* sanity check */
 		if (fu_firmware_get_id(img) == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "image 0x%x must have an ID",
 				    (guint)fu_firmware_get_idx(img));
 			return NULL;

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -60,8 +60,8 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 	num_of_entries = fu_struct_ifwi_fpt_get_num_of_entries(st_hdr);
 	if (num_of_entries > FU_IFWI_FPT_MAX_ENTRIES) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid FPT number of entries %u",
 			    num_of_entries);
 		return FALSE;
@@ -69,8 +69,8 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 	if (fu_struct_ifwi_fpt_get_header_version(st_hdr) <
 	    FU_STRUCT_IFWI_FPT_DEFAULT_HEADER_VERSION) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid FPT header version: 0x%x",
 			    fu_struct_ifwi_fpt_get_header_version(st_hdr));
 		return FALSE;

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -201,8 +201,8 @@ fu_ihex_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 	/* sanity check */
 	if (token_idx > FU_IHEX_FIRMWARE_TOKENS_MAX) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "file has too many lines");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -85,8 +85,8 @@ fu_input_stream_read_safe(GInputStream *stream,
 	}
 	if ((gsize)rc != count) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_PARTIAL_INPUT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_READ,
 			    "requested 0x%x and got 0x%x",
 			    (guint)count,
 			    (guint)rc);
@@ -286,8 +286,8 @@ fu_input_stream_read_byte_array(GInputStream *stream, gsize offset, gsize count,
 			return NULL;
 		if (offset > streamsz) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "offset 0x%x is out of range of stream size 0x%x",
 				    (guint)offset,
 				    (guint)streamsz);

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -519,8 +519,8 @@ fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 	}
 	if (priv->family == FU_INTEL_THUNDERBOLT_NVM_FAMILY_UNKNOWN) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unknown NVM family");
 		return FALSE;
 	}
@@ -854,8 +854,8 @@ fu_intel_thunderbolt_nvm_build(FuFirmware *firmware, XbNode *n, GError **error)
 		priv->family = fu_intel_thunderbolt_nvm_family_from_string(tmp);
 		if (priv->family == FU_INTEL_THUNDERBOLT_NVM_FAMILY_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unknown family: %s",
 				    tmp);
 			return FALSE;

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -191,8 +191,8 @@ fu_io_channel_write_raw(FuIOChannel *self,
 				return FALSE;
 			}
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
 				    "failed to write: "
 				    "wrote %" G_GSSIZE_FORMAT " of %" G_GSIZE_FORMAT,
 				    wrote,
@@ -345,7 +345,7 @@ fu_io_channel_read_byte_array(FuIOChannel *self,
 		/* wait for data to appear */
 		gint rc = g_poll(&fds, 1, (gint)timeout_ms);
 		if (rc == 0) {
-			g_set_error(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "timeout");
+			g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "timeout");
 			return NULL;
 		}
 		if (rc < 0) {

--- a/libfwupdplugin/fu-kernel.c
+++ b/libfwupdplugin/fu-kernel.c
@@ -251,8 +251,8 @@ fu_kernel_parse_config_line_cb(GString *token, guint token_idx, gpointer user_da
 	kv = g_strsplit(token->str, "=", 2);
 	if (g_strv_length(kv) != 2) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid format for '%s'",
 			    token->str);
 		return FALSE;
@@ -505,8 +505,8 @@ fu_kernel_check_cmdline_mutable(GError **error)
 		}
 		if (!g_file_info_get_attribute_boolean(info, G_FILE_ATTRIBUTE_ACCESS_CAN_WRITE)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "%s is not writable",
 				    config_files[i]);
 			return FALSE;

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -70,8 +70,8 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 		priv->image_gtype = g_type_from_name(tmp);
 		if (priv->image_gtype == G_TYPE_INVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "GType %s not registered",
 				    tmp);
 			return FALSE;

--- a/libfwupdplugin/fu-lzma-common.c
+++ b/libfwupdplugin/fu-lzma-common.c
@@ -41,8 +41,8 @@ fu_lzma_decompress_bytes(GBytes *blob, GError **error)
 	if (rc != LZMA_OK) {
 		lzma_end(&strm);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set up LZMA decoder rc=%u",
 			    rc);
 		return NULL;
@@ -60,15 +60,15 @@ fu_lzma_decompress_bytes(GBytes *blob, GError **error)
 	/* success */
 	if (rc != LZMA_OK && rc != LZMA_STREAM_END) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to decode LZMA data rc=%u",
 			    rc);
 		return NULL;
 	}
 	return g_bytes_new(buf->data, buf->len);
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "missing lzma support");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "missing lzma support");
 	return NULL;
 #endif
 }
@@ -101,8 +101,8 @@ fu_lzma_compress_bytes(GBytes *blob, GError **error)
 	if (rc != LZMA_OK) {
 		lzma_end(&strm);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set up LZMA encoder rc=%u",
 			    rc);
 		return NULL;
@@ -120,15 +120,15 @@ fu_lzma_compress_bytes(GBytes *blob, GError **error)
 	/* success */
 	if (rc != LZMA_OK && rc != LZMA_STREAM_END) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to encode LZMA data rc=%u",
 			    rc);
 		return NULL;
 	}
 	return g_bytes_new(buf->data, buf->len);
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "missing lzma support");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "missing lzma support");
 	return NULL;
 #endif
 }

--- a/libfwupdplugin/fu-mem.c
+++ b/libfwupdplugin/fu-mem.c
@@ -287,8 +287,8 @@ fu_memcmp_safe(const guint8 *buf1,
 	for (guint i = 0x0; i < n; i++) {
 		if (buf1[buf1_offset + i] != buf2[buf2_offset + i]) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "got 0x%02x, expected 0x%02x @ 0x%04x",
 				    buf1[buf1_offset + i],
 				    buf2[buf2_offset + i],
@@ -541,8 +541,8 @@ fu_memdup_safe(const guint8 *src, gsize n, GError **error)
 	/* sanity check */
 	if (n > 0x40000000) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot allocate %uGB of memory",
 			    (guint)(n / 0x40000000));
 		return NULL;
@@ -970,8 +970,8 @@ fu_memstrsafe(const guint8 *buf, gsize bufsz, gsize offset, gsize maxsz, GError 
 	str = fu_strsafe((const gchar *)buf + offset, maxsz);
 	if (str == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid ASCII string");
 		return NULL;
 	}

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -139,8 +139,8 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	pci_header_offset = fu_struct_oprom_get_pci_header_offset(st_hdr);
 	if (pci_header_offset == 0x0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "no PCI data structure offset provided");
 		return FALSE;
 	}
@@ -155,7 +155,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	/* get length */
 	image_length = fu_struct_oprom_pci_get_image_length(st_pci);
 	if (image_length == 0x0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid image length");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "invalid image length");
 		return FALSE;
 	}
 	fu_firmware_set_size(firmware, image_length * FU_OPROM_FIRMWARE_ALIGN_LEN);

--- a/libfwupdplugin/fu-partial-input-stream.c
+++ b/libfwupdplugin/fu-partial-input-stream.c
@@ -104,8 +104,8 @@ fu_partial_input_stream_truncate(GSeekable *seekable,
 				 GError **error)
 {
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot truncate FuPartialInputStream");
 	return FALSE;
 }

--- a/libfwupdplugin/fu-path.c
+++ b/libfwupdplugin/fu-path.c
@@ -539,8 +539,8 @@ fu_path_glob(const gchar *directory, const gchar *pattern, GError **error)
 	}
 	if (files->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "no files matched pattern");
 		return NULL;
 	}

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -91,8 +91,8 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 		sect_id = fu_strsafe((const gchar *)buf, sizeof(buf));
 		if (sect_id == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "no section name");
 			return FALSE;
 		}
@@ -266,8 +266,8 @@ fu_pefile_firmware_write(FuFirmware *firmware, GError **error)
 		/* set the name directly, or add to the string table */
 		if (section->id == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "image %u has no ID",
 				    i);
 			return NULL;
@@ -288,8 +288,8 @@ fu_pefile_firmware_write(FuFirmware *firmware, GError **error)
 					    strlen(section->id));
 			if (strtab_buf->len > FU_PEFILE_SECTION_ID_STRTAB_SIZE) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "image ID %s is too long",
 					    section->id);
 				return NULL;

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -316,8 +316,8 @@ fu_plugin_open(FuPlugin *self, const gchar *filename, GError **error)
 	priv->module = g_module_open(filename, 0);
 	if (priv->module == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to open plugin %s: %s",
 			    filename,
 			    g_module_error());
@@ -330,8 +330,8 @@ fu_plugin_open(FuPlugin *self, const gchar *filename, GError **error)
 	g_module_symbol(priv->module, "fu_plugin_init_vfuncs", (gpointer *)&init_vfuncs);
 	if (init_vfuncs == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "failed to init_vfuncs() on plugin %s",
 			    filename);
 		fu_plugin_add_flag(self, FWUPD_PLUGIN_FLAG_FAILED_OPEN);
@@ -2364,8 +2364,8 @@ fu_plugin_runner_fix_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr,
 
 	if (vfuncs->fix_host_security_attr == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "fix is not supported");
 		return FALSE;
 	}
@@ -2394,8 +2394,8 @@ fu_plugin_runner_undo_host_security_attr(FuPlugin *self, FwupdSecurityAttr *attr
 
 	if (vfuncs->undo_host_security_attr == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "undo is not supported");
 		return FALSE;
 	}
@@ -2678,7 +2678,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (fd < 0) {
 		g_set_error(error,
 			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 			    "could not open %s file",
 			    filename);
 		return FALSE;
@@ -2687,7 +2687,7 @@ g_file_set_contents_full(const gchar *filename,
 	if (wrote != length) {
 		g_set_error(error,
 			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 			    "did not write %s file",
 			    filename);
 		g_close(fd, NULL);
@@ -2720,8 +2720,8 @@ fu_plugin_set_config_value(FuPlugin *self, const gchar *key, const gchar *value,
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (config == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "cannot get config value with no loaded context");
 		return FALSE;
 	}
@@ -2748,8 +2748,8 @@ fu_plugin_reset_config_values(FuPlugin *self, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 	if (config == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "cannot reset config values with no loaded context");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -115,16 +115,16 @@ fu_quirks_validate_flags(const gchar *value, GError **error)
 			continue;
 		if (!g_ascii_isalnum(tmp)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "%c is not alphanumeric",
 				    tmp);
 			return FALSE;
 		}
 		if (g_ascii_isalpha(tmp) && !g_ascii_islower(tmp)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "%c is not lowercase",
 				    tmp);
 			return FALSE;
@@ -175,8 +175,8 @@ fu_quirks_convert_keyfile_to_xml_cb(GString *token,
 	/* neither a key=value or [group] */
 	if (token->len < 3) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid line: %s",
 			    token->str);
 		return FALSE;
@@ -200,8 +200,8 @@ fu_quirks_convert_keyfile_to_xml_cb(GString *token,
 	/* no current group */
 	if (helper->bn == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid line when group unset: %s",
 			    token->str);
 		return FALSE;
@@ -211,8 +211,8 @@ fu_quirks_convert_keyfile_to_xml_cb(GString *token,
 	kv = g_strsplit(token->str, "=", 2);
 	if (kv[1] == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid line: not key=value: %s",
 			    token->str);
 		return FALSE;

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -76,8 +76,8 @@
     len = strlen(value);
     if (len > {{item.size}}) {
         g_set_error(error,
-                    G_IO_ERROR,
-                    G_IO_ERROR_INVALID_DATA,
+                    FWUPD_ERROR,
+                    FWUPD_ERROR_INVALID_DATA,
                     "string '%s' (0x%x bytes) does not fit in {{obj.name}}.{{item.element_id}} (0x%x bytes)",
                     value, (guint) len, (guint) {{item.size}});
         return FALSE;
@@ -241,8 +241,8 @@
     if ({{item.c_getter}}(st) != {{item.constant}}) {
 {%- endif %}
         g_set_error_literal(error,
-                            G_IO_ERROR,
-                            G_IO_ERROR_INVALID_DATA,
+                            FWUPD_ERROR,
+                            FWUPD_ERROR_INVALID_DATA,
                             "constant {{obj.name}}.{{item.element_id}} was not valid");
         return FALSE;
     }
@@ -307,8 +307,8 @@
     }
     if ((gsize) rc != st->len) {
         g_set_error(error,
-                    G_IO_ERROR,
-                    G_IO_ERROR_PARTIAL_INPUT,
+                    FWUPD_ERROR,
+                    FWUPD_ERROR_INVALID_DATA,
                     "{{obj.name}} requested 0x%x and got 0x%x",
                     (guint) st->len,
                     (guint) rc);
@@ -405,8 +405,8 @@
     }
     if ((gsize) rc != st->len) {
         g_set_error(error,
-                    G_IO_ERROR,
-                    G_IO_ERROR_PARTIAL_INPUT,
+                    FWUPD_ERROR,
+                    FWUPD_ERROR_INVALID_DATA,
                     "{{obj.name}} requested 0x%x and got 0x%x",
                     (guint) st->len,
                     (guint) rc);

--- a/libfwupdplugin/fu-security-attrs.c
+++ b/libfwupdplugin/fu-security-attrs.c
@@ -127,8 +127,8 @@ fu_security_attrs_get_by_appstream_id(FuSecurityAttrs *self,
 	g_return_val_if_fail(FU_IS_SECURITY_ATTRS(self), NULL);
 	if (self->attrs->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "no attributes are loaded");
 		return NULL;
 	}
@@ -137,7 +137,7 @@ fu_security_attrs_get_by_appstream_id(FuSecurityAttrs *self,
 		if (g_strcmp0(fwupd_security_attr_get_appstream_id(attr), appstream_id) == 0)
 			return g_object_ref(attr);
 	}
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no attr with ID %s", appstream_id);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no attr with ID %s", appstream_id);
 	return NULL;
 }
 
@@ -576,7 +576,10 @@ fu_security_attrs_from_json(FuSecurityAttrs *self, JsonNode *json_node, GError *
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 	obj = json_node_get_object(json_node);
@@ -584,8 +587,8 @@ fu_security_attrs_from_json(FuSecurityAttrs *self, JsonNode *json_node, GError *
 	/* this has to exist */
 	if (!json_object_has_member(obj, "SecurityAttributes")) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no SecurityAttributes property in object");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -84,7 +84,7 @@ fu_archive_invalid_func(void)
 	g_assert_nonnull(data);
 
 	archive = fu_archive_new(data, FU_ARCHIVE_FLAG_NONE, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_null(archive);
 }
 
@@ -130,7 +130,7 @@ fu_archive_cab_func(void)
 	g_assert_cmpstr(checksum2, ==, "7c0ae84b191822bcadbdcbe2f74a011695d783c7");
 
 	data_tmp = fu_archive_lookup_by_fn(archive, "NOTGOINGTOEXIST.xml", &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
 	g_assert_null(data_tmp);
 }
 
@@ -191,7 +191,7 @@ fu_common_byte_array_func(void)
 	g_assert_cmpint(memcmp(array2->data, "hello\0\0\0\0\0", array2->len), ==, 0);
 
 	array3 = fu_byte_array_from_string("ZZZ", &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(array3);
 }
 
@@ -389,7 +389,7 @@ fu_string_utf16_func(void)
 	/* failure */
 	g_byte_array_set_size(buf, buf->len - 1);
 	str2 = fu_utf16_to_utf8_byte_array(buf, G_LITTLE_ENDIAN, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_cmpstr(str2, ==, NULL);
 }
 
@@ -1426,7 +1426,7 @@ static gboolean
 _fail_open_cb(FuDevice *device, GError **error)
 {
 	fu_device_set_metadata_boolean(device, "Test::Open", TRUE);
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "fail");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "fail");
 	return FALSE;
 }
 
@@ -1434,7 +1434,7 @@ static gboolean
 _fail_close_cb(FuDevice *device, GError **error)
 {
 	fu_device_set_metadata_boolean(device, "Test::Close", TRUE);
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "busy");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "busy");
 	return FALSE;
 }
 
@@ -1448,7 +1448,7 @@ fu_device_locker_fail_func(void)
 					   (FuDeviceLockerFunc)_fail_open_cb,
 					   (FuDeviceLockerFunc)_fail_close_cb,
 					   &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_FAILED);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
 	g_assert_null(locker);
 	g_assert_true(fu_device_get_metadata_boolean(device, "Test::Open"));
 	g_assert_true(fu_device_get_metadata_boolean(device, "Test::Close"));
@@ -1517,7 +1517,7 @@ fu_common_bytes_get_data_func(void)
 
 	/* use the safe function */
 	buf = fu_bytes_get_data_safe(bytes2, NULL, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(buf);
 }
 
@@ -2081,7 +2081,7 @@ fu_chunk_array_func(void)
 	g_assert_cmpint(strncmp((const gchar *)fu_chunk_get_data(chk3), "d", 1), ==, 0);
 
 	chk4 = fu_chunk_array_index(chunks, 3, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(chk4);
 	chk4 = fu_chunk_array_index(chunks, 1024, NULL);
 	g_assert_null(chk4);
@@ -2728,7 +2728,7 @@ fu_firmware_fdt_func(void)
 
 	/* wrong type */
 	ret = fu_fdt_image_get_attr_u64(img2, "key", &val64, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
 
@@ -3126,7 +3126,7 @@ fu_firmware_archive_func(void)
 	g_assert_nonnull(img_asc);
 	img_both =
 	    fu_archive_firmware_get_image_fnmatch(FU_ARCHIVE_FIRMWARE(firmware), "*.bin*", &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(img_both);
 }
 
@@ -3450,7 +3450,7 @@ fu_hid_descriptor_func(void)
 						"report-id",
 						0xF1,
 						NULL);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
 	g_assert_null(report3);
 }
 
@@ -3553,7 +3553,7 @@ fu_firmware_common_func(void)
 	g_assert_cmpint(value, ==, 0x00);
 
 	ret = fu_firmware_strparse_uint8_safe("ff00XX", 6, 4, &value, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
 
@@ -3605,7 +3605,7 @@ fu_firmware_dedupe_func(void)
 	g_assert_cmpstr(fu_firmware_get_id(img_idx), ==, "secondary");
 
 	ret = fu_firmware_add_image_full(firmware, img3, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
 
@@ -3692,7 +3692,7 @@ fu_efivar_func(void)
 				 NULL,
 				 NULL,
 				 &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
 	g_assert_false(ret);
 }
 
@@ -5151,7 +5151,7 @@ fu_input_stream_func(void)
 					bufsz, /* count */
 					&error);
 	fu_dump_raw(G_LOG_DOMAIN, "dst", buf2, bufsz);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_READ);
 	g_assert_false(ret);
 }
 
@@ -5211,11 +5211,11 @@ fu_plugin_struct_func(void)
 	/* parse failing signature */
 	st->data[0] = 0xFF;
 	st3 = fu_struct_self_test_parse(st->data, st->len, 0x0, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(st3);
 	g_clear_error(&error);
 	ret = fu_struct_self_test_validate(st->data, st->len, 0x0, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
 
@@ -5283,11 +5283,11 @@ fu_plugin_struct_wrapped_func(void)
 	/* parse failing signature */
 	st->data[FU_STRUCT_SELF_TEST_WRAPPED_OFFSET_BASE] = 0xFF;
 	st3 = fu_struct_self_test_wrapped_parse(st->data, st->len, 0x0, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(st3);
 	g_clear_error(&error);
 	ret = fu_struct_self_test_wrapped_validate(st->data, st->len, 0x0, &error);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
 

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -180,8 +180,8 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 	/* sanity check */
 	if (token_idx > FU_SREC_FIRMWARE_TOKENS_MAX) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "file has too many lines");
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -38,8 +38,8 @@ fu_strtoull(const gchar *str, guint64 *value, guint64 min, guint64 max, GError *
 	/* sanity check */
 	if (str == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "cannot parse NULL");
 		return FALSE;
 	}
@@ -53,15 +53,15 @@ fu_strtoull(const gchar *str, guint64 *value, guint64 min, guint64 max, GError *
 	/* convert */
 	value_tmp = g_ascii_strtoull(str, &endptr, base);
 	if ((gsize)(endptr - str) != strlen(str) && *endptr != '\n') {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "cannot parse %s", str);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "cannot parse %s", str);
 		return FALSE;
 	}
 
 	/* overflow check */
 	if (value_tmp == G_MAXUINT64) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as caused overflow",
 			    str);
 		return FALSE;
@@ -70,8 +70,8 @@ fu_strtoull(const gchar *str, guint64 *value, guint64 min, guint64 max, GError *
 	/* range check */
 	if (value_tmp < min) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "value %" G_GUINT64_FORMAT " was below minimum %" G_GUINT64_FORMAT,
 			    value_tmp,
 			    min);
@@ -79,8 +79,8 @@ fu_strtoull(const gchar *str, guint64 *value, guint64 min, guint64 max, GError *
 	}
 	if (value_tmp > max) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "value %" G_GUINT64_FORMAT " was above maximum %" G_GUINT64_FORMAT,
 			    value_tmp,
 			    max);
@@ -118,8 +118,8 @@ fu_strtoll(const gchar *str, gint64 *value, gint64 min, gint64 max, GError **err
 	/* sanity check */
 	if (str == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "cannot parse NULL");
 		return FALSE;
 	}
@@ -133,15 +133,15 @@ fu_strtoll(const gchar *str, gint64 *value, gint64 min, gint64 max, GError **err
 	/* convert */
 	value_tmp = g_ascii_strtoll(str, &endptr, base);
 	if ((gsize)(endptr - str) != strlen(str) && *endptr != '\n') {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "cannot parse %s", str);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "cannot parse %s", str);
 		return FALSE;
 	}
 
 	/* overflow check */
 	if (value_tmp == G_MAXINT64) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot parse %s as caused overflow",
 			    str);
 		return FALSE;
@@ -150,8 +150,8 @@ fu_strtoll(const gchar *str, gint64 *value, gint64 min, gint64 max, GError **err
 	/* range check */
 	if (value_tmp < min) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "value %" G_GINT64_FORMAT " was below minimum %" G_GINT64_FORMAT,
 			    value_tmp,
 			    min);
@@ -159,8 +159,8 @@ fu_strtoll(const gchar *str, gint64 *value, gint64 min, gint64 max, GError **err
 	}
 	if (value_tmp > max) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "value %" G_GINT64_FORMAT " was above maximum %" G_GINT64_FORMAT,
 			    value_tmp,
 			    max);
@@ -191,8 +191,8 @@ fu_strtobool(const gchar *str, gboolean *value, GError **error)
 	/* sanity check */
 	if (str == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "cannot parse NULL");
 		return FALSE;
 	}
@@ -211,8 +211,8 @@ fu_strtobool(const gchar *str, gboolean *value, GError **error)
 
 	/* invalid */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_DATA,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "cannot parse %s as boolean, expected true|false",
 		    str);
 	return FALSE;
@@ -708,8 +708,8 @@ fu_utf16_to_utf8_byte_array(GByteArray *array, FuEndianType endian, GError **err
 
 	if (array->len % 2 != 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid UTF-16 buffer length");
 		return NULL;
 	}

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1339,8 +1339,8 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 	if (udev_device == NULL) {
 		g_autofree gchar *str = fu_udev_device_get_parent_subsystems(self);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to find device with subsystems %s, only got %s",
 			    subsystems,
 			    str);
@@ -1351,8 +1351,8 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 		tmp = g_udev_device_get_property(udev_device, "PCI_SLOT_NAME");
 		if (tmp == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to find PCI_SLOT_NAME");
 			return FALSE;
 		}
@@ -1365,8 +1365,8 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 		tmp = g_udev_device_get_property(udev_device, "DEVPATH");
 		if (tmp == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to find DEVPATH");
 			return FALSE;
 		}
@@ -1375,8 +1375,8 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 		tmp = g_udev_device_get_property(udev_device, "HID_PHYS");
 		if (tmp == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to find HID_PHYS");
 			return FALSE;
 		}
@@ -1386,16 +1386,16 @@ fu_udev_device_set_physical_id(FuUdevDevice *self, const gchar *subsystems, GErr
 		tmp = g_udev_device_get_property(udev_device, "DEVNAME");
 		if (tmp == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to find DEVNAME");
 			return FALSE;
 		}
 		physical_id = g_strdup_printf("DEVNAME=%s", tmp);
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot handle subsystem %s",
 			    subsystem);
 		return FALSE;
@@ -1453,8 +1453,8 @@ fu_udev_device_set_logical_id(FuUdevDevice *self, const gchar *subsystem, GError
 	}
 	if (udev_device == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to find device with subsystem %s",
 			    subsystem);
 		return FALSE;
@@ -1465,16 +1465,16 @@ fu_udev_device_set_logical_id(FuUdevDevice *self, const gchar *subsystem, GError
 		tmp = g_udev_device_get_property(udev_device, "HID_UNIQ");
 		if (tmp == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to find HID_UNIQ");
 			return FALSE;
 		}
 		logical_id = g_strdup_printf("HID_UNIQ=%s", tmp);
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot handle subsystem %s",
 			    subsystem);
 		return FALSE;
@@ -1628,11 +1628,12 @@ fu_udev_device_open(FuDevice *device, GError **error)
 #ifdef HAVE_ERRNO_H
 				    g_io_error_from_errno(errno),
 #else
-				    G_IO_ERROR_FAILED,
+				    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 				    "failed to open %s: %s",
 				    priv->device_file,
 				    g_strerror(errno));
+			fwupd_error_convert(error);
 			return FALSE;
 		}
 		io_channel = fu_io_channel_unix_new(fd);
@@ -1821,11 +1822,12 @@ fu_udev_device_pread(FuUdevDevice *self, goffset port, guint8 *buf, gsize bufsz,
 #ifdef HAVE_ERRNO_H
 			    g_io_error_from_errno(errno),
 #else
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 			    "failed to read from port 0x%04x: %s",
 			    (guint)port,
 			    g_strerror(errno));
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	return TRUE;
@@ -1876,11 +1878,12 @@ fu_udev_device_seek(FuUdevDevice *self, goffset offset, GError **error)
 #ifdef HAVE_ERRNO_H
 			    g_io_error_from_errno(errno),
 #else
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 			    "failed to seek to 0x%04x: %s",
 			    (guint)offset,
 			    g_strerror(errno));
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	return TRUE;
@@ -1938,11 +1941,12 @@ fu_udev_device_pwrite(FuUdevDevice *self,
 #ifdef HAVE_ERRNO_H
 			    g_io_error_from_errno(errno),
 #else
-			    G_IO_ERROR_FAILED,
+			    G_IO_ERROR_FAILED, /* nocheck */
 #endif
 			    "failed to write to port %04x: %s",
 			    (guint)port,
 			    g_strerror(errno));
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	return TRUE;
@@ -2006,14 +2010,17 @@ fu_udev_device_get_sysfs_attr(FuUdevDevice *self, const gchar *attr, GError **er
 
 	/* nothing to do */
 	if (priv->udev_device == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "not yet initialized");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "not yet initialized");
 		return NULL;
 	}
 	result = g_udev_device_get_sysfs_attr(priv->udev_device, attr);
 	if (result == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "attribute %s returned no data",
 			    attr);
 		return NULL;
@@ -2022,8 +2029,8 @@ fu_udev_device_get_sysfs_attr(FuUdevDevice *self, const gchar *attr, GError **er
 	return result;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "getting attributes is not supported as no GUdev support");
 	return NULL;
 #endif
@@ -2112,6 +2119,7 @@ fu_udev_device_write_sysfs(FuUdevDevice *self,
 				    path,
 				    g_strerror(errno));
 			(void)close(fd);
+			fwupd_error_convert(error);
 			return FALSE;
 		}
 	} while (n < 1);
@@ -2124,6 +2132,7 @@ fu_udev_device_write_sysfs(FuUdevDevice *self,
 			    "could not close %s: %s",
 			    path,
 			    g_strerror(errno));
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -100,8 +100,8 @@ fu_usb_device_ds20_apply_to_device(FuUsbDeviceDs20 *self, FuUsbDevice *device, G
 	}
 	if (total_length != actual_length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "expected 0x%x bytes from vendor code 0x%02x, but got 0x%x",
 			    (guint)total_length,
 			    vendor_code,
@@ -209,16 +209,16 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 		/* not valid */
 		if (dsinfo->platform_ver == 0x0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "invalid platform version 0x%08x",
 				    dsinfo->platform_ver);
 			return FALSE;
 		}
 		if (dsinfo->platform_ver < priv->version_lowest) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "invalid platform version 0x%08x, expected >= 0x%08x",
 				    dsinfo->platform_ver,
 				    priv->version_lowest);
@@ -234,7 +234,10 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 	}
 
 	/* failed */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported platform version");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "no supported platform version");
 	return FALSE;
 }
 

--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -46,8 +46,8 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 	buf = g_bytes_get_data(blob, &bufsz);
 	if (g_strstr_len((const gchar *)buf, bufsz, "\r") != NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "Windows line endings are not supported");
 		return FALSE;
 	}
@@ -66,8 +66,8 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 
 	if (!g_utf8_validate((const gchar *)buf, (gssize)bufsz_safe, NULL)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "DS20 descriptor is not valid UTF-8");
 		return FALSE;
 	}
@@ -91,8 +91,8 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 		kv = g_strsplit(lines[i], "=", 2);
 		if (g_strv_length(kv) < 2) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "expected key=value for '%s'",
 				    lines[i]);
 			return FALSE;

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -636,7 +636,10 @@ fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, GUsbBosDescriptor *bos, GE
 
 	/* sanity check */
 	if (g_bytes_get_size(extra) == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "zero sized data");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "zero sized data");
 		return FALSE;
 	}
 

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -270,8 +270,8 @@ fu_uswid_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 		priv->compression = fu_uswid_payload_compression_from_string(str);
 		if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_NONE) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid compression type %s",
 				    str);
 			return FALSE;

--- a/libfwupdplugin/fu-version-common.c
+++ b/libfwupdplugin/fu-version-common.c
@@ -559,8 +559,8 @@ fu_version_verify_format(const gchar *version, FwupdVersionFormat fmt, GError **
 	fmt_guess = fu_version_guess_format(version);
 	if (fmt_guess != fmt_base) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "%s is not a valid %s (guessed %s)",
 			    version,
 			    fwupd_version_format_to_string(fmt),

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -399,6 +399,7 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 				    G_IO_ERROR,
 				    g_io_error_from_errno(errno),
 				    g_strerror(errno));
+		fwupd_error_convert(error);
 		return 0;
 	}
 	rc = ioctl(fd, BLKSSZGET, &sector_size);
@@ -409,8 +410,8 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 				    g_strerror(errno));
 	} else if (sector_size == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to get non-zero logical sector size");
 	}
 	g_close(fd, NULL);
@@ -624,8 +625,8 @@ fu_volume_mount(FuVolume *self, GError **error)
 		if (g_error_matches(error_local, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_INTERFACE) ||
 		    g_error_matches(error_local, G_DBUS_ERROR, G_DBUS_ERROR_UNKNOWN_METHOD)) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    error_local->message);
 			return FALSE;
 		}
@@ -888,7 +889,11 @@ fu_volume_new_by_kind(const gchar *kind, GError **error)
 		g_ptr_array_add(volumes, g_steal_pointer(&vol));
 	}
 	if (volumes->len == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no volumes of type %s", kind);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "no volumes of type %s",
+			    kind);
 		return NULL;
 	}
 	return g_steal_pointer(&volumes);
@@ -959,7 +964,7 @@ fu_volume_new_by_device(const gchar *device, GError **error)
 	}
 
 	/* failed */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no volumes for device %s", device);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no volumes for device %s", device);
 	return NULL;
 }
 
@@ -997,6 +1002,6 @@ fu_volume_new_by_devnum(guint32 devnum, GError **error)
 	}
 
 	/* failed */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no volumes for devnum %u", devnum);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no volumes for devnum %u", devnum);
 	return NULL;
 }

--- a/plugins/acpi-dmar/fu-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar.c
@@ -35,8 +35,8 @@ fu_acpi_dmar_parse(FuFirmware *firmware,
 	/* check signature and read flags */
 	if (g_strcmp0(fu_firmware_get_id(FU_FIRMWARE(self)), "DMAR") != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Not a DMAR table, got %s",
 			    fu_firmware_get_id(FU_FIRMWARE(self)));
 		return FALSE;

--- a/plugins/acpi-ivrs/fu-acpi-ivrs.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs.c
@@ -37,8 +37,8 @@ fu_acpi_ivrs_parse(FuFirmware *firmware,
 	/* check signature and read flags */
 	if (g_strcmp0(fu_firmware_get_id(FU_FIRMWARE(self)), "IVRS") != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Not a IVRS table, got %s",
 			    fu_firmware_get_id(FU_FIRMWARE(self)));
 		return FALSE;

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -55,8 +55,8 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 		return FALSE;
 	if (rcdlen != streamsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "record length not valid: %" G_GUINT16_FORMAT,
 			    rcdlen);
 		return FALSE;
@@ -80,8 +80,8 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 		}
 		if (ubufsz == 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "device path not valid: %" G_GSIZE_FORMAT,
 				    ubufsz);
 			return FALSE;
@@ -163,8 +163,8 @@ fu_acpi_phat_health_record_build(FuFirmware *firmware, XbNode *n, GError **error
 	tmp64 = xb_node_query_text_as_uint(n, "am_healthy", NULL);
 	if (tmp64 > G_MAXUINT8) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "am_healthy value invalid, got 0x%x",
 			    (guint)tmp64);
 		return FALSE;

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -47,8 +47,8 @@ fu_acpi_phat_record_parse(FuFirmware *firmware,
 		return FALSE;
 	if (record_length < 5) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "PHAT record length invalid, got 0x%x",
 			    record_length);
 		return FALSE;
@@ -116,8 +116,8 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz < length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "PHAT table invalid size, got 0x%x, expected 0x%x",
 			    (guint)streamsz,
 			    length);
@@ -131,8 +131,8 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 			return FALSE;
 		if (revision != FU_ACPI_PHAT_REVISION) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "PHAT table revision invalid, got 0x%x, expected 0x%x",
 				    revision,
 				    (guint)FU_ACPI_PHAT_REVISION);
@@ -148,8 +148,8 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 			return FALSE;
 		if (checksum != 0x00) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "PHAT table checksum invalid, got 0x%x",
 				    checksum);
 			return FALSE;

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -319,8 +319,8 @@ fu_algoltek_usb_device_status_check_cb(FuDevice *self, gpointer user_data, GErro
 	case AG_UPDATE_FAIL:
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "update procedure is failed.");
 		return FALSE;
 	}

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -122,7 +122,10 @@ fu_amd_gpu_atom_parse_vbios_date(FuAmdGpuAtomFirmware *self, GByteArray *atom_im
 	g_autoptr(GByteArray) st = fu_struct_atom_image_get_vbios_date(atom_image);
 
 	if (st == NULL) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "ATOMBIOS date is invalid");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "ATOMBIOS date is invalid");
 		return FALSE;
 	}
 
@@ -153,16 +156,16 @@ fu_amd_gpu_atom_parse_vbios_pn(FuAmdGpuAtomFirmware *self,
 	num_str = fu_struct_atom_image_get_num_strings(atom_image);
 	if (num_str == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "ATOMBIOS number of strings is 0");
 		return FALSE;
 	}
 	idx = fu_struct_atom_image_get_str_loc(atom_image);
 	if (idx == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "ATOMBIOS string location is invalid");
 		return FALSE;
 	}
@@ -171,8 +174,8 @@ fu_amd_gpu_atom_parse_vbios_pn(FuAmdGpuAtomFirmware *self,
 	atombios_size = fu_firmware_get_size(FU_FIRMWARE(self));
 	if ((gsize)(idx + (num_str * (STRLEN_NORMAL - 1))) > atombios_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "bufsz is too small for all strings");
 		return FALSE;
 	}
@@ -204,8 +207,8 @@ fu_amd_gpu_atom_parse_vbios_pn(FuAmdGpuAtomFirmware *self,
 			break;
 		default:
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unknown string index: %d",
 				    i);
 			return FALSE;
@@ -218,8 +221,8 @@ fu_amd_gpu_atom_parse_vbios_pn(FuAmdGpuAtomFirmware *self,
 	/* make sure there is enough space for name string */
 	if ((gsize)(idx + STRLEN_LONG - 1) > atombios_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "bufsz is too small for name string");
 		return FALSE;
 	}

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -230,8 +230,8 @@ fu_amd_gpu_device_wait_for_completion_cb(FuDevice *device, gpointer user_data, G
 		return FALSE;
 	if (status != PSPVBFLASH_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "status was %" G_GUINT64_FORMAT,
 			    status);
 		return FALSE;

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -123,8 +123,8 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 			break;
 		default:
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "Unknown ISH FWID: %x",
 				    fu_struct_psp_dir_table_get_fw_id(l1_entry));
 			return FALSE;
@@ -165,9 +165,9 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 			break;
 		default:
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "Unknown Partition FWID: %x",
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "unknown Partition FWID: %x",
 				    fu_struct_image_slot_header_get_fw_id(ish));
 			return FALSE;
 		}

--- a/plugins/amd-pmc/fu-amd-pmc-device.c
+++ b/plugins/amd-pmc/fu-amd-pmc-device.c
@@ -29,7 +29,7 @@ fu_amd_pmc_device_probe(FuDevice *device, GError **error)
 	version =
 	    fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "smu_fw_version", &error_local);
 	if (version == NULL) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -65,8 +65,8 @@ fu_analogix_device_send(FuAnalogixDevice *self,
 	}
 	if (actual_len != bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "send data length is incorrect");
 		return FALSE;
 	}
@@ -108,8 +108,8 @@ fu_analogix_device_receive(FuAnalogixDevice *self,
 	}
 	if (actual_len != bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "receive data length is incorrect");
 		return FALSE;
 	}

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -141,7 +141,7 @@ fu_android_boot_device_open(FuDevice *device, GError **error)
 
 	/* FuUdevDevice->open */
 	if (!FU_DEVICE_CLASS(fu_android_boot_device_parent_class)->open(device, &error_local)) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_PERMISSION_DENIED)) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED,
@@ -325,7 +325,10 @@ fu_android_boot_device_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -71,8 +71,8 @@ fu_aver_hid_device_ensure_status(FuAverHidDevice *self, GError **error)
 		return FALSE;
 	if (fu_struct_aver_hid_res_isp_status_get_status(res) == FU_AVER_HID_STATUS_BUSY) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "device has status %s",
 			    fu_aver_hid_status_to_string(
 				fu_struct_aver_hid_res_isp_status_get_status(res)));
@@ -193,8 +193,8 @@ fu_aver_hid_device_isp_file_dnload(FuAverHidDevice *self,
 		if (fu_struct_aver_hid_res_isp_status_get_status(res) ==
 		    FU_AVER_HID_STATUS_FILEERR) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_BUSY,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_BUSY,
 				    "device has status %s",
 				    fu_aver_hid_status_to_string(
 					fu_struct_aver_hid_res_isp_status_get_status(res)));
@@ -223,8 +223,8 @@ fu_aver_hid_device_wait_for_ready_cb(FuDevice *device, gpointer user_data, GErro
 		return FALSE;
 	if (fu_struct_aver_hid_res_isp_status_get_status(res) != FU_AVER_HID_STATUS_READY) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "device has status %s",
 			    fu_aver_hid_status_to_string(
 				fu_struct_aver_hid_res_isp_status_get_status(res)));
@@ -302,8 +302,8 @@ fu_aver_hid_device_wait_for_untar_cb(FuDevice *device, gpointer user_data, GErro
 	       fu_aver_hid_status_to_string(fu_struct_aver_hid_res_isp_status_get_status(res)));
 	if (fu_struct_aver_hid_res_isp_status_get_status(res) != FU_AVER_HID_STATUS_WAITUSR) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "device has status %s",
 			    fu_aver_hid_status_to_string(
 				fu_struct_aver_hid_res_isp_status_get_status(res)));
@@ -358,8 +358,8 @@ fu_aver_hid_device_wait_for_reboot_cb(FuDevice *device, gpointer user_data, GErr
 		if (percentage < 100)
 			fu_progress_set_percentage(progress, percentage);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "device has status %s",
 			    fu_aver_hid_status_to_string(
 				fu_struct_aver_hid_res_isp_status_get_status(res)));
@@ -367,8 +367,8 @@ fu_aver_hid_device_wait_for_reboot_cb(FuDevice *device, gpointer user_data, GErr
 	}
 	if (fu_struct_aver_hid_res_isp_status_get_status(res) != FU_AVER_HID_STATUS_REBOOT) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "device has status %s",
 			    fu_aver_hid_status_to_string(
 				fu_struct_aver_hid_res_isp_status_get_status(res)));

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -177,8 +177,8 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 			    FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_TO_M12MO);
 		} else {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid argument %u",
 				    partition);
 			return FALSE;
@@ -301,8 +301,8 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 	cx3_fw_buf = g_bytes_get_data(cx3_fw, &cx3_fw_size);
 	if (cx3_fw_size > 256 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cx3 file size is invalid: 0x%x",
 			    (guint)cx3_fw_size);
 
@@ -315,8 +315,8 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 	m12_fw_buf = g_bytes_get_data(m12_fw, &m12_fw_size);
 	if (m12_fw_size > 3 * 1024 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "m12 file size is invalid: 0x%x",
 			    (guint)m12_fw_size);
 		return FALSE;

--- a/plugins/bcm57xx/fu-bcm57xx-common.c
+++ b/plugins/bcm57xx/fu-bcm57xx-common.c
@@ -30,8 +30,8 @@ fu_bcm57xx_verify_crc(GInputStream *stream, GError **error)
 		return FALSE;
 	if (streamsz < sizeof(guint32)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "image is too small for CRC");
 		return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -80,8 +80,8 @@ fu_bcm57xx_device_nvram_write(FuBcm57xxDevice *self,
 	/* sanity check */
 	if (address + bufsz > fu_device_get_firmware_size_max(FU_DEVICE(self))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "tried to read outside of EEPROM size [0x%x]",
 			    (guint)fu_device_get_firmware_size_max(FU_DEVICE(self)));
 		return FALSE;
@@ -107,7 +107,11 @@ fu_bcm57xx_device_nvram_write(FuBcm57xxDevice *self,
 	return FALSE;
 #endif
 	if (rc < 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "cannot write eeprom [%i]", rc);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot write eeprom [%i]",
+			    rc);
 		return FALSE;
 	}
 
@@ -147,8 +151,8 @@ fu_bcm57xx_device_nvram_read(FuBcm57xxDevice *self,
 	/* sanity check */
 	if (address + bufsz > fu_device_get_firmware_size_max(FU_DEVICE(self))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "tried to read outside of EEPROM size [0x%x]",
 			    (guint)fu_device_get_firmware_size_max(FU_DEVICE(self)));
 		return FALSE;
@@ -172,7 +176,11 @@ fu_bcm57xx_device_nvram_read(FuBcm57xxDevice *self,
 	return FALSE;
 #endif
 	if (rc < 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "cannot read eeprom [%i]", rc);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "cannot read eeprom [%i]",
+			    rc);
 		return FALSE;
 	}
 
@@ -230,8 +238,8 @@ fu_bcm57xx_device_nvram_check(FuBcm57xxDevice *self, GError **error)
 #endif
 	if (rc < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot get driver information [%i]",
 			    rc);
 		return FALSE;
@@ -248,8 +256,8 @@ fu_bcm57xx_device_nvram_check(FuBcm57xxDevice *self, GError **error)
 		fu_device_set_firmware_size(FU_DEVICE(self), drvinfo.eedump_len);
 	} else if (drvinfo.eedump_len != fu_device_get_firmware_size_max(FU_DEVICE(self))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "EEPROM size invalid, got 0x%x, expected 0x%x",
 			    drvinfo.eedump_len,
 			    (guint)fu_device_get_firmware_size_max(FU_DEVICE(self)));
@@ -554,8 +562,8 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 	self->ethtool_fd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (self->ethtool_fd < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to open socket: %s",
 #ifdef HAVE_ERRNO_H
 			    g_strerror(errno));
@@ -567,8 +575,8 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "socket() not supported as sys/socket.h not available");
 	return FALSE;
 #endif

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -41,8 +41,8 @@ fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz < sizeof(guint32)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "dict image is too small");
 		return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -280,8 +280,8 @@ fu_bcm57xx_recovery_device_nvram_acquire_lock(FuBcm57xxRecoveryDevice *self, GEr
 
 	/* timed out */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_TIMED_OUT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
 			    "timed out trying to acquire lock #1");
 	return FALSE;
 }
@@ -318,7 +318,7 @@ fu_bcm57xx_recovery_device_nvram_wait_done(FuBcm57xxRecoveryDevice *self, GError
 	} while (TRUE);
 
 	/* timed out */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "timed out");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "timed out");
 	return FALSE;
 }
 
@@ -742,8 +742,8 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 	/* this can't work */
 	if (RUNNING_ON_VALGRIND) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "cannot mmap'ing BARs when using valgrind");
 		return FALSE;
 	}
@@ -763,16 +763,16 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 		memfd = open(fn, O_RDWR | O_SYNC);
 		if (memfd < 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "error opening %s",
 				    fn);
 			return FALSE;
 		}
 		if (fstat(memfd, &st) < 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "could not stat %s",
 				    fn);
 			close(memfd);
@@ -787,8 +787,8 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 		close(memfd);
 		if (self->bar[i].buf == MAP_FAILED) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "could not mmap %s: %s",
 				    fn,
 				    g_strerror(errno));
@@ -800,8 +800,8 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "mmap() not supported as sys/mman.h not available");
 	return FALSE;
 #endif
@@ -827,8 +827,8 @@ fu_bcm57xx_recovery_device_close(FuDevice *device, GError **error)
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "munmap() not supported as sys/mman.h not available");
 	return FALSE;
 #endif

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -84,8 +84,8 @@ fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 		return FALSE;
 	if (streamsz < sizeof(guint32)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "stage1 image is too small");
 		return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -32,8 +32,8 @@ fu_bcm57xx_stage2_image_parse(FuFirmware *image,
 		return FALSE;
 	if (streamsz < sizeof(guint32)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "stage2 image is too small");
 		return FALSE;
 	}

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -778,7 +778,7 @@ fu_ccgx_dmc_device_set_quirk_kv(FuDevice *device,
 		self->trigger_code = tmp;
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }
 

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -194,7 +194,7 @@ fu_ccgx_dmc_devx_device_set_quirk_kv(FuDevice *device,
 		}
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }
 

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -296,8 +296,8 @@ fu_ccgx_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 	/* sanity check */
 	if (token_idx > FU_CCGX_FIRMWARE_TOKENS_MAX) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "file has too many lines");
 		return FALSE;
 	}

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -692,8 +692,8 @@ fu_ccgx_hpi_device_wait_for_event(FuCcgxHpiDevice *self,
 
 	/* timed out */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_TIMED_OUT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
 		    "failed to wait for event in %ums",
 		    timeout_ms);
 	return FALSE;
@@ -733,7 +733,7 @@ fu_ccgx_hpi_device_clear_all_events(FuCcgxHpiDevice *self, guint32 io_timeout, G
 						       event_array,
 						       io_timeout,
 						       &error_local)) {
-			if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
+			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 				g_propagate_prefixed_error(error,
 							   g_steal_pointer(&error_local),
 							   "failed to clear events: ");
@@ -1499,7 +1499,7 @@ fu_ccgx_hpi_device_setup(FuDevice *device, GError **error)
 					  &hpi_event,
 					  HPI_CMD_SETUP_EVENT_WAIT_TIME_MS,
 					  &error_local)) {
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
@@ -1544,12 +1544,12 @@ fu_ccgx_hpi_device_set_quirk_kv(FuDevice *device,
 		if (self->fw_image_type != FU_CCGX_IMAGE_TYPE_UNKNOWN)
 			return TRUE;
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid CcgxImageKind");
 		return FALSE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }
 

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -445,7 +445,7 @@ fu_ccgx_pure_hid_device_set_quirk_kv(FuDevice *device,
 		return TRUE;
 	}
 
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "not supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
 	return FALSE;
 }
 

--- a/plugins/cfu/fu-cfu-device.c
+++ b/plugins/cfu/fu-cfu-device.c
@@ -102,8 +102,8 @@ fu_cfu_device_send_offer_info(FuCfuDevice *self, FuCfuOfferInfoCode info_code, G
 	if (fu_struct_cfu_offer_rsp_get_token(st_res) !=
 	    FU_STRUCT_CFU_OFFER_INFO_REQ_DEFAULT_TOKEN) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "token invalid: got 0x%x and expected 0x%x",
 			    fu_struct_cfu_offer_rsp_get_token(st_res),
 			    (guint)FU_STRUCT_CFU_OFFER_INFO_REQ_DEFAULT_TOKEN);
@@ -112,8 +112,8 @@ fu_cfu_device_send_offer_info(FuCfuDevice *self, FuCfuOfferInfoCode info_code, G
 	if (fu_struct_cfu_offer_rsp_get_status(st_res) != FU_CFU_OFFER_STATUS_ACCEPT) {
 		g_set_error(
 		    error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_SUPPORTED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "offer info %s not supported: %s",
 		    fu_cfu_offer_info_code_to_string(info_code),
 		    fu_cfu_offer_status_to_string(fu_struct_cfu_offer_rsp_get_status(st_res)));
@@ -177,8 +177,8 @@ fu_cfu_device_send_offer(FuCfuDevice *self,
 	if (fu_struct_cfu_offer_rsp_get_token(st) !=
 	    fu_cfu_offer_get_token(FU_CFU_OFFER(firmware))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "offer token invalid: got %02x but expected %02x",
 			    fu_struct_cfu_offer_rsp_get_token(st),
 			    fu_cfu_offer_get_token(FU_CFU_OFFER(firmware)));
@@ -186,8 +186,8 @@ fu_cfu_device_send_offer(FuCfuDevice *self,
 	}
 	if (fu_struct_cfu_offer_rsp_get_status(st) != FU_CFU_OFFER_STATUS_ACCEPT) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "offer not supported: %s: %s",
 			    fu_cfu_offer_status_to_string(fu_struct_cfu_offer_rsp_get_status(st)),
 			    fu_cfu_rr_code_to_string(fu_struct_cfu_offer_rsp_get_rr_code(st)));
@@ -268,8 +268,8 @@ fu_cfu_device_send_payload(FuCfuDevice *self,
 		if (fu_struct_cfu_content_rsp_get_seq_number(st_rsp) !=
 		    fu_struct_cfu_content_req_get_seq_number(st_req)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "sequence number invalid 0x%x: expected 0x%x",
 				    fu_struct_cfu_content_rsp_get_seq_number(st_rsp),
 				    fu_struct_cfu_content_req_get_seq_number(st_req));
@@ -277,8 +277,8 @@ fu_cfu_device_send_payload(FuCfuDevice *self,
 		}
 		if (fu_struct_cfu_content_rsp_get_status(st_rsp) != FU_CFU_CONTENT_STATUS_SUCCESS) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to send chunk %u: %s",
 				    i + 1,
 				    fu_cfu_content_status_to_string(
@@ -447,8 +447,8 @@ fu_cfu_device_setup(FuDevice *device, GError **error)
 	}
 	if (self->content_get_report.ct == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no CFU descriptor found: %s",
 			    descriptors_error->str);
 		return FALSE;
@@ -548,7 +548,10 @@ fu_cfu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -145,8 +145,8 @@ fu_cfu_module_write_firmware(FuDevice *device,
 	proxy = fu_device_get_proxy(device);
 	if (proxy == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no proxy device assigned");
 		return FALSE;
 	}

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -126,8 +126,8 @@ fu_ch347_device_read(FuCh347Device *self, guint8 cmd, guint8 *buf, gsize bufsz, 
 	cmd_rsp = cmdbuf->data[0];
 	if (cmd_rsp != cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid cmd, got 0x%02x, expected 0x%02x",
 			    cmd_rsp,
 			    cmd);
@@ -136,8 +136,8 @@ fu_ch347_device_read(FuCh347Device *self, guint8 cmd, guint8 *buf, gsize bufsz, 
 	size_rsp = fu_memread_uint16(cmdbuf->data + 0x1, G_LITTLE_ENDIAN);
 	if (size_rsp != bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "size invalid, got 0x%04x, expected 0x04%x",
 			    size_rsp,
 			    (guint)bufsz);

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -77,8 +77,8 @@ fu_corsair_bp_command(FuCorsairBp *self,
 	}
 	if (actual_len != self->cmd_write_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wrong size written: %" G_GSIZE_FORMAT,
 			    actual_len);
 		return FALSE;
@@ -103,8 +103,8 @@ fu_corsair_bp_command(FuCorsairBp *self,
 	}
 	if (actual_len != self->cmd_read_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wrong size read: %" G_GSIZE_FORMAT,
 			    actual_len);
 		return FALSE;
@@ -114,8 +114,8 @@ fu_corsair_bp_command(FuCorsairBp *self,
 
 	if (data[CORSAIR_OFFSET_CMD_STATUS] != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "device replied with error: 0x%02x",
 			    data[CORSAIR_OFFSET_CMD_STATUS]);
 		return FALSE;

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -452,8 +452,8 @@ fu_corsair_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, 
 			return TRUE;
 
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unsupported device in quirk");
 		return FALSE;
 	}
@@ -471,7 +471,10 @@ fu_corsair_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value, 
 		return TRUE;
 	}
 
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -313,7 +313,7 @@ fu_cpu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		fu_device_set_metadata(device, "CpuMitigationsRequired", value);
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }
 

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -37,8 +37,8 @@ fu_cros_ec_firmware_pick_sections(FuCrosEcFirmware *self, guint32 writeable_offs
 
 	if (!found) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "no writeable section found with offset: 0x%x",
 			    writeable_offset);
 		return FALSE;
@@ -61,8 +61,8 @@ fu_cros_ec_firmware_get_needed_sections(FuCrosEcFirmware *self, GError **error)
 	}
 	if (needed_sections->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no needed sections");
 		return NULL;
 	}
@@ -100,8 +100,8 @@ fu_cros_ec_firmware_parse(FuFirmware *firmware,
 			fmap_fwid_name = "RW_FWID";
 		} else {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "incorrect section name");
 			return FALSE;
 		}

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -144,8 +144,8 @@ fu_cros_ec_usb_device_probe(FuDevice *device, GError **error)
 
 	if (self->chunk_len == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wMaxPacketSize isn't valid: %" G_GUINT16_FORMAT,
 			    self->chunk_len);
 		return FALSE;
@@ -189,8 +189,8 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 		}
 		if (actual != outlen) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_PARTIAL_INPUT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
 				    "only sent %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " bytes",
 				    actual,
 				    outlen);
@@ -213,8 +213,8 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 		}
 		if (actual != inlen && !allow_less) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_PARTIAL_INPUT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "only received %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " bytes",
 				    actual,
 				    inlen);
@@ -249,8 +249,8 @@ fu_cros_ec_usb_device_flush(FuDevice *device, gpointer user_data, GError **error
 				       NULL)) {
 		g_debug("flushing %" G_GSIZE_FORMAT " bytes", actual);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "flushing %" G_GSIZE_FORMAT " bytes",
 			    actual);
 		return FALSE;
@@ -345,8 +345,8 @@ fu_cros_ec_usb_device_start_request(FuDevice *device, gpointer user_data, GError
 	/* we got something, so check for errors in response */
 	if (rxed_size < 8) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_PARTIAL_INPUT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_READ,
 			    "unexpected response size %" G_GSIZE_FORMAT,
 			    rxed_size);
 		return FALSE;
@@ -385,8 +385,8 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 
 	if (self->protocol_version < 5 || self->protocol_version > 6) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "unsupported protocol version %d",
 			    self->protocol_version);
 		return FALSE;
@@ -396,8 +396,8 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 	error_code = GUINT32_FROM_BE(start_resp.rpdu.return_value);
 	if (error_code != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "target reporting error %u",
 			    error_code);
 		return FALSE;
@@ -556,13 +556,13 @@ fu_cros_ec_usb_device_transfer_block(FuDevice *device, gpointer user_data, GErro
 	}
 	if (transfer_size == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "zero bytes received for block reply");
 		return FALSE;
 	}
 	if (reply != 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "error: status 0x%#x", reply);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "error: status 0x%#x", reply);
 		return FALSE;
 	}
 
@@ -594,8 +594,8 @@ fu_cros_ec_usb_device_transfer_section(FuDevice *device,
 	data_ptr = (const guint8 *)g_bytes_get_data(img_bytes, &data_len);
 	if (data_ptr == NULL || data_len != section->size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "image and section sizes do not match: image = %" G_GSIZE_FORMAT
 			    " bytes vs section size = %" G_GSIZE_FORMAT " bytes",
 			    data_len,

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -446,9 +446,9 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 	}
 	if (result != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Thunderbolt authentication failed: %s",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_AUTH_FAILED,
+			    "thunderbolt authentication failed: %s",
 			    fu_dell_dock_hid_tbt_map_error(result));
 		return FALSE;
 	}

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -172,7 +172,10 @@ fu_dell_dock_hub_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -667,8 +667,8 @@ fu_dell_dock_ec_activate(FuDevice *device, FuProgress *progress, GError **error)
 
 	if (status != FW_UPDATE_IN_PROGRESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "No firmware update pending for %s",
 			    fu_device_get_name(device));
 		return FALSE;
@@ -753,8 +753,8 @@ fu_dell_dock_ec_commit_package(FuDevice *device, GBytes *blob_fw, GError **error
 
 	if (length != sizeof(FuDellDockDockPackageFWVersion)) {
 		g_set_error(error,
-			    G_IO_ERR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "Invalid package size %" G_GSIZE_FORMAT,
 			    length);
 		return FALSE;
@@ -908,7 +908,10 @@ fu_dell_dock_ec_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *va
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -332,13 +332,19 @@ fu_dell_dock_trigger_rc_command(FuDevice *device, GError **error)
 		return fu_dell_dock_mst_enable_remote_control(device, error);
 	/* error scenarios */
 	case 3:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unknown error");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "Unknown error");
 		return FALSE;
 	case 2:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Unsupported command");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "Unsupported command");
 		return FALSE;
 	case 1:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Invalid argument");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "Invalid argument");
 		return FALSE;
 	/* success scenario */
 	case 0:
@@ -346,9 +352,9 @@ fu_dell_dock_trigger_rc_command(FuDevice *device, GError **error)
 
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Command timed out or unknown failure: %x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
+			    "command timed out or unknown failure: 0x%x",
 			    tmp);
 		return FALSE;
 	}
@@ -541,9 +547,9 @@ fu_dell_dock_mst_checksum_bank(FuDevice *device,
 	/* bank is specified outside of payload */
 	if (attribs->start + attribs->length > length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Payload %u is bigger than bank %u",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "payload %u is bigger than bank %u",
 			    attribs->start + attribs->length,
 			    bank);
 		return FALSE;
@@ -848,8 +854,8 @@ fu_dell_dock_mst_invalidate_bank(FuDevice *device, MSTBank bank_in_use, GError *
 		}
 		if (retries_cnt > retries) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "set tag invalid fail (new 0x%x; old 0x%x)",
 				    new_tag[3],
 				    crc_tag[3]);
@@ -903,7 +909,7 @@ fu_dell_dock_mst_write_bank(FuDevice *device,
 	}
 
 	/* failed after all our retries */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to write to bank %u", bank);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "failed to write to bank %u", bank);
 	return FALSE;
 }
 
@@ -1010,7 +1016,7 @@ fu_dell_dock_mst_write_cayenne(FuDevice *device,
 	}
 	/* failed after all our retries */
 	if (!checksum) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Failed to write to bank");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "failed to write to bank");
 		return FALSE;
 	}
 	/* activate the FW */
@@ -1128,7 +1134,10 @@ fu_dell_dock_mst_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -179,7 +179,10 @@ fu_dell_dock_tbt_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -133,7 +133,10 @@ fu_dell_dock_status_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -91,7 +91,10 @@ fu_dell_supported(FuPlugin *plugin, GError **error)
 		return FALSE;
 	}
 	if (value != 0xDE) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid DE data");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid DE data");
 		return FALSE;
 	}
 
@@ -112,8 +115,8 @@ fu_dell_supported(FuPlugin *plugin, GError **error)
 	}
 	if (!(da_values.supported_cmds & (1 << DACI_FLASH_INTERFACE_CLASS))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "unable to access flash interface. supported commands: 0x%x",
 			    da_values.supported_cmds);
 		return FALSE;
@@ -126,7 +129,7 @@ fu_dell_supported(FuPlugin *plugin, GError **error)
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "chassis invalid");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "chassis invalid");
 	return FALSE;
 }
 

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -209,8 +209,8 @@ fu_dfu_device_parse_iface_data(FuDfuDevice *self, GBytes *iface_data, GError **e
 		if (bufstr->len > 0)
 			g_string_truncate(bufstr, bufstr->len - 1);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "interface found, but not the correct length for "
 			    "functional data: %" G_GSIZE_FORMAT " bytes: %s",
 			    sz,
@@ -1500,7 +1500,10 @@ fu_dfu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -49,7 +49,7 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 
 	/* check size */
 	if (in_len > 64 - 8) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "input buffer too large");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "input buffer too large");
 		return FALSE;
 	}
 
@@ -89,8 +89,8 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 					     NULL, /* cancellable */
 					     &error_local)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to send to device on ep 0x%02x: %s",
 			    (guint)FU_EBITDO_USB_BOOTLOADER_EP_OUT,
 			    error_local->message);
@@ -123,8 +123,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 					     NULL, /* cancellable */
 					     &error_local)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to retrieve from device on ep 0x%02x: %s",
 			    (guint)ep_in,
 			    error_local->message);
@@ -144,8 +144,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 		if (out != NULL) {
 			if (fu_struct_ebitdo_pkt_get_payload_len(st_hdr) < out_len) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "payload too small, expected %" G_GSIZE_FORMAT
 					    " got %u",
 					    out_len,
@@ -170,8 +170,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 		if (out != NULL) {
 			if (out_len != 4) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "outbuf size wrong, expected 4 got %" G_GSIZE_FORMAT,
 					    out_len);
 				return FALSE;
@@ -195,8 +195,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 		if (out != NULL) {
 			if (fu_struct_ebitdo_pkt_get_cmd_len(st_hdr) != out_len) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "outbuf size wrong, expected %" G_GSIZE_FORMAT
 					    " got %i",
 					    out_len,
@@ -223,8 +223,8 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 		if (fu_struct_ebitdo_pkt_get_cmd(st_hdr) != FU_EBITDO_PKT_CMD_ACK) {
 			g_set_error(
 			    error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "write failed, got %s",
 			    fu_ebitdo_pkt_cmd_to_string(fu_struct_ebitdo_pkt_get_cmd(st_hdr)));
 			return FALSE;
@@ -233,10 +233,7 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 	}
 
 	/* unhandled */
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
-			    "unexpected device response");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unexpected device response");
 	return FALSE;
 }
 
@@ -260,8 +257,8 @@ fu_ebitdo_device_validate(FuEbitdoDevice *self, GError **error)
 	ven = fu_device_get_vendor(FU_DEVICE(self));
 	if (ven == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "could not check vendor descriptor: ");
 		return FALSE;
 	}
@@ -270,8 +267,8 @@ fu_ebitdo_device_validate(FuEbitdoDevice *self, GError **error)
 			return TRUE;
 	}
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_DATA,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "vendor '%s' did not match allowlist, "
 		    "probably not a 8BitDo device…",
 		    ven);

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -40,8 +40,8 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	payload_len = (guint32)(streamsz - st->len);
 	if (payload_len != fu_struct_ebitdo_hdr_get_destination_len(st)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "file size incorrect, expected 0x%04x got 0x%04x",
 			    (guint)fu_struct_ebitdo_hdr_get_destination_len(st),
 			    (guint)payload_len);

--- a/plugins/elanfp/fu-elanfp-device.c
+++ b/plugins/elanfp/fu-elanfp-device.c
@@ -187,8 +187,8 @@ fu_elanfp_device_do_xfer(FuElanfpDevice *self,
 		}
 		if (actual != outlen) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_PARTIAL_INPUT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
 				    "only sent %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " bytes",
 				    actual,
 				    outlen);
@@ -211,8 +211,8 @@ fu_elanfp_device_do_xfer(FuElanfpDevice *self,
 		}
 		if (actual != inlen && !allow_less) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_PARTIAL_INPUT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "only received %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " bytes",
 				    actual,
 				    outlen);
@@ -328,8 +328,8 @@ fu_elanfp_device_write_payload(FuElanfpDevice *self,
 		}
 		if (recvbuf[5] != FU_CFU_CONTENT_STATUS_SUCCESS) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to send chunk %u: %s",
 				    i + 1,
 				    fu_cfu_content_status_to_string(recvbuf[5]));
@@ -398,8 +398,8 @@ fu_elanfp_device_write_firmware(FuDevice *device,
 	}
 	if (items[i].tag == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no CFU offer was accepted");
 		return FALSE;
 	}

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -922,7 +922,10 @@ fu_elantp_hid_device_set_quirk_kv(FuDevice *device,
 		self->iap_password = (guint16)tmp;
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -186,11 +186,11 @@ fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(FuDevice *parent,
 	self->iap_ctrl = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 
 	if ((self->iap_ctrl & 0x800) != 0x800) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT, "bit11 fail");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bit11 fail");
 		return FALSE;
 	}
 	if ((self->iap_ctrl & 0x1000) == 0x1000) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_BUSY, "bit12 fail, resend");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "bit12 fail, resend");
 		return FALSE;
 	}
 
@@ -215,8 +215,8 @@ fu_elantp_hid_haptic_device_get_haptic_driver_ic(FuDevice *parent,
 	value = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	if (value == 0xFFFF || value == ETP_CMD_I2C_FORCE_TYPE_ENABLE) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to read haptic enable cmd");
 		return FALSE;
 	}
@@ -224,8 +224,8 @@ fu_elantp_hid_haptic_device_get_haptic_driver_ic(FuDevice *parent,
 	if ((buf[0] & ETP_FW_FORCE_TYPE_ENABLE_BIT) == 0 ||
 	    (buf[0] & ETP_FW_EEPROM_ENABLE_BIT) == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "eeprom enable bit unset");
 		return FALSE;
 	}
@@ -362,8 +362,8 @@ fu_elantp_hid_haptic_device_write_checksum_cb(FuDevice *parent, gpointer user_da
 
 	if ((value & 0xFFFF) != ETP_CMD_I2C_EEPROM_WRITE_INFORMATION) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "failed to set haptic info (0x%04x): ",
 			    value);
 		return FALSE;
@@ -405,8 +405,8 @@ fu_elantp_hid_haptic_device_write_checksum_cb(FuDevice *parent, gpointer user_da
 	value = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	if ((value & 0xFFFF) != helper->checksum) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "eeprom checksum failed 0x%04x != 0x%04x : ",
 			    value,
 			    helper->checksum);
@@ -442,7 +442,11 @@ fu_elantp_hid_haptic_device_wait_calc_checksum_cb(FuDevice *parent,
 	}
 	ctrl = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	if ((ctrl & 0x20) == 0x20) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "ctrl failed 0x%04x", ctrl);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "ctrl failed 0x%04x",
+			    ctrl);
 		return FALSE;
 	}
 
@@ -634,8 +638,8 @@ fu_elantp_hid_haptic_device_prepare_firmware(FuDevice *device,
 	driver_ic = fu_elantp_haptic_firmware_get_driver_ic(FU_ELANTP_HAPTIC_FIRMWARE(firmware));
 	if (driver_ic != self->driver_ic) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "driver IC 0x%x != 0x%x",
 			    (guint)driver_ic,
 			    (guint)self->driver_ic);
@@ -899,16 +903,16 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 	/* haptic EEPROM IAP process runs in the TP main code */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "in touchpad bootloader mode");
 		return FALSE;
 	}
 
 	if (self->driver_ic != 0x2 || self->iap_ver != 0x1) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no support for EEPROM IAP 0x%x 0x%x: ",
 			    (guint)self->driver_ic,
 			    (guint)self->iap_ver);
@@ -1092,7 +1096,10 @@ fu_elantp_hid_haptic_device_set_quirk_kv(FuDevice *device,
 		self->iap_password = (guint16)tmp;
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -788,7 +788,10 @@ fu_elantp_i2c_device_set_quirk_kv(FuDevice *device,
 		self->i2c_addr = (guint16)tmp;
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -492,8 +492,8 @@ fu_emmc_device_write_firmware(FuDevice *device,
 			return FALSE;
 		if (total_done != streamsz) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware size and number of sectors written "
 				    "mismatch (%" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT "):",
 				    total_done,
@@ -545,8 +545,8 @@ fu_emmc_device_write_firmware(FuDevice *device,
 			return FALSE;
 		if (ext_csd[EXT_CSD_FFU_STATUS] != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "FFU install failed: %d",
 				    ext_csd[EXT_CSD_FFU_STATUS]);
 			return FALSE;
@@ -569,7 +569,10 @@ fu_emmc_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 		return TRUE;
 	}
 
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -220,7 +220,7 @@ fu_ep963x_device_wait_cb(FuDevice *device, gpointer user_data, GError **error)
 		return FALSE;
 	}
 	if (bufhw[2] != FU_EP963_USB_STATE_READY) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "hardware is not ready");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "hardware is not ready");
 		return FALSE;
 	}
 	return TRUE;

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -81,8 +81,8 @@ fu_fastboot_device_write(FuDevice *device, const guint8 *buf, gsize buflen, GErr
 	}
 	if (actual_len != buflen) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only wrote %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;
@@ -96,8 +96,8 @@ fu_fastboot_device_writestr(FuDevice *device, const gchar *str, GError **error)
 	gsize buflen = strlen(str);
 	if (buflen > FASTBOOT_CMD_BUFSZ - 4) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "fastboot limits writes to %i bytes",
 			    FASTBOOT_CMD_BUFSZ - 4);
 		return FALSE;
@@ -158,8 +158,8 @@ fu_fastboot_device_read(FuDevice *device,
 		fu_dump_raw(G_LOG_DOMAIN, "read", buf, actual_len);
 		if (actual_len < 4) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "only read %" G_GSIZE_FORMAT "bytes",
 				    actual_len);
 			return FALSE;
@@ -187,8 +187,8 @@ fu_fastboot_device_read(FuDevice *device,
 		/* failure */
 		if (memcmp(buf, "FAIL", 4) == 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "failed to read response: %s",
 				    tmp);
 			return FALSE;
@@ -196,14 +196,14 @@ fu_fastboot_device_read(FuDevice *device,
 
 		/* unknown failure */
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to read response");
 		return FALSE;
 	}
 
 	/* we timed out a *lot* */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "no response to read");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "no response to read");
 	return FALSE;
 }
 
@@ -390,8 +390,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 	/* oem */
 	if (g_strcmp0(op, "oem") == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "OEM commands are not supported");
 		return FALSE;
 	}
@@ -405,8 +405,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 		if (var == NULL) {
 			tmp = xb_node_export(part, XB_NODE_EXPORT_FLAG_NONE, NULL);
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "required var for part: %s",
 				    tmp);
 			return FALSE;
@@ -417,8 +417,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 			return FALSE;
 		if (tmp == NULL || tmp[0] == '\0') {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to getvar %s",
 				    var);
 			return FALSE;
@@ -436,8 +436,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 			g_autofree gchar *tmp = NULL;
 			tmp = xb_node_export(part, XB_NODE_EXPORT_FLAG_NONE, NULL);
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "required partition for part: %s",
 				    tmp);
 			return FALSE;
@@ -469,8 +469,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 			g_autofree gchar *tmp = NULL;
 			tmp = xb_node_export(part, XB_NODE_EXPORT_FLAG_NONE, NULL);
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "required partition and filename: %s",
 				    tmp);
 			return FALSE;
@@ -495,8 +495,8 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 			csum_actual = g_compute_checksum_for_bytes(csum_kinds[i].kind, data);
 			if (g_strcmp0(csum, csum_actual) != 0) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "%s invalid, expected %s, got %s",
 					    filename,
 					    csum,
@@ -523,7 +523,7 @@ fu_fastboot_device_write_motorola_part(FuDevice *device,
 	}
 
 	/* unknown */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "unknown operation %s", op);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "unknown operation %s", op);
 	return FALSE;
 }
 
@@ -633,7 +633,10 @@ fu_fastboot_device_write_firmware(FuDevice *device,
 		return fu_fastboot_device_write_motorola(device, firmware, progress, error);
 
 	/* not supported */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "manifest not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "manifest not supported");
 	return FALSE;
 }
 
@@ -661,7 +664,10 @@ fu_fastboot_device_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/flashrom/fu-flashrom-cmos.c
+++ b/plugins/flashrom/fu-flashrom-cmos.c
@@ -57,7 +57,7 @@ fu_flashrom_cmos_reset(GError **error)
 	/* success */
 	return TRUE;
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no <sys/io.h> support");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no <sys/io.h> support");
 	return FALSE;
 #endif
 }

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -48,7 +48,7 @@ fu_flashrom_device_set_quirk_kv(FuDevice *device,
 		fu_device_set_metadata_integer(device, "PciBcrAddr", tmp);
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }
 

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -136,8 +136,8 @@ fu_focalfp_buffer_check_cmd_crc(const guint8 *buf, gsize bufsz, guint8 cmd, GErr
 	/* check was correct response */
 	if (buf[4] != cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got cmd 0x%02x, expected 0x%02x",
 			    buf[4],
 			    cmd);
@@ -150,8 +150,8 @@ fu_focalfp_buffer_check_cmd_crc(const guint8 *buf, gsize bufsz, guint8 cmd, GErr
 	csum_actual = fu_focaltp_buffer_generate_checksum(buf + 1, buf[3] - 1);
 	if (csum != csum_actual) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got checksum 0x%02x, expected 0x%02x",
 			    csum,
 			    csum_actual);
@@ -339,8 +339,8 @@ fu_focalfp_hid_device_send_data(FuFocalfpHidDevice *self,
 	/* sanity check */
 	if (bufsz > REPORT_SIZE - 8) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "data length 0x%x invalid",
 			    bufsz);
 		return FALSE;
@@ -473,8 +473,8 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (us_ic_id != UPGRADE_ID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got us_ic_id 0x%02x, expected 0x%02x",
 			    us_ic_id,
 			    (guint)UPGRADE_ID);
@@ -510,8 +510,8 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	if (checksum != fu_focalfp_firmware_get_checksum(FU_FOCALFP_FIRMWARE(firmware))) {
 		fu_device_sleep(device, 500);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "device checksum invalid, got 0x%02x, expected 0x%02x",
 			    checksum,
 			    fu_focalfp_firmware_get_checksum(FU_FOCALFP_FIRMWARE(firmware)));
@@ -538,8 +538,8 @@ fu_focalfp_hid_device_reload(FuDevice *device, GError **error)
 	g_debug("id1=%x, id2=%x", idbuf[1], idbuf[0]);
 	if (idbuf[1] != 0x58 && idbuf[0] != 0x22) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "firmware id invalid, got 0x%02x:0x%02x, expected 0x%02x:0x%02x",
 			    idbuf[1],
 			    idbuf[0],
@@ -569,8 +569,8 @@ fu_focalfp_hid_device_detach_cb(FuDevice *device, gpointer user_data, GError **e
 	/* 1: upgrade mode; 2: fw mode */
 	if (uc_mode != 1) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got uc_mode 0x%02x, expected 0x%02x",
 			    uc_mode,
 			    (guint)1);

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -86,7 +86,7 @@ fu_fpc_device_dfu_cmd(FuFpcDevice *self,
 	gsize actual_len = 0;
 
 	if (data == NULL && length > 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Invalid input data");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "Invalid input data");
 		return FALSE;
 	}
 
@@ -108,8 +108,8 @@ fu_fpc_device_dfu_cmd(FuFpcDevice *self,
 		return FALSE;
 	if (actual_len != length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only sent 0x%04x of 0x%04x",
 			    (guint)actual_len,
 			    (guint)length);
@@ -130,7 +130,7 @@ fu_fpc_device_fw_cmd(FuFpcDevice *self,
 	gsize actual_len = 0;
 
 	if (data == NULL && length > 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "Invalid input data");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "Invalid input data");
 		return FALSE;
 	}
 
@@ -151,8 +151,8 @@ fu_fpc_device_fw_cmd(FuFpcDevice *self,
 		return FALSE;
 	if (actual_len != length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only sent 0x%04x of 0x%04x",
 			    (guint)actual_len,
 			    (guint)length);

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -60,9 +60,9 @@ fu_genesys_gl32xx_device_cmd_none(FuGenesysGl32xxDevice *self,
 		return FALSE;
 	if (io_hdr.status) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
 			    io_hdr.status,
 			    sense_buffer[2],
 			    sense_buffer[12],
@@ -115,9 +115,9 @@ fu_genesys_gl32xx_device_cmd_in(FuGenesysGl32xxDevice *self,
 		return FALSE;
 	if (io_hdr.status) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
 			    io_hdr.status,
 			    sense_buffer[2],
 			    sense_buffer[12],
@@ -173,9 +173,9 @@ fu_genesys_gl32xx_device_cmd_out(FuGenesysGl32xxDevice *self,
 		return FALSE;
 	if (io_hdr.status) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "command fail with status %x, senseKey 0x%02x, asc 0x%02x, ascq 0x%02x",
 			    io_hdr.status,
 			    sense_buffer[2],
 			    sense_buffer[12],
@@ -321,8 +321,8 @@ fu_genesys_gl32xx_device_ensure_version(FuGenesysGl32xxDevice *self, GError **er
 	}
 	if (buf->len < 0x24) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to read version");
 		return FALSE;
 	}
@@ -547,8 +547,8 @@ fu_genesys_gl32xx_device_get_usb_mode(FuGenesysGl32xxDevice *self, GError **erro
 		break;
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "unknown USB mode 0x%02x read from device",
 			    mode);
 		return FALSE;

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
@@ -52,8 +52,8 @@ fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		if (streamsz < 2) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "image is too small");
 			return FALSE;
 		}

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -34,8 +34,8 @@ fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz < sizeof(self->public_key)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "image is too small");
 		return FALSE;
 	}

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -164,7 +164,10 @@ fu_genesys_usbhub_firmware_calculate_size(GInputStream *stream,
 		return FALSE;
 	}
 	if (kbs == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "invalid codesize");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid codesize");
 		return FALSE;
 	}
 	if (size != NULL)
@@ -445,8 +448,8 @@ fu_genesys_usbhub_firmware_build(FuFirmware *firmware, XbNode *n, GError **error
 	tmp = xb_node_query_text(n, "tool_string_version", NULL);
 	if (tmp == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid tool_string_version");
 		return FALSE;
 	} else {
@@ -459,8 +462,8 @@ fu_genesys_usbhub_firmware_build(FuFirmware *firmware, XbNode *n, GError **error
 		gsize len = strlen(tmp);
 		if (len != 4) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid mask_project_code %s, got 0x%x length",
 				    tmp,
 				    (guint)len);
@@ -478,8 +481,8 @@ fu_genesys_usbhub_firmware_build(FuFirmware *firmware, XbNode *n, GError **error
 		gsize len = strlen(tmp);
 		if (len != 6) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid mask_project_ic_type %s, got 0x%x length",
 				    tmp,
 				    (guint)len);

--- a/plugins/goodix-tp/fu-goodixtp-hid-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-hid-device.c
@@ -94,8 +94,8 @@ fu_goodixtp_hid_device_get_report(FuGoodixtpHidDevice *self,
 	}
 	if (rcv_buf[0] != REPORT_ID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "rcv_buf[0]:%02x != 0x0E",
 			    rcv_buf[0]);
 		return FALSE;
@@ -106,8 +106,8 @@ fu_goodixtp_hid_device_get_report(FuGoodixtpHidDevice *self,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -132,8 +132,8 @@ fu_goodixtp_hid_device_set_report(FuGoodixtpHidDevice *self,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif

--- a/plugins/gpio/fu-gpio-plugin.c
+++ b/plugins/gpio/fu-gpio-plugin.c
@@ -39,8 +39,8 @@ fu_gpio_plugin_parse_level(const gchar *str, gboolean *ret, GError **error)
 		return TRUE;
 	}
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_DATA,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "cannot parse level, got %s and expected high|low",
 		    str);
 	return FALSE;
@@ -58,8 +58,8 @@ fu_gpio_plugin_process_quirk(FuPlugin *plugin, const gchar *str, GError **error)
 	/* sanity check */
 	if (g_strv_length(split) != 3) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid format, CHIP_NAME,PIN_NAME,LEVEL, got '%s'",
 			    str);
 		return FALSE;

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -61,8 +61,8 @@ fu_hailuck_tp_device_cmd_cb(FuDevice *device, gpointer user_data, GError **error
 		success_tmp = req->type - 0x10;
 	if (buf[0] != FU_HAILUCK_REPORT_ID_SHORT || buf[1] != success_tmp) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "report mismatch for type=0x%02x[%s]: "
 			    "expected=0x%02x, received=0x%02x",
 			    req->type,
@@ -140,8 +140,8 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 		fu_byte_array_append_uint16(buf, 0xCCCC, G_LITTLE_ENDIAN);
 		if (buf->len != block_size + 16) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "packet mismatch: len=0x%04x, expected=0x%04x",
 				    buf->len,
 				    block_size + 16);

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -77,8 +77,8 @@ fu_igsc_aux_firmware_match_device(FuIgscAuxFirmware *self,
 
 	/* not us */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
 		    "could not find 0x%04x:0x%04x 0x%04x:0x%04x in the image",
 		    vendor_id,
 		    device_id,
@@ -176,8 +176,8 @@ fu_igsc_aux_firmware_parse_extension(FuIgscAuxFirmware *self, FuFirmware *fw, GE
 	} else if (fu_firmware_get_idx(fw) == MFT_EXT_TYPE_FWDATA_UPDATE) {
 		if (bufsz != sizeof(struct mft_fwdata_update_ext)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "signed data update manifest ext was 0x%x bytes",
 				    (guint)bufsz);
 			return FALSE;
@@ -232,8 +232,8 @@ fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 	}
 	if (!self->has_manifest_ext || self->device_infos->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "missing extensions");
 		return FALSE;
 	}

--- a/plugins/intel-gsc/fu-igsc-code-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-code-firmware.c
@@ -71,8 +71,8 @@ fu_igsc_code_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz > FU_IGSC_FIRMWARE_MAX_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "image size too big: 0x%x",
 			    (guint)streamsz);
 		return FALSE;

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -83,14 +83,14 @@ fu_igsc_device_heci_validate_response_header(FuIgscDevice *self,
 {
 	if (resp_header->header.command_id != command_id) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid command ID (%d): ",
 			    resp_header->header.command_id);
 		return FALSE;
 	}
 	if (!resp_header->header.is_response) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not a response");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "not a response");
 		return FALSE;
 	}
 	if (resp_header->status != GSC_FWU_STATUS_SUCCESS) {
@@ -118,8 +118,8 @@ fu_igsc_device_heci_validate_response_header(FuIgscDevice *self,
 			break;
 		}
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "HECI message failed: %s [0x%x]: ",
 			    msg,
 			    resp_header->status);
@@ -127,8 +127,8 @@ fu_igsc_device_heci_validate_response_header(FuIgscDevice *self,
 	}
 	if (resp_header->reserved != 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "HECI message response is leaking data");
 		return FALSE;
 	}
@@ -161,8 +161,8 @@ fu_igsc_device_command(FuIgscDevice *self,
 		return FALSE;
 	if (resp_readsz != resp_bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "read 0x%x bytes but expected 0x%x",
 			    (guint)resp_readsz,
 			    (guint)resp_bufsz);
@@ -200,16 +200,16 @@ fu_igsc_device_get_version_raw(FuIgscDevice *self,
 		return FALSE;
 	if (res->partition != partition) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid HECI message response payload: 0x%x: ",
 			    res->partition);
 		return FALSE;
 	}
 	if (bufsz > 0 && res->version_length != bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid HECI message response version_length: 0x%x, expected 0x%x: ",
 			    res->version_length,
 			    (guint)bufsz);
@@ -325,8 +325,8 @@ fu_igsc_device_get_config(FuIgscDevice *self, GError **error)
 		return FALSE;
 	if (res.format_version != GSC_FWU_GET_CONFIG_FORMAT_VERSION) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid config version 0x%x, expected 0x%x",
 			    res.format_version,
 			    (guint)GSC_FWU_GET_CONFIG_FORMAT_VERSION);
@@ -342,8 +342,8 @@ fu_igsc_device_get_config(FuIgscDevice *self, GError **error)
 		self->hw_sku = GSC_IFWI_TAG_SOC2_SKU_BIT;
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid hw sku 0x%x, expected 0..2",
 			    res.hw_sku);
 		return FALSE;
@@ -622,7 +622,7 @@ fu_igsc_device_wait_for_reset(FuIgscDevice *self, GError **error)
 			return TRUE;
 		fu_device_sleep(FU_DEVICE(self), 100);
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "device did not reset");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "device did not reset");
 	return FALSE;
 }
 

--- a/plugins/intel-gsc/fu-igsc-oprom-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-firmware.c
@@ -71,8 +71,8 @@ fu_igsc_oprom_firmware_match_device(FuIgscOpromFirmware *self,
 
 	/* not us */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
 		    "could not find 0x%04x:0x%04x 0x%04x:0x%04x in the image",
 		    vendor_id,
 		    device_id,
@@ -162,8 +162,8 @@ fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 	if (fu_oprom_firmware_get_subsystem(FU_OPROM_FIRMWARE(firmware)) !=
 	    FU_OPROM_FIRMWARE_SUBSYSTEM_EFI_BOOT_SRV_DRV) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid subsystem, got 0x%x, expected 0x%x",
 			    fu_oprom_firmware_get_subsystem(FU_OPROM_FIRMWARE(firmware)),
 			    (guint)FU_OPROM_FIRMWARE_SUBSYSTEM_EFI_BOOT_SRV_DRV);
@@ -172,8 +172,8 @@ fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 	if (fu_oprom_firmware_get_machine_type(FU_OPROM_FIRMWARE(firmware)) !=
 	    FU_OPROM_FIRMWARE_MACHINE_TYPE_X64) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid machine type, got 0x%x, expected 0x%x",
 			    fu_oprom_firmware_get_machine_type(FU_OPROM_FIRMWARE(firmware)),
 			    (guint)FU_OPROM_FIRMWARE_MACHINE_TYPE_X64);
@@ -182,8 +182,8 @@ fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 	if (fu_oprom_firmware_get_compression_type(FU_OPROM_FIRMWARE(firmware)) !=
 	    FU_OPROM_FIRMWARE_COMPRESSION_TYPE_NONE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid compression type, got 0x%x, expected 0x%x (uncompressed)",
 			    fu_oprom_firmware_get_compression_type(FU_OPROM_FIRMWARE(firmware)),
 			    (guint)FU_OPROM_FIRMWARE_COMPRESSION_TYPE_NONE);
@@ -196,8 +196,8 @@ fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (!FU_IS_IFWI_CPD_FIRMWARE(fw_cpd)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "CPD was not FuIfwiCpdFirmware");
 		return FALSE;
 	}

--- a/plugins/intel-me/fu-intel-me-common.c
+++ b/plugins/intel-me/fu-intel-me-common.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <fwupd.h>
+
 #include "fu-intel-me-common.h"
 
 static gboolean
@@ -19,13 +21,17 @@ fu_intel_me_mkhi_result_to_error(FuMkhiResult result, GError **error)
 	case MKHI_STATUS_NOT_AVAILABLE:
 	case MKHI_STATUS_NOT_SET:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "not supported [0x%x]",
 			    result);
 		break;
 	default:
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "generic failure [0x%x]", result);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "generic failure [0x%x]",
+			    result);
 		break;
 	}
 	return FALSE;
@@ -38,8 +44,8 @@ fu_intel_me_mkhi_verify_header(const FuMkhiHeader *hdr_req,
 {
 	if (hdr_req->group_id != hdr_res->group_id) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid response group ID, requested 0x%x and got 0x%x",
 			    hdr_req->group_id,
 			    hdr_res->group_id);
@@ -47,8 +53,8 @@ fu_intel_me_mkhi_verify_header(const FuMkhiHeader *hdr_req,
 	}
 	if (hdr_req->command != hdr_res->command) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid response command, requested 0x%x and got 0x%x",
 			    (guint)hdr_req->command,
 			    (guint)hdr_res->command);
@@ -56,8 +62,8 @@ fu_intel_me_mkhi_verify_header(const FuMkhiHeader *hdr_req,
 	}
 	if (!hdr_res->is_resp) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid response group ID, not a response!");
 		return FALSE;
 	}
@@ -81,15 +87,15 @@ fu_intel_me_convert_checksum(GByteArray *buf, GError **error)
 	}
 	if (!seen_non00_data) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_INITIALIZED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "buffer was all 0x00");
 		return NULL;
 	}
 	if (!seen_nonff_data) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_INITIALIZED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "buffer was all 0xFF");
 		return NULL;
 	}

--- a/plugins/intel-me/fu-intel-me-heci-device.c
+++ b/plugins/intel-me/fu-intel-me-heci-device.c
@@ -38,8 +38,8 @@ fu_intel_me_heci_device_read_file_response(GByteArray *buf_res, guint32 datasz_r
 		return NULL;
 	if (datasz_res > datasz_req || datasz_res == 0x0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid response data size, requested 0x%x and got 0x%x",
 			    datasz_req,
 			    datasz_res);

--- a/plugins/intel-me/fu-intel-me-mca-device.c
+++ b/plugins/intel-me/fu-intel-me-mca-device.c
@@ -65,8 +65,8 @@ fu_intel_me_mca_device_setup(FuDevice *device, GError **error)
 								file_ids[i],
 								0x0,
 								&error_local)) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED) ||
-			    g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
+			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA)) {
 				continue;
 			}
 			g_warning("failed to get public key using file-id 0x%x: %s",

--- a/plugins/intel-me/fu-intel-me-mkhi-device.c
+++ b/plugins/intel-me/fu-intel-me-mkhi-device.c
@@ -51,9 +51,8 @@ fu_intel_me_mkhi_device_setup(FuDevice *device, GError **error)
 		if (!fu_intel_me_mkhi_device_add_checksum_for_filename(self,
 								       fns[i],
 								       &error_local)) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED))
 				continue;
-			}
 			g_warning("failed to get public key using %s: %s",
 				  fns[i],
 				  error_local->message);

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -108,8 +108,8 @@ fu_intel_usb4_device_get_mmio(FuDevice *device,
 		/* error status bit */
 		if (fu_struct_intel_usb4_mbox_get_status(st_regex) & MBOX_ERROR) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "GET_MMIO opcode [0x%x] nonzero error bit in status [0x%x]",
 				    fu_struct_intel_usb4_mbox_get_opcode(st_regex),
 				    fu_struct_intel_usb4_mbox_get_status(st_regex));
@@ -119,8 +119,8 @@ fu_intel_usb4_device_get_mmio(FuDevice *device,
 		/* operation valid (OV) bit should be 0'b */
 		if (fu_struct_intel_usb4_mbox_get_status(st_regex) & MBOX_OPVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "GET_MMIO opcode [0x%x] nonzero OV bit in status [0x%x]",
 				    fu_struct_intel_usb4_mbox_get_opcode(st_regex),
 				    fu_struct_intel_usb4_mbox_get_status(st_regex));
@@ -171,8 +171,8 @@ fu_intel_usb4_device_mbox_data_read(FuDevice *device, guint8 *data, guint8 lengt
 
 	if (length > 64 || length % 4) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid firmware data read length %u",
 			    length);
 		return FALSE;
@@ -203,8 +203,8 @@ fu_intel_usb4_device_mbox_data_write(FuDevice *device,
 
 	if (length > 64 || length % 4) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "invalid firmware data write length %u",
 			    length);
 		return FALSE;
@@ -238,8 +238,8 @@ fu_intel_usb4_device_operation(FuDevice *device,
 	case FU_INTEL_USB4_OPCODE_DROM_READ:
 		if (metadata == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "hub opcode 0x%x requires metadata",
 				    opcode);
 			return FALSE;
@@ -255,8 +255,8 @@ fu_intel_usb4_device_operation(FuDevice *device,
 		break;
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "invalid hub opcode: 0x%x",
 			    opcode);
 		return FALSE;

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -577,8 +577,8 @@ fu_jabra_gnp_device_prepare_firmware(FuDevice *device,
 		return NULL;
 	if (fu_jabra_gnp_firmware_get_dfu_pid(FU_JABRA_GNP_FIRMWARE(firmware)) != self->dfu_pid) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wrong DFU PID, got 0x%x, expected 0x%x",
 			    fu_jabra_gnp_firmware_get_dfu_pid(FU_JABRA_GNP_FIRMWARE(firmware)),
 			    self->dfu_pid);

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -34,7 +34,10 @@ fu_jabra_gnp_firmware_parse_version(FuJabraGnpFirmware *self, GError **error)
 
 	split = g_strsplit(fu_firmware_get_version(FU_FIRMWARE(self)), ".", -1);
 	if (g_strv_length(split) != 3) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "version invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "version invalid");
 		return FALSE;
 	}
 	if (!fu_strtoull(split[0], &val, 0x0, 0xFF, error))
@@ -68,8 +71,8 @@ fu_jabra_gnp_firmware_parse_info(FuJabraGnpFirmware *self, XbSilo *silo, GError 
 	version = xb_node_get_attr(build_vector, "version");
 	if (version == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "buildVector version missing");
 		return FALSE;
 	}
@@ -141,7 +144,7 @@ fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuJabraGnpImage) img = fu_jabra_gnp_image_new();
 		g_autoptr(GError) error_local = NULL;
 		if (!fu_jabra_gnp_image_parse(img, n, firmware_archive, &error_local)) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_DATA)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA)) {
 				g_debug("ignoring image 0x%x: %s", i, error_local->message);
 				continue;
 			}

--- a/plugins/jabra-gnp/fu-jabra-gnp-image.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-image.c
@@ -43,13 +43,16 @@ fu_jabra_gnp_image_parse(FuJabraGnpImage *self,
 	/* only match on US English */
 	language = xb_node_query_text(n, "language", NULL);
 	if (language == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "language missing");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "language missing");
 		return FALSE;
 	}
 	if (g_strcmp0(language, "English") != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "language was not 'English', got '%s'",
 			    language);
 		return FALSE;
@@ -58,7 +61,7 @@ fu_jabra_gnp_image_parse(FuJabraGnpImage *self,
 	/* get the CRC */
 	crc_str = xb_node_query_text(n, "crc", NULL);
 	if (crc_str == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "crc missing");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "crc missing");
 		return FALSE;
 	}
 	if (!fu_strtoull(crc_str, &crc_expected, 0x0, 0xFFFFFFFF, error)) {
@@ -70,8 +73,8 @@ fu_jabra_gnp_image_parse(FuJabraGnpImage *self,
 	part_str = xb_node_query_text(n, "partition", NULL);
 	if (part_str == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "partition missing");
 		return FALSE;
 	}
@@ -84,7 +87,7 @@ fu_jabra_gnp_image_parse(FuJabraGnpImage *self,
 	/* get the file pointed to by 'name' */
 	name = xb_node_get_attr(n, "name");
 	if (name == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "name missing");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "name missing");
 		return FALSE;
 	}
 	fu_firmware_set_id(FU_FIRMWARE(self), name);
@@ -101,8 +104,8 @@ fu_jabra_gnp_image_parse(FuJabraGnpImage *self,
 	self->crc32 = fu_jabra_gnp_calculate_crc(blob);
 	if (self->crc32 != (guint32)crc_expected) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "checksum invalid, got 0x%x, expected 0x%x",
 			    (guint)self->crc32,
 			    (guint)crc_expected);

--- a/plugins/jabra/fu-jabra-device.c
+++ b/plugins/jabra/fu-jabra-device.c
@@ -127,14 +127,17 @@ fu_jabra_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *va
 			return TRUE;
 		}
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unsupported jabra quirk format");
 		return FALSE;
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/kinetic-dp/fu-kinetic-dp-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-device.c
@@ -87,8 +87,8 @@ fu_kinetic_dp_device_dpcd_read_oui(FuKineticDpDevice *self,
 {
 	if (bufsz < DPCD_SIZE_IEEE_OUI) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "aux dpcd read buffer size [0x%x] is too small to read IEEE OUI",
 			    (guint)bufsz);
 		return FALSE;
@@ -188,7 +188,10 @@ fu_kinetic_dp_device_setup(FuDevice *device, GError **error)
 
 	/* sanity check */
 	if (fu_dpaux_device_get_dpcd_ieee_oui(FU_DPAUX_DEVICE(device)) == 0x0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no IEEE OUI set");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no IEEE OUI set");
 		return FALSE;
 	}
 

--- a/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
@@ -47,8 +47,8 @@ fu_kinetic_dp_plugin_create_device(FuDpauxDevice *dpaux_device, GError **error)
 	/* sanity check */
 	if (dev_id == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "device has no DPCD device id");
 		return NULL;
 	}
@@ -72,8 +72,8 @@ fu_kinetic_dp_plugin_create_device(FuDpauxDevice *dpaux_device, GError **error)
 		    FU_KINETIC_DP_DEVICE(g_object_new(FU_TYPE_KINETIC_DP_PUMA_DEVICE, NULL));
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "%s is not a supported Kinetic device",
 			    dev_id);
 		return NULL;
@@ -105,7 +105,7 @@ fu_kinetic_dp_plugin_backend_device_added(FuPlugin *plugin,
 		return FALSE;
 	locker = fu_device_locker_new(dev, &error_local);
 	if (locker == NULL) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			g_debug("no device found: %s", error_local->message);
 			return TRUE;
 		}

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -59,8 +59,8 @@ fu_kinetic_dp_puma_device_wait_dpcd_cmd_status_cb(FuDevice *device,
 	}
 	if (status != status_want) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "flash mode was %s, wanted %s",
 			    fu_kinetic_dp_puma_mode_to_string(status),
 			    fu_kinetic_dp_puma_mode_to_string(status_want));
@@ -91,8 +91,8 @@ fu_kinetic_dp_puma_device_wait_dpcd_sink_mode_cb(FuDevice *device,
 	}
 	if (status != status_want) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "flash mode was %s, wanted %s",
 			    fu_kinetic_dp_puma_mode_to_string(status),
 			    fu_kinetic_dp_puma_mode_to_string(status_want));
@@ -281,14 +281,14 @@ fu_kinetic_dp_puma_device_send_isp_drv(FuKineticDpPumaDevice *self,
 	if (self->flash_size == 0) {
 		if (self->flash_id > 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "SPI flash not supported");
 			return FALSE;
 		}
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "SPI flash not connected");
 		return FALSE;
 	}
@@ -352,14 +352,14 @@ fu_kinetic_dp_puma_device_enable_fw_update_mode(FuKineticDpPumaDevice *self,
 		if (self->flash_size == 0) {
 			if (self->flash_id > 0) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_NOT_SUPPORTED,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_NOT_SUPPORTED,
 						    "SPI flash not supported");
 				return FALSE;
 			}
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "SPI flash not connected");
 			return FALSE;
 		}

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -88,8 +88,8 @@ fu_kinetic_dp_puma_firmware_parse_chip_id(GInputStream *stream,
 
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no valid Chip ID is found in the firmware");
 	return FALSE;
 }
@@ -116,8 +116,8 @@ fu_kinetic_dp_puma_device_parse_app_fw(FuKineticDpPumaFirmware *self,
 		return FALSE;
 	if (streamsz < 512 * 1024) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "firmware payload size (0x%x) is not valid",
 			    (guint)streamsz);
 		return FALSE;
@@ -140,8 +140,8 @@ fu_kinetic_dp_puma_device_parse_app_fw(FuKineticDpPumaFirmware *self,
 	}
 	if (code_size < (512 * 1024) + offset) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid firmware -- file size 0x%x is not reasonable",
 			    code_size);
 		return FALSE;
@@ -177,15 +177,15 @@ fu_kinetic_dp_puma_device_parse_app_fw(FuKineticDpPumaFirmware *self,
 		return FALSE;
 	if (cmdb_tmp->len != FU_KINETIC_DP_PUMA_REQUEST_CMDB_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid firmware -- cmdb block invalid");
 		return FALSE;
 	}
 	if (memcmp(cmdb_tmp->data, cmdb_sig, sizeof(cmdb_sig)) != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid firmware -- cmdb block not found");
 		return FALSE;
 	}

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -132,14 +132,14 @@ fu_kinetic_dp_secure_device_send_kt_prop_cmd_cb(FuDevice *device,
 			status &= DPCD_KT_COMMAND_MASK;
 			if (status == (guint8)FU_KINETIC_DP_DPCD_STS_CRC_FAILURE) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_FAILED_HANDLED,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "chunk data CRC failed: ");
 				return FALSE;
 			}
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "Invalid value in DPCD_KT_CMD_STATUS_REG: 0x%x",
 				    status);
 			return FALSE;
@@ -150,8 +150,8 @@ fu_kinetic_dp_secure_device_send_kt_prop_cmd_cb(FuDevice *device,
 
 	/* failed */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "waiting for prop cmd, got %s",
 		    fu_kinetic_dp_dpcd_to_string(status));
 	return FALSE;
@@ -205,8 +205,8 @@ fu_kinetic_dp_secure_device_read_dpcd_reply_data_reg(FuKineticDpSecureDevice *se
 
 	if (bufsz < read_data_len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "buffer size [%u] is not enough to read DPCD_ISP_REPLY_DATA_REG [%u]",
 			    (guint)bufsz,
 			    read_data_len);
@@ -239,8 +239,8 @@ fu_kinetic_dp_secure_device_write_dpcd_reply_data_reg(FuKineticDpSecureDevice *s
 
 	if (len > DPCD_SIZE_ISP_REPLY_DATA_REG) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "length bigger than DPCD_SIZE_ISP_REPLY_DATA_REG [%u]",
 			    (guint)len);
 		return FALSE;
@@ -466,22 +466,22 @@ fu_kinetic_dp_secure_device_wait_dpcd_cmd_cleared_cb(FuDevice *device,
 		 * it means that target responded with failure */
 		if (status == FU_KINETIC_DP_DPCD_STS_INVALID_IMAGE) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED_HANDLED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "invalid ISP driver");
 			return FALSE;
 		}
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to execute ISP driver");
 		return FALSE;
 	}
 
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "waiting for sink to clear status");
 	return FALSE;
 }
@@ -530,8 +530,8 @@ fu_kinetic_dp_secure_device_execute_isp_drv(FuKineticDpSecureDevice *self, GErro
 	if (status != FU_KINETIC_DP_DPCD_STS_SECURE_ENABLED &&
 	    status != FU_KINETIC_DP_DPCD_STS_SECURE_DISABLED) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_TIMED_OUT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_TIMED_OUT,
 				    "waiting for ISP driver ready failed!");
 		return FALSE;
 	}
@@ -558,14 +558,14 @@ fu_kinetic_dp_secure_device_execute_isp_drv(FuKineticDpSecureDevice *self, GErro
 	if (self->flash_size == 0) {
 		if (self->flash_id > 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "SPI flash not supported");
 			return FALSE;
 		}
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "SPI flash not connected");
 		return FALSE;
 	}
@@ -807,16 +807,16 @@ fu_kinetic_dp_secure_device_install_fw_images_cb(FuDevice *device,
 		if ((status & FU_KINETIC_DP_DPCD_CMD_INSTALL_IMAGES) > 0)
 			return TRUE;
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED_HANDLED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to install images");
 		return FALSE;
 	}
 
 	/* failed */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "waiting for status, got %s",
 		    fu_kinetic_dp_dpcd_to_string(status));
 	return FALSE;
@@ -880,7 +880,7 @@ fu_kinetic_dp_secure_device_get_flash_bank_idx(FuKineticDpSecureDevice *self, GE
 	g_debug("secure aux got active flash bank 0x%x (0=BankA, 1=BankB, 2=TotalBanks)", res);
 	self->flash_bank = (FuKineticDpBank)res;
 	if (self->flash_bank == FU_KINETIC_DP_BANK_NONE) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "bank not NONE");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "bank not NONE");
 		return FALSE;
 	}
 
@@ -1015,7 +1015,7 @@ fu_kinetic_dp_secure_device_init(FuKineticDpSecureDevice *self)
 	self->isp_secure_auth_mode = TRUE;
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_KINETIC_DP_SECURE_FIRMWARE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_retry_add_recovery(FU_DEVICE(self), G_IO_ERROR, G_IO_ERROR_FAILED_HANDLED, NULL);
+	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -91,8 +91,8 @@ fu_kinetic_dp_secure_firmware_parse_chip_id(GInputStream *stream,
 
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no valid Chip ID is found in the firmware");
 	return FALSE;
 }
@@ -153,8 +153,8 @@ fu_kinetic_dp_secure_device_parse_app_fw(FuKineticDpSecureFirmware *self,
 		return FALSE;
 	if (streamsz != STD_FW_PAYLOAD_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "firmware payload size (0x%x) is not valid",
 			    (guint)streamsz);
 		return FALSE;

--- a/plugins/linux-lockdown/fu-linux-lockdown-plugin.c
+++ b/plugins/linux-lockdown/fu-linux-lockdown-plugin.c
@@ -107,8 +107,8 @@ fu_linux_lockdown_plugin_ensure_security_attr_flags(FwupdSecurityAttr *attr, GEr
 		return FALSE;
 	if (!g_hash_table_contains(config, "CONFIG_LOCK_DOWN_KERNEL_FORCE_NONE")) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "config does not have CONFIG_LOCK_DOWN_KERNEL_FORCE_NONE");
 		return FALSE;
 	}
@@ -118,8 +118,8 @@ fu_linux_lockdown_plugin_ensure_security_attr_flags(FwupdSecurityAttr *attr, GEr
 	    fu_efivar_secure_boot_enabled(NULL)) {
 		g_set_error_literal(
 		    error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_ARGUMENT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "kernel lockdown cannot be changed when secure boot is enabled");
 		return FALSE;
 	}

--- a/plugins/linux-swap/fu-self-test.c
+++ b/plugins/linux-swap/fu-self-test.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <fwupd.h>
+
 #include "fu-linux-swap.h"
 
 static void
@@ -32,7 +34,8 @@ fu_linux_swap_plain_func(void)
 			      "/dev/nvme0n1p4                          partition\t5962748\t0\t-2\n",
 			      0,
 			      &error);
-	if (g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER) ||
+	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
+	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_NAME_HAS_NO_OWNER) ||
 	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
 	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_EXEC_FAILED) ||
 	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CONNECTION_REFUSED) ||
@@ -57,7 +60,8 @@ fu_linux_swap_encrypted_func(void)
 			      "/dev/dm-1                               partition\t5962748\t0\t-2\n",
 			      0,
 			      &error);
-	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
+	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
+	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
 	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SERVICE_UNKNOWN) ||
 	    g_error_matches(error, G_DBUS_ERROR, G_DBUS_ERROR_SPAWN_EXEC_FAILED) ||
 	    g_error_matches(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT)) {

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-common.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-common.c
@@ -117,8 +117,8 @@ proto_manager_decode_message(const guint8 *data,
 	    logi__device__proto__usb_msg__unpack(NULL, len, (const unsigned char *)data);
 	if (usb_msg == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unable to unpack data");
 		return NULL;
 	}
@@ -130,8 +130,8 @@ proto_manager_decode_message(const guint8 *data,
 	case LOGI__DEVICE__PROTO__USB_MSG__MESSAGE_RESPONSE:
 		if (!usb_msg->response) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "no USB response");
 			return NULL;
 		}
@@ -153,8 +153,8 @@ proto_manager_decode_message(const guint8 *data,
 				if (!usb_msg->response->transition_to_devicemode_response
 					 ->success) {
 					g_set_error(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_FAILED,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_NOT_SUPPORTED,
 						    "transition mode request failed. error: %u",
 						    (guint)usb_msg->response
 							->transition_to_devicemode_response->error);
@@ -169,8 +169,8 @@ proto_manager_decode_message(const guint8 *data,
 	case LOGI__DEVICE__PROTO__USB_MSG__MESSAGE_EVENT:
 		if (!usb_msg->response) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "no USB event");
 			return NULL;
 		}

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -134,7 +134,10 @@ fu_logitech_bulkcontroller_device_send(FuLogitechBulkcontrollerDevice *self,
 	} else if (interface_id == BULK_INTERFACE_UPD) {
 		ep = self->update_ep[EP_OUT];
 	} else {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "interface is invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "interface is invalid");
 		return FALSE;
 	}
 	fu_dump_full(G_LOG_DOMAIN, "request", buf, bufsz, 20, FU_DUMP_FLAGS_SHOW_ASCII);
@@ -170,7 +173,10 @@ fu_logitech_bulkcontroller_device_recv(FuLogitechBulkcontrollerDevice *self,
 	} else if (interface_id == BULK_INTERFACE_UPD) {
 		ep = self->update_ep[EP_IN];
 	} else {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "interface is invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "interface is invalid");
 		return FALSE;
 	}
 	g_debug("read response");
@@ -298,8 +304,8 @@ fu_logitech_bulkcontroller_device_sync_wait_any(FuLogitechBulkcontrollerDevice *
 			    fu_struct_logitech_bulkcontroller_send_sync_res_get_payload_length(st));
 	if (response->data == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
 				    "failed to receive packet");
 		return NULL;
 	}
@@ -319,8 +325,8 @@ fu_logitech_bulkcontroller_device_sync_wait_cmd(FuLogitechBulkcontrollerDevice *
 		return NULL;
 	if (response->cmd != cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "command invalid, expected %s and got %s",
 			    fu_logitech_bulkcontroller_cmd_to_string(cmd),
 			    fu_logitech_bulkcontroller_cmd_to_string(response->cmd));
@@ -330,8 +336,8 @@ fu_logitech_bulkcontroller_device_sync_wait_cmd(FuLogitechBulkcontrollerDevice *
 	/* verify the sequence ID */
 	if (response->sequence_id != sequence_id) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "sequence ID invalid, expected 0x%04x and got 0x%04x",
 			    sequence_id,
 			    response->sequence_id);
@@ -407,8 +413,8 @@ fu_logitech_bulkcontroller_device_sync_check_ack_cmd(GByteArray *buf,
 		(guint)ack_cmd);
 	if (ack_cmd != cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "command invalid, expected %s and got %s",
 			    fu_logitech_bulkcontroller_cmd_to_string(cmd),
 			    fu_logitech_bulkcontroller_cmd_to_string(ack_cmd));
@@ -466,8 +472,8 @@ fu_logitech_bulkcontroller_device_sync_check_ack(FuLogitechBulkcontrollerRespons
 	/* verify the sequence ID */
 	if (response->sequence_id != sequence_id) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "sequence ID invalid, expected 0x%04x and got 0x%04x",
 			    sequence_id,
 			    response->sequence_id);
@@ -529,8 +535,8 @@ fu_logitech_bulkcontroller_device_sync_write(FuLogitechBulkcontrollerDevice *sel
 		if (response_tmp->cmd == FU_LOGITECH_BULKCONTROLLER_CMD_ACK) {
 			if (res_ack != NULL) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_FAILED,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "already received ack");
 				return NULL;
 			}
@@ -546,8 +552,8 @@ fu_logitech_bulkcontroller_device_sync_write(FuLogitechBulkcontrollerDevice *sel
 		} else if (response_tmp->cmd == FU_LOGITECH_BULKCONTROLLER_CMD_BUFFER_READ) {
 			if (res_read != NULL) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_FAILED,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "already received read-buffer");
 				return NULL;
 			}
@@ -626,8 +632,8 @@ fu_logitech_bulkcontroller_device_upd_send_cmd(FuLogitechBulkcontrollerDevice *s
 	if (fu_struct_logitech_bulkcontroller_update_res_get_cmd(&buf_ack) !=
 	    FU_LOGITECH_BULKCONTROLLER_CMD_ACK) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "not CMD_ACK, got %s",
 			    fu_logitech_bulkcontroller_cmd_to_string(
 				fu_struct_logitech_bulkcontroller_update_res_get_cmd(&buf_ack)));
@@ -636,8 +642,8 @@ fu_logitech_bulkcontroller_device_upd_send_cmd(FuLogitechBulkcontrollerDevice *s
 	if (fu_struct_logitech_bulkcontroller_update_res_get_cmd_req(&buf_ack) != cmd) {
 		g_set_error(
 		    error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
 		    "invalid upd message received, expected %s, got %s",
 		    fu_logitech_bulkcontroller_cmd_to_string(cmd),
 		    fu_logitech_bulkcontroller_cmd_to_string(
@@ -711,8 +717,8 @@ fu_logitech_bulkcontroller_device_json_parser(FuLogitechBulkcontrollerDevice *se
 	json_root = json_parser_get_root(json_parser);
 	if (json_root == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "did not get JSON root");
 		return FALSE;
 	}
@@ -720,24 +726,24 @@ fu_logitech_bulkcontroller_device_json_parser(FuLogitechBulkcontrollerDevice *se
 	json_payload = json_object_get_object_member(json_object, "payload");
 	if (json_payload == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "did not get JSON payload");
 		return FALSE;
 	}
 	json_devices = json_object_get_array_member(json_payload, "devices");
 	if (json_devices == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "did not get JSON devices");
 		return FALSE;
 	}
 	json_device = json_array_get_object_element(json_devices, 0);
 	if (json_device == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "did not get JSON device");
 		return FALSE;
 	}
@@ -784,8 +790,8 @@ fu_logitech_bulkcontroller_device_parse_info(FuLogitechBulkcontrollerDevice *sel
 		bufstr);
 	if (proto_id != kProtoId_GetDeviceInfoResponse && proto_id != kProtoId_KongEvent) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "incorrect response for device info request");
 		return FALSE;
 	}
@@ -1064,8 +1070,8 @@ fu_logitech_bulkcontroller_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (self->update_status == FU_LOGITECH_BULKCONTROLLER_UPDATE_STATE_ERROR) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware upgrade failed");
 		return FALSE;
 	}
@@ -1107,8 +1113,8 @@ fu_logitech_fu_logitech_bulkcontroller_device_set_time_cb(FuDevice *device,
 		bufstr);
 	if (proto_id != kProtoId_Ack) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "incorrect response");
 		return FALSE;
 	}
@@ -1151,8 +1157,8 @@ fu_logitech_bulkcontroller_device_transition_to_device_mode_cb(FuDevice *device,
 	g_debug("received transition mode response: id: %u, length %u", proto_id, res->len);
 	if (proto_id != kProtoId_TransitionToDeviceModeResponse) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "incorrect response");
 		return FALSE;
 	}
@@ -1198,7 +1204,7 @@ fu_logitech_bulkcontroller_device_clear_queue_cb(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "got valid data, so keep going");
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "got valid data, so keep going");
 	return FALSE;
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-nordic.c
@@ -108,8 +108,8 @@ fu_logitech_hidpp_bootloader_nordic_write_signature(FuLogitechHidppBootloader *s
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_RAM_BUFFER_INVALID_ADDR) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "failed to write @%04x: signature is too big",
 			    addr);
 		return FALSE;
@@ -131,8 +131,8 @@ fu_logitech_hidpp_bootloader_nordic_write(FuLogitechHidppBootloader *self,
 	req->len = len;
 	if (req->len > 28) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "failed to write @%04x: data length too large %02x",
 			    addr,
 			    req->len);
@@ -145,16 +145,16 @@ fu_logitech_hidpp_bootloader_nordic_write(FuLogitechHidppBootloader *self,
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_INVALID_ADDR) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to write @%04x: invalid address",
 			    addr);
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_VERIFY_FAIL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
 			    "failed to write @%04x: failed to verify flash content",
 			    addr);
 		return FALSE;
@@ -165,16 +165,16 @@ fu_logitech_hidpp_bootloader_nordic_write(FuLogitechHidppBootloader *self,
 			req->addr,
 			req->data[0]);
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to write @%04x: only 1 byte write of 0xff supported",
 			    addr);
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_INVALID_CRC) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to write @%04x: invalid CRC",
 			    addr);
 		return FALSE;
@@ -198,16 +198,16 @@ fu_logitech_hidpp_bootloader_nordic_erase(FuLogitechHidppBootloader *self,
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_ERASE_PAGE_INVALID_ADDR) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to erase @%04x: invalid page",
 			    addr);
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_ERASE_PAGE_NONZERO_START) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to erase @%04x: byte 0x00 is not 0xff",
 			    addr);
 		return FALSE;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader-texas.c
@@ -47,7 +47,10 @@ fu_logitech_hidpp_bootloader_texas_compute_and_test_crc(FuLogitechHidppBootloade
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_FLASH_RAM_WRONG_CRC) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "CRC is incorrect");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CRC is incorrect");
 		return FALSE;
 	}
 	return TRUE;
@@ -70,24 +73,24 @@ fu_logitech_hidpp_bootloader_texas_flash_ram_buffer(FuLogitechHidppBootloader *s
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_FLASH_RAM_INVALID_ADDR) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to flash ram buffer @%04x: invalid flash page",
 			    addr);
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_FLASH_RAM_PAGE0_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to flash ram buffer @%04x: invalid App JMP vector",
 			    addr);
 		return FALSE;
 	}
 	if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_FLASH_RAM_INVALID_ORDER) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to flash ram buffer @%04x: page flashed before page 0",
 			    addr);
 		return FALSE;
@@ -166,8 +169,8 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 		/* check size */
 		if (payload->len != 16) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "payload size invalid @%04x: got 0x%02x",
 				    payload->addr,
 				    payload->len);
@@ -199,16 +202,16 @@ fu_logitech_hidpp_bootloader_texas_write_firmware(FuDevice *device,
 		}
 		if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_RAM_BUFFER_INVALID_ADDR) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to write ram buffer @%04x: invalid location",
 				    req->addr);
 			return FALSE;
 		}
 		if (req->cmd == FU_LOGITECH_HIDPP_BOOTLOADER_CMD_WRITE_RAM_BUFFER_OVERFLOW) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to write ram buffer @%04x: invalid size 0x%02x",
 				    req->addr,
 				    req->len);

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-bootloader.c
@@ -75,8 +75,8 @@ fu_logitech_hidpp_bootloader_parse_requests(FuLogitechHidppBootloader *self,
 		payload->len = fu_logitech_hidpp_buffer_read_uint8(tmp + 0x01);
 		if (payload->len > 28) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware data invalid: too large %u bytes",
 				    payload->len);
 			return NULL;
@@ -104,8 +104,8 @@ fu_logitech_hidpp_bootloader_parse_requests(FuLogitechHidppBootloader *self,
 				return NULL;
 			if (offset != 0x0000) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "extended linear addresses with offset different from "
 					    "0 are not supported");
 				return NULL;
@@ -122,8 +122,8 @@ fu_logitech_hidpp_bootloader_parse_requests(FuLogitechHidppBootloader *self,
 			break;
 		default:
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "intel hex file record type %02x not supported",
 				    rec_type);
 			return NULL;
@@ -137,8 +137,8 @@ fu_logitech_hidpp_bootloader_parse_requests(FuLogitechHidppBootloader *self,
 			const gchar *ptr = tmp + 0x09 + (j * 2);
 			if (ptr[0] == '\0') {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "firmware data invalid: expected %u bytes",
 					    payload->len);
 				return NULL;
@@ -176,8 +176,8 @@ fu_logitech_hidpp_bootloader_parse_requests(FuLogitechHidppBootloader *self,
 	}
 	if (reqs->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware data invalid: no payloads found");
 		return NULL;
 	}
@@ -283,8 +283,8 @@ fu_logitech_hidpp_bootloader_setup(FuDevice *device, GError **error)
 	}
 	if (req->len != 0x06) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to get meminfo: invalid size %02x",
 			    req->len);
 		return FALSE;
@@ -391,8 +391,8 @@ fu_logitech_hidpp_bootloader_request(FuLogitechHidppBootloader *self,
 	/* parse response */
 	if ((buf_response[0x00] & 0xf0) != req->cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid command response of %02x, expected %02x",
 			    buf_response[0x00],
 			    req->cmd);
@@ -403,8 +403,8 @@ fu_logitech_hidpp_bootloader_request(FuLogitechHidppBootloader *self,
 	req->len = buf_response[0x03];
 	if (req->len > 28) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid data size of %02x",
 			    req->len);
 		return FALSE;

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp-msg.c
@@ -82,74 +82,77 @@ fu_logitech_hidpp_msg_is_error(FuLogitechHidppHidppMsg *msg, GError **error)
 		switch (msg->data[1]) {
 		case HIDPP_ERR_INVALID_SUBID:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "invalid SubID");
 			break;
 		case HIDPP_ERR_INVALID_ADDRESS:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "invalid address");
 			break;
 		case HIDPP_ERR_INVALID_VALUE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "invalid value");
 			break;
 		case HIDPP_ERR_CONNECT_FAIL:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
 					    "connection request failed");
 			break;
 		case HIDPP_ERR_TOO_MANY_DEVICES:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NO_SPACE,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "too many devices connected");
 			break;
 		case HIDPP_ERR_ALREADY_EXISTS:
-			g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_EXISTS, "already exists");
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
+					    "already exists");
 			break;
 		case HIDPP_ERR_BUSY:
-			g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "busy");
+			g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "busy");
 			break;
 		case HIDPP_ERR_UNKNOWN_DEVICE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "unknown device");
 			break;
 		case HIDPP_ERR_RESOURCE_ERROR:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_HOST_UNREACHABLE,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "resource error");
 			break;
 		case HIDPP_ERR_REQUEST_UNAVAILABLE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_EXISTS,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "request not valid in current context");
 			break;
 		case HIDPP_ERR_INVALID_PARAM_VALUE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "request parameter has unsupported value");
 			break;
 		case HIDPP_ERR_WRONG_PIN_CODE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_CONNECTION_REFUSED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_AUTH_FAILED,
 					    "the pin code was wrong");
 			break;
 		default:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
 					    "generic failure");
 		}
 		return FALSE;
@@ -158,48 +161,48 @@ fu_logitech_hidpp_msg_is_error(FuLogitechHidppHidppMsg *msg, GError **error)
 		switch (msg->data[1]) {
 		case HIDPP_ERROR_CODE_INVALID_ARGUMENT:
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "Invalid argument 0x%02x",
 				    msg->data[2]);
 			break;
 		case HIDPP_ERROR_CODE_OUT_OF_RANGE:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "out of range");
 			break;
 		case HIDPP_ERROR_CODE_HW_ERROR:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_BROKEN_PIPE,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "hardware error");
 			break;
 		case HIDPP_ERROR_CODE_INVALID_FEATURE_INDEX:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_ARGUMENT,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "invalid feature index");
 			break;
 		case HIDPP_ERROR_CODE_INVALID_FUNCTION_ID:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_ARGUMENT,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "invalid function ID");
 			break;
 		case HIDPP_ERROR_CODE_BUSY:
-			g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "busy");
+			g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "busy");
 			break;
 		case HIDPP_ERROR_CODE_UNSUPPORTED:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "unsupported");
 			break;
 		default:
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
 					    "generic failure");
 			break;
 		}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-hidpp.c
@@ -121,8 +121,8 @@ fu_logitech_hidpp_receive(FuIOChannel *io_channel,
 	fu_dump_raw(G_LOG_DOMAIN, "device->host", (guint8 *)msg, read_size);
 	if (read_size < fu_logitech_hidpp_msg_get_payload_length(msg)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "message length too small, "
 			    "got %" G_GSIZE_FORMAT " expected %" G_GSIZE_FORMAT,
 			    read_size,
@@ -219,8 +219,8 @@ fu_logitech_hidpp_transfer(FuIOChannel *io_channel, FuLogitechHidppHidppMsg *msg
 		/* hardware not responding */
 		if (ignore_cnt++ > 10) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "too many messages to ignore");
 			return FALSE;
 		}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-bolt.c
@@ -293,7 +293,7 @@ fu_logitech_hidpp_runtime_bolt_poll(FuDevice *device, GError **error)
 					       msg,
 					       timeout,
 					       &error_local)) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT))
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT))
 				break;
 			g_propagate_prefixed_error(error,
 						   g_steal_pointer(&error_local),
@@ -465,7 +465,7 @@ fu_logitech_hidpp_runtime_bolt_setup(FuDevice *device, GError **error)
 		fu_device_sleep(device, 200); /* ms */
 		if (fu_logitech_hidpp_runtime_bolt_setup_internal(device, &error_local))
 			return TRUE;
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_DATA)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -145,7 +145,7 @@ fu_logitech_hidpp_runtime_unifying_setup(FuDevice *device, GError **error)
 		fu_device_sleep(device, 200); /* ms */
 		if (fu_logitech_hidpp_runtime_unifying_setup_internal(device, &error_local))
 			return TRUE;
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_DATA)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -89,7 +89,7 @@ fu_logitech_hidpp_runtime_poll(FuDevice *device, GError **error)
 	/* is there any pending data to read */
 	msg->hidpp_version = 1;
 	if (!fu_logitech_hidpp_receive(priv->io_channel, msg, timeout, &error_local)) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 			return TRUE;
 		}
 		g_warning("failed to get pending read: %s", error_local->message);
@@ -199,8 +199,8 @@ fu_logitech_hidpp_runtime_probe(FuDevice *device, GError **error)
 			    g_udev_device_get_property(udev_parent_usb_interface, "INTERFACE");
 			if (interface_str == NULL) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "INTERFACE property not found in parent device");
 				return FALSE;
 			}

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -44,8 +44,8 @@ fu_logitech_rallysystem_audio_device_set_feature(FuLogitechRallysystemAudioDevic
 #else
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -72,8 +72,8 @@ fu_logitech_rallysystem_audio_device_get_feature(FuLogitechRallysystemAudioDevic
 #else
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -61,8 +61,8 @@ fu_logitech_rallysystem_tablehub_device_probe(FuDevice *device, GError **error)
 	}
 	if (bulk_iface == G_MAXUINT8) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no bulk interface found");
 		return FALSE;
 	}
@@ -90,8 +90,8 @@ fu_logitech_rallysystem_tablehub_device_send(FuLogitechRallysystemTablehubDevice
 	}
 	if (bufsz != actual_length) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to send full packet using bulk transfer");
 		return FALSE;
 	}
@@ -120,8 +120,8 @@ fu_logitech_rallysystem_tablehub_device_recv(FuLogitechRallysystemTablehubDevice
 	}
 	if (bufsz != actual_length) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to receive full packet using bulk transfer");
 		return FALSE;
 	}
@@ -187,8 +187,8 @@ fu_logitech_rallysystem_tablehub_device_progress_cb(FuDevice *device,
 		return FALSE;
 	if (fu_struct_usb_progress_response_get_completed(st_res) != 100) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "percentage only %u%%",
 			    fu_struct_usb_progress_response_get_completed(st_res));
 		return FALSE;

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -96,7 +96,10 @@ fu_logitech_scribe_device_send(FuLogitechScribeDevice *self,
 	if (interface_id == BULK_INTERFACE_UPD) {
 		ep = self->update_ep[EP_OUT];
 	} else {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "interface is invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "interface is invalid");
 		return FALSE;
 	}
 	if (!g_usb_device_bulk_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(usb_device)),
@@ -128,7 +131,10 @@ fu_logitech_scribe_device_recv(FuLogitechScribeDevice *self,
 	if (interface_id == BULK_INTERFACE_UPD) {
 		ep = self->update_ep[EP_IN];
 	} else {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "interface is invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "interface is invalid");
 		return FALSE;
 	}
 	if (!g_usb_device_bulk_transfer(fu_usb_device_get_dev(FU_USB_DEVICE(usb_device)),
@@ -193,7 +199,11 @@ fu_logitech_scribe_device_send_upd_cmd(FuLogitechScribeDevice *self,
 				    error))
 		return FALSE;
 	if (cmd_tmp != CMD_ACK) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "not CMD_ACK, got %x", cmd);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "not CMD_ACK, got %x",
+			    cmd);
 		return FALSE;
 	}
 	if (!fu_memread_uint32_safe(buf_ack->data,
@@ -205,8 +215,8 @@ fu_logitech_scribe_device_send_upd_cmd(FuLogitechScribeDevice *self,
 		return FALSE;
 	if (cmd_tmp != cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid upd message received, expected %x, got %x",
 			    cmd,
 			    cmd_tmp);
@@ -437,8 +447,8 @@ fu_logitech_scribe_device_write_firmware(FuDevice *device,
 	usb_device = fu_usb_device_new(fu_device_get_context(device), g_usb_device);
 	if (usb_device == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to create usb device instance");
 		return FALSE;
 	}
@@ -460,8 +470,8 @@ fu_logitech_scribe_device_write_firmware(FuDevice *device,
 	endpoints = g_usb_interface_get_endpoints(intf);
 	if (endpoints == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to get usb device endpoints");
 		return FALSE;
 	}

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -186,8 +186,8 @@ fu_logitech_tap_hdmi_device_ait_initiate_update(FuLogitechTapHdmiDevice *self, G
 		return FALSE;
 	if (data_len > XU_INPUT_DATA_LEN) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "initiate query packet was too large at 0x%x bytes: ",
 			    data_len);
 		return FALSE;
@@ -203,8 +203,8 @@ fu_logitech_tap_hdmi_device_ait_initiate_update(FuLogitechTapHdmiDevice *self, G
 		return FALSE;
 	if (mmp_get_data[0] != kLogiDefaultAitSuccessValue) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to initialize AIT update, invalid result data: 0x%x",
 			    mmp_get_data[0]);
 		return FALSE;
@@ -260,8 +260,8 @@ fu_logitech_tap_hdmi_device_ait_finalize_update(FuLogitechTapHdmiDevice *self, G
 			break;
 		} else if (mmp_get_data[0] == kLogiDefaultAitFailureValue) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to finalize image burning, invalid result data: 0x%x",
 				    mmp_get_data[0]);
 			return FALSE;
@@ -269,8 +269,8 @@ fu_logitech_tap_hdmi_device_ait_finalize_update(FuLogitechTapHdmiDevice *self, G
 		if (duration_ms > kLogiDefaultAitFinalizeMaxPollingDurationMs) {
 			/* if device never returns 0x82 or 0x00, bail out */
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to finalize image burning, duration_ms: %u",
 				    duration_ms);
 			return FALSE;
@@ -400,8 +400,8 @@ fu_logitech_tap_hdmi_device_set_version(FuLogitechTapHdmiDevice *self, GError **
 		return FALSE;
 	if (bufsz > XU_INPUT_DATA_LEN) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "version query packet was too large at 0x%x bytes: ",
 			    bufsz);
 		return FALSE;

--- a/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
@@ -73,8 +73,8 @@ fu_logitech_tap_sensor_device_set_feature(FuLogitechTapSensorDevice *self,
 #else
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -113,8 +113,8 @@ fu_logitech_tap_sensor_device_get_feature(FuLogitechTapSensorDevice *self,
 #else
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -177,8 +177,8 @@ fu_mediatek_scaler_device_ddc_read(FuMediatekScalerDevice *self, GByteArray *st_
 	/* verify read buffer: [0] == source address */
 	if (buf[0] != FU_DDC_I2C_ADDR_DISPLAY_DEVICE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid read buffer: addr(src) expected 0x%02x, got 0x%02x.",
 			    (guint)FU_DDC_I2C_ADDR_DISPLAY_DEVICE,
 			    buf[0]);
@@ -188,8 +188,8 @@ fu_mediatek_scaler_device_ddc_read(FuMediatekScalerDevice *self, GByteArray *st_
 	/* verify read buffer: [1] as the length of data */
 	if (buf[1] <= DDC_DATA_LEN_DFT) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid read buffer: size 0x%02x must greater than 0x%02x.",
 			    buf[1],
 			    (guint)DDC_DATA_LEN_DFT);
@@ -200,8 +200,8 @@ fu_mediatek_scaler_device_ddc_read(FuMediatekScalerDevice *self, GByteArray *st_
 	report_data_sz = buf[1] - DDC_DATA_LEN_DFT;
 	if (report_data_sz + 3 > sizeof(buf)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid read buffer: size 0x%02x exceeded 0x%02x",
 			    (guint)report_data_sz,
 			    (guint)sizeof(buf));
@@ -216,8 +216,8 @@ fu_mediatek_scaler_device_ddc_read(FuMediatekScalerDevice *self, GByteArray *st_
 		return NULL;
 	if (checksum_hw != checksum) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid read buffer, checksum expected 0x%02x, got 0x%02x.",
 			    checksum,
 			    checksum_hw);
@@ -430,8 +430,8 @@ fu_mediatek_scaler_device_verify_controller_type(FuMediatekScalerDevice *self, G
 	/* restrict to specific controller type */
 	if (controller_type != FU_MEDIATEK_SCALER_SUPPORTED_CONTROLLER_TYPE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "0x%x is not supported",
 			    controller_type);
 		return FALSE;
@@ -508,8 +508,8 @@ fu_mediatek_scaler_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	if (!fu_device_has_private_flag(device, FU_MEDIATEK_SCALER_DEVICE_FLAG_PROBE_VCP)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "%04X:%04X: is not supported",
 			    fu_udev_device_get_subsystem_vendor(udev_parent),
 			    fu_udev_device_get_subsystem_model(udev_parent));
@@ -721,7 +721,7 @@ fu_mediatek_scaler_device_set_isp_reboot(FuMediatekScalerDevice *self, GError **
 	/* device will reboot after this, so the write will timed out fail */
 	fu_struct_ddc_cmd_set_vcp_code(st_req, FU_DDC_VCP_CODE_REBOOT);
 	if (!fu_mediatek_scaler_device_ddc_write(self, st_req, &error_local)) {
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 			g_propagate_prefixed_error(error,
 						   g_steal_pointer(&error_local),
 						   "failed to set isp reboot: ");

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -110,9 +110,9 @@ validate_program_action(XbNode *program, FuArchive *archive, GError **error)
 	filename_attr = xb_node_get_attr(program, "filename");
 	if (filename_attr == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Missing 'filename' attribute in 'program' action");
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "missing 'filename' attribute in 'program' action");
 		return FALSE;
 	}
 
@@ -127,9 +127,9 @@ validate_program_action(XbNode *program, FuArchive *archive, GError **error)
 	num_partition_sectors = xb_node_get_attr_as_uint(program, "num_partition_sectors");
 	if (num_partition_sectors == G_MAXUINT64) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Missing 'num_partition_sectors' attribute in 'program' action for "
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "missing 'num_partition_sectors' attribute in 'program' action for "
 			    "filename '%s'",
 			    filename_attr);
 		return FALSE;
@@ -137,9 +137,9 @@ validate_program_action(XbNode *program, FuArchive *archive, GError **error)
 	sector_size_in_bytes = xb_node_get_attr_as_uint(program, "SECTOR_SIZE_IN_BYTES");
 	if (sector_size_in_bytes == G_MAXUINT64) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Missing 'SECTOR_SIZE_IN_BYTES' attribute in 'program' action for "
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "missing 'SECTOR_SIZE_IN_BYTES' attribute in 'program' action for "
 			    "filename '%s'",
 			    filename_attr);
 		return FALSE;
@@ -152,9 +152,9 @@ validate_program_action(XbNode *program, FuArchive *archive, GError **error)
 	if (computed_num_partition_sectors != num_partition_sectors) {
 		g_set_error(
 		    error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
-		    "Invalid 'num_partition_sectors' in 'program' action for filename '%s': "
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INVALID_DATA,
+		    "invalid 'num_partition_sectors' in 'program' action for filename '%s': "
 		    "expected %" G_GUINT64_FORMAT " instead of %" G_GUINT64_FORMAT " bytes",
 		    filename_attr,
 		    computed_num_partition_sectors,
@@ -189,7 +189,7 @@ fu_firehose_validate_rawprogram(GBytes *rawprogram,
 	data_node = xb_silo_get_root(silo);
 	action_nodes = xb_node_get_children(data_node);
 	if (action_nodes == NULL || action_nodes->len == 0) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "No actions given");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no actions given");
 		return FALSE;
 	}
 
@@ -230,10 +230,10 @@ fu_firehose_updater_open(FuFirehoseUpdater *self, GError **error)
 		return self->io_channel != NULL;
 	}
 
-	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
-		    "No device to write firehose commands to");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "no device to write firehose commands to");
 	return FALSE;
 }
 
@@ -281,7 +281,10 @@ fu_firehose_updater_process_response(GBytes *rsp_bytes,
 
 	data_node = xb_silo_get_root(silo);
 	if (data_node == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Missing root data node");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "missing root data node");
 		return FALSE;
 	}
 
@@ -377,9 +380,9 @@ fu_firehose_updater_send_and_receive(FuFirehoseUpdater *self,
 	}
 
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_TIMED_OUT,
-		    "Didn't get any response in the last %d messages",
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
+		    "didn't get any response in the last %d messages",
 		    MAX_RECV_MESSAGES);
 	return FALSE;
 }
@@ -408,9 +411,9 @@ fu_firehose_updater_initialize(FuFirehoseUpdater *self, GError **error)
 
 	if (n_msg == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Couldn't read initial firehose messages from device");
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "couldn't read initial firehose messages from device");
 		return FALSE;
 	}
 
@@ -478,7 +481,10 @@ fu_firehose_updater_configure(FuFirehoseUpdater *self, GError **error)
 		return max_payload_size;
 	}
 
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Configure operation failed");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "configure operation failed");
 	return 0;
 }
 
@@ -503,7 +509,10 @@ fu_firehose_updater_reset(FuFirehoseUpdater *self, GError **error)
 	}
 
 	if (!fu_firehose_updater_check_operation_result(rsp_node, NULL)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Reset operation failed");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "reset operation failed");
 		return FALSE;
 	}
 
@@ -599,9 +608,9 @@ fu_firehose_updater_actions_validate(GPtrArray *action_nodes,
 		program_file = xb_node_get_data(node, name);
 		if (program_file == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "Failed to validate program file: failed to get %s",
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "failed to validate program file: failed to get %s",
 				    name);
 			return FALSE;
 		}
@@ -609,9 +618,9 @@ fu_firehose_updater_actions_validate(GPtrArray *action_nodes,
 		program_filename = xb_node_get_attr(node, name);
 		if (program_filename == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "Failed to validate program file: failed to get %s",
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "failed to validate program file: failed to get %s",
 				    name);
 			return FALSE;
 		}
@@ -619,9 +628,9 @@ fu_firehose_updater_actions_validate(GPtrArray *action_nodes,
 		program_sector_size_in_bytes = xb_node_get_attr_as_uint(node, name);
 		if (program_sector_size_in_bytes > max_payload_size) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "Failed to validate program file '%s' command: "
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "failed to validate program file '%s' command: "
 				    "requested sector size bigger (%" G_GUINT64_FORMAT " bytes) "
 				    "than maximum payload size agreed with device (%u bytes)",
 				    program_filename,
@@ -684,9 +693,9 @@ fu_firehose_updater_run_action_program(FuFirehoseUpdater *self,
 
 	if (rawmode == FALSE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Failed to download program file '%s': rawmode not enabled",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to download program file '%s': rawmode not enabled",
 			    program_filename);
 		return FALSE;
 	}
@@ -694,7 +703,10 @@ fu_firehose_updater_run_action_program(FuFirehoseUpdater *self,
 	while ((payload_size + (guint)program_sector_size) <= max_payload_size)
 		payload_size += (guint)program_sector_size;
 	if (payload_size == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "payload size invalid");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "payload size invalid");
 		return FALSE;
 	}
 
@@ -707,32 +719,32 @@ fu_firehose_updater_run_action_program(FuFirehoseUpdater *self,
 						   payload_size,
 						   program_sector_size,
 						   error)) {
-		g_prefix_error(error, "Failed to send program file '%s': ", program_filename);
+		g_prefix_error(error, "failed to send program file '%s': ", program_filename);
 		return FALSE;
 	}
 
 	g_debug("waiting for program file download confirmation...");
 	if (!fu_firehose_updater_send_and_receive(self, NULL, &rsp_silo, &rsp_node, error)) {
 		g_prefix_error(error,
-			       "Download confirmation not received for file '%s': ",
+			       "download confirmation not received for file '%s': ",
 			       program_filename);
 		return FALSE;
 	}
 
 	if (!fu_firehose_updater_check_operation_result(rsp_node, &rawmode)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Download confirmation failed for file '%s'",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "download confirmation failed for file '%s'",
 			    program_filename);
 		return FALSE;
 	}
 
 	if (rawmode != FALSE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Download confirmation failed for file '%s': rawmode still enabled",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "download confirmation failed for file '%s': rawmode still enabled",
 			    program_filename);
 		return FALSE;
 	}
@@ -770,12 +782,16 @@ fu_firehose_updater_run_action(FuFirehoseUpdater *self,
 						  &rsp_silo,
 						  &rsp_node,
 						  error)) {
-		g_prefix_error(error, "Failed to run command '%s': ", action);
+		g_prefix_error(error, "failed to run command '%s': ", action);
 		return FALSE;
 	}
 
 	if (!fu_firehose_updater_check_operation_result(rsp_node, &rawmode)) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "Command '%s' failed", action);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "command '%s' failed",
+			    action);
 		return FALSE;
 	}
 

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -356,8 +356,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_sysfs_path = g_steal_pointer(&qmi_device_sysfs_path);
 		} else if (g_strcmp0(device_sysfs_path, qmi_device_sysfs_path) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device sysfs path: %s != %s",
 				    device_sysfs_path,
 				    qmi_device_sysfs_path);
@@ -367,8 +367,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_bus = g_steal_pointer(&qmi_device_bus);
 		} else if (g_strcmp0(device_bus, qmi_device_bus) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device bus: %s != %s",
 				    device_bus,
 				    qmi_device_bus);
@@ -387,8 +387,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_sysfs_path = g_steal_pointer(&mbim_device_sysfs_path);
 		} else if (g_strcmp0(device_sysfs_path, mbim_device_sysfs_path) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device sysfs path: %s != %s",
 				    device_sysfs_path,
 				    mbim_device_sysfs_path);
@@ -398,8 +398,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_bus = g_steal_pointer(&mbim_device_bus);
 		} else if (g_strcmp0(device_bus, mbim_device_bus) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device bus: %s != %s",
 				    device_bus,
 				    mbim_device_bus);
@@ -419,8 +419,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_sysfs_path = g_steal_pointer(&qcdm_device_sysfs_path);
 		} else if (g_strcmp0(device_sysfs_path, qcdm_device_sysfs_path) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device sysfs path: %s != %s",
 				    device_sysfs_path,
 				    qcdm_device_sysfs_path);
@@ -430,8 +430,8 @@ fu_mm_device_probe_default(FuDevice *device, GError **error)
 			device_bus = g_steal_pointer(&qcdm_device_bus);
 		} else if (g_strcmp0(device_bus, qcdm_device_bus) != 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "mismatched device bus: %s != %s",
 				    device_bus,
 				    qcdm_device_bus);
@@ -1683,7 +1683,10 @@ fu_mm_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *value
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/modem-manager/fu-mm-utils.c
+++ b/plugins/modem-manager/fu-mm-utils.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#include <gio/gio.h>
+#include <fwupd.h>
 
 #include "fu-mm-utils.h"
 
@@ -55,8 +55,8 @@ fu_mm_utils_get_udev_port_info(GUdevDevice *device,
 	device_bus = find_device_bus_subsystem(device);
 	if (device_bus == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to lookup device info: bus not found");
 		return FALSE;
 	}
@@ -102,8 +102,8 @@ fu_mm_utils_get_udev_port_info(GUdevDevice *device,
 	} else {
 		/* other subsystems, we don't support firmware upgrade for those */
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "device bus unsupported: %s",
 			    device_bus);
 		return FALSE;
@@ -111,8 +111,8 @@ fu_mm_utils_get_udev_port_info(GUdevDevice *device,
 
 	if (device_sysfs_path == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to lookup device info: physical device not found");
 		return FALSE;
 	}
@@ -140,8 +140,8 @@ fu_mm_utils_get_port_info(const gchar *path,
 	dev = g_udev_client_query_by_device_file(client, path);
 	if (dev == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to lookup device by path");
 		return FALSE;
 	}
@@ -179,8 +179,8 @@ fu_mm_utils_find_device_file(const gchar *device_sysfs_path,
 
 	if (device_file == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to find %s port in device %s",
 			    subsystem,
 			    device_sysfs_path);

--- a/plugins/modem-manager/fu-qmi-pdc-updater.c
+++ b/plugins/modem-manager/fu-qmi-pdc-updater.c
@@ -269,8 +269,8 @@ fu_qmi_pdc_updater_load_config_timeout(gpointer user_data)
 	ctx->indication_id = 0;
 
 	g_set_error_literal(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
 			    "couldn't load mcfg: timed out");
 	g_main_loop_quit(ctx->mainloop);
 
@@ -310,8 +310,8 @@ fu_qmi_pdc_updater_load_config_indication(QmiClientPdc *client,
 		}
 
 		g_set_error(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "couldn't load mcfg: %s",
 			    qmi_protocol_error_get_string((QmiProtocolError)error_code));
 		g_main_loop_quit(ctx->mainloop);
@@ -321,8 +321,8 @@ fu_qmi_pdc_updater_load_config_indication(QmiClientPdc *client,
 	if (qmi_indication_pdc_load_config_output_get_frame_reset(output, &frame_reset, NULL) &&
 	    frame_reset) {
 		g_set_error(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "couldn't load mcfg: sent data discarded");
 		g_main_loop_quit(ctx->mainloop);
 		return;
@@ -518,8 +518,8 @@ fu_qmi_pdc_updater_activate_config_indication(QmiClientPdc *client,
 
 	if (error_code != 0) {
 		g_set_error(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "couldn't activate config: %s",
 			    qmi_protocol_error_get_string((QmiProtocolError)error_code));
 		g_main_loop_quit(ctx->mainloop);
@@ -607,8 +607,8 @@ fu_qmi_pdc_updater_set_selected_config_timeout(gpointer user_data)
 	ctx->indication_id = 0;
 
 	g_set_error_literal(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
 			    "couldn't set selected config: timed out");
 	g_main_loop_quit(ctx->mainloop);
 
@@ -636,8 +636,8 @@ fu_qmi_pdc_updater_set_selected_config_indication(QmiClientPdc *client,
 
 	if (error_code != 0) {
 		g_set_error(&ctx->error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "couldn't set selected config: %s",
 			    qmi_protocol_error_get_string((QmiProtocolError)error_code));
 		g_main_loop_quit(ctx->mainloop);

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -126,9 +126,9 @@ fu_sahara_loader_find_interface(FuSaharaLoader *self, FuUsbDevice *usb_device, G
 	if (g_usb_device_get_vid(g_usb_device) != 0x05c6 ||
 	    g_usb_device_get_pid(g_usb_device) != 0x9008) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Wrong device and/or vendor id: 0x%04x 0x%04x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "wrong device and/or vendor id: 0x%04x 0x%04x",
 			    g_usb_device_get_vid(g_usb_device),
 			    g_usb_device_get_pid(g_usb_device));
 		return FALSE;
@@ -234,7 +234,7 @@ fu_sahara_loader_qdl_read(FuSaharaLoader *self, GError **error)
 
 	return g_steal_pointer(&buf);
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "GUsb not supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "GUsb not supported");
 	return NULL;
 #endif
 }
@@ -267,8 +267,8 @@ fu_sahara_loader_qdl_write(FuSaharaLoader *self, const guint8 *data, gsize sz, G
 		}
 		if (actual_len != fu_chunk_get_data_sz(chk)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "only wrote %" G_GSIZE_FORMAT "bytes",
 				    actual_len);
 			return FALSE;
@@ -291,7 +291,7 @@ fu_sahara_loader_qdl_write(FuSaharaLoader *self, const guint8 *data, gsize sz, G
 
 	return TRUE;
 #else
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "GUsb not supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "GUsb not supported");
 	return FALSE;
 #endif
 }
@@ -415,9 +415,9 @@ fu_sahara_loader_send_reset_packet(FuSaharaLoader *self, GError **error)
 	if (rx_packet == NULL ||
 	    sahara_packet_get_command_id(rx_packet) != SAHARA_RESET_RESPONSE_ID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Failed to receive RESET_RESPONSE packet");
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "failed to receive RESET_RESPONSE packet");
 		return FALSE;
 	}
 
@@ -446,9 +446,9 @@ fu_sahara_loader_wait_hello_rsp(FuSaharaLoader *self, GError **error)
 
 	if (sahara_packet_get_command_id(rx_packet) != SAHARA_HELLO_ID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Received a different packet while waiting for the HELLO packet");
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "received a different packet while waiting for the HELLO packet");
 		fu_sahara_loader_send_reset_packet(self, NULL);
 		return FALSE;
 	}
@@ -481,9 +481,9 @@ fu_sahara_loader_run(FuSaharaLoader *self, GBytes *prog, GError **error)
 			break;
 		if (rx_packet->len != sahara_packet_get_length(rx_packet)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
-				    "Received packet length is not matching");
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "received packet length is not matching");
 			break;
 		}
 		fu_dump_raw(G_LOG_DOMAIN, "rx_packet", rx_packet->data, rx_packet->len);

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -636,8 +636,8 @@ fu_msr_plugin_modify_config(FuPlugin *plugin, const gchar *key, const gchar *val
 	const gchar *keys[] = {"MinimumSmeKernelVersion", NULL};
 	if (!g_strv_contains(keys, key)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "config key %s not supported",
 			    key);
 		return FALSE;

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -164,7 +164,7 @@ fu_mtd_device_open(FuDevice *device, GError **error)
 
 	/* FuUdevDevice->open */
 	if (!FU_DEVICE_CLASS(fu_mtd_device_parent_class)->open(device, &error_local)) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_PERMISSION_DENIED)) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED,
@@ -199,7 +199,7 @@ fu_mtd_device_probe(FuDevice *device, GError **error)
 						  "flags",
 						  &flags,
 						  &error_local)) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_SUPPORTED,
@@ -523,7 +523,10 @@ fu_mtd_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -62,8 +62,8 @@ nitrokey_execute_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 	memcpy(&res, buf, sizeof(buf));
 	if (GUINT32_FROM_LE(res.last_command_crc) != crc_tmp) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got response CRC %x, expected %x",
 			    GUINT32_FROM_LE(res.last_command_crc),
 			    crc_tmp);
@@ -74,8 +74,8 @@ nitrokey_execute_cmd_cb(FuDevice *device, gpointer user_data, GError **error)
 	crc_tmp = fu_nitrokey_perform_crc32(buf, sizeof(res) - 4);
 	if (GUINT32_FROM_LE(res.crc) != crc_tmp) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got packet CRC %x, expected %x",
 			    GUINT32_FROM_LE(res.crc),
 			    crc_tmp);

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -145,8 +145,8 @@ fu_nordic_hid_cfg_channel_get_udev_device(FuNordicHidCfgChannel *self, GError **
 	/* parent */
 	if (self->parent_udev == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no parent for peer 0x%02x",
 			    self->peer_id);
 		return NULL;
@@ -177,8 +177,8 @@ fu_nordic_hid_cfg_channel_send(FuNordicHidCfgChannel *self,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -334,8 +334,8 @@ fu_nordic_hid_cfg_channel_cmd_send_by_id(FuNordicHidCfgChannel *self,
 	if (data != NULL) {
 		if (data_len > REPORT_DATA_MAX_LEN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "requested to send %d bytes, while maximum is %d",
 				    data_len,
 				    REPORT_DATA_MAX_LEN);
@@ -680,8 +680,8 @@ fu_nordic_hid_cfg_channel_update_peers(FuNordicHidCfgChannel *self,
 
 	if (peer_id != INVALID_PEER_ID) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_BROKEN_PIPE,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "too many peers detected");
 		return FALSE;
 	}
@@ -1110,8 +1110,8 @@ fu_nordic_hid_cfg_channel_dfu_reboot(FuNordicHidCfgChannel *self, GError **error
 		return FALSE;
 	if (res->data_len != 1 || res->data[0] != 0x01) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "reboot data was invalid");
 		return FALSE;
 	}
@@ -1149,8 +1149,8 @@ fu_nordic_hid_cfg_channel_dfu_sync_cb(FuDevice *device, gpointer user_data, GErr
 		}
 		if (recv_msg->data_len != 0x0F) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "incorrect length of reply");
 			return FALSE;
 		}
@@ -1248,8 +1248,8 @@ fu_nordic_hid_cfg_channel_dfu_start(FuNordicHidCfgChannel *self,
 	/* sanity check */
 	if (img_length > G_MAXUINT32) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "payload was too large");
 		return FALSE;
 	}
@@ -1642,8 +1642,8 @@ fu_nordic_hid_cfg_channel_set_quirk_kv(FuDevice *device,
 	if (g_strcmp0(key, "NordicHidBootloader") == 0) {
 		if (g_strcmp0(value, "B0") != 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "can be only 'B0' in quirk");
 			return FALSE;
 		}
@@ -1654,8 +1654,8 @@ fu_nordic_hid_cfg_channel_set_quirk_kv(FuDevice *device,
 	if (g_strcmp0(key, "NordicHidGeneration") == 0) {
 		if (g_strcmp0(value, "default") != 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "can be only 'default' in quirk");
 			return FALSE;
 		}
@@ -1664,7 +1664,10 @@ fu_nordic_hid_cfg_channel_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -30,8 +30,8 @@ fu_nordic_hid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kin
 	FuNordicHidFirmwarePrivate *priv = GET_PRIVATE(self);
 	if (!fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "unable to calculate the checksum of the update binary");
 		return NULL;
 	}

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -216,8 +216,8 @@ fu_nvme_device_parse_cns(FuNvmeDevice *self, const guint8 *buf, gsize sz, GError
 	/* wrong size */
 	if (sz != FU_NVME_ID_CTRL_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to parse blob, expected 0x%04x bytes",
 			    (guint)FU_NVME_ID_CTRL_SIZE);
 		return FALSE;
@@ -443,7 +443,10 @@ fu_nvme_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 		return TRUE;
 	}
 
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -262,8 +262,8 @@ fu_parade_lspcon_poll_register(FuParadeLspconDevice *self,
 	} while (g_timer_elapsed(timer, NULL) <= 10.0);
 
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_TIMED_OUT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
 		    "register %x did not read %x (mask %x) within 10 seconds: read %x",
 		    register_address,
 		    expected,
@@ -397,8 +397,8 @@ fu_parade_lspcon_flash_wait_ready(FuParadeLspconDevice *self, GError **error)
 	} while (g_timer_elapsed(timer, NULL) <= 10.0);
 
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_TIMED_OUT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
 			    "flash did not become ready within 10 seconds");
 	return FALSE;
 }

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -84,8 +84,8 @@ fu_mei_parse_fwvers(FuPlugin *plugin, const gchar *fwvers, GError **error)
 	lines = g_strsplit(fwvers, "\n", -1);
 	if (g_strv_length(lines) < 1) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "expected data, got %s",
 			    fwvers);
 		return FALSE;
@@ -95,8 +95,8 @@ fu_mei_parse_fwvers(FuPlugin *plugin, const gchar *fwvers, GError **error)
 	sections = g_strsplit(lines[0], ":", -1);
 	if (g_strv_length(sections) != 2) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "expected platform:major.minor.micro.build, got %s",
 			    lines[0]);
 		return FALSE;
@@ -111,8 +111,8 @@ fu_mei_parse_fwvers(FuPlugin *plugin, const gchar *fwvers, GError **error)
 	split = g_strsplit(sections[1], ".", -1);
 	if (g_strv_length(split) != 4) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "expected major.minor.micro.build, got %s",
 			    sections[1]);
 		return FALSE;

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -166,8 +166,8 @@ fu_pxi_ble_device_set_feature(FuPxiBleDevice *self, GByteArray *req, GError **er
 			       error);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -199,8 +199,8 @@ fu_pxi_ble_device_get_feature(FuPxiBleDevice *self, guint8 *buf, guint bufsz, GE
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -347,8 +347,8 @@ fu_pxi_ble_device_check_support_report_id(FuPxiBleDevice *self, GError **error)
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE
 #endif
@@ -832,8 +832,8 @@ fu_pxi_ble_device_fw_get_info(FuPxiBleDevice *self, GError **error)
 		return FALSE;
 	if (opcode != FU_PXI_DEVICE_CMD_FW_GET_INFO) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "FwGetInfo opcode invalid 0x%02x",
 			    opcode);
 		return FALSE;

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -107,8 +107,8 @@ fu_pxi_firmware_parse(FuFirmware *firmware,
 	if (fu_pxi_firmware_is_hpac(self)) {
 		if (streamsz < PIXART_RF_FW_HEADER_HPAC_VERSION_POS_FROM_END) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "image is too small");
 			return FALSE;
 		}
@@ -125,8 +125,8 @@ fu_pxi_firmware_parse(FuFirmware *firmware,
 	} else {
 		if (streamsz < sizeof(fw_header)) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "image is too small");
 			return FALSE;
 		}
@@ -249,8 +249,8 @@ fu_pxi_firmware_write(FuFirmware *firmware, GError **error)
 	if (!g_ascii_isdigit(fw_header[0]) || !g_ascii_isdigit(fw_header[2]) ||
 	    !g_ascii_isdigit(fw_header[4])) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot write invalid version number 0x%x",
 			    (guint)version_raw);
 		return NULL;

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -102,8 +102,8 @@ fu_pxi_receiver_device_set_feature(FuPxiReceiverDevice *self,
 				    error);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -128,8 +128,8 @@ fu_pxi_receiver_device_get_feature(FuPxiReceiverDevice *self,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -806,8 +806,8 @@ fu_pxi_receiver_device_add_peripherals(FuPxiReceiverDevice *device, guint idx, G
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -839,8 +839,8 @@ fu_pxi_receiver_device_setup_guid(FuPxiReceiverDevice *device, GError **error)
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -101,8 +101,8 @@ fu_pxi_wireless_device_set_feature(FuDevice *self, const guint8 *buf, guint bufs
 				    error);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif
@@ -124,8 +124,8 @@ fu_pxi_wireless_device_get_feature(FuDevice *self, guint8 *buf, guint bufsz, GEr
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "<linux/hidraw.h> not available");
 	return FALSE;
 #endif

--- a/plugins/qsi-dock/fu-qsi-dock-child-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-child-device.c
@@ -38,7 +38,7 @@ fu_qsi_dock_mcu_device_prepare_firmware(FuDevice *device,
 {
 	FuDevice *parent = fu_device_get_parent(device);
 	if (parent == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no parent");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return NULL;
 	}
 	return fu_device_prepare_firmware(parent, stream, flags, error);
@@ -55,7 +55,7 @@ fu_qsi_dock_mcu_device_write_firmware(FuDevice *device,
 	FuQsiDockChildDevice *self = FU_QSI_DOCK_CHILD_DEVICE(device);
 	FuDevice *parent = fu_device_get_parent(device);
 	if (parent == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no parent");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return FALSE;
 	}
 	return fu_qsi_dock_mcu_device_write_firmware_with_idx(FU_QSI_DOCK_MCU_DEVICE(parent),

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -348,8 +348,8 @@ mst_poll_register(FuRealtekMstDevice *self,
 		return TRUE;
 
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_TIMED_OUT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
 		    "register %x still reads %x after %us, wanted %x (mask %x)",
 		    address,
 		    value,

--- a/plugins/redfish/fu-redfish-common.c
+++ b/plugins/redfish/fu-redfish-common.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <fwupd.h>
+
 #include "fu-redfish-common.h"
 
 gchar *
@@ -93,26 +95,29 @@ fu_redfish_common_parse_version_lenovo(const gchar *version,
 
 	/* sanity check */
 	if (g_strv_length(versplit) != 2) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not two sections");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "not two sections");
 		return FALSE;
 	}
 	if (strlen(versplit[0]) != 3) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid length first section");
 		return FALSE;
 	}
 
 	/* milestone */
 	if (!g_ascii_isdigit(versplit[0][0]) || !g_ascii_isdigit(versplit[0][1])) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "milestone number invalid");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "milestone number invalid");
 		return FALSE;
 	}
 
 	/* build is only one letter from A -> Z */
 	if (!g_ascii_isalpha(versplit[0][2])) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "build letter invalid");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "build letter invalid");
 		return FALSE;
 	}
 

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -244,8 +244,8 @@ fu_redfish_device_set_version_lenovo(FuRedfishDevice *self, const gchar *version
 	priv->milestone = g_ascii_strtoull(out_build, NULL, 10);
 	if (priv->milestone == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "version milestone invalid");
 		return FALSE;
 	}
@@ -257,7 +257,7 @@ fu_redfish_device_set_version_lenovo(FuRedfishDevice *self, const gchar *version
 
 	/* build is only one letter from A -> Z */
 	if (!g_ascii_isalpha(out_build[2])) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "build letter invalid");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "build letter invalid");
 		return FALSE;
 	}
 	priv->build = g_strndup(out_build + 2, 1);
@@ -705,7 +705,7 @@ fu_redfish_device_poll_task_once(FuRedfishDevice *self, FuRedfishDevicePollCtx *
 		return TRUE;
 	}
 	if (g_strcmp0(state_tmp, "Cancelled") == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_CANCELLED, "Task was cancelled");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "Task was cancelled");
 		return FALSE;
 	}
 	if (g_strcmp0(state_tmp, "Exception") == 0 ||

--- a/plugins/redfish/fu-redfish-network-device.c
+++ b/plugins/redfish/fu-redfish-network-device.c
@@ -41,8 +41,8 @@ fu_redfish_network_device_get_state(FuRedfishNetworkDevice *self,
 	retval = g_dbus_proxy_get_cached_property(proxy, "State");
 	if (retval == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_CONNECTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find State");
 		return FALSE;
 	}
@@ -100,8 +100,8 @@ fu_redfish_network_device_connect(FuRedfishNetworkDevice *self, GError **error)
 
 	/* timed out */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_TIMED_OUT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_TIMED_OUT,
 			    "could not activate connection");
 	return FALSE;
 }
@@ -132,8 +132,8 @@ fu_redfish_network_device_get_address(FuRedfishNetworkDevice *self, GError **err
 	ip4_config = g_dbus_proxy_get_cached_property(proxy, "Ip4Config");
 	if (ip4_config == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_CONNECTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find IPv4 config");
 		return NULL;
 	}
@@ -156,8 +156,8 @@ fu_redfish_network_device_get_address(FuRedfishNetworkDevice *self, GError **err
 	}
 	if (address == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_CONNECTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find IP address for device");
 		return NULL;
 	}

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -85,7 +85,10 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 		if (vid == helper->vid && pid == helper->pid)
 			helper->device = fu_redfish_network_device_new(object_path);
 #else
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no UDev support");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no UDev support");
 		return FALSE;
 #endif
 	}

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -653,8 +653,8 @@ fu_redfish_plugin_modify_config(FuPlugin *plugin,
 			       NULL};
 	if (!g_strv_contains(keys, key)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "config key %s not supported",
 			    key);
 		return FALSE;

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -103,7 +103,7 @@ fu_test_redfish_ipmi_func(void)
 
 	/* create device */
 	locker = fu_device_locker_new(device, &error);
-	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_PERMISSION_DENIED)) {
+	if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_PERMISSION_DENIED)) {
 		g_test_skip("permission denied for access to IPMI hardware");
 		return;
 	}

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -197,7 +197,10 @@ fu_rts54hid_module_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -215,8 +215,8 @@ fu_rts54hub_device_write_flash(FuRts54HubDevice *self,
 	}
 	if (actual_len != datasz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only wrote %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;
@@ -249,7 +249,7 @@ fu_rts54hub_device_read_flash (FuRts54HubDevice *self,
 		return FALSE;
 	}
 	if (actual_len != datasz) {
-		g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA,
 			     "only read %" G_GSIZE_FORMAT "bytes", actual_len);
 		return FALSE;
 	}
@@ -358,8 +358,8 @@ fu_rts54hub_device_ensure_status(FuRts54HubDevice *self, GError **error)
 	}
 	if (actual_len != FU_RTS54HUB_DEVICE_STATUS_LEN) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only read %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -243,8 +243,8 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	}
 	if (read_buf[0] != ISP_STATUS_IDLE_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed project ID with error 0x%02x: ",
 			    read_buf[0]);
 		return FALSE;

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-device.c
@@ -82,7 +82,10 @@ fu_rts54hub_rtd21xx_device_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -290,8 +290,8 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	}
 	if (read_buf[0] != ISP_STATUS_IDLE_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed project ID with error 0x%02x: ",
 			    read_buf[0]);
 		return FALSE;

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -185,9 +185,9 @@ fu_scsi_device_send_scsi_cmd_v3(FuScsiDevice *self,
 
 	if (io_hdr.status) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
-			    "Command fail with status %x, senseKey %s, asc 0x%02x, ascq 0x%02x",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "command fail with status %x, senseKey %s, asc 0x%02x, ascq 0x%02x",
 			    io_hdr.status,
 			    fu_scsi_sense_key_to_string(sense_buffer[2]),
 			    sense_buffer[12],

--- a/plugins/steelseries/fu-steelseries-device.c
+++ b/plugins/steelseries/fu-steelseries-device.c
@@ -57,8 +57,8 @@ fu_steelseries_device_cmd(FuSteelseriesDevice *self,
 	}
 	if (actual_len != datasz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only wrote %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;
@@ -85,8 +85,8 @@ fu_steelseries_device_cmd(FuSteelseriesDevice *self,
 	}
 	if (actual_len != priv->ep_in_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only read %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -32,8 +32,8 @@ fu_steelseries_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz < sizeof(checksum)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "image is too small");
 		return FALSE;
 	}

--- a/plugins/steelseries/fu-steelseries-fizz-hid.c
+++ b/plugins/steelseries/fu-steelseries-fizz-hid.c
@@ -58,7 +58,7 @@ fu_steelseries_fizz_hid_command_cb(FuDevice *device, gpointer user_data, GError 
 		/* since fu_udev_device_pread() treats unexpected data size as error
 		 * we have to check the output additionally since the size of
 		 * unexpected data size from mouse input data is only 16b */
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_FAILED) ||
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INTERNAL) ||
 		    report_id != 0x01) {
 			g_propagate_prefixed_error(error,
 						   g_steal_pointer(&error_local),
@@ -71,8 +71,8 @@ fu_steelseries_fizz_hid_command_cb(FuDevice *device, gpointer user_data, GError 
 
 	if (report_id != STEELSERIES_HID_GET_REPORT) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "data with unexpected Report ID (%u)",
 			    report_id);
 		return FALSE;

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -141,8 +141,8 @@ fu_steelseries_fizz_command_error_to_error(guint8 cmd, guint8 err, GError **erro
 
 	/* fallback */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_INTERNAL,
 		    "command 0x%02x returned error 0x%02x",
 		    cmd,
 		    err);

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -221,8 +221,8 @@ fu_steelseries_gamepad_write_checksum(FuDevice *device, guint32 checksum, GError
 	/* validate checksum */
 	if (data[0] != 0xA5 || data[1] != 0xAA || data[2] != 0x55 || data[3] != 0x01) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "Controller is unable to validate checksum");
 		return FALSE;
 	}

--- a/plugins/steelseries/fu-steelseries-mouse.c
+++ b/plugins/steelseries/fu-steelseries-mouse.c
@@ -52,8 +52,8 @@ fu_steelseries_mouse_setup(FuDevice *device, GError **error)
 	}
 	if (actual_len != 32) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only wrote %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;
@@ -72,8 +72,8 @@ fu_steelseries_mouse_setup(FuDevice *device, GError **error)
 	}
 	if (actual_len != 32) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only read %" G_GSIZE_FORMAT "bytes",
 			    actual_len);
 		return FALSE;

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -33,7 +33,10 @@ fu_superio_device_io_read(FuSuperioDevice *self, guint8 addr, guint8 *data, GErr
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
 
 	if (priv->port == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "port isn't set");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "port isn't set");
 		return FALSE;
 	}
 
@@ -63,7 +66,10 @@ fu_superio_device_io_write(FuSuperioDevice *self, guint8 addr, guint8 data, GErr
 	FuSuperioDevicePrivate *priv = GET_PRIVATE(self);
 
 	if (priv->port == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "port isn't set");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "port isn't set");
 		return FALSE;
 	}
 
@@ -135,8 +141,8 @@ fu_superio_device_check_id(FuSuperioDevice *self, GError **error)
 	/* no quirk entry */
 	if (priv->id == 0x0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "invalid SuperioId");
 		return FALSE;
 	}
@@ -150,8 +156,8 @@ fu_superio_device_check_id(FuSuperioDevice *self, GError **error)
 		return FALSE;
 	if (priv->id != id_tmp) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "SuperIO chip not supported, got %04x, expected %04x",
 			    (guint)id_tmp,
 			    (guint)priv->id);
@@ -182,8 +188,8 @@ fu_superio_device_wait_for(FuSuperioDevice *self, guint8 mask, gboolean set, GEr
 			return TRUE;
 	} while (TRUE);
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_TIMED_OUT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_TIMED_OUT,
 		    "timed out whilst waiting for 0x%02x:%i",
 		    mask,
 		    set);
@@ -237,8 +243,8 @@ fu_superio_device_ec_flush(FuSuperioDevice *self, GError **error)
 			return FALSE;
 		if (g_timer_elapsed(timer, NULL) * 1000.f > priv->timeout_ms) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_TIMED_OUT,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_TIMED_OUT,
 					    "timed out whilst waiting for flush");
 			return FALSE;
 		}
@@ -464,7 +470,10 @@ fu_superio_device_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/superio/fu-superio-it55-device.c
+++ b/plugins/superio/fu-superio-it55-device.c
@@ -611,8 +611,8 @@ fu_superio_it55_device_set_quirk_kv(FuDevice *device,
 			self->autoload_action = AUTOLOAD_SET_OFF;
 		} else {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "invalid value");
 			return FALSE;
 		}

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -460,8 +460,8 @@ fu_superio_it89_device_detach(FuDevice *device, FuProgress *progress, GError **e
 		return FALSE;
 	if (tmp != 0x33) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to clear HOSTWA, got 0x%02x, expected 0x33",
 			    tmp);
 		return FALSE;

--- a/plugins/superio/fu-superio-plugin.c
+++ b/plugins/superio/fu-superio-plugin.c
@@ -39,8 +39,8 @@ fu_superio_plugin_coldplug_chipset(FuPlugin *plugin, const gchar *guid, GError *
 	custom_gtype = g_type_from_name(chipset);
 	if (custom_gtype == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "SuperIO GType %s unsupported",
 			    chipset);
 		return FALSE;

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -188,40 +188,49 @@ fu_synaptics_cape_device_rc_set_error(const FuCapCmd *rsp, GError **error)
 
 	switch (rsp->data_len) {
 	case FU_SYNAPTICS_CAPE_MODULE_RC_GENERIC_FAILURE:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "generic failure");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "generic failure");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_ALREADY_EXISTS:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "already exists");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "already exists");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_NULL_APP_POINTER:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "null app pointer");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "null app pointer");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_NULL_MODULE_POINTER:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "null module pointer");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "null module pointer");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_NULL_POINTER:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "null pointer");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "null pointer");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_BAD_APP_ID:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "bad app id");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bad app id");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_MODULE_TYPE_HAS_NO_API:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "has no api");
+		g_set_error_literal(error, G_IO_ERROR, FWUPD_ERROR_INTERNAL, "has no api");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_BAD_MAGIC_NUMBER:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "bad magic number");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "bad magic number");
 		break;
 	case FU_SYNAPTICS_CAPE_MODULE_RC_CMD_MODE_UNSUPPORTED:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "mode unsupported");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_EAGAIN:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "query timeout");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "query timeout");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_FAIL:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "command failed");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "command failed");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_WRITE_FAIL:
 		g_set_error_literal(error,
@@ -237,8 +246,8 @@ fu_synaptics_cape_device_rc_set_error(const FuCapCmd *rsp, GError **error)
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_CRC_ERROR:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware data has been corrupted");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_USB_ID_NOT_MATCH:
@@ -255,32 +264,32 @@ fu_synaptics_cape_device_rc_set_error(const FuCapCmd *rsp, GError **error)
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_HEADER_CORRUPTION:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware header data has been corrupted");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_IMAGE_CORRUPTION:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "firmware payload data has been corrupted");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_ALREADY_ACTIVE:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "failed to active new firmward");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_NOT_READY:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_BUSY,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_BUSY,
 				    "firmware update is not ready");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_SIGN_TRANSFER_CORRUPTION:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "signature data has been corrupted");
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_DIGITAL_SIGNATURE_VERFIICATION_FAILED:
@@ -291,12 +300,16 @@ fu_synaptics_cape_device_rc_set_error(const FuCapCmd *rsp, GError **error)
 		break;
 	case FU_SYNAPTICS_CAPE_ERROR_SFU_TASK_NOT_RUNING:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "firmware update task is not running");
 		break;
 	default:
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_BUSY, "unknown error %d", rsp->data_len);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "unknown error %d",
+			    rsp->data_len);
 	}
 
 	/* success */

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -72,8 +72,8 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		if (crc_calc != fu_struct_synaptics_cape_sngl_hdr_get_file_crc(st)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "CRC did not match, got 0x%x, expected 0x%x",
 				    fu_struct_synaptics_cape_sngl_hdr_get_file_crc(st),
 				    crc_calc);
@@ -93,8 +93,8 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 	num_fw_file = fu_struct_synaptics_cape_sngl_hdr_get_fw_file_num(st);
 	if (num_fw_file == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no image files found");
 		return FALSE;
 	}

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -44,7 +44,7 @@ fu_synaptics_mst_plugin_backend_device_added(FuPlugin *plugin,
 	/* open */
 	locker = fu_device_locker_new(dev, &error_local);
 	if (locker == NULL) {
-		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED) ||
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
 		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_READ)) {
 			g_debug("no device found: %s", error_local->message);
 			return TRUE;

--- a/plugins/synaptics-prometheus/fu-synaprom-common.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-common.c
@@ -52,46 +52,43 @@ fu_synaprom_error_from_status(guint16 status, GError **error)
 		return TRUE;
 	switch (status) {
 	case FU_SYNAPROM_RESULT_GEN_OPERATION_CANCELED:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_CANCELLED, "cancelled");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "cancelled");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_BAD_PARAM:
-		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
-				    "bad parameter");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "bad parameter");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_NULL_POINTER:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "NULL pointer");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "NULL pointer");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_UNEXPECTED_FORMAT:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "unexpected format");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_TIMEOUT:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "timed out");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "timed out");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_OBJECT_DOESNT_EXIST:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "object does not exist");
 		break;
 	case FU_SYNAPROM_RESULT_GEN_ERROR:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_FAILED, "generic error");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "generic error");
 		break;
 	case FU_SYNAPROM_RESULT_SENSOR_MALFUNCTIONED:
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_INITIALIZED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "sensor malfunctioned");
 		break;
 	case FU_SYNAPROM_RESULT_SYS_OUT_OF_MEMORY:
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_AGAIN, "out of heap memory");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "out of heap memory");
 		break;
 	default:
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "error status: 0x%x", status);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "error status: 0x%x", status);
 	}
 	return FALSE;
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -59,8 +59,8 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	if (reply->len < FU_STRUCT_SYNAPROM_REPLY_IOTA_FIND_HDR_SIZE +
 			     FU_STRUCT_SYNAPROM_IOTA_CONFIG_VERSION_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "CFG return data invalid size: 0x%04x",
 			    reply->len);
 		return FALSE;
@@ -71,8 +71,8 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	if (fu_struct_synaprom_reply_iota_find_hdr_get_itype(st_hdr) !=
 	    FU_SYNAPROM_IOTA_ITYPE_CONFIG_VERSION) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "CFG iota had invalid itype: 0x%04x",
 			    fu_struct_synaprom_reply_iota_find_hdr_get_itype(st_hdr));
 		return FALSE;
@@ -148,8 +148,8 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 				  (guint)FU_SYNAPROM_PRODUCT_PROMETHEUS);
 		} else {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "CFG metadata not compatible, "
 				    "got 0x%02x expected 0x%02x",
 				    fu_struct_synaprom_cfg_hdr_get_product(st_hdr),
@@ -168,8 +168,8 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 				  self->configid2);
 		} else {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "CFG version not compatible, "
 				    "got %u:%u expected %u:%u",
 				    fu_struct_synaprom_cfg_hdr_get_id1(st_hdr),

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -102,8 +102,8 @@ fu_synaprom_device_cmd_send(FuSynapromDevice *device,
 	}
 	if (actual_len < request->len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only sent 0x%04x of 0x%04x",
 			    (guint)actual_len,
 			    request->len);
@@ -226,8 +226,8 @@ fu_synaprom_device_setup(FuDevice *device, GError **error)
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "device %u is not supported by this plugin",
 			    product);
 		return FALSE;
@@ -281,8 +281,8 @@ fu_synaprom_device_prepare_firmware(FuDevice *device,
 				  (guint)FU_SYNAPROM_PRODUCT_TRITON);
 		} else {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "MFW metadata not compatible, "
 				    "got 0x%02x expected 0x%02x or 0x%02x",
 				    product_id,
@@ -434,8 +434,8 @@ fu_synaprom_device_attach(FuDevice *device, FuProgress *progress, GError **error
 		return FALSE;
 	if (actual_len != sizeof(data)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only sent 0x%04x of 0x%04x",
 			    (guint)actual_len,
 			    (guint)sizeof(data));
@@ -480,8 +480,8 @@ fu_synaprom_device_detach(FuDevice *device, FuProgress *progress, GError **error
 		return FALSE;
 	if (actual_len != sizeof(data)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "only sent 0x%04x of 0x%04x",
 			    (guint)actual_len,
 			    (guint)sizeof(data));

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -61,8 +61,8 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	if (streamsz < self->signature_size + FU_STRUCT_SYNAPROM_HDR_SIZE) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "blob is too small to be firmware");
 		return FALSE;
 	}
@@ -84,8 +84,8 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		tag = fu_struct_synaprom_hdr_get_tag(st_hdr);
 		if (tag >= FU_SYNAPROM_FIRMWARE_TAG_MAX) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "tag 0x%04x is too large",
 				    tag);
 			return FALSE;
@@ -95,8 +95,8 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		img_old = fu_firmware_get_image_by_idx(firmware, tag, NULL);
 		if (img_old != NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "tag 0x%04x already present in image",
 				    tag);
 			return FALSE;
@@ -104,8 +104,8 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		hdrsz = fu_struct_synaprom_hdr_get_bufsz(st_hdr);
 		if (hdrsz == 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "empty header for tag 0x%04x",
 				    tag);
 			return FALSE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -243,7 +243,7 @@ fu_synaptics_rmi_hid_device_wait_for_attr(FuSynapticsRmiDevice *rmi_device,
 						    FU_IO_CHANNEL_FLAG_NONE,
 						    &error_local);
 		if (res == NULL) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT))
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT))
 				break;
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-ps2-device.c
@@ -113,7 +113,7 @@ fu_synaptics_rmi_ps2_device_read_ack(FuSynapticsRmiPs2Device *self, guint8 *pbuf
 					    10,
 					    FU_IO_CHANNEL_FLAG_USE_BLOCKING_IO,
 					    &error_local)) {
-			if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_TIMED_OUT)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 				g_warning("read timed out: %u", i);
 				fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 				continue;
@@ -123,7 +123,7 @@ fu_synaptics_rmi_ps2_device_read_ack(FuSynapticsRmiPs2Device *self, guint8 *pbuf
 		}
 		return TRUE;
 	}
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "read timed out");
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "read timed out");
 	return FALSE;
 }
 
@@ -284,7 +284,7 @@ fu_synaptics_rmi_ps2_device_status_request_sequence(FuSynapticsRmiPs2Device *sel
 		break;
 	}
 	if (success == FALSE) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "failed");
 		return FALSE;
 	}
 
@@ -687,8 +687,8 @@ fu_synaptics_rmi_ps2_device_read(FuSynapticsRmiDevice *rmi_device,
 			g_debug("buf->len(%u) != req_sz(%u)", buf->len, (guint)req_sz);
 			if (retries++ > 2) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "buffer length did not match: %u vs %u",
 					    buf->len,
 					    (guint)req_sz);
@@ -825,8 +825,8 @@ fu_synaptics_rmi_ps2_device_open(FuDevice *device, GError **error)
 		}
 		if (buf[0] != 0xAA || buf[1] != 0x00) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to read 0xAA00, got 0x%02X%02X: ",
 				    buf[0],
 				    buf[1]);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -194,8 +194,8 @@ fu_synaptics_rmi_v5_device_secure_check(FuDevice *device,
 			if (retries++ > 2) {
 				g_set_error(
 				    error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "RSA public key length not matched %u: after %u retries: ",
 				    pubkey_buf->len,
 				    retries);

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -57,8 +57,8 @@ fu_system76_launch_device_response_cb(FuDevice *device, gpointer user_data, GErr
 	}
 	if (actual_len < helper->len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "response truncated: received %" G_GSIZE_FORMAT " bytes",
 			    actual_len);
 		return FALSE;
@@ -90,8 +90,8 @@ fu_system76_launch_device_command(FuDevice *device, guint8 *data, gsize len, GEr
 	}
 	if (actual_len < len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "command truncated: sent %" G_GSIZE_FORMAT " bytes",
 			    actual_len);
 		return FALSE;

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -105,8 +105,8 @@ fu_test_plugin_modify_config(FuPlugin *plugin, const gchar *key, const gchar *va
 			       NULL};
 	if (!g_strv_contains(keys, key)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "config key %s not supported",
 			    key);
 		return FALSE;

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1084,7 +1084,7 @@ test_image_validation(ThunderboltTest *tt, gconstpointer user_data)
 	/* parse; should fail, bad image */
 	ret = fu_firmware_parse(firmware_bad, bad_data, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_false(ret);
-	g_assert_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_debug("expected image validation error [ctl]: %s", error->message);
 	g_clear_error(&error);
 

--- a/plugins/thunderbolt/fu-thunderbolt-common.c
+++ b/plugins/thunderbolt/fu-thunderbolt-common.c
@@ -12,14 +12,14 @@
 static gboolean
 fu_thunderbolt_device_check_usb4_port_path(FuUdevDevice *device,
 					   const gchar *attribute,
-					   GError **err)
+					   GError **error)
 {
 	g_autofree const gchar *path =
 	    g_build_filename(fu_udev_device_get_sysfs_path(device), attribute, NULL);
 	g_autofree gchar *fn = g_strdup_printf("%s", path);
 	g_autoptr(GFile) file = g_file_new_for_path(fn);
 	if (!g_file_query_exists(file, NULL)) {
-		g_set_error(err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "failed to find %s", fn);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "failed to find %s", fn);
 		return FALSE;
 	}
 	return TRUE;

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -99,8 +99,8 @@ fu_thunderbolt_plugin_modify_config(FuPlugin *plugin,
 	const gchar *keys[] = {"DelayedActivation", "MinimumKernelVersion", NULL};
 	if (!g_strv_contains(keys, key)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "config key %s not supported",
 			    key);
 		return FALSE;

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -70,8 +70,8 @@ fu_ti_tps6598x_device_usbep_read_raw(FuTiTps6598xDevice *self,
 	fu_dump_raw(G_LOG_DOMAIN, title, buf->data, buf->len);
 	if (actual_length != buf->len) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "got 0x%x but requested 0x%x",
 			    (guint)actual_length,
 			    (guint)buf->len);
@@ -99,8 +99,8 @@ fu_ti_tps6598x_device_usbep_read(FuTiTps6598xDevice *self,
 	/* check then remove size */
 	if (buf->data[0] < length) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "response 0x%x but requested 0x%x",
 			    (guint)buf->data[0],
 			    (guint)length);
@@ -151,8 +151,8 @@ fu_ti_tps6598x_device_usbep_write(FuTiTps6598xDevice *self,
 		}
 		if (actual_length != fu_chunk_get_data_sz(chk)) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "wrote 0x%x but expected 0x%x",
 				    (guint)actual_length,
 				    (guint)fu_chunk_get_data_sz(chk));
@@ -203,8 +203,8 @@ fu_ti_tps6598x_device_write_4cc(FuTiTps6598xDevice *self,
 	/* sanity check */
 	if (strlen(cmd) != 4) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "expected 4-char cmd");
 		return FALSE;
 	}
@@ -237,8 +237,8 @@ fu_ti_tps6598x_device_wait_for_command_cb(FuDevice *device, gpointer user_data, 
 	/* check the value of the cmd register */
 	if (buf->data[0] != 0 || buf->data[1] != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid status register, got 0x%02x:0x%02x",
 			    buf->data[1],
 			    buf->data[2]);
@@ -303,8 +303,8 @@ fu_ti_tps6598x_device_sfwi(FuTiTps6598xDevice *self, GError **error)
 	res = buf->data[0] & 0b1111;
 	if (res != FU_TI_TPS6598X_SFWI_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SFWi failed, got %s [0x%02x]",
 			    fu_ti_tps6598x_sfwi_to_string(res),
 			    res);
@@ -335,8 +335,8 @@ fu_ti_tps6598x_device_sfwd(FuTiTps6598xDevice *self, GByteArray *data, GError **
 	res = buf->data[0] & 0b1111;
 	if (res != FU_TI_TPS6598X_SFWD_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SFWd failed, got %s [0x%02x]",
 			    fu_ti_tps6598x_sfwd_to_string(res),
 			    res);
@@ -365,8 +365,8 @@ fu_ti_tps6598x_device_sfws(FuTiTps6598xDevice *self, GByteArray *data, GError **
 	res = buf->data[0] & 0b1111;
 	if (res != FU_TI_TPS6598X_SFWS_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_ARGUMENT,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "SFWs failed, got %s [0x%02x]",
 			    fu_ti_tps6598x_sfws_to_string(res),
 			    res);
@@ -407,8 +407,8 @@ fu_ti_tps6598x_device_read_target_register(FuTiTps6598xDevice *self,
 	/* check then remove response code */
 	if (buf->data[0] != 0x00) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "response code 0x%02x",
 			    (guint)buf->data[0]);
 		return NULL;
@@ -459,8 +459,8 @@ fu_ti_tps6598x_device_ensure_mode(FuTiTps6598xDevice *self, GError **error)
 
 	/* unhandled */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_INVALID_ARGUMENT,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "device in unknown mode: %s",
 		    str);
 	return FALSE;

--- a/plugins/tpm/fu-tpm-eventlog-common.c
+++ b/plugins/tpm/fu-tpm-eventlog-common.c
@@ -92,8 +92,8 @@ fu_tpm_eventlog_calc_checksums(GPtrArray *items, guint8 pcr, GError **error)
 	/* sanity check */
 	if (items->len == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no event log data");
 		return NULL;
 	}
@@ -159,8 +159,8 @@ fu_tpm_eventlog_calc_checksums(GPtrArray *items, guint8 pcr, GError **error)
 	}
 	if (cnt_sha1 == 0 && cnt_sha256 == 0 && cnt_sha384 == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "no SHA1, SHA256, or SHA384 data");
 		return NULL;
 	}

--- a/plugins/tpm/fu-tpm-eventlog.c
+++ b/plugins/tpm/fu-tpm-eventlog.c
@@ -56,8 +56,8 @@ fu_tmp_eventlog_process(const gchar *fn, gint pcr, GError **error)
 	}
 	if (pcr > max_pcr) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid PCR specified: %d",
 			    pcr);
 		return FALSE;

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -42,24 +42,24 @@ fu_tpm_v2_device_get_uint32(FuTpmV2Device *self, guint32 query, guint32 *val, GE
 				&capability);
 	if (rc != TSS2_RC_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "capability request failed for query %x",
 			    query);
 		return FALSE;
 	}
 	if (capability->data.tpmProperties.count == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no properties returned for query %x",
 			    query);
 		return FALSE;
 	}
 	if (capability->data.tpmProperties.tpmProperty[0].property != query) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "wrong query returned (got %x expected %x)",
 			    capability->data.tpmProperties.tpmProperty[0].property,
 			    query);
@@ -163,8 +163,8 @@ fu_tpm_v2_device_setup_pcrs(FuTpmV2Device *self, GError **error)
 				&capability_data);
 	if (rc != TSS2_RC_SUCCESS) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to get hash algorithms supported by TPM");
 		return FALSE;
 	}
@@ -189,8 +189,8 @@ fu_tpm_v2_device_setup_pcrs(FuTpmV2Device *self, GError **error)
 			   &pcr_values);
 	if (rc != TSS2_RC_SUCCESS) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to read PCR values from TPM");
 		return FALSE;
 	}
@@ -236,8 +236,8 @@ fu_tpm_v2_device_ensure_commands(FuTpmV2Device *self, GError **error)
 				&capability);
 	if (rc != TSS2_RC_SUCCESS) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "capability request failed for TPM2_CAP_COMMANDS");
 		return FALSE;
 	}
@@ -293,8 +293,8 @@ fu_tpm_v2_device_setup(FuDevice *device, GError **error)
 	rc = Esys_Startup(self->esys_context, TPM2_SU_CLEAR);
 	if (rc != TSS2_RC_SUCCESS) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to initialize TPM");
 		return FALSE;
 	}

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -89,8 +89,8 @@ fu_acpi_uefi_parse(FuFirmware *firmware,
 	/* check signature and read flags */
 	if (g_strcmp0(fu_firmware_get_id(FU_FIRMWARE(self)), "UEFI") != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Not a UEFI table, got %s",
 			    fu_firmware_get_id(FU_FIRMWARE(self)));
 		return FALSE;
@@ -155,8 +155,8 @@ fu_acpi_uefi_cod_functional(FuAcpiUefi *self, GError **error)
 	if (!self->is_insyde || self->insyde_cod_status > 0)
 		return TRUE;
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Capsule-on-Disk may have a firmware bug");
 	return FALSE;
 }

--- a/plugins/uefi-capsule/fu-uefi-bgrt.c
+++ b/plugins/uefi-capsule/fu-uefi-bgrt.c
@@ -36,16 +36,16 @@ fu_uefi_bgrt_setup(FuUefiBgrt *self, GError **error)
 	bgrtdir = g_build_filename(sysfsfwdir, "acpi", "bgrt", NULL);
 	if (!g_file_test(bgrtdir, G_FILE_TEST_EXISTS)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "BGRT is not supported");
 		return FALSE;
 	}
 	type = fu_uefi_read_file_as_uint64(bgrtdir, "type");
 	if (type != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "BGRT type was %" G_GUINT64_FORMAT,
 			    type);
 		return FALSE;
@@ -53,8 +53,8 @@ fu_uefi_bgrt_setup(FuUefiBgrt *self, GError **error)
 	version = fu_uefi_read_file_as_uint64(bgrtdir, "version");
 	if (version != 1) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "BGRT version was %" G_GUINT64_FORMAT,
 			    version);
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -121,8 +121,8 @@ fu_uefi_bootmgr_verify_fwupd(GError **error)
 
 	/* did not find */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "no 'Linux Firmware Updater' entry found");
 	return FALSE;
 }
@@ -218,8 +218,8 @@ fu_uefi_setup_bootnext_with_loadopt(FuEfiLoadOption *loadopt,
 		}
 		if (boot_next == G_MAXUINT16) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no free boot variables (tried %x)",
 				    boot_next);
 			return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -557,8 +557,8 @@ fu_uefi_capsule_plugin_is_esp_linux(FuVolume *esp, GError **error)
 	/* look for any likely basenames */
 	if (mount_point == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no mountpoint for ESP");
 		return FALSE;
 	}
@@ -578,8 +578,8 @@ fu_uefi_capsule_plugin_is_esp_linux(FuVolume *esp, GError **error)
 	/* failed */
 	basenames_str = g_strjoinv("|", (gchar **)basenames);
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
 		    "did not find %s in %s",
 		    basenames_str,
 		    mount_point);
@@ -696,8 +696,8 @@ fu_uefi_capsule_plugin_get_default_esp(FuPlugin *plugin, GError **error)
 
 		if (g_hash_table_size(esp_scores) == 0) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no EFI system partition found");
 			return NULL;
 		}
@@ -728,8 +728,8 @@ fu_uefi_capsule_plugin_get_default_esp(FuPlugin *plugin, GError **error)
 
 			if (g_strcmp0(mount, user_esp_location) != 0) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "user specified ESP %s not found",
 					    user_esp_location);
 				return NULL;
@@ -1053,8 +1053,8 @@ fu_uefi_capsule_plugin_check_cod_support(FuUefiCapsulePlugin *self, GError **err
 		return FALSE;
 	if ((value & EFI_OS_INDICATIONS_FILE_CAPSULE_DELIVERY_SUPPORTED) == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "Capsule-on-Disk is not supported");
 		return FALSE;
 	}
@@ -1179,8 +1179,8 @@ fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 		return FALSE;
 	if (esp_path == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no mountpoint for ESP");
 		return FALSE;
 	}
@@ -1293,8 +1293,8 @@ fu_uefi_capsule_plugin_modify_config(FuPlugin *plugin,
 			       NULL};
 	if (!g_strv_contains(keys, key)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "config key %s not supported",
 			    key);
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -98,8 +98,8 @@ fu_uefi_cod_device_get_variable_idx(const gchar *name, guint *value, GError **er
 		return FALSE;
 	if (!g_str_has_prefix(str, "Capsule")) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "wrong contents, got %s",
 			    str);
 		return FALSE;
@@ -123,8 +123,7 @@ fu_uefi_cod_device_get_results(FuDevice *device, GError **error)
 		g_autoptr(GError) error_local = NULL;
 		if (fu_uefi_cod_device_get_results_for_idx(device, i, &error_local))
 			return TRUE;
-		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) &&
-		    !g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -39,8 +39,8 @@ fu_uefi_bootmgr_get_suffix(GError **error)
 	firmware_bits = fu_uefi_read_file_as_uint64(sysfsefidir, "fw_platform_size");
 	if (firmware_bits == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "%s/fw_platform_size cannot be found",
 			    sysfsefidir);
 		return NULL;
@@ -53,8 +53,8 @@ fu_uefi_bootmgr_get_suffix(GError **error)
 
 	/* this should exist */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
 		    "%s/fw_platform_size has unknown value %" G_GUINT64_FORMAT,
 		    sysfsefidir,
 		    firmware_bits);
@@ -110,8 +110,8 @@ fu_uefi_get_built_app_path(const gchar *binary, GError **error)
 	if (fu_efivar_secure_boot_enabled(NULL)) {
 		if (!source_path_signed_exists) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "%s cannot be found",
 				    source_path_signed);
 			return NULL;
@@ -125,8 +125,8 @@ fu_uefi_get_built_app_path(const gchar *binary, GError **error)
 		return g_steal_pointer(&source_path_signed);
 
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_NOT_FOUND,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
 		    "%s and %s cannot be found",
 		    source_path,
 		    source_path_signed);
@@ -145,8 +145,8 @@ fu_uefi_get_framebuffer_size(guint32 *width, guint32 *height, GError **error)
 	fbdir = g_build_filename(sysfsdriverdir, "efi-framebuffer", "efi-framebuffer.0", NULL);
 	if (!g_file_test(fbdir, G_FILE_TEST_EXISTS)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "EFI framebuffer not found");
 		return FALSE;
 	}
@@ -154,8 +154,8 @@ fu_uefi_get_framebuffer_size(guint32 *width, guint32 *height, GError **error)
 	width_tmp = fu_uefi_read_file_as_uint64(fbdir, "width");
 	if (width_tmp == 0 || height_tmp == 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "EFI framebuffer has invalid size "
 			    "%" G_GUINT32_FORMAT "x%" G_GUINT32_FORMAT,
 			    width_tmp,
@@ -183,8 +183,8 @@ fu_uefi_get_bitmap_size(const guint8 *buf,
 	/* check header */
 	if (bufsz < 26 || memcmp(buf, "BM", 2) != 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "invalid BMP header signature");
 		return FALSE;
 	}
@@ -194,8 +194,8 @@ fu_uefi_get_bitmap_size(const guint8 *buf,
 		return FALSE;
 	if (ui32 < 26) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "BMP header invalid @ %" G_GUINT32_FORMAT "x",
 			    ui32);
 		return FALSE;
@@ -206,8 +206,8 @@ fu_uefi_get_bitmap_size(const guint8 *buf,
 		return FALSE;
 	if (ui32 < 26 - 14) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "BITMAPINFOHEADER invalid @ %" G_GUINT32_FORMAT "x",
 			    ui32);
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -36,8 +36,8 @@ fu_uefi_grub_device_mkconfig(FuDevice *device,
 		argv_mkconfig[2] = "/boot/grub2/grub.cfg";
 	if (!g_file_test(argv_mkconfig[2], G_FILE_TEST_EXISTS)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find grub.conf");
 		return FALSE;
 	}
@@ -48,8 +48,8 @@ fu_uefi_grub_device_mkconfig(FuDevice *device,
 		grub_mkconfig = fu_path_find_program("grub2-mkconfig", NULL);
 	if (grub_mkconfig == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find grub-mkconfig");
 		return FALSE;
 	}
@@ -60,8 +60,8 @@ fu_uefi_grub_device_mkconfig(FuDevice *device,
 		grub_reboot = fu_path_find_program("grub2-reboot", NULL);
 	if (grub_reboot == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "could not find grub-reboot");
 		return FALSE;
 	}

--- a/plugins/uefi-dbx/fu-efi-image.c
+++ b/plugins/uefi-dbx/fu-efi-image.c
@@ -119,8 +119,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 		return NULL;
 	if (dos_sig != 0x5a4d) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Invalid DOS header magic %04x",
 			    dos_sig);
 		return NULL;
@@ -143,8 +143,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 		return NULL;
 	if (nt_sig != 0x4550) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Invalid PE header signature %08x",
 			    nt_sig);
 		return NULL;
@@ -169,8 +169,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 			return NULL;
 		if (machine != 0x020b) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "Invalid a.out machine type %04x",
 				    machine);
 			return NULL;
@@ -201,8 +201,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 			return NULL;
 		if (machine != 0x010b) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "Invalid a.out machine type %04x",
 				    machine);
 			return NULL;
@@ -220,8 +220,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "Invalid PE header machine %04x",
 			    machine);
 		return NULL;
@@ -313,8 +313,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 
 		if (file_offset + r->size > bufsz) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "file-aligned section %s extends beyond end of file",
 				    r->name);
 			return NULL;
@@ -333,8 +333,8 @@ fu_efi_image_new(GBytes *data, GError **error)
 					bufsz - cert_table_size);
 	} else if (image_bytes + cert_table_size > bufsz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "checksum_offset areas outside image size");
 		return NULL;
 	}

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.c
@@ -188,7 +188,7 @@ fu_uefi_dbx_signature_list_validate(FuContext *ctx,
 		g_autoptr(GError) error_local = NULL;
 		locker = fu_volume_locker(esp, &error_local);
 		if (locker == NULL) {
-			if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 				g_propagate_error(error, g_steal_pointer(&error_local));
 				return FALSE;
 			}

--- a/plugins/uefi-pk/fu-uefi-pk-device.c
+++ b/plugins/uefi-pk/fu-uefi-pk-device.c
@@ -95,8 +95,8 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 	rc = gnutls_x509_crt_init(&crt);
 	if (rc < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "crt_init: %s [%i]",
 			    gnutls_strerror(rc),
 			    rc);
@@ -112,8 +112,8 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 	rc = gnutls_x509_crt_import(crt, &d, GNUTLS_X509_FMT_DER);
 	if (rc < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "crt_import: %s [%i]",
 			    gnutls_strerror(rc),
 			    rc);
@@ -143,8 +143,8 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 	rc = gnutls_x509_crt_get_key_id(crt, 0, key_id, &key_idsz);
 	if (rc < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to get key ID: %s [%i]",
 			    gnutls_strerror(rc),
 			    rc);
@@ -153,8 +153,8 @@ fu_uefi_pk_device_parse_signature(FuUefiPkDevice *self, FuEfiSignature *sig, GEr
 	key_idstr = g_compute_checksum_for_data(G_CHECKSUM_SHA1, key_id, key_idsz);
 	if (key_idstr == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to calculate key ID for 0x%x bytes",
 			    (guint)key_idsz);
 		return FALSE;

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -34,8 +34,8 @@ fu_uf2_device_prepare_firmware(FuDevice *device,
 	if (self->family_id > 0 && fu_firmware_get_idx(firmware) > 0 &&
 	    self->family_id != fu_firmware_get_idx(firmware)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "family ID was different, expected 0x%08x and got 0x%08x",
 			    (guint)self->family_id,
 			    (guint)fu_firmware_get_idx(firmware));
@@ -95,8 +95,8 @@ fu_block_device_get_full_path(FuUf2Device *self, const gchar *filename, GError *
 	/* sanity check */
 	if (devfile == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_FAILED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "invalid path: no devfile");
 		return NULL;
 	}

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -48,24 +48,24 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	flags = fu_struct_uf2_get_flags(st);
 	if (flags & FU_UF2_FIRMWARE_BLOCK_FLAG_IS_CONTAINER) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "container U2F firmware not supported");
 		return FALSE;
 	}
 	datasz = fu_struct_uf2_get_payload_size(st);
 	if (datasz > 476) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "data size impossible got 0x%08x",
 			    datasz);
 		return FALSE;
 	}
 	if (fu_struct_uf2_get_block_no(st) != fu_chunk_get_idx(chk)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "block count invalid, expected 0x%04x and got 0x%04x",
 			    fu_chunk_get_idx(chk),
 			    fu_struct_uf2_get_block_no(st));
@@ -73,16 +73,16 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	}
 	if (fu_struct_uf2_get_num_blocks(st) == 0) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "block count invalid, expected > 0");
 		return FALSE;
 	}
 	if (flags & FU_UF2_FIRMWARE_BLOCK_FLAG_HAS_FAMILY) {
 		if (fu_struct_uf2_get_family_id(st) == 0) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "family_id required but not supplied");
 			return FALSE;
 		}
@@ -99,8 +99,8 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	if (flags & FU_UF2_FIRMWARE_BLOCK_FLAG_HAS_MD5) {
 		if (datasz < 24) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_INVALID_DATA,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
 					    "not enough space for MD5 checksum");
 			return FALSE;
 		}
@@ -116,8 +116,8 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 				return FALSE;
 			if (sz < 4) {
 				g_set_error_literal(error,
-						    G_IO_ERROR,
-						    G_IO_ERROR_INVALID_DATA,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_DATA,
 						    "invalid extension tag size");
 				return FALSE;
 			}

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -38,7 +38,7 @@ fu_usi_dock_mcu_device_prepare_firmware(FuDevice *device,
 {
 	FuDevice *parent = fu_device_get_parent(device);
 	if (parent == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no parent");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return NULL;
 	}
 	return fu_device_prepare_firmware(parent, stream, flags, error);
@@ -55,7 +55,7 @@ fu_usi_dock_mcu_device_write_firmware(FuDevice *device,
 	FuUsiDockChildDevice *self = FU_USI_DOCK_CHILD_DEVICE(device);
 	FuDevice *parent = fu_device_get_parent(device);
 	if (parent == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "no parent");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return FALSE;
 	}
 	return fu_usi_dock_mcu_device_write_firmware_with_idx(FU_USI_DOCK_MCU_DEVICE(parent),

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -135,11 +135,11 @@ fu_usi_dock_mcu_device_get_status(FuUsiDockMcuDevice *self, GError **error)
 		return FALSE;
 	}
 	if (response == 0x1) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_BUSY, "device is busy");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "device is busy");
 		return FALSE;
 	}
 	if (response == 0xFF) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "device timed out");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "device timed out");
 		return FALSE;
 	}
 
@@ -486,8 +486,8 @@ fu_usi_dock_mcu_device_wait_for_spi_ready_cb(FuDevice *device, gpointer user_dat
 		return FALSE;
 	if (val != FU_USI_DOCK_SPI_STATE_READY) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "SPI state is %s [0x%02x]",
 			    fu_usi_dock_spi_state_to_string(val),
 			    val);
@@ -517,8 +517,8 @@ fu_usi_dock_mcu_device_wait_for_spi_initial_ready_cb(FuDevice *device,
 		return FALSE;
 	if (val != FU_USI_DOCK_SPI_STATE_READY) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_BUSY,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_BUSY,
 			    "SPI state is %s [0x%02x]",
 			    fu_usi_dock_spi_state_to_string(val),
 			    val);
@@ -644,8 +644,8 @@ fu_usi_dock_mcu_device_write_firmware_with_idx(FuUsiDockMcuDevice *self,
 
 	if (checksum != 0x0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "invalid checksum result for CMD_FWBUFER_CHECKSUM, got 0x%02x",
 			    checksum);
 		return FALSE;

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -207,7 +207,11 @@ fu_vbe_simple_device_get_cfg_compatible(FuVbeSimpleDevice *self,
 
 	/* failure */
 	str = g_strjoinv(", ", device_compatible);
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no images found that match %s", str);
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
+		    "no images found that match %s",
+		    str);
 	return NULL;
 }
 

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -291,7 +291,7 @@ fu_{{vendor}}_{{example}}_device_set_quirk_kv(FuDevice *device,
 	}
 
 	/* failed */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -150,7 +150,7 @@ fu_vli_device_spi_wait_finish(FuVliDevice *self, GError **error)
 		}
 		fu_device_sleep(FU_DEVICE(self), 500); /* ms */
 	}
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "failed to wait for SPI");
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "failed to wait for SPI");
 	return FALSE;
 }
 
@@ -191,8 +191,8 @@ fu_vli_device_spi_erase_sector(FuVliDevice *self, guint32 addr, GError **error)
 		for (guint i = 0; i < sizeof(buf); i++) {
 			if (buf[i] != 0xff) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_READ,
 					    "failed to check blank @0x%x",
 					    addr + offset + i);
 				return FALSE;
@@ -248,8 +248,8 @@ fu_vli_device_spi_write_block(FuVliDevice *self,
 	/* sanity check */
 	if (bufsz > FU_VLI_DEVICE_TXSIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot write 0x%x in one block",
 			    (guint)bufsz);
 		return FALSE;
@@ -360,8 +360,8 @@ fu_vli_device_spi_erase_all(FuVliDevice *self, FuProgress *progress, GError **er
 		for (guint i = 0; i < sizeof(buf); i++) {
 			if (buf[i] != 0xff) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_READ,
 					    "failed to verify erase @0x%x: ",
 					    addr);
 				return FALSE;
@@ -653,8 +653,8 @@ fu_vli_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		device_kind = fu_vli_device_kind_from_string(value);
 		if (device_kind == FU_VLI_DEVICE_KIND_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "VliDeviceKind %s is not supported",
 				    value);
 			return FALSE;

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -619,9 +619,9 @@ fu_vli_usbhub_device_guess_kind(FuVliUsbhubDevice *self, GError **error)
 				break;
 			default:
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
-					    "Packet Type match failed: ");
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "packet Type match failed: ");
 				return FALSE;
 			}
 		} else {
@@ -669,8 +669,8 @@ fu_vli_usbhub_device_guess_kind(FuVliUsbhubDevice *self, GError **error)
 			fu_vli_device_set_kind(FU_VLI_DEVICE(self), FU_VLI_DEVICE_KIND_VL812B3);
 	} else {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "hardware is not supported");
 		return FALSE;
 	}
@@ -859,8 +859,8 @@ fu_vli_usbhub_device_ready(FuDevice *device, GError **error)
 		break;
 	default:
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "hardware is not supported, dev_id=0x%x",
 			    (guint)fu_struct_vli_usbhub_hdr_get_dev_id(self->st_hd1));
 		return FALSE;
@@ -1152,8 +1152,8 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
 	hd1_fw_sz = fu_struct_vli_usbhub_hdr_get_usb3_fw_sz(self->st_hd1);
 	if (hd1_fw_sz > 0xF000) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "FW1 size abnormal 0x%x",
 			    (guint)hd1_fw_sz);
 		return FALSE;

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -309,8 +309,8 @@ fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 	/* device not supported */
 	if (self->device_kind == FU_VLI_DEVICE_KIND_UNKNOWN) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "device kind unknown");
 		return FALSE;
 	}

--- a/plugins/wacom-raw/fu-wacom-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-aes-device.c
@@ -55,8 +55,8 @@ fu_wacom_aes_add_recovery_hwid(FuDevice *device, GError **error)
 	}
 	if (rsp.size8 != cmd.size8) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "firmware does not support this feature");
 		return FALSE;
 	}
@@ -64,8 +64,8 @@ fu_wacom_aes_add_recovery_hwid(FuDevice *device, GError **error)
 	pid = (rsp.data[7] << 8) + (rsp.data[6]);
 	if ((pid == 0xFFFF) || (pid == 0x0000)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "invalid recovery product ID %04x",
 			    pid);
 		return FALSE;
@@ -102,9 +102,9 @@ fu_wacom_aes_query_operation_mode(FuWacomAesDevice *self, GError **error)
 
 	/* unsupported */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
-		    "Failed to query operation mode, got 0x%x",
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "failed to query operation mode, got 0x%x",
 		    buf[1]);
 	return FALSE;
 }
@@ -218,8 +218,8 @@ fu_wacom_aes_device_write_block(FuWacomAesDevice *self,
 	/* check size */
 	if (datasz != blocksz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "block size 0x%x != 0x%x untested",
 			    (guint)datasz,
 			    (guint)blocksz);

--- a/plugins/wacom-raw/fu-wacom-common.c
+++ b/plugins/wacom-raw/fu-wacom-common.c
@@ -6,7 +6,7 @@
 
 #include "config.h"
 
-#include <gio/gio.h>
+#include <fwupd.h>
 
 #include "fu-wacom-common.h"
 
@@ -17,8 +17,8 @@ fu_wacom_common_check_reply(const FuWacomRawRequest *req,
 {
 	if (rsp->report_id != FU_WACOM_RAW_BL_REPORT_ID_GET) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "report ID failed, expected 0x%02x, got 0x%02x",
 			    (guint)FU_WACOM_RAW_BL_REPORT_ID_GET,
 			    req->report_id);
@@ -26,8 +26,8 @@ fu_wacom_common_check_reply(const FuWacomRawRequest *req,
 	}
 	if (req->cmd != rsp->cmd) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cmd failed, expected 0x%02x, got 0x%02x",
 			    req->cmd,
 			    rsp->cmd);
@@ -35,8 +35,8 @@ fu_wacom_common_check_reply(const FuWacomRawRequest *req,
 	}
 	if (req->echo != rsp->echo) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "echo failed, expected 0x%02x, got 0x%02x",
 			    req->echo,
 			    rsp->echo);
@@ -51,30 +51,39 @@ fu_wacom_common_rc_set_error(const FuWacomRawResponse *rsp, GError **error)
 	if (rsp->resp == FU_WACOM_RAW_RC_OK)
 		return TRUE;
 	if (rsp->resp == FU_WACOM_RAW_RC_BUSY) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_BUSY, "device is busy");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_BUSY, "device is busy");
 		return FALSE;
 	}
 	if (rsp->resp == FU_WACOM_RAW_RC_MCUTYPE) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "MCU type does not match");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "MCU type does not match");
 		return FALSE;
 	}
 	if (rsp->resp == FU_WACOM_RAW_RC_PID) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "PID does not match");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "PID does not match");
 		return FALSE;
 	}
 	if (rsp->resp == FU_WACOM_RAW_RC_CHECKSUM1) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "checksum1 does not match");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "checksum1 does not match");
 		return FALSE;
 	}
 	if (rsp->resp == FU_WACOM_RAW_RC_CHECKSUM2) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "checksum2 does not match");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "checksum2 does not match");
 		return FALSE;
 	}
 	if (rsp->resp == FU_WACOM_RAW_RC_TIMEOUT) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT, "command timed out");
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "command timed out");
 		return FALSE;
 	}
-	g_set_error(error, G_IO_ERROR, G_IO_ERROR_FAILED, "unknown error 0x%02x", rsp->resp);
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unknown error 0x%02x", rsp->resp);
 	return FALSE;
 }
 

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -76,8 +76,8 @@ fu_wacom_device_check_mpu(FuWacomDevice *self, GError **error)
 
 	/* unsupported */
 	g_set_error(error,
-		    G_IO_ERROR,
-		    G_IO_ERROR_FAILED,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
 		    "MPU is not W9013 or W9021: 0x%x",
 		    rsp.resp);
 	return FALSE;
@@ -142,8 +142,8 @@ fu_wacom_device_check_mode(FuWacomDevice *self, GError **error)
 	}
 	if (rsp.resp != 0x06) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "check mode failed, mode=0x%02x",
 			    rsp.resp);
 		return FALSE;
@@ -192,8 +192,8 @@ fu_wacom_device_write_firmware(FuDevice *device,
 	/* check start address and size */
 	if (fu_firmware_get_addr(firmware) != priv->flash_base_addr) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "base addr invalid: 0x%05x",
 			    (guint)fu_firmware_get_addr(firmware));
 		return FALSE;
@@ -203,8 +203,8 @@ fu_wacom_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (g_bytes_get_size(fw) > priv->flash_size) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "size is invalid: 0x%05x",
 			    (guint)g_bytes_get_size(fw));
 		return FALSE;
@@ -312,7 +312,10 @@ fu_wacom_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *va
 		priv->flash_size = tmp;
 		return TRUE;
 	}
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "quirk key not supported");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
 	return FALSE;
 }
 

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -180,16 +180,16 @@ fu_wacom_emr_device_write_block(FuWacomEmrDevice *self,
 	/* check size */
 	if (datasz > sizeof(req.data)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "data size 0x%x too large for packet",
 			    (guint)datasz);
 		return FALSE;
 	}
 	if (datasz != blocksz) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "block size 0x%x != 0x%x untested",
 			    (guint)datasz,
 			    (guint)blocksz);

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -43,8 +43,8 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 	/* sanity check */
 	if (token_idx > FU_WAC_FIRMWARE_TOKENS_MAX) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "file has too many lines");
 		return FALSE;
 	}

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -92,8 +92,8 @@ fu_wistron_dock_device_control_cb(FuDevice *device, gpointer user_data, GError *
 			return FALSE;
 		if (helper->buf[7] != FU_WISTRON_DOCK_CMD_ICP_DONE) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "not icp-done, got 0x%02x",
 				    helper->cmd[7]);
 			return FALSE;
@@ -174,8 +174,8 @@ fu_wistron_dock_device_data_write_cb(FuDevice *device, gpointer user_data, GErro
 		return FALSE;
 	if (helper->cmd[7] != FU_WISTRON_DOCK_CMD_ICP_DONE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "not icp-done, got 0x%02x",
 			    helper->cmd[7]);
 		return FALSE;
@@ -363,8 +363,8 @@ fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 	/* sanity check sizes */
 	if (fu_firmware_get_size(fw_wsig) < FU_WISTRON_DOCK_WDFL_SIG_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "WDFL signature size invalid, got 0x%x, expected >= 0x%x",
 			    (guint)fu_firmware_get_size(fw_wsig),
 			    (guint)FU_WISTRON_DOCK_WDFL_SIG_SIZE);
@@ -372,8 +372,8 @@ fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 	}
 	if (fu_firmware_get_size(fw_wdfl) != FU_WISTRON_DOCK_WDFL_DATA_SIZE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "WDFL size invalid, got 0x%x, expected 0x%x",
 			    (guint)fu_firmware_get_size(fw_wdfl),
 			    (guint)FU_WISTRON_DOCK_WDFL_DATA_SIZE);
@@ -599,8 +599,8 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 		return FALSE;
 	if (fu_struct_wistron_dock_wdit_get_tag_id(st) != FU_WISTRON_DOCK_WDIT_TAG_ID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "WDIT tag invalid, expected 0x%x, got 0x%x",
 			    (guint)FU_WISTRON_DOCK_WDIT_TAG_ID,
 			    fu_struct_wistron_dock_wdit_get_tag_id(st));
@@ -611,8 +611,8 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 	if (fu_struct_wistron_dock_wdit_get_vid(st) != fu_usb_device_get_vid(FU_USB_DEVICE(self)) ||
 	    fu_struct_wistron_dock_wdit_get_pid(st) != fu_usb_device_get_pid(FU_USB_DEVICE(self))) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "USB VID:PID invalid, expected %04X:%04X, got %04X:%04X",
 			    (guint)fu_usb_device_get_vid(FU_USB_DEVICE(self)),
 			    (guint)fu_usb_device_get_pid(FU_USB_DEVICE(self)),

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -68,7 +68,7 @@ fu_cabinet_get_silo(FuCabinet *self, GError **error)
 	g_return_val_if_fail(FU_IS_CABINET(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 	if (self->silo == NULL) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_INITIALIZED, "no silo");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no silo");
 		return NULL;
 	}
 	return g_object_ref(self->silo);

--- a/src/fu-console.c
+++ b/src/fu-console.c
@@ -48,16 +48,16 @@ fu_console_setup(FuConsole *self, GError **error)
 	hOut = GetStdHandle(STD_OUTPUT_HANDLE);
 	if (hOut == INVALID_HANDLE_VALUE) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to get stdout [%u]",
 			    (guint)GetLastError());
 		return FALSE;
 	}
 	if (!GetConsoleMode(hOut, &dwMode)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to get mode [%u]",
 			    (guint)GetLastError());
 		return FALSE;
@@ -65,31 +65,31 @@ fu_console_setup(FuConsole *self, GError **error)
 	dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	if (!SetConsoleMode(hOut, dwMode)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set mode [%u]",
 			    (guint)GetLastError());
 		return FALSE;
 	}
 	if (!SetConsoleOutputCP(CP_UTF8)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set output UTF-8 [%u]",
 			    (guint)GetLastError());
 		return FALSE;
 	}
 	if (!SetConsoleCP(CP_UTF8)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set UTF-8 [%u]",
 			    (guint)GetLastError());
 		return FALSE;
 	}
 #else
 	if (isatty(fileno(stdout)) == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "not a TTY");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not a TTY");
 		return FALSE;
 	}
 #endif

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -405,6 +405,13 @@ fu_daemon_auth_helper_free(FuMainAuthHelper *helper)
 	g_free(helper);
 }
 
+static void
+fu_daemon_method_invocation_return_gerror(GDBusMethodInvocation *invocation, GError *error)
+{
+	fwupd_error_convert(&error);
+	g_dbus_method_invocation_return_gerror(invocation, error);
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuMainAuthHelper, fu_daemon_auth_helper_free)
@@ -418,13 +425,13 @@ fu_daemon_authorize_unlock_cb(GObject *source, GAsyncResult *res, gpointer user_
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* authenticated */
 	if (!fu_engine_unlock(helper->self->engine, helper->device_id, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -443,7 +450,7 @@ fu_daemon_authorize_get_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -462,7 +469,7 @@ fu_daemon_authorize_set_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -471,7 +478,7 @@ fu_daemon_authorize_set_bios_settings_cb(GObject *source, GAsyncResult *res, gpo
 					    helper->bios_settings,
 					    FALSE,
 					    &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 	/* success */
@@ -486,7 +493,7 @@ fu_daemon_authorize_set_approved_firmware_cb(GObject *source, GAsyncResult *res,
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -506,13 +513,13 @@ fu_daemon_authorize_set_blocked_firmware_cb(GObject *source, GAsyncResult *res, 
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* success */
 	if (!fu_engine_set_blocked_firmware(helper->self->engine, helper->checksums, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 	g_dbus_method_invocation_return_value(helper->invocation, NULL);
@@ -528,13 +535,13 @@ fu_daemon_authorize_fix_host_security_attr_cb(GObject *source,
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* success */
 	if (!fu_engine_fix_host_security_attr(helper->self->engine, helper->key, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 	g_dbus_method_invocation_return_value(helper->invocation, NULL);
@@ -550,13 +557,13 @@ fu_daemon_authorize_undo_host_security_attr_cb(GObject *source,
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* success */
 	if (!fu_engine_undo_host_security_attr(helper->self->engine, helper->key, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 	g_dbus_method_invocation_return_value(helper->invocation, NULL);
@@ -571,14 +578,14 @@ fu_daemon_authorize_self_sign_cb(GObject *source, GAsyncResult *res, gpointer us
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* authenticated */
 	sig = fu_engine_self_sign(helper->self->engine, helper->value, helper->flags, &error);
 	if (sig == NULL) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -594,7 +601,7 @@ fu_daemon_modify_config_cb(GObject *source, GAsyncResult *res, gpointer user_dat
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -603,7 +610,7 @@ fu_daemon_modify_config_cb(GObject *source, GAsyncResult *res, gpointer user_dat
 				     helper->key,
 				     helper->value,
 				     &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -619,11 +626,11 @@ fu_daemon_reset_config_cb(GObject *source, GAsyncResult *res, gpointer user_data
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 	if (!fu_engine_reset_config(helper->self->engine, helper->section, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -658,7 +665,7 @@ fu_daemon_authorize_activate_cb(GObject *source, GAsyncResult *res, gpointer use
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -675,7 +682,7 @@ fu_daemon_authorize_activate_cb(GObject *source, GAsyncResult *res, gpointer use
 
 	/* authenticated */
 	if (!fu_engine_activate(helper->self->engine, helper->device_id, progress, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -692,7 +699,7 @@ fu_daemon_authorize_verify_update_cb(GObject *source, GAsyncResult *res, gpointe
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -709,7 +716,7 @@ fu_daemon_authorize_verify_update_cb(GObject *source, GAsyncResult *res, gpointe
 
 	/* authenticated */
 	if (!fu_engine_verify_update(helper->self->engine, helper->device_id, progress, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -725,7 +732,7 @@ fu_daemon_authorize_modify_remote_cb(GObject *source, GAsyncResult *res, gpointe
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -735,7 +742,7 @@ fu_daemon_authorize_modify_remote_cb(GObject *source, GAsyncResult *res, gpointe
 				     helper->key,
 				     helper->value,
 				     &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -755,7 +762,7 @@ fu_daemon_authorize_install_cb(GObject *source, GAsyncResult *res, gpointer user
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -814,7 +821,7 @@ fu_daemon_authorize_install_queue(FuMainAuthHelper *helper_ref)
 	if (self->pending_stop)
 		g_main_loop_quit(self->loop);
 	if (!ret) {
-		g_dbus_method_invocation_return_gerror(helper->invocation, error);
+		fu_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
@@ -1133,7 +1140,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 	/* build request */
 	request = fu_daemon_create_request(self, sender, &error);
 	if (request == NULL) {
-		g_dbus_method_invocation_return_gerror(invocation, error);
+		fu_daemon_method_invocation_return_gerror(invocation, error);
 		return;
 	}
 	if (fu_engine_request_has_device_flag(request, FWUPD_DEVICE_FLAG_TRUSTED))
@@ -1147,12 +1154,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_debug("Called %s()", method_name);
 		devices = fu_engine_get_devices(self->engine, &error);
 		if (devices == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_device_array_to_variant(self, request, devices, &error);
 		if (val == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, val);
@@ -1170,12 +1177,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		releases = fu_engine_get_releases(self->engine, request, device_id, &error);
 		if (releases == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_release_array_to_variant(releases);
@@ -1215,7 +1222,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 
 		metadata = fu_engine_get_report_metadata(self->engine, &error);
 		if (metadata == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_variant_builder_init(&builder, G_VARIANT_TYPE("a{ss}"));
@@ -1337,12 +1344,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		releases = fu_engine_get_downgrades(self->engine, request, device_id, &error);
 		if (releases == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_release_array_to_variant(releases);
@@ -1355,12 +1362,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		releases = fu_engine_get_upgrades(self->engine, request, device_id, &error);
 		if (releases == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_release_array_to_variant(releases);
@@ -1372,7 +1379,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_debug("Called %s()", method_name);
 		remotes = fu_engine_get_remotes(self->engine, &error);
 		if (remotes == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_remote_array_to_variant(remotes);
@@ -1384,12 +1391,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_debug("Called %s()", method_name);
 		devices = fu_engine_get_history(self->engine, &error);
 		if (devices == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_device_array_to_variant(self, request, devices, &error);
 		if (val == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, val);
@@ -1436,7 +1443,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 #else
 		attrs = fu_engine_get_host_security_events(self->engine, limit, &error);
 		if (attrs == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_security_attrs_to_variant(attrs);
@@ -1449,7 +1456,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_engine_clear_results(self->engine, device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, NULL);
@@ -1503,7 +1510,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s&s&s)", &device_id, &key, &value);
 		g_debug("Called %s(%s,%s=%s)", method_name, device_id, key, value);
 		if (!fu_engine_modify_device(self->engine, device_id, key, value, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, NULL);
@@ -1515,12 +1522,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		result = fu_engine_get_results(self->engine, device_id, &error);
 		if (result == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fwupd_device_to_variant(result);
@@ -1543,30 +1550,30 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		fd_list = g_dbus_message_get_unix_fd_list(message);
 		if (fd_list == NULL || g_unix_fd_list_get_length(fd_list) != 2) {
 			g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "invalid handle");
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		fd_data = g_unix_fd_list_get(fd_list, 0, &error);
 		if (fd_data < 0) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		fd_sig = g_unix_fd_list_get(fd_list, 1, &error);
 		if (fd_sig < 0) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
 		/* store new metadata (will close the fds when done) */
 		if (!fu_engine_update_metadata(self->engine, remote_id, fd_data, fd_sig, &error)) {
 			g_prefix_error(&error, "Failed to update metadata for %s: ", remote_id);
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, NULL);
 #else
 		g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unsupported feature");
-		g_dbus_method_invocation_return_gerror(invocation, error);
+		fu_daemon_method_invocation_return_gerror(invocation, error);
 #endif /* HAVE_GIO_UNIX */
 		return;
 	}
@@ -1577,7 +1584,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
@@ -1604,7 +1611,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
@@ -1710,7 +1717,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
@@ -1739,7 +1746,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&s)", &device_id);
 		g_debug("Called %s(%s)", method_name, device_id);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
@@ -1755,7 +1762,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 				 self);
 
 		if (!fu_engine_verify(self->engine, device_id, progress, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		g_dbus_method_invocation_return_value(invocation, NULL);
@@ -1860,7 +1867,7 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_variant_get(parameters, "(&sha{sv})", &device_id, &fd_handle, &iter);
 		g_debug("Called %s(%s,%i)", method_name, device_id, fd_handle);
 		if (!fu_daemon_device_id_valid(device_id, &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
@@ -1901,12 +1908,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		fd_list = g_dbus_message_get_unix_fd_list(message);
 		if (fd_list == NULL || g_unix_fd_list_get_length(fd_list) != 1) {
 			g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "invalid handle");
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		fd = g_unix_fd_list_get(fd_list, 0, &error);
 		if (fd < 0) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		helper->stream = fu_unix_seekable_input_stream_new(fd, TRUE);
@@ -1919,12 +1926,12 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 				     G_CALLBACK(fu_daemon_client_flags_notify_cb),
 				     helper);
 		if (!fu_daemon_install_with_helper(g_steal_pointer(&helper), &error)) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 #else
 		g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unsupported feature");
-		g_dbus_method_invocation_return_gerror(invocation, error);
+		fu_daemon_method_invocation_return_gerror(invocation, error);
 #endif /* HAVE_GIO_UNIX */
 
 		/* async return */
@@ -1948,31 +1955,31 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		fd_list = g_dbus_message_get_unix_fd_list(message);
 		if (fd_list == NULL || g_unix_fd_list_get_length(fd_list) != 1) {
 			g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "invalid handle");
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		fd = g_unix_fd_list_get(fd_list, 0, &error);
 		if (fd < 0) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 
 		/* get details about the file (will close the fd when done) */
 		stream = fu_unix_seekable_input_stream_new(fd, TRUE);
 		if (stream == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		results = fu_engine_get_details(self->engine, request, stream, &error);
 		if (results == NULL) {
-			g_dbus_method_invocation_return_gerror(invocation, error);
+			fu_daemon_method_invocation_return_gerror(invocation, error);
 			return;
 		}
 		val = fu_daemon_result_array_to_variant(results);
 		g_dbus_method_invocation_return_value(invocation, val);
 #else
 		g_set_error(&error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unsupported feature");
-		g_dbus_method_invocation_return_gerror(invocation, error);
+		fu_daemon_method_invocation_return_gerror(invocation, error);
 #endif /* HAVE_GIO_UNIX */
 		return;
 	}
@@ -2087,12 +2094,11 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 					  g_steal_pointer(&helper));
 		return;
 	}
-	g_set_error(&error,
-		    G_DBUS_ERROR,
-		    G_DBUS_ERROR_UNKNOWN_METHOD,
-		    "no such method %s",
-		    method_name);
-	g_dbus_method_invocation_return_gerror(invocation, error);
+	g_dbus_method_invocation_return_error(invocation,
+					      G_DBUS_ERROR,
+					      G_DBUS_ERROR_UNKNOWN_METHOD,
+					      "no such method %s",
+					      method_name);
 }
 
 static GVariant *
@@ -2365,9 +2371,9 @@ fu_daemon_setup(FuDaemon *self, const gchar *socket_address, GError **error)
 		self->machine_kind = fu_daemon_machine_kind_from_string(machine_kind);
 		if (self->machine_kind == FU_DAEMON_MACHINE_KIND_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
-				    "Invalid machine kind specified: %s",
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid machine kind specified: %s",
 				    machine_kind);
 			return FALSE;
 		}

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -37,8 +37,8 @@ fu_engine_config_report_from_flags(FwupdReport *report, const gchar *flags_str, 
 		FwupdReportFlags flag = fwupd_report_flag_from_string(flags_strv[i]);
 		if (flag == FWUPD_REPORT_FLAG_UNKNOWN) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "report flag '%s' unknown",
 				    flags_strv[i]);
 			return FALSE;
@@ -59,8 +59,8 @@ fu_engine_config_report_from_spec(FuEngineConfig *self, const gchar *report_spec
 		g_auto(GStrv) kv = g_strsplit(parts[i], "=", 2);
 		if (g_strv_length(kv) != 2) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to parse report specifier key=value %s",
 				    parts[i]);
 			return NULL;
@@ -93,8 +93,8 @@ fu_engine_config_report_from_spec(FuEngineConfig *self, const gchar *report_spec
 				return NULL;
 		} else {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_DATA,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
 				    "failed to parse report specifier key %s",
 				    kv[0]);
 			return NULL;

--- a/src/fu-engine-helper.c
+++ b/src/fu-engine-helper.c
@@ -289,7 +289,7 @@ fu_engine_integrity_new(GError **error)
 
 	/* nothing of use */
 	if (g_hash_table_size(self) == 0) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "no measurements");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no measurements");
 		return NULL;
 	}
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1272,7 +1272,7 @@ fu_engine_verify_from_local_metadata(FuEngine *self, FuDevice *device, GError **
 	fn = g_strdup_printf("%s/verify/%s.xml", localstatedir, fu_device_get_id(device));
 	file = g_file_new_for_path(fn);
 	if (!g_file_query_exists(file, NULL)) {
-		g_set_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "failed to find %s", fn);
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "failed to find %s", fn);
 		return NULL;
 	}
 
@@ -1342,7 +1342,7 @@ fu_engine_verify_from_system_metadata(FuEngine *self, FuDevice *device, GError *
 	}
 
 	/* not found */
-	g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, "failed to find release");
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "failed to find release");
 	return NULL;
 }
 
@@ -1407,7 +1407,7 @@ fu_engine_verify(FuEngine *self, const gchar *device_id, FuProgress *progress, G
 		g_autoptr(GError) error_system = NULL;
 		release = fu_engine_verify_from_system_metadata(self, device, &error_system);
 		if (release == NULL) {
-			if (!g_error_matches(error_system, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) &&
+			if (!g_error_matches(error_system, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) &&
 			    !g_error_matches(error_system,
 					     G_IO_ERROR,
 					     G_IO_ERROR_INVALID_ARGUMENT)) {
@@ -1941,8 +1941,8 @@ fu_engine_install_releases(FuEngine *self,
 		GInputStream *stream = fu_release_get_stream(release);
 		if (stream == NULL) {
 			g_set_error_literal(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_SUPPORTED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "no stream for release");
 			return FALSE;
 		}
@@ -2103,16 +2103,16 @@ fu_realpath(const gchar *filename, GError **error)
 	if (_fullpath(full_tmp, filename, sizeof(full_tmp)) == NULL) {
 #endif
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot resolve path: %s",
 			    g_strerror(errno));
 		return NULL;
 	}
 	if (!g_file_test(full_tmp, G_FILE_TEST_EXISTS)) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVALID_DATA,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot find path: %s",
 			    full_tmp);
 		return NULL;
@@ -3774,8 +3774,8 @@ fu_engine_create_metadata(FuEngine *self, XbBuilder *builder, FwupdRemote *remot
 	path = fwupd_remote_get_filename_cache(remote);
 	if (path == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "no filename cache for %s",
 			    fwupd_remote_get_id(remote));
 		return FALSE;
@@ -6752,8 +6752,8 @@ fu_engine_get_previous_bios_security_attr(FuEngine *self,
 
 	/* failed */
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot find previous BIOS value");
 	return NULL;
 }
@@ -6785,8 +6785,8 @@ fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GErr
 		return FALSE;
 	if (!fwupd_security_attr_has_flag(hsi_attr, FWUPD_SECURITY_ATTR_FLAG_CAN_FIX)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "cannot auto-fix attribute");
 		return FALSE;
 	}
@@ -6798,7 +6798,7 @@ fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GErr
 
 	/* first try the per-plugin vfunc */
 	if (!fu_plugin_runner_fix_host_security_attr(plugin, hsi_attr, &error_local)) {
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
@@ -6811,8 +6811,8 @@ fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GErr
 	/* fall back to setting the BIOS attribute */
 	if (fwupd_security_attr_get_bios_setting_id(hsi_attr) == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no BIOS setting ID set");
 		return FALSE;
 	}
@@ -6820,8 +6820,8 @@ fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GErr
 						fwupd_security_attr_get_bios_setting_id(hsi_attr));
 	if (bios_attr == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot get BIOS setting %s",
 			    fwupd_security_attr_get_bios_setting_id(hsi_attr));
 		return FALSE;
@@ -6860,8 +6860,8 @@ fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GEr
 		return FALSE;
 	if (!fwupd_security_attr_has_flag(hsi_attr, FWUPD_SECURITY_ATTR_FLAG_CAN_UNDO)) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "cannot auto-undo attribute");
 		return FALSE;
 	}
@@ -6873,7 +6873,7 @@ fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GEr
 
 	/* first try the per-plugin vfunc */
 	if (!fu_plugin_runner_undo_host_security_attr(plugin, hsi_attr, &error_local)) {
-		if (!g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
@@ -6882,8 +6882,8 @@ fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GEr
 	/* fall back to setting the BIOS attribute */
 	if (fwupd_security_attr_get_bios_setting_id(hsi_attr) == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no BIOS setting ID");
 		return FALSE;
 	}
@@ -6891,16 +6891,16 @@ fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GEr
 						fwupd_security_attr_get_bios_setting_id(hsi_attr));
 	if (bios_attr == NULL) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot get BIOS setting %s",
 			    fwupd_security_attr_get_bios_setting_id(hsi_attr));
 		return FALSE;
 	}
 	if (fwupd_security_attr_get_bios_setting_current_value(hsi_attr) == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no BIOS setting current value");
 		return FALSE;
 	}
@@ -6924,7 +6924,10 @@ fu_engine_security_attrs_from_json(FuEngine *self, JsonNode *json_node, GError *
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 
@@ -6947,7 +6950,10 @@ fu_engine_devices_from_json(FuEngine *self, JsonNode *json_node, GError **error)
 
 	/* sanity check */
 	if (!JSON_NODE_HOLDS_OBJECT(json_node)) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA, "not JSON object");
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "not JSON object");
 		return FALSE;
 	}
 
@@ -7451,8 +7457,8 @@ fu_engine_backend_device_added_run_plugin(FuEngine *self,
 		/* sanity check */
 		if (*error == NULL) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_INVALID_ARGUMENT,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
 				    "%s failed but no error set",
 				    fu_device_get_backend_id(device));
 			return FALSE;
@@ -7481,8 +7487,7 @@ fu_engine_backend_device_added_run_plugins(FuEngine *self, FuDevice *device, FuP
 							       plugin_name,
 							       fu_progress_get_child(progress),
 							       &error_local)) {
-			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
-			    g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED)) {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 				g_debug("%s ignoring: %s", plugin_name, error_local->message);
 			} else {
 				g_warning("failed to add device %s: %s",
@@ -7789,23 +7794,24 @@ static void
 fu_engine_ensure_client_certificate(FuEngine *self)
 {
 	g_autoptr(GBytes) blob = g_bytes_new_static(NULL, 0);
-	g_autoptr(GError) error = NULL;
+	g_autoptr(GError) error_local = NULL;
 	g_autoptr(JcatBlob) jcat_sig = NULL;
 	g_autoptr(JcatEngine) jcat_engine = NULL;
 
 	/* create keyring and sign dummy data to ensure certificate exists */
-	jcat_engine = jcat_context_get_engine(self->jcat_context, JCAT_BLOB_KIND_PKCS7, &error);
+	jcat_engine =
+	    jcat_context_get_engine(self->jcat_context, JCAT_BLOB_KIND_PKCS7, &error_local);
 	if (jcat_engine == NULL) {
-		g_message("failed to create keyring: %s", error->message);
+		g_message("failed to create keyring: %s", error_local->message);
 		return;
 	}
-	jcat_sig = jcat_engine_self_sign(jcat_engine, blob, JCAT_SIGN_FLAG_NONE, &error);
+	jcat_sig = jcat_engine_self_sign(jcat_engine, blob, JCAT_SIGN_FLAG_NONE, &error_local);
 	if (jcat_sig == NULL) {
-		if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT)) {
-			g_info("client certificate now exists: %s", error->message);
+		if (g_error_matches(error_local, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT)) {
+			g_info("client certificate now exists: %s", error_local->message);
 			return;
 		}
-		g_message("failed to sign using keyring: %s", error->message);
+		g_message("failed to sign using keyring: %s", error_local->message);
 		return;
 	}
 	g_info("client certificate exists and working");
@@ -7908,9 +7914,9 @@ fu_common_win32_registry_get_string(HKEY hkey,
 	rc = RegGetValue(hkey, subkey, value, RRF_RT_REG_SZ, NULL, (PVOID)&buf, &bufsz);
 	if (rc != ERROR_SUCCESS) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVAL,
-			    "Failed to get registry string %s [0x%lX]",
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to get registry string %s [0x%lX]",
 			    subkey,
 			    (unsigned long)rc);
 		return NULL;
@@ -8073,8 +8079,8 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	/* sanity check libraries are in sync with daemon */
 	if (g_strcmp0(fwupd_version_string(), VERSION) != 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_INVAL,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "libfwupd version %s does not match daemon %s",
 			    fwupd_version_string(),
 			    VERSION);

--- a/src/fu-polkit-agent.c
+++ b/src/fu-polkit-agent.c
@@ -189,8 +189,8 @@ fu_polkit_agent_open(GError **error)
 		return TRUE;
 	if (pipe(pipe_fd) < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to create pipe: %s",
 			    g_strerror(errno));
 		return FALSE;
@@ -207,8 +207,8 @@ fu_polkit_agent_open(GError **error)
 		       NULL);
 	if (r < 0) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_FAILED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
 			    "failed to fork TTY ask password agent: %s",
 			    g_strerror(-r));
 		close_nointr_nofail(pipe_fd[1]);

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -214,8 +214,8 @@ fu_remote_list_cleanup_remote(FwupdRemote *remote, GError **error)
 			g_info("deleting obsolete %s", fn);
 			if (g_unlink(fn) == -1) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_FAILED,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INTERNAL,
 					    "failed to delete obsolete %s",
 					    fn);
 				return FALSE;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -6057,7 +6057,7 @@ fu_remote_auth_func(void)
 					  fwupd_remote_get_filename_cache_sig(remote),
 					  &error);
 	if (!ret) {
-		if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_PARTIAL_INPUT)) {
+		if (g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_READ)) {
 			g_test_skip("no jcat-tool, so skipping test");
 			return;
 		}

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2602,8 +2602,8 @@ fu_util_firmware_parse(FuUtilPrivate *priv, gchar **values, GError **error)
 			gtype_tmp = fu_context_get_firmware_gtype_by_id(ctx, gtype_id);
 			if (gtype_tmp == G_TYPE_INVALID) {
 				g_set_error(error,
-					    G_IO_ERROR,
-					    G_IO_ERROR_NOT_FOUND,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_FOUND,
 					    "GType %s not supported",
 					    gtype_id);
 				return FALSE;
@@ -2634,8 +2634,8 @@ fu_util_firmware_parse(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype = fu_context_get_firmware_gtype_by_id(ctx, firmware_type);
 	if (gtype == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type);
 		return FALSE;
@@ -2704,8 +2704,8 @@ fu_util_firmware_export(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype = fu_context_get_firmware_gtype_by_id(ctx, firmware_type);
 	if (gtype == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type);
 		return FALSE;
@@ -2762,8 +2762,8 @@ fu_util_firmware_extract(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype = fu_context_get_firmware_gtype_by_id(ctx, firmware_type);
 	if (gtype == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type);
 		return FALSE;
@@ -2862,8 +2862,8 @@ fu_util_firmware_build(FuUtilPrivate *priv, gchar **values, GError **error)
 		gtype = g_type_from_name(tmp);
 		if (gtype == G_TYPE_INVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "GType %s not registered",
 				    tmp);
 			return FALSE;
@@ -2875,8 +2875,8 @@ fu_util_firmware_build(FuUtilPrivate *priv, gchar **values, GError **error)
 		    fu_context_get_firmware_gtype_by_id(fu_engine_get_context(priv->engine), tmp);
 		if (gtype == G_TYPE_INVALID) {
 			g_set_error(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_FOUND,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
 				    "GType %s not supported",
 				    tmp);
 			return FALSE;
@@ -2957,8 +2957,8 @@ fu_util_firmware_convert(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype_src = fu_context_get_firmware_gtype_by_id(ctx, firmware_type_src);
 	if (gtype_src == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type_src);
 		return FALSE;
@@ -2970,8 +2970,8 @@ fu_util_firmware_convert(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype_dst = fu_context_get_firmware_gtype_by_id(ctx, firmware_type_dst);
 	if (gtype_dst == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type_dst);
 		return FALSE;
@@ -3096,8 +3096,8 @@ fu_util_firmware_patch(FuUtilPrivate *priv, gchar **values, GError **error)
 	gtype = fu_context_get_firmware_gtype_by_id(ctx, firmware_type);
 	if (gtype == G_TYPE_INVALID) {
 		g_set_error(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_FOUND,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
 			    "GType %s not supported",
 			    firmware_type);
 		return FALSE;
@@ -3532,8 +3532,8 @@ fu_util_esp_list(FuUtilPrivate *priv, gchar **values, GError **error)
 	mount_point = fu_volume_get_mount_point(volume);
 	if (mount_point == NULL) {
 		g_set_error_literal(error,
-				    G_IO_ERROR,
-				    G_IO_ERROR_NOT_SUPPORTED,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "no mountpoint for ESP");
 		return FALSE;
 	}
@@ -3990,7 +3990,7 @@ static gboolean
 fu_util_setup_interactive(FuUtilPrivate *priv, GError **error)
 {
 	if (priv->as_json) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "using --json");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "using --json");
 		return FALSE;
 	}
 	return fu_console_setup(priv->console, error);

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -93,9 +93,10 @@ fu_unix_seekable_input_stream_truncate(GSeekable *seekable,
 				       GCancellable *cancellable,
 				       GError **error)
 {
+	/* using GIOError here as this will eventually go into GLib */
 	g_set_error_literal(error,
 			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    G_IO_ERROR_NOT_SUPPORTED, /* nocheck */
 			    "cannot truncate FuUnixSeekableInputStream");
 	return FALSE;
 }

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -180,8 +180,8 @@ fu_usb_backend_load(FuBackend *backend,
 	return g_usb_context_load_with_tag(self->usb_ctx, json_object, tag, error);
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "GUsb version too old to load backends");
 	return FALSE;
 #endif
@@ -220,8 +220,8 @@ fu_usb_backend_save(FuBackend *backend,
 	return TRUE;
 #else
 	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "GUsb version too old to save backends");
 	return FALSE;
 #endif

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4791,7 +4791,7 @@ static gboolean
 fu_util_setup_interactive(FuUtilPrivate *priv, GError **error)
 {
 	if (priv->as_json) {
-		g_set_error_literal(error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED, "using --json");
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "using --json");
 		return FALSE;
 	}
 	return fu_console_setup(priv->console, error);


### PR DESCRIPTION
At the moment plugins are using the error domains interchangably, which means we have to have multiple g_error_matches() cases for each domain, for each place we're converting the error.

Also make sure we're returning only a FwupdError from daemon D-Bus methods, as failures seems to be leaking out, making it impossible for the front-end to do anything sane.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
