### PR TITLE
audio-s5gen2: plugin for updating Qualcomm audio devices

### DIFF
--- a/data/device-tests/qualcomm-qcc5171.json
+++ b/data/device-tests/qualcomm-qcc5171.json
@@ -1,0 +1,18 @@
+{
+  "name": "Qualcomm QCC5171",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "https://fwupd.org/downloads/084ebf794bfcb56b7c749238b4c6ed211342738cece664d02b0cbe285eb646f8-Qualcomm_qcc517X_1.1.2.cab",
+      "emulation-url": "https://fwupd.org/downloads/e87827fa8ee36d0dc8cfc217fd2a8964183caeff963ef248ed11d43b0e582959-qc-reinstall-1.1.2.zip",
+      "components": [
+        {
+          "version": "1.1.2",
+          "guids": [
+            "f3eb444d-46de-59da-97b1-7a281cb6a778"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/audio-s5gen2/README.md
+++ b/plugins/audio-s5gen2/README.md
@@ -1,0 +1,58 @@
+---
+title: Plugin: audio-s5gen2
+---
+
+## Introduction
+
+Firmware Update Plug-in for Qualcomm Voice & Music Series 5 Gen 1 and Gen 2, and Series 3 Gen 1, Gen 2 and Gen 3.
+
+## Firmware Format
+
+The daemon will decompress the cabinet archive and extract a firmware blob in
+a packed binary file format.
+
+The DFU file format is covered in documentation from Qualcomm, referenced by 80-CH281-1.
+
+This plugin supports the following protocol ID:
+
+* `com.qualcomm.s5gen2`
+
+## GUID Generation
+
+These devices use the standard  DeviceInstanceId values, e.g.
+
+* `USB\VID_0A12&PID_4007`
+
+## Update Behavior
+
+The device is updated in runtime mode and rebooted with a new version. The new
+firmware is saved after commit command, otherwise the device is rebooted with
+a previous version.
+
+The upgrade protocol and update behivior are specified in documentation from Qualcomm,
+referenced by 80-CH281-1 and 80-CU043-1.
+
+## Vendor ID Security
+
+The vendor ID is set from the USB vendor, in this instance set to `USB:0x0A12`
+
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+* no specific quirks
+
+## External Interface Access
+
+This plugin requires read/write access to `/dev/bus/usb`.
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.0.0`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Denis Pynkin: @d4s

--- a/plugins/audio-s5gen2/audio-s5gen2.quirk
+++ b/plugins/audio-s5gen2/audio-s5gen2.quirk
@@ -1,0 +1,5 @@
+# 5171 devboard
+[USB\VID_0A12&PID_4007]
+Plugin = audio_s5gen2
+Flags = enforce-requires
+ProxyGType = FuQcS5gen2HidDevice

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-device.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-device.c
@@ -1,0 +1,685 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-audio-s5gen2-device.h"
+#include "fu-audio-s5gen2-firmware.h"
+#include "fu-audio-s5gen2-impl.h"
+#include "fu-audio-s5gen2-struct.h"
+
+#define FU_QC_S5GEN2_DEVICE_DATA_REQ_SLEEP 1000 /* ms */
+#define FU_QC_S5GEN2_DEVICE_SEND_DELAY	   2	/* ms */
+
+/* 100ms delay requested by device as a rule */
+#define FU_QC_S5GEN2_DEVICE_VALIDATION_RETRIES (60000 / 100)
+
+struct _FuQcS5gen2Device {
+	FuDevice parent_instance;
+	guint32 file_id;
+	guint8 file_version;
+	guint16 battery_raw;
+};
+
+G_DEFINE_TYPE(FuQcS5gen2Device, fu_qc_s5gen2_device, FU_TYPE_DEVICE)
+
+static void
+fu_qc_s5gen2_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	fu_string_append_kx(str, idt, "FileId", self->file_id);
+	fu_string_append_kx(str, idt, "FileVersion", self->file_version);
+	fu_string_append_kx(str, idt, "BatteryRaw", self->battery_raw);
+}
+
+static gboolean
+fu_qc_s5gen2_device_msg_out(FuQcS5gen2Device *self, guint8 *data, gsize data_len, GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(FU_DEVICE(self));
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
+		return FALSE;
+	}
+	return fu_qc_s5gen2_impl_msg_out(FU_QC_S5GEN2_IMPL(proxy), data, data_len, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_msg_in(FuQcS5gen2Device *self, guint8 *data_in, gsize data_len, GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(FU_DEVICE(self));
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
+		return FALSE;
+	}
+	return fu_qc_s5gen2_impl_msg_in(FU_QC_S5GEN2_IMPL(proxy), data_in, data_len, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_msg_cmd(FuQcS5gen2Device *self, guint8 *data, gsize data_len, GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(FU_DEVICE(self));
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
+		return FALSE;
+	}
+	return fu_qc_s5gen2_impl_msg_cmd(FU_QC_S5GEN2_IMPL(proxy), data, data_len, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_req_disconnect(FuQcS5gen2Device *self, GError **error)
+{
+	g_autoptr(GByteArray) req = fu_struct_qc_disconnect_req_new();
+	return fu_qc_s5gen2_device_msg_cmd(self, req->data, req->len, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_req_connect(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data_in[FU_STRUCT_QC_UPDATE_STATUS_SIZE] = {0x0};
+	FuQcStatus update_status;
+	g_autoptr(GByteArray) req = fu_struct_qc_connect_req_new();
+	g_autoptr(GByteArray) st = NULL;
+
+	if (!fu_qc_s5gen2_device_msg_cmd(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data_in, sizeof(data_in), error))
+		return FALSE;
+	st = fu_struct_qc_update_status_parse(data_in, sizeof(data_in), 0, error);
+	if (st == NULL)
+		return FALSE;
+
+	update_status = fu_struct_qc_update_status_get_status(st);
+	switch (update_status) {
+	case FU_QC_STATUS_SUCCESS:
+		break;
+	case FU_QC_STATUS_ALREADY_CONNECTED_WARNING:
+		g_info("device is already connected");
+		/* FIXME: continue the previous update for wireless
+		 * atm fail for USB */
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "device is already connected");
+		return FALSE;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "invalid update status (%s)",
+			    fu_qc_status_to_string(update_status));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_abort(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data[FU_STRUCT_QC_ABORT_SIZE] = {0};
+	g_autoptr(GByteArray) req = fu_struct_qc_abort_req_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	reply = fu_struct_qc_abort_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_sync(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data[FU_STRUCT_QC_SYNC_SIZE] = {0};
+	FuQcResumePoint rp;
+	g_autoptr(GByteArray) req = fu_struct_qc_sync_req_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	fu_struct_qc_sync_req_set_file_id(req, self->file_id);
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	/* FIXME: correct error handling -- move to msg_in()? */
+	if (data[0] == 0x11) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "unexpected error (0x%.02X)",
+			    data[0]);
+		return FALSE;
+	}
+
+	reply = fu_struct_qc_sync_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	if (self->file_version != fu_struct_qc_sync_get_protocol_version(reply)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "unsupported firmware protocol version on device %u, expected %u",
+			    fu_struct_qc_sync_get_protocol_version(reply),
+			    self->file_version);
+		return FALSE;
+	}
+
+	rp = fu_struct_qc_sync_get_resume_point(reply);
+	switch (rp) {
+	case FU_QC_RESUME_POINT_START:
+	case FU_QC_RESUME_POINT_POST_REBOOT:
+		break;
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "unexpected resume point (%s)",
+			    fu_qc_resume_point_to_string(rp));
+		return FALSE;
+	}
+
+	if (self->file_id != fu_struct_qc_sync_get_file_id(reply)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "unexpected file ID from the device (%u), expected (%u)",
+			    fu_struct_qc_sync_get_file_id(reply),
+			    self->file_id);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_start(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data[FU_STRUCT_QC_START_SIZE] = {0};
+	FuQcStartStatus status;
+	g_autoptr(GByteArray) req = fu_struct_qc_start_req_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	reply = fu_struct_qc_start_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	status = fu_struct_qc_start_get_status(reply);
+	if (status != FU_QC_START_STATUS_SUCCESS) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "status failure in upgrade (%s)",
+			    fu_qc_start_status_to_string(status));
+		return FALSE;
+	}
+
+	/* check battery */
+	self->battery_raw = fu_struct_qc_start_get_battery_level(reply);
+
+	/* FIXME: calculate and set real percentage here.
+	 * For now just pass the threshold. */
+	fu_device_set_battery_level(FU_DEVICE(self), 100);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_start_data(FuQcS5gen2Device *self, GError **error)
+{
+	g_autoptr(GByteArray) req = fu_struct_qc_start_data_req_new();
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+
+	fu_device_sleep(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_DATA_REQ_SLEEP);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_validation(FuQcS5gen2Device *self, GError **error)
+{
+	FuQcOpcode opcode;
+	guint16 delay_ms;
+	guint8 data[FU_STRUCT_QC_VALIDATION_SIZE] = {0};
+	g_autoptr(GByteArray) req = fu_struct_qc_validation_req_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	/* do not care about FU_QC_OPCODE_TRANSFER_COMPLETE_IND format */
+	reply = fu_struct_qc_validation_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	opcode = fu_struct_qc_validation_get_opcode(reply);
+	switch (opcode) {
+	case FU_QC_OPCODE_TRANSFER_COMPLETE_IND:
+		break;
+	case FU_QC_OPCODE_IS_VALIDATION_DONE_CFM:
+		delay_ms = fu_struct_qc_validation_get_delay(reply);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "validation of the image is not complete, waiting (%u) ms",
+			    delay_ms);
+		fu_device_sleep(FU_DEVICE(self), delay_ms);
+		return FALSE;
+	default:
+		fu_device_sleep(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_SEND_DELAY);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "unexpected opcode (%s)",
+			    fu_qc_opcode_to_string(opcode));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_validation_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	return fu_qc_s5gen2_device_cmd_validation(FU_QC_S5GEN2_DEVICE(device), error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_transfer_complete(FuQcS5gen2Device *self, GError **error)
+{
+	g_autoptr(GByteArray) req = fu_struct_qc_transfer_complete_new();
+
+	fu_struct_qc_transfer_complete_set_action(req, FU_QC_ACTION_PROCEED);
+
+	return fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_proceed_to_commit(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data[FU_STRUCT_QC_COMMIT_REQ_SIZE] = {0};
+	g_autoptr(GByteArray) req = fu_struct_qc_proceed_to_commit_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	fu_struct_qc_proceed_to_commit_set_action(req, FU_QC_ACTION_PROCEED);
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	reply = fu_struct_qc_commit_req_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_cmd_commit(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 data[FU_STRUCT_QC_COMPLETE_SIZE] = {0};
+	g_autoptr(GByteArray) req = fu_struct_qc_commit_cfm_new();
+	g_autoptr(GByteArray) reply = NULL;
+
+	fu_struct_qc_commit_cfm_set_action(req, FU_QC_COMMIT_ACTION_UPGRADE);
+
+	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), error))
+		return FALSE;
+
+	reply = fu_struct_qc_complete_parse(data, sizeof(data), 0, error);
+	if (reply == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_ensure_version(FuQcS5gen2Device *self, GError **error)
+{
+	guint8 ver_raw[FU_STRUCT_QC_VERSION_SIZE] = {0};
+	g_autofree gchar *ver_str = NULL;
+	g_autoptr(FuDeviceLocker) locker = NULL;
+	g_autoptr(GByteArray) version = NULL;
+	g_autoptr(GByteArray) version_req = fu_struct_qc_version_req_new();
+
+	locker =
+	    fu_device_locker_new_full(FU_DEVICE(self),
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_connect,
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_disconnect,
+				      error);
+	if (locker == NULL)
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_out(self, version_req->data, version_req->len, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_msg_in(self, ver_raw, sizeof(ver_raw), error))
+		return FALSE;
+	version = fu_struct_qc_version_parse(ver_raw, sizeof(ver_raw), 0, error);
+	if (version == NULL)
+		return FALSE;
+
+	ver_str = g_strdup_printf("%u.%u.%u",
+				  fu_struct_qc_version_get_major(version),
+				  fu_struct_qc_version_get_minor(version),
+				  fu_struct_qc_version_get_config(version));
+	fu_device_set_version(FU_DEVICE(self), ver_str);
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	locker =
+	    fu_device_locker_new_full(device,
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_connect,
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_disconnect,
+				      error);
+	if (locker == NULL) {
+		g_prefix_error(error, "failed to connect: ");
+		return FALSE;
+	}
+	if (!fu_qc_s5gen2_device_cmd_sync(self, error)) {
+		g_prefix_error(error, "failed to cmd-sync: ");
+		return FALSE;
+	}
+	if (!fu_qc_s5gen2_device_cmd_start(self, error)) {
+		g_prefix_error(error, "failed to cmd-start: ");
+		return FALSE;
+	}
+	if (!fu_qc_s5gen2_device_cmd_proceed_to_commit(self, error)) {
+		g_prefix_error(error, "failed to cmd-proceed-to-commit: ");
+		return FALSE;
+	}
+	if (!fu_qc_s5gen2_device_cmd_commit(self, error)) {
+		g_prefix_error(error, "failed to cmd-commit: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_reload(FuDevice *device, GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	return fu_qc_s5gen2_device_ensure_version(self, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_setup(FuDevice *device, GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	return fu_qc_s5gen2_device_ensure_version(self, error);
+}
+
+static gboolean
+fu_qc_s5gen2_device_prepare(FuDevice *device,
+			    FuProgress *progress,
+			    FwupdInstallFlags flags,
+			    GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	locker =
+	    fu_device_locker_new_full(device,
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_connect,
+				      (FuDeviceLockerFunc)fu_qc_s5gen2_device_cmd_req_disconnect,
+				      error);
+	if (locker == NULL) {
+		g_prefix_error(error, "failed to connect: ");
+		return FALSE;
+	}
+
+	/* FIXME: do abort of any stalled upgrade for USB only
+	 * rework that part to continue update for wireless/USB */
+	if (!fu_qc_s5gen2_device_cmd_abort(self, error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_device_write_bucket(FuQcS5gen2Device *self,
+				 GBytes *data,
+				 FuQcMoreData last,
+				 GError **error)
+{
+	g_autoptr(FuChunkArray) chunks = NULL;
+
+	chunks = fu_chunk_array_new_from_bytes(data, 0, FU_STRUCT_QC_DATA_SIZE_DATA);
+
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		g_autoptr(GByteArray) pkt = fu_struct_qc_data_new();
+		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i, error);
+
+		if (chk == NULL)
+			return FALSE;
+
+		fu_struct_qc_data_set_data_len(pkt, fu_chunk_get_data_sz(chk) + 1);
+		/* only the last block of the last bucket should have flag LAST */
+		if ((i + 1) == fu_chunk_array_length(chunks))
+			fu_struct_qc_data_set_last_packet(pkt, last);
+		else
+			fu_struct_qc_data_set_last_packet(pkt, FU_QC_MORE_DATA_MORE);
+
+		if (!fu_struct_qc_data_set_data(pkt,
+						fu_chunk_get_data(chk),
+						fu_chunk_get_data_sz(chk),
+						error))
+			return FALSE;
+
+		if (!fu_qc_s5gen2_device_msg_out(self, pkt->data, pkt->len, error))
+			return FALSE;
+
+		/* wait between packets sending */
+		fu_device_sleep(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_SEND_DELAY);
+	}
+
+	return TRUE;
+}
+static gboolean
+fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
+				 GBytes *bytes,
+				 FuProgress *progress,
+				 GError **error)
+{
+	const gsize blobsz = g_bytes_get_size(bytes);
+	guint32 cur_offset = 0;
+	FuQcMoreData more_data = FU_QC_MORE_DATA_MORE;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+
+	/* device is requesting data from the host */
+	do {
+		guint8 buf_in[FU_STRUCT_QC_DATA_REQ_SIZE] = {0};
+		guint32 data_sz;
+		guint32 data_offset;
+		g_autoptr(GByteArray) data_req = NULL;
+		g_autoptr(GBytes) data_out = NULL;
+
+		if (!fu_qc_s5gen2_device_msg_in(self, buf_in, sizeof(buf_in), error))
+			return FALSE;
+		data_req = fu_struct_qc_data_req_parse(buf_in, sizeof(buf_in), 0, error);
+		if (data_req == NULL)
+			return FALSE;
+
+		/* requested data */
+		data_sz = fu_struct_qc_data_req_get_fw_data_len(data_req);
+		data_offset = fu_struct_qc_data_req_get_fw_data_offset(data_req);
+
+		cur_offset += data_offset;
+		/* requested data might be larger than the single packet payload */
+		/* FIXME: checking the data is less or equal the firmware size? */
+		if (blobsz < (cur_offset + data_sz)) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "unexpected firmware data requested: offset=%u, size=%u",
+				    cur_offset,
+				    data_sz);
+			return FALSE;
+		}
+
+		more_data = (blobsz <= (cur_offset + data_sz)) ? FU_QC_MORE_DATA_LAST
+							       : FU_QC_MORE_DATA_MORE;
+
+		data_out = g_bytes_new_from_bytes(bytes, cur_offset, data_sz);
+
+		if (!fu_qc_s5gen2_device_write_bucket(self, data_out, more_data, error))
+			return FALSE;
+
+		/* update progress */
+		fu_progress_set_percentage_full(progress, data_sz + cur_offset, blobsz);
+
+		cur_offset += data_sz;
+
+		/* FIXME: petentially infinite loop if device requesting wrong data?
+		   some counter or timeout? */
+	} while (more_data != FU_QC_MORE_DATA_LAST);
+
+	/* success */
+	return TRUE;
+}
+
+static FuFirmware *
+fu_qc_s5gen2_device_prepare_firmware(FuDevice *device,
+				     GInputStream *stream,
+				     FwupdInstallFlags flags,
+				     GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	g_autoptr(FuFirmware) firmware = fu_qc_s5gen2_firmware_new();
+
+	if (!fu_firmware_parse_stream(firmware, stream, 0, flags, error))
+		return NULL;
+
+	self->file_version =
+	    fu_qc_s5gen2_firmware_get_protocol_version(FU_QC_S5GEN2_FIRMWARE(firmware));
+	self->file_id = fu_qc_s5gen2_firmware_get_id(FU_QC_S5GEN2_FIRMWARE(firmware));
+
+	return g_steal_pointer(&firmware);
+}
+
+static gboolean
+fu_qc_s5gen2_device_write_firmware(FuDevice *device,
+				   FuFirmware *firmware,
+				   FuProgress *progress,
+				   FwupdInstallFlags flags,
+				   GError **error)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	g_autoptr(GBytes) fw = NULL;
+
+	if (!fu_qc_s5gen2_device_cmd_req_connect(self, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_cmd_sync(self, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_cmd_start(self, error))
+		return FALSE;
+	if (!fu_qc_s5gen2_device_cmd_start_data(self, error))
+		return FALSE;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 83, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 17, NULL);
+
+	/* get default image */
+	fw = fu_firmware_get_bytes(firmware, error);
+	if (fw == NULL)
+		return FALSE;
+
+	if (!fu_qc_s5gen2_device_write_blocks(self, fw, fu_progress_get_child(progress), error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* send validation request */
+	/* get the FU_QC_OPCODE_TRANSFER_COMPLETE_IND during 60000ms or fail */
+	if (!fu_device_retry_full(device,
+				  fu_qc_s5gen2_device_validation_cb,
+				  FU_QC_S5GEN2_DEVICE_VALIDATION_RETRIES,
+				  0, /* custom delay based on value in response */
+				  NULL,
+				  error))
+		return FALSE;
+
+	fu_progress_step_done(progress);
+
+	/* complete & reboot the device */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return fu_qc_s5gen2_device_cmd_transfer_complete(self, error);
+}
+
+static void
+fu_qc_s5gen2_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "reload");
+}
+
+static void
+fu_qc_s5gen2_hid_device_replace(FuDevice *device, FuDevice *donor)
+{
+	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);
+	FuQcS5gen2Device *self_donor = FU_QC_S5GEN2_DEVICE(donor);
+	self->file_id = self_donor->file_id;
+	self->file_version = self_donor->file_version;
+	self->battery_raw = self_donor->battery_raw;
+}
+
+static void
+fu_qc_s5gen2_device_init(FuQcS5gen2Device *self)
+{
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_remove_delay(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_REMOVE_DELAY);
+	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.s5gen2");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN);
+}
+
+static void
+fu_qc_s5gen2_device_class_init(FuQcS5gen2DeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_qc_s5gen2_device_to_string;
+	device_class->setup = fu_qc_s5gen2_device_setup;
+	device_class->reload = fu_qc_s5gen2_device_reload;
+	device_class->prepare = fu_qc_s5gen2_device_prepare;
+	device_class->attach = fu_qc_s5gen2_device_attach;
+	device_class->prepare_firmware = fu_qc_s5gen2_device_prepare_firmware;
+	device_class->write_firmware = fu_qc_s5gen2_device_write_firmware;
+	device_class->set_progress = fu_qc_s5gen2_hid_device_set_progress;
+	device_class->replace = fu_qc_s5gen2_hid_device_replace;
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-device.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-device.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_QC_S5GEN2_DEVICE_REMOVE_DELAY 90000 /* ms */
+
+#define FU_TYPE_QC_S5GEN2_DEVICE (fu_qc_s5gen2_device_get_type())
+G_DECLARE_FINAL_TYPE(FuQcS5gen2Device, fu_qc_s5gen2_device, FU, QC_S5GEN2_DEVICE, FuDevice)

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-audio-s5gen2-firmware.h"
+#include "fu-audio-s5gen2-fw-struct.h"
+
+struct _FuQcS5gen2Firmware {
+	FuFirmware parent_instance;
+	guint32 file_id;
+	guint8 protocol_ver;
+	gchar *device_variant;
+};
+
+G_DEFINE_TYPE(FuQcS5gen2Firmware, fu_qc_s5gen2_firmware, FU_TYPE_FIRMWARE)
+
+guint8
+fu_qc_s5gen2_firmware_get_protocol_version(FuQcS5gen2Firmware *self)
+{
+	return self->protocol_ver;
+}
+
+/* generated ID unique for the firmware */
+guint32
+fu_qc_s5gen2_firmware_get_id(FuQcS5gen2Firmware *self)
+{
+	return self->file_id;
+}
+
+static void
+fu_qc_s5gen2_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
+{
+	FuQcS5gen2Firmware *self = FU_QC_S5GEN2_FIRMWARE(firmware);
+	fu_xmlb_builder_insert_kv(bn, "device_variant", self->device_variant);
+	fu_xmlb_builder_insert_kx(bn, "protocol_version", self->protocol_ver);
+	fu_xmlb_builder_insert_kx(bn, "generated_file_id", self->file_id);
+}
+
+static gboolean
+fu_qc_s5gen2_firmware_validate(FuFirmware *firmware,
+			       GInputStream *stream,
+			       gsize offset,
+			       GError **error)
+{
+	return fu_struct_qc_fw_update_hdr_validate_stream(stream, offset, error);
+}
+
+static gboolean
+fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
+			    GInputStream *stream,
+			    gsize offset,
+			    FwupdInstallFlags flags,
+			    GError **error)
+{
+	FuQcS5gen2Firmware *self = FU_QC_S5GEN2_FIRMWARE(firmware);
+	const guint8 *device_variant;
+	gsize config_offset = 26;
+	guint16 config_ver;
+	g_autofree gchar *ver_str = NULL;
+	g_autoptr(GByteArray) hdr = NULL;
+
+	/* FIXME: deal with encrypted? */
+	hdr = fu_struct_qc_fw_update_hdr_parse_stream(stream, offset, error);
+	if (hdr == NULL)
+		return FALSE;
+
+	/* protocol version */
+	self->protocol_ver = fu_struct_qc_fw_update_hdr_get_protocol(hdr) - '0';
+	device_variant = fu_struct_qc_fw_update_hdr_get_dev_variant(hdr, NULL);
+	self->device_variant = fu_strsafe((const gchar *)device_variant, 8);
+
+	config_offset += fu_struct_qc_fw_update_hdr_get_upgrades(hdr) * 4;
+	if (!fu_input_stream_read_u16(stream, config_offset, &config_ver, G_BIG_ENDIAN, error))
+		return FALSE;
+
+	ver_str = g_strdup_printf("%u.%u.%u",
+				  fu_struct_qc_fw_update_hdr_get_major(hdr),
+				  fu_struct_qc_fw_update_hdr_get_minor(hdr),
+				  config_ver);
+	fu_firmware_set_version(firmware, ver_str);
+
+	if (!fu_firmware_set_stream(firmware, stream, error))
+		return FALSE;
+	if (!fu_input_stream_compute_crc32(stream, &self->file_id, 0xEDB88320, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static GByteArray *
+fu_qc_s5gen2_firmware_write(FuFirmware *firmware, GError **error)
+{
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autoptr(GBytes) fw = NULL;
+
+	/* data first */
+	fw = fu_firmware_get_bytes_with_patches(firmware, error);
+	if (fw == NULL)
+		return NULL;
+
+	fu_byte_array_append_bytes(buf, fw);
+
+	/* success */
+	return g_steal_pointer(&buf);
+}
+
+static void
+fu_qc_s5gen2_firmware_init(FuQcS5gen2Firmware *self)
+{
+	self->device_variant = NULL;
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
+}
+
+static void
+fu_qc_s5gen2_firmware_finalize(GObject *object)
+{
+	FuQcS5gen2Firmware *self = FU_QC_S5GEN2_FIRMWARE(object);
+	g_free(self->device_variant);
+	G_OBJECT_CLASS(fu_qc_s5gen2_firmware_parent_class)->finalize(object);
+}
+
+static void
+fu_qc_s5gen2_firmware_class_init(FuQcS5gen2FirmwareClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuFirmwareClass *klass_firmware = FU_FIRMWARE_CLASS(klass);
+	object_class->finalize = fu_qc_s5gen2_firmware_finalize;
+	klass_firmware->validate = fu_qc_s5gen2_firmware_validate;
+	klass_firmware->parse = fu_qc_s5gen2_firmware_parse;
+	klass_firmware->write = fu_qc_s5gen2_firmware_write;
+	klass_firmware->export = fu_qc_s5gen2_firmware_export;
+}
+
+FuFirmware *
+fu_qc_s5gen2_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_QC_S5GEN2_FIRMWARE, NULL));
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_QC_S5GEN2_FIRMWARE (fu_qc_s5gen2_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuQcS5gen2Firmware, fu_qc_s5gen2_firmware, FU, QC_S5GEN2_FIRMWARE, FuFirmware)
+
+FuFirmware *
+fu_qc_s5gen2_firmware_new(void);
+
+guint8
+fu_qc_s5gen2_firmware_get_protocol_version(FuQcS5gen2Firmware *self);
+
+guint32
+fu_qc_s5gen2_firmware_get_id(FuQcS5gen2Firmware *self);

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-fw.rs
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-fw.rs
@@ -1,0 +1,15 @@
+// Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+// SPDX-License-Identifier: LGPL-2.1+
+
+#[derive(ParseStream, ValidateStream)]
+struct FuStructQcFwUpdateHdr {
+    magic1: u32be == 0x41505055,
+    magic2: u16be == 0x4844,
+    magic3: u8 == 0x52,
+    protocol: u8,
+    length: u32be,
+    dev_variant: [u8; 8],
+    major: u16be,
+    minor: u16be,
+    upgrades: u16be,
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-hid-device.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-hid-device.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ * Copyright (C) 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-audio-s5gen2-device.h"
+#include "fu-audio-s5gen2-hid-device.h"
+#include "fu-audio-s5gen2-hid-struct.h"
+#include "fu-audio-s5gen2-impl.h"
+
+#define HID_IFACE  0x01
+#define HID_EP_IN  0x82
+#define HID_EP_OUT 0x01
+
+/* FIXME: value :-| */
+#define FU_QC_S5GEN2_HID_DEVICE_TIMEOUT 0 /* ms */
+
+struct _FuQcS5gen2HidDevice {
+	FuHidDevice parent_instance;
+};
+
+static void
+fu_qc_s5gen2_hid_device_impl_iface_init(FuQcS5gen2ImplInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuQcS5gen2HidDevice,
+			fu_qc_s5gen2_hid_device,
+			FU_TYPE_HID_DEVICE,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_QC_S5GEN2_IMPL,
+					      fu_qc_s5gen2_hid_device_impl_iface_init))
+
+static gboolean
+fu_qc_s5gen2_hid_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
+	g_autoptr(GByteArray) msg = fu_struct_qc_hid_data_transfer_new();
+
+	fu_struct_qc_hid_data_transfer_set_payload_len(msg, data_len);
+	if (!fu_struct_qc_hid_data_transfer_set_payload(msg, data, data_len, error))
+		return FALSE;
+
+	return fu_hid_device_set_report(FU_HID_DEVICE(self),
+					0x00,
+					msg->data,
+					FU_STRUCT_QC_HID_DATA_TRANSFER_SIZE,
+					FU_QC_S5GEN2_HID_DEVICE_TIMEOUT,
+					FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
+					error);
+}
+
+static gboolean
+fu_qc_s5gen2_hid_device_msg_in(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
+	guint8 buf[FU_STRUCT_QC_HID_RESPONSE_SIZE] = {0x0};
+	g_autoptr(GByteArray) msg = NULL;
+
+	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
+				      0x00,
+				      buf,
+				      FU_STRUCT_QC_HID_RESPONSE_SIZE,
+				      FU_QC_S5GEN2_HID_DEVICE_TIMEOUT,
+				      FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
+				      error))
+		return FALSE;
+
+	msg = fu_struct_qc_hid_response_parse(buf, FU_STRUCT_QC_HID_RESPONSE_SIZE, 0, error);
+	if (msg == NULL)
+		return FALSE;
+
+	if (!fu_memcpy_safe(data,
+			    data_len,
+			    0,
+			    msg->data,
+			    msg->len,
+			    FU_STRUCT_QC_HID_RESPONSE_OFFSET_PAYLOAD,
+			    fu_struct_qc_hid_response_get_payload_len(msg),
+			    error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_hid_device_msg_cmd(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
+	g_autoptr(GByteArray) msg = fu_struct_qc_hid_command_new();
+
+	fu_struct_qc_hid_command_set_payload_len(msg, data_len);
+	if (!fu_struct_qc_hid_command_set_payload(msg, data, data_len, error))
+		return FALSE;
+
+	return fu_hid_device_set_report(FU_HID_DEVICE(self),
+					0x03,
+					msg->data,
+					FU_STRUCT_QC_HID_COMMAND_SIZE,
+					0,
+					FU_HID_DEVICE_FLAG_IS_FEATURE,
+					error);
+}
+
+static gboolean
+fu_qc_s5gen2_hid_device_probe(FuDevice *device, GError **error)
+{
+	FuHidDevice *hid_device = FU_HID_DEVICE(device);
+	GUsbDevice *usb_device = fu_usb_device_get_dev(FU_USB_DEVICE(device));
+	GUsbInterface *iface = NULL;
+	g_autoptr(GPtrArray) ifaces = NULL;
+
+	ifaces = g_usb_device_get_interfaces(usb_device, error);
+	if (ifaces == NULL)
+		return FALSE;
+
+	/* need the second HID interface */
+	if (ifaces->len <= HID_IFACE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "transitional device detected");
+		return FALSE;
+	}
+
+	iface = g_ptr_array_index(ifaces, HID_IFACE);
+	if (g_usb_interface_get_class(iface) != G_USB_DEVICE_CLASS_HID) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "target interface is not HID");
+		return FALSE;
+	}
+
+	fu_hid_device_set_interface(hid_device, HID_IFACE);
+	fu_hid_device_set_ep_addr_in(hid_device, HID_EP_IN);
+	fu_hid_device_set_ep_addr_out(hid_device, HID_EP_OUT);
+
+	/* FuHidDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_qc_s5gen2_hid_device_parent_class)->probe(device, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_qc_s5gen2_hid_device_init(FuQcS5gen2HidDevice *self)
+{
+	fu_hid_device_add_flag(FU_HID_DEVICE(self), FU_HID_DEVICE_FLAG_RETRY_FAILURE);
+	fu_device_set_remove_delay(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_REMOVE_DELAY);
+	fu_device_set_battery_threshold(FU_DEVICE(self), 0);
+}
+
+static void
+fu_qc_s5gen2_hid_device_impl_iface_init(FuQcS5gen2ImplInterface *iface)
+{
+	iface->msg_in = fu_qc_s5gen2_hid_device_msg_in;
+	iface->msg_out = fu_qc_s5gen2_hid_device_msg_out;
+	iface->msg_cmd = fu_qc_s5gen2_hid_device_msg_cmd;
+}
+
+static void
+fu_qc_s5gen2_hid_device_class_init(FuQcS5gen2HidDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_qc_s5gen2_hid_device_probe;
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-hid-device.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-hid-device.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_QC_S5GEN2_HID_DEVICE (fu_qc_s5gen2_hid_device_get_type())
+G_DECLARE_FINAL_TYPE(FuQcS5gen2HidDevice,
+		     fu_qc_s5gen2_hid_device,
+		     FU,
+		     QC_S5GEN2_HID_DEVICE,
+		     FuHidDevice)

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-hid.rs
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-hid.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+// SPDX-License-Identifier: LGPL-2.1+
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcReportId {
+    Command = 3,
+    DataTransfer = 5,
+    Response = 6,
+}
+
+#[derive(New)]
+struct FuStructQcHidCommand {
+    report_id: FuQcReportId == Command,
+    payload_len: u8,
+    payload: [u8; 61],
+}
+
+#[derive(Parse)]
+struct FuStructQcHidResponse {
+    report_id: FuQcReportId == Response,
+    payload_len: u8,
+    payload: [u8; 11],
+}
+
+#[derive(New)]
+struct FuStructQcHidDataTransfer {
+    report_id: FuQcReportId == DataTransfer,
+    payload_len: u8,
+    payload: [u8; 253],
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-impl.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-impl.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-audio-s5gen2-impl.h"
+
+G_DEFINE_INTERFACE(FuQcS5gen2Impl, fu_qc_s5gen2_impl, G_TYPE_OBJECT)
+
+static void
+fu_qc_s5gen2_impl_default_init(FuQcS5gen2ImplInterface *iface)
+{
+}
+
+gboolean
+fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2ImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
+
+	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
+	if (iface->msg_in == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->msg_in not implemented");
+		return FALSE;
+	}
+	return (*iface->msg_in)(self, data, data_len, error);
+}
+
+gboolean
+fu_qc_s5gen2_impl_msg_out(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2ImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
+
+	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
+	if (iface->msg_out == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->msg_out not implemented");
+		return FALSE;
+	}
+	return (*iface->msg_out)(self, data, data_len, error);
+}
+
+gboolean
+fu_qc_s5gen2_impl_msg_cmd(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2ImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
+
+	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
+	if (iface->msg_cmd == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->msg_cmd not implemented");
+		return FALSE;
+	}
+	return (*iface->msg_cmd)(self, data, data_len, error);
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-impl.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-impl.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_QC_S5GEN2_IMPL (fu_qc_s5gen2_impl_get_type())
+G_DECLARE_INTERFACE(FuQcS5gen2Impl, fu_qc_s5gen2_impl, FU, QC_S5GEN2_IMPL, GObject)
+
+struct _FuQcS5gen2ImplInterface {
+	GTypeInterface g_iface;
+	gboolean (*msg_in)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+	gboolean (*msg_out)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+	gboolean (*msg_cmd)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+};
+
+gboolean
+fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+gboolean
+fu_qc_s5gen2_impl_msg_out(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+gboolean
+fu_qc_s5gen2_impl_msg_cmd(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-audio-s5gen2-device.h"
+#include "fu-audio-s5gen2-firmware.h"
+#include "fu-audio-s5gen2-hid-device.h"
+#include "fu-audio-s5gen2-plugin.h"
+
+struct _FuAudioS5gen2Plugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuAudioS5gen2Plugin, fu_audio_s5gen2_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_audio_s5gen2_plugin_init(FuAudioS5gen2Plugin *self)
+{
+}
+
+static void
+fu_audio_s5gen2_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_HID_DEVICE);
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QC_S5GEN2_DEVICE);
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_QC_S5GEN2_FIRMWARE);
+}
+
+static void
+fu_audio_s5gen2_plugin_class_init(FuAudioS5gen2PluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_audio_s5gen2_plugin_constructed;
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuAudioS5gen2Plugin, fu_audio_s5gen2_plugin, FU, AUDIO_S5GEN2_PLUGIN, FuPlugin)

--- a/plugins/audio-s5gen2/fu-audio-s5gen2.rs
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2023 Denis Pynkin <denis.pynkin@collabora.com>
+// SPDX-License-Identifier: LGPL-2.1+
+
+#[derive(ToString)]
+#[repr(u8)]
+// Upgrade protocol OpCode
+enum FuQcOpcode {
+    StartReq = 0x01,
+    StartCfm = 0x02,
+    DataBytesReq = 0x03,
+    Data = 0x04,
+    AbortReq = 0x07,
+    AbortCfm = 0x08,
+    TransferCompleteInd = 0x0B,
+    TransferCompleteRes = 0x0C,
+    ProceedToCommit = 0x0E,
+    CommitReq = 0x0F,
+    CommitCfm = 0x10,
+    ErrorInd = 0x11,
+    CompleteInd = 0x12,
+    SyncReq = 0x13,
+    SyncCfm = 0x14,
+    StartDataReq = 0x15,
+    IsValidationDoneReq = 0x16,
+    IsValidationDoneCfm = 0x17,
+    HostVersionReq = 0x19,
+    HostVersionCfm = 0x1A,
+    ErrorRes = 0x1F,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcAction {
+    Proceed = 0,
+    NotProceed = 1,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcReq {
+    Connect = 0x02,
+    Disconnect = 0x07,
+}
+#[derive(New)]
+struct FuStructQcConnectReq {
+    req: FuQcReq == Connect,
+}
+#[derive(New)]
+struct FuStructQcDisconnectReq {
+    req: FuQcReq == Disconnect,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcStatus {
+    Success = 0,         // Operation succeeded
+    UnexpectedError,    // Operation failed
+    AlreadyConnectedWarning,       // Already connected
+    InProgress,         // Requested operation failed, an upgrade is in progress
+    Busy,                // UNUSED
+    InvalidPowerState,  // Invalid power management state
+}
+#[derive(Parse)]
+struct FuStructQcUpdateStatus {
+    status: FuQcStatus,
+}
+
+#[derive(New)]
+struct FuStructQcVersionReq {
+    opcode: FuQcOpcode == HostVersionReq,
+    data_len: u16be == 0x00,
+}
+#[derive(Parse)]
+struct FuStructQcVersion {
+    status: FuQcOpcode == HostVersionCfm,
+    data_len: u16be == 0x0006,
+    major: u16be,
+    minor: u16be,
+    config: u16be,
+}
+
+#[derive(New)]
+struct FuStructQcAbortReq {
+    opcode: FuQcOpcode == AbortReq,
+    data_len: u16be = 0x00,
+}
+#[derive(Parse)]
+struct FuStructQcAbort {
+    opcode: FuQcOpcode == AbortCfm,
+    data_len: u16be = 0x00,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcResumePoint {
+    Start = 0,
+    PreValidate,
+    PreReboot,
+    PostReboot,
+    PostCommit,
+}
+#[derive(New)]
+struct FuStructQcSyncReq {
+    opcode: FuQcOpcode == SyncReq,
+    data_len: u16be = 0x04,
+    fileId: u32be,
+}
+#[derive(Parse)]
+struct FuStructQcSync {
+    opcode: FuQcOpcode == SyncCfm,
+    data_len: u16be = 0x06,
+    resume_point: FuQcResumePoint,
+    file_id: u32be,
+    protocolVersion: u8,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcStartStatus {
+    Success = 0,
+    Failure = 1,
+}
+#[derive(New)]
+struct FuStructQcStartReq {
+    opcode: FuQcOpcode == StartReq,
+    data_len: u16be = 0x00,
+}
+#[derive(Parse)]
+struct FuStructQcStart {
+    opcode: FuQcOpcode == StartCfm,
+    data_len: u16be = 0x0003,
+    status: FuQcStartStatus,
+    battery_level: u16be,
+}
+
+#[derive(New)]
+struct FuStructQcStartDataReq {
+    opcode: FuQcOpcode == StartDataReq,
+    data_len: u16be = 0x00,
+    data: [u8; 250],
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcMoreData {
+    More = 0,
+    Last = 1,
+}
+#[derive(Parse)]
+struct FuStructQcDataReq {
+    opcode: FuQcOpcode == DataBytesReq,
+    data_len: u16be = 0x0008,
+    fw_data_len: u32be,
+    fw_data_offset: u32be,
+}
+#[derive(New)]
+struct FuStructQcData {
+    opcode: FuQcOpcode == Data,
+    data_len: u16be,
+    last_packet: FuQcMoreData,
+    data: [u8; 249],
+}
+
+#[derive(New)]
+struct FuStructQcValidationReq {
+    opcode: FuQcOpcode == IsValidationDoneReq,
+    data_len: u16be = 0x00,
+}
+#[derive(Parse)]
+struct FuStructQcValidation {
+    opcode: FuQcOpcode, // Could be TransferCompleteInd or IsValidationDoneCfm
+    data_len: u16be,
+    delay: u16be,
+}
+
+#[derive(New)]
+struct FuStructQcTransferComplete {
+    opcode: FuQcOpcode == TransferCompleteRes,
+    data_len: u16be = 0x01,
+    action: FuQcAction,
+}
+
+#[derive(New)]
+struct FuStructQcProceedToCommit {
+    opcode: FuQcOpcode == ProceedToCommit,
+    data_len: u16be = 0x01,
+    action: FuQcAction,
+}
+#[derive(Parse)]
+struct FuStructQcCommitReq {
+    opcode: FuQcOpcode == CommitReq,
+    data_len: u16be = 0x00,
+}
+
+#[derive(ToString)]
+#[repr(u8)]
+enum FuQcCommitAction {
+    Upgrade = 0,
+    Rollback = 1,
+}
+#[derive(New)]
+struct FuStructQcCommitCfm {
+    opcode: FuQcOpcode == CommitCfm,
+    data_len: u16be = 0x01,
+    action: FuQcCommitAction,
+}
+#[derive(Parse)]
+struct FuStructQcComplete {
+    opcode: FuQcOpcode == CompleteInd,
+    data_len: u16be = 0x00,
+}

--- a/plugins/audio-s5gen2/meson.build
+++ b/plugins/audio-s5gen2/meson.build
@@ -1,0 +1,22 @@
+if gusb.found()
+cargs = ['-DG_LOG_DOMAIN="FuPluginQcS5gen2"']
+
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+plugin_quirks += files('audio-s5gen2.quirk')
+plugin_builtins += static_library('fu_plugin_audio_s5gen2',
+  rustgen.process('fu-audio-s5gen2.rs'),
+  rustgen.process('fu-audio-s5gen2-hid.rs'),
+  rustgen.process('fu-audio-s5gen2-fw.rs'),
+  sources: [
+    'fu-audio-s5gen2-device.c',
+    'fu-audio-s5gen2-hid-device.c',
+    'fu-audio-s5gen2-firmware.c',
+    'fu-audio-s5gen2-plugin.c',
+    'fu-audio-s5gen2-impl.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -26,6 +26,7 @@ plugins = {
   'analogix': false,
   'android-boot': false,
   'ata': false,
+  'audio-s5gen2': false,
   'aver-hid': false,
   'bcm57xx': false,
   'bios': false,


### PR DESCRIPTION
Firmware Update Plug-in for Qualcomm Voice & Music Series 5 Gen 1 and Gen 2, and Series 3 Gen 1, Gen 2 and Gen 3.

The initial variant of the plugin allows to update devices based on Qualcomm 5 series via USB HID. Tested with development board only.

Type of pull request:

- [x ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
