### PR TITLE
Auto-fix remotes from .gz to .xz

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8118,7 +8118,7 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 
 	/* read remotes */
 	if (flags & FU_ENGINE_LOAD_FLAG_REMOTES) {
-		FuRemoteListLoadFlags remote_list_flags = FU_REMOTE_LIST_LOAD_FLAG_NONE;
+		FuRemoteListLoadFlags remote_list_flags = FU_REMOTE_LIST_LOAD_FLAG_FIX_METADATA_URI;
 		if (fu_engine_config_get_test_devices(self->config))
 			remote_list_flags |= FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE;
 		if (flags & FU_ENGINE_LOAD_FLAG_READONLY)

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -36,6 +36,7 @@ struct _FuRemoteList {
 	GPtrArray *array;	  /* (element-type FwupdRemote) */
 	GPtrArray *monitors;	  /* (element-type GFileMonitor) */
 	gboolean testing_remote;
+	gboolean fix_metadata_uri;
 	XbSilo *silo;
 };
 
@@ -237,6 +238,18 @@ fu_remote_list_add_remote(FuRemoteList *self, FwupdRemote *remote)
 }
 
 static gboolean
+fu_remote_list_is_remote_origin_lvfs(FwupdRemote *remote)
+{
+	if (fwupd_remote_get_id(remote) != NULL &&
+	    g_strstr_len(fwupd_remote_get_id(remote), -1, "lvfs") != NULL)
+		return TRUE;
+	if (fwupd_remote_get_metadata_uri(remote) != NULL &&
+	    g_strstr_len(fwupd_remote_get_metadata_uri(remote), -1, "fwupd.org") != NULL)
+		return TRUE;
+	return FALSE;
+}
+
+static gboolean
 fu_remote_list_add_for_file(FuRemoteList *self,
 			    GHashTable *os_release,
 			    const gchar *filename,
@@ -264,6 +277,20 @@ fu_remote_list_add_for_file(FuRemoteList *self,
 			fwupd_remote_get_id(remote),
 			fwupd_remote_get_filename_source(remote_tmp));
 		return TRUE;
+	}
+
+	/* auto-fix before setup */
+	if (self->fix_metadata_uri && fu_remote_list_is_remote_origin_lvfs(remote)) {
+		const gchar *metadata_url = fwupd_remote_get_metadata_uri(remote);
+		if (metadata_url != NULL && g_str_has_suffix(metadata_url, ".gz")) {
+			g_autoptr(GString) str = g_string_new(metadata_url);
+			g_string_replace(str, ".gz", ".xz", 0);
+			g_info("auto-fixing remote %s MetadataURI from %s to %s",
+			       fwupd_remote_get_id(remote),
+			       metadata_url,
+			       str->str);
+			fwupd_remote_set_metadata_uri(remote, str->str);
+		}
 	}
 
 	/* load remote */
@@ -614,6 +641,10 @@ fu_remote_list_load(FuRemoteList *self, FuRemoteListLoadFlags flags, GError **er
 	/* enable testing only remotes */
 	if (flags & FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE)
 		self->testing_remote = TRUE;
+
+	/* autofix on reload too */
+	if (flags & FU_REMOTE_LIST_LOAD_FLAG_FIX_METADATA_URI)
+		self->fix_metadata_uri = TRUE;
 
 	/* load AppStream about the remote_list */
 	if (!fu_remote_list_load_metainfos(builder, error))

--- a/src/fu-remote-list.h
+++ b/src/fu-remote-list.h
@@ -17,6 +17,7 @@ G_DECLARE_FINAL_TYPE(FuRemoteList, fu_remote_list, FU, REMOTE_LIST, GObject)
  * @FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS:	Ignore readonly filesystem errors
  * @FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE:		Do not save persistent xmlb silos
  * @FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE:		Enable test mode remotes
+ * @FU_REMOTE_LIST_LOAD_FLAG_FIX_METADATA_URI:	Auto-fix to use the newest supported metadata
  *
  * The flags to use when loading a remote_listuration file.
  **/
@@ -25,6 +26,7 @@ typedef enum {
 	FU_REMOTE_LIST_LOAD_FLAG_READONLY_FS = 1 << 0,
 	FU_REMOTE_LIST_LOAD_FLAG_NO_CACHE = 1 << 1,
 	FU_REMOTE_LIST_LOAD_FLAG_TEST_REMOTE = 1 << 2,
+	FU_REMOTE_LIST_LOAD_FLAG_FIX_METADATA_URI = 1 << 3,
 	/*< private >*/
 	FU_REMOTE_LIST_LOAD_FLAG_LAST
 } FuRemoteListLoadFlags;

--- a/src/tests/remotes.d/legacy-lvfs.conf
+++ b/src/tests/remotes.d/legacy-lvfs.conf
@@ -1,0 +1,3 @@
+[fwupd Remote]
+Enabled=false
+MetadataURI=http://localhost/stable.xml.gz

--- a/src/tests/remotes.d/legacy.conf
+++ b/src/tests/remotes.d/legacy.conf
@@ -1,0 +1,3 @@
+[fwupd Remote]
+Enabled=false
+MetadataURI=http://localhost/stable.xml.gz


### PR DESCRIPTION
Some users are using old lvfs.conf remotes for various reasons, for example copying around an embargo remote file rather than re-downloading it from the LVFS.
Also, rpm installs the file as fwupd.conf.rpmnew if there have been changes.

In this case fix up the remote to use .xz so that one day we might be able to stop generating the gz version. This also means more-releases per components and test reports become available to end users.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
