### PR TITLE
aver-hid: Fix a double-free when writing firmware

### DIFF
--- a/libfwupdplugin/fu-archive.c
+++ b/libfwupdplugin/fu-archive.c
@@ -85,7 +85,7 @@ fu_archive_add_entry(FuArchive *self, const gchar *fn, GBytes *blob)
  *
  * Finds the blob referenced by filename
  *
- * Returns: (transfer none): a #GBytes, or %NULL if the filename was not found
+ * Returns: (transfer container): a #GBytes, or %NULL if the filename was not found
  *
  * Since: 1.2.2
  **/
@@ -103,7 +103,7 @@ fu_archive_lookup_by_fn(FuArchive *self, const gchar *fn, GError **error)
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no blob for %s", fn);
 		return NULL;
 	}
-	return bytes;
+	return g_bytes_ref(bytes);
 }
 
 /**

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -96,8 +96,10 @@ fu_archive_cab_func(void)
 	g_autofree gchar *filename = NULL;
 	g_autoptr(FuArchive) archive = NULL;
 	g_autoptr(GBytes) data = NULL;
+	g_autoptr(GBytes) data_tmp1 = NULL;
+	g_autoptr(GBytes) data_tmp2 = NULL;
+	g_autoptr(GBytes) data_tmp3 = NULL;
 	g_autoptr(GError) error = NULL;
-	GBytes *data_tmp;
 
 #ifndef HAVE_LIBARCHIVE
 	g_test_skip("no libarchive support");
@@ -117,21 +119,21 @@ fu_archive_cab_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(archive);
 
-	data_tmp = fu_archive_lookup_by_fn(archive, "firmware.metainfo.xml", &error);
+	data_tmp1 = fu_archive_lookup_by_fn(archive, "firmware.metainfo.xml", &error);
 	g_assert_no_error(error);
-	g_assert_nonnull(data_tmp);
-	checksum1 = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, data_tmp);
+	g_assert_nonnull(data_tmp1);
+	checksum1 = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, data_tmp1);
 	g_assert_cmpstr(checksum1, ==, "8611114f51f7151f190de86a5c9259d79ff34216");
 
-	data_tmp = fu_archive_lookup_by_fn(archive, "firmware.bin", &error);
+	data_tmp2 = fu_archive_lookup_by_fn(archive, "firmware.bin", &error);
 	g_assert_no_error(error);
-	g_assert_nonnull(data_tmp);
-	checksum2 = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, data_tmp);
+	g_assert_nonnull(data_tmp2);
+	checksum2 = g_compute_checksum_for_bytes(G_CHECKSUM_SHA1, data_tmp2);
 	g_assert_cmpstr(checksum2, ==, "7c0ae84b191822bcadbdcbe2f74a011695d783c7");
 
-	data_tmp = fu_archive_lookup_by_fn(archive, "NOTGOINGTOEXIST.xml", &error);
+	data_tmp3 = fu_archive_lookup_by_fn(archive, "NOTGOINGTOEXIST.xml", &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
-	g_assert_null(data_tmp);
+	g_assert_null(data_tmp3);
 }
 
 static void

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -101,11 +101,11 @@ static gboolean
 validate_program_action(XbNode *program, FuArchive *archive, GError **error)
 {
 	const gchar *filename_attr;
-	GBytes *file;
 	gsize file_size;
 	guint64 computed_num_partition_sectors;
 	guint64 num_partition_sectors;
 	guint64 sector_size_in_bytes;
+	g_autoptr(GBytes) file = NULL;
 
 	filename_attr = xb_node_get_attr(program, "filename");
 	if (filename_attr == NULL) {

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -32,8 +32,8 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 	JsonArray *json_files;
 	guint manifest_ver;
 	guint files_cnt = 0;
-	GBytes *manifest = NULL;
 	g_autoptr(FuArchive) archive = NULL;
+	g_autoptr(GBytes) manifest = NULL;
 	g_autoptr(JsonParser) parser = json_parser_new();
 
 	/* load archive */
@@ -102,10 +102,10 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 		const gchar *bootloader_name = NULL;
 		guint image_addr = 0;
 		JsonObject *obj = json_array_get_object_element(json_files, i);
-		GBytes *blob = NULL;
 		g_autoptr(FuFirmware) image = NULL;
 		g_autofree gchar *image_id = NULL;
 		g_auto(GStrv) board_split = NULL;
+		g_autoptr(GBytes) blob = NULL;
 
 		if (!json_object_has_member(obj, "file")) {
 			g_set_error_literal(error,

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -273,8 +273,8 @@ fu_uefi_capsule_plugin_get_splash_data(guint width, guint height, GError **error
 
 	/* find the closest locale match, falling back to `en` and `C` */
 	for (guint i = 0; langs[i] != NULL; i++) {
-		GBytes *blob_tmp;
 		g_autofree gchar *fn = NULL;
+		g_autoptr(GBytes) blob_tmp = NULL;
 		if (g_str_has_suffix(langs[i], ".UTF-8"))
 			continue;
 		fn = g_strdup_printf("fwupd-%s-%u-%u.bmp", langs[i], width, height);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2684,9 +2684,10 @@ fu_engine_emulation_load(FuEngine *self, GBytes *data, GError **error)
 		g_autofree gchar *fn =
 		    g_strdup_printf("%s.json", fu_engine_install_phase_to_string(phase));
 		g_autofree gchar *json_safe = NULL;
-		GBytes *blob = fu_archive_lookup_by_fn(archive, fn, NULL);
+		g_autoptr(GBytes) blob = NULL;
 
 		/* not found */
+		blob = fu_archive_lookup_by_fn(archive, fn, NULL);
 		if (blob == NULL)
 			continue;
 		json_safe = g_strndup(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));


### PR DESCRIPTION
Rather than remove the g_autoptr(), *remove the foot-gun* by making fu_archive_lookup_by_fn() return a reference.

This means it matches the other GBytes API we have in libfwupdplugin, and also means the faulure case is 'leaks memory' rather than 'double free'.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
