### PR TITLE
Do not probe the BOS descriptors of the Nostromo n52 gamepad

### DIFF
--- a/data/ds20.quirk
+++ b/data/ds20.quirk
@@ -1,0 +1,3 @@
+# Nostromo n52 gamepad
+[USB\VID_050D&PID_0815]
+Flags = no-probe

--- a/data/meson.build
+++ b/data/meson.build
@@ -30,6 +30,7 @@ if build_standalone
     install_mode: 'rw-r-----',
   )
   plugin_quirks += files([
+    'ds20.quirk',
     'power.quirk',
     'cfi.quirk',
   ])

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -689,6 +689,12 @@ fu_usb_device_probe_bos_descriptors(FuUsbDevice *self, GError **error)
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) bos_descriptors = NULL;
 
+	/* already matched a quirk entry */
+	if (fu_device_has_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_NO_PROBE)) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not probing");
+		return FALSE;
+	}
+
 	/* not supported, so there is no point opening */
 	if (g_usb_device_get_spec(priv->usb_device) <= 0x0200) {
 		g_set_error(error,


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/6871

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
