### PR TITLE
Actually set the created property when creating FuDevice

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -6570,6 +6570,7 @@ fu_device_init(FuDevice *self)
 							 "notify::flags",
 							 G_CALLBACK(fu_device_flags_notify_cb),
 							 NULL);
+	fu_device_set_created(self, (guint64)g_get_real_time() / G_USEC_PER_SEC);
 }
 
 static void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1861,6 +1861,7 @@ fu_device_private_flags_func(void)
 	fu_device_set_custom_flags(device, "baz");
 	g_assert_cmpint(fu_device_get_private_flags(device), ==, TEST_FLAG_FOO);
 
+	fu_device_set_created(device, 0);
 	tmp = fu_device_to_string(device);
 	g_assert_cmpstr(tmp,
 			==,
@@ -2043,6 +2044,7 @@ fu_device_incorporate_func(void)
 	fu_device_set_equivalent_id(device, "DO_NOT_OVERWRITE");
 	fu_device_set_metadata(device, "test2", "DO_NOT_OVERWRITE");
 	fu_device_set_modified(device, 789);
+	fu_device_set_created(device, 0);
 
 	/* incorporate properties from donor to device */
 	fu_device_incorporate(device, donor);


### PR DESCRIPTION
We used to do this in FwupdDevice which made the tests harder to write, but we can at least do it one layer higher.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
