### PR TITLE
Introduce ProcSubset, drop @clock @cpu-emulation

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -18,6 +18,7 @@ MemoryDenyWriteExecute=yes
 NoNewPrivileges=no
 PrivateDevices=no
 PrivateTmp=true
+ProcSubset=pid
 ProtectClock=yes
 ProtectControlGroups=yes
 ProtectHome=yes
@@ -31,5 +32,5 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
-SystemCallFilter=~@mount
+SystemCallFilter=~@clock @cpu-emulation @mount
 @dynamic_options@


### PR DESCRIPTION
Type of pull request:

- [X] Feature

This introduces the ProcSubset option and drops the @clock and @cpu-emulation system calls from the service.

ProcSubset was introduced in Systemd v247 and should present no issues following the bump to minimum v249.

@clock covers calls for manipulating the system clock and time (should not be required).
@cpu-emulation covers calls for CPU emulation functionality.

More details at https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
