### PR TITLE
Drop @debug & @module, apply SystemCallErrorNumber

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -32,5 +32,6 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @mount
+SystemCallErrorNumber=EPERM
+SystemCallFilter=~@clock @cpu-emulation @debug @module @mount
 @dynamic_options@

--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -18,6 +18,7 @@ MemoryDenyWriteExecute=yes
 NoNewPrivileges=no
 PrivateDevices=no
 PrivateTmp=true
+ProcSubset=pid
 ProtectClock=yes
 ProtectControlGroups=yes
 ProtectHome=yes
@@ -31,5 +32,5 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
-SystemCallFilter=~@mount
+SystemCallFilter=~@clock @cpu-emulation @mount
 @dynamic_options@


### PR DESCRIPTION
Type of pull request:

- [X] Feature

This drops the @debug and @module system calls and sets the action to be logged as "Operation not permitted" when calling a prohibited system call rather than immediate process termination.

@debug calls are related to debugging, performance monitoring and tracing functionality.
@module calls are related to loading and unloading of kernel modules (ProtectKernelModules is enabled, so this should be unobtrusive).

SystemCallErrorNumber is set to return EPERM (Operation not permitted) - this value will be returned when a deny-listed system call is triggered, instead of terminating the processes immediately.

Source: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html


