### PR TITLE
trivial: fix mistake in de84009c39024153b92cef15d6f22e0f9c889000

### DIFF
--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -186,7 +186,7 @@ def _get_installer_cmd(profile: str, yes: bool):
         print(f"\tsupported profiles: {get_possible_profiles()}")
         sys.exit(1)
     if os.geteuid() != 0:
-        installer.prepend("sudo")
+        installer.insert(0, "sudo")
     if yes:
         installer += ["-y"]
     return installer


### PR DESCRIPTION
Lists in python don't have `.prepend()`.  Use `.insert(0, x)` instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
