### PR TITLE
trivial: Fix 'fwupdtool update' on macOS

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -164,6 +164,12 @@ static guint signals[SIGNAL_LAST] = {0};
 
 G_DEFINE_TYPE(FuEngine, fu_engine, G_TYPE_OBJECT)
 
+gboolean
+fu_engine_get_loaded(FuEngine *self)
+{
+	return self->loaded;
+}
+
 static gboolean
 fu_engine_update_motd_timeout_cb(gpointer user_data)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -48,6 +48,8 @@ typedef enum {
 
 FuEngine *
 fu_engine_new(FuContext *ctx);
+gboolean
+fu_engine_get_loaded(FuEngine *self);
 void
 fu_engine_add_plugin_filter(FuEngine *self, const gchar *plugin_glob);
 void

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -226,6 +226,10 @@ fu_util_start_engine(FuUtilPrivate *priv,
 		     FuProgress *progress,
 		     GError **error)
 {
+	/* already done */
+	if (fu_engine_get_loaded(priv->engine))
+		return TRUE;
+
 	if (!fu_util_lock(priv, error)) {
 		/* TRANSLATORS: another fwupdtool instance is already running */
 		g_prefix_error(error, "%s: ", _("Failed to lock"));


### PR DESCRIPTION
It seems macOS can't do a recursive F_OFD_SETLK -- and we shouldn't be reloading the engine anyway.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
