### PR TITLE
Allow classic snaps to call fwupd

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -214,7 +214,7 @@ fu_util_lock(FuUtilPrivate *priv, GError **error)
 static const gchar *
 fu_util_get_systemd_unit(void)
 {
-	if (g_getenv("SNAP") != NULL)
+	if (g_getenv("SNAP_NAME") == "fwupd")
 		return SYSTEMD_SNAP_FWUPD_UNIT;
 	return SYSTEMD_FWUPD_UNIT;
 }


### PR DESCRIPTION
The systemd unit is set to the snap version (snap.fwupd.fwupd.service) if the name of the snap is fwupd. This allows classic snaps to call a version of fwupd installed from classic package repositories (deb or rpm).

Fix #6946

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

Tested by building fwupd, then:

Running the deamon in a terminal:

```shell
$ /home/pieq/dev/work/fwupd/venv/bin/fwupd
```

while running `fwupdmgr` from the user session first:

```shell
$ /home/pieq/dev/work/fwupd/venv/bin/fwupdmgr get-devices
WARNING: This package has not been validated, it may not work properly.
Dell Inc. Precision 3570
│
(...)
```

then from a classic snap:

```shell
$ snap run --shell kate
(inside-kate-snap) $ /home/pieq/dev/work/fwupd/venv/bin/fwupdmgr get-devices
WARNING: This package has not been validated, it may not work properly.
Dell Inc. Precision 3570
│
(...)
```