### PR TITLE
Add an internal flag to use the proxy to open the device

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -243,6 +243,8 @@ fu_device_internal_flag_to_string(FuDeviceInternalFlags flag)
 		return "no-auto-remove-children";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_OPEN)
 		return "use-parent-for-open";
+	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN)
+		return "use-proxy-for-open";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY)
 		return "use-parent-for-battery";
 	if (flag == FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FALLBACK)
@@ -347,6 +349,8 @@ fu_device_internal_flag_from_string(const gchar *flag)
 		return FU_DEVICE_INTERNAL_FLAG_NO_AUTO_REMOVE_CHILDREN;
 	if (g_strcmp0(flag, "use-parent-for-open") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_OPEN;
+	if (g_strcmp0(flag, "use-proxy-for-open") == 0)
+		return FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN;
 	if (g_strcmp0(flag, "use-parent-for-battery") == 0)
 		return FU_DEVICE_INTERNAL_FLAG_USE_PARENT_FOR_BATTERY;
 	if (g_strcmp0(flag, "use-proxy-fallback") == 0)
@@ -4887,6 +4891,17 @@ fu_device_open(FuDevice *self, GError **error)
 		}
 		return fu_device_open_internal(parent, error);
 	}
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN)) {
+		FuDevice *proxy = fu_device_get_proxy(self);
+		if (proxy == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "no proxy device");
+			return FALSE;
+		}
+		return fu_device_open_internal(proxy, error);
+	}
 	return fu_device_open_internal(self, error);
 }
 
@@ -4958,6 +4973,17 @@ fu_device_close(FuDevice *self, GError **error)
 			return FALSE;
 		}
 		return fu_device_close_internal(parent, error);
+	}
+	if (fu_device_has_internal_flag(self, FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN)) {
+		FuDevice *proxy = fu_device_get_proxy(self);
+		if (proxy == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "no proxy device");
+			return FALSE;
+		}
+		return fu_device_close_internal(proxy, error);
 	}
 	return fu_device_close_internal(self, error);
 }

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2031,7 +2031,7 @@ fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GEr
 	}
 	if (g_strcmp0(key, FU_QUIRKS_PROXY_GTYPE) == 0) {
 		if (priv->proxy_gtype != G_TYPE_INVALID) {
-			g_debug("already set GType to %s, ignoring %s",
+			g_debug("already set proxy GType to %s, ignoring %s",
 				g_type_name(priv->proxy_gtype),
 				value);
 			return TRUE;
@@ -4900,7 +4900,8 @@ fu_device_open(FuDevice *self, GError **error)
 					    "no proxy device");
 			return FALSE;
 		}
-		return fu_device_open_internal(proxy, error);
+		if (!fu_device_open_internal(proxy, error))
+			return FALSE;
 	}
 	return fu_device_open_internal(self, error);
 }
@@ -4983,7 +4984,8 @@ fu_device_close(FuDevice *self, GError **error)
 					    "no proxy device");
 			return FALSE;
 		}
-		return fu_device_close_internal(proxy, error);
+		if (!fu_device_close_internal(proxy, error))
+			return FALSE;
 	}
 	return fu_device_close_internal(self, error);
 }

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -600,6 +600,14 @@ typedef enum {
 	 */
 	FU_DEVICE_INTERNAL_FLAG_REFCOUNTED_PROXY = 1ull << 43,
 	/**
+	 * FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN:
+	 *
+	 * Use proxy to open and close the device.
+	 *
+	 * Since: 1.9.16
+	 */
+	FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN = 1ull << 44,
+	/**
 	 * FU_DEVICE_INTERNAL_FLAG_UNKNOWN:
 	 *
 	 * Unknown flag value.


### PR DESCRIPTION
Sometimes a device might have a proxy but not a parent->child relationship.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
