### PR TITLE
trivial: Include the type in the UEFI capsule device summary

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -257,6 +257,7 @@ fu_uefi_cod_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_cod_device_init(FuUefiCodDevice *self)
 {
+	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (CoD)");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -257,7 +257,7 @@ fu_uefi_cod_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_cod_device_init(FuUefiCodDevice *self)
 {
-	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (CoD)");
+	fu_device_set_summary(FU_DEVICE(self), "UEFI System Resource Table device (Updated via caspule-on-disk)");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -688,7 +688,6 @@ fu_uefi_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_uefi_device_init(FuUefiDevice *self)
 {
-	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device");
 	fu_device_add_protocol(FU_DEVICE(self), "org.uefi.capsule");
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_MD_SET_SIGNED);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_MD_SET_FLAGS);

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -198,6 +198,7 @@ fu_uefi_grub_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_grub_device_init(FuUefiGrubDevice *self)
 {
+	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (grub)");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -198,7 +198,7 @@ fu_uefi_grub_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_grub_device_init(FuUefiGrubDevice *self)
 {
-	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (grub)");
+	fu_device_set_summary(FU_DEVICE(self), "UEFI System Resource Table device (updated via grub)");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -133,6 +133,7 @@ fu_uefi_nvram_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_nvram_device_init(FuUefiNvramDevice *self)
 {
+	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (NVRAM)");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -133,7 +133,7 @@ fu_uefi_nvram_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_nvram_device_init(FuUefiNvramDevice *self)
 {
-	fu_device_set_summary(FU_DEVICE(self), "UEFI ESRT device (NVRAM)");
+	fu_device_set_summary(FU_DEVICE(self), "UEFI System Resource Table device (updated via NVRAM)");
 }
 
 static void


### PR DESCRIPTION
This means we can spot CoD just from a fwupdmgr get-devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
