### PR TITLE
Drop ProcSubset from systemd service

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -18,7 +18,6 @@ MemoryDenyWriteExecute=yes
 NoNewPrivileges=no
 PrivateDevices=no
 PrivateTmp=true
-ProcSubset=pid
 ProtectClock=yes
 ProtectControlGroups=yes
 ProtectHome=yes


### PR DESCRIPTION
This breaks access to /proc/cmdline and /proc/sys

```
Mar 22 16:35:43 arch-phoenix fwupd[3519]: 15:35:43.727 FuPluginIommu        failed to get kernel cmdline: Failed to open file "/proc/cmdline": No such file or directory
Mar 22 16:35:43 arch-phoenix fwupd[3519]: 15:35:43.727 FuPluginLinuxTainted could not open /proc/sys/kernel/tainted: Error opening file /proc/sys/kernel/tainted: No such file or directory
```

Fixes: 850af666d9
See: https://github.com/fwupd/fwupd/issues/6956

CC @RZR7332 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
