### PR TITLE
trivial: set fu_uefi_bootmgr_get_suffix() as static

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -10,7 +10,7 @@
 #include "fu-uefi-common.h"
 #include "fu-uefi-device.h"
 
-const gchar *
+static const gchar *
 fu_uefi_bootmgr_get_suffix(GError **error)
 {
 	guint64 firmware_bits;

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -44,5 +44,3 @@ fu_uefi_esp_target_copy(const gchar *source_fn,
 			FuVolume *esp,
 			const gchar *target_no_mountpoint,
 			GError **error);
-const gchar *
-fu_uefi_bootmgr_get_suffix(GError **error);


### PR DESCRIPTION
It's only used in fu-uefi-common.c.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
