### PR TITLE
trivial: debian: set hard requirement on libfwupd version

### DIFF
--- a/contrib/debian/control.in
+++ b/contrib/debian/control.in
@@ -32,6 +32,7 @@ Package: fwupd
 Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         libfwupd3 (= ${binary:Version}),
          shared-mime-info,
          systemd-sysusers
 Recommends: python3,


### PR DESCRIPTION
libfwupd and the daemon are expected to move together.  Don't let people move them separately.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1062820

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
