### PR TITLE
trivial: debian: drop libtool dependency

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -896,17 +896,6 @@
       <package variant="x86_64">passim</package>
     </distro>
   </dependency>
-  <dependency id="libtool-bin">
-    <distro id="debian">
-      <control />
-      <package variant="x86_64" />
-      <package variant="i386" />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-    </distro>
-  </dependency>
   <dependency id="libstemmer-0">
     <distro id="centos">
       <package variant="x86_64" />


### PR DESCRIPTION
It shouldn't be needed anymore when built with meson.

Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1064659

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
