### PR TITLE
Add a D-Bus method that allows getting the device debug output

### DIFF
--- a/libfwupd/fwupd-client-sync.h
+++ b/libfwupd/fwupd-client-sync.h
@@ -107,6 +107,11 @@ fwupd_client_get_results(FwupdClient *self,
 			 const gchar *device_id,
 			 GCancellable *cancellable,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+gchar *
+fwupd_client_get_device_debuglog(FwupdClient *self,
+				 const gchar *device_id,
+				 GCancellable *cancellable,
+				 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fwupd_client_modify_bios_setting(FwupdClient *self,
 				 GHashTable *settings,

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -2881,6 +2881,89 @@ fwupd_client_get_results_finish(FwupdClient *self, GAsyncResult *res, GError **e
 	return g_task_propagate_pointer(G_TASK(res), error);
 }
 
+static void
+fwupd_client_get_device_debuglog_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(GTask) task = G_TASK(user_data);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GVariant) val = NULL;
+
+	val = g_dbus_proxy_call_finish(G_DBUS_PROXY(source), res, &error);
+	if (val == NULL) {
+		fwupd_client_fixup_dbus_error(error);
+		g_task_return_error(task, g_steal_pointer(&error));
+		return;
+	}
+
+	/* success */
+	g_task_return_pointer(task,
+			      fwupd_device_from_variant(val),
+			      (GDestroyNotify)g_ptr_array_unref);
+}
+
+/**
+ * fwupd_client_get_device_debuglog_async:
+ * @self: a #FwupdClient
+ * @device_id: (not nullable): the device ID
+ * @cancellable: (nullable): optional #GCancellable
+ * @callback: (scope async) (closure callback_data): the function to run on completion
+ * @callback_data: the data to pass to @callback
+ *
+ * Gets the debug log for a specific device.
+ *
+ * You must have called [method@Client.connect_async] on @self before using
+ * this method.
+ *
+ * Since: 1.9.16
+ **/
+void
+fwupd_client_get_device_debuglog_async(FwupdClient *self,
+				       const gchar *device_id,
+				       GCancellable *cancellable,
+				       GAsyncReadyCallback callback,
+				       gpointer callback_data)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_autoptr(GTask) task = NULL;
+
+	g_return_if_fail(FWUPD_IS_CLIENT(self));
+	g_return_if_fail(device_id != NULL);
+	g_return_if_fail(cancellable == NULL || G_IS_CANCELLABLE(cancellable));
+	g_return_if_fail(priv->proxy != NULL);
+
+	/* call into daemon */
+	task = g_task_new(self, cancellable, callback, callback_data);
+	g_dbus_proxy_call(priv->proxy,
+			  "GetDebuglog",
+			  g_variant_new("(s)", device_id),
+			  G_DBUS_CALL_FLAGS_NONE,
+			  FWUPD_CLIENT_DBUS_PROXY_TIMEOUT,
+			  cancellable,
+			  fwupd_client_get_device_debuglog_cb,
+			  g_steal_pointer(&task));
+}
+
+/**
+ * fwupd_client_get_device_debuglog_finish:
+ * @self: a #FwupdClient
+ * @res: (not nullable): the asynchronous result
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the result of [method@FwupdClient.get_device_debuglog_async].
+ *
+ * Returns: (transfer full): a device, or %NULL for failure
+ *
+ * Since: 1.9.16
+ **/
+gchar *
+fwupd_client_get_device_debuglog_finish(FwupdClient *self, GAsyncResult *res, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), NULL);
+	g_return_val_if_fail(g_task_is_valid(res, self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+	return g_task_propagate_pointer(G_TASK(res), error);
+}
+
 #ifdef HAVE_GIO_UNIX
 
 static void

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -243,6 +243,17 @@ fwupd_client_get_results_finish(FwupdClient *self,
 				GAsyncResult *res,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 void
+fwupd_client_get_device_debuglog_async(FwupdClient *self,
+				       const gchar *device_id,
+				       GCancellable *cancellable,
+				       GAsyncReadyCallback callback,
+				       gpointer callback_data) G_GNUC_NON_NULL(1, 2);
+gchar *
+fwupd_client_get_device_debuglog_finish(FwupdClient *self,
+					GAsyncResult *res,
+					GError **error) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1, 2);
+void
 fwupd_client_modify_bios_setting_async(FwupdClient *self,
 				       GHashTable *settings,
 				       GCancellable *cancellable,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -977,6 +977,14 @@ LIBFWUPD_1.9.15 {
   local: *;
 } LIBFWUPD_1.9.10;
 
+LIBFWUPD_1.9.16 {
+  global:
+    fwupd_client_get_device_debuglog;
+    fwupd_client_get_device_debuglog_async;
+    fwupd_client_get_device_debuglog_finish;
+  local: *;
+} LIBFWUPD_1.9.15;
+
 LIBFWUPD_2.0.0 {
   global:
     fwupd_client_install_release;
@@ -997,4 +1005,4 @@ LIBFWUPD_2.0.0 {
     fwupd_remote_set_security_report_uri;
     fwupd_remote_set_username;
   local: *;
-} LIBFWUPD_1.9.15;
+} LIBFWUPD_1.9.16;

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -4361,6 +4361,38 @@ fu_device_get_results(FuDevice *self, GError **error)
 }
 
 /**
+ * fu_device_get_debuglog:
+ * @self: a #FuDevice
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the debugging log from a device.
+ *
+ * Returns: (transfer full): a string on success
+ *
+ * Since: 1.9.16
+ **/
+gchar *
+fu_device_get_debuglog(FuDevice *self, GError **error)
+{
+	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(self);
+
+	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* no plugin-specific method */
+	if (device_class->get_debuglog == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "getting results not supported by device");
+		return NULL;
+	}
+
+	/* call vfunc */
+	return device_class->get_debuglog(self, error);
+}
+
+/**
  * fu_device_write_firmware:
  * @self: a #FuDevice
  * @stream: #GInputStream firmware

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -87,6 +87,7 @@ struct _FuDeviceClass {
 	void (*set_progress)(FuDevice *self, FuProgress *progress);
 	void (*invalidate)(FuDevice *self);
 	gchar *(*convert_version)(FuDevice *self, guint64 version_raw);
+	gchar *(*get_debuglog)(FuDevice *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 #endif
 };
 
@@ -783,6 +784,8 @@ gboolean
 fu_device_has_internal_flag(FuDevice *self, FuDeviceInternalFlags flag) G_GNUC_NON_NULL(1);
 gboolean
 fu_device_get_results(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
+gchar *
+fu_device_get_debuglog(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
 gboolean
 fu_device_write_firmware(FuDevice *self,
 			 GInputStream *stream,

--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -1534,6 +1534,25 @@ fu_daemon_daemon_method_call(GDBusConnection *connection,
 		g_dbus_method_invocation_return_value(invocation, g_variant_new_tuple(&val, 1));
 		return;
 	}
+	if (g_strcmp0(method_name, "GetDebuglog") == 0) {
+		const gchar *device_id = NULL;
+		g_autofree gchar *result = NULL;
+
+		g_variant_get(parameters, "(&s)", &device_id);
+		g_debug("Called %s(%s)", method_name, device_id);
+		if (!fu_daemon_device_id_valid(device_id, &error)) {
+			fu_daemon_method_invocation_return_gerror(invocation, error);
+			return;
+		}
+		result = fu_engine_get_device_debuglog(self->engine, device_id, &error);
+		if (result == NULL) {
+			fu_daemon_method_invocation_return_gerror(invocation, error);
+			return;
+		}
+		val = g_variant_new_string(result);
+		g_dbus_method_invocation_return_value(invocation, g_variant_new_tuple(&val, 1));
+		return;
+	}
 	if (g_strcmp0(method_name, "UpdateMetadata") == 0) {
 #ifdef HAVE_GIO_UNIX
 		GDBusMessage *message;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5914,6 +5914,32 @@ fu_engine_get_results(FuEngine *self, const gchar *device_id, GError **error)
 	return g_object_ref(FWUPD_DEVICE(device));
 }
 
+/**
+ * fu_engine_get_device_debuglog:
+ * @self: a #FuEngine
+ * @device_id: a device ID
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the debug log for a specific device.
+ *
+ * Returns: (transfer full): a string, or %NULL
+ **/
+gchar *
+fu_engine_get_device_debuglog(FuEngine *self, const gchar *device_id, GError **error)
+{
+	g_autoptr(FuDevice) device = NULL;
+
+	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
+	g_return_val_if_fail(device_id != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* find the device */
+	device = fu_device_list_get_by_id(self->device_list, device_id, error);
+	if (device == NULL)
+		return NULL;
+	return fu_device_get_debuglog(device, error);
+}
+
 static void
 fu_engine_plugins_startup(FuEngine *self, FuProgress *progress)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -111,6 +111,8 @@ fu_engine_get_upgrades(FuEngine *self,
 		       GError **error);
 FwupdDevice *
 fu_engine_get_results(FuEngine *self, const gchar *device_id, GError **error);
+gchar *
+fu_engine_get_device_debuglog(FuEngine *self, const gchar *device_id, GError **error);
 FuSecurityAttrs *
 fu_engine_get_host_security_attrs(FuEngine *self);
 FuSecurityAttrs *

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1585,6 +1585,27 @@ fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 				 issue);
 	}
 
+	{
+		g_autofree gchar *debuglog = NULL;
+		g_autoptr(GError) error_local = NULL;
+		debuglog = fwupd_client_get_device_debuglog(client,
+							    fwupd_device_get_id(dev),
+							    NULL,
+							    &error_local);
+		if (debuglog != NULL) {
+			/* TRANSLATORS: for programmers */
+			fu_string_append(str, idt + 1, "Debug Log", debuglog);
+		} else {
+			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
+			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+				g_debug("ignoring: %s", error_local->message);
+			} else {
+				/* TRANSLATORS: for programmers */
+				fu_string_append(str, idt + 1, "Debug Log", error_local->message);
+			}
+		}
+	}
+
 	return g_string_free(g_steal_pointer(&str), FALSE);
 }
 

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -552,6 +552,31 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='GetDebuglog'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Gets the debug log for a specific device.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>A device ID</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+      <arg type='s' name='results' direction='out'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>Device debug output, usually containing multiple lines</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='GetRemotes'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
In some case this may be very verbose, and isn't really suitable to put as a D-Bus property stored in memory.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
