### PR TITLE
Put the fwupd-efi verbose debugging in the journal

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -547,19 +547,19 @@ fu_uefi_device_capture_efi_debugging(FuDevice *device)
 				       NULL,
 				       &error_local);
 	if (buf == NULL) {
-		fu_device_set_update_error(device, error_local->message);
+		g_warning("failed to capture EFI debugging: %s", error_local->message);
 		return;
 	}
 
 	/* convert from UCS-2 to UTF-8 */
 	str = fu_utf16_to_utf8_bytes(buf, G_LITTLE_ENDIAN, &error_local);
 	if (str == NULL) {
-		fu_device_set_update_error(device, error_local->message);
+		g_warning("failed to capture EFI debugging: %s", error_local->message);
 		return;
 	}
 
-	/* success */
-	fu_device_set_update_error(device, str);
+	/* success, dump into journal */
+	g_info("EFI debugging: %s", str);
 }
 
 gboolean


### PR DESCRIPTION
Reusing the device error string is both confusing and looks terrible in the UI.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
