### PR TITLE
Fix capturing emulation data for dell-dock

### DIFF
--- a/libfwupdplugin/fu-backend-private.h
+++ b/libfwupdplugin/fu-backend-private.h
@@ -20,3 +20,6 @@ fu_backend_save(FuBackend *self,
 		const gchar *tag,
 		FuBackendSaveFlags flags,
 		GError **error) G_GNUC_NON_NULL(1, 2);
+
+gboolean
+fu_backend_clear(FuBackend *self, GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -265,6 +265,34 @@ fu_backend_load(FuBackend *self,
 }
 
 /**
+ * fu_backend_clear:
+ * @self: a #FuBackend
+ * @error: (nullable): optional return location for an error
+ *
+ * Clears saved events from the backend. Intended to be called at the end
+ * of a phase.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.0.0
+ **/
+gboolean
+fu_backend_clear(FuBackend *self, GError **error)
+{
+	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
+
+	g_return_val_if_fail(FU_IS_BACKEND(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* optional */
+	if (klass->clear != NULL) {
+		if (!klass->clear(self, error))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+/**
  * fu_backend_save:
  * @self: a #FuBackend
  * @json_builder: a #JsonBuilder

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -44,6 +44,7 @@ struct _FuBackendClass {
 			 const gchar *tag,
 			 FuBackendSaveFlags flags,
 			 GError **error);
+	gboolean (*clear)(FuBackend *self, GError **error);
 };
 
 const gchar *

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3031,8 +3031,10 @@ fu_engine_prepare(FuEngine *self,
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
 			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
-			return FALSE;
+		if (fu_device_get_composite_id(device) == NULL) {
+			if (!fu_engine_backends_clear_phase(self, error))
+				return FALSE;
+		}
 	}
 
 	/* wait for any device to disconnect and reconnect */
@@ -3078,8 +3080,10 @@ fu_engine_cleanup(FuEngine *self,
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
 			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
-			return FALSE;
+		if (fu_device_get_composite_id(device) == NULL) {
+			if (!fu_engine_backends_clear_phase(self, error))
+				return FALSE;
+		}
 	}
 
 	/* wait for any device to disconnect and reconnect */
@@ -3150,8 +3154,10 @@ fu_engine_detach(FuEngine *self,
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
 			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
-			return FALSE;
+		if (fu_device_get_composite_id(device) == NULL) {
+			if (!fu_engine_backends_clear_phase(self, error))
+				return FALSE;
+		}
 	}
 
 	/* wait for any device to disconnect and reconnect */
@@ -3198,8 +3204,10 @@ fu_engine_attach(FuEngine *self, const gchar *device_id, FuProgress *progress, G
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
 			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
-			return FALSE;
+		if (fu_device_get_composite_id(device) == NULL) {
+			if (!fu_engine_backends_clear_phase(self, error))
+				return FALSE;
+		}
 	}
 
 	/* wait for any device to disconnect and reconnect */
@@ -3292,8 +3300,10 @@ fu_engine_reload(FuEngine *self, const gchar *device_id, GError **error)
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
 			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
-			return FALSE;
+		if (fu_device_get_composite_id(device) == NULL) {
+			if (!fu_engine_backends_clear_phase(self, error))
+				return FALSE;
+		}
 	}
 
 	/* wait for any device to disconnect and reconnect */
@@ -3381,8 +3391,6 @@ fu_engine_write_firmware(FuEngine *self,
 	if (fu_context_has_flag(self->ctx, FU_CONTEXT_FLAG_SAVE_EVENTS) &&
 	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
 		if (!fu_engine_backends_save_phase(self, error))
-			return FALSE;
-		if (!fu_engine_backends_clear_phase(self, error))
 			return FALSE;
 	}
 

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -174,6 +174,20 @@ fu_usb_backend_load(FuBackend *backend,
 }
 
 static gboolean
+fu_usb_backend_clear(FuBackend *backend, GError **error)
+{
+	FuUsbBackend *self = FU_USB_BACKEND(backend);
+	g_autoptr(GPtrArray) devices = g_usb_context_get_devices(self->usb_ctx);
+
+	for (guint i = 0; i < devices->len; i++) {
+		GUsbDevice *usb_device = g_ptr_array_index(devices, i);
+		g_usb_device_clear_events(usb_device);
+	}
+
+	return TRUE;
+}
+
+static gboolean
 fu_usb_backend_save(FuBackend *backend,
 		    JsonBuilder *json_builder,
 		    const gchar *tag,
@@ -198,10 +212,6 @@ fu_usb_backend_save(FuBackend *backend,
 		return TRUE;
 	if (!g_usb_context_save_with_tag(self->usb_ctx, json_builder, tag, error))
 		return FALSE;
-	for (guint i = 0; i < devices->len; i++) {
-		GUsbDevice *usb_device = g_ptr_array_index(devices, i);
-		g_usb_device_clear_events(usb_device);
-	}
 	return TRUE;
 }
 
@@ -251,6 +261,7 @@ fu_usb_backend_class_init(FuUsbBackendClass *klass)
 	backend_class->coldplug = fu_usb_backend_coldplug;
 	backend_class->load = fu_usb_backend_load;
 	backend_class->save = fu_usb_backend_save;
+	backend_class->clear = fu_usb_backend_clear;
 	backend_class->registered = fu_usb_backend_registered;
 }
 


### PR DESCRIPTION
Using a proxy and composite devices leads to some mismatches with how emulation data is captured.  These commits help it.

I captured this using an old WD19TB I found.

```
$ fwupdmgr get-devices --filter emulated
WARNING: This package has not been validated, it may not work properly.
LENOVO 21D2SIT061
│
├─WD19TB:
│ │   Device ID:          48d6d6f37e7e7285eea2e215be449958b00246d7
│ │   Summary:            High performance dock
│ │   Current version:    01.01.00.07
│ │   Vendor:             Dell Inc. (USB:0x413C)
│ │   Install Duration:   2 seconds
│ │   Serial Number:      J4T6SV2/3169046018716226
│ │   Update State:       Success
│ │   Update Message:     The update will continue when the device USB cable has been unplugged.
│ │   Last modified:      2024-03-27 04:21
│ │   GUID:               cd357cf1-40b2-5d87-b8df-bb2dd82774aa ← USB\VID_413C&PID_B06E&hub&embedded
│ │   Device Flags:       • Supported on remote server
│ │                       • Device update needs activation
│ │                       • Device stages updates
│ │                       • Device can recover flash failures
│ │                       • Device is usable for the duration of the update
│ │                       • Updatable
│ │                       • Signed Payload
│ │                       • Emulated
│ │   Device Requests:    • Message (custom)
│ │ 
│ ├─Package level of Dell dock:
│ │     Device ID:        947b690100e39186e0f84e1a7e65c4c1805321fe
│ │     Summary:          A representation of dock update status
│ │     Current version:  01.00.36.01
│ │     Vendor:           Dell Inc. (USB:0x413C)
│ │     Install Duration: 2 seconds
│ │     Update State:     Success
│ │     Update Message:   The update will continue when the device USB cable has been unplugged.
│ │     Update Error:     Pending activation
│ │     Last modified:    2024-03-27 04:21
│ │     GUIDs:            d8927ff5-a5b2-5618-848b-8e8bfb75b66f
│ │                       8ceeeffd-51b6-580c-9b75-69143227aff8 ← USB\VID_413C&PID_B06E&hub&status
│ │     Device Flags:     • Supported on remote server
│ │                       • Device can recover flash failures
│ │                       • Device is usable for the duration of the update
│ │                       • Updatable
│ │                       • Unsigned Payload
│ │                       • Emulated
│ │     Device Requests:  • Message (custom)
│ │   
│ ├─RTS5413 in Dell dock:
│ │     Device ID:        91e14468ba8b4fa96e38d6a2e5761a1e184526e5
│ │     Summary:          USB 3.1 Generation 1 Hub
│ │     Current version:  01.22
│ │     Vendor:           Dell Inc. (USB:0x413C)
│ │     Install Duration: 2 seconds
│ │     Update State:     Success
│ │     Update Message:   The update will continue when the device USB cable has been unplugged.
│ │     Last modified:    2024-03-27 04:21
│ │     GUIDs:            b27d25f1-019d-5718-b41a-02ddaefe5577 ← USB\VID_413C&PID_B06F
│ │                       ac5b774c-b49d-566b-9255-85f0f7f8a4ed ← USB\VID_413C&PID_B06F&hub
│ │     Device Flags:     • Updatable
│ │                       • Supported on remote server
│ │                       • Device stages updates
│ │                       • Device is usable for the duration of the update
│ │                       • Signed Payload
│ │                       • Emulated
│ │     Device Requests:  • Message (custom)
│ │   
│ ├─RTS5487 in Dell dock:
│ │     Device ID:        dd07c50fa2af962e92734d9858c470432e1e6e23
│ │     Summary:          USB 3.1 Generation 2 Hub
│ │     Current version:  01.57
│ │     Vendor:           Dell Inc. (USB:0x413C)
│ │     Install Duration: 2 seconds
│ │     Update State:     Success
│ │     Update Message:   The update will continue when the device USB cable has been unplugged.
│ │     Last modified:    2024-03-27 04:21
│ │     GUIDs:            acfcd89b-105d-55b9-b85b-08bf8508f38c ← USB\VID_413C&PID_B06E
│ │                       568ffa1e-a0db-5287-9ea3-872b60f7730b ← USB\VID_413C&PID_B06E&hub
│ │     Device Flags:     • Updatable
│ │                       • Supported on remote server
│ │                       • Device stages updates
│ │                       • Device is usable for the duration of the update
│ │                       • Signed Payload
│ │                       • Emulated
│ │     Device Requests:  • Message (custom)
│ │   
│ └─VMM5331 in Dell dock:
│       Device ID:        54325b801dd0ebc0b69d51776a57c3adf1efbeea
│       Summary:          Multi Stream Transport controller
│       Current version:  05.07.04
│       Vendor:           Dell Inc. (USB:0x413C)
│       Install Duration: 2 seconds
│       Update State:     Success
│       Update Error:     Pending activation
│       Last modified:    2024-03-27 04:21
│       GUID:             89fec0b6-6b76-5008-b82c-5e5c6c164007 ← MST-panamera-vmm5331-259
│       Device Flags:     • Supported on remote server
│                         • Device stages updates
│                         • Device is usable for the duration of the update
│                         • Updatable
│                         • Unsigned Payload
│                         • Emulated

$ fwupdmgr install ./05*cab --allow-reinstall 
WARNING: This package has not been validated, it may not work properly.
Waiting…                 [***************************************] Less than one minute remaining…
Successfully installed firmware
```

Here is the emulation file I captured.  Assuming all is good @hughsie can you please add it to the matching LVFS upload and then build the device-test using it so we can have coverage in our tests?
[wd19tb.zip](https://github.com/fwupd/fwupd/files/14767440/wd19tb.zip)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
