### PR TITLE
trivial: stop sorting activation by order

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2229,8 +2229,6 @@ fu_util_activate(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* activate anything with _NEEDS_ACTIVATION */
-	/* order by device priority */
-	g_ptr_array_sort(devices, fu_util_device_order_sort_cb);
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device = g_ptr_array_index(devices, i);
 		if (!fwupd_device_match_flags(FWUPD_DEVICE(device),

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -2807,24 +2807,6 @@ fu_util_sort_devices_by_flags_cb(gconstpointer a, gconstpointer b)
 	return 0;
 }
 
-static gint
-fu_util_device_order_compare(FuDevice *device1, FuDevice *device2)
-{
-	if (fu_device_get_order(device1) < fu_device_get_order(device2))
-		return -1;
-	if (fu_device_get_order(device1) > fu_device_get_order(device2))
-		return 1;
-	return 0;
-}
-
-gint
-fu_util_device_order_sort_cb(gconstpointer a, gconstpointer b)
-{
-	FuDevice *device_a = *((FuDevice **)a);
-	FuDevice *device_b = *((FuDevice **)b);
-	return fu_util_device_order_compare(device_a, device_b);
-}
-
 gboolean
 fu_util_switch_branch_warning(FuConsole *console,
 			      FwupdDevice *dev,

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -121,8 +121,6 @@ fu_util_send_report(FwupdClient *client,
 		    GError **error);
 gint
 fu_util_sort_devices_by_flags_cb(gconstpointer a, gconstpointer b);
-gint
-fu_util_device_order_sort_cb(gconstpointer a, gconstpointer b);
 
 gboolean
 fu_util_switch_branch_warning(FuConsole *console,

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3483,8 +3483,6 @@ fu_util_activate(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* activate anything with _NEEDS_ACTIVATION */
-	/* order by device priority */
-	g_ptr_array_sort(devices, fu_util_device_order_sort_cb);
 	for (guint i = 0; i < devices->len; i++) {
 		FwupdDevice *device = g_ptr_array_index(devices, i);
 		if (!fwupd_device_match_flags(device,


### PR DESCRIPTION
This doesn't actually work.  Over the dbus wire devices that are returned are FwupdDevices (without order).  So they couldn't actually be sorted anyway.

FuDevice-CRITICAL **: 23:29:18.565: fu_device_get_order: assertion 'FU_IS_DEVICE(self)' failed

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
