### PR TITLE
trivial: fix critical warning on unsupported builds

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -311,11 +311,6 @@ fu_error_convert(GError **perror)
 	if (error == NULL)
 		return;
 
-	/* convert GIOError and GFileError */
-	fwupd_error_convert(perror);
-	if (error->domain == FWUPD_ERROR)
-		return;
-
 	/* find match */
 	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
 		if (g_error_matches(error, map[i].domain, map[i].code)) {
@@ -324,6 +319,11 @@ fu_error_convert(GError **perror)
 			return;
 		}
 	}
+
+	/* convert GIOError and GFileError */
+	fwupd_error_convert(perror);
+	if (error->domain == FWUPD_ERROR)
+		return;
 
 	/* fallback */
 #ifndef SUPPORTED_BUILD


### PR DESCRIPTION
If any USB errors are passed up they won't be caught by `fwupd_error_convert()` but are caught by `fu_error_convert()`.  Run through `fu_error_convert()` first.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
