### PR TITLE
tpm: Mark Pluton TPMs as part of the main CPU

### DIFF
--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -7,6 +7,7 @@ if hsi and \
 cargs = ['-DG_LOG_DOMAIN="FuPluginTpm"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
+plugin_quirks += files('tpm.quirk')
 plugin_builtin_tpm = static_library('fu_plugin_tpm',
   rustgen.process('fu-tpm.rs'),
   sources: [

--- a/plugins/tpm/tpm.quirk
+++ b/plugins/tpm/tpm.quirk
@@ -1,0 +1,2 @@
+[TPM\VEN_MSFT&MOD_Pluton.TPM.A]
+Flags = host-cpu-child


### PR DESCRIPTION
Pluton is on die.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
