### PR TITLE
Drop @memlock & @pkey system calls

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -95,7 +95,7 @@ if build_daemon
     endif
 
     # flashrom requires raw-io
-    system_call_filter = ['~@clock', '@cpu-emulation', '@debug', '@module', '@mount', '@obsolete']
+    system_call_filter = ['~@clock', '@cpu-emulation', '@debug', '@memlock', '@module', '@mount', '@obsolete', '@pkey']
     if not allow_flashrom
       system_call_filter += ['@raw-io']
     endif


### PR DESCRIPTION
This PR drops the @memlock and @pkey system calls from fwupd.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X ] Feature
- [ ] Documentation

Details of system calls will be listed in the comments section.