### PR TITLE
Ensure child firmware GTypes exist when building

### DIFF
--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -286,6 +286,7 @@ fu_efi_file_init(FuEfiFile *self)
 	priv->attrib = FU_EFI_FILE_ATTRIB_NONE;
 	priv->type = FU_EFI_FILE_TYPE_RAW;
 	fu_firmware_set_alignment(FU_FIRMWARE(self), FU_FIRMWARE_ALIGNMENT_8);
+	g_type_ensure(FU_TYPE_EFI_SECTION);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -130,6 +130,7 @@ fu_efi_filesystem_init(FuEfiFilesystem *self)
 	    FU_FIRMWARE(self),
 	    g_getenv("FWUPD_FUZZER_RUNNING") == NULL ? FU_EFI_FILESYSTEM_FILES_MAX : 50);
 	fu_firmware_set_alignment(FU_FIRMWARE(self), FU_FIRMWARE_ALIGNMENT_8);
+	g_type_ensure(FU_TYPE_EFI_FILE);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -463,6 +463,7 @@ fu_efi_section_init(FuEfiSection *self)
 				   g_getenv("FWUPD_FUZZER_RUNNING") != NULL ? 10 : 2000);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
 	//	fu_firmware_set_alignment (FU_FIRMWARE (self), FU_FIRMWARE_ALIGNMENT_8);
+	g_type_ensure(FU_TYPE_EFI_VOLUME);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -311,6 +311,7 @@ fu_efi_volume_init(FuEfiVolume *self)
 {
 	FuEfiVolumePrivate *priv = GET_PRIVATE(self);
 	priv->attrs = 0xfeff;
+	g_type_ensure(FU_TYPE_EFI_FILESYSTEM);
 }
 
 static void

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -10,6 +10,7 @@
 
 #include "fu-byte-array.h"
 #include "fu-bytes.h"
+#include "fu-efi-volume.h"
 #include "fu-ifd-bios.h"
 #include "fu-ifd-common.h"
 #include "fu-ifd-firmware.h"
@@ -424,6 +425,9 @@ fu_ifd_firmware_init(FuIfdFirmware *self)
 	priv->flash_master[3] = 0x00800900;
 	priv->flash_ich_strap_base_addr = 0x100;
 	priv->flash_mch_strap_base_addr = 0x300;
+	g_type_ensure(FU_TYPE_IFD_BIOS);
+	g_type_ensure(FU_TYPE_IFD_IMAGE);
+	g_type_ensure(FU_TYPE_EFI_VOLUME);
 }
 
 static void

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -293,6 +293,7 @@ fu_uswid_firmware_init(FuUswidFirmware *self)
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALWAYS_SEARCH);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
+	g_type_ensure(FU_TYPE_COSWID_FIRMWARE);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -82,6 +82,7 @@ fu_acpi_phat_version_record_init(FuAcpiPhatVersionRecord *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
+	g_type_ensure(FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -306,6 +306,8 @@ fu_acpi_phat_init(FuAcpiPhat *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+	g_type_ensure(FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
+	g_type_ensure(FU_TYPE_ACPI_PHAT_VERSION_RECORD);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -643,6 +643,9 @@ fu_bcm57xx_firmware_init(FuBcm57xxFirmware *self)
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_ID);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
+	g_type_ensure(FU_TYPE_BCM57XX_STAGE1_IMAGE);
+	g_type_ensure(FU_TYPE_BCM57XX_STAGE2_IMAGE);
+	g_type_ensure(FU_TYPE_BCM57XX_DICT_IMAGE);
 }
 
 static void

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -199,6 +199,8 @@ static void
 fu_elanfp_firmware_init(FuElanfpFirmware *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 256);
+	g_type_ensure(FU_TYPE_CFU_OFFER);
+	g_type_ensure(FU_TYPE_CFU_PAYLOAD);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -369,6 +369,7 @@ static void
 fu_wac_firmware_init(FuWacFirmware *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
+	g_type_ensure(FU_TYPE_SREC_FIRMWARE);
 }
 
 static void


### PR DESCRIPTION
This ensures we can load the firmware from an XML builder without starting the daemon or creating the plugin.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
