### PR TITLE
Set a generic message request flag when the ID is known

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5253,7 +5253,8 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 		}
 		update_request_id = fu_release_get_update_request_id(release);
 		if (fu_device_get_update_request_id(device) == NULL && update_request_id != NULL) {
-			fu_device_add_request_flag(device, FWUPD_REQUEST_FLAG_NON_GENERIC_MESSAGE);
+			fu_device_add_request_flag(device,
+						   FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 			fu_device_set_update_request_id(device, update_request_id);
 		}
 


### PR DESCRIPTION
Generic message makes sense when there is no ID, but if the ID is provided it's not generic.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
