### PR TITLE
Drop heap as part of a housekeeping action

### DIFF
--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -20,9 +20,6 @@
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#endif
 
 #include "fu-daemon.h"
 #include "fu-debug.h"
@@ -207,11 +204,6 @@ main(int argc, char *argv[])
 		g_idle_add(fu_main_timed_exit_cb, daemon);
 	else if (timed_exit)
 		g_timeout_add_seconds(5, fu_main_timed_exit_cb, daemon);
-
-#ifdef HAVE_MALLOC_TRIM
-	/* drop heap except one page */
-	malloc_trim(4096);
-#endif
 
 	/* wait */
 	g_message("Daemon ready for requests (locale %s)", g_getenv("LANG"));


### PR DESCRIPTION
Doing it at startup really helps to make fwupd 'look better' in ps (even though the kernel would eventually reclaim the pages on memory pressure) but refreshing the metadata allocates dozens of pages that we can discard when the engine is idle again.

Note, this doesn't change how much RSS fwupd actually uses, but it'll make the number look smaller in any kind of process explorer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
