### PR TITLE
trivial: update links in SECURITY.md to link to the actual report

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 Due to the nature of what we are doing, fwupd takes security very seriously.
-If you have any concerns please [let us know](https://github.com/fwupd/fwupd/security).
+If you have any concerns please [let us know](https://github.com/fwupd/fwupd/security/advisories/new).
 
 ## Supported Versions
 
@@ -32,7 +32,7 @@ is unwilling to update to a supported version.
 ## Reporting a Vulnerability
 
 If you find a vulnerability in fwupd you should let us know using a
-[private vulnerability disclosure](https://github.com/fwupd/fwupd/security) on GitHub,
+[private vulnerability disclosure](https://github.com/fwupd/fwupd/security/advisories/new) on GitHub,
 with a description of the issue, the steps you took to create the issue, affected
 versions, and, if known, mitigations for the issue.
 


### PR DESCRIPTION
Following @superm1 [comment](https://github.com/fwupd/fwupd/pull/7044#issuecomment-2041433470) on previous PR, update the links in this page to link to the report page itself (what the "Report a vulnerability" button links to) instead of linking to this same page

Validation: used preview to make sure it renders correctly and both links open the expected page

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [X] Documentation
