### PR TITLE
Compile libcbor without LTO to fix oss-fuzz

### DIFF
--- a/contrib/ci/oss-fuzz-libcbor-lto.patch
+++ b/contrib/ci/oss-fuzz-libcbor-lto.patch
@@ -1,0 +1,17 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a35d62b..fc19111 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -156,12 +156,6 @@ include_directories(${PROJECT_BINARY_DIR})
+ # Policy CMP0069 enables this behavior when we set the minimum CMake version < 3.9.0
+ # Checking for LTO support before setting INTERPROCEDURAL_OPTIMIZATION is mandatory with CMP0069 set to NEW.
+ set(use_lto FALSE)
+-if(${CMAKE_VERSION} VERSION_GREATER "3.9.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.9.0")
+-    cmake_policy(SET CMP0069 NEW)
+-    # Require LTO support to build libcbor with newer CMake versions
+-    include(CheckIPOSupported)
+-    check_ipo_supported(RESULT use_lto)
+-endif(${CMAKE_VERSION} VERSION_GREATER "3.9.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.9.0")
+ if(use_lto)
+     message(STATUS "LTO is enabled")
+ else()


### PR DESCRIPTION
It seems there's no way to *disable* LTO using cmake -- and LTO isn't going to work for a static library...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
