### PR TITLE
trivial: snap: build with newer libxmlb

### DIFF
--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -156,7 +156,6 @@ parts:
       - libsqlite3-dev
       - libsystemd-dev
       - libtss2-dev
-      - libxmlb-dev
       - libmm-glib-dev
       - libqmi-glib-dev
       - libmbim-glib-dev
@@ -201,7 +200,6 @@ parts:
       - libtss2-tcti-mssim0
       - libtss2-tcti-swtpm0
       - libtss2-tctildr0
-      - libxmlb2
       - glib-networking
       - libglib2.0-bin
       - libglib2.0-0


### PR DESCRIPTION
Ensure that the snap gets built with the version we have in the subproject. This should make sure it's always got "What we want" instead of "What's in Ubuntu's archive".

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
