### PR TITLE
trivial: snap: build with newer libxmlb

### DIFF
--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -157,7 +157,6 @@ parts:
       - libsqlite3-dev
       - libsystemd-dev
       - libtss2-dev
-      - libxmlb-dev
       - libmm-glib-dev
       - libqmi-glib-dev
       - libmbim-glib-dev
@@ -200,7 +199,6 @@ parts:
       - libtss2-tcti-mssim0
       - libtss2-tcti-swtpm0
       - libtss2-tctildr0
-      - libxmlb2
       - glib-networking
       - libglib2.0-bin
       - libglib2.0-0

--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.3.12
+revision = b3371e28fc6d153305c5ab01377b9127f6c60857


### PR DESCRIPTION
Ensure that the snap gets built with the version we have in the subproject.
This should make sure it's always got "What we want" instead of "What's in
Ubuntu's archive".

(cherry picked from commit 7dc9b4e6d4e940213b741013e7c2976c5158e656)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
