### PR TITLE
trivial: bump libxmlb requirement to 0.3.18

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -223,7 +223,7 @@ if hsi
   conf.set('HAVE_HSI', '1')
 endif
 libxmlb = dependency('xmlb', version: '>= 0.3.6', fallback: ['libxmlb', 'libxmlb_dep'])
-if libxmlb.version().version_compare('>= 0.3.17')
+if libxmlb.version().version_compare('>= 0.3.18')
   if libxmlb.get_variable('zstd') == 'true'
     lvfs_metadata_format = 'zst'
   elif libxmlb.get_variable('lzma') == 'true'

--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = b3371e28fc6d153305c5ab01377b9127f6c60857
+revision = 0.3.18


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/7060

This won't work until 0.3.18 is actually tagged.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
