### PR TITLE
trivial: require libxmlb 0.3.18 or later

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/build
         cd $GITHUB_WORKSPACE/build
-        meson setup .. -Dman=false --prefix=$GITHUB_WORKSPACE/dist
+        meson setup .. -Dman=false --prefix=$GITHUB_WORKSPACE/dist -Dlibxmlb:gtkdoc=false
         ninja
 
     - name: Perform CodeQL Analysis

--- a/contrib/build-openbmc.sh
+++ b/contrib/build-openbmc.sh
@@ -15,6 +15,7 @@ meson setup build-openbmc \
     -Dtests=true \
     -Dudevdir=/tmp \
     -Dsystemd_root_prefix=/tmp \
+    -Dlibxmlb:gtkdoc=false \
     $@
 
 ninja install -C build-openbmc

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -348,7 +348,7 @@ if introspection.allowed()
   endif
   if libxmlb.type_name() == 'internal'
     girtargets += subproject('libxmlb').get_variable('gir')[0]
-  elif libxmlb.version().version_compare ('>= 0.3.2')
+  else
     girtargets += 'Xmlb-2.0'
   endif
   fwupdplugin_gir = gnome.generate_gir(fwupd,

--- a/meson.build
+++ b/meson.build
@@ -222,17 +222,13 @@ hsi = get_option('hsi').disable_auto_if(host_machine.system() != 'linux').disabl
 if hsi
   conf.set('HAVE_HSI', '1')
 endif
-libxmlb = dependency('xmlb', version: '>= 0.3.6', fallback: ['libxmlb', 'libxmlb_dep'])
-if libxmlb.version().version_compare('>= 0.3.18')
-  if libxmlb.get_variable('zstd') == 'true'
-    lvfs_metadata_format = 'zst'
-  elif libxmlb.get_variable('lzma') == 'true'
-    lvfs_metadata_format = 'xz'
-  else
-    lvfs_metadata_format = 'gz'
-  endif
-else
+libxmlb = dependency('xmlb', version: '>= 0.3.18', fallback: ['libxmlb', 'libxmlb_dep'])
+if libxmlb.get_variable('zstd') == 'true'
+  lvfs_metadata_format = 'zst'
+elif libxmlb.get_variable('lzma') == 'true'
   lvfs_metadata_format = 'xz'
+else
+  lvfs_metadata_format = 'gz'
 endif
 conf.set_quoted('FU_LVFS_METADATA_FORMAT', lvfs_metadata_format)
 gusb = dependency('gusb', version: '>= 0.4.8', fallback: ['gusb', 'gusb_dep'], required: get_option('gusb'))


### PR DESCRIPTION
Stop allowing support for older releases on the 2.0.0 branch.  This isn't intended to backport.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
