### PR TITLE
Appdata related changes

### DIFF
--- a/data/org.freedesktop.fwupd.metainfo.xml
+++ b/data/org.freedesktop.fwupd.metainfo.xml
@@ -26,8 +26,8 @@
   <url type="vcs-browser">https://github.com/fwupd/fwupd</url>
   <update_contact>richard_at_hughsie.com</update_contact>
   <developer_name>The fwupd authors</developer_name>
-    <name translatable="no">The fwupd authors</name>
   <developer id="org.fwupd">
+    <name translate="no">The fwupd authors</name>
   </developer>
   <translation type="gettext">fwupd</translation>
   <content_rating type="oars-1.1">

--- a/data/org.freedesktop.fwupd.metainfo.xml
+++ b/data/org.freedesktop.fwupd.metainfo.xml
@@ -26,8 +26,8 @@
   <url type="vcs-browser">https://github.com/fwupd/fwupd</url>
   <update_contact>richard_at_hughsie.com</update_contact>
   <developer_name>The fwupd authors</developer_name>
-  <developer id="fwupd.org">
     <name translatable="no">The fwupd authors</name>
+  <developer id="org.fwupd">
   </developer>
   <translation type="gettext">fwupd</translation>
   <content_rating type="oars-1.1">


### PR DESCRIPTION
Type of pull request:

- [x] Documentation or chore

### appdata: Update developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer

### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html