### PR TITLE
cros-ec: Do not add a generic instance ID

### DIFF
--- a/plugins/cros-ec/README.md
+++ b/plugins/cros-ec/README.md
@@ -29,6 +29,11 @@ These devices use the standard USB DeviceInstanceId values, e.g.
 
 * `USB\VID_18D1&PID_501A`
 
+It also adds one more instance ID that includes the board name, parsed from
+the device version string, e.g.
+
+* `USB\VID_18D1&PID_501A&BOARDNAME_gingerbread`
+
 ## Update Behavior
 
 The device usually presents in runtime mode, but on detach re-enumerates with

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -462,7 +462,17 @@ fu_cros_ec_usb_device_setup(FuDevice *device, GError **error)
 		fu_device_set_version(FU_DEVICE(device), self->active_version.triplet);
 		fu_device_set_version_bootloader(FU_DEVICE(device), self->version.triplet);
 	}
-	fu_device_add_instance_id(FU_DEVICE(device), self->version.boardname);
+
+	/* one extra instance ID */
+	fu_device_add_instance_str(FU_DEVICE(device), "BOARDNAME", self->version.boardname);
+	if (!fu_device_build_instance_id(FU_DEVICE(device),
+					 error,
+					 "USB",
+					 "VID",
+					 "PID",
+					 "BOARDNAME",
+					 NULL))
+		return FALSE;
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Use an instance ID of 'USB\VID_18D1&PID_501A&BOARDNAME_gingerbread' rather than just 'gingerbread' as it might accidentally match other devices.

Fixes https://github.com/fwupd/fwupd/issues/7022

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
