### PR TITLE
Change SystemCallFilter to whitelist

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -32,4 +32,5 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallErrorNumber=EPERM
+SystemCallFilter=~@resources
 @dynamic_options@

--- a/data/meson.build
+++ b/data/meson.build
@@ -95,8 +95,8 @@ if build_daemon
     endif
 
     # flashrom requires raw-io
-    system_call_filter = ['~@clock', '@cpu-emulation', '@debug', '@memlock', '@module', '@mount', '@obsolete', '@pkey', '@reboot', '@resources', '@swap']
-    if not allow_flashrom
+    system_call_filter = ['@system-service']
+    if allow_flashrom
       system_call_filter += ['@raw-io']
     endif
     dynamic_options += ['SystemCallFilter=' + ' '.join(system_call_filter)]


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

This PR will change the current SystemCallFilter string to whitelist rather than blacklist. As per the systemd documentation:

Generally, allow-listing system calls (rather than deny-listing) is the safer mode of operation. It is recommended to enforce system call allow lists for all long-running system services. Specifically, the following lines are a relatively safe basic choice for the majority of system services:

[Service]
SystemCallFilter=@system-service
SystemCallErrorNumber=EPERM

Source: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html

The system-service system call group allows access to @privileged and @resources as well (hence the unconditional deny of @resources). Assuming my syntax is correct for the dynamic options file, this should also whitelist @raw-io if flashrom is in use.