### PR TITLE
trivial: make fwupd-tests remote mandatory for test devices

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -797,8 +797,19 @@ fu_engine_modify_config(FuEngine *self,
 			return FALSE;
 		}
 
-		/* modify, effective next reboot */
-		return fu_config_set_value(FU_CONFIG(self->config), section, key, value, error);
+		/* many options need a reboot after this */
+		if (!fu_config_set_value(FU_CONFIG(self->config), section, key, value, error))
+			return FALSE;
+
+		/* reload remotes */
+		if (g_strcmp0(key, "TestDevices") == 0 &&
+		    !fu_remote_list_set_testing_remote_enabled(
+			self->remote_list,
+			fu_engine_config_get_test_devices(self->config),
+			error))
+			return FALSE;
+
+		return TRUE;
 	}
 
 	/* handled per-plugin */

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -659,6 +659,28 @@ fu_remote_list_load_metainfos(XbBuilder *builder, GError **error)
 }
 
 gboolean
+fu_remote_list_set_testing_remote_enabled(FuRemoteList *self, gboolean enable, GError **error)
+{
+	g_return_val_if_fail(FU_IS_REMOTE_LIST(self), FALSE);
+
+	/* not yet initialized */
+	if (self->silo == NULL)
+		return TRUE;
+
+	if (self->testing_remote == enable)
+		return TRUE;
+
+	self->testing_remote = enable;
+
+	if (!fu_remote_list_reload(self, error))
+		return FALSE;
+
+	fu_remote_list_emit_changed(self);
+
+	return TRUE;
+}
+
+gboolean
 fu_remote_list_load(FuRemoteList *self, FuRemoteListLoadFlags flags, GError **error)
 {
 	const gchar *const *locales = g_get_language_names();

--- a/src/fu-remote-list.h
+++ b/src/fu-remote-list.h
@@ -34,6 +34,9 @@ typedef enum {
 FuRemoteList *
 fu_remote_list_new(void);
 gboolean
+fu_remote_list_set_testing_remote_enabled(FuRemoteList *self, gboolean enable, GError **error)
+    G_GNUC_NON_NULL(1);
+gboolean
 fu_remote_list_load(FuRemoteList *self, FuRemoteListLoadFlags flags, GError **error)
     G_GNUC_NON_NULL(1);
 gboolean


### PR DESCRIPTION
Debian (currently) packages fwupd-tests as a separate package from fwupd.  If test mode is enabled a lot of test things work, but locally installed metadata specifically doesn't.

Make it clearer when test mode is enabled that the fwupd-tests remote also needs to be present.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
