### PR TITLE
Include the Passim download saving number in the fwupd firmware metadata

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1697,6 +1697,17 @@ fu_engine_get_report_metadata(FuEngine *self, GError **error)
 	if (tmp != NULL)
 		g_hash_table_insert(hash, g_strdup("HostBkc"), g_strdup(tmp));
 
+#ifdef HAVE_PASSIM
+#if PASSIM_CHECK_VERSION(0, 1, 6)
+	/* this is useful to know if passim support is actually helping bandwidth use */
+	g_hash_table_insert(
+	    hash,
+	    g_strdup("PassimDownloadSaving"),
+	    g_strdup_printf("%" G_GUINT64_FORMAT,
+			    passim_client_get_download_saving(self->passim_client)));
+#endif
+#endif
+
 	/* DMI data */
 	if (fu_context_has_flag(self->ctx, FU_CONTEXT_FLAG_LOADED_HWINFO)) {
 		struct {


### PR DESCRIPTION
At the moment we have no idea if Passim is helping with metadata distribution or not. Of course, this will be skewed to customers allowing random network access, and to those with deployed firmware updates -- but a number that's 'going up' gives us a good idea on how it is being used in the real world.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
