### PR TITLE
Change SystemCallFilter to allowlist

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -94,12 +94,15 @@ if build_daemon
       dynamic_options += 'RestrictAddressFamilies=AF_NETLINK AF_UNIX'
     endif
 
-    # flashrom requires raw-io
-    system_call_filter = ['~@clock', '@cpu-emulation', '@debug', '@memlock', '@module', '@mount', '@obsolete', '@pkey', '@reboot', '@resources', '@swap']
-    if not allow_flashrom
-      system_call_filter += ['@raw-io']
+    # the order of SystemCallFilter is important as the first encountered will take precedence and
+    # will dictate the default action
+    syscall_allow = ['@system-service']
+    syscall_deny = ['@resources']
+    if allow_flashrom
+      syscall_allow += ['@raw-io']
     endif
-    dynamic_options += ['SystemCallFilter=' + ' '.join(system_call_filter)]
+    dynamic_options += ['SystemCallFilter=' + ' '.join(syscall_allow)]
+    dynamic_options += ['SystemCallFilter=~' + ' '.join(syscall_deny)] # tilde is not a typo
 
     con2.set('dynamic_options', '\n'.join(dynamic_options))
     con2.set('motd_dir', motd_dir)


### PR DESCRIPTION
As per the systemd documentation:

Generally, allow-listing system calls (rather than deny-listing) is the safer mode of operation. It is recommended to enforce system call allow lists for all long-running system services.

Verified with no notible changes to `systemd-analyze security fwupd.service`

Many thanks to RZR7332 for the original patch.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
