### PR TITLE
trivial: don't build efi binary by default

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         mkdir -p $GITHUB_WORKSPACE/build
         cd $GITHUB_WORKSPACE/build
-        meson setup .. -Dman=false -Defi_binary=false --prefix=$GITHUB_WORKSPACE/dist
+        meson setup .. -Dman=false --prefix=$GITHUB_WORKSPACE/dist
         ninja
 
     - name: Perform CodeQL Analysis

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -31,7 +31,6 @@ build() {
         -Dplugin_powerd=disabled \
         -Dlaunchd=disabled \
         -Ddocs=enabled \
-        -Defi_binary=false \
         -Dsupported_build=enabled
 
     ninja -v -C ../build

--- a/contrib/ci/ubuntu.sh
+++ b/contrib/ci/ubuntu.sh
@@ -33,7 +33,7 @@ root=$(pwd)
 export BUILD=${root}/build
 rm -rf ${BUILD}
 chown -R nobody ${root}
-sudo -u nobody meson ${BUILD} -Defi_binary=false -Doffline=true -Dman=false -Ddocs=enabled -Dgusb:tests=false --prefix=${root}/dist
+sudo -u nobody meson ${BUILD} -Doffline=true -Dman=false -Ddocs=enabled -Dgusb:tests=false --prefix=${root}/dist
 #build with clang
 sudo -u nobody ninja -C ${BUILD} test -v
 

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -36,7 +36,7 @@ ifneq ($(filter nodoc,$(DEB_BUILD_PROFILES)),)
 	CONFARGS += -Ddocs=disabled
 endif
 
-CONFARGS += -Dplugin_powerd=disabled -Dsupported_build=enabled -Dplugin_modem_manager=enabled -Defi_binary=false
+CONFARGS += -Dplugin_powerd=disabled -Dsupported_build=enabled -Dplugin_modem_manager=enabled
 
 %:
 	dh $@ --with gir

--- a/contrib/freebsd/Makefile
+++ b/contrib/freebsd/Makefile
@@ -45,7 +45,6 @@ MESON_ARGS=	-Dgudev=disabled \
 		-Dpolkit=disabled \
 		-Dsystemd=disabled \
 		-Dtests=false \
-		-Ddocs=enabled \
-		-Defi_binary=false
+		-Ddocs=enabled
 
 .include <bsd.port.mk>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -260,7 +260,6 @@ fwupd wrapper for Qubes OS
     -Dplugin_uefi_capsule=enabled \
     -Dplugin_uefi_pk=enabled \
     -Dplugin_tpm=enabled \
-    -Defi_binary=false \
 %else
     -Dplugin_uefi_capsule=disabled \
     -Dplugin_uefi_pk=disabled \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -494,7 +494,7 @@ option('efi_os_dir',
 )
 option('efi_binary',
   type: 'boolean',
-  value: true,
+  value: false,
   description: 'generate uefi binary if missing',
 )
 option('metainfo',

--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -11,8 +11,7 @@ With the UpdateCapsule boot service it can be used to update system firmware.
 If you don't want or need this functionality you can use the
 `-Dplugin_uefi_capsule=disabled` option.
 
-When this plugin is enabled, the companion UEFI binary may also be built from the [fwupd-efi](https://github.com/fwupd/fwupd-efi) project if not already present on the filesystem.
-This behavior can be overridden using the meson option `-Defi_binary=false`.
+When this plugin is enabled, the companion UEFI binary may also be built from the [fwupd-efi](https://github.com/fwupd/fwupd-efi) project if not already present on the filesystem by using the meson option `-Defi_binary=true`.
 
 For this companion binary to work with secure boot, it will need to be signed by an authority trusted with shim and/or the host environment.
 


### PR DESCRIPTION
"Most" people doing fwupd development and packaging won't need the EFI binary by default, so don't build it.

Fixes: https://github.com/fwupd/fwupd/issues/7119

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
