### PR TITLE
Detect BlueTooth devices by GATT service UUID

### DIFF
--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -385,7 +385,7 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 		fu_device_set_name(device, g_variant_get_string(val_name, NULL));
 	val_icon = g_dbus_proxy_get_cached_property(priv->proxy, "Icon");
 	if (val_icon != NULL)
-		fu_device_add_icon(device, g_variant_get_string(val_name, NULL));
+		fu_device_add_icon(device, g_variant_get_string(val_icon, NULL));
 	val_modalias = g_dbus_proxy_get_cached_property(priv->proxy, "Modalias");
 	if (val_modalias != NULL)
 		fu_bluez_device_set_modalias(self, g_variant_get_string(val_modalias, NULL));

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -270,7 +270,12 @@ fu_bluez_device_get_ble_property(const gchar *obj_path,
 	g_dbus_proxy_set_default_timeout(proxy, DEFAULT_PROXY_TIMEOUT);
 	val = g_dbus_proxy_get_cached_property(proxy, prop_name);
 	if (val == NULL) {
-		g_prefix_error(error, "property %s not found in %s: ", prop_name, obj_path);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "property %s not found in %s: ",
+			    prop_name,
+			    obj_path);
 		return NULL;
 	}
 

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -411,6 +411,10 @@ fu_bluez_device_read(FuBluezDevice *self, const gchar *uuid, GError **error)
 	g_autoptr(GVariantIter) iter = NULL;
 	g_autoptr(GVariant) val = NULL;
 
+	g_return_val_if_fail(FU_IS_BLUEZ_DEVICE(self), NULL);
+	g_return_val_if_fail(uuid != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
 	uuid_helper = fu_bluez_device_get_uuid_helper(self, uuid, error);
 	if (uuid_helper == NULL)
 		return NULL;
@@ -491,6 +495,11 @@ fu_bluez_device_write(FuBluezDevice *self, const gchar *uuid, GByteArray *buf, G
 	GVariant *opt_variant = NULL;
 	GVariant *val_variant = NULL;
 
+	g_return_val_if_fail(FU_IS_BLUEZ_DEVICE(self), FALSE);
+	g_return_val_if_fail(uuid != NULL, FALSE);
+	g_return_val_if_fail(buf != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	uuid_helper = fu_bluez_device_get_uuid_helper(self, uuid, error);
 	if (uuid_helper == NULL)
 		return FALSE;
@@ -543,6 +552,10 @@ fu_bluez_device_notify_start(FuBluezDevice *self, const gchar *uuid, GError **er
 	FuBluezDeviceUuidHelper *uuid_helper;
 	g_autoptr(GVariant) retval = NULL;
 
+	g_return_val_if_fail(FU_IS_BLUEZ_DEVICE(self), FALSE);
+	g_return_val_if_fail(uuid != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
 	uuid_helper = fu_bluez_device_get_uuid_helper(self, uuid, error);
 	if (uuid_helper == NULL)
 		return FALSE;
@@ -581,6 +594,10 @@ fu_bluez_device_notify_stop(FuBluezDevice *self, const gchar *uuid, GError **err
 {
 	FuBluezDeviceUuidHelper *uuid_helper;
 	g_autoptr(GVariant) retval = NULL;
+
+	g_return_val_if_fail(FU_IS_BLUEZ_DEVICE(self), FALSE);
+	g_return_val_if_fail(uuid != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	uuid_helper = fu_bluez_device_get_uuid_helper(self, uuid, error);
 	if (uuid_helper == NULL)

--- a/libfwupdplugin/fu-bluez-device.h
+++ b/libfwupdplugin/fu-bluez-device.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fu-device.h"
+#include "fu-io-channel.h"
 
 #define FU_TYPE_BLUEZ_DEVICE (fu_bluez_device_get_type())
 G_DECLARE_DERIVABLE_TYPE(FuBluezDevice, fu_bluez_device, FU, BLUEZ_DEVICE, FuDevice)
@@ -29,3 +30,9 @@ fu_bluez_device_notify_start(FuBluezDevice *self, const gchar *uuid, GError **er
 gboolean
 fu_bluez_device_notify_stop(FuBluezDevice *self, const gchar *uuid, GError **error)
     G_GNUC_NON_NULL(1, 2);
+FuIOChannel *
+fu_bluez_device_notify_acquire(FuBluezDevice *self, const gchar *uuid, gint32 *mtu, GError **error)
+    G_GNUC_NON_NULL(1, 2, 3);
+FuIOChannel *
+fu_bluez_device_write_acquire(FuBluezDevice *self, const gchar *uuid, gint32 *mtu, GError **error)
+    G_GNUC_NON_NULL(1, 2, 3);


### PR DESCRIPTION
Some BT devices don't provide VID, so fwupd can't detect such devices properly. In the same time, the device might announce service with unique UUID for firmware upgrading.

This commit allows to detect BT devices by UUID of the updating service, for instance:
  21608f80-6c9c-5cd1-91ed-0fbf18e31958 ← BLUETOOTH\GATT_00001100-d102-11e1-9b23-00025b00a5a5

In addition, added querying of Battery service if available, and battery percentage is set according to received value

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x ] Feature
- [ ] Documentation
