### PR TITLE
trivial: Fix a regression from 587927

### DIFF
--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -481,7 +481,8 @@ fu_coswid_firmware_malloc(size_t size)
 		g_debug("failing CBOR allocation of 0x%x bytes", (guint)size);
 		return NULL;
 	}
-	return g_malloc0(size);
+	/* libcbor expects a valid pointer for a zero sized allocation */
+	return g_malloc0(MAX(size, 1));
 }
 
 static void *
@@ -491,7 +492,8 @@ fu_coswid_firmware_realloc(void *ptr, size_t size)
 		g_debug("failing CBOR reallocation of 0x%x bytes", (guint)size);
 		return NULL;
 	}
-	return g_realloc(ptr, size);
+	/* libcbor expects a valid pointer for a zero sized allocation */
+	return g_realloc(ptr, MAX(size, 1));
 }
 
 static void


### PR DESCRIPTION
Apparently, libcbor expects a valid pointer for a zero sized allocation.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68115

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
