### PR TITLE
Emit a signal when a request is no longer valid

### DIFF
--- a/libfwupd/fwupd-request-private.h
+++ b/libfwupd/fwupd-request-private.h
@@ -13,4 +13,7 @@ G_BEGIN_DECLS
 GVariant *
 fwupd_request_to_variant(FwupdRequest *self) G_GNUC_NON_NULL(1);
 
+void
+fwupd_request_emit_invalidate(FwupdRequest *self) G_GNUC_NON_NULL(1);
+
 G_END_DECLS

--- a/libfwupd/fwupd-request.h
+++ b/libfwupd/fwupd-request.h
@@ -15,8 +15,8 @@ G_DECLARE_DERIVABLE_TYPE(FwupdRequest, fwupd_request, FWUPD, REQUEST, GObject)
 
 struct _FwupdRequestClass {
 	GObjectClass parent_class;
+	void (*invalidate)(FwupdRequest *client);
 	/*< private >*/
-	void (*_fwupd_reserved1)(void);
 	void (*_fwupd_reserved2)(void);
 	void (*_fwupd_reserved3)(void);
 	void (*_fwupd_reserved4)(void);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -977,6 +977,12 @@ LIBFWUPD_1.9.15 {
   local: *;
 } LIBFWUPD_1.9.10;
 
+LIBFWUPD_1.9.17 {
+  global:
+    fwupd_request_emit_invalidate;
+  local: *;
+} LIBFWUPD_1.9.15;
+
 LIBFWUPD_2.0.0 {
   global:
     fwupd_client_install_release;
@@ -997,4 +1003,4 @@ LIBFWUPD_2.0.0 {
     fwupd_remote_set_security_report_uri;
     fwupd_remote_set_username;
   local: *;
-} LIBFWUPD_1.9.15;
+} LIBFWUPD_1.9.17;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3101,6 +3101,7 @@ fu_engine_detach(FuEngine *self,
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) poll_locker = NULL;
+	g_autoptr(FuDeviceProgress) device_progress = NULL;
 
 	/* the device and plugin both may have changed */
 	device = fu_engine_get_device(self, device_id, error);
@@ -3108,6 +3109,8 @@ fu_engine_detach(FuEngine *self,
 		g_prefix_error(error, "failed to get device before update detach: ");
 		return FALSE;
 	}
+	device_progress = fu_device_progress_new(device, progress);
+	g_assert(device_progress != NULL);
 
 	/* pause the polling */
 	poll_locker = fu_device_poll_locker_new(device, error);
@@ -3167,6 +3170,7 @@ fu_engine_attach(FuEngine *self, const gchar *device_id, FuProgress *progress, G
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) poll_locker = NULL;
+	g_autoptr(FuDeviceProgress) device_progress = NULL;
 
 	/* the device and plugin both may have changed */
 	device = fu_engine_get_device(self, device_id, error);
@@ -3174,6 +3178,9 @@ fu_engine_attach(FuEngine *self, const gchar *device_id, FuProgress *progress, G
 		g_prefix_error(error, "failed to get device before update attach: ");
 		return FALSE;
 	}
+	device_progress = fu_device_progress_new(device, progress);
+	g_assert(device_progress != NULL);
+
 	str = fu_device_to_string(device);
 	g_info("attach -> %s", str);
 	plugin =
@@ -3310,6 +3317,7 @@ fu_engine_write_firmware(FuEngine *self,
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuDevice) device = NULL;
 	g_autoptr(FuDeviceLocker) poll_locker = NULL;
+	g_autoptr(FuDeviceProgress) device_progress = NULL;
 	g_autoptr(GError) error_write = NULL;
 
 	/* cancel the pending action */
@@ -3322,6 +3330,8 @@ fu_engine_write_firmware(FuEngine *self,
 		g_prefix_error(error, "failed to get device before update: ");
 		return FALSE;
 	}
+	device_progress = fu_device_progress_new(device, progress);
+	g_assert(device_progress != NULL);
 
 	/* pause the polling */
 	poll_locker = fu_device_poll_locker_new(device, error);


### PR DESCRIPTION
Although we can do this looking at the device changed events, it's much nicer to provide a signal that GUI clients can use directly.

Fixes https://github.com/fwupd/fwupd/issues/7130

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
