### PR TITLE
Drop audit/suspend block/checkpoint capabilities from fwupd

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -13,6 +13,16 @@ RuntimeDirectory=@motd_dir@
 RuntimeDirectoryPreserve=yes
 BusName=org.freedesktop.fwupd
 ExecStart=@libexecdir@/fwupd/fwupd
+
+# Already implicitly dropped, dropping explicitly
+CapabilityBoundingSet=~CAP_SYS_MODULE
+CapabilityBoundingSet=~CAP_SYS_TIME
+CapabilityBoundingSet=~CAP_SYSLOG
+
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND
+CapabilityBoundingSet=~CAP_CHECKPOINT_RESTORE
+
 KeyringMode=private
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
This PR aims to drop the AUDIT subsystem, suspend block and checkpoint restore capabilties from fwupd, as well as explicitly drops the capabilities which have been implicitly dropped as a result of other settings.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation

It is my intention to follow a similar process here as done with SystemCallFilter: drop cautiously, and hopefully transition to a whitelist at the end of the process (although blacklisting will also work - I see no systemd recommendation as to the best option).

Some calls have been implicitly dropped as a result of other settings, assumptions below:

- CAP_SYS_MODULE dropped by ProtectKernelModules;
- CAP_SYS_TIME dropped by ProtectClock;
- CAP_SYSLOG dropped by ProtectKernelLogs.

I shall provide some details for the other capabilities in the comments. Multiple lines are permitted (and combined) if prefaced with ~ - from the man page:

This option may appear more than once, in which case the bounding sets are merged by OR, or by AND if the lines are prefixed with "~"

Source: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html

The details of the respective capabilities can be found at https://man7.org/linux/man-pages/man7/capabilities.7.html