### PR TITLE
trivial: Fix P2pPolicy's nothing value in docs

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -203,7 +203,7 @@ The `[fwupd]` section can contain the following parameters:
 
   There are three possible values:
 
-* `none`: Do not publish any files
+* `nothing`: Do not publish any files
 
 * `metadata`: Only publish shared metadata that is common to each machine.
 


### PR DESCRIPTION
rustgen output:

FuP2pPolicy
fu_p2p_policy_from_string(const gchar *val)
{
    if (g_strcmp0(val, "nothing") == 0)
        return FU_P2P_POLICY_NOTHING;
    if (g_strcmp0(val, "metadata") == 0)
        return FU_P2P_POLICY_METADATA;
    if (g_strcmp0(val, "firmware") == 0)
        return FU_P2P_POLICY_FIRMWARE;
    return FU_P2P_POLICY_NOTHING;
}

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
