### PR TITLE
Add splice to syscall_filter

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -105,6 +105,7 @@ if build_daemon
       '@sync',
       'ioctl',
       'uname',
+      'splice'
     ]
     if allow_flashrom
       syscall_filter += ['@raw-io']


### PR DESCRIPTION
Include `splice` in the `SystemCallFilter` directive of the systemd service file.

After switching to a simple allow list for SystemCallFilter (c4af843d2 "Use simple allow-listing for the syscall filter"), updating firmware can fail with "Failed to copy /usr/lib/fwupd/efi/fwupdx64.efi to /boot/EFI/arch/fwupdx64.efi: Error splicing file: Operation not permitted".

This is caused by removing the previously allowed @system-service group (which includes splice).

`splice()` is used through `g_file_copy()` when available (see https://github.com/fwupd/fwupd/issues/7166#issuecomment-2074462255).

Note: cannot test this, as I have no pending firmware updates.

See #7166.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
