### PR TITLE
trivial: Use a newer ColorHug firmware for the emulated tests

### DIFF
--- a/data/device-tests/hughski-colorhug.json
+++ b/data/device-tests/hughski-colorhug.json
@@ -3,7 +3,7 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/9a4e77009da7d3b5f15a1388afeb9e5d41a5a8ae-hughski-colorhug2-1.2.5.cab",
+      "url": "https://fwupd.org/downloads/42a0a07a978018af235833c9b861461e923163dffd1fb177a9caa59a0c36995e-hughski-colorhug2-1.2.5.cab",
       "emulation-url": "https://fwupd.org/downloads/08ddc01a50fb866398d01cc4829531640e651f0233306e10a54117f88474b153-hughski-colorhug-1.2.5.zip",
       "components": [
         {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
