### PR TITLE
Drop heap as part of a housekeeping action

### DIFF
--- a/src/fu-daemon.c
+++ b/src/fu-daemon.c
@@ -36,6 +36,10 @@
 #include "fu-release.h"
 #include "fu-security-attrs-private.h"
 
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+
 static void
 fu_daemon_finalize(GObject *obj);
 
@@ -53,6 +57,7 @@ struct _FuDaemon {
 	guint owner_id;
 	guint process_quit_id;
 	FuEngine *engine;
+	guint housekeeping_id;
 	gboolean update_in_progress;
 	gboolean pending_stop;
 	FuDaemonMachineKind machine_kind;
@@ -61,10 +66,40 @@ struct _FuDaemon {
 
 G_DEFINE_TYPE(FuDaemon, fu_daemon, G_TYPE_OBJECT)
 
+#define FU_DAEMON_HOUSEKEEPING_DELAY 10 /* seconds */
+
+static gboolean
+fu_daemon_schedule_housekeeping_cb(gpointer user_data)
+{
+	FuDaemon *self = FU_DAEMON(user_data);
+
+#ifdef HAVE_MALLOC_TRIM
+	/* drop heap except one page */
+	malloc_trim(0);
+#endif
+
+	/* success */
+	self->housekeeping_id = 0;
+	return G_SOURCE_REMOVE;
+}
+
+static void
+fu_daemon_schedule_housekeeping(FuDaemon *self)
+{
+	if (self->update_in_progress)
+		return;
+	if (self->housekeeping_id != 0)
+		g_source_remove(self->housekeeping_id);
+	self->housekeeping_id = g_timeout_add_seconds(FU_DAEMON_HOUSEKEEPING_DELAY,
+						      fu_daemon_schedule_housekeeping_cb,
+						      self);
+}
+
 void
 fu_daemon_start(FuDaemon *self)
 {
 	g_return_if_fail(FU_IS_DAEMON(self));
+	fu_daemon_schedule_housekeeping(self);
 	g_main_loop_run(self->loop);
 }
 
@@ -92,6 +127,7 @@ fu_daemon_engine_changed_cb(FuEngine *engine, FuDaemon *self)
 				      "Changed",
 				      NULL,
 				      NULL);
+	fu_daemon_schedule_housekeeping(self);
 }
 
 static void
@@ -110,6 +146,7 @@ fu_daemon_engine_device_added_cb(FuEngine *engine, FuDevice *device, FuDaemon *s
 				      "DeviceAdded",
 				      g_variant_new_tuple(&val, 1),
 				      NULL);
+	fu_daemon_schedule_housekeeping(self);
 }
 
 static void
@@ -128,6 +165,7 @@ fu_daemon_engine_device_removed_cb(FuEngine *engine, FuDevice *device, FuDaemon 
 				      "DeviceRemoved",
 				      g_variant_new_tuple(&val, 1),
 				      NULL);
+	fu_daemon_schedule_housekeeping(self);
 }
 
 static void
@@ -146,6 +184,7 @@ fu_daemon_engine_device_changed_cb(FuEngine *engine, FuDevice *device, FuDaemon 
 				      "DeviceChanged",
 				      g_variant_new_tuple(&val, 1),
 				      NULL);
+	fu_daemon_schedule_housekeeping(self);
 }
 
 static void
@@ -2453,6 +2492,8 @@ fu_daemon_finalize(GObject *obj)
 		g_object_unref(self->client_list);
 	if (self->process_quit_id != 0)
 		g_source_remove(self->process_quit_id);
+	if (self->housekeeping_id != 0)
+		g_source_remove(self->housekeeping_id);
 	if (self->loop != NULL)
 		g_main_loop_unref(self->loop);
 	if (self->owner_id > 0)

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -20,9 +20,6 @@
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#endif
 
 #include "fu-daemon.h"
 #include "fu-debug.h"
@@ -207,11 +204,6 @@ main(int argc, char *argv[])
 		g_idle_add(fu_main_timed_exit_cb, daemon);
 	else if (timed_exit)
 		g_timeout_add_seconds(5, fu_main_timed_exit_cb, daemon);
-
-#ifdef HAVE_MALLOC_TRIM
-	/* drop heap except one page */
-	malloc_trim(4096);
-#endif
 
 	/* wait */
 	g_message("Daemon ready for requests (locale %s)", g_getenv("LANG"));


### PR DESCRIPTION
Doing it at startup really helps to make fwupd 'look better' in ps (even though the kernel would eventually reclaim the pages on memory pressure) but refreshing the metadata allocates dozens of pages that we can discard when the engine is idle again.

Note, this doesn't change how much RSS fwupd actually uses, but it'll make the number look smaller in any kind of process explorer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
