### PR TITLE
trivial: Ensure device parents are setup when using FwupdClient

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -1665,6 +1665,7 @@ fwupd_client_get_devices_cb(GObject *source, GAsyncResult *res, gpointer user_da
 		g_task_return_error(task, g_steal_pointer(&error));
 		return;
 	}
+	fwupd_device_array_ensure_parents(array);
 
 	/* success */
 	g_task_return_pointer(task, g_steal_pointer(&array), (GDestroyNotify)g_ptr_array_unref);
@@ -1833,6 +1834,7 @@ fwupd_client_get_history_cb(GObject *source, GAsyncResult *res, gpointer user_da
 		g_task_return_error(task, g_steal_pointer(&error));
 		return;
 	}
+	fwupd_device_array_ensure_parents(array);
 
 	/* success */
 	g_task_return_pointer(task, g_steal_pointer(&array), (GDestroyNotify)g_ptr_array_unref);


### PR DESCRIPTION
In b6633f4 I forgot that `fwupd_device_array_from_variant()` had the magic ability to set up the parents when converting from a GVariant.

This fixes the device nesting in 'fwupdmgr get-devices'

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
