### PR TITLE
Only read back the thunderbolt firmware if we can parse the NVM

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -42,6 +42,7 @@ struct _FuDeviceClass {
 	gboolean (*rescan)(FuDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	FuFirmware *(*prepare_firmware)(FuDevice *self,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*set_quirk_kv)(FuDevice *self,
@@ -792,8 +793,9 @@ fu_device_write_firmware(FuDevice *self,
 FuFirmware *
 fu_device_prepare_firmware(FuDevice *self,
 			   GInputStream *stream,
+			   FuProgress *progress,
 			   FwupdInstallFlags flags,
-			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
 FuFirmware *
 fu_device_read_firmware(FuDevice *self,
 			FuProgress *progress,

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -87,6 +87,8 @@ fu_firmware_flag_to_string(FuFirmwareFlags flag)
 		return "always-search";
 	if (flag == FU_FIRMWARE_FLAG_NO_AUTO_DETECTION)
 		return "no-auto-detection";
+	if (flag == FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE)
+		return "has-check-compatible";
 	return NULL;
 }
 
@@ -119,6 +121,8 @@ fu_firmware_flag_from_string(const gchar *flag)
 		return FU_FIRMWARE_FLAG_ALWAYS_SEARCH;
 	if (g_strcmp0(flag, "no-auto-detection") == 0)
 		return FU_FIRMWARE_FLAG_NO_AUTO_DETECTION;
+	if (g_strcmp0(flag, "has-check-compatible") == 0)
+		return FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE;
 	return FU_FIRMWARE_FLAG_NONE;
 }
 
@@ -1054,6 +1058,10 @@ fu_firmware_parse_stream(FuFirmware *self,
 	/* any FuFirmware subclass that gets past this point might have allocated memory in
 	 * ->tokenize() or ->parse() and needs to be destroyed before parsing again */
 	fu_firmware_add_flag(self, FU_FIRMWARE_FLAG_DONE_PARSE);
+
+	/* this allows devices to skip reading the old firmware if the GType is unsuitable */
+	if (klass->check_compatible != NULL)
+		fu_firmware_add_flag(self, FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE);
 
 	/* optional */
 	if (klass->tokenize != NULL) {

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -163,6 +163,14 @@ typedef enum {
 	 **/
 	FU_FIRMWARE_FLAG_NO_AUTO_DETECTION = 1u << 7,
 	/**
+	 * FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE:
+	 *
+	 * The firmware subclass implements a compatibility check.
+	 *
+	 * Since: 1.9.20
+	 **/
+	FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE = 1u << 8,
+	/**
 	 * FU_FIRMWARE_FLAG_UNKNOWN:
 	 *
 	 * Unknown flag value.

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -176,6 +176,7 @@ fu_amd_gpu_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_amd_gpu_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
+				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-device.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-device.c
@@ -569,6 +569,7 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 static FuFirmware *
 fu_qc_s5gen2_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
+				     FuProgress *progress,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -130,6 +130,7 @@ fu_aver_hid_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_aver_hid_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -328,6 +328,7 @@ fu_bcm57xx_device_read_firmware(FuDevice *device, FuProgress *progress, GError *
 static FuFirmware *
 fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
+				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {
@@ -340,7 +341,6 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	g_autoptr(FuFirmware) img_ape = NULL;
 	g_autoptr(FuFirmware) img_stage1 = NULL;
 	g_autoptr(FuFirmware) img_stage2 = NULL;
-	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GPtrArray) images = NULL;
 
 	/* try to parse NVRAM, stage1 or APE */
@@ -370,6 +370,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* get the existing firmware from the device */
+	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 	fw_old = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw_old == NULL)
 		return NULL;

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -540,6 +540,7 @@ fu_bcm57xx_recovery_device_dump_firmware(FuDevice *device, FuProgress *progress,
 static FuFirmware *
 fu_bcm57xx_recovery_device_prepare_firmware(FuDevice *device,
 					    GInputStream *stream,
+					    FuProgress *progress,
 					    FwupdInstallFlags flags,
 					    GError **error)
 {

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -646,6 +646,7 @@ fu_ccgx_dmc_write_firmware(FuDevice *device,
 static FuFirmware *
 fu_ccgx_dmc_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1099,6 +1099,7 @@ fu_ccgx_hpi_device_attach(FuDevice *device, FuProgress *progress, GError **error
 static FuFirmware *
 fu_ccgx_hpi_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -196,6 +196,7 @@ fu_ccgx_pure_hid_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_ccgx_pure_hid_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -83,6 +83,7 @@ fu_cfu_module_setup(FuCfuModule *self, const guint8 *buf, gsize bufsz, gsize off
 static FuFirmware *
 fu_cfu_module_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
+			       FuProgress *progress,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -904,6 +904,7 @@ fu_cros_ec_usb_device_write_firmware(FuDevice *device,
 static FuFirmware *
 fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
+				       FuProgress *progress,
 				       FwupdInstallFlags flags,
 				       GError **error)
 {

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1433,6 +1433,7 @@ fu_dfu_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **err
 static FuFirmware *
 fu_dfu_device_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
+			       FuProgress *progress,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -450,6 +450,7 @@ fu_elantp_hid_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_elantp_hid_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -625,6 +625,7 @@ fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_elantp_hid_haptic_device_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
+					     FuProgress *progress,
 					     FwupdInstallFlags flags,
 					     GError **error)
 {

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -420,6 +420,7 @@ fu_elantp_i2c_device_open(FuDevice *device, GError **error)
 static FuFirmware *
 fu_elantp_i2c_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -329,6 +329,7 @@ fu_emmc_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_emmc_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
+				FuProgress *progress,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -192,6 +192,7 @@ fu_fresco_pd_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_fresco_pd_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
+				     FuProgress *progress,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -761,6 +761,7 @@ fu_genesys_gl32xx_device_read_firmware(FuDevice *device, FuProgress *progress, G
 static FuFirmware *
 fu_genesys_gl32xx_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1694,6 +1694,7 @@ fu_genesys_scaler_device_dump_firmware(FuDevice *device, FuProgress *progress, G
 static FuFirmware *
 fu_genesys_scaler_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -2159,6 +2159,7 @@ fu_genesys_usbhub_device_adjust_fw_addr(FuGenesysUsbhubDevice *self,
 static FuFirmware *
 fu_genesys_usbhub_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -393,6 +393,7 @@ fu_goodixtp_brlb_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_goodixtp_brlb_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -440,6 +440,7 @@ fu_goodixtp_gtx8_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_goodixtp_gtx8_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -82,6 +82,7 @@ fu_igsc_aux_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_igsc_aux_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -476,6 +476,7 @@ fu_igsc_device_probe(FuDevice *device, GError **error)
 static FuFirmware *
 fu_igsc_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
+				FuProgress *progress,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -104,6 +104,7 @@ fu_igsc_oprom_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_igsc_oprom_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -452,6 +452,7 @@ fu_intel_usb4_device_activate(FuDevice *device, FuProgress *progress, GError **e
 static FuFirmware *
 fu_intel_usb4_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -566,6 +566,7 @@ fu_jabra_gnp_device_write_dfu_from_squif(FuJabraGnpDevice *self, GError **error)
 static FuFirmware *
 fu_jabra_gnp_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
+				     FuProgress *progress,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -939,6 +939,7 @@ fu_mediatek_scaler_device_write_firmware(FuDevice *device,
 static FuFirmware *
 fu_mediatek_scaler_device_prepare_firmware(FuDevice *device,
 					   GInputStream *stream,
+					   FuProgress *progress,
 					   FwupdInstallFlags flags,
 					   GError **error)
 {

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -84,6 +84,7 @@ fu_pxi_ble_device_to_string(FuDevice *device, guint idt, GString *str)
 static FuFirmware *
 fu_pxi_ble_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
+				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -56,6 +56,7 @@ fu_pxi_receiver_device_to_string(FuDevice *device, guint idt, GString *str)
 static FuFirmware *
 fu_pxi_receiver_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -53,6 +53,7 @@ fu_pxi_wireless_device_get_parent(FuDevice *self, GError **error)
 static FuFirmware *
 fu_pxi_wireless_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {

--- a/plugins/qsi-dock/fu-qsi-dock-child-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-child-device.c
@@ -33,6 +33,7 @@ fu_qsi_dock_child_device_to_string(FuDevice *device, guint idt, GString *str)
 static FuFirmware *
 fu_qsi_dock_mcu_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {
@@ -41,7 +42,7 @@ fu_qsi_dock_mcu_device_prepare_firmware(FuDevice *device,
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return NULL;
 	}
-	return fu_device_prepare_firmware(parent, stream, flags, error);
+	return fu_device_prepare_firmware(parent, stream, progress, flags, error);
 }
 
 /* only update this specific child component */

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -519,6 +519,7 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 static FuFirmware *
 fu_rts54hub_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -143,6 +143,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 static FuFirmware *
 fu_scsi_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
+				FuProgress *progress,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -1004,6 +1004,7 @@ fu_steelseries_sonic_parse_firmware(FuFirmware *firmware, FwupdInstallFlags flag
 static FuFirmware *
 fu_steelseries_sonic_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -605,6 +605,7 @@ fu_synaptics_cape_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -609,6 +609,7 @@ fu_synaptics_cxaudio_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_synaptics_cxaudio_device_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
+					     FuProgress *progress,
 					     FwupdInstallFlags flags,
 					     GError **error)
 {

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1344,6 +1344,7 @@ fu_synaptics_mst_device_restart(FuSynapticsMstDevice *self, GError **error)
 static FuFirmware *
 fu_synaptics_mst_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -26,6 +26,7 @@ fu_test_synaprom_firmware_func(void)
 	g_autoptr(GInputStream) stream = NULL;
 	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware = fu_synaprom_firmware_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "test.pkg", NULL);
 	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {
@@ -66,6 +67,7 @@ fu_test_synaprom_firmware_func(void)
 	stream = g_memory_input_stream_new_from_bytes(fw);
 	firmware2 = fu_synaprom_device_prepare_firmware(FU_DEVICE(device),
 							stream,
+							progress,
 							FWUPD_INSTALL_FLAG_NONE,
 							&error);
 	g_assert_no_error(error);

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -107,6 +107,7 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_synaprom_config_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -254,6 +254,7 @@ fu_synaprom_device_setup(FuDevice *device, GError **error)
 FuFirmware *
 fu_synaprom_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/synaptics-prometheus/fu-synaprom-device.h
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.h
@@ -61,6 +61,7 @@ fu_synaprom_device_set_version(FuSynapromDevice *self,
 FuFirmware *
 fu_synaprom_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
+				    FuProgress *progress,
 				    FwupdInstallFlags flags,
 				    GError **error);
 

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -545,6 +545,7 @@ fu_synaptics_rmi_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_synaptics_rmi_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -171,6 +171,8 @@ fu_thunderbolt_controller_setup_usb4(FuThunderboltController *self, GError **err
 {
 	if (!fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(self), error))
 		return FALSE;
+	if (self->host_online_timer_id > 0)
+		g_source_remove(self->host_online_timer_id);
 	self->host_online_timer_id =
 	    g_timeout_add_seconds(5, fu_thunderbolt_controller_set_port_online_cb, self);
 	return TRUE;

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -296,6 +296,7 @@ fu_thunderbolt_device_write_data(FuThunderboltDevice *self,
 static FuFirmware *
 fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
+				       FuProgress *progress,
 				       FwupdInstallFlags flags,
 				       GError **error)
 {
@@ -319,6 +320,7 @@ fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 		g_autoptr(GFile) nvmem = NULL;
 		g_autoptr(GInputStream) controller_fw = NULL;
 
+		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_READ);
 		nvmem = fu_thunderbolt_device_find_nvmem(self, TRUE, error);
 		if (nvmem == NULL)
 			return NULL;

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -243,54 +243,58 @@ fu_thunderbolt_device_rescan(FuDevice *device, GError **error)
 }
 
 static gboolean
+fu_thunderbolt_device_write_stream(GOutputStream *ostream,
+				   GBytes *bytes,
+				   FuProgress *progress,
+				   GError **error)
+{
+	gsize bufsz = g_bytes_get_size(bytes);
+	gsize total_written = 0;
+
+	do {
+		gssize wrote;
+		g_autoptr(GBytes) fw_data = NULL;
+		fw_data = fu_bytes_new_offset(bytes, total_written, bufsz - total_written, error);
+		if (fw_data == NULL)
+			return FALSE;
+		wrote = g_output_stream_write_bytes(ostream, fw_data, NULL, error);
+		if (wrote < 0)
+			return FALSE;
+		total_written += wrote;
+		fu_progress_set_percentage_full(progress, total_written, bufsz);
+	} while (total_written < bufsz);
+	if (total_written != bufsz) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "only wrote 0x%x of 0x%x",
+			    (guint)total_written,
+			    (guint)bufsz);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_thunderbolt_device_write_data(FuThunderboltDevice *self,
 				 GBytes *blob_fw,
 				 FuProgress *progress,
 				 GError **error)
 {
-	gsize fw_size;
-	gsize nwritten;
-	gssize n;
 	g_autoptr(GFile) nvmem = NULL;
-	g_autoptr(GOutputStream) os = NULL;
+	g_autoptr(GOutputStream) ostream = NULL;
 
 	nvmem = fu_thunderbolt_device_find_nvmem(self, FALSE, error);
 	if (nvmem == NULL)
 		return FALSE;
-
-	os = (GOutputStream *)g_file_append_to(nvmem, G_FILE_CREATE_NONE, NULL, error);
-
-	if (os == NULL)
+	ostream = (GOutputStream *)g_file_append_to(nvmem, G_FILE_CREATE_NONE, NULL, error);
+	if (ostream == NULL)
 		return FALSE;
-
-	nwritten = 0;
-	fw_size = g_bytes_get_size(blob_fw);
-
-	do {
-		g_autoptr(GBytes) fw_data = NULL;
-
-		fw_data = fu_bytes_new_offset(blob_fw, nwritten, fw_size - nwritten, error);
-		if (fw_data == NULL)
-			return FALSE;
-
-		n = g_output_stream_write_bytes(os, fw_data, NULL, error);
-		if (n < 0)
-			return FALSE;
-
-		nwritten += n;
-		fu_progress_set_percentage_full(progress, nwritten, fw_size);
-
-	} while (nwritten < fw_size);
-
-	if (nwritten != fw_size) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_WRITE,
-				    "Could not write all data to nvmem");
+	if (!fu_thunderbolt_device_write_stream(ostream, blob_fw, progress, error))
 		return FALSE;
-	}
-
-	return g_output_stream_close(os, NULL, error);
+	return g_output_stream_close(ostream, NULL, error);
 }
 
 static FuFirmware *

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -301,9 +301,6 @@ fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);
 	g_autoptr(FuFirmware) firmware = NULL;
-	g_autoptr(FuFirmware) firmware_old = NULL;
-	g_autoptr(GInputStream) controller_fw = NULL;
-	g_autoptr(GFile) nvmem = NULL;
 
 	/* parse */
 	firmware = fu_firmware_new_from_gtypes(stream,
@@ -317,23 +314,29 @@ fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 		return NULL;
 
 	/* get current NVMEM */
-	nvmem = fu_thunderbolt_device_find_nvmem(self, TRUE, error);
-	if (nvmem == NULL)
-		return NULL;
-	controller_fw = G_INPUT_STREAM(g_file_read(nvmem, NULL, error));
-	if (controller_fw == NULL)
-		return NULL;
-	firmware_old = fu_firmware_new_from_gtypes(controller_fw,
-						   0x0,
-						   flags,
-						   error,
-						   FU_TYPE_INTEL_THUNDERBOLT_NVM,
-						   FU_TYPE_FIRMWARE,
-						   G_TYPE_INVALID);
-	if (firmware_old == NULL)
-		return NULL;
-	if (!fu_firmware_check_compatible(firmware_old, firmware, flags, error))
-		return NULL;
+	if (fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE)) {
+		g_autoptr(FuFirmware) firmware_old = NULL;
+		g_autoptr(GFile) nvmem = NULL;
+		g_autoptr(GInputStream) controller_fw = NULL;
+
+		nvmem = fu_thunderbolt_device_find_nvmem(self, TRUE, error);
+		if (nvmem == NULL)
+			return NULL;
+		controller_fw = G_INPUT_STREAM(g_file_read(nvmem, NULL, error));
+		if (controller_fw == NULL)
+			return NULL;
+		firmware_old = fu_firmware_new_from_gtypes(controller_fw,
+							   0x0,
+							   flags,
+							   error,
+							   FU_TYPE_INTEL_THUNDERBOLT_NVM,
+							   FU_TYPE_FIRMWARE,
+							   G_TYPE_INVALID);
+		if (firmware_old == NULL)
+			return NULL;
+		if (!fu_firmware_check_compatible(firmware_old, firmware, flags, error))
+			return NULL;
+	}
 
 	/* success */
 	return g_steal_pointer(&firmware);

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -619,6 +619,7 @@ fu_uefi_device_get_esp(FuUefiDevice *self)
 static FuFirmware *
 fu_uefi_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
+				FuProgress *progress,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -88,6 +88,7 @@ fu_uefi_dbx_device_version_notify_cb(FuDevice *device, GParamSpec *pspec, gpoint
 static FuFirmware *
 fu_uefi_dbx_prepare_firmware(FuDevice *device,
 			     GInputStream *stream,
+			     FuProgress *progress,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -101,7 +102,7 @@ fu_uefi_dbx_prepare_firmware(FuDevice *device,
 
 	/* validate this is safe to apply */
 	if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
-		//		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
+		fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_VERIFY);
 		if (!fu_uefi_dbx_signature_list_validate(ctx,
 							 FU_EFI_SIGNATURE_LIST(siglist),
 							 flags,

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -20,6 +20,7 @@ G_DEFINE_TYPE(FuUf2Device, fu_uf2_device, FU_TYPE_UDEV_DEVICE)
 static FuFirmware *
 fu_uf2_device_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
+			       FuProgress *progress,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -33,6 +33,7 @@ fu_usi_dock_child_device_to_string(FuDevice *device, guint idt, GString *str)
 static FuFirmware *
 fu_usi_dock_mcu_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {
@@ -41,7 +42,7 @@ fu_usi_dock_mcu_device_prepare_firmware(FuDevice *device,
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
 		return NULL;
 	}
-	return fu_device_prepare_firmware(parent, stream, flags, error);
+	return fu_device_prepare_firmware(parent, stream, progress, flags, error);
 }
 
 /* only update this specific child component */

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -215,6 +215,7 @@ fu_vbe_simple_device_get_cfg_compatible(FuVbeSimpleDevice *self,
 static FuFirmware *
 fu_vbe_simple_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -149,6 +149,7 @@ fu_{{vendor}}_{{example}}_device_cleanup(FuDevice *device,
 static FuFirmware *
 fu_{{vendor}}_{{example}}_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
+					  FuProgress *progress,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -454,6 +454,7 @@ fu_vli_pd_device_setup(FuDevice *device, GError **error)
 static FuFirmware *
 fu_vli_pd_device_prepare_firmware(FuDevice *device,
 				  GInputStream *stream,
+				  FuProgress *progress,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -912,6 +912,7 @@ fu_vli_usbhub_device_ready(FuDevice *device, GError **error)
 static FuFirmware *
 fu_vli_usbhub_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
+				      FuProgress *progress,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -149,6 +149,7 @@ fu_vli_usbhub_pd_device_reload(FuDevice *device, GError **error)
 static FuFirmware *
 fu_vli_usbhub_pd_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
+					 FuProgress *progress,
 					 FwupdInstallFlags flags,
 					 GError **error)
 {

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -132,6 +132,7 @@ fu_wac_module_bluetooth_id9_write_blocks(FuWacModule *self,
 static FuFirmware *
 fu_wac_module_bluetooth_id9_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
+					     FuProgress *progress,
 					     FwupdInstallFlags flags,
 					     GError **error)
 {

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -332,6 +332,7 @@ fu_wistron_dock_device_write_blocks(FuWistronDockDevice *self,
 static FuFirmware *
 fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
+					FuProgress *progress,
 					FwupdInstallFlags flags,
 					GError **error)
 {


### PR DESCRIPTION
We fallback from FuIntelThunderboltFirmware to FuFirmware for non-controller devices, and for this there's no point taking 10 seconds to dump the old NVM firmware.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
