### PR TITLE
Allow the user to upload the entire devicelist to the LVFS

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -36,6 +36,7 @@ _fwupdmgr_cmd_list=(
 	'quit'
 	'reinstall'
 	'refresh'
+	'report-devices'
 	'report-history'
 	'report-export'
 	'security'

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -527,6 +527,12 @@ fwupd_remote_build_uri(FwupdRemote *self, const gchar *url_noauth, GError **erro
 	g_autoptr(curlptr) tmp_uri = NULL;
 	g_autoptr(CURLU) uri = curl_url();
 
+	/* sanity check */
+	if (url_noauth == NULL) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO, "no URI set");
+		return NULL;
+	}
+
 	/* the LVFS can't accept basic auth on an endpoint not expecting authentication */
 	if (!g_str_has_suffix(url_noauth, "/auth") &&
 	    (priv->username != NULL || priv->password != NULL)) {


### PR DESCRIPTION
It would be really helpful to go to vendors and say '12,345 Linux users are not getting firmware updates for model ABC' -- at the moment we don't have any numbers and sometimes vendors need a bit of convincing.

This would be opt-in to preserve privacy. The salted machine ID is only used to dedupe multiple uploads from the same machine.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
