### PR TITLE
Do not verify the SSL hostname when using DISABLE_SSL_STRICT=1

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -807,8 +807,10 @@ fwupd_client_curl_new(FwupdClient *self, GError **error)
 #endif
 
 	/* relax the SSL checks for broken corporate proxies */
-	if (g_getenv("DISABLE_SSL_STRICT") != NULL)
+	if (g_getenv("DISABLE_SSL_STRICT") != NULL) {
 		(void)curl_easy_setopt(helper->curl, CURLOPT_SSL_VERIFYPEER, 0L);
+		(void)curl_easy_setopt(helper->curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	}
 
 	/* this disables the double-compression of the firmware.xml.gz file */
 	(void)curl_easy_setopt(helper->curl, CURLOPT_HTTP_CONTENT_DECODING, 0L);


### PR DESCRIPTION
This also allows us to test with a localhost LVFS instance with a self-signed certificate.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
