### PR TITLE
Explicitly enable shadow stack support in fwupd.service

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -31,4 +31,5 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
+Environment="GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK"
 @dynamic_options@


### PR DESCRIPTION
Shadow stack as of glibc 2.39 is opt-in only. Enable it for the fwupd service.

Link: https://sourceware.org/git/?p=glibc.git;a=commit;h=55d63e731253de82e96ed4ddca2e294076cd0bc5

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
