### PR TITLE
trivial: venv: check build.ninja presence

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -9,7 +9,7 @@ EXTRA_ARGS="-Dsystemd=disabled -Dlaunchd=disabled"
 if [ -d /opt/homebrew/opt/libarchive/lib/pkgconfig ]; then
         EXTRA_ARGS="${EXTRA_ARGS} -Dpkg_config_path=/opt/homebrew/opt/libarchive/lib/pkgconfig"
 fi
-if [ ! -d ${BUILD} ]; then
+if [ ! -d ${BUILD} ] || ! [ -e ${BUILD}/build.ninja ]; then
         meson setup ${BUILD} --prefix=${DIST} -Dudevdir=${DIST} ${EXTRA_ARGS} $@
 fi
 ninja -C ${BUILD} install


### PR DESCRIPTION
If Meson failed partway through, it’s possible that the build directory exists but build.ninja inside doesn’t, which would make Ninja fail immediately. Fixes #7227.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
