### PR TITLE
Leverage 3 bytes for system version

### DIFF
--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -85,9 +85,6 @@ fu_logitech_rallysystem_audio_device_set_version(FuLogitechRallysystemAudioDevic
 {
 	guint8 buf[TOPOLOGY_DATA_LEN] = {0x3E, 0x0};
 	guint32 fwversion = 0;
-	guint8 major = 0;
-	guint8 minor = 0;
-	guint8 build = 0;
 
 	/* setup HID report to query current device version */
 	if (!fu_logitech_rallysystem_audio_device_get_feature(self, buf, sizeof(buf), error))
@@ -100,14 +97,6 @@ fu_logitech_rallysystem_audio_device_set_version(FuLogitechRallysystemAudioDevic
 		G_BIG_ENDIAN,
 		error))
 		return FALSE;
-	/*
-	 * device reports system version in 3 bytes: major.minor.build
-	 * convert major.minor.build -> major.minor.0.build
-	 */
-	major = (fwversion >> 16) & 0xFF;
-	minor = (fwversion >> 8) & 0xFF;
-	build = (fwversion >> 0) & 0xFF;
-	fwversion = ((major << 24) | (minor << 16) | 0 | (build << 0));
 	fu_device_set_version_raw(FU_DEVICE(self), fwversion);
 
 	/* success */
@@ -205,6 +194,19 @@ fu_logitech_rallysystem_audio_device_set_progress(FuDevice *self, FuProgress *pr
 static gchar *
 fu_logitech_rallysystem_audio_device_convert_version(FuDevice *device, guint64 version_raw)
 {
+	guint32 fwversion = 0;
+	guint8 major = 0;
+	guint8 minor = 0;
+	guint8 build = 0;
+	fwversion = version_raw;
+	major = (fwversion >> 16) & 0xFF;
+	minor = (fwversion >> 8) & 0xFF;
+	build = (fwversion >> 0) & 0xFF;
+	fwversion = ((major << 24) | (minor << 16) | 0 | (build << 0));
+	major = (version_raw >> 16) & 0xFF;
+	minor = (version_raw >> 8) & 0xFF;
+	build = (version_raw >> 0) & 0xFF;
+	version_raw = ((major << 24) | (minor << 16) | 0 | (build << 0));
 	return fu_version_from_uint32(version_raw, fu_device_get_version_format(device));
 }
 

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -194,15 +194,13 @@ fu_logitech_rallysystem_audio_device_set_progress(FuDevice *self, FuProgress *pr
 static gchar *
 fu_logitech_rallysystem_audio_device_convert_version(FuDevice *device, guint64 version_raw)
 {
-	guint32 fwversion = 0;
 	guint8 major = 0;
 	guint8 minor = 0;
 	guint8 build = 0;
-	fwversion = version_raw;
-	major = (fwversion >> 16) & 0xFF;
-	minor = (fwversion >> 8) & 0xFF;
-	build = (fwversion >> 0) & 0xFF;
-	fwversion = ((major << 24) | (minor << 16) | 0 | (build << 0));
+	/*
+	 * device reports system version in 3 bytes: major.minor.build
+	 * convert major.minor.build -> major.minor.0.build
+	 */
 	major = (version_raw >> 16) & 0xFF;
 	minor = (version_raw >> 8) & 0xFF;
 	build = (version_raw >> 0) & 0xFF;

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -85,6 +85,9 @@ fu_logitech_rallysystem_audio_device_set_version(FuLogitechRallysystemAudioDevic
 {
 	guint8 buf[TOPOLOGY_DATA_LEN] = {0x3E, 0x0};
 	guint32 fwversion = 0;
+	guint8 major = 0;
+	guint8 minor = 0;
+	guint8 build = 0;
 
 	/* setup HID report to query current device version */
 	if (!fu_logitech_rallysystem_audio_device_get_feature(self, buf, sizeof(buf), error))
@@ -97,6 +100,14 @@ fu_logitech_rallysystem_audio_device_set_version(FuLogitechRallysystemAudioDevic
 		G_BIG_ENDIAN,
 		error))
 		return FALSE;
+	/*
+	 * device reports system version in 3 bytes: major.minor.build
+	 * convert major.minor.build -> major.minor.0.build
+	 */
+	major = (fwversion >> 16) & 0xFF;
+	minor = (fwversion >> 8) & 0xFF;
+	build = (fwversion >> 0) & 0xFF;
+	fwversion = ((major << 24) | (minor << 16) | 0 | (build << 0));
 	fu_device_set_version_raw(FU_DEVICE(self), fwversion);
 
 	/* success */

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -204,7 +204,7 @@ fu_logitech_rallysystem_audio_device_convert_version(FuDevice *device, guint64 v
 	major = (version_raw >> 16) & 0xFF;
 	minor = (version_raw >> 8) & 0xFF;
 	build = (version_raw >> 0) & 0xFF;
-	version_raw = ((major << 24) | (minor << 16) | 0 | (build << 0));
+	version_raw = (major << 24) | (minor << 16) | (build << 0);
 	return fu_version_from_uint32(version_raw, fu_device_get_version_format(device));
 }
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Added filler to convert 3 bytes into guint32. fu_device_set_version_raw() expects 4 bytes