### PR TITLE
trivial: fix enable-remote/disable-remote bash completion to use json interface

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -281,7 +281,7 @@ _show_reset_config()
 _show_remotes()
 {
 	local remotes
-	remotes="$(command fwupdmgr get-remotes | command awk '/Remote ID/ { print $4 }')"
+	remotes="$(command fwupdmgr get-remotes --json 2>/dev/null | jq '.Remotes | .[] | .Id')"
 	COMPREPLY+=( $(compgen -W "${remotes}" -- "$cur") )
 }
 

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -192,7 +192,7 @@ _show_reset_config()
 _show_remotes()
 {
 	local remotes
-	remotes="$(command fwupdtool get-remotes | command awk '/Remote ID/ { print $4 }')"
+	remotes="$(command fwupdtool get-remotes --json 2>/dev/null | jq '.Remotes | .[] | .Id')"
 	COMPREPLY+=( $(compgen -W "${remotes}" -- "$cur") )
 }
 


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/2065948

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
