### PR TITLE
Invalidate the original input stream if using fu_firmware_set_bytes()

### DIFF
--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -582,6 +582,9 @@ fu_firmware_set_bytes(FuFirmware *self, GBytes *bytes)
 	if (priv->bytes != NULL)
 		g_bytes_unref(priv->bytes);
 	priv->bytes = g_bytes_ref(bytes);
+
+	/* the input stream is no longer valid */
+	g_clear_object(&priv->stream);
 }
 
 /**


### PR DESCRIPTION
This should fix flashing the wacom_usb touch module.

Resolves: https://github.com/fwupd/fwupd/issues/7267

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
