### PR TITLE
Rename private flag to avoid conflict

### DIFF
--- a/plugins/logitech-tap/fu-logitech-tap-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-device.c
@@ -29,8 +29,8 @@ fu_logitech_tap_device_init(FuLogitechTapDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_register_private_flag(FU_DEVICE(self),
-					FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_NEEDS_REBOOT,
-					"needs-reboot");
+					FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_SENSOR_NEEDS_REBOOT,
+					"sensor-needs-reboot");
 }
 
 static void

--- a/plugins/logitech-tap/fu-logitech-tap-device.h
+++ b/plugins/logitech-tap/fu-logitech-tap-device.h
@@ -20,8 +20,8 @@ struct _FuLogitechTapDeviceClass {
 };
 
 /**
- * FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_NEEDS_REBOOT:
+ * FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_SENSOR_NEEDS_REBOOT:
  *
  * Firmware updated for HDMI component, trigger composite device reboot
  */
-#define FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_NEEDS_REBOOT (1ull << 1)
+#define FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_SENSOR_NEEDS_REBOOT (1ull << 1)

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -328,7 +328,8 @@ fu_logitech_tap_hdmi_device_write_fw(FuLogitechTapHdmiDevice *self,
 		return FALSE;
 
 	/* signal for sensor device to trigger composite device reboot */
-	fu_device_add_private_flag(FU_DEVICE(self), FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_private_flag(FU_DEVICE(self),
+				   FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_SENSOR_NEEDS_REBOOT);
 	return TRUE;
 }
 

--- a/plugins/logitech-tap/fu-logitech-tap-plugin.c
+++ b/plugins/logitech-tap/fu-logitech-tap-plugin.c
@@ -30,8 +30,9 @@ fu_logitech_tap_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, G
 
 		if ((g_strcmp0(fu_device_get_plugin(dev), "logitech_tap") == 0) &&
 		    (FU_IS_LOGITECH_TAP_HDMI_DEVICE(dev)) &&
-		    (fu_device_has_private_flag(dev,
-						FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_NEEDS_REBOOT)) &&
+		    (fu_device_has_private_flag(
+			dev,
+			FU_LOGITECH_TAP_HDMI_DEVICE_FLAG_SENSOR_NEEDS_REBOOT)) &&
 		    self->hdmi_device != NULL) {
 			g_debug("device needs reboot");
 			if (!fu_logitech_tap_sensor_device_reboot_device(


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Rename private flag name to avoid conflict with existing internal flag (FWUPD_DEVICE_FLAG_NEEDS_REBOOT)