### PR TITLE
Add PID for Movink(DTH135K0C)

### DIFF
--- a/plugins/wacom-usb/wacom-usb.quirk
+++ b/plugins/wacom-usb/wacom-usb.quirk
@@ -1,3 +1,7 @@
+# Movink (USB) [DTH135K0C]
+[USB\VID_056A&PID_03F0]
+Plugin = wacom_usb
+GType = FuWacDevice
 
 # Intuos Pro medium (2nd-gen USB) [PTH-660]
 [USB\VID_056A&PID_0357]


### PR DESCRIPTION
The PID for Wacom new device, Movink, is added

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ v] Feature
- [ ] Documentation
