### PR TITLE
android-boot: Add SHIFTphone 8 (otter) to quirk file

### DIFF
--- a/plugins/android-boot/android-boot.quirk
+++ b/plugins/android-boot/android-boot.quirk
@@ -11,3 +11,17 @@ Flags = updatable,signed-payload
 Vendor = SHIFT GmbH
 VendorId = eco.shift
 AndroidBootVersionProperty = androidboot.abl.revision
+
+# SHIFTphone 8 ABL A
+[DRIVE\UUID_0072779b-8343-75c6-525f-44ff0e1d04db&LABEL_abl-a]
+Flags = updatable,signed-payload
+Vendor = SHIFT GmbH
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision
+
+# SHIFTphone 8 ABL B
+[DRIVE\UUID_584e4f5f-6023-f6d6-eb3f-48bb7da59feb&LABEL_abl-b]
+Flags = updatable,signed-payload
+Vendor = SHIFT GmbH
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision

--- a/plugins/android-boot/android-boot.quirk
+++ b/plugins/android-boot/android-boot.quirk
@@ -2,14 +2,14 @@
 [DRIVE\UUID_c49183ed-aaec-9bf5-760a-66330fbcffc1&LABEL_abl-a]
 Flags = updatable,signed-payload
 Vendor = SHIFT GmbH
-VendorId = eco.shift
+VendorId = DRIVE:SHIFT
 AndroidBootVersionProperty = androidboot.abl.revision
 
 # SHIFT6mq ABL B
 [DRIVE\UUID_3d7b21e8-048b-db0b-0c18-d07a9bb32f2d&LABEL_abl-b]
 Flags = updatable,signed-payload
 Vendor = SHIFT GmbH
-VendorId = eco.shift
+VendorId = DRIVE:SHIFT
 AndroidBootVersionProperty = androidboot.abl.revision
 
 # SHIFTphone 8 ABL A


### PR DESCRIPTION
The SHIFTphone 8 (otter) is an upcoming smartphone based on the Qualcomm QCM6490 SoC.

As the partition table is not expected to change in future (fingers crossed), the quirk making the ABLs available to update can be added already.

Tested on postmarketOS using a DVT1 device.

Repo to generate the firmware cab files as reference: https://github.com/SHIFTPHONES/fwupd_packaging/tree/otter/abl

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
