### PR TITLE
trivial: switch to allowlist for partition kinds

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1447,7 +1447,7 @@ fu_context_get_esp_volumes(FuContext *self, GError **error)
 		for (guint i = 0; i < volumes_esp->len; i++) {
 			FuVolume *vol = g_ptr_array_index(volumes_esp, i);
 			g_autofree gchar *type = fu_volume_get_id_type(vol);
-			if (g_strcmp0(type, "ext4") == 0)
+			if (g_strcmp0(type, "vfat") != 0)
 				continue;
 			fu_context_add_esp_volume(self, vol);
 		}

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -943,7 +943,7 @@ fu_volume_new_by_kind(const gchar *kind, GError **error)
 		id_type = fu_volume_get_id_type(vol);
 		g_info("device %s, type: %s, internal: %d, fs: %s",
 		       g_dbus_proxy_get_object_path(proxy_blk),
-		       type_str,
+		       fu_volume_is_mdraid(vol) ? "mdraid" : type_str,
 		       fu_volume_is_internal(vol),
 		       id_type);
 		if (g_strcmp0(type_str, kind) != 0)

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -633,7 +633,6 @@ fu_uefi_capsule_plugin_get_default_esp(FuPlugin *plugin, GError **error)
 			guint score = 0;
 			g_autofree gchar *name = NULL;
 			g_autofree gchar *kind = NULL;
-			g_autofree gchar *id_type = NULL;
 			g_autoptr(FuDeviceLocker) locker = NULL;
 			g_autoptr(GError) error_local = NULL;
 
@@ -672,13 +671,6 @@ fu_uefi_capsule_plugin_get_default_esp(FuPlugin *plugin, GError **error)
 					}
 					continue;
 				}
-			}
-
-			/* in case an installer messes up the kind */
-			id_type = fu_volume_get_id_type(esp);
-			if (g_strcmp0(id_type, "btrfs") == 0) {
-				g_debug("skipping %s as it's a %s type", name, id_type);
-				continue;
 			}
 
 			/* big partitions are better than small partitions */


### PR DESCRIPTION
A user has reported an md array that is an xfs kind that with the wrong partition table flags.  Explicitly only allow vfat and ntfs for ESPs.

Fixes: b42ad1d45 ("trivial: catch miscategorized ESP partitions") Fixes https://github.com/fwupd/fwupd/issues/7298

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
