### PR TITLE
trivial: fix markdown syntax for u16le and update its description

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -911,7 +911,7 @@ rustc*, so small differences may be noticeable.
 The struct types currently supported are:
 
 - `u8`: a `guint8`
-- `u16le`: a `guint16
+- `u16le`: little endian `guint16`
 - `u24`: a 24 bit number represented as a `guint32`
 - `u32le`:  little endian `guint32`
 - `u64be`:  big endian `guint64`


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

TL;DR: very tiny update for _tutorial.md_ about `u16le`.

Hello. I've heard a lot about this project and recently I was getting curious about it again so I started to scout official documentation, so by pure accident I discovered [this tiny formatting mistype](https://github.com/ia/fwupd/blob/d674f9584697802c53a833d7bb5a5236ab2ca98b/docs/tutorial.md?plain=1#L914) which I'm more than happy to help to fix. But let me know if this should be modified in any other way. Thanks.