### PR TITLE
trivial: Move some EFI variable setup code to libfwupdplugin

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -54,7 +54,7 @@ Remember: Plugins should be upstream!
 * `fu_usb_device_new_full()`: Use `fu_usb_device_new()` instead -- as the latter always specifies the context.
 * `fu_device_new_with_context()`: Use `fu_device_new()` instead -- as the latter always specifies the context.
 * `fu_plugin_has_custom_flag()`: Use `fu_plugin_has_private_flag()` instead.
-* `fu_efivar_secure_boot_enabled_full()`: Use `fu_efivars_secure_boot_enabled()` instead -- as the latter always specifies the error.
+* `fu_efivar_secure_boot_enabled_full()`: Use `fu_efivars_get_secure_boot()` instead -- as the latter always specifies the error.
 * `fu_progress_add_step()`: Add a 4th parameter to the function to specify the nice name for the step, or NULL.
 * `fu_backend_setup()`: Now requires a `FuProgress`, although it can be ignored.
 * `fu_backend_coldplug`: Now requires a `FuProgress`, although it can be ignored.

--- a/libfwupdplugin/fu-efivars-private.h
+++ b/libfwupdplugin/fu-efivars-private.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-efivars.h"
+#include "fu-volume.h"
+
+gboolean
+fu_efivars_set_secure_boot(FuEfivars *self, gboolean enabled, GError **error) G_GNUC_NON_NULL(1);
+gboolean
+fu_efivars_set_boot_current(FuEfivars *self, guint16 idx, GError **error) G_GNUC_NON_NULL(1);
+gboolean
+fu_efivars_build_boot_order(FuEfivars *self, GError **error, ...) G_GNUC_NON_NULL(1);
+gboolean
+fu_efivars_create_boot_entry_for_volume(FuEfivars *self,
+					guint16 idx,
+					FuVolume *volume,
+					const gchar *name,
+					const gchar *target,
+					GError **error) G_GNUC_NON_NULL(1, 3, 4, 5);

--- a/libfwupdplugin/fu-efivars.h
+++ b/libfwupdplugin/fu-efivars.h
@@ -115,7 +115,7 @@ GPtrArray *
 fu_efivars_get_names(FuEfivars *self, const gchar *guid, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_efivars_secure_boot_enabled(FuEfivars *self, GError **error) G_GNUC_NON_NULL(1);
+fu_efivars_get_secure_boot(FuEfivars *self, gboolean *enabled, GError **error) G_GNUC_NON_NULL(1);
 
 gboolean
 fu_efivars_get_boot_next(FuEfivars *self, guint16 *idx, GError **error) G_GNUC_NON_NULL(1);

--- a/plugins/linux-lockdown/fu-linux-lockdown-plugin.c
+++ b/plugins/linux-lockdown/fu-linux-lockdown-plugin.c
@@ -93,6 +93,7 @@ fu_linux_lockdown_plugin_ensure_security_attr_flags(FuLinuxLockdownPlugin *self,
 	FuContext *ctx = fu_plugin_get_context(FU_PLUGIN(self));
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
 	const gchar *value;
+	gboolean secureboot_enabled = FALSE;
 	g_autoptr(GHashTable) cmdline = NULL;
 	g_autoptr(GHashTable) config = NULL;
 
@@ -118,8 +119,9 @@ fu_linux_lockdown_plugin_ensure_security_attr_flags(FuLinuxLockdownPlugin *self,
 	}
 
 	/* we cannot change this */
+	fu_efivars_get_secure_boot(efivars, &secureboot_enabled, NULL);
 	if (g_hash_table_contains(config, "CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT") &&
-	    fu_efivars_secure_boot_enabled(efivars, NULL)) {
+	    secureboot_enabled) {
 		g_set_error_literal(
 		    error,
 		    FWUPD_ERROR,

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -343,7 +343,7 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 {
 	const gchar *filepath = NULL;
 	gboolean use_fwup_path = TRUE;
-	gboolean secure_boot = FALSE;
+	gboolean secureboot_enabled = FALSE;
 	g_autofree gchar *shim_app = NULL;
 	g_autofree gchar *shim_cpy = NULL;
 	g_autofree gchar *source_app = NULL;
@@ -362,8 +362,9 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 		return FALSE;
 
 	/* test if we should use shim */
-	secure_boot = fu_efivars_secure_boot_enabled(efivars, NULL);
-	if (secure_boot) {
+	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, error))
+		return FALSE;
+	if (secureboot_enabled) {
 		shim_app = fu_uefi_get_esp_app_path("shim", error);
 		if (shim_app == NULL)
 			return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -92,6 +92,7 @@ fu_uefi_get_built_app_path(FuEfivars *efivars, const gchar *binary, GError **err
 	g_autofree gchar *prefix = NULL;
 	g_autofree gchar *source_path = NULL;
 	g_autofree gchar *source_path_signed = NULL;
+	gboolean secureboot_enabled = FALSE;
 	gboolean source_path_exists = FALSE;
 	gboolean source_path_signed_exists = FALSE;
 
@@ -106,7 +107,9 @@ fu_uefi_get_built_app_path(FuEfivars *efivars, const gchar *binary, GError **err
 	source_path_exists = g_file_test(source_path, G_FILE_TEST_EXISTS);
 	source_path_signed_exists = g_file_test(source_path_signed, G_FILE_TEST_EXISTS);
 
-	if (fu_efivars_secure_boot_enabled(efivars, NULL)) {
+	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, error))
+		return NULL;
+	if (secureboot_enabled) {
 		if (!source_path_signed_exists) {
 			g_set_error(error,
 				    FWUPD_ERROR,


### PR DESCRIPTION
This allows us to share the 'create a plausible UEFI system' code to be used in the other self test binaries.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
