### PR TITLE
uefi-capsule: Only clean up an ESP that exists

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1193,6 +1193,9 @@ fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 	g_autoptr(FuDeviceLocker) esp_locker = NULL;
 	g_autoptr(GPtrArray) files = NULL;
 
+	if (self->esp == NULL)
+		return TRUE;
+
 	/* delete any files matching the glob in the ESP */
 	esp_locker = fu_volume_locker(self->esp, error);
 	if (esp_locker == NULL)


### PR DESCRIPTION
Might help fix https://github.com/fwupd/fwupd/issues/7351

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
