### PR TITLE
Add 'FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG' for waiting device reset.

### DIFF
--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -803,6 +803,7 @@ fu_pxi_ble_device_write_firmware(FuDevice *device,
 	if (!fu_pxi_ble_device_reset(self, error))
 		return FALSE;
 	fu_progress_step_done(progress);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success */
 	return TRUE;
@@ -1011,6 +1012,7 @@ fu_pxi_ble_device_init(FuPxiBleDevice *self)
 	self->feature_report_id = PXI_HID_DEV_OTA_FEATURE_REPORT_ID;
 	self->input_report_id = PXI_HID_DEV_OTA_INPUT_REPORT_ID;
 	fu_device_register_private_flag(FU_DEVICE(self), FU_PXI_DEVICE_FLAG_IS_HPAC, "is-hpac");
+	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
 }
 
 static void

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -619,6 +619,7 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 	if (!fu_pxi_receiver_device_reset(device, error))
 		return FALSE;
 	fu_progress_step_done(progress);
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success */
 	return TRUE;
@@ -939,6 +940,7 @@ fu_pxi_receiver_device_init(FuPxiReceiverDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self), FU_PXI_DEVICE_FLAG_IS_HPAC, "is-hpac");
 	fu_udev_device_add_flag(FU_UDEV_DEVICE(self), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 	fu_udev_device_add_flag(FU_UDEV_DEVICE(self), FU_UDEV_DEVICE_FLAG_OPEN_WRITE);
+	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
 }
 
 static void


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [* ] Code fix
- [ ] Feature
- [ ] Documentation
