### PR TITLE
Allow emulating FuUdevDevice superclasses

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "fu-backend-private.h"
+#include "fu-device-private.h"
 #include "fu-string.h"
 
 /**
@@ -25,17 +26,27 @@ typedef struct {
 	gboolean enabled;
 	gboolean done_setup;
 	gboolean can_invalidate;
+	GType device_gtype;
 	GHashTable *devices; /* device_id : * FuDevice */
 	GThread *thread_init;
 } FuBackendPrivate;
 
 enum { SIGNAL_ADDED, SIGNAL_REMOVED, SIGNAL_CHANGED, SIGNAL_LAST };
 
-enum { PROP_0, PROP_NAME, PROP_CAN_INVALIDATE, PROP_CONTEXT, PROP_LAST };
+enum { PROP_0, PROP_NAME, PROP_CAN_INVALIDATE, PROP_CONTEXT, PROP_DEVICE_GTYPE, PROP_LAST };
 
 static guint signals[SIGNAL_LAST] = {0};
 
-G_DEFINE_TYPE_WITH_PRIVATE(FuBackend, fu_backend, G_TYPE_OBJECT)
+static void
+fu_backend_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FuBackend,
+		       fu_backend,
+		       G_TYPE_OBJECT,
+		       0,
+		       G_ADD_PRIVATE(FuBackend)
+			   G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC, fu_backend_codec_iface_init));
+
 #define GET_PRIVATE(o) (fu_backend_get_instance_private(o))
 
 /**
@@ -229,6 +240,16 @@ fu_backend_setup(FuBackend *self, FuProgress *progress, GError **error)
 	return TRUE;
 }
 
+static gchar *
+fu_backend_get_emulation_array_member_name(FuBackend *self)
+{
+	FuBackendPrivate *priv = GET_PRIVATE(self);
+
+	if (priv->name == NULL)
+		return NULL;
+	return g_strdup_printf("%c%sDevices", g_ascii_toupper(priv->name[0]), priv->name + 1);
+}
+
 /**
  * fu_backend_load:
  * @self: a #FuBackend
@@ -251,15 +272,83 @@ fu_backend_load(FuBackend *self,
 		GError **error)
 {
 	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
+	FuBackendPrivate *priv = GET_PRIVATE(self);
+	JsonArray *json_array;
+	g_autofree gchar *list_name = NULL;
+	g_autoptr(GPtrArray) devices_added =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	g_autoptr(GPtrArray) devices_remove =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	g_autoptr(GList) devices = NULL;
 
 	g_return_val_if_fail(FU_IS_BACKEND(self), FALSE);
+	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* optional */
-	if (klass->load != NULL) {
-		if (!klass->load(self, json_object, tag, flags, error))
-			return FALSE;
+	if (klass->load != NULL)
+		return klass->load(self, json_object, tag, flags, error);
+
+	/* sanity check */
+	list_name = fu_backend_get_emulation_array_member_name(self);
+	if (!json_object_has_member(json_object, list_name))
+		return TRUE;
+
+	/* four steps:
+	 *
+	 * 1. store all the existing devices matching the tag in devices_remove
+	 * 2. read the devices in the array:
+	 *    - if the platform-id exists: replace the event data & remove from devices_remove
+	 *    - otherwise add to devices_added
+	 * 3. emit devices in devices_remove
+	 * 4. emit devices in devices_added
+	 */
+	devices = g_hash_table_get_values(priv->devices);
+	for (GList *l = devices; l != NULL; l = l->next) {
+		FuDevice *device = FU_DEVICE(l->data);
+		g_ptr_array_add(devices_remove, g_object_ref(device));
 	}
+	json_array = json_object_get_array_member(json_object, list_name);
+	for (guint i = 0; i < json_array_get_length(json_array); i++) {
+		JsonNode *node_tmp = json_array_get_element(json_array, i);
+		FuDevice *device_old;
+		g_autoptr(FuDevice) device_tmp =
+		    g_object_new(priv->device_gtype, "context", priv->ctx, NULL);
+
+		if (!fwupd_codec_from_json(FWUPD_CODEC(device_tmp), node_tmp, error))
+			return FALSE;
+
+		/* does a device with this platform ID [and the same created date] already exist */
+		device_old = fu_backend_lookup_by_id(self, fu_device_get_backend_id(device_tmp));
+		if (device_old != NULL &&
+		    fu_device_get_created(device_old) == fu_device_get_created(device_tmp)) {
+			GPtrArray *events = fu_device_get_events(device_tmp);
+			fu_device_clear_events(device_old);
+			for (guint j = 0; j < events->len; j++) {
+				FuDeviceEvent *event = g_ptr_array_index(events, j);
+				fu_device_add_event(device_old, event);
+			}
+			fu_backend_device_changed(self, device_old);
+			g_ptr_array_remove(devices_remove, device_old);
+			continue;
+		}
+
+		/* new to us! */
+		g_ptr_array_add(devices_added, g_object_ref(device_tmp));
+	}
+
+	/* emit removes then adds */
+	for (guint i = 0; i < devices_remove->len; i++) {
+		FuDevice *device = g_ptr_array_index(devices_remove, i);
+		fu_backend_device_removed(self, device);
+	}
+	for (guint i = 0; i < devices_added->len; i++) {
+		FuDevice *device = g_ptr_array_index(devices_added, i);
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_EMULATED);
+		fu_backend_device_added(self, device);
+	}
+
+	/* success */
 	return TRUE;
 }
 
@@ -290,11 +379,37 @@ fu_backend_save(FuBackend *self,
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* optional */
-	if (klass->save != NULL) {
-		if (!klass->save(self, json_builder, tag, flags, error))
-			return FALSE;
-	}
+	if (klass->save != NULL)
+		return klass->save(self, json_builder, tag, flags, error);
+
+	/* internal */
+	json_builder_begin_object(json_builder);
+	fwupd_codec_to_json(FWUPD_CODEC(self), json_builder, FWUPD_CODEC_FLAG_NONE);
+	json_builder_end_object(json_builder);
 	return TRUE;
+}
+
+static void
+fu_backend_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags flags)
+{
+	FuBackend *self = FU_BACKEND(codec);
+	FuBackendPrivate *priv = GET_PRIVATE(self);
+	g_autofree gchar *list_name = NULL;
+	g_autoptr(GList) devices = NULL;
+
+	list_name = fu_backend_get_emulation_array_member_name(self);
+	json_builder_set_member_name(builder, list_name);
+	json_builder_begin_array(builder);
+	devices = g_hash_table_get_values(priv->devices);
+	for (GList *l = devices; l != NULL; l = l->next) {
+		FuDevice *device = FU_DEVICE(l->data);
+		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATION_TAG))
+			continue;
+		json_builder_begin_object(builder);
+		fwupd_codec_to_json(FWUPD_CODEC(device), builder, FWUPD_CODEC_FLAG_NONE);
+		json_builder_end_object(builder);
+	}
+	json_builder_end_array(builder);
 }
 
 /**
@@ -463,6 +578,9 @@ fu_backend_get_property(GObject *object, guint prop_id, GValue *value, GParamSpe
 	case PROP_CONTEXT:
 		g_value_set_object(value, priv->ctx);
 		break;
+	case PROP_DEVICE_GTYPE:
+		g_value_set_gtype(value, priv->device_gtype);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -484,6 +602,9 @@ fu_backend_set_property(GObject *object, guint prop_id, const GValue *value, GPa
 	case PROP_CONTEXT:
 		g_set_object(&priv->ctx, g_value_get_object(value));
 		break;
+	case PROP_DEVICE_GTYPE:
+		priv->device_gtype = g_value_get_gtype(value);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -491,10 +612,17 @@ fu_backend_set_property(GObject *object, guint prop_id, const GValue *value, GPa
 }
 
 static void
+fu_backend_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_json = fu_backend_add_json;
+}
+
+static void
 fu_backend_init(FuBackend *self)
 {
 	FuBackendPrivate *priv = GET_PRIVATE(self);
 	priv->enabled = TRUE;
+	priv->device_gtype = FU_TYPE_DEVICE;
 	priv->thread_init = g_thread_self();
 	priv->devices =
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_object_unref);
@@ -576,6 +704,21 @@ fu_backend_class_init(FuBackendClass *klass)
 				FU_TYPE_CONTEXT,
 				G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_CONTEXT, pspec);
+
+	/**
+	 * FuBackend:device-gtype:
+	 *
+	 * The #GType to use when creating emulated devices.
+	 *
+	 * Since: 2.0.0
+	 */
+	pspec =
+	    g_param_spec_gtype("device-gtype",
+			       NULL,
+			       NULL,
+			       FU_TYPE_DEVICE,
+			       G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_DEVICE_GTYPE, pspec);
 
 	/**
 	 * FuBackend::device-added:

--- a/libfwupdplugin/fu-device-event-private.h
+++ b/libfwupdplugin/fu-device-event-private.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-device-event.h"
+
+FuDeviceEvent *
+fu_device_event_new(const gchar *id);
+
+const gchar *
+fu_device_event_get_id(FuDeviceEvent *self) G_GNUC_NON_NULL(1);
+
+void
+fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *value)
+    G_GNUC_NON_NULL(1, 2);
+const gchar *
+fu_device_event_get_str(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+void
+fu_device_event_set_i64(FuDeviceEvent *self, const gchar *key, gint64 value) G_GNUC_NON_NULL(1, 2);
+gint64
+fu_device_event_get_i64(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+void
+fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
+    G_GNUC_NON_NULL(1, 2, 3);
+void
+fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *buf, gsize bufsz)
+    G_GNUC_NON_NULL(1, 2, 3);
+GBytes *
+fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_device_event_copy_data(FuDeviceEvent *self,
+			  const gchar *key,
+			  guint8 *buf,
+			  gsize bufsz,
+			  GError **error) G_GNUC_NON_NULL(1, 2, 3);

--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -1,0 +1,424 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuDeviceEvent"
+
+#include "config.h"
+
+#include "fu-device-event-private.h"
+#include "fu-mem.h"
+
+/**
+ * FuDeviceEvent:
+ *
+ * A device event, used to enumulate hardware.
+ *
+ * See also: [class@FuDevice]
+ */
+
+typedef struct {
+	GType gtype;
+	gpointer data;
+	GDestroyNotify destroy;
+} FuDeviceEventBlob;
+
+typedef struct {
+	gchar *id;
+	GHashTable *values; /* (utf-8) (FuDeviceEventBlob) */
+} FuDeviceEventPrivate;
+
+static void
+fu_device_event_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FuDeviceEvent,
+		       fu_device_event,
+		       G_TYPE_OBJECT,
+		       0,
+		       G_ADD_PRIVATE(FuDeviceEvent)
+			   G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
+						 fu_device_event_codec_iface_init));
+
+#define GET_PRIVATE(o) (fu_device_event_get_instance_private(o))
+
+static void
+fu_device_event_blob_free(FuDeviceEventBlob *blob)
+{
+	if (blob->destroy)
+		blob->destroy(blob->data);
+	g_free(blob);
+}
+
+static FuDeviceEventBlob *
+fu_device_event_blob_create(GType gtype, gpointer data, GDestroyNotify destroy)
+{
+	FuDeviceEventBlob *blob = g_new0(FuDeviceEventBlob, 1);
+	blob->gtype = gtype;
+	blob->data = data;
+	blob->destroy = destroy;
+	return blob;
+}
+
+/**
+ * fu_device_event_get_id:
+ * @self: a #FuDeviceEvent
+ *
+ * Return the id of the #FuDeviceEvent, which is normally set when creating the object.
+ *
+ * Returns: (nullable): string
+ *
+ * Since: 2.0.0
+ **/
+const gchar *
+fu_device_event_get_id(FuDeviceEvent *self)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), NULL);
+	return priv->id;
+}
+
+/**
+ * fu_device_event_set_str:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @value: (nullable): a string
+ *
+ * Sets a string value on the event.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *value)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_DEVICE_EVENT(self));
+	g_return_if_fail(key != NULL);
+	g_hash_table_insert(priv->values,
+			    g_strdup(key),
+			    fu_device_event_blob_create(G_TYPE_STRING, g_strdup(value), g_free));
+}
+
+/**
+ * fu_device_event_set_i64:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @value: (nullable): a string
+ *
+ * Sets an integer value on the string.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_event_set_i64(FuDeviceEvent *self, const gchar *key, gint64 value)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FU_IS_DEVICE_EVENT(self));
+	g_return_if_fail(key != NULL);
+
+	g_hash_table_insert(
+	    priv->values,
+	    g_strdup(key),
+	    fu_device_event_blob_create(G_TYPE_INT, g_memdup2(&value, sizeof(value)), g_free));
+}
+
+/**
+ * fu_device_event_set_bytes:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @value: (not nullable): a #GBytes
+ *
+ * Sets a blob on the event. Note: blobs are stored internally as BASE-64 strings.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_DEVICE_EVENT(self));
+	g_return_if_fail(key != NULL);
+	g_return_if_fail(value != NULL);
+	g_hash_table_insert(
+	    priv->values,
+	    g_strdup(key),
+	    fu_device_event_blob_create(
+		G_TYPE_STRING,
+		g_base64_encode(g_bytes_get_data(value, NULL), g_bytes_get_size(value)),
+		g_free));
+}
+
+/**
+ * fu_device_event_set_data:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @buf: (not nullable): a buffer
+ * @bufsz: size of @buf
+ *
+ * Sets a memory buffer on the event. Note: memory buffers are stored internally as BASE-64 strings.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *buf, gsize bufsz)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	g_return_if_fail(FU_IS_DEVICE_EVENT(self));
+	g_return_if_fail(key != NULL);
+	g_return_if_fail(buf != NULL);
+	g_hash_table_insert(
+	    priv->values,
+	    g_strdup(key),
+	    fu_device_event_blob_create(G_TYPE_STRING, g_base64_encode(buf, bufsz), g_free));
+}
+
+static gpointer
+fu_device_event_lookup(FuDeviceEvent *self, const gchar *key, GType gtype, GError **error)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	FuDeviceEventBlob *blob = g_hash_table_lookup(priv->values, key);
+	if (blob == NULL) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no event for key %s", key);
+		return NULL;
+	}
+	if (blob->gtype != gtype) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "invalid event type for key %s",
+			    key);
+		return NULL;
+	}
+	return blob->data;
+}
+
+/**
+ * fu_device_event_get_str:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets a string value from the event.
+ *
+ * Returns: (nullable): string, or %NULL on error
+ *
+ * Since: 2.0.0
+ **/
+const gchar *
+fu_device_event_get_str(FuDeviceEvent *self, const gchar *key, GError **error)
+{
+	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), NULL);
+	g_return_val_if_fail(key != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+	return (const gchar *)fu_device_event_lookup(self, key, G_TYPE_STRING, error);
+}
+
+/**
+ * fu_device_event_get_i64:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets an integer value from the event.
+ *
+ * Returns: (nullable): integer, or %G_MAXINT64 on error
+ *
+ * Since: 2.0.0
+ **/
+gint64
+fu_device_event_get_i64(FuDeviceEvent *self, const gchar *key, GError **error)
+{
+	gint64 *val;
+	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), G_MAXINT64);
+	g_return_val_if_fail(key != NULL, G_MAXINT64);
+	g_return_val_if_fail(error == NULL || *error == NULL, G_MAXINT64);
+	val = fu_device_event_lookup(self, key, G_TYPE_INT, error);
+	if (val == NULL)
+		return G_MAXINT64;
+	return *val;
+}
+
+/**
+ * fu_device_event_get_bytes:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets a memory blob from the event.
+ *
+ * Returns: (transfer full) (nullable): byes data, or %NULL on error
+ *
+ * Since: 2.0.0
+ **/
+GBytes *
+fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
+{
+	const gchar *blobstr;
+	gsize bufsz = 0;
+	g_autofree guchar *buf = NULL;
+
+	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), NULL);
+	g_return_val_if_fail(key != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	blobstr = fu_device_event_lookup(self, key, G_TYPE_STRING, error);
+	if (blobstr == NULL)
+		return NULL;
+	buf = g_base64_decode(blobstr, &bufsz);
+	return g_bytes_new_take(g_steal_pointer(&buf), bufsz);
+}
+
+/**
+ * fu_device_event_copy_data:
+ * @self: a #FuDeviceEvent
+ * @key: (not nullable): a unique key, e.g. `Name`
+ * @buf: (not nullable): a buffer
+ * @bufsz: size of @buf
+ * @error: (nullable): optional return location for an error
+ *
+ * Copies memory from the event.
+ *
+ * Returns: %TRUE if the buffer was copied
+ *
+ * Since: 2.0.0
+ **/
+gboolean
+fu_device_event_copy_data(FuDeviceEvent *self,
+			  const gchar *key,
+			  guint8 *buf,
+			  gsize bufsz,
+			  GError **error)
+{
+	const gchar *blobstr;
+	gsize bufsz_src = 0;
+	g_autofree guchar *buf_src = NULL;
+
+	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), FALSE);
+	g_return_val_if_fail(key != NULL, FALSE);
+	g_return_val_if_fail(buf != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	blobstr = fu_device_event_lookup(self, key, G_TYPE_STRING, error);
+	if (blobstr == NULL)
+		return FALSE;
+	buf_src = g_base64_decode(blobstr, &bufsz_src);
+	return fu_memcpy_safe(buf, bufsz, 0x0, buf_src, bufsz_src, 0x0, bufsz_src, error);
+}
+
+static void
+fu_device_event_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags flags)
+{
+	FuDeviceEvent *self = FU_DEVICE_EVENT(codec);
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	GHashTableIter iter;
+	gpointer key, value;
+
+	if (priv->id != NULL) {
+		json_builder_set_member_name(builder, "Id");
+		json_builder_add_string_value(builder, priv->id);
+	}
+
+	g_hash_table_iter_init(&iter, priv->values);
+	while (g_hash_table_iter_next(&iter, &key, &value)) {
+		FuDeviceEventBlob *blob = (FuDeviceEventBlob *)value;
+		if (blob->gtype == G_TYPE_INT) {
+			json_builder_set_member_name(builder, (const gchar *)key);
+			json_builder_add_int_value(builder, *((gint64 *)blob->data));
+		} else if (blob->gtype == G_TYPE_BYTES || blob->gtype == G_TYPE_STRING) {
+			json_builder_set_member_name(builder, (const gchar *)key);
+			json_builder_add_string_value(builder, (const gchar *)blob->data);
+		} else {
+			g_warning("invalid GType %s, ignoring", g_type_name(blob->gtype));
+		}
+	}
+}
+
+static gboolean
+fu_device_event_from_json(FwupdCodec *codec, JsonNode *json_node, GError **error)
+{
+	FuDeviceEvent *self = FU_DEVICE_EVENT(codec);
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	JsonNode *member_node;
+	JsonObjectIter iter;
+	JsonObject *json_object = json_node_get_object(json_node);
+	const gchar *member_name;
+
+	json_object_iter_init(&iter, json_object);
+	while (json_object_iter_next(&iter, &member_name, &member_node)) {
+		GType gtype;
+		if (JSON_NODE_TYPE(member_node) != JSON_NODE_VALUE)
+			continue;
+		gtype = json_node_get_value_type(member_node);
+		if (gtype == G_TYPE_STRING) {
+			if (g_strcmp0(member_name, "Id") == 0) {
+				g_free(priv->id);
+				priv->id = json_node_dup_string(member_node);
+				continue;
+			}
+			fu_device_event_set_str(self,
+						member_name,
+						json_node_get_string(member_node));
+			continue;
+		}
+		if (gtype == G_TYPE_INT64) {
+			fu_device_event_set_i64(self, member_name, json_node_get_int(member_node));
+			continue;
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_device_event_init(FuDeviceEvent *self)
+{
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	priv->values = g_hash_table_new_full(g_str_hash,
+					     g_str_equal,
+					     g_free,
+					     (GDestroyNotify)fu_device_event_blob_free);
+}
+
+static void
+fu_device_event_finalize(GObject *object)
+{
+	FuDeviceEvent *self = FU_DEVICE_EVENT(object);
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	g_free(priv->id);
+	g_hash_table_unref(priv->values);
+	G_OBJECT_CLASS(fu_device_event_parent_class)->finalize(object);
+}
+
+static void
+fu_device_event_class_init(FuDeviceEventClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_device_event_finalize;
+}
+
+static void
+fu_device_event_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_json = fu_device_event_add_json;
+	iface->from_json = fu_device_event_from_json;
+}
+
+/**
+ * fu_device_event_new:
+ * @id: a cache key
+ *
+ * Return value: (transfer full): a new #FuDeviceEvent object.
+ *
+ * Since: 2.0.0
+ **/
+FuDeviceEvent *
+fu_device_event_new(const gchar *id)
+{
+	FuDeviceEvent *self = g_object_new(FU_TYPE_DEVICE_EVENT, NULL);
+	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
+	priv->id = g_strdup(id);
+	return FU_DEVICE_EVENT(self);
+}

--- a/libfwupdplugin/fu-device-event.h
+++ b/libfwupdplugin/fu-device-event.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupd.h>
+
+#define FU_TYPE_DEVICE_EVENT (fu_device_event_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuDeviceEvent, fu_device_event, FU, DEVICE_EVENT, GObject)
+
+struct _FuDeviceEventClass {
+	GObjectClass parent_class;
+};

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include <fu-device.h>
 #include <xmlb.h>
+
+#include "fu-device-event.h"
+#include "fu-device.h"
 
 #define fu_device_set_plugin(d, v) fwupd_device_set_plugin(FWUPD_DEVICE(d), v)
 
@@ -75,3 +77,14 @@ gboolean
 fu_device_has_counterpart_guid(FuDevice *self, const gchar *guid) G_GNUC_NON_NULL(1, 2);
 GPtrArray *
 fu_device_get_counterpart_guids(FuDevice *self) G_GNUC_NON_NULL(1);
+
+void
+fu_device_add_event(FuDevice *self, FuDeviceEvent *event);
+void
+fu_device_clear_events(FuDevice *self);
+GPtrArray *
+fu_device_get_events(FuDevice *self);
+FuDeviceEvent *
+fu_device_save_event(FuDevice *self, const gchar *id);
+FuDeviceEvent *
+fu_device_load_event(FuDevice *self, const gchar *id, GError **error);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "fu-device-event-private.h"
 #include "fu-device-private.h"
 #include "fu-i2c-device.h"
 #include "fu-string.h"
@@ -51,7 +52,16 @@ typedef struct {
 	FuUdevDeviceFlags flags;
 } FuUdevDevicePrivate;
 
-G_DEFINE_TYPE_WITH_PRIVATE(FuUdevDevice, fu_udev_device, FU_TYPE_DEVICE)
+static void
+fu_udev_device_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FuUdevDevice,
+		       fu_udev_device,
+		       FU_TYPE_DEVICE,
+		       0,
+		       G_ADD_PRIVATE(FuUdevDevice)
+			   G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
+						 fu_udev_device_codec_iface_init));
 
 enum {
 	PROP_0,
@@ -1716,11 +1726,42 @@ fu_udev_device_ioctl(FuUdevDevice *self,
 	FuUdevDevicePrivate *priv = GET_PRIVATE(self);
 	gint rc_tmp;
 	g_autoptr(GTimer) timer = g_timer_new();
+	FuDeviceEvent *event = NULL;
+	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
+	g_autofree gchar *event_id = NULL;
 
 	g_return_val_if_fail(FU_IS_UDEV_DEVICE(self), FALSE);
 	g_return_val_if_fail(request != 0x0, FALSE);
 	g_return_val_if_fail(buf != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* emulated */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED) ||
+	    fu_context_has_flag(ctx, FU_CONTEXT_FLAG_SAVE_EVENTS)) {
+		g_autofree gchar *buf_base64 = g_base64_encode(buf, bufsz);
+		event_id = g_strdup_printf("Ioctl:"
+					   "Request=0x%04x,"
+					   "Data=%s,"
+					   "Length=0x%x",
+					   (guint)request,
+					   buf_base64,
+					   (guint)bufsz);
+		g_debug("%s", event_id);
+	}
+
+	/* emulated */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED)) {
+		event = fu_device_load_event(FU_DEVICE(self), event_id, error);
+		if (event == NULL)
+			return FALSE;
+		return fu_device_event_copy_data(event, "Data", buf, bufsz, error);
+	}
+
+	/* save */
+	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_SAVE_EVENTS)) {
+		event = fu_device_save_event(FU_DEVICE(self), event_id);
+		fu_device_event_set_data(event, "Data", buf, bufsz);
+	}
 
 	/* not open! */
 	if (priv->io_channel == NULL) {
@@ -1770,6 +1811,12 @@ fu_udev_device_ioctl(FuUdevDevice *self,
 #endif
 		return FALSE;
 	}
+
+	/* save response */
+	if (event != NULL)
+		fu_device_event_set_data(event, "DataOut", buf, bufsz);
+
+	/* success */
 	return TRUE;
 #else
 	g_set_error(error,
@@ -2468,6 +2515,86 @@ fu_udev_device_dump_firmware(FuDevice *device, FuProgress *progress, GError **er
 }
 
 static void
+fu_udev_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags flags)
+{
+	FuDevice *device = FU_DEVICE(codec);
+	FuUdevDevice *self = FU_UDEV_DEVICE(codec);
+	FuUdevDevicePrivate *priv = GET_PRIVATE(self);
+	GPtrArray *events = fu_device_get_events(device);
+
+	/* optional properties */
+	if (priv->device_file != NULL) {
+		json_builder_set_member_name(builder, "DeviceFile");
+		json_builder_add_string_value(builder, priv->device_file);
+	}
+	if (fu_device_get_backend_id(device) != NULL) {
+		json_builder_set_member_name(builder, "BackendId");
+		json_builder_add_string_value(builder, fu_device_get_backend_id(device));
+	}
+#if GLIB_CHECK_VERSION(2, 62, 0)
+	if (fu_device_get_created(device) != 0) {
+		g_autoptr(GDateTime) dt =
+		    g_date_time_new_from_unix_utc(fu_device_get_created(device));
+		g_autofree gchar *str = g_date_time_format_iso8601(dt);
+		json_builder_set_member_name(builder, "Created");
+		json_builder_add_string_value(builder, str);
+	}
+#endif
+
+	/* events */
+	if (events->len > 0) {
+		json_builder_set_member_name(builder, "Events");
+		json_builder_begin_array(builder);
+		for (guint i = 0; i < events->len; i++) {
+			FuDeviceEvent *event = g_ptr_array_index(events, i);
+			fwupd_codec_to_json(FWUPD_CODEC(event), builder, flags);
+		}
+		json_builder_end_array(builder);
+	}
+}
+
+static gboolean
+fu_udev_device_from_json(FwupdCodec *codec, JsonNode *json_node, GError **error)
+{
+	FuDevice *device = FU_DEVICE(codec);
+	FuUdevDevice *self = FU_UDEV_DEVICE(codec);
+	FuUdevDevicePrivate *priv = GET_PRIVATE(self);
+	JsonObject *json_object = json_node_get_object(json_node);
+	const gchar *tmp;
+
+	tmp = json_object_get_string_member_with_default(json_object, "DeviceFile", NULL);
+	if (tmp != NULL) {
+		g_free(priv->device_file);
+		priv->device_file = g_strdup(tmp);
+	}
+	tmp = json_object_get_string_member_with_default(json_object, "BackendId", NULL);
+	if (tmp != NULL)
+		fu_device_set_backend_id(device, tmp);
+
+	tmp = json_object_get_string_member_with_default(json_object, "Created", NULL);
+	if (tmp != NULL) {
+		g_autoptr(GDateTime) dt = g_date_time_new_from_iso8601(tmp, NULL);
+		if (dt != NULL)
+			fu_device_set_created(device, g_date_time_to_unix(dt));
+	}
+
+	/* array of events */
+	if (json_object_has_member(json_object, "Events")) {
+		JsonArray *json_array = json_object_get_array_member(json_object, "Events");
+		for (guint i = 0; i < json_array_get_length(json_array); i++) {
+			JsonNode *node_tmp = json_array_get_element(json_array, i);
+			g_autoptr(FuDeviceEvent) event = fu_device_event_new(NULL);
+			if (!fwupd_codec_from_json(FWUPD_CODEC(event), node_tmp, error))
+				return FALSE;
+			fu_device_add_event(device, event);
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
 fu_udev_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
 	FuUdevDevice *self = FU_UDEV_DEVICE(object);
@@ -2652,6 +2779,13 @@ fu_udev_device_class_init(FuUdevDeviceClass *klass)
 				    NULL,
 				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_DEVICE_FILE, pspec);
+}
+
+static void
+fu_udev_device_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_json = fu_udev_device_add_json;
+	iface->from_json = fu_udev_device_from_json;
 }
 
 /**

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -32,6 +32,7 @@
 #include <libfwupdplugin/fu-crc.h>
 #include <libfwupdplugin/fu-csv-entry.h>
 #include <libfwupdplugin/fu-csv-firmware.h>
+#include <libfwupdplugin/fu-device-event.h>
 #include <libfwupdplugin/fu-device-locker.h>
 #include <libfwupdplugin/fu-device-metadata.h>
 #include <libfwupdplugin/fu-device.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -70,6 +70,7 @@ fwupdplugin_src = [
   'fu-csv-entry.c', # fuzzing
   'fu-csv-firmware.c', # fuzzing
   'fu-device.c', # fuzzing
+  'fu-device-event.c', # fuzzing
   'fu-device-locker.c', # fuzzing
   'fu-device-progress.c',
   'fu-dfu-firmware.c', # fuzzing
@@ -198,6 +199,7 @@ fwupdplugin_headers = [
   'fu-csv-entry.h',
   'fu-csv-firmware.h',
   'fu-device.h',
+  'fu-device-event.h',
   'fu-device-locker.h',
   'fu-device-metadata.h',
   'fu-device-private.h',

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -364,5 +364,12 @@ fu_udev_backend_class_init(FuUdevBackendClass *klass)
 FuBackend *
 fu_udev_backend_new(FuContext *ctx)
 {
-	return FU_BACKEND(g_object_new(FU_TYPE_UDEV_BACKEND, "name", "udev", "context", ctx, NULL));
+	return FU_BACKEND(g_object_new(FU_TYPE_UDEV_BACKEND,
+				       "name",
+				       "udev",
+				       "context",
+				       ctx,
+				       "device-gtype",
+				       FU_TYPE_UDEV_DEVICE,
+				       NULL));
 }

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -257,5 +257,12 @@ fu_usb_backend_class_init(FuUsbBackendClass *klass)
 FuBackend *
 fu_usb_backend_new(FuContext *ctx)
 {
-	return FU_BACKEND(g_object_new(FU_TYPE_USB_BACKEND, "name", "usb", "context", ctx, NULL));
+	return FU_BACKEND(g_object_new(FU_TYPE_USB_BACKEND,
+				       "name",
+				       "usb",
+				       "context",
+				       ctx,
+				       "device-gtype",
+				       FU_TYPE_USB_DEVICE,
+				       NULL));
 }


### PR DESCRIPTION
The medium-term aim here is to also do the FuUsbDevice type.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
