### PR TITLE
Do not add nonsense sections to FuElfFirmware

### DIFF
--- a/libfwupdplugin/fu-elf.rs
+++ b/libfwupdplugin/fu-elf.rs
@@ -47,6 +47,7 @@ struct FuStructElfProgramHeader64le {
 }
 
 #[repr(u32le)]
+#[derive(ToString)]
 enum FuElfSectionHeaderType {
     Null = 0x0,
     Progbits = 0x1,


### PR DESCRIPTION
The NULL and autogenerated .shrtrtab sections should not be added as images.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
