### PR TITLE
tpm: Ensure the FuTpmDeviceClass is big enough for a FuUdevDevice

### DIFF
--- a/plugins/tpm/fu-tpm-device.h
+++ b/plugins/tpm/fu-tpm-device.h
@@ -12,7 +12,7 @@
 G_DECLARE_DERIVABLE_TYPE(FuTpmDevice, fu_tpm_device, FU, TPM_DEVICE, FuUdevDevice)
 
 struct _FuTpmDeviceClass {
-	FuDeviceClass parent_class;
+	FuUdevDeviceClass parent_class;
 };
 
 void


### PR DESCRIPTION
I have no idea how this worked before.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
