### PR TITLE
trivial: Rename fu_udev_device_get_slot_depth() to fu_udev_device_get_subsystem_depth()

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -129,3 +129,4 @@ Remember: Plugins should be upstream!
 
 * `fu_hid_device_parse_descriptor()`: Use `fu_hid_device_parse_descriptors()` instead
 * `fu_udev_device_set_flags()`: Use `fu_udev_device_add_flag()` instead
+* `fu_udev_device_get_slot_depth()`: Use `fu_udev_device_get_subsystem_depth()` instead

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -752,7 +752,7 @@ fu_udev_device_set_dev(FuUdevDevice *self, GUdevDevice *udev_device)
 }
 
 /**
- * fu_udev_device_get_slot_depth:
+ * fu_udev_device_get_subsystem_depth:
  * @self: a #FuUdevDevice
  * @subsystem: a subsystem
  *
@@ -760,10 +760,10 @@ fu_udev_device_set_dev(FuUdevDevice *self, GUdevDevice *udev_device)
  *
  * Returns: unsigned integer
  *
- * Since: 1.2.4
+ * Since: 2.0.0
  **/
 guint
-fu_udev_device_get_slot_depth(FuUdevDevice *self, const gchar *subsystem)
+fu_udev_device_get_subsystem_depth(FuUdevDevice *self, const gchar *subsystem)
 {
 #ifdef HAVE_GUDEV
 	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(self));

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -138,7 +138,7 @@ fu_udev_device_get_revision(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 guint64
 fu_udev_device_get_number(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 guint
-fu_udev_device_get_slot_depth(FuUdevDevice *self, const gchar *subsystem) G_GNUC_NON_NULL(1);
+fu_udev_device_get_subsystem_depth(FuUdevDevice *self, const gchar *subsystem) G_GNUC_NON_NULL(1);
 gboolean
 fu_udev_device_set_physical_id(FuUdevDevice *self,
 			       const gchar *subsystems,

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -487,8 +487,8 @@ fu_ata_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* look at the PCI and USB depth to work out if in an external enclosure */
-	self->pci_depth = fu_udev_device_get_slot_depth(FU_UDEV_DEVICE(device), "pci");
-	self->usb_depth = fu_udev_device_get_slot_depth(FU_UDEV_DEVICE(device), "usb");
+	self->pci_depth = fu_udev_device_get_subsystem_depth(FU_UDEV_DEVICE(device), "pci");
+	self->usb_depth = fu_udev_device_get_subsystem_depth(FU_UDEV_DEVICE(device), "usb");
 	if (self->pci_depth <= 2 && self->usb_depth <= 2) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -312,7 +312,7 @@ fu_nvme_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* look at the PCI depth to work out if in an external enclosure */
-	self->pci_depth = fu_udev_device_get_slot_depth(FU_UDEV_DEVICE(device), "pci");
+	self->pci_depth = fu_udev_device_get_subsystem_depth(FU_UDEV_DEVICE(device), "pci");
 	if (self->pci_depth <= 2) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);


### PR DESCRIPTION
The concept of "slots" only works for PCI devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
