### PR TITLE
trivial: Remove fu_udev_device_get_parent_name()

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1994,34 +1994,6 @@ fu_udev_device_pwrite(FuUdevDevice *self,
 }
 
 /**
- * fu_udev_device_get_parent_name
- * @self: a #FuUdevDevice
- *
- * Returns the name of the direct ancestor of this device
- *
- * Returns: string or NULL if unset or invalid
- *
- * Since: 1.4.5
- **/
-gchar *
-fu_udev_device_get_parent_name(FuUdevDevice *self)
-{
-#ifdef HAVE_GUDEV
-	FuUdevDevicePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GUdevDevice) parent = NULL;
-
-	g_return_val_if_fail(FU_IS_UDEV_DEVICE(self), NULL);
-
-	if (priv->udev_device == NULL)
-		return NULL;
-	parent = g_udev_device_get_parent(priv->udev_device);
-	return parent == NULL ? NULL : g_strdup(g_udev_device_get_name(parent));
-#else
-	return NULL;
-#endif
-}
-
-/**
  * fu_udev_device_get_sysfs_attr:
  * @self: a #FuUdevDevice
  * @attr: name of attribute to get

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -182,8 +182,6 @@ fu_udev_device_get_sysfs_attr_uint64(FuUdevDevice *self,
 				     const gchar *attr,
 				     guint64 *value,
 				     GError **error) G_GNUC_NON_NULL(1);
-gchar *
-fu_udev_device_get_parent_name(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 
 gboolean
 fu_udev_device_write_sysfs(FuUdevDevice *self,

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -80,15 +80,18 @@ static gboolean
 fu_thunderbolt_controller_probe(FuDevice *device, GError **error)
 {
 	FuThunderboltController *self = FU_THUNDERBOLT_CONTROLLER(device);
+	const gchar *parent_name = NULL;
 	const gchar *unique_id;
-	g_autofree gchar *parent_name = NULL;
+	g_autoptr(FuUdevDevice) device_parent = NULL;
 
 	/* FuUdevDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_thunderbolt_controller_parent_class)->probe(device, error))
 		return FALSE;
 
 	/* determine if host controller or not */
-	parent_name = fu_udev_device_get_parent_name(FU_UDEV_DEVICE(self));
+	device_parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self), NULL, NULL);
+	if (device_parent != NULL)
+		parent_name = fu_device_get_name(FU_DEVICE(device_parent));
 	if (parent_name != NULL && g_str_has_prefix(parent_name, "domain"))
 		self->controller_kind = FU_THUNDERBOLT_CONTROLLER_KIND_HOST;
 	unique_id = fu_udev_device_get_sysfs_attr(FU_UDEV_DEVICE(device), "unique_id", NULL);


### PR DESCRIPTION
It's only used in one place and it is trivial to implement.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
