### PR TITLE
trivial: Remove FU_UDEV_DEVICE_FLAG_USE_CONFIG and implement directly

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1560,17 +1560,6 @@ fu_udev_device_add_flag(FuUdevDevice *self, FuUdevDeviceFlags flag)
 	if (priv->flags & flag)
 		return;
 	priv->flags |= flag;
-
-#ifdef HAVE_GUDEV
-	/* overwrite */
-	if (flag & FU_UDEV_DEVICE_FLAG_USE_CONFIG) {
-		g_free(priv->device_file);
-		priv->device_file =
-		    g_build_filename(g_udev_device_get_sysfs_path(priv->udev_device),
-				     "config",
-				     NULL);
-	}
-#endif
 }
 
 static gboolean

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -29,7 +29,6 @@ struct _FuUdevDeviceClass {
  * @FU_UDEV_DEVICE_FLAG_OPEN_READ:		Open the device read-only
  * @FU_UDEV_DEVICE_FLAG_OPEN_WRITE:		Open the device write-only
  * @FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT:	Get the vendor ID from a parent or grandparent
- * @FU_UDEV_DEVICE_FLAG_USE_CONFIG:		Read and write from the device config
  * @FU_UDEV_DEVICE_FLAG_OPEN_NONBLOCK:		Open nonblocking, e.g. O_NONBLOCK
  * @FU_UDEV_DEVICE_FLAG_OPEN_SYNC:		Open sync, e.g. O_SYNC
  * @FU_UDEV_DEVICE_FLAG_IOCTL_RETRY:		Retry the ioctl() call when required
@@ -42,7 +41,6 @@ typedef enum {
 	FU_UDEV_DEVICE_FLAG_OPEN_READ = 1 << 0,
 	FU_UDEV_DEVICE_FLAG_OPEN_WRITE = 1 << 1,
 	FU_UDEV_DEVICE_FLAG_VENDOR_FROM_PARENT = 1 << 2,
-	FU_UDEV_DEVICE_FLAG_USE_CONFIG = 1 << 3,
 	FU_UDEV_DEVICE_FLAG_OPEN_NONBLOCK = 1 << 4,
 	FU_UDEV_DEVICE_FLAG_OPEN_SYNC = 1 << 5,
 	FU_UDEV_DEVICE_FLAG_IOCTL_RETRY = 1 << 6,

--- a/plugins/pci-bcr/fu-pci-bcr-plugin.c
+++ b/plugins/pci-bcr/fu-pci-bcr-plugin.c
@@ -163,6 +163,7 @@ fu_pci_bcr_plugin_backend_device_added(FuPlugin *plugin,
 {
 	FuPciBcrPlugin *self = FU_PCI_BCR_PLUGIN(plugin);
 	FuDevice *device_msf;
+	g_autofree gchar *device_file = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* not supported */
@@ -181,7 +182,9 @@ fu_pci_bcr_plugin_backend_device_added(FuPlugin *plugin,
 		return TRUE;
 
 	/* open the config */
-	fu_udev_device_add_flag(FU_UDEV_DEVICE(device), FU_UDEV_DEVICE_FLAG_USE_CONFIG);
+	device_file =
+	    g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "config", NULL);
+	fu_udev_device_set_device_file(FU_UDEV_DEVICE(device), device_file);
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error))
 		return FALSE;
 	locker = fu_device_locker_new(device, error);

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -165,6 +165,7 @@ fu_pci_mei_plugin_backend_device_added(FuPlugin *plugin,
 	FuPciMeiPlugin *self = FU_PCI_MEI_PLUGIN(plugin);
 	const gchar *fwvers;
 	guint8 buf[4] = {0x0};
+	g_autofree gchar *device_file = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* interesting device? */
@@ -174,7 +175,10 @@ fu_pci_mei_plugin_backend_device_added(FuPlugin *plugin,
 		return TRUE;
 
 	/* open the config */
-	fu_udev_device_add_flag(FU_UDEV_DEVICE(device), FU_UDEV_DEVICE_FLAG_USE_CONFIG);
+	device_file =
+	    g_build_filename(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device)), "config", NULL);
+	fu_udev_device_set_device_file(FU_UDEV_DEVICE(device), device_file);
+
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error))
 		return FALSE;
 	locker = fu_device_locker_new(device, error);


### PR DESCRIPTION
This flag is only used in two places and makes the device path lifecycle very complicated to explain.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
