### PR TITLE
Add support for Framework SD Expansion Card

### DIFF
--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -681,10 +681,12 @@ fu_genesys_gl32xx_device_setup(FuDevice *device, GError **error)
 	/* if not detected above */
 	if (self->chip_name == NULL)
 		fu_genesys_gl32xx_device_set_chip_name(self, "GL32xx");
-	name = g_strdup_printf("%s SD reader [0x%04X]",
-			       self->chip_name,
-			       fu_udev_device_get_model(FU_UDEV_DEVICE(device)));
-	fu_device_set_name(device, name);
+	if (fu_device_has_vendor_id(device, "BLOCK:0x05E3")) {
+		name = g_strdup_printf("%s SD reader [0x%04X]",
+				       self->chip_name,
+				       fu_udev_device_get_model(FU_UDEV_DEVICE(device)));
+		fu_device_set_name(device, name);
+	}
 
 	if (!fu_genesys_gl32xx_device_ensure_cid(self, error))
 		return FALSE;
@@ -916,7 +918,7 @@ static void
 fu_genesys_gl32xx_device_init(FuGenesysGl32xxDevice *self)
 {
 	self->packetsz = 64;
-	fu_device_set_vendor(FU_DEVICE(self), "Genesys");
+
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_firmware_size(FU_DEVICE(self),

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
@@ -25,9 +25,11 @@ static void
 fu_genesys_gl32xx_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_GL32XX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_GL32XX_FIRMWARE);
+	fu_context_add_quirk_key(ctx, "GenesysGl32xxCompatibleModel");
 }
 
 static void

--- a/plugins/genesys-gl32xx/genesys-gl32xx.quirk
+++ b/plugins/genesys-gl32xx/genesys-gl32xx.quirk
@@ -5,3 +5,9 @@ FirmwareSize = 0x10000
 [BLOCK\VEN_05E3&DEV_0764]
 Plugin = genesys_gl32xx
 FirmwareSize = 0x1C000
+
+[BLOCK\VEN_32AC&DEV_0009]
+Plugin = genesys_gl32xx
+FirmwareSize = 0x1C000
+Name = Framework SD Expansion Card
+Vendor = Framework

--- a/plugins/genesys-gl32xx/genesys-gl32xx.quirk
+++ b/plugins/genesys-gl32xx/genesys-gl32xx.quirk
@@ -14,3 +14,5 @@ Plugin = genesys_gl32xx
 FirmwareSize = 0x1C000
 Name = Framework SD Expansion Card
 Vendor = Framework
+# Compatible with Genesys PID 0x0764
+GenesysGl32xxCompatibleModel = 0x0764

--- a/plugins/genesys-gl32xx/genesys-gl32xx.quirk
+++ b/plugins/genesys-gl32xx/genesys-gl32xx.quirk
@@ -1,3 +1,6 @@
+[BLOCK\VEN_05E3]
+Vendor = Genesys
+
 [BLOCK\VEN_05E3&DEV_0749]
 Plugin = genesys_gl32xx
 FirmwareSize = 0x10000


### PR DESCRIPTION
It was just recently [announced](https://frame.work/tw/en/blog/introducing-the-new-framework-laptop-13-with-intel-core-ultra-series-1-processors) together with the Intel Core Ultra platforms.
It will be available soon here: https://frame.work/tw/en/products/sd-expansion-card

It uses a GL3230 controller, so it's already supported by the plugin, but the plugin currently does not handle non-genesys VID/PID devices.