### PR TITLE
usi-dock: add PCB tag in uuid to distinguish different PCB versions

### DIFF
--- a/plugins/usi-dock/README.md
+++ b/plugins/usi-dock/README.md
@@ -22,6 +22,10 @@ Additionally, some extra "component ID" instance IDs are added.
 * `USB\VID_17EF&PID_7226&CID_USB3`
 * `USB\VID_17EF&PID_7226&CID_40B0&DMCVER_10.10`
 
+Additionally, some extra "REV version" instance values are added.
+
+* `USB\VID_17EF&PID_7226&CID_40B0&REV_0040`
+
 ## Update Behavior
 
 The device usually presents in runtime mode, but on detach re-enumerates with

--- a/plugins/usi-dock/fu-usi-dock-dmc-device.c
+++ b/plugins/usi-dock/fu-usi-dock-dmc-device.c
@@ -20,6 +20,7 @@ fu_usi_dock_dmc_device_parent_notify_cb(FuDevice *device, GParamSpec *pspec, gpo
 	FuDevice *parent = fu_device_get_parent(device);
 	if (parent != NULL) {
 		g_autoptr(GError) error = NULL;
+		const gchar *serialnum;
 
 		/* slightly odd: the MCU device uses the DMC version number */
 		g_info("absorbing DMC version into MCU");
@@ -53,6 +54,28 @@ fu_usi_dock_dmc_device_parent_notify_cb(FuDevice *device, GParamSpec *pspec, gpo
 						      NULL)) {
 			g_warning("failed to build MCU DMC Instance ID: %s", error->message);
 			return;
+		}
+
+		/* allow matching PCB version */
+		serialnum = fu_device_get_serial(device);
+		if (serialnum != NULL && strlen(serialnum) >= 8) {
+			if (serialnum[6] == 'Z' && serialnum[7] == 'D') {
+				/* REV4.0 */
+				fu_device_add_instance_u16(parent, "REV", 0x40);
+			} else {
+				fu_device_add_instance_u16(parent, "REV", 0x30);
+			}
+			if (!fu_device_build_instance_id(parent,
+							 &error,
+							 "USB",
+							 "VID",
+							 "PID",
+							 "CID",
+							 "REV",
+							 NULL)) {
+				g_warning("failed to build ID: %s", error->message);
+				return;
+			}
 		}
 
 		/* use a better device name */


### PR DESCRIPTION
From the next version of the FW, a new GUID will be used for differentiation.
