### PR TITLE
drop python<=3.7 support

### DIFF
--- a/contrib/ci/check-headers.py
+++ b/contrib/ci/check-headers.py
@@ -14,7 +14,7 @@ from typing import List
 
 def __get_includes(fn: str) -> List[str]:
     includes: List[str] = []
-    with open(fn, "r") as f:
+    with open(fn) as f:
         for line in f.read().split("\n"):
             if line.find("#include") == -1:
                 continue

--- a/contrib/ci/check-license.py
+++ b/contrib/ci/check-license.py
@@ -42,7 +42,7 @@ def test_files() -> int:
         lic: str = ""
         cprts: list[str] = []
         lines: list[str] = []
-        with open(fn, "r") as f:
+        with open(fn) as f:
             for line in f.read().split("\n"):
                 lines.append(line)
         if len(lines) < 2:

--- a/contrib/ci/check-quirks.py
+++ b/contrib/ci/check-quirks.py
@@ -12,7 +12,7 @@ def test_files() -> int:
     rc: int = 0
 
     for fn in glob.glob("**/*.quirk", recursive=True):
-        with open(fn, "r") as f:
+        with open(fn) as f:
             for line in f.read().split("\n"):
                 if line.startswith(" ") or line.endswith(" "):
                     print(f"{fn} has leading or trailing whitespace: {line}")

--- a/contrib/ci/flatpak.py
+++ b/contrib/ci/flatpak.py
@@ -23,7 +23,7 @@ def prepare(target):
     if os.path.isdir("build"):
         shutil.rmtree("build")
     data = {}
-    with open("contrib/flatpak/org.freedesktop.fwupd.json", "r") as rfd:
+    with open("contrib/flatpak/org.freedesktop.fwupd.json") as rfd:
         data = json.load(rfd, strict=False)
     platform = f"runtime/{data['runtime']}/x86_64/{data['runtime-version']}"
     sdk = f"runtime/{data['sdk']}/x86_64/{data['runtime-version']}"

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -69,7 +69,7 @@ def get_minimum_meson_version():
 
     directory = os.path.join(os.path.dirname(sys.argv[0]), "..", "..")
 
-    with open(os.path.join(directory, "meson.build"), "r") as f:
+    with open(os.path.join(directory, "meson.build")) as f:
         for line in f:
             if "meson_version" in line:
                 return re.search(r"(\d+\.\d+\.\d+)", line).group(1)

--- a/contrib/ci/generate_debian.py
+++ b/contrib/ci/generate_debian.py
@@ -22,7 +22,7 @@ def update_debian_control(target):
         print(f"Missing file {control_in}")
         sys.exit(1)
 
-    with open(control_in, "r") as rfd:
+    with open(control_in) as rfd:
         lines = rfd.readlines()
 
     deps, QUBES = parse_control_dependencies()
@@ -31,7 +31,7 @@ def update_debian_control(target):
     if QUBES:
         lines += "\n"
         control_qubes_in = os.path.join(target, "control.qubes.in")
-        with open(control_qubes_in, "r") as rfd:
+        with open(control_qubes_in) as rfd:
             lines += rfd.readlines()
 
     with open(control_out, "w") as wfd:
@@ -63,7 +63,7 @@ def update_debian_copyright(directory):
             if target.startswith("./po/") or file == "COPYING":
                 continue
             try:
-                with open(target, "r") as rfd:
+                with open(target) as rfd:
                     # read about the first few lines of the file only
                     lines = rfd.readlines(220)
             except UnicodeDecodeError:
@@ -78,7 +78,7 @@ def update_debian_copyright(directory):
                     partition = parts.partition(" ")[2]  # remove the year string
                     copyrights += [f"{partition}"]
     copyrights = "\n\t   ".join(sorted(set(copyrights)))
-    with open(copyright_in, "r") as rfd:
+    with open(copyright_in) as rfd:
         lines = rfd.readlines()
 
     with open(copyright_out, "w") as wfd:

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -40,7 +40,7 @@ if not os.path.exists(f):
     print(f"Missing input file {f} for {OS}")
     sys.exit(1)
 
-with open(f, "r") as rfd:
+with open(f) as rfd:
     lines = rfd.readlines()
 
 with open("Dockerfile", "w") as wfd:

--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -142,7 +142,7 @@ class Builder:
         """map changes"""
 
         dst = os.path.basename(src).replace(".in", "")
-        with open(os.path.join(self.srcdir, src), "r") as f:
+        with open(os.path.join(self.srcdir, src)) as f:
             blob = f.read()
             for key in replacements:
                 blob = blob.replace(key, replacements[key])
@@ -252,7 +252,7 @@ class Builder:
     def grep_meson(self, src: str, token: str = "fuzzing") -> List[str]:
         """find source files tagged with a specific comment"""
         srcs = []
-        with open(os.path.join(self.srcdir, src, "meson.build"), "r") as f:
+        with open(os.path.join(self.srcdir, src, "meson.build")) as f:
             for line in f.read().split("\n"):
                 if line.find(token) == -1:
                     continue

--- a/contrib/ci/populate-bios-setting-translations.py
+++ b/contrib/ci/populate-bios-setting-translations.py
@@ -21,7 +21,7 @@ def populate_translations(path):
             val: str = ""
             if not file.endswith("display_name"):
                 continue
-            with open(os.path.join(root, file), "r") as f:
+            with open(os.path.join(root, file)) as f:
                 val = f.read().replace('"', "").strip()
             if not val:
                 continue

--- a/contrib/firmware_packager/add_dfu_header.py
+++ b/contrib/firmware_packager/add_dfu_header.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 #
 # Copyright 2020 Richard Hughes <richard@hughsie.com>
 #

--- a/contrib/generate-ds20.py
+++ b/contrib/generate-ds20.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         if len(sections) != 1:
             print("Multiple devices found, use --instance-id to choose between:")
             for section in sections:
-                print(" • {}".format(section))
+                print(f" • {section}")
             sys.exit(1)
         args.instance_id = sections[0]
 
@@ -53,12 +53,12 @@ if __name__ == "__main__":
     try:
         for key in config[args.instance_id]:
             if key in ["Inhibit", "Issue"]:
-                print("WARNING: skipping key {}".format(key))
+                print(f"WARNING: skipping key {key}")
                 continue
             value = config[args.instance_id][key]
-            lines.append("{}={}".format(key, value))
+            lines.append(f"{key}={value}")
     except KeyError:
-        print("No {} section".format(args.instance_id))
+        print(f"No {args.instance_id} section")
         sys.exit(1)
 
     # pad to the buffer size
@@ -70,5 +70,5 @@ if __name__ == "__main__":
 
     # success
     print("DS20 descriptor control transfer data:")
-    print(" ".join(["{:02x}".format(val) for val in list(buf)]))
+    print(" ".join([f"{val:02x}" for val in list(buf)]))
     print(base64.b64encode(buf).decode())

--- a/contrib/migrate.py
+++ b/contrib/migrate.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     for fn in fns:
         modified: bool = False
-        with open(fn, "r") as f:
+        with open(fn) as f:
             buf = f.read()
         for old, new in {
             "fu_common_sum8": "fu_sum8",

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -242,7 +242,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
         crawler_output = io.StringIO()
         sys.stdout = crawler_output
         self.q._output_crawler(json.loads(UPDATE_INFO), 0)
-        with open("test/logs/get_devices.log", "r") as get_devices:
+        with open("test/logs/get_devices.log") as get_devices:
             self.assertEqual(
                 get_devices.read(), crawler_output.getvalue().strip() + "\n"
             )
@@ -273,7 +273,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
         help_output = io.StringIO()
         sys.stdout = help_output
         self.q.help()
-        with open("test/logs/help.log", "r") as help_log:
+        with open("test/logs/help.log") as help_log:
             self.assertEqual(help_log.read(), help_output.getvalue().strip() + "\n")
         sys.stdout = self.captured_output
 

--- a/contrib/standalone-installer/assets/header.py
+++ b/contrib/standalone-installer/assets/header.py
@@ -302,7 +302,7 @@ def run_installation(directory, verbose, allow_reinstall, allow_older, uninstall
     minimum_path = os.path.join(directory, "minimum")
     minimum = None
     if os.path.exists(minimum_path):
-        with open(minimum_path, "r") as rfd:
+        with open(minimum_path) as rfd:
             minimum = rfd.read()
 
     if not use_included_version(minimum):

--- a/contrib/upload-smc-license.py
+++ b/contrib/upload-smc-license.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         print("License:")
         license = sys.stdin.read()
     else:
-        with open(args.file, "r") as fd:
+        with open(args.file) as fd:
             license = fd.read()
 
     sslctx = ssl.create_default_context()

--- a/generate-build/generate-version-script.py
+++ b/generate-build/generate-version-script.py
@@ -111,13 +111,13 @@ class LdVersionScript:
         oldversion = None
         for version in sorted(versions, key=parse_version):
             symbols = sorted(self.releases[version])
-            verout += "\n%s_%s {\n" % (self.library_name, version)
+            verout += "\n{}_{} {{\n".format(self.library_name, version)
             verout += "  global:\n"
             for symbol in symbols:
                 verout += f"    {symbol};\n"
             verout += "  local: *;\n"
             if oldversion:
-                verout += "} %s_%s;\n" % (self.library_name, oldversion)
+                verout += "}} {}_{};\n".format(self.library_name, oldversion)
             else:
                 verout += "};\n"
             oldversion = version

--- a/generate-build/unittest_inspector.py
+++ b/generate-build/unittest_inspector.py
@@ -18,7 +18,7 @@ def list_tests(module):
     for name, obj in inspect.getmembers(module):
         if inspect.isclass(obj) and issubclass(obj, unittest.TestCase):
             cases = unittest.defaultTestLoader.getTestCaseNames(obj)
-            tests += [(obj, "{}.{}".format(name, t)) for t in cases]
+            tests += [(obj, f"{name}.{t}") for t in cases]
     return tests
 
 

--- a/plugins/amd-gpu/amd_gpu_test.py
+++ b/plugins/amd-gpu/amd_gpu_test.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import ctypes
 import gi
 import os
 import sys

--- a/plugins/nvme/nvme_test.py
+++ b/plugins/nvme/nvme_test.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import ctypes
 import gi
 import os
 import sys

--- a/plugins/uefi-capsule/make-images.py
+++ b/plugins/uefi-capsule/make-images.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017 Peter Jones <pjones@redhat.com>
 # Copyright 2020 Richard Hughes <richard@hughsie.com>
@@ -29,7 +28,7 @@ from gi.repository import Pango, PangoCairo
 
 
 def languages(podir: str):
-    for x in open(os.path.join(podir, "LINGUAS"), "r").readlines():
+    for x in open(os.path.join(podir, "LINGUAS")).readlines():
         yield x.strip()
     yield "en"
 
@@ -41,7 +40,7 @@ class PotFile:
             self.parse(fn)
 
     def parse(self, fn: str) -> None:
-        with open(fn, "r") as f:
+        with open(fn) as f:
             lang_en: Optional[str] = None
             for line in f.read().split("\n"):
                 if not line:


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
