### PR TITLE
Add the concept of a plugin inhibit

### DIFF
--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1064,13 +1064,21 @@ typedef enum {
 	 */
 	FWUPD_PLUGIN_FLAG_READY = 1ull << 17,
 	/**
+	 * FWUPD_PLUGIN_FLAG_INHIBITED:
+	 *
+	 * The plugin is being inhibited by other plugin.
+	 *
+	 * Since: 1.9.22
+	 */
+	FWUPD_PLUGIN_FLAG_INHIBITED = 1ull << 18,
+	/**
 	 * FWUPD_PLUGIN_FLAG_TEST_ONLY:
 	 *
 	 * The plugin is used for virtual devices that exercising daemon flows.
 	 *
 	 * Since: 2.0.0
 	 */
-	FWUPD_PLUGIN_FLAG_TEST_ONLY = 1ull << 18,
+	FWUPD_PLUGIN_FLAG_TEST_ONLY = 1ull << 19,
 	/**
 	 * FWUPD_PLUGIN_FLAG_UNKNOWN:
 	 *

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -929,3 +929,8 @@ fu_device_build_instance_id_full(FuDevice *self,
 				 ...) G_GNUC_NULL_TERMINATED G_GNUC_NON_NULL(1, 4);
 FuDeviceLocker *
 fu_device_poll_locker_new(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
+
+void
+fu_device_add_plugin_inhibit(FuDevice *self, const gchar *plugin_name) G_GNUC_NON_NULL(1, 2);
+GPtrArray *
+fu_device_get_plugin_inhibits(FuDevice *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -439,3 +439,11 @@ fu_quirks_add_possible_key(FuQuirks *self, const gchar *possible_key) G_GNUC_NON
  * Since: 1.8.2
  **/
 #define FU_QUIRKS_CFI_DEVICE_BLOCK_SIZE "CfiDeviceBlockSize"
+/**
+ * FU_QUIRKS_PLUGIN_INHIBIT:
+ *
+ * The quirk key for the list of plugin inhibits, split by comma if required.
+ *
+ * Since: 1.9.22
+ **/
+#define FU_QUIRKS_PLUGIN_INHIBIT "PluginInhibit"

--- a/plugins/cros-ec/cros-ec.quirk
+++ b/plugins/cros-ec/cros-ec.quirk
@@ -11,6 +11,7 @@ Summary = Quiche Reference Board
 # Baklava (D501)
 [USB\VID_0502&PID_1195]
 Plugin = cros_ec
+PluginInhibit = rts54hub
 Summary = D501 Device (Google Quiche derivative)
 
 # Gingerbread

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -125,6 +125,7 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 
 	/* never show these, they're way too generic */
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
+	flags &= ~FWUPD_PLUGIN_FLAG_INHIBITED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
 	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
 	flags &= ~FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1612,6 +1612,10 @@ fu_util_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		/* TRANSLATORS: Plugin is inactive and not used */
 		return _("Disabled");
 	}
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_INHIBITED) {
+		/* TRANSLATORS: Plugin is inhibited by another plugin */
+		return _("Inhibited");
+	}
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_NO_HARDWARE) {
 		/* TRANSLATORS: not required for this system */
 		return _("Required hardware was not found");
@@ -1690,6 +1694,7 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 		return fu_console_color_format(fu_util_plugin_flag_to_string(plugin_flag),
 					       FU_CONSOLE_COLOR_GREEN);
 	case FWUPD_PLUGIN_FLAG_DISABLED:
+	case FWUPD_PLUGIN_FLAG_INHIBITED:
 	case FWUPD_PLUGIN_FLAG_NO_HARDWARE:
 	case FWUPD_PLUGIN_FLAG_TEST_ONLY:
 		return fu_console_color_format(fu_util_plugin_flag_to_string(plugin_flag),

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4385,6 +4385,7 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 
 	/* never show these, they're way too generic */
 	flags &= ~FWUPD_PLUGIN_FLAG_DISABLED;
+	flags &= ~FWUPD_PLUGIN_FLAG_INHIBITED;
 	flags &= ~FWUPD_PLUGIN_FLAG_NO_HARDWARE;
 	flags &= ~FWUPD_PLUGIN_FLAG_REQUIRE_HWID;
 	flags &= ~FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY;


### PR DESCRIPTION
On the Acer 501 dock the i2c bus is used by two different plugins with different exposed devices. Using each one in isolation works fine, but together they explode as they both try probing the device at the same time in different ways.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
