### PR TITLE
Completely remove fu_usb_device_get_dev()

### DIFF
--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -106,7 +106,7 @@ fu_hid_device_parse_descriptors(FuHidDevice *self, GError **error)
 	g_return_val_if_fail(FU_HID_DEVICE(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	fws = g_usb_device_get_hid_descriptors(fu_usb_device_get_dev(FU_USB_DEVICE(self)), error);
+	fws = fu_usb_device_get_hid_descriptors(FU_USB_DEVICE(self), error);
 	if (fws == NULL)
 		return NULL;
 	for (guint i = 0; i < fws->len; i++) {
@@ -171,7 +171,7 @@ fu_hid_device_open(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* self tests */
-	if (fu_usb_device_get_dev(FU_USB_DEVICE(device)) == NULL)
+	if (fu_usb_device_get_spec(FU_USB_DEVICE(device)) == 0x0)
 		return TRUE;
 
 	/* auto-detect */
@@ -224,7 +224,7 @@ fu_hid_device_close(FuDevice *device, GError **error)
 	g_autoptr(GError) error_local = NULL;
 
 	/* self tests */
-	if (fu_usb_device_get_dev(FU_USB_DEVICE(device)) == NULL)
+	if (fu_usb_device_get_spec(FU_USB_DEVICE(device)) == 0x0)
 		return TRUE;
 
 	/* release */

--- a/libfwupdplugin/fu-usb-device-private.h
+++ b/libfwupdplugin/fu-usb-device-private.h
@@ -12,7 +12,5 @@
 
 FuUsbDevice *
 fu_usb_device_new(FuContext *ctx, GUsbDevice *usb_device) G_GNUC_NON_NULL(1);
-GUsbDevice *
-fu_usb_device_get_dev(FuUsbDevice *device) G_GNUC_NON_NULL(1);
 const gchar *
 fu_usb_device_get_platform_id(FuUsbDevice *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -143,3 +143,5 @@ fu_usb_device_get_string_descriptor_bytes_full(FuUsbDevice *self,
 					       guint16 langid,
 					       gsize length,
 					       GError **error) G_GNUC_NON_NULL(1);
+GPtrArray *
+fu_usb_device_get_hid_descriptors(FuUsbDevice *self, GError **error) G_GNUC_NON_NULL(1);


### PR DESCRIPTION
We want to drop GUsb longer term, so don't expose the internal device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
