### PR TITLE
trivial: Add a GError to fu_usb_device_get_configuration_index()

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1718,16 +1718,17 @@ fu_usb_device_release_interface(FuUsbDevice *self,
 /**
  * fu_usb_device_get_configuration_index
  * @self: a #FuUsbDevice
+ * @error: a #GError, or %NULL
  *
  * Get the index for the active Configuration string descriptor
  * ie, iConfiguration.
  *
- * Return value: a string descriptor index.
+ * Return value: a string descriptor index, or 0x0 on error
  *
  * Since: 2.0.0
  **/
 guint8
-fu_usb_device_get_configuration_index(FuUsbDevice *self)
+fu_usb_device_get_configuration_index(FuUsbDevice *self, GError **error)
 {
 	FuUsbDevicePrivate *priv = GET_PRIVATE(self);
 

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -46,7 +46,7 @@ guint8
 fu_usb_device_get_device_class(FuUsbDevice *self);
 
 guint8
-fu_usb_device_get_configuration_index(FuUsbDevice *self);
+fu_usb_device_get_configuration_index(FuUsbDevice *self, GError **error);
 guint8
 fu_usb_device_get_serial_number_index(FuUsbDevice *self);
 guint8

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -78,7 +78,9 @@ fu_cros_ec_usb_device_get_configuration(FuCrosEcUsbDevice *self, GError **error)
 	guint8 index;
 	g_autofree gchar *configuration = NULL;
 
-	index = fu_usb_device_get_configuration_index(FU_USB_DEVICE(self));
+	index = fu_usb_device_get_configuration_index(FU_USB_DEVICE(self), error);
+	if (index == 0x0)
+		return FALSE;
 	configuration = fu_usb_device_get_string_descriptor(FU_USB_DEVICE(self), index, error);
 	if (configuration == NULL)
 		return FALSE;


### PR DESCRIPTION
In GUsb this is failable, and there's a nasty `g_return_val_if_fail` that I want to handle properly longer term.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
