### PR TITLE
trivial: mark 1.7.x as EOL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Additionally, the `1.7.x` and `1.8.x` branches are supported for security fixes.
 | 2.0.x   | :heavy_check_mark: | 2028-01-01 |
 | 1.9.x   | :heavy_check_mark: | 2027-01-01 |
 | 1.8.x   | :white_check_mark: | 2025-01-01 |
-| 1.7.x   | :white_check_mark: | 2024-06-01 |
+| 1.7.x   | :x:                | 2024-06-01 |
 | 1.6.x   | :x:                | 2024-01-01 |
 | 1.5.x   | :x:                | 2022-01-01 |
 | 1.4.x   | :x:                | 2021-05-01 |


### PR DESCRIPTION
We're past the date advertised as EoL now, update the document.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
