### PR TITLE
trivial: Make fu_device_event_copy_data() more useful

### DIFF
--- a/libfwupdplugin/fu-device-event-private.h
+++ b/libfwupdplugin/fu-device-event-private.h
@@ -39,4 +39,5 @@ fu_device_event_copy_data(FuDeviceEvent *self,
 			  const gchar *key,
 			  guint8 *buf,
 			  gsize bufsz,
+			  gsize *actual_length,
 			  GError **error) G_GNUC_NON_NULL(1, 2, 3);

--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -274,8 +274,9 @@ fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
  * fu_device_event_copy_data:
  * @self: a #FuDeviceEvent
  * @key: (not nullable): a unique key, e.g. `Name`
- * @buf: (not nullable): a buffer
+ * @buf: (nullable): a buffer
  * @bufsz: size of @buf
+ * @actual_length: (out) (optional): the actual number of bytes sent, or %NULL
  * @error: (nullable): optional return location for an error
  *
  * Copies memory from the event.
@@ -289,6 +290,7 @@ fu_device_event_copy_data(FuDeviceEvent *self,
 			  const gchar *key,
 			  guint8 *buf,
 			  gsize bufsz,
+			  gsize *actual_length,
 			  GError **error)
 {
 	const gchar *blobstr;
@@ -297,14 +299,17 @@ fu_device_event_copy_data(FuDeviceEvent *self,
 
 	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), FALSE);
 	g_return_val_if_fail(key != NULL, FALSE);
-	g_return_val_if_fail(buf != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	blobstr = fu_device_event_lookup(self, key, G_TYPE_STRING, error);
 	if (blobstr == NULL)
 		return FALSE;
 	buf_src = g_base64_decode(blobstr, &bufsz_src);
-	return fu_memcpy_safe(buf, bufsz, 0x0, buf_src, bufsz_src, 0x0, bufsz_src, error);
+	if (actual_length != NULL)
+		*actual_length = bufsz_src;
+	if (buf != NULL)
+		return fu_memcpy_safe(buf, bufsz, 0x0, buf_src, bufsz_src, 0x0, bufsz_src, error);
+	return TRUE;
 }
 
 static void

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1724,7 +1724,7 @@ fu_udev_device_ioctl(FuUdevDevice *self,
 		event = fu_device_load_event(FU_DEVICE(self), event_id, error);
 		if (event == NULL)
 			return FALSE;
-		return fu_device_event_copy_data(event, "Data", buf, bufsz, error);
+		return fu_device_event_copy_data(event, "Data", buf, bufsz, NULL, error);
 	}
 
 	/* save */


### PR DESCRIPTION
Allow passing the actual data length back to the caller.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
