### PR TITLE
trivial: Fix two warnings when probing raw FuUdevDevices

### DIFF
--- a/plugins/pci-bcr/fu-pci-bcr-plugin.c
+++ b/plugins/pci-bcr/fu-pci-bcr-plugin.c
@@ -187,6 +187,7 @@ fu_pci_bcr_plugin_backend_device_added(FuPlugin *plugin,
 	fu_udev_device_set_device_file(FU_UDEV_DEVICE(device), device_file);
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error))
 		return FALSE;
+	fu_udev_device_add_flag(FU_UDEV_DEVICE(device), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 	locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;

--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -181,6 +181,7 @@ fu_pci_mei_plugin_backend_device_added(FuPlugin *plugin,
 
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "pci", error))
 		return FALSE;
+	fu_udev_device_add_flag(FU_UDEV_DEVICE(device), FU_UDEV_DEVICE_FLAG_OPEN_READ);
 	locker = fu_device_locker_new(device, error);
 	if (locker == NULL)
 		return FALSE;


### PR DESCRIPTION
Fixes some of https://github.com/fwupd/fwupd/issues/7402

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
