### PR TITLE
data: fwupd.service.in: Add missing hidraw permission

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -11,6 +11,7 @@ TimeoutSec=180
 RuntimeDirectory=@motd_dir@
 RuntimeDirectoryPreserve=yes
 BusName=org.freedesktop.fwupd
+DeviceAllow=char-hidraw rw
 ExecStart=@libexecdir@/fwupd/fwupd
 KeyringMode=private
 LockPersonality=yes


### PR DESCRIPTION
Setting `ProtectClock=yes` implies `DeviceAllow=char-rtc r` which seems to effectively block fwupd from accessing hidraw. Change adds missing `DeviceAllow` to let fwupd access hidraw.

Fixes: https://github.com/fwupd/fwupd/issues/7414

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
