### PR TITLE
trivial: Only reset the device created timestamp if not already set

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -320,8 +320,8 @@ fu_backend_load(FuBackend *self,
 
 		/* does a device with this platform ID [and the same created date] already exist */
 		device_old = fu_backend_lookup_by_id(self, fu_device_get_backend_id(device_tmp));
-		if (device_old != NULL &&
-		    fu_device_get_created(device_old) == fu_device_get_created(device_tmp)) {
+		if (device_old != NULL && fu_device_get_created_usec(device_old) ==
+					      fu_device_get_created_usec(device_tmp)) {
 			GPtrArray *events = fu_device_get_events(device_tmp);
 			fu_device_clear_events(device_old);
 			for (guint j = 0; j < events->len; j++) {

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -158,10 +158,8 @@ fu_device_new(FuContext *ctx);
 #define fu_device_add_icon(d, v)	   fwupd_device_add_icon(FWUPD_DEVICE(d), v)
 #define fu_device_has_icon(d, v)	   fwupd_device_has_icon(FWUPD_DEVICE(d), v)
 #define fu_device_add_issue(d, v)	   fwupd_device_add_issue(FWUPD_DEVICE(d), v)
-#define fu_device_set_created(d, v)	   fwupd_device_set_created(FWUPD_DEVICE(d), v)
 #define fu_device_set_description(d, v)	   fwupd_device_set_description(FWUPD_DEVICE(d), v)
 #define fu_device_set_flags(d, v)	   fwupd_device_set_flags(FWUPD_DEVICE(d), v)
-#define fu_device_set_modified(d, v)	   fwupd_device_set_modified(FWUPD_DEVICE(d), v)
 #define fu_device_set_plugin(d, v)	   fwupd_device_set_plugin(FWUPD_DEVICE(d), v)
 #define fu_device_set_serial(d, v)	   fwupd_device_set_serial(FWUPD_DEVICE(d), v)
 #define fu_device_set_summary(d, v)	   fwupd_device_set_summary(FWUPD_DEVICE(d), v)
@@ -181,8 +179,6 @@ fu_device_new(FuContext *ctx);
 #define fu_device_set_install_duration(d, v) fwupd_device_set_install_duration(FWUPD_DEVICE(d), v)
 #define fu_device_get_checksums(d)	     fwupd_device_get_checksums(FWUPD_DEVICE(d))
 #define fu_device_get_flags(d)		     fwupd_device_get_flags(FWUPD_DEVICE(d))
-#define fu_device_get_created(d)	     fwupd_device_get_created(FWUPD_DEVICE(d))
-#define fu_device_get_modified(d)	     fwupd_device_get_modified(FWUPD_DEVICE(d))
 #define fu_device_get_guids(d)		     fwupd_device_get_guids(FWUPD_DEVICE(d))
 #define fu_device_get_guid_default(d)	     fwupd_device_get_guid_default(FWUPD_DEVICE(d))
 #define fu_device_get_instance_ids(d)	     fwupd_device_get_instance_ids(FWUPD_DEVICE(d))
@@ -762,6 +758,16 @@ guint
 fu_device_get_battery_threshold(FuDevice *self) G_GNUC_NON_NULL(1);
 void
 fu_device_set_battery_threshold(FuDevice *self, guint battery_threshold) G_GNUC_NON_NULL(1);
+
+gint64
+fu_device_get_created_usec(FuDevice *self) G_GNUC_NON_NULL(1);
+void
+fu_device_set_created_usec(FuDevice *self, gint64 created_usec) G_GNUC_NON_NULL(1);
+gint64
+fu_device_get_modified_usec(FuDevice *self) G_GNUC_NON_NULL(1);
+void
+fu_device_set_modified_usec(FuDevice *self, gint64 modified_usec) G_GNUC_NON_NULL(1);
+
 void
 fu_device_set_update_state(FuDevice *self, FwupdUpdateState update_state) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -509,8 +509,8 @@ fu_plugin_device_add(FuPlugin *self, FuDevice *device)
 	}
 
 	g_debug("emit added from %s: %s", fu_plugin_get_name(self), fu_device_get_id(device));
-	if (fu_device_get_created(device) == 0)
-		fu_device_set_created(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
+	if (fu_device_get_created_usec(device) == 0)
+		fu_device_set_created_usec(device, g_get_real_time());
 	fu_device_set_plugin(device, fu_plugin_get_name(self));
 	g_signal_emit(self, signals[SIGNAL_DEVICE_ADDED], 0, device);
 
@@ -518,7 +518,7 @@ fu_plugin_device_add(FuPlugin *self, FuDevice *device)
 	children = fu_device_get_children(device);
 	for (guint i = 0; i < children->len; i++) {
 		FuDevice *child = g_ptr_array_index(children, i);
-		if (fu_device_get_created(child) == 0)
+		if (fu_device_get_created_usec(child) == 0)
 			fu_plugin_device_add(self, child);
 	}
 
@@ -2105,7 +2105,7 @@ fu_plugin_runner_activate(FuPlugin *self, FuDevice *device, FuProgress *progress
 
 	/* update with correct flags */
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
-	fu_device_set_modified(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
+	fu_device_set_modified_usec(device, g_get_real_time());
 	return TRUE;
 }
 
@@ -2152,7 +2152,7 @@ fu_plugin_runner_unlock(FuPlugin *self, FuDevice *device, GError **error)
 
 	/* update with correct flags */
 	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_LOCKED);
-	fu_device_set_modified(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
+	fu_device_set_modified_usec(device, g_get_real_time());
 	return TRUE;
 }
 

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -509,7 +509,8 @@ fu_plugin_device_add(FuPlugin *self, FuDevice *device)
 	}
 
 	g_debug("emit added from %s: %s", fu_plugin_get_name(self), fu_device_get_id(device));
-	fu_device_set_created(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
+	if (fu_device_get_created(device) == 0)
+		fu_device_set_created(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
 	fu_device_set_plugin(device, fu_plugin_get_name(self));
 	g_signal_emit(self, signals[SIGNAL_DEVICE_ADDED], 0, device);
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2121,14 +2121,14 @@ fu_device_incorporate_func(void)
 
 	/* base properties */
 	fu_device_add_flag(donor, FWUPD_DEVICE_FLAG_REQUIRE_AC);
-	fu_device_set_created(donor, 123);
-	fu_device_set_modified(donor, 456);
+	fu_device_set_created_usec(donor, 1514338000ull * G_USEC_PER_SEC);
+	fu_device_set_modified_usec(donor, 1514338999ull * G_USEC_PER_SEC);
 	fu_device_add_icon(donor, "computer");
 
 	/* existing properties */
 	fu_device_set_equivalent_id(device, "DO_NOT_OVERWRITE");
 	fu_device_set_metadata(device, "test2", "DO_NOT_OVERWRITE");
-	fu_device_set_modified(device, 789);
+	fu_device_set_modified_usec(device, 1514340000ull * G_USEC_PER_SEC);
 
 	/* incorporate properties from donor to device */
 	fu_device_incorporate(device, donor);
@@ -2136,8 +2136,8 @@ fu_device_incorporate_func(void)
 	g_assert_cmpstr(fu_device_get_metadata(device, "test"), ==, "me");
 	g_assert_cmpstr(fu_device_get_metadata(device, "test2"), ==, "DO_NOT_OVERWRITE");
 	g_assert_true(fu_device_has_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC));
-	g_assert_cmpint(fu_device_get_created(device), ==, 123);
-	g_assert_cmpint(fu_device_get_modified(device), ==, 789);
+	g_assert_cmpint(fu_device_get_created_usec(device), ==, 1514338000ull * G_USEC_PER_SEC);
+	g_assert_cmpint(fu_device_get_modified_usec(device), ==, 1514340000ull * G_USEC_PER_SEC);
 	g_assert_cmpint(fu_device_get_icons(device)->len, ==, 1);
 	ret = fu_device_build_instance_id(device, &error, "USB", "VID", NULL);
 	g_assert_no_error(error);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -2496,10 +2496,10 @@ fu_udev_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags
 		json_builder_set_member_name(builder, "BackendId");
 		json_builder_add_string_value(builder, fu_device_get_backend_id(device));
 	}
-#if GLIB_CHECK_VERSION(2, 62, 0)
-	if (fu_device_get_created(device) != 0) {
+#if GLIB_CHECK_VERSION(2, 80, 0)
+	if (fu_device_get_created_usec(device) != 0) {
 		g_autoptr(GDateTime) dt =
-		    g_date_time_new_from_unix_utc(fu_device_get_created(device));
+		    g_date_time_new_from_unix_utc_usec(fu_device_get_created_usec(device));
 		g_autofree gchar *str = g_date_time_format_iso8601(dt);
 		json_builder_set_member_name(builder, "Created");
 		json_builder_add_string_value(builder, str);
@@ -2535,13 +2535,14 @@ fu_udev_device_from_json(FwupdCodec *codec, JsonNode *json_node, GError **error)
 	tmp = json_object_get_string_member_with_default(json_object, "BackendId", NULL);
 	if (tmp != NULL)
 		fu_device_set_backend_id(device, tmp);
-
+#if GLIB_CHECK_VERSION(2, 80, 0)
 	tmp = json_object_get_string_member_with_default(json_object, "Created", NULL);
 	if (tmp != NULL) {
 		g_autoptr(GDateTime) dt = g_date_time_new_from_iso8601(tmp, NULL);
 		if (dt != NULL)
-			fu_device_set_created(device, g_date_time_to_unix(dt));
+			fu_device_set_created_usec(device, g_date_time_to_unix_usec(dt));
 	}
+#endif
 
 	/* array of events */
 	if (json_object_has_member(json_object, "Events")) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3485,7 +3485,7 @@ fu_engine_install_blob(FuEngine *self,
 	}
 
 	/* mark this as modified even if we actually fail to do the update */
-	fu_device_set_modified(device, (guint64)g_get_real_time() / G_USEC_PER_SEC);
+	fu_device_set_modified_usec(device, g_get_real_time());
 
 	/* signal to all the plugins the update is about to happen */
 	device_id = g_strdup(fu_device_get_id(device));

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -85,10 +85,10 @@ fu_history_device_from_stmt(sqlite3_stmt *stmt)
 		fu_device_set_plugin(device, tmp);
 
 	/* device_created */
-	fu_device_set_created(device, sqlite3_column_int64(stmt, 3));
+	fu_device_set_created_usec(device, sqlite3_column_int64(stmt, 3) * G_USEC_PER_SEC);
 
 	/* device_modified */
-	fu_device_set_modified(device, sqlite3_column_int64(stmt, 4));
+	fu_device_set_modified_usec(device, sqlite3_column_int64(stmt, 4) * G_USEC_PER_SEC);
 
 	/* display_name */
 	tmp = (const gchar *)sqlite3_column_text(stmt, 5);
@@ -210,8 +210,8 @@ fu_history_create_database(FuHistory *self, GError **error)
 			  "filename TEXT,"
 			  "display_name TEXT,"
 			  "plugin TEXT,"
-			  "device_created INTEGER DEFAULT 0,"
-			  "device_modified INTEGER DEFAULT 0,"
+			  "device_created INTEGER DEFAULT 0,"  /* seconds */
+			  "device_modified INTEGER DEFAULT 0," /* seconds */
 			  "checksum TEXT DEFAULT NULL,"
 			  "flags INTEGER DEFAULT 0,"
 			  "metadata TEXT DEFAULT NULL,"
@@ -737,7 +737,7 @@ fu_history_modify_device(FuHistory *self, FuDevice *device, GError **error)
 	    fwupd_checksum_get_by_kind(fu_device_get_checksums(device), G_CHECKSUM_SHA1),
 	    -1,
 	    SQLITE_STATIC);
-	sqlite3_bind_int64(stmt, 7, fu_device_get_modified(device));
+	sqlite3_bind_int64(stmt, 7, fu_device_get_modified_usec(device) / G_USEC_PER_SEC);
 	sqlite3_bind_int64(stmt, 8, fu_device_get_install_duration(device));
 
 	if (!fu_history_stmt_exec(self, stmt, NULL, error))
@@ -825,7 +825,7 @@ fu_history_modify_device_release(FuHistory *self,
 	    fwupd_checksum_get_by_kind(fu_device_get_checksums(device), G_CHECKSUM_SHA1),
 	    -1,
 	    SQLITE_STATIC);
-	sqlite3_bind_int64(stmt, 7, fu_device_get_modified(device));
+	sqlite3_bind_int64(stmt, 7, fu_device_get_modified_usec(device) / G_USEC_PER_SEC);
 	sqlite3_bind_text(stmt, 8, metadata, -1, SQLITE_STATIC);
 
 	return fu_history_stmt_exec(self, stmt, NULL, error);
@@ -925,8 +925,8 @@ fu_history_add_device(FuHistory *self, FuDevice *device, FuRelease *release, GEr
 	sqlite3_bind_text(stmt, 8, fu_device_get_plugin(device), -1, SQLITE_STATIC);
 	sqlite3_bind_text(stmt, 9, fu_device_get_guid_default(device), -1, SQLITE_STATIC);
 	sqlite3_bind_text(stmt, 10, metadata, -1, SQLITE_STATIC);
-	sqlite3_bind_int64(stmt, 11, fu_device_get_created(device));
-	sqlite3_bind_int64(stmt, 12, fu_device_get_modified(device));
+	sqlite3_bind_int64(stmt, 11, fu_device_get_created_usec(device) / G_USEC_PER_SEC);
+	sqlite3_bind_int64(stmt, 12, fu_device_get_modified_usec(device) / G_USEC_PER_SEC);
 	sqlite3_bind_text(stmt, 13, fu_device_get_version(device), -1, SQLITE_STATIC);
 	sqlite3_bind_text(stmt, 14, fu_release_get_version(release), -1, SQLITE_STATIC);
 	sqlite3_bind_text(stmt, 15, checksum_device, -1, SQLITE_STATIC);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2534,7 +2534,7 @@ fu_engine_history_func(gconstpointer user_data)
 	fu_device_add_checksum(device, "0123456789abcdef0123456789abcdef01234567");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
@@ -2587,7 +2587,7 @@ fu_engine_history_func(gconstpointer user_data)
 	g_assert_nonnull(device2);
 	g_assert_cmpint(fu_device_get_update_state(device2), ==, FWUPD_UPDATE_STATE_SUCCESS);
 	g_assert_cmpstr(fu_device_get_update_error(device2), ==, NULL);
-	fu_device_set_modified(device2, 1514338000);
+	fu_device_set_modified_usec(device2, 1514338000ull * G_USEC_PER_SEC);
 	g_hash_table_remove_all(fwupd_release_get_metadata(fu_device_get_release_default(device2)));
 	device_str = fu_device_to_string(device2);
 	checksum = fu_input_stream_compute_checksum(stream, G_CHECKSUM_SHA1, &error);
@@ -2667,7 +2667,7 @@ fu_engine_history_verfmt_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_internal_flag(device, FU_DEVICE_INTERNAL_FLAG_MD_SET_VERFMT);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	g_assert_cmpint(fu_device_get_version_format(device), ==, FWUPD_VERSION_FORMAT_TRIPLET);
 	g_assert_cmpstr(fu_device_get_version(device), ==, "0.1.27");
@@ -2726,7 +2726,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_ALL_RELEASES);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 
 	filename = g_test_build_filename(G_TEST_BUILT,
@@ -2853,7 +2853,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
@@ -2993,7 +2993,7 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
@@ -3105,7 +3105,7 @@ fu_engine_install_request(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_request_flag(device, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
@@ -3200,7 +3200,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_set_created(device, 1515338000);
+	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
 	fu_engine_add_device(engine, device);
 	devices = fu_engine_get_devices(engine, &error);
 	g_assert_no_error(error);
@@ -3246,7 +3246,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	g_assert_cmpint(fu_device_get_update_state(device2), ==, FWUPD_UPDATE_STATE_FAILED);
 	g_assert_cmpstr(fu_device_get_update_error(device2), ==, error->message);
 	g_clear_error(&error);
-	fu_device_set_modified(device2, 1514338000);
+	fu_device_set_modified_usec(device2, 1514338000ull * G_USEC_PER_SEC);
 	g_hash_table_remove_all(fwupd_release_get_metadata(fu_device_get_release_default(device2)));
 	device_str = fu_device_to_string(device2);
 	checksum = fu_input_stream_compute_checksum(stream, G_CHECKSUM_SHA1, &error);
@@ -4407,8 +4407,8 @@ fu_history_func(gconstpointer user_data)
 	fu_device_set_update_error(device, "word");
 	fu_device_add_guid(device, "827edddd-9bb6-5632-889f-2c01255503da");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
-	fu_device_set_created(device, 123);
-	fu_device_set_modified(device, 456);
+	fu_device_set_created_usec(device, 1514338000ull * G_USEC_PER_SEC);
+	fu_device_set_modified_usec(device, 1514338999ull * G_USEC_PER_SEC);
 	release = fu_release_new();
 	fu_release_set_filename(release, "/var/lib/dave.cap"),
 	    fu_release_add_checksum(release, "abcdef");
@@ -4441,8 +4441,8 @@ fu_history_func(gconstpointer user_data)
 	g_assert_cmpint(fu_device_get_flags(device),
 			==,
 			FWUPD_DEVICE_FLAG_INTERNAL | FWUPD_DEVICE_FLAG_HISTORICAL);
-	g_assert_cmpint(fu_device_get_created(device), ==, 123);
-	g_assert_cmpint(fu_device_get_modified(device), ==, 456);
+	g_assert_cmpint(fu_device_get_created_usec(device), ==, 1514338000ull * G_USEC_PER_SEC);
+	g_assert_cmpint(fu_device_get_modified_usec(device), ==, 1514338999ull * G_USEC_PER_SEC);
 	release = FU_RELEASE(fu_device_get_release_default(device));
 	g_assert_nonnull(release);
 	g_assert_cmpstr(fu_release_get_version(release), ==, "3.0.2");


### PR DESCRIPTION
It might have been set from emulation data.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
