### PR TITLE
trivial: Reset the device event index when clearing events

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -6744,6 +6744,7 @@ fu_device_clear_events(FuDevice *self)
 	if (priv->events == NULL)
 		return;
 	g_ptr_array_set_size(priv->events, 0);
+	priv->event_idx = 0;
 }
 
 static void


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
