### PR TITLE
Add a plugin to handle AMD Kria SoM

### DIFF
--- a/contrib/codespell.cfg
+++ b/contrib/codespell.cfg
@@ -1,4 +1,4 @@
 [codespell]
 builtin = clear,informal,en-GB_to_en-US
 skip = *.po,*.csv,*.svg,*.p7c,subprojects,.git,pcrs,build*,.ossfuzz,*/tests/*,contrib/codespell.cfg
-ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname,wel,FPT,$FPT,inout
+ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname,wel,FPT,$FPT,inout,som,SoM

--- a/plugins/amd-kria/README.md
+++ b/plugins/amd-kria/README.md
@@ -1,0 +1,39 @@
+# AMD Kria
+
+The AMD Kria plugin is used to represent the system firmware stored on QSPI
+for the AMD Kria system on module device specifically when not booted using
+UEFI support in U-Boot.  **When UEFI support is used the plugin will be disabled.**
+
+It uses the devices created by the mtd plugin to discover the firmware
+version and uses the known behavior of U-Boot ESP handling to distribute
+updates to the device.
+
+U-Boot will automatically pick up the firmware (so no efivars are needed) and
+will also clean up the firmware after upgrade is completed.
+
+## GUID Generation
+
+These devices use a GUID generation scheme that reflects data stored in the
+EEPROM on the board the Kria SoM is inserted into.
+
+* `UEFI\VENDOR_XILINX`
+* `UEFI\VENDOR_XILINX&PRODUCT_SMK-K26-XCL2G`
+
+## Firmware Format
+
+The firmware is distributed in UEFI capsule format and it's format is described
+in <https://xilinx.github.io/kria-apps-docs/bootfw/build/html/docs/bootfw_overview.html>.
+
+* `org.uefi.capsule`
+
+## Quirks
+
+* `AmdKriaEepromAddr` represents the I2C address for the SoM EEPROM
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Mario Limonciello: @superm1
+* Michal Simek @michalsimek

--- a/plugins/amd-kria/eeprom.txt
+++ b/plugins/amd-kria/eeprom.txt
@@ -1,0 +1,50 @@
+$ sudo ipmi-fru --fru-file=/sys/bus/i2c/devices/1-0051/eeprom --interpret-oem-data
+FRU Inventory From File: /sys/bus/i2c/devices/1-0051/eeprom
+
+  FRU Board Manufacturing Date/Time: 05/13/24 - 18:26:00
+  FRU Board Manufacturer: XILINX
+  FRU Board Product Name: SCK-KV-G
+  FRU Board Serial Number: XFL1XEYN4SLK
+  FRU Board Part Number: 5066-01
+  FRU FRU File ID: 00h
+  FRU Board Custom Info: 1
+  FRU Board Custom Info: 10h EEh 00h 00h 00h 00h 00h 00h
+  FRU Board Custom Info: C5h 4Eh 65h 57h B5h 9Ah 4Bh 48h A0h C4h 53h 7Ah 9Fh 53h B0h CBh
+
+  FRU DC Load Output Number: 1
+  FRU DC Load Nominal Voltage: 12000 mV
+  FRU DC Load Spec'd Minimum Voltage: 11500 mV
+  FRU DC Load Spec'd Maximum Voltage: 12500 mV
+  FRU DC Load Spec'd Ripple and Noise pk-pk: 100 mV
+  FRU DC Load Minimum Current Load: 0 mA
+  FRU DC Load Maximum Current Load: 3000 mA
+
+  FRU Error: multirecord area checksum invalid
+ipmi_fru_next: multirecord area checksum invalid
+$ sudo ipmi-fru --fru-file=/sys/bus/i2c/devices/1-0050/eeprom --interpret-oem-data
+FRU Inventory From File: /sys/bus/i2c/devices/1-0050/eeprom
+
+  FRU Board Manufacturing Date/Time: 05/13/24 - 18:28:00
+  FRU Board Manufacturer: XILINX
+  FRU Board Product Name: SMK-K26-XCL2G
+  FRU Board Serial Number: XFL1T4UVG44P
+  FRU Board Part Number: 5057-01
+  FRU FRU File ID: 00h
+  FRU Board Custom Info: 1
+  FRU Board Custom Info: 10h EEh 00h 00h 00h 00h 00h 00h
+  FRU Board Custom Info: 92h 2Ah B2h C5h F9h F1h 43h BFh 81h 38h DDh 73h 55h ABh 62h 71h
+
+  FRU DC Load Output Number: 1
+  FRU DC Load Nominal Voltage: 5000 mV
+  FRU DC Load Spec'd Minimum Voltage: 4500 mV
+  FRU DC Load Spec'd Maximum Voltage: 5500 mV
+  FRU DC Load Spec'd Ripple and Noise pk-pk: 100 mV
+  FRU DC Load Minimum Current Load: 0 mA
+  FRU DC Load Maximum Current Load: 4000 mA
+
+  FRU OEM Manufacturer ID: Xilinx, Inc. (10DAh)
+  FRU OEM MAC Version: DUT - MAC (31h)
+  FRU OEM MAC ID 0: 00:0a:35:17:98:8f
+
+  FRU Error: multirecord area checksum invalid
+ipmi_fru_next: multirecord area checksum invalid

--- a/plugins/amd-kria/fu-amd-kria-device.c
+++ b/plugins/amd-kria/fu-amd-kria-device.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2018 Richard Hughes <richard@hughsie.com>
+ * Copyright 2024 Advanced Micro Devices Inc.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-amd-kria-device.h"
+#include "fu-amd-kria-som-eeprom.h"
+
+typedef struct {
+	FuVolume *esp;
+	FuDeviceLocker *esp_locker;
+	gchar *eeprom_address;
+} FuAmdKriaDevicePrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(FuAmdKriaDevice, fu_amd_kria_device, FU_TYPE_I2C_DEVICE)
+
+#define GET_PRIVATE(o) (fu_amd_kria_device_get_instance_private(o))
+
+static void
+fu_amd_kria_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+	fwupd_codec_string_append(str, idt, "AmdKriaEepromAddr", priv->eeprom_address);
+}
+
+static gboolean
+fu_amd_kria_device_prepare(FuDevice *device,
+			   FuProgress *progress,
+			   FwupdInstallFlags flags,
+			   GError **error)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+
+	priv->esp_locker = fu_volume_locker(priv->esp, error);
+	if (priv->esp_locker == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_device_cleanup(FuDevice *device,
+			   FuProgress *progress,
+			   FwupdInstallFlags flags,
+			   GError **error)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (!fu_device_locker_close(priv->esp_locker, error))
+		return FALSE;
+	g_clear_object(&priv->esp_locker);
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_device_write_firmware(FuDevice *device,
+				  FuFirmware *firmware,
+				  FuProgress *progress,
+				  FwupdInstallFlags flags,
+				  GError **error)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+	g_autofree gchar *cod_path = NULL;
+	g_autoptr(GBytes) fw = NULL;
+
+	fw = fu_firmware_get_bytes(firmware, error);
+	if (fw == NULL)
+		return FALSE;
+	cod_path = g_build_filename(fu_volume_get_mount_point(priv->esp),
+				    "EFI", "UpdateCapsule", "fwupd.cap", NULL);
+	g_debug("using %s for capsule", cod_path);
+	if (!fu_path_mkdir_parent(cod_path, error))
+		return FALSE;
+	if (!fu_bytes_set_contents(cod_path, fw, error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_device_set_quirk_kv(FuDevice *device,
+				const gchar *key,
+				const gchar *value,
+				GError **error)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (g_strcmp0(key, "AmdKriaEepromAddr") == 0) {
+		priv->eeprom_address = g_strdup(value);
+		return TRUE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_device_probe(FuDevice *device, GError **error)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(device);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	const gchar *tmp;
+	g_auto(GStrv) of_name = NULL;
+
+	/* FuI2cDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_amd_kria_device_parent_class)->probe(device, error))
+		return FALSE;
+
+	/*
+	 * Fetch the OF_FULLNAME udev property and look for the I2C address in it
+	 * sample format: OF_FULLNAME=/axi/i2c@ff030000/eeprom@50
+	 */
+	tmp = g_udev_device_get_property(udev_device, "OF_FULLNAME");
+	if (tmp == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no OF_FULLNAME property");
+		return FALSE;
+	}
+	of_name = fu_strsplit(tmp, strlen(tmp), "@", -1);
+	if (of_name == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "no '@' found in %s", tmp);
+		return FALSE;
+	}
+	tmp = of_name[g_strv_length(of_name) - 1];
+
+	if (g_strcmp0(priv->eeprom_address, tmp) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "invalid device");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_device_setup(FuDevice *device, GError **error)
+{
+	const gchar *devpath = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
+	gsize bufsz = 0;
+	g_autofree gchar *buf = NULL;
+	g_autofree gchar *vendor_id = NULL;
+	g_autofree gchar *path = g_build_path("/", devpath, "eeprom", NULL);
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(GError) error_esp = NULL;
+	g_autoptr(GBytes) bytes = NULL;
+
+	if (!g_file_get_contents(path, &buf, &bufsz, error))
+		return FALSE;
+
+	/* parse the eeprom */
+	bytes = g_bytes_new(buf, bufsz);
+	firmware = fu_amd_kria_som_eeprom_new();
+	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+		return FALSE;
+
+	/* build instance IDs from EEPROM data */
+	fu_device_set_vendor(device, fu_amd_kria_som_get_manufacturer(FU_AMD_KRIA_SOM_EEPROM(firmware)));
+	vendor_id = g_strdup_printf("DMI:%s", fu_device_get_vendor(device));
+	fu_device_add_vendor_id(device, vendor_id);
+	fu_device_add_instance_str(device, "VENDOR", fu_device_get_vendor(device));
+	fu_device_add_instance_str(device, "PRODUCT", fu_amd_kria_som_get_product_name(FU_AMD_KRIA_SOM_EEPROM(firmware)));
+	fu_device_set_serial(device, fu_amd_kria_som_get_serial_number(FU_AMD_KRIA_SOM_EEPROM(firmware)));
+	if (!fu_device_build_instance_id(device, error, "UEFI", "VENDOR", NULL))
+		return FALSE;
+	if (!fu_device_build_instance_id(device, error, "UEFI", "VENDOR", "PRODUCT", NULL))
+		return FALSE;
+
+	return TRUE;
+}
+
+static void
+fu_amd_kria_device_constructed(GObject *obj)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(obj);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+	FuContext *ctx;
+	g_autoptr(GError) error_esp = NULL;
+
+	/* setup the default ESP */
+	ctx = fu_device_get_context(FU_DEVICE(obj));
+	priv->esp = fu_context_get_default_esp(ctx, &error_esp);
+	if (priv->esp == NULL)
+		fu_device_inhibit(FU_DEVICE(obj), "no-esp", error_esp->message);
+}
+
+static void
+fu_amd_kria_device_init(FuAmdKriaDevice *self)
+{
+	fu_device_set_name(FU_DEVICE(self), "System Firmware");
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_logical_id(FU_DEVICE(self), "U-Boot");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_icon(FU_DEVICE(self), "computer");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_device_set_summary(FU_DEVICE(self),
+			      "AMD Kria device (Updated via capsule-on-disk)");
+	fu_device_add_protocol(FU_DEVICE(self), "org.uefi.capsule");
+}
+
+static void
+fu_amd_kria_finalize(GObject *object)
+{
+	FuAmdKriaDevice *self = FU_AMD_KRIA_DEVICE(object);
+	FuAmdKriaDevicePrivate *priv = GET_PRIVATE(self);
+
+	if (priv->esp != NULL)
+		g_object_unref(priv->esp);
+	if (priv->esp_locker != NULL)
+		g_object_unref(priv->esp_locker);
+	g_free(priv->eeprom_address);
+
+	G_OBJECT_CLASS(fu_amd_kria_device_parent_class)->finalize(object);
+}
+
+
+static void
+fu_amd_kria_device_class_init(FuAmdKriaDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+
+	object_class->finalize = fu_amd_kria_finalize;
+	object_class->constructed = fu_amd_kria_device_constructed;
+
+	device_class->set_quirk_kv = fu_amd_kria_device_set_quirk_kv;
+	device_class->setup = fu_amd_kria_device_setup;
+	device_class->prepare = fu_amd_kria_device_prepare;
+	device_class->cleanup = fu_amd_kria_device_cleanup;
+	device_class->probe = fu_amd_kria_device_probe;
+	device_class->write_firmware = fu_amd_kria_device_write_firmware;
+	device_class->to_string = fu_amd_kria_device_to_string;
+}

--- a/plugins/amd-kria/fu-amd-kria-device.h
+++ b/plugins/amd-kria/fu-amd-kria-device.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 Richard Hughes <richard@hughsie.com>
+ * Copyright 2024 Advanced Micro Devices Inc.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_AMD_KRIA_DEVICE (fu_amd_kria_device_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuAmdKriaDevice, fu_amd_kria_device, FU, AMD_KRIA_DEVICE, FuI2cDevice)
+
+struct _FuAmdKriaDeviceClass {
+	FuDeviceClass parent_class;
+};

--- a/plugins/amd-kria/fu-amd-kria-image-reg.c
+++ b/plugins/amd-kria/fu-amd-kria-image-reg.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#include "config.h"
+
+#include "fu-amd-kria-image-reg.h"
+
+struct _FuAmdKriaImageFirmware {
+	FuFirmwareClass parent_instance;
+};
+
+#define VERSION_OFFSET	0x70
+#define VERSION_SIZE	0x24
+
+G_DEFINE_TYPE(FuAmdKriaImageFirmware, fu_amd_kria_image_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_amd_kria_image_firmware_parse(FuFirmware *firmware,
+			         GInputStream *stream,
+			         gsize offset,
+			         FwupdInstallFlags flags,
+			         GError **error)
+{
+	const gchar *buf;
+	gsize bufsz = 0;
+	g_autoptr(GBytes) fw = NULL;
+	g_autofree gchar *version = NULL;
+
+	fw = fu_input_stream_read_bytes(stream, offset + VERSION_OFFSET, VERSION_SIZE, error);
+	if (fw == NULL)
+		return FALSE;
+
+	buf = g_bytes_get_data(fw, &bufsz);
+
+	version = fu_strsafe(buf, bufsz);
+	if (version == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_SIGNATURE_INVALID, "no valid version");
+		return FALSE;
+	}
+
+	fu_firmware_set_version(FU_FIRMWARE(firmware), version);
+
+	return TRUE;
+}
+
+static void
+fu_amd_kria_image_firmware_init(FuAmdKriaImageFirmware *self)
+{
+}
+
+static void
+fu_amd_kria_image_firmware_class_init(FuAmdKriaImageFirmwareClass *klass)
+{
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_amd_kria_image_firmware_parse;
+}
+
+FuFirmware *
+fu_amd_kria_image_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_AMD_KRIA_IMAGE_FIRMWARE, NULL));
+}

--- a/plugins/amd-kria/fu-amd-kria-image-reg.h
+++ b/plugins/amd-kria/fu-amd-kria-image-reg.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_AMD_KRIA_IMAGE_FIRMWARE (fu_amd_kria_image_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuAmdKriaImageFirmware,
+		     fu_amd_kria_image_firmware,
+		     FU,
+		     AMD_KRIA_IMAGE_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_amd_kria_image_firmware_new(void);

--- a/plugins/amd-kria/fu-amd-kria-persistent-reg.c
+++ b/plugins/amd-kria/fu-amd-kria-persistent-reg.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#include "config.h"
+
+#include "fu-amd-kria-persistent-struct.h"
+#include "fu-amd-kria-persistent-reg.h"
+
+struct _FuAmdKriaPersistentFirmware {
+	FuFirmwareClass parent_instance;
+	BootImageId last_booted;
+};
+
+G_DEFINE_TYPE(FuAmdKriaPersistentFirmware, fu_amd_kria_persistent_firmware, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_amd_kria_persistent_firmware_parse(FuFirmware *firmware,
+				      GInputStream *stream,
+				      gsize offset,
+				      FwupdInstallFlags flags,
+				      GError **error)
+{
+	FuAmdKriaPersistentFirmware *self = FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware);
+	g_autoptr(FuStructAmdKriaPersistReg) content = NULL;
+
+	content = fu_struct_amd_kria_persist_reg_parse_stream(stream, offset, error);
+	if (content == NULL)
+		return FALSE;
+	self->last_booted = fu_struct_amd_kria_persist_reg_get_last_booted_img(content);
+
+	return TRUE;
+}
+
+gboolean
+fu_amd_kria_persistent_booted_image_a(FuAmdKriaPersistentFirmware *self)
+{
+	return self->last_booted == BOOT_IMAGE_ID_A;
+}
+
+static void
+fu_amd_kria_persistent_firmware_init(FuAmdKriaPersistentFirmware *self)
+{
+}
+
+static void
+fu_amd_kria_persistent_firmware_export(FuFirmware *firmware,
+				       FuFirmwareExportFlags flags,
+				       XbBuilderNode *bn)
+{
+	FuAmdKriaPersistentFirmware *self = FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware);
+
+	fu_xmlb_builder_insert_kv(bn, "last_booted", self->last_booted == BOOT_IMAGE_ID_A ? "A": "B");
+}
+
+static void
+fu_amd_kria_persistent_firmware_class_init(FuAmdKriaPersistentFirmwareClass *klass)
+{
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_amd_kria_persistent_firmware_parse;
+	firmware_class->export = fu_amd_kria_persistent_firmware_export;
+}
+
+FuFirmware *
+fu_amd_kria_persistent_firmware_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_AMD_KRIA_PERSISTENT_FIRMWARE, NULL));
+}

--- a/plugins/amd-kria/fu-amd-kria-persistent-reg.h
+++ b/plugins/amd-kria/fu-amd-kria-persistent-reg.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_AMD_KRIA_PERSISTENT_FIRMWARE (fu_amd_kria_persistent_firmware_get_type())
+G_DECLARE_FINAL_TYPE(FuAmdKriaPersistentFirmware,
+		     fu_amd_kria_persistent_firmware,
+		     FU,
+		     AMD_KRIA_PERSISTENT_FIRMWARE,
+		     FuFirmware)
+
+FuFirmware *
+fu_amd_kria_persistent_firmware_new(void);
+
+gboolean
+fu_amd_kria_persistent_booted_image_a(FuAmdKriaPersistentFirmware *self);

--- a/plugins/amd-kria/fu-amd-kria-persistent.rs
+++ b/plugins/amd-kria/fu-amd-kria-persistent.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 Advanced Micro Devices Inc.
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+
+#[derive(ParseStream)]
+struct FuStructAmdKriaPersistReg {
+    id_sig: [char; 4] == "ABUM",
+    ver: u32,
+    len: u32,
+    checksum: u32,
+    last_booted_img: u8,
+    requested_booted_img: u8,
+    img_b_bootable: u8,
+    img_a_bootable: u8,
+    img_a_offset: u32,
+    img_b_offset: u32,
+    recovery_offset: u32,
+}
+
+
+#[repr(u8)]
+enum BootImageId {
+    A = 0x00,
+    B = 0x01,
+}

--- a/plugins/amd-kria/fu-amd-kria-plugin.c
+++ b/plugins/amd-kria/fu-amd-kria-plugin.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#include "config.h"
+
+#include "fu-amd-kria-plugin.h"
+#include "fu-amd-kria-device.h"
+#include "fu-amd-kria-image-reg.h"
+#include "fu-amd-kria-persistent-reg.h"
+#include "fu-amd-kria-som-eeprom.h"
+
+struct _FuAmdKriaPlugin {
+	FuPlugin parent_instance;
+	gchar *version_a;
+	gchar *version_b;
+	const gchar *active;
+};
+
+G_DEFINE_TYPE(FuAmdKriaPlugin, fu_amd_kria_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_amd_kria_plugin_init(FuAmdKriaPlugin *self)
+{
+}
+
+static gboolean
+fu_amd_kria_plugin_process_image(FuPlugin *plugin, FuDevice *dev, GError **error)
+{
+	g_autoptr(GBytes) bytes = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(NULL);
+
+	bytes = fu_device_dump_firmware(dev, progress, error);
+	if (bytes == NULL)
+		return FALSE;
+	firmware = fu_amd_kria_image_firmware_new();
+
+	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+		return FALSE;
+
+	fu_device_set_version(dev, fu_firmware_get_version(firmware));
+
+	return TRUE;
+}
+
+static gboolean
+fu_amd_kria_plugin_process_persistent(FuPlugin *plugin, FuDevice *dev, GError **error)
+{
+	FuAmdKriaPlugin *self = FU_AMD_KRIA_PLUGIN(plugin);
+	g_autoptr(GBytes) bytes = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(NULL);
+
+	bytes = fu_device_dump_firmware(dev, progress, error);
+	if (bytes == NULL)
+		return FALSE;
+	firmware = fu_amd_kria_persistent_firmware_new();
+
+	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+		return FALSE;
+
+	if (fu_amd_kria_persistent_booted_image_a(FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware)))
+		self->active = "A";
+	else
+		self->active = "B";
+
+	return TRUE;
+}
+
+static void
+fu_amd_kria_plugin_device_registered(FuPlugin *plugin, FuDevice *dev)
+{
+	FuAmdKriaPlugin *self;
+	const gchar *name;
+	g_autoptr(GError) error_local = NULL;
+
+	if (g_strcmp0(fu_device_get_plugin(dev), "mtd") != 0)
+		return;
+
+	self = FU_AMD_KRIA_PLUGIN(plugin);
+	name = fu_device_get_name(dev);
+	if (g_strcmp0(name, "Image A") == 0) {
+		if (!fu_amd_kria_plugin_process_image(plugin, dev, &error_local))
+			g_warning("%s", error_local->message);
+		self->version_a = g_strdup(fu_device_get_version(dev));
+	} else if (g_strcmp0(name, "Image B") == 0) {
+		if (!fu_amd_kria_plugin_process_image(plugin, dev, &error_local))
+			g_warning("%s", error_local->message);
+		self->version_b = g_strdup(fu_device_get_version(dev));
+	} else if (g_strcmp0(name, "Persistent Register") == 0) {
+		if (!fu_amd_kria_plugin_process_persistent(plugin, dev, &error_local))
+			g_warning("%s", error_local->message);
+	}
+
+	/* mark the active partition version on the created KRIA device */
+	if (fu_device_get_parent(dev) != NULL && fu_device_get_version(dev) != NULL) {
+		if (g_strcmp0(self->active, "A") == 0 && self->version_a != NULL)
+			fu_device_set_version(fu_device_get_parent(dev), self->version_a);
+		else if (g_strcmp0(self->active, "B") == 0 && self->version_b != NULL)
+			fu_device_set_version(fu_device_get_parent(dev), self->version_b);
+		fu_device_add_flag(fu_device_get_parent(dev), FWUPD_DEVICE_FLAG_UPDATABLE);
+	}
+
+	fu_device_remove_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+}
+
+static void
+fu_amd_kria_plugin_to_string(FuPlugin *plugin, guint idt, GString *str)
+{
+	FuAmdKriaPlugin *self = FU_AMD_KRIA_PLUGIN(plugin);
+
+	fwupd_codec_string_append(str, idt, "VersionA", self->version_a);
+	fwupd_codec_string_append(str, idt, "VersionB", self->version_b);
+	fwupd_codec_string_append(str, idt, "Activeimage", self->active);
+}
+
+static gboolean
+fu_amd_kria_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	g_autofree gchar *sysfsfwdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW);
+	g_autofree gchar *esrt_path = g_build_filename(sysfsfwdir, "efi", "esrt", NULL);
+
+#if !defined(__aarch64__)
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "only for aarch64");
+	return FALSE;
+#endif
+
+	/* If there is an ESRT use that instead and disable the plugin */
+	if (g_file_test(esrt_path, G_FILE_TEST_IS_DIR)) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "system uses UEFI ESRT");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void
+fu_amd_kria_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+
+	/* for parsing QSPI in registered callback */
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_IMAGE_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_PERSISTENT_FIRMWARE);
+
+	/* for reading FRU inventory */
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMD_KRIA_DEVICE);
+	fu_plugin_add_udev_subsystem(plugin, "i2c");
+	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_SOM_EEPROM);
+}
+
+static void
+fu_amd_kria_plugin_finalize(GObject *obj)
+{
+	FuAmdKriaPlugin *self = FU_AMD_KRIA_PLUGIN(obj);
+
+	g_free(self->version_a);
+	g_free(self->version_b);
+	G_OBJECT_CLASS(fu_amd_kria_plugin_parent_class)->finalize(obj);
+}
+
+static void
+fu_amd_kria_plugin_class_init(FuAmdKriaPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	object_class->finalize = fu_amd_kria_plugin_finalize;
+
+	plugin_class->startup = fu_amd_kria_plugin_startup;
+	plugin_class->device_registered = fu_amd_kria_plugin_device_registered;
+	plugin_class->constructed = fu_amd_kria_plugin_constructed;
+	plugin_class->to_string = fu_amd_kria_plugin_to_string;
+}

--- a/plugins/amd-kria/fu-amd-kria-plugin.h
+++ b/plugins/amd-kria/fu-amd-kria-plugin.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuAmdKriaPlugin, fu_amd_kria_plugin, FU, AMD_KRIA_PLUGIN, FuPlugin)

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#include "config.h"
+
+#include "fu-amd-kria-som-eeprom-struct.h"
+#include "fu-amd-kria-som-eeprom.h"
+
+struct _FuAmdKriaSomEeprom {
+	FuFirmwareClass parent_instance;
+	gchar *manufacturer;
+	gchar *product_name;
+	gchar *serial_number;
+};
+
+G_DEFINE_TYPE(FuAmdKriaSomEeprom, fu_amd_kria_som_eeprom, FU_TYPE_FIRMWARE)
+
+/* IPMI spec encodes 0:5 as length and 6:7 as "type" code */
+#define LENGTH(data)	data & 0x3f
+#define TYPE_CODE(data)	data >> 6
+
+static gboolean
+fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
+			     GInputStream *stream,
+			     gsize offset,
+			     FwupdInstallFlags flags,
+			     GError **error)
+{
+	FuAmdKriaSomEeprom *self = FU_AMD_KRIA_SOM_EEPROM(firmware);
+	guint8 str_len = 0;
+	guint8 str_offset = FU_STRUCT_BOARD_INFO_OFFSET_MANUFACTURER_LEN;
+	guint8 board_offset;
+	const guint8 *buf;
+	gsize bufsz = 0;
+	g_autoptr(FuStructIpmiCommon) common = NULL;
+	g_autoptr(FuStructBoardInfo) board = NULL;
+	g_autoptr(GBytes) fw = NULL;
+
+	/* parse IPMI common header */
+	common = fu_struct_ipmi_common_parse_stream(stream, offset, error);
+	if (common == NULL)
+		return FALSE;
+	board_offset = offset + fu_struct_ipmi_common_get_board_offset(common) * 8;
+
+	/* parse board info area */
+	board = fu_struct_board_info_parse_stream(stream, board_offset, error);
+	if (board == NULL)
+		return FALSE;
+
+	fw = fu_input_stream_read_bytes(stream, board_offset,
+					fu_struct_board_info_get_length(board) * 8,
+					error);
+	if (fw == NULL)
+		return FALSE;
+	buf = fu_bytes_get_data_safe(fw, &bufsz, error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* manufacturer string in board area */
+	str_offset = str_offset + str_len;
+	str_len = LENGTH(buf[str_offset]);
+	str_offset++;
+	self->manufacturer = fu_strsafe((gchar *) buf + str_offset, str_len);
+
+	str_offset = str_offset + str_len;
+	str_len = LENGTH(buf[str_offset]);
+	str_offset++;
+	self->product_name = fu_strsafe((gchar *) buf + str_offset, str_len);
+
+	str_offset = str_offset + str_len;
+	str_len = LENGTH(buf[str_offset]);
+	str_offset++;
+	self->serial_number = fu_strsafe((gchar *) buf + str_offset, str_len);
+
+	return TRUE;
+}
+
+const gchar *
+fu_amd_kria_som_get_manufacturer(FuAmdKriaSomEeprom *self)
+{
+	return self->manufacturer;
+}
+
+const gchar *
+fu_amd_kria_som_get_product_name(FuAmdKriaSomEeprom *self)
+{
+	return self->product_name;
+}
+
+const gchar *
+fu_amd_kria_som_get_serial_number(FuAmdKriaSomEeprom *self)
+{
+	return self->serial_number;
+}
+
+static void
+fu_amd_kria_som_eeprom_export(FuFirmware *firmware,
+			      FuFirmwareExportFlags flags,
+			      XbBuilderNode *bn)
+{
+	FuAmdKriaSomEeprom *self = FU_AMD_KRIA_SOM_EEPROM(firmware);
+
+	fu_xmlb_builder_insert_kv(bn, "manufacturer", self->manufacturer);
+	fu_xmlb_builder_insert_kv(bn, "product_name", self->product_name);
+	fu_xmlb_builder_insert_kv(bn, "serial_number", self->serial_number);
+}
+
+static void
+fu_amd_kria_som_eeprom_init(FuAmdKriaSomEeprom *self)
+{
+}
+
+static void
+fu_amd_kria_som_eeprom_finalize(GObject *object)
+{
+	FuAmdKriaSomEeprom *self = FU_AMD_KRIA_SOM_EEPROM(object);
+
+	g_free(self->manufacturer);
+	g_free(self->product_name);
+	g_free(self->serial_number);
+
+	G_OBJECT_CLASS(fu_amd_kria_som_eeprom_parent_class)->finalize(object);
+}
+static void
+fu_amd_kria_som_eeprom_class_init(FuAmdKriaSomEepromClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	object_class->finalize = fu_amd_kria_som_eeprom_finalize;
+	firmware_class->parse = fu_amd_kria_som_eeprom_parse;
+	firmware_class->export = fu_amd_kria_som_eeprom_export;
+}
+
+FuFirmware *
+fu_amd_kria_som_eeprom_new(void)
+{
+	return FU_FIRMWARE(g_object_new(FU_TYPE_AMD_KRIA_SOM_EEPROM, NULL));
+}

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.h
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Advanced Micro Devices Inc.
+ * All rights reserved.
+ *
+ * This file is provided under a dual MIT/LGPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ * AMD Chooses the MIT license part of Dual MIT/LGPLv2 license agreement.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_AMD_KRIA_SOM_EEPROM (fu_amd_kria_som_eeprom_get_type())
+G_DECLARE_FINAL_TYPE(FuAmdKriaSomEeprom,
+		     fu_amd_kria_som_eeprom,
+		     FU,
+		     AMD_KRIA_SOM_EEPROM,
+		     FuFirmware)
+
+FuFirmware *
+fu_amd_kria_som_eeprom_new(void);
+
+const gchar *
+fu_amd_kria_som_get_manufacturer(FuAmdKriaSomEeprom *self);
+const gchar *
+fu_amd_kria_som_get_product_name(FuAmdKriaSomEeprom *self);
+const gchar *
+fu_amd_kria_som_get_serial_number(FuAmdKriaSomEeprom *self);

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.rs
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.rs
@@ -1,0 +1,33 @@
+// Copyright 2024 Advanced Micro Devices Inc.
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+
+// https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-platform-mgt-fru-info-storage-def-v1-0-rev-1-3-spec-update.pdf
+
+#[derive(ParseStream)]
+struct FuStructIpmiCommon {
+    version: u8 = 0x1,
+    internal_offest: u8,
+    chassis_offeset: u8,
+    board_offset: u8,
+    product_offset: u8,
+    multirecord_offset: u8,
+    reserved: u8,
+    checksum: u8,
+}
+
+#[derive(ParseStream)]
+struct FuStructBoardInfo {
+    version: u8 = 0x1,
+    length: u8,
+    lang_code: u8,
+    mfg_date: u24le,
+    manufacturer_len: u8,
+}
+
+#[repr(u8)]
+enum TypeCode {
+    Binary = 0,
+    BcdPlus = 1,
+    Acsii6 = 2,
+    LangCodeDep = 3,
+}

--- a/plugins/amd-kria/kria.quirk
+++ b/plugins/amd-kria/kria.quirk
@@ -1,0 +1,29 @@
+[I2C\NAME_24c64]
+Plugin = amd_kria
+AmdKriaEepromAddr = 50
+
+# KV260
+[MTD\VENDOR_xlnx&NAME_Image-A-FSBL-PMU-ATF-U-Boot]
+Name = Image A
+ParentGuid = UEFI\VENDOR_XILINX
+[MTD\VENDOR_xlnx&NAME_Image-B-FSBL-PMU-ATF-U-Boot]
+Name = Image B
+ParentGuid = UEFI\VENDOR_XILINX
+[MTD\VENDOR_xlnx&NAME_Persistent-Register]
+Name = Persistent Register
+ParentGuid = UEFI\VENDOR_XILINX
+[MTD\VENDOR_xlnx&NAME_Persistent-Register-Backup]
+Name = Persistent Register Backup
+ParentGuid = UEFI\VENDOR_XILINX
+[MTD\VENDOR_xlnx&NAME_Open-1]
+Flags = no-probe
+[MTD\VENDOR_xlnx&NAME_Open-2]
+Flags = no-probe
+[MTD\VENDOR_xlnx&NAME_Secure-OS-Storage]
+Flags = no-probe
+[MTD\VENDOR_xlnx&NAME_U-Boot-storage-variables]
+Flags = no-probe
+[MTD\VENDOR_xlnx&NAME_U-Boot-storage-variables-backup]
+Flags = no-probe
+[MTD\VENDOR_xlnx&NAME_User]
+Flags = no-probe

--- a/plugins/amd-kria/meson.build
+++ b/plugins/amd-kria/meson.build
@@ -1,0 +1,25 @@
+if gudev.found() and get_option('plugin_mtd').allowed()
+cargs = ['-DG_LOG_DOMAIN="FuPluginAmdKria"']
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+
+plugin_quirks += files('kria.quirk')
+plugin_builtin_kria = static_library('fu_plugin_amd_kria',
+  rustgen.process(
+    'fu-amd-kria-persistent.rs',          # fuzzing
+    'fu-amd-kria-som-eeprom.rs',          # fuzzing
+  ),
+  sources: [
+    'fu-amd-kria-plugin.c',
+    'fu-amd-kria-device.c',
+    'fu-amd-kria-image-reg.c',
+    'fu-amd-kria-persistent-reg.c',
+    'fu-amd-kria-som-eeprom.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+plugin_builtins += plugin_builtin_kria
+
+endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -22,6 +22,7 @@ plugins = {
   'acpi-phat': false,
   'algoltek-aux': false,
   'algoltek-usb': false,
+  'amd-kria': false,
   'amd-pmc': false,
   'amd-gpu': false,
   'analogix': false,

--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -16,21 +16,3 @@ Flags = no-probe
 [MTD\NAME_BIOS]
 Name = Internal SPI Controller
 #FirmwareGType = FuIfdFirmware
-
-# AMD Kria System on Module
-[MTD\VENDOR_xlnx&PRODUCT_ZynqMP-KV260-revB&NAME_Image-A-FSBL-PMU-ATF-U-Boot]
-Name = Image A
-[MTD\VENDOR_xlnx&PRODUCT_ZynqMP-KV260-revB&NAME_Image-B-FSBL-PMU-ATF-U-Boot]
-Name = Image B
-[MTD\VENDOR_xlnx&NAME_Open-1]
-Flags = no-probe
-[MTD\VENDOR_xlnx&NAME_Open-2]
-Flags = no-probe
-[MTD\VENDOR_xlnx&NAME_Secure-OS-Storage]
-Flags = no-probe
-[MTD\VENDOR_xlnx&NAME_U-Boot-storage-variables]
-Flags = no-probe
-[MTD\VENDOR_xlnx&NAME_U-Boot-storage-variables-backup]
-Flags = no-probe
-[MTD\VENDOR_xlnx&NAME_User]
-Flags = no-probe


### PR DESCRIPTION
The AMD Kria SoM https://www.amd.com/en/products/system-on-modules/kria.html is an aarch64 device that can be booted multiple ways.  When booted in UEFI mode, U-boot exports an ESRT and limited UEFI boot and runtime services such that CoD works.

When booted outside of UEFI mode U-boot can still handle updating via a capsule, but there is no ESRT to relay this information to the OS.  Instead add a plugin that detects that an ESRT is missing and pulls the version information from the MTD partition.

Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Note: this is draft to align on how this will work, it's still missing the ability to pull the firmware version out of the MTD partition.
