### PR TITLE
Support more CRC-32 types

### DIFF
--- a/contrib/codespell.cfg
+++ b/contrib/codespell.cfg
@@ -1,4 +1,4 @@
 [codespell]
 builtin = clear,informal,en-GB_to_en-US
 skip = *.po,*.csv,*.svg,*.p7c,subprojects,.git,pcrs,build*,.ossfuzz,*/tests/*,contrib/codespell.cfg
-ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname,wel,FPT,$FPT
+ignore-words-list = conexant,Conexant,gir,GIR,hsi,HSI,cancelled,Cancelled,te,mitre,distroname,wel,FPT,$FPT,inout

--- a/contrib/migrate.py
+++ b/contrib/migrate.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             "fu_common_crc16": "fu_crc16",
             "fu_common_crc16_full": "fu_crc16_full",
             "fu_common_crc32": "fu_crc32",
-            "fu_common_crc32_full": "fu_crc32_full",
+            "fu_common_crc32_full": "fu_crc32",
             "fu_byte_array_set_size_full": "fu_byte_array_set_size",
             "fu_common_string_replace": "g_string_replace",
             "fu_common_string_append_kv": "fwupd_codec_string_append",

--- a/libfwupdplugin/fu-crc.c
+++ b/libfwupdplugin/fu-crc.c
@@ -102,35 +102,108 @@ fu_crc16(const guint8 *buf, gsize bufsz)
 	return fu_crc16_full(buf, bufsz, 0xFFFF, 0xA001);
 }
 
+const struct {
+	FuCrc32Kind kind;
+	guint32 poly;
+	guint32 init;
+	gboolean reflected;
+	gboolean inverted;
+} crc32_map[] = {
+    {FU_CRC32_KIND_UNKNOWN, 0x00000000, 0x00000000, TRUE, TRUE},
+    {FU_CRC32_KIND_STANDARD, 0x04C11DB7, 0xFFFFFFFF, TRUE, TRUE},
+    {FU_CRC32_KIND_BZIP2, 0x04C11DB7, 0xFFFFFFFF, FALSE, TRUE},
+    {FU_CRC32_KIND_JAMCRC, 0x04C11DB7, 0xFFFFFFFF, TRUE, FALSE},
+    {FU_CRC32_KIND_MPEG2, 0x04C11DB7, 0xFFFFFFFF, FALSE, FALSE},
+    {FU_CRC32_KIND_POSIX, 0x04C11DB7, 0x00000000, FALSE, TRUE},
+    {FU_CRC32_KIND_SATA, 0x04C11DB7, 0x52325032, FALSE, FALSE},
+    {FU_CRC32_KIND_XFER, 0x000000AF, 0x00000000, FALSE, FALSE},
+    {FU_CRC32_KIND_C, 0x1EDC6F41, 0xFFFFFFFF, TRUE, TRUE},
+    {FU_CRC32_KIND_D, 0xA833982B, 0xFFFFFFFF, TRUE, TRUE},
+    {FU_CRC32_KIND_Q, 0x814141AB, 0x00000000, FALSE, FALSE},
+};
+
+static guint8
+_reflect8(guint8 data)
+{
+	guint8 val = 0;
+	for (guint8 bit = 0; bit < 8; bit++) {
+		if (data & 0x01)
+			val |= 1 << (7 - bit);
+		data = (data >> 1);
+	}
+	return val;
+}
+
+static guint32
+_reflect32(guint32 data)
+{
+	guint32 val = 0;
+	for (guint8 bit = 0; bit < 32; bit++) {
+		if (data & 0x01)
+			val |= 1ul << (31 - bit);
+		data = (data >> 1);
+	}
+	return val;
+}
+
 /**
- * fu_crc32_full:
+ * fu_crc32_step:
+ * @kind: a #FuCrc32Kind, typically %FU_CRC32_KIND_STANDARD
  * @buf: memory buffer
  * @bufsz: size of @buf
- * @crc: initial CRC value, typically 0xFFFFFFFF
- * @polynomial: CRC polynomial, typically 0xEDB88320
+ * @crc: initial CRC value
  *
- * Returns the cyclic redundancy check value for the given memory buffer.
+ * Computes the cyclic redundancy check section value for the given memory buffer.
+ *
+ * NOTE: When all data has been added, you should call fu_crc32_done() to return the final value.
  *
  * Returns: CRC value
  *
- * Since: 1.8.2
+ * Since: 2.0.0
  **/
 guint32
-fu_crc32_full(const guint8 *buf, gsize bufsz, guint32 crc, guint32 polynomial)
+fu_crc32_step(FuCrc32Kind kind, const guint8 *buf, gsize bufsz, guint32 crc)
 {
-	for (guint32 idx = 0; idx < bufsz; idx++) {
-		guint8 data = *buf++;
-		crc = crc ^ data;
-		for (guint32 bit = 0; bit < 8; bit++) {
-			guint32 mask = -(crc & 1);
-			crc = (crc >> 1) ^ (polynomial & mask);
+	g_return_val_if_fail(kind < FU_CRC32_KIND_LAST, 0x0);
+
+	for (gsize i = 0; i < bufsz; ++i) {
+		guint32 tmp = crc32_map[kind].reflected ? _reflect8(buf[i]) : buf[i];
+		crc ^= tmp << 24;
+		for (guint8 bit = 0; bit < 8; bit++) {
+			if (crc & (1ul << 31)) {
+				crc = (crc << 1) ^ crc32_map[kind].poly;
+			} else {
+				crc = (crc << 1);
+			}
 		}
 	}
-	return ~crc;
+	return crc;
+}
+
+/**
+ * fu_crc32_done:
+ * @kind: a #FuCrc32Kind, typically %FU_CRC32_KIND_STANDARD
+ * @crc: initial CRC value
+ *
+ * Returns the finished cyclic redundancy check value.
+ *
+ * Returns: CRC value
+ *
+ * Since: 2.0.0
+ **/
+guint32
+fu_crc32_done(FuCrc32Kind kind, guint32 crc)
+{
+	g_return_val_if_fail(kind < FU_CRC32_KIND_LAST, 0x0);
+	crc = crc32_map[kind].reflected ? _reflect32(crc) : crc;
+	if (crc32_map[kind].inverted)
+		crc ^= 0xFFFFFFFF;
+	return crc;
 }
 
 /**
  * fu_crc32:
+ * @kind: a #FuCrc32Kind, typically %FU_CRC32_KIND_STANDARD
  * @buf: memory buffer
  * @bufsz: size of @buf
  *
@@ -138,12 +211,41 @@ fu_crc32_full(const guint8 *buf, gsize bufsz, guint32 crc, guint32 polynomial)
  *
  * Returns: CRC value
  *
- * Since: 1.8.2
+ * Since: 2.0.0
  **/
 guint32
-fu_crc32(const guint8 *buf, gsize bufsz)
+fu_crc32(FuCrc32Kind kind, const guint8 *buf, gsize bufsz)
 {
-	return fu_crc32_full(buf, bufsz, 0xFFFFFFFF, 0xEDB88320);
+	g_return_val_if_fail(kind < FU_CRC32_KIND_LAST, 0x0);
+	return fu_crc32_done(kind, fu_crc32_step(kind, buf, bufsz, crc32_map[kind].init));
+}
+
+/**
+ * fu_crc32_find:
+ * @buf: memory buffer
+ * @bufsz: size of @buf
+ * @crc_target: "correct" CRC32 value
+ *
+ * Returns the cyclic redundancy kind for the given memory buffer and target CRC.
+ *
+ * You can use a very simple buffer to discover most types of standard CRC-32:
+ *
+ *    guint8 buf[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+ *    g_print("CRC:%u", fu_crc32_find(buf, sizeof(buf), _custom_crc(buf, sizeof(buf))));
+ *
+ * Returns: a #FuCrc32Kind, or %FU_CRC32_KIND_UNKNOWN on error
+ *
+ * Since: 2.0.0
+ **/
+FuCrc32Kind
+fu_crc32_find(const guint8 *buf, gsize bufsz, guint32 crc_target)
+{
+	for (guint i = 0; i < G_N_ELEMENTS(crc32_map); i++) {
+		guint32 crc_tmp = fu_crc32(crc32_map[i].kind, buf, bufsz);
+		if (crc_tmp == crc_target)
+			return crc32_map[i].kind;
+	}
+	return FU_CRC32_KIND_UNKNOWN;
 }
 
 static guint16

--- a/libfwupdplugin/fu-crc.h
+++ b/libfwupdplugin/fu-crc.h
@@ -12,14 +12,52 @@ guint8
 fu_crc8(const guint8 *buf, gsize bufsz);
 guint8
 fu_crc8_full(const guint8 *buf, gsize bufsz, guint8 crc_init, guint8 polynomial);
+
 guint16
 fu_crc16(const guint8 *buf, gsize bufsz);
 guint16
 fu_crc16_full(const guint8 *buf, gsize bufsz, guint16 crc, guint16 polynomial);
+
+/**
+ * FuCrc32Kind:
+ * @FU_CRC32_KIND_UNKNOWN:	Unknown
+ * @FU_CRC32_KIND_STANDARD:	CRC-32
+ * @FU_CRC32_KIND_BZIP2:	CRC-32/BZIP2
+ * @FU_CRC32_KIND_JAMCRC:	CRC-32/JAMCRC
+ * @FU_CRC32_KIND_MPEG2:	CRC-32/MPEG-2
+ * @FU_CRC32_KIND_POSIX:	CRC-32/POSIX
+ * @FU_CRC32_KIND_SATA:		CRC-32/SATA
+ * @FU_CRC32_KIND_XFER:		CRC-32/XFER
+ * @FU_CRC32_KIND_C:		CRC-32C
+ * @FU_CRC32_KIND_D:		CRC-32D
+ * @FU_CRC32_KIND_Q:		CRC-32Q
+ *
+ * The type of CRC-32.
+ **/
+typedef enum {
+	FU_CRC32_KIND_UNKNOWN,
+	FU_CRC32_KIND_STANDARD,
+	FU_CRC32_KIND_BZIP2,
+	FU_CRC32_KIND_JAMCRC,
+	FU_CRC32_KIND_MPEG2,
+	FU_CRC32_KIND_POSIX,
+	FU_CRC32_KIND_SATA,
+	FU_CRC32_KIND_XFER,
+	FU_CRC32_KIND_C,
+	FU_CRC32_KIND_D,
+	FU_CRC32_KIND_Q,
+	/*< private >*/
+	FU_CRC32_KIND_LAST,
+} FuCrc32Kind;
+
 guint32
-fu_crc32(const guint8 *buf, gsize bufsz);
+fu_crc32(FuCrc32Kind kind, const guint8 *buf, gsize bufsz);
 guint32
-fu_crc32_full(const guint8 *buf, gsize bufsz, guint32 crc, guint32 polynomial);
+fu_crc32_step(FuCrc32Kind kind, const guint8 *buf, gsize bufsz, guint32 crc);
+guint32
+fu_crc32_done(FuCrc32Kind kind, guint32 crc);
+FuCrc32Kind
+fu_crc32_find(const guint8 *buf, gsize bufsz, guint32 crc_target);
 
 guint16
 fu_misr16(guint16 init, const guint8 *buf, gsize bufsz);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -242,7 +242,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 
 	/* verify the checksum */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
-		guint32 crc_new = ~fu_crc32(buf, bufsz - 4);
+		guint32 crc_new = fu_crc32(FU_CRC32_KIND_JAMCRC, buf, bufsz - 4);
 		if (fu_struct_dfu_ftr_get_crc(st) != crc_new) {
 			g_set_error(error,
 				    FWUPD_ERROR,
@@ -309,7 +309,9 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
 	fu_struct_dfu_ftr_set_vid(st, priv->vid);
 	fu_struct_dfu_ftr_set_ver(st, priv->dfu_version);
 	g_byte_array_append(buf, st->data, st->len - sizeof(guint32));
-	fu_byte_array_append_uint32(buf, ~fu_crc32(buf->data, buf->len), G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf,
+				    fu_crc32(FU_CRC32_KIND_JAMCRC, buf->data, buf->len),
+				    G_LITTLE_ENDIAN);
 	return g_steal_pointer(&buf);
 }
 

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -100,7 +100,8 @@ fu_fit_firmware_verify_crc32(FuFirmware *firmware,
 				       &value,
 				       error))
 		return FALSE;
-	value_calc = fu_crc32(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));
+	value_calc =
+	    fu_crc32(FU_CRC32_KIND_STANDARD, g_bytes_get_data(blob, NULL), g_bytes_get_size(blob));
 	if (value_calc != value) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fu-common.h"
+#include "fu-crc.h"
 
 GInputStream *
 fu_input_stream_from_path(const gchar *path, GError **error) G_GNUC_WARN_UNUSED_RESULT
@@ -79,10 +80,8 @@ fu_input_stream_compute_crc16(GInputStream *stream,
 			      guint16 polynomial,
 			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_input_stream_compute_crc32(GInputStream *stream,
-			      guint32 *crc,
-			      guint32 polynomial,
-			      GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+fu_input_stream_compute_crc32(GInputStream *stream, FuCrc32Kind kind, guint32 *crc, GError **error)
+    G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 3);
 gchar *
 fu_input_stream_compute_checksum(GInputStream *stream,
 				 GChecksumType checksum_type,

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-firmware.c
@@ -87,7 +87,7 @@ fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 
 	if (!fu_firmware_set_stream(firmware, stream, error))
 		return FALSE;
-	if (!fu_input_stream_compute_crc32(stream, &self->file_id, 0xEDB88320, error))
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC32_KIND_STANDARD, &self->file_id, error))
 		return FALSE;
 
 	/* success */
@@ -115,6 +115,7 @@ static void
 fu_qc_s5gen2_firmware_init(FuQcS5gen2Firmware *self)
 {
 	self->device_variant = NULL;
+	self->file_id = 0xFFFFFFFF;
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);

--- a/plugins/bcm57xx/fu-bcm57xx-common.c
+++ b/plugins/bcm57xx/fu-bcm57xx-common.c
@@ -11,16 +11,10 @@
 
 #include "fu-bcm57xx-common.h"
 
-guint32
-fu_bcm57xx_nvram_crc(const guint8 *buf, gsize bufsz)
-{
-	return fu_crc32(buf, bufsz);
-}
-
 gboolean
 fu_bcm57xx_verify_crc(GInputStream *stream, GError **error)
 {
-	guint32 crc_actual = 0;
+	guint32 crc_actual = 0xFFFFFFFF;
 	guint32 crc_file = 0;
 	gsize streamsz = 0;
 	g_autoptr(GInputStream) stream_tmp = NULL;
@@ -46,7 +40,7 @@ fu_bcm57xx_verify_crc(GInputStream *stream, GError **error)
 	stream_tmp = fu_partial_input_stream_new(stream, 0, streamsz - sizeof(guint32), error);
 	if (stream_tmp == NULL)
 		return FALSE;
-	if (!fu_input_stream_compute_crc32(stream_tmp, &crc_actual, 0xEDB88320, error))
+	if (!fu_input_stream_compute_crc32(stream_tmp, FU_CRC32_KIND_STANDARD, &crc_actual, error))
 		return FALSE;
 	if (crc_actual != crc_file) {
 		g_set_error(error,

--- a/plugins/bcm57xx/fu-bcm57xx-common.h
+++ b/plugins/bcm57xx/fu-bcm57xx-common.h
@@ -56,8 +56,6 @@ typedef struct {
 	FwupdVersionFormat verfmt;
 } Bcm57xxVeritem;
 
-guint32
-fu_bcm57xx_nvram_crc(const guint8 *buf, gsize bufsz);
 gboolean
 fu_bcm57xx_verify_crc(GInputStream *stream, GError **error);
 gboolean

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -76,7 +76,7 @@ fu_bcm57xx_dict_image_write(FuFirmware *firmware, GError **error)
 	fu_byte_array_append_bytes(blob, fw_nocrc);
 
 	/* add CRC */
-	crc = fu_bcm57xx_nvram_crc(buf, bufsz);
+	crc = fu_crc32(FU_CRC32_KIND_STANDARD, buf, bufsz);
 	fu_byte_array_append_uint32(blob, crc, G_LITTLE_ENDIAN);
 	return g_steal_pointer(&blob);
 }

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -536,7 +536,7 @@ fu_bcm57xx_firmware_write(FuFirmware *firmware, GError **error)
 				    G_BIG_ENDIAN);
 	fu_byte_array_append_uint32(buf, BCM_NVRAM_STAGE1_BASE, G_BIG_ENDIAN);
 	fu_byte_array_append_uint32(buf,
-				    fu_bcm57xx_nvram_crc(buf->data, buf->len),
+				    fu_crc32(FU_CRC32_KIND_STANDARD, buf->data, buf->len),
 				    G_LITTLE_ENDIAN);
 
 	/* add directory entries */

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -140,7 +140,7 @@ fu_bcm57xx_stage1_image_write(FuFirmware *firmware, GError **error)
 	    0x00);
 
 	/* add CRC */
-	crc = fu_bcm57xx_nvram_crc(buf->data, buf->len);
+	crc = fu_crc32(FU_CRC32_KIND_STANDARD, buf->data, buf->len);
 	fu_byte_array_append_uint32(buf, crc, G_LITTLE_ENDIAN);
 	return g_steal_pointer(&buf);
 }

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -66,7 +66,9 @@ fu_bcm57xx_stage2_image_write(FuFirmware *image, GError **error)
 	fu_byte_array_append_bytes(blob, fw_nocrc);
 
 	/* add CRC */
-	fu_byte_array_append_uint32(blob, fu_bcm57xx_nvram_crc(buf, bufsz), G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(blob,
+				    fu_crc32(FU_CRC32_KIND_STANDARD, buf, bufsz),
+				    G_LITTLE_ENDIAN);
 	return g_steal_pointer(&blob);
 }
 

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -398,7 +398,7 @@ fu_corsair_bp_activate_firmware(FuCorsairBp *self, FuFirmware *firmware, GError 
 		return FALSE;
 	}
 
-	crc = fu_corsair_calculate_crc(firmware_raw, firmware_size);
+	crc = fu_crc32(FU_CRC32_KIND_MPEG2, firmware_raw, firmware_size);
 	fu_memwrite_uint32(&cmd[CORSAIR_OFFSET_CMD_CRC], crc, G_LITTLE_ENDIAN);
 
 	return fu_corsair_bp_command(self, cmd, CORSAIR_ACTIVATION_TIMEOUT, TRUE, error);

--- a/plugins/corsair/fu-corsair-common.c
+++ b/plugins/corsair/fu-corsair-common.c
@@ -8,29 +8,6 @@
 
 #include "fu-corsair-common.h"
 
-guint32
-fu_corsair_calculate_crc(const guint8 *data, guint32 data_len)
-{
-	gboolean bit;
-	guint8 c;
-	guint32 crc = 0xffffffff;
-
-	while (data_len--) {
-		c = *data++;
-		for (guint i = 0x80; i > 0; i >>= 1) {
-			bit = (crc & 0x80000000) > 0;
-			if (c & i) {
-				bit = !bit;
-			}
-			crc <<= 1;
-			if (bit) {
-				crc ^= 0x04c11db7;
-			}
-		}
-	}
-	return crc;
-}
-
 /**
  * fu_corsair_version_from_uint32:
  * @val: version in corsair device format

--- a/plugins/corsair/fu-corsair-common.h
+++ b/plugins/corsair/fu-corsair-common.h
@@ -27,8 +27,5 @@ typedef enum {
 	FU_CORSAIR_DEVICE_MODE_BOOTLOADER = 0x03
 } FuCorsairDeviceMode;
 
-guint32
-fu_corsair_calculate_crc(const guint8 *data, guint32 data_len);
-
 gchar *
 fu_corsair_version_from_uint32(guint32 val);

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -48,7 +48,7 @@ goodixmoc_device_cmd_send(FuGoodixMocDevice *self,
 	fu_byte_array_append_uint8(buf, crc_hdr);
 	fu_byte_array_append_uint8(buf, ~crc_hdr);
 	g_byte_array_append(buf, req->data, req->len);
-	crc_all = fu_crc32(buf->data, buf->len);
+	crc_all = fu_crc32(FU_CRC32_KIND_STANDARD, buf->data, buf->len);
 	fu_byte_array_append_uint32(buf, crc_all, G_LITTLE_ENDIAN);
 
 	/* send zero length package */
@@ -141,7 +141,7 @@ goodixmoc_device_cmd_recv(FuGoodixMocDevice *self,
 					    error))
 			return FALSE;
 		offset = sizeof(GxfpPkgHeader) + header_len - GX_SIZE_CRC32;
-		crc_actual = fu_crc32(reply->data, offset);
+		crc_actual = fu_crc32(FU_CRC32_KIND_STANDARD, reply->data, offset);
 		if (!fu_memread_uint32_safe(reply->data,
 					    reply->len,
 					    offset,

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -49,7 +49,7 @@ fu_nordic_hid_firmware_parse(FuFirmware *firmware,
 	FuNordicHidFirmwarePrivate *priv = GET_PRIVATE(self);
 
 	priv->crc32 = 0x01;
-	if (!fu_input_stream_compute_crc32(stream, &priv->crc32, 0xEDB88320, error))
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC32_KIND_STANDARD, &priv->crc32, error))
 		return FALSE;
 
 	/* success */

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -23,7 +23,7 @@ fu_steelseries_firmware_parse(FuFirmware *firmware,
 			      GError **error)
 {
 	FuSteelseriesFirmware *self = FU_STEELSERIES_FIRMWARE(firmware);
-	guint32 checksum_tmp = 0;
+	guint32 checksum_tmp = 0xFFFFFFFF;
 	guint32 checksum = 0;
 	gsize streamsz = 0;
 	g_autoptr(GInputStream) stream_tmp = NULL;
@@ -47,7 +47,10 @@ fu_steelseries_firmware_parse(FuFirmware *firmware,
 	stream_tmp = fu_partial_input_stream_new(stream, 0, streamsz - sizeof(checksum_tmp), error);
 	if (stream_tmp == NULL)
 		return FALSE;
-	if (!fu_input_stream_compute_crc32(stream_tmp, &checksum_tmp, 0xEDB88320, error))
+	if (!fu_input_stream_compute_crc32(stream_tmp,
+					   FU_CRC32_KIND_STANDARD,
+					   &checksum_tmp,
+					   error))
 		return FALSE;
 	if (checksum_tmp != checksum) {
 		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -976,8 +976,9 @@ fu_steelseries_sonic_parse_firmware(FuFirmware *firmware, FwupdInstallFlags flag
 				    G_LITTLE_ENDIAN,
 				    error))
 		return FALSE;
-	checksum_tmp =
-	    fu_crc32(g_bytes_get_data(blob, NULL), g_bytes_get_size(blob) - sizeof(checksum_tmp));
+	checksum_tmp = fu_crc32(FU_CRC32_KIND_STANDARD,
+				g_bytes_get_data(blob, NULL),
+				g_bytes_get_size(blob) - sizeof(checksum_tmp));
 	checksum_tmp = ~checksum_tmp;
 	if (checksum_tmp != checksum) {
 		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -64,13 +64,16 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 
 	/* check CRC */
 	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
-		guint32 crc_calc = 0;
+		guint32 crc_calc = 0xFFFFFFFF;
 		g_autoptr(GInputStream) stream_tmp = NULL;
 
 		stream_tmp = fu_partial_input_stream_new(stream, 8, streamsz - 8, error);
 		if (stream_tmp == NULL)
 			return FALSE;
-		if (!fu_input_stream_compute_crc32(stream_tmp, &crc_calc, 0xEDB88320, error))
+		if (!fu_input_stream_compute_crc32(stream_tmp,
+						   FU_CRC32_KIND_STANDARD,
+						   &crc_calc,
+						   error))
 			return FALSE;
 		if (crc_calc != fu_struct_synaptics_cape_sngl_hdr_get_file_crc(st)) {
 			g_set_error(error,

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -27,7 +27,6 @@ G_DEFINE_TYPE(FuWacModuleBluetoothId9, fu_wac_module_bluetooth_id9, FU_TYPE_WAC_
 #define FU_WAC_MODULE_BLUETOOTH_ID9_LOADER_RAM	   0x02
 #define FU_WAC_MODULE_BLUETOOTH_ID9_LOADER_BEGIN   0x03
 #define FU_WAC_MODULE_BLUETOOTH_ID9_LOADER_DATA	   0x04
-#define FU_WAC_MODULE_BLUETOOTH_ID9_CRC_POLYNOMIAL 0xEDB88320
 
 #define FU_WAC_MODULE_BLUETOOTH_ID9_POLL_INTERVAL 5	/* ms */
 #define FU_WAC_MODULE_BLUETOOTH_ID9_START_TIMEOUT 75000 /* ms */
@@ -56,14 +55,8 @@ fu_wac_module_bluetooth_id9_get_startcmd(GInputStream *stream, gboolean full_era
 	fu_struct_id9_loader_cmd_set_command(loader_cmd, command);
 	fu_struct_id9_loader_cmd_set_size(loader_cmd, streamsz + FU_STRUCT_ID9_SPI_CMD_SIZE);
 	/* CRC(concat(spi_cmd, *data)) */
-	crc = fu_crc32_full(spi_cmd->data,
-			    FU_STRUCT_ID9_SPI_CMD_SIZE,
-			    ~0,
-			    FU_WAC_MODULE_BLUETOOTH_ID9_CRC_POLYNOMIAL);
-	if (!fu_input_stream_compute_crc32(stream,
-					   &crc,
-					   FU_WAC_MODULE_BLUETOOTH_ID9_CRC_POLYNOMIAL,
-					   error))
+	crc = fu_crc32(FU_CRC32_KIND_STANDARD, spi_cmd->data, FU_STRUCT_ID9_SPI_CMD_SIZE);
+	if (!fu_input_stream_compute_crc32(stream, FU_CRC32_KIND_STANDARD, &crc, error))
 		return NULL;
 	fu_struct_id9_loader_cmd_set_crc(loader_cmd, crc);
 	if (!fu_struct_id9_loader_cmd_set_data(loader_cmd, spi_cmd, error))


### PR DESCRIPTION
Many plugins are being developed with "custom" CRC-32 checksums. It turns out they're not actually custom at all, and if we support more types we can remove a lot of bit-twiddling.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
