### PR TITLE
trivial: bios: don't compile other than on x86

### DIFF
--- a/plugins/bios/fu-bios-plugin.c
+++ b/plugins/bios/fu-bios-plugin.c
@@ -36,16 +36,14 @@ fu_bios_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
 	g_autofree gchar *sysfsfwdir = NULL;
 	g_autofree gchar *esrt_path = NULL;
+	g_autoptr(GError) error_local = NULL;
 
 	/* are the EFI dirs set up so we can update each device */
-#if defined(__x86_64__) || defined(__i386__)
-	g_autoptr(GError) error_local = NULL;
 	if (!fu_efivars_supported(efivars, &error_local)) {
 		fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_LEGACY_BIOS);
 		fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_USER_WARNING);
 		return TRUE;
 	}
-#endif
 
 	/* get the directory of ESRT entries */
 	sysfsfwdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW);

--- a/plugins/bios/meson.build
+++ b/plugins/bios/meson.build
@@ -1,4 +1,4 @@
-if allow_uefi_capsule
+if allow_uefi_capsule and (host_cpu == 'x86' or host_cpu == 'x86_64')
 cargs = ['-DG_LOG_DOMAIN="FuPluginBios"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 


### PR DESCRIPTION
The BIOS plugin has an assumption that users can switch modes and that an ESRT is used for updating.

The main purpose of the plugin is to guide people what to do. This isn't strictly true for non-x86 architectures. Disable the plugin on non-x86.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
