### PR TITLE
libfwupdplugin: Hide i2c instance IDs by default

### DIFF
--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -132,7 +132,6 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_strsafe(device, "NAME", tmp);
 	if (!fu_device_build_instance_id_full(device,
 					      FU_DEVICE_INSTANCE_FLAG_GENERIC |
-						  FU_DEVICE_INSTANCE_FLAG_VISIBLE |
 						  FU_DEVICE_INSTANCE_FLAG_QUIRKS,
 					      error,
 					      "I2C",


### PR DESCRIPTION
These are very generic and platform specific and plugins can/should add other instance IDs that are more specific and narrow.

This is useful for hiding the unused I2C GUID in AMD Kria SOM.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
