### PR TITLE
Remove the unused fu_i2c_device_get_bus_number()

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -136,3 +136,4 @@ Remember: Plugins should be upstream!
 * `fu_udev_device_write_sysfs()`: Add a timeout in milliseconds
 * `fu_udev_device_get_sysfs_attr_uint64()`: Use `fu_udev_device_read_sysfs()` instead
 * `fu_udev_device_get_sysfs_attr`: Use `fu_udev_device_read_sysfs()` instead
+* `fu_i2c_device_get_bus_number()`: Use `fu_udev_device_get_number()` instead

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -28,101 +28,14 @@
  * See also: #FuUdevDevice
  */
 
-typedef struct {
-	guint bus_number;
-} FuI2cDevicePrivate;
-
-G_DEFINE_TYPE_WITH_PRIVATE(FuI2cDevice, fu_i2c_device, FU_TYPE_UDEV_DEVICE)
-
-enum { PROP_0, PROP_BUS_NUMBER, PROP_LAST };
-
-#define GET_PRIVATE(o) (fu_i2c_device_get_instance_private(o))
-
-static void
-fu_i2c_device_to_string(FuDevice *device, guint idt, GString *str)
-{
-	FuI2cDevice *self = FU_I2C_DEVICE(device);
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	fwupd_codec_string_append_hex(str, idt, "BusNumber", priv->bus_number);
-}
-
-static void
-fu_i2c_device_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
-{
-	FuI2cDevice *self = FU_I2C_DEVICE(object);
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	switch (prop_id) {
-	case PROP_BUS_NUMBER:
-		g_value_set_uint(value, priv->bus_number);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-		break;
-	}
-}
-
-static void
-fu_i2c_device_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
-{
-	FuI2cDevice *self = FU_I2C_DEVICE(object);
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	switch (prop_id) {
-	case PROP_BUS_NUMBER:
-		priv->bus_number = g_value_get_uint(value);
-		break;
-	default:
-		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-		break;
-	}
-}
-
-static gboolean
-fu_i2c_device_open(FuDevice *device, GError **error)
-{
-#ifdef HAVE_GUDEV
-	FuI2cDevice *self = FU_I2C_DEVICE(device);
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	gint bus_fd;
-	g_autofree gchar *bus_path = NULL;
-	g_autoptr(FuIOChannel) io_channel = NULL;
-
-	/* open the bus, not the device represented by self */
-	bus_path = g_strdup_printf("/dev/i2c-%u", priv->bus_number);
-	if ((bus_fd = g_open(bus_path, O_RDWR, 0)) == -1) {
-		g_set_error(error,
-			    G_IO_ERROR, /* nocheck */
-#ifdef HAVE_ERRNO_H
-			    g_io_error_from_errno(errno),
-#else
-			    G_IO_ERROR_FAILED, /* nocheck */
-#endif
-			    "failed to open %s read-write",
-			    bus_path);
-		fwupd_error_convert(error);
-		return FALSE;
-	}
-	io_channel = fu_io_channel_unix_new(bus_fd);
-	fu_udev_device_set_io_channel(FU_UDEV_DEVICE(self), io_channel);
-	fu_udev_device_add_flag(FU_UDEV_DEVICE(self), FU_UDEV_DEVICE_FLAG_IGNORE_NONE);
-#endif
-
-	/* FuUdevDevice->open */
-	return FU_DEVICE_CLASS(fu_i2c_device_parent_class)->open(device, error);
-}
+G_DEFINE_TYPE(FuI2cDevice, fu_i2c_device, FU_TYPE_UDEV_DEVICE)
 
 static gboolean
 fu_i2c_device_probe(FuDevice *device, GError **error)
 {
 	FuI2cDevice *self = FU_I2C_DEVICE(device);
-#ifdef HAVE_GUDEV
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
-#endif
 	g_autofree gchar *attr_name = NULL;
-#ifdef HAVE_GUDEV
-	g_autofree gchar *devname = NULL;
-	g_autoptr(GUdevDevice) udev_parent = NULL;
-#endif
+	g_autoptr(FuUdevDevice) udev_parent = NULL;
 
 	/* set physical ID */
 	if (!fu_udev_device_set_physical_id(FU_UDEV_DEVICE(device), "i2c", error))
@@ -145,64 +58,20 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 					      NULL))
 		return FALSE;
 
-#ifdef HAVE_GUDEV
 	/* get bus number out of sysfs path */
-	udev_parent = g_udev_device_get_parent(udev_device);
-	if (udev_parent != NULL)
-		devname = g_path_get_basename(g_udev_device_get_sysfs_path(udev_parent));
-	if (devname != NULL && g_str_has_prefix(devname, "i2c-")) {
-		guint64 tmp64 = 0;
-		g_autoptr(GError) error_local = NULL;
-		if (!fu_strtoull(devname + 4,
-				 &tmp64,
-				 0,
-				 G_MAXUINT,
-				 FU_INTEGER_BASE_AUTO,
-				 &error_local)) {
-			g_debug("ignoring i2c devname bus number: %s", error_local->message);
-		} else {
-			priv->bus_number = tmp64;
-		}
+	udev_parent =
+	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device), "i2c", NULL, NULL);
+	if (udev_parent != NULL) {
+		g_autofree gchar *devfile = NULL;
+		if (!fu_udev_device_parse_number(udev_parent, error))
+			return FALSE;
+		devfile =
+		    g_strdup_printf("/dev/i2c-%u", (guint)fu_udev_device_get_number(udev_parent));
+		fu_udev_device_set_device_file(FU_UDEV_DEVICE(self), devfile);
 	}
-#endif
 
 	/* success */
 	return TRUE;
-}
-
-/**
- * fu_i2c_device_get_bus_number:
- * @self: a #FuI2cDevice
- *
- * Gets the I²C bus number.
- *
- * Returns: integer
- *
- * Since: 1.6.1
- **/
-guint
-fu_i2c_device_get_bus_number(FuI2cDevice *self)
-{
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FU_IS_I2C_DEVICE(self), G_MAXUINT);
-	return priv->bus_number;
-}
-
-/**
- * fu_i2c_device_set_bus_number:
- * @self: a #FuI2cDevice
- * @bus_number: integer, typically the output of g_udev_device_get_number()
- *
- * Sets the I²C bus number.
- *
- * Since: 1.6.2
- **/
-void
-fu_i2c_device_set_bus_number(FuI2cDevice *self, guint bus_number)
-{
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FU_IS_I2C_DEVICE(self));
-	priv->bus_number = bus_number;
 }
 
 /**
@@ -244,20 +113,6 @@ fu_i2c_device_read(FuI2cDevice *self, guint8 *buf, gsize bufsz, GError **error)
 }
 
 static void
-fu_i2c_device_incorporate(FuDevice *device, FuDevice *donor)
-{
-	FuI2cDevice *self = FU_I2C_DEVICE(device);
-	FuI2cDevicePrivate *priv = GET_PRIVATE(self);
-	FuI2cDevicePrivate *priv_donor = GET_PRIVATE(FU_I2C_DEVICE(donor));
-
-	g_return_if_fail(FU_IS_I2C_DEVICE(self));
-	g_return_if_fail(FU_IS_I2C_DEVICE(donor));
-
-	/* copy private instance data */
-	priv->bus_number = priv_donor->bus_number;
-}
-
-static void
 fu_i2c_device_init(FuI2cDevice *self)
 {
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
@@ -267,29 +122,5 @@ static void
 fu_i2c_device_class_init(FuI2cDeviceClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	GParamSpec *pspec;
-
-	object_class->get_property = fu_i2c_device_get_property;
-	object_class->set_property = fu_i2c_device_set_property;
-	device_class->open = fu_i2c_device_open;
 	device_class->probe = fu_i2c_device_probe;
-	device_class->to_string = fu_i2c_device_to_string;
-	device_class->incorporate = fu_i2c_device_incorporate;
-
-	/**
-	 * FuI2cDevice:bus-number:
-	 *
-	 * The I²C bus number.
-	 *
-	 * Since: 1.6.2
-	 */
-	pspec = g_param_spec_uint("bus-number",
-				  NULL,
-				  NULL,
-				  0x0,
-				  G_MAXUINT,
-				  0x0,
-				  G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
-	g_object_class_install_property(object_class, PROP_BUS_NUMBER, pspec);
 }

--- a/libfwupdplugin/fu-i2c-device.h
+++ b/libfwupdplugin/fu-i2c-device.h
@@ -15,10 +15,6 @@ struct _FuI2cDeviceClass {
 	FuUdevDeviceClass parent_class;
 };
 
-guint
-fu_i2c_device_get_bus_number(FuI2cDevice *self) G_GNUC_NON_NULL(1);
-void
-fu_i2c_device_set_bus_number(FuI2cDevice *self, guint bus_number) G_GNUC_NON_NULL(1);
 gboolean
 fu_i2c_device_read(FuI2cDevice *self, guint8 *buf, gsize bufsz, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-udev-device-private.h
+++ b/libfwupdplugin/fu-udev-device-private.h
@@ -12,3 +12,5 @@ void
 fu_udev_device_emit_changed(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 void
 fu_udev_device_set_io_channel(FuUdevDevice *self, FuIOChannel *io_channel) G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_udev_device_parse_number(FuUdevDevice *self, GError **error) G_GNUC_NON_NULL(1);


### PR DESCRIPTION
We can just use fu_udev_device_get_number() as well -- it's the same thing!

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
