### PR TITLE
Add libusb as a hard dep

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -26,9 +26,7 @@
 #include "fu-i2c-device.h"
 #include "fu-string.h"
 #include "fu-udev-device-private.h"
-#ifdef HAVE_LIBUSB
 #include "fu-usb-device-private.h"
-#endif
 
 /**
  * FuUdevDevice:
@@ -2497,7 +2495,7 @@ fu_udev_device_get_children_with_subsystem(FuUdevDevice *self, const gchar *cons
 FuDevice *
 fu_udev_device_find_usb_device(FuUdevDevice *self, GError **error)
 {
-#if defined(HAVE_GUDEV) && defined(HAVE_LIBUSB)
+#if defined(HAVE_GUDEV)
 	guint64 bus = 0;
 	guint64 address = 0;
 	gint rc;

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -104,6 +104,7 @@ fwupdplugin_src = [
   'fu-fit-firmware.c', # fuzzing
   'fu-fmap-firmware.c', # fuzzing
   'fu-hid-descriptor.c', # fuzzing
+  'fu-hid-device.c',
   'fu-hid-report-item.c', # fuzzing
   'fu-hid-report.c', # fuzzing
   'fu-hwids.c', # fuzzing
@@ -146,23 +147,17 @@ fwupdplugin_src = [
   'fu-string.c', # fuzzing
   'fu-sum.c', # fuzzing
   'fu-udev-device.c',
+  'fu-usb-bos-descriptor.c',
+  'fu-usb-device.c',
+  'fu-usb-device-ds20.c',
+  'fu-usb-device-fw-ds20.c',
+  'fu-usb-device-ms-ds20.c',
+  'fu-usb-endpoint.c',
+  'fu-usb-interface.c',
   'fu-uswid-firmware.c', # fuzzing
   'fu-version-common.c', # fuzzing
   'fu-volume.c', # fuzzing
 ]
-
-if libusb.found()
-  fwupdplugin_src += [
-    'fu-hid-device.c',
-    'fu-usb-bos-descriptor.c',
-    'fu-usb-device.c',
-    'fu-usb-device-ds20.c',
-    'fu-usb-device-fw-ds20.c',
-    'fu-usb-device-ms-ds20.c',
-    'fu-usb-endpoint.c',
-    'fu-usb-interface.c',
-  ]
-endif
 
 if host_machine.system() == 'linux'
   fwupdplugin_src += 'fu-common-linux.c' # fuzzing

--- a/meson.build
+++ b/meson.build
@@ -233,16 +233,13 @@ endif
 conf.set_quoted('FU_LVFS_METADATA_FORMAT', lvfs_metadata_format)
 
 # FreeBSD is missing some libusb symbols
-libusb = dependency('libusb-1.0', version : '>= 0.1.12', required: get_option('usb'))
-if libusb.found()
-  conf.set('HAVE_LIBUSB', '1')
-  conf.set_quoted('LIBUSB_VERSION', libusb.version())
-  if cc.has_header_symbol('libusb.h', 'libusb_set_option', dependencies: libusb)
-    conf.set('HAVE_LIBUSB_SET_OPTION', '1')
-  endif
-  if cc.has_header_symbol('libusb.h', 'libusb_get_parent', dependencies: libusb)
-    conf.set('HAVE_LIBUSB_GET_PARENT', '1')
-  endif
+libusb = dependency('libusb-1.0', version : '>= 0.1.12')
+conf.set_quoted('LIBUSB_VERSION', libusb.version())
+if cc.has_header_symbol('libusb.h', 'libusb_set_option', dependencies: libusb)
+  conf.set('HAVE_LIBUSB_SET_OPTION', '1')
+endif
+if cc.has_header_symbol('libusb.h', 'libusb_get_parent', dependencies: libusb)
+  conf.set('HAVE_LIBUSB_GET_PARENT', '1')
 endif
 
 sqlite = dependency('sqlite3', required: get_option('sqlite'))
@@ -556,11 +553,6 @@ else
   libdir_pkg = join_paths(libdir, 'fwupd-@0@'.format(fwupd_version))
 endif
 conf.set_quoted('FWUPD_LIBDIR_PKG', libdir_pkg)
-endif
-
-# sanity check, otherwise there is not point building
-if build_standalone and host_machine.system() == 'windows' and not libusb.found()
-  error('libusb is required for Windows build')
 endif
 
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -78,10 +78,6 @@ option('gudev',
     'false': 'disabled',
   },
 )
-option('usb',
-  type: 'feature',
-  description: 'USB support',
-)
 option('bluez',
   type: 'feature',
   description: 'BlueZ support',

--- a/plugins/algoltek-usb/meson.build
+++ b/plugins/algoltek-usb/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginAlgoltekUsb"']
 
 plugins += {meson.current_source_dir().split('/')[-1]: true}
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_algoltek_usb',
     c_args: cargs,
     dependencies: plugin_deps,
 )
-endif

--- a/plugins/analogix/meson.build
+++ b/plugins/analogix/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginAnalogix"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_analogix',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/audio-s5gen2/meson.build
+++ b/plugins/audio-s5gen2/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginQcS5gen2"']
 
 plugins += {meson.current_source_dir().split('/')[-1]: true}
@@ -19,4 +18,3 @@ plugin_builtins += static_library('fu_plugin_audio_s5gen2',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/aver-hid/meson.build
+++ b/plugins/aver-hid/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginAverHid"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -16,4 +15,3 @@ plugin_builtins += static_library('fu_plugin_aver_hid',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/ccgx-dmc/meson.build
+++ b/plugins/ccgx-dmc/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCcgxDmc"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -49,5 +48,4 @@ if get_option('tests')
     ],
   )
   test('ccgx-dmc-self-test', e, env: env)
-endif
 endif

--- a/plugins/ccgx/meson.build
+++ b/plugins/ccgx/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCcgx"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -55,5 +54,4 @@ if get_option('tests')
     ],
   )
   test('ccgx-self-test', e, env: env)
-endif
 endif

--- a/plugins/cfu/meson.build
+++ b/plugins/cfu/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCfu"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -28,4 +27,3 @@ plugin_builtin_cfu = static_library('fu_plugin_cfu',
 )
 plugin_builtins += plugin_builtin_cfu
 plugincfu_incdir = include_directories('.')
-endif

--- a/plugins/ch341a/meson.build
+++ b/plugins/ch341a/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCh341a"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_ch341a',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/ch347/meson.build
+++ b/plugins/ch347/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCh347"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_ch347',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/colorhug/meson.build
+++ b/plugins/colorhug/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginColorHug"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_colorhug',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/corsair/meson.build
+++ b/plugins/corsair/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCorsair"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -16,4 +15,3 @@ plugin_builtins += static_library('fu_plugin_corsair',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/cros-ec/meson.build
+++ b/plugins/cros-ec/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginCrosEc"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_cros_ec',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/dell-dock/meson.build
+++ b/plugins/dell-dock/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginDellDock"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -26,4 +25,3 @@ plugin_builtins += static_library('fu_plugin_dell_dock',
     gudev,
   ],
 )
-endif

--- a/plugins/dfu-csr/meson.build
+++ b/plugins/dfu-csr/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginDfuCsr"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -24,4 +23,3 @@ plugin_builtins += static_library('fu_plugin_dfu_csr',
     plugin_builtin_dfu,
   ],
 )
-endif

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginDfu"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -65,4 +64,3 @@ if get_option('tests')
 endif
 
 plugindfu_incdir = include_directories('.')
-endif

--- a/plugins/ebitdo/meson.build
+++ b/plugins/ebitdo/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginEbitdo"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -17,4 +16,3 @@ plugin_builtins += static_library('fu_plugin_ebitdo',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/elanfp/meson.build
+++ b/plugins/elanfp/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginElanfp"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -24,4 +23,3 @@ plugin_builtins += static_library('fu_plugin_elanfp',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/ep963x/meson.build
+++ b/plugins/ep963x/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_ep963x').disable_auto_if(host_machine.system() != 'linux').disable_auto_if(not libusb.found()).allowed()
+if get_option('plugin_ep963x').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginEp963x"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/fastboot/meson.build
+++ b/plugins/fastboot/meson.build
@@ -1,5 +1,4 @@
-if get_option('plugin_fastboot').require(libusb.found(),
-    error_message: 'libusb is needed for plugin_fastboot').allowed()
+if get_option('plugin_fastboot').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginFastboot"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/fpc/meson.build
+++ b/plugins/fpc/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginFpc"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_fpc',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/fresco-pd/meson.build
+++ b/plugins/fresco-pd/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginFrescoPd"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_fresco_pd',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/genesys/meson.build
+++ b/plugins/genesys/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginGenesys"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -23,4 +22,3 @@ plugin_builtins += static_library('fu_plugin_genesys',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/goodix-moc/meson.build
+++ b/plugins/goodix-moc/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginGoodixMoc"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -13,4 +12,3 @@ plugin_builtins += static_library('fu_plugin_goodixmoc',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/goodix-tp/meson.build
+++ b/plugins/goodix-tp/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginGoodixtp"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -19,4 +18,3 @@ plugin_builtins += static_library('fu_plugin_goodixtp',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/hailuck/meson.build
+++ b/plugins/hailuck/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginNovatek"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -17,4 +16,3 @@ plugin_builtins += static_library('fu_plugin_hailuck',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/intel-usb4/meson.build
+++ b/plugins/intel-usb4/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginIntelUsb4"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -17,4 +16,3 @@ plugin_builtins += static_library('fu_plugin_intel_usb4',
     gudev,
   ],
 )
-endif

--- a/plugins/jabra-gnp/meson.build
+++ b/plugins/jabra-gnp/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginJabraGnp"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -16,4 +15,3 @@ plugin_builtins += static_library('fu_plugin_jabra_gnp',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/jabra/meson.build
+++ b/plugins/jabra/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginJabra"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -13,4 +12,3 @@ plugin_builtins += static_library('fu_plugin_jabra',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/logitech-bulkcontroller/meson.build
+++ b/plugins/logitech-bulkcontroller/meson.build
@@ -1,4 +1,4 @@
-if libusb.found() and protobufc.found() and protoc.found()
+if protobufc.found() and protoc.found()
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechBulkController"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}

--- a/plugins/logitech-hidpp/meson.build
+++ b/plugins/logitech-hidpp/meson.build
@@ -1,4 +1,4 @@
-if gudev.found() and libusb.found()
+if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechHidpp"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/logitech-rallysystem/meson.build
+++ b/plugins/logitech-rallysystem/meson.build
@@ -1,4 +1,4 @@
-if gudev.found() and libusb.found()
+if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechRallysystem"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/logitech-scribe/meson.build
+++ b/plugins/logitech-scribe/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_logitech_scribe').require(libusb.found() and gudev.found(),
+if get_option('plugin_logitech_scribe').require(gudev.found(),
     error_message: 'usb and udev are needed for plugin_logitech_scribe').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechScribe"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}

--- a/plugins/logitech-tap/meson.build
+++ b/plugins/logitech-tap/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_logitech_tap').require(libusb.found() and gudev.found(),
+if get_option('plugin_logitech_tap').require(gudev.found(),
     error_message: 'usb and udev are needed for plugin_logitech_tap').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogitechTap"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -2,10 +2,6 @@ libmm_glib = dependency('mm-glib', version: '>= 1.18.0', required: get_option('p
 libqmi_glib = dependency('qmi-glib', version: '>= 1.30.0', required: get_option('plugin_modem_manager'))
 libmbim_glib = dependency('mbim-glib', version: '>= 1.26.0', required: get_option('plugin_modem_manager'))
 
-if get_option('plugin_modem_manager').require(libusb.found(),
-    error_message: 'libusb is needed for plugin_modem_manager').allowed()
-endif
-
 if libmm_glib.found() and \
    libqmi_glib.found() and \
    libmbim_glib.found() and \

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -1,4 +1,4 @@
-if get_option('plugin_nitrokey').disable_auto_if(host_machine.system() != 'linux').disable_auto_if(not libusb.found()).allowed()
+if get_option('plugin_nitrokey').disable_auto_if(host_machine.system() != 'linux').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginNitrokey"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/nordic-hid/meson.build
+++ b/plugins/nordic-hid/meson.build
@@ -1,4 +1,4 @@
-if gudev.found() and libusb.found()
+if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginNordicHid"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/qsi-dock/meson.build
+++ b/plugins/qsi-dock/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginQsiDock"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_qsi_dock',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/rts54hid/meson.build
+++ b/plugins/rts54hid/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginRts54Hid"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_rts54hid',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/rts54hub/meson.build
+++ b/plugins/rts54hub/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginRts54Hub"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -16,4 +15,3 @@ plugin_builtins += static_library('fu_plugin_rts54hub',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/steelseries/meson.build
+++ b/plugins/steelseries/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginSteelSeries"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -20,4 +19,3 @@ plugin_builtins += static_library('fu_plugin_steelseries',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/synaptics-cape/meson.build
+++ b/plugins/synaptics-cape/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsCape"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -19,4 +18,3 @@ plugin_builtins += static_library('fu_plugin_synaptics_cape',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/synaptics-cxaudio/meson.build
+++ b/plugins/synaptics-cxaudio/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsCxaudio"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_synaptics_cxaudio',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/synaptics-prometheus/meson.build
+++ b/plugins/synaptics-prometheus/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsPrometheus"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -47,5 +46,4 @@ if get_option('tests')
     ],
   )
   test('synaptics-prometheus-self-test', e, env: env)  # added to installed-tests
-endif
 endif

--- a/plugins/synaptics-vmm9/meson.build
+++ b/plugins/synaptics-vmm9/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsVmm9"']
 
 plugins += {meson.current_source_dir().split('/')[-1]: true}
@@ -15,4 +14,3 @@ plugin_builtins += static_library('fu_plugin_synaptics_vmm9',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/system76-launch/meson.build
+++ b/plugins/system76-launch/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 cargs = ['-DG_LOG_DOMAIN="FuPluginSystem76Launch"']
 
@@ -13,4 +12,3 @@ plugin_builtins += static_library('fu_plugin_system76_launch',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/thelio-io/meson.build
+++ b/plugins/thelio-io/meson.build
@@ -1,4 +1,4 @@
-if gudev.found() and libusb.found()
+if gudev.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginThelioIo"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 

--- a/plugins/ti-tps6598x/meson.build
+++ b/plugins/ti-tps6598x/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 cargs = ['-DG_LOG_DOMAIN="FuPluginTiTps6598x"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -17,4 +16,3 @@ plugin_builtins += static_library('fu_plugin_ti_tps6598x',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/usi-dock/meson.build
+++ b/plugins/usi-dock/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 cargs = ['-DG_LOG_DOMAIN="FuPluginUsiDock"']
 
@@ -16,4 +15,3 @@ plugin_builtins += static_library('fu_plugin_usi_dock',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/plugins/vendor-example/meson.build.in
+++ b/plugins/vendor-example/meson.build.in
@@ -1,6 +1,4 @@
-{%- if Parent in ['Usb', 'Hid'] -%}
-if libusb.found()
-{%- elif Parent == 'Udev' -%}
+{%- if Parent == 'Udev' -%}
 if gudev.found()
 {%- endif %}
 cargs = ['-DG_LOG_DOMAIN="FuPlugin{{VendorExample}}"']
@@ -20,6 +18,6 @@ plugin_builtins += static_library('fu_plugin_{{vendor_example}}',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-{%- if Parent in ['Usb', 'Hid', 'Udev'] %}
+{%- if Parent == 'Udev' %}
 endif
 {%- endif %}

--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 cargs = ['-DG_LOG_DOMAIN="FuPluginVliUsbhub"']
 
@@ -55,5 +54,4 @@ if get_option('tests')
     c_args: cargs,
   )
   test('vli-self-test', e, env: env)  # added to installed-tests
-endif
 endif

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 cargs = ['-DG_LOG_DOMAIN="FuPluginWacomUsb"']
 
@@ -56,5 +55,4 @@ if get_option('tests')
     ],
   )
   test('wacom-usb-self-test', e, env: env)  # added to installed-tests
-endif
 endif

--- a/plugins/wistron-dock/meson.build
+++ b/plugins/wistron-dock/meson.build
@@ -1,4 +1,3 @@
-if libusb.found()
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 cargs = ['-DG_LOG_DOMAIN="FuPluginWistronDock"']
 
@@ -14,4 +13,3 @@ plugin_builtins += static_library('fu_plugin_wistron_dock',
   c_args: cargs,
   dependencies: plugin_deps,
 )
-endif

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -61,20 +61,16 @@
 #include "fu-security-attr-common.h"
 #include "fu-security-attrs-private.h"
 #include "fu-udev-device-private.h"
+#include "fu-usb-backend.h"
 #include "fu-usb-device-fw-ds20.h"
 #include "fu-usb-device-ms-ds20.h"
-#ifdef HAVE_LIBUSB
 #include "fu-usb-device-private.h"
-#endif
 
 #ifdef HAVE_GIO_UNIX
 #include "fu-unix-seekable-input-stream.h"
 #endif
 #ifdef HAVE_GUDEV
 #include "fu-udev-backend.h"
-#endif
-#ifdef HAVE_LIBUSB
-#include "fu-usb-backend.h"
 #endif
 #ifdef HAVE_BLUEZ
 #include "fu-bluez-backend.h"
@@ -8388,10 +8384,8 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	fu_context_add_firmware_gtype(self->ctx,
 				      "intel-thunderbolt-nvm",
 				      FU_TYPE_INTEL_THUNDERBOLT_NVM);
-#ifdef HAVE_LIBUSB
 	fu_context_add_firmware_gtype(self->ctx, "usb-device-fw-ds20", FU_TYPE_USB_DEVICE_FW_DS20);
 	fu_context_add_firmware_gtype(self->ctx, "usb-device-ms-ds20", FU_TYPE_USB_DEVICE_MS_DS20);
-#endif
 
 	/* we are emulating a different host */
 	if (host_emulate != NULL) {
@@ -8820,9 +8814,7 @@ fu_engine_constructed(GObject *obj)
 			 self);
 
 	/* backends */
-#ifdef HAVE_LIBUSB
 	g_ptr_array_add(self->backends, fu_usb_backend_new(self->ctx));
-#endif
 #ifdef HAVE_GUDEV
 	g_ptr_array_add(self->backends, fu_udev_backend_new(self->ctx));
 #endif
@@ -8861,9 +8853,7 @@ fu_engine_constructed(GObject *obj)
 #endif
 
 	fu_context_add_compile_version(self->ctx, "org.freedesktop.fwupd", VERSION);
-#ifdef HAVE_LIBUSB
 	fu_context_add_compile_version(self->ctx, "info.libusb", LIBUSB_VERSION);
-#endif
 #ifdef HAVE_PASSIM
 	{
 		g_autofree gchar *version = g_strdup_printf("%i.%i.%i",

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4016,7 +4016,6 @@ _plugin_device_register_cb(FuPlugin *plugin, FuDevice *device, gpointer user_dat
 	fu_plugin_runner_device_register(plugin, device);
 }
 
-#ifdef HAVE_LIBUSB
 static void
 fu_backend_usb_hotplug_cb(FuBackend *backend, FuDevice *device, gpointer user_data)
 {
@@ -4038,7 +4037,6 @@ fu_backend_usb_load_file(FuBackend *backend, const gchar *fn)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }
-#endif
 
 /*
  * To generate the fwupd DS20 descriptor in the usb-devices.json file save fw-ds20.builder.xml:
@@ -4066,7 +4064,6 @@ fu_backend_usb_load_file(FuBackend *backend, const gchar *fn)
 static void
 fu_backend_usb_func(gconstpointer user_data)
 {
-#ifdef HAVE_LIBUSB
 	FuTest *self = (FuTest *)user_data;
 	gboolean ret;
 	guint cnt_added = 0;
@@ -4146,15 +4143,11 @@ fu_backend_usb_func(gconstpointer user_data)
 	fu_backend_usb_load_file(backend, usb_emulate_fn3);
 	g_assert_cmpint(cnt_added, ==, 2);
 	g_assert_cmpint(cnt_removed, ==, 1);
-#else
-	g_test_skip("No GUsb support");
-#endif
 }
 
 static void
 fu_backend_usb_invalid_func(gconstpointer user_data)
 {
-#ifdef HAVE_LIBUSB
 	FuTest *self = (FuTest *)user_data;
 	gboolean ret;
 	FuDevice *device_tmp;
@@ -4204,9 +4197,6 @@ fu_backend_usb_invalid_func(gconstpointer user_data)
 
 	/* check the fwupd DS20 descriptor was *not* parsed */
 	g_assert_false(fu_device_has_icon(device_tmp, "computer"));
-#else
-	g_test_skip("No GUsb support");
-#endif
 }
 
 static void

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,7 @@ fwupd_engine_src = [
   'fu-remote.c',
   'fu-remote-list.c',
   'fu-security-attr-common.c',
+  'fu-usb-backend.c',
   'fu-client.c',
   'fu-client-list.c',
 ] + systemd_src
@@ -64,12 +65,8 @@ fwupd_engine_src = [
 if giounix.found()
   fwupd_engine_src += 'fu-unix-seekable-input-stream.c'
 endif
-
 if gudev.found()
   fwupd_engine_src += 'fu-udev-backend.c'
-endif
-if libusb.found()
-  fwupd_engine_src += 'fu-usb-backend.c'
 endif
 if bluez.allowed()
   fwupd_engine_src += 'fu-bluez-backend.c'


### PR DESCRIPTION
There are too many ifdefs right now, and it's a bit of a confusing mess to work out what include files should be included in each case.

From a 40,000ft view it's also not something I really want to support -- you either get the 'full fat' fwupd where everything works the same or nothing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
