### PR TITLE
Move getting the device parent from the device to the backend

### DIFF
--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -26,6 +26,10 @@ struct _FuBackendClass {
 	void (*registered)(FuBackend *self, FuDevice *device);
 	void (*invalidate)(FuBackend *self);
 	void (*to_string)(FuBackend *self, guint indent, GString *str);
+	FuDevice *(*get_device_parent)(FuBackend *self,
+				       FuDevice *device,
+				       const gchar *kind,
+				       GError **error)G_GNUC_WARN_UNUSED_RESULT;
 };
 
 const gchar *
@@ -58,3 +62,5 @@ void
 fu_backend_invalidate(FuBackend *self) G_GNUC_NON_NULL(1);
 void
 fu_backend_add_string(FuBackend *self, guint idt, GString *str) G_GNUC_NON_NULL(1, 3);
+FuDevice *
+fu_backend_get_device_parent(FuBackend *self, FuDevice *device, const gchar *kind, GError **error);

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -8,6 +8,7 @@
 
 #include <xmlb.h>
 
+#include "fu-backend.h"
 #include "fu-device-event.h"
 #include "fu-device.h"
 
@@ -88,3 +89,8 @@ FuDeviceEvent *
 fu_device_save_event(FuDevice *self, const gchar *id);
 FuDeviceEvent *
 fu_device_load_event(FuDevice *self, const gchar *id, GError **error);
+
+FuBackend *
+fu_device_get_backend(FuDevice *self);
+void
+fu_device_set_backend(FuDevice *self, FuBackend *backend);

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -640,6 +640,11 @@ FuDevice *
 fu_device_get_root(FuDevice *self) G_GNUC_NON_NULL(1);
 FuDevice *
 fu_device_get_parent(FuDevice *self) G_GNUC_NON_NULL(1);
+FuDevice *
+fu_device_get_backend_parent(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
+FuDevice *
+fu_device_get_backend_parent_with_kind(FuDevice *self, const gchar *kind, GError **error)
+    G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_device_get_children(FuDevice *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -129,7 +129,7 @@ fu_drm_device_get_edid(FuDrmDevice *self)
 static gboolean
 fu_drm_device_probe(FuDevice *device, GError **error)
 {
-	g_autoptr(FuUdevDevice) parent = NULL;
+	g_autoptr(FuDevice) parent = NULL;
 	FuDrmDevice *self = FU_DRM_DEVICE(device);
 	FuDrmDevicePrivate *priv = GET_PRIVATE(self);
 	const gchar *sysfs_path = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
@@ -171,12 +171,12 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* set the parent */
-	parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-							  "pci",
-							  NULL, /* devtype */
-							  NULL);
-	if (parent != NULL)
-		fu_device_add_parent_backend_id(device, fu_udev_device_get_sysfs_path(parent));
+	parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", NULL);
+	if (parent != NULL) {
+		fu_device_add_parent_backend_id(
+		    device,
+		    fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(parent)));
+	}
 
 	/* read EDID and parse it */
 	if (priv->display_state == FU_DISPLAY_STATE_CONNECTED) {

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -59,8 +59,7 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* get bus number out of sysfs path */
-	udev_parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device), "i2c", NULL, NULL);
+	udev_parent = FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "i2c", NULL));
 	if (udev_parent != NULL) {
 		g_autofree gchar *devfile = NULL;
 		if (!fu_udev_device_parse_number(udev_parent, error))

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -75,10 +75,8 @@ fu_mei_device_ensure_parent_device_file(FuMeiDevice *self, GError **error)
 	g_autoptr(GDir) dir = NULL;
 
 	/* get direct parent */
-	parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-							  "pci", /* subsystem */
-							  NULL,	 /* devtype */
-							  error);
+	parent =
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error));
 	if (parent == NULL)
 		return FALSE;
 

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -215,11 +215,6 @@ fu_udev_device_get_siblings_with_subsystem(FuUdevDevice *self,
 GPtrArray *
 fu_udev_device_get_children_with_subsystem(FuUdevDevice *self, const gchar *subsystem)
     G_GNUC_NON_NULL(1, 2);
-FuUdevDevice *
-fu_udev_device_get_parent_with_subsystem(FuUdevDevice *self,
-					 const gchar *subsystem,
-					 const gchar *devtype,
-					 GError **error) G_GNUC_NON_NULL(1);
 
 FuDevice *
 fu_udev_device_find_usb_device(FuUdevDevice *self, GError **error) G_GNUC_WARN_UNUSED_RESULT

--- a/libfwupdplugin/fu-usb-device-private.h
+++ b/libfwupdplugin/fu-usb-device-private.h
@@ -14,3 +14,5 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(libusb_context, libusb_exit)
 
 FuUsbDevice *
 fu_usb_device_new(FuContext *ctx, libusb_device *usb_device) G_GNUC_NON_NULL(1);
+libusb_device *
+fu_usb_device_get_dev(FuUsbDevice *self);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -169,6 +169,17 @@ fu_usb_device_libusb_status_to_gerror(gint status, GError **error)
 	return ret;
 }
 
+/**
+ * fu_usb_device_get_dev: (skip):
+ **/
+libusb_device *
+fu_usb_device_get_dev(FuUsbDevice *self)
+{
+	FuUsbDevicePrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FU_IS_USB_DEVICE(self), NULL);
+	return priv->usb_device;
+}
+
 static gboolean
 fu_usb_device_not_open_error(FuUsbDevice *self, GError **error)
 {
@@ -268,33 +279,6 @@ fu_usb_device_init(FuUsbDevice *device)
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_PERMISSION_DENIED,
 				     NULL);
-}
-
-/**
- * fu_usb_device_get_parent:
- * @self: a #FuUsbDevice
- *
- * Gets the USB device parent.
- *
- * Returns: (transfer full): a #FuUsbDevice, or %NULL for error
- *
- * Since: 2.0.0
- **/
-FuUsbDevice *
-fu_usb_device_get_parent(FuUsbDevice *self)
-{
-	FuUsbDevicePrivate *priv = GET_PRIVATE(self);
-	libusb_device *usb_device;
-
-	g_return_val_if_fail(FU_IS_USB_DEVICE(self), NULL);
-
-	/* sanity check */
-	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED))
-		return NULL;
-	usb_device = libusb_get_parent(priv->usb_device);
-	if (usb_device == NULL)
-		return NULL;
-	return fu_usb_device_new(fu_device_get_context(FU_DEVICE(self)), usb_device);
 }
 
 /**

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -29,9 +29,6 @@ typedef enum {
 	FU_USB_DEVICE_CLAIM_FLAG_KERNEL_DRIVER = 1 << 0,
 } FuUsbDeviceClaimFlags;
 
-FuUsbDevice *
-fu_usb_device_get_parent(FuUsbDevice *self) G_GNUC_NON_NULL(1);
-
 guint8
 fu_usb_device_get_bus(FuUsbDevice *self) G_GNUC_NON_NULL(1);
 guint8

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -102,10 +102,7 @@ fu_elantp_i2c_device_probe(FuDevice *device, GError **error)
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "i2c") == 0) {
 		g_autoptr(GPtrArray) i2c_buses = NULL;
 		FuUdevDevice *i2c_device =
-		    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device),
-							     "i2c",
-							     NULL, /* devtype */
-							     error);
+		    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "i2c", error));
 		if (i2c_device == NULL)
 			return FALSE;
 

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -140,7 +140,7 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 	g_autoptr(GRegex) dev_regex = NULL;
 
 	udev_parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device), "mmc", "disk", NULL);
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "mmc:disk", NULL));
 	if (udev_parent == NULL) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no MMC parent");
 		return FALSE;

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -58,22 +58,21 @@ fu_genesys_plugin_get_device_by_physical_id(FuPlugin *self, const gchar *physica
 static void
 fu_genesys_plugin_device_added(FuPlugin *self, FuDevice *device)
 {
-	FuUsbDevice *usb_parent = NULL;
 	FuDevice *parent = NULL;
+	g_autoptr(FuDevice) usb_parent = NULL;
 
 	/* link hid to parent hub */
 	if (!FU_IS_GENESYS_HUBHID_DEVICE(device))
 		return;
 
-	usb_parent = fu_usb_device_get_parent(FU_USB_DEVICE(device));
+	usb_parent = fu_device_get_backend_parent(device, NULL);
 	if (usb_parent == NULL)
 		return;
-	parent = fu_genesys_plugin_get_device_by_physical_id(
-	    self,
-	    fu_device_get_physical_id(FU_DEVICE(usb_parent)));
+	parent = fu_genesys_plugin_get_device_by_physical_id(self,
+							     fu_device_get_physical_id(usb_parent));
 	if (parent == NULL) {
 		g_warning("hubhid cannot find parent, platform_id(%s)",
-			  fu_device_get_physical_id(FU_DEVICE(usb_parent)));
+			  fu_device_get_physical_id(usb_parent));
 		fu_plugin_device_remove(self, device);
 	} else {
 		fu_genesys_usbhub_device_set_hid_channel(parent, device);

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -759,13 +759,13 @@ fu_igsc_device_write_firmware(FuDevice *device,
 static gboolean
 fu_igsc_device_set_pci_power_policy(FuIgscDevice *self, const gchar *val, GError **error)
 {
-	g_autoptr(FuUdevDevice) parent = NULL;
+	g_autoptr(FuDevice) parent = NULL;
 
 	/* get PCI parent */
-	parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self), "pci", NULL, error);
+	parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error);
 	if (parent == NULL)
 		return FALSE;
-	return fu_udev_device_write_sysfs(parent,
+	return fu_udev_device_write_sysfs(FU_UDEV_DEVICE(parent),
 					  "power/control",
 					  val,
 					  FU_IGSC_DEVICE_POWER_WRITE_TIMEOUT,

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -495,8 +495,7 @@ fu_mediatek_scaler_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* set vid and pid from PCI bus */
-	udev_parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device), "pci", NULL, error);
+	udev_parent = FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "pci", error));
 	if (udev_parent == NULL)
 		return FALSE;
 	if (!fu_device_probe(FU_DEVICE(udev_parent), error))

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -274,12 +274,9 @@ fu_nvme_device_parse_cns(FuNvmeDevice *self, const guint8 *buf, gsize sz, GError
 static gboolean
 fu_nvme_device_is_pci(FuNvmeDevice *self, GError **error)
 {
-	g_autoptr(FuUdevDevice) parent_pci = NULL;
+	g_autoptr(FuDevice) parent_pci = NULL;
 
-	parent_pci = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-							      "pci",
-							      NULL, /* devtype */
-							      error);
+	parent_pci = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error);
 	if (parent_pci == NULL)
 		return FALSE;
 

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -901,16 +901,13 @@ static gboolean
 fu_pxi_receiver_device_probe(FuDevice *device, GError **error)
 {
 	g_autofree gchar *iface_nr = NULL;
-	g_autoptr(FuUdevDevice) usb_parent = NULL;
+	g_autoptr(FuDevice) usb_parent = NULL;
 
 	/* check USB interface number */
-	usb_parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device),
-							      "usb",
-							      NULL, /* devtype */
-							      error);
+	usb_parent = fu_device_get_backend_parent_with_kind(device, "usb", error);
 	if (usb_parent == NULL)
 		return FALSE;
-	iface_nr = fu_udev_device_read_sysfs(usb_parent,
+	iface_nr = fu_udev_device_read_sysfs(FU_UDEV_DEVICE(usb_parent),
 					     "bInterfaceNumber",
 					     FU_UDEV_DEVICE_ATTR_READ_TIMEOUT_DEFAULT,
 					     error);

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -48,7 +48,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 	FuScsiDevice *self = FU_SCSI_DEVICE(device);
 	g_autofree gchar *attr_removable = NULL;
 	g_autofree gchar *vendor_id = NULL;
-	g_autoptr(FuUdevDevice) ufshci_parent = NULL;
+	g_autoptr(FuDevice) ufshci_parent = NULL;
 	const gchar *subsystem_parents[] = {"pci", "platform", NULL};
 
 	/* check is valid */
@@ -75,10 +75,8 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 
 	/* the ufshci controller could really be on any bus... search in order of priority */
 	for (guint i = 0; subsystem_parents[i] != NULL && ufshci_parent == NULL; i++) {
-		ufshci_parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device),
-									 subsystem_parents[i],
-									 NULL, /* devtype */
-									 NULL);
+		ufshci_parent =
+		    fu_device_get_backend_parent_with_kind(device, subsystem_parents[i], NULL);
 	}
 	if (ufshci_parent != NULL) {
 		g_autofree gchar *attr_ufs_features = NULL;
@@ -86,7 +84,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 
 		/* check if this is a UFS device */
 		g_info("found ufshci controller at %s",
-		       fu_udev_device_get_sysfs_path(ufshci_parent));
+		       fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(ufshci_parent)));
 
 		attr_ufs_features =
 		    fu_udev_device_read_sysfs(FU_UDEV_DEVICE(self),

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -349,33 +349,28 @@ fu_synaptics_rmi_hid_device_rebind_driver(FuSynapticsRmiDevice *self, GError **e
 	const gchar *subsystem;
 	g_autofree gchar *fn_rebind = NULL;
 	g_autofree gchar *fn_unbind = NULL;
-	g_autoptr(FuUdevDevice) parent_hid = NULL;
+	g_autoptr(FuDevice) parent_hid = NULL;
 	g_autoptr(FuUdevDevice) parent_phys = NULL;
 	g_auto(GStrv) hid_strs = NULL;
 
 	/* get actual HID node */
-	parent_hid = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-							      "hid",
-							      NULL, /* devtype */
-							      error);
+	parent_hid = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "hid", error);
 	if (parent_hid == NULL)
 		return FALSE;
 
 	/* build paths */
 	parent_phys =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self), "i2c", NULL, NULL);
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "i2c", NULL));
 	if (parent_phys == NULL) {
-		parent_phys = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-								       "usb",
-								       NULL, /* devtype */
-								       NULL);
+		parent_phys = FU_UDEV_DEVICE(
+		    fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "usb", NULL));
 	}
 	if (parent_phys == NULL) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "no parent device for %s",
-			    fu_udev_device_get_sysfs_path(parent_hid));
+			    fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(parent_hid)));
 		return FALSE;
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -82,19 +82,18 @@ fu_thunderbolt_controller_probe(FuDevice *device, GError **error)
 	FuThunderboltController *self = FU_THUNDERBOLT_CONTROLLER(device);
 	const gchar *parent_name = NULL;
 	g_autofree gchar *attr_unique_id = NULL;
-	g_autoptr(FuUdevDevice) device_parent = NULL;
+	g_autoptr(FuDevice) device_parent = NULL;
 
 	/* FuUdevDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_thunderbolt_controller_parent_class)->probe(device, error))
 		return FALSE;
 
 	/* determine if host controller or not */
-	device_parent = fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(self),
-								 "thunderbolt",
-								 "thunderbolt_domain",
-								 NULL);
+	device_parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self),
+							       "thunderbolt:thunderbolt_domain",
+							       NULL);
 	if (device_parent != NULL)
-		parent_name = fu_device_get_name(FU_DEVICE(device_parent));
+		parent_name = fu_device_get_name(device_parent);
 	if (parent_name != NULL && g_str_has_prefix(parent_name, "domain"))
 		self->controller_kind = FU_THUNDERBOLT_CONTROLLER_KIND_HOST;
 

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -433,15 +433,14 @@ fu_thunderbolt_device_write_firmware(FuDevice *device,
 static gboolean
 fu_thunderbolt_device_probe(FuDevice *device, GError **error)
 {
-	g_autoptr(FuUdevDevice) udev_parent = NULL;
+	g_autoptr(FuDevice) udev_parent = NULL;
 
 	/* if the PCI ID is Intel then it's signed, no idea otherwise */
-	udev_parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device), "pci", NULL, NULL);
+	udev_parent = fu_device_get_backend_parent_with_kind(device, "pci", NULL);
 	if (udev_parent != NULL) {
-		if (!fu_device_probe(FU_DEVICE(udev_parent), error))
+		if (!fu_device_probe(udev_parent, error))
 			return FALSE;
-		if (fu_udev_device_get_vendor(udev_parent) == 0x8086)
+		if (fu_udev_device_get_vendor(FU_UDEV_DEVICE(udev_parent)) == 0x8086)
 			fu_device_add_flag(device, FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	}
 

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -20,27 +20,21 @@ G_DEFINE_TYPE(FuThunderboltRetimer, fu_thunderbolt_retimer, FU_TYPE_THUNDERBOLT_
 gboolean
 fu_thunderbolt_retimer_set_parent_port_offline(FuDevice *device, GError **error)
 {
-	g_autoptr(FuUdevDevice) parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device),
-						     "thunderbolt",
-						     "thunderbolt_domain",
-						     error);
+	g_autoptr(FuDevice) parent =
+	    fu_device_get_backend_parent_with_kind(device, "thunderbolt:thunderbolt_domain", error);
 	if (parent == NULL)
 		return FALSE;
-	return fu_thunderbolt_udev_set_port_offline(parent, error);
+	return fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(parent), error);
 }
 
 gboolean
 fu_thunderbolt_retimer_set_parent_port_online(FuDevice *device, GError **error)
 {
-	g_autoptr(FuUdevDevice) parent =
-	    fu_udev_device_get_parent_with_subsystem(FU_UDEV_DEVICE(device),
-						     "thunderbolt",
-						     "thunderbolt_domain",
-						     error);
+	g_autoptr(FuDevice) parent =
+	    fu_device_get_backend_parent_with_kind(device, "thunderbolt:thunderbolt_domain", error);
 	if (parent == NULL)
 		return FALSE;
-	return fu_thunderbolt_udev_set_port_online(parent, error);
+	return fu_thunderbolt_udev_set_port_online(FU_UDEV_DEVICE(parent), error);
 }
 
 static gboolean

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -88,13 +88,10 @@ fu_udev_backend_rescan_dpaux_devices(FuUdevBackend *self)
 				  self);
 }
 
-static void
-fu_udev_backend_device_add(FuUdevBackend *self, GUdevDevice *udev_device)
+static FuUdevDevice *
+fu_udev_backend_create_device(FuUdevBackend *self, GUdevDevice *udev_device)
 {
-	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
 	GType gtype = FU_TYPE_UDEV_DEVICE;
-	g_autoptr(FuUdevDevice) device = NULL;
-	g_autoptr(GPtrArray) possible_plugins = NULL;
 	struct {
 		const gchar *subsystem;
 		GType gtype;
@@ -113,14 +110,18 @@ fu_udev_backend_device_add(FuUdevBackend *self, GUdevDevice *udev_device)
 			break;
 		}
 	}
+	return g_object_new(gtype, "backend", FU_BACKEND(self), "udev-device", udev_device, NULL);
+}
 
-	/* success */
-	device = g_object_new(gtype,
-			      "context",
-			      fu_backend_get_context(FU_BACKEND(self)),
-			      "udev-device",
-			      udev_device,
-			      NULL);
+static void
+fu_udev_backend_device_add(FuUdevBackend *self, GUdevDevice *udev_device)
+{
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	g_autoptr(FuUdevDevice) device = NULL;
+	g_autoptr(GPtrArray) possible_plugins = NULL;
+
+	/* use the subsystem to create the correct GType */
+	device = fu_udev_backend_create_device(self, udev_device);
 
 	/* these are used without a subclass */
 	if (g_strcmp0(g_udev_device_get_subsystem(udev_device), "msr") == 0)
@@ -327,6 +328,80 @@ fu_udev_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **erro
 	return TRUE;
 }
 
+static gboolean
+fu_udev_device_match_subsystem_devtype(GUdevDevice *udev_device,
+				       const gchar *subsystem,
+				       const gchar *devtype)
+{
+	if (subsystem != NULL) {
+		if (g_strcmp0(g_udev_device_get_subsystem(udev_device), subsystem) != 0)
+			return FALSE;
+	}
+	if (devtype != NULL) {
+		if (g_strcmp0(g_udev_device_get_devtype(udev_device), devtype) != 0)
+			return FALSE;
+	}
+	return TRUE;
+}
+
+static FuDevice *
+fu_udev_backend_get_device_parent(FuBackend *backend,
+				  FuDevice *device,
+				  const gchar *kind,
+				  GError **error)
+{
+	FuUdevBackend *self = FU_UDEV_BACKEND(backend);
+	GUdevDevice *udev_device = fu_udev_device_get_dev(FU_UDEV_DEVICE(device));
+	g_autoptr(GUdevDevice) device_tmp = NULL;
+	g_auto(GStrv) subsystem_devtype = NULL;
+
+	/* sanity check */
+	if (udev_device == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "not initialized");
+		return NULL;
+	}
+	if (kind == NULL) {
+		g_autoptr(GUdevDevice) parent = g_udev_device_get_parent(udev_device);
+		if (parent == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "no parent");
+			return NULL;
+		}
+		return FU_DEVICE(fu_udev_backend_create_device(self, parent));
+	}
+	subsystem_devtype = g_strsplit(kind, ",", 2);
+	device_tmp = g_object_ref(udev_device);
+	while (device_tmp != NULL) {
+		g_autoptr(GUdevDevice) parent = NULL;
+		if (fu_udev_device_match_subsystem_devtype(device_tmp,
+							   subsystem_devtype[0],
+							   subsystem_devtype[1]))
+			break;
+		parent = g_udev_device_get_parent(device_tmp);
+		g_set_object(&device_tmp, parent);
+	}
+	if (device_tmp == NULL) {
+		if (subsystem_devtype[1] != NULL) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no parent with subsystem %s and devtype %s",
+				    subsystem_devtype[0],
+				    subsystem_devtype[1]);
+			return NULL;
+		}
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "no parent with subsystem %s",
+			    subsystem_devtype[0]);
+		return NULL;
+	}
+	return FU_DEVICE(fu_udev_backend_create_device(self, device_tmp));
+}
+
 static void
 fu_udev_backend_finalize(GObject *object)
 {
@@ -359,6 +434,7 @@ fu_udev_backend_class_init(FuUdevBackendClass *klass)
 	object_class->finalize = fu_udev_backend_finalize;
 	backend_class->coldplug = fu_udev_backend_coldplug;
 	backend_class->to_string = fu_udev_backend_to_string;
+	backend_class->get_device_parent = fu_udev_backend_get_device_parent;
 }
 
 FuBackend *


### PR DESCRIPTION
In some cases the device itself doesn't have enough of a 'world-view' to understand what the parent should be.

Move this to the backend which can also create the right GType as required, e.g. creating a custom FuI2cDevice parent rather than a 'plain' FuUdevDevice.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
