### PR TITLE
dell-dock: setup hub version until dock type is known to be supported

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -123,6 +123,10 @@ fu_dell_dock_hub_setup(FuDevice *device, GError **error)
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_dell_dock_hub_parent_class)->setup(device, error))
 		return FALSE;
+
+	if (fu_device_has_private_flag(device, FU_DELL_DOCK_HUB_FLAG_HAS_BRIDGE))
+		return TRUE;
+
 	return fu_dell_dock_hid_get_hub_version(device, error);
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -365,7 +365,6 @@ fu_dell_dock_ec_get_dock_info(FuDevice *device, GError **error)
 	const FuDellDockDockInfoHeader *header = NULL;
 	const FuDellDockEcQueryEntry *device_entry = NULL;
 	const FuDellDockEcAddrMap *map = NULL;
-	const gchar *hub_version;
 	guint32 oldest_base_pd = 0;
 	g_autoptr(GBytes) data = NULL;
 
@@ -497,16 +496,7 @@ fu_dell_dock_ec_get_dock_info(FuDevice *device, GError **error)
 		fu_device_set_install_duration(device, tmp + 20);
 	}
 
-	/* Determine if the passive flow should be used when flashing */
-	hub_version = fu_device_get_version(fu_device_get_proxy(device));
-	if (fu_version_compare(hub_version, "1.42", FWUPD_VERSION_FORMAT_PAIR) < 0) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "dock containing hub2 version %s is not supported",
-			    hub_version);
-		return FALSE;
-	}
+	/* passive flow is default enabled for production docks */
 	self->passive_flow = PASSIVE_REBOOT_MASK;
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_SKIPS_RESTART);
 	return TRUE;

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -310,6 +310,10 @@ fu_dell_dock_plugin_backend_device_added(FuPlugin *plugin,
 			if (!fu_dell_dock_plugin_create_node(plugin, FU_DEVICE(ec_v1_dev), error))
 				return FALSE;
 
+			/* hub delayed version setup until dock type is known to be supported */
+			if (!fu_dell_dock_hid_get_hub_version(FU_DEVICE(hub_device), error))
+				return FALSE;
+
 			/* add dock ec sub-components */
 			if (!fu_dell_dock_plugin_probe_ec_v1_subcomponents(plugin,
 									   FU_DEVICE(ec_v1_dev),


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

The device ID is being reused in the existing docks and the upcoming one, and the commands in this plugin will not work for the new dock. We will delay the hub commands until we know the dock is fully supported within this plugin.

In the ec device side, the version comparison must be removed because the hub version is detauled to `1.1` (due to delayed probing) which will always fail to be added.