### PR TITLE
trivial: Never return the original device from fu_device_get_backend_…

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -153,17 +153,20 @@ fu_backend_registered(FuBackend *self, FuDevice *device)
  * fu_backend_get_device_parent:
  * @self: a #FuBackend
  * @device: a #FuDevice
- * @kind: (nullable): an optional device kind, e.g. "usb:usb_device"
+ * @subsystem: (nullable): an optional device subsystem, e.g. "usb:usb_device"
  * @error: (nullable): optional return location for an error
  *
- * Asks the backend to create the parent device (of the correct type) for a given device kind.
+ * Asks the backend to create the parent device (of the correct type) for a given device subsystem.
  *
  * Returns: (transfer full): a #FuDevice or %NULL if not found or unimplemented
  *
  * Since: 2.0.0
  **/
 FuDevice *
-fu_backend_get_device_parent(FuBackend *self, FuDevice *device, const gchar *kind, GError **error)
+fu_backend_get_device_parent(FuBackend *self,
+			     FuDevice *device,
+			     const gchar *subsystem,
+			     GError **error)
 {
 	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
 
@@ -178,7 +181,7 @@ fu_backend_get_device_parent(FuBackend *self, FuDevice *device, const gchar *kin
 				    "not implemented");
 		return NULL;
 	}
-	return klass->get_device_parent(self, device, kind, error);
+	return klass->get_device_parent(self, device, subsystem, error);
 }
 
 /**

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -28,7 +28,7 @@ struct _FuBackendClass {
 	void (*to_string)(FuBackend *self, guint indent, GString *str);
 	FuDevice *(*get_device_parent)(FuBackend *self,
 				       FuDevice *device,
-				       const gchar *kind,
+				       const gchar *subsystem,
 				       GError **error)G_GNUC_WARN_UNUSED_RESULT;
 };
 
@@ -63,4 +63,7 @@ fu_backend_invalidate(FuBackend *self) G_GNUC_NON_NULL(1);
 void
 fu_backend_add_string(FuBackend *self, guint idt, GString *str) G_GNUC_NON_NULL(1, 3);
 FuDevice *
-fu_backend_get_device_parent(FuBackend *self, FuDevice *device, const gchar *kind, GError **error);
+fu_backend_get_device_parent(FuBackend *self,
+			     FuDevice *device,
+			     const gchar *subsystem,
+			     GError **error);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -3677,9 +3677,9 @@ fu_device_set_backend(FuDevice *self, FuBackend *backend)
 }
 
 /**
- * fu_device_get_backend_parent_with_kind:
+ * fu_device_get_backend_parent_with_subsystem:
  * @self: a #FuDevice
- * @kind: (nullable): an optional device kind, e.g. "usb:usb_device"
+ * @subsystem: (nullable): an optional device subsystem, e.g. "usb:usb_device"
  * @error: (nullable): optional return location for an error
  *
  * Creates a device parent (of the correct type) using the current backend for a given device kind.
@@ -3693,7 +3693,7 @@ fu_device_set_backend(FuDevice *self, FuBackend *backend)
  * Since: 2.0.0
  **/
 FuDevice *
-fu_device_get_backend_parent_with_kind(FuDevice *self, const gchar *kind, GError **error)
+fu_device_get_backend_parent_with_subsystem(FuDevice *self, const gchar *subsystem, GError **error)
 {
 	FuDevicePrivate *priv = GET_PRIVATE(self);
 
@@ -3707,7 +3707,7 @@ fu_device_get_backend_parent_with_kind(FuDevice *self, const gchar *kind, GError
 				    "no backend set for device");
 		return NULL;
 	}
-	return fu_backend_get_device_parent(priv->backend, self, kind, error);
+	return fu_backend_get_device_parent(priv->backend, self, subsystem, error);
 }
 
 /**
@@ -3730,7 +3730,7 @@ fu_device_get_backend_parent(FuDevice *self, GError **error)
 {
 	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-	return fu_device_get_backend_parent_with_kind(self, NULL, error);
+	return fu_device_get_backend_parent_with_subsystem(self, NULL, error);
 }
 
 /**

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -643,7 +643,7 @@ fu_device_get_parent(FuDevice *self) G_GNUC_NON_NULL(1);
 FuDevice *
 fu_device_get_backend_parent(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
 FuDevice *
-fu_device_get_backend_parent_with_kind(FuDevice *self, const gchar *kind, GError **error)
+fu_device_get_backend_parent_with_subsystem(FuDevice *self, const gchar *subsystem, GError **error)
     G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_device_get_children(FuDevice *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -171,7 +171,7 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* set the parent */
-	parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", NULL);
+	parent = fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "pci", NULL);
 	if (parent != NULL) {
 		fu_device_add_parent_backend_id(
 		    device,

--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -59,7 +59,8 @@ fu_i2c_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* get bus number out of sysfs path */
-	udev_parent = FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "i2c", NULL));
+	udev_parent =
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_subsystem(device, "i2c", NULL));
 	if (udev_parent != NULL) {
 		g_autofree gchar *devfile = NULL;
 		if (!fu_udev_device_parse_number(udev_parent, error))

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -75,8 +75,8 @@ fu_mei_device_ensure_parent_device_file(FuMeiDevice *self, GError **error)
 	g_autoptr(GDir) dir = NULL;
 
 	/* get direct parent */
-	parent =
-	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error));
+	parent = FU_UDEV_DEVICE(
+	    fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "pci", error));
 	if (parent == NULL)
 		return FALSE;
 

--- a/libfwupdplugin/fu-udev-device-private.h
+++ b/libfwupdplugin/fu-udev-device-private.h
@@ -14,3 +14,5 @@ void
 fu_udev_device_set_io_channel(FuUdevDevice *self, FuIOChannel *io_channel) G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_udev_device_parse_number(FuUdevDevice *self, GError **error) G_GNUC_NON_NULL(1);
+gboolean
+fu_udev_device_match_subsystem(FuUdevDevice *self, const gchar *subsystem) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -208,6 +208,7 @@ fu_udev_device_write_sysfs(FuUdevDevice *self,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
 const gchar *
 fu_udev_device_get_devtype(FuUdevDevice *self) G_GNUC_NON_NULL(1);
+
 GPtrArray *
 fu_udev_device_get_siblings_with_subsystem(FuUdevDevice *self,
 					   const gchar *subsystem,

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -101,8 +101,8 @@ fu_elantp_i2c_device_probe(FuDevice *device, GError **error)
 	/* check is valid */
 	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "i2c") == 0) {
 		g_autoptr(GPtrArray) i2c_buses = NULL;
-		FuUdevDevice *i2c_device =
-		    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "i2c", error));
+		FuUdevDevice *i2c_device = FU_UDEV_DEVICE(
+		    fu_device_get_backend_parent_with_subsystem(device, "i2c", error));
 		if (i2c_device == NULL)
 			return FALSE;
 

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -140,7 +140,7 @@ fu_emmc_device_probe(FuDevice *device, GError **error)
 	g_autoptr(GRegex) dev_regex = NULL;
 
 	udev_parent =
-	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "mmc:disk", NULL));
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_subsystem(device, "mmc:disk", NULL));
 	if (udev_parent == NULL) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no MMC parent");
 		return FALSE;

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -762,7 +762,7 @@ fu_igsc_device_set_pci_power_policy(FuIgscDevice *self, const gchar *val, GError
 	g_autoptr(FuDevice) parent = NULL;
 
 	/* get PCI parent */
-	parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error);
+	parent = fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "pci", error);
 	if (parent == NULL)
 		return FALSE;
 	return fu_udev_device_write_sysfs(FU_UDEV_DEVICE(parent),

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -109,7 +109,7 @@ fu_logitech_hidpp_runtime_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* generate bootloader-specific GUID */
-	device_usb = fu_device_get_backend_parent_with_kind(device, "usb:usb_device", NULL);
+	device_usb = fu_device_get_backend_parent_with_subsystem(device, "usb:usb_device", NULL);
 	if (device_usb != NULL) {
 		g_autofree gchar *prop_revision = NULL;
 		prop_revision =
@@ -149,9 +149,9 @@ fu_logitech_hidpp_runtime_probe(FuDevice *device, GError **error)
 		case 0x0500:
 			/* Bolt */
 			device_usb_iface =
-			    fu_device_get_backend_parent_with_kind(device,
-								   "usb:usb_interface",
-								   error);
+			    fu_device_get_backend_parent_with_subsystem(device,
+									"usb:usb_interface",
+									error);
 			if (device_usb_iface == NULL)
 				return FALSE;
 			prop_interface =

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -495,7 +495,8 @@ fu_mediatek_scaler_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* set vid and pid from PCI bus */
-	udev_parent = FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(device, "pci", error));
+	udev_parent =
+	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_subsystem(device, "pci", error));
 	if (udev_parent == NULL)
 		return FALSE;
 	if (!fu_device_probe(FU_DEVICE(udev_parent), error))

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -276,7 +276,7 @@ fu_nvme_device_is_pci(FuNvmeDevice *self, GError **error)
 {
 	g_autoptr(FuDevice) parent_pci = NULL;
 
-	parent_pci = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "pci", error);
+	parent_pci = fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "pci", error);
 	if (parent_pci == NULL)
 		return FALSE;
 

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -904,7 +904,7 @@ fu_pxi_receiver_device_probe(FuDevice *device, GError **error)
 	g_autoptr(FuDevice) usb_parent = NULL;
 
 	/* check USB interface number */
-	usb_parent = fu_device_get_backend_parent_with_kind(device, "usb", error);
+	usb_parent = fu_device_get_backend_parent_with_subsystem(device, "usb", error);
 	if (usb_parent == NULL)
 		return FALSE;
 	iface_nr = fu_udev_device_read_sysfs(FU_UDEV_DEVICE(usb_parent),

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -76,7 +76,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 	/* the ufshci controller could really be on any bus... search in order of priority */
 	for (guint i = 0; subsystem_parents[i] != NULL && ufshci_parent == NULL; i++) {
 		ufshci_parent =
-		    fu_device_get_backend_parent_with_kind(device, subsystem_parents[i], NULL);
+		    fu_device_get_backend_parent_with_subsystem(device, subsystem_parents[i], NULL);
 	}
 	if (ufshci_parent != NULL) {
 		g_autofree gchar *attr_ufs_features = NULL;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -354,16 +354,16 @@ fu_synaptics_rmi_hid_device_rebind_driver(FuSynapticsRmiDevice *self, GError **e
 	g_auto(GStrv) hid_strs = NULL;
 
 	/* get actual HID node */
-	parent_hid = fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "hid", error);
+	parent_hid = fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "hid", error);
 	if (parent_hid == NULL)
 		return FALSE;
 
 	/* build paths */
-	parent_phys =
-	    FU_UDEV_DEVICE(fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "i2c", NULL));
+	parent_phys = FU_UDEV_DEVICE(
+	    fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "i2c", NULL));
 	if (parent_phys == NULL) {
 		parent_phys = FU_UDEV_DEVICE(
-		    fu_device_get_backend_parent_with_kind(FU_DEVICE(self), "usb", NULL));
+		    fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "usb", NULL));
 	}
 	if (parent_phys == NULL) {
 		g_set_error(error,

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -89,9 +89,10 @@ fu_thunderbolt_controller_probe(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* determine if host controller or not */
-	device_parent = fu_device_get_backend_parent_with_kind(FU_DEVICE(self),
-							       "thunderbolt:thunderbolt_domain",
-							       NULL);
+	device_parent =
+	    fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self),
+							"thunderbolt:thunderbolt_domain",
+							NULL);
 	if (device_parent != NULL)
 		parent_name = fu_device_get_name(device_parent);
 	if (parent_name != NULL && g_str_has_prefix(parent_name, "domain"))

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -436,7 +436,7 @@ fu_thunderbolt_device_probe(FuDevice *device, GError **error)
 	g_autoptr(FuDevice) udev_parent = NULL;
 
 	/* if the PCI ID is Intel then it's signed, no idea otherwise */
-	udev_parent = fu_device_get_backend_parent_with_kind(device, "pci", NULL);
+	udev_parent = fu_device_get_backend_parent_with_subsystem(device, "pci", NULL);
 	if (udev_parent != NULL) {
 		if (!fu_device_probe(udev_parent, error))
 			return FALSE;

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -21,7 +21,9 @@ gboolean
 fu_thunderbolt_retimer_set_parent_port_offline(FuDevice *device, GError **error)
 {
 	g_autoptr(FuDevice) parent =
-	    fu_device_get_backend_parent_with_kind(device, "thunderbolt:thunderbolt_domain", error);
+	    fu_device_get_backend_parent_with_subsystem(device,
+							"thunderbolt:thunderbolt_domain",
+							error);
 	if (parent == NULL)
 		return FALSE;
 	return fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(parent), error);
@@ -31,7 +33,9 @@ gboolean
 fu_thunderbolt_retimer_set_parent_port_online(FuDevice *device, GError **error)
 {
 	g_autoptr(FuDevice) parent =
-	    fu_device_get_backend_parent_with_kind(device, "thunderbolt:thunderbolt_domain", error);
+	    fu_device_get_backend_parent_with_subsystem(device,
+							"thunderbolt:thunderbolt_domain",
+							error);
 	if (parent == NULL)
 		return FALSE;
 	return fu_thunderbolt_udev_set_port_online(FU_UDEV_DEVICE(parent), error);

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -344,7 +344,7 @@ fu_usb_backend_registered(FuBackend *backend, FuDevice *device)
 static FuDevice *
 fu_usb_backend_get_device_parent(FuBackend *backend,
 				 FuDevice *device,
-				 const gchar *kind,
+				 const gchar *subsystem,
 				 GError **error)
 {
 	FuUsbBackend *self = FU_USB_BACKEND(backend);


### PR DESCRIPTION
…parent()

All this recent confusion on *_get_parent() was really down to two different consumers wanting two different behaviours; fu_udev_device_set_physical_id() wanted to match the passed-in device and everything else didn't.

Rather than complicating an already complicated codepath, just check @self when using fu_udev_device_set_physical_id() and abstract out some common code.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
