### PR TITLE
trivial: Do not fall back to flashrom dependency if disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -486,11 +486,12 @@ if build_standalone
   conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
 endif
 
-allow_flashrom = get_option('plugin_flashrom').disable_auto_if(host_machine.system() != 'linux').allowed()
+flashrom = get_option('plugin_flashrom').disable_auto_if(host_machine.system() != 'linux')
+allow_flashrom = flashrom.allowed()
 if build_standalone
-  libflashrom = dependency('flashrom', 
-                            fallback: ['flashrom', 'flashrom_dep'], 
-                            required: allow_flashrom)
+  libflashrom = dependency('flashrom',
+                            fallback: ['flashrom', 'flashrom_dep'],
+                            required: flashrom)
 endif
 
 if libsystemd.found()


### PR DESCRIPTION
Setting `required` to a `bool` vs. `feature` behaves differently (see [meson docs](https://mesonbuild.com/Reference-manual_functions.html#dependency_required)). When `flashrom_allowed` is `false`, the flashrom dependency will still build the fallback subproject.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
