### PR TITLE
Remove fu_usb_interface_get_extra()

### DIFF
--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -21,7 +21,7 @@
 #include "fu-usb-bos-descriptor-private.h"
 
 struct _FuUsbBosDescriptor {
-	FuFirmware parent_instance;
+	FuUsbDescriptor parent_instance;
 	struct libusb_bos_dev_capability_descriptor bos_cap;
 };
 
@@ -30,7 +30,7 @@ fu_usb_bos_descriptor_codec_iface_init(FwupdCodecInterface *iface);
 
 G_DEFINE_TYPE_EXTENDED(FuUsbBosDescriptor,
 		       fu_usb_bos_descriptor,
-		       FU_TYPE_FIRMWARE,
+		       FU_TYPE_USB_DESCRIPTOR,
 		       0,
 		       G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC,
 					     fu_usb_bos_descriptor_codec_iface_init));
@@ -126,13 +126,17 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 	FuUsbBosDescriptor *self = FU_USB_BOS_DESCRIPTOR(firmware);
 	g_autoptr(FuUsbBosHdr) st = NULL;
 
+	/* FuUsbDescriptor */
+	if (!FU_FIRMWARE_CLASS(fu_usb_bos_descriptor_parent_class)
+		 ->parse(firmware, stream, offset, flags, error))
+		return FALSE;
+
 	/* parse */
 	st = fu_usb_bos_hdr_parse_stream(stream, offset, error);
 	if (st == NULL)
 		return FALSE;
 	self->bos_cap.bLength = fu_usb_bos_hdr_get_length(st);
 	self->bos_cap.bDevCapabilityType = fu_usb_bos_hdr_get_dev_capability_type(st);
-	fu_firmware_set_size(FU_FIRMWARE(self), self->bos_cap.bLength);
 
 	/* data */
 	if (self->bos_cap.bLength > st->len) {

--- a/libfwupdplugin/fu-usb-bos-descriptor.h
+++ b/libfwupdplugin/fu-usb-bos-descriptor.h
@@ -6,11 +6,14 @@
 
 #pragma once
 
-#include "fu-firmware.h"
-#include "fu-usb-struct.h"
+#include "fu-usb-descriptor.h"
 
 #define FU_TYPE_USB_BOS_DESCRIPTOR (fu_usb_bos_descriptor_get_type())
-G_DECLARE_FINAL_TYPE(FuUsbBosDescriptor, fu_usb_bos_descriptor, FU, USB_BOS_DESCRIPTOR, FuFirmware)
+G_DECLARE_FINAL_TYPE(FuUsbBosDescriptor,
+		     fu_usb_bos_descriptor,
+		     FU,
+		     USB_BOS_DESCRIPTOR,
+		     FuUsbDescriptor)
 
 guint8
 fu_usb_bos_descriptor_get_capability(FuUsbBosDescriptor *self);

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-partial-input-stream.h"
+#include "fu-usb-descriptor.h"
+
+G_DEFINE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU_TYPE_FIRMWARE)
+
+static gboolean
+fu_usb_descriptor_parse(FuFirmware *firmware,
+			GInputStream *stream,
+			gsize offset,
+			FwupdInstallFlags flags,
+			GError **error)
+{
+	FuUsbDescriptor *self = FU_USB_DESCRIPTOR(firmware);
+	g_autoptr(FuUsbBaseHdr) st = NULL;
+	g_autoptr(GInputStream) stream_partial = NULL;
+
+	/* parse */
+	st = fu_usb_base_hdr_parse_stream(stream, offset, error);
+	if (st == NULL)
+		return FALSE;
+	stream_partial =
+	    fu_partial_input_stream_new(stream, offset, fu_usb_base_hdr_get_length(st), error);
+	if (stream_partial == NULL)
+		return FALSE;
+	if (!fu_firmware_set_stream(firmware, stream_partial, error))
+		return FALSE;
+	fu_firmware_set_idx(FU_FIRMWARE(self), fu_usb_base_hdr_get_descriptor_type(st));
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_usb_descriptor_class_init(FuUsbDescriptorClass *klass)
+{
+	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	firmware_class->parse = fu_usb_descriptor_parse;
+}
+
+static void
+fu_usb_descriptor_init(FuUsbDescriptor *self)
+{
+}

--- a/libfwupdplugin/fu-usb-descriptor.h
+++ b/libfwupdplugin/fu-usb-descriptor.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-firmware.h"
+#include "fu-usb-struct.h"
+
+#define FU_TYPE_USB_DESCRIPTOR (fu_usb_descriptor_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU, USB_DESCRIPTOR, FuFirmware)
+
+struct _FuUsbDescriptorClass {
+	FuFirmwareClass parent_class;
+};

--- a/libfwupdplugin/fu-usb-endpoint.h
+++ b/libfwupdplugin/fu-usb-endpoint.h
@@ -7,14 +7,11 @@
 
 #pragma once
 
-#include "fu-firmware.h"
-#include "fu-usb-struct.h"
+#include "fu-usb-descriptor.h"
 
 #define FU_TYPE_USB_ENDPOINT (fu_usb_endpoint_get_type())
-G_DECLARE_FINAL_TYPE(FuUsbEndpoint, fu_usb_endpoint, FU, USB_ENDPOINT, FuFirmware)
+G_DECLARE_FINAL_TYPE(FuUsbEndpoint, fu_usb_endpoint, FU, USB_ENDPOINT, FuUsbDescriptor)
 
-FuUsbDescriptorKind
-fu_usb_endpoint_get_kind(FuUsbEndpoint *self) G_GNUC_NON_NULL(1);
 guint16
 fu_usb_endpoint_get_maximum_packet_size(FuUsbEndpoint *self) G_GNUC_NON_NULL(1);
 guint8

--- a/libfwupdplugin/fu-usb-interface-private.h
+++ b/libfwupdplugin/fu-usb-interface-private.h
@@ -11,4 +11,5 @@
 #include "fu-usb-interface.h"
 
 FuUsbInterface *
-fu_usb_interface_new(const struct libusb_interface_descriptor *iface) G_GNUC_NON_NULL(1);
+fu_usb_interface_new(const struct libusb_interface_descriptor *iface, GError **error)
+    G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-usb-interface.h
+++ b/libfwupdplugin/fu-usb-interface.h
@@ -7,14 +7,11 @@
 
 #pragma once
 
-#include "fu-firmware.h"
-#include "fu-usb-struct.h"
+#include "fu-usb-descriptor.h"
 
 #define FU_TYPE_USB_INTERFACE (fu_usb_interface_get_type())
-G_DECLARE_FINAL_TYPE(FuUsbInterface, fu_usb_interface, FU, USB_INTERFACE, FuFirmware)
+G_DECLARE_FINAL_TYPE(FuUsbInterface, fu_usb_interface, FU, USB_INTERFACE, FuUsbDescriptor)
 
-FuUsbDescriptorKind
-fu_usb_interface_get_kind(FuUsbInterface *self) G_GNUC_NON_NULL(1);
 guint8
 fu_usb_interface_get_number(FuUsbInterface *self) G_GNUC_NON_NULL(1);
 guint8
@@ -27,7 +24,5 @@ guint8
 fu_usb_interface_get_protocol(FuUsbInterface *self) G_GNUC_NON_NULL(1);
 guint8
 fu_usb_interface_get_index(FuUsbInterface *self) G_GNUC_NON_NULL(1);
-GBytes *
-fu_usb_interface_get_extra(FuUsbInterface *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_usb_interface_get_endpoints(FuUsbInterface *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-usb.rs
+++ b/libfwupdplugin/fu-usb.rs
@@ -69,7 +69,7 @@ enum FuUsbDescriptorKind {
     SsEndpointCompanion = 0x30,
 }
 
-#[derive(ParseStream)]
+#[derive(ParseStream, Parse)]
 struct FuUsbBaseHdr {
     length: u8,
     descriptor_type: FuUsbDescriptorKind,
@@ -103,6 +103,27 @@ struct FuUsbDescriptorHdr {
     configuration: u8,
     attributes: u8,
     max_power: u8,
+}
+
+#[derive(ParseStream)]
+struct FuUsbHidDescriptorHdr {
+    length: u8,
+    descriptor_type: FuUsbDescriptorKind == Hid,
+    hid: u16le,
+    country_code: u8,
+    num_descriptors: u8,
+    class_descriptor_type: u8,
+    class_descriptor_length: u16le,
+}
+
+#[derive(ParseBytes)]
+struct FuUsbDfuDescriptorHdr {
+    length: u8,
+    descriptor_type: FuUsbDescriptorKind == Hid,
+    attributes: u8,
+    detach_timeout: u16le,
+    transfer_size: u16le,
+    dfu_version: u16le,
 }
 
 #[derive(ParseStream)]

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -148,6 +148,7 @@ fwupdplugin_src = [
   'fu-sum.c', # fuzzing
   'fu-udev-device.c',
   'fu-usb-bos-descriptor.c',
+  'fu-usb-descriptor.c',
   'fu-usb-device.c',
   'fu-usb-device-ds20.c',
   'fu-usb-device-fw-ds20.c',


### PR DESCRIPTION
Add functional descriptors as children of FuUsbInterface; just because libusb dumps them as raw blobs doesn't mean we have to copy the same broken design.

Expose them as FuUsbDescriptor, and make the other descriptor superclasses depend (and use) this new baseclass.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
