### PR TITLE
Revert "data: fwupd.service.in: Add missing hidraw permission"

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -11,7 +11,6 @@ TimeoutSec=180
 RuntimeDirectory=@motd_dir@
 RuntimeDirectoryPreserve=yes
 BusName=org.freedesktop.fwupd
-DeviceAllow=char-hidraw rw
 ExecStart=@libexecdir@/fwupd/fwupd
 PrivateTmp=yes
 ProtectHome=yes


### PR DESCRIPTION
This reverts commit bd82124ad438ded78900e39b92fbdd646f14321a.

This fixes a regression on 1.9.22 that caused many devices not to probe.  The change doesn't make sense on 1_9_X because ProtectClock=yes was never set there.

Fixes https://github.com/fwupd/fwupd/issues/7547
Fixes https://github.com/fwupd/fwupd/issues/7545

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
