### PR TITLE
contrib: Use /usr/bin/env for more compatibility

### DIFF
--- a/contrib/launch-venv.sh
+++ b/contrib/launch-venv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 gcc=$(gcc -dumpmachine)
 DIST="$(dirname $0)/../dist"
 BIN="$(basename $0)"

--- a/contrib/setup
+++ b/contrib/setup
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 # Setup the repository and local system for development
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
Like in many other scripts, use /usr/bin/env for maximum OS compatibility. I was trying to build on FreeBSD and they don't have their binaries in /bin.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
