### PR TITLE
trivial: fix delimiter symbol for udev subsystem

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1376,7 +1376,7 @@ fu_udev_device_match_subsystem(FuUdevDevice *self, const gchar *subsystem)
 	g_return_val_if_fail(FU_IS_UDEV_DEVICE(self), FALSE);
 	g_return_val_if_fail(subsystem != NULL, FALSE);
 
-	subsys_devtype = g_strsplit(subsystem, ",", 2);
+	subsys_devtype = g_strsplit(subsystem, ":", 2);
 	if (g_strcmp0(fu_udev_device_get_subsystem(self), subsys_devtype[0]) != 0)
 		return FALSE;
 	if (subsys_devtype[1] != NULL &&


### PR DESCRIPTION
Using ':' symbol for splitting to check devtype properly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
