### PR TITLE
Do not ping paired with Bolt devices 

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -226,11 +226,13 @@ fu_logitech_hidpp_device_poll(FuDevice *device, GError **error)
 	}
 
 	/* just ping */
-	if (!fu_logitech_hidpp_device_ping(self, &error_local)) {
-		g_warning("failed to ping %s: %s",
-			  fu_device_get_name(FU_DEVICE(self)),
-			  error_local->message);
-		return TRUE;
+	if (fu_device_has_private_flag(device, FU_LOGITECH_HIDPP_DEVICE_FLAG_REBIND_ATTACH)) {
+		if (!fu_logitech_hidpp_device_ping(self, &error_local)) {
+			g_warning("failed to ping %s: %s",
+				  fu_device_get_name(device),
+				  error_local->message);
+			return TRUE;
+		}
 	}
 
 	/* this is the first time the device has been active */

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -251,6 +251,15 @@ fu_logitech_hidpp_device_open(FuDevice *device, GError **error)
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	const gchar *devpath = fu_udev_device_get_device_file(FU_UDEV_DEVICE(device));
 
+	if (devpath == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "device path is not detected for '%s'",
+			    fu_device_get_name(device));
+		return FALSE;
+	}
+
 	/* open */
 	priv->io_channel =
 	    fu_io_channel_new_file(devpath,
@@ -1425,6 +1434,8 @@ fu_logitech_hidpp_device_new(FuUdevDevice *parent)
 			    parent,
 			    "udev-device",
 			    fu_udev_device_get_dev(parent),
+			    "device-file",
+			    fu_udev_device_get_device_file(parent),
 			    NULL);
 	priv = GET_PRIVATE(self);
 	priv->io_channel = fu_logitech_hidpp_runtime_get_io_channel(FU_HIDPP_RUNTIME(parent));


### PR DESCRIPTION
Partially fixes https://github.com/fwupd/fwupd/issues/7011

I did a test with available devices.

Probably we can remove the polling at all -- but need to be careful with devices supporting only previous protocol versions. As well as with BT/BLE devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
