### PR TITLE
Fix a thinko when recording emulation of USB devices

### DIFF
--- a/libfwupdplugin/fu-backend-private.h
+++ b/libfwupdplugin/fu-backend-private.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-backend.h"
+
+gchar *
+fu_backend_get_emulation_array_member_name(FuBackend *self);

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -8,7 +8,7 @@
 
 #include "config.h"
 
-#include "fu-backend.h"
+#include "fu-backend-private.h"
 #include "fu-device-private.h"
 #include "fu-string.h"
 
@@ -278,7 +278,8 @@ fu_backend_setup(FuBackend *self, FuProgress *progress, GError **error)
 	return TRUE;
 }
 
-static gchar *
+/* private */
+gchar *
 fu_backend_get_emulation_array_member_name(FuBackend *self)
 {
 	FuBackendPrivate *priv = GET_PRIVATE(self);


### PR DESCRIPTION
We want to record the emaultion of the superclass device, not the backend device -- i.e. we need to capture the plugin-specific setup() actions, not just the generic backend ones...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
