### PR TITLE
Use block device instead of partition to detect ESPs to skip

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1644,6 +1644,8 @@ fu_context_get_default_esp(FuContext *ctx, GError **error)
 
 			/* ignore a partition that claims to be a recovery partition */
 			name = fu_volume_get_partition_name(esp);
+			if (name == NULL)
+				name = fu_volume_get_block_name(esp);
 			if (name != NULL) {
 				g_autoptr(GString) name_safe = g_string_new(name);
 				g_string_replace(name_safe, " ", "_", 0);

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -529,6 +529,33 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 }
 
 /**
+ * fu_volume_get_block_label:
+ * @self: a @FuVolume
+ *
+ * Gets the block name of the volume
+ *
+ * Returns: (transfer full): block device name, e.g 'Recovery Partition'
+ *
+ * Since: 1.9.24
+ **/
+gchar *
+fu_volume_get_block_name(FuVolume *self)
+{
+	g_autoptr(GVariant) val = NULL;
+
+	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
+
+	if (self->proxy_blk == NULL)
+		return NULL;
+
+	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "IdLabel");
+	if (val == NULL)
+		return NULL;
+
+	return g_variant_dup_string(val, NULL);
+}
+
+/**
  * fu_volume_get_block_size:
  * @self: a @FuVolume
  *

--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -44,6 +44,8 @@ gboolean
 fu_volume_is_encrypted(FuVolume *self) G_GNUC_NON_NULL(1);
 guint64
 fu_volume_get_size(FuVolume *self) G_GNUC_NON_NULL(1);
+gchar *
+fu_volume_get_block_name(FuVolume *self) G_GNUC_NON_NULL(1);
 gsize
 fu_volume_get_block_size(FuVolume *self, GError **error) G_GNUC_NON_NULL(1);
 gchar *


### PR DESCRIPTION
The Partition `Name` key isn't populated on many devices, but the Block `IdLabel` key is.

Use the Block `IdLabel` key instead for heuristics to skip partitions.

Fixes: https://github.com/fwupd/fwupd/issues/7546

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
