### PR TITLE
capsule on disk: add support for Dell systems

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -679,6 +679,8 @@ fu_uefi_capsule_plugin_coldplug_device(FuPlugin *plugin, FuUefiDevice *dev, GErr
 	}
 	if (fu_context_has_hwid_flag(ctx, "modify-bootorder"))
 		fu_device_add_private_flag(FU_DEVICE(dev), FU_UEFI_DEVICE_FLAG_MODIFY_BOOTORDER);
+	if (fu_context_has_hwid_flag(ctx, "cod-dell-recovery"))
+		fu_device_add_private_flag(FU_DEVICE(dev), FU_UEFI_DEVICE_FLAG_COD_DELL_RECOVERY);
 
 	/* detected InsydeH2O */
 	if (self->acpi_uefi != NULL &&

--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -180,6 +180,17 @@ fu_uefi_cod_device_get_filename(FuUefiDevice *self, GError **error)
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_UEFI_DEVICE_FLAG_COD_INDEXED_FILENAME))
 		return fu_uefi_cod_device_get_indexed_filename(self, error);
 
+	/* Dell Inc. */
+	if (fu_device_has_private_flag(FU_DEVICE(self), FU_UEFI_DEVICE_FLAG_COD_DELL_RECOVERY)) {
+		return g_build_filename(esp_path,
+					"EFI",
+					"dell",
+					"bios",
+					"recovery",
+					"BIOS_TRS.rcv",
+					NULL);
+	}
+
 	/* fallback */
 	basename = g_strdup_printf("fwupd-%s.cap", fu_uefi_device_get_guid(self));
 	return g_build_filename(esp_path, "EFI", "UpdateCapsule", basename, NULL);

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -762,6 +762,9 @@ fu_uefi_device_init(FuUefiDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_UEFI_DEVICE_FLAG_MODIFY_BOOTORDER,
 					"modify-bootorder");
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_UEFI_DEVICE_FLAG_COD_DELL_RECOVERY,
+					"cod-dell-recovery");
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-device.h
+++ b/plugins/uefi-capsule/fu-uefi-device.h
@@ -80,6 +80,12 @@ struct _FuUefiDeviceClass {
  * Modify `BootOrder` as well as `BootNext` to work around BIOS bugs.
  */
 #define FU_UEFI_DEVICE_FLAG_MODIFY_BOOTORDER (1 << 10)
+/**
+ * FU_UEFI_DEVICE_FLAG_COD_DELL_RECOVERY:
+ *
+ * Use Dell customized file location for the capsule on disk.
+ */
+#define FU_UEFI_DEVICE_FLAG_COD_DELL_RECOVERY (1 << 11)
 
 void
 fu_uefi_device_set_esp(FuUefiDevice *self, FuVolume *esp);

--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -16,7 +16,7 @@ Flags = supports-boot-order-lock,use-legacy-bootmgr-desc,no-ux-capsule,no-lid-cl
 
 # Dell Inc.
 [85d38fda-fc0e-5c6f-808f-076984ae7978]
-Flags = modify-bootorder
+Flags = modify-bootorder,cod-dell-recovery
 
 # ASUSTeK COMPUTER INC.
 [65605ed1-09e2-57aa-bd0f-a26c1d35433f]


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation


Dell added customization for capsule on disk feature. If system manufacturer is `Dell Inc.` and the support is advertised by system firmware then use the destination.
