### PR TITLE
redfish: Do not re-use the connection cache to fix BMC restart

### DIFF
--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -524,7 +524,6 @@ fu_redfish_backend_init(FuRedfishBackend *self)
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
-	curl_share_setopt(self->curlsh, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
 }
 
 FuRedfishBackend *


### PR DESCRIPTION
Each redfish request will be a few ms slower, but most redfish requests take multiple seconds (or minutes!) to complete.

Fixes https://github.com/fwupd/fwupd/issues/7593

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
