### PR TITLE
Add modem-manager cinterion fdl-based update

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -362,6 +362,9 @@ endif
 if cc.has_header('sys/ioctl.h')
   conf.set('HAVE_IOCTL_H', '1')
 endif
+if cc.has_header('termios.h')
+  conf.set('HAVE_TERMIOS_H', '1')
+endif
 if cc.has_header('errno.h')
   conf.set('HAVE_ERRNO_H', '1')
 endif

--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -107,6 +107,15 @@ with files described in 'firehose-rawprogram.xml'.
 
 Update protocol: `com.qualcomm.firehose`
 
+## Update method: cinterion-fdl
+
+If the device supports the 'cinterion-fdl' update method, it should have an AT-port
+exposed. The device is then switched to Firmware Download Modem (FDL) and flashed
+with the content of the firmware file. After an update, the device will not replug
+until an ignition is sent, or the device is rebooted.
+
+Update protocol: `com.cinterion.fdl`
+
 ## External Interface Access
 
 This plugin requires read/write access to `/dev/bus/usb` and `/dev/bus/pci`.

--- a/plugins/modem-manager/fu-cinterion-fdl-updater.c
+++ b/plugins/modem-manager/fu-cinterion-fdl-updater.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2024 TDT AG <development@tdt.de>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <libmm-glib.h>
+#include <string.h>
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif
+
+#include "fu-cinterion-fdl-updater-struct.h"
+#include "fu-cinterion-fdl-updater.h"
+
+#ifdef HAVE_TERMIOS_H
+#define FU_CINTERION_FDL_DEFAULT_BAUDRATE  B115200
+#endif
+#define FU_CINTERION_FDL_MAX_READ_RETRIES  100
+#define FU_CINTERION_FDL_MAX_WRITE_RETRIES 10
+#define FU_CINTERION_FDL_SIZE_BYTES	   2
+
+struct _FuCinterionFdlUpdater {
+	GObject parent_instance;
+	gchar *port;
+	FuIOChannel *io_channel;
+};
+
+G_DEFINE_TYPE(FuCinterionFdlUpdater, fu_cinterion_fdl_updater, G_TYPE_OBJECT)
+
+#if MM_CHECK_VERSION(1, 24, 0)
+gboolean
+fu_cinterion_fdl_updater_wait_ready(FuCinterionFdlUpdater *self, FuDevice *device, GError **error)
+{
+	guint8 byte = 0;
+	gsize bytes_read = 0;
+
+	for (guint i = 0; i < FU_CINTERION_FDL_MAX_READ_RETRIES; i++) {
+		if (!fu_io_channel_read_raw(self->io_channel,
+					    &byte,
+					    0x1,
+					    &bytes_read,
+					    100,
+					    FU_IO_CHANNEL_FLAG_USE_BLOCKING_IO,
+					    error)) {
+			return FALSE;
+		}
+		if (bytes_read == 1 && byte == FU_CINTERION_FDL_RESPONSE_OK) {
+			g_debug("start signal read");
+			return TRUE;
+		}
+
+		fu_device_sleep(device, 100);
+	}
+
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_READ,
+		    "no response from device after %d reads",
+		    FU_CINTERION_FDL_MAX_READ_RETRIES);
+	return FALSE;
+}
+
+static gboolean
+fu_cinterion_fdl_updater_set_io_flags(FuCinterionFdlUpdater *self, GError **error)
+{
+#ifdef HAVE_TERMIOS_H
+	struct termios tio;
+	gint fd;
+
+	fd = fu_io_channel_unix_get_fd(self->io_channel);
+
+	memset(&tio, 0, sizeof(tio));
+	tio.c_cflag = CS8 | CREAD | CLOCAL | HUPCL | FU_CINTERION_FDL_DEFAULT_BAUDRATE;
+
+	if (tcsetattr(fd, TCSANOW, &tio) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "could not set termios attributes");
+		return FALSE;
+	}
+
+	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "Not supported as <termios.h> not found");
+	return FALSE;
+#endif
+}
+
+gboolean
+fu_cinterion_fdl_updater_open(FuCinterionFdlUpdater *self, GError **error)
+{
+	/* sanity check */
+	if (self->port == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no port provided for update");
+		return FALSE;
+	}
+
+	self->io_channel =
+	    fu_io_channel_new_file(self->port,
+				   FU_IO_CHANNEL_OPEN_FLAG_READ | FU_IO_CHANNEL_OPEN_FLAG_WRITE,
+				   error);
+	if (self->io_channel == NULL)
+		return FALSE;
+
+	if (!fu_cinterion_fdl_updater_set_io_flags(self, error))
+		return FALSE;
+
+	return TRUE;
+}
+
+gboolean
+fu_cinterion_fdl_updater_close(FuCinterionFdlUpdater *self, GError **error)
+{
+	if (self->io_channel != NULL) {
+		g_debug("closing io port...");
+		if (!fu_io_channel_shutdown(self->io_channel, error))
+			return FALSE;
+		g_clear_object(&self->io_channel);
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_cinterion_fdl_updater_write_chunk(FuCinterionFdlUpdater *self,
+				     GBytes *size_bytes,
+				     GBytes *chunk_bytes,
+				     GError **error)
+{
+	if (!fu_io_channel_write_bytes(self->io_channel,
+				       size_bytes,
+				       1500,
+				       FU_IO_CHANNEL_FLAG_USE_BLOCKING_IO,
+				       error)) {
+		return FALSE;
+	}
+	if (!fu_io_channel_write_bytes(self->io_channel,
+				       chunk_bytes,
+				       1500,
+				       FU_IO_CHANNEL_FLAG_USE_BLOCKING_IO,
+				       error)) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_cinterion_fdl_read_response(FuCinterionFdlUpdater *self,
+			       FuDevice *device,
+			       FuCinterionFdlResponse *response,
+			       GError **error)
+{
+	guint8 byte = 0;
+	gsize bytes_read = 0;
+
+	for (guint i = 0; i < FU_CINTERION_FDL_MAX_READ_RETRIES; i++) {
+		if (!fu_io_channel_read_raw(self->io_channel,
+					    &byte,
+					    0x1,
+					    &bytes_read,
+					    100,
+					    FU_IO_CHANNEL_FLAG_USE_BLOCKING_IO,
+					    error)) {
+			return FALSE;
+		}
+		if (bytes_read != 1) {
+			/* retry until byte read */
+			fu_device_sleep(device, 10);
+			continue;
+		}
+
+		switch (byte) {
+		case FU_CINTERION_FDL_RESPONSE_OK:
+			*response = FU_CINTERION_FDL_RESPONSE_OK;
+			break;
+		case FU_CINTERION_FDL_RESPONSE_RETRY:
+			*response = FU_CINTERION_FDL_RESPONSE_RETRY;
+			break;
+		case FU_CINTERION_FDL_RESPONSE_BUSY:
+			*response = FU_CINTERION_FDL_RESPONSE_BUSY;
+			break;
+		default:
+			*response = FU_CINTERION_FDL_RESPONSE_UNKNOWN;
+			break;
+		}
+
+		return TRUE;
+	}
+
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_READ,
+		    "no response from device after %d reads",
+		    FU_CINTERION_FDL_MAX_READ_RETRIES);
+	return FALSE;
+}
+
+static gboolean
+fu_cinterion_fdl_updater_write_chunk_retry(FuCinterionFdlUpdater *self,
+					   FuDevice *device,
+					   GBytes *size_bytes,
+					   GBytes *chunk_bytes,
+					   GError **error)
+{
+	guint write_retries = 0;
+
+	while (write_retries < FU_CINTERION_FDL_MAX_WRITE_RETRIES) {
+		guint read_retries = 0;
+		FuCinterionFdlResponse response;
+
+		if (!fu_cinterion_fdl_updater_write_chunk(self, size_bytes, chunk_bytes, error))
+			return FALSE;
+
+		while (read_retries < FU_CINTERION_FDL_MAX_READ_RETRIES) {
+			if (!fu_cinterion_fdl_read_response(self, device, &response, error))
+				return FALSE;
+
+			if (response == FU_CINTERION_FDL_RESPONSE_OK) {
+				/* chunk written successfully, stop reading */
+				return TRUE;
+			}
+
+			if (response == FU_CINTERION_FDL_RESPONSE_BUSY) {
+				/* retry reading response */
+				read_retries++;
+			} else if (response == FU_CINTERION_FDL_RESPONSE_RETRY) {
+				/* stop reading and retry write */
+				break;
+			} else {
+				/* fatal response */
+				g_set_error_literal(error,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INTERNAL,
+						    "received fatal response");
+				return FALSE;
+			}
+		}
+
+		if (read_retries >= FU_CINTERION_FDL_MAX_READ_RETRIES) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_READ,
+				    "no response from device after %d reads",
+				    FU_CINTERION_FDL_MAX_READ_RETRIES);
+			return FALSE;
+		}
+
+		write_retries++;
+	}
+
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_WRITE,
+		    "failed writing chunk %d times",
+		    FU_CINTERION_FDL_MAX_WRITE_RETRIES);
+	return FALSE;
+}
+
+gboolean
+fu_cinterion_fdl_updater_write(FuCinterionFdlUpdater *self,
+			       FuProgress *progress,
+			       FuDevice *device,
+			       GBytes *fw,
+			       GError **error)
+{
+	guint chunk = 0;
+	gsize offset = 0;
+	gsize fw_len = g_bytes_get_size(fw);
+
+	while (offset < fw_len) {
+		g_autoptr(GBytes) size_bytes = NULL;
+		g_autoptr(GBytes) chunk_bytes = NULL;
+		guint16 chunk_size = 0;
+
+		size_bytes = g_bytes_new_from_bytes(fw, offset, FU_CINTERION_FDL_SIZE_BYTES);
+		if (!fu_memread_uint16_safe(g_bytes_get_data(size_bytes, NULL),
+					    FU_CINTERION_FDL_SIZE_BYTES,
+					    0x0,
+					    &chunk_size,
+					    G_LITTLE_ENDIAN,
+					    error))
+			return FALSE;
+
+		offset += FU_CINTERION_FDL_SIZE_BYTES;
+
+		chunk_bytes = g_bytes_new_from_bytes(fw, offset, chunk_size);
+		offset += chunk_size;
+
+		if (!fu_cinterion_fdl_updater_write_chunk_retry(self,
+								device,
+								size_bytes,
+								chunk_bytes,
+								error)) {
+			g_prefix_error(error, "could not write chunk %u", chunk);
+			return FALSE;
+		}
+		if (chunk % 100 == 0)
+			g_debug("wrote chunk %u successfully", chunk);
+
+		fu_progress_set_percentage_full(progress, offset, fw_len);
+		chunk++;
+	}
+
+	if (fw_len != offset) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "expected %" G_GSIZE_FORMAT " bytes, but wrote %" G_GSIZE_FORMAT,
+			    fw_len,
+			    offset);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+#endif // MM_CHECK_VERSION(1, 24, 0)
+
+static void
+fu_cinterion_fdl_updater_init(FuCinterionFdlUpdater *self)
+{
+}
+
+static void
+fu_cinterion_fdl_updater_finalize(GObject *object)
+{
+	FuCinterionFdlUpdater *self = FU_CINTERION_FDL_UPDATER(object);
+	g_free(self->port);
+	G_OBJECT_CLASS(fu_cinterion_fdl_updater_parent_class)->finalize(object);
+}
+
+static void
+fu_cinterion_fdl_updater_class_init(FuCinterionFdlUpdaterClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	object_class->finalize = fu_cinterion_fdl_updater_finalize;
+}
+
+#if MM_CHECK_VERSION(1, 24, 0)
+FuCinterionFdlUpdater *
+fu_cinterion_fdl_updater_new(const gchar *port)
+{
+	FuCinterionFdlUpdater *self = g_object_new(FU_TYPE_CINTERION_FDL_UPDATER, NULL);
+	self->port = g_strdup(port);
+	return self;
+}
+#endif // MM_CHECK_VERSION(1, 24, 0)

--- a/plugins/modem-manager/fu-cinterion-fdl-updater.h
+++ b/plugins/modem-manager/fu-cinterion-fdl-updater.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 TDT AG <development@tdt.de>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_CINTERION_FDL_UPDATER (fu_cinterion_fdl_updater_get_type())
+G_DECLARE_FINAL_TYPE(FuCinterionFdlUpdater,
+		     fu_cinterion_fdl_updater,
+		     FU,
+		     CINTERION_FDL_UPDATER,
+		     GObject)
+
+FuCinterionFdlUpdater *
+fu_cinterion_fdl_updater_new(const gchar *port);
+gboolean
+fu_cinterion_fdl_updater_open(FuCinterionFdlUpdater *self, GError **error);
+gboolean
+fu_cinterion_fdl_updater_write(FuCinterionFdlUpdater *self,
+			       FuProgress *progress,
+			       FuDevice *device,
+			       GBytes *fw,
+			       GError **error);
+gboolean
+fu_cinterion_fdl_updater_close(FuCinterionFdlUpdater *self, GError **error);
+gboolean
+fu_cinterion_fdl_updater_wait_ready(FuCinterionFdlUpdater *self, FuDevice *device, GError **error);

--- a/plugins/modem-manager/fu-cinterion-fdl-updater.rs
+++ b/plugins/modem-manager/fu-cinterion-fdl-updater.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 TDT AG <development@tdt.de>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#[repr(u8)]
+enum FuCinterionFdlResponse {
+    Ok = 0x01,
+    Retry = 0x02,
+    Unknown = 0x03,
+    Busy = 0x04,
+}

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -15,6 +15,9 @@ plugins += {meson.current_source_dir().split('/')[-1]: true}
 plugin_quirks += files('modem-manager.quirk')
 
 shared_module('fu_plugin_modem_manager',
+  rustgen.process(
+    'fu-cinterion-fdl-updater.rs',
+  ),
   sources: [
     'fu-mm-plugin.c',
     'fu-mm-device.c',
@@ -22,6 +25,7 @@ shared_module('fu_plugin_modem_manager',
     'fu-mbim-qdu-updater.c',
     'fu-firehose-updater.c',
     'fu-sahara-loader.c',
+    'fu-cinterion-fdl-updater.c',
     'fu-mm-utils.c'
   ],
   include_directories: plugin_incdirs,

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -117,3 +117,8 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf
 Summary = Fibocom FM101-GL Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_2CB7&PID_D00D
+
+# Cinterion PLS8
+[USB\VID_1e2d&PID_0061]
+Summary = Cinterion PLS8 AT^SFDL update
+Plugin = modem_manager


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Adds Cinterion `AT^SFDL` 'Firmware Download Mode' based update.

When the `AT^SFDL` command has been successfully sent, the device is supposed to be in firmware download mode after 15 seconds. Reading an `ok (0x01)` byte confirms that the device is ready for firmware download.
The firmware file is written to the device chunk by chunk, where each chunk consists of:
- 8 bits indicating the current chunk's data size in bytes
- chunk data with above size in little endian format

The `cinterion-fdl` update method depends on [this merge request](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/merge_requests/1205) in ModemManager.