### PR TITLE
Exclude known recovery partitions from ESP volume building

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -373,7 +373,9 @@ fu_volume_get_partition_kind(FuVolume *self)
 gchar *
 fu_volume_get_partition_name(FuVolume *self)
 {
+	g_autofree gchar *name = NULL;
 	g_autoptr(GVariant) val = NULL;
+	gsize namesz = 0;
 
 	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
 
@@ -382,7 +384,12 @@ fu_volume_get_partition_name(FuVolume *self)
 	val = g_dbus_proxy_get_cached_property(self->proxy_part, "Name");
 	if (val == NULL)
 		return NULL;
-	return g_variant_dup_string(val, NULL);
+
+	/* only return if non-zero length */
+	name = g_variant_dup_string(val, &namesz);
+	if (namesz == 0)
+		return NULL;
+	return g_steal_pointer(&name);
 }
 
 /**
@@ -462,6 +469,8 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 gchar *
 fu_volume_get_block_name(FuVolume *self)
 {
+	gsize namesz = 0;
+	g_autofree gchar *name = NULL;
 	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
@@ -473,7 +482,11 @@ fu_volume_get_block_name(FuVolume *self)
 	if (val == NULL)
 		return NULL;
 
-	return g_variant_dup_string(val, NULL);
+	/* only return if non-zero length */
+	name = g_variant_dup_string(val, &namesz);
+	if (namesz == 0)
+		return NULL;
+	return g_steal_pointer(&name);
 }
 
 /**

--- a/libfwupdplugin/fu-volume.h
+++ b/libfwupdplugin/fu-volume.h
@@ -44,6 +44,8 @@ gboolean
 fu_volume_is_encrypted(FuVolume *self) G_GNUC_NON_NULL(1);
 guint64
 fu_volume_get_size(FuVolume *self) G_GNUC_NON_NULL(1);
+gchar *
+fu_volume_get_block_name(FuVolume *self) G_GNUC_NON_NULL(1);
 gsize
 fu_volume_get_block_size(FuVolume *self, GError **error) G_GNUC_NON_NULL(1);
 gchar *


### PR DESCRIPTION
This is a backport of portions of the following commits:
c67531079c26bdc80c9bfffe291b764a05cb260a
5f221172736fcd460441abc62ea1c399f41512c1
c67531079c26bdc80c9bfffe291b764a05cb260a

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
