### PR TITLE
Ensure that partition name and block name are non-zero string length

### DIFF
--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -450,7 +450,9 @@ fu_volume_set_partition_uuid(FuVolume *self, const gchar *partition_uuid)
 gchar *
 fu_volume_get_partition_name(FuVolume *self)
 {
+	g_autofree gchar *name = NULL;
 	g_autoptr(GVariant) val = NULL;
+	gsize namesz = 0;
 
 	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
 
@@ -459,7 +461,12 @@ fu_volume_get_partition_name(FuVolume *self)
 	val = g_dbus_proxy_get_cached_property(self->proxy_part, "Name");
 	if (val == NULL)
 		return NULL;
-	return g_variant_dup_string(val, NULL);
+
+	/* only return if non-zero length */
+	name = g_variant_dup_string(val, &namesz);
+	if (namesz == 0)
+		return NULL;
+	return g_steal_pointer(&name);
 }
 
 /**
@@ -541,6 +548,8 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 gchar *
 fu_volume_get_block_name(FuVolume *self)
 {
+	gsize namesz = 0;
+	g_autofree gchar *name = NULL;
 	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
@@ -552,7 +561,11 @@ fu_volume_get_block_name(FuVolume *self)
 	if (val == NULL)
 		return NULL;
 
-	return g_variant_dup_string(val, NULL);
+	/* only return if non-zero length */
+	name = g_variant_dup_string(val, &namesz);
+	if (namesz == 0)
+		return NULL;
+	return g_steal_pointer(&name);
 }
 
 /**


### PR DESCRIPTION
Based on a patch by Mario Limonciello <mario.limonciello@amd.com>, many thanks.

Fixes: https://github.com/fwupd/fwupd/issues/6477

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
