### PR TITLE
audio-s5gen2: initial support of BLE devices

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -92,6 +92,10 @@ class Checker:
             "fu_audio_s5gen2_firmware": "fu_qc_s5gen2_firmware",
             "fu_audio_s5gen2": "fu_qc_s5gen2",  # FIXME: rename after merging #7638
             "fu_audio_s5gen2_hid": "fu_qc_s5gen2_hid",
+            "fu_audio_s5gen2_ble": "fu_qc_s5gen2_ble",
+            "fu_audio_s5gen2_hid_device": "fu_qc_s5gen2_hid_device",
+            "fu_audio_s5gen2_ble_device": "fu_qc_s5gen2_ble_device",
+            "fu_crc": "fu_misr",  # FIXME: split out to fu-misr.[c|h]
             "fu_darwin_efivars": "fu_efivars",
             "fu_dbus_daemon": "fu_daemon",
             "fu_dbxtool": "fu_util",

--- a/data/device-tests/qualcomm-qcc5171.json
+++ b/data/device-tests/qualcomm-qcc5171.json
@@ -4,7 +4,6 @@
   "steps": [
     {
       "url": "https://fwupd.org/downloads/084ebf794bfcb56b7c749238b4c6ed211342738cece664d02b0cbe285eb646f8-Qualcomm_qcc517X_1.1.2.cab",
-      "emulation-url": "https://fwupd.org/downloads/e87827fa8ee36d0dc8cfc217fd2a8964183caeff963ef248ed11d43b0e582959-qc-reinstall-1.1.2.zip",
       "components": [
         {
           "version": "1.1.2",

--- a/plugins/audio-s5gen2/README.md
+++ b/plugins/audio-s5gen2/README.md
@@ -23,6 +23,21 @@ These devices use the standard  DeviceInstanceId values, e.g.
 
 * `USB\VID_0A12&PID_4007`
 
+Typically, BlueTooth devices should be detected by GAIA primary service with if
+default vendor ID has been used:
+
+* `BLUETOOTH\GATT_00001100-d102-11e1-9b23-00025b00a5a5`
+
+For firmware file, it is recommended to use the unique GUID generated from the
+variant read from the device, for instance:
+
+* `BLUETOOTH\GAIA_QCC5171`
+
+If needed to use own vendor ID for communication, the name detected by BlueZ
+backend should be used in quirk file:
+
+* `BLUETOOTH\NAME_QCC5171`
+
 ## Update Behavior
 
 The device is updated in runtime mode and rebooted with a new version.
@@ -31,6 +46,9 @@ the device will reboot with the previous firmware version.
 
 The upgrade protocol and update behivior are specified in documentation from Qualcomm,
 referenced by 80-CH281-1 and 80-CU043-1.
+
+It is expected that OS is responsible for the correct BLE reconnection during update
+of BlueTooth devices.
 
 ## Vendor ID Security
 

--- a/plugins/audio-s5gen2/audio-s5gen2.quirk
+++ b/plugins/audio-s5gen2/audio-s5gen2.quirk
@@ -1,5 +1,18 @@
-# 5171 devboard
+# 5171 devboard connected via USB
 [USB\VID_0A12&PID_4007]
 Plugin = audio_s5gen2
 Flags = enforce-requires
 ProxyGType = FuQcS5gen2HidDevice
+
+# 5171 devboard connected via BT
+[BLUETOOTH\NAME_QCC5171]
+Plugin = audio_s5gen2
+Flags = enforce-requires
+ProxyGType = FuQcS5gen2BleDevice
+AudioS5gen2Gaia3VendorId = 0x001D
+
+# by GAIA primary service with default vendor ID
+[BLUETOOTH\GATT_00001100-d102-11e1-9b23-00025b00a5a5]
+Plugin = audio_s5gen2
+ProxyGType = FuQcS5gen2BleDevice
+AudioS5gen2Gaia3VendorId = 0x001D

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-ble-device.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-ble-device.c
@@ -1,0 +1,630 @@
+/*
+ * Copyright 2024 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-audio-s5gen2-ble-device.h"
+#include "fu-audio-s5gen2-ble-struct.h"
+#include "fu-audio-s5gen2-device.h"
+#include "fu-audio-s5gen2-impl.h"
+#include "fu-audio-s5gen2-struct.h"
+
+#define FU_QC_S5GEN2_GAIA_V3_SUPPORTED_VERSION_MAJOR 3
+
+#define FU_QC_S5GEN2_GAIA_V3_DEFAULT_VENDOR 0x001d
+#define FU_QC_S5GEN2_GAIA_V3_HDR_SZ	    4
+
+#define FU_QC_S5GEN2_BLE_DEVICE_SEND "00001101-d102-11e1-9b23-00025b00a5a5"
+#define FU_QC_S5GEN2_BLE_DEVICE_RECV "00001102-d102-11e1-9b23-00025b00a5a5"
+#define FU_QC_S5GEN2_BLE_DEVICE_DATA "00001103-d102-11e1-9b23-00025b00a5a5"
+
+#define FU_QC_S5GEN2_BLE_DEVICE_TIMEOUT 15000 /* ms */
+
+#define FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ 256
+
+#define FU_QC_S5GEN2_GAIA_PROTOCOL_VERSION 0x03
+
+#define FU_QC_S5GEN2_BLE_DEVICE_AQUIRE_RETRIES 25
+#define FU_QC_S5GEN2_BLE_DEVICE_AQUIRE_DELAY   200
+
+typedef struct {
+	guint8 core;
+	guint8 dfu;
+} gaia_features_version_t;
+
+struct _FuQcS5gen2BleDevice {
+	FuBluezDevice parent_instance;
+	guint16 vid_v3;
+	FuIOChannel *io_cmd;
+	gint32 mtu;
+	gaia_features_version_t feature;
+};
+
+static void
+fu_qc_s5gen2_ble_device_impl_iface_init(FuQcS5gen2ImplInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE(FuQcS5gen2BleDevice,
+			fu_qc_s5gen2_ble_device,
+			FU_TYPE_BLUEZ_DEVICE,
+			G_IMPLEMENT_INTERFACE(FU_TYPE_QC_S5GEN2_IMPL,
+					      fu_qc_s5gen2_ble_device_impl_iface_init))
+
+static gboolean
+fu_qc_s5gen2_ble_device_notify_release(FuQcS5gen2BleDevice *self, GError **error)
+{
+	if (self->io_cmd == NULL)
+		return (TRUE);
+
+	g_object_unref(self->io_cmd);
+	self->io_cmd = NULL;
+	self->mtu = 0;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_notify_acquire(FuQcS5gen2BleDevice *self, GError **error)
+{
+	if (self->io_cmd != NULL)
+		return (TRUE);
+
+	self->io_cmd = fu_bluez_device_notify_acquire(FU_BLUEZ_DEVICE(self),
+						      FU_QC_S5GEN2_BLE_DEVICE_RECV,
+						      &(self->mtu),
+						      error);
+	if (self->io_cmd == NULL) {
+		self->mtu = 0;
+		return (FALSE);
+	}
+	g_debug("MTU = %d", self->mtu);
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_send(FuQcS5gen2BleDevice *self,
+			     guint8 *data,
+			     gsize data_len,
+			     GError **error)
+{
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	buf = g_byte_array_append(buf, data, data_len);
+
+	if (!fu_bluez_device_write(FU_BLUEZ_DEVICE(self), FU_QC_S5GEN2_BLE_DEVICE_SEND, buf, error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_recv(FuQcS5gen2BleDevice *self,
+			     guint8 *data_in,
+			     gsize data_len,
+			     gsize *read_len,
+			     GError **error)
+{
+	if (!fu_io_channel_read_raw(self->io_cmd,
+				    data_in,
+				    (self->mtu < (gint32)data_len) ? (gsize)self->mtu : data_len,
+				    read_len,
+				    FU_QC_S5GEN2_BLE_DEVICE_TIMEOUT,
+				    FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
+				    error))
+		return FALSE;
+
+	fu_dump_raw(G_LOG_DOMAIN, "Read from device:", data_in, *read_len);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_control_cmd_new();
+	g_autoptr(GByteArray) validate = NULL;
+
+	fu_struct_qc_gaia_v3_upgrade_control_cmd_set_vendor_id(req, self->vid_v3);
+
+	g_byte_array_append(req, data, data_len);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	validate = fu_struct_qc_gaia_v3_upgrade_control_ack_parse(buf, read_len, 0, error);
+	if (validate == NULL) {
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_msg_in(FuQcS5gen2Impl *impl,
+			       guint8 *data_in,
+			       gsize data_len,
+			       gsize *read_len,
+			       GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
+	gsize bufsz = 0;
+	g_autofree guint8 *buf = NULL;
+
+	bufsz = ((gsize)self->mtu < data_len + FU_QC_S5GEN2_GAIA_V3_HDR_SZ)
+		    ? (gsize)self->mtu
+		    : data_len + FU_QC_S5GEN2_GAIA_V3_HDR_SZ;
+
+	buf = g_malloc0(bufsz);
+
+	if (!fu_io_channel_read_raw(self->io_cmd,
+				    buf,
+				    bufsz,
+				    read_len,
+				    FU_QC_S5GEN2_BLE_DEVICE_TIMEOUT,
+				    FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
+				    error))
+		return FALSE;
+
+	fu_dump_raw(G_LOG_DOMAIN, "Read from device:", buf, *read_len);
+	if (*read_len <= FU_QC_S5GEN2_GAIA_V3_HDR_SZ) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "got %lu bytes, less or equal to GAIA header",
+			    (unsigned long)*read_len);
+		return FALSE;
+	}
+	/* don't need GAIA header for upper layer */
+	*read_len -= FU_QC_S5GEN2_GAIA_V3_HDR_SZ;
+	if (!fu_memcpy_safe(data_in,
+			    data_len,
+			    0,
+			    buf,
+			    bufsz,
+			    FU_QC_S5GEN2_GAIA_V3_HDR_SZ,
+			    *read_len,
+			    error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_req_connect(FuQcS5gen2Impl *impl, GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_connect_cmd_new();
+	g_autoptr(GByteArray) validate = NULL;
+
+	fu_struct_qc_gaia_v3_upgrade_connect_cmd_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_notify_acquire(self, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	validate = fu_struct_qc_gaia_v3_upgrade_connect_ack_parse(buf, read_len, 0, error);
+	if (validate == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_req_disconnect(FuQcS5gen2Impl *impl, GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_new();
+	g_autoptr(GByteArray) validate = NULL;
+
+	fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	validate = fu_struct_qc_gaia_v3_upgrade_disconnect_ack_parse(buf, read_len, 0, error);
+	if (validate == NULL)
+		return FALSE;
+
+	return fu_qc_s5gen2_ble_device_notify_release(self, error);
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_data_size(FuQcS5gen2Impl *impl, gsize *data_sz, GError **error)
+{
+	/* TODO: atm for GAIA only */
+	gsize headers_sz = FU_STRUCT_QC_DATA_SIZE + FU_QC_S5GEN2_GAIA_V3_HDR_SZ + 3;
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
+
+	if ((gsize)self->mtu <= headers_sz) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "MTU is not sufficient");
+		return FALSE;
+	}
+
+	*data_sz = (gsize)self->mtu - headers_sz;
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_get_api(FuQcS5gen2BleDevice *self, GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	guint8 api_major;
+	guint8 api_minor;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_api_req_new();
+	g_autoptr(GByteArray) resp = NULL;
+
+	fu_struct_qc_gaia_v3_api_req_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	resp = fu_struct_qc_gaia_v3_api_parse(buf, read_len, 0, error);
+	if (resp == NULL)
+		return FALSE;
+
+	api_major = fu_struct_qc_gaia_v3_api_get_major(resp);
+	api_minor = fu_struct_qc_gaia_v3_api_get_minor(resp);
+
+	if (api_major < FU_QC_S5GEN2_GAIA_V3_SUPPORTED_VERSION_MAJOR) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "GAIA protocol %u.%u is not supported",
+			    api_major,
+			    api_minor);
+		return FALSE;
+	}
+	g_debug("GAIA API version: %u.%u", api_major, api_minor);
+	return TRUE;
+}
+
+/* read the list of supported features from device */
+static gboolean
+fu_qc_s5gen2_ble_device_get_features(FuQcS5gen2BleDevice *self, gboolean next, GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_supported_features_req_new();
+	g_autoptr(GByteArray) resp = NULL;
+
+	fu_struct_qc_gaia_v3_supported_features_req_set_vendor_id(req, self->vid_v3);
+
+	fu_struct_qc_gaia_v3_supported_features_req_set_command(
+	    req,
+	    (next == FALSE) ? FU_QC_GAIA_V3_CMD_GET_SUPPORTED_FEATURES_REQ
+			    : FU_QC_GAIA_V3_CMD_GET_SUPPORTED_FEATURES_NEXT_REQ);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	resp = fu_struct_qc_gaia_v3_supported_features_parse(buf, read_len, 0, error);
+	if (resp == NULL)
+		return FALSE;
+
+	/* must be odd: header 5B + feature pairs */
+	if ((read_len & 0x01) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "got incorrect features list");
+		return FALSE;
+	}
+
+	/* parse feature:version pairs */
+	for (gsize i = FU_STRUCT_QC_GAIA_V3_SUPPORTED_FEATURES_SIZE;
+	     i < read_len && i < sizeof(buf);
+	     i += 2) {
+		switch (buf[i]) {
+		case FU_QC_GAIA_V3_FEATURES_CORE:
+			self->feature.core = buf[i + 1];
+			g_debug("Core feature version: %u", self->feature.core);
+			break;
+		case FU_QC_GAIA_V3_FEATURES_DFU:
+			self->feature.dfu = buf[i + 1];
+			g_debug("DFU feature version: %u", self->feature.dfu);
+			break;
+		default:
+			break;
+		}
+	}
+
+	/* request the rest of the list */
+	if (fu_struct_qc_gaia_v3_supported_features_get_more_features(resp) == FU_QC_MORE_MORE)
+		return fu_qc_s5gen2_ble_device_get_features(self, TRUE, error);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_get_serial(FuQcS5gen2BleDevice *self, GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_serial_req_new();
+	g_autoptr(GByteArray) validate = NULL;
+	g_autofree gchar *serial = NULL;
+
+	fu_struct_qc_gaia_v3_serial_req_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	/* Check if response is valid */
+	validate =
+	    fu_struct_qc_gaia_v3_serial_parse(buf, FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE, 0, error);
+	if (validate == NULL)
+		return FALSE;
+
+	serial = fu_strsafe((gchar *)(buf + FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE),
+			    read_len - FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE);
+
+	if (serial != NULL)
+		fu_device_set_serial(FU_DEVICE(self), serial);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_get_variant(FuQcS5gen2BleDevice *self, GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_variant_req_new();
+	g_autoptr(GByteArray) validate = NULL;
+	g_autofree gchar *variant = NULL;
+
+	fu_struct_qc_gaia_v3_variant_req_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	/* check if response is valid */
+	validate =
+	    fu_struct_qc_gaia_v3_variant_parse(buf, FU_STRUCT_QC_GAIA_V3_VARIANT_SIZE, 0, error);
+	if (validate == NULL)
+		return FALSE;
+
+	variant = fu_strsafe((gchar *)(buf + FU_STRUCT_QC_GAIA_V3_VARIANT_SIZE),
+			     read_len - FU_STRUCT_QC_GAIA_V3_VARIANT_SIZE);
+
+	if (variant == NULL) {
+		g_debug("read non-printable device variant, skipping");
+		return TRUE;
+	}
+
+	/* create the GUID based on variant read from device */
+	fu_device_add_instance_str(FU_DEVICE(self), "GAIA", variant);
+	fu_device_build_instance_id_full(FU_DEVICE(self),
+					 FU_DEVICE_INSTANCE_FLAG_VISIBLE |
+					     FU_DEVICE_INSTANCE_FLAG_QUIRKS,
+					 NULL,
+					 "BLUETOOTH",
+					 "GAIA",
+					 NULL);
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_register_notification(FuQcS5gen2BleDevice *self, GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len = 0;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_register_notification_cmd_new();
+	g_autoptr(GByteArray) validate = NULL;
+
+	/* register only for update feature */
+	fu_struct_qc_gaia_v3_register_notification_cmd_set_vendor_id(req, self->vid_v3);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	/* Check if response is valid */
+	validate = fu_struct_qc_gaia_v3_register_notification_ack_parse(
+	    buf,
+	    FU_STRUCT_QC_GAIA_V3_REGISTER_NOTIFICATION_ACK_SIZE,
+	    0,
+	    error);
+	if (validate == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_set_transport_protocol(FuQcS5gen2BleDevice *self,
+					       guint32 version,
+					       GError **error)
+{
+	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
+	gsize read_len;
+	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_set_transport_info_req_new();
+	g_autoptr(GByteArray) validate = NULL;
+
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_key(req, 0x07);
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_value(req, version);
+
+	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
+		return FALSE;
+
+	validate = fu_struct_qc_gaia_v3_set_transport_info_parse(buf, read_len, 0, error);
+	if (validate == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+static void
+fu_qc_s5gen2_ble_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(device);
+	fwupd_codec_string_append_hex(str, idt, "GaiaVendorId", self->vid_v3);
+	fwupd_codec_string_append_hex(str, idt, "GaiaCoreFeatureVersion", self->feature.core);
+	fwupd_codec_string_append_hex(str, idt, "GaiaDfuFeatureVersion", self->feature.dfu);
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_notify_acquire_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(device);
+
+	if (!fu_qc_s5gen2_ble_device_notify_release(self, error))
+		return FALSE;
+
+	return fu_qc_s5gen2_ble_device_notify_acquire(self, error);
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_probe(FuDevice *device, GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(device);
+	g_autofree gchar *vendor_id = NULL;
+
+	if (!FU_DEVICE_CLASS(fu_qc_s5gen2_ble_device_parent_class)->probe(device, error))
+		return FALSE;
+
+	/* after reboot the device might appear too fast */
+	if (!fu_device_retry_full(device,
+				  fu_qc_s5gen2_ble_device_notify_acquire_cb,
+				  FU_QC_S5GEN2_BLE_DEVICE_AQUIRE_RETRIES,
+				  FU_QC_S5GEN2_BLE_DEVICE_AQUIRE_DELAY,
+				  NULL,
+				  error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_get_api(self, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_get_features(self, FALSE, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_get_serial(self, error))
+		return FALSE;
+
+	if (!fu_qc_s5gen2_ble_device_get_variant(self, error))
+		return FALSE;
+
+	if (self->feature.core >= 2) {
+		if (!fu_qc_s5gen2_ble_device_set_transport_protocol(
+			self,
+			FU_QC_S5GEN2_GAIA_PROTOCOL_VERSION,
+			error))
+			return FALSE;
+	}
+
+	/* set vendor ID to avoid update error */
+	vendor_id = g_strdup_printf("BLUETOOTH:%04X", self->vid_v3);
+	fu_device_add_vendor_id(device, vendor_id);
+
+	if (!fu_qc_s5gen2_ble_device_register_notification(self, error))
+		return FALSE;
+
+	return fu_qc_s5gen2_ble_device_notify_release(FU_QC_S5GEN2_BLE_DEVICE(device), error);
+}
+
+static gboolean
+fu_qc_s5gen2_ble_device_set_quirk_kv(FuDevice *device,
+				     const gchar *key,
+				     const gchar *value,
+				     GError **error)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(device);
+	guint64 tmp = 0;
+
+	if (g_strcmp0(key, "AudioS5gen2Gaia3VendorId") == 0) {
+		if (!fu_strtoull(value, &tmp, 0, G_MAXUINT16, FU_INTEGER_BASE_AUTO, error))
+			return FALSE;
+		self->vid_v3 = tmp;
+		return TRUE;
+	}
+
+	/* failed */
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
+	return FALSE;
+}
+
+static void
+fu_qc_s5gen2_ble_device_init(FuQcS5gen2BleDevice *self)
+{
+	self->vid_v3 = FU_QC_S5GEN2_GAIA_V3_DEFAULT_VENDOR;
+	self->mtu = 0;
+	self->feature.core = 0;
+	self->feature.dfu = 0;
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
+	fu_device_set_remove_delay(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_REMOVE_DELAY);
+	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.s5gen2");
+}
+
+static void
+fu_qc_s5gen2_ble_device_finalize(GObject *object)
+{
+	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(object);
+	g_object_unref(self->io_cmd);
+	G_OBJECT_CLASS(fu_qc_s5gen2_ble_device_parent_class)->finalize(object);
+}
+
+static void
+fu_qc_s5gen2_ble_device_impl_iface_init(FuQcS5gen2ImplInterface *iface)
+{
+	iface->msg_in = fu_qc_s5gen2_ble_device_msg_in;
+	iface->msg_out = fu_qc_s5gen2_ble_device_msg_out;
+	iface->req_connect = fu_qc_s5gen2_ble_device_req_connect;
+	iface->req_disconnect = fu_qc_s5gen2_ble_device_req_disconnect;
+	iface->data_size = fu_qc_s5gen2_ble_device_data_size;
+}
+
+static void
+fu_qc_s5gen2_ble_device_class_init(FuQcS5gen2BleDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_qc_s5gen2_ble_device_finalize;
+	device_class->to_string = fu_qc_s5gen2_ble_device_to_string;
+	device_class->probe = fu_qc_s5gen2_ble_device_probe;
+	device_class->set_quirk_kv = fu_qc_s5gen2_ble_device_set_quirk_kv;
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-ble-device.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-ble-device.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Denis Pynkin <denis.pynkin@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_QC_S5GEN2_BLE_DEVICE (fu_qc_s5gen2_ble_device_get_type())
+G_DECLARE_FINAL_TYPE(FuQcS5gen2BleDevice,
+		     fu_qc_s5gen2_ble_device,
+		     FU,
+		     QC_S5GEN2_BLE_DEVICE,
+		     FuBluezDevice)

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-ble.rs
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-ble.rs
@@ -1,0 +1,181 @@
+// Copyright 2024 Denis Pynkin <denis.pynkin@collabora.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+
+#[repr(u8)]
+enum FuQcGaiaV3Features {
+    Core = 0x00,
+    Dfu = 0x06,
+}
+
+// Commands: 80-CH482-1, 80-CF422-1, 80-CF378-1
+
+#[repr(u16be)]
+enum FuQcGaiaV3Cmd {
+    GetApiReq = 0x0000,
+    GetApiResp = 0x0100,
+    GetSupportedFeaturesReq = 0x0001,
+    GetSupportedFeaturesResp = 0x0101,
+    GetSupportedFeaturesNextReq = 0x0002,
+    GetSupportedFeaturesNextResp = 0x0102,
+    GetSerialReq = 0x0003,
+    GetSerialResp = 0x0103,
+    GetVariantReq = 0x0004,
+    GetVariantResp = 0x0104,
+    RegisterNotificationCmd = 0x0007,
+    RegisterNotificationAck = 0x0107,
+    GetTransportInfoReq = 0x000c,
+    GetTransportInfoResp = 0x010c,
+    SetTransportInfoReq = 0x000d,
+    SetTransportInfoResp = 0x010d,
+    GetSystemInfoReq = 0x0011,
+    GetSystemInfoResp = 0x0111,
+    UpgradeConnectCmd = 0x0c00,
+    UpgradeConnectAck = 0x0d00,
+    UpgradeDisconnectCmd = 0x0c01,
+    UpgradeDisconnectAck = 0x0d01,
+    UpgradeControlCmd = 0x0c02,
+    UpgradeControlAck = 0x0d02,
+ }
+
+#[repr(u8)]
+enum FuQcGaiaCmdStatus {
+    Success = 0x00,
+    NotSupported = 0x01,
+    InsufficientResources = 0x03,
+    InvalidParameter = 0x05,
+    IncorrectState = 0x06,
+    InProgerss = 0x07,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3ApiReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetApiReq,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3Api {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetApiResp,
+    major: u8,
+    minor: u8,
+}
+
+#[repr(u8)]
+enum FuQcMore {
+    More = 1,
+    Last = 0,
+}
+#[derive(New)]
+struct FuStructQcGaiaV3SupportedFeaturesReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3SupportedFeatures {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd,
+    moreFeatures: FuQcMore,
+    // variable length
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3SerialReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetSerialReq,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3Serial {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetSerialResp,
+    // variable string
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3VariantReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetVariantReq,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3Variant {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetVariantResp,
+    // variable string
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3GetTransportInfoReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetTransportInfoReq,
+    key: u8,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3GetTransportInfo {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == GetTransportInfoResp,
+    key: u8,
+    value: u32be,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3SetTransportInfoReq {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == SetTransportInfoReq,
+    key: u8,
+    value: u32be,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3SetTransportInfo {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == SetTransportInfoResp,
+    key: u8,
+    value: u32be,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3UpgradeConnectCmd {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeConnectCmd,
+}
+
+#[derive(Parse)]
+struct FuStructQcGaiaV3UpgradeConnectAck {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeConnectAck,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3UpgradeDisconnectCmd {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeDisconnectCmd,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3UpgradeDisconnectAck {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeDisconnectAck,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3RegisterNotificationCmd {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == RegisterNotificationCmd,
+    feature: u8 == 0x06,
+}
+
+#[derive(Parse)]
+struct FuStructQcGaiaV3RegisterNotificationAck {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == RegisterNotificationAck,
+}
+
+#[derive(New)]
+struct FuStructQcGaiaV3UpgradeControlCmd {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeControlCmd,
+}
+#[derive(Parse)]
+struct FuStructQcGaiaV3UpgradeControlAck {
+    vendorId: u16be,
+    command: FuQcGaiaV3Cmd == UpgradeControlAck,
+    status: FuQcGaiaCmdStatus == Success,
+}

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-impl.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-impl.c
@@ -16,7 +16,11 @@ fu_qc_s5gen2_impl_default_init(FuQcS5gen2ImplInterface *iface)
 }
 
 gboolean
-fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error)
+fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self,
+			 guint8 *data,
+			 gsize data_len,
+			 gsize *read_len,
+			 GError **error)
 {
 	FuQcS5gen2ImplInterface *iface;
 
@@ -30,7 +34,7 @@ fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GEr
 				    "iface->msg_in not implemented");
 		return FALSE;
 	}
-	return (*iface->msg_in)(self, data, data_len, error);
+	return (*iface->msg_in)(self, data, data_len, read_len, error);
 }
 
 gboolean
@@ -52,19 +56,55 @@ fu_qc_s5gen2_impl_msg_out(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GE
 }
 
 gboolean
-fu_qc_s5gen2_impl_msg_cmd(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error)
+fu_qc_s5gen2_impl_req_connect(FuQcS5gen2Impl *self, GError **error)
 {
 	FuQcS5gen2ImplInterface *iface;
 
 	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
 
 	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
-	if (iface->msg_cmd == NULL) {
+	if (iface->req_connect == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
-				    "iface->msg_cmd not implemented");
+				    "iface->req_connect not implemented");
 		return FALSE;
 	}
-	return (*iface->msg_cmd)(self, data, data_len, error);
+	return (*iface->req_connect)(self, error);
+}
+
+gboolean
+fu_qc_s5gen2_impl_req_disconnect(FuQcS5gen2Impl *self, GError **error)
+{
+	FuQcS5gen2ImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
+
+	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
+	if (iface->req_disconnect == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->req_connect not implemented");
+		return FALSE;
+	}
+	return (*iface->req_disconnect)(self, error);
+}
+
+gboolean
+fu_qc_s5gen2_impl_data_size(FuQcS5gen2Impl *self, gsize *data_sz, GError **error)
+{
+	FuQcS5gen2ImplInterface *iface;
+
+	g_return_val_if_fail(FU_IS_QC_S5GEN2_IMPL(self), FALSE);
+
+	iface = FU_QC_S5GEN2_IMPL_GET_IFACE(self);
+	if (iface->data_size == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "iface->data_size not implemented");
+		return FALSE;
+	}
+	return (*iface->data_size)(self, data_sz, error);
 }

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-impl.h
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-impl.h
@@ -13,14 +13,29 @@ G_DECLARE_INTERFACE(FuQcS5gen2Impl, fu_qc_s5gen2_impl, FU, QC_S5GEN2_IMPL, GObje
 
 struct _FuQcS5gen2ImplInterface {
 	GTypeInterface g_iface;
-	gboolean (*msg_in)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+	gboolean (*msg_in)(FuQcS5gen2Impl *self,
+			   guint8 *data,
+			   gsize data_len,
+			   gsize *read_len,
+			   GError **error);
 	gboolean (*msg_out)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
-	gboolean (*msg_cmd)(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+	gchar *(*get_version)(FuQcS5gen2Impl *self, GError **error);
+	gboolean (*req_connect)(FuQcS5gen2Impl *self, GError **error);
+	gboolean (*req_disconnect)(FuQcS5gen2Impl *self, GError **error);
+	gboolean (*data_size)(FuQcS5gen2Impl *self, gsize *datasz, GError **error);
 };
 
 gboolean
-fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+fu_qc_s5gen2_impl_msg_in(FuQcS5gen2Impl *self,
+			 guint8 *data,
+			 gsize data_len,
+			 gsize *read_len,
+			 GError **error);
 gboolean
 fu_qc_s5gen2_impl_msg_out(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
 gboolean
-fu_qc_s5gen2_impl_msg_cmd(FuQcS5gen2Impl *self, guint8 *data, gsize data_len, GError **error);
+fu_qc_s5gen2_impl_req_connect(FuQcS5gen2Impl *self, GError **error);
+gboolean
+fu_qc_s5gen2_impl_req_disconnect(FuQcS5gen2Impl *self, GError **error);
+gboolean
+fu_qc_s5gen2_impl_data_size(FuQcS5gen2Impl *self, gsize *data_sz, GError **error);

--- a/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.c
+++ b/plugins/audio-s5gen2/fu-audio-s5gen2-plugin.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include "fu-audio-s5gen2-ble-device.h"
 #include "fu-audio-s5gen2-device.h"
 #include "fu-audio-s5gen2-firmware.h"
 #include "fu-audio-s5gen2-hid-device.h"
@@ -26,6 +27,9 @@ static void
 fu_audio_s5gen2_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	fu_context_add_quirk_key(ctx, "AudioS5gen2Gaia3VendorId");
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_BLE_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_HID_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QC_S5GEN2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_QC_S5GEN2_FIRMWARE);

--- a/plugins/audio-s5gen2/meson.build
+++ b/plugins/audio-s5gen2/meson.build
@@ -4,10 +4,12 @@ plugins += {meson.current_source_dir().split('/')[-1]: true}
 plugin_quirks += files('audio-s5gen2.quirk')
 plugin_builtins += static_library('fu_plugin_audio_s5gen2',
   rustgen.process('fu-audio-s5gen2.rs'),
+  rustgen.process('fu-audio-s5gen2-ble.rs'),
   rustgen.process('fu-audio-s5gen2-hid.rs'),
   rustgen.process('fu-audio-s5gen2-fw.rs'),
   sources: [
     'fu-audio-s5gen2-device.c',
+    'fu-audio-s5gen2-ble-device.c',
     'fu-audio-s5gen2-hid-device.c',
     'fu-audio-s5gen2-firmware.c',
     'fu-audio-s5gen2-plugin.c',


### PR DESCRIPTION
Typically, BlueTooth devices should be detected by GAIA primary service with if default vendor ID has been used:
* BLUETOOTH\GATT_00001100-d102-11e1-9b23-00025b00a5a5

Unique GUID is constructed with the info read from device:
* BLUETOOTH\GAIA_QCC5171

Example:
├─QCC5171:
│     Device ID:          b67d007c2e3436dd21838d08c9053e07e7902ef6
│     Current version:    1.1.2
│     Vendor:             BLUETOOTH:001D
│     Serial Number:      ABCDEF0123456789
│     Battery:            96% (threshold 10%)
│     GUIDs:              2216161a-9f4e-59f4-ba05-b202e0c28e16 ← BLUETOOTH\NAME_QCC5171
│                         61497166-1419-572c-8da9-15d8460e0d0f ← BLUETOOTH\GAIA_QCC5171
│     Device Flags:       • Updatable
│                         • Device stages updates
│                         • Device can recover flash failures
│                         • Device is usable for the duration of the update
│                         • Signed Payload

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
