### PR TITLE
trivial: bump libjcat and passim deps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -243,7 +243,7 @@ sqlite = dependency('sqlite3', required: get_option('sqlite'))
 if sqlite.found()
   conf.set('HAVE_SQLITE', '1')
 endif
-passim = dependency('passim', version: '>= 0.1.2', required: get_option('passim'), fallback: ['passim', 'passim_dep'])
+passim = dependency('passim', version: '>= 0.1.5', required: get_option('passim'), fallback: ['passim', 'passim_dep'])
 if passim.found()
   conf.set('HAVE_PASSIM', '1')
 endif
@@ -255,7 +255,7 @@ if libarchive.found()
   endif
 endif
 endif
-libjcat = dependency('jcat', version: '>= 0.1.4', fallback: ['libjcat', 'libjcat_dep'])
+libjcat = dependency('jcat', version: '>= 0.2.0', fallback: ['libjcat', 'libjcat_dep'])
 libjsonglib = dependency('json-glib-1.0', version: '>= 1.6.0')
 valgrind = dependency('valgrind', required: false)
 libcurl = dependency('libcurl', version: '>= 7.62.0', required: get_option('curl'))

--- a/subprojects/libjcat.wrap
+++ b/subprojects/libjcat.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libjcat
 url = https://github.com/hughsie/libjcat.git
-revision = 0.1.14
+revision = 0.2.1


### PR DESCRIPTION
These should have been bumped as part of 62f6f19d269212871493ba8343bf0d53204c7fb7

(cherry picked from commit 774b87fed0c6addd49cdc65a3ecc24923f7c76ae)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
