### PR TITLE
Make modem-manager VID_PID IDs visible

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -160,7 +160,7 @@ fu_mm_device_add_instance_id(FuDevice *dev, const gchar *device_id)
 		return;
 	}
 	if (g_pattern_match_simple("???\\VID_????&PID_????", device_id)) {
-		fu_device_add_instance_id_full(dev, device_id, FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+		fu_device_add_instance_id(dev, device_id);
 		return;
 	}
 	if (g_pattern_match_simple("???\\VID_????&PID_????&REV_????", device_id)) {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Currently only `VID_&PID_&REV_` and `VID_&PID_&REV_&CARRIER_` instance IDs are visible for modem-manager devices.
It would be useful to be able to select a device matching `VID_&PID_` only, independent of its revision, in LVFS metadata.

```
└─EC25:
      Summary:            Quectel EG25-G/EC25 modem
      ...
      GUID:               1a2996cb-f86e-5583-a464-e1b96e1c6ae9 ← USB\VID_2C7C&PID_0125&REV_0318
      Device Flags:       • Updatable
```