### PR TITLE
Allow setting NULL data in fu_device_event_set_data()

### DIFF
--- a/libfwupdplugin/fu-device-event-private.h
+++ b/libfwupdplugin/fu-device-event-private.h
@@ -30,7 +30,7 @@ fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
     G_GNUC_NON_NULL(1, 2, 3);
 void
 fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *buf, gsize bufsz)
-    G_GNUC_NON_NULL(1, 2, 3);
+    G_GNUC_NON_NULL(1, 2);
 GBytes *
 fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
     G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -154,7 +154,7 @@ fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
  * fu_device_event_set_data:
  * @self: a #FuDeviceEvent
  * @key: (not nullable): a unique key, e.g. `Name`
- * @buf: (not nullable): a buffer
+ * @buf: (nullable): a buffer
  * @bufsz: size of @buf
  *
  * Sets a memory buffer on the event. Note: memory buffers are stored internally as BASE-64 strings.
@@ -167,7 +167,6 @@ fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *bu
 	FuDeviceEventPrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FU_IS_DEVICE_EVENT(self));
 	g_return_if_fail(key != NULL);
-	g_return_if_fail(buf != NULL);
 	g_hash_table_insert(
 	    priv->values,
 	    g_strdup(key),
@@ -266,6 +265,8 @@ fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
 	blobstr = fu_device_event_lookup(self, key, G_TYPE_STRING, error);
 	if (blobstr == NULL)
 		return NULL;
+	if (blobstr[0] == '\0')
+		return g_bytes_new(NULL, 0);
 	buf = g_base64_decode(blobstr, &bufsz);
 	return g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 }

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1853,11 +1853,13 @@ fu_device_event_func(void)
 	g_autoptr(FuDeviceEvent) event2 = fu_device_event_new(NULL);
 	g_autoptr(GBytes) blob1 = g_bytes_new_static("hello", 6);
 	g_autoptr(GBytes) blob2 = NULL;
+	g_autoptr(GBytes) blob3 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	fu_device_event_set_str(event1, "Name", "Richard");
 	fu_device_event_set_i64(event1, "Age", 123);
 	fu_device_event_set_bytes(event1, "Blob", blob1);
+	fu_device_event_set_data(event1, "Data", NULL, 0);
 
 	json = fwupd_codec_to_json_string(FWUPD_CODEC(event1), FWUPD_CODEC_FLAG_NONE, &error);
 	g_assert_no_error(error);
@@ -1865,6 +1867,7 @@ fu_device_event_func(void)
 			==,
 			"{\n"
 			"  \"Id\" : \"foo:bar:baz\",\n"
+			"  \"Data\" : \"\",\n"
 			"  \"Age\" : 123,\n"
 			"  \"Name\" : \"Richard\",\n"
 			"  \"Blob\" : \"aGVsbG8A\"\n"
@@ -1879,6 +1882,9 @@ fu_device_event_func(void)
 	blob2 = fu_device_event_get_bytes(event2, "Blob", &error);
 	g_assert_nonnull(blob2);
 	g_assert_cmpstr(g_bytes_get_data(blob2, NULL), ==, "hello");
+	blob3 = fu_device_event_get_bytes(event2, "Data", &error);
+	g_assert_nonnull(blob3);
+	g_assert_cmpstr(g_bytes_get_data(blob3, NULL), ==, NULL);
 
 	/* invalid type */
 	str = fu_device_event_get_str(event2, "Age", &error);


### PR DESCRIPTION
The Huddly USB device does a zero-length bulk transfer to reset the device, and that doesn't get saved in the emulation data. Handle NULL.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
