### PR TITLE
trivial: drop support for deprecated quirk strings

### DIFF
--- a/contrib/ci/check-quirks.py
+++ b/contrib/ci/check-quirks.py
@@ -25,11 +25,6 @@ def test_files() -> int:
                         print(f"{fn} has invalid section header: {line}")
                         rc = 1
                         continue
-                    for deprecated in ["DeviceInstanceId", "Guid"]:
-                        if line.find(deprecated) != -1:
-                            print(f"{fn} has deprecated prefix: {deprecated}")
-                            rc = 1
-                            continue
                 else:
                     sections = line.split(" = ")
                     if len(sections) != 2:

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -94,22 +94,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(sqlite3_stmt, sqlite3_finalize);
 static gchar *
 fu_quirks_build_group_key(const gchar *group)
 {
-	const gchar *guid_prefixes[] = {"DeviceInstanceId=", "Guid=", "HwId=", NULL};
-
-	/* this is a GUID */
-	for (guint i = 0; guid_prefixes[i] != NULL; i++) {
-		if (g_str_has_prefix(group, guid_prefixes[i])) {
-			gsize len = strlen(guid_prefixes[i]);
-			g_warning("using %s for %s in quirk files is deprecated!",
-				  guid_prefixes[i],
-				  group);
-			if (fwupd_guid_is_valid(group + len))
-				return g_strdup(group + len);
-			return fwupd_guid_hash_string(group + len);
-		}
-	}
-
-	/* fallback */
 	if (fwupd_guid_is_valid(group))
 		return g_strdup(group);
 	return fwupd_guid_hash_string(group);


### PR DESCRIPTION
These were deprecated 3.5 years ago in 7d132b728c.
Drop support for them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
