### PR TITLE
trivial: bump meson version to a more modern version

### DIFF
--- a/libfwupdplugin/tests/efi/efivars/meson.build
+++ b/libfwupdplugin/tests/efi/efivars/meson.build
@@ -1,15 +1,9 @@
-configure_file(input: 'BootNext-8be4df61-93ca-11d2-aa0d-00e098032b8c',
-               output: 'BootNext-8be4df61-93ca-11d2-aa0d-00e098032b8c',
-               copy: true,
-               install: true,
-               install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))
-configure_file(input: 'fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e-0-0abba7dc-e516-4167-bbf5-4d9d1c739416',
-               output: 'fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e-0-0abba7dc-e516-4167-bbf5-4d9d1c739416',
-               copy: true,
-               install: true,
-               install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))
-configure_file(input: 'SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c',
-               output: 'SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c',
-               copy: true,
-               install: true,
-               install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))
+fs.copyfile('BootNext-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+            install: true,
+            install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))
+fs.copyfile('fwupd-ddc0ee61-e7f0-4e7d-acc5-c070a398838e-0-0abba7dc-e516-4167-bbf5-4d9d1c739416',
+            install: true,
+            install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))
+fs.copyfile('SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c',
+            install: true,
+            install_dir: join_paths(installed_test_datadir, 'tests/efi/efivars'))

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version: '2.0.0',
   license: 'LGPL-2.1-or-later',
-  meson_version: '>=0.62.0',
+  meson_version: '>=1.3.0',
   default_options: ['warning_level=2', 'c_std=c11'],
 )
 


### PR DESCRIPTION
Don't pigeonhole into 0.xx series for a modern fwupd.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
