### PR TITLE
Fix loading USB emulation data

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2327,8 +2327,9 @@ fu_backend_emulate_func(void)
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(GError) error = NULL;
 	const gchar *json1 = "{"
-			     "  \"UdevDevices\" : ["
+			     "  \"UsbDevices\" : ["
 			     "    {"
+			     "      \"GType\" : \"FuUdevDevice\",\n"
 			     "      \"BackendId\" : \"foo:bar:baz\","
 			     "      \"Created\" : \"2023-02-01T16:35:03.302027Z\","
 			     "      \"Events\" : ["
@@ -2345,8 +2346,9 @@ fu_backend_emulate_func(void)
 			     "  ]"
 			     "}";
 	const gchar *json2 = "{\n"
-			     "  \"UdevDevices\" : [\n"
+			     "  \"UsbDevices\" : [\n"
 			     "    {\n"
+			     "      \"GType\" : \"FuUdevDevice\",\n"
 #if GLIB_CHECK_VERSION(2, 80, 0)
 			     "      \"BackendId\" : \"usb:FF:FF:06\",\n"
 			     "      \"Created\" : \"2099-02-01T16:35:03Z\"\n"

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -2170,6 +2170,7 @@ fu_udev_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags
 	GPtrArray *events = fu_device_get_events(device);
 
 	/* optional properties */
+	fwupd_codec_json_append(builder, "GType", "FuUdevDevice");
 	if (fu_udev_device_get_sysfs_path(self) != NULL)
 		fwupd_codec_json_append(builder, "BackendId", fu_udev_device_get_sysfs_path(self));
 	if (priv->device_file != NULL)

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -251,6 +251,12 @@ fu_bluez_backend_class_init(FuBluezBackendClass *klass)
 FuBackend *
 fu_bluez_backend_new(FuContext *ctx)
 {
-	return FU_BACKEND(
-	    g_object_new(FU_TYPE_BLUEZ_BACKEND, "name", "bluez", "context", ctx, NULL));
+	return FU_BACKEND(g_object_new(FU_TYPE_BLUEZ_BACKEND,
+				       "name",
+				       "bluez",
+				       "context",
+				       ctx,
+				       "device-gtype",
+				       FU_TYPE_BLUEZ_DEVICE,
+				       NULL));
 }

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2833,56 +2833,23 @@ fu_engine_emulation_save(FuEngine *self, GOutputStream *stream, GError **error)
 static void
 fu_engine_backends_to_json(FuEngine *self, JsonBuilder *json_builder)
 {
-	GHashTableIter iter;
-	GPtrArray *devices_array;
-	const gchar *list_name;
-	g_autoptr(GHashTable) backend_devices = NULL;
 	g_autoptr(GPtrArray) devices = fu_device_list_get_active(self->device_list);
 
-	/* create a map of { list_name: [devices] } */
-	backend_devices = g_hash_table_new_full(g_str_hash,
-						g_str_equal,
-						g_free,
-						(GDestroyNotify)g_ptr_array_unref);
+	/* not always correct, but we want to remain compatible with all the old emulation files */
+	json_builder_begin_object(json_builder);
+	json_builder_set_member_name(json_builder, "UsbDevices");
+	json_builder_begin_array(json_builder);
 	for (guint i = 0; i < devices->len; i++) {
 		FuDevice *device = g_ptr_array_index(devices, i);
-		FuBackend *backend = fu_device_get_backend(device);
-		g_autofree gchar *list_name_new = NULL;
 
 		/* interesting? */
 		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATION_TAG))
 			continue;
-		if (backend == NULL)
-			continue;
-
-		/* find the array, or create if required */
-		list_name_new = fu_backend_get_emulation_array_member_name(backend);
-		devices_array = g_hash_table_lookup(backend_devices, list_name_new);
-		if (devices_array == NULL) {
-			devices_array = g_ptr_array_new();
-			g_hash_table_insert(backend_devices,
-					    g_steal_pointer(&list_name_new),
-					    (gpointer)devices_array);
-		}
-		g_ptr_array_add(devices_array, device);
+		json_builder_begin_object(json_builder);
+		fwupd_codec_to_json(FWUPD_CODEC(device), json_builder, FWUPD_CODEC_FLAG_NONE);
+		json_builder_end_object(json_builder);
 	}
-
-	/* devices in per-backend array */
-	json_builder_begin_object(json_builder);
-	g_hash_table_iter_init(&iter, backend_devices);
-	while (g_hash_table_iter_next(&iter, (gpointer *)&list_name, (gpointer *)&devices_array)) {
-		json_builder_set_member_name(json_builder, list_name);
-		json_builder_begin_array(json_builder);
-		for (guint i = 0; i < devices_array->len; i++) {
-			FuDevice *device = g_ptr_array_index(devices_array, i);
-			json_builder_begin_object(json_builder);
-			fwupd_codec_to_json(FWUPD_CODEC(device),
-					    json_builder,
-					    FWUPD_CODEC_FLAG_NONE);
-			json_builder_end_object(json_builder);
-		}
-		json_builder_end_array(json_builder);
-	}
+	json_builder_end_array(json_builder);
 	json_builder_end_object(json_builder);
 
 	/* we've recorded these, now drop them */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4081,6 +4081,7 @@ fu_backend_usb_func(gconstpointer user_data)
 #endif
 
 	/* check there were events */
+	g_object_set(backend, "device-gtype", FU_TYPE_USB_DEVICE, NULL);
 	g_signal_connect(backend,
 			 "device-added",
 			 G_CALLBACK(fu_backend_usb_hotplug_cb),
@@ -4161,6 +4162,7 @@ fu_backend_usb_invalid_func(gconstpointer user_data)
 	g_autoptr(JsonParser) parser = json_parser_new();
 
 	/* load the JSON into the backend */
+	g_object_set(backend, "device-gtype", FU_TYPE_USB_DEVICE, NULL);
 	usb_emulate_fn =
 	    g_test_build_filename(G_TEST_DIST, "tests", "usb-devices-invalid.json", NULL);
 	ret = json_parser_load_from_file(parser, usb_emulate_fn, &error);

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -441,7 +441,5 @@ fu_usb_backend_new(FuContext *ctx)
 				       "usb",
 				       "context",
 				       ctx,
-				       "device-gtype",
-				       FU_TYPE_USB_DEVICE,
 				       NULL));
 }


### PR DESCRIPTION
Since FuUdevBackend is actually creating FuUsbDevice objects on Linux we can't rely on one backend handling just one kind of emulated device GType.

Lets simplify loading and saving the emulation data. Rather than splitting up the arrays per-backend just load everything and respect the device GType, but defaulting to FuUsbDevice to allow older emulation data to run.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
