### PR TITLE
trivial: set minimum glib version to 2.80

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -203,8 +203,8 @@ mandir = join_paths(prefix, get_option('mandir'))
 localedir = join_paths(prefix, get_option('localedir'))
 
 diffcmd = find_program('diff')
-gio = dependency('gio-2.0', version: '>= 2.68.0')
-giounix = dependency('gio-unix-2.0', version: '>= 2.68.0', required: false)
+gio = dependency('gio-2.0', version: '>= 2.72.0')
+giounix = dependency('gio-unix-2.0', version: '>= 2.72.0', required: false)
 if giounix.found()
   conf.set('HAVE_GIO_UNIX', '1')
 endif

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -379,19 +379,11 @@ fu_cpu_device_add_security_attrs_cet_active(FuCpuDevice *self, FuSecurityAttrs *
 		g_warning("failed to test CET: %s", error_local->message);
 		return;
 	}
-#if GLIB_CHECK_VERSION(2, 69, 2)
 	if (!g_spawn_check_wait_status(exit_status, &error_local)) {
 		g_debug("CET does not function, not supported: %s", error_local->message);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);
 		return;
 	}
-#else
-	if (!g_spawn_check_exit_status(exit_status, &error_local)) {
-		g_debug("CET does not function, not supported: %s", error_local->message);
-		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_SUPPORTED);
-		return;
-	}
-#endif
 
 	/* success */
 	fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);


### PR DESCRIPTION
This will let us drop some special cased code for older glib versions.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
