### PR TITLE
medaitek-scaler: update bank 1 and add quirk key bank2-only for backward support

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -3,7 +3,7 @@
 VENV=$(dirname $0)/..
 BUILD=${VENV}/build
 DIST=${VENV}/dist
-EXTRA_ARGS="-Dsystemd=disabled -Dlaunchd=disabled"
+EXTRA_ARGS="-Dlibxmlb:gtkdoc=false -Dsystemd=disabled -Dlaunchd=disabled"
 
 #build and install
 if [ -d /opt/homebrew/opt/libarchive/lib/pkgconfig ]; then

--- a/plugins/mediatek-scaler/README.md
+++ b/plugins/mediatek-scaler/README.md
@@ -26,22 +26,76 @@ This plugin supports the following protocol ID:
 
 ## GUID Generation
 
+Devices use instance ID and the ingredients are vary according to fwupd version.
+
+### fwupd 1.9.6
+
 Devices use instance ID that is composed of `Subsystem ID`, `Subsystem Model`, and
 the `Hardware Version`. The hardware version is read from the device.
 
-* `DISPLAY\VID_1028&PID_0C88&HWVER_2.1.2.1`
-* `DISPLAY\VID_1028&PID_0C8A&HWVER_2.1.2.1`
+* `DISPLAY\VID_1028&PID_0C88&HWVER_2.1.2.1` (metadata)
+* `DISPLAY\VID_1028&PID_0C8A&HWVER_2.1.2.1` (metadata)
+
+### fwupd 1.9.10
+
+The DDC/CI commands used to test the target device have been restricted to run on
+specific hardware only. Typically by adding a quirk file to match the system `VID`
+and `PID` from the `PCI` bus.
+
+* `DISPLAY\VID_1028&PID_0C88&HWVER_2.1.2.1` (metadata)
+* `DISPLAY\VID_1028&PID_0C8A&HWVER_2.1.2.1` (metadata)
+* `PCI\VID_1028&PID_0C88` (only-quirks)
 * `PCI\VID_1028&PID_0C8A` (only-quirks)
+
+### fwupd 2.0.0
+
+The enumeration of `i2c` devices has been centralized to daemon libfwupdplugin and
+declared as a `proxy` device for the `drm` subsystem device. The instance ID will
+be composed of `VEN`, `DEV` and the `HWVER`.
+
+The instance ID `VEN` is equivalent to the `mfg id` in device `EDID` while `DEV` is
+the `product code`.
+
+* `DRM\VEN_DEL&DEV_4340&HWVER_2.1.2.1` (quirks and metadata)
+* `DRM\VEN_DEL&DEV_7430&HWVER_3.1.5.1` (quirks and metadata)
+
+Example below for the information in EDID:
+
+```shell
+$ sudo apt install ddcutil
+$ sudo ddcutil detect
+Display 1
+   I2C bus:  /dev/i2c-14
+   DRM connector:           card1-DP-2
+   EDID synopsis:
+      Mfg id:               DEL - Dell Inc.
+      Model:                OptiPlex AIO
+      Product code:         17216  (0x4340)
+      Serial number:
+      Binary serial number: 1145581640 (0x44483048)
+      Manufacture year:     2023,  Week: 30
+   VCP version:         2.1
+```
 
 ## Update Behavior
 
 The firmware is deployed when the device is in normal runtime mode, and the
 device will reset when the new firmware has been written. On some hardware the
-MST device may not enumerate if there is no monitor actually plugged in.
+DRM device may not enumerate if there is no monitor actually plugged in.
 
 ## Vendor ID security
 
 The vendor ID is set from the PCI vendor, for instance `PCI:0x1028` on Dell systems.
+
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### `bank2-only`
+
+Install firmware to bank 2 only.
+
+Since: 2.0.0
 
 ## External Interface Access
 

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -30,11 +30,25 @@
 /* delay time before a ddc read or write */
 #define FU_MEDIATEK_SCALER_DDC_MSG_DELAY_MS 50
 
+/* delay time before a ddc read or write */
+#define FU_MEDIATEK_SCALER_CHUNK_SENT_DELAY_MS 1
+
 /* interval in ms between the poll to check device status */
 #define FU_MEDIATEK_SCALER_DEVICE_POLL_INTERVAL 1000
 
+/* maximum retries for polliing the device existence */
+#define FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY 100
+
 /* firmware payload size */
 #define FU_MEDIATEK_SCALER_FW_SIZE_MAX 0x100000
+
+/* device private flag */
+#define FWUPD_MEDIATEK_SCALER_FLAG_BANK2_ONLY "bank2-only"
+
+typedef struct {
+	FuChunk *chk;
+	guint32 sent_sz;
+} FuMediatekScalerWriteChunkHelper;
 
 struct _FuMediatekScalerDevice {
 	FuDrmDevice parent_instance;
@@ -440,11 +454,13 @@ fu_mediatek_scaler_device_prepare_update_cb(FuDevice *device, gpointer user_data
 	if (!fu_mediatek_scaler_device_get_data_ack_size(device, &acksz, error))
 		return FALSE;
 	if (fw_sz != (gsize)acksz) {
-		g_prefix_error(error,
-			       "device nak the incoming filesize, requested: %" G_GSIZE_FORMAT
-			       ", ack: %u",
-			       fw_sz,
-			       acksz);
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "device nak the incoming filesize, requested: %" G_GSIZE_FORMAT
+			    ", ack: %u",
+			    fw_sz,
+			    acksz);
 		return FALSE;
 	}
 
@@ -489,6 +505,7 @@ fu_mediatek_scaler_device_set_data(FuMediatekScalerDevice *self, FuChunk *chk, G
 			g_prefix_error(error, "failed to send firmware to device: ");
 			return FALSE;
 		}
+		fu_device_sleep(FU_DEVICE(self), FU_MEDIATEK_SCALER_CHUNK_SENT_DELAY_MS);
 	}
 	return TRUE;
 }
@@ -515,39 +532,37 @@ fu_mediatek_scaler_device_get_staged_data(FuMediatekScalerDevice *self,
 
 static gboolean
 fu_mediatek_scaler_device_check_sent_info(FuMediatekScalerDevice *self,
-					  GInputStream *stream,
+					  FuChunk *chk,
+					  guint32 sent_size,
 					  GError **error)
 {
 	guint16 chksum = 0;
 	guint16 sum16 = 0;
 	guint32 pktcnt = 0;
-	gsize streamsz = 0;
 
-	if (!fu_mediatek_scaler_device_get_staged_data(self, &chksum, &pktcnt, error))
+	if (!fu_mediatek_scaler_device_get_staged_data(self, &chksum, &pktcnt, error)) {
+		g_prefix_error(error, "failed to get the staged data: ");
 		return FALSE;
+	}
 
 	/* verify the staged packets on chip */
-	if (!fu_input_stream_size(stream, &streamsz, error))
-		return FALSE;
-	if (streamsz != pktcnt) {
+	if (sent_size != pktcnt) {
 		g_set_error(error,
 			    FWUPD_ERROR,
-			    FWUPD_ERROR_WRITE,
-			    "failed data verification, sent size: %" G_GSIZE_FORMAT
-			    ", ack size: %u",
-			    streamsz,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data packet size mismatched, expected: %X, chip got: %X",
+			    sent_size,
 			    pktcnt);
 		return FALSE;
 	}
 
 	/* verify the checksum on chip */
-	if (!fu_input_stream_compute_sum16(stream, &sum16, error))
-		return FALSE;
+	sum16 = fu_sum16(fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 	if (sum16 != chksum) {
 		g_set_error(error,
 			    FWUPD_ERROR,
-			    FWUPD_ERROR_WRITE,
-			    "failed data checksum comparison, expected: %u, got: %u",
+			    FWUPD_ERROR_INVALID_DATA,
+			    "data packet checksum mismatched, expected: %X, chip got: %X",
 			    sum16,
 			    chksum);
 		return FALSE;
@@ -571,8 +586,10 @@ fu_mediatek_scaler_device_commit_firmware(FuMediatekScalerDevice *self,
 					  GError **error)
 {
 	guint16 sum16 = 0;
+
 	if (!fu_input_stream_compute_sum16(stream, &sum16, error))
 		return FALSE;
+
 	if (!(fu_mediatek_scaler_device_run_isp(self, sum16, error))) {
 		g_prefix_error(error, "failed to commit firmware: ");
 		return FALSE;
@@ -600,9 +617,10 @@ fu_mediatek_scaler_device_set_isp_reboot(FuMediatekScalerDevice *self, GError **
 }
 
 static gboolean
-fu_mediatek_scaler_device_get_isp_status(FuMediatekScalerDevice *self, GError **error)
+fu_mediatek_scaler_device_get_isp_status(FuMediatekScalerDevice *self,
+					 guint8 *isp_status,
+					 GError **error)
 {
-	guint8 isp_status = 0;
 	g_autoptr(GByteArray) st_req = fu_struct_ddc_cmd_new();
 	g_autoptr(GByteArray) st_res = NULL;
 
@@ -611,43 +629,59 @@ fu_mediatek_scaler_device_get_isp_status(FuMediatekScalerDevice *self, GError **
 	st_res = fu_mediatek_scaler_device_ddc_read(self, st_req, error);
 	if (st_res == NULL)
 		return FALSE;
-	if (!fu_memread_uint8_safe(st_res->data, st_res->len, 2, &isp_status, error))
+
+	if (!fu_memread_uint8_safe(st_res->data, st_res->len, 2, isp_status, error))
 		return FALSE;
-	if (isp_status != 2) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_INTERNAL,
-			    "incorrect isp status, expected: 0x%02X, got 0x%u",
-			    (guint)2,
-			    isp_status);
-		return FALSE;
-	}
+
 	return TRUE;
 }
 
 static gboolean
-fu_mediatek_scaler_device_verify(FuDevice *device, gsize sz, GError **error)
+fu_mediatek_scaler_device_is_update_success_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuMediatekScalerDevice *self = FU_MEDIATEK_SCALER_DEVICE(device);
-	guint base = sz / 1024 / 512;
-	guint max_tries = base < 1 ? 60 : base * 60;
+	guint8 isp_status = 0;
 
+	if (!fu_mediatek_scaler_device_get_isp_status(self, &isp_status, error))
+		return FALSE;
+
+	if (isp_status != FU_MEDIATEK_SCALER_ISP_STATUS_SUCCESS) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "incorrect isp status, expected: 0x%x, got: 0x%x",
+			    (guint)FU_MEDIATEK_SCALER_ISP_STATUS_SUCCESS,
+			    isp_status);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_mediatek_scaler_device_verify(FuDevice *device, GError **error)
+{
 	if (!fu_device_retry_full(device,
 				  fu_mediatek_scaler_device_display_is_connected_cb,
-				  max_tries,
+				  FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY,
 				  FU_MEDIATEK_SCALER_DEVICE_POLL_INTERVAL,
 				  NULL,
 				  error)) {
 		g_prefix_error(error,
 			       "display controller did not reconnect after %u retries: ",
-			       max_tries);
+			       (guint)FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY);
 		return FALSE;
 	}
 
-	if (!fu_mediatek_scaler_device_get_isp_status(self, error)) {
-		g_prefix_error(error, "failed to get isp status: ");
+	/* ensure isp status */
+	if (!fu_device_retry_full(device,
+				  fu_mediatek_scaler_device_is_update_success_cb,
+				  FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY,
+				  FU_MEDIATEK_SCALER_DEVICE_POLL_INTERVAL,
+				  NULL,
+				  error))
 		return FALSE;
-	}
+
 	return TRUE;
 }
 
@@ -663,13 +697,44 @@ fu_mediatek_scaler_device_chunk_data_is_blank(FuChunk *chk)
 
 static gboolean
 fu_mediatek_scaler_device_set_data_fast_forward(FuMediatekScalerDevice *self,
-						FuChunk *chk,
+						guint32 sent_sz,
 						GError **error)
 {
 	g_autoptr(GByteArray) st_req = fu_struct_ddc_cmd_new();
 	fu_struct_ddc_cmd_set_vcp_code(st_req, FU_DDC_VCP_CODE_SET_DATA_FF);
-	fu_byte_array_append_uint32(st_req, fu_chunk_get_data_sz(chk), G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(st_req, sent_sz, G_LITTLE_ENDIAN);
 	return fu_mediatek_scaler_device_ddc_write(self, st_req, error);
+}
+
+static gboolean
+fu_mediatek_scaler_device_write_chunk(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuMediatekScalerDevice *self = FU_MEDIATEK_SCALER_DEVICE(device);
+	FuMediatekScalerWriteChunkHelper *helper = (FuMediatekScalerWriteChunkHelper *)user_data;
+
+	/* fast forward if possible */
+	if (fu_mediatek_scaler_device_chunk_data_is_blank(helper->chk)) {
+		/* fast forward if chunk is empty */
+		if (!fu_mediatek_scaler_device_set_data_fast_forward(self, helper->sent_sz, error))
+			return FALSE;
+	} else {
+		/* set data per fragment size */
+		if (!fu_mediatek_scaler_device_set_data(self, helper->chk, error))
+			return FALSE;
+	}
+
+	/* verify the sent data chunk */
+	if (!fu_mediatek_scaler_device_check_sent_info(self, helper->chk, helper->sent_sz, error)) {
+		/* restore the data size counter */
+		if (!fu_mediatek_scaler_device_set_data_fast_forward(
+			self,
+			helper->sent_sz - fu_chunk_get_data_sz(helper->chk),
+			error))
+			return FALSE;
+	}
+
+	/* ff to reset the checksum */
+	return fu_mediatek_scaler_device_set_data_fast_forward(self, helper->sent_sz, error);
 }
 
 static gboolean
@@ -678,74 +743,46 @@ fu_mediatek_scaler_device_write_firmware_impl(FuMediatekScalerDevice *self,
 					      FuProgress *progress,
 					      GError **error)
 {
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_stream(stream, 0x00, DDC_DATA_PAGE_SIZE, error);
+	guint32 sent_sz = 0x0;
+	g_autoptr(FuChunkArray) chunks = NULL;
+
+	chunks = fu_chunk_array_new_from_stream(stream, 0x00, DDC_DATA_PAGE_SIZE, error);
 	if (chunks == NULL)
 		return FALSE;
-	for (gint retry = 1; retry <= DDC_RW_MAX_RETRY_CNT; retry++) {
-		g_autoptr(GError) error_local = NULL;
-		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-			g_autoptr(FuChunk) chk = NULL;
 
-			/* prepare chunk */
-			chk = fu_chunk_array_index(chunks, i, error);
-			if (chk == NULL)
-				return FALSE;
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 
-			/* fast forward if chunk is empty, otherwise set data per fragment size */
-			if (fu_mediatek_scaler_device_chunk_data_is_blank(chk)) {
-				if (!fu_mediatek_scaler_device_set_data_fast_forward(self,
-										     chk,
-										     error))
-					return FALSE;
-			} else {
-				if (!fu_mediatek_scaler_device_set_data(self, chk, error))
-					return FALSE;
-				fu_device_sleep(FU_DEVICE(self), 1);
-			}
+	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
+		FuMediatekScalerWriteChunkHelper helper_wchunk = {0x0};
+		g_autoptr(FuChunk) chk = NULL;
 
-			/* update progress */
-			fu_progress_set_percentage_full(fu_progress_get_child(progress),
-							(gsize)i + 1,
-							(gsize)fu_chunk_array_length(chunks));
-		}
+		/* prepare chunk */
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
 
-		/* exit the try loop when successes */
-		fu_device_sleep(FU_DEVICE(self), FU_MEDIATEK_SCALER_DDC_MSG_DELAY_MS);
-		if (fu_mediatek_scaler_device_check_sent_info(self, stream, &error_local))
-			return TRUE;
-		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_WRITE)) {
-			g_propagate_error(error, g_steal_pointer(&error_local));
+		/* data size already sent to chip */
+		sent_sz += fu_chunk_get_data_sz(chk);
+
+		/* retry writing data chunk */
+		helper_wchunk.chk = chk;
+		helper_wchunk.sent_sz = sent_sz;
+		if (!fu_device_retry_full(FU_DEVICE(self),
+					  fu_mediatek_scaler_device_write_chunk,
+					  DDC_RW_MAX_RETRY_CNT,
+					  FU_MEDIATEK_SCALER_DDC_MSG_DELAY_MS,
+					  &helper_wchunk,
+					  error)) {
+			g_prefix_error(error, "writing chunk exceeded the maximum retries");
 			return FALSE;
 		}
 
-		g_debug("retry write_firmware: step: %d, max: %d", retry, DDC_RW_MAX_RETRY_CNT);
-	}
-	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "maximum tries exceeded");
-	return FALSE;
-}
+		/* write chunk successfully, update the progress */
+		fu_progress_step_done(progress);
 
-static gboolean
-fu_mediatek_scaler_device_attach(FuDevice *device, FuProgress *progress, GError **error)
-{
-	FuMediatekScalerDevice *self = FU_MEDIATEK_SCALER_DEVICE(device);
-	guint max_tries = 30;
-
-	/* reboot the device */
-	if (!(fu_mediatek_scaler_device_set_isp_reboot(self, error)))
-		return FALSE;
-
-	/* wait for the device back */
-	if (!fu_device_retry_full(device,
-				  fu_mediatek_scaler_device_display_is_connected_cb,
-				  max_tries,
-				  FU_MEDIATEK_SCALER_DEVICE_POLL_INTERVAL,
-				  NULL,
-				  error)) {
-		g_prefix_error(error,
-			       "display controller did not reconnect after %u retries: ",
-			       max_tries);
-		return FALSE;
+		g_debug("data size sent to chip: 0x%x", sent_sz);
 	}
 
 	return TRUE;
@@ -765,9 +802,10 @@ fu_mediatek_scaler_device_write_firmware(FuDevice *device,
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 0, "prepare");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 75, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 76, "write");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "commit");
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 25, "verify");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 12, "verify");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "reset");
 
 	/* get default image */
 	stream = fu_firmware_get_stream(firmware, error);
@@ -791,9 +829,30 @@ fu_mediatek_scaler_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	/* verify display and ISP status */
-	if (!fu_mediatek_scaler_device_verify(device, fw_size, error))
+	/* verify display and ISP status; for bank 1 devices 0xF8 will do self-reboot */
+	if (!fu_mediatek_scaler_device_verify(device, error))
 		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* for bank 2 update */
+	if (fu_device_has_private_flag(device, FWUPD_MEDIATEK_SCALER_FLAG_BANK2_ONLY)) {
+		/* send reboot command to take effect immediately */
+		if (!(fu_mediatek_scaler_device_set_isp_reboot(self, error)))
+			return FALSE;
+
+		/* ensure device is back */
+		if (!fu_device_retry_full(device,
+					  fu_mediatek_scaler_device_display_is_connected_cb,
+					  FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY,
+					  FU_MEDIATEK_SCALER_DEVICE_POLL_INTERVAL,
+					  NULL,
+					  error)) {
+			g_prefix_error(error,
+				       "display controller did not reconnect after %u retries: ",
+				       (guint)FU_MEDIATEK_SCALER_DEVICE_PRESENT_RETRY);
+			return FALSE;
+		}
+	}
 	fu_progress_step_done(progress);
 
 	/* success */
@@ -848,6 +907,7 @@ fu_mediatek_scaler_device_init(FuMediatekScalerDevice *self)
 	fu_device_set_name(FU_DEVICE(self), "Display Controller");
 	fu_device_add_icon(FU_DEVICE(self), "video-display");
 	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_MEDIATEK_SCALER_FW_SIZE_MAX);
+	fu_device_register_private_flag(FU_DEVICE(self), FWUPD_MEDIATEK_SCALER_FLAG_BANK2_ONLY);
 }
 
 static void
@@ -860,7 +920,6 @@ fu_mediatek_scaler_device_class_init(FuMediatekScalerDeviceClass *klass)
 	device_class->close = fu_mediatek_scaler_device_close;
 	device_class->prepare_firmware = fu_mediatek_scaler_device_prepare_firmware;
 	device_class->write_firmware = fu_mediatek_scaler_device_write_firmware;
-	device_class->attach = fu_mediatek_scaler_device_attach;
 	device_class->reload = fu_mediatek_scaler_device_setup;
 	device_class->set_progress = fu_mediatek_scaler_device_set_progress;
 }

--- a/plugins/mediatek-scaler/fu-mediatek-scaler.rs
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler.rs
@@ -46,3 +46,11 @@ enum FuDdcciPriority{
     Normal,
     Up,
 }
+
+#[repr(u8)]
+enum FuMediatekScalerIspStatus {
+    Busy = 0x00,
+    Failure,
+    Success,
+    Idle = 0x99,
+}

--- a/plugins/mediatek-scaler/mediatek-scaler.quirk
+++ b/plugins/mediatek-scaler/mediatek-scaler.quirk
@@ -1,4 +1,6 @@
 [DRM\VEN_DEL&DEV_4340]
 Plugin = mediatek_scaler
+Flags = bank2-only
+
 [DRM\VEN_DEL&DEV_7430]
 Plugin = mediatek_scaler


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Starting from scaler chip 7430, the firmware will go bank 1 in addition to bank 2. The chip will do a self-reboot and update bank 1 internally.