### PR TITLE
Store the udev properties in a hash table

### DIFF
--- a/libfwupdplugin/fu-udev-device-private.h
+++ b/libfwupdplugin/fu-udev-device-private.h
@@ -18,6 +18,8 @@ void
 fu_udev_device_set_number(FuUdevDevice *self, guint64 number) G_GNUC_NON_NULL(1);
 void
 fu_udev_device_set_subsystem(FuUdevDevice *self, const gchar *subsystem) G_GNUC_NON_NULL(1);
+void
+fu_udev_device_add_property(FuUdevDevice *self, const gchar *key, const gchar *value);
 gboolean
 fu_udev_device_parse_number(FuUdevDevice *self, GError **error) G_GNUC_NON_NULL(1);
 gboolean


### PR DESCRIPTION
This is better than splitting the `key=value` for each call to `fu_udev_device_read_property()` and also allows us to pre-seed properties when listening on the netlink socket.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
