### PR TITLE
trivial: Add the backends to the FuContext

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -198,7 +198,7 @@ class Checker:
             "g_assert(": "Use g_set_error() or g_return_val_if_fail() instead",
             "g_udev_device_get_sysfs_attr(": "Use fu_udev_device_read_sysfs() instead",
             "g_udev_device_get_property(": "Use fu_udev_device_read_property() instead",
-            "g_udev_client_new(": "Use fu_device_get_backend_parent_with_subsystem() instead",
+            "g_udev_client_new(": "Use fu_backend_create_device() instead",
             "HIDIOCSFEATURE": "Use fu_hidraw_device_set_feature() instead",
             "HIDIOCGFEATURE": "Use fu_hidraw_device_get_feature() instead",
             "|= 1 <<": "Use FU_BIT_SET() instead",

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -186,6 +186,37 @@ fu_backend_get_device_parent(FuBackend *self,
 }
 
 /**
+ * fu_backend_create_device:
+ * @self: a #FuBackend
+ * @backend_id: a backend ID, typically a sysfs path
+ * @error: (nullable): optional return location for an error
+ *
+ * Asks the backend to create a device (of the correct type) for a given device backend ID.
+ *
+ * Returns: (transfer full): a #FuDevice or %NULL if not found or unimplemented
+ *
+ * Since: 2.0.0
+ **/
+FuDevice *
+fu_backend_create_device(FuBackend *self, const gchar *backend_id, GError **error)
+{
+	FuBackendClass *klass = FU_BACKEND_GET_CLASS(self);
+
+	g_return_val_if_fail(FU_IS_BACKEND(self), NULL);
+	g_return_val_if_fail(backend_id != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	if (klass->create_device == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "not implemented");
+		return NULL;
+	}
+	return klass->create_device(self, backend_id, error);
+}
+
+/**
  * fu_backend_invalidate:
  * @self: a #FuBackend
  *

--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -642,6 +642,7 @@ fu_backend_dispose(GObject *object)
 	FuBackend *self = FU_BACKEND(object);
 	FuBackendPrivate *priv = GET_PRIVATE(self);
 	g_hash_table_remove_all(priv->devices);
+	g_clear_object(&priv->ctx);
 	G_OBJECT_CLASS(fu_backend_parent_class)->dispose(object);
 }
 
@@ -650,8 +651,6 @@ fu_backend_finalize(GObject *object)
 {
 	FuBackend *self = FU_BACKEND(object);
 	FuBackendPrivate *priv = GET_PRIVATE(self);
-	if (priv->ctx != NULL)
-		g_object_unref(priv->ctx);
 	g_free(priv->name);
 	g_hash_table_unref(priv->devices);
 	G_OBJECT_CLASS(fu_backend_parent_class)->finalize(object);

--- a/libfwupdplugin/fu-backend.h
+++ b/libfwupdplugin/fu-backend.h
@@ -50,6 +50,9 @@ struct _FuBackendClass {
 				       FuDevice *device,
 				       const gchar *subsystem,
 				       GError **error)G_GNUC_WARN_UNUSED_RESULT;
+	FuDevice *(*create_device)(FuBackend *self,
+				   const gchar *backend_id,
+				   GError **error)G_GNUC_WARN_UNUSED_RESULT;
 };
 
 const gchar *
@@ -86,4 +89,7 @@ FuDevice *
 fu_backend_get_device_parent(FuBackend *self,
 			     FuDevice *device,
 			     const gchar *subsystem,
-			     GError **error);
+			     GError **error) G_GNUC_NON_NULL(1, 2);
+FuDevice *
+fu_backend_create_device(FuBackend *self, const gchar *backend_id, GError **error)
+    G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-context-helper.h
+++ b/libfwupdplugin/fu-context-helper.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-backend.h"
+#include "fu-context.h"
+
+/* this header exists to prevent an #include loop between fu-context.h and fu-backend.h */
+
+void
+fu_context_add_backend(FuContext *self, FuBackend *backend) G_GNUC_NON_NULL(1, 2);
+FuBackend *
+fu_context_get_backend_by_name(FuContext *self, const gchar *name, GError **error)
+    G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -53,6 +53,8 @@ fu_context_add_udev_subsystem(FuContext *self, const gchar *subsystem, const gch
 GPtrArray *
 fu_context_get_udev_subsystems(FuContext *self) G_GNUC_NON_NULL(1);
 GPtrArray *
+fu_context_get_backends(FuContext *self) G_GNUC_NON_NULL(1);
+GPtrArray *
 fu_context_get_plugin_names_for_udev_subsystem(FuContext *self,
 					       const gchar *subsystem,
 					       GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -6714,11 +6714,22 @@ fu_device_clear_events(FuDevice *self)
 }
 
 static void
+fu_device_dispose(GObject *object)
+{
+	FuDevice *self = FU_DEVICE(object);
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	g_clear_object(&priv->ctx);
+	G_OBJECT_CLASS(fu_device_parent_class)->dispose(object);
+}
+
+static void
 fu_device_class_init(FuDeviceClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	GParamSpec *pspec;
+
+	object_class->dispose = fu_device_dispose;
 	object_class->finalize = fu_device_finalize;
 	object_class->get_property = fu_device_get_property;
 	object_class->set_property = fu_device_set_property;
@@ -6986,8 +6997,6 @@ fu_device_finalize(GObject *object)
 	}
 	if (priv->backend != NULL)
 		g_object_remove_weak_pointer(G_OBJECT(priv->backend), (gpointer *)&priv->backend);
-	if (priv->ctx != NULL)
-		g_object_unref(priv->ctx);
 	if (priv->poll_id != 0)
 		g_source_remove(priv->poll_id);
 	if (priv->metadata != NULL)

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -2884,6 +2884,7 @@ fu_plugin_dispose(GObject *object)
 		g_ptr_array_set_size(priv->devices, 0);
 	if (priv->cache != NULL)
 		g_hash_table_remove_all(priv->cache);
+	g_clear_object(&priv->ctx);
 
 	G_OBJECT_CLASS(fu_plugin_parent_class)->dispose(object);
 }
@@ -3032,8 +3033,6 @@ fu_plugin_finalize(GObject *object)
 	}
 	if (priv->devices != NULL)
 		g_ptr_array_unref(priv->devices);
-	if (priv->ctx != NULL)
-		g_object_unref(priv->ctx);
 	if (priv->runtime_versions != NULL)
 		g_hash_table_unref(priv->runtime_versions);
 	if (priv->compile_versions != NULL)

--- a/libfwupdplugin/fu-security-attr.c
+++ b/libfwupdplugin/fu-security-attr.c
@@ -74,20 +74,19 @@ fu_security_attr_init(FuSecurityAttr *self)
 }
 
 static void
-fu_security_attr_finalize(GObject *object)
+fu_security_attr_dispose(GObject *object)
 {
 	FuSecurityAttr *self = FU_SECURITY_ATTR(object);
 	FuSecurityAttrPrivate *priv = GET_PRIVATE(self);
-	if (priv->ctx != NULL)
-		g_object_unref(priv->ctx);
-	G_OBJECT_CLASS(fu_security_attr_parent_class)->finalize(object);
+	g_clear_object(&priv->ctx);
+	G_OBJECT_CLASS(fu_security_attr_parent_class)->dispose(object);
 }
 
 static void
 fu_security_attr_class_init(FuSecurityAttrClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->finalize = fu_security_attr_finalize;
+	object_class->dispose = fu_security_attr_dispose;
 }
 
 /**

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -15,6 +15,7 @@
 
 #include "fwupd-security-attr-private.h"
 
+#include "fu-backend-private.h"
 #include "fu-bios-settings-private.h"
 #include "fu-common-private.h"
 #include "fu-config-private.h"
@@ -680,6 +681,20 @@ fu_smbios3_func(void)
 	str = fu_smbios_get_string(smbios, FU_SMBIOS_STRUCTURE_TYPE_BIOS, 0x04, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(str, ==, "Dell Inc.");
+}
+
+static void
+fu_context_backends_func(void)
+{
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuBackend) backend2 = NULL;
+	g_autoptr(FuBackend) backend = g_object_new(FU_TYPE_BACKEND, "name", "dummy", NULL);
+	g_autoptr(GError) error = NULL;
+
+	fu_context_add_backend(ctx, backend);
+	backend2 = fu_context_get_backend_by_name(ctx, "dummy", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(backend2);
 }
 
 static void
@@ -5951,6 +5966,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/efivar{bootxxxx}", fu_efivar_boot_func);
 	g_test_add_func("/fwupd/hwids", fu_hwids_func);
 	g_test_add_func("/fwupd/context{flags}", fu_context_flags_func);
+	g_test_add_func("/fwupd/context{backends}", fu_context_backends_func);
 	g_test_add_func("/fwupd/context{hwids-dmi}", fu_context_hwids_dmi_func);
 	g_test_add_func("/fwupd/context{firmware-gtypes}", fu_context_firmware_gtypes_func);
 	g_test_add_func("/fwupd/context{state}", fu_context_state_func);

--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -29,6 +29,7 @@
 #include <libfwupdplugin/fu-common.h>
 #include <libfwupdplugin/fu-composite-input-stream.h>
 #include <libfwupdplugin/fu-config.h>
+#include <libfwupdplugin/fu-context-helper.h>
 #include <libfwupdplugin/fu-context.h>
 #include <libfwupdplugin/fu-crc.h>
 #include <libfwupdplugin/fu-csv-entry.h>

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -9,6 +9,7 @@
 #include "fu-redfish-network.h"
 
 typedef struct {
+	FuContext *ctx;
 	FuRedfishNetworkDevice *device;
 	const gchar *mac_addr;
 	guint16 vid;
@@ -54,47 +55,29 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 
 	/* compare VID:PID */
 	if (helper->vid != 0x0 && helper->pid != 0x0) {
-#ifdef HAVE_GUDEV
-		const gchar *sysfs_path = NULL;
-		const gchar *tmp;
-		guint64 pid = 0;
-		guint64 vid = 0;
+		g_autoptr(FuBackend) udev_backend = NULL;
+		g_autoptr(FuUdevDevice) udev_device = NULL;
 		g_autoptr(GVariant) udi = NULL;
-		g_autoptr(GUdevClient) udev_client = NULL;
-		g_autoptr(GUdevDevice) udev_device = NULL;
+		guint16 pid = 0;
+		guint16 vid = 0;
 
 		udi = g_dbus_proxy_get_cached_property(proxy, "Udi");
 		if (udi == NULL)
 			return TRUE;
-		sysfs_path = g_variant_get_string(udi, NULL);
-
-		/* get the VID and PID */
-		udev_client = g_udev_client_new(NULL); /* nocheck:blocked */
-		udev_device = g_udev_client_query_by_sysfs_path(udev_client, sysfs_path);
+		udev_backend = fu_context_get_backend_by_name(helper->ctx, "udev", error);
+		if (udev_backend == NULL)
+			return FALSE;
+		udev_device = FU_UDEV_DEVICE(
+		    fu_backend_create_device(udev_backend, g_variant_get_string(udi, NULL), error));
 		if (udev_device == NULL)
-			return TRUE;
-		tmp = g_udev_device_get_property(udev_device, "ID_VENDOR_ID"); /* nocheck:blocked */
-		if (tmp != NULL) {
-			if (!fu_strtoull(tmp, &vid, 0, G_MAXUINT16, FU_INTEGER_BASE_16, error))
-				return FALSE;
-		}
-		tmp = g_udev_device_get_property(udev_device, "ID_MODEL_ID"); /* nocheck:blocked */
-		if (tmp != NULL) {
-			if (!fu_strtoull(tmp, &pid, 0, G_MAXUINT16, FU_INTEGER_BASE_16, error))
-				return FALSE;
-		}
+			return FALSE;
 
 		/* verify */
-		g_debug("%s: 0x%04x, 0x%04x", sysfs_path, (guint)vid, (guint)pid);
+		vid = fu_udev_device_get_vendor(udev_device);
+		pid = fu_udev_device_get_model(udev_device);
+		g_debug("%s: 0x%04x, 0x%04x", g_variant_get_string(udi, NULL), vid, pid);
 		if (vid == helper->vid && pid == helper->pid)
 			helper->device = fu_redfish_network_device_new(object_path);
-#else
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "no UDev support");
-		return FALSE;
-#endif
 	}
 
 	/* assume success */
@@ -178,9 +161,10 @@ fu_redfish_network_device_match(FuRedfishNetworkMatchHelper *helper, GError **er
 }
 
 FuRedfishNetworkDevice *
-fu_redfish_network_device_for_mac_addr(const gchar *mac_addr, GError **error)
+fu_redfish_network_device_for_mac_addr(FuContext *ctx, const gchar *mac_addr, GError **error)
 {
 	FuRedfishNetworkMatchHelper helper = {
+	    .ctx = ctx,
 	    .mac_addr = mac_addr,
 	};
 	if (!fu_redfish_network_device_match(&helper, error)) {
@@ -191,9 +175,10 @@ fu_redfish_network_device_for_mac_addr(const gchar *mac_addr, GError **error)
 }
 
 FuRedfishNetworkDevice *
-fu_redfish_network_device_for_vid_pid(guint16 vid, guint16 pid, GError **error)
+fu_redfish_network_device_for_vid_pid(FuContext *ctx, guint16 vid, guint16 pid, GError **error)
 {
 	FuRedfishNetworkMatchHelper helper = {
+	    .ctx = ctx,
 	    .vid = vid,
 	    .pid = pid,
 	};

--- a/plugins/redfish/fu-redfish-network.h
+++ b/plugins/redfish/fu-redfish-network.h
@@ -17,6 +17,8 @@
 #define NETWORK_MANAGER_PATH		     "/org/freedesktop/NetworkManager"
 
 FuRedfishNetworkDevice *
-fu_redfish_network_device_for_mac_addr(const gchar *mac_addr, GError **error);
+fu_redfish_network_device_for_mac_addr(FuContext *ctx, const gchar *mac_addr, GError **error)
+    G_GNUC_NON_NULL(1, 2);
 FuRedfishNetworkDevice *
-fu_redfish_network_device_for_vid_pid(guint16 vid, guint16 pid, GError **error);
+fu_redfish_network_device_for_vid_pid(FuContext *ctx, guint16 vid, guint16 pid, GError **error)
+    G_GNUC_NON_NULL(1);

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -248,6 +248,7 @@ fu_redfish_plugin_discover_smbios_table(FuPlugin *plugin, GError **error)
 static gboolean
 fu_redfish_plugin_autoconnect_network_device(FuRedfishPlugin *self, GError **error)
 {
+	FuContext *ctx = fu_plugin_get_context(FU_PLUGIN(self));
 	g_autofree gchar *hostname = NULL;
 	g_autoptr(FuRedfishNetworkDevice) device = NULL;
 
@@ -263,7 +264,8 @@ fu_redfish_plugin_autoconnect_network_device(FuRedfishPlugin *self, GError **err
 		const gchar *mac_addr = fu_redfish_smbios_get_mac_addr(self->smbios);
 		if (mac_addr != NULL) {
 			g_autoptr(GError) error_network = NULL;
-			device = fu_redfish_network_device_for_mac_addr(mac_addr, &error_network);
+			device =
+			    fu_redfish_network_device_for_mac_addr(ctx, mac_addr, &error_network);
 			if (device == NULL)
 				g_debug("failed to get device: %s", error_network->message);
 		}
@@ -273,7 +275,8 @@ fu_redfish_plugin_autoconnect_network_device(FuRedfishPlugin *self, GError **err
 		guint16 pid = fu_redfish_smbios_get_pid(self->smbios);
 		if (vid != 0x0 && pid != 0x0) {
 			g_autoptr(GError) error_network = NULL;
-			device = fu_redfish_network_device_for_vid_pid(vid, pid, &error_network);
+			device =
+			    fu_redfish_network_device_for_vid_pid(ctx, vid, pid, &error_network);
 			if (device == NULL)
 				g_debug("failed to get device: %s", error_network->message);
 		}

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -217,10 +217,11 @@ fu_test_redfish_network_mac_addr_func(void)
 	FuRedfishNetworkDeviceState state = FU_REDFISH_NETWORK_DEVICE_STATE_UNKNOWN;
 	gboolean ret;
 	g_autofree gchar *ip_addr = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuRedfishNetworkDevice) device = NULL;
 	g_autoptr(GError) error = NULL;
 
-	device = fu_redfish_network_device_for_mac_addr("00:13:F7:29:C2:D8", &error);
+	device = fu_redfish_network_device_for_mac_addr(ctx, "00:13:F7:29:C2:D8", &error);
 	if (device == NULL && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 		g_test_skip("no hardware");
 		return;
@@ -249,10 +250,11 @@ static void
 fu_test_redfish_network_vid_pid_func(void)
 {
 	g_autofree gchar *ip_addr = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuRedfishNetworkDevice) device = NULL;
 	g_autoptr(GError) error = NULL;
 
-	device = fu_redfish_network_device_for_vid_pid(0x0707, 0x0201, &error);
+	device = fu_redfish_network_device_for_vid_pid(ctx, 0x0707, 0x0201, &error);
 	if (device == NULL && g_error_matches(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 		g_test_skip("no hardware");
 		return;

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -540,6 +540,24 @@ fu_device_list_remove(FuDeviceList *self, FuDevice *device)
 	g_rw_lock_writer_unlock(&self->devices_mutex);
 }
 
+/**
+ * fu_device_list_remove_all:
+ * @self: a device list
+ *
+ * Removes all devices from the list.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_list_remove_all(FuDeviceList *self)
+{
+	g_return_if_fail(FU_IS_DEVICE_LIST(self));
+
+	g_rw_lock_writer_lock(&self->devices_mutex);
+	g_ptr_array_set_size(self->devices, 0);
+	g_rw_lock_writer_unlock(&self->devices_mutex);
+}
+
 static void
 fu_device_list_add_missing_guids(FuDevice *device_new, FuDevice *device_old)
 {

--- a/src/fu-device-list.h
+++ b/src/fu-device-list.h
@@ -17,6 +17,8 @@ void
 fu_device_list_add(FuDeviceList *self, FuDevice *device) G_GNUC_NON_NULL(1, 2);
 void
 fu_device_list_remove(FuDeviceList *self, FuDevice *device) G_GNUC_NON_NULL(1, 2);
+void
+fu_device_list_remove_all(FuDeviceList *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_device_list_get_all(FuDeviceList *self) G_GNUC_NON_NULL(1);
 GPtrArray *

--- a/src/fu-plugin-list.c
+++ b/src/fu-plugin-list.c
@@ -97,6 +97,27 @@ fu_plugin_list_add(FuPluginList *self, FuPlugin *plugin)
 }
 
 /**
+ * fu_plugin_list_remove_all:
+ * @self: a #FuPluginList
+ *
+ * Removed all the plugins from the list.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_plugin_list_remove_all(FuPluginList *self)
+{
+	g_return_if_fail(FU_IS_PLUGIN_LIST(self));
+
+	for (guint i = 0; i < self->plugins->len; i++) {
+		FuPlugin *plugin = g_ptr_array_index(self->plugins, i);
+		g_signal_handlers_disconnect_by_data(plugin, self);
+	}
+	g_ptr_array_set_size(self->plugins, 0);
+	g_hash_table_remove_all(self->plugins_hash);
+}
+
+/**
  * fu_plugin_list_find_by_name:
  * @self: a #FuPluginList
  * @name: a plugin name, e.g. `dfu`

--- a/src/fu-plugin-list.h
+++ b/src/fu-plugin-list.h
@@ -15,6 +15,8 @@ FuPluginList *
 fu_plugin_list_new(void);
 void
 fu_plugin_list_add(FuPluginList *self, FuPlugin *plugin) G_GNUC_NON_NULL(1, 2);
+void
+fu_plugin_list_remove_all(FuPluginList *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_plugin_list_get_all(FuPluginList *self) G_GNUC_NON_NULL(1);
 FuPlugin *

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -6338,12 +6338,6 @@ fu_test_engine_fake_usb(gconstpointer user_data)
 
 	/* load engine and check the device was found */
 	fu_engine_add_plugin_filter(engine, "colorhug");
-	fu_engine_add_plugin_filter(engine, "optionrom");     /* for pci */
-	fu_engine_add_plugin_filter(engine, "synaptics_rmi"); /* for serio */
-	fu_engine_add_plugin_filter(engine, "tpm");	      /* for tpm */
-	fu_engine_add_plugin_filter(engine, "intel_me");      /* for mei */
-	fu_engine_add_plugin_filter(engine, "nvme");	      /* for nvme */
-	fu_engine_add_plugin_filter(engine, "scsi");	      /* for scsi */
 	ret = fu_engine_load(engine,
 			     FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS |
 				 FU_ENGINE_LOAD_FLAG_NO_IDLE_SOURCES | FU_ENGINE_LOAD_FLAG_READONLY,

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -630,6 +630,13 @@ fu_udev_backend_get_device_parent(FuBackend *backend,
 	return NULL;
 }
 
+static FuDevice *
+fu_udev_backend_create_device_impl(FuBackend *backend, const gchar *backend_id, GError **error)
+{
+	FuUdevBackend *self = FU_UDEV_BACKEND(backend);
+	return FU_DEVICE(fu_udev_backend_create_device_from_path(self, backend_id, error));
+}
+
 static void
 fu_udev_backend_finalize(GObject *object)
 {
@@ -665,6 +672,7 @@ fu_udev_backend_class_init(FuUdevBackendClass *klass)
 	backend_class->coldplug = fu_udev_backend_coldplug;
 	backend_class->to_string = fu_udev_backend_to_string;
 	backend_class->get_device_parent = fu_udev_backend_get_device_parent;
+	backend_class->create_device = fu_udev_backend_create_device_impl;
 }
 
 FuBackend *


### PR DESCRIPTION
This allows plugins to get the backend object, which is needed when interfacing with daemons such as NetworkManager that say 'here's a sysfs path' and we need a FuDevice without using GUdevClient.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
