### PR TITLE
Recalculate the device supported flag when reparenting devices using ParentGuid

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5902,6 +5902,14 @@ fu_engine_adopt_children_device(FuEngine *self, FuDevice *device, FuDevice *devi
 }
 
 static void
+fu_engine_set_device_parent(FuEngine *self, FuDevice *device, FuDevice *parent)
+{
+	fu_device_set_parent(device, parent);
+	fu_engine_ensure_device_supported(self, device);
+	fu_engine_ensure_device_supported(self, parent);
+}
+
+static void
 fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 {
 	GPtrArray *guids;
@@ -5924,8 +5932,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 			if (fu_device_has_parent_physical_id(
 				device,
 				fu_device_get_physical_id(device_tmp))) {
-				fu_device_set_parent(device, device_tmp);
-				fu_engine_ensure_device_supported(self, device_tmp);
+				fu_engine_set_device_parent(self, device, device_tmp);
 				break;
 			}
 		}
@@ -5941,8 +5948,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 				continue;
 			if (fu_device_has_parent_backend_id(device,
 							    fu_device_get_backend_id(device_tmp))) {
-				fu_device_set_parent(device, device_tmp);
-				fu_engine_ensure_device_supported(self, device_tmp);
+				fu_engine_set_device_parent(self, device, device_tmp);
 				break;
 			}
 		}
@@ -5954,8 +5960,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 			for (guint i = 0; i < devices->len; i++) {
 				FuDevice *device_tmp = g_ptr_array_index(devices, i);
 				if (fu_device_has_guid(device_tmp, guid)) {
-					fu_device_set_parent(device, device_tmp);
-					fu_engine_ensure_device_supported(self, device_tmp);
+					fu_engine_set_device_parent(self, device, device_tmp);
 					break;
 				}
 			}
@@ -5974,7 +5979,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 		for (guint i = 0; i < parent_physical_ids->len; i++) {
 			const gchar *parent_physical_id = g_ptr_array_index(parent_physical_ids, i);
 			if (g_strcmp0(parent_physical_id, fu_device_get_physical_id(device)) == 0)
-				fu_device_set_parent(device_tmp, device);
+				fu_engine_set_device_parent(self, device_tmp, device);
 		}
 	}
 	for (guint j = 0; j < devices->len; j++) {
@@ -5988,7 +5993,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 		for (guint i = 0; i < parent_backend_ids->len; i++) {
 			const gchar *parent_backend_id = g_ptr_array_index(parent_backend_ids, i);
 			if (g_strcmp0(parent_backend_id, fu_device_get_backend_id(device)) == 0)
-				fu_device_set_parent(device_tmp, device);
+				fu_engine_set_device_parent(self, device_tmp, device);
 		}
 	}
 	guids = fu_device_get_guids(device);
@@ -5999,7 +6004,7 @@ fu_engine_adopt_children(FuEngine *self, FuDevice *device)
 			if (fu_device_get_parent(device_tmp) != NULL)
 				continue;
 			if (fu_device_has_parent_guid(device_tmp, guid))
-				fu_device_set_parent(device_tmp, device);
+				fu_engine_set_device_parent(self, device_tmp, device);
 		}
 	}
 }


### PR DESCRIPTION
Additionally, make sure we recalculate the parent and the child to fix hotplug of the Lenovo ThinkPad Thunderbolt Dock 4.

Fixes https://github.com/fwupd/firmware-lenovo/issues/468

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
