### PR TITLE
fix: set non-block fu-io-channel behavior by default for RDWR mode

### DIFF
--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -541,7 +541,7 @@ fu_io_channel_new_file(const gchar *filename, FuIoChannelOpenFlag open_flags, GE
 #endif
 	if (open_flags & FU_IO_CHANNEL_OPEN_FLAG_READ &&
 	    open_flags & FU_IO_CHANNEL_OPEN_FLAG_WRITE) {
-		flags = O_RDWR;
+		flags |= O_RDWR;
 	} else if (open_flags & FU_IO_CHANNEL_OPEN_FLAG_READ) {
 		flags |= O_RDONLY;
 	} else if (open_flags & FU_IO_CHANNEL_OPEN_FLAG_WRITE) {


### PR DESCRIPTION
If HAVE_POLL_H is defined the non-block behaviour should be used for all modes by default.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
