### PR TITLE
Remove children and parent when storing the old device in the device …

### DIFF
--- a/libfwupd/fwupd-device-private.h
+++ b/libfwupd/fwupd-device-private.h
@@ -14,5 +14,7 @@ G_BEGIN_DECLS
 
 void
 fwupd_device_incorporate(FwupdDevice *self, FwupdDevice *donor) G_GNUC_NON_NULL(1, 2);
+void
+fwupd_device_remove_children(FwupdDevice *self) G_GNUC_NON_NULL(1);
 
 G_END_DECLS

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -621,6 +621,31 @@ fwupd_device_remove_child(FwupdDevice *self, FwupdDevice *child)
 }
 
 /**
+ * fwupd_device_remove_children:
+ * @self: a #FwupdDevice
+ *
+ * Removes all child devices.
+ *
+ * NOTE: You should never call this function from user code, it is for daemon
+ * use only.
+ *
+ * Since: 2.0.0
+ **/
+void
+fwupd_device_remove_children(FwupdDevice *self)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE(self);
+
+	g_return_if_fail(FWUPD_IS_DEVICE(self));
+
+	for (guint i = 0; i < priv->children->len; i++) {
+		FwupdDevice *child = g_ptr_array_index(priv->children, i);
+		g_object_weak_unref(G_OBJECT(child), fwupd_device_child_finalized_cb, self);
+	}
+	g_ptr_array_set_size(priv->children, 0);
+}
+
+/**
  * fwupd_device_get_guids:
  * @self: a #FwupdDevice
  *

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -977,6 +977,7 @@ LIBFWUPD_2.0.0 {
     fwupd_codec_to_json_string;
     fwupd_codec_to_string;
     fwupd_codec_to_variant;
+    fwupd_device_remove_children;
     fwupd_error_convert;
     fwupd_install_flags_to_string;
     fwupd_remote_get_privacy_uri;

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -14,6 +14,8 @@
 
 #define fu_device_set_plugin(d, v) fwupd_device_set_plugin(FWUPD_DEVICE(d), v)
 
+void
+fu_device_remove_children(FuDevice *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_device_get_parent_guids(FuDevice *self) G_GNUC_NON_NULL(1);
 gboolean

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1325,6 +1325,32 @@ fu_device_remove_child(FuDevice *self, FuDevice *child)
 	g_signal_emit(self, signals[SIGNAL_CHILD_REMOVED], 0, child);
 }
 
+/**
+ * fu_device_remove_children:
+ * @self: a #FuDevice
+ *
+ * Removes all child devices.
+ *
+ * Since: 2.0.0
+ **/
+void
+fu_device_remove_children(FuDevice *self)
+{
+	GPtrArray *children;
+
+	g_return_if_fail(FU_IS_DEVICE(self));
+
+	/* proxy */
+	fwupd_device_remove_children(FWUPD_DEVICE(self));
+
+	/* signal to the plugin */
+	children = fu_device_get_children(self);
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *child = g_ptr_array_index(children, i);
+		g_signal_emit(self, signals[SIGNAL_CHILD_REMOVED], 0, child);
+	}
+}
+
 static void
 fu_device_ensure_parent_guids(FuDevice *self)
 {

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -594,6 +594,14 @@ fu_device_list_item_finalized_cb(gpointer data, GObject *where_the_object_was)
 	g_rw_lock_writer_unlock(&self->devices_mutex);
 }
 
+static void
+fu_device_list_item_set_device_old(FuDeviceItem *item, FuDevice *device)
+{
+	fu_device_set_parent(device, NULL);
+	fu_device_remove_children(device);
+	g_set_object(&item->device_old, device);
+}
+
 /* this should never be required, and yet here we are */
 static void
 fu_device_list_item_set_device(FuDeviceItem *item, FuDevice *device)
@@ -745,7 +753,7 @@ fu_device_list_replace(FuDeviceList *self, FuDeviceItem *item, FuDevice *device)
 	_fu_device_incorporate_update_state(item->device, device);
 
 	/* assign the new device */
-	g_set_object(&item->device_old, item->device);
+	fu_device_list_item_set_device_old(item, item->device);
 	fu_device_list_item_set_device(item, device);
 	fu_device_list_emit_device_changed(self, device);
 


### PR DESCRIPTION
…list

This prevents having references to old devices that are not connected anymore.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
