### PR TITLE
Add the vendor-id for FuHidrawDevice subclasses

### DIFF
--- a/libfwupdplugin/fu-hidraw-device.c
+++ b/libfwupdplugin/fu-hidraw-device.c
@@ -129,6 +129,9 @@ fu_hidraw_device_probe(FuDevice *device, GError **error)
 					 "VEN",
 					 "DEV",
 					 NULL);
+	fu_device_build_vendor_id_u16(device,
+				      "HIDRAW",
+				      fu_udev_device_get_vendor(FU_UDEV_DEVICE(self)));
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Tested with the "Nordic Semiconductor ASA Mouse nRF52 Desktop" board.

This was missed in f0e5444, mea culpa.

Fixes https://github.com/fwupd/fwupd/issues/7759

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
