### PR TITLE
trivial: amd-gpu: read 1 byte instead of 0 bytes

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -201,13 +201,18 @@ fu_amd_gpu_device_prepare_firmware(FuDevice *device,
 
 	fw_pn = fu_amd_gpu_atom_firmware_get_vbios_pn(csm);
 	if (g_strcmp0(fw_pn, self->vbios_pn) != 0) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "firmware for %s does not match %s",
-			    fw_pn,
-			    self->vbios_pn);
-		return NULL;
+		if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "firmware for %s does not match %s",
+				    fw_pn,
+				    self->vbios_pn);
+			return NULL;
+		}
+		g_warning("firmware for %s does not match %s but is being force installed anyway",
+			  fw_pn,
+			  self->vbios_pn);
 	}
 
 	return g_steal_pointer(&firmware);

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -250,6 +250,7 @@ fu_amd_gpu_device_write_firmware(FuDevice *device,
 	g_autofree gchar *psp_vbflash = NULL;
 	g_autoptr(FuIOChannel) image_io = NULL;
 	g_autoptr(GBytes) fw = NULL;
+	g_autoptr(GError) error_read = NULL;
 	const gchar *base;
 
 	base = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
@@ -272,8 +273,14 @@ fu_amd_gpu_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* trigger the update (this looks funny but amdgpu returns 0 bytes) */
-	if (!fu_io_channel_read_raw(image_io, NULL, 0, NULL, 100, FU_IO_CHANNEL_FLAG_NONE, NULL))
-		g_debug("triggered update");
+	if (!fu_io_channel_read_raw(image_io,
+				    NULL,
+				    1,
+				    NULL,
+				    100,
+				    FU_IO_CHANNEL_FLAG_NONE,
+				    &error_read))
+		g_debug("triggered update: %s", error_read->message);
 
 	/* poll for completion */
 	return fu_device_retry_full(device,


### PR DESCRIPTION
This should help with failures triggering the write process in the kernel.

Suggested-by: Richard Hughes <richard@hughsie.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
