### PR TITLE
Do not set a zero-length device name when matching the vendor name

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -2620,6 +2620,14 @@ fu_device_fixup_vendor_name(FuDevice *self)
 	if (name != NULL && vendor != NULL) {
 		g_autofree gchar *name_up = g_utf8_strup(name, -1);
 		g_autofree gchar *vendor_up = g_utf8_strup(vendor, -1);
+		if (g_strcmp0(name_up, vendor_up) == 0) {
+#ifndef SUPPORTED_BUILD
+			g_warning("name and vendor are the same for %s [%s]",
+				  fu_device_get_name(self),
+				  fu_device_get_id(self));
+#endif
+			return;
+		}
 		if (g_str_has_prefix(name_up, vendor_up)) {
 			gsize vendor_len = strlen(vendor);
 			g_autofree gchar *name1 = g_strdup(name + vendor_len);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -489,6 +489,15 @@ fu_device_name_func(void)
 	fu_device_set_name(device2, "Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz");
 	fu_device_set_vendor(device2, "Intel");
 	g_assert_cmpstr(fu_device_get_name(device2), ==, "Core™ i7-10850H CPU @ 2.70GHz");
+
+	/* name and vendor are the same */
+#ifndef SUPPORTED_BUILD
+	g_test_expect_message("FuDevice", G_LOG_LEVEL_WARNING, "name and vendor are the same*");
+#endif
+	fu_device_set_name(device2, "example");
+	fu_device_set_vendor(device2, "EXAMPLE");
+	g_assert_cmpstr(fu_device_get_name(device2), ==, "example");
+	g_assert_cmpstr(fu_device_get_vendor(device2), ==, "EXAMPLE");
 }
 
 static void


### PR DESCRIPTION
This happens when the device has the same name as the vendor -- which does not make for great UI and is probably a USB descriptor issue.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
