### PR TITLE
Listen to the netlink udev socket rather than using GUdevClient

### DIFF
--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -315,7 +315,6 @@ introspection_deps = [
   libxmlb,
   giounix,
   libusb,
-  gudev,
 ]
 
 pkgg_requires = [ 'gio-2.0',

--- a/meson.build
+++ b/meson.build
@@ -238,6 +238,9 @@ conf.set_quoted('LIBUSB_VERSION', libusb.version())
 if cc.has_header_symbol('libusb.h', 'libusb_set_option', dependencies: libusb)
   conf.set('HAVE_LIBUSB_SET_OPTION', '1')
 endif
+if cc.has_header_symbol('libusb.h', 'libusb_init_context', dependencies: libusb)
+  conf.set('HAVE_LIBUSB_INIT_CONTEXT', '1')
+endif
 if cc.has_header_symbol('libusb.h', 'libusb_get_parent', dependencies: libusb)
   conf.set('HAVE_LIBUSB_GET_PARENT', '1')
 endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -4,7 +4,6 @@ plugin_deps = [
   giounix,
   gnutls,
   gmodule,
-  gudev,
   libusb,
   libarchive,
   libjsonglib,

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -6,10 +6,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_GUDEV
-#include <gudev/gudev.h>
-#endif
-
 #include "fu-context-private.h"
 #include "fu-mtd-device.h"
 #include "fu-udev-device-private.h"
@@ -17,7 +13,6 @@
 static void
 fu_test_mtd_device_func(void)
 {
-#ifdef HAVE_GUDEV
 	gsize bufsz;
 	gboolean ret;
 	g_autoptr(FuContext) ctx = fu_context_new();
@@ -88,9 +83,6 @@ fu_test_mtd_device_func(void)
 	ret = fu_bytes_compare(fw, fw2, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-#else
-	g_test_skip("no GUdev support");
-#endif
 }
 
 int

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -6,10 +6,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_GUDEV
-#include <gudev/gudev.h>
-#endif
-
 #include "fu-redfish-network.h"
 
 typedef struct {

--- a/src/fu-engine.rs
+++ b/src/fu-engine.rs
@@ -46,3 +46,35 @@ enum FuClientFlag {
     None = 0,
     Active = 1 << 0,
 }
+
+#[derive(ParseBytes)]
+struct FuStructUdevMonitorNetlinkHeader {
+    prefix: [char; 8] == "libudev",
+    magic: u32be == 0xFEEDCAFE,
+    header_size: u32le,
+    properties_off: u32le,
+    properties_len: u32le,
+    filter_subsystem_hash: u32le,
+    filter_devtype_hash: u32le,
+    filter_tag_bloom_hi: u32le,
+    filter_tag_bloom_lo: u32le,
+}
+
+enum FuUdevMonitorNetlinkGroup {
+    None,
+    Kernel,
+    Udev,
+}
+
+#[derive(FromString)]
+enum FuUdevAction {
+    Unknown,
+    Add,
+    Remove,
+    Change,
+    Move,
+    Online,
+    Offline,
+    Bind,
+    Unbind,
+}

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -275,7 +275,15 @@ fu_usb_backend_setup(FuBackend *backend,
 	gint log_level = g_getenv("FWUPD_VERBOSE") != NULL ? 3 : 0;
 	gint rc;
 
+#ifdef HAVE_LIBUSB_INIT_CONTEXT
+	const struct libusb_init_option options[] = {{.option = LIBUSB_OPTION_NO_DEVICE_DISCOVERY,
+						      .value = {
+							  .ival = 1,
+						      }}};
+	rc = libusb_init_context(&self->ctx, options, G_N_ELEMENTS(options));
+#else
 	rc = libusb_init(&self->ctx);
+#endif
 	if (rc < 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,6 @@ engine_dep = [
   libxmlb,
   giounix,
   gmodule,
-  gudev,
   libusb,
   libjsonglib,
   polkit,
@@ -24,7 +23,6 @@ if get_option('passim').allowed()
 endif
 
 client_dep = [
-  gudev,
   libcurl,
   libjcat,
   libjsonglib,


### PR DESCRIPTION
This is way more efficient as we only need the sysfs path and do all the probing ourselves. It might even work on Android.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
