### PR TITLE
trivial: look for 'systemd' directory on ESPs

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -349,6 +349,7 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 	g_autofree gchar *source_app = NULL;
 	g_autofree gchar *source_shim = NULL;
 	g_autofree gchar *target_app = NULL;
+	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
 	g_autoptr(FuEfiDevicePathList) dp_buf = NULL;
 	g_autoptr(FuEfiLoadOption) loadopt = fu_efi_load_option_new();
 
@@ -365,7 +366,7 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, error))
 		return FALSE;
 	if (secureboot_enabled) {
-		shim_app = fu_uefi_get_esp_app_path("shim", error);
+		shim_app = fu_uefi_get_esp_app_path(esp_path, "shim", error);
 		if (shim_app == NULL)
 			return FALSE;
 
@@ -383,7 +384,7 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 		if (fu_uefi_esp_target_exists(esp, shim_app)) {
 			/* use a custom copy of shim for firmware updates */
 			if (flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_UNIQUE) {
-				shim_cpy = fu_uefi_get_esp_app_path("shimfwupd", error);
+				shim_cpy = fu_uefi_get_esp_app_path(esp_path, "shimfwupd", error);
 				if (shim_cpy == NULL)
 					return FALSE;
 				if (!fu_uefi_esp_target_verify(shim_app, esp, shim_cpy)) {
@@ -410,7 +411,7 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 	}
 
 	/* test if correct asset in place */
-	target_app = fu_uefi_get_esp_app_path("fwupd", error);
+	target_app = fu_uefi_get_esp_app_path(esp_path, "fwupd", error);
 	if (target_app == NULL)
 		return FALSE;
 	if (!fu_uefi_esp_target_verify(source_app, esp, target_app)) {

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -342,7 +342,7 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 
 	/* save to a predictable filename */
 	esp_path = fu_volume_get_mount_point(self->esp);
-	directory = fu_uefi_get_esp_path_for_os();
+	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", FU_EFIVARS_GUID_UX_CAPSULE);
 	capsule_path = g_build_filename(directory, "fw", basename, NULL);
 	fn = g_build_filename(esp_path, capsule_path, NULL);
@@ -992,7 +992,7 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 static gboolean
 fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 {
-	g_autofree gchar *esp_os_base = fu_uefi_get_esp_path_for_os();
+	g_autofree gchar *esp_os_base = NULL;
 	g_autofree gchar *esp_path = NULL;
 	g_autofree gchar *pattern = NULL;
 	g_autoptr(FuDeviceLocker) esp_locker = NULL;
@@ -1016,6 +1016,7 @@ fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 	files = fu_path_get_files(esp_path, error);
 	if (files == NULL)
 		return FALSE;
+	esp_os_base = fu_uefi_get_esp_path_for_os(esp_path);
 	pattern = g_build_filename(esp_path, esp_os_base, "fw", "fwupd*.cap", NULL);
 	for (guint i = 0; i < files->len; i++) {
 		const gchar *fn = g_ptr_array_index(files, i);

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -193,9 +193,19 @@ fu_uefi_get_esp_path_for_os(const gchar *esp_base)
 	const gchar *id_like = NULL;
 	g_autofree gchar *esp_path = NULL;
 	g_autofree gchar *full_path = NULL;
+	g_autofree gchar *systemd_path = NULL;
+	g_autofree gchar *full_systemd_path = NULL;
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GHashTable) os_release = fwupd_get_os_release(&error_local);
+	g_autoptr(GHashTable) os_release = NULL;
+
+	/* distro (or user) is using systemd-boot */
+	systemd_path = g_build_filename("EFI", "systemd", NULL);
+	full_systemd_path = g_build_filename(esp_base, systemd_path, NULL);
+	if (g_file_test(full_systemd_path, G_FILE_TEST_IS_DIR))
+		return g_steal_pointer(&systemd_path);
+
 	/* try to lookup /etc/os-release ID key */
+	os_release = fwupd_get_os_release(&error_local);
 	if (os_release != NULL) {
 		os_release_id = g_hash_table_lookup(os_release, "ID");
 	} else {

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -20,13 +20,13 @@
 #define EFI_OS_INDICATIONS_FILE_CAPSULE_DELIVERY_SUPPORTED 0x0000000000000004ULL
 
 gchar *
-fu_uefi_get_esp_app_path(const gchar *cmd, GError **error);
+fu_uefi_get_esp_app_path(const gchar *base, const gchar *cmd, GError **error);
 gchar *
 fu_uefi_get_built_app_path(FuEfivars *efivars, const gchar *binary, GError **error);
 gboolean
 fu_uefi_get_framebuffer_size(guint32 *width, guint32 *height, GError **error);
 gchar *
-fu_uefi_get_esp_path_for_os(void);
+fu_uefi_get_esp_path_for_os(const gchar *base);
 guint64
 fu_uefi_read_file_as_uint64(const gchar *path, const gchar *attr_name);
 gboolean

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -141,7 +141,7 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* save the blob to the ESP */
-	directory = fu_uefi_get_esp_path_for_os();
+	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", fw_class);
 	capsule_path = g_build_filename(directory, "fw", basename, NULL);
 	fn = g_build_filename(esp_path, capsule_path, NULL);
@@ -180,7 +180,7 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* test if correct asset in place */
-	target_app = fu_uefi_get_esp_app_path("fwupd", error);
+	target_app = fu_uefi_get_esp_app_path(esp_path, "fwupd", error);
 	if (target_app == NULL)
 		return FALSE;
 	if (!fu_uefi_esp_target_verify(source_app, esp, target_app)) {

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -82,7 +82,7 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* save the blob to the ESP */
-	directory = fu_uefi_get_esp_path_for_os();
+	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", fw_class);
 	capsule_path = g_build_filename(directory, "fw", basename, NULL);
 	fn = g_build_filename(esp_path, capsule_path, NULL);


### PR DESCRIPTION
When using systemd-boot, assets aren't stored in a distro lsb-release directory. Look for this first as a preference.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
