### PR TITLE
trivial: Add the default homebrew path when looking for usb.ids

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1037,6 +1037,8 @@ fu_usb_device_probe_internal(FuUsbDevice *self, GError **error)
 		}
 		priv->busnum = libusb_get_bus_number(priv->usb_device);
 		priv->devnum = libusb_get_device_address(priv->usb_device);
+		fu_udev_device_set_vendor(FU_UDEV_DEVICE(self), priv->desc.idVendor);
+		fu_udev_device_set_model(FU_UDEV_DEVICE(self), priv->desc.idProduct);
 	} else {
 		guint64 busnum = 0;
 		guint64 devnum = 0;

--- a/meson.build
+++ b/meson.build
@@ -298,6 +298,9 @@ if vendor_ids_dir == ''
     vendor_ids_dir = '/usr/share/misc'
   endif
   if not fs.is_file(join_paths(vendor_ids_dir, 'usb.ids'))
+    vendor_ids_dir = '/usr/local/var/homebrew/linked/usb.ids/share/misc'
+  endif
+  if not fs.is_file(join_paths(vendor_ids_dir, 'usb.ids'))
     error('could not auto-detect -Dvendor_ids_dir=')
   endif
 endif

--- a/plugins/dell-k2/fu-dell-k2-pd-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-pd-firmware.c
@@ -71,7 +71,6 @@ fu_dell_k2_pd_firmware_set_version(FuFirmware *firmware,
 	gsize streamsz = 0;
 	gsize version_offset = magic_offset + DOCK_PD_VERSION_OFFSET;
 	guint32 raw_version = 0;
-	g_autofree gchar *ver = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;

--- a/plugins/dell-k2/fu-dell-k2-plugin.c
+++ b/plugins/dell-k2/fu-dell-k2-plugin.c
@@ -141,7 +141,6 @@ fu_dell_k2_plugin_backend_device_added(FuPlugin *plugin,
 				       GError **error)
 {
 	guint16 vid, pid;
-	g_autofree const gchar *instance_id = NULL;
 
 	/* not interesting */
 	if (!FU_IS_USB_DEVICE(device))

--- a/plugins/hpi-cfu/fu-hpi-cfu-device.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-device.c
@@ -1404,8 +1404,6 @@ FuHpiCfuStateMachineFramework hpi_cfu_states[] = {
 static gboolean
 fu_hpi_cfu_device_setup(FuDevice *device, GError **error)
 {
-	g_autoptr(GError) error_local = NULL;
-	g_autofree gchar *version = NULL;
 	guint32 version_raw;
 	gint8 version_table_offset = 4;
 	gint8 component_id_offset = 5;
@@ -1484,7 +1482,6 @@ fu_hpi_cfu_device_write_firmware(FuDevice *device,
 	gsize payload_file_size = 0;
 	g_autoptr(FuFirmware) fw_offer = NULL;
 	g_autoptr(FuFirmware) fw_payload = NULL;
-	g_autoptr(GBytes) blob_offer = NULL;
 	g_autoptr(GBytes) blob_payload = NULL;
 
 	/* progress */


### PR DESCRIPTION
This means we can use build-fwupd in the venv like every other target.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
