### PR TITLE
amd-gpu: Only compare the first 10 characters of part number

### DIFF
--- a/plugins/amd-gpu/amd_gpu_test.py
+++ b/plugins/amd-gpu/amd_gpu_test.py
@@ -224,10 +224,10 @@ A: vendor=0x1022
             self.assertEqual(dev.get_version(), "022.012.000.027.000001")
             guids = dev.get_guids()
             self.assertEqual(len(guids), 1)
-            self.assertIn("6c23af4f-d6cd-5ffc-a502-0b85e472e7cb", guids)
+            self.assertIn("4a1501b7-b500-5255-9d9c-41d652a4d5bc", guids)
             instance_ids = dev.get_instance_ids()
             self.assertEqual(len(instance_ids), 1)
-            self.assertIn("AMD\\113-PHXGENERIC-001", instance_ids)
+            self.assertIn("AMD\\113-PHXGEN", instance_ids)
         self.assertGreater(count, 0)
 
 


### PR DESCRIPTION
Apparently the rest of the characters are not relevant for the purpose of making sure a firmware applies to a given part.

So shorten the GUID and only compare 10 characters from the rest.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
