### PR TITLE
trivial: copy raw version to bootloader device

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -700,18 +700,22 @@ fu_device_list_replace(FuDeviceList *self, FuDeviceItem *item, FuDevice *device)
 	/* copy over the version strings if not set */
 	if (fu_device_get_version(item->device) != NULL && fu_device_get_version(device) == NULL) {
 		const gchar *version = fu_device_get_version(item->device);
+		guint64 raw = fu_device_get_version_raw(item->device);
 		g_info("copying old version %s to new device", version);
 		fu_device_set_version_format(device, fu_device_get_version_format(item->device));
-		fu_device_set_version(device, version);
+		fu_device_set_version(device, version); /* nocheck:set-version */
+		fu_device_set_version_raw(device, raw);
 	}
 
 	/* always use the runtime version */
 	if (fu_device_has_private_flag(item->device, FU_DEVICE_PRIVATE_FLAG_USE_RUNTIME_VERSION) &&
 	    fu_device_has_flag(item->device, FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER)) {
 		const gchar *version = fu_device_get_version(item->device);
+		guint64 raw = fu_device_get_version_raw(item->device);
 		g_info("forcing runtime version %s to new device", version);
 		fu_device_set_version_format(device, fu_device_get_version_format(item->device));
-		fu_device_set_version(device, version);
+		fu_device_set_version(device, version); /* nocheck:set-version */
+		fu_device_set_version_raw(device, raw);
 	}
 
 	/* allow another plugin to handle the write too */


### PR DESCRIPTION
Plugins may look at the runtime version through the bootloader device
and need to have accurate values.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
