### PR TITLE
Unexport FwupdDevice:UpdateMessage

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -12,6 +12,7 @@
 * Convert `fwupd_client_emulation_load()` to take a readable file rather than taking bytes
 * Convert `fwupd_client_emulation_save()` to take a writable file rather than returning bytes
 * Drop use of FWUPD_DEVICE_FLAG_ONLY_OFFLINE
+* Drop use of `fwupd_device_get_update_message()` and `fwupd_device_get_update_image()`
 
 ## Migration from Version 1.x.x
 

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -64,8 +64,6 @@ typedef struct {
 	guint32 install_duration;
 	FwupdUpdateState update_state;
 	gchar *update_error;
-	gchar *update_message;
-	gchar *update_image;
 	FwupdStatus status;
 	guint percentage;
 	GPtrArray *releases;
@@ -83,9 +81,7 @@ enum {
 	PROP_PERCENTAGE,
 	PROP_PARENT,
 	PROP_UPDATE_STATE,
-	PROP_UPDATE_MESSAGE,
 	PROP_UPDATE_ERROR,
-	PROP_UPDATE_IMAGE,
 	PROP_BATTERY_LEVEL,
 	PROP_BATTERY_THRESHOLD,
 	PROP_PROBLEMS,
@@ -1934,10 +1930,6 @@ fwupd_device_incorporate(FwupdDevice *self, FwupdDevice *donor)
 	}
 	if (priv->update_error == NULL)
 		fwupd_device_set_update_error(self, priv_donor->update_error);
-	if (priv->update_message == NULL)
-		fwupd_device_set_update_message(self, priv_donor->update_message);
-	if (priv->update_image == NULL)
-		fwupd_device_set_update_image(self, priv_donor->update_image);
 	if (priv->version == NULL)
 		fwupd_device_set_version(self, priv_donor->version);
 	if (priv->version_lowest == NULL)
@@ -2193,18 +2185,6 @@ fwupd_device_add_variant(FwupdCodec *codec, GVariantBuilder *builder, FwupdCodec
 				      FWUPD_RESULT_KEY_UPDATE_ERROR,
 				      g_variant_new_string(priv->update_error));
 	}
-	if (priv->update_message != NULL) {
-		g_variant_builder_add(builder,
-				      "{sv}",
-				      FWUPD_RESULT_KEY_UPDATE_MESSAGE,
-				      g_variant_new_string(priv->update_message));
-	}
-	if (priv->update_image != NULL) {
-		g_variant_builder_add(builder,
-				      "{sv}",
-				      FWUPD_RESULT_KEY_UPDATE_IMAGE,
-				      g_variant_new_string(priv->update_image));
-	}
 	if (priv->update_state != FWUPD_UPDATE_STATE_UNKNOWN) {
 		g_variant_builder_add(builder,
 				      "{sv}",
@@ -2414,14 +2394,6 @@ fwupd_device_from_key_value(FwupdDevice *self, const gchar *key, GVariant *value
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_ERROR) == 0) {
 		fwupd_device_set_update_error(self, g_variant_get_string(value, NULL));
-		return;
-	}
-	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_MESSAGE) == 0) {
-		fwupd_device_set_update_message(self, g_variant_get_string(value, NULL));
-		return;
-	}
-	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_IMAGE) == 0) {
-		fwupd_device_set_update_image(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_STATE) == 0) {
@@ -2652,90 +2624,6 @@ fwupd_device_set_version_build_date(FwupdDevice *self, guint64 version_build_dat
 	FwupdDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FWUPD_IS_DEVICE(self));
 	priv->version_build_date = version_build_date;
-}
-
-/**
- * fwupd_device_get_update_message:
- * @self: a #FwupdDevice
- *
- * Gets the update message string.
- *
- * Returns: the update message string, or %NULL if unset
- *
- * Since: 1.2.4
- **/
-const gchar *
-fwupd_device_get_update_message(FwupdDevice *self)
-{
-	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FWUPD_IS_DEVICE(self), NULL);
-	return priv->update_message;
-}
-
-/**
- * fwupd_device_set_update_message:
- * @self: a #FwupdDevice
- * @update_message: (nullable): the update message string
- *
- * Sets the update message string.
- *
- * Since: 1.2.4
- **/
-void
-fwupd_device_set_update_message(FwupdDevice *self, const gchar *update_message)
-{
-	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FWUPD_IS_DEVICE(self));
-
-	/* not changed */
-	if (g_strcmp0(priv->update_message, update_message) == 0)
-		return;
-
-	g_free(priv->update_message);
-	priv->update_message = g_strdup(update_message);
-	g_object_notify(G_OBJECT(self), "update-message");
-}
-
-/**
- * fwupd_device_get_update_image:
- * @self: a #FwupdDevice
- *
- * Gets the update image URL.
- *
- * Returns: the update image URL, or %NULL if unset
- *
- * Since: 1.4.5
- **/
-const gchar *
-fwupd_device_get_update_image(FwupdDevice *self)
-{
-	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FWUPD_IS_DEVICE(self), NULL);
-	return priv->update_image;
-}
-
-/**
- * fwupd_device_set_update_image:
- * @self: a #FwupdDevice
- * @update_image: (nullable): the update image URL
- *
- * Sets the update image URL.
- *
- * Since: 1.4.5
- **/
-void
-fwupd_device_set_update_image(FwupdDevice *self, const gchar *update_image)
-{
-	FwupdDevicePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FWUPD_IS_DEVICE(self));
-
-	/* not changed */
-	if (g_strcmp0(priv->update_image, update_image) == 0)
-		return;
-
-	g_free(priv->update_image);
-	priv->update_image = g_strdup(update_image);
-	g_object_notify(G_OBJECT(self), "update-image");
 }
 
 /**
@@ -3098,8 +2986,6 @@ fwupd_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags f
 	if (priv->percentage > 0)
 		fwupd_codec_json_append_int(builder, FWUPD_RESULT_KEY_PERCENTAGE, priv->percentage);
 	fwupd_codec_json_append(builder, FWUPD_RESULT_KEY_UPDATE_ERROR, priv->update_error);
-	fwupd_codec_json_append(builder, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
-	fwupd_codec_json_append(builder, FWUPD_RESULT_KEY_UPDATE_IMAGE, priv->update_image);
 	if (priv->releases->len > 0)
 		fwupd_codec_array_to_json(priv->releases, "Releases", builder, flags);
 }
@@ -3307,20 +3193,6 @@ fwupd_device_from_json(FwupdCodec *codec, JsonNode *json_node, GError **error)
 							       FWUPD_RESULT_KEY_UPDATE_ERROR,
 							       NULL);
 		fwupd_device_set_update_error(self, tmp);
-	}
-	if (json_object_has_member(obj, FWUPD_RESULT_KEY_UPDATE_MESSAGE)) {
-		const gchar *tmp =
-		    json_object_get_string_member_with_default(obj,
-							       FWUPD_RESULT_KEY_UPDATE_MESSAGE,
-							       NULL);
-		fwupd_device_set_update_message(self, tmp);
-	}
-	if (json_object_has_member(obj, FWUPD_RESULT_KEY_UPDATE_IMAGE)) {
-		const gchar *tmp =
-		    json_object_get_string_member_with_default(obj,
-							       FWUPD_RESULT_KEY_UPDATE_IMAGE,
-							       NULL);
-		fwupd_device_set_update_image(self, tmp);
 	}
 	if (json_object_has_member(obj, FWUPD_RESULT_KEY_INSTANCE_IDS)) {
 		JsonArray *array = json_object_get_array_member(obj, FWUPD_RESULT_KEY_INSTANCE_IDS);
@@ -3570,8 +3442,6 @@ fwupd_device_add_string(FwupdCodec *codec, guint idt, GString *str)
 						FWUPD_RESULT_KEY_UPDATE_STATE,
 						priv->update_state);
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_UPDATE_ERROR, priv->update_error);
-	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_UPDATE_MESSAGE, priv->update_message);
-	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_UPDATE_IMAGE, priv->update_image);
 	for (guint i = 0; i < priv->releases->len; i++) {
 		FwupdRelease *release = g_ptr_array_index(priv->releases, i);
 		fwupd_codec_add_string(FWUPD_CODEC(release), idt, str);
@@ -3602,14 +3472,8 @@ fwupd_device_get_property(GObject *object, guint prop_id, GValue *value, GParamS
 	case PROP_REQUEST_FLAGS:
 		g_value_set_uint64(value, priv->request_flags);
 		break;
-	case PROP_UPDATE_MESSAGE:
-		g_value_set_string(value, priv->update_message);
-		break;
 	case PROP_UPDATE_ERROR:
 		g_value_set_string(value, priv->update_error);
-		break;
-	case PROP_UPDATE_IMAGE:
-		g_value_set_string(value, priv->update_image);
 		break;
 	case PROP_STATUS:
 		g_value_set_uint(value, priv->status);
@@ -3658,14 +3522,8 @@ fwupd_device_set_property(GObject *object, guint prop_id, const GValue *value, G
 	case PROP_REQUEST_FLAGS:
 		fwupd_device_set_request_flags(self, g_value_get_uint64(value));
 		break;
-	case PROP_UPDATE_MESSAGE:
-		fwupd_device_set_update_message(self, g_value_get_string(value));
-		break;
 	case PROP_UPDATE_ERROR:
 		fwupd_device_set_update_error(self, g_value_get_string(value));
-		break;
-	case PROP_UPDATE_IMAGE:
-		fwupd_device_set_update_image(self, g_value_get_string(value));
 		break;
 	case PROP_STATUS:
 		fwupd_device_set_status(self, g_value_get_uint(value));
@@ -3853,20 +3711,6 @@ fwupd_device_class_init(FwupdDeviceClass *klass)
 	g_object_class_install_property(object_class, PROP_UPDATE_STATE, pspec);
 
 	/**
-	 * FwupdDevice:update-message:
-	 *
-	 * The device update message.
-	 *
-	 * Since: 1.2.4
-	 */
-	pspec = g_param_spec_string("update-message",
-				    NULL,
-				    NULL,
-				    NULL,
-				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
-	g_object_class_install_property(object_class, PROP_UPDATE_MESSAGE, pspec);
-
-	/**
 	 * FwupdDevice:update-error:
 	 *
 	 * The device update error.
@@ -3879,20 +3723,6 @@ fwupd_device_class_init(FwupdDeviceClass *klass)
 				    NULL,
 				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
 	g_object_class_install_property(object_class, PROP_UPDATE_ERROR, pspec);
-
-	/**
-	 * FwupdDevice:update-image:
-	 *
-	 * The update image for the device.
-	 *
-	 * Since: 1.4.5
-	 */
-	pspec = g_param_spec_string("update-image",
-				    NULL,
-				    NULL,
-				    NULL,
-				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
-	g_object_class_install_property(object_class, PROP_UPDATE_IMAGE, pspec);
 
 	/**
 	 * FwupdDevice:battery-level:
@@ -3967,8 +3797,6 @@ fwupd_device_finalize(GObject *object)
 	g_free(priv->vendor);
 	g_free(priv->plugin);
 	g_free(priv->update_error);
-	g_free(priv->update_message);
-	g_free(priv->update_image);
 	g_free(priv->version);
 	g_free(priv->version_lowest);
 	g_free(priv->version_bootloader);

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -233,14 +233,6 @@ const gchar *
 fwupd_device_get_update_error(FwupdDevice *self) G_GNUC_NON_NULL(1);
 void
 fwupd_device_set_update_error(FwupdDevice *self, const gchar *update_error) G_GNUC_NON_NULL(1);
-const gchar *
-fwupd_device_get_update_message(FwupdDevice *self) G_GNUC_NON_NULL(1);
-void
-fwupd_device_set_update_message(FwupdDevice *self, const gchar *update_message) G_GNUC_NON_NULL(1);
-const gchar *
-fwupd_device_get_update_image(FwupdDevice *self) G_GNUC_NON_NULL(1);
-void
-fwupd_device_set_update_image(FwupdDevice *self, const gchar *update_image) G_GNUC_NON_NULL(1);
 FwupdStatus
 fwupd_device_get_status(FwupdDevice *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -263,8 +263,6 @@ LIBFWUPD_1.2.2 {
 LIBFWUPD_1.2.4 {
   global:
     fwupd_client_get_tainted;
-    fwupd_device_get_update_message;
-    fwupd_device_set_update_message;
     fwupd_release_get_details_url;
     fwupd_release_get_source_url;
     fwupd_release_get_update_message;
@@ -403,8 +401,6 @@ LIBFWUPD_1.4.5 {
     fwupd_client_set_user_agent_for_package;
     fwupd_client_update_metadata_bytes;
     fwupd_client_upload_bytes;
-    fwupd_device_get_update_image;
-    fwupd_device_set_update_image;
     fwupd_feature_flag_from_string;
     fwupd_feature_flag_to_string;
     fwupd_release_get_update_image;

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -228,6 +228,22 @@ typedef enum {
 	 * Since: 2.0.0
 	 **/
 	FU_DEVICE_INCORPORATE_FLAG_PID = 1ull << 13,
+	/**
+	 * FU_DEVICE_INCORPORATE_FLAG_UPDATE_MESSAGE:
+	 *
+	 * Set the update message.
+	 *
+	 * Since: 2.0.0
+	 **/
+	FU_DEVICE_INCORPORATE_FLAG_UPDATE_MESSAGE = 1ull << 14,
+	/**
+	 * FU_DEVICE_INCORPORATE_FLAG_UPDATE_IMAGE:
+	 *
+	 * Set the update image.
+	 *
+	 * Since: 2.0.0
+	 **/
+	FU_DEVICE_INCORPORATE_FLAG_UPDATE_IMAGE = 1ull << 15,
 	/*< private >*/
 	FU_DEVICE_INCORPORATE_FLAG_ALL = G_MAXUINT64,
 } FuDeviceIncorporateFlags;
@@ -287,8 +303,6 @@ fu_device_new(FuContext *ctx);
 #define fu_device_set_serial(d, v)	   fwupd_device_set_serial(FWUPD_DEVICE(d), v)
 #define fu_device_set_summary(d, v)	   fwupd_device_set_summary(FWUPD_DEVICE(d), v)
 #define fu_device_set_branch(d, v)	   fwupd_device_set_branch(FWUPD_DEVICE(d), v)
-#define fu_device_set_update_message(d, v) fwupd_device_set_update_message(FWUPD_DEVICE(d), v)
-#define fu_device_set_update_image(d, v)   fwupd_device_set_update_image(FWUPD_DEVICE(d), v)
 #define fu_device_set_update_error(d, v)   fwupd_device_set_update_error(FWUPD_DEVICE(d), v)
 #define fu_device_add_vendor_id(d, v)	   fwupd_device_add_vendor_id(FWUPD_DEVICE(d), v)
 #define fu_device_add_protocol(d, v)	   fwupd_device_add_protocol(FWUPD_DEVICE(d), v)
@@ -316,8 +330,6 @@ fu_device_new(FuContext *ctx);
 #define fu_device_get_plugin(d)		     fwupd_device_get_plugin(FWUPD_DEVICE(d))
 #define fu_device_get_update_error(d)	     fwupd_device_get_update_error(FWUPD_DEVICE(d))
 #define fu_device_get_update_state(d)	     fwupd_device_get_update_state(FWUPD_DEVICE(d))
-#define fu_device_get_update_message(d)	     fwupd_device_get_update_message(FWUPD_DEVICE(d))
-#define fu_device_get_update_image(d)	     fwupd_device_get_update_image(FWUPD_DEVICE(d))
 #define fu_device_get_vendor(d)		     fwupd_device_get_vendor(FWUPD_DEVICE(d))
 #define fu_device_get_version(d)	     fwupd_device_get_version(FWUPD_DEVICE(d))
 #define fu_device_get_version_lowest(d)	     fwupd_device_get_version_lowest(FWUPD_DEVICE(d))
@@ -905,6 +917,14 @@ guint
 fu_device_get_battery_threshold(FuDevice *self) G_GNUC_NON_NULL(1);
 void
 fu_device_set_battery_threshold(FuDevice *self, guint battery_threshold) G_GNUC_NON_NULL(1);
+const gchar *
+fu_device_get_update_message(FuDevice *self) G_GNUC_NON_NULL(1);
+void
+fu_device_set_update_message(FuDevice *self, const gchar *update_message) G_GNUC_NON_NULL(1);
+const gchar *
+fu_device_get_update_image(FuDevice *self) G_GNUC_NON_NULL(1);
+void
+fu_device_set_update_image(FuDevice *self, const gchar *update_image) G_GNUC_NON_NULL(1);
 
 gint64
 fu_device_get_created_usec(FuDevice *self) G_GNUC_NON_NULL(1);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5203,14 +5203,12 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 
 		/* add update message if exists but device doesn't already have one */
 		update_message = fwupd_release_get_update_message(FWUPD_RELEASE(release));
-		if (fwupd_device_get_update_message(FWUPD_DEVICE(device)) == NULL &&
-		    update_message != NULL) {
+		if (fu_device_get_update_message(device) == NULL && update_message != NULL) {
 			fu_device_set_update_message(device, update_message);
 		}
 		update_image = fwupd_release_get_update_image(FWUPD_RELEASE(release));
-		if (fwupd_device_get_update_image(FWUPD_DEVICE(device)) == NULL &&
-		    update_image != NULL) {
-			fwupd_device_set_update_image(FWUPD_DEVICE(device), update_image);
+		if (fu_device_get_update_image(device) == NULL && update_image != NULL) {
+			fu_device_set_update_image(device, update_image);
 		}
 		update_request_id = fu_release_get_update_request_id(release);
 		if (fu_device_get_update_request_id(device) == NULL && update_request_id != NULL) {

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1411,19 +1411,6 @@ fu_util_device_to_string(FwupdClient *client, FwupdDevice *dev, guint idt)
 					  _("Update State"),
 					  fu_util_update_state_to_string(state));
 
-		if (state == FWUPD_UPDATE_STATE_SUCCESS) {
-			tmp = fwupd_device_get_update_message(dev);
-			if (tmp != NULL) {
-				g_autofree gchar *color =
-				    fu_console_color_format(tmp, FU_CONSOLE_COLOR_BLUE);
-				fwupd_codec_string_append(
-				    str,
-				    idt + 1,
-				    /* TRANSLATORS: helpful messages from last update */
-				    _("Update Message"),
-				    color);
-			}
-		}
 	}
 
 	/* battery, but only if we're not about to show the same info as an inhibit */


### PR DESCRIPTION
We only need this in the daemon, and the client does not need to interact with this in any way.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
