### PR TITLE
vli: add Cable Matters

### DIFF
--- a/plugins/vli/meson.build
+++ b/plugins/vli/meson.build
@@ -3,6 +3,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginVliUsbhub"']
 
 plugin_quirks += files([
   'vli-bizlink.quirk',
+  'vli-cablematters.quirk',
   'vli-dell.quirk',
   'vli-fujitsu.quirk',
   'vli-goodway.quirk',

--- a/plugins/vli/vli-cablematters.quirk
+++ b/plugins/vli/vli-cablematters.quirk
@@ -1,0 +1,4 @@
+# Cable Matters
+[USB\VID_2BD5&PID_5240]
+Plugin = vli
+GType = FuVliPdDevice


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Why Howdy, 
It's us; inconspicuous, reoccurring, characters. On behalf of Cable Matters, we're adding support for their device. We also have some questions about using pre-commit hooks:
1. Is it intentional to have the developer `git add .pre-commit-config.yaml` in every PR?
2. Is there an official, unofficial guide for pushing branches and restoring files when using venv/hooks?

Thanks!

reference: [guide](https://fwupd.github.io/libfwupdplugin/building.html?q=pre-commit)