### PR TITLE
trivial: exclude non-card DRM devices

### DIFF
--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -218,6 +218,12 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 	g_autofree gchar *attr_connector_id = NULL;
 	g_autofree gchar *physical_id = g_path_get_basename(sysfs_path);
 
+	/* check if "card" is in the sysfs_path string */
+	if (g_strstr_len(sysfs_path, -1, "card") == NULL) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not a DRM card device");
+		return FALSE;
+	}
+
 	/* basic properties */
 	attr_enabled = fu_udev_device_read_sysfs(FU_UDEV_DEVICE(self),
 						 "enabled",


### PR DESCRIPTION
fwupd doesn't need to look at render nodes, and these also are not accessible for DRM resources when the screen is off.

Fixes: https://github.com/fwupd/fwupd/issues/7816

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
