### PR TITLE
trivial: make less noise on supported builds for BOS descriptors

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1013,8 +1013,12 @@ fu_usb_device_probe_bos_descriptors(FuUsbDevice *self, GError **error)
 		if (fu_usb_bos_descriptor_get_capability(bos) != 0x5)
 			continue;
 		if (!fu_usb_device_probe_bos_descriptor(self, bos, &error_loop)) {
+#ifdef SUPPORTED_BUILD
+			g_debug("failed to parse platform BOS descriptor: %s", error_loop->message);
+#else
 			g_warning("failed to parse platform BOS descriptor: %s",
 				  error_loop->message);
+#endif
 		}
 	}
 	return TRUE;


### PR DESCRIPTION
This message is most interesting to those who are debugging the BOS descriptors that they've added to their devices (IE developers working on unsupported builds).

Drop the messages about failure to parse to debug.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
