### PR TITLE
Allow specifying devices to emulate in the config file

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -107,6 +107,7 @@ fwupd_modify_config_opts=(
 	'BlockedFirmware'
 	'DisabledDevices'
 	'DisabledPlugins'
+	'EmulatedDevices'
 	'EspLocation'
 	'EnumerateAllDevices'
 	'HostBkc'
@@ -436,7 +437,7 @@ _fwupdmgr()
 				;;
 			ApprovedFirmware|BlockedFirmware)
 				;;
-			DisabledDevices)
+			DisabledDevices|EmulatedDevices)
 				_show_device_ids
 				;;
 			DisabledPlugins)

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -101,6 +101,7 @@ fwupd_modify_config_opts=(
 	'BlockedFirmware'
 	'DisabledDevices'
 	'DisabledPlugins'
+	'EmulatedDevices'
 	'EspLocation'
 	'EnumerateAllDevices'
 	'HostBkc'
@@ -369,7 +370,7 @@ _fwupdtool()
 				;;
 			ApprovedFirmware|BlockedFirmware)
 				;;
-			DisabledDevices)
+			DisabledDevices|EmulatedDevices)
 				_show_device_ids
 				;;
 			DisabledPlugins)

--- a/docs/device-emulation.md
+++ b/docs/device-emulation.md
@@ -70,6 +70,10 @@ For example:
     Waiting…                 [***************************************]
     Hughski ColorHug2: OK!
 
+For devices that cannot be hotplugged, the `fwupd.conf` config option `EmulatedDevices` option
+can be used, by specifying the device IDs of the device that should be monitored.
+When adding modifying `EmulatedDevices` the daemon must be restarted for it to take effect.
+
 ## Pcap file conversion
 
 Emulation can also be used during the development phase of the plugin if the hardware is not

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -46,6 +46,13 @@ The `[fwupd]` section can contain the following parameters:
 
   Allow blocking specific devices by their GUID, using semicolons as delimiter.
 
+**EmulatedDevices={{EmulatedDevices}}**
+
+  Allow adding specific devices by their device ID, using semicolons as delimiter.
+
+  This config option is useful to build emulations of "internal" devices which typically cannot be
+  hotplugged.
+
 **DisabledPlugins={{DisabledPlugins}}**
 
   Allow blocking specific plugins by name.

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -174,6 +174,7 @@ fu_config_migrate_keyfile(FuConfig *self)
 			  {"fwupd", "ArchiveSizeMax", "0"},
 			  {"fwupd", "BlockedFirmware", NULL},
 			  {"fwupd", "DisabledDevices", NULL},
+			  {"fwupd", "EmulatedDevices", NULL},
 			  {"fwupd", "EnumerateAllDevices", NULL},
 			  {"fwupd", "EspLocation", NULL},
 			  {"fwupd", "HostBkc", NULL},

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -15,6 +15,7 @@
 struct _FuEngineConfig {
 	FuConfig parent_instance;
 	GPtrArray *disabled_devices;  /* (element-type utf-8) */
+	GPtrArray *emulated_devices;  /* (element-type utf-8) */
 	GPtrArray *disabled_plugins;  /* (element-type utf-8) */
 	GPtrArray *approved_firmware; /* (element-type utf-8) */
 	GPtrArray *blocked_firmware;  /* (element-type utf-8) */
@@ -143,6 +144,14 @@ fu_engine_config_reload(FuEngineConfig *self)
 		}
 	}
 
+	/* get emulated devices */
+	g_ptr_array_set_size(self->emulated_devices, 0);
+	devices = fu_config_get_value_strv(FU_CONFIG(self), "fwupd", "EmulatedDevices");
+	if (devices != NULL) {
+		for (guint i = 0; devices[i] != NULL; i++)
+			g_ptr_array_add(self->emulated_devices, g_strdup(devices[i]));
+	}
+
 	/* get approved firmware */
 	g_ptr_array_set_size(self->approved_firmware, 0);
 	approved_firmware = fu_config_get_value_strv(FU_CONFIG(self), "fwupd", "ApprovedFirmware");
@@ -241,6 +250,13 @@ fu_engine_config_get_disabled_devices(FuEngineConfig *self)
 {
 	g_return_val_if_fail(FU_IS_ENGINE_CONFIG(self), NULL);
 	return self->disabled_devices;
+}
+
+GPtrArray *
+fu_engine_config_get_emulated_devices(FuEngineConfig *self)
+{
+	g_return_val_if_fail(FU_IS_ENGINE_CONFIG(self), NULL);
+	return self->emulated_devices;
 }
 
 GArray *
@@ -400,6 +416,7 @@ fu_engine_config_init(FuEngineConfig *self)
 	g_autofree gchar *archive_size_max_default = fu_engine_config_archive_size_max_default();
 	self->disabled_devices = g_ptr_array_new_with_free_func(g_free);
 	self->disabled_plugins = g_ptr_array_new_with_free_func(g_free);
+	self->emulated_devices = g_ptr_array_new_with_free_func(g_free);
 	self->approved_firmware = g_ptr_array_new_with_free_func(g_free);
 	self->blocked_firmware = g_ptr_array_new_with_free_func(g_free);
 	self->trusted_uids = g_array_new(FALSE, FALSE, sizeof(guint64));
@@ -414,6 +431,7 @@ fu_engine_config_init(FuEngineConfig *self)
 	fu_engine_config_set_default(self, "ArchiveSizeMax", archive_size_max_default);
 	fu_engine_config_set_default(self, "BlockedFirmware", NULL);
 	fu_engine_config_set_default(self, "DisabledDevices", NULL);
+	fu_engine_config_set_default(self, "EmulatedDevices", NULL);
 	fu_engine_config_set_default(self, "DisabledPlugins", "");
 	fu_engine_config_set_default(self, "EnumerateAllDevices", "false");
 	fu_engine_config_set_default(self, "EspLocation", NULL);
@@ -442,6 +460,7 @@ fu_engine_config_finalize(GObject *obj)
 
 	g_ptr_array_unref(self->disabled_devices);
 	g_ptr_array_unref(self->disabled_plugins);
+	g_ptr_array_unref(self->emulated_devices);
 	g_ptr_array_unref(self->approved_firmware);
 	g_ptr_array_unref(self->blocked_firmware);
 	g_ptr_array_unref(self->uri_schemes);

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -23,6 +23,8 @@ GPtrArray *
 fu_engine_config_get_disabled_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_engine_config_get_disabled_plugins(FuEngineConfig *self) G_GNUC_NON_NULL(1);
+GPtrArray *
+fu_engine_config_get_emulated_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GArray *
 fu_engine_config_get_trusted_uids(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GPtrArray *


### PR DESCRIPTION
This allows us to record the emulations of devices we can't hotplug, for instance NVMe drives.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
