### PR TITLE
Allow plugins to save emulation data directly

### DIFF
--- a/libfwupdplugin/fu-device-event-private.h
+++ b/libfwupdplugin/fu-device-event-private.h
@@ -13,31 +13,3 @@ fu_device_event_new(const gchar *id);
 
 const gchar *
 fu_device_event_get_id(FuDeviceEvent *self) G_GNUC_NON_NULL(1);
-
-void
-fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *value)
-    G_GNUC_NON_NULL(1, 2);
-const gchar *
-fu_device_event_get_str(FuDeviceEvent *self, const gchar *key, GError **error)
-    G_GNUC_NON_NULL(1, 2);
-void
-fu_device_event_set_i64(FuDeviceEvent *self, const gchar *key, gint64 value) G_GNUC_NON_NULL(1, 2);
-gint64
-fu_device_event_get_i64(FuDeviceEvent *self, const gchar *key, GError **error)
-    G_GNUC_NON_NULL(1, 2);
-void
-fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
-    G_GNUC_NON_NULL(1, 2, 3);
-void
-fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *buf, gsize bufsz)
-    G_GNUC_NON_NULL(1, 2);
-GBytes *
-fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
-    G_GNUC_NON_NULL(1, 2);
-gboolean
-fu_device_event_copy_data(FuDeviceEvent *self,
-			  const gchar *key,
-			  guint8 *buf,
-			  gsize bufsz,
-			  gsize *actual_length,
-			  GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -104,7 +104,7 @@ fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *valu
  * fu_device_event_set_i64:
  * @self: a #FuDeviceEvent
  * @key: (not nullable): a unique key, e.g. `Name`
- * @value: (nullable): a string
+ * @value: a string
  *
  * Sets an integer value on the string.
  *
@@ -222,7 +222,7 @@ fu_device_event_get_str(FuDeviceEvent *self, const gchar *key, GError **error)
  *
  * Gets an integer value from the event.
  *
- * Returns: (nullable): integer, or %G_MAXINT64 on error
+ * Returns: integer, or %G_MAXINT64 on error
  *
  * Since: 2.0.0
  **/

--- a/libfwupdplugin/fu-device-event.h
+++ b/libfwupdplugin/fu-device-event.h
@@ -14,3 +14,31 @@ G_DECLARE_DERIVABLE_TYPE(FuDeviceEvent, fu_device_event, FU, DEVICE_EVENT, GObje
 struct _FuDeviceEventClass {
 	GObjectClass parent_class;
 };
+
+void
+fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *value)
+    G_GNUC_NON_NULL(1, 2);
+const gchar *
+fu_device_event_get_str(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+void
+fu_device_event_set_i64(FuDeviceEvent *self, const gchar *key, gint64 value) G_GNUC_NON_NULL(1, 2);
+gint64
+fu_device_event_get_i64(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+void
+fu_device_event_set_bytes(FuDeviceEvent *self, const gchar *key, GBytes *value)
+    G_GNUC_NON_NULL(1, 2, 3);
+void
+fu_device_event_set_data(FuDeviceEvent *self, const gchar *key, const guint8 *buf, gsize bufsz)
+    G_GNUC_NON_NULL(1, 2);
+GBytes *
+fu_device_event_get_bytes(FuDeviceEvent *self, const gchar *key, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_device_event_copy_data(FuDeviceEvent *self,
+			  const gchar *key,
+			  guint8 *buf,
+			  gsize bufsz,
+			  gsize *actual_length,
+			  GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -9,7 +9,6 @@
 #include <xmlb.h>
 
 #include "fu-backend.h"
-#include "fu-device-event.h"
 #include "fu-device.h"
 
 #define fu_device_set_plugin(d, v) fwupd_device_set_plugin(FWUPD_DEVICE(d), v)
@@ -82,10 +81,6 @@ void
 fu_device_clear_events(FuDevice *self);
 GPtrArray *
 fu_device_get_events(FuDevice *self);
-FuDeviceEvent *
-fu_device_save_event(FuDevice *self, const gchar *id);
-FuDeviceEvent *
-fu_device_load_event(FuDevice *self, const gchar *id, GError **error);
 void
 fu_device_set_target(FuDevice *self, FuDevice *target);
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -9,6 +9,7 @@
 #include <fwupd.h>
 
 #include "fu-context.h"
+#include "fu-device-event.h"
 #include "fu-device-locker.h"
 #include "fu-firmware.h"
 #include "fu-progress.h"
@@ -1117,3 +1118,8 @@ void
 fu_device_build_vendor_id_u16(FuDevice *self, const gchar *prefix, guint16 value);
 FuDeviceLocker *
 fu_device_poll_locker_new(FuDevice *self, GError **error) G_GNUC_NON_NULL(1);
+
+FuDeviceEvent *
+fu_device_save_event(FuDevice *self, const gchar *id);
+FuDeviceEvent *
+fu_device_load_event(FuDevice *self, const gchar *id, GError **error);


### PR DESCRIPTION
In some plugins like nvme we have to record the structure contents, rather than just the byte array as a 2nd buffer is passed by pointer address.

Make some of the API non-private to make this possible.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
