### PR TITLE
trivial: Don't show plugin flags if they're unset

### DIFF
--- a/libfwupd/fwupd-plugin.c
+++ b/libfwupd/fwupd-plugin.c
@@ -267,7 +267,8 @@ fwupd_plugin_add_string(FwupdCodec *codec, guint idt, GString *str)
 	FwupdPlugin *self = FWUPD_PLUGIN(codec);
 	FwupdPluginPrivate *priv = GET_PRIVATE(self);
 	fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_NAME, priv->name);
-	fwupd_plugin_string_append_flags(str, idt, FWUPD_RESULT_KEY_FLAGS, priv->flags);
+	if (priv->flags != FWUPD_PLUGIN_FLAG_NONE)
+		fwupd_plugin_string_append_flags(str, idt, FWUPD_RESULT_KEY_FLAGS, priv->flags);
 }
 
 static void


### PR DESCRIPTION
This makes it easier to compare the output of 1_9_X and the main branch.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
