### PR TITLE
Remove gudev as a required dep

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -24,7 +24,6 @@ depends=(
   json-glib
   libarchive
   libcbor
-  libgudev
   libusb
   libjcat
   libmbim
@@ -93,7 +92,6 @@ package() {
     libarchive.so
     libcbor.so
     libcurl.so
-    libgudev-1.0.so
     libjson-glib-1.0.so
     libmm-glib.so
     libpassim.so

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -862,27 +862,6 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
-  <dependency id="libgudev-1.0-dev">
-    <distro id="centos">
-      <package variant="x86_64">libgudev1-devel</package>
-    </distro>
-    <distro id="fedora">
-      <package variant="x86_64">libgudev1-devel</package>
-      <package variant="aarch64">libgudev1-devel</package>
-    </distro>
-    <distro id="debian">
-      <control />
-      <package variant="x86_64" />
-      <package variant="s390x">libgudev-1.0-dev:s390x</package>
-      <package variant="i386" />
-      <package variant="aarch64" />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-      <package variant="aarch64" />
-    </distro>
-  </dependency>
   <dependency id="libusb-1.0-0-dev">
     <distro id="arch">
       <package variant="x86_64">libusb</package>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -56,7 +56,6 @@ Source0:   http://people.freedesktop.org/~hughsient/releases/%{name}-%{version}.
 BuildRequires: gettext
 BuildRequires: glib2-devel >= %{glib2_version}
 BuildRequires: libxmlb-devel >= %{libxmlb_version}
-BuildRequires: libgudev1-devel
 BuildRequires: libusb1-devel >= %{libusb_version}
 BuildRequires: libcurl-devel >= %{libcurl_version}
 BuildRequires: libjcat-devel >= %{libjcat_version}

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -143,7 +143,6 @@ parts:
       - libarchive-dev
       - libcbor-dev
       - libcairo-dev
-      - libgudev-1.0-dev
       - libglib2.0-dev
       - libgnutls28-dev
       - libgpgme11-dev
@@ -186,7 +185,6 @@ parts:
       - libjcat1
       - liblzma5
       - libusb-1.0-0
-      - libgudev-1.0-0
       - libgpgme11
       - libprotobuf-c1
       - libpolkit-gobject-1-0

--- a/meson.build
+++ b/meson.build
@@ -647,9 +647,6 @@ umockdev_integration_tests = get_option('umockdev_tests')                     \
                               .disable_auto_if(not run_sanitize_unsafe_tests) \
                               .disable_auto_if(dbusmock.returncode() != 0)
 umockdev = dependency('umockdev-1.0', required: get_option('umockdev_tests'))
-if umockdev.found()
-  gudev = dependency('gudev-1.0', version: '>= 232')
-endif
 
 if dbusmock.returncode() != 0 and get_option('umockdev_tests').allowed()
   warning('python dbusmock not found, umockdev tests will be disabled')

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -18,40 +18,4 @@ plugin_builtin_thunderbolt = static_library('fu_plugin_thunderbolt',
   dependencies: plugin_deps,
 )
 plugin_builtins += plugin_builtin_thunderbolt
-
-# we use functions from 2.52 in the tests
-if get_option('tests') and run_sanitize_unsafe_tests and umockdev.found() and gio.version().version_compare('>= 2.52')
-  env = environment()
-  env.set('G_TEST_SRCDIR', meson.current_source_dir())
-  env.set('G_TEST_BUILDDIR', meson.current_build_dir())
-  env.set('FWUPD_LOCALSTATEDIR', '/tmp/fwupd-self-test/var')
-  env.set('FWUPD_DATADIR_QUIRKS', meson.current_source_dir())
-  e = executable(
-    'thunderbolt-self-test',
-    sources: [
-      'fu-self-test.c',
-    ],
-    include_directories: plugin_incdirs,
-    dependencies: [
-      gudev,
-      plugin_deps,
-      umockdev,
-    ],
-    link_with: [
-      fwupd,
-      fwupdplugin,
-      plugin_builtin_thunderbolt,
-    ],
-    c_args: [
-      cargs,
-      '-DSRCDIR="' + meson.current_source_dir() + '"',
-    ],
-  )
-  if get_option('b_sanitize') == 'address'
-    env.prepend('LD_PRELOAD', 'libasan.so.5', 'libumockdev-preload.so.0', separator: ' ')
-  else
-    env.prepend('LD_PRELOAD', 'libumockdev-preload.so.0')
-  endif
-  test('thunderbolt-self-test', e, env: env, timeout: 120)
-endif
 endif


### PR DESCRIPTION
We're only using it in the thunderbolt tests, and we can redesign those to use emulation for 2.0.x.

It's a much clearer message dropping the dep completely.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
