### PR TITLE
meson: fix source version outside git

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ conf.set('MICRO_VERSION', fwupd_micro_version)
 conf.set_quoted('PACKAGE_VERSION', fwupd_version)
 
 # get source version, falling back to package version
+source_version = fwupd_version
 git = find_program('git', required: false)
 tag = false
 if git.found()
@@ -26,8 +27,8 @@ if git.found()
     source_version = fwupd_version
   endif
   tag = run_command([git, 'describe', '--exact-match'], check: false).returncode() == 0
-  conf.set_quoted('SOURCE_VERSION', source_version)
 endif
+conf.set_quoted('SOURCE_VERSION', source_version)
 
 # libtool versioning - this applies to libfwupd
 #


### PR DESCRIPTION
when git is not found the whole conf var is skipped, and that fails to compile

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
