### PR TITLE
trivial: Enable emulation support by default

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -102,7 +102,6 @@ fwupd_modify_config_sections=(
 
 fwupd_modify_config_opts=(
 	'ArchiveSizeMax'
-	'AllowEmulation'
 	'ApprovedFirmware'
 	'BlockedFirmware'
 	'DisabledDevices'
@@ -418,7 +417,7 @@ _fwupdmgr()
 			return 0
 		elif [[ "$args" = "4" ]]; then
 			case $prev in
-			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
+			EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
 				COMPREPLY=( $(compgen -W "True False" -- "$cur") )
 				;;
 			AnotherWriteRequired|NeedsActivation|NeedsReboot|RegistrationSupported|RequestSupported|WriteSupported)

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -96,7 +96,6 @@ fwupd_modify_config_sections=(
 
 fwupd_modify_config_opts=(
 	'ArchiveSizeMax'
-	'AllowEmulation'
 	'ApprovedFirmware'
 	'BlockedFirmware'
 	'DisabledDevices'
@@ -351,7 +350,7 @@ _fwupdtool()
 			return 0
 		elif [[ "$args" = "4" ]]; then
 			case $prev in
-			AllowEmulation|EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
+			EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
 				COMPREPLY=( $(compgen -W "True False" -- "$cur") )
 				;;
 			AnotherWriteRequired|NeedsActivation|NeedsReboot|RegistrationSupported|RequestSupported|WriteSupported)

--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -13,7 +13,6 @@ run_test()
 run_device_tests()
 {
 	if [ -n "$CI_NETWORK" ] && [ -d @devicetestdir@ ]; then
-		fwupdmgr modify-config AllowEmulation true -y
 		for f in `grep --files-with-matches -r emulation-url @devicetestdir@`; do
 		        echo "Emulating for $f"
 		        fwupdmgr device-emulate \

--- a/docs/device-emulation.md
+++ b/docs/device-emulation.md
@@ -38,7 +38,6 @@ pending database like we would do for a successful firmware update.
 To demo this, something like this could be done:
 
     # connect ColorHug2
-    fwupdmgr modify-config AllowEmulation true
     fwupdmgr emulation-tag b0a78eb71f4eeea7df8fb114522556ba8ce22074
     # or, using the GUID
     # fwupdmgr emulation-tag 2082b5e0-7a64-478a-b1b2-e3404fab6dad
@@ -51,7 +50,6 @@ To demo this, something like this could be done:
     fwupdmgr emulation-load colorhug.zip
     fwupdmgr get-devices --filter emulated
     fwupdmgr install e5* --allow-reinstall
-    fwupdmgr modify-config AllowEmulation false
 
 ## Device Tests
 
@@ -139,7 +137,5 @@ For example:
     contrib/pcap2emulation.py CalDigit.pcapng /tmp/caldigit 0451:ace1
     # this will generate /tmp/caldigit.zip
     # the new emulation file can be used for emulation
-    fwupdmgr modify-config AllowEmulation true
     fwupdmgr emulation-load /tmp/caldigit.zip
     fwupdmgr get-devices --filter emulated
-    fwupdmgr modify-config AllowEmulation false

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -119,11 +119,6 @@ The `[fwupd]` section can contain the following parameters:
 
   Show data such as device serial numbers which some users may consider private.
 
-**AllowEmulation={{AllowEmulation}}**
-
-  Allow capturing and loading device emulation by logging all USB transfers.
-  Enabling this will greatly increase the amount of memory fwupd uses when upgrading devices.
-
 **TrustedUids={{TrustedUids}}**
 
   UIDs matching these values that call the D-Bus interface should marked as trusted.

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -190,7 +190,6 @@ fu_config_migrate_keyfile(FuConfig *self)
 			  {"fwupd", "IgnorePower", NULL},
 			  {"fwupd", "DisabledPlugins", "test;test_ble;invalid"},
 			  {"fwupd", "DisabledPlugins", "test;test_ble"},
-			  {"fwupd", "AllowEmulation", NULL},
 			  {"redfish", "IpmiDisableCreateUser", NULL},
 			  {"redfish", "ManagerResetTimeout", NULL},
 			  {"msr", "MinimumSmeKernelVersion", NULL},

--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -240,4 +240,40 @@
       <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
+
+  <action id="org.freedesktop.fwupd.emulation-load">
+    <description>Load device emulation data</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to load hardware emulation data</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.freedesktop.fwupd.emulation-save">
+    <description>Save device emulation data</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to save hardware emulation data</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.emulation-load</annotate>
+  </action>
+
+  <action id="org.freedesktop.fwupd.emulation-tag">
+    <description>Enable emulation data collection</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to enable hardware emulation</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.emulation-load</annotate>
+  </action>
+
 </policyconfig>

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -277,6 +277,7 @@ typedef struct {
 	gchar *section;
 	gchar *key;
 	gchar *value;
+	gint32 handle;
 	FuCabinet *cabinet;
 	GHashTable *bios_settings; /* str:str */
 	gboolean is_fix;
@@ -1566,28 +1567,29 @@ fu_dbus_daemon_method_clear_results(FuDbusDaemon *self,
 }
 
 static void
-fu_dbus_daemon_method_emulation_load(FuDbusDaemon *self,
-				     GVariant *parameters,
-				     FuEngineRequest *request,
-				     GDBusMethodInvocation *invocation)
+fu_dbus_daemon_authorize_emulation_load_cb(GObject *source, GAsyncResult *res, gpointer user_data)
 {
-	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(self));
-	gint32 fd_handle = 0;
+	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GInputStream) stream = NULL;
+	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(helper->self));
 
-	g_variant_get(parameters, "(h)", &fd_handle);
+	/* get result */
+	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
+		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
+		return;
+	}
 
 	/* get stream */
-	stream = fu_dbus_daemon_invocation_get_input_stream(invocation, &error);
+	stream = fu_dbus_daemon_invocation_get_input_stream(helper->invocation, &error);
 	if (stream == NULL) {
-		fu_dbus_daemon_method_invocation_return_gerror(invocation, error);
+		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;
 	}
 
 	/* load data into engine */
 	if (!fu_engine_emulation_load(engine, stream, &error)) {
-		g_dbus_method_invocation_return_error(invocation,
+		g_dbus_method_invocation_return_error(helper->invocation,
 						      error->domain,
 						      error->code,
 						      "failed to load emulation data: %s",
@@ -1596,37 +1598,132 @@ fu_dbus_daemon_method_emulation_load(FuDbusDaemon *self,
 	}
 
 	/* success */
-	g_dbus_method_invocation_return_value(invocation, NULL);
+	g_dbus_method_invocation_return_value(helper->invocation, NULL);
 }
 
+static void
+fu_dbus_daemon_method_emulation_load(FuDbusDaemon *self,
+				     GVariant *parameters,
+				     FuEngineRequest *request,
+				     GDBusMethodInvocation *invocation)
+{
+	gint32 fd_handle = 0;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuMainAuthHelper) helper = NULL;
+
+	g_variant_get(parameters, "(h)", &fd_handle);
+
+	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	helper = g_new0(FuMainAuthHelper, 1);
+	helper->self = self;
+	helper->request = g_object_ref(request);
+	helper->invocation = g_object_ref(invocation);
+	helper->handle = fd_handle;
+	fu_polkit_authority_check(self->authority,
+				  fu_engine_request_get_sender(request),
+				  "org.freedesktop.fwupd.emulation-load",
+				  fu_dbus_daemon_engine_request_get_authority_check_flags(request),
+				  NULL,
+				  fu_dbus_daemon_authorize_emulation_load_cb,
+				  g_steal_pointer(&helper));
+}
+
+static void
+fu_dbus_daemon_authorize_emulation_save_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GOutputStream) stream = NULL;
+	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(helper->self));
+
+	/* get result */
+	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
+		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
+		return;
+	}
+
+	/* get stream */
+	stream = fu_dbus_daemon_invocation_get_output_stream(helper->invocation, &error);
+	if (stream == NULL) {
+		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
+		return;
+	}
+
+	/* save data from engine */
+	if (!fu_engine_emulation_save(engine, stream, &error)) {
+		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
+		return;
+	}
+
+	/* success */
+	g_dbus_method_invocation_return_value(helper->invocation, NULL);
+}
 static void
 fu_dbus_daemon_method_emulation_save(FuDbusDaemon *self,
 				     GVariant *parameters,
 				     FuEngineRequest *request,
 				     GDBusMethodInvocation *invocation)
 {
-	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(self));
 	gint32 fd_handle = 0;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(GOutputStream) stream = NULL;
+	g_autoptr(FuMainAuthHelper) helper = NULL;
 
 	g_variant_get(parameters, "(h)", &fd_handle);
 
-	/* get stream */
-	stream = fu_dbus_daemon_invocation_get_output_stream(invocation, &error);
-	if (stream == NULL) {
+	fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+	helper = g_new0(FuMainAuthHelper, 1);
+	helper->self = self;
+	helper->request = g_object_ref(request);
+	helper->invocation = g_object_ref(invocation);
+	helper->handle = fd_handle;
+	fu_polkit_authority_check(self->authority,
+				  fu_engine_request_get_sender(request),
+				  "org.freedesktop.fwupd.emulation-save",
+				  fu_dbus_daemon_engine_request_get_authority_check_flags(request),
+				  NULL,
+				  fu_dbus_daemon_authorize_emulation_save_cb,
+				  g_steal_pointer(&helper));
+}
+
+static void
+fu_dbus_daemon_authorize_modify_device_internal(FuEngine *engine,
+						const gchar *device_id,
+						const gchar *key,
+						const gchar *value,
+						GDBusMethodInvocation *invocation)
+{
+	g_autoptr(GError) error = NULL;
+
+	if (!fu_engine_modify_device(engine, device_id, key, value, &error)) {
 		fu_dbus_daemon_method_invocation_return_gerror(invocation, error);
 		return;
 	}
-
-	/* save data from engine */
-	if (!fu_engine_emulation_save(engine, stream, &error)) {
-		fu_dbus_daemon_method_invocation_return_gerror(invocation, error);
-		return;
-	}
-
-	/* success */
 	g_dbus_method_invocation_return_value(invocation, NULL);
+}
+
+static void
+fu_dbus_daemon_authorize_modify_device_cb(GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *)user_data;
+
+	fu_dbus_daemon_authorize_modify_device_internal(
+	    fu_daemon_get_engine(FU_DAEMON(helper->self)),
+	    helper->device_id,
+	    helper->key,
+	    helper->value,
+	    helper->invocation);
+}
+
+static gboolean
+fu_dbus_daemon_method_modify_device_flag_needs_auth(const gchar *key, const gchar *value)
+{
+	if (g_strcmp0(key, "Flags") != 0)
+		return FALSE;
+	if (g_strcmp0(value, "emulation-tag") == 0)
+		return TRUE;
+	if (g_strcmp0(value, "~emulation-tag") == 0)
+		return TRUE;
+	return FALSE;
 }
 
 static void
@@ -1635,19 +1732,35 @@ fu_dbus_daemon_method_modify_device(FuDbusDaemon *self,
 				    FuEngineRequest *request,
 				    GDBusMethodInvocation *invocation)
 {
-	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(self));
 	const gchar *device_id;
-	const gchar *key = NULL;
-	const gchar *value = NULL;
-	g_autoptr(GError) error = NULL;
+	const gchar *key;
+	const gchar *value;
 
-	/* check the id exists */
 	g_variant_get(parameters, "(&s&s&s)", &device_id, &key, &value);
-	if (!fu_engine_modify_device(engine, device_id, key, value, &error)) {
-		fu_dbus_daemon_method_invocation_return_gerror(invocation, error);
-		return;
-	}
-	g_dbus_method_invocation_return_value(invocation, NULL);
+	if (fu_dbus_daemon_method_modify_device_flag_needs_auth(key, value)) {
+		g_autoptr(FuMainAuthHelper) helper = g_new0(FuMainAuthHelper, 1);
+		helper->self = self;
+		helper->request = g_object_ref(request);
+		helper->invocation = g_object_ref(invocation);
+		helper->device_id = g_strdup(device_id);
+		helper->key = g_strdup(key);
+		helper->value = g_strdup(value);
+		fu_dbus_daemon_set_status(self, FWUPD_STATUS_WAITING_FOR_AUTH);
+		fu_polkit_authority_check(
+		    self->authority,
+		    fu_engine_request_get_sender(request),
+		    "org.freedesktop.fwupd.emulation-tag",
+		    fu_dbus_daemon_engine_request_get_authority_check_flags(request),
+		    NULL,
+		    fu_dbus_daemon_authorize_modify_device_cb,
+		    g_steal_pointer(&helper));
+	} else
+		fu_dbus_daemon_authorize_modify_device_internal(
+		    fu_daemon_get_engine(FU_DAEMON(self)),
+		    device_id,
+		    key,
+		    value,
+		    invocation);
 }
 
 static void

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -341,12 +341,6 @@ fu_engine_config_get_test_devices(FuEngineConfig *self)
 }
 
 gboolean
-fu_engine_config_get_allow_emulation(FuEngineConfig *self)
-{
-	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "AllowEmulation");
-}
-
-gboolean
 fu_engine_config_get_ignore_requirements(FuEngineConfig *self)
 {
 	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "IgnoreRequirements");
@@ -427,7 +421,6 @@ fu_engine_config_init(FuEngineConfig *self)
 	g_signal_connect(self, "changed", G_CALLBACK(fu_engine_config_changed_cb), NULL);
 
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
-	fu_engine_config_set_default(self, "AllowEmulation", "false");
 	fu_engine_config_set_default(self, "ApprovedFirmware", NULL);
 	fu_engine_config_set_default(self, "ArchiveSizeMax", archive_size_max_default);
 	fu_engine_config_set_default(self, "BlockedFirmware", NULL);

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -49,8 +49,6 @@ fu_engine_config_get_show_device_private(FuEngineConfig *self) G_GNUC_NON_NULL(1
 gboolean
 fu_engine_config_get_test_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
-fu_engine_config_get_allow_emulation(FuEngineConfig *self) G_GNUC_NON_NULL(1);
-gboolean
 fu_engine_config_get_ignore_requirements(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
 fu_engine_config_get_release_dedupe(FuEngineConfig *self) G_GNUC_NON_NULL(1);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -821,14 +821,29 @@ fu_engine_modify_config(FuEngine *self,
 	/* check keys are valid */
 	if (g_strcmp0(section, "fwupd") == 0) {
 		const gchar *keys[] = {
-		    "ArchiveSizeMax",  "AllowEmulation",      "ApprovedFirmware",
-		    "BlockedFirmware", "DisabledDevices",     "DisabledPlugins",
-		    "EmulatedDevices", "EnumerateAllDevices", "EspLocation",
-		    "HostBkc",	       "IdleTimeout",	      "IgnorePower",
-		    "OnlyTrusted",     "P2pPolicy",	      "ReleaseDedupe",
-		    "ReleasePriority", "ShowDevicePrivate",   "TestDevices",
-		    "TrustedReports",  "TrustedUids",	      "UpdateMotd",
-		    "UriSchemes",      "VerboseDomains",      NULL,
+		    "ArchiveSizeMax",
+		    "ApprovedFirmware",
+		    "BlockedFirmware",
+		    "DisabledDevices",
+		    "DisabledPlugins",
+		    "EmulatedDevices",
+		    "EnumerateAllDevices",
+		    "EspLocation",
+		    "HostBkc",
+		    "IdleTimeout",
+		    "IgnorePower",
+		    "OnlyTrusted",
+		    "P2pPolicy",
+		    "ReleaseDedupe",
+		    "ReleasePriority",
+		    "ShowDevicePrivate",
+		    "TestDevices",
+		    "TrustedReports",
+		    "TrustedUids",
+		    "UpdateMotd",
+		    "UriSchemes",
+		    "VerboseDomains",
+		    NULL,
 		};
 		if (!g_strv_contains(keys, key)) {
 			g_set_error(error,
@@ -992,8 +1007,7 @@ fu_engine_modify_bios_settings(FuEngine *self,
 static void
 fu_engine_ensure_context_flag_save_events(FuEngine *self)
 {
-	if (g_hash_table_size(self->emulation_ids) > 0 &&
-	    fu_engine_config_get_allow_emulation(self->config)) {
+	if (g_hash_table_size(self->emulation_ids) > 0) {
 		fu_context_add_flag(self->ctx, FU_CONTEXT_FLAG_SAVE_EVENTS);
 	} else {
 		fu_context_remove_flag(self->ctx, FU_CONTEXT_FLAG_SAVE_EVENTS);
@@ -2689,15 +2703,6 @@ fu_engine_emulation_load(FuEngine *self, GInputStream *stream, GError **error)
 	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	/* not supported */
-	if (!fu_engine_config_get_allow_emulation(self->config)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "emulation is not allowed from config");
-		return FALSE;
-	}
-
 	/* unload any existing devices */
 	if (!fu_engine_emulation_load_json_blob(self, json_blob, error))
 		return FALSE;
@@ -2751,15 +2756,6 @@ fu_engine_emulation_save(FuEngine *self, GOutputStream *stream, GError **error)
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	/* not supported */
-	if (!fu_engine_config_get_allow_emulation(self->config)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "emulation is not allowed from config");
-		return FALSE;
-	}
 
 	/* sanity check */
 	for (guint phase = FU_ENGINE_INSTALL_PHASE_SETUP; phase < FU_ENGINE_INSTALL_PHASE_LAST;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -6325,18 +6325,9 @@ fu_config_migrate_1_9_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	ret = fu_config_set_value(config, "fwupd", "AllowEmulation", "true", &error);
-	g_assert_no_error(error);
-	g_assert_true(ret);
-
-	/* ensure that all keys except AllowEmulation migrated */
-	ret = g_file_get_contents(fake_localconf_fn, &localconf_data, NULL, &error);
-	g_assert_no_error(error);
-	g_assert_true(ret);
-	g_assert_cmpstr(localconf_data,
-			==,
-			"[fwupd]\n"
-			"AllowEmulation=true\n");
+	/* ensure that all keys migrated */
+	ret = g_file_test(fake_localconf_fn, G_FILE_TEST_EXISTS);
+	g_assert_false(ret);
 }
 
 static void


### PR DESCRIPTION
There isn't any reason to keep the turned off, it just makes it more
difficult for users to record and load emulation data which would
mean that a graphical client that wants to onboard an emulation flow
would have a harder time.

Enable it by default instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
