### PR TITLE
plugins: snapd integration for UEFI DBX updates

### DIFF
--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -91,6 +91,7 @@ parts:
                        -Dpython=/usr/bin/python3,
                        -Dplugin_flashrom=disabled,
                        -Dplugin_powerd=disabled,
+                       -Dplugin_snapd=enabled,
                        -Defi_os_dir=fwupd,
                        "-Dlibxmlb:gtkdoc=false",
                        "-Dlibxmlb:introspection=false",

--- a/libfwupdplugin/fu-secure-boot-device.c
+++ b/libfwupdplugin/fu-secure-boot-device.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuSecureBootDevice"
+
+#include "config.h"
+
+#include "fu-firmware.h"
+#include "fu-secure-boot-device.h"
+
+/**
+ * FuSecureBootDevice
+ *
+ * Is an interface implemented by devices which operate on data that may be
+ * inspected or measured during secure boot process, eg. UEFI DBX, PK and
+ * others.
+ *
+ */
+
+G_DEFINE_INTERFACE(FuSecureBootDevice, fu_secure_boot_device, G_TYPE_OBJECT)
+
+static void
+fu_secure_boot_device_default_init(FuSecureBootDeviceInterface *iface)
+{
+}
+
+/**
+ * fu_secure_boot_device_get_kind:
+ * @self: a #FuSecureBootDevice
+ *
+ * Gets the kind of device.
+ *
+ * Returns: #FuSecureBootDeviceKind
+ *
+ **/
+FuSecureBootDeviceKind
+fu_secure_boot_device_get_kind(FuSecureBootDevice *self)
+{
+	FuSecureBootDeviceInterface *iface = NULL;
+
+	g_return_val_if_fail(FU_IS_SECURE_BOOT_DEVICE(self),
+			     FU_SECURE_BOOT_DEVICE_KIND_UNSPECIFIED);
+
+	iface = FU_SECURE_BOOT_DEVICE_GET_IFACE(self);
+	return iface->get_kind(self);
+}
+
+/**
+ * fu_secure_boot_device_set_firmware_write_observe:
+ * @self: a #FuSecureBootDevice
+ *
+ * Install a callback for observing firmware writes.
+ *
+ * There can be only one callback registered for any secure boot object.
+ *
+ * Returns: TRUE if the callback was set.
+ *
+ **/
+gboolean
+fu_secure_boot_device_set_firmware_write_observe(FuSecureBootDevice *self,
+						 FuSecureBootDeviceFirmwareObserveFunc func_cb,
+						 gpointer user_data)
+{
+	FuSecureBootDeviceInterface *iface = NULL;
+
+	/* TODO find vfunc? */
+	g_return_val_if_fail(FU_IS_SECURE_BOOT_DEVICE(self), FALSE);
+	iface = FU_SECURE_BOOT_DEVICE_GET_IFACE(self);
+	return iface->set_firmware_write_observe(self, func_cb, user_data);
+}
+
+/**
+ * fu_secure_boot_device_reset_firmware_write_observe:
+ * @self: a #FuSecureBootDevice
+ *
+ * Reset/clear firmare write observe callback.
+ *
+ **/
+void
+fu_secure_boot_device_reset_firmware_write_observe(FuSecureBootDevice *self)
+{
+	FuSecureBootDeviceInterface *iface = NULL;
+
+	g_return_if_fail(FU_IS_SECURE_BOOT_DEVICE(self));
+	iface = FU_SECURE_BOOT_DEVICE_GET_IFACE(self);
+	(void)iface->set_firmware_write_observe(self, NULL, NULL);
+}

--- a/libfwupdplugin/fu-secure-boot-device.h
+++ b/libfwupdplugin/fu-secure-boot-device.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-device.h"
+#include "fu-firmware.h"
+#include "glibconfig.h"
+
+#define FU_TYPE_SECURE_BOOT_DEVICE (fu_secure_boot_device_get_type())
+G_DECLARE_INTERFACE(FuSecureBootDevice, fu_secure_boot_device, FU, SECURE_BOOT_DEVICE, GObject)
+
+typedef enum {
+	FU_SECURE_BOOT_DEVICE_KIND_UNSPECIFIED = 0,
+	FU_SECURE_BOOT_DEVICE_KIND_UEFI_DBX,
+	/*< private >*/
+	FU_SECURE_BOOT_DEVICE_KIND_LAST
+} FuSecureBootDeviceKind;
+
+/**
+ * FuSecureBootDeviceFirmwareObserveFunc
+ * @dev: a #FuSecureBootDevice
+ * @fw: a #FuFirmware about to be written to the device
+ * @user_data: a pointer to user data
+ *
+ * Function called by secure device right before writing the device firmware.
+ * May be called multiple times in during an update. It is generally expected
+ * that this is a place where a plugin may interact with other parts of the
+ * system.
+ *
+ **/
+typedef gboolean (*FuSecureBootDeviceFirmwareObserveFunc)(FuSecureBootDevice *dev,
+							  FuFirmware *fw,
+							  gpointer user_data,
+							  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+struct _FuSecureBootDeviceInterface {
+	GTypeInterface parent;
+
+	/**
+	 * get_kind
+	 * @self: a #FuSecureBootDevice
+	 *
+	 * Obtain device kind.
+	 *
+	 * Returns: #FuSecureBootDeviceKind
+	 *
+	 * Since: 1.7.2
+	 **/
+	FuSecureBootDeviceKind (*get_kind)(FuSecureBootDevice *self);
+
+	/**
+	 * set_firmware_write_observe
+	 * @self: a #FuSecureBootDevice
+	 * @cb: a callback to invoke when attempting to write the firmware
+	 *
+	 * Set the callback to invoke for when the device firmware is about to be
+	 * written. It is generally expected there will be just one callback
+	 * registered for any given device. Calling with a NULL callback is
+	 * equivalent to clearing it.
+	 *
+	 * Returns: TRUE when no callback was previously set.
+	 *
+	 * Since: 1.7.2
+	 **/
+	gboolean (*set_firmware_write_observe)(FuSecureBootDevice *self,
+					       FuSecureBootDeviceFirmwareObserveFunc cb,
+					       gpointer user_data);
+};
+
+FuSecureBootDeviceKind
+fu_secure_boot_device_get_kind(FuSecureBootDevice *self) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_secure_boot_device_set_firmware_write_observe(FuSecureBootDevice *self,
+						 FuSecureBootDeviceFirmwareObserveFunc func,
+						 gpointer user_data);
+void
+fu_secure_boot_device_reset_firmware_write_observe(FuSecureBootDevice *self);

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -147,6 +147,7 @@ fwupdplugin_src = [
   'fu-progress.c', # fuzzing
   'fu-quirks.c', # fuzzing
   'fu-sbatlevel-section.c', # fuzzing
+  'fu-secure-boot-device.c', # fuzzing
   'fu-security-attr.c', # fuzzing
   'fu-security-attrs.c',
   'fu-serio-device.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -297,6 +297,10 @@ option('qubes',
   value: false,
   description: 'build packages for Qubes OS',
 )
+option('plugin_snapd',
+  type: 'feature',
+  description: 'enable snapd integration',
+)
 option('sqlite',
   type: 'feature',
   description: 'sqlite support',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -107,6 +107,7 @@ plugins = {
   'rts54hub': false,
   'steelseries': false,
   'scsi': false,
+  'snapd': false,
   'synaptics-cape': false,
   'synaptics-cxaudio': false,
   'synaptics-mst': false,

--- a/plugins/snapd/README.md
+++ b/plugins/snapd/README.md
@@ -1,0 +1,24 @@
+---
+title: Plugin: snapd
+---
+
+## Introduction
+
+The plugin provides integration with snapd. 
+
+## Update Behavior
+
+When devices such as UEFI DBX are being updated, the snapd plugin will reach out
+to snapd and pass the update payload, such that the FDE implemented by snapd can
+properly update the TPM policies.
+
+## External Interface Access
+
+This plugin requires:
+
+* access to /run/snapd.socket
+* access to /run/snapd-snap.socket
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.0.0`.

--- a/plugins/snapd/fu-snapd-error.c
+++ b/plugins/snapd/fu-snapd-error.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "fu-snapd-error.h"
+
+/**
+ * fu_snapd_error_quark:
+ *
+ * Returns: an error quark
+ **/
+GQuark
+fu_snapd_error_quark(void)
+{
+	static GQuark quark = 0;
+	if (!quark) {
+		quark = g_quark_from_static_string("FuSnapdError");
+	}
+	return quark;
+}

--- a/plugins/snapd/fu-snapd-error.h
+++ b/plugins/snapd/fu-snapd-error.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#define FU_SNAPD_ERROR fu_snapd_error_quark()
+
+/**
+ * FuSnapdError:
+ *
+ * The error code.
+ **/
+typedef enum {
+	FU_SNAPD_ERROR_INTERNAL,
+	FU_SNAPD_ERROR_UNSUPPORTED,
+	/*< private >*/
+	FU_SNAPD_ERROR_LAST
+} FuSnapdError;
+
+GQuark
+fu_snapd_error_quark(void);

--- a/plugins/snapd/fu-snapd-observer.c
+++ b/plugins/snapd/fu-snapd-observer.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include "fu-snapd-observer.h"
+
+#include <curl/curl.h>
+#include <curl/easy.h>
+
+#include "fwupd-error.h"
+
+#include "fu-snapd-error.h"
+#include "fu-snapd-snap.h"
+
+struct _FuSnapdObserver {
+	GObject parent_instance;
+	CURL *curl_template;
+	struct curl_slist *req_hdrs;
+};
+
+G_DEFINE_TYPE(FuSnapdObserver, fu_snapd_observer, G_TYPE_OBJECT)
+
+FuSnapdObserver *
+fu_snapd_observer_new(void)
+{
+	return g_object_new(FU_TYPE_SNAPD_OBSERVER, NULL);
+}
+
+static void
+fu_snapd_observer_init(FuSnapdObserver *self)
+{
+	self->curl_template = curl_easy_init();
+	/* TODO choose different socket when in snap vs non-snap */
+	if (fu_snapd_is_in_snap()) {
+		curl_easy_setopt(self->curl_template,
+				 CURLOPT_UNIX_SOCKET_PATH,
+				 "/run/snapd-snap.socket");
+	} else {
+		curl_easy_setopt(self->curl_template,
+				 CURLOPT_UNIX_SOCKET_PATH,
+				 "/run/snapd.socket");
+	}
+
+	self->req_hdrs = curl_slist_append(self->req_hdrs, "Content-Type: application/json");
+	curl_easy_setopt(self->curl_template, CURLOPT_HTTPHEADER, self->req_hdrs);
+}
+
+static void
+fu_snapd_observer_finalize(GObject *object)
+{
+	FuSnapdObserver *self = FU_SNAPD_OBSERVER(object);
+	curl_slist_free_all(self->req_hdrs);
+	curl_easy_cleanup(self->curl_template);
+	G_OBJECT_CLASS(fu_snapd_observer_parent_class)->finalize(object);
+}
+
+static void
+fu_snapd_observer_class_init(FuSnapdObserverClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_snapd_observer_finalize;
+}
+
+/* see CURLOPT_WRITEFUNCTION(3) */
+static size_t
+fu_snapd_observer_rsp_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	GByteArray *bufarr = (GByteArray *)userdata;
+	gsize sz = size * nmemb;
+	g_byte_array_append(bufarr, (const guint8 *)ptr, sz);
+	return sz;
+}
+
+static gboolean
+fu_snapd_observer_simple_req(FuSnapdObserver *self,
+			     const char *endpoint,
+			     const char *data,
+			     gsize len,
+			     GError **error)
+{
+	CURL *curl = NULL;
+	CURLcode res = -1;
+	glong status_code = 0;
+	g_autofree gchar *endpoint_str = NULL;
+	g_autoptr(GByteArray) rsp_buf = g_byte_array_new();
+
+	/* duplicate a preconfigured curl handle */
+	curl = curl_easy_duphandle(self->curl_template);
+
+	endpoint_str = g_strdup_printf("http://localhost%s", endpoint);
+
+	curl_easy_setopt(curl, CURLOPT_URL, endpoint_str);
+
+	g_debug("snapd simple request to %s with %" G_GSIZE_FORMAT " bytes of data",
+		endpoint_str,
+		len);
+	g_debug("request data: '%s'", data);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+
+	/* collect response for debugging */
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, rsp_buf);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fu_snapd_observer_rsp_cb);
+
+	/* TODO: disable verbose */
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK) {
+		/* TODO inspect the error */
+		g_set_error(error,
+			    FU_SNAPD_ERROR,
+			    FU_SNAPD_ERROR_INTERNAL,
+			    "cannot communicate with snapd: %s",
+			    curl_easy_strerror(res));
+		g_warning("cannot notify snapd: %s", curl_easy_strerror(res));
+		return FALSE;
+	}
+
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+	curl_easy_cleanup(curl);
+
+	if (status_code == 404) {
+		g_set_error(error,
+			    FU_SNAPD_ERROR,
+			    FU_SNAPD_ERROR_UNSUPPORTED,
+			    "snapd notification endpoint not supported by snapd API");
+		return FALSE;
+	}
+
+	if (status_code != 200) {
+		if (rsp_buf->len > 0) {
+			/* make sure the response is null terminated */
+			g_byte_array_append(rsp_buf, (const guint8 *)"\0", 1);
+		}
+
+		/* TODO check whether the response is even printable? */
+		g_warning("snapd request failed with status %ld, response: %s",
+			  (glong)status_code,
+			  rsp_buf->data);
+		g_set_error(error,
+			    FU_SNAPD_ERROR,
+			    FU_SNAPD_ERROR_INTERNAL,
+			    "snapd request failed with status %ld",
+			    (glong)status_code);
+		return FALSE;
+	}
+
+	g_debug("snapd request success");
+
+	return TRUE;
+}
+
+gboolean
+fu_snapd_observer_notify_secureboot_manager_startup(FuSnapdObserver *self, GError **error)
+{
+	const char *startup_msg = "{"
+				  "\"action\":\"efi-secureboot-update-startup\""
+				  "}";
+
+	g_debug("snapd observer secureboot manager startup");
+
+	if (!fu_snapd_observer_simple_req(self,
+					  "/v2/system-secureboot",
+					  startup_msg,
+					  strlen(startup_msg),
+					  error)) {
+		g_prefix_error(error, "failed to notify snapd of startup: ");
+		return FALSE;
+	}
+
+	g_debug("snapd notified of secureboot manager startup");
+
+	return TRUE;
+}
+
+/**
+ * fu_snapd_observer_notify_secureboot_dbx_update_prepare:
+ * @self: a #FuSnapdObserver
+ * @fw_payload: payload used for the update
+ *
+ * Notify of an upcoming update to the DBX. A successful call shall initiate a
+ * change tracking an update to the DBX on the snapd side.
+ *
+ * Returns: TRUE if the notification was successful.
+ *
+ **/
+gboolean
+fu_snapd_observer_notify_secureboot_dbx_update_prepare(FuSnapdObserver *self,
+						       GBytes *fw_payload,
+						       GError **error)
+{
+	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw_payload, &bufsz);
+	g_autofree gchar *b64data = g_base64_encode(buf, bufsz);
+	g_autofree gchar *msg = g_strdup_printf("{"
+						"\"action\":\"efi-secureboot-update-db-prepare\","
+						"\"key-database\":\"DBX\","
+						"\"payload\":\"%s\""
+						"}",
+						b64data);
+
+	g_debug("snapd observer prepare, with %" G_GSIZE_FORMAT " bytes of data", bufsz);
+
+	if (!fu_snapd_observer_simple_req(self, "/v2/system-secureboot", msg, strlen(msg), error)) {
+		g_prefix_error(error, "failed to notify snapd of prepare: ");
+		return FALSE;
+	}
+
+	g_debug("snapd notified of prepare");
+
+	return TRUE;
+}
+
+/**
+ * fu_snapd_observer_notify_secureboot_db_update_cleanup:
+ * @self: a #FuSnapdObserver
+ *
+ * Notify of an completed update to one of secureboot key databases. A
+ * successful call shall result in completion of a corresponding change on the
+ * snapd side.
+ *
+ * Returns: TRUE if the notification was successful.
+ *
+ **/
+gboolean
+fu_snapd_observer_notify_secureboot_db_update_cleanup(FuSnapdObserver *self, GError **error)
+{
+	const char *msg = "{"
+			  "\"action\":\"efi-secureboot-update-db-cleanup\""
+			  "}";
+
+	g_debug("snapd observer cleanup");
+
+	if (!fu_snapd_observer_simple_req(self, "/v2/system-secureboot", msg, strlen(msg), error)) {
+		g_prefix_error(error, "failed to notify snapd of cleanup: ");
+		return FALSE;
+	}
+
+	g_debug("snapd notified of cleanup");
+
+	return TRUE;
+}

--- a/plugins/snapd/fu-snapd-observer.h
+++ b/plugins/snapd/fu-snapd-observer.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_SNAPD_OBSERVER (fu_snapd_observer_get_type())
+G_DECLARE_FINAL_TYPE(FuSnapdObserver, fu_snapd_observer, FU, SNAPD_OBSERVER, GObject)
+
+FuSnapdObserver *
+fu_snapd_observer_new(void);
+
+gboolean
+fu_snapd_observer_notify_secureboot_manager_startup(FuSnapdObserver *self, GError **error);
+
+gboolean
+fu_snapd_observer_notify_secureboot_dbx_update_prepare(FuSnapdObserver *self,
+						       GBytes *fw_payload,
+						       GError **error);
+
+gboolean
+fu_snapd_observer_notify_secureboot_db_update_cleanup(FuSnapdObserver *self, GError **error);

--- a/plugins/snapd/fu-snapd-plugin.c
+++ b/plugins/snapd/fu-snapd-plugin.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <time.h>
+
+#include "fwupd-enums.h"
+#include "fwupd-error.h"
+
+#include "fu-firmware.h"
+#include "fu-progress.h"
+#include "fu-secure-boot-device.h"
+#include "fu-snapd-error.h"
+#include "fu-snapd-observer.h"
+#include "fu-snapd-plugin.h"
+#include "fu-snapd-snap.h"
+#include "glib.h"
+
+struct _FuSnapdPlugin {
+	FuPlugin parent_instance;
+
+	FuSnapdObserver *snapd_observer;
+};
+
+G_DEFINE_TYPE(FuSnapdPlugin, fu_snapd_plugin, FU_TYPE_PLUGIN)
+
+static gboolean
+fu_snapd_plugin_notify_init(FuSnapdPlugin *self, GError **error);
+
+static void
+fu_snapd_plugin_init(FuSnapdPlugin *self)
+{
+}
+
+static void
+fu_snapd_plugin_finalize(GObject *object)
+{
+	FuSnapdPlugin *self = FU_SNAPD_PLUGIN(object);
+	if (self->snapd_observer != NULL) {
+		g_object_unref(self->snapd_observer);
+		self->snapd_observer = NULL;
+	}
+}
+
+static gboolean
+fu_snapd_notify_secure_boot_dbx_write(FuSecureBootDevice *dev,
+				      FuFirmware *fw,
+				      gpointer user_data,
+				      GError **error);
+
+static gboolean
+fu_snapd_plugin_composite_prepare(FuPlugin *plugin, GPtrArray *devices, GError **error)
+{
+	FuSnapdPlugin *self = FU_SNAPD_PLUGIN(plugin);
+
+	g_debug("composite prepare");
+
+	g_return_val_if_fail(self->snapd_observer != NULL, TRUE);
+
+	/* TODO which devices are part of the update */
+	/* TODO if found UEFI DBX device, then register a callback */
+	for (guint i = 0; i < devices->len; i++) {
+		FuDevice *dev = g_ptr_array_index(devices, i);
+		if (FU_IS_SECURE_BOOT_DEVICE(dev)) {
+			FuSecureBootDevice *sbdev = FU_SECURE_BOOT_DEVICE(dev);
+			FuSecureBootDeviceKind kind = fu_secure_boot_device_get_kind(sbdev);
+			if (kind != FU_SECURE_BOOT_DEVICE_KIND_UEFI_DBX) {
+				continue;
+			}
+
+			g_debug("found DBX device");
+			if (!fu_secure_boot_device_set_firmware_write_observe(
+				sbdev,
+				fu_snapd_notify_secure_boot_dbx_write,
+				(gpointer)plugin)) {
+				g_warning("cannot install firmware write observer");
+				return FALSE;
+			}
+		}
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_snapd_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GError **error)
+{
+	FuSnapdPlugin *self = FU_SNAPD_PLUGIN(plugin);
+	g_autoptr(GError) snapd_cleanup_error = NULL;
+	gboolean dbx_device_found = FALSE;
+
+	g_debug("composite cleanup");
+
+	g_return_val_if_fail(self->snapd_observer != NULL, TRUE);
+
+	for (guint i = 0; i < devices->len; i++) {
+		FuDevice *dev = g_ptr_array_index(devices, i);
+		if (FU_IS_SECURE_BOOT_DEVICE(dev)) {
+			FuSecureBootDevice *sbdev = FU_SECURE_BOOT_DEVICE(dev);
+			FuSecureBootDeviceKind kind = fu_secure_boot_device_get_kind(sbdev);
+			if (kind != FU_SECURE_BOOT_DEVICE_KIND_UEFI_DBX) {
+				continue;
+			}
+
+			g_debug("found DBX device");
+			dbx_device_found = TRUE;
+			fu_secure_boot_device_reset_firmware_write_observe(sbdev);
+		}
+	}
+
+	if (dbx_device_found) {
+		if (!fu_snapd_observer_notify_secureboot_db_update_cleanup(self->snapd_observer,
+									   &snapd_cleanup_error)) {
+			g_warning("snapd cleanup failed: %s", snapd_cleanup_error->message);
+			/* TODO do we care about failures here? */
+		}
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_snapd_plugin_startup(FuPlugin *obj, FuProgress *progress, GError **error)
+{
+	GError *snapd_error = NULL;
+	gboolean res = FALSE;
+
+	/* TODO check if SecureBoot is enabled, see uefi-sbat plugin */
+
+	if (!fu_snapd_is_in_snap()) {
+		g_debug("disabling snapd integration in non-snap scenario");
+		g_set_error_literal(error,
+				    FU_SNAPD_ERROR,
+				    FU_SNAPD_ERROR_UNSUPPORTED,
+				    "snapd integration outside of snap is not supported");
+		return FALSE;
+	}
+
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 100, "snapd-probe");
+
+	g_debug("snapd startup");
+
+	res = fu_snapd_plugin_notify_init(FU_SNAPD_PLUGIN(obj), &snapd_error);
+
+	fu_progress_step_done(progress);
+
+	if (!res) {
+		/* TODO inspect the error, maybe simply unavailable */
+		g_debug("snapd integration error: %s",
+			(snapd_error != NULL) ? snapd_error->message : "(unknown)");
+
+		if (g_error_matches(snapd_error, FU_SNAPD_ERROR, FU_SNAPD_ERROR_UNSUPPORTED)) {
+			g_warning("snapd integration not supported");
+		}
+		g_propagate_error(error, snapd_error);
+		g_prefix_error(error, "cannot initialize snapd integration: ");
+		/* plugin becomes disabled */
+		return FALSE;
+	}
+
+	g_debug("snapd integration enabled ");
+
+	return TRUE;
+}
+
+static void
+fu_snapd_plugin_class_init(FuSnapdPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+
+	plugin_class->startup = fu_snapd_plugin_startup;
+	plugin_class->finalize = fu_snapd_plugin_finalize;
+	plugin_class->composite_prepare = fu_snapd_plugin_composite_prepare;
+	plugin_class->composite_cleanup = fu_snapd_plugin_composite_cleanup;
+}
+
+static gboolean
+fu_snapd_plugin_notify_init(FuSnapdPlugin *self, GError **error)
+{
+	g_autoptr(FuSnapdObserver) obs = fu_snapd_observer_new();
+
+	if (!fu_snapd_observer_notify_secureboot_manager_startup(obs, error)) {
+		/* TODO inspect the error to device whether  */
+		g_warning("snapd notification init failed");
+		return FALSE;
+	}
+
+	self->snapd_observer = g_object_ref(obs);
+	return TRUE;
+}
+
+static gboolean
+fu_snapd_notify_secure_boot_dbx_write(FuSecureBootDevice *dev,
+				      FuFirmware *fw,
+				      gpointer user_data,
+				      GError **error)
+{
+	GBytes *payload = NULL;
+	FuSnapdPlugin *self = FU_SNAPD_PLUGIN(user_data);
+
+	g_warning("snapd write observe call");
+	if (fu_secure_boot_device_get_kind(dev) == FU_SECURE_BOOT_DEVICE_KIND_UEFI_DBX) {
+		g_warning("snapd write observe called for UEFI DBX device");
+	}
+
+	payload = fu_firmware_get_bytes(fw, error);
+	if (payload == NULL) {
+		return FALSE;
+	}
+
+	if (!fu_snapd_observer_notify_secureboot_dbx_update_prepare(self->snapd_observer,
+								    payload,
+								    error)) {
+		g_prefix_error(error, "cannot notify snapd: ");
+		return FALSE;
+	}
+
+	g_debug("successfully notified snapd of a DBX update");
+
+	return TRUE;
+}

--- a/plugins/snapd/fu-snapd-plugin.h
+++ b/plugins/snapd/fu-snapd-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuSnapdPlugin, fu_snapd_plugin, FU, SNAPD_PLUGIN, FuPlugin)

--- a/plugins/snapd/fu-snapd-snap.c
+++ b/plugins/snapd/fu-snapd-snap.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "fu-snapd-snap.h"
+
+/**
+ * fu_snapd_is_in_snap:
+ *
+ * Check whether the current process is running inside a snap.
+ *
+ * Returns: TRUE if current process is running inside a snap.
+ **/
+gboolean
+fu_snapd_is_in_snap(void)
+{
+	if (getenv("SNAP") != NULL) {
+		return TRUE;
+	}
+	return FALSE;
+}

--- a/plugins/snapd/fu-snapd-snap.h
+++ b/plugins/snapd/fu-snapd-snap.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+gboolean
+fu_snapd_is_in_snap(void);

--- a/plugins/snapd/meson.build
+++ b/plugins/snapd/meson.build
@@ -1,0 +1,23 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginSnapd"']
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+
+if get_option('plugin_snapd').require(libcurl.found(),
+  error_message: 'curl is needed for plugin_snapd').disable_auto_if(host_machine.system() != 'linux').allowed()
+endif
+
+plugin_builtin_snapd = static_library('fu_plugin_snapd',
+  sources: [
+    'fu-snapd-error.c',
+    'fu-snapd-observer.c',
+    'fu-snapd-plugin.c',
+    'fu-snapd-snap.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: [
+    plugin_deps,
+    libcurl,
+  ]
+)
+plugin_builtins += plugin_builtin_snapd


### PR DESCRIPTION
This draft PR introduces a new plugin for integrating snapd with fwupd, designed to handle UEFI DBX updates in Ubuntu Core systems, especially those with full-disk encryption (FDE).

In detail, in Ubuntu Core system and hybrid Ubuntu installations using FDE, snapd plays a role in resealing the encryption keys to the TPM. The constructed boot policy includes contents of DBX. In order to have the encryption key unsealed and to keep the system bootable, the DBX update payload must presented to snapd, such that a boot policy will account for the updated content.

The high level idea is for snapd to be notified of a DBX update in progress just before the new content is written to efivars. This allows for the new boot policy to be constructed, with a branch for both the old and new DBX content. This step is referred to as `prepare`. Subsequent call would happen right after the update completes, enabling snapd to introspect the actual content of DBX and reseal the keys once again taking only the current content into account. This is known as a `cleanup` step. An additional `startup` step would be triggered whenever fwupd starts up, such that an update which may have previously been interrupted by a reboot or a crash (whether planned or not) could be accounted for.

Snapd exposes a single integration endpoint via its UNIX socket API at `/v2/system-secureboot` which accepts JSON requests (as implemented in https://github.com/canonical/snapd/pull/14541). 

Initially, we are focusing on a simpler use case of `fwupd` running within a snap, which addresses the use case of Ubuntu Core systems, but in future, this will be extended to cover the classic distro integration in Ubuntu desktop.

In essence the branch attempts to explore means of integration within the structure of fwupd. The initial snapd plugin implements `startup`, `composite_update` and `composite_cleanup` vfuncs. While `startup` and `cleanup` are mostly straightforward, there are open questions around how to best 'observe' the update payload. I would appreciate your guidance on the most convenient way of identifying a device in question (I saw some plugins attaching metadata, and/or directly querying which plugin owns a device) and witnessing the update payload. 

Please note that there are some TODOs left and quirks in the code, such as verbose curl and similar debugging aids. I will address all of this before marking the PR as non draft once there is a clearer idea how the integration should look like.

Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Fill out `README.md` with update protocol (not applicable)
- [x] Fill out `README.md` with any custom quirks and flags (not applicable)
- [x] Fill out `README.md` with the vendor ID security value (not applicable)
- [x] Implement `FuFirmware->write()` and include at least one fuzzer testcase in `src/fuzzing/firmware` for any custom `FuFirmware` subclass
  - [ ]  not applicable, not writing any firmware
- [x] CI run of the plugin for at least one target
   - snap
- [ ] Document targets CI isn't currently run and the reasons (i.e. minimum versions needed or distribution limitations etc).
