### PR TITLE
trivial: Provide a helper to get the FuUdevDevice devpath

### DIFF
--- a/libfwupdplugin/fu-block-device.c
+++ b/libfwupdplugin/fu-block-device.c
@@ -35,7 +35,7 @@ fu_block_device_probe(FuDevice *device, GError **error)
 	/* block devices are weird in that the vendor and model are generic */
 	usb_device = fu_device_get_backend_parent_with_subsystem(device, "usb:usb_device", NULL);
 	if (usb_device != NULL) {
-		g_autofree gchar *physical_id = NULL;
+		g_autofree gchar *devpath = fu_udev_device_get_devpath(FU_UDEV_DEVICE(usb_device));
 
 		/* copy the VID and PID, and reconstruct compatible IDs */
 		if (!fu_device_probe(usb_device, error))
@@ -62,10 +62,10 @@ fu_block_device_probe(FuDevice *device, GError **error)
 					  FU_DEVICE_INCORPORATE_FLAG_PID);
 
 		/* USB devpath as physical ID */
-		physical_id =
-		    g_strdup_printf("DEVPATH=%s",
-				    fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(usb_device)));
-		fu_device_set_physical_id(device, physical_id);
+		if (devpath != NULL) {
+			g_autofree gchar *physical_id = g_strdup_printf("DEVPATH=%s", devpath);
+			fu_device_set_physical_id(device, physical_id);
+		}
 	}
 
 	/* success */

--- a/libfwupdplugin/fu-serio-device.c
+++ b/libfwupdplugin/fu-serio-device.c
@@ -23,7 +23,7 @@ static gboolean
 fu_serio_device_probe(FuDevice *device, GError **error)
 {
 	FuSerioDevice *self = FU_SERIO_DEVICE(device);
-	g_auto(GStrv) sysfs_parts = NULL;
+	g_autofree gchar *devpath = fu_udev_device_get_devpath(FU_UDEV_DEVICE(self));
 	g_autofree gchar *summary = NULL;
 	g_autofree gchar *firmware_id = NULL;
 
@@ -72,9 +72,8 @@ fu_serio_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* we don't have anything better to use */
-	sysfs_parts = g_strsplit(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(self)), "/sys", 2);
-	if (sysfs_parts[1] != NULL) {
-		g_autofree gchar *physical_id = g_strdup_printf("DEVPATH=%s", sysfs_parts[1]);
+	if (devpath != NULL) {
+		g_autofree gchar *physical_id = g_strdup_printf("DEVPATH=%s", devpath);
 		fu_device_set_physical_id(device, physical_id);
 	}
 

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -840,6 +840,28 @@ fu_udev_device_get_device_file_from_subsystem(FuUdevDevice *self,
 }
 
 /**
+ * fu_udev_device_get_devpath:
+ * @self: a #FuUdevDevice
+ *
+ * Sets the physical ID from the sysfs path, with the `/sys` prefixed removed.
+ *
+ * Returns: The udev-compatble device path, or %NULL on error.
+ *
+ * Since: 2.0.1
+ **/
+gchar *
+fu_udev_device_get_devpath(FuUdevDevice *self)
+{
+	gchar *full_devpath;
+	if (fu_udev_device_get_sysfs_path(self) == NULL)
+		return NULL;
+	full_devpath = g_strrstr(fu_udev_device_get_sysfs_path(self), "/sys");
+	if (full_devpath == NULL)
+		return NULL;
+	return g_strdup(full_devpath + 4);
+}
+
+/**
  * fu_udev_device_set_physical_id:
  * @self: a #FuUdevDevice
  * @subsystems: a subsystem string, e.g. `pci,usb,scsi:scsi_target`

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -43,6 +43,8 @@ void
 fu_udev_device_set_device_file(FuUdevDevice *self, const gchar *device_file) G_GNUC_NON_NULL(1);
 const gchar *
 fu_udev_device_get_sysfs_path(FuUdevDevice *self) G_GNUC_NON_NULL(1);
+gchar *
+fu_udev_device_get_devpath(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 const gchar *
 fu_udev_device_get_subsystem(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 const gchar *

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -138,14 +138,10 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 	device_target =
 	    fu_device_get_backend_parent_with_subsystem(device, "scsi:scsi_target", NULL);
 	if (device_target != NULL) {
-		g_auto(GStrv) sysfs_parts = NULL;
-		sysfs_parts =
-		    g_strsplit(fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device_target)),
-			       "/sys",
-			       2);
-		if (sysfs_parts[1] != NULL) {
-			g_autofree gchar *physical_id =
-			    g_strdup_printf("DEVPATH=%s", sysfs_parts[1]);
+		g_autofree gchar *devpath =
+		    fu_udev_device_get_devpath(FU_UDEV_DEVICE(device_target));
+		if (devpath != NULL) {
+			g_autofree gchar *physical_id = g_strdup_printf("DEVPATH=%s", devpath);
 			fu_device_set_physical_id(device, physical_id);
 		}
 	}


### PR DESCRIPTION
Splitting on /sys isn't the right thing to do, as on ChromeOS we have a path like `~/sys-apps/fwupd/src/tests/sys/devices` -- and we only want the right-most /sys suffix.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
