### PR TITLE
Tag devices that can be emulated

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -187,6 +187,8 @@ fwupd_device_flag_to_string(FwupdDeviceFlags device_flag)
 		return "emulation-tag";
 	if (device_flag == FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES)
 		return "only-explicit-updates";
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG)
+		return "can-emulation-tag";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -279,6 +281,8 @@ fwupd_device_flag_from_string(const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_EMULATION_TAG;
 	if (g_strcmp0(device_flag, "only-explicit-updates") == 0)
 		return FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES;
+	if (g_strcmp0(device_flag, "can-emulation-tag") == 0)
+		return FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -572,6 +572,14 @@ typedef enum {
 	 */
 	FWUPD_DEVICE_FLAG_ONLY_EXPLICIT_UPDATES = 1ull << 51,
 	/**
+	 * FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG:
+	 *
+	 * The device can be recorded by the backend, allowing emulation.
+	 *
+	 * Since: 2.0.1
+	 */
+	FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG = 1ull << 52,
+	/**
 	 * FWUPD_DEVICE_FLAG_UNKNOWN:
 	 *
 	 * This flag is not defined, this typically will happen from mismatched fwupd library and

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1952,6 +1952,7 @@ fu_udev_device_init(FuUdevDevice *self)
 	FuUdevDevicePrivate *priv = GET_PRIVATE(self);
 	priv->properties = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	fu_device_set_acquiesce_delay(FU_DEVICE(self), 2500);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG);
 	g_signal_connect(FU_DEVICE(self),
 			 "notify::vid",
 			 G_CALLBACK(fu_udev_device_vid_notify_cb),

--- a/plugins/amd-gpu/amd_gpu_test.py
+++ b/plugins/amd-gpu/amd_gpu_test.py
@@ -215,10 +215,7 @@ A: vendor=0x1022
                 continue
             print(dev.to_string())
             count += 1
-            self.assertEqual(
-                dev.get_flags(),
-                1 | Fwupd.DeviceFlags.INTERNAL,
-            )
+            self.assertTrue(dev.has_flag(Fwupd.DeviceFlags.INTERNAL))
             self.assertEqual(dev.get_summary(), "AMD AMD_PHOENIX_GENERIC")
             self.assertEqual(dev.get_vendor(), "Advanced Micro Devices, Inc. [AMD/ATI]")
             self.assertEqual(dev.get_version(), "022.012.000.027.000001")

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1160,6 +1160,14 @@ fu_engine_add_device_flag(FuEngine *self,
 		device = fu_device_list_get_by_id(self->device_list, device_id, error);
 		if (device == NULL)
 			return FALSE;
+		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG)) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "device %s cannot be tagged for emulation",
+				    fu_device_get_id(device));
+			return FALSE;
+		}
 		proxy = fu_device_get_proxy(device);
 		if (proxy != NULL) {
 			g_set_error(error,

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1170,6 +1170,10 @@ fu_util_device_flag_to_string(guint64 device_flag)
 		 * specified */
 		return _("Installing a specific release is explicitly required");
 	}
+	if (device_flag == FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG) {
+		/* TRANSLATORS: we can save all device enumeration events for emulation */
+		return _("Can tag for emulation");
+	}
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN) {
 		return NULL;
 	}

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4605,6 +4605,7 @@ fu_util_emulation_tag(FuUtilPrivate *priv, gchar **values, GError **error)
 	g_autoptr(FwupdDevice) dev = NULL;
 
 	/* set the flag */
+	priv->filter_device_include |= FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG;
 	dev = fu_util_get_device_or_prompt(priv, values, error);
 	if (dev == NULL)
 		return FALSE;


### PR DESCRIPTION
This means we only show supported devices when using 'fwupdmgr emulation-tag' and in any future gnome-firmware GUI elements.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
