### PR TITLE
Add fu_firmware_parse_bytes() and remove two clunky symbols

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -4,6 +4,11 @@
 
 * Typedef `FwupdFeatureFlags` to `guint64` so it's the same size on all platforms
 
+## Migration from Version 2.0.0
+
+* Migrate from `fu_firmware_parse_full()` to `fu_firmware_parse_bytes()`
+* Migrate from `fu_firmware_parse()` to `fu_firmware_parse_bytes()` by adding an offset of 0x0
+
 ## Migration from Version 1.9.x
 
 * Migrate from `fwupd_build_machine_id()` to `fwupd_client_get_host_machine_id()`

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -93,7 +93,7 @@ Remember: Plugins should be upstream!
 * `fu_common_cab_build_silo()`: You should not be using this.
 * `fu_i2c_device_read_full()`: Use `fu_i2c_device_read` instead.
 * `fu_i2c_device_write_full()`: Use `fu_i2c_device_write` instead.
-* `fu_firmware_parse_full()`: Remove the `addr_end` parameter, and ensure that `offset` is a `gsize`.
+* `fu_firmware_parse_bytes()`: Remove the `addr_end` parameter, and ensure that `offset` is a `gsize`.
 
 ## 1.8.5
 

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -170,7 +170,7 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 	fu_firmware_set_idx(entry, token_idx);
 	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), entry, error))
 		return FALSE;
-	if (!fu_firmware_parse(entry, fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(entry, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 	return TRUE;
 }

--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -269,7 +269,11 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 		blob = fu_bytes_get_contents(edid_path, error);
 		if (blob == NULL)
 			return FALSE;
-		if (!fu_firmware_parse(FU_FIRMWARE(edid), blob, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_bytes(FU_FIRMWARE(edid),
+					     blob,
+					     0x0,
+					     FWUPD_INSTALL_FLAG_NONE,
+					     error))
 			return FALSE;
 		g_set_object(&priv->edid, edid);
 

--- a/libfwupdplugin/fu-efivars.c
+++ b/libfwupdplugin/fu-efivars.c
@@ -806,7 +806,11 @@ fu_efivars_get_boot_entry(FuEfivars *self, guint16 idx, GError **error)
 	blob = fu_efivars_get_data_bytes(self, FU_EFIVARS_GUID_EFI_GLOBAL, name, NULL, error);
 	if (blob == NULL)
 		return NULL;
-	if (!fu_firmware_parse(FU_FIRMWARE(loadopt), blob, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(loadopt),
+				     blob,
+				     0x0,
+				     FWUPD_INSTALL_FLAG_NONE,
+				     error))
 		return NULL;
 	fu_firmware_set_idx(FU_FIRMWARE(loadopt), idx);
 	return g_steal_pointer(&loadopt);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1171,7 +1171,7 @@ fu_firmware_parse_stream(FuFirmware *self,
 }
 
 /**
- * fu_firmware_parse_full:
+ * fu_firmware_parse_bytes:
  * @self: a #FuFirmware
  * @fw: firmware blob
  * @offset: start offset, useful for ignoring a bootloader
@@ -1182,14 +1182,14 @@ fu_firmware_parse_stream(FuFirmware *self,
  *
  * Returns: %TRUE for success
  *
- * Since: 1.8.2
+ * Since: 2.0.1
  **/
 gboolean
-fu_firmware_parse_full(FuFirmware *self,
-		       GBytes *fw,
-		       gsize offset,
-		       FwupdInstallFlags flags,
-		       GError **error)
+fu_firmware_parse_bytes(FuFirmware *self,
+			GBytes *fw,
+			gsize offset,
+			FwupdInstallFlags flags,
+			GError **error)
 {
 	g_autoptr(GInputStream) stream = NULL;
 
@@ -1199,25 +1199,6 @@ fu_firmware_parse_full(FuFirmware *self,
 
 	stream = g_memory_input_stream_new_from_bytes(fw);
 	return fu_firmware_parse_stream(self, stream, offset, flags, error);
-}
-
-/**
- * fu_firmware_parse:
- * @self: a #FuFirmware
- * @fw: firmware blob
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
- * @error: (nullable): optional return location for an error
- *
- * Parses a firmware, typically breaking the firmware into images.
- *
- * Returns: %TRUE for success
- *
- * Since: 1.3.1
- **/
-gboolean
-fu_firmware_parse(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GError **error)
-{
-	return fu_firmware_parse_full(self, fw, 0x0, flags, error);
 }
 
 /**

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -130,7 +130,7 @@ typedef enum {
 	/**
 	 * FU_FIRMWARE_FLAG_DONE_PARSE:
 	 *
-	 * The firmware object has been used by fu_firmware_parse_full().
+	 * The firmware object has been used by fu_firmware_parse_bytes().
 	 *
 	 * Since: 1.7.3
 	 **/
@@ -364,9 +364,6 @@ fu_firmware_build_from_filename(FuFirmware *self,
 				const gchar *filename,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_firmware_parse(FuFirmware *self, GBytes *fw, FwupdInstallFlags flags, GError **error)
-    G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
-gboolean
 fu_firmware_parse_stream(FuFirmware *self,
 			 GInputStream *stream,
 			 gsize offset,
@@ -376,11 +373,11 @@ gboolean
 fu_firmware_parse_file(FuFirmware *self, GFile *file, FwupdInstallFlags flags, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_firmware_parse_full(FuFirmware *self,
-		       GBytes *fw,
-		       gsize offset,
-		       FwupdInstallFlags flags,
-		       GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
+fu_firmware_parse_bytes(FuFirmware *self,
+			GBytes *fw,
+			gsize offset,
+			FwupdInstallFlags flags,
+			GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 GBytes *
 fu_firmware_write(FuFirmware *self, GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 GBytes *

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -17,12 +17,13 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 
 	(void)g_setenv("G_DEBUG", "fatal-criticals", TRUE);
 	(void)g_setenv("FWUPD_FUZZER_RUNNING", "1", TRUE);
-	ret = fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
+	ret = fu_firmware_parse_bytes(firmware, fw, FWUPD_INSTALL_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		g_clear_object(&firmware);
 		firmware = FU_FIRMWARE(@FIRMWARENEW@);
-		ret = fu_firmware_parse(firmware,
+		ret = fu_firmware_parse_bytes(firmware,
 					fw,
+					0x0,
 					FWUPD_INSTALL_FLAG_NO_SEARCH |
 					    FWUPD_INSTALL_FLAG_IGNORE_VID_PID |
 					    FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM,

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -114,7 +114,7 @@ fu_hid_device_parse_descriptors(FuHidDevice *self, GError **error)
 		g_autoptr(FuFirmware) descriptor = fu_hid_descriptor_new();
 		g_autofree gchar *title = g_strdup_printf("HidDescriptor:0x%x", i);
 		fu_dump_bytes(G_LOG_DOMAIN, title, fw);
-		if (!fu_firmware_parse(descriptor, fw, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_bytes(descriptor, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 			return NULL;
 		g_ptr_array_add(descriptors, g_steal_pointer(&descriptor));
 	}

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3088,13 +3088,13 @@ fu_firmware_raw_aligned_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("hello", 5);
 
 	/* no alignment */
-	ret = fu_firmware_parse(firmware1, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware1, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	/* invalid alignment */
 	fu_firmware_set_alignment(firmware2, FU_FIRMWARE_ALIGNMENT_4K);
-	ret = fu_firmware_parse(firmware2, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware2, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -3203,7 +3203,11 @@ fu_firmware_ihex_offset_func(void)
 			":00000001FF\n");
 
 	/* check we can load it too */
-	ret = fu_firmware_parse(firmware_verify, data_bin, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware_verify,
+				      data_bin,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(fu_firmware_get_addr(firmware_verify), ==, 0x80000000);
@@ -3604,7 +3608,7 @@ fu_firmware_csv_func(void)
 	g_assert_cmpstr(fu_csv_firmware_get_column_id(FU_CSV_FIRMWARE(firmware), 6), ==, NULL);
 
 	blob = g_bytes_new(data, strlen(data));
-	ret = fu_firmware_parse(firmware, blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_firmware_to_string(firmware);
@@ -3693,7 +3697,7 @@ fu_firmware_linear_func(void)
 	g_assert_cmpint(g_bytes_get_size(blob3), ==, 1024);
 
 	/* parse them back */
-	ret = fu_firmware_parse(firmware2, blob3, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware2, blob3, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_firmware_to_string(firmware2);
@@ -3815,7 +3819,7 @@ fu_firmware_oprom_func(void)
 	g_assert_cmpint(g_bytes_get_size(data_bin), ==, 1024);
 
 	/* re-parse to get the CPD image */
-	ret = fu_firmware_parse(firmware2, data_bin, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(firmware2, data_bin, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	img1 = fu_firmware_get_image_by_id(firmware2, "cpd", &error);
@@ -4872,7 +4876,11 @@ fu_firmware_builder_round_trip_func(void)
 		blob = fu_firmware_write(firmware1, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(blob);
-		ret = fu_firmware_parse(firmware3, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+		ret = fu_firmware_parse_bytes(firmware3,
+					      blob,
+					      0x0,
+					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      &error);
 		if (!ret)
 			g_prefix_error(&error, "%s: ", map[i].xml_fn);
 		g_assert_no_error(error);
@@ -5674,8 +5682,11 @@ fu_efi_lz77_decompressor_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(blob_tiano);
 	g_assert_cmpint(g_bytes_get_size(blob_tiano), ==, 144);
-	ret =
-	    fu_firmware_parse(lz77_decompressor_tiano, blob_tiano, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(lz77_decompressor_tiano,
+				      blob_tiano,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	blob_tiano2 = fu_firmware_get_bytes(lz77_decompressor_tiano, &error);
@@ -5690,10 +5701,11 @@ fu_efi_lz77_decompressor_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(blob_legacy);
 	g_assert_cmpint(g_bytes_get_size(blob_legacy), ==, 144);
-	ret = fu_firmware_parse(lz77_decompressor_legacy,
-				blob_tiano,
-				FWUPD_INSTALL_FLAG_NONE,
-				&error);
+	ret = fu_firmware_parse_bytes(lz77_decompressor_legacy,
+				      blob_tiano,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	blob_legacy2 = fu_firmware_get_bytes(lz77_decompressor_legacy, &error);

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -49,11 +49,11 @@ fu_usb_interface_parse_extra(FuUsbInterface *self, const guint8 *buf, gsize bufs
 	/* this is common to all descriptor types */
 	while (offset < bufsz) {
 		g_autoptr(FuUsbDescriptor) img = g_object_new(FU_TYPE_USB_DESCRIPTOR, NULL);
-		if (!fu_firmware_parse_full(FU_FIRMWARE(img),
-					    bytes,
-					    offset,
-					    FWUPD_INSTALL_FLAG_NONE,
-					    error))
+		if (!fu_firmware_parse_bytes(FU_FIRMWARE(img),
+					     bytes,
+					     offset,
+					     FWUPD_INSTALL_FLAG_NONE,
+					     error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
 			return FALSE;

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -160,10 +160,11 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		fw2 = fu_bytes_new_offset(payload, offset_tmp, payloadsz - offset_tmp, error);
 		if (fw2 == NULL)
 			return FALSE;
-		if (!fu_firmware_parse(firmware_coswid,
-				       fw2,
-				       flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
-				       error))
+		if (!fu_firmware_parse_bytes(firmware_coswid,
+					     fw2,
+					     0x0,
+					     flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(firmware, firmware_coswid, error))
 			return FALSE;

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -42,7 +42,7 @@ fu_acpi_phat_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **er
 		g_propagate_error(error, g_steal_pointer(&error_local));
 		return FALSE;
 	}
-	if (!fu_firmware_parse(phat, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(phat, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return FALSE;
 	str = fu_acpi_phat_to_report_string(FU_ACPI_PHAT(phat));
 	fu_plugin_add_report_metadata(plugin, "PHAT", str);

--- a/plugins/acpi-phat/fu-self-test.c
+++ b/plugins/acpi-phat/fu-self-test.c
@@ -26,10 +26,11 @@ fu_acpi_phat_parse_func(void)
 	blob = fu_bytes_get_contents(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(blob);
-	ret = fu_firmware_parse(phat,
-				blob,
-				FWUPD_INSTALL_FLAG_FORCE | FWUPD_INSTALL_FLAG_NO_SEARCH,
-				&error);
+	ret = fu_firmware_parse_bytes(phat,
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_FORCE | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_acpi_phat_to_report_string(FU_ACPI_PHAT(phat));

--- a/plugins/amd-kria/fu-amd-kria-device.c
+++ b/plugins/amd-kria/fu-amd-kria-device.c
@@ -172,7 +172,7 @@ fu_amd_kria_device_setup(FuDevice *device, GError **error)
 	/* parse the eeprom */
 	bytes = g_bytes_new(buf, bufsz);
 	firmware = fu_amd_kria_som_eeprom_new();
-	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 
 	/* build instance IDs from EEPROM data */

--- a/plugins/amd-kria/fu-amd-kria-plugin.c
+++ b/plugins/amd-kria/fu-amd-kria-plugin.c
@@ -43,7 +43,7 @@ fu_amd_kria_plugin_process_image(FuPlugin *plugin, FuDevice *dev, GError **error
 		return FALSE;
 	firmware = fu_amd_kria_image_firmware_new();
 
-	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 
 	fu_device_set_version(dev, fu_firmware_get_version(firmware));
@@ -64,7 +64,7 @@ fu_amd_kria_plugin_process_persistent(FuPlugin *plugin, FuDevice *dev, GError **
 		return FALSE;
 	firmware = fu_amd_kria_persistent_firmware_new();
 
-	if (!fu_firmware_parse(firmware, bytes, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 
 	if (fu_amd_kria_persistent_firmware_booted_image_a(

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -288,7 +288,7 @@ fu_bcm57xx_device_read_firmware(FuDevice *device, FuProgress *progress, GError *
 	fw = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return NULL;
 
 	/* remove images that will contain user-data */
@@ -349,7 +349,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	fw_old = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw_old == NULL)
 		return NULL;
-	if (!fu_firmware_parse(firmware, fw_old, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
+	if (!fu_firmware_parse_bytes(firmware, fw_old, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
 		g_prefix_error(error, "failed to parse existing firmware: ");
 		return NULL;
 	}

--- a/plugins/bcm57xx/fu-self-test.c
+++ b/plugins/bcm57xx/fu-self-test.c
@@ -84,7 +84,7 @@ fu_bcm57xx_firmware_talos_func(void)
 	blob = fu_bytes_get_contents(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(blob);
-	ret = fu_firmware_parse(firmware, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	images = fu_firmware_get_images(firmware);

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -109,7 +109,7 @@ fu_cfu_module_prepare_firmware(FuDevice *device,
 	blob_offer = fu_firmware_get_bytes(fw_offer, NULL);
 	if (blob_offer == NULL)
 		return NULL;
-	if (!fu_firmware_parse(offer, blob_offer, flags, error))
+	if (!fu_firmware_parse_bytes(offer, blob_offer, 0x0, flags, error))
 		return NULL;
 	fu_firmware_set_id(offer, FU_FIRMWARE_ID_HEADER);
 	fu_firmware_add_image(firmware, offer);
@@ -123,7 +123,7 @@ fu_cfu_module_prepare_firmware(FuDevice *device,
 	blob_payload = fu_firmware_get_bytes(fw_payload, NULL);
 	if (blob_payload == NULL)
 		return NULL;
-	if (!fu_firmware_parse(payload, blob_payload, flags, error))
+	if (!fu_firmware_parse_bytes(payload, blob_payload, 0x0, flags, error))
 		return NULL;
 	fu_firmware_set_id(payload, FU_FIRMWARE_ID_PAYLOAD);
 	fu_firmware_add_image(firmware, payload);

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -187,7 +187,11 @@ fu_dfu_csr_device_upload(FuDevice *device, FuProgress *progress, GError **error)
 		/* get the total size using the CSR header */
 		if (i == 0) {
 			g_autoptr(FuFirmware) firmware = fu_dfu_csr_firmware_new();
-			if (!fu_firmware_parse(firmware, chunk, FWUPD_INSTALL_FLAG_NONE, error))
+			if (!fu_firmware_parse_bytes(firmware,
+						     chunk,
+						     0x0,
+						     FWUPD_INSTALL_FLAG_NONE,
+						     error))
 				return NULL;
 			total_sz = fu_dfu_csr_firmware_get_total_sz(FU_DFU_CSR_FIRMWARE(firmware));
 		}

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -586,7 +586,7 @@ fu_genesys_gl32xx_device_read_firmware(FuDevice *device, FuProgress *progress, G
 	fw = fu_genesys_gl32xx_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
 
 	/* success */

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -214,7 +214,7 @@ fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 
 	/* parse as CPD */
-	if (!fu_firmware_parse(fw_cpd, blob_dataimg, flags, error))
+	if (!fu_firmware_parse_bytes(fw_cpd, blob_dataimg, 0x0, flags, error))
 		return FALSE;
 
 	/* get manifest */

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -548,7 +548,7 @@ fu_intel_usb4_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 	blob = g_bytes_new(buf, sizeof(buf));
-	if (!fu_firmware_parse(fw, blob, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_bytes(fw, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error)) {
 		g_prefix_error(error, "NVM parse error: ");
 		return FALSE;
 	}

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -338,7 +338,11 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 		fwupd_image_id =
 		    g_strdup_printf("%s_%s_bank%01u", board_name, bootloader_name, flash_area_id);
 
-		if (!fu_firmware_parse(image, blob, flags | FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+		if (!fu_firmware_parse_bytes(image,
+					     blob,
+					     0x0,
+					     flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     error))
 			return FALSE;
 
 		fu_firmware_set_id(image, fwupd_image_id);

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -294,7 +294,7 @@ fu_pxi_ble_device_check_support_report_id(FuPxiBleDevice *self, GError **error)
 
 	/* parse the descriptor, but use the defaults if it fails */
 	fw = g_bytes_new(rpt_desc.value, rpt_desc.size);
-	if (!fu_firmware_parse(descriptor, fw, FWUPD_INSTALL_FLAG_NONE, &error_local)) {
+	if (!fu_firmware_parse_bytes(descriptor, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, &error_local)) {
 		g_debug("failed to parse descriptor: %s", error_local->message);
 		return TRUE;
 	}

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -39,7 +39,7 @@ fu_pxi_firmware_xml_func(void)
 	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
 
 	/* ensure we can parse */
-	ret = fu_firmware_parse(firmware3, fw, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(firmware3, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -227,10 +227,11 @@ fu_redfish_plugin_discover_smbios_table(FuPlugin *plugin, GError **error)
 	for (guint i = 0; i < type42_tables->len; i++) {
 		GBytes *type42_blob = g_ptr_array_index(type42_tables, i);
 		g_autoptr(FuRedfishSmbios) smbios = fu_redfish_smbios_new();
-		if (!fu_firmware_parse(FU_FIRMWARE(smbios),
-				       type42_blob,
-				       FWUPD_INSTALL_FLAG_NO_SEARCH,
-				       error)) {
+		if (!fu_firmware_parse_bytes(FU_FIRMWARE(smbios),
+					     type42_blob,
+					     0x0,
+					     FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     error)) {
 			g_prefix_error(error, "failed to parse SMBIOS entry type 42: ");
 			return FALSE;
 		}

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -864,7 +864,7 @@ fu_steelseries_fizz_read_firmware_fs(FuDevice *device,
 
 	fu_dump_raw(G_LOG_DOMAIN, "Firmware", buf, size);
 	blob = g_bytes_new_take(g_steal_pointer(&buf), size);
-	if (!fu_firmware_parse(firmware, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return NULL;
 
 	/* success */

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -40,7 +40,7 @@ fu_test_synaprom_firmware_func(void)
 	g_assert_cmpint(sz, ==, 294);
 	g_assert_cmpint(buf[0], ==, 0x01);
 	g_assert_cmpint(buf[1], ==, 0x00);
-	ret = fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -524,7 +524,7 @@ fu_synaptics_vmm9_device_read_firmware(FuDevice *device, FuProgress *progress, G
 
 	/* parse */
 	fw = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
-	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
 
 	/* success */

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -82,7 +82,7 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 	 *   will compare 'image_id' in fu_firmware_get_image_by_id()
 	 *   e.g. 8278_otav1_bank0 */
 	image_id = g_strdup_printf("%s_%s_bank%01u", board_name, bootloader_name, i);
-	if (!fu_firmware_parse(image, blob, flags, error))
+	if (!fu_firmware_parse_bytes(image, blob, 0x0, flags, error))
 		return FALSE;
 	g_debug("image_id=%s", image_id);
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1068,7 +1068,11 @@ test_image_validation(ThunderboltTest *tt, gconstpointer user_data)
 	g_assert_nonnull(bad_data);
 
 	/* parse; should fail, bad image */
-	ret = fu_firmware_parse(firmware_bad, bad_data, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware_bad,
+				      bad_data,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_READ);
 	g_debug("expected image validation error [ctl]: %s", error->message);

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -139,10 +139,11 @@ fu_uefi_bootmgr_setup_bootnext_with_loadopt(FuEfivars *efivars,
 			g_debug("failed to get data for name %s: %s", name, error_local->message);
 			continue;
 		}
-		if (!fu_firmware_parse(FU_FIRMWARE(loadopt_tmp),
-				       loadopt_blob_tmp,
-				       FWUPD_INSTALL_FLAG_NONE,
-				       &error_local)) {
+		if (!fu_firmware_parse_bytes(FU_FIRMWARE(loadopt_tmp),
+					     loadopt_blob_tmp,
+					     0x0,
+					     FWUPD_INSTALL_FLAG_NONE,
+					     &error_local)) {
 			g_debug("%s -> load option was invalid: %s", name, error_local->message);
 			continue;
 		}
@@ -251,10 +252,11 @@ fu_uefi_bootmgr_shim_is_safe(FuEfivars *efivars, const gchar *source_shim, GErro
 	fu_csv_firmware_add_column_id(FU_CSV_FIRMWARE(current_sbatlevel), "$id");
 	fu_csv_firmware_add_column_id(FU_CSV_FIRMWARE(current_sbatlevel), "component_generation");
 	fu_csv_firmware_add_column_id(FU_CSV_FIRMWARE(current_sbatlevel), "date_stamp");
-	if (!fu_firmware_parse(current_sbatlevel,
-			       current_sbatlevel_bytes,
-			       FWUPD_INSTALL_FLAG_NONE,
-			       error)) {
+	if (!fu_firmware_parse_bytes(current_sbatlevel,
+				     current_sbatlevel_bytes,
+				     0x0,
+				     FWUPD_INSTALL_FLAG_NONE,
+				     error)) {
 		g_prefix_error(error, "failed to load SbatLevelRT: ");
 		return FALSE;
 	}

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -331,11 +331,11 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	g_autoptr(GOutputStream) ostream = NULL;
 
 	/* get screen dimensions */
-	if (!fu_firmware_parse_full(FU_FIRMWARE(bmp_image),
-				    blob,
-				    0x0,
-				    FWUPD_INSTALL_FLAG_NONE,
-				    error)) {
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(bmp_image),
+				     blob,
+				     0x0,
+				     FWUPD_INSTALL_FLAG_NONE,
+				     error)) {
 		g_prefix_error(error, "splash invalid: ");
 		return FALSE;
 	}

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -260,7 +260,7 @@ fu_uefi_device_load_update_info(FuUefiDevice *self, GError **error)
 	fw = fu_efivars_get_data_bytes(efivars, FU_EFIVARS_GUID_FWUPDATE, varname, NULL, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse(FU_FIRMWARE(info), fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(info), fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
 	return g_steal_pointer(&info);
 }

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -39,7 +39,7 @@ fu_dbxtool_get_siglist_system(FuContext *ctx, GError **error)
 					 error);
 	if (blob == NULL)
 		return NULL;
-	if (!fu_firmware_parse(dbx, blob, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(dbx, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return NULL;
 	return g_steal_pointer(&dbx);
 }
@@ -282,7 +282,11 @@ main(int argc, char *argv[])
 			g_printerr("%s: %s\n", _("Failed to load local dbx"), error->message);
 			return EXIT_FAILURE;
 		}
-		if (!fu_firmware_parse(dbx_update, blob, FWUPD_INSTALL_FLAG_NONE, &error)) {
+		if (!fu_firmware_parse_bytes(dbx_update,
+					     blob,
+					     0x0,
+					     FWUPD_INSTALL_FLAG_NONE,
+					     &error)) {
 			/* TRANSLATORS: could not parse file */
 			g_printerr("%s: %s\n", _("Failed to parse local dbx"), error->message);
 			return EXIT_FAILURE;

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -72,7 +72,7 @@ fu_uefi_dbx_device_set_version_number(FuDevice *device, GError **error)
 					     error);
 	if (dbx_blob == NULL)
 		return FALSE;
-	if (!fu_firmware_parse(dbx, dbx_blob, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(dbx, dbx_blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
 		return FALSE;
 
 	/* add the last checksum to the device */
@@ -144,7 +144,7 @@ fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 	    fu_efivars_get_data_bytes(efivars, FU_EFIVARS_GUID_EFI_GLOBAL, "KEK", NULL, error);
 	if (kek_blob == NULL)
 		return FALSE;
-	if (!fu_firmware_parse(kek, kek_blob, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(kek, kek_blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 	fu_device_add_instance_strup(device, "ARCH", EFI_MACHINE_TYPE_NAME);
 

--- a/plugins/uefi-pk/fu-uefi-pk-device.c
+++ b/plugins/uefi-pk/fu-uefi-pk-device.c
@@ -179,7 +179,7 @@ fu_uefi_pk_device_probe(FuDevice *device, GError **error)
 	pk_blob = fu_efivars_get_data_bytes(efivars, FU_EFIVARS_GUID_EFI_GLOBAL, "PK", NULL, error);
 	if (pk_blob == NULL)
 		return FALSE;
-	if (!fu_firmware_parse(pk, pk_blob, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_bytes(pk, pk_blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error)) {
 		g_prefix_error(error, "failed to parse PK: ");
 		return FALSE;
 	}

--- a/plugins/uefi-sbat/fu-uefi-sbat-device.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-device.c
@@ -229,7 +229,7 @@ fu_uefi_sbat_device_new(FuContext *ctx, GBytes *blob, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* copy the version across */
-	if (!fu_firmware_parse(firmware, blob, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
 	self = g_object_new(FU_TYPE_UEFI_SBAT_DEVICE, "context", ctx, NULL);
 	fu_device_set_version(FU_DEVICE(self), fu_firmware_get_version(firmware));

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -57,7 +57,7 @@ fu_uf2_device_probe_current_fw(FuDevice *device, GBytes *fw, GError **error)
 	g_autoptr(GBytes) fw_raw = NULL;
 
 	/* parse to get version */
-	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 	if (fu_firmware_get_version(firmware) != NULL)
 		fu_device_set_version(device, fu_firmware_get_version(firmware));
@@ -189,7 +189,7 @@ fu_uf2_device_read_firmware(FuDevice *device, FuProgress *progress, GError **err
 	fw = fu_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse(firmware, fw, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return NULL;
 
 	return g_steal_pointer(&firmware);

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -233,11 +233,11 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 		/* parse SREC file and add as image */
 		blob = g_bytes_new(helper->image_buffer->str, helper->image_buffer->len);
 		fu_srec_firmware_set_addr_min(FU_SREC_FIRMWARE(firmware_srec), hdr->addr);
-		if (!fu_firmware_parse_full(firmware_srec,
-					    blob,
-					    0x0,
-					    helper->flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
-					    error))
+		if (!fu_firmware_parse_bytes(firmware_srec,
+					     blob,
+					     0x0,
+					     helper->flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     error))
 			return FALSE;
 		fw_srec = fu_firmware_get_bytes(firmware_srec, error);
 		if (fw_srec == NULL)

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4700,7 +4700,11 @@ fu_plugin_composite_func(gconstpointer user_data)
 	    "firmware.bin",
 	    "world",
 	    NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	components = fu_cabinet_get_components(cabinet, &error);
@@ -5362,7 +5366,11 @@ fu_common_store_cab_func(void)
 	    "firmware.dfu.asc",
 	    "signature",
 	    NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5428,7 +5436,11 @@ fu_common_store_cab_artifact_func(void)
 	    "firmware.dfu.asc",
 	    "signature",
 	    NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet1), blob1, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet1),
+				      blob1,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5455,7 +5467,11 @@ fu_common_store_cab_artifact_func(void)
 				  "firmware.dfu.asc",
 				  "signature",
 				  NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet2), blob2, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet2),
+				      blob2,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5485,7 +5501,11 @@ fu_common_store_cab_artifact_func(void)
 	    "firmware.dfu.asc",
 	    "signature",
 	    NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet3), blob3, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet3),
+				      blob3,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5510,7 +5530,11 @@ fu_common_store_cab_artifact_func(void)
 			      "firmware.dfu.asc",
 			      "signature",
 			      NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet4), blob4, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet4),
+				      blob4,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }
@@ -5540,7 +5564,11 @@ fu_common_store_cab_unsigned_func(void)
 				 "firmware.bin",
 				 "world",
 				 NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5589,7 +5617,11 @@ fu_common_store_cab_sha256_func(void)
 	    "firmware.bin",
 	    "world",
 	    NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 }
@@ -5618,7 +5650,11 @@ fu_common_store_cab_folder_func(void)
 				 "lvfs\\firmware.bin",
 				 "world",
 				 NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -5649,7 +5685,11 @@ fu_common_store_cab_error_no_metadata_func(void)
 	g_autoptr(GError) error = NULL;
 
 	blob = fu_test_build_cab(FALSE, "foo.txt", "hello", "bar.txt", "world", NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -5677,7 +5717,11 @@ fu_common_store_cab_error_wrong_size_func(void)
 				 "firmware.bin",
 				 "world",
 				 NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -5703,7 +5747,11 @@ fu_common_store_cab_error_missing_file_func(void)
 				 "firmware.bin",
 				 "world",
 				 NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -5728,7 +5776,11 @@ fu_common_store_cab_error_size_func(void)
 				 "world",
 				 NULL);
 	fu_firmware_set_size_max(FU_FIRMWARE(cabinet), 123);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -5755,7 +5807,11 @@ fu_common_store_cab_error_wrong_checksum_func(void)
 				 "firmware.bin",
 				 "world",
 				 NULL);
-	ret = fu_firmware_parse(FU_FIRMWARE(cabinet), blob, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
+				      blob,
+				      0x0,
+				      FWUPD_INSTALL_FLAG_NONE,
+				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2982,7 +2982,7 @@ fu_util_firmware_build(FuUtilPrivate *priv, gchar **values, GError **error)
 
 	/* show what we wrote */
 	firmware_dst = g_object_new(gtype, NULL);
-	if (!fu_firmware_parse(firmware_dst, blob_dst, priv->flags, error))
+	if (!fu_firmware_parse_bytes(firmware_dst, blob_dst, 0x0, priv->flags, error))
 		return FALSE;
 	str = fu_firmware_to_string(firmware_dst);
 	fu_console_print_literal(priv->console, str);
@@ -4231,7 +4231,11 @@ fu_util_build_cabinet(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* sanity check JCat and XML MetaInfo files */
-	if (!fu_firmware_parse(FU_FIRMWARE(cab_file), cab_blob, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(cab_file),
+				     cab_blob,
+				     0x0,
+				     FWUPD_INSTALL_FLAG_NONE,
+				     error))
 		return FALSE;
 
 	return fu_bytes_set_contents(values[0], cab_blob, error);


### PR DESCRIPTION
This allows us to make bigger changes in the future to FuFirmware->parse() without aliasing the symbol in the docs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
