### PR TITLE
Simplify firmware loading

### DIFF
--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -117,7 +117,6 @@ fu_acpi_table_get_oem_revision(FuAcpiTable *self)
 static gboolean
 fu_acpi_table_parse(FuFirmware *firmware,
 		    GInputStream *stream,
-		    gsize offset,
 		    FwupdInstallFlags flags,
 		    GError **error)
 {
@@ -129,7 +128,7 @@ fu_acpi_table_parse(FuFirmware *firmware,
 	g_autoptr(FuStructAcpiTable) st = NULL;
 
 	/* parse */
-	st = fu_struct_acpi_table_parse_stream(stream, offset, error);
+	st = fu_struct_acpi_table_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	id = fu_struct_acpi_table_get_signature(st);

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -56,7 +56,6 @@ fu_archive_firmware_parse_cb(FuArchive *self,
 static gboolean
 fu_archive_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -528,12 +528,12 @@ fu_cab_firmware_parse_helper_new(GInputStream *stream, FwupdInstallFlags flags, 
 static gboolean
 fu_cab_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
 	FuCabFirmware *self = FU_CAB_FIRMWARE(firmware);
 	gsize off_cffile = 0;
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autoptr(GByteArray) st = NULL;
 	g_autoptr(FuCabFirmwareParseHelper) helper = NULL;

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -419,7 +419,6 @@ fu_cfu_offer_set_product_id(FuCfuOffer *self, guint16 product_id)
 static gboolean
 fu_cfu_offer_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {
@@ -431,7 +430,7 @@ fu_cfu_offer_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st = NULL;
 
 	/* parse */
-	st = fu_struct_cfu_offer_parse_stream(stream, offset, error);
+	st = fu_struct_cfu_offer_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	priv->segment_number = fu_struct_cfu_offer_get_segment_number(st);

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -32,10 +32,10 @@ G_DEFINE_TYPE(FuCfuPayload, fu_cfu_payload, FU_TYPE_FIRMWARE)
 static gboolean
 fu_cfu_payload_parse(FuFirmware *firmware,
 		     GInputStream *stream,
-		     gsize offset,
 		     FwupdInstallFlags flags,
 		     GError **error)
 {
+	gsize offset = 0;
 	gsize streamsz = 0;
 
 	/* process into chunks */

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -554,7 +554,6 @@ fu_coswid_firmware_free(void *ptr)
 static gboolean
 fu_coswid_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -566,7 +565,7 @@ fu_coswid_firmware_parse(FuFirmware *firmware,
 	g_autoptr(cbor_item_t) item = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
-	fw = fu_input_stream_read_bytes(stream, offset, G_MAXSIZE, error);
+	fw = fu_input_stream_read_bytes(stream, 0x0, G_MAXSIZE, error);
 	if (fw == NULL)
 		return FALSE;
 	item = cbor_load(g_bytes_get_data(fw, NULL), g_bytes_get_size(fw), &result);

--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -198,12 +198,11 @@ fu_csv_entry_parse_token_cb(GString *token, guint token_idx, gpointer user_data,
 static gboolean
 fu_csv_entry_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {
 	FuCsvEntry *self = FU_CSV_ENTRY(firmware);
-	return fu_strsplit_stream(stream, offset, ",", fu_csv_entry_parse_token_cb, self, error);
+	return fu_strsplit_stream(stream, 0x0, ",", fu_csv_entry_parse_token_cb, self, error);
 }
 
 static GByteArray *

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -178,12 +178,11 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 static gboolean
 fu_csv_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
 	FuCsvFirmware *self = FU_CSV_FIRMWARE(firmware);
-	return fu_strsplit_stream(stream, offset, "\n", fu_csv_firmware_parse_line_cb, self, error);
+	return fu_strsplit_stream(stream, 0x0, "\n", fu_csv_firmware_parse_line_cb, self, error);
 }
 
 static GByteArray *

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -272,7 +272,6 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 static gboolean
 fu_dfu_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -113,11 +113,11 @@ fu_dfuse_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_dfuse_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
 	FuDfuFirmware *dfu_firmware = FU_DFU_FIRMWARE(firmware);
+	gsize offset = 0;
 	gsize streamsz = 0;
 	guint8 targets = 0;
 	g_autoptr(GByteArray) st_hdr = NULL;

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -219,12 +219,12 @@ fu_edid_parse_descriptor(FuEdid *self, GInputStream *stream, gsize offset, GErro
 static gboolean
 fu_edid_parse(FuFirmware *firmware,
 	      GInputStream *stream,
-	      gsize offset,
 	      FwupdInstallFlags flags,
 	      GError **error)
 {
 	FuEdid *self = FU_EDID(firmware);
 	const guint8 *manu_id;
+	gsize offset = 0;
 	g_autofree gchar *pnp_id = NULL;
 	g_autoptr(GByteArray) st = NULL;
 

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -68,10 +68,10 @@ fu_efi_device_path_list_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdC
 static gboolean
 fu_efi_device_path_list_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {
+	gsize offset = 0;
 	gsize streamsz = 0;
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -72,7 +72,6 @@ fu_efi_file_hdr_checksum8(GBytes *blob)
 static gboolean
 fu_efi_file_parse(FuFirmware *firmware,
 		  GInputStream *stream,
-		  gsize offset,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
@@ -84,7 +83,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 	g_autoptr(GInputStream) partial_stream = NULL;
 
 	/* parse */
-	st = fu_struct_efi_file_parse_stream(stream, offset, error);
+	st = fu_struct_efi_file_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	priv->type = fu_struct_efi_file_get_type(st);
@@ -104,7 +103,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		g_byte_array_unref(st);
-		st = fu_struct_efi_file2_parse_stream(stream, offset, error);
+		st = fu_struct_efi_file2_parse_stream(stream, 0x0, error);
 		if (st == NULL)
 			return FALSE;
 		size = fu_struct_efi_file2_get_extended_size(st);

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -29,10 +29,10 @@ G_DEFINE_TYPE(FuEfiFilesystem, fu_efi_filesystem, FU_TYPE_FIRMWARE)
 static gboolean
 fu_efi_filesystem_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
+	gsize offset = 0;
 	gsize streamsz = 0;
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -93,7 +93,6 @@ fu_efi_hard_drive_device_path_add_json(FwupdCodec *codec,
 static gboolean
 fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    gsize offset,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {
@@ -101,7 +100,7 @@ fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st = NULL;
 
 	/* re-parse */
-	st = fu_struct_efi_hard_drive_device_path_parse_stream(stream, offset, error);
+	st = fu_struct_efi_hard_drive_device_path_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	self->partition_number = fu_struct_efi_hard_drive_device_path_get_partition_number(st);

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -239,11 +239,11 @@ fu_efi_load_option_parse_optional(FuEfiLoadOption *self,
 static gboolean
 fu_efi_load_option_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	FuEfiLoadOption *self = FU_EFI_LOAD_OPTION(firmware);
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autofree gchar *id = NULL;
 	g_autoptr(FuEfiDevicePathList) device_path_list = fu_efi_device_path_list_new();

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -587,7 +587,6 @@ fu_efi_lz77_decompressor_internal(FuEfiLz77DecompressHelper *helper,
 static gboolean
 fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
@@ -605,11 +604,11 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 	/* parse header */
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	st = fu_struct_efi_lz77_decompressor_header_parse_stream(stream, offset, error);
+	st = fu_struct_efi_lz77_decompressor_header_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	src_bufsz = fu_struct_efi_lz77_decompressor_header_get_src_size(st);
-	if (streamsz - offset < src_bufsz + st->len) {
+	if (streamsz < src_bufsz + st->len) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
@@ -645,7 +644,7 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 		};
 		g_autoptr(GError) error_local = NULL;
 
-		if (!g_seekable_seek(G_SEEKABLE(stream), offset + st->len, G_SEEK_SET, NULL, error))
+		if (!g_seekable_seek(G_SEEKABLE(stream), st->len, G_SEEK_SET, NULL, error))
 			return FALSE;
 		if (fu_efi_lz77_decompressor_internal(&helper,
 						      decompressor_versions[i],

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -248,12 +248,12 @@ fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse(FuFirmware *firmware,
 		     GInputStream *stream,
-		     gsize offset,
 		     FwupdInstallFlags flags,
 		     GError **error)
 {
 	FuEfiSection *self = FU_EFI_SECTION(firmware);
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
+	gsize offset = 0;
 	gsize streamsz = 0;
 	guint32 size;
 	g_autoptr(GByteArray) st = NULL;

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -212,11 +212,11 @@ fu_efi_signature_list_validate(FuFirmware *firmware,
 static gboolean
 fu_efi_signature_list_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
 	FuEfiSignatureList *self = FU_EFI_SIGNATURE_LIST(firmware);
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autofree gchar *version_str = NULL;
 

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -334,7 +334,6 @@ fu_fdt_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_fdt_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -346,7 +345,7 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* sanity check */
-	st_hdr = fu_struct_fdt_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_fdt_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -367,7 +366,7 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 	priv->cpuid = fu_struct_fdt_get_boot_cpuid_phys(st_hdr);
 	off_mem_rsvmap = fu_struct_fdt_get_off_mem_rsvmap(st_hdr);
 	if (off_mem_rsvmap != 0x0) {
-		if (!fu_fdt_firmware_parse_mem_rsvmap(self, stream, offset + off_mem_rsvmap, error))
+		if (!fu_fdt_firmware_parse_mem_rsvmap(self, stream, off_mem_rsvmap, error))
 			return FALSE;
 	}
 	if (fu_struct_fdt_get_last_comp_version(st_hdr) < FDT_LAST_COMP_VERSION) {
@@ -387,18 +386,18 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 		g_autoptr(GByteArray) dt_strings = NULL;
 		g_autoptr(GByteArray) dt_struct = NULL;
 		g_autoptr(GBytes) dt_struct_buf = NULL;
-		dt_strings = fu_input_stream_read_byte_array(
-		    stream,
-		    offset + fu_struct_fdt_get_off_dt_strings(st_hdr),
-		    fu_struct_fdt_get_size_dt_strings(st_hdr),
-		    error);
+		dt_strings =
+		    fu_input_stream_read_byte_array(stream,
+						    fu_struct_fdt_get_off_dt_strings(st_hdr),
+						    fu_struct_fdt_get_size_dt_strings(st_hdr),
+						    error);
 		if (dt_strings == NULL)
 			return FALSE;
-		dt_struct = fu_input_stream_read_byte_array(
-		    stream,
-		    offset + fu_struct_fdt_get_off_dt_struct(st_hdr),
-		    fu_struct_fdt_get_size_dt_struct(st_hdr),
-		    error);
+		dt_struct =
+		    fu_input_stream_read_byte_array(stream,
+						    fu_struct_fdt_get_off_dt_struct(st_hdr),
+						    fu_struct_fdt_get_size_dt_struct(st_hdr),
+						    error);
 		if (dt_struct == NULL)
 			return FALSE;
 		if (dt_struct->len != fu_struct_fdt_get_size_dt_struct(st_hdr)) {

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -59,14 +59,12 @@ struct _FuFirmwareClass {
 	GObjectClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	GByteArray *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	void (*export)(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode *bn);
 	gboolean (*tokenize)(FuFirmware *self,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*build)(FuFirmware *self, XbNode *n, GError **error) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -293,7 +293,6 @@ fu_fit_firmware_verify_configuration(FuFirmware *firmware,
 static gboolean
 fu_fit_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -304,8 +303,7 @@ fu_fit_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GPtrArray) img_cfgs_array = NULL;
 
 	/* FuFdtFirmware->parse */
-	if (!FU_FIRMWARE_CLASS(fu_fit_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+	if (!FU_FIRMWARE_CLASS(fu_fit_firmware_parent_class)->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* sanity check */

--- a/libfwupdplugin/fu-fmap-firmware.h
+++ b/libfwupdplugin/fu-fmap-firmware.h
@@ -16,11 +16,6 @@ G_DECLARE_DERIVABLE_TYPE(FuFmapFirmware, fu_fmap_firmware, FU, FMAP_FIRMWARE, Fu
 
 struct _FuFmapFirmwareClass {
 	FuFirmwareClass parent_class;
-	gboolean (*parse)(FuFirmware *self,
-			  GInputStream *stream,
-			  gsize offset,
-			  FwupdInstallFlags flags,
-			  GError **error);
 };
 
 FuFirmware *

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -52,10 +52,10 @@ fu_hid_descriptor_count_table_dupes(GPtrArray *table, FuHidReportItem *item)
 static gboolean
 fu_hid_descriptor_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autoptr(GPtrArray) table_state =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -30,10 +30,10 @@ G_DEFINE_TYPE(FuIfdBios, fu_ifd_bios, FU_TYPE_IFD_IMAGE)
 static gboolean
 fu_ifd_bios_parse(FuFirmware *firmware,
 		  GInputStream *stream,
-		  gsize offset,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
+	gsize offset = 0;
 	gsize streamsz = 0;
 	guint img_cnt = 0;
 

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -126,7 +126,6 @@ fu_ifd_firmware_fixup_stream(GInputStream *stream, GError **error)
 static gboolean
 fu_ifd_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -145,13 +145,13 @@ fu_ifwi_cpd_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuIfwiCpdFirmware *self = FU_IFWI_CPD_FIRMWARE(firmware);
 	FuIfwiCpdFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GByteArray) st_hdr = NULL;
+	gsize offset = 0;
 	guint32 num_of_entries;
 
 	/* other header fields */

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -46,11 +46,11 @@ fu_ifwi_fpt_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	guint32 num_of_entries;
+	gsize offset = 0;
 	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* sanity check */

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -232,24 +232,17 @@ fu_ihex_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_ihex_firmware_tokenize(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
 	FuIhexFirmware *self = FU_IHEX_FIRMWARE(firmware);
 	FuIhexFirmwareTokenHelper helper = {.self = self, .flags = flags};
-	return fu_strsplit_stream(stream,
-				  offset,
-				  "\n",
-				  fu_ihex_firmware_tokenize_cb,
-				  &helper,
-				  error);
+	return fu_strsplit_stream(stream, 0x0, "\n", fu_ihex_firmware_tokenize_cb, &helper, error);
 }
 
 static gboolean
 fu_ihex_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -86,12 +86,12 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 static gboolean
 fu_linear_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	FuLinearFirmware *self = FU_LINEAR_FIRMWARE(firmware);
 	FuLinearFirmwarePrivate *priv = GET_PRIVATE(self);
+	gsize offset = 0;
 	gsize streamsz = 0;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -116,7 +116,6 @@ fu_oprom_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_oprom_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
@@ -129,7 +128,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st_pci = NULL;
 
 	/* parse header */
-	st_hdr = fu_struct_oprom_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_oprom_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	priv->subsystem = fu_struct_oprom_get_subsystem(st_hdr);
@@ -147,7 +146,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* verify signature */
-	st_pci = fu_struct_oprom_pci_parse_stream(stream, offset + pci_header_offset, error);
+	st_pci = fu_struct_oprom_pci_parse_stream(stream, pci_header_offset, error);
 	if (st_pci == NULL)
 		return FALSE;
 	priv->vendor_id = fu_struct_oprom_pci_get_vendor_id(st_pci);
@@ -167,7 +166,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	if (expansion_header_offset != 0x0) {
 		g_autoptr(FuFirmware) img = NULL;
 		img = fu_firmware_new_from_gtypes(stream,
-						  offset + expansion_header_offset,
+						  expansion_header_offset,
 						  FWUPD_INSTALL_FLAG_NONE,
 						  error,
 						  FU_TYPE_IFWI_CPD_FIRMWARE,

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -201,13 +201,13 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 static gboolean
 fu_pefile_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	FuPefileFirmware *self = FU_PEFILE_FIRMWARE(firmware);
 	FuPefileFirmwarePrivate *priv = GET_PRIVATE(self);
 	guint32 cert_table_sz = 0;
+	gsize offset = 0;
 	gsize streamsz = 0;
 	gsize strtab_offset;
 	guint32 nr_sections;

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -71,19 +71,18 @@ fu_sbatlevel_section_add_entry(FuFirmware *firmware,
 static gboolean
 fu_sbatlevel_section_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	g_autoptr(GByteArray) st = NULL;
 
-	st = fu_struct_sbat_level_section_header_parse_stream(stream, offset, error);
+	st = fu_struct_sbat_level_section_header_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	if (!fu_sbatlevel_section_add_entry(
 		firmware,
 		stream,
-		offset + sizeof(guint32) + fu_struct_sbat_level_section_header_get_previous(st),
+		sizeof(guint32) + fu_struct_sbat_level_section_header_get_previous(st),
 		"previous",
 		0,
 		flags,
@@ -91,7 +90,7 @@ fu_sbatlevel_section_parse(FuFirmware *firmware,
 		return FALSE;
 	if (!fu_sbatlevel_section_add_entry(firmware,
 					    stream,
-					    offset + sizeof(guint32) +
+					    sizeof(guint32) +
 						fu_struct_sbat_level_section_header_get_latest(st),
 					    "latest",
 					    1,

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -326,13 +326,12 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 static gboolean
 fu_smbios_parse(FuFirmware *firmware,
 		GInputStream *stream,
-		gsize offset,
 		FwupdInstallFlags flags,
 		GError **error)
 {
 	FuSmbios *self = FU_SMBIOS(firmware);
 	g_autoptr(GBytes) fw = NULL;
-	fw = fu_input_stream_read_bytes(stream, offset, G_MAXSIZE, error);
+	fw = fu_input_stream_read_bytes(stream, 0x0, G_MAXSIZE, error);
 	if (fw == NULL)
 		return FALSE;
 	return fu_smbios_setup_from_data(self,

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -373,7 +373,6 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_srec_firmware_tokenize(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
@@ -381,7 +380,7 @@ fu_srec_firmware_tokenize(FuFirmware *firmware,
 	FuSrecFirmwareTokenHelper helper = {.self = self, .flags = flags, .got_eof = FALSE};
 
 	/* parse records */
-	if (!fu_strsplit_stream(stream, offset, "\n", fu_srec_firmware_tokenize_cb, &helper, error))
+	if (!fu_strsplit_stream(stream, 0x0, "\n", fu_srec_firmware_tokenize_cb, &helper, error))
 		return FALSE;
 
 	/* no EOF */
@@ -398,7 +397,6 @@ fu_srec_firmware_tokenize(FuFirmware *firmware,
 static gboolean
 fu_srec_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -119,7 +119,6 @@ fu_usb_bos_descriptor_get_capability(FuUsbBosDescriptor *self)
 static gboolean
 fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
@@ -128,11 +127,11 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 
 	/* FuUsbDescriptor */
 	if (!FU_FIRMWARE_CLASS(fu_usb_bos_descriptor_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* parse */
-	st = fu_usb_bos_hdr_parse_stream(stream, offset, error);
+	st = fu_usb_bos_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	self->bos_cap.bLength = fu_usb_bos_hdr_get_length(st);
@@ -144,7 +143,7 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 		g_autoptr(GInputStream) img_stream = NULL;
 
 		img_stream = fu_partial_input_stream_new(stream,
-							 offset + st->len,
+							 st->len,
 							 self->bos_cap.bLength - st->len,
 							 error);
 		if (img_stream == NULL)

--- a/libfwupdplugin/fu-usb-config-descriptor.c
+++ b/libfwupdplugin/fu-usb-config-descriptor.c
@@ -114,7 +114,6 @@ fu_usb_config_descriptor_get_configuration_value(FuUsbConfigDescriptor *self)
 static gboolean
 fu_usb_config_descriptor_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
@@ -122,7 +121,7 @@ fu_usb_config_descriptor_parse(FuFirmware *firmware,
 	g_autoptr(FuUsbDescriptorHdr) st = NULL;
 
 	/* parse */
-	st = fu_usb_descriptor_hdr_parse_stream(stream, offset, error);
+	st = fu_usb_descriptor_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	self->configuration = fu_usb_descriptor_hdr_get_configuration(st);

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -14,7 +14,6 @@ G_DEFINE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU_TYPE_FIRMWARE)
 static gboolean
 fu_usb_descriptor_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
@@ -23,11 +22,11 @@ fu_usb_descriptor_parse(FuFirmware *firmware,
 	g_autoptr(GInputStream) stream_partial = NULL;
 
 	/* parse */
-	st = fu_usb_base_hdr_parse_stream(stream, offset, error);
+	st = fu_usb_base_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	stream_partial =
-	    fu_partial_input_stream_new(stream, offset, fu_usb_base_hdr_get_length(st), error);
+	    fu_partial_input_stream_new(stream, 0x0, fu_usb_base_hdr_get_length(st), error);
 	if (stream_partial == NULL)
 		return FALSE;
 	if (!fu_firmware_set_stream(firmware, stream_partial, error))

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -157,7 +157,6 @@ fu_usb_device_ds20_sort_by_platform_ver_cb(gconstpointer a, gconstpointer b)
 static gboolean
 fu_usb_device_ds20_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/libfwupdplugin/fu-usb-endpoint.c
+++ b/libfwupdplugin/fu-usb-endpoint.c
@@ -190,7 +190,6 @@ fu_usb_endpoint_get_direction(FuUsbEndpoint *self)
 static gboolean
 fu_usb_endpoint_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -198,12 +197,11 @@ fu_usb_endpoint_parse(FuFirmware *firmware,
 	g_autoptr(FuUsbEndpointHdr) st = NULL;
 
 	/* FuUsbDescriptor */
-	if (!FU_FIRMWARE_CLASS(fu_usb_endpoint_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+	if (!FU_FIRMWARE_CLASS(fu_usb_endpoint_parent_class)->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* parse */
-	st = fu_usb_endpoint_hdr_parse_stream(stream, offset, error);
+	st = fu_usb_endpoint_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	self->endpoint_descriptor.bLength = fu_usb_endpoint_hdr_get_length(st);

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -348,7 +348,6 @@ fu_usb_interface_add_endpoint(FuUsbInterface *self, FuUsbEndpoint *endpoint)
 static gboolean
 fu_usb_interface_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
@@ -357,11 +356,11 @@ fu_usb_interface_parse(FuFirmware *firmware,
 
 	/* FuUsbDescriptor */
 	if (!FU_FIRMWARE_CLASS(fu_usb_interface_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* parse as proper interface with endpoints */
-	st = fu_usb_interface_hdr_parse_stream(stream, offset, error);
+	st = fu_usb_interface_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	self->iface.bLength = fu_usb_interface_hdr_get_length(st);
@@ -379,7 +378,7 @@ fu_usb_interface_parse(FuFirmware *firmware,
 	if (self->iface.bLength > st->len) {
 		g_autoptr(GByteArray) buf = NULL;
 		buf = fu_input_stream_read_byte_array(stream,
-						      offset + st->len,
+						      st->len,
 						      self->iface.bLength - st->len,
 						      error);
 		if (buf == NULL)

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -61,7 +61,6 @@ fu_uswid_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_uswid_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
@@ -73,7 +72,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) payload = NULL;
 
 	/* unpack */
-	st = fu_struct_uswid_parse_stream(stream, offset, error);
+	st = fu_struct_uswid_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 
@@ -120,7 +119,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		g_autoptr(GInputStream) istream1 = NULL;
 		g_autoptr(GInputStream) istream2 = NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB));
-		istream1 = fu_partial_input_stream_new(stream, offset + hdrsz, payloadsz, error);
+		istream1 = fu_partial_input_stream_new(stream, hdrsz, payloadsz, error);
 		if (istream1 == NULL)
 			return FALSE;
 		if (!g_seekable_seek(G_SEEKABLE(istream1), 0, G_SEEK_SET, NULL, error))
@@ -131,14 +130,14 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 	} else if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_LZMA) {
 		g_autoptr(GBytes) payload_tmp = NULL;
-		payload_tmp = fu_input_stream_read_bytes(stream, offset + hdrsz, payloadsz, error);
+		payload_tmp = fu_input_stream_read_bytes(stream, hdrsz, payloadsz, error);
 		if (payload_tmp == NULL)
 			return FALSE;
 		payload = fu_lzma_decompress_bytes(payload_tmp, error);
 		if (payload == NULL)
 			return FALSE;
 	} else if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_NONE) {
-		payload = fu_input_stream_read_bytes(stream, offset + hdrsz, payloadsz, error);
+		payload = fu_input_stream_read_bytes(stream, hdrsz, payloadsz, error);
 		if (payload == NULL)
 			return FALSE;
 	} else {

--- a/plugins/acpi-dmar/fu-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar.c
@@ -20,7 +20,6 @@ G_DEFINE_TYPE(FuAcpiDmar, fu_acpi_dmar, FU_TYPE_ACPI_TABLE)
 static gboolean
 fu_acpi_dmar_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {
@@ -29,7 +28,7 @@ fu_acpi_dmar_parse(FuFirmware *firmware,
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_dmar_parent_class)
-		 ->parse(FU_FIRMWARE(self), stream, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+		 ->parse(FU_FIRMWARE(self), stream, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 
 	/* check signature and read flags */

--- a/plugins/acpi-ivrs/fu-acpi-ivrs.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs.c
@@ -22,7 +22,6 @@ G_DEFINE_TYPE(FuAcpiIvrs, fu_acpi_ivrs, FU_TYPE_ACPI_TABLE)
 static gboolean
 fu_acpi_ivrs_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {
@@ -31,7 +30,7 @@ fu_acpi_ivrs_parse(FuFirmware *firmware,
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_ivrs_parent_class)
-		 ->parse(FU_FIRMWARE(self), stream, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+		 ->parse(FU_FIRMWARE(self), stream, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
 
 	/* check signature and read flags */

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -36,7 +36,6 @@ fu_acpi_phat_health_record_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -47,7 +46,7 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st = NULL;
 
 	/* sanity check record length */
-	st = fu_struct_acpi_phat_health_record_parse_stream(stream, offset, error);
+	st = fu_struct_acpi_phat_health_record_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	rcdlen = fu_struct_acpi_phat_health_record_get_rcdlen(st);
@@ -88,7 +87,7 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 		}
 
 		/* align and convert */
-		ubuf = fu_input_stream_read_bytes(stream, offset + 28, ubufsz, error);
+		ubuf = fu_input_stream_read_bytes(stream, 28, ubufsz, error);
 		if (ubuf == NULL)
 			return FALSE;
 		self->device_path = fu_utf16_to_utf8_bytes(ubuf, G_LITTLE_ENDIAN, error);

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -32,7 +32,6 @@ fu_acpi_phat_version_element_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 				   GInputStream *stream,
-				   gsize offset,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {
@@ -40,7 +39,7 @@ fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st = NULL;
 
 	/* unpack */
-	st = fu_struct_acpi_phat_version_element_parse_stream(stream, offset, error);
+	st = fu_struct_acpi_phat_version_element_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	fu_firmware_set_size(firmware, st->len);

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -20,10 +20,10 @@ G_DEFINE_TYPE(FuAcpiPhatVersionRecord, fu_acpi_phat_version_record, FU_TYPE_FIRM
 static gboolean
 fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  gsize offset,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {
+	gsize offset = 0;
 	guint32 record_count = 0;
 	g_autoptr(GByteArray) st = NULL;
 

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -98,7 +98,6 @@ fu_acpi_phat_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, 
 static gboolean
 fu_acpi_phat_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   gsize offset,
 		   FwupdInstallFlags flags,
 		   GError **error)
 {
@@ -114,7 +113,7 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	/* parse table */
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	if (!fu_input_stream_read_u32(stream, offset + 4, &length, G_LITTLE_ENDIAN, error))
+	if (!fu_input_stream_read_u32(stream, 4, &length, G_LITTLE_ENDIAN, error))
 		return FALSE;
 	if (streamsz < length) {
 		g_set_error(error,
@@ -129,7 +128,7 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	/* spec revision */
 	if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		guint8 revision = 0;
-		if (!fu_input_stream_read_u8(stream, offset + 8, &revision, error))
+		if (!fu_input_stream_read_u8(stream, 8, &revision, error))
 			return FALSE;
 		if (revision != FU_ACPI_PHAT_REVISION) {
 			g_set_error(error,
@@ -165,8 +164,8 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	if (!fu_input_stream_read_safe(stream,
 				       (guint8 *)oem_id,
 				       sizeof(oem_id),
-				       0x0,	    /* dst */
-				       offset + 10, /* src */
+				       0x0, /* dst */
+				       10,  /* src */
 				       sizeof(oem_id),
 				       error))
 		return FALSE;
@@ -177,19 +176,19 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	if (!fu_input_stream_read_safe(stream,
 				       (guint8 *)oem_table_id,
 				       sizeof(oem_table_id),
-				       0x0,	    /* dst */
-				       offset + 16, /* src */
+				       0x0, /* dst */
+				       16,  /* src */
 				       sizeof(oem_table_id),
 				       error))
 		return FALSE;
 	oem_table_id_safe = fu_strsafe((const gchar *)oem_table_id, sizeof(oem_table_id));
 	fu_firmware_set_id(firmware, oem_table_id_safe);
-	if (!fu_input_stream_read_u32(stream, offset + 24, &oem_revision, G_LITTLE_ENDIAN, error))
+	if (!fu_input_stream_read_u32(stream, 24, &oem_revision, G_LITTLE_ENDIAN, error))
 		return FALSE;
 	fu_firmware_set_version_raw(firmware, oem_revision);
 
 	/* platform telemetry records */
-	for (gsize offset_tmp = offset + 36; offset_tmp < length;) {
+	for (gsize offset_tmp = 36; offset_tmp < length;) {
 		if (!fu_acpi_phat_record_parse(firmware, stream, &offset_tmp, flags, error))
 			return FALSE;
 	}

--- a/plugins/algoltek-aux/fu-algoltek-aux-firmware.c
+++ b/plugins/algoltek-aux/fu-algoltek-aux-firmware.c
@@ -29,11 +29,11 @@ fu_algoltek_aux_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_algoltek_aux_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
 	const gchar *version;
+	gsize offset = 0;
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(GByteArray) st = NULL;

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -30,11 +30,11 @@ fu_algoltek_usb_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
 	const gchar *version;
+	gsize offset = 0;
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(GByteArray) st = NULL;

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
@@ -30,11 +30,11 @@ fu_algoltek_usbcr_firmware_export(FuFirmware *firmware,
 static gboolean
 fu_algoltek_usbcr_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
 	FuAlgoltekUsbcrFirmware *self = FU_ALGOLTEK_USBCR_FIRMWARE(firmware);
+	gsize offset = 0;
 	guint16 app_ver = 0;
 	guint16 emmc_support_ver = 0;
 	guint16 emmc_ver = 0;

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -265,7 +265,6 @@ fu_amd_gpu_atom_firmware_parse_config_filename(FuAmdGpuAtomFirmware *self,
 static gboolean
 fu_amd_gpu_atom_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
@@ -276,11 +275,11 @@ fu_amd_gpu_atom_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) blob = NULL;
 
 	if (!FU_FIRMWARE_CLASS(fu_amd_gpu_atom_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* atom rom image */
-	atom_image = fu_struct_atom_image_parse_stream(stream, offset, error);
+	atom_image = fu_struct_atom_image_parse_stream(stream, 0x0, error);
 	if (atom_image == NULL)
 		return FALSE;
 
@@ -288,12 +287,12 @@ fu_amd_gpu_atom_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_size(firmware, fu_struct_atom_image_get_size(atom_image) * 512);
 
 	/* atom rom header */
-	loc = fu_struct_atom_image_get_rom_loc(atom_image) + offset;
+	loc = fu_struct_atom_image_get_rom_loc(atom_image);
 	atom_rom = fu_struct_atom_rom21_header_parse_stream(stream, loc, error);
 	if (atom_rom == NULL)
 		return FALSE;
 
-	blob = fu_input_stream_read_bytes(stream, offset, G_MAXSIZE, error);
+	blob = fu_input_stream_read_bytes(stream, 0x0, G_MAXSIZE, error);
 	if (blob == NULL)
 		return FALSE;
 	if (!fu_amd_gpu_atom_firmware_parse_config_filename(self, blob, atom_rom, error))

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -191,7 +191,6 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 static gboolean
 fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/amd-kria/fu-amd-kria-image-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-image-firmware.c
@@ -25,7 +25,6 @@ G_DEFINE_TYPE(FuAmdKriaImageFirmware, fu_amd_kria_image_firmware, FU_TYPE_FIRMWA
 static gboolean
 fu_amd_kria_image_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -34,7 +33,7 @@ fu_amd_kria_image_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) fw = NULL;
 	g_autofree gchar *version = NULL;
 
-	fw = fu_input_stream_read_bytes(stream, offset + VERSION_OFFSET, VERSION_SIZE, error);
+	fw = fu_input_stream_read_bytes(stream, VERSION_OFFSET, VERSION_SIZE, error);
 	if (fw == NULL)
 		return FALSE;
 

--- a/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
@@ -24,14 +24,13 @@ G_DEFINE_TYPE(FuAmdKriaPersistentFirmware, fu_amd_kria_persistent_firmware, FU_T
 static gboolean
 fu_amd_kria_persistent_firmware_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      gsize offset,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {
 	FuAmdKriaPersistentFirmware *self = FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware);
 	g_autoptr(FuStructAmdKriaPersistReg) content = NULL;
 
-	content = fu_struct_amd_kria_persist_reg_parse_stream(stream, offset, error);
+	content = fu_struct_amd_kria_persist_reg_parse_stream(stream, 0x0, error);
 	if (content == NULL)
 		return FALSE;
 	self->last_booted = fu_struct_amd_kria_persist_reg_get_last_booted_img(content);

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -29,7 +29,6 @@ G_DEFINE_TYPE(FuAmdKriaSomEeprom, fu_amd_kria_som_eeprom, FU_TYPE_FIRMWARE)
 static gboolean
 fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -44,10 +43,10 @@ fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) fw = NULL;
 
 	/* parse IPMI common header */
-	common = fu_struct_ipmi_common_parse_stream(stream, offset, error);
+	common = fu_struct_ipmi_common_parse_stream(stream, 0x0, error);
 	if (common == NULL)
 		return FALSE;
-	board_offset = offset + fu_struct_ipmi_common_get_board_offset(common) * 8;
+	board_offset = fu_struct_ipmi_common_get_board_offset(common) * 8;
 
 	/* parse board info area */
 	board = fu_struct_board_info_parse_stream(stream, board_offset, error);

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -18,7 +18,6 @@ G_DEFINE_TYPE(FuAnalogixFirmware, fu_analogix_firmware, FU_TYPE_IHEX_FIRMWARE)
 static gboolean
 fu_analogix_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
@@ -36,7 +35,7 @@ fu_analogix_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) blob_stx = NULL;
 
 	/* convert to binary with FuIhexFirmware->parse */
-	if (!klass->parse(firmware, stream, offset, flags, error))
+	if (!klass->parse(firmware, stream, flags, error))
 		return FALSE;
 	blob = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (blob == NULL)

--- a/plugins/aver-hid/fu-aver-hid-firmware.c
+++ b/plugins/aver-hid/fu-aver-hid-firmware.c
@@ -33,7 +33,6 @@ fu_aver_hid_firmware_parse_archive_cb(FuArchive *self,
 static gboolean
 fu_aver_hid_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -30,7 +30,6 @@ fu_bcm57xx_dict_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -330,7 +330,6 @@ fu_bcm57xx_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -18,7 +18,6 @@ G_DEFINE_TYPE(FuBcm57xxStage1Image, fu_bcm57xx_stage1_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -18,7 +18,6 @@ G_DEFINE_TYPE(FuBcm57xxStage2Image, fu_bcm57xx_stage2_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage2_image_parse(FuFirmware *image,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -258,7 +258,6 @@ fu_ccgx_dmc_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
@@ -271,7 +270,7 @@ fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* parse */
-	st_hdr = fu_struct_ccgx_dmc_fwct_info_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_ccgx_dmc_fwct_info_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 
@@ -293,22 +292,18 @@ fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 		fu_firmware_set_version_raw(firmware, hdr_composite_version);
 
 	/* read fwct data */
-	self->fwct_blob = fu_input_stream_read_bytes(stream, offset, hdr_size, error);
+	self->fwct_blob = fu_input_stream_read_bytes(stream, 0x0, hdr_size, error);
 	if (self->fwct_blob == NULL)
 		return FALSE;
 
 	/* create custom meta binary */
-	if (!fu_input_stream_read_u16(stream,
-				      offset + hdr_size,
-				      &mdbufsz,
-				      G_LITTLE_ENDIAN,
-				      error)) {
+	if (!fu_input_stream_read_u16(stream, hdr_size, &mdbufsz, G_LITTLE_ENDIAN, error)) {
 		g_prefix_error(error, "failed to read metadata size: ");
 		return FALSE;
 	}
 	if (mdbufsz > 0) {
 		self->custom_meta_blob =
-		    fu_input_stream_read_bytes(stream, offset + hdr_size + 2, mdbufsz, error);
+		    fu_input_stream_read_bytes(stream, hdr_size + 2, mdbufsz, error);
 		if (self->custom_meta_blob == NULL)
 			return FALSE;
 	}

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -345,7 +345,6 @@ fu_ccgx_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_ccgx_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       gsize offset,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
@@ -353,7 +352,7 @@ fu_ccgx_firmware_parse(FuFirmware *firmware,
 	FuCcgxFirmwareTokenHelper helper = {.self = self, .flags = flags};
 
 	/* tokenize */
-	if (!fu_strsplit_stream(stream, offset, "\n", fu_ccgx_firmware_tokenize_cb, &helper, error))
+	if (!fu_strsplit_stream(stream, 0x0, "\n", fu_ccgx_firmware_tokenize_cb, &helper, error))
 		return FALSE;
 
 	/* address is first data entry */

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -70,16 +70,9 @@ fu_cros_ec_firmware_get_needed_sections(FuCrosEcFirmware *self, GError **error)
 	return g_steal_pointer(&needed_sections);
 }
 
-static gboolean
-fu_cros_ec_firmware_parse(FuFirmware *firmware,
-			  GInputStream *stream,
-			  gsize offset,
-			  FwupdInstallFlags flags,
-			  GError **error)
+gboolean
+fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error)
 {
-	FuCrosEcFirmware *self = FU_CROS_EC_FIRMWARE(firmware);
-	FuFirmware *fmap_firmware = FU_FIRMWARE(firmware);
-
 	for (gsize i = 0; i < self->sections->len; i++) {
 		gboolean rw = FALSE;
 		FuCrosEcFirmwareSection *section = g_ptr_array_index(self->sections, i);
@@ -106,13 +99,13 @@ fu_cros_ec_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 
-		img = fu_firmware_get_image_by_id(fmap_firmware, fmap_name, error);
+		img = fu_firmware_get_image_by_id(FU_FIRMWARE(self), fmap_name, error);
 		if (img == NULL) {
 			g_prefix_error(error, "%s image not found: ", fmap_name);
 			return FALSE;
 		}
 
-		fwid_img = fu_firmware_get_image_by_id(fmap_firmware, fmap_fwid_name, error);
+		fwid_img = fu_firmware_get_image_by_id(FU_FIRMWARE(self), fmap_fwid_name, error);
 		if (fwid_img == NULL) {
 			g_prefix_error(error, "%s image not found: ", fmap_fwid_name);
 			return FALSE;
@@ -159,7 +152,7 @@ fu_cros_ec_firmware_parse(FuFirmware *firmware,
 					       section->raw_version);
 				return FALSE;
 			}
-			fu_firmware_set_version(firmware, version_rw->triplet);
+			fu_firmware_set_version(FU_FIRMWARE(self), version_rw->triplet);
 		}
 	}
 
@@ -193,8 +186,6 @@ static void
 fu_cros_ec_firmware_class_init(FuCrosEcFirmwareClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	FuFmapFirmwareClass *firmware_class = FU_FMAP_FIRMWARE_CLASS(klass);
-	firmware_class->parse = fu_cros_ec_firmware_parse;
 	object_class->finalize = fu_cros_ec_firmware_finalize;
 }
 

--- a/plugins/cros-ec/fu-cros-ec-firmware.h
+++ b/plugins/cros-ec/fu-cros-ec-firmware.h
@@ -27,6 +27,8 @@ typedef struct {
 } FuCrosEcFirmwareSection;
 
 gboolean
+fu_cros_ec_firmware_ensure_version(FuCrosEcFirmware *self, GError **error);
+gboolean
 fu_cros_ec_firmware_pick_sections(FuCrosEcFirmware *self, guint32 writeable_offset, GError **error);
 GPtrArray *
 fu_cros_ec_firmware_get_needed_sections(FuCrosEcFirmware *self, GError **error);

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -867,15 +867,17 @@ fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 				       GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);
-	FuCrosEcFirmware *cros_ec_firmware = NULL;
 	g_autoptr(FuFirmware) firmware = fu_cros_ec_firmware_new();
 
 	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
 		return NULL;
-	cros_ec_firmware = FU_CROS_EC_FIRMWARE(firmware);
+	if (!fu_cros_ec_firmware_ensure_version(FU_CROS_EC_FIRMWARE(firmware), error))
+		return NULL;
 
 	/* pick sections */
-	if (!fu_cros_ec_firmware_pick_sections(cros_ec_firmware, self->writeable_offset, error)) {
+	if (!fu_cros_ec_firmware_pick_sections(FU_CROS_EC_FIRMWARE(firmware),
+					       self->writeable_offset,
+					       error)) {
 		g_prefix_error(error, "failed to pick sections: ");
 		return NULL;
 	}

--- a/plugins/dell-k2/fu-dell-k2-dpmux-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-dpmux-firmware.c
@@ -26,7 +26,6 @@ fu_dell_k2_dpmux_firmware_convert_version(FuFirmware *firmware, guint64 version_
 static gboolean
 fu_dell_k2_dpmux_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/dell-k2/fu-dell-k2-ilan-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-ilan-firmware.c
@@ -20,7 +20,6 @@ G_DEFINE_TYPE(FuDellK2IlanFirmware, fu_dell_k2_ilan_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_dell_k2_ilan_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {

--- a/plugins/dell-k2/fu-dell-k2-pd-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-pd-firmware.c
@@ -93,7 +93,6 @@ fu_dell_k2_pd_firmware_set_version(FuFirmware *firmware,
 static gboolean
 fu_dell_k2_pd_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {

--- a/plugins/dell-k2/fu-dell-k2-rtshub-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-rtshub-firmware.c
@@ -63,7 +63,6 @@ fu_dell_k2_rtshub_firmware_set_offset(GInputStream *stream,
 static gboolean
 fu_dell_k2_rtshub_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/dell-k2/fu-dell-k2-wtpd-firmware.c
+++ b/plugins/dell-k2/fu-dell-k2-wtpd-firmware.c
@@ -26,7 +26,6 @@ fu_dell_k2_wtpd_firmware_convert_version(FuFirmware *firmware, guint64 version_r
 static gboolean
 fu_dell_k2_wtpd_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       gsize offset,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {

--- a/plugins/dfu-csr/fu-dfu-csr-firmware.c
+++ b/plugins/dfu-csr/fu-dfu-csr-firmware.c
@@ -37,7 +37,6 @@ fu_dfu_csr_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_dfu_csr_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
@@ -45,7 +44,7 @@ fu_dfu_csr_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* parse file header */
-	st_hdr = fu_struct_dfu_csr_file_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_dfu_csr_file_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	self->total_sz = fu_struct_dfu_csr_file_get_file_len(st_hdr);

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -18,7 +18,6 @@ G_DEFINE_TYPE(FuEbitdoFirmware, fu_ebitdo_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_ebitdo_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -31,7 +30,7 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GInputStream) stream_payload = NULL;
 
 	/* check the file size */
-	st = fu_struct_ebitdo_hdr_parse_stream(stream, offset, error);
+	st = fu_struct_ebitdo_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -50,11 +50,11 @@ fu_elanfp_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elanfp_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
 	FuElanfpFirmware *self = FU_ELANFP_FIRMWARE(firmware);
+	gsize offset = 0;
 
 	/* file format version */
 	if (!fu_input_stream_read_u32(stream,

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -111,7 +111,6 @@ fu_elantp_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elantp_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {
@@ -123,7 +122,7 @@ fu_elantp_firmware_parse(FuFirmware *firmware,
 
 	/* presumably in words */
 	if (!fu_input_stream_read_u16(stream,
-				      offset + ETP_IAP_START_ADDR_WRDS * 2,
+				      ETP_IAP_START_ADDR_WRDS * 2,
 				      &iap_addr_wrds,
 				      G_LITTLE_ENDIAN,
 				      error))
@@ -140,7 +139,7 @@ fu_elantp_firmware_parse(FuFirmware *firmware,
 
 	/* read module ID */
 	if (!fu_input_stream_read_u16(stream,
-				      offset + self->iap_addr,
+				      self->iap_addr,
 				      &module_id_wrds,
 				      G_LITTLE_ENDIAN,
 				      error))
@@ -154,19 +153,19 @@ fu_elantp_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 	if (!fu_input_stream_read_u16(stream,
-				      offset + module_id_wrds * 2,
+				      module_id_wrds * 2,
 				      &self->module_id,
 				      G_LITTLE_ENDIAN,
 				      error))
 		return FALSE;
 	if (!fu_input_stream_read_u16(stream,
-				      offset + ETP_IC_TYPE_ADDR_WRDS * 2,
+				      ETP_IC_TYPE_ADDR_WRDS * 2,
 				      &self->ic_type,
 				      G_LITTLE_ENDIAN,
 				      error))
 		return FALSE;
 	if (!fu_input_stream_read_u16(stream,
-				      offset + ETP_IAP_VER_ADDR_WRDS * 2,
+				      ETP_IAP_VER_ADDR_WRDS * 2,
 				      &self->iap_ver,
 				      G_LITTLE_ENDIAN,
 				      error))
@@ -177,7 +176,7 @@ fu_elantp_firmware_parse(FuFirmware *firmware,
 
 	if (self->iap_ver <= 4) {
 		if (!fu_input_stream_read_u16(stream,
-					      offset + (self->iap_addr + 6),
+					      self->iap_addr + 6,
 					      &force_table_addr_wrds,
 					      G_LITTLE_ENDIAN,
 					      &error_local)) {
@@ -186,7 +185,7 @@ fu_elantp_firmware_parse(FuFirmware *firmware,
 		}
 	} else {
 		if (!fu_input_stream_read_u16(stream,
-					      offset + ETP_IAP_FORCETABLE_ADDR_V5 * 2,
+					      ETP_IAP_FORCETABLE_ADDR_V5 * 2,
 					      &force_table_addr_wrds,
 					      G_LITTLE_ENDIAN,
 					      &error_local)) {

--- a/plugins/elantp/fu-elantp-haptic-firmware.c
+++ b/plugins/elantp/fu-elantp-haptic-firmware.c
@@ -45,7 +45,6 @@ fu_elantp_haptic_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elantp_haptic_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {
@@ -57,13 +56,13 @@ fu_elantp_haptic_firmware_parse(FuFirmware *firmware,
 	guint8 tmp = 0;
 	g_autofree gchar *version_str = NULL;
 
-	if (!fu_input_stream_read_u8(stream, offset + 0x4, &tmp, error))
+	if (!fu_input_stream_read_u8(stream, 0x4, &tmp, error))
 		return FALSE;
 	v_m = tmp & 0xF;
 	v_s = (tmp & 0xF0) >> 4;
-	if (!fu_input_stream_read_u8(stream, offset + 0x5, &v_d, error))
+	if (!fu_input_stream_read_u8(stream, 0x5, &v_d, error))
 		return FALSE;
-	if (!fu_input_stream_read_u8(stream, offset + 0x6, &v_y, error))
+	if (!fu_input_stream_read_u8(stream, 0x6, &v_y, error))
 		return FALSE;
 	if (v_y == 0xFF || v_d == 0xFF || v_m == 0xF) {
 		g_set_error(error,

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -30,7 +30,6 @@ fu_ep963x_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ep963x_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/focalfp/fu-focalfp-firmware.c
+++ b/plugins/focalfp/fu-focalfp-firmware.c
@@ -55,7 +55,6 @@ fu_focalfp_firmware_compute_checksum_cb(const guint8 *buf,
 static gboolean
 fu_focalfp_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/plugins/fpc/fu-fpc-ff2-firmware.c
+++ b/plugins/fpc/fu-fpc-ff2-firmware.c
@@ -37,14 +37,13 @@ fu_fpc_ff2_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_fpc_ff2_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {
 	FuFpcFf2Firmware *self = FU_FPC_FF2_FIRMWARE(firmware);
 	g_autoptr(FuStructFpcFf2Hdr) st_hdr = NULL;
 
-	st_hdr = fu_struct_fpc_ff2_hdr_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_fpc_ff2_hdr_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	self->blocks_num = fu_struct_fpc_ff2_hdr_get_blocks_num(st_hdr);

--- a/plugins/fresco-pd/fu-fresco-pd-firmware.c
+++ b/plugins/fresco-pd/fu-fresco-pd-firmware.c
@@ -33,7 +33,6 @@ fu_fresco_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_fresco_pd_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
@@ -22,7 +22,6 @@ G_DEFINE_TYPE(FuGenesysGl32xxFirmware, fu_genesys_gl32xx_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -19,7 +19,6 @@ G_DEFINE_TYPE(FuGenesysScalerFirmware, fu_genesys_scaler_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -50,7 +50,6 @@ fu_genesys_usbhub_codesign_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
 					  GInputStream *stream,
-					  gsize offset,
 					  FwupdInstallFlags flags,
 					  GError **error)
 {
@@ -60,19 +59,15 @@ fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	code_size = streamsz - offset;
+	code_size = streamsz;
 	if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_RSA_SIZE) {
-		if (!fu_struct_genesys_fw_codesign_info_rsa_validate_stream(stream,
-									    offset,
-									    error)) {
+		if (!fu_struct_genesys_fw_codesign_info_rsa_validate_stream(stream, 0x0, error)) {
 			g_prefix_error(error, "not valid for codesign: ");
 			return FALSE;
 		}
 		self->codesign = FU_GENESYS_FW_CODESIGN_RSA;
 	} else if (code_size == FU_STRUCT_GENESYS_FW_CODESIGN_INFO_ECDSA_SIZE) {
-		if (!fu_struct_genesys_fw_codesign_info_ecdsa_validate_stream(stream,
-									      offset,
-									      error)) {
+		if (!fu_struct_genesys_fw_codesign_info_ecdsa_validate_stream(stream, 0x0, error)) {
 			g_prefix_error(error, "not valid for codesign: ");
 			return FALSE;
 		}
@@ -81,8 +76,7 @@ fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
-			    "unknown file format at 0x%x:0x%x",
-			    (guint)offset,
+			    "unknown file format of size 0x%x",
 			    (guint)streamsz);
 		return FALSE;
 	}

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -29,7 +29,6 @@ fu_genesys_usbhub_dev_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     gsize offset,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {
@@ -41,11 +40,11 @@ fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_alignment(firmware, FU_FIRMWARE_ALIGNMENT_1K);
 
 	/* truncate to correct size */
-	if (!fu_genesys_usbhub_firmware_calculate_size(stream, offset, &code_size, error)) {
+	if (!fu_genesys_usbhub_firmware_calculate_size(stream, &code_size, error)) {
 		g_prefix_error(error, "not valid for dev: ");
 		return FALSE;
 	}
-	stream_trunc = fu_partial_input_stream_new(stream, offset, code_size, error);
+	stream_trunc = fu_partial_input_stream_new(stream, 0x0, code_size, error);
 	if (stream_trunc == NULL)
 		return FALSE;
 	if (!fu_firmware_set_stream(firmware, stream_trunc, error))

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -25,7 +25,6 @@ G_DEFINE_TYPE(FuGenesysUsbhubFirmware, fu_genesys_usbhub_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 				    GInputStream *stream,
-				    gsize offset,
 				    GError **error)
 {
 	guint8 project_ic_type[6];
@@ -36,7 +35,7 @@ fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 		project_ic_type,
 		sizeof(project_ic_type),
 		0, /* dst */
-		offset + GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3523 +
+		GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3523 +
 		    FU_STRUCT_GENESYS_TS_STATIC_OFFSET_MASK_PROJECT_IC_TYPE, /* src */
 		sizeof(project_ic_type),
 		error))
@@ -60,7 +59,7 @@ fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 		project_ic_type,
 		sizeof(project_ic_type),
 		0, /* dst */
-		offset + GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3590 +
+		GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3590 +
 		    FU_STRUCT_GENESYS_TS_STATIC_OFFSET_MASK_PROJECT_IC_TYPE, /* src */
 		sizeof(project_ic_type),
 		error))
@@ -78,7 +77,7 @@ fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 		project_ic_type,
 		sizeof(project_ic_type),
 		0, /* dst */
-		offset + GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3525 +
+		GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3525 +
 		    FU_STRUCT_GENESYS_TS_STATIC_OFFSET_MASK_PROJECT_IC_TYPE, /* src */
 		sizeof(project_ic_type),
 		error))
@@ -96,7 +95,7 @@ fu_genesys_usbhub_firmware_get_chip(FuGenesysUsbhubFirmware *self,
 		project_ic_type,
 		sizeof(project_ic_type),
 		0, /* dst */
-		offset + GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3525_V2 +
+		GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3525_V2 +
 		    FU_STRUCT_GENESYS_TS_STATIC_OFFSET_MASK_PROJECT_IC_TYPE, /* src */
 		sizeof(project_ic_type),
 		error))
@@ -160,15 +159,11 @@ fu_genesys_usbhub_firmware_verify_checksum(GInputStream *stream, GError **error)
 
 gboolean
 fu_genesys_usbhub_firmware_calculate_size(GInputStream *stream,
-					  gsize offset,
 					  gsize *size,
 					  GError **error)
 {
 	guint8 kbs = 0;
-	if (!fu_input_stream_read_u8(stream,
-				     offset + GENESYS_USBHUB_CODE_SIZE_OFFSET,
-				     &kbs,
-				     error)) {
+	if (!fu_input_stream_read_u8(stream, GENESYS_USBHUB_CODE_SIZE_OFFSET, &kbs, error)) {
 		g_prefix_error(error, "failed to get codesize: ");
 		return FALSE;
 	}
@@ -220,18 +215,18 @@ fu_genesys_usbhub_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
 	FuGenesysUsbhubFirmware *self = FU_GENESYS_USBHUB_FIRMWARE(firmware);
 	gsize code_size = 0;
+	gsize offset = 0;
 	gsize streamsz = 0;
 	guint32 static_ts_offset = 0;
 	g_autoptr(GInputStream) stream_trunc = NULL;
 
 	/* get chip */
-	if (!fu_genesys_usbhub_firmware_get_chip(self, stream, offset, error)) {
+	if (!fu_genesys_usbhub_firmware_get_chip(self, stream, error)) {
 		g_prefix_error(error, "failed to get chip: ");
 		return FALSE;
 	}
@@ -278,7 +273,6 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 	case ISP_MODEL_HUB_GL3523: {
 		if (self->chip.revision == 50) {
 			if (!fu_genesys_usbhub_firmware_calculate_size(stream,
-								       offset,
 								       &code_size,
 								       error))
 				return FALSE;
@@ -289,7 +283,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 	}
 	case ISP_MODEL_HUB_GL3590:
 	case ISP_MODEL_HUB_GL3525: {
-		if (!fu_genesys_usbhub_firmware_calculate_size(stream, offset, &code_size, error))
+		if (!fu_genesys_usbhub_firmware_calculate_size(stream, &code_size, error))
 			return FALSE;
 		break;
 	}

--- a/plugins/genesys/fu-genesys-usbhub-firmware.h
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.h
@@ -21,7 +21,6 @@ gboolean
 fu_genesys_usbhub_firmware_verify_checksum(GInputStream *stream, GError **error);
 gboolean
 fu_genesys_usbhub_firmware_calculate_size(GInputStream *stream,
-					  gsize offset,
 					  gsize *size,
 					  GError **error);
 gboolean

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -29,7 +29,6 @@ fu_genesys_usbhub_pd_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    gsize offset,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {
@@ -41,11 +40,11 @@ fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_alignment(firmware, FU_FIRMWARE_ALIGNMENT_1K);
 
 	/* truncate to correct size */
-	if (!fu_genesys_usbhub_firmware_calculate_size(stream, offset, &code_size, error)) {
+	if (!fu_genesys_usbhub_firmware_calculate_size(stream, &code_size, error)) {
 		g_prefix_error(error, "not valid for pd: ");
 		return FALSE;
 	}
-	stream_trunc = fu_partial_input_stream_new(stream, offset, code_size, error);
+	stream_trunc = fu_partial_input_stream_new(stream, 0x0, code_size, error);
 	if (stream_trunc == NULL)
 		return FALSE;
 	if (!fu_firmware_set_stream(firmware, stream_trunc, error))

--- a/plugins/hailuck/fu-hailuck-kbd-firmware.c
+++ b/plugins/hailuck/fu-hailuck-kbd-firmware.c
@@ -17,7 +17,6 @@ G_DEFINE_TYPE(FuHailuckKbdFirmware, fu_hailuck_kbd_firmware, FU_TYPE_IHEX_FIRMWA
 static gboolean
 fu_hailuck_kbd_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -192,7 +192,6 @@ fu_igsc_aux_firmware_parse_extension(FuIgscAuxFirmware *self, FuFirmware *fw, GE
 static gboolean
 fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
@@ -204,7 +203,7 @@ fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 
 	/* FuIfwiFptFirmware->parse */
 	if (!FU_FIRMWARE_CLASS(fu_igsc_aux_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* parse data section */

--- a/plugins/intel-gsc/fu-igsc-code-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-code-firmware.c
@@ -54,7 +54,6 @@ fu_igsc_code_firmware_parse_imgi(FuIgscCodeFirmware *self, GInputStream *stream,
 static gboolean
 fu_igsc_code_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
@@ -80,7 +79,7 @@ fu_igsc_code_firmware_parse(FuFirmware *firmware,
 
 	/* FuIfwiFptFirmware->parse */
 	if (!FU_FIRMWARE_CLASS(fu_igsc_code_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	stream_info = fu_firmware_get_image_by_idx_stream(FU_FIRMWARE(self),

--- a/plugins/intel-gsc/fu-igsc-oprom-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-firmware.c
@@ -145,7 +145,6 @@ fu_igsc_oprom_firmware_parse_extension(FuIgscOpromFirmware *self, FuFirmware *fw
 static gboolean
 fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -155,7 +154,7 @@ fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 
 	/* FuOpromFirmware->parse */
 	if (!FU_FIRMWARE_CLASS(fu_igsc_oprom_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	/* check sanity */

--- a/plugins/jabra-file/fu-jabra-file-firmware.c
+++ b/plugins/jabra-file/fu-jabra-file-firmware.c
@@ -65,7 +65,6 @@ fu_jabra_file_firmware_parse_info(FuJabraFileFirmware *self, XbSilo *silo, GErro
 static gboolean
 fu_jabra_file_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -84,7 +83,7 @@ fu_jabra_file_firmware_parse(FuFirmware *firmware,
 				       FU_ARCHIVE_FORMAT_ZIP);
 	fu_archive_firmware_set_compression(FU_ARCHIVE_FIRMWARE(firmware_archive),
 					    FU_ARCHIVE_COMPRESSION_NONE);
-	if (!fu_firmware_parse_stream(firmware_archive, stream, offset, flags, error))
+	if (!fu_firmware_parse_stream(firmware_archive, stream, 0x0, flags, error))
 		return FALSE;
 
 	img_xml = fu_archive_firmware_get_image_fnmatch(FU_ARCHIVE_FIRMWARE(firmware_archive),

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -98,7 +98,6 @@ fu_jabra_gnp_firmware_parse_info(FuJabraGnpFirmware *self, XbSilo *silo, GError 
 static gboolean
 fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
@@ -116,7 +115,7 @@ fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
 				       FU_ARCHIVE_FORMAT_ZIP);
 	fu_archive_firmware_set_compression(FU_ARCHIVE_FIRMWARE(firmware_archive),
 					    FU_ARCHIVE_COMPRESSION_NONE);
-	if (!fu_firmware_parse_stream(firmware_archive, stream, offset, flags, error))
+	if (!fu_firmware_parse_stream(firmware_archive, stream, 0x0, flags, error))
 		return FALSE;
 
 	/* parse the XML metadata */

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -221,7 +221,6 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 static gboolean
 fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  gsize offset,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -187,7 +187,6 @@ fu_kinetic_dp_secure_firmware_parse_app_fw(FuKineticDpSecureFirmware *self,
 static gboolean
 fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    gsize offset,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -38,7 +38,6 @@ fu_legion_hid2_firmware_get_version(FuFirmware *firmware)
 static gboolean
 fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
@@ -122,7 +122,6 @@ fu_logitech_tap_touch_firmware_calculate_basic_cb(const guint8 *buf,
 static gboolean
 fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     gsize offset,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
@@ -25,7 +25,6 @@ G_DEFINE_TYPE(FuMediatekScalerFirmware, fu_mediatek_scaler_firmware, FU_TYPE_FIR
 static gboolean
 fu_mediatek_scaler_firmware_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  gsize offset,
 				  FwupdInstallFlags flags,
 				  GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -215,7 +215,6 @@ fu_nordic_hid_archive_parse_file_get_flash_area_id(JsonObject *obj,
 static gboolean
 fu_nordic_hid_archive_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -110,12 +110,11 @@ fu_nordic_hid_firmware_b0_read_fwinfo(FuFirmware *firmware, GInputStream *stream
 static gboolean
 fu_nordic_hid_firmware_b0_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_b0_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 	return fu_nordic_hid_firmware_b0_read_fwinfo(firmware, stream, error);
 }

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -124,12 +124,11 @@ fu_nordic_hid_firmware_mcuboot_validate(FuFirmware *firmware, GInputStream *stre
 static gboolean
 fu_nordic_hid_firmware_mcuboot_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     gsize offset,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_mcuboot_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 	return fu_nordic_hid_firmware_mcuboot_validate(firmware, stream, error);
 }

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -41,7 +41,6 @@ fu_nordic_hid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kin
 static gboolean
 fu_nordic_hid_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {

--- a/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
@@ -28,7 +28,6 @@ fu_parade_usbhub_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_parade_usbhub_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -96,7 +96,6 @@ fu_pxi_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_pxi_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
@@ -54,7 +54,6 @@ fu_qc_s5gen2_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
@@ -66,7 +65,7 @@ fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) hdr = NULL;
 
 	/* FIXME: deal with encrypted? */
-	hdr = fu_struct_qc_fw_update_hdr_parse_stream(stream, offset, error);
+	hdr = fu_struct_qc_fw_update_hdr_parse_stream(stream, 0x0, error);
 	if (hdr == NULL)
 		return FALSE;
 

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -267,18 +267,18 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
 static gboolean
 fu_redfish_smbios_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			gsize offset,
 			FwupdInstallFlags flags,
 			GError **error)
 {
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autoptr(GByteArray) st = NULL;
 
 	/* check size */
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	if (streamsz < 0x09 + offset) {
+	if (streamsz < 0x09) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -18,7 +18,6 @@ G_DEFINE_TYPE(FuSteelseriesFirmware, fu_steelseries_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_steelseries_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -22,7 +22,6 @@ G_DEFINE_TYPE(FuSynapticsCapeHidFirmware,
 static gboolean
 fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     gsize offset,
 				     FwupdInstallFlags flags,
 				     GError **error)
 {
@@ -46,7 +45,7 @@ fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* unpack */
-	st = fu_struct_synaptics_cape_hid_hdr_parse_stream(stream, offset, error);
+	st = fu_struct_synaptics_cape_hid_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	fu_synaptics_cape_firmware_set_vid(FU_SYNAPTICS_CAPE_FIRMWARE(self),

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -22,7 +22,6 @@ G_DEFINE_TYPE(FuSynapticsCapeSnglFirmware,
 static gboolean
 fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      gsize offset,
 				      FwupdInstallFlags flags,
 				      GError **error)
 {
@@ -51,7 +50,7 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* unpack */
-	st = fu_struct_synaptics_cape_sngl_hdr_parse_stream(stream, offset, error);
+	st = fu_struct_synaptics_cape_sngl_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
 	if (fu_struct_synaptics_cape_sngl_hdr_get_file_size(st) != streamsz) {

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -154,7 +154,6 @@ fu_synaptics_cxaudio_firmware_avoid_badblocks(GPtrArray *badblocks, GPtrArray *r
 static gboolean
 fu_synaptics_cxaudio_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    gsize offset,
 				    FwupdInstallFlags flags,
 				    GError **error)
 {

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -78,7 +78,6 @@ fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self,
 static gboolean
 fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {
@@ -87,7 +86,7 @@ fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 
 	/* if device family not specified by caller, try to get from firmware file */
 	if (self->family == FU_SYNAPTICS_MST_FAMILY_UNKNOWN) {
-		if (!fu_synaptics_mst_firmware_detect_family(self, stream, offset, error))
+		if (!fu_synaptics_mst_firmware_detect_family(self, stream, 0x0, error))
 			return FALSE;
 	}
 
@@ -112,7 +111,7 @@ fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 			    fu_synaptics_mst_family_to_string(self->family));
 		return FALSE;
 	}
-	if (!fu_input_stream_read_u16(stream, offset + addr, &self->board_id, G_BIG_ENDIAN, error))
+	if (!fu_input_stream_read_u16(stream, addr, &self->board_id, G_BIG_ENDIAN, error))
 		return FALSE;
 
 	/* success */

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -50,11 +50,11 @@ fu_synaprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 static gboolean
 fu_synaprom_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   gsize offset,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);
+	gsize offset = 0;
 	gsize streamsz = 0;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -398,7 +398,6 @@ fu_synaptics_rmi_firmware_parse_v0x(FuFirmware *firmware, GInputStream *stream, 
 static gboolean
 fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				gsize offset,
 				FwupdInstallFlags flags,
 				GError **error)
 {
@@ -409,13 +408,13 @@ fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GBytes) fw = NULL;
 
 	/* maybe stream later */
-	fw = fu_input_stream_read_bytes(stream, offset, G_MAXSIZE, error);
+	fw = fu_input_stream_read_bytes(stream, 0x0, G_MAXSIZE, error);
 	if (fw == NULL)
 		return FALSE;
 	buf = g_bytes_get_data(fw, &bufsz);
 
 	/* sanity check */
-	st_img = fu_struct_rmi_img_parse_stream(stream, offset, error);
+	st_img = fu_struct_rmi_img_parse_stream(stream, 0x0, error);
 	if (st_img == NULL)
 		return FALSE;
 	if (bufsz % 2 != 0) {

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
@@ -45,7 +45,6 @@ fu_synaptics_vmm9_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_synaptics_vmm9_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -57,7 +56,7 @@ fu_synaptics_vmm9_firmware_parse(FuFirmware *firmware,
 	g_autofree gchar *version = NULL;
 
 	/* verify header */
-	st_hdr = fu_struct_synaptics_vmm9_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_synaptics_vmm9_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -112,7 +112,6 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 static gboolean
 fu_telink_dfu_archive_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -30,11 +30,11 @@ fu_ti_tps6598x_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      gsize offset,
 			      FwupdInstallFlags flags,
 			      GError **error)
 {
 	guint8 verbuf[3] = {0x0};
+	gsize offset = 0;
 	gsize streamsz = 0;
 	g_autofree gchar *version_str = NULL;
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();

--- a/plugins/uefi-capsule/fu-bitmap-image.c
+++ b/plugins/uefi-capsule/fu-bitmap-image.c
@@ -28,7 +28,6 @@ fu_bitmap_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_bitmap_image_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -36,13 +35,13 @@ fu_bitmap_image_parse(FuFirmware *firmware,
 	g_autoptr(FuStructBitmapFileHeader) st_file = NULL;
 	g_autoptr(FuStructBitmapInfoHeader) st_info = NULL;
 
-	st_file = fu_struct_bitmap_file_header_parse_stream(stream, offset, error);
+	st_file = fu_struct_bitmap_file_header_parse_stream(stream, 0x0, error);
 	if (st_file == NULL) {
 		g_prefix_error(error, "image is corrupt: ");
 		return FALSE;
 	}
 	fu_firmware_set_size(firmware, fu_struct_bitmap_file_header_get_size(st_file));
-	st_info = fu_struct_bitmap_info_header_parse_stream(stream, offset + st_file->len, error);
+	st_info = fu_struct_bitmap_info_header_parse_stream(stream, st_file->len, error);
 	if (st_info == NULL) {
 		g_prefix_error(error, "header is corrupt: ");
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -142,7 +142,6 @@ fu_uefi_update_info_write(FuFirmware *firmware, GError **error)
 static gboolean
 fu_uefi_update_info_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  gsize offset,
 			  FwupdInstallFlags flags,
 			  GError **error)
 {

--- a/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
@@ -17,7 +17,6 @@ G_DEFINE_TYPE(FuUefiSbatFirmware, fu_uefi_sbat_firmware, FU_TYPE_CSV_FIRMWARE)
 static gboolean
 fu_uefi_sbat_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    gsize offset,
 			    FwupdInstallFlags flags,
 			    GError **error)
 {
@@ -29,7 +28,7 @@ fu_uefi_sbat_firmware_parse(FuFirmware *firmware,
 
 	/* FuCsvFirmware->parse */
 	if (!FU_FIRMWARE_CLASS(fu_uefi_sbat_firmware_parent_class)
-		 ->parse(firmware, stream, offset, flags, error))
+		 ->parse(firmware, stream, flags, error))
 		return FALSE;
 
 	imgs = fu_firmware_get_images(firmware);

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -41,7 +41,6 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	st = fu_struct_uf2_parse(fu_chunk_get_data(chk),
 				 fu_chunk_get_data_sz(chk),
 				 0, /* offset */
-
 				 error);
 	if (st == NULL)
 		return FALSE;
@@ -170,7 +169,6 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 static gboolean
 fu_uf2_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -180,7 +178,7 @@ fu_uf2_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* read in fixed sized chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, offset, 512, error);
+	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 512, error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -56,7 +56,6 @@ fu_{{vendor_example}}_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_{{vendor_example}}_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 gsize offset,
 				 FwupdInstallFlags flags,
 				 GError **error)
 {
@@ -64,7 +63,7 @@ fu_{{vendor_example}}_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st_hdr = NULL;
 
 	/* TODO: parse firmware into images */
-	st_hdr = fu_struct_{{vendor_example}}_hdr_parse_stream(stream, offset, error);
+	st_hdr = fu_struct_{{vendor_example}}_hdr_parse_stream(stream, 0x0, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	self->start_addr = 0x1234;

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -37,7 +37,6 @@ fu_vli_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 static gboolean
 fu_vli_pd_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 gsize offset,
 			 FwupdInstallFlags flags,
 			 GError **error)
 {

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -44,7 +44,6 @@ fu_vli_usbhub_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags,
 static gboolean
 fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     gsize offset,
 			     FwupdInstallFlags flags,
 			     GError **error)
 {
@@ -58,7 +57,7 @@ fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 	g_autoptr(GByteArray) st = NULL;
 
 	/* map into header */
-	st = fu_struct_vli_usbhub_hdr_parse_stream(stream, offset, error);
+	st = fu_struct_vli_usbhub_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL) {
 		g_prefix_error(error, "failed to read header: ");
 		return FALSE;

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -266,7 +266,6 @@ fu_wac_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_wac_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      gsize offset,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
@@ -279,7 +278,7 @@ fu_wac_firmware_parse(FuFirmware *firmware,
 					   .images_cnt = 0};
 
 	/* tokenize */
-	if (!fu_strsplit_stream(stream, offset, "\n", fu_wac_firmware_tokenize_cb, &helper, error))
+	if (!fu_strsplit_stream(stream, 0x0, "\n", fu_wac_firmware_tokenize_cb, &helper, error))
 		return FALSE;
 
 	/* verify data is complete */

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -862,7 +862,6 @@ fu_cabinet_sign(FuCabinet *self,
 static gboolean
 fu_cabinet_parse(FuFirmware *firmware,
 		 GInputStream *stream,
-		 gsize offset,
 		 FwupdInstallFlags flags,
 		 GError **error)
 {
@@ -879,7 +878,7 @@ fu_cabinet_parse(FuFirmware *firmware,
 	/* decompress and calculate container hashes */
 	if (stream != NULL) {
 		if (!FU_FIRMWARE_CLASS(fu_cabinet_parent_class)
-			 ->parse(firmware, stream, offset, flags, error))
+			 ->parse(firmware, stream, flags, error))
 			return FALSE;
 		self->container_checksum =
 		    fu_firmware_get_checksum(firmware, G_CHECKSUM_SHA1, error);


### PR DESCRIPTION
Remove the offset from `FuFirmware->tokenize()` and `FuFirmware->parse()` -- out of 128 superclasses only 59 were using it and only 25 were actually using it *correctly*.

Rather that adding masses of code to fix up the ~80% of plugins doing it wrong, just remove the feature altogether now that FuPartialStream exists.

We're already creating the FuInputStream with the offset, so just use that in the superclass with no additional overhead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
