### PR TITLE
Save the emulation-tag devices to the database rather than the config file

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -106,7 +106,6 @@ fwupd_modify_config_opts=(
 	'BlockedFirmware'
 	'DisabledDevices'
 	'DisabledPlugins'
-	'EmulatedDevices'
 	'EspLocation'
 	'EnumerateAllDevices'
 	'HostBkc'
@@ -436,7 +435,7 @@ _fwupdmgr()
 				;;
 			ApprovedFirmware|BlockedFirmware)
 				;;
-			DisabledDevices|EmulatedDevices)
+			DisabledDevices)
 				_show_device_ids
 				;;
 			DisabledPlugins)

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -100,7 +100,6 @@ fwupd_modify_config_opts=(
 	'BlockedFirmware'
 	'DisabledDevices'
 	'DisabledPlugins'
-	'EmulatedDevices'
 	'EspLocation'
 	'EnumerateAllDevices'
 	'HostBkc'
@@ -369,7 +368,7 @@ _fwupdtool()
 				;;
 			ApprovedFirmware|BlockedFirmware)
 				;;
-			DisabledDevices|EmulatedDevices)
+			DisabledDevices)
 				_show_device_ids
 				;;
 			DisabledPlugins)

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -46,13 +46,6 @@ The `[fwupd]` section can contain the following parameters:
 
   Allow blocking specific devices by their GUID, using semicolons as delimiter.
 
-**EmulatedDevices={{EmulatedDevices}}**
-
-  Allow adding specific devices by their device ID, using semicolons as delimiter.
-
-  This config option is useful to build emulations of "internal" devices which typically cannot be
-  hotplugged.
-
 **DisabledPlugins={{DisabledPlugins}}**
 
   Allow blocking specific plugins by name.

--- a/libfwupd/fwupd-request.c
+++ b/libfwupd/fwupd-request.c
@@ -401,6 +401,8 @@ fwupd_request_get_message(FwupdRequest *self)
 			return "Press unlock on the device.";
 		if (g_strcmp0(priv->id, FWUPD_REQUEST_ID_DO_NOT_POWER_OFF) == 0)
 			return "Do not turn off your computer or remove the AC adaptor.";
+		if (g_strcmp0(priv->id, FWUPD_REQUEST_ID_RESTART_DAEMON) == 0)
+			return "Please restart the fwupd service.";
 	}
 
 	/* unknown */

--- a/libfwupd/fwupd-request.h
+++ b/libfwupd/fwupd-request.h
@@ -131,6 +131,16 @@ typedef enum {
 #define FWUPD_REQUEST_ID_REPLUG_POWER "org.freedesktop.fwupd.replug-power"
 
 /**
+ * FWUPD_REQUEST_ID_RESTART_DAEMON:
+ *
+ * Show the user a message that they need to restart the daemon, e.g.
+ * "Please restart the fwupd service."
+ *
+ * Since 2.0.1
+ */
+#define FWUPD_REQUEST_ID_RESTART_DAEMON "org.freedesktop.fwupd.restart-daemon"
+
+/**
  * FwupdRequestFlags:
  *
  * Flags used to represent request attributes

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -174,7 +174,6 @@ fu_config_migrate_keyfile(FuConfig *self)
 			  {"fwupd", "ArchiveSizeMax", "0"},
 			  {"fwupd", "BlockedFirmware", NULL},
 			  {"fwupd", "DisabledDevices", NULL},
-			  {"fwupd", "EmulatedDevices", NULL},
 			  {"fwupd", "EnumerateAllDevices", NULL},
 			  {"fwupd", "EspLocation", NULL},
 			  {"fwupd", "HostBkc", NULL},

--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -259,7 +259,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.emulation-load</annotate>
   </action>
@@ -271,7 +271,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.emulation-load</annotate>
   </action>

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -15,7 +15,6 @@
 struct _FuEngineConfig {
 	FuConfig parent_instance;
 	GPtrArray *disabled_devices;  /* (element-type utf-8) */
-	GPtrArray *emulated_devices;  /* (element-type utf-8) */
 	GPtrArray *disabled_plugins;  /* (element-type utf-8) */
 	GPtrArray *approved_firmware; /* (element-type utf-8) */
 	GPtrArray *blocked_firmware;  /* (element-type utf-8) */
@@ -115,7 +114,6 @@ fu_engine_config_reload(FuEngineConfig *self)
 	g_auto(GStrv) approved_firmware = NULL;
 	g_auto(GStrv) blocked_firmware = NULL;
 	g_auto(GStrv) disabled_devices = NULL;
-	g_auto(GStrv) emulated_devices = NULL;
 	g_auto(GStrv) plugins = NULL;
 	g_auto(GStrv) report_specs = NULL;
 	g_auto(GStrv) uids = NULL;
@@ -143,14 +141,6 @@ fu_engine_config_reload(FuEngineConfig *self)
 			g_strdelimit(plugin_name, "-", '_');
 			g_ptr_array_add(self->disabled_plugins, g_steal_pointer(&plugin_name));
 		}
-	}
-
-	/* get emulated devices */
-	g_ptr_array_set_size(self->emulated_devices, 0);
-	emulated_devices = fu_config_get_value_strv(FU_CONFIG(self), "fwupd", "EmulatedDevices");
-	if (emulated_devices != NULL) {
-		for (guint i = 0; emulated_devices[i] != NULL; i++)
-			g_ptr_array_add(self->emulated_devices, g_strdup(emulated_devices[i]));
 	}
 
 	/* get approved firmware */
@@ -251,13 +241,6 @@ fu_engine_config_get_disabled_devices(FuEngineConfig *self)
 {
 	g_return_val_if_fail(FU_IS_ENGINE_CONFIG(self), NULL);
 	return self->disabled_devices;
-}
-
-GPtrArray *
-fu_engine_config_get_emulated_devices(FuEngineConfig *self)
-{
-	g_return_val_if_fail(FU_IS_ENGINE_CONFIG(self), NULL);
-	return self->emulated_devices;
 }
 
 GArray *
@@ -411,7 +394,6 @@ fu_engine_config_init(FuEngineConfig *self)
 	g_autofree gchar *archive_size_max_default = fu_engine_config_archive_size_max_default();
 	self->disabled_devices = g_ptr_array_new_with_free_func(g_free);
 	self->disabled_plugins = g_ptr_array_new_with_free_func(g_free);
-	self->emulated_devices = g_ptr_array_new_with_free_func(g_free);
 	self->approved_firmware = g_ptr_array_new_with_free_func(g_free);
 	self->blocked_firmware = g_ptr_array_new_with_free_func(g_free);
 	self->trusted_uids = g_array_new(FALSE, FALSE, sizeof(guint64));
@@ -425,7 +407,6 @@ fu_engine_config_init(FuEngineConfig *self)
 	fu_engine_config_set_default(self, "ArchiveSizeMax", archive_size_max_default);
 	fu_engine_config_set_default(self, "BlockedFirmware", NULL);
 	fu_engine_config_set_default(self, "DisabledDevices", NULL);
-	fu_engine_config_set_default(self, "EmulatedDevices", NULL);
 	fu_engine_config_set_default(self, "DisabledPlugins", "");
 	fu_engine_config_set_default(self, "EnumerateAllDevices", "false");
 	fu_engine_config_set_default(self, "EspLocation", NULL);
@@ -454,7 +435,6 @@ fu_engine_config_finalize(GObject *obj)
 
 	g_ptr_array_unref(self->disabled_devices);
 	g_ptr_array_unref(self->disabled_plugins);
-	g_ptr_array_unref(self->emulated_devices);
 	g_ptr_array_unref(self->approved_firmware);
 	g_ptr_array_unref(self->blocked_firmware);
 	g_ptr_array_unref(self->uri_schemes);

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -23,8 +23,6 @@ GPtrArray *
 fu_engine_config_get_disabled_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_engine_config_get_disabled_plugins(FuEngineConfig *self) G_GNUC_NON_NULL(1);
-GPtrArray *
-fu_engine_config_get_emulated_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GArray *
 fu_engine_config_get_trusted_uids(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 GPtrArray *

--- a/src/fu-history.h
+++ b/src/fu-history.h
@@ -57,3 +57,13 @@ fu_history_add_security_attribute(FuHistory *self,
 				  GError **error) G_GNUC_NON_NULL(1, 2, 3);
 GPtrArray *
 fu_history_get_security_attrs(FuHistory *self, guint limit, GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_history_add_emulation_tag(FuHistory *self, const gchar *device_id, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_history_remove_emulation_tag(FuHistory *self, const gchar *device_id, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_history_has_emulation_tag(FuHistory *self, const gchar *device_id, GError **error)
+    G_GNUC_NON_NULL(1);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -4439,13 +4439,13 @@ static void
 fu_history_func(gconstpointer user_data)
 {
 	FuTest *self = (FuTest *)user_data;
-	GError *error = NULL;
 	GPtrArray *checksums;
 	gboolean ret;
 	FuDevice *device;
 	FuRelease *release;
 	g_autoptr(FuDevice) device_found = NULL;
 	g_autoptr(FuHistory) history = NULL;
+	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) approved_firmware = NULL;
 	g_autofree gchar *dirname = NULL;
 	g_autofree gchar *filename = NULL;
@@ -4569,6 +4569,26 @@ fu_history_func(gconstpointer user_data)
 	g_assert_cmpint(approved_firmware->len, ==, 2);
 	g_assert_cmpstr(g_ptr_array_index(approved_firmware, 0), ==, "foo");
 	g_assert_cmpstr(g_ptr_array_index(approved_firmware, 1), ==, "bar");
+
+	/* emulation-tag */
+	ret = fu_history_add_emulation_tag(history, "id", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_history_has_emulation_tag(history, "id", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_history_has_emulation_tag(history, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_history_remove_emulation_tag(history, "id", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_history_remove_emulation_tag(history, "id", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_history_has_emulation_tag(history, "id", &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_false(ret);
 }
 
 static GBytes *


### PR DESCRIPTION
This also simplifies loading the daemon -- rather than having an in-memory hashtable of IDs *and* a config file array, we can instead use the database like a database and only have one codepath for internal and hotplugged devices.

The tagged-for-emulation device ID is also not the kind of thing an admin would want to set anyway.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
