### PR TITLE
Add Polkit authentication action for quitting the daemon

### DIFF
--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -13,6 +13,17 @@
   <vendor_url>https://github.com/fwupd/fwupd</vendor_url>
   <icon_name>application-x-firmware</icon_name>
 
+  <action id="org.freedesktop.fwupd.quit">
+    <description>Stop the fwupd service</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to stop the firmware update service</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.freedesktop.fwupd.update-internal-trusted">
     <description>Install signed system firmware</description>
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->


### PR DESCRIPTION
This lets the GUI restart the daemon to automatically tag for emulation internal firmware devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
