### PR TITLE
trivial: subprojects: bump the libxmlb version to 0.3.20

### DIFF
--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.3.19
+revision = 0.3.20


### PR DESCRIPTION
This will make subprojected builds like snap pick up the new release.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
