### PR TITLE
Use 'fu-common-linux.c' when compiling for android

### DIFF
--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -170,7 +170,7 @@ fwupdplugin_src = [
   'fu-volume.c', # fuzzing
 ]
 
-if host_machine.system() == 'linux'
+if host_machine.system() in ['linux', 'android']
   fwupdplugin_src += 'fu-common-linux.c' # fuzzing
   fwupdplugin_src += 'fu-linux-efivars.c'
 elif host_machine.system() == 'freebsd'


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Currently cross compiling for android gives undefined symbols. This reuses the linux ones.