### PR TITLE
Add json-glib wrap file to override libjcat

### DIFF
--- a/subprojects/json-glib.wrap
+++ b/subprojects/json-glib.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+directory = json-glib
+url = https://gitlab.gnome.org/GNOME/json-glib.git
+revision = 1.10.0
+
+[provide]
+dependency_names = json-glib-1.0


### PR DESCRIPTION
Currently building using the libjcat and json-glib-1.0 subprojects

```bash
meson setup _build --force-fallback-for json-glib-1.0,libjcat -Djson-glib:documentation=disabled
```
will fail with
```
Dependency json-glib-1.0 found: NO found 1.5.1 but need: '>= 1.6.0' (cached)
```

This is because libjcat includes a wrap file for json-glib `1.5.1` but fwupd specifies `1.6.0`.

This solves the issue by adding a wrap file pulling in the most recent version. An alternative option would be bumping the libjcat wrap file to `1.6.0`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
