### PR TITLE
Save the usb.ids and pci.ids name in the quirk database

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -899,10 +899,11 @@ static void
 fu_context_lookup_quirk_by_id_iter_cb(FuQuirks *self,
 				      const gchar *key,
 				      const gchar *value,
+				      FuContextQuirkSource source,
 				      gpointer user_data)
 {
 	FuContextQuirkLookupHelper *helper = (FuContextQuirkLookupHelper *)user_data;
-	helper->iter_cb(helper->self, key, value, helper->user_data);
+	helper->iter_cb(helper->self, key, value, source, helper->user_data);
 }
 
 /**
@@ -975,7 +976,11 @@ fu_context_housekeeping(FuContext *self)
 typedef gboolean (*FuContextHwidsSetupFunc)(FuContext *self, FuHwids *hwids, GError **error);
 
 static void
-fu_context_hwid_quirk_cb(FuContext *self, const gchar *key, const gchar *value, gpointer user_data)
+fu_context_hwid_quirk_cb(FuContext *self,
+			 const gchar *key,
+			 const gchar *value,
+			 FuContextQuirkSource source,
+			 gpointer user_data)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
 	if (value != NULL) {

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -27,10 +27,43 @@ struct _FuContextClass {
 };
 
 /**
+ * FuContextQuirkSource:
+ *
+ * The source of the quirk data, ordered by how good the data is.
+ **/
+typedef enum {
+	/**
+	 * FU_CONTEXT_QUIRK_SOURCE_DEVICE:
+	 *
+	 * From the device itself, perhaps a USB descriptor.
+	 *
+	 * Since: 2.0.2
+	 **/
+	FU_CONTEXT_QUIRK_SOURCE_DEVICE,
+	/**
+	 * FU_CONTEXT_QUIRK_SOURCE_FILE:
+	 *
+	 * From an internal `.quirk` file.
+	 *
+	 * Since: 2.0.2
+	 **/
+	FU_CONTEXT_QUIRK_SOURCE_FILE,
+	/**
+	 * FU_CONTEXT_QUIRK_SOURCE_DB:
+	 *
+	 * From the database, populated from `usb.ids` and `pci.ids`.
+	 *
+	 * Since: 2.0.2
+	 **/
+	FU_CONTEXT_QUIRK_SOURCE_DB,
+} FuContextQuirkSource;
+
+/**
  * FuContextLookupIter:
  * @self: a #FuContext
  * @key: a key
  * @value: a value
+ * @source: a #FuContextQuirkSource, e.g. %FU_CONTEXT_QUIRK_SOURCE_DB
  * @user_data: user data
  *
  * The context lookup iteration callback.
@@ -38,6 +71,7 @@ struct _FuContextClass {
 typedef void (*FuContextLookupIter)(FuContext *self,
 				    const gchar *key,
 				    const gchar *value,
+				    FuContextQuirkSource source,
 				    gpointer user_data);
 
 /**

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -56,6 +56,14 @@ typedef enum {
 	 * Since: 2.0.2
 	 **/
 	FU_CONTEXT_QUIRK_SOURCE_DB,
+	/**
+	 * FU_CONTEXT_QUIRK_SOURCE_FALLBACK:
+	 *
+	 * A good fallback, perhaps from the PCI class information.
+	 *
+	 * Since: 2.0.2
+	 **/
+	FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
 } FuContextQuirkSource;
 
 /**

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -56,8 +56,11 @@ fu_device_get_request_cnt(FuDevice *self, FwupdRequestKind request_kind) G_GNUC_
 void
 fu_device_set_progress(FuDevice *self, FuProgress *progress) G_GNUC_NON_NULL(1);
 gboolean
-fu_device_set_quirk_kv(FuDevice *self, const gchar *key, const gchar *value, GError **error)
-    G_GNUC_NON_NULL(1, 2, 3);
+fu_device_set_quirk_kv(FuDevice *self,
+		       const gchar *key,
+		       const gchar *value,
+		       FuContextQuirkSource source,
+		       GError **error) G_GNUC_NON_NULL(1, 2, 3);
 void
 fu_device_set_specialized_gtype(FuDevice *self, GType gtype) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -1802,6 +1802,9 @@ fu_device_set_quirk_kv(FuDevice *self,
 	}
 	if (g_strcmp0(key, FU_QUIRKS_ICON) == 0) {
 		g_auto(GStrv) sections = g_strsplit(value, ",", -1);
+		if (fu_device_get_icons(self)->len > 0 &&
+		    source >= FU_CONTEXT_QUIRK_SOURCE_FALLBACK)
+			return TRUE;
 		for (guint i = 0; sections[i] != NULL; i++)
 			fu_device_add_icon(self, sections[i]);
 		return TRUE;

--- a/libfwupdplugin/fu-pci-device.c
+++ b/libfwupdplugin/fu-pci-device.c
@@ -8,7 +8,9 @@
 
 #include "config.h"
 
+#include "fu-device-private.h"
 #include "fu-pci-device.h"
+#include "fu-quirks.h"
 #include "fu-string.h"
 
 /**
@@ -265,7 +267,6 @@ fu_pci_device_probe(FuDevice *device, GError **error)
 		if (version != NULL) {
 			fu_device_set_version(device, version);
 			fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PLAIN);
-			fu_device_add_icon(FU_DEVICE(self), "video-display");
 		}
 	}
 
@@ -375,6 +376,231 @@ fu_pci_device_probe(FuDevice *device, GError **error)
 }
 
 static void
+fu_pci_device_set_quirks_fallback(FuPciDevice *self, guint16 base)
+{
+	if (base == FU_PCI_DEVICE_BASE_CLS_MASS_STORAGE) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Mass Storage Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "drive-harddisk-solidstate",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_NETWORK) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Network Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "network-wired",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_DISPLAY) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Display Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "video-display",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_MULTIMEDIA) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Multimedia Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "audio-card",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_MEMORY) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Memory Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "drive-harddisk-solidstate",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_BRIDGE) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Bridge Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "dock",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_SIMPLE_COMMUNICATION) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Simple Communication Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "network-wired",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_BASE) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Base Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_INPUT) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Input Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_DOCKING) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Docking Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "dock",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_PROCESSORS) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Processor Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_SERIAL_BUS) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Serial Bus Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_WIRELESS) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Wireless Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "network-wireless",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_INTELLIGENT_IO) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Intelligent I/O Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_SATELLITE) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Satellite Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_ENCRYPTION) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Encryption Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "auth-fingerprint",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_SIGNAL_PROCESSING) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Signal Processing Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_ACCELERATOR) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Accelerator Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_ICON,
+				       "gpu",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+	if (base == FU_PCI_DEVICE_BASE_CLS_NON_ESSENTIAL) {
+		fu_device_set_quirk_kv(FU_DEVICE(self),
+				       FU_QUIRKS_NAME,
+				       "Non-essential Device",
+				       FU_CONTEXT_QUIRK_SOURCE_FALLBACK,
+				       NULL);
+		return;
+	}
+}
+
+static void
+fu_pci_device_probe_complete(FuDevice *device)
+{
+	FuPciDevice *self = FU_PCI_DEVICE(device);
+	FuPciDevicePrivate *priv = GET_PRIVATE(self);
+
+	/* FuUdevDevice->probe_complete */
+	FU_DEVICE_CLASS(fu_pci_device_parent_class)->probe_complete(device);
+
+	/* "Display Adapter" is much better than "Unknown Device" */
+	fu_pci_device_set_quirks_fallback(self, priv->class >> 16);
+}
+
+static void
 fu_pci_device_init(FuPciDevice *self)
 {
 }
@@ -385,5 +611,6 @@ fu_pci_device_class_init(FuPciDeviceClass *klass)
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	device_class->to_string = fu_pci_device_to_string;
 	device_class->probe = fu_pci_device_probe;
+	device_class->probe_complete = fu_pci_device_probe_complete;
 	device_class->incorporate = fu_pci_device_to_incorporate;
 }

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -574,7 +574,7 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 		while (sqlite3_step(stmt) == SQLITE_ROW) {
 			const gchar *key_tmp = (const gchar *)sqlite3_column_text(stmt, 0);
 			const gchar *value = (const gchar *)sqlite3_column_text(stmt, 1);
-			iter_cb(self, key_tmp, value, user_data);
+			iter_cb(self, key_tmp, value, FU_CONTEXT_QUIRK_SOURCE_DB, user_data);
 		}
 	}
 #endif
@@ -612,7 +612,11 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 		XbNode *n = g_ptr_array_index(results, i);
 		if (self->verbose)
 			g_debug("%s → %s", guid, xb_node_get_text(n));
-		iter_cb(self, xb_node_get_attr(n, "key"), xb_node_get_text(n), user_data);
+		iter_cb(self,
+			xb_node_get_attr(n, "key"),
+			xb_node_get_text(n),
+			FU_CONTEXT_QUIRK_SOURCE_FILE,
+			user_data);
 	}
 
 	return TRUE;

--- a/libfwupdplugin/fu-quirks.h
+++ b/libfwupdplugin/fu-quirks.h
@@ -42,6 +42,7 @@ typedef enum {
 typedef void (*FuQuirksIter)(FuQuirks *self,
 			     const gchar *key,
 			     const gchar *value,
+			     FuContextQuirkSource source,
 			     gpointer user_data);
 
 FuQuirks *

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -13,6 +13,7 @@
 #include <glib/gstdio.h>
 #include <string.h>
 
+#include "fwupd-enums-private.h"
 #include "fwupd-security-attr-private.h"
 
 #include "fu-backend-private.h"
@@ -1475,6 +1476,8 @@ fu_quirks_vendor_ids_func(void)
 	g_autofree gchar *guid1 = fwupd_guid_hash_string("PCI\\VEN_8086");
 	g_autofree gchar *guid2 = fwupd_guid_hash_string("USB\\VID_8086");
 	g_autofree gchar *guid3 = fwupd_guid_hash_string("PNP\\VID_ICO");
+	g_autofree gchar *guid4 = fwupd_guid_hash_string("PCI\\VEN_8086&DEV_0007");
+	g_autofree gchar *guid5 = fwupd_guid_hash_string("USB\\VID_8086&PID_0001");
 	g_autofree gchar *datadata = fu_path_from_kind(FU_PATH_KIND_CACHEDIR_PKG);
 	g_autofree gchar *quirksdb = g_build_filename(datadata, "quirks.db", NULL);
 	g_autoptr(FuQuirks) quirks = fu_quirks_new(ctx);
@@ -1497,9 +1500,15 @@ fu_quirks_vendor_ids_func(void)
 	tmp = fu_quirks_lookup_by_id(quirks, guid2, "Vendor");
 	g_assert_true(ret);
 	g_assert_cmpstr(tmp, ==, "Intel Corp.");
-	tmp = fu_quirks_lookup_by_id(quirks, guid3, "Vendor");
+	tmp = fu_quirks_lookup_by_id(quirks, guid3, FWUPD_RESULT_KEY_VENDOR);
 	g_assert_true(ret);
 	g_assert_cmpstr(tmp, ==, "Intel Corp");
+	tmp = fu_quirks_lookup_by_id(quirks, guid4, FWUPD_RESULT_KEY_NAME);
+	g_assert_true(ret);
+	g_assert_cmpstr(tmp, ==, "82379AB");
+	tmp = fu_quirks_lookup_by_id(quirks, guid5, FWUPD_RESULT_KEY_NAME);
+	g_assert_true(ret);
+	g_assert_cmpstr(tmp, ==, "AnyPoint (TM) Home Network 1.6 Mbps Wireless Adapter");
 }
 
 static void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1403,6 +1403,7 @@ static void
 fu_plugin_quirks_append_cb(FuQuirks *quirks,
 			   const gchar *key,
 			   const gchar *value,
+			   FuContextQuirkSource source,
 			   gpointer user_data)
 {
 	FuPluginQuirksAppendHelper *helper = (FuPluginQuirksAppendHelper *)user_data;

--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -107,7 +107,11 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 		/* it's fine to be strict here, as we checked the fwupd version was new enough in
 		 * FuUsbDeviceDs20Item */
 		g_debug("setting ds20 device quirk '%s'='%s'", key, value);
-		if (!fu_device_set_quirk_kv(FU_DEVICE(device), key, value, error))
+		if (!fu_device_set_quirk_kv(FU_DEVICE(device),
+					    key,
+					    value,
+					    FU_CONTEXT_QUIRK_SOURCE_DEVICE,
+					    error))
 			return FALSE;
 	}
 


### PR DESCRIPTION
This doubles the size of the quirk database, but means we're much less likely to show 'Unknown Device' as the device name.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
