### PR TITLE
Add a vercmp command to fwupdtool

### DIFF
--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -32,6 +32,7 @@ _fwupdtool_cmd_list=(
 	'get-remotes'
 	'get-report-metadata'
 	'get-topology'
+	'get-version-formats'
 	'hwids'
 	'update'
 	'upgrade'

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -59,6 +59,7 @@ _fwupdtool_cmd_list=(
 	'bind-driver'
 	'export-hwids'
 	'reboot-cleanup'
+	'vercmp'
 )
 
 _fwupdtool_opts=(

--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -56,3 +56,18 @@ rc=$?; if [ $rc != 2 ]; then exit $rc; fi
 echo "Resetting config..."
 fwupdtool reset-config test
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+
+# ---
+echo "Testing good version compare"
+fwupdtool vercmp 1.0.0 1.0.0 triplet
+rc=$?; if [ $rc != 0 ]; then exit $rc; fi
+
+# ---
+echo "Testing bad version compare"
+fwupdtool vercmp 1.0.0 1.0.1 foo
+rc=$?; if [ $rc != 1 ]; then exit $rc; fi
+
+# ---
+echo "Getting supported version formats..."
+fwupdtool get-version-formats --json
+rc=$?; if [ $rc != 0 ]; then exit $rc; fi


### PR DESCRIPTION
This makes it easy to explain to OEMs how semver comparisons are made.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
