### PR TITLE
uf2: re-enumerate device after write_firmware

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -297,6 +297,7 @@ fu_device_register_flags(FuDevice *self)
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_USE_RUNTIME_VERSION);
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_SKIPS_RESTART);
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_IS_FAKE);
+	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_AUTOMATICALLY_RESTARTS);
 }
 
 static void

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -781,6 +781,15 @@ fu_device_new(FuContext *ctx);
  */
 #define FU_DEVICE_PRIVATE_FLAG_IS_FAKE "is-fake"
 
+/**
+ * FU_DEVICE_PRIVATE_FLAG_AUTOMATICALLY_RESTARTS:
+ *
+ * The device automatically restarts after firmware is written to it.
+ *
+ * Since: 2.0.2
+ */
+#define FU_DEVICE_PRIVATE_FLAG_AUTOMATICALLY_RESTARTS "automatically-restarts"
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self) G_GNUC_NON_NULL(1);

--- a/plugins/uf2/README.md
+++ b/plugins/uf2/README.md
@@ -16,6 +16,8 @@ Writing any file to the MSD will cause the firmware to be written.
 Sometimes the device will restart and the volume will be unmounted and then
 mounted again. In some cases the volume may not “come back” until the user
 manually puts the device back in programming mode.
+If the device automatically restarts and does not "come back" in UF2 mode,
+the flag "will-disappear" should be set.
 
 Match the block devices using the VID, PID and UUID, and then create a
 UF2 device which can be used to flash firmware.

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -157,6 +157,11 @@ fu_uf2_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 
+	if (fu_device_has_private_flag(device, FU_DEVICE_PRIVATE_FLAG_AUTOMATICALLY_RESTARTS)) {
+		/* the device automatically reboots */
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	}
+
 	/* success */
 	return TRUE;
 }

--- a/plugins/uf2/uf2.quirk
+++ b/plugins/uf2/uf2.quirk
@@ -1,7 +1,7 @@
 # Raspberry Pi RP2 [no CURRENT.UF2]
 [USB\VID_2E8A&PID_0003]
 Guid = UF2\FAMILY_E48BFF56
-Flags = updatable,will-disappear
+Flags = updatable
 
 # Adafruit Trinket
 [USB\VID_1781&PID_0C9F]
@@ -149,6 +149,7 @@ Name = ESP32C3
 [UF2\FAMILY_E48BFF56]
 Name = RP2040
 Vendor = Raspberry Pi
+Flags = automatically-restarts
 
 [UF2\FAMILY_00FF6919]
 Name = STM32L4


### PR DESCRIPTION
The uf2 device I have at hand (rp2040) automatically reboots after writing the new firmware, and usually changes VID/PID. Set wait-for-replug to trigger a re-enumeration.

Previously, attach is tried against FuUf2Device, expecting the fake mass storage device to still exist/reappear, and then fail because that does not happen.

Fixes the attach failure reported in #7912

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
