### PR TITLE
Fix the address values when splitting memory blocks with pages

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -154,3 +154,8 @@ Remember: Plugins should be upstream!
 * `fu_udev_device_get_subsystem_model`: Use `fu_pci_device_get_subsystem_pid()` instead
 * `fu_udev_device_get_revision`: Use `fu_pci_device_get_revision()` instead
 * `fu_udev_device_set_revision`: Use `fu_pci_device_set_revision()` instead
+
+## 2.0.2
+
+* `fu_chunk_array_new_from_bytes()`: Add a page size, typically `FU_CHUNK_PAGESZ_NONE`
+* `fu_chunk_array_new_from_stream()`: Add a page size, typically `FU_CHUNK_PAGESZ_NONE`

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -694,7 +694,10 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 	}
 	cfdata_linear_blob =
 	    g_byte_array_free_to_bytes(g_steal_pointer(&cfdata_linear)); /* nocheck:blocked */
-	chunks = fu_chunk_array_new_from_bytes(cfdata_linear_blob, 0x0, 0x8000);
+	chunks = fu_chunk_array_new_from_bytes(cfdata_linear_blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       0x8000);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GByteArray) chunk_zlib = g_byte_array_new();

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -914,7 +914,10 @@ fu_cfi_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each block */
-	pages = fu_chunk_array_new_from_bytes(fw, 0x0, fu_cfi_device_get_page_size(self));
+	pages = fu_chunk_array_new_from_bytes(fw,
+					      FU_CHUNK_ADDR_OFFSET_NONE,
+					      FU_CHUNK_PAGESZ_NONE,
+					      fu_cfi_device_get_page_size(self));
 	if (!fu_cfi_device_write_pages(self, pages, fu_progress_get_child(progress), error)) {
 		g_prefix_error(error, "failed to write pages: ");
 		return FALSE;

--- a/libfwupdplugin/fu-chunk-array.h
+++ b/libfwupdplugin/fu-chunk-array.h
@@ -15,12 +15,13 @@
 G_DECLARE_FINAL_TYPE(FuChunkArray, fu_chunk_array, FU, CHUNK_ARRAY, GObject)
 
 FuChunkArray *
-fu_chunk_array_new_from_bytes(GBytes *blob, guint32 addr_start, guint32 packet_sz)
+fu_chunk_array_new_from_bytes(GBytes *blob, gsize addr_offset, gsize page_sz, gsize packet_sz)
     G_GNUC_NON_NULL(1);
 FuChunkArray *
 fu_chunk_array_new_from_stream(GInputStream *stream,
-			       guint32 addr_start,
-			       guint32 packet_sz,
+			       gsize addr_offset,
+			       gsize page_sz,
+			       gsize packet_sz,
 			       GError **error) G_GNUC_NON_NULL(1);
 guint
 fu_chunk_array_length(FuChunkArray *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-chunk.c
+++ b/libfwupdplugin/fu-chunk.c
@@ -361,7 +361,7 @@ fu_chunk_array_to_string(GPtrArray *chunks)
  * fu_chunk_array_mutable_new:
  * @data: a mutable blob of memory
  * @data_sz: size of @data_sz
- * @addr_start: the hardware address offset, or 0
+ * @addr_offset: the hardware address offset, or 0
  * @page_sz: the hardware page size, or 0
  * @packet_sz: the transfer size, or 0
  *
@@ -375,7 +375,7 @@ fu_chunk_array_to_string(GPtrArray *chunks)
 GPtrArray *
 fu_chunk_array_mutable_new(guint8 *data,
 			   gsize data_sz,
-			   gsize addr_start,
+			   gsize addr_offset,
 			   gsize page_sz,
 			   gsize packet_sz)
 {
@@ -384,7 +384,7 @@ fu_chunk_array_mutable_new(guint8 *data,
 	g_return_val_if_fail(data != NULL, NULL);
 	g_return_val_if_fail(data_sz > 0, NULL);
 
-	chunks = fu_chunk_array_new(data, data_sz, addr_start, page_sz, packet_sz);
+	chunks = fu_chunk_array_new(data, data_sz, addr_offset, page_sz, packet_sz);
 	if (chunks == NULL)
 		return NULL;
 	for (guint i = 0; i < chunks->len; i++) {
@@ -398,7 +398,7 @@ fu_chunk_array_mutable_new(guint8 *data,
  * fu_chunk_array_new:
  * @data: (nullable): an optional linear blob of memory
  * @data_sz: size of @data_sz
- * @addr_start: the hardware address offset, or 0
+ * @addr_offset: the hardware address offset, or 0
  * @page_sz: the hardware page size, or 0
  * @packet_sz: the transfer size, or 0
  *
@@ -412,7 +412,7 @@ fu_chunk_array_mutable_new(guint8 *data,
 GPtrArray *
 fu_chunk_array_new(const guint8 *data,
 		   gsize data_sz,
-		   gsize addr_start,
+		   gsize addr_offset,
 		   gsize page_sz,
 		   gsize packet_sz)
 {
@@ -424,12 +424,12 @@ fu_chunk_array_new(const guint8 *data,
 	while (offset < data_sz) {
 		gsize chunksz = MIN(packet_sz, data_sz - offset);
 		gsize page = 0;
-		gsize address_offset = addr_start + offset;
+		gsize address_offset = addr_offset + offset;
 
 		/* if page_sz is not specified then all the pages are 0 */
 		if (page_sz > 0) {
 			address_offset %= page_sz;
-			page = (offset + addr_start) / page_sz;
+			page = (offset + addr_offset) / page_sz;
 		}
 
 		/* cut the packet so it does not straddle multiple blocks */

--- a/libfwupdplugin/fu-chunk.h
+++ b/libfwupdplugin/fu-chunk.h
@@ -12,6 +12,24 @@
 
 G_DECLARE_FINAL_TYPE(FuChunk, fu_chunk, FU, CHUNK, GObject)
 
+/**
+ * FU_CHUNK_PAGESZ_NONE:
+ *
+ * No page size is used.
+ *
+ * Since: 2.0.2
+ **/
+#define FU_CHUNK_PAGESZ_NONE 0
+
+/**
+ * FU_CHUNK_ADDR_OFFSET_NONE:
+ *
+ * No address offset is used.
+ *
+ * Since: 2.0.2
+ **/
+#define FU_CHUNK_ADDR_OFFSET_NONE 0
+
 FuChunk *
 fu_chunk_bytes_new(GBytes *bytes);
 void
@@ -47,12 +65,12 @@ fu_chunk_array_to_string(GPtrArray *chunks) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_chunk_array_new(const guint8 *data,
 		   gsize data_sz,
-		   gsize addr_start,
+		   gsize addr_offset,
 		   gsize page_sz,
 		   gsize packet_sz);
 GPtrArray *
 fu_chunk_array_mutable_new(guint8 *data,
 			   gsize data_sz,
-			   gsize addr_start,
+			   gsize addr_offset,
 			   gsize page_sz,
 			   gsize packet_sz) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -817,7 +817,11 @@ fu_device_set_contents(FuDevice *self,
 		return FALSE;
 
 	/* write in 32k chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 0x8000, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						0x8000,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -703,7 +703,11 @@ fu_input_stream_chunkify(GInputStream *stream,
 	g_return_val_if_fail(func_cb != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 0x8000, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						0x8000,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (gsize i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2702,7 +2702,8 @@ fu_chunk_array_func(void)
 	g_autoptr(FuChunk) chk4 = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GBytes) fw = g_bytes_new_static("hello world", 11);
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 100, 5);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(fw, 100, FU_CHUNK_PAGESZ_NONE, 5);
 
 	g_assert_cmpint(fu_chunk_array_length(chunks), ==, 3);
 

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -621,7 +621,10 @@ fu_srec_firmware_write(FuFirmware *firmware, GError **error)
 	/* payload */
 	if (g_bytes_get_size(buf_blob) > 0) {
 		g_autoptr(FuChunkArray) chunks =
-		    fu_chunk_array_new_from_bytes(buf_blob, fu_firmware_get_addr(firmware), 64);
+		    fu_chunk_array_new_from_bytes(buf_blob,
+						  fu_firmware_get_addr(firmware),
+						  FU_CHUNK_PAGESZ_NONE,
+						  64);
 		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			g_autoptr(FuChunk) chk = NULL;
 

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -478,7 +478,11 @@ fu_strsplit_stream(GInputStream *stream,
 	} else {
 		stream_partial = g_object_ref(stream);
 	}
-	chunks = fu_chunk_array_new_from_stream(stream_partial, 0x0, 0x8000, error);
+	chunks = fu_chunk_array_new_from_stream(stream_partial,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						0x8000,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (gsize i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/algoltek-aux/fu-algoltek-aux-device.c
+++ b/plugins/algoltek-aux/fu-algoltek-aux-device.c
@@ -198,7 +198,11 @@ fu_algoltek_aux_device_isp(FuAlgoltekAuxDevice *self,
 	g_autoptr(FuChunkArray) chunks = NULL;
 	guint16 serialno = 0;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0, 8, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						8,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
@@ -311,7 +315,11 @@ fu_algoltek_aux_device_wrf(FuAlgoltekAuxDevice *self,
 	guint8 start_length = 0;
 	guint16 serialno = 1;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0, 8, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						8,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -220,7 +220,11 @@ fu_algoltek_usb_device_isp(FuAlgoltekUsbDevice *self,
 	guint8 basic_data_size = 5;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, address, 64 - basic_data_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						address,
+						FU_CHUNK_PAGESZ_NONE,
+						64 - basic_data_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);
@@ -371,7 +375,11 @@ fu_algoltek_usb_device_wrf(FuAlgoltekUsbDevice *self,
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GByteArray) buf_parameter = g_byte_array_new();
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 64, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						64,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -602,7 +602,11 @@ fu_algoltek_usbcr_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	chunks = fu_chunk_array_new_from_stream(stream, 0, 32, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						32,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -311,7 +311,11 @@ fu_analogix_device_write_image(FuAnalogixDevice *self,
 	fu_progress_step_done(progress);
 
 	/* write data */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, BILLBOARD_MAX_PACKET_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						BILLBOARD_MAX_PACKET_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_analogix_device_write_chunks(self,

--- a/plugins/android-boot/fu-android-boot-device.c
+++ b/plugins/android-boot/fu-android-boot-device.c
@@ -206,7 +206,10 @@ fu_android_boot_device_erase(FuAndroidBootDevice *self, FuProgress *progress, GE
 	g_autofree guint8 *buf = g_malloc0(bufsz);
 	g_autoptr(GBytes) fw = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 10 * 1024);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       10 * 1024);
 	return fu_android_boot_device_write(self, chunks, progress, error);
 }
 
@@ -271,7 +274,11 @@ fu_android_boot_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 10 * 1024, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						10 * 1024,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -790,7 +790,11 @@ fu_ata_device_write_firmware(FuDevice *device,
 
 	/* write each block */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, chunksz, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						chunksz,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -432,7 +432,8 @@ fu_aver_hid_device_write_firmware(FuDevice *device,
 
 	/* ISP_FILE_DNLOAD */
 	chunks = fu_chunk_array_new_from_bytes(aver_fw,
-					       0x00,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
 					       FU_STRUCT_AVER_HID_REQ_ISP_FILE_DNLOAD_SIZE_DATA);
 
 	if (!fu_aver_hid_device_isp_file_dnload(self,

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -338,7 +338,10 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* CX3 safeisp firmware upload */
-	chunks = fu_chunk_array_new_from_bytes(cx3_fw, 0x00, 512);
+	chunks = fu_chunk_array_new_from_bytes(cx3_fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       512);
 	if (!fu_aver_safeisp_device_upload(self,
 					   chunks,
 					   fu_progress_get_child(progress),
@@ -362,7 +365,10 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* M12 safeisp firmware upload */
-	chunks = fu_chunk_array_new_from_bytes(m12_fw, 0x00, 512);
+	chunks = fu_chunk_array_new_from_bytes(m12_fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       512);
 	if (!fu_aver_safeisp_device_upload(self,
 					   chunks,
 					   fu_progress_get_child(progress),

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -435,7 +435,10 @@ fu_bcm57xx_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* hit hardware */
-	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, FU_BCM57XX_BLOCK_SZ);
+	chunks = fu_chunk_array_new_from_bytes(blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_BCM57XX_BLOCK_SZ);
 	if (!fu_bcm57xx_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))
 		return FALSE;
 	fu_progress_step_done(progress);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -368,7 +368,10 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 		g_autoptr(GBytes) img_bytes = fu_firmware_get_bytes(img, error);
 		if (img_bytes == NULL)
 			return NULL;
-		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 64);
+		chunks = fu_chunk_array_new_from_bytes(img_bytes,
+						       FU_CHUNK_ADDR_OFFSET_NONE,
+						       FU_CHUNK_PAGESZ_NONE,
+						       64);
 		fu_struct_ccgx_dmc_fwct_segmentation_info_set_num_rows(
 		    st_info,
 		    MAX(fu_chunk_array_length(chunks), 1));
@@ -394,7 +397,10 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 		img_bytes = fu_firmware_get_bytes(img, error);
 		if (img_bytes == NULL)
 			return NULL;
-		chunks = fu_chunk_array_new_from_bytes(img_bytes, 0x0, 64);
+		chunks = fu_chunk_array_new_from_bytes(img_bytes,
+						       FU_CHUNK_ADDR_OFFSET_NONE,
+						       FU_CHUNK_PAGESZ_NONE,
+						       64);
 		img_padded = fu_bytes_pad(img_bytes, MAX(fu_chunk_array_length(chunks), 1) * 64);
 		fu_byte_array_append_bytes(buf, img_padded);
 		g_checksum_update(csum,

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -427,7 +427,10 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	fw = fu_firmware_get_bytes_with_patches(firmware, error);
 	if (fw == NULL)
 		return NULL;
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x100);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       0x100);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/ch341a/fu-ch341a-cfi-device.c
+++ b/plugins/ch341a/fu-ch341a-cfi-device.c
@@ -219,7 +219,10 @@ fu_ch341a_cfi_device_write_page(FuCh341aCfiDevice *self, FuChunk *page, GError *
 		return FALSE;
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_bytes(page_blob, 0x0, CH341A_PAYLOAD_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(page_blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       CH341A_PAYLOAD_SIZE);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		guint8 buf2[CH341A_PAYLOAD_SIZE] = {0x0};
@@ -362,7 +365,8 @@ fu_ch341a_cfi_device_write_firmware(FuDevice *device,
 
 	/* write each block */
 	pages = fu_chunk_array_new_from_bytes(fw,
-					      0x0,
+					      FU_CHUNK_ADDR_OFFSET_NONE,
+					      FU_CHUNK_PAGESZ_NONE,
 					      fu_cfi_device_get_page_size(FU_CFI_DEVICE(self)));
 	if (!fu_ch341a_cfi_device_write_pages(self,
 					      pages,

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -162,7 +162,10 @@ fu_ch347_device_send_command(FuCh347Device *self,
 	if (wbufsz > 0) {
 		g_autoptr(GBytes) wblob = g_bytes_new_static(wbuf, wbufsz);
 		g_autoptr(FuChunkArray) chunks =
-		    fu_chunk_array_new_from_bytes(wblob, 0x0, FU_CH347_PAYLOAD_SIZE);
+		    fu_chunk_array_new_from_bytes(wblob,
+						  FU_CHUNK_ADDR_OFFSET_NONE,
+						  FU_CHUNK_PAGESZ_NONE,
+						  FU_CH347_PAYLOAD_SIZE);
 		for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 			guint8 buf[1] = {0x0};
 			g_autoptr(FuChunk) chk = NULL;

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -550,6 +550,7 @@ fu_colorhug_device_write_firmware(FuDevice *device,
 	/* write each block */
 	chunks = fu_chunk_array_new_from_stream(stream,
 						self->start_addr,
+						FU_CHUNK_PAGESZ_NONE,
 						CH_FLASH_TRANSFER_BLOCK_SIZE,
 						error);
 	if (chunks == NULL)

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -361,6 +361,7 @@ fu_corsair_bp_write_firmware(FuDevice *device,
 	chunks =
 	    fu_chunk_array_new_from_bytes(rest_of_firmware,
 					  first_chunk_size,
+					  FU_CHUNK_PAGESZ_NONE,
 					  self->cmd_write_size - CORSAIR_NEXT_CHUNKS_HEADER_SIZE);
 
 	if (!fu_corsair_bp_write_firmware_chunks(self,

--- a/plugins/dell-k2/fu-dell-k2-dpmux.c
+++ b/plugins/dell-k2/fu-dell-k2-dpmux.c
@@ -79,7 +79,10 @@ fu_dell_k2_dpmux_write(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_DP_MUX, 0);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* write to device */
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/dell-k2/fu-dell-k2-ec.c
+++ b/plugins/dell-k2/fu-dell-k2-ec.c
@@ -706,7 +706,10 @@ fu_dell_k2_ec_write_firmware(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_MAIN_EC, 0);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* erase */
 	if (!fu_dell_k2_ec_hid_erase_bank(device, 0xff, error))

--- a/plugins/dell-k2/fu-dell-k2-ilan.c
+++ b/plugins/dell-k2/fu-dell-k2-ilan.c
@@ -76,7 +76,10 @@ fu_dell_k2_ilan_write(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_LAN, 0);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* write to device */
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/dell-k2/fu-dell-k2-pd.c
+++ b/plugins/dell-k2/fu-dell-k2-pd.c
@@ -104,7 +104,10 @@ fu_dell_k2_pd_write(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_PD, self->pd_identifier);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* write to device */
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/dell-k2/fu-dell-k2-rmm.c
+++ b/plugins/dell-k2/fu-dell-k2-rmm.c
@@ -79,7 +79,10 @@ fu_dell_k2_rmm_write(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_RMM, 0);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* write to device */
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/dell-k2/fu-dell-k2-rtshub.c
+++ b/plugins/dell-k2/fu-dell-k2-rtshub.c
@@ -232,8 +232,11 @@ fu_dell_k2_rtshub_write_firmware(FuDevice *device,
 	if (stream == NULL)
 		return FALSE;
 
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0x00, DELL_K2_RTSHUB_TRANSFER_BLOCK_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						DELL_K2_RTSHUB_TRANSFER_BLOCK_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/dell-k2/fu-dell-k2-wtpd.c
+++ b/plugins/dell-k2/fu-dell-k2-wtpd.c
@@ -76,7 +76,10 @@ fu_dell_k2_wtpd_write(FuDevice *device,
 	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, DELL_K2_EC_DEV_TYPE_WTPD, 0);
 
 	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, DELL_K2_EC_HID_DATA_PAGE_SZ);
+	chunks = fu_chunk_array_new_from_bytes(fw_whdr,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       DELL_K2_EC_HID_DATA_PAGE_SZ);
 
 	/* write to device */
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/dfu-csr/fu-dfu-csr-device.c
+++ b/plugins/dfu-csr/fu-dfu-csr-device.c
@@ -291,7 +291,8 @@ fu_dfu_csr_device_download(FuDevice *device,
 
 	/* create chunks */
 	chunks = fu_chunk_array_new_from_stream(stream,
-						0x0,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
 						FU_DFU_CSR_PACKET_DATA_SIZE -
 						    FU_STRUCT_DFU_CSR_COMMAND_HEADER_SIZE,
 						error);

--- a/plugins/dfu/fu-dfu-target-stm.c
+++ b/plugins/dfu/fu-dfu-target-stm.c
@@ -434,6 +434,7 @@ fu_dfu_target_stm_download_element(FuDfuTarget *target,
 	bytes = fu_chunk_get_bytes(chk);
 	chunks = fu_chunk_array_new_from_bytes(bytes,
 					       fu_chunk_get_address(chk),
+					       FU_CHUNK_PAGESZ_NONE,
 					       fu_dfu_device_get_transfer_size(device));
 	if (!fu_dfu_target_stm_download_element1(target,
 						 chunks,

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -510,7 +510,11 @@ fu_ebitdo_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* flash the firmware in 32 byte blocks */
-	chunks = fu_chunk_array_new_from_stream(stream_payload, 0x0, 32, error);
+	chunks = fu_chunk_array_new_from_stream(stream_payload,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						32,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -656,7 +656,10 @@ fu_elantp_hid_haptic_device_write_chunks_cb(FuDevice *device, gpointer user_data
 		return FALSE;
 
 	/* progress */
-	chunks = fu_chunk_array_new_from_bytes(helper->fw, 0x0, eeprom_fw_page_size);
+	chunks = fu_chunk_array_new_from_bytes(helper->fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       eeprom_fw_page_size);
 	fu_progress_set_id(helper->progress, G_STRLOC);
 	fu_progress_set_steps(helper->progress,
 			      fu_chunk_array_length(chunks) - helper->idx_page_start + 1);

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -444,7 +444,10 @@ fu_elantp_i2c_device_write_firmware(FuDevice *device,
 	fw2 = fu_bytes_new_offset(fw, iap_addr, g_bytes_get_size(fw) - iap_addr, error);
 	if (fw2 == NULL)
 		return FALSE;
-	chunks = fu_chunk_array_new_from_bytes(fw2, 0x0, self->fw_page_size);
+	chunks = fu_chunk_array_new_from_bytes(fw2,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       self->fw_page_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		guint16 csum_tmp;
 		gsize blksz = self->fw_page_size + 4;

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -426,7 +426,11 @@ fu_emmc_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* build packets */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, sector_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						sector_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	while (failure_cnt < 3) {

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -266,7 +266,11 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each block */
-	blocks = fu_chunk_array_new_from_stream(stream, 0x00, FU_EP963_TRANSFER_BLOCK_SIZE, error);
+	blocks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_EP963_TRANSFER_BLOCK_SIZE,
+						error);
 	if (blocks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(blocks); i++) {
@@ -297,6 +301,7 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 		chk_blob = fu_chunk_get_bytes(chk2);
 		chunks = fu_chunk_array_new_from_bytes(chk_blob,
 						       fu_chunk_get_address(chk2),
+						       FU_CHUNK_PAGESZ_NONE,
 						       FU_EP963_TRANSFER_CHUNK_SIZE);
 		for (guint j = 0; j < fu_chunk_array_length(chunks); j++) {
 			g_autoptr(FuChunk) chk = NULL;

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -266,7 +266,10 @@ fu_fastboot_device_download(FuDevice *device, GBytes *fw, FuProgress *progress, 
 
 	/* send the data in chunks */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, self->blocksz);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       self->blocksz);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -488,7 +488,11 @@ fu_focalfp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send packet data */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, MAX_USB_PACKET_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						MAX_USB_PACKET_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_focalfp_hid_device_write_chunks(self,

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -400,7 +400,11 @@ fu_fpc_device_write_ff2_blocks(FuFpcDevice *self, GInputStream *stream, GError *
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, FPC_FLASH_BLOCK_SIZE_4096, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FPC_FLASH_BLOCK_SIZE_4096,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -570,7 +574,11 @@ fu_fpc_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* build packets */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, self->max_block_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						self->max_block_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -707,7 +707,10 @@ fu_genesys_gl32xx_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_bytes(fw, FU_GENESYS_GL32XX_FW_START_ADDR, self->packetsz);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_GENESYS_GL32XX_FW_START_ADDR,
+					       FU_CHUNK_PAGESZ_NONE,
+					       self->packetsz);
 	if (!fu_genesys_gl32xx_device_write_blocks(self,
 						   chunks,
 						   fu_progress_get_child(progress),

--- a/plugins/goodix-moc/fu-goodixmoc-device.c
+++ b/plugins/goodix-moc/fu-goodixmoc-device.c
@@ -351,7 +351,10 @@ fu_goodixmoc_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* build packets */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, GX_FLASH_TRANSFER_BLOCK_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       GX_FLASH_TRANSFER_BLOCK_SIZE);
 
 	/* don't auto-boot firmware */
 	if (!fu_goodixmoc_device_update_init(self, &error_local)) {

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -422,6 +422,7 @@ fu_goodixtp_brlb_device_write_image(FuGoodixtpBrlbDevice *self,
 		return FALSE;
 	chunks = fu_chunk_array_new_from_stream(stream,
 						fu_firmware_get_addr(img),
+						FU_CHUNK_PAGESZ_NONE,
 						RAM_BUFFER_SIZE,
 						error);
 	if (chunks == NULL)

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -469,6 +469,7 @@ fu_goodixtp_gtx8_device_write_image(FuGoodixtpGtx8Device *self,
 		return FALSE;
 	chunks = fu_chunk_array_new_from_stream(stream,
 						fu_firmware_get_addr(img),
+						FU_CHUNK_PAGESZ_NONE,
 						RAM_BUFFER_SIZE,
 						error);
 	if (chunks == NULL)

--- a/plugins/hailuck/fu-hailuck-bl-device.c
+++ b/plugins/hailuck/fu-hailuck-bl-device.c
@@ -236,7 +236,10 @@ fu_hailuck_bl_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* build packets */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 2048);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       2048);
 
 	/* intentionally corrupt first chunk so that CRC fails */
 	chk0 = fu_chunk_array_index(chunks, 0, error);

--- a/plugins/hailuck/fu-hailuck-tp-device.c
+++ b/plugins/hailuck/fu-hailuck-tp-device.c
@@ -114,7 +114,11 @@ fu_hailuck_tp_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, block_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						block_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -681,7 +681,11 @@ fu_igsc_device_write_blob(FuIgscDevice *self,
 	fu_progress_step_done(progress);
 
 	/* data */
-	chunks = fu_chunk_array_new_from_stream(fw, 0x0, payloadsz, error);
+	chunks = fu_chunk_array_new_from_stream(fw,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						payloadsz,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_igsc_device_write_chunks(self, chunks, fu_progress_get_child(progress), error))

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -370,7 +370,10 @@ fu_intel_usb4_device_nvm_write(FuIntelUsb4Device *self,
 	}
 
 	/* write data in 64 byte blocks */
-	chunks = fu_chunk_array_new_from_bytes(blob, 0x0, 64);
+	chunks = fu_chunk_array_new_from_bytes(blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       64);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -587,7 +587,11 @@ fu_jabra_file_device_write_firmware(FuDevice *device,
 		stream = fu_firmware_get_stream(firmware, error);
 		if (stream == NULL)
 			return FALSE;
-		chunks = fu_chunk_array_new_from_stream(stream, 0x00, chunk_size, error);
+		chunks = fu_chunk_array_new_from_stream(stream,
+							FU_CHUNK_ADDR_OFFSET_NONE,
+							FU_CHUNK_PAGESZ_NONE,
+							chunk_size,
+							error);
 		if (chunks == NULL)
 			return FALSE;
 

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -990,7 +990,11 @@ fu_jabra_gnp_device_write_image(FuJabraGnpDevice *self,
 	fu_progress_step_done(progress);
 
 	/* write chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, chunk_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						chunk_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_jabra_gnp_device_write_crc(self,

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -142,7 +142,8 @@ fu_kinetic_dp_puma_device_send_chunk(FuKineticDpPumaDevice *self,
 				     GBytes *fw,
 				     GError **error)
 {
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 16);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(fw, FU_CHUNK_ADDR_OFFSET_NONE, FU_CHUNK_PAGESZ_NONE, 16);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 
@@ -174,8 +175,10 @@ fu_kinetic_dp_puma_device_send_payload(FuKineticDpPumaDevice *self,
 				       gboolean ignore_error,
 				       GError **error)
 {
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(fw, 0x0, PUMA_DPCD_DATA_SIZE);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       PUMA_DPCD_DATA_SIZE);
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -348,7 +348,8 @@ fu_kinetic_dp_secure_device_send_chunk(FuKineticDpSecureDevice *self,
 				       FuProgress *progress,
 				       GError **error)
 {
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 16);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(fw, FU_CHUNK_ADDR_OFFSET_NONE, FU_CHUNK_PAGESZ_NONE, 16);
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -384,8 +385,10 @@ fu_kinetic_dp_secure_device_send_payload(FuKineticDpSecureDevice *self,
 					 FuProgress *progress,
 					 GError **error)
 {
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(fw, 0x0, DPCD_SIZE_KT_AUX_WIN);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       DPCD_SIZE_KT_AUX_WIN);
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -341,8 +341,11 @@ fu_legion_hid2_device_write_data(FuLegionHid2Device *self,
 	if (stream == NULL)
 		return FALSE;
 
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0, FU_STRUCT_LEGION_IAP_TLV_SIZE_VALUE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_STRUCT_LEGION_IAP_TLV_SIZE_VALUE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_legion_hid2_device_write_data_chunks(self,
@@ -368,8 +371,11 @@ fu_legion_hid2_device_write_sig(FuLegionHid2Device *self,
 	if (stream == NULL)
 		return FALSE;
 
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0, FU_STRUCT_LEGION_IAP_TLV_SIZE_VALUE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_STRUCT_LEGION_IAP_TLV_SIZE_VALUE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_legion_hid2_device_write_data_chunks(self,

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -970,7 +970,8 @@ fu_logitech_bulkcontroller_device_write_fw(FuLogitechBulkcontrollerDevice *self,
 
 	chunks = fu_chunk_array_new_from_stream(
 	    stream,
-	    0x0,
+	    FU_CHUNK_ADDR_OFFSET_NONE,
+	    FU_CHUNK_PAGESZ_NONE,
 	    self->transfer_bufsz - FU_STRUCT_LOGITECH_BULKCONTROLLER_UPDATE_REQ_SIZE,
 	    error);
 	if (chunks == NULL)

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -135,7 +135,11 @@ fu_logitech_rallysystem_tablehub_device_write_fw(FuLogitechRallysystemTablehubDe
 						 FuProgress *progress,
 						 GError **error)
 {
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_stream(stream, 0x0, 0x200, error);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_stream(stream,
+									FU_CHUNK_ADDR_OFFSET_NONE,
+									FU_CHUNK_PAGESZ_NONE,
+									0x200,
+									error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -371,7 +371,11 @@ fu_logitech_scribe_device_write_fw(FuLogitechScribeDevice *self,
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, PAYLOAD_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						PAYLOAD_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -366,7 +366,11 @@ fu_logitech_tap_hdmi_device_write_firmware(FuDevice *device,
 
 	/* write */
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, kLogiDefaultImageBlockSize, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						kLogiDefaultImageBlockSize,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_logitech_tap_hdmi_device_write_fw(self,

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -601,7 +601,8 @@ fu_logitech_tap_touch_device_write_blocks(FuLogitechTapTouchDevice *self,
 	if (stream == NULL)
 		return FALSE;
 	chunks = fu_chunk_array_new_from_stream(stream,
-						0x0,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
 						FU_LOGITECH_TAP_TOUCH_TRANSFER_BLOCK_SIZE,
 						error);
 	if (chunks == NULL)

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -489,7 +489,10 @@ fu_mediatek_scaler_device_set_data(FuMediatekScalerDevice *self, FuChunk *chk, G
 	g_autoptr(GBytes) chk_bytes = fu_chunk_get_bytes(chk);
 
 	/* smaller slices to accodomate pch variants */
-	chk_slices = fu_chunk_array_new_from_bytes(chk_bytes, 0x00, DDC_DATA_FRAGEMENT_SIZE);
+	chk_slices = fu_chunk_array_new_from_bytes(chk_bytes,
+						   FU_CHUNK_ADDR_OFFSET_NONE,
+						   FU_CHUNK_PAGESZ_NONE,
+						   DDC_DATA_FRAGEMENT_SIZE);
 	for (guint i = 0; i < fu_chunk_array_length(chk_slices); i++) {
 		g_autoptr(FuChunk) chk_slice = NULL;
 		g_autoptr(GByteArray) st_req = fu_struct_ddc_cmd_new();
@@ -746,7 +749,11 @@ fu_mediatek_scaler_device_write_firmware_impl(FuMediatekScalerDevice *self,
 	guint32 sent_sz = 0x0;
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, DDC_DATA_PAGE_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						DDC_DATA_PAGE_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -542,8 +542,10 @@ fu_firehose_updater_send_program_file(FuFirehoseUpdater *self,
 				      GError **error)
 {
 	g_autoptr(FuChunk) chk_last = NULL;
-	g_autoptr(FuChunkArray) chunks =
-	    fu_chunk_array_new_from_bytes(program_file, 0, payload_size);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(program_file,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       payload_size);
 
 	/* last block needs to be padded to the next sector_size,
 	 * so that we always send full sectors */

--- a/plugins/modem-manager/fu-mbim-qdu-updater.c
+++ b/plugins/modem-manager/fu-mbim-qdu-updater.c
@@ -353,7 +353,10 @@ fu_mbim_qdu_updater_file_open_ready(MbimDevice *device, GAsyncResult *res, gpoin
 		return;
 	}
 
-	ctx->chunks = fu_chunk_array_new_from_bytes(ctx->blob, 0x00, out_max_transfer_size);
+	ctx->chunks = fu_chunk_array_new_from_bytes(ctx->blob,
+						    FU_CHUNK_ADDR_OFFSET_NONE,
+						    FU_CHUNK_PAGESZ_NONE,
+						    out_max_transfer_size);
 	chk = fu_chunk_array_index(ctx->chunks, 0, &ctx->error);
 	if (chk == NULL) {
 		g_main_loop_quit(ctx->mainloop);

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -287,7 +287,11 @@ fu_mtd_device_erase(FuMtdDevice *self, GInputStream *stream, FuProgress *progres
 #ifdef HAVE_MTD_USER_H
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, self->erasesize, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						self->erasesize,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 
@@ -421,7 +425,11 @@ fu_mtd_device_write_verify(FuMtdDevice *self,
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 10 * 1024, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						10 * 1024,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -1523,7 +1523,11 @@ fu_nordic_hid_cfg_channel_write_firmware_blob(FuNordicHidCfgChannel *self,
 	if (!fu_nordic_hid_cfg_channel_dfu_sync(self, dfu_info, DFU_STATE_ACTIVE, error))
 		return FALSE;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0, dfu_info->sync_buffer_size, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						dfu_info->sync_buffer_size,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -433,7 +433,10 @@ fu_nvme_device_write_firmware(FuDevice *device,
 	}
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_bytes(fw2, 0x00, block_size);
+	chunks = fu_chunk_array_new_from_bytes(fw2,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       block_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -430,7 +430,8 @@ fu_parade_lspcon_device_flash_write(FuParadeLspconDevice *self,
 			return FALSE;
 	}
 
-	chunks = fu_chunk_array_new_from_stream(stream, base_address, 256, error);
+	chunks =
+	    fu_chunk_array_new_from_stream(stream, base_address, FU_CHUNK_PAGESZ_NONE, 256, error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -370,7 +370,10 @@ fu_pxi_ble_device_check_support_resume(FuPxiBleDevice *self,
 		return FALSE;
 
 	/* check offset is invalid or not */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_PXI_DEVICE_OBJECT_SIZE_MAX);
 	if (self->fwstate.offset > fu_chunk_array_length(chunks)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -532,6 +535,7 @@ fu_pxi_ble_device_write_chunk(FuPxiBleDevice *self, FuChunk *chk, GError **error
 	/* write payload */
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
+					       FU_CHUNK_PAGESZ_NONE,
 					       self->fwstate.mtu_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk2 = NULL;
@@ -753,7 +757,10 @@ fu_pxi_ble_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* prepare write fw into device */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_PXI_DEVICE_OBJECT_SIZE_MAX);
 	if (!fu_pxi_ble_device_check_support_resume(self,
 						    firmware,
 						    fu_progress_get_child(progress),

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -332,6 +332,7 @@ fu_pxi_receiver_device_write_chunk(FuDevice *device, FuChunk *chk, GError **erro
 	/* write payload */
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
+					       FU_CHUNK_PAGESZ_NONE,
 					       self->fwstate.mtu_size);
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -519,7 +520,10 @@ fu_pxi_receiver_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_PXI_DEVICE_OBJECT_SIZE_MAX);
 	/* prepare write fw into device */
 	self->fwstate.offset = 0;
 	self->fwstate.checksum = 0;

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -340,6 +340,7 @@ fu_pxi_wireless_device_write_chunk(FuDevice *device, FuChunk *chk, GError **erro
 	/* write payload */
 	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
 					       fu_chunk_get_address(chk),
+					       FU_CHUNK_PAGESZ_NONE,
 					       self->fwstate.mtu_size);
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -694,7 +695,10 @@ fu_pxi_wireless_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, FU_PXI_DEVICE_OBJECT_SIZE_MAX);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_PXI_DEVICE_OBJECT_SIZE_MAX);
 	/* prepare write fw into device */
 	self->fwstate.offset = 0;
 	self->fwstate.checksum = 0;

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -489,7 +489,10 @@ fu_qc_s5gen2_device_write_bucket(FuQcS5gen2Device *self,
 	if (!fu_qc_s5gen2_device_data_size(self, &data_sz, error))
 		return FALSE;
 
-	chunks = fu_chunk_array_new_from_bytes(data, 0, data_sz);
+	chunks = fu_chunk_array_new_from_bytes(data,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       data_sz);
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(GByteArray) pkt = fu_struct_qc_data_new();

--- a/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
@@ -269,7 +269,10 @@ fu_qsi_dock_mcu_device_write_chunk(FuQsiDockMcuDevice *self,
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GBytes) chk_bytes = fu_chunk_get_bytes(chk_page);
 
-	chunks = fu_chunk_array_new_from_bytes(chk_bytes, 0x0, FU_QSI_DOCK_TX_ISP_LENGTH_MCU);
+	chunks = fu_chunk_array_new_from_bytes(chk_bytes,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_QSI_DOCK_TX_ISP_LENGTH_MCU);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -507,7 +510,10 @@ fu_qsi_dock_mcu_device_write_firmware_with_idx(FuQsiDockMcuDevice *self,
 		return FALSE;
 
 	/* write external flash */
-	chunks = fu_chunk_array_new_from_bytes(fw_align, 0, FU_QSI_DOCK_EXTERN_FLASH_PAGE_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw_align,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_QSI_DOCK_EXTERN_FLASH_PAGE_SIZE);
 	if (!fu_qsi_dock_mcu_device_write_chunks(self,
 						 chunks,
 						 &checksum_val,

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -458,7 +458,8 @@ fu_realtek_mst_device_flash_iface_write(FuRealtekMstDevice *self,
 					GError **error)
 {
 	gsize total_size = g_bytes_get_size(data);
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(data, address, 256);
+	g_autoptr(FuChunkArray) chunks =
+	    fu_chunk_array_new_from_bytes(data, address, FU_CHUNK_PAGESZ_NONE, 256);
 
 	g_debug("write %#" G_GSIZE_MODIFIER "x bytes at %#08x", total_size, address);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -362,8 +362,11 @@ fu_rts54hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each block */
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0x00, FU_RTS54HID_TRANSFER_BLOCK_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_RTS54HID_TRANSFER_BLOCK_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -226,8 +226,11 @@ fu_rts54hid_module_write_firmware(FuDevice *module,
 		return FALSE;
 
 	/* build packets */
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0x00, FU_RTS54HID_TRANSFER_BLOCK_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_RTS54HID_TRANSFER_BLOCK_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (0) {

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -460,7 +460,11 @@ fu_rts54hub_device_write_firmware(FuDevice *device,
 	}
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, FU_RTS54HUB_DEVICE_BLOCK_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_RTS54HUB_DEVICE_BLOCK_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -293,7 +293,11 @@ fu_rts54hub_rtd21xx_background_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, ISP_DATA_BLOCKSIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						ISP_DATA_BLOCKSIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -339,7 +339,11 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, ISP_DATA_BLOCKSIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						ISP_DATA_BLOCKSIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -324,7 +324,11 @@ fu_scsi_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* prepare chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, chunksz, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						chunksz,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -175,7 +175,10 @@ fu_steelseries_fizz_write_fs(FuDevice *device,
 	if (tunnel)
 		cmd |= STEELSERIES_FIZZ_COMMAND_TUNNEL_BIT;
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, STEELSERIES_BUFFER_TRANSFER_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       STEELSERIES_BUFFER_TRANSFER_SIZE);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -245,7 +245,10 @@ fu_steelseries_gamepad_write_firmware(FuDevice *device,
 	if (blob == NULL)
 		return FALSE;
 
-	chunks = fu_chunk_array_new_from_bytes(blob, 0, STEELSERIES_BUFFER_TRANSFER_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       STEELSERIES_BUFFER_TRANSFER_SIZE);
 	if (fu_chunk_array_length(chunks) > (G_MAXUINT16 + 1)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -330,7 +330,10 @@ fu_steelseries_sonic_write_to_ram(FuDevice *device,
 	guint8 data[STEELSERIES_BUFFER_CONTROL_SIZE] = {0};
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, STEELSERIES_BUFFER_RAM_TRANSFER_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       STEELSERIES_BUFFER_RAM_TRANSFER_SIZE);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
@@ -406,7 +409,10 @@ fu_steelseries_sonic_write_to_flash(FuDevice *device,
 	guint8 data[STEELSERIES_BUFFER_CONTROL_SIZE] = {0};
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x0, STEELSERIES_BUFFER_FLASH_TRANSFER_SIZE);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       STEELSERIES_BUFFER_FLASH_TRANSFER_SIZE);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_status(progress, FWUPD_STATUS_DEVICE_WRITE);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -712,7 +712,8 @@ fu_synaptics_cape_device_write_firmware_image(FuSynapticsCapeDevice *self,
 
 	chunks =
 	    fu_chunk_array_new_from_stream(stream,
-					   0x00,
+					   FU_CHUNK_ADDR_OFFSET_NONE,
+					   FU_CHUNK_PAGESZ_NONE,
 					   sizeof(guint32) * FU_SYNAPTICS_CAPE_CMD_WRITE_DATAL_LEN,
 					   error);
 	if (chunks == NULL)

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -700,7 +700,10 @@ fu_synaptics_mst_device_update_esm(FuSynapticsMstDevice *self,
 	g_debug("ESM checksum %x doesn't match expected %x", flash_checksum, helper->checksum);
 
 	helper->progress = g_object_ref(progress);
-	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw, EEPROM_ESM_OFFSET, BLOCK_UNIT);
+	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
+						       EEPROM_ESM_OFFSET,
+						       FU_CHUNK_PAGESZ_NONE,
+						       BLOCK_UNIT);
 	return fu_device_retry(FU_DEVICE(self),
 			       fu_synaptics_mst_device_update_esm_cb,
 			       MAX_RETRY_COUNTS,
@@ -789,7 +792,10 @@ fu_synaptics_mst_device_update_tesla_leaf_firmware(FuSynapticsMstDevice *self,
 	helper->fw = g_bytes_ref(fw);
 	helper->checksum = fu_sum32_bytes(fw);
 	helper->progress = g_object_ref(progress);
-	helper->chunks = fu_chunk_array_new_from_bytes(fw, 0x0, BLOCK_UNIT);
+	helper->chunks = fu_chunk_array_new_from_bytes(fw,
+						       FU_CHUNK_ADDR_OFFSET_NONE,
+						       FU_CHUNK_PAGESZ_NONE,
+						       BLOCK_UNIT);
 	return fu_device_retry(FU_DEVICE(self),
 			       fu_synaptics_mst_device_update_tesla_leaf_firmware_cb,
 			       MAX_RETRY_COUNTS,
@@ -1074,6 +1080,7 @@ fu_synaptics_mst_device_update_panamera_firmware(FuSynapticsMstDevice *self,
 	helper->progress = g_object_ref(progress);
 	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
 						       EEPROM_BANK_OFFSET * helper->bank_to_update,
+						       FU_CHUNK_PAGESZ_NONE,
 						       BLOCK_UNIT);
 	if (!fu_device_retry_full(FU_DEVICE(self),
 				  fu_synaptics_mst_device_update_panamera_firmware_cb,
@@ -1298,7 +1305,10 @@ fu_synaptics_mst_device_update_firmware(FuSynapticsMstDevice *self,
 							    g_bytes_get_data(helper->fw, NULL),
 							    g_bytes_get_size(helper->fw));
 	helper->progress = g_object_ref(progress);
-	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw, 0x0, BLOCK_UNIT);
+	helper->chunks = fu_chunk_array_new_from_bytes(helper->fw,
+						       FU_CHUNK_ADDR_OFFSET_NONE,
+						       FU_CHUNK_PAGESZ_NONE,
+						       BLOCK_UNIT);
 	if (!fu_device_retry(FU_DEVICE(self),
 			     fu_synaptics_mst_device_update_firmware_cb,
 			     MAX_RETRY_COUNTS,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v5-device.c
@@ -364,8 +364,14 @@ fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 		address = f34->data_base + RMI_F34_BLOCK_DATA_V1_OFFSET;
 	else
 		address = f34->data_base + RMI_F34_BLOCK_DATA_OFFSET;
-	chunks_bin = fu_chunk_array_new_from_bytes(firmware_bin, 0x00, flash->block_size);
-	chunks_cfg = fu_chunk_array_new_from_bytes(bytes_cfg, 0x00, flash->block_size);
+	chunks_bin = fu_chunk_array_new_from_bytes(firmware_bin,
+						   FU_CHUNK_ADDR_OFFSET_NONE,
+						   FU_CHUNK_PAGESZ_NONE,
+						   flash->block_size);
+	chunks_cfg = fu_chunk_array_new_from_bytes(bytes_cfg,
+						   FU_CHUNK_ADDR_OFFSET_NONE,
+						   FU_CHUNK_PAGESZ_NONE,
+						   flash->block_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks_bin); i++) {
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks_bin, i, error);
 		if (chk == NULL)
@@ -392,7 +398,8 @@ fu_synaptics_rmi_v5_device_write_firmware(FuDevice *device,
 		FuProgress *progress_child = fu_progress_get_child(progress);
 		g_autoptr(FuChunkArray) chunks_sig = NULL;
 		chunks_sig = fu_chunk_array_new_from_bytes(signature_bin,
-							   0x00, /* start addr */
+							   FU_CHUNK_ADDR_OFFSET_NONE,
+							   FU_CHUNK_PAGESZ_NONE,
 							   flash->block_size);
 		if (!fu_synaptics_rmi_device_write(self,
 						   f34->data_base,

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -212,7 +212,10 @@ fu_synaptics_rmi_v7_device_write_blocks(FuSynapticsRmiDevice *self,
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* write FW blocks */
-	chunks = fu_chunk_array_new_from_bytes(fw, 0x00, flash->block_size);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       flash->block_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GByteArray) req = g_byte_array_new();
@@ -288,7 +291,8 @@ fu_synaptics_rmi_v7_device_write_partition_signature(FuSynapticsRmiDevice *self,
 
 	chunks =
 	    fu_chunk_array_new_from_bytes(bytes,
-					  0x00,
+					  FU_CHUNK_ADDR_OFFSET_NONE,
+					  FU_CHUNK_PAGESZ_NONE,
 					  (gsize)flash->payload_length * (gsize)flash->block_size);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
@@ -375,7 +379,8 @@ fu_synaptics_rmi_v7_device_write_partition(FuSynapticsRmiDevice *self,
 	/* write partition */
 	chunks =
 	    fu_chunk_array_new_from_bytes(bytes,
-					  0x00,
+					  FU_CHUNK_ADDR_OFFSET_NONE,
+					  FU_CHUNK_PAGESZ_NONE,
 					  (gsize)flash->payload_length * (gsize)flash->block_size);
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks) + 1);

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -564,8 +564,11 @@ fu_synaptics_vmm9_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	chunks =
-	    fu_chunk_array_new_from_stream(stream, 0x0, FU_STRUCT_HID_PAYLOAD_SIZE_FIFO, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						FU_STRUCT_HID_PAYLOAD_SIZE_FIFO,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_synaptics_vmm9_device_write_blocks(self,

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -143,6 +143,7 @@ fu_telink_dfu_ble_device_write_blob(FuTelinkDfuBleDevice *self,
 	/* OTA firmware data */
 	chunks = fu_chunk_array_new_from_bytes(blob,
 					       FU_TELINK_DFU_HID_DEVICE_START_ADDR,
+					       FU_CHUNK_PAGESZ_NONE,
 					       FU_STRUCT_TELINK_DFU_BLE_PKT_SIZE_PAYLOAD);
 	if (!fu_telink_dfu_ble_device_write_blocks(self,
 						   chunks,

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -677,7 +677,11 @@ fu_ti_tps6598x_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* write each SFWd block */
-	chunks_payload = fu_chunk_array_new_from_stream(stream_payload, 0x0, 64, error);
+	chunks_payload = fu_chunk_array_new_from_stream(stream_payload,
+							FU_CHUNK_ADDR_OFFSET_NONE,
+							FU_CHUNK_PAGESZ_NONE,
+							64,
+							error);
 	if (chunks_payload == NULL)
 		return FALSE;
 	if (!fu_ti_tps6598x_device_write_chunks(self,
@@ -693,7 +697,11 @@ fu_ti_tps6598x_device_write_firmware(FuDevice *device,
 	stream_sig = fu_firmware_get_image_by_id_stream(firmware, FU_FIRMWARE_ID_SIGNATURE, error);
 	if (stream_sig == NULL)
 		return FALSE;
-	chunks_sig = fu_chunk_array_new_from_stream(stream_sig, 0x0, 64, error);
+	chunks_sig = fu_chunk_array_new_from_stream(stream_sig,
+						    FU_CHUNK_ADDR_OFFSET_NONE,
+						    FU_CHUNK_PAGESZ_NONE,
+						    64,
+						    error);
 	if (chunks_sig == NULL)
 		return FALSE;
 	if (!fu_ti_tps6598x_device_write_sfws_chunks(self,
@@ -709,7 +717,11 @@ fu_ti_tps6598x_device_write_firmware(FuDevice *device,
 	stream_pubkey = fu_firmware_get_image_by_id_stream(firmware, "pubkey", error);
 	if (stream_pubkey == NULL)
 		return FALSE;
-	chunks_pubkey = fu_chunk_array_new_from_stream(stream_pubkey, 0x0, 64, error);
+	chunks_pubkey = fu_chunk_array_new_from_stream(stream_pubkey,
+						       FU_CHUNK_ADDR_OFFSET_NONE,
+						       FU_CHUNK_PAGESZ_NONE,
+						       64,
+						       error);
 	if (chunks_pubkey == NULL)
 		return FALSE;
 	if (!fu_ti_tps6598x_device_write_sfws_chunks(self,

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -389,7 +389,11 @@ fu_tpm_v2_device_upgrade_data(FuTpmV2Device *self,
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, TPM2_MAX_DIGEST_BUFFER, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						TPM2_MAX_DIGEST_BUFFER,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -178,7 +178,11 @@ fu_uf2_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* read in fixed sized chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, 512, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						512,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
@@ -240,7 +244,11 @@ fu_uf2_firmware_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* write in chunks */
-	chunks = fu_chunk_array_new_from_stream(stream, fu_firmware_get_addr(firmware), 256, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						fu_firmware_get_addr(firmware),
+						FU_CHUNK_PAGESZ_NONE,
+						256,
+						error);
 	if (chunks == NULL)
 		return NULL;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -428,7 +428,10 @@ fu_usi_dock_mcu_device_write_page(FuUsiDockMcuDevice *self, FuChunk *chk_page, G
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GBytes) chk_blob = fu_chunk_get_bytes(chk_page);
 
-	chunks = fu_chunk_array_new_from_bytes(chk_blob, 0x0, FU_STRUCT_USI_DOCK_HID_REQ_SIZE_BUF);
+	chunks = fu_chunk_array_new_from_bytes(chk_blob,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       FU_STRUCT_USI_DOCK_HID_REQ_SIZE_BUF);
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
 
@@ -608,7 +611,11 @@ fu_usi_dock_mcu_device_write_firmware_with_idx(FuUsiDockMcuDevice *self,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	chunks = fu_chunk_array_new_from_stream(stream, 0x0, W25Q16DV_PAGE_SIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						W25Q16DV_PAGE_SIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_usi_dock_mcu_device_write_pages(self,

--- a/plugins/vendor-example/fu-vendor-example-device.c.in
+++ b/plugins/vendor-example/fu-vendor-example-device.c.in
@@ -255,7 +255,7 @@ fu_{{vendor_example}}_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* write each block */
-	chunks = fu_chunk_array_new_from_stream(stream, self->start_addr, 64 /* block_size */, error);
+	chunks = fu_chunk_array_new_from_stream(stream, self->start_addr, FU_CHUNK_PAGESZ_NONE, 64 /* block_size */, error);
 	if (chunks == NULL)
 		return FALSE;
 	if (!fu_{{vendor_example}}_device_write_blocks(self,

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -501,7 +501,10 @@ fu_vli_pd_parade_device_write_firmware(FuDevice *device,
 		return FALSE;
 	if (!fu_vli_pd_parade_device_wait_ready(self, error))
 		return FALSE;
-	blocks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x10000);
+	blocks = fu_chunk_array_new_from_bytes(fw,
+					       FU_CHUNK_ADDR_OFFSET_NONE,
+					       FU_CHUNK_PAGESZ_NONE,
+					       0x10000);
 	for (guint i = 1; i < fu_chunk_array_length(blocks); i++) {
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(blocks, i, error);
 		if (chk == NULL)

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -418,7 +418,11 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* send data */
-	chunks = fu_chunk_array_new_from_stream(stream, 0x00, ISP_DATA_BLOCKSIZE, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						ISP_DATA_BLOCKSIZE,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -224,7 +224,10 @@ fu_wacom_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* flash chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw, priv->flash_base_addr, priv->flash_block_size);
+	chunks = fu_chunk_array_new_from_bytes(fw,
+					       priv->flash_base_addr,
+					       FU_CHUNK_PAGESZ_NONE,
+					       priv->flash_block_size);
 	return klass->write_firmware(device, chunks, progress, error);
 }
 

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -542,8 +542,10 @@ fu_wac_device_write_firmware(FuDevice *device,
 			return FALSE;
 
 		/* write block in chunks */
-		chunks =
-		    fu_chunk_array_new_from_bytes(blob_block, fd->start_addr, self->write_block_sz);
+		chunks = fu_chunk_array_new_from_bytes(blob_block,
+						       fd->start_addr,
+						       FU_CHUNK_PAGESZ_NONE,
+						       self->write_block_sz);
 		for (guint j = 0; j < fu_chunk_array_length(chunks); j++) {
 			g_autoptr(FuChunk) chk = NULL;
 			g_autoptr(GBytes) blob_chunk = NULL;

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id6.c
@@ -67,7 +67,8 @@ fu_wac_module_bluetooth_id6_write_blob(FuWacModule *self,
 {
 	g_autoptr(FuChunkArray) chunks =
 	    fu_chunk_array_new_from_stream(stream,
-					   0x0,
+					   FU_CHUNK_ADDR_OFFSET_NONE,
+					   FU_CHUNK_PAGESZ_NONE,
 					   FU_WAC_MODULE_BLUETOOTH_ID6_PAYLOAD_SZ,
 					   error);
 	if (chunks == NULL)

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -119,7 +119,11 @@ fu_wac_module_bluetooth_id9_write_blocks(FuWacModule *self,
 {
 	g_autoptr(FuChunkArray) chunks = NULL;
 
-	chunks = fu_chunk_array_new_from_stream(stream, 0, block_len, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
+						block_len,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/wacom-usb/fu-wac-module-touch.c
+++ b/plugins/wacom-usb/fu-wac-module-touch.c
@@ -44,7 +44,11 @@ fu_wac_module_touch_write_firmware(FuDevice *device,
 		g_prefix_error(error, "wacom touch module failed to get stream: ");
 		return FALSE;
 	}
-	chunks = fu_chunk_array_new_from_stream(stream, fu_firmware_get_addr(firmware), 128, error);
+	chunks = fu_chunk_array_new_from_stream(stream,
+						fu_firmware_get_addr(firmware),
+						FU_CHUNK_PAGESZ_NONE,
+						128,
+						error);
 	if (chunks == NULL)
 		return FALSE;
 

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -439,7 +439,8 @@ fu_wistron_dock_device_write_firmware(FuDevice *device,
 	if (stream_cbin == NULL)
 		return FALSE;
 	chunks = fu_chunk_array_new_from_stream(stream_cbin,
-						0x0,
+						FU_CHUNK_ADDR_OFFSET_NONE,
+						FU_CHUNK_PAGESZ_NONE,
 						FU_WISTRON_DOCK_TRANSFER_BLOCK_SIZE,
 						error);
 	if (chunks == NULL)


### PR DESCRIPTION
This also uses a much cleverer (and more efficient) method to work out the chunk sizes for a given offset.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
