### PR TITLE
Skip payload validation for uninit buffer response

### DIFF
--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -305,7 +305,9 @@ fu_logitech_bulkcontroller_device_sync_wait_any(FuLogitechBulkcontrollerDevice *
 	g_byte_array_append(response->data,
 			    buf + st->len,
 			    fu_struct_logitech_bulkcontroller_send_sync_res_get_payload_length(st));
-	if (response->data->len == 0) {
+	/* no palyload for UninitBuffer, skip check */
+	if ((response->cmd != FU_LOGITECH_BULKCONTROLLER_CMD_UNINIT_BUFFER) &&
+	    (response->data->len == 0)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_READ,

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -305,7 +305,7 @@ fu_logitech_bulkcontroller_device_sync_wait_any(FuLogitechBulkcontrollerDevice *
 	g_byte_array_append(response->data,
 			    buf + st->len,
 			    fu_struct_logitech_bulkcontroller_send_sync_res_get_payload_length(st));
-	/* no palyload for UninitBuffer, skip check */
+	/* no payload for UninitBuffer, skip check */
 	if ((response->cmd != FU_LOGITECH_BULKCONTROLLER_CMD_UNINIT_BUFFER) &&
 	    (response->data->len == 0)) {
 		g_set_error_literal(error,


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Prior to 2.x, device response was only validated against NULL. New 2.x refactored code, validate response payload length as well. Skip length validation for responses that has no payload.

[fwupdtool_vv.log](https://github.com/user-attachments/files/17498953/fwupdtool_vv.log)


