### PR TITLE
Add support for enumerate-only device emulation data

### DIFF
--- a/data/device-tests/gigadevice-gd32vf103.json
+++ b/data/device-tests/gigadevice-gd32vf103.json
@@ -1,0 +1,17 @@
+{
+  "name": "GigaDevice GD32VF103",
+  "interactive": false,
+  "steps": [
+    {
+      "emulation-url": "https://github.com/fwupd/fwupd-test-firmware/raw/refs/heads/main/device-tests/dfu-gd32-emulation.zip",
+      "components": [
+        {
+          "version": "1.0",
+          "guids": [
+            "f40ef7cf-e4f6-5708-b274-13edfb04646e"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/device-tests/meson.build
+++ b/data/device-tests/meson.build
@@ -19,6 +19,7 @@ install_data([
     'fpc-lenfy-moh.json',
     'fwupd-a3bu-xplained.json',
     'fwupd-at90usbkey.json',
+    'gigadevice-gd32vf103.json',
     'google-servo-micro.json',
     'hp-910-bt-keyboard.json',
     'hp-910-bt-mouse.json',


### PR DESCRIPTION
This is for devices that don't have updates on the LVFS (yet?), but we do want to test that they enumerated correctly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
