### PR TITLE
trivial: add a dependency on json-glib to the generated pkgconfig file

### DIFF
--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -88,7 +88,7 @@ libfwupd_dep = declare_dependency(
 pkgg = import('pkgconfig')
 pkgg.generate(
   fwupd,
-  requires: [ 'gio-2.0' ],
+  requires: [ 'gio-2.0', 'json-glib-1.0' ],
   subdirs: base_dir,
   version: meson.project_version(),
   name: 'fwupd',


### PR DESCRIPTION
This is needed when building with `-Dwrap_mode=nodownload` since fwupd.h
is including header files from json-glib.

Fixes #7988

Ping: @superm1 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
