### PR TITLE
trivial: Fix some harmless -Wformat warnings with clang 19

### DIFF
--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -222,7 +222,7 @@ fu_cfi_device_wait_for_status_cb(FuDevice *device, gpointer user_data, GError **
 			    FWUPD_ERROR_INTERNAL,
 			    "wanted 0x%x, got 0x%x",
 			    helper->value,
-			    buf[0x1] & helper->mask);
+			    (guint)(buf[0x1] & helper->mask));
 		return FALSE;
 	}
 

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -36,7 +36,7 @@ fu_ccgx_dmc_devx_device_version_dmc_bfw(FuCcgxDmcDevxDevice *self, gsize offset)
 {
 	const guint8 *fw_version = fu_ccgx_dmc_devx_device_get_fw_version(self);
 	return g_strdup_printf("%u.%u.%u.%u",
-			       fw_version[offset + 3] >> 4,
+			       (guint)(fw_version[offset + 3] >> 4),
 			       fw_version[offset + 3] & 0xFu,
 			       fw_version[offset + 2],
 			       fu_memread_uint16(fw_version + offset, G_LITTLE_ENDIAN));
@@ -47,7 +47,7 @@ fu_ccgx_dmc_devx_device_version_dmc_app(FuCcgxDmcDevxDevice *self, gsize offset)
 {
 	const guint8 *fw_version = fu_ccgx_dmc_devx_device_get_fw_version(self);
 	return g_strdup_printf("%u.%u.%u",
-			       fw_version[offset + 4 + 3] >> 4,
+			       (guint)(fw_version[offset + 4 + 3] >> 4),
 			       fw_version[offset + 4 + 3] & 0xFu,
 			       fw_version[offset + 4 + 2]);
 }

--- a/plugins/ch341a/fu-ch341a-cfi-device.c
+++ b/plugins/ch341a/fu-ch341a-cfi-device.c
@@ -57,7 +57,7 @@ fu_ch341a_cfi_device_wait_for_status_cb(FuDevice *device, gpointer user_data, GE
 			    FWUPD_ERROR_INTERNAL,
 			    "wanted 0x%x, got 0x%x",
 			    helper->value,
-			    buf[0x1] & helper->mask);
+			    (guint)(buf[0x1] & helper->mask));
 		return FALSE;
 	}
 

--- a/plugins/pixart-rf/fu-pxi-common.c
+++ b/plugins/pixart-rf/fu-pxi-common.c
@@ -133,9 +133,9 @@ gchar *
 fu_pxi_hpac_version_info_parse(const guint16 hpac_ver)
 {
 	return g_strdup_printf("%u%u.%u%u.%u",
-			       hpac_ver / 10000,
-			       (hpac_ver / 1000) % 10,
-			       ((hpac_ver / 100) % 10),
-			       (hpac_ver / 10) % 10,
-			       hpac_ver % 10);
+			       (guint)(hpac_ver / 10000),
+			       (guint)((hpac_ver / 1000) % 10),
+			       (guint)((hpac_ver / 100) % 10),
+			       (guint)((hpac_ver / 10) % 10),
+			       (guint)(hpac_ver % 10));
 }

--- a/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
@@ -134,7 +134,10 @@ fu_qsi_dock_mcu_device_enumerate_children(FuQsiDockMcuDevice *self, GError **err
 				continue;
 			}
 
-			version = g_strdup_printf("%x.%x.%02x", val[0] & 0xFu, val[0] >> 4, val[1]);
+			version = g_strdup_printf("%x.%x.%02x",
+						  val[0] & 0xFu,
+						  (guint)(val[0] >> 4),
+						  val[1]);
 			g_debug("ignoring %s --> %s", components[i].name, version);
 
 			continue;

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -199,9 +199,9 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 			if (fu_device_has_private_flag(FU_DEVICE(self),
 						       FU_USI_DOCK_DEVICE_FLAG_VERFMT_HP)) {
 				version = g_strdup_printf("%x.%x.%x.%x",
-							  val[0] >> 4,
+							  (guint)(val[0] >> 4),
 							  val[0] & 0xFu,
-							  val[1] >> 4,
+							  (guint)(val[1] >> 4),
 							  val[1] & 0xFu);
 				fu_device_set_version_format(FU_DEVICE(self),
 							     FWUPD_VERSION_FORMAT_QUAD);
@@ -209,7 +209,7 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 			} else {
 				version = g_strdup_printf("%x.%x.%02x",
 							  val[0] & 0xFu,
-							  val[0] >> 4,
+							  (guint)(val[0] >> 4),
 							  val[1]);
 				g_debug("ignoring %s --> %s", components[i].name, version);
 			}
@@ -325,7 +325,7 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 				g_debug("ignoring %s", components[i].name);
 				continue;
 			}
-			version = g_strdup_printf("%x.%x.%x", val[2] >> 4, val[3], val[4]);
+			version = g_strdup_printf("%x.%x.%x", (guint)(val[2] >> 4), val[3], val[4]);
 			fu_device_set_version_format(child, FWUPD_VERSION_FORMAT_TRIPLET);
 			fu_device_set_version(child, version);
 			fu_device_add_icon(child, "network-wired");
@@ -339,9 +339,9 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 			if (fu_device_has_private_flag(FU_DEVICE(self),
 						       FU_USI_DOCK_DEVICE_FLAG_VERFMT_HP)) {
 				version = g_strdup_printf("%x.%x.%x.%x",
-							  val[0] >> 4,
+							  (guint)(val[0] >> 4),
 							  val[0] & 0xFu,
-							  val[1] >> 4,
+							  (guint)(val[1] >> 4),
 							  val[1] & 0xFu);
 				fu_device_set_version_format(child, FWUPD_VERSION_FORMAT_QUAD);
 			} else {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
