### PR TITLE
trivial: remove emulation-tag from lower priority devices

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -850,6 +850,7 @@ fu_device_list_add(FuDeviceList *self, FuDevice *device)
 			       fu_device_get_id(device),
 			       fu_device_get_plugin(device),
 			       fu_device_get_plugin(item->device));
+			fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_EMULATION_TAG);
 			return;
 		}
 


### PR DESCRIPTION
Emulation tags are by device ID.  If a device ID has two fwupd devices of different priorities the tag gets added to both.

Lower priority devices aren't added to the engine, but the engine still tries to gather emulation data.

Drop the emulation tag device flag from the lower priority device to ensure the emulation data isn't lost for the higher priority device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
