### PR TITLE
dell-k2: rework the update flow for ec managed devices

### DIFF
--- a/plugins/dell-k2/dell-k2.quirk
+++ b/plugins/dell-k2/dell-k2.quirk
@@ -21,18 +21,20 @@ Plugin = dell_k2
 Name = Unprobed Dell accessory endpoint
 Plugin = dell_k2
 
+[USB\VID_413C&PID_B0A4]
+Name = Remote Management in Dell dock
+Plugin = dell_k2
+
 [USB\VID_413C&PID_B0A5]
 Name = Unprobed Dell accessory endpoint
 Plugin = synaptics_vmm9
 
-# K2 TBT5 controller
 [TBT-00d4b0a2]
 Name = USB4v2 controller in Dell dock
 Summary = USB4v2 controller
 Vendor = Dell Inc.
 VendorId = TBT:0x00D4
 
-# K2 TBT4 controller
 [TBT-00d4b0a1]
 Name = USB4 controller in Dell dock
 Summary = USB4 controller

--- a/plugins/dell-k2/fu-dell-k2-dpmux.c
+++ b/plugins/dell-k2/fu-dell-k2-dpmux.c
@@ -46,7 +46,7 @@ fu_dell_k2_dpmux_setup(FuDevice *device, GError **error)
 
 	/* version */
 	dpmux_version = fu_dell_k2_ec_get_dpmux_version(proxy);
-	fu_device_set_version_raw(device, GUINT32_FROM_BE(dpmux_version));
+	fu_device_set_version_raw(device, dpmux_version);
 
 	return TRUE;
 }
@@ -58,51 +58,11 @@ fu_dell_k2_dpmux_write(FuDevice *device,
 		       FwupdInstallFlags flags,
 		       GError **error)
 {
-	FuDevice *proxy = fu_device_get_proxy(device);
-	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GBytes) fw_whdr = NULL;
-	g_autoptr(FuChunkArray) chunks = NULL;
-
-	/* progress */
-	fu_progress_set_id(progress, G_STRLOC);
-
-	/* basic tests */
-	g_return_val_if_fail(device != NULL, FALSE);
-	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
-
-	/* get default firmware image */
-	fw = fu_firmware_get_bytes(firmware, error);
-	if (fw == NULL)
-		return FALSE;
-
-	/* construct writing buffer */
-	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, FU_DELL_K2_EC_DEV_TYPE_DP_MUX, 0);
-
-	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, FU_DELL_K2_EC_HID_DATA_PAGE_SZ);
-
-	/* write to device */
-	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
-
-		if (chk == NULL)
-			return FALSE;
-
-		if (!fu_dell_k2_ec_hid_write(proxy, fu_chunk_get_bytes(chk), error))
-			return FALSE;
-
-		/* update progress */
-		fu_progress_set_percentage_full(progress,
-						(gsize)i + 1,
-						(gsize)fu_chunk_array_length(chunks));
-	}
-
-	/* check version is not required */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-
-	/* success */
-	g_debug("dpmux/retimer firmware written successfully");
-	return TRUE;
+	return fu_dell_k2_ec_write_firmware_helper(fu_device_get_proxy(device),
+						   firmware,
+						   FU_DELL_K2_EC_DEV_TYPE_DP_MUX,
+						   0,
+						   error);
 }
 
 static void
@@ -122,6 +82,7 @@ fu_dell_k2_dpmux_init(FuDellK2Dpmux *self)
 	fu_device_add_vendor_id(FU_DEVICE(self), "USB:0x413C");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN);

--- a/plugins/dell-k2/fu-dell-k2-ec-hid.h
+++ b/plugins/dell-k2/fu-dell-k2-ec-hid.h
@@ -13,6 +13,9 @@
 #define FU_DELL_K2_EC_HID_CMD_FWUPDATE	  0xAB
 #define FU_DELL_K2_EC_HID_EXT_FWUPDATE	  0x80
 #define FU_DELL_K2_EC_HID_SUBCMD_FWUPDATE 0x00
+#define FU_DELL_K2_EC_DEV_EC_CHUNK_SZ	  160000
+#define FU_DELL_K2_EC_DEV_ANY_CHUNK_SZ	  180000
+#define FU_DELL_K2_EC_DEV_NO_CHUNK_SZ	  G_MAXSIZE
 #define FU_DELL_K2_EC_HID_DATA_PAGE_SZ	  192
 #define FU_DELL_K2_EC_HID_RESPONSE_LENGTH 0x03
 #define FU_DELL_K2_EC_HID_I2C_ADDRESS	  0xec
@@ -37,7 +40,7 @@ gboolean
 fu_dell_k2_ec_hid_write(FuDevice *device, GBytes *buf, GError **error);
 
 GBytes *
-fu_dell_k2_ec_hid_fwup_pkg_new(GBytes *fw, guint8 dev_type, guint8 dev_identifier);
+fu_dell_k2_ec_hid_fwup_pkg_new(FuChunk *chk, gsize fw_sz, guint8 dev_type, guint8 dev_identifier);
 
 gboolean
 fu_dell_k2_ec_hid_i2c_write(FuDevice *self, const guint8 *input, gsize write_size, GError **error);

--- a/plugins/dell-k2/fu-dell-k2-ec.h
+++ b/plugins/dell-k2/fu-dell-k2-ec.h
@@ -26,7 +26,7 @@ fu_dell_k2_ec_new(FuDevice *proxy);
 void
 fu_dell_k2_ec_enable_tbt_passive(FuDevice *device);
 gboolean
-fu_dell_k2_ec_modify_lock(FuDevice *device, gboolean lock, GError **error);
+fu_dell_k2_ec_own_dock(FuDevice *device, gboolean lock, GError **error);
 gboolean
 fu_dell_k2_ec_run_passive_update(FuDevice *device, GError **error);
 guint32
@@ -53,3 +53,9 @@ gboolean
 fu_dell_k2_ec_is_dock_ready4update(FuDevice *device, GError **error);
 gboolean
 fu_dell_k2_ec_is_dev_present(FuDevice *device, guint8 dev_type, guint8 sub_type, guint8 instance);
+gboolean
+fu_dell_k2_ec_write_firmware_helper(FuDevice *device,
+				    FuFirmware *firmware,
+				    guint8 dev_type,
+				    guint8 dev_identifier,
+				    GError **error);

--- a/plugins/dell-k2/fu-dell-k2-ec.rs
+++ b/plugins/dell-k2/fu-dell-k2-ec.rs
@@ -92,3 +92,10 @@ enum K2DockSku {
     Tbt4,
     Tbt5,
 }
+
+#[repr(u8)] // dock resp to chunk write
+enum DellK2EcRespToChunk {
+    UpdateComplete = 1,
+    SendNextChunk,
+    UpdateFailed,
+}

--- a/plugins/dell-k2/fu-dell-k2-package.c
+++ b/plugins/dell-k2/fu-dell-k2-package.c
@@ -47,7 +47,7 @@ fu_dell_k2_package_setup(FuDevice *device, GError **error)
 
 	/* setup version */
 	pkg_version_raw = fu_dell_k2_ec_get_package_version(proxy);
-	fu_device_set_version_raw(device, GUINT32_FROM_BE(pkg_version_raw));
+	fu_device_set_version_raw(device, pkg_version_raw);
 
 	return TRUE;
 }

--- a/plugins/dell-k2/fu-dell-k2-pd.c
+++ b/plugins/dell-k2/fu-dell-k2-pd.c
@@ -64,7 +64,7 @@ fu_dell_k2_pd_setup(FuDevice *device, GError **error)
 
 	/* version */
 	raw_version = fu_dell_k2_ec_get_pd_version(proxy, self->pd_subtype, self->pd_instance);
-	fu_device_set_version_raw(device, GUINT32_FROM_BE(raw_version));
+	fu_device_set_version_raw(device, raw_version);
 
 	return TRUE;
 }
@@ -76,59 +76,13 @@ fu_dell_k2_pd_write(FuDevice *device,
 		    FwupdInstallFlags flags,
 		    GError **error)
 {
-	FuDevice *proxy = fu_device_get_proxy(device);
 	FuDellK2Pd *self = FU_DELL_K2_PD(device);
-	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GBytes) fw_whdr = NULL;
-	g_autoptr(FuChunkArray) chunks = NULL;
 
-	/* progress */
-	fu_progress_set_id(progress, G_STRLOC);
-
-	/* basic tests */
-	g_return_val_if_fail(device != NULL, FALSE);
-	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
-
-	/* get default firmware image */
-	fw = fu_firmware_get_bytes(firmware, error);
-	if (fw == NULL)
-		return FALSE;
-
-	/* version message */
-	g_debug("%s firmware version, old: %s, new: %s.",
-		fu_device_get_name(device),
-		fu_device_get_version(device),
-		fu_firmware_get_version(firmware));
-
-	/* construct writing buffer */
-	fw_whdr =
-	    fu_dell_k2_ec_hid_fwup_pkg_new(fw, FU_DELL_K2_EC_DEV_TYPE_PD, self->pd_identifier);
-
-	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, FU_DELL_K2_EC_HID_DATA_PAGE_SZ);
-
-	/* write to device */
-	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
-
-		if (chk == NULL)
-			return FALSE;
-
-		if (!fu_dell_k2_ec_hid_write(proxy, fu_chunk_get_bytes(chk), error))
-			return FALSE;
-
-		/* update progress */
-		fu_progress_set_percentage_full(progress,
-						(gsize)i + 1,
-						(gsize)fu_chunk_array_length(chunks));
-	}
-
-	/* check version is not required */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-
-	/* success */
-	g_debug("%s firmware written successfully.", fu_device_get_name(device));
-	return TRUE;
+	return fu_dell_k2_ec_write_firmware_helper(fu_device_get_proxy(device),
+						   firmware,
+						   FU_DELL_K2_EC_DEV_TYPE_PD,
+						   self->pd_identifier,
+						   error);
 }
 
 static void
@@ -148,6 +102,7 @@ fu_dell_k2_pd_init(FuDellK2Pd *self)
 	fu_device_add_vendor_id(FU_DEVICE(self), "USB:0x413C");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SKIPS_RESTART);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN);

--- a/plugins/dell-k2/fu-dell-k2-rmm.c
+++ b/plugins/dell-k2/fu-dell-k2-rmm.c
@@ -14,7 +14,7 @@ struct _FuDellK2Rmm {
 	FuDevice parent_instance;
 };
 
-G_DEFINE_TYPE(FuDellK2Rmm, fu_dell_k2_rmm, FU_TYPE_DEVICE)
+G_DEFINE_TYPE(FuDellK2Rmm, fu_dell_k2_rmm, FU_TYPE_HID_DEVICE)
 
 static gchar *
 fu_dell_k2_rmm_convert_version(FuDevice *device, guint64 version_raw)
@@ -25,29 +25,29 @@ fu_dell_k2_rmm_convert_version(FuDevice *device, guint64 version_raw)
 			       (guint)(version_raw >> 8) & 0xFF);
 }
 
+void
+fu_dell_k2_rmm_fix_version(FuDevice *device)
+{
+	FuDevice *parent = NULL;
+
+	/* use version given by parent */
+	parent = fu_device_get_parent(device);
+	if (parent != NULL) {
+		guint32 rmm_version;
+
+		rmm_version = fu_dell_k2_ec_get_rmm_version(parent);
+		fu_device_set_version_raw(device, rmm_version);
+	}
+}
+
 static gboolean
 fu_dell_k2_rmm_setup(FuDevice *device, GError **error)
 {
-	FuDevice *proxy = fu_device_get_proxy(device);
-	guint32 rmm_version;
-	FuDellK2BaseType dock_type = fu_dell_k2_ec_get_dock_type(proxy);
-	guint8 dev_type = FU_DELL_K2_EC_DEV_TYPE_RMM;
-	g_autofree const gchar *devname = NULL;
+	/* FuUsbDevice->setup */
+	if (!FU_DEVICE_CLASS(fu_dell_k2_rmm_parent_class)->setup(device, error))
+		return FALSE;
 
-	/* name */
-	devname = g_strdup_printf("%s", fu_dell_k2_ec_devicetype_to_str(dev_type, 0, 0));
-	fu_device_set_name(device, devname);
-	fu_device_set_logical_id(device, devname);
-
-	/* IDs */
-	fu_device_add_instance_u8(device, "DOCKTYPE", dock_type);
-	fu_device_add_instance_u8(device, "DEVTYPE", dev_type);
-	fu_device_build_instance_id(device, error, "EC", "DOCKTYPE", "DEVTYPE", NULL);
-
-	/* version */
-	rmm_version = fu_dell_k2_ec_get_rmm_version(proxy);
-	fu_device_set_version_raw(device, GUINT32_FROM_BE(rmm_version));
-
+	fu_dell_k2_rmm_fix_version(device);
 	return TRUE;
 }
 
@@ -58,51 +58,11 @@ fu_dell_k2_rmm_write(FuDevice *device,
 		     FwupdInstallFlags flags,
 		     GError **error)
 {
-	FuDevice *proxy = fu_device_get_proxy(device);
-	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GBytes) fw_whdr = NULL;
-	g_autoptr(FuChunkArray) chunks = NULL;
-
-	/* progress */
-	fu_progress_set_id(progress, G_STRLOC);
-
-	/* basic tests */
-	g_return_val_if_fail(device != NULL, FALSE);
-	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
-
-	/* get default firmware image */
-	fw = fu_firmware_get_bytes(firmware, error);
-	if (fw == NULL)
-		return FALSE;
-
-	/* construct writing buffer */
-	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, FU_DELL_K2_EC_DEV_TYPE_RMM, 0);
-
-	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, FU_DELL_K2_EC_HID_DATA_PAGE_SZ);
-
-	/* write to device */
-	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
-
-		if (chk == NULL)
-			return FALSE;
-
-		if (!fu_dell_k2_ec_hid_write(proxy, fu_chunk_get_bytes(chk), error))
-			return FALSE;
-
-		/* update progress */
-		fu_progress_set_percentage_full(progress,
-						(gsize)i + 1,
-						(gsize)fu_chunk_array_length(chunks));
-	}
-
-	/* check version is not required */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-
-	/* success */
-	g_debug("Remote Management firmware written successfully");
-	return TRUE;
+	return fu_dell_k2_ec_write_firmware_helper(device,
+						   firmware,
+						   FU_DELL_K2_EC_DEV_TYPE_RMM,
+						   0,
+						   error);
 }
 
 static void
@@ -123,7 +83,7 @@ fu_dell_k2_rmm_init(FuDellK2Rmm *self)
 	fu_device_add_icon(FU_DEVICE(self), "dock-usb");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
-	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 }
@@ -139,11 +99,10 @@ fu_dell_k2_rmm_class_init(FuDellK2RmmClass *klass)
 }
 
 FuDellK2Rmm *
-fu_dell_k2_rmm_new(FuDevice *proxy)
+fu_dell_k2_rmm_new(FuUsbDevice *device)
 {
-	FuContext *ctx = fu_device_get_context(proxy);
-	FuDellK2Rmm *self = NULL;
-	self = g_object_new(FU_TYPE_DELL_K2_RMM, "context", ctx, NULL);
-	fu_device_set_proxy(FU_DEVICE(self), proxy);
+	FuDellK2Rmm *self = g_object_new(FU_TYPE_DELL_K2_RMM, NULL);
+
+	fu_device_incorporate(FU_DEVICE(self), FU_DEVICE(device));
 	return self;
 }

--- a/plugins/dell-k2/fu-dell-k2-rmm.h
+++ b/plugins/dell-k2/fu-dell-k2-rmm.h
@@ -8,8 +8,13 @@
 
 #include <fwupdplugin.h>
 
+/* Device IDs: USB RMM */
+#define DELL_K2_USB_RMM_PID 0xB0A4
+
 #define FU_TYPE_DELL_K2_RMM (fu_dell_k2_rmm_get_type())
-G_DECLARE_FINAL_TYPE(FuDellK2Rmm, fu_dell_k2_rmm, FU, DELL_K2_RMM, FuDevice)
+G_DECLARE_FINAL_TYPE(FuDellK2Rmm, fu_dell_k2_rmm, FU, DELL_K2_RMM, FuHidDevice)
 
 FuDellK2Rmm *
-fu_dell_k2_rmm_new(FuDevice *proxy);
+fu_dell_k2_rmm_new(FuUsbDevice *device);
+void
+fu_dell_k2_rmm_fix_version(FuDevice *device);

--- a/plugins/dell-k2/fu-dell-k2-rtshub.c
+++ b/plugins/dell-k2/fu-dell-k2-rtshub.c
@@ -268,9 +268,6 @@ fu_dell_k2_rtshub_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	/* check version is not required */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-
 	/* success! */
 	return TRUE;
 }
@@ -431,6 +428,7 @@ fu_dell_k2_rtshub_init(FuDellK2RtsHub *self)
 	fu_device_add_icon(FU_DEVICE(self), "dock-usb");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SKIPS_RESTART);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_RETRY_OPEN);

--- a/plugins/dell-k2/fu-dell-k2-wtpd.c
+++ b/plugins/dell-k2/fu-dell-k2-wtpd.c
@@ -58,43 +58,11 @@ fu_dell_k2_wtpd_write(FuDevice *device,
 		      FwupdInstallFlags flags,
 		      GError **error)
 {
-	FuDevice *proxy = fu_device_get_proxy(device);
-	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GBytes) fw_whdr = NULL;
-	g_autoptr(FuChunkArray) chunks = NULL;
-
-	/* basic tests */
-	g_return_val_if_fail(device != NULL, FALSE);
-	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
-
-	/* get default firmware image */
-	fw = fu_firmware_get_bytes(firmware, error);
-	if (fw == NULL)
-		return FALSE;
-
-	/* construct writing buffer */
-	fw_whdr = fu_dell_k2_ec_hid_fwup_pkg_new(fw, FU_DELL_K2_EC_DEV_TYPE_WTPD, 0);
-
-	/* prepare the chunks */
-	chunks = fu_chunk_array_new_from_bytes(fw_whdr, 0, FU_DELL_K2_EC_HID_DATA_PAGE_SZ);
-
-	/* write to device */
-	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i);
-
-		if (chk == NULL)
-			return FALSE;
-
-		if (!fu_dell_k2_ec_hid_write(proxy, fu_chunk_get_bytes(chk), error))
-			return FALSE;
-	}
-
-	/* check version is not required */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
-
-	/* success */
-	g_debug("pd firmware written successfully");
-	return TRUE;
+	return fu_dell_k2_ec_write_firmware_helper(fu_device_get_proxy(device),
+						   firmware,
+						   FU_DELL_K2_EC_DEV_TYPE_WTPD,
+						   0,
+						   error);
 }
 
 static void
@@ -114,6 +82,7 @@ fu_dell_k2_wtpd_init(FuDellK2Wtpd *self)
 	fu_device_add_vendor_id(FU_DEVICE(self), "USB:0x413C");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_EXPLICIT_ORDER);
 	fu_device_add_internal_flag(FU_DEVICE(self), FU_DEVICE_INTERNAL_FLAG_USE_PROXY_FOR_OPEN);


### PR DESCRIPTION
1. Consolidate the update code for the devices managed by ec
2. Use chunk and page for ec relevant update
3. RMM has its own usb handle so separate it from ec subcomponents
4. Add delay time for chunk and page to improve the stability
5. Move per device prepare to the composite level

(cherry picked from commit 6be958827569a116f2890ecdffdc225e8ec6a99b)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
