### PR TITLE
trivial: ci: drop coveralls

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -43,12 +43,6 @@ jobs:
           CI: true
         run: |
           docker run --privileged -e CI=true -t -v $GITHUB_WORKSPACE:/github/workspace docker.pkg.github.com/fwupd/fwupd/fwupd-${{matrix.os}}:latest contrib/ci/${{matrix.os}}-test.sh
-      - name: Coveralls
-        if: matrix.os == 'debian-x86_64' || matrix.os == 'debian-i386'
-        uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8 # v2.3.4
-        with:
-          flag-name: run-${{ join(matrix.*, '-') }}
-          parallel: true
       - name: Save any coverage data
         if: matrix.os == 'debian-x86_64'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -56,16 +50,6 @@ jobs:
           name: coverage
           path: ${{ github.workspace }}/coverage.xml
           if-no-files-found: ignore
-
-  finish:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Close parallel build
-        uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8 # v2.3.4
-        with:
-          parallel-finished: true
-          carryforward: "run-debian-i386,run-debian-x86_64"
 
   codecov:
     needs: build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/10744/badge.svg)](https://scan.coverity.com/projects/10744)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/fwupd.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:fwupd)
 [![CircleCI](https://circleci.com/gh/fwupd/fwupd/tree/main.svg?style=svg)](https://circleci.com/gh/fwupd/fwupd/tree/main)
-[![Coveralls Coverage Status](https://coveralls.io/repos/github/fwupd/fwupd/badge.svg)](https://coveralls.io/github/fwupd/fwupd)
 [![Codecov Coverage Status](https://codecov.io/gh/fwupd/fwupd/graph/badge.svg?token=vykt2ROfu9)](https://codecov.io/gh/fwupd/fwupd)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/fwupd/fwupd/badge)](https://securityscorecards.dev/viewer/?uri=github.com/fwupd/fwupd)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8751/badge)](https://www.bestpractices.dev/projects/8751)


### PR DESCRIPTION
I'm generally more happy with codecov having seen it in action the last few days.  I like the inline warnings on missing coverage, the view of coverage of patches and project and it's a lot faster UI.

Drop coveralls from CI.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
