### PR TITLE
trivial: enable code coverage for all 'matrix' builds

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -44,22 +44,10 @@ jobs:
         run: |
           docker run --privileged -e CI=true -t -v $GITHUB_WORKSPACE:/github/workspace docker.pkg.github.com/fwupd/fwupd/fwupd-${{matrix.os}}:latest contrib/ci/${{matrix.os}}-test.sh
       - name: Save any coverage data
-        if: matrix.os == 'debian-x86_64'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: coverage
+          name: coverage-${{ join(matrix.*, '-') }}
           path: ${{ github.workspace }}/coverage.xml
-          if-no-files-found: ignore
-
-  codecov:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download coverage data
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        id: download
-        with:
-          name: coverage
       - name: Upload to codecov
         uses: codecov/codecov-action@v4
         env:

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -70,7 +70,7 @@ pkgver() {
 build() {
   cd ${pkgname}
   if [ -n "$CI" ]; then
-    export CI="--wrap-mode=default"
+    export CI="--wrap-mode=default -Db_coverage=true"
   fi
   arch-meson -D b_lto=false $CI ../build \
     -Dplugin_powerd=disabled \

--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -3,7 +3,7 @@
 pacman -U --noconfirm dist/*.pkg.*
 
 #run the CI tests for Qt5
-pacman -S --noconfirm qt5-base
+pacman -S --noconfirm qt5-base gcovr
 meson qt5-thread-test contrib/ci/qt5-thread-test
 ninja -C qt5-thread-test test
 
@@ -22,3 +22,14 @@ fwupdtool enable-test-devices
 sleep 10
 /usr/share/installed-tests/fwupd/fwupdmgr.sh
 /usr/share/installed-tests/fwupd/fwupdtool.sh
+
+# generate coverage report
+if [ "$CI" = "true" ]; then
+	gcovr -x \
+		--filter build/libfwupd \
+		--filter build/libfwupdplugin \
+		--filter build/plugins \
+		--filter build/src \
+		-o coverage.xml
+	sed "s,build/,,g" coverage.xml -i
+fi

--- a/contrib/ci/fedora-test.sh
+++ b/contrib/ci/fedora-test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 #install RPM packages
 dnf install -y dist/*.rpm
+dnf install -y gcovr
 
 fwupdtool enable-test-devices
 
@@ -19,3 +20,14 @@ sleep 5
 /usr/libexec/fwupd/fwupd --verbose &
 sleep 10
 gnome-desktop-testing-runner fwupd
+
+# generate coverage report
+if [ "$CI" = "true" ]; then
+	gcovr -x \
+		--filter build/libfwupd \
+		--filter build/libfwupdplugin \
+		--filter build/plugins \
+		--filter build/src \
+		-o coverage.xml
+	sed "s,build/,,g" coverage.xml -i
+fi

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -233,6 +233,7 @@ fwupd wrapper for Qubes OS
 %meson \
 %if 0%{?enable_ci}
     --werror \
+    -Db_coverage=true \
     -Db_sanitize=address,undefined \
 %endif
     -Dumockdev_tests=disabled \


### PR DESCRIPTION
Some specific distro builds are the only ones covering certain thing and codecov is supposed to merge automatically.

Link: https://docs.codecov.com/docs/merging-reports

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
