### PR TITLE
trivial: enable emulation-tag during Fedora testing

### DIFF
--- a/contrib/ci/fedora-test.sh
+++ b/contrib/ci/fedora-test.sh
@@ -13,9 +13,8 @@ dbus-daemon --system --fork
 /usr/lib/polkit-1/polkitd &
 sleep 5
 
-# Avoid this in Fedora right now; there appears to be a memory leak
-# found by asan that needs to be fixed first.
-# fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
+# Enable testing capturing emulation data
+fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
 
 # run the daemon startup to check it can start
 /usr/libexec/fwupd/fwupd --immediate-exit --verbose

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -604,6 +604,25 @@ fu_strsafe(const gchar *str, gsize maxsz)
 }
 
 /**
+ * fu_strsafe_bytes:
+ * @blob: (not nullable): a #GBytes
+ * @maxsz: maximum size of returned string
+ *
+ * Converts a #GBytes into something that can be safely printed.
+ *
+ * Returns: (transfer full): safe string, or %NULL if there was nothing valid
+ *
+ * Since: 2.0.2
+ **/
+gchar *
+fu_strsafe_bytes(GBytes *blob, gsize maxsz)
+{
+	g_return_val_if_fail(blob != NULL, NULL);
+	return fu_strsafe((const gchar *)g_bytes_get_data(blob, NULL),
+			  MIN(g_bytes_get_size(blob), maxsz));
+}
+
+/**
  * fu_strjoin:
  * @separator: (nullable): string to insert between each of the strings
  * @array: (element-type utf8): a #GPtrArray

--- a/libfwupdplugin/fu-string.h
+++ b/libfwupdplugin/fu-string.h
@@ -19,6 +19,8 @@ typedef enum {
 gchar *
 fu_strsafe(const gchar *str, gsize maxsz);
 gchar *
+fu_strsafe_bytes(GBytes *blob, gsize maxsz);
+gchar *
 fu_strpassmask(const gchar *str) G_GNUC_NON_NULL(1);
 gboolean
 fu_strtoull(const gchar *str,


### PR DESCRIPTION
I don't really expect this to work right now, but want to see if it stands out what's wrong.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
