### PR TITLE
trivial: Install gcovr on Fedora before meson configure runs

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -49,7 +49,6 @@ jobs:
           name: coverage-${{ join(matrix.*, '-') }}
           path: ${{ github.workspace }}/coverage.xml
       - name: Upload to codecov
-        if: matrix.os == 'debian-x86_64' || matrix.os == 'debian-i386' || matrix.os == 'arch'
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -133,6 +133,9 @@
     <distro id="ubuntu">
       <package variant="x86_64" />
     </distro>
+    <distro id="fedora">
+      <package variant="x86_64" />
+    </distro>
   </dependency>
   <dependency id="gcc-multilib-s390x-linux-gnu">
     <distro id="debian">


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/8024

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
