### PR TITLE
Mark UEFI dbx updates as FWUPD_DEVICE_FLAG_AFFECTS_FDE (#7939)

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1036,7 +1036,7 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 		fu_device_add_flag(FU_DEVICE(dev), FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_device_add_flag(FU_DEVICE(dev), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
 
-		/* only system firmware "BIOS" can change the PCRx registers */
+		/* system firmware "BIOS" can change the PCRx registers */
 		if (fu_uefi_device_get_kind(dev) == FU_UEFI_DEVICE_KIND_SYSTEM_FIRMWARE && has_fde)
 			fu_device_add_flag(FU_DEVICE(dev), FWUPD_DEVICE_FLAG_AFFECTS_FDE);
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Addresses https://github.com/fwupd/fwupd/issues/7939

tl;dr: Duplicate the FDE flag code from the UEFI Capsule plugin for UEFI DBX updates

## Background

In the issue we discovered that PCR7 is expected to get changed by a `dbx` update:
From https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClientSpecPlat_TPM_2p0_1p04_pub.pdf
Section 2.3.4.8 PCR[7] – Secure Boot Policy Measurements has:
> Platform` Firmware adhering to the policy MUST therefore measure the following values into PCR[7]:
    ...
    6. Entries in the UEFI_IMAGE_SECURITY_DATABASE that are used to validate UEFI Drivers or UEFI Boot Applications in the boot path

## Tests

Primarily relying on CI runs, `test-fwupd` passed locally.

Output without this patch applied:
```
$ fwupdtool --plugins uefi_dbx get-devices 
Loading…                 [************************************** ]
WARNING: This package has not been validated, it may not work properly.
LENOVO 20UFCTO1WW
│
└─UEFI dbx:
      Device ID:          362301da643102b9f38477387e2193e57abaa590
      Summary:            UEFI revocation database
      Current version:    77
      Minimum Version:    77
      Vendor:             UEFI:Linux Foundation
      Install Duration:   1 second
      GUIDs:              5971a208-da00-5fce-b5f5-1234342f9cf7 ← UEFI\CRT_A9087D1044AD18F7A94916D284CBC01827CF23CD8F60B79072C9CAA1FEF4D649&ARCH_X64
                          f8ba2887-9411-5c36-9cee-88995bb39731 ← UEFI\CRT_A1117F516A32CEFCBA3F2D1ACE10A87972FD6BBE8FE0D0B996E09E65D802A503&ARCH_X64
      Device Flags:       • Internal device
                          • Updatable
                          • Needs a reboot after installation
                          • Device is usable for the duration of the update
                          • Only version upgrades are allowed
                          • Signed Payload
```

Output after `build-fwupd`:
```
$ fwupdtool --plugins uefi_dbx get-devices 
Loading…                 [************************************** ]
WARNING: This package has not been validated, it may not work properly.
LENOVO 20UFCTO1WW
│
└─UEFI dbx:
      Device ID:          362301da643102b9f38477387e2193e57abaa590
      Summary:            UEFI revocation database
      Current version:    77
      Minimum Version:    77
      Vendor:             UEFI:Linux Foundation
      Install Duration:   1 second
      GUIDs:              5971a208-da00-5fce-b5f5-1234342f9cf7 ← UEFI\CRT_A9087D1044AD18F7A94916D284CBC01827CF23CD8F60B79072C9CAA1FEF4D649&ARCH_X64
                          f8ba2887-9411-5c36-9cee-88995bb39731 ← UEFI\CRT_A1117F516A32CEFCBA3F2D1ACE10A87972FD6BBE8FE0D0B996E09E65D802A503&ARCH_X64
      Device Flags:       • Internal device
                          • Updatable
                          • Needs a reboot after installation
                          • Device is usable for the duration of the update
                          • Only version upgrades are allowed
                          • Full disk encryption secrets may be invalidated when updating  <-- this is new
                          • Signed Payload
```

And checked the output of the actual update to ensure it shows up there as well
```
$ sudo  /home/admin/fwupd/venv/bin/fwupdtool update 362301da643102b9f38477387e2193e57abaa590
Loading…                 [****************                       ]04:54:54.217 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/nvme/nvme0/nvme0n1/nvme0n1p4: failed to setup: no value for UUID
04:54:54.234 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:02.1/0000:01:00.0/nvme/nvme0/nvme0n1/nvme0n1p5: failed to setup: no value for UUID
Loading…                 [*****************                      ]04:54:54.288 FuPluginDfu          failed to parse interface data: no image idx 33 found in firmware
04:54:54.288 FuPluginDfu          DFU version 0x0000 invalid, v1.1 assumed
Loading…                 [************************************** ]
WARNING: This package has not been validated, it may not work properly.
╔══════════════════════════════════════════════════════════════════════════════╗
║ Upgrade UEFI dbx from 77 to 371?                                             ║
╠══════════════════════════════════════════════════════════════════════════════╣
║ Insecure versions of the Microsoft Windows boot manager affected by Black    ║
║ Lotus were added to the list of forbidden signatures due to a discovered     ║
║ security problem.This updates the dbx to the latest release from Microsoft.  ║
║                                                                              ║
║ Before installing the update, fwupd will check for any affected executables  ║
║ in the ESP and will refuse to update if it finds any boot binaries signed    ║
║ with any of the forbidden signatures.Applying this update may also cause     ║
║ some Windows install media to not start correctly.                           ║
║                                                                              ║
╚══════════════════════════════════════════════════════════════════════════════╝
Perform operation? [Y|n]: y
╔══════════════════════════════════════════════════════════════════════════════╗
║ Full Disk Encryption Detected                                                ║
╠══════════════════════════════════════════════════════════════════════════════╣
║ Some of the platform secrets may be invalidated when updating this           ║
║ firmware. Please ensure you have the volume recovery key before continuing.  ║
║                                                                              ║
║ See https://github.com/fwupd/fwupd/wiki/Full-Disk-Encryption-Detected for    ║
║ more details.                                                                ║
╚══════════════════════════════════════════════════════════════════════════════╝
Perform operation? [Y|n]: n
Request canceled
```
