### PR TITLE
Allow individual attributes to fail setup

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -125,6 +125,11 @@
       <package variant="mingw64">mingw64-gcc</package>
     </distro>
   </dependency>
+  <dependency id="gdb">
+    <distro id="fedora">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency id="gcovr">
     <distro id="debian">
       <package variant="x86_64" />

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -44,8 +44,8 @@
       <package variant="i386" />
     </distro>
     <distro id="fedora">
-      <package variant="x86_64" />
-      <package variant="aarch64" />
+      <package variant="x86_64">bash-completion-devel</package>
+      <package variant="aarch64">bash-completion-devel</package>
     </distro>
     <distro id="ubuntu">
       <package variant="x86_64" />

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -417,14 +417,8 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 								 full_path,
 								 name,
 								 &error_local)) {
-				if (g_error_matches(error_local,
-						    FWUPD_ERROR,
-						    FWUPD_ERROR_NOT_SUPPORTED)) {
-					g_debug("%s is not supported", name);
-					continue;
-				}
-				g_propagate_error(error, g_steal_pointer(&error_local));
-				return FALSE;
+				g_debug("%s is not supported: %s", name, error_local->message);
+				continue;
 			}
 		} while (++count);
 	} while (TRUE);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -4494,9 +4494,8 @@ fu_bios_settings_load_func(void)
 		(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 
 		ret = fu_context_reload_bios_settings(ctx, &error);
-		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-		g_assert_false(ret);
-		g_clear_error(&error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
 	}
 	g_free(test_dir);
 
@@ -4575,8 +4574,8 @@ fu_bios_settings_load_func(void)
 	if (g_file_test(test_dir, G_FILE_TEST_EXISTS)) {
 		(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", test_dir, TRUE);
 		ret = fu_context_reload_bios_settings(ctx, &error);
-		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
-		g_assert_false(ret);
+		g_assert_no_error(error);
+		g_assert_true(ret);
 		g_clear_error(&error);
 	}
 	g_free(test_dir);


### PR DESCRIPTION
Some Lenovo systems the thinklmi driver fails on random attributes. Rather than fail the remaining attributes skip the bad ones.

Fixes: https://github.com/fwupd/firmware-lenovo/issues/456

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
