### PR TITLE
pefile: Parse PE subsystem

### DIFF
--- a/libfwupdplugin/fu-pefile.rs
+++ b/libfwupdplugin/fu-pefile.rs
@@ -65,6 +65,7 @@ enum FuPeCoffMagic {
 }
 
 #[repr(u16le)]
+#[derive(ToString)]
 enum FuCoffSubsystem {
     Unknown,
     Native = 1,


### PR DESCRIPTION
I tried the `fwupdtool firmware-parse` with `pefile`. I don't have a particular use for it right now, but it seems useful if it decoded the subsystem.
That makes it easy to tell Windows, EFI App, EFI driver apart from oneanother.

Currently it just prints, but might be useful to add to the XML. As a child with `authenticode_hash` seems appropriate?

Sample:

```
> ./venv/bin/fwupdtool firmware-parse CapsuleApp.efi pefile
03:49:57.618 FuFirmware           PE Subsystem 0x000a efi-application

<firmware gtype="FuPefileFirmware">
  <data size="0x15408">[GInputStream]</data>
  <authenticode_hash>dccba699b7337f8bdba60cfb2c3acbc629661e91654d1666405230963fa23658</authenticode_hash>
  <subsystem>efi-application</subsystem>
  <firmware>
    <id>.text</id>
    <offset>0x240</offset>
    <data size="0x14040">[GInputStream]</data>
  </firmware>
  <firmware>
    <id>.data</id>
    <offset>0x14280</offset>
    <data size="0x8c0">[GInputStream]</data>
  </firmware>
  <firmware>
    <id>.reloc</id>
    <offset>0x14b40</offset>
    <data size="0xc0">
    </data>
  </firmware>
</firmware>
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
