### PR TITLE
plugins: scsi: Fix SCSI INQUIRY DATA decoding

### DIFF
--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -304,7 +304,7 @@ fu_scsi_device_setup(FuDevice *device, GError **error)
 	vendor = fu_strsafe((const gchar *)buf + 8, 8);
 	if (vendor != NULL)
 		fu_device_set_vendor(device, vendor);
-	model = fu_strsafe((const gchar *)buf + 16, 8);
+	model = fu_strsafe((const gchar *)buf + 16, 16);
 	if (model != NULL)
 		fu_device_set_name(device, model);
 	revision = fu_strsafe((const gchar *)buf + 32, 4);


### PR DESCRIPTION
The Product ID is 16 bytes long.

Using Samsung UFS KLUDG4UHGC-B0E1 as an example:

Before:
??KLUDG4UH:
      Device ID:          645dd3eabfbffd6d82917cc4a4cddc0487c3187d
      Vendor:             SAMSUNG (SCSI:SAMSUNG)
      GUIDs:              906223b2-9aee-5f6a-b78c-facb87a09056 ?  SCSI\VEN_SAMSUNG&DEV_KLUDG4UH
After: (as expected and like 1.9.22 branch)
??KLUDG4UHGC-B0E1:
      Device ID:          645dd3eabfbffd6d82917cc4a4cddc0487c3187d
      Vendor:             SAMSUNG (SCSI:SAMSUNG)
      GUIDs:              41a057a2-a1ff-5764-bc6f-71aa045706ff ?  SCSI\VEN_SAMSUNG&DEV_KLUDG4UHGC-B0E1

fixes: e915154a8bf ("scsi: Do SG_IO INQUIRY_CMD rather than relying on the udev prober")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
