### PR TITLE
plugins: scsi: Fix UFS device feature discovery

### DIFF
--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -69,7 +69,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 		       fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(ufshci_parent)));
 
 		attr_ufs_features =
-		    fu_udev_device_read_sysfs(FU_UDEV_DEVICE(self),
+		    fu_udev_device_read_sysfs(FU_UDEV_DEVICE(ufshci_parent),
 					      "device_descriptor/ufs_features",
 					      FU_UDEV_DEVICE_ATTR_READ_TIMEOUT_DEFAULT,
 					      NULL);
@@ -91,7 +91,7 @@ fu_scsi_device_probe(FuDevice *device, GError **error)
 				fu_device_add_protocol(device, "org.jedec.ufs");
 			}
 			attr_ffu_timeout =
-			    fu_udev_device_read_sysfs(FU_UDEV_DEVICE(self),
+			    fu_udev_device_read_sysfs(FU_UDEV_DEVICE(ufshci_parent),
 						      "device_descriptor/ffu_timeout",
 						      FU_UDEV_DEVICE_ATTR_READ_TIMEOUT_DEFAULT,
 						      error);


### PR DESCRIPTION
Properties "device_descriptor" are attached to the UFS host controller, not the UFS memory device. Using Samsung UFS KLUDG4UHGC-B0E1 as an example:

Before:
??KLUDG4UH:
      Device ID:          645dd3eabfbffd6d82917cc4a4cddc0487c3187d
      Summary:            SCSI device
      ...
      Device Flags:       ? Internal device
                          ? Can tag for emulation

After:
      Device ID:          645dd3eabfbffd6d82917cc4a4cddc0487c3187d
      Summary:            UFS device
      ...
      Device Flags:       ? Internal device
                          ? Updatable
                          ? Can tag for emulation

fixes: afb22f7cc0 ("trivial: Convert from fu_udev_device_get_sysfs_attr_uint64() to fu_udev_device_read_sysfs()")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
