### PR TITLE
trivial: asus-hid: update the proxy on detach

### DIFF
--- a/plugins/asus-hid/asus-hid.quirk
+++ b/plugins/asus-hid/asus-hid.quirk
@@ -16,12 +16,14 @@ Flags = use-runtime-version
 
 # Ally Bootloader
 [USB\VID_048D&PID_89DB]
+AsusHidNumMcu = 2
 Plugin = asus_hid
 Flags = is-bootloader,can-verify-image
 FirmwareSizeMax = 0x40000
 
 # Ally X Bootloader
 [USB\VID_048D&PID_89DC]
+AsusHidNumMcu = 1
 Plugin = asus_hid
 Flags = is-bootloader,can-verify-image
 FirmwareSizeMax = 0x40000

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -237,40 +237,40 @@ fu_asus_hid_child_device_write_firmware(FuDevice *device,
 					FwupdInstallFlags flags,
 					GError **error)
 {
-	FuDevice *parent = fu_device_get_parent(device);
+	FuDevice *proxy = fu_device_get_proxy(device);
 
-	if (parent == NULL) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
 		return FALSE;
 	}
 
-	return fu_asus_hid_device_write_firmware(parent, firmware, progress, flags, error);
+	return fu_asus_hid_device_write_firmware(proxy, firmware, progress, flags, error);
 }
 
 static gboolean
 fu_asus_hid_child_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
-	FuDevice *parent = fu_device_get_parent(device);
+	FuDevice *proxy = fu_device_get_proxy(device);
 
-	if (parent == NULL) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
 		return FALSE;
 	}
 
-	return fu_device_attach(parent, error);
+	return fu_device_attach(proxy, error);
 }
 
 static gboolean
 fu_asus_hid_child_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
-	FuDevice *parent = fu_device_get_parent(device);
+	FuDevice *proxy = fu_device_get_proxy(device);
 
-	if (parent == NULL) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no parent");
+	if (proxy == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
 		return FALSE;
 	}
 
-	return fu_device_detach(parent, error);
+	return fu_device_detach(proxy, error);
 }
 
 static void

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -155,6 +155,27 @@ fu_asus_hid_child_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 
+	name = g_strdup_printf("Microcontroller %u", self->idx);
+	fu_device_set_name(FU_DEVICE(self), name);
+
+	if (fu_device_has_flag(fu_device_get_proxy(FU_DEVICE(self)),
+			       FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		g_autofree gchar *recovery_str = g_strdup_printf("%d", self->idx);
+		// RC71LS = 0
+		// RC71LM = 1
+		fu_device_add_instance_strsafe(FU_DEVICE(self), "RECOVERY", recovery_str);
+		fu_device_build_instance_id(FU_DEVICE(self),
+					    NULL,
+					    "USB",
+					    "VID",
+					    "PID",
+					    "RECOVERY",
+					    NULL);
+		fu_device_set_logical_id(FU_DEVICE(self), recovery_str);
+		fu_device_set_version(FU_DEVICE(self), "0");
+		return TRUE;
+	}
+
 	if (!fu_asus_hid_child_device_ensure_manufacturer(self, error)) {
 		g_prefix_error(error, "failed to ensure manufacturer: ");
 		return FALSE;
@@ -163,9 +184,6 @@ fu_asus_hid_child_device_setup(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to ensure version: ");
 		return FALSE;
 	}
-
-	name = g_strdup_printf("Microcontroller %u", self->idx);
-	fu_device_set_name(FU_DEVICE(self), name);
 
 	return TRUE;
 }


### PR DESCRIPTION
During detach to bootloader mode the proxy pointer becomes invalid because the device changes.  Update it explicitly when the children are adopted to the new parent.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
