### PR TITLE
trivial: don't allow out of order emulation events

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -7433,9 +7433,13 @@ fu_device_load_event(FuDevice *self, const gchar *id, GError **error)
 	for (guint i = 0; i < priv->events->len; i++) {
 		FuDeviceEvent *event = g_ptr_array_index(priv->events, i);
 		if (g_strcmp0(fu_device_event_get_id(event), id_hash) == 0) {
-			g_debug("found out-of-order %s at position %u", id, i);
-			priv->event_idx = i + 1;
-			return event;
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "found out-of-order event %s at position %u",
+				    id,
+				    i);
+			return NULL;
 		}
 	}
 

--- a/plugins/cros-ec/tests/google-servo-micro.json
+++ b/plugins/cros-ec/tests/google-servo-micro.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "url": "https://fwupd.org/downloads/3c3123b6eaa89d5469553b301210a9e4cb06efa98a1cb7c6847a1d10bb0a0c4b-servo_micro_v2.4.0.cab",
-      "emulation-url": "https://fwupd.org/downloads/72f84e212c5c5976bd46ea0fa4f1dda26b4c41f35ac01aaa212867e672690726-servo_micro_v2.4.0.zip",
+      "emulation-url": "https://fwupd.org/downloads/86fd0f1ae48eec0aad0ec97eaebc5bb8aa67fe03485f7b5824e6e1e9dfab42a6-servo_micro_v2.4.0.zip",
       "components": [
         {
           "version": "2.4.0",
@@ -16,7 +16,7 @@
     },
     {
       "url": "https://fwupd.org/downloads/1dc362734f138e71fa838ac5503491d297715d7e9bccc0424a62c4a5c68526cc-servo_micro_v2.4.17.cab",
-      "emulation-url": "https://fwupd.org/downloads/b5f152b8e1f814375ae586bdac9536b70b3a9cd1a2a12bf685e8da50eef78f2a-servo_micro_v2.4.17.zip",
+      "emulation-url": "https://fwupd.org/downloads/4e85ebbd498b25b1528151745f86b167363629665f4a2580a472773ea176dc14-servo_micro_v2.4.17.zip",
       "components": [
         {
           "version": "2.4.17",


### PR DESCRIPTION
These could lead to a false sense of things working correctly when porting a plugin.

Require all emulation events to come in the EXACT same order.

Draft to see if any existing emulations blow up from this.  If they do, it might be better to have a configurable behavior.
 
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
