### PR TITLE
Remove the unconditional O_NONBLOCK flag when opening a FuIOChannel

### DIFF
--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -632,9 +632,6 @@ fu_io_channel_new_file(const gchar *filename, FuIoChannelOpenFlag open_flags, GE
 	g_return_val_if_fail(filename != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-#ifdef HAVE_POLL_H
-	flags |= O_NONBLOCK;
-#endif
 	if (open_flags & FU_IO_CHANNEL_OPEN_FLAG_READ &&
 	    open_flags & FU_IO_CHANNEL_OPEN_FLAG_WRITE) {
 		flags |= O_RDWR;


### PR DESCRIPTION
The behaviour was copied in dc3758e -- but it's completely wrong -- we already have `FU_IO_CHANNEL_OPEN_FLAG_NONBLOCK` for when non-blocking opens are needed.

Fixes https://github.com/fwupd/fwupd/issues/8086

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
