### PR TITLE
Minor fixes for steelseries

### DIFF
--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -262,7 +262,6 @@ fu_steelseries_fizz_tunnel_setup(FuDevice *device, GError **error)
 						     &error_local);
 	if (serial != NULL) {
 		fu_device_set_serial(device, serial);
-		fu_device_set_equivalent_id(device, serial);
 	} else {
 		g_debug("ignoring error: %s", error_local->message);
 	}

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -708,14 +708,6 @@ fu_steelseries_fizz_set_progress(FuDevice *self, FuProgress *progress)
 }
 
 static void
-fu_steelseries_fizz_replace(FuDevice *device, FuDevice *donor)
-{
-	/* copy to device without serial, i.e. USB-C connection in bootloader mode */
-	if (fu_device_get_equivalent_id(device) == NULL)
-		fu_device_set_equivalent_id(device, fu_device_get_equivalent_id(donor));
-}
-
-static void
 fu_steelseries_fizz_class_init(FuSteelseriesFizzClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
@@ -723,7 +715,6 @@ fu_steelseries_fizz_class_init(FuSteelseriesFizzClass *klass)
 	device_class->detach = fu_steelseries_fizz_detach;
 	device_class->attach = fu_steelseries_fizz_attach;
 	device_class->setup = fu_steelseries_fizz_setup;
-	device_class->replace = fu_steelseries_fizz_replace;
 	device_class->write_firmware = fu_steelseries_fizz_write_firmware;
 	device_class->read_firmware = fu_steelseries_fizz_read_firmware;
 	device_class->set_progress = fu_steelseries_fizz_set_progress;

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -297,7 +297,7 @@ fu_steelseries_gamepad_init(FuSteelseriesGamepad *self)
 
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_BCD);
-
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ADD_COUNTERPART_GUIDS);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_protocol(FU_DEVICE(self), "com.steelseries.gamepad");

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -927,6 +927,7 @@ fu_steelseries_sonic_init(FuSteelseriesSonic *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 	fu_device_add_protocol(FU_DEVICE(self), "com.steelseries.sonic");


### PR DESCRIPTION
Removed unneeded equivalent ID causing error message.
Added flag indicating unsigned payload for gamepads and Rival 3 mose.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation
