### PR TITLE
fix: plug memory leaks from rustgen char* getters

### DIFF
--- a/plugins/algoltek-aux/fu-algoltek-aux-firmware.c
+++ b/plugins/algoltek-aux/fu-algoltek-aux-firmware.c
@@ -32,7 +32,7 @@ fu_algoltek_aux_firmware_parse(FuFirmware *firmware,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
-	const gchar *version;
+	g_autofree gchar *version = NULL;
 	gsize offset = 0;
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -33,7 +33,7 @@ fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 			       FwupdInstallFlags flags,
 			       GError **error)
 {
-	const gchar *version;
+	g_autofree gchar *version = NULL;
 	gsize offset = 0;
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -123,6 +123,11 @@ fu_amd_gpu_atom_firmware_parse_vbios_date(FuAmdGpuAtomFirmware *self,
 					  GError **error)
 {
 	g_autoptr(GByteArray) st = fu_struct_atom_image_get_vbios_date(atom_image);
+	g_autofree gchar *year = NULL;
+	g_autofree gchar *month = NULL;
+	g_autofree gchar *day = NULL;
+	g_autofree gchar *hours = NULL;
+	g_autofree gchar *minutes = NULL;
 
 	if (st == NULL) {
 		g_set_error(error,
@@ -132,13 +137,14 @@ fu_amd_gpu_atom_firmware_parse_vbios_date(FuAmdGpuAtomFirmware *self,
 		return FALSE;
 	}
 
+	year = fu_struct_vbios_date_get_year(st);
+	month = fu_struct_vbios_date_get_month(st);
+	day = fu_struct_vbios_date_get_day(st);
+	hours = fu_struct_vbios_date_get_hours(st);
+	minutes = fu_struct_vbios_date_get_minutes(st);
+
 	/* same date format as atom_get_vbios_date() */
-	self->bios_date = g_strdup_printf("20%s/%s/%s %s:%s",
-					  fu_struct_vbios_date_get_year(st),
-					  fu_struct_vbios_date_get_month(st),
-					  fu_struct_vbios_date_get_day(st),
-					  fu_struct_vbios_date_get_hours(st),
-					  fu_struct_vbios_date_get_minutes(st));
+	self->bios_date = g_strdup_printf("20%s/%s/%s %s:%s", year, month, day, hours, minutes);
 
 	return TRUE;
 }

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -67,7 +67,7 @@ fu_asus_hid_child_device_transfer_feature(FuAsusHidChildDevice *self,
 static gboolean
 fu_asus_hid_child_device_ensure_manufacturer(FuAsusHidChildDevice *self, GError **error)
 {
-	const gchar *man;
+	g_autofree gchar *man = NULL;
 	g_autoptr(FuStructAsusManCommand) cmd = fu_struct_asus_man_command_new();
 	g_autoptr(FuStructAsusManResult) result = fu_struct_asus_man_result_new();
 
@@ -96,6 +96,8 @@ fu_asus_hid_child_device_ensure_version(FuAsusHidChildDevice *self, GError **err
 {
 	g_autoptr(FuStructAsusHidCommand) cmd = fu_struct_asus_hid_command_new();
 	g_autoptr(FuStructAsusHidFwInfo) result = fu_struct_asus_hid_fw_info_new();
+	g_autoptr(FuStructAsusHidFwInfo) fw_info = NULL;
+	g_autofree gchar *version = NULL;
 
 	if (self->idx == FU_ASUS_HID_CONTROLLER_PRIMARY)
 		fu_struct_asus_hid_command_set_cmd(cmd, FU_ASUS_HID_COMMAND_FW_VERSION);
@@ -118,9 +120,9 @@ fu_asus_hid_child_device_ensure_version(FuAsusHidChildDevice *self, GError **err
 						       error))
 		return FALSE;
 
-	fu_device_set_version(FU_DEVICE(self),
-			      fu_struct_asus_hid_desc_get_version(
-				  fu_struct_asus_hid_fw_info_get_description(result)));
+	fw_info = fu_struct_asus_hid_fw_info_get_description(result);
+	version = fu_struct_asus_hid_desc_get_version(fw_info);
+	fu_device_set_version(FU_DEVICE(self), version);
 
 	if (fu_device_get_logical_id(FU_DEVICE(self)) == NULL) {
 		fu_device_add_instance_strsafe(

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -51,9 +51,9 @@ fu_asus_hid_firmware_parse(FuFirmware *firmware,
 	desc = fu_struct_asus_hid_desc_parse_stream(stream, FGA_OFFSET, error);
 	if (desc == NULL)
 		return FALSE;
-	self->fga = g_strdup(fu_struct_asus_hid_desc_get_fga(desc));
-	self->product = g_strdup(fu_struct_asus_hid_desc_get_product(desc));
-	self->version = g_strdup(fu_struct_asus_hid_desc_get_version(desc));
+	self->fga = fu_struct_asus_hid_desc_get_fga(desc);
+	self->product = fu_struct_asus_hid_desc_get_product(desc);
+	self->version = fu_struct_asus_hid_desc_get_version(desc);
 
 	stream_payload = fu_partial_input_stream_new(stream, 0x2000, G_MAXSIZE, error);
 	if (stream_payload == NULL)


### PR DESCRIPTION
afaict, these always will return newly allocated char arrays because it may be necessary to insert a trailing null byte.

I tried to check all plugins but I still may have missed some and there is more potential from at least getters for nested structs which return `GByteArray`s that I did not check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Plugin maintainers please verify that I am not totally wrong here: @YiJaneWu @MasonLyu @superm1