### PR TITLE
trivial: ci: debian: run daemon as a service again

### DIFF
--- a/contrib/ci/debian-x86_64-test.sh
+++ b/contrib/ci/debian-x86_64-test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# Set up fatal-criticals systemd override
+SYSTEMD_OVERRIDE="/etc/systemd/system/fwupd.service.d"
+mkdir -p ${SYSTEMD_OVERRIDE}
+cp contrib/fwupd-systemd-fatal-criticals.conf ${SYSTEMD_OVERRIDE}/override.conf
+
 # install
 apt update
 apt install -y gcovr ./dist/*.deb
@@ -11,7 +16,6 @@ fwupdtool emulation-tag 08d460be0f1f9f128413f816022a6439e0078018
 ./contrib/ci/get_test_firmware.sh
 cp fwupd-test-firmware/installed-tests/* /usr/share/installed-tests/fwupd/ -LRv
 service dbus restart
-G_DEBUG=fatal-criticals /usr/libexec/fwupd/fwupd --verbose &
 gnome-desktop-testing-runner fwupd
 
 # generate coverage report

--- a/contrib/fwupd-systemd-fatal-criticals.conf
+++ b/contrib/fwupd-systemd-fatal-criticals.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="G_DEBUG=fatal-criticals"


### PR DESCRIPTION
Inject G_DEBUG=fatal-criticals into the environment for it instead

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
