### PR TITLE
Check that getpid() returned a sensible PID

### DIFF
--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -527,6 +527,15 @@ fu_udev_backend_netlink_setup(FuUdevBackend *self, GError **error)
 	};
 	g_autoptr(GSource) source = NULL;
 
+	/* minijail -p prevents access */
+	if (nls.nl_pid <= 2) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to get PID, perhaps sandboxed?");
+		return FALSE;
+	}
+
 	self->netlink_fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_KOBJECT_UEVENT);
 	if (self->netlink_fd < 0) {
 		g_set_error(error,


### PR DESCRIPTION
It seems `minijail -p` sandboxes getpid() which means we get the very confusing reported PID of *2*. Report this as the error, rather than the very unhelpful `bind to udev socket failed` text.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
