### PR TITLE
trivial: venv: set GLIBC_TUNABLES if not set

### DIFF
--- a/contrib/launch-venv.sh
+++ b/contrib/launch-venv.sh
@@ -30,8 +30,12 @@ fi
 if [ -z "${G_DEBUG}" ]; then
         G_DEBUG="fatal-criticals"
 fi
+if [ -z "${GLIBC_TUNABLES}" ]; then
+        GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK
+fi
 ENV="FWUPD_POLKIT_NOCHECK=1 \
      G_DEBUG=${G_DEBUG} \
+     GLIBC_TUNABLES=${GLIBC_TUNABLES} \
      LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 for var in $(env | grep FWUPD | cut -d= -f1); do
         ENV="${ENV} ${var}=${!var}"


### PR DESCRIPTION
This mirrors what the systemd unit does too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
