### PR TITLE
Add additional version checks for AMD Sinkclose

### DIFF
--- a/docs/hsi-tests.d/org.fwupd.hsi.Amd.SmmLocked.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Amd.SmmLocked.json
@@ -3,16 +3,21 @@
   "name": "SMM locked down",
   "description": [
     "Disable SMM_BASE from being saved to and restored from the SMM save state area.",
-    "Code in the ASeg and TSeg range and the SMM registers are Read-only and SMI interrupts are not intercepted in SVM."
+    "Code in the ASeg and TSeg range and the SMM registers are Read-only and SMI interrupts are not intercepted in SVM.",
+    "This check also ensures that the system is not affected by the Sinkclose vulnerability."
   ],
   "failure-impact": [
     "An attacker with an existing unrelated vulnerability can the SMM save state area to exfiltrate data."
   ],
   "failure-results": {
-    "not-locked": "SMM is not locked down"
+    "not-locked": "SMM is not locked down",
+    "not-valid": "Vulnerable to Sinkclose"
   },
   "success-results": {
     "locked": "SMM is locked down"
+  },
+  "references": {
+    "https://www.amd.com/en/resources/product-security/bulletin/amd-sb-7014.html": "AMD Sinkclose"
   },
   "hsi-level": 1,
   "fwupd-version": "2.0.2"

--- a/libfwupdplugin/fu-device-metadata.h
+++ b/libfwupdplugin/fu-device-metadata.h
@@ -50,3 +50,10 @@
  * CPU mitigations required. See the CPU plugin for more details.
  */
 #define FU_DEVICE_METADATA_CPU_MITIGATIONS_REQUIRED "CpuMitigationsRequired"
+
+/**
+ * FU_DEVICE_METADATA_CPU_SINKCLOSE_MICROCODE_VER:
+ *
+ * Microcode version required to mitigate Sinkclose. See the CPU plugin for more details.
+ */
+#define FU_DEVICE_METADATA_CPU_SINKCLOSE_MICROCODE_VER "CpuSinkcloseMicrocodeVersion"

--- a/plugins/cpu/README.md
+++ b/plugins/cpu/README.md
@@ -28,6 +28,16 @@ Mitigations required for this specific CPU. Valid values are:
 
 Since: 1.9.4
 
+* `sinkclose`
+
+Since: 2.0.2
+
+### CpuSinkcloseMicrocodeVersion
+
+Minimum version of microcode to mitigate the `sinkclose` vulnerability.
+
+Since: 2.0.2
+
 ## External Interface Access
 
 This plugin requires no extra access.

--- a/plugins/cpu/cpu.quirk
+++ b/plugins/cpu/cpu.quirk
@@ -69,3 +69,71 @@ CpuMitigationsRequired = gds
 CpuMitigationsRequired = gds
 [CPUID\PRO_0&FAM_06&MOD_A7]
 CpuMitigationsRequired = gds
+
+#Affected by Sinkclose
+[CPUID\PRO_0&FAM_17&MOD_01&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0800126f
+[CPUID\PRO_0&FAM_17&MOD_31&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0830107c
+[CPUID\PRO_0&FAM_17&MOD_60&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0860010d
+[CPUID\PRO_0&FAM_17&MOD_68&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x08608108
+[CPUID\PRO_0&FAM_17&MOD_71&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x08701034
+[CPUID\PRO_0&FAM_17&MOD_A0&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x08a0000a
+[CPUID\PRO_0&FAM_19&MOD_01&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a0011d5
+[CPUID\PRO_0&FAM_19&MOD_01&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a001238
+[CPUID\PRO_0&FAM_19&MOD_08&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a00820c
+[CPUID\PRO_0&FAM_19&MOD_11&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a101148
+[CPUID\PRO_0&FAM_19&MOD_11&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a101248
+[CPUID\PRO_0&FAM_19&MOD_18&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a108108
+[CPUID\PRO_0&FAM_19&MOD_21&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a20102d
+[CPUID\PRO_0&FAM_19&MOD_21&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a201210
+[CPUID\PRO_0&FAM_19&MOD_44&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a404107
+[CPUID\PRO_0&FAM_19&MOD_50&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a500011
+[CPUID\PRO_0&FAM_19&MOD_61&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a601209
+[CPUID\PRO_0&FAM_19&MOD_74&STP_1]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a704107
+[CPUID\PRO_0&FAM_19&MOD_77&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a705206
+[CPUID\PRO_0&FAM_19&MOD_78&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a708007
+[CPUID\PRO_0&FAM_19&MOD_7C&STP_0]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0a70c005
+[CPUID\PRO_0&FAM_19&MOD_A0&STP_2]
+CpuMitigationsRequired = sinkclose
+CpuSinkcloseMicrocodeVersion = 0x0aa00215

--- a/plugins/cpu/fu-cpu-device.c
+++ b/plugins/cpu/fu-cpu-device.c
@@ -313,6 +313,15 @@ fu_cpu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 		fu_device_set_metadata(device, "CpuMitigationsRequired", value);
 		return TRUE;
 	}
+	if (g_strcmp0(key, "CpuSinkcloseMicrocodeVersion") == 0) {
+		guint64 tmp = 0;
+		if (!fu_strtoull(value, &tmp, 0, G_MAXUINT32, FU_INTEGER_BASE_16, error))
+			return FALSE;
+		fu_device_set_metadata_integer(device,
+					       FU_DEVICE_METADATA_CPU_SINKCLOSE_MICROCODE_VER,
+					       tmp);
+		return TRUE;
+	}
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no supported");
 	return FALSE;
 }

--- a/plugins/cpu/fu-cpu-plugin.c
+++ b/plugins/cpu/fu-cpu-plugin.c
@@ -50,6 +50,7 @@ fu_cpu_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "CpuMitigationsRequired");
+	fu_context_add_quirk_key(ctx, "CpuSinkcloseMicrocodeVersion");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_BEFORE, "msr");
 }
 


### PR DESCRIPTION
This adds checks for the microcode versions in all datacenter CPU processors, and Zen 1, Zen 2, Zen 3, and 4 client processors.

Datacenter graphics and embedded processors are currently excluded.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
