### PR TITLE
vli: Check the USB3 firmware size before erasing

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1277,6 +1277,14 @@ fu_vli_usbhub_device_update_v3(FuVliUsbhubDevice *self,
 		return FALSE;
 	hd2_fw_sz = (fu_struct_vli_usbhub_hdr_get_usb3_fw_sz_high(st_hd) << 16);
 	hd2_fw_sz += fu_struct_vli_usbhub_hdr_get_usb3_fw_sz(st_hd);
+	if (hd2_fw_sz == 0 || hd2_fw_sz > 0x40000) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "FW2 size abnormal 0x%x",
+			    (guint)hd2_fw_sz);
+		return FALSE;
+	}
 	hd2_fw_offset = (fu_struct_vli_usbhub_hdr_get_usb3_fw_addr_high(st_hd) << 16);
 	hd2_fw_offset += fu_struct_vli_usbhub_hdr_get_usb3_fw_addr(st_hd);
 	g_debug("FW2 @0x%x (length 0x%x, offset 0x%x)", hd2_fw_addr, hd2_fw_sz, hd2_fw_offset);


### PR DESCRIPTION
Spotted by Coverity.

Fixes https://github.com/fwupd/fwupd/issues/8104

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
