### PR TITLE
asus-hid: Actually be safe when using fu_memcpy_safe()

### DIFF
--- a/plugins/asus-hid/fu-asus-hid-device.c
+++ b/plugins/asus-hid/fu-asus-hid-device.c
@@ -268,6 +268,8 @@ fu_asus_hid_device_dump_firmware(FuDevice *device, FuProgress *progress, GError 
 	fu_progress_set_steps(progress, blocks->len);
 	for (guint i = 0, offset = 0; i < blocks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(blocks, i);
+		const guint8 *buf;
+		gsize bufsz = 0;
 		g_autoptr(FuStructAsusReadFlashCommand) cmd =
 		    fu_struct_asus_read_flash_command_new();
 		g_autoptr(FuStructAsusReadFlashCommand) result =
@@ -282,12 +284,12 @@ fu_asus_hid_device_dump_firmware(FuDevice *device, FuProgress *progress, GError 
 							 FU_ASUS_HID_REPORT_ID_FLASHING,
 							 error))
 			return NULL;
-
+		buf = fu_struct_asus_read_flash_command_get_data(result, &bufsz);
 		if (!fu_memcpy_safe(fu_chunk_get_data_out(chk),
 				    fu_chunk_get_data_sz(chk),
 				    0x0,
-				    fu_struct_asus_read_flash_command_get_data(result, NULL),
-				    fu_struct_asus_read_flash_command_get_datasz(result),
+				    buf,
+				    bufsz,
 				    0x0,
 				    fu_struct_asus_read_flash_command_get_datasz(result),
 				    error))


### PR DESCRIPTION
The datasz is the number of bytes returned, not the size of the source buffer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
