### PR TITLE
upower: Add a quirk for Framework systems

### DIFF
--- a/plugins/upower/fu-upower-plugin.c
+++ b/plugins/upower/fu-upower-plugin.c
@@ -80,6 +80,15 @@ fu_upower_plugin_rescan_devices(FuPlugin *plugin)
 		return;
 	}
 	fu_context_set_battery_level(ctx, g_variant_get_double(percentage_val));
+
+	/*
+	 * Quirk for behavior on Framework systems where the EC reports as discharging
+	 * while on AC but at 100%.
+	 */
+	if (fu_context_get_power_state(ctx) == FU_POWER_STATE_BATTERY_DISCHARGING &&
+	    fu_context_get_battery_level(ctx) == 100 &&
+	    fu_context_has_hwid_guid(ctx, "2185e781-ed4b-5fc2-8839-b5ddb1e7d649"))
+		fu_context_set_power_state(ctx, FU_POWER_STATE_AC_FULLY_CHARGED);
 }
 
 static void


### PR DESCRIPTION
When the system battery is charged to 100% Frameworks' EC doesn't report the system as charging anymore.  Instead it's reported as discharging which makes fwupd's upower plugin block updates.

Frameworks' own guidance on their website even tells people to unplug the machine for a few minutes to get it below 100% to get updates to work.
```
LVFS may not update if the battery is 100% charged. LVFS uses the battery status
to determine if it is safe to apply updates. However if our battery is at 100%
and the charger is off, we set the battery charging status to false. In this
case you can discharge your battery a few percent, then plug in AC again and
run fwupdmgr update.

```

This is all crazy, add a quirk to fwupd to detect the behavior from the Framework HWID and override the AC status.

As this is a Framework specific behavior use the CHID that is manufacturer only.

```
Computer Information
--------------------
BiosVendor: INSYDE Corp.
BiosVersion: 3.06
BiosMajorRelease: 3
BiosMinorRelease: 6
FirmwareMajorRelease: ff
FirmwareMinorRelease: ff
Manufacturer: Framework
Family: Laptop
ProductName: Laptop 13 (AMD Ryzen 7040Series)
ProductSku: FRANMDCP05
EnclosureKind: a
BaseboardManufacturer: Framework
BaseboardProduct: FRANMDCP05
Hardware IDs
------------
{038b6e01-64b1-5c0c-a13d-b0a2beef9761}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
{40212839-2919-560d-b395-b7f594540473}   <- Manufacturer + Family + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
{4ce6d486-2e9e-55e7-9e5e-9282ebdc452d}   <- Manufacturer + ProductName + BiosVendor + BiosVersion + BiosMajorRelease + BiosMinorRelease
{73bc287b-1ca4-5fcc-8bd6-c5f254c319c7}   <- Manufacturer + Family + ProductName + ProductSku + BaseboardManufacturer + BaseboardProduct
{640eafcf-ddc1-57fb-90b7-67801a1fc3b6}   <- Manufacturer + Family + ProductName + ProductSku
{b5f7dcc1-568c-50f8-a4dd-e39d1f93fda1}   <- Manufacturer + Family + ProductName
{032934f7-f16b-565e-97a3-74b3e18f9ea0}   <- Manufacturer + ProductSku + BaseboardManufacturer + BaseboardProduct
{67db3983-eb54-5f87-bea8-ac85eb6eb12b}   <- Manufacturer + ProductSku
{d7fbed23-a06d-58aa-bbd7-ad4231feb8dd}   <- Manufacturer + ProductName + BaseboardManufacturer + BaseboardProduct
{e3046147-c2a7-586d-81c4-85209eda3481}   <- Manufacturer + ProductName
{4243db2f-8597-5a77-aa31-581e0de38158}   <- Manufacturer + Family + BaseboardManufacturer + BaseboardProduct
{b3bdb2e4-c5cb-5c1b-bdc3-e6fc132462ff}   <- Manufacturer + Family
{96ef7072-4be1-53aa-ac9a-1c095c7784f0}   <- Manufacturer + EnclosureKind
{c08b003e-b14e-5019-a85a-ee726b24cc40}   <- Manufacturer + BaseboardManufacturer + BaseboardProduct
{2185e781-ed4b-5fc2-8839-b5ddb1e7d649}   <- Manufacturer
Extra Hardware IDs
------------------
{0fe96828-134e-5c6e-8aa1-84955c1663ab}   <- Manufacturer + Family + ProductName + ProductSku + BiosVendor
{faaf505b-81b1-5761-a210-162574bbdaf3}   <- Manufacturer + Family + ProductName + BiosVendor
{b2aa53b6-90b2-52dd-8382-75d014678f63}   <- Manufacturer + BiosVendor
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
