### PR TITLE
dell-kestrel: restrict firmware size according to hardware

### DIFF
--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.rs
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.rs
@@ -82,7 +82,7 @@ struct FuStructDellKestrelDockData {
     dock_type: u8,
     reserved: u16le,
     module_type: u16le,
-    reserved: u16le,
+    board_id: u16le,
     reserved: u16le,
     reserved: u16le,
     dock_firmware_pkg_ver: u32le,


### PR DESCRIPTION
1. Use a generic name for the PD device.
2. Restrict the firmware size for the LAN device.
3. Improve code readability for device locking.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
