### PR TITLE
Parse FDTs with missing END tokens

### DIFF
--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -277,13 +277,8 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 	}
 
 	/* did not see FDT_END */
-	if (!has_end) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "did not see FDT_END");
-		return FALSE;
-	}
+	if (!has_end)
+		g_warning("did not see FDT_END, perhaps size_dt_struct is invalid?");
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
This seems to affect all MediaTek-based Chromebooks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
