### PR TITLE
trivial: Do not allow plugins to use g_random_int_range()

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -199,6 +199,7 @@ class Checker:
             "g_usb_device_set_interface_alt(": "Use fu_usb_device_set_interface_alt() instead",
             "g_ascii_strtoull(": "Use fu_strtoull() instead",
             "g_ascii_strtoll(": "Use fu_strtoll() instead",
+            "g_random_int_range(": "Use a predicatable token instead",
             "g_assert(": "Use g_set_error() or g_return_val_if_fail() instead",
             "g_udev_device_get_sysfs_attr(": "Use fu_udev_device_read_sysfs() instead",
             "g_udev_device_get_property(": "Use fu_udev_device_read_property() instead",

--- a/libfwupd/fwupd-thread-test.c
+++ b/libfwupd/fwupd-thread-test.c
@@ -54,7 +54,7 @@ fwupd_thread_test_idle_cb(gpointer user_data)
 	for (guint i = 0; i < 30; i++) {
 		g_autofree gchar *thread_str = g_strdup_printf("worker%02u", i);
 		GThread *thread = g_thread_new(thread_str, fwupd_thread_test_thread_cb, self);
-		g_usleep(g_random_int_range(0, 1000));
+		g_usleep(g_random_int_range(0, 1000)); /* nocheck:blocked */
 		g_ptr_array_add(self->worker_threads, thread);
 		if (i > 0)
 			g_application_hold(self->app);

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -655,9 +655,10 @@ fu_genesys_usbhub_device_authenticate(FuGenesysUsbhubDevice *self, GError **erro
 	high_byte = (release & 0xff00) >> 8;
 	temp_byte = low_byte ^ high_byte;
 
-	offset_start = g_random_int_range(GENESYS_USBHUB_ENCRYPT_REGION_START,
+	offset_start = g_random_int_range(GENESYS_USBHUB_ENCRYPT_REGION_START, /* nocheck:blocked */
 					  GENESYS_USBHUB_ENCRYPT_REGION_END - 1);
-	offset_end = g_random_int_range(offset_start + 1, GENESYS_USBHUB_ENCRYPT_REGION_END);
+	offset_end = g_random_int_range(offset_start + 1, /* nocheck:blocked */
+					GENESYS_USBHUB_ENCRYPT_REGION_END);
 	for (guint8 i = offset_start; i <= offset_end; i++) {
 		temp_byte ^= self->st_fwinfo_ts->data[i];
 	}

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -52,6 +52,7 @@ typedef struct {
 
 struct _FuMediatekScalerDevice {
 	FuDrmDevice parent_instance;
+	guint8 randval_cnt;
 };
 
 G_DEFINE_TYPE(FuMediatekScalerDevice, fu_mediatek_scaler_device, FU_TYPE_DRM_DEVICE)
@@ -198,8 +199,8 @@ fu_mediatek_scaler_device_display_is_connected(FuMediatekScalerDevice *self, GEr
 	g_autoptr(GByteArray) st_res = NULL;
 	g_autoptr(GError) error_local = NULL;
 	guint8 randval_req = 0;
-	guint8 randval1 = g_random_int_range(1, 255);
-	guint8 randval2 = g_random_int_range(1, 255);
+	guint8 randval1 = self->randval_cnt++;
+	guint8 randval2 = self->randval_cnt++;
 
 	fu_struct_ddc_cmd_set_vcp_code(st_req, FU_DDC_VCP_CODE_SUM);
 	fu_byte_array_append_uint8(st_req, randval1);

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -56,7 +56,7 @@ fu_redfish_plugin_generate_password(guint length)
 
 	/* get a random password string */
 	while (str->len < length) {
-		gchar tmp = (gchar)g_random_int_range(0x0, 0xff);
+		gchar tmp = (gchar)g_random_int_range(0x0, 0xff); /* nocheck:blocked */
 		if (g_ascii_isalnum(tmp))
 			g_string_append_c(str, tmp);
 	}

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -2146,7 +2146,8 @@ fu_dbus_daemon_method_inhibit(FuDbusDaemon *self,
 	/* watch */
 	inhibit = g_new0(FuDbusDaemonSystemInhibit, 1);
 	inhibit->sender = g_strdup(fu_engine_request_get_sender(request));
-	inhibit->id = g_strdup_printf("dbus-%i", g_random_int_range(1, G_MAXINT - 1));
+	inhibit->id =
+	    g_strdup_printf("dbus-%i", g_random_int_range(1, G_MAXINT - 1)); /* nocheck:blocked */
 	inhibit->watcher_id =
 	    g_bus_watch_name_on_connection(self->connection,
 					   fu_engine_request_get_sender(request),

--- a/src/fu-idle.c
+++ b/src/fu-idle.c
@@ -118,7 +118,7 @@ fu_idle_inhibit(FuIdle *self, FuIdleInhibit inhibit, const gchar *reason)
 	item = g_new0(FuIdleItem, 1);
 	item->inhibit = inhibit;
 	item->reason = g_strdup(reason);
-	item->token = g_random_int_range(1, G_MAXINT);
+	item->token = g_random_int_range(1, G_MAXINT); /* nocheck:blocked */
 	g_ptr_array_add(self->items, item);
 
 	fu_idle_emit_inhibit_changed(self);


### PR DESCRIPTION
Use a predicatable token value to make emulation possible.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
