### PR TITLE
rustgen: Define an 'unref' function for custom structs

### DIFF
--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -1,5 +1,7 @@
 typedef GByteArray {{obj.name}};
-G_DEFINE_AUTOPTR_CLEANUP_FUNC({{obj.name}}, g_byte_array_unref)
+
+#define {{obj.c_method('Unref')}} g_byte_array_unref
+G_DEFINE_AUTOPTR_CLEANUP_FUNC({{obj.name}}, {{obj.c_method('Unref')}})
 
 {%- if obj.export('New') == Export.PUBLIC %}
 {{obj.name}} *{{obj.c_method('New')}}(void) G_GNUC_WARN_UNUSED_RESULT;

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -317,7 +317,7 @@ fu_ccgx_dmc_devx_device_finalize(GObject *object)
 {
 	FuCcgxDmcDevxDevice *self = FU_CCGX_DMC_DEVX_DEVICE(object);
 	if (self->status != NULL)
-		g_byte_array_unref(self->status);
+		fu_struct_ccgx_dmc_devx_status_unref(self->status);
 	G_OBJECT_CLASS(fu_ccgx_dmc_devx_device_parent_class)->finalize(object);
 }
 

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -3088,7 +3088,7 @@ fu_genesys_usbhub_device_finalize(GObject *object)
 {
 	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(object);
 	if (self->st_static_ts != NULL)
-		g_byte_array_unref(self->st_static_ts);
+		fu_struct_genesys_ts_static_unref(self->st_static_ts);
 	if (self->st_dynamic_ts != NULL)
 		g_byte_array_unref(self->st_dynamic_ts);
 	if (self->st_fwinfo_ts != NULL)

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -517,7 +517,7 @@ fu_genesys_usbhub_firmware_finalize(GObject *object)
 {
 	FuGenesysUsbhubFirmware *self = FU_GENESYS_USBHUB_FIRMWARE(object);
 	if (self->st_static_ts != NULL)
-		g_byte_array_unref(self->st_static_ts);
+		fu_struct_genesys_ts_static_unref(self->st_static_ts);
 	G_OBJECT_CLASS(fu_genesys_usbhub_firmware_parent_class)->finalize(object);
 }
 

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -74,7 +74,7 @@ fu_vli_usbhub_pd_device_setup(FuDevice *device, GError **error)
 			g_prefix_error(error, "failed to read PD header: ");
 			return FALSE;
 		}
-		g_byte_array_unref(st);
+		fu_struct_vli_pd_hdr_unref(st);
 		st = fu_struct_vli_pd_hdr_parse(buf, bufsz, 0x0, error);
 		if (st == NULL)
 			return FALSE;


### PR DESCRIPTION
(cherry picked from commit d2b5dcef027d99538a99bf836ef5aefde41083e6)
