### PR TITLE
fix(realtek-mst): fix refcounting memory leak

### DIFF
--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -687,6 +687,7 @@ fu_realtek_mst_device_read_firmware(FuDevice *device, FuProgress *progress, GErr
 	FuRealtekMstDevice *self = FU_REALTEK_MST_DEVICE(device);
 	guint32 bank_address;
 	g_autofree guint8 *image_bytes = NULL;
+	g_autoptr(GBytes) firmware_bytes = NULL;
 
 	if (self->active_bank == FU_REALTEK_MST_DEVICE_FLASH_BANK_USER1)
 		bank_address = FLASH_USER1_ADDR;
@@ -711,8 +712,9 @@ fu_realtek_mst_device_read_firmware(FuDevice *device, FuProgress *progress, GErr
 						    progress,
 						    error))
 		return NULL;
-	return fu_firmware_new_from_bytes(
-	    g_bytes_new_take(g_steal_pointer(&image_bytes), FLASH_USER_SIZE));
+	firmware_bytes = g_bytes_new_take(g_steal_pointer(&image_bytes), FLASH_USER_SIZE);
+
+	return fu_firmware_new_from_bytes(firmware_bytes);
 }
 
 static GBytes *


### PR DESCRIPTION
The original reference to the `GBytes` is never going to be unref'ed, `fu_firmware_new_from_bytes()` takes its own reference to the supplied `GBytes`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
