### PR TITLE
trivial: allow controlling unrequired dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -263,11 +263,11 @@ endif
 endif
 libjcat = dependency('jcat', version: '>= 0.2.0', fallback: ['libjcat', 'libjcat_dep'])
 libjsonglib = dependency('json-glib-1.0', version: '>= 1.6.0', fallback: ['libjsonglib', 'libjsonglib_dep'])
-libblkid = dependency('blkid', required: false)
+libblkid = dependency('blkid', required: get_option('blkid'))
 if libblkid.found()
   conf.set('HAVE_BLKID', '1')
 endif
-valgrind = dependency('valgrind', required: false)
+valgrind = dependency('valgrind', required: get_option('valgrind'))
 libcurl = dependency('libcurl', version: '>= 7.62.0', required: get_option('curl'))
 if libcurl.found()
   conf.set('HAVE_LIBCURL', '1')
@@ -729,6 +729,7 @@ summary({
   'libblkid': libblkid,
   'libcurl': libcurl,
   'libdrm': libdrm,
+  'valgrind': valgrind,
   'lzma': lzma,
   'polkit': polkit,
   'python3': python3,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -95,6 +95,14 @@ option('libdrm',
   type: 'feature',
   description: 'libdrm support',
 )
+option('valgrind',
+  type: 'feature',
+  description: 'valgrind support',
+)
+option('blkid',
+  type: 'feature',
+  description: 'libblkid support',
+)
 option('lvfs',
   type: 'combo',
   choices: [


### PR DESCRIPTION
When setting meson's dependency `required` argument to `false`, meson will automatically enable or disable the dependency based on the build environment.
Adds two meson options to manually disable `blkid` and `valgrind` dependencies to guarantee a consistent build with the same runtime dependencies independent of the build environment.

Similar: #7877

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
