### PR TITLE
logitech-hidpp: trivial cleanup while fetching info

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -377,7 +377,7 @@ fu_logitech_hidpp_device_fetch_firmware_info(FuLogitechHidppDevice *self, GError
 	guint8 idx;
 	guint8 entity_count;
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
+	g_autoptr(FuLogitechHidppHidppMsg) msg_count = fu_logitech_hidpp_msg_new();
 	gboolean radio_ok = FALSE;
 
 	/* get the feature index */
@@ -387,16 +387,16 @@ fu_logitech_hidpp_device_fetch_firmware_info(FuLogitechHidppDevice *self, GError
 		return TRUE;
 
 	/* get the entity count */
-	msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-	msg->device_id = priv->device_idx;
-	msg->sub_id = idx;
-	msg->function_id = 0x00 << 4; /* getCount */
-	msg->hidpp_version = priv->hidpp_version;
-	if (!fu_logitech_hidpp_transfer(priv->io_channel, msg, error)) {
+	msg_count->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+	msg_count->device_id = priv->device_idx;
+	msg_count->sub_id = idx;
+	msg_count->function_id = 0x00 << 4; /* getCount */
+	msg_count->hidpp_version = priv->hidpp_version;
+	if (!fu_logitech_hidpp_transfer(priv->io_channel, msg_count, error)) {
 		g_prefix_error(error, "failed to get firmware count: ");
 		return FALSE;
 	}
-	entity_count = msg->data[0];
+	entity_count = msg_count->data[0];
 	g_debug("firmware entity count is %u", entity_count);
 
 	/* get firmware, bootloader, hardware versions */
@@ -404,11 +404,13 @@ fu_logitech_hidpp_device_fetch_firmware_info(FuLogitechHidppDevice *self, GError
 		guint16 build;
 		g_autofree gchar *version = NULL;
 		g_autofree gchar *name = NULL;
+		g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
 
 		msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
 		msg->device_id = priv->device_idx;
 		msg->sub_id = idx;
 		msg->function_id = 0x01 << 4; /* getInfo */
+		msg->hidpp_version = priv->hidpp_version;
 		msg->data[0] = i;
 		if (!fu_logitech_hidpp_transfer(priv->io_channel, msg, error)) {
 			g_prefix_error(error, "failed to get firmware info: ");


### PR DESCRIPTION
Device might send additional debug bytes in the response, which were included into the next query, potentially affecting to device internals. Recreate the send buffer before querying entities.

Example, before the patch:
```
16:40:23.201 FuPluginLogitechHidpp host->device:   10 06 02 07 00 00 00 
16:40:23.216 FuPluginLogitechHidpp device->host:   11 06 02 07 04 **66 40** 11 9e 00 02 b3 4e 00 00 00 00 00 01 00 
16:40:23.217 FuPluginLogitechHidpp firmware entity count is 4

16:40:23.217 FuPluginLogitechHidpp host->device:   10 06 02 17 00 **66 40** 
16:40:23.239 FuPluginLogitechHidpp device->host:   11 06 02 17 01 **4c 44** 00 01 00 00 00 00 00 00 e5 4a d6 8d 00 

16:40:23.240 FuPluginLogitechHidpp host->device:   10 06 02 17 01 **4c 44** 
16:40:23.254 FuPluginLogitechHidpp device->host:   11 06 02 17 00 52 42 4f 03 00 90 02 01 b3 4e 6e 80 fb 06 00 
...
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
