### PR TITLE
amd-gpu: Deinitialize after getting marketing name

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -180,6 +180,7 @@ fu_amd_gpu_device_set_marketing_name(FuAmdGpuDevice *self)
 		const gchar *marketing_name = amdgpu_get_marketing_name(device_handle);
 		if (marketing_name != NULL)
 			fu_device_set_name(FU_DEVICE(self), marketing_name);
+		amdgpu_device_deinitialize(device_handle);
 	} else
 		g_warning("unable to set marketing name: %s", g_strerror(r));
 }


### PR DESCRIPTION
This should release the fd so that fwupd doesn't show up as drm master anymore.

Fixes: https://github.com/fwupd/fwupd/issues/7929

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
