### PR TITLE
trivial: Do not allow new plugins to use GUINT32_FROM_BE

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -227,6 +227,18 @@ class Checker:
             "&= ~(1ull <<": "Use FU_BIT_CLEAR() instead",
             "__attribute__((packed))": "Use rustgen instead",
             "memcpy(": "Use fu_memcpy_safe or rustgen instead",
+            "GUINT16_FROM_BE(": "Use fu_memread_uint16_safe() or rustgen instead",
+            "GUINT16_FROM_LE(": "Use fu_memread_uint16_safe() or rustgen instead",
+            "GUINT16_TO_BE(": "Use fu_memwrite_uint16_safe() or rustgen instead",
+            "GUINT16_TO_LE(": "Use fu_memwrite_uint16_safe() or rustgen instead",
+            "GUINT32_FROM_BE(": "Use fu_memread_uint32_safe() or rustgen instead",
+            "GUINT32_FROM_LE(": "Use fu_memread_uint32_safe() or rustgen instead",
+            "GUINT32_TO_BE(": "Use fu_memwrite_uint32_safe() or rustgen instead",
+            "GUINT32_TO_LE(": "Use fu_memwrite_uint32_safe() or rustgen instead",
+            "GUINT64_FROM_BE(": "Use fu_memread_uint64_safe() or rustgen instead",
+            "GUINT64_FROM_LE(": "Use fu_memread_uint64_safe() or rustgen instead",
+            "GUINT64_TO_BE(": "Use fu_memwrite_uint64_safe() or rustgen instead",
+            "GUINT64_TO_LE(": "Use fu_memwrite_uint64_safe() or rustgen instead",
             " ioctl(": "Use fu_udev_device_ioctl() instead",
         }.items():
             if line.find(token) != -1:

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -184,10 +184,10 @@ fwupd_guid_to_string(const fwupd_guid_t *guid, FwupdGuidFlags flags)
 	/* mixed is bizaar, but specified as the DCE encoding */
 	if (flags & FWUPD_GUID_FLAG_MIXED_ENDIAN) {
 		return g_strdup_printf("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",
-				       (guint)GUINT32_FROM_LE(gnat.a),
-				       (guint)GUINT16_FROM_LE(gnat.b),
-				       (guint)GUINT16_FROM_LE(gnat.c),
-				       (guint)GUINT16_FROM_BE(gnat.d),
+				       (guint)GUINT32_FROM_LE(gnat.a), /* nocheck:blocked */
+				       (guint)GUINT16_FROM_LE(gnat.b), /* nocheck:blocked */
+				       (guint)GUINT16_FROM_LE(gnat.c), /* nocheck:blocked */
+				       (guint)GUINT16_FROM_BE(gnat.d), /* nocheck:blocked */
 				       gnat.e[0],
 				       gnat.e[1],
 				       gnat.e[2],
@@ -196,10 +196,10 @@ fwupd_guid_to_string(const fwupd_guid_t *guid, FwupdGuidFlags flags)
 				       gnat.e[5]);
 	}
 	return g_strdup_printf("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",
-			       (guint)GUINT32_FROM_BE(gnat.a),
-			       (guint)GUINT16_FROM_BE(gnat.b),
-			       (guint)GUINT16_FROM_BE(gnat.c),
-			       (guint)GUINT16_FROM_BE(gnat.d),
+			       (guint)GUINT32_FROM_BE(gnat.a), /* nocheck:blocked */
+			       (guint)GUINT16_FROM_BE(gnat.b), /* nocheck:blocked */
+			       (guint)GUINT16_FROM_BE(gnat.c), /* nocheck:blocked */
+			       (guint)GUINT16_FROM_BE(gnat.d), /* nocheck:blocked */
 			       gnat.e[0],
 			       gnat.e[1],
 			       gnat.e[2],
@@ -264,16 +264,16 @@ fwupd_guid_from_string(const gchar *guidstr,
 	/* parse */
 	if (!g_ascii_string_to_unsigned(split[0], 16, 0, 0xffffffff, &tmp, error))
 		return FALSE;
-	gu.a = mixed_endian ? GUINT32_TO_LE(tmp) : GUINT32_TO_BE(tmp);
+	gu.a = mixed_endian ? GUINT32_TO_LE(tmp) : GUINT32_TO_BE(tmp); /* nocheck:blocked */
 	if (!g_ascii_string_to_unsigned(split[1], 16, 0, 0xffff, &tmp, error))
 		return FALSE;
-	gu.b = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp);
+	gu.b = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp); /* nocheck:blocked */
 	if (!g_ascii_string_to_unsigned(split[2], 16, 0, 0xffff, &tmp, error))
 		return FALSE;
-	gu.c = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp);
+	gu.c = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp); /* nocheck:blocked */
 	if (!g_ascii_string_to_unsigned(split[3], 16, 0, 0xffff, &tmp, error))
 		return FALSE;
-	gu.d = GUINT16_TO_BE(tmp);
+	gu.d = GUINT16_TO_BE(tmp); /* nocheck:blocked */
 	for (guint i = 0; i < 6; i++) {
 		gchar buffer[3] = {0x0};
 		memcpy(buffer, split[4] + (i * 2), 2); /* nocheck:blocked */

--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -148,7 +148,7 @@ fu_hwids_get_guid_for_str(const gchar *str, GError **error)
 
 	/* ensure the data is in little endian format */
 	for (glong i = 0; i < items_written; i++)
-		data[i] = GUINT16_TO_LE(data[i]);
+		data[i] = GUINT16_TO_LE(data[i]); /* nocheck:blocked */
 
 	/* convert to a GUID */
 	return fwupd_guid_hash_data((guint8 *)data,

--- a/libfwupdplugin/fu-mem.c
+++ b/libfwupdplugin/fu-mem.c
@@ -29,10 +29,10 @@ fu_memwrite_uint16(guint8 *buf, guint16 val_native, FuEndianType endian)
 	guint16 val_hw;
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_hw = GUINT16_TO_BE(val_native);
+		val_hw = GUINT16_TO_BE(val_native); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_hw = GUINT16_TO_LE(val_native);
+		val_hw = GUINT16_TO_LE(val_native); /* nocheck:blocked */
 		break;
 	default:
 		val_hw = val_native;
@@ -57,11 +57,11 @@ fu_memwrite_uint24(guint8 *buf, guint32 val_native, FuEndianType endian)
 	guint32 val_hw;
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_hw = GUINT32_TO_BE(val_native);
+		val_hw = GUINT32_TO_BE(val_native);		   /* nocheck:blocked */
 		memcpy(buf, ((const guint8 *)&val_hw) + 0x1, 0x3); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_hw = GUINT32_TO_LE(val_native);
+		val_hw = GUINT32_TO_LE(val_native); /* nocheck:blocked */
 		memcpy(buf, &val_hw, 0x3); /* nocheck:blocked */
 		break;
 	default:
@@ -85,10 +85,10 @@ fu_memwrite_uint32(guint8 *buf, guint32 val_native, FuEndianType endian)
 	guint32 val_hw;
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_hw = GUINT32_TO_BE(val_native);
+		val_hw = GUINT32_TO_BE(val_native); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_hw = GUINT32_TO_LE(val_native);
+		val_hw = GUINT32_TO_LE(val_native); /* nocheck:blocked */
 		break;
 	default:
 		val_hw = val_native;
@@ -113,10 +113,10 @@ fu_memwrite_uint64(guint8 *buf, guint64 val_native, FuEndianType endian)
 	guint64 val_hw;
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_hw = GUINT64_TO_BE(val_native);
+		val_hw = GUINT64_TO_BE(val_native); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_hw = GUINT64_TO_LE(val_native);
+		val_hw = GUINT64_TO_LE(val_native); /* nocheck:blocked */
 		break;
 	default:
 		val_hw = val_native;
@@ -143,10 +143,10 @@ fu_memread_uint16(const guint8 *buf, FuEndianType endian)
 	memcpy(&val_hw, buf, sizeof(val_hw)); /* nocheck:blocked */
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_native = GUINT16_FROM_BE(val_hw);
+		val_native = GUINT16_FROM_BE(val_hw); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_native = GUINT16_FROM_LE(val_hw);
+		val_native = GUINT16_FROM_LE(val_hw); /* nocheck:blocked */
 		break;
 	default:
 		val_native = val_hw;
@@ -174,11 +174,11 @@ fu_memread_uint24(const guint8 *buf, FuEndianType endian)
 	switch (endian) {
 	case G_BIG_ENDIAN:
 		memcpy(((guint8 *)&val_hw) + 0x1, buf, 0x3); /* nocheck:blocked */
-		val_native = GUINT32_FROM_BE(val_hw);
+		val_native = GUINT32_FROM_BE(val_hw);	     /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
 		memcpy(&val_hw, buf, 0x3); /* nocheck:blocked */
-		val_native = GUINT32_FROM_LE(val_hw);
+		val_native = GUINT32_FROM_LE(val_hw); /* nocheck:blocked */
 		break;
 	default:
 		val_native = val_hw;
@@ -205,10 +205,10 @@ fu_memread_uint32(const guint8 *buf, FuEndianType endian)
 	memcpy(&val_hw, buf, sizeof(val_hw)); /* nocheck:blocked */
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_native = GUINT32_FROM_BE(val_hw);
+		val_native = GUINT32_FROM_BE(val_hw); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_native = GUINT32_FROM_LE(val_hw);
+		val_native = GUINT32_FROM_LE(val_hw); /* nocheck:blocked */
 		break;
 	default:
 		val_native = val_hw;
@@ -235,10 +235,10 @@ fu_memread_uint64(const guint8 *buf, FuEndianType endian)
 	memcpy(&val_hw, buf, sizeof(val_hw)); /* nocheck:blocked */
 	switch (endian) {
 	case G_BIG_ENDIAN:
-		val_native = GUINT64_FROM_BE(val_hw);
+		val_native = GUINT64_FROM_BE(val_hw); /* nocheck:blocked */
 		break;
 	case G_LITTLE_ENDIAN:
-		val_native = GUINT64_FROM_LE(val_hw);
+		val_native = GUINT64_FROM_LE(val_hw); /* nocheck:blocked */
 		break;
 	default:
 		val_native = val_hw;

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -513,7 +513,7 @@ fu_bcm57xx_device_setup(FuDevice *device, GError **error)
 	if (fwversion != 0x0) {
 		/* this is only set on the OSS firmware */
 		fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
-		fu_device_set_version_raw(device, GUINT32_FROM_BE(fwversion));
+		fu_device_set_version_raw(device, GUINT32_FROM_BE(fwversion)); /* nocheck:blocked */
 		fu_device_set_branch(device, BCM_FW_BRANCH_OSS_FIRMWARE);
 	} else {
 		guint8 bufver[16] = {0x0};
@@ -527,7 +527,7 @@ fu_bcm57xx_device_setup(FuDevice *device, GError **error)
 						  sizeof(guint32),
 						  error))
 			return FALSE;
-		veraddr = GUINT32_FROM_BE(veraddr);
+		veraddr = GUINT32_FROM_BE(veraddr); /* nocheck:blocked */
 		if (veraddr > BCM_PHYS_ADDR_DEFAULT)
 			veraddr -= BCM_PHYS_ADDR_DEFAULT;
 		if (!fu_bcm57xx_device_nvram_read(self,

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -375,7 +375,7 @@ fu_bcm57xx_recovery_device_nvram_read(FuBcm57xxRecoveryDevice *self,
 							 &val32,
 							 error))
 			return FALSE;
-		buf[i] = GUINT32_FROM_BE(val32);
+		buf[i] = GUINT32_FROM_BE(val32); /* nocheck:blocked */
 		address += sizeof(guint32);
 		fu_progress_step_done(progress);
 	}
@@ -411,11 +411,12 @@ fu_bcm57xx_recovery_device_nvram_write(FuBcm57xxRecoveryDevice *self,
 		BcmRegNVMCommand tmp = {0};
 		if (!fu_bcm57xx_recovery_device_nvram_clear_done(self, error))
 			return FALSE;
-		if (!fu_bcm57xx_recovery_device_bar_write(self,
-							  FU_BCM57XX_BAR_DEVICE,
-							  REG_NVM_WRITE,
-							  GUINT32_TO_BE(buf[i]),
-							  error))
+		if (!fu_bcm57xx_recovery_device_bar_write(
+			self,
+			FU_BCM57XX_BAR_DEVICE,
+			REG_NVM_WRITE,
+			GUINT32_TO_BE(buf[i]), /* nocheck:blocked */
+			error))
 			return FALSE;
 		if (!fu_bcm57xx_recovery_device_bar_write(self,
 							  FU_BCM57XX_BAR_DEVICE,
@@ -689,7 +690,7 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 	if (fwversion != 0x0) {
 		/* this is only set on the OSS firmware */
 		fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
-		fu_device_set_version_raw(device, GUINT32_FROM_BE(fwversion));
+		fu_device_set_version_raw(device, GUINT32_FROM_BE(fwversion)); /* nocheck:blocked */
 		fu_device_set_branch(device, BCM_FW_BRANCH_OSS_FIRMWARE);
 		fu_progress_step_done(progress);
 		fu_progress_step_done(progress);
@@ -708,7 +709,7 @@ fu_bcm57xx_recovery_device_setup(FuDevice *device, GError **error)
 							   error))
 			return FALSE;
 		fu_progress_step_done(progress);
-		veraddr = GUINT32_FROM_BE(veraddr);
+		veraddr = GUINT32_FROM_BE(veraddr); /* nocheck:blocked */
 		if (veraddr > BCM_PHYS_ADDR_DEFAULT)
 			veraddr -= BCM_PHYS_ADDR_DEFAULT;
 		if (!fu_bcm57xx_recovery_device_nvram_read(self,

--- a/plugins/dell-dock/fu-dell-dock-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-ec.c
@@ -481,7 +481,8 @@ fu_dell_dock_ec_get_dock_info(FuDevice *device, GError **error)
 			   map->location == LOCATION_BASE && map->sub_type == 0) {
 			if (oldest_base_pd == 0 ||
 			    device_entry[i].version.version_32 < oldest_base_pd)
-				oldest_base_pd = GUINT32_TO_BE(device_entry[i].version.version_32);
+				oldest_base_pd = GUINT32_TO_BE(/* nocheck:blocked */
+							       device_entry[i].version.version_32);
 			g_debug("\tParsed version: %02x.%02x.%02x.%02x",
 				device_entry[i].version.version_8[0],
 				device_entry[i].version.version_8[1],

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -130,7 +130,7 @@ fu_dell_dock_hid_get_hub_version(FuDevice *self, GError **error)
 	    .cmd_data1 = 0,
 	    .cmd_data2 = 0,
 	    .cmd_data3 = 0,
-	    .bufferlen = GUINT16_TO_LE(12),
+	    .bufferlen = GUINT16_TO_LE(12), /* nocheck:blocked */
 	    .parameters = {.i2ctargetaddr = 0, .regaddrlen = 0, .i2cspeed = 0},
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
@@ -206,8 +206,8 @@ fu_dell_dock_hid_write_flash(FuDevice *self,
 	FuHIDCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_WRITE_DATA,
 	    .ext = HUB_EXT_WRITEFLASH,
-	    .dwregaddr = GUINT32_TO_LE(dwAddr),
-	    .bufferlen = GUINT16_TO_LE(write_size),
+	    .dwregaddr = GUINT32_TO_LE(dwAddr),	    /* nocheck:blocked */
+	    .bufferlen = GUINT16_TO_LE(write_size), /* nocheck:blocked */
 	    .parameters = {.i2ctargetaddr = 0, .regaddrlen = 0, .i2cspeed = 0},
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
@@ -236,7 +236,7 @@ fu_dell_dock_hid_verify_update(FuDevice *self, gboolean *result, GError **error)
 	    .cmd_data1 = 0,
 	    .cmd_data2 = 0,
 	    .cmd_data3 = 0,
-	    .bufferlen = GUINT16_TO_LE(1),
+	    .bufferlen = GUINT16_TO_LE(1), /* nocheck:blocked */
 	    .parameters = {.i2ctargetaddr = 0, .regaddrlen = 0, .i2cspeed = 0},
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
@@ -265,7 +265,7 @@ fu_dell_dock_hid_i2c_write(FuDevice *self,
 	    .cmd = HUB_CMD_WRITE_DATA,
 	    .ext = HUB_EXT_I2C_WRITE,
 	    .dwregaddr = 0,
-	    .bufferlen = GUINT16_TO_LE(write_size),
+	    .bufferlen = GUINT16_TO_LE(write_size), /* nocheck:blocked */
 	    .parameters = {.i2ctargetaddr = parameters->i2ctargetaddr,
 			   .regaddrlen = 0,
 			   .i2cspeed = parameters->i2cspeed | 0x80},
@@ -290,8 +290,8 @@ fu_dell_dock_hid_i2c_read(FuDevice *self,
 	FuHIDCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_WRITE_DATA,
 	    .ext = HUB_EXT_I2C_READ,
-	    .dwregaddr = GUINT32_TO_LE(cmd),
-	    .bufferlen = GUINT16_TO_LE(read_size),
+	    .dwregaddr = GUINT32_TO_LE(cmd),	   /* nocheck:blocked */
+	    .bufferlen = GUINT16_TO_LE(read_size), /* nocheck:blocked */
 	    .parameters = {.i2ctargetaddr = parameters->i2ctargetaddr,
 			   .regaddrlen = parameters->regaddrlen,
 			   .i2cspeed = parameters->i2cspeed | 0x80},
@@ -364,7 +364,7 @@ fu_dell_dock_hid_tbt_write(FuDevice *self,
 	    .ext = HUB_EXT_WRITE_TBT_FLASH,
 	    .i2ctargetaddr = parameters->i2ctargetaddr,
 	    .i2cspeed = parameters->i2cspeed, /* unlike other commands doesn't need | 0x80 */
-	    .startaddress = GUINT32_TO_LE(start_addr),
+	    .startaddress = GUINT32_TO_LE(start_addr), /* nocheck:blocked */
 	    .bufferlen = write_size,
 	    .extended_cmdarea[0 ... 53] = 0,
 	};
@@ -412,7 +412,7 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 	    .ext = HUB_EXT_WRITE_TBT_FLASH,
 	    .i2ctargetaddr = parameters->i2ctargetaddr,
 	    .i2cspeed = parameters->i2cspeed, /* unlike other commands doesn't need | 0x80 */
-	    .tbt_command = GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE),
+	    .tbt_command = GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE), /* nocheck:blocked */
 	    .bufferlen = 0,
 	    .extended_cmdarea[0 ... 53] = 0,
 	};
@@ -423,7 +423,8 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 		return FALSE;
 	}
 
-	cmd_buffer.tbt_command = GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE_STATUS);
+	cmd_buffer.tbt_command =
+	    GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE_STATUS); /* nocheck:blocked */
 	/* needs at least 2 seconds */
 	fu_device_sleep(self, 2000);
 	for (gint i = 1; i <= TBT_MAX_RETRIES; i++) {

--- a/plugins/dell-dock/fu-dell-dock-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-mst.c
@@ -584,7 +584,8 @@ fu_dell_dock_mst_checksum_bank(FuDevice *device,
 					    error))
 		return FALSE;
 	data = g_bytes_get_data(csum_bytes, NULL);
-	bank_sum = GUINT32_FROM_LE(data[0] | data[1] << 8 | data[2] << 16 | data[3] << 24);
+	bank_sum = GUINT32_FROM_LE(data[0] | data[1] << 8 | data[2] << 16 | /* nocheck:blocked */
+				   data[3] << 24);
 	g_debug("MST: Bank %u checksum: 0x%x", bank, bank_sum);
 
 	*checksum = (bank_sum == payload_sum);

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -324,7 +324,8 @@ fu_ebitdo_device_setup(FuDevice *device, GError **error)
 					      error)) {
 			return FALSE;
 		}
-		fu_device_set_version_raw(FU_DEVICE(self), GUINT32_FROM_LE(version_tmp));
+		fu_device_set_version_raw(FU_DEVICE(self),
+					  GUINT32_FROM_LE(version_tmp)); /* nocheck:blocked */
 		return TRUE;
 	}
 
@@ -341,7 +342,7 @@ fu_ebitdo_device_setup(FuDevice *device, GError **error)
 	if (!fu_ebitdo_device_receive(self, (guint8 *)&version_tmp, sizeof(version_tmp), error)) {
 		return FALSE;
 	}
-	fu_device_set_version_raw(device, GUINT32_FROM_LE(version_tmp));
+	fu_device_set_version_raw(device, GUINT32_FROM_LE(version_tmp)); /* nocheck:blocked */
 
 	/* get verification ID */
 	if (!fu_ebitdo_device_send(self,
@@ -357,7 +358,7 @@ fu_ebitdo_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 	for (guint i = 0; i < 9; i++)
-		self->serial[i] = GUINT32_FROM_LE(serial_tmp[i]);
+		self->serial[i] = GUINT32_FROM_LE(serial_tmp[i]); /* nocheck:blocked */
 
 	/* success */
 	return TRUE;

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -556,8 +556,8 @@ fu_synaptics_rmi_firmware_write_v10(FuFirmware *firmware, GError **error)
 
 	/* header | desc_hdr | offset_table | desc | flash_config |
 	 *        \0x0       \0x20          \0x24  \0x44          |0x48 */
-	guint32 offset_table[] = {
-	    GUINT32_TO_LE(RMI_IMG_FW_OFFSET + 0x24)}; /* offset to first descriptor */
+	guint32 offset_table[] = {/* offset to first descriptor */
+				  GUINT32_TO_LE(RMI_IMG_FW_OFFSET + 0x24)}; /* nocheck:blocked */
 	fu_struct_rmi_container_descriptor_set_container_id(desc, FU_RMI_CONTAINER_ID_FLASH_CONFIG);
 	fu_struct_rmi_container_descriptor_set_content_address(desc, RMI_IMG_FW_OFFSET + 0x44);
 

--- a/plugins/tpm/fu-tpm-v2-device.c
+++ b/plugins/tpm/fu-tpm-v2-device.c
@@ -98,7 +98,7 @@ fu_tpm_v2_device_get_string(FuTpmV2Device *self, guint32 query, GError **error)
 	/* return four bytes */
 	if (!fu_tpm_v2_device_get_uint32(self, query, &val_be, error))
 		return NULL;
-	val = GUINT32_FROM_BE(val_be);
+	val = GUINT32_FROM_BE(val_be);	  /* nocheck:blocked */
 	memcpy(result, (gchar *)&val, 4); /* nocheck:blocked */
 
 	/* convert non-ASCII into spaces */

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -563,7 +563,8 @@ fu_wac_device_write_firmware(FuDevice *device,
 		}
 
 		/* calculate expected checksum and save to device RAM */
-		csum_local[i] = GUINT32_TO_LE(fu_sum32w_bytes(blob_block, G_LITTLE_ENDIAN));
+		csum_local[i] = GUINT32_TO_LE(/* nocheck:blocked */
+					      fu_sum32w_bytes(blob_block, G_LITTLE_ENDIAN));
 		g_debug("block checksum %02u: 0x%08x", i, csum_local[i]);
 		if (!fu_wac_device_set_checksum_of_block(self, i, csum_local[i], error))
 			return FALSE;


### PR DESCRIPTION
They should be using one of the safe helpers or rustgen instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
