### PR TITLE
dell-kestrel: Do not show 'Device has been removed' as the device error

### DIFF
--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.c
@@ -740,6 +740,7 @@ fu_dell_kestrel_ec_init(FuDellKestrelEc *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_EXPLICIT_ORDER);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_RETRY_OPEN);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_FLAGS);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ONLY_WAIT_FOR_REPLUG);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 }
 

--- a/plugins/dell-kestrel/fu-dell-kestrel-rmm.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rmm.c
@@ -81,6 +81,7 @@ fu_dell_kestrel_rmm_init(FuDellKestrelRmm *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INSTALL_SKIP_VERSION_CHECK);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_EXPLICIT_ORDER);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ONLY_WAIT_FOR_REPLUG);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 }
 

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
@@ -369,6 +369,7 @@ fu_dell_kestrel_rtshub_init(FuDellKestrelRtsHub *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_SKIPS_RESTART);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_EXPLICIT_ORDER);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_RETRY_OPEN);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ONLY_WAIT_FOR_REPLUG);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_DELL_KESTREL_RTSHUB_FIRMWARE);
 	fu_device_retry_set_delay(FU_DEVICE(self), 1000);


### PR DESCRIPTION
Add ONLY_WAIT_FOR_REPLUG to all final devices or subclasses.

Fixes https://github.com/fwupd/fwupd/issues/8183

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
