### PR TITLE
trivial: ci: check out from Github mirrors for GNOME content

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -303,7 +303,7 @@ def _build(bld: Builder) -> None:
 
     # GLib
     src = bld.checkout_source(
-        "glib", url="https://gitlab.gnome.org/GNOME/glib.git", commit="glib-2-68"
+        "glib", url="https://github.com/GNOME/glib.git", commit="glib-2-68"
     )
     bld.build_meson_project(
         src,
@@ -329,7 +329,7 @@ def _build(bld: Builder) -> None:
     # JSON-GLib
     src = bld.checkout_source(
         "json-glib",
-        url="https://gitlab.gnome.org/GNOME/json-glib.git",
+        url="https://github.com/GNOME/json-glib.git",
         commit="1.8.0-actual",
     )
     bld.build_meson_project(

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=gi-docgen
-url=https://gitlab.gnome.org/GNOME/gi-docgen.git
+url=https://github.com/GNOME/gi-docgen.git
 revision=2024.1
 depth=1

--- a/subprojects/json-glib.wrap
+++ b/subprojects/json-glib.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 directory = json-glib
-url = https://gitlab.gnome.org/GNOME/json-glib.git
+url = https://github.com/GNOME/json-glib.git
 revision = 1.10.0
 
 [provide]


### PR DESCRIPTION
This should make CI more impervious to GNOME server issues.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
