### PR TITLE
trivial: ci: check out from Github mirrors for GNOME content

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -295,7 +295,7 @@ def _build(bld: Builder) -> None:
 
     # GLib
     src = bld.checkout_source(
-        "glib", url="https://gitlab.gnome.org/GNOME/glib.git", commit="glib-2-68"
+        "glib", url="https://github.com/GNOME/glib.git", commit="glib-2-68"
     )
     bld.build_meson_project(
         src,
@@ -319,9 +319,7 @@ def _build(bld: Builder) -> None:
     bld.add_build_ldflag("lib/libgthread-2.0.a")
 
     # JSON-GLib
-    src = bld.checkout_source(
-        "json-glib", url="https://gitlab.gnome.org/GNOME/json-glib.git"
-    )
+    src = bld.checkout_source("json-glib", url="https://github.com/GNOME/json-glib.git")
     bld.build_meson_project(
         src, ["-Dgtk_doc=disabled", "-Dtests=false", "-Dintrospection=disabled"]
     )

--- a/subprojects/gi-docgen.wrap
+++ b/subprojects/gi-docgen.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=gi-docgen
-url=https://gitlab.gnome.org/GNOME/gi-docgen.git
+url=https://github.com/GNOME/gi-docgen.git
 revision=2021.8
 depth=1


### PR DESCRIPTION
This should make CI more impervious to GNOME server issues.

(cherry picked from commit b60d20c941934e3e8e015a2d631096dfb206f29b)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
