### PR TITLE
plugins/uefi-dbx: snapd integration for UEFI DBX updates (v2)

### DIFF
--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -27,9 +27,12 @@ cp -R ../../../!(build|dist) .
 popd
 chown nobody . -R
 
-# install and run the custom redfish simulator
+# install dependencies for auxiliary simulators
 pacman -S --noconfirm python-flask
+# run custom redfish simulator
 ../plugins/redfish/tests/redfish.py &
+# run custom snapd simulator
+../plugins/uefi-dbx/tests/snapd.py &
 
 # install and run TPM simulator necessary for plugins/uefi-capsule/uefi-self-test
 pacman -S --noconfirm swtpm tpm2-tools

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -193,6 +193,7 @@ fu_common_check_full_disk_encryption(GError **error)
 				    g_variant_get_bytestring(device));
 			return FALSE;
 		}
+		/* TODO identify Ubuntu Core FDE volumes */
 	}
 	return TRUE;
 }

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -357,3 +357,18 @@ fu_xmlb_builder_insert_kb(XbBuilderNode *bn, const gchar *key, gboolean value)
 {
 	xb_builder_node_insert_text(bn, key, value ? "true" : "false", NULL);
 }
+
+/**
+ * fu_snap_is_in_snap:
+ *
+ * Check whether the current process is running inside a snap.
+ *
+ * Returns: TRUE if current process is running inside a snap.
+ *
+ * Since: 2.0.4
+ **/
+gboolean
+fu_snap_is_in_snap(void)
+{
+	return getenv("SNAP") != NULL;
+}

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -119,3 +119,6 @@ void
 fu_xmlb_builder_insert_kx(XbBuilderNode *bn, const gchar *key, guint64 value) G_GNUC_NON_NULL(1);
 void
 fu_xmlb_builder_insert_kb(XbBuilderNode *bn, const gchar *key, gboolean value) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_snap_is_in_snap(void);

--- a/plugins/uefi-dbx/fu-self-test.c
+++ b/plugins/uefi-dbx/fu-self-test.c
@@ -6,7 +6,16 @@
 
 #include "config.h"
 
-#include "fu-uefi-dbx-common.h"
+#include <curl/curl.h>
+#include <curl/easy.h>
+
+#include "fwupd-error.h"
+
+#include "fu-context-private.h"
+#include "fu-device-private.h"
+#include "fu-plugin-private.h"
+#include "fu-uefi-dbx-device.h"
+#include "fu-uefi-dbx-plugin.h"
 
 static void
 fu_efi_image_func(void)
@@ -45,9 +54,551 @@ fu_efi_image_func(void)
 	}
 }
 
+typedef struct {
+	guint devices_cnt;
+	gboolean with_snapd;
+	gboolean snapd_supported;
+	const gchar *mock_snapd_scenario;
+} FuTestCase;
+
+typedef struct {
+	FuContext *ctx;
+
+	gboolean mock_snapd_available;
+
+	CURL *mock_snapd_curl;
+	struct curl_slist *mock_curl_hdrs;
+} FuTestFixture;
+
+static gboolean
+fu_self_test_mock_snapd_easy_post_request(FuTestFixture *fixture,
+					  const gchar *endpoint,
+					  const gchar *data,
+					  gsize len)
+{
+	CURL *curl = curl_easy_duphandle(fixture->mock_snapd_curl);
+	CURLcode res = -1;
+	glong status_code = 0;
+	g_autofree gchar *endpoint_str = g_strdup_printf("http://localhost%s", endpoint);
+
+	g_debug("mock snapd request to %s with data: '%s'", endpoint_str, data);
+
+	/* use snap dedicated socket when running inside a snap */
+	curl_easy_setopt(curl, CURLOPT_URL, endpoint_str);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+	res = curl_easy_perform(curl);
+	g_debug("curl error: %u %s", res, curl_easy_strerror(res));
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+	curl_easy_cleanup(curl);
+	return res == CURLE_OK && status_code == 200;
+}
+
+static size_t
+fu_self_test_curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	GByteArray *bufarr = (GByteArray *)userdata;
+	gsize sz = size * nmemb;
+	g_byte_array_append(bufarr, (const guint8 *)ptr, sz);
+	return sz;
+}
+
+static GBytes *
+fu_self_test_mock_snapd_easy_get_request(FuTestFixture *fixture, const gchar *endpoint)
+{
+	CURL *curl = curl_easy_duphandle(fixture->mock_snapd_curl);
+	CURLcode res = -1;
+	glong status_code = 0;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	g_autofree gchar *endpoint_str = g_strdup_printf("http://localhost%s", endpoint);
+
+	/* use snap dedicated socket when running inside a snap */
+	curl_easy_setopt(curl, CURLOPT_URL, endpoint_str);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fu_self_test_curl_write_callback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, buf);
+	res = curl_easy_perform(curl);
+	g_debug("curl error: %u %s", res, curl_easy_strerror(res));
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+	curl_easy_cleanup(curl);
+
+	g_assert_true(res == CURLE_OK);
+	g_assert_true(status_code == 200);
+
+	g_debug("rsp:\n%s", buf->data);
+
+	return g_bytes_new(buf->data, buf->len);
+}
+
+typedef struct {
+	guint startup;
+	guint prepare;
+	guint cleanup;
+} FuTestSnapdCalls;
+
+static void
+fu_self_test_mock_snapd_assert_calls(FuTestFixture *fixture, FuTestSnapdCalls calls)
+{
+	guint64 val = 0xffffff;
+	g_autoptr(GBytes) rsp = NULL;
+	g_autoptr(GKeyFile) kf = g_key_file_new();
+	g_autoptr(GError) error = NULL;
+
+	rsp = fu_self_test_mock_snapd_easy_get_request(fixture, "/test/stats");
+
+	g_key_file_load_from_bytes(kf, rsp, 0, &error);
+	g_assert_no_error(error);
+
+	val = g_key_file_get_uint64(kf, "stats", "efi-secureboot-update-startup", &error);
+	g_assert_no_error(error);
+	g_assert_cmpuint(val, ==, calls.startup);
+
+	val = g_key_file_get_uint64(kf, "stats", "efi-secureboot-update-db-prepare", &error);
+	g_assert_no_error(error);
+	g_assert_cmpuint(val, ==, calls.prepare);
+
+	val = g_key_file_get_uint64(kf, "stats", "efi-secureboot-update-db-cleanup", &error);
+	g_assert_no_error(error);
+	g_assert_cmpuint(val, ==, calls.cleanup);
+}
+
+static gboolean
+fu_self_test_mock_snapd_reset(FuTestFixture *fixture)
+{
+	return fu_self_test_mock_snapd_easy_post_request(fixture, "/test/reset", NULL, 0);
+}
+
+static gboolean
+fu_self_test_mock_snapd_setup_scenario(FuTestFixture *fixture, const gchar *scenario)
+{
+	g_autofree gchar *scenario_request = g_strdup_printf("{\"scenario\":\"%s\"}", scenario);
+
+	return fu_self_test_mock_snapd_easy_post_request(fixture,
+							 "/test/setup",
+							 scenario_request,
+							 strlen(scenario_request));
+}
+
+static gboolean
+fu_self_test_mock_snapd_init(FuTestFixture *fixture)
+{
+	CURL *curl = curl_easy_init();
+	struct curl_slist *req_hdrs = NULL;
+	const char *mock_snapd_snap_socket = g_getenv("FWUPD_SNAPD_SNAP_SOCKET");
+
+	g_assert_nonnull(mock_snapd_snap_socket);
+
+	/* use snap dedicated socket when running inside a snap */
+	curl_easy_setopt(curl, CURLOPT_UNIX_SOCKET_PATH, mock_snapd_snap_socket);
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+	req_hdrs = curl_slist_append(req_hdrs, "Content-Type: application/json");
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, req_hdrs);
+
+	fixture->mock_snapd_curl = curl;
+	fixture->mock_curl_hdrs = req_hdrs;
+
+	return fu_self_test_mock_snapd_reset(fixture);
+}
+
+static void
+fu_self_test_set_up(FuTestFixture *fixture, gconstpointer user_data)
+{
+	FuTestCase *tc = (FuTestCase *)user_data;
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+
+	if (tc->with_snapd && fu_self_test_mock_snapd_init(fixture)) {
+		fixture->mock_snapd_available = TRUE;
+
+		(void)g_setenv("SNAP", "fwupd", TRUE);
+
+		fu_self_test_mock_snapd_setup_scenario(fixture, tc->mock_snapd_scenario);
+	}
+
+	fixture->ctx = fu_context_new();
+	ret = fu_context_load_quirks(fixture->ctx,
+				     FU_QUIRKS_LOAD_FLAG_NO_CACHE | FU_QUIRKS_LOAD_FLAG_NO_VERIFY,
+				     &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fu_self_test_tear_down(FuTestFixture *fixture, gconstpointer user_data)
+{
+	FuTestCase *tc = (FuTestCase *)user_data;
+	if (tc->with_snapd) {
+		g_unsetenv("SNAP");
+
+		if (fixture->mock_snapd_available)
+			fu_self_test_mock_snapd_reset(fixture);
+
+		if (fixture->mock_snapd_curl)
+			curl_easy_cleanup(fixture->mock_snapd_curl);
+
+		if (fixture->mock_curl_hdrs)
+			curl_slist_free_all(fixture->mock_curl_hdrs);
+	}
+
+	g_object_unref(fixture->ctx);
+}
+
+static void
+fu_uefi_dbx_test_plugin_coldplug_no_device(FuTestFixture *fixture, gconstpointer user_data)
+{
+	gboolean ret;
+	FuContext *ctx = fixture->ctx;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_uefi_dbx_plugin_get_type(), ctx);
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_false(ret);
+}
+
+static gboolean
+fu_test_mock_efivar_content(FuEfivars *efivars,
+			    const gchar *guid,
+			    const gchar *name,
+			    const gchar *path,
+			    GError **error)
+{
+	gchar *mock_blob = NULL;
+	gsize mock_blob_size = 0;
+	g_autoptr(GBytes) mock_bytes = NULL;
+
+	if (!g_file_get_contents(path, &mock_blob, &mock_blob_size, error))
+		return FALSE;
+
+	mock_bytes = g_bytes_new_take(mock_blob, mock_blob_size);
+
+	return fu_efivars_set_data_bytes(efivars, guid, name, mock_bytes, 0, error);
+}
+
+static gboolean
+fu_test_mock_dbx_efivars(FuEfivars *efivars, GError **error)
+{
+	g_autofree gchar *mock_kek_path =
+	    g_test_build_filename(G_TEST_DIST,
+				  "tests/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c",
+				  NULL);
+	g_autofree gchar *mock_dbx_path =
+	    g_test_build_filename(G_TEST_DIST,
+				  "tests/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
+				  NULL);
+
+	if (!fu_test_mock_efivar_content(efivars,
+					 FU_EFIVARS_GUID_EFI_GLOBAL,
+					 "KEK",
+					 mock_kek_path,
+					 error))
+		return FALSE;
+
+	return fu_test_mock_efivar_content(efivars,
+					   FU_EFIVARS_GUID_SECURITY_DATABASE,
+					   "dbx",
+					   mock_dbx_path,
+					   error);
+}
+
+static GInputStream *
+fu_test_mock_dbx_update_stream(void)
+{
+	gchar *mock_blob = NULL;
+	gsize mock_blob_size = 0;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GBytes) mock_bytes = NULL;
+	g_autofree gchar *mock_dbx_update_path =
+	    g_test_build_filename(G_TEST_DIST, "tests/dbx-update.auth", NULL);
+
+	g_file_get_contents(mock_dbx_update_path, &mock_blob, &mock_blob_size, &error);
+	g_assert_no_error(error);
+
+	mock_bytes = g_bytes_new_take(mock_blob, mock_blob_size);
+	return g_memory_input_stream_new_from_bytes(mock_bytes);
+}
+
+static void
+fu_uefi_dbx_test_plugin_update(FuTestFixture *fixture, gconstpointer user_data)
+{
+	/* run though an update */
+
+	FuTestCase *tc = (FuTestCase *)user_data;
+	gboolean ret;
+	FuContext *ctx = fixture->ctx;
+	GPtrArray *devs = NULL;
+	FuDevice *dev = NULL;
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_uefi_dbx_plugin_get_type(), ctx);
+
+	if (tc->with_snapd && !fixture->mock_snapd_available) {
+		g_test_skip("mock snapd not available");
+		return;
+	}
+
+	if (!fu_test_mock_dbx_efivars(efivars, &error) &&
+	    g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+		g_test_skip("test assets unavailable");
+		return;
+	}
+	g_assert_no_error(error);
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	devs = fu_plugin_get_devices(plugin);
+	g_assert_nonnull(devs);
+	g_assert_cmpuint(devs->len, ==, 1);
+	dev = g_ptr_array_index(devs, 0);
+
+	stream_fw = fu_test_mock_dbx_update_stream();
+	ret = fu_plugin_runner_write_firmware(plugin,
+					      dev,
+					      stream_fw,
+					      progress,
+					      /* skip verification of ESP binaries*/
+					      FWUPD_INSTALL_FLAG_FORCE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_device_has_flag(dev, FWUPD_DEVICE_FLAG_NEEDS_REBOOT));
+
+	/* this is normally invoked by FuEngine */
+	ret = fu_device_cleanup(dev, progress, 0, &error);
+	g_assert_true(ret);
+	g_assert_no_error(error);
+
+	if (tc->with_snapd) {
+		fu_self_test_mock_snapd_assert_calls(fixture,
+						     (FuTestSnapdCalls){
+							 .startup = 1,
+							 .prepare = 1,
+							 .cleanup = 1,
+						     });
+	}
+}
+
+static void
+fu_uefi_dbx_test_plugin_failed_update(FuTestFixture *fixture, gconstpointer user_data)
+{
+	/* update which fails at either write or cleanup steps, this test can only
+	 * properly mock the environment when using snapd integration */
+
+	FuTestCase *tc = (FuTestCase *)user_data;
+	gboolean ret;
+	FuContext *ctx = fixture->ctx;
+	GPtrArray *devs = NULL;
+	FuDevice *dev = NULL;
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GInputStream) stream_fw = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_uefi_dbx_plugin_get_type(), ctx);
+
+	if (!tc->with_snapd) {
+		g_test_skip("only supports snapd integration variant");
+		return;
+	}
+
+	if (!fixture->mock_snapd_available) {
+		g_test_skip("mock snapd not available");
+		return;
+	}
+
+	if (!fu_test_mock_dbx_efivars(efivars, &error) &&
+	    g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+		g_test_skip("test assets unavailable");
+		return;
+	}
+	g_assert_no_error(error);
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	devs = fu_plugin_get_devices(plugin);
+	g_assert_nonnull(devs);
+	g_assert_cmpuint(devs->len, ==, 1);
+	dev = g_ptr_array_index(devs, 0);
+
+	stream_fw = fu_test_mock_dbx_update_stream();
+	ret = fu_plugin_runner_write_firmware(plugin,
+					      dev,
+					      stream_fw,
+					      progress,
+					      /* skip verification of ESP binaries*/
+					      FWUPD_INSTALL_FLAG_FORCE,
+					      &error);
+	if (g_str_equal(tc->mock_snapd_scenario, "failed-prepare")) {
+		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+		g_clear_error(&error);
+	} else {
+		g_assert_no_error(error);
+		g_assert_true(ret);
+	}
+
+	/* engine invokes cleanup */
+	ret = fu_device_cleanup(dev, progress, 0, &error);
+	if (g_str_equal(tc->mock_snapd_scenario, "failed-cleanup")) {
+		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	} else {
+		g_assert_no_error(error);
+		g_assert_true(ret);
+	}
+
+	fu_self_test_mock_snapd_assert_calls(fixture,
+					     (FuTestSnapdCalls){
+						 .startup = 1,
+						 .prepare = 1,
+						 .cleanup = 1,
+					     });
+}
+
+static void
+fu_uefi_dbx_test_plugin_coldplug_probed_device(FuTestFixture *fixture, gconstpointer user_data)
+{
+	FuTestCase *tc = (FuTestCase *)user_data;
+	gboolean ret;
+	FuContext *ctx = fixture->ctx;
+	GPtrArray *devs = NULL;
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_uefi_dbx_plugin_get_type(), ctx);
+
+	if (tc->with_snapd && !fixture->mock_snapd_available) {
+		g_test_skip("mock snapd not available");
+		return;
+	}
+
+	if (!fu_test_mock_dbx_efivars(efivars, &error) &&
+	    g_error_matches(error, G_FILE_ERROR, G_FILE_ERROR_NOENT)) {
+		g_test_skip("test assets unavailable");
+		return;
+	}
+	g_assert_no_error(error);
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	devs = fu_plugin_get_devices(plugin);
+	g_assert_nonnull(devs);
+	g_assert_cmpuint(devs->len, ==, 1);
+	g_assert_true(FU_IS_UEFI_DBX_DEVICE(g_ptr_array_index(devs, 0)));
+	ret = fu_device_is_updatable(g_ptr_array_index(devs, 0));
+	g_assert_true(ret);
+
+	ret = fu_device_has_inhibit(g_ptr_array_index(devs, 0), "no-snapd-dbx");
+	if (tc->with_snapd && tc->snapd_supported &&
+	    g_str_equal(tc->mock_snapd_scenario, "failed-startup")) {
+		/* startup failed for whatever reason, device updates are inhibited */
+		g_assert_true(ret);
+	} else
+		g_assert_false(ret);
+
+	if (tc->with_snapd) {
+		fu_self_test_mock_snapd_assert_calls(fixture,
+						     (FuTestSnapdCalls){
+							 .startup = 1,
+						     });
+	}
+}
+
+static void
+fu_uefi_dbx_test_plugin_startup(FuTestFixture *fixture, gconstpointer user_data)
+{
+	FuTestCase *tc = (FuTestCase *)user_data;
+	gboolean ret;
+	FuContext *ctx = fixture->ctx;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_uefi_dbx_plugin_get_type(), ctx);
+
+	if (tc->with_snapd && !fixture->mock_snapd_available) {
+		g_test_skip("mock snapd not available");
+		return;
+	}
+
+	ret = fu_context_load_quirks(ctx,
+				     FU_QUIRKS_LOAD_FLAG_NO_CACHE | FU_QUIRKS_LOAD_FLAG_NO_VERIFY,
+				     &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	if (tc->with_snapd) {
+		fu_self_test_mock_snapd_assert_calls(fixture,
+						     (FuTestSnapdCalls){
+							 .startup = 1,
+						     });
+	}
+}
+
 int
 main(int argc, char **argv)
 {
+	FuTestCase simple = {
+	    .with_snapd = FALSE,
+	    .devices_cnt = 0,
+	};
+	/* test variants with snapd, see tests/snapd.py for what a specific scenario
+	 * supports */
+	FuTestCase with_snapd = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "happy-startup",
+	};
+	FuTestCase with_snapd_no_support = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = FALSE,
+	    .mock_snapd_scenario = "not-supported",
+	};
+	FuTestCase with_snapd_bad_startup = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "failed-startup",
+	};
+	FuTestCase with_snapd_update = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "happy-update",
+	};
+	FuTestCase with_snapd_update_failed_prepare = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "failed-prepare",
+	};
+	FuTestCase with_snapd_update_failed_cleanup = {
+	    .with_snapd = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "failed-cleanup",
+	};
+	g_autofree gchar *testdatadir = NULL;
+
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 
@@ -55,7 +606,103 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
 
+	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
+
+	(void)g_setenv("FWUPD_SYSFSFWDIR", testdatadir, TRUE);
+	(void)g_setenv("FWUPD_EFIVARS", "dummy", TRUE);
+	(void)g_setenv("FWUPD_SYSFSDRIVERDIR", testdatadir, TRUE);
+	(void)g_setenv("FWUPD_SYSFSFWATTRIBDIR", testdatadir, TRUE);
+	(void)g_setenv("FWUPD_SNAPD_SNAP_SOCKET", "/tmp/mock-snapd-test.sock", TRUE);
+
 	/* tests go here */
 	g_test_add_func("/uefi-dbx/image", fu_efi_image_func);
+
+	g_test_add("/uefi-dbx/startup",
+		   FuTestFixture,
+		   &simple,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_startup,
+		   fu_self_test_tear_down);
+	g_test_add("/uefi-dbx/update",
+		   FuTestFixture,
+		   &simple,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_update,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/startup/snapd/supported",
+		   FuTestFixture,
+		   &with_snapd,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_startup,
+		   fu_self_test_tear_down);
+	g_test_add("/uefi-dbx/startup/snapd/not-supported",
+		   FuTestFixture,
+		   &with_snapd_no_support,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_startup,
+		   fu_self_test_tear_down);
+	g_test_add("/uefi-dbx/startup/snapd/supported-failure",
+		   FuTestFixture,
+		   &with_snapd_bad_startup,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_startup,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/coldplug/no-device",
+		   FuTestFixture,
+		   &simple,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_coldplug_no_device,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/coldplug/with-device",
+		   FuTestFixture,
+		   &simple,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_coldplug_probed_device,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/coldplug/snapd/supported",
+		   FuTestFixture,
+		   &with_snapd,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_coldplug_probed_device,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/coldplug/snapd/not-supported",
+		   FuTestFixture,
+		   &with_snapd_no_support,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_coldplug_probed_device,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/coldplug/snapd/supported-failure",
+		   FuTestFixture,
+		   &with_snapd_bad_startup,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_coldplug_probed_device,
+		   fu_self_test_tear_down);
+	g_test_add("/uefi-dbx/update/snapd/success",
+		   FuTestFixture,
+		   &with_snapd_update,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_update,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/update/snapd/failed-prepare",
+		   FuTestFixture,
+		   &with_snapd_update_failed_prepare,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_failed_update,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/update/snapd/failed-cleanup",
+		   FuTestFixture,
+		   &with_snapd_update_failed_cleanup,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_failed_update,
+		   fu_self_test_tear_down);
+
 	return g_test_run();
 }

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.h
@@ -8,8 +8,13 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-uefi-dbx-snapd-notifier.h"
+
 #define FU_TYPE_UEFI_DBX_DEVICE (fu_uefi_dbx_device_get_type())
 G_DECLARE_FINAL_TYPE(FuUefiDbxDevice, fu_uefi_dbx_device, FU, UEFI_DBX_DEVICE, FuDevice)
 
 FuUefiDbxDevice *
 fu_uefi_dbx_device_new(FuContext *ctx);
+
+void
+fu_uefi_dbx_device_set_snapd_notifier(FuUefiDbxDevice *self, FuUefiDbxSnapdNotifier *obs);

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -8,9 +8,13 @@
 
 #include "fu-uefi-dbx-device.h"
 #include "fu-uefi-dbx-plugin.h"
+#include "fu-uefi-dbx-snapd-notifier.h"
 
 struct _FuUefiDbxPlugin {
 	FuPlugin parent_instance;
+
+	FuUefiDbxSnapdNotifier *snapd_notifier;
+	gboolean snapd_integration_supported;
 };
 
 G_DEFINE_TYPE(FuUefiDbxPlugin, fu_uefi_dbx_plugin, FU_TYPE_PLUGIN)
@@ -20,6 +24,8 @@ fu_uefi_dbx_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **err
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	g_autoptr(FuUefiDbxDevice) device = fu_uefi_dbx_device_new(ctx);
+	FuUefiDbxPlugin *self = FU_UEFI_DBX_PLUGIN(plugin);
+	gboolean inhibited = FALSE;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -38,7 +44,24 @@ fu_uefi_dbx_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **err
 		fu_device_inhibit(FU_DEVICE(device),
 				  "no-dbx",
 				  "System firmware cannot accept DBX updates");
+		inhibited = TRUE;
 	}
+
+	if (self->snapd_notifier != NULL) {
+		fu_uefi_dbx_device_set_snapd_notifier(device, self->snapd_notifier);
+	} else if (!inhibited && self->snapd_integration_supported && fu_snap_is_in_snap()) {
+		/* we're running inside a snap, the device is not inhibited and snapd
+		 * supports integration, in which case this is a hard error and we
+		 * should not give an option to dbx */
+
+		/* TODO should check for FDE flag, otherwise in a system where DBX is
+		measured during the boot, updating it without notifying snapd
+		can result in failed boot or needing to use recovery keys */
+		fu_device_inhibit(FU_DEVICE(device),
+				  "no-snapd-dbx",
+				  "Snapd integration for DBX update is not available");
+	}
+
 	fu_plugin_device_add(plugin, FU_DEVICE(device));
 	return TRUE;
 }
@@ -49,18 +72,66 @@ fu_uefi_dbx_plugin_init(FuUefiDbxPlugin *self)
 }
 
 static void
+fu_uefi_dbx_plugin_finalize(GObject *object)
+{
+	FuUefiDbxPlugin *self = FU_UEFI_DBX_PLUGIN(object);
+	if (self->snapd_notifier != NULL) {
+		g_object_unref(self->snapd_notifier);
+		self->snapd_notifier = NULL;
+	}
+
+	G_OBJECT_CLASS(fu_uefi_dbx_plugin_parent_class)->finalize(object);
+}
+
+static gboolean
+fu_uefi_dbx_plugin_snapd_notify_init(FuUefiDbxPlugin *self, GError **error)
+{
+	g_autoptr(FuUefiDbxSnapdNotifier) obs = fu_uefi_dbx_snapd_notifier_new();
+
+	if (!fu_uefi_dbx_snapd_notifier_dbx_manager_startup(obs, error))
+		return FALSE;
+
+	g_set_object(&self->snapd_notifier, obs);
+	return TRUE;
+}
+
+static void
 fu_uefi_dbx_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_capsule");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EFI_SIGNATURE_LIST);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DBX_DEVICE);
+
+	if (fu_snap_is_in_snap()) {
+		FuUefiDbxPlugin *self = FU_UEFI_DBX_PLUGIN(plugin);
+		g_autoptr(GError) error_local = NULL;
+		/* only enable snapd integration if running inside a snap */
+		if (!fu_uefi_dbx_plugin_snapd_notify_init(FU_UEFI_DBX_PLUGIN(obj), &error_local)) {
+			/* specific error code if relevant APIs are not present and thus
+			 * integration cannot be supported */
+			self->snapd_integration_supported =
+			    !g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+
+			g_info("snapd integration non-functional: %s", error_local->message);
+		} else {
+			g_info("snapd integration enabled ");
+			self->snapd_integration_supported = TRUE;
+		}
+	} else {
+		/* TODO figure out non-snap scenarios */
+		g_info("snapd integration outside of snap is not supported");
+	}
 }
 
 static void
 fu_uefi_dbx_plugin_class_init(FuUefiDbxPluginClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+
 	plugin_class->constructed = fu_uefi_dbx_plugin_constructed;
 	plugin_class->coldplug = fu_uefi_dbx_plugin_coldplug;
+
+	object_class->finalize = fu_uefi_dbx_plugin_finalize;
 }

--- a/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#include "config.h"
+
+#include <curl/curl.h>
+#include <curl/easy.h>
+
+#include "fu-uefi-dbx-snapd-notifier.h"
+#include "glib.h"
+
+struct _FuUefiDbxSnapdNotifier {
+	GObject parent_instance;
+	CURL *curl_template;
+	struct curl_slist *req_hdrs;
+};
+
+G_DEFINE_TYPE(FuUefiDbxSnapdNotifier, fu_uefi_dbx_snapd_notifier, G_TYPE_OBJECT)
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CURL, curl_easy_cleanup);
+
+FuUefiDbxSnapdNotifier *
+fu_uefi_dbx_snapd_notifier_new(void)
+{
+	return g_object_new(FU_TYPE_UEFI_DBX_SNAPD_NOTIFIER, NULL);
+}
+
+static void
+fu_uefi_dbx_snapd_notifier_init(FuUefiDbxSnapdNotifier *self)
+{
+	/* default path for use inside the snap sandbox */
+	const char *snapd_snap_socket = "/run/snapd-snap.socket";
+	const char *snapd_snap_socket_override = g_getenv("FWUPD_SNAPD_SNAP_SOCKET");
+
+	self->curl_template = curl_easy_init();
+
+	/* TODO support system wide snapd socket for outside of snap scenarios */
+	if (!fu_snap_is_in_snap())
+		g_warning("attempted use of snapd notifier outside of snap");
+
+	if (snapd_snap_socket_override != NULL)
+		snapd_snap_socket = snapd_snap_socket_override;
+
+	/* use snap dedicated socket when running inside a snap */
+	curl_easy_setopt(self->curl_template, CURLOPT_UNIX_SOCKET_PATH, snapd_snap_socket);
+
+	self->req_hdrs = curl_slist_append(self->req_hdrs, "Content-Type: application/json");
+	curl_easy_setopt(self->curl_template, CURLOPT_HTTPHEADER, self->req_hdrs);
+}
+
+static void
+fu_uefi_dbx_snapd_notifier_finalize(GObject *object)
+{
+	FuUefiDbxSnapdNotifier *self = FU_UEFI_DBX_SNAPD_NOTIFIER(object);
+	curl_slist_free_all(self->req_hdrs);
+	curl_easy_cleanup(self->curl_template);
+	G_OBJECT_CLASS(fu_uefi_dbx_snapd_notifier_parent_class)->finalize(object);
+}
+
+static void
+fu_uefi_dbx_snapd_notifier_class_init(FuUefiDbxSnapdNotifierClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fu_uefi_dbx_snapd_notifier_finalize;
+}
+
+/* see CURLOPT_WRITEFUNCTION(3) */
+static size_t
+fu_uefi_dbx_snapd_notifier_rsp_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	GByteArray *bufarr = (GByteArray *)userdata;
+	gsize sz = size * nmemb;
+	g_byte_array_append(bufarr, (const guint8 *)ptr, sz);
+	return sz;
+}
+
+static gboolean
+fu_uefi_dbx_snapd_notifier_simple_req(FuUefiDbxSnapdNotifier *self,
+				      const char *endpoint,
+				      const char *data,
+				      gsize len,
+				      GError **error)
+{
+	CURLcode res = -1;
+	glong status_code = 0;
+	g_autoptr(CURL) curl = NULL;
+	g_autofree gchar *endpoint_str = NULL;
+	g_autoptr(GByteArray) rsp_buf = g_byte_array_new();
+
+	/* duplicate a preconfigured curl handle */
+	curl = curl_easy_duphandle(self->curl_template);
+
+	endpoint_str = g_strdup_printf("http://localhost%s", endpoint);
+
+	curl_easy_setopt(curl, CURLOPT_URL, endpoint_str);
+
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+
+	/* collect response for debugging */
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, rsp_buf);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fu_uefi_dbx_snapd_notifier_rsp_cb);
+
+	res = curl_easy_perform(curl);
+	if (res != CURLE_OK) {
+		/* TODO inspect the error */
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "failed to communicate with snapd: %s",
+			    curl_easy_strerror(res));
+		return FALSE;
+	}
+
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+
+	if (status_code == 404) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "snapd notification endpoint not supported by snapd API");
+		return FALSE;
+	}
+
+	if (status_code != 200) {
+		g_autofree gchar *rsp = NULL;
+		if (rsp_buf->len > 0) {
+			/* make sure the response is printable */
+			rsp = fu_strsafe((const char *)rsp_buf->data, rsp_buf->len + 1);
+		}
+
+		/* TODO check whether the response is even printable? */
+		g_info("snapd request failed with status %ld, response: %s",
+		       (glong)status_code,
+		       rsp != NULL ? rsp : "<none>");
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "snapd request failed with status %ld",
+			    (glong)status_code);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * fu_uefi_dbx_snapd_notifier_dbx_manager_startup:
+ * @self: a #FuUefiDbxSnapdNotifier
+ * @error: (nullable): optional return location for an error
+ *
+ * Notify snapd of that the DBX manager has started.
+ *
+ * Returns: #TRUE if the notification was successful.
+ **/
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_manager_startup(FuUefiDbxSnapdNotifier *self, GError **error)
+{
+	const char *startup_msg = "{\"action\":\"efi-secureboot-update-startup\"}";
+
+	if (!fu_uefi_dbx_snapd_notifier_simple_req(self,
+						   "/v2/system-secureboot",
+						   startup_msg,
+						   strlen(startup_msg),
+						   error)) {
+		g_prefix_error(error, "failed to notify snapd of startup: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * fu_uefi_dbx_snapd_notifier_dbx_update_prepare:
+ * @self: a #FuUefiDbxSnapdNotifier
+ * @fw_payload: payload used for the update
+ * @error: (nullable): optional return location for an error
+ *
+ * Notify of an upcoming update to the DBX. A successful call shall initiate a
+ * change tracking an update to the DBX on the snapd side.
+ *
+ * Returns: #TRUE if the notification was successful.
+ **/
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_update_prepare(FuUefiDbxSnapdNotifier *self,
+					      GBytes *fw_payload,
+					      GError **error)
+{
+	gsize bufsz = 0;
+	const guint8 *buf = g_bytes_get_data(fw_payload, &bufsz);
+	g_autofree gchar *b64data = g_base64_encode(buf, bufsz);
+	g_autofree gchar *msg = g_strdup_printf("{"
+						"\"action\":\"efi-secureboot-update-db-prepare\","
+						"\"key-database\":\"DBX\","
+						"\"payload\":\"%s\""
+						"}",
+						b64data);
+
+	if (!fu_uefi_dbx_snapd_notifier_simple_req(self,
+						   "/v2/system-secureboot",
+						   msg,
+						   strlen(msg),
+						   error)) {
+		g_prefix_error(error, "failed to notify snapd of prepare: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
+ * fu_uefi_dbx_snapd_notifier_dbx_update_cleanup:
+ * @self: a #FuUefiDbxSnapdNotifier
+ * @error: (nullable): optional return location for an error
+ *
+ * Notify of an completed update to one of secureboot key databases. A
+ * successful call shall result in completion of a corresponding change on the
+ * snapd side.
+ *
+ * Returns: #TRUE if the notification was successful.
+ **/
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_update_cleanup(FuUefiDbxSnapdNotifier *self, GError **error)
+{
+	const char *msg = "{\"action\":\"efi-secureboot-update-db-cleanup\"}";
+
+	if (!fu_uefi_dbx_snapd_notifier_simple_req(self,
+						   "/v2/system-secureboot",
+						   msg,
+						   strlen(msg),
+						   error)) {
+		g_prefix_error(error, "failed to notify snapd of cleanup: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}

--- a/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_UEFI_DBX_SNAPD_NOTIFIER (fu_uefi_dbx_snapd_notifier_get_type())
+G_DECLARE_FINAL_TYPE(FuUefiDbxSnapdNotifier,
+		     fu_uefi_dbx_snapd_notifier,
+		     FU,
+		     UEFI_DBX_SNAPD_NOTIFIER,
+		     GObject)
+
+FuUefiDbxSnapdNotifier *
+fu_uefi_dbx_snapd_notifier_new(void);
+
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_manager_startup(FuUefiDbxSnapdNotifier *self, GError **error);
+
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_update_prepare(FuUefiDbxSnapdNotifier *self,
+					      GBytes *fw_payload,
+					      GError **error);
+
+gboolean
+fu_uefi_dbx_snapd_notifier_dbx_update_cleanup(FuUefiDbxSnapdNotifier *self, GError **error);

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -22,6 +22,9 @@ plugin_builtin_uefi_dbx = static_library('fu_plugin_uefi_dbx',
 plugin_builtins += plugin_builtin_uefi_dbx
 
 if get_option('tests')
+  install_data(['tests/snapd.py'],
+    install_dir: join_paths(installed_test_datadir, 'tests'))
+
   env = environment()
   env.set('G_TEST_SRCDIR', meson.current_source_dir())
   env.set('G_TEST_BUILDDIR', meson.current_build_dir())
@@ -32,7 +35,10 @@ if get_option('tests')
       'fu-self-test.c',
     ],
     include_directories: plugin_incdirs,
-    dependencies: plugin_deps,
+    dependencies: [
+      plugin_deps,
+      libcurl,
+    ],
     link_with: [
       plugin_libs,
       plugin_builtin_uefi_dbx,

--- a/plugins/uefi-dbx/meson.build
+++ b/plugins/uefi-dbx/meson.build
@@ -1,3 +1,5 @@
+# snapd integration has a hard dependency on curl
+if get_option('curl').allowed()
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefiDbx"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
@@ -7,11 +9,15 @@ plugin_builtin_uefi_dbx = static_library('fu_plugin_uefi_dbx',
     'fu-uefi-dbx-plugin.c',
     'fu-uefi-dbx-common.c',
     'fu-uefi-dbx-device.c',
+    'fu-uefi-dbx-snapd-notifier.c',
   ],
   include_directories: plugin_incdirs,
   link_with: plugin_libs,
   c_args: cargs,
-  dependencies: plugin_deps,
+  dependencies: [
+    plugin_deps,
+    libcurl,
+  ],
 )
 plugin_builtins += plugin_builtin_uefi_dbx
 
@@ -82,4 +88,5 @@ if build_docs
     ],
   )
   man_md += ['"dbxtool.md"']
+endif
 endif

--- a/plugins/uefi-dbx/tests/snapd.py
+++ b/plugins/uefi-dbx/tests/snapd.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024 Maciej Borzecki <maciej.borzecki@canonical.cm>
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""The app provides a mock snapd API for use with fwupd unit tests. The
+/v2/system-secureboot endpoint mimics the behavior of snapd wrt. DBX updates.
+
+The app exposes a couple of test specific endpoinds, /test/scenario, which picks
+one of the scenarios (expected to be called in when setting a test fixture),
+/test/reset, for resetting the state (usually called in tear down), and
+/test/stats which provides the count of actions invoked since last reset.
+"""
+
+import argparse
+import logging
+import base64
+import json
+import os.path
+from io import StringIO
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import Any, Optional
+
+from flask import Flask, Response, request, current_app
+
+
+@dataclass
+class Scenario:
+    handler: Callable[[dict[str, Any]], Response]
+
+
+@dataclass
+class State:
+    scenario: Optional[str]
+    stats: dict[str, int]
+
+    def __init__(self):
+        self.scenario = None
+        self.stats = {k: 0 for k in supported_actions}
+
+
+app = Flask(__name__)
+
+supported_actions = [
+    "efi-secureboot-update-startup",
+    "efi-secureboot-update-db-cleanup",
+    "efi-secureboot-update-db-prepare",
+]
+
+
+def assert_no_extra_keys(d: dict[str, Any], allowed: list[str]):
+    unexpected = [a for a in d.keys() if a not in allowed]
+    assert len(unexpected) == 0, f"unexpected keys in request data: {unexpected}"
+
+
+def assert_prepare_req(req: dict[str, Any]):
+    assert req.get("action") == "efi-secureboot-update-db-prepare", "unexpected action"
+    assert "payload" in req, "missing payload field"
+    assert "key-database" in req, "missing key-database field"
+    assert req.get("key-database") == "DBX", "unexpected key database"
+
+    payload = req.get("payload")
+    assert_no_extra_keys(req, ["action", "payload", "key-database"])
+    assert payload is not None, "no update payload"
+    # payload must be valid base64
+    try:
+        raw_payload = base64.urlsafe_b64decode(payload)
+        with open(os.path.join(current_app.datadir, "dbx-update.auth"), "rb") as inf:
+            reference_payload = inf.read()
+
+        assert raw_payload == reference_payload, "unexpected payload content"
+    except Exception as err:
+        raise AssertionError("invalid base64 data in request") from err
+
+
+def assert_startup_req(req: dict[str, Any]):
+    assert req.get("action") == "efi-secureboot-update-startup", "unexpected action"
+    assert_no_extra_keys(req, ["action"])
+
+
+def assert_cleanup_req(req: dict[str, Any]):
+    assert req.get("action") == "efi-secureboot-update-db-cleanup", "unexpected action"
+    assert_no_extra_keys(req, ["action"])
+
+
+def happy_startup(req: dict[str, Any]) -> Response:
+    assert_startup_req(req)
+    return Response(None, status=200)
+
+
+def not_supported(req: dict[str, Any]) -> Response:
+    assert_startup_req(req)
+    # pretend relevant APIs are missing, hence 404
+    return Response("", status=404)
+
+
+def failed_startup(req: dict[str, Any]) -> Response:
+    assert_startup_req(req)
+    return Response(None, status=400)
+
+
+def happy_prepare(req: dict[str, Any]) -> Response:
+    assert_prepare_req(req)
+    return Response("", status=200)
+
+
+def failed_prepare(req: dict[str, Any]) -> Response:
+    action = req.get("action")
+    if action == "efi-secureboot-update-db-cleanup":
+        return happy_cleanup(req)
+    if action == "efi-secureboot-update-db-prepare":
+        assert_prepare_req(req)
+        return Response(
+            json.dumps(
+                {
+                    "status": "500",
+                    "error": {
+                        "kind": "internal-error",
+                        "message": "cannot reseal keys in prepare",
+                    },
+                }
+            ),
+            status=500,
+        )
+    if action == "efi-secureboot-update-startup":
+        return happy_startup(req)
+
+    raise AssertionError(f"unexpected action {action}")
+
+
+def failed_cleanup(req: dict[str, Any]) -> Response:
+    action = req.get("action")
+    if action == "efi-secureboot-update-db-cleanup":
+        assert_cleanup_req(req)
+        return Response(
+            json.dumps(
+                {
+                    "status": "500",
+                    "error": {
+                        "kind": "internal-error",
+                        "message": "cannot reseal keys in cleanup",
+                    },
+                }
+            ),
+            status=500,
+        )
+    if action == "efi-secureboot-update-db-prepare":
+        return happy_prepare(req)
+    if action == "efi-secureboot-update-startup":
+        return happy_startup(req)
+
+    raise AssertionError(f"unexpected action {action}")
+
+
+def happy_cleanup(req: dict[str, Any]) -> Response:
+    assert_cleanup_req(req)
+    return Response("", status=200)
+
+
+def happy_update(req: dict[str, Any]) -> Response:
+    action = req.get("action")
+    if action == "efi-secureboot-update-db-cleanup":
+        return happy_cleanup(req)
+    if action == "efi-secureboot-update-db-prepare":
+        return happy_prepare(req)
+    if action == "efi-secureboot-update-startup":
+        return happy_startup(req)
+
+    raise AssertionError(f"unexpected action {action}")
+
+
+playbook: dict[str, Scenario] = {
+    # successful startup
+    "happy-startup": Scenario(handler=happy_startup),
+    # startup with mock failure
+    "failed-startup": Scenario(handler=failed_startup),
+    # 404 on the API endpoint, indicating lack of support on the snapd side
+    "not-supported": Scenario(handler=not_supported),
+    # prepare step fails
+    "failed-prepare": Scenario(handler=failed_prepare),
+    # prepare is successful, but cleanup fails
+    "failed-cleanup": Scenario(handler=failed_cleanup),
+    # successful update cycle
+    "happy-update": Scenario(handler=happy_update),
+}
+
+
+def assert_scenario(f):
+    def do():
+        with app.app_context():
+            assert current_app.state.scenario is not None, "test scenario is not set"
+            return f()
+
+    return do
+
+
+def app_init_state():
+    with app.app_context():
+        current_app.state = State()
+
+
+@app.route("/v2/system-secureboot", methods=["POST"])
+@assert_scenario
+def system_secureboot():
+    assert len(request.view_args) == 0
+    assert request.headers.get("Content-Type") == "application/json"
+
+    req = request.get_json()
+    logging.debug("req: %r", req)
+    action = req.get("action")
+
+    assert action in supported_actions, f"unknown action {action}"
+
+    current_app.state.stats[action] += 1
+
+    return playbook[current_app.state.scenario].handler(req)
+
+
+@app.route("/test/setup", methods=["POST"])
+def test_setup():
+    req = request.get_json()
+    logging.debug("req: %r", req)
+    scenario = req.get("scenario")
+
+    assert scenario in playbook, f"unknown scenario {scenario}"
+
+    logging.debug("setting scenario to '%s'", scenario)
+    current_app.state.scenario = scenario
+    return Response("", status=200)
+
+
+@app.route("/test/reset", methods=["POST"])
+def test_reset():
+    app_init_state()
+    return Response("", status=200)
+
+
+@app.route("/test/stats")
+def test_stats():
+    out = StringIO()
+    # use a key-file format so that glib side parsing is easy
+    out.write("[stats]\n")
+    for action in sorted(current_app.state.stats.keys()):
+        out.write(f"{action}={current_app.state.stats[action]}\n")
+    return Response(out.getvalue(), status=200)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="mock snapd APIs")
+    parser.add_argument(
+        "--socket", help="socket path", default="/tmp/mock-snapd-test.sock"
+    )
+    parser.add_argument(
+        "--datadir",
+        default=os.path.dirname(__file__),
+        help="path to directory with test data files",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    opts = parse_arguments()
+    logging.basicConfig(level=logging.DEBUG)
+    logging.debug("socket path: %s", opts.socket)
+    logging.debug("data dir: %s", opts.datadir)
+    with app.app_context():
+        current_app.datadir = opts.datadir
+    app_init_state()
+    app.run(host="unix://" + opts.socket)


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

This a v2 draft PR (see https://github.com/fwupd/fwupd/pull/7861 for previous proposal) which introduces integration of fwupd with snapd in the context of UEFI DBX updates. The main use case is Ubuntu Core systems, especially those with full-disk encryption (FDE).

In detail, in Ubuntu Core system and hybrid Ubuntu installations using FDE, snapd plays a role in resealing the encryption keys to the TPM. The constructed boot policy includes contents of DBX. In order to have the encryption key unsealed and to keep the system bootable, the DBX update payload must presented to snapd, such that a boot policy will account for the updated content.

The high level idea is for snapd to be notified of a DBX update in progress just before the new content is written to efivars. This allows for the new boot policy to be constructed, with a branch for both the old and new DBX content. This step is referred to as prepare. Subsequent call would happen right after the update completes, enabling snapd to introspect the actual content of DBX and reseal the keys once again taking only the current content into account. This is known as a cleanup step. An additional startup step would be triggered whenever fwupd starts up, such that an update which may have previously been interrupted by a reboot or a crash (whether planned or not) could be accounted for.

Snapd exposes a single integration endpoint via its UNIX socket API at /v2/system-secureboot which accepts JSON requests (as implemented in https://github.com/canonical/snapd/pull/14541).

Initially, we are focusing on a simpler use case of fwupd running within a snap, which addresses the immediate use case of Ubuntu Core systems, but in future, this will be extended to cover the classic distro integration in Ubuntu desktop.

In essence the branch is a v2 attempt to explore means of integration within the structure of fwupd. The previous proposal included a dedicated snapd plugin. However it did introduce significant complexity related to matching of the right devices and hooking into the firmware write path. Hence, this branch explores a simpler approach, by integrating directly within `uefi-dbx` plugin.

Please note that there are some TODOs left and quirks in the code, such as verbose curl and similar debugging aids. I will address all of this before marking the PR as non draft once a consensus as to its shape is reached.