### PR TITLE
modem-manager: Fix Firehose padding

### DIFF
--- a/plugins/modem-manager/fu-firehose-updater.c
+++ b/plugins/modem-manager/fu-firehose-updater.c
@@ -540,44 +540,39 @@ fu_firehose_updater_send_program_file(FuFirehoseUpdater *self,
 				      gsize sector_size,
 				      GError **error)
 {
-	g_autoptr(FuChunk) chk_last = NULL;
 	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(program_file,
 								       FU_CHUNK_ADDR_OFFSET_NONE,
 								       FU_CHUNK_PAGESZ_NONE,
 								       payload_size);
 
-	/* last block needs to be padded to the next sector_size,
-	 * so that we always send full sectors */
-	chk_last = fu_chunk_array_index(chunks, fu_chunk_array_length(chunks) - 1, error);
-	if (chk_last == NULL)
-		return FALSE;
-	if ((fu_chunk_get_data_sz(chk_last) % sector_size) != 0) {
-		g_autoptr(GBytes) padded_bytes = NULL;
-		gsize padded_sz = sector_size * (fu_chunk_get_data_sz(chk_last) / sector_size + 1);
-
-		padded_bytes = fu_bytes_pad(fu_chunk_get_bytes(chk_last), padded_sz);
-		fu_chunk_set_bytes(chk_last, padded_bytes);
-
-		g_return_val_if_fail(fu_chunk_get_data_sz(chk_last) == padded_sz, FALSE);
-	}
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
+		g_autoptr(GBytes) block = NULL;
+		g_autoptr(GBytes) block_padded = NULL;
+		gsize block_padded_sz;
 
 		/* prepare chunk */
 		chk = fu_chunk_array_index(chunks, i, error);
 		if (chk == NULL)
 			return FALSE;
 
+		block = fu_chunk_get_bytes(chk);
+		/* block needs to be padded to the next sector_size,
+		 * so that we always send full sectors */
+		block_padded_sz =
+		    ((g_bytes_get_size(block) + sector_size - 1) / sector_size) * sector_size;
+		block_padded = fu_bytes_pad(block, block_padded_sz);
+
 		/* log only in blocks of 250 plus first/last */
 		if (i == 0 || i == (fu_chunk_array_length(chunks) - 1) || (i + 1) % 250 == 0)
-			g_debug("sending %u bytes in block %u/%u of file '%s'",
-				(guint)fu_chunk_get_data_sz(chk),
+			g_debug("sending %" G_GSIZE_FORMAT " bytes in block %u/%u of file '%s'",
+				block_padded_sz,
 				i + 1,
 				fu_chunk_array_length(chunks),
 				program_filename);
 
 		if (!fu_firehose_updater_write_internal(self,
-							fu_chunk_get_bytes(chk),
+							block_padded,
 							1500,
 							FU_IO_CHANNEL_FLAG_FLUSH_INPUT,
 							error)) {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

When getting a `FuChunk *` with `fu_chunk_array_index` and then setting that `FuChunk`'s bytes, we won't update the bytes in the chunk array since `fu_chunk_array_index` gives a copy of the chunk, not a reference to it.