### PR TITLE
pci-mei: fix debug logging of Hfsts data

### DIFF
--- a/plugins/pci-mei/fu-pci-mei-plugin.c
+++ b/plugins/pci-mei/fu-pci-mei-plugin.c
@@ -31,7 +31,7 @@ fu_pci_mei_plugin_to_string(FuPlugin *plugin, guint idt, GString *str)
 					  "PciDevice",
 					  fu_device_get_id(self->pci_device));
 	}
-	for (guint i = 0; i < 6; i++) {
+	for (guint i = 1; i < G_N_ELEMENTS(self->hfsts_buf); i++) {
 		g_autofree gchar *title = g_strdup_printf("Hfsts%u", i);
 		fwupd_codec_string_append_hex(
 		    str,


### PR DESCRIPTION
I don't know what Hfsts is, but we store the data in elements 1 through 6, leaving element 0 unused, so we're iterating through the data incorrectly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
