### PR TITLE
Adjust number of retries to read thunderbolt nvm version

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -215,6 +215,14 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 	g_autoptr(GError) error_gen = NULL;
 	g_autoptr(GError) error_version = NULL;
 
+	/* requires kernel 5.5 or later, non-fatal if not available */
+	self->gen =
+	    fu_thunderbolt_udev_get_attr_uint16(FU_UDEV_DEVICE(self), "generation", &error_gen);
+	if (self->gen == 0)
+		g_debug("unable to read generation: %s", error_gen->message);
+	if (self->gen >= 4)
+		fu_thunderbolt_device_set_retries(FU_THUNDERBOLT_DEVICE(self), 1);
+
 	/* try to read the version */
 	if (!fu_thunderbolt_device_get_version(FU_THUNDERBOLT_DEVICE(self), &error_version)) {
 		if (self->controller_kind != FU_THUNDERBOLT_CONTROLLER_KIND_HOST &&
@@ -233,12 +241,6 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 	did = fu_device_get_pid(device);
 	if (did == 0x0)
 		g_debug("failed to get Device ID");
-
-	/* requires kernel 5.5 or later, non-fatal if not available */
-	self->gen =
-	    fu_thunderbolt_udev_get_attr_uint16(FU_UDEV_DEVICE(self), "generation", &error_gen);
-	if (self->gen == 0)
-		g_debug("unable to read generation: %s", error_gen->message);
 
 	if (self->controller_kind == FU_THUNDERBOLT_CONTROLLER_KIND_HOST) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);

--- a/plugins/thunderbolt/fu-thunderbolt-device.h
+++ b/plugins/thunderbolt/fu-thunderbolt-device.h
@@ -28,3 +28,5 @@ gboolean
 fu_thunderbolt_device_check_authorized(FuThunderboltDevice *self, GError **error);
 void
 fu_thunderbolt_device_set_auth_method(FuThunderboltDevice *self, const gchar *auth_method);
+void
+fu_thunderbolt_device_set_retries(FuThunderboltDevice *self, guint retries);

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -114,6 +114,7 @@ fu_thunderbolt_retimer_init(FuThunderboltRetimer *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_NO_AUTO_REMOVE);
+	fu_thunderbolt_device_set_retries(FU_THUNDERBOLT_DEVICE(self), 1);
 }
 
 static void


### PR DESCRIPTION
TBT3 devices: keep at 50
USB4 devices: adjust to 1
retimers: adjust to 1

This will help avoid running into a kernel bug that makes fwupd retry reading retimer NVM version 50 times.
Link: https://github.com/fwupd/fwupd/issues/8200

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
