### PR TITLE
Fix UEFI capsule updates when using 4096 byte NVME blocksize

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -111,6 +111,10 @@ if build_daemon
     if get_option('plugin_intel_me').allowed()
       device_allows += ['char-mei']
     endif
+    if get_option('plugin_uefi_capsule').allowed()
+      # for BLKSSZGET
+      device_allows += ['block-blkext']
+    endif
     foreach device_allow: device_allows
       dynamic_options += ['DeviceAllow=' + device_allow + ' rw']
     endforeach


### PR DESCRIPTION
We need `block-blkext rw` for `ioctl(BLKSSZGET)`, otherwise we fall back to the default of 512 bytes.

Fixes https://github.com/fwupd/fwupd/issues/7967

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
