### PR TITLE
modem-manager: Add support for devices without zero-length packets

### DIFF
--- a/plugins/modem-manager/fu-firehose-updater.h
+++ b/plugins/modem-manager/fu-firehose-updater.h
@@ -17,6 +17,8 @@ G_DECLARE_FINAL_TYPE(FuFirehoseUpdater, fu_firehose_updater, FU, FIREHOSE_UPDATE
 FuFirehoseUpdater *
 fu_firehose_updater_new(const gchar *port, FuSaharaLoader *sahara);
 
+void
+fu_firehose_updater_set_supports_zlp(FuFirehoseUpdater *self, gboolean supports_zlp);
 gboolean
 fu_firehose_updater_open(FuFirehoseUpdater *self, GError **error);
 gboolean

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -14,7 +14,8 @@
 #define FU_MM_DEVICE_FLAG_DETACH_AT_FASTBOOT_HAS_NO_RESPONSE "detach-at-fastboot-has-no-response"
 #define FU_MM_DEVICE_FLAG_UNINHIBIT_MM_AFTER_FASTBOOT_REBOOT                                       \
 	"uninhibit-modemmanager-after-fastboot-reboot"
-#define FU_MM_DEVICE_FLAG_USE_BRANCH "use-branch"
+#define FU_MM_DEVICE_FLAG_USE_BRANCH  "use-branch"
+#define FU_MM_DEVICE_FLAG_DISABLE_ZLP "disable-zlp"
 
 #define FU_TYPE_MM_DEVICE (fu_mm_device_get_type())
 G_DECLARE_FINAL_TYPE(FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -26,6 +26,7 @@ struct _FuSaharaLoader {
 	int ep_out;
 	gsize maxpktsize_in;
 	gsize maxpktsize_out;
+	gboolean supports_zlp;
 };
 
 G_DEFINE_TYPE(FuSaharaLoader, fu_sahara_loader, G_TYPE_OBJECT)
@@ -178,7 +179,7 @@ fu_sahara_loader_qdl_write(FuSaharaLoader *self, const guint8 *data, gsize sz, G
 			return FALSE;
 		}
 	}
-	if (sz % self->maxpktsize_out == 0) {
+	if (self->supports_zlp && sz % self->maxpktsize_out == 0) {
 		/* sent zlp packet if needed */
 		if (!fu_usb_device_bulk_transfer(self->usb_device,
 						 self->ep_out,
@@ -202,6 +203,12 @@ fu_sahara_loader_qdl_write_bytes(FuSaharaLoader *self, GBytes *bytes, GError **e
 	gsize sz;
 	const guint8 *data = g_bytes_get_data(bytes, &sz);
 	return fu_sahara_loader_qdl_write(self, data, sz, error);
+}
+
+void
+fu_sahara_loader_set_supports_zlp(FuSaharaLoader *self, gboolean supports_zlp)
+{
+	self->supports_zlp = supports_zlp;
 }
 
 static gboolean
@@ -377,6 +384,8 @@ fu_sahara_loader_run(FuSaharaLoader *self, GBytes *prog, GError **error)
 static void
 fu_sahara_loader_init(FuSaharaLoader *self)
 {
+	/* supported by most devices - enable by default */
+	self->supports_zlp = TRUE;
 }
 
 static void

--- a/plugins/modem-manager/fu-sahara-loader.h
+++ b/plugins/modem-manager/fu-sahara-loader.h
@@ -21,6 +21,8 @@ GByteArray *
 fu_sahara_loader_qdl_read(FuSaharaLoader *self, GError **error);
 gboolean
 fu_sahara_loader_qdl_write_bytes(FuSaharaLoader *self, GBytes *bytes, GError **error);
+void
+fu_sahara_loader_set_supports_zlp(FuSaharaLoader *self, gboolean supports_zlp);
 
 gboolean
 fu_sahara_loader_open(FuSaharaLoader *self, FuUsbDevice *usb_device, GError **error);

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -132,3 +132,9 @@ ModemManagerFirehoseProgFile = prog_firehose_sdx24.mbn
 [PCI\VID_203E&PID_1001]
 Summary = Netprisma FCUN69 firehose prog file
 ModemManagerFirehoseProgFile = prog_firehose_sdx6x.elf
+
+# Fibocom NL668-EAU
+[USB\VID_1508&PID_1001]
+Summary = Fibocom NL668-EAU LTE Module
+ModemManagerFirehoseProgFile = prog_nand_firehose_9x07.mbn
+Flags = disable-zlp


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Some devices do not support the zero-length packet (zlp) feature. Adds a new flag `disable-zlp` that removes zlp support for devices requiring to do so.

Also adds Fibocom NL668-EAU to supported devices which depends on this flag.