### PR TITLE
uefi-capsule: Fix UEFI capsule updates on RHEL 10

### DIFF
--- a/plugins/fpc/tests/fpc-lenfy-moh.json
+++ b/plugins/fpc/tests/fpc-lenfy-moh.json
@@ -3,7 +3,7 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/bbc350a290baed298fca24be8aadb9b3b78ecc806845a42ba9e796b9fc45e5d8-fpc-lenfy-moh-v27_26_23_19.cab",
+      "url": "https://fwupd.org/downloads/0f69958d888545c4f99e09544ed81c982470f58723ad99c8b0b45997211371be-fpc-lenfy-moh-v27_26_23_19.cab",
       "emulation-url": "https://fwupd.org/downloads/8ef3c5f6bf4d294bec4738eb6077652171939f8c5f7eee1e13fd9ca1e5c4ba9e-fpc-lenfy-moh-v27_26_23_19.zip",
       "components": [
         {

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -207,6 +207,12 @@ fu_uefi_get_esp_path_for_os(const gchar *esp_base)
 	if (os_release_id == NULL)
 		os_release_id = g_strdup("unknown");
 
+	/* for compatibility; I have no idea why we still do this */
+	if (g_strcmp0(os_release_id, "rhel") == 0) {
+		g_free(os_release_id);
+		os_release_id = g_strdup("redhat");
+	}
+
 	/* if ID key points at something existing return it */
 	esp_path = g_build_filename("EFI", os_release_id, NULL);
 	full_path = g_build_filename(esp_base, esp_path, NULL);


### PR DESCRIPTION
For some unknown reason RHEL uses 'redhat' rather than 'rhel' for the EFI path.

Fixes https://issues.redhat.com/browse/RHEL-71066

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
