### PR TITLE
trivial: Do not connect percentage-changed if the fraction is less than 0.1%

### DIFF
--- a/libfwupdplugin/fu-progress-private.h
+++ b/libfwupdplugin/fu-progress-private.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-progress.h"
+
+gdouble
+fu_progress_get_global_fraction(FuProgress *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -31,6 +31,7 @@
 #include "fu-efivars-private.h"
 #include "fu-lzma-common.h"
 #include "fu-plugin-private.h"
+#include "fu-progress-private.h"
 #include "fu-security-attrs-private.h"
 #include "fu-self-test-struct.h"
 #include "fu-smbios-private.h"
@@ -5209,6 +5210,32 @@ fu_progress_finish_func(void)
 }
 
 static void
+fu_progress_global_fraction_func(void)
+{
+	FuProgress *child;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+
+	/* sanity check */
+	fu_progress_set_steps(progress, 100);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_global_fraction(progress), 1.f, 0.001);
+
+	/* 1% */
+	child = fu_progress_get_child(progress);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_global_fraction(child), 0.01f, 0.001);
+
+	/* 0.01% */
+	fu_progress_set_id(child, G_STRLOC);
+	fu_progress_set_steps(child, 100);
+	fu_progress_step_done(child);
+	fu_progress_step_done(child);
+	fu_progress_step_done(child);
+	fu_progress_finished(child);
+
+	/* done */
+	fu_progress_finished(progress);
+}
+
+static void
 fu_progress_child_finished(void)
 {
 	FuProgress *child;
@@ -6198,6 +6225,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/progress{parent-1-step}", fu_progress_parent_one_step_proxy_func);
 	g_test_add_func("/fwupd/progress{no-equal}", fu_progress_non_equal_steps_func);
 	g_test_add_func("/fwupd/progress{finish}", fu_progress_finish_func);
+	g_test_add_func("/fwupd/progress{global-fraction}", fu_progress_global_fraction_func);
 	g_test_add_func("/fwupd/bios-attrs{load}", fu_bios_settings_load_func);
 	g_test_add_func("/fwupd/security-attrs{hsi}", fu_security_attrs_hsi_func);
 	g_test_add_func("/fwupd/security-attrs{compare}", fu_security_attrs_compare_func);


### PR DESCRIPTION
This reduces startup time a little.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
