### PR TITLE
qc-s5gen2: custom GUID for USB devices

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -630,7 +630,17 @@ fu_usb_device_get_address(FuUsbDevice *self)
 	return priv->devnum;
 }
 
-static guint8
+/**
+ * fu_usb_device_get_manufacturer_index:
+ * @self: a #FuUsbDevice
+ *
+ * Gets the index for the iManufacturer string descriptor.
+ *
+ * Return value: a string descriptor index.
+ *
+ * Since: 2.0.4
+ **/
+guint8
 fu_usb_device_get_manufacturer_index(FuUsbDevice *self)
 {
 	FuUsbDevicePrivate *priv = GET_PRIVATE(self);
@@ -638,7 +648,17 @@ fu_usb_device_get_manufacturer_index(FuUsbDevice *self)
 	return priv->desc.iManufacturer;
 }
 
-static guint8
+/**
+ * fu_usb_device_get_product_index:
+ * @self: a #FuUsbDevice
+ *
+ * Gets the index for the iProduct string descriptor.
+ *
+ * Return value: a string descriptor index.
+ *
+ * Since: 2.0.4
+ **/
+guint8
 fu_usb_device_get_product_index(FuUsbDevice *self)
 {
 	FuUsbDevicePrivate *priv = GET_PRIVATE(self);

--- a/libfwupdplugin/fu-usb-device.h
+++ b/libfwupdplugin/fu-usb-device.h
@@ -45,6 +45,10 @@ fu_usb_device_get_configuration_index(FuUsbDevice *self, GError **error) G_GNUC_
 guint8
 fu_usb_device_get_serial_number_index(FuUsbDevice *self) G_GNUC_NON_NULL(1);
 guint8
+fu_usb_device_get_manufacturer_index(FuUsbDevice *self) G_GNUC_NON_NULL(1);
+guint8
+fu_usb_device_get_product_index(FuUsbDevice *self) G_GNUC_NON_NULL(1);
+guint8
 fu_usb_device_get_custom_index(FuUsbDevice *self,
 			       guint8 class_id,
 			       guint8 subclass_id,

--- a/plugins/qc-s5gen2/README.md
+++ b/plugins/qc-s5gen2/README.md
@@ -23,6 +23,12 @@ These devices use the standard  DeviceInstanceId values, e.g.
 
 * `USB\VID_0A12&PID_4007`
 
+Pair 0A12:4007 is shared among vendors and shouldn't be used for the single device.
+Also these devices use a custom GUID generation scheme, please use GUID based on
+manufacturer and product names in case of shared VID:PID pair:
+
+* `USB\VID_0A12&PID_4007&MANUFACTURER_{iManufacturer}&PRODUCT_{iProduct}`
+
 Typically, BlueTooth devices should be detected by GAIA primary service with if
 default vendor ID has been used:
 

--- a/plugins/qc-s5gen2/qc-s5gen2.quirk
+++ b/plugins/qc-s5gen2/qc-s5gen2.quirk
@@ -1,7 +1,7 @@
 # 5171 devboard connected via USB
 [USB\VID_0A12&PID_4007]
 Plugin = qc_s5gen2
-Flags = enforce-requires
+Flags = no-generic-guids
 ProxyGType = FuQcS5gen2HidDevice
 
 # 5171 devboard connected via BT


### PR DESCRIPTION
 0A12:4007 pair is owned by Qualcomm and set as example in their ADK. However a lot of vendors are using that VID:PID pair as is for their products, so we can't distinguish devices.
    
Hopefully ADK requires to set manufacturer and product names in `subsys7_config3.htf`: USBProductString and USBManufString.
For USB device they are recognized as iManufacturer and iProduct.

Access to iManufacturer and iProduct is required, so exposing `fu_usb_device_get_manufacturer_index()` and `fu_usb_device_get_product_index()` from USB devices.
    
That allows to identify the target device with unique GUID, based on 4 parameters: VID, PID, Manufacturer and Product name.
Setting the `no-generic-guids` flag prevents devices from updating for generic GUID but allows to detect devices with it, showing unique GUID  to be used in CAB file.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation
