### PR TITLE
Never read more of the composite stream from a partial stream

### DIFF
--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -322,7 +322,7 @@ fu_composite_input_stream_read(GInputStream *stream,
 
 	/* we have to keep track of this in case we have to switch the FuCompositeInputStreamItem
 	 * without an explicit seek */
-	self->pos_offset += rc;
+	self->pos += rc;
 	return rc;
 }
 

--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -285,23 +285,6 @@ fu_input_stream_read_byte_array(GInputStream *stream,
 		return NULL;
 	}
 
-	/* do not rely on composite input stream doing the right thing */
-	if (count == G_MAXSIZE) {
-		gsize streamsz = 0;
-		if (!fu_input_stream_size(stream, &streamsz, error))
-			return NULL;
-		if (offset > streamsz) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INTERNAL,
-				    "offset 0x%x is out of range of stream size 0x%x",
-				    (guint)offset,
-				    (guint)streamsz);
-			return NULL;
-		}
-		count = streamsz - offset;
-	}
-
 	/* seek back to start */
 	if (G_IS_SEEKABLE(stream) && g_seekable_can_seek(G_SEEKABLE(stream))) {
 		if (!g_seekable_seek(G_SEEKABLE(stream), offset, G_SEEK_SET, NULL, error))


### PR DESCRIPTION
We need to keep track of the current offset of the composite stream, rather than just the offset within the partial stream.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
