### PR TITLE
Properly handle FU_DEVICE_PRIVATE_FLAG_NO_GENERIC_GUIDS

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -116,7 +116,7 @@ data from `sysfs` or `/dev`.
     {
         g_autoptr(FuDevice) dev = NULL;
         fu_device_set_id(dev, "dummy-1:2:3");
-        fu_device_add_guid(dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+        fu_device_add_instance_id(dev, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
         fu_device_set_version(dev, "1.2.3");
         fu_device_get_version_lowest(dev, "1.2.2");
         fu_device_get_version_bootloader(dev, "0.1.2");
@@ -141,7 +141,7 @@ Some notable points:
 plugins, so including the plugin name as a prefix is probably a good idea.
 
 - The GUID value can be generated automatically using
-`fu_device_add_guid(dev,"some-identifier")` but is quoted here explicitly. The
+`fu_device_add_instance_id(dev,"some-identifier")` but is quoted here explicitly. The
 GUID value has to match the `provides` value in the `.metainfo.xml` file for the
 firmware update to succeed.
 

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -65,8 +65,6 @@ void
 fu_device_set_specialized_gtype(FuDevice *self, GType gtype) G_GNUC_NON_NULL(1);
 void
 fu_device_set_proxy_gtype(FuDevice *self, GType gtype) G_GNUC_NON_NULL(1);
-gboolean
-fu_device_has_counterpart_guid(FuDevice *self, const gchar *guid) G_GNUC_NON_NULL(1, 2);
 GPtrArray *
 fu_device_get_counterpart_guids(FuDevice *self) G_GNUC_NON_NULL(1);
 gboolean

--- a/libfwupdplugin/fu-device.rs
+++ b/libfwupdplugin/fu-device.rs
@@ -1,0 +1,11 @@
+// Copyright 2024 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#[derive(ToBitString)]
+enum FuDeviceInstanceFlag {
+    None    = 0,
+    Visible = 1 << 0,
+    Quirks  = 1 << 1,
+    Generic = 1 << 2, // added by a baseclass
+    Counterpart = 1 << 3,
+}

--- a/libfwupdplugin/fu-mei-device.c
+++ b/libfwupdplugin/fu-mei-device.c
@@ -166,7 +166,7 @@ fu_mei_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	}
 	fu_mei_device_set_uuid(self, uuid);
-	fu_device_add_guid(device, uuid);
+	fu_device_add_instance_id(device, uuid);
 
 	/* get the mei[0-9] device file the parent is using */
 	if (!fu_mei_device_ensure_parent_device_file(self, error))

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -485,6 +485,9 @@ fu_plugin_device_add(FuPlugin *self, FuDevice *device)
 	g_return_if_fail(FU_IS_PLUGIN(self));
 	g_return_if_fail(FU_IS_DEVICE(device));
 
+	/* make tests easier */
+	fu_device_convert_instance_ids(device);
+
 	/* ensure the device ID is set from the physical and logical IDs */
 	if (!fu_device_ensure_id(device, &error)) {
 		g_warning("ignoring add: %s", error->message);

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -6,6 +6,7 @@ fwupdplugin_structs = [
   'fu-cab.rs', # fuzzing
   'fu-cfu-firmware.rs', # fuzzing
   'fu-coswid.rs', # fuzzing
+  'fu-device.rs', # fuzzing
   'fu-dfu-firmware.rs', # fuzzing
   'fu-dpaux.rs', # fuzzing
   'fu-edid.rs', # fuzzing

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -144,7 +144,6 @@ fu_ata_device_parse_id_maybe_dell(FuAtaDevice *self, const guint16 *buf)
 	g_autofree gchar *component_id = NULL;
 	g_autofree gchar *guid_efi = NULL;
 	g_autofree gchar *guid_id = NULL;
-	g_autofree gchar *guid = NULL;
 
 	/* add extra component ID if set */
 	component_id = fu_ata_device_get_string(buf, 137, 140);
@@ -160,13 +159,11 @@ fu_ata_device_parse_id_maybe_dell(FuAtaDevice *self, const guint16 *buf)
 	/* add instance ID *and* GUID as using no-auto-instance-ids */
 	guid_id = g_strdup_printf("STORAGE-DELL-%s", component_id);
 	fu_device_add_instance_id(FU_DEVICE(self), guid_id);
-	guid = fwupd_guid_hash_string(guid_id);
-	fu_device_add_guid(FU_DEVICE(self), guid);
 
 	/* also add the EFI GUID */
 	guid_efi = fu_ata_device_get_guid_safe(buf, 129);
 	if (guid_efi != NULL)
-		fu_device_add_guid(FU_DEVICE(self), guid_efi);
+		fu_device_add_instance_id(FU_DEVICE(self), guid_efi);
 
 	/* owned by Dell */
 	fu_device_set_vendor(FU_DEVICE(self), "Dell");

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -366,7 +366,7 @@ fu_colorhug_device_setup(FuDevice *device, GError **error)
 	if (idx != 0x00) {
 		g_autofree gchar *tmp = NULL;
 		tmp = fu_usb_device_get_string_descriptor(FU_USB_DEVICE(device), idx, NULL);
-		fu_device_add_guid(device, tmp);
+		fu_device_add_instance_id(device, tmp);
 	}
 
 	/* using the USB descriptor and old firmware */

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -45,10 +45,6 @@ fu_dell_dock_plugin_create_node(FuPlugin *plugin, FuDevice *device, GError **err
 static gboolean
 fu_dell_dock_plugin_probe(FuPlugin *plugin, FuDevice *proxy, GError **error)
 {
-	const gchar *instance_id_mst;
-	const gchar *instance_id_status;
-	g_autofree const gchar *instance_guid_mst = NULL;
-	g_autofree const gchar *instance_guid_status = NULL;
 	g_autoptr(FuDellDockEc) ec_device = NULL;
 	g_autoptr(FuDellDockMst) mst_device = NULL;
 	g_autoptr(FuDellDockStatus) status_device = NULL;
@@ -66,12 +62,9 @@ fu_dell_dock_plugin_probe(FuPlugin *plugin, FuDevice *proxy, GError **error)
 	/* create mst endpoint */
 	mst_device = fu_dell_dock_mst_new(ctx);
 	if (fu_dell_dock_ec_get_dock_type(FU_DEVICE(ec_device)) == DOCK_BASE_TYPE_ATOMIC)
-		instance_id_mst = DELL_DOCK_VMM6210_INSTANCE_ID;
+		fu_device_add_instance_id(FU_DEVICE(mst_device), DELL_DOCK_VMM6210_INSTANCE_ID);
 	else
-		instance_id_mst = DELL_DOCK_VM5331_INSTANCE_ID;
-	fu_device_add_instance_id(FU_DEVICE(mst_device), instance_id_mst);
-	instance_guid_mst = fwupd_guid_hash_string(instance_id_mst);
-	fu_device_add_guid(FU_DEVICE(mst_device), instance_guid_mst);
+		fu_device_add_instance_id(FU_DEVICE(mst_device), DELL_DOCK_VM5331_INSTANCE_ID);
 	if (!fu_device_probe(FU_DEVICE(mst_device), error))
 		return FALSE;
 	fu_device_add_child(FU_DEVICE(ec_device), FU_DEVICE(mst_device));
@@ -80,25 +73,22 @@ fu_dell_dock_plugin_probe(FuPlugin *plugin, FuDevice *proxy, GError **error)
 
 	/* create package version endpoint */
 	status_device = fu_dell_dock_status_new(ctx);
-	if (fu_dell_dock_ec_get_dock_type(FU_DEVICE(ec_device)) == DOCK_BASE_TYPE_ATOMIC)
-		instance_id_status = DELL_DOCK_ATOMIC_STATUS_INSTANCE_ID;
-	else if (fu_dell_dock_ec_module_is_usb4(FU_DEVICE(ec_device)))
-		instance_id_status = DELL_DOCK_DOCK2_INSTANCE_ID;
-	else
-		instance_id_status = DELL_DOCK_DOCK1_INSTANCE_ID;
-	instance_guid_status = fwupd_guid_hash_string(instance_id_status);
-	fu_device_add_guid(FU_DEVICE(status_device), fwupd_guid_hash_string(instance_guid_status));
+	if (fu_dell_dock_ec_get_dock_type(FU_DEVICE(ec_device)) == DOCK_BASE_TYPE_ATOMIC) {
+		fu_device_add_instance_id(FU_DEVICE(status_device),
+					  DELL_DOCK_ATOMIC_STATUS_INSTANCE_ID);
+	} else if (fu_dell_dock_ec_module_is_usb4(FU_DEVICE(ec_device))) {
+		fu_device_add_instance_id(FU_DEVICE(status_device), DELL_DOCK_DOCK2_INSTANCE_ID);
+	} else {
+		fu_device_add_instance_id(FU_DEVICE(status_device), DELL_DOCK_DOCK1_INSTANCE_ID);
+	}
 	fu_device_add_child(FU_DEVICE(ec_device), FU_DEVICE(status_device));
-	fu_device_add_instance_id(FU_DEVICE(status_device), instance_id_status);
 	if (!fu_dell_dock_plugin_create_node(plugin, FU_DEVICE(status_device), error))
 		return FALSE;
 
 	/* create TBT endpoint if Thunderbolt SKU and Thunderbolt link inactive */
 	if (fu_dell_dock_ec_needs_tbt(FU_DEVICE(ec_device))) {
 		g_autoptr(FuDellDockTbt) tbt_device = fu_dell_dock_tbt_new(proxy);
-		g_autofree const gchar *instance_guid_tbt =
-		    fwupd_guid_hash_string(DELL_DOCK_TBT_INSTANCE_ID);
-		fu_device_add_guid(FU_DEVICE(tbt_device), instance_guid_tbt);
+		fu_device_add_instance_id(FU_DEVICE(tbt_device), DELL_DOCK_TBT_INSTANCE_ID);
 		fu_device_add_child(FU_DEVICE(ec_device), FU_DEVICE(tbt_device));
 		if (!fu_dell_dock_plugin_create_node(plugin, FU_DEVICE(tbt_device), error))
 			return FALSE;

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -641,8 +641,12 @@ fu_ebitdo_device_probe(FuDevice *device, GError **error)
 
 	/* only the bootloader can do the update */
 	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		fu_device_add_counterpart_guid(device, "USB\\VID_0483&PID_5750");
-		fu_device_add_counterpart_guid(device, "USB\\VID_2DC8&PID_5750");
+		fu_device_add_instance_id_full(device,
+					       "USB\\VID_0483&PID_5750",
+					       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
+		fu_device_add_instance_id_full(device,
+					       "USB\\VID_2DC8&PID_5750",
+					       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
 	}
 
 	/* success */

--- a/plugins/intel-usb4/fu-intel-usb4-plugin.c
+++ b/plugins/intel-usb4/fu-intel-usb4-plugin.c
@@ -45,7 +45,9 @@ fu_intel_usb4_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 		for (guint j = 0; j < instance_ids->len; j++) {
 			const gchar *instance_id = g_ptr_array_index(instance_ids, j);
 			if (g_str_has_prefix(instance_id, "TBT-") &&
-			    fu_device_has_instance_id(device_tmp, instance_id)) {
+			    fu_device_has_instance_id(device_tmp,
+						      instance_id,
+						      FU_DEVICE_INSTANCE_FLAG_VISIBLE)) {
 				fu_device_remove_private_flag(
 				    device,
 				    FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);

--- a/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
+++ b/plugins/lenovo-thinklmi/fu-lenovo-thinklmi-plugin.c
@@ -38,7 +38,9 @@ static void
 fu_lenovo_thinklmi_plugin_cpu_registered(FuContext *ctx, FuDevice *device)
 {
 	/* Ryzen 6000 doesn't support S3 even if the BIOS offers it */
-	if (fu_device_has_instance_id(device, "CPUID\\PRO_0&FAM_19&MOD_44")) {
+	if (fu_device_has_instance_id(device,
+				      "CPUID\\PRO_0&FAM_19&MOD_44",
+				      FU_DEVICE_INSTANCE_FLAG_VISIBLE)) {
 		FwupdBiosSetting *attr = fu_context_get_bios_setting(ctx, BIOS_SETTING_SLEEP_MODE);
 
 		if (attr != NULL) {

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime.c
@@ -118,7 +118,9 @@ fu_logitech_hidpp_runtime_probe(FuDevice *device, GError **error)
 			    g_strdup_printf("USB\\VID_%04X&PID_%04X",
 					    (guint)FU_LOGITECH_HIDPP_DEVICE_VID,
 					    (guint)FU_LOGITECH_HIDPP_DEVICE_PID_BOOTLOADER_BOLT);
-			fu_device_add_counterpart_guid(device, devid2);
+			fu_device_add_instance_id_full(device,
+						       devid2,
+						       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
 			priv->version_bl_major = 0x03;
 			break;
 		default:

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -196,7 +196,6 @@ fu_nvme_device_parse_cns_maybe_dell(FuNvmeDevice *self, const guint8 *buf)
 	g_autofree gchar *component_id = NULL;
 	g_autofree gchar *devid = NULL;
 	g_autofree gchar *guid_efi = NULL;
-	g_autofree gchar *guid = NULL;
 
 	/* add extra component ID if set */
 	component_id = fu_nvme_device_get_string_safe(buf, 0xc36, 0xc3d);
@@ -212,13 +211,11 @@ fu_nvme_device_parse_cns_maybe_dell(FuNvmeDevice *self, const guint8 *buf)
 	/* add instance ID *and* GUID as using no-auto-instance-ids */
 	devid = g_strdup_printf("STORAGE-DELL-%s", component_id);
 	fu_device_add_instance_id(FU_DEVICE(self), devid);
-	guid = fwupd_guid_hash_string(devid);
-	fu_device_add_guid(FU_DEVICE(self), guid);
 
 	/* also add the EFI GUID */
 	guid_efi = fu_nvme_device_get_guid_safe(buf, 0x0c26);
 	if (guid_efi != NULL)
-		fu_device_add_guid(FU_DEVICE(self), guid_efi);
+		fu_device_add_instance_id(FU_DEVICE(self), guid_efi);
 }
 
 static gboolean
@@ -269,7 +266,7 @@ fu_nvme_device_parse_cns(FuNvmeDevice *self, const guint8 *buf, gsize sz, GError
 	/* FRU globally unique identifier (FGUID) */
 	gu = fu_nvme_device_get_guid_safe(buf, 127);
 	if (gu != NULL)
-		fu_device_add_guid(FU_DEVICE(self), gu);
+		fu_device_add_instance_id(FU_DEVICE(self), gu);
 
 	/* Dell helpfully provide an EFI GUID we can use in the vendor offset,
 	 * but don't have a header or any magic we can use -- so check if the

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -477,7 +477,7 @@ fu_redfish_device_probe(FuDevice *dev, GError **error)
 	/* some vendors use a GUID, others use an ID like BMC-AFBT-10 */
 	guid_lower = g_ascii_strdown(guid, -1);
 	if (fwupd_guid_is_valid(guid_lower)) {
-		fu_device_add_guid(dev, guid_lower);
+		fu_device_add_instance_id(dev, guid_lower);
 	} else {
 		if (fu_device_has_private_flag(dev, FU_REDFISH_DEVICE_FLAG_UNSIGNED_BUILD))
 			fu_device_add_instance_str(dev, "TYPE", "UNSIGNED");

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -21,7 +21,7 @@ fu_test_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 	g_autoptr(FuDevice) device = NULL;
 	device = fu_device_new(ctx);
 	fu_device_set_id(device, "FakeDevice");
-	fu_device_add_guid(device, "b585990a-003e-5270-89d5-3705a17f9a43");
+	fu_device_add_instance_id(device, "b585990a-003e-5270-89d5-3705a17f9a43");
 	fu_device_set_name(device, "Integrated_Webcam(TM)");
 	fu_device_add_icon(device, "preferences-desktop-keyboard");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_REQUIRE_AC);
@@ -60,7 +60,7 @@ fu_test_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 		fu_device_add_protocol(child1, "com.acme");
 		fu_device_set_physical_id(child1, "fake");
 		fu_device_set_logical_id(child1, "child1");
-		fu_device_add_guid(child1, "7fddead7-12b5-4fb9-9fa0-6d30305df755");
+		fu_device_add_instance_id(child1, "7fddead7-12b5-4fb9-9fa0-6d30305df755");
 		fu_device_set_name(child1, "Module1");
 		fu_device_set_version_format(child1, FWUPD_VERSION_FORMAT_PLAIN);
 		fu_device_set_version(child1, "1");
@@ -75,7 +75,7 @@ fu_test_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 		fu_device_add_protocol(child2, "com.acme");
 		fu_device_set_physical_id(child2, "fake");
 		fu_device_set_logical_id(child2, "child2");
-		fu_device_add_guid(child2, "b8fe6b45-8702-4bcd-8120-ef236caac76f");
+		fu_device_add_instance_id(child2, "b8fe6b45-8702-4bcd-8120-ef236caac76f");
 		fu_device_set_name(child2, "Module2");
 		fu_device_set_version_format(child2, FWUPD_VERSION_FORMAT_PLAIN);
 		fu_device_set_version(child2, "10");

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -25,7 +25,9 @@ fu_thelio_io_device_probe(FuDevice *device, GError **error)
 	g_autoptr(GError) error_local = NULL;
 
 	/* this is the atmel bootloader */
-	fu_device_add_counterpart_guid(device, "USB\\VID_03EB&PID_2FF4");
+	fu_device_add_instance_id_full(device,
+				       "USB\\VID_03EB&PID_2FF4",
+				       FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
 
 	devpath = fu_udev_device_get_sysfs_path(FU_UDEV_DEVICE(device));
 	if (G_UNLIKELY(devpath == NULL)) {

--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -526,7 +526,7 @@ fu_uefi_device_probe(FuDevice *device, GError **error)
 	}
 
 	/* add GUID first, as quirks may set the version format */
-	fu_device_add_guid(device, priv->fw_class);
+	fu_device_add_instance_id(device, priv->fw_class);
 
 	/* set versions */
 	fu_device_set_version_raw(device, priv->fw_version);

--- a/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
+++ b/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
@@ -41,7 +41,7 @@ fu_uefi_recovery_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError 
 	fu_device_add_icon(device, "computer");
 	for (guint i = 0; i < hwids->len; i++) {
 		const gchar *hwid = g_ptr_array_index(hwids, i);
-		fu_device_add_guid(device, hwid);
+		fu_device_add_instance_id(device, hwid);
 	}
 
 	/* set vendor ID as the BIOS vendor */

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -464,7 +464,7 @@ static void
 fu_vbe_simple_device_constructed(GObject *obj)
 {
 	FuVbeSimpleDevice *self = FU_VBE_SIMPLE_DEVICE(obj);
-	fu_device_add_guid(FU_DEVICE(self), "bb3b05a8-ebef-11ec-be98-d3a15278be95");
+	fu_device_add_instance_id(FU_DEVICE(self), "bb3b05a8-ebef-11ec-be98-d3a15278be95");
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -235,7 +235,7 @@ fu_wacom_emr_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90, NULL);
 
 	/* erase W9013 */
-	if (fu_device_has_instance_id(device, "WacomEMR_W9013")) {
+	if (fu_device_has_instance_id(device, "WacomEMR_W9013", FU_DEVICE_INSTANCE_FLAG_QUIRKS)) {
 		if (!fu_wacom_emr_device_w9013_erase_data(self, error))
 			return FALSE;
 		for (guint i = 127; i >= 8; i--) {
@@ -245,7 +245,7 @@ fu_wacom_emr_device_write_firmware(FuDevice *device,
 	}
 
 	/* erase W9021 */
-	if (fu_device_has_instance_id(device, "WacomEMR_W9021")) {
+	if (fu_device_has_instance_id(device, "WacomEMR_W9021", FU_DEVICE_INSTANCE_FLAG_QUIRKS)) {
 		if (!fu_wacom_emr_device_w9021_erase_all(self, error))
 			return FALSE;
 	}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -7390,6 +7390,8 @@ fu_engine_backend_device_changed_cb(FuBackend *backend, FuDevice *device, FuEngi
 		FuDevice *device_tmp = g_ptr_array_index(devices, i);
 		if (!fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_EMULATED))
 			continue;
+		if (!fu_device_has_flag(device_tmp, FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG))
+			continue;
 		if (g_strcmp0(fu_device_get_backend_id(device_tmp),
 			      fu_device_get_backend_id(device)) == 0) {
 			g_debug("incorporating new device for %s", fu_device_get_id(device_tmp));

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2737,6 +2737,7 @@ fu_engine_device_check_power(FuEngine *self,
 
 	/* not enough just in case */
 	if (!fu_device_has_private_flag(device, FU_DEVICE_PRIVATE_FLAG_IGNORE_SYSTEM_POWER) &&
+	    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED) &&
 	    fu_context_get_battery_level(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_threshold(self->ctx) != FWUPD_BATTERY_LEVEL_INVALID &&
 	    fu_context_get_battery_level(self->ctx) < fu_context_get_battery_threshold(self->ctx)) {

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1368,6 +1368,7 @@ fu_engine_get_component_by_guids(FuEngine *self, FuDevice *device)
 {
 	GPtrArray *guids = fu_device_get_guids(device);
 	XbNode *component = NULL;
+	fu_device_convert_instance_ids(device);
 	for (guint i = 0; i < guids->len; i++) {
 		const gchar *guid = g_ptr_array_index(guids, i);
 		component = fu_engine_get_component_by_guid(self, guid);
@@ -4337,8 +4338,9 @@ fu_engine_get_result_from_component(FuEngine *self,
 		}
 
 		/* add GUID */
-		fu_device_add_guid(dev, guid);
+		fu_device_add_instance_id(dev, guid);
 	}
+	fu_device_convert_instance_ids(dev);
 	if (fu_device_get_guids(dev)->len == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -6014,8 +6016,12 @@ fu_engine_add_device(FuEngine *self, FuDevice *device)
 	GPtrArray *device_guids;
 	g_autoptr(XbNode) component = NULL;
 
-	/* device has no GUIDs set! */
+	/* make tests easier */
 	device_guids = fu_device_get_guids(device);
+	if (device_guids->len == 0)
+		fu_device_convert_instance_ids(device);
+
+	/* device still has no GUIDs set! */
 	if (device_guids->len == 0) {
 		g_warning("no GUIDs for device %s [%s]",
 			  fu_device_get_name(device),

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -119,7 +119,7 @@ fu_history_device_from_stmt(sqlite3_stmt *stmt)
 	/* guid_default */
 	tmp = (const gchar *)sqlite3_column_text(stmt, 9);
 	if (tmp != NULL)
-		fu_device_add_guid_full(device, tmp, FU_DEVICE_INSTANCE_FLAG_VISIBLE);
+		fu_device_add_instance_id_full(device, tmp, FU_DEVICE_INSTANCE_FLAG_VISIBLE);
 
 	/* update_state */
 	fu_device_set_update_state(device, sqlite3_column_int(stmt, 10));
@@ -168,6 +168,7 @@ fu_history_device_from_stmt(sqlite3_stmt *stmt)
 	fu_release_set_flags(release, sqlite3_column_int(stmt, 20));
 
 	/* success */
+	fu_device_convert_instance_ids(device);
 	return device;
 }
 
@@ -886,6 +887,9 @@ fu_history_add_device(FuHistory *self, FuDevice *device, FuRelease *release, GEr
 	/* lazy load */
 	if (!fu_history_load(self, error))
 		return FALSE;
+
+	/* make tests easier */
+	fu_device_convert_instance_ids(device);
 
 	/* ensure all old device(s) with this ID are removed */
 	if (!fu_history_remove_device(self, device, error))

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -137,6 +137,10 @@ void
 fu_release_set_device(FuRelease *self, FuDevice *device)
 {
 	g_return_if_fail(FU_IS_RELEASE(self));
+
+	/* make tests easier */
+	fu_device_convert_instance_ids(device);
+
 	g_set_object(&self->device, device);
 	fu_release_set_device_version_old(self, fu_device_get_version(device));
 }

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -234,7 +234,7 @@ fu_engine_generate_md_func(gconstpointer user_data)
 			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.3");
 	component = fu_engine_get_component_by_guids(engine, device);
@@ -527,7 +527,7 @@ fu_engine_requirements_version_require_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require one thing */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -576,7 +576,7 @@ fu_engine_requirements_version_lowest_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require one thing */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -673,7 +673,8 @@ fu_engine_requirements_child_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
+
 	fu_device_set_version_format(child, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(child, "0.0.999");
 	fu_device_set_physical_id(child, "dummy");
@@ -734,7 +735,8 @@ fu_engine_requirements_child_fail_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
+
 	fu_device_set_version_format(child, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(child, "0.0.1");
 	fu_device_set_physical_id(child, "dummy");
@@ -848,7 +850,7 @@ fu_engine_requirements_device_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_VERSION_CHECK_REQUIRED);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require three things */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -917,7 +919,7 @@ fu_engine_requirements_device_plain_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require three things */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -969,7 +971,7 @@ fu_engine_requirements_version_format_func(gconstpointer user_data)
 	fu_device_set_version(device, "1.2.3.4");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require three things */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -1015,7 +1017,7 @@ fu_engine_requirements_only_upgrade_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE);
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 
 	/* make the component require three things */
 	silo = xb_silo_new_from_xml(xml, &error);
@@ -1227,7 +1229,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device1, "USB", 0xFFFF);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_protocol(device1, "com.acme");
 	fu_engine_add_device(engine, device1);
 
@@ -1237,7 +1239,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	fu_device_set_version(parent, "1.0.0");
 	fu_device_add_flag(parent, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(parent, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(parent, "42f3d696-0b6f-4d69-908f-357f98ef115e");
+	fu_device_add_instance_id(parent, "42f3d696-0b6f-4d69-908f-357f98ef115e");
 	fu_device_add_protocol(parent, "com.acme");
 	fu_device_add_child(parent, device1);
 	fu_engine_add_device(engine, parent);
@@ -1251,7 +1253,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	fu_device_set_version(unrelated_device3, "1.5.3");
 	fu_device_add_flag(unrelated_device3, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(unrelated_device3, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(unrelated_device3, "3e455c08-352e-4a16-84d3-f04287289fa2");
+	fu_device_add_instance_id(unrelated_device3, "3e455c08-352e-4a16-84d3-f04287289fa2");
 	fu_engine_add_device(engine, unrelated_device3);
 
 	/* import firmware metainfo */
@@ -1282,7 +1284,7 @@ fu_engine_requirements_sibling_device_func(gconstpointer user_data)
 	fu_device_set_version(device2, "4.5.6");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_device_add_instance_id(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 	fu_device_add_child(parent, device2);
 	fu_engine_add_device(engine, device2);
 
@@ -1342,7 +1344,7 @@ fu_engine_requirements_other_device_func(gconstpointer user_data)
 	fu_device_set_version(device1, "1.2.3");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 
 	/* set up a different device */
 	fu_device_set_id(device2, "id2");
@@ -1351,7 +1353,7 @@ fu_engine_requirements_other_device_func(gconstpointer user_data)
 	fu_device_set_name(device2, "Secondary firmware");
 	fu_device_set_version_format(device2, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device2, "4.5.6");
-	fu_device_add_guid(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_device_add_instance_id(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 	fu_engine_add_device(engine, device2);
 
 	/* import firmware metainfo */
@@ -1415,7 +1417,7 @@ fu_engine_requirements_protocol_check_func(gconstpointer user_data)
 	fu_device_build_vendor_id(device1, "DMI", "ACME");
 	fu_device_set_version_format(device1, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device1, "1.2.3");
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device1);
@@ -1426,7 +1428,7 @@ fu_engine_requirements_protocol_check_func(gconstpointer user_data)
 	fu_device_build_vendor_id(device2, "DMI", "ACME");
 	fu_device_set_version_format(device2, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device2, "1.2.3");
-	fu_device_add_guid(device2, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device2, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device2);
@@ -1502,7 +1504,7 @@ fu_engine_requirements_parent_device_func(gconstpointer user_data)
 	fu_device_set_version(device2, "4.5.6");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_device_add_instance_id(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 
 	/* set up a parent device */
 	fu_device_set_id(device1, "parent");
@@ -1511,7 +1513,7 @@ fu_engine_requirements_parent_device_func(gconstpointer user_data)
 	fu_device_set_name(device1, "parent");
 	fu_device_set_version_format(device1, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device1, "1.2.3");
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_child(device1, device2);
 	fu_engine_add_device(engine, device1);
 
@@ -1574,7 +1576,7 @@ fu_engine_requirements_child_device_func(gconstpointer user_data)
 	fu_device_set_name(device1, "parent");
 	fu_device_set_version_format(device1, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device1, "1.2.3");
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 
@@ -1583,9 +1585,8 @@ fu_engine_requirements_child_device_func(gconstpointer user_data)
 	fu_device_set_name(device2, "child");
 	fu_device_set_version_format(device2, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device2, "4.5.6");
-	fu_device_add_guid(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
+	fu_device_add_instance_id(device2, "1ff60ab2-3905-06a1-b476-0371f00c9e9b");
 	fu_device_add_child(device1, device2);
-
 	fu_engine_add_device(engine, device1);
 
 	/* import firmware metainfo */
@@ -1626,7 +1627,6 @@ fu_engine_device_parent_guid_func(gconstpointer user_data)
 	fu_device_add_protocol(device2, "com.acme");
 	fu_device_add_instance_id(device1, "child-GUID-1");
 	fu_device_add_parent_guid(device1, "parent-GUID");
-	fu_device_convert_instance_ids(device1);
 	fu_engine_add_device(engine, device1);
 
 	/* parent */
@@ -1635,13 +1635,11 @@ fu_engine_device_parent_guid_func(gconstpointer user_data)
 	fu_device_add_protocol(device2, "com.acme");
 	fu_device_add_instance_id(device2, "parent-GUID");
 	fu_device_set_vendor(device2, "oem");
-	fu_device_convert_instance_ids(device2);
 
 	/* add another child */
 	fu_device_set_id(device3, "child2");
 	fu_device_add_instance_id(device3, "child-GUID-2");
 	fu_device_add_parent_guid(device3, "parent-GUID");
-	fu_device_convert_instance_ids(device3);
 	fu_device_add_child(device2, device3);
 
 	/* add two together */
@@ -1685,7 +1683,6 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_device_add_instance_id(device1, "child-GUID-1");
 	fu_device_add_parent_physical_id(device1, "parent-ID-notfound");
 	fu_device_add_parent_physical_id(device1, "parent-ID");
-	fu_device_convert_instance_ids(device1);
 	fu_engine_add_device(engine, device1);
 
 	/* parent */
@@ -1698,7 +1695,6 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_device_add_instance_id(device2, "parent-GUID");
 	fu_device_set_vendor(device2, "oem");
 	fu_device_add_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_AUTO_PARENT_CHILDREN);
-	fu_device_convert_instance_ids(device2);
 
 	/* add another child */
 	fu_device_set_id(device3, "child2");
@@ -1706,7 +1702,6 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_device_set_physical_id(device3, "child-ID2");
 	fu_device_add_instance_id(device3, "child-GUID-2");
 	fu_device_add_parent_physical_id(device3, "parent-ID");
-	fu_device_convert_instance_ids(device3);
 	fu_device_add_child(device2, device3);
 
 	/* add two together */
@@ -1720,7 +1715,6 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_device_add_protocol(device4, "com.acme");
 	fu_device_add_instance_id(device4, "child-GUID-4");
 	fu_device_add_parent_physical_id(device4, "parent-ID");
-	fu_device_convert_instance_ids(device4);
 	fu_engine_add_device(engine, device4);
 
 	/* this is normally done by fu_plugin_device_add() */
@@ -1734,7 +1728,6 @@ fu_engine_device_parent_id_func(gconstpointer user_data)
 	fu_device_add_protocol(device5, "com.acme");
 	fu_device_add_instance_id(device5, "child-GUID-5");
 	fu_device_add_parent_backend_id(device5, "/sys/devices/foo/bar/baz");
-	fu_device_convert_instance_ids(device5);
 	fu_engine_add_device(engine, device5);
 
 	/* this is normally done by fu_plugin_device_add() */
@@ -1774,14 +1767,14 @@ fu_engine_partial_hash_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device1, "USB", 0xFFFF);
 	fu_device_add_protocol(device1, "com.acme");
 	fu_device_set_plugin(device1, "test");
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_engine_add_device(engine, device1);
 	fu_device_set_id(device2, "device21");
 	fu_device_build_vendor_id_u16(device2, "USB", 0xFFFF);
 	fu_device_add_protocol(device2, "com.acme");
 	fu_device_set_plugin(device2, "test");
 	fu_device_set_equivalent_id(device2, "b92f5b7560b84ca005a79f5a15de3c003ce494cf");
-	fu_device_add_guid(device2, "87654321-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device2, "87654321-1234-1234-1234-123456789012");
 	fu_engine_add_device(engine, device2);
 
 	/* match nothing */
@@ -1853,7 +1846,7 @@ fu_engine_device_unlock_func(gconstpointer user_data)
 	fu_device_set_id(device, "UEFI-dummy-dev0");
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_LOCKED);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -1890,7 +1883,7 @@ fu_engine_device_equivalent_func(gconstpointer user_data)
 	fu_device_set_name(device1, "device1");
 	fu_device_build_vendor_id_u16(device1, "USB", 0xFFFF);
 	fu_device_add_protocol(device1, "com.acme");
-	fu_device_add_guid(device1, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device1, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device1);
@@ -1902,7 +1895,7 @@ fu_engine_device_equivalent_func(gconstpointer user_data)
 	fu_device_set_priority(device2, 999);
 	fu_device_build_vendor_id_u16(device2, "USB", 0xFFFF);
 	fu_device_add_protocol(device2, "com.acme");
-	fu_device_add_guid(device2, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device2, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device2);
@@ -1983,7 +1976,7 @@ fu_engine_device_md_set_flags_func(gconstpointer user_data)
 	fu_device_set_version(device, "0");
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_MD_SET_FLAGS);
@@ -2036,7 +2029,7 @@ fu_engine_require_hwid_func(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.2");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device);
@@ -2094,7 +2087,7 @@ fu_engine_get_details_added_func(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.2");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device);
@@ -2296,7 +2289,7 @@ fu_engine_downgrade_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
-	fu_device_add_guid(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+	fu_device_add_instance_id(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_engine_add_device(engine, device);
@@ -2437,7 +2430,7 @@ fu_engine_md_verfmt_func(gconstpointer user_data)
 	fu_device_set_id(device, "test_device");
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+	fu_device_add_instance_id(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_engine_add_device(engine, device);
 
@@ -2525,7 +2518,7 @@ fu_engine_install_duration_func(gconstpointer user_data)
 	fu_device_set_id(device, "test_device");
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+	fu_device_add_instance_id(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_set_install_duration(device, 999);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -2610,7 +2603,7 @@ fu_engine_release_dedupe_func(gconstpointer user_data)
 	fu_device_set_id(device, "test_device");
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+	fu_device_add_instance_id(device, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 	fu_device_set_install_duration(device, 999);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -2714,7 +2707,7 @@ fu_engine_history_func(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_checksum(device, "0123456789abcdef0123456789abcdef01234567");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -2794,6 +2787,7 @@ fu_engine_history_func(gconstpointer user_data)
 			    "    Version:            1.2.3\n"
 			    "    Checksum:           SHA1(%s)\n"
 			    "    Flags:              trusted-payload|trusted-metadata\n"
+			    "  InstanceId[vi]:       12345678-1234-1234-1234-123456789012\n"
 			    "  AcquiesceDelay:       50\n",
 			    checksum);
 	ret = g_strcmp0(device_str, device_str_expected) == 0;
@@ -2846,7 +2840,7 @@ fu_engine_history_verfmt_func(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_checksum(device, "0123456789abcdef0123456789abcdef01234567");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -2906,7 +2900,7 @@ fu_engine_multiple_rels_func(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_checksum(device, "0123456789abcdef0123456789abcdef01234567");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
@@ -3036,7 +3030,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
@@ -3112,7 +3106,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.2");
 	fu_engine_add_device(engine, device);
@@ -3129,7 +3123,7 @@ fu_engine_history_inherit(gconstpointer user_data)
 	fu_device_build_vendor_id_u16(device, "USB", 0xFFFF);
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_version(device, "1.2.2");
 	fu_engine_add_device(engine, device);
@@ -3177,7 +3171,7 @@ fu_engine_install_needs_reboot(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
@@ -3286,7 +3280,7 @@ fu_engine_install_request(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_request_flag(device, FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
@@ -3383,7 +3377,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	fu_device_add_protocol(device, "com.acme");
 	fu_device_set_name(device, "Test Device");
 	fu_device_set_plugin(device, "test");
-	fu_device_add_guid(device, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_set_created_usec(device, 1515338000ull * G_USEC_PER_SEC);
@@ -3458,6 +3452,7 @@ fu_engine_history_error_func(gconstpointer user_data)
 	    "    Version:            1.2.3\n"
 	    "    Checksum:           SHA1(%s)\n"
 	    "    Flags:              trusted-payload|trusted-metadata\n"
+	    "  InstanceId[vi]:       12345678-1234-1234-1234-123456789012\n"
 	    "  AcquiesceDelay:       50\n",
 	    checksum);
 	ret = g_strcmp0(device_str, device_str_expected) == 0;
@@ -3532,7 +3527,6 @@ fu_device_list_delay_func(gconstpointer user_data)
 	fu_device_add_instance_id(device1, "foobar");
 	fu_device_add_private_flag(device1, FU_DEVICE_PRIVATE_FLAG_DELAYED_REMOVAL);
 	fu_device_set_remove_delay(device1, 100);
-	fu_device_convert_instance_ids(device1);
 	fu_device_list_add(device_list, device1);
 	g_assert_cmpint(added_cnt, ==, 1);
 	g_assert_cmpint(removed_cnt, ==, 0);
@@ -3670,15 +3664,15 @@ fu_device_list_replug_user_func(gconstpointer user_data)
 	fu_device_add_instance_id(device1, "bar");
 	fu_device_set_plugin(device1, "self-test");
 	fu_device_set_remove_delay(device1, FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
-	fu_device_convert_instance_ids(device1);
 	fu_device_set_id(device2, "device2");
 	fu_device_set_name(device2, "device2");
 	fu_device_add_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_instance_id(device2, "baz");
-	fu_device_add_counterpart_guid(device2, "bar"); /* matches */
+	fu_device_add_instance_id_full(device2,
+				       "bar",
+				       FU_DEVICE_INSTANCE_FLAG_COUNTERPART); /* matches */
 	fu_device_set_plugin(device2, "self-test");
 	fu_device_set_remove_delay(device2, FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
-	fu_device_convert_instance_ids(device2);
 
 	/* not yet added */
 	ret = fu_device_list_wait_for_replug(device_list, &error);
@@ -3763,9 +3757,8 @@ fu_device_list_compatible_func(gconstpointer user_data)
 	fu_device_add_private_flag(device1, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(device1, FU_DEVICE_PRIVATE_FLAG_DELAYED_REMOVAL);
 	fu_device_add_instance_id(device1, "foobar");
-	fu_device_add_counterpart_guid(device1, "bootloader");
+	fu_device_add_instance_id_full(device1, "bootloader", FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
 	fu_device_set_remove_delay(device1, 100);
-	fu_device_convert_instance_ids(device1);
 	fu_device_list_add(device_list, device1);
 	g_assert_cmpint(added_cnt, ==, 1);
 	g_assert_cmpint(removed_cnt, ==, 0);
@@ -3776,7 +3769,6 @@ fu_device_list_compatible_func(gconstpointer user_data)
 	fu_device_set_plugin(device2, "plugin-for-bootloader");
 	fu_device_add_instance_id(device2, "bootloader");
 	fu_device_add_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
-	fu_device_convert_instance_ids(device2);
 
 	/* verify only a changed event was generated */
 	added_cnt = removed_cnt = changed_cnt = 0;
@@ -3837,7 +3829,6 @@ fu_device_list_remove_chain_func(gconstpointer user_data)
 	/* add child */
 	fu_device_set_id(device_child, "child");
 	fu_device_add_instance_id(device_child, "child-GUID-1");
-	fu_device_convert_instance_ids(device_child);
 	fu_device_list_add(device_list, device_child);
 	g_assert_cmpint(added_cnt, ==, 1);
 	g_assert_cmpint(removed_cnt, ==, 0);
@@ -3846,7 +3837,6 @@ fu_device_list_remove_chain_func(gconstpointer user_data)
 	/* add parent */
 	fu_device_set_id(device_parent, "parent");
 	fu_device_add_instance_id(device_parent, "parent-GUID-1");
-	fu_device_convert_instance_ids(device_parent);
 	fu_device_add_child(device_parent, device_child);
 	fu_device_list_add(device_list, device_parent);
 	g_assert_cmpint(added_cnt, ==, 2);
@@ -3871,10 +3861,8 @@ fu_device_list_explicit_order_func(gconstpointer user_data)
 	/* add both */
 	fu_device_set_id(device_root, "device");
 	fu_device_add_instance_id(device_root, "foobar");
-	fu_device_convert_instance_ids(device_root);
 	fu_device_set_id(device_child, "device-child");
 	fu_device_add_instance_id(device_child, "baz");
-	fu_device_convert_instance_ids(device_child);
 	fu_device_add_child(device_root, device_child);
 	fu_device_list_add(device_list, device_root);
 
@@ -3895,10 +3883,8 @@ fu_device_list_explicit_order_post_func(gconstpointer user_data)
 	/* add both */
 	fu_device_set_id(device_root, "device");
 	fu_device_add_instance_id(device_root, "foobar");
-	fu_device_convert_instance_ids(device_root);
 	fu_device_set_id(device_child, "device-child");
 	fu_device_add_instance_id(device_child, "baz");
-	fu_device_convert_instance_ids(device_child);
 	fu_device_add_child(device_root, device_child);
 	fu_device_list_add(device_list, device_root);
 	fu_device_list_add(device_list, device_child);
@@ -3945,7 +3931,7 @@ fu_device_list_better_than_func(gconstpointer user_data)
 	fu_device_set_id(device1, "87ea5dfc8b8e384d848979496e706390b497e547");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device1, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device1, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_protocol(device1, "com.acme");
 	fu_plugin_device_add(plugin1, device1);
 
@@ -3953,7 +3939,7 @@ fu_device_list_better_than_func(gconstpointer user_data)
 	fu_device_set_id(device2, "87ea5dfc8b8e384d848979496e706390b497e547");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
-	fu_device_add_guid(device2, "12345678-1234-1234-1234-123456789012");
+	fu_device_add_instance_id(device2, "12345678-1234-1234-1234-123456789012");
 	fu_device_add_protocol(device2, "com.acme");
 	fu_plugin_device_add(plugin2, device2);
 
@@ -3987,8 +3973,7 @@ fu_device_list_counterpart_func(gconstpointer user_data)
 	/* add and then remove runtime */
 	fu_device_set_id(device1, "device-runtime");
 	fu_device_add_instance_id(device1, "runtime"); /* 420dde7c-3102-5d8f-86bc-aaabd7920150 */
-	fu_device_add_counterpart_guid(device1, "bootloader");
-	fu_device_convert_instance_ids(device1);
+	fu_device_add_instance_id_full(device1, "bootloader", FU_DEVICE_INSTANCE_FLAG_COUNTERPART);
 	fu_device_set_remove_delay(device1, 100);
 	fu_device_list_add(device_list, device1);
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
@@ -4000,7 +3985,6 @@ fu_device_list_counterpart_func(gconstpointer user_data)
 	fu_device_add_instance_id(device2, "bootloader"); /* 015370aa-26f2-5daa-9661-a75bf4c1a913 */
 	fu_device_add_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_ADD_COUNTERPART_GUIDS);
-	fu_device_convert_instance_ids(device2);
 	fu_device_list_add(device_list, device2);
 
 	/* should have matched the runtime */
@@ -4008,7 +3992,8 @@ fu_device_list_counterpart_func(gconstpointer user_data)
 
 	/* should not have *visible* GUID of runtime */
 	g_assert_false(fu_device_has_guid(device2, "runtime"));
-	g_assert_true(fu_device_has_counterpart_guid(device2, "runtime"));
+	g_assert_false(
+	    fu_device_has_instance_id(device2, "runtime", FU_DEVICE_INSTANCE_FLAG_VISIBLE));
 }
 
 static void
@@ -4052,7 +4037,6 @@ fu_device_list_unconnected_no_delay_func(gconstpointer user_data)
 	fu_device_set_id(device1, "device1");
 	fu_device_add_flag(device1, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_instance_id(device1, "foobar");
-	fu_device_convert_instance_ids(device1);
 	fu_device_list_add(device_list, device1);
 	g_assert_false(fu_device_has_private_flag(device1, FU_DEVICE_PRIVATE_FLAG_UNCONNECTED));
 
@@ -4070,7 +4054,6 @@ fu_device_list_unconnected_no_delay_func(gconstpointer user_data)
 	fu_device_set_id(device2, "device1");
 	fu_device_add_flag(device2, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_instance_id(device2, "foobar");
-	fu_device_convert_instance_ids(device2);
 	fu_device_list_add(device_list, device2);
 	g_assert_false(fu_device_has_private_flag(device2, FU_DEVICE_PRIVATE_FLAG_UNCONNECTED));
 	fu_device_list_remove(device_list, device2);
@@ -4108,11 +4091,9 @@ fu_device_list_func(gconstpointer user_data)
 	/* add both */
 	fu_device_set_id(device1, "device1");
 	fu_device_add_instance_id(device1, "foobar");
-	fu_device_convert_instance_ids(device1);
 	fu_device_list_add(device_list, device1);
 	fu_device_set_id(device2, "device2");
 	fu_device_add_instance_id(device2, "baz");
-	fu_device_convert_instance_ids(device2);
 	fu_device_list_add(device_list, device2);
 	g_assert_cmpint(added_cnt, ==, 2);
 	g_assert_cmpint(removed_cnt, ==, 0);
@@ -4508,7 +4489,9 @@ fu_backend_usb_invalid_func(gconstpointer user_data)
 
 	/* check the device was processed correctly by FuUsbDevice */
 	g_assert_cmpstr(fu_device_get_name(device_tmp), ==, "ColorHug2");
-	g_assert_true(fu_device_has_instance_id(device_tmp, "USB\\VID_273F&PID_1004"));
+	g_assert_true(fu_device_has_instance_id(device_tmp,
+						"USB\\VID_273F&PID_1004",
+						FU_DEVICE_INSTANCE_FLAG_VISIBLE));
 	g_assert_true(fu_device_has_vendor_id(device_tmp, "USB:0x273F"));
 
 	/* check the fwupd DS20 descriptor was *not* parsed */
@@ -4601,7 +4584,7 @@ fu_history_func(gconstpointer user_data)
 	fu_device_set_version(device, "3.0.1"),
 	    fu_device_set_update_state(device, FWUPD_UPDATE_STATE_FAILED);
 	fu_device_set_update_error(device, "word");
-	fu_device_add_guid(device, "827edddd-9bb6-5632-889f-2c01255503da");
+	fu_device_add_instance_id(device, "827edddd-9bb6-5632-889f-2c01255503da");
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_set_created_usec(device, 1514338000ull * G_USEC_PER_SEC);
 	fu_device_set_modified_usec(device, 1514338999ull * G_USEC_PER_SEC);
@@ -5290,7 +5273,7 @@ fu_release_trusted_report_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_engine_add_device(engine, device);
 
@@ -5345,7 +5328,7 @@ fu_release_trusted_report_oem_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_engine_add_device(engine, device);
 
@@ -5400,7 +5383,7 @@ fu_release_no_trusted_report_upgrade_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_engine_add_device(engine, device);
 
@@ -5455,7 +5438,7 @@ fu_release_no_trusted_report_func(gconstpointer user_data)
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_protocol(device, "com.acme");
-	fu_device_add_guid(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
+	fu_device_add_instance_id(device, "2d47f29b-83a2-4f31-a2e8-63474f4d4c2e");
 	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_engine_add_device(engine, device);
 
@@ -6981,7 +6964,9 @@ fu_test_engine_fake_serio(gconstpointer user_data)
 			==,
 			"DEVPATH=/devices/platform/i8042/serio1");
 	g_assert_cmpstr(fu_device_get_logical_id(device), ==, NULL);
-	g_assert_true(fu_device_has_instance_id(device, "SERIO\\FWID_LEN0305-PNP0F13"));
+	g_assert_true(fu_device_has_instance_id(device,
+						"SERIO\\FWID_LEN0305-PNP0F13",
+						FU_DEVICE_INSTANCE_FLAG_VISIBLE));
 }
 
 static void


### PR DESCRIPTION
The old code just removed all the FwupdDevice baseclass instance IDs before copying the new superclass IDs -- which was a bit of a hack and only just about worked.

The new code adds the instance IDs to a FuDevice-specific list, which is then moved into the baseclass when running FuDevice->setup(). This allows two things; only doing the quirk match once per duplicate ID, and also doing the incorporate of IDs in the proper way.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
