### PR TITLE
vli: hub attach command result

### DIFF
--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -415,6 +415,7 @@ fu_vli_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **err
 						    NULL,
 						    &error_local)) {
 			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
+			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_READ) ||
 			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT) ||
 			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INTERNAL)) {
 				g_debug("ignoring %s", error_local->message);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

When the device receives the attach command, it immediately resets itself and does not complete the command. So  it may cause LIBUSB_ERROR_IO and get error _code FWUPD_ERROR_READ.
