### PR TITLE
vli:prepare test json file

### DIFF
--- a/plugins/vli/tests/lenovo-4X90V55523-vli.json
+++ b/plugins/vli/tests/lenovo-4X90V55523-vli.json
@@ -3,7 +3,7 @@
   "interactive": false,
   "steps": [
     {
-      "url": "placeholder",
+      "url": "https://fwupd.org/downloads/d3756f8f7083cda7fd487e30b13a3c2593139f1b87945242129e1632c8066139-Linxee-7_in_1_Dock-2025-01-08-150958_New.cab",
       "emulation-url": "placeholder",
       "components": [
         {
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "url": "placeholder",
+      "url": "https://fwupd.org/downloads/e1a718a5c233179702c2631f289a4f4af40cae32807c12b1ecd30c1a6b4b71db-Linxee-7_in_1_Dock-2025-01-08-150953_Old.cab",
       "emulation-url": "placeholder",
       "components": [
         {

--- a/plugins/vli/tests/lenovo-4X90V55523-vli.json
+++ b/plugins/vli/tests/lenovo-4X90V55523-vli.json
@@ -1,0 +1,46 @@
+{
+  "name": "Lenovo 7in1 Dock WWCB [VL822+VL105]",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "placeholder",
+      "emulation-url": "placeholder",
+      "components": [
+        {
+          "name": "tier1",
+          "version": "49.34",
+          "guids": [
+            "3f7f4e9e-9fda-5066-93c4-e3ea8cc63480"
+          ]
+        },
+        {
+          "name": "tier3",
+          "version": "12.84.38.50",
+          "guids": [
+            "bbd87765-6316-5c61-9cce-b90353304b47"
+          ]
+        }
+      ]
+    },
+    {
+      "url": "placeholder",
+      "emulation-url": "placeholder",
+      "components": [
+        {
+          "name": "tier1",
+          "version": "8.64",
+          "guids": [
+            "3f7f4e9e-9fda-5066-93c4-e3ea8cc63480"
+          ]
+        },
+        {
+          "name": "tier3",
+          "version": "12.84.32.50",
+          "guids": [
+            "bbd87765-6316-5c61-9cce-b90353304b47"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/vli/vli-lenovo.quirk
+++ b/plugins/vli/vli-lenovo.quirk
@@ -224,7 +224,7 @@ ParentGuid = USB\VID_17EF&PID_722A
 [USB\VID_17EF&PID_10CA]
 Plugin = vli
 GType = FuVliUsbhubDevice
-Flags = usb3,has-shared-spi-pd
+Flags = usb3,has-shared-spi-pd,unsigned-payload
 CounterpartGuid = USB\VID_17EF&PID_10CB
 [USB\VID_17EF&PID_10CB]
 Plugin = vli

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -6965,6 +6965,8 @@ fu_engine_load_plugins_builtins(FuEngine *self, FuProgress *progress)
 	/* count possible steps */
 	for (guint i = 0; fu_plugin_externals[i] != NULL; i++)
 		steps++;
+	if (steps == 0)
+		return;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Hello,
I've run into two issues.


Problem the first: my user account on LVFS has been disabled! I am unable to upload test cab files or emulation zips.

Problem the second: following doc/emulation.md all steps PASS up until i run the emulation-load process to install the cab file. I've attached my error log on the "fwupdmgr install 17*.cab --allow-reinstall -vv"
[debug_emulation_log.txt](https://github.com/user-attachments/files/18296362/debug_emulation_log.txt)

Additional notes: I've chosen to ignore the g_critical "does not declare signed/unsigned payload -- perhaps add fu_device_add_flag(device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD)" while running fwupdmgr.

Much obliged.

  