### PR TITLE
Probe sd_mod before starting

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=Firmware update daemon
 Documentation=https://fwupd.org/
-After=dbus.service
+Wants=modprobe@sd_mod.service
+After=modprobe@sd_mod.service dbus.service
 Before=display-manager.service
 ConditionVirtualization=!container
 


### PR DESCRIPTION
Type of pull request:

- [x] Code fix


Necessary for "DeviceAllow=block-sd rw" to be resolved by systemd at unit startup. rp2040 and other UF2 devices will present an USB Storage (which uses the sd_mod kernel module), and some of them (notably rp2040) only show up in a replug sequence.

See systemd.resource-control(5) for documentation. https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#DeviceAllow=

Fixes: fwupd/fwupd#8265

