### PR TITLE
trivial: ci: update metadata during arch tests

### DIFF
--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 
+pacman -Sy --noconfirm qt5-base gcovr
 pacman -U --noconfirm dist/*.pkg.*
 
 #run the CI tests for Qt5
-pacman -S --noconfirm qt5-base gcovr
 meson qt5-thread-test contrib/ci/qt5-thread-test
 ninja -C qt5-thread-test test
 


### PR DESCRIPTION
Base containers are only created once per day, but if the arch metadata is out of date then the test job could fail.  Always update arch metadata during test to avoid this failure.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
