### PR TITLE
uefi-capsule: Do not record the ESP path if it is not set

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-device.c
+++ b/plugins/uefi-capsule/fu-uefi-device.c
@@ -107,7 +107,11 @@ fu_uefi_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 	if (priv->esp != NULL) {
 		g_autofree gchar *kind = fu_volume_get_partition_kind(priv->esp);
 		g_autofree gchar *mount_point = fu_volume_get_mount_point(priv->esp);
-		g_hash_table_insert(metadata, g_strdup("EspPath"), g_steal_pointer(&mount_point));
+		if (mount_point != NULL) {
+			g_hash_table_insert(metadata,
+					    g_strdup("EspPath"),
+					    g_steal_pointer(&mount_point));
+		}
 		if (kind != NULL)
 			g_hash_table_insert(metadata, g_strdup("EspKind"), g_steal_pointer(&kind));
 	}


### PR DESCRIPTION
Seen on the LVFS from a CoD update, and matches what we do further up the file...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
