### PR TITLE
parade-usbhub: Do not claim interface 0x0 to avoid downstream port re…

### DIFF
--- a/plugins/parade-usbhub/fu-parade-usbhub-device.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-device.c
@@ -1267,7 +1267,6 @@ fu_parade_usbhub_device_init(FuParadeUsbhubDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
 	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
-	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0);
 }
 
 static void


### PR DESCRIPTION
…sets

The issue seems to be that `fu_usb_device_release_interface()` causes the kernel usbhub driver to reset any child devices.

We're only claiming the interface because we explicitly asked the FuUsbDevice to do that with `fu_usb_device_add_interface(FU_USB_DEVICE(self), 0)` and removing that line still allows the enumeration (and update!) to complete without the child port reset.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
