### PR TITLE
trivial: fu-tool don't connect device changed signal for update

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1568,10 +1568,6 @@ fu_util_update(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	priv->current_operation = FU_UTIL_OPERATION_UPDATE;
-	g_signal_connect(FU_ENGINE(priv->engine),
-			 "device-changed",
-			 G_CALLBACK(fu_util_update_device_changed_cb),
-			 priv);
 
 	devices = fu_engine_get_devices(priv->engine, error);
 	if (devices == NULL)


### PR DESCRIPTION
Update calls install release which calls install.  The device changed signal is connected in update.

This fixes pre-emptively trying to match devices to releases causing the signal to apply to wrong devices.

Fixes: https://github.com/fwupd/fwupd/issues/8282

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
