### PR TITLE
Make the coverage stats less scary

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 comment: off
 
 coverage:
+  range: 40..60
   status:
     project:
       default:


### PR DESCRIPTION
We're not adding to the blocklist, instead we're just remapping >40% as yellow, and >60% as green. As we're dealing with real hardware, trying to cover every error path is essentially impossible, and not useful.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
