### PR TITLE
Fix a regression in updating the PinePhone modem

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -363,6 +363,15 @@ fu_device_add_private_flag(FuDevice *self, const gchar *flag)
 	if (g_strcmp0(flag, FU_DEVICE_PRIVATE_FLAG_UNCONNECTED) == 0)
 		fu_device_inhibit(self, "unconnected", "Device has been removed");
 
+	/* add counterpart GUIDs already added */
+	if (g_strcmp0(flag, FU_DEVICE_PRIVATE_FLAG_COUNTERPART_VISIBLE) == 0) {
+		for (guint i = 0; priv->instance_ids != NULL && i < priv->instance_ids->len; i++) {
+			FuDeviceInstanceIdItem *item = g_ptr_array_index(priv->instance_ids, i);
+			if (item->flags & FU_DEVICE_INSTANCE_FLAG_COUNTERPART)
+				item->flags |= FU_DEVICE_INSTANCE_FLAG_VISIBLE;
+		}
+	}
+
 	/* reset this back to the default */
 	if (g_strcmp0(flag, FU_DEVICE_PRIVATE_FLAG_EXPLICIT_ORDER) == 0) {
 		GPtrArray *children = fu_device_get_children(self);

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -78,7 +78,7 @@ CounterpartGuid = PCI\VID_105B&PID_E0F9
 [USB\VID_2C7C&PID_0125]
 Summary = Quectel EG25-G/EC25 modem
 CounterpartGuid = USB\VID_18D1&PID_D00D
-Flags = detach-at-fastboot-has-no-response
+Flags = detach-at-fastboot-has-no-response,counterpart-visible
 ModemManagerBranchAtCommand = AT+GETFWBRANCH
 Plugin = modem_manager
 


### PR DESCRIPTION
Allow existing firmware to match the counterpart ID.

Fixes https://github.com/fwupd/fwupd/issues/8267

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
