### PR TITLE
trivial: drop requirement for `CI_NETWORK` variable in tests

### DIFF
--- a/plugins/acpi-dmar/fu-self-test.c
+++ b/plugins/acpi-dmar/fu-self-test.c
@@ -11,7 +11,6 @@
 static void
 fu_acpi_dmar_opt_in_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	gboolean ret;
 	g_autoptr(FuAcpiDmar) dmar = fu_acpi_dmar_new();
 	g_autoptr(GError) error = NULL;
@@ -19,7 +18,7 @@ fu_acpi_dmar_opt_in_func(void)
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "DMAR", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing DMAR");
 		return;
 	}
@@ -39,7 +38,6 @@ fu_acpi_dmar_opt_in_func(void)
 static void
 fu_acpi_dmar_opt_out_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	gboolean ret;
 	g_autoptr(FuAcpiDmar) dmar = fu_acpi_dmar_new();
 	g_autoptr(GError) error = NULL;
@@ -47,7 +45,7 @@ fu_acpi_dmar_opt_out_func(void)
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "DMAR-OPTOUT", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing DMAR-OPTOUT");
 		return;
 	}

--- a/plugins/acpi-facp/fu-self-test.c
+++ b/plugins/acpi-facp/fu-self-test.c
@@ -13,14 +13,13 @@
 static void
 fu_acpi_facp_s2i_disabled_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuAcpiFacp) facp = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GError) error = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "FACP", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing FACP");
 		return;
 	}
@@ -36,14 +35,13 @@ fu_acpi_facp_s2i_disabled_func(void)
 static void
 fu_acpi_facp_s2i_enabled_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autofree gchar *fn = NULL;
 	g_autoptr(FuAcpiFacp) facp = NULL;
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GError) error = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "FACP-S2I", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing FACP-S2I");
 		return;
 	}

--- a/plugins/acpi-ivrs/fu-self-test.c
+++ b/plugins/acpi-ivrs/fu-self-test.c
@@ -12,7 +12,6 @@
 static void
 fu_acpi_ivrs_dma_remap_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	gboolean ret;
 	g_autoptr(FuAcpiIvrs) ivrs = fu_acpi_ivrs_new();
 	g_autoptr(GError) error = NULL;
@@ -20,7 +19,7 @@ fu_acpi_ivrs_dma_remap_func(void)
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "IVRS-REMAP", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing IVRS-REMAP");
 		return;
 	}
@@ -40,7 +39,6 @@ fu_acpi_ivrs_dma_remap_func(void)
 static void
 fu_acpi_ivrs_no_dma_remap_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	gboolean ret;
 	g_autoptr(FuAcpiIvrs) ivrs = fu_acpi_ivrs_new();
 	g_autoptr(GError) error = NULL;
@@ -48,7 +46,7 @@ fu_acpi_ivrs_no_dma_remap_func(void)
 	g_autofree gchar *fn = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "IVRS-NOREMAP", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing IVRS-NOREMAP");
 		return;
 	}

--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -15,7 +15,6 @@ fu_ata_id_func(void)
 {
 	gboolean ret;
 	gsize sz;
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autofree gchar *data = NULL;
 	g_autofree gchar *path = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
@@ -27,7 +26,7 @@ fu_ata_id_func(void)
 	g_assert_true(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "StarDrive-SBFM61.2.bin", NULL);
-	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(path, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing StarDrive-SBFM61.2.bin");
 		return;
 	}
@@ -49,7 +48,6 @@ fu_ata_oui_func(void)
 {
 	gboolean ret;
 	gsize sz;
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autofree gchar *data = NULL;
 	g_autofree gchar *path = NULL;
 	g_autofree gchar *str = NULL;
@@ -62,7 +60,7 @@ fu_ata_oui_func(void)
 	g_assert_true(ret);
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "Samsung SSD 860 EVO 500GB.bin", NULL);
-	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(path, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing Samsung SSD 860 EVO 500GB.bin");
 		return;
 	}

--- a/plugins/nvme/fu-self-test.c
+++ b/plugins/nvme/fu-self-test.c
@@ -15,7 +15,6 @@ fu_nvme_cns_func(void)
 {
 	gboolean ret;
 	gsize sz;
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autofree gchar *data = NULL;
 	g_autofree gchar *path = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
@@ -28,7 +27,7 @@ fu_nvme_cns_func(void)
 
 	path = g_test_build_filename(G_TEST_DIST, "tests", "TOSHIBA_THNSN5512GPU7.bin", NULL);
 
-	if (!g_file_test(path, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(path, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing TOSHIBA_THNSN5512GPU7.bin");
 		return;
 	}

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -82,7 +82,6 @@ static void
 fu_plugin_synaptics_mst_none_func(void)
 {
 	gboolean ret;
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuPlugin) plugin = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
@@ -112,7 +111,7 @@ fu_plugin_synaptics_mst_none_func(void)
 	g_assert_true(ret);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "no_devices", NULL);
-	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(filename, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing no_devices");
 		return;
 	}
@@ -125,7 +124,6 @@ static void
 fu_plugin_synaptics_mst_tb16_func(void)
 {
 	gboolean ret;
-	const gchar *ci = g_getenv("CI_NETWORK");
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuPlugin) plugin = NULL;
@@ -156,7 +154,7 @@ fu_plugin_synaptics_mst_tb16_func(void)
 	g_assert_true(ret);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "tb16_dock", NULL);
-	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(filename, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing tb16_dock");
 		return;
 	}

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -13,7 +13,6 @@
 static void
 fu_test_synaprom_firmware_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	const guint8 *buf;
 	gboolean ret;
 	gsize sz = 0;
@@ -29,7 +28,7 @@ fu_test_synaprom_firmware_func(void)
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "test.pkg", NULL);
-	if (!g_file_test(filename, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(filename, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing test.pkg");
 		return;
 	}

--- a/plugins/tpm/fu-self-test.c
+++ b/plugins/tpm/fu-self-test.c
@@ -124,7 +124,6 @@ fu_tpm_device_2_0_func(void)
 static void
 fu_tpm_eventlog_parse_v1_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	const gchar *tmp;
 	gboolean ret;
 	gsize bufsz = 0;
@@ -135,7 +134,7 @@ fu_tpm_eventlog_parse_v1_func(void)
 	g_autoptr(GPtrArray) pcr0s = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "binary_bios_measurements-v1", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing binary_bios_measurements-v1");
 		return;
 	}
@@ -158,7 +157,6 @@ fu_tpm_eventlog_parse_v1_func(void)
 static void
 fu_tpm_eventlog_parse_v2_func(void)
 {
-	const gchar *ci = g_getenv("CI_NETWORK");
 	const gchar *tmp;
 	gboolean ret;
 	gsize bufsz = 0;
@@ -169,7 +167,7 @@ fu_tpm_eventlog_parse_v2_func(void)
 	g_autoptr(GPtrArray) pcr0s = NULL;
 
 	fn = g_test_build_filename(G_TEST_DIST, "tests", "binary_bios_measurements-v2", NULL);
-	if (!g_file_test(fn, G_FILE_TEST_EXISTS) && ci == NULL) {
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
 		g_test_skip("Missing binary_bios_measurements-v2");
 		return;
 	}


### PR DESCRIPTION
This should help coverage for any installed tests that are launched through gnome-desktop-test-runner.

If the files are missing they'll be skipped, just as before.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
