### PR TITLE
Run arch simulators during test phase

### DIFF
--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -1,7 +1,23 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
-pacman -Sy --noconfirm qt5-base gcovr
+pacman -Sy --noconfirm qt5-base gcovr python-flask swtpm tpm2-tools
 pacman -U --noconfirm dist/*.pkg.*
+
+# run custom redfish simulator
+plugins/redfish/tests/redfish.py &
+
+# run custom snapd simulator
+plugins/uefi-dbx/tests/snapd.py &
+
+# run TPM simulator
+#swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &
+#trap 'kill $!' EXIT
+# extend a PCR0 value for test suite
+#sleep 2
+#tpm2_startup -c
+#tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+# mark as disabled until it is fixed
+#export TPM_SERVER_RUNNING=1
 
 #run the CI tests for Qt5
 meson qt5-thread-test contrib/ci/qt5-thread-test --werror -Db_coverage=true

--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -27,23 +27,6 @@ cp -R ../../../!(build|dist) .
 popd
 chown nobody . -R
 
-# install dependencies for auxiliary simulators
-pacman -S --noconfirm python-flask
-# run custom redfish simulator
-../plugins/redfish/tests/redfish.py &
-# run custom snapd simulator
-../plugins/uefi-dbx/tests/snapd.py &
-
-# install and run TPM simulator necessary for plugins/uefi-capsule/uefi-self-test
-pacman -S --noconfirm swtpm tpm2-tools
-swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &
-trap 'kill $!' EXIT
-# extend a PCR0 value for test suite
-sleep 2
-tpm2_startup -c
-tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-export TPM_SERVER_RUNNING=1
-
 # build the package
 sudo -E -u nobody PKGEXT='.pkg.tar' makepkg -e --noconfirm --nocheck
 

--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -52,6 +52,7 @@ run_test nvme-self-test
 run_test optionrom-self-test
 run_test redfish-self-test
 run_test synaptics-prometheus-self-test
+run_test tpm-self-test
 run_test uefi-dbx-self-test
 run_test vli-self-test
 run_test wacom-usb-self-test

--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -46,6 +46,7 @@ run_test ata-self-test
 run_test dfu-self-test
 run_test fwupdplugin-self-test
 run_test linux-swap-self-test
+run_test logitech-hidpp-self-test
 run_test mtd-self-test
 run_test nitrokey-self-test
 run_test nvme-self-test

--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -40,22 +40,21 @@ run_umockdev_test()
 
 run_test acpi-dmar-self-test
 run_test acpi-facp-self-test
-run_test acpi-phat-self-test
 run_test acpi-ivrs-self-test
+run_test acpi-phat-self-test
 run_test ata-self-test
-run_test fwupdplugin-self-test
-run_test nitrokey-self-test
-run_test linux-swap-self-test
-run_test nvme-self-test
-run_test wacom-usb-self-test
-run_test redfish-self-test
-run_test optionrom-self-test
-run_test vli-self-test
-run_test uefi-dbx-self-test
-run_test synaptics-prometheus-self-test
 run_test dfu-self-test
+run_test fwupdplugin-self-test
+run_test linux-swap-self-test
 run_test mtd-self-test
+run_test nitrokey-self-test
+run_test nvme-self-test
+run_test optionrom-self-test
+run_test redfish-self-test
+run_test synaptics-prometheus-self-test
+run_test uefi-dbx-self-test
 run_test vli-self-test
+run_test wacom-usb-self-test
 run_device_tests
 run_umockdev_test fwupd_test.py
 run_umockdev_test pci_psp_test.py

--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -9,75 +9,76 @@ INPUT="@installedtestsdir@/fakedevice124.bin \
        @installedtestsdir@/fakedevice124.jcat \
        @installedtestsdir@/fakedevice124.metainfo.xml"
 DEVICE=08d460be0f1f9f128413f816022a6439e0078018
+FWUPDTOOL="fwupdtool -v"
 
 # ---
 echo "Show help output"
-fwupdtool --help
+${FWUPDTOOL} --help
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Show version output"
-fwupdtool --version
+${FWUPDTOOL} --version
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Showing hwids"
-fwupdtool hwids
+${FWUPDTOOL} hwids
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Showing plugins"
-fwupdtool -vv get-plugins
+${FWUPDTOOL} get-plugins
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Showing plugins (json)"
-fwupdtool get-plugins --json
+${FWUPDTOOL} get-plugins --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Enabling test device..."
-fwupdtool enable-test-devices
+${FWUPDTOOL} enable-test-devices
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Checking device-flags"
-fwupdtool -vv get-device-flags
+${FWUPDTOOL} get-device-flags
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Checking firmware-gtypes"
-fwupdtool -vv get-firmware-gtypes
+${FWUPDTOOL} get-firmware-gtypes
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Checking firmware-types"
-fwupdtool -vv get-firmware-types
+${FWUPDTOOL} get-firmware-types
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Checking for updates"
-fwupdtool -vv get-updates
+${FWUPDTOOL} get-updates
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Checking for updates"
-fwupdtool -vv get-updates --json
+${FWUPDTOOL} get-updates --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Building ${CAB}..."
-fwupdtool build-cabinet ${CAB} ${INPUT} --force
+${FWUPDTOOL} build-cabinet ${CAB} ${INPUT} --force
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Examining ${CAB}..."
-fwupdtool get-details ${CAB}
+${FWUPDTOOL} get-details ${CAB}
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Installing ${CAB} cabinet..."
-fwupdtool install ${CAB}
+${FWUPDTOOL} install ${CAB}
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
@@ -86,87 +87,87 @@ rm -f ${CAB}
 
 # ---
 echo "Verifying update..."
-fwupdtool verify-update ${DEVICE}
+${FWUPDTOOL} verify-update ${DEVICE}
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Getting history (should be one)..."
-fwupdtool get-history
+${FWUPDTOOL} get-history
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Clearing history..."
-fwupdtool clear-history ${DEVICE}
+${FWUPDTOOL} clear-history ${DEVICE}
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Getting history (should be none)..."
-fwupdtool get-history
+${FWUPDTOOL} get-history
 rc=$?; if [ $rc != 2 ]; then exit $rc; fi
 
 # ---
 echo "Resetting config..."
-fwupdtool reset-config test
+${FWUPDTOOL} reset-config test
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Testing good version compare"
-fwupdtool vercmp 1.0.0 1.0.0 triplet
+${FWUPDTOOL} vercmp 1.0.0 1.0.0 triplet
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Testing bad version compare"
-fwupdtool vercmp 1.0.0 1.0.1 foo
+${FWUPDTOOL} vercmp 1.0.0 1.0.1 foo
 rc=$?; if [ $rc != 1 ]; then exit $rc; fi
 
 # ---
 echo "Getting supported version formats..."
-fwupdtool get-version-formats --json
+${FWUPDTOOL} get-version-formats --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Getting the list of remotes"
-fwupdtool get-remotes --json
+${FWUPDTOOL} get-remotes --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Disabling LVFS remote..."
-fwupdtool modify-remote lvfs Enabled false
+${FWUPDTOOL} modify-remote lvfs Enabled false
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Enabling LVFS remote..."
-fwupdtool modify-remote lvfs Enabled true
+${FWUPDTOOL} modify-remote lvfs Enabled true
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Modify unknown remote (should fail)..."
-fwupdtool modify-remote foo Enabled true
+${FWUPDTOOL} modify-remote foo Enabled true
 rc=$?; if [ $rc != 1 ]; then exit $rc; fi
 
 # ---
 echo "Modify known remote but unknown key (should fail)..."
-fwupdtool modify-remote lvfs bar true
+${FWUPDTOOL} modify-remote lvfs bar true
 rc=$?; if [ $rc != 3 ]; then exit $rc; fi
 
 # ---
 echo "Getting devices (should be one)..."
-fwupdtool get-devices --json
+${FWUPDTOOL} get-devices --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Changing VALID config on test device..."
-fwupdtool modify-config test AnotherWriteRequired true
+${FWUPDTOOL} modify-config test AnotherWriteRequired true
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 # ---
 echo "Changing INVALID config on test device...(should fail)"
-fwupdtool modify-config test Foo true
+${FWUPDTOOL} modify-config test Foo true
 rc=$?; if [ $rc != 1 ]; then exit $rc; fi
 
 # ---
 echo "Disabling test device..."
-fwupdtool disable-test-devices
+${FWUPDTOOL} disable-test-devices
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
 BASEDIR=@installedtestsdir@/tests/bios-attrs/dell-xps13-9310/
@@ -176,37 +177,37 @@ if [ -d $BASEDIR ]; then
        export FWUPD_SYSFSFWATTRIBDIR=$WORKDIR/dell-xps13-9310/
        # ---
        echo "Get BIOS settings..."
-       fwupdtool get-bios-settings --json
+       ${FWUPDTOOL} get-bios-settings --json
        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
        # ---
        echo "Get BIOS setting as json..."
-       fwupdtool get-bios-settings WlanAutoSense --json
+       ${FWUPDTOOL} get-bios-settings WlanAutoSense --json
        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
        # ---
        echo "Get BIOS setting as a string..."
-       fwupdtool get-bios-settings WlanAutoSense
+       ${FWUPDTOOL} get-bios-settings WlanAutoSense
        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
        # ---
        echo "Modify BIOS setting to different value..."
-       fwupdtool set-bios-setting WlanAutoSense Enabled  --no-reboot-check
+       ${FWUPDTOOL} set-bios-setting WlanAutoSense Enabled  --no-reboot-check
        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
        # ---
        echo "Modify BIOS setting back to default..."
-       fwupdtool set-bios-setting WlanAutoSense Disabled  --no-reboot-check
+       ${FWUPDTOOL} set-bios-setting WlanAutoSense Disabled  --no-reboot-check
        rc=$?; if [ $rc != 0 ]; then exit $rc; fi
 
        # ---
        echo "Modify BIOS setting to bad value (should fail)..."
-       fwupdtool set-bios-setting WlanAutoSense foo  --no-reboot-check
+       ${FWUPDTOOL} set-bios-setting WlanAutoSense foo  --no-reboot-check
        rc=$?; if [ $rc != 1 ]; then exit $rc; fi
 
        # ---
        echo "Modify Unknown BIOS setting (should fail)..."
-       fwupdtool set-bios-setting foo bar  --no-reboot-check
+       ${FWUPDTOOL} set-bios-setting foo bar  --no-reboot-check
        rc=$?; if [ $rc != 3 ]; then exit $rc; fi
 fi
 
@@ -217,5 +218,5 @@ fi
 
 # ---
 echo "Refresh remotes"
-fwupdtool refresh --json
+${FWUPDTOOL} refresh --json
 rc=$?; if [ $rc != 0 ]; then exit $rc; fi

--- a/plugins/logitech-hidpp/meson.build
+++ b/plugins/logitech-hidpp/meson.build
@@ -53,6 +53,9 @@ if get_option('tests')
       plugin_libs,
       plugin_builtin_logitech_hidpp,
     ],
+    install: true,
+    install_rpath: libdir_pkg,
+    install_dir: installed_test_bindir,
     c_args: [
       cargs,
       '-DSRCDIR="' + meson.current_source_dir() + '"',

--- a/plugins/tpm/meson.build
+++ b/plugins/tpm/meson.build
@@ -54,12 +54,35 @@ if get_option('tests')
       fwupdplugin,
       plugin_builtin_tpm,
     ],
+    install: true,
+    install_rpath: libdir_pkg,
+    install_dir: installed_test_bindir,
     c_args: [
       cargs,
       '-DSRCDIR="' + meson.current_source_dir() + '"',
     ],
   )
   test('tpm-self-test', e, env: env)
+
+  install_data([
+      'tests/tpm0/active',
+      'tests/tpm0/caps',
+      'tests/tpm0/enabled',
+      'tests/tpm0/owned',
+      'tests/tpm0/pcrs',
+    ],
+    install_dir: join_paths(installed_test_datadir, 'tests', 'tpm0'),
+  )
+  install_data([
+      'tests/empty_pcr/tpm0/active',
+      'tests/empty_pcr/tpm0/caps',
+      'tests/empty_pcr/tpm0/enabled',
+      'tests/empty_pcr/tpm0/owned',
+      'tests/empty_pcr/tpm0/pcrs',
+    ],
+    install_dir: join_paths(installed_test_datadir, 'tests', 'empty_pcr', 'tpm0'),
+  )
+
 endif
 
 executable(


### PR DESCRIPTION
Coverage data is generated and captured in test phase not build phase.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
