### PR TITLE
trivial: ci: enable the TPM2.0 tests

### DIFF
--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -10,14 +10,12 @@ plugins/redfish/tests/redfish.py &
 plugins/uefi-dbx/tests/snapd.py &
 
 # run TPM simulator
-#swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &
-#trap 'kill $!' EXIT
+export TPM2TOOLS_TCTI=swtpm:host=127.0.0.1,port=2321
+swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init,startup-clear --tpmstate "dir=$PWD" &
+trap 'kill $!' EXIT
 # extend a PCR0 value for test suite
-#sleep 2
-#tpm2_startup -c
-#tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
-# mark as disabled until it is fixed
-#export TPM_SERVER_RUNNING=1
+sleep 2
+tpm2_pcrextend 0:sha1=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
 
 #run the CI tests for Qt5
 meson qt5-thread-test contrib/ci/qt5-thread-test --werror -Db_coverage=true

--- a/docs/env.md
+++ b/docs/env.md
@@ -31,7 +31,7 @@ with a non-standard filesystem layout.
 ## Self Tests
 
 * `CI_NETWORK` if CI is running with network access
-* `TPM_SERVER_RUNNING` if an emulated TPM is running
+* `TPM2TOOLS_TCTI` if a TPM2.0 TPM is available (even if emulated)
 * `UMOCKDEV_DIR` if set, running under umockdev
 
 Other variables, include:

--- a/plugins/tpm/fu-self-test.c
+++ b/plugins/tpm/fu-self-test.c
@@ -88,7 +88,7 @@ fu_tpm_device_2_0_func(void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) pcr0s = NULL;
 	g_autoptr(GPtrArray) pcrXs = NULL;
-	const gchar *tpm_server_running = g_getenv("TPM_SERVER_RUNNING");
+	const gchar *tpm_server_running = g_getenv("TPM2TOOLS_TCTI");
 	(void)g_setenv("FWUPD_FORCE_TPM2", "1", TRUE);
 
 #ifdef HAVE_GETUID


### PR DESCRIPTION
To judge a TPM is available use the TPM2TOOLS_TCTI, and set that in CI.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
