### PR TITLE
Fix an issue where UEFI capsule reboot_cleanup wasn't running

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1069,7 +1069,6 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 static gboolean
 fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 {
-	g_autofree gchar *esp_os_base = NULL;
 	g_autofree gchar *esp_path = NULL;
 	g_autofree gchar *pattern = NULL;
 	g_autoptr(FuDeviceLocker) esp_locker = NULL;
@@ -1093,8 +1092,7 @@ fu_uefi_capsule_plugin_cleanup_esp(FuUefiCapsulePlugin *self, GError **error)
 	files = fu_path_get_files(esp_path, error);
 	if (files == NULL)
 		return FALSE;
-	esp_os_base = fu_uefi_get_esp_path_for_os(esp_path);
-	pattern = g_build_filename(esp_path, esp_os_base, "fw", "fwupd*.cap", NULL);
+	pattern = g_build_filename("*", "fw", "fwupd*.cap", NULL);
 	for (guint i = 0; i < files->len; i++) {
 		const gchar *fn = g_ptr_array_index(files, i);
 		if (g_pattern_match_simple(pattern, fn)) {


### PR DESCRIPTION
VFAT is a little bit unusual for a filesystem in that it's case-insensitive. This means that if a distro happens to inconsistently use `EFI` vs `efi` cleanup may fail.

For me this happened on a system with a very small (~150MB) ESP, which meant that I couldn't run updates back to back without manually cleaning.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
