### PR TITLE
trivial: ci: pass a path to uefi-dbx test artifacts

### DIFF
--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -7,7 +7,7 @@ pacman -U --noconfirm dist/*.pkg.*
 plugins/redfish/tests/redfish.py &
 
 # run custom snapd simulator
-plugins/uefi-dbx/tests/snapd.py &
+plugins/uefi-dbx/tests/snapd.py --datadir /usr/share/installed-tests/fwupd/tests &
 
 # run TPM simulator
 #swtpm socket --tpm2 --server port=2321 --ctrl type=tcp,port=2322 --flags not-need-init --tpmstate "dir=$PWD" &


### PR DESCRIPTION
Pass a path to uefi-dbx test artifacts when running mock snapd API service.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Maybe fixes: #8327