### PR TITLE
amd-gpu: Split up the VBIOS P/N for the version

### DIFF
--- a/plugins/amd-gpu/tests/amd-apu.json
+++ b/plugins/amd-gpu/tests/amd-apu.json
@@ -6,7 +6,7 @@
       "emulation-file": "@enumeration_datadir@/amd-apu-setup.json",
       "components": [
         {
-          "version": "023.010.001.017.000001",
+          "version": "1",
           "guids": [
             "cc72cddc-68ef-5809-afce-bb1e5bcf571f"
           ]

--- a/plugins/amd-gpu/tests/amd-dgpu-navi3x.json
+++ b/plugins/amd-gpu/tests/amd-dgpu-navi3x.json
@@ -3,11 +3,11 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/732d1df025e809ee620fd411c9e8dcc488a492cf2bec3d0ea3ba5f43f7d91461-D704_XT_A0_20GB_MBA_NAVI31_Baseline_PRD004B_69818.cab",
+      "url": "https://fwupd.org/downloads/270e46249e7fb134ff3de616a3b30355e07bdc51b72bb1b05b63d5a5bd6b6dc8-D704_XT_A0_20GB_MBA_NAVI31_Baseline_PRD004B_69818.cab",
       "emulation-url": "https://fwupd.org/downloads/808f6a085f8a59a8db62d08921e786e15d252eb3cf5069ee4c0b991e4a250cf1-navi31.zip",
       "components": [
         {
-          "version": "022.001.002.030.000001",
+          "version": "114",
           "guids": [
             "8ed32270-e736-52e2-87d8-acef1dd2a946"
           ]

--- a/plugins/amd-gpu/tests/amd-dgpu.json
+++ b/plugins/amd-gpu/tests/amd-dgpu.json
@@ -6,7 +6,7 @@
       "emulation-file": "@enumeration_datadir@/amd-dgpu-setup.json",
       "components": [
         {
-          "version": "015.050.003.000.012636",
+          "version": "100",
           "guids": [
             "fec45400-2aa5-51b9-9bba-091bfb972433"
           ]


### PR DESCRIPTION
Recently there have been some cases that the amd-gpu plugin isn't showing update that /should/ be present. This is because the version string was being misinterpreted.

The version string is supposed to be populated by the VBIOS P/N not "the legacy" CSM version string.

A typical string is:

```
XXX-YYYYYYZZ-WWW
```

`XXX-YYYYYY` is used for matching a given board.  This is what was done as part of commit ea8ee1b69 ("amd-gpu: Only compare the first 10 characters of part number").

But the `WWW` is actually a collection of ALL firmware changes and will change any time the firmware is changed in ANY way.  It should be used to reflect the version.

Adjust the `setup()` callback to tokeninze the string and split it. If tokenization fails (such as on really old parts) then just show the CSM string as before.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
