### PR TITLE
trivial: Add missing `fwupd_install_flags_from_string()`

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -831,6 +831,43 @@ fwupd_version_format_to_string(FwupdVersionFormat kind)
 }
 
 /**
+ * fwupd_install_flags_from_string:
+ * @str: (nullable): a string, e.g. `allow-reinstall`
+ *
+ * Converts text to an install flag
+ *
+ * Returns: an enumerated install flag, e.g. %FWUPD_INSTALL_FLAG_ALLOW_REINSTALL
+ *
+ * Since: 2.0.4
+ **/
+FwupdInstallFlags
+fwupd_install_flags_from_string(const gchar *str)
+{
+	if (g_strcmp0(str, "none") == 0)
+		return FWUPD_INSTALL_FLAG_NONE;
+	if (g_strcmp0(str, "allow-reinstall") == 0)
+		return FWUPD_INSTALL_FLAG_ALLOW_REINSTALL;
+	if (g_strcmp0(str, "allow-older") == 0)
+		return FWUPD_INSTALL_FLAG_ALLOW_OLDER;
+	if (g_strcmp0(str, "force") == 0)
+		return FWUPD_INSTALL_FLAG_FORCE;
+	if (g_strcmp0(str, "no-history") == 0)
+		return FWUPD_INSTALL_FLAG_NO_HISTORY;
+	if (g_strcmp0(str, "allow-branch-switch") == 0)
+		return FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
+	if (g_strcmp0(str, "ignore-checksum") == 0)
+		return FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM;
+	if (g_strcmp0(str, "ignore-vid-pid") == 0)
+		return FWUPD_INSTALL_FLAG_IGNORE_VID_PID;
+	if (g_strcmp0(str, "no-search") == 0)
+		return FWUPD_INSTALL_FLAG_NO_SEARCH;
+	if (g_strcmp0(str, "ignore-requirements") == 0)
+		return FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS;
+
+	return FWUPD_INSTALL_FLAG_UNKNOWN;
+}
+
+/**
  * fwupd_install_flags_to_string:
  * @install_flags: a #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  *

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1395,6 +1395,8 @@ FwupdVersionFormat
 fwupd_version_format_from_string(const gchar *str);
 const gchar *
 fwupd_version_format_to_string(FwupdVersionFormat kind);
+FwupdInstallFlags
+fwupd_install_flags_from_string(const gchar *str);
 const gchar *
 fwupd_install_flags_to_string(FwupdInstallFlags install_flags);
 

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -128,6 +128,12 @@ fwupd_enums_func(void)
 			break;
 		g_assert_cmpint(fwupd_remote_flag_from_string(tmp), ==, i);
 	}
+	for (guint64 i = 1; i <= FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS; i *= 2) {
+		const gchar *tmp = fwupd_install_flags_to_string(i);
+		if (tmp == NULL)
+			continue;
+		g_assert_cmpint(fwupd_install_flags_from_string(tmp), ==, i);
+	}
 }
 
 static void

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1000,3 +1000,9 @@ LIBFWUPD_2.0.2 {
     fwupd_remote_set_firmware_base_uri;
   local: *;
 } LIBFWUPD_2.0.1;
+
+LIBFWUPD_2.0.4 {
+  global:
+    fwupd_install_flags_from_string;
+  local: *;
+} LIBFWUPD_2.0.2;


### PR DESCRIPTION
Unlike other libfwupd enums `fwupd_install_flags_to_string()` is missing the matching function to convert back.  Add that function and test coverage for both.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
