### PR TITLE
(backport) qc-s5gen2: added custom GUID for USB devices

### DIFF
--- a/plugins/audio-s5gen2/README.md
+++ b/plugins/audio-s5gen2/README.md
@@ -23,6 +23,12 @@ These devices use the standard  DeviceInstanceId values, e.g.
 
 * `USB\VID_0A12&PID_4007`
 
+Pair 0A12:4007 is shared among vendors and shouldn't be used for the single device.
+Also these devices use a custom GUID generation scheme, please use GUID based on
+manufacturer and product names in case of shared VID:PID pair:
+
+* `USB\VID_0A12&PID_4007&MANUFACTURER_{iManufacturer}&PRODUCT_{iProduct}`
+
 ## Update Behavior
 
 The device is updated in runtime mode and rebooted with a new version.

--- a/plugins/audio-s5gen2/audio-s5gen2.quirk
+++ b/plugins/audio-s5gen2/audio-s5gen2.quirk
@@ -1,7 +1,7 @@
 # 5171 devboard
 [USB\VID_0A12&PID_4007]
 Plugin = audio_s5gen2
-Flags = enforce-requires
+Flags = no-generic-guids
 ProxyGType = FuQcS5gen2HidDevice
 
 # GID8 headset


### PR DESCRIPTION
Backported from commit 2e7d708654bda112a7b3d8df2ced3fbc365e58e8:
- used GUsb, see https://github.com/fwupd/fwupd/pull/7412
- GUID is correct, but `fwupd` doesn't show the appropriate instance ID
  fixed in https://github.com/fwupd/fwupd/pull/8250, but not backported

```
└─CCC5171X:
      Device ID:          c0170efdf195b8590000fa21474253c0d97e7335
      Current version:    1.0.1
      Vendor:             Collabora (USB:0x0A12)
      Serial Number:      5B23541510FF00B52000
      GUID:               bf2dbb2f-2174-5041-a77b-0661e752f3ac
      Device Flags:       • Updatable
                          • Device stages updates
                          • Device can recover flash failures
                          • Device is usable for the duration of the update
                          • Signed Payload
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
