### PR TITLE
trivial: fix build with uclibc

### DIFF
--- a/libfwupdplugin/fu-block-device.c
+++ b/libfwupdplugin/fu-block-device.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #ifdef HAVE_SCSI_SG_H
+#include <stddef.h>
 #include <scsi/sg.h>
 #endif
 

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include <stddef.h>
 #include <scsi/sg.h>
 
 #include "fu-ata-device.h"

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include <stddef.h>
 #include <scsi/sg.h>
 
 #include "fu-scsi-device.h"


### PR DESCRIPTION
We need to include stddef.h before scsi/sg.h for builds to work with uclibc.

Fixes:
```c
In file included from ../libfwupdplugin/fu-block-device.c:12:
/usr/include/scsi/sg.h:38:3: error: unknown type name ‘size_t’
   38 |   size_t iov_len;             /* Length in bytes  */
      |   ^~~~~~
```
```c
In file included from ../plugins/ata/fu-ata-device.c:9:
/usr/include/scsi/sg.h:38:3: error: unknown type name ‘size_t’
   38 |   size_t iov_len;             /* Length in bytes  */
      |   ^~~~~~
```
```c
In file included from ../plugins/scsi/fu-scsi-device.c:9:
/usr/include/scsi/sg.h:38:3: error: unknown type name ‘size_t’
   38 |   size_t iov_len;             /* Length in bytes  */
      |   ^~~~~~
```
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
