### PR TITLE
trivial: Remove fu_common_is_live_media()

### DIFF
--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -93,40 +93,6 @@ fu_cpu_get_vendor(void)
 }
 
 /**
- * fu_common_is_live_media:
- *
- * Checks if the user is running from a live media using various heuristics.
- *
- * Returns: %TRUE if live
- *
- * Since: 1.4.6
- **/
-gboolean
-fu_common_is_live_media(void)
-{
-	gsize bufsz = 0;
-	g_autofree gchar *buf = NULL;
-	g_auto(GStrv) tokens = NULL;
-	const gchar *args[] = {
-	    "rd.live.image",
-	    "boot=live",
-	    NULL, /* last entry */
-	};
-	if (g_file_test("/cdrom/.disk/info", G_FILE_TEST_EXISTS))
-		return TRUE;
-	if (!g_file_get_contents("/proc/cmdline", &buf, &bufsz, NULL))
-		return FALSE;
-	if (bufsz <= 1)
-		return FALSE;
-	tokens = fu_strsplit(buf, bufsz - 1, " ", -1);
-	for (guint i = 0; args[i] != NULL; i++) {
-		if (g_strv_contains((const gchar *const *)tokens, args[i]))
-			return TRUE;
-	}
-	return FALSE;
-}
-
-/**
  * fu_common_get_memory_size:
  *
  * Returns the size of physical memory.

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -94,8 +94,6 @@ fu_cpuid(guint32 leaf, guint32 *eax, guint32 *ebx, guint32 *ecx, guint32 *edx, G
     G_GNUC_WARN_UNUSED_RESULT;
 FuCpuVendor
 fu_cpu_get_vendor(void);
-gboolean
-fu_common_is_live_media(void);
 guint64
 fu_common_get_memory_size(void);
 gchar *

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -295,13 +295,6 @@ main(int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 
-		/* check if on live media */
-		if (fu_common_is_live_media() && !force) {
-			/* TRANSLATORS: the user is using a LiveCD or LiveUSB install disk */
-			g_printerr("%s\n", _("Cannot apply updates on live media"));
-			return EXIT_FAILURE;
-		}
-
 		/* validate this is safe to apply */
 		if (!force) {
 			/* TRANSLATORS: ESP refers to the EFI System Partition */

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -262,8 +262,7 @@ fu_uefi_dbx_device_init(FuUefiDbxDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_ONLY_CHECKSUM);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_VERSION);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_HOST_FIRMWARE_CHILD);
-	if (!fu_common_is_live_media())
-		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	g_signal_connect(FWUPD_DEVICE(self),
 			 "notify::version",
 			 G_CALLBACK(fu_uefi_dbx_device_version_notify_cb),


### PR DESCRIPTION
We now check *all* ESPs, and so we don't need the additional check.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
