### PR TITLE
Raise authentication requirements for emulation-load

### DIFF
--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -259,7 +259,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
 


### PR DESCRIPTION
Allowing this operation for local users without admin authentication seems unnecessary. Raise the setting to `auth_admin` as for the other emulation related actions.

Link: https://github.com/fwupd/fwupd/issues/8360

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
