### PR TITLE
Add PlatformArchitecture to collect the userspace architecture

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -358,6 +358,9 @@ endif
 libsystemd = dependency('libsystemd',
                         required: get_option('systemd').disable_auto_if(host_machine.system() != 'linux'))
 
+if cc.has_header('sys/auxv.h')
+  conf.set('HAVE_AUXV_H', '1')
+endif
 if cc.has_header('sys/utsname.h')
   conf.set('HAVE_UTSNAME_H', '1')
 endif

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -21,6 +21,9 @@
 #ifdef HAVE_UTSNAME_H
 #include <sys/utsname.h>
 #endif
+#ifdef HAVE_AUXV_H
+#include <sys/auxv.h>
+#endif
 #include <errno.h>
 
 #ifdef _WIN32
@@ -1966,6 +1969,13 @@ fu_engine_get_report_metadata(FuEngine *self, GError **error)
 		g_hash_table_insert(hash, g_strdup("KernelName"), g_strdup(name_tmp.sysname));
 		g_hash_table_insert(hash, g_strdup("KernelVersion"), g_strdup(name_tmp.release));
 	}
+#endif
+#ifdef HAVE_AUXV_H
+	/* this is the architecture of the userspace, e.g. i686 would be returned for
+	 * glibc-2.40-17.fc41.i686 on kernel-6.12.9-200.fc41.x86_64 */
+	g_hash_table_insert(hash,
+			    g_strdup("PlatformArchitecture"),
+			    g_strdup((const gchar *)getauxval(AT_PLATFORM)));
 #endif
 
 	/* add the kernel boot time so we can detect a reboot */


### PR DESCRIPTION
For example, `i686` would be returned for `glibc-2.40-17.fc41.i686` on `kernel-6.12.9-200.fc41.x86_64`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
