### PR TITLE
Use the kernel architecture when building the dbx instance ID

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -482,22 +482,6 @@ endif
 if build_standalone
   efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
   conf.set_quoted('EFI_APP_LOCATION', efi_app_location)
-  if host_cpu == 'x86'
-    EFI_MACHINE_TYPE_NAME = 'ia32'
-  elif host_cpu == 'x86_64'
-    EFI_MACHINE_TYPE_NAME = 'x64'
-  elif host_cpu == 'arm'
-    EFI_MACHINE_TYPE_NAME = 'arm'
-  elif host_cpu == 'aarch64'
-    EFI_MACHINE_TYPE_NAME = 'aa64'
-  elif host_cpu == 'loongarch64'
-    EFI_MACHINE_TYPE_NAME = 'loongarch64'
-  elif host_cpu == 'riscv64'
-    EFI_MACHINE_TYPE_NAME = 'riscv64'
-  else
-    EFI_MACHINE_TYPE_NAME = ''
-  endif
-  conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
 endif
 
 flashrom = get_option('plugin_flashrom').disable_auto_if(host_machine.system() != 'linux')

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.c
@@ -6,7 +6,39 @@
 
 #include "config.h"
 
+#ifdef HAVE_UTSNAME_H
+#include <sys/utsname.h>
+#endif
+
 #include "fu-uefi-dbx-common.h"
+
+const gchar *
+fu_uefi_dbx_get_efi_arch(void)
+{
+#ifdef HAVE_UTSNAME_H
+	struct utsname name_tmp;
+	struct {
+		const gchar *arch;
+		const gchar *arch_efi;
+	} map[] = {
+	    {"x86", "ia32"},
+	    {"x86_64", "x64"},
+	    {"arm", "arm"},
+	    {"aarch64", "aa64"},
+	    {"loongarch64", "loongarch64"},
+	    {"riscv64", "riscv64"},
+	};
+
+	memset(&name_tmp, 0, sizeof(struct utsname));
+	if (uname(&name_tmp) < 0)
+		return NULL;
+	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
+		if (g_strcmp0(name_tmp.machine, map[i].arch) == 0)
+			return map[i].arch_efi;
+	}
+#endif
+	return NULL;
+}
 
 static gchar *
 fu_uefi_dbx_get_authenticode_hash(const gchar *fn, GError **error)

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.h
@@ -8,6 +8,8 @@
 
 #include <fwupdplugin.h>
 
+const gchar *
+fu_uefi_dbx_get_efi_arch(void);
 gboolean
 fu_uefi_dbx_signature_list_validate(FuContext *ctx,
 				    FuEfiSignatureList *siglist,

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -205,7 +205,7 @@ fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 		return FALSE;
 	if (!fu_firmware_parse_bytes(kek, kek_blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
 		return FALSE;
-	fu_device_add_instance_strup(device, "ARCH", EFI_MACHINE_TYPE_NAME);
+	fu_device_add_instance_strup(device, "ARCH", fu_uefi_dbx_get_efi_arch());
 
 	sigs = fu_firmware_get_images(kek);
 	for (guint j = 0; j < sigs->len; j++) {


### PR DESCRIPTION
The dbx is updated using a kernel interface, and the platform architecture (e.g. is using 32 bit glibc) is not relevant.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
