### PR TITLE
uefi-dbx: inhibit dbx updates when on an ubuntu-style FDE system

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1020,12 +1020,17 @@ fu_context_detect_full_disk_encryption(FuContext *self)
 		GDBusProxy *proxy = g_ptr_array_index(devices, i);
 		g_autoptr(GVariant) id_type = g_dbus_proxy_get_cached_property(proxy, "IdType");
 		g_autoptr(GVariant) device = g_dbus_proxy_get_cached_property(proxy, "Device");
-		if (id_type == NULL || device == NULL)
-			continue;
-		if (g_strcmp0(g_variant_get_string(id_type, NULL), "BitLocker") == 0)
+		g_autoptr(GVariant) id_label = g_dbus_proxy_get_cached_property(proxy, "IdLabel");
+		if (id_type != NULL && device != NULL &&
+		    g_strcmp0(g_variant_get_string(id_type, NULL), "BitLocker") == 0)
 			priv->flags |= FU_CONTEXT_FLAG_FDE_BITLOCKER;
+
+		if (id_type != NULL && id_label != NULL &&
+		    g_strcmp0(g_variant_get_string(id_label, NULL), "ubuntu-data-enc") == 0 &&
+		    g_strcmp0(g_variant_get_string(id_type, NULL), "crypto_LUKS") == 0) {
+			priv->flags |= FU_CONTEXT_FLAG_FDE_SNAPD;
+		}
 	}
-	/* TODO identify Ubuntu Core FDE volumes */
 }
 
 static void

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -136,6 +136,14 @@ typedef enum {
 	 * Since: 2.0.5
 	 **/
 	FU_CONTEXT_FLAG_FDE_BITLOCKER = 1u << 4,
+	/**
+	 * FU_CONTEXT_FLAG_FDE_SNAPD:
+	 *
+	 * Snapd style full disk encryption is in use
+	 *
+	 * Since: 2.0.5
+	 **/
+	FU_CONTEXT_FLAG_FDE_SNAPD = 1u << 5,
 
 	/**
 	 * FU_CONTEXT_FLAG_LOADED_UNKNOWN:

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -35,14 +35,9 @@ fu_uefi_dbx_plugin_device_created(FuPlugin *plugin, FuDevice *device, GError **e
 	if (self->snapd_notifier != NULL) {
 		fu_uefi_dbx_device_set_snapd_notifier(FU_UEFI_DBX_DEVICE(device),
 						      self->snapd_notifier);
-	} else if (!inhibited && self->snapd_integration_supported && fu_snap_is_in_snap()) {
-		/* we're running inside a snap, the device is not inhibited and snapd
-		 * supports integration, in which case this is a hard error and we
-		 * should not give an option to dbx */
-
-		/* TODO should check for FDE flag, otherwise in a system where DBX is
-		measured during the boot, updating it without notifying snapd
-		can result in failed boot or needing to use recovery keys */
+	} else if (!inhibited && self->snapd_integration_supported) {
+		/* if snapd integration is supported, but we are unable to use the snapd notifier,
+		then we should inhibit the update if it isn't already inhibited */
 		fu_device_inhibit(FU_DEVICE(device),
 				  "no-snapd-dbx",
 				  "Snapd integration for DBX update is not available");
@@ -87,29 +82,29 @@ fu_uefi_dbx_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	g_autoptr(FuVolume) esp = NULL;
 	g_autoptr(GError) error_udisks2 = NULL;
+	FuUefiDbxPlugin *self = FU_UEFI_DBX_PLUGIN(plugin);
+	FuContext *ctx = fu_plugin_get_context(plugin);
 
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_capsule");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EFI_SIGNATURE_LIST);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DBX_DEVICE);
 
-	if (fu_snap_is_in_snap()) {
-		FuUefiDbxPlugin *self = FU_UEFI_DBX_PLUGIN(plugin);
+	/* only enable snapd integration if either running inside a snap or we detect that this is a
+	snapd FDE setup. either of these cases makes snapd integration mandatory */
+	if (fu_snap_is_in_snap() || fu_context_has_flag(ctx, FU_CONTEXT_FLAG_FDE_SNAPD)) {
 		g_autoptr(GError) error_local = NULL;
-		/* only enable snapd integration if running inside a snap */
 		if (!fu_uefi_dbx_plugin_snapd_notify_init(FU_UEFI_DBX_PLUGIN(obj), &error_local)) {
-			/* specific error code if relevant APIs are not present and thus
-			 * integration cannot be supported */
+			/* unless we got specific error code indicating lack of relevant APIs, snapd
+			integration is considered to be supported, even if snapd itself cannot be
+			reached */
 			self->snapd_integration_supported =
 			    !g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 
 			g_info("snapd integration non-functional: %s", error_local->message);
 		} else {
-			g_info("snapd integration enabled ");
+			g_info("snapd integration enabled");
 			self->snapd_integration_supported = TRUE;
 		}
-	} else {
-		/* TODO figure out non-snap scenarios */
-		g_info("snapd integration outside of snap is not supported");
 	}
 
 	/* ensure that an ESP was found */

--- a/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-snapd-notifier.c
@@ -30,15 +30,12 @@ fu_uefi_dbx_snapd_notifier_new(void)
 static void
 fu_uefi_dbx_snapd_notifier_init(FuUefiDbxSnapdNotifier *self)
 {
-	/* default path for use inside the snap sandbox */
-	const char *snapd_snap_socket = "/run/snapd-snap.socket";
+	/* default path is different inside the snap sandbox vs out */
+	const char *snapd_snap_socket = fu_snap_is_in_snap() ? "/run/snapd-snap.socket"
+							     : "/run/snapd.socket";
 	const char *snapd_snap_socket_override = g_getenv("FWUPD_SNAPD_SNAP_SOCKET");
 
 	self->curl_template = curl_easy_init();
-
-	/* TODO support system wide snapd socket for outside of snap scenarios */
-	if (!fu_snap_is_in_snap())
-		g_warning("attempted use of snapd notifier outside of snap");
 
 	if (snapd_snap_socket_override != NULL)
 		snapd_snap_socket = snapd_snap_socket_override;


### PR DESCRIPTION
This PR builds on the work that was started in https://github.com/fwupd/fwupd/pull/8210.

This change makes it so we can inhibit DBX updates on systems where fwupd isn't running inside of a snap. To determine if we should inhibit the update, we check if there are any `crypto_LUKS` partitions with an `ubuntu-data-enc` label. The existence of this should indicate an Ubuntu-style FDE system, which requires fwupd to coordinate with snapd to ensure that the system remains bootable.

Note that this may incur some false positives, given that it is possible for a user to have a LUKS partition with that label while not on a system where snapd is managing the FDE setup.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
