### PR TITLE
thunderbolt: Reload the retimer version after the payload is deployed

### DIFF
--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -57,6 +57,33 @@ If a user sets `DelayedActivation` configuration option then the update will
 be staged but not completed until `activate` is separately called such as at
 logout or shutdown.
 
+### USB4 Retimer
+
+To update the retimer userspace need to set the port offline (`echo 1 > offline`), and then
+rescan it (`echo 1 > rescan`).
+This will cause the retimer to be visible to the OS, it will be added to sysfs and thus a fwupd
+`FuThunderboltRetimer` device will be created.
+
+If the system is on AC power, and the controller is offlined, the system will think that is has
+been unplugged and so the fwupd plugin should inhibit the system power change until the controller
+is onlined with `echo 0 > offline`.
+
+When the controller is offlined (perhaps after enumeration), the retimer device will disappear
+from sysfs which is why the device flag `no-auto-remove` is required.
+
+A further complication is that userspace needs to re-start the retimer to get the new version
+number, for example:
+
+* `1->offline`
+* `->write_firmware()`
+* `0->offline ()`
+* Retimer gets removed, which fwupd should ignore, due to no-auto-remove
+* `1->offline`
+* `1->rescan`
+* Retimer gets added
+* `1->online`
+* Retimer gets removed, which fwupd should ignore again
+
 ## Vendor ID Security
 
 The vendor ID is set from the udev vendor, for example set to `TBT:0x$(vid)`

--- a/plugins/thunderbolt/fu-thunderbolt-common.h
+++ b/plugins/thunderbolt/fu-thunderbolt-common.h
@@ -17,5 +17,7 @@ gboolean
 fu_thunderbolt_udev_set_port_online(FuUdevDevice *device, GError **error);
 gboolean
 fu_thunderbolt_udev_set_port_offline(FuUdevDevice *device, GError **error);
+gboolean
+fu_thunderbolt_udev_rescan_port(FuUdevDevice *device, GError **error);
 guint16
 fu_thunderbolt_udev_get_attr_uint16(FuUdevDevice *device, const gchar *name, GError **error);

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -190,6 +190,8 @@ fu_thunderbolt_controller_setup_usb4(FuThunderboltController *self, GError **err
 {
 	if (!fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(self), error))
 		return FALSE;
+	if (!fu_thunderbolt_udev_rescan_port(FU_UDEV_DEVICE(self), error))
+		return FALSE;
 	if (self->host_online_timer_id > 0)
 		g_source_remove(self->host_online_timer_id);
 	self->host_online_timer_id =
@@ -215,6 +217,15 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 		g_debug("unable to read generation: %s", error_gen->message);
 	if (self->gen >= 4)
 		fu_thunderbolt_device_set_retries(FU_THUNDERBOLT_DEVICE(self), 1);
+
+	/* discover retimers */
+	if (self->controller_kind == FU_THUNDERBOLT_CONTROLLER_KIND_HOST &&
+	    fu_device_has_private_flag(FU_DEVICE(self),
+				       FU_THUNDERBOLT_DEVICE_FLAG_FORCE_ENUMERATION)) {
+		g_autoptr(GError) error_local = NULL;
+		if (!fu_thunderbolt_controller_setup_usb4(self, &error_local))
+			g_warning("failed to setup host: %s", error_local->message);
+	}
 
 	/* try to read the version */
 	if (!fu_thunderbolt_device_get_version(FU_THUNDERBOLT_DEVICE(self), &error_version)) {
@@ -327,13 +338,6 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 		fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_INSTALL_PARENT_FIRST);
 	} else {
 		fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
-	}
-	if (self->controller_kind == FU_THUNDERBOLT_CONTROLLER_KIND_HOST &&
-	    fu_device_has_private_flag(FU_DEVICE(self),
-				       FU_THUNDERBOLT_DEVICE_FLAG_FORCE_ENUMERATION)) {
-		g_autoptr(GError) error_local = NULL;
-		if (!fu_thunderbolt_controller_setup_usb4(self, &error_local))
-			g_warning("failed to setup host: %s", error_local->message);
 	}
 
 	/* set up signed payload attribute */

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -17,9 +17,6 @@ struct _FuThunderboltPlugin {
 
 G_DEFINE_TYPE(FuThunderboltPlugin, fu_thunderbolt_plugin, FU_TYPE_PLUGIN)
 
-/* 5 seconds sleep until retimer is available after nvm update */
-#define FU_THUNDERBOLT_RETIMER_CLEANUP_DELAY 5000 /* ms */
-
 static gboolean
 fu_thunderbolt_plugin_safe_kernel(FuPlugin *plugin, GError **error)
 {

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.c
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.c
@@ -26,7 +26,9 @@ fu_thunderbolt_retimer_set_parent_port_offline(FuDevice *device, GError **error)
 							error);
 	if (parent == NULL)
 		return FALSE;
-	return fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(parent), error);
+	if (!fu_thunderbolt_udev_set_port_offline(FU_UDEV_DEVICE(parent), error))
+		return FALSE;
+	return fu_thunderbolt_udev_rescan_port(FU_UDEV_DEVICE(parent), error);
 }
 
 gboolean
@@ -51,6 +53,43 @@ fu_thunderbolt_retimer_probe(FuDevice *device, GError **error)
 	if (physical_id != NULL)
 		fu_device_set_physical_id(device, physical_id);
 
+	return TRUE;
+}
+
+static gboolean
+fu_thunderbolt_retimer_reload(FuDevice *device, GError **error)
+{
+	/* get version */
+	if (!fu_thunderbolt_udev_rescan_port(FU_UDEV_DEVICE(device), error))
+		return FALSE;
+	if (!fu_thunderbolt_device_get_version(FU_THUNDERBOLT_DEVICE(device), error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_thunderbolt_retimer_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	/* FuThunderboltDevice->attach for nvm_authenticate */
+	if (!FU_DEVICE_CLASS(fu_thunderbolt_retimer_parent_class)->attach(device, progress, error))
+		return FALSE;
+
+	/* online */
+	fu_device_sleep(device, FU_THUNDERBOLT_RETIMER_CLEANUP_DELAY);
+	if (!fu_thunderbolt_retimer_set_parent_port_online(device, error))
+		return FALSE;
+
+	/* retimer gets removed, which we ignore, due to no-auto-remove */
+	fu_device_sleep(device, 1000);
+
+	/* get the new retimer firmware version by rescanning */
+	if (!fu_thunderbolt_retimer_set_parent_port_offline(device, error))
+		return FALSE;
+
+	/* wait for it to re-appear */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 
@@ -114,6 +153,8 @@ static void
 fu_thunderbolt_retimer_class_init(FuThunderboltRetimerClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->attach = fu_thunderbolt_retimer_attach;
 	device_class->setup = fu_thunderbolt_retimer_setup;
+	device_class->reload = fu_thunderbolt_retimer_reload;
 	device_class->probe = fu_thunderbolt_retimer_probe;
 }

--- a/plugins/thunderbolt/fu-thunderbolt-retimer.h
+++ b/plugins/thunderbolt/fu-thunderbolt-retimer.h
@@ -18,6 +18,9 @@ G_DECLARE_FINAL_TYPE(FuThunderboltRetimer,
 		     THUNDERBOLT_RETIMER,
 		     FuThunderboltDevice)
 
+/* 5 seconds sleep until retimer is available after nvm update */
+#define FU_THUNDERBOLT_RETIMER_CLEANUP_DELAY 5000 /* ms */
+
 gboolean
 fu_thunderbolt_retimer_set_parent_port_offline(FuDevice *device, GError **error);
 

--- a/plugins/thunderbolt/thunderbolt.quirk
+++ b/plugins/thunderbolt/thunderbolt.quirk
@@ -13,3 +13,7 @@ Flags = retimer-offline-mode
 # Google Rex
 [​​fe682559-28dc-58b3-bf61-aa8414d9f363]
 Flags = retimer-offline-mode
+
+# Google Screebo
+[967000fc-42df-5a17-a0a2-70a43738e78b]
+Flags = retimer-offline-mode


### PR DESCRIPTION
Also, discover retimers even if the host controller is not-updatable.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
