### PR TITLE
Move FDE detection into the context

### DIFF
--- a/data/tests/fwupd.sh.orig
+++ b/data/tests/fwupd.sh.orig
@@ -21,6 +21,7 @@ run_device_tests()
 				--no-metadata-check \
 				"$f"
 		done
+		fwupdmgr quit
 	fi
 }
 

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -124,47 +124,6 @@ fu_common_get_kernel_cmdline(GError **error)
 }
 
 /**
- * fu_common_check_full_disk_encryption:
- * @error: (nullable): optional return location for an error
- *
- * Checks that all FDE volumes are not going to be affected by a firmware update. If unsure,
- * return with failure and let the user decide.
- *
- * Returns: %TRUE for success
- *
- * Since: 1.7.1
- **/
-gboolean
-fu_common_check_full_disk_encryption(GError **error)
-{
-	g_autoptr(GPtrArray) devices = NULL;
-
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-	devices = fu_common_get_block_devices(error);
-	if (devices == NULL)
-		return FALSE;
-	for (guint i = 0; i < devices->len; i++) {
-		GDBusProxy *proxy = g_ptr_array_index(devices, i);
-		g_autoptr(GVariant) id_type = g_dbus_proxy_get_cached_property(proxy, "IdType");
-		g_autoptr(GVariant) device = g_dbus_proxy_get_cached_property(proxy, "Device");
-		if (id_type == NULL || device == NULL)
-			continue;
-		if (g_strcmp0(g_variant_get_string(id_type, NULL), "BitLocker") == 0) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_AUTH_EXPIRED,
-				    "%s device %s is encrypted",
-				    g_variant_get_string(id_type, NULL),
-				    g_variant_get_bytestring(device));
-			return FALSE;
-		}
-		/* TODO identify Ubuntu Core FDE volumes */
-	}
-	return TRUE;
-}
-
-/**
  * fu_common_get_olson_timezone_id:
  * @error: (nullable): optional return location for an error
  *

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -98,8 +98,6 @@ guint64
 fu_common_get_memory_size(void);
 gchar *
 fu_common_get_kernel_cmdline(GError **error);
-gboolean
-fu_common_check_full_disk_encryption(GError **error);
 gchar *
 fu_common_get_olson_timezone_id(GError **error);
 

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -129,6 +129,15 @@ typedef enum {
 	 **/
 	FU_CONTEXT_FLAG_INHIBIT_VOLUME_MOUNT = 1u << 3,
 	/**
+	 * FU_CONTEXT_FLAG_FDE_BITLOCKER:
+	 *
+	 * Bitlocker style full disk encryption is in use
+	 *
+	 * Since: 2.0.5
+	 **/
+	FU_CONTEXT_FLAG_FDE_BITLOCKER = 1u << 4,
+
+	/**
 	 * FU_CONTEXT_FLAG_LOADED_UNKNOWN:
 	 *
 	 * Unknown flag value.

--- a/patch
+++ b/patch
@@ -1,0 +1,24 @@
+diff --git a/data/tests/fwupd.sh b/data/tests/fwupd.sh
+index cbab49d31..4c23f3767 100755
+--- a/data/tests/fwupd.sh
++++ b/data/tests/fwupd.sh
+@@ -21,7 +21,6 @@ run_device_tests()
+                                --no-metadata-check \
+                                "$f"
+                done
+-               fwupdmgr quit
+        fi
+ }
+
+@@ -58,9 +57,10 @@ run_test tpm-self-test
+ run_test uefi-dbx-self-test
+ run_test vli-self-test
+ run_test wacom-usb-self-test
+-run_device_tests
+ run_umockdev_test fwupd_test.py
+ run_umockdev_test pci_psp_test.py
++run_device_tests
++fwupdmgr quit
+
+ # success!
+ exit 0

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -988,6 +988,7 @@ static gboolean
 fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	FuUefiCapsulePlugin *self = FU_UEFI_CAPSULE_PLUGIN(plugin);
+	FuContext *ctx = fu_plugin_get_context(plugin);
 	const gchar *str;
 	gboolean has_fde = FALSE;
 	g_autoptr(GError) error_fde = NULL;
@@ -1016,10 +1017,8 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 	fu_progress_step_done(progress);
 
 	/*  warn the user that BitLocker might ask for recovery key after fw update */
-	if (!fu_common_check_full_disk_encryption(&error_fde)) {
-		g_debug("FDE in use, set flag: %s", error_fde->message);
+	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_FDE_BITLOCKER))
 		has_fde = TRUE;
-	}
 	fu_progress_step_done(progress);
 
 	/* add each device */

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -195,6 +195,7 @@ static gboolean
 fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 {
 	FuUefiDbxDevice *self = FU_UEFI_DBX_DEVICE(device);
+	FuContext *ctx = fu_device_get_context(device);
 	g_autoptr(FuFirmware) kek = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error_fde = NULL;
@@ -228,10 +229,8 @@ fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 
 	/* dbx changes are expected to change PCR7, warn the user that BitLocker might ask for
 	recovery key after fw update */
-	if (!fu_common_check_full_disk_encryption(&error_fde)) {
-		g_debug("FDE in use, set flag: %s", error_fde->message);
+	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_FDE_BITLOCKER))
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_AFFECTS_FDE);
-	}
 
 	return fu_uefi_dbx_device_ensure_checksum(self, error);
 }


### PR DESCRIPTION
Whether FDE is detected won't change for the lifecycle of the daemon run and multiple plugins use it.

Move the detection into the context and then let plugins get the information from the context.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
