### PR TITLE
trivial: explicitly set the device for a release when getting history

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4746,6 +4746,8 @@ fu_engine_fixup_history_device(FuEngine *self, FuDevice *device)
 				g_warning("failed to load component: %s", error_local->message);
 				continue;
 			}
+			fu_release_set_device(FU_RELEASE(release), device);
+
 			if (!fu_release_load(FU_RELEASE(release),
 					     NULL,
 					     component,


### PR DESCRIPTION
Does this help #8177?

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
