### PR TITLE
trivial: don't show plugin warnings in json mode

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -108,6 +108,9 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 	FwupdPluginFlags flags = FWUPD_PLUGIN_FLAG_NONE;
 	GPtrArray *plugins;
 
+	if (priv->as_json)
+		return;
+
 	/* get a superset so we do not show the same message more than once */
 	plugins = fu_engine_get_plugins(priv->engine);
 	for (guint i = 0; i < plugins->len; i++) {

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -4503,6 +4503,9 @@ fu_util_show_plugin_warnings(FuUtilPrivate *priv)
 	FwupdPluginFlags flags = FWUPD_PLUGIN_FLAG_NONE;
 	g_autoptr(GPtrArray) plugins = NULL;
 
+	if (priv->as_json)
+		return;
+
 	/* get plugins from daemon, ignoring if the daemon is too old */
 	plugins = fwupd_client_get_plugins(priv->client, priv->cancellable, NULL);
 	if (plugins == NULL)


### PR DESCRIPTION
This will break json parsing tools.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
