### PR TITLE
pixart-rf: Convert FuPxiReceiverDevice from FuHidrawDevice to FuHidDevice

### DIFF
--- a/plugins/pixart-rf/fu-pxi-common.h
+++ b/plugins/pixart-rf/fu-pxi-common.h
@@ -42,6 +42,7 @@
 #define FU_PXI_WIRELESS_DEVICE_RETRY_MAXIMUM 1000
 
 #define FU_PXI_DEVICE_IOCTL_TIMEOUT 5000 /* ms */
+#define FU_PXI_DEVICE_HID_TIMEOUT   500	 /* ms */
 
 /* pixart device model structure */
 struct ota_fw_dev_model {

--- a/plugins/pixart-rf/fu-pxi-receiver-device.h
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.h
@@ -15,4 +15,4 @@ G_DECLARE_FINAL_TYPE(FuPxiReceiverDevice,
 		     fu_pxi_receiver_device,
 		     FU,
 		     PXI_RECEIVER_DEVICE,
-		     FuHidrawDevice)
+		     FuHidDevice)

--- a/plugins/pixart-rf/pixart-rf.quirk
+++ b/plugins/pixart-rf/pixart-rf.quirk
@@ -19,17 +19,17 @@ Plugin = pixart_rf
 GType = FuPxiBleDevice
 
 # Pixart 2861
-[HIDRAW\VEN_093A&DEV_2861]
+[USB\VID_093A&PID_2861]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
 # Pixart 2862
-[HIDRAW\VEN_093A&DEV_2862]
+[USB\VID_093A&PID_2862]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
 # Pixart 2452
-[HIDRAW\VEN_093A&DEV_2452]
+[USB\VID_093A&PID_2452]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
@@ -224,22 +224,22 @@ GType = FuPxiBleDevice
 Flags = is-hpac
 
 # Pixart 2404
-[HIDRAW\VEN_093A&DEV_2404]
+[USB\VID_093A&PID_2404]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
 # Pixart 4206
-[HIDRAW\VEN_093A&DEV_4206]
+[USB\VID_093A&PID_4206]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
 # Pixart 2440
-[HIDRAW\VEN_093A&DEV_2440]
+[USB\VID_093A&PID_2440]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 
 # Pixart 2418
-[HIDRAW\VEN_093A&DEV_2418]
+[USB\VID_093A&PID_2418]
 Plugin = pixart_rf
 GType = FuPxiReceiverDevice
 


### PR DESCRIPTION
This allows the DS-20 BOS descriptor to work.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
