### PR TITLE
Update huddly plugin to support new version format

### DIFF
--- a/plugins/huddly-usb/fu-huddly-usb-device.c
+++ b/plugins/huddly-usb/fu-huddly-usb-device.c
@@ -242,7 +242,8 @@ fu_huddly_usb_device_ensure_product_info(FuHuddlyUsbDevice *self, GError **error
 		g_prefix_error(error, "failed to read product info: ");
 		return FALSE;
 	}
-	version_split = g_strsplit(fu_msgpack_item_get_string(item_version)->str, "-", 2);
+	version_split =
+	    g_regex_split_simple("[-+]", fu_msgpack_item_get_string(item_version)->str, 0, 0);
 	fu_device_set_version(FU_DEVICE(self), version_split[0]);
 
 	/* state */


### PR DESCRIPTION
An update to huddly semantic version format causes the version number check to fail in the huddly plugin.

This change will update the plugin to support both the old and new format by splitting the version format string on either "-" or "+"

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ *] Code fix
- [ ] Feature
- [ ] Documentation
