### PR TITLE
Do not add invalid CoSWID entities

### DIFF
--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -515,6 +515,22 @@ fu_coswid_firmware_parse_entity(cbor_item_t *item, gpointer user_data, GError **
 		}
 	}
 
+	/* sanity check */
+	if (entity->name == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "entity does not have a name");
+		return FALSE;
+	}
+	if (entity->roles == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "entity has no roles");
+		return FALSE;
+	}
+
 	/* success */
 	g_ptr_array_add(priv->entities, g_steal_pointer(&entity));
 	return TRUE;


### PR DESCRIPTION
This fixes a 'hang' from OSSFuzz where it generated thousands of empty (and completely useless) entities.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
