### PR TITLE
trivial: Do not replace the built-in UEFI PK device when emulating

### DIFF
--- a/libfwupdplugin/fu-backend.c
+++ b/libfwupdplugin/fu-backend.c
@@ -77,6 +77,10 @@ fu_backend_device_added(FuBackend *self, FuDevice *device)
 	if (fu_device_get_backend_id(device) == NULL)
 		fu_device_set_backend_id(device, priv->name);
 
+	/* set created to *now* */
+	if (fu_device_get_created_usec(device) == 0)
+		fu_device_set_created_usec(device, g_get_real_time());
+
 	/* sanity check */
 	if ((g_getenv("FWUPD_UEFI_TEST") == NULL) &&
 	    g_hash_table_contains(priv->devices, fu_device_get_backend_id(device))) {

--- a/plugins/uefi-pk/tests/uefi-pk-setup.json
+++ b/plugins/uefi-pk/tests/uefi-pk-setup.json
@@ -4,6 +4,7 @@
       "GType": "FuUefiDevice",
       "BackendId": "8be4df61-93ca-11d2-aa0d-00e098032b8c-PK",
       "Guid": "8be4df61-93ca-11d2-aa0d-00e098032b8c",
+      "Created": "2025-02-13T00:00:00Z",
       "Name": "PK",
       "Events": [
         {


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
