### PR TITLE
uefi-capsule: Add a device quirk to signify that no additional ESP space is required

### DIFF
--- a/libfwupdplugin/fu-volume-private.h
+++ b/libfwupdplugin/fu-volume-private.h
@@ -18,3 +18,7 @@ void
 fu_volume_set_partition_kind(FuVolume *self, const gchar *partition_kind) G_GNUC_NON_NULL(1, 2);
 void
 fu_volume_set_partition_uuid(FuVolume *self, const gchar *partition_uuid) G_GNUC_NON_NULL(1, 2);
+
+/* for tests */
+void
+fu_volume_set_filesystem_free(FuVolume *self, guint64 filesystem_free) G_GNUC_NON_NULL(1);

--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -183,6 +183,13 @@ Modify `BootOrder` as well as `BootNext` to work around BIOS bugs.
 
 Use Dell customized file location for the capsule on disk.
 
+### `Flags=no-esp-backup`
+
+The UEFI ESRT entry does not need extra ESP space to write a backup ROM.
+If this flag is set then the `RequireESPFreeSpace` config file option is ignored.
+
+Since: 2.0.7
+
 ## External Interface Access
 
 This plugin requires:

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.h
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.h
@@ -34,6 +34,7 @@ struct _FuUefiCapsuleDeviceClass {
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_COD_INDEXED_FILENAME     "cod-indexed-filename"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_MODIFY_BOOTORDER	     "modify-bootorder"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_COD_DELL_RECOVERY	     "cod-dell-recovery"
+#define FU_UEFI_CAPSULE_DEVICE_FLAG_NO_ESP_BACKUP	     "no-esp-backup"
 
 void
 fu_uefi_capsule_device_set_esp(FuUefiCapsuleDevice *self, FuVolume *esp);


### PR DESCRIPTION
As this is a device flag, this can be set in the quirk file, in the metadata at firmware upload time or added to existing firmware on the LVFS.

Fixes https://github.com/fwupd/fwupd/issues/8462

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
