### PR TITLE
trivial: tests: Only run fwupdmgr security tests on x86_64

### DIFF
--- a/data/tests/fwupdmgr.sh
+++ b/data/tests/fwupdmgr.sh
@@ -268,15 +268,21 @@ echo "Getting approved firmware..."
 fwupdmgr get-approved-firmware
 rc=$?; if [ $rc != 0 ]; then error $rc; fi
 
+UNAME=$(uname -m)
+if [ "${UNAME}" = "x86_64" ] || [ "${UNAME}" = "x86" ]; then
+       EXPECTED=0
+else
+       EXPECTED=1
+fi
 # ---
 echo "Run security tests..."
 fwupdmgr security
-rc=$?; if [ $rc = 1 ]; then error $rc; fi
+rc=$?; if [ $rc != $EXPECTED ]; then error $rc; fi
 
 # ---
 echo "Run security tests (json)..."
 fwupdmgr security --json
-rc=$?; if [ $rc = 1 ]; then error $rc; fi
+rc=$?; if [ $rc != $EXPECTED ]; then error $rc; fi
 
 # success!
 exit 0

--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -45,10 +45,16 @@ echo "Showing hwids"
 run hwids
 rc=$?; if [ $rc != 0 ]; then error $rc; fi
 
+UNAME=$(uname -m)
+if [ "${UNAME}" = "x86_64" ] || [ "${UNAME}" = "x86" ]; then
+       EXPECTED=0
+else
+       EXPECTED=1
+fi
 # ---
 echo "Showing security"
 run security
-rc=$?; if [ $rc != 0 ]; then error $rc; fi
+rc=$?; if [ $rc != $EXPECTED ]; then error $rc; fi
 
 # ---
 echo "Showing plugins"


### PR DESCRIPTION
HSI isn't supported on non-x86 currently, and this causes autopkgtest failures for Debian.

```
 43s Showing security
 43s cmd: fwupdtool -v security
 43s 19:07:31.573 FuDebug              verbose to info (on console 0)
 43s 19:07:31.573 FuEngine             starting fwupd 2.0.6...
 43s Host Security ID (HSI) is not supported
 43s FAIL: fwupd/fwupdtool.test (Child process exited with code 1)
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
