### PR TITLE
meson: don't pass strings to boolean options

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -338,7 +338,7 @@ option('systemd_unit_user',
 )
 option('systemd_syscall_filter',
   type: 'boolean',
-  value: 'true',
+  value: true,
   description: 'Enable systemd syscall filter',
 )
 option('tests',


### PR DESCRIPTION
This has been deprecated since meson 1.1.0 and the project now targets >=1.3.0.

Prevents the following warning during configure: 

```
meson_options.txt:339: WARNING: Project targets '>=1.3.0' but uses feature deprecated since '1.1.0': "boolean option" keyword argument "value" of type str. use a boolean, not a string
```

Type of pull request:

- [x] Code fix
