### PR TITLE
trivial: Fix the self tests with the new libxmlb installed

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2953,7 +2953,11 @@ fu_chunk_func(void)
 	chunked5 = fu_chunk_array_new(NULL, 0, 0x0, 0x0, 4);
 	g_assert_cmpint(chunked5->len, ==, 0);
 	chunked5_str = fu_chunk_array_to_string(chunked5);
+#if LIBXMLB_CHECK_VERSION(0, 3, 22)
+	g_assert_cmpstr(chunked5_str, ==, "<chunks />\n");
+#else
 	g_assert_cmpstr(chunked5_str, ==, "<chunks>\n</chunks>\n");
+#endif
 
 	chunked1 = fu_chunk_array_new((const guint8 *)"0123456789abcdef", 16, 0x0, 10, 4);
 	chunked1_str = fu_chunk_array_to_string(chunked1);


### PR DESCRIPTION
We fixed the collapse-empty bug in https://github.com/hughsie/libxmlb/pull/233

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
