### PR TITLE
trivial: Allow creating cab archives up to 2GB in size

### DIFF
--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -994,7 +994,7 @@ static void
 fu_cabinet_init(FuCabinet *self)
 {
 	fu_cab_firmware_set_only_basename(FU_CAB_FIRMWARE(self), TRUE);
-	fu_firmware_set_size_max(FU_FIRMWARE(self), 1024 * 1024 * 100);
+	fu_firmware_set_size_max(FU_FIRMWARE(self), 0x80000000); /* 2GB */
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();
 	self->jcat_context = jcat_context_new();


### PR DESCRIPTION
We have a int16_t block size and a uint16_t number of blocks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
