### PR TITLE
trivial: Add some error context to fu_partial_input_stream_new()

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -239,8 +239,10 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 	/* verify checksum */
 	partial_stream =
 	    fu_partial_input_stream_new(helper->stream, *offset + hdr_sz, blob_comp, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut cabinet checksum: ");
 		return FALSE;
+	}
 	if ((helper->install_flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 checksum = fu_struct_cab_data_get_checksum(st);
 		if (checksum != 0) {
@@ -478,8 +480,10 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 					     fu_struct_cab_file_get_uoffset(st),
 					     fu_struct_cab_file_get_usize(st),
 					     error);
-	if (stream == NULL)
+	if (stream == NULL) {
+		g_prefix_error(error, "failed to cut cabinet image: ");
 		return FALSE;
+	}
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(img), stream, 0x0, helper->install_flags, error))
 		return FALSE;
 	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))

--- a/libfwupdplugin/fu-composite-input-stream.c
+++ b/libfwupdplugin/fu-composite-input-stream.c
@@ -174,8 +174,10 @@ fu_composite_input_stream_add_stream(FuCompositeInputStream *self,
 
 	/* create a partial stream that is actually the size of the entire GInputStream */
 	partial_stream = fu_partial_input_stream_new(stream, 0x0, G_MAXSIZE, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to add input stream: ");
 		return FALSE;
+	}
 	fu_composite_input_stream_add_partial_stream(self, FU_PARTIAL_INPUT_STREAM(partial_stream));
 
 	/* success */

--- a/libfwupdplugin/fu-efi-common.c
+++ b/libfwupdplugin/fu-efi-common.c
@@ -98,8 +98,10 @@ fu_efi_parse_sections(FuFirmware *firmware,
 		/* parse maximum payload */
 		partial_stream =
 		    fu_partial_input_stream_new(stream, offset, streamsz - offset, error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut payload: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -141,8 +141,10 @@ fu_efi_file_parse(FuFirmware *firmware,
 
 	/* add simple blob */
 	partial_stream = fu_partial_input_stream_new(stream, st->len, size - st->len, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut EFI blob: ");
 		return FALSE;
+	}
 
 	/* verify data checksum */
 	if ((priv->attrib & FU_EFI_FILE_ATTRIB_CHECKSUM) > 0 &&

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -58,8 +58,10 @@ fu_efi_filesystem_parse(FuFirmware *firmware,
 			break;
 		}
 		stream_tmp = fu_partial_input_stream_new(stream, offset, streamsz - offset, error);
-		if (stream_tmp == NULL)
+		if (stream_tmp == NULL) {
+			g_prefix_error(error, "failed to cut EFI file: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img,
 					      stream_tmp,
 					      0x0,

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -321,8 +321,10 @@ fu_efi_section_parse(FuFirmware *firmware,
 	/* create blob */
 	offset += st->len;
 	partial_stream = fu_partial_input_stream_new(stream, offset, size - offset, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut data: ");
 		return FALSE;
+	}
 	fu_firmware_set_offset(firmware, offset);
 	fu_firmware_set_size(firmware, size);
 	if (!fu_firmware_set_stream(firmware, partial_stream, error))

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -169,8 +169,10 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	/* add image */
 	partial_stream =
 	    fu_partial_input_stream_new(stream, hdr_length, fv_length - hdr_length, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut EFI volume: ");
 		return FALSE;
+	}
 	fu_firmware_set_id(firmware, guid_str);
 	fu_firmware_set_size(firmware, fv_length);
 

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -117,8 +117,10 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 		if (sect_size > 0) {
 			g_autoptr(GInputStream) img_stream =
 			    fu_partial_input_stream_new(stream, sect_offset, sect_size, error);
-			if (img_stream == NULL)
+			if (img_stream == NULL) {
+				g_prefix_error(error, "failed to cut EFI image: ");
 				return FALSE;
+			}
 			if (!fu_firmware_parse_stream(img, img_stream, 0x0, flags, error))
 				return FALSE;
 		}

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1140,8 +1140,10 @@ fu_firmware_parse_stream(FuFirmware *self,
 	} else {
 		g_autoptr(GInputStream) partial_stream =
 		    fu_partial_input_stream_new(stream, offset, priv->streamsz, error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut firmware: ");
 			return FALSE;
+		}
 		g_set_object(&priv->stream, partial_stream);
 	}
 

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -91,8 +91,10 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 							 (gsize)area_offset,
 							 (gsize)area_size,
 							 error);
-		if (img_stream == NULL)
+		if (img_stream == NULL) {
+			g_prefix_error(error, "failed to cut FMAP area: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img, img_stream, 0x0, flags, error))
 			return FALSE;
 		area_name = fu_struct_fmap_area_get_name(st_area);

--- a/libfwupdplugin/fu-hid-report-item.c
+++ b/libfwupdplugin/fu-hid-report-item.c
@@ -107,8 +107,10 @@ fu_hid_report_item_parse(FuFirmware *firmware,
 				return FALSE;
 		}
 		partial_stream = fu_partial_input_stream_new(stream, 1, data_size, error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut HID payload: ");
 			return FALSE;
+		}
 		if (!fu_firmware_set_stream(firmware, partial_stream, error))
 			return FALSE;
 	}

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -223,8 +223,10 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 		/* create image */
 		g_debug("freg %s 0x%04x -> 0x%04x", freg_str, freg_base, freg_limt);
 		partial_stream = fu_partial_input_stream_new(stream2, freg_base, freg_size, error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut IFD image: ");
 			return FALSE;
+		}
 		if (i == FU_IFD_REGION_BIOS) {
 			img = fu_ifd_bios_new();
 		} else {

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -113,8 +113,10 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware, GInputStream *stream, 
 							     offset + st_mex->len,
 							     extension_length - st_mex->len,
 							     error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut CPD extension: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
@@ -203,8 +205,10 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 						img_offset,
 						fu_struct_ifwi_cpd_entry_get_length(st_ent),
 						error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut IFD image: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img, partial_stream, 0x0, flags, error))
 			return FALSE;
 

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -106,8 +106,10 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 			g_autoptr(GInputStream) partial_stream = NULL;
 			partial_stream =
 			    fu_partial_input_stream_new(stream, data_offset, data_length, error);
-			if (partial_stream == NULL)
+			if (partial_stream == NULL) {
+				g_prefix_error(error, "failed to cut FPT image: ");
 				return FALSE;
+			}
 			if (!fu_firmware_parse_stream(img, partial_stream, 0x0, flags, error))
 				return FALSE;
 			fu_firmware_set_offset(img, data_offset);

--- a/libfwupdplugin/fu-intel-thunderbolt-firmware.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-firmware.c
@@ -72,8 +72,10 @@ fu_intel_thunderbolt_firmware_parse(FuFirmware *firmware,
 
 	/* FuIntelThunderboltNvm->parse */
 	partial_stream = fu_partial_input_stream_new(stream, farb_pointer, G_MAXSIZE, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut from NVM: ");
 		return FALSE;
+	}
 	return FU_FIRMWARE_CLASS(fu_intel_thunderbolt_firmware_parent_class)
 	    ->parse(firmware, partial_stream, flags, error);
 }

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -101,8 +101,10 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 		g_autoptr(GInputStream) stream_tmp = NULL;
 
 		stream_tmp = fu_partial_input_stream_new(stream, offset, streamsz - offset, error);
-		if (stream_tmp == NULL)
+		if (stream_tmp == NULL) {
+			g_prefix_error(error, "failed to cut linear image: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img,
 					      stream_tmp,
 					      0x0,

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -183,8 +183,10 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 						sect_offset,
 						fu_struct_pe_coff_section_get_size_of_raw_data(st),
 						error);
-		if (img_stream == NULL)
+		if (img_stream == NULL) {
+			g_prefix_error(error, "failed to cut raw PE data: ");
 			return FALSE;
+		}
 		if (!fu_firmware_parse_stream(img, img_stream, 0x0, flags, error)) {
 			g_prefix_error(error, "failed to parse raw data %s: ", sect_id);
 			return FALSE;
@@ -344,8 +346,10 @@ fu_pefile_firmware_parse(FuFirmware *firmware,
 			(guint)(r->offset + r->size),
 			(guint)r->size);
 		partial_stream = fu_partial_input_stream_new(stream, r->offset, r->size, error);
-		if (partial_stream == NULL)
+		if (partial_stream == NULL) {
+			g_prefix_error(error, "failed to cut Authenticode region: ");
 			return FALSE;
+		}
 		fu_composite_input_stream_add_partial_stream(
 		    FU_COMPOSITE_INPUT_STREAM(composite_stream),
 		    FU_PARTIAL_INPUT_STREAM(partial_stream));

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -55,8 +55,10 @@ fu_sbatlevel_section_add_entry(FuFirmware *firmware,
 	fu_firmware_set_id(entry_fw, entry_name);
 	fu_firmware_set_offset(entry_fw, offset);
 	partial_stream = fu_partial_input_stream_new(stream, offset, streamsz - offset, error);
-	if (partial_stream == NULL)
+	if (partial_stream == NULL) {
+		g_prefix_error(error, "failed to cut CSV section: ");
 		return FALSE;
+	}
 	if (!fu_firmware_parse_stream(entry_fw, partial_stream, 0, flags, error)) {
 		g_prefix_error(error, "failed to parse %s: ", entry_name);
 		return FALSE;

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -500,8 +500,10 @@ fu_strsplit_stream(GInputStream *stream,
 	helper.delimiter_sz = strlen(delimiter);
 	if (offset > 0) {
 		stream_partial = fu_partial_input_stream_new(stream, offset, G_MAXSIZE, error);
-		if (stream_partial == NULL)
+		if (stream_partial == NULL) {
+			g_prefix_error(error, "failed to cut string: ");
 			return FALSE;
+		}
 	} else {
 		stream_partial = g_object_ref(stream);
 	}

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -182,8 +182,10 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 							 st->len,
 							 self->bos_cap.bLength - st->len,
 							 error);
-		if (img_stream == NULL)
+		if (img_stream == NULL) {
+			g_prefix_error(error, "failed to cut BOS descriptor: ");
 			return FALSE;
+		}
 		if (!fu_firmware_set_stream(img, img_stream, error))
 			return FALSE;
 		fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -27,8 +27,10 @@ fu_usb_descriptor_parse(FuFirmware *firmware,
 		return FALSE;
 	stream_partial =
 	    fu_partial_input_stream_new(stream, 0x0, fu_usb_base_hdr_get_length(st), error);
-	if (stream_partial == NULL)
+	if (stream_partial == NULL) {
+		g_prefix_error(error, "failed to cut USB descriptor: ");
 		return FALSE;
+	}
 	if (!fu_firmware_set_stream(firmware, stream_partial, error))
 		return FALSE;
 	fu_firmware_set_idx(FU_FIRMWARE(self), fu_usb_base_hdr_get_descriptor_type(st));

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -120,8 +120,10 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		g_autoptr(GInputStream) istream2 = NULL;
 		conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_ZLIB));
 		istream1 = fu_partial_input_stream_new(stream, hdrsz, payloadsz, error);
-		if (istream1 == NULL)
+		if (istream1 == NULL) {
+			g_prefix_error(error, "failed to cut uSWID payload: ");
 			return FALSE;
+		}
 		if (!g_seekable_seek(G_SEEKABLE(istream1), 0, G_SEEK_SET, NULL, error))
 			return FALSE;
 		istream2 = g_converter_input_stream_new(istream1, conv);


### PR DESCRIPTION
Given a bug report of the form:

    base was 0xY bytes in size, and tried to create partial @0x0 of 0xZ bytes

..it's not always obvious where to even *start* debugging.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
