### PR TITLE
Support cabinet archives greater in size than 2GB

### DIFF
--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -994,7 +994,7 @@ static void
 fu_cabinet_init(FuCabinet *self)
 {
 	fu_cab_firmware_set_only_basename(FU_CAB_FIRMWARE(self), TRUE);
-	fu_firmware_set_size_max(FU_FIRMWARE(self), 0x80000000); /* 2GB */
+	fu_firmware_set_size_max(FU_FIRMWARE(self), G_MAXUINT32); /* ~4GB */
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();
 	self->jcat_context = jcat_context_new();

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -994,7 +994,7 @@ static void
 fu_cabinet_init(FuCabinet *self)
 {
 	fu_cab_firmware_set_only_basename(FU_CAB_FIRMWARE(self), TRUE);
-	fu_firmware_set_size_max(FU_FIRMWARE(self), 1024 * 1024 * 100);
+	fu_firmware_set_size_max(FU_FIRMWARE(self), 0x80000000); /* 2GB */
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();
 	self->jcat_context = jcat_context_new();


### PR DESCRIPTION
When the archive is greater in size than 2GB, the `FuStructCabFolder.ndatab` property looks completely wrong as it is truncated to a `uint16_t`.

Looking at the specification, it says:

    u2 cCFData: Number of CFDATA structures for this folder.

In reality, however, `gcab` and `cabextract` are a bit more relaxed and keep decoding `CFDATA` structures -- ignoring the value of `cCFData` completely.

We could fix this one of three ways:

 * Increasing the block size to 0xFFFF, and redefine it as a `uint16_t`.
   - This would mean we'd have to use `fwupdtool` to generate the .cab archive which would give us a maximum payload of still only ~4GB

 * Split the data up into multiple CFOLDER sections, and allow CFFILEs to span folders
   - This would upset other decoders as it's somewhat out-of-spec

 * Use the stream size and just "keep going" until the end of the archive

Implement option 3, which is also what gcab does, accidentally.

So, using 0xFFFF as the block size gets us to ~4GB which is probably still too small longer term.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
