### PR TITLE
Fix a critical warning when rescanning a device with no GUIDs

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -5771,7 +5771,8 @@ fu_device_rescan(FuDevice *self, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* remove all GUIDs */
-	g_ptr_array_set_size(priv->instance_ids, 0);
+	if (priv->instance_ids != NULL)
+		g_ptr_array_set_size(priv->instance_ids, 0);
 	g_ptr_array_set_size(fu_device_get_instance_ids(self), 0);
 	g_ptr_array_set_size(fu_device_get_guids(self), 0);
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -537,6 +537,19 @@ fu_device_open_refcount_func(void)
 }
 
 static void
+fu_device_rescan_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuDevice) device = fu_device_new(NULL);
+	g_autoptr(GError) error = NULL;
+
+	/* no GUIDs! */
+	ret = fu_device_rescan(device, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
 fu_device_name_func(void)
 {
 	g_autoptr(FuDevice) device1 = fu_device_new(NULL);
@@ -6745,6 +6758,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/device-locker{success}", fu_device_locker_func);
 	g_test_add_func("/fwupd/device-locker{fail}", fu_device_locker_fail_func);
 	g_test_add_func("/fwupd/device{name}", fu_device_name_func);
+	g_test_add_func("/fwupd/device{rescan}", fu_device_rescan_func);
 	g_test_add_func("/fwupd/device{metadata}", fu_device_metadata_func);
 	g_test_add_func("/fwupd/device{open-refcount}", fu_device_open_refcount_func);
 	g_test_add_func("/fwupd/device{version-format}", fu_device_version_format_func);


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/8518

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
