### PR TITLE
trivial: stop checking missing-hwid/firmware.bin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,6 @@ repos:
               plugins/uefi-capsule/tests/test\.bmp|
               src/tests/auth/firmware\.xml\.gz|
               src/tests/history_v[12]\.db|
-              src/tests/missing-hwid/firmware\.bin|
               src/tests/sys/devices/pci0000:00/0000:00:14\.0/usb1/1-1/descriptors
             )$
     - id: check-null-false-returns


### PR DESCRIPTION
This was converted in commit 5d9d26caf ("trivial: drop DMI tables from fwupd source tree"), but that should have been it's own commit. Whoops.

Fixes: 5d9d26caf ("trivial: drop DMI tables from fwupd source tree")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
