### PR TITLE
libfwupdplugin: fixes for fu-device-locker

### DIFF
--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -180,9 +180,13 @@ fu_device_locker_new_full(gpointer device,
 	if (!self->open_func(device, error)) {
 		g_autoptr(GError) error_local = NULL;
 		if (!self->close_func(device, &error_local)) {
-			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO)) {
-				g_debug("ignoring close error on aborted open: %s",
-					error_local->message);
+			if (error_local != NULL) {
+				if (!g_error_matches(error_local,
+						     FWUPD_ERROR,
+						     FWUPD_ERROR_NOTHING_TO_DO)) {
+					g_debug("ignoring close error on aborted open: %s",
+						error_local->message);
+				}
 			}
 		}
 		return NULL;

--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -189,6 +189,7 @@ fu_device_locker_new_full(gpointer device,
 				}
 			}
 		}
+		g_object_unref(device);
 		return NULL;
 	}
 


### PR DESCRIPTION
- libfwupdplugin: fix NULL reference in fu_device_locker_new_full if error is NULL
- libfwupdplugin: add missing g_object_unref on error in fu_device_locker_new_full

- [ ] New plugin
- [x] Code fix
- [ ] Feature
- [ ] Documentation
