### PR TITLE
plugins/modem-manager: add fixes and improvements

### DIFF
--- a/plugins/modem-manager/fu-dfota-updater.c
+++ b/plugins/modem-manager/fu-dfota-updater.c
@@ -173,7 +173,10 @@ fu_dfota_updater_parse_upload_result(FuDfotaUpdater *self,
 gboolean
 fu_dfota_updater_upload_firmware(FuDfotaUpdater *self, GBytes *fw, GError **error)
 {
-	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw, 0x0, 0x800);
+	g_autoptr(FuChunkArray) chunks = fu_chunk_array_new_from_bytes(fw,
+								       FU_CHUNK_ADDR_OFFSET_NONE,
+								       FU_CHUNK_PAGESZ_NONE,
+								       0x800);
 	guint chunk_count = fu_chunk_array_length(chunks);
 	g_autofree gchar *checksum = fu_dfota_updater_compute_checksum(fw);
 	g_autofree gchar *checksum_parsed = NULL;

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -85,7 +85,10 @@ fu_sahara_loader_find_interface(FuSaharaLoader *self, FuUsbDevice *usb_device, G
 		return TRUE;
 	}
 
-	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no update interface found");
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "no valid usb interface found");
 	return FALSE;
 }
 

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -73,7 +73,8 @@ fu_sahara_loader_find_interface(FuSaharaLoader *self, FuUsbDevice *usb_device, G
 			g_debug("wrong subclass detected: %x", fu_usb_interface_get_subclass(intf));
 			continue;
 		}
-		if (fu_usb_interface_get_protocol(intf) != 0xFF)
+		if ((fu_usb_interface_get_protocol(intf) != 0xFF) &&
+		    (fu_usb_interface_get_protocol(intf) != 0x11)) {
 			g_debug("wrong protocol detected: %x", fu_usb_interface_get_protocol(intf));
 			continue;
 		}

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -55,34 +55,34 @@ fu_sahara_loader_find_interface(FuSaharaLoader *self, FuUsbDevice *usb_device, G
 		return FALSE;
 	for (guint i = 0; i < intfs->len; i++) {
 		FuUsbInterface *intf = g_ptr_array_index(intfs, i);
-		if (fu_usb_interface_get_class(intf) == 0xFF &&
-		    fu_usb_interface_get_subclass(intf) == 0xFF &&
-		    fu_usb_interface_get_protocol(intf) == 0xFF) {
-			FuUsbEndpoint *ep;
-			g_autoptr(GPtrArray) endpoints = NULL;
+		FuUsbEndpoint *ep;
+		g_autoptr(GPtrArray) endpoints = NULL;
 
-			endpoints = fu_usb_interface_get_endpoints(intf);
-			if (endpoints == NULL || endpoints->len == 0)
-				continue;
+		if (fu_usb_interface_get_class(intf) != 0xFF)
+			continue;
+		if (fu_usb_interface_get_subclass(intf) != 0xFF)
+			continue;
+		if (fu_usb_interface_get_protocol(intf) != 0xFF)
+			continue;
 
-			for (guint j = 0; j < endpoints->len; j++) {
-				ep = g_ptr_array_index(endpoints, j);
-				if (fu_usb_endpoint_get_direction(ep) ==
-				    FU_USB_DIRECTION_DEVICE_TO_HOST) {
-					self->ep_in = fu_usb_endpoint_get_address(ep);
-					self->maxpktsize_in =
-					    fu_usb_endpoint_get_maximum_packet_size(ep);
-				} else {
-					self->ep_out = fu_usb_endpoint_get_address(ep);
-					self->maxpktsize_out =
-					    fu_usb_endpoint_get_maximum_packet_size(ep);
-				}
+		endpoints = fu_usb_interface_get_endpoints(intf);
+		if (endpoints == NULL || endpoints->len == 0)
+			continue;
+
+		for (guint j = 0; j < endpoints->len; j++) {
+			ep = g_ptr_array_index(endpoints, j);
+			if (fu_usb_endpoint_get_direction(ep) == FU_USB_DIRECTION_DEVICE_TO_HOST) {
+				self->ep_in = fu_usb_endpoint_get_address(ep);
+				self->maxpktsize_in = fu_usb_endpoint_get_maximum_packet_size(ep);
+			} else {
+				self->ep_out = fu_usb_endpoint_get_address(ep);
+				self->maxpktsize_out = fu_usb_endpoint_get_maximum_packet_size(ep);
 			}
-
-			fu_usb_device_add_interface(usb_device, fu_usb_interface_get_number(intf));
-
-			return TRUE;
 		}
+
+		fu_usb_device_add_interface(usb_device, fu_usb_interface_get_number(intf));
+
+		return TRUE;
 	}
 
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no update interface found");

--- a/plugins/modem-manager/fu-sahara-loader.c
+++ b/plugins/modem-manager/fu-sahara-loader.c
@@ -105,6 +105,13 @@ fu_sahara_loader_open(FuSaharaLoader *self, FuUsbDevice *usb_device, GError **er
 gboolean
 fu_sahara_loader_close(FuSaharaLoader *self, GError **error)
 {
+	if (!self->usb_device) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOTHING_TO_DO,
+				    "usb device interface was not found");
+		return FALSE;
+	}
 	if (!fu_device_close(FU_DEVICE(self->usb_device), error))
 		return FALSE;
 	g_clear_object(&self->usb_device);


### PR DESCRIPTION
modem-manager: add additional usb protocol number check '0x11' for 'EDL'
modem-manager: add additional debug logs on fu_sahara_loader_find_interface
modem-manager: update error message of no valid usb interface is found
modem-manager: refactoring fu_sahara_loader_find_interface function
modem-manager: add a check to 'fu_sahara_loader_close' if 'self->usb_device' is NULL
modem-manager: fix api change for function fu_chunk_array_new_from_bytes

- [ ] New plugin
- [x] Code fix
- [ ] Feature
- [ ] Documentation
