### PR TITLE
uefi-capsule: Support activating A/B firmware

### DIFF
--- a/plugins/uefi-capsule/fu-uefi.rs
+++ b/plugins/uefi-capsule/fu-uefi.rs
@@ -89,3 +89,16 @@ struct FuStructBitmapInfoHeader {
     width: u32le,
     height: u32le,
 }
+
+#[repr(u32le)]
+enum FuAbIndicationsValue {
+    Unknown,
+    Revert,
+    Accept,
+}
+
+#[derive(New, Default)]
+#[repr(C, packed)]
+struct FuStructAbIndications {
+    value: FuAbIndicationsValue = Accept,
+}


### PR DESCRIPTION
The idea here is that firmware deployed in an A/B scheme is 'activated' by the customer application starting correctly (or by 'did the session start' as a fallback) which sets the 'new' firmware as good for booting by default.

This is all work in progress and nothing is standardized yet.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
