### PR TITLE
fix test failure for certain locales

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ max_line_length = 80
 [*.{yml,yaml}]
 indent_size = 2
 
+[meson{.build,.options,_options.txt}]
+indent_size = 2
+
 [*.py]
 indent_size = 4
 

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,17 @@ if cc.get_id() == 'msvc'
   error('MSVC is not supported as it does not support __attribute__((cleanup))')
 endif
 
+# ensure tests do not fail because of locale specific decimal separators (e.g. when comparing
+# outputs with `diff`)
+add_test_setup(
+  'default',
+  env: {
+    'LANG': 'C.UTF-8',
+    'LC_ALL': 'C.UTF-8',
+  },
+  is_default: true,
+)
+
 # enable full RELRO where possible
 # FIXME: until https://github.com/mesonbuild/meson/issues/1140 is fixed
 global_link_args = []


### PR DESCRIPTION
With e.g. some European locales you would otherwise get test failures like this:

```
+++ /tmp/a	2025-03-05 12:42:41.767258633 +0100
@@ -15,7 +15,7 @@ FwupdRelease:
   Checksum:             SHA1(checksum)
   Tags:                 tag
   License:              license
-  Size:                 1.2 kB
+  Size:                 1,2 kB
   Created:              1970-01-01
   Uri:                  location
   Homepage:             homepage
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
