### PR TITLE
trivial: Load some external plugins during the self tests too

### DIFF
--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -69,6 +69,12 @@ fu_flashrom_device_open(FuDevice *device, GError **error)
 {
 	FuFlashromDevice *self = FU_FLASHROM_DEVICE(device);
 
+	/* sanity check */
+	if (self->flashctx == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no flashctx");
+		return FALSE;
+	}
+
 	/* get the flash size from the device if not already been quirked */
 	if (fu_device_get_firmware_size_max(device) == 0) {
 		gsize flash_size = flashrom_flash_getsize(self->flashctx);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1170,12 +1170,33 @@ fu_engine_plugin_gtypes_func(gconstpointer user_data)
 	    "linux_swap",
 	    "linux_tainted",
 	};
+	const gchar *external_plugins[] = {
+	    "flashrom",
+	};
+	g_autoptr(GPtrArray) external_plugin_dirs = g_ptr_array_new_with_free_func(g_free);
+	g_autofree gchar *external_plugindir = NULL;
 
 	/* no metadata in daemon */
 	fu_engine_set_silo(engine, silo_empty);
 
-	/* load all internal plugins */
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS, progress, &error);
+	/* load these from the build directory, not the install directory */
+	for (guint i = 0; i < G_N_ELEMENTS(external_plugins); i++) {
+		g_ptr_array_add(external_plugin_dirs,
+				g_test_build_filename(G_TEST_BUILT,
+						      "..",
+						      "plugins",
+						      external_plugins[i],
+						      NULL));
+	}
+	external_plugindir = fu_strjoin(",", external_plugin_dirs);
+	g_setenv("FWUPD_LIBDIR_PKG", external_plugindir, TRUE);
+
+	/* load all plugins */
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS |
+				 FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS,
+			     progress,
+			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	plugins = fu_engine_get_plugins(engine);


### PR DESCRIPTION
We need to be slightly careful and use the *built* location, rather than the installed location.

ModemManager will come later too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
