### PR TITLE
uefi-mok: Add a plugin to verify UEFI memory protection attributes

### DIFF
--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -57,6 +57,7 @@ run_test redfish-self-test
 run_test synaptics-prometheus-self-test
 run_test tpm-self-test
 run_test uefi-dbx-self-test
+run_test uefi-mok-self-test
 run_test vli-self-test
 run_test wacom-usb-self-test
 run_umockdev_test fwupd_test.py

--- a/docs/hsi-tests.d/meson.build
+++ b/docs/hsi-tests.d/meson.build
@@ -34,6 +34,7 @@ hsi_test_jsons = files([
   'org.fwupd.hsi.Tpm.ReconstructionPcr0.json',
   'org.fwupd.hsi.Tpm.Version20.json',
   'org.fwupd.hsi.Uefi.BootserviceVars.json',
+  'org.fwupd.hsi.Uefi.MemoryProtection.json',
   'org.fwupd.hsi.Uefi.Pk.json',
   'org.fwupd.hsi.Uefi.SecureBoot.json',
   'org.fwupd.hsi.Bios.RollbackProtection.json',

--- a/docs/hsi-tests.d/org.fwupd.hsi.Uefi.MemoryProtection.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Uefi.MemoryProtection.json
@@ -1,0 +1,25 @@
+{
+  "id": "org.fwupd.hsi.Uefi.MemoryProtection",
+  "name": "Early-boot UEFI Memory Protections",
+  "description": [
+    "The UEFI system can set up memory attributes at boot which prevent common exploits from running. For instance, the stack can be marked as non-executable to prevent running any malicious code that can be written to the stack.",
+    "In the same way, writing to sections that are read-only can also be prevented, making the system more secure from attackers.",
+    "Distribution vendors should tag the bootloader as NX compatible, and BIOS vendors should provide a 'memory attribute protocol' table that tags memory sections with specific properties.",
+    "Microsoft Virtualization-based security (VBS) also requires NX protection for UEFI runtime services for DeviceGuard compliance."
+  ],
+  "failure-impact": [
+    "The attacker is able to run arbitrary executable code from the stack, or write to memory that is supposed to be read-only."
+  ],
+  "failure-results": {
+    "not-locked": "memory is still executable or writable",
+    "not-enabled": "the bootloader is not marked as NX compatible and the firmware may be operating in a compatibility mode"
+  },
+  "success-results": {
+    "locked": "memory is not executable or writable"
+  },
+  "hsi-level": 3,
+  "references": {
+    "https://aka.ms/WHCP": "Microsoft Windows WHCP"
+  },
+  "fwupd-version": "2.0.7"
+}

--- a/libfwupd/fwupd-security-attr-private.h
+++ b/libfwupd/fwupd-security-attr-private.h
@@ -388,6 +388,14 @@ G_BEGIN_DECLS
  * Since: 2.0.2
  **/
 #define FWUPD_SECURITY_ATTR_ID_AMD_SMM_LOCKED "org.fwupd.hsi.Amd.SmmLocked"
+/**
+ * FWUPD_SECURITY_ATTR_ID_UEFI_MEMORY_PROTECTION:
+ *
+ * Host Security ID attribute for UEFI memory protection
+ *
+ * Since: 2.0.7
+ **/
+#define FWUPD_SECURITY_ATTR_ID_UEFI_MEMORY_PROTECTION "org.fwupd.hsi.Uefi.MemoryProtection"
 
 FwupdSecurityAttr *
 fwupd_security_attr_copy(FwupdSecurityAttr *self) G_GNUC_NON_NULL(1);

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -1700,7 +1700,8 @@ fwupd_security_attr_add_string(FwupdCodec *codec, guint idt, GString *str)
 		fwupd_codec_string_append(str, idt, FWUPD_RESULT_KEY_GUID, guid);
 	}
 	if (priv->metadata != NULL) {
-		g_autoptr(GList) keys = g_hash_table_get_keys(priv->metadata);
+		g_autoptr(GList) keys =
+		    g_list_sort(g_hash_table_get_keys(priv->metadata), (GCompareFunc)g_strcmp0);
 		for (GList *l = keys; l != NULL; l = l->next) {
 			const gchar *key = l->data;
 			const gchar *value = g_hash_table_lookup(priv->metadata, key);

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -125,6 +125,7 @@ plugins = {
   'tpm': false,
   'uefi-dbx': false,
   'uefi-esrt': false,
+  'uefi-mok': false,
   'uefi-pk': false,
   'uefi-recovery': false,
   'uefi-sbat': false,

--- a/plugins/uefi-mok/README.md
+++ b/plugins/uefi-mok/README.md
@@ -1,0 +1,62 @@
+---
+title: Plugin: UEFI MOK
+---
+
+## Introduction
+
+Shim 16.0 and newer export a `/sys/firmware/efi/mok-variables/HSIStatus` file that contains some
+BootService-only attributes in an easy-to-digest format.
+
+We can use these attributes to populate the `org.fwupd.hsi.UefiMemoryProtections` Host Security ID
+attribute. The attributes are x64, aarch64 and riscv specific:
+
+### shim-has-nx-compat-set
+
+This attribute will be `1` if shim has the NX-compatible bit set in the COFF header,
+and `0` otherwise.
+
+### heap-is-executable
+
+This attribute will be `1` if heap is executable, and `0` otherwise.
+
+### stack-is-executable
+
+This attribute will be `1` if the stack is executable, and `0` otherwise.
+
+### ro-sections-are-writable
+
+This attribute will be `1` if read-only sections are actually writable, and`0` otherwise.
+
+### has-memory-attribute-protocol
+
+This attribute will be `1` if the memory attribute protocol is supported by the firmware,
+and `0` otherwise.
+
+### has-dxe-services-table
+
+This attribute will be `1` if the firmware provides a DXE services table, and `0` otherwise.
+
+### has-get-memory-space-descriptor
+
+This attribute will be `1` if `DxeServicesTable` has `GetMemorySpaceDescriptor()` populated,
+and `0` otherwise.
+
+### has-set-memory-space-attributes
+
+This attribute will be `1` if `DxeServicesTable` has `SetMemorySpaceAttributes()` populated,
+and `0` otherwise.
+
+## External Interface Access
+
+This plugin requires read access to `/sys/firmware/efi/mok-variables`.
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.0.7`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Richard Hughes: @hughsie

--- a/plugins/uefi-mok/fu-self-test.c
+++ b/plugins/uefi-mok/fu-self-test.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-context-private.h"
+#include "fu-plugin-private.h"
+#include "fu-uefi-mok-common.h"
+
+static void
+fu_uefi_mok_nx_disabled_func(void)
+{
+	g_autofree gchar *str = NULL;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_DIST, "tests", "HSIStatus-nx-disabled", NULL);
+	attr = fu_uefi_mok_attr_new(plugin, fn, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(attr);
+
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+
+	fwupd_security_attr_set_created(attr, 0);
+	str = fwupd_codec_to_string(FWUPD_CODEC(attr));
+	g_assert_cmpstr(str,
+			==,
+			"FuSecurityAttr:\n"
+			"  AppstreamId:          org.fwupd.hsi.Uefi.MemoryProtection\n"
+			"  HsiLevel:             2\n"
+			"  HsiResult:            not-enabled\n"
+			"  HsiResultSuccess:     locked\n"
+			"  Flags:                action-config-os\n"
+			"  Plugin:               uefi_mok\n"
+			"  has-dxe-services-table: 0\n"
+			"  has-get-memory-space-descriptor: 0\n"
+			"  has-memory-attribute-protocol: 0\n"
+			"  has-set-memory-space-attributes: 0\n"
+			"  heap-is-executable:   0\n"
+			"  ro-sections-are-writable: 0\n"
+			"  shim-has-nx-compat-set: 0\n"
+			"  stack-is-executable:  0\n");
+}
+
+static void
+fu_uefi_mok_nx_invalid_func(void)
+{
+	g_autofree gchar *str = NULL;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_DIST, "tests", "HSIStatus-nx-invalid", NULL);
+	attr = fu_uefi_mok_attr_new(plugin, fn, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(attr);
+
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED);
+	g_assert_false(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+
+	fwupd_security_attr_set_created(attr, 0);
+	str = fwupd_codec_to_string(FWUPD_CODEC(attr));
+	g_assert_cmpstr(str,
+			==,
+			"FuSecurityAttr:\n"
+			"  AppstreamId:          org.fwupd.hsi.Uefi.MemoryProtection\n"
+			"  HsiLevel:             2\n"
+			"  HsiResult:            not-locked\n"
+			"  HsiResultSuccess:     locked\n"
+			"  Flags:                action-contact-oem\n"
+			"  Plugin:               uefi_mok\n"
+			"  has-dxe-services-table: 1\n"
+			"  has-get-memory-space-descriptor: 0\n"
+			"  has-memory-attribute-protocol: 0\n"
+			"  has-set-memory-space-attributes: 0\n"
+			"  heap-is-executable:   1\n"
+			"  ro-sections-are-writable: 1\n"
+			"  shim-has-nx-compat-set: 1\n"
+			"  stack-is-executable:  1\n"
+			"  this-property-does-not-exist: 1\n");
+}
+
+static void
+fu_uefi_mok_nx_valid_func(void)
+{
+	g_autofree gchar *str = NULL;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuPlugin) plugin = fu_plugin_new(ctx);
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GError) error = NULL;
+
+	fn = g_test_build_filename(G_TEST_DIST, "tests", "HSIStatus-nx-valid", NULL);
+	attr = fu_uefi_mok_attr_new(plugin, fn, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(attr);
+
+	g_assert_cmpint(fwupd_security_attr_get_result(attr),
+			==,
+			FWUPD_SECURITY_ATTR_RESULT_LOCKED);
+	g_assert_true(fwupd_security_attr_has_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS));
+
+	fwupd_security_attr_set_created(attr, 0);
+	str = fwupd_codec_to_string(FWUPD_CODEC(attr));
+	g_assert_cmpstr(str,
+			==,
+			"FuSecurityAttr:\n"
+			"  AppstreamId:          org.fwupd.hsi.Uefi.MemoryProtection\n"
+			"  HsiLevel:             2\n"
+			"  HsiResult:            locked\n"
+			"  HsiResultSuccess:     locked\n"
+			"  Flags:                success\n"
+			"  Plugin:               uefi_mok\n"
+			"  has-dxe-services-table: 1\n"
+			"  has-get-memory-space-descriptor: 1\n"
+			"  has-memory-attribute-protocol: 1\n"
+			"  has-set-memory-space-attributes: 1\n"
+			"  heap-is-executable:   0\n"
+			"  ro-sections-are-writable: 0\n"
+			"  shim-has-nx-compat-set: 1\n"
+			"  stack-is-executable:  0\n");
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
+	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
+
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/uefi/mok{nx-disabled}", fu_uefi_mok_nx_disabled_func);
+	g_test_add_func("/uefi/mok{nx-invalid}", fu_uefi_mok_nx_invalid_func);
+	g_test_add_func("/uefi/mok{nx-valid}", fu_uefi_mok_nx_valid_func);
+	return g_test_run();
+}

--- a/plugins/uefi-mok/fu-uefi-mok-common.c
+++ b/plugins/uefi-mok/fu-uefi-mok-common.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-uefi-mok-common.h"
+#include "fu-uefi-mok-struct.h"
+
+FwupdSecurityAttr *
+fu_uefi_mok_attr_new(FuPlugin *plugin, const gchar *filename, GError **error)
+{
+	FuUefiMokHsiKey key_all = FU_UEFI_MOK_HSI_KEY_NONE;
+	g_auto(GStrv) lines = NULL;
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GBytes) blob = NULL;
+
+	/* create attr */
+	attr = fu_plugin_security_attr_new(plugin, FWUPD_SECURITY_ATTR_ID_UEFI_MEMORY_PROTECTION);
+	fwupd_security_attr_set_plugin(attr, "uefi_mok");
+	fwupd_security_attr_set_result_success(attr, FWUPD_SECURITY_ATTR_RESULT_LOCKED);
+	fwupd_security_attr_set_level(attr, FWUPD_SECURITY_ATTR_LEVEL_IMPORTANT);
+
+	/* split into lines */
+	blob = fu_bytes_get_contents(filename, error);
+	if (blob == NULL)
+		return NULL;
+	lines = fu_strsplit_bytes(blob, "\n", -1);
+	for (guint i = 0; lines[i] != NULL; i++) {
+		g_auto(GStrv) kv = NULL;
+
+		if (lines[i][0] == '\0')
+			continue;
+		kv = g_strsplit(lines[i], ": ", -1);
+		if (g_strv_length(kv) != 2)
+			continue;
+		if (g_strcmp0(kv[1], "1") == 0)
+			key_all |= fu_uefi_mok_hsi_key_from_string(kv[0]);
+		fwupd_security_attr_add_metadata(attr, kv[0], kv[1]);
+	}
+
+	/* is this valid? */
+	if ((key_all & FU_UEFI_MOK_HSI_KEY_SHIM_HAS_NX_COMPAT_SET) == 0) {
+		/* the bootloader is not marked as NX compatible and the firmware may be operating
+		 * in a compatibility mode */
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONFIG_OS);
+		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_ENABLED);
+	} else if ((key_all & FU_UEFI_MOK_HSI_KEY_HEAP_IS_EXECUTABLE) > 0 ||
+		   (key_all & FU_UEFI_MOK_HSI_KEY_STACK_IS_EXECUTABLE) > 0 ||
+		   (key_all & FU_UEFI_MOK_HSI_KEY_RO_SECTIONS_ARE_WRITABLE) > 0) {
+		/* the firmware is being dumb */
+		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_LOCKED);
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_ACTION_CONTACT_OEM);
+	} else {
+		fwupd_security_attr_add_flag(attr, FWUPD_SECURITY_ATTR_FLAG_SUCCESS);
+	}
+
+	/* success */
+	return g_steal_pointer(&attr);
+}

--- a/plugins/uefi-mok/fu-uefi-mok-common.h
+++ b/plugins/uefi-mok/fu-uefi-mok-common.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+FwupdSecurityAttr *
+fu_uefi_mok_attr_new(FuPlugin *plugin, const gchar *filename, GError **error);

--- a/plugins/uefi-mok/fu-uefi-mok-plugin.c
+++ b/plugins/uefi-mok/fu-uefi-mok-plugin.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-uefi-mok-common.h"
+#include "fu-uefi-mok-plugin.h"
+
+struct _FuUefiMokPlugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuUefiMokPlugin, fu_uefi_mok_plugin, FU_TYPE_PLUGIN)
+
+static gchar *
+fu_uefi_mok_plugin_get_filename(void)
+{
+	g_autofree gchar *sysfsdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW);
+	return g_build_filename(sysfsdir, "efi", "mok-variables", "HSIStatus", NULL);
+}
+
+static gboolean
+fu_uefi_mok_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	g_autofree gchar *fn = fu_uefi_mok_plugin_get_filename();
+
+	/* sanity check */
+	if (!g_file_test(fn, G_FILE_TEST_EXISTS)) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "%s does not exist", fn);
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_uefi_mok_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
+{
+	g_autoptr(FwupdSecurityAttr) attr = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autofree gchar *fn = fu_uefi_mok_plugin_get_filename();
+
+	attr = fu_uefi_mok_attr_new(plugin, fn, &error_local);
+	if (attr == NULL) {
+		g_warning("failed to load %s: %s", fn, error_local->message);
+		return;
+	}
+	fu_security_attrs_append(attrs, attr);
+}
+
+static void
+fu_uefi_mok_plugin_init(FuUefiMokPlugin *self)
+{
+}
+
+static void
+fu_uefi_mok_plugin_class_init(FuUefiMokPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->startup = fu_uefi_mok_plugin_startup;
+	plugin_class->add_security_attrs = fu_uefi_mok_plugin_add_security_attrs;
+}

--- a/plugins/uefi-mok/fu-uefi-mok-plugin.h
+++ b/plugins/uefi-mok/fu-uefi-mok-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuUefiMokPlugin, fu_uefi_mok_plugin, FU, UEFI_MOK_PLUGIN, FuPlugin)

--- a/plugins/uefi-mok/fu-uefi-mok.rs
+++ b/plugins/uefi-mok/fu-uefi-mok.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#[derive(FromString)]
+enum FuUefiMokHsiKey {
+    None                            = 0,
+    ShimHasNxCompatSet              = 1 << 0,
+    HeapIsExecutable                = 1 << 1,
+    StackIsExecutable               = 1 << 2,
+    RoSectionsAreWritable           = 1 << 3,
+    HasMemoryAttributeProtocol      = 1 << 4,
+    HasDxeServicesTable             = 1 << 5,
+    HasGetMemorySpaceDescriptor     = 1 << 6,
+    HasSetMemorySpaceAttributes     = 1 << 7,
+}

--- a/plugins/uefi-mok/meson.build
+++ b/plugins/uefi-mok/meson.build
@@ -1,0 +1,55 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginUefiMok"']
+
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+
+plugin_builtin_uefi_mok = static_library('fu_plugin_uefi_mok',
+  rustgen.process('fu-uefi-mok.rs'),
+  sources: [
+    'fu-uefi-mok-common.c',
+    'fu-uefi-mok-plugin.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+plugin_builtins += plugin_builtin_uefi_mok
+
+if get_option('tests')
+  install_data(
+    [
+      'tests/HSIStatus-nx-disabled',
+      'tests/HSIStatus-nx-invalid',
+      'tests/HSIStatus-nx-valid',
+    ],
+    install_dir: join_paths(installed_test_datadir, 'tests')
+  )
+  env = environment()
+  env.set('G_TEST_SRCDIR', meson.current_source_dir())
+  env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+  e = executable(
+    'uefi-mok-self-test',
+    rustgen.process('fu-uefi-mok.rs'),
+    sources: [
+      'fu-self-test.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: [
+      plugin_deps,
+      platform_deps,
+    ],
+    link_with: [
+      fwupd,
+      fwupdplugin,
+      plugin_builtin_uefi_mok,
+    ],
+    install: true,
+    install_rpath: libdir_pkg,
+    install_dir: installed_test_bindir,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
+  )
+  test('uefi-mok-self-test', e, env: env)
+endif

--- a/plugins/uefi-mok/tests/HSIStatus-nx-disabled
+++ b/plugins/uefi-mok/tests/HSIStatus-nx-disabled
@@ -1,0 +1,8 @@
+shim-has-nx-compat-set: 0
+heap-is-executable: 0
+stack-is-executable: 0
+ro-sections-are-writable: 0
+has-memory-attribute-protocol: 0
+has-dxe-services-table: 0
+has-get-memory-space-descriptor: 0
+has-set-memory-space-attributes: 0

--- a/plugins/uefi-mok/tests/HSIStatus-nx-invalid
+++ b/plugins/uefi-mok/tests/HSIStatus-nx-invalid
@@ -1,0 +1,10 @@
+# this is a comment
+this-property-does-not-exist: 1
+shim-has-nx-compat-set: 1
+heap-is-executable: 1
+stack-is-executable: 1
+ro-sections-are-writable: 1
+has-memory-attribute-protocol: 0
+has-dxe-services-table: 1
+has-get-memory-space-descriptor: 0
+has-set-memory-space-attributes: 0

--- a/plugins/uefi-mok/tests/HSIStatus-nx-valid
+++ b/plugins/uefi-mok/tests/HSIStatus-nx-valid
@@ -1,0 +1,8 @@
+shim-has-nx-compat-set: 1
+heap-is-executable: 0
+stack-is-executable: 0
+ro-sections-are-writable: 0
+has-memory-attribute-protocol: 1
+has-dxe-services-table: 1
+has-get-memory-space-descriptor: 1
+has-set-memory-space-attributes: 1

--- a/src/tests/efi/mok-variables/HSIStatus
+++ b/src/tests/efi/mok-variables/HSIStatus
@@ -1,0 +1,1 @@
+../../../../plugins/uefi-mok/tests/HSIStatus-nx-valid


### PR DESCRIPTION
Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
