### PR TITLE
uefi-capsule: Add support for capsule installation in the bootloader

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -469,6 +469,11 @@ fu_uefi_capsule_device_check_asset(FuUefiCapsuleDevice *self, GError **error)
 
 	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, error))
 		return FALSE;
+
+	/* if fwupd-efi isn't in use, skip checks for the signed binary */
+	if (!fu_device_has_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_USE_FWUPD_EFI))
+		return TRUE;
+
 	source_app = fu_uefi_get_built_app_path(efivars, "fwupd", error);
 	if (source_app == NULL && secureboot_enabled) {
 		g_prefix_error(error, "missing signed bootloader for secure boot: ");
@@ -786,6 +791,7 @@ fu_uefi_capsule_device_init(FuUefiCapsuleDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_UEFI_CAPSULE_DEVICE_FLAG_COD_DELL_RECOVERY);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_NO_ESP_BACKUP);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_USE_FWUPD_EFI);
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.h
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.h
@@ -35,6 +35,7 @@ struct _FuUefiCapsuleDeviceClass {
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_MODIFY_BOOTORDER	     "modify-bootorder"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_COD_DELL_RECOVERY	     "cod-dell-recovery"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_NO_ESP_BACKUP	     "no-esp-backup"
+#define FU_UEFI_CAPSULE_DEVICE_FLAG_USE_FWUPD_EFI	     "use-fwupd-efi"
 
 void
 fu_uefi_capsule_device_set_esp(FuUefiCapsuleDevice *self, FuVolume *esp);


### PR DESCRIPTION
This allows capsules to be installed by the system's regular bootloader, instead of fwupd-efi.

The bootloader signals support by creating a runtime-accessible UEFI var called `BootloaderSupportsFwupd` with the vendor set to `FU_EFIVARS_GUID_FWUPDATE`, and a one-byte value of 1.

Closes https://github.com/fwupd/fwupd/issues/8504

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
