### PR TITLE
redfish: add required Dell identifiers

### DIFF
--- a/plugins/redfish/fu-redfish-backend-vendors.c
+++ b/plugins/redfish/fu-redfish-backend-vendors.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 Arno Dubois <arno.du@orange.fr>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-redfish-backend-vendors.h"
+#include "fu-redfish-backend.h"
+
+G_DEFINE_TYPE(FuRedfishBackendVendorSpecific, fu_redfish_backend_vendors_specific, G_TYPE_OBJECT)
+
+struct _FuRedfishBackendDellSpecific {
+	FuRedfishBackendVendorSpecific parent_instance;
+	guint16 system_id;
+};
+G_DEFINE_TYPE(FuRedfishBackendDellSpecific,
+	      fu_redfish_backend_vendors_dell_specific,
+	      FU_TYPE_REDFISH_BACKEND_VENDOR_SPECIFIC)
+
+static void
+fu_redfish_backend_vendors_specific_class_init(FuRedfishBackendVendorSpecificClass *klass)
+{
+}
+
+static void
+fu_redfish_backend_vendors_specific_init(FuRedfishBackendVendorSpecific *self)
+{
+}
+
+static void
+fu_redfish_backend_vendors_dell_specific_class_init(FuRedfishBackendDellSpecificClass *klass)
+{
+}
+
+static void
+fu_redfish_backend_vendors_dell_specific_init(FuRedfishBackendDellSpecific *self)
+{
+	self->system_id = 0;
+}
+
+gboolean
+fu_redfish_backend_vendors_dell_specific_init_systemid(FuBackend *backend,
+						       FuRedfishBackendDellSpecific *dell_specific,
+						       FuProgress *progress,
+						       GError **error)
+{
+	JsonObject *json_obj = NULL;
+	g_autoptr(FuRedfishRequest) request =
+	    fu_redfish_backend_request_new(FU_REDFISH_BACKEND(backend));
+	const gchar *member_uri = NULL;
+	JsonArray *members = NULL;
+
+	if (!fu_redfish_request_perform(request,
+					"/redfish/v1/Systems",
+					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+					error))
+		return FALSE;
+	json_obj = fu_redfish_request_get_json_object(request);
+	if (!json_object_has_member(json_obj, "Members")) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no Members object");
+		return FALSE;
+	}
+
+	members = json_object_get_array_member(json_obj, "Members");
+	if (members != NULL && json_array_get_length(members) > 0) {
+		JsonObject *member = json_array_get_object_element(members, 0);
+		member_uri = json_object_get_string_member(member, "@odata.id");
+	} else {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "no Members array or array empty");
+		return FALSE;
+	}
+
+	g_free(request);
+	request = fu_redfish_backend_request_new(FU_REDFISH_BACKEND(backend));
+
+	if (fu_redfish_request_perform(request,
+				       member_uri,
+				       FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
+				       error)) {
+		JsonObject *oem_obj = NULL;
+		json_obj = fu_redfish_request_get_json_object(request);
+		oem_obj = json_object_get_object_member(json_obj, "Oem");
+		if (oem_obj != NULL) {
+			JsonObject *dell_obj = json_object_get_object_member(oem_obj, "Dell");
+			if (dell_obj != NULL) {
+				JsonObject *dell_system_obj =
+				    json_object_get_object_member(dell_obj, "DellSystem");
+				if (dell_system_obj != NULL &&
+				    json_object_has_member(dell_system_obj, "SystemID")) {
+					dell_specific->system_id = (unsigned short)
+					    json_object_get_int_member(dell_system_obj, "SystemID");
+					return TRUE;
+				}
+			}
+		}
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "no SystemID in system properties");
+	}
+	return FALSE;
+}
+
+guint16
+fu_redfish_backend_vendors_dell_specific_get_systemid(FuRedfishBackendDellSpecific *self)
+{
+	return self->system_id;
+}

--- a/plugins/redfish/fu-redfish-backend-vendors.h
+++ b/plugins/redfish/fu-redfish-backend-vendors.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Arno Dubois <arno.du@orange.fr>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_REDFISH_BACKEND_VENDOR_SPECIFIC (fu_redfish_backend_vendors_specific_get_type())
+G_DECLARE_DERIVABLE_TYPE(FuRedfishBackendVendorSpecific,
+			 fu_redfish_backend_vendors_specific,
+			 FU,
+			 REDFISH_BACKEND_VENDOR_SPECIFIC,
+			 GObject)
+
+struct _FuRedfishBackendVendorSpecificClass {
+	GObjectClass parent_class;
+};
+
+#define FU_TYPE_REDFISH_BACKEND_DELL_SPECIFIC (fu_redfish_backend_vendors_dell_specific_get_type())
+G_DECLARE_FINAL_TYPE(FuRedfishBackendDellSpecific,
+		     fu_redfish_backend_vendors_dell_specific,
+		     FU,
+		     REDFISH_BACKEND_DELL_SPECIFIC,
+		     FuRedfishBackendVendorSpecific)
+
+gboolean
+fu_redfish_backend_vendors_dell_specific_init_systemid(FuBackend *self,
+						       FuRedfishBackendDellSpecific *dell_backend,
+						       FuProgress *progress,
+						       GError **error);
+
+guint16
+fu_redfish_backend_vendors_dell_specific_get_systemid(FuRedfishBackendDellSpecific *self);

--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -8,6 +8,7 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-redfish-backend-vendors.h"
 #include "fu-redfish-request.h"
 
 #define FU_REDFISH_TYPE_BACKEND (fu_redfish_backend_get_type())
@@ -42,6 +43,8 @@ const gchar *
 fu_redfish_backend_get_push_uri_path(FuRedfishBackend *self);
 const gchar *
 fu_redfish_backend_get_session_key(FuRedfishBackend *self);
+FuRedfishBackendVendorSpecific *
+fu_redfish_backend_get_vendor_specific(FuRedfishBackend *self);
 gboolean
 fu_redfish_backend_create_session(FuRedfishBackend *self, GError **error);
 FuRedfishRequest *

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -16,6 +16,7 @@ plugin_builtin_redfish = static_library('fu_plugin_redfish',
   ),
   sources: [
     'fu-redfish-plugin.c',
+    'fu-redfish-backend-vendors.c',
     'fu-redfish-backend.c',
     'fu-redfish-common.c',     # fuzzing
     'fu-redfish-device.c',


### PR DESCRIPTION
This should allow us to properly identify which system it is and select the good firmware.

Note that is not ready yet, a few elements are missing, notably:
- tests
- do we actually want to keep the "SYSTEMID" property for the GUIDs? It looks cool, but IDK if it can break other systems. I could use another property, but I did not want to cannibalize a property that would not be coherent among vendors
- I have a doubt about the `fu_device_add_instance_str(dev, "ID", fu_device_get_backend_id(dev));`
- I still need to test an actual firmware upgrade, after I made the .cab packager for Dell firmware

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
