### PR TITLE
redfish: Only use the 'ID' instance ID for quirks

### DIFF
--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -501,7 +501,13 @@ fu_redfish_device_probe(FuDevice *dev, GError **error)
 	}
 
 	/* used for quirking and parenting */
-	fu_device_build_instance_id(dev, NULL, "REDFISH", "VENDOR", "ID", NULL);
+	fu_device_build_instance_id_full(dev,
+					 FU_DEVICE_INSTANCE_FLAG_QUIRKS,
+					 NULL,
+					 "REDFISH",
+					 "VENDOR",
+					 "ID",
+					 NULL);
 
 	if (json_object_has_member(member, "Name")) {
 		const gchar *tmp = json_object_get_string_member(member, "Name");


### PR DESCRIPTION
This matches what the README file and the comment, so make it true in reality.

Based on a patch by Arno DUBOIS <a.dubois@criteo.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
