### PR TITLE
usi-dock: Correctly format triplet numbers

### DIFF
--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -325,7 +325,7 @@ fu_usi_dock_mcu_device_enumerate_children(FuUsiDockMcuDevice *self, GError **err
 				g_debug("ignoring %s", components[i].name);
 				continue;
 			}
-			version = g_strdup_printf("%x.%x.%x", (guint)(val[2] >> 4), val[3], val[4]);
+			version = g_strdup_printf("%u.%u.%u", (guint)(val[2] >> 4), val[3], val[4]);
 			fu_device_set_version_format(child, FWUPD_VERSION_FORMAT_TRIPLET);
 			fu_device_set_version(child, version);
 			fu_device_add_icon(child, "network-wired");


### PR DESCRIPTION
This prevents a critical warning of:

    1.94.ff is not a valid triplet (guessed plain)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
