### PR TITLE
fix(meson): silence warning about str fmt files

### DIFF
--- a/data/device-tests/meson.build
+++ b/data/device-tests/meson.build
@@ -11,7 +11,7 @@ con.set('enumeration_datadir', enumeration_datadir)
 
 foreach test: device_tests
   configure_file(
-    input: join_paths(meson.project_source_root(),'@0@'.format(test)),
+    input: test,
     output: '@BASENAME@.json',
     configuration: con,
     install: true,


### PR DESCRIPTION
Since all members of device_tests are returned by the `files()` function, we can just use them regardless of the current working directory.

```
../data/device-tests/meson.build:14: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.3.0': str.format: Value other than strings, integers, bools, options, dictionaries and lists thereof..
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
