### PR TITLE
Fix build against pygobject 3.52

### DIFF
--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -5,7 +5,8 @@ BUILD=${VENV}/build
 INSTALLED_TESTS=${VENV}/dist/share/installed-tests/fwupd
 export G_TEST_BUILDDIR=${INSTALLED_TESTS}
 export G_TEST_SRCDIR=${INSTALLED_TESTS}
-export LIBFWUPD_BUILD_DIR=${BUILD}/libfwupd
+export GI_TYPELIB_PATH=${BUILD}/libfwupd
+export LD_LIBRARY_PATH=${BUILD}/libfwupd
 export DAEMON_BUILDDIR=${BUILD}/src
 export PATH=${VENV}/bin:$PATH
 

--- a/data/tests/fwupd_test.py
+++ b/data/tests/fwupd_test.py
@@ -22,19 +22,6 @@ gi.require_version("UMockdev", "1.0")
 from gi.repository import UMockdev
 
 
-def override_gi_search_path():
-    if "LIBFWUPD_BUILD_DIR" in os.environ:
-        gi.require_version("GIRepository", "2.0")
-        from gi.repository import GIRepository
-
-        GIRepository.Repository.prepend_search_path(
-            os.path.join(os.environ["LIBFWUPD_BUILD_DIR"])
-        )
-        GIRepository.Repository.prepend_library_path(
-            os.path.join(os.environ["LIBFWUPD_BUILD_DIR"])
-        )
-
-
 class FwupdTest(dbusmock.DBusTestCase):
     DBUS_NAME = "org.freedesktop.fwupd"
     DBUS_PATH = "/"
@@ -59,8 +46,6 @@ class FwupdTest(dbusmock.DBusTestCase):
         # set up a fake system D-BUS
         cls.start_system_bus()
         cls.dbus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
-
-        override_gi_search_path()
 
     def setUp(self):
         self.testbed = UMockdev.Testbed.new()

--- a/data/tests/meson.build
+++ b/data/tests/meson.build
@@ -140,10 +140,11 @@ if umockdev_integration_tests.allowed()
   foreach ut: unit_tests
       test(ut, python3, args: [fwupd_mockdev_tests, ut], is_parallel: false,
           env: {
-            'DAEMON_BUILDDIR': join_paths(meson.project_build_root(), 'src'),
-            'LIBFWUPD_BUILD_DIR': join_paths(meson.project_build_root(), 'libfwupd'),
-            'STATE_DIRECTORY': join_paths(meson.project_build_root(), 'state'),
             'CACHE_DIRECTORY': join_paths(meson.project_build_root(), 'cache'),
+            'DAEMON_BUILDDIR': join_paths(meson.project_build_root(), 'src'),
+            'GI_TYPELIB_PATH': join_paths(meson.project_build_root(), 'libfwupd'),
+            'LD_LIBRARY_PATH': join_paths(meson.project_build_root(), 'libfwupd'),
+            'STATE_DIRECTORY': join_paths(meson.project_build_root(), 'state')
           },
           )
   endforeach

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -153,12 +153,13 @@ endforeach
 
 if umockdev_integration_tests.allowed()
   envs = environment()
-  envs.set('DAEMON_BUILDDIR', join_paths(meson.project_build_root(), 'src'))
-  envs.set('LIBFWUPD_BUILD_DIR', join_paths(meson.project_build_root(), 'libfwupd'))
-  envs.set('PYTHONPATH', join_paths(meson.project_source_root(), 'data', 'tests'))
-  envs.set('FWUPD_DATADIR_QUIRKS', join_paths(meson.project_build_root()))
-  envs.set('STATE_DIRECTORY', join_paths(meson.project_build_root(), 'state'))
   envs.set('CACHE_DIRECTORY', join_paths(meson.project_build_root(), 'cache'))
+  envs.set('DAEMON_BUILDDIR', join_paths(meson.project_build_root(), 'src'))
+  envs.set('FWUPD_DATADIR_QUIRKS', join_paths(meson.project_build_root()))
+  envs.set('GI_TYPELIB_PATH', join_paths(meson.project_build_root(), 'libfwupd'))
+  envs.set('LD_LIBRARY_PATH', join_paths(meson.project_build_root(), 'libfwupd'))
+  envs.set('PYTHONPATH', join_paths(meson.project_source_root(), 'data', 'tests'))
+  envs.set('STATE_DIRECTORY', join_paths(meson.project_build_root(), 'state'))
 
   foreach suite: umockdev_tests
     r = run_command(unittest_inspector, suite,

--- a/plugins/pci-psp/pci_psp_test.py
+++ b/plugins/pci-psp/pci_psp_test.py
@@ -8,10 +8,9 @@ import gi
 import os
 import sys
 import unittest
-from fwupd_test import FwupdTest, override_gi_search_path
+from fwupd_test import FwupdTest
 
 try:
-    override_gi_search_path()
     gi.require_version("Fwupd", "2.0")
     from gi.repository import Fwupd  # pylint: disable=wrong-import-position
 except ValueError:


### PR DESCRIPTION
With the introduction of pygobject 3.52, accessing GIRepository 2.0 is
no longer permitted.

Instead of complicating the test code with conditionalizing between
GIRepository 2.0 and GIRepository 3.0 in override_gi_search_path,
we can drop override_gi_search_path entirely and rely on GIRepository's
own envvar GI_TYPELIB_PATH to help it find our freshly built typelib

Fixes #8569

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
