### PR TITLE
qc-s5gen2: rename enum value Last

### DIFF
--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -583,7 +583,7 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 			return FALSE;
 		}
 
-		more_data = (blobsz <= (cur_offset + data_sz)) ? FU_QC_MORE_DATA_LAST
+		more_data = (blobsz <= (cur_offset + data_sz)) ? FU_QC_MORE_DATA_LAST_PACKET
 							       : FU_QC_MORE_DATA_MORE;
 
 		data_out = g_bytes_new_from_bytes(bytes, cur_offset, data_sz);
@@ -599,7 +599,7 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 
 		/* FIXME: petentially infinite loop if device requesting wrong data?
 		   some counter or timeout? */
-	} while (more_data != FU_QC_MORE_DATA_LAST);
+	} while (more_data != FU_QC_MORE_DATA_LAST_PACKET);
 
 	/* success */
 	return TRUE;

--- a/plugins/qc-s5gen2/fu-qc-s5gen2.rs
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2.rs
@@ -149,7 +149,7 @@ struct FuStructQcStartDataReq {
 #[repr(u8)]
 enum FuQcMoreData {
     More,
-    Last,
+    LastPacket,
 }
 #[derive(Parse, Default)]
 #[repr(C, packed)]


### PR DESCRIPTION
The ac473b8 commit added redefinition of the FU_QC_MORE_DATA_LAST value.
See https://github.com/fwupd/fwupd/issues/8592 for details.

Explicitly rename the value to avoid even occasional intersections.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
