### PR TITLE
logitech-rallysystem: Fix a small memory leak when emumerating devices

### DIFF
--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-plugin.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-plugin.c
@@ -45,9 +45,8 @@ fu_logitech_rallysystem_plugin_device_added(FuPlugin *plugin, FuDevice *device)
 			for (guint i = 0; i < devices->len; i++) {
 				FuDevice *device_tmp = g_ptr_array_index(devices, i);
 				if (FU_IS_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE(device_tmp)) {
-					fu_device_set_version(
-					    device_tmp,
-					    strdup(fu_device_get_version(device)));
+					fu_device_set_version(device_tmp,
+							      fu_device_get_version(device));
 					g_debug("overwriting tablehub version to: %s",
 						fu_device_get_version(device));
 					break;
@@ -58,9 +57,8 @@ fu_logitech_rallysystem_plugin_device_added(FuPlugin *plugin, FuDevice *device)
 			for (guint i = 0; i < devices->len; i++) {
 				FuDevice *device_tmp = g_ptr_array_index(devices, i);
 				if (FU_IS_LOGITECH_RALLYSYSTEM_AUDIO_DEVICE(device_tmp)) {
-					fu_device_set_version(
-					    device,
-					    strdup(fu_device_get_version(device_tmp)));
+					fu_device_set_version(device,
+							      fu_device_get_version(device_tmp));
 					g_debug("overwriting tablehub version to %s",
 						fu_device_get_version(device_tmp));
 					break;


### PR DESCRIPTION
Found using `meson configure -Dc_args="-fanalyzer"`

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
