### PR TITLE
trivial: fix "** Expected a Fwupd.DeviceFlags, but got int ***"

### DIFF
--- a/contrib/firmware_packager/install_dell_bios_exe.py
+++ b/contrib/firmware_packager/install_dell_bios_exe.py
@@ -68,10 +68,10 @@ def find_uefi_device(client, deviceid):
             if item.get_id() != deviceid:
                 continue
         # internal
-        if not item.has_flag(1 << 0):
+        if not item.has_flag(Fwupd.DeviceFlags.INTERNAL):
             continue
         # needs reboot
-        if not item.has_flag(1 << 8):
+        if not item.has_flag(Fwupd.DeviceFlags.NEEDS_REBOOT):
             continue
         # return the first hit for UEFI plugin
         if item.get_plugin() == "uefi" or item.get_plugin() == "uefi_capsule":


### PR DESCRIPTION
Adjust the script to use the correct value.

Suggested-by: Adrien Dorsaz <adrien@adorsaz.ch>
Link: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1093432

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
