### PR TITLE
qc-s5gen2: Use the explicit Last value

### DIFF
--- a/libfwupdplugin/fu-rustgen-enum.h.in
+++ b/libfwupdplugin/fu-rustgen-enum.h.in
@@ -8,7 +8,7 @@ typedef enum {
 {%- endfor %}
 } {{obj.c_type}};
 
-{%- if not obj.items_any_defaults %}
+{%- if not obj.items_any_defaults and not obj.item('Last') %}
 #define {{obj.c_define_last}} {{obj.items|length}}
 {%- endif %}
 


### PR DESCRIPTION
If we see an enum entry of 'Last' then don't create the _LAST auto-define.

Based on a patch by Denis Pynkin <denis.pynkin@collabora.com>, many thanks.

Fixes https://github.com/fwupd/fwupd/issues/8592

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
