### PR TITLE
trivial: Match visible GUIDs when getting the device during replug

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -435,7 +435,8 @@ fu_device_list_get_by_guids_removed(FuDeviceList *self, GPtrArray *guids)
 			if (fu_device_has_guid(item->device, guid) ||
 			    fu_device_has_instance_id(item->device,
 						      guid,
-						      FU_DEVICE_INSTANCE_FLAG_COUNTERPART))
+						      FU_DEVICE_INSTANCE_FLAG_COUNTERPART |
+							  FU_DEVICE_INSTANCE_FLAG_VISIBLE))
 				return item;
 		}
 	}
@@ -450,7 +451,8 @@ fu_device_list_get_by_guids_removed(FuDeviceList *self, GPtrArray *guids)
 			if (fu_device_has_guid(item->device_old, guid) ||
 			    fu_device_has_instance_id(item->device_old,
 						      guid,
-						      FU_DEVICE_INSTANCE_FLAG_COUNTERPART))
+						      FU_DEVICE_INSTANCE_FLAG_COUNTERPART |
+							  FU_DEVICE_INSTANCE_FLAG_VISIBLE))
 				return item;
 		}
 	}


### PR DESCRIPTION
This saves adding CounterpartGuid entries that just list the same GUIDs as used in runtime.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
