### PR TITLE
qc-firehose: Split out FuDevice->attach() to allow device recovery

### DIFF
--- a/plugins/qc-firehose/fu-qc-firehose-impl.h
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.h
@@ -31,3 +31,5 @@ fu_qc_firehose_impl_write_firmware(FuQcFirehoseImpl *self,
 				   gboolean no_zlp,
 				   FuProgress *progress,
 				   GError **error) G_GNUC_NON_NULL(1, 2, 4);
+gboolean
+fu_qc_firehose_impl_reset(FuQcFirehoseImpl *self, GError **error) G_GNUC_NON_NULL(1);

--- a/plugins/qc-firehose/fu-qc-firehose-raw-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-raw-device.c
@@ -191,6 +191,7 @@ fu_qc_firehose_raw_device_init(FuQcFirehoseRawDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);

--- a/plugins/qc-firehose/fu-qc-firehose-raw-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-raw-device.c
@@ -66,6 +66,23 @@ fu_qc_firehose_raw_device_impl_write_firmware(FuDevice *device,
 }
 
 static gboolean
+fu_qc_firehose_raw_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuQcFirehoseRawDevice *self = FU_QC_FIREHOSE_RAW_DEVICE(device);
+
+	/* if called in recovery we have no supported functions */
+	if (self->supported_functions == 0 ||
+	    (self->supported_functions & FU_QC_FIREHOSE_FUNCTIONS_POWER) > 0) {
+		if (!fu_qc_firehose_impl_reset(FU_QC_FIREHOSE_IMPL(self), error))
+			return FALSE;
+	}
+
+	/* success */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}
+
+static gboolean
 fu_qc_firehose_raw_device_probe(FuDevice *device, GError **error)
 {
 	const gchar *device_file;
@@ -189,4 +206,5 @@ fu_qc_firehose_raw_device_class_init(FuQcFirehoseRawDeviceClass *klass)
 	device_class->write_firmware = fu_qc_firehose_raw_device_impl_write_firmware;
 	device_class->set_progress = fu_qc_firehose_raw_device_set_progress;
 	device_class->probe = fu_qc_firehose_raw_device_probe;
+	device_class->attach = fu_qc_firehose_raw_device_attach;
 }

--- a/plugins/qc-firehose/fu-qc-firehose-raw-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-raw-device.c
@@ -183,7 +183,6 @@ fu_qc_firehose_raw_device_impl_iface_init(FuQcFirehoseImplInterface *iface)
 static void
 fu_qc_firehose_raw_device_init(FuQcFirehoseRawDevice *self)
 {
-	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_set_name(FU_DEVICE(self), "Firehose");
 	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.firehose");
 	fu_device_set_version(FU_DEVICE(self), "0.0");
@@ -193,7 +192,7 @@ fu_qc_firehose_raw_device_init(FuQcFirehoseRawDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
-	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_remove_delay(FU_DEVICE(self), 60000);
 	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -207,6 +207,23 @@ fu_qc_firehose_usb_device_probe(FuDevice *device, GError **error)
 }
 
 static gboolean
+fu_qc_firehose_usb_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuQcFirehoseUsbDevice *self = FU_QC_FIREHOSE_USB_DEVICE(device);
+
+	/* if called in recovery we have no supported functions */
+	if (self->supported_functions == 0 ||
+	    (self->supported_functions & FU_QC_FIREHOSE_FUNCTIONS_POWER) > 0) {
+		if (!fu_qc_firehose_impl_reset(FU_QC_FIREHOSE_IMPL(self), error))
+			return FALSE;
+	}
+
+	/* success */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}
+
+static gboolean
 fu_qc_firehose_usb_device_impl_write_firmware(FuDevice *device,
 					      FuFirmware *firmware,
 					      FuProgress *progress,
@@ -335,5 +352,6 @@ fu_qc_firehose_usb_device_class_init(FuQcFirehoseUsbDeviceClass *klass)
 	device_class->probe = fu_qc_firehose_usb_device_probe;
 	device_class->replace = fu_qc_firehose_usb_device_replace;
 	device_class->write_firmware = fu_qc_firehose_usb_device_impl_write_firmware;
+	device_class->attach = fu_qc_firehose_usb_device_attach;
 	device_class->set_progress = fu_qc_firehose_usb_device_set_progress;
 }

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -337,6 +337,7 @@ fu_qc_firehose_usb_device_init(FuQcFirehoseUsbDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_QC_FIREHOSE_USB_DEVICE_NO_ZLP);

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -332,14 +332,13 @@ fu_qc_firehose_usb_device_sahara_impl_iface_init(FuQcFirehoseSaharaImplInterface
 static void
 fu_qc_firehose_usb_device_init(FuQcFirehoseUsbDevice *self)
 {
-	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.firehose");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
-	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_remove_delay(FU_DEVICE(self), 60000);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_QC_FIREHOSE_USB_DEVICE_NO_ZLP);
 	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0x00);
 	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);

--- a/plugins/qc-firehose/tests/qc-eg25ggc.json
+++ b/plugins/qc-firehose/tests/qc-eg25ggc.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "url": "https://fwupd.org/downloads/b1cd72c75053f5c29e55784ef30e5d4be722c1aacc2400995b1ee248f07be7d6-EG25GGC-0.0.cab",
-      "emulation-url": "https://fwupd.org/downloads/e7697987b10173ec94b98624ab31a0f16433e3c36cecc7aee53c3fc593b90209-emulation.zip",
+      "emulation-url": "https://fwupd.org/downloads/0f21d648b33736fa0f8d1ec36805627291428c5a6197cc2443988ccb80df0fa4-emulation.zip",
       "components": [
         {
           "version": "0.0",

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1075,6 +1075,7 @@ fu_engine_remove_device_flag(FuEngine *self,
 				    fu_device_get_id(device));
 			return FALSE;
 		}
+		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 		fu_backend_device_removed(fu_device_get_backend(device), device);
 		return TRUE;
 	}


### PR DESCRIPTION
If the FuDevice->write_firmware() fails then we want to 'recover' the device back to runtime so that the user does not think the modem is bricked.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
