### PR TITLE
trivial: Allow plugins to restart the install-loop without using hacks

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -315,6 +315,7 @@ fu_device_register_flags(FuDevice *self)
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_COUNTERPART_VISIBLE);
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_DETACH_PREPARE_FIRMWARE);
 	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_EMULATED_REQUIRE_SETUP);
+	fu_device_register_private_flag_safe(self, FU_DEVICE_PRIVATE_FLAG_INSTALL_LOOP_RESTART);
 }
 
 static void

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -822,6 +822,16 @@ fu_device_new(FuContext *ctx);
  */
 #define FU_DEVICE_PRIVATE_FLAG_EMULATED_REQUIRE_SETUP "emulated-require-setup"
 
+/**
+ * FU_DEVICE_PRIVATE_FLAG_INSTALL_LOOP_RESTART:
+ *
+ * Restart the `detach->write_firmware->attach->reload` loop without completing the sequence.
+ * This can be set on any step, unlike `another-write-required` which does all steps.
+ *
+ * Since: 2.0.7
+ */
+#define FU_DEVICE_PRIVATE_FLAG_INSTALL_LOOP_RESTART "install-loop-restart"
+
 /* accessors */
 gchar *
 fu_device_to_string(FuDevice *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3031,11 +3031,11 @@ fu_chunk_func(void)
 	chunked5 = fu_chunk_array_new(NULL, 0, 0x0, 0x0, 4);
 	g_assert_cmpint(chunked5->len, ==, 0);
 	chunked5_str = fu_chunk_array_to_string(chunked5);
-#if LIBXMLB_CHECK_VERSION(0, 3, 22)
-	g_assert_cmpstr(chunked5_str, ==, "<chunks />\n");
-#else
-	g_assert_cmpstr(chunked5_str, ==, "<chunks>\n</chunks>\n");
-#endif
+	if (fu_version_compare(xb_version_string(), "0.3.22", FWUPD_VERSION_FORMAT_TRIPLET) >= 0) {
+		g_assert_cmpstr(chunked5_str, ==, "<chunks />\n");
+	} else {
+		g_assert_cmpstr(chunked5_str, ==, "<chunks>\n</chunks>\n");
+	}
 
 	chunked1 = fu_chunk_array_new((const guint8 *)"0123456789abcdef", 16, 0x0, 10, 4);
 	chunked1_str = fu_chunk_array_to_string(chunked1);

--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -235,8 +235,7 @@ fu_qc_firehose_impl_write_xml(FuQcFirehoseImpl *self, XbBuilderNode *bn, GError 
 	    error);
 	if (xml == NULL)
 		return FALSE;
-#if !LIBXMLB_CHECK_VERSION(0, 3, 22)
-	{
+	if (fu_version_compare(xb_version_string(), "0.3.22", FWUPD_VERSION_FORMAT_TRIPLET) < 0) {
 		/* firehose is *very* picky about XML and will not accept empty elements */
 		GString *xml_fixed = g_string_new(xml);
 		g_string_replace(xml_fixed, ">\n  </configure>", " />", 0);
@@ -248,7 +247,6 @@ fu_qc_firehose_impl_write_xml(FuQcFirehoseImpl *self, XbBuilderNode *bn, GError 
 		g_free(xml);
 		xml = g_string_free(xml_fixed, FALSE);
 	}
-#endif
 	g_debug("XML request: %s", xml);
 	return fu_device_retry(FU_DEVICE(self), fu_qc_firehose_impl_write_xml_cb, 5, xml, error);
 }

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -327,6 +327,13 @@ fu_test_plugin_write_firmware(FuPlugin *plugin,
 		fu_device_set_metadata_boolean(device, "DoneAnotherWriteRequired", TRUE);
 	}
 
+	/* do this all over again */
+	if (fu_plugin_get_config_value_boolean(plugin, "InstallLoopRestart") &&
+	    !fu_device_get_metadata_boolean(device, "DoneInstallLoopRestart")) {
+		fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_INSTALL_LOOP_RESTART);
+		fu_device_set_metadata_boolean(device, "DoneInstallLoopRestart", TRUE);
+	}
+
 	/* for the self tests only */
 	fu_device_set_metadata_integer(device,
 				       "nr-update",
@@ -374,6 +381,15 @@ fu_test_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GError **
 	return TRUE;
 }
 
+static gboolean
+fu_test_plugin_attach(FuPlugin *plugin, FuDevice *device, FuProgress *progress, GError **error)
+{
+	fu_device_set_metadata_integer(device,
+				       "nr-attach",
+				       fu_device_get_metadata_integer(device, "nr-attach") + 1);
+	return TRUE;
+}
+
 static void
 fu_test_plugin_init(FuTestPlugin *self)
 {
@@ -385,6 +401,7 @@ fu_test_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_config_default(plugin, "AnotherWriteRequired", "false");
+	fu_plugin_set_config_default(plugin, "InstallLoopRestart", "false");
 	fu_plugin_set_config_default(plugin, "CompositeChild", "false");
 	fu_plugin_set_config_default(plugin, "DecompressDelay", "0");
 	fu_plugin_set_config_default(plugin, "NeedsActivation", "false");
@@ -418,6 +435,7 @@ fu_test_plugin_class_init(FuTestPluginClass *klass)
 	plugin_class->activate = fu_test_plugin_activate;
 	plugin_class->write_firmware = fu_test_plugin_write_firmware;
 	plugin_class->verify = fu_test_plugin_verify;
+	plugin_class->attach = fu_test_plugin_attach;
 	plugin_class->coldplug = fu_test_plugin_coldplug;
 	plugin_class->device_registered = fu_test_plugin_device_registered;
 	plugin_class->modify_config = fu_test_plugin_modify_config;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -3444,6 +3444,9 @@ fu_engine_install_request(gconstpointer user_data)
 	fu_engine_set_silo(engine, silo_empty);
 
 	/* set up dummy plugin */
+	ret = fu_plugin_reset_config_values(plugin, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 	ret = fu_plugin_set_config_value(plugin, "RequestSupported", "true", &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -3541,6 +3544,9 @@ fu_engine_history_error_func(gconstpointer user_data)
 	fu_engine_set_silo(engine, silo_empty);
 
 	/* set up dummy plugin */
+	ret = fu_plugin_reset_config_values(plugin, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 	ret = fu_plugin_set_config_value(plugin, "WriteSupported", "false", &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -4675,6 +4681,9 @@ fu_plugin_module_func(gconstpointer user_data)
 	fu_engine_set_silo(engine, silo_empty);
 
 	/* create a fake device */
+	ret = fu_plugin_reset_config_values(plugin, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 	ret = fu_plugin_set_config_value(plugin, "RegistrationSupported", "true", &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
