### PR TITLE
Put a memory limit on decoding LZMA streams

### DIFF
--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -89,7 +89,7 @@ fu_efi_section_parse_lzma_sections(FuEfiSection *self,
 	blob = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, NULL, error);
 	if (blob == NULL)
 		return FALSE;
-	blob_uncomp = fu_lzma_decompress_bytes(blob, error);
+	blob_uncomp = fu_lzma_decompress_bytes(blob, 128 * 1024 * 1024, error);
 	if (blob_uncomp == NULL) {
 		g_prefix_error(error, "failed to decompress: ");
 		return FALSE;

--- a/libfwupdplugin/fu-lzma-common.c
+++ b/libfwupdplugin/fu-lzma-common.c
@@ -13,21 +13,21 @@
 /**
  * fu_lzma_decompress_bytes:
  * @blob: data
+ * @memlimit: decompression memory limit, in bytes
  * @error: (nullable): optional return location for an error
  *
  * Decompresses a LZMA stream.
  *
- * Returns: decompressed data
+ * Returns: (transfer full): decompressed data
  *
- * Since: 1.9.8
+ * Since: 2.0.7
  **/
 GBytes *
-fu_lzma_decompress_bytes(GBytes *blob, GError **error)
+fu_lzma_decompress_bytes(GBytes *blob, guint64 memlimit, GError **error)
 {
 	const gsize tmpbufsz = 0x20000;
 	lzma_ret rc;
 	lzma_stream strm = LZMA_STREAM_INIT;
-	uint64_t memlimit = G_MAXUINT32;
 	g_autofree guint8 *tmpbuf = g_malloc0(tmpbufsz);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
@@ -73,7 +73,7 @@ fu_lzma_decompress_bytes(GBytes *blob, GError **error)
  *
  * Compresses into a LZMA stream.
  *
- * Returns: compressed data
+ * Returns: (transfer full): compressed data
  *
  * Since: 1.9.8
  **/

--- a/libfwupdplugin/fu-lzma-common.h
+++ b/libfwupdplugin/fu-lzma-common.h
@@ -9,6 +9,6 @@
 #include <fwupd.h>
 
 GBytes *
-fu_lzma_decompress_bytes(GBytes *blob, GError **error) G_GNUC_NON_NULL(1);
+fu_lzma_decompress_bytes(GBytes *blob, guint64 memlimit, GError **error) G_GNUC_NON_NULL(1);
 GBytes *
 fu_lzma_compress_bytes(GBytes *blob, GError **error) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -6253,7 +6253,7 @@ fu_lzma_func(void)
 	g_assert_cmpint(g_bytes_get_size(blob_out), <, 500);
 
 	/* decompress */
-	blob_orig = fu_lzma_decompress_bytes(blob_out, &error);
+	blob_orig = fu_lzma_decompress_bytes(blob_out, 128 * 1024 * 1024, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(blob_orig);
 	ret = fu_bytes_compare(blob_in, blob_orig, &error);

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -136,7 +136,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		payload_tmp = fu_input_stream_read_bytes(stream, hdrsz, payloadsz, NULL, error);
 		if (payload_tmp == NULL)
 			return FALSE;
-		payload = fu_lzma_decompress_bytes(payload_tmp, error);
+		payload = fu_lzma_decompress_bytes(payload_tmp, 16 * 1024 * 1024, error);
 		if (payload == NULL)
 			return FALSE;
 	} else if (priv->compression == FU_USWID_PAYLOAD_COMPRESSION_NONE) {


### PR DESCRIPTION
This prevents the fuzzer from allocating ~3GB of RSS when decoding an invalid uSWID blob.

Fixes https://issues.oss-fuzz.com/u/1/issues/405498892

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
