### PR TITLE
trivial: Allow installing firmware from emulations in fwupdtool

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -351,15 +351,6 @@ fu_engine_set_emulator_phase(FuEngine *self, FuEngineEmulatorPhase emulator_phas
 	self->emulator_phase = emulator_phase;
 }
 
-gboolean
-fu_engine_emulation_load_phase(FuEngine *self, FuEngineEmulatorPhase emulator_phase, GError **error)
-{
-	return fu_engine_emulator_load_phase(self->emulation,
-					     emulator_phase,
-					     FU_ENGINE_EMULATOR_WRITE_COUNT_DEFAULT,
-					     error);
-}
-
 static void
 fu_engine_watch_device(FuEngine *self, FuDevice *device)
 {

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -273,10 +273,6 @@ gboolean
 fu_engine_emulation_load(FuEngine *self, GInputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_engine_emulation_load_phase(FuEngine *self,
-			       FuEngineEmulatorPhase emulator_phase,
-			       GError **error);
-gboolean
 fu_engine_emulation_save(FuEngine *self, GOutputStream *stream, GError **error)
     G_GNUC_NON_NULL(1, 2);
 gboolean


### PR DESCRIPTION
This makes it a lot more valuable as you can use `--plugins` to speed up the engine startup and increase the speed of debugging.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
