### PR TITLE
qc-firehose: Detect the protocol features if not automatically sent

### DIFF
--- a/plugins/qc-firehose/fu-qc-firehose-impl-common.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl-common.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-qc-firehose-impl-common.h"
+
+/**
+ * fu_qc_firehose_impl_retry:
+ * @self: (nullable): a #FuQcFirehoseImpl
+ * @timeout_ms: timeout total
+ * @func: (scope caller): a #FuQcFirehoseImplRetryFunc
+ * @user_data: pointer for @func
+ * @error: (nullable): optional return location for an error
+ *
+ * Retry @func up to 100 times, but if the function keeps replying with "timeout" then this will
+ * abort with a failure after @timeout_ms.
+ *
+ * NOTE: we can't use `GTimer` or `g_usleep()` here as we want to do this in ~0 time when emulating,
+ * so keep a counter of the timeout total and assume that @func is limited to 500ms.
+ *
+ * Returns: %TRUE for success
+ **/
+gboolean
+fu_qc_firehose_impl_retry(FuQcFirehoseImpl *self,
+			  guint timeout_ms,
+			  FuQcFirehoseImplRetryFunc func,
+			  gpointer user_data,
+			  GError **error)
+{
+	const guint retry_cnt = 100;
+	const guint retry_timeout = 500; /* ms */
+	guint total_ms = 0;
+
+	g_return_val_if_fail(func != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* try up to retry_cnt tries, but always less than timeout_ms */
+	for (guint i = 0; total_ms < timeout_ms; i++) {
+		gboolean done = FALSE;
+		g_autoptr(GError) error_local = NULL;
+
+		/* sanity check */
+		if (i >= retry_cnt) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "retry limit %u reached: ",
+				    retry_cnt);
+			return FALSE;
+		}
+		if (!func(self, &done, retry_timeout, user_data, &error_local)) {
+			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
+				g_propagate_error(error, g_steal_pointer(&error_local));
+				return FALSE;
+			}
+			g_debug("ignoring: %s", error_local->message);
+			total_ms += retry_timeout;
+		} else if (done) {
+			return TRUE;
+		}
+	}
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, "timed out after %ums", total_ms);
+	return FALSE;
+}

--- a/plugins/qc-firehose/fu-qc-firehose-impl-common.h
+++ b/plugins/qc-firehose/fu-qc-firehose-impl-common.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-qc-firehose-impl.h"
+
+typedef gboolean (*FuQcFirehoseImplRetryFunc)(FuQcFirehoseImpl *self,
+					      gboolean *done,
+					      guint timeout_ms,
+					      gpointer user_data,
+					      GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+gboolean
+fu_qc_firehose_impl_retry(FuQcFirehoseImpl *self,
+			  guint timeout_ms,
+			  FuQcFirehoseImplRetryFunc func,
+			  gpointer user_data,
+			  GError **error) G_GNUC_NON_NULL(3);

--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -8,11 +8,10 @@
 
 #include "config.h"
 
+#include "fu-qc-firehose-impl-common.h"
 #include "fu-qc-firehose-impl.h"
 
-G_DEFINE_INTERFACE(FuQcFirehoseImpl, fu_qc_firehose_impl, FU_TYPE_DEVICE)
-
-#define FU_QC_FIREHOSE_IMPL_TIMEOUT_MS 500
+G_DEFINE_INTERFACE(FuQcFirehoseImpl, fu_qc_firehose_impl, G_TYPE_OBJECT)
 
 static void
 fu_qc_firehose_impl_default_init(FuQcFirehoseImplInterface *iface)
@@ -38,7 +37,11 @@ fu_qc_firehose_impl_read(FuQcFirehoseImpl *self, guint timeout_ms, GError **erro
 }
 
 static gboolean
-fu_qc_firehose_impl_write(FuQcFirehoseImpl *self, const guint8 *buf, gsize bufsz, GError **error)
+fu_qc_firehose_impl_write(FuQcFirehoseImpl *self,
+			  const guint8 *buf,
+			  gsize bufsz,
+			  guint timeout_ms,
+			  GError **error)
 {
 	FuQcFirehoseImplInterface *iface;
 
@@ -52,7 +55,7 @@ fu_qc_firehose_impl_write(FuQcFirehoseImpl *self, const guint8 *buf, gsize bufsz
 				    "iface->write not implemented");
 		return FALSE;
 	}
-	return (*iface->write)(self, buf, bufsz, error);
+	return (*iface->write)(self, buf, bufsz, timeout_ms, error);
 }
 
 static gboolean
@@ -81,11 +84,21 @@ fu_qc_firehose_impl_add_function(FuQcFirehoseImpl *self, FuQcFirehoseFunctions f
 	return (*iface->add_function)(self, func);
 }
 
-static void
-fu_qc_firehose_impl_parse_log_text(FuQcFirehoseImpl *self, const gchar *text)
+typedef gboolean (*FuQcFirehoseImplReadFunc)(FuQcFirehoseImpl *self,
+					     XbNode *xn,
+					     gboolean *done,
+					     GError **error) G_GNUC_WARN_UNUSED_RESULT;
+
+static gboolean
+fu_qc_firehose_impl_read_xml_init_log(FuQcFirehoseImpl *self,
+				      XbNode *xn,
+				      gboolean *done,
+				      GError **error)
 {
+	const gchar *text = xb_node_get_attr(xn, "value");
 	if (text == NULL)
-		return;
+		return TRUE;
+
 	if (g_str_has_prefix(text, "Supported Functions: ")) {
 		g_auto(GStrv) split = g_strsplit(text + 21, " ", -1);
 		for (guint i = 0; split[i] != NULL; i++) {
@@ -94,6 +107,75 @@ fu_qc_firehose_impl_parse_log_text(FuQcFirehoseImpl *self, const gchar *text)
 			    fu_qc_firehose_functions_from_string(split[i]));
 		}
 	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_qc_firehose_impl_read_xml_init_cb(FuQcFirehoseImpl *self,
+				     XbNode *xn,
+				     gboolean *done,
+				     GError **error)
+{
+	g_autoptr(GPtrArray) xn_logs = NULL;
+
+	/* logs to the console */
+	xn_logs = xb_node_query(xn, "log", 0, NULL);
+	if (xn_logs != NULL) {
+		for (guint i = 0; i < xn_logs->len; i++) {
+			XbNode *xn_log = g_ptr_array_index(xn_logs, i);
+			if (!fu_qc_firehose_impl_read_xml_init_log(self, xn_log, done, error))
+				return FALSE;
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_qc_firehose_impl_read_xml_nop_log(FuQcFirehoseImpl *self,
+				     XbNode *xn,
+				     gboolean *done,
+				     GError **error)
+{
+	const gchar *text = xb_node_get_attr(xn, "value");
+	if (text == NULL)
+		return TRUE;
+	if (g_str_has_prefix(text, "INFO: ")) {
+		if (g_str_has_prefix(text + 6, "End of supported functions")) {
+			*done = TRUE;
+			return TRUE;
+		}
+		fu_qc_firehose_impl_add_function(self,
+						 fu_qc_firehose_functions_from_string(text + 6));
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_qc_firehose_impl_read_xml_nop_cb(FuQcFirehoseImpl *self,
+				    XbNode *xn,
+				    gboolean *done,
+				    GError **error)
+{
+	g_autoptr(GPtrArray) xn_logs = NULL;
+
+	/* logs to the console */
+	xn_logs = xb_node_query(xn, "log", 0, NULL);
+	if (xn_logs != NULL) {
+		for (guint i = 0; i < xn_logs->len; i++) {
+			XbNode *xn_log = g_ptr_array_index(xn_logs, i);
+			if (!fu_qc_firehose_impl_read_xml_nop_log(self, xn_log, done, error))
+				return FALSE;
+		}
+	}
+
+	/* success */
+	return TRUE;
 }
 
 typedef struct {
@@ -101,12 +183,16 @@ typedef struct {
 	gboolean no_zlp;
 	gboolean rawmode;
 	guint64 max_payload_size;
+	FuQcFirehoseImplReadFunc read_func;
 } FuQcFirehoseImplHelper;
 
 static gboolean
-fu_qc_firehose_impl_read_xml_cb(FuDevice *device, gpointer user_data, GError **error)
+fu_qc_firehose_impl_read_xml_cb(FuQcFirehoseImpl *self,
+				gboolean *done,
+				guint timeout_ms,
+				gpointer user_data,
+				GError **error)
 {
-	FuQcFirehoseImpl *self = FU_QC_FIREHOSE_IMPL(device);
 	FuQcFirehoseImplHelper *helper = (FuQcFirehoseImplHelper *)user_data;
 	const gchar *tmp;
 	g_autofree gchar *xml = NULL;
@@ -116,18 +202,20 @@ fu_qc_firehose_impl_read_xml_cb(FuDevice *device, gpointer user_data, GError **e
 	g_autoptr(XbNode) xn_response = NULL;
 	g_autoptr(XbSilo) silo = NULL;
 
-	buf = fu_qc_firehose_impl_read(self, FU_QC_FIREHOSE_IMPL_TIMEOUT_MS, error);
+	buf = fu_qc_firehose_impl_read(self, timeout_ms, error);
 	if (buf == NULL)
 		return FALSE;
 	xml = g_strndup((const gchar *)buf->data, buf->len);
-	if (xml == NULL) {
+	if (xml == NULL || xml[0] == '\0') {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "no string data");
 		return FALSE;
 	}
 	g_debug("XML response: %s", xml);
 	silo = xb_silo_new_from_xml(xml, error);
-	if (silo == NULL)
+	if (silo == NULL) {
+		fwupd_error_convert(error);
 		return FALSE;
+	}
 
 	/* parse response */
 	xn_data = xb_silo_query_first(silo, "data", error);
@@ -136,21 +224,23 @@ fu_qc_firehose_impl_read_xml_cb(FuDevice *device, gpointer user_data, GError **e
 		return FALSE;
 	}
 
-	/* logs to the console */
+	/* special case handling */
+	if (helper->read_func != NULL)
+		return helper->read_func(self, xn_data, done, error);
+
+	/* logs to the console, no other processing */
 	xn_logs = xb_node_query(xn_data, "log", 0, NULL);
 	if (xn_logs != NULL) {
 		for (guint i = 0; i < xn_logs->len; i++) {
 			XbNode *xn_log = g_ptr_array_index(xn_logs, i);
-			fu_qc_firehose_impl_parse_log_text(self, xb_node_get_attr(xn_log, "value"));
+			g_debug("%s", xb_node_get_attr(xn_log, "value"));
 		}
 	}
 
 	/* from configure */
 	xn_response = xb_node_query_first(xn_data, "response", NULL);
-	if (xn_response == NULL) {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOTHING_TO_DO, "no response");
-		return FALSE;
-	}
+	if (xn_response == NULL)
+		return TRUE;
 
 	/* switch to binary mode? */
 	tmp = xb_node_get_attr(xn_response, "rawmode");
@@ -202,6 +292,7 @@ fu_qc_firehose_impl_read_xml_cb(FuDevice *device, gpointer user_data, GError **e
 	}
 
 	/* success */
+	*done = TRUE;
 	return TRUE;
 }
 
@@ -211,24 +302,37 @@ fu_qc_firehose_impl_read_xml(FuQcFirehoseImpl *self,
 			     FuQcFirehoseImplHelper *helper,
 			     GError **error)
 {
-	return fu_device_retry(FU_DEVICE(self),
-			       fu_qc_firehose_impl_read_xml_cb,
-			       timeout_ms / FU_QC_FIREHOSE_IMPL_TIMEOUT_MS,
-			       helper,
-			       error);
+	/* retry a few times */
+	return fu_qc_firehose_impl_retry(self,
+					 timeout_ms,
+					 fu_qc_firehose_impl_read_xml_cb,
+					 helper,
+					 error);
 }
 
 static gboolean
-fu_qc_firehose_impl_write_xml_cb(FuDevice *device, gpointer user_data, GError **error)
+fu_qc_firehose_impl_write_xml_xb(FuQcFirehoseImpl *self,
+				 gboolean *done,
+				 guint timeout_ms,
+				 gpointer user_data,
+				 GError **error)
 {
-	FuQcFirehoseImpl *self = FU_QC_FIREHOSE_IMPL(device);
-	const gchar *xml = (const gchar *)user_data;
-	return fu_qc_firehose_impl_write(self, (const guint8 *)xml, strlen(xml), error);
+	GString *xml = (GString *)user_data;
+
+	/* write XML string to the device */
+	if (!fu_qc_firehose_impl_write(self, (const guint8 *)xml->str, xml->len, timeout_ms, error))
+		return FALSE;
+
+	/* success */
+	*done = TRUE;
+	return TRUE;
 }
 
 static gboolean
 fu_qc_firehose_impl_write_xml(FuQcFirehoseImpl *self, XbBuilderNode *bn, GError **error)
 {
+	g_autoptr(GString) xml_fixed = NULL;
+
 	g_autofree gchar *xml = NULL;
 	xml = xb_builder_node_export(
 	    bn,
@@ -237,20 +341,25 @@ fu_qc_firehose_impl_write_xml(FuQcFirehoseImpl *self, XbBuilderNode *bn, GError 
 	    error);
 	if (xml == NULL)
 		return FALSE;
+	xml_fixed = g_string_new(xml);
+	/* firehose is *very* picky about XML and will not accept empty elements */
 	if (fu_version_compare(xb_version_string(), "0.3.22", FWUPD_VERSION_FORMAT_TRIPLET) < 0) {
-		/* firehose is *very* picky about XML and will not accept empty elements */
-		GString *xml_fixed = g_string_new(xml);
 		g_string_replace(xml_fixed, ">\n  </configure>", " />", 0);
 		g_string_replace(xml_fixed, ">\n  </program>", " />", 0);
 		g_string_replace(xml_fixed, ">\n  </erase>", " />", 0);
 		g_string_replace(xml_fixed, ">\n  </patch>", " />", 0);
 		g_string_replace(xml_fixed, ">\n  </setbootablestoragedrive>", " />", 0);
 		g_string_replace(xml_fixed, ">\n  </power>", " />", 0);
-		g_free(xml);
-		xml = g_string_free(xml_fixed, FALSE);
+		g_string_replace(xml_fixed, ">\n  </nop>", " />", 0);
 	}
-	g_debug("XML request: %s", xml);
-	return fu_device_retry(FU_DEVICE(self), fu_qc_firehose_impl_write_xml_cb, 5, xml, error);
+	g_debug("XML request: %s", xml_fixed->str);
+
+	/* retry a few times */
+	return fu_qc_firehose_impl_retry(self,
+					 2500,
+					 fu_qc_firehose_impl_write_xml_xb,
+					 xml_fixed,
+					 error);
 }
 
 static gboolean
@@ -382,6 +491,7 @@ fu_qc_firehose_impl_write_blocks(FuQcFirehoseImpl *self,
 		if (!fu_qc_firehose_impl_write(self,
 					       fu_chunk_get_data(chk),
 					       fu_chunk_get_data_sz(chk),
+					       500,
 					       error))
 			return FALSE;
 
@@ -462,10 +572,7 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 	}
 	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
 		return FALSE;
-	if (!fu_qc_firehose_impl_read_xml(self,
-					  5 * FU_QC_FIREHOSE_IMPL_TIMEOUT_MS,
-					  helper,
-					  error)) {
+	if (!fu_qc_firehose_impl_read_xml(self, 2500, helper, error)) {
 		g_prefix_error(error, "failed to setup: ");
 		return FALSE;
 	}
@@ -563,7 +670,7 @@ fu_qc_firehose_impl_set_bootable(FuQcFirehoseImpl *self,
 	xb_builder_node_insert_text(bn, "setbootablestoragedrive", NULL, "value", partstr, NULL);
 	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
 		return FALSE;
-	if (!fu_qc_firehose_impl_read_xml(self, FU_QC_FIREHOSE_IMPL_TIMEOUT_MS, helper, error)) {
+	if (!fu_qc_firehose_impl_read_xml(self, 500, helper, error)) {
 		g_prefix_error(error, "failed to mark partition %u as bootable: ", part);
 		return FALSE;
 	}
@@ -690,22 +797,42 @@ fu_qc_firehose_impl_find_bootable(FuQcFirehoseImpl *self, GPtrArray *xns)
 	return G_MAXUINT64;
 }
 
+static gboolean
+fu_qc_firehose_impl_send_nop(FuQcFirehoseImpl *self, FuQcFirehoseImplHelper *helper, GError **error)
+{
+	g_autoptr(XbBuilderNode) bn = xb_builder_node_new("data");
+
+	/* <data><nop /></data> */
+	xb_builder_node_insert_text(bn, "nop", NULL, NULL);
+	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
+		return FALSE;
+	return fu_qc_firehose_impl_read_xml(self, 500, helper, error);
+}
+
 gboolean
 fu_qc_firehose_impl_setup(FuQcFirehoseImpl *self, GError **error)
 {
-	FuQcFirehoseImplHelper helper = {0x0};
+	FuQcFirehoseImplHelper helper = {
+	    .read_func = fu_qc_firehose_impl_read_xml_init_cb,
+	};
 	g_autoptr(GError) error_local = NULL;
 
-	/* clear buffer */
-	if (!fu_qc_firehose_impl_read_xml(self,
-					  5 * FU_QC_FIREHOSE_IMPL_TIMEOUT_MS,
-					  &helper,
-					  &error_local)) {
+	/* clear buffer, looking for pending messages */
+	if (!fu_qc_firehose_impl_read_xml(self, 2000, &helper, &error_local)) {
 		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
 		g_debug("ignoring: %s", error_local->message);
+	}
+
+	/* no supported functions, poke the device */
+	if (!fu_qc_firehose_impl_has_function(self, FU_QC_FIREHOSE_FUNCTIONS_CONFIGURE)) {
+		helper.read_func = fu_qc_firehose_impl_read_xml_nop_cb;
+		if (!fu_qc_firehose_impl_send_nop(self, &helper, error)) {
+			g_prefix_error(error, "failed to send NOP: ");
+			return FALSE;
+		}
 	}
 
 	/* success */

--- a/plugins/qc-firehose/fu-qc-firehose-impl.h
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.h
@@ -11,15 +11,18 @@
 #include "fu-qc-firehose-struct.h"
 
 #define FU_TYPE_QC_FIREHOSE_IMPL (fu_qc_firehose_impl_get_type())
-G_DECLARE_INTERFACE(FuQcFirehoseImpl, fu_qc_firehose_impl, FU, QC_FIREHOSE_IMPL, FuDevice)
+G_DECLARE_INTERFACE(FuQcFirehoseImpl, fu_qc_firehose_impl, FU, QC_FIREHOSE_IMPL, GObject)
 
 struct _FuQcFirehoseImplInterface {
 	GTypeInterface g_iface;
 	GByteArray *(*read)(FuQcFirehoseImpl *self,
 			    guint timeout_ms,
 			    GError **error)G_GNUC_NON_NULL(1);
-	gboolean (*write)(FuQcFirehoseImpl *self, const guint8 *buf, gsize bufsz, GError **error)
-	    G_GNUC_NON_NULL(1);
+	gboolean (*write)(FuQcFirehoseImpl *self,
+			  const guint8 *buf,
+			  gsize bufsz,
+			  guint timeout_ms,
+			  GError **error) G_GNUC_NON_NULL(1);
 	gboolean (*has_function)(FuQcFirehoseImpl *self, FuQcFirehoseFunctions func)
 	    G_GNUC_NON_NULL(1);
 	void (*add_function)(FuQcFirehoseImpl *self, FuQcFirehoseFunctions func) G_GNUC_NON_NULL(1);

--- a/plugins/qc-firehose/fu-qc-firehose-raw-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-raw-device.c
@@ -12,8 +12,6 @@
 
 #define FU_QC_FIREHOSE_RAW_DEVICE_RAW_BUFFER_SIZE (4 * 1024)
 
-#define FU_QC_FIREHOSE_RAW_DEVICE_TIMEOUT_MS 500
-
 struct _FuQcFirehoseRawDevice {
 	FuUdevDevice parent_instance;
 	FuQcFirehoseFunctions supported_functions;
@@ -59,8 +57,10 @@ fu_qc_firehose_raw_device_impl_write_firmware(FuDevice *device,
 {
 	FuQcFirehoseRawDevice *self = FU_QC_FIREHOSE_RAW_DEVICE(device);
 	if (self->supported_functions == FU_QC_FIREHOSE_FUNCTIONS_NONE) {
-		if (!fu_qc_firehose_impl_setup(FU_QC_FIREHOSE_IMPL(self), error))
+		if (!fu_qc_firehose_impl_setup(FU_QC_FIREHOSE_IMPL(self), error)) {
+			g_prefix_error(error, "failed to setup before write: ");
 			return FALSE;
+		}
 	}
 	return fu_qc_firehose_impl_write_firmware(FU_QC_FIREHOSE_IMPL(self),
 						  firmware,
@@ -160,7 +160,7 @@ fu_qc_firehose_raw_device_impl_read(FuQcFirehoseImpl *impl, guint timeout_ms, GE
 				 buf->len,
 				 &actual_len,
 				 timeout_ms,
-				 FU_IO_CHANNEL_FLAG_NONE,
+				 FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
 				 error)) {
 		g_prefix_error(error, "failed to do bulk transfer (read): ");
 		return NULL;
@@ -175,13 +175,14 @@ static gboolean
 fu_qc_firehose_raw_device_impl_write(FuQcFirehoseImpl *impl,
 				     const guint8 *buf,
 				     gsize bufsz,
+				     guint timeout_ms,
 				     GError **error)
 {
 	FuQcFirehoseRawDevice *self = FU_QC_FIREHOSE_RAW_DEVICE(impl);
 	return fu_udev_device_write(FU_UDEV_DEVICE(self),
 				    buf,
 				    bufsz,
-				    FU_QC_FIREHOSE_RAW_DEVICE_TIMEOUT_MS,
+				    timeout_ms,
 				    FU_IO_CHANNEL_FLAG_FLUSH_INPUT,
 				    error);
 }
@@ -200,6 +201,7 @@ fu_qc_firehose_raw_device_init(FuQcFirehoseRawDevice *self)
 {
 	fu_device_set_name(FU_DEVICE(self), "Firehose");
 	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.firehose");
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_BCD);
 	fu_device_set_version(FU_DEVICE(self), "0.0");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
@@ -208,7 +210,6 @@ fu_qc_firehose_raw_device_init(FuQcFirehoseRawDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
 	fu_device_set_remove_delay(FU_DEVICE(self), 60000);
-	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
 }

--- a/plugins/qc-firehose/fu-qc-firehose-sahara-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-sahara-impl.c
@@ -13,7 +13,7 @@
 
 G_DEFINE_INTERFACE(FuQcFirehoseSaharaImpl, fu_qc_firehose_sahara_impl, G_TYPE_OBJECT)
 
-#define FU_QC_FIREHOSE_USB_DEVICE_TIMEOUT_MS 500
+#define FU_QC_FIREHOSE_SAHARA_IMPL_TIMEOUT_MS 500
 
 static void
 fu_qc_firehose_sahara_impl_default_init(FuQcFirehoseSaharaImplInterface *iface)
@@ -21,7 +21,7 @@ fu_qc_firehose_sahara_impl_default_init(FuQcFirehoseSaharaImplInterface *iface)
 }
 
 static GByteArray *
-fu_qc_firehose_sahara_impl_read(FuQcFirehoseSaharaImpl *self, guint timeout_ms, GError **error)
+fu_qc_firehose_sahara_impl_read(FuQcFirehoseSaharaImpl *self, GError **error)
 {
 	FuQcFirehoseSaharaImplInterface *iface;
 
@@ -35,7 +35,7 @@ fu_qc_firehose_sahara_impl_read(FuQcFirehoseSaharaImpl *self, guint timeout_ms, 
 				    "iface->read not implemented");
 		return NULL;
 	}
-	return (*iface->read)(self, timeout_ms, error);
+	return (*iface->read)(self, FU_QC_FIREHOSE_SAHARA_IMPL_TIMEOUT_MS, error);
 }
 
 static gboolean
@@ -56,7 +56,7 @@ fu_qc_firehose_sahara_impl_write(FuQcFirehoseSaharaImpl *self,
 				    "iface->write not implemented");
 		return FALSE;
 	}
-	return (*iface->write)(self, buf, bufsz, error);
+	return (*iface->write)(self, buf, bufsz, FU_QC_FIREHOSE_SAHARA_IMPL_TIMEOUT_MS, error);
 }
 
 static gboolean
@@ -196,9 +196,7 @@ fu_qc_firehose_sahara_impl_write_firmware(FuQcFirehoseSaharaImpl *self,
 		g_autoptr(FuQcFirehoseSaharaPkt) pkt = NULL;
 		g_autoptr(GByteArray) buf = NULL;
 
-		buf = fu_qc_firehose_sahara_impl_read(self,
-						      FU_QC_FIREHOSE_USB_DEVICE_TIMEOUT_MS,
-						      error);
+		buf = fu_qc_firehose_sahara_impl_read(self, error);
 		if (buf == NULL) {
 			g_prefix_error(error, "failed to get device response: ");
 			return FALSE;

--- a/plugins/qc-firehose/fu-qc-firehose-sahara-impl.h
+++ b/plugins/qc-firehose/fu-qc-firehose-sahara-impl.h
@@ -23,6 +23,7 @@ struct _FuQcFirehoseSaharaImplInterface {
 	gboolean (*write)(FuQcFirehoseSaharaImpl *self,
 			  const guint8 *buf,
 			  gsize bufsz,
+			  guint timeout_ms,
 			  GError **error) G_GNUC_NON_NULL(1);
 };
 

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -17,8 +17,6 @@
 
 #define FU_QC_FIREHOSE_USB_DEVICE_RAW_BUFFER_SIZE (4 * 1024)
 
-#define FU_QC_FIREHOSE_USB_DEVICE_TIMEOUT_MS 500
-
 struct _FuQcFirehoseUsbDevice {
 	FuUsbDevice parent_instance;
 	guint8 ep_in;
@@ -95,6 +93,7 @@ static gboolean
 fu_qc_firehose_usb_device_write(FuQcFirehoseUsbDevice *self,
 				const guint8 *buf,
 				gsize sz,
+				guint timeout_ms,
 				GError **error)
 {
 	gsize actual_len = 0;
@@ -118,7 +117,7 @@ fu_qc_firehose_usb_device_write(FuQcFirehoseUsbDevice *self,
 						 fu_chunk_get_data_out(chk),
 						 fu_chunk_get_data_sz(chk),
 						 &actual_len,
-						 FU_QC_FIREHOSE_USB_DEVICE_TIMEOUT_MS,
+						 timeout_ms,
 						 NULL,
 						 error)) {
 			g_prefix_error(error, "failed to do bulk transfer (write data): ");
@@ -142,7 +141,7 @@ fu_qc_firehose_usb_device_write(FuQcFirehoseUsbDevice *self,
 						 NULL,
 						 0,
 						 NULL,
-						 FU_QC_FIREHOSE_USB_DEVICE_TIMEOUT_MS,
+						 timeout_ms,
 						 NULL,
 						 error)) {
 			g_prefix_error(error, "failed to do bulk transfer (write zlp): ");
@@ -299,20 +298,22 @@ static gboolean
 fu_qc_firehose_usb_device_sahara_impl_write(FuQcFirehoseSaharaImpl *impl,
 					    const guint8 *buf,
 					    gsize sz,
+					    guint timeout_ms,
 					    GError **error)
 {
 	FuQcFirehoseUsbDevice *self = FU_QC_FIREHOSE_USB_DEVICE(impl);
-	return fu_qc_firehose_usb_device_write(self, buf, sz, error);
+	return fu_qc_firehose_usb_device_write(self, buf, sz, timeout_ms, error);
 }
 
 static gboolean
 fu_qc_firehose_usb_device_impl_write(FuQcFirehoseImpl *impl,
 				     const guint8 *buf,
 				     gsize sz,
+				     guint timeout_ms,
 				     GError **error)
 {
 	FuQcFirehoseUsbDevice *self = FU_QC_FIREHOSE_USB_DEVICE(impl);
-	return fu_qc_firehose_usb_device_write(self, buf, sz, error);
+	return fu_qc_firehose_usb_device_write(self, buf, sz, timeout_ms, error);
 }
 
 static void
@@ -335,6 +336,7 @@ static void
 fu_qc_firehose_usb_device_init(FuQcFirehoseUsbDevice *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.qualcomm.firehose");
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_BCD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
@@ -343,7 +345,6 @@ fu_qc_firehose_usb_device_init(FuQcFirehoseUsbDevice *self)
 	fu_device_set_remove_delay(FU_DEVICE(self), 60000);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_QC_FIREHOSE_USB_DEVICE_NO_ZLP);
 	fu_usb_device_add_interface(FU_USB_DEVICE(self), 0x00);
-	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, NULL);
 }
 
 static void

--- a/plugins/qc-firehose/fu-self-test.c
+++ b/plugins/qc-firehose/fu-self-test.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-qc-firehose-impl-common.h"
+
+typedef struct {
+	guint cnt;
+	guint cnt_done;
+	FwupdError error_code;
+} FooHelper;
+
+static gboolean
+fu_qc_firehose_retry_cb(FuQcFirehoseImpl *self,
+			gboolean *done,
+			guint timeout_ms,
+			gpointer user_data,
+			GError **error)
+{
+	FooHelper *helper = (FooHelper *)user_data;
+	helper->cnt++;
+	if (helper->cnt_done > 0 && helper->cnt == helper->cnt_done)
+		*done = TRUE;
+	return TRUE;
+}
+
+static void
+fu_qc_firehose_retry_true_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	FooHelper helper = {0};
+
+	ret = fu_qc_firehose_impl_retry(NULL, 2500, fu_qc_firehose_retry_cb, &helper, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+	g_assert_false(ret);
+	g_assert_cmpint(helper.cnt, ==, 100);
+}
+
+static void
+fu_qc_firehose_retry_done_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	FooHelper helper = {
+	    .cnt_done = 10,
+	};
+
+	ret = fu_qc_firehose_impl_retry(NULL, 2500, fu_qc_firehose_retry_cb, &helper, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(helper.cnt, ==, 10);
+}
+
+static gboolean
+fu_qc_firehose_retry_error_cb(FuQcFirehoseImpl *self,
+			      gboolean *done,
+			      guint timeout_ms,
+			      gpointer user_data,
+			      GError **error)
+{
+	FooHelper *helper = (FooHelper *)user_data;
+	helper->cnt++;
+	g_set_error_literal(error, FWUPD_ERROR, (gint)helper->error_code, "timeout");
+	return FALSE;
+}
+
+static void
+fu_qc_firehose_retry_timeout_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	FooHelper helper = {
+	    .error_code = FWUPD_ERROR_TIMED_OUT,
+	};
+
+	ret = fu_qc_firehose_impl_retry(NULL, 2500, fu_qc_firehose_retry_error_cb, &helper, &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, (gint)helper.error_code);
+	g_assert_cmpint(helper.cnt, ==, 5);
+}
+
+static void
+fu_qc_firehose_retry_invalid_func(void)
+{
+	gboolean ret;
+	g_autoptr(GError) error = NULL;
+	FooHelper helper = {
+	    .error_code = FWUPD_ERROR_INVALID_DATA,
+	};
+
+	ret = fu_qc_firehose_impl_retry(NULL, 2500, fu_qc_firehose_retry_error_cb, &helper, &error);
+	g_assert_false(ret);
+	g_assert_error(error, FWUPD_ERROR, (gint)helper.error_code);
+	g_assert_cmpint(helper.cnt, ==, 1);
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
+	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
+
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/qc-firehose/retry{true}", fu_qc_firehose_retry_true_func);
+	g_test_add_func("/qc-firehose/retry{done}", fu_qc_firehose_retry_done_func);
+	g_test_add_func("/qc-firehose/retry{timeout}", fu_qc_firehose_retry_timeout_func);
+	g_test_add_func("/qc-firehose/retry{invalid}", fu_qc_firehose_retry_invalid_func);
+	return g_test_run();
+}

--- a/plugins/qc-firehose/meson.build
+++ b/plugins/qc-firehose/meson.build
@@ -7,6 +7,7 @@ plugin_builtins += static_library('fu_plugin_qc_firehose',
   rustgen.process('fu-qc-firehose.rs'),
   sources: [
     'fu-qc-firehose-impl.c',
+    'fu-qc-firehose-impl-common.c',
     'fu-qc-firehose-sahara-impl.c',
     'fu-qc-firehose-usb-device.c',
     'fu-qc-firehose-raw-device.c',
@@ -27,4 +28,33 @@ enumeration_data += files(
   'tests/qc-ec25au-setup.json',
   'tests/qc-em160r-setup.json',
 )
+
+if get_option('tests')
+  env = environment()
+  env.set('G_TEST_SRCDIR', meson.current_source_dir())
+  env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+  e = executable(
+    'qc-firehose-self-test',
+    rustgen.process('fu-qc-firehose.rs'),
+    sources: [
+      'fu-self-test.c',
+      'fu-qc-firehose-impl-common.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: [
+      plugin_deps,
+      platform_deps,
+    ],
+    link_with: [
+      fwupd,
+      fwupdplugin,
+    ],
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
+  )
+  test('qc-firehose-self-test', e, env: env)
+endif
+
 endif


### PR DESCRIPTION
This also re-implements the FuDevice retry logic in a way that suits firehose; i.e. that we only return with timeout if *all* the requests timeouts add up to the maximum value.

This also allows the given vfunc to end the polling (setting `*done = TRUE`) when we *know* that the command stream is complete.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
