### PR TITLE
Dpaux dpcd check

### DIFF
--- a/libfwupdplugin/fu-dpaux-device.h
+++ b/libfwupdplugin/fu-dpaux-device.h
@@ -22,6 +22,10 @@ struct _FuDpauxDeviceClass {
 #define FU_DPAUX_DEVICE_DPCD_OFFSET_SINK_DEVICE		0x400
 #define FU_DPAUX_DEVICE_DPCD_OFFSET_BRANCH_DEVICE	0x500
 
+goffset
+fu_dpaux_device_get_dpcd_offset(FuDpauxDevice *self) G_GNUC_NON_NULL(1);
+void
+fu_dpaux_device_set_dpcd_offset(FuDpauxDevice *self, goffset dpcd_offset) G_GNUC_NON_NULL(1);
 guint32
 fu_dpaux_device_get_dpcd_ieee_oui(FuDpauxDevice *self) G_GNUC_NON_NULL(1);
 void

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -11,6 +11,9 @@
 #include "fu-bnr-dp-firmware.h"
 #include "fu-bnr-dp-struct.h"
 
+#define FU_BNR_DP_IEEE_OUI    0x006065
+#define FU_BNR_DP_IEEE_DEV_ID "B&R-DP"
+
 #define FU_BNR_DP_DEVICE_HEADER_OFFSET 0x00A00
 #define FU_BNR_DP_DEVICE_DATA_OFFSET   0x00900
 
@@ -494,9 +497,24 @@ fu_bnr_dp_device_setup(FuDevice *device, GError **error)
 	g_autoptr(FuStructBnrDpPayloadHeader) st_header = NULL;
 	g_autoptr(FuStructBnrDpFactoryData) st_factory_data = NULL;
 
-	/* DpauxDevice->setup */
+	/* this is a sink device, this offset provides the most complete information */
+	fu_dpaux_device_set_dpcd_offset(FU_DPAUX_DEVICE(device),
+					FU_DPAUX_DEVICE_DPCD_OFFSET_SINK_DEVICE);
+
+	/* FuDpauxDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_bnr_dp_device_parent_class)->setup(device, error))
 		return FALSE;
+
+	/* check if device dpcd matches before writing anything else to the device */
+	if (fu_dpaux_device_get_dpcd_ieee_oui(FU_DPAUX_DEVICE(device)) != FU_BNR_DP_IEEE_OUI ||
+	    g_strcmp0(fu_dpaux_device_get_dpcd_dev_id(FU_DPAUX_DEVICE(device)),
+		      FU_BNR_DP_IEEE_DEV_ID) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "device id doesn't match");
+		return FALSE;
+	}
 
 	st_header = fu_bnr_dp_device_fw_header(self, FU_BNR_DP_MODULE_NUMBER_RECEIVER, error);
 	if (st_header == NULL)


### PR DESCRIPTION
I am getting these messages on my personal PC that shouldn't have any matching devices:

```
Mar 31 18:49:50 path systemd[1]: Starting Firmware update daemon...
Mar 31 18:49:51 path fwupd[9228]: 16:49:51.290 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:02.0/drm/card1/card1-DP-3/drm_dp_aux3: failed to setup: failed to read device firmware header: checksum mismatch in device response header (header specified: 0x0, actual: 0xAB)
Mar 31 18:49:51 path fwupd[9228]: 16:49:51.341 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:02.0/drm/card1/card1-DP-6/drm_dp_aux6: failed to setup: failed to read device firmware header: failed to write 7 bytes to 13: Input/output error
Mar 31 18:49:51 path fwupd[9228]: 16:49:51.377 FuEngine             failed to add device /sys/devices/pci0000:00/0000:00:02.0/drm/card1/card1-eDP-1/drm_dp_aux0: failed to setup: failed to read device firmware header: failed to write 7 bytes to 13: Input/output error
```

I am a bit concerned about the first one because it involves `dpaux_device_write()` to devices that do not match. I assume it would probably be better to avoid this.

I still have to test this on actual hardware.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
