### PR TITLE
trivial: Reduce spinlock contention when checking inotify

### DIFF
--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -119,7 +119,7 @@ fu_remote_list_fixup_inotify_error(GError **error)
 		g_prefix_error(error, "Could not initialize inotify, check %s: ", fn);
 		return;
 	}
-	wd = inotify_add_watch(fd, "/", 0);
+	wd = inotify_add_watch(fd, fn, 0);
 	if (wd < 0) {
 		if (errno == ENOSPC)
 			g_prefix_error(error, "No space for inotify, check %s: ", fn);


### PR DESCRIPTION
We only need to monitor one file, not the entire filesystem.

May help towards https://issues.redhat.com/browse/RHEL-85941

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
