### PR TITLE
trivial: print the fwupd version when starting

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8763,8 +8763,6 @@ fu_engine_constructed(GObject *obj)
 	g_autofree gchar *pkidir_md = NULL;
 	g_autofree gchar *sysconfdir = NULL;
 
-	/* for debugging */
-	g_info("starting fwupd %s…", VERSION);
 	g_signal_connect(FU_CONTEXT(self->ctx),
 			 "security-changed",
 			 G_CALLBACK(fu_engine_context_security_changed_cb),

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
 		g_timeout_add_seconds(5, fu_main_timed_exit_cb, daemon);
 
 	/* wait */
-	g_message("Daemon ready for requests (locale %s)", g_getenv("LANG"));
+	g_message("fwupd %s ready for requests (locale %s)", VERSION, g_getenv("LANG"));
 	if (!fu_daemon_start(daemon, &error)) {
 		g_printerr("Failed to start daemon: %s\n", error->message);
 		return EXIT_FAILURE;


### PR DESCRIPTION
On a distro that doesn't use journald the version when starting is useful to include to characterize issues.

Closes: https://github.com/fwupd/fwupd/issues/8464

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
