### PR TITLE
trivial: motd: correct fwupd-refresh.service man page location

### DIFF
--- a/data/motd/fwupd-refresh.service.md
+++ b/data/motd/fwupd-refresh.service.md
@@ -2,7 +2,7 @@
 title: Message Of The Day Integration
 ---
 
-% fwupd-refresh.service(5) {{PACKAGE_VERSION}} | Message Of The Day Integration
+% fwupd-refresh.service(8) {{PACKAGE_VERSION}} | Message Of The Day Integration
 
 ## NAME
 


### PR DESCRIPTION
The man page is installed to section 8, update the markdown to match.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
