### PR TITLE
Record the emulations uncompressed by default

### DIFF
--- a/libfwupd/fwupd-codec.h
+++ b/libfwupd/fwupd-codec.h
@@ -36,6 +36,14 @@ typedef enum {
 	 * Since: 2.0.0
 	 */
 	FWUPD_CODEC_FLAG_TRUSTED = 1 << 0,
+	/**
+	 * FWUPD_CODEC_FLAG_COMPRESSED:
+	 *
+	 * Compress values to the smallest possible size.
+	 *
+	 * Since: 2.0.8
+	 */
+	FWUPD_CODEC_FLAG_COMPRESSED = 1 << 1,
 } FwupdCodecFlags;
 
 struct _FwupdCodecInterface {

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -2225,7 +2225,7 @@ fu_device_event_func(void)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
-	json = fwupd_codec_to_json_string(FWUPD_CODEC(event1), FWUPD_CODEC_FLAG_NONE, &error);
+	json = fwupd_codec_to_json_string(FWUPD_CODEC(event1), FWUPD_CODEC_FLAG_COMPRESSED, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(json,
 			==,
@@ -2261,6 +2261,25 @@ fu_device_event_func(void)
 	g_assert_error(error_copy, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_cmpstr(error_copy->message, ==, "invalid event type for key Age");
 	g_assert_false(ret);
+}
+
+static void
+fu_device_event_uncompressed_func(void)
+{
+	g_autofree gchar *json = NULL;
+	g_autoptr(FuDeviceEvent) event = fu_device_event_new("foo:bar:baz");
+	g_autoptr(GError) error = NULL;
+
+	/* uncompressed */
+	fu_device_event_set_str(event, "Name", "Richard");
+	json = fwupd_codec_to_json_string(FWUPD_CODEC(event), FWUPD_CODEC_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_cmpstr(json,
+			==,
+			"{\n"
+			"  \"Id\" : \"foo:bar:baz\",\n"
+			"  \"Name\" : \"Richard\"\n"
+			"}");
 }
 
 static void
@@ -6953,6 +6972,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/archive{cab}", fu_archive_cab_func);
 	g_test_add_func("/fwupd/device", fu_device_func);
 	g_test_add_func("/fwupd/device{event}", fu_device_event_func);
+	g_test_add_func("/fwupd/device{event-uncompressed}", fu_device_event_uncompressed_func);
 	g_test_add_func("/fwupd/device{event-donor}", fu_device_event_donor_func);
 	g_test_add_func("/fwupd/device{vfuncs}", fu_device_vfuncs_func);
 	g_test_add_func("/fwupd/device{instance-ids}", fu_device_instance_ids_func);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -2189,7 +2189,10 @@ fu_udev_device_add_json(FuDevice *device, JsonBuilder *builder, FwupdCodecFlags 
 		for (guint i = 0; i < events->len; i++) {
 			FuDeviceEvent *event = g_ptr_array_index(events, i);
 			json_builder_begin_object(builder);
-			fwupd_codec_to_json(FWUPD_CODEC(event), builder, flags);
+			fwupd_codec_to_json(FWUPD_CODEC(event),
+					    builder,
+					    events->len > 1000 ? flags | FWUPD_CODEC_FLAG_COMPRESSED
+							       : flags);
 			json_builder_end_object(builder);
 		}
 		json_builder_end_array(builder);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -2991,7 +2991,10 @@ fu_usb_device_add_json(FuDevice *device, JsonBuilder *builder, FwupdCodecFlags f
 		for (guint i = 0; i < events->len; i++) {
 			FuDeviceEvent *event = g_ptr_array_index(events, i);
 			json_builder_begin_object(builder);
-			fwupd_codec_to_json(FWUPD_CODEC(event), builder, flags);
+			fwupd_codec_to_json(FWUPD_CODEC(event),
+					    builder,
+					    events->len > 1000 ? flags | FWUPD_CODEC_FLAG_COMPRESSED
+							       : flags);
 			json_builder_end_object(builder);
 		}
 		json_builder_end_array(builder);


### PR DESCRIPTION
Automatically switch to the compressed version if there are over 1000 events -- it's more useful to see the actual values when debugging emulation failures.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
