### PR TITLE
fu-util: Don't show prompts in --json mode

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -239,7 +239,7 @@ fu_util_perhaps_show_unreported(FuUtilPrivate *priv, GError **error)
 	gboolean all_automatic = FALSE;
 
 	/* we don't want to ask anything */
-	if (priv->no_unreported_check) {
+	if (priv->no_unreported_check || priv->as_json) {
 		g_debug("skipping unreported check");
 		return TRUE;
 	}
@@ -2488,7 +2488,7 @@ fu_util_perhaps_refresh_remotes(FuUtilPrivate *priv, GError **error)
 	const guint64 age_limit_days = 30;
 
 	/* we don't want to ask anything */
-	if (priv->no_metadata_check) {
+	if (priv->no_metadata_check || priv->as_json) {
 		g_debug("skipping metadata check");
 		return TRUE;
 	}
@@ -3246,6 +3246,9 @@ fu_util_remote_enable(FuUtilPrivate *priv, gchar **values, GError **error)
 					priv->cancellable,
 					error))
 		return FALSE;
+
+	if (priv->as_json)
+		return TRUE;
 
 	/* ask for permission to refresh */
 	if (priv->no_remote_check || fwupd_remote_get_kind(remote) != FWUPD_REMOTE_KIND_DOWNLOAD) {
@@ -4794,27 +4797,37 @@ fu_util_report_devices(FuUtilPrivate *priv, gchar **values, GError **error)
 	if (data == NULL)
 		return FALSE;
 
-	/* show the user the entire data blob */
-	fu_console_print_kv(priv->console, _("Target"), report_uri);
-	fu_console_print_kv(priv->console, _("Payload"), data);
-	fu_console_print(priv->console,
-			 /* TRANSLATORS: explain why we want to upload */
-			 _("Uploading a device list allows the %s team to know what hardware "
-			   "exists, and allows us to put pressure on vendors that do not upload "
-			   "firmware updates for their hardware."),
-			 fwupd_remote_get_title(remote));
-	if (!fu_console_input_bool(priv->console,
-				   TRUE,
-				   "%s (%s)",
-				   /* TRANSLATORS: ask the user to upload */
-				   _("Upload data now?"),
-				   /* TRANSLATORS: metadata is downloaded */
-				   _("Requires internet connection"))) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOTHING_TO_DO,
-				    "Declined upload");
-		return FALSE;
+	if (priv->as_json) {
+		if (!priv->assume_yes) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_ARGS,
+					    "pass --yes to enable uploads");
+			return FALSE;
+		}
+	} else {
+		/* show the user the entire data blob */
+		fu_console_print_kv(priv->console, _("Target"), report_uri);
+		fu_console_print_kv(priv->console, _("Payload"), data);
+		fu_console_print(priv->console,
+				 /* TRANSLATORS: explain why we want to upload */
+				 _("Uploading a device list allows the %s team to know what hardware "
+				   "exists, and allows us to put pressure on vendors that do not upload "
+				   "firmware updates for their hardware."),
+				 fwupd_remote_get_title(remote));
+		if (!fu_console_input_bool(priv->console,
+					   TRUE,
+					   "%s (%s)",
+					   /* TRANSLATORS: ask the user to upload */
+					   _("Upload data now?"),
+					   /* TRANSLATORS: metadata is downloaded */
+					   _("Requires internet connection"))) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOTHING_TO_DO,
+					    "Declined upload");
+			return FALSE;
+		}
 	}
 
 	/* send to the LVFS */
@@ -4829,9 +4842,12 @@ fu_util_report_devices(FuUtilPrivate *priv, gchar **values, GError **error)
 		return FALSE;
 
 	/* success */
-	fu_console_print_literal(priv->console,
-				 /* TRANSLATORS: success, so say thank you to the user */
-				 _("Device list uploaded successfully, thanks!"));
+	if (!priv->as_json) {
+		fu_console_print_literal(priv->console,
+					 /* TRANSLATORS: success, so say thank you to the user */
+					 _("Device list uploaded successfully, thanks!"));
+	}
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Scripts shouldn't be interacting with non-json output.  So add checks to all cases that would prompt for internet connection and adjust behavior accordingly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
