### PR TITLE
redfish: Do not match SMC updating method accidentally

### DIFF
--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -344,7 +344,8 @@ fu_redfish_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **e
 	    json_object_has_member(json_obj, "MultipartHttpPushUri")) {
 		const gchar *tmp = json_object_get_string_member(json_obj, "MultipartHttpPushUri");
 		if (tmp != NULL) {
-			if (fu_redfish_backend_has_smc_update_path(json_obj)) {
+			if (g_strcmp0(self->vendor, "SMCI") == 0 &&
+			    fu_redfish_backend_has_smc_update_path(json_obj)) {
 				self->device_gtype = FU_TYPE_REDFISH_SMC_DEVICE;
 			} else {
 				self->device_gtype = FU_TYPE_REDFISH_MULTIPART_DEVICE;

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -69,6 +69,9 @@ fu_test_self_init(FuTest *self)
 		g_assert_no_error(error);
 		g_assert_true(ret);
 		fu_redfish_plugin_set_credentials(self->smc_plugin, "smc_username", "password2");
+		ret = fu_redfish_plugin_reload(self->smc_plugin, progress, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
 		ret = fu_plugin_runner_coldplug(self->smc_plugin, progress, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
@@ -86,6 +89,9 @@ fu_test_self_init(FuTest *self)
 		fu_redfish_plugin_set_credentials(self->unlicensed_plugin,
 						  "unlicensed_username",
 						  "password2");
+		ret = fu_redfish_plugin_reload(self->unlicensed_plugin, progress, &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
 		ret = fu_plugin_runner_coldplug(self->unlicensed_plugin, progress, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);

--- a/plugins/redfish/tests/redfish.py
+++ b/plugins/redfish/tests/redfish.py
@@ -69,6 +69,12 @@ def index():
     if request.authorization["username"] == HARDCODED_DELL_USERNAME:
         res["Vendor"] = "Dell"
 
+    if request.authorization["username"] in (
+        HARDCODED_SMC_USERNAME,
+        HARDCODED_UNL_USERNAME,
+    ):
+        res["Vendor"] = "SMCI"
+
     return Response(json.dumps(res), status=200, mimetype="application/json")
 
 


### PR DESCRIPTION
It seems (well, it does not "seems", it just does) that since the "SMC update path" is Redfish standard, it will match other standard Redfish implementations and fail later on. I'm not 100% sure about this matching, I hope it is correct but needs checking and I don't have a Supermicro machine with me.

Would be cool if @flanfly could take a quick look on their side :)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
