### PR TITLE
json-output: re-add common json entries for devices

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -7647,6 +7647,8 @@ fu_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags flag
 {
 	FuDevice *self = FU_DEVICE(codec);
 	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(self);
+	FwupdCodecInterface *fwupd_dev_interface =
+	    g_type_interface_peek_parent(FWUPD_CODEC_GET_IFACE(codec));
 
 	if (fu_device_get_created_usec(self) != 0) {
 #if GLIB_CHECK_VERSION(2, 80, 0)
@@ -7660,6 +7662,8 @@ fu_device_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdCodecFlags flag
 		json_builder_set_member_name(builder, "Created");
 		json_builder_add_string_value(builder, str);
 	}
+
+	fwupd_dev_interface->add_json(codec, builder, flags);
 
 	/* subclassed */
 	if (device_class->add_json != NULL)


### PR DESCRIPTION
It seems that this bug has been introduced in
b869ee4782c34b99b711c8a5651b127130b946db since it was calling the parent codec interface.
I specifically call the parent interface in this override, that should fix the "common fwupd part" of the JSON output.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
