### PR TITLE
trivial: Allow char-wwan_port when using the modem-manager plugin

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -112,6 +112,9 @@ if build_daemon
       # for BLKSSZGET
       device_allows += ['block-blkext']
     endif
+    if get_option('plugin_modem_manager').allowed()
+      device_allows += ['char-wwan_port']
+    endif
     foreach device_allow: device_allows
       dynamic_options += ['DeviceAllow=' + device_allow + ' rw']
     endforeach


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
