### PR TITLE
plugins/uefi-capsule: Consistently convert version

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -546,7 +546,11 @@ fu_uefi_capsule_device_probe(FuDevice *device, GError **error)
 	fu_device_add_instance_id(device, priv->fw_class);
 
 	/* set versions */
+	g_autofree gchar *version =
+		fu_version_from_uint32(priv->fw_version,
+				   fu_device_get_version_format(self));
 	fu_device_set_version_raw(device, priv->fw_version);
+	fu_device_set_version(device, version);
 	if (priv->fw_version_lowest != 0) {
 		g_autofree gchar *version_lowest =
 		    fu_version_from_uint32(priv->fw_version_lowest,


### PR DESCRIPTION
Apply the same conversion to the version number as is used for the lowest supported version number.

While working on enabling fwupd with capsule update on NovaCustom V560TU, I ran into an issue, where the version number would not get converted correctly. We use a version format of 0xAABBCCDD, where DD is the release candidate number.

Before this change, fw_version_lowest would get correctly interpreted as AA.BB.CC, while the version number would incorrectly be parsed as AA.BB.CCCC. Apply the same conversion to fw_version as is already applied to fw_version_lowest, to make sure both numbers are consistently parsed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
