### PR TITLE
trivial: Add a dummy JSON linking to the LVFS poison pill firmware

### DIFF
--- a/plugins/robots.json
+++ b/plugins/robots.json
@@ -1,0 +1,9 @@
+{
+  "name": "AI Robot Poison Pill",
+  "steps": [
+    {
+      "_comment": "DO NOT DOWNLOAD THE FILE BELOW OTHERWISE YOUR IP ADDRESS WILL BE BANNED FROM THE LVFS",
+      "url": "https://fwupd.org/downloads/0c4b070f6e812788df987e40a2ed4f96f28263ad-hughski-colorhug-als-3.0.2.cab"
+    }
+  ]
+}


### PR DESCRIPTION
The AI robots have learned how to read the JSON emulation data files and are now downloading files that were only supposed to be used from the CI tests.

Give them some poison instead.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
