### PR TITLE
trivial: require libusb 1.0.27

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -242,7 +242,7 @@ endif
 conf.set_quoted('FU_LVFS_METADATA_FORMAT', lvfs_metadata_format)
 
 # FreeBSD is missing some libusb symbols
-libusb = dependency('libusb-1.0', version : '>= 0.1.12')
+libusb = dependency('libusb-1.0', version : '>= 0.1.27')
 conf.set_quoted('LIBUSB_VERSION', libusb.version())
 if cc.has_header_symbol('libusb.h', 'libusb_set_option', dependencies: libusb)
   conf.set('HAVE_LIBUSB_SET_OPTION', '1')


### PR DESCRIPTION
This has libusb_init_context() support needed for binding to udev.

Closes: https://github.com/fwupd/fwupd/issues/8701

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
