### PR TITLE
Fix a crash when paring uevents that are not KEY=VALUE

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -38,6 +38,7 @@
 #include "fu-self-test-struct.h"
 #include "fu-smbios-private.h"
 #include "fu-test-device.h"
+#include "fu-udev-device-private.h"
 #include "fu-volume-private.h"
 
 static GMainLoop *_test_loop = NULL;
@@ -6363,6 +6364,20 @@ fu_plugin_efi_signature_list_func(void)
 }
 
 static void
+fu_device_udev_func(void)
+{
+	g_autofree gchar *prop = NULL;
+	g_autofree gchar *sysfs_path = g_test_build_filename(G_TEST_DIST, "tests", NULL);
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuUdevDevice) udev_device = fu_udev_device_new(ctx, sysfs_path);
+	g_autoptr(GError) error = NULL;
+
+	prop = fu_udev_device_read_property(udev_device, "MODALIAS", &error);
+	g_assert_no_error(error);
+	g_assert_cmpstr(prop, ==, "hdaudio:v10EC0298r00100103a01");
+}
+
+static void
 fu_cab_checksum_func(void)
 {
 	guint8 buf[] = {0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80};
@@ -6984,6 +6999,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/archive{invalid}", fu_archive_invalid_func);
 	g_test_add_func("/fwupd/archive{cab}", fu_archive_cab_func);
 	g_test_add_func("/fwupd/device", fu_device_func);
+	g_test_add_func("/fwupd/device{udev}", fu_device_udev_func);
 	g_test_add_func("/fwupd/device{event}", fu_device_event_func);
 	g_test_add_func("/fwupd/device{event-uncompressed}", fu_device_event_uncompressed_func);
 	g_test_add_func("/fwupd/device{event-donor}", fu_device_event_donor_func);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -2131,10 +2131,13 @@ fu_udev_device_read_property(FuUdevDevice *self, const gchar *key, GError **erro
 			return NULL;
 		uevent_lines = g_strsplit(str, "\n", -1);
 		for (guint i = 0; uevent_lines[i] != NULL; i++) {
-			g_autofree gchar **kvs = g_strsplit(uevent_lines[i], "=", 2);
-			g_hash_table_insert(priv->properties,
-					    g_steal_pointer(&kvs[0]),
-					    g_steal_pointer(&kvs[1]));
+			/* only split KEY=VALUE */
+			if (g_strstr_len(uevent_lines[i], -1, "=") != NULL) {
+				g_autofree gchar **kvs = g_strsplit(uevent_lines[i], "=", 2);
+				g_hash_table_insert(priv->properties,
+						    g_steal_pointer(&kvs[0]),
+						    g_steal_pointer(&kvs[1]));
+			}
 		}
 		priv->properties_valid = TRUE;
 	}

--- a/libfwupdplugin/tests/meson.build
+++ b/libfwupdplugin/tests/meson.build
@@ -76,6 +76,7 @@ install_data([
     'pci.ids',
     'pnp.ids',
     'usb.ids',
+    'uevent',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests')
 )

--- a/libfwupdplugin/tests/uevent
+++ b/libfwupdplugin/tests/uevent
@@ -1,0 +1,3 @@
+DRIVER=snd_hda_codec_realtek
+MODALIAS=hdaudio:v10EC0298r00100103a01
+


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/8707

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
