### PR TITLE
trivial/documentation: Swap around SPI Write and Replay protection

### DIFF
--- a/docs/hsi-tests.d/org.fwupd.hsi.Amd.SpiReplayProtection.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Amd.SpiReplayProtection.json
@@ -1,8 +1,8 @@
 {
   "id": "org.fwupd.hsi.Amd.SpiReplayProtection",
-  "name": "AMD SPI Write protections",
+  "name": "AMD SPI Replay protections",
   "description": [
-    "SOCs may enforce control of the SPI bus to prevent writes other than by verified entities."
+    "SOCs may include support for replay-protected monotonic counters to prevent replay attacks."
   ],
   "failure-impact": [
     "SOCs without this feature may be attacked by an attacker modifying the SPI."
@@ -13,7 +13,7 @@
   "success-results": {
     "enabled": "SPI protections enabled"
   },
-  "hsi-level": 2,
+  "hsi-level": 3,
   "requires": [
     "CPUID\\VID_AuthenticAMD"
   ],

--- a/docs/hsi-tests.d/org.fwupd.hsi.Amd.SpiWriteProtection.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Amd.SpiWriteProtection.json
@@ -1,8 +1,8 @@
 {
   "id": "org.fwupd.hsi.Amd.SpiWriteProtection",
-  "name": "AMD SPI Replay protections",
+  "name": "AMD SPI Write protections",
   "description": [
-    "SOCs may include support for replay-protected monotonic counters to prevent replay attacks."
+    "SOCs may enforce control of the SPI bus to prevent writes other than by verified entities."
   ],
   "failure-impact": [
     "SOCs without this feature may be attacked by an attacker modifying the SPI."
@@ -13,7 +13,7 @@
   "success-results": {
     "enabled": "SPI protections enabled"
   },
-  "hsi-level": 3,
+  "hsi-level": 2,
   "requires": [
     "CPUID\\VID_AuthenticAMD"
   ],


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [X] Documentation

I noticed that `name` and `description` fields were swapped in these two files, so I adjusted them accordingly.
AFAIK Write protection is supposed to be HSI level 2 and Replay protection level 3, so I adjusted the `hsi-level` value accordingly as well.