### PR TITLE
trivial: Clear any old BOS descriptors from failed probing

### DIFF
--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1017,6 +1017,9 @@ fu_usb_device_ensure_bos_descriptors(FuUsbDevice *self, GError **error)
 	if (priv->bos_descriptors_valid)
 		return TRUE;
 
+	/* clear any old descriptors */
+	g_ptr_array_set_size(priv->bos_descriptors, 0);
+
 	/* libusb or kernel */
 	if (priv->usb_device != NULL) {
 		gint rc;


### PR DESCRIPTION
Maybe fixes https://github.com/fwupd/fwupd/issues/8712

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
