### PR TITLE
trivial: drop google pixel fastboot device

### DIFF
--- a/plugins/fastboot/ci.quirk
+++ b/plugins/fastboot/ci.quirk
@@ -1,0 +1,3 @@
+# Google Pixel 3a
+[USB\VID_18D1&PID_4EE0]
+Plugin = fastboot

--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -39,7 +39,3 @@ CounterpartGuid = USB\VID_0489&PID_E0B4
 Plugin = fastboot
 Summary = Foxconn T77w968/eSIM LTE modem (fastboot)
 CounterpartGuid = USB\VID_0489&PID_E0B5
-
-# Google Pixel 3a
-[USB\VID_18D1&PID_4EE0]
-Plugin = fastboot

--- a/plugins/fastboot/meson.build
+++ b/plugins/fastboot/meson.build
@@ -13,5 +13,8 @@ plugin_builtins += static_library('fu_plugin_fastboot',
   dependencies: plugin_deps,
 )
 
-enumeration_data += files('tests/fastboot-google-sargo-setup.json')
-device_tests += files('tests/fastboot-google-sargo.json')
+if not supported_build
+  plugin_quirks += files('ci.quirk')
+  enumeration_data += files('tests/fastboot-google-sargo-setup.json')
+  device_tests += files('tests/fastboot-google-sargo.json')
+endif


### PR DESCRIPTION
This is marked as a pixel3a, but it actually applies to a pixel 9 as well.  We don't plan to be flashing pixel devices with fwupd and this could cause problems with things like /usr/bin/fastboot if fwupd takes the device.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
