### PR TITLE
fu-flashrom-plugin: Fix SMBIOS parsing for ROM size >= 16MiB

### DIFF
--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -109,16 +109,11 @@ fu_flashrom_plugin_device_set_bios_info(FuPlugin *plugin, FuDevice *device, GErr
 	if (bios_tables == NULL)
 		return FALSE;
 
-	/* ROM size if not already been quirked */
+	/* Get SMBIOS data */
 	bios_blob = g_ptr_array_index(bios_tables, 0);
 	buf = g_bytes_get_data(bios_blob, &bufsz);
-	if (fu_device_get_firmware_size_max(device) == 0) {
-		guint8 bios_sz = 0x0;
-		if (fu_memread_uint8_safe(buf, bufsz, 0x9, &bios_sz, NULL)) {
-			guint64 firmware_size = (bios_sz + 1) * 64 * 1024;
-			fu_device_set_firmware_size_max(device, firmware_size);
-		}
-	}
+	if (bufsz == 0)
+		return FALSE;
 
 	/* BIOS characteristics */
 	if (fu_memread_uint32_safe(buf, bufsz, 0xa, &bios_char, G_LITTLE_ENDIAN, NULL)) {
@@ -127,6 +122,32 @@ fu_flashrom_plugin_device_set_bios_info(FuPlugin *plugin, FuDevice *device, GErr
 					  "bios-characteristics",
 					  "Not supported from SMBIOS");
 		}
+	}
+
+	/* ROM size if not already been quirked */
+	if (fu_device_get_firmware_size_max(device) == 0) {
+		guint8 bios_sz = 0x0;
+		guint64 firmware_size = 0x0;
+		if (!fu_memread_uint8_safe(buf, bufsz, 0x9, &bios_sz, NULL))
+			return FALSE;
+
+		if (bios_sz == 0xff) {
+			/* Need to read extended ROM size */
+			if (!fu_memread_uint8_safe(buf, bufsz, 0x18, &bios_sz, NULL))
+				return FALSE;
+
+			/* Bits 15-14 scale, 13-0 size
+			 *  00 scale -> MiB
+			 *  01 scale -> GiB
+			 *  others reserved
+			 */
+			firmware_size = (bios_sz & 0x3ff) * (1024 * 1024);
+			if (bios_sz & 0xc000)
+				firmware_size *= 1024;
+		} else {
+			firmware_size = (bios_sz + 1) * 64 * 1024;
+		}
+		fu_device_set_firmware_size_max(device, firmware_size);
 	}
 	return TRUE;
 }


### PR DESCRIPTION
According to the SMBIOS 3.x spec, if the value for the ROM size at offset 0x9 is 0xff, then the Extended ROM Size field at offset 0x18 should be used instead. Implement this per the SMBIOS 3.x spec.

Reading of BIOS characteristics is moved ahead of the ROM size in order to facilitate cleaner exiting of the function should either of the reads from SMBIOS fail.

Addresses issue #8570

Type of pull request:

- [ ] New plugin
- [X] Code fix
- [ ] Feature
- [ ] Documentation
