### PR TITLE
uefi-db: Dedupe the Microsoft Windows Signature Database entry

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -62,10 +62,7 @@ fu_efi_signature_list_get_newest(FuEfiSignatureList *self)
 		g_autofree gchar *key = NULL;
 
 		if (fu_efi_signature_get_kind(sig) == FU_EFI_SIGNATURE_KIND_X509) {
-			key = g_strdup_printf(
-			    "%s:%s",
-			    fu_efi_x509_signature_get_subject_vendor(FU_EFI_X509_SIGNATURE(sig)),
-			    fu_efi_x509_signature_get_subject_name(FU_EFI_X509_SIGNATURE(sig)));
+			key = fu_efi_x509_signature_build_dedupe_key(FU_EFI_X509_SIGNATURE(sig));
 		} else {
 			key = fu_firmware_get_checksum(FU_FIRMWARE(sig), G_CHECKSUM_SHA256, NULL);
 		}

--- a/libfwupdplugin/fu-efi-x509-signature-private.h
+++ b/libfwupdplugin/fu-efi-x509-signature-private.h
@@ -15,3 +15,5 @@ fu_efi_x509_signature_set_issuer(FuEfiX509Signature *self, const gchar *issuer) 
 void
 fu_efi_x509_signature_set_subject(FuEfiX509Signature *self, const gchar *subject)
     G_GNUC_NON_NULL(1);
+gchar *
+fu_efi_x509_signature_build_dedupe_key(FuEfiX509Signature *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-efi-x509-signature.c
+++ b/libfwupdplugin/fu-efi-x509-signature.c
@@ -129,6 +129,20 @@ fu_efi_x509_signature_set_subject_name(FuEfiX509Signature *self, const gchar *na
 }
 
 /* private */
+gchar *
+fu_efi_x509_signature_build_dedupe_key(FuEfiX509Signature *self)
+{
+	g_return_val_if_fail(FU_IS_EFI_X509_SIGNATURE(self), NULL);
+
+	/* in 2023 Microsoft renamed "Microsoft Windows Production PCA" -> "Windows UEFI CA" */
+	if (g_strcmp0(self->subject_vendor, "Microsoft") == 0 &&
+	    g_strcmp0(self->subject_name, "Microsoft Windows Production PCA") == 0) {
+		return g_strdup("Microsoft:Windows UEFI CA");
+	}
+	return g_strdup_printf("%s:%s", self->subject_vendor, self->subject_name);
+}
+
+/* private */
 void
 fu_efi_x509_signature_set_subject(FuEfiX509Signature *self, const gchar *subject)
 {


### PR DESCRIPTION
I've confirmed with Microsoft that the new 'Windows' cert is supposed to replace the 'PCA' 2011 one.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
