### PR TITLE
trivial: Enforce that we check the return value of fu_firmware_has_flag()

### DIFF
--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -160,7 +160,8 @@ fu_context_add_flag(FuContext *context, FuContextFlags flag) G_GNUC_NON_NULL(1);
 void
 fu_context_remove_flag(FuContext *context, FuContextFlags flag) G_GNUC_NON_NULL(1);
 gboolean
-fu_context_has_flag(FuContext *context, FuContextFlags flag) G_GNUC_NON_NULL(1);
+fu_context_has_flag(FuContext *context, FuContextFlags flag) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
 
 const gchar *
 fu_context_get_smbios_string(FuContext *self,

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -287,7 +287,8 @@ fu_firmware_get_version_format(FuFirmware *self) G_GNUC_NON_NULL(1);
 void
 fu_firmware_add_flag(FuFirmware *firmware, FuFirmwareFlags flag) G_GNUC_NON_NULL(1);
 gboolean
-fu_firmware_has_flag(FuFirmware *firmware, FuFirmwareFlags flag) G_GNUC_NON_NULL(1);
+fu_firmware_has_flag(FuFirmware *firmware, FuFirmwareFlags flag) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
 const gchar *
 fu_firmware_get_filename(FuFirmware *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -29,7 +29,8 @@ fu_progress_add_flag(FuProgress *self, FuProgressFlag flag) G_GNUC_NON_NULL(1);
 void
 fu_progress_remove_flag(FuProgress *self, FuProgressFlag flag) G_GNUC_NON_NULL(1);
 gboolean
-fu_progress_has_flag(FuProgress *self, FuProgressFlag flag) G_GNUC_NON_NULL(1);
+fu_progress_has_flag(FuProgress *self, FuProgressFlag flag) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
 FwupdStatus
 fu_progress_get_status(FuProgress *self) G_GNUC_NON_NULL(1);
 void

--- a/src/fu-client.h
+++ b/src/fu-client.h
@@ -29,4 +29,4 @@ fu_client_get_feature_flags(FuClient *self) G_GNUC_NON_NULL(1);
 void
 fu_client_remove_flag(FuClient *self, FuClientFlag flag) G_GNUC_NON_NULL(1);
 gboolean
-fu_client_has_flag(FuClient *self, FuClientFlag flag) G_GNUC_NON_NULL(1);
+fu_client_has_flag(FuClient *self, FuClientFlag flag) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);

--- a/src/fu-engine-request.h
+++ b/src/fu-engine-request.h
@@ -20,7 +20,8 @@ fu_engine_request_get_sender(FuEngineRequest *self) G_GNUC_NON_NULL(1);
 void
 fu_engine_request_add_flag(FuEngineRequest *self, FuEngineRequestFlag flag) G_GNUC_NON_NULL(1);
 gboolean
-fu_engine_request_has_flag(FuEngineRequest *self, FuEngineRequestFlag flag) G_GNUC_NON_NULL(1);
+fu_engine_request_has_flag(FuEngineRequest *self,
+			   FuEngineRequestFlag flag) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 FwupdFeatureFlags
 fu_engine_request_get_feature_flags(FuEngineRequest *self) G_GNUC_NON_NULL(1);
 void


### PR DESCRIPTION
My code was doing fu_firmware_has_flag() rather than fu_firmware_add_flag() and the compiler said nothing...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
