### PR TITLE
Split FuFirmwareParseFlags from FwupdInstallFlags

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -855,12 +855,6 @@ fwupd_install_flags_from_string(const gchar *str)
 		return FWUPD_INSTALL_FLAG_NO_HISTORY;
 	if (g_strcmp0(str, "allow-branch-switch") == 0)
 		return FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
-	if (g_strcmp0(str, "ignore-checksum") == 0)
-		return FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM;
-	if (g_strcmp0(str, "ignore-vid-pid") == 0)
-		return FWUPD_INSTALL_FLAG_IGNORE_VID_PID;
-	if (g_strcmp0(str, "no-search") == 0)
-		return FWUPD_INSTALL_FLAG_NO_SEARCH;
 	if (g_strcmp0(str, "ignore-requirements") == 0)
 		return FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS;
 
@@ -892,12 +886,6 @@ fwupd_install_flags_to_string(FwupdInstallFlags install_flags)
 		return "no-history";
 	if (install_flags == FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH)
 		return "allow-branch-switch";
-	if (install_flags == FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM)
-		return "ignore-checksum";
-	if (install_flags == FWUPD_INSTALL_FLAG_IGNORE_VID_PID)
-		return "ignore-vid-pid";
-	if (install_flags == FWUPD_INSTALL_FLAG_NO_SEARCH)
-		return "no-search";
 	if (install_flags == FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS)
 		return "ignore-requirements";
 	return NULL;

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1093,7 +1093,7 @@ typedef enum {
 	/**
 	 * FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM:
 	 *
-	 * Ignore firmware CRCs and checksums.
+	 * This is now unused; see #FuFirmwareParseFlags.
 	 *
 	 * Since: 1.5.0
 	 */
@@ -1101,7 +1101,7 @@ typedef enum {
 	/**
 	 * FWUPD_INSTALL_FLAG_IGNORE_VID_PID:
 	 *
-	 * Ignore firmware vendor and project checks.
+	 * This is now unused; see #FuFirmwareParseFlags.
 	 *
 	 * Since: 1.5.0
 	 */
@@ -1109,7 +1109,7 @@ typedef enum {
 	/**
 	 * FWUPD_INSTALL_FLAG_NO_SEARCH:
 	 *
-	 * Do not use heuristics when parsing the image.
+	 * This is now unused; see #FuFirmwareParseFlags.
 	 *
 	 * Since: 1.5.0
 	 */

--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -117,7 +117,7 @@ fu_acpi_table_get_oem_revision(FuAcpiTable *self)
 static gboolean
 fu_acpi_table_parse(FuFirmware *firmware,
 		    GInputStream *stream,
-		    FwupdInstallFlags flags,
+		    FuFirmwareParseFlags flags,
 		    GError **error)
 {
 	FuAcpiTable *self = FU_ACPI_TABLE(firmware);
@@ -154,7 +154,7 @@ fu_acpi_table_parse(FuFirmware *firmware,
 	fu_firmware_set_size(firmware, length);
 
 	/* checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 checksum_actual = 0;
 		if (!fu_input_stream_compute_sum8(stream, &checksum_actual, error))
 			return FALSE;

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -56,7 +56,7 @@ fu_archive_firmware_parse_cb(FuArchive *self,
 static gboolean
 fu_archive_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	g_autoptr(FuArchive) archive = NULL;

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -108,7 +108,7 @@ fu_cab_firmware_set_only_basename(FuCabFirmware *self, gboolean only_basename)
 
 typedef struct {
 	GInputStream *stream;
-	FwupdInstallFlags install_flags;
+	FuFirmwareParseFlags parse_flags;
 	gsize rsvd_folder;
 	gsize rsvd_block;
 	gsize size_total;
@@ -244,7 +244,7 @@ fu_cab_firmware_parse_data(FuCabFirmware *self,
 		g_prefix_error(error, "failed to cut cabinet checksum: ");
 		return FALSE;
 	}
-	if ((helper->install_flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((helper->parse_flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 checksum = fu_struct_cab_data_get_checksum(st);
 		if (checksum != 0) {
 			guint32 checksum_actual = 0;
@@ -491,7 +491,7 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 		g_prefix_error(error, "failed to cut cabinet image: ");
 		return FALSE;
 	}
-	if (!fu_firmware_parse_stream(FU_FIRMWARE(img), stream, 0x0, helper->install_flags, error))
+	if (!fu_firmware_parse_stream(FU_FIRMWARE(img), stream, 0x0, helper->parse_flags, error))
 		return FALSE;
 	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
 		return FALSE;
@@ -520,7 +520,7 @@ fu_cab_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 }
 
 static FuCabFirmwareParseHelper *
-fu_cab_firmware_parse_helper_new(GInputStream *stream, FwupdInstallFlags flags, GError **error)
+fu_cab_firmware_parse_helper_new(GInputStream *stream, FuFirmwareParseFlags flags, GError **error)
 {
 	int zret;
 	g_autoptr(FuCabFirmwareParseHelper) helper = g_new0(FuCabFirmwareParseHelper, 1);
@@ -539,7 +539,7 @@ fu_cab_firmware_parse_helper_new(GInputStream *stream, FwupdInstallFlags flags, 
 	}
 
 	helper->stream = g_object_ref(stream);
-	helper->install_flags = flags;
+	helper->parse_flags = flags;
 	helper->folder_data = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	helper->decompress_bufsz = FU_CAB_FIRMWARE_DECOMPRESS_BUFSZ;
 	return g_steal_pointer(&helper);
@@ -548,7 +548,7 @@ fu_cab_firmware_parse_helper_new(GInputStream *stream, FwupdInstallFlags flags, 
 static gboolean
 fu_cab_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuCabFirmware *self = FU_CAB_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -419,7 +419,7 @@ fu_cfu_offer_set_product_id(FuCfuOffer *self, guint16 product_id)
 static gboolean
 fu_cfu_offer_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuCfuOffer *self = FU_CFU_OFFER(firmware);

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -32,7 +32,7 @@ G_DEFINE_TYPE(FuCfuPayload, fu_cfu_payload, FU_TYPE_FIRMWARE)
 static gboolean
 fu_cfu_payload_parse(FuFirmware *firmware,
 		     GInputStream *stream,
-		     FwupdInstallFlags flags,
+		     FuFirmwareParseFlags flags,
 		     GError **error)
 {
 	gsize offset = 0;

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -132,7 +132,10 @@ fu_context_get_fdt(FuContext *self, GError **error)
 		g_autoptr(GFile) file = fu_context_get_fdt_file(error);
 		if (file == NULL)
 			return NULL;
-		if (!fu_firmware_parse_file(fdt_tmp, file, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
+		if (!fu_firmware_parse_file(fdt_tmp,
+					    file,
+					    FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
+					    error)) {
 			g_prefix_error(error, "failed to parse FDT: ");
 			return NULL;
 		}
@@ -1874,7 +1877,7 @@ fu_context_esp_load_pe_file(const gchar *filename, GError **error)
 	g_autoptr(FuFirmware) firmware = fu_pefile_firmware_new();
 	g_autoptr(GFile) file = g_file_new_for_path(filename);
 	fu_firmware_set_filename(firmware, filename);
-	if (!fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, error)) {
 		g_prefix_error(error, "failed to load %s: ", filename);
 		return NULL;
 	}

--- a/libfwupdplugin/fu-coswid-firmware.c
+++ b/libfwupdplugin/fu-coswid-firmware.c
@@ -570,7 +570,7 @@ fu_coswid_firmware_free(void *ptr)
 static gboolean
 fu_coswid_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 #ifdef HAVE_CBOR

--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -190,7 +190,7 @@ fu_csv_entry_parse_token_cb(GString *token, guint token_idx, gpointer user_data,
 static gboolean
 fu_csv_entry_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuCsvEntry *self = FU_CSV_ENTRY(firmware);

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -169,7 +169,7 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 	fu_firmware_set_idx(entry, token_idx);
 	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), entry, error))
 		return FALSE;
-	if (!fu_firmware_parse_bytes(entry, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(entry, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 	return TRUE;
 }
@@ -177,7 +177,7 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 static gboolean
 fu_csv_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuCsvFirmware *self = FU_CSV_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -5182,7 +5182,7 @@ fu_device_write_firmware(FuDevice *self,
  * fu_device_prepare_firmware:
  * @self: a #FuDevice
  * @stream: a #GInputStream
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Prepares the firmware by calling an optional device-specific vfunc for the
@@ -5201,7 +5201,7 @@ FuFirmware *
 fu_device_prepare_firmware(FuDevice *self,
 			   GInputStream *stream,
 			   FuProgress *progress,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(self);
@@ -5306,7 +5306,7 @@ fu_device_read_firmware(FuDevice *self, FuProgress *progress, GError **error)
 		return NULL;
 	if (priv->firmware_gtype != G_TYPE_INVALID) {
 		g_autoptr(FuFirmware) firmware = g_object_new(priv->firmware_gtype, NULL);
-		if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 			return NULL;
 		return g_steal_pointer(&firmware);
 	}

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -45,7 +45,7 @@ struct _FuDeviceClass {
 	FuFirmware *(*prepare_firmware)(FuDevice *self,
 					GInputStream *stream,
 					FuProgress *progress,
-					FwupdInstallFlags flags,
+					FuFirmwareParseFlags flags,
 					GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*set_quirk_kv)(FuDevice *self,
 				 const gchar *key,
@@ -1035,7 +1035,7 @@ FuFirmware *
 fu_device_prepare_firmware(FuDevice *self,
 			   GInputStream *stream,
 			   FuProgress *progress,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
 FuFirmware *
 fu_device_read_firmware(FuDevice *self,

--- a/libfwupdplugin/fu-dfu-firmware-private.h
+++ b/libfwupdplugin/fu-dfu-firmware-private.h
@@ -16,5 +16,5 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
 gboolean
 fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -216,7 +216,7 @@ fu_dfu_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 gboolean
 fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -241,7 +241,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 	priv->footer_len = fu_struct_dfu_ftr_get_len(st);
 
 	/* verify the checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 crc_new = fu_crc32(FU_CRC_KIND_B32_JAMCRC, buf, bufsz - 4);
 		if (fu_struct_dfu_ftr_get_crc(st) != crc_new) {
 			g_set_error(error,
@@ -272,7 +272,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 static gboolean
 fu_dfu_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuDfuFirmware *self = FU_DFU_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -114,7 +114,7 @@ fu_dfuse_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_dfuse_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	FuDfuFirmware *dfu_firmware = FU_DFU_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-drm-device.c
+++ b/libfwupdplugin/fu-drm-device.c
@@ -272,7 +272,7 @@ fu_drm_device_probe(FuDevice *device, GError **error)
 		if (!fu_firmware_parse_bytes(FU_FIRMWARE(edid),
 					     blob,
 					     0x0,
-					     FWUPD_INSTALL_FLAG_NONE,
+					     FU_FIRMWARE_PARSE_FLAG_NONE,
 					     error))
 			return FALSE;
 		g_set_object(&priv->edid, edid);

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -217,7 +217,10 @@ fu_edid_parse_descriptor(FuEdid *self, GInputStream *stream, gsize offset, GErro
 }
 
 static gboolean
-fu_edid_parse(FuFirmware *firmware, GInputStream *stream, FwupdInstallFlags flags, GError **error)
+fu_edid_parse(FuFirmware *firmware,
+	      GInputStream *stream,
+	      FuFirmwareParseFlags flags,
+	      GError **error)
 {
 	FuEdid *self = FU_EDID(firmware);
 	const guint8 *manu_id;

--- a/libfwupdplugin/fu-efi-common.c
+++ b/libfwupdplugin/fu-efi-common.c
@@ -71,7 +71,7 @@ fu_efi_guid_to_name(const gchar *guid)
  * fu_efi_parse_sections:
  * @firmware: #FuFirmware
  * @stream: a #GInputStream
- * @flags: flags
+ * @flags: #FuFirmwareParseFlags
  * @error: (nullable): optional return location for an error
  *
  * Parses a UEFI section.
@@ -84,7 +84,7 @@ gboolean
 fu_efi_parse_sections(FuFirmware *firmware,
 		      GInputStream *stream,
 		      gsize offset,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	gsize streamsz = 0;
@@ -105,7 +105,7 @@ fu_efi_parse_sections(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error)) {
 			g_prefix_error(error,
 				       "failed to parse section of size 0x%x: ",

--- a/libfwupdplugin/fu-efi-common.h
+++ b/libfwupdplugin/fu-efi-common.h
@@ -36,5 +36,5 @@ gboolean
 fu_efi_parse_sections(FuFirmware *firmware,
 		      GInputStream *stream,
 		      gsize offset,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -68,7 +68,7 @@ fu_efi_device_path_list_add_json(FwupdCodec *codec, JsonBuilder *builder, FwupdC
 static gboolean
 fu_efi_device_path_list_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	gsize offset = 0;

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -91,7 +91,7 @@ fu_efi_device_path_set_subtype(FuEfiDevicePath *self, guint8 subtype)
 static gboolean
 fu_efi_device_path_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuEfiDevicePath *self = FU_EFI_DEVICE_PATH(firmware);

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -72,7 +72,7 @@ fu_efi_file_hdr_checksum8(GBytes *blob)
 static gboolean
 fu_efi_file_parse(FuFirmware *firmware,
 		  GInputStream *stream,
-		  FwupdInstallFlags flags,
+		  FuFirmwareParseFlags flags,
 		  GError **error)
 {
 	FuEfiFile *self = FU_EFI_FILE(firmware);
@@ -120,7 +120,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 	}
 
 	/* verify header checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 hdr_checksum_verify;
 		g_autoptr(GBytes) hdr_blob = NULL;
 
@@ -148,7 +148,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 
 	/* verify data checksum */
 	if ((priv->attrib & FU_EFI_FILE_ATTRIB_CHECKSUM) > 0 &&
-	    (flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	    (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 data_checksum_verify = 0;
 		if (!fu_input_stream_compute_sum8(partial_stream, &data_checksum_verify, error))
 			return FALSE;

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -29,7 +29,7 @@ G_DEFINE_TYPE(FuEfiFilesystem, fu_efi_filesystem, FU_TYPE_FIRMWARE)
 static gboolean
 fu_efi_filesystem_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	gsize offset = 0;
@@ -65,7 +65,7 @@ fu_efi_filesystem_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      stream_tmp,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error)) {
 			g_prefix_error(error, "failed to parse EFI file at 0x%x: ", (guint)offset);
 			return FALSE;

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -93,7 +93,7 @@ fu_efi_hard_drive_device_path_add_json(FwupdCodec *codec,
 static gboolean
 fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuEfiHardDriveDevicePath *self = FU_EFI_HARD_DRIVE_DEVICE_PATH(firmware);

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -292,7 +292,7 @@ fu_efi_load_option_parse_optional(FuEfiLoadOption *self,
 static gboolean
 fu_efi_load_option_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuEfiLoadOption *self = FU_EFI_LOAD_OPTION(firmware);

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -587,7 +587,7 @@ fu_efi_lz77_decompressor_internal(FuEfiLz77DecompressHelper *helper,
 static gboolean
 fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	gsize streamsz = 0;

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -60,14 +60,14 @@ fu_efi_section_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuild
 static gboolean
 fu_efi_section_parse_volume_image(FuEfiSection *self,
 				  GInputStream *stream,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	g_autoptr(FuFirmware) img = fu_efi_volume_new();
 	if (!fu_firmware_parse_stream(img,
 				      stream,
 				      0x0,
-				      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      error)) {
 		return FALSE;
 	}
@@ -78,7 +78,7 @@ fu_efi_section_parse_volume_image(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse_lzma_sections(FuEfiSection *self,
 				   GInputStream *stream,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	g_autoptr(GBytes) blob = NULL;
@@ -105,7 +105,7 @@ fu_efi_section_parse_lzma_sections(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse_user_interface(FuEfiSection *self,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
@@ -131,7 +131,7 @@ fu_efi_section_parse_user_interface(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse_version(FuEfiSection *self,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	guint16 version_raw = 0;
@@ -160,7 +160,7 @@ fu_efi_section_parse_version(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse_compression_sections(FuEfiSection *self,
 					  GInputStream *stream,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	g_autoptr(GByteArray) st = NULL;
@@ -222,7 +222,7 @@ fu_efi_section_freeform_subtype_guid_to_string(const gchar *guid)
 static gboolean
 fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
 					   GInputStream *stream,
-					   FwupdInstallFlags flags,
+					   FuFirmwareParseFlags flags,
 					   GError **error)
 {
 	const gchar *guid_ui;
@@ -248,7 +248,7 @@ fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
 static gboolean
 fu_efi_section_parse(FuFirmware *firmware,
 		     GInputStream *stream,
-		     FwupdInstallFlags flags,
+		     FuFirmwareParseFlags flags,
 		     GError **error)
 {
 	FuEfiSection *self = FU_EFI_SECTION(firmware);

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -158,7 +158,7 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 		if (!fu_firmware_parse_stream(FU_FIRMWARE(sig),
 					      stream,
 					      offset_tmp,
-					      FWUPD_INSTALL_FLAG_NONE,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
 					      error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(sig), error))
@@ -205,7 +205,7 @@ fu_efi_signature_list_validate(FuFirmware *firmware,
 static gboolean
 fu_efi_signature_list_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuEfiSignatureList *self = FU_EFI_SIGNATURE_LIST(firmware);

--- a/libfwupdplugin/fu-efi-signature.c
+++ b/libfwupdplugin/fu-efi-signature.c
@@ -113,7 +113,7 @@ fu_efi_signature_get_owner(FuEfiSignature *self)
 static gboolean
 fu_efi_signature_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuEfiSignature *self = FU_EFI_SIGNATURE(firmware);

--- a/libfwupdplugin/fu-efi-variable-authentication2.c
+++ b/libfwupdplugin/fu-efi-variable-authentication2.c
@@ -145,7 +145,11 @@ fu_efi_variable_authentication2_parse_pkcs7_certs(FuEfiVariableAuthentication2 *
 
 	/* parse PKCS#7 blob */
 	blob = g_bytes_new(buf->data, buf->len);
-	if (!fu_firmware_parse_bytes(FU_FIRMWARE(pkcs7), blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(pkcs7),
+				     blob,
+				     0x0,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
+				     error))
 		return FALSE;
 
 	/* add certificates that signed this variable */
@@ -162,7 +166,7 @@ fu_efi_variable_authentication2_parse_pkcs7_certs(FuEfiVariableAuthentication2 *
 static gboolean
 fu_efi_variable_authentication2_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuEfiVariableAuthentication2 *self = FU_EFI_VARIABLE_AUTHENTICATION2(firmware);

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -56,7 +56,7 @@ fu_efi_volume_validate(FuFirmware *firmware, GInputStream *stream, gsize offset,
 static gboolean
 fu_efi_volume_parse(FuFirmware *firmware,
 		    GInputStream *stream,
-		    FwupdInstallFlags flags,
+		    FuFirmwareParseFlags flags,
 		    GError **error)
 {
 	FuEfiVolume *self = FU_EFI_VOLUME(firmware);
@@ -119,7 +119,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	}
 
 	/* verify checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint16 checksum_verify;
 		g_autoptr(GBytes) blob_hdr = NULL;
 
@@ -184,7 +184,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
 		fu_firmware_add_image(firmware, img);

--- a/libfwupdplugin/fu-efi-x509-signature.c
+++ b/libfwupdplugin/fu-efi-x509-signature.c
@@ -222,7 +222,7 @@ fu_efi_x509_signature_get_subject_vendor(FuEfiX509Signature *self)
 static gboolean
 fu_efi_x509_signature_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuEfiX509Signature *self = FU_EFI_X509_SIGNATURE(firmware);

--- a/libfwupdplugin/fu-efivars.c
+++ b/libfwupdplugin/fu-efivars.c
@@ -825,7 +825,7 @@ fu_efivars_get_boot_entry(FuEfivars *self, guint16 idx, GError **error)
 	if (!fu_firmware_parse_bytes(FU_FIRMWARE(loadopt),
 				     blob,
 				     0x0,
-				     FWUPD_INSTALL_FLAG_NONE,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
 				     error))
 		return NULL;
 	fu_firmware_set_idx(FU_FIRMWARE(loadopt), idx);

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -37,7 +37,7 @@ fu_elf_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_elf_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	gsize offset_secthdr = 0;

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -322,7 +322,7 @@ fu_fdt_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_fdt_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuFdtFirmware *self = FU_FDT_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -938,7 +938,7 @@ fu_firmware_get_checksum(FuFirmware *self, GChecksumType csum_kind, GError **err
  * fu_firmware_tokenize:
  * @self: a #FuFirmware
  * @stream: a #GInputStream
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Tokenizes a firmware, typically breaking the firmware into records.
@@ -953,7 +953,7 @@ fu_firmware_get_checksum(FuFirmware *self, GChecksumType csum_kind, GError **err
 gboolean
 fu_firmware_tokenize(FuFirmware *self,
 		     GInputStream *stream,
-		     FwupdInstallFlags flags,
+		     FuFirmwareParseFlags flags,
 		     GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
@@ -972,7 +972,7 @@ fu_firmware_tokenize(FuFirmware *self,
  * fu_firmware_check_compatible:
  * @self: a #FuFirmware
  * @other: a #FuFirmware
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Check a new firmware is compatible with the existing firmware.
@@ -984,7 +984,7 @@ fu_firmware_tokenize(FuFirmware *self,
 gboolean
 fu_firmware_check_compatible(FuFirmware *self,
 			     FuFirmware *other,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
@@ -1003,7 +1003,7 @@ static gboolean
 fu_firmware_validate_for_offset(FuFirmware *self,
 				GInputStream *stream,
 				gsize *offset,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
@@ -1015,7 +1015,7 @@ fu_firmware_validate_for_offset(FuFirmware *self,
 
 	/* fuzzing */
 	if (!fu_firmware_has_flag(self, FU_FIRMWARE_FLAG_ALWAYS_SEARCH) &&
-	    (flags & FWUPD_INSTALL_FLAG_NO_SEARCH) > 0) {
+	    (flags & FU_FIRMWARE_PARSE_FLAG_NO_SEARCH) > 0) {
 		if (!klass->validate(self, stream, *offset, error))
 			return FALSE;
 		return TRUE;
@@ -1055,7 +1055,7 @@ fu_firmware_validate_for_offset(FuFirmware *self,
  * @self: a #FuFirmware
  * @stream: input stream
  * @offset: start offset
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Parses a firmware from a stream, typically breaking the firmware into images.
@@ -1068,7 +1068,7 @@ gboolean
 fu_firmware_parse_stream(FuFirmware *self,
 			 GInputStream *stream,
 			 gsize offset,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
@@ -1179,7 +1179,7 @@ fu_firmware_parse_stream(FuFirmware *self,
  * @self: a #FuFirmware
  * @fw: firmware blob
  * @offset: start offset, useful for ignoring a bootloader
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Parses a firmware, typically breaking the firmware into images.
@@ -1192,7 +1192,7 @@ gboolean
 fu_firmware_parse_bytes(FuFirmware *self,
 			GBytes *fw,
 			gsize offset,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	g_autoptr(GInputStream) stream = NULL;
@@ -1515,7 +1515,7 @@ fu_firmware_build_from_filename(FuFirmware *self, const gchar *filename, GError 
  * fu_firmware_parse_file:
  * @self: a #FuFirmware
  * @file: a file
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_FORCE
+ * @flags: #FuFirmwareParseFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: (nullable): optional return location for an error
  *
  * Parses a firmware file, typically breaking the firmware into images.
@@ -1525,7 +1525,7 @@ fu_firmware_build_from_filename(FuFirmware *self, const gchar *filename, GError 
  * Since: 1.3.3
  **/
 gboolean
-fu_firmware_parse_file(FuFirmware *self, GFile *file, FwupdInstallFlags flags, GError **error)
+fu_firmware_parse_file(FuFirmware *self, GFile *file, FuFirmwareParseFlags flags, GError **error)
 {
 	g_autoptr(GFileInputStream) stream = NULL;
 
@@ -2548,7 +2548,7 @@ fu_firmware_new_from_bytes(GBytes *fw)
  * fu_firmware_new_from_gtypes:
  * @stream: a #GInputStream
  * @offset: start offset, useful for ignoring a bootloader
- * @flags: install flags, e.g. %FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM
+ * @flags: install flags, e.g. %FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM
  * @error: (nullable): optional return location for an error
  * @...: an array of #GTypes, ending with %G_TYPE_INVALID
  *
@@ -2561,7 +2561,7 @@ fu_firmware_new_from_bytes(GBytes *fw)
 FuFirmware *
 fu_firmware_new_from_gtypes(GInputStream *stream,
 			    gsize offset,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error,
 			    ...)
 {

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -55,17 +55,57 @@ typedef enum {
 	FU_FIRMWARE_EXPORT_FLAG_UNKNOWN = G_MAXUINT64,
 } FuFirmwareExportFlags;
 
+/**
+ * FuFirmwareParseFlags:
+ *
+ * The firmware parse flags.
+ **/
+typedef enum {
+	/**
+	 * FWUPD_INSTALL_FLAG_NONE:
+	 *
+	 * No flags set.
+	 *
+	 * Since: 2.0.9
+	 */
+	FU_FIRMWARE_PARSE_FLAG_NONE = 0,
+	/**
+	 * FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM:
+	 *
+	 * Ignore firmware CRCs and checksums.
+	 *
+	 * Since: 2.0.9
+	 */
+	FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM = 1 << 6,
+	/**
+	 * FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID:
+	 *
+	 * Ignore firmware vendor and project checks.
+	 *
+	 * Since: 2.0.9
+	 */
+	FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID = 1 << 7,
+	/**
+	 * FU_FIRMWARE_PARSE_FLAG_NO_SEARCH:
+	 *
+	 * Do not use heuristics when parsing the image.
+	 *
+	 * Since: 2.0.9
+	 */
+	FU_FIRMWARE_PARSE_FLAG_NO_SEARCH = 1 << 8,
+} FuFirmwareParseFlags;
+
 struct _FuFirmwareClass {
 	GObjectClass parent_class;
 	gboolean (*parse)(FuFirmware *self,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	GByteArray *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	void (*export)(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode *bn);
 	gboolean (*tokenize)(FuFirmware *self,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gboolean (*build)(FuFirmware *self, XbNode *n, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	gchar *(*get_checksum)(FuFirmware *self,
@@ -74,7 +114,7 @@ struct _FuFirmwareClass {
 	gboolean (*validate)(FuFirmware *self, GInputStream *stream, gsize offset, GError **error);
 	gboolean (*check_compatible)(FuFirmware *self,
 				     FuFirmware *other,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error);
 	gchar *(*convert_version)(FuFirmware *self, guint64 version_raw);
 };
@@ -260,7 +300,7 @@ fu_firmware_new_from_bytes(GBytes *fw);
 FuFirmware *
 fu_firmware_new_from_gtypes(GInputStream *stream,
 			    gsize offset,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error,
 			    ...) G_GNUC_NON_NULL(1);
 gchar *
@@ -349,7 +389,7 @@ fu_firmware_set_parent(FuFirmware *self, FuFirmware *parent) G_GNUC_NON_NULL(1);
 gboolean
 fu_firmware_tokenize(FuFirmware *self,
 		     GInputStream *stream,
-		     FwupdInstallFlags flags,
+		     FuFirmwareParseFlags flags,
 		     GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_firmware_build(FuFirmware *self, XbNode *n, GError **error) G_GNUC_WARN_UNUSED_RESULT
@@ -366,16 +406,16 @@ gboolean
 fu_firmware_parse_stream(FuFirmware *self,
 			 GInputStream *stream,
 			 gsize offset,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_firmware_parse_file(FuFirmware *self, GFile *file, FwupdInstallFlags flags, GError **error)
+fu_firmware_parse_file(FuFirmware *self, GFile *file, FuFirmwareParseFlags flags, GError **error)
     G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_firmware_parse_bytes(FuFirmware *self,
 			GBytes *fw,
 			gsize offset,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 GBytes *
 fu_firmware_write(FuFirmware *self, GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
@@ -391,7 +431,7 @@ fu_firmware_get_checksum(FuFirmware *self, GChecksumType csum_kind, GError **err
 gboolean
 fu_firmware_check_compatible(FuFirmware *self,
 			     FuFirmware *other,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_NON_NULL(1, 2);
 
 void

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -210,7 +210,7 @@ static gboolean
 fu_fit_firmware_verify_image(FuFirmware *firmware,
 			     GInputStream *stream,
 			     FuFirmware *img,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	g_autoptr(GBytes) blob = NULL;
@@ -245,7 +245,7 @@ fu_fit_firmware_verify_image(FuFirmware *firmware,
 	fu_dump_bytes(G_LOG_DOMAIN, "data", blob);
 
 	/* verify any hashes we recognize */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		g_autoptr(GPtrArray) img_hashes = fu_firmware_get_images(img);
 		for (guint i = 0; i < img_hashes->len; i++) {
 			FuFirmware *img_hash = g_ptr_array_index(img_hashes, i);
@@ -274,7 +274,7 @@ fu_fit_firmware_verify_image(FuFirmware *firmware,
 static gboolean
 fu_fit_firmware_verify_configuration(FuFirmware *firmware,
 				     FuFirmware *img,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	/* sanity check */
@@ -291,7 +291,7 @@ fu_fit_firmware_verify_configuration(FuFirmware *firmware,
 static gboolean
 fu_fit_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	g_autoptr(FuFirmware) img_cfgs = NULL;

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -29,7 +29,7 @@ G_DEFINE_TYPE(FuFmapFirmware, fu_fmap_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_fmap_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	gsize offset = 0;

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -17,16 +17,16 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 
 	(void)g_setenv("G_DEBUG", "fatal-criticals", TRUE);
 	(void)g_setenv("FWUPD_FUZZER_RUNNING", "1", TRUE);
-	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, NULL);
+	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		g_clear_object(&firmware);
 		firmware = FU_FIRMWARE(@FIRMWARENEW@);
 		ret = fu_firmware_parse_bytes(firmware,
 					fw,
 					0x0,
-					FWUPD_INSTALL_FLAG_NO_SEARCH |
-					    FWUPD_INSTALL_FLAG_IGNORE_VID_PID |
-					    FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM,
+					FU_FIRMWARE_PARSE_FLAG_NO_SEARCH |
+					    FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID |
+					    FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM,
 					NULL);
 	}
 	if (ret) {

--- a/libfwupdplugin/fu-gcab.c
+++ b/libfwupdplugin/fu-gcab.c
@@ -85,7 +85,7 @@ main(int argc, char **argv)
 		g_autoptr(GFile) file = g_file_new_for_path(argv[1]);
 		if (!fu_firmware_parse_file(FU_FIRMWARE(cab_firmware),
 					    file,
-					    FWUPD_INSTALL_FLAG_NONE,
+					    FU_FIRMWARE_PARSE_FLAG_NONE,
 					    &error)) {
 			g_printerr("Failed to parse %s: %s\n", argv[1], error->message);
 			return EXIT_FAILURE;

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -52,7 +52,7 @@ fu_hid_descriptor_count_table_dupes(GPtrArray *table, FuHidReportItem *item)
 static gboolean
 fu_hid_descriptor_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	gsize offset = 0;

--- a/libfwupdplugin/fu-hid-device.c
+++ b/libfwupdplugin/fu-hid-device.c
@@ -114,7 +114,11 @@ fu_hid_device_parse_descriptors(FuHidDevice *self, GError **error)
 		g_autoptr(FuFirmware) descriptor = fu_hid_descriptor_new();
 		g_autofree gchar *title = g_strdup_printf("HidDescriptor:0x%x", i);
 		fu_dump_bytes(G_LOG_DOMAIN, title, fw);
-		if (!fu_firmware_parse_bytes(descriptor, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_bytes(descriptor,
+					     fw,
+					     0x0,
+					     FU_FIRMWARE_PARSE_FLAG_NONE,
+					     error))
 			return NULL;
 		g_ptr_array_add(descriptors, g_steal_pointer(&descriptor));
 	}

--- a/libfwupdplugin/fu-hid-report-item.c
+++ b/libfwupdplugin/fu-hid-report-item.c
@@ -57,7 +57,7 @@ fu_hid_report_item_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 static gboolean
 fu_hid_report_item_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuHidReportItem *self = FU_HID_REPORT_ITEM(firmware);

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -30,7 +30,7 @@ G_DEFINE_TYPE(FuIfdBios, fu_ifd_bios, FU_TYPE_IFD_IMAGE)
 static gboolean
 fu_ifd_bios_parse(FuFirmware *firmware,
 		  GInputStream *stream,
-		  FwupdInstallFlags flags,
+		  FuFirmwareParseFlags flags,
 		  GError **error)
 {
 	gsize offset = 0;

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -126,7 +126,7 @@ fu_ifd_firmware_fixup_stream(GInputStream *stream, GError **error)
 static gboolean
 fu_ifd_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuIfdFirmware *self = FU_IFD_FIRMWARE(firmware);
@@ -235,7 +235,7 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
 		fu_firmware_set_addr(img, freg_base);

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -120,7 +120,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware, GInputStream *stream, 
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
-					      FWUPD_INSTALL_FLAG_NONE,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
 					      error))
 			return FALSE;
 
@@ -147,7 +147,7 @@ fu_ifwi_cpd_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuIfwiCpdFirmware *self = FU_IFWI_CPD_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -46,7 +46,7 @@ fu_ifwi_fpt_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	guint32 num_of_entries;

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -88,7 +88,7 @@ fu_ihex_firmware_record_free(FuIhexFirmwareRecord *rcd)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuIhexFirmwareRecord, fu_ihex_firmware_record_free)
 
 static FuIhexFirmwareRecord *
-fu_ihex_firmware_record_new(guint ln, const gchar *line, FwupdInstallFlags flags, GError **error)
+fu_ihex_firmware_record_new(guint ln, const gchar *line, FuFirmwareParseFlags flags, GError **error)
 {
 	g_autoptr(FuIhexFirmwareRecord) rcd = NULL;
 	gsize linesz = strlen(line);
@@ -138,7 +138,7 @@ fu_ihex_firmware_record_new(guint ln, const gchar *line, FwupdInstallFlags flags
 	}
 
 	/* verify checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 checksum = 0;
 		for (guint i = 1; i < line_end + 2; i += 2) {
 			guint8 data_tmp = 0;
@@ -168,7 +168,7 @@ fu_ihex_firmware_record_new(guint ln, const gchar *line, FwupdInstallFlags flags
 
 typedef struct {
 	FuIhexFirmware *self;
-	FwupdInstallFlags flags;
+	FuFirmwareParseFlags flags;
 } FuIhexFirmwareTokenHelper;
 
 static gboolean
@@ -212,7 +212,7 @@ fu_ihex_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_ihex_firmware_tokenize(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuIhexFirmware *self = FU_IHEX_FIRMWARE(firmware);
@@ -223,7 +223,7 @@ fu_ihex_firmware_tokenize(FuFirmware *firmware,
 static gboolean
 fu_ihex_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuIhexFirmware *self = FU_IHEX_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-intel-thunderbolt-firmware.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-firmware.c
@@ -39,7 +39,7 @@ fu_intel_thunderbolt_firmware_nvm_valid_farb_pointer(guint32 pointer)
 static gboolean
 fu_intel_thunderbolt_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	const guint32 farb_offsets[] = {0x0, 0x1000};

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -356,7 +356,7 @@ fu_intel_thunderbolt_nvm_missing_needed_drom(FuIntelThunderboltNvm *self)
 static gboolean
 fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	FuIntelThunderboltNvm *self = FU_INTEL_THUNDERBOLT_NVM(firmware);
@@ -612,7 +612,7 @@ fu_intel_thunderbolt_nvm_write(FuFirmware *firmware, GError **error)
 static gboolean
 fu_intel_thunderbolt_nvm_check_compatible(FuFirmware *firmware,
 					  FuFirmware *firmware_other,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuIntelThunderboltNvm *self = FU_INTEL_THUNDERBOLT_NVM(firmware);
@@ -647,7 +647,7 @@ fu_intel_thunderbolt_nvm_check_compatible(FuFirmware *firmware,
 			    priv_other->device_id);
 		return FALSE;
 	}
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 		if (priv->model_id != priv_other->model_id) {
 			g_set_error(error,
 				    FWUPD_ERROR,

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -86,7 +86,7 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 static gboolean
 fu_linear_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuLinearFirmware *self = FU_LINEAR_FIRMWARE(firmware);
@@ -108,7 +108,7 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      stream_tmp,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error)) {
 			g_prefix_error(error, "failed to parse at 0x%x: ", (guint)offset);
 			return FALSE;

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -116,7 +116,7 @@ fu_oprom_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_oprom_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	FuOpromFirmware *self = FU_OPROM_FIRMWARE(firmware);
@@ -167,7 +167,7 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) img = NULL;
 		img = fu_firmware_new_from_gtypes(stream,
 						  expansion_header_offset,
-						  FWUPD_INSTALL_FLAG_NONE,
+						  FU_FIRMWARE_PARSE_FLAG_NONE,
 						  error,
 						  FU_TYPE_IFWI_CPD_FIRMWARE,
 						  FU_TYPE_FIRMWARE,

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -102,7 +102,7 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 				 gsize hdr_offset,
 				 gsize strtab_offset,
 				 GPtrArray *regions,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	g_autofree gchar *sect_id = NULL;
@@ -206,7 +206,7 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 static gboolean
 fu_pefile_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuPefileFirmware *self = FU_PEFILE_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-pkcs7.c
+++ b/libfwupdplugin/fu-pkcs7.c
@@ -47,7 +47,11 @@ fu_pkcs7_parse_x509_certificate(FuPkcs7 *self, gnutls_datum_t *data, GError **er
 
 	/* parse as a X.509 certificate */
 	blob = g_bytes_new(data->data, data->size);
-	if (!fu_firmware_parse_bytes(FU_FIRMWARE(crt), blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(crt),
+				     blob,
+				     0x0,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
+				     error))
 		return FALSE;
 	fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(crt));
 
@@ -57,7 +61,10 @@ fu_pkcs7_parse_x509_certificate(FuPkcs7 *self, gnutls_datum_t *data, GError **er
 #endif
 
 static gboolean
-fu_pkcs7_parse(FuFirmware *firmware, GInputStream *stream, FwupdInstallFlags flags, GError **error)
+fu_pkcs7_parse(FuFirmware *firmware,
+	       GInputStream *stream,
+	       FuFirmwareParseFlags flags,
+	       GError **error)
 {
 #ifdef HAVE_GNUTLS
 	FuPkcs7 *self = FU_PKCS7(firmware);

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -25,7 +25,7 @@ fu_sbatlevel_section_add_entry(FuFirmware *firmware,
 			       gsize offset,
 			       const gchar *entry_name,
 			       guint64 entry_idx,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	gsize streamsz = 0;
@@ -73,7 +73,7 @@ fu_sbatlevel_section_add_entry(FuFirmware *firmware,
 static gboolean
 fu_sbatlevel_section_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	g_autoptr(GByteArray) st = NULL;

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3437,13 +3437,15 @@ fu_firmware_raw_aligned_func(void)
 	g_autoptr(GBytes) blob = g_bytes_new_static("hello", 5);
 
 	/* no alignment */
-	ret = fu_firmware_parse_bytes(firmware1, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret =
+	    fu_firmware_parse_bytes(firmware1, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
 	/* invalid alignment */
 	fu_firmware_set_alignment(firmware2, FU_FIRMWARE_ALIGNMENT_4K);
-	ret = fu_firmware_parse_bytes(firmware2, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret =
+	    fu_firmware_parse_bytes(firmware2, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
 }
@@ -3555,7 +3557,7 @@ fu_firmware_ihex_offset_func(void)
 	ret = fu_firmware_parse_bytes(firmware_verify,
 				      data_bin,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -3687,7 +3689,7 @@ fu_firmware_srec_tokenization_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(data_srec);
 	stream = g_memory_input_stream_new_from_bytes(data_srec);
-	ret = fu_firmware_tokenize(firmware, stream, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_tokenize(firmware, stream, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3893,7 +3895,7 @@ fu_firmware_new_from_gtypes_func(void)
 	/* dfu -> FuDfuFirmware */
 	firmware1 = fu_firmware_new_from_gtypes(stream,
 						0x0,
-						FWUPD_INSTALL_FLAG_NONE,
+						FU_FIRMWARE_PARSE_FLAG_NONE,
 						&error,
 						FU_TYPE_SREC_FIRMWARE,
 						FU_TYPE_DFUSE_FIRMWARE,
@@ -3906,7 +3908,7 @@ fu_firmware_new_from_gtypes_func(void)
 	/* dfu -> FuFirmware */
 	firmware2 = fu_firmware_new_from_gtypes(stream,
 						0x0,
-						FWUPD_INSTALL_FLAG_NONE,
+						FU_FIRMWARE_PARSE_FLAG_NONE,
 						&error,
 						FU_TYPE_SREC_FIRMWARE,
 						FU_TYPE_FIRMWARE,
@@ -3918,7 +3920,7 @@ fu_firmware_new_from_gtypes_func(void)
 	/* dfu -> error */
 	firmware3 = fu_firmware_new_from_gtypes(stream,
 						0x0,
-						FWUPD_INSTALL_FLAG_NONE,
+						FU_FIRMWARE_PARSE_FLAG_NONE,
 						&error,
 						FU_TYPE_SREC_FIRMWARE,
 						G_TYPE_INVALID);
@@ -3957,7 +3959,7 @@ fu_firmware_csv_func(void)
 	g_assert_cmpstr(fu_csv_firmware_get_column_id(FU_CSV_FIRMWARE(firmware), 6), ==, NULL);
 
 	blob = g_bytes_new(data, strlen(data));
-	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_firmware_to_string(firmware);
@@ -3995,7 +3997,7 @@ fu_firmware_archive_func(void)
 
 	fn = g_test_build_filename(G_TEST_BUILT, "tests", "firmware.zip", NULL);
 	file = g_file_new_for_path(fn);
-	ret = fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	g_assert_cmpint(fu_archive_firmware_get_format(FU_ARCHIVE_FIRMWARE(firmware)),
@@ -4046,7 +4048,11 @@ fu_firmware_linear_func(void)
 	g_assert_cmpint(g_bytes_get_size(blob3), ==, 1024);
 
 	/* parse them back */
-	ret = fu_firmware_parse_bytes(firmware2, blob3, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware2,
+				      blob3,
+				      0x0,
+				      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
+				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_firmware_to_string(firmware2);
@@ -4168,7 +4174,8 @@ fu_firmware_oprom_func(void)
 	g_assert_cmpint(g_bytes_get_size(data_bin), ==, 1024);
 
 	/* re-parse to get the CPD image */
-	ret = fu_firmware_parse_bytes(firmware2, data_bin, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret =
+	    fu_firmware_parse_bytes(firmware2, data_bin, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	img1 = fu_firmware_get_image_by_id(firmware2, "cpd", &error);
@@ -5394,7 +5401,7 @@ fu_firmware_builder_round_trip_func(void)
 		ret = fu_firmware_parse_bytes(firmware3,
 					      blob,
 					      0x0,
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      &error);
 		if (!ret)
 			g_prefix_error(&error, "%s: ", map[i].xml_fn);
@@ -6357,7 +6364,7 @@ fu_plugin_efi_variable_authentication2_func(void)
 		return;
 	}
 	file = g_file_new_for_path(fn);
-	ret = fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	str = fu_firmware_to_string(firmware);
@@ -6494,7 +6501,7 @@ fu_efi_lz77_decompressor_func(void)
 	ret = fu_firmware_parse_bytes(lz77_decompressor_tiano,
 				      blob_tiano,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6517,7 +6524,7 @@ fu_efi_lz77_decompressor_func(void)
 	ret = fu_firmware_parse_bytes(lz77_decompressor_legacy,
 				      blob_tiano,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -333,7 +333,10 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 }
 
 static gboolean
-fu_smbios_parse(FuFirmware *firmware, GInputStream *stream, FwupdInstallFlags flags, GError **error)
+fu_smbios_parse(FuFirmware *firmware,
+		GInputStream *stream,
+		FuFirmwareParseFlags flags,
+		GError **error)
 {
 	FuSmbios *self = FU_SMBIOS(firmware);
 	g_autoptr(GBytes) fw = NULL;

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -160,7 +160,7 @@ fu_srec_firmware_record_get_type(void)
 
 typedef struct {
 	FuSrecFirmware *self;
-	FwupdInstallFlags flags;
+	FuFirmwareParseFlags flags;
 	gboolean got_eof;
 } FuSrecFirmwareTokenHelper;
 
@@ -231,7 +231,7 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 	}
 
 	/* checksum check */
-	if ((helper->flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((helper->flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 rec_csum = 0;
 		guint8 rec_csum_expected;
 		for (guint8 i = 0; i < rec_count; i++) {
@@ -373,7 +373,7 @@ fu_srec_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_srec_firmware_tokenize(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuSrecFirmware *self = FU_SREC_FIRMWARE(firmware);
@@ -397,7 +397,7 @@ fu_srec_firmware_tokenize(FuFirmware *firmware,
 static gboolean
 fu_srec_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuSrecFirmware *self = FU_SREC_FIRMWARE(firmware);

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -155,7 +155,7 @@ fu_usb_bos_descriptor_get_capability(FuUsbBosDescriptor *self)
 static gboolean
 fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuUsbBosDescriptor *self = FU_USB_BOS_DESCRIPTOR(firmware);

--- a/libfwupdplugin/fu-usb-config-descriptor.c
+++ b/libfwupdplugin/fu-usb-config-descriptor.c
@@ -114,7 +114,7 @@ fu_usb_config_descriptor_get_configuration_value(FuUsbConfigDescriptor *self)
 static gboolean
 fu_usb_config_descriptor_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	FuUsbConfigDescriptor *self = FU_USB_CONFIG_DESCRIPTOR(firmware);

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -14,7 +14,7 @@ G_DEFINE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU_TYPE_FIRMWARE)
 static gboolean
 fu_usb_descriptor_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	FuUsbDescriptor *self = FU_USB_DESCRIPTOR(firmware);

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -157,7 +157,7 @@ fu_usb_device_ds20_sort_by_platform_ver_cb(gconstpointer a, gconstpointer b)
 static gboolean
 fu_usb_device_ds20_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuUsbDeviceDs20 *self = FU_USB_DEVICE_DS20(firmware);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -874,7 +874,7 @@ fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, FuUsbBosDescriptor *bos, G
 		return FALSE;
 	ds20 = fu_firmware_new_from_gtypes(stream,
 					   0x0,
-					   FWUPD_INSTALL_FLAG_NONE,
+					   FU_FIRMWARE_PARSE_FLAG_NONE,
 					   error,
 					   FU_TYPE_USB_DEVICE_FW_DS20,
 					   FU_TYPE_USB_DEVICE_MS_DS20,
@@ -974,7 +974,7 @@ fu_usb_device_parse_bos_descriptor(FuUsbDevice *self, GInputStream *stream, GErr
 	if (!fu_firmware_parse_stream(firmware,
 				      stream,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE) ||
 		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA)) {
@@ -1856,7 +1856,7 @@ fu_usb_device_parse_descriptor(FuUsbDevice *self, GInputStream *stream, GError *
 			if (!fu_firmware_parse_stream(FU_FIRMWARE(cfg_descriptor),
 						      stream,
 						      offset,
-						      FWUPD_INSTALL_FLAG_NONE,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error))
 				return FALSE;
 			g_ptr_array_add(priv->cfg_descriptors, g_steal_pointer(&cfg_descriptor));
@@ -1865,7 +1865,7 @@ fu_usb_device_parse_descriptor(FuUsbDevice *self, GInputStream *stream, GError *
 			if (!fu_firmware_parse_stream(FU_FIRMWARE(iface),
 						      stream,
 						      offset,
-						      FWUPD_INSTALL_FLAG_NONE,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error))
 				return FALSE;
 			fu_usb_device_add_interface_internal(self, iface);
@@ -1875,7 +1875,7 @@ fu_usb_device_parse_descriptor(FuUsbDevice *self, GInputStream *stream, GError *
 			if (!fu_firmware_parse_stream(FU_FIRMWARE(ep),
 						      stream,
 						      offset,
-						      FWUPD_INSTALL_FLAG_NONE,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error))
 				return FALSE;
 			if (iface_last == NULL) {
@@ -1889,7 +1889,7 @@ fu_usb_device_parse_descriptor(FuUsbDevice *self, GInputStream *stream, GError *
 			if (!fu_firmware_parse_stream(FU_FIRMWARE(hid_descriptor),
 						      stream,
 						      offset,
-						      FWUPD_INSTALL_FLAG_NONE,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error))
 				return FALSE;
 			if (iface_last == NULL) {

--- a/libfwupdplugin/fu-usb-endpoint.c
+++ b/libfwupdplugin/fu-usb-endpoint.c
@@ -190,7 +190,7 @@ fu_usb_endpoint_get_direction(FuUsbEndpoint *self)
 static gboolean
 fu_usb_endpoint_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuUsbEndpoint *self = FU_USB_ENDPOINT(firmware);

--- a/libfwupdplugin/fu-usb-hid-descriptor.c
+++ b/libfwupdplugin/fu-usb-hid-descriptor.c
@@ -148,7 +148,7 @@ fu_usb_hid_descriptor_set_blob(FuUsbHidDescriptor *self, GBytes *blob)
 static gboolean
 fu_usb_hid_descriptor_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuUsbHidDescriptor *self = FU_USB_HID_DESCRIPTOR(firmware);

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -65,7 +65,7 @@ fu_usb_interface_parse_extra(FuUsbInterface *self, const guint8 *buf, gsize bufs
 		if (!fu_firmware_parse_bytes(FU_FIRMWARE(img),
 					     bytes,
 					     offset,
-					     FWUPD_INSTALL_FLAG_NONE,
+					     FU_FIRMWARE_PARSE_FLAG_NONE,
 					     error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
@@ -361,7 +361,7 @@ fu_usb_interface_add_endpoint(FuUsbInterface *self, FuUsbEndpoint *endpoint)
 static gboolean
 fu_usb_interface_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuUsbInterface *self = FU_USB_INTERFACE(firmware);

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -61,7 +61,7 @@ fu_uswid_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize off
 static gboolean
 fu_uswid_firmware_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	FuUswidFirmware *self = FU_USWID_FIRMWARE(firmware);
@@ -165,7 +165,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_bytes(firmware_coswid,
 					     fw2,
 					     0x0,
-					     flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					     error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(firmware, firmware_coswid, error))

--- a/libfwupdplugin/fu-x509-certificate.c
+++ b/libfwupdplugin/fu-x509-certificate.c
@@ -112,7 +112,7 @@ fu_x509_certificate_get_subject(FuX509Certificate *self)
 static gboolean
 fu_x509_certificate_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 #ifdef HAVE_GNUTLS

--- a/plugins/acpi-dmar/fu-acpi-dmar-plugin.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar-plugin.c
@@ -46,7 +46,7 @@ fu_acpi_dmar_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(dmar),
 				      stream,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error_local)) {
 		g_warning("failed to parse %s: %s", fn, error_local->message);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);

--- a/plugins/acpi-dmar/fu-acpi-dmar.c
+++ b/plugins/acpi-dmar/fu-acpi-dmar.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuAcpiDmar, fu_acpi_dmar, FU_TYPE_ACPI_TABLE)
 static gboolean
 fu_acpi_dmar_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiDmar *self = FU_ACPI_DMAR(firmware);
@@ -28,7 +28,7 @@ fu_acpi_dmar_parse(FuFirmware *firmware,
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_dmar_parent_class)
-		 ->parse(FU_FIRMWARE(self), stream, FWUPD_INSTALL_FLAG_NONE, error))
+		 ->parse(FU_FIRMWARE(self), stream, flags, error))
 		return FALSE;
 
 	/* check signature and read flags */

--- a/plugins/acpi-dmar/fu-self-test.c
+++ b/plugins/acpi-dmar/fu-self-test.c
@@ -28,7 +28,7 @@ fu_acpi_dmar_opt_in_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(dmar),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -55,7 +55,7 @@ fu_acpi_dmar_opt_out_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(dmar),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/acpi-ivrs/fu-acpi-ivrs-plugin.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs-plugin.c
@@ -47,7 +47,7 @@ fu_acpi_ivrs_plugin_add_security_attrs(FuPlugin *plugin, FuSecurityAttrs *attrs)
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(ivrs),
 				      stream,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error_local)) {
 		g_warning("failed to parse %s: %s", fn, error_local->message);
 		fwupd_security_attr_set_result(attr, FWUPD_SECURITY_ATTR_RESULT_NOT_VALID);

--- a/plugins/acpi-ivrs/fu-acpi-ivrs.c
+++ b/plugins/acpi-ivrs/fu-acpi-ivrs.c
@@ -22,7 +22,7 @@ G_DEFINE_TYPE(FuAcpiIvrs, fu_acpi_ivrs, FU_TYPE_ACPI_TABLE)
 static gboolean
 fu_acpi_ivrs_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiIvrs *self = FU_ACPI_IVRS(firmware);
@@ -30,7 +30,7 @@ fu_acpi_ivrs_parse(FuFirmware *firmware,
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_ivrs_parent_class)
-		 ->parse(FU_FIRMWARE(self), stream, FWUPD_INSTALL_FLAG_NONE, error))
+		 ->parse(FU_FIRMWARE(self), stream, flags, error))
 		return FALSE;
 
 	/* check signature and read flags */

--- a/plugins/acpi-ivrs/fu-self-test.c
+++ b/plugins/acpi-ivrs/fu-self-test.c
@@ -31,7 +31,7 @@ fu_acpi_ivrs_dma_remap_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(ivrs),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -72,7 +72,7 @@ fu_acpi_ivrs_no_dma_remap_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(ivrs),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -36,7 +36,7 @@ fu_acpi_phat_health_record_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuAcpiPhatHealthRecord *self = FU_ACPI_PHAT_HEALTH_RECORD(firmware);

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -42,7 +42,7 @@ fu_acpi_phat_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **er
 		g_propagate_error(error, g_steal_pointer(&error_local));
 		return FALSE;
 	}
-	if (!fu_firmware_parse_bytes(phat, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(phat, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, error))
 		return FALSE;
 	str = fu_acpi_phat_to_report_string(FU_ACPI_PHAT(phat));
 	fu_plugin_add_report_metadata(plugin, "PHAT", str);

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -32,7 +32,7 @@ fu_acpi_phat_version_element_export(FuFirmware *firmware,
 static gboolean
 fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 				   GInputStream *stream,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	FuAcpiPhatVersionElement *self = FU_ACPI_PHAT_VERSION_ELEMENT(firmware);

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -20,7 +20,7 @@ G_DEFINE_TYPE(FuAcpiPhatVersionRecord, fu_acpi_phat_version_record, FU_TYPE_FIRM
 static gboolean
 fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	gsize offset = 0;
@@ -44,7 +44,7 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(firmware_tmp,
 					      stream_tmp,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(firmware, firmware_tmp, error))

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -32,7 +32,7 @@ static gboolean
 fu_acpi_phat_record_parse(FuFirmware *firmware,
 			  GInputStream *stream,
 			  gsize *offset,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	guint16 record_length = 0;
@@ -98,7 +98,7 @@ fu_acpi_phat_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, 
 static gboolean
 fu_acpi_phat_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiPhat *self = FU_ACPI_PHAT(firmware);
@@ -142,7 +142,7 @@ fu_acpi_phat_parse(FuFirmware *firmware,
 	}
 
 	/* verify checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 checksum = 0;
 		g_autoptr(GInputStream) stream_tmp =
 		    fu_partial_input_stream_new(stream, 0, length, error);

--- a/plugins/acpi-phat/fu-self-test.c
+++ b/plugins/acpi-phat/fu-self-test.c
@@ -29,7 +29,7 @@ fu_acpi_phat_parse_func(void)
 	ret = fu_firmware_parse_bytes(phat,
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_FORCE | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      FWUPD_INSTALL_FLAG_FORCE | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -30,7 +30,7 @@ fu_algoltek_usb_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	g_autofree gchar *version = NULL;

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -453,7 +453,7 @@ static FuFirmware *
 fu_algoltek_usbcr_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_algoltek_usbcr_firmware_new();

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-firmware.c
@@ -30,7 +30,7 @@ fu_algoltek_usbcr_firmware_export(FuFirmware *firmware,
 static gboolean
 fu_algoltek_usbcr_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuAlgoltekUsbcrFirmware *self = FU_ALGOLTEK_USBCR_FIRMWARE(firmware);

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -271,7 +271,7 @@ fu_amd_gpu_atom_firmware_parse_config_filename(FuAmdGpuAtomFirmware *self,
 static gboolean
 fu_amd_gpu_atom_firmware_parse(FuFirmware *firmware,
 			       GInputStream *stream,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	FuAmdGpuAtomFirmware *self = FU_AMD_GPU_ATOM_FIRMWARE(firmware);

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -273,7 +273,7 @@ static FuFirmware *
 fu_amd_gpu_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
 				   FuProgress *progress,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	FuAmdGpuDevice *self = FU_AMDGPU_DEVICE(device);

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -133,7 +133,11 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 		ish = fu_struct_image_slot_header_parse_stream(stream, loc, error);
 		if (ish == NULL)
 			return FALSE;
-		if (!fu_firmware_parse_stream(ish_img, stream, loc, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_stream(ish_img,
+					      stream,
+					      loc,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      error))
 			return FALSE;
 		fu_firmware_set_addr(ish_img, loc);
 		fu_firmware_add_image(firmware, ish_img);
@@ -141,7 +145,11 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 		/* parse the csm image */
 		loc = fu_struct_image_slot_header_get_loc_csm(ish);
 		fu_firmware_set_addr(csm_img, loc);
-		if (!fu_firmware_parse_stream(csm_img, stream, loc, FWUPD_INSTALL_FLAG_NONE, error))
+		if (!fu_firmware_parse_stream(csm_img,
+					      stream,
+					      loc,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      error))
 			return FALSE;
 
 		loc = fu_struct_image_slot_header_get_loc(ish);
@@ -172,7 +180,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(l2_img,
 					      l2_stream,
 					      0x0,
-					      FWUPD_INSTALL_FLAG_NONE,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
 					      error))
 			return FALSE;
 		fu_firmware_add_image(ish_img, l2_img);
@@ -191,7 +199,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 static gboolean
 fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	FuAmdGpuPspFirmware *self = FU_AMD_GPU_PSP_FIRMWARE(firmware);

--- a/plugins/amd-kria/fu-amd-kria-device.c
+++ b/plugins/amd-kria/fu-amd-kria-device.c
@@ -175,7 +175,7 @@ fu_amd_kria_device_setup(FuDevice *device, GError **error)
 	/* parse the eeprom */
 	bytes = g_bytes_new(buf, bufsz);
 	firmware = fu_amd_kria_som_eeprom_new();
-	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 
 	/* build instance IDs from EEPROM data */

--- a/plugins/amd-kria/fu-amd-kria-image-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-image-firmware.c
@@ -25,7 +25,7 @@ G_DEFINE_TYPE(FuAmdKriaImageFirmware, fu_amd_kria_image_firmware, FU_TYPE_FIRMWA
 static gboolean
 fu_amd_kria_image_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	const gchar *buf;

--- a/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
@@ -24,7 +24,7 @@ G_DEFINE_TYPE(FuAmdKriaPersistentFirmware, fu_amd_kria_persistent_firmware, FU_T
 static gboolean
 fu_amd_kria_persistent_firmware_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuAmdKriaPersistentFirmware *self = FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware);

--- a/plugins/amd-kria/fu-amd-kria-plugin.c
+++ b/plugins/amd-kria/fu-amd-kria-plugin.c
@@ -43,7 +43,7 @@ fu_amd_kria_plugin_process_image(FuPlugin *plugin, FuDevice *dev, GError **error
 		return FALSE;
 	firmware = fu_amd_kria_image_firmware_new();
 
-	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 
 	fu_device_set_version(dev, fu_firmware_get_version(firmware));
@@ -64,7 +64,7 @@ fu_amd_kria_plugin_process_persistent(FuPlugin *plugin, FuDevice *dev, GError **
 		return FALSE;
 	firmware = fu_amd_kria_persistent_firmware_new();
 
-	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, bytes, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 
 	if (fu_amd_kria_persistent_firmware_booted_image_a(

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -29,7 +29,7 @@ G_DEFINE_TYPE(FuAmdKriaSomEeprom, fu_amd_kria_som_eeprom, FU_TYPE_FIRMWARE)
 static gboolean
 fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuAmdKriaSomEeprom *self = FU_AMD_KRIA_SOM_EEPROM(firmware);

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuAnalogixFirmware, fu_analogix_firmware, FU_TYPE_IHEX_FIRMWARE)
 static gboolean
 fu_analogix_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_CLASS(fu_analogix_firmware_parent_class);

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -33,7 +33,7 @@ fu_asus_hid_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 static gboolean
 fu_asus_hid_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuAsusHidFirmware *self = FU_ASUS_HID_FIRMWARE(firmware);

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -131,7 +131,7 @@ static FuFirmware *
 fu_aver_hid_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_aver_hid_firmware_new();

--- a/plugins/aver-hid/fu-aver-hid-firmware.c
+++ b/plugins/aver-hid/fu-aver-hid-firmware.c
@@ -33,7 +33,7 @@ fu_aver_hid_firmware_parse_archive_cb(FuArchive *self,
 static gboolean
 fu_aver_hid_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	g_autoptr(FuArchive) archive = NULL;

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -307,7 +307,7 @@ fu_bcm57xx_device_read_firmware(FuDevice *device, FuProgress *progress, GError *
 	fw = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, error))
 		return NULL;
 
 	/* remove images that will contain user-data */
@@ -324,7 +324,7 @@ static FuFirmware *
 fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
 				   FuProgress *progress,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	guint dict_cnt = 0;
@@ -345,7 +345,7 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* for full NVRAM image, verify if correct device */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 		guint16 vid = fu_bcm57xx_firmware_get_vendor(FU_BCM57XX_FIRMWARE(firmware_tmp));
 		guint16 did = fu_bcm57xx_firmware_get_model(FU_BCM57XX_FIRMWARE(firmware_tmp));
 		if (vid != 0x0 && did != 0x0 &&
@@ -368,7 +368,11 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 	fw_old = fu_bcm57xx_device_dump_firmware(device, progress, error);
 	if (fw_old == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(firmware, fw_old, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error)) {
+	if (!fu_firmware_parse_bytes(firmware,
+				     fw_old,
+				     0x0,
+				     FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
+				     error)) {
 		g_prefix_error(error, "failed to parse existing firmware: ");
 		return NULL;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-dict-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-dict-image.c
@@ -30,7 +30,7 @@ fu_bcm57xx_dict_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	g_autoptr(GInputStream) stream_nocrc = NULL;
@@ -45,7 +45,7 @@ fu_bcm57xx_dict_image_parse(FuFirmware *firmware,
 				    "dict image is too small");
 		return FALSE;
 	}
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_bcm57xx_verify_crc(stream, error))
 			return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -91,7 +91,7 @@ fu_bcm57xx_firmware_parse_info(FuBcm57xxFirmware *self, GInputStream *stream, GE
 		return NULL;
 
 	/* success */
-	if (!fu_firmware_parse_stream(img, stream, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_stream(img, stream, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 	fu_firmware_set_id(img, "info");
 	return g_steal_pointer(&img);
@@ -101,7 +101,7 @@ static FuFirmware *
 fu_bcm57xx_firmware_parse_stage1(FuBcm57xxFirmware *self,
 				 GInputStream *stream,
 				 guint32 *out_stage1_sz,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	gsize streamsz = 0;
@@ -152,7 +152,7 @@ fu_bcm57xx_firmware_parse_stage1(FuBcm57xxFirmware *self,
 	if (!fu_firmware_parse_stream(img,
 				      stream_tmp,
 				      0x0,
-				      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      error))
 		return NULL;
 
@@ -170,7 +170,7 @@ static FuFirmware *
 fu_bcm57xx_firmware_parse_stage2(FuBcm57xxFirmware *self,
 				 GInputStream *stream,
 				 guint32 stage1_sz,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	gsize streamsz = 0;
@@ -207,7 +207,7 @@ fu_bcm57xx_firmware_parse_stage2(FuBcm57xxFirmware *self,
 	if (!fu_firmware_parse_stream(img,
 				      stream_tmp,
 				      0x0,
-				      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      error))
 		return NULL;
 
@@ -221,7 +221,7 @@ static gboolean
 fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 			       GInputStream *stream,
 			       guint idx,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	gsize streamsz = 0;
@@ -292,7 +292,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 	if (!fu_firmware_parse_stream(img,
 				      stream_tmp,
 				      0x0,
-				      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      error))
 		return FALSE;
 
@@ -330,7 +330,7 @@ fu_bcm57xx_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuBcm57xxFirmware *self = FU_BCM57XX_FIRMWARE(firmware);

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -542,7 +542,7 @@ static FuFirmware *
 fu_bcm57xx_recovery_device_prepare_firmware(FuDevice *device,
 					    GInputStream *stream,
 					    FuProgress *progress,
-					    FwupdInstallFlags flags,
+					    FuFirmwareParseFlags flags,
 					    GError **error)
 {
 	g_autoptr(FuFirmware) firmware_bin = fu_firmware_new();

--- a/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage1-image.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuBcm57xxStage1Image, fu_bcm57xx_stage1_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	gsize streamsz = 0;
@@ -26,7 +26,7 @@ fu_bcm57xx_stage1_image_parse(FuFirmware *image,
 	g_autoptr(GInputStream) stream_nocrc = NULL;
 
 	/* verify CRC */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_bcm57xx_verify_crc(stream, error))
 			return FALSE;
 	}

--- a/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
+++ b/plugins/bcm57xx/fu-bcm57xx-stage2-image.c
@@ -18,12 +18,12 @@ G_DEFINE_TYPE(FuBcm57xxStage2Image, fu_bcm57xx_stage2_image, FU_TYPE_FIRMWARE)
 static gboolean
 fu_bcm57xx_stage2_image_parse(FuFirmware *image,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	gsize streamsz = 0;
 	g_autoptr(GInputStream) stream_nocrc = NULL;
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_bcm57xx_verify_crc(stream, error))
 			return FALSE;
 	}

--- a/plugins/bcm57xx/fu-self-test.c
+++ b/plugins/bcm57xx/fu-self-test.c
@@ -84,7 +84,8 @@ fu_bcm57xx_firmware_talos_func(void)
 	blob = fu_bytes_get_contents(fn, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(blob);
-	ret = fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret =
+	    fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	images = fu_firmware_get_images(firmware);

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -641,7 +641,7 @@ static FuFirmware *
 fu_bnr_dp_device_prepare_firmware(FuDevice *device,
 				  GInputStream *stream,
 				  FuProgress *progress,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	FuBnrDpDevice *self = FU_BNR_DP_DEVICE(device);

--- a/plugins/bnr-dp/fu-bnr-dp-firmware.c
+++ b/plugins/bnr-dp/fu-bnr-dp-firmware.c
@@ -270,7 +270,7 @@ fu_bnr_dp_firmware_payload_parse(FuBnrDpFirmware *self,
 static gboolean
 fu_bnr_dp_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuBnrDpFirmware *self = FU_BNR_DP_FIRMWARE(firmware);
@@ -490,7 +490,7 @@ fu_bnr_dp_firmware_check(FuBnrDpFirmware *self,
 			 const FuStructBnrDpFactoryData *st_factory_data,
 			 const FuStructBnrDpPayloadHeader *st_active_header,
 			 const FuStructBnrDpPayloadHeader *st_fw_header,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	guint64 active_version = 0;

--- a/plugins/bnr-dp/fu-bnr-dp-firmware.h
+++ b/plugins/bnr-dp/fu-bnr-dp-firmware.h
@@ -39,5 +39,5 @@ fu_bnr_dp_firmware_check(FuBnrDpFirmware *self,
 			 const FuStructBnrDpFactoryData *st_factory_data,
 			 const FuStructBnrDpPayloadHeader *st_active_header,
 			 const FuStructBnrDpPayloadHeader *st_fw_header,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error) G_GNUC_NON_NULL(1, 2, 3, 4);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -642,7 +642,7 @@ static FuFirmware *
 fu_ccgx_dmc_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_ccgx_dmc_firmware_new();

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -90,7 +90,7 @@ fu_ccgx_dmc_firmware_parse_segment(FuFirmware *firmware,
 				   GInputStream *stream,
 				   FuCcgxDmcFirmwareRecord *img_rcd,
 				   gsize *seg_off,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	FuCcgxDmcFirmware *self = FU_CCGX_DMC_FIRMWARE(firmware);
@@ -157,7 +157,7 @@ fu_ccgx_dmc_firmware_parse_segment(FuFirmware *firmware,
 	}
 
 	/* check checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 csumbuf[DMC_HASH_SIZE] = {0x0};
 		gsize csumbufsz = sizeof(csumbuf);
 		g_checksum_get_digest(csum, csumbuf, &csumbufsz);
@@ -178,7 +178,7 @@ static gboolean
 fu_ccgx_dmc_firmware_parse_image(FuFirmware *firmware,
 				 guint8 image_count,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuCcgxDmcFirmware *self = FU_CCGX_DMC_FIRMWARE(firmware);
@@ -259,7 +259,7 @@ fu_ccgx_dmc_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuCcgxDmcFirmware *self = FU_CCGX_DMC_FIRMWARE(firmware);

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -80,7 +80,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuCcgxFirmwareRecord, fu_ccgx_firmware_record_free
 static gboolean
 fu_ccgx_firmware_add_record(FuCcgxFirmware *self,
 			    GString *token,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	guint16 buflen;
@@ -125,7 +125,7 @@ fu_ccgx_firmware_add_record(FuCcgxFirmware *self,
 	rcd->data = g_bytes_new(data->data, data->len);
 
 	/* verify 2s complement checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint8 checksum_file;
 		if (!fu_firmware_strparse_uint8_safe(token->str,
 						     token->len,
@@ -161,7 +161,7 @@ fu_ccgx_firmware_add_record(FuCcgxFirmware *self,
 }
 
 static gboolean
-fu_ccgx_firmware_parse_md_block(FuCcgxFirmware *self, FwupdInstallFlags flags, GError **error)
+fu_ccgx_firmware_parse_md_block(FuCcgxFirmware *self, FuFirmwareParseFlags flags, GError **error)
 {
 	FuCcgxFirmwareRecord *rcd;
 	gsize bufsz = 0;
@@ -232,7 +232,7 @@ fu_ccgx_firmware_parse_md_block(FuCcgxFirmware *self, FwupdInstallFlags flags, G
 		return FALSE;
 	}
 	checksum_calc = 1 + ~checksum_calc;
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (fu_struct_ccgx_metadata_hdr_get_fw_checksum(st_metadata) != checksum_calc) {
 			g_set_error(error,
 				    FWUPD_ERROR,
@@ -281,7 +281,7 @@ fu_ccgx_firmware_parse_md_block(FuCcgxFirmware *self, FwupdInstallFlags flags, G
 
 typedef struct {
 	FuCcgxFirmware *self;
-	FwupdInstallFlags flags;
+	FuFirmwareParseFlags flags;
 } FuCcgxFirmwareTokenHelper;
 
 static gboolean
@@ -345,7 +345,7 @@ fu_ccgx_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data
 static gboolean
 fu_ccgx_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
-		       FwupdInstallFlags flags,
+		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuCcgxFirmware *self = FU_CCGX_FIRMWARE(firmware);

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1093,7 +1093,7 @@ static FuFirmware *
 fu_ccgx_hpi_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuCcgxHpiDevice *self = FU_CCGX_HPI_DEVICE(device);
@@ -1117,7 +1117,7 @@ fu_ccgx_hpi_device_prepare_firmware(FuDevice *device,
 			    fw_silicon_id);
 		return NULL;
 	}
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 		fw_app_type = fu_ccgx_firmware_get_app_type(FU_CCGX_FIRMWARE(firmware));
 		if (fw_app_type != self->fw_app_type) {
 			g_set_error(error,

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -200,7 +200,7 @@ static FuFirmware *
 fu_ccgx_pure_hid_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuCcgxPureHidDevice *self = FU_CCGX_PURE_HID_DEVICE(device);

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -84,7 +84,7 @@ static FuFirmware *
 fu_cfu_module_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
 			       FuProgress *progress,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_firmware_new();

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -877,7 +877,7 @@ static FuFirmware *
 fu_cros_ec_usb_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
 				       FuProgress *progress,
-				       FwupdInstallFlags flags,
+				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
 	FuCrosEcUsbDevice *self = FU_CROS_EC_USB_DEVICE(device);

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub-firmware.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub-firmware.c
@@ -63,7 +63,7 @@ fu_dell_kestrel_rtshub_firmware_set_offset(GInputStream *stream,
 static gboolean
 fu_dell_kestrel_rtshub_firmware_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuDellKestrelRtshubFirmware *self = FU_DELL_KESTREL_RTSHUB_FIRMWARE(firmware);

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1388,7 +1388,7 @@ static FuFirmware *
 fu_dfu_device_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
 			       FuProgress *progress,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	return fu_firmware_new_from_gtypes(stream,
@@ -1415,7 +1415,7 @@ fu_dfu_device_write_firmware(FuDevice *device,
 	/* open it */
 	if (!fu_dfu_device_refresh_and_clear(self, error))
 		return FALSE;
-	if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) {
+	if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) {
 		transfer_flags |= DFU_TARGET_TRANSFER_FLAG_WILDCARD_VID;
 		transfer_flags |= DFU_TARGET_TRANSFER_FLAG_WILDCARD_PID;
 	}

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuEbitdoFirmware, fu_ebitdo_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_ebitdo_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	guint32 payload_len;

--- a/plugins/elan-kbd/fu-elan-kbd-firmware.c
+++ b/plugins/elan-kbd/fu-elan-kbd-firmware.c
@@ -28,7 +28,7 @@ fu_elan_kbd_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elan_kbd_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	g_autoptr(FuFirmware) firmware_app = fu_firmware_new();

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -50,7 +50,7 @@ fu_elanfp_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elanfp_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuElanfpFirmware *self = FU_ELANFP_FIRMWARE(firmware);
@@ -137,7 +137,7 @@ fu_elanfp_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      stream_tmp,
 					      0x0,
-					      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(firmware, img, error))

--- a/plugins/elantp/fu-elantp-firmware.c
+++ b/plugins/elantp/fu-elantp-firmware.c
@@ -111,7 +111,7 @@ fu_elantp_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elantp_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuElantpFirmware *self = FU_ELANTP_FIRMWARE(firmware);

--- a/plugins/elantp/fu-elantp-haptic-firmware.c
+++ b/plugins/elantp/fu-elantp-haptic-firmware.c
@@ -45,7 +45,7 @@ fu_elantp_haptic_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_elantp_haptic_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuElantpHapticFirmware *self = FU_ELANTP_HAPTIC_FIRMWARE(firmware);

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -441,7 +441,7 @@ static FuFirmware *
 fu_elantp_hid_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuElantpHidDevice *self = FU_ELANTP_HID_DEVICE(device);

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -609,7 +609,7 @@ static FuFirmware *
 fu_elantp_hid_haptic_device_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
 					     FuProgress *progress,
-					     FwupdInstallFlags flags,
+					     FuFirmwareParseFlags flags,
 					     GError **error)
 {
 	FuElantpHidHapticDevice *self = FU_ELANTP_HID_HAPTIC_DEVICE(device);

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -383,7 +383,7 @@ static FuFirmware *
 fu_elantp_i2c_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuElantpI2cDevice *self = FU_ELANTP_I2C_DEVICE(device);

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -333,7 +333,7 @@ static FuFirmware *
 fu_emmc_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
 				FuProgress *progress,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuEmmcDevice *self = FU_EMMC_DEVICE(device);

--- a/plugins/ep963x/fu-ep963x-firmware.c
+++ b/plugins/ep963x/fu-ep963x-firmware.c
@@ -30,7 +30,7 @@ fu_ep963x_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ep963x_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	gsize streamsz = 0;

--- a/plugins/focalfp/fu-focalfp-firmware.c
+++ b/plugins/focalfp/fu-focalfp-firmware.c
@@ -55,7 +55,7 @@ fu_focalfp_firmware_compute_checksum_cb(const guint8 *buf,
 static gboolean
 fu_focalfp_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuFocalfpFirmware *self = FU_FOCALFP_FIRMWARE(firmware);

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -54,7 +54,7 @@ static FuFirmware *
 fu_fpc_device_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
 			       FuProgress *progress,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	return fu_firmware_new_from_gtypes(stream,

--- a/plugins/fpc/fu-fpc-ff2-firmware.c
+++ b/plugins/fpc/fu-fpc-ff2-firmware.c
@@ -37,7 +37,7 @@ fu_fpc_ff2_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_fpc_ff2_firmware_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuFpcFf2Firmware *self = FU_FPC_FF2_FIRMWARE(firmware);

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -190,7 +190,7 @@ static FuFirmware *
 fu_fresco_pd_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
 				     FuProgress *progress,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuFrescoPdDevice *self = FU_FRESCO_PD_DEVICE(device);

--- a/plugins/fresco-pd/fu-fresco-pd-firmware.c
+++ b/plugins/fresco-pd/fu-fresco-pd-firmware.c
@@ -33,7 +33,7 @@ fu_fresco_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, 
 static gboolean
 fu_fresco_pd_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuFrescoPdFirmware *self = FU_FRESCO_PD_FIRMWARE(firmware);

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -586,7 +586,7 @@ fu_genesys_gl32xx_device_read_firmware(FuDevice *device, FuProgress *progress, G
 	fw = fu_genesys_gl32xx_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 
 	/* success */
@@ -597,7 +597,7 @@ static FuFirmware *
 fu_genesys_gl32xx_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_genesys_gl32xx_firmware_new();

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-firmware.c
@@ -22,7 +22,7 @@ G_DEFINE_TYPE(FuGenesysGl32xxFirmware, fu_genesys_gl32xx_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	guint8 ver[4] = {0};
@@ -41,7 +41,7 @@ fu_genesys_gl32xx_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_version(firmware, version);
 
 	/* verify checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		gsize streamsz = 0;
 		guint8 chksum_actual = 0;
 		guint8 chksum_expected = 0;

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1659,7 +1659,7 @@ static FuFirmware *
 fu_genesys_scaler_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuGenesysScalerDevice *self = FU_GENESYS_SCALER_DEVICE(device);

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -19,7 +19,7 @@ G_DEFINE_TYPE(FuGenesysScalerFirmware, fu_genesys_scaler_firmware, FU_TYPE_FIRMW
 static gboolean
 fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuGenesysScalerFirmware *self = FU_GENESYS_SCALER_FIRMWARE(firmware);

--- a/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-codesign-firmware.c
@@ -50,7 +50,7 @@ fu_genesys_usbhub_codesign_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_codesign_firmware_parse(FuFirmware *firmware,
 					  GInputStream *stream,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuGenesysUsbhubCodesignFirmware *self = FU_GENESYS_USBHUB_CODESIGN_FIRMWARE(firmware);

--- a/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-dev-firmware.c
@@ -29,7 +29,7 @@ fu_genesys_usbhub_dev_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	gsize code_size = 0;
@@ -51,7 +51,7 @@ fu_genesys_usbhub_dev_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 
 	/* calculate checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_genesys_usbhub_firmware_verify_checksum(stream_trunc, error)) {
 			g_prefix_error(error, "not valid for dev: ");
 			return FALSE;

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -2148,7 +2148,7 @@ static FuFirmware *
 fu_genesys_usbhub_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -213,7 +213,7 @@ fu_genesys_usbhub_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuGenesysUsbhubFirmware *self = FU_GENESYS_USBHUB_FIRMWARE(firmware);
@@ -295,7 +295,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 
 	/* calculate checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_genesys_usbhub_firmware_verify_checksum(stream_trunc, error))
 			return FALSE;
 	}
@@ -312,7 +312,7 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) firmware_sub = NULL;
 		firmware_sub = fu_firmware_new_from_gtypes(stream,
 							   offset,
-							   flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+							   flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 							   error,
 							   FU_TYPE_GENESYS_USBHUB_DEV_FIRMWARE,
 							   FU_TYPE_GENESYS_USBHUB_PD_FIRMWARE,

--- a/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-pd-firmware.c
@@ -29,7 +29,7 @@ fu_genesys_usbhub_pd_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	gsize code_size = 0;
@@ -51,7 +51,7 @@ fu_genesys_usbhub_pd_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 
 	/* calculate checksum */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		if (!fu_genesys_usbhub_firmware_verify_checksum(stream_trunc, error)) {
 			g_prefix_error(error, "not valid for pd: ");
 			return FALSE;

--- a/plugins/goodix-tp/fu-goodixtp-brlb-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-device.c
@@ -394,7 +394,7 @@ static FuFirmware *
 fu_goodixtp_brlb_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuGoodixtpBrlbDevice *self = FU_GOODIXTP_BRLB_DEVICE(device);

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-device.c
@@ -441,7 +441,7 @@ static FuFirmware *
 fu_goodixtp_gtx8_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuGoodixtpGtx8Device *self = FU_GOODIXTP_GTX8_DEVICE(device);

--- a/plugins/hailuck/fu-hailuck-kbd-firmware.c
+++ b/plugins/hailuck/fu-hailuck-kbd-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuHailuckKbdFirmware, fu_hailuck_kbd_firmware, FU_TYPE_IHEX_FIRMWA
 static gboolean
 fu_hailuck_kbd_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	GPtrArray *records = fu_ihex_firmware_get_records(FU_IHEX_FIRMWARE(firmware));

--- a/plugins/intel-cvs/fu-intel-cvs-device.c
+++ b/plugins/intel-cvs/fu-intel-cvs-device.c
@@ -100,7 +100,7 @@ static FuFirmware *
 fu_intel_cvs_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
 				     FuProgress *progress,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuIntelCvsDevice *self = FU_INTEL_CVS_DEVICE(device);

--- a/plugins/intel-cvs/fu-intel-cvs-firmware.c
+++ b/plugins/intel-cvs/fu-intel-cvs-firmware.c
@@ -39,7 +39,7 @@ fu_intel_cvs_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_intel_cvs_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuIntelCvsFirmware *self = FU_INTEL_CVS_FIRMWARE(firmware);

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -83,7 +83,7 @@ static FuFirmware *
 fu_igsc_aux_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuIgscAuxDevice *self = FU_IGSC_AUX_DEVICE(device);

--- a/plugins/intel-gsc/fu-igsc-aux-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-aux-firmware.c
@@ -192,7 +192,7 @@ fu_igsc_aux_firmware_parse_extension(FuIgscAuxFirmware *self, FuFirmware *fw, GE
 static gboolean
 fu_igsc_aux_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuIgscAuxFirmware *self = FU_IGSC_AUX_FIRMWARE(firmware);

--- a/plugins/intel-gsc/fu-igsc-code-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-code-firmware.c
@@ -54,7 +54,7 @@ fu_igsc_code_firmware_parse_imgi(FuIgscCodeFirmware *self, GInputStream *stream,
 static gboolean
 fu_igsc_code_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuIgscCodeFirmware *self = FU_IGSC_CODE_FIRMWARE(firmware);

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -497,7 +497,7 @@ static FuFirmware *
 fu_igsc_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
 				FuProgress *progress,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuIgscDevice *self = FU_IGSC_DEVICE(device);

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -105,7 +105,7 @@ static FuFirmware *
 fu_igsc_oprom_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuIgscOpromDevice *self = FU_IGSC_OPROM_DEVICE(device);

--- a/plugins/intel-gsc/fu-igsc-oprom-firmware.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-firmware.c
@@ -145,7 +145,7 @@ fu_igsc_oprom_firmware_parse_extension(FuIgscOpromFirmware *self, FuFirmware *fw
 static gboolean
 fu_igsc_oprom_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuIgscOpromFirmware *self = FU_IGSC_OPROM_FIRMWARE(firmware);

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -437,7 +437,7 @@ static FuFirmware *
 fu_intel_usb4_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuIntelUsb4Device *self = FU_INTEL_USB4_DEVICE(device);
@@ -453,7 +453,7 @@ fu_intel_usb4_device_prepare_firmware(FuDevice *device,
 	fw_vendor_id = fu_intel_thunderbolt_nvm_get_vendor_id(FU_INTEL_THUNDERBOLT_NVM(firmware));
 	fw_model_id = fu_intel_thunderbolt_nvm_get_model_id(FU_INTEL_THUNDERBOLT_NVM(firmware));
 	if (self->nvm_vendor_id != fw_vendor_id || self->nvm_model_id != fw_model_id) {
-		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+		if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -538,7 +538,7 @@ fu_intel_usb4_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 	}
 	blob = g_bytes_new(buf, sizeof(buf));
-	if (!fu_firmware_parse_bytes(fw, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_bytes(fw, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error)) {
 		g_prefix_error(error, "NVM parse error: ");
 		return FALSE;
 	}

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -572,7 +572,7 @@ static FuFirmware *
 fu_jabra_file_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuJabraFileDevice *self = FU_JABRA_FILE_DEVICE(device);

--- a/plugins/jabra-file/fu-jabra-file-firmware.c
+++ b/plugins/jabra-file/fu-jabra-file-firmware.c
@@ -71,7 +71,7 @@ fu_jabra_file_firmware_parse_info(FuJabraFileFirmware *self, XbSilo *silo, GErro
 static gboolean
 fu_jabra_file_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuJabraFileFirmware *self = FU_JABRA_FILE_FIRMWARE(firmware);

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -814,7 +814,7 @@ static FuFirmware *
 fu_jabra_gnp_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
 				     FuProgress *progress,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuJabraGnpDevice *self = FU_JABRA_GNP_DEVICE(device);

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -104,7 +104,7 @@ fu_jabra_gnp_firmware_parse_info(FuJabraGnpFirmware *self, XbSilo *silo, GError 
 static gboolean
 fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuJabraGnpFirmware *self = FU_JABRA_GNP_FIRMWARE(firmware);

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -222,7 +222,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 static gboolean
 fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	FuKineticDpPumaFirmware *self = FU_KINETIC_DP_PUMA_FIRMWARE(firmware);

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -187,7 +187,7 @@ fu_kinetic_dp_secure_firmware_parse_app_fw(FuKineticDpSecureFirmware *self,
 static gboolean
 fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuKineticDpSecureFirmware *self = FU_KINETIC_DP_SECURE_FIRMWARE(firmware);

--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -142,7 +142,7 @@ static FuFirmware *
 fu_legion_hid2_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
 				       FuProgress *progress,
-				       FwupdInstallFlags flags,
+				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
 	guint32 version;

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -38,7 +38,7 @@ fu_legion_hid2_firmware_get_version(FuFirmware *firmware)
 static gboolean
 fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	FuLegionHid2Firmware *self = FU_LEGION_HID2_FIRMWARE(firmware);

--- a/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
@@ -122,7 +122,7 @@ fu_logitech_tap_touch_firmware_calculate_basic_cb(const guint8 *buf,
 static gboolean
 fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuLogitechTapTouchFirmware *self = FU_LOGITECH_TAP_TOUCH_FIRMWARE(firmware);

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -871,7 +871,7 @@ static FuFirmware *
 fu_mediatek_scaler_device_prepare_firmware(FuDevice *device,
 					   GInputStream *stream,
 					   FuProgress *progress,
-					   FwupdInstallFlags flags,
+					   FuFirmwareParseFlags flags,
 					   GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_mediatek_scaler_firmware_new();

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-firmware.c
@@ -25,7 +25,7 @@ G_DEFINE_TYPE(FuMediatekScalerFirmware, fu_mediatek_scaler_firmware, FU_TYPE_FIR
 static gboolean
 fu_mediatek_scaler_firmware_parse(FuFirmware *firmware,
 				  GInputStream *stream,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	guint32 ver_tmp = 0x0;

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -70,7 +70,7 @@ fu_mtd_device_read_firmware(FuDevice *device, FuProgress *progress, GError **err
 	if (!fu_firmware_parse_stream(firmware,
 				      stream_partial,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      error)) {
 		g_prefix_error(error, "failed to parse image: ");
 		return NULL;

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -215,7 +215,7 @@ fu_nordic_hid_archive_parse_file_get_flash_area_id(JsonObject *obj,
 static gboolean
 fu_nordic_hid_archive_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	JsonNode *json_root_node;
@@ -340,7 +340,7 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_bytes(image,
 					     blob,
 					     0x0,
-					     flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					     error))
 			return FALSE;
 

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-b0.c
@@ -110,7 +110,7 @@ fu_nordic_hid_firmware_b0_read_fwinfo(FuFirmware *firmware, GInputStream *stream
 static gboolean
 fu_nordic_hid_firmware_b0_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_b0_parent_class)

--- a/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware-mcuboot.c
@@ -124,7 +124,7 @@ fu_nordic_hid_firmware_mcuboot_validate(FuFirmware *firmware, GInputStream *stre
 static gboolean
 fu_nordic_hid_firmware_mcuboot_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	if (!FU_FIRMWARE_CLASS(fu_nordic_hid_firmware_mcuboot_parent_class)

--- a/plugins/nordic-hid/fu-nordic-hid-firmware.c
+++ b/plugins/nordic-hid/fu-nordic-hid-firmware.c
@@ -41,7 +41,7 @@ fu_nordic_hid_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kin
 static gboolean
 fu_nordic_hid_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuNordicHidFirmware *self = FU_NORDIC_HID_FIRMWARE(firmware);

--- a/plugins/parade-usbhub/fu-parade-usbhub-device.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-device.c
@@ -1138,7 +1138,7 @@ static FuFirmware *
 fu_parade_usbhub_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_parade_usbhub_firmware_new();

--- a/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-firmware.c
@@ -28,7 +28,7 @@ fu_parade_usbhub_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_parade_usbhub_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	gsize streamsz = 0;

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -81,7 +81,7 @@ static FuFirmware *
 fu_pxi_ble_device_prepare_firmware(FuDevice *device,
 				   GInputStream *stream,
 				   FuProgress *progress,
-				   FwupdInstallFlags flags,
+				   FuFirmwareParseFlags flags,
 				   GError **error)
 {
 	FuPxiBleDevice *self = FU_PXI_BLE_DEVICE(device);
@@ -109,7 +109,7 @@ fu_pxi_ble_device_prepare_firmware(FuDevice *device,
 
 		/* check is compatible with hardware */
 		model_name = fu_pxi_firmware_get_model_name(FU_PXI_FIRMWARE(firmware));
-		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+		if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 			if (self->model_name == NULL || model_name == NULL) {
 				g_set_error_literal(error,
 						    FWUPD_ERROR,
@@ -289,7 +289,11 @@ fu_pxi_ble_device_check_support_report_id(FuPxiBleDevice *self, GError **error)
 
 	/* parse the descriptor, but use the defaults if it fails */
 	fw = g_bytes_new(rpt_desc.value, rpt_desc.size);
-	if (!fu_firmware_parse_bytes(descriptor, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, &error_local)) {
+	if (!fu_firmware_parse_bytes(descriptor,
+				     fw,
+				     0x0,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
+				     &error_local)) {
 		g_debug("failed to parse descriptor: %s", error_local->message);
 		return TRUE;
 	}

--- a/plugins/pixart-rf/fu-pxi-firmware.c
+++ b/plugins/pixart-rf/fu-pxi-firmware.c
@@ -96,7 +96,7 @@ fu_pxi_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_pxi_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuPxiFirmware *self = FU_PXI_FIRMWARE(firmware);

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -30,7 +30,7 @@ static FuFirmware *
 fu_pxi_receiver_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
 					FuProgress *progress,
-					FwupdInstallFlags flags,
+					FuFirmwareParseFlags flags,
 					GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_pxi_firmware_new();

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -54,7 +54,7 @@ static FuFirmware *
 fu_pxi_wireless_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
 					FuProgress *progress,
-					FwupdInstallFlags flags,
+					FuFirmwareParseFlags flags,
 					GError **error)
 {
 	FuPxiReceiverDevice *parent;

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -39,7 +39,7 @@ fu_pxi_firmware_xml_func(void)
 	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
 
 	/* ensure we can parse */
-	ret = fu_firmware_parse_bytes(firmware3, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, &error);
+	ret = fu_firmware_parse_bytes(firmware3, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -609,7 +609,7 @@ static FuFirmware *
 fu_qc_s5gen2_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
 				     FuProgress *progress,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuQcS5gen2Device *self = FU_QC_S5GEN2_DEVICE(device);

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
@@ -54,7 +54,7 @@ fu_qc_s5gen2_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuQcS5gen2Firmware *self = FU_QC_S5GEN2_FIRMWARE(firmware);

--- a/plugins/qsi-dock/fu-qsi-dock-child-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-child-device.c
@@ -34,7 +34,7 @@ static FuFirmware *
 fu_qsi_dock_child_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -250,7 +250,7 @@ fu_redfish_plugin_discover_smbios_table(FuPlugin *plugin, GError **error)
 		if (!fu_firmware_parse_bytes(FU_FIRMWARE(smbios),
 					     type42_blob,
 					     0x0,
-					     FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					     error)) {
 			g_prefix_error(error, "failed to parse SMBIOS entry type 42: ");
 			return FALSE;

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -267,7 +267,7 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
 static gboolean
 fu_redfish_smbios_parse(FuFirmware *firmware,
 			GInputStream *stream,
-			FwupdInstallFlags flags,
+			FuFirmwareParseFlags flags,
 			GError **error)
 {
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -489,7 +489,7 @@ fu_test_redfish_hpe_update_func(gconstpointer user_data)
 					      dev,
 					      stream_fw,
 					      fu_progress_get_child(progress),
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -528,7 +528,7 @@ fu_test_redfish_update_func(gconstpointer user_data)
 					      dev,
 					      firmware,
 					      fu_progress_get_child(progress),
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -540,7 +540,7 @@ fu_test_redfish_update_func(gconstpointer user_data)
 					      dev,
 					      firmware,
 					      fu_progress_get_child(progress),
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_WRITE);
 	g_assert_false(ret);
@@ -581,7 +581,7 @@ fu_test_redfish_smc_update_func(gconstpointer user_data)
 					      dev,
 					      firmware1,
 					      fu_progress_get_child(progress),
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -594,7 +594,7 @@ fu_test_redfish_smc_update_func(gconstpointer user_data)
 					      dev,
 					      firmware2,
 					      fu_progress_get_child(progress),
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FWUPD_INSTALL_FLAG_NONE,
 					      &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_ALREADY_PENDING);

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -512,7 +512,7 @@ static FuFirmware *
 fu_rts54hub_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	guint8 tmp = 0;

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -180,7 +180,7 @@ static FuFirmware *
 fu_scsi_device_prepare_firmware(FuDevice *device,
 				GInputStream *stream,
 				FuProgress *progress,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_firmware_new();

--- a/plugins/steelseries/fu-steelseries-firmware.c
+++ b/plugins/steelseries/fu-steelseries-firmware.c
@@ -18,7 +18,7 @@ G_DEFINE_TYPE(FuSteelseriesFirmware, fu_steelseries_firmware, FU_TYPE_FIRMWARE)
 static gboolean
 fu_steelseries_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	FuSteelseriesFirmware *self = FU_STEELSERIES_FIRMWARE(firmware);
@@ -52,7 +52,7 @@ fu_steelseries_firmware_parse(FuFirmware *firmware,
 					   error))
 		return FALSE;
 	if (checksum_tmp != checksum) {
-		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+		if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -639,7 +639,7 @@ fu_steelseries_fizz_read_firmware_fs(FuSteelseriesFizz *self,
 
 	fu_dump_raw(G_LOG_DOMAIN, "Firmware", buf, size);
 	blob = g_bytes_new_take(g_steal_pointer(&buf), size);
-	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, error))
 		return NULL;
 
 	/* success */

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -802,7 +802,9 @@ fu_steelseries_sonic_write_firmware(FuDevice *device,
 }
 
 static gboolean
-fu_steelseries_sonic_parse_firmware(FuFirmware *firmware, FwupdInstallFlags flags, GError **error)
+fu_steelseries_sonic_parse_firmware(FuFirmware *firmware,
+				    FuFirmwareParseFlags flags,
+				    GError **error)
 {
 	guint32 checksum_tmp;
 	guint32 checksum;
@@ -824,7 +826,7 @@ fu_steelseries_sonic_parse_firmware(FuFirmware *firmware, FwupdInstallFlags flag
 				g_bytes_get_size(blob) - sizeof(checksum_tmp));
 	checksum_tmp = ~checksum_tmp;
 	if (checksum_tmp != checksum) {
-		if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+		if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
@@ -849,7 +851,7 @@ static FuFirmware *
 fu_steelseries_sonic_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	g_autoptr(FuFirmware) firmware_nordic = NULL;

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -503,7 +503,7 @@ static FuFirmware *
 fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuSynapticsCapeDevice *self = FU_SYNAPTICS_CAPE_DEVICE(device);
@@ -535,7 +535,7 @@ fu_synaptics_cape_device_prepare_firmware(FuDevice *device,
 		return NULL;
 
 	/* verify if correct device */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 		const guint16 vid =
 		    fu_synaptics_cape_firmware_get_vid(FU_SYNAPTICS_CAPE_FIRMWARE(firmware));
 		const guint16 pid =

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -22,7 +22,7 @@ G_DEFINE_TYPE(FuSynapticsCapeHidFirmware,
 static gboolean
 fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 				     GInputStream *stream,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuSynapticsCapeHidFirmware *self = FU_SYNAPTICS_CAPE_HID_FIRMWARE(firmware);

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -22,7 +22,7 @@ G_DEFINE_TYPE(FuSynapticsCapeSnglFirmware,
 static gboolean
 fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 				      GInputStream *stream,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuSynapticsCapeSnglFirmware *self = FU_SYNAPTICS_CAPE_SNGL_FIRMWARE(firmware);
@@ -62,7 +62,7 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* check CRC */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 crc_calc = 0xFFFFFFFF;
 		g_autoptr(GInputStream) stream_tmp = NULL;
 

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -609,7 +609,7 @@ static FuFirmware *
 fu_synaptics_cxaudio_device_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
 					     FuProgress *progress,
-					     FwupdInstallFlags flags,
+					     FuFirmwareParseFlags flags,
 					     GError **error)
 {
 	FuSynapticsCxaudioDevice *self = FU_SYNAPTICS_CXAUDIO_DEVICE(device);

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -154,7 +154,7 @@ fu_synaptics_cxaudio_firmware_avoid_badblocks(GPtrArray *badblocks, GPtrArray *r
 static gboolean
 fu_synaptics_cxaudio_firmware_parse(FuFirmware *firmware,
 				    GInputStream *stream,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuSynapticsCxaudioFirmware *self = FU_SYNAPTICS_CXAUDIO_FIRMWARE(firmware);

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1372,7 +1372,7 @@ static FuFirmware *
 fu_synaptics_mst_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuSynapticsMstDevice *self = FU_SYNAPTICS_MST_DEVICE(device);
@@ -1384,7 +1384,7 @@ fu_synaptics_mst_device_prepare_firmware(FuDevice *device,
 	/* check firmware and board ID match */
 	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
 		return NULL;
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0 &&
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0 &&
 	    !fu_device_has_private_flag(device, FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID)) {
 		guint16 board_id =
 		    fu_synaptics_mst_firmware_get_board_id(FU_SYNAPTICS_MST_FIRMWARE(firmware));

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -78,7 +78,7 @@ fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self,
 static gboolean
 fu_synaptics_mst_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuSynapticsMstFirmware *self = FU_SYNAPTICS_MST_FIRMWARE(firmware);

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -39,7 +39,7 @@ fu_test_synaprom_firmware_func(void)
 	g_assert_cmpint(sz, ==, 294);
 	g_assert_cmpint(buf[0], ==, 0x01);
 	g_assert_cmpint(buf[1], ==, 0x00);
-	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -67,7 +67,7 @@ fu_test_synaprom_firmware_func(void)
 	firmware2 = fu_synaprom_device_prepare_firmware(FU_DEVICE(device),
 							stream,
 							progress,
-							FWUPD_INSTALL_FLAG_NONE,
+							FU_FIRMWARE_PARSE_FLAG_NONE,
 							&error);
 	g_assert_no_error(error);
 	g_assert_nonnull(firmware2);

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -110,7 +110,7 @@ static FuFirmware *
 fu_synaprom_config_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuSynapromConfig *self = FU_SYNAPROM_CONFIG(device);
@@ -144,7 +144,7 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 		return NULL;
 	}
 	if (fu_struct_synaprom_cfg_hdr_get_product(st_hdr) != FU_SYNAPROM_PRODUCT_PROMETHEUS) {
-		if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) {
+		if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) {
 			g_warning("CFG metadata not compatible, "
 				  "got 0x%02x expected 0x%02x",
 				  fu_struct_synaprom_cfg_hdr_get_product(st_hdr),
@@ -162,7 +162,7 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 	}
 	if (fu_struct_synaprom_cfg_hdr_get_id1(st_hdr) != self->configid1 ||
 	    fu_struct_synaprom_cfg_hdr_get_id2(st_hdr) != self->configid2) {
-		if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) {
+		if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) {
 			g_warning("CFG version not compatible, "
 				  "got %u:%u expected %u:%u",
 				  fu_struct_synaprom_cfg_hdr_get_id1(st_hdr),

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -232,7 +232,7 @@ FuFirmware *
 fu_synaprom_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	guint32 product_id;
@@ -251,7 +251,7 @@ fu_synaprom_device_prepare_firmware(FuDevice *device,
 	product_id = fu_synaprom_firmware_get_product_id(FU_SYNAPROM_FIRMWARE(firmware));
 	if (product_id != FU_SYNAPROM_PRODUCT_PROMETHEUS &&
 	    product_id != FU_SYNAPROM_PRODUCT_TRITON) {
-		if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) {
+		if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) {
 			g_warning("MFW metadata not compatible, "
 				  "got 0x%02x expected 0x%02x or 0x%02x",
 				  product_id,

--- a/plugins/synaptics-prometheus/fu-synaprom-device.h
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.h
@@ -37,7 +37,7 @@ FuFirmware *
 fu_synaprom_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error);
 
 guint32

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -50,7 +50,7 @@ fu_synaprom_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, X
 static gboolean
 fu_synaprom_firmware_parse(FuFirmware *firmware,
 			   GInputStream *stream,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-device.c
@@ -546,7 +546,7 @@ static FuFirmware *
 fu_synaptics_rmi_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuSynapticsRmiDevice *self = FU_SYNAPTICS_RMI_DEVICE(device);

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -54,7 +54,7 @@ fu_synaptics_rmi_firmware_add_image(FuFirmware *firmware,
 	partial_stream = fu_partial_input_stream_new(stream, offset, bufsz, error);
 	if (partial_stream == NULL)
 		return FALSE;
-	if (!fu_firmware_parse_stream(img, partial_stream, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_stream(img, partial_stream, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 	fu_firmware_set_id(img, id);
 	return fu_firmware_add_image_full(firmware, img, error);
@@ -82,7 +82,7 @@ fu_synaptics_rmi_firmware_add_image_v10(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(img,
 					      partial_stream,
 					      0x0,
-					      FWUPD_INSTALL_FLAG_NONE,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
 					      error))
 			return FALSE;
 		sig_id = g_strdup_printf("%s-signature", id);
@@ -398,7 +398,7 @@ fu_synaptics_rmi_firmware_parse_v0x(FuFirmware *firmware, GInputStream *stream, 
 static gboolean
 fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 				GInputStream *stream,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);
@@ -434,7 +434,7 @@ fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 
 	/* verify checksum */
 	self->checksum = fu_struct_rmi_img_get_checksum(st_img);
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint32 checksum_calculated =
 		    fu_synaptics_rmi_generate_checksum(buf + 4, bufsz - 4);
 		if (self->checksum != checksum_calculated) {

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -378,7 +378,7 @@ static FuFirmware *
 fu_synaptics_vmm9_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuSynapticsVmm9Device *self = FU_SYNAPTICS_VMM9_DEVICE(device);
@@ -396,7 +396,7 @@ fu_synaptics_vmm9_device_prepare_firmware(FuDevice *device,
 		return NULL;
 
 	/* verify this firmware is for this hardware */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID) == 0) {
 		if (self->board_id !=
 		    fu_synaptics_vmm9_firmware_get_board_id(FU_SYNAPTICS_VMM9_FIRMWARE(firmware))) {
 			g_set_error(error,
@@ -524,7 +524,7 @@ fu_synaptics_vmm9_device_read_firmware(FuDevice *device, FuProgress *progress, G
 
 	/* parse */
 	fw = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
-	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 
 	/* success */

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
@@ -45,7 +45,7 @@ fu_synaptics_vmm9_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_synaptics_vmm9_firmware_parse(FuFirmware *firmware,
 				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	FuSynapticsVmm9Firmware *self = FU_SYNAPTICS_VMM9_FIRMWARE(firmware);

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -22,7 +22,7 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 				FuArchive *archive,
 				JsonObject *obj,
 				guint i,
-				FwupdInstallFlags flags,
+				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	struct {
@@ -123,7 +123,7 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 static gboolean
 fu_telink_dfu_archive_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	FuTelinkDfuArchive *self = FU_TELINK_DFU_ARCHIVE(firmware);

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -1071,7 +1071,7 @@ test_image_validation(ThunderboltTest *tt, gconstpointer user_data)
 	ret = fu_firmware_parse_bytes(firmware_bad,
 				      bad_data,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      &error);
 	g_assert_false(ret);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_READ);
@@ -1139,7 +1139,7 @@ test_update_working(ThunderboltTest *tt, gconstpointer user_data)
 					      tree->fu_device,
 					      tt->fw_stream,
 					      progress,
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1193,7 +1193,7 @@ test_update_wd19(ThunderboltTest *tt, gconstpointer user_data)
 					      tree->fu_device,
 					      tt->fw_stream,
 					      progress,
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1231,7 +1231,7 @@ test_update_fail(ThunderboltTest *tt, gconstpointer user_data)
 					      tree->fu_device,
 					      tt->fw_stream,
 					      progress,
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1284,7 +1284,7 @@ test_update_fail_nowshow(ThunderboltTest *tt, gconstpointer user_data)
 					      tree->fu_device,
 					      tt->fw_stream,
 					      progress,
-					      FWUPD_INSTALL_FLAG_NO_SEARCH,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -141,7 +141,7 @@ fu_thunderbolt_controller_read_status_block(FuThunderboltController *self, GErro
 	istr_partial = g_memory_input_stream_new_from_bytes(blob);
 	firmware = fu_firmware_new_from_gtypes(istr_partial,
 					       0x0,
-					       FWUPD_INSTALL_FLAG_NO_SEARCH,
+					       FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					       error,
 					       FU_TYPE_INTEL_THUNDERBOLT_NVM,
 					       FU_TYPE_FIRMWARE,

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -325,7 +325,7 @@ static FuFirmware *
 fu_thunderbolt_device_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
 				       FuProgress *progress,
-				       FwupdInstallFlags flags,
+				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
 	FuThunderboltDevice *self = FU_THUNDERBOLT_DEVICE(device);

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -30,7 +30,7 @@ fu_ti_tps6598x_firmware_validate(FuFirmware *firmware,
 static gboolean
 fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 			      GInputStream *stream,
-			      FwupdInstallFlags flags,
+			      FuFirmwareParseFlags flags,
 			      GError **error)
 {
 	guint8 verbuf[3] = {0x0};

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -73,7 +73,7 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, GInputStream *stream, GError **error
 static gboolean
 fu_acpi_uefi_parse(FuFirmware *firmware,
 		   GInputStream *stream,
-		   FwupdInstallFlags flags,
+		   FuFirmwareParseFlags flags,
 		   GError **error)
 {
 	FuAcpiUefi *self = FU_ACPI_UEFI(firmware);
@@ -81,7 +81,7 @@ fu_acpi_uefi_parse(FuFirmware *firmware,
 
 	/* FuAcpiTable->parse */
 	if (!FU_FIRMWARE_CLASS(fu_acpi_uefi_parent_class)
-		 ->parse(FU_FIRMWARE(self), stream, FWUPD_INSTALL_FLAG_NONE, error))
+		 ->parse(FU_FIRMWARE(self), stream, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 
 	/* check signature and read flags */

--- a/plugins/uefi-capsule/fu-bitmap-image.c
+++ b/plugins/uefi-capsule/fu-bitmap-image.c
@@ -28,7 +28,7 @@ fu_bitmap_image_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 static gboolean
 fu_bitmap_image_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuBitmapImage *self = FU_BITMAP_IMAGE(firmware);

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -32,8 +32,11 @@ fu_uefi_update_esp_valid_func(void)
 
 	device = g_object_new(FU_TYPE_UEFI_CAPSULE_DEVICE, "context", ctx, NULL);
 	fu_uefi_capsule_device_set_esp(FU_UEFI_CAPSULE_DEVICE(device), volume_esp);
-	firmware =
-	    fu_device_prepare_firmware(device, stream, progress, FWUPD_INSTALL_FLAG_NONE, &error);
+	firmware = fu_device_prepare_firmware(device,
+					      stream,
+					      progress,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(firmware);
 }
@@ -56,8 +59,11 @@ fu_uefi_update_esp_invalid_func(void)
 
 	device = g_object_new(FU_TYPE_UEFI_CAPSULE_DEVICE, "context", ctx, NULL);
 	fu_uefi_capsule_device_set_esp(FU_UEFI_CAPSULE_DEVICE(device), volume_esp);
-	firmware =
-	    fu_device_prepare_firmware(device, stream, progress, FWUPD_INSTALL_FLAG_NONE, &error);
+	firmware = fu_device_prepare_firmware(device,
+					      stream,
+					      progress,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_null(firmware);
 }
@@ -81,8 +87,11 @@ fu_uefi_update_esp_no_backup_func(void)
 	device = g_object_new(FU_TYPE_UEFI_CAPSULE_DEVICE, "context", ctx, NULL);
 	fu_device_add_private_flag(device, "no-esp-backup");
 	fu_uefi_capsule_device_set_esp(FU_UEFI_CAPSULE_DEVICE(device), volume_esp);
-	firmware =
-	    fu_device_prepare_firmware(device, stream, progress, FWUPD_INSTALL_FLAG_NONE, &error);
+	firmware = fu_device_prepare_firmware(device,
+					      stream,
+					      progress,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
+					      &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(firmware);
 }
@@ -133,7 +142,7 @@ fu_uefi_bitmap_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(bmp_image),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/plugins/uefi-capsule/fu-uefi-bgrt.c
+++ b/plugins/uefi-capsule/fu-uefi-bgrt.c
@@ -66,7 +66,10 @@ fu_uefi_bgrt_setup(FuUefiBgrt *self, GError **error)
 	self->yoffset = fu_uefi_read_file_as_uint64(bgrtdir, "yoffset");
 	imagefn = g_build_filename(bgrtdir, "image", NULL);
 	file = g_file_new_build_filename(bgrtdir, "image", NULL);
-	if (!fu_firmware_parse_file(FU_FIRMWARE(bmp_image), file, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_file(FU_FIRMWARE(bmp_image),
+				    file,
+				    FU_FIRMWARE_PARSE_FLAG_NONE,
+				    error)) {
 		g_prefix_error(error, "BGRT image invalid: ");
 		return FALSE;
 	}

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -142,7 +142,7 @@ fu_uefi_bootmgr_setup_bootnext_with_loadopt(FuEfivars *efivars,
 		if (!fu_firmware_parse_bytes(FU_FIRMWARE(loadopt_tmp),
 					     loadopt_blob_tmp,
 					     0x0,
-					     FWUPD_INSTALL_FLAG_NONE,
+					     FU_FIRMWARE_PARSE_FLAG_NONE,
 					     &error_local)) {
 			g_debug("%s -> load option was invalid: %s", name, error_local->message);
 			continue;
@@ -230,7 +230,7 @@ fu_uefi_bootmgr_shim_is_safe(FuEfivars *efivars, const gchar *source_shim, GErro
 	g_autoptr(GPtrArray) shim_entries = NULL;
 
 	file = g_file_new_for_path(source_shim);
-	if (!fu_firmware_parse_file(shim, file, FWUPD_INSTALL_FLAG_NONE, error)) {
+	if (!fu_firmware_parse_file(shim, file, FU_FIRMWARE_PARSE_FLAG_NONE, error)) {
 		g_prefix_error(error, "failed to load %s: ", source_shim);
 		return FALSE;
 	}
@@ -255,7 +255,7 @@ fu_uefi_bootmgr_shim_is_safe(FuEfivars *efivars, const gchar *source_shim, GErro
 	if (!fu_firmware_parse_bytes(current_sbatlevel,
 				     current_sbatlevel_bytes,
 				     0x0,
-				     FWUPD_INSTALL_FLAG_NONE,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
 				     error)) {
 		g_prefix_error(error, "failed to load SbatLevelRT: ");
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -273,7 +273,11 @@ fu_uefi_capsule_device_load_update_info(FuUefiCapsuleDevice *self, GError **erro
 	fw = fu_efivars_get_data_bytes(efivars, FU_EFIVARS_GUID_FWUPDATE, varname, NULL, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(FU_FIRMWARE(info), fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(FU_FIRMWARE(info),
+				     fw,
+				     0x0,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
+				     error))
 		return NULL;
 	return g_steal_pointer(&info);
 }
@@ -673,7 +677,7 @@ static FuFirmware *
 fu_uefi_capsule_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
 					FuProgress *progress,
-					FwupdInstallFlags flags,
+					FuFirmwareParseFlags flags,
 					GError **error)
 {
 	FuUefiCapsuleDevice *self = FU_UEFI_CAPSULE_DEVICE(device);

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -335,7 +335,7 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	if (!fu_firmware_parse_bytes(FU_FIRMWARE(bmp_image),
 				     blob,
 				     0x0,
-				     FWUPD_INSTALL_FLAG_NONE,
+				     FU_FIRMWARE_PARSE_FLAG_NONE,
 				     error)) {
 		g_prefix_error(error, "splash invalid: ");
 		return FALSE;
@@ -763,7 +763,7 @@ fu_uefi_capsule_plugin_parse_acpi_uefi(FuUefiCapsulePlugin *self, GError **error
 	path = fu_path_from_kind(FU_PATH_KIND_ACPI_TABLES);
 	fn = g_build_filename(path, "UEFI", NULL);
 	file = g_file_new_for_path(fn);
-	if (!fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 	return g_steal_pointer(&firmware);
 }

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -144,7 +144,7 @@ fu_uefi_update_info_write(FuFirmware *firmware, GError **error)
 static gboolean
 fu_uefi_update_info_parse(FuFirmware *firmware,
 			  GInputStream *stream,
-			  FwupdInstallFlags flags,
+			  FuFirmwareParseFlags flags,
 			  GError **error)
 {
 	FuUefiUpdateInfo *self = FU_UEFI_UPDATE_INFO(firmware);
@@ -172,7 +172,7 @@ fu_uefi_update_info_parse(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(FU_FIRMWARE(dpbuf),
 					      stream,
 					      FU_STRUCT_EFI_UPDATE_INFO_SIZE,
-					      FWUPD_INSTALL_FLAG_NONE,
+					      FU_FIRMWARE_PARSE_FLAG_NONE,
 					      error)) {
 			g_prefix_error(error, "failed to parse dpbuf: ");
 			return FALSE;

--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -39,7 +39,7 @@ fu_dbxtool_get_siglist_system(FuContext *ctx, GError **error)
 					 error);
 	if (blob == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(dbx, blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(dbx, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, error))
 		return NULL;
 	return g_steal_pointer(&dbx);
 }
@@ -50,7 +50,7 @@ fu_dbxtool_get_siglist_local(const gchar *filename, GError **error)
 	g_autoptr(GFile) file = NULL;
 	g_autoptr(FuFirmware) siglist = fu_efi_signature_list_new();
 	file = g_file_new_for_path(filename);
-	if (!fu_firmware_parse_file(siglist, file, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_file(siglist, file, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 	return g_steal_pointer(&siglist);
 }
@@ -280,7 +280,7 @@ main(int argc, char *argv[])
 		if (!fu_firmware_parse_bytes(dbx_update,
 					     blob,
 					     0x0,
-					     FWUPD_INSTALL_FLAG_NONE,
+					     FU_FIRMWARE_PARSE_FLAG_NONE,
 					     &error)) {
 			/* TRANSLATORS: could not parse file */
 			g_printerr("%s: %s\n", _("Failed to parse local dbx"), error->message);
@@ -301,7 +301,7 @@ main(int argc, char *argv[])
 			g_print("%s\n", _("Validating ESP contents…"));
 			if (!fu_uefi_dbx_signature_list_validate(ctx,
 								 FU_EFI_SIGNATURE_LIST(dbx_update),
-								 FWUPD_INSTALL_FLAG_NONE,
+								 FU_FIRMWARE_PARSE_FLAG_NONE,
 								 &error)) {
 				g_printerr("%s: %s\n",
 					   /* TRANSLATORS: something with a blocked hash exists

--- a/plugins/uefi-dbx/fu-self-test.c
+++ b/plugins/uefi-dbx/fu-self-test.c
@@ -44,7 +44,7 @@ fu_efi_image_func(void)
 			g_test_skip(msg);
 			return;
 		}
-		ret = fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, &error);
+		ret = fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
 

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.c
@@ -45,7 +45,7 @@ fu_uefi_dbx_get_authenticode_hash(const gchar *fn, GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_pefile_firmware_new();
 	g_autoptr(GFile) file = g_file_new_for_path(fn);
-	if (!fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 	return fu_firmware_get_checksum(firmware, G_CHECKSUM_SHA256, error);
 }
@@ -54,7 +54,7 @@ static gboolean
 fu_uefi_dbx_signature_list_validate_filename(FuContext *ctx,
 					     FuEfiSignatureList *siglist,
 					     const gchar *fn,
-					     FwupdInstallFlags flags,
+					     FuFirmwareParseFlags flags,
 					     GError **error)
 {
 	g_autofree gchar *checksum = NULL;
@@ -88,7 +88,7 @@ fu_uefi_dbx_signature_list_validate_filename(FuContext *ctx,
 gboolean
 fu_uefi_dbx_signature_list_validate(FuContext *ctx,
 				    FuEfiSignatureList *siglist,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	g_autoptr(GPtrArray) files = NULL;

--- a/plugins/uefi-dbx/fu-uefi-dbx-common.h
+++ b/plugins/uefi-dbx/fu-uefi-dbx-common.h
@@ -13,5 +13,5 @@ fu_uefi_dbx_get_efi_arch(void);
 gboolean
 fu_uefi_dbx_signature_list_validate(FuContext *ctx,
 				    FuEfiSignatureList *siglist,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error);

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -121,7 +121,7 @@ fu_uefi_dbx_device_ensure_checksum(FuUefiDbxDevice *self, GError **error)
 						   error);
 	if (dbx_blob == NULL)
 		return FALSE;
-	if (!fu_firmware_parse_bytes(dbx, dbx_blob, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, error))
+	if (!fu_firmware_parse_bytes(dbx, dbx_blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, error))
 		return FALSE;
 
 	/* add the last checksum to the device */
@@ -158,7 +158,7 @@ static FuFirmware *
 fu_uefi_dbx_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
-				    FwupdInstallFlags flags,
+				    FuFirmwareParseFlags flags,
 				    GError **error)
 {
 	FuContext *ctx = fu_device_get_context(device);

--- a/plugins/uefi-sbat/fu-uefi-sbat-device.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-device.c
@@ -57,7 +57,7 @@ static FuFirmware *
 fu_uefi_sbat_device_prepare_firmware(FuDevice *device,
 				     GInputStream *stream,
 				     FuProgress *progress,
-				     FwupdInstallFlags flags,
+				     FuFirmwareParseFlags flags,
 				     GError **error)
 {
 	FuContext *ctx = fu_device_get_context(device);
@@ -231,7 +231,7 @@ fu_uefi_sbat_device_new(FuContext *ctx, GBytes *blob, GError **error)
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
 	/* copy the version across */
-	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 	self = g_object_new(FU_TYPE_UEFI_SBAT_DEVICE, "context", ctx, NULL);
 	fu_device_set_version(FU_DEVICE(self), fu_firmware_get_version(firmware));

--- a/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-firmware.c
@@ -17,7 +17,7 @@ G_DEFINE_TYPE(FuUefiSbatFirmware, fu_uefi_sbat_firmware, FU_TYPE_CSV_FIRMWARE)
 static gboolean
 fu_uefi_sbat_firmware_parse(FuFirmware *firmware,
 			    GInputStream *stream,
-			    FwupdInstallFlags flags,
+			    FuFirmwareParseFlags flags,
 			    GError **error)
 {
 	guint semver[] = {0, 0, 0};
@@ -70,7 +70,7 @@ fu_uefi_sbat_firmware_parse(FuFirmware *firmware,
 static gboolean
 fu_uefi_sbat_firmware_check_compatible(FuFirmware *firmware,
 				       FuFirmware *other,
-				       FwupdInstallFlags flags,
+				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
 	g_autoptr(FuFirmware) esp_sbat = NULL;

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -23,7 +23,7 @@ static FuFirmware *
 fu_uf2_device_prepare_firmware(FuDevice *device,
 			       GInputStream *stream,
 			       FuProgress *progress,
-			       FwupdInstallFlags flags,
+			       FuFirmwareParseFlags flags,
 			       GError **error)
 {
 	FuUf2Device *self = FU_UF2_DEVICE(device);
@@ -59,7 +59,7 @@ fu_uf2_device_probe_current_fw(FuDevice *device, GBytes *fw, GError **error)
 	g_autoptr(GBytes) fw_raw = NULL;
 
 	/* parse to get version */
-	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;
 	if (fu_firmware_get_version(firmware) != NULL)
 		fu_device_set_version(device, fu_firmware_get_version(firmware));
@@ -156,7 +156,7 @@ fu_uf2_device_read_firmware(FuDevice *device, FuProgress *progress, GError **err
 	fw = fu_device_dump_firmware(device, progress, error);
 	if (fw == NULL)
 		return NULL;
-	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NONE, error))
+	if (!fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return NULL;
 
 	return g_steal_pointer(&firmware);

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -169,7 +169,7 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 static gboolean
 fu_uf2_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	FuUf2Firmware *self = FU_UF2_FIRMWARE(firmware);

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -43,7 +43,7 @@ static FuFirmware *
 fu_usi_dock_child_device_prepare_firmware(FuDevice *device,
 					  GInputStream *stream,
 					  FuProgress *progress,
-					  FwupdInstallFlags flags,
+					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -216,7 +216,7 @@ static FuFirmware *
 fu_vbe_simple_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuVbeSimpleDevice *self = FU_VBE_SIMPLE_DEVICE(device);

--- a/plugins/vendor-example/fu-vendor-example-firmware.c.in
+++ b/plugins/vendor-example/fu-vendor-example-firmware.c.in
@@ -55,8 +55,7 @@ fu_{{vendor_example}}_firmware_validate(FuFirmware *firmware,
 
 static gboolean
 fu_{{vendor_example}}_firmware_parse(FuFirmware *firmware,
-				 GInputStream *stream,
-				 FwupdInstallFlags flags,
+				 GInputStream *stream, FuFirmwareParseFlags flags,
 				 GError **error)
 {
 	Fu{{VendorExample}}Firmware *self = FU_{{VENDOR_EXAMPLE}}_FIRMWARE(firmware);

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -445,7 +445,7 @@ static FuFirmware *
 fu_vli_pd_device_prepare_firmware(FuDevice *device,
 				  GInputStream *stream,
 				  FuProgress *progress,
-				  FwupdInstallFlags flags,
+				  FuFirmwareParseFlags flags,
 				  GError **error)
 {
 	FuVliPdDevice *self = FU_VLI_PD_DEVICE(device);

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -37,7 +37,7 @@ fu_vli_pd_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 static gboolean
 fu_vli_pd_firmware_parse(FuFirmware *firmware,
 			 GInputStream *stream,
-			 FwupdInstallFlags flags,
+			 FuFirmwareParseFlags flags,
 			 GError **error)
 {
 	FuVliPdFirmware *self = FU_VLI_PD_FIRMWARE(firmware);
@@ -79,7 +79,7 @@ fu_vli_pd_firmware_parse(FuFirmware *firmware,
 	}
 
 	/* check CRC */
-	if ((flags & FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM) == 0) {
+	if ((flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM) == 0) {
 		guint16 crc_actual = 0xFFFF;
 		guint16 crc_file = 0x0;
 		g_autoptr(GInputStream) stream_tmp = NULL;

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -861,7 +861,7 @@ static FuFirmware *
 fu_vli_usbhub_device_prepare_firmware(FuDevice *device,
 				      GInputStream *stream,
 				      FuProgress *progress,
-				      FwupdInstallFlags flags,
+				      FuFirmwareParseFlags flags,
 				      GError **error)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE(device);

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -44,7 +44,7 @@ fu_vli_usbhub_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags,
 static gboolean
 fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 			     GInputStream *stream,
-			     FwupdInstallFlags flags,
+			     FuFirmwareParseFlags flags,
 			     GError **error)
 {
 	FuVliUsbhubFirmware *self = FU_VLI_USBHUB_FIRMWARE(firmware);

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -156,7 +156,7 @@ static FuFirmware *
 fu_vli_usbhub_pd_device_prepare_firmware(FuDevice *device,
 					 GInputStream *stream,
 					 FuProgress *progress,
-					 FwupdInstallFlags flags,
+					 FuFirmwareParseFlags flags,
 					 GError **error)
 {
 	FuVliUsbhubPdDevice *self = FU_VLI_USBHUB_PD_DEVICE(device);

--- a/plugins/wacom-usb/fu-self-test.c
+++ b/plugins/wacom-usb/fu-self-test.c
@@ -31,7 +31,7 @@ fu_wac_firmware_parse_func(void)
 		return;
 	}
 	file = g_file_new_for_path(fn);
-	ret = fu_firmware_parse_file(firmware, file, FWUPD_INSTALL_FLAG_NO_SEARCH, &error);
+	ret = fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NO_SEARCH, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -28,7 +28,7 @@ typedef struct {
 
 typedef struct {
 	FuFirmware *firmware;
-	FwupdInstallFlags flags;
+	FuFirmwareParseFlags flags;
 	GPtrArray *header_infos;
 	GString *image_buffer;
 	guint8 images_cnt;
@@ -236,7 +236,7 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 		if (!fu_firmware_parse_bytes(firmware_srec,
 					     blob,
 					     0x0,
-					     helper->flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+					     helper->flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					     error))
 			return FALSE;
 		fw_srec = fu_firmware_get_bytes(firmware_srec, error);
@@ -266,7 +266,7 @@ fu_wac_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offse
 static gboolean
 fu_wac_firmware_parse(FuFirmware *firmware,
 		      GInputStream *stream,
-		      FwupdInstallFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error)
 {
 	g_autoptr(GPtrArray) header_infos = g_ptr_array_new_with_free_func(g_free);

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -148,7 +148,7 @@ static FuFirmware *
 fu_wac_module_bluetooth_id9_prepare_firmware(FuDevice *device,
 					     GInputStream *stream,
 					     FuProgress *progress,
-					     FwupdInstallFlags flags,
+					     FuFirmwareParseFlags flags,
 					     GError **error)
 {
 	const guint8 *blob;

--- a/plugins/wacom-usb/fu-wac-module-sub-cpu.c
+++ b/plugins/wacom-usb/fu-wac-module-sub-cpu.c
@@ -209,14 +209,14 @@ static FuFirmware *
 fu_wac_module_sub_cpu_prepare_firmware(FuDevice *self,
 				       GInputStream *stream,
 				       FuProgress *progress,
-				       FwupdInstallFlags flags,
+				       FuFirmwareParseFlags flags,
 				       GError **error)
 {
 	FuFirmware *firmware_srec = fu_srec_firmware_new();
 	if (!fu_firmware_parse_stream(firmware_srec,
 				      stream,
 				      0,
-				      flags | FWUPD_INSTALL_FLAG_NO_SEARCH,
+				      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 				      error)) {
 		g_prefix_error(error, "wacom sub_cpu failed to parse firmware: ");
 		return NULL;

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -333,7 +333,7 @@ static FuFirmware *
 fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
 					FuProgress *progress,
-					FwupdInstallFlags flags,
+					FuFirmwareParseFlags flags,
 					GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_archive_firmware_new();

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -885,7 +885,7 @@ fu_cabinet_sign(FuCabinet *self,
 static gboolean
 fu_cabinet_parse(FuFirmware *firmware,
 		 GInputStream *stream,
-		 FwupdInstallFlags flags,
+		 FuFirmwareParseFlags flags,
 		 GError **error)
 {
 	FuCabinet *self = FU_CABINET(firmware);

--- a/src/fu-engine-requirements.c
+++ b/src/fu-engine-requirements.c
@@ -297,7 +297,7 @@ fu_engine_requirements_check_firmware(FuEngine *self,
 
 	/* vendor ID */
 	if (g_strcmp0(xb_node_get_text(req), "vendor-id") == 0) {
-		if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID)
+		if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID)
 			return TRUE;
 		return fu_engine_requirements_check_vendor_id(self, req, device_actual, error);
 	}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2848,7 +2848,7 @@ fu_engine_prepare_firmware(FuEngine *self,
 			   const gchar *device_id,
 			   GInputStream *stream,
 			   FuProgress *progress,
-			   FwupdInstallFlags flags,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
 	g_autoptr(FuDevice) device = NULL;
@@ -3415,7 +3415,7 @@ fu_engine_install_loop(FuEngine *self,
 						      device_id,
 						      stream_fw,
 						      fu_progress_get_child(progress),
-						      flags,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error);
 		if (firmware == NULL)
 			return FALSE;
@@ -3438,7 +3438,7 @@ fu_engine_install_loop(FuEngine *self,
 						      device_id,
 						      stream_fw,
 						      fu_progress_get_child(progress),
-						      flags,
+						      FU_FIRMWARE_PARSE_FLAG_NONE,
 						      error);
 		if (firmware == NULL)
 			return FALSE;
@@ -4547,7 +4547,7 @@ fu_engine_build_cabinet_from_stream(FuEngine *self, GInputStream *stream, GError
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(cabinet),
 				      stream,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      error))
 		return NULL;
 	return g_steal_pointer(&cabinet);
@@ -4644,7 +4644,7 @@ fu_engine_get_result_from_component(FuEngine *self,
 		cabinet,
 		component,
 		rel,
-		FWUPD_INSTALL_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_REINSTALL |
+		FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_REINSTALL |
 		    FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH | FWUPD_INSTALL_FLAG_ALLOW_OLDER,
 		&error_reqs)) {
 		if (!fu_device_has_inhibit(dev, "not-found"))
@@ -5134,7 +5134,7 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) releases_tmp = NULL;
 	FwupdInstallFlags install_flags =
-	    FWUPD_INSTALL_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH |
+	    FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH |
 	    FWUPD_INSTALL_FLAG_ALLOW_REINSTALL | FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 
 	/* get all releases */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1142,8 +1142,11 @@ fu_engine_plugin_firmware_gtype(FuTest *self, GType gtype)
 	/* parse nonsense */
 	if (gtype != FU_TYPE_FIRMWARE &&
 	    !fu_firmware_has_flag(FU_FIRMWARE(firmware), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION)) {
-		ret =
-		    fu_firmware_parse_bytes(firmware, fw, 0x0, FWUPD_INSTALL_FLAG_NO_SEARCH, NULL);
+		ret = fu_firmware_parse_bytes(firmware,
+					      fw,
+					      0x0,
+					      FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
+					      NULL);
 		g_assert_false(ret);
 	}
 
@@ -5080,7 +5083,7 @@ fu_plugin_composite_func(gconstpointer user_data)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -5399,7 +5402,7 @@ fu_common_cabinet_func(void)
 	ret = fu_firmware_parse_stream(FU_FIRMWARE(cabinet),
 				       stream,
 				       0x0,
-				       FWUPD_INSTALL_FLAG_NONE,
+				       FU_FIRMWARE_PARSE_FLAG_NONE,
 				       &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -5846,7 +5849,7 @@ fu_common_store_cab_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -5916,7 +5919,7 @@ fu_common_store_cab_artifact_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet1),
 				      blob1,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -5947,7 +5950,7 @@ fu_common_store_cab_artifact_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet2),
 				      blob2,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -5981,7 +5984,7 @@ fu_common_store_cab_artifact_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet3),
 				      blob3,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6010,7 +6013,7 @@ fu_common_store_cab_artifact_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet4),
 				      blob4,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6044,7 +6047,7 @@ fu_common_store_cab_unsigned_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6097,7 +6100,7 @@ fu_common_store_cab_sha256_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6130,7 +6133,7 @@ fu_common_store_cab_folder_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6165,7 +6168,7 @@ fu_common_store_cab_error_no_metadata_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
@@ -6197,7 +6200,7 @@ fu_common_store_cab_error_wrong_size_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
@@ -6227,7 +6230,7 @@ fu_common_store_cab_error_missing_file_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
@@ -6256,7 +6259,7 @@ fu_common_store_cab_error_size_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);
@@ -6287,7 +6290,7 @@ fu_common_store_cab_error_wrong_checksum_func(void)
 	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cabinet),
 				      blob,
 				      0x0,
-				      FWUPD_INSTALL_FLAG_NONE,
+				      FU_FIRMWARE_PARSE_FLAG_NONE,
 				      &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_false(ret);


### PR DESCRIPTION
This really undoes a bad design decision in 1.6.something -- one set of flags is now used for parsing firmware, and another set of flags is used to install firmware onto devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
