### PR TITLE
Simplify parsing USB descriptors

### DIFF
--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -777,20 +777,3 @@ fu_input_stream_find(GInputStream *stream,
 		    (guint)bufsz);
 	return FALSE;
 }
-
-/**
- * fu_input_stream_locker_unref:
- * @stream: a #GInputStream
- *
- * Closes an input stream and then unrefs it.
- *
- * Since: 2.0.7
- **/
-void
-fu_input_stream_locker_unref(FuInputStreamLocker *stream)
-{
-	g_autoptr(GError) error_local = NULL;
-	if (!g_input_stream_close(stream, NULL, &error_local))
-		g_warning("failed to close input stream: %s", error_local->message);
-	g_object_unref(stream);
-}

--- a/libfwupdplugin/fu-input-stream.h
+++ b/libfwupdplugin/fu-input-stream.h
@@ -106,9 +106,3 @@ fu_input_stream_find(GInputStream *stream,
 		     gsize bufsz,
 		     gsize *offset,
 		     GError **error) G_GNUC_NON_NULL(1, 2);
-
-/* useful to close file descriptors backing the input stream */
-typedef GInputStream FuInputStreamLocker;
-void
-fu_input_stream_locker_unref(FuInputStreamLocker *stream) G_GNUC_NON_NULL(1);
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuInputStreamLocker, fu_input_stream_locker_unref);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -5811,17 +5811,17 @@ fu_partial_input_stream_closed_base_func(void)
 	gboolean ret;
 	gssize rc;
 	guint8 buf[2] = {0x0};
+	g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GInputStream) stream = NULL;
+	g_autoptr(GInputStream) base_stream = g_memory_input_stream_new_from_bytes(blob);
 
-	{
-		g_autoptr(GBytes) blob = g_bytes_new_static("12345678", 8);
-		g_autoptr(FuInputStreamLocker) base_stream =
-		    g_memory_input_stream_new_from_bytes(blob);
-		stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
-		g_assert_no_error(error);
-		g_assert_nonnull(stream);
-	}
+	stream = fu_partial_input_stream_new(base_stream, 2, 4, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(stream);
+	ret = g_input_stream_close(base_stream, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	ret = g_seekable_seek(G_SEEKABLE(stream), 0x0, G_SEEK_SET, NULL, &error);
 	g_assert_no_error(error);

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -102,7 +102,11 @@ fu_usb_bos_descriptor_from_json(FwupdCodec *codec, JsonNode *json_node, GError *
 
 		/* create child */
 		stream = g_memory_input_stream_new_from_data(g_steal_pointer(&buf), bufsz, g_free);
-		if (!fu_firmware_set_stream(img, stream, error))
+		if (!fu_firmware_parse_stream(img,
+					      stream,
+					      0x0,
+					      FU_FIRMWARE_PARSE_FLAG_CACHE_BLOB,
+					      error))
 			return FALSE;
 		fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
@@ -186,7 +190,11 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 			g_prefix_error(error, "failed to cut BOS descriptor: ");
 			return FALSE;
 		}
-		if (!fu_firmware_set_stream(img, img_stream, error))
+		if (!fu_firmware_parse_stream(img,
+					      img_stream,
+					      0x0,
+					      FU_FIRMWARE_PARSE_FLAG_CACHE_BLOB,
+					      error))
 			return FALSE;
 		fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))

--- a/libfwupdplugin/fu-usb-descriptor.c
+++ b/libfwupdplugin/fu-usb-descriptor.c
@@ -6,7 +6,6 @@
 
 #include "config.h"
 
-#include "fu-partial-input-stream.h"
 #include "fu-usb-descriptor.h"
 
 G_DEFINE_TYPE(FuUsbDescriptor, fu_usb_descriptor, FU_TYPE_FIRMWARE)
@@ -17,23 +16,14 @@ fu_usb_descriptor_parse(FuFirmware *firmware,
 			FuFirmwareParseFlags flags,
 			GError **error)
 {
-	FuUsbDescriptor *self = FU_USB_DESCRIPTOR(firmware);
 	g_autoptr(FuUsbBaseHdr) st = NULL;
-	g_autoptr(GInputStream) stream_partial = NULL;
 
 	/* parse */
 	st = fu_usb_base_hdr_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
-	stream_partial =
-	    fu_partial_input_stream_new(stream, 0x0, fu_usb_base_hdr_get_length(st), error);
-	if (stream_partial == NULL) {
-		g_prefix_error(error, "failed to cut USB descriptor: ");
-		return FALSE;
-	}
-	if (!fu_firmware_set_stream(firmware, stream_partial, error))
-		return FALSE;
-	fu_firmware_set_idx(FU_FIRMWARE(self), fu_usb_base_hdr_get_descriptor_type(st));
+	fu_firmware_set_size(firmware, fu_usb_base_hdr_get_length(st));
+	fu_firmware_set_idx(firmware, fu_usb_base_hdr_get_descriptor_type(st));
 
 	/* success */
 	return TRUE;

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -65,7 +65,7 @@ fu_usb_interface_parse_extra(FuUsbInterface *self, const guint8 *buf, gsize bufs
 		if (!fu_firmware_parse_bytes(FU_FIRMWARE(img),
 					     bytes,
 					     offset,
-					     FU_FIRMWARE_PARSE_FLAG_NONE,
+					     FU_FIRMWARE_PARSE_FLAG_CACHE_BLOB,
 					     error))
 			return FALSE;
 		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))


### PR DESCRIPTION
Storing the partial stream in the FuUsbDescriptor caused all kinds of lifecycle issues for the file descriptor. Rip it all out and make it simpler, fixing various fd-not-closed issues in the process...

Fixes https://github.com/fwupd/fwupd/issues/8712

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
