### PR TITLE
bnr-dp: Build only for Linux host machine

### DIFF
--- a/plugins/bnr-dp/meson.build
+++ b/plugins/bnr-dp/meson.build
@@ -1,3 +1,4 @@
+if host_machine.system() == 'linux'
 cargs = ['-DG_LOG_DOMAIN="FuPluginBnrDp"']
 
 plugins += {meson.current_source_dir().split('/')[-1]: true}
@@ -50,4 +51,5 @@ if get_option('tests')
       },
     ),
   )
+endif
 endif


### PR DESCRIPTION
Just like the other plugins under drm_dp_aux_dev subsystem, the plugin depends on udev support and should check if the host machine is Linux.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation