### PR TITLE
logitech-scribe: add wait for replug

### DIFF
--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -483,6 +483,7 @@ fu_logitech_scribe_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 94, "device-write-blocks");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, "end-transfer");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 5, "uninit");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "sleep");
 
 	/* get default image */
 	stream = fu_firmware_get_stream(firmware, error);
@@ -561,6 +562,9 @@ fu_logitech_scribe_device_write_firmware(FuDevice *device,
 	 * image file pushed. Device validates and uploads new image on inactive partition. Reboots
 	 * wait for RemoveDelay duration
 	 */
+	fu_device_sleep_full(FU_DEVICE(self), 60 * 1000, fu_progress_get_child(progress));
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	fu_progress_step_done(progress);
 
 	/* success! */
 	return TRUE;
@@ -651,6 +655,8 @@ fu_logitech_scribe_device_init(FuLogitechScribeDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_retry_set_delay(FU_DEVICE(self), 1000);
+	fu_device_set_remove_delay(FU_DEVICE(self), 2 * 60 * 1000);
+	fu_device_set_install_duration(FU_DEVICE(self), 120);
 }
 
 static void

--- a/plugins/logitech-scribe/logitech-scribe.quirk
+++ b/plugins/logitech-scribe/logitech-scribe.quirk
@@ -1,4 +1,2 @@
 [VIDEO4LINUX\VEN_046D&DEV_08E2]
 Plugin = logitech_scribe
-InstallDuration = 120
-RemoveDelay = 120000


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

fwupdmgr reporting same firmware, after the upgrade. Added missing FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG 
Moved config setting from quirk to device class 