### PR TITLE
Add notes on security implications of `systemd_unit_user` build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,11 @@ fwupdmgr is a command line client, but various additional graphical frontends ar
 
 - [Coverity](https://scan.coverity.com/) - static analyzer for Java, C/C++, C#, JavaScript, Ruby, and Python code.
 - [PVS-Studio](https://pvs-studio.com/en/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C, C++, C#, and Java code.
+
+## Packaging notes
+
+If you are working or maintaining a package of fwupd downstream, please consider the following notes.
+
+- The Meson build option `systemd_unit_user` should be used carefully, and the specified user (or resulting group) should be inaccessible to
+  unprivileged system users. Otherwise, this may pose a risk for privilege escalation. The default value for this setting (`DynamicUser=true`) is
+  secure and should be used in the general case.

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -18,6 +18,9 @@ if libsystemd.found()
       con2.set('user', 'DynamicUser=yes')
       warning('Using systemd DynamicUser for fwupd-refresh.service. See https://github.com/systemd/systemd/issues/22737 for possible implications')
   else
+      if get_option('systemd_unit_user') != 'root'
+        warning('fwupd-refresh.service is run with user "', get_option('systemd_unit_user'), '". This may be a security risk. See https://github.com/fwupd/fwupd/README.md#systemd-service for more information.')
+      endif
       dynamic_options = [
                          'ProtectSystem=strict',
                          'ProtectHome=read-only',


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

This adds a warning if fwupd is built with the `systemd_unit_user` meson option set to a specific user, but not `root`.
In some cases, where the user the unit runs as may be accessible to other users, this may pose a risk for privilege escalation.

Additionally, this adds a section to the README with note for downstream packagers and maintainers, initially starting with only this option explained.

For the latter, I wonder whether there might be a more appropriate place or way of putting these notes. Open to feedback here!