### PR TITLE
trivial: Link into the UEFI Secure Boot Certificates page from the HSI failure

### DIFF
--- a/docs/hsi-tests.d/org.fwupd.hsi.Uefi.Db.json
+++ b/docs/hsi-tests.d/org.fwupd.hsi.Uefi.Db.json
@@ -16,6 +16,7 @@
   },
   "resolution": "Apply the LVFS KEK update for your hardware, and then apply the LVFS db update.",
   "references": {
+    "https://fwupd.github.io/libfwupdplugin/uefi-db.html": "fwupd Documentation for UEFI Secure Boot Certificates",
     "https://wiki.ubuntu.com/UEFI/SecureBoot/Testing": "Ubuntu SecureBoot Wiki Page"
   },
   "fwupd-version": "2.0.8"


### PR DESCRIPTION
Maybe fixes https://github.com/fwupd/fwupd/issues/8787

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
