### PR TITLE
uefi-capsule: Never write a UX capsule when using Capsule-On-Disk

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-cod-device.c
+++ b/plugins/uefi-capsule/fu-uefi-cod-device.c
@@ -305,6 +305,7 @@ fu_uefi_cod_device_report_metadata_pre(FuDevice *device, GHashTable *metadata)
 static void
 fu_uefi_cod_device_init(FuUefiCodDevice *self)
 {
+	fu_device_add_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_NO_UX_CAPSULE);
 	fu_device_set_summary(FU_DEVICE(self),
 			      "UEFI System Resource Table device (Updated via capsule-on-disk)");
 }


### PR DESCRIPTION
Writing the UX capsule to the ESP (in a place the firmware isn't looking) is pointless at best, but writing the efivar key as well might be confusing to the firmware. Just stop doing it.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
