### PR TITLE
Provide a way for the client to restrict the GUID list to an emulated device

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -69,6 +69,7 @@ _fwupdmgr_opts=(
 	'--no-safety-check'
 	'--no-remote-check'
 	'--no-security-fix'
+	'--only-emulated'
 	'--show-all'
 	'--sign'
 	'--filter'

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -857,6 +857,8 @@ fwupd_install_flags_from_string(const gchar *str)
 		return FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
 	if (g_strcmp0(str, "ignore-requirements") == 0)
 		return FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS;
+	if (g_strcmp0(str, "only-emulated") == 0)
+		return FWUPD_INSTALL_FLAG_ONLY_EMULATED;
 
 	return FWUPD_INSTALL_FLAG_UNKNOWN;
 }
@@ -888,5 +890,7 @@ fwupd_install_flags_to_string(FwupdInstallFlags install_flags)
 		return "allow-branch-switch";
 	if (install_flags == FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS)
 		return "ignore-requirements";
+	if (install_flags == FWUPD_INSTALL_FLAG_ONLY_EMULATED)
+		return "only-emulated";
 	return NULL;
 }

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1122,6 +1122,14 @@ typedef enum {
 	 * Since: 1.9.21
 	 */
 	FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS = 1 << 9,
+	/**
+	 * FWUPD_INSTALL_FLAG_ONLY_EMULATED:
+	 *
+	 * Only install to emulated devices.
+	 *
+	 * Since: 2.0.10
+	 */
+	FWUPD_INSTALL_FLAG_ONLY_EMULATED = 1 << 10,
 	/*< private >*/
 	FWUPD_INSTALL_FLAG_UNKNOWN = G_MAXUINT64,
 } FwupdInstallFlags;

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -128,7 +128,7 @@ fwupd_enums_func(void)
 			break;
 		g_assert_cmpint(fwupd_remote_flag_from_string(tmp), ==, i);
 	}
-	for (guint64 i = 1; i <= FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS; i *= 2) {
+	for (guint64 i = 1; i <= FWUPD_INSTALL_FLAG_ONLY_EMULATED; i *= 2) {
 		const gchar *tmp = fwupd_install_flags_to_string(i);
 		if (tmp == NULL)
 			continue;

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -956,6 +956,14 @@ fu_dbus_daemon_install_with_helper(FuMainAuthHelper *helper_ref, GError **error)
 		XbNode *component = g_ptr_array_index(components, i);
 		for (guint j = 0; j < devices_possible->len; j++) {
 			FuDevice *device = g_ptr_array_index(devices_possible, j);
+
+			/* emulating */
+			if ((helper->flags & FWUPD_INSTALL_FLAG_ONLY_EMULATED) &&
+			    !fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
+				g_debug("skipping non-emulated %s", fu_device_get_id(device));
+				continue;
+			}
+
 			g_debug("testing device %u [%s] with component %u",
 				j,
 				fu_device_get_id(device),

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1456,6 +1456,7 @@ fu_util_device_emulate(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FuUtilDeviceTestHelper) helper = fu_util_device_test_helper_new();
 	helper->use_emulation = TRUE;
+	priv->flags |= FWUPD_INSTALL_FLAG_ONLY_EMULATED;
 	priv->filter_device_include |= FWUPD_DEVICE_FLAG_EMULATED;
 	return fu_util_device_test_full(priv, values, helper, error);
 }
@@ -5043,6 +5044,7 @@ main(int argc, char *argv[])
 	gboolean allow_branch_switch = FALSE;
 	gboolean allow_older = FALSE;
 	gboolean allow_reinstall = FALSE;
+	gboolean only_emulated = FALSE;
 	gboolean only_p2p = FALSE;
 	gboolean is_interactive = FALSE;
 	gboolean no_history = FALSE;
@@ -5110,6 +5112,14 @@ main(int argc, char *argv[])
 	     &allow_branch_switch,
 	     /* TRANSLATORS: command line option */
 	     N_("Allow switching firmware branch"),
+	     NULL},
+	    {"only-emulated",
+	     '\0',
+	     0,
+	     G_OPTION_ARG_NONE,
+	     &only_emulated,
+	     /* TRANSLATORS: command line option */
+	     N_("Only install onto emulated devices"),
 	     NULL},
 	    {"force",
 	     '\0',
@@ -5756,6 +5766,8 @@ main(int argc, char *argv[])
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 	if (allow_branch_switch)
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH;
+	if (only_emulated)
+		priv->flags |= FWUPD_INSTALL_FLAG_ONLY_EMULATED;
 	if (force) {
 		priv->flags |= FWUPD_INSTALL_FLAG_FORCE;
 		priv->flags |= FWUPD_INSTALL_FLAG_IGNORE_REQUIREMENTS;


### PR DESCRIPTION
This allows me to do `fwupdmgr device-emulation` when an actual physical device is plugged into a different USB socket than the emulation was recorded for.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
