### PR TITLE
uefi-pk: Include the UEFI PK certificate key ID in the uploaded report

### DIFF
--- a/plugins/uefi-pk/fu-uefi-pk-device.h
+++ b/plugins/uefi-pk/fu-uefi-pk-device.h
@@ -10,3 +10,6 @@
 
 #define FU_TYPE_UEFI_PK_DEVICE (fu_uefi_pk_device_get_type())
 G_DECLARE_FINAL_TYPE(FuUefiPkDevice, fu_uefi_pk_device, FU, UEFI_PK_DEVICE, FuUefiDevice)
+
+const gchar *
+fu_uefi_pk_device_get_key_id(FuUefiPkDevice *self) G_GNUC_NON_NULL(1);

--- a/plugins/uefi-pk/fu-uefi-pk-plugin.c
+++ b/plugins/uefi-pk/fu-uefi-pk-plugin.c
@@ -27,9 +27,21 @@ fu_uefi_pk_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_UEFI_PK_DEVICE);
 }
 
+static gboolean
+fu_uefi_pk_plugin_device_created(FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	if (!fu_device_probe(device, error))
+		return FALSE;
+	fu_plugin_add_report_metadata(plugin,
+				      "UefiPkKeyId",
+				      fu_uefi_pk_device_get_key_id(FU_UEFI_PK_DEVICE(device)));
+	return TRUE;
+}
+
 static void
 fu_uefi_pk_plugin_class_init(FuUefiPkPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
 	plugin_class->constructed = fu_uefi_pk_plugin_constructed;
+	plugin_class->device_created = fu_uefi_pk_plugin_device_created;
 }


### PR DESCRIPTION
This will be very useful to debug and filter KEK deployment failures.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
