### PR TITLE
Include AGESA version in summary of secure processor device

### DIFF
--- a/libfwupdplugin/fu-device-event.c
+++ b/libfwupdplugin/fu-device-event.c
@@ -256,7 +256,10 @@ fu_device_event_check_error(FuDeviceEvent *self, GError **error)
 	const gchar *message;
 
 	g_return_val_if_fail(FU_IS_DEVICE_EVENT(self), FALSE);
-	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* nothing to do */
+	if (error == NULL)
+		return TRUE;
 
 	/* anything set */
 	code = fu_device_event_get_i64(self, "Error", NULL);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -983,6 +983,83 @@ fu_device_get_contents_bytes(FuDevice *self,
 }
 
 /**
+ * fu_device_get_smbios_string:
+ * @self: a #FuDevice
+ * @type: a SMBIOS structure type, e.g. %FU_SMBIOS_STRUCTURE_TYPE_BIOS
+ * @length: expected length of the structure, or %FU_SMBIOS_STRUCTURE_LENGTH_ANY
+ * @offset: a SMBIOS offset
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets a hardware SMBIOS string.
+ *
+ * The @type and @offset can be referenced from the DMTF SMBIOS specification:
+ * https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.1.1.pdf
+ *
+ * Returns: a string, or %NULL
+ *
+ * Since: 2.0.10
+ **/
+const gchar *
+fu_device_get_smbios_string(FuDevice *self,
+			    guint8 type,
+			    guint8 length,
+			    guint8 offset,
+			    GError **error)
+{
+	FuDevicePrivate *priv = GET_PRIVATE(self);
+	FuDeviceEvent *event = NULL;
+	const gchar *str;
+	g_autofree gchar *event_id = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* need event ID */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED) ||
+	    fu_context_has_flag(fu_device_get_context(FU_DEVICE(self)),
+				FU_CONTEXT_FLAG_SAVE_EVENTS)) {
+		event_id = g_strdup_printf("GetSmbiosString:"
+					   "Type=0x%02x,"
+					   "Length=0x%02x,"
+					   "Offset=0x%02x",
+					   type,
+					   length,
+					   offset);
+	}
+
+	/* emulated */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED)) {
+		event = fu_device_load_event(FU_DEVICE(self), event_id, error);
+		if (event == NULL)
+			return NULL;
+		if (!fu_device_event_check_error(event, error))
+			return NULL;
+		return fu_device_event_get_str(event, "Data", error);
+	}
+
+	/* save */
+	if (event_id != NULL)
+		event = fu_device_save_event(FU_DEVICE(self), event_id);
+
+	/* use context */
+	str = fu_context_get_smbios_string(priv->ctx, type, length, offset, &error_local);
+	if (str == NULL) {
+		if (event != NULL)
+			fu_device_event_set_error(event, error_local);
+		g_propagate_error(error, g_steal_pointer(&error_local));
+		return NULL;
+	}
+
+	/* save response */
+	if (event != NULL)
+		fu_device_event_set_str(event, "Data", str);
+
+	/* success */
+	return str;
+}
+
+/**
  * fu_device_query_file_exists:
  * @self: a #FuDevice
  * @filename: filename

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1415,6 +1415,12 @@ fu_device_get_contents_bytes(FuDevice *self,
 gboolean
 fu_device_query_file_exists(FuDevice *self, const gchar *filename, gboolean *exists, GError **error)
     G_GNUC_NON_NULL(1, 2, 3);
+const gchar *
+fu_device_get_smbios_string(FuDevice *self,
+			    guint8 type,
+			    guint8 length,
+			    guint8 offset,
+			    GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
 void
 fu_device_add_possible_plugin(FuDevice *self, const gchar *plugin) G_GNUC_NON_NULL(1, 2);
 

--- a/plugins/pci-psp/meson.build
+++ b/plugins/pci-psp/meson.build
@@ -14,4 +14,10 @@ plugin_builtins += static_library('fu_plugin_pci_psp',
   dependencies: plugin_deps,
 )
 umockdev_tests += files('pci_psp_test.py')
+device_tests += files(
+  'tests/pci-psp-strix.json',
+)
+enumeration_data += files(
+  'tests/pci-psp-strix-enumerate.json',
+)
 endif

--- a/plugins/pci-psp/meson.build
+++ b/plugins/pci-psp/meson.build
@@ -15,9 +15,9 @@ plugin_builtins += static_library('fu_plugin_pci_psp',
 )
 umockdev_tests += files('pci_psp_test.py')
 device_tests += files(
-  'tests/pci-psp-strix.json',
+  'tests/pci-psp-strix-enumerate.json',
 )
 enumeration_data += files(
-  'tests/pci-psp-strix-enumerate.json',
+  'tests/pci-psp-strix.json',
 )
 endif

--- a/plugins/pci-psp/tests/pci-psp-strix-enumerate.json
+++ b/plugins/pci-psp/tests/pci-psp-strix-enumerate.json
@@ -1,0 +1,17 @@
+{
+  "name": "pci psp strix (enumerate only)",
+  "interactive": false,
+  "steps": [
+    {
+      "emulation-file": "@enumeration_datadir@/pci-psp-strix.json",
+      "components": [
+        {
+          "version": "00.3e.04.74",
+          "guids": [
+            "92c96a95-c187-5183-ae27-eab2f47e0f63"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/pci-psp/tests/pci-psp-strix.json
+++ b/plugins/pci-psp/tests/pci-psp-strix.json
@@ -1,0 +1,112 @@
+{
+  "FwupdVersion": "2.0.9",
+  "UsbDevices": [
+    {
+      "Created": "2025-05-19T11:44:58.764803Z",
+      "GType": "FuUdevDevice",
+      "BackendId": "/sys/devices/pci0000:00/0000:00:08.1/0000:c1:00.2",
+      "Subsystem": "pci",
+      "Driver": "ccp",
+      "BindId": "0000:c1:00.2",
+      "Vendor": 4130,
+      "Model": 6112,
+      "Events": [
+        {
+          "Id": "GetSymlinkTarget:Attr=subsystem",
+          "Data": "pci"
+        },
+        {
+          "Id": "GetSymlinkTarget:Attr=driver",
+          "Data": "ccp"
+        },
+        {
+          "Id": "ReadProp:Key=DEVTYPE"
+        },
+        {
+          "Id": "ReadAttr:Attr=uevent",
+          "Data": "DRIVER=ccp\nPCI_CLASS=108000\nPCI_ID=1022:17E0\nPCI_SUBSYS_ID=F111:000B\nPCI_SLOT_NAME=0000:c1:00.2\nMODALIAS=pci:v00001022d000017E0sv0000F111sd0000000Bbc10sc80i00"
+        },
+        {
+          "Id": "ReadProp:Key=DEVNAME"
+        },
+        {
+          "Id": "ReadAttr:Attr=vendor",
+          "Data": "0x1022"
+        },
+        {
+          "Id": "ReadAttr:Attr=device",
+          "Data": "0x17e0"
+        },
+        {
+          "Id": "ReadAttr:Attr=class",
+          "Data": "0x108000"
+        },
+        {
+          "Id": "ReadProp:Key=DEVTYPE"
+        },
+        {
+          "Id": "ReadProp:Key=DEVTYPE"
+        },
+        {
+          "Id": "ReadAttr:Attr=uevent",
+          "Data": "DRIVER=ccp\nPCI_CLASS=108000\nPCI_ID=1022:17E0\nPCI_SUBSYS_ID=F111:000B\nPCI_SLOT_NAME=0000:c1:00.2\nMODALIAS=pci:v00001022d000017E0sv0000F111sd0000000Bbc10sc80i00"
+        },
+        {
+          "Id": "ReadProp:Key=DEVNAME"
+        },
+        {
+          "Id": "ReadAttr:Attr=vendor",
+          "Data": "0x1022"
+        },
+        {
+          "Id": "ReadAttr:Attr=device",
+          "Data": "0x17e0"
+        },
+        {
+          "Id": "ReadAttr:Attr=class",
+          "Data": "0x108000"
+        },
+        {
+          "Id": "ReadProp:Key=DEVTYPE"
+        },
+        {
+          "Id": "GetBackendParent:Subsystem=i2c",
+          "Error": 8,
+          "ErrorMsg": "no parent with subsystem i2c"
+        },
+        {
+          "Id": "ReadAttr:Attr=class",
+          "Data": "0x108000"
+        },
+        {
+          "Id": "ReadAttr:Attr=revision",
+          "Data": "0x00"
+        },
+        {
+          "Id": "ReadAttr:Attr=subsystem_vendor",
+          "Data": "0xf111"
+        },
+        {
+          "Id": "ReadAttr:Attr=subsystem_device",
+          "Data": "0x000b"
+        },
+        {
+          "Id": "ReadProp:Key=PCI_SLOT_NAME",
+          "Data": "0000:c1:00.2"
+        },
+        {
+          "Id": "ReadAttr:Attr=bootloader_version",
+          "Data": "74.04.3e.00"
+        },
+        {
+          "Id": "ReadAttr:Attr=tee_version",
+          "Data": "00.3e.04.74"
+        },
+        {
+          "Id": "GetSmbiosString:Type=0x28,Length=0x0e,Offset=0x04",
+          "Data": "AGESA!V9 StrixKrackanPI-FP8 1.1.0.0a"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The AGESA version on AMD platforms is like a meta version to indicate what platform initialization code the BIOS was built with.

On newer platforms this is stored in an SMBIOS type 40 entry.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
