### PR TITLE
uefi-kek: Fix regression preventing installation of KEKs

### DIFF
--- a/libfwupdplugin/fu-efi-x509-device.c
+++ b/libfwupdplugin/fu-efi-x509-device.c
@@ -98,11 +98,15 @@ fu_efi_x509_device_write_firmware(FuDevice *device,
 {
 	FuDeviceClass *device_class;
 	FuDevice *proxy;
-	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
+	g_autoptr(GPtrArray) imgs = NULL;
 
 	/* not an archive */
-	if (imgs->len == 0)
+	if (FU_IS_EFI_VARIABLE_AUTHENTICATION2(firmware)) {
+		imgs = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 		g_ptr_array_add(imgs, g_object_ref(firmware));
+	} else {
+		imgs = fu_firmware_get_images(firmware);
+	}
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);


### PR DESCRIPTION
The enhancement in 5ced1c18 broke installing KEKs as an EFI_SIGNATURE_LIST has a list of signature images. Check the firmware GType to decide on what to do.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
