### PR TITLE
legion-hid2: Add support for reading touchpad child device

### DIFF
--- a/plugins/legion-hid2/fu-legion-hid2-child-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-child-device.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 Mario Limonciello <superm1@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-legion-hid2-child-device.h"
+#include "fu-legion-hid2-device.h"
+#include "fu-legion-hid2-struct.h"
+
+struct _FuLegionHid2ChildDevice {
+	FuDevice parent_instance;
+	guint8 manufacturer;
+};
+
+G_DEFINE_TYPE(FuLegionHid2ChildDevice, fu_legion_hid2_child_device, FU_TYPE_DEVICE)
+
+#define FU_LEGION_HID2_CHILD_DEVICE_TIMEOUT 200 /* ms */
+
+static void
+fu_legion_hid2_child_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuLegionHid2ChildDevice *self = FU_LEGION_HID2_CHILD_DEVICE(device);
+	fwupd_codec_string_append_int(str, idt, "ChipManufacturer", self->manufacturer);
+}
+
+static gboolean
+fu_legion_hid2_child_device_transfer(FuLegionHid2ChildDevice *self,
+				     GByteArray *req,
+				     GByteArray *res,
+				     GError **error)
+{
+	FuHidDevice *hid_dev = FU_HID_DEVICE(fu_device_get_proxy(FU_DEVICE(self)));
+
+	if (req != NULL) {
+		if (!fu_hid_device_set_report(hid_dev,
+					      req->data[0],
+					      req->data,
+					      req->len,
+					      FU_LEGION_HID2_CHILD_DEVICE_TIMEOUT,
+					      FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
+					      error)) {
+			g_prefix_error(error, "failed to send packet: ");
+			return FALSE;
+		}
+	}
+	if (res != NULL) {
+		if (!fu_hid_device_get_report(hid_dev,
+					      req->data[0],
+					      res->data,
+					      res->len,
+					      FU_LEGION_HID2_CHILD_DEVICE_TIMEOUT,
+					      FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
+					      error)) {
+			g_prefix_error(error, "failed to receive packet: ");
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_legion_hid2_child_device_probe(FuDevice *device, GError **error)
+{
+	FuLegionHid2ChildDevice *self = FU_LEGION_HID2_CHILD_DEVICE(device);
+	g_autoptr(GByteArray) cmd = fu_struct_legion_get_pl_test_new();
+	g_autoptr(GByteArray) tp_man = fu_struct_legion_get_pl_test_result_new();
+
+	if (fu_device_get_proxy(FU_DEVICE(self)) == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
+		return FALSE;
+	}
+
+	fu_struct_legion_get_pl_test_set_index(cmd, FU_LEGION_HID2_PL_TEST_TP_MANUFACTURER);
+
+	if (!fu_legion_hid2_child_device_transfer(self, cmd, tp_man, error))
+		return FALSE;
+
+	self->manufacturer = fu_struct_legion_get_pl_test_result_get_content(tp_man);
+	switch (self->manufacturer) {
+	case FU_LEGION_HID2_TP_MAN_BETTER_LIFE:
+		fu_device_set_vendor(device, "Better Life");
+		fu_device_add_instance_strsafe(FU_DEVICE(self), "TP", "BL");
+		break;
+	case FU_LEGION_HID2_TP_MAN_SIPO:
+		fu_device_set_vendor(device, "SIPO");
+		fu_device_add_instance_strsafe(FU_DEVICE(self), "TP", "SIPO");
+		break;
+	default:
+	case FU_LEGION_HID2_TP_MAN_NONE:
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "no touchpad found");
+		return FALSE;
+	}
+	fu_device_build_instance_id(FU_DEVICE(self), NULL, "USB", "VID", "PID", "TP", NULL);
+
+	return TRUE;
+}
+
+static gboolean
+fu_legion_hid2_child_device_setup(FuDevice *device, GError **error)
+{
+	FuLegionHid2ChildDevice *self = FU_LEGION_HID2_CHILD_DEVICE(device);
+	g_autoptr(GByteArray) cmd = fu_struct_legion_get_pl_test_new();
+	g_autoptr(GByteArray) tp_ver = fu_struct_legion_get_pl_test_result_new();
+	g_autofree gchar *version = NULL;
+
+	if (fu_device_get_proxy(FU_DEVICE(self)) == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no proxy");
+		return FALSE;
+	}
+
+	fu_struct_legion_get_pl_test_set_index(cmd, FU_LEGION_HID2_PL_TEST_TP_VERSION);
+
+	if (!fu_legion_hid2_child_device_transfer(self, cmd, tp_ver, error))
+		return FALSE;
+
+	version = g_strdup_printf("%d", fu_struct_legion_get_pl_test_result_get_content(tp_ver));
+	fu_device_set_version(device, version);
+
+	return TRUE;
+}
+
+static void
+fu_legion_hid2_child_device_init(FuLegionHid2ChildDevice *self)
+{
+	fu_device_set_name(FU_DEVICE(self), "Touchpad");
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PROXY_FALLBACK);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REFCOUNTED_PROXY);
+	fu_device_add_protocol(FU_DEVICE(self), "com.lenovo.legion-hid2");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_NUMBER);
+	fu_device_set_logical_id(FU_DEVICE(self), "touchpad");
+}
+
+static void
+fu_legion_hid2_child_device_class_init(FuLegionHid2ChildDeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->to_string = fu_legion_hid2_child_device_to_string;
+	device_class->setup = fu_legion_hid2_child_device_setup;
+	device_class->probe = fu_legion_hid2_child_device_probe;
+}
+
+FuDevice *
+fu_legion_hid2_child_device_new(FuDevice *proxy)
+{
+	return g_object_new(FU_TYPE_LEGION_HID2_CHILD_DEVICE, "proxy", proxy, NULL);
+}

--- a/plugins/legion-hid2/fu-legion-hid2-child-device.h
+++ b/plugins/legion-hid2/fu-legion-hid2-child-device.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 Mario Limonciello <superm1@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_LEGION_HID2_CHILD_DEVICE (fu_legion_hid2_child_device_get_type())
+G_DECLARE_FINAL_TYPE(FuLegionHid2ChildDevice,
+		     fu_legion_hid2_child_device,
+		     FU,
+		     LEGION_HID2_CHILD_DEVICE,
+		     FuDevice)
+
+FuDevice *
+fu_legion_hid2_child_device_new(FuDevice *proxy) G_GNUC_NON_NULL(1);

--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -118,10 +118,14 @@ fu_legion_hid2_device_probe(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+/*
+ * older MCU firmware doesn't support TP child commands, so setup needs to
+ * to be non-fatal or the MCU won't enumerate.
+ */
 static void
-fu_legion_hid2_device_setup_child(FuDevice *device)
+fu_legion_hid2_device_setup_child(FuLegionHid2Device *self)
 {
-	g_autoptr(FuDevice) child = fu_legion_hid2_child_device_new(device);
+	g_autoptr(FuDevice) child = fu_legion_hid2_child_device_new(FU_DEVICE(self));
 	g_autoptr(GError) error_child = NULL;
 
 	if (!fu_device_probe(child, &error_child)) {
@@ -134,7 +138,7 @@ fu_legion_hid2_device_setup_child(FuDevice *device)
 		return;
 	}
 
-	fu_device_add_child(device, child);
+	fu_device_add_child(FU_DEVICE(self), child);
 }
 
 static gboolean
@@ -154,7 +158,7 @@ fu_legion_hid2_device_setup(FuDevice *device, GError **error)
 	if (!fu_legion_hid2_device_ensure_mcu_id(device, error))
 		return FALSE;
 
-	fu_legion_hid2_device_setup_child(device);
+	fu_legion_hid2_device_setup_child(FU_LEGION_HID2_DEVICE(device));
 
 	/* success */
 	return TRUE;

--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include "fu-legion-hid2-child-device.h"
 #include "fu-legion-hid2-device.h"
 #include "fu-legion-hid2-firmware.h"
 #include "fu-legion-hid2-struct.h"
@@ -117,6 +118,25 @@ fu_legion_hid2_device_probe(FuDevice *device, GError **error)
 	return TRUE;
 }
 
+static void
+fu_legion_hid2_device_setup_child(FuDevice *device)
+{
+	g_autoptr(FuDevice) child = fu_legion_hid2_child_device_new(device);
+	g_autoptr(GError) error_child = NULL;
+
+	if (!fu_device_probe(child, &error_child)) {
+		g_info("%s", error_child->message);
+		return;
+	}
+
+	if (!fu_device_setup(child, &error_child)) {
+		g_info("%s", error_child->message);
+		return;
+	}
+
+	fu_device_add_child(device, child);
+}
+
 static gboolean
 fu_legion_hid2_device_setup(FuDevice *device, GError **error)
 {
@@ -133,6 +153,8 @@ fu_legion_hid2_device_setup(FuDevice *device, GError **error)
 
 	if (!fu_legion_hid2_device_ensure_mcu_id(device, error))
 		return FALSE;
+
+	fu_legion_hid2_device_setup_child(device);
 
 	/* success */
 	return TRUE;

--- a/plugins/legion-hid2/fu-legion-hid2-plugin.c
+++ b/plugins/legion-hid2/fu-legion-hid2-plugin.c
@@ -5,6 +5,7 @@
 
 #include "config.h"
 
+#include "fu-legion-hid2-child-device.h"
 #include "fu-legion-hid2-device.h"
 #include "fu-legion-hid2-firmware.h"
 #include "fu-legion-hid2-plugin.h"
@@ -25,6 +26,8 @@ fu_legion_hid2_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID2_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID2_CHILD_DEVICE);
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LEGION_HID2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_LEGION_HID2_FIRMWARE);
 }
 

--- a/plugins/legion-hid2/fu-legion-hid2.rs
+++ b/plugins/legion-hid2/fu-legion-hid2.rs
@@ -6,8 +6,23 @@
 enum FuLegionHid2Command {
     GetVersion = 0x01,
     GetMcuId = 0x02,
+    GetPlTest = 0xDF,
     StartIap = 0xE1,
     IcReset = 0xEF,
+}
+
+#[repr(u8)]
+enum FuLegionHid2PlTest {
+    TpManufacturer = 0x2,
+    AgSensorManufacturer = 0x3,
+    TpVersion = 0x4,
+}
+
+#[repr(u8)]
+enum FuLegionHid2TpMan {
+    None = 0x0,
+    BetterLife = 0x1,
+    Sipo = 0x2,
 }
 
 #[repr(u8)]
@@ -41,6 +56,22 @@ struct FuStructLegionGetMcuId {
 struct FuStructLegionMcuId {
     id: [u8; 12],
     reserved: [u8; 52],
+}
+
+#[derive(New, Default)]
+#[repr(C, packed)]
+struct FuStructLegionGetPlTest {
+    cmd: u8 == 0xDF,
+    index: u8,
+}
+
+#[derive(New, Getters)]
+#[repr(C, packed)]
+struct FuStructLegionGetPlTestResult {
+    cmd: u8,
+    index: u8,
+    content: u8,
+    reserved: [u8; 61],
 }
 
 #[derive(New, Default)]

--- a/plugins/legion-hid2/meson.build
+++ b/plugins/legion-hid2/meson.build
@@ -6,6 +6,7 @@ plugin_builtins += static_library('fu_plugin_legion_hid2',
   rustgen.process('fu-legion-hid2.rs'),
   sources: [
     'fu-legion-hid2-device.c',
+    'fu-legion-hid2-child-device.c',
     'fu-legion-hid2-plugin.c',
     'fu-legion-hid2-firmware.c',
   ],

--- a/plugins/legion-hid2/tests/legion-hid2.json
+++ b/plugins/legion-hid2/tests/legion-hid2.json
@@ -3,11 +3,11 @@
   "interactive": false,
   "steps": [
     {
-      "url": "76ea95f3d3fa893a70de6716a9b34115365f4cb3ac57f290190ce9de20935f9d-firmware.cab",
-      "emulation-url": "05162d6d3cf6c595da613fcd5c57415022c08e57a76454b7c19de533492bc3f2-legion-hid2.zip",
+      "url": "7976f433d469946007e29682c84f87d87696c4a667d3f82fb2e22dd2d15f2d6c-0_0_3_6.cab",
+      "emulation-url": "8897ce2e5215fdd13d033aff1700253afe84231f47cd34b9d2ecf797682eb3ab-legionhid2_0036.zip",
       "components": [
         {
-          "version": "0.0.2.4",
+          "version": "0.0.3.6",
           "guids": [
             "65619675-fec6-5035-801d-7f5e59fd9749"
           ]


### PR DESCRIPTION
On Legion-hid2 devices the touchpad is connected to the MCU and some information can be queried from that. Create child devices as such.

Update support for this device will be later - this is read only for now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
