### PR TITLE
intel-cvs: Do not wait for the device to 'come back'

### DIFF
--- a/plugins/intel-cvs/fu-intel-cvs-device.c
+++ b/plugins/intel-cvs/fu-intel-cvs-device.c
@@ -222,8 +222,7 @@ fu_intel_cvs_device_write_firmware(FuDevice *device,
 		}
 	}
 
-	/* wait for hardware to re-appear */
-	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	/* success */
 	return TRUE;
 }
 


### PR DESCRIPTION
The ioext-main branch of usbio cannot cope with a device replug.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
