### PR TITLE
synaptics-vmm9: add delay between rc_disable and rc_enable

### DIFF
--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -330,6 +330,7 @@ fu_synaptics_vmm9_device_open(FuDevice *device, GError **error)
 		g_prefix_error(error, "failed to DISABLE_RC before ENABLE_RC: ");
 		return FALSE;
 	}
+	fu_device_sleep(device, 10);
 	if (!fu_synaptics_vmm9_device_command(self,
 					      FU_SYNAPTICS_VMM9_RC_CTRL_ENABLE_RC,
 					      0x0, /* offset */


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation


There is a timing issue where `RC_CMD_ENABLE` intercepts `RC_CMD_DISABLE` and continues to receive status report from previous command (i.e. `RC_CMD_DISABLE`).  Adding 500 ms delay between `disable` and `enable` givens sufficient time to ensure that `RC_CMD_DISABLE` is completed.

<details>

```

01:50:56.124 FuDevice             using 963961de6b2409c2b3185b18fd3d322bd136ae7c for 3-1.3.4.2
01:50:56.125 FuPluginSynapticsVmm9 FuStructHidSetCommand:
  size: 0xc
  payload: FuStructHidPayload:
  cap: 0x0
  state: 0x0
  ctrl: 0x82 [disable-rc-busy]
  sts: 0x0 [success]
  offset: 0x0
  length: 0x0
  fifo: 0x7200000000000000000000000000000000000000000000000000000000000000
  checksum: 0x0
01:50:56.125 FuHidDevice          HID::SetReport [wValue=0x0201, wIndex=0]:
01 00 0c 00 00 82 00 00 00 00 00 00 00 00 00 72 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
01:50:56.125 FuPluginSynapticsVmm9 FuStructHidSetCommand:
  size: 0x11
  payload: FuStructHidPayload:
  cap: 0x0
  state: 0x0
  ctrl: 0x81 [enable-rc-busy]
  sts: 0x0 [success]
  offset: 0x0
  length: 0x5
  fifo: 0x5052495553000000000000000000000000000000000000000000000000000000
  checksum: 0xd6
01:50:56.125 FuHidDevice          HID::SetReport [wValue=0x0201, wIndex=0]:
01 00 11 00 00 81 00 00 00 00 00 05 00 00 00 50 52 49 55 53 00 00 00 00 00 00 00 00 00 00 00 00 
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d6 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
01:50:56.125 FuHidDevice          HID::GetReport [wValue=0x0101, wIndex=0]:
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
01:50:56.125 FuHidDevice          HID::GetReport [wValue=0x0101, wIndex=0]:
01 00 2c b4 00 02 04 00 00 00 00 05 00 00 00 50 52 49 55 53 00 00 00 00 00 00 00 00 00 00 00 00 
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 81 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
01:50:56.125 FuStruct             FuStructHidGetCommand:
  size: 0x2c
  payload: FuStructHidPayload:
  cap: 0xb4
  state: 0x0
  ctrl: 0x2 [disable-rc]
  sts: 0x4 [disabled]
  offset: 0x0
  length: 0x5
  fifo: 0x5052495553000000000000000000000000000000000000000000000000000000
  checksum: 0x81

```

</details>

[disabled.txt](https://github.com/user-attachments/files/20403441/disabled.txt)
