### PR TITLE
Use the UEFI PK report attributes for the other UEFI plugins

### DIFF
--- a/plugins/uefi-db/fu-uefi-db-plugin.c
+++ b/plugins/uefi-db/fu-uefi-db-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_uefi_db_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DB_DEVICE);
 }
 

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -86,6 +86,7 @@ fu_uefi_dbx_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_capsule");
+	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EFI_SIGNATURE_LIST);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DBX_DEVICE);
 

--- a/plugins/uefi-kek/fu-uefi-kek-plugin.c
+++ b/plugins/uefi-kek/fu-uefi-kek-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_uefi_kek_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_KEK_DEVICE);
 }
 


### PR DESCRIPTION
This fixes 19bd0257 to actually work from other plugins.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
