### PR TITLE
trivial: thunderbolt: set all gen 3 controllers as signed

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -343,6 +343,8 @@ fu_thunderbolt_controller_setup(FuDevice *device, GError **error)
 	/* set up signed payload attribute */
 	if (self->controller_kind == FU_THUNDERBOLT_CONTROLLER_KIND_HOST && self->gen >= 3)
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	else if (self->gen == 3)
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
The only vendor for TBT3 controllers is Intel, and all the Intel controllers use signed payloads.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
