### PR TITLE
Add new device support with ccgx-dmc plugin

### DIFF
--- a/plugins/ccgx-dmc/ccgx-dmc.quirk
+++ b/plugins/ccgx-dmc/ccgx-dmc.quirk
@@ -1,3 +1,11 @@
+# Lenovo ThinkPad Thunderbolt 5 Smart Dock
+[USB\VID_17EF&PID_310D]
+Plugin = ccgx_dmc
+Summary = Dock Management Controller Device
+Name = ThinkPad Thunderbolt 5 Smart Dock
+CcgxDmcTriggerCode = 1200
+RemoveDelay = 120000
+
 # Lenovo ThinkPad Universal USB-C Dock
 [USB\VID_17EF&PID_30A9]
 Plugin = ccgx_dmc

--- a/plugins/ccgx-dmc/ccgx-dmc.quirk
+++ b/plugins/ccgx-dmc/ccgx-dmc.quirk
@@ -5,7 +5,7 @@ Summary = Dock Management Controller Device
 Name = ThinkPad Thunderbolt 5 Smart Dock
 CcgxDmcTriggerCode = 0x01
 InstallDuration = 1200
-RemoveDelay = 120000
+RemoveDelay = 1200000
 
 # Lenovo ThinkPad Universal USB-C Dock
 [USB\VID_17EF&PID_30A9]

--- a/plugins/ccgx-dmc/ccgx-dmc.quirk
+++ b/plugins/ccgx-dmc/ccgx-dmc.quirk
@@ -3,7 +3,8 @@
 Plugin = ccgx_dmc
 Summary = Dock Management Controller Device
 Name = ThinkPad Thunderbolt 5 Smart Dock
-CcgxDmcTriggerCode = 1200
+CcgxDmcTriggerCode = 0x01
+InstallDuration = 1200
 RemoveDelay = 120000
 
 # Lenovo ThinkPad Universal USB-C Dock

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -299,8 +299,10 @@ fu_ccgx_dmc_devx_device_probe(FuDevice *device, GError **error)
 
 	/* version, if possible */
 	if (device_version_type == FU_CCGX_DMC_DEVX_DEVICE_TYPE_DMC) {
-		version = fu_ccgx_dmc_devx_device_version_dmc_bfw(self, offset);
-		fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
+		/*version = fu_ccgx_dmc_devx_device_version_dmc_bfw(self, offset);*/
+		/*fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);*/
+                version = fu_ccgx_dmc_devx_device_version_dmc_app(self, offset);
+                fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	} else if (device_version_type == FU_CCGX_DMC_DEVX_DEVICE_TYPE_HX3) {
 		version = fu_ccgx_dmc_devx_device_version_hx3(self, offset);
 		fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);


### PR DESCRIPTION
Main changes with below items:
- [ 1] Add thunderbolt 5 smart dock support with ccgx-dmc plugin 
- [ 2] Code fix-Change dmc version format from QUAD to TRIPLET for ccgx-dmc plugin
