### PR TITLE
legion-hid2: Allow downgrades without --force

### DIFF
--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -172,7 +172,6 @@ fu_legion_hid2_device_prepare_firmware(FuDevice *device,
 				       GError **error)
 {
 	guint32 version;
-	g_autofree gchar *version_str = NULL;
 	g_autoptr(FuFirmware) firmware = fu_legion_hid2_firmware_new();
 
 	/* sanity check */
@@ -181,18 +180,9 @@ fu_legion_hid2_device_prepare_firmware(FuDevice *device,
 
 	version = fu_legion_hid2_firmware_get_version(firmware);
 	if (fu_device_get_version_raw(device) > version) {
-		version_str = fu_version_from_uint32(version, FWUPD_VERSION_FORMAT_QUAD);
-		if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "downgrading from %s to %s is not supported",
-				    fu_device_get_version(device),
-				    version_str);
-			return NULL;
-		}
-		g_warning("firmware %s is a downgrade but is being force installed anyway",
-			  version_str);
+		g_autofree gchar *version_str =
+		    fu_version_from_uint32(version, FWUPD_VERSION_FORMAT_QUAD);
+		g_info("downgrading to firmware %s", version_str);
 	}
 
 	return g_steal_pointer(&firmware);


### PR DESCRIPTION
Downgrades need to be opted in from the client and this will work as long as the firmware doesn't reject it.  If/when the firmware rejects it, it will happen at end of process instead.

See https://github.com/fwupd/fwupd/issues/8841

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
