### PR TITLE
trivial: fix a mismatch of flags

### DIFF
--- a/libfwupd/README.md
+++ b/libfwupd/README.md
@@ -4,7 +4,6 @@
 
 * Typedef `FwupdFeatureFlags` to `guint64` so it's the same size on all platforms
 * Remove `FWUPD_INSTALL_FLAG_IGNORE_CHECKSUM`
-* Remove `FWUPD_INSTALL_FLAG_IGNORE_VID_PID`
 * Remove `FWUPD_INSTALL_FLAG_NO_SEARCH`
 
 ## Migration from Version 2.0.0

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1109,7 +1109,7 @@ typedef enum {
 	/**
 	 * FWUPD_INSTALL_FLAG_NO_SEARCH:
 	 *
-	 * This is now unused; see #FuFirmwareParseFlags.
+	 * This is now only for internal use.
 	 *
 	 * Since: 1.5.0
 	 */

--- a/src/fu-engine-requirements.c
+++ b/src/fu-engine-requirements.c
@@ -297,7 +297,7 @@ fu_engine_requirements_check_firmware(FuEngine *self,
 
 	/* vendor ID */
 	if (g_strcmp0(xb_node_get_text(req), "vendor-id") == 0) {
-		if (flags & FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID)
+		if (flags & FWUPD_INSTALL_FLAG_IGNORE_VID_PID)
 			return TRUE;
 		return fu_engine_requirements_check_vendor_id(self, req, device_actual, error);
 	}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4667,7 +4667,7 @@ fu_engine_get_result_from_component(FuEngine *self,
 		cabinet,
 		component,
 		rel,
-		FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_REINSTALL |
+		FWUPD_INSTALL_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_REINSTALL |
 		    FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH | FWUPD_INSTALL_FLAG_ALLOW_OLDER,
 		&error_reqs)) {
 		if (!fu_device_has_inhibit(dev, "not-found"))
@@ -5157,7 +5157,7 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) releases_tmp = NULL;
 	FwupdInstallFlags install_flags =
-	    FU_FIRMWARE_PARSE_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH |
+	    FWUPD_INSTALL_FLAG_IGNORE_VID_PID | FWUPD_INSTALL_FLAG_ALLOW_BRANCH_SWITCH |
 	    FWUPD_INSTALL_FLAG_ALLOW_REINSTALL | FWUPD_INSTALL_FLAG_ALLOW_OLDER;
 
 	/* get all releases */


### PR DESCRIPTION
A few cases regressed in 6dd024dbaaefb54d464646a479f63765835f4d8f that parse flags were passed where install flags are used.

This shouldn't be a functional problem because they had the same meaning though.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
