### PR TITLE
fu-tool: drop an extra call to prompt for reboot

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1544,7 +1544,7 @@ fu_util_install(FuUtilPrivate *priv, gchar **values, GError **error)
 	}
 
 	/* success */
-	return fu_util_prompt_complete(priv->console, priv->completion_flags, TRUE, error);
+	return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
Reboot is already prompted by all callers to fu_util_install(), it's
not necessary to call for individual releases.

Fixes: #8846

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
