### PR TITLE
Add a new check-reboot-needed command

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -1,6 +1,7 @@
 _fwupdmgr_cmd_list=(
 	'activate'
 	'block-firmware'
+	'check-reboot-needed'
 	'clear-results'
 	'disable-remote'
 	'device-test'
@@ -312,7 +313,7 @@ _fwupdmgr()
 	esac
 
 	case $arg in
-	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update|get-updates|switch-branch|update|upgrade|report-export)
+	activate|check-reboot-needed|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update|get-updates|switch-branch|update|upgrade|report-export)
 		#device ID
 		if [[ "$args" = "2" ]]; then
 			_show_device_ids

--- a/data/tests/fwupdmgr.sh
+++ b/data/tests/fwupdmgr.sh
@@ -284,5 +284,16 @@ echo "Run security tests (json)..."
 fwupdmgr security --json
 rc=$?; if [ $rc != $EXPECTED ]; then error $rc; fi
 
+# ---
+echo "Check reboot behavior"
+fwupdmgr quit
+fwupdtool modify-config test NeedsReboot true
+rc=$?; if [ $rc != 0 ]; then error $rc; fi
+fwupdmgr update $device -y
+rc=$?; if [ $rc != 0 ]; then error $rc; fi
+fwupdmgr check-reboot-needed $device --json
+rc=$?; if [ $rc != 0 ]; then error $rc; fi
+fwupdtool modify-config test NeedsReboot false
+
 # success!
 exit 0


### PR DESCRIPTION
The check-reboot-needed command when run in json mode will return 0
if a reboot is needed or NOTHING_TO_DO if it's not.

When run in interactive mode it will prompt for reboot.

Fixes: #8816

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
