### PR TITLE
Use strerrordesc_np() to avoid locale-specific low level error messages

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -216,6 +216,7 @@ class Checker:
             "g_byte_array_free_to_bytes(": "Use g_bytes_new() instead",
             "g_ascii_strtoull(": "Use fu_strtoull() instead",
             "g_ascii_strtoll(": "Use fu_strtoll() instead",
+            "g_strerror(": "Use fwupd_strerror() instead",
             "g_random_int_range(": "Use a predicatable token instead",
             "g_assert(": "Use g_set_error() or g_return_val_if_fail() instead",
             "HIDIOCSFEATURE": "Use fu_hidraw_device_set_feature() instead",

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -535,7 +535,7 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "failed to seek: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return NULL;
 	}
 	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(fd, TRUE));

--- a/libfwupd/fwupd-error.c
+++ b/libfwupd/fwupd-error.c
@@ -250,3 +250,22 @@ fwupd_error_convert(GError **perror)
 	error->domain = FWUPD_ERROR;
 	error->code = FWUPD_ERROR_INTERNAL;
 }
+
+/**
+ * fwupd_strerror:
+ *
+ * Returns an untranslated string corresponding to the given error code, e.g. “no such process”.
+ *
+ * Returns: string describing the error code
+ *
+ * Since: 2.0.11
+ **/
+const gchar *
+fwupd_strerror(gint errnum) /* nocheck:name */
+{
+#ifdef HAVE_STRERRORDESC_NP
+	return strerrordesc_np(errnum);
+#else
+	return g_strerror(errnum); /* nocheck:blocked */
+#endif
+}

--- a/libfwupd/fwupd-error.h
+++ b/libfwupd/fwupd-error.h
@@ -206,5 +206,7 @@ FwupdError
 fwupd_error_from_string(const gchar *error);
 void
 fwupd_error_convert(GError **perror);
+const gchar *
+fwupd_strerror(gint errnum);
 
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1021,3 +1021,9 @@ LIBFWUPD_2.0.10 {
     fwupd_codec_json_append_map;
   local: *;
 } LIBFWUPD_2.0.7;
+
+LIBFWUPD_2.0.11 {
+  global:
+    fwupd_strerror;
+  local: *;
+} LIBFWUPD_2.0.10;

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -118,7 +118,7 @@ fu_io_channel_seek(FuIOChannel *self, gsize offset, GError **error)
 #endif
 			    "failed to seek to 0x%04x: %s",
 			    (guint)offset,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return FALSE;
 	}
@@ -284,7 +284,7 @@ fu_io_channel_write_raw(FuIOChannel *self,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_NOT_FOUND,
 					    "failed to write: %s",
-					    g_strerror(errno));
+					    fwupd_strerror(errno));
 				return FALSE;
 			}
 			g_set_error(error,
@@ -333,7 +333,7 @@ fu_io_channel_write_raw(FuIOChannel *self,
 						    FWUPD_ERROR,
 						    FWUPD_ERROR_NOT_FOUND,
 						    "failed to write: %s",
-						    g_strerror(errno));
+						    fwupd_strerror(errno));
 					return FALSE;
 				}
 				g_set_error(error,
@@ -342,7 +342,7 @@ fu_io_channel_write_raw(FuIOChannel *self,
 					    "failed to write %" G_GSIZE_FORMAT " bytes to %i: %s",
 					    datasz,
 					    self->fd,
-					    g_strerror(errno));
+					    fwupd_strerror(errno));
 				return FALSE;
 			}
 			if (flags & FU_IO_CHANNEL_FLAG_SINGLE_SHOT)
@@ -429,7 +429,7 @@ fu_io_channel_read_byte_array(FuIOChannel *self,
 #endif
 					    "failed to read %i: %s",
 					    self->fd,
-					    g_strerror(errno));
+					    fwupd_strerror(errno));
 				fwupd_error_convert(error);
 				return NULL;
 			}
@@ -478,7 +478,7 @@ fu_io_channel_read_byte_array(FuIOChannel *self,
 #endif
 					    "failed to read %i: %s",
 					    self->fd,
-					    g_strerror(errno));
+					    fwupd_strerror(errno));
 				fwupd_error_convert(error);
 				return NULL;
 			}
@@ -659,7 +659,7 @@ fu_io_channel_new_file(const gchar *filename, FuIoChannelOpenFlag open_flags, GE
 #endif
 			    "failed to open %s: %s",
 			    filename,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return NULL;
 	}
@@ -697,7 +697,7 @@ fu_io_channel_virtual_new(const gchar *name, GError **error)
 #endif
 			    "failed to create %s: %s",
 			    name,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return NULL;
 	}

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -76,7 +76,7 @@ fu_linux_efivars_set_immutable_fd(int fd, gboolean value, gboolean *value_old, G
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "failed to get flags: %s",
-				    g_strerror(errno));
+				    fwupd_strerror(errno));
 			return FALSE;
 		}
 	} else {
@@ -105,7 +105,7 @@ fu_linux_efivars_set_immutable_fd(int fd, gboolean value, gboolean *value_old, G
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to set flags: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	return TRUE;
@@ -128,7 +128,7 @@ fu_linux_efivars_set_immutable(const gchar *fn, gboolean value, gboolean *value_
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_FOUND,
 			    "failed to open: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	istr = g_unix_input_stream_new(fd, TRUE);
@@ -448,7 +448,7 @@ fu_linux_efivars_set_data(FuEfivars *efivars,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "failed to open %s: %s",
 			    fn,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	ostr = g_unix_output_stream_new(fd, TRUE);

--- a/libfwupdplugin/fu-path.c
+++ b/libfwupdplugin/fu-path.c
@@ -152,7 +152,7 @@ fu_path_mkdir(const gchar *dirname, GError **error)
 			    FWUPD_ERROR_INTERNAL,
 			    "Failed to create '%s': %s",
 			    dirname,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	return TRUE;
@@ -601,7 +601,7 @@ fu_path_make_absolute(const gchar *filename, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot resolve path: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return NULL;
 	}
 #else
@@ -610,7 +610,7 @@ fu_path_make_absolute(const gchar *filename, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "cannot resolve path: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return NULL;
 	}
 #endif

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -1245,7 +1245,7 @@ fu_udev_device_ioctl(FuUdevDevice *self,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "ioctl error: %s [%i]",
-			    g_strerror(errno),
+			    fwupd_strerror(errno),
 			    errno);
 #else
 		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "unspecified ioctl error");
@@ -1334,7 +1334,7 @@ fu_udev_device_pread(FuUdevDevice *self, goffset port, guint8 *buf, gsize bufsz,
 #endif
 			    "failed to read from port 0x%04x: %s",
 			    (guint)port,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return FALSE;
 	}
@@ -1442,7 +1442,7 @@ fu_udev_device_pwrite(FuUdevDevice *self,
 #endif
 			    "failed to write to port %04x: %s",
 			    (guint)port,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return FALSE;
 	}

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -508,7 +508,7 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 		g_set_error_literal(error,
 				    G_IO_ERROR, /* nocheck:error */
 				    g_io_error_from_errno(errno),
-				    g_strerror(errno));
+				    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 		return 0;
 	}
@@ -517,7 +517,7 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 		g_set_error_literal(error,
 				    G_IO_ERROR, /* nocheck:error */
 				    g_io_error_from_errno(errno),
-				    g_strerror(errno));
+				    fwupd_strerror(errno));
 		fwupd_error_convert(error);
 	} else if (sector_size == 0) {
 		g_set_error_literal(error,

--- a/meson.build
+++ b/meson.build
@@ -446,6 +446,9 @@ endif
 if cc.has_function('memfd_create')
   conf.set('HAVE_MEMFD_CREATE', '1')
 endif
+if cc.has_function('strerrordesc_np')
+  conf.set('HAVE_STRERRORDESC_NP', '1')
+endif
 if cc.has_header_symbol('locale.h', 'LC_MESSAGES')
   conf.set('HAVE_LC_MESSAGES', '1')
 endif

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -182,7 +182,7 @@ fu_amd_gpu_device_set_marketing_name(FuAmdGpuDevice *self)
 			fu_device_set_name(FU_DEVICE(self), marketing_name);
 		amdgpu_device_deinitialize(device_handle);
 	} else
-		g_warning("unable to set marketing name: %s", g_strerror(r));
+		g_warning("unable to set marketing name: %s", fwupd_strerror(r));
 }
 
 static gboolean

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -571,7 +571,7 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to open socket: %s",
 #ifdef HAVE_ERRNO_H
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 #else
 			    "unspecified error");
 #endif

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -793,7 +793,7 @@ fu_bcm57xx_recovery_device_open(FuDevice *device, GError **error)
 				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "could not mmap %s: %s",
 				    fn,
-				    g_strerror(errno));
+				    fwupd_strerror(errno));
 			return FALSE;
 		}
 	}

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -344,11 +344,11 @@ static const gchar *
 fu_dell_dock_hid_tbt_map_error(guint32 code)
 {
 	if (code == 1)
-		return g_strerror(EINVAL);
+		return fwupd_strerror(EINVAL);
 	if (code == 2)
-		return g_strerror(EPERM);
+		return fwupd_strerror(EPERM);
 
-	return g_strerror(EIO);
+	return fwupd_strerror(EIO);
 }
 
 gboolean

--- a/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
@@ -52,7 +52,7 @@ fu_mm_mhi_qcdm_device_search_path_locker_new(FuMmMhiQcdmDevice *self, GError **e
 			    FWUPD_ERROR_INTERNAL,
 			    "Failed to create '%s': %s",
 			    mm_fw_dir,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return NULL;
 	}
 	locker = fu_kernel_search_path_locker_new(mm_fw_dir, error);

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -138,7 +138,7 @@ fu_vbe_simple_device_open(FuDevice *device, GError **error)
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "cannot open %s [%s]",
 			    self->devname,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 #else
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -316,7 +316,7 @@ fu_vbe_simple_device_write_firmware_img(FuVbeSimpleDevice *self,
 			    "cannot seek file '%s' to 0x%x [%s]",
 			    self->devname,
 			    (guint)seek_to,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 #else
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -337,7 +337,7 @@ fu_vbe_simple_device_write_firmware_img(FuVbeSimpleDevice *self,
 			    FWUPD_ERROR_WRITE,
 			    "cannot write file '%s' [%s]",
 			    self->devname,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 #else
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -403,7 +403,7 @@ fu_vbe_simple_device_upload(FuDevice *device, FuProgress *progress, GError **err
 			    "cannot seek file %s to 0x%x [%s]",
 			    self->devname,
 			    (guint)self->area_start,
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 #else
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/src/fu-polkit-agent.c
+++ b/src/fu-polkit-agent.c
@@ -209,7 +209,7 @@ fu_polkit_agent_open(FuPolkitAgent *self, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_NOT_SUPPORTED,
 			    "failed to create pipe: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 
@@ -227,7 +227,7 @@ fu_polkit_agent_open(FuPolkitAgent *self, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "failed to fork TTY ask password agent: %s",
-			    g_strerror(-r));
+			    fwupd_strerror(-r));
 		fu_polkit_agent_close_nointr_nofail(pipe_fd[1]);
 		fu_polkit_agent_close_nointr_nofail(pipe_fd[0]);
 		return FALSE;

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -542,7 +542,7 @@ fu_udev_backend_netlink_setup(FuUdevBackend *self, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "failed to connect to netlink: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	if (bind(self->netlink_fd, (void *)&nls, sizeof(nls))) {
@@ -550,7 +550,7 @@ fu_udev_backend_netlink_setup(FuUdevBackend *self, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "bind to udev socket failed: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	source = g_unix_fd_source_new(self->netlink_fd, G_IO_IN);

--- a/src/fu-unix-seekable-input-stream.c
+++ b/src/fu-unix-seekable-input-stream.c
@@ -8,6 +8,8 @@
 
 #include "config.h"
 
+#include "fwupd-error.h"
+
 #include "fu-unix-seekable-input-stream.h"
 
 struct _FuUnixSeekableInputStream {
@@ -29,7 +31,7 @@ fu_unix_seekable_input_stream_tell(GSeekable *seekable)
 {
 	goffset rc = lseek(g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(seekable)), 0, SEEK_CUR);
 	if (rc < 0)
-		g_critical("cannot tell FuUnixSeekableInputStream: %s", g_strerror(errno));
+		g_critical("cannot tell FuUnixSeekableInputStream: %s", fwupd_strerror(errno));
 	return rc;
 }
 
@@ -75,7 +77,7 @@ fu_unix_seekable_input_stream_seek(GSeekable *seekable,
 			    G_IO_ERROR, /* nocheck:error */
 			    g_io_error_from_errno(errno),
 			    "Error seeking file descriptor: %s",
-			    g_strerror(errno));
+			    fwupd_strerror(errno));
 		return FALSE;
 	}
 	return TRUE;


### PR DESCRIPTION
Some of the LVFS known issue rules fail to match when the error code is translated.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
