### PR TITLE
Process all pending event sources when waiting for replug

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -1016,7 +1016,9 @@ fu_device_list_wait_for_replug(FuDeviceList *self, GError **error)
 	do {
 		g_autoptr(GPtrArray) devices_wfr_tmp = NULL;
 		g_usleep(1000);
-		g_main_context_iteration(NULL, FALSE);
+		while (g_main_context_iteration(NULL, FALSE)) {
+			/* nothing needs to be done here */
+		};
 		devices_wfr_tmp = fu_device_list_get_wait_for_replug(self);
 		if (devices_wfr_tmp->len == 0)
 			break;


### PR DESCRIPTION
This ensures that if we process all the pending events -- which could be a *lot* in the case of composite devices like docks.

We shouldn't have to set a longer timeout just to process pending events.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
