### PR TITLE
modem-manager: Parse the correct VendorID from the device ID

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -145,10 +145,13 @@ static void
 fu_mm_device_add_instance_id(FuMmDevice *self, const gchar *device_id)
 {
 	if (g_pattern_match_simple("???\\VID_????", device_id)) {
-		g_autofree gchar *vendor_id = g_strdup_printf("USB:0x%s", device_id + 8);
+		g_autofree gchar *prefix = g_strndup(device_id, 3);
+		g_autofree gchar *vendor_id = NULL;
+
 		fu_device_add_instance_id_full(FU_DEVICE(self),
 					       device_id,
 					       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+		vendor_id = g_strdup_printf("%s:0x%s", prefix, device_id + 8);
 		fu_device_add_vendor_id(FU_DEVICE(self), vendor_id);
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/8864

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
