### PR TITLE
logitech-hidpp: rdfu: increase timeout requested by device

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -798,9 +798,11 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 		g_autoptr(GError) error_local = NULL;
 
 		/* wait for requested time or event */
+		/* NB: waiting longer than `rdfu_wait` breaks the specification;
+		 * unfortunately, some early firmware versions require this. */
 		if (!fu_logitech_hidpp_receive(FU_UDEV_DEVICE(self),
 					       msg_in_wait,
-					       priv->rdfu_wait * 2, /* be tolerant */
+					       priv->rdfu_wait * 3, /* be tolerant */
 					       &error_local)) {
 			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 				g_debug("ignored error: %s", error_local->message);


### PR DESCRIPTION
Waiting longer than `rdfu_wait` breaks the specification; unfortunately, some early firmware versions require this.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
