### PR TITLE
logitech-hidpp: do not create radio for RDFU-capable devices

### DIFF
--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -423,6 +423,7 @@ fu_logitech_hidpp_device_fetch_firmware_info(FuLogitechHidppDevice *self, GError
 
 	/* the device is probably in bootloader mode and the last SoftDevice FW upgrade failed */
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_LOGITECH_HIDPP_DEVICE_FLAG_ADD_RADIO) &&
+	    !fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU) &&
 	    !radio_ok) {
 		g_debug("no radio found, creating a fake one for recovery");
 		if (!fu_logitech_hidpp_device_create_radio_child(self, 1, 0, error)) {

--- a/plugins/logitech-hidpp/logitech-hidpp.quirk
+++ b/plugins/logitech-hidpp/logitech-hidpp.quirk
@@ -196,13 +196,6 @@ GType = FuLogitechHidppDevice
 Flags = add-radio,ble,rebind-attach,no-request-required
 InstallDuration = 270
 
-# MX Mechanical
-[HIDRAW\VEN_046D&MOD_B34E00000000]
-Plugin = logitech_hidpp
-GType = FuLogitechHidppDevice
-Flags = ~add-radio
-InstallDuration = 308
-
 # MX Mechanical (BLE direct)
 [HIDRAW\VEN_046D&DEV_B34E]
 Plugin = logitech_hidpp


### PR DESCRIPTION
If the device announces support for the x00d1 feature, do not force the creation of an unnecessary radio device.

Don't need the entry in quirk file for RDFU-capable devices attached via Bolt receiver anymore.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ x] Code fix
- [ ] Feature
- [ ] Documentation
