### PR TITLE
Introduce an option to disable probing anything that stops a device working momentarily

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -118,6 +118,7 @@ fwupd_modify_config_opts=(
 	'P2pPolicy'
 	'ReleaseDedupe'
 	'ReleasePriority'
+	'RequireImmutableEnumeration'
 	'ShowDevicePrivate'
 	'TestDevices'
 	'TrustedReports'

--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -120,6 +120,7 @@ fwupd_modify_config_opts=(
 	'P2pPolicy'
 	'ReleaseDedupe'
 	'ReleasePriority'
+	'RequireImmutableEnumeration'
 	'ShowDevicePrivate'
 	'TestDevices'
 	'TrustedReports'
@@ -378,7 +379,7 @@ _fwupdtool()
 			return 0
 		elif [[ "$args" = "4" ]]; then
 			case $prev in
-			EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|TestDevices)
+			EnumerateAllDevices|OnlyTrusted|IgnorePower|UpdateMotd|ShowDevicePrivate|ReleaseDedupe|RequireImmutableEnumeration|TestDevices)
 				COMPREPLY=( $(compgen -W "True False" -- "$cur") )
 				;;
 			AnotherWriteRequired|NeedsActivation|NeedsReboot|RegistrationSupported|RequestSupported|WriteSupported)

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -139,6 +139,12 @@ The `[fwupd]` section can contain the following parameters:
   Set the preferred location used for the EFI system partition (ESP) path.
   This is typically used if UDisks was not able to automatically identify the location for any reason.
 
+**RequireImmutableEnumeration={{RequireImmutableEnumeration}}**
+
+  Don't allow fwupd plugins to directly interact with devices during probe or setup stages.
+  The kernel should provide all device information in sysfs files or udev properties.
+  This will block some plugins from working.
+
 **Manufacturer=**
 
 **ProductName=**

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -433,6 +433,8 @@ fwupd_plugin_flag_to_string(FwupdPluginFlags plugin_flag)
 		return "ready";
 	if (plugin_flag == FWUPD_PLUGIN_FLAG_TEST_ONLY)
 		return "test-only";
+	if (plugin_flag == FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION)
+		return "mutable-enumeration";
 	return NULL;
 }
 
@@ -489,6 +491,8 @@ fwupd_plugin_flag_from_string(const gchar *plugin_flag)
 		return FWUPD_PLUGIN_FLAG_READY;
 	if (g_strcmp0(plugin_flag, "test-only") == 0)
 		return FWUPD_PLUGIN_FLAG_TEST_ONLY;
+	if (g_strcmp0(plugin_flag, "mutable-enumeration") == 0)
+		return FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION;
 	return FWUPD_PLUGIN_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -1026,6 +1026,15 @@ typedef enum {
 	 */
 	FWUPD_PLUGIN_FLAG_TEST_ONLY = 1ull << 18,
 	/**
+	 * FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION:
+	 *
+	 * Some devices supported by the plugin may cause a device to momentarily
+	 * stop working while probing.
+	 *
+	 * Since: 2.0.12
+	 */
+	FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION = 1ull << 19,
+	/**
 	 * FWUPD_PLUGIN_FLAG_UNKNOWN:
 	 *
 	 * The plugin flag is unknown.

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -182,3 +182,7 @@ Remember: Plugins should be upstream!
 ## 2.0.11
 
 * `fu_device_read_firmware()`: Add `FuFirmwareParseFlags` to `fu_device_read_firmware`.
+
+## 2.0.12
+
+* Plugins that don't allow devices to function 100% through probe should use `FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION`

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -187,6 +187,7 @@ fu_config_migrate_keyfile(FuConfig *self)
 			  {"fwupd", "VerboseDomains", NULL},
 			  {"fwupd", "OnlyTrusted", NULL},
 			  {"fwupd", "IgnorePower", NULL},
+			  {"fwupd", "RequireImmutableEnumeration", NULL},
 			  {"fwupd", "DisabledPlugins", "test;test_ble;invalid"},
 			  {"fwupd", "DisabledPlugins", "test;test_ble"},
 			  {"redfish", "IpmiDisableCreateUser", NULL},

--- a/plugins/aver-hid/fu-aver-hid-plugin.c
+++ b/plugins/aver-hid/fu-aver-hid-plugin.c
@@ -20,6 +20,7 @@ G_DEFINE_TYPE(FuAverHidPlugin, fu_aver_hid_plugin, FU_TYPE_PLUGIN)
 static void
 fu_aver_hid_plugin_init(FuAverHidPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/ccgx/fu-ccgx-plugin.c
+++ b/plugins/ccgx/fu-ccgx-plugin.c
@@ -21,6 +21,7 @@ G_DEFINE_TYPE(FuCcgxPlugin, fu_ccgx_plugin, FU_TYPE_PLUGIN)
 static void
 fu_ccgx_plugin_init(FuCcgxPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/cfu/fu-cfu-plugin.c
+++ b/plugins/cfu/fu-cfu-plugin.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE(FuCfuPlugin, fu_cfu_plugin, FU_TYPE_PLUGIN)
 static void
 fu_cfu_plugin_init(FuCfuPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -304,6 +304,7 @@ fu_dell_dock_plugin_composite_cleanup(FuPlugin *plugin, GPtrArray *devices, GErr
 static void
 fu_dell_dock_plugin_init(FuDellDockPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
@@ -456,6 +456,7 @@ fu_dell_kestrel_plugin_prepare(FuPlugin *plugin,
 static void
 fu_dell_kestrel_plugin_init(FuDellKestrelPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/elan-kbd/fu-elan-kbd-plugin.c
+++ b/plugins/elan-kbd/fu-elan-kbd-plugin.c
@@ -21,6 +21,7 @@ G_DEFINE_TYPE(FuElanKbdPlugin, fu_elan_kbd_plugin, FU_TYPE_PLUGIN)
 static void
 fu_elan_kbd_plugin_init(FuElanKbdPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/ep963x/fu-ep963x-plugin.c
+++ b/plugins/ep963x/fu-ep963x-plugin.c
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(FuEp963XPlugin, fu_ep963x_plugin, FU_TYPE_PLUGIN)
 static void
 fu_ep963x_plugin_init(FuEp963XPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -21,6 +21,7 @@ G_DEFINE_TYPE(FuGenesysPlugin, fu_genesys_plugin, FU_TYPE_PLUGIN)
 static void
 fu_genesys_plugin_init(FuGenesysPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE(FuHpiCfuPlugin, fu_hpi_cfu_plugin, FU_TYPE_PLUGIN)
 static void
 fu_hpi_cfu_plugin_init(FuHpiCfuPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/jabra-file/fu-jabra-file-plugin.c
+++ b/plugins/jabra-file/fu-jabra-file-plugin.c
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(FuJabraFilePlugin, fu_jabra_file_plugin, FU_TYPE_PLUGIN)
 static void
 fu_jabra_file_plugin_init(FuJabraFilePlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -24,6 +24,7 @@ G_DEFINE_TYPE(FuLogitechHidppPlugin, fu_logitech_hidpp_plugin, FU_TYPE_PLUGIN)
 static void
 fu_logitech_hidpp_plugin_init(FuLogitechHidppPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
@@ -21,6 +21,7 @@ G_DEFINE_TYPE(FuQcS5gen2Plugin, fu_qc_s5gen2_plugin, FU_TYPE_PLUGIN)
 static void
 fu_qc_s5gen2_plugin_init(FuQcS5gen2Plugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/qsi-dock/fu-qsi-dock-plugin.c
+++ b/plugins/qsi-dock/fu-qsi-dock-plugin.c
@@ -20,6 +20,7 @@ G_DEFINE_TYPE(FuQsiDockPlugin, fu_qsi_dock_plugin, FU_TYPE_PLUGIN)
 static void
 fu_qsi_dock_plugin_init(FuQsiDockPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/rp-pico/fu-rp-pico-plugin.c
+++ b/plugins/rp-pico/fu-rp-pico-plugin.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE(FuRpPicoPlugin, fu_rp_pico_plugin, FU_TYPE_PLUGIN)
 static void
 fu_rp_pico_plugin_init(FuRpPicoPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/rts54hid/fu-rts54hid-plugin.c
+++ b/plugins/rts54hid/fu-rts54hid-plugin.c
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(FuRts54HidPlugin, fu_rts54hid_plugin, FU_TYPE_PLUGIN)
 static void
 fu_rts54hid_plugin_init(FuRts54HidPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-plugin.c
+++ b/plugins/steelseries/fu-steelseries-plugin.c
@@ -26,6 +26,7 @@ G_DEFINE_TYPE(FuSteelseriesPlugin, fu_steelseries_plugin, FU_TYPE_PLUGIN)
 static void
 fu_steelseries_plugin_init(FuSteelseriesPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
@@ -20,6 +20,7 @@ G_DEFINE_TYPE(FuSynapticsCapePlugin, fu_synaptics_cape_plugin, FU_TYPE_PLUGIN)
 static void
 fu_synaptics_cape_plugin_init(FuSynapticsCapePlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(FuSynapticsCxaudioPlugin, fu_synaptics_cxaudio_plugin, FU_TYPE_PLU
 static void
 fu_synaptics_cxaudio_plugin_init(FuSynapticsCxaudioPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(FuSynapticsVmm9Plugin, fu_synaptics_vmm9_plugin, FU_TYPE_PLUGIN)
 static void
 fu_synaptics_vmm9_plugin_init(FuSynapticsVmm9Plugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/telink-dfu/fu-telink-dfu-plugin.c
+++ b/plugins/telink-dfu/fu-telink-dfu-plugin.c
@@ -20,6 +20,7 @@ G_DEFINE_TYPE(FuTelinkDfuPlugin, fu_telink_dfu_plugin, FU_TYPE_PLUGIN)
 static void
 fu_telink_dfu_plugin_init(FuTelinkDfuPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/usi-dock/fu-usi-dock-plugin.c
+++ b/plugins/usi-dock/fu-usi-dock-plugin.c
@@ -84,6 +84,7 @@ fu_usi_dock_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 static void
 fu_usi_dock_plugin_init(FuUsiDockPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/vendor-example/fu-vendor-example-plugin.c.in
+++ b/plugins/vendor-example/fu-vendor-example-plugin.c.in
@@ -19,6 +19,7 @@ G_DEFINE_TYPE(Fu{{VendorExample}}Plugin, fu_{{vendor_example}}_plugin, FU_TYPE_P
 static void
 fu_{{vendor_example}}_plugin_init(Fu{{VendorExample}}Plugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-plugin.c
+++ b/plugins/wacom-usb/fu-wac-plugin.c
@@ -93,6 +93,7 @@ fu_wac_plugin_composite_cleanup(FuPlugin *self, GPtrArray *devices, GError **err
 static void
 fu_wac_plugin_init(FuWacPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/plugins/wistron-dock/fu-wistron-dock-plugin.c
+++ b/plugins/wistron-dock/fu-wistron-dock-plugin.c
@@ -18,6 +18,7 @@ G_DEFINE_TYPE(FuWistronDockPlugin, fu_wistron_dock_plugin, FU_TYPE_PLUGIN)
 static void
 fu_wistron_dock_plugin_init(FuWistronDockPlugin *self)
 {
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
 }
 
 static void

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -359,6 +359,12 @@ fu_engine_config_get_enumerate_all_devices(FuEngineConfig *self)
 	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "EnumerateAllDevices");
 }
 
+gboolean
+fu_engine_config_get_require_immutable_enumeration(FuEngineConfig *self)
+{
+	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "RequireImmutableEnumeration");
+}
+
 const gchar *
 fu_engine_config_get_host_bkc(FuEngineConfig *self)
 {
@@ -419,6 +425,7 @@ fu_engine_config_init(FuEngineConfig *self)
 	fu_engine_config_set_default(self, "P2pPolicy", FU_DEFAULT_P2P_POLICY);
 	fu_engine_config_set_default(self, "ReleaseDedupe", "true");
 	fu_engine_config_set_default(self, "ReleasePriority", "local");
+	fu_engine_config_set_default(self, "RequireImmutableEnumeration", "false");
 	fu_engine_config_set_default(self, "ShowDevicePrivate", "true");
 	fu_engine_config_set_default(self, "TestDevices", "false");
 	fu_engine_config_set_default(self, "TrustedReports", "VendorId=$OEM");

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -39,6 +39,8 @@ fu_engine_config_get_update_motd(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
 fu_engine_config_get_enumerate_all_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
+fu_engine_config_get_require_immutable_enumeration(FuEngineConfig *self);
+gboolean
 fu_engine_config_get_ignore_power(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
 fu_engine_config_get_only_trusted(FuEngineConfig *self) G_GNUC_NON_NULL(1);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -863,17 +863,29 @@ fu_engine_modify_config(FuEngine *self,
 	/* check keys are valid */
 	if (g_strcmp0(section, "fwupd") == 0) {
 		const gchar *keys[] = {
-		    "ArchiveSizeMax",	 "ApprovedFirmware",
-		    "BlockedFirmware",	 "DisabledDevices",
-		    "DisabledPlugins",	 "EnumerateAllDevices",
-		    "EspLocation",	 "HostBkc",
-		    "IdleTimeout",	 "IgnorePower",
-		    "OnlyTrusted",	 "P2pPolicy",
-		    "ReleaseDedupe",	 "ReleasePriority",
-		    "ShowDevicePrivate", "TestDevices",
-		    "TrustedReports",	 "TrustedUids",
-		    "UpdateMotd",	 "UriSchemes",
-		    "VerboseDomains",	 NULL,
+		    "ArchiveSizeMax",
+		    "ApprovedFirmware",
+		    "BlockedFirmware",
+		    "DisabledDevices",
+		    "DisabledPlugins",
+		    "EnumerateAllDevices",
+		    "EspLocation",
+		    "HostBkc",
+		    "IdleTimeout",
+		    "IgnorePower",
+		    "OnlyTrusted",
+		    "P2pPolicy",
+		    "ReleaseDedupe",
+		    "ReleasePriority",
+		    "RequireImmutableEnumeration",
+		    "ShowDevicePrivate",
+		    "TestDevices",
+		    "TrustedReports",
+		    "TrustedUids",
+		    "UpdateMotd",
+		    "UriSchemes",
+		    "VerboseDomains",
+		    NULL,
 		};
 		if (!g_strv_contains(keys, key)) {
 			g_set_error(error,
@@ -6521,6 +6533,14 @@ fu_engine_is_uid_trusted(FuEngine *self, guint64 calling_uid)
 	return FALSE;
 }
 
+gboolean
+fu_engine_plugin_allows_enumeration(FuEngine *self, FuPlugin *plugin)
+{
+	if (!fu_engine_config_get_require_immutable_enumeration(self->config))
+		return TRUE;
+	return !fu_plugin_has_flag(plugin, FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION);
+}
+
 static gboolean
 fu_engine_is_test_plugin_disabled(FuEngine *self, FuPlugin *plugin)
 {
@@ -7346,7 +7366,8 @@ fu_engine_plugins_init(FuEngine *self, FuProgress *progress, GError **error)
 		/* is disabled */
 		if (fu_engine_is_plugin_name_disabled(self, name) ||
 		    fu_engine_is_test_plugin_disabled(self, plugin) ||
-		    !fu_engine_is_plugin_name_enabled(self, name)) {
+		    !fu_engine_is_plugin_name_enabled(self, name) ||
+		    !fu_engine_plugin_allows_enumeration(self, plugin)) {
 			g_ptr_array_add(plugins_disabled, g_strdup(name));
 			fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_DISABLED);
 			fu_progress_step_done(progress);

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -289,3 +289,5 @@ fu_engine_fix_host_security_attr(FuEngine *self, const gchar *appstream_id, GErr
 gboolean
 fu_engine_undo_host_security_attr(FuEngine *self, const gchar *appstream_id, GError **error)
     G_GNUC_NON_NULL(1, 2);
+gboolean
+fu_engine_plugin_allows_enumeration(FuEngine *self, FuPlugin *plugin) G_GNUC_NON_NULL(1, 2);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -1648,6 +1648,7 @@ fu_util_plugin_flag_to_cli_text(FwupdPluginFlags plugin_flag)
 	case FWUPD_PLUGIN_FLAG_DISABLED:
 	case FWUPD_PLUGIN_FLAG_NO_HARDWARE:
 	case FWUPD_PLUGIN_FLAG_TEST_ONLY:
+	case FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION:
 		return fu_console_color_format(plugin_flag_str, FU_CONSOLE_COLOR_BLACK);
 	case FWUPD_PLUGIN_FLAG_LEGACY_BIOS:
 	case FWUPD_PLUGIN_FLAG_CAPSULES_UNSUPPORTED:


### PR DESCRIPTION
If a device stops working (even for a moment) while probing it should be forbidden from being probed.

This will block all HID devices that don't use Hidraw.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
