### PR TITLE
uefi-capsule: Make tar a dependency of the tests

### DIFF
--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -537,7 +537,7 @@ fu_uefi_plugin_nvram_func(void)
 	/* check UX splash was created */
 	g_assert_true(fu_uefi_plugin_esp_file_exists(
 	    esp,
-	    "EFI/" EFI_OS_DIR "/fw/fwupd-3b8c8162-188c-46a4-aec9-be43f1d65697.cap"));
+	    "EFI/" EFI_OS_DIR "/fw/fwupd-" FU_EFIVARS_GUID_UX_CAPSULE ".cap"));
 	g_assert_true(fu_efivars_exists(fu_context_get_efivars(ctx),
 					FU_EFIVARS_GUID_FWUPDATE,
 					"fwupd-ux-capsule"));
@@ -586,7 +586,7 @@ fu_uefi_plugin_nvram_func(void)
 	/* check both files and variables no longer exist */
 	g_assert_false(fu_uefi_plugin_esp_file_exists(
 	    esp,
-	    "EFI/" EFI_OS_DIR "/fw/fwupd-3b8c8162-188c-46a4-aec9-be43f1d65697.cap"));
+	    "EFI/" EFI_OS_DIR "/fw/fwupd-" FU_EFIVARS_GUID_UX_CAPSULE ".cap"));
 	g_assert_false(fu_efivars_exists(fu_context_get_efivars(ctx),
 					 FU_EFIVARS_GUID_FWUPDATE,
 					 "fwupd-ux-capsule"));

--- a/plugins/uefi-capsule/meson.build
+++ b/plugins/uefi-capsule/meson.build
@@ -69,6 +69,7 @@ if get_option('efi_binary')
   efi_binary = dependency('fwupd-efi', version: '>= 1.6', fallback: ['fwupd-efi', 'fwupd_efi_dep'])
 endif
 
+ux_capsule_tar = []
 if get_option('plugin_uefi_capsule_splash')
   # add the archive of pregenerated images
   splash_deps = run_command([
@@ -79,7 +80,7 @@ if get_option('plugin_uefi_capsule_splash')
   if splash_deps.returncode() != 0
     error(splash_deps.stderr().strip())
   endif
-  custom_target('ux-capsule-tar',
+  ux_capsule_tar = custom_target('ux-capsule-tar',
     input: [
       join_paths(meson.project_source_root(), 'po', 'LINGUAS'),
       files('make-images.py'),
@@ -108,6 +109,7 @@ if get_option('tests')
     rustgen.process('fu-uefi.rs'),
     uefi_insyde_blob,
     fwupdx64_efi_signed,
+    ux_capsule_tar,
     sources: [
       'fu-self-test.c',
     ],
@@ -149,4 +151,3 @@ summary({
   'capsule splash': get_option('plugin_uefi_capsule_splash'),
 }, section:'uefi capsule options')
 endif
-


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

---

When running the tests without running `meson compile` or `meson install`, one of the tests would fail due to missing `uefi-capsule-ux.tar.xz`. This PR adds a dependency of `ux-capsule-tar` to the tests, so that `meson test` would create `uefi-capsule-ux.tar.xz` if it doesn't already exist.

In addition I removed the literal `3b8c8162-188c-46a4-aec9-be43f1d65697` uuids with `FU_EFIVARS_GUID_UX_CAPSULE`.