### PR TITLE
Update igsc.quirk for Intel Arc Battlemage products

### DIFF
--- a/plugins/intel-gsc/igsc.quirk
+++ b/plugins/intel-gsc/igsc.quirk
@@ -123,6 +123,14 @@ Name = ATS-M3
 Flags = has-aux,has-oprom
 
 [PCI\VEN_8086&DEV_E20B]
+Name = Arc B580
 Flags = has-oprom
 [PCI\VEN_8086&DEV_E20C]
+Name = Arc B570
+Flags = has-oprom
+[PCI\VEN_8086&DEV_E211]
+Name = Arc Pro B60
+Flags = has-oprom
+[PCI\VEN_8086&DEV_E212]
+Name = Arc Pro B50
 Flags = has-oprom


### PR DESCRIPTION
This PR updates the intel-gsc/igsc.quirk with the following:
- Adds Arc Pro B50 and B60 Battlemage products.
- Adds `Name` param for each existing & new Battlemage product.