### PR TITLE
modem-manager: Allow multiple GTypes for Quectel EC25/EG25

### DIFF
--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -120,7 +120,6 @@ Summary = Foxconn T99W696.00 5G modem
 
 # Quectel EG25-G/EC25
 [USB\VID_2C7C&PID_0125]
-GType = FuMmFastbootDevice
 Summary = Quectel EG25-G/EC25 modem
 Flags = detach-at-fastboot-has-no-response
 Plugin = modem_manager


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation

Quectel EC25/EG25 allow updating with either DFOTA, Firehose or Fastboot.
Fall back to ModemManager's `get_update_settings` for those devices since setting the `GType = ` quirk does not allow more than one type.