### PR TITLE
redfish: improve Dell server handling

### DIFF
--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -647,7 +647,9 @@ fu_redfish_device_parse_message_id(FuRedfishDevice *self,
 		return TRUE;
 
 	/* set flags */
-	if (g_pattern_match_simple("Base.*.ResetRequired", message_id)) {
+	if (g_pattern_match_simple("Base.*.ResetRequired", message_id) ||
+	    g_pattern_match_simple("IDRAC.*.JCP001", message_id) ||
+	    g_pattern_match_simple("IDRAC.*.RED014", message_id)) {
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 		return TRUE;
 	}
@@ -796,7 +798,8 @@ fu_redfish_device_poll_task_once(FuRedfishDevice *self, FuRedfishDevicePollCtx *
 	}
 	state_tmp = json_object_get_string_member(json_obj, "TaskState");
 	g_debug("TaskState now %s", state_tmp);
-	if (g_strcmp0(state_tmp, "Completed") == 0) {
+	if (g_strcmp0(state_tmp, "Completed") == 0 ||
+	    fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT)) {
 		ctx->completed = TRUE;
 		return TRUE;
 	}

--- a/plugins/redfish/fu-redfish-device.c
+++ b/plugins/redfish/fu-redfish-device.c
@@ -421,6 +421,17 @@ fu_redfish_device_probe_oem_dell(FuRedfishDevice *self, JsonObject *json_object,
 						   FU_REDFISH_DEVICE_FLAG_IS_BACKUP);
 	}
 
+	if (json_object_has_member(software_info, "Id")) {
+		const gchar *status = json_object_get_string_member(software_info, "Id");
+		if (g_ascii_strncasecmp(status, "DCIM:INSTALLED", 12) != 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "firmware is in repository");
+			return FALSE;
+		}
+	}
+
 	/* it does not seem that Dell allows targeting a device when updating */
 	fu_device_add_private_flag(FU_DEVICE(self), FU_REDFISH_DEVICE_FLAG_WILDCARD_TARGETS);
 

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -109,7 +109,14 @@ fu_redfish_multipart_device_write_firmware(FuDevice *device,
 	part = curl_mime_addpart(mime);
 	curl_mime_name(part, "UpdateFile");
 	(void)curl_mime_type(part, "application/octet-stream");
-	(void)curl_mime_filename(part, "firmware.bin");
+
+	if (fu_redfish_backend_get_vendor(backend) != NULL &&
+	    g_strcmp0(fu_redfish_backend_get_vendor(backend), "Dell") == 0) {
+		/* Dell's iDRAC requires a specific filename to know in advance how to flash it */
+		(void)curl_mime_filename(part, "firmware.exe");
+	} else {
+		(void)curl_mime_filename(part, "firmware.bin");
+	}
 	(void)curl_mime_data(part, g_bytes_get_data(fw, NULL), g_bytes_get_size(fw));
 
 	(void)curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
@@ -124,6 +131,7 @@ fu_redfish_multipart_device_write_firmware(FuDevice *device,
 					FU_REDFISH_REQUEST_PERFORM_FLAG_LOAD_JSON,
 					error))
 		return FALSE;
+
 	if (fu_redfish_request_get_status_code(request) != 202) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -23,6 +23,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(curl_mime, curl_mime_free)
 static GString *
 fu_redfish_multipart_device_get_parameters(FuRedfishMultipartDevice *self)
 {
+	FuRedfishBackend *backend = fu_redfish_device_get_backend(FU_REDFISH_DEVICE(self));
 	g_autoptr(GString) str = g_string_new(NULL);
 	g_autoptr(JsonBuilder) builder = json_builder_new();
 	g_autoptr(JsonGenerator) json_generator = json_generator_new();
@@ -37,8 +38,15 @@ fu_redfish_multipart_device_get_parameters(FuRedfishMultipartDevice *self)
 		json_builder_add_string_value(builder, logical_id);
 	}
 	json_builder_end_array(builder);
+
 	json_builder_set_member_name(builder, "@Redfish.OperationApplyTime");
-	json_builder_add_string_value(builder, "Immediate");
+	if (fu_redfish_backend_get_vendor(backend) != NULL &&
+	    g_strcmp0(fu_redfish_backend_get_vendor(backend), "Dell") == 0) {
+		json_builder_add_string_value(builder, "OnReset");
+	} else {
+		json_builder_add_string_value(builder, "Immediate");
+	}
+
 	json_builder_end_object(builder);
 
 	/* export as a string */

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -135,7 +135,8 @@ fu_redfish_request_load_json(FuRedfishRequest *self, GByteArray *buf, GError **e
 		else if (g_strcmp0(id, "SMC.1.0.OemLicenseNotPassed") == 0)
 			error_code = FWUPD_ERROR_NOT_SUPPORTED;
 		else if (g_strcmp0(id, "SMC.1.0.OemFirmwareAlreadyInUpdateMode") == 0 ||
-			 g_strcmp0(id, "SMC.1.0.OemBiosUpdateIsInProgress") == 0)
+			 g_strcmp0(id, "SMC.1.0.OemBiosUpdateIsInProgress") == 0 ||
+			 g_pattern_match_simple("IDRAC.*.RED014", id))
 			error_code = FWUPD_ERROR_ALREADY_PENDING;
 		g_set_error_literal(error, FWUPD_ERROR, error_code, msg);
 		return FALSE;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

This PR should allow installing firmware on Dell server platforms using a recent version of iDRAC. It's a bit "dell specific" in the way it is implemented but I wanted to make sure it does not break anything else.

Note: Unfortunately, I could not find a way to check whether a firmware was already queued or not. The job information is very scarce and just show "Network firmware" (which is not helpful at all). So I ended up doing what the BMC itself (and Dell's example Redfish scripts in their repo) do: upload the firmware and depending on the task result, simply continue.
The other issue I had is having two devices displayed, but sharing the same firmware: I thought about deduplicating them (because if you already show one and all the devices are going to be updated based on their model number, you might as well...) but I did not want to deal with the case where you put the same device with an older firmware and not showing because of it. So it's a bit slower, but I'm not sure we can really do better unless Dell implements a better way somewhere.