### PR TITLE
Allow plugins to know the firmware filename

### DIFF
--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -195,7 +195,7 @@ fu_engine_install_release(FuEngine *self,
 gboolean
 fu_engine_install_blob(FuEngine *self,
 		       FuDevice *device,
-		       GInputStream *stream_fw,
+		       FuRelease *release,
 		       FuProgress *progress,
 		       FwupdInstallFlags flags,
 		       FwupdFeatureFlags feature_flags,

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -54,6 +54,8 @@ FuDevice *
 fu_release_get_device(FuRelease *self) G_GNUC_NON_NULL(1);
 GInputStream *
 fu_release_get_stream(FuRelease *self) G_GNUC_NON_NULL(1);
+void
+fu_release_set_stream(FuRelease *self, GInputStream *stream) G_GNUC_NON_NULL(1, 2);
 FuEngineRequest *
 fu_release_get_request(FuRelease *self) G_GNUC_NON_NULL(1);
 GPtrArray *
@@ -64,6 +66,8 @@ const gchar *
 fu_release_get_update_request_id(FuRelease *self) G_GNUC_NON_NULL(1);
 const gchar *
 fu_release_get_device_version_old(FuRelease *self) G_GNUC_NON_NULL(1);
+const gchar *
+fu_release_get_firmware_basename(FuRelease *self) G_GNUC_NON_NULL(1);
 
 void
 fu_release_set_request(FuRelease *self, FuEngineRequest *request) G_GNUC_NON_NULL(1);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -3167,6 +3167,7 @@ fu_engine_install_loop_restart_func(gconstpointer user_data)
 	g_autoptr(FuEngine) engine = fu_engine_new(self->ctx);
 	g_autoptr(FuPlugin) plugin = fu_plugin_new_from_gtype(fu_test_plugin_get_type(), self->ctx);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GInputStream) stream_fw = NULL;
 	g_autoptr(XbSilo) silo_empty = xb_silo_new();
@@ -3207,14 +3208,15 @@ fu_engine_install_loop_restart_func(gconstpointer user_data)
 	fu_device_set_metadata_integer(device, "nr-attach", 0);
 
 	stream_fw = g_memory_input_stream_new_from_data((const guint8 *)"1.2.3", 5, NULL);
-	ret =
-	    fu_engine_install_blob(engine,
-				   device,
-				   stream_fw,
-				   progress,
-				   FWUPD_INSTALL_FLAG_NO_HISTORY | FU_FIRMWARE_PARSE_FLAG_CACHE_STREAM,
-				   FWUPD_FEATURE_FLAG_NONE,
-				   &error);
+	fu_release_set_stream(release, stream_fw);
+	ret = fu_engine_install_blob(engine,
+				     device,
+				     release,
+				     progress,
+				     FWUPD_INSTALL_FLAG_NO_HISTORY |
+					 FU_FIRMWARE_PARSE_FLAG_CACHE_STREAM,
+				     FWUPD_FEATURE_FLAG_NONE,
+				     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3685,6 +3687,7 @@ fu_engine_install_request(gconstpointer user_data)
 	ret = fu_release_load(release, cabinet, component, NULL, FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
+	g_assert_cmpstr(fu_release_get_firmware_basename(release), ==, "firmware.bin");
 
 	g_signal_connect(FU_ENGINE(engine),
 			 "device-request",

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1038,6 +1038,7 @@ static gboolean
 fu_util_install_blob(FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuRelease) release = fu_release_new();
 	g_autoptr(GInputStream) stream_fw = NULL;
 
 	/* progress */
@@ -1062,6 +1063,7 @@ fu_util_install_blob(FuUtilPrivate *priv, gchar **values, GError **error)
 		fu_util_maybe_prefix_sandbox_error(values[0], error);
 		return FALSE;
 	}
+	fu_release_set_stream(release, stream_fw);
 	fu_progress_step_done(priv->progress);
 
 	/* load engine */
@@ -1105,7 +1107,7 @@ fu_util_install_blob(FuUtilPrivate *priv, gchar **values, GError **error)
 	priv->flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
 	if (!fu_engine_install_blob(priv->engine,
 				    device,
-				    stream_fw,
+				    release,
 				    fu_progress_get_child(priv->progress),
 				    priv->flags,
 				    fu_engine_request_get_feature_flags(priv->request),


### PR DESCRIPTION
This means passing around the FuRelease for longer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
