### PR TITLE
heci: Handle unknown/unsupported status (0x0b) for Dell hardware

### DIFF
--- a/libfwupdplugin/fu-heci-device.c
+++ b/libfwupdplugin/fu-heci-device.c
@@ -30,6 +30,7 @@ fu_heci_device_result_to_error(FuMkhiStatus result, GError **error)
 		return TRUE;
 
 	switch (result) {
+	case FU_MKHI_STATUS_UNKNOWN_PERHAPS_NOT_SUPPORTED:
 	case FU_MKHI_STATUS_NOT_SUPPORTED:
 	case FU_MKHI_STATUS_NOT_AVAILABLE:
 	case FU_MKHI_STATUS_NOT_SET:

--- a/libfwupdplugin/fu-heci.rs
+++ b/libfwupdplugin/fu-heci.rs
@@ -22,6 +22,7 @@ enum FuMkhiStatus {
     InvalidState,
     MessageSkipped,
     SizeError = 0x05,
+    UnknownPerhapsNotSupported = 0x0b, // guessed
     NotSet = 0x0F, // guessed
     NotAvailable = 0x18, // guessed
     InvalidAccess = 0x84,


### PR DESCRIPTION
Some Dell systems were failing with "mei0: failed to setup: generic failure [0xb]" due to an unrecognized HECI status code. This patch:

1. Adds FU_MKHI_STATUS_UNKNOWN_PERHAPS_NOT_SUPPORTED enum value for status 0x0b
2. Treats this status as non-fatal in fu_heci_device_result_to_error()

This matches the observed behavior where the status appears to indicate unsupported functionality rather than an actual error condition.

Fixes: https://github.com/fwupd/fwupd/issues/8878

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
