### PR TITLE
Abstract out the sleep-after-phase functionality

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1277,6 +1277,12 @@ void
 fu_device_set_pid(FuDevice *self, guint16 pid);
 
 void
+fu_device_set_phase_delay(FuDevice *self, FuDevicePhaseDelay phase_sleep, guint delay_ms)
+    G_GNUC_NON_NULL(1);
+guint
+fu_device_get_phase_delay(FuDevice *self, FuDevicePhaseDelay phase_sleep) G_GNUC_NON_NULL(1);
+
+void
 fu_device_set_update_state(FuDevice *self, FwupdUpdateState update_state) G_GNUC_NON_NULL(1);
 void
 fu_device_set_context(FuDevice *self, FuContext *ctx) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-device.rs
+++ b/libfwupdplugin/fu-device.rs
@@ -9,3 +9,12 @@ enum FuDeviceInstanceFlag {
     Generic = 1 << 2, // added by a baseclass
     Counterpart = 1 << 3,
 }
+
+#[derive(ToString)]
+enum FuDevicePhaseDelay {
+    PostPrepare,
+    PostDetach,
+    PostWrite,
+    PostAttach,
+    PostCleanup,
+}

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -605,7 +605,6 @@ fu_elantp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "detach");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 30, NULL);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10, "reset");
 
 	/* simple image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -739,10 +738,6 @@ fu_elantp_hid_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* wait for a reset */
-	fu_device_sleep_full(device,
-			     ELANTP_DELAY_COMPLETE,
-			     fu_progress_get_child(progress)); /* ms */
-	fu_progress_step_done(progress);
 	return TRUE;
 }
 
@@ -950,6 +945,9 @@ fu_elantp_hid_device_init(FuElantpHidDevice *self)
 	fu_device_set_vendor(FU_DEVICE(self), "ELAN Microelectronics");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_priority(FU_DEVICE(self), 1); /* better than i2c */
+	fu_device_set_phase_delay(FU_DEVICE(self),
+				  FU_DEVICE_PHASE_DELAY_POST_WRITE,
+				  ELANTP_DELAY_COMPLETE);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_NONBLOCK);

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -431,7 +431,6 @@ fu_elantp_i2c_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 2, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 10, NULL);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 1, NULL);
 
 	/* simple image */
 	fw = fu_firmware_get_bytes(firmware, error);
@@ -532,10 +531,6 @@ fu_elantp_i2c_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* wait for a reset */
-	fu_device_sleep_full(device,
-			     ELANTP_DELAY_COMPLETE,
-			     fu_progress_get_child(progress)); /* ms */
-	fu_progress_step_done(progress);
 	return TRUE;
 }
 
@@ -784,6 +779,9 @@ fu_elantp_i2c_device_init(FuElantpI2cDevice *self)
 	fu_device_add_protocol(FU_DEVICE(self), "tw.com.emc.elantp");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_vendor(FU_DEVICE(self), "ELAN Microelectronics");
+	fu_device_set_phase_delay(FU_DEVICE(self),
+				  FU_DEVICE_PHASE_DELAY_POST_WRITE,
+				  ELANTP_DELAY_COMPLETE);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_ELANTP_I2C_DEVICE_ABSOLUTE);

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -534,7 +534,6 @@ fu_focalfp_hid_device_reload(FuDevice *device, GError **error)
 	FuFocalfpHidDevice *self = FU_FOCALFP_HID_DEVICE(device);
 	guint8 idbuf[2] = {0x0};
 
-	fu_device_sleep(device, 500);
 	if (!fu_focalfp_hid_device_read_reg(self, 0x9F, &idbuf[0], error))
 		return FALSE;
 	if (!fu_focalfp_hid_device_read_reg(self, 0xA3, &idbuf[1], error))
@@ -610,7 +609,6 @@ fu_focalfp_hid_device_detach(FuDevice *device, FuProgress *progress, GError **er
 		return FALSE;
 
 	/* success */
-	fu_device_sleep(device, 200);
 	return TRUE;
 }
 
@@ -630,7 +628,6 @@ fu_focalfp_hid_device_attach(FuDevice *device, FuProgress *progress, GError **er
 		return FALSE;
 
 	/* success */
-	fu_device_sleep(device, 500);
 	return TRUE;
 }
 
@@ -661,6 +658,9 @@ fu_focalfp_hid_device_init(FuFocalfpHidDevice *self)
 	fu_device_set_firmware_size(FU_DEVICE(self), 0x1E000);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_FOCALFP_FIRMWARE);
 	fu_device_set_summary(FU_DEVICE(self), "Forcepad");
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_DETACH, 200);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_WRITE, 500);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_ATTACH, 500);
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_INPUT_TOUCHPAD);
 	fu_device_add_protocol(FU_DEVICE(self), "tw.com.focalfp");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -682,7 +682,6 @@ static gboolean
 fu_jabra_file_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuJabraFileDevice *self = FU_JABRA_FILE_DEVICE(device);
-	fu_device_sleep_full(FU_DEVICE(self), 900000, progress);
 	fu_device_set_remove_delay(FU_DEVICE(self), 10000);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
@@ -712,6 +711,7 @@ fu_jabra_file_device_init(FuJabraFileDevice *self)
 	fu_device_add_protocol(FU_DEVICE(self), "com.jabra.file");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_JABRA_FILE_FIRMWARE);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_WRITE, 900000);
 }
 
 static void

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -557,7 +557,6 @@ fu_logitech_tap_touch_device_attach(FuDevice *device, FuProgress *progress, GErr
 		return FALSE;
 
 	/* mode switch delay for application/bootloader */
-	fu_device_sleep(FU_DEVICE(self), 100);
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success */
@@ -847,6 +846,7 @@ fu_logitech_tap_touch_device_init(FuLogitechTapTouchDevice *self)
 	fu_device_set_firmware_size_min(FU_DEVICE(self), FU_LOGITECH_TAP_TOUCH_MIN_FW_FILE_SIZE);
 	fu_device_set_firmware_size_max(FU_DEVICE(self), FU_LOGITECH_TAP_TOUCH_MAX_FW_FILE_SIZE);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_LOGITECH_TAP_TOUCH_FIRMWARE);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_ATTACH, 100);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_NONBLOCK);

--- a/plugins/modem-manager/fu-mm-dfota-device.c
+++ b/plugins/modem-manager/fu-mm-dfota-device.c
@@ -427,7 +427,6 @@ fu_mm_dfota_device_write_firmware(FuDevice *device,
 		g_prefix_error(error, "failed to start update: ");
 		return FALSE;
 	}
-	fu_device_sleep(FU_DEVICE(self), FU_MM_DFOTA_DEVICE_FOTA_RESTART_TIMEOUT_SECS * 1000);
 
 	/* success */
 	return TRUE;
@@ -471,6 +470,9 @@ static void
 fu_mm_dfota_device_init(FuMmDfotaDevice *self)
 {
 	fu_device_add_protocol(FU_DEVICE(self), "com.quectel.dfota");
+	fu_device_set_phase_delay(FU_DEVICE(self),
+				  FU_DEVICE_PHASE_DELAY_POST_WRITE,
+				  FU_MM_DFOTA_DEVICE_FOTA_RESTART_TIMEOUT_SECS * 1000);
 }
 
 static void

--- a/plugins/modem-manager/fu-mm-fdl-device.c
+++ b/plugins/modem-manager/fu-mm-fdl-device.c
@@ -40,7 +40,6 @@ fu_mm_fdl_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 	}
 
 	/* wait 15 s before reopening port */
-	fu_device_sleep(device, 15000);
 	return TRUE;
 }
 
@@ -355,6 +354,7 @@ fu_mm_fdl_device_init(FuMmFdlDevice *self)
 {
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_DETACH, 15000);
 	fu_device_add_protocol(FU_DEVICE(self), "com.cinterion.fdl");
 }
 

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-background.c
@@ -148,7 +148,6 @@ fu_rts54hub_rtd21xx_background_attach(FuDevice *device, FuProgress *progress, GE
 		g_prefix_error(error, "failed to attach: ");
 		return FALSE;
 	}
-	fu_device_sleep_full(device, 1000, progress); /* ms */
 
 	/* success */
 	return TRUE;
@@ -357,6 +356,7 @@ static void
 fu_rts54hub_rtd21xx_background_init(FuRts54hubRtd21xxBackground *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_ATTACH, 1000);
 }
 
 static void

--- a/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
+++ b/plugins/rts54hub/fu-rts54hub-rtd21xx-foreground.c
@@ -150,10 +150,6 @@ fu_rts54hub_rtd21xx_foreground_attach(FuDevice *device, FuProgress *progress, GE
 		return FALSE;
 	}
 
-	/* the device needs some time to restart with the new firmware before
-	 * it can be queried again */
-	fu_device_sleep_full(device, 60000, progress); /* ms */
-
 	/* success */
 	return TRUE;
 }
@@ -398,6 +394,7 @@ fu_rts54hub_rtd21xx_foreground_write_firmware(FuDevice *device,
 static void
 fu_rts54hub_rtd21xx_foreground_init(FuRts54hubRtd21xxForeground *self)
 {
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_ATTACH, 60000);
 }
 
 static void

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -382,8 +382,6 @@ fu_synaptics_cape_device_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_synaptics_cape_device_reset(FuSynapticsCapeDevice *self, GError **error)
 {
-	g_autoptr(GTimer) timer = g_timer_new();
-
 	g_return_val_if_fail(FU_IS_SYNAPTICS_CAPE_DEVICE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -397,10 +395,6 @@ fu_synaptics_cape_device_reset(FuSynapticsCapeDevice *self, GError **error)
 		g_prefix_error(error, "reset command is not supported: ");
 		return FALSE;
 	}
-
-	fu_device_sleep(FU_DEVICE(self), FU_SYNAPTICS_CAPE_DEVICE_USB_RESET_DELAY_MS);
-
-	g_debug("reset took %.2lfms", g_timer_elapsed(timer, NULL) * 1000);
 
 	/* success */
 	return TRUE;
@@ -760,6 +754,9 @@ fu_synaptics_cape_device_init(FuSynapticsCapeDevice *self)
 	fu_device_add_protocol(FU_DEVICE(self), "com.synaptics.cape");
 	fu_device_retry_set_delay(FU_DEVICE(self), 100); /* ms */
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_set_phase_delay(FU_DEVICE(self),
+				  FU_DEVICE_PHASE_DELAY_POST_WRITE,
+				  FU_SYNAPTICS_CAPE_DEVICE_USB_RESET_DELAY_MS);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_CAPE_DEVICE_FLAG_USE_IN_REPORT_INTERRUPT);
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -108,6 +108,7 @@ fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 	fu_device_set_summary(FU_DEVICE(self), "Multi-stream transport device");
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_VIDEO_DISPLAY);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_TRIPLET);
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_WRITE, 2000);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IGNORE_BOARD_ID);
 	fu_device_register_private_flag(FU_DEVICE(self),
@@ -1431,12 +1432,6 @@ fu_synaptics_mst_device_write_firmware(FuDevice *device,
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
-	/* progress */
-	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 90, NULL);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10, NULL);
-
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
@@ -1501,11 +1496,8 @@ fu_synaptics_mst_device_write_firmware(FuDevice *device,
 			    "Unsupported chip family");
 		return FALSE;
 	}
-	fu_progress_step_done(progress);
 
 	/* wait for flash clear to settle */
-	fu_device_sleep_full(device, 2000, fu_progress_get_child(progress)); /* ms */
-	fu_progress_step_done(progress);
 	return TRUE;
 }
 

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -316,7 +316,6 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 10, "enable-isp");
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 50, NULL);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 10, NULL);
 
 	/* open device */
 	locker = fu_device_locker_new(parent, error);
@@ -482,12 +481,7 @@ fu_vli_usbhub_rtd21xx_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 
-	/* the device needs some time to restart with the new firmware before
-	 * it can be queried again */
-	fu_device_sleep_full(device, 20000, progress); /* ms */
-
 	/* success */
-	fu_progress_step_done(progress);
 	return TRUE;
 }
 
@@ -544,6 +538,7 @@ fu_vli_usbhub_rtd21xx_device_init(FuVliUsbhubRtd21xxDevice *self)
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_set_install_duration(FU_DEVICE(self), 100); /* seconds */
 	fu_device_set_logical_id(FU_DEVICE(self), "I2C");
+	fu_device_set_phase_delay(FU_DEVICE(self), FU_DEVICE_PHASE_DELAY_POST_WRITE, 20000);
 	fu_device_retry_set_delay(FU_DEVICE(self), 30); /* ms */
 }
 


### PR DESCRIPTION
This allows us to do the sleep *after* the device is closed.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
