### PR TITLE
Add a daemon config option to ignore the efivars free space

### DIFF
--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -103,6 +103,11 @@ The `[fwupd]` section can contain the following parameters:
   child, parent or sibling.
   This is not recommended for production systems, although it may be useful for firmware development.
 
+**IgnoreEfivarsFreeSpace={{IgnoreEfivarsFreeSpace}}**
+
+  Ignore the efivars free space requirement for db, dbx, KEK and PK updates.
+  This may be required on Linux kernels older than 6.4, or where the hardware does not support UEFI `RT->QueryVariableInfo`.
+
 **OnlyTrusted={{OnlyTrusted}}**
 
   Only support installing firmware signed with a trusted key.

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -185,6 +185,10 @@ fu_context_efivars_check_free_space(FuContext *self, gsize count, GError **error
 	g_return_val_if_fail(FU_IS_CONTEXT(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	/* escape hatch */
+	if (fu_context_has_flag(self, FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE))
+		return TRUE;
+
 	total = fu_efivars_space_free(priv->efivars, error);
 	if (total == G_MAXUINT64)
 		return FALSE;

--- a/libfwupdplugin/fu-context.h
+++ b/libfwupdplugin/fu-context.h
@@ -144,6 +144,14 @@ typedef enum {
 	 * Since: 2.0.5
 	 **/
 	FU_CONTEXT_FLAG_FDE_SNAPD = 1u << 5,
+	/**
+	 * FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE:
+	 *
+	 * Ignore the efivars free space requirement for db, dbx, KEK and PK updates.
+	 *
+	 * Since: 2.0.13
+	 **/
+	FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE = 1u << 6,
 
 	/**
 	 * FU_CONTEXT_FLAG_LOADED_UNKNOWN:

--- a/src/fu-engine-config.c
+++ b/src/fu-engine-config.c
@@ -330,6 +330,12 @@ fu_engine_config_get_ignore_requirements(FuEngineConfig *self)
 }
 
 gboolean
+fu_engine_config_get_ignore_efivars_free_space(FuEngineConfig *self)
+{
+	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "IgnoreEfivarsFreeSpace");
+}
+
+gboolean
 fu_engine_config_get_release_dedupe(FuEngineConfig *self)
 {
 	return fu_config_get_value_bool(FU_CONFIG(self), "fwupd", "ReleaseDedupe");
@@ -419,6 +425,7 @@ fu_engine_config_init(FuEngineConfig *self)
 	fu_engine_config_set_default(self, "HostBkc", NULL);
 	fu_engine_config_set_default(self, "IdleTimeout", "300");		  /* s */
 	fu_engine_config_set_default(self, "IdleInhibitStartupThreshold", "500"); /* ms */
+	fu_engine_config_set_default(self, "IgnoreEfivarsFreeSpace", "false");
 	fu_engine_config_set_default(self, "IgnorePower", "false");
 	fu_engine_config_set_default(self, "IgnoreRequirements", "false");
 	fu_engine_config_set_default(self, "OnlyTrusted", "true");

--- a/src/fu-engine-config.h
+++ b/src/fu-engine-config.h
@@ -51,6 +51,8 @@ fu_engine_config_get_test_devices(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
 fu_engine_config_get_ignore_requirements(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 gboolean
+fu_engine_config_get_ignore_efivars_free_space(FuEngineConfig *self) G_GNUC_NON_NULL(1);
+gboolean
 fu_engine_config_get_release_dedupe(FuEngineConfig *self) G_GNUC_NON_NULL(1);
 FuReleasePriority
 fu_engine_config_get_release_priority(FuEngineConfig *self) G_GNUC_NON_NULL(1);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -8384,6 +8384,10 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	if (flags & FU_ENGINE_LOAD_FLAG_READONLY)
 		fu_context_add_flag(self->ctx, FU_CONTEXT_FLAG_INHIBIT_VOLUME_MOUNT);
 
+	/* required on Linux kernel < 6.4, or when `RT->QueryVariableInfo` is not supported */
+	if (fu_engine_config_get_ignore_efivars_free_space(self->config))
+		fu_context_add_flag(self->ctx, FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE);
+
 	/* load SMBIOS and the hwids */
 	if (flags & FU_ENGINE_LOAD_FLAG_HWINFO) {
 		if (!fu_context_load_hwinfo(self->ctx,


### PR DESCRIPTION
Fixes: https://github.com/fwupd/fwupd/issues/8946

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
