### PR TITLE
fix: NULL-check readline(3)

### DIFF
--- a/src/fu-console.c
+++ b/src/fu-console.c
@@ -174,6 +174,9 @@ fu_console_input_uint(FuConsole *self, guint maxnum, const gchar *format, ...)
 	do {
 		g_autofree gchar *buffer = readline(prompt);
 
+		if (buffer == NULL)
+			break;
+
 		/* get a number */
 		retval = sscanf(buffer, "%u", &answer);
 
@@ -209,7 +212,7 @@ fu_console_input_bool(FuConsole *self, gboolean def, const gchar *format, ...)
 	do {
 		g_autofree gchar *buffer = readline(prompt);
 
-		if (!strlen(buffer))
+		if (buffer == NULL || !strlen(buffer))
 			return def;
 		buffer[0] = g_ascii_toupper(buffer[0]);
 		if (g_strcmp0(buffer, "Y") == 0)


### PR DESCRIPTION
NULL is returned if a user enters just an EOF with ctrl-d without any other input.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
