### PR TITLE
Fix warning during install because of missing follow_symlinks setting

### DIFF
--- a/libfwupdplugin/tests/meson.build
+++ b/libfwupdplugin/tests/meson.build
@@ -68,7 +68,8 @@ install_data([
     'uswid.builder.xml',
     'uswid-compressed.builder.xml',
   ],
-  install_dir: join_paths(installed_test_datadir, 'tests')
+  install_dir: join_paths(installed_test_datadir, 'tests'),
+  follow_symlinks: true,
 )
 
 install_data([
@@ -105,6 +106,7 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/pending_reboot',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes'),
+  follow_symlinks: true,
 )
 install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/WlanAutoSense/current_value',
@@ -117,6 +119,7 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/WlanAutoSense/type',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/WlanAutoSense'),
+  follow_symlinks: true,
 )
 
 install_data([
@@ -131,6 +134,7 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/CustomChargeStop/type',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/CustomChargeStop'),
+  follow_symlinks: true,
 )
 
 install_data([
@@ -144,6 +148,7 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Asset/max_length',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/Asset'),
+  follow_symlinks: true,
 )
 
 install_data([
@@ -158,6 +163,7 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/BiosRcvrFrmHdd/type',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/BiosRcvrFrmHdd'),
+  follow_symlinks: true,
 )
 
 install_data([
@@ -171,4 +177,5 @@ install_data([
     'bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/SecureBoot/type',
   ],
   install_dir: join_paths(installed_test_datadir, 'tests/bios-attrs/dell-xps13-9310/dell-wmi-sysman/attributes/SecureBoot'),
+  follow_symlinks: true,
 )


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
