### PR TITLE
trivial: Set the device state to a transient failure if the power is too low

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2920,8 +2920,10 @@ fu_engine_prepare(FuEngine *self,
 	}
 	fu_device_add_problem(device, FWUPD_DEVICE_PROBLEM_UPDATE_IN_PROGRESS);
 
-	if (!fu_engine_device_check_power(self, device, flags, error))
+	if (!fu_engine_device_check_power(self, device, flags, error)) {
+		fu_device_set_update_state(device, FWUPD_UPDATE_STATE_FAILED_TRANSIENT);
 		return FALSE;
+	}
 
 	str = fu_device_to_string(device);
 	g_info("prepare -> %s", str);


### PR DESCRIPTION
This explains some of the LVFS failures about battery level.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
