### PR TITLE
Only show the 'Full Disk Encryption Detected' warning when required

### DIFF
--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1068,7 +1068,6 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 	FuUefiCapsulePlugin *self = FU_UEFI_CAPSULE_PLUGIN(plugin);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	const gchar *str;
-	gboolean has_fde = FALSE;
 	gboolean bootloader_supports_fwupd = fu_uefi_capsule_plugin_bootloader_supports_fwupd(ctx);
 	g_autoptr(GError) error_fde = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -1077,8 +1076,7 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "check-cod");
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 8, "check-bitlocker");
-	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 64, "coldplug");
+	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 72, "coldplug");
 	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 26, "add-devices");
 	fu_progress_add_step(progress, FWUPD_STATUS_LOADING, 1, "setup-bgrt");
 
@@ -1093,11 +1091,6 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 			    FU_TYPE_UEFI_COD_DEVICE);
 		}
 	}
-	fu_progress_step_done(progress);
-
-	/*  warn the user that BitLocker might ask for recovery key after fw update */
-	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_FDE_BITLOCKER))
-		has_fde = TRUE;
 	fu_progress_step_done(progress);
 
 	/* add each device */
@@ -1130,8 +1123,7 @@ fu_uefi_capsule_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 
 		/* system firmware "BIOS" can change the PCRx registers */
 		if (fu_uefi_capsule_device_get_kind(dev) ==
-			FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE &&
-		    has_fde)
+		    FU_UEFI_CAPSULE_DEVICE_KIND_SYSTEM_FIRMWARE)
 			fu_device_add_flag(FU_DEVICE(dev), FWUPD_DEVICE_FLAG_AFFECTS_FDE);
 
 		/* load all configuration variables */

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -197,7 +197,6 @@ static gboolean
 fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 {
 	FuUefiDbxDevice *self = FU_UEFI_DBX_DEVICE(device);
-	FuContext *ctx = fu_device_get_context(device);
 	g_autoptr(FuFirmware) kek = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GPtrArray) sigs = NULL;
@@ -230,12 +229,6 @@ fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 						 NULL);
 		fu_device_build_instance_id(device, NULL, "UEFI", "CRT", "ARCH", NULL);
 	}
-
-	/* dbx changes are expected to change PCR7, warn the user that BitLocker might ask for
-	recovery key after fw update */
-	if (fu_context_has_flag(ctx, FU_CONTEXT_FLAG_FDE_BITLOCKER))
-		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_AFFECTS_FDE);
-
 	return fu_uefi_dbx_device_ensure_checksum(self, error);
 }
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -446,6 +446,19 @@ fu_engine_ensure_device_display_required_inhibit(FuEngine *self, FuDevice *devic
 }
 
 static void
+fu_engine_ensure_device_maybe_remove_affects_fde(FuEngine *self, FuDevice *device)
+{
+	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_AFFECTS_FDE))
+		return;
+	if (!fu_context_has_flag(self->ctx, FU_CONTEXT_FLAG_FDE_BITLOCKER) &&
+	    !fu_context_has_flag(self->ctx, FU_CONTEXT_FLAG_FDE_SNAPD)) {
+		g_debug("removing affects-fde from %s as no FDE detected",
+			fu_device_get_id(device));
+		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_AFFECTS_FDE);
+	}
+}
+
+static void
 fu_engine_ensure_device_system_inhibit(FuEngine *self, FuDevice *device)
 {
 	if (fu_context_has_flag(self->ctx, FU_CONTEXT_FLAG_SYSTEM_INHIBIT) &&
@@ -509,6 +522,7 @@ fu_engine_device_added_cb(FuDeviceList *device_list, FuDevice *device, FuEngine 
 	fu_engine_ensure_device_lid_inhibit(self, device);
 	fu_engine_ensure_device_display_required_inhibit(self, device);
 	fu_engine_ensure_device_system_inhibit(self, device);
+	fu_engine_ensure_device_maybe_remove_affects_fde(self, device);
 	fu_engine_acquiesce_reset(self);
 	g_signal_emit(self, signals[SIGNAL_DEVICE_ADDED], 0, device);
 }


### PR DESCRIPTION
This also makes the warning for the dbx correctly show up when using Snap FDE.

Fixes https://github.com/fwupd/fwupd/issues/8963

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
