### PR TITLE
uefi-capsule: key name typo correction for Intel ME reference firmware

### DIFF
--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -20,7 +20,7 @@ Flags = supports-boot-order-lock,use-legacy-bootmgr-desc,no-ux-capsule,no-lid-cl
 
 # Intel CSME reference value
 [23192307-d667-4bdf-af1a-6059db171246]
-Fags = ~md-set-vendor
+Flags = ~md-set-vendor
 
 # Dell Inc.
 [85d38fda-fc0e-5c6f-808f-076984ae7978]


### PR DESCRIPTION
Cf. #8966

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

----

I hate to offer a pull request without a corresponding test to catch the issue in the future but I'm afraid I only have a couple of moments to spare on this.  In principle it should be reasonable to knock together a simple check for compare key names appearing in `.quirk` files against a list of allowable values and bail out with filenames and line numbers if any are found, and wire that up in the CI framework.  I'm very sorry that I can't put in the time to do this right now.