### PR TITLE
trivial: Fix parsing concatenated oprom images with padding

### DIFF
--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -89,6 +89,8 @@ fu_firmware_flag_to_string(FuFirmwareFlags flag)
 		return "no-auto-detection";
 	if (flag == FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE)
 		return "has-check-compatible";
+	if (flag == FU_FIRMWARE_FLAG_IS_LAST_IMAGE)
+		return "is-last-image";
 	return NULL;
 }
 
@@ -123,6 +125,8 @@ fu_firmware_flag_from_string(const gchar *flag)
 		return FU_FIRMWARE_FLAG_NO_AUTO_DETECTION;
 	if (g_strcmp0(flag, "has-check-compatible") == 0)
 		return FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE;
+	if (g_strcmp0(flag, "is-last-image") == 0)
+		return FU_FIRMWARE_FLAG_IS_LAST_IMAGE;
 	return FU_FIRMWARE_FLAG_NONE;
 }
 

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -228,6 +228,15 @@ typedef enum {
 	 **/
 	FU_FIRMWARE_FLAG_HAS_CHECK_COMPATIBLE = 1u << 8,
 	/**
+	 * FU_FIRMWARE_FLAG_IS_LAST_IMAGE:
+	 *
+	 * The firmware is the last image in the composite set. This can be used when parsing
+	 * a ``FuLinearFirmware` when additional padding is present.
+	 *
+	 * Since: 2.0.13
+	 **/
+	FU_FIRMWARE_FLAG_IS_LAST_IMAGE = 1u << 9,
+	/**
 	 * FU_FIRMWARE_FLAG_UNKNOWN:
 	 *
 	 * Unknown flag value.

--- a/libfwupdplugin/fu-oprom.rs
+++ b/libfwupdplugin/fu-oprom.rs
@@ -31,6 +31,12 @@ struct FuStructOprom {
     expansion_header_offset: u16le,
 }
 
+#[repr(u8)]
+enum FuOpromIndicatorFlag {
+    None,
+    Last = 0x80,
+}
+
 #[derive(New, ParseStream, Default)]
 #[repr(C, packed)]
 struct FuStructOpromPci {
@@ -44,7 +50,7 @@ struct FuStructOpromPci {
     image_length: u16le,		// of 512 bytes
     image_revision: u16le,
     code_type: u8,
-    indicator: u8,
+    indicator: FuOpromIndicatorFlag,
     max_runtime_image_length: u16le,
     conf_util_code_header_pointer: u16le,
     dmtf_clp_entry_point_pointer: u16le,


### PR DESCRIPTION
The `FuStructOpromPci.indicator` is used to signify the 'last image', so use that to abort processing of the much larger input stream.

Fixes parsing the Intel BMG GPU update, e.g.

    fwupdtool firmware-parse bmg_OpromCode.bin oprom

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
