### PR TITLE
Don't build with Android binder by default

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -3,7 +3,7 @@
 VENV=$(dirname $0)/..
 BUILD=${VENV}/build
 DIST=${VENV}/dist
-EXTRA_ARGS="-Dlibxmlb:gtkdoc=false -Dsystemd=disabled -Dbinder=enabled"
+EXTRA_ARGS="-Dlibxmlb:gtkdoc=false -Dsystemd=disabled"
 
 #build and install
 if [ -d /opt/homebrew/opt/libarchive/lib/pkgconfig ]; then

--- a/libfwupd/fwupd-binder-variant-hack.h
+++ b/libfwupd/fwupd-binder-variant-hack.h
@@ -6,7 +6,7 @@
 
 #include <glib.h>
 
-// TODO: This is a hack to work around android bundles not supporting signed numbers
+// TODO: This is a hack to work around android bundles not supporting unsigned numbers
 static guint64
 fwupd_codec_variant_get_uint32(GVariant *value)
 {

--- a/meson.build
+++ b/meson.build
@@ -380,9 +380,8 @@ if enable_binder
     name: 'binder link test',
     dependencies: binder_ndk,
     include_directories: binder_ndk_platform_incdir,
-    required: true)
-
-  if conf.get('HAS_BINDER_NDK') != 1
+    required: false)
+  if not links_service
     error('libbinder_ndk.so is incompatible')
   endif
 endif


### PR DESCRIPTION
`fwupd-binder` shouldn't be built by default -- it breaks the normal build workflow.

Also applied patches from https://github.com/fwupd/fwupd/tree/hughsie/binder-fixes

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x ] Code fix
- [ ] Feature
- [ ] Documentation
