### PR TITLE
build-certs.py: use /usr/bin/env for python3

### DIFF
--- a/data/tests/build-certs.py
+++ b/data/tests/build-certs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-2.1+
 
 import os


### PR DESCRIPTION
Avoids errors if python3 install path is not
in /usr/bin.

Type of pull request:
- [x] Code fix
