### PR TITLE
Show KEK child devices in fwupdmgr

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -866,7 +866,7 @@ fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs, FuDev
 					      self->filter_device_include,
 					      self->filter_device_exclude))
 			continue;
-		if (!self->show_all && !fu_util_is_interesting_device(FWUPD_DEVICE(dev_tmp)))
+		if (!self->show_all && !fu_util_is_interesting_device(devs, FWUPD_DEVICE(dev_tmp)))
 			continue;
 		if (fu_device_get_parent(dev_tmp) == dev) {
 			FuUtilNode *child = g_node_append_data(root, g_object_ref(dev_tmp));
@@ -1678,7 +1678,7 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 		}
 		if (g_strv_length(values) > 0 && dev_skip_byid)
 			continue;
-		if (!fu_util_is_interesting_device(dev))
+		if (!fu_util_is_interesting_device(devices, dev))
 			continue;
 
 		/* only show stuff that has metadata available */

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -137,19 +137,20 @@ fu_util_print_node(FuConsole *console, FwupdClient *client, FuUtilNode *n)
 }
 
 static gboolean
-fu_util_is_interesting_child(FwupdDevice *dev)
+fu_util_is_interesting_child(GPtrArray *devs, FwupdDevice *dev)
 {
-	GPtrArray *children = fwupd_device_get_children(dev);
-	for (guint i = 0; i < children->len; i++) {
-		FwupdDevice *child = g_ptr_array_index(children, i);
-		if (fu_util_is_interesting_device(child))
+	for (guint i = 0; i < devs->len; i++) {
+		FwupdDevice *child = g_ptr_array_index(devs, i);
+		if (fwupd_device_get_parent(child) != dev)
+			continue;
+		if (fu_util_is_interesting_device(devs, child))
 			return TRUE;
 	}
 	return FALSE;
 }
 
 gboolean
-fu_util_is_interesting_device(FwupdDevice *dev)
+fu_util_is_interesting_device(GPtrArray *devs, FwupdDevice *dev)
 {
 	if (fwupd_device_has_flag(dev, FWUPD_DEVICE_FLAG_UPDATABLE))
 		return TRUE;
@@ -160,7 +161,7 @@ fu_util_is_interesting_device(FwupdDevice *dev)
 	/* device not plugged in, get-details */
 	if (fwupd_device_get_flags(dev) == 0)
 		return TRUE;
-	if (fu_util_is_interesting_child(dev))
+	if (fu_util_is_interesting_child(devs, dev))
 		return TRUE;
 	return FALSE;
 }

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -46,7 +46,7 @@ fu_util_free_node(FuUtilNode *n) G_GNUC_NON_NULL(1);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuUtilNode, fu_util_free_node)
 
 gboolean
-fu_util_is_interesting_device(FwupdDevice *dev) G_GNUC_NON_NULL(1);
+fu_util_is_interesting_device(GPtrArray *devs, FwupdDevice *dev) G_GNUC_NON_NULL(1, 2);
 gchar *
 fu_util_get_user_cache_path(const gchar *fn) G_GNUC_NON_NULL(1);
 

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -438,74 +438,21 @@ fu_util_perhaps_show_unreported(FuUtil *self, GError **error)
 }
 
 static void
-fu_util_build_device_tree_node(FuUtil *self, FuUtilNode *root, FwupdDevice *dev)
+fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs, FwupdDevice *dev)
 {
-	FuUtilNode *root_child = g_node_append_data(root, g_object_ref(dev));
-	if (fwupd_device_get_release_default(dev) != NULL)
-		g_node_append_data(root_child, g_object_ref(fwupd_device_get_release_default(dev)));
-}
-
-static gboolean
-fu_util_build_device_tree_cb(FuUtilNode *n, gpointer user_data)
-{
-	FuUtil *self = (FuUtil *)user_data;
-	FwupdDevice *dev = n->data;
-
-	/* root node */
-	if (dev == NULL)
-		return FALSE;
-
-	/* release */
-	if (FWUPD_IS_RELEASE(n->data))
-		return FALSE;
-
-	/* an interesting child, so include the parent */
-	for (FuUtilNode *c = n->children; c != NULL; c = c->next) {
-		if (c->data != NULL)
-			return FALSE;
-	}
-
-	/* not interesting, clear the node data */
-	if (!fwupd_device_match_flags(dev,
-				      self->filter_device_include,
-				      self->filter_device_exclude))
-		g_clear_object(&n->data);
-	else if (!self->show_all && !fu_util_is_interesting_device(dev))
-		g_clear_object(&n->data);
-
-	/* continue */
-	return FALSE;
-}
-
-static void
-fu_util_build_device_tree(FuUtil *self, FuUtilNode *root, GPtrArray *devs)
-{
-	/* add the top-level parents */
 	for (guint i = 0; i < devs->len; i++) {
 		FwupdDevice *dev_tmp = g_ptr_array_index(devs, i);
-		if (fwupd_device_get_parent(dev_tmp) != NULL)
+		if (!fwupd_device_match_flags(dev_tmp,
+					      self->filter_device_include,
+					      self->filter_device_exclude))
 			continue;
-		fu_util_build_device_tree_node(self, root, dev_tmp);
+		if (!self->show_all && !fu_util_is_interesting_device(devs, dev_tmp))
+			continue;
+		if (fwupd_device_get_parent(dev_tmp) == dev) {
+			FuUtilNode *child = g_node_append_data(root, g_object_ref(dev_tmp));
+			fu_util_build_device_tree(self, child, devs, dev_tmp);
+		}
 	}
-
-	/* children */
-	for (guint i = 0; i < devs->len; i++) {
-		FwupdDevice *dev_tmp = g_ptr_array_index(devs, i);
-		FuUtilNode *root_parent;
-
-		if (fwupd_device_get_parent(dev_tmp) == NULL)
-			continue;
-		root_parent = g_node_find(root,
-					  G_PRE_ORDER,
-					  G_TRAVERSE_ALL,
-					  fwupd_device_get_parent(dev_tmp));
-		if (root_parent == NULL)
-			continue;
-		fu_util_build_device_tree_node(self, root_parent, dev_tmp);
-	}
-
-	/* prune children that are not updatable */
-	g_node_traverse(root, G_POST_ORDER, G_TRAVERSE_ALL, -1, fu_util_build_device_tree_cb, self);
 }
 
 static gboolean
@@ -655,7 +602,7 @@ fu_util_get_devices(FuUtil *self, gchar **values, GError **error)
 
 	/* print */
 	if (devs->len > 0)
-		fu_util_build_device_tree(self, root, devs);
+		fu_util_build_device_tree(self, root, devs, NULL);
 	if (g_node_n_children(root) == 0) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -1643,7 +1590,7 @@ fu_util_get_details(FuUtil *self, gchar **values, GError **error)
 		return fu_util_print_builder(self->console, builder, error);
 	}
 
-	fu_util_build_device_tree(self, root, array);
+	fu_util_build_device_tree(self, root, array, NULL);
 	fu_util_print_node(self->console, self->client, root);
 
 	return TRUE;


### PR DESCRIPTION
This worked in fwupdtool as it was using fwupd_device_get_children() -- which is only set up when adding devices to the engine. This meant we were hiding any non-updatable device that had updatable children -- like the KEK devices.

Use the parent like the comment in fwupd_device_add_child() suggests we do. This also allows us to use the same implementation to build the tree for fwupdtool and fwupdmgr.

Fixes https://github.com/fwupd/fwupd/issues/8971

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
