### PR TITLE
fu-lzma-common.c: reduce lzma compression level from 9 to default 6

### DIFF
--- a/libfwupdplugin/fu-lzma-common.c
+++ b/libfwupdplugin/fu-lzma-common.c
@@ -89,7 +89,8 @@ fu_lzma_compress_bytes(GBytes *blob, GError **error)
 	strm.next_in = g_bytes_get_data(blob, NULL);
 	strm.avail_in = g_bytes_get_size(blob);
 
-	rc = lzma_easy_encoder(&strm, 9, LZMA_CHECK_CRC64);
+        /* xz default compression level is 6, higher values increase CPU and memory usage */
+	rc = lzma_easy_encoder(&strm, 6, LZMA_CHECK_CRC64);
 	if (rc != LZMA_OK) {
 		lzma_end(&strm);
 		g_set_error(error,


### PR DESCRIPTION
xz manual page says default is 6 and levels higher than that can cause huge CPU and memory usage. On yocto qemu target, the fwupd tests fail to run with compression level 9:

FuSelfTest:ERROR:../sources/fwupd-2.0.12/libfwupdplugin/fu-self-test.c:6342:fu_lzma_func: assertion failed (error == NULL): failed to set up LZMA encoder rc=5 (FwupdError, 10)
not ok /fwupd/lzma - FuSelfTest:ERROR:../sources/fwupd-2.0.12/libfwupdplugin/fu-self-test.c:6342:fu_lzma_func: assertion failed (error == NULL): failed to set up LZMA encoder rc=5 (FwupdError, 10)

With default compression level 6 the tests pass.

https://linux.die.net/man/1/xz

 -6 ... -9
    Excellent compression with medium to high memory usage.
    These are also slower than the lower preset levels.
    The default is -6. Unless you want to maximize the compression ratio,
    you probably don't want a higher preset level than -7 due to
    speed and memory usage.

Type of pull request:

- [x] Code fix
