### PR TITLE
Add erase align up flag

### DIFF
--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -315,6 +315,17 @@ fu_mtd_device_erase(FuMtdDevice *self, GInputStream *stream, FuProgress *progres
 			return FALSE;
 		erase.start = fu_chunk_get_address(chk);
 		erase.length = fu_chunk_get_data_sz(chk);
+
+		/* the last chunk may be smaller than the erasesize. if it is, extend the last erase
+		 * up to the erasesize */
+		if (erase.length < self->erasesize) {
+			g_debug("extending last erase from %" G_GUINT32_FORMAT
+				" bytes to %" G_GUINT64_FORMAT " bytes",
+				erase.length,
+				self->erasesize);
+			erase.length = self->erasesize;
+		}
+
 		if (!fu_ioctl_execute(ioctl,
 				      MEMERASE,
 				      (guint8 *)&erase,


### PR DESCRIPTION
Useful for cases where the MTD device driver does not allow erases that are multiples of the `erasesize` and the firmware is not padded or aligned according to the specific `erasesize`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
