### PR TITLE
Fail console setup if stdout is redirected

### DIFF
--- a/src/fu-console.c
+++ b/src/fu-console.c
@@ -97,6 +97,11 @@ fu_console_setup(FuConsole *self, GError **error)
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not a TTY");
 		return FALSE;
 	}
+	if (isatty(fileno(stdout)) == 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not a TTY");
+		return FALSE;
+	}
+
 #endif
 	/* success */
 	return TRUE;


### PR DESCRIPTION
If a user does:
```
fwupdmgr get-devices > foo.txt
```
instead of:
```
fwupdmgr get-devices > foo.txt < EOF
```

Then stdin is still coming from a TTY and thus console detection
isn't setup as a user logically expects.

Use stdout to decide to fail console setup as well.
Fixes: https://github.com/fwupd/fwupd/issues/9003

Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
