### PR TITLE
hpi-cfu: Adding new Dock 'HP USB-C 100W G6 Dock' to hpi-cfu

### DIFF
--- a/plugins/hpi-cfu/hpi-cfu.quirk
+++ b/plugins/hpi-cfu/hpi-cfu.quirk
@@ -5,3 +5,7 @@ Plugin = hpi_cfu
 # HP Thunderbolt 4 Ultra 180W/280W G6 Dock
 [USB\VID_03F0&PID_03B7]
 Plugin = hpi_cfu
+
+# HP USB-C 100W G6 Dock
+[USB\VID_03F0&PID_04B7]
+Plugin = hpi_cfu


### PR DESCRIPTION
Type of pull request:


- [hpi-cfu: Adding new Dock 'HP USB-C 100W G6 Dock' to hpi-cfu ] Code fix