### PR TITLE
mtd: Add version reading for pci-backed devices

### DIFF
--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -16,3 +16,8 @@ Flags = no-probe
 [MTD\NAME_BIOS]
 Name = Internal SPI Controller
 #FirmwareGType = FuIfdFirmware
+
+# B&R Industrial Automation GmbH 5ACCIFM0.FCAN-000
+[MTD\VEN_1677&DEV_28A4]
+Flags = usable-during-update,unsigned-payload
+VersionFormat = pair


### PR DESCRIPTION
This is of course a total mess in this initial implementation. But hoping to arrive at a reasonable, generic solution. Reading the version from the deployed firmware blob is not reasonably possible for us.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
