### PR TITLE
trivial: don't show netlink messages for missing devices

### DIFF
--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -601,7 +601,8 @@ fu_udev_backend_netlink_cb(gint fd, GIOCondition condition, gpointer user_data)
 		return TRUE;
 	blob = g_bytes_new(buf, len);
 	if (!fu_udev_backend_netlink_parse_blob(self, blob, &error_local)) {
-		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
+		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_debug("ignoring netlink message: %s", error_local->message);
 			return TRUE;
 		}


### PR DESCRIPTION
While using a donor to probe there might be missing stuff.
```
ignoring netlink message: failed to probe donor: failed to read subsystem: Error when getting information for file “/sys/devices/pci0000:00/0000:00:08.3/0000:c4:00.3/usb5/5-1/5-1.5/5-1.5:1.0/0003:413C:B06E.0025/subsystem”: No such file or directory
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
