### PR TITLE
Add devlink flash plugin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -300,6 +300,7 @@ if build_daemon
 endif
 libm = cc.find_library('m', required: false)
 zlib = dependency('zlib')
+libmnl = dependency('libmnl', required: false)
 
 fs = import('fs')
 

--- a/plugins/devlink/README.md
+++ b/plugins/devlink/README.md
@@ -1,0 +1,153 @@
+---
+title: Plugin: Devlink
+---
+
+## Introduction
+
+This plugin provides firmware update support for network interface cards that support the Linux devlink interface.
+This is a generic plugin that can work with any device that implements devlink functionality.
+
+## Supported Devices
+
+The plugin supports any device that implements the devlink interface, regardless the bus it resides on.
+
+## Firmware Format
+
+The daemon will decompress the cabinet archive and extract a firmware blob in
+a packed binary file format.
+
+This plugin supports the following protocol ID:
+
+* `org.kernel.devlink`
+
+## GUID Generation
+
+These devices use custom instance IDs consisting of the component name.
+
+* `PCI\VEN_15B3&DEV_1021&COMPONENT_fw`
+
+Optionally, additional GUID might get generated as specified in the squirk file, see below.
+
+### Device Identification
+
+Devices are identified using their in the format:
+
+```text
+BUS_NAME/DEV_NAME
+```
+
+For PCI, this is for example:
+
+```text
+pci/0000:01:00.0
+```
+
+## Requirements
+
+* Linux kernel with devlink support
+* Device driver with devlink implementation
+* Root privileges (required for devlink write commands)
+
+## Update Behavior
+
+The plugin uses the Linux devlink netlink interface to communicate with the kernel and perform firmware updates.
+The process involves:
+
+1. **Netlink Communication**: Opens Netlink socket to communicate with the devlink subsystem
+2. **Device Detection**:  Gets all existing devlink devices
+3. **Firmware Upload**: Writes the firmware file to `CACHE_DIRECTORY` and instructs devlink to flash it
+4. **Progress Monitoring**: Monitors devlink status messages to provide real-time progress updates
+5. **Firmware Activation**: Activates firmware using devlink reload activate action
+
+### Devlink Protocol
+
+The plugin implements the devlink generic netlink protocol:
+
+1. **Device Enumeration**: Sends `DEVLINK_CMD_GET` with dump flag to discover all devlink devices
+2. **Device Monitoring**: Receives `DEVLINK_CMD_NEW` notifications when devices are added
+3. **Device Removal**: Receives `DEVLINK_CMD_DEL` notifications when devices are removed
+4. **Device Information**: Sends `DEVLINK_CMD_INFO_GET` to retrieve device details and versions
+5. **Flash Command**: Sends `DEVLINK_CMD_FLASH_UPDATE` with device and file information
+6. **Status Monitoring**: Receives `DEVLINK_CMD_FLASH_UPDATE_STATUS` messages for progress
+7. **Completion**: Waits for `DEVLINK_CMD_FLASH_UPDATE_END` to confirm completion
+8. **Firmware Activation**: Sends `DEVLINK_CMD_RELOAD` with fw_activate action to activate updated firmware
+
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### DevlinkFixedVersions
+
+Specifies a comma-separated list of "fixed version" names that should be used
+to generate additional GUID instance IDs for component matching. This is useful to
+target specific device according to device IDs, like ASIC ID, Board ID, etc.
+
+**Example usage in quirk file:**
+
+```ini
+[PCI\VEN_15B3&DEV_1021]
+DevlinkFixedVersions = fw.psid
+```
+
+Since: 2.0.15
+
+## Private Flags
+
+The plugin supports the following private flags:
+
+### `Flags=omit-component-name`
+
+When this flag is set, the plugin will not include the `DEVLINK_ATTR_FLASH_UPDATE_COMPONENT`
+attribute in the flash command.
+This is useful for devices that don't support component-specific updates. For such,
+passing `DEVLINK_ATTR_FLASH_UPDATE_COMPONENT` in flash netlink message
+would cause an error.
+
+**Usage in metainfo XML:**
+
+```xml
+<custom>
+  <value key="LVFS::DeviceFlags">omit-component-name</value>
+</custom>
+```
+
+Since: 2.0.15
+
+### Error Handling
+
+The plugin handles various error conditions:
+
+* Kernel without devlink support
+* Device without devlink implementation
+* Device without devlink flash implementation
+* Firmware file access issues
+* Flash operation failures
+
+## Security Considerations
+
+* Firmware files are temporarily stored in `/lib/firmware/`
+* Root privileges are required for devlink write commands
+* Temporary files are cleaned up after the operation
+
+## Vendor ID Security
+
+The vendor ID is set from the PCI vendor.
+
+## External Interface Access
+
+This plugin requires read/write access to `/dev/bus/usb`.
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.0.15`.
+
+## Owners
+
+Anyone can submit a pull request to modify this plugin, but the following people should be
+consulted before making major or functional changes:
+
+* Jiří Pírko: @jpirko
+
+## References
+
+* [Linux Devlink Documentation](https://www.kernel.org/doc/html/latest/networking/devlink/)

--- a/plugins/devlink/devlink.quirk
+++ b/plugins/devlink/devlink.quirk
@@ -1,0 +1,13 @@
+[DEVLINK\COMPONENT_fw]
+Name = Composite
+[DEVLINK\COMPONENT_fw.mgmt]
+Name = Management
+
+# emulated device is owned by the Linux Foundation
+[NETDEVSIM\COMPONENT_fw.mgmt]
+Vendor = Linux Foundation
+VendorId = PCI:0x1D6B
+
+# NVIDIA ConnectX-7
+[PCI\VEN_15B3&DEV_1021]
+DevlinkFixedVersions = fw.psid

--- a/plugins/devlink/fu-devlink-backend.c
+++ b/plugins/devlink/fu-devlink-backend.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-devlink-backend.h"
+#include "fu-devlink-device.h"
+
+struct _FuDevlinkBackend {
+	FuBackend parent_instance;
+};
+
+G_DEFINE_TYPE(FuDevlinkBackend, fu_devlink_backend, FU_TYPE_BACKEND)
+
+static FuDevice *
+fu_devlink_backend_create_pci_parent(FuDevlinkBackend *self,
+				     const gchar *bus_name,
+				     const gchar *dev_name,
+				     GError **error)
+{
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	FuBackend *udev_backend = NULL;
+	g_autofree gchar *pci_sysfs_path = NULL;
+	g_autoptr(FuDevice) pci_device = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	/* get the udev backend to create PCI parent device */
+	udev_backend = fu_context_get_backend_by_name(ctx, "udev", &error_local);
+	if (udev_backend == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "udev backend not available: %s",
+			    error_local->message);
+		return NULL;
+	}
+
+	/* construct PCI sysfs path from bus_name (e.g., "pci/0000:01:00.0") */
+	pci_sysfs_path = g_strdup_printf("/sys/bus/pci/devices/%s", dev_name);
+
+	/* create PCI device from sysfs path */
+	pci_device = fu_backend_create_device(udev_backend, pci_sysfs_path, &error_local);
+	if (pci_device == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_FOUND,
+			    "failed to create PCI device for %s: %s",
+			    pci_sysfs_path,
+			    error_local->message);
+		return NULL;
+	}
+
+	/* ensure PCI device is probed to get vendor/device info */
+	if (!fu_device_probe(pci_device, error)) {
+		g_prefix_error_literal(error, "failed to probe PCI device: ");
+		return NULL;
+	}
+
+	return g_steal_pointer(&pci_device);
+}
+
+static FuDevice *
+fu_devlink_backend_create_netdevsim_parent(FuDevlinkBackend *self,
+					   const gchar *bus_name,
+					   const gchar *dev_name,
+					   GError **error)
+{
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	g_autoptr(FuDevice) netdevsim_device = NULL;
+	g_autofree gchar *physical_id = NULL;
+
+	/* create a fake netdevsim parent device for testing */
+	netdevsim_device = fu_device_new(ctx);
+
+	/* set netdevsim device properties */
+	physical_id = g_strdup_printf("netdevsim-%s", dev_name);
+	fu_device_set_physical_id(netdevsim_device, physical_id);
+	fu_device_set_name(netdevsim_device, "Network Device Simulator");
+
+	return g_steal_pointer(&netdevsim_device);
+}
+
+gboolean
+fu_devlink_backend_device_added(FuDevlinkBackend *self,
+				const gchar *bus_name,
+				const gchar *dev_name,
+				GError **error)
+{
+	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
+	g_autoptr(FuDevice) devlink_device = NULL;
+	g_autoptr(FuDevice) parent_device = NULL;
+
+	g_return_val_if_fail(FU_IS_DEVLINK_BACKEND(self), FALSE);
+	g_return_val_if_fail(bus_name != NULL, FALSE);
+	g_return_val_if_fail(dev_name != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	/* only support PCI and netdevsim buses */
+	if (g_strcmp0(bus_name, "pci") == 0) {
+		parent_device =
+		    fu_devlink_backend_create_pci_parent(self, bus_name, dev_name, error);
+		if (parent_device == NULL)
+			return FALSE;
+	} else if (g_strcmp0(bus_name, "netdevsim") == 0) {
+		parent_device =
+		    fu_devlink_backend_create_netdevsim_parent(self, bus_name, dev_name, error);
+		if (parent_device == NULL)
+			return FALSE;
+	} else {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "unsupported bus type: %s (only 'pci' and 'netdevsim' are supported)",
+			    bus_name);
+		return FALSE;
+	}
+
+	/* create devlink device */
+	devlink_device = fu_devlink_device_new(ctx, bus_name, dev_name);
+	if (devlink_device == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to create devlink device");
+		return FALSE;
+	}
+
+	/* incorporate information from parent device (without setting hierarchy) */
+	fu_device_incorporate(devlink_device,
+			      parent_device,
+			      FU_DEVICE_INCORPORATE_FLAG_BASECLASS |
+				  FU_DEVICE_INCORPORATE_FLAG_VENDOR |
+				  FU_DEVICE_INCORPORATE_FLAG_VENDOR_IDS |
+				  FU_DEVICE_INCORPORATE_FLAG_VID | FU_DEVICE_INCORPORATE_FLAG_PID);
+
+	/* only add the devlink device to the backend - parent is managed by its own backend */
+	fu_backend_device_added(FU_BACKEND(self), devlink_device);
+
+	return TRUE;
+}
+
+void
+fu_devlink_backend_device_removed(FuDevlinkBackend *self,
+				  const gchar *bus_name,
+				  const gchar *dev_name)
+{
+	FuDevice *devlink_device;
+	g_autofree gchar *backend_id = g_strdup_printf("%s/%s", bus_name, dev_name);
+
+	g_return_if_fail(FU_IS_DEVLINK_BACKEND(self));
+	g_return_if_fail(bus_name != NULL);
+	g_return_if_fail(dev_name != NULL);
+
+	devlink_device = fu_backend_lookup_by_id(FU_BACKEND(self), backend_id);
+	if (devlink_device == NULL)
+		return;
+
+	fu_backend_device_removed(FU_BACKEND(self), devlink_device);
+}
+
+static void
+fu_devlink_backend_init(FuDevlinkBackend *self)
+{
+}
+
+static void
+fu_devlink_backend_class_init(FuDevlinkBackendClass *klass)
+{
+}
+
+FuBackend *
+fu_devlink_backend_new(FuContext *ctx)
+{
+	return FU_BACKEND(g_object_new(FU_TYPE_DEVLINK_BACKEND,
+				       "name",
+				       "devlink",
+				       "context",
+				       ctx,
+				       "device-gtype",
+				       FU_TYPE_DEVLINK_DEVICE,
+				       NULL));
+}

--- a/plugins/devlink/fu-devlink-backend.h
+++ b/plugins/devlink/fu-devlink-backend.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_DEVLINK_BACKEND (fu_devlink_backend_get_type())
+G_DECLARE_FINAL_TYPE(FuDevlinkBackend, fu_devlink_backend, FU, DEVLINK_BACKEND, FuBackend)
+
+FuBackend *
+fu_devlink_backend_new(FuContext *ctx) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_devlink_backend_device_added(FuDevlinkBackend *self,
+				const gchar *bus_name,
+				const gchar *dev_name,
+				GError **error) G_GNUC_NON_NULL(1, 2, 3);
+
+void
+fu_devlink_backend_device_removed(FuDevlinkBackend *self,
+				  const gchar *bus_name,
+				  const gchar *dev_name) G_GNUC_NON_NULL(1, 2, 3);

--- a/plugins/devlink/fu-devlink-component.c
+++ b/plugins/devlink/fu-devlink-component.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-devlink-component.h"
+#include "fu-devlink-device.h"
+
+/**
+ * FU_DEVLINK_DEVICE_FLAG_OMIT_COMPONENT_NAME:
+ *
+ * Do not set the DEVLINK_ATTR_FLASH_UPDATE_COMPONENT attribute when flashing firmware.
+ * This allows for firmware updates without specifying a specific component name.
+ *
+ * Since: 2.0.15
+ */
+#define FU_DEVLINK_DEVICE_FLAG_OMIT_COMPONENT_NAME "omit-component-name"
+
+struct _FuDevlinkComponent {
+	FuDevice parent_instance;
+	GPtrArray *instance_keys;
+};
+
+G_DEFINE_TYPE(FuDevlinkComponent, fu_devlink_component, FU_TYPE_DEVICE)
+
+static gboolean
+fu_devlink_component_write_firmware(FuDevice *device,
+				    FuFirmware *firmware,
+				    FuProgress *progress,
+				    FwupdInstallFlags flags,
+				    GError **error)
+{
+	FuDevlinkComponent *self = FU_DEVLINK_COMPONENT(device);
+	FuDevice *proxy = fu_device_get_proxy(device);
+	gboolean omit_component_name =
+	    fu_device_has_private_flag(FU_DEVICE(self), FU_DEVLINK_DEVICE_FLAG_OMIT_COMPONENT_NAME);
+
+	return fu_devlink_device_write_firmware_component(FU_DEVLINK_DEVICE(proxy),
+							  fu_device_get_logical_id(device),
+							  omit_component_name,
+							  firmware,
+							  progress,
+							  flags,
+							  error);
+}
+
+void
+fu_devlink_component_add_instance_keys(FuDevice *device, gchar **keys)
+{
+	FuDevlinkComponent *self = FU_DEVLINK_COMPONENT(device);
+
+	if (self->instance_keys == NULL)
+		self->instance_keys = g_ptr_array_new_with_free_func((GDestroyNotify)g_strfreev);
+	g_ptr_array_add(self->instance_keys, keys);
+}
+
+static gboolean
+fu_devlink_component_probe(FuDevice *device, GError **error)
+{
+	FuDevlinkComponent *self = FU_DEVLINK_COMPONENT(device);
+	FuDevice *proxy = fu_device_get_proxy(device);
+	g_autofree gchar *subsystem = NULL;
+	g_autoptr(GStrvBuilder) basekeys_builder = NULL;
+	g_auto(GStrv) basekeys = NULL;
+
+	/* declare all variables at the beginning */
+	subsystem = g_ascii_strup(fu_devlink_device_get_bus_name(FU_DEVLINK_DEVICE(proxy)), -1);
+
+	basekeys_builder = g_strv_builder_new();
+	if (fu_device_get_instance_str(device, "VEN") != NULL &&
+	    fu_device_get_instance_str(device, "DEV") != NULL) {
+		g_strv_builder_add(basekeys_builder, "VEN");
+		g_strv_builder_add(basekeys_builder, "DEV");
+	}
+	g_strv_builder_add(basekeys_builder, "COMPONENT");
+	basekeys = g_strv_builder_end(basekeys_builder);
+
+	/* build instance id just for component name */
+	if (!fu_device_build_instance_id_strv(device, subsystem, basekeys, error))
+		return FALSE;
+
+	if (self->instance_keys == NULL)
+		return TRUE;
+
+	/* Build instance id for each fixed versions array from quirk file for which
+	   kernel provides all fixed version values. */
+	for (guint i = 0; i < self->instance_keys->len; i++) {
+		GStrv instance_keys = g_ptr_array_index(self->instance_keys, i);
+		guint j;
+		g_autoptr(GStrvBuilder) keys_builder = g_strv_builder_new();
+		g_auto(GStrv) keys = NULL;
+
+		/* Future optimization: use g_strv_builder_addv() when available on all supported
+		   platforms. */
+		for (j = 0; basekeys[j] != NULL; j++)
+			g_strv_builder_add(keys_builder, basekeys[j]);
+		for (j = 0; instance_keys[j] != NULL; j++)
+			g_strv_builder_add(keys_builder, instance_keys[j]);
+		keys = g_strv_builder_end(keys_builder);
+		if (!fu_device_build_instance_id_strv(device, subsystem, keys, error))
+			return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_component_reload(FuDevice *device, GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(device);
+	return fu_device_reload(proxy, error);
+}
+
+static gboolean
+fu_devlink_component_activate(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(device);
+	return fu_device_activate(proxy, progress, error);
+}
+
+static gboolean
+fu_devlink_component_prepare(FuDevice *device,
+			     FuProgress *progress,
+			     FwupdInstallFlags flags,
+			     GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(device);
+	return fu_device_prepare(proxy, progress, flags, error);
+}
+
+static gboolean
+fu_devlink_component_cleanup(FuDevice *device,
+			     FuProgress *progress,
+			     FwupdInstallFlags flags,
+			     GError **error)
+{
+	FuDevice *proxy = fu_device_get_proxy(device);
+	return fu_device_cleanup(proxy, progress, flags, error);
+}
+
+static void
+fu_devlink_component_set_progress(FuDevice *self, FuProgress *progress)
+{
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);
+	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "detach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 57, "write");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_RESTART, 0, "attach");
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 43, "reload");
+}
+
+FuDevice *
+fu_devlink_component_new(FuDevice *proxy, const gchar *logical_id)
+{
+	g_autoptr(FuDevlinkComponent) self = NULL;
+
+	g_return_val_if_fail(logical_id != NULL, NULL);
+
+	self =
+	    g_object_new(FU_TYPE_DEVLINK_COMPONENT, "proxy", proxy, "logical-id", logical_id, NULL);
+	fu_device_add_instance_str(FU_DEVICE(self), "COMPONENT", logical_id);
+	return FU_DEVICE(g_steal_pointer(&self));
+}
+
+static void
+fu_devlink_component_init(FuDevlinkComponent *self)
+{
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_add_protocol(FU_DEVICE(self), "org.kernel.devlink");
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_FLAGS);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REFCOUNTED_PROXY);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PROXY_FALLBACK);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
+	fu_device_register_private_flag(FU_DEVICE(self),
+					FU_DEVLINK_DEVICE_FLAG_OMIT_COMPONENT_NAME);
+}
+
+static void
+fu_devlink_component_finalize(GObject *object)
+{
+	FuDevlinkComponent *self = FU_DEVLINK_COMPONENT(object);
+
+	if (self->instance_keys != NULL)
+		g_ptr_array_unref(self->instance_keys);
+
+	G_OBJECT_CLASS(fu_devlink_component_parent_class)->finalize(object);
+}
+
+static void
+fu_devlink_component_class_init(FuDevlinkComponentClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+
+	object_class->finalize = fu_devlink_component_finalize;
+	device_class->write_firmware = fu_devlink_component_write_firmware;
+	device_class->set_progress = fu_devlink_component_set_progress;
+	device_class->probe = fu_devlink_component_probe;
+	device_class->reload = fu_devlink_component_reload;
+	device_class->activate = fu_devlink_component_activate;
+	device_class->prepare = fu_devlink_component_prepare;
+	device_class->cleanup = fu_devlink_component_cleanup;
+}

--- a/plugins/devlink/fu-devlink-component.h
+++ b/plugins/devlink/fu-devlink-component.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_DEVLINK_COMPONENT (fu_devlink_component_get_type())
+G_DECLARE_FINAL_TYPE(FuDevlinkComponent, fu_devlink_component, FU, DEVLINK_COMPONENT, FuDevice)
+
+void
+fu_devlink_component_add_instance_keys(FuDevice *device, gchar **keys) G_GNUC_NON_NULL(1, 2);
+
+FuDevice *
+fu_devlink_component_new(FuDevice *proxy, const gchar *logical_id) G_GNUC_NON_NULL(1, 2);

--- a/plugins/devlink/fu-devlink-device.c
+++ b/plugins/devlink/fu-devlink-device.c
@@ -1,0 +1,1000 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <glib/gstdio.h>
+
+#include "fu-devlink-component.h"
+#include "fu-devlink-device.h"
+#include "fu-devlink-netlink.h"
+
+struct _FuDevlinkDevice {
+	FuDevice parent_instance;
+	gchar *bus_name;
+	gchar *dev_name;
+	FuDevlinkGenSocket *nlg;
+	FuKernelSearchPathLocker *search_path_locker;
+	GPtrArray *fixed_versions;
+};
+
+G_DEFINE_TYPE(FuDevlinkDevice, fu_devlink_device, FU_TYPE_DEVICE)
+
+typedef struct {
+	gchar *fixed;
+	gchar *running;
+	gchar *stored;
+} FuDevlinkVersionInfo;
+
+static void
+fu_devlink_device_version_info_free(FuDevlinkVersionInfo *version_info)
+{
+	g_free(version_info->fixed);
+	g_free(version_info->running);
+	g_free(version_info->stored);
+	g_free(version_info);
+}
+
+static GHashTable *
+fu_devlink_device_populate_attrs_map(const struct nlmsghdr *nlh)
+{
+	FuDevlinkVersionInfo *version_info;
+	struct nlattr *attr;
+	g_autoptr(GHashTable) version_table = NULL;
+
+	version_table = g_hash_table_new_full(g_str_hash,
+					      g_str_equal,
+					      g_free,
+					      (GDestroyNotify)fu_devlink_device_version_info_free);
+	mnl_attr_for_each(attr, nlh, sizeof(struct genlmsghdr))
+	{
+		struct nlattr *ver_tb[DEVLINK_ATTR_MAX + 1] = {};
+		g_autofree gchar *name = NULL;
+		g_autofree gchar *value = NULL;
+
+		if (mnl_attr_get_type(attr) != DEVLINK_ATTR_INFO_VERSION_FIXED &&
+		    mnl_attr_get_type(attr) != DEVLINK_ATTR_INFO_VERSION_RUNNING &&
+		    mnl_attr_get_type(attr) != DEVLINK_ATTR_INFO_VERSION_STORED)
+			continue;
+		if (mnl_attr_parse_nested(attr, fu_devlink_netlink_attr_cb, ver_tb) != MNL_CB_OK)
+			continue;
+		if (ver_tb[DEVLINK_ATTR_INFO_VERSION_NAME] == NULL ||
+		    ver_tb[DEVLINK_ATTR_INFO_VERSION_VALUE] == NULL)
+			continue;
+
+		name =
+		    fu_strsafe(mnl_attr_get_str(ver_tb[DEVLINK_ATTR_INFO_VERSION_NAME]), G_MAXSIZE);
+		value = fu_strsafe(mnl_attr_get_str(ver_tb[DEVLINK_ATTR_INFO_VERSION_VALUE]),
+				   G_MAXSIZE);
+		version_info = g_hash_table_lookup(version_table, name);
+		if (version_info == NULL) {
+			version_info = g_new0(FuDevlinkVersionInfo, 1);
+			g_hash_table_insert(version_table, g_strdup(name), version_info);
+		}
+
+		/* There are three types of versions: "fixed", "running", "stored". When "running"
+		   and "stored" are tightly coupled and describe one component, "fixed" is
+		   a different beast. "fixed" is used for static device identification, like ASIC
+		   ID, ASIC revision, BOARD ID, etc. */
+		switch (mnl_attr_get_type(attr)) {
+		case DEVLINK_ATTR_INFO_VERSION_FIXED:
+			version_info->fixed = g_strdup(value);
+			break;
+		case DEVLINK_ATTR_INFO_VERSION_RUNNING:
+			version_info->running = g_strdup(value);
+			break;
+		case DEVLINK_ATTR_INFO_VERSION_STORED:
+			version_info->stored = g_strdup(value);
+			break;
+		default:
+			continue;
+		}
+	}
+
+	return g_steal_pointer(&version_table);
+}
+
+typedef struct {
+	const gchar *component_name;
+	gboolean *needs_activation;
+} FuDevlinkDeviceNeedsActivationHelper;
+
+static gint
+fu_devlink_device_needs_activation_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkDeviceNeedsActivationHelper *helper = data;
+	struct genlmsghdr *genl = mnl_nlmsg_get_payload(nlh);
+	FuDevlinkVersionInfo *version_info;
+	g_autoptr(GHashTable) version_table = NULL;
+
+	if (genl->cmd != DEVLINK_CMD_INFO_GET)
+		return MNL_CB_OK;
+	version_table = fu_devlink_device_populate_attrs_map(nlh);
+	version_info = g_hash_table_lookup(version_table, helper->component_name);
+	if (version_info == NULL)
+		return MNL_CB_OK;
+	*helper->needs_activation = version_info->stored != NULL && version_info->running != NULL &&
+				    g_strcmp0(version_info->stored, version_info->running) != 0;
+	return MNL_CB_OK;
+}
+
+static gboolean
+fu_devlink_device_needs_activation(FuDevlinkDevice *self,
+				   const gchar *component_name,
+				   gboolean *needs_activation,
+				   GError **error)
+{
+	FuDevlinkDeviceNeedsActivationHelper helper = {
+	    .component_name = component_name,
+	    .needs_activation = needs_activation,
+	};
+	struct nlmsghdr *nlh;
+
+	/* prepare dev info command */
+	nlh = fu_devlink_netlink_cmd_prepare(self->nlg, DEVLINK_CMD_INFO_GET, FALSE);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_BUS_NAME, self->bus_name);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_DEV_NAME, self->dev_name);
+
+	/* send command and process response */
+	if (!fu_devlink_netlink_msg_send_recv(self->nlg,
+					      nlh,
+					      fu_devlink_device_needs_activation_cb,
+					      &helper,
+					      error)) {
+		g_prefix_error_literal(error, "failed to get device info: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+/* perform firmware activation using devlink reload with fw_activate action */
+static gboolean
+fu_devlink_device_ensure_activate(FuDevlinkDevice *self,
+				  const gchar *component_name,
+				  GError **error)
+{
+	struct nlmsghdr *nlh;
+	gboolean needs_activation = FALSE;
+
+	if (!fu_devlink_device_needs_activation(self, component_name, &needs_activation, error))
+		return FALSE;
+	if (!needs_activation)
+		return TRUE;
+
+	g_debug("activating firmware for %s/%s", self->bus_name, self->dev_name);
+
+	/* prepare reload command with fw_activate action */
+	nlh = fu_devlink_netlink_cmd_prepare(self->nlg, DEVLINK_CMD_RELOAD, FALSE);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_BUS_NAME, self->bus_name);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_DEV_NAME, self->dev_name);
+	mnl_attr_put_u8(nlh, DEVLINK_ATTR_RELOAD_ACTION, DEVLINK_RELOAD_ACTION_FW_ACTIVATE);
+
+	g_debug("sending devlink reload command with fw_activate action for %s/%s",
+		self->bus_name,
+		self->dev_name);
+
+	/* send command and wait for response */
+	if (!fu_devlink_netlink_msg_send(self->nlg, nlh, error)) {
+		g_prefix_error_literal(error, "failed to send devlink reload command: ");
+		return FALSE;
+	}
+
+	/* success */
+	g_debug("firmware activation completed for %s/%s", self->bus_name, self->dev_name);
+	return TRUE;
+}
+
+/* flash status context for monitoring progress */
+typedef struct {
+	FuProgress *progress;
+	FuDevlinkDevice *self;
+	FuDevlinkGenSocket *nlg;
+} FuDevlinkFlashMonHelper;
+
+/* flash send context for thread */
+typedef struct {
+	FuDevlinkDevice *self;
+	const gchar *component_name;
+	const gchar *filename;
+	GError **error;
+	GMainLoop *loop;
+} FuDevlinkFlashSendHelper;
+
+/* handle flash update status and end messages */
+static gint
+fu_devlink_device_flash_mon_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkFlashMonHelper *helper = data;
+	const gchar *bus_name;
+	const gchar *dev_name;
+	guint64 done = 0;
+	guint64 total = 0;
+	struct genlmsghdr *genl = mnl_nlmsg_get_payload(nlh);
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1] = {};
+
+	/* only handle flash update status and end messages */
+	if (genl->cmd != DEVLINK_CMD_FLASH_UPDATE_STATUS &&
+	    genl->cmd != DEVLINK_CMD_FLASH_UPDATE_END)
+		return MNL_CB_OK;
+
+	/* parse message attributes */
+	mnl_attr_parse(nlh, sizeof(*genl), fu_devlink_netlink_attr_cb, tb);
+
+	/* verify this is for our device */
+	if (tb[DEVLINK_ATTR_BUS_NAME] == NULL || tb[DEVLINK_ATTR_DEV_NAME] == NULL)
+		return MNL_CB_OK;
+
+	bus_name = mnl_attr_get_str(tb[DEVLINK_ATTR_BUS_NAME]);
+	dev_name = mnl_attr_get_str(tb[DEVLINK_ATTR_DEV_NAME]);
+
+	if (g_strcmp0(bus_name, helper->self->bus_name) != 0 ||
+	    g_strcmp0(dev_name, helper->self->dev_name) != 0)
+		return MNL_CB_OK;
+
+	if (genl->cmd == DEVLINK_CMD_FLASH_UPDATE_END) {
+		fu_progress_set_percentage(helper->progress, 100);
+		return MNL_CB_STOP;
+	}
+
+	/* extract progress information from status message */
+	if (tb[DEVLINK_ATTR_FLASH_UPDATE_STATUS_DONE] != NULL)
+		done = mnl_attr_get_u64(tb[DEVLINK_ATTR_FLASH_UPDATE_STATUS_DONE]);
+	if (tb[DEVLINK_ATTR_FLASH_UPDATE_STATUS_TOTAL] != NULL)
+		total = mnl_attr_get_u64(tb[DEVLINK_ATTR_FLASH_UPDATE_STATUS_TOTAL]);
+
+	if (total > 0)
+		fu_progress_set_percentage_full(helper->progress, done, total);
+
+	return MNL_CB_OK;
+}
+
+/* send flash command */
+static gboolean
+fu_devlink_device_flash_send(FuDevlinkDevice *self,
+			     const gchar *component_name,
+			     const gchar *filename,
+			     GError **error)
+{
+	struct nlmsghdr *nlh;
+
+	/* prepare flash update command */
+	nlh = fu_devlink_netlink_cmd_prepare(self->nlg, DEVLINK_CMD_FLASH_UPDATE, FALSE);
+
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_BUS_NAME, self->bus_name);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_DEV_NAME, self->dev_name);
+
+	if (component_name != NULL) {
+		mnl_attr_put_strz(nlh, DEVLINK_ATTR_FLASH_UPDATE_COMPONENT, component_name);
+		g_debug("sending flash update command for %s/%s with component %s and file %s",
+			self->bus_name,
+			self->dev_name,
+			component_name,
+			filename);
+	} else {
+		g_debug("sending flash update command for %s/%s with file %s",
+			self->bus_name,
+			self->dev_name,
+			filename);
+	}
+
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_FLASH_UPDATE_FILE_NAME, filename);
+
+	/* send flash update command - this will block until completion */
+	return fu_devlink_netlink_msg_send(self->nlg, nlh, error);
+}
+
+/* thread function that sends the flash update command and quits main loop */
+static gpointer
+fu_devlink_device_flash_send_thread(gpointer user_data)
+{
+	FuDevlinkFlashSendHelper *helper = user_data;
+	gboolean ret;
+
+	g_debug("flash send thread started for %s/%s",
+		helper->self->bus_name,
+		helper->self->dev_name);
+	ret = fu_devlink_device_flash_send(helper->self,
+					   helper->component_name,
+					   helper->filename,
+					   helper->error);
+
+	/* signal completion by quitting the main loop  */
+	g_main_loop_quit(helper->loop);
+
+	return GINT_TO_POINTER(ret ? 1 : 0);
+}
+
+/* netlink callback for flash progress monitoring */
+static gboolean
+fu_devlink_device_flash_mon_netlink_cb(GIOChannel *channel,
+				       GIOCondition condition,
+				       gpointer user_data)
+{
+	FuDevlinkFlashMonHelper *helper = user_data;
+	gsize len;
+	GIOStatus status;
+	g_autoptr(GError) error = NULL;
+
+	if (condition & (G_IO_ERR | G_IO_HUP)) {
+		g_debug("devlink netlink socket error during flash monitoring");
+		return FALSE;
+	}
+
+	/* read netlink message via GIOChannel */
+	status = g_io_channel_read_chars(channel,
+					 fu_devlink_netlink_gen_socket_get_buf(helper->nlg),
+					 FU_DEVLINK_NETLINK_BUF_SIZE,
+					 &len,
+					 &error);
+	if (status != G_IO_STATUS_NORMAL) {
+		if (error != NULL)
+			g_debug("failed to read devlink netlink message: %s", error->message);
+		return TRUE;
+	}
+
+	/* process netlink messages */
+	if (!fu_devlink_netlink_msg_run(helper->nlg,
+					len,
+					0,
+					fu_devlink_device_flash_mon_cb,
+					helper,
+					&error)) {
+		g_warning("failed to process netlink message: %s", error->message);
+		/* We should not return FALSE here, because we want to continue monitoring */
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_device_flash(FuDevlinkDevice *self,
+			const gchar *component_name,
+			const gchar *filename,
+			FuProgress *progress,
+			GError **error)
+{
+	FuDevlinkFlashMonHelper flash_mon_ctx = {
+	    .progress = progress,
+	    .self = self,
+	};
+	g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
+	FuDevlinkFlashSendHelper flash_send_ctx = {
+	    .self = self,
+	    .component_name = component_name,
+	    .filename = filename,
+	    .loop = loop,
+	    .error = error,
+	};
+	guint watch_id;
+	gint fd;
+	gpointer thread_result;
+	gboolean ret;
+	g_autoptr(FuDevlinkGenSocket) nlg = NULL;
+	g_autoptr(GIOChannel) channel = NULL;
+	g_autoptr(GThread) flash_send_thread = NULL;
+
+	/* open netlink socket and subscribe to multicast */
+	nlg = fu_devlink_netlink_gen_socket_open(NULL, error);
+	if (nlg == NULL)
+		return FALSE;
+	if (!fu_devlink_netlink_mcast_group_subscribe(nlg, error))
+		return FALSE;
+
+	flash_mon_ctx.nlg = nlg;
+	/* setup netlink channel and watch */
+	fd = fu_devlink_netlink_gen_socket_get_fd(nlg);
+	channel = g_io_channel_unix_new(fd);
+	g_io_channel_set_encoding(channel, NULL, NULL);
+	g_io_channel_set_buffered(channel, FALSE);
+	watch_id = g_io_add_watch(channel,
+				  G_IO_IN | G_IO_ERR | G_IO_HUP,
+				  fu_devlink_device_flash_mon_netlink_cb,
+				  &flash_mon_ctx);
+
+	fu_progress_set_percentage(progress, 0);
+
+	/* start the flash send thread */
+	flash_send_thread = g_thread_new("devlink-flash-send",
+					 fu_devlink_device_flash_send_thread,
+					 &flash_send_ctx);
+	if (flash_send_thread == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "failed to create flash send thread");
+		g_source_remove(watch_id);
+		return FALSE;
+	}
+
+	/* run the main loop until completion */
+	g_main_loop_run(loop);
+
+	g_source_remove(watch_id);
+
+	/* get thread result */
+	thread_result = g_thread_join(flash_send_thread);
+	g_steal_pointer(&flash_send_thread);
+	ret = GPOINTER_TO_INT(thread_result) != 0;
+	if (ret)
+		fu_progress_set_percentage(progress, 100);
+
+	return ret;
+}
+
+gboolean
+fu_devlink_device_write_firmware_component(FuDevlinkDevice *self,
+					   const gchar *component_name,
+					   gboolean omit_component_name,
+					   FuFirmware *firmware,
+					   FuProgress *progress,
+					   FwupdInstallFlags flags,
+					   GError **error)
+{
+	gboolean ret;
+	const gchar *fw_search_path;
+	g_autofree gchar *fw_basename = NULL;
+	g_autofree gchar *fw_fullpath = NULL;
+	g_autoptr(GBytes) fw = NULL;
+
+	/* get firmware data */
+	fw = fu_firmware_get_bytes(firmware, error);
+	if (fw == NULL)
+		return FALSE;
+
+	/* create firmware file in the kernel search path for devlink */
+	fw_search_path = fu_kernel_search_path_locker_get_path(self->search_path_locker);
+	fw_basename = g_strdup_printf("%s-%s-%s.bin",
+				      self->bus_name,
+				      self->dev_name,
+				      omit_component_name ? "default" : component_name);
+	fw_fullpath = g_build_filename(fw_search_path, fw_basename, NULL);
+	g_debug("writing firmware to %s", fw_fullpath);
+
+	/* write firmware to kernel search path */
+	if (!fu_bytes_set_contents(fw_fullpath, fw, error))
+		return FALSE;
+
+	ret = fu_devlink_device_flash(self,
+				      omit_component_name ? NULL : component_name,
+				      fw_basename,
+				      progress,
+				      error);
+
+	/* clean up temporary firmware file */
+	if (g_unlink(fw_fullpath) != 0) {
+		g_warning("failed to delete temporary firmware file %s: %s",
+			  fw_fullpath,
+			  fwupd_strerror(errno));
+	}
+
+	if (!ret)
+		return FALSE;
+
+	/* check if activation is needed */
+	return fu_devlink_device_ensure_activate(self, component_name, error);
+}
+
+static FuDevice *
+fu_devlink_device_get_component_by_logical_id(FuDevice *device, const gchar *name)
+{
+	GPtrArray *children = fu_device_get_children(device);
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *component = g_ptr_array_index(children, i);
+		if (g_strcmp0(fu_device_get_logical_id(component), name) == 0)
+			return g_object_ref(component);
+	}
+	return NULL;
+}
+
+typedef struct {
+	FuDevice *device;
+	GHashTable *version_table;
+} FuDevlinkDeviceUpdateComponentHelper;
+
+static void
+fu_devlink_device_add_component_instance_strs(FuDevice *component,
+					      FuDevlinkDeviceUpdateComponentHelper *helper)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(helper->device);
+
+	if (self->fixed_versions == NULL)
+		return;
+
+	/* There might me multiple arrays of fixed versions obtained from quirk file.
+	   Iterate over all of them and add instance strings to component device. */
+	for (guint i = 0; i < self->fixed_versions->len; i++) {
+		gboolean complete_set = TRUE;
+		const gchar **names = g_ptr_array_index(self->fixed_versions, i);
+		g_autoptr(GStrvBuilder) keys_builder = g_strv_builder_new();
+
+		for (guint j = 0; names[j] != NULL; j++) {
+			FuDevlinkVersionInfo *version_info =
+			    g_hash_table_lookup(helper->version_table, names[j]);
+			g_autofree gchar *key = NULL;
+
+			if (version_info == NULL || version_info->fixed == NULL) {
+				complete_set = FALSE;
+				continue;
+			}
+			key = g_ascii_strup(names[j], -1);
+			g_strv_builder_add(keys_builder, key);
+
+			/* avoid re-insertion of the same key */
+			if (fu_device_get_instance_str(component, key) == NULL)
+				fu_device_add_instance_str(component, key, version_info->fixed);
+		}
+		/* In case all keys are present in version table obtained from kernel,
+		   add the set to component to build instance id for it during probe. */
+		if (complete_set)
+			fu_devlink_component_add_instance_keys(component,
+							       g_strv_builder_end(keys_builder));
+	}
+}
+
+static void
+fu_devlink_device_update_component_cb(gpointer key, gpointer value, gpointer user_data)
+{
+	FuDevlinkDeviceUpdateComponentHelper *helper = user_data;
+	const gchar *name = (const gchar *)key;
+	FuDevlinkVersionInfo *version_info = value;
+	const gchar *version;
+	g_autofree gchar *instance_id = g_strdup_printf("DEVLINK\\COMPONENT_%s", name);
+	g_autoptr(FuDevice) component = NULL;
+	g_autoptr(GError) error_local = NULL;
+
+	/* "fw.bootloader" is a special case. If there is a fixed version of it present,
+	   set it as the bootloader version. */
+	if (g_strcmp0(name, "fw.bootloader") == 0)
+		fu_device_set_version_bootloader(helper->device, version_info->fixed);
+
+	/* A component and running-stored tuple has 1:1 relationship. No guarantee
+	   that both are present, if either is present, try to create component. */
+	if (version_info->stored != NULL)
+		version = version_info->stored;
+	else if (version_info->running != NULL)
+		version = version_info->running;
+	else
+		return;
+
+	component = fu_devlink_device_get_component_by_logical_id(helper->device, name);
+	if (component != NULL) {
+		fu_device_set_version(component, version);
+		g_debug("updated component %s (version: %s)", name, version);
+		return;
+	}
+
+	/* create new component and lookup quirk to added as a child */
+	component = fu_devlink_component_new(helper->device, name);
+	fu_device_add_instance_id_full(component, instance_id, FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+	if (fu_device_get_name(component) == NULL) {
+		g_debug("ignoring %s", name);
+		return;
+	}
+	fu_devlink_device_add_component_instance_strs(component, helper);
+	fu_device_set_version_format(component, fu_version_guess_format(version));
+	fu_device_set_version(component, version);
+	if (!fu_device_probe(component, &error_local)) {
+		g_warning("failed to probe %s: %s", name, error_local->message);
+		return;
+	}
+	fu_device_add_child(helper->device, component);
+	g_debug("added component %s (version: %s)", name, version);
+}
+
+/* callback for parsing devlink dev info response */
+static gint
+fu_devlink_device_info_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevice *device = FU_DEVICE(data);
+	FuDevlinkDeviceUpdateComponentHelper helper = {0};
+	GPtrArray *children = fu_device_get_children(device);
+	struct genlmsghdr *genl = mnl_nlmsg_get_payload(nlh);
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1] = {};
+	g_autoptr(GHashTable) version_table = NULL;
+	g_autoptr(GPtrArray) components_to_remove = g_ptr_array_new();
+
+	if (genl->cmd != DEVLINK_CMD_INFO_GET)
+		return MNL_CB_OK;
+
+	/* parse main attributes */
+	mnl_attr_parse(nlh, sizeof(*genl), fu_devlink_netlink_attr_cb, tb);
+
+	if (tb[DEVLINK_ATTR_INFO_SERIAL_NUMBER] != NULL) {
+		g_autofree gchar *serial_number =
+		    fu_strsafe(mnl_attr_get_str(tb[DEVLINK_ATTR_INFO_SERIAL_NUMBER]), G_MAXSIZE);
+		fu_device_set_serial(device, serial_number);
+	}
+
+	version_table = fu_devlink_device_populate_attrs_map(nlh);
+
+	/* remove components that are not in the attrs map */
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *component = g_ptr_array_index(children, i);
+		const gchar *logical_id = fu_device_get_logical_id(component);
+		FuDevlinkVersionInfo *version_info = g_hash_table_lookup(version_table, logical_id);
+
+		if (version_info == NULL) {
+			g_debug("removed component %s", logical_id);
+			g_ptr_array_add(components_to_remove, component);
+		}
+	}
+	for (guint i = 0; i < components_to_remove->len; i++) {
+		FuDevice *component = g_ptr_array_index(components_to_remove, i);
+		fu_device_remove_child(device, component);
+	}
+
+	helper.device = device;
+	helper.version_table = version_table;
+	g_hash_table_foreach(version_table, fu_devlink_device_update_component_cb, &helper);
+
+	return MNL_CB_OK;
+}
+
+/* get device information using devlink dev info */
+static gboolean
+fu_devlink_device_get_info(FuDevice *device, GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+	struct nlmsghdr *nlh;
+
+	/* prepare dev info command */
+	nlh = fu_devlink_netlink_cmd_prepare(self->nlg, DEVLINK_CMD_INFO_GET, FALSE);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_BUS_NAME, self->bus_name);
+	mnl_attr_put_strz(nlh, DEVLINK_ATTR_DEV_NAME, self->dev_name);
+
+	/* send command and process response */
+	if (!fu_devlink_netlink_msg_send_recv(self->nlg,
+					      nlh,
+					      fu_devlink_device_info_cb,
+					      device,
+					      error)) {
+		g_prefix_error_literal(error, "failed to get device info: ");
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_devlink_device_to_string(FuDevice *device, guint idt, GString *str)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	fwupd_codec_string_append(str, idt, "BusName", self->bus_name);
+	fwupd_codec_string_append(str, idt, "DevName", self->dev_name);
+}
+
+static gboolean
+fu_devlink_device_setup(FuDevice *device, GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+	g_autofree gchar *subsystem = NULL;
+	g_autofree gchar *summary = NULL;
+
+	/* check if device has been properly initialized */
+	if (self->bus_name == NULL || self->dev_name == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "devlink device not properly initialized");
+		return FALSE;
+	}
+
+	subsystem = g_ascii_strup(self->bus_name, -1);
+
+	/* set summary with devlink handle for better user visibility */
+	summary = g_strdup_printf("Devlink device (%s/%s)", self->bus_name, self->dev_name);
+	fu_device_set_summary(device, summary);
+
+	/* use quirk database for a better name */
+	if (fu_device_get_vid(device) != 0 && fu_device_get_pid(device) != 0) {
+		fu_device_add_instance_u16(device, "VEN", fu_device_get_vid(device));
+		fu_device_add_instance_u16(device, "DEV", fu_device_get_pid(device));
+		if (!fu_device_build_instance_id_full(device,
+						      FU_DEVICE_INSTANCE_FLAG_QUIRKS,
+						      error,
+						      subsystem,
+						      "VEN",
+						      "DEV",
+						      NULL)) {
+			g_prefix_error_literal(error, "failed to create quirk for name: ");
+			return FALSE;
+		}
+	}
+
+	/* get device information and version */
+	return fu_devlink_device_get_info(device, error);
+}
+
+const gchar *
+fu_devlink_device_get_bus_name(FuDevlinkDevice *self)
+{
+	return self->bus_name;
+}
+
+static void
+fu_devlink_device_set_bus_name(FuDevlinkDevice *self, const gchar *bus_name)
+{
+	g_free(self->bus_name);
+	self->bus_name = g_strdup(bus_name);
+}
+
+static void
+fu_devlink_device_set_dev_name(FuDevlinkDevice *self, const gchar *dev_name)
+{
+	g_free(self->dev_name);
+	self->dev_name = g_strdup(dev_name);
+}
+
+FuDevice *
+fu_devlink_device_new(FuContext *ctx, const gchar *bus_name, const gchar *dev_name)
+{
+	g_autoptr(FuDevlinkDevice) self = NULL;
+	g_autofree gchar *device_id = NULL;
+
+	g_return_val_if_fail(bus_name != NULL, NULL);
+	g_return_val_if_fail(dev_name != NULL, NULL);
+
+	/* create object and assign the strings */
+	self = g_object_new(FU_TYPE_DEVLINK_DEVICE, "context", ctx, NULL);
+	fu_devlink_device_set_bus_name(self, bus_name);
+	fu_devlink_device_set_dev_name(self, dev_name);
+
+	device_id = g_strdup_printf("%s/%s", bus_name, dev_name);
+	fu_device_set_physical_id(FU_DEVICE(self), device_id);
+
+	return FU_DEVICE(g_steal_pointer(&self));
+}
+
+static gboolean
+fu_devlink_device_open(FuDevice *device, GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	/* open devlink netlink socket */
+	self->nlg = fu_devlink_netlink_gen_socket_open(device, error);
+	if (self->nlg == NULL)
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_device_close(FuDevice *device, GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	/* close devlink netlink socket */
+	fu_devlink_netlink_gen_socket_close(self->nlg);
+
+	return TRUE;
+}
+
+static FuKernelSearchPathLocker *
+fu_devlink_device_search_path_locker_new(FuDevlinkDevice *self, GError **error)
+{
+	g_autofree gchar *cachedir = NULL;
+	g_autofree gchar *devlink_fw_dir = NULL;
+	g_autoptr(FuKernelSearchPathLocker) locker = NULL;
+
+	/* create a directory to store firmware files for devlink plugin */
+	cachedir = fu_path_from_kind(FU_PATH_KIND_CACHEDIR_PKG);
+	devlink_fw_dir = g_build_filename(cachedir, "devlink", "firmware", NULL);
+	if (g_mkdir_with_parents(devlink_fw_dir, 0700) == -1) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "failed to create '%s': %s",
+			    devlink_fw_dir,
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+	locker = fu_kernel_search_path_locker_new(devlink_fw_dir, error);
+	if (locker == NULL)
+		return NULL;
+	return g_steal_pointer(&locker);
+}
+
+static gboolean
+fu_devlink_device_prepare(FuDevice *device,
+			  FuProgress *progress,
+			  FwupdInstallFlags flags,
+			  GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	/* setup kernel firmware search path for devlink device */
+	self->search_path_locker = fu_devlink_device_search_path_locker_new(self, error);
+	if (self->search_path_locker == NULL)
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_device_cleanup(FuDevice *device,
+			  FuProgress *progress,
+			  FwupdInstallFlags flags,
+			  GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	/* restore the firmware search path */
+	g_clear_object(&self->search_path_locker);
+
+	return TRUE;
+}
+
+static void
+fu_devlink_device_add_json(FuDevice *device, JsonBuilder *builder, FwupdCodecFlags flags)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+	GPtrArray *events = fu_device_get_events(device);
+
+	/* add device type identifier */
+	fwupd_codec_json_append(builder, "GType", "FuDevlinkDevice");
+
+	/* add devlink-specific properties for regular devices */
+	fwupd_codec_json_append(builder, "BusName", self->bus_name);
+	fwupd_codec_json_append(builder, "DevName", self->dev_name);
+
+	/* serialize recorded events */
+	if (events->len > 0) {
+		json_builder_set_member_name(builder, "Events");
+		json_builder_begin_array(builder);
+		for (guint i = 0; i < events->len; i++) {
+			FuDeviceEvent *event = g_ptr_array_index(events, i);
+
+			json_builder_begin_object(builder);
+			fwupd_codec_to_json(FWUPD_CODEC(event),
+					    builder,
+					    events->len > 1000 ? flags | FWUPD_CODEC_FLAG_COMPRESSED
+							       : flags);
+			json_builder_end_object(builder);
+		}
+		json_builder_end_array(builder);
+	}
+}
+
+static gboolean
+fu_devlink_device_from_json(FuDevice *device, JsonObject *json_object, GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+	const gchar *bus_name;
+	const gchar *dev_name;
+	g_autofree gchar *device_id = NULL;
+
+	/* devlink-specific properties */
+	bus_name = json_object_get_string_member_with_default(json_object, "BusName", NULL);
+	dev_name = json_object_get_string_member_with_default(json_object, "DevName", NULL);
+
+	if (bus_name == NULL || dev_name == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "BusName and DevName required for devlink device");
+		return FALSE;
+	}
+
+	fu_devlink_device_set_bus_name(self, bus_name);
+	fu_devlink_device_set_dev_name(self, dev_name);
+
+	device_id = g_strdup_printf("%s/%s", bus_name, dev_name);
+	fu_device_set_physical_id(FU_DEVICE(self), device_id);
+	fu_device_set_name(FU_DEVICE(self), device_id);
+	fu_device_set_backend_id(device, device_id);
+
+	/* array of events */
+	if (json_object_has_member(json_object, "Events")) {
+		JsonArray *json_array = json_object_get_array_member(json_object, "Events");
+
+		for (guint i = 0; i < json_array_get_length(json_array); i++) {
+			JsonNode *node_tmp = json_array_get_element(json_array, i);
+			g_autoptr(FuDeviceEvent) event = fu_device_event_new(NULL);
+
+			if (!fwupd_codec_from_json(FWUPD_CODEC(event), node_tmp, error))
+				return FALSE;
+			fu_device_add_event(device, event);
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_devlink_device_incorporate(FuDevice *device, FuDevice *donor_device)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+	FuDevlinkDevice *donor = FU_DEVLINK_DEVICE(donor_device);
+
+	g_return_if_fail(FU_IS_DEVLINK_DEVICE(device));
+	g_return_if_fail(FU_IS_DEVLINK_DEVICE(donor_device));
+
+	/* copy bus_name if not already set */
+	if (self->bus_name == NULL && donor->bus_name != NULL)
+		fu_devlink_device_set_bus_name(self, donor->bus_name);
+
+	/* copy dev_name if not already set */
+	if (self->dev_name == NULL && donor->dev_name != NULL)
+		fu_devlink_device_set_dev_name(self, donor->dev_name);
+}
+
+static void
+fu_devlink_device_add_fixed_versions(FuDevlinkDevice *self, gchar **fixed_versions)
+{
+	if (self->fixed_versions == NULL)
+		self->fixed_versions = g_ptr_array_new_with_free_func((GDestroyNotify)g_strfreev);
+	g_ptr_array_add(self->fixed_versions, fixed_versions);
+}
+
+static gboolean
+fu_devlink_device_set_quirk_kv(FuDevice *device,
+			       const gchar *key,
+			       const gchar *value,
+			       GError **error)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(device);
+
+	if (g_strcmp0(key, "DevlinkFixedVersions") == 0) {
+		fu_devlink_device_add_fixed_versions(self, g_strsplit(value, ",", -1));
+		return TRUE;
+	}
+
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "quirk key not supported");
+	return FALSE;
+}
+
+static void
+fu_devlink_device_init(FuDevlinkDevice *self)
+{
+	fu_device_add_protocol(FU_DEVICE(self), "org.kernel.devlink");
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG);
+	fu_device_add_possible_plugin(FU_DEVICE(self), "devlink");
+}
+
+static void
+fu_devlink_device_finalize(GObject *object)
+{
+	FuDevlinkDevice *self = FU_DEVLINK_DEVICE(object);
+
+	g_free(self->bus_name);
+	g_free(self->dev_name);
+	if (self->fixed_versions != NULL)
+		g_ptr_array_unref(self->fixed_versions);
+
+	G_OBJECT_CLASS(fu_devlink_device_parent_class)->finalize(object);
+}
+
+static void
+fu_devlink_device_class_init(FuDevlinkDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+
+	object_class->finalize = fu_devlink_device_finalize;
+	device_class->open = fu_devlink_device_open;
+	device_class->close = fu_devlink_device_close;
+	device_class->prepare = fu_devlink_device_prepare;
+	device_class->cleanup = fu_devlink_device_cleanup;
+	device_class->to_string = fu_devlink_device_to_string;
+	device_class->setup = fu_devlink_device_setup;
+	device_class->reload = fu_devlink_device_setup;
+	device_class->add_json = fu_devlink_device_add_json;
+	device_class->from_json = fu_devlink_device_from_json;
+	device_class->incorporate = fu_devlink_device_incorporate;
+	device_class->set_quirk_kv = fu_devlink_device_set_quirk_kv;
+}

--- a/plugins/devlink/fu-devlink-device.h
+++ b/plugins/devlink/fu-devlink-device.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_DEVLINK_DEVICE (fu_devlink_device_get_type())
+G_DECLARE_FINAL_TYPE(FuDevlinkDevice, fu_devlink_device, FU, DEVLINK_DEVICE, FuDevice)
+
+FuDevice *
+fu_devlink_device_new(FuContext *ctx, const gchar *bus_name, const gchar *dev_name) G_GNUC_NON_NULL(1, 2, 3);
+
+const gchar *
+fu_devlink_device_get_bus_name(FuDevlinkDevice *self) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_devlink_device_write_firmware_component(FuDevlinkDevice *self,
+					   const gchar *component_name,
+					   gboolean omit_component_name,
+					   FuFirmware *firmware,
+					   FuProgress *progress,
+					   FwupdInstallFlags flags,
+					   GError **error) G_GNUC_NON_NULL(1, 2, 4, 5);

--- a/plugins/devlink/fu-devlink-netlink.c
+++ b/plugins/devlink/fu-devlink-netlink.c
@@ -1,0 +1,647 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <glib-unix.h>
+#include <libmnl/libmnl.h>
+#include <linux/genetlink.h>
+#include <linux/netlink.h>
+
+#include "fu-devlink-netlink.h"
+
+static struct nlmsghdr *
+fu_devlink_netlink_msg_prepare(gpointer buf,
+			       guint32 nlmsg_type,
+			       gboolean dump,
+			       gpointer extra_header,
+			       gsize extra_header_size)
+{
+	struct nlmsghdr *nlh;
+	gpointer eh;
+
+	nlh = mnl_nlmsg_put_header(buf);
+	nlh->nlmsg_type = nlmsg_type;
+	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	if (dump)
+		nlh->nlmsg_flags |= NLM_F_DUMP;
+	nlh->nlmsg_seq = (guint32)time(NULL);
+
+	eh = mnl_nlmsg_put_extra_header(nlh, extra_header_size);
+	memcpy(eh, extra_header, extra_header_size); /* nocheck:blocked */
+
+	return nlh;
+}
+
+/* attribute parser callback for netlink error attributes */
+static gint
+fu_devlink_netlink_nlmsgerr_attr_cb(const struct nlattr *attr, gpointer data)
+{
+	const struct nlattr **tb = data;
+	gint type = mnl_attr_get_type(attr);
+
+	if (mnl_attr_type_valid(attr, NLMSGERR_ATTR_MAX) < 0)
+		return MNL_CB_OK;
+
+	tb[type] = attr;
+	return MNL_CB_OK;
+}
+
+typedef struct {
+	gpointer user_data;
+	mnl_cb_t user_cb;
+	GError **error;
+} FuDevlinkCbHelper;
+
+static gboolean
+fu_devlink_netlink_error_cb_extack(const struct nlmsghdr *nlh, GError **error)
+{
+	const struct nlmsgerr *err = mnl_nlmsg_get_payload(nlh);
+	struct nlattr *tb[NLMSGERR_ATTR_MAX + 1] = {};
+	guint hlen = sizeof(struct nlmsgerr);
+
+	if ((nlh->nlmsg_flags & NLM_F_ACK_TLVS) == 0)
+		return FALSE;
+	if ((nlh->nlmsg_flags & NLM_F_CAPPED) == 0)
+		hlen += mnl_nlmsg_get_payload_len(&err->msg);
+	if (mnl_attr_parse(nlh, hlen, fu_devlink_netlink_nlmsgerr_attr_cb, tb) != MNL_CB_OK)
+		return FALSE;
+	if (tb[NLMSGERR_ATTR_MSG] == NULL)
+		return FALSE;
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "netlink error: %s; %s",
+		    fwupd_strerror(-err->error),
+		    mnl_attr_get_str(tb[NLMSGERR_ATTR_MSG]));
+	return TRUE;
+}
+
+/* error callback parses extack messages */
+static gint
+fu_devlink_netlink_error_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	const struct nlmsgerr *err = mnl_nlmsg_get_payload(nlh);
+	FuDevlinkCbHelper *helper = data;
+
+	if (mnl_nlmsg_get_payload_len(nlh) < sizeof(*err))
+		return MNL_CB_STOP;
+	if (err->error == 0)
+		return MNL_CB_STOP;
+	if (fu_devlink_netlink_error_cb_extack(nlh, helper->error))
+		return MNL_CB_ERROR;
+	g_set_error(helper->error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "netlink error: %s",
+		    fwupd_strerror(-err->error));
+	return MNL_CB_ERROR;
+}
+
+static gint
+fu_devlink_netlink_noop_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	return MNL_CB_STOP;
+}
+
+static gint
+fu_devlink_netlink_done_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	return MNL_CB_STOP;
+}
+
+/* data callback wrapper that calls the user callback */
+static gint
+fu_devlink_netlink_data_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkCbHelper *helper = data;
+
+	if (helper->user_cb == NULL)
+		return MNL_CB_OK;
+	return helper->user_cb(nlh, helper->user_data);
+}
+
+static gint
+fu_devlink_netlink_msg_cb_run(FuDevlinkGenSocket *nlg,
+			      gsize len,
+			      guint32 seq,
+			      mnl_cb_t cb,
+			      gpointer data,
+			      GError **error)
+{
+	guint32 portid;
+	FuDevlinkCbHelper helper = {
+	    .user_data = data,
+	    .user_cb = cb,
+	    .error = error,
+	};
+	mnl_cb_t cbs[NLMSG_MIN_TYPE] = {
+	    [NLMSG_NOOP] = fu_devlink_netlink_noop_cb,
+	    [NLMSG_ERROR] = fu_devlink_netlink_error_cb,
+	    [NLMSG_DONE] = fu_devlink_netlink_done_cb,
+	    [NLMSG_OVERRUN] = fu_devlink_netlink_noop_cb,
+	};
+
+	if (nlg->is_emulated) {
+		struct nlmsghdr *nlh = (gpointer)nlg->buf;
+
+		nlh->nlmsg_seq = seq;
+		portid = nlh->nlmsg_pid;
+	} else {
+		portid = mnl_socket_get_portid(nlg->nl);
+	}
+
+	return mnl_cb_run2(nlg->buf,
+			   len,
+			   seq,
+			   portid,
+			   fu_devlink_netlink_data_cb,
+			   &helper,
+			   cbs,
+			   MNL_ARRAY_SIZE(cbs));
+}
+
+/* run callback on netlink messages */
+gboolean
+fu_devlink_netlink_msg_run(FuDevlinkGenSocket *nlg,
+			   gsize len,
+			   guint32 seq,
+			   mnl_cb_t cb,
+			   gpointer data,
+			   GError **error)
+{
+	g_return_val_if_fail(nlg != NULL, FALSE);
+	return fu_devlink_netlink_msg_cb_run(nlg, len, seq, cb, data, error) != MNL_CB_ERROR;
+}
+
+/* callback for extracting event_id from devlink messages */
+static gint
+fu_devlink_netlink_event_id_msg_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	struct genlmsghdr *genl = mnl_nlmsg_get_payload(nlh);
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1] = {};
+	GStrvBuilder *tuples_builder = data;
+
+	switch (genl->cmd) {
+	case DEVLINK_CMD_GET:
+		g_strv_builder_add(tuples_builder, "cmd=get");
+		break;
+	case DEVLINK_CMD_RELOAD:
+		g_strv_builder_add(tuples_builder, "cmd=reload");
+		break;
+	case DEVLINK_CMD_INFO_GET:
+		g_strv_builder_add(tuples_builder, "cmd=info_get");
+		break;
+	case DEVLINK_CMD_FLASH_UPDATE:
+		g_strv_builder_add(tuples_builder, "cmd=flash_update");
+		break;
+	default:
+		break;
+	}
+
+	/* parse attributes */
+	mnl_attr_parse(nlh, sizeof(*genl), fu_devlink_netlink_attr_cb, tb);
+
+	/* extract attribute name and value based on type */
+	if (tb[DEVLINK_ATTR_BUS_NAME] != NULL) {
+		g_strv_builder_add(
+		    tuples_builder,
+		    g_strdup_printf("bus_name=%s", mnl_attr_get_str(tb[DEVLINK_ATTR_BUS_NAME])));
+	}
+	if (tb[DEVLINK_ATTR_DEV_NAME] != NULL) {
+		g_strv_builder_add(
+		    tuples_builder,
+		    g_strdup_printf("dev_name=%s", mnl_attr_get_str(tb[DEVLINK_ATTR_DEV_NAME])));
+	}
+	if (tb[DEVLINK_ATTR_FLASH_UPDATE_FILE_NAME] != NULL) {
+		g_strv_builder_add(
+		    tuples_builder,
+		    g_strdup_printf("file_name=%s",
+				    mnl_attr_get_str(tb[DEVLINK_ATTR_FLASH_UPDATE_FILE_NAME])));
+	}
+	if (tb[DEVLINK_ATTR_FLASH_UPDATE_COMPONENT] != NULL) {
+		g_strv_builder_add(
+		    tuples_builder,
+		    g_strdup_printf("component=%s",
+				    mnl_attr_get_str(tb[DEVLINK_ATTR_FLASH_UPDATE_COMPONENT])));
+	}
+	if (tb[DEVLINK_ATTR_RELOAD_ACTION] != NULL) {
+		g_strv_builder_add(
+		    tuples_builder,
+		    g_strdup_printf("reload_action=%u",
+				    mnl_attr_get_u8(tb[DEVLINK_ATTR_RELOAD_ACTION])));
+	}
+
+	return MNL_CB_OK;
+}
+
+static gchar *
+fu_devlink_netlink_get_event_id(FuDevlinkGenSocket *nlg, struct nlmsghdr *nlh)
+{
+	g_autoptr(GStrvBuilder) tuples_builder = g_strv_builder_new();
+	g_auto(GStrv) strv = NULL;
+
+	/* parse the message and build get event_id tuples */
+	mnl_cb_run(nlh,
+		   nlh->nlmsg_len,
+		   nlh->nlmsg_seq,
+		   nlh->nlmsg_pid,
+		   fu_devlink_netlink_event_id_msg_cb,
+		   tuples_builder);
+
+	strv = g_strv_builder_end(tuples_builder);
+
+	/* return the constructed event_id */
+	return g_strjoinv(",", strv);
+}
+
+/* receive and run callback on netlink messages */
+static gboolean
+fu_devlink_netlink_msg_recv_run(FuDevlinkGenSocket *nlg,
+				struct nlmsghdr *nlh,
+				mnl_cb_t cb,
+				gpointer data,
+				GError **error)
+{
+	FuDeviceEvent *event = NULL;
+	guint i = 0;
+	guint32 seq = nlh->nlmsg_seq;
+	gint rc;
+	g_autofree gchar *event_id = NULL;
+
+	/* generate event ID if device is available and we need emulation/recording */
+	if (nlg->is_emulated || nlg->save_events)
+		event_id = fu_devlink_netlink_get_event_id(nlg, nlh);
+
+	if (nlg->is_emulated) {
+		event = fu_device_load_event(nlg->device, event_id, error);
+		if (event == NULL)
+			return FALSE;
+	}
+
+	if (nlg->save_events)
+		event = fu_device_save_event(nlg->device, event_id);
+
+	do {
+		if (nlg->is_emulated) {
+			const guint8 *response_buf;
+			gsize response_len;
+			g_autofree gchar *response_key = g_strdup_printf("ResponseData%u", i++);
+			g_autoptr(GBytes) response_data =
+			    fu_device_event_get_bytes(event, response_key, NULL);
+
+			if (response_data == NULL)
+				return TRUE;
+
+			response_buf = g_bytes_get_data(response_data, &response_len);
+			if (response_len > (gsize)FU_DEVLINK_NETLINK_BUF_SIZE) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
+					    "recorded response too large: %zu > %ld",
+					    response_len,
+					    FU_DEVLINK_NETLINK_BUF_SIZE);
+				return FALSE;
+			}
+			memcpy(nlg->buf, response_buf, response_len); /* nocheck:blocked */
+			rc = response_len;
+		} else {
+			rc = mnl_socket_recvfrom(nlg->nl, nlg->buf, MNL_SOCKET_BUFFER_SIZE);
+			if (rc == 0)
+				return TRUE;
+			if (rc < 0) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "failed to receive netlink message: %s",
+					    fwupd_strerror(errno));
+				return FALSE;
+			}
+			if (nlg->save_events) {
+				g_autoptr(GBytes) response_data = g_bytes_new(nlg->buf, rc);
+				g_autofree gchar *response_key =
+				    g_strdup_printf("ResponseData%u", i++);
+
+				fu_device_event_set_bytes(event, response_key, response_data);
+			}
+		}
+
+		rc = fu_devlink_netlink_msg_cb_run(nlg, rc, seq, cb, data, error);
+	} while (rc > MNL_CB_STOP);
+
+	return rc == MNL_CB_ERROR ? FALSE : TRUE;
+}
+
+/* send message and receive response */
+gboolean
+fu_devlink_netlink_msg_send_recv(FuDevlinkGenSocket *nlg,
+				 struct nlmsghdr *nlh,
+				 mnl_cb_t cb,
+				 gpointer data,
+				 GError **error)
+{
+	gint rc;
+
+	g_return_val_if_fail(nlg != NULL, FALSE);
+	g_return_val_if_fail(nlh != NULL, FALSE);
+
+	if (!nlg->is_emulated) {
+		/* send netlink message */
+		rc = mnl_socket_sendto(nlg->nl, nlh, nlh->nlmsg_len);
+		if (rc < 0) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "failed to send netlink message: %s",
+				    fwupd_strerror(errno));
+			return FALSE;
+		}
+	}
+	return fu_devlink_netlink_msg_recv_run(nlg, nlh, cb, data, error);
+}
+
+gboolean
+fu_devlink_netlink_msg_send(FuDevlinkGenSocket *nlg, struct nlmsghdr *nlh, GError **error)
+{
+	g_return_val_if_fail(nlg != NULL, FALSE);
+	return fu_devlink_netlink_msg_send_recv(nlg, nlh, NULL, NULL, error);
+}
+
+/* generic netlink control attribute callback */
+static gint
+fu_devlink_netlink_genl_ctrl_attr_cb(const struct nlattr *attr, gpointer data)
+{
+	const struct nlattr **tb = data;
+	gint type = mnl_attr_get_type(attr);
+
+	if (mnl_attr_type_valid(attr, CTRL_ATTR_MAX) < 0)
+		return MNL_CB_OK;
+
+	tb[type] = attr;
+	return MNL_CB_OK;
+}
+
+static gint
+fu_devlink_netlink_genl_mcast_group_attr_cb(const struct nlattr *attr, gpointer data)
+{
+	const struct nlattr **tb = data;
+	gint type = mnl_attr_get_type(attr);
+
+	if (mnl_attr_type_valid(attr, CTRL_ATTR_MCAST_GRP_MAX) < 0)
+		return MNL_CB_OK;
+
+	tb[type] = attr;
+	return MNL_CB_OK;
+}
+
+/* family resolution callback */
+static gint
+fu_devlink_netlink_fu_devlink_netlink_genl_family_get_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkGenSocket *nlg = data;
+	struct genlmsghdr *genl = mnl_nlmsg_get_payload(nlh);
+	struct nlattr *tb[CTRL_ATTR_MAX + 1] = {};
+	struct nlattr *mcgrp;
+
+	g_return_val_if_fail(nlh != NULL, MNL_CB_ERROR);
+
+	mnl_attr_parse(nlh, sizeof(*genl), fu_devlink_netlink_genl_ctrl_attr_cb, tb);
+	if (tb[CTRL_ATTR_FAMILY_ID] == NULL)
+		return MNL_CB_ERROR;
+	nlg->family_id = mnl_attr_get_u16(tb[CTRL_ATTR_FAMILY_ID]);
+
+	if (tb[CTRL_ATTR_MCAST_GROUPS] == NULL)
+		return MNL_CB_ERROR;
+
+	mnl_attr_for_each_nested(mcgrp, tb[CTRL_ATTR_MCAST_GROUPS])
+	{
+		struct nlattr *tb_grp[CTRL_ATTR_MCAST_GRP_MAX + 1] = {};
+
+		mnl_attr_parse_nested(mcgrp, fu_devlink_netlink_genl_mcast_group_attr_cb, tb_grp);
+
+		if (tb_grp[CTRL_ATTR_MCAST_GRP_NAME] == NULL ||
+		    tb_grp[CTRL_ATTR_MCAST_GRP_ID] == NULL)
+			continue;
+
+		if (g_strcmp0(mnl_attr_get_str(tb_grp[CTRL_ATTR_MCAST_GRP_NAME]),
+			      DEVLINK_GENL_MCGRP_CONFIG_NAME) == 0) {
+			nlg->config_group_id = mnl_attr_get_u32(tb_grp[CTRL_ATTR_MCAST_GRP_ID]);
+			return MNL_CB_OK;
+		}
+	}
+
+	return MNL_CB_ERROR;
+}
+
+/* get generic netlink family ID */
+static gboolean
+fu_devlink_netlink_genl_family_get(FuDevlinkGenSocket *nlg,
+				   const gchar *family_name,
+				   GError **error)
+{
+	struct genlmsghdr hdr = {
+	    .cmd = CTRL_CMD_GETFAMILY,
+	    .version = 0x1,
+	};
+	struct nlmsghdr *nlh;
+
+	g_return_val_if_fail(nlg != NULL, FALSE);
+	g_return_val_if_fail(family_name != NULL, FALSE);
+
+	nlh = fu_devlink_netlink_msg_prepare(nlg->buf, GENL_ID_CTRL, FALSE, &hdr, sizeof(hdr));
+	mnl_attr_put_strz(nlh, CTRL_ATTR_FAMILY_NAME, family_name);
+	return fu_devlink_netlink_msg_send_recv(
+	    nlg,
+	    nlh,
+	    fu_devlink_netlink_fu_devlink_netlink_genl_family_get_cb,
+	    nlg,
+	    error);
+}
+
+/* open generic netlink socket for devlink family */
+FuDevlinkGenSocket *
+fu_devlink_netlink_gen_socket_open(FuDevice *device, GError **error)
+{
+	g_autoptr(FuDevlinkGenSocket) nlg = NULL;
+	gint one = 1;
+	gint rc;
+
+	g_return_val_if_fail(FU_IS_DEVICE(device) || device == NULL, NULL);
+
+	/* allocate and initialize structure */
+	nlg = g_new0(FuDevlinkGenSocket, 1);
+
+	/* initialize structure with properly aligned buffer */
+	nlg->buf = g_malloc0(FU_DEVLINK_NETLINK_BUF_SIZE);
+
+	if (device != NULL) {
+		nlg->device = g_object_ref(device);
+		if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
+			/* skip actual socket operations if emulated */
+			/* create dummy pipe for emulation */
+			if (!g_unix_open_pipe(nlg->pipe_fds, O_CLOEXEC, error)) {
+				g_prefix_error_literal(error,
+						       "failed to create pipe for emulation: ");
+				return NULL;
+			}
+			nlg->is_emulated = TRUE;
+
+			/* set family ID to a valid value */
+			nlg->family_id = NLMSG_MIN_TYPE + 1;
+			return g_steal_pointer(&nlg);
+		}
+	}
+
+	/* open netlink socket */
+	nlg->nl = mnl_socket_open(NETLINK_GENERIC);
+	if (nlg->nl == NULL) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to open netlink socket: %s",
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+
+	rc = mnl_socket_setsockopt(nlg->nl, NETLINK_CAP_ACK, &one, sizeof(one));
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to set netlink CAP_ACK: %s",
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+
+	rc = mnl_socket_setsockopt(nlg->nl, NETLINK_EXT_ACK, &one, sizeof(one));
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to set netlink EXT_ACK: %s",
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+
+	rc = mnl_socket_bind(nlg->nl, 0, MNL_SOCKET_AUTOPID);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to bind netlink socket: %s",
+			    fwupd_strerror(errno));
+		return NULL;
+	}
+
+	/* resolve devlink family ID dynamically */
+	if (!fu_devlink_netlink_genl_family_get(nlg, DEVLINK_GENL_NAME, error)) {
+		g_prefix_error_literal(error, "failed to resolve devlink family ID: ");
+		return NULL;
+	}
+
+	if (device != NULL &&
+	    fu_context_has_flag(fu_device_get_context(nlg->device), FU_CONTEXT_FLAG_SAVE_EVENTS)) {
+		nlg->save_events = TRUE;
+	}
+
+	return g_steal_pointer(&nlg);
+}
+
+/* close generic netlink socket */
+void
+fu_devlink_netlink_gen_socket_close(FuDevlinkGenSocket *nlg)
+{
+	if (nlg == NULL)
+		return;
+	if (nlg->nl != NULL)
+		mnl_socket_close(nlg->nl);
+	/* close both ends of the pipe if they were created */
+	if (nlg->pipe_fds[0] != 0)
+		g_close(nlg->pipe_fds[0], NULL);
+	if (nlg->pipe_fds[1] != 0)
+		g_close(nlg->pipe_fds[1], NULL);
+	g_free(nlg->buf);
+	if (nlg->device != NULL)
+		g_object_unref(nlg->device);
+	g_free(nlg);
+}
+
+gint
+fu_devlink_netlink_gen_socket_get_fd(FuDevlinkGenSocket *nlg)
+{
+	g_return_val_if_fail(nlg != NULL, -1);
+
+	/* return read side of pipe for emulated devices */
+	if (nlg->is_emulated)
+		return nlg->pipe_fds[0]; /* read end of the pipe */
+	return mnl_socket_get_fd(nlg->nl);
+}
+
+gchar *
+fu_devlink_netlink_gen_socket_get_buf(FuDevlinkGenSocket *nlg)
+{
+	g_return_val_if_fail(nlg != NULL, NULL);
+	return nlg->buf;
+}
+
+/* prepare devlink command message */
+struct nlmsghdr *
+fu_devlink_netlink_cmd_prepare(FuDevlinkGenSocket *nlg, guint8 cmd, gboolean dump)
+{
+	struct genlmsghdr hdr = {
+	    .cmd = cmd,
+	    .version = DEVLINK_GENL_VERSION,
+	};
+
+	g_return_val_if_fail(nlg != NULL, NULL);
+
+	return fu_devlink_netlink_msg_prepare(nlg->buf, nlg->family_id, dump, &hdr, sizeof(hdr));
+}
+
+gboolean
+fu_devlink_netlink_mcast_group_subscribe(FuDevlinkGenSocket *nlg, GError **error)
+{
+	guint32 devlink_config_grp = nlg->config_group_id;
+	gint rc;
+
+	g_return_val_if_fail(nlg != NULL, FALSE);
+
+	/* skip multicast subscription for emulated devices */
+	if (nlg->is_emulated)
+		return TRUE;
+
+	rc = mnl_socket_setsockopt(nlg->nl,
+				   NETLINK_ADD_MEMBERSHIP,
+				   &devlink_config_grp,
+				   sizeof(devlink_config_grp));
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to subscribe to devlink notifications: %s",
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+/* simple attribute parser callback for devlink attributes */
+gint
+fu_devlink_netlink_attr_cb(const struct nlattr *attr, gpointer data)
+{
+	const struct nlattr **tb = data;
+	gint type = mnl_attr_get_type(attr);
+	gint rc;
+
+	rc = mnl_attr_type_valid(attr, DEVLINK_ATTR_MAX);
+	if (rc < 0)
+		return MNL_CB_OK;
+
+	tb[type] = attr;
+	return MNL_CB_OK;
+}

--- a/plugins/devlink/fu-devlink-netlink.h
+++ b/plugins/devlink/fu-devlink-netlink.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#include <libmnl/libmnl.h>
+#include <linux/devlink.h>
+#include <linux/genetlink.h>
+#include <linux/netlink.h>
+
+/* generic netlink socket wrapper */
+typedef struct {
+	struct mnl_socket *nl;
+	gchar *buf;
+	guint32 family_id;
+	guint32 config_group_id;
+	FuDevice *device; /* device for emulation recording/playback */
+	gboolean is_emulated;
+	gboolean save_events;
+	gint pipe_fds[2];  /* dummy pipe for emulation (read=0, write=1) */
+} FuDevlinkGenSocket;
+
+/* do zero check to silence warnings*/
+#define FU_DEVLINK_NETLINK_BUF_SIZE (MNL_SOCKET_BUFFER_SIZE > 0 ? MNL_SOCKET_BUFFER_SIZE : 0)
+
+/* send/receive functions */
+gboolean
+fu_devlink_netlink_msg_run(FuDevlinkGenSocket *nlg,
+			   gsize len,
+			   guint32 seq,
+			   mnl_cb_t cb,
+			   gpointer data,
+			   GError **error) G_GNUC_NON_NULL(1, 4);
+
+gboolean
+fu_devlink_netlink_msg_send_recv(FuDevlinkGenSocket *nlg,
+				 struct nlmsghdr *nlh,
+				 mnl_cb_t cb,
+				 gpointer data,
+				 GError **error) G_GNUC_NON_NULL(1, 2);
+
+gboolean
+fu_devlink_netlink_msg_send(FuDevlinkGenSocket *nlg, struct nlmsghdr *nlh, GError **error) G_GNUC_NON_NULL(1, 2);
+
+/* socket management */
+FuDevlinkGenSocket *
+fu_devlink_netlink_gen_socket_open(FuDevice *device, GError **error);
+
+void
+fu_devlink_netlink_gen_socket_close(FuDevlinkGenSocket *nlg);
+
+gint
+fu_devlink_netlink_gen_socket_get_fd(FuDevlinkGenSocket *nlg) G_GNUC_NON_NULL(1);
+
+gchar *
+fu_devlink_netlink_gen_socket_get_buf(FuDevlinkGenSocket *nlg) G_GNUC_NON_NULL(1);
+
+/* prepare devlink command message */
+struct nlmsghdr *
+fu_devlink_netlink_cmd_prepare(FuDevlinkGenSocket *nlg, guint8 cmd, gboolean dump) G_GNUC_NON_NULL(1);
+
+/* multicast group management */
+gboolean
+fu_devlink_netlink_mcast_group_subscribe(FuDevlinkGenSocket *nlg, GError **error) G_GNUC_NON_NULL(1);
+
+/* attribute parsing callback */
+gint
+fu_devlink_netlink_attr_cb(const struct nlattr *attr, gpointer data) G_GNUC_NON_NULL(1, 2);
+
+/* cleanup function for auto cleanup */
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuDevlinkGenSocket, fu_devlink_netlink_gen_socket_close)

--- a/plugins/devlink/fu-devlink-plugin.c
+++ b/plugins/devlink/fu-devlink-plugin.c
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-devlink-backend.h"
+#include "fu-devlink-device.h"
+#include "fu-devlink-netlink.h"
+#include "fu-devlink-plugin.h"
+
+struct _FuDevlinkPlugin {
+	FuPlugin parent_instance;
+	FuDevlinkGenSocket *nlg;
+	GSource *netlink_source;
+	FuDevlinkBackend *backend;
+};
+
+G_DEFINE_TYPE(FuDevlinkPlugin, fu_devlink_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_devlink_plugin_device_added_from_netlink(FuDevlinkPlugin *self, const struct nlmsghdr *nlh)
+{
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1] = {};
+	const gchar *bus_name = NULL;
+	const gchar *dev_name = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* parse netlink attributes using libmnl */
+	mnl_attr_parse(nlh, sizeof(struct genlmsghdr), fu_devlink_netlink_attr_cb, tb);
+
+	/* extract bus and device names */
+	if (tb[DEVLINK_ATTR_BUS_NAME] != NULL)
+		bus_name = mnl_attr_get_str(tb[DEVLINK_ATTR_BUS_NAME]);
+	if (tb[DEVLINK_ATTR_DEV_NAME] != NULL)
+		dev_name = mnl_attr_get_str(tb[DEVLINK_ATTR_DEV_NAME]);
+
+	if (bus_name == NULL || dev_name == NULL) {
+		g_debug("devlink device notification missing bus_name or dev_name");
+		return;
+	}
+
+	g_debug("devlink device added: %s/%s", bus_name, dev_name);
+
+	/* use backend to create device with proper hierarchy */
+	if (!fu_devlink_backend_device_added(self->backend, bus_name, dev_name, &error)) {
+		g_warning("failed to add devlink device %s/%s: %s",
+			  bus_name,
+			  dev_name,
+			  error->message);
+		return;
+	}
+}
+
+static void
+fu_devlink_plugin_device_removed_from_netlink(FuDevlinkPlugin *self, const struct nlmsghdr *nlh)
+{
+	struct nlattr *tb[DEVLINK_ATTR_MAX + 1] = {};
+	const gchar *bus_name = NULL;
+	const gchar *dev_name = NULL;
+
+	/* parse netlink attributes using libmnl */
+	mnl_attr_parse(nlh, sizeof(struct genlmsghdr), fu_devlink_netlink_attr_cb, tb);
+
+	/* extract bus and device names */
+	if (tb[DEVLINK_ATTR_BUS_NAME] != NULL)
+		bus_name = mnl_attr_get_str(tb[DEVLINK_ATTR_BUS_NAME]);
+	if (tb[DEVLINK_ATTR_DEV_NAME] != NULL)
+		dev_name = mnl_attr_get_str(tb[DEVLINK_ATTR_DEV_NAME]);
+
+	if (bus_name == NULL || dev_name == NULL) {
+		g_debug("devlink device removal notification missing bus_name or dev_name");
+		return;
+	}
+
+	g_debug("devlink device removed: %s/%s", bus_name, dev_name);
+
+	/* use backend to remove device */
+	fu_devlink_backend_device_removed(self->backend, bus_name, dev_name);
+}
+
+/* callback for processing individual netlink messages */
+static gint
+fu_devlink_plugin_process_message_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(data);
+	struct genlmsghdr *genl;
+
+	genl = mnl_nlmsg_get_payload(nlh);
+	switch (genl->cmd) {
+	case DEVLINK_CMD_NEW:
+		fu_devlink_plugin_device_added_from_netlink(self, nlh);
+		break;
+	case DEVLINK_CMD_DEL:
+		fu_devlink_plugin_device_removed_from_netlink(self, nlh);
+		break;
+	default:
+		break;
+	}
+
+	return MNL_CB_OK;
+}
+
+static gboolean
+fu_devlink_plugin_netlink_cb(GIOChannel *channel, GIOCondition condition, gpointer user_data)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(user_data);
+	gsize len;
+	GIOStatus status;
+	g_autoptr(GError) error_local = NULL;
+
+	if (condition & (G_IO_ERR | G_IO_HUP)) {
+		g_debug("devlink netlink socket error");
+		return FALSE;
+	}
+
+	/* read netlink message via GIOChannel */
+	status = g_io_channel_read_chars(channel,
+					 fu_devlink_netlink_gen_socket_get_buf(self->nlg),
+					 FU_DEVLINK_NETLINK_BUF_SIZE,
+					 &len,
+					 &error_local);
+	if (status != G_IO_STATUS_NORMAL) {
+		if (error_local != NULL)
+			g_debug("failed to read devlink netlink message: %s", error_local->message);
+		return TRUE;
+	}
+
+	/* process netlink messages */
+	if (!fu_devlink_netlink_msg_run(self->nlg,
+					len,
+					0,
+					fu_devlink_plugin_process_message_cb,
+					self,
+					&error_local))
+		g_warning("failed to process netlink message: %s", error_local->message);
+
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_plugin_setup_netlink(FuDevlinkPlugin *self, GError **error)
+{
+	gint fd;
+	guint watch_id;
+	g_autoptr(GIOChannel) channel = NULL;
+
+	/* open devlink netlink socket */
+	self->nlg = fu_devlink_netlink_gen_socket_open(NULL, error);
+	if (self->nlg == NULL)
+		return FALSE;
+
+	/* subscribe to devlink multicast notifications */
+	if (!fu_devlink_netlink_mcast_group_subscribe(self->nlg, error))
+		return FALSE;
+
+	/* create GIOChannel for the netlink socket */
+	fd = fu_devlink_netlink_gen_socket_get_fd(self->nlg);
+	channel = g_io_channel_unix_new(fd);
+	g_io_channel_set_encoding(channel, NULL, NULL);
+	g_io_channel_set_buffered(channel, FALSE);
+
+	/* setup monitoring source using proper GIO pattern */
+	watch_id = g_io_add_watch(channel,
+				  G_IO_IN | G_IO_ERR | G_IO_HUP,
+				  fu_devlink_plugin_netlink_cb,
+				  self);
+	self->netlink_source = g_main_context_find_source_by_id(NULL, watch_id);
+	if (self->netlink_source != NULL)
+		g_source_ref(self->netlink_source);
+
+	return TRUE;
+}
+
+/* device enumeration callback */
+static gint
+fu_devlink_plugin_enumerate_cb(const struct nlmsghdr *nlh, gpointer data)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(data);
+	struct genlmsghdr *genl;
+
+	genl = mnl_nlmsg_get_payload(nlh);
+	if (genl->cmd == DEVLINK_CMD_NEW)
+		fu_devlink_plugin_device_added_from_netlink(self, nlh);
+
+	return MNL_CB_OK;
+}
+
+static gboolean
+fu_devlink_plugin_enumerate_devices(FuDevlinkPlugin *self, GError **error)
+{
+	struct nlmsghdr *nlh;
+
+	/* prepare device enumeration command */
+	nlh = fu_devlink_netlink_cmd_prepare(self->nlg, DEVLINK_CMD_GET, TRUE);
+
+	/* send enumeration request and receive responses */
+	if (!fu_devlink_netlink_msg_send_recv(self->nlg,
+					      nlh,
+					      fu_devlink_plugin_enumerate_cb,
+					      self,
+					      error)) {
+		g_prefix_error_literal(error, "failed to enumerate devlink devices: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(plugin);
+
+	/* setup devlink netlink monitoring */
+	if (!fu_devlink_plugin_setup_netlink(self, error)) {
+		g_prefix_error_literal(error, "failed to setup devlink netlink: ");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_devlink_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(plugin);
+
+	/* enumerate existing devlink devices */
+	if (!fu_devlink_plugin_enumerate_devices(self, error)) {
+		g_prefix_error_literal(error, "failed to enumerate devlink devices: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void
+fu_devlink_plugin_finalize(GObject *object)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(object);
+
+	/* clean up netlink resources */
+	if (self->netlink_source != NULL) {
+		g_source_destroy(self->netlink_source);
+		g_source_unref(self->netlink_source);
+	}
+
+	fu_devlink_netlink_gen_socket_close(self->nlg);
+
+	/* clean up backend */
+	if (self->backend != NULL)
+		g_object_unref(self->backend);
+
+	G_OBJECT_CLASS(fu_devlink_plugin_parent_class)->finalize(object);
+}
+
+static void
+fu_devlink_plugin_constructed(GObject *obj)
+{
+	FuDevlinkPlugin *self = FU_DEVLINK_PLUGIN(obj);
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	FuContext *ctx = fu_plugin_get_context(plugin);
+
+	/* create and add devlink backend */
+	self->backend = FU_DEVLINK_BACKEND(fu_devlink_backend_new(ctx));
+	fu_context_add_backend(ctx, FU_BACKEND(self->backend));
+	fu_context_add_quirk_key(ctx, "DevlinkFixedVersions");
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_DEVLINK_DEVICE);
+}
+
+static void
+fu_devlink_plugin_init(FuDevlinkPlugin *self)
+{
+}
+
+static void
+fu_devlink_plugin_class_init(FuDevlinkPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	object_class->finalize = fu_devlink_plugin_finalize;
+	object_class->constructed = fu_devlink_plugin_constructed;
+	plugin_class->startup = fu_devlink_plugin_startup;
+	plugin_class->coldplug = fu_devlink_plugin_coldplug;
+}

--- a/plugins/devlink/fu-devlink-plugin.h
+++ b/plugins/devlink/fu-devlink-plugin.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuDevlinkPlugin, fu_devlink_plugin, FU, DEVLINK_PLUGIN, FuPlugin)

--- a/plugins/devlink/fu-self-test.c
+++ b/plugins/devlink/fu-self-test.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 NVIDIA Corporation & Affiliates
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-context-private.h"
+#include "fu-devlink-component.h"
+#include "fu-devlink-device.h"
+#include "fu-devlink-plugin.h"
+#include "fu-plugin-private.h"
+
+typedef struct {
+	guint device_id;
+} FuDevlinkNetdevsim;
+
+static gboolean
+fu_devlink_file_write_helper(const gchar *path, const guint value, GError **error)
+{
+	g_autofree gchar *value_str = g_strdup_printf("%u", value);
+	g_autoptr(FuIOChannel) io = NULL;
+
+	/* check if file exists first */
+	if (!g_file_test(path, G_FILE_TEST_IS_REGULAR)) {
+		g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "file not found: %s", path);
+		return FALSE;
+	}
+
+	io = fu_io_channel_new_file(path, FU_IO_CHANNEL_OPEN_FLAG_WRITE, error);
+	if (io == NULL)
+		return FALSE;
+
+	return fu_io_channel_write_raw(io,
+				       (const guint8 *)value_str,
+				       strlen(value_str),
+				       1000,
+				       FU_IO_CHANNEL_FLAG_NONE,
+				       error);
+}
+
+static gboolean
+fu_devlink_netdevsim_sysfs_write(const gchar *filename, const guint value, GError **error)
+{
+	g_autofree gchar *sysfs_dir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR);
+	g_autofree gchar *path = g_build_filename(sysfs_dir, "bus", "netdevsim", filename, NULL);
+
+	return fu_devlink_file_write_helper(path, value, error);
+}
+
+static gboolean
+fu_devlink_netdevsim_debugfs_write(const guint device_id,
+				   const gchar *filename,
+				   const guint value,
+				   GError **error)
+{
+	g_autofree gchar *device_id_str = g_strdup_printf("netdevsim%u", device_id);
+	g_autofree gchar *debugfs_dir = fu_path_from_kind(FU_PATH_KIND_DEBUGFSDIR);
+	g_autofree gchar *path =
+	    g_build_filename(debugfs_dir, "netdevsim", device_id_str, filename, NULL);
+
+	return fu_devlink_file_write_helper(path, value, error);
+}
+
+static void
+fu_devlink_netdevsim_cleanup(FuDevlinkNetdevsim *ndsim)
+{
+	g_autoptr(GError) error_local = NULL;
+
+	if (ndsim->device_id != 0) {
+		/* remove netdevsim device */
+		if (!fu_devlink_netdevsim_sysfs_write("del_device",
+						      ndsim->device_id,
+						      &error_local)) {
+			g_debug("Failed to remove netdevsim device %u: %s",
+				ndsim->device_id,
+				error_local->message);
+		}
+	}
+	g_free(ndsim);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuDevlinkNetdevsim, fu_devlink_netdevsim_cleanup)
+
+#define FU_DEVLINK_NETDEVSIM_FW_UPDATE_FLASH_CHUNK_TIME_MS 1 /* 1ms */
+
+static FuDevlinkNetdevsim *
+fu_devlink_netdevsim_new(guint device_id, GError **error)
+{
+	g_autoptr(FuDevlinkNetdevsim) ndsim = g_new0(FuDevlinkNetdevsim, 1);
+	g_autoptr(GError) error_local = NULL;
+
+	/* create netdevsim device */
+	if (!fu_devlink_netdevsim_sysfs_write("new_device", device_id, error))
+		return NULL;
+
+	ndsim->device_id = device_id;
+
+	if (!fu_devlink_netdevsim_debugfs_write(device_id,
+						"fw_update_flash_chunk_time_ms",
+						FU_DEVLINK_NETDEVSIM_FW_UPDATE_FLASH_CHUNK_TIME_MS,
+						&error_local)) {
+		g_debug("Failed to write fw_update_flash_chunk_time_ms: %s", error_local->message);
+		g_clear_error(&error_local);
+	}
+
+	return g_steal_pointer(&ndsim);
+}
+
+#define FU_DEVLINK_NETDEVSIM_DEVICE_ID	 472187
+#define FU_DEVLINK_NETDEVSIM_DEVICE_NAME "netdevsim" G_STRINGIFY(FU_DEVLINK_NETDEVSIM_DEVICE_ID)
+
+static void
+fu_devlink_plugin_flash_func(void)
+{
+	gboolean ret;
+	const gchar *fw_content = "FWUPD_TEST_FIRMWARE_v2.0.0\nTest firmware for devlink device";
+	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuDevice) component = NULL;
+	g_autoptr(FuDevlinkNetdevsim) ndsim = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuFirmware) firmware = fu_firmware_new();
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GBytes) fw_data = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autofree gchar *instance_id = NULL;
+
+	/* create test netdevsim to set up netdevsim device */
+	ndsim = fu_devlink_netdevsim_new(FU_DEVLINK_NETDEVSIM_DEVICE_ID, &error_local);
+	if (ndsim == NULL) {
+		g_autofree gchar *msg =
+		    g_strdup_printf("failed to create netdevsim device: %s", error_local->message);
+		g_test_skip(msg);
+		return;
+	}
+
+	/* create device with valid bus and device names */
+	device = fu_devlink_device_new(ctx, "netdevsim", FU_DEVLINK_NETDEVSIM_DEVICE_NAME);
+	g_assert_nonnull(device);
+
+	/* probe device first */
+	ret = fu_device_probe(device, &error_local);
+	g_assert_true(ret);
+
+	/* open device */
+	ret = fu_device_open(device, &error_local);
+
+	g_assert_true(ret);
+
+	/* create fw.mgmt component */
+	component = fu_devlink_component_new(device, "fw.mgmt");
+	g_assert_nonnull(component);
+
+	/* set up parent-child relationship */
+	fu_device_add_child(device, component);
+
+	/* set component version for testing */
+	fu_device_set_version(component, "1.0.0");
+
+	/* create firmware */
+	fw_data = g_bytes_new(fw_content, strlen(fw_content));
+	fu_firmware_set_bytes(firmware, fw_data);
+	fu_firmware_set_version(firmware, "2.0.0");
+
+	/* prepare the component */
+	ret = fu_device_prepare(component, progress, FWUPD_INSTALL_FLAG_NONE, &error_local);
+	g_assert_true(ret);
+
+	/* test firmware flashing on the fw.mgmt component */
+	g_test_message("Testing firmware flash for fw.mgmt component on netdevsim/%s",
+		       FU_DEVLINK_NETDEVSIM_DEVICE_NAME);
+	ret = fu_device_write_firmware(component,
+				       firmware,
+				       progress,
+				       FWUPD_INSTALL_FLAG_NONE,
+				       &error_local);
+	g_assert_true(ret);
+
+	g_test_message("Firmware flash completed successfully for fw.mgmt component!");
+	g_assert_cmpuint(fu_progress_get_percentage(progress), ==, 100);
+
+	/* cleanup the component */
+	ret = fu_device_cleanup(component, progress, FWUPD_INSTALL_FLAG_NONE, &error_local);
+	g_assert_true(ret);
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+
+	/* only critical and error are fatal */
+	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+
+	/* tests go here */
+	g_test_add_func("/devlink/plugin/flash", fu_devlink_plugin_flash_func);
+	return g_test_run();
+}

--- a/plugins/devlink/meson.build
+++ b/plugins/devlink/meson.build
@@ -1,0 +1,60 @@
+host_machine.system() == 'linux' or subdir_done()
+libmnl.found() or subdir_done()
+
+cargs = ['-DG_LOG_DOMAIN="FuPluginDevlink"']
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+
+plugin_quirks += files('devlink.quirk')
+plugin_builtin_devlink = static_library('fu_plugin_devlink',
+  sources: [
+    'fu-devlink-plugin.c',
+    'fu-devlink-backend.c',
+    'fu-devlink-device.c',
+    'fu-devlink-component.c',
+    'fu-devlink-netlink.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: [
+    fwupdplugin,
+    fwupd,
+  ],
+  c_args: cargs,
+  dependencies: [
+    plugin_deps,
+    valgrind,
+    libmnl,
+  ],
+)
+plugin_builtins += plugin_builtin_devlink
+
+device_tests += files(
+  'tests/devlink-netdevsim.json',
+)
+
+if get_option('tests')
+  env = environment()
+  env.set('G_TEST_SRCDIR', meson.current_source_dir())
+  env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+  e = executable(
+    'devlink-self-test',
+    sources: [
+      'fu-self-test.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: [
+      plugin_deps,
+      valgrind,
+      libmnl,
+    ],
+    link_with: [
+      plugin_builtin_devlink,
+      fwupdplugin,
+      fwupd,
+    ],
+    install: true,
+    install_rpath: libdir_pkg,
+    install_tag: 'tests',
+    install_dir: installed_test_bindir,
+  )
+  test('devlink-self-test', e, env: env)
+endif

--- a/plugins/devlink/tests/devlink-netdevsim.json
+++ b/plugins/devlink/tests/devlink-netdevsim.json
@@ -1,0 +1,20 @@
+{
+  "name": "Devlink Netdevsim Setup",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "fbdca7ac3b80f7df24b1a1b435963a46aee19b987ba55b5cff7dddb4de158664-netdevsim_test_firmware_new.cab",
+      "emulation-url": "def54dc305e6d84bafcc8d8fe551efcd31c314b89f54ec5b76734ee954f2032a-netdevsim_setup_install_record_new.zip",
+      "components": [
+        {
+          "name": "fw.mgmt",
+          "protocol": "org.kernel.devlink",
+          "version": "10.20.30",
+          "guids": [
+            "6e9dfa4e-17f5-53dd-80d9-59a200c48b2d"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -43,6 +43,7 @@ plugins = {
   'dell': false,
   'dell-dock': false,
   'dell-kestrel': false,
+  'devlink': false,
   'dfu': false,
   'ebitdo': false,
   'egis-moc': false,


### PR DESCRIPTION
Type of pull request:

- [x] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
  - [x] Fill out `README.md` with update protocol
  - [x] Fill out `README.md` with any custom quirks and flags.
  - [ ] Fill out `README.md` with the vendor ID security value
    - devlink provides interface to various drivers and devlink plugin in generic
  - [ ] Implement `FuFirmware->write()` and include at least one fuzzer testcase in `src/fuzzing/firmware` for any custom `FuFirmware` subclass
    - no need, generic FuFirmware suits good as devlink plugin just passes firmware blobs of various formats
  - [x] CI run of the plugin for at least one target
  - [x] Document targets CI isn't currently run and the reasons (i.e. minimum versions needed or distribution limitations etc).
    - not aware of anything