### PR TITLE
modem-manager: Set QCDM device to raw mode

### DIFF
--- a/plugins/modem-manager/fu-mm-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-qcdm-device.c
@@ -10,6 +10,10 @@
 
 #include "fu-mm-qcdm-device.h"
 
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif
+
 G_DEFINE_TYPE(FuMmQcdmDevice, fu_mm_qcdm_device, FU_TYPE_MM_DEVICE)
 
 static gboolean
@@ -90,6 +94,51 @@ fu_mm_qcdm_device_probe(FuDevice *device, GError **error)
 }
 
 static gboolean
+fu_mm_qcdm_device_set_io_flags(FuMmQcdmDevice *self, GError **error)
+{
+#ifdef HAVE_TERMIOS_H
+	gint fd = fu_io_channel_unix_get_fd(fu_udev_device_get_io_channel(FU_UDEV_DEVICE(self)));
+	struct termios tio;
+
+	if (tcgetattr(fd, &tio) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "could not get termios attributes");
+		return FALSE;
+	}
+
+	cfmakeraw(&tio);
+
+	if (tcsetattr(fd, TCSANOW, &tio) != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "could not set termios attributes");
+		return FALSE;
+	}
+
+	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "Not supported as <termios.h> not found");
+	return FALSE;
+#endif
+}
+
+static gboolean
+fu_mm_qcdm_device_open(FuDevice *device, GError **error)
+{
+	FuMmQcdmDevice *self = FU_MM_QCDM_DEVICE(device);
+
+	if (!FU_DEVICE_CLASS(fu_mm_qcdm_device_parent_class)->open(device, error))
+		return FALSE;
+	return fu_mm_qcdm_device_set_io_flags(self, error);
+}
+
+static gboolean
 fu_mm_qcdm_device_prepare(FuDevice *device,
 			  FuProgress *progress,
 			  FwupdInstallFlags flags,
@@ -135,6 +184,7 @@ static void
 fu_mm_qcdm_device_class_init(FuMmQcdmDeviceClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->open = fu_mm_qcdm_device_open;
 	device_class->probe = fu_mm_qcdm_device_probe;
 	device_class->detach = fu_mm_qcdm_device_detach;
 	device_class->prepare = fu_mm_qcdm_device_prepare;


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

When using a port that was not previously configured by ModemManager (e.g. ModemManager 'ignored' port), we need to configure the serial ourselves (see [MM serial port config](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/blob/adb6dc9b44224136ccdd087f29f4796e0bfa54ed/src/mm-port-serial.c#L472)).