### PR TITLE
trivial: ci: add libmnl-dev to build deps

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1156,6 +1156,28 @@
       <package variant="aarch64" />
     </distro>
   </dependency>
+  <dependency id="libmnl-dev">
+    <distro id="arch">
+      <package variant="x86_64">libmnl</package>
+    </distro>
+    <distro id="centos">
+      <package variant="x86_64">libmnl-devel</package>
+    </distro>
+    <distro id="fedora">
+      <package variant="x86_64">libmnl-devel</package>
+      <package variant="aarch64">libmnl-devel</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+      <package variant="aarch64" />
+    </distro>
+  </dependency>
   <dependency id="libqmi-glib-dev">
     <distro id="fedora">
       <package variant="x86_64">libqmi-devel</package>


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Can't say it's one of the above. As suggested here: https://github.com/fwupd/fwupd/pull/9053#discussion_r2219640974 moving dependencies of devlink plugin to a separate PR.