### PR TITLE
Add support for ignoring network connectivity

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -19,6 +19,7 @@ with a non-standard filesystem layout.
 * `FWUPD_EFIVARS` can be set to `dummy` to emulate an EFI variable store
 * `FWUPD_FUZZER_RUNNING` if the firmware format is being fuzzed
 * `FWUPD_POLKIT_NOCHECK` if we should not check for polkit policies to be installed
+* `FWUPD_IGNORE_NETWORK_REACHABLE` if we should skip network connectivity tests
 * standard glibc variables like `LANG` are also honored for CLI tools that are translated
 * libcurl respects the session proxy, e.g. `http_proxy`, `all_proxy`, `sftp_proxy` and `no_proxy`
 


### PR DESCRIPTION
If a user has a complicated network setup they may be gated behind
GLib checks for network connectivity in order to use fwupd.

Add an escape hatch for glib bugs.

Link: https://gitlab.gnome.org/GNOME/glib/-/issues/3737
Closes: https://github.com/fwupd/fwupd/issues/9061
Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
