### PR TITLE
trivial: Use fwupd_error_convert() in more places

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -189,3 +189,7 @@ Remember: Plugins should be upstream!
 
 * Plugins that don't allow devices to function 100% through probe should use `FWUPD_PLUGIN_FLAG_MUTABLE_ENUMERATION`
 * `fu_device_get_contents_bytes()`: Add a maximum read size, typically `G_MAXSIZE`
+
+## 2.0.14
+
+* `fu_error_convert()`: Use `fwupd_error_convert()` instead

--- a/libfwupdplugin/fu-bios-settings.c
+++ b/libfwupdplugin/fu-bios-settings.c
@@ -66,7 +66,7 @@ fu_bios_setting_get_key(FwupdBiosSetting *attr, /* nocheck:name */
 	tmp = g_build_filename(fwupd_bios_setting_get_path(attr), key, NULL);
 	if (!g_file_get_contents(tmp, value_out, NULL, error)) {
 		g_prefix_error(error, "failed to load %s: ", key);
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	g_strchomp(*value_out);
@@ -393,7 +393,7 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 	sysfsfwdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR_FW_ATTRIB);
 	class_dir = g_dir_open(sysfsfwdir, 0, error);
 	if (class_dir == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	do {
@@ -409,7 +409,7 @@ fu_bios_settings_setup(FuBiosSettings *self, GError **error)
 		}
 		driver_dir = g_dir_open(path, 0, error);
 		if (driver_dir == NULL) {
-			fu_error_convert(error);
+			fwupd_error_convert(error);
 			return FALSE;
 		}
 		do {

--- a/libfwupdplugin/fu-common.c
+++ b/libfwupdplugin/fu-common.c
@@ -278,38 +278,6 @@ fu_power_state_is_ac(FuPowerState power_state)
 }
 
 /**
- * fu_error_convert:
- * @perror: (nullable): A #GError, perhaps with domain #GIOError
- *
- * Convert the error to a #FwupdError, if required.
- *
- * Since: 2.0.0
- **/
-void
-fu_error_convert(GError **perror)
-{
-	GError *error = (perror != NULL) ? *perror : NULL;
-
-	/* sanity check */
-	if (error == NULL)
-		return;
-
-	/* convert GIOError and GFileError */
-	fwupd_error_convert(perror);
-	if (error->domain == FWUPD_ERROR)
-		return;
-
-#ifndef SUPPORTED_BUILD
-	/* fallback */
-	g_critical("GError %s:%i sending over D-Bus was not converted to FwupdError",
-		   g_quark_to_string(error->domain),
-		   error->code);
-#endif
-	error->domain = FWUPD_ERROR;
-	error->code = FWUPD_ERROR_INTERNAL;
-}
-
-/**
  * fu_xmlb_builder_insert_kv:
  * @bn: #XbBuilderNode
  * @key: string key

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -121,6 +121,16 @@ fu_error_map_entry_to_gerror(guint value,
 			     guint n_entries,
 			     GError **error) G_GNUC_NON_NULL(2);
 
+typedef struct {
+	GQuark domain;
+	gint code;
+	FwupdError error;
+} FuErrorConvertEntry;
+
+gboolean
+fu_error_convert(const FuErrorConvertEntry entries[], guint n_entries, GError **perror)
+    G_GNUC_NON_NULL(1);
+
 void
 fu_xmlb_builder_insert_kv(XbBuilderNode *bn, const gchar *key, const gchar *value)
     G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -120,8 +120,6 @@ fu_error_map_entry_to_gerror(guint value,
 			     const FuErrorMapEntry entries[],
 			     guint n_entries,
 			     GError **error) G_GNUC_NON_NULL(2);
-void
-fu_error_convert(GError **perror);
 
 void
 fu_xmlb_builder_insert_kv(XbBuilderNode *bn, const gchar *key, const gchar *value)

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1475,7 +1475,7 @@ fu_firmware_parse_file(FuFirmware *self, GFile *file, FuFirmwareParseFlags flags
 
 	stream = g_file_read(file, NULL, error);
 	if (stream == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	return fu_firmware_parse_stream(self, G_INPUT_STREAM(stream), 0, flags, error);

--- a/libfwupdplugin/fu-oprom-device.c
+++ b/libfwupdplugin/fu-oprom-device.c
@@ -41,7 +41,7 @@ fu_oprom_device_set_enabled(FuOpromDevice *self, gboolean value, GError **error)
 	if (output_stream == NULL)
 		return FALSE;
 	if (!g_output_stream_write_all(output_stream, value ? "1" : "0", 1, NULL, NULL, error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 

--- a/libfwupdplugin/fu-path.c
+++ b/libfwupdplugin/fu-path.c
@@ -650,7 +650,7 @@ fu_path_get_symlink_target(const gchar *filename, GError **error)
 				 NULL,
 				 error);
 	if (info == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 	target =

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -277,7 +277,7 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 	/* get the smbios entry point */
 	ep_fn = g_build_filename(path, "smbios_entry_point", NULL);
 	if (!g_file_get_contents(ep_fn, &ep_raw, &sz, error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 
@@ -313,7 +313,7 @@ fu_smbios_setup_from_path(FuSmbios *self, const gchar *path, GError **error)
 	/* get the DMI data */
 	dmi_fn = g_build_filename(path, "DMI", NULL);
 	if (!g_file_get_contents(dmi_fn, &dmi_raw, &sz, error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	if (sz > self->structure_table_len) {

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -845,7 +845,7 @@ fu_udev_device_get_device_file_from_subsystem(FuUdevDevice *self,
 			return NULL;
 		}
 		g_propagate_error(error, g_steal_pointer(&error_local));
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 	fn = g_dir_read_name(dir);

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1054,7 +1054,7 @@ fu_usb_device_probe_bos_descriptors(FuUsbDevice *self, GError **error)
 			return TRUE;
 		}
 		g_propagate_error(error, g_steal_pointer(&error_local));
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	for (guint i = 0; i < priv->bos_descriptors->len; i++) {

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -190,7 +190,7 @@ fu_cros_ec_usb_device_do_xfer(FuCrosEcUsbDevice *self,
 						 FU_CROS_EC_BULK_RECV_TIMEOUT,
 						 NULL,
 						 error)) {
-			fu_error_convert(error);
+			fwupd_error_convert(error);
 			return FALSE;
 		}
 		if (actual != inlen && !allow_less) {

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -92,7 +92,7 @@ fu_fpc_device_dfu_cmd(FuFpcDevice *self,
 		FPC_USB_TRANSFER_TIMEOUT,
 		NULL,
 		error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	if (actual_len != length) {
@@ -131,7 +131,7 @@ fu_fpc_device_fw_cmd(FuFpcDevice *self,
 					    FPC_USB_TRANSFER_TIMEOUT,
 					    NULL,
 					    error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	if (actual_len != length) {

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -53,7 +53,7 @@ fu_fresco_pd_device_transfer_read(FuFrescoPdDevice *self,
 					    NULL,
 					    error)) {
 		g_prefix_error(error, "failed to read from offset 0x%x: ", offset);
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 	if (bufsz != actual_length) {

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -564,7 +564,7 @@ fu_logitech_bulkcontroller_device_upd_send_cmd(FuLogitechBulkcontrollerDevice *s
 					 NULL,
 					 error)) {
 		g_prefix_error(error, "failed to send upd bulk transfer: ");
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 

--- a/plugins/modem-manager/fu-mm-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-mbim-device.c
@@ -107,6 +107,16 @@ fu_mm_mbim_device_new_sync(FuMmMbimDevice *self, GFile *file, guint timeout_ms, 
 
 	mbim_device_new(file, helper->cancellable, fu_mm_mbim_device_new_cb, helper);
 	g_main_loop_run(helper->loop);
+
+	/* save response */
+	if (helper->mbim_device == NULL) {
+		if (event != NULL)
+			fu_device_event_set_error(event, helper->error);
+		g_propagate_error(error, g_steal_pointer(&helper->error));
+		return NULL;
+	}
+
+	/* success */
 	return g_steal_pointer(&helper->mbim_device);
 }
 

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -54,7 +54,7 @@ fu_wac_module_refresh(FuWacModule *self, GError **error)
 					      FU_HID_DEVICE_FLAG_ALLOW_TRUNC,
 					      error)) {
 		g_prefix_error(error, "failed to refresh status: ");
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -320,7 +320,7 @@ fu_dbus_daemon_auth_helper_free(FuMainAuthHelper *helper)
 static void
 fu_dbus_daemon_method_invocation_return_gerror(GDBusMethodInvocation *invocation, GError *error)
 {
-	fu_error_convert(&error);
+	fwupd_error_convert(&error);
 	g_dbus_method_invocation_return_gerror(invocation, error);
 }
 

--- a/src/fu-engine-emulator.c
+++ b/src/fu-engine-emulator.c
@@ -68,7 +68,7 @@ fu_engine_emulator_save(FuEngineEmulator *self, GOutputStream *stream, GError **
 	if (!fu_output_stream_write_bytes(stream, blob, NULL, error))
 		return FALSE;
 	if (!g_output_stream_flush(stream, NULL, error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return FALSE;
 	}
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1503,7 +1503,7 @@ fu_engine_verify_from_system_metadata(FuEngine *self, FuDevice *device, GError *
 				  XB_QUERY_FLAG_OPTIMIZE | XB_QUERY_FLAG_USE_INDEXES,
 				  error);
 	if (query == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 
@@ -4344,12 +4344,12 @@ fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **e
 	if (istream == NULL)
 		return NULL;
 	if (!jcat_file_import_stream(jcat_file, istream, JCAT_IMPORT_FLAG_NONE, NULL, error)) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 	jcat_item = jcat_file_get_item_default(jcat_file, error);
 	if (jcat_item == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 	results = jcat_context_verify_item(self->jcat_context,
@@ -4359,7 +4359,7 @@ fu_engine_get_system_jcat_result(FuEngine *self, FwupdRemote *remote, GError **e
 					       JCAT_VERIFY_FLAG_REQUIRE_SIGNATURE,
 					   error);
 	if (results == NULL) {
-		fu_error_convert(error);
+		fwupd_error_convert(error);
 		return NULL;
 	}
 


### PR DESCRIPTION
The functionality is the same, so the internal one provides no benefit.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
