### PR TITLE
Incorporate ANOTHER_WRITE_REQUIRED flag within fu_device_list_replace()

### DIFF
--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -768,6 +768,9 @@ fu_device_list_replace(FuDeviceList *self, FuDeviceItem *item, FuDevice *device)
 		fu_device_set_version_raw(device, raw);
 	}
 
+	/* allow another plugin to handle the write too */
+	fu_device_incorporate_flag(device, item->device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
+
 	/* seems like a sane assumption if we've tagged the runtime mode as signed */
 	fu_device_incorporate_flag(device, item->device, FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_incorporate_flag(device, item->device, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation

Hello!

I was testing with cros-ec plugin; it usually requires multiple ANOTHER_WRITE_REQUIRED, but I found that it only does one writing round then it stops.

I think it might have stopped working after this PR https://github.com/fwupd/fwupd/pull/8597, so I tried to put that line back and it fixed it, not sure though if that breaks something related with emulations?