### PR TITLE
modem-manager: Fix an enumeration regression in 9d908d10

### DIFF
--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -43,6 +43,16 @@ although it requires that the firmware branch is also set in the firmware metada
 
 Since: 1.9.8
 
+### `Flags=make-serial-raw`
+
+When using a port that was not previously configured by ModemManager (an 'ignored' port), we need
+to configure the serial port manually.
+
+This is automatically added for any ports being used from `mm_modem_get_ignored_ports()` and should
+not need to be added in quirk files.
+
+Since: 2.0.14
+
 ### `Flags=detach-at-fastboot-has-no-response`
 
 If no AT response is expected when entering fastboot mode.

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -6,6 +6,10 @@
 
 #include "config.h"
 
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+#endif
+
 #include "fu-mm-common.h"
 #include "fu-mm-device.h"
 
@@ -20,11 +24,22 @@
 /* not strictly last, but the last we care about */
 #define MM_MODEM_PORT_TYPE_LAST (MM_MODEM_PORT_TYPE_IGNORED + 1)
 
+typedef enum {
+	FU_MM_DEVICE_PORT_FLAG_NONE = 0,
+	FU_MM_DEVICE_PORT_FLAG_MAKE_RAW = 1 << 0,
+} FuMmDevicePortFlags;
+
+typedef struct {
+	MMModemPortType type;
+	gchar *device_file;
+	FuMmDevicePortFlags flags;
+} FuMmDevicePort;
+
 typedef struct {
 	gboolean inhibited;
 	gchar *branch_at;
 	gchar *inhibition_uid;
-	gchar *port[MM_MODEM_PORT_TYPE_LAST];
+	GPtrArray *ports; /* element-type FuMmDevicePort */
 } FuMmDevicePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuMmDevice, fu_mm_device, FU_TYPE_UDEV_DEVICE);
@@ -36,6 +51,13 @@ G_DEFINE_TYPE_WITH_PRIVATE(FuMmDevice, fu_mm_device, FU_TYPE_UDEV_DEVICE);
 #define FU_MM_DEVICE_AT_DELAY 3000 /* ms */
 
 enum { PROP_0, PROP_INHIBITED, PROP_LAST };
+
+static void
+fu_mm_device_port_free(FuMmDevicePort *port)
+{
+	g_free(port->device_file);
+	g_free(port);
+}
 
 static void
 fu_mm_device_set_branch_at(FuMmDevice *self, const gchar *branch_at)
@@ -55,12 +77,11 @@ fu_mm_device_to_string(FuDevice *device, guint idt, GString *str)
 	fwupd_codec_string_append(str, idt, "BranchAt", priv->branch_at);
 	fwupd_codec_string_append_bool(str, idt, "Inhibited", priv->inhibited);
 	fwupd_codec_string_append(str, idt, "InhibitionUid", priv->inhibition_uid);
-	for (guint i = 0; i < MM_MODEM_PORT_TYPE_LAST; i++) {
-		if (priv->port[i] != NULL) {
-			g_autofree gchar *title =
-			    g_strdup_printf("Port[%s]", fu_mm_device_port_type_to_string(i));
-			fwupd_codec_string_append(str, idt, title, priv->port[i]);
-		}
+	for (guint i = 0; i < priv->ports->len; i++) {
+		FuMmDevicePort *port = g_ptr_array_index(priv->ports, i);
+		g_autofree gchar *title =
+		    g_strdup_printf("Port[%s]", fu_mm_device_port_type_to_string(port->type));
+		fwupd_codec_string_append(str, idt, title, port->device_file);
 	}
 }
 
@@ -96,17 +117,27 @@ fu_mm_device_set_device_file(FuMmDevice *self, MMModemPortType port_type, GError
 {
 	FuMmDevicePrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FU_IS_MM_DEVICE(self), FALSE);
-	g_return_val_if_fail(port_type < MM_MODEM_PORT_TYPE_LAST, FALSE);
-	if (priv->port[port_type] == NULL) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "no port for %s",
-			    fu_mm_device_port_type_to_string(port_type));
-		return FALSE;
+
+	/* find port by type */
+	for (guint i = 0; i < priv->ports->len; i++) {
+		FuMmDevicePort *port = g_ptr_array_index(priv->ports, i);
+		if (port_type == port->type) {
+			if (port->flags & FU_MM_DEVICE_PORT_FLAG_MAKE_RAW) {
+				fu_device_add_private_flag(FU_DEVICE(self),
+							   FU_MM_DEVICE_FLAG_MAKE_SERIAL_RAW);
+			}
+			fu_udev_device_set_device_file(FU_UDEV_DEVICE(self), port->device_file);
+			return TRUE;
+		}
 	}
-	fu_udev_device_set_device_file(FU_UDEV_DEVICE(self), priv->port[port_type]);
-	return TRUE;
+
+	/* not found */
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_SUPPORTED,
+		    "no port for %s",
+		    fu_mm_device_port_type_to_string(port_type));
+	return FALSE;
 }
 
 static gboolean
@@ -310,14 +341,30 @@ fu_mm_device_add_instance_id(FuMmDevice *self, const gchar *device_id, GError **
 }
 
 static void
-fu_mm_device_add_port(FuMmDevice *self, MMModemPortType port_type, const gchar *device_file)
+fu_mm_device_add_port(FuMmDevice *self,
+		      MMModemPortType port_type,
+		      const gchar *device_file,
+		      FuMmDevicePortFlags flags)
 {
 	FuMmDevicePrivate *priv = GET_PRIVATE(self);
+	FuMmDevicePort *port;
+
 	if (port_type >= MM_MODEM_PORT_TYPE_LAST)
 		return;
-	if (priv->port[port_type] != NULL)
-		return;
-	priv->port[port_type] = g_strdup(device_file);
+
+	/* already exists */
+	for (guint i = 0; i < priv->ports->len; i++) {
+		port = g_ptr_array_index(priv->ports, i);
+		if (port->type == port_type)
+			return;
+	}
+
+	/* create new */
+	port = g_new0(FuMmDevicePort, 1);
+	port->type = port_type;
+	port->flags = flags;
+	port->device_file = g_strdup(device_file);
+	g_ptr_array_add(priv->ports, port);
 }
 
 gboolean
@@ -389,9 +436,15 @@ fu_mm_device_probe_from_omodem(FuMmDevice *self, MMObject *omodem, GError **erro
 			continue;
 		if (used_ports[i].type == MM_MODEM_PORT_TYPE_IGNORED &&
 		    g_pattern_match_simple("wwan*qcdm*", used_ports[i].name)) {
-			fu_mm_device_add_port(self, MM_MODEM_PORT_TYPE_QCDM, device_file);
+			fu_mm_device_add_port(self,
+					      MM_MODEM_PORT_TYPE_QCDM,
+					      device_file,
+					      FU_MM_DEVICE_PORT_FLAG_NONE);
 		} else {
-			fu_mm_device_add_port(self, used_ports[i].type, device_file);
+			fu_mm_device_add_port(self,
+					      used_ports[i].type,
+					      device_file,
+					      FU_MM_DEVICE_PORT_FLAG_NONE);
 		}
 	}
 	mm_modem_port_info_array_free(used_ports, n_used_ports);
@@ -408,8 +461,10 @@ fu_mm_device_probe_from_omodem(FuMmDevice *self, MMObject *omodem, GError **erro
 		g_autofree gchar *device_file = g_strdup_printf("/dev/%s", ignored_ports[i].name);
 		if (ignored_ports[i].type >= MM_MODEM_PORT_TYPE_LAST)
 			continue;
-
-		fu_mm_device_add_port(self, ignored_ports[i].type, device_file);
+		fu_mm_device_add_port(self,
+				      ignored_ports[i].type,
+				      device_file,
+				      FU_MM_DEVICE_PORT_FLAG_MAKE_RAW);
 	}
 	mm_modem_port_info_array_free(ignored_ports, n_ignored_ports);
 #endif // MM_CHECK_VERSION(1, 26, 0)
@@ -687,6 +742,70 @@ fu_mm_device_ensure_payload(FuMmDevice *self)
 }
 
 static gboolean
+fu_mm_device_make_serial_raw(FuMmDevice *self, GError **error)
+{
+#ifdef HAVE_TERMIOS_H
+	gint fd = fu_io_channel_unix_get_fd(fu_udev_device_get_io_channel(FU_UDEV_DEVICE(self)));
+	struct termios tio;
+
+	if (tcgetattr(fd, &tio) != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+#ifdef HAVE_ERRNO_H
+			    g_io_error_from_errno(errno),
+#else
+			    G_IO_ERROR_FAILED, /* nocheck:blocked */
+#endif
+			    "could not get termios attributes: %s",
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	cfmakeraw(&tio);
+
+	if (tcsetattr(fd, TCSANOW, &tio) != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+#ifdef HAVE_ERRNO_H
+			    g_io_error_from_errno(errno),
+#else
+			    G_IO_ERROR_FAILED, /* nocheck:blocked */
+#endif
+			    "could not set termios attributes: %s",
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	return TRUE;
+#else
+	g_set_error_literal(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "Not supported as <termios.h> not found");
+	return FALSE;
+#endif
+}
+
+static gboolean
+fu_mm_device_open(FuDevice *device, GError **error)
+{
+	FuMmDevice *self = FU_MM_DEVICE(device);
+
+	/* FuUdevDevice->open() */
+	if (!FU_DEVICE_CLASS(fu_mm_device_parent_class)->open(device, error))
+		return FALSE;
+
+	/* ignored ports have not previously been configured by ModemManager */
+	if (fu_device_has_private_flag(device, FU_MM_DEVICE_FLAG_MAKE_SERIAL_RAW)) {
+		if (!fu_mm_device_make_serial_raw(self, error))
+			return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_mm_device_setup(FuDevice *device, GError **error)
 {
 	FuMmDevice *self = FU_MM_DEVICE(device);
@@ -757,7 +876,8 @@ fu_mm_device_from_json(FuDevice *device, JsonObject *json_object, GError **error
 			const gchar *port_type = l->data;
 			fu_mm_device_add_port(self,
 					      fu_mm_device_port_type_from_string(port_type),
-					      json_object_get_string_member(json_ports, port_type));
+					      json_object_get_string_member(json_ports, port_type),
+					      FU_MM_DEVICE_PORT_FLAG_NONE);
 		}
 	}
 
@@ -808,12 +928,11 @@ fu_mm_device_add_json(FuDevice *device, JsonBuilder *builder, FwupdCodecFlags fl
 	/* ports always specified */
 	json_builder_set_member_name(builder, "Ports");
 	json_builder_begin_object(builder);
-	for (guint i = 0; i < MM_MODEM_PORT_TYPE_LAST; i++) {
-		if (priv->port[i] != NULL) {
-			fwupd_codec_json_append(builder,
-						fu_mm_device_port_type_to_string(i),
-						priv->port[i]);
-		}
+	for (guint i = 0; i < priv->ports->len; i++) {
+		FuMmDevicePort *port = g_ptr_array_index(priv->ports, i);
+		fwupd_codec_json_append(builder,
+					fu_mm_device_port_type_to_string(port->type),
+					port->device_file);
 	}
 	json_builder_end_object(builder);
 }
@@ -850,6 +969,7 @@ fu_mm_device_set_property(GObject *object, guint prop_id, const GValue *value, G
 static void
 fu_mm_device_init(FuMmDevice *self)
 {
+	FuMmDevicePrivate *priv = GET_PRIVATE(self);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ARCHIVE_FIRMWARE);
@@ -862,9 +982,11 @@ fu_mm_device_init(FuMmDevice *self)
 	fu_device_set_summary(FU_DEVICE(self), "Mobile broadband device");
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_MODEM);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_MM_DEVICE_FLAG_USE_BRANCH);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_MM_DEVICE_FLAG_MAKE_SERIAL_RAW);
 	fu_device_add_possible_plugin(FU_DEVICE(self), "modem_manager");
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
+	priv->ports = g_ptr_array_new_with_free_func((GDestroyNotify)fu_mm_device_port_free);
 }
 
 static void
@@ -873,10 +995,9 @@ fu_mm_device_finalize(GObject *object)
 	FuMmDevice *self = FU_MM_DEVICE(object);
 	FuMmDevicePrivate *priv = GET_PRIVATE(self);
 
-	for (guint i = 0; i < MM_MODEM_PORT_TYPE_LAST; i++)
-		g_free(priv->port[i]);
 	g_free(priv->branch_at);
 	g_free(priv->inhibition_uid);
+	g_ptr_array_unref(priv->ports);
 
 	G_OBJECT_CLASS(fu_mm_device_parent_class)->finalize(object);
 }
@@ -896,6 +1017,7 @@ fu_mm_device_class_init(FuMmDeviceClass *klass)
 	device_class->set_quirk_kv = fu_mm_device_set_quirk_kv;
 	device_class->from_json = fu_mm_device_from_json;
 	device_class->add_json = fu_mm_device_add_json;
+	device_class->open = fu_mm_device_open;
 
 	pspec = g_param_spec_boolean("inhibited",
 				     NULL,

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -15,6 +15,8 @@ G_DECLARE_DERIVABLE_TYPE(FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuUdevDevice)
 
 #define FU_MM_DEVICE_FLAG_USE_BRANCH "use-branch"
 
+#define FU_MM_DEVICE_FLAG_MAKE_SERIAL_RAW "make-serial-raw"
+
 /* less ifdefs */
 #if !MM_CHECK_VERSION(1, 24, 0)
 #define MM_MODEM_FIRMWARE_UPDATE_METHOD_DFOTA	      (1 << 5)


### PR DESCRIPTION
We only want to set the port to raw mode if ModemManager is ignoring the port.

Fixes a regression to enumerate the EM160R.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
