### PR TITLE
Do not add a vendor-id of UNKNOWN when the signature has no O=

### DIFF
--- a/libfwupdplugin/fu-efi-x509-device.c
+++ b/libfwupdplugin/fu-efi-x509-device.c
@@ -58,9 +58,8 @@ fu_efi_x509_device_probe(FuDevice *device, GError **error)
 				     subject_vendor != NULL ? subject_vendor : "UNKNOWN");
 	fu_device_set_logical_id(device, logical_id);
 
-	fu_device_build_vendor_id(device,
-				  "UEFI",
-				  subject_vendor != NULL ? subject_vendor : "UNKNOWN");
+	if (subject_vendor != NULL)
+		fu_device_build_vendor_id(device, "UEFI", subject_vendor);
 
 	/* success */
 	fu_device_add_instance_strup(device, "CRT", fu_firmware_get_id(FU_FIRMWARE(priv->sig)));


### PR DESCRIPTION
This means we need a quirk entry, but that's better than adding `UNKNOWN` to a vendor on the LVFS. We also don't want to show two vendor-ids in this case.

Fixes https://github.com/fwupd/fwupd/issues/9056

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
