### PR TITLE
generate-ds20.py: Print number of bytes

### DIFF
--- a/contrib/generate-ds20.py
+++ b/contrib/generate-ds20.py
@@ -66,6 +66,6 @@ if __name__ == "__main__":
         buf = buf.ljust(args.bufsz, b"\0")
 
     # success
-    print("DS20 descriptor control transfer data:")
+    print(f"DS20 descriptor control transfer data ({len(buf)} Bytes):")
     print(", ".join([f"0x{val:02x}" for val in list(buf)]))
     print(base64.b64encode(buf).decode())


### PR DESCRIPTION
When adding the DS20 descriptor in the firmware I have to specify the length, so it's useful if the tool tells me about it.

Example:
```
> ./contrib/generate-ds20.py fwupd.quirk
DS20 descriptor control transfer data (89 Bytes):
0x50, 0x6c, 0x75, 0x67, 0x69, 0x6e, 0x3d, 0x72, 0x70, 0x5f, 0x70, 0x69, 0x63, 0x6f, 0x0a, 0x46, 0x6c, 0x61, 0x67, 0x73, 0x3d, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x0a, 0x49, 0x63, 0x6f, 0x6e, 0x3d, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x2d, 0x6b, 0x65, 0x79, 0x62, 0x6f, 0x61, 0x72, 0x64, 0x0a, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x70, 0x61, 0x72, 0x74, 0x47, 0x75, 0x69, 0x64, 0x3d, 0x42, 0x4c, 0x4f, 0x43, 0x4b, 0x5c, 0x56, 0x45, 0x4e, 0x5f, 0x32, 0x45, 0x38, 0x41, 0x26, 0x44, 0x45, 0x56, 0x5f, 0x30, 0x30, 0x30, 0x33 UGx1Z2luPXJwX3BpY28KRmxhZ3M9aW50ZXJuYWwKSWNvbj1pbnB1dC1rZXlib2FyZApDb3VudGVycGFydEd1aWQ9QkxPQ0tcVkVOXzJFOEEmREVWXzAwMDM=
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
