### PR TITLE
modem-manager: Do not fail if no ports found

### DIFF
--- a/plugins/modem-manager/fu-mm-backend.c
+++ b/plugins/modem-manager/fu-mm-backend.c
@@ -200,36 +200,26 @@ fu_mm_backend_probe_gtype_fallback(FuMmBackend *self, MMObject *omodem, GError *
 		return NULL;
 	}
 
-	if (!mm_modem_get_ports(modem, &used_ports, &n_used_ports)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "failed to get port information");
-		return NULL;
+	if (mm_modem_get_ports(modem, &used_ports, &n_used_ports)) {
+		for (guint i = 0; i < n_used_ports; i++) {
+			g_debug("found port %s: %s",
+				used_ports[i].name,
+				fu_mm_device_port_type_to_string(used_ports[i].type));
+			FU_BIT_SET(ports_bitmask, used_ports[i].type);
+		}
+		mm_modem_port_info_array_free(used_ports, n_used_ports);
 	}
-	for (guint i = 0; i < n_used_ports; i++) {
-		g_debug("found port %s: %s",
-			used_ports[i].name,
-			fu_mm_device_port_type_to_string(used_ports[i].type));
-		FU_BIT_SET(ports_bitmask, used_ports[i].type);
-	}
-	mm_modem_port_info_array_free(used_ports, n_used_ports);
 
 #if MM_CHECK_VERSION(1, 26, 0)
-	if (!mm_modem_get_ignored_ports(modem, &ignored_ports, &n_ignored_ports)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "failed to get port information");
-		return NULL;
+	if (mm_modem_get_ignored_ports(modem, &ignored_ports, &n_ignored_ports)) {
+		for (guint i = 0; i < n_ignored_ports; i++) {
+			g_debug("found port %s: %s",
+				ignored_ports[i].name,
+				fu_mm_device_port_type_to_string(ignored_ports[i].type));
+			FU_BIT_SET(ports_bitmask, ignored_ports[i].type);
+		}
+		mm_modem_port_info_array_free(ignored_ports, n_ignored_ports);
 	}
-	for (guint i = 0; i < n_ignored_ports; i++) {
-		g_debug("found port %s: %s",
-			ignored_ports[i].name,
-			fu_mm_device_port_type_to_string(ignored_ports[i].type));
-		FU_BIT_SET(ports_bitmask, ignored_ports[i].type);
-	}
-	mm_modem_port_info_array_free(ignored_ports, n_ignored_ports);
 #endif // MM_CHECK_VERSION(1, 26, 0)
 
 	/* find the correct GType */


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

`mm_modem_get_ports` and `mm_modem_get_ignored_ports` return `FALSE` and set `MMModemPortInfo *` to `NULL` if the number of ports is zero, so we shouldn't treat this as an error directly.