### PR TITLE
plugins/nvme: Set ensure-semver for Lexar drives

### DIFF
--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -46,6 +46,10 @@ Flags = signed-payload
 [NVME\VEN_025E&DEV_F1AB]
 Flags = needs-shutdown
 
+# Lexar
+[NVME\VEN_1D97]
+Flags = ensure-semver
+
 [NVME\VEN_144D&DEV_A80A&VER_2B2QGXA7]
 Issue = https://www.pugetsystems.com/support/guides/critical-samsung-ssd-firmware-update/
 [NVME\VEN_144D&DEV_A80A&VER_3B2QGXA7]


### PR DESCRIPTION
Lexar versioning is "unique"; one update is from version `12544` to `SN13767`. Strip the characters so vercomp evaluates this correctly.

