### PR TITLE
modem-manager: Get Firehose loader using glob

### DIFF
--- a/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
@@ -116,7 +116,10 @@ fu_mm_mhi_qcdm_device_write_firmware(FuDevice *device,
 
 	/* firehose modems that use mhi_pci drivers require firehose binary
 	 * to be present in the firmware-loader search path. */
-	firehose_prog = fu_firmware_get_image_by_id_bytes(firmware, "firehose-prog.mbn", error);
+	firehose_prog =
+	    fu_firmware_get_image_by_id_bytes(firmware,
+					      "firehose-prog.mbn|prog_nand*.mbn|prog_firehose*",
+					      error);
 	if (firehose_prog == NULL)
 		return FALSE;
 	if (!fu_mm_mhi_qcdm_device_copy_firehose_prog(self, firehose_prog, error))


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Uses the same expression as in the `qc-firehose` Sahara implementation to get the firmware-loader, which allows using vendor-provided firmware directly also for mhi-qcdm.
```
├── appsboot.mbn
├── ENPRG9x07.mbn
├── partition_complete_p4K_b256K.mbn
├── prog_nand_firehose_9x07.mbn
├── rawprogram_nand_p4K_b256K_update.xml
├── sbl1.mbn
└── tz.mbn
```