### PR TITLE
rustgen: Support initializing array with values

### DIFF
--- a/libfwupdplugin/fu-elf.rs
+++ b/libfwupdplugin/fu-elf.rs
@@ -19,7 +19,7 @@ struct FuStructElfFileHeader64le {
     ei_version: u8 == 0x1,
     ei_osabi: u8 = 0x3,
     ei_abiversion: u8,
-    _ei_padding: [u8; 7] = 0x00000000000000,
+    _ei_padding: [u8; 7],
     type: FuElfFileHeaderType,
     machine: u16le,
     version: u32le == 0x1,

--- a/libfwupdplugin/fu-ifd.rs
+++ b/libfwupdplugin/fu-ifd.rs
@@ -19,7 +19,7 @@ enum FuIfdRegion {
 #[derive(ParseStream, New, ValidateStream, Default)]
 #[repr(C, packed)]
 struct FuStructIfdFdbar {
-    reserved: [u8; 16] = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+    reserved: [u8; 16] = [0xFF; 16],
     signature: u32le == 0x0FF0A55A,
     descriptor_map0: u32le,
     descriptor_map1: u32le,

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -6776,7 +6776,7 @@ fu_plugin_struct_func(void)
 	g_autofree gchar *oem_table_id = NULL;
 
 	/* size */
-	g_assert_cmpint(st->len, ==, 51);
+	g_assert_cmpint(st->len, ==, 59);
 
 	/* getters and setters */
 	fu_struct_self_test_set_revision(st, 0xFF);
@@ -6792,7 +6792,7 @@ fu_plugin_struct_func(void)
 	g_assert_cmpstr(str1,
 			==,
 			"12345678adde0000ff000000000000000000000000000000004142434445465800000000"
-			"00000000000000dfdfdfdf00000000");
+			"00000000000000dfdfdfdf00000000ffffffffffffffff");
 
 	/* parse */
 	st2 = fu_struct_self_test_parse(st->data, st->len, 0x0, &error);
@@ -6842,7 +6842,7 @@ fu_plugin_struct_wrapped_func(void)
 	g_autoptr(GError) error = NULL;
 
 	/* size */
-	g_assert_cmpint(st->len, ==, 53);
+	g_assert_cmpint(st->len, ==, 61);
 
 	/* getters and setters */
 	fu_struct_self_test_wrapped_set_less(st, 0x99);
@@ -6851,8 +6851,8 @@ fu_plugin_struct_wrapped_func(void)
 	str1 = fu_byte_array_to_string(st);
 	g_assert_cmpstr(str1,
 			==,
-			"991234567833000000000000000000000000000000000000000041424344454600000000"
-			"0000000000000000dfdfdfdf0000000012");
+			"99123456783b000000000000000000000000000000000000000041424344454600000000"
+			"0000000000000000dfdfdfdf00000000ffffffffffffffff12");
 
 	/* modify the base */
 	fu_struct_self_test_set_revision(st_base, 0xFE);
@@ -6862,8 +6862,8 @@ fu_plugin_struct_wrapped_func(void)
 	str4 = fu_byte_array_to_string(st);
 	g_assert_cmpstr(str4,
 			==,
-			"991234567833000000fe0000000000000000000000000000000041424344454600000000"
-			"0000000000000000dfdfdfdf0000000012");
+			"99123456783b000000fe0000000000000000000000000000000041424344454600000000"
+			"0000000000000000dfdfdfdf00000000ffffffffffffffff12");
 
 	/* parse */
 	st2 = fu_struct_self_test_wrapped_parse(st->data, st->len, 0x0, &error);
@@ -6881,7 +6881,7 @@ fu_plugin_struct_wrapped_func(void)
 			"FuStructSelfTestWrapped:\n"
 			"  less: 0x99\n"
 			"  base: FuStructSelfTest:\n"
-			"  length: 0x33\n"
+			"  length: 0x3b\n"
 			"  revision: 0xfe\n"
 			"  owner: 00000000-0000-0000-0000-000000000000\n"
 			"  oem_revision: 0x0\n"

--- a/libfwupdplugin/fu-self-test.rs
+++ b/libfwupdplugin/fu-self-test.rs
@@ -17,7 +17,7 @@ struct FuStructSelfTest {
     oem_id: [char; 6] == "ABCDEF",
     oem_table_id: [char; 8],
     oem_revision: u32le,
-    asl_compiler_id: [u8; 4] =	0xDF,
+    asl_compiler_id: [u8; 4] =	[0xDF; 4],
     asl_compiler_revision: u32le,
     reserved: [u8; 8] == [0xFF; 8],
 }

--- a/libfwupdplugin/fu-self-test.rs
+++ b/libfwupdplugin/fu-self-test.rs
@@ -19,6 +19,7 @@ struct FuStructSelfTest {
     oem_revision: u32le,
     asl_compiler_id: [u8; 4] =	0xDF,
     asl_compiler_revision: u32le,
+    reserved: [u8; 8] == [0xFF; 8],
 }
 
 #[derive(New, Validate, Parse, ToString)]

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -491,14 +491,6 @@ class StructItem:
         raise ValueError(f"do not know how to parse value for type: {self.type}")
 
     def parse_default(self, val: str) -> None:
-        if (
-            self.type == Type.U8
-            and self.n_elements
-            and val.startswith("0x")
-            and len(val) == 4
-        ):
-            self.padding = val
-            return
         self.default = self._parse_default(val)
 
     def parse_constant(self, val: str) -> None:

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -457,11 +457,23 @@ class StructItem:
                 val_hex += f"\\x{value:x}"
             return val_hex
         if self.type == Type.U8 and self.n_elements:
+            val_hex = ""
+            if val.startswith("[") and val.endswith("]"):
+                value, n_elements = val[1:-1].split(";", maxsplit=1)
+                if not value.startswith("0x"):
+                    raise ValueError(f"0x prefix for hex number expected, got: {val}")
+                if self.size != int(n_elements):
+                    raise ValueError(
+                        f"data has to be {self.size} bytes exactly. Is {n_elements}"
+                    )
+                for _ in range(int(n_elements)):
+                    val_hex += f"\\x{value[2:]}"
+                return val_hex
+
             if not val.startswith("0x"):
                 raise ValueError(f"0x prefix for hex number expected, got: {val}")
             if len(val) != (self.size * 2) + 2:
                 raise ValueError(f"data has to be {self.size} bytes exactly")
-            val_hex = ""
             for idx in range(2, len(val), 2):
                 val_hex += f"\\x{val[idx:idx+2]}"
             return val_hex

--- a/plugins/aver-hid/fu-aver-hid.rs
+++ b/plugins/aver-hid/fu-aver-hid.rs
@@ -73,7 +73,7 @@ struct FuStructAverHidReqIsp {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
     custom_isp_cmd: u8,
-    data: [u8; 508] = 0xFF,
+    data: [u8; 508] = [0xFF; 508],
     end: u8 == 0x00,
 }
 
@@ -86,7 +86,7 @@ struct FuStructAverHidReqIspFileStart {
     file_name: [char; 52],
     file_size: u32le,
     free_space: u32le,
-    _reserved: [u8; 448] = 0xFF,
+    _reserved: [u8; 448] = [0xFF; 448],
     end: u8 == 0x00,
 }
 
@@ -96,7 +96,7 @@ struct FuStructAverHidReqIspFileDnload {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
     custom_isp_cmd: u8,
-    data: [u8; 508] = 0xFF,
+    data: [u8; 508] = [0xFF; 508],
 }
 
 #[derive(Setters, Getters, New, Default)]
@@ -109,7 +109,7 @@ struct FuStructAverHidReqIspFileEnd {
     end_flag: u8,
     file_size: u32le,
     free_space: u32le,
-    _reserved: [u8; 448] = 0xFF,
+    _reserved: [u8; 448] = [0xFF; 448],
     end: u8 == 0x00,
 }
 
@@ -120,7 +120,7 @@ struct FuStructAverHidReqIspStart {
     custom_cmd_isp: u8 == 0x10,
     custom_isp_cmd: u8,
     isp_cmd: [u8; 60],
-    _reserved: [u8; 448] = 0xFF,
+    _reserved: [u8; 448] = [0xFF; 448],
     end: u8 == 0x00,
 }
 
@@ -130,7 +130,7 @@ struct FuStructAverHidReqDeviceVersion {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x25,
     ver: [u8; 11],
-    _reserved: [u8; 498] = 0xFF,
+    _reserved: [u8; 498] = [0xFF; 498],
     end: u8 == 0x00,
 }
 
@@ -143,7 +143,7 @@ struct FuStructAverHidResIspStatus {
     status: u8,
     status_string: [char; 58],
     progress: u8,
-    _reserved: [u8; 448] = 0xFF,
+    _reserved: [u8; 448] = [0xFF; 448],
     end: u8 == 0x00,
 }
 
@@ -153,7 +153,7 @@ struct FuStructAverHidResIsp {
     report_id_custom_command: u8 == 0x09,
     custom_cmd_isp: u8 == 0x10,
     custom_isp_cmd: u8,
-    _reserved: [u8; 508] = 0xFF,
+    _reserved: [u8; 508] = [0xFF; 508],
     end: u8 == 0x00,
 }
 
@@ -163,7 +163,7 @@ struct FuStructAverHidResDeviceVersion {
     report_id_custom_command: u8 == 0x09,
     custom_cmd_isp: u8 == 0x25,
     ver: [u8; 11],
-    _reserved: [u8; 498] = 0xFF,
+    _reserved: [u8; 498] = [0xFF; 498],
     end: u8 == 0x00,
 }
 
@@ -175,7 +175,7 @@ struct FuStructAverSafeispReq {
     custom_res: u16le,
     custom_parm0: u32le = 0x00,
     custom_parm1: u32le = 0x00,
-    data: [u8; 1012] = 0x00,
+    data: [u8; 1012] = [0x00; 1012],
 };
 
 #[derive(New, Getters, Validate, Default)]
@@ -186,7 +186,7 @@ struct FuStructAverSafeispRes {
     custom_res: u16le,
     custom_parm0: u32le,
     custom_parm1: u32le,
-    data: [u8; 4] = 0x00,
+    data: [u8; 4] = [0x00; 4],
 };
 
 #[derive(Getters, Validate, Default)]
@@ -195,5 +195,5 @@ struct FuStructAverSafeispResDeviceVersion {
     report_id_custom_command: u8 == 0x09,
     custom_cmd: u8 == 0x14,
     ver: [u8; 11],
-    _reserved: [u8; 3] = 0x00,
+    _reserved: [u8; 3] = [0x00; 3],
 }

--- a/plugins/dell-kestrel/fu-dell-kestrel-hid.rs
+++ b/plugins/dell-kestrel/fu-dell-kestrel-hid.rs
@@ -19,8 +19,8 @@ struct FuStructDellKestrelHidCmdBuffer {
     dwregaddr: u32le,
     bufferlen: u16le,
     parameters: [u8; 3] = 0xEC0180, // addr, length, speed
-    extended_cmdarea: [u8; 53] = 0x00,
-    databytes: [u8; 192] = 0x00,
+    extended_cmdarea: [u8; 53],
+    databytes: [u8; 192],
 }
 
 #[derive(New, Setters)]

--- a/plugins/telink-dfu/fu-telink-dfu.rs
+++ b/plugins/telink-dfu/fu-telink-dfu.rs
@@ -23,7 +23,7 @@ struct FuStructTelinkDfuEndCheck {
 #[repr(C, packed)]
 struct FuStructTelinkDfuBlePkt {
     preamble: u16le,
-    payload: [u8; 16] = 0xFF,
+    payload: [u8; 16] = [0xFF; 16],
     crc: u16le,
 }
 
@@ -31,7 +31,7 @@ struct FuStructTelinkDfuBlePkt {
 #[repr(C, packed)]
 struct FuStructTelinkDfuHidPktPayload {
     ota_cmd: u16le = 0xFFFF,
-    ota_data: [u8; 16] = 0xFF,
+    ota_data: [u8; 16] = [0xFF; 16],
     crc: u16le = 0xFFFF,
 }
 


### PR DESCRIPTION
For example:

```
struct FuStructFoo {
    bar: [u8; 30] == [0xFE; 30],
}
```

instead of having to to 0xFEFEFEFEFEFEFEFE..........

https://doc.rust-lang.org/std/primitive.array.html#examples

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
