### PR TITLE
trivial: Allow plugins to use couple of event helpers related to json

### DIFF
--- a/libfwupdplugin/fu-device-event-private.h
+++ b/libfwupdplugin/fu-device-event-private.h
@@ -8,9 +8,6 @@
 
 #include "fu-device-event.h"
 
-FuDeviceEvent *
-fu_device_event_new(const gchar *id);
-
 const gchar *
 fu_device_event_get_id(FuDeviceEvent *self) G_GNUC_NON_NULL(1);
 gchar *

--- a/libfwupdplugin/fu-device-event.h
+++ b/libfwupdplugin/fu-device-event.h
@@ -11,6 +11,8 @@
 #define FU_TYPE_DEVICE_EVENT (fu_device_event_get_type())
 G_DECLARE_FINAL_TYPE(FuDeviceEvent, fu_device_event, FU, DEVICE_EVENT, GObject)
 
+FuDeviceEvent *
+fu_device_event_new(const gchar *id);
 void
 fu_device_event_set_str(FuDeviceEvent *self, const gchar *key, const gchar *value)
     G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -81,11 +81,7 @@ void
 fu_device_set_custom_flags(FuDevice *self, const gchar *custom_flags) G_GNUC_NON_NULL(1);
 
 void
-fu_device_add_event(FuDevice *self, FuDeviceEvent *event);
-void
 fu_device_clear_events(FuDevice *self);
-GPtrArray *
-fu_device_get_events(FuDevice *self);
 void
 fu_device_set_target(FuDevice *self, FuDevice *target);
 

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -1487,3 +1487,7 @@ FuDeviceEvent *
 fu_device_save_event(FuDevice *self, const gchar *id);
 FuDeviceEvent *
 fu_device_load_event(FuDevice *self, const gchar *id, GError **error);
+void
+fu_device_add_event(FuDevice *self, FuDeviceEvent *event);
+GPtrArray *
+fu_device_get_events(FuDevice *self);


### PR DESCRIPTION
In order to properly implement json serialization and deserialization for emulation purposes, allow plugins to use these helpers.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Can't say it's one of the above. As suggested here: https://github.com/fwupd/fwupd/pull/9053#discussion_r2262849421 moving dependencies of devlink plugin to a separate PR.