### PR TITLE
qc-firehose: Apply patch file

### DIFF
--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -847,13 +847,17 @@ fu_qc_firehose_impl_write_firmware(FuQcFirehoseImpl *self,
 				   GError **error)
 {
 	const gchar *fnglob = "firehose-rawprogram.xml|rawprogram_*.xml";
+	const gchar *fnglob_patch = "firehose-patch.xml|patch_*.xml|patch-*.xml";
 	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GBytes) blob_patch = NULL;
 	g_autoptr(GPtrArray) xns_erase = NULL;
 	g_autoptr(GPtrArray) xns_program = NULL;
 	g_autoptr(GPtrArray) xns_patch = NULL;
 	g_autoptr(XbBuilder) builder = xb_builder_new();
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new();
+	g_autoptr(XbBuilderSource) source_patch = xb_builder_source_new();
 	g_autoptr(XbSilo) silo = NULL;
+	g_autoptr(GError) error_local = NULL;
 	FuQcFirehoseImplHelper helper = {
 	    .no_zlp = no_zlp,
 	    .rawmode = FALSE,
@@ -880,6 +884,24 @@ fu_qc_firehose_impl_write_firmware(FuQcFirehoseImpl *self,
 		return FALSE;
 	}
 	xb_builder_import_source(builder, source);
+
+	/* load patch XML */
+	blob_patch = fu_firmware_get_image_by_id_bytes(firmware, fnglob_patch, &error_local);
+	if (blob_patch == NULL) {
+		/* continue even without patch XML */
+		g_info("failed to find patch file %s: %s", fnglob_patch, error_local->message);
+	} else {
+		if (!xb_builder_source_load_bytes(source_patch,
+						  blob_patch,
+						  XB_BUILDER_SOURCE_FLAG_NONE,
+						  error)) {
+			g_prefix_error(error, "failed to load %s: ", fnglob_patch);
+			fwupd_error_convert(error);
+			return FALSE;
+		}
+		xb_builder_import_source(builder, source_patch);
+	}
+
 	silo = xb_builder_compile(builder, XB_BUILDER_COMPILE_FLAG_NONE, NULL, error);
 	if (silo == NULL) {
 		g_prefix_error(error, "failed to compile %s: ", fnglob);
@@ -923,7 +945,7 @@ fu_qc_firehose_impl_write_firmware(FuQcFirehoseImpl *self,
 	fu_progress_step_done(progress);
 
 	/* patch */
-	xns_patch = xb_silo_query(silo, "data/patch", 0, NULL);
+	xns_patch = xb_silo_query(silo, "data/patch|patches/patch", 0, NULL);
 	if (xns_patch != NULL) {
 		if (!fu_qc_firehose_impl_patch_targets(self,
 						       xns_patch,


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Besides the `rawprogram*.xml` file, most Firehose updates include a `patch*.xml` file with additional `<patch></patch>` nodes.

E.g. `patch_p4K_b256K.xml`:
```xml
<?xml version="1.0" ?>
<patches>
  <!--NOTE: This is an ** Autogenerated file **-->
  <!--NOTE: Patching is in little endian format, i.e. 0xAABBCCDD will look like DD CC BB AA in the file or on disk-->
  <patch SECTOR_SIZE_IN_BYTES="4096" byte_offset="545" filename="partition_complete_p4K_b256K.mbn" physical_partition_number="0" size_in_bytes="4" start_sector="1" value="NUM_DISK_BLOCKS-1824." what="Update sector size limit of MIBIB partition"/>
</patches>

```