### PR TITLE
Update sl.po

### DIFF
--- a/po/sl.po
+++ b/po/sl.po
@@ -7,15 +7,584 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: fwupd\n"
-"Report-Msgid-Bugs-To: \n"
-"Language-Team: Slovenian (http://app.transifex.com/freedesktop/fwupd/language/sl/)\n"
+"Report-Msgid-Bugs-To: https://github.com/hughsie/fwupd/issues\n"
+"POT-Creation-Date: 2025-08-13 03:27+0000\n"
+"Language-Team: Slovenian (http://app.transifex.com/freedesktop/fwupd/"
+"language/sl/)\n"
+"Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sl\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
+"X-Generator: Poedit 2.2.1\n"
+
+#: data/remotes.d/lvfs.metainfo.xml:6
+msgid "Linux Vendor Firmware Service (stable firmware)"
+msgstr ""
+"Storitev dobaviteljev strojne programske opreme za Linux (stabilna strojna "
+"programska oprema)"
+
+#. TRANSLATORS: do not translate the variables marked using $
+#: data/remotes.d/lvfs.metainfo.xml:12
+#: data/remotes.d/lvfs-testing.metainfo.xml:12
+msgid ""
+"The LVFS is a free service that operates as an independent legal entity and "
+"has no connection with $OS_RELEASE:NAME$. Your distributor may not have "
+"verified any of the firmware updates for compatibility with your system or "
+"connected devices. All firmware is provided only by the original equipment "
+"manufacturer."
+msgstr ""
+"LVFS je brezplačna storitev, ki deluje kot samostojna pravna oseba in nima "
+"nobene povezave z $OS_RELEASE:NAME$. Vaš distributer morda ni preveril "
+"nobene posodobitve strojno programske opreme za združljivost z vašim "
+"sistemom ali priključenimi napravami. Vso strojno programsko opremo "
+"zagotavlja samo originalni proizvajalec opreme."
+
+#: data/remotes.d/lvfs.metainfo.xml:19
+#: data/remotes.d/lvfs-testing.metainfo.xml:25
+msgid ""
+"Enabling this functionality is done at your own risk, which means you have "
+"to contact your original equipment manufacturer regarding any problems "
+"caused by these updates. Only problems with the update process itself should "
+"be filed at $OS_RELEASE:BUG_REPORT_URL$."
+msgstr ""
+"To funkcijo omogočite na lastno odgovornost, kar pomeni, da se morate glede "
+"morebitnih težav, ki jih povzročijo te posodobitve, obrniti na proizvajalca "
+"originalne opreme. Samo težave s samim postopkom posodabljanja je treba "
+"vložiti na $OS_RELEASE:BUG_REPORT_URL$."
+
+#: data/remotes.d/lvfs-testing.metainfo.xml:6
+msgid "Linux Vendor Firmware Service (testing firmware)"
+msgstr ""
+"Storitev dobaviteljev strojne programske opreme za Linux (preizkusna strojna "
+"programska oprema)"
+
+#: data/remotes.d/lvfs-testing.metainfo.xml:19
+msgid ""
+"This remote contains firmware which is not embargoed, but is still being "
+"tested by the hardware vendor. You should ensure you have a way to manually "
+"downgrade the firmware if the firmware update fails."
+msgstr ""
+"Ta oddaljeni strežnik vsebuje vdelano programsko opremo, na katero ne velja "
+"embargo, vendar jo še vedno preizkuša prodajalec strojne opreme. Prepričajte "
+"se, da imate način za ročno zamenjavo vdelane programske opreme, če "
+"posodobitev vdelane programske opreme ne uspe."
+
+#. TRANSLATORS: description of a BIOS setting
+#: libfwupdplugin/fu-bios-settings.c:325
+msgid "Settings will apply after system reboots"
+msgstr "Nastavitve bodo veljale po ponovnem zagonu sistema"
+
+#. TRANSLATORS: description of a BIOS setting
+#: libfwupdplugin/fu-bios-settings.c:329
+msgid "BIOS updates delivered via LVFS or Windows Update"
+msgstr "Posodobitve BIOS-a, dostavljene prek LVFS ali Windows Update"
+
+#: libfwupdplugin/fu-bios-settings.c:339
+msgid "Enable"
+msgstr "Omogoči"
+
+#. TRANSLATORS: if the remote is enabled
+#. TRANSLATORS: Suffix: the HSI result
+#: libfwupdplugin/fu-bios-settings.c:342 src/fu-util-common.c:2029
+#: src/fu-util-common.c:2179
+msgid "Enabled"
+msgstr "Omogočeno"
+
+#: policy/org.freedesktop.fwupd.policy.in:17
+msgid "Stop the fwupd service"
+msgstr "Ustavi storitev fwupd"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:19
+msgid "Authentication is required to stop the firmware update service"
+msgstr ""
+"Preverjanje pristnosti je potrebno za ustavitev storitve posodabljanja "
+"strojno programske opreme"
+
+#: policy/org.freedesktop.fwupd.policy.in:28
+msgid "Install signed system firmware"
+msgstr "Namesti podpisano sistemsko strojno programsko opremo"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:30
+#: policy/org.freedesktop.fwupd.policy.in:41
+msgid "Authentication is required to update the firmware on this machine"
+msgstr ""
+"Preverjanje pristnosti je potrebno za posodobitev strojno programske opreme "
+"v tem računalniku"
+
+#: policy/org.freedesktop.fwupd.policy.in:39
+msgid "Install unsigned system firmware"
+msgstr "Namesti nepodpisano sistemsko strojno programsko opremo"
+
+#: policy/org.freedesktop.fwupd.policy.in:51
+msgid "Install old version of signed system firmware"
+msgstr "Namesti staro različico podpisane sistemske strojne programske opreme"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:53
+#: policy/org.freedesktop.fwupd.policy.in:65
+msgid "Authentication is required to downgrade the firmware on this machine"
+msgstr ""
+"Preverjanje pristnosti je potrebno za vrnitev na starejšo različico vdelane "
+"programske opreme v tem računalniku"
+
+#: policy/org.freedesktop.fwupd.policy.in:63
+msgid "Install old version of unsigned system firmware"
+msgstr ""
+"Namesti staro različico nepodpisane sistemske strojne programske opreme"
+
+#: policy/org.freedesktop.fwupd.policy.in:75
+#: policy/org.freedesktop.fwupd.policy.in:98
+msgid "Install signed device firmware"
+msgstr "Namesti podpisano strojno programsko opremo naprave"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:77
+#: policy/org.freedesktop.fwupd.policy.in:88
+msgid "Authentication is required to update the firmware on a removable device"
+msgstr ""
+"Preverjanje pristnosti je potrebno za posodobitev strojno programske opreme "
+"v izmenljivi napravi"
+
+#: policy/org.freedesktop.fwupd.policy.in:86
+#: policy/org.freedesktop.fwupd.policy.in:109
+msgid "Install unsigned device firmware"
+msgstr "Namesti nepodpisano strojno programsko opremo naprave"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:100
+#: policy/org.freedesktop.fwupd.policy.in:111
+msgid ""
+"Authentication is required to downgrade the firmware on a removable device"
+msgstr ""
+"Preverjanje pristnosti je potrebno za vrnitev na starejšo različico vdelane "
+"programske opreme na izmenljivi napravi"
+
+#: policy/org.freedesktop.fwupd.policy.in:121
+msgid "Unlock the device to allow access"
+msgstr "Odkleni napravo za omogočanje dostopa"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:123
+msgid "Authentication is required to unlock a device"
+msgstr "Za odklepanje naprave je potrebno preverjanje pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:132
+msgid "Modify daemon configuration"
+msgstr "Spremeni prilagoditev prikritega procesa"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:134
+msgid "Authentication is required to modify daemon configuration"
+msgstr ""
+"Za spreminjanje prilagoditve prikritega procesa je potrebno preverjanje "
+"pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:144
+msgid "Reset daemon configuration"
+msgstr "Ponastavi prilagoditev prikritega procesa"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:146
+msgid "Authentication is required to reset daemon configuration to defaults"
+msgstr ""
+"Za spreminjanje prilagoditve prikritega procesa na privzeto je potrebno "
+"preverjanje pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:156
+msgid "Activate the new firmware on the device"
+msgstr "Aktiviraj novo strojno programsko opremo v napravi"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:158
+msgid "Authentication is required to switch to the new firmware version"
+msgstr ""
+"Preverjanje pristnosti je potrebno za preklop na novo različico strojne "
+"programske opreme"
+
+#: policy/org.freedesktop.fwupd.policy.in:167
+msgid "Update the stored device verification information"
+msgstr "Posodobi shranjene informacije za preverjanje naprave"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:169
+msgid ""
+"Authentication is required to update the stored checksums for the device"
+msgstr ""
+"Preverjanje pristnosti je potrebno za posodobitev shranjenih kontrolnih vsot "
+"za napravo"
+
+#: policy/org.freedesktop.fwupd.policy.in:178
+msgid "Modify a configured remote"
+msgstr "Spremeni nastavljeni oddaljeni strežnik"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:180
+msgid ""
+"Authentication is required to modify a configured remote used for firmware "
+"updates"
+msgstr ""
+"Preverjanje pristnosti je potrebno za spreminjanje nastavitev oddaljenega "
+"strežnika, ki se uporablja za posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: firmware approved by the admin
+#: policy/org.freedesktop.fwupd.policy.in:189 src/fu-util.c:5509
+msgid "Sets the list of approved firmware"
+msgstr "Nastavi seznam odobrene vdelane programske opreme"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:191
+msgid "Authentication is required to set the list of approved firmware"
+msgstr ""
+"Preverjanje pristnosti je potrebno za nastavitev seznama odobrene vdelane "
+"programske opreme"
+
+#: policy/org.freedesktop.fwupd.policy.in:200
+msgid "Sign data using the client certificate"
+msgstr "Podpiši podatke s potrdilom odjemalca"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:202
+msgid "Authentication is required to sign data using the client certificate"
+msgstr ""
+"Preverjanje pristnosti je potrebno za podpisovanje podatkov s potrdilom "
+"odjemalca"
+
+#: policy/org.freedesktop.fwupd.policy.in:211
+msgid "Get BIOS settings"
+msgstr "Pridobi nastavitve BIOS-a"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:213
+msgid "Authentication is required to read BIOS settings"
+msgstr "Za branje nastavitev BIOS-a je potrebno preverjanje pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:222
+msgid "Set one or more BIOS settings"
+msgstr "Nastavite eno ali več nastavitev BIOS-a"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:224
+msgid "Authentication is required to modify BIOS settings"
+msgstr "Za spreminjanje nastavitev BIOS-a je potrebno preverjanje pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:234
+#: policy/org.freedesktop.fwupd.policy.in:245
+msgid "Security hardening for HSI"
+msgstr "Utrjevanje varnosti za HSI"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:236
+msgid "Authentication is required to fix a host security issue"
+msgstr ""
+"Preverjanje pristnosti je potrebno za odpravljanje težave z varnostjo "
+"gostitelja"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:247
+msgid "Authentication is required to undo the fix for a host security issue"
+msgstr ""
+"Preverjanje pristnosti je potrebno, če želite razveljaviti popravek za "
+"težavo z varnostjo gostitelja"
+
+#. TRANSLATORS: command description
+#: policy/org.freedesktop.fwupd.policy.in:256 src/fu-tool.c:5523
+#: src/fu-util.c:5645
+msgid "Load device emulation data"
+msgstr "Naloži emulacijske podatke naprave"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:258
+msgid "Authentication is required to load hardware emulation data"
+msgstr ""
+"Za nalaganje podatkov emulacije strojne opreme je potrebno preverjanje "
+"pristnosti"
+
+#. TRANSLATORS: command description
+#: policy/org.freedesktop.fwupd.policy.in:267 src/fu-util.c:5652
+msgid "Save device emulation data"
+msgstr "Shrani emulacijske podatke naprave"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:269
+msgid "Authentication is required to save hardware emulation data"
+msgstr ""
+"Za shranjevanje podatkov emulacije strojne opreme je potrebno preverjanje "
+"pristnosti"
+
+#: policy/org.freedesktop.fwupd.policy.in:279
+msgid "Enable emulation data collection"
+msgstr "Omogoči zbiranje podatkov emulacije"
+
+#. TRANSLATORS: this is the PolicyKit modal dialog
+#: policy/org.freedesktop.fwupd.policy.in:281
+msgid "Authentication is required to enable emulation data collection"
+msgstr ""
+"Za omogočanje zbiranja podatkov emulacije strojne opreme je potrebno "
+"preverjanje pristnosti"
+
+#. TRANSLATORS: command line option
+#: plugins/tpm/fu-tpm-eventlog.c:102 plugins/uefi-dbx/fu-dbxtool.c:112
+#: src/fu-util.c:5108
+msgid "Show extra debugging information"
+msgstr "Pokaži dodatne podatke za razhroščevanje"
+
+#. TRANSLATORS: command line option
+#: plugins/tpm/fu-tpm-eventlog.c:110
+msgid "Only show single PCR value"
+msgstr "Pokaži samo eno vrednost PCR"
+
+#. TRANSLATORS: we're poking around as a power user
+#: plugins/tpm/fu-tpm-eventlog.c:123 plugins/uefi-dbx/fu-dbxtool.c:248
+#: src/fu-tool.c:5899
+msgid "This program may only work correctly as root"
+msgstr "Ta program lahko pravilno deluje le kot root"
+
+#. TRANSLATORS: program name
+#: plugins/tpm/fu-tpm-eventlog.c:127
+msgid "fwupd TPM event log utility"
+msgstr "Pripomoček dnevnika dogodkov fwupd TPM"
+
+#. TRANSLATORS: CLI description
+#: plugins/tpm/fu-tpm-eventlog.c:131
+msgid ""
+"This tool will read and parse the TPM event log from the system firmware."
+msgstr ""
+"To orodje bo prebralo in razčlenilo dnevnik dogodkov TPM iz vdelane "
+"programske opreme sistema."
+
+#. TRANSLATORS: the user didn't read the man page
+#: plugins/tpm/fu-tpm-eventlog.c:135 plugins/uefi-dbx/fu-dbxtool.c:184
+#: src/fu-tool.c:5765 src/fu-util.c:5734
+msgid "Failed to parse arguments"
+msgstr "Argumentov ni bilo mogoče razčleniti"
+
+#. TRANSLATORS: failed to read measurements file
+#: plugins/tpm/fu-tpm-eventlog.c:149
+msgid "Failed to parse file"
+msgstr "Razčlenjevanje datoteke je spodletelo"
+
+#. TRANSLATORS: this is shown when updating the firmware after the reboot
+#: plugins/uefi-capsule/fu-uefi-capsule-plugin.c:589
+msgid "Installing firmware update…"
+msgstr "Nameščanje posodobitve strojne programske opreme ..."
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:120
+msgid "Show the calculated version of the dbx"
+msgstr "Pokaži izračunano različico dbx"
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:128
+msgid "List entries in dbx"
+msgstr "Izpiši vnose v dbx"
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:136
+msgid "Apply update files"
+msgstr "Uveljavi posodobitvene datoteke"
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:144
+msgid "Specify the dbx database file"
+msgstr "Določite datoteko zbirke podatkov dbx"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: plugins/uefi-dbx/fu-dbxtool.c:146 src/fu-util.c:5643 src/fu-util.c:5650
+msgid "FILENAME"
+msgstr "IMEDATOTEKE"
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:153
+msgid "Override the default ESP path"
+msgstr "Preglasi kot privzeto pot ESP"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: plugins/uefi-dbx/fu-dbxtool.c:155
+msgid "PATH"
+msgstr "POT"
+
+#. TRANSLATORS: command line option
+#: plugins/uefi-dbx/fu-dbxtool.c:162
+msgid "Apply update even when not advised"
+msgstr "Uporabi posodobitev, tudi je bila odsvetovana"
+
+#. TRANSLATORS: description of dbxtool
+#: plugins/uefi-dbx/fu-dbxtool.c:177
+msgid "This tool allows an administrator to apply UEFI dbx updates."
+msgstr "To orodje omogoča skrbniku, da uporabi posodobitve dbx UEFI."
+
+#. TRANSLATORS: program name
+#: plugins/uefi-dbx/fu-dbxtool.c:180
+msgid "UEFI dbx Utility"
+msgstr "Pripomoček UEFI dbx"
+
+#. TRANSLATORS: could not read existing system data
+#. TRANSLATORS: could not read file
+#: plugins/uefi-dbx/fu-dbxtool.c:209 plugins/uefi-dbx/fu-dbxtool.c:279
+msgid "Failed to load local dbx"
+msgstr "Ni bilo mogoče naložiti krajevnega dbx"
+
+#. TRANSLATORS: could not read existing system data
+#: plugins/uefi-dbx/fu-dbxtool.c:218 plugins/uefi-dbx/fu-dbxtool.c:270
+msgid "Failed to load system dbx"
+msgstr "Sistemskega dbx ni bilo mogoče naložiti"
+
+#. TRANSLATORS: the detected version number of the dbx
+#: plugins/uefi-dbx/fu-dbxtool.c:225
+msgid "Version"
+msgstr "Različica"
+
+#. TRANSLATORS: user did not include a filename parameter
+#: plugins/uefi-dbx/fu-dbxtool.c:261
+msgid "Filename required"
+msgstr "Zahtevano je ime datoteke"
+
+#. TRANSLATORS: reading existing dbx from the system
+#: plugins/uefi-dbx/fu-dbxtool.c:266
+msgid "Parsing system dbx…"
+msgstr "Razčlenjevanje sistemskega dbx ..."
+
+#. TRANSLATORS: reading new dbx from the update
+#: plugins/uefi-dbx/fu-dbxtool.c:275
+msgid "Parsing dbx update…"
+msgstr "Razčlenjevanje posodobitve dbx ..."
+
+#. TRANSLATORS: could not parse file
+#: plugins/uefi-dbx/fu-dbxtool.c:288
+msgid "Failed to parse local dbx"
+msgstr "Razčlenitev krajevnega dbx ni uspela"
+
+#. TRANSLATORS: same or newer update already applied
+#: plugins/uefi-dbx/fu-dbxtool.c:296
+msgid "Cannot apply as dbx update has already been applied."
+msgstr "Ni možno uveljaviti, ker je bila posodobitev dbx že uveljavljena."
+
+#. TRANSLATORS: ESP refers to the EFI System Partition
+#: plugins/uefi-dbx/fu-dbxtool.c:303
+msgid "Validating ESP contents…"
+msgstr "Preverjanje vsebine ESP ..."
+
+#. TRANSLATORS: something with a blocked hash exists
+#. * in the users ESP -- which would be bad!
+#: plugins/uefi-dbx/fu-dbxtool.c:311
+msgid "Failed to validate ESP contents"
+msgstr "Preverjanje vsebine ESP ni uspelo"
+
+#. TRANSLATORS: actually sending the update to the hardware
+#: plugins/uefi-dbx/fu-dbxtool.c:318
+msgid "Applying update…"
+msgstr "Uveljavljanje posodobitve …"
+
+#. TRANSLATORS: dbx file failed to be applied as an update
+#: plugins/uefi-dbx/fu-dbxtool.c:330
+msgid "Failed to apply update"
+msgstr "Posodobitve ni bilo mogoče uveljaviti"
+
+#. TRANSLATORS: success
+#: plugins/uefi-dbx/fu-dbxtool.c:335
+msgid "Done!"
+msgstr "Opravljeno!"
+
+#. TRANSLATORS: user did not tell the tool what to do
+#: plugins/uefi-dbx/fu-dbxtool.c:342
+msgid "No action specified!"
+msgstr "Nobeno dejanje ni določeno!"
+
+#. TRANSLATORS: the user isn't reading the question
+#: src/fu-console.c:194
+#, c-format
+msgid "Please enter a number from 0 to %u: "
+msgstr "Vnesite številko od 0 do %u: "
+
+#. TRANSLATORS: the user isn't reading the question -- %1 is 'Y' and %2 is
+#. * 'N'
+#: src/fu-console.c:231
+#, c-format
+msgid "Please enter either %s or %s: "
+msgstr "Vnesite %s ali %s:"
+
+#. TRANSLATORS: daemon is inactive
+#: src/fu-console.c:363
+msgid "Idle…"
+msgstr "Nedejavno …"
+
+#. TRANSLATORS: decompressing the firmware file
+#: src/fu-console.c:367
+msgid "Decompressing…"
+msgstr "Razširjanje ..."
+
+#. TRANSLATORS: parsing the firmware information
+#: src/fu-console.c:371
+msgid "Loading…"
+msgstr "Poteka nalaganje …"
+
+#. TRANSLATORS: restarting the device to pick up new F/W
+#: src/fu-console.c:375
+msgid "Restarting device…"
+msgstr "Ponovni zagon naprave ..."
+
+#. TRANSLATORS: reading from the flash chips
+#: src/fu-console.c:379
+msgid "Reading…"
+msgstr "Poteka branje ..."
+
+#. TRANSLATORS: writing to the flash chips
+#: src/fu-console.c:383
+msgid "Writing…"
+msgstr "Poteka zapisovanje ..."
+
+#. TRANSLATORS: erasing contents of the flash chips
+#: src/fu-console.c:387
+msgid "Erasing…"
+msgstr "Poteka brisanje..."
+
+#. TRANSLATORS: verifying we wrote the firmware correctly
+#: src/fu-console.c:391
+msgid "Verifying…"
+msgstr "Poteka preverjanje ..."
+
+#. TRANSLATORS: scheduling an update to be done on the next boot
+#: src/fu-console.c:395
+msgid "Scheduling…"
+msgstr "Časovno načrtovanje procesov ..."
+
+#. TRANSLATORS: downloading from a remote server
+#: src/fu-console.c:399
+msgid "Downloading…"
+msgstr "Poteka prejemanje …"
+
+#. TRANSLATORS: waiting for user to authenticate
+#: src/fu-console.c:403
+msgid "Authenticating…"
+msgstr "Preverjanje pristnosti..."
+
+#. TRANSLATORS: waiting for device to do something
+#: src/fu-console.c:408
+msgid "Waiting…"
+msgstr "Čakanje …"
+
+#. TRANSLATORS: current daemon status is unknown
+#. TRANSLATORS: we don't know the license of the update
+#. TRANSLATORS: unknown release urgency
+#. TRANSLATORS: Suffix: the fallback HSI result
+#: src/fu-console.c:415 src/fu-util-common.c:1717 src/fu-util-common.c:1757
+#: src/fu-util-common.c:2245
+msgid "Unknown"
+msgstr "Neznano"
+
+#. TRANSLATORS: time remaining for completing firmware flash
+#: src/fu-console.c:469
+msgid "Less than one minute remaining"
+msgstr "Preostalo je manj kot eno minuto"
 
 #. TRANSLATORS: more than a minute
+#: src/fu-console.c:474
 #, c-format
 msgid "%.0f minute remaining"
 msgid_plural "%.0f minutes remaining"
@@ -24,284 +593,43 @@ msgstr[1] "Preostala je %.0f minuta"
 msgstr[2] "Preostali sta %.0f minuti"
 msgstr[3] "Preostale so %.0f minute"
 
-#. TRANSLATORS: BMC refers to baseboard management controller which
-#. * is the device that updates all the other firmware on the system
-#, c-format
-msgid "%s BMC Update"
-msgstr "Posodobitev BMC %s"
+#. TRANSLATORS: this is a prefix on the console
+#: src/fu-console.c:552
+msgid "WARNING"
+msgstr "OPOZORILO"
 
-#. TRANSLATORS: battery refers to the system power source
-#, c-format
-msgid "%s Battery Update"
-msgstr "Posodobitev baterije %s"
+#. TRANSLATORS: turn on all debugging
+#: src/fu-debug.c:241
+msgid "Show debugging information for all domains"
+msgstr "Pokaži informacije razhroščevanja za vse domene"
 
-#. TRANSLATORS: the CPU microcode is firmware loaded onto the CPU
-#. * at system boot-up
-#, c-format
-msgid "%s CPU Microcode Update"
-msgstr "Posodobitev mikrokode CPE %s"
+#. TRANSLATORS: turn on all debugging
+#: src/fu-debug.c:249
+msgid "Do not include timestamp prefix"
+msgstr "Ne vključi predpone časovnega žiga"
 
-#. TRANSLATORS: camera can refer to the laptop internal
-#. * camera in the bezel or external USB webcam
-#, c-format
-msgid "%s Camera Update"
-msgstr "Posodobitev kamere %s"
+#. TRANSLATORS: turn on all debugging
+#: src/fu-debug.c:257
+msgid "Do not include log domain prefix"
+msgstr "Ne vključi predpone domene dnevnika"
 
-#. TRANSLATORS: a specific part of hardware,
-#. * the first %s is the device name, e.g. 'Secure Boot`
-#, c-format
-msgid "%s Configuration Update"
-msgstr "Posodobitev nastavitev %s"
+#. TRANSLATORS: this is for daemon development
+#: src/fu-debug.c:265
+msgid "Show daemon verbose information for a particular domain"
+msgstr "Pokaži opisne informacije prikritega procesa za določeno domeno"
 
-#. TRANSLATORS: ME stands for Management Engine, where
-#. * the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s Consumer ME Update"
-msgstr "Posodobitev uporabniškega upravljalnika %s"
+#. TRANSLATORS: for the --verbose arg
+#: src/fu-debug.c:345
+msgid "Debugging Options"
+msgstr "Možnosti razhroščevanja"
 
-#. TRANSLATORS: the controller is a device that has other devices
-#. * plugged into it, for example ThunderBolt, FireWire or USB,
-#. * the first %s is the device name, e.g. 'Intel ThunderBolt`
-#, c-format
-msgid "%s Controller Update"
-msgstr "Posodobitev krmilnika %s"
-
-#. TRANSLATORS: ME stands for Management Engine (with Intel AMT),
-#. * where the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s Corporate ME Update"
-msgstr "Posodobitev poslovnega upravljalnika %s"
-
-#. TRANSLATORS: a specific part of hardware,
-#. * the first %s is the device name, e.g. 'Unifying Receiver`
-#, c-format
-msgid "%s Device Update"
-msgstr "Posodobitev naprave %s"
-
-#. TRANSLATORS: Video Display refers to the laptop internal display or
-#. * external monitor
-#, c-format
-msgid "%s Display Update"
-msgstr "Posodobitev zaslona %s"
-
-#. TRANSLATORS: Dock refers to the port replicator hardware laptops are
-#. * cradled in, or lowered onto
-#, c-format
-msgid "%s Dock Update"
-msgstr "Posodobitev priklopne postaje %s"
-
-#. TRANSLATORS: drive refers to a storage device, e.g. SATA disk
-#, c-format
-msgid "%s Drive Update"
-msgstr "Posodobitev naprave %s"
-
-#. TRANSLATORS: the EC is typically the keyboard controller chip,
-#. * the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s Embedded Controller Update"
-msgstr "Posodobitev vgrajenega krmilnika %s"
-
-#. TRANSLATORS: a device that can read your fingerprint pattern
-#, c-format
-msgid "%s Fingerprint Reader Update"
-msgstr "Posodobitev bralnika prstnih odtisov %s"
-
-#. TRANSLATORS: flash refers to solid state storage, e.g. UFS or eMMC
-#, c-format
-msgid "%s Flash Drive Update"
-msgstr "Posodobitev bliskovnega pogona %s"
-
-#. TRANSLATORS: GPU refers to a Graphics Processing Unit, e.g.
-#. * the "video card"
-#, c-format
-msgid "%s GPU Update"
-msgstr "Posodobitev GPE %s"
-
-#. TRANSLATORS: a large pressure-sensitive drawing area typically used
-#. * by artists and digital artists
-#, c-format
-msgid "%s Graphics Tablet Update"
-msgstr "Posodobitev grafične tablice %s"
-
-#. TRANSLATORS: two miniature speakers attached to your ears
-#, c-format
-msgid "%s Headphones Update"
-msgstr "Posodobitev slušalk %s"
-
-#. TRANSLATORS: headphones with an integrated microphone
-#, c-format
-msgid "%s Headset Update"
-msgstr "Posodobitev slušalk z mikrofonom %s"
-
-#. TRANSLATORS: an input device used by gamers, e.g. a joystick
-#, c-format
-msgid "%s Input Controller Update"
-msgstr "Posodobitev vhodnega krmilnika %s"
-
-#. TRANSLATORS: Keyboard refers to an input device for typing
-#, c-format
-msgid "%s Keyboard Update"
-msgstr "Posodobitev tipkovnice %s"
-
-#. TRANSLATORS: ME stands for Management Engine, the Intel AMT thing,
-#. * the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s ME Update"
-msgstr "Posodobitev ME %s"
-
-#. TRANSLATORS: Mouse refers to a handheld input device
-#, c-format
-msgid "%s Mouse Update"
-msgstr "Posodobitev miške %s"
-
-#. TRANSLATORS: Network Interface refers to the physical
-#. * PCI card, not the logical wired connection
-#, c-format
-msgid "%s Network Interface Update"
-msgstr "Posodobitev omrežnega vmesnika %s"
-
-#. TRANSLATORS: SSD refers to a Solid State Drive, e.g. non-rotating
-#. * SATA or NVMe disk
-#, c-format
-msgid "%s SSD Update"
-msgstr "Posodobitev SSD %s"
-
-#. TRANSLATORS: Storage Controller is typically a RAID or SAS adapter
-#, c-format
-msgid "%s Storage Controller Update"
-msgstr "Posodobitev krmilnika shrambe %s"
-
-#. TRANSLATORS: the entire system, e.g. all internal devices,
-#. * the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s System Update"
-msgstr "Posodobitev sistema %s"
-
-#. TRANSLATORS: TPM refers to a Trusted Platform Module
-#, c-format
-msgid "%s TPM Update"
-msgstr "Posodobitev modula okolja TPM %s"
-
-#. TRANSLATORS: the Thunderbolt controller is a device that
-#. * has other high speed Thunderbolt devices plugged into it;
-#. * the first %s is the system name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s Thunderbolt Controller Update"
-msgstr "Posodobitev krmilnika Thunderbolt %s"
-
-#. TRANSLATORS: TouchPad refers to a flat input device
-#, c-format
-msgid "%s Touchpad Update"
-msgstr "Posodobitev sledilne ploščice %s"
-
-#. TRANSLATORS: Dock refers to the port replicator device connected
-#. * by plugging in a USB cable -- which may or may not also provide power
-#, c-format
-msgid "%s USB Dock Update"
-msgstr "Posodobitev priklopne postaje USB %s"
-
-#. TRANSLATORS: Receiver refers to a radio device, e.g. a tiny Bluetooth
-#. * device that stays in the USB port so the wireless peripheral works
-#, c-format
-msgid "%s USB Receiver Update"
-msgstr "Posodobitev sprejemnika USB %s"
-
-#. TRANSLATORS: this is the fallback where we don't know if the release
-#. * is updating the system, the device, or a device class, or something else
-#. --
-#. * the first %s is the device name, e.g. 'ThinkPad P50`
-#, c-format
-msgid "%s Update"
-msgstr "Posodobitev %s"
-
-#. TRANSLATORS: warn the user before updating, %1 is a device name
-#, c-format
-msgid "%s and all connected devices may not be usable while updating."
-msgstr "%s in vse povezane naprave med posodabljanjem morda ne bodo uporabne."
-
-#. TRANSLATORS: %1 refers to some kind of security test, e.g. "Encrypted RAM".
-#. %2 refers to a result value, e.g. "Invalid"
-#, c-format
-msgid "%s appeared: %s"
-msgstr "%s se je pojavil: %s"
-
-#. TRANSLATORS: %1 refers to some kind of security test, e.g. "UEFI platform
-#. key".
-#. * %2 and %3 refer to results value, e.g. "Valid" and "Invalid"
-#, c-format
-msgid "%s changed: %s → %s"
-msgstr "%s spremenjeno: %s → %s"
-
-#. TRANSLATORS: %1 refers to some kind of security test, e.g. "SPI BIOS
-#. region".
-#. %2 refers to a result value, e.g. "Invalid"
-#, c-format
-msgid "%s disappeared: %s"
-msgstr "%s je izginil: %s"
-
-#. TRANSLATORS: the device has a reason it can't update, e.g. laptop lid
-#. closed
-#, c-format
-msgid "%s is not currently updatable"
-msgstr "%s trenutno ni mogoče posodobiti"
-
-#. TRANSLATORS: %1 is a device name, e.g. "ThinkPad Universal
-#. * ThunderBolt 4 Dock" and %2 is "fwupdmgr activate"
-#, c-format
-msgid "%s is pending activation; use %s to complete the update."
-msgstr "%s čaka na aktivacijo; uporabite %s za dokončanje posodobitve."
-
-#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
-#, c-format
-msgid "%s manufacturing mode"
-msgstr "Način izdelave %s"
-
-#. TRANSLATORS: warn the user before
-#. * updating, %1 is a device name
-#, c-format
-msgid "%s must remain connected for the duration of the update to avoid damage."
-msgstr "%s mora ostati povezana ves čas trajanja posodobitve, da se prepreči škoda."
-
-#. TRANSLATORS: warn the user before updating, %1 is a machine
-#. * name
-#, c-format
-msgid "%s must remain plugged into a power source for the duration of the update to avoid damage."
-msgstr "%s mora ostati priključen na vir napajanja ves čas trajanja posodobitve, da se prepreči škoda."
-
-#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
-#, c-format
-msgid "%s override"
-msgstr "Preglasitev %s"
-
-#. TRANSLATORS: Title: %1 is ME kind, e.g. CSME/TXT, %2 is a version number
-#, c-format
-msgid "%s v%s"
-msgstr "%s v%s"
-
-#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
-#, c-format
-msgid "%s version"
-msgstr "Različica %s"
-
-#. TRANSLATORS: duration in days!
-#, c-format
-msgid "%u day"
-msgid_plural "%u days"
-msgstr[0] "%u dni"
-msgstr[1] "%u dan"
-msgstr[2] "%u dneva"
-msgstr[3] "%u dnevi"
+#. TRANSLATORS: for the --verbose arg
+#: src/fu-debug.c:347
+msgid "Show debugging options"
+msgstr "Pokaži možnosti razhroščevanja"
 
 #. TRANSLATORS: this is shown in the MOTD
-#, c-format
-msgid "%u device has a firmware upgrade available."
-msgid_plural "%u devices have a firmware upgrade available."
-msgstr[0] "%u naprav ima na voljo posodobitev vdelane programske opreme."
-msgstr[1] "%u naprava ima na voljo posodobitev vdelane programske opreme."
-msgstr[2] "%u napravi imata na voljo posodobitev vdelane programske opreme."
-msgstr[3] "%u naprave imajo na voljo posodobitev vdelane programske opreme."
-
-#. TRANSLATORS: this is shown in the MOTD
+#: src/fu-engine-helper.c:120
 #, c-format
 msgid "%u device is not the best known configuration."
 msgid_plural "%u devices are not the best known configuration."
@@ -310,664 +638,893 @@ msgstr[1] " %u naprava ni najboljša znana konfiguracija."
 msgstr[2] "%u napravi nista najboljša znana konfiguracija."
 msgstr[3] "%u naprave niso najboljša znana konfiguracija."
 
-#. TRANSLATORS: duration in minutes
+#. TRANSLATORS: this is shown in the MOTD -- %1 is the
+#. * command name, e.g. `fwupdmgr sync`
+#: src/fu-engine-helper.c:128
 #, c-format
-msgid "%u hour"
-msgid_plural "%u hours"
-msgstr[0] "%u ur"
-msgstr[1] "%u ura"
-msgstr[2] "%u uri"
-msgstr[3] "%u ure"
+msgid "Run `%s` to complete this action."
+msgstr "Zaženite »%s«, da dokončate to dejanje."
 
-#. TRANSLATORS: duration in minutes
+#. TRANSLATORS: this is shown in the MOTD
+#: src/fu-engine-helper.c:135
 #, c-format
-msgid "%u minute"
-msgid_plural "%u minutes"
-msgstr[0] "%u minut"
-msgstr[1] "%u minuta"
-msgstr[2] "%u minuti"
-msgstr[3] "%u minute"
+msgid "%u device has a firmware upgrade available."
+msgid_plural "%u devices have a firmware upgrade available."
+msgstr[0] "%u naprav ima na voljo posodobitev vdelane programske opreme."
+msgstr[1] "%u naprava ima na voljo posodobitev vdelane programske opreme."
+msgstr[2] "%u napravi imata na voljo posodobitev vdelane programske opreme."
+msgstr[3] "%u naprave imajo na voljo posodobitev vdelane programske opreme."
 
-#. TRANSLATORS: duration in seconds
+#. TRANSLATORS: this is shown in the MOTD -- %1 is the
+#. * command name, e.g. `fwupdmgr get-upgrades`
+#: src/fu-engine-helper.c:143
 #, c-format
-msgid "%u second"
-msgid_plural "%u seconds"
-msgstr[0] "%u s"
-msgstr[1] "%u s"
-msgstr[2] "%u s"
-msgstr[3] "%u s"
+msgid "Run `%s` for more information."
+msgstr "Za več informacij zaženite »%s«."
 
-#. TRANSLATORS: device tests can be specific to a CPU type
+#. TRANSLATORS: exit after we've started up, used for user profiling
+#: src/fu-main.c:117
+msgid "Exit after a small delay"
+msgstr "Končaj po kratki zakasnitvi"
+
+#. TRANSLATORS: exit straight away, used for automatic profiling
+#: src/fu-main.c:125
+msgid "Exit after the engine has loaded"
+msgstr "Končaj, ko se programnik naloži"
+
+#. TRANSLATORS: program name
+#: src/fu-main.c:143
+msgid "Firmware Update Daemon"
+msgstr "Prikriti proces posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: program summary
+#: src/fu-main.c:148
+msgid "Firmware Update D-Bus Service"
+msgstr "Storitev D-Bus posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: show the user a warning
+#: src/fu-remote-list.c:163
+msgid ""
+"Your distributor may not have verified any of the firmware updates for "
+"compatibility with your system or connected devices."
+msgstr ""
+"Vaš distributer morda ni preveril nobene posodobitve vdelane programske "
+"opreme za združljivost z vašim sistemom ali priključenimi napravami."
+
+#. TRANSLATORS: show the user a warning
+#: src/fu-remote-list.c:169
+msgid "Enabling this remote is done at your own risk."
+msgstr "Ta oddaljeni strežnik omogočite na lastno odgovornost."
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:22
+msgid "SPI write"
+msgstr "Pisanje SPI"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:26
+msgid "SPI lock"
+msgstr "Zaklepanje SPI"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:30
+msgid "SPI BIOS region"
+msgstr "Regija SPI BIOS-a"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:34
+msgid "SPI BIOS Descriptor"
+msgstr "Deskriptor SPI BIOS-a"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: src/fu-security-attr-common.c:38
+msgid "Pre-boot DMA protection"
+msgstr "Zaščita DMA pred zagonom"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: src/fu-security-attr-common.c:42 src/fu-security-attr-common.c:267
+msgid "Intel BootGuard"
+msgstr "Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: src/fu-security-attr-common.c:47
+msgid "Intel BootGuard verified boot"
+msgstr "Preverjen zagon Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: src/fu-security-attr-common.c:52
+msgid "Intel BootGuard ACM protected"
+msgstr "Zaščiteno z Intel BootGuard ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: src/fu-security-attr-common.c:57
+msgid "Intel BootGuard error policy"
+msgstr "Pravilnik o napakah Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * OTP = one time programmable
+#: src/fu-security-attr-common.c:62
+msgid "Intel BootGuard OTP fuse"
+msgstr "Varovalka Intel BootGuard OTP"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * enabled means supported by the processor
+#: src/fu-security-attr-common.c:67
+msgid "CET Platform"
+msgstr "Platforma CET"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
+#. * Utilized by OS means the distribution enabled it
+#: src/fu-security-attr-common.c:72
+msgid "CET OS Support"
+msgstr "Podpora za operacijski sistem CET"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: src/fu-security-attr-common.c:76
+msgid "SMAP"
+msgstr "SMAP"
+
+#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
+#: src/fu-security-attr-common.c:80 src/fu-security-attr-common.c:299
+msgid "Encrypted RAM"
+msgstr "Šifrirani RAM"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: src/fu-security-attr-common.c:85
+msgid "IOMMU"
+msgstr "IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: src/fu-security-attr-common.c:89
+msgid "Linux kernel lockdown"
+msgstr "Zaklepanje jedra Linuxa"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: src/fu-security-attr-common.c:93
+msgid "Linux kernel"
+msgstr "Jedro Linuxa"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: src/fu-security-attr-common.c:97
+msgid "Linux swap"
+msgstr "Izmenjevalni prostor Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: src/fu-security-attr-common.c:101
+msgid "Suspend-to-ram"
+msgstr "Začasna prekinitev v RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: src/fu-security-attr-common.c:105
+msgid "Suspend-to-idle"
+msgstr "Začasna prekinitev v mirovanje"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: src/fu-security-attr-common.c:109
+msgid "UEFI platform key"
+msgstr "Ključ platforme UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: src/fu-security-attr-common.c:113
+msgid "UEFI secure boot"
+msgstr "Varni zagon vmesnika UEFI"
+
+#. TRANSLATORS: Title: Bootservice is when only readable from early-boot
+#: src/fu-security-attr-common.c:117
+msgid "UEFI bootservice variables"
+msgstr "Spremenljivke zagonske storitve UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: src/fu-security-attr-common.c:121
+msgid "TPM empty PCRs"
+msgstr "Prazni PCR-ji TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: src/fu-security-attr-common.c:125
+msgid "TPM PCR0 reconstruction"
+msgstr "Rekonstrukcija TPM PCR0"
+
+#. TRANSLATORS: Title: TPM = Trusted Platform Module
+#: src/fu-security-attr-common.c:129 src/fu-security-attr-common.c:348
+msgid "TPM v2.0"
+msgstr "TPM v2.0"
+
+#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
+#: src/fu-security-attr-common.c:135
 #, c-format
-msgid "%u test was skipped"
-msgid_plural "%u tests were skipped"
-msgstr[0] "%u  preizkusov je preskočenih"
-msgstr[1] "%u  preizkus je preskočen"
-msgstr[2] "%u  preizkusa sta preskočena"
-msgstr[3] "%u preizkusi so preskočeni"
+msgid "%s manufacturing mode"
+msgstr "Način izdelave %s"
 
-#. TRANSLATORS: first percentage is current value, 2nd percentage is the
-#. * lowest limit the firmware update is allowed for the update to happen
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: src/fu-security-attr-common.c:138
+msgid "MEI manufacturing mode"
+msgstr "Način izdelave MEI"
+
+#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
+#: src/fu-security-attr-common.c:144
 #, c-format
-msgid "%u%% (threshold %u%%)"
-msgstr "%u %% (prag %u%%)"
+msgid "%s override"
+msgstr "Preglasitev %s"
 
-#. TRANSLATORS: this is shown as a suffix for obsoleted tests
-msgid "(obsoleted)"
-msgstr "(zastarelo)"
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the
+#. * "override" is the physical PIN that can be driven to
+#. * logic high -- luckily it is probably not accessible to
+#. * end users on consumer boards
+#: src/fu-security-attr-common.c:150
+msgid "MEI override"
+msgstr "Preglasitev MEI"
 
-#. TRANSLATORS: HSI event title
-msgid "A TPM PCR is now an invalid value"
-msgstr "PCR TPM je zdaj neveljavna vrednost"
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and key refer
+#. * to the private/public key used to secure loading of firmware
+#: src/fu-security-attr-common.c:155
+msgid "MEI key manifest"
+msgstr "Manifest ključa MEI"
+
+#. TRANSLATORS: Title: %1 is ME kind, e.g. CSME/TXT, %2 is a version number
+#.
+#: src/fu-security-attr-common.c:164
+#, c-format
+msgid "%s v%s"
+msgstr "%s v%s"
+
+#. TRANSLATORS: Title: %s is ME kind, e.g. CSME/TXT
+#: src/fu-security-attr-common.c:168
+#, c-format
+msgid "%s version"
+msgstr "Različica %s"
+
+#: src/fu-security-attr-common.c:170
+msgid "MEI version"
+msgstr "Različica MEI"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: src/fu-security-attr-common.c:174
+msgid "Firmware updates"
+msgstr "Posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: src/fu-security-attr-common.c:178
+msgid "Firmware attestation"
+msgstr "Atest strojne programske opreme"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: src/fu-security-attr-common.c:182
+msgid "fwupd plugins"
+msgstr "Vstavki fwupd"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: src/fu-security-attr-common.c:187
+msgid "Platform debugging"
+msgstr "Odpravljanje napak na platformi"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: src/fu-security-attr-common.c:191
+msgid "Supported CPU"
+msgstr "Podprta CPE"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: src/fu-security-attr-common.c:195
+msgid "Processor rollback protection"
+msgstr "Zaščita pred povrnitvijo procesorja"
 
 #. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: src/fu-security-attr-common.c:199
+msgid "SPI replay protection"
+msgstr "Zaščita pred ponovnim predvajanjem SPI"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: src/fu-security-attr-common.c:203
+msgid "SPI write protection"
+msgstr "Zaščita pred zapisovanjem SPI"
+
+#. TRANSLATORS: Title: if the part has been fused
+#: src/fu-security-attr-common.c:207
+msgid "Fused platform"
+msgstr "Spojena platforma"
+
+#. TRANSLATORS: Title: if we are emulating a different host
+#: src/fu-security-attr-common.c:211
+msgid "Emulated host"
+msgstr "Emulirani gostitelj"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: src/fu-security-attr-common.c:215
+msgid "BIOS rollback protection"
+msgstr "Zaščita pred povrnitvijo BIOS-a"
+
+#. TRANSLATORS: Title: GDS is where the CPU leaks information
+#: src/fu-security-attr-common.c:219
+msgid "Intel GDS mitigation"
+msgstr "Blaženje posledic Intel GDS"
+
+#. TRANSLATORS: Title: Whether BIOS Firmware updates is enabled
+#: src/fu-security-attr-common.c:223
+msgid "BIOS firmware updates"
+msgstr "Posodobitve vdelane programske opreme BIOS-a"
+
+#. TRANSLATORS: Title: Whether firmware is locked down
+#: src/fu-security-attr-common.c:227
+msgid "SMM locked down"
+msgstr "SMM (NUS) zaklenjen"
+
+#. TRANSLATORS: Title: is UEFI early-boot memory protection turned on
+#: src/fu-security-attr-common.c:231
+msgid "UEFI memory protection"
+msgstr "Zaščita pomnilnika UEFI"
+
+#. TRANSLATORS: Title: is UEFI db up-to-date
+#: src/fu-security-attr-common.c:235 src/fu-security-attr-common.c:428
+msgid "UEFI db"
+msgstr "Db UEFI"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:247
+msgid "Firmware Write Protection"
+msgstr "Zaščita pred pisanjem vdelane programske opreme"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:251
+msgid "Firmware Write Protection Lock"
+msgstr "Zaščitni zaklep pred pisanjem vdelane programske opreme"
+
+#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:255
+msgid "Firmware BIOS Region"
+msgstr "Področje BIOS-a vdelane programske opreme"
+
+#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
+#: src/fu-security-attr-common.c:259
+msgid "Firmware BIOS Descriptor"
+msgstr "Opisnik SPI BIOS-a vdelane programske opreme"
+
+#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
+#: src/fu-security-attr-common.c:263
+msgid "Pre-boot DMA Protection"
+msgstr "Zaščita DMA pred zagonom"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * verified boot refers to the way the boot process is verified
+#: src/fu-security-attr-common.c:272
+msgid "Intel BootGuard Verified Boot"
+msgstr "Preverjeni zagon Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * ACM means to verify the integrity of Initial Boot Block
+#: src/fu-security-attr-common.c:277
+msgid "Intel BootGuard ACM Protected"
+msgstr "Zaščiteno z Intel BootGuard ACM"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
+#. * error policy is what to do on failure
+#: src/fu-security-attr-common.c:282
+msgid "Intel BootGuard Error Policy"
+msgstr "Pravilnik o napakah Intel BootGuard"
+
+#. TRANSLATORS: Title: BootGuard is a trademark from Intel
+#: src/fu-security-attr-common.c:286
+msgid "Intel BootGuard Fuse"
+msgstr "Varovalka Intel Boot Guard"
+
+#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology
+#: src/fu-security-attr-common.c:291
+msgid "Control-flow Enforcement Technology"
+msgstr "Tehnologija nadzora in nadzora pretoka"
+
+#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
+#: src/fu-security-attr-common.c:295
+msgid "Supervisor Mode Access Prevention"
+msgstr "Preprečevanje dostopa v načinu nadzornika"
+
+#. TRANSLATORS: Title:
+#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
+#: src/fu-security-attr-common.c:304
+msgid "IOMMU Protection"
+msgstr "Zaščita IOMMU"
+
+#. TRANSLATORS: Title: lockdown is a security mode of the kernel
+#: src/fu-security-attr-common.c:308
+msgid "Linux Kernel Lockdown"
+msgstr "Zaklepanje jedra Linuxa"
+
+#. TRANSLATORS: Title: if it's tainted or not
+#: src/fu-security-attr-common.c:312
+msgid "Linux Kernel Verification"
+msgstr "Preverjanje jedra Linuxa"
+
+#. TRANSLATORS: Title: swap space or swap partition
+#: src/fu-security-attr-common.c:316
+msgid "Linux Swap"
+msgstr "Izmenjevalni prostor Linux"
+
+#. TRANSLATORS: Title: sleep state
+#: src/fu-security-attr-common.c:320
+msgid "Suspend To RAM"
+msgstr "Začasna prekinitev v pomnilnik RAM"
+
+#. TRANSLATORS: Title: a better sleep state
+#: src/fu-security-attr-common.c:324
+msgid "Suspend To Idle"
+msgstr "Začasna prekinitev v mirovanje"
+
+#. TRANSLATORS: Title: PK is the 'platform key' for the machine
+#: src/fu-security-attr-common.c:328
+msgid "UEFI Platform Key"
+msgstr "Ključ platforme UEFI"
+
+#. TRANSLATORS: Title: SB is a way of locking down UEFI
+#: src/fu-security-attr-common.c:332
+msgid "UEFI Secure Boot"
+msgstr "Varni zagon vmesnika UEFI"
+
+#. TRANSLATORS: Title: Bootservice is when only readable from early-boot
+#: src/fu-security-attr-common.c:336
+msgid "UEFI Bootservice Variables"
+msgstr "Spremenljivke zagonske storitve UEFI"
+
+#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be empty
+#: src/fu-security-attr-common.c:340
+msgid "TPM Platform Configuration"
+msgstr "Konfiguracija platforme TPM"
+
+#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
+#: src/fu-security-attr-common.c:344
+msgid "TPM Reconstruction"
+msgstr "Rekonstrukcija TPM"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: src/fu-security-attr-common.c:352
+msgid "Intel Management Engine Manufacturing Mode"
+msgstr "Način izdelave mehanizma Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is enabled
+#. * with a jumper -- luckily it is probably not accessible to end users on consumer
+#. * boards
+#: src/fu-security-attr-common.c:358
+msgid "Intel Management Engine Override"
+msgstr "Preglasitev mehanizma Intel Management Engine"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine, and key refers
+#. * to the private/public key used to secure loading of firmware
+#: src/fu-security-attr-common.c:363
+msgid "MEI Key Manifest"
+msgstr "Manifest ključa MEI"
+
+#. TRANSLATORS: Title: MEI = Intel Management Engine
+#: src/fu-security-attr-common.c:367
+msgid "Intel Management Engine Version"
+msgstr "Različica orodja Intel Management Engine"
+
+#. TRANSLATORS: Title: if firmware updates are available
+#: src/fu-security-attr-common.c:371
+msgid "Firmware Updates"
+msgstr "Posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: Title: if we can verify the firmware checksums
+#: src/fu-security-attr-common.c:375
+msgid "Firmware Attestation"
+msgstr "Atest strojne programske opreme"
+
+#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
+#: src/fu-security-attr-common.c:379
+msgid "Firmware Updater Verification"
+msgstr "Preverjanje orodja za posodabljanje vdelane programske opreme"
+
+#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
+#: src/fu-security-attr-common.c:384
+msgid "Platform Debugging"
+msgstr "Odpravljanje napak na platformi"
+
+#. TRANSLATORS: Title: if fwupd supports HSI on this chip
+#: src/fu-security-attr-common.c:388
+msgid "Processor Security Checks"
+msgstr "Varnostni pregledi procesorja"
+
+#. TRANSLATORS: Title: if firmware enforces rollback protection
+#: src/fu-security-attr-common.c:392
+msgid "AMD Secure Processor Rollback Protection"
+msgstr ""
+"Varnostna zaščita pred povrnitvijo procesorja AMD (AMD Secure Processor "
+"Rollback Protection)"
+
+#. TRANSLATORS: Title: if hardware enforces control of SPI replays
+#: src/fu-security-attr-common.c:396
 msgid "AMD Firmware Replay Protection"
 msgstr "Zaščita pred ponovnim predvajanjem vdelane programske opreme AMD"
 
 #. TRANSLATORS: Title: if hardware enforces control of SPI writes
+#: src/fu-security-attr-common.c:400
 msgid "AMD Firmware Write Protection"
 msgstr "Zaščita pred pisanjem vdelane programske opreme AMD"
 
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-msgid "AMD Secure Processor Rollback Protection"
-msgstr "Varnostna zaščita pred povrnitvijo procesorja AMD (AMD Secure Processor Rollback Protection)"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "ARCHIVE FIRMWARE METAINFO [FIRMWARE] [METAINFO] [JCATFILE]"
-msgstr "ARHIV VDELANA-PROG-OPREMA METAPODATKI [VDELANA-PROG-OPREMA] [METAPODATKI] [DATOTEKAJCAT]"
-
-#. TRANSLATORS: the user needs to do something, e.g. remove the device
-msgid "Action Required:"
-msgstr "Potrebni je ukrepanje:"
-
-#. TRANSLATORS: command description
-msgid "Activate devices"
-msgstr "Aktiviraj naprave"
-
-#. TRANSLATORS: command description
-msgid "Activate pending devices"
-msgstr "Aktiviraj čakajoče naprave"
-
-msgid "Activate the new firmware on the device"
-msgstr "Aktiviraj novo strojno programsko opremo v napravi"
-
-#. TRANSLATORS: shown when shutting down to switch to the new version
-msgid "Activating firmware update"
-msgstr "Aktiviranje posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: shown when shutting down to switch to the new version
-msgid "Activating firmware update for"
-msgstr "Aktiviranje posodobitve vdelane programske opreme za"
-
-#. TRANSLATORS: command description
-msgid "Adds devices to watch for future emulation"
-msgstr "Doda naprave za spremljanje prihodnje emulacije"
-
-#. TRANSLATORS: the age of the metadata
-msgid "Age"
-msgstr "Starost"
-
-#. TRANSLATORS: should the remote still be enabled
-msgid "Agree and enable the remote?"
-msgstr "Se strinjate in želite omogočiti oddaljeni strežnik?"
-
-#. TRANSLATORS: this is a command alias, e.g. 'get-devices'
-#, c-format
-msgid "Alias to %s"
-msgstr "Vzdevek za %s"
-
-#. TRANSLATORS: HSI event title
-msgid "All TPM PCRs are now valid"
-msgstr "Vsi PCR-ji TPM so zdaj veljavni"
-
-#. TRANSLATORS: HSI event title
-msgid "All TPM PCRs are valid"
-msgstr "Vsi PCR-ji TPM so veljavni"
-
-#. TRANSLATORS: an application is preventing system updates
-msgid "All devices are prevented from update by system inhibit"
-msgstr "Sistem preprečuje posodobitev vsem napravam"
-
-#. TRANSLATORS: on some systems certain devices have to have matching
-#. versions,
-#. * e.g. the EFI driver for a given network card cannot be different
-msgid "All devices of the same type will be updated at the same time"
-msgstr "Vse naprave iste vrste bodo posodobljene hkrati"
-
-#. TRANSLATORS: command line option
-msgid "Allow downgrading firmware versions"
-msgstr "Dovoli zamenjavo različic vdelane programske opreme s starejšo različico"
-
-#. TRANSLATORS: command line option
-msgid "Allow reinstalling existing firmware versions"
-msgstr "Dovoli vnovično namestitev obstoječih različic vdelane programske opreme"
-
-#. TRANSLATORS: command line option
-msgid "Allow switching firmware branch"
-msgstr "Dovoli preklapljanje veje vdelane programske opreme"
-
-#. TRANSLATORS: error message
-msgid "Already exists, and no --force specified"
-msgstr "Že obstaja, parameter --force ni naveden"
-
-#. TRANSLATORS: is not the main firmware stream
-msgid "Alternate branch"
-msgstr "Nadomestna veja"
-
-#. TRANSLATORS: another application is updating the device already
-msgid "An update is in progress"
-msgstr "Posodobitev je v teku"
-
-#. TRANSLATORS: explain why we want to reboot
-msgid "An update requires a reboot to complete."
-msgstr "Posodobitev zahteva vnovični zagon, da bo dokončana."
-
-#. TRANSLATORS: explain why
-msgid "An update requires the system to shutdown to complete."
-msgstr "Posodobitev zahteva zaustavitev sistema, da bo dokončana."
-
-#. TRANSLATORS: command line option
-msgid "Answer yes to all questions"
-msgstr "Na vsa vprašanja odgovori pritrdilno"
-
-#. TRANSLATORS: command line option
-msgid "Apply update even when not advised"
-msgstr "Uporabi posodobitev, tudi je bila odsvetovana"
-
-#. TRANSLATORS: command line option
-msgid "Apply update files"
-msgstr "Uveljavi posodobitvene datoteke"
-
-#. TRANSLATORS: actually sending the update to the hardware
-msgid "Applying update…"
-msgstr "Uveljavljanje posodobitve …"
-
-#. TRANSLATORS: approved firmware has been checked by
-#. * the domain administrator
-msgid "Approved firmware:"
-msgid_plural "Approved firmware:"
-msgstr[0] "Odobrena strojna programska oprema:"
-msgstr[1] "Odobrena strojna programska oprema:"
-msgstr[2] "Odobrena strojna programska oprema:"
-msgstr[3] "Odobrena strojna programska oprema:"
-
-#. TRANSLATORS: command description
-msgid "Asks the daemon to quit"
-msgstr "Naroči prikritemu procesu, naj neha delovati"
-
-#. TRANSLATORS: command description
-msgid "Attach to firmware mode"
-msgstr "Pripni na način vdelane programske opreme"
-
-#. TRANSLATORS: waiting for user to authenticate
-msgid "Authenticating…"
-msgstr "Preverjanje pristnosti..."
-
-#. TRANSLATORS: user needs to run a command
-msgid "Authentication details are required"
-msgstr "Zahtevane so podrobnosti preverjanja pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to downgrade the firmware on a removable device"
-msgstr "Preverjanje pristnosti je potrebno za vrnitev na starejšo različico vdelane programske opreme na izmenljivi napravi"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to downgrade the firmware on this machine"
-msgstr "Preverjanje pristnosti je potrebno za vrnitev na starejšo različico vdelane programske opreme v tem računalniku"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to enable emulation data collection"
-msgstr "Za omogočanje zbiranja podatkov emulacije strojne opreme je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to fix a host security issue"
-msgstr "Preverjanje pristnosti je potrebno za odpravljanje težave z varnostjo gostitelja"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to load hardware emulation data"
-msgstr "Za nalaganje podatkov emulacije strojne opreme je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to modify BIOS settings"
-msgstr "Za spreminjanje nastavitev BIOS-a je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to modify a configured remote used for firmware updates"
-msgstr "Preverjanje pristnosti je potrebno za spreminjanje nastavitev oddaljenega strežnika, ki se uporablja za posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to modify daemon configuration"
-msgstr "Za spreminjanje prilagoditve prikritega procesa je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to read BIOS settings"
-msgstr "Za branje nastavitev BIOS-a je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to reset daemon configuration to defaults"
-msgstr "Za spreminjanje prilagoditve prikritega procesa na privzeto je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to save hardware emulation data"
-msgstr "Za shranjevanje podatkov emulacije strojne opreme je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to set the list of approved firmware"
-msgstr "Preverjanje pristnosti je potrebno za nastavitev seznama odobrene vdelane programske opreme"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to sign data using the client certificate"
-msgstr "Preverjanje pristnosti je potrebno za podpisovanje podatkov s potrdilom odjemalca"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to stop the firmware update service"
-msgstr "Preverjanje pristnosti je potrebno za ustavitev storitve posodabljanja strojno programske opreme"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to switch to the new firmware version"
-msgstr "Preverjanje pristnosti je potrebno za preklop na novo različico strojne programske opreme"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to undo the fix for a host security issue"
-msgstr "Preverjanje pristnosti je potrebno, če želite razveljaviti popravek za težavo z varnostjo gostitelja"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to unlock a device"
-msgstr "Za odklepanje naprave je potrebno preverjanje pristnosti"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to update the firmware on a removable device"
-msgstr "Preverjanje pristnosti je potrebno za posodobitev strojno programske opreme v izmenljivi napravi"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to update the firmware on this machine"
-msgstr "Preverjanje pristnosti je potrebno za posodobitev strojno programske opreme v tem računalniku"
-
-#. TRANSLATORS: this is the PolicyKit modal dialog
-msgid "Authentication is required to update the stored checksums for the device"
-msgstr "Preverjanje pristnosti je potrebno za posodobitev shranjenih kontrolnih vsot za napravo"
-
-#. TRANSLATORS: Boolean value to automatically send reports
-msgid "Automatic Reporting"
-msgstr "Samodejno poročanje"
-
-#. TRANSLATORS: we can auto-uninhibit after a timeout
-#, c-format
-msgid "Automatically uninhibiting in %ums…"
-msgstr "Samodejno sproščanje sistema čez %u ms ..."
-
-#. TRANSLATORS: can we JFDI?
-msgid "Automatically upload every time?"
-msgstr "Želite vsakič samodejno naložiti?"
-
-#. TRANSLATORS: Title: Whether BIOS Firmware updates is enabled
-msgid "BIOS Firmware Updates"
-msgstr "Posodobitve vdelane programske opreme BIOS-a"
+#. TRANSLATORS: Title: if the part has been fused
+#: src/fu-security-attr-common.c:404
+msgid "Fused Platform"
+msgstr "Spojena platforma"
 
 #. TRANSLATORS: Title: if firmware enforces rollback protection
+#: src/fu-security-attr-common.c:408
 msgid "BIOS Rollback Protection"
 msgstr "Zaščita pred vračanjem BIOS-a"
 
+#. TRANSLATORS: Title: GDS is where the CPU leaks information
+#: src/fu-security-attr-common.c:412
+msgid "Intel GDS Mitigation"
+msgstr "Blaženje posledic Intel GDS"
+
 #. TRANSLATORS: Title: Whether BIOS Firmware updates is enabled
-msgid "BIOS firmware updates"
+#: src/fu-security-attr-common.c:416
+msgid "BIOS Firmware Updates"
 msgstr "Posodobitve vdelane programske opreme BIOS-a"
 
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-msgid "BIOS rollback protection"
-msgstr "Zaščita pred povrnitvijo BIOS-a"
+#. TRANSLATORS: Title: Whether firmware is locked down
+#: src/fu-security-attr-common.c:420
+msgid "System Management Mode"
+msgstr "Način upravljanja sistema"
 
-#. TRANSLATORS: description of a BIOS setting
-msgid "BIOS updates delivered via LVFS or Windows Update"
-msgstr "Posodobitve BIOS-a, dostavljene prek LVFS ali Windows Update"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "BUILDER-XML FILENAME-DST"
-msgstr "BUILDER-XML IMEDATOTEKE-DST"
-
-#. TRANSLATORS: refers to the battery inside the peripheral device
-msgid "Battery"
-msgstr "Baterija"
-
-#. TRANSLATORS: command description
-msgid "Bind new kernel driver"
-msgstr "Poveži novi gonilnik jedra"
-
-#. TRANSLATORS: there follows a list of hashes
-msgid "Blocked firmware files:"
-msgstr "Blokirane datoteke vdelane programske opreme:"
-
-#. TRANSLATORS: version cannot be installed due to policy
-msgid "Blocked version"
-msgstr "Blokirana različica"
-
-#. TRANSLATORS: we will not offer this firmware to the user
-msgid "Blocking firmware:"
-msgstr "Blokiranje vdelane programske opreme:"
-
-#. TRANSLATORS: command description
-msgid "Blocks a specific firmware from being installed"
-msgstr "Blokira namestitev določene vdelane programske opreme"
-
-#. TRANSLATORS: firmware version of bootloader
-msgid "Bootloader Version"
-msgstr "Različica zagonskega nalagalnika"
-
-#. TRANSLATORS: the stream of firmware, e.g. nonfree
-msgid "Branch"
-msgstr "Veja"
-
-#. TRANSLATORS: command description
-msgid "Build a cabinet archive from a firmware blob and XML metadata"
-msgstr "Ustvari arhiv vsebnika iz zbirke dvojiških podatkov in metapodatkov XML vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Build a firmware file"
-msgstr "Ustvari datoteko vdelane programske opreme"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * Utilized by OS means the distribution enabled it
-msgid "CET OS Support"
-msgstr "Podpora za operacijski sistem CET"
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology,
-#. * enabled means supported by the processor
-msgid "CET Platform"
-msgstr "Platforma CET"
+#. TRANSLATORS: Title: is UEFI early-boot memory protection turned on
+#: src/fu-security-attr-common.c:424
+msgid "UEFI Memory Protection"
+msgstr "Zaščita pomnilnika UEFI"
 
 #. TRANSLATORS: longer description
-msgid "CPU Microcode must be updated to mitigate against various information-disclosure security issues."
-msgstr "Mikrokodo CPE je treba posodobiti, da se ublažijo različna varnostna vprašanja razkritja informacij."
-
-#. TRANSLATORS: we can save all device enumeration events for emulation
-msgid "Can tag for emulation"
-msgstr "Lahko označite za emulacijo"
-
-#. TRANSLATORS: this is to abort the interactive prompt
-msgid "Cancel"
-msgstr "Prekliči"
-
-#. TRANSLATORS: this is when a device ctrl+c's a watch
-#. TRANSLATORS: this is from ctrl+c
-msgid "Cancelled"
-msgstr "Preklicano"
-
-#. TRANSLATORS: same or newer update already applied
-msgid "Cannot apply as dbx update has already been applied."
-msgstr "Ni možno uveljaviti, ker je bila posodobitev dbx že uveljavljena."
-
-#. TRANSLATORS: this is when the daemon state changes
-msgid "Changed"
-msgstr "Spremenjeno"
-
-#. TRANSLATORS: command description
-msgid "Check if any devices are pending a reboot to complete update"
-msgstr "Preveri, če katera od naprav čaka na ponoven zagon za zaključek posodobitve"
-
-#. TRANSLATORS: command description
-msgid "Checks cryptographic hash matches firmware"
-msgstr "Preverja, da se kriptografska kontrolna vsota ujema z vdelano programsko opremo"
-
-#. TRANSLATORS: hash to that exact firmware archive
-#. TRANSLATORS: remote checksum
-msgid "Checksum"
-msgstr "Kontrolna vsota"
-
-#. TRANSLATORS: get interactive prompt, where branch is the
-#. * supplier of the firmware, e.g. "non-free" or "free"
-msgid "Choose branch"
-msgstr "Izberite vejo"
-
-#. TRANSLATORS: get interactive prompt
-msgid "Choose device"
-msgstr "Izberite napravo"
-
-#. TRANSLATORS: get interactive prompt
-msgid "Choose firmware"
-msgstr "Izberite strojno programsko opremo"
-
-#. TRANSLATORS: get interactive prompt
-msgid "Choose release"
-msgstr "Izberite izdajo"
-
-#. TRANSLATORS: get interactive prompt
-msgid "Choose volume"
-msgstr "Izberite nosilec"
-
-#. TRANSLATORS: command description
-msgid "Clears the results from the last update"
-msgstr "Počisti rezultate zadnje posodobitve."
-
-#. TRANSLATORS: error message
-msgid "Command not found"
-msgstr "Ukaz ni mogoče najti"
-
-#. TRANSLATORS: is not supported by the vendor
-msgid "Community supported"
-msgstr "Podprto s strani skupnosti"
-
-#. TRANSLATORS: command description
-msgid "Compares two versions for equality"
-msgstr "Primerja dve različici, če sta enaki"
-
-#. TRANSLATORS: title prefix for the BIOS settings dialog
-msgid "Configuration Change Suggested"
-msgstr "Predlagana sprememba konfiguracije"
-
-#. TRANSLATORS: no peeking
-msgid "Configuration is only readable by the system administrator"
-msgstr "Konfiguracijo lahko prebere le skrbnik sistema"
+#: src/fu-security-attr-common.c:442
+msgid ""
+"Firmware Write Protection protects device firmware memory from being "
+"tampered with."
+msgstr ""
+"Zaščita pred zapisovanjem vdelane programske opreme ščiti pomnilnik vdelane "
+"programske opreme naprave pred nedovoljenimi posegi."
 
 #. TRANSLATORS: longer description
-msgid "Control-Flow Enforcement Technology detects and prevents certain methods for running malicious software on the device."
-msgstr "Tehnologija Control-Flow Enforcement Technology zazna in prepreči določene načine za izvajanje zlonamerne programske opreme v napravi."
-
-#. TRANSLATORS: Title: CET = Control-flow Enforcement Technology
-msgid "Control-flow Enforcement Technology"
-msgstr "Tehnologija nadzora in nadzora pretoka"
-
-#. TRANSLATORS: command description
-msgid "Convert a firmware file"
-msgstr "Pretvori datoteko vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Create an EFI boot entry"
-msgstr "Ustvari zagonski vnos za EFI"
-
-#. TRANSLATORS: when the update was built
-msgid "Created"
-msgstr "Ustvarjeno"
-
-#. TRANSLATORS: the release urgency
-msgid "Critical"
-msgstr "Kritično"
-
-#. TRANSLATORS: Device supports some form of checksum verification
-msgid "Cryptographic hash verification is available"
-msgstr "Na voljo je preverjanje kriptografske kontrolne vsote"
-
-#. TRANSLATORS: current value of a BIOS setting
-msgid "Current Value"
-msgstr "Trenutna vrednost"
-
-#. TRANSLATORS: version number of current firmware
-msgid "Current version"
-msgstr "Trenutna različica"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "DEVICE-ID|GUID"
-msgstr "ID-NAPRAVE|GUID"
-
-#. TRANSLATORS: for the --verbose arg
-msgid "Debugging Options"
-msgstr "Možnosti razhroščevanja"
-
-#. TRANSLATORS: decompressing the firmware file
-msgid "Decompressing…"
-msgstr "Razširjanje ..."
-
-#. TRANSLATORS: command description
-msgid "Delete an EFI boot entry"
-msgstr "Izbriše zagonski vnos za EFI"
-
-#. TRANSLATORS: description of BIOS setting
-#. TRANSLATORS: multiline description of device
-msgid "Description"
-msgstr "Opis"
-
-#. TRANSLATORS: command description
-msgid "Detach to bootloader mode"
-msgstr "Odklopi v način zagonskega nalagalnika"
-
-#. TRANSLATORS: more details about the update link
-msgid "Details"
-msgstr "Podrobnosti"
-
-#. TRANSLATORS: the best known configuration is a set of software that we know
-#. works
-#. * well together. In the OEM and ODM industries it is often called a BKC
-msgid "Deviate from the best known configuration?"
-msgstr "Odstopate od najbolj znane konfiguracije?"
-
-#. TRANSLATORS: description of device ability
-msgid "Device Flags"
-msgstr "Zastavice naprave"
-
-#. TRANSLATORS: ID for hardware, typically a SHA1 sum
-msgid "Device ID"
-msgstr "Določilo ID naprave"
-
-#. TRANSLATORS: description of the device requests
-msgid "Device Requests"
-msgstr "Zahteve naprave"
-
-#. TRANSLATORS: this is when a device is hotplugged
-msgid "Device added:"
-msgstr "Dodana naprava:"
-
-#. TRANSLATORS: the device is already connected
-msgid "Device already exists"
-msgstr "Naprava že obstaja"
-
-#. TRANSLATORS: for example the batteries *inside* the Bluetooth mouse
-msgid "Device battery power is too low"
-msgstr "Napetost baterije naprave je prenizka"
-
-#. TRANSLATORS: for example the batteries *inside* the Bluetooth mouse
-#, c-format
-msgid "Device battery power is too low (%u%%, requires %u%%)"
-msgstr "Napolnjenost baterije naprave je prenizka (%u %%, zahtevano je vsaj %u %%)"
-
-#. TRANSLATORS: Device supports a safety mechanism for flashing
-msgid "Device can recover flash failures"
-msgstr "Naprava lahko obnovi napake bliskovnega pisanja"
-
-#. TRANSLATORS: lid means "laptop top cover"
-msgid "Device cannot be updated while the lid is closed"
-msgstr "Naprave ni mogoče posodobiti, ko je pokrov zaprt"
-
-#. TRANSLATORS: this is when a device has been updated
-msgid "Device changed:"
-msgstr "Spremenjena naprava:"
-
-#. TRANSLATORS: a version check is required for all firmware
-msgid "Device firmware is required to have a version check"
-msgstr "Vdelana programska oprema naprave mora imeti preverjanje različice"
-
-#. TRANSLATORS: emulated means we are pretending to be a different model
-msgid "Device is emulated"
-msgstr "Naprava je emulirana"
-
-#. TRANSLATORS: device cannot be interrupted, for instance taking a phone call
-msgid "Device is in use"
-msgstr "Naprava je v uporabi"
-
-#. TRANSLATORS: Is locked and can be unlocked
-msgid "Device is locked"
-msgstr "Naprava je zaklenjena"
-
-#. TRANSLATORS: we have two ways of communicating with the device, so we hide
-#. one
-msgid "Device is lower priority than an equivalent device"
-msgstr "Naprava ima nižjo prednost kot ekvivalentna naprava"
-
-#. TRANSLATORS: the device cannot update from A->C and has to go A->B->C
-msgid "Device is required to install all provided releases"
-msgstr "Naprava je potrebna za namestitev vseh priloženih izdaj"
-
-#. TRANSLATORS: currently unreachable, perhaps because it is in a lower power
-#. state
-#. * or is out of wireless range
-msgid "Device is unreachable"
-msgstr "Naprava je nedosegljiva"
-
-#. TRANSLATORS: for example, a Bluetooth mouse that is in powersave mode
-msgid "Device is unreachable, or out of wireless range"
-msgstr "Naprava je nedosegljiva ali je zunaj brezžičnega območja"
-
-#. TRANSLATORS: Device remains usable during update
-msgid "Device is usable for the duration of the update"
-msgstr "Naprava je uporabna ves čas trajanja posodobitve"
-
-#. TRANSLATORS: usually this is when we're waiting for a reboot
-msgid "Device is waiting for the update to be applied"
-msgstr "Naprava je pripravljena za uveljavitev posodobitve"
-
-#. TRANSLATORS: success, so say thank you to the user
-msgid "Device list uploaded successfully, thanks!"
-msgstr "Seznam naprav je uspešno naložen, hvala!"
-
-#. TRANSLATORS: this is when a device is hotplugged
-msgid "Device removed:"
-msgstr "Odstranjena naprava:"
-
-#. TRANSLATORS: as in, wired mains power for a laptop
-msgid "Device requires AC power to be connected"
-msgstr "Naprava mora biti priključena na električno omrežje"
-
-#. TRANSLATORS: device does not have a display connected
-msgid "Device requires a display to be plugged in"
-msgstr "Naprava zahteva, da je zaslon priključen"
-
-#. TRANSLATORS: The device cannot be updated due to missing vendor's license."
-msgid "Device requires a software license to update"
-msgstr "Naprava za posodobitev potrebuje licenco programske opreme"
+#: src/fu-security-attr-common.c:447
+msgid ""
+"Firmware BIOS Region protects device firmware memory from being tampered "
+"with."
+msgstr ""
+"Firmware BIOS Region ščiti pomnilnik vdelane programske opreme naprave pred "
+"nedovoljenimi posegi."
 
 #. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:452
+msgid ""
+"Firmware BIOS Descriptor protects device firmware memory from being tampered "
+"with."
+msgstr ""
+"Deskriptor vdelane programske opreme BIOS-a ščiti pomnilnik vdelane "
+"programske opreme naprave pred nedovoljenimi posegi."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:457
+msgid ""
+"Pre-boot DMA protection prevents devices from accessing system memory after "
+"being connected to the computer."
+msgstr ""
+"Zaščita DMA pred zagonom preprečuje napravam dostop do sistemskega "
+"pomnilnika, ko so priključene na računalnik."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:465
+msgid ""
+"Intel BootGuard prevents unauthorized device software from operating when "
+"the device is started."
+msgstr ""
+"Intel BootGuard prepreči delovanje nepooblaščene programske opreme naprave "
+"ob zagonu naprave."
+
+#: src/fu-security-attr-common.c:471
+msgid ""
+"Intel BootGuard Error Policy ensures the device does not continue to start "
+"if its device software has been tampered with."
+msgstr ""
+"Pravilnik o napakah Intel BootGuard zagotavlja, da se naprava ne zažene "
+"naprej, če je bila spremenjena programska oprema naprave."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:477
+msgid ""
+"Control-Flow Enforcement Technology detects and prevents certain methods for "
+"running malicious software on the device."
+msgstr ""
+"Tehnologija Control-Flow Enforcement Technology zazna in prepreči določene "
+"načine za izvajanje zlonamerne programske opreme v napravi."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:482
+msgid ""
+"Supervisor Mode Access Prevention ensures critical parts of device memory "
+"are not accessed by less secure programs."
+msgstr ""
+"Preprečitev dostopa do načina nadzornika zagotavlja, da do kritičnih delov "
+"pomnilnika naprave ne dostopajo manj varni programi."
+
+#: src/fu-security-attr-common.c:488
+msgid ""
+"Encrypted RAM makes it impossible for information that is stored in device "
+"memory to be read if the memory chip is removed and accessed."
+msgstr ""
+"Šifrirani RAM onemogoča branje informacij, ki so shranjene v pomnilniku "
+"naprave, če je pomnilniški čip odstranjen in je dostopano do njega."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:493
+msgid ""
+"IOMMU Protection prevents connected devices from accessing unauthorized "
+"parts of system memory."
+msgstr ""
+"Zaščita IOMMU povezanim napravam preprečuje dostop do nepooblaščenih delov "
+"sistemskega pomnilnika."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:498
+msgid ""
+"Linux Kernel Lockdown mode prevents administrator (root) accounts from "
+"accessing and changing critical parts of system software."
+msgstr ""
+"Način zaklepanja jedra Linuxa skrbniškim (korenskim) računom preprečuje "
+"dostop do kritičnih delov sistemske programske opreme in njihovo "
+"spreminjanje."
+
+#: src/fu-security-attr-common.c:504
+msgid ""
+"Linux Kernel Verification makes sure that critical system software has not "
+"been tampered with. Using device drivers which are not provided with the "
+"system can prevent this security feature from working correctly."
+msgstr ""
+"Preverjanje jedra Linuxa zagotavlja, da kritična sistemska programska oprema "
+"ni bila spremenjena. Uporaba gonilnikov naprav, ki niso priloženi sistemu, "
+"lahko prepreči pravilno delovanje te varnostne funkcije."
+
+#: src/fu-security-attr-common.c:511
+msgid ""
+"Linux Kernel Swap temporarily saves information to disk as you work. If the "
+"information is not protected, it could be accessed by someone if they "
+"obtained the disk."
+msgstr ""
+"Zamenjava jedra Linuxa med delom začasno shrani informacije na disk. Če "
+"podatki niso zaščiteni, lahko do njih dostopa nekdo, če je dobil dostop do "
+"diska."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:517
+msgid ""
+"Suspend to RAM allows the device to quickly go to sleep in order to save "
+"power. While the device has been suspended, its memory could be physically "
+"removed and its information accessed."
+msgstr ""
+"Prekinitev v RAM omogoča, da naprava hitro preide v stanje pripravljenosti, "
+"da prihrani energijo. Ko je bila naprava začasno prekinjena, je bil njen "
+"pomnilnik fizično odstranjen in dostop do informacij."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:523
+msgid ""
+"Suspend to Idle allows the device to quickly go to sleep in order to save "
+"power. While the device has been suspended, its memory could be physically "
+"removed and its information accessed."
+msgstr ""
+"Prekinitev v mirovanje omogoča napravi, da hitro preide v stanje mirovanja, "
+"da prihrani energijo. Ko je bila naprava začasno prekinjena, je bil njen "
+"pomnilnik fizično odstranjen in dostop do informacij."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:529
+msgid ""
+"The UEFI Platform Key is used to determine if device software comes from a "
+"trusted source."
+msgstr ""
+"Ključ platforme UEFI se uporablja za ugotavljanje, ali programska oprema "
+"naprave prihaja iz zaupanja vrednega vira."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:534
+msgid ""
+"UEFI Secure Boot prevents malicious software from being loaded when the "
+"device starts."
+msgstr ""
+"Varni zagon UEFI Secure Boot preprečuje nalaganje zlonamerne programske "
+"opreme ob zagonu naprave."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:539
+msgid "UEFI boot service variables should not be readable from runtime mode."
+msgstr ""
+"Spremenljivke zagonske storitve UEFI ne smejo biti berljive iz načina "
+"izvajanja."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:543
+msgid ""
+"The TPM (Trusted Platform Module) Platform Configuration is used to check "
+"whether the device start process has been modified."
+msgstr ""
+"Konfiguracija platforme modula zaupanja TPM (Trusted Platform Module) se "
+"uporablja za preverjanje, ali je bil postopek zagona naprave spremenjen."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:548
+msgid ""
+"The TPM (Trusted Platform Module) Reconstruction is used to check whether "
+"the device start process has been modified."
+msgstr ""
+"Rekonstrukcija modula zaupanja TPM (Trusted Platform Module) se uporablja za "
+"preverjanje, ali je bil postopek zagona naprave spremenjen."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:553
+msgid ""
+"TPM (Trusted Platform Module) is a computer chip that detects when hardware "
+"components have been tampered with."
+msgstr ""
+"TPM (Trusted Platform Module) je računalniški čip, ki zazna, kdaj so bile "
+"spremenjene komponente strojne opreme."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:559
+msgid ""
+"Manufacturing Mode is used when the device is manufactured and security "
+"features are not yet enabled."
+msgstr ""
+"Način izdelave se uporablja, ko je naprava izdelana, varnostne funkcije pa "
+"še niso omogočene."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:564
+msgid ""
+"Intel Management Engine Override disables checks for device software "
+"tampering."
+msgstr ""
+"Intel Management Engine Override onemogoči preverjanja nedovoljenih posegov "
+"v programsko opremo naprave."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:569
+msgid ""
+"The Intel Management Engine Key Manifest must be valid so that the device "
+"firmware can be trusted by the CPU."
+msgstr ""
+"Manifest ključa Intel Management Engine mora biti veljaven, tako da lahko "
+"CPE zaupa strojni programski opremi naprave."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:574
+msgid ""
+"The Intel Management Engine controls device components and needs to have a "
+"recent version to avoid security issues."
+msgstr ""
+"Intel Management Engine nadzoruje komponente naprave in mora imeti "
+"najnovejšo različico, da se izogne varnostnim težavam."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:579
 msgid "Device software updates are provided for this device."
 msgstr "Za to napravo so na voljo posodobitve programske opreme naprave."
 
-#. TRANSLATORS: Device supports a safety mechanism for flashing
-msgid "Device stages updates"
-msgstr "Naprava ima več stopenj posodobitve"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:583
+msgid ""
+"Firmware Attestation checks device software using a reference copy, to make "
+"sure that it has not been changed."
+msgstr ""
+"Potrdilo o vdelani programski opremi preveri programsko opremo naprave z "
+"referenčno kopijo in se prepriča, da ni bila spremenjena."
 
-#. TRANSLATORS: there is more than one supplier of the firmware
-msgid "Device supports switching to a different branch of firmware"
-msgstr "Naprava podpira preklop na drugo vejo vdelane programske opreme"
+#: src/fu-security-attr-common.c:589
+msgid ""
+"Firmware Updater Verification checks that software used for updating has not "
+"been tampered with."
+msgstr ""
+"Preverjanje orodja za posodabljanje vdelane programske opreme preveri, ali "
+"programska oprema, uporabljena za posodabljanje, ni bila spremenjena."
 
-#. TRANSLATORS: Device update needs to be separately activated
-msgid "Device update needs activation"
-msgstr "Posodobitev naprave je treba aktivirati"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:595
+msgid ""
+"Platform Debugging allows device security features to be disabled. This "
+"should only be used by hardware manufacturers."
+msgstr ""
+"Odpravljanje napak na platformi omogoča onemogočanje varnostnih funkcij "
+"naprave. To naj uporabljajo samo proizvajalci strojne opreme."
 
-#. TRANSLATORS: save the old firmware to disk before installing the new one
-msgid "Device will backup firmware before installing"
-msgstr "Naprava bo pred namestitvijo varnostno kopirala vdelano programsko opremo"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:600
+msgid "Each system should have tests to ensure firmware security."
+msgstr ""
+"Vsak sistem mora imeti preizkuse za zagotovitev varnosti vdelane programske "
+"opreme."
 
-#. TRANSLATORS: Device will not return after update completes
-msgid "Device will not re-appear after update completes"
-msgstr "Naprava se po dokončanju posodobitve ne bo več prikazala"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:606
+msgid ""
+"Rollback Protection prevents device software from being downgraded to an "
+"older version that has security problems."
+msgstr ""
+"Zaščita pred povrnitvijo preprečuje zamenjavo programske opreme naprave s "
+"starejšo različico, ki ima varnostne težave."
 
-#. TRANSLATORS: a list of successful updates
-msgid "Devices that have been updated successfully:"
-msgstr "Naprave, ki so bile uspešno posodobljene:"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:611
+msgid ""
+"CPU Microcode must be updated to mitigate against various information-"
+"disclosure security issues."
+msgstr ""
+"Mikrokodo CPE je treba posodobiti, da se ublažijo različna varnostna "
+"vprašanja razkritja informacij."
 
-#. TRANSLATORS: a list of failed updates
-msgid "Devices that were not updated correctly:"
-msgstr "Naprave, ki niso bile pravilno posodobljene:"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:616
+msgid "Enabling firmware updates for the BIOS allows fixing security issues."
+msgstr ""
+"Če omogočite posodobitve vdelane programske opreme za BIOS, lahko odpravite "
+"varnostne težave."
 
-#. TRANSLATORS: message letting the user there is an update
-#. * waiting, but there is a reason it cannot be deployed
-msgid "Devices with firmware updates that need user action: "
-msgstr "Naprave s posodobitvami vdelane programske opreme, ki zahtevajo ukrepanje:"
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:620
+msgid ""
+"System management mode is used by the firmware to access resident BIOS code "
+"and data."
+msgstr ""
+"Način upravljanja sistema uporablja programje strojne opreme za dostop do "
+"kode in podatkov rezidenčnega BIOS-a."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:625
+msgid ""
+"The UEFI system can set up memory attributes at boot which prevent common "
+"exploits from running."
+msgstr ""
+"Sistem UEFI lahko nastavi atribute pomnilnika ob zagonu, ki preprečujejo "
+"pogosta vsiljena izvajanja pred izvršitvijo."
+
+#. TRANSLATORS: longer description
+#: src/fu-security-attr-common.c:630
+msgid ""
+"The UEFI db contains the list of valid certificates that can be used to "
+"authorize what EFI binaries are allowed to run."
+msgstr ""
+"Zbirka podatkov UEFI vsebuje seznam veljavnih potrdil, ki jih lahko "
+"uporabite za overjanje, katere izvršne datoteke EFI je dovoljeno izvajati."
+
+#. TRANSLATORS: %s is a link to a website
+#: src/fu-tool.c:143 src/fu-util.c:4722
+#, c-format
+msgid "See %s for more information."
+msgstr "Za več podrobnosti glejte %s."
+
+#. TRANSLATORS: another fwupdtool instance is already running
+#: src/fu-tool.c:228
+msgid "Failed to lock"
+msgstr "Zaklepanje je spodletelo"
+
+#. TRANSLATORS: this is when a device ctrl+c's a watch
+#. TRANSLATORS: this is from ctrl+c
+#: src/fu-tool.c:287 src/fu-util.c:5060
+msgid "Cancelled"
+msgstr "Preklicano"
+
+#. TRANSLATORS: the user needs to do something, e.g. remove the device
+#: src/fu-tool.c:385 src/fu-util.c:102
+msgid "Action Required:"
+msgstr "Potrebni je ukrepanje:"
+
+#. TRANSLATORS: device has been chosen by the daemon for the user
+#: src/fu-tool.c:559 src/fu-util.c:187
+msgid "Selected device"
+msgstr "Izbrana naprava"
+
+#. TRANSLATORS: this is to abort the interactive prompt
+#: src/fu-tool.c:575 src/fu-tool.c:2937 src/fu-tool.c:3937 src/fu-tool.c:4195
+#: src/fu-util.c:203 src/fu-util.c:2480 src/fu-util.c:3623
+msgid "Cancel"
+msgstr "Prekliči"
+
+#. TRANSLATORS: get interactive prompt
+#: src/fu-tool.c:586 src/fu-util.c:213
+msgid "Choose device"
+msgstr "Izberite napravo"
 
 #. TRANSLATORS: message letting the user know no device
 #. * upgrade available due to missing on LVFS
@@ -977,6 +1534,7 @@ msgstr "Naprave s posodobitvami vdelane programske opreme, ki zahtevajo ukrepanj
 #. * upgrade available due to missing on LVFS
 #. TRANSLATORS: message letting the user know no
 #. * device upgrade available due to missing on LVFS
+#: src/fu-tool.c:755 src/fu-tool.c:1757 src/fu-util.c:2723 src/fu-util.c:3207
 msgid "Devices with no available firmware updates: "
 msgstr "Naprave brez razpoložljivih posodobitev vdelane programske opreme: "
 
@@ -986,1841 +1544,1079 @@ msgstr "Naprave brez razpoložljivih posodobitev vdelane programske opreme: "
 #. TRANSLATORS: message letting the user know no device upgrade available
 #. TRANSLATORS: message letting the user know no device
 #. * upgrade available
+#: src/fu-tool.c:765 src/fu-tool.c:1747 src/fu-util.c:2733 src/fu-util.c:3197
 msgid "Devices with the latest available firmware version:"
-msgstr "Naprave z najnovejšo različico vdelane programske opreme, ki je na voljo:"
+msgstr ""
+"Naprave z najnovejšo različico vdelane programske opreme, ki je na voljo:"
 
-#. TRANSLATORS: this is for the device tests
-msgid "Did not find any devices with matching GUIDs"
-msgstr "Ni najdenih naprav z ujemajočimi se GUID-ji"
+#: src/fu-tool.c:777
+msgid "No updates available for remaining devices"
+msgstr "Za preostale naprave ni na voljo nobenih posodobitev"
 
-#. TRANSLATORS: Plugin is inactive and not used
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Disabled"
-msgstr "Onemogočeno"
-
-#. TRANSLATORS: command description
-msgid "Disables a given remote"
-msgstr "Onemogoči dani oddaljeni strežnik"
-
-#. TRANSLATORS: command description
-msgid "Disables virtual testing devices"
-msgstr "Onemogoči navidezne preizkusne naprave"
-
-#. TRANSLATORS: the OS the release was tested on
-msgid "Distribution"
-msgstr "Distribucija"
-
-#. TRANSLATORS: command line option
-msgid "Do not check for old metadata"
-msgstr "Ne preverjaj, ali so na voljo stari metapodatki"
-
-#. TRANSLATORS: command line option
-msgid "Do not check for unreported history"
-msgstr "Ne preverjaj, ali je na voljo neprijavljena zgodovina"
-
-#. TRANSLATORS: command line option
-msgid "Do not check if download remotes should be enabled"
-msgstr "Ne preverjaj, ali naj bodo omogočeni oddaljeni strežniki za prenos"
-
-#. TRANSLATORS: command line option
-msgid "Do not check or prompt for reboot after update"
-msgstr "Po posodobitvi ne preverjaj in ne pozivaj k vnovičnemu zagonu"
-
-#. TRANSLATORS: turn on all debugging
-msgid "Do not include log domain prefix"
-msgstr "Ne vključi predpone domene dnevnika"
-
-#. TRANSLATORS: turn on all debugging
-msgid "Do not include timestamp prefix"
-msgstr "Ne vključi predpone časovnega žiga"
-
-#. TRANSLATORS: command line option
-msgid "Do not perform device safety checks"
-msgstr "Ne izvajaj varnostnih preverjanj naprav"
-
-#. TRANSLATORS: command line option
-msgid "Do not prompt for devices"
-msgstr "Ne povprašuj po napravah"
-
-#. TRANSLATORS: command line option
-msgid "Do not prompt to fix security issues"
-msgstr "Ne pozivaj k odpravljanju varnostnih težav"
-
-#. TRANSLATORS: command line option
-msgid "Do not search the firmware when parsing"
-msgstr "Med razčlenjevanjem ne išči vdelane programske opreme"
-
-#. TRANSLATORS: warning message shown after update has been scheduled
-msgid "Do not turn off your computer or remove the AC adaptor while the update is in progress."
-msgstr "Med posodabljanjem ne izklapljajte računalnika in ne odstranjujte napajalnika."
-
-#. TRANSLATORS: command line option
-msgid "Do not write to the history database"
-msgstr "Ne piši v zbirko podatkov zgodovine"
-
-#. TRANSLATORS: should the branch be changed
-msgid "Do you understand the consequences of changing the firmware branch?"
-msgstr "Ali razumete posledice spremembe veje vdelane programske opreme?"
-
-#. TRANSLATORS: ask the user if it's okay to convert,
-#. * "it" being the data contained in the EFI boot entry
-msgid "Do you want to convert it now?"
-msgstr "Ali ga želite zdaj pretvoriti?"
-
-#. TRANSLATORS: offer to disable this nag
-msgid "Do you want to disable this feature for future updates?"
-msgstr "Ali želite onemogočiti to funkcijo za prihodnje posodobitve?"
-
-#. TRANSLATORS: ask if we can update the metadata
-msgid "Do you want to refresh this remote now?"
-msgstr "Ali želite zdaj osvežiti ta oddaljeni strežnik?"
-
-#. TRANSLATORS: offer to stop asking the question
-msgid "Do you want to upload reports automatically for future updates?"
-msgstr "Ali želite samodejno naložiti poročila za prihodnje posodobitve?"
-
-#. TRANSLATORS: command line option
-msgid "Don't prompt for authentication (less details may be shown)"
-msgstr "Ne pozivaj k preverjanju pristnosti (morda bo prikazanih manj podrobnosti)"
-
-#. TRANSLATORS: success
-msgid "Done!"
-msgstr "Opravljeno!"
-
-#. TRANSLATORS: message letting the user know an downgrade is available
-#. * %1 is the device name and %2 and %3 are version strings
-#, c-format
-msgid "Downgrade %s from %s to %s?"
-msgstr "Želite povrniti %s s %s na starejšo %s?"
-
-#. TRANSLATORS: command description
-msgid "Downgrades the firmware on a device"
-msgstr "Zamenja vdelano programsko opremo naprave s starejšo različico"
+#. TRANSLATORS: nothing attached that can be upgraded
+#: src/fu-tool.c:964 src/fu-util.c:611
+msgid "No hardware detected with firmware update capability"
+msgstr ""
+"Zaznana ni nobena strojna oprema z možnostjo posodobitve vdelane programske "
+"opreme"
 
 #. TRANSLATORS: %1 is a device name
+#: src/fu-tool.c:1003 src/fu-util.c:148
 #, c-format
-msgid "Downgrading %s…"
-msgstr "Povrnitev na starejšo različico %s ..."
-
-#. TRANSLATORS: command description
-msgid "Download a file"
-msgstr "Prejmite datoteko"
-
-#. TRANSLATORS: downloading from a remote server
-msgid "Downloading…"
-msgstr "Poteka prejemanje …"
-
-#. TRANSLATORS: command description
-msgid "Dump SMBIOS data from a file"
-msgstr "Odloži podatke SMBIOS-a iz datoteke"
-
-#. TRANSLATORS: length of time the update takes to apply
-msgid "Duration"
-msgstr "Trajanje"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "EMULATION-FILE [ARCHIVE-FILE]"
-msgstr "DATOTEKA-EMULACIJE [ARHIVSKA-DATOTEKA]"
-
-#. TRANSLATORS: longer description
-msgid "Each system should have tests to ensure firmware security."
-msgstr "Vsak sistem mora imeti preizkuse za zagotovitev varnosti vdelane programske opreme."
-
-#. TRANSLATORS: command description
-msgid "Emulate a device using a JSON manifest"
-msgstr "Posnemajte napravo z manifestom JSON"
-
-#. TRANSLATORS: this device is not actually real
-msgid "Emulated"
-msgstr "Emulirani"
-
-#. TRANSLATORS: Title: if we are emulating a different host
-msgid "Emulated host"
-msgstr "Emulirani gostitelj"
-
-msgid "Enable"
-msgstr "Omogoči"
-
-msgid "Enable emulation data collection"
-msgstr "Omogoči zbiranje podatkov emulacije"
-
-#. TRANSLATORS: a remote here is like a 'repo' or software source
-msgid "Enable new remote?"
-msgstr "Želite omogočiti nov oddaljeni strežnik?"
-
-#. TRANSLATORS: Turn on the remote
-msgid "Enable this remote?"
-msgstr "Želite omogočiti ta oddaljeni strežnik?"
-
-#. TRANSLATORS: if the remote is enabled
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Enabled"
-msgstr "Omogočeno"
-
-#. TRANSLATORS: Plugin is active only if hardware is found
-msgid "Enabled if hardware matches"
-msgstr "Omogočeno, če se strojna oprema ujema"
-
-#. TRANSLATORS: command description
-msgid "Enables a given remote"
-msgstr "Omogoči dani oddaljeni strežnik"
-
-#. TRANSLATORS: command description
-msgid "Enables virtual testing devices"
-msgstr "Omogoči navidezne preizkusne naprave"
-
-#. TRANSLATORS: longer description
-msgid "Enabling firmware updates for the BIOS allows fixing security issues."
-msgstr "Če omogočite posodobitve vdelane programske opreme za BIOS, lahko odpravite varnostne težave."
-
-msgid "Enabling this functionality is done at your own risk, which means you have to contact your original equipment manufacturer regarding any problems caused by these updates. Only problems with the update process itself should be filed at $OS_RELEASE:BUG_REPORT_URL$."
-msgstr "To funkcijo omogočite na lastno odgovornost, kar pomeni, da se morate glede morebitnih težav, ki jih povzročijo te posodobitve, obrniti na proizvajalca originalne opreme. Samo težave s samim postopkom posodabljanja je treba vložiti na $OS_RELEASE:BUG_REPORT_URL$."
-
-#. TRANSLATORS: show the user a warning
-msgid "Enabling this remote is done at your own risk."
-msgstr "Ta oddaljeni strežnik omogočite na lastno odgovornost."
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Encrypted"
-msgstr "Šifrirano"
-
-#. TRANSLATORS: Title: Memory contents are encrypted, e.g. Intel TME
-msgid "Encrypted RAM"
-msgstr "Šifrirani RAM"
-
-msgid "Encrypted RAM makes it impossible for information that is stored in device memory to be read if the memory chip is removed and accessed."
-msgstr "Šifrirani RAM onemogoča branje informacij, ki so shranjene v pomnilniku naprave, če je pomnilniški čip odstranjen in je dostopano do njega."
-
-#. TRANSLATORS: the vendor is no longer supporting the device
-msgid "End of life"
-msgstr "Konec življenjske dobe"
-
-#. TRANSLATORS: The BIOS setting can only be changed to fixed values
-msgid "Enumeration"
-msgstr "Številčenje"
-
-#. TRANSLATORS: command description
-msgid "Erase all firmware update history"
-msgstr "Izbriši vso zgodovino posodobitev vdelane programske opreme"
-
-#. TRANSLATORS: erasing contents of the flash chips
-msgid "Erasing…"
-msgstr "Poteka brisanje..."
-
-#. TRANSLATORS: exit after we've started up, used for user profiling
-msgid "Exit after a small delay"
-msgstr "Končaj po kratki zakasnitvi"
-
-#. TRANSLATORS: exit straight away, used for automatic profiling
-msgid "Exit after the engine has loaded"
-msgstr "Končaj, ko se programnik naloži"
-
-#. TRANSLATORS: command description
-msgid "Export a firmware file structure to XML"
-msgstr "Izvozi strukturo datoteke vdelane programske opreme v XML"
-
-#. TRANSLATORS: command description
-msgid "Export firmware history for manual upload"
-msgstr "Izvozi zgodovino vdelane programske opreme za ročni prenos"
-
-#. TRANSLATORS: command description
-msgid "Extract a firmware blob to images"
-msgstr "Izvlecite zbirko podatkov vdelane programske opreme v slike"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILE"
-msgstr "DATOTEKA"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILE [DEVICE-ID|GUID]"
-msgstr "DATOTEKA [ID-NAPRAVE|GUID]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME"
-msgstr "IMEDATOTEKE"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME CERTIFICATE PRIVATE-KEY"
-msgstr "IME-DATOTEKE POTRDILO OSEBNI-KLJUČ"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME DEVICE-ID"
-msgstr "IMEDATOTEKE ID-NAPRAVE"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME OFFSET DATA [FIRMWARE-TYPE]"
-msgstr "IME-DATOTEKE ODMIK PODATKI [VRSTA-VDELANE-PROGRAMSKE-OPREME]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME [DEVICE-ID|GUID]"
-msgstr "IME-DATOTEKE [ID-NAPRAVE|GUID]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME [FIRMWARE-TYPE]"
-msgstr "IME-DATOTEKE [VRSTA-VDELANE-PROGRAMSKE-OPREME]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME-SRC FILENAME-DST [FIRMWARE-TYPE-SRC] [FIRMWARE-TYPE-DST]"
-msgstr "IMEDATOTEKE-SRC IMEDATOTEKE-DST [FIRMWARE-VRSTA-SRC] [FIRMWARE-VRSTA-DST]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "FILENAME|CHECKSUM1[,CHECKSUM2][,CHECKSUM3]"
-msgstr "IMEDATOTEKE|KONTR-VSOTA1[,KONTR-VSOTA2][,KONTR-VSOTA3]"
-
-#. TRANSLATORS: the update state of the specific device
-msgid "Failed"
-msgstr "Napaka"
-
-#. TRANSLATORS: dbx file failed to be applied as an update
-msgid "Failed to apply update"
-msgstr "Posodobitve ni bilo mogoče uveljaviti"
-
-#. TRANSLATORS: error message for Windows
-msgid "Failed to connect to Windows service, please ensure it's running."
-msgstr "Povezave s storitvijo Windows ni možno vzpostaviti, prepričajte se, da se izvaja."
-
-#. TRANSLATORS: could not contact the fwupd service over D-Bus
-msgid "Failed to connect to daemon"
-msgstr "Povezave s prikritim procesom ni bilo mogoče vzpostaviti"
-
-#. TRANSLATORS: could not read existing system data
-#. TRANSLATORS: could not read file
-msgid "Failed to load local dbx"
-msgstr "Ni bilo mogoče naložiti krajevnega dbx"
-
-#. TRANSLATORS: could not read existing system data
-msgid "Failed to load system dbx"
-msgstr "Sistemskega dbx ni bilo mogoče naložiti"
-
-#. TRANSLATORS: another fwupdtool instance is already running
-msgid "Failed to lock"
-msgstr "Zaklepanje je spodletelo"
-
-#. TRANSLATORS: the user didn't read the man page
-msgid "Failed to parse arguments"
-msgstr "Argumentov ni bilo mogoče razčleniti"
-
-#. TRANSLATORS: failed to read measurements file
-msgid "Failed to parse file"
-msgstr "Razčlenjevanje datoteke je spodletelo"
-
-#. TRANSLATORS: the user didn't read the man page, %1 is '--filter'
-#. TRANSLATORS: the user didn't read the man page,
-#. * %1 is '--filter-release'
-#. TRANSLATORS: the user didn't read the man page, %1 is '--filter'
-#. TRANSLATORS: the user didn't read the man page,
-#. * %1 is '--filter-release'
-#, c-format
-msgid "Failed to parse flags for %s"
-msgstr "Zastavic za %s ni bilo mogoče razčleniti"
-
-#. TRANSLATORS: could not parse file
-msgid "Failed to parse local dbx"
-msgstr "Razčlenitev krajevnega dbx ni uspela"
-
-#. TRANSLATORS: a feature is something like "can show an image"
-msgid "Failed to set front-end features"
-msgstr "Nastavljanje funkcij pročelja ni uspelo"
-
-#. TRANSLATORS: something with a blocked hash exists
-#. * in the users ESP -- which would be bad!
-msgid "Failed to validate ESP contents"
-msgstr "Preverjanje vsebine ESP ni uspelo"
-
-#. TRANSLATORS: item is FALSE
-msgid "False"
-msgstr "napak"
-
-#. TRANSLATORS: filename of the local file
-msgid "Filename"
-msgstr "Ime datoteke"
-
-#. TRANSLATORS: filename of the local file
-msgid "Filename Signature"
-msgstr "Podpis imena datoteke"
-
-#. TRANSLATORS: full path of the remote.conf file
-msgid "Filename Source"
-msgstr "Vir imena datoteke"
-
-#. TRANSLATORS: user did not include a filename parameter
-msgid "Filename required"
-msgstr "Zahtevano je ime datoteke"
-
-#. TRANSLATORS: command line option
-msgid "Filter with a set of device flags using a ~ prefix to exclude, e.g. 'internal,~needs-reboot'"
-msgstr "Filtriraj z nizom zastavic naprave s predpono ~, da izključite, npr. \"notranji,~potreben-ponovni zagon\" oz. 'internal,~needs-reboot'"
-
-#. TRANSLATORS: command line option
-msgid "Filter with a set of release flags using a ~ prefix to exclude, e.g. 'trusted-release,~trusted-metadata'"
-msgstr "Filtriraj z naborom zastavic za izdajo s predpono ~, da se izključijo npr. »zaupanja-vredna-izdaja,~zaupanja-vredni-metapodatki« oz.  'trusted-release,~trusted-metadata'"
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-msgid "Firmware Attestation"
-msgstr "Atest strojne programske opreme"
-
-#. TRANSLATORS: longer description
-msgid "Firmware Attestation checks device software using a reference copy, to make sure that it has not been changed."
-msgstr "Potrdilo o vdelani programski opremi preveri programsko opremo naprave z referenčno kopijo in se prepriča, da ni bila spremenjena."
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-msgid "Firmware BIOS Descriptor"
-msgstr "Opisnik SPI BIOS-a vdelane programske opreme"
-
-#. TRANSLATORS: longer description
-msgid "Firmware BIOS Descriptor protects device firmware memory from being tampered with."
-msgstr "Deskriptor vdelane programske opreme BIOS-a ščiti pomnilnik vdelane programske opreme naprave pred nedovoljenimi posegi."
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-msgid "Firmware BIOS Region"
-msgstr "Področje BIOS-a vdelane programske opreme"
-
-#. TRANSLATORS: longer description
-msgid "Firmware BIOS Region protects device firmware memory from being tampered with."
-msgstr "Firmware BIOS Region ščiti pomnilnik vdelane programske opreme naprave pred nedovoljenimi posegi."
-
-#. TRANSLATORS: remote URI
-msgid "Firmware Base URI"
-msgstr "Osnovni URI vdelane programske opreme"
-
-#. TRANSLATORS: program summary
-msgid "Firmware Update D-Bus Service"
-msgstr "Storitev D-Bus posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: program name
-msgid "Firmware Update Daemon"
-msgstr "Prikriti proces posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-msgid "Firmware Updater Verification"
-msgstr "Preverjanje orodja za posodabljanje vdelane programske opreme"
-
-msgid "Firmware Updater Verification checks that software used for updating has not been tampered with."
-msgstr "Preverjanje orodja za posodabljanje vdelane programske opreme preveri, ali programska oprema, uporabljena za posodabljanje, ni bila spremenjena."
-
-#. TRANSLATORS: Title: if firmware updates are available
-msgid "Firmware Updates"
-msgstr "Posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: program name
-msgid "Firmware Utility"
-msgstr "Pripomoček za vdelano programsko opremo"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-msgid "Firmware Write Protection"
-msgstr "Zaščita pred pisanjem vdelane programske opreme"
-
-#. TRANSLATORS: Title: firmware refers to the flash chip in the computer
-msgid "Firmware Write Protection Lock"
-msgstr "Zaščitni zaklep pred pisanjem vdelane programske opreme"
-
-#. TRANSLATORS: longer description
-msgid "Firmware Write Protection protects device firmware memory from being tampered with."
-msgstr "Zaščita pred zapisovanjem vdelane programske opreme ščiti pomnilnik vdelane programske opreme naprave pred nedovoljenimi posegi."
-
-#. TRANSLATORS: Title: if we can verify the firmware checksums
-msgid "Firmware attestation"
-msgstr "Atest strojne programske opreme"
-
-#. TRANSLATORS: user selected something not possible
-msgid "Firmware is already blocked"
-msgstr "Vdelana programska oprema je že blokirana"
-
-#. TRANSLATORS: user selected something not possible
-msgid "Firmware is not already blocked"
-msgstr "Vdelana programska oprema še ni blokirana"
-
-#. TRANSLATORS: the metadata is very out of date; %u is a number > 1
-#, c-format
-msgid "Firmware metadata has not been updated for %u day and may not be up to date."
-msgid_plural "Firmware metadata has not been updated for %u days and may not be up to date."
-msgstr[0] "Metapodatki vdelane programske oprem niso bili posodobljeni %u dan in morda niso aktualni."
-msgstr[1] "Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda niso aktualni."
-msgstr[2] "Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda niso aktualni."
-msgstr[3] "Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda niso aktualni."
-
-#. TRANSLATORS: Title: if firmware updates are available
-msgid "Firmware updates"
-msgstr "Posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: user needs to run a command, %1 is 'fwupdmgr unlock'
-#, c-format
-msgid "Firmware updates disabled; run '%s' to enable"
-msgstr "Posodobitve vdelane programske opreme so onemogočene; zaženite »%s«, da jih omogočite"
-
-#. TRANSLATORS: command description
-msgid "Fix a specific host security attribute"
-msgstr "Popravi določen varnostni atribut gostitelja"
-
-#. TRANSLATORS: we've fixed a security problem on the machine
-msgid "Fix reverted successfully"
-msgstr "Popravek je bil uspešno povrnjen"
-
-#. TRANSLATORS: we've fixed a security problem on the machine
-msgid "Fixed successfully"
-msgstr "Uspešno popravljeno"
-
-#. TRANSLATORS: description of plugin state, e.g. disabled
-msgid "Flags"
-msgstr "Zastavice"
-
-#. TRANSLATORS: command line option
-msgid "Force the action by relaxing some runtime checks"
-msgstr "Vsilite dejanje s sprostitvijo nekaterih preverjanj med izvajanjem"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Found"
-msgstr "Najdeno"
-
-#. TRANSLATORS: title text, shown as a warning
-msgid "Full Disk Encryption Detected"
-msgstr "Zaznano je popolno šifriranje diska"
-
-#. TRANSLATORS: we might ask the user the recovery key when next booting
-#. Windows
-msgid "Full disk encryption secrets may be invalidated when updating"
-msgstr "Skrivnosti polnega šifriranja diska se lahko pri posodabljanju razveljavijo"
-
-#. TRANSLATORS: Title: if the part has been fused
-msgid "Fused Platform"
-msgstr "Spojena platforma"
-
-#. TRANSLATORS: Title: if the part has been fused
-msgid "Fused platform"
-msgstr "Spojena platforma"
-
-#. TRANSLATORS: global ID common to all similar hardware
-msgid "GUID"
-msgid_plural "GUIDs"
-msgstr[0] "GUID-ji"
-msgstr[1] "GUID"
-msgstr[2] "GUID-ja"
-msgstr[3] "GUID-ji"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgctxt "command-argument"
-msgid "GUID"
-msgstr "GUID"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "GUID|DEVICE-ID"
-msgstr "GUID|ID-NAPRAVE"
-
-msgid "Get BIOS settings"
-msgstr "Pridobi nastavitve BIOS-a"
-
-#. TRANSLATORS: command description
-msgid "Get all device flags supported by fwupd"
-msgstr "Pridobi vse zastavice naprav, ki jih podpira fwupd"
-
-#. TRANSLATORS: command description
-msgid "Get all devices that support firmware updates"
-msgstr "Pridobi vse naprave, ki podpirajo posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Get all enabled plugins registered with the system"
-msgstr "Pridobi vse omogočene vstavke, registrirane v sistemu"
-
-#. TRANSLATORS: command description
-msgid "Get all known version formats"
-msgstr "Pridobi vse znane oblike različic"
-
-#. TRANSLATORS: command description
-msgid "Get device report metadata"
-msgstr "Pridobi metapodatke poročila o napravi"
-
-#. TRANSLATORS: command description
-msgid "Gets details about a firmware file"
-msgstr "Pridobi podrobnosti o datoteki strojne programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Gets the configured remotes"
-msgstr "Pridobi nastavljene oddaljene strežnike"
-
-#. TRANSLATORS: command description
-msgid "Gets the host security attributes"
-msgstr "Pridobi varnostne atribute gostitelja"
-
-#. TRANSLATORS: firmware approved by the admin
-msgid "Gets the list of approved firmware"
-msgstr "Pridobi seznam odobrene vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Gets the list of blocked firmware"
-msgstr "Pridobi seznam blokirane vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Gets the list of updates for all specified devices, or all devices if unspecified"
-msgstr "Pridobi seznam posodobitev za vse navedene naprave ali za vse naprave, če nobena ni izrecno navedena"
-
-#. TRANSLATORS: command description
-msgid "Gets the releases for a device"
-msgstr "Pridobi izdaje za napravo"
-
-#. TRANSLATORS: command description
-msgid "Gets the results from the last update"
-msgstr "Pridobi rezultate zadnje posodobitve"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "HWIDS-FILE"
-msgstr "DATOTEKA-HWIDS"
-
-#. TRANSLATORS: the hardware is waiting to be replugged
-msgid "Hardware is waiting to be replugged"
-msgstr "Strojna oprema čaka na ponovno priključitev"
-
-#. TRANSLATORS: the release urgency
-msgid "High"
-msgstr "Visoko"
-
-#. TRANSLATORS: title for host security events
-msgid "Host Security Events"
-msgstr "Dogodki varnosti gostitelja"
-
-#. TRANSLATORS: error message for unsupported feature
-#, c-format
-msgid "Host Security ID (HSI) is not supported"
-msgstr "Varnostni ID gostitelja (HSI) ni podprt"
-
-#. TRANSLATORS: success, so say thank you to the user
-msgid "Host Security ID attributes uploaded successfully, thanks!"
-msgstr "Atributi varnostnega ID-ja gostitelja so bili uspešno naloženi, hvala!"
-
-#. TRANSLATORS: this is a string like 'HSI:2-U'
-msgid "Host Security ID:"
-msgstr "Varnostni ID gostitelja:"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "INDEX"
-msgstr "INDEKS"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "INDEX KEY [VALUE]"
-msgstr "INDEKS KLJUČ [VREDNOST]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "INDEX NAME TARGET [MOUNTPOINT]"
-msgstr "INDEKS IME CILJ  [TOČKAPRIKLOPA]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "INDEX1,INDEX2"
-msgstr "INDEKS1,INDEKS2"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "INHIBIT-ID"
-msgstr "ID-PREPREČI"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-msgid "IOMMU"
-msgstr "IOMMU"
-
-#. TRANSLATORS: Title:
-#. * https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit
-msgid "IOMMU Protection"
-msgstr "Zaščita IOMMU"
-
-#. TRANSLATORS: longer description
-msgid "IOMMU Protection prevents connected devices from accessing unauthorized parts of system memory."
-msgstr "Zaščita IOMMU povezanim napravam preprečuje dostop do nepooblaščenih delov sistemskega pomnilnika."
-
-#. TRANSLATORS: HSI event title
-msgid "IOMMU device protection disabled"
-msgstr "Zaščita naprav IOMMU je onemogočena"
-
-#. TRANSLATORS: HSI event title
-msgid "IOMMU device protection enabled"
-msgstr "Omogočena je zaščita naprav IOMMU"
-
-#. TRANSLATORS: daemon is inactive
-msgid "Idle…"
-msgstr "Nedejavno …"
-
-#. TRANSLATORS: command line option
-msgid "Ignore SSL strict checks when downloading files"
-msgstr "Prezri stroga preverjanja SSL pri prenosu datotek"
-
-#. TRANSLATORS: command line option
-msgid "Ignore firmware checksum failures"
-msgstr "Prezri napake kontrolne vsote vdelane programske opreme"
-
-#. TRANSLATORS: command line option
-msgid "Ignore firmware hardware mismatch failures"
-msgstr "Prezri napake pri neujemanju strojne opreme"
-
-#. TRANSLATORS: command line option
-msgid "Ignore non-critical firmware requirements"
-msgstr "Prezri ne kritične zahteve vdelane programske opreme"
-
-#. TRANSLATORS: try to help
-msgid "Ignoring SSL strict checks, to do this automatically in the future export DISABLE_SSL_STRICT in your environment"
-msgstr "Ignoriranje strogih preverjanj SSL, da to storite samodejno v prihodnjih izvoznih DISABLE_SSL_STRICT v svojem okolju"
-
-#. TRANSLATORS: show the user a generic image that can be themed
-msgid "Image"
-msgstr "Slika"
-
-#. TRANSLATORS: show the user a random image from the internet
-msgid "Image (custom)"
-msgstr "Slika (po meri)"
-
-#. TRANSLATORS: the inhibit ID is a short string like dbus-123456
-#, c-format
-msgid "Inhibit ID is %s."
-msgstr "ID preprečitve je %s."
-
-#. TRANSLATORS: command description
-msgid "Inhibit the system to prevent upgrades"
-msgstr "Nastavite sistem, da prepreči nadgradnje"
-
-#. TRANSLATORS: length of time the update takes to apply
-msgid "Install Duration"
-msgstr "Trajanje namestitve"
-
-#. TRANSLATORS: command description
-msgid "Install a firmware file in cabinet format on this hardware"
-msgstr "Na to strojno opremo namesti datoteko vdelane programske opreme v obliki paketa"
-
-#. TRANSLATORS: command description
-msgid "Install a raw firmware blob on a device"
-msgstr "Namestite neobdelano dvojiško zbirko podatkov vdelane programske opreme v napravo"
-
-#. TRANSLATORS: command description
-msgid "Install a specific firmware file on all devices that match"
-msgstr "Namesti določeno datoteko vdelane programske opreme v vse naprave, ki se ujemajo"
-
-#. TRANSLATORS: command description
-msgid "Install a specific firmware on a device, all possible devices will also be installed once the CAB matches"
-msgstr "Namestite določeno vdelano programsko opremo na napravo, vse možne naprave bodo prav tako nameščene, če se CAB ujema"
-
-msgid "Install old version of signed system firmware"
-msgstr "Namesti staro različico podpisane sistemske strojne programske opreme"
-
-msgid "Install old version of unsigned system firmware"
-msgstr "Namesti staro različico nepodpisane sistemske strojne programske opreme"
-
-msgid "Install signed device firmware"
-msgstr "Namesti podpisano strojno programsko opremo naprave"
-
-msgid "Install signed system firmware"
-msgstr "Namesti podpisano sistemsko strojno programsko opremo"
-
-msgid "Install unsigned device firmware"
-msgstr "Namesti nepodpisano strojno programsko opremo naprave"
-
-msgid "Install unsigned system firmware"
-msgstr "Namesti nepodpisano sistemsko strojno programsko opremo"
-
-#. TRANSLATORS: stay on one firmware version unless the new version is
-#. explicitly
-#. * specified
-msgid "Installing a specific release is explicitly required"
-msgstr "Namestitev določene izdaje je izrecno zahtevana"
-
-#. TRANSLATORS: this is shown when updating the firmware after the reboot
-msgid "Installing firmware update…"
-msgstr "Nameščanje posodobitve strojne programske opreme ..."
+msgid "Updating %s…"
+msgstr "Posodabljanje %s ..."
 
 #. TRANSLATORS: %1 is a device name
+#: src/fu-tool.c:1007 src/fu-util.c:156
 #, c-format
 msgid "Installing on %s…"
 msgstr "Nameščanje na %s ..."
 
-#. TRANSLATORS: if it breaks, you get to keep both pieces
-msgid "Installing this update may also void any device warranty."
-msgstr "Namestitev te posodobitve lahko razveljavi tudi garancijo naprave."
-
-#. TRANSLATORS: The BIOS setting only accepts integers in a fixed range
-msgid "Integer"
-msgstr "integer"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-msgid "Intel BootGuard"
-msgstr "Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-msgid "Intel BootGuard ACM Protected"
-msgstr "Zaščiteno z Intel BootGuard ACM"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * ACM means to verify the integrity of Initial Boot Block
-msgid "Intel BootGuard ACM protected"
-msgstr "Zaščiteno z Intel BootGuard ACM"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-msgid "Intel BootGuard Error Policy"
-msgstr "Pravilnik o napakah Intel BootGuard"
-
-msgid "Intel BootGuard Error Policy ensures the device does not continue to start if its device software has been tampered with."
-msgstr "Pravilnik o napakah Intel BootGuard zagotavlja, da se naprava ne zažene naprej, če je bila spremenjena programska oprema naprave."
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel
-msgid "Intel BootGuard Fuse"
-msgstr "Varovalka Intel Boot Guard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * OTP = one time programmable
-msgid "Intel BootGuard OTP fuse"
-msgstr "Varovalka Intel BootGuard OTP"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-msgid "Intel BootGuard Verified Boot"
-msgstr "Preverjeni zagon Intel BootGuard"
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * error policy is what to do on failure
-msgid "Intel BootGuard error policy"
-msgstr "Pravilnik o napakah Intel BootGuard"
-
-#. TRANSLATORS: longer description
-msgid "Intel BootGuard prevents unauthorized device software from operating when the device is started."
-msgstr "Intel BootGuard prepreči delovanje nepooblaščene programske opreme naprave ob zagonu naprave."
-
-#. TRANSLATORS: Title: BootGuard is a trademark from Intel,
-#. * verified boot refers to the way the boot process is verified
-msgid "Intel BootGuard verified boot"
-msgstr "Preverjen zagon Intel BootGuard"
-
-#. TRANSLATORS: Title: GDS is where the CPU leaks information
-msgid "Intel GDS Mitigation"
-msgstr "Blaženje posledic Intel GDS"
-
-#. TRANSLATORS: Title: GDS is where the CPU leaks information
-msgid "Intel GDS mitigation"
-msgstr "Blaženje posledic Intel GDS"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-msgid "Intel Management Engine Manufacturing Mode"
-msgstr "Način izdelave mehanizma Intel Management Engine"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the "override" is
-#. enabled
-#. * with a jumper -- luckily it is probably not accessible to end users on
-#. consumer
-#. * boards
-msgid "Intel Management Engine Override"
-msgstr "Preglasitev mehanizma Intel Management Engine"
-
-#. TRANSLATORS: longer description
-msgid "Intel Management Engine Override disables checks for device software tampering."
-msgstr "Intel Management Engine Override onemogoči preverjanja nedovoljenih posegov v programsko opremo naprave."
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-msgid "Intel Management Engine Version"
-msgstr "Različica orodja Intel Management Engine"
-
-#. TRANSLATORS: Device cannot be removed easily
-msgid "Internal device"
-msgstr "Notranja naprava"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Invalid"
-msgstr "Neveljavno"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments"
-msgstr "Neveljavni argumenti"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments, expected GUID"
-msgstr "Neveljavni argumenti, pričakovan GUID"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments, expected INDEX KEY [VALUE]"
-msgstr "Neveljavni argumenti, pričakovano je INDEKS KLJUČ [VREDNOST]"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments, expected INDEX NAME TARGET [MOUNTPOINT]"
-msgstr "Neveljavni argumenti, pričakovano je INDEKS IME CILJ [TOČKAPRIKLOPA]"
-
-#. TRANSLATOR: This is the error message for
-#. * incorrect parameter
-msgid "Invalid arguments, expected an AppStream ID"
-msgstr "Neveljavni argumenti, pričakovan je ID AppStream"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments, expected at least ARCHIVE FIRMWARE METAINFO"
-msgstr "Neveljavni argumenti, pričakovani vsaj ARHIV VDELANAPROGRAMSKAOPREMA METAPODATKI"
-
-#. TRANSLATORS: error message
-msgid "Invalid arguments, expected base-16 integer"
-msgstr "Neveljavni argumenti, pričakovano je celo število base-16"
-
-#. TRANSLATORS: version is older
-msgid "Is downgrade"
-msgstr "Je povrnitev na starejšo različico"
-
-#. TRANSLATORS: Is currently in bootloader mode
-msgid "Is in bootloader mode"
-msgstr "Je v načinu zagonskega nalagalnika"
-
-#. TRANSLATORS: version is newer
-msgid "Is upgrade"
-msgstr "Je nadgradnja"
-
-#. TRANSLATORS: issue fixed with the release, e.g. CVE
-msgid "Issue"
-msgid_plural "Issues"
-msgstr[0] "Težave"
-msgstr[1] "Težava"
-msgstr[2] "Težavi"
-msgstr[3] "Težave"
-
-#. TRANSLATORS: HSI event title
-msgid "Kernel is no longer tainted"
-msgstr "Jedro ni več okuženo"
-
-#. TRANSLATORS: HSI event title
-msgid "Kernel is tainted"
-msgstr "Jedro je okuženo"
-
-#. TRANSLATORS: HSI event title
-msgid "Kernel lockdown disabled"
-msgstr "Zaklepanje jedra je onemogočeno"
-
-#. TRANSLATORS: HSI event title
-msgid "Kernel lockdown enabled"
-msgstr "Omogočeno zaklepanje jedra"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "LOCATION"
-msgstr "MESTO"
-
-#. TRANSLATORS: the original time/date the device was modified
-msgid "Last modified"
-msgstr "Nazadnje spremenjeno"
-
-#. TRANSLATORS: time remaining for completing firmware flash
-msgid "Less than one minute remaining"
-msgstr "Preostalo je manj kot eno minuto"
-
-#. TRANSLATORS: e.g. GPLv2+, Proprietary etc
-msgid "License"
-msgstr "Dovoljenje"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-msgid "Linux Kernel Lockdown"
-msgstr "Zaklepanje jedra Linuxa"
-
-#. TRANSLATORS: longer description
-msgid "Linux Kernel Lockdown mode prevents administrator (root) accounts from accessing and changing critical parts of system software."
-msgstr "Način zaklepanja jedra Linuxa skrbniškim (korenskim) računom preprečuje dostop do kritičnih delov sistemske programske opreme in njihovo spreminjanje."
-
-msgid "Linux Kernel Swap temporarily saves information to disk as you work. If the information is not protected, it could be accessed by someone if they obtained the disk."
-msgstr "Zamenjava jedra Linuxa med delom začasno shrani informacije na disk. Če podatki niso zaščiteni, lahko do njih dostopa nekdo, če je dobil dostop do diska."
-
-#. TRANSLATORS: Title: if it's tainted or not
-msgid "Linux Kernel Verification"
-msgstr "Preverjanje jedra Linuxa"
-
-msgid "Linux Kernel Verification makes sure that critical system software has not been tampered with. Using device drivers which are not provided with the system can prevent this security feature from working correctly."
-msgstr "Preverjanje jedra Linuxa zagotavlja, da kritična sistemska programska oprema ni bila spremenjena. Uporaba gonilnikov naprav, ki niso priloženi sistemu, lahko prepreči pravilno delovanje te varnostne funkcije."
-
-#. TRANSLATORS: Title: swap space or swap partition
-msgid "Linux Swap"
-msgstr "Izmenjevalni prostor Linux"
-
-msgid "Linux Vendor Firmware Service (stable firmware)"
-msgstr "Storitev dobaviteljev strojne programske opreme za Linux (stabilna strojna programska oprema)"
-
-msgid "Linux Vendor Firmware Service (testing firmware)"
-msgstr "Storitev dobaviteljev strojne programske opreme za Linux (preizkusna strojna programska oprema)"
-
-#. TRANSLATORS: Title: if it's tainted or not
-msgid "Linux kernel"
-msgstr "Jedro Linuxa"
-
-#. TRANSLATORS: Title: lockdown is a security mode of the kernel
-msgid "Linux kernel lockdown"
-msgstr "Zaklepanje jedra Linuxa"
-
-#. TRANSLATORS: Title: swap space or swap partition
-msgid "Linux swap"
-msgstr "Izmenjevalni prostor Linux"
-
-#. TRANSLATORS: command description
-msgid "List EFI boot files"
-msgstr "Izpiši seznam datotek zagona EFI"
-
-#. TRANSLATORS: command description
-msgid "List EFI boot parameters"
-msgstr "Izpiši seznam parametrov zagona EFI"
-
-#. TRANSLATORS: command description
-msgid "List EFI variables with a specific GUID"
-msgstr "Izpiši seznam spremenljivk EFI z določenim GUID-om"
-
-#. TRANSLATORS: command line option
-msgid "List entries in dbx"
-msgstr "Izpiši vnose v dbx"
-
-#. TRANSLATORS: command description
-msgid "List the available firmware GTypes"
-msgstr "Izpiše seznam razpoložljive vdelane programske opreme GTypes"
-
-#. TRANSLATORS: command description
-msgid "List the available firmware types"
-msgstr "Izpiše seznam razpoložljivih vrst vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Lists files on the ESP"
-msgstr "Izpiše datoteke v ESP"
-
-#. TRANSLATORS: command description
-msgid "Load device emulation data"
-msgstr "Naloži emulacijske podatke naprave"
-
-#. TRANSLATORS: the plugin was created from a .so object, and was not built-in
-msgid "Loaded from an external module"
-msgstr "Naloženo iz zunanjega modula"
-
-#. TRANSLATORS: parsing the firmware information
-msgid "Loading…"
-msgstr "Poteka nalaganje …"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Locked"
-msgstr "Zaklenjen"
-
-#. TRANSLATORS: the release urgency
-msgid "Low"
-msgstr "Nizko"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and key refers
-#. * to the private/public key used to secure loading of firmware
-msgid "MEI Key Manifest"
-msgstr "Manifest ključa MEI"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and key refer
-#. * to the private/public key used to secure loading of firmware
-msgid "MEI key manifest"
-msgstr "Manifest ključa MEI"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine
-msgid "MEI manufacturing mode"
-msgstr "Način izdelave MEI"
-
-#. TRANSLATORS: Title: MEI = Intel Management Engine, and the
-#. * "override" is the physical PIN that can be driven to
-#. * logic high -- luckily it is probably not accessible to
-#. * end users on consumer boards
-msgid "MEI override"
-msgstr "Preglasitev MEI"
-
-msgid "MEI version"
-msgstr "Različica MEI"
-
-#. TRANSLATORS: command line option
-msgid "Manually enable specific plugins"
-msgstr "Ročno omogoči določene vstavke"
-
-#. TRANSLATORS: longer description
-msgid "Manufacturing Mode is used when the device is manufactured and security features are not yet enabled."
-msgstr "Način izdelave se uporablja, ko je naprava izdelana, varnostne funkcije pa še niso omogočene."
-
-#. TRANSLATORS: Longest valid string for BIOS setting
-msgid "Maximum length"
-msgstr "Največja dolžina"
-
-#. TRANSLATORS: Highest valid integer for BIOS setting
-msgid "Maximum value"
-msgstr "N_ajvečja vrednost"
-
-#. TRANSLATORS: the release urgency
-msgid "Medium"
-msgstr "Srednje"
-
-#. TRANSLATORS: ask the user to do a simple task which should be translated
-msgid "Message"
-msgstr "Sporočila"
-
-#. TRANSLATORS: ask the user a question, and it will not be translated
-msgid "Message (custom)"
-msgstr "Sporočilo (po meri)"
-
-#. TRANSLATORS: remote URI
-msgid "Metadata Signature"
-msgstr "Podpis metapodatkov"
-
-#. TRANSLATORS: remote URI
-msgid "Metadata URI"
-msgstr "URI metapodatkov"
-
-#. TRANSLATORS: explain why no metadata available
-msgid "Metadata can be obtained from the Linux Vendor Firmware Service."
-msgstr "Metapodatke je mogoče pridobiti iz storitve vdelane programske opreme ponudnika Linuxa (Linux Vendor Firmware Service)."
-
-#. TRANSLATORS: error message for a user who ran fwupdmgr
-#. * refresh recently -- %1 is '--force'
-#, c-format
-msgid "Metadata is up to date; use %s to refresh again."
-msgstr "Metapodatki so posodobljeni; Uporabite %s za ponovno osvežitev."
-
-#. TRANSLATORS: smallest version number installable on device
-msgid "Minimum Version"
-msgstr "Najmanjša različica"
-
-#. TRANSLATORS: Shortest valid string for BIOS setting
-msgid "Minimum length"
-msgstr "Najmanjša dolžina"
-
-#. TRANSLATORS: Lowest valid integer for BIOS setting
-msgid "Minimum value"
-msgstr "Najmanjša vrednost"
-
-#. TRANSLATORS: sets something in the daemon configuration file
-msgid "Modifies a daemon configuration value"
-msgstr "Spremeni konfiguracijsko vrednost prikritega procesa"
-
-#. TRANSLATORS: command description
-msgid "Modifies a given remote"
-msgstr "Spremeni dani oddaljeni strežnik"
-
-msgid "Modify a configured remote"
-msgstr "Spremeni nastavljeni oddaljeni strežnik"
-
-msgid "Modify daemon configuration"
-msgstr "Spremeni prilagoditev prikritega procesa"
-
-#. TRANSLATORS: command description
-msgid "Monitor the daemon for events"
-msgstr "Spremljaj dogodke prikritega procesa"
-
-#. TRANSLATORS: command description
-msgid "Mounts the ESP"
-msgstr "Priklopi ESP"
-
-#. TRANSLATORS: Requires a reboot to apply firmware or to reload hardware
-msgid "Needs a reboot after installation"
-msgstr "Po namestitvi je potreben ponovni zagon"
-
-#. TRANSLATORS: the update state of the specific device
-msgid "Needs reboot"
-msgstr "Potreben je ponovni zagon"
-
-#. TRANSLATORS: Requires system shutdown to apply firmware
-msgid "Needs shutdown after installation"
-msgstr "Po namestitvi je potrebna zaustavitev"
-
-#. TRANSLATORS: version number of new firmware
-msgid "New version"
-msgstr "Nova različica"
-
-#. TRANSLATORS: user did not tell the tool what to do
-msgid "No action specified!"
-msgstr "Nobeno dejanje ni določeno!"
-
-#. TRANSLATORS: message letting the user know no device downgrade available
-#. * %1 is the device name
-#, c-format
-msgid "No downgrades for %s"
-msgstr "Ni povrnitev na starejšo različico za %s"
-
-#. TRANSLATORS: nothing found
-msgid "No firmware IDs found"
-msgstr "ID-jev vdelane programske opreme ni bilo mogoče najti"
-
-#. TRANSLATORS: nothing found
-msgid "No firmware found"
-msgstr "Vdelane programske opreme ni bilo mogoče najti"
-
-#. TRANSLATORS: nothing attached that can be upgraded
-msgid "No hardware detected with firmware update capability"
-msgstr "Zaznana ni nobena strojna oprema z možnostjo posodobitve vdelane programske opreme"
-
-#. TRANSLATORS: no rebooting needed
-msgid "No reboot is necessary"
-msgstr "Ponoven zagon ni potreben"
-
-#. TRANSLATORS: no repositories to download from
-msgid "No releases available"
-msgstr "Izdaje niso na voljo"
-
-#. TRANSLATORS: explain why no metadata available
-msgid "No remotes are currently enabled so no metadata is available."
-msgstr "Oddaljeni strežniki trenutno niso omogočeni, zato metapodatki niso na voljo."
-
-#. TRANSLATORS: no repositories to download from
-msgid "No remotes available"
-msgstr "Oddaljeni strežniki niso na voljo"
-
-#. TRANSLATORS: this is an error string
-msgid "No updatable devices"
-msgstr "Ni naprav, ki jih je mogoče posodobiti"
-
-#. TRANSLATORS: this is an error string
-msgid "No updates available"
-msgstr "Posodobitve niso na voljo"
-
-msgid "No updates available for remaining devices"
-msgstr "Za preostale naprave ni na voljo nobenih posodobitev"
-
-#. TRANSLATORS: error message
-#, c-format
-msgid "No volume matched %s"
-msgstr "Noben pogon se ne ujema s/z %s"
-
-#. TRANSLATORS: version cannot be installed due to policy
-msgid "Not approved"
-msgstr "Ni odobreno"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Not found"
-msgstr "Predmeta ni mogoče najti"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Not supported"
-msgstr "Ni podprto"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "OK"
-msgstr "V redu"
-
-#. TRANSLATORS: this is for the device tests
-msgid "OK!"
-msgstr "V redu!"
-
-#. TRANSLATORS: the firmware old version
-msgid "Old version"
-msgstr "Stara različica"
-
-#. TRANSLATORS: command line option
-msgid "Only install onto emulated devices"
-msgstr "Namesti samo na emulirane naprave"
-
-#. TRANSLATORS: command line option
-msgid "Only show single PCR value"
-msgstr "Pokaži samo eno vrednost PCR"
-
-#. TRANSLATORS: command line option
-msgid "Only use peer-to-peer networking when downloading files"
-msgstr "Omrežje vrstnikov uporabljaj samo pri prenosu datotek"
-
-#. TRANSLATORS: some devices can only be updated to a new semver and cannot
-#. * be downgraded or reinstalled with the existing version
-msgid "Only version upgrades are allowed"
-msgstr "Dovoljene so samo nadgradnje različic"
-
-#. TRANSLATORS: command line option
-msgid "Output in JSON format (disables all interactive prompts)"
-msgstr "Izpis v zapisu JSON (onemogoči vsa vprašanja uporabniku)"
-
-#. TRANSLATORS: command line option
-msgid "Override the default ESP path"
-msgstr "Preglasi kot privzeto pot ESP"
-
-#. TRANSLATORS: if we can get metadata from peer-to-peer clients
-msgid "P2P Firmware"
-msgstr "Vdelana programska oprema P2P"
-
-#. TRANSLATORS: if we can get metadata from peer-to-peer clients
-msgid "P2P Metadata"
-msgstr "Metapodatki P2P"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "PATH"
-msgstr "POT"
-
-#. TRANSLATORS: command description
-msgid "Parse and show details about a firmware file"
-msgstr "Razčleni in prikaži podrobnosti o datoteki vdelane programske opreme"
-
-#. TRANSLATORS: reading new dbx from the update
-msgid "Parsing dbx update…"
-msgstr "Razčlenjevanje posodobitve dbx ..."
-
-#. TRANSLATORS: reading existing dbx from the system
-msgid "Parsing system dbx…"
-msgstr "Razčlenjevanje sistemskega dbx ..."
-
-#. TRANSLATORS: remote filename base
-msgid "Password"
-msgstr "Geslo"
-
-#. TRANSLATORS: command description
-msgid "Patch a firmware blob at a known offset"
-msgstr "Popravi dvojiško zbirko podatkov vdelane programske opreme pri znanem odmiku"
-
-msgid "Payload"
-msgstr "Obremenitev"
-
-#. TRANSLATORS: the update state of the specific device
-msgid "Pending"
-msgstr "V čakanju"
-
-#. TRANSLATORS: prompt to apply the update
-msgid "Perform operation?"
-msgstr "Želite izvesti opravilo?"
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-msgid "Platform Debugging"
-msgstr "Odpravljanje napak na platformi"
-
-#. TRANSLATORS: longer description
-msgid "Platform Debugging allows device security features to be disabled. This should only be used by hardware manufacturers."
-msgstr "Odpravljanje napak na platformi omogoča onemogočanje varnostnih funkcij naprave. To naj uporabljajo samo proizvajalci strojne opreme."
-
-#. TRANSLATORS: Title: Allows debugging of parts using proprietary hardware
-msgid "Platform debugging"
-msgstr "Odpravljanje napak na platformi"
-
-#. TRANSLATORS: 'recovery key' here refers to a code, rather than a physical
-#. metal thing
-msgid "Please ensure you have the volume recovery key before continuing."
-msgstr "Pred nadaljevanjem se prepričajte, da imate ključ za obnovitev nosilca."
-
-#. TRANSLATORS: the user isn't reading the question
-#, c-format
-msgid "Please enter a number from 0 to %u: "
-msgstr "Vnesite številko od 0 do %u: "
-
-#. TRANSLATORS: the user isn't reading the question -- %1 is 'Y' and %2 is
-#. * 'N'
-#, c-format
-msgid "Please enter either %s or %s: "
-msgstr "Vnesite %s ali %s:"
-
-#. TRANSLATORS: Failed to open plugin, hey Arch users
-msgid "Plugin dependencies missing"
-msgstr "Manjkajo odvisnosti vstavkov"
-
-#. TRANSLATORS: The plugin is only for testing
-msgid "Plugin is only for testing"
-msgstr "Vstavek je namenjen le preizkušanju"
-
-#. TRANSLATORS: Possible values for a bios setting
-msgid "Possible Values"
-msgstr "Možne vrednosti"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-msgid "Pre-boot DMA Protection"
-msgstr "Zaščita DMA pred zagonom"
-
-#. TRANSLATORS: Title: DMA as in https://en.wikipedia.org/wiki/DMA_attack
-msgid "Pre-boot DMA protection"
-msgstr "Zaščita DMA pred zagonom"
-
-#. TRANSLATORS: HSI event title
-msgid "Pre-boot DMA protection is disabled"
-msgstr "Zaščita DMA pred zagonom je onemogočena"
-
-#. TRANSLATORS: HSI event title
-msgid "Pre-boot DMA protection is enabled"
-msgstr "Zaščita DMA pred zagonom je omogočena"
-
-#. TRANSLATORS: longer description
-msgid "Pre-boot DMA protection prevents devices from accessing system memory after being connected to the computer."
-msgstr "Zaščita DMA pred zagonom preprečuje napravam dostop do sistemskega pomnilnika, ko so priključene na računalnik."
-
-#. TRANSLATORS: warning message
-msgid "Press unlock on the device to continue the update process."
-msgstr "Na napravi pritisnite odklepanje, da nadaljujete postopek posodabljanja."
-
-#. TRANSLATORS: version number of previous firmware
-msgid "Previous version"
-msgstr "Prejšnja različica"
-
-#. TRANSLATORS: the numeric priority
-msgid "Priority"
-msgstr "Prednost"
-
-#. TRANSLATORS: reasons the device is not updatable
-msgid "Problems"
-msgstr "Težave"
-
-msgid "Proceed with upload?"
-msgstr "Ali želite nadaljevati z nalaganjem na strežnik?"
-
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-msgid "Processor Security Checks"
-msgstr "Varnostni pregledi procesorja"
-
-#. TRANSLATORS: Title: if firmware enforces rollback protection
-msgid "Processor rollback protection"
-msgstr "Zaščita pred povrnitvijo procesorja"
-
-#. TRANSLATORS: a non-free software license
-msgid "Proprietary"
-msgstr "Lastniško"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "REMOTE-ID"
-msgstr "ID-ODDALJENEGA"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "REMOTE-ID KEY VALUE"
-msgstr "ID-ODDALJENI KLJUČ VREDNOST"
-
-#. TRANSLATORS: BIOS setting is read only
-msgid "Read Only"
-msgstr "Samo za branje"
-
-#. TRANSLATORS: command description
-msgid "Read a firmware blob from a device"
-msgstr "Preberi dvojiško zbirko podatkov vdelane programske opreme iz naprave"
-
-#. TRANSLATORS: command description
-msgid "Read a firmware from a device"
-msgstr "Preberi vdelano programsko opremo iz naprave"
-
 #. TRANSLATORS: %1 is a device name
+#: src/fu-tool.c:1011
 #, c-format
 msgid "Reading from %s…"
 msgstr "Branje iz %s ..."
 
-#. TRANSLATORS: reading from the flash chips
-msgid "Reading…"
-msgstr "Poteka branje ..."
-
-#. TRANSLATORS: Plugin is active and in use
-msgid "Ready"
-msgstr "Pripravljeno"
-
-#. TRANSLATORS: how often we should refresh the metadata
-msgid "Refresh Interval"
-msgstr "Interval osveževanja"
-
-#. TRANSLATORS: command description
-msgid "Refresh metadata from remote server"
-msgstr "Osveži metapodatke iz oddaljenega strežnika"
-
-#. TRANSLATORS: message letting the user know an upgrade is available
-#. * %1 is the device name and %2 is a version string
+#. TRANSLATORS: the device has a reason it can't update, e.g. laptop lid closed
+#: src/fu-tool.c:1571 src/fu-util.c:3003
 #, c-format
-msgid "Reinstall %s to %s?"
-msgstr "Želite ponovno namestiti %s na %s?"
-
-#. TRANSLATORS: command description
-msgid "Reinstall current firmware on the device"
-msgstr "V napravo znova namestite trenutno vdelano programsko opremo"
-
-#. TRANSLATORS: command description
-msgid "Reinstall firmware on a device"
-msgstr "Vnovično namesti vdelano programsko opremo na napravo"
-
-#. TRANSLATORS: the stream of firmware, e.g. nonfree
-msgid "Release Branch"
-msgstr "Veja izdaje"
-
-#. TRANSLATORS: release attributes
-msgid "Release Flags"
-msgstr "Zastavice izdaje"
-
-#. TRANSLATORS: the exact component on the server
-msgid "Release ID"
-msgstr "ID izdaje"
-
-#. TRANSLATORS: the server the file is coming from
-#. TRANSLATORS: remote identifier, e.g. lvfs-testing
-msgid "Remote ID"
-msgstr "ID oddaljenega strežnika"
-
-#. TRANSLATORS: command description
-msgid "Removes devices to watch for future emulation"
-msgstr "Odstrani naprave za spremljanje prihodnje emulacije"
-
-#. TRANSLATORS: URI to send success/failure reports
-msgid "Report URI"
-msgstr "URI poročila"
-
-#. TRANSLATORS: Has been reported to a metadata server
-msgid "Reported to remote server"
-msgstr "Prijavljeno oddaljenemu strežniku"
-
-#. TRANSLATORS: the user is using Gentoo/Arch and has screwed something up
-msgid "Required efivarfs filesystem was not found"
-msgstr "Zahtevanega datotečnega sistema efivarfs ni bilo mogoče najti"
-
-#. TRANSLATORS: not required for this system
-msgid "Required hardware was not found"
-msgstr "Zahtevane strojne opreme ni bilo mogoče najti"
-
-#. TRANSLATORS: Requires a bootloader mode to be manually enabled by the user
-msgid "Requires a bootloader"
-msgstr "Zahteva zagonski nalagalnik"
-
-#. TRANSLATORS: metadata is downloaded
-msgid "Requires internet connection"
-msgstr "Zahteva internetno povezavo"
-
-msgid "Reset daemon configuration"
-msgstr "Ponastavi prilagoditev prikritega procesa"
-
-#. TRANSLATORS: sets something in the daemon configuration file
-msgid "Resets a daemon configuration section"
-msgstr "Ponastavi razdelek prilagoditev prikritega procesa"
-
-#. TRANSLATORS: reboot to apply the update
-msgid "Restart now?"
-msgstr "Želite ponovno zagnati zdaj?"
-
-#. TRANSLATORS: changes only take effect on restart
-msgid "Restart the daemon to make the change effective?"
-msgstr "Želite znova zagnati prikriti proces, da bo sprememba uveljavljena?"
-
-#. TRANSLATORS: restarting the device to pick up new F/W
-msgid "Restarting device…"
-msgstr "Ponovni zagon naprave ..."
-
-#. TRANSLATORS: command description
-msgid "Retrieve BIOS settings.  If no arguments are passed all settings are returned"
-msgstr "Pridobi nastavitve BIOS-a.  Če argumenti niso posredovani, so vrnjene vse nastavitve"
-
-#. TRANSLATORS: command description
-msgid "Return all the hardware IDs for the machine"
-msgstr "Vrnite vse ID-je strojne opreme za napravo"
-
-#. TRANSLATORS: ask the user to upload
-msgid "Review and upload report now?"
-msgstr "Želite pregledati in naložiti poročilo zdaj?"
-
-#. TRANSLATORS: longer description
-msgid "Rollback Protection prevents device software from being downgraded to an older version that has security problems."
-msgstr "Zaščita pred povrnitvijo preprečuje zamenjavo programske opreme naprave s starejšo različico, ki ima varnostne težave."
-
-#. TRANSLATORS: this is shown in the MOTD -- %1 is the
-#. * command name, e.g. `fwupdmgr get-upgrades`
-#, c-format
-msgid "Run `%s` for more information."
-msgstr "Za več informacij zaženite »%s«."
-
-#. TRANSLATORS: this is shown in the MOTD -- %1 is the
-#. * command name, e.g. `fwupdmgr sync`
-#, c-format
-msgid "Run `%s` to complete this action."
-msgstr "Zaženite »%s«, da dokončate to dejanje."
-
-#. TRANSLATORS: command line option
-msgid "Run the plugin composite cleanup routine when using install-blob"
-msgstr "Zaženite rutino čiščenja vstavkov, ko uporabljate zbirko dvojiških podatkov za namestitev"
-
-#. TRANSLATORS: command line option
-msgid "Run the plugin composite prepare routine when using install-blob"
-msgstr "Zaženite rutino priprave kompozitnih vstavkov pri uporabi zbirke dvojiških podatkov za namestitev (install-blob)"
-
-#. TRANSLATORS: command description
-msgid "Run the post-reboot cleanup action"
-msgstr "Zaženi dejanje čiščenja po ponovnem zagonu"
-
-#. TRANSLATORS: tell a user how to get information
-#, c-format
-msgid "Run without '%s' to see"
-msgstr "Izvedite brez '%s' za ogled"
-
-#. TRANSLATORS: The kernel does not support this plugin
-msgid "Running kernel is too old"
-msgstr "Izvajalno jedro je prestaro"
-
-#. TRANSLATORS:  this is the HSI suffix
-msgid "Runtime Suffix"
-msgstr "Pripona izvajalne datoteke"
-
-#. TRANSLATORS: Software Bill of Materials link
-msgid "SBOM"
-msgstr "SBOM"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "SECTION"
-msgstr "RAZDELEK"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "SETTING VALUE"
-msgstr "NASTAVITEV VREDNOST"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "SETTING1 VALUE1 [SETTING2] [VALUE2]"
-msgstr "NASTAVITEV1 VREDNOST1 [NASTAVITEV2] [VREDNOST2]"
-
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-msgid "SMAP"
-msgstr "SMAP"
-
-#. TRANSLATORS: Title: Whether firmware is locked down
-msgid "SMM locked down"
-msgstr "SMM (NUS) zaklenjen"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-msgid "SPI BIOS Descriptor"
-msgstr "Deskriptor SPI BIOS-a"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-msgid "SPI BIOS region"
-msgstr "Regija SPI BIOS-a"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-msgid "SPI lock"
-msgstr "Zaklepanje SPI"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI replays
-msgid "SPI replay protection"
-msgstr "Zaščita pred ponovnim predvajanjem SPI"
-
-#. TRANSLATORS: Title: SPI refers to the flash chip in the computer
-msgid "SPI write"
-msgstr "Pisanje SPI"
-
-#. TRANSLATORS: Title: if hardware enforces control of SPI writes
-msgid "SPI write protection"
-msgstr "Zaščita pred zapisovanjem SPI"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "SUBSYSTEM DRIVER [DEVICE-ID|GUID]"
-msgstr "PODSISTEM GONILNIK [ID-NAPRAVE|GUID]"
-
-#. TRANSLATORS: command description
-msgid "Save a file that allows generation of hardware IDs"
-msgstr "Shranite datoteko, ki omogoča tvorjenje ID-jev strojne opreme"
-
-#. TRANSLATORS: command description
-msgid "Save device emulation data"
-msgstr "Shrani emulacijske podatke naprave"
-
-#. TRANSLATORS: key for a offline report filename
-msgid "Saved report"
-msgstr "Shranjeno poročilo"
-
-#. TRANSLATORS: Scalar increment for integer BIOS setting
-msgid "Scalar Increment"
-msgstr "Skalarni prirastek"
-
-#. TRANSLATORS: scheduling an update to be done on the next boot
-msgid "Scheduling…"
-msgstr "Časovno načrtovanje procesov ..."
-
-#. TRANSLATORS: HSI event title
-msgid "Secure Boot disabled"
-msgstr "Varni zagon je onemogočen"
-
-#. TRANSLATORS: HSI event title
-msgid "Secure Boot enabled"
-msgstr "Varni zagon je omogočen"
-
-msgid "Security hardening for HSI"
-msgstr "Utrjevanje varnosti za HSI"
-
-#. TRANSLATORS: the %1 is a URL to a wiki page
-#, c-format
-msgid "See %s for more details."
-msgstr "Za več podrobnosti glejte %s."
-
-#. TRANSLATORS: %s is a link to a website
-#, c-format
-msgid "See %s for more information."
-msgstr "Za več podrobnosti glejte %s."
-
-#. TRANSLATORS: device has been chosen by the daemon for the user
-msgid "Selected device"
-msgstr "Izbrana naprava"
-
-#. TRANSLATORS: Volume has been chosen by the user
-msgid "Selected volume"
-msgstr "Izbrani nosilec"
-
-#. TRANSLATORS: serial number of hardware
-msgid "Serial Number"
-msgstr "Serijska številka"
-
-#. TRANSLATORS: Configured a BIOS setting to a value
-#, c-format
-msgid "Set BIOS setting '%s' using '%s'."
-msgstr "Nastavite nastavitev BIOS-a »%s« z uporabo možnosti »%s«."
-
-#. TRANSLATORS: command description
-msgid "Set a BIOS setting"
-msgstr "Določite nastavitev BIOS-a"
-
-msgid "Set one or more BIOS settings"
-msgstr "Nastavite eno ali več nastavitev BIOS-a"
-
-#. TRANSLATORS: command description
-msgid "Set or remove an EFI boot hive entry"
-msgstr "Nastavite ali odstranite zagonski vnos satovja za EFI"
-
-#. TRANSLATORS: command description
-msgid "Set the EFI boot next"
-msgstr "Nadalje nastavite zagon EFI"
-
-#. TRANSLATORS: command description
-msgid "Set the EFI boot order"
-msgstr "Nastavite zaporedje zagona EFI"
-
-#. TRANSLATORS: command line option
-msgid "Set the download retries for transient errors"
-msgstr "Nastavite število ponovnih poskusov za občasne napake"
-
-#. TRANSLATORS: command description
-msgid "Sets one or more BIOS settings"
-msgstr "Nastavi eno ali več nastavitev BIOS-a"
-
-#. TRANSLATORS: firmware approved by the admin
-msgid "Sets the list of approved firmware"
-msgstr "Nastavi seznam odobrene vdelane programske opreme"
-
-#. TRANSLATORS: type of BIOS setting
-msgid "Setting type"
-msgstr "Vrsta nastavitve"
-
-#. TRANSLATORS: description of a BIOS setting
-msgid "Settings will apply after system reboots"
-msgstr "Nastavitve bodo veljale po ponovnem zagonu sistema"
-
-#. TRANSLATORS: command description
-msgid "Share firmware history with the developers"
-msgstr "Deli zgodovino vdelane programske opreme z razvijalci"
-
-#. TRANSLATORS: command line option
-msgid "Show all results"
-msgstr "Pokaži vse rezultate"
-
-#. TRANSLATORS: command line option
-msgid "Show client and daemon versions"
-msgstr "Pokaži različici odjemalca in prikritega procesa"
-
-#. TRANSLATORS: this is for daemon development
-msgid "Show daemon verbose information for a particular domain"
-msgstr "Pokaži opisne informacije prikritega procesa za določeno domeno"
-
-#. TRANSLATORS: turn on all debugging
-msgid "Show debugging information for all domains"
-msgstr "Pokaži informacije razhroščevanja za vse domene"
-
-#. TRANSLATORS: for the --verbose arg
-msgid "Show debugging options"
-msgstr "Pokaži možnosti razhroščevanja"
-
-#. TRANSLATORS: command line option
-msgid "Show devices that are not updatable"
-msgstr "Pokaži naprave, ki jih ni mogoče posodobiti"
-
-#. TRANSLATORS: command line option
-msgid "Show extra debugging information"
-msgstr "Pokaži dodatne podatke za razhroščevanje"
-
-#. TRANSLATORS: command description
-msgid "Show history of firmware updates"
-msgstr "Pokaži zgodovino posodobitev strojne programske opreme"
-
-#. TRANSLATORS: command line option
-msgid "Show the calculated version of the dbx"
-msgstr "Pokaži izračunano različico dbx"
-
-#. TRANSLATORS: shutdown to apply the update
-msgid "Shutdown now?"
-msgstr "Želite zaustaviti zdaj?"
-
-#. TRANSLATORS: command description
-msgid "Sign a firmware with a new key"
-msgstr "Podpiši vdelano programsko opremo z novim ključem"
-
-msgid "Sign data using the client certificate"
-msgstr "Podpiši podatke s potrdilom odjemalca"
-
-#. TRANSLATORS: command description
-msgctxt "command-description"
-msgid "Sign data using the client certificate"
-msgstr "Podpiši podatke s potrdilom odjemalca"
-
-#. TRANSLATORS: command line option
-msgid "Sign the uploaded data with the client certificate"
-msgstr "Podpiši naložene podatke s potrdilom odjemalca"
-
-msgid "Signature"
-msgstr "Podpis"
-
-#. TRANSLATORS: firmware is verified on-device the payload using strong crypto
-msgid "Signed Payload"
-msgstr "Podpisani tovor"
-
-#. TRANSLATORS: file size of the download
-msgid "Size"
-msgstr "Velikost"
-
-#. TRANSLATORS: the platform secret is stored in the PCRx registers on the TPM
-msgid "Some of the platform secrets may be invalidated when updating this firmware."
-msgstr "Nekatere skrivnosti platforme se lahko razveljavijo s posodabljanjem te vdelane programske opreme."
-
-#. TRANSLATORS: source (as in code) link
-msgid "Source"
-msgstr "Vir"
-
-#. TRANSLATORS: command line option
-msgid "Specify the dbx database file"
-msgstr "Določite datoteko zbirke podatkov dbx"
-
-msgid "Stop the fwupd service"
-msgstr "Ustavi storitev fwupd"
-
-#. TRANSLATORS: The BIOS setting accepts strings
-msgid "String"
-msgstr "Niz znakov"
-
-#. TRANSLATORS: the update state of the specific device
-msgid "Success"
-msgstr "Uspešno zaključeno"
-
-#. TRANSLATORS: success message -- where activation is making the new
-#. * firmware take effect, usually after updating offline
-msgid "Successfully activated all devices"
-msgstr "Uspešno aktivirane vse naprave"
+msgid "%s is not currently updatable"
+msgstr "%s trenutno ni mogoče posodobiti"
+
+#. TRANSLATORS: message letting the user there is an update
+#. * waiting, but there is a reason it cannot be deployed
+#: src/fu-tool.c:1768 src/fu-util.c:3218
+msgid "Devices with firmware updates that need user action: "
+msgstr ""
+"Naprave s posodobitvami vdelane programske opreme, ki zahtevajo ukrepanje:"
+
+#. TRANSLATORS: success message -- a per-system setting value
+#: src/fu-tool.c:2227 src/fu-util.c:3911
+msgid "Successfully modified configuration value"
+msgstr "Uspešno spremenjena konfiguracijska vrednost"
+
+#. TRANSLATORS: success message -- a per-system setting value
+#: src/fu-tool.c:2254
+msgid "Successfully reset configuration section"
+msgstr "Uspešno ponastavljena konfiguracijska vrednost"
+
+#. TRANSLATORS: success message for a per-remote setting change
+#: src/fu-tool.c:2291 src/fu-util.c:3281
+msgid "Successfully modified remote"
+msgstr "Uspešno spremenjen oddaljeni strežnik"
 
 #. TRANSLATORS: success message
+#: src/fu-tool.c:2325 src/fu-util.c:3372
 msgid "Successfully disabled remote"
 msgstr "Uspešno onemogočen oddaljeni strežnik"
 
-#. TRANSLATORS: comment explaining result of command
-msgid "Successfully disabled test devices"
-msgstr "Uspešno onemogočene preizkusne naprave"
-
-#. TRANSLATORS: success message -- where 'metadata' is information
-#. * about available firmware on the remote server
-msgid "Successfully downloaded new metadata: "
-msgstr "Uspešno preneseni novi metapodatki: "
-
 #. TRANSLATORS: success message
-msgid "Successfully enabled and refreshed remote"
-msgstr "Uspešno omogočen in osvežen oddaljeni strežnik"
-
-#. TRANSLATORS: success message
+#: src/fu-tool.c:2402 src/fu-util.c:3315 src/fu-util.c:3327
 msgid "Successfully enabled remote"
 msgstr "Uspešno omogočen oddaljeni strežnik"
 
 #. TRANSLATORS: comment explaining result of command
+#: src/fu-tool.c:2429
+msgid "Successfully disabled test devices"
+msgstr "Uspešno onemogočene preizkusne naprave"
+
+#. TRANSLATORS: comment explaining result of command
+#: src/fu-tool.c:2476
 msgid "Successfully enabled test devices"
 msgstr "Uspešno omogočene preizkusne naprave"
 
+#. TRANSLATORS: shown when shutting down to switch to the new version
+#: src/fu-tool.c:2572
+msgid "Activating firmware update"
+msgstr "Aktiviranje posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: this is when a device is hotplugged
+#: src/fu-tool.c:2779
+msgid "Device added:"
+msgstr "Dodana naprava:"
+
+#. TRANSLATORS: this is when a device is hotplugged
+#: src/fu-tool.c:2794
+msgid "Device removed:"
+msgstr "Odstranjena naprava:"
+
+#. TRANSLATORS: this is when a device has been updated
+#: src/fu-tool.c:2809
+msgid "Device changed:"
+msgstr "Spremenjena naprava:"
+
+#. TRANSLATORS: this is when the daemon state changes
+#: src/fu-tool.c:2821
+msgid "Changed"
+msgstr "Spremenjeno"
+
+#. TRANSLATORS: nothing found
+#: src/fu-tool.c:2879
+msgid "No firmware IDs found"
+msgstr "ID-jev vdelane programske opreme ni bilo mogoče najti"
+
+#. TRANSLATORS: nothing found
+#: src/fu-tool.c:2909
+msgid "No firmware found"
+msgstr "Vdelane programske opreme ni bilo mogoče najti"
+
+#. TRANSLATORS: get interactive prompt
+#: src/fu-tool.c:2943
+msgid "Choose firmware"
+msgstr "Izberite strojno programsko opremo"
+
+#. TRANSLATORS: decompressing images from a container firmware
+#: src/fu-tool.c:3214
+msgid "Writing file:"
+msgstr "Zapisovanje datoteke:"
+
+#. TRANSLATORS: error message for unsupported feature
+#: src/fu-tool.c:3844 src/fu-tool.c:4321 src/fu-tool.c:4358 src/fu-util.c:4305
+#: src/fu-util.c:4815 src/fu-util.c:4931
+msgid "Host Security ID (HSI) is not supported"
+msgstr "Varnostni ID gostitelja (HSI) ni podprt"
+
+#. TRANSLATORS: this is a string like 'HSI:2-U'
+#: src/fu-tool.c:3881 src/fu-util.c:4344
+msgid "Host Security ID:"
+msgstr "Varnostni ID gostitelja:"
+
+#. TRANSLATORS: Volume has been chosen by the user
+#: src/fu-tool.c:3930
+msgid "Selected volume"
+msgstr "Izbrani nosilec"
+
+#. TRANSLATORS: get interactive prompt
+#: src/fu-tool.c:3943
+msgid "Choose volume"
+msgstr "Izberite nosilec"
+
+#. TRANSLATORS: get interactive prompt, where branch is the
+#. * supplier of the firmware, e.g. "non-free" or "free"
+#: src/fu-tool.c:4205 src/fu-util.c:3633
+msgid "Choose branch"
+msgstr "Izberite vejo"
+
+#. TRANSLATORS: Configured a BIOS setting to a value
+#: src/fu-tool.c:4297 src/fu-util.c:4752
+#, c-format
+msgid "Set BIOS setting '%s' using '%s'."
+msgstr "Nastavite nastavitev BIOS-a »%s« z uporabo možnosti »%s«."
+
+#. TRANSLATOR: This is the error message for
+#. * incorrect parameter
+#: src/fu-tool.c:4331 src/fu-tool.c:4368 src/fu-util.c:4825 src/fu-util.c:4941
+msgid "Invalid arguments, expected an AppStream ID"
+msgstr "Neveljavni argumenti, pričakovan je ID AppStream"
+
+#. TRANSLATORS: we've fixed a security problem on the machine
+#: src/fu-tool.c:4346 src/fu-util.c:4835
+msgid "Fixed successfully"
+msgstr "Uspešno popravljeno"
+
+#. TRANSLATORS: we've fixed a security problem on the machine
+#: src/fu-tool.c:4383 src/fu-util.c:4954
+msgid "Fix reverted successfully"
+msgstr "Popravek je bil uspešno povrnjen"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4420 src/fu-util.c:4793
+msgid "This system doesn't support firmware settings"
+msgstr "Ta sistem ne podpira nastavitev vdelane programske opreme"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4429 src/fu-util.c:4801
+msgid "Unable to find attribute"
+msgstr "Atributa ni mogoče najti"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4566
+msgid "Invalid arguments, expected INDEX NAME TARGET [MOUNTPOINT]"
+msgstr "Neveljavni argumenti, pričakovano je INDEKS IME CILJ [TOČKAPRIKLOPA]"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4580
+msgid "Already exists, and no --force specified"
+msgstr "Že obstaja, parameter --force ni naveden"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4608
+#, c-format
+msgid "No volume matched %s"
+msgstr "Noben pogon se ne ujema s/z %s"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4632
+msgid "Invalid arguments, expected base-16 integer"
+msgstr "Neveljavni argumenti, pričakovano je celo število base-16"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4693
+msgid "Invalid arguments, expected INDEX KEY [VALUE]"
+msgstr "Neveljavni argumenti, pričakovano je INDEKS KLJUČ [VREDNOST]"
+
+#. TRANSLATORS: try to treat the legacy format as a hive
+#: src/fu-tool.c:4711
+msgid "The EFI boot entry was not in hive format, falling back"
+msgstr "Zagonski vnos za EFI ni v obliki satovja, povrnitev v prejšnje stanje"
+
+#. TRANSLATORS: the boot entry was in a legacy format
+#: src/fu-tool.c:4729
+msgid ""
+"The EFI boot entry is not in hive format, and shim may not be new enough to "
+"read it."
+msgstr ""
+"Zagonski vnos za EFI ni v obliki satovja, povezovalni element morda ni "
+"dovolj nov, da bi ga lahko prebral."
+
+#. TRANSLATORS: ask the user if it's okay to convert,
+#. * "it" being the data contained in the EFI boot entry
+#: src/fu-tool.c:4737
+msgid "Do you want to convert it now?"
+msgstr "Ali ga želite zdaj pretvoriti?"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4872
+msgid "Invalid arguments, expected GUID"
+msgstr "Neveljavni argumenti, pričakovan GUID"
+
+#. TRANSLATORS: error message
+#: src/fu-tool.c:4900
+msgid "Invalid arguments, expected at least ARCHIVE FIRMWARE METAINFO"
+msgstr ""
+"Neveljavni argumenti, pričakovani vsaj ARHIV VDELANAPROGRAMSKAOPREMA "
+"METAPODATKI"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5031 src/fu-util.c:5116
+msgid "Show client and daemon versions"
+msgstr "Pokaži različici odjemalca in prikritega procesa"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5039 src/fu-util.c:5132
+msgid "Allow reinstalling existing firmware versions"
+msgstr ""
+"Dovoli vnovično namestitev obstoječih različic vdelane programske opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5047 src/fu-util.c:5140
+msgid "Allow downgrading firmware versions"
+msgstr ""
+"Dovoli zamenjavo različic vdelane programske opreme s starejšo različico"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5055 src/fu-util.c:5148
+msgid "Allow switching firmware branch"
+msgstr "Dovoli preklapljanje veje vdelane programske opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5063 src/fu-util.c:5164
+msgid "Force the action by relaxing some runtime checks"
+msgstr "Vsilite dejanje s sprostitvijo nekaterih preverjanj med izvajanjem"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5071
+msgid "Ignore firmware checksum failures"
+msgstr "Prezri napake kontrolne vsote vdelane programske opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5079
+msgid "Ignore firmware hardware mismatch failures"
+msgstr "Prezri napake pri neujemanju strojne opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5087
+msgid "Ignore non-critical firmware requirements"
+msgstr "Prezri ne kritične zahteve vdelane programske opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5095 src/fu-util.c:5212
+msgid "Do not check or prompt for reboot after update"
+msgstr "Po posodobitvi ne preverjaj in ne pozivaj k vnovičnemu zagonu"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5103
+msgid "Do not search the firmware when parsing"
+msgstr "Med razčlenjevanjem ne išči vdelane programske opreme"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5111 src/fu-util.c:5220
+msgid "Do not perform device safety checks"
+msgstr "Ne izvajaj varnostnih preverjanj naprav"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5119 src/fu-util.c:5228
+msgid "Do not prompt for devices"
+msgstr "Ne povprašuj po napravah"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5127 src/fu-util.c:5244
+msgid "Show all results"
+msgstr "Pokaži vse rezultate"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5135 src/fu-util.c:5252
+msgid "Show devices that are not updatable"
+msgstr "Pokaži naprave, ki jih ni mogoče posodobiti"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5143 src/fu-tool.c:5151
+msgid "Manually enable specific plugins"
+msgstr "Ročno omogoči določene vstavke"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5159
+msgid "Run the plugin composite prepare routine when using install-blob"
+msgstr ""
+"Zaženite rutino priprave kompozitnih vstavkov pri uporabi zbirke dvojiških "
+"podatkov za namestitev (install-blob)"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5167
+msgid "Run the plugin composite cleanup routine when using install-blob"
+msgstr ""
+"Zaženite rutino čiščenja vstavkov, ko uporabljate zbirko dvojiških podatkov "
+"za namestitev"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5175 src/fu-util.c:5260
+msgid "Ignore SSL strict checks when downloading files"
+msgstr "Prezri stroga preverjanja SSL pri prenosu datotek"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5183 src/fu-util.c:5276
+msgid ""
+"Filter with a set of device flags using a ~ prefix to exclude, e.g. "
+"'internal,~needs-reboot'"
+msgstr ""
+"Filtriraj z nizom zastavic naprave s predpono ~, da izključite, npr. "
+"\"notranji,~potreben-ponovni zagon\" oz. 'internal,~needs-reboot'"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5192 src/fu-util.c:5285
+msgid ""
+"Filter with a set of release flags using a ~ prefix to exclude, e.g. "
+"'trusted-release,~trusted-metadata'"
+msgstr ""
+"Filtriraj z naborom zastavic za izdajo s predpono ~, da se izključijo npr. "
+"»zaupanja-vredna-izdaja,~zaupanja-vredni-metapodatki« oz.  'trusted-release,"
+"~trusted-metadata'"
+
+#. TRANSLATORS: command line option
+#: src/fu-tool.c:5201 src/fu-util.c:5294
+msgid "Output in JSON format (disables all interactive prompts)"
+msgstr "Izpis v zapisu JSON (onemogoči vsa vprašanja uporabniku)"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5255 src/fu-tool.c:5268 src/fu-util.c:5388
+msgid "FILE"
+msgstr "DATOTEKA"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5257
+msgid "Dump SMBIOS data from a file"
+msgstr "Odloži podatke SMBIOS-a iz datoteke"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5263 src/fu-util.c:5575
+msgid "Get all enabled plugins registered with the system"
+msgstr "Pridobi vse omogočene vstavke, registrirane v sistemu"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5270 src/fu-util.c:5390
+msgid "Gets details about a firmware file"
+msgstr "Pridobi podrobnosti o datoteki strojne programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5276 src/fu-util.c:5357
+msgid "Show history of firmware updates"
+msgstr "Pokaži zgodovino posodobitev strojne programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5281 src/fu-tool.c:5349 src/fu-tool.c:5363 src/fu-tool.c:5390
+#: src/fu-tool.c:5405 src/fu-tool.c:5507 src/fu-tool.c:5514 src/fu-util.c:5343
+#: src/fu-util.c:5395 src/fu-util.c:5403 src/fu-util.c:5411 src/fu-util.c:5439
+#: src/fu-util.c:5452 src/fu-util.c:5466 src/fu-util.c:5494 src/fu-util.c:5528
+#: src/fu-util.c:5657 src/fu-util.c:5664
+msgid "[DEVICE-ID|GUID]"
+msgstr "[ID-NAPRAVE|GUID]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5283 src/fu-util.c:5397
+msgid ""
+"Gets the list of updates for all specified devices, or all devices if "
+"unspecified"
+msgstr ""
+"Pridobi seznam posodobitev za vse navedene naprave ali za vse naprave, če "
+"nobena ni izrecno navedena"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5290 src/fu-util.c:5351
+msgid "Get all devices that support firmware updates"
+msgstr ""
+"Pridobi vse naprave, ki podpirajo posodobitve vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5296
+msgid "Get all device flags supported by fwupd"
+msgstr "Pridobi vse zastavice naprav, ki jih podpira fwupd"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5302
+msgid "Watch for hardware changes"
+msgstr "Spremljaj spremembe strojne opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5307
+msgid "FILENAME DEVICE-ID [VERSION]"
+msgstr "IMEDATOTEKE ID-NAPRAVE [RAZLIČICA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5309
+msgid "Install a raw firmware blob on a device"
+msgstr ""
+"Namestite neobdelano dvojiško zbirko podatkov vdelane programske opreme v "
+"napravo"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5314 src/fu-util.c:5381
+msgid "FILE [DEVICE-ID|GUID]"
+msgstr "DATOTEKA [ID-NAPRAVE|GUID]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5316
+msgid ""
+"Install a specific firmware on a device, all possible devices will also be "
+"installed once the CAB matches"
+msgstr ""
+"Namestite določeno vdelano programsko opremo na napravo, vse možne naprave "
+"bodo prav tako nameščene, če se CAB ujema"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5322 src/fu-tool.c:5329 src/fu-tool.c:5342 src/fu-util.c:5418
+#: src/fu-util.c:5425 src/fu-util.c:5432
+msgid "DEVICE-ID|GUID"
+msgstr "ID-NAPRAVE|GUID"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5324
+msgid "Reinstall firmware on a device"
+msgstr "Vnovično namesti vdelano programsko opremo na napravo"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5331
+msgid "Attach to firmware mode"
+msgstr "Pripni na način vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5337
+msgid "Get device report metadata"
+msgstr "Pridobi metapodatke poročila o napravi"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5344
+msgid "Detach to bootloader mode"
+msgstr "Odklopi v način zagonskega nalagalnika"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5351
+msgid "Unbind current driver"
+msgstr "Razveži trenutni gonilnik"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5356
+msgid "SUBSYSTEM DRIVER [DEVICE-ID|GUID]"
+msgstr "PODSISTEM GONILNIK [ID-NAPRAVE|GUID]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5358
+msgid "Bind new kernel driver"
+msgstr "Poveži novi gonilnik jedra"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5365
+msgid "Activate pending devices"
+msgstr "Aktiviraj čakajoče naprave"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5370
+msgid "[SMBIOS-FILE|HWIDS-FILE]"
+msgstr "[DATOTEKA-SMBIOS|DATOTEKA-HWIDS]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5372
+msgid "Return all the hardware IDs for the machine"
+msgstr "Vrnite vse ID-je strojne opreme za napravo"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5377
+msgid "HWIDS-FILE"
+msgstr "DATOTEKA-HWIDS"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5379
+msgid "Save a file that allows generation of hardware IDs"
+msgstr "Shranite datoteko, ki omogoča tvorjenje ID-jev strojne opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5385
+msgid "Monitor the daemon for events"
+msgstr "Spremljaj dogodke prikritega procesa"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5392 src/fu-util.c:5405
+msgid ""
+"Updates all specified devices to latest firmware version, or all devices if "
+"unspecified"
+msgstr ""
+"Posodobi vse navedene naprave na najnovejšo različico vdelane programske "
+"opreme ali vse naprave, če niso navedene"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5398
+msgid "TEXT"
+msgstr "BESEDILO"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5400
+msgctxt "command-description"
+msgid "Sign data using the client certificate"
+msgstr "Podpiši podatke s potrdilom odjemalca"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5407
+msgid "Update the stored metadata with current contents"
+msgstr "Posodobi shranjene metapodatke s trenutno vsebino"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5412
+msgid "FILENAME CERTIFICATE PRIVATE-KEY"
+msgstr "IME-DATOTEKE POTRDILO OSEBNI-KLJUČ"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5414
+msgid "Sign a firmware with a new key"
+msgstr "Podpiši vdelano programsko opremo z novim ključem"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5419 src/fu-tool.c:5426
+msgid "FILENAME [DEVICE-ID|GUID]"
+msgstr "IME-DATOTEKE [ID-NAPRAVE|GUID]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5421
+msgid "Read a firmware blob from a device"
+msgstr "Preberi dvojiško zbirko podatkov vdelane programske opreme iz naprave"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5428
+msgid "Read a firmware from a device"
+msgstr "Preberi vdelano programsko opremo iz naprave"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5433
+msgid "FILENAME OFFSET DATA [FIRMWARE-TYPE]"
+msgstr "IME-DATOTEKE ODMIK PODATKI [VRSTA-VDELANE-PROGRAMSKE-OPREME]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5435
+msgid "Patch a firmware blob at a known offset"
+msgstr ""
+"Popravi dvojiško zbirko podatkov vdelane programske opreme pri znanem odmiku"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5441
+msgid "FILENAME-SRC FILENAME-DST [FIRMWARE-TYPE-SRC] [FIRMWARE-TYPE-DST]"
+msgstr ""
+"IMEDATOTEKE-SRC IMEDATOTEKE-DST [FIRMWARE-VRSTA-SRC] [FIRMWARE-VRSTA-DST]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5443
+msgid "Convert a firmware file"
+msgstr "Pretvori datoteko vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5448
+msgid "BUILDER-XML FILENAME-DST"
+msgstr "BUILDER-XML IMEDATOTEKE-DST"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5450
+msgid "Build a firmware file"
+msgstr "Ustvari datoteko vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5455 src/fu-tool.c:5462 src/fu-tool.c:5469
+msgid "FILENAME [FIRMWARE-TYPE]"
+msgstr "IME-DATOTEKE [VRSTA-VDELANE-PROGRAMSKE-OPREME]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5457
+msgid "Parse and show details about a firmware file"
+msgstr "Razčleni in prikaži podrobnosti o datoteki vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5464
+msgid "Export a firmware file structure to XML"
+msgstr "Izvozi strukturo datoteke vdelane programske opreme v XML"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5471
+msgid "Extract a firmware blob to images"
+msgstr "Izvlecite zbirko podatkov vdelane programske opreme v slike"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5477
+msgid "List the available firmware types"
+msgstr "Izpiše seznam razpoložljivih vrst vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5483
+msgid "List the available firmware GTypes"
+msgstr "Izpiše seznam razpoložljive vdelane programske opreme GTypes"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5489 src/fu-util.c:5447
+msgid "Gets the configured remotes"
+msgstr "Pridobi nastavljene oddaljene strežnike"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5495 src/fu-util.c:5461
+msgid "Refresh metadata from remote server"
+msgstr "Osveži metapodatke iz oddaljenega strežnika"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5500
+msgid "[FWUPD-VERSION]"
+msgstr "[FWUPD-RAZLIČICA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5502 src/fu-util.c:5543
+msgid "Gets the host security attributes"
+msgstr "Pridobi varnostne atribute gostitelja"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5509 src/fu-util.c:5659
+msgid "Adds devices to watch for future emulation"
+msgstr "Doda naprave za spremljanje prihodnje emulacije"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5516 src/fu-util.c:5666
+msgid "Removes devices to watch for future emulation"
+msgstr "Odstrani naprave za spremljanje prihodnje emulacije"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5521
+msgid "EMULATION-FILE [ARCHIVE-FILE]"
+msgstr "DATOTEKA-EMULACIJE [ARHIVSKA-DATOTEKA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5529
+msgid "Mounts the ESP"
+msgstr "Priklopi ESP"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5535
+msgid "Unmounts the ESP"
+msgstr "Odklopi ESP"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5541
+msgid "Lists files on the ESP"
+msgstr "Izpiše datoteke v ESP"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5546 src/fu-util.c:5535
+msgid "[DEVICE-ID|GUID] [BRANCH]"
+msgstr "[ID-NAPRAVE|GUID] [VEJA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5548 src/fu-util.c:5537
+msgid "Switch the firmware branch on the device"
+msgstr "Preklopite vejo vdelane programske opreme na napravi"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5554
+msgid "Erase all firmware update history"
+msgstr "Izbriši vso zgodovino posodobitev vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5560
+msgid "[SETTING1] [SETTING2]..."
+msgstr "[NASTAVITEV1] [NASTAVITEV2]..."
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5562 src/fu-util.c:5631
+msgid ""
+"Retrieve BIOS settings.  If no arguments are passed all settings are returned"
+msgstr ""
+"Pridobi nastavitve BIOS-a.  Če argumenti niso posredovani, so vrnjene vse "
+"nastavitve"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5567
+msgid "SETTING VALUE"
+msgstr "NASTAVITEV VREDNOST"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5569
+msgid "Set a BIOS setting"
+msgstr "Določite nastavitev BIOS-a"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5574
+msgid "ARCHIVE FIRMWARE METAINFO [FIRMWARE] [METAINFO] [JCATFILE]"
+msgstr ""
+"ARHIV VDELANA-PROG-OPREMA METAPODATKI [VDELANA-PROG-OPREMA] [METAPODATKI] "
+"[DATOTEKAJCAT]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5576
+msgid "Build a cabinet archive from a firmware blob and XML metadata"
+msgstr ""
+"Ustvari arhiv vsebnika iz zbirke dvojiških podatkov in metapodatkov XML "
+"vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5581
+msgctxt "command-argument"
+msgid "GUID"
+msgstr "GUID"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5583
+msgid "List EFI variables with a specific GUID"
+msgstr "Izpiši seznam spremenljivk EFI z določenim GUID-om"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5591
+msgid "List EFI boot parameters"
+msgstr "Izpiši seznam parametrov zagona EFI"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5596 src/fu-tool.c:5610
+msgid "INDEX"
+msgstr "INDEKS"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5598
+msgid "Set the EFI boot next"
+msgstr "Nadalje nastavite zagon EFI"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5603
+msgid "INDEX1,INDEX2"
+msgstr "INDEKS1,INDEKS2"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5605
+msgid "Set the EFI boot order"
+msgstr "Nastavite zaporedje zagona EFI"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5612
+msgid "Delete an EFI boot entry"
+msgstr "Izbriše zagonski vnos za EFI"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5617
+msgid "INDEX NAME TARGET [MOUNTPOINT]"
+msgstr "INDEKS IME CILJ  [TOČKAPRIKLOPA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5619
+msgid "Create an EFI boot entry"
+msgstr "Ustvari zagonski vnos za EFI"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5624
+msgid "INDEX KEY [VALUE]"
+msgstr "INDEKS KLJUČ [VREDNOST]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5626
+msgid "Set or remove an EFI boot hive entry"
+msgstr "Nastavite ali odstranite zagonski vnos satovja za EFI"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5633
+msgid "List EFI boot files"
+msgstr "Izpiši seznam datotek zagona EFI"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5638 src/fu-tool.c:5645 src/fu-util.c:5671 src/fu-util.c:5678
+msgid "[APPSTREAM_ID]"
+msgstr "[APPSTREAM_ID]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5640 src/fu-util.c:5673
+msgid "Fix a specific host security attribute"
+msgstr "Popravi določen varnostni atribut gostitelja"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5647 src/fu-util.c:5680
+msgid "Undo the host security attribute fix"
+msgstr "Razveljavi popravek varnostnega atributa gostitelja"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5652
+msgid "[DEVICE]"
+msgstr "[NAPRAVA]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5654
+msgid "Run the post-reboot cleanup action"
+msgstr "Zaženi dejanje čiščenja po ponovnem zagonu"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5659 src/fu-util.c:5514
+msgid "[SECTION] KEY VALUE"
+msgstr "[RAZDELEK] KLJUČ VREDNOST"
+
+#. TRANSLATORS: sets something in the daemon configuration file
+#: src/fu-tool.c:5661 src/fu-util.c:5516
+msgid "Modifies a daemon configuration value"
+msgstr "Spremeni konfiguracijsko vrednost prikritega procesa"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5666 src/fu-util.c:5521
+msgid "SECTION"
+msgstr "RAZDELEK"
+
+#. TRANSLATORS: sets something in the daemon configuration file
+#: src/fu-tool.c:5668 src/fu-util.c:5523
+msgid "Resets a daemon configuration section"
+msgstr "Ponastavi razdelek prilagoditev prikritega procesa"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5673 src/fu-util.c:5473
+msgid "REMOTE-ID KEY VALUE"
+msgstr "ID-ODDALJENI KLJUČ VREDNOST"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5675 src/fu-util.c:5475
+msgid "Modifies a given remote"
+msgstr "Spremeni dani oddaljeni strežnik"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5680 src/fu-tool.c:5687 src/fu-util.c:5480 src/fu-util.c:5487
+msgid "REMOTE-ID"
+msgstr "ID-ODDALJENEGA"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5682 src/fu-util.c:5482
+msgid "Enables a given remote"
+msgstr "Omogoči dani oddaljeni strežnik"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5689 src/fu-util.c:5489
+msgid "Disables a given remote"
+msgstr "Onemogoči dani oddaljeni strežnik"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5695
+msgid "Enables virtual testing devices"
+msgstr "Omogoči navidezne preizkusne naprave"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5701
+msgid "Disables virtual testing devices"
+msgstr "Onemogoči navidezne preizkusne naprave"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5707
+msgid "Get all known version formats"
+msgstr "Pridobi vse znane oblike različic"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-tool.c:5712
+msgid "VERSION1 VERSION2 [FORMAT]"
+msgstr "VERSION1 VERSION2 [FORMAT]"
+
+#. TRANSLATORS: command description
+#: src/fu-tool.c:5714
+msgid "Compares two versions for equality"
+msgstr "Primerja dve različici, če sta enaki"
+
+#. TRANSLATORS: CLI description
+#: src/fu-tool.c:5753
+msgid ""
+"This tool allows an administrator to use the fwupd plugins without being "
+"installed on the host system."
+msgstr ""
+"To orodje skrbniku omogoča uporabo vstavkov fwupd, ne da bi bili nameščeni v "
+"gostiteljskem sistemu."
+
+#. TRANSLATORS: program name
+#: src/fu-tool.c:5757 src/fu-util.c:5727
+msgid "Firmware Utility"
+msgstr "Pripomoček za vdelano programsko opremo"
+
+#. TRANSLATORS: try to help
+#: src/fu-tool.c:5777 src/fu-util.c:5745
+msgid ""
+"Ignoring SSL strict checks, to do this automatically in the future export "
+"DISABLE_SSL_STRICT in your environment"
+msgstr ""
+"Ignoriranje strogih preverjanj SSL, da to storite samodejno v prihodnjih "
+"izvoznih DISABLE_SSL_STRICT v svojem okolju"
+
+#. TRANSLATORS: the user didn't read the man page, %1 is '--filter'
+#. TRANSLATORS: the user didn't read the man page,
+#. * %1 is '--filter-release'
+#. TRANSLATORS: the user didn't read the man page, %1 is '--filter'
+#. TRANSLATORS: the user didn't read the man page,
+#. * %1 is '--filter-release'
+#: src/fu-tool.c:5791 src/fu-tool.c:5805 src/fu-util.c:5771 src/fu-util.c:5785
+#, c-format
+msgid "Failed to parse flags for %s"
+msgstr "Zastavic za %s ni bilo mogoče razčleniti"
+
+#. TRANSLATORS: explain how to get help, %1 is
+#. * 'fwupdtool --help'
+#. TRANSLATORS: explain how to get help,
+#. * where $1 is something like 'fwupdmgr --help'
+#: src/fu-tool.c:5879 src/fu-util.c:5948
+#, c-format
+msgid "Use %s for help"
+msgstr "Uporabite %s za pomoč"
+
+#. TRANSLATORS: %1 is a device name
+#: src/fu-util.c:152
+#, c-format
+msgid "Downgrading %s…"
+msgstr "Povrnitev na starejšo različico %s ..."
+
+#. TRANSLATORS: a list of failed updates
+#: src/fu-util.c:336
+msgid "Devices that were not updated correctly:"
+msgstr "Naprave, ki niso bile pravilno posodobljene:"
+
+#. TRANSLATORS: a list of successful updates
+#: src/fu-util.c:352
+msgid "Devices that have been updated successfully:"
+msgstr "Naprave, ki so bile uspešno posodobljene:"
+
+#. TRANSLATORS: explain why we want to upload
+#: src/fu-util.c:367
+msgid ""
+"Uploading firmware reports helps hardware vendors to quickly identify "
+"failing and successful updates on real devices."
+msgstr ""
+"Nalaganje poročil o vdelani programski opremi pomaga prodajalcem strojne "
+"opreme, da hitro prepoznajo neuspešne in uspešne posodobitve v resničnih "
+"napravah."
+
+#. TRANSLATORS: ask the user to upload
+#: src/fu-util.c:374
+msgid "Review and upload report now?"
+msgstr "Želite pregledati in naložiti poročilo zdaj?"
+
+#. TRANSLATORS: metadata is downloaded
+#: src/fu-util.c:376 src/fu-util.c:2583 src/fu-util.c:3325 src/fu-util.c:4893
+msgid "Requires internet connection"
+msgstr "Zahteva internetno povezavo"
+
+#. TRANSLATORS: offer to disable this nag
+#: src/fu-util.c:381
+msgid "Do you want to disable this feature for future updates?"
+msgstr "Ali želite onemogočiti to funkcijo za prihodnje posodobitve?"
+
+#. TRANSLATORS: offer to stop asking the question
+#: src/fu-util.c:415
+msgid "Do you want to upload reports automatically for future updates?"
+msgstr "Ali želite samodejno naložiti poročila za prihodnje posodobitve?"
+
+#. TRANSLATORS: no rebooting needed
+#: src/fu-util.c:568
+msgid "No reboot is necessary"
+msgstr "Ponoven zagon ni potreben"
+
 #. TRANSLATORS: success message
+#: src/fu-util.c:691
 msgid "Successfully installed firmware"
 msgstr "Uspešno nameščena vdelana programska oprema"
 
-#. TRANSLATORS: success message -- a per-system setting value
-msgid "Successfully modified configuration value"
-msgstr "Uspešno spremenjena konfiguracijska vrednost"
+#. TRANSLATORS: this is for the device tests
+#: src/fu-util.c:823
+msgid "Did not find any devices with matching GUIDs"
+msgstr "Ni najdenih naprav z ujemajočimi se GUID-ji"
 
-#. TRANSLATORS: success message for a per-remote setting change
-msgid "Successfully modified remote"
-msgstr "Uspešno spremenjen oddaljeni strežnik"
+#. TRANSLATORS: this is for the device tests
+#: src/fu-util.c:878
+msgid "OK!"
+msgstr "V redu!"
 
-#. TRANSLATORS: success message -- the user can do this by-hand too
-msgid "Successfully refreshed metadata manually"
-msgstr "Ročno uspešno osveženi metapodatki"
+#. TRANSLATORS: the inhibit ID is a short string like dbus-123456
+#: src/fu-util.c:1266
+#, c-format
+msgid "Inhibit ID is %s."
+msgstr "ID preprečitve je %s."
 
-#. TRANSLATORS: success message -- a per-system setting value
-msgid "Successfully reset configuration section"
-msgstr "Uspešno ponastavljena konfiguracijska vrednost"
+#. TRANSLATORS: we can auto-uninhibit after a timeout
+#: src/fu-util.c:1271
+#, c-format
+msgid "Automatically uninhibiting in %ums…"
+msgstr "Samodejno sproščanje sistema čez %u ms ..."
 
-#. TRANSLATORS: success message -- a per-system setting value
-msgid "Successfully reset configuration values"
-msgstr "Uspešno ponastavljene konfiguracijske vrednosti"
+#. TRANSLATORS: CTRL^C [holding control, and then pressing C] will exit the program
+#: src/fu-util.c:1276
+msgid "Use CTRL^C to cancel."
+msgstr "Za preklic uporabite CTRL^C."
 
-#. TRANSLATORS: success message when user refreshes device checksums
-msgid "Successfully updated device checksums"
-msgstr "Uspešno posodobljene kontrolne vsote naprave"
+#. TRANSLATORS: this CLI tool is now preventing system updates
+#: src/fu-util.c:1278
+msgid "System Update Inhibited"
+msgstr "Posodobitev sistema je preprečena"
+
+#. TRANSLATORS: the device is already connected
+#: src/fu-util.c:1347 src/fu-util.c:1353
+msgid "Device already exists"
+msgstr "Naprava že obstaja"
+
+#. TRANSLATORS: the device showed up in time
+#: src/fu-util.c:1381
+#, c-format
+msgid "Successfully waited %.0fms for device"
+msgstr "Uspešno čakanje %.0fms za napravo"
+
+#. TRANSLATORS: device tests can be specific to a CPU type
+#: src/fu-util.c:1444
+#, c-format
+msgid "%u test was skipped"
+msgid_plural "%u tests were skipped"
+msgstr[0] "%u  preizkusov je preskočenih"
+msgstr[1] "%u  preizkus je preskočen"
+msgstr[2] "%u  preizkusa sta preskočena"
+msgstr[3] "%u preizkusi so preskočeni"
+
+#. show the user the entire data blob
+#: src/fu-util.c:1668 src/fu-util.c:4031 src/fu-util.c:4878
+msgid "Target"
+msgstr "Cilj"
+
+#: src/fu-util.c:1669 src/fu-util.c:4033 src/fu-util.c:4879
+msgid "Payload"
+msgstr "Obremenitev"
+
+#: src/fu-util.c:1671 src/fu-util.c:4035
+msgid "Signature"
+msgstr "Podpis"
+
+#: src/fu-util.c:1672 src/fu-util.c:4036
+msgid "Proceed with upload?"
+msgstr "Ali želite nadaljevati z nalaganjem na strežnik?"
+
+#. TRANSLATORS: the server sent the user a small message
+#: src/fu-util.c:1698
+msgid "Update failure is a known issue, visit this URL for more information:"
+msgstr ""
+"Napaka pri posodobitvi je znana težava, za več informacij obiščite ta URL:"
 
 #. TRANSLATORS: success message -- where the user has uploaded
 #. * success and/or failure reports to the remote server
+#: src/fu-util.c:1741
 #, c-format
 msgid "Successfully uploaded %u report"
 msgid_plural "Successfully uploaded %u reports"
@@ -2829,141 +2625,1798 @@ msgstr[1] "Uspešno naloženo %u poročilo"
 msgstr[2] "Uspešno naloženi %u poročili"
 msgstr[3] "Uspešno naložena %u poročila"
 
+#. TRANSLATORS: key for a offline report filename
+#: src/fu-util.c:1870
+msgid "Saved report"
+msgstr "Shranjeno poročilo"
+
+#. TRANSLATORS: %1 is a device name, e.g. "ThinkPad Universal
+#. * ThunderBolt 4 Dock" and %2 is "fwupdmgr activate"
+#: src/fu-util.c:1908
+#, c-format
+msgid "%s is pending activation; use %s to complete the update."
+msgstr "%s čaka na aktivacijo; uporabite %s za dokončanje posodobitve."
+
+#. TRANSLATORS: success message when user refreshes device checksums
+#: src/fu-util.c:2153
+msgid "Successfully updated device checksums"
+msgstr "Uspešno posodobljene kontrolne vsote naprave"
+
+#. TRANSLATORS: explain why no metadata available
+#: src/fu-util.c:2170
+msgid "No remotes are currently enabled so no metadata is available."
+msgstr ""
+"Oddaljeni strežniki trenutno niso omogočeni, zato metapodatki niso na voljo."
+
+#. TRANSLATORS: explain why no metadata available
+#: src/fu-util.c:2174
+msgid "Metadata can be obtained from the Linux Vendor Firmware Service."
+msgstr ""
+"Metapodatke je mogoče pridobiti iz storitve vdelane programske opreme "
+"ponudnika Linuxa (Linux Vendor Firmware Service)."
+
+#. TRANSLATORS: Turn on the remote
+#: src/fu-util.c:2177
+msgid "Enable this remote?"
+msgstr "Želite omogočiti ta oddaljeni strežnik?"
+
+#: src/fu-util.c:2266
+msgid "Updating"
+msgstr "Posodabljanje"
+
+#. TRANSLATORS: error message for a user who ran fwupdmgr
+#. * refresh recently -- %1 is '--force'
+#: src/fu-util.c:2296
+#, c-format
+msgid "Metadata is up to date; use %s to refresh again."
+msgstr "Metapodatki so posodobljeni; Uporabite %s za ponovno osvežitev."
+
+#. TRANSLATORS: success message -- where 'metadata' is information
+#. * about available firmware on the remote server
+#: src/fu-util.c:2320
+msgid "Successfully downloaded new metadata: "
+msgstr "Uspešno preneseni novi metapodatki: "
+
+#. TRANSLATORS: how many local devices can expect updates now
+#: src/fu-util.c:2324
+#, c-format
+msgid "Updates have been published for %u local device"
+msgid_plural "Updates have been published for %u of %u local devices"
+msgstr[0] "Posodobitve so objavljene za %u od %u krajevnih naprav"
+msgstr[1] "Posodobitve so objavljene za %u od %u krajevnih naprav"
+msgstr[2] "Posodobitve so objavljene za %u od %u krajevnih naprav"
+msgstr[3] "Posodobitve so objavljene za %u od %u krajevnih naprav"
+
+#. TRANSLATORS: success message -- the user can do this by-hand too
+#: src/fu-util.c:2370
+msgid "Successfully refreshed metadata manually"
+msgstr "Ročno uspešno osveženi metapodatki"
+
+#. TRANSLATORS: no repositories to download from
+#: src/fu-util.c:2428
+msgid "No releases available"
+msgstr "Izdaje niso na voljo"
+
+#. TRANSLATORS: get interactive prompt
+#: src/fu-util.c:2489
+msgid "Choose release"
+msgstr "Izberite izdajo"
+
 #. TRANSLATORS: success message when user verified device checksums
+#: src/fu-util.c:2520
 msgid "Successfully verified device checksums"
 msgstr "Uspešno preverjene kontrolne vsote naprave"
 
-#. TRANSLATORS: the device showed up in time
+#. TRANSLATORS: the metadata is very out of date; %u is a number > 1
+#: src/fu-util.c:2571
 #, c-format
-msgid "Successfully waited %.0fms for device"
-msgstr "Uspešno čakanje %.0fms za napravo"
+msgid ""
+"Firmware metadata has not been updated for %u day and may not be up to date."
+msgid_plural ""
+"Firmware metadata has not been updated for %u days and may not be up to date."
+msgstr[0] ""
+"Metapodatki vdelane programske oprem niso bili posodobljeni %u dan in morda "
+"niso aktualni."
+msgstr[1] ""
+"Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda "
+"niso aktualni."
+msgstr[2] ""
+"Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda "
+"niso aktualni."
+msgstr[3] ""
+"Metapodatki vdelane programske oprem niso bili posodobljeni %u dni in morda "
+"niso aktualni."
 
-#. TRANSLATORS: one line summary of device
-msgid "Summary"
-msgstr "Povzetek"
+#. TRANSLATORS: ask if we can update metadata
+#: src/fu-util.c:2581
+msgid "Update now?"
+msgstr "Želite posodobiti zdaj?"
 
-#. TRANSLATORS: Title: SMAP = Supervisor Mode Access Prevention
-msgid "Supervisor Mode Access Prevention"
-msgstr "Preprečevanje dostopa v načinu nadzornika"
+#. TRANSLATORS: this is an error string
+#: src/fu-util.c:2750
+msgid "No updatable devices"
+msgstr "Ni naprav, ki jih je mogoče posodobiti"
 
-#. TRANSLATORS: longer description
-msgid "Supervisor Mode Access Prevention ensures critical parts of device memory are not accessed by less secure programs."
-msgstr "Preprečitev dostopa do načina nadzornika zagotavlja, da do kritičnih delov pomnilnika naprave ne dostopajo manj varni programi."
+#. TRANSLATORS: this is an error string
+#: src/fu-util.c:2759
+msgid "No updates available"
+msgstr "Posodobitve niso na voljo"
 
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Supported"
-msgstr "Podprto"
+#. TRANSLATORS: no repositories to download from
+#: src/fu-util.c:2788
+msgid "No remotes available"
+msgstr "Oddaljeni strežniki niso na voljo"
 
-#. TRANSLATORS: Title: if fwupd supports HSI on this chip
-msgid "Supported CPU"
-msgstr "Podprta CPE"
+#. TRANSLATORS: BKC is the industry name for the best known configuration and is a set
+#. * of firmware that works together
+#: src/fu-util.c:2895
+#, c-format
+msgid "Your system is set up to the BKC of %s."
+msgstr "Vaš sistem je nastavljen na BKC %s."
+
+#. TRANSLATORS: %1 is the current device version number, and %2 is the
+#. command name, e.g. `fwupdmgr sync`
+#: src/fu-util.c:2901
+#, c-format
+msgid ""
+"This device will be reverted back to %s when the %s command is performed."
+msgstr "Ta naprava bo povrnjena nazaj na %s, ko bo izveden ukaz %s."
+
+#. TRANSLATORS: the best known configuration is a set of software that we know works
+#. * well together. In the OEM and ODM industries it is often called a BKC
+#: src/fu-util.c:2909
+msgid "Deviate from the best known configuration?"
+msgstr "Odstopate od najbolj znane konfiguracije?"
+
+#. TRANSLATORS: prompt to apply the update
+#: src/fu-util.c:2914 src/fu-util.c:4277 src/fu-util-common.c:380
+#: src/fu-util-common.c:2772
+msgid "Perform operation?"
+msgstr "Želite izvesti opravilo?"
+
+#. TRANSLATORS: ask if we can update the metadata
+#: src/fu-util.c:3323
+msgid "Do you want to refresh this remote now?"
+msgstr "Ali želite zdaj osvežiti ta oddaljeni strežnik?"
+
+#. TRANSLATORS: success message
+#: src/fu-util.c:3339
+msgid "Successfully enabled and refreshed remote"
+msgstr "Uspešno omogočen in osvežen oddaljeni strežnik"
+
+#. TRANSLATORS: message letting the user know no device downgrade available
+#. * %1 is the device name
+#: src/fu-util.c:3407
+#, c-format
+msgid "No downgrades for %s"
+msgstr "Ni povrnitev na starejšo različico za %s"
+
+#. TRANSLATORS: shown when shutting down to switch to the new version
+#: src/fu-util.c:3766
+msgid "Activating firmware update for"
+msgstr "Aktiviranje posodobitve vdelane programske opreme za"
+
+#. TRANSLATORS: success message -- where activation is making the new
+#. * firmware take effect, usually after updating offline
+#: src/fu-util.c:3780
+msgid "Successfully activated all devices"
+msgstr "Uspešno aktivirane vse naprave"
+
+#. TRANSLATORS: approved firmware has been checked by
+#. * the domain administrator
+#: src/fu-util.c:3852
+msgid "There is no approved firmware."
+msgstr "Ni odobrene vdelane programske opreme."
+
+#. TRANSLATORS: approved firmware has been checked by
+#. * the domain administrator
+#: src/fu-util.c:3858
+msgid "Approved firmware:"
+msgid_plural "Approved firmware:"
+msgstr[0] "Odobrena strojna programska oprema:"
+msgstr[1] "Odobrena strojna programska oprema:"
+msgstr[2] "Odobrena strojna programska oprema:"
+msgstr[3] "Odobrena strojna programska oprema:"
+
+#. TRANSLATORS: changes only take effect on restart
+#: src/fu-util.c:3901 src/fu-util.c:3937
+msgid "Restart the daemon to make the change effective?"
+msgstr "Želite znova zagnati prikriti proces, da bo sprememba uveljavljena?"
+
+#. TRANSLATORS: success message -- a per-system setting value
+#: src/fu-util.c:3946
+msgid "Successfully reset configuration values"
+msgstr "Uspešno ponastavljene konfiguracijske vrednosti"
+
+#. TRANSLATORS: ask the user to share, %s is something
+#. * like: "Linux Vendor Firmware Service"
+#: src/fu-util.c:4009
+#, c-format
+msgid "Upload these anonymous results to the %s to help other users?"
+msgstr ""
+"Želite naložiti te anonimne rezultate na %s, da pomagate drugim uporabnikom?"
+
+#. TRANSLATORS: success, so say thank you to the user
+#: src/fu-util.c:4060
+msgid "Host Security ID attributes uploaded successfully, thanks!"
+msgstr "Atributi varnostnega ID-ja gostitelja so bili uspešno naloženi, hvala!"
+
+#. TRANSLATORS: can we JFDI?
+#: src/fu-util.c:4068
+msgid "Automatically upload every time?"
+msgstr "Želite vsakič samodejno naložiti?"
+
+#. TRANSLATORS: title prefix for the BIOS settings dialog
+#: src/fu-util.c:4222
+msgid "Configuration Change Suggested"
+msgstr "Predlagana sprememba konfiguracije"
+
+#. TRANSLATORS: the %1 is a BIOS setting name.
+#. * %2 and %3 are the values, e.g. "True" or "Windows10"
+#: src/fu-util.c:4234
+#, c-format
+msgid ""
+"This tool can change the BIOS setting '%s' from '%s' to '%s' automatically, "
+"but it will only be active after restarting the computer."
+msgstr ""
+"To orodje lahko samodejno spremeni nastavitev BIOS-a »%s« iz »%s« v »%s«, "
+"vendar bo aktivna šele po ponovnem zagonu računalnika."
+
+#. TRANSLATORS: the user has to manually recover; we can't do it
+#: src/fu-util.c:4243
+msgid ""
+"You should ensure you are comfortable restoring the setting from the system "
+"firmware setup, as this change may cause the system to not boot into Linux "
+"or cause other system instability."
+msgstr ""
+"Prepričajte se, da želite obnoviti nastavitev iz nastavitve vdelane "
+"programske opreme sistema, saj lahko ta sprememba povzroči, da se sistem ne "
+"zažene v Linux ali povzroči drugo nestabilnost sistema."
+
+#. TRANSLATORS: the %1 is a kernel command line key=value
+#: src/fu-util.c:4253
+#, c-format
+msgid ""
+"This tool can change the kernel argument from '%s' to '%s', but it will only "
+"be active after restarting the computer."
+msgstr ""
+"To orodje lahko spremeni argument jedra iz »%s« v »%s«, vendar bo aktiven "
+"šele po vnovičnem zagonu računalnika."
+
+#. TRANSLATORS: the %1 is a kernel command line key=value
+#: src/fu-util.c:4261
+#, c-format
+msgid ""
+"This tool can add a kernel argument of '%s', but it will only be active "
+"after restarting the computer."
+msgstr ""
+"To orodje lahko doda argument jedra »%s«, vendar bo aktiven šele po "
+"vnovičnem zagonu računalnika."
+
+#. TRANSLATORS: the user has to manually recover; we can't do it
+#: src/fu-util.c:4268
+msgid ""
+"You should ensure you are comfortable restoring the setting from a recovery "
+"or installation disk, as this change may cause the system to not boot into "
+"Linux or cause other system instability."
+msgstr ""
+"Prepričajte se, da želite obnoviti nastavitev z obnovitvenega ali "
+"namestitvenega diska, saj lahko ta sprememba povzroči, da se sistem ne "
+"zažene v Linux ali povzroči drugo nestabilnost sistema."
+
+#. TRANSLATORS: error message
+#: src/fu-util.c:4471
+msgid "Unable to connect to service"
+msgstr "Povezave s storitvijo ni možno vzpostaviti"
+
+#. TRANSLATORS: error message
+#: src/fu-util.c:4480
+#, c-format
+msgid "Unsupported daemon version %s, client version is %s"
+msgstr "Nepodprta različica prikritega procesa %s, različica odjemalca je %s"
+
+#. TRANSLATORS: user selected something not possible
+#: src/fu-util.c:4576
+msgid "Firmware is already blocked"
+msgstr "Vdelana programska oprema je že blokirana"
+
+#. TRANSLATORS: we will not offer this firmware to the user
+#: src/fu-util.c:4581
+msgid "Blocking firmware:"
+msgstr "Blokiranje vdelane programske opreme:"
+
+#. TRANSLATORS: nothing to show
+#: src/fu-util.c:4612 src/fu-util.c:4662
+msgid "There are no blocked firmware files"
+msgstr "Ni blokiranih datotek vdelane programske opreme"
+
+#. TRANSLATORS: user selected something not possible
+#: src/fu-util.c:4631
+msgid "Firmware is not already blocked"
+msgstr "Vdelana programska oprema še ni blokirana"
+
+#. TRANSLATORS: we will now offer this firmware to the user
+#: src/fu-util.c:4636
+msgid "Unblocking firmware:"
+msgstr "Deblokiranje vdelane programske opreme:"
+
+#. TRANSLATORS: there follows a list of hashes
+#: src/fu-util.c:4667
+msgid "Blocked firmware files:"
+msgstr "Blokirane datoteke vdelane programske opreme:"
+
+#. TRANSLATORS: explain why we want to upload
+#: src/fu-util.c:4883
+#, c-format
+msgid ""
+"Uploading a device list allows the %s team to know what hardware exists, and "
+"allows us to put pressure on vendors that do not upload firmware updates for "
+"their hardware."
+msgstr ""
+"Nalaganje seznama naprav omogoča ekipi %s, da so seznanjeni, kakšna strojna "
+"oprema obstaja, ter da pritiskamo na tiste proizvajalce, ki ne nalagajo "
+"posodobitev vdelane programske opreme za svojo strojno opremo."
+
+#. TRANSLATORS: ask the user to upload
+#: src/fu-util.c:4891
+msgid "Upload data now?"
+msgstr "Želite zdaj naložiti podatke?"
+
+#. TRANSLATORS: success, so say thank you to the user
+#: src/fu-util.c:4917
+msgid "Device list uploaded successfully, thanks!"
+msgstr "Seznam naprav je uspešno naložen, hvala!"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5124
+msgid "Set the download retries for transient errors"
+msgstr "Nastavite število ponovnih poskusov za občasne napake"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5156
+msgid "Only install onto emulated devices"
+msgstr "Namesti samo na emulirane naprave"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5172
+msgid "Answer yes to all questions"
+msgstr "Na vsa vprašanja odgovori pritrdilno"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5180
+msgid "Sign the uploaded data with the client certificate"
+msgstr "Podpiši naložene podatke s potrdilom odjemalca"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5188
+msgid "Do not check for unreported history"
+msgstr "Ne preverjaj, ali je na voljo neprijavljena zgodovina"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5196
+msgid "Do not check for old metadata"
+msgstr "Ne preverjaj, ali so na voljo stari metapodatki"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5204
+msgid "Do not check if download remotes should be enabled"
+msgstr "Ne preverjaj, ali naj bodo omogočeni oddaljeni strežniki za prenos"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5236
+msgid "Do not write to the history database"
+msgstr "Ne piši v zbirko podatkov zgodovine"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5268
+msgid "Only use peer-to-peer networking when downloading files"
+msgstr "Omrežje vrstnikov uporabljaj samo pri prenosu datotek"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5302
+msgid "Do not prompt to fix security issues"
+msgstr "Ne pozivaj k odpravljanju varnostnih težav"
+
+#. TRANSLATORS: command line option
+#: src/fu-util.c:5310
+msgid "Don't prompt for authentication (less details may be shown)"
+msgstr ""
+"Ne pozivaj k preverjanju pristnosti (morda bo prikazanih manj podrobnosti)"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5345
+msgid "Check if any devices are pending a reboot to complete update"
+msgstr ""
+"Preveri, če katera od naprav čaka na ponoven zagon za zaključek posodobitve"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5363
+msgid "Share firmware history with the developers"
+msgstr "Deli zgodovino vdelane programske opreme z razvijalci"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5369
+msgid "Export firmware history for manual upload"
+msgstr "Izvozi zgodovino vdelane programske opreme za ročni prenos"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5374
+msgid "[DEVICE-ID|GUID] [VERSION]"
+msgstr "[ID-NAPRAVE|GUID] [RAZLIČICA]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5376
+msgid "Install a specific firmware file on all devices that match"
+msgstr ""
+"Namesti določeno datoteko vdelane programske opreme v vse naprave, ki se "
+"ujemajo"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5383
+msgid "Install a firmware file in cabinet format on this hardware"
+msgstr ""
+"Na to strojno opremo namesti datoteko vdelane programske opreme v obliki "
+"paketa"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5413
+msgid "Checks cryptographic hash matches firmware"
+msgstr ""
+"Preverja, da se kriptografska kontrolna vsota ujema z vdelano programsko "
+"opremo"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5420
+msgid "Unlocks the device for firmware access"
+msgstr "Odklene napravo za dostop do vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5427
+msgid "Clears the results from the last update"
+msgstr "Počisti rezultate zadnje posodobitve."
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5434
+msgid "Gets the results from the last update"
+msgstr "Pridobi rezultate zadnje posodobitve"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5441
+msgid "Gets the releases for a device"
+msgstr "Pridobi izdaje za napravo"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5454
+msgid "Downgrades the firmware on a device"
+msgstr "Zamenja vdelano programsko opremo naprave s starejšo različico"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5459
+msgid "[FILE FILE_SIG REMOTE-ID]"
+msgstr "[DATOTEKA PODP_DATOTEKE ID-ODDALJENEGA]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5468
+msgid "Update the stored cryptographic hash with current ROM contents"
+msgstr ""
+"Posodobite shranjeno kriptografsko kontrolno vsoto s trenutno vsebino ROM-a"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5496
+msgid "Activate devices"
+msgstr "Aktiviraj naprave"
+
+#. TRANSLATORS: firmware approved by the admin
+#: src/fu-util.c:5502
+msgid "Gets the list of approved firmware"
+msgstr "Pridobi seznam odobrene vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5507
+msgid "FILENAME|CHECKSUM1[,CHECKSUM2][,CHECKSUM3]"
+msgstr "IMEDATOTEKE|KONTR-VSOTA1[,KONTR-VSOTA2][,KONTR-VSOTA3]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5530
+msgid "Reinstall current firmware on the device"
+msgstr "V napravo znova namestite trenutno vdelano programsko opremo"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5549
+msgid "Sync firmware versions to the chosen configuration"
+msgstr ""
+"Sinhronizirajte različice vdelane programske opreme z izbrano konfiguracijo"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5554 src/fu-util.c:5561
+msgid "[CHECKSUM]"
+msgstr "[KONTROLNAVSOTA]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5556
+msgid "Blocks a specific firmware from being installed"
+msgstr "Blokira namestitev določene vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5563
+msgid "Unblocks a specific firmware from being installed"
+msgstr "Odblokira namestitev določene vdelane programske opreme"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5569
+msgid "Gets the list of blocked firmware"
+msgstr "Pridobi seznam blokirane vdelane programske opreme"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5580
+msgid "LOCATION"
+msgstr "MESTO"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5582
+msgid "Download a file"
+msgstr "Prejmite datoteko"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5587 src/fu-util.c:5594
+msgid "[FILENAME1] [FILENAME2]"
+msgstr "[IMEDATOTEKE1] [IMEDATOTEKE2]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5589
+msgid "Test a device using a JSON manifest"
+msgstr "Preskusite napravo z manifestom JSON"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5596
+msgid "Emulate a device using a JSON manifest"
+msgstr "Posnemajte napravo z manifestom JSON"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5601
+msgid "[REASON] [TIMEOUT]"
+msgstr "[REASON] [TIMEOUT]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5603
+msgid "Inhibit the system to prevent upgrades"
+msgstr "Nastavite sistem, da prepreči nadgradnje"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5608
+msgid "INHIBIT-ID"
+msgstr "ID-PREPREČI"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5610
+msgid "Uninhibit the system to allow upgrades"
+msgstr "Nastavite sistem, da omogoči nadgradnje"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5615
+msgid "GUID|DEVICE-ID"
+msgstr "GUID|ID-NAPRAVE"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5617
+msgid "Wait for a device to appear"
+msgstr "Počakajte, da se naprava prikaže"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5623
+msgid "Asks the daemon to quit"
+msgstr "Naroči prikritemu procesu, naj neha delovati"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5629
+msgid "[SETTING1] [SETTING2] [--no-authenticate]"
+msgstr "[NASTAVITEV1] [NASTAVITEV2] [--no-authenticate]"
+
+#. TRANSLATORS: command argument: uppercase, spaces->dashes
+#: src/fu-util.c:5636
+msgid "SETTING1 VALUE1 [SETTING2] [VALUE2]"
+msgstr "NASTAVITEV1 VREDNOST1 [NASTAVITEV2] [VREDNOST2]"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5638
+msgid "Sets one or more BIOS settings"
+msgstr "Nastavi eno ali več nastavitev BIOS-a"
+
+#. TRANSLATORS: command description
+#: src/fu-util.c:5686
+msgid "Upload the list of updatable devices to a remote server"
+msgstr "Naloži seznam posodobljivih naprav na oddaljeni strežnik"
+
+#. TRANSLATORS: CLI description
+#: src/fu-util.c:5722
+msgid ""
+"This tool allows an administrator to query and control the fwupd daemon, "
+"allowing them to perform actions such as installing or downgrading firmware."
+msgstr ""
+"To orodje omogoča skrbniku, da poizveduje in nadzoruje demona fwupd, kar mu "
+"omogoča izvajanje dejanj, kot je namestitev ali zamenjava vdelane programske "
+"opreme."
+
+#. TRANSLATORS: try to help
+#: src/fu-util.c:5759
+msgid ""
+"The system clock has not been set correctly and downloading files may fail."
+msgstr ""
+"Sistemska ura ni bila pravilno nastavljena in prenos datotek morda ne bo "
+"uspel."
+
+#. TRANSLATORS: error message for Windows
+#: src/fu-util.c:5862
+msgid "Failed to connect to Windows service, please ensure it's running."
+msgstr ""
+"Povezave s storitvijo Windows ni možno vzpostaviti, prepričajte se, da se "
+"izvaja."
+
+#. TRANSLATORS: could not contact the fwupd service over D-Bus
+#: src/fu-util.c:5866
+msgid "Failed to connect to daemon"
+msgstr "Povezave s prikritim procesom ni bilo mogoče vzpostaviti"
+
+#. TRANSLATORS: the user is SOL for support...
+#: src/fu-util.c:5876
+msgid ""
+"The daemon has loaded 3rd party code and is no longer supported by the "
+"upstream developers!"
+msgstr ""
+"Prikriti proces je naložil kodo tretje strani in razvijalci novih različic "
+"je ne podpirajo več!"
+
+#. TRANSLATORS: a feature is something like "can show an image"
+#: src/fu-util.c:5926
+msgid "Failed to set front-end features"
+msgstr "Nastavljanje funkcij pročelja ni uspelo"
+
+#. TRANSLATORS: The BIOS setting can only be changed to fixed values
+#: src/fu-util-bios-setting.c:33
+msgid "Enumeration"
+msgstr "Številčenje"
+
+#. TRANSLATORS: The BIOS setting only accepts integers in a fixed range
+#: src/fu-util-bios-setting.c:37
+msgid "Integer"
+msgstr "integer"
+
+#. TRANSLATORS: The BIOS setting accepts strings
+#: src/fu-util-bios-setting.c:41
+msgid "String"
+msgstr "Niz znakov"
+
+#. TRANSLATORS: type of BIOS setting
+#: src/fu-util-bios-setting.c:107
+msgid "Setting type"
+msgstr "Vrsta nastavitve"
+
+#. TRANSLATORS: tell a user how to get information
+#: src/fu-util-bios-setting.c:115
+#, c-format
+msgid "Run without '%s' to see"
+msgstr "Izvedite brez '%s' za ogled"
+
+#. TRANSLATORS: current value of a BIOS setting
+#: src/fu-util-bios-setting.c:118
+msgid "Current Value"
+msgstr "Trenutna vrednost"
+
+#. TRANSLATORS: description of BIOS setting
+#. TRANSLATORS: multiline description of device
+#: src/fu-util-bios-setting.c:124 src/fu-util-common.c:1968
+msgid "Description"
+msgstr "Opis"
+
+#. TRANSLATORS: item is TRUE
+#: src/fu-util-bios-setting.c:129
+msgid "True"
+msgstr "prav"
+
+#. TRANSLATORS: item is FALSE
+#: src/fu-util-bios-setting.c:132
+msgid "False"
+msgstr "napak"
+
+#. TRANSLATORS: BIOS setting is read only
+#: src/fu-util-bios-setting.c:135
+msgid "Read Only"
+msgstr "Samo za branje"
+
+#. TRANSLATORS: Lowest valid integer for BIOS setting
+#: src/fu-util-bios-setting.c:149
+msgid "Minimum value"
+msgstr "Najmanjša vrednost"
+
+#. TRANSLATORS: Highest valid integer for BIOS setting
+#: src/fu-util-bios-setting.c:151
+msgid "Maximum value"
+msgstr "N_ajvečja vrednost"
+
+#. TRANSLATORS: Scalar increment for integer BIOS setting
+#: src/fu-util-bios-setting.c:156
+msgid "Scalar Increment"
+msgstr "Skalarni prirastek"
+
+#. TRANSLATORS: Shortest valid string for BIOS setting
+#: src/fu-util-bios-setting.c:160
+msgid "Minimum length"
+msgstr "Najmanjša dolžina"
+
+#. TRANSLATORS: Longest valid string for BIOS setting
+#: src/fu-util-bios-setting.c:162
+msgid "Maximum length"
+msgstr "Največja dolžina"
+
+#. TRANSLATORS: Possible values for a bios setting
+#: src/fu-util-bios-setting.c:168
+msgid "Possible Values"
+msgstr "Možne vrednosti"
+
+#. TRANSLATORS: error message
+#: src/fu-util-bios-setting.c:200
+msgid "Invalid arguments"
+msgstr "Neveljavni argumenti"
+
+#. TRANSLATORS: the vendor did not upload this
+#: src/fu-util-common.c:268
+msgid ""
+"This firmware is provided by LVFS community members and is not provided (or "
+"supported) by the original hardware vendor."
+msgstr ""
+"To vdelano programsko opremo zagotavljajo člani skupnosti LVFS in je ne "
+"zagotavlja (ali podpira) prvotni prodajalec strojne opreme."
+
+#. TRANSLATORS: if it breaks, you get to keep both pieces
+#: src/fu-util-common.c:274
+msgid "Installing this update may also void any device warranty."
+msgstr "Namestitev te posodobitve lahko razveljavi tudi garancijo naprave."
+
+#. TRANSLATORS: naughty vendor
+#: src/fu-util-common.c:282
+msgid "The vendor did not supply any release notes."
+msgstr "Proizvajalec ni predložil opomb ob izdaji."
+
+#. TRANSLATORS: message letting the user know an downgrade is available
+#. * %1 is the device name and %2 and %3 are version strings
+#: src/fu-util-common.c:310
+#, c-format
+msgid "Downgrade %s from %s to %s?"
+msgstr "Želite povrniti %s s %s na starejšo %s?"
+
+#. TRANSLATORS: message letting the user know an upgrade is available
+#. * %1 is the device name and %2 and %3 are version strings
+#: src/fu-util-common.c:319
+#, c-format
+msgid "Upgrade %s from %s to %s?"
+msgstr "Želite nadgraditi %s s %s na %s?"
+
+#. TRANSLATORS: message letting the user know an upgrade is available
+#. * %1 is the device name and %2 is a version string
+#: src/fu-util-common.c:328
+#, c-format
+msgid "Reinstall %s to %s?"
+msgstr "Želite ponovno namestiti %s na %s?"
+
+#. TRANSLATORS: warn the user before updating, %1 is a device name
+#: src/fu-util-common.c:350
+#, c-format
+msgid "%s and all connected devices may not be usable while updating."
+msgstr "%s in vse povezane naprave med posodabljanjem morda ne bodo uporabne."
+
+#. TRANSLATORS: warn the user before
+#. * updating, %1 is a device name
+#.
+#: src/fu-util-common.c:362
+#, c-format
+msgid ""
+"%s must remain connected for the duration of the update to avoid damage."
+msgstr ""
+"%s mora ostati povezana ves čas trajanja posodobitve, da se prepreči škoda."
+
+#. TRANSLATORS: warn the user before updating, %1 is a machine
+#. * name
+#.
+#: src/fu-util-common.c:371
+#, c-format
+msgid ""
+"%s must remain plugged into a power source for the duration of the update to "
+"avoid damage."
+msgstr ""
+"%s mora ostati priključen na vir napajanja ves čas trajanja posodobitve, da "
+"se prepreči škoda."
+
+#. TRANSLATORS: explain why
+#: src/fu-util-common.c:401
+msgid "An update requires the system to shutdown to complete."
+msgstr "Posodobitev zahteva zaustavitev sistema, da bo dokončana."
+
+#. TRANSLATORS: shutdown to apply the update
+#: src/fu-util-common.c:404
+msgid "Shutdown now?"
+msgstr "Želite zaustaviti zdaj?"
+
+#. TRANSLATORS: explain why we want to reboot
+#: src/fu-util-common.c:415
+msgid "An update requires a reboot to complete."
+msgstr "Posodobitev zahteva vnovični zagon, da bo dokončana."
+
+#. TRANSLATORS: reboot to apply the update
+#: src/fu-util-common.c:417
+msgid "Restart now?"
+msgstr "Želite ponovno zagnati zdaj?"
+
+#. TRANSLATORS: this is a command alias, e.g. 'get-devices'
+#: src/fu-util-common.c:475
+#, c-format
+msgid "Alias to %s"
+msgstr "Vzdevek za %s"
+
+#. TRANSLATORS: error message
+#: src/fu-util-common.c:511
+msgid "Command not found"
+msgstr "Ukaz ni mogoče najti"
+
+#. TRANSLATORS: this is the default branch name when unset
+#: src/fu-util-common.c:560
+msgid "default"
+msgstr "privzeto"
+
+#. TRANSLATORS: a specific part of hardware,
+#. * the first %s is the device name, e.g. 'Unifying Receiver`
+#: src/fu-util-common.c:576
+#, c-format
+msgid "%s Device Update"
+msgstr "Posodobitev naprave %s"
+
+#. TRANSLATORS: a specific part of hardware,
+#. * the first %s is the device name, e.g. 'Secure Boot`
+#: src/fu-util-common.c:581
+#, c-format
+msgid "%s Configuration Update"
+msgstr "Posodobitev nastavitev %s"
+
+#. TRANSLATORS: the entire system, e.g. all internal devices,
+#. * the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:586
+#, c-format
+msgid "%s System Update"
+msgstr "Posodobitev sistema %s"
+
+#. TRANSLATORS: the EC is typically the keyboard controller chip,
+#. * the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:591
+#, c-format
+msgid "%s Embedded Controller Update"
+msgstr "Posodobitev vgrajenega krmilnika %s"
+
+#. TRANSLATORS: ME stands for Management Engine, the Intel AMT thing,
+#. * the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:596
+#, c-format
+msgid "%s ME Update"
+msgstr "Posodobitev ME %s"
+
+#. TRANSLATORS: ME stands for Management Engine (with Intel AMT),
+#. * where the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:601
+#, c-format
+msgid "%s Corporate ME Update"
+msgstr "Posodobitev poslovnega upravljalnika %s"
+
+#. TRANSLATORS: ME stands for Management Engine, where
+#. * the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:606
+#, c-format
+msgid "%s Consumer ME Update"
+msgstr "Posodobitev uporabniškega upravljalnika %s"
+
+#. TRANSLATORS: the controller is a device that has other devices
+#. * plugged into it, for example ThunderBolt, FireWire or USB,
+#. * the first %s is the device name, e.g. 'Intel ThunderBolt`
+#: src/fu-util-common.c:612
+#, c-format
+msgid "%s Controller Update"
+msgstr "Posodobitev krmilnika %s"
+
+#. TRANSLATORS: the Thunderbolt controller is a device that
+#. * has other high speed Thunderbolt devices plugged into it;
+#. * the first %s is the system name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:618
+#, c-format
+msgid "%s Thunderbolt Controller Update"
+msgstr "Posodobitev krmilnika Thunderbolt %s"
+
+#. TRANSLATORS: the CPU microcode is firmware loaded onto the CPU
+#. * at system boot-up
+#: src/fu-util-common.c:623
+#, c-format
+msgid "%s CPU Microcode Update"
+msgstr "Posodobitev mikrokode CPE %s"
+
+#. TRANSLATORS: battery refers to the system power source
+#: src/fu-util-common.c:627
+#, c-format
+msgid "%s Battery Update"
+msgstr "Posodobitev baterije %s"
+
+#. TRANSLATORS: camera can refer to the laptop internal
+#. * camera in the bezel or external USB webcam
+#: src/fu-util-common.c:632
+#, c-format
+msgid "%s Camera Update"
+msgstr "Posodobitev kamere %s"
+
+#. TRANSLATORS: TPM refers to a Trusted Platform Module
+#: src/fu-util-common.c:636
+#, c-format
+msgid "%s TPM Update"
+msgstr "Posodobitev modula okolja TPM %s"
+
+#. TRANSLATORS: TouchPad refers to a flat input device
+#: src/fu-util-common.c:640
+#, c-format
+msgid "%s Touchpad Update"
+msgstr "Posodobitev sledilne ploščice %s"
+
+#. TRANSLATORS: Mouse refers to a handheld input device
+#: src/fu-util-common.c:644
+#, c-format
+msgid "%s Mouse Update"
+msgstr "Posodobitev miške %s"
+
+#. TRANSLATORS: Keyboard refers to an input device for typing
+#: src/fu-util-common.c:648
+#, c-format
+msgid "%s Keyboard Update"
+msgstr "Posodobitev tipkovnice %s"
+
+#. TRANSLATORS: Storage Controller is typically a RAID or SAS adapter
+#: src/fu-util-common.c:652
+#, c-format
+msgid "%s Storage Controller Update"
+msgstr "Posodobitev krmilnika shrambe %s"
+
+#. TRANSLATORS: Network Interface refers to the physical
+#. * PCI card, not the logical wired connection
+#: src/fu-util-common.c:657
+#, c-format
+msgid "%s Network Interface Update"
+msgstr "Posodobitev omrežnega vmesnika %s"
+
+#. TRANSLATORS: Video Display refers to the laptop internal display or
+#. * external monitor
+#: src/fu-util-common.c:662
+#, c-format
+msgid "%s Display Update"
+msgstr "Posodobitev zaslona %s"
+
+#. TRANSLATORS: BMC refers to baseboard management controller which
+#. * is the device that updates all the other firmware on the system
+#: src/fu-util-common.c:667
+#, c-format
+msgid "%s BMC Update"
+msgstr "Posodobitev BMC %s"
+
+#. TRANSLATORS: Receiver refers to a radio device, e.g. a tiny Bluetooth
+#. * device that stays in the USB port so the wireless peripheral works
+#: src/fu-util-common.c:672
+#, c-format
+msgid "%s USB Receiver Update"
+msgstr "Posodobitev sprejemnika USB %s"
+
+#. TRANSLATORS: drive refers to a storage device, e.g. SATA disk
+#: src/fu-util-common.c:676
+#, c-format
+msgid "%s Drive Update"
+msgstr "Posodobitev naprave %s"
+
+#. TRANSLATORS: flash refers to solid state storage, e.g. UFS or eMMC
+#: src/fu-util-common.c:680
+#, c-format
+msgid "%s Flash Drive Update"
+msgstr "Posodobitev bliskovnega pogona %s"
+
+#. TRANSLATORS: SSD refers to a Solid State Drive, e.g. non-rotating
+#. * SATA or NVMe disk
+#: src/fu-util-common.c:685
+#, c-format
+msgid "%s SSD Update"
+msgstr "Posodobitev SSD %s"
+
+#. TRANSLATORS: GPU refers to a Graphics Processing Unit, e.g.
+#. * the "video card"
+#: src/fu-util-common.c:690
+#, c-format
+msgid "%s GPU Update"
+msgstr "Posodobitev GPE %s"
+
+#. TRANSLATORS: Dock refers to the port replicator hardware laptops are
+#. * cradled in, or lowered onto
+#: src/fu-util-common.c:695
+#, c-format
+msgid "%s Dock Update"
+msgstr "Posodobitev priklopne postaje %s"
+
+#. TRANSLATORS: Dock refers to the port replicator device connected
+#. * by plugging in a USB cable -- which may or may not also provide power
+#: src/fu-util-common.c:700
+#, c-format
+msgid "%s USB Dock Update"
+msgstr "Posodobitev priklopne postaje USB %s"
+
+#. TRANSLATORS: a device that can read your fingerprint pattern
+#: src/fu-util-common.c:704
+#, c-format
+msgid "%s Fingerprint Reader Update"
+msgstr "Posodobitev bralnika prstnih odtisov %s"
+
+#. TRANSLATORS: a large pressure-sensitive drawing area typically used
+#. * by artists and digital artists
+#: src/fu-util-common.c:709
+#, c-format
+msgid "%s Graphics Tablet Update"
+msgstr "Posodobitev grafične tablice %s"
+
+#. TRANSLATORS: an input device used by gamers, e.g. a joystick
+#: src/fu-util-common.c:713
+#, c-format
+msgid "%s Input Controller Update"
+msgstr "Posodobitev vhodnega krmilnika %s"
+
+#. TRANSLATORS: two miniature speakers attached to your ears
+#: src/fu-util-common.c:717
+#, c-format
+msgid "%s Headphones Update"
+msgstr "Posodobitev slušalk %s"
+
+#. TRANSLATORS: headphones with an integrated microphone
+#: src/fu-util-common.c:721
+#, c-format
+msgid "%s Headset Update"
+msgstr "Posodobitev slušalk z mikrofonom %s"
+
+#. TRANSLATORS: this is the fallback where we don't know if the release
+#. * is updating the system, the device, or a device class, or something else --
+#. * the first %s is the device name, e.g. 'ThinkPad P50`
+#: src/fu-util-common.c:728
+#, c-format
+msgid "%s Update"
+msgstr "Posodobitev %s"
+
+#. TRANSLATORS: duration in seconds
+#: src/fu-util-common.c:978
+#, c-format
+msgid "%u second"
+msgid_plural "%u seconds"
+msgstr[0] "%u s"
+msgstr[1] "%u s"
+msgstr[2] "%u s"
+msgstr[3] "%u s"
+
+#. TRANSLATORS: duration in minutes
+#: src/fu-util-common.c:985
+#, c-format
+msgid "%u minute"
+msgid_plural "%u minutes"
+msgstr[0] "%u minut"
+msgstr[1] "%u minuta"
+msgstr[2] "%u minuti"
+msgstr[3] "%u minute"
+
+#. TRANSLATORS: duration in minutes
+#: src/fu-util-common.c:992
+#, c-format
+msgid "%u hour"
+msgid_plural "%u hours"
+msgstr[0] "%u ur"
+msgstr[1] "%u ura"
+msgstr[2] "%u uri"
+msgstr[3] "%u ure"
+
+#. TRANSLATORS: duration in days!
+#: src/fu-util-common.c:998
+#, c-format
+msgid "%u day"
+msgid_plural "%u days"
+msgstr[0] "%u dni"
+msgstr[1] "%u dan"
+msgstr[2] "%u dneva"
+msgstr[3] "%u dnevi"
+
+#. TRANSLATORS: Device cannot be removed easily
+#: src/fu-util-common.c:1009
+msgid "Internal device"
+msgstr "Notranja naprava"
+
+#. TRANSLATORS: Device is updatable in this or any other mode
+#: src/fu-util-common.c:1014
+msgid "Updatable"
+msgstr "Posodobljivo"
+
+#. TRANSLATORS: Must be plugged into an outlet
+#: src/fu-util-common.c:1018
+msgid "System requires external power source"
+msgstr "Sistem zahteva zunanji vir napajanja"
+
+#. TRANSLATORS: Is locked and can be unlocked
+#: src/fu-util-common.c:1022
+msgid "Device is locked"
+msgstr "Naprava je zaklenjena"
 
 #. TRANSLATORS: Is found in current metadata
+#: src/fu-util-common.c:1026
 msgid "Supported on remote server"
 msgstr "Podprto na oddaljenem strežniku"
 
-#. TRANSLATORS: Title: a better sleep state
-msgid "Suspend To Idle"
-msgstr "Začasna prekinitev v mirovanje"
+#. TRANSLATORS: Requires a bootloader mode to be manually enabled by the user
+#: src/fu-util-common.c:1030
+msgid "Requires a bootloader"
+msgstr "Zahteva zagonski nalagalnik"
 
-#. TRANSLATORS: Title: sleep state
-msgid "Suspend To RAM"
-msgstr "Začasna prekinitev v pomnilnik RAM"
+#. TRANSLATORS: Requires a reboot to apply firmware or to reload hardware
+#: src/fu-util-common.c:1034
+msgid "Needs a reboot after installation"
+msgstr "Po namestitvi je potreben ponovni zagon"
 
-#. TRANSLATORS: longer description
-msgid "Suspend to Idle allows the device to quickly go to sleep in order to save power. While the device has been suspended, its memory could be physically removed and its information accessed."
-msgstr "Prekinitev v mirovanje omogoča napravi, da hitro preide v stanje mirovanja, da prihrani energijo. Ko je bila naprava začasno prekinjena, je bil njen pomnilnik fizično odstranjen in dostop do informacij."
+#. TRANSLATORS: Requires system shutdown to apply firmware
+#: src/fu-util-common.c:1038
+msgid "Needs shutdown after installation"
+msgstr "Po namestitvi je potrebna zaustavitev"
 
-#. TRANSLATORS: longer description
-msgid "Suspend to RAM allows the device to quickly go to sleep in order to save power. While the device has been suspended, its memory could be physically removed and its information accessed."
-msgstr "Prekinitev v RAM omogoča, da naprava hitro preide v stanje pripravljenosti, da prihrani energijo. Ko je bila naprava začasno prekinjena, je bil njen pomnilnik fizično odstranjen in dostop do informacij."
+#. TRANSLATORS: Has been reported to a metadata server
+#: src/fu-util-common.c:1042
+msgid "Reported to remote server"
+msgstr "Prijavljeno oddaljenemu strežniku"
 
-#. TRANSLATORS: Title: a better sleep state
-msgid "Suspend-to-idle"
-msgstr "Začasna prekinitev v mirovanje"
+#. TRANSLATORS: User has been notified
+#: src/fu-util-common.c:1046
+msgid "User has been notified"
+msgstr "Uporabnik je bil obveščen"
 
-#. TRANSLATORS: Title: sleep state
-msgid "Suspend-to-ram"
-msgstr "Začasna prekinitev v RAM"
+#. TRANSLATORS: Is currently in bootloader mode
+#: src/fu-util-common.c:1050
+msgid "Is in bootloader mode"
+msgstr "Je v načinu zagonskega nalagalnika"
 
-#. TRANSLATORS: show and ask user to confirm --
-#. * %1 is the old branch name, %2 is the new branch name
-#, c-format
-msgid "Switch branch from %s to %s?"
-msgstr "Želite preklopiti vejo iz %s v %s?"
+#. TRANSLATORS: the hardware is waiting to be replugged
+#: src/fu-util-common.c:1054
+msgid "Hardware is waiting to be replugged"
+msgstr "Strojna oprema čaka na ponovno priključitev"
 
-#. TRANSLATORS: command description
-msgid "Switch the firmware branch on the device"
-msgstr "Preklopite vejo vdelane programske opreme na napravi"
+#. TRANSLATORS: Device update needs to be separately activated
+#: src/fu-util-common.c:1062
+msgid "Device update needs activation"
+msgstr "Posodobitev naprave je treba aktivirati"
 
-#. TRANSLATORS: command description
-msgid "Sync firmware versions to the chosen configuration"
-msgstr "Sinhronizirajte različice vdelane programske opreme z izbrano konfiguracijo"
+#. TRANSLATORS: Device will not return after update completes
+#: src/fu-util-common.c:1070
+msgid "Device will not re-appear after update completes"
+msgstr "Naprava se po dokončanju posodobitve ne bo več prikazala"
 
-#. TRANSLATORS: Title: Whether firmware is locked down
-msgid "System Management Mode"
-msgstr "Način upravljanja sistema"
+#. TRANSLATORS: Device supports some form of checksum verification
+#: src/fu-util-common.c:1074
+msgid "Cryptographic hash verification is available"
+msgstr "Na voljo je preverjanje kriptografske kontrolne vsote"
 
-#. TRANSLATORS: this CLI tool is now preventing system updates
-msgid "System Update Inhibited"
-msgstr "Posodobitev sistema je preprečena"
+#. TRANSLATORS: Device supports a safety mechanism for flashing
+#: src/fu-util-common.c:1082
+msgid "Device stages updates"
+msgstr "Naprava ima več stopenj posodobitve"
 
-#. TRANSLATORS: longer description
-msgid "System management mode is used by the firmware to access resident BIOS code and data."
-msgstr "Način upravljanja sistema uporablja programje strojne opreme za dostop do kode in podatkov rezidenčnega BIOS-a."
+#. TRANSLATORS: Device supports a safety mechanism for flashing
+#: src/fu-util-common.c:1086
+msgid "Device can recover flash failures"
+msgstr "Naprava lahko obnovi napake bliskovnega pisanja"
+
+#. TRANSLATORS: Device remains usable during update
+#: src/fu-util-common.c:1090
+msgid "Device is usable for the duration of the update"
+msgstr "Naprava je uporabna ves čas trajanja posodobitve"
+
+#. TRANSLATORS: a version check is required for all firmware
+#: src/fu-util-common.c:1094
+msgid "Device firmware is required to have a version check"
+msgstr "Vdelana programska oprema naprave mora imeti preverjanje različice"
+
+#. TRANSLATORS: the device cannot update from A->C and has to go A->B->C
+#: src/fu-util-common.c:1098
+msgid "Device is required to install all provided releases"
+msgstr "Naprava je potrebna za namestitev vseh priloženih izdaj"
+
+#. TRANSLATORS: there is more than one supplier of the firmware
+#: src/fu-util-common.c:1102
+msgid "Device supports switching to a different branch of firmware"
+msgstr "Naprava podpira preklop na drugo vejo vdelane programske opreme"
+
+#. TRANSLATORS: save the old firmware to disk before installing the new one
+#: src/fu-util-common.c:1106
+msgid "Device will backup firmware before installing"
+msgstr ""
+"Naprava bo pred namestitvijo varnostno kopirala vdelano programsko opremo"
+
+#. TRANSLATORS: on some systems certain devices have to have matching versions,
+#. * e.g. the EFI driver for a given network card cannot be different
+#: src/fu-util-common.c:1111
+msgid "All devices of the same type will be updated at the same time"
+msgstr "Vse naprave iste vrste bodo posodobljene hkrati"
+
+#. TRANSLATORS: some devices can only be updated to a new semver and cannot
+#. * be downgraded or reinstalled with the existing version
+#: src/fu-util-common.c:1116
+msgid "Only version upgrades are allowed"
+msgstr "Dovoljene so samo nadgradnje različic"
+
+#. TRANSLATORS: currently unreachable, perhaps because it is in a lower power state
+#. * or is out of wireless range
+#: src/fu-util-common.c:1121
+msgid "Device is unreachable"
+msgstr "Naprava je nedosegljiva"
+
+#. TRANSLATORS: we might ask the user the recovery key when next booting Windows
+#: src/fu-util-common.c:1125
+msgid "Full disk encryption secrets may be invalidated when updating"
+msgstr ""
+"Skrivnosti polnega šifriranja diska se lahko pri posodabljanju razveljavijo"
+
+#. TRANSLATORS: the vendor is no longer supporting the device
+#: src/fu-util-common.c:1129
+msgid "End of life"
+msgstr "Konec življenjske dobe"
+
+#. TRANSLATORS: firmware is verified on-device the payload using strong crypto
+#: src/fu-util-common.c:1133
+msgid "Signed Payload"
+msgstr "Podpisani tovor"
+
+#. TRANSLATORS: firmware payload is unsigned and it is possible to modify it
+#: src/fu-util-common.c:1137
+msgid "Unsigned Payload"
+msgstr "Nepodpisani tovor"
+
+#. TRANSLATORS: this device is not actually real
+#: src/fu-util-common.c:1141
+msgid "Emulated"
+msgstr "Emulirani"
+
+#. TRANSLATORS: we're saving all USB events for emulation
+#: src/fu-util-common.c:1145
+msgid "Tagged for emulation"
+msgstr "Označeno za emulacijo"
+
+#. TRANSLATORS: stay on one firmware version unless the new version is explicitly
+#. * specified
+#: src/fu-util-common.c:1150
+msgid "Installing a specific release is explicitly required"
+msgstr "Namestitev določene izdaje je izrecno zahtevana"
+
+#. TRANSLATORS: we can save all device enumeration events for emulation
+#: src/fu-util-common.c:1154
+msgid "Can tag for emulation"
+msgstr "Lahko označite za emulacijo"
+
+#. TRANSLATORS: ask the user to do a simple task which should be translated
+#: src/fu-util-common.c:1169
+msgid "Message"
+msgstr "Sporočila"
+
+#. TRANSLATORS: show the user a generic image that can be themed
+#: src/fu-util-common.c:1173
+msgid "Image"
+msgstr "Slika"
+
+#. TRANSLATORS: ask the user a question, and it will not be translated
+#: src/fu-util-common.c:1177
+msgid "Message (custom)"
+msgstr "Sporočilo (po meri)"
+
+#. TRANSLATORS: show the user a random image from the internet
+#: src/fu-util-common.c:1181
+msgid "Image (custom)"
+msgstr "Slika (po meri)"
+
+#. TRANSLATORS: the update state of the specific device
+#: src/fu-util-common.c:1191
+msgid "Pending"
+msgstr "V čakanju"
+
+#. TRANSLATORS: the update state of the specific device
+#: src/fu-util-common.c:1195
+msgid "Success"
+msgstr "Uspešno zaključeno"
+
+#. TRANSLATORS: the update state of the specific device
+#: src/fu-util-common.c:1199
+msgid "Failed"
+msgstr "Napaka"
+
+#. TRANSLATORS: the update state of the specific device
+#: src/fu-util-common.c:1203
+msgid "Transient failure"
+msgstr "Začasen neuspeh"
+
+#. TRANSLATORS: the update state of the specific device
+#: src/fu-util-common.c:1207
+msgid "Needs reboot"
+msgstr "Potreben je ponovni zagon"
 
 #. TRANSLATORS: as in laptop battery power
+#: src/fu-util-common.c:1223
 msgid "System power is too low"
 msgstr "Napolnjenost sistemske baterije je prenizka"
 
 #. TRANSLATORS: as in laptop battery power
+#: src/fu-util-common.c:1227
 #, c-format
 msgid "System power is too low (%u%%, requires %u%%)"
-msgstr "Napolnjenost sistemske baterije je prenizka (%u %%, potrebnih je %u %%)"
+msgstr ""
+"Napolnjenost sistemske baterije je prenizka (%u %%, potrebnih je %u %%)"
 
-#. TRANSLATORS: Must be plugged into an outlet
-msgid "System requires external power source"
-msgstr "Sistem zahteva zunanji vir napajanja"
+#. TRANSLATORS: for example, a Bluetooth mouse that is in powersave mode
+#: src/fu-util-common.c:1233
+msgid "Device is unreachable, or out of wireless range"
+msgstr "Naprava je nedosegljiva ali je zunaj brezžičnega območja"
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "TEXT"
-msgstr "BESEDILO"
+#. TRANSLATORS: for example the batteries *inside* the Bluetooth mouse
+#: src/fu-util-common.c:1239
+msgid "Device battery power is too low"
+msgstr "Napetost baterije naprave je prenizka"
 
-#. TRANSLATORS: longer description
-msgid "TPM (Trusted Platform Module) is a computer chip that detects when hardware components have been tampered with."
-msgstr "TPM (Trusted Platform Module) je računalniški čip, ki zazna, kdaj so bile spremenjene komponente strojne opreme."
+#. TRANSLATORS: for example the batteries *inside* the Bluetooth mouse
+#: src/fu-util-common.c:1242
+#, c-format
+msgid "Device battery power is too low (%u%%, requires %u%%)"
+msgstr ""
+"Napolnjenost baterije naprave je prenizka (%u %%, zahtevano je vsaj %u %%)"
 
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-msgid "TPM PCR0 reconstruction"
-msgstr "Rekonstrukcija TPM PCR0"
+#. TRANSLATORS: usually this is when we're waiting for a reboot
+#: src/fu-util-common.c:1248
+msgid "Device is waiting for the update to be applied"
+msgstr "Naprava je pripravljena za uveljavitev posodobitve"
 
-#. TRANSLATORS: HSI event title
-msgid "TPM PCR0 reconstruction is invalid"
-msgstr "Rekonstrukcija TPM PCR0 ni veljavna"
+#. TRANSLATORS: as in, wired mains power for a laptop
+#: src/fu-util-common.c:1252
+msgid "Device requires AC power to be connected"
+msgstr "Naprava mora biti priključena na električno omrežje"
 
-#. TRANSLATORS: HSI event title
-msgid "TPM PCR0 reconstruction is now valid"
-msgstr "Rekonstrukcija TPM PCR0 je zdaj veljavna"
+#. TRANSLATORS: lid means "laptop top cover"
+#: src/fu-util-common.c:1256
+msgid "Device cannot be updated while the lid is closed"
+msgstr "Naprave ni mogoče posodobiti, ko je pokrov zaprt"
 
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be
-#. empty
-msgid "TPM Platform Configuration"
-msgstr "Konfiguracija platforme TPM"
+#. TRANSLATORS: emulated means we are pretending to be a different model
+#: src/fu-util-common.c:1260
+msgid "Device is emulated"
+msgstr "Naprava je emulirana"
 
-#. TRANSLATORS: Title: the PCR is rebuilt from the TPM event log
-msgid "TPM Reconstruction"
-msgstr "Rekonstrukcija TPM"
+#. TRANSLATORS: The device cannot be updated due to missing vendor's license."
+#: src/fu-util-common.c:1264
+msgid "Device requires a software license to update"
+msgstr "Naprava za posodobitev potrebuje licenco programske opreme"
 
-#. TRANSLATORS: Title: PCRs (Platform Configuration Registers) shouldn't be
-#. empty
-msgid "TPM empty PCRs"
-msgstr "Prazni PCR-ji TPM"
+#. TRANSLATORS: an application is preventing system updates
+#: src/fu-util-common.c:1268
+msgid "All devices are prevented from update by system inhibit"
+msgstr "Sistem preprečuje posodobitev vsem napravam"
 
-#. TRANSLATORS: Title: TPM = Trusted Platform Module
-msgid "TPM v2.0"
-msgstr "TPM v2.0"
+#. TRANSLATORS: another application is updating the device already
+#: src/fu-util-common.c:1272
+msgid "An update is in progress"
+msgstr "Posodobitev je v teku"
+
+#. TRANSLATORS: device cannot be interrupted, for instance taking a phone call
+#: src/fu-util-common.c:1276
+msgid "Device is in use"
+msgstr "Naprava je v uporabi"
+
+#. TRANSLATORS: device does not have a display connected
+#: src/fu-util-common.c:1280
+msgid "Device requires a display to be plugged in"
+msgstr "Naprava zahteva, da je zaslon priključen"
+
+#. TRANSLATORS: we have two ways of communicating with the device, so we hide one
+#: src/fu-util-common.c:1284
+msgid "Device is lower priority than an equivalent device"
+msgstr "Naprava ima nižjo prednost kot ekvivalentna naprava"
+
+#. TRANSLATORS: Name of hardware
+#: src/fu-util-common.c:1315
+msgid "Unknown Device"
+msgstr "Neznana naprava"
+
+#. TRANSLATORS: ID for hardware, typically a SHA1 sum
+#: src/fu-util-common.c:1320
+msgid "Device ID"
+msgstr "Določilo ID naprave"
+
+#. TRANSLATORS: one line summary of device
+#: src/fu-util-common.c:1323 src/fu-util-common.c:1881
+msgid "Summary"
+msgstr "Povzetek"
+
+#. TRANSLATORS: version number of previous firmware
+#: src/fu-util-common.c:1340
+msgid "Previous version"
+msgstr "Prejšnja različica"
+
+#. TRANSLATORS: version number of current firmware
+#: src/fu-util-common.c:1344
+msgid "Current version"
+msgstr "Trenutna različica"
+
+#. TRANSLATORS: smallest version number installable on device
+#: src/fu-util-common.c:1350
+msgid "Minimum Version"
+msgstr "Najmanjša različica"
+
+#. TRANSLATORS: firmware version of bootloader
+#: src/fu-util-common.c:1355
+msgid "Bootloader Version"
+msgstr "Različica zagonskega nalagalnika"
+
+#. TRANSLATORS: manufacturer of hardware
+#: src/fu-util-common.c:1364 src/fu-util-common.c:1367
+#: src/fu-util-common.c:1371 src/fu-util-common.c:1928
+msgid "Vendor"
+msgstr "Ponudnik"
+
+#. TRANSLATORS: the stream of firmware, e.g. nonfree
+#: src/fu-util-common.c:1378
+msgid "Release Branch"
+msgstr "Veja izdaje"
+
+#. TRANSLATORS: length of time the update takes to apply
+#: src/fu-util-common.c:1386
+msgid "Install Duration"
+msgstr "Trajanje namestitve"
+
+#. TRANSLATORS: serial number of hardware
+#: src/fu-util-common.c:1390
+msgid "Serial Number"
+msgstr "Serijska številka"
+
+#. TRANSLATORS: hardware state, e.g. "pending"
+#: src/fu-util-common.c:1398
+msgid "Update State"
+msgstr "Posodobi stanje"
+
+#. TRANSLATORS: first percentage is current value, 2nd percentage is the
+#. * lowest limit the firmware update is allowed for the update to happen
+#: src/fu-util-common.c:1409
+#, c-format
+msgid "%u%% (threshold %u%%)"
+msgstr "%u %% (prag %u%%)"
+
+#. TRANSLATORS: refers to the battery inside the peripheral device
+#: src/fu-util-common.c:1413 src/fu-util-common.c:1418
+msgid "Battery"
+msgstr "Baterija"
+
+#. TRANSLATORS: error message from last update attempt
+#: src/fu-util-common.c:1429
+msgid "Update Error"
+msgstr "Napaka pri posodobitvi"
+
+#. TRANSLATORS: reasons the device is not updatable
+#: src/fu-util-common.c:1433
+msgid "Problems"
+msgstr "Težave"
+
+#. TRANSLATORS: the original time/date the device was modified
+#: src/fu-util-common.c:1453
+msgid "Last modified"
+msgstr "Nazadnje spremenjeno"
+
+#. TRANSLATORS: global ID common to all similar hardware
+#: src/fu-util-common.c:1479
+msgid "GUID"
+msgid_plural "GUIDs"
+msgstr[0] "GUID-ji"
+msgstr[1] "GUID"
+msgstr[2] "GUID-ja"
+msgstr[3] "GUID-ji"
+
+#. TRANSLATORS: description of device ability
+#: src/fu-util-common.c:1487
+msgid "Device Flags"
+msgstr "Zastavice naprave"
+
+#. TRANSLATORS: description of the device requests
+#: src/fu-util-common.c:1508
+msgid "Device Requests"
+msgstr "Zahteve naprave"
+
+#. TRANSLATORS: issue fixed with the release, e.g. CVE
+#: src/fu-util-common.c:1532 src/fu-util-common.c:1977
+msgid "Issue"
+msgid_plural "Issues"
+msgstr[0] "Težave"
+msgstr[1] "Težava"
+msgstr[2] "Težavi"
+msgstr[3] "Težave"
+
+#. TRANSLATORS: Plugin is active only if hardware is found
+#: src/fu-util-common.c:1558
+msgid "Enabled if hardware matches"
+msgstr "Omogočeno, če se strojna oprema ujema"
+
+#. TRANSLATORS: Plugin is active and in use
+#: src/fu-util-common.c:1562
+msgid "Ready"
+msgstr "Pripravljeno"
+
+#. TRANSLATORS: Plugin is inactive and not used
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:1566 src/fu-util-common.c:2183
+msgid "Disabled"
+msgstr "Onemogočeno"
+
+#. TRANSLATORS: not required for this system
+#: src/fu-util-common.c:1570
+msgid "Required hardware was not found"
+msgstr "Zahtevane strojne opreme ni bilo mogoče najti"
+
+#. TRANSLATORS: system is not booted in UEFI mode
+#: src/fu-util-common.c:1574
+msgid "UEFI firmware can not be updated in legacy BIOS mode"
+msgstr ""
+"Vdelane programske opreme UEFI ni mogoče posodobiti v zastarelem načinu BIOS-"
+"a"
+
+#. TRANSLATORS: capsule updates are an optional BIOS feature
+#: src/fu-util-common.c:1579
+msgid "UEFI capsule updates not available or enabled in firmware setup"
+msgstr ""
+"Posodobitve kapsul UEFI niso na voljo ali omogočene pri nastavitvi vdelane "
+"programske opreme"
+
+#. TRANSLATORS: user needs to run a command, %1 is 'fwupdmgr unlock'
+#: src/fu-util-common.c:1583
+#, c-format
+msgid "Firmware updates disabled; run '%s' to enable"
+msgstr ""
+"Posodobitve vdelane programske opreme so onemogočene; zaženite »%s«, da jih "
+"omogočite"
+
+#. TRANSLATORS: user needs to run a command
+#: src/fu-util-common.c:1588
+msgid "Authentication details are required"
+msgstr "Zahtevane so podrobnosti preverjanja pristnosti"
+
+#. TRANSLATORS: no peeking
+#: src/fu-util-common.c:1592
+msgid "Configuration is only readable by the system administrator"
+msgstr "Konfiguracijo lahko prebere le skrbnik sistema"
+
+#. TRANSLATORS: the plugin was created from a .so object, and was not built-in
+#: src/fu-util-common.c:1596
+msgid "Loaded from an external module"
+msgstr "Naloženo iz zunanjega modula"
+
+#. TRANSLATORS: check various UEFI and ACPI tables are unchanged after the update
+#: src/fu-util-common.c:1600
+msgid "Will measure elements of system integrity around an update"
+msgstr "Izmeri elemente integritete sistema okoli posodobitve"
+
+#. TRANSLATORS: the user is using Gentoo/Arch and has screwed something up
+#: src/fu-util-common.c:1604
+msgid "Required efivarfs filesystem was not found"
+msgstr "Zahtevanega datotečnega sistema efivarfs ni bilo mogoče najti"
+
+#. TRANSLATORS: partition refers to something on disk, again, hey Arch users
+#: src/fu-util-common.c:1608
+msgid "UEFI ESP partition not detected or configured"
+msgstr "Razdelek UEFI ESP ni zaznan ali konfiguriran"
+
+#. TRANSLATORS: partition refers to something on disk, again, hey Arch users
+#: src/fu-util-common.c:1612
+msgid "UEFI ESP partition may not be set up correctly"
+msgstr "Razdelek UEFI ESP morda ni pravilno nastavljen"
+
+#. TRANSLATORS: Failed to open plugin, hey Arch users
+#: src/fu-util-common.c:1616
+msgid "Plugin dependencies missing"
+msgstr "Manjkajo odvisnosti vstavkov"
+
+#. TRANSLATORS: The kernel does not support this plugin
+#: src/fu-util-common.c:1620
+msgid "Running kernel is too old"
+msgstr "Izvajalno jedro je prestaro"
+
+#. TRANSLATORS: The plugin is only for testing
+#: src/fu-util-common.c:1624
+msgid "Plugin is only for testing"
+msgstr "Vstavek je namenjen le preizkušanju"
+
+#. TRANSLATORS: The plugin enumeration might change the device current mode
+#: src/fu-util-common.c:1628
+msgid "Plugin enumeration may change device state"
+msgstr "Oštevilčenje vstavkov lahko spremeni stanje naprave"
+
+#. TRANSLATORS: description of plugin state, e.g. disabled
+#: src/fu-util-common.c:1683
+msgid "Flags"
+msgstr "Zastavice"
+
+#. TRANSLATORS: a non-free software license
+#: src/fu-util-common.c:1728
+msgid "Proprietary"
+msgstr "Lastniško"
+
+#. TRANSLATORS: the release urgency
+#: src/fu-util-common.c:1742
+msgid "Low"
+msgstr "Nizko"
+
+#. TRANSLATORS: the release urgency
+#: src/fu-util-common.c:1746
+msgid "Medium"
+msgstr "Srednje"
+
+#. TRANSLATORS: the release urgency
+#: src/fu-util-common.c:1750
+msgid "High"
+msgstr "Visoko"
+
+#. TRANSLATORS: the release urgency
+#: src/fu-util-common.c:1754
+msgid "Critical"
+msgstr "Kritično"
+
+#. TRANSLATORS: We verified the payload against the server
+#: src/fu-util-common.c:1767
+msgid "Trusted payload"
+msgstr "Zaupanja vreden tovor"
+
+#. TRANSLATORS: We verified the metadata against the server
+#: src/fu-util-common.c:1771
+msgid "Trusted metadata"
+msgstr "Zaupanja vredni metapodatki"
+
+#. TRANSLATORS: version is newer
+#: src/fu-util-common.c:1775
+msgid "Is upgrade"
+msgstr "Je nadgradnja"
+
+#. TRANSLATORS: version is older
+#: src/fu-util-common.c:1779
+msgid "Is downgrade"
+msgstr "Je povrnitev na starejšo različico"
+
+#. TRANSLATORS: version cannot be installed due to policy
+#: src/fu-util-common.c:1783
+msgid "Blocked version"
+msgstr "Blokirana različica"
+
+#. TRANSLATORS: version cannot be installed due to policy
+#: src/fu-util-common.c:1787
+msgid "Not approved"
+msgstr "Ni odobreno"
+
+#. TRANSLATORS: is not the main firmware stream
+#: src/fu-util-common.c:1791
+msgid "Alternate branch"
+msgstr "Nadomestna veja"
+
+#. TRANSLATORS: is not supported by the vendor
+#: src/fu-util-common.c:1795
+msgid "Community supported"
+msgstr "Podprto s strani skupnosti"
+
+#. TRANSLATORS: someone we trust has tested this
+#: src/fu-util-common.c:1799
+msgid "Tested by trusted vendor"
+msgstr "Preizkušeno s strani zaupanja vrednega proizvajalca"
+
+#. TRANSLATORS: the %s is a vendor name, e.g. Lenovo
+#: src/fu-util-common.c:1812
+#, c-format
+msgid "Tested by %s"
+msgstr "Preizkušeno s strani %s"
+
+#. TRANSLATORS: when the release was tested
+#: src/fu-util-common.c:1815
+msgid "Tested"
+msgstr "Preizkušeno"
+
+#. TRANSLATORS: the OS the release was tested on
+#: src/fu-util-common.c:1827
+msgid "Distribution"
+msgstr "Distribucija"
+
+#. TRANSLATORS: the firmware old version
+#: src/fu-util-common.c:1832
+msgid "Old version"
+msgstr "Stara različica"
+
+#. TRANSLATORS: the fwupd version the release was tested on
+#: src/fu-util-common.c:1838
+msgid "Version[fwupd]"
+msgstr "Različica[fwupd]"
+
+#. TRANSLATORS: version number of new firmware
+#: src/fu-util-common.c:1861
+msgid "New version"
+msgstr "Nova različica"
+
+#. TRANSLATORS: the server the file is coming from
+#. TRANSLATORS: remote identifier, e.g. lvfs-testing
+#: src/fu-util-common.c:1866 src/fu-util-common.c:2020
+msgid "Remote ID"
+msgstr "ID oddaljenega strežnika"
+
+#. TRANSLATORS: the exact component on the server
+#: src/fu-util-common.c:1871
+msgid "Release ID"
+msgstr "ID izdaje"
+
+#. TRANSLATORS: the stream of firmware, e.g. nonfree
+#: src/fu-util-common.c:1876
+msgid "Branch"
+msgstr "Veja"
+
+#. TRANSLATORS: one line variant of release (e.g. 'China')
+#: src/fu-util-common.c:1886
+msgid "Variant"
+msgstr "Različica"
+
+#. TRANSLATORS: e.g. GPLv2+, Proprietary etc
+#: src/fu-util-common.c:1892
+msgid "License"
+msgstr "Dovoljenje"
+
+#. TRANSLATORS: file size of the download
+#: src/fu-util-common.c:1895
+msgid "Size"
+msgstr "Velikost"
+
+#. TRANSLATORS: when the update was built
+#: src/fu-util-common.c:1897
+msgid "Created"
+msgstr "Ustvarjeno"
+
+#. TRANSLATORS: how important the release is
+#: src/fu-util-common.c:1903
+msgid "Urgency"
+msgstr "Nujnost"
+
+#. TRANSLATORS: more details about the update link
+#: src/fu-util-common.c:1913
+msgid "Details"
+msgstr "Podrobnosti"
+
+#. TRANSLATORS: source (as in code) link
+#: src/fu-util-common.c:1918
+msgid "Source"
+msgstr "Vir"
+
+#. TRANSLATORS: Software Bill of Materials link
+#: src/fu-util-common.c:1923
+msgid "SBOM"
+msgstr "SBOM"
+
+#. TRANSLATORS: length of time the update takes to apply
+#: src/fu-util-common.c:1934
+msgid "Duration"
+msgstr "Trajanje"
+
+#. TRANSLATORS: helpful messages for the update
+#: src/fu-util-common.c:1939
+msgid "Update Message"
+msgstr "Posodobi sporočilo"
+
+#. TRANSLATORS: helpful image for the update
+#: src/fu-util-common.c:1944
+msgid "Update Image"
+msgstr "Posodobi sliko"
+
+#. TRANSLATORS: release attributes
+#: src/fu-util-common.c:1948
+msgid "Release Flags"
+msgstr "Zastavice izdaje"
 
 #. TRANSLATORS: release tag set for release, e.g. lenovo-2021q3
+#: src/fu-util-common.c:1989
 msgid "Tag"
 msgid_plural "Tags"
 msgstr[0] "Oznake"
@@ -2971,632 +4424,432 @@ msgstr[1] "Oznaka"
 msgstr[2] "Oznaki"
 msgstr[3] "Oznake"
 
-#. TRANSLATORS: we're saving all USB events for emulation
-msgid "Tagged for emulation"
-msgstr "Označeno za emulacijo"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Tainted"
-msgstr "V nevarnosti"
-
-#. show the user the entire data blob
-msgid "Target"
-msgstr "Cilj"
-
-#. TRANSLATORS: command description
-msgid "Test a device using a JSON manifest"
-msgstr "Preskusite napravo z manifestom JSON"
-
-#. TRANSLATORS: when the release was tested
-msgid "Tested"
-msgstr "Preizkušeno"
-
-#. TRANSLATORS: the %s is a vendor name, e.g. Lenovo
-#, c-format
-msgid "Tested by %s"
-msgstr "Preizkušeno s strani %s"
-
-#. TRANSLATORS: someone we trust has tested this
-msgid "Tested by trusted vendor"
-msgstr "Preizkušeno s strani zaupanja vrednega proizvajalca"
-
-#. TRANSLATORS: the boot entry was in a legacy format
-msgid "The EFI boot entry is not in hive format, and shim may not be new enough to read it."
-msgstr "Zagonski vnos za EFI ni v obliki satovja, povezovalni element morda ni dovolj nov, da bi ga lahko prebral."
-
-#. TRANSLATORS: try to treat the legacy format as a hive
-msgid "The EFI boot entry was not in hive format, falling back"
-msgstr "Zagonski vnos za EFI ni v obliki satovja, povrnitev v prejšnje stanje"
-
-#. TRANSLATORS: longer description
-msgid "The Intel Management Engine Key Manifest must be valid so that the device firmware can be trusted by the CPU."
-msgstr "Manifest ključa Intel Management Engine mora biti veljaven, tako da lahko CPE zaupa strojni programski opremi naprave."
-
-#. TRANSLATORS: longer description
-msgid "The Intel Management Engine controls device components and needs to have a recent version to avoid security issues."
-msgstr "Intel Management Engine nadzoruje komponente naprave in mora imeti najnovejšo različico, da se izogne varnostnim težavam."
-
-#. TRANSLATORS: do not translate the variables marked using $
-msgid "The LVFS is a free service that operates as an independent legal entity and has no connection with $OS_RELEASE:NAME$. Your distributor may not have verified any of the firmware updates for compatibility with your system or connected devices. All firmware is provided only by the original equipment manufacturer."
-msgstr "LVFS je brezplačna storitev, ki deluje kot samostojna pravna oseba in nima nobene povezave z $OS_RELEASE:NAME$. Vaš distributer morda ni preveril nobene posodobitve strojno programske opreme za združljivost z vašim sistemom ali priključenimi napravami. Vso strojno programsko opremo zagotavlja samo originalni proizvajalec opreme."
-
-#. TRANSLATORS: longer description
-msgid "The TPM (Trusted Platform Module) Platform Configuration is used to check whether the device start process has been modified."
-msgstr "Konfiguracija platforme modula zaupanja TPM (Trusted Platform Module) se uporablja za preverjanje, ali je bil postopek zagona naprave spremenjen."
-
-#. TRANSLATORS: longer description
-msgid "The TPM (Trusted Platform Module) Reconstruction is used to check whether the device start process has been modified."
-msgstr "Rekonstrukcija modula zaupanja TPM (Trusted Platform Module) se uporablja za preverjanje, ali je bil postopek zagona naprave spremenjen."
-
-#. TRANSLATORS: this is more background on a security measurement problem
-msgid "The TPM PCR0 differs from reconstruction."
-msgstr "TPM PCR0 se razlikuje od rekonstrukcije."
-
-#. TRANSLATORS: longer description
-msgid "The UEFI Platform Key is used to determine if device software comes from a trusted source."
-msgstr "Ključ platforme UEFI se uporablja za ugotavljanje, ali programska oprema naprave prihaja iz zaupanja vrednega vira."
-
-#. TRANSLATORS: HSI event title
-msgid "The UEFI certificate store is now up to date"
-msgstr "Shramba potrdil UEFI je zdaj posodobljena"
-
-#. TRANSLATORS: longer description
-msgid "The UEFI db contains the list of valid certificates that can be used to authorize what EFI binaries are allowed to run."
-msgstr "Zbirka podatkov UEFI vsebuje seznam veljavnih potrdil, ki jih lahko uporabite za overjanje, katere izvršne datoteke EFI je dovoljeno izvajati."
-
-#. TRANSLATORS: longer description
-msgid "The UEFI system can set up memory attributes at boot which prevent common exploits from running."
-msgstr "Sistem UEFI lahko nastavi atribute pomnilnika ob zagonu, ki preprečujejo pogosta vsiljena izvajanja pred izvršitvijo."
-
-#. TRANSLATORS: the user is SOL for support...
-msgid "The daemon has loaded 3rd party code and is no longer supported by the upstream developers!"
-msgstr "Prikriti proces je naložil kodo tretje strani in razvijalci novih različic je ne podpirajo več!"
-
-#. TRANSLATORS: %1 is the firmware vendor, %2 is the device vendor name
-#, c-format
-msgid "The firmware from %s is not supplied by %s, the hardware vendor."
-msgstr "Vdelane programske opreme podjetja %s ne dobavlja %s, izdelovalec strojne opreme."
-
-#. TRANSLATORS: try to help
-msgid "The system clock has not been set correctly and downloading files may fail."
-msgstr "Sistemska ura ni bila pravilno nastavljena in prenos datotek morda ne bo uspel."
-
-#. TRANSLATORS: warning message shown after update has been scheduled
-msgid "The update will continue when the device USB cable has been re-inserted."
-msgstr "Posodobitev se bo nadaljevala, ko bo kabel naprave USB znova vstavljen."
-
-#. TRANSLATORS: warning message shown after update has been scheduled
-msgid "The update will continue when the device USB cable has been unplugged and then re-inserted."
-msgstr "Posodobitev se bo nadaljevala, ko bo kabel naprave  USB izključen in nato znova vstavljen."
-
-#. TRANSLATORS: warning message shown after update has been scheduled
-msgid "The update will continue when the device USB cable has been unplugged."
-msgstr "Posodobitev se bo nadaljevala, ko bo kabel naprave USB izključen."
-
-#. TRANSLATORS: warning message
-msgid "The update will continue when the device power cable has been removed and re-inserted."
-msgstr "Posodobitev se bo nadaljevala, ko bo napajalni kabel naprave odstranjen in znova vstavljen."
-
-#. TRANSLATORS: naughty vendor
-msgid "The vendor did not supply any release notes."
-msgstr "Proizvajalec ni predložil opomb ob izdaji."
-
-#. TRANSLATORS: now list devices with unfixed high-priority issues
-msgid "There are devices with issues:"
-msgstr "Obstajajo naprave s težavami:"
-
-#. TRANSLATORS: nothing to show
-msgid "There are no blocked firmware files"
-msgstr "Ni blokiranih datotek vdelane programske opreme"
-
-#. TRANSLATORS: approved firmware has been checked by
-#. * the domain administrator
-msgid "There is no approved firmware."
-msgstr "Ni odobrene vdelane programske opreme."
-
-#. TRANSLATORS: %1 is the current device version number, and %2 is the
-#. command name, e.g. `fwupdmgr sync`
-#, c-format
-msgid "This device will be reverted back to %s when the %s command is performed."
-msgstr "Ta naprava bo povrnjena nazaj na %s, ko bo izveden ukaz %s."
-
-#. TRANSLATORS: the vendor did not upload this
-msgid "This firmware is provided by LVFS community members and is not provided (or supported) by the original hardware vendor."
-msgstr "To vdelano programsko opremo zagotavljajo člani skupnosti LVFS in je ne zagotavlja (ali podpira) prvotni prodajalec strojne opreme."
-
-#. TRANSLATORS: unsupported build of the package
-msgid "This package has not been validated, it may not work properly."
-msgstr "Ta paket ni bil preverjen, morda ne bo deloval pravilno."
-
-#. TRANSLATORS: we're poking around as a power user
-msgid "This program may only work correctly as root"
-msgstr "Ta program lahko pravilno deluje le kot root"
-
-msgid "This remote contains firmware which is not embargoed, but is still being tested by the hardware vendor. You should ensure you have a way to manually downgrade the firmware if the firmware update fails."
-msgstr "Ta oddaljeni strežnik vsebuje vdelano programsko opremo, na katero ne velja embargo, vendar jo še vedno preizkuša prodajalec strojne opreme. Prepričajte se, da imate način za ročno zamenjavo vdelane programske opreme, če posodobitev vdelane programske opreme ne uspe."
-
-#. TRANSLATORS: error message
-msgid "This system doesn't support firmware settings"
-msgstr "Ta sistem ne podpira nastavitev vdelane programske opreme"
-
-#. TRANSLATORS: this is instructions on how to improve the HSI suffix
-msgid "This system has HSI runtime issues."
-msgstr "Ta sistem ima težave z izvajanjem HSI."
-
-#. TRANSLATORS: this is instructions on how to improve the HSI security level
-msgid "This system has a low HSI security level."
-msgstr "Ta sistem ima nizko raven varnosti HSI."
-
-#. TRANSLATORS: description of dbxtool
-msgid "This tool allows an administrator to apply UEFI dbx updates."
-msgstr "To orodje omogoča skrbniku, da uporabi posodobitve dbx UEFI."
-
-#. TRANSLATORS: CLI description
-msgid "This tool allows an administrator to query and control the fwupd daemon, allowing them to perform actions such as installing or downgrading firmware."
-msgstr "To orodje omogoča skrbniku, da poizveduje in nadzoruje demona fwupd, kar mu omogoča izvajanje dejanj, kot je namestitev ali zamenjava vdelane programske opreme."
-
-#. TRANSLATORS: CLI description
-msgid "This tool allows an administrator to use the fwupd plugins without being installed on the host system."
-msgstr "To orodje skrbniku omogoča uporabo vstavkov fwupd, ne da bi bili nameščeni v gostiteljskem sistemu."
-
-#. TRANSLATORS: the %1 is a kernel command line key=value
-#, c-format
-msgid "This tool can add a kernel argument of '%s', but it will only be active after restarting the computer."
-msgstr "To orodje lahko doda argument jedra »%s«, vendar bo aktiven šele po vnovičnem zagonu računalnika."
-
-#. TRANSLATORS: the %1 is a BIOS setting name.
-#. * %2 and %3 are the values, e.g. "True" or "Windows10"
-#, c-format
-msgid "This tool can change the BIOS setting '%s' from '%s' to '%s' automatically, but it will only be active after restarting the computer."
-msgstr "To orodje lahko samodejno spremeni nastavitev BIOS-a »%s« iz »%s« v »%s«, vendar bo aktivna šele po ponovnem zagonu računalnika."
-
-#. TRANSLATORS: the %1 is a kernel command line key=value
-#, c-format
-msgid "This tool can change the kernel argument from '%s' to '%s', but it will only be active after restarting the computer."
-msgstr "To orodje lahko spremeni argument jedra iz »%s« v »%s«, vendar bo aktiven šele po vnovičnem zagonu računalnika."
-
-#. TRANSLATORS: CLI description
-msgid "This tool will read and parse the TPM event log from the system firmware."
-msgstr "To orodje bo prebralo in razčlenilo dnevnik dogodkov TPM iz vdelane programske opreme sistema."
-
-#. TRANSLATORS: the update state of the specific device
-msgid "Transient failure"
-msgstr "Začasen neuspeh"
-
-#. TRANSLATORS: item is TRUE
-msgid "True"
-msgstr "prav"
-
-#. TRANSLATORS: We verified the metadata against the server
-msgid "Trusted metadata"
-msgstr "Zaupanja vredni metapodatki"
-
-#. TRANSLATORS: We verified the payload against the server
-msgid "Trusted payload"
-msgstr "Zaupanja vreden tovor"
+#. TRANSLATORS: hash to that exact firmware archive
+#. TRANSLATORS: remote checksum
+#: src/fu-util-common.c:2001 src/fu-util-common.c:2049
+msgid "Checksum"
+msgstr "Kontrolna vsota"
 
 #. TRANSLATORS: remote type, e.g. remote or local
+#: src/fu-util-common.c:2023
 msgid "Type"
 msgstr "Vrsta"
 
-#. TRANSLATORS: Title: Bootservice is when only readable from early-boot
-msgid "UEFI Bootservice Variables"
-msgstr "Spremenljivke zagonske storitve UEFI"
+#. TRANSLATORS: if we can get metadata from peer-to-peer clients
+#: src/fu-util-common.c:2036
+msgid "P2P Metadata"
+msgstr "Metapodatki P2P"
 
-#. TRANSLATORS: partition refers to something on disk, again, hey Arch users
-msgid "UEFI ESP partition may not be set up correctly"
-msgstr "Razdelek UEFI ESP morda ni pravilno nastavljen"
+#. TRANSLATORS: if we can get metadata from peer-to-peer clients
+#: src/fu-util-common.c:2043
+msgid "P2P Firmware"
+msgstr "Vdelana programska oprema P2P"
 
-#. TRANSLATORS: partition refers to something on disk, again, hey Arch users
-msgid "UEFI ESP partition not detected or configured"
-msgstr "Razdelek UEFI ESP ni zaznan ali konfiguriran"
+#. TRANSLATORS: the age of the metadata
+#: src/fu-util-common.c:2056
+msgid "Age"
+msgstr "Starost"
 
-#. TRANSLATORS: Title: is UEFI early-boot memory protection turned on
-msgid "UEFI Memory Protection"
-msgstr "Zaščita pomnilnika UEFI"
+#. TRANSLATORS: how often we should refresh the metadata
+#: src/fu-util-common.c:2062
+msgid "Refresh Interval"
+msgstr "Interval osveževanja"
 
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-msgid "UEFI Platform Key"
-msgstr "Ključ platforme UEFI"
+#. TRANSLATORS: the numeric priority
+#: src/fu-util-common.c:2069
+msgid "Priority"
+msgstr "Prednost"
 
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-msgid "UEFI Secure Boot"
-msgstr "Varni zagon vmesnika UEFI"
+#. TRANSLATORS: remote filename base
+#: src/fu-util-common.c:2072
+msgid "Username"
+msgstr "Uporabniško ime"
 
-#. TRANSLATORS: longer description
-msgid "UEFI Secure Boot prevents malicious software from being loaded when the device starts."
-msgstr "Varni zagon UEFI Secure Boot preprečuje nalaganje zlonamerne programske opreme ob zagonu naprave."
+#. TRANSLATORS: remote filename base
+#: src/fu-util-common.c:2077
+msgid "Password"
+msgstr "Geslo"
 
-#. TRANSLATORS: longer description
-msgid "UEFI boot service variables should not be readable from runtime mode."
-msgstr "Spremenljivke zagonske storitve UEFI ne smejo biti berljive iz načina izvajanja."
+#. TRANSLATORS: filename of the local file
+#: src/fu-util-common.c:2082
+msgid "Filename"
+msgstr "Ime datoteke"
 
-#. TRANSLATORS: Title: Bootservice is when only readable from early-boot
-msgid "UEFI bootservice variables"
-msgstr "Spremenljivke zagonske storitve UEFI"
+#. TRANSLATORS: filename of the local file
+#: src/fu-util-common.c:2087
+msgid "Filename Signature"
+msgstr "Podpis imena datoteke"
 
-#. TRANSLATORS: capsule updates are an optional BIOS feature
-msgid "UEFI capsule updates not available or enabled in firmware setup"
-msgstr "Posodobitve kapsul UEFI niso na voljo ali omogočene pri nastavitvi vdelane programske opreme"
+#. TRANSLATORS: full path of the remote.conf file
+#: src/fu-util-common.c:2092
+msgid "Filename Source"
+msgstr "Vir imena datoteke"
 
-#. TRANSLATORS: Title: is UEFI db up-to-date
-msgid "UEFI db"
-msgstr "Db UEFI"
+#. TRANSLATORS: remote URI
+#: src/fu-util-common.c:2097
+msgid "Metadata URI"
+msgstr "URI metapodatkov"
 
-#. TRANSLATORS: program name
-msgid "UEFI dbx Utility"
-msgstr "Pripomoček UEFI dbx"
+#. TRANSLATORS: remote URI
+#: src/fu-util-common.c:2102
+msgid "Metadata Signature"
+msgstr "Podpis metapodatkov"
 
-#. TRANSLATORS: system is not booted in UEFI mode
-msgid "UEFI firmware can not be updated in legacy BIOS mode"
-msgstr "Vdelane programske opreme UEFI ni mogoče posodobiti v zastarelem načinu BIOS-a"
+#. TRANSLATORS: remote URI
+#: src/fu-util-common.c:2107
+msgid "Firmware Base URI"
+msgstr "Osnovni URI vdelane programske opreme"
 
-#. TRANSLATORS: Title: is UEFI early-boot memory protection turned on
-msgid "UEFI memory protection"
-msgstr "Zaščita pomnilnika UEFI"
+#. TRANSLATORS: URI to send success/failure reports
+#: src/fu-util-common.c:2112
+msgid "Report URI"
+msgstr "URI poročila"
+
+#. TRANSLATORS: Boolean value to automatically send reports
+#: src/fu-util-common.c:2117
+msgid "Automatic Reporting"
+msgstr "Samodejno poročanje"
+
+#. TRANSLATORS: warning message shown after update has been scheduled
+#: src/fu-util-common.c:2131
+msgid ""
+"The update will continue when the device USB cable has been unplugged and "
+"then re-inserted."
+msgstr ""
+"Posodobitev se bo nadaljevala, ko bo kabel naprave  USB izključen in nato "
+"znova vstavljen."
+
+#. TRANSLATORS: warning message shown after update has been scheduled
+#: src/fu-util-common.c:2136
+msgid "The update will continue when the device USB cable has been unplugged."
+msgstr "Posodobitev se bo nadaljevala, ko bo kabel naprave USB izključen."
+
+#. TRANSLATORS: warning message shown after update has been scheduled
+#: src/fu-util-common.c:2141
+msgid ""
+"The update will continue when the device USB cable has been re-inserted."
+msgstr ""
+"Posodobitev se bo nadaljevala, ko bo kabel naprave USB znova vstavljen."
+
+#. TRANSLATORS: warning message
+#: src/fu-util-common.c:2146
+msgid "Press unlock on the device to continue the update process."
+msgstr ""
+"Na napravi pritisnite odklepanje, da nadaljujete postopek posodabljanja."
+
+#. TRANSLATORS: warning message shown after update has been scheduled
+#: src/fu-util-common.c:2150
+msgid ""
+"Do not turn off your computer or remove the AC adaptor while the update is "
+"in progress."
+msgstr ""
+"Med posodabljanjem ne izklapljajte računalnika in ne odstranjujte "
+"napajalnika."
+
+#. TRANSLATORS: message shown after device has been marked for emulation
+#: src/fu-util-common.c:2155
+msgid "Unplug and replug the device to continue the update process."
+msgstr ""
+"Odklopite napravo in jo znova priključite, da nadaljujete postopek "
+"posodabljanja."
+
+#. TRANSLATORS: warning message
+#: src/fu-util-common.c:2159
+msgid ""
+"The update will continue when the device power cable has been removed and re-"
+"inserted."
+msgstr ""
+"Posodobitev se bo nadaljevala, ko bo napajalni kabel naprave odstranjen in "
+"znova vstavljen."
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2171
+msgid "Valid"
+msgstr "Veljavno"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2175
+msgid "Invalid"
+msgstr "Neveljavno"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2187
+msgid "Locked"
+msgstr "Zaklenjen"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2191
+msgid "Unlocked"
+msgstr "Odklenjeno"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2195
+msgid "Encrypted"
+msgstr "Šifrirano"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2199
+msgid "Unencrypted"
+msgstr "Nešifrirano"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2203
+msgid "Tainted"
+msgstr "V nevarnosti"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2207
+msgid "Untainted"
+msgstr "Neomadeževano"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2211
+msgid "Found"
+msgstr "Najdeno"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2215
+msgid "Not found"
+msgstr "Predmeta ni mogoče najti"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2219
+msgid "Supported"
+msgstr "Podprto"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2223
+msgid "Not supported"
+msgstr "Ni podprto"
+
+#. TRANSLATORS: Suffix: the HSI result
+#: src/fu-util-common.c:2241
+msgid "OK"
+msgstr "V redu"
+
+#. TRANSLATORS: this is shown as a suffix for obsoleted tests
+#: src/fu-util-common.c:2295
+msgid "(obsoleted)"
+msgstr "(zastarelo)"
 
 #. TRANSLATORS: HSI event title
-msgid "UEFI memory protection enabled and locked"
-msgstr "Zaščita pomnilnika UEFI je omogočena in zaklenjena"
+#: src/fu-util-common.c:2313
+msgid "IOMMU device protection enabled"
+msgstr "Omogočena je zaščita naprav IOMMU"
 
 #. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2318
+msgid "IOMMU device protection disabled"
+msgstr "Zaščita naprav IOMMU je onemogočena"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2337
+msgid "Kernel is no longer tainted"
+msgstr "Jedro ni več okuženo"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2342
+msgid "Kernel is tainted"
+msgstr "Jedro je okuženo"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2348
+msgid "Kernel lockdown disabled"
+msgstr "Zaklepanje jedra je onemogočeno"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2353
+msgid "Kernel lockdown enabled"
+msgstr "Omogočeno zaklepanje jedra"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2359
+msgid "Pre-boot DMA protection is disabled"
+msgstr "Zaščita DMA pred zagonom je onemogočena"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2364
+msgid "Pre-boot DMA protection is enabled"
+msgstr "Zaščita DMA pred zagonom je omogočena"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2370
+msgid "Secure Boot disabled"
+msgstr "Varni zagon je onemogočen"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2375
+msgid "Secure Boot enabled"
+msgstr "Varni zagon je omogočen"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2381
+msgid "All TPM PCRs are valid"
+msgstr "Vsi PCR-ji TPM so veljavni"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2386
+msgid "A TPM PCR is now an invalid value"
+msgstr "PCR TPM je zdaj neveljavna vrednost"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2391
+msgid "All TPM PCRs are now valid"
+msgstr "Vsi PCR-ji TPM so zdaj veljavni"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2397
+msgid "TPM PCR0 reconstruction is invalid"
+msgstr "Rekonstrukcija TPM PCR0 ni veljavna"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2402
+msgid "TPM PCR0 reconstruction is now valid"
+msgstr "Rekonstrukcija TPM PCR0 je zdaj veljavna"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2408
 msgid "UEFI memory protection enabled but not locked"
 msgstr "Zaščita pomnilnika UEFI je omogočena, vendar ni zaklenjena"
 
 #. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2413
+msgid "UEFI memory protection enabled and locked"
+msgstr "Zaščita pomnilnika UEFI je omogočena in zaklenjena"
+
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2418
 msgid "UEFI memory protection is now locked"
 msgstr "Zaščita pomnilnika UEFI je zdaj zaklenjena"
 
 #. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2423
 msgid "UEFI memory protection is now unlocked"
 msgstr "Zaščita pomnilnika UEFI je zdaj odklenjena"
 
-#. TRANSLATORS: Title: PK is the 'platform key' for the machine
-msgid "UEFI platform key"
-msgstr "Ključ platforme UEFI"
+#. TRANSLATORS: HSI event title
+#: src/fu-util-common.c:2428
+msgid "The UEFI certificate store is now up to date"
+msgstr "Shramba potrdil UEFI je zdaj posodobljena"
 
-#. TRANSLATORS: Title: SB is a way of locking down UEFI
-msgid "UEFI secure boot"
-msgstr "Varni zagon vmesnika UEFI"
-
-#. TRANSLATORS: error message
-msgid "Unable to connect to service"
-msgstr "Povezave s storitvijo ni možno vzpostaviti"
-
-#. TRANSLATORS: error message
-msgid "Unable to find attribute"
-msgstr "Atributa ni mogoče najti"
-
-#. TRANSLATORS: command description
-msgid "Unbind current driver"
-msgstr "Razveži trenutni gonilnik"
-
-#. TRANSLATORS: we will now offer this firmware to the user
-msgid "Unblocking firmware:"
-msgstr "Deblokiranje vdelane programske opreme:"
-
-#. TRANSLATORS: command description
-msgid "Unblocks a specific firmware from being installed"
-msgstr "Odblokira namestitev določene vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Undo the host security attribute fix"
-msgstr "Razveljavi popravek varnostnega atributa gostitelja"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Unencrypted"
-msgstr "Nešifrirano"
-
-#. TRANSLATORS: command description
-msgid "Uninhibit the system to allow upgrades"
-msgstr "Nastavite sistem, da omogoči nadgradnje"
-
-#. TRANSLATORS: current daemon status is unknown
-#. TRANSLATORS: we don't know the license of the update
-#. TRANSLATORS: unknown release urgency
-#. TRANSLATORS: Suffix: the fallback HSI result
-msgid "Unknown"
-msgstr "Neznano"
-
-#. TRANSLATORS: Name of hardware
-msgid "Unknown Device"
-msgstr "Neznana naprava"
-
-msgid "Unlock the device to allow access"
-msgstr "Odkleni napravo za omogočanje dostopa"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Unlocked"
-msgstr "Odklenjeno"
-
-#. TRANSLATORS: command description
-msgid "Unlocks the device for firmware access"
-msgstr "Odklene napravo za dostop do vdelane programske opreme"
-
-#. TRANSLATORS: command description
-msgid "Unmounts the ESP"
-msgstr "Odklopi ESP"
-
-#. TRANSLATORS: message shown after device has been marked for emulation
-msgid "Unplug and replug the device to continue the update process."
-msgstr "Odklopite napravo in jo znova priključite, da nadaljujete postopek posodabljanja."
-
-#. TRANSLATORS: firmware payload is unsigned and it is possible to modify it
-msgid "Unsigned Payload"
-msgstr "Nepodpisani tovor"
-
-#. TRANSLATORS: error message
+#. TRANSLATORS: %1 refers to some kind of security test, e.g. "SPI BIOS region".
+#. %2 refers to a result value, e.g. "Invalid"
+#: src/fu-util-common.c:2453
 #, c-format
-msgid "Unsupported daemon version %s, client version is %s"
-msgstr "Nepodprta različica prikritega procesa %s, različica odjemalca je %s"
+msgid "%s disappeared: %s"
+msgstr "%s je izginil: %s"
 
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Untainted"
-msgstr "Neomadeževano"
-
-#. TRANSLATORS: Device is updatable in this or any other mode
-msgid "Updatable"
-msgstr "Posodobljivo"
-
-#. TRANSLATORS: error message from last update attempt
-msgid "Update Error"
-msgstr "Napaka pri posodobitvi"
-
-#. TRANSLATORS: helpful image for the update
-msgid "Update Image"
-msgstr "Posodobi sliko"
-
-#. TRANSLATORS: helpful messages for the update
-msgid "Update Message"
-msgstr "Posodobi sporočilo"
-
-#. TRANSLATORS: hardware state, e.g. "pending"
-msgid "Update State"
-msgstr "Posodobi stanje"
-
-#. TRANSLATORS: the server sent the user a small message
-msgid "Update failure is a known issue, visit this URL for more information:"
-msgstr "Napaka pri posodobitvi je znana težava, za več informacij obiščite ta URL:"
-
-#. TRANSLATORS: ask if we can update metadata
-msgid "Update now?"
-msgstr "Želite posodobiti zdaj?"
-
-#. TRANSLATORS: command description
-msgid "Update the stored cryptographic hash with current ROM contents"
-msgstr "Posodobite shranjeno kriptografsko kontrolno vsoto s trenutno vsebino ROM-a"
-
-msgid "Update the stored device verification information"
-msgstr "Posodobi shranjene informacije za preverjanje naprave"
-
-#. TRANSLATORS: command description
-msgid "Update the stored metadata with current contents"
-msgstr "Posodobi shranjene metapodatke s trenutno vsebino"
-
-#. TRANSLATORS: command description
-msgid "Updates all specified devices to latest firmware version, or all devices if unspecified"
-msgstr "Posodobi vse navedene naprave na najnovejšo različico vdelane programske opreme ali vse naprave, če niso navedene"
-
-#. TRANSLATORS: how many local devices can expect updates now
+#. TRANSLATORS: %1 refers to some kind of security test, e.g. "Encrypted RAM".
+#. %2 refers to a result value, e.g. "Invalid"
+#: src/fu-util-common.c:2465
 #, c-format
-msgid "Updates have been published for %u local device"
-msgid_plural "Updates have been published for %u of %u local devices"
-msgstr[0] "Posodobitve so objavljene za %u krajevnih naprav"
-msgstr[1] "Posodobitve so objavljene za %u od %u krajevnih naprav"
-msgstr[2] "Posodobitve so objavljene za %u od %u krajevnih naprav"
-msgstr[3] "Posodobitve so objavljene za %u od %u krajevnih naprav"
+msgid "%s appeared: %s"
+msgstr "%s se je pojavil: %s"
 
-msgid "Updating"
-msgstr "Posodabljanje"
-
-#. TRANSLATORS: %1 is a device name
+#. TRANSLATORS: %1 refers to some kind of security test, e.g. "UEFI platform key".
+#. * %2 and %3 refer to results value, e.g. "Valid" and "Invalid"
+#: src/fu-util-common.c:2475
 #, c-format
-msgid "Updating %s…"
-msgstr "Posodabljanje %s ..."
+msgid "%s changed: %s → %s"
+msgstr "%s spremenjeno: %s → %s"
 
-#. TRANSLATORS: message letting the user know an upgrade is available
-#. * %1 is the device name and %2 and %3 are version strings
+#. TRANSLATORS: title for host security events
+#: src/fu-util-common.c:2520
+msgid "Host Security Events"
+msgstr "Dogodki varnosti gostitelja"
+
+#. TRANSLATORS: now list devices with unfixed high-priority issues
+#: src/fu-util-common.c:2548
+msgid "There are devices with issues:"
+msgstr "Obstajajo naprave s težavami:"
+
+#. TRANSLATORS:  this is the HSI suffix
+#: src/fu-util-common.c:2616
+msgid "Runtime Suffix"
+msgstr "Pripona izvajalne datoteke"
+
+#. TRANSLATORS: this is instructions on how to improve the HSI security level
+#: src/fu-util-common.c:2638
+msgid "This system has a low HSI security level."
+msgstr "Ta sistem ima nizko raven varnosti HSI."
+
+#. TRANSLATORS: this is instructions on how to improve the HSI suffix
+#: src/fu-util-common.c:2646
+msgid "This system has HSI runtime issues."
+msgstr "Ta sistem ima težave z izvajanjem HSI."
+
+#. TRANSLATORS: this is more background on a security measurement problem
+#: src/fu-util-common.c:2655
+msgid "The TPM PCR0 differs from reconstruction."
+msgstr "TPM PCR0 se razlikuje od rekonstrukcije."
+
+#. TRANSLATORS: %1 is the firmware vendor, %2 is the device vendor name
+#: src/fu-util-common.c:2699
 #, c-format
-msgid "Upgrade %s from %s to %s?"
-msgstr "Želite nadgraditi %s s %s na %s?"
-
-#. TRANSLATORS: ask the user to upload
-msgid "Upload data now?"
-msgstr "Želite zdaj naložiti podatke?"
-
-#. TRANSLATORS: command description
-msgid "Upload the list of updatable devices to a remote server"
-msgstr "Naloži seznam posodobljivih naprav na oddaljeni strežnik"
-
-#. TRANSLATORS: ask the user to share, %s is something
-#. * like: "Linux Vendor Firmware Service"
-#, c-format
-msgid "Upload these anonymous results to the %s to help other users?"
-msgstr "Želite naložiti te anonimne rezultate na %s, da pomagate drugim uporabnikom?"
-
-#. TRANSLATORS: explain why we want to upload
-#, c-format
-msgid "Uploading a device list allows the %s team to know what hardware exists, and allows us to put pressure on vendors that do not upload firmware updates for their hardware."
-msgstr "Nalaganje seznama naprav omogoča ekipi %s, da so seznanjeni, kakšna strojna oprema obstaja, ter da pritiskamo na tiste proizvajalce, ki ne nalagajo posodobitev vdelane programske opreme za svojo strojno opremo."
-
-#. TRANSLATORS: explain why we want to upload
-msgid "Uploading firmware reports helps hardware vendors to quickly identify failing and successful updates on real devices."
-msgstr "Nalaganje poročil o vdelani programski opremi pomaga prodajalcem strojne opreme, da hitro prepoznajo neuspešne in uspešne posodobitve v resničnih napravah."
-
-#. TRANSLATORS: how important the release is
-msgid "Urgency"
-msgstr "Nujnost"
-
-#. TRANSLATORS: explain how to get help, %1 is
-#. * 'fwupdtool --help'
-#. TRANSLATORS: explain how to get help,
-#. * where $1 is something like 'fwupdmgr --help'
-#, c-format
-msgid "Use %s for help"
-msgstr "Uporabite %s za pomoč"
-
-#. TRANSLATORS: CTRL^C [holding control, and then pressing C] will exit the
-#. program
-msgid "Use CTRL^C to cancel."
-msgstr "Za preklic uporabite CTRL^C."
-
-#. TRANSLATORS: User has been notified
-msgid "User has been notified"
-msgstr "Uporabnik je bil obveščen"
-
-#. TRANSLATORS: remote filename base
-msgid "Username"
-msgstr "Uporabniško ime"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "VERSION1 VERSION2 [FORMAT]"
-msgstr "VERSION1 VERSION2 [FORMAT]"
-
-#. TRANSLATORS: Suffix: the HSI result
-msgid "Valid"
-msgstr "Veljavno"
-
-#. TRANSLATORS: ESP refers to the EFI System Partition
-msgid "Validating ESP contents…"
-msgstr "Preverjanje vsebine ESP ..."
-
-#. TRANSLATORS: one line variant of release (e.g. 'China')
-msgid "Variant"
-msgstr "Različica"
-
-#. TRANSLATORS: manufacturer of hardware
-msgid "Vendor"
-msgstr "Ponudnik"
-
-#. TRANSLATORS: verifying we wrote the firmware correctly
-msgid "Verifying…"
-msgstr "Poteka preverjanje ..."
-
-#. TRANSLATORS: the detected version number of the dbx
-msgid "Version"
-msgstr "Različica"
-
-#. TRANSLATORS: the fwupd version the release was tested on
-msgid "Version[fwupd]"
-msgstr "Različica[fwupd]"
-
-#. TRANSLATORS: this is a prefix on the console
-msgid "WARNING"
-msgstr "OPOZORILO"
-
-#. TRANSLATORS: command description
-msgid "Wait for a device to appear"
-msgstr "Počakajte, da se naprava prikaže"
-
-#. TRANSLATORS: waiting for device to do something
-msgid "Waiting…"
-msgstr "Čakanje …"
-
-#. TRANSLATORS: command description
-msgid "Watch for hardware changes"
-msgstr "Spremljaj spremembe strojne opreme"
-
-#. TRANSLATORS: check various UEFI and ACPI tables are unchanged after the
-#. update
-msgid "Will measure elements of system integrity around an update"
-msgstr "Izmeri elemente integritete sistema okoli posodobitve"
-
-#. TRANSLATORS: decompressing images from a container firmware
-msgid "Writing file:"
-msgstr "Zapisovanje datoteke:"
-
-#. TRANSLATORS: writing to the flash chips
-msgid "Writing…"
-msgstr "Poteka zapisovanje ..."
-
-#. TRANSLATORS: the user has to manually recover; we can't do it
-msgid "You should ensure you are comfortable restoring the setting from a recovery or installation disk, as this change may cause the system to not boot into Linux or cause other system instability."
-msgstr "Prepričajte se, da želite obnoviti nastavitev z obnovitvenega ali namestitvenega diska, saj lahko ta sprememba povzroči, da se sistem ne zažene v Linux ali povzroči drugo nestabilnost sistema."
-
-#. TRANSLATORS: the user has to manually recover; we can't do it
-msgid "You should ensure you are comfortable restoring the setting from the system firmware setup, as this change may cause the system to not boot into Linux or cause other system instability."
-msgstr "Prepričajte se, da želite obnoviti nastavitev iz nastavitve vdelane programske opreme sistema, saj lahko ta sprememba povzroči, da se sistem ne zažene v Linux ali povzroči drugo nestabilnost sistema."
-
-#. TRANSLATORS: show the user a warning
-msgid "Your distributor may not have verified any of the firmware updates for compatibility with your system or connected devices."
-msgstr "Vaš distributer morda ni preveril nobene posodobitve vdelane programske opreme za združljivost z vašim sistemom ali priključenimi napravami."
+msgid "The firmware from %s is not supplied by %s, the hardware vendor."
+msgstr ""
+"Vdelane programske opreme podjetja %s ne dobavlja %s, izdelovalec strojne "
+"opreme."
 
 #. TRANSLATORS: %1 is the device vendor name
+#: src/fu-util-common.c:2706
 #, c-format
-msgid "Your hardware may be damaged using this firmware, and installing this release may void any warranty with %s."
-msgstr "S to vdelano programsko opremo se lahko poškoduje vaša strojna oprema in namestitev te izdaje lahko razveljavi garancijo %s."
+msgid ""
+"Your hardware may be damaged using this firmware, and installing this "
+"release may void any warranty with %s."
+msgstr ""
+"S to vdelano programsko opremo se lahko poškoduje vaša strojna oprema in "
+"namestitev te izdaje lahko razveljavi garancijo %s."
 
-#. TRANSLATORS: BKC is the industry name for the best known configuration and
-#. is a set
-#. * of firmware that works together
+#. TRANSLATORS: show and ask user to confirm --
+#. * %1 is the old branch name, %2 is the new branch name
+#: src/fu-util-common.c:2724
 #, c-format
-msgid "Your system is set up to the BKC of %s."
-msgstr "Vaš sistem je nastavljen na BKC %s."
+msgid "Switch branch from %s to %s?"
+msgstr "Želite preklopiti vejo iz %s v %s?"
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[APPSTREAM_ID]"
-msgstr "[APPSTREAM_ID]"
+#. TRANSLATORS: should the branch be changed
+#: src/fu-util-common.c:2733
+msgid "Do you understand the consequences of changing the firmware branch?"
+msgstr "Ali razumete posledice spremembe veje vdelane programske opreme?"
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[CHECKSUM]"
-msgstr "[KONTROLNAVSOTA]"
+#. TRANSLATORS: the platform secret is stored in the PCRx registers on the TPM
+#: src/fu-util-common.c:2757
+msgid ""
+"Some of the platform secrets may be invalidated when updating this firmware."
+msgstr ""
+"Nekatere skrivnosti platforme se lahko razveljavijo s posodabljanjem te "
+"vdelane programske opreme."
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[DEVICE-ID|GUID]"
-msgstr "[ID-NAPRAVE|GUID]"
+#. TRANSLATORS: 'recovery key' here refers to a code, rather than a physical
+#. metal thing
+#: src/fu-util-common.c:2762
+msgid "Please ensure you have the volume recovery key before continuing."
+msgstr ""
+"Pred nadaljevanjem se prepričajte, da imate ključ za obnovitev nosilca."
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[DEVICE-ID|GUID] [BRANCH]"
-msgstr "[ID-NAPRAVE|GUID] [VEJA]"
+#. TRANSLATORS: the %1 is a URL to a wiki page
+#: src/fu-util-common.c:2766
+#, c-format
+msgid "See %s for more details."
+msgstr "Za več podrobnosti glejte %s."
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[DEVICE-ID|GUID] [VERSION]"
-msgstr "[ID-NAPRAVE|GUID] [RAZLIČICA]"
+#. TRANSLATORS: title text, shown as a warning
+#: src/fu-util-common.c:2769
+msgid "Full Disk Encryption Detected"
+msgstr "Zaznano je popolno šifriranje diska"
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[DEVICE]"
-msgstr "[NAPRAVA]"
+#. TRANSLATORS: unsupported build of the package
+#: src/fu-util-common.c:2793
+msgid "This package has not been validated, it may not work properly."
+msgstr "Ta paket ni bil preverjen, morda ne bo deloval pravilno."
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[FILE FILE_SIG REMOTE-ID]"
-msgstr "[DATOTEKA PODP_DATOTEKE ID-ODDALJENEGA]"
+#. TRANSLATORS: a remote here is like a 'repo' or software source
+#: src/fu-util-common.c:2815
+msgid "Enable new remote?"
+msgstr "Želite omogočiti nov oddaljeni strežnik?"
 
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[FILENAME1] [FILENAME2]"
-msgstr "[IMEDATOTEKE1] [IMEDATOTEKE2]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[FWUPD-VERSION]"
-msgstr "[FWUPD-RAZLIČICA]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[REASON] [TIMEOUT]"
-msgstr "[REASON] [TIMEOUT]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[SECTION] KEY VALUE"
-msgstr "[RAZDELEK] KLJUČ VREDNOST"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[SETTING1] [SETTING2] [--no-authenticate]"
-msgstr "[NASTAVITEV1] [NASTAVITEV2] [--no-authenticate]"
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[SETTING1] [SETTING2]..."
-msgstr "[NASTAVITEV1] [NASTAVITEV2]..."
-
-#. TRANSLATORS: command argument: uppercase, spaces->dashes
-msgid "[SMBIOS-FILE|HWIDS-FILE]"
-msgstr "[DATOTEKA-SMBIOS|DATOTEKA-HWIDS]"
-
-#. TRANSLATORS: this is the default branch name when unset
-msgid "default"
-msgstr "privzeto"
-
-#. TRANSLATORS: program name
-msgid "fwupd TPM event log utility"
-msgstr "Pripomoček dnevnika dogodkov fwupd TPM"
-
-#. TRANSLATORS: Title: if the fwupd plugins are all present and correct
-msgid "fwupd plugins"
-msgstr "Vstavki fwupd"
+#. TRANSLATORS: should the remote still be enabled
+#: src/fu-util-common.c:2821
+msgid "Agree and enable the remote?"
+msgstr "Se strinjate in želite omogočiti oddaljeni strežnik?"


### PR DESCRIPTION
Translation in transifex does not allow to properly translate one singular/plural string (singular form for "Updates have been published for %u local device" is marked as erroneous by pocheck, so singular in this change also uses two %u variables), also there was a new string added.

Type of pull request:
- translation update
