### PR TITLE
Verify the checksum of the serialized data in tests

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -5281,13 +5281,13 @@ fu_firmware_builder_round_trip_func(void)
 	    {
 		FU_TYPE_SREC_FIRMWARE,
 		"srec.builder.xml",
-		"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		"c8b405b7995d5934086c56b091a4c5df47b3b0d7",
 		FU_FIRMWARE_BUILDER_FLAG_NO_BINARY_COMPARE,
 	    },
 	    {
 		FU_TYPE_IHEX_FIRMWARE,
 		"ihex.builder.xml",
-		"a8d74f767f3fc992b413e5ba801cedc80a4cf013",
+		"e7c39355f1c87a3e9bf2195a406584c5dac828bc",
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	    {
@@ -5323,13 +5323,13 @@ fu_firmware_builder_round_trip_func(void)
 	    {
 		FU_TYPE_EFI_SECTION,
 		"efi-section.builder.xml",
-		"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		"a0ede7316209c536b50b6e5fb22cce8135153bc3",
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	    {
 		FU_TYPE_EFI_SECTION,
 		"efi-section.builder.xml",
-		"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		"a0ede7316209c536b50b6e5fb22cce8135153bc3",
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	    {
@@ -5365,7 +5365,7 @@ fu_firmware_builder_round_trip_func(void)
 	    {
 		FU_TYPE_EFI_VOLUME,
 		"efi-volume.builder.xml",
-		"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		"e4d8e1a15ef20f97acf2d5bf3a75da5865a2db0b",
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	    {
@@ -5401,7 +5401,7 @@ fu_firmware_builder_round_trip_func(void)
 	    {
 		FU_TYPE_OPROM_FIRMWARE,
 		"oprom.builder.xml",
-		"2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		"2e8387c1ef14ed4038e6bc637146b86b4d702fa8",
 		FU_FIRMWARE_BUILDER_FLAG_NONE,
 	    },
 	    {

--- a/plugins/bnr-dp/fu-self-test.c
+++ b/plugins/bnr-dp/fu-self-test.c
@@ -31,7 +31,7 @@ fu_bnr_dp_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "e5d645902551f55258827223905fb097cf3af58c");
+	g_assert_cmpstr(csum1, ==, "b83504af44c2a53561f9e5f25fb133903e1c19fc");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/ccgx-dmc/fu-self-test.c
+++ b/plugins/ccgx-dmc/fu-self-test.c
@@ -31,7 +31,7 @@ fu_ccgx_dmc_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "8bfcf543805d54280164813d792581764bd4b48b");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/ccgx/fu-self-test.c
+++ b/plugins/ccgx/fu-self-test.c
@@ -31,7 +31,7 @@ fu_ccgx_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "ccc06acf112b7e3baf0b4ff6574d759110c7bd5d");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/elantp/fu-self-test.c
+++ b/plugins/elantp/fu-self-test.c
@@ -31,7 +31,7 @@ fu_elantp_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "de53a29a438ff297202055151381433b86a2f64d");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -36,7 +36,7 @@ fu_pxi_firmware_xml_func(void)
 	g_assert_nonnull(fw);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "61efee24b3fad7358ce64144300e9e004b825759");
 
 	/* ensure we can parse */
 	ret = fu_firmware_parse_bytes(firmware3, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, &error);

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -190,7 +190,7 @@ fu_synaptics_mst_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "bfcdf3e6ca6cef45543bfbb57509c92aec9a39fb");
+	g_assert_cmpstr(csum1, ==, "67b8fc4661f7585a8cd6c46ef6088293d4399135");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -109,7 +109,7 @@ fu_synaprom_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "5fa24664fb28e78cbd88970e6026d996fc051550");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);

--- a/plugins/uf2/fu-self-test.c
+++ b/plugins/uf2/fu-self-test.c
@@ -31,7 +31,7 @@ fu_uf2_firmware_xml_func(void)
 	g_assert_true(ret);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
-	g_assert_cmpstr(csum1, ==, "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed");
+	g_assert_cmpstr(csum1, ==, "3d36175e6b652797d6ad1df043f1cfd5167f303c");
 
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);


### PR DESCRIPTION
Hilariously, we've been verifying the *data blob* in the tests, rather than the serialized structured data.

This explains why so many were `2aae6c35c94fcfb415dbe95f408b9ce91ee846ed` which is the SHA1 of `hello world`...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
