### PR TITLE
modem-manager: per-device main context

### DIFF
--- a/plugins/modem-manager/fu-mm-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-mbim-device.c
@@ -109,7 +109,6 @@ typedef struct {
 	GMainLoop *loop;
 	GSource *timeout_source;
 	GCancellable *cancellable;
-	guint timeout_id;
 	MbimDevice *mbim_device;
 	MbimMessage *mbim_message;
 	GError *error;
@@ -120,7 +119,6 @@ fu_mm_mbim_device_helper_timeout_cb(gpointer user_data)
 {
 	FuMmMbimDeviceHelper *helper = (FuMmMbimDeviceHelper *)user_data;
 	g_cancellable_cancel(helper->cancellable);
-	helper->timeout_id = 0;
 	return G_SOURCE_REMOVE;
 }
 
@@ -146,8 +144,6 @@ fu_mm_mbim_device_helper_free(FuMmMbimDeviceHelper *helper)
 {
 	g_main_context_pop_thread_default(helper->main_ctx);
 	g_source_destroy(helper->timeout_source);
-	if (helper->timeout_id != 0)
-		g_source_remove(helper->timeout_id);
 	if (helper->mbim_device != NULL)
 		g_object_unref(helper->mbim_device);
 	if (helper->mbim_message != NULL)


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

All MBIM message responses are sent to the main context the device was opened with.
If using a new context for each MBIM action (open/command/close), we are never going to see any response (except for the first time).
-> Use a single context per MBIM device and reuse it for every of its MBIM actions.

Fixes: #9071