### PR TITLE
rts54hub: Assign a default gtype

### DIFF
--- a/plugins/rts54hub/fu-rts54hub-plugin.c
+++ b/plugins/rts54hub/fu-rts54hub-plugin.c
@@ -38,7 +38,7 @@ fu_rts54hub_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
 	fu_context_add_quirk_key(ctx, "Rts54BlockSize");
-	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_DEVICE);
+	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_RTS54HUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_BACKGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_FOREGROUND);
 }


### PR DESCRIPTION
Fixes #9164

I'm seeing this error:

failed to add device
/sys/devices/pci0000:00/0000:00:08.3/0000:c5:00.0/usb4/4-2: too many GTypes to choose a default, got:
FuRts54HubDevice,FuRts54hubRtd21xxBackground,FuRts54hubRtd21xxForeground

With this change I can see the firmware version:

```
> fwupdtool get-devices --plugins rts54hub
[sudo] password for zoid: 
Loading…                 [************************************** ]
Framework Laptop 16 (AMD Ryzen AI 300 Series)
│
└─4-Port USB 3.0 Hub:
      Device ID:          a36485667d707d3146ca8dd945fe82adb031e9b2
      Current version:    0.7
      Vendor:             Realtek Semiconductor Corp. (USB:0x0BDA)
      Update Error:       device does not support authentication
      GUIDs:              e08c4b70-8556-5634-9628-e5dd44b9bdae ← USB\VID_0BDA&PID_0432
                          240c5cc4-fc76-5076-911a-1eb4dcea9a94 ← USB\VID_0BDA&PID_0432&HUB_0000
      Device Flags:       • Signed Payload
                          • Can tag for emulation
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
