### PR TITLE
parade-usbhub: Enforce a requirement for the default PS5512 devboard VID/PID

### DIFF
--- a/plugins/parade-usbhub/parade-usbhub.quirk
+++ b/plugins/parade-usbhub/parade-usbhub.quirk
@@ -1,21 +1,27 @@
 # PS5511 devboard
 [USB\VID_1DA0&PID_5511]
 Plugin = parade_usbhub
+Flags = enforce-requires
 [USB\VID_1DA0&PID_55A1]
 Plugin = parade_usbhub
+Flags = enforce-requires
 
 # PS5512 devboard
 [USB\VID_1DA0&PID_5512]
 Plugin = parade_usbhub
+Flags = enforce-requires
 [USB\VID_1DA0&PID_551D]
 Plugin = parade_usbhub
+Flags = enforce-requires
 
 # PS188
 [USB\VID_1DA0&PID_0188]
 Plugin = parade_usbhub
+Flags = enforce-requires
 ParadeUsbhubChip = ps188
 [USB\VID_1DA0&PID_2188]
 Plugin = parade_usbhub
+Flags = enforce-requires
 ParadeUsbhubChip = ps188
 
 # PS188 - Lenovo


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
