### PR TITLE
trivial: contrib/setup: Don't prompt questions when CI=1

### DIFF
--- a/contrib/setup
+++ b/contrib/setup
@@ -25,7 +25,11 @@ rename_branch()
 
 setup_deps()
 {
-    read -p "Install build dependencies? (y/N) " question
+    if [ -z "$CI" ]; then
+        read -p "Install build dependencies? (y/N) " question
+    else
+        question=y
+    fi
     if [ "$question" = "y" ]; then
         python3 $HELPER install-dependencies $HELPER_ARGS -y
     fi


### PR DESCRIPTION
Let agents like Copilot and Claude set CI=1 in the environment so that they don't get asked questions they can't figure out how to answer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
