### PR TITLE
fix number order in ja.po

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -3339,7 +3339,7 @@ msgstr "指定されたデバイスを最新ファームウェアバージョン
 #, c-format
 msgid "Updates have been published for %u local device"
 msgid_plural "Updates have been published for %u of %u local devices"
-msgstr[0] "ローカルデバイス %u 台中 %u 台でアップデートが公開されました"
+msgstr[0] "ローカルデバイス %2$u 台中 %1$u 台でアップデートが公開されました"
 
 msgid "Updating"
 msgstr "アップデート中"


### PR DESCRIPTION
> $ fwupdmgr refresh --force
> アップデート中 lvfs
> ダウンロード中…          [********************                   ]
> 新しいメタデータを正常にダウンロードしました: ローカルデバイス 3 台中 11 台でアップデートが公開されました
> Successfully uploaded report

It says "Updates have been published for 11 of 3 local devices" in Japanese ;-)
We should specify its order with numbers (with gettext feature).

Type of pull request:
- (tiny) Code fix
