### PR TITLE
Allow child devices to get the parent name prefix

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -846,6 +846,14 @@ fu_device_new(FuContext *ctx);
  * Since: 2.0.12
  */
 #define FU_DEVICE_PRIVATE_FLAG_MD_SET_REQUIRED_FREE "md-set-required-free"
+/**
+ * FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX:
+ *
+ * Use the parent device as the name prefix.
+ *
+ * Since: 2.0.15
+ */
+#define FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX "parent-name-prefix"
 
 /* standard icons */
 

--- a/plugins/asus-hid/fu-asus-hid-child-device.c
+++ b/plugins/asus-hid/fu-asus-hid-child-device.c
@@ -222,6 +222,7 @@ fu_asus_hid_child_device_init(FuAsusHidChildDevice *self)
 	fu_device_add_protocol(FU_DEVICE(self), "com.asus.hid");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 }
 

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -352,6 +352,7 @@ fu_ccgx_dmc_devx_device_convert_version(FuDevice *device, guint64 version_raw)
 static void
 fu_ccgx_dmc_devx_device_init(FuCcgxDmcDevxDevice *self)
 {
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 }
 
 static void

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -35,7 +35,6 @@ gboolean
 fu_cfu_module_setup(FuCfuModule *self, const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
 	FuDevice *device = FU_DEVICE(self);
-	FuDevice *parent = fu_device_get_proxy(device);
 	g_autofree gchar *logical_id = NULL;
 	g_autoptr(GByteArray) st = NULL;
 
@@ -60,11 +59,8 @@ fu_cfu_module_setup(FuCfuModule *self, const guint8 *buf, gsize bufsz, gsize off
 
 	/* set name, if not already set using a quirk */
 	if (fu_device_get_name(device) == NULL) {
-		g_autofree gchar *name = NULL;
-		name = g_strdup_printf("%s (0x%02X:0x%02x)",
-				       fu_device_get_name(parent),
-				       self->component_id,
-				       self->bank);
+		g_autofree gchar *name =
+		    g_strdup_printf("0x%02X:0x%02x", self->component_id, self->bank);
 		fu_device_set_name(device, name);
 	}
 
@@ -183,6 +179,7 @@ fu_cfu_module_init(FuCfuModule *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_SIGNED);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PARENT_FOR_OPEN);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 }
 
 static void

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -44,6 +44,7 @@ fu_dfu_target_init(FuDfuTarget *self)
 {
 	FuDfuTargetPrivate *priv = GET_PRIVATE(self);
 	priv->sectors = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 }
 
 static void

--- a/plugins/elan-kbd/fu-elan-kbd-debug-device.c
+++ b/plugins/elan-kbd/fu-elan-kbd-debug-device.c
@@ -59,11 +59,12 @@ fu_elan_kbd_debug_device_set_progress(FuDevice *self, FuProgress *progress)
 static void
 fu_elan_kbd_debug_device_init(FuElanKbdDebugDevice *self)
 {
-	fu_device_set_name(FU_DEVICE(self), "ELAN USB Keyboard (debug)");
+	fu_device_set_name(FU_DEVICE(self), "Debug");
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_protocol(FU_DEVICE(self), "com.elan.kbd");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_INPUT_KEYBOARD);
 }
 

--- a/plugins/elan-kbd/fu-elan-kbd-runtime.c
+++ b/plugins/elan-kbd/fu-elan-kbd-runtime.c
@@ -66,6 +66,7 @@ fu_elan_kbd_runtime_init(FuElanKbdRuntime *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_INPUT_KEYBOARD);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_ELAN_KBD_FIRMWARE);
 	fu_device_add_instance_id_full(FU_DEVICE(self),

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -33,7 +33,6 @@ static gboolean
 fu_igsc_aux_device_probe(FuDevice *device, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(device);
-	g_autofree gchar *name = NULL;
 
 	/* from the self tests */
 	if (parent == NULL) {
@@ -43,10 +42,6 @@ fu_igsc_aux_device_probe(FuDevice *device, GError **error)
 				    "no parent FuIgscDevice");
 		return FALSE;
 	}
-
-	/* fix name */
-	name = g_strdup_printf("%s Data", fu_device_get_name(parent));
-	fu_device_set_name(device, name);
 
 	/* add extra instance IDs */
 	fu_device_add_instance_str(device,
@@ -205,9 +200,11 @@ fu_igsc_aux_device_init(FuIgscAuxDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 	fu_device_add_protocol(FU_DEVICE(self), "com.intel.gsc");
 	fu_device_set_logical_id(FU_DEVICE(self), "fw-data");
+	fu_device_set_name(FU_DEVICE(self), "Data");
 }
 
 static void

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -55,10 +55,7 @@ fu_igsc_oprom_device_probe(FuDevice *device, GError **error)
 			? "OPROMCODE_RECOVERY"
 			: "OPROMCODE");
 		fu_device_set_logical_id(FU_DEVICE(self), "oprom-code");
-		if (parent != NULL) {
-			name = g_strdup_printf("%s OptionROM Code", fu_device_get_name(parent));
-			fu_device_set_name(FU_DEVICE(self), name);
-		}
+		fu_device_set_name(FU_DEVICE(self), "OptionROM Code");
 	} else if (self->payload_type == FU_IGSC_FWU_HECI_PAYLOAD_TYPE_OPROM_DATA) {
 		self->partition_version = FU_IGSC_FWU_HECI_PARTITION_VERSION_OPROM_DATA;
 		fu_device_add_instance_str(
@@ -68,10 +65,7 @@ fu_igsc_oprom_device_probe(FuDevice *device, GError **error)
 			? "OPROMDATA_RECOVERY"
 			: "OPROMDATA");
 		fu_device_set_logical_id(FU_DEVICE(self), "oprom-data");
-		if (parent != NULL) {
-			name = g_strdup_printf("%s OptionROM Data", fu_device_get_name(parent));
-			fu_device_set_name(FU_DEVICE(self), name);
-		}
+		fu_device_set_name(FU_DEVICE(self), "OptionROM Data");
 	}
 
 	/* add extra instance IDs */
@@ -275,6 +269,7 @@ fu_igsc_oprom_device_init(FuIgscOpromDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_add_protocol(FU_DEVICE(self), "com.intel.gsc");
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
@@ -96,6 +96,7 @@ fu_logitech_hidpp_radio_init(FuLogitechHidppRadio *self)
 	fu_device_set_install_duration(FU_DEVICE(self), 270);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PARENT_FOR_BATTERY);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_add_protocol(FU_DEVICE(self), "com.logitech.unifyingsigned");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);
 }

--- a/plugins/mtd/fu-mtd-ifd-device.c
+++ b/plugins/mtd/fu-mtd-ifd-device.c
@@ -106,6 +106,7 @@ static void
 fu_mtd_ifd_device_init(FuMtdIfdDevice *self)
 {
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_COMPUTER);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -120,6 +120,7 @@ fu_synaptics_mst_device_init(FuSynapticsMstDevice *self)
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_SYNAPTICS_MST_DEVICE_FLAG_IS_SOMEWHAT_EMULATED);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 
 	/* this is set from ->incorporate() */
@@ -1630,9 +1631,7 @@ static gboolean
 fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 {
 	FuSynapticsMstDevice *self = FU_SYNAPTICS_MST_DEVICE(device);
-	FuDevice *parent;
 	const gchar *name_family;
-	const gchar *name_parent = NULL;
 	guint8 buf_ver[3] = {0x0};
 	guint8 buf_cid[2] = {0x0};
 	guint8 rc_cap = 0x0;
@@ -1741,14 +1740,7 @@ fu_synaptics_mst_device_setup(FuDevice *device, GError **error)
 	if (!fu_synaptics_mst_device_ensure_board_id(self, error))
 		return FALSE;
 
-	parent = fu_device_get_parent(FU_DEVICE(self));
-	if (parent != NULL)
-		name_parent = fu_device_get_name(parent);
-	if (name_parent != NULL) {
-		name = g_strdup_printf("VMM%04x inside %s", self->chip_id, name_parent);
-	} else {
-		name = g_strdup_printf("VMM%04x", self->chip_id);
-	}
+	name = g_strdup_printf("VMM%04x", self->chip_id);
 	fu_device_set_name(FU_DEVICE(self), name);
 
 	/* set up the device name and kind via quirks */

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -214,9 +214,10 @@ fu_synaprom_config_init(FuSynapromConfig *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_ONLY_VERSION_UPGRADE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PARENT_FOR_OPEN);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_logical_id(FU_DEVICE(self), "cfg");
-	fu_device_set_name(FU_DEVICE(self), "Prometheus IOTA Config");
+	fu_device_set_name(FU_DEVICE(self), "IOTA Config");
 	fu_device_set_summary(FU_DEVICE(self), "Fingerprint reader config");
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_AUTH_FINGERPRINT);
 }

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -68,6 +68,7 @@ fu_test_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 		fu_device_add_flag(child1, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_device_add_flag(child1, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 		fu_device_add_private_flag(child1, FU_DEVICE_PRIVATE_FLAG_INSTALL_PARENT_FIRST);
+		fu_device_add_private_flag(child1, FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 		fu_plugin_device_add(plugin, child1);
 
 		child2 = fu_device_new(ctx);
@@ -83,6 +84,7 @@ fu_test_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
 		fu_device_add_flag(child2, FWUPD_DEVICE_FLAG_UPDATABLE);
 		fu_device_add_flag(child2, FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 		fu_device_add_private_flag(child2, FU_DEVICE_PRIVATE_FLAG_INSTALL_PARENT_FIRST);
+		fu_device_add_private_flag(child2, FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 		fu_plugin_device_add(plugin, child2);
 	}
 

--- a/plugins/usi-dock/fu-usi-dock-child-device.c
+++ b/plugins/usi-dock/fu-usi-dock-child-device.c
@@ -80,6 +80,7 @@ static void
 fu_usi_dock_child_device_init(FuUsiDockChildDevice *self)
 {
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PARENT_FOR_OPEN);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-raw-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-aes-device.c
@@ -286,7 +286,7 @@ fu_wacom_raw_aes_device_write_firmware(FuDevice *device,
 static void
 fu_wacom_raw_aes_device_init(FuWacomRawAesDevice *self)
 {
-	fu_device_set_name(FU_DEVICE(self), "Wacom AES Device");
+	fu_device_set_name(FU_DEVICE(self), "AES Device");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 }
 

--- a/plugins/wacom-raw/fu-wacom-raw-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-emr-device.c
@@ -292,7 +292,7 @@ fu_wacom_raw_emr_device_convert_version(FuDevice *device, guint64 version_raw)
 static void
 fu_wacom_raw_emr_device_init(FuWacomRawEmrDevice *self)
 {
-	fu_device_set_name(FU_DEVICE(self), "Wacom EMR Device");
+	fu_device_set_name(FU_DEVICE(self), "EMR Device");
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
 }
 

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -639,8 +639,6 @@ fu_wac_device_write_firmware(FuDevice *device,
 static gboolean
 fu_wac_device_add_modules_bluetooth(FuWacDevice *self, GError **error)
 {
-	g_autofree gchar *name = NULL;
-	g_autofree gchar *name_id6 = NULL;
 	g_autoptr(FuWacModule) module = NULL;
 	g_autoptr(FuWacModule) module_id6 = NULL;
 	guint16 fw_ver;
@@ -669,17 +667,14 @@ fu_wac_device_add_modules_bluetooth(FuWacDevice *self, GError **error)
 	 * Initialize both and rely on the firmware update containing the appropriate
 	 * package.
 	 */
-	name = g_strdup_printf("%s [Legacy Bluetooth Module]", fu_device_get_name(FU_DEVICE(self)));
 	module = fu_wac_module_bluetooth_new(FU_DEVICE(self));
 	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-	fu_device_set_name(FU_DEVICE(module), name);
+	fu_device_set_name(FU_DEVICE(module), "Legacy Bluetooth Module");
 	fu_device_set_version_raw(FU_DEVICE(module), fw_ver);
 
-	name_id6 = g_strdup_printf("%s [Legacy Bluetooth Module (ID6)]",
-				   fu_device_get_name(FU_DEVICE(self)));
 	module_id6 = fu_wac_module_bluetooth_id6_new(FU_DEVICE(self));
 	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module_id6));
-	fu_device_set_name(FU_DEVICE(module_id6), name_id6);
+	fu_device_set_name(FU_DEVICE(module_id6), "Legacy Bluetooth Module ID6");
 	fu_device_set_version_raw(FU_DEVICE(module_id6), fw_ver);
 	return TRUE;
 }
@@ -804,7 +799,6 @@ fu_wac_device_add_modules(FuWacDevice *self, GError **error)
 		guint32 ver;
 		guint16 ver2;
 		FuWacModuleFwType fw_type;
-		g_autofree gchar *name = NULL;
 		g_autoptr(FuStructModuleItem) st_item = NULL;
 		g_autoptr(FuWacModule) module = NULL;
 
@@ -828,61 +822,47 @@ fu_wac_device_add_modules(FuWacDevice *self, GError **error)
 		switch (fw_type) {
 		case FU_WAC_MODULE_FW_TYPE_TOUCH:
 			module = fu_wac_module_touch_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Touch Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Touch Module");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_TOUCH_ID7:
 			module = fu_wac_module_touch_id7_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Touch Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Touch Module");
 			fu_device_set_summary(FU_DEVICE(module), "ID7");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_BLUETOOTH:
 			module = fu_wac_module_bluetooth_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Bluetooth Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Bluetooth Module");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_BLUETOOTH_ID6:
 			module = fu_wac_module_bluetooth_id6_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Bluetooth Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Bluetooth Module");
 			fu_device_set_summary(FU_DEVICE(module), "ID6");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_SCALER:
 			module = fu_wac_module_scaler_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Scaler Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Scaler Module");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_BLUETOOTH_ID9:
 			module = fu_wac_module_bluetooth_id9_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Bluetooth Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Bluetooth Module");
 			fu_device_set_summary(FU_DEVICE(module), "ID9");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_SUB_CPU:
 			module = fu_wac_module_sub_cpu_new(FU_DEVICE(self));
-			name = g_strdup_printf("%s [Sub CPU Module]",
-					       fu_device_get_name(FU_DEVICE(self)));
 			fu_device_add_child(FU_DEVICE(self), FU_DEVICE(module));
-			fu_device_set_name(FU_DEVICE(module), name);
+			fu_device_set_name(FU_DEVICE(module), "Sub CPU Module");
 			fu_device_set_version_raw(FU_DEVICE(module), ver);
 			break;
 		case FU_WAC_MODULE_FW_TYPE_MAIN:

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -269,6 +269,7 @@ fu_wac_module_init(FuWacModule *self)
 	fu_device_add_protocol(FU_DEVICE(self), "com.wacom.usb");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_FLAGS);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_BCD);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }


### PR DESCRIPTION
Prefixing the parent device name to the child is something that quite a few fwupd plugins do, but it's not consistent and not easy to get correct if the child devices have a different lifecycle to the parent.

Provide a new private device flag. This means the various UI prompts using the device name make a lot more sense, e.g.

	├─Bolt Receiver:
	│ │   Device ID:          a942915e100e5b46d64d74bd7b536cb4ec9e197f
	│ │
	│ ├─Bolt Receiver (Radio):
	│ │     Device ID:        21cf6b13940829283aa207ee4311573f0c869677
	│ │
	│ └─MX Master 3 B:
	│   │   Device ID:        ab69d297bf9c4fa4bc4f5c3159c89b9c212aed36
	│   │
	│   └─MX Master 3 B (Radio):
	│         Device ID:      c676b78262cd2f39a542ef2c26c90d13ecbc97bb

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
