### PR TITLE
modem-manager: Erase the RM520N-GL correctly

### DIFF
--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -7884,6 +7884,7 @@ fu_device_load_event(FuDevice *self, const gchar *id, GError **error)
 		FuDeviceEvent *event = g_ptr_array_index(priv->events, i);
 		if (g_strcmp0(fu_device_event_get_id(event), id_hash) == 0) {
 			priv->event_idx = i + 1;
+			g_debug("found event with ID %s [%s]", id, id_hash);
 			return event;
 		}
 	}
@@ -7903,7 +7904,12 @@ fu_device_load_event(FuDevice *self, const gchar *id, GError **error)
 	}
 
 	/* nothing found */
-	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no event with ID %s", id);
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
+		    "no event with ID %s [%s]",
+		    id,
+		    id_hash);
 	return NULL;
 }
 

--- a/plugins/modem-manager/tests/lenovo-em061kgl-mbim.json
+++ b/plugins/modem-manager/tests/lenovo-em061kgl-mbim.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "url": "b6d45ea6cc285ae4ae7c9cdae9607a3b7b579c78c7bf1f65825a3dc707ec20cb-EM061KGLAAR01A02M2G_01.013.01.013.cab",
-      "emulation-url": "fa74269fd6b466f108acca8aab442ecf5df4f14f450c2b37ae6b49b1fcaac1ad-EM061KGLAAR01A02M2G_01.013.01.013.zip",
+      "emulation-url": "d2627a4a2334f567d42e7b10b8e4c2c3ff5cf0baf132cc5e607da642d6dbcea7-EM061KGLAAR01A02M2G_01.013.01.013_fixed.zip",
       "components": [
         {
           "version": "EM061KGLAAR01A02M2G_01.013.01.013",

--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -448,12 +448,23 @@ fu_qc_firehose_impl_erase(FuQcFirehoseImpl *self,
 {
 	g_autoptr(XbBuilderNode) bn = xb_builder_node_new("data");
 	g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, xb_node_get_element(xn), NULL);
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	g_autoptr(GHashTable) xn_attrs = NULL;
+#else
 	const gchar *names[] = {
 	    "PAGES_PER_BLOCK",
 	    "SECTOR_SIZE_IN_BYTES",
 	    "num_partition_sectors",
+	    "physical_partition_number",
 	    "start_sector",
+	    /* these are Quectel-specific */
+	    "a_rawdata_start_sector",
+	    "b_rawdata_num_sector",
+	    "c_project_name",
+	    "d_project_type",
+	    "vendor",
 	};
+#endif
 
 	/* sanity check */
 	if (!fu_qc_firehose_impl_has_function(self, FU_QC_FIREHOSE_FUNCTIONS_ERASE)) {
@@ -463,11 +474,26 @@ fu_qc_firehose_impl_erase(FuQcFirehoseImpl *self,
 				    "erase is not supported");
 		return FALSE;
 	}
+
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	/* copy over all attributes */
+	xn_attrs = xb_node_get_attrs(xn);
+	if (g_hash_table_size(xn_attrs) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "erase with no attributes is not supported");
+		return FALSE;
+	}
+	xb_builder_node_set_attrs(bc, xn_attrs);
+#else
+	/* copy over all *known* attributes */
 	for (guint i = 0; i < G_N_ELEMENTS(names); i++) {
 		const gchar *value = xb_node_get_attr(xn, names[i]);
 		if (value != NULL)
 			xb_builder_node_set_attr(bc, names[i], value);
 	}
+#endif
 	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
 		return FALSE;
 	return fu_qc_firehose_impl_read_xml(self, 30000, helper, error);
@@ -538,6 +564,9 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 	g_autoptr(GBytes) blob_padded = NULL;
 	g_autoptr(XbBuilderNode) bn = xb_builder_node_new("data");
 	g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, xb_node_get_element(xn), NULL);
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	g_autoptr(GHashTable) xn_attrs = NULL;
+#else
 	const gchar *names[] = {
 	    "PAGES_PER_BLOCK",
 	    "SECTOR_SIZE_IN_BYTES",
@@ -547,6 +576,7 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 	    "start_sector",
 	    "last_sector",
 	};
+#endif
 
 	/* sanity check */
 	if (!fu_qc_firehose_impl_has_function(self, FU_QC_FIREHOSE_FUNCTIONS_PROGRAM)) {
@@ -565,12 +595,25 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 	if (blob == NULL)
 		return FALSE;
 
-	/* copy across */
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	/* copy over all attributes */
+	xn_attrs = xb_node_get_attrs(xn);
+	if (g_hash_table_size(xn_attrs) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "program with no attributes is not supported");
+		return FALSE;
+	}
+	xb_builder_node_set_attrs(bc, xn_attrs);
+#else
+	/* copy over all *known* attributes */
 	for (guint i = 0; i < G_N_ELEMENTS(names); i++) {
 		const gchar *value = xb_node_get_attr(xn, names[i]);
 		if (value != NULL)
 			xb_builder_node_set_attr(bc, names[i], value);
 	}
+#endif
 	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
 		return FALSE;
 	if (!fu_qc_firehose_impl_read_xml(self, 2500, helper, error)) {
@@ -630,6 +673,9 @@ fu_qc_firehose_impl_apply_patch(FuQcFirehoseImpl *self,
 {
 	g_autoptr(XbBuilderNode) bn = xb_builder_node_new("data");
 	g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, xb_node_get_element(xn), NULL);
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	g_autoptr(GHashTable) xn_attrs = NULL;
+#else
 	const gchar *names[] = {
 	    "SECTOR_SIZE_IN_BYTES",
 	    "byte_offset",
@@ -639,6 +685,7 @@ fu_qc_firehose_impl_apply_patch(FuQcFirehoseImpl *self,
 	    "start_sector",
 	    "value",
 	};
+#endif
 
 	/* sanity check */
 	if (!fu_qc_firehose_impl_has_function(self, FU_QC_FIREHOSE_FUNCTIONS_PATCH)) {
@@ -648,11 +695,26 @@ fu_qc_firehose_impl_apply_patch(FuQcFirehoseImpl *self,
 				    "patch is not supported");
 		return FALSE;
 	}
+
+#if LIBXMLB_CHECK_VERSION(0, 3, 24)
+	/* copy over all attributes */
+	xn_attrs = xb_node_get_attrs(xn);
+	if (g_hash_table_size(xn_attrs) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "patch with no attributes is not supported");
+		return FALSE;
+	}
+	xb_builder_node_set_attrs(bc, xn_attrs);
+#else
+	/* copy over all *known* attributes */
 	for (guint i = 0; i < G_N_ELEMENTS(names); i++) {
 		const gchar *value = xb_node_get_attr(xn, names[i]);
 		if (value != NULL)
 			xb_builder_node_set_attr(bc, names[i], value);
 	}
+#endif
 	if (!fu_qc_firehose_impl_write_xml(self, bn, error))
 		return FALSE;
 	return fu_qc_firehose_impl_read_xml(self, 5000, helper, error);

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -127,8 +127,9 @@ fu_qc_firehose_usb_device_write(FuQcFirehoseUsbDevice *self,
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
-				    "only wrote %" G_GSIZE_FORMAT "bytes",
-				    actual_len);
+				    "only wrote 0x%x of 0x%x bytes",
+				    (guint)actual_len,
+				    (guint)fu_chunk_get_data_sz(chk));
 			return FALSE;
 		}
 	}

--- a/plugins/qc-firehose/tests/qc-eg25ggc.json
+++ b/plugins/qc-firehose/tests/qc-eg25ggc.json
@@ -4,7 +4,7 @@
   "steps": [
     {
       "url": "b1cd72c75053f5c29e55784ef30e5d4be722c1aacc2400995b1ee248f07be7d6-EG25GGC-0.0.cab",
-      "emulation-url": "0f21d648b33736fa0f8d1ec36805627291428c5a6197cc2443988ccb80df0fa4-emulation.zip",
+      "emulation-url": "7868d8239184b8d3c63ba9936441f86410447411a650f2ba0169c3f870d63dcf-emulation.zip",
       "components": [
         {
           "version": "0.0",


### PR DESCRIPTION
Fix a bug where a vendor-specific firehose `<erase>` attributes were mis-copied which lead to a complete device erasure.

See https://github.com/hughsie/libxmlb/pull/260 for the new libxmlb API needed.

Hopefully fixes https://github.com/fwupd/fwupd/issues/8382

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
