### PR TITLE
nvme: Require a full system shutdown for all Micron NVMe drives

### DIFF
--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -6,6 +6,10 @@ Flags = force-align,needs-shutdown
 [NVME\VEN_2646]
 Flags = needs-shutdown
 
+# Micron
+[NVME\VEN_1344]
+Flags = needs-shutdown
+
 # KIOXIA
 [NVME\VEN_1179]
 Flags = signed-payload


### PR DESCRIPTION
Fixes https://github.com/fwupd/firmware-lenovo/issues/526

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
