### PR TITLE
goodix-moc: Fix enumeration after the plugin rename

### DIFF
--- a/plugins/goodix-moc/fu-goodix-moc-plugin.c
+++ b/plugins/goodix-moc/fu-goodix-moc-plugin.c
@@ -22,13 +22,6 @@ fu_goodix_moc_plugin_init(FuGoodixMocPlugin *self)
 }
 
 static void
-fu_goodix_moc_plugin_object_constructed(GObject *obj)
-{
-	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_set_name(plugin, "goodixmoc");
-}
-
-static void
 fu_goodix_moc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
@@ -39,7 +32,5 @@ static void
 fu_goodix_moc_plugin_class_init(FuGoodixMocPluginClass *klass)
 {
 	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
-	object_class->constructed = fu_goodix_moc_plugin_object_constructed;
 	plugin_class->constructed = fu_goodix_moc_plugin_constructed;
 }


### PR DESCRIPTION
The plugin was renamed in 2.0.14 from goodixmoc to goodix-moc -- but the explicit `fu_plugin_set_name()` was missed as it wasn't actually needed in the first place.

Fixes: https://github.com/fwupd/fwupd/issues/9205

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
