### PR TITLE
devlink: Fix PCI instance ID for component device

### DIFF
--- a/plugins/devlink/fu-devlink-device.c
+++ b/plugins/devlink/fu-devlink-device.c
@@ -577,6 +577,7 @@ fu_devlink_device_update_component_cb(gpointer key, gpointer value, gpointer use
 		g_debug("ignoring %s", name);
 		return;
 	}
+	fu_device_incorporate(component, helper->device, FU_DEVICE_INCORPORATE_FLAG_INSTANCE_KEYS);
 	fu_devlink_device_add_component_instance_strs(component, helper);
 	fu_device_set_version_format(component, fu_version_guess_format(version));
 	fu_device_set_version(component, version);


### PR DESCRIPTION
This fixes bug of instance ID creation for component device. VEN and DEV instance strings were not inherited from parent device and therefore never filled. Fix that by incorporating parent keys before component probe.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
