### PR TITLE
mtd: Fix version number for B&R device

### DIFF
--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -44,14 +44,8 @@ fu_mtd_device_convert_version(FuDevice *device, guint64 version_raw)
 {
 	FuMtdDevice *self = FU_MTD_DEVICE(device);
 
-	/* let's assume for now that any PCI device with pair version format uses B&R encoding */
-	if (self->is_pci_device &&
-	    fu_device_get_version_format(self) == FWUPD_VERSION_FORMAT_PAIR) {
-		guint64 major = version_raw / 100;
-		guint64 minor = version_raw % 100;
-
-		return g_strdup_printf("%" G_GUINT64_FORMAT ".%02" G_GUINT64_FORMAT, major, minor);
-	}
+	if (fu_device_get_version_format(self) == FWUPD_VERSION_FORMAT_NUMBER)
+		return g_strdup_printf("%" G_GUINT64_FORMAT, version_raw);
 
 	return NULL;
 }

--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -22,4 +22,4 @@ Name = PCH SPI Controller
 # B&R Industrial Automation GmbH 5ACCIFM0.FCAN-000
 [MTD\VEN_1677&DEV_28A4]
 Flags = ~needs-reboot,needs-shutdown,usable-during-update,unsigned-payload
-VersionFormat = pair
+VersionFormat = number


### PR DESCRIPTION
This was a misunderstanding and was actually supposed to be a simple number format because of the limitation of the PCI revision type.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

Not sure if there is a better solution here in terms of compatiblity but we will likely only publish an official public release on LVFS after a version has been released with this fix. Otherwise we would presumably have to maintain two cab files with separate fw versions and fwupd version restrictions.