### PR TITLE
fix `-fsanitize=function` in tests

### DIFF
--- a/libfwupdplugin/fu-device-locker.c
+++ b/libfwupdplugin/fu-device-locker.c
@@ -95,6 +95,27 @@ fu_device_locker_close(FuDeviceLocker *self, GError **error)
 }
 
 /**
+ * Callback used to placate `-fsanitize=function`; passed so we can avoid casts of
+ * `fu_device_open` to this function's signature.
+ */
+static gboolean
+fu_device_open_callback(GObject *device, GError **error)
+{
+	return fu_device_open((FuDevice *)device, error);
+}
+
+/**
+ * Callback used to placate `-fsanitize=function`; passed so we can avoid casts of
+ * `fu_device_close` to this function's signature.
+ */
+static gboolean
+fu_device_close_callback(GObject *device, GError **error)
+{
+	return fu_device_close((FuDevice *)device, error);
+}
+
+
+/**
  * fu_device_locker_new:
  * @device: a #GObject
  * @error: (nullable): optional return location for an error
@@ -126,8 +147,8 @@ fu_device_locker_new(gpointer device, GError **error)
 	/* FuDevice */
 	if (FU_IS_DEVICE(device)) {
 		return fu_device_locker_new_full(device,
-						 (FuDeviceLockerFunc)fu_device_open,
-						 (FuDeviceLockerFunc)fu_device_close,
+						 fu_device_open_callback,
+						 fu_device_close_callback,
 						 error);
 	}
 	g_set_error_literal(error,

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -557,6 +557,16 @@ fu_usb_device_open(FuDevice *device, GError **error)
 }
 
 /**
+ * Callback used to placate `-fsanitize=function`; passed so we can avoid casts of
+ * `fu_usb_device_open` to this function's signature.
+ */
+static gboolean
+fu_usb_device_open_callback(GObject *device, GError **error)
+{
+	return fu_usb_device_open((FuDevice *)device, error);
+}
+
+/**
  * fu_usb_device_get_bus:
  * @self: a #FuUsbDevice
  *
@@ -826,6 +836,16 @@ fu_usb_device_close(FuDevice *device, GError **error)
 	return FU_DEVICE_CLASS(fu_usb_device_parent_class)->close(device, error);
 }
 
+/**
+ * Callback used to placate `-fsanitize=function`; passed so we can avoid casts of
+ * `fu_usb_device_close` to this function's signature.
+ */
+static gboolean
+fu_usb_device_close_callback(GObject *device, GError **error)
+{
+	return fu_usb_device_close((FuDevice *)device, error);
+}
+
 static gboolean
 fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, FuUsbBosDescriptor *bos, GError **error)
 {
@@ -859,8 +879,8 @@ fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, FuUsbBosDescriptor *bos, G
 
 	/* set the quirks onto the device */
 	usb_locker = fu_device_locker_new_full(self,
-					       (FuDeviceLockerFunc)fu_usb_device_open,
-					       (FuDeviceLockerFunc)fu_usb_device_close,
+					       fu_usb_device_open_callback,
+					       fu_usb_device_close_callback,
 					       error);
 	if (usb_locker == NULL)
 		return FALSE;


### PR DESCRIPTION
It's technically undefined behavior to call `void (*)(U *)` as though it were `void (*)(U *)`.

In practice, this is unlikely to break much on its own, but cleaning this up does allow for `-fsanitize=function` to be more widely used on this codebase, which can catch much more interesting forms of undefined behavior (e.g., calling `void (*)(int, int)` as `void (*)(int)`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
