### PR TITLE
contribu/setup: Allow bootstrapping on FreeBSD

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -21,6 +21,9 @@
       <package variant="aarch64" />
       <package variant="mingw64" />
     </distro>
+    <distro id="freebsd">
+      <package variant="amd64" />
+    </distro>
   </dependency>
   <dependency id="pesign">
     <distro id="centos">
@@ -213,6 +216,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>libdrm</package>
+    </distro>
   </dependency>
   <dependency id="libjson-glib-dev">
     <distro id="arch">
@@ -305,6 +311,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>noto-sans</package>
     </distro>
   </dependency>
   <dependency id="devscripts">
@@ -518,6 +527,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>gettext</package>
+    </distro>
   </dependency>
   <dependency id="gnupg2">
     <distro id="centos">
@@ -526,6 +538,9 @@
     <distro id="fedora">
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>gpgme</package>
     </distro>
   </dependency>
   <dependency id="gnu-efi-devel">
@@ -612,6 +627,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>glib</package>
+    </distro>
   </dependency>
   <dependency id="glibc-langpack-en">
     <distro id="centos">
@@ -645,6 +663,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package variant="amd64" />
     </distro>
   </dependency>
   <dependency id="gnome-desktop-testing">
@@ -682,6 +703,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>gnutls</package>
     </distro>
   </dependency>
   <dependency id="gnutls-bin">
@@ -752,6 +776,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>libxmlb</package>
+    </distro>
   </dependency>
   <dependency id="libjcat-dev">
     <distro id="arch">
@@ -774,6 +801,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>libjcat</package>
     </distro>
   </dependency>
   <dependency id="libblkid-dev">
@@ -853,6 +883,9 @@
     <distro id="darwin">
       <package>libarchive</package>
     </distro>
+    <distro id="freebsd">
+      <package>libarchive</package>
+    </distro>
   </dependency>
   <dependency id="libcbor-dev">
     <distro id="arch">
@@ -875,6 +908,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>libcbor</package>
     </distro>
   </dependency>
   <dependency id="libgirepository1.0-dev">
@@ -1043,6 +1079,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package variant="amd64" />
+    </distro>
   </dependency>
   <dependency id="mingw-w64-tools">
     <distro id="centos">
@@ -1088,6 +1127,9 @@
       <control />
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>pango</package>
     </distro>
   </dependency>
   <dependency id="pkg-config">
@@ -1249,6 +1291,9 @@
     <distro id="arch">
       <package variant="x86_64">python-pip</package>
     </distro>
+    <distro id="freebsd">
+      <package>py311-pip</package>
+    </distro>
   </dependency>
   <dependency id="python3-virtualenv">
     <distro id="debian">
@@ -1377,6 +1422,9 @@
       <package variant="x86_64" />
       <package variant="aarch64" />
     </distro>
+    <distro id="freebsd">
+      <package>py311-gi-docgen</package>
+    </distro>
   </dependency>
   <!-- These are needed for gi-docgen -->
   <dependency id="python3-pygments">
@@ -1460,6 +1508,9 @@
     <distro id="fedora">
       <package variant="x86_64" />
       <package variant="aarch64" />
+    </distro>
+    <distro id="freebsd">
+      <package>py311-pygobject</package>
     </distro>
   </dependency>
   <dependency id="python3-requests">
@@ -1551,6 +1602,9 @@
     </distro>
     <distro id="darwin">
       <package>sqlite</package>
+    </distro>
+    <distro id="freebsd">
+      <package>sqlite3</package>
     </distro>
   </dependency>
   <dependency id="systemd">

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -18,7 +18,7 @@ MINIMUM_MARKDOWN = (3, 2, 0)
 
 
 def get_possible_profiles():
-    return ["fedora", "centos", "debian", "ubuntu", "arch", "darwin"]
+    return ["fedora", "centos", "debian", "ubuntu", "arch", "darwin", "freebsd"]
 
 
 def detect_profile():
@@ -195,6 +195,8 @@ def _get_installer_cmd(profile: str, yes: bool):
         installer = ["dnf", "install"]
     elif profile == "arch":
         installer = ["pacman", "-Syu", "--noconfirm", "--needed"]
+    elif profile == "freebsd":
+        installer = ["pkg", "install"]
     else:
         print("unable to detect OS profile, use --os= to specify")
         print(f"\tsupported profiles: {get_possible_profiles()}")

--- a/contrib/setup
+++ b/contrib/setup
@@ -210,7 +210,7 @@ detect_os "$@"
 #if interactive install build deps and prepare environment
 if [ -t 2 ]; then
     case $OS in
-        debian|ubuntu|arch|fedora|darwin)
+        debian|ubuntu|arch|fedora|darwin|freebsd)
             setup_deps
             ;;
     esac


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Now we can run `./contrib/setup` like on many linux distros and get the necessary dependencies :)
And also run `build-fwupd`, though compilation still has some errors.