### PR TITLE
trivial: ci: explicitly set read/write on matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,10 @@ on:
   push:
     branches: [ main ]
 
-permissions:
-  contents: read
-
 jobs:
   snap:
+    permissions:
+      contents: read
     uses: ./.github/workflows/snap.yml
     with:
       deploy: true

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -5,11 +5,10 @@ on:
         required: true
         type: boolean
 
-permissions:
-  contents: read
-
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: library
     strategy:
@@ -64,6 +63,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   openbmc:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     if: ${{ !inputs.publish }}
     steps:
@@ -81,6 +82,8 @@ jobs:
           ./contrib/build-openbmc.sh --prefix=/home/runner/.root
 
   library:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -114,6 +117,8 @@ jobs:
           path: ${{ github.workspace }}/build/meson-dist/*xz
 
   macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     if: ${{ !inputs.publish }}
     steps:
@@ -128,6 +133,8 @@ jobs:
       run: ninja -C build-macos
 
   build-windows:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: fedora:42
@@ -143,6 +150,8 @@ jobs:
           ${{ github.workspace }}/dist/setup/*.msi
 
   publish-docs:
+    permissions:
+      contents: read
     name: Publish docs
     if: ${{ inputs.publish }}
     runs-on: ubuntu-latest
@@ -178,6 +187,8 @@ jobs:
           git push git@github.com:fwupd/fwupd.github.io.git
 
   publish-windows:
+    permissions:
+      contents: write
     name: Publish Windows binaries
     runs-on: ubuntu-latest
     if: ${{ inputs.publish }}

--- a/.github/workflows/pull-request-reviews.yml
+++ b/.github/workflows/pull-request-reviews.yml
@@ -3,11 +3,10 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
commit b06410d74 ("trivial: ci: add write permissions to Windows publish job") attempted to set write permisions for the windows publishing job but this broke matrix parsing due to nested permission mismatches. This was reverted in commit 94ede82c1 ("Revert "trivial: ci: add write permissions to Windows publish job"")

Instead explicitly set permissions on each job.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
