### PR TITLE
Fix missing release locations when loading from artifact

### DIFF
--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -439,7 +439,7 @@ fu_release_load_artifact(FuRelease *self, XbNode *artifact, GError **error)
 	filename = xb_node_query_text(artifact, "filename", NULL);
 	if (filename != NULL) {
 		g_autofree gchar *fn_lowercase = g_ascii_strdown(filename, -1);
-		if (g_str_has_suffix(fn_lowercase, ".cab")) {
+		if (!g_str_has_suffix(fn_lowercase, ".cab")) {
 			/* some firmware archives was signed with <artifact type="binary"> where the
 			 * checksums were the *content* checksums, not the *container* checksum */
 			g_debug("ignoring non-binary artifact entry: %s", filename);


### PR DESCRIPTION
This regressed in dd56b98a.

Fixes https://github.com/fwupd/fwupd/issues/9231

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
