### PR TITLE
trivial: Allow disabling libmnl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -413,7 +413,7 @@ libm = cc.find_library(
 zlib = dependency('zlib')
 libmnl = dependency(
   'libmnl',
-  required: false,
+  required: get_option('libmnl'),
 )
 
 fs = import('fs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -78,6 +78,10 @@ option('libdrm',
   type: 'feature',
   description: 'libdrm support',
 )
+option('libmnl',
+  type: 'feature',
+  description: 'libmnl support'
+)
 option('valgrind',
   type: 'feature',
   description: 'valgrind support',


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

`required: false` may or may not link against libmnl depending on the build system's installed dependencies.
This should not change anything by default if `-Dlibmnl` is not configured.