### PR TITLE
Allow new default path for homebrew

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -439,6 +439,9 @@ if vendor_ids_dir == ''
     vendor_ids_dir = '/usr/local/var/homebrew/linked/usb.ids/share/misc'
   endif
   if not fs.is_file(join_paths(vendor_ids_dir, 'usb.ids'))
+    vendor_ids_dir = '/opt/homebrew/share/misc'
+  endif
+  if not fs.is_file(join_paths(vendor_ids_dir, 'usb.ids'))
     error('could not auto-detect -Dvendor_ids_dir=')
   endif
 endif


### PR DESCRIPTION
The usb.ids is normally installed by homebrew. However, homebrew change its default path to /opt/homebrew/. We add the /opt/homebrew to default search path in usb.ids.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
