### PR TITLE
trivial: Set a better default filename when parsing a FuEfiX509Signature

### DIFF
--- a/libfwupdplugin/fu-efi-x509-signature.c
+++ b/libfwupdplugin/fu-efi-x509-signature.c
@@ -254,6 +254,15 @@ fu_efi_x509_signature_parse(FuFirmware *firmware,
 		}
 	}
 
+	/* set something plausible */
+	if (fu_firmware_get_filename(firmware) == NULL &&
+	    fu_x509_certificate_get_subject(crt) != NULL) {
+		g_autofree gchar *filename = g_strdup_printf("%s_%s.der",
+							     fu_firmware_get_id(FU_FIRMWARE(crt)),
+							     fu_x509_certificate_get_subject(crt));
+		fu_firmware_set_filename(firmware, filename);
+	}
+
 	/* success */
 	return TRUE;
 }


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
