### PR TITLE
Only add the USB subsystem when actually needed

### DIFF
--- a/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_algoltek_usb_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ALGOLTEK_USB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ALGOLTEK_USB_FIRMWARE);
 }

--- a/plugins/analogix/fu-analogix-plugin.c
+++ b/plugins/analogix/fu-analogix-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_analogix_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ANALOGIX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ANALOGIX_FIRMWARE);
 }

--- a/plugins/aver-hid/fu-aver-hid-plugin.c
+++ b/plugins/aver-hid/fu-aver-hid-plugin.c
@@ -27,6 +27,7 @@ static void
 fu_aver_hid_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_SAFEISP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AVER_HID_FIRMWARE);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
@@ -29,6 +29,7 @@ fu_ccgx_dmc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "CcgxDmcTriggerCode");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_CCGX_DMC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_DMC_DEVX_DEVICE); /* coverage */

--- a/plugins/ccgx/fu-ccgx-plugin.c
+++ b/plugins/ccgx/fu-ccgx-plugin.c
@@ -32,6 +32,7 @@ fu_ccgx_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CcgxFlashRowSize");
 	fu_context_add_quirk_key(ctx, "CcgxFlashSize");
 	fu_context_add_quirk_key(ctx, "CcgxImageKind");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_PURE_HID_DEVICE);

--- a/plugins/cfu/fu-cfu-plugin.c
+++ b/plugins/cfu/fu-cfu-plugin.c
@@ -31,6 +31,7 @@ fu_cfu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CfuOfferGetReport");
 	fu_context_add_quirk_key(ctx, "CfuContentSetReport");
 	fu_context_add_quirk_key(ctx, "CfuContentGetReport");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CFU_DEVICE);
 }
 

--- a/plugins/ch341a/fu-ch341a-plugin.c
+++ b/plugins/ch341a/fu-ch341a-plugin.c
@@ -31,6 +31,7 @@ static void
 fu_ch341a_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CH341A_DEVICE);
 }
 

--- a/plugins/ch347/fu-ch347-plugin.c
+++ b/plugins/ch347/fu-ch347-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_ch347_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CH347_DEVICE);
 }
 

--- a/plugins/corsair/fu-corsair-plugin.c
+++ b/plugins/corsair/fu-corsair-plugin.c
@@ -30,6 +30,7 @@ fu_corsair_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CorsairDeviceKind");
 	fu_context_add_quirk_key(ctx, "CorsairVendorInterfaceId");
 	fu_context_add_quirk_key(ctx, "CorsairSubdeviceId");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_CORSAIR_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CORSAIR_BP); /* coverage */
 }

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_cros_ec_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_FIRMWARE);
 }

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -322,6 +322,8 @@ fu_dell_dock_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "DellDockUnlockTarget");
 	fu_context_add_quirk_key(ctx, "DellDockVersionLowest");
 
+	fu_plugin_add_udev_subsystem(plugin, "usb");
+
 	/* allow these to be built by quirks */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_DOCK_STATUS);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_DOCK_MST);

--- a/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
@@ -450,6 +450,8 @@ fu_dell_kestrel_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 
+	fu_plugin_add_udev_subsystem(plugin, "usb");
+
 	/* allow these to be built by quirks */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_KESTREL_PACKAGE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_KESTREL_PD);

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -244,6 +244,8 @@ fu_dell_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 
+	fu_plugin_add_udev_subsystem(plugin, "usb");
+
 	/* make sure that UEFI plugin is ready to receive devices */
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_AFTER, "uefi_capsule");
 }

--- a/plugins/dfu/fu-dfu-plugin.c
+++ b/plugins/dfu/fu-dfu-plugin.c
@@ -28,6 +28,7 @@ fu_dfu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "DfuAltName");
 	fu_context_add_quirk_key(ctx, "DfuForceTimeout");
 	fu_context_add_quirk_key(ctx, "DfuForceVersion");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DFU_DEVICE);
 }
 

--- a/plugins/ebitdo/fu-ebitdo-plugin.c
+++ b/plugins/ebitdo/fu-ebitdo-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_ebitdo_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EBITDO_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EBITDO_FIRMWARE);
 }

--- a/plugins/egis-moc/fu-egis-moc-plugin.c
+++ b/plugins/egis-moc/fu-egis-moc-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_egis_moc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EGIS_MOC_DEVICE);
 }
 

--- a/plugins/elan-kbd/fu-elan-kbd-plugin.c
+++ b/plugins/elan-kbd/fu-elan-kbd-plugin.c
@@ -28,6 +28,7 @@ static void
 fu_elan_kbd_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELAN_KBD_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELAN_KBD_DEBUG_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_ELAN_KBD_RUNTIME);

--- a/plugins/elanfp/fu-elanfp-plugin.c
+++ b/plugins/elanfp/fu-elanfp-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_elanfp_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANFP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANFP_FIRMWARE);
 }

--- a/plugins/ep963x/fu-ep963x-plugin.c
+++ b/plugins/ep963x/fu-ep963x-plugin.c
@@ -33,6 +33,7 @@ static void
 fu_ep963x_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EP963X_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EP963X_FIRMWARE);
 }

--- a/plugins/fastboot/fu-fastboot-plugin.c
+++ b/plugins/fastboot/fu-fastboot-plugin.c
@@ -27,6 +27,7 @@ fu_fastboot_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "FastbootBlockSize");
 	fu_context_add_quirk_key(ctx, "FastbootOperationDelay");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FASTBOOT_DEVICE);
 }
 

--- a/plugins/fpc/fu-fpc-plugin.c
+++ b/plugins/fpc/fu-fpc-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_fpc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FPC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_FPC_FF2_FIRMWARE);
 }

--- a/plugins/fresco-pd/fu-fresco-pd-plugin.c
+++ b/plugins/fresco-pd/fu-fresco-pd-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_fresco_pd_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FRESCO_PD_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_FRESCO_PD_FIRMWARE);
 }

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -36,6 +36,7 @@ fu_genesys_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "GenesysUsbhubReadRequest");
 	fu_context_add_quirk_key(ctx, "GenesysUsbhubSwitchRequest");
 	fu_context_add_quirk_key(ctx, "GenesysUsbhubWriteRequest");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_USBHUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_HUBHID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_USBHUB_FIRMWARE);

--- a/plugins/goodix-moc/fu-goodix-moc-plugin.c
+++ b/plugins/goodix-moc/fu-goodix-moc-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_goodix_moc_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GOODIX_MOC_DEVICE);
 }
 

--- a/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_hpi_cfu_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HPI_CFU_DEVICE);
 }
 

--- a/plugins/huddly-usb/fu-huddly-usb-plugin.c
+++ b/plugins/huddly-usb/fu-huddly-usb-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_huddly_usb_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HUDDLY_USB_DEVICE);
 }
 

--- a/plugins/hughski-colorhug/fu-hughski-colorhug-plugin.c
+++ b/plugins/hughski-colorhug/fu-hughski-colorhug-plugin.c
@@ -24,6 +24,7 @@ static void
 fu_hughski_colorhug_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HUGHSKI_COLORHUG_DEVICE);
 }
 

--- a/plugins/intel-usb4/fu-intel-usb4-plugin.c
+++ b/plugins/intel-usb4/fu-intel-usb4-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_intel_usb4_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_USB4_DEVICE);
 }
 

--- a/plugins/jabra-file/fu-jabra-file-plugin.c
+++ b/plugins/jabra-file/fu-jabra-file-plugin.c
@@ -26,6 +26,7 @@ static void
 fu_jabra_file_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_FILE_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_FILE_FIRMWARE);
 }

--- a/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
@@ -28,6 +28,7 @@ fu_jabra_gnp_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "JabraGnpAddress");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_GNP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_GNP_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_GNP_IMAGE); /* coverage */

--- a/plugins/jabra/fu-jabra-plugin.c
+++ b/plugins/jabra/fu-jabra-plugin.c
@@ -61,6 +61,7 @@ fu_jabra_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "JabraMagic");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_DEVICE);
 }
 

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
@@ -65,6 +65,7 @@ static void
 fu_logitech_bulkcontroller_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LOGITECH_BULKCONTROLLER_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_BULKCONTROLLER_CHILD); /* coverage */
 }

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -34,6 +34,7 @@ fu_logitech_hidpp_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "LogitechHidppModelId");
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "unifying");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_BOOTLOADER_NORDIC);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_BOOTLOADER_TEXAS);

--- a/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
@@ -27,6 +27,7 @@ fu_parade_usbhub_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "ParadeUsbhubChip");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PARADE_USBHUB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_PARADE_USBHUB_FIRMWARE);
 }

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
@@ -30,6 +30,7 @@ fu_qc_s5gen2_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "QcS5gen2Gaia3VendorId");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_BLE_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_HID_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QC_S5GEN2_DEVICE);

--- a/plugins/qsi-dock/fu-qsi-dock-plugin.c
+++ b/plugins/qsi-dock/fu-qsi-dock-plugin.c
@@ -27,6 +27,7 @@ static void
 fu_qsi_dock_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QSI_DOCK_MCU_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QSI_DOCK_CHILD_DEVICE); /* coverage */
 }

--- a/plugins/rp-pico/fu-rp-pico-plugin.c
+++ b/plugins/rp-pico/fu-rp-pico-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_rp_pico_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RP_PICO_DEVICE);
 }
 

--- a/plugins/rts54hub/fu-rts54hub-plugin.c
+++ b/plugins/rts54hub/fu-rts54hub-plugin.c
@@ -38,6 +38,7 @@ fu_rts54hub_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "Rts54I2cSpeed");
 	fu_context_add_quirk_key(ctx, "Rts54RegisterAddrLen");
 	fu_context_add_quirk_key(ctx, "Rts54BlockSize");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_RTS54HUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_BACKGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_FOREGROUND);

--- a/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
@@ -27,6 +27,7 @@ static void
 fu_synaptics_cape_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CAPE_HID_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CAPE_SNGL_FIRMWARE);

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
@@ -31,6 +31,7 @@ fu_synaptics_cxaudio_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CxaudioPatch1ValidAddr");
 	fu_context_add_quirk_key(ctx, "CxaudioPatch2ValidAddr");
 	fu_context_add_quirk_key(ctx, "CxaudioSoftwareReset");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
 }

--- a/plugins/synaptics-prometheus/fu-synaprom-plugin.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-plugin.c
@@ -33,6 +33,7 @@ static void
 fu_synaprom_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_SYNAPROM_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPROM_CONFIG); /* for coverage */
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPROM_FIRMWARE);

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
@@ -26,6 +26,7 @@ static void
 fu_synaptics_vmm9_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_VMM9_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_VMM9_FIRMWARE);
 }

--- a/plugins/system76-launch/fu-system76-launch-plugin.c
+++ b/plugins/system76-launch/fu-system76-launch-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_system76_launch_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYSTEM76_LAUNCH_DEVICE);
 }
 

--- a/plugins/thelio-io/fu-thelio-io-plugin.c
+++ b/plugins/thelio-io/fu-thelio-io-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_thelio_io_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_THELIO_IO_DEVICE);
 }
 

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
@@ -27,6 +27,7 @@ static void
 fu_ti_tps6598x_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_TI_TPS6598X_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TI_TPS6598X_PD_DEVICE); /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, "ti-tps6598x", FU_TYPE_TI_TPS6598X_FIRMWARE);

--- a/plugins/usi-dock/fu-usi-dock-plugin.c
+++ b/plugins/usi-dock/fu-usi-dock-plugin.c
@@ -91,6 +91,7 @@ static void
 fu_usi_dock_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_MCU_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_DMC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_CHILD_DEVICE); /* coverage */

--- a/plugins/vendor-example/fu-vendor-example-plugin.c.in
+++ b/plugins/vendor-example/fu-vendor-example-plugin.c.in
@@ -28,6 +28,11 @@ fu_{{vendor_example}}_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "{{VendorExample}}StartAddr");
+{%- if Parent == 'Usb' %}
+	fu_plugin_add_udev_subsystem(plugin, "usb");
+{%- elif Parent == 'Hid' %}
+	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+{%- endif %}
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_{{VENDOR_EXAMPLE}}_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_{{VENDOR_EXAMPLE}}_FIRMWARE);
 }

--- a/plugins/vli/fu-vli-plugin.c
+++ b/plugins/vli/fu-vli-plugin.c
@@ -34,6 +34,7 @@ fu_vli_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "VliDeviceKind");
 	fu_context_add_quirk_key(ctx, "VliSpiAutoDetect");
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_USBHUB_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_PD_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_DEVICE);

--- a/plugins/wacom-usb/fu-wac-plugin.c
+++ b/plugins/wacom-usb/fu-wac-plugin.c
@@ -108,6 +108,7 @@ static void
 fu_wac_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_WAC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_ANDROID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WAC_MODULE_BLUETOOTH);     /* coverage */

--- a/plugins/wistron-dock/fu-wistron-dock-plugin.c
+++ b/plugins/wistron-dock/fu-wistron-dock-plugin.c
@@ -25,6 +25,7 @@ static void
 fu_wistron_dock_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WISTRON_DOCK_DEVICE);
 }
 

--- a/src/fu-usb-backend.c
+++ b/src/fu-usb-backend.c
@@ -303,7 +303,6 @@ fu_usb_backend_setup(FuBackend *backend,
 	libusb_set_debug(self->ctx, log_level);
 #endif
 	fu_context_set_data(ctx, "libusb_context", self->ctx);
-	fu_context_add_udev_subsystem(ctx, "usb", NULL);
 
 	/* no hotplug required, probably in tests */
 	if ((flags & FU_BACKEND_SETUP_FLAG_USE_HOTPLUG) == 0)


### PR DESCRIPTION
This makes debugging non-USB plugins much less verbose.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
