### PR TITLE
Fix the inotify race when refreshing metadata

### DIFF
--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -33,6 +33,8 @@ void
 fwupd_remote_set_metadata_uri(FwupdRemote *self, const gchar *metadata_uri) G_GNUC_NON_NULL(1);
 void
 fwupd_remote_set_mtime(FwupdRemote *self, guint64 mtime) G_GNUC_NON_NULL(1);
+gboolean
+fwupd_remote_ensure_mtime(FwupdRemote *self, GError **error) G_GNUC_NON_NULL(1);
 gchar **
 fwupd_remote_get_order_after(FwupdRemote *self) G_GNUC_NON_NULL(1);
 gchar **

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1039,5 +1039,6 @@ LIBFWUPD_2.0.16 {
 LIBFWUPD_2.0.17 {
   global:
     fwupd_client_get_hwids;
+    fwupd_remote_ensure_mtime;
   local: *;
 } LIBFWUPD_2.0.16;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4600,6 +4600,8 @@ fu_engine_update_metadata_bytes(FuEngine *self,
 	/* save XML and signature to remotes.d */
 	if (!fu_bytes_set_contents(fwupd_remote_get_filename_cache(remote), bytes_raw, error))
 		return FALSE;
+	if (!fwupd_remote_ensure_mtime(remote, error))
+		return FALSE;
 
 #ifdef HAVE_PASSIM
 	/* lazy load */

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -84,25 +84,6 @@ fu_remote_list_monitor_changed_cb(GFileMonitor *monitor,
 	fu_remote_list_emit_changed(self);
 }
 
-static guint64
-_fwupd_remote_get_mtime(FwupdRemote *remote)
-{
-	g_autoptr(GFile) file = NULL;
-	g_autoptr(GFileInfo) info = NULL;
-
-	file = g_file_new_for_path(fwupd_remote_get_filename_cache(remote));
-	if (!g_file_query_exists(file, NULL))
-		return G_MAXUINT64;
-	info = g_file_query_info(file,
-				 G_FILE_ATTRIBUTE_TIME_MODIFIED,
-				 G_FILE_QUERY_INFO_NONE,
-				 NULL,
-				 NULL);
-	if (info == NULL)
-		return G_MAXUINT64;
-	return g_file_info_get_attribute_uint64(info, G_FILE_ATTRIBUTE_TIME_MODIFIED);
-}
-
 /* GLib only returns the very unhelpful "Unable to find default local file monitor type"
  * when /proc/sys/fs/inotify/max_user_instances is set too low; detect this and set a proper
  * error prefix to aid debugging when the daemon fails to start */
@@ -403,7 +384,8 @@ fu_remote_list_add_for_file(FuRemoteList *self, const gchar *filename, GError **
 	}
 
 	/* set mtime */
-	fwupd_remote_set_mtime(remote, _fwupd_remote_get_mtime(remote));
+	if (!fwupd_remote_ensure_mtime(remote, error))
+		return FALSE;
 	fu_remote_list_add_remote(self, remote);
 
 	/* success */


### PR DESCRIPTION
If the user does 'fwupdmgr refresh && fwupdmgr refresh' both download new metadata as the inotify watch will not have fired.

Manually update the remote mtime so that the remote age is always correct.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
