### PR TITLE
trivial: Allow parsing as a full-fat cabinet file

### DIFF
--- a/src/fu-engine-helper.c
+++ b/src/fu-engine-helper.c
@@ -13,6 +13,7 @@
 
 #include <glib/gi18n.h>
 
+#include "fu-cabinet.h"
 #include "fu-context-private.h"
 #include "fu-engine-helper.h"
 #include "fu-engine.h"
@@ -25,6 +26,7 @@ fu_engine_add_firmware_gtypes(FuEngine *self)
 	FuContext *ctx = fu_engine_get_context(self);
 	fu_context_add_firmware_gtype(ctx, "raw", FU_TYPE_FIRMWARE);
 	fu_context_add_firmware_gtype(ctx, "cab", FU_TYPE_CAB_FIRMWARE);
+	fu_context_add_firmware_gtype(ctx, "cabinet", FU_TYPE_CABINET);
 	fu_context_add_firmware_gtype(ctx, "dfu", FU_TYPE_DFU_FIRMWARE);
 	fu_context_add_firmware_gtype(ctx, "fdt", FU_TYPE_FDT_FIRMWARE);
 	fu_context_add_firmware_gtype(ctx, "csv", FU_TYPE_CSV_FIRMWARE);


### PR DESCRIPTION
Having this would have made finding the libjcat memory leak much easier...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
