### PR TITLE
trivial: Set the size of the FuLinearFirmware

### DIFF
--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -119,13 +119,16 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_add_image_full(firmware, img, error))
 			return FALSE;
 
+		/* next! */
+		offset += fu_firmware_get_size(img);
+
 		/* skip any padding */
 		if (fu_firmware_has_flag(img, FU_FIRMWARE_FLAG_IS_LAST_IMAGE))
 			break;
-
-		/* next! */
-		offset += fu_firmware_get_size(img);
 	}
+
+	/* this might be less than streamsz if padded */
+	fu_firmware_set_size(firmware, offset);
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
The size of the enclosed images might be less than the stream size.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
