### PR TITLE
bnr-dp: fix return type annotation

### DIFF
--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -409,7 +409,7 @@ fu_bnr_dp_device_write_data(FuBnrDpDevice *self,
 	return TRUE;
 }
 
-static FuStructBnrDpPayloadHeader *
+static FuStructBnrDpFactoryData *
 fu_bnr_dp_device_factory_data(FuBnrDpDevice *self,
 			      FuBnrDpModuleNumber module_number,
 			      GError **error)


### PR DESCRIPTION
Thankfully, this is functionally not critical in any of the instances where the function is called.

All of the rustgen types are aliases of GByteArray anyway but that also means that type checking doesn't really work, at least not with just the compiler and settings.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
