### PR TITLE
genesys: usbhub: replace to use hid proxy

### DIFF
--- a/plugins/genesys/fu-genesys-hubhid-device.c
+++ b/plugins/genesys/fu-genesys-hubhid-device.c
@@ -290,14 +290,9 @@ fu_genesys_hubhid_device_send_report(FuGenesysHubhidDevice *self,
 							     datasz,
 							     progress,
 							     error);
-	} else {
-		return fu_genesys_hubhid_device_command_write(self,
-							      setup,
-							      data,
-							      datasz,
-							      progress,
-							      error);
 	}
+
+	return fu_genesys_hubhid_device_command_write(self, setup, data, datasz, progress, error);
 }
 
 static gboolean
@@ -367,8 +362,10 @@ fu_genesys_hubhid_device_setup(FuDevice *device, GError **error)
 	FuGenesysHubhidDevice *self = FU_GENESYS_HUBHID_DEVICE(device);
 
 	/* validate by string token */
-	if (!fu_genesys_hubhid_device_validate_token(self, error))
+	if (!fu_genesys_hubhid_device_validate_token(self, error)) {
+		g_prefix_error_literal(error, "error validate token: ");
 		return FALSE;
+	}
 
 	/* FuHidDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_genesys_hubhid_device_parent_class)->setup(device, error)) {

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -88,11 +88,11 @@ fu_genesys_plugin_device_added(FuPlugin *self, FuDevice *device)
 	parent = fu_genesys_plugin_get_device_by_physical_id(self,
 							     fu_device_get_physical_id(usb_parent));
 	if (parent == NULL) {
-		g_warning("hubhid cannot find parent, platform_id(%s)",
+		g_warning("hubhid cannot find parent, physical_id(%s)",
 			  fu_device_get_physical_id(usb_parent));
 		fu_plugin_device_remove(self, device);
 	} else {
-		fu_genesys_usbhub_device_set_hid_channel(FU_GENESYS_USBHUB_DEVICE(parent), device);
+		fu_genesys_usbhub_device_set_proxy(FU_GENESYS_USBHUB_DEVICE(parent), device);
 		fu_device_add_child(parent, device);
 	}
 }

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -134,27 +134,22 @@ struct _FuGenesysUsbhubDevice {
 	FuStructGenesysFwEcdsaPublicKey *st_ecdsa_pubkey;
 	FuStructGenesysFwCodesignInfoEcdsa *st_codesign_ecdsa;
 	GByteArray *st_public_key;
-
-	/* hid channel */
-	FuGenesysHubhidDevice *hid_channel;
 };
 
 G_DEFINE_TYPE(FuGenesysUsbhubDevice, fu_genesys_usbhub_device, FU_TYPE_USB_DEVICE)
 
 void
-fu_genesys_usbhub_device_set_hid_channel(FuGenesysUsbhubDevice *self, FuDevice *channel)
+fu_genesys_usbhub_device_set_proxy(FuGenesysUsbhubDevice *self, FuDevice *proxy)
 {
 	g_return_if_fail(FU_IS_GENESYS_USBHUB_DEVICE(self));
-	g_return_if_fail(FU_IS_GENESYS_HUBHID_DEVICE(channel));
+	g_return_if_fail(FU_IS_GENESYS_HUBHID_DEVICE(proxy));
 
-	if (self->hid_channel != NULL) {
-		g_warning("already set hid_channel, physical_id(%s)",
-			  fu_device_get_physical_id(FU_DEVICE(self->hid_channel)));
-	} else {
-		self->hid_channel = FU_GENESYS_HUBHID_DEVICE(channel);
-		/* align usb max length(0xffff) to usb2 packet size(0x40) */
-		self->flash_rw_size = 0xffc0;
-	}
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REFCOUNTED_PROXY);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PROXY_FOR_OPEN);
+	fu_device_set_proxy(FU_DEVICE(self), proxy);
+
+	/* align usb max length(0xffff) to usb2 packet size(0x40) */
+	self->flash_rw_size = 0xffc0;
 }
 
 static gboolean
@@ -173,8 +168,11 @@ fu_genesys_usbhub_device_ctrl_transfer(FuGenesysUsbhubDevice *self,
 				       GCancellable *cancellable,
 				       GError **error)
 {
-	if (self->hid_channel != NULL) {
-		return fu_genesys_hubhid_device_send_report(self->hid_channel,
+	FuDevice *proxy;
+
+	proxy = fu_device_get_proxy(FU_DEVICE(self), NULL);
+	if (proxy != NULL) {
+		return fu_genesys_hubhid_device_send_report(FU_GENESYS_HUBHID_DEVICE(proxy),
 							    progress,
 							    direction,
 							    request_type,
@@ -185,21 +183,21 @@ fu_genesys_usbhub_device_ctrl_transfer(FuGenesysUsbhubDevice *self,
 							    data,
 							    length,
 							    error);
-	} else {
-		return fu_usb_device_control_transfer(FU_USB_DEVICE(self),
-						      direction,
-						      request_type,
-						      recipient,
-						      request,
-						      value,
-						      idx,
-						      data,
-						      length,
-						      actual_length,
-						      timeout,
-						      cancellable,
-						      error);
 	}
+
+	return fu_usb_device_control_transfer(FU_USB_DEVICE(self),
+					      direction,
+					      request_type,
+					      recipient,
+					      request,
+					      value,
+					      idx,
+					      data,
+					      length,
+					      actual_length,
+					      timeout,
+					      cancellable,
+					      error);
 }
 
 static gboolean
@@ -1356,12 +1354,14 @@ static gboolean
 fu_genesys_usbhub_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
 	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
+	FuDevice *proxy;
+
 	if (!fu_genesys_usbhub_device_reset(self, error))
 		return FALSE;
 
-	if (self->hid_channel != NULL) {
-		fu_device_add_flag(FU_DEVICE(self->hid_channel), FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	}
+	proxy = fu_device_get_proxy(device, NULL);
+	if (proxy != NULL)
+		fu_device_add_flag(proxy, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 
 	/* success */
 	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
@@ -1427,42 +1427,6 @@ fu_genesys_usbhub_device_probe(FuDevice *device, GError **error)
 				    FWUPD_ERROR_NOT_SUPPORTED,
 				    "unsupported USB3 hub");
 		return FALSE;
-	}
-
-	return TRUE;
-}
-
-static gboolean
-fu_genesys_usbhub_device_open(FuDevice *device, GError **error)
-{
-	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
-
-	/* FuUsbDevice->open */
-	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->open(device, error))
-		return FALSE;
-
-	/* FuGenesysHubhidDevice->open */
-	if (self->hid_channel != NULL) {
-		if (!fu_device_open(FU_DEVICE(self->hid_channel), error))
-			return FALSE;
-	}
-
-	return TRUE;
-}
-
-static gboolean
-fu_genesys_usbhub_device_close(FuDevice *device, GError **error)
-{
-	FuGenesysUsbhubDevice *self = FU_GENESYS_USBHUB_DEVICE(device);
-
-	/* FuUsbDevice->close */
-	if (!FU_DEVICE_CLASS(fu_genesys_usbhub_device_parent_class)->close(device, error))
-		return FALSE;
-
-	/* FuGenesysHubhidDevice->close */
-	if (self->hid_channel != NULL) {
-		if (!fu_device_close(FU_DEVICE(self->hid_channel), error))
-			return FALSE;
 	}
 
 	return TRUE;
@@ -3203,6 +3167,7 @@ fu_genesys_usbhub_device_init(FuGenesysUsbhubDevice *self)
 	fu_device_set_remove_delay(FU_DEVICE(self), 5000); /* 5s */
 	fu_device_register_private_flag(FU_DEVICE(self), FU_GENESYS_USBHUB_FLAG_HAS_MSTAR_SCALER);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_GENESYS_USBHUB_FLAG_HAS_PUBLIC_KEY);
+	fu_device_set_proxy_gtype(FU_DEVICE(self), FU_TYPE_GENESYS_HUBHID_DEVICE);
 	fu_device_set_install_duration(FU_DEVICE(self), 9); /* 9 s */
 
 	self->vcs.req_switch = GENESYS_USBHUB_GL_HUB_SWITCH;
@@ -3256,8 +3221,6 @@ fu_genesys_usbhub_device_class_init(FuGenesysUsbhubDeviceClass *klass)
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
 	object_class->finalize = fu_genesys_usbhub_device_finalize;
 	device_class->probe = fu_genesys_usbhub_device_probe;
-	device_class->open = fu_genesys_usbhub_device_open;
-	device_class->close = fu_genesys_usbhub_device_close;
 	device_class->setup = fu_genesys_usbhub_device_setup;
 	device_class->dump_firmware = fu_genesys_usbhub_device_dump_firmware;
 	device_class->prepare = fu_genesys_usbhub_device_prepare;

--- a/plugins/genesys/fu-genesys-usbhub-device.h
+++ b/plugins/genesys/fu-genesys-usbhub-device.h
@@ -16,4 +16,4 @@ G_DECLARE_FINAL_TYPE(FuGenesysUsbhubDevice,
 		     FuUsbDevice)
 
 void
-fu_genesys_usbhub_device_set_hid_channel(FuGenesysUsbhubDevice *self, FuDevice *channel);
+fu_genesys_usbhub_device_set_proxy(FuGenesysUsbhubDevice *self, FuDevice *proxy);


### PR DESCRIPTION
there is private flag to use proxy for open.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Continue #9300.
There is a private flag to use proxy for open. And should add emulation test with HID.