### PR TITLE
trivial: Use the opaque typedef names where possible

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -428,7 +428,7 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 	guint16 index;
 	guint16 time;
 	g_autoptr(FuCabImage) img = fu_cab_image_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCabFile) st = NULL;
 	g_autoptr(GDateTime) created = NULL;
 	g_autoptr(GInputStream) stream = NULL;
 	g_autoptr(GString) filename = g_string_new(NULL);
@@ -554,7 +554,7 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 	gsize off_cffile = 0;
 	gsize offset = 0;
 	gsize streamsz = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCabHeader) st = NULL;
 	g_autoptr(FuCabFirmwareParseHelper) helper = NULL;
 
 	/* get size */
@@ -676,8 +676,8 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 	gsize archive_size;
 	gsize offset;
 	guint32 index_into = 0;
-	g_autoptr(GByteArray) st_hdr = fu_struct_cab_header_new();
-	g_autoptr(GByteArray) st_folder = fu_struct_cab_folder_new();
+	g_autoptr(FuStructCabHeader) st_hdr = fu_struct_cab_header_new();
+	g_autoptr(FuStructCabFolder) st_folder = fu_struct_cab_folder_new();
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) cfdata_linear = g_byte_array_new();
 	g_autoptr(GBytes) cfdata_linear_blob = NULL;
@@ -809,7 +809,7 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 		FuCabFileAttribute fattr = FU_CAB_FILE_ATTRIBUTE_NONE;
 		GDateTime *created = fu_cab_image_get_created(FU_CAB_IMAGE(img));
 		const gchar *filename_win32 = fu_cab_image_get_win32_filename(FU_CAB_IMAGE(img));
-		g_autoptr(GByteArray) st_file = fu_struct_cab_file_new();
+		g_autoptr(FuStructCabFile) st_file = fu_struct_cab_file_new();
 		g_autoptr(GBytes) img_blob = fu_firmware_get_bytes(img, NULL);
 
 		if (!g_str_is_ascii(filename_win32))
@@ -840,7 +840,7 @@ fu_cab_firmware_write(FuFirmware *firmware, GError **error)
 		GByteArray *chunk_zlib = g_ptr_array_index(chunks_zlib, i);
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GByteArray) hdr = g_byte_array_new();
-		g_autoptr(GByteArray) st_data = fu_struct_cab_data_new();
+		g_autoptr(FuStructCabData) st_data = fu_struct_cab_data_new();
 
 		/* prepare chunk */
 		chk = fu_chunk_array_index(chunks, i, error);

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -426,7 +426,7 @@ fu_cfu_offer_parse(FuFirmware *firmware,
 	guint8 flags1;
 	guint8 flags2;
 	guint8 flags3;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCfuOffer) st = NULL;
 
 	/* parse */
 	st = fu_struct_cfu_offer_parse_stream(stream, 0x0, error);
@@ -462,7 +462,7 @@ fu_cfu_offer_write(FuFirmware *firmware, GError **error)
 {
 	FuCfuOffer *self = FU_CFU_OFFER(firmware);
 	FuCfuOfferPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) st = fu_struct_cfu_offer_new();
+	g_autoptr(FuStructCfuOffer) st = fu_struct_cfu_offer_new();
 
 	/* component info */
 	fu_struct_cfu_offer_set_segment_number(st, priv->segment_number);

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -42,7 +42,7 @@ fu_cfu_payload_parse(FuFirmware *firmware,
 		guint8 chunk_size = 0;
 		g_autoptr(FuChunk) chk = NULL;
 		g_autoptr(GBytes) blob = NULL;
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructCfuPayload) st = NULL;
 
 		st = fu_struct_cfu_payload_parse_stream(stream, offset, error);
 		if (st == NULL)
@@ -82,7 +82,7 @@ fu_cfu_payload_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);
-		g_autoptr(GByteArray) st = fu_struct_cfu_payload_new();
+		g_autoptr(FuStructCfuPayload) st = fu_struct_cfu_payload_new();
 		fu_struct_cfu_payload_set_addr(st, fu_chunk_get_address(chk));
 		fu_struct_cfu_payload_set_size(st, fu_chunk_get_data_sz(chk));
 		g_byte_array_append(buf, st->data, st->len);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -221,7 +221,7 @@ fu_dfu_firmware_parse_footer(FuDfuFirmware *self,
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize bufsz;
 	const guint8 *buf;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructDfuFtr) st = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	fw = fu_input_stream_read_bytes(stream, 0, G_MAXSIZE, NULL, error);
@@ -298,7 +298,7 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
 {
 	FuDfuFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st = fu_struct_dfu_ftr_new();
+	g_autoptr(FuStructDfuFtr) st = fu_struct_dfu_ftr_new();
 
 	/* add the raw firmware data, the footer-less-CRC, and only then the CRC */
 	fu_byte_array_append_bytes(buf, contents);

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -31,7 +31,7 @@ fu_dfuse_firmware_image_chunk_parse(FuDfuseFirmware *self,
 				    GError **error)
 {
 	g_autoptr(FuChunk) chk = NULL;
-	g_autoptr(GByteArray) st_ele = NULL;
+	g_autoptr(FuStructDfuseElement) st_ele = NULL;
 	g_autoptr(GBytes) blob = NULL;
 
 	/* create new chunk */
@@ -62,7 +62,7 @@ fu_dfuse_firmware_image_parse_stream(FuDfuseFirmware *self,
 {
 	guint chunks;
 	g_autoptr(FuFirmware) image = fu_firmware_new();
-	g_autoptr(GByteArray) st_img = NULL;
+	g_autoptr(FuStructDfuseImage) st_img = NULL;
 
 	/* verify image signature */
 	st_img = fu_struct_dfuse_image_parse_stream(stream, *offset, error);
@@ -116,7 +116,7 @@ fu_dfuse_firmware_parse(FuFirmware *firmware,
 	gsize offset = 0;
 	gsize streamsz = 0;
 	guint8 targets = 0;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructDfuseHdr) st_hdr = NULL;
 
 	/* DFU footer first */
 	if (!fu_dfu_firmware_parse_footer(dfu_firmware, stream, flags, error))
@@ -163,7 +163,7 @@ fu_dfuse_firmware_parse(FuFirmware *firmware,
 static GBytes *
 fu_dfuse_firmware_chunk_write(FuDfuseFirmware *self, FuChunk *chk)
 {
-	g_autoptr(GByteArray) st_ele = fu_struct_dfuse_element_new();
+	g_autoptr(FuStructDfuseElement) st_ele = fu_struct_dfuse_element_new();
 	fu_struct_dfuse_element_set_address(st_ele, fu_chunk_get_address(chk));
 	fu_struct_dfuse_element_set_size(st_ele, fu_chunk_get_data_sz(chk));
 	g_byte_array_append(st_ele, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
@@ -174,7 +174,7 @@ static GBytes *
 fu_dfuse_firmware_write_image(FuDfuseFirmware *self, FuFirmware *image, GError **error)
 {
 	gsize totalsz = 0;
-	g_autoptr(GByteArray) st_img = fu_struct_dfuse_image_new();
+	g_autoptr(FuStructDfuseImage) st_img = fu_struct_dfuse_image_new();
 	g_autoptr(GPtrArray) blobs = NULL;
 	g_autoptr(GPtrArray) chunks = NULL;
 
@@ -215,7 +215,7 @@ fu_dfuse_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuDfuseFirmware *self = FU_DFUSE_FIRMWARE(firmware);
 	gsize totalsz = 0;
-	g_autoptr(GByteArray) st_hdr = fu_struct_dfuse_hdr_new();
+	g_autoptr(FuStructDfuseHdr) st_hdr = fu_struct_dfuse_hdr_new();
 	g_autoptr(GBytes) blob_noftr = NULL;
 	g_autoptr(GPtrArray) blobs = NULL;
 	g_autoptr(GPtrArray) images = NULL;

--- a/libfwupdplugin/fu-dpaux-device.c
+++ b/libfwupdplugin/fu-dpaux-device.c
@@ -99,7 +99,8 @@ fu_dpaux_device_setup(FuDevice *device, GError **error)
 	FuDpauxDevice *self = FU_DPAUX_DEVICE(device);
 	FuDpauxDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 buf[FU_STRUCT_DPAUX_DPCD_SIZE] = {0x0};
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructDpauxDpcd) st = NULL;
+
 	/* ignore all Framework FRANDGCP07 BIOS version 3.02 */
 	if (fu_device_get_name(device) != NULL &&
 	    g_str_has_prefix(fu_device_get_name(device), "AMDGPU DM") &&

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -222,7 +222,7 @@ fu_edid_parse_descriptor(FuEdid *self, GInputStream *stream, gsize offset, GErro
 {
 	gsize buf2sz = 0;
 	const guint8 *buf2;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEdidDescriptor) st = NULL;
 
 	st = fu_struct_edid_descriptor_parse_stream(stream, offset, error);
 	if (st == NULL)
@@ -261,7 +261,7 @@ fu_edid_parse(FuFirmware *firmware,
 	const guint8 *manu_id;
 	gsize offset = 0;
 	g_autofree gchar *pnp_id = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEdid) st = NULL;
 
 	/* parse header */
 	st = fu_struct_edid_parse_stream(stream, offset, error);
@@ -303,7 +303,7 @@ static GByteArray *
 fu_edid_write(FuFirmware *firmware, GError **error)
 {
 	FuEdid *self = FU_EDID(firmware);
-	g_autoptr(GByteArray) st = fu_struct_edid_new();
+	g_autoptr(FuStructEdid) st = fu_struct_edid_new();
 	guint64 serial_number = 0;
 	gsize offset_desc = FU_STRUCT_EDID_OFFSET_DATA_BLOCKS;
 
@@ -320,7 +320,7 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 
 	/* store descriptors */
 	if (self->product_name != NULL) {
-		g_autoptr(GByteArray) st_desc = fu_struct_edid_descriptor_new();
+		g_autoptr(FuStructEdidDescriptor) st_desc = fu_struct_edid_descriptor_new();
 		fu_struct_edid_descriptor_set_tag(st_desc,
 						  FU_EDID_DESCRIPTOR_TAG_DISPLAY_PRODUCT_NAME);
 		if (!fu_struct_edid_descriptor_set_data(st_desc,
@@ -334,7 +334,7 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 		offset_desc += st_desc->len;
 	}
 	if (self->serial_number != NULL) {
-		g_autoptr(GByteArray) st_desc = fu_struct_edid_descriptor_new();
+		g_autoptr(FuStructEdidDescriptor) st_desc = fu_struct_edid_descriptor_new();
 		fu_struct_edid_descriptor_set_tag(
 		    st_desc,
 		    FU_EDID_DESCRIPTOR_TAG_DISPLAY_PRODUCT_SERIAL_NUMBER);
@@ -349,7 +349,7 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 		offset_desc += st_desc->len;
 	}
 	if (self->eisa_id != NULL) {
-		g_autoptr(GByteArray) st_desc = fu_struct_edid_descriptor_new();
+		g_autoptr(FuStructEdidDescriptor) st_desc = fu_struct_edid_descriptor_new();
 		fu_struct_edid_descriptor_set_tag(st_desc,
 						  FU_EDID_DESCRIPTOR_TAG_ALPHANUMERIC_DATA_STRING);
 		if (!fu_struct_edid_descriptor_set_data(st_desc,

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -77,7 +77,7 @@ fu_efi_device_path_list_parse(FuFirmware *firmware,
 		return FALSE;
 	while (offset < streamsz) {
 		g_autoptr(FuEfiDevicePath) efi_dp = NULL;
-		g_autoptr(GByteArray) st_dp = NULL;
+		g_autoptr(FuStructEfiDevicePath) st_dp = NULL;
 
 		/* parse the header so we can work out what GType to create */
 		st_dp = fu_struct_efi_device_path_parse_stream(stream, offset, error);
@@ -114,7 +114,7 @@ fu_efi_device_path_list_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_dp_end = NULL;
+	g_autoptr(FuStructEfiDevicePath) st_dp_end = NULL;
 
 	/* add each image */
 	for (guint i = 0; i < imgs->len; i++) {

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -97,7 +97,7 @@ fu_efi_device_path_parse(FuFirmware *firmware,
 	FuEfiDevicePathPrivate *priv = GET_PRIVATE(self);
 	gsize dp_length;
 	gsize streamsz = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiDevicePath) st = NULL;
 
 	/* parse */
 	st = fu_struct_efi_device_path_parse_stream(stream, 0x0, error);
@@ -142,7 +142,7 @@ fu_efi_device_path_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiDevicePath *self = FU_EFI_DEVICE_PATH(firmware);
 	FuEfiDevicePathPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) st = fu_struct_efi_device_path_new();
+	g_autoptr(FuStructEfiDevicePath) st = fu_struct_efi_device_path_new();
 	g_autoptr(GBytes) payload = NULL;
 
 	/* required */

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -78,7 +78,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 	FuEfiFilePrivate *priv = GET_PRIVATE(self);
 	guint32 size = 0x0;
 	g_autofree gchar *guid_str = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiFile) st = NULL;
 	g_autoptr(GInputStream) partial_stream = NULL;
 
 	/* parse */
@@ -234,7 +234,7 @@ fu_efi_file_write(FuFirmware *firmware, GError **error)
 	FuEfiFile *self = FU_EFI_FILE(firmware);
 	FuEfiFilePrivate *priv = GET_PRIVATE(self);
 	fwupd_guid_t guid = {0x0};
-	g_autoptr(GByteArray) st = fu_struct_efi_file_new();
+	g_autoptr(FuStructEfiFile) st = fu_struct_efi_file_new();
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GBytes) hdr_blob = NULL;
 

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -95,7 +95,7 @@ fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
 				    GError **error)
 {
 	FuEfiHardDriveDevicePath *self = FU_EFI_HARD_DRIVE_DEVICE_PATH(firmware);
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiHardDriveDevicePath) st = NULL;
 
 	/* re-parse */
 	st = fu_struct_efi_hard_drive_device_path_parse_stream(stream, 0x0, error);
@@ -119,7 +119,7 @@ static GByteArray *
 fu_efi_hard_drive_device_path_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiHardDriveDevicePath *self = FU_EFI_HARD_DRIVE_DEVICE_PATH(firmware);
-	g_autoptr(GByteArray) st = fu_struct_efi_hard_drive_device_path_new();
+	g_autoptr(FuStructEfiHardDriveDevicePath) st = fu_struct_efi_hard_drive_device_path_new();
 
 	/* required */
 	fu_struct_efi_hard_drive_device_path_set_partition_number(st, self->partition_number);

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -298,7 +298,7 @@ fu_efi_load_option_parse(FuFirmware *firmware,
 	g_autofree gchar *id = NULL;
 	g_autoptr(FuEfiDevicePathList) device_path_list = fu_efi_device_path_list_new();
 	g_autoptr(GByteArray) buf_utf16 = g_byte_array_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiLoadOption) st = NULL;
 
 	/* parse header */
 	st = fu_struct_efi_load_option_parse_stream(stream, offset, error);
@@ -416,7 +416,7 @@ fu_efi_load_option_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiLoadOption *self = FU_EFI_LOAD_OPTION(firmware);
 	g_autoptr(GByteArray) buf_utf16 = NULL;
-	g_autoptr(GByteArray) st = fu_struct_efi_load_option_new();
+	g_autoptr(FuStructEfiLoadOption) st = fu_struct_efi_load_option_new();
 	g_autoptr(GBytes) dpbuf = NULL;
 
 	/* header */

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -608,7 +608,7 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 	gsize streamsz = 0;
 	guint32 dst_bufsz;
 	guint32 src_bufsz;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiLz77DecompressorHeader) st = NULL;
 	g_autoptr(GError) error_all = NULL;
 	g_autoptr(GByteArray) dst = g_byte_array_new();
 	FuEfiLz77DecompressorVersion decompressor_versions[] = {

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -161,7 +161,7 @@ fu_efi_section_parse_compression_sections(FuEfiSection *self,
 					  FuFirmwareParseFlags flags,
 					  GError **error)
 {
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiSectionCompression) st = NULL;
 	st = fu_struct_efi_section_compression_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
@@ -225,7 +225,7 @@ fu_efi_section_parse_freeform_subtype_guid(FuEfiSection *self,
 {
 	const gchar *guid_ui;
 	g_autofree gchar *guid_str = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiSectionFreeformSubtypeGuid) st = NULL;
 
 	st = fu_struct_efi_section_freeform_subtype_guid_parse_stream(stream, 0x0, error);
 	if (st == NULL)
@@ -254,7 +254,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 	gsize offset = 0;
 	gsize streamsz = 0;
 	guint32 size;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiSection) st = NULL;
 	g_autoptr(GInputStream) partial_stream = NULL;
 
 	/* parse */
@@ -298,7 +298,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 	priv->type = fu_struct_efi_section_get_type(st);
 	if (priv->type == FU_EFI_SECTION_TYPE_GUID_DEFINED) {
 		g_autofree gchar *guid_str = NULL;
-		g_autoptr(GByteArray) st_def = NULL;
+		g_autoptr(FuStructEfiSectionGuidDefined) st_def = NULL;
 		st_def = fu_struct_efi_section_guid_defined_parse_stream(stream, st->len, error);
 		if (st_def == NULL)
 			return FALSE;
@@ -399,7 +399,7 @@ fu_efi_section_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiSection *self = FU_EFI_SECTION(firmware);
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) buf = fu_struct_efi_section_new();
+	g_autoptr(FuStructEfiSection) buf = fu_struct_efi_section_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	/* simple blob for now */
@@ -410,7 +410,8 @@ fu_efi_section_write(FuFirmware *firmware, GError **error)
 	/* header */
 	if (priv->type == FU_EFI_SECTION_TYPE_GUID_DEFINED) {
 		fwupd_guid_t guid = {0x0};
-		g_autoptr(GByteArray) st_def = fu_struct_efi_section_guid_defined_new();
+		g_autoptr(FuStructEfiSectionGuidDefined) st_def =
+		    fu_struct_efi_section_guid_defined_new();
 		if (!fwupd_guid_from_string(fu_firmware_get_id(firmware),
 					    &guid,
 					    FWUPD_GUID_FLAG_MIXED_ENDIAN,

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -104,7 +104,7 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 	guint32 list_size;
 	guint32 size;
 	g_autofree gchar *sig_type = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEfiSignatureList) st = NULL;
 
 	/* read EFI_SIGNATURE_LIST */
 	st = fu_struct_efi_signature_list_parse_stream(stream, *offset, error);

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -149,7 +149,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	guint64 fv_length = 0;
 	guint8 alignment;
 	g_autofree gchar *guid_str = NULL;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructEfiVolume) st_hdr = NULL;
 	g_autoptr(GInputStream) partial_stream = NULL;
 
 	/* parse */
@@ -228,7 +228,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 
 	/* extended header items */
 	if (fu_struct_efi_volume_get_ext_hdr(st_hdr) != 0) {
-		g_autoptr(GByteArray) st_ext_hdr = NULL;
+		g_autoptr(FuStructEfiVolumeExtHeader) st_ext_hdr = NULL;
 		goffset offset_ext = fu_struct_efi_volume_get_ext_hdr(st_hdr);
 		st_ext_hdr =
 		    fu_struct_efi_volume_ext_header_parse_stream(stream, offset_ext, error);
@@ -236,7 +236,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 			return FALSE;
 		offset_ext += fu_struct_efi_volume_ext_header_get_size(st_ext_hdr);
 		do {
-			g_autoptr(GByteArray) st_ext_entry = NULL;
+			g_autoptr(FuStructEfiVolumeExtEntry) st_ext_entry = NULL;
 			st_ext_entry =
 			    fu_struct_efi_volume_ext_entry_parse_stream(stream, offset_ext, error);
 			if (st_ext_entry == NULL)
@@ -304,7 +304,7 @@ fu_efi_volume_parse(FuFirmware *firmware,
 	while (offset < streamsz) {
 		guint32 num_blocks;
 		guint32 length;
-		g_autoptr(GByteArray) st_blk = NULL;
+		g_autoptr(FuStructEfiVolumeBlockMap) st_blk = NULL;
 		st_blk = fu_struct_efi_volume_block_map_parse_stream(stream, offset, error);
 		if (st_blk == NULL)
 			return FALSE;

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -44,7 +44,7 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 	guint16 phentsize;
 	guint16 phnum;
 	guint16 shnum;
-	g_autoptr(GByteArray) st_fhdr = NULL;
+	g_autoptr(FuStructElfFileHeader64le) st_fhdr = NULL;
 	g_autoptr(GByteArray) shstrndx_buf = NULL;
 	g_autoptr(GPtrArray) sections =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)g_byte_array_unref);
@@ -59,7 +59,7 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 	phentsize = fu_struct_elf_file_header64le_get_phentsize(st_fhdr);
 	phnum = fu_struct_elf_file_header64le_get_phnum(st_fhdr);
 	for (guint i = 0; i < phnum; i++) {
-		g_autoptr(GByteArray) st_phdr =
+		g_autoptr(FuStructElfProgramHeader64le) st_phdr =
 		    fu_struct_elf_program_header64le_parse_stream(stream, offset_proghdr, error);
 		if (st_phdr == NULL)
 			return FALSE;

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -236,7 +236,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 			guint32 prop_nameoff;
 			g_autoptr(GBytes) blob = NULL;
 			g_autoptr(GString) str = NULL;
-			g_autoptr(GByteArray) st_prp = NULL;
+			g_autoptr(FuStructFdtProp) st_prp = NULL;
 
 			/* sanity check */
 			if (firmware_current == FU_FIRMWARE(self)) {
@@ -304,7 +304,7 @@ fu_fdt_firmware_parse_mem_rsvmap(FuFdtFirmware *self,
 	for (; offset < streamsz; offset += FU_STRUCT_FDT_RESERVE_ENTRY_SIZE) {
 		guint64 address = 0;
 		guint64 size = 0;
-		g_autoptr(GByteArray) st_res = NULL;
+		g_autoptr(FuStructFdtReserveEntry) st_res = NULL;
 		st_res = fu_struct_fdt_reserve_entry_parse_stream(stream, offset, error);
 		if (st_res == NULL)
 			return FALSE;
@@ -336,7 +336,7 @@ fu_fdt_firmware_parse(FuFirmware *firmware,
 	guint32 totalsize;
 	gsize streamsz = 0;
 	guint32 off_mem_rsvmap = 0;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructFdt) st_hdr = NULL;
 
 	/* sanity check */
 	st_hdr = fu_struct_fdt_parse_stream(stream, 0x0, error);
@@ -470,7 +470,7 @@ fu_fdt_firmware_write_image(FuFdtFirmware *self,
 	for (guint i = 0; i < attrs->len; i++) {
 		const gchar *key = g_ptr_array_index(attrs, i);
 		g_autoptr(GBytes) blob = NULL;
-		g_autoptr(GByteArray) st_prp = fu_struct_fdt_prop_new();
+		g_autoptr(FuStructFdtProp) st_prp = fu_struct_fdt_prop_new();
 
 		blob = fu_fdt_image_get_attr(img, key, error);
 		if (blob == NULL)
@@ -508,8 +508,8 @@ fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 	g_autoptr(GByteArray) dt_struct = g_byte_array_new();
 	g_autoptr(GHashTable) strtab = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
-	g_autoptr(GByteArray) st_hdr = fu_struct_fdt_new();
-	g_autoptr(GByteArray) mem_rsvmap = fu_struct_fdt_reserve_entry_new();
+	g_autoptr(FuStructFdt) st_hdr = fu_struct_fdt_new();
+	g_autoptr(FuStructFdtReserveEntry) mem_rsvmap = fu_struct_fdt_reserve_entry_new();
 	FuFdtFirmwareBuildHelper helper = {
 	    .dt_strings = dt_strings,
 	    .dt_struct = dt_struct,

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -35,7 +35,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 	gsize offset = 0;
 	gsize streamsz = 0;
 	guint32 nareas;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructFmap) st_hdr = NULL;
 
 	/* find the magic token */
 	if (!fu_input_stream_find(stream,
@@ -76,7 +76,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		guint32 area_size;
 		g_autofree gchar *area_name = NULL;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
-		g_autoptr(GByteArray) st_area = NULL;
+		g_autoptr(FuStructFmapArea) st_area = NULL;
 		g_autoptr(GInputStream) img_stream = NULL;
 
 		/* load area */
@@ -125,7 +125,7 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	gsize offset;
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_hdr = fu_struct_fmap_new();
+	g_autoptr(FuStructFmap) st_hdr = fu_struct_fmap_new();
 
 	/* pad to offset */
 	if (fu_firmware_get_offset(firmware) > 0)
@@ -151,7 +151,7 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GBytes) fw = fu_firmware_get_bytes_with_patches(img, NULL);
-		g_autoptr(GByteArray) st_area = fu_struct_fmap_area_new();
+		g_autoptr(FuStructFmapArea) st_area = fu_struct_fmap_area_new();
 		fu_struct_fmap_area_set_offset(st_area, fu_firmware_get_offset(firmware) + offset);
 		fu_struct_fmap_area_set_size(st_area, g_bytes_get_size(fw));
 		if (fu_firmware_get_id(img) != NULL) {

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -163,8 +163,8 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 	FuIfdFirmware *self = FU_IFD_FIRMWARE(firmware);
 	FuIfdFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize streamsz = 0;
-	g_autoptr(GByteArray) st_fcba = NULL;
-	g_autoptr(GByteArray) st_fdbar = NULL;
+	g_autoptr(FuStructIfdFcba) st_fcba = NULL;
+	g_autoptr(FuStructIfdFdbar) st_fdbar = NULL;
 	g_autoptr(GInputStream) stream2 = NULL;
 
 	/* check size */
@@ -321,8 +321,8 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 	FuIfdFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize bufsz_max = 0x0;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_fcba = fu_struct_ifd_fcba_new();
-	g_autoptr(GByteArray) st_fdbar = fu_struct_ifd_fdbar_new();
+	g_autoptr(FuStructIfdFcba) st_fcba = fu_struct_ifd_fcba_new();
+	g_autoptr(FuStructIfdFdbar) st_fdbar = fu_struct_ifd_fdbar_new();
 	g_autoptr(GHashTable) blobs = NULL;
 	g_autoptr(FuFirmware) img_desc = NULL;
 

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -57,7 +57,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware,
 	gsize streamsz = 0;
 	guint32 size;
 	gsize offset = 0;
-	g_autoptr(GByteArray) st_mhd = NULL;
+	g_autoptr(FuStructIfwiCpdManifest) st_mhd = NULL;
 
 	/* raw version */
 	st_mhd = fu_struct_ifwi_cpd_manifest_parse_stream(stream, offset, error);
@@ -85,7 +85,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware,
 		guint32 extension_type = 0;
 		guint32 extension_length = 0;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
-		g_autoptr(GByteArray) st_mex = NULL;
+		g_autoptr(FuStructIfwiCpdManifestExt) st_mex = NULL;
 		g_autoptr(GInputStream) partial_stream = NULL;
 
 		/* set the extension type as the index */
@@ -148,7 +148,7 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 {
 	FuIfwiCpdFirmware *self = FU_IFWI_CPD_FIRMWARE(firmware);
 	FuIfwiCpdFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructIfwiCpd) st_hdr = NULL;
 	gsize offset = 0;
 	guint32 num_of_entries;
 
@@ -176,7 +176,7 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 		guint32 img_offset = 0;
 		g_autofree gchar *id = NULL;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
-		g_autoptr(GByteArray) st_ent = NULL;
+		g_autoptr(FuStructIfwiCpdEntry) st_ent = NULL;
 		g_autoptr(GInputStream) partial_stream = NULL;
 
 		/* the IDX is the position in the file */
@@ -232,7 +232,7 @@ fu_ifwi_cpd_firmware_write(FuFirmware *firmware, GError **error)
 	FuIfwiCpdFirmware *self = FU_IFWI_CPD_FIRMWARE(firmware);
 	FuIfwiCpdFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize offset = 0;
-	g_autoptr(GByteArray) buf = fu_struct_ifwi_cpd_new();
+	g_autoptr(FuStructIfwiCpd) buf = fu_struct_ifwi_cpd_new();
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 
 	/* write the header */
@@ -262,7 +262,7 @@ fu_ifwi_cpd_firmware_write(FuFirmware *firmware, GError **error)
 	/* add entry headers */
 	for (guint i = 0; i < imgs->len; i++) {
 		FuFirmware *img = g_ptr_array_index(imgs, i);
-		g_autoptr(GByteArray) st_ent = fu_struct_ifwi_cpd_entry_new();
+		g_autoptr(FuStructIfwiCpdEntry) st_ent = fu_struct_ifwi_cpd_entry_new();
 
 		/* sanity check */
 		if (fu_firmware_get_id(img) == NULL) {

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -50,7 +50,7 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 {
 	guint32 num_of_entries;
 	gsize offset = 0;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructIfwiFpt) st_hdr = NULL;
 
 	/* sanity check */
 	st_hdr = fu_struct_ifwi_fpt_parse_stream(stream, offset, error);
@@ -84,7 +84,7 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 		guint32 partition_name;
 		g_autofree gchar *id = NULL;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
-		g_autoptr(GByteArray) st_ent = NULL;
+		g_autoptr(FuStructIfwiFptEntry) st_ent = NULL;
 
 		/* read IDX */
 		st_ent = fu_struct_ifwi_fpt_entry_parse_stream(stream, offset, error);
@@ -128,7 +128,7 @@ static GByteArray *
 fu_ifwi_fpt_firmware_write(FuFirmware *firmware, GError **error)
 {
 	gsize offset = 0;
-	g_autoptr(GByteArray) buf = fu_struct_ifwi_fpt_new();
+	g_autoptr(FuStructIfwiFpt) buf = fu_struct_ifwi_fpt_new();
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 
 	/* fixup the image offsets */

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -571,10 +571,11 @@ fu_intel_thunderbolt_nvm_write(FuFirmware *firmware, GError **error)
 {
 	FuIntelThunderboltNvm *self = FU_INTEL_THUNDERBOLT_NVM(firmware);
 	FuIntelThunderboltNvmPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(GByteArray) st = fu_intel_thunderbolt_nvm_digital_new();
-	g_autoptr(GByteArray) st_drom = fu_intel_thunderbolt_nvm_drom_new();
-	g_autoptr(GByteArray) st_arc = fu_intel_thunderbolt_nvm_arc_params_new();
-	g_autoptr(GByteArray) st_dram = fu_intel_thunderbolt_nvm_dram_new();
+	g_autoptr(FuIntelThunderboltNvmDigital) st = fu_intel_thunderbolt_nvm_digital_new();
+	g_autoptr(FuIntelThunderboltNvmDrom) st_drom = fu_intel_thunderbolt_nvm_drom_new();
+	g_autoptr(FuIntelThunderboltNvmArcParams) st_arc =
+	    fu_intel_thunderbolt_nvm_arc_params_new();
+	g_autoptr(FuIntelThunderboltNvmDram) st_dram = fu_intel_thunderbolt_nvm_dram_new();
 
 	/* digital section */
 	fu_intel_thunderbolt_nvm_digital_set_available_sections(

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -121,8 +121,8 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 	guint16 expansion_header_offset = 0;
 	guint16 pci_header_offset;
 	guint16 image_length = 0;
-	g_autoptr(GByteArray) st_hdr = NULL;
-	g_autoptr(GByteArray) st_pci = NULL;
+	g_autoptr(FuStructOprom) st_hdr = NULL;
+	g_autoptr(FuStructOpromPci) st_pci = NULL;
 
 	/* parse header */
 	st_hdr = fu_struct_oprom_parse_stream(stream, 0x0, error);
@@ -193,8 +193,8 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	FuOpromFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize image_size = 0;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_hdr = fu_struct_oprom_new();
-	g_autoptr(GByteArray) st_pci = fu_struct_oprom_pci_new();
+	g_autoptr(FuStructOprom) st_hdr = fu_struct_oprom_new();
+	g_autoptr(FuStructOpromPci) st_pci = fu_struct_oprom_pci_new();
 	g_autoptr(GBytes) blob_cpd = NULL;
 
 	/* the smallest each image (and header) can be is 512 bytes */

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -108,7 +108,7 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 	g_autofree gchar *sect_id = NULL;
 	g_autofree gchar *sect_id_tmp = NULL;
 	g_autoptr(FuFirmware) img = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructPeCoffSection) st = NULL;
 
 	st = fu_struct_pe_coff_section_parse_stream(stream, hdr_offset, error);
 	if (st == NULL) {
@@ -390,9 +390,10 @@ fu_pefile_firmware_write(FuFirmware *firmware, GError **error)
 {
 	gsize offset = 0;
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
-	g_autoptr(GByteArray) st = fu_struct_pe_dos_header_new();
-	g_autoptr(GByteArray) st_hdr = fu_struct_pe_coff_file_header_new();
-	g_autoptr(GByteArray) st_opt = fu_struct_pe_coff_optional_header64_new();
+	g_autoptr(FuStructPeDosHeader) st = fu_struct_pe_dos_header_new();
+	g_autoptr(FuStructPeCoffFileHeader) st_hdr = fu_struct_pe_coff_file_header_new();
+	g_autoptr(FuStructPeCoffOptionalHeader64) st_opt =
+	    fu_struct_pe_coff_optional_header64_new();
 	g_autoptr(GByteArray) strtab = g_byte_array_new();
 	g_autoptr(GPtrArray) sections =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_pefile_firmware_section_free);

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -74,7 +74,7 @@ fu_sbatlevel_section_parse(FuFirmware *firmware,
 			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructSbatLevelSectionHeader) st = NULL;
 
 	st = fu_struct_sbat_level_section_header_parse_stream(stream, 0x0, error);
 	if (st == NULL)
@@ -105,7 +105,7 @@ fu_sbatlevel_section_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(FuFirmware) img_ltst = NULL;
 	g_autoptr(FuFirmware) img_prev = NULL;
-	g_autoptr(GByteArray) buf = fu_struct_sbat_level_section_header_new();
+	g_autoptr(FuStructSbatLevelSectionHeader) buf = fu_struct_sbat_level_section_header_new();
 	g_autoptr(GBytes) blob_ltst = NULL;
 	g_autoptr(GBytes) blob_prev = NULL;
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -6967,9 +6967,9 @@ static void
 fu_plugin_struct_func(void)
 {
 	gboolean ret;
-	g_autoptr(GByteArray) st = fu_struct_self_test_new();
-	g_autoptr(GByteArray) st2 = NULL;
-	g_autoptr(GByteArray) st3 = NULL;
+	g_autoptr(FuStructSelfTest) st = fu_struct_self_test_new();
+	g_autoptr(FuStructSelfTest) st2 = NULL;
+	g_autoptr(FuStructSelfTest) st3 = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *str1 = NULL;
 	g_autofree gchar *str2 = NULL;
@@ -7034,11 +7034,11 @@ fu_plugin_struct_wrapped_func(void)
 	g_autofree gchar *str1 = NULL;
 	g_autofree gchar *str2 = NULL;
 	g_autofree gchar *str4 = NULL;
-	g_autoptr(GByteArray) st2 = NULL;
-	g_autoptr(GByteArray) st3 = NULL;
-	g_autoptr(GByteArray) st_base2 = NULL;
-	g_autoptr(GByteArray) st_base = fu_struct_self_test_new();
-	g_autoptr(GByteArray) st = fu_struct_self_test_wrapped_new();
+	g_autoptr(FuStructSelfTestWrapped) st2 = NULL;
+	g_autoptr(FuStructSelfTestWrapped) st3 = NULL;
+	g_autoptr(FuStructSelfTest) st_base2 = NULL;
+	g_autoptr(FuStructSelfTest) st_base = fu_struct_self_test_new();
+	g_autoptr(FuStructSelfTestWrapped) st = fu_struct_self_test_wrapped_new();
 	g_autoptr(GError) error = NULL;
 
 	/* size */

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -174,7 +174,7 @@ fu_smbios_parse_ep32(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **er
 	guint8 csum = 0;
 	g_autofree gchar *version_str = NULL;
 	g_autofree gchar *intermediate_anchor_str = NULL;
-	g_autoptr(GByteArray) st_ep32 = NULL;
+	g_autoptr(FuStructSmbiosEp32) st_ep32 = NULL;
 
 	/* verify checksum */
 	st_ep32 = fu_struct_smbios_ep32_parse(buf, bufsz, 0x0, error);
@@ -226,7 +226,7 @@ fu_smbios_parse_ep64(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **er
 {
 	guint8 csum = 0;
 	g_autofree gchar *version_str = NULL;
-	g_autoptr(GByteArray) st_ep64 = NULL;
+	g_autoptr(FuStructSmbiosEp64) st_ep64 = NULL;
 
 	/* verify checksum */
 	st_ep64 = fu_struct_smbios_ep64_parse(buf, bufsz, 0x0, error);

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -119,7 +119,7 @@ fu_usb_device_ds20_validate(FuFirmware *firmware,
 			    gsize offset,
 			    GError **error)
 {
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructDs20) st = NULL;
 	g_autofree gchar *guid_str = NULL;
 
 	/* matches the correct UUID */
@@ -168,7 +168,7 @@ fu_usb_device_ds20_parse(FuFirmware *firmware,
 		return FALSE;
 	for (gsize off = 0; off < streamsz; off += FU_STRUCT_DS20_SIZE) {
 		g_autofree FuUsbDeviceDs20Item *dsinfo = g_new0(FuUsbDeviceDs20Item, 1);
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructDs20) st = NULL;
 
 		/* parse */
 		st = fu_struct_ds20_parse_stream(stream, off, error);

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -43,7 +43,7 @@ fu_acpi_phat_health_record_parse(FuFirmware *firmware,
 	gsize streamsz = 0;
 	guint16 rcdlen;
 	guint32 dataoff;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructAcpiPhatHealthRecord) st = NULL;
 
 	/* sanity check record length */
 	st = fu_struct_acpi_phat_health_record_parse_stream(stream, 0x0, error);
@@ -103,7 +103,7 @@ static GByteArray *
 fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 {
 	FuAcpiPhatHealthRecord *self = FU_ACPI_PHAT_HEALTH_RECORD(firmware);
-	g_autoptr(GByteArray) st = fu_struct_acpi_phat_health_record_new();
+	g_autoptr(FuStructAcpiPhatHealthRecord) st = fu_struct_acpi_phat_health_record_new();
 
 	/* convert device path ahead of time */
 	if (self->device_path != NULL) {

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -36,7 +36,7 @@ fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 				   GError **error)
 {
 	FuAcpiPhatVersionElement *self = FU_ACPI_PHAT_VERSION_ELEMENT(firmware);
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructAcpiPhatVersionElement) st = NULL;
 
 	/* unpack */
 	st = fu_struct_acpi_phat_version_element_parse_stream(stream, 0x0, error);
@@ -55,7 +55,7 @@ static GByteArray *
 fu_acpi_phat_version_element_write(FuFirmware *firmware, GError **error)
 {
 	FuAcpiPhatVersionElement *self = FU_ACPI_PHAT_VERSION_ELEMENT(firmware);
-	g_autoptr(GByteArray) st = fu_struct_acpi_phat_version_element_new();
+	g_autoptr(FuStructAcpiPhatVersionElement) st = fu_struct_acpi_phat_version_element_new();
 
 	/* pack */
 	if (self->guid != NULL) {

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -25,7 +25,7 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 {
 	gsize offset = 0;
 	guint32 record_count = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructAcpiPhatVersionRecord) st = NULL;
 
 	st = fu_struct_acpi_phat_version_record_parse_stream(stream, offset, error);
 	if (st == NULL)
@@ -58,7 +58,7 @@ static GByteArray *
 fu_acpi_phat_version_record_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf2 = g_byte_array_new();
-	g_autoptr(GByteArray) st = fu_struct_acpi_phat_version_record_new();
+	g_autoptr(FuStructAcpiPhatVersionRecord) st = fu_struct_acpi_phat_version_record_new();
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 
 	/* write each element so we get the image size */

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -47,7 +47,7 @@ fu_algoltek_usb_device_ctrl_transfer(FuAlgoltekUsbDevice *self,
 static GByteArray *
 fu_algoltek_usb_device_rdr(FuAlgoltekUsbDevice *self, int address, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 5);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_RDR);
@@ -72,7 +72,7 @@ static GByteArray *
 fu_algoltek_usb_device_rdv(FuAlgoltekUsbDevice *self, GError **error)
 {
 	guint16 version_prefix;
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_transfer_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdTransferPkt) st = fu_struct_algoltek_cmd_transfer_pkt_new();
 	g_autoptr(GByteArray) version_data = g_byte_array_new();
 
 	fu_struct_algoltek_cmd_transfer_pkt_set_len(st, 3);
@@ -122,7 +122,7 @@ fu_algoltek_usb_device_rdv(FuAlgoltekUsbDevice *self, GError **error)
 static gboolean
 fu_algoltek_usb_device_en(FuAlgoltekUsbDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 3);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_EN);
@@ -146,7 +146,7 @@ fu_algoltek_usb_device_en(FuAlgoltekUsbDevice *self, GError **error)
 static gboolean
 fu_algoltek_usb_device_rst(FuAlgoltekUsbDevice *self, guint16 address, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 4);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_RST);
@@ -180,7 +180,7 @@ fu_algoltek_usb_device_rst(FuAlgoltekUsbDevice *self, guint16 address, GError **
 static gboolean
 fu_algoltek_usb_device_wrr(FuAlgoltekUsbDevice *self, int address, int value, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 7);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_WRR);
@@ -234,7 +234,8 @@ fu_algoltek_usb_device_isp(FuAlgoltekUsbDevice *self,
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
-		g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_transfer_pkt_new();
+		g_autoptr(FuStructAlgoltekCmdTransferPkt) st =
+		    fu_struct_algoltek_cmd_transfer_pkt_new();
 
 		chk = fu_chunk_array_index(chunks, i, error);
 		if (chk == NULL)
@@ -282,7 +283,7 @@ fu_algoltek_usb_device_isp(FuAlgoltekUsbDevice *self,
 static gboolean
 fu_algoltek_usb_device_bot(FuAlgoltekUsbDevice *self, int address, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 5);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_BOT);
@@ -320,7 +321,7 @@ fu_algoltek_usb_device_ers(FuAlgoltekUsbDevice *self,
 			   GError **error)
 {
 	guint16 value;
-	g_autoptr(GByteArray) st = fu_struct_algoltek_cmd_address_pkt_new();
+	g_autoptr(FuStructAlgoltekCmdAddressPkt) st = fu_struct_algoltek_cmd_address_pkt_new();
 
 	fu_struct_algoltek_cmd_address_pkt_set_len(st, 3);
 	fu_struct_algoltek_cmd_address_pkt_set_cmd(st, FU_ALGOLTEK_CMD_ERS);

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -37,7 +37,7 @@ fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 	gsize offset = 0;
 	g_autoptr(FuFirmware) img_isp = fu_firmware_new();
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructAlgoltekProductIdentity) st = NULL;
 	g_autoptr(GInputStream) stream_isp = NULL;
 	g_autoptr(GInputStream) stream_payload = NULL;
 

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -50,7 +50,7 @@ fu_algoltek_usbcr_device_write_reg(FuAlgoltekUsbcrDevice *self,
 				   guint8 ram_dest,
 				   GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_reg_cdb_new();
+	g_autoptr(FuStructAgUsbcrRegCdb) st = fu_struct_ag_usbcr_reg_cdb_new();
 
 	fu_struct_ag_usbcr_reg_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_GENERIC_CMD);
 	fu_struct_ag_usbcr_reg_cdb_set_subcmd(st, FU_AG_USBCR_RD_WR_RAM);
@@ -69,7 +69,7 @@ fu_algoltek_usbcr_device_read_reg(FuAlgoltekUsbcrDevice *self,
 				  guint8 ram_dest,
 				  GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_reg_cdb_new();
+	g_autoptr(FuStructAgUsbcrRegCdb) st = fu_struct_ag_usbcr_reg_cdb_new();
 
 	fu_struct_ag_usbcr_reg_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_GENERIC_CMD);
 	fu_struct_ag_usbcr_reg_cdb_set_subcmd(st, FU_AG_USBCR_RD_WR_RAM);
@@ -88,7 +88,7 @@ static gboolean
 fu_algoltek_usbcr_device_send_spi_cmd(FuAlgoltekUsbcrDevice *self, guint8 cmd, GError **error)
 {
 	guint8 buf[8] = {0};
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_spi_cdb_new();
+	g_autoptr(FuStructAgUsbcrSpiCdb) st = fu_struct_ag_usbcr_spi_cdb_new();
 
 	fu_struct_ag_usbcr_spi_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_EEPROM_WR);
 	fu_struct_ag_usbcr_spi_cdb_set_addr(st, 0xFFFF);
@@ -115,7 +115,7 @@ fu_algoltek_usbcr_device_do_write_spi(FuAlgoltekUsbcrDevice *self,
 				      guint8 access_sz,
 				      GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_spi_cdb_new();
+	g_autoptr(FuStructAgUsbcrSpiCdb) st = fu_struct_ag_usbcr_spi_cdb_new();
 
 	if (!fu_algoltek_usbcr_device_send_spi_cmd(self, FU_AG_USBCR_WREN, error))
 		return FALSE;
@@ -141,7 +141,7 @@ fu_algoltek_usbcr_device_do_read_spi(FuAlgoltekUsbcrDevice *self,
 				     guint8 bufsz,
 				     GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_spi_cdb_new();
+	g_autoptr(FuStructAgUsbcrSpiCdb) st = fu_struct_ag_usbcr_spi_cdb_new();
 
 	fu_struct_ag_usbcr_spi_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_EEPROM_RD);
 	fu_struct_ag_usbcr_spi_cdb_set_addr(st, addr);
@@ -374,7 +374,7 @@ fu_algoltek_usbcr_device_set_clear_soft_reset_flag(FuAlgoltekUsbcrDevice *self,
 						   guint8 val,
 						   GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_reset_cdb_new();
+	g_autoptr(FuStructAgUsbcrResetCdb) st = fu_struct_ag_usbcr_reset_cdb_new();
 
 	fu_struct_ag_usbcr_reset_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_GENERIC_CMD);
 	fu_struct_ag_usbcr_reset_cdb_set_subcmd(st, 0x96);
@@ -387,7 +387,7 @@ fu_algoltek_usbcr_device_set_clear_soft_reset_flag(FuAlgoltekUsbcrDevice *self,
 static gboolean
 fu_algoltek_usbcr_device_reset_chip(FuAlgoltekUsbcrDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ag_usbcr_reset_cdb_new();
+	g_autoptr(FuStructAgUsbcrResetCdb) st = fu_struct_ag_usbcr_reset_cdb_new();
 
 	fu_struct_ag_usbcr_reset_cdb_set_cmd(st, FU_AG_USBCR_SCSIOP_VENDOR_GENERIC_CMD);
 	fu_struct_ag_usbcr_reset_cdb_set_subcmd(st, 0x95);

--- a/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-atom-firmware.c
@@ -67,7 +67,7 @@ fu_amd_gpu_atom_firmware_validate(FuFirmware *firmware,
 				  gsize offset,
 				  GError **error)
 {
-	g_autoptr(GByteArray) atom = NULL;
+	g_autoptr(FuStructAtomImage) atom = NULL;
 
 	atom = fu_struct_atom_image_parse_stream(stream, offset, error);
 	if (atom == NULL)
@@ -122,7 +122,7 @@ fu_amd_gpu_atom_firmware_parse_vbios_date(FuAmdGpuAtomFirmware *self,
 					  FuStructAtomImage *atom_image,
 					  GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_atom_image_get_vbios_date(atom_image);
+	g_autoptr(FuStructVbiosDate) st = fu_struct_atom_image_get_vbios_date(atom_image);
 	g_autofree gchar *year = NULL;
 	g_autofree gchar *month = NULL;
 	g_autofree gchar *day = NULL;

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -52,7 +52,7 @@ fu_amd_gpu_psp_firmware_validate(FuFirmware *firmware,
 				 gsize offset,
 				 GError **error)
 {
-	g_autoptr(GByteArray) efs = NULL;
+	g_autoptr(FuStructEfs) efs = NULL;
 
 	efs = fu_struct_efs_parse_stream(stream, 0, error);
 	if (efs == NULL)
@@ -192,7 +192,7 @@ fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
 			      GError **error)
 {
 	FuAmdGpuPspFirmware *self = FU_AMD_GPU_PSP_FIRMWARE(firmware);
-	g_autoptr(GByteArray) efs = NULL;
+	g_autoptr(FuStructEfs) efs = NULL;
 
 	efs = fu_struct_efs_parse_stream(stream, 0, error);
 	if (efs == NULL)

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -61,8 +61,8 @@ fu_aver_hid_device_transfer(FuAverHidDevice *self, GByteArray *req, GByteArray *
 static gboolean
 fu_aver_hid_device_ensure_status(FuAverHidDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIsp) req = fu_struct_aver_hid_req_isp_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	fu_struct_aver_hid_req_isp_set_custom_isp_cmd(req, FU_AVER_HID_CUSTOM_ISP_CMD_STATUS);
 	if (!fu_aver_hid_device_transfer(self, req, res, error))
@@ -85,8 +85,10 @@ static gboolean
 fu_aver_hid_device_ensure_version(FuAverHidDevice *self, GError **error)
 {
 	g_autofree gchar *ver = NULL;
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_device_version_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_device_version_new();
+	g_autoptr(FuStructAverHidReqDeviceVersion) req =
+	    fu_struct_aver_hid_req_device_version_new();
+	g_autoptr(FuStructAverHidResDeviceVersion) res =
+	    fu_struct_aver_hid_res_device_version_new();
 	g_autoptr(GError) error_local = NULL;
 
 	if (!fu_aver_hid_device_transfer(self, req, res, &error_local)) {
@@ -151,8 +153,10 @@ fu_aver_hid_device_isp_file_dnload(FuAverHidDevice *self,
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
-		g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_file_dnload_new();
-		g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+		g_autoptr(FuStructAverHidReqIspFileDnload) req =
+		    fu_struct_aver_hid_req_isp_file_dnload_new();
+		g_autoptr(FuStructAverHidResIspStatus) res =
+		    fu_struct_aver_hid_res_isp_status_new();
 
 		/* prepare chunk */
 		chk = fu_chunk_array_index(chunks, i, error);
@@ -212,8 +216,8 @@ static gboolean
 fu_aver_hid_device_wait_for_ready_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuAverHidDevice *self = FU_AVER_HID_DEVICE(device);
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIsp) req = fu_struct_aver_hid_req_isp_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	fu_struct_aver_hid_req_isp_set_custom_isp_cmd(req, FU_AVER_HID_CUSTOM_ISP_CMD_STATUS);
 	if (!fu_aver_hid_device_transfer(self, req, res, error))
@@ -238,8 +242,8 @@ fu_aver_hid_device_isp_file_start(FuAverHidDevice *self,
 				  const gchar *name,
 				  GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_file_start_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIspFileStart) req = fu_struct_aver_hid_req_isp_file_start_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_AVER_HID_FLAG_DUAL_ISP)) {
 		fu_struct_aver_hid_req_isp_file_start_set_custom_isp_cmd(
@@ -263,8 +267,8 @@ fu_aver_hid_device_isp_file_start(FuAverHidDevice *self,
 static gboolean
 fu_aver_hid_device_isp_file_end(FuAverHidDevice *self, gsize sz, const gchar *name, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_file_end_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIspFileEnd) req = fu_struct_aver_hid_req_isp_file_end_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_AVER_HID_FLAG_DUAL_ISP)) {
 		fu_struct_aver_hid_req_isp_file_end_set_custom_isp_cmd(
@@ -290,8 +294,8 @@ static gboolean
 fu_aver_hid_device_wait_for_untar_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuAverHidDevice *self = FU_AVER_HID_DEVICE(device);
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_file_end_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIsp) req = fu_struct_aver_hid_req_isp_file_end_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	fu_struct_aver_hid_req_isp_set_custom_isp_cmd(req, FU_AVER_HID_CUSTOM_ISP_CMD_STATUS);
 	if (!fu_aver_hid_device_transfer(self, req, res, error))
@@ -314,8 +318,8 @@ fu_aver_hid_device_wait_for_untar_cb(FuDevice *device, gpointer user_data, GErro
 static gboolean
 fu_aver_hid_device_isp_start(FuAverHidDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIspStart) req = fu_struct_aver_hid_req_isp_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	if (fu_device_has_private_flag(FU_DEVICE(self), FU_AVER_HID_FLAG_DUAL_ISP)) {
 		fu_struct_aver_hid_req_isp_start_set_custom_isp_cmd(
@@ -336,7 +340,7 @@ fu_aver_hid_device_isp_start(FuAverHidDevice *self, GError **error)
 static gboolean
 fu_aver_hid_device_isp_reboot(FuAverHidDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_new();
+	g_autoptr(FuStructAverHidReqIsp) req = fu_struct_aver_hid_req_isp_new();
 	fu_struct_aver_hid_req_isp_set_custom_isp_cmd(req, FU_AVER_HID_CUSTOM_ISP_CMD_ISP_REBOOT);
 	return fu_aver_hid_device_transfer(self, req, NULL, error);
 }
@@ -346,8 +350,8 @@ fu_aver_hid_device_wait_for_reboot_cb(FuDevice *device, gpointer user_data, GErr
 {
 	FuAverHidDevice *self = FU_AVER_HID_DEVICE(device);
 	FuProgress *progress = FU_PROGRESS(user_data);
-	g_autoptr(GByteArray) req = fu_struct_aver_hid_req_isp_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_hid_res_isp_status_new();
+	g_autoptr(FuStructAverHidReqIsp) req = fu_struct_aver_hid_req_isp_new();
+	g_autoptr(FuStructAverHidResIspStatus) res = fu_struct_aver_hid_res_isp_status_new();
 
 	fu_struct_aver_hid_req_isp_set_custom_isp_cmd(req, FU_AVER_HID_CUSTOM_ISP_CMD_STATUS);
 	if (!fu_aver_hid_device_transfer(self, req, res, error))

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -62,8 +62,8 @@ static gboolean
 fu_aver_safeisp_device_ensure_version(FuAverSafeispDevice *self, GError **error)
 {
 	g_autofree gchar *ver = NULL;
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispResDeviceVersion) res = fu_struct_aver_safeisp_res_new();
 	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_GET_VERSION);
 	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
 		return FALSE;
@@ -95,8 +95,8 @@ fu_aver_safeisp_device_setup(FuDevice *device, GError **error)
 static gboolean
 fu_aver_safeisp_device_support(FuAverSafeispDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_SUPPORT);
 	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
@@ -114,8 +114,8 @@ fu_aver_safeisp_device_upload_prepare(FuAverSafeispDevice *self,
 				      gsize size,
 				      GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_PREPARE);
 	fu_struct_aver_safeisp_req_set_custom_parm0(req, partition);
@@ -133,8 +133,8 @@ fu_aver_safeisp_device_erase_flash(FuAverSafeispDevice *self,
 				   gsize param1,
 				   GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_ERASE_TEMP);
 	fu_struct_aver_safeisp_req_set_custom_parm0(req, param0);
@@ -158,8 +158,8 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
-		g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-		g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+		g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+		g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
 
 		/* prepare chunk */
 		chk = fu_chunk_array_index(chunks, i, error);
@@ -222,8 +222,8 @@ fu_aver_safeisp_device_upload_checksum(FuAverSafeispDevice *self,
 				       gsize param1,
 				       GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(GByteArray) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(
 	    req,
@@ -242,7 +242,7 @@ fu_aver_safeisp_device_upload_checksum(FuAverSafeispDevice *self,
 static gboolean
 fu_aver_safeisp_device_update(FuAverSafeispDevice *self, gsize param0, gsize param1, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_UPDATE_START);
 	fu_struct_aver_safeisp_req_set_custom_parm0(req, param0);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -42,7 +42,7 @@ G_DEFINE_TYPE(FuCcgxDmcDevice, fu_ccgx_dmc_device, FU_TYPE_USB_DEVICE)
 static gboolean
 fu_ccgx_dmc_device_ensure_dock_id(FuCcgxDmcDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) st_id = fu_struct_ccgx_dmc_dock_identity_new();
+	g_autoptr(FuStructCcgxDmcDockIdentity) st_id = fu_struct_ccgx_dmc_dock_identity_new();
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_DEVICE_TO_HOST,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -70,7 +70,7 @@ fu_ccgx_dmc_device_ensure_status(FuCcgxDmcDevice *self, GError **error)
 	gsize bufsz;
 	gsize offset = FU_STRUCT_CCGX_DMC_DOCK_STATUS_SIZE;
 	g_autofree guint8 *buf = NULL;
-	g_autoptr(GByteArray) st = fu_struct_ccgx_dmc_dock_status_new();
+	g_autoptr(FuStructCcgxDmcDockStatus) st = fu_struct_ccgx_dmc_dock_status_new();
 
 	/* read minimum status length */
 	fu_byte_array_set_size(st, 32, 0x0);
@@ -278,7 +278,9 @@ fu_ccgx_dmc_device_send_fwct(FuCcgxDmcDevice *self,
 }
 
 static gboolean
-fu_ccgx_dmc_device_read_intr_req(FuCcgxDmcDevice *self, GByteArray *intr_rqt, GError **error)
+fu_ccgx_dmc_device_read_intr_req(FuCcgxDmcDevice *self,
+				 FuStructCcgxDmcIntRqt *intr_rqt,
+				 GError **error)
 {
 	guint8 rqt_opcode;
 	g_autofree gchar *title = NULL;
@@ -380,7 +382,7 @@ fu_ccgx_dmc_device_get_image_write_status_cb(FuDevice *device, gpointer user_dat
 	FuCcgxDmcDevice *self = FU_CCGX_DMC_DEVICE(device);
 	const guint8 *req_data;
 	guint8 req_opcode;
-	g_autoptr(GByteArray) dmc_int_req = fu_struct_ccgx_dmc_int_rqt_new();
+	g_autoptr(FuStructCcgxDmcIntRqt) dmc_int_req = fu_struct_ccgx_dmc_int_rqt_new();
 
 	/* get interrupt request */
 	if (!fu_ccgx_dmc_device_read_intr_req(self, dmc_int_req, error)) {
@@ -520,7 +522,7 @@ fu_ccgx_dmc_device_write_firmware(FuDevice *device,
 	gsize fw_data_written = 0;
 	guint8 img_index = 0;
 	guint8 rqt_opcode;
-	g_autoptr(GByteArray) dmc_int_rqt = fu_struct_ccgx_dmc_int_rqt_new();
+	g_autoptr(FuStructCcgxDmcIntRqt) dmc_int_rqt = fu_struct_ccgx_dmc_int_rqt_new();
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-devx-device.c
@@ -14,7 +14,7 @@
 
 struct _FuCcgxDmcDevxDevice {
 	FuDevice parent_instance;
-	GByteArray *status; /* DmcDevxStatus */
+	FuStructCcgxDmcDevxStatus *status;
 };
 
 G_DEFINE_TYPE(FuCcgxDmcDevxDevice, fu_ccgx_dmc_devx_device, FU_TYPE_DEVICE)

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -106,7 +106,7 @@ fu_ccgx_dmc_firmware_parse_segment(FuFirmware *firmware,
 	for (guint32 i = 0; i < img_rcd->num_img_segments; i++) {
 		guint16 row_size_bytes = 0;
 		g_autoptr(FuCcgxDmcFirmwareSegmentRecord) seg_rcd = NULL;
-		g_autoptr(GByteArray) st_info = NULL;
+		g_autoptr(FuStructCcgxDmcFwctSegmentationInfo) st_info = NULL;
 
 		/* read segment info  */
 		seg_rcd = g_new0(FuCcgxDmcFirmwareSegmentRecord, 1);
@@ -189,7 +189,7 @@ fu_ccgx_dmc_firmware_parse_image(FuFirmware *firmware,
 	/* set initial segment info offset */
 	for (guint32 i = 0; i < image_count; i++) {
 		g_autoptr(FuCcgxDmcFirmwareRecord) img_rcd = NULL;
-		g_autoptr(GByteArray) st_img = NULL;
+		g_autoptr(FuStructCcgxDmcFwctImageInfo) st_img = NULL;
 
 		/* read image info */
 		img_rcd = g_new0(FuCcgxDmcFirmwareRecord, 1);
@@ -268,7 +268,7 @@ fu_ccgx_dmc_firmware_parse(FuFirmware *firmware,
 	guint16 mdbufsz = 0;
 	guint32 hdr_composite_version = 0;
 	guint8 hdr_image_count = 0;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructCcgxDmcFwctInfo) st_hdr = NULL;
 
 	/* parse */
 	st_hdr = fu_struct_ccgx_dmc_fwct_info_parse_stream(stream, 0x0, error);
@@ -328,7 +328,7 @@ static GByteArray *
 fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_hdr = fu_struct_ccgx_dmc_fwct_info_new();
+	g_autoptr(FuStructCcgxDmcFwctInfo) st_hdr = fu_struct_ccgx_dmc_fwct_info_new();
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 
 	/* add header */
@@ -361,7 +361,8 @@ fu_ccgx_dmc_firmware_write(FuFirmware *firmware, GError **error)
 	/* add segments */
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
-		g_autoptr(GByteArray) st_info = fu_struct_ccgx_dmc_fwct_segmentation_info_new();
+		g_autoptr(FuStructCcgxDmcFwctSegmentationInfo) st_info =
+		    fu_struct_ccgx_dmc_fwct_segmentation_info_new();
 		g_autoptr(FuChunkArray) chunks = NULL;
 		g_autoptr(GBytes) img_bytes = fu_firmware_get_bytes(img, error);
 		if (img_bytes == NULL)

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -170,7 +170,7 @@ fu_ccgx_firmware_parse_md_block(FuCcgxFirmware *self, FuFirmwareParseFlags flags
 	guint32 rcd_version_idx = 0;
 	guint32 version = 0;
 	guint8 checksum_calc = 0;
-	g_autoptr(GByteArray) st_metadata = NULL;
+	g_autoptr(FuStructCcgxMetadataHdr) st_metadata = NULL;
 
 	/* sanity check */
 	if (self->records->len == 0) {
@@ -410,7 +410,7 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	const guint8 *fwbuf;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GByteArray) mdbuf = g_byte_array_new();
-	g_autoptr(GByteArray) st_metadata = fu_struct_ccgx_metadata_hdr_new();
+	g_autoptr(FuStructCcgxMetadataHdr) st_metadata = fu_struct_ccgx_metadata_hdr_new();
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(FuChunkArray) chunks = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1268,7 +1268,7 @@ fu_ccgx_hpi_device_write_firmware(FuDevice *device,
 	GPtrArray *records = fu_ccgx_firmware_get_records(FU_CCGX_FIRMWARE(firmware));
 	FuCcgxFwMode fw_mode_alt = fu_ccgx_fw_mode_get_alternate(self->fw_mode);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GByteArray) st_metadata = fu_struct_ccgx_metadata_hdr_new();
+	g_autoptr(FuStructCcgxMetadataHdr) st_metadata = fu_struct_ccgx_metadata_hdr_new();
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -34,7 +34,7 @@ fu_ccgx_pure_hid_device_command(FuCcgxPureHidDevice *self,
 				guint8 param2,
 				GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_ccgx_pure_hid_command_new();
+	g_autoptr(FuStructCcgxPureHidCommand) cmd = fu_struct_ccgx_pure_hid_command_new();
 	fu_struct_ccgx_pure_hid_command_set_cmd(cmd, param1);
 	fu_struct_ccgx_pure_hid_command_set_opt(cmd, param2);
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
@@ -103,7 +103,7 @@ fu_ccgx_pure_hid_device_ensure_fw_info(FuCcgxPureHidDevice *self, GError **error
 	guint8 buf[0x40] = {FU_CCGX_PURE_HID_REPORT_ID_INFO, 0};
 	guint version = 0;
 	g_autofree gchar *bl_ver = NULL;
-	g_autoptr(GByteArray) st_info = NULL;
+	g_autoptr(FuStructCcgxPureHidFwInfo) st_info = NULL;
 
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      buf[0],
@@ -313,7 +313,7 @@ fu_ccgx_pure_hid_device_write_row(FuCcgxPureHidDevice *self,
 				  gsize row_len,
 				  GError **error)
 {
-	g_autoptr(GByteArray) st_hdr = fu_struct_ccgx_pure_hid_write_hdr_new();
+	g_autoptr(FuStructCcgxPureHidWriteHdr) st_hdr = fu_struct_ccgx_pure_hid_write_hdr_new();
 
 	fu_struct_ccgx_pure_hid_write_hdr_set_pd_resp(st_hdr,
 						      FU_CCGX_PD_RESP_FLASH_READ_WRITE_CMD_SIG);

--- a/plugins/cfu/fu-cfu-device.c
+++ b/plugins/cfu/fu-cfu-device.c
@@ -60,8 +60,8 @@ fu_cfu_device_send_offer_info(FuCfuDevice *self, FuCfuOfferInfoCode info_code, G
 {
 	g_autoptr(GByteArray) buf_in = g_byte_array_new();
 	g_autoptr(GByteArray) buf_out = g_byte_array_new();
-	g_autoptr(GByteArray) st_req = fu_struct_cfu_offer_info_req_new();
-	g_autoptr(GByteArray) st_res = NULL;
+	g_autoptr(FuStructCfuOfferInfoReq) st_req = fu_struct_cfu_offer_info_req_new();
+	g_autoptr(FuStructCfuOfferRsp) st_res = NULL;
 
 	/* not all devices handle this */
 	if (!fu_device_has_private_flag(FU_DEVICE(self), FU_CFU_DEVICE_FLAG_SEND_OFFER_INFO))
@@ -133,7 +133,7 @@ fu_cfu_device_send_offer(FuCfuDevice *self,
 {
 	g_autoptr(GByteArray) buf_in = g_byte_array_new();
 	g_autoptr(GByteArray) buf_out = g_byte_array_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCfuOfferRsp) st = NULL;
 	g_autoptr(GBytes) blob = NULL;
 
 	/* generate a offer blob */
@@ -216,8 +216,8 @@ fu_cfu_device_send_payload(FuCfuDevice *self,
 		FuChunk *chk = g_ptr_array_index(chunks, i);
 		g_autoptr(GByteArray) buf_in = g_byte_array_new();
 		g_autoptr(GByteArray) buf_out = g_byte_array_new();
-		g_autoptr(GByteArray) st_req = fu_struct_cfu_content_req_new();
-		g_autoptr(GByteArray) st_rsp = NULL;
+		g_autoptr(FuStructCfuContentReq) st_req = fu_struct_cfu_content_req_new();
+		g_autoptr(FuStructCfuContentRsp) st_rsp = NULL;
 
 		/* build */
 		if (i == 0) {
@@ -412,7 +412,7 @@ fu_cfu_device_setup(FuDevice *device, GError **error)
 	guint8 component_cnt = 0;
 	gsize offset = 0;
 	g_autoptr(GHashTable) modules_by_cid = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCfuGetVersionRsp) st = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(GPtrArray) descriptors = NULL;
 	g_autoptr(GString) descriptors_error = g_string_new(NULL);

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -36,7 +36,7 @@ fu_cfu_module_setup(FuCfuModule *self, const guint8 *buf, gsize bufsz, gsize off
 {
 	FuDevice *device = FU_DEVICE(self);
 	g_autofree gchar *logical_id = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructCfuGetVersionRspComponent) st = NULL;
 
 	/* parse */
 	st = fu_struct_cfu_get_version_rsp_component_parse(buf, bufsz, offset, error);

--- a/plugins/ch347/fu-ch347-device.c
+++ b/plugins/ch347/fu-ch347-device.c
@@ -92,7 +92,7 @@ fu_ch347_device_read(FuCh347Device *self,
 {
 	gsize actual_length = 0;
 	guint16 size_rsp;
-	g_autoptr(GByteArray) st = fu_struct_ch347_req_new();
+	g_autoptr(FuStructCh347Req) st = fu_struct_ch347_req_new();
 
 	/* pack */
 	fu_struct_ch347_req_set_cmd(st, cmd);

--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.c
@@ -350,7 +350,7 @@ static gboolean
 fu_dell_kestrel_ec_dock_info_cmd(FuDellKestrelEc *self, GError **error)
 {
 	FuDellKestrelEcCmd cmd = FU_DELL_KESTREL_EC_CMD_GET_DOCK_INFO;
-	g_autoptr(GByteArray) res = fu_struct_dell_kestrel_dock_info_new();
+	g_autoptr(FuStructDellKestrelDockInfo) res = fu_struct_dell_kestrel_dock_info_new();
 
 	/* get dock info over HID */
 	if (!fu_dell_kestrel_ec_read(self, cmd, res, error)) {
@@ -387,7 +387,7 @@ static gboolean
 fu_dell_kestrel_ec_dock_data_cmd(FuDellKestrelEc *self, GError **error)
 {
 	FuDellKestrelEcCmd cmd = FU_DELL_KESTREL_EC_CMD_GET_DOCK_DATA;
-	g_autoptr(GByteArray) res = fu_struct_dell_kestrel_dock_data_new();
+	g_autoptr(FuStructDellKestrelDockData) res = fu_struct_dell_kestrel_dock_data_new();
 
 	/* get dock data over HID */
 	if (!fu_dell_kestrel_ec_read(self, cmd, res, error)) {
@@ -448,7 +448,8 @@ gboolean
 fu_dell_kestrel_ec_own_dock(FuDellKestrelEc *self, gboolean lock, GError **error)
 {
 	guint16 bitmask = 0x0;
-	g_autoptr(GByteArray) st_req = fu_struct_dell_kestrel_ec_databytes_new();
+	g_autoptr(FuStructDellKestrelEcDatabytes) st_req =
+	    fu_struct_dell_kestrel_ec_databytes_new();
 	g_autoptr(GError) error_local = NULL;
 	g_autofree gchar *msg = NULL;
 
@@ -489,7 +490,8 @@ gboolean
 fu_dell_kestrel_ec_run_passive_update(FuDellKestrelEc *self, GError **error)
 {
 	guint max_tries = 2;
-	g_autoptr(GByteArray) st_req = fu_struct_dell_kestrel_ec_databytes_new();
+	g_autoptr(FuStructDellKestrelEcDatabytes) st_req =
+	    fu_struct_dell_kestrel_ec_databytes_new();
 	const guint8 bitmap = 0x07;
 
 	/* ec included in cmd, set bit2 in data for tbt */
@@ -629,7 +631,8 @@ fu_dell_kestrel_ec_get_package_version(FuDellKestrelEc *self)
 gboolean
 fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, GInputStream *stream, GError **error)
 {
-	g_autoptr(GByteArray) st_req = fu_struct_dell_kestrel_ec_databytes_new();
+	g_autoptr(FuStructDellKestrelEcDatabytes) st_req =
+	    fu_struct_dell_kestrel_ec_databytes_new();
 	g_autoptr(GByteArray) buf = NULL;
 	gsize streamsz = 0;
 

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
@@ -32,7 +32,7 @@ fu_dell_kestrel_rtshub_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_dell_kestrel_rtshub_set_clock_mode(FuDellKestrelRtshub *self, gboolean enable, GError **error)
 {
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
 	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_MCUMODIFYCLOCK);
@@ -55,7 +55,7 @@ fu_dell_kestrel_rtshub_set_clock_mode(FuDellKestrelRtshub *self, gboolean enable
 static gboolean
 fu_dell_kestrel_rtshub_erase_spare_bank(FuDellKestrelRtshub *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
 	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_ERASEBANK);
@@ -80,7 +80,7 @@ fu_dell_kestrel_rtshub_verify_update_fw(FuDellKestrelRtshub *self,
 					FuProgress *progress,
 					GError **error)
 {
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
 	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_VERIFYUPDATE);
@@ -118,7 +118,7 @@ fu_dell_kestrel_rtshub_verify_update_fw(FuDellKestrelRtshub *self,
 static gboolean
 fu_dell_kestrel_rtshub_reset_device(FuDellKestrelRtshub *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
 	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_RESET_TO_FLASH);
@@ -144,7 +144,7 @@ fu_dell_kestrel_rtshub_write_flash(FuDellKestrelRtshub *self,
 				   guint16 data_sz,
 				   GError **error)
 {
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	g_return_val_if_fail(data_sz <= 128, FALSE);
 	g_return_val_if_fail(data != NULL, FALSE);
@@ -265,7 +265,7 @@ fu_dell_kestrel_rtshub_get_status(FuDevice *device, GError **error)
 {
 	FuDellKestrelRtshub *self = FU_DELL_KESTREL_RTSHUB(device);
 	g_autofree gchar *version = NULL;
-	g_autoptr(GByteArray) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
 
 	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_READ_DATA);
 	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_READ_STATUS);

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -37,7 +37,7 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 {
 	gsize actual_length;
 	guint8 ep_out = FU_EBITDO_USB_RUNTIME_EP_OUT;
-	g_autoptr(GByteArray) st_hdr = fu_struct_ebitdo_pkt_new();
+	g_autoptr(FuStructEbitdoPkt) st_hdr = fu_struct_ebitdo_pkt_new();
 	g_autoptr(GError) error_local = NULL;
 
 	fu_byte_array_set_size(st_hdr, FU_EBITDO_USB_EP_SIZE, 0x0);
@@ -107,7 +107,7 @@ fu_ebitdo_device_receive(FuEbitdoDevice *self, guint8 *out, gsize out_len, GErro
 	guint8 packet[FU_EBITDO_USB_EP_SIZE] = {0};
 	gsize actual_length;
 	guint8 ep_in = FU_EBITDO_USB_RUNTIME_EP_IN;
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructEbitdoPkt) st_hdr = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* different */

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -25,7 +25,7 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	guint32 version;
 	gsize streamsz = 0;
 	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructEbitdoHdr) st = NULL;
 	g_autoptr(GInputStream) stream_hdr = NULL;
 	g_autoptr(GInputStream) stream_payload = NULL;
 
@@ -73,7 +73,7 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 static GByteArray *
 fu_ebitdo_firmware_write(FuFirmware *firmware, GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_ebitdo_hdr_new();
+	g_autoptr(FuStructEbitdoHdr) st = fu_struct_ebitdo_hdr_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	/* header then payload */

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -246,7 +246,7 @@ static gboolean
 fu_fpc_device_check_dfu_status_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuFpcDevice *self = FU_FPC_DEVICE(device);
-	g_autoptr(GByteArray) dfu_status = fu_struct_fpc_dfu_new();
+	g_autoptr(FuStructFpcDfu) dfu_status = fu_struct_fpc_dfu_new();
 
 	if (!fu_fpc_device_dfu_cmd(self,
 				   FPC_CMD_DFU_GETSTATUS,

--- a/plugins/framework-qmk/fu-framework-qmk-device.c
+++ b/plugins/framework-qmk/fu-framework-qmk-device.c
@@ -24,7 +24,8 @@ fu_framework_qmk_device_detach(FuDevice *device, FuProgress *progress, GError **
 {
 	FuFrameworkQmkDevice *self = FU_FRAMEWORK_QMK_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GByteArray) req = fu_struct_framework_qmk_reset_request_new();
+	g_autoptr(FuStructFrameworkQmkResetRequest) req =
+	    fu_struct_framework_qmk_reset_request_new();
 
 	if (!fu_hidraw_device_set_report(FU_HIDRAW_DEVICE(self),
 					 req->data,

--- a/plugins/genesys/fu-genesys-usbhub-device.c
+++ b/plugins/genesys/fu-genesys-usbhub-device.c
@@ -87,11 +87,11 @@ typedef struct {
 
 struct _FuGenesysUsbhubDevice {
 	FuUsbDevice parent_instance;
-	GByteArray *st_static_ts;
+	FuStructGenesysTsStatic *st_static_ts;
 	GByteArray *st_dynamic_ts;
-	GByteArray *st_fwinfo_ts;
-	GByteArray *st_vendor_ts;
-	GByteArray *st_project_ts;
+	FuStructGenesysTsFirmwareInfo *st_fwinfo_ts;
+	FuStructGenesysTsVendorSupport *st_vendor_ts;
+	FuStructGenesysTsBrandProject *st_project_ts;
 	FuGenesysVendorCommandSetting vcs;
 	FuGenesysModelSpec spec;
 
@@ -2592,7 +2592,7 @@ fu_genesys_usbhub_device_send_hash_data_length(FuGenesysUsbhubDevice *self,
 
 static gboolean
 fu_genesys_usbhub_device_send_hash_digest(FuGenesysUsbhubDevice *self,
-					  GByteArray *st_codesign,
+					  FuStructGenesysFwCodesignInfoEcdsa *st_codesign,
 					  GError **error)
 {
 	gsize hash_bufsz = 0;
@@ -2701,7 +2701,7 @@ fu_genesys_usbhub_device_toggle_hw_read_key(FuGenesysUsbhubDevice *self,
 
 static gboolean
 fu_genesys_usbhub_device_send_signature(FuGenesysUsbhubDevice *self,
-					GByteArray *st_codesign,
+					FuStructGenesysFwCodesignInfoEcdsa *st_codesign,
 					GError **error)
 {
 	gsize sig_bufsz = 0;
@@ -2822,7 +2822,7 @@ fu_genesys_usbhub_device_examine_fw_codesign_hw(FuGenesysUsbhubDevice *self,
 	gsize codesize_to_hash = 0;
 	g_autoptr(FuFirmware) codesign_img = NULL;
 	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GByteArray) st_codesign = NULL;
+	g_autoptr(FuStructGenesysFwCodesignInfoEcdsa) st_codesign = NULL;
 	g_autoptr(GPtrArray) imgs = fu_firmware_get_images(firmware);
 
 	/* get fw codesign info */
@@ -3223,11 +3223,11 @@ fu_genesys_usbhub_device_finalize(GObject *object)
 	if (self->st_dynamic_ts != NULL)
 		g_byte_array_unref(self->st_dynamic_ts);
 	if (self->st_fwinfo_ts != NULL)
-		g_byte_array_unref(self->st_fwinfo_ts);
+		fu_struct_genesys_ts_firmware_info_unref(self->st_fwinfo_ts);
 	if (self->st_vendor_ts != NULL)
-		g_byte_array_unref(self->st_vendor_ts);
+		fu_struct_genesys_ts_vendor_support_unref(self->st_vendor_ts);
 	if (self->st_project_ts != NULL)
-		g_byte_array_unref(self->st_project_ts);
+		fu_struct_genesys_ts_brand_project_unref(self->st_project_ts);
 	if (self->hub_fw_bank1_data != NULL)
 		g_bytes_unref(self->hub_fw_bank1_data);
 	if (self->st_codesign != NULL)

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -16,7 +16,7 @@
 
 struct _FuGenesysUsbhubFirmware {
 	FuFirmware parent_instance;
-	GByteArray *st_static_ts;
+	FuStructGenesysTsStatic *st_static_ts;
 	FuGenesysChip chip;
 };
 

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
@@ -33,7 +33,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 	guint8 cfg_ver = 0;
 	gsize bufsz = 0;
 	const guint8 *buf;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructGoodixBrlbHdr) st = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	st = fu_struct_goodix_brlb_hdr_parse_stream(stream, 0x0, error);
@@ -96,7 +96,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 	offset_hdr = st->len;
 	for (guint i = 0; i < subsys_num; i++) {
 		guint32 img_size;
-		g_autoptr(GByteArray) st_img = NULL;
+		g_autoptr(FuStructGoodixBrlbImg) st_img = NULL;
 
 		st_img = fu_struct_goodix_brlb_img_parse_stream(stream, offset_hdr, error);
 		if (st_img == NULL)

--- a/plugins/hpi-cfu/fu-hpi-cfu-device.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-device.c
@@ -68,7 +68,7 @@ static gboolean
 fu_hpi_cfu_device_start_entire_transaction(FuHpiCfuDevice *self, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GByteArray) st_req = fu_struct_hpi_cfu_buf_new();
+	g_autoptr(FuStructHpiCfuBuf) st_req = fu_struct_hpi_cfu_buf_new();
 
 	fu_struct_hpi_cfu_buf_set_report_id(st_req, OFFER_REPORT_ID);
 	fu_struct_hpi_cfu_buf_set_command(st_req, FU_CFU_OFFER_INFO_CODE_START_ENTIRE_TRANSACTION);
@@ -134,7 +134,7 @@ static gboolean
 fu_hpi_cfu_device_send_start_offer_list(FuHpiCfuDevice *self, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GByteArray) st_req = fu_struct_hpi_cfu_buf_new();
+	g_autoptr(FuStructHpiCfuBuf) st_req = fu_struct_hpi_cfu_buf_new();
 
 	fu_struct_hpi_cfu_buf_set_report_id(st_req, OFFER_REPORT_ID);
 	fu_struct_hpi_cfu_buf_set_command(st_req, FU_CFU_OFFER_INFO_CODE_START_OFFER_LIST);
@@ -214,7 +214,7 @@ fu_hpi_cfu_device_send_offer_update_command(FuHpiCfuDevice *self,
 	const guint8 *buf;
 	gint8 flag_value = 0;
 	gsize bufsz = 0;
-	g_autoptr(GByteArray) st_req = fu_struct_hpi_cfu_offer_cmd_new();
+	g_autoptr(FuStructHpiCfuOfferCmd) st_req = fu_struct_hpi_cfu_offer_cmd_new();
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GBytes) blob_offer = NULL;
 
@@ -373,7 +373,7 @@ static gboolean
 fu_hpi_cfu_device_send_end_offer_list(FuHpiCfuDevice *self, GError **error)
 {
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(GByteArray) st_req = fu_struct_hpi_cfu_buf_new();
+	g_autoptr(FuStructHpiCfuBuf) st_req = fu_struct_hpi_cfu_buf_new();
 
 	fu_struct_hpi_cfu_buf_set_report_id(st_req, OFFER_REPORT_ID);
 	fu_struct_hpi_cfu_buf_set_command(st_req, FU_CFU_OFFER_INFO_CODE_END_OFFER_LIST);
@@ -586,7 +586,7 @@ fu_hpi_cfu_device_handler_send_offer_accepted(FuHpiCfuDevice *self,
 static gboolean
 fu_hpi_cfu_device_send_payload(FuHpiCfuDevice *self, GByteArray *cfu_buf, GError **error)
 {
-	g_autoptr(GByteArray) st_req = fu_struct_hpi_cfu_payload_cmd_new();
+	g_autoptr(FuStructHpiCfuPayloadCmd) st_req = fu_struct_hpi_cfu_payload_cmd_new();
 	g_autoptr(GError) error_local = NULL;
 
 	fu_struct_hpi_cfu_payload_cmd_set_report_id(st_req, FIRMWARE_REPORT_ID);

--- a/plugins/huddly-usb/fu-huddly-usb-common.c
+++ b/plugins/huddly-usb/fu-huddly-usb-common.c
@@ -15,7 +15,7 @@ fu_huddly_usb_hlink_msg_free(FuHuddlyUsbHLinkMsg *msg)
 {
 	g_free(msg->msg_name);
 	if (msg->header != NULL)
-		g_byte_array_unref(msg->header);
+		fu_struct_h_link_header_unref(msg->header);
 	if (msg->payload != NULL)
 		g_byte_array_unref(msg->payload);
 	g_free(msg);

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -97,7 +97,7 @@ fu_intel_usb4_device_get_mmio(FuIntelUsb4Device *self,
 	}
 	/* verify status for specific hub mailbox register */
 	if (mbox_reg == MBOX_REG) {
-		g_autoptr(GByteArray) st_regex = NULL;
+		g_autoptr(FuStructIntelUsb4Mbox) st_regex = NULL;
 
 		st_regex = fu_struct_intel_usb4_mbox_parse(buf, bufsz, 0x0, error);
 		if (st_regex == NULL)
@@ -226,7 +226,7 @@ fu_intel_usb4_device_operation(FuIntelUsb4Device *self,
 			       GError **error)
 {
 	gint max_tries = 100;
-	g_autoptr(GByteArray) st_regex = fu_struct_intel_usb4_mbox_new();
+	g_autoptr(FuStructIntelUsb4Mbox) st_regex = fu_struct_intel_usb4_mbox_new();
 
 	/* Write metadata register for operations that use it */
 	switch (opcode) {

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -222,7 +222,7 @@ fu_kinetic_dp_puma_device_wait_drv_ready(FuKineticDpPumaDevice *self,
 					 GError **error)
 {
 	guint8 flashinfo[FU_STRUCT_KINETIC_DP_FLASH_INFO_SIZE] = {0};
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructKineticDpFlashInfo) st = NULL;
 
 	self->flash_id = 0;
 	self->flash_size = 0;
@@ -321,7 +321,7 @@ fu_kinetic_dp_puma_device_enable_fw_update_mode(FuKineticDpPumaDevice *self,
 	if (fu_kinetic_dp_device_get_fw_state(FU_KINETIC_DP_DEVICE(self)) ==
 	    FU_KINETIC_DP_FW_STATE_APP) {
 		guint8 flashinfo[FU_STRUCT_KINETIC_DP_FLASH_INFO_SIZE] = {0};
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructKineticDpFlashInfo) st = NULL;
 
 		/* Puma takes about 18ms (Winbond EF13) to get ISP driver ready for flash info */
 		fu_device_sleep(FU_DEVICE(self), 18);

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -109,7 +109,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 	guint8 checksum_actual;
 	guint8 cmdb_sig[FU_KINETIC_DP_PUMA_REQUEST_FW_CMDB_SIG_SIZE] = {'P', 'M', 'D', 'B'};
 	g_autoptr(GByteArray) cmdb_tmp = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructKineticDpPumaHeader) st = NULL;
 
 	/* sanity check */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -130,7 +130,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 	offset += st->len;
 	code_size += FU_STRUCT_KINETIC_DP_PUMA_HEADER_SIZE;
 	for (guint i = 0; i < FU_STRUCT_KINETIC_DP_PUMA_HEADER_DEFAULT_OBJECT_COUNT; i++) {
-		g_autoptr(GByteArray) st_obj =
+		g_autoptr(FuStructKineticDpPumaHeaderInfo) st_obj =
 		    fu_struct_kinetic_dp_puma_header_info_parse_stream(stream, offset, error);
 		if (st_obj == NULL)
 			return FALSE;

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -516,7 +516,7 @@ fu_kinetic_dp_secure_device_execute_isp_drv(FuKineticDpSecureDevice *self, GErro
 	guint8 status;
 	guint8 read_len;
 	guint8 reply_data[6] = {0};
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructKineticDpFlashInfo) st = NULL;
 
 	/* in Jaguar, it takes about FU_KINETIC_DP_DEVICE_TIMEOUT ms to boot up and initialize */
 	self->flash_id = 0;

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -146,7 +146,7 @@ fu_kinetic_dp_secure_firmware_parse_app_fw(FuKineticDpSecureFirmware *self,
 	gsize streamsz = 0;
 	guint32 app_code_block_size;
 	guint32 std_fw_ver = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructKineticDpJaguarFooter) st = NULL;
 
 	/* sanity check */
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/legion-hid2/fu-legion-hid2-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-device.c
@@ -62,8 +62,8 @@ fu_legion_hid2_device_convert_version(FuDevice *device, guint64 version_raw)
 static gboolean
 fu_legion_hid2_device_ensure_version(FuLegionHid2Device *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_get_version_new();
-	g_autoptr(GByteArray) result = fu_struct_legion_version_new();
+	g_autoptr(FuStructLegionGetVersion) cmd = fu_struct_legion_get_version_new();
+	g_autoptr(FuStructLegionVersion) result = fu_struct_legion_version_new();
 
 	if (!fu_legion_hid2_device_transfer(self, cmd, result, error))
 		return FALSE;
@@ -79,9 +79,9 @@ fu_legion_hid2_device_ensure_version(FuLegionHid2Device *self, GError **error)
 static void
 fu_legion_hid2_device_setup_touchpad_direct(FuLegionHid2Device *self)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_get_pl_test_new();
-	g_autoptr(GByteArray) tp_man = fu_struct_legion_get_pl_test_result_new();
-	g_autoptr(GByteArray) tp_ver = fu_struct_legion_get_pl_test_result_new();
+	g_autoptr(FuStructLegionGetPlTest) cmd = fu_struct_legion_get_pl_test_new();
+	g_autoptr(FuStructLegionGetPlTestResult) tp_man = fu_struct_legion_get_pl_test_result_new();
+	g_autoptr(FuStructLegionGetPlTestResult) tp_ver = fu_struct_legion_get_pl_test_result_new();
 	g_autoptr(FuDevice) child = NULL;
 	g_autoptr(GError) error_child = NULL;
 
@@ -274,8 +274,8 @@ fu_legion_hid2_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_legion_hid2_device_detach(FuDevice *device, FuProgress *progress, GError **error)
 {
-	g_autoptr(GByteArray) cmd = NULL;
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionStartIap) cmd = NULL;
+	g_autoptr(FuStructLegionIapResult) result = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	cmd = fu_struct_legion_start_iap_new();

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -46,8 +46,8 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_sig = fu_firmware_new();
 	g_autoptr(GInputStream) stream_payload = NULL;
 	g_autoptr(GInputStream) stream_sig = NULL;
-	g_autoptr(GByteArray) header = NULL;
-	g_autoptr(GByteArray) version = NULL;
+	g_autoptr(FuStructLegionHid2Header) header = NULL;
+	g_autoptr(FuStructLegionHid2Version) version = NULL;
 
 	header = fu_struct_legion_hid2_header_parse_stream(stream, 0x0, error);
 	if (header == NULL)

--- a/plugins/legion-hid2/fu-legion-hid2-iap-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-iap-device.c
@@ -50,10 +50,12 @@ fu_legion_hid2_iap_device_transfer(FuLegionHid2IapDevice *self,
 	return TRUE;
 }
 
-static GByteArray *
-fu_legion_hid2_iap_device_tlv(FuLegionHid2IapDevice *self, GByteArray *cmd, GError **error)
+static FuStructLegionIapTlv *
+fu_legion_hid2_iap_device_tlv(FuLegionHid2IapDevice *self,
+			      FuStructLegionIapTlv *cmd,
+			      GError **error)
 {
-	g_autoptr(GByteArray) result = fu_struct_legion_iap_tlv_new();
+	g_autoptr(FuStructLegionIapTlv) result = fu_struct_legion_iap_tlv_new();
 	const guint8 *value;
 	guint8 expected;
 	guint16 tag;
@@ -91,8 +93,8 @@ fu_legion_hid2_iap_device_tlv(FuLegionHid2IapDevice *self, GByteArray *cmd, GErr
 static gboolean
 fu_legion_hid2_iap_device_attach(FuDevice *device, FuProgress *progress, GError **error)
 {
-	g_autoptr(GByteArray) cmd = NULL;
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionIapTlv) cmd = NULL;
+	g_autoptr(FuStructLegionIapTlv) result = NULL;
 	g_autoptr(GError) error_attach = NULL;
 
 	cmd = fu_struct_legion_iap_tlv_new();
@@ -128,8 +130,8 @@ fu_legion_hid2_iap_device_prepare_firmware(FuDevice *device,
 static gboolean
 fu_legion_hid2_iap_device_unlock_flash(FuLegionHid2IapDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_iap_tlv_new();
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionIapTlv) cmd = fu_struct_legion_iap_tlv_new();
+	g_autoptr(FuStructLegionIapTlv) result = NULL;
 
 	fu_struct_legion_iap_tlv_set_tag(cmd, FU_LEGION_IAP_HOST_TAG_IAP_UNLOCK);
 
@@ -145,8 +147,8 @@ fu_legion_hid2_iap_device_unlock_flash(FuLegionHid2IapDevice *self, GError **err
 static gboolean
 fu_legion_hid2_iap_device_verify_signature(FuLegionHid2IapDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_iap_tlv_new();
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionIapTlv) cmd = fu_struct_legion_iap_tlv_new();
+	g_autoptr(FuStructLegionIapTlv) result = NULL;
 
 	fu_struct_legion_iap_tlv_set_tag(cmd, FU_LEGION_IAP_HOST_TAG_IAP_UPDATE);
 
@@ -162,8 +164,8 @@ fu_legion_hid2_iap_device_verify_signature(FuLegionHid2IapDevice *self, GError *
 static gboolean
 fu_legion_hid2_iap_device_verify_code(FuLegionHid2IapDevice *self, GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_iap_tlv_new();
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionIapTlv) cmd = fu_struct_legion_iap_tlv_new();
+	g_autoptr(FuStructLegionIapTlv) result = NULL;
 
 	fu_struct_legion_iap_tlv_set_tag(cmd, FU_LEGION_IAP_HOST_TAG_IAP_VERIFY);
 
@@ -187,8 +189,8 @@ fu_legion_hid2_iap_device_write_data_chunks(FuLegionHid2IapDevice *self,
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
-		g_autoptr(GByteArray) req = fu_struct_legion_iap_tlv_new();
-		g_autoptr(GByteArray) res = NULL;
+		g_autoptr(FuStructLegionIapTlv) req = fu_struct_legion_iap_tlv_new();
+		g_autoptr(FuStructLegionIapTlv) res = NULL;
 
 		fu_struct_legion_iap_tlv_set_tag(req, tag);
 
@@ -220,8 +222,8 @@ fu_legion_hid2_iap_device_write_data_chunks(FuLegionHid2IapDevice *self,
 static gboolean
 fu_legion_hid2_iap_device_wait_for_complete_cb(FuDevice *device, gpointer user_data, GError **error)
 {
-	g_autoptr(GByteArray) cmd = fu_struct_legion_iap_tlv_new();
-	g_autoptr(GByteArray) result = NULL;
+	g_autoptr(FuStructLegionIapTlv) cmd = fu_struct_legion_iap_tlv_new();
+	g_autoptr(FuStructLegionIapTlv) result = NULL;
 	const guint8 *value;
 
 	fu_struct_legion_iap_tlv_set_tag(cmd, FU_LEGION_IAP_HOST_TAG_IAP_CARRY);

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -542,7 +542,8 @@ fu_logitech_bulkcontroller_device_upd_send_cmd(FuLogitechBulkcontrollerDevice *s
 {
 	gsize actual_length = 0;
 	g_autofree guint8 *buf_tmp = g_malloc0(self->transfer_bufsz);
-	GByteArray buf_ack = {.data = buf_tmp, .len = self->transfer_bufsz};
+	FuStructLogitechBulkcontrollerUpdateRes buf_ack = {.data = buf_tmp,
+							   .len = self->transfer_bufsz};
 	g_autoptr(FuStructLogitechBulkcontrollerUpdateReq) buf_pkt =
 	    fu_struct_logitech_bulkcontroller_update_req_new();
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -642,7 +642,7 @@ fu_logitech_hidpp_device_rdfu_get_capabilities(FuLogitechHidppDevice *self, GErr
 	guint8 idx;
 	g_autoptr(FuStructLogitechHidppRdfuGetCapabilities) msg =
 	    fu_struct_logitech_hidpp_rdfu_get_capabilities_new();
-	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuCapabilities) response = NULL;
 
 	priv->rdfu_capabilities = 0; /* set empty */
 
@@ -678,7 +678,7 @@ fu_logitech_hidpp_device_rdfu_start_dfu(FuLogitechHidppDevice *self,
 	guint8 status;
 	g_autoptr(FuStructLogitechHidppRdfuStartDfu) msg =
 	    fu_struct_logitech_hidpp_rdfu_start_dfu_new();
-	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuStartDfuResponse) response = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
 	if (idx == 0x00) {
@@ -774,7 +774,7 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint retry = 0;
-	g_autoptr(GByteArray) params = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuDataTransferWait) params = NULL;
 
 	params = fu_struct_logitech_hidpp_rdfu_data_transfer_wait_parse(
 	    response->data,
@@ -794,7 +794,7 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 	priv->rdfu_state = FU_LOGITECH_HIDPP_RDFU_STATE_WAIT;
 
 	while (priv->rdfu_state == FU_LOGITECH_HIDPP_RDFU_STATE_WAIT) {
-		g_autoptr(GByteArray) wait_response = NULL;
+		g_autoptr(FuStructLogitechHidppRdfuResponse) wait_response = NULL;
 		g_autoptr(FuLogitechHidppHidppMsg) msg_in_wait = fu_logitech_hidpp_msg_new();
 		g_autoptr(GError) error_local = NULL;
 
@@ -844,12 +844,12 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_status_pkt_ack(FuLogitechHidppDevice *self,
-					     GByteArray *response,
+					     FuStructLogitechHidppRdfuResponse *response,
 					     GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint32 pkt;
-	g_autoptr(GByteArray) params = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuDfuTransferPktAck) params = NULL;
 
 	priv->rdfu_state = FU_LOGITECH_HIDPP_RDFU_STATE_TRANSFER;
 	params = fu_struct_logitech_hidpp_rdfu_dfu_transfer_pkt_ack_parse(
@@ -890,10 +890,10 @@ fu_logitech_hidpp_device_rdfu_status_pkt_ack(FuLogitechHidppDevice *self,
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_check_status(FuLogitechHidppDevice *self,
-					   GByteArray *response,
+					   FuStructLogitechHidppRdfuResponse *response,
 					   GError **error)
 {
-	guint8 status = fu_struct_logitech_hidpp_rdfu_start_dfu_response_get_status_code(response);
+	guint8 status = fu_struct_logitech_hidpp_rdfu_response_get_status_code(response);
 
 	switch (status) {
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DFU_NOT_STARTED:
@@ -953,7 +953,7 @@ fu_logitech_hidpp_device_rdfu_get_dfu_status(FuLogitechHidppDevice *self, GError
 	guint8 idx;
 	g_autoptr(FuStructLogitechHidppRdfuGetDfuStatus) msg =
 	    fu_struct_logitech_hidpp_rdfu_get_dfu_status_new();
-	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuResponse) response = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
@@ -1043,7 +1043,7 @@ fu_logitech_hidpp_device_rdfu_transfer_pkt(FuLogitechHidppDevice *self,
 	guint8 idx;
 	g_autoptr(FuStructLogitechHidppRdfuTransferDfuData) msg =
 	    fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_new();
-	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuResponse) response = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -57,7 +57,7 @@ fu_logitech_rallysystem_audio_device_set_serial(FuLogitechRallysystemAudioDevice
 	guint8 buf_req[SERIAL_NUMBER_REQUEST_DATA_LEN] =
 	    {0x28, 0x85, 0x08, 0xBB, 0x1B, 0x00, 0x01, 0x30, 0, 0, 0, 0x0C};
 	guint8 buf_res[SERIAL_NUMBER_RESPONSE_DATA_LEN] = {0x29, 0x0};
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructAudioSerialNumber) st = NULL;
 	g_autoptr(GString) serial = g_string_new(NULL);
 
 	/* setup HID report for serial number request */

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -175,7 +175,7 @@ fu_logitech_rallysystem_tablehub_device_progress_cb(FuDevice *device,
 {
 	FuLogitechRallysystemTablehubDevice *self = FU_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE(device);
 	guint8 buf[FU_STRUCT_USB_PROGRESS_RESPONSE_SIZE] = {0x0};
-	g_autoptr(GByteArray) st_res = NULL;
+	g_autoptr(FuStructUsbProgressResponse) st_res = NULL;
 
 	if (!fu_logitech_rallysystem_tablehub_device_recv(
 		self,
@@ -213,8 +213,9 @@ fu_logitech_rallysystem_tablehub_device_write_firmware(FuDevice *device,
 	gsize streamsz = 0;
 	guint8 buf[FU_STRUCT_USB_FIRMWARE_DOWNLOAD_RESPONSE_SIZE] = {0x0};
 	g_autoptr(GInputStream) stream = NULL;
-	g_autoptr(GByteArray) st_req = fu_struct_usb_firmware_download_request_new();
-	g_autoptr(GByteArray) st_res = NULL;
+	g_autoptr(FuStructUsbFirmwareDownloadRequest) st_req =
+	    fu_struct_usb_firmware_download_request_new();
+	g_autoptr(FuStructUsbFirmwareDownloadResponse) st_res = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -294,8 +295,8 @@ fu_logitech_rallysystem_tablehub_device_send_init_cmd_cb(FuDevice *device,
 {
 	FuLogitechRallysystemTablehubDevice *self = FU_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE(device);
 	guint8 buf[FU_STRUCT_USB_INIT_RESPONSE_SIZE] = {0x0};
-	g_autoptr(GByteArray) st_req = fu_struct_usb_init_request_new();
-	g_autoptr(GByteArray) st_res = NULL;
+	g_autoptr(FuStructUsbInitRequest) st_req = fu_struct_usb_init_request_new();
+	g_autoptr(FuStructUsbInitResponse) st_res = NULL;
 
 	if (!fu_logitech_rallysystem_tablehub_device_send(self, st_req->data, st_req->len, error)) {
 		g_prefix_error_literal(error, "failed to send init packet: ");
@@ -326,8 +327,8 @@ fu_logitech_rallysystem_tablehub_device_setup(FuDevice *device, GError **error)
 	FuLogitechRallysystemTablehubDevice *self = FU_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE(device);
 	guint8 buf[FU_STRUCT_USB_READ_VERSION_RESPONSE_SIZE] = {0x0};
 	g_autofree gchar *fw_version = NULL;
-	g_autoptr(GByteArray) st_req = fu_struct_usb_read_version_request_new();
-	g_autoptr(GByteArray) st_res = NULL;
+	g_autoptr(FuStructUsbReadVersionRequest) st_req = fu_struct_usb_read_version_request_new();
+	g_autoptr(FuStructUsbReadVersionResponse) st_res = NULL;
 
 	/* FuUsbDevice->setup */
 	if (!FU_DEVICE_CLASS(fu_logitech_rallysystem_tablehub_device_parent_class)

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -89,7 +89,7 @@ fu_logitech_tap_touch_device_get_feature_cb(FuDevice *device, gpointer user_data
 
 static gboolean
 fu_logitech_tap_touch_device_hid_transfer(FuLogitechTapTouchDevice *self,
-					  GByteArray *st_req,
+					  FuStructLogitechTapTouchHidReq *st_req,
 					  guint delay,
 					  GByteArray *buf_res,
 					  GError **error)

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-ble-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-ble-device.c
@@ -125,8 +125,9 @@ fu_qc_s5gen2_ble_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_l
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_control_cmd_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeControlCmd) req =
+	    fu_struct_qc_gaia_v3_upgrade_control_cmd_new();
+	g_autoptr(FuStructQcGaiaV3UpgradeControlAck) validate = NULL;
 
 	fu_struct_qc_gaia_v3_upgrade_control_cmd_set_vendor_id(req, self->vid_v3);
 
@@ -202,8 +203,9 @@ fu_qc_s5gen2_ble_device_req_connect(FuQcS5gen2Impl *impl, GError **error)
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_connect_cmd_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeConnectCmd) req =
+	    fu_struct_qc_gaia_v3_upgrade_connect_cmd_new();
+	g_autoptr(FuStructQcGaiaV3UpgradeConnectAck) validate = NULL;
 
 	fu_struct_qc_gaia_v3_upgrade_connect_cmd_set_vendor_id(req, self->vid_v3);
 
@@ -229,8 +231,9 @@ fu_qc_s5gen2_ble_device_req_disconnect(FuQcS5gen2Impl *impl, GError **error)
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectCmd) req =
+	    fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_new();
+	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectAck) validate = NULL;
 
 	fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_set_vendor_id(req, self->vid_v3);
 
@@ -273,8 +276,8 @@ fu_qc_s5gen2_ble_device_get_api(FuQcS5gen2BleDevice *self, GError **error)
 	gsize read_len;
 	guint8 api_major;
 	guint8 api_minor;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_api_req_new();
-	g_autoptr(GByteArray) resp = NULL;
+	g_autoptr(FuStructQcGaiaV3ApiReq) req = fu_struct_qc_gaia_v3_api_req_new();
+	g_autoptr(FuStructQcGaiaV3Api) resp = NULL;
 
 	fu_struct_qc_gaia_v3_api_req_set_vendor_id(req, self->vid_v3);
 
@@ -310,8 +313,9 @@ fu_qc_s5gen2_ble_device_get_features(FuQcS5gen2BleDevice *self, gboolean next, G
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_supported_features_req_new();
-	g_autoptr(GByteArray) resp = NULL;
+	g_autoptr(FuStructQcGaiaV3SupportedFeaturesReq) req =
+	    fu_struct_qc_gaia_v3_supported_features_req_new();
+	g_autoptr(FuStructQcGaiaV3SupportedFeatures) resp = NULL;
 
 	fu_struct_qc_gaia_v3_supported_features_req_set_vendor_id(req, self->vid_v3);
 
@@ -369,8 +373,8 @@ fu_qc_s5gen2_ble_device_get_serial(FuQcS5gen2BleDevice *self, GError **error)
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_serial_req_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3SerialReq) req = fu_struct_qc_gaia_v3_serial_req_new();
+	g_autoptr(FuStructQcGaiaV3Serial) validate = NULL;
 	g_autofree gchar *serial = NULL;
 
 	fu_struct_qc_gaia_v3_serial_req_set_vendor_id(req, self->vid_v3);
@@ -401,8 +405,8 @@ fu_qc_s5gen2_ble_device_get_variant(FuQcS5gen2BleDevice *self, GError **error)
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_variant_req_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3VariantReq) req = fu_struct_qc_gaia_v3_variant_req_new();
+	g_autoptr(FuStructQcGaiaV3Variant) validate = NULL;
 	g_autofree gchar *variant = NULL;
 
 	fu_struct_qc_gaia_v3_variant_req_set_vendor_id(req, self->vid_v3);
@@ -445,8 +449,9 @@ fu_qc_s5gen2_ble_device_register_notification(FuQcS5gen2BleDevice *self, GError 
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len = 0;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_register_notification_cmd_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3RegisterNotificationCmd) req =
+	    fu_struct_qc_gaia_v3_register_notification_cmd_new();
+	g_autoptr(FuStructQcGaiaV3RegisterNotificationAck) validate = NULL;
 
 	/* register only for update feature */
 	fu_struct_qc_gaia_v3_register_notification_cmd_set_vendor_id(req, self->vid_v3);
@@ -476,8 +481,9 @@ fu_qc_s5gen2_ble_device_set_transport_protocol(FuQcS5gen2BleDevice *self,
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_gaia_v3_set_transport_info_req_new();
-	g_autoptr(GByteArray) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3SetTransportInfoReq) req =
+	    fu_struct_qc_gaia_v3_set_transport_info_req_new();
+	g_autoptr(FuStructQcGaiaV3SetTransportInfo) validate = NULL;
 
 	fu_struct_qc_gaia_v3_set_transport_info_req_set_vendor_id(req, self->vid_v3);
 	fu_struct_qc_gaia_v3_set_transport_info_req_set_key(req, 0x07);

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -55,7 +55,7 @@ fu_qc_s5gen2_device_msg_in(FuQcS5gen2Device *self,
 			   GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy(FU_DEVICE(self));
-	g_autoptr(GByteArray) err_msg = NULL;
+	g_autoptr(FuStructQcErrorInd) err_msg = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	if (proxy == NULL) {
@@ -139,8 +139,8 @@ fu_qc_s5gen2_device_cmd_abort(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_ABORT_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_abort_req_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcAbortReq) req = fu_struct_qc_abort_req_new();
+	g_autoptr(FuStructQcAbort) reply = NULL;
 
 	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
 		return FALSE;
@@ -159,8 +159,8 @@ fu_qc_s5gen2_device_cmd_sync(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_SYNC_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_sync_req_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcSyncReq) req = fu_struct_qc_sync_req_new();
+	g_autoptr(FuStructQcSync) reply = NULL;
 
 	fu_struct_qc_sync_req_set_file_id(req, self->file_id);
 	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
@@ -208,8 +208,8 @@ fu_qc_s5gen2_device_cmd_start(FuQcS5gen2Device *self, GError **error)
 	guint8 data[FU_STRUCT_QC_START_SIZE] = {0};
 	gsize read_len;
 	FuQcStartStatus status;
-	g_autoptr(GByteArray) req = fu_struct_qc_start_req_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcStartReq) req = fu_struct_qc_start_req_new();
+	g_autoptr(FuStructQcStart) reply = NULL;
 
 	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
 		return FALSE;
@@ -255,8 +255,8 @@ fu_qc_s5gen2_device_cmd_validation(FuQcS5gen2Device *self, GError **error)
 	guint16 delay_ms;
 	guint8 data[FU_STRUCT_QC_IS_VALIDATION_DONE_SIZE] = {0};
 	gsize read_len = 0;
-	g_autoptr(GByteArray) req = fu_struct_qc_validation_req_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcValidationReq) req = fu_struct_qc_validation_req_new();
+	g_autoptr(FuStructQcTransferCompleteInd) reply = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
@@ -305,7 +305,7 @@ fu_qc_s5gen2_device_cmd_transfer_complete(FuQcS5gen2Device *self, GError **error
 {
 	/* reboot immediately */
 	FuQcTransferAction action = FU_QC_TRANSFER_ACTION_INTERACTIVE;
-	g_autoptr(GByteArray) req = fu_struct_qc_transfer_complete_new();
+	g_autoptr(FuStructQcTransferComplete) req = fu_struct_qc_transfer_complete_new();
 
 	fu_struct_qc_transfer_complete_set_action(req, action);
 
@@ -318,8 +318,8 @@ fu_qc_s5gen2_device_cmd_proceed_to_commit(FuQcS5gen2Device *self, GError **error
 {
 	guint8 data[FU_STRUCT_QC_COMMIT_REQ_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_proceed_to_commit_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcProceedToCommit) req = fu_struct_qc_proceed_to_commit_new();
+	g_autoptr(FuStructQcCommitReq) reply = NULL;
 
 	fu_struct_qc_proceed_to_commit_set_action(req, FU_QC_COMMIT_ACTION_PROCEED);
 
@@ -340,8 +340,8 @@ fu_qc_s5gen2_device_cmd_commit_cfm(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_COMPLETE_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(GByteArray) req = fu_struct_qc_commit_cfm_new();
-	g_autoptr(GByteArray) reply = NULL;
+	g_autoptr(FuStructQcCommitCfm) req = fu_struct_qc_commit_cfm_new();
+	g_autoptr(FuStructQcComplete) reply = NULL;
 
 	fu_struct_qc_commit_cfm_set_action(req, FU_QC_COMMIT_CFM_ACTION_UPGRADE);
 
@@ -367,8 +367,8 @@ fu_qc_s5gen2_device_ensure_version(FuQcS5gen2Device *self, GError **error)
 	g_autofree gchar *ver_str = NULL;
 	gsize read_len;
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GByteArray) version = NULL;
-	g_autoptr(GByteArray) version_req = fu_struct_qc_version_req_new();
+	g_autoptr(FuStructQcVersion) version = NULL;
+	g_autoptr(FuStructQcVersionReq) version_req = fu_struct_qc_version_req_new();
 
 	locker =
 	    fu_device_locker_new_full(FU_DEVICE(self),
@@ -495,7 +495,7 @@ fu_qc_s5gen2_device_write_bucket(FuQcS5gen2Device *self,
 					       data_sz);
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(GByteArray) pkt = fu_struct_qc_data_new();
+		g_autoptr(FuStructQcData) pkt = fu_struct_qc_data_new();
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i, error);
 
 		if (chk == NULL)
@@ -541,7 +541,7 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 		gsize read_len;
 		guint32 data_sz;
 		guint32 data_offset;
-		g_autoptr(GByteArray) data_req = NULL;
+		g_autoptr(FuStructQcDataReq) data_req = NULL;
 		g_autoptr(GBytes) data_out = NULL;
 
 		if (!fu_qc_s5gen2_device_msg_in(self, buf_in, sizeof(buf_in), &read_len, error))

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
@@ -62,7 +62,7 @@ fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 	gsize config_offset = 26;
 	guint16 config_ver;
 	g_autofree gchar *ver_str = NULL;
-	g_autoptr(GByteArray) hdr = NULL;
+	g_autoptr(FuStructQcFwUpdateHdr) hdr = NULL;
 
 	/* FIXME: deal with encrypted? */
 	hdr = fu_struct_qc_fw_update_hdr_parse_stream(stream, 0x0, error);

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-hid-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-hid-device.c
@@ -38,7 +38,7 @@ static gboolean
 fu_qc_s5gen2_hid_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
-	g_autoptr(GByteArray) msg = fu_struct_qc_hid_data_transfer_new();
+	g_autoptr(FuStructQcHidDataTransfer) msg = fu_struct_qc_hid_data_transfer_new();
 
 	fu_struct_qc_hid_data_transfer_set_payload_len(msg, data_len);
 	if (!fu_struct_qc_hid_data_transfer_set_payload(msg, data, data_len, error))
@@ -62,7 +62,7 @@ fu_qc_s5gen2_hid_device_msg_in(FuQcS5gen2Impl *impl,
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
 	guint8 buf[FU_STRUCT_QC_HID_RESPONSE_SIZE] = {0x0};
-	g_autoptr(GByteArray) msg = NULL;
+	g_autoptr(FuStructQcHidResponse) msg = NULL;
 
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      0x00,
@@ -96,7 +96,7 @@ static gboolean
 fu_qc_s5gen2_hid_device_msg_cmd(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
-	g_autoptr(GByteArray) msg = fu_struct_qc_hid_command_new();
+	g_autoptr(FuStructQcHidCommand) msg = fu_struct_qc_hid_command_new();
 
 	fu_struct_qc_hid_command_set_payload_len(msg, data_len);
 	if (!fu_struct_qc_hid_command_set_payload(msg, data, data_len, error))
@@ -114,7 +114,7 @@ fu_qc_s5gen2_hid_device_msg_cmd(FuQcS5gen2Impl *impl, guint8 *data, gsize data_l
 static gboolean
 fu_qc_s5gen2_hid_device_cmd_req_disconnect(FuQcS5gen2Impl *impl, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_qc_disconnect_req_new();
+	g_autoptr(FuStructQcDisconnectReq) req = fu_struct_qc_disconnect_req_new();
 	return fu_qc_s5gen2_hid_device_msg_cmd(impl, req->data, req->len, error);
 }
 
@@ -124,8 +124,8 @@ fu_qc_s5gen2_hid_device_cmd_req_connect(FuQcS5gen2Impl *impl, GError **error)
 	guint8 data_in[FU_STRUCT_QC_UPDATE_STATUS_SIZE] = {0x0};
 	gsize read_len;
 	FuQcStatus update_status;
-	g_autoptr(GByteArray) req = fu_struct_qc_connect_req_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructQcConnectReq) req = fu_struct_qc_connect_req_new();
+	g_autoptr(FuStructQcUpdateStatus) st = NULL;
 
 	if (!fu_qc_s5gen2_hid_device_msg_cmd(impl, req->data, req->len, error))
 		return FALSE;

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -217,7 +217,7 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
 {
 	guint8 hostname_length;
 	guint8 service_ip_address_format;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructRedfishProtocolOverIp) st = NULL;
 
 	/* port + IP address */
 	st = fu_struct_redfish_protocol_over_ip_parse_stream(stream, offset, error);
@@ -273,7 +273,7 @@ fu_redfish_smbios_parse(FuFirmware *firmware,
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);
 	gsize offset = 0;
 	gsize streamsz = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructRedfishSmbiosType42) st = NULL;
 
 	/* check size */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -348,7 +348,7 @@ fu_redfish_smbios_write(FuFirmware *firmware, GError **error)
 {
 	FuRedfishSmbios *self = FU_REDFISH_SMBIOS(firmware);
 	gsize hostname_sz = 0;
-	g_autoptr(GByteArray) st = fu_struct_redfish_protocol_over_ip_new();
+	g_autoptr(FuStructRedfishProtocolOverIp) st = fu_struct_redfish_protocol_over_ip_new();
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
 	if (self->hostname != NULL)

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -29,7 +29,7 @@ fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 	gsize streamsz = 0;
 	g_autofree gchar *version_str = NULL;
 	g_autoptr(FuFirmware) img_hdr = fu_firmware_new();
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructSynapticsCapeHidHdr) st = NULL;
 	g_autoptr(GInputStream) stream_hdr = NULL;
 	g_autoptr(GInputStream) stream_body = NULL;
 
@@ -86,7 +86,7 @@ fu_synaptics_cape_hid_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsCapeHidFirmware *self = FU_SYNAPTICS_CAPE_HID_FIRMWARE(firmware);
 	guint64 ver = fu_firmware_get_version_raw(firmware);
-	g_autoptr(GByteArray) buf = fu_struct_synaptics_cape_hid_hdr_new();
+	g_autoptr(FuStructSynapticsCapeHidHdr) buf = fu_struct_synaptics_cape_hid_hdr_new();
 	g_autoptr(GBytes) payload = NULL;
 
 	/* pack */

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -28,7 +28,7 @@ fu_synaptics_cape_sngl_firmware_parse(FuFirmware *firmware,
 	FuSynapticsCapeSnglFirmware *self = FU_SYNAPTICS_CAPE_SNGL_FIRMWARE(firmware);
 	gsize streamsz = 0;
 	guint16 num_fw_file;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructSynapticsCapeSnglHdr) st = NULL;
 	g_autofree gchar *version_str = NULL;
 
 	/* sanity check */
@@ -111,7 +111,7 @@ static GByteArray *
 fu_synaptics_cape_sngl_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsCapeSnglFirmware *self = FU_SYNAPTICS_CAPE_SNGL_FIRMWARE(firmware);
-	g_autoptr(GByteArray) buf = fu_struct_synaptics_cape_sngl_hdr_new();
+	g_autoptr(FuStructSynapticsCapeSnglHdr) buf = fu_struct_synaptics_cape_sngl_hdr_new();
 
 	/* pack */
 	fu_struct_synaptics_cape_sngl_hdr_set_vid(

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -295,7 +295,7 @@ fu_synaptics_cxaudio_device_eeprom_read_string(FuSynapticsCxaudioDevice *self,
 	guint8 buf[FU_STRUCT_SYNAPTICS_CXAUDIO_STRING_HEADER_SIZE] = {0};
 	guint8 header_length;
 	g_autofree gchar *str = NULL;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructSynapticsCxaudioStringHeader) st = NULL;
 
 	/* read header */
 	if (!fu_synaptics_cxaudio_device_operation(self,
@@ -396,8 +396,8 @@ fu_synaptics_cxaudio_device_setup(FuDevice *device, GError **error)
 	g_autofree gchar *summary = NULL;
 	g_autofree gchar *version_fw = NULL;
 	g_autofree gchar *version_patch = NULL;
-	g_autoptr(GByteArray) st_inf = NULL;
-	g_autoptr(GByteArray) st_sig = NULL;
+	g_autoptr(FuStructSynapticsCxaudioCustomInfo) st_inf = NULL;
+	g_autoptr(FuStructSynapticsCxaudioValiditySignature) st_sig = NULL;
 	guint8 cinfo[FU_STRUCT_SYNAPTICS_CXAUDIO_CUSTOM_INFO_SIZE] = {0x0};
 
 	/* FuUsbDevice->setup */
@@ -747,7 +747,7 @@ fu_synaptics_cxaudio_device_write_firmware(FuDevice *device,
 	 * as it may have not been done by the S37 file */
 	if (file_kind == FU_SYNAPTICS_CXAUDIO_FILE_KIND_CX2070X_FW) {
 		guint8 buf[FU_STRUCT_SYNAPTICS_CXAUDIO_PATCH_INFO_SIZE] = {0};
-		g_autoptr(GByteArray) st_pat = NULL;
+		g_autoptr(FuStructSynapticsCxaudioPatchInfo) st_pat = NULL;
 
 		if (!fu_synaptics_cxaudio_device_operation(
 			self,

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-firmware.c
@@ -160,9 +160,9 @@ fu_synaptics_cxaudio_firmware_parse(FuFirmware *firmware,
 	FuSynapticsCxaudioFirmware *self = FU_SYNAPTICS_CXAUDIO_FIRMWARE(firmware);
 	GPtrArray *records = fu_srec_firmware_get_records(FU_SREC_FIRMWARE(firmware));
 	guint8 dev_kind_candidate = G_MAXUINT8;
-	g_autoptr(GByteArray) st = NULL;
-	g_autoptr(GByteArray) st_sig = NULL;
-	g_autoptr(GByteArray) st_pat = NULL;
+	g_autoptr(FuStructSynapticsCxaudioCustomInfo) st = NULL;
+	g_autoptr(FuStructSynapticsCxaudioValiditySignature) st_sig = NULL;
+	g_autoptr(FuStructSynapticsCxaudioPatchInfo) st_pat = NULL;
 	guint8 shadow[FU_SYNAPTICS_CXAUDIO_EEPROM_SHADOW_SIZE] = {0x0};
 
 	/* copy shadow EEPROM */

--- a/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-firmware.c
@@ -56,7 +56,7 @@ fu_synaptics_mst_firmware_detect_family(FuSynapticsMstFirmware *self,
 {
 	guint16 addrs[] = {ADDR_CONFIG_TESLA, ADDR_CONFIG_CAYENNE, ADDR_CONFIG_CARRERA};
 	for (guint i = 0; i < G_N_ELEMENTS(addrs); i++) {
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructSynapticsFirmwareConfig) st = NULL;
 		st = fu_struct_synaptics_firmware_config_parse_stream(stream,
 								      offset + addrs[i],
 								      error);

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -37,10 +37,10 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	g_autofree gchar *configid2_str = NULL;
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) reply = NULL;
-	g_autoptr(GByteArray) st_request = fu_struct_synaprom_request_new();
-	g_autoptr(GByteArray) st_cfg = NULL;
-	g_autoptr(GByteArray) st_hdr = NULL;
-	g_autoptr(GByteArray) st_cmd = fu_struct_synaprom_cmd_iota_find_new();
+	g_autoptr(FuStructSynapromRequest) st_request = fu_struct_synaprom_request_new();
+	g_autoptr(FuStructSynapromIotaConfigVersion) st_cfg = NULL;
+	g_autoptr(FuStructSynapromReplyIotaFindHdr) st_hdr = NULL;
+	g_autoptr(FuStructSynapromCmdIotaFind) st_cmd = fu_struct_synaprom_cmd_iota_find_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 
 	/* get IOTA */
@@ -115,7 +115,7 @@ fu_synaprom_config_prepare_firmware(FuDevice *device,
 {
 	FuSynapromConfig *self = FU_SYNAPROM_CONFIG(device);
 	FuDevice *parent = fu_device_get_parent(device);
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructSynapromCfgHdr) st_hdr = NULL;
 	g_autoptr(GInputStream) stream_hdr = NULL;
 	g_autoptr(FuFirmware) firmware = fu_synaprom_firmware_new();
 	g_autoptr(FuFirmware) img_hdr = NULL;

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -74,7 +74,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		guint32 tag;
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autoptr(FuFirmware) img_old = NULL;
-		g_autoptr(GByteArray) st_hdr = NULL;
+		g_autoptr(FuStructSynapromHdr) st_hdr = NULL;
 		g_autoptr(GInputStream) partial_stream = NULL;
 
 		/* verify item header */
@@ -128,7 +128,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 		/* metadata */
 		if (tag == FU_SYNAPROM_FIRMWARE_TAG_MFW_UPDATE_HEADER) {
 			g_autofree gchar *version = NULL;
-			g_autoptr(GByteArray) st_mfw = NULL;
+			g_autoptr(FuStructSynapromMfwHdr) st_mfw = NULL;
 			st_mfw = fu_struct_synaprom_mfw_hdr_parse_stream(stream, offset, error);
 			if (st_mfw == NULL)
 				return FALSE;
@@ -150,8 +150,8 @@ fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapromFirmware *self = FU_SYNAPROM_FIRMWARE(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_hdr = fu_struct_synaprom_hdr_new();
-	g_autoptr(GByteArray) st_mfw = fu_struct_synaprom_mfw_hdr_new();
+	g_autoptr(FuStructSynapromHdr) st_hdr = fu_struct_synaprom_hdr_new();
+	g_autoptr(FuStructSynapromMfwHdr) st_mfw = fu_struct_synaprom_mfw_hdr_new();
 	g_autoptr(GBytes) payload = NULL;
 
 	/* add header */

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -124,7 +124,7 @@ fu_synaptics_rmi_firmware_parse_v10(FuFirmware *firmware,
 	gsize bufsz = 0;
 	const guint8 *buf;
 	guint32 signature_size;
-	g_autoptr(GByteArray) st_dsc = NULL;
+	g_autoptr(FuStructRmiContainerDescriptor) st_dsc = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	/* maybe stream later */
@@ -189,7 +189,7 @@ fu_synaptics_rmi_firmware_parse_v10(FuFirmware *firmware,
 		guint32 content_addr;
 		guint32 addr;
 		guint32 length;
-		g_autoptr(GByteArray) st_dsc2 = NULL;
+		g_autoptr(FuStructRmiContainerDescriptor) st_dsc2 = NULL;
 
 		if (!fu_memread_uint32_safe(buf, bufsz, offset, &addr, G_LITTLE_ENDIAN, error))
 			return FALSE;
@@ -363,7 +363,7 @@ fu_synaptics_rmi_firmware_parse_v0x(FuFirmware *firmware,
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);
 	guint32 cfg_sz;
 	guint32 img_sz;
-	g_autoptr(GByteArray) st_img = NULL;
+	g_autoptr(FuStructRmiImg) st_img = NULL;
 
 	/* main firmware */
 	st_img = fu_struct_rmi_img_parse_stream(stream, 0x0, error);
@@ -417,7 +417,7 @@ fu_synaptics_rmi_firmware_parse(FuFirmware *firmware,
 	FuSynapticsRmiFirmware *self = FU_SYNAPTICS_RMI_FIRMWARE(firmware);
 	gsize bufsz = 0;
 	const guint8 *buf;
-	g_autoptr(GByteArray) st_img = NULL;
+	g_autoptr(FuStructRmiImg) st_img = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	/* maybe stream later */
@@ -519,7 +519,7 @@ fu_synaptics_rmi_firmware_write_v0x(FuFirmware *firmware, GError **error)
 	guint32 csum;
 	g_autoptr(FuFirmware) img = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) st_img = fu_struct_rmi_img_new();
+	g_autoptr(FuStructRmiImg) st_img = fu_struct_rmi_img_new();
 	g_autoptr(GBytes) buf_blob = NULL;
 
 	/* default image */
@@ -563,8 +563,9 @@ fu_synaptics_rmi_firmware_write_v10(FuFirmware *firmware, GError **error)
 	guint32 csum;
 	g_autoptr(FuFirmware) img = NULL;
 	g_autoptr(GByteArray) buf = g_byte_array_new();
-	g_autoptr(GByteArray) desc_hdr = fu_struct_rmi_container_descriptor_new();
-	g_autoptr(GByteArray) desc = fu_struct_rmi_container_descriptor_new();
+	g_autoptr(FuStructRmiContainerDescriptor) desc_hdr =
+	    fu_struct_rmi_container_descriptor_new();
+	g_autoptr(FuStructRmiContainerDescriptor) desc = fu_struct_rmi_container_descriptor_new();
 	g_autoptr(GBytes) buf_blob = NULL;
 
 	/* header | desc_hdr | offset_table | desc | flash_config |

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-v7-device.c
@@ -847,7 +847,7 @@ fu_synaptics_rmi_v7_device_read_flash_config(FuSynapticsRmiDevice *self, GError 
 	/* parse the config length */
 	for (guint i = 0x2; i < res->len; i += partition_size) {
 		guint16 partition_id;
-		g_autoptr(GByteArray) st_prt = NULL;
+		g_autoptr(FuStructRmiPartitionTbl) st_prt = NULL;
 		st_prt = fu_struct_rmi_partition_tbl_parse(res->data, res->len, i, error);
 		if (st_prt == NULL)
 			return FALSE;

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-firmware.c
@@ -49,7 +49,7 @@ fu_synaptics_vmm9_firmware_parse(FuFirmware *firmware,
 				 GError **error)
 {
 	FuSynapticsVmm9Firmware *self = FU_SYNAPTICS_VMM9_FIRMWARE(firmware);
-	g_autoptr(GByteArray) st_hdr = NULL;
+	g_autoptr(FuStructSynapticsVmm9) st_hdr = NULL;
 	guint8 version_major = 0;
 	guint8 version_minor = 0;
 	guint16 version_micro = 0;

--- a/plugins/telink-dfu/fu-telink-dfu-hid-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-hid-device.c
@@ -43,7 +43,8 @@ fu_telink_dfu_hid_device_create_packet(FuTelinkDfuCmd cmd,
 {
 	guint16 ota_data_len;
 	g_autoptr(FuStructTelinkDfuHidPkt) st_pkt = fu_struct_telink_dfu_hid_pkt_new();
-	g_autoptr(FuStructTelinkDfuHidPkt) st_payload = fu_struct_telink_dfu_hid_pkt_payload_new();
+	g_autoptr(FuStructTelinkDfuHidPktPayload) st_payload =
+	    fu_struct_telink_dfu_hid_pkt_payload_new();
 
 	switch (cmd) {
 	case FU_TELINK_DFU_CMD_OTA_FW_VERSION:

--- a/plugins/tpm/fu-tpm-eventlog-common.c
+++ b/plugins/tpm/fu-tpm-eventlog-common.c
@@ -97,7 +97,7 @@ fu_tpm_eventlog_calc_checksums(GPtrArray *items, guint8 pcr, GError **error)
 		/* if TXT is enabled then the first event for PCR0 should be a StartupLocality */
 		if (item->kind == FU_TPM_EVENTLOG_ITEM_KIND_EV_NO_ACTION && item->pcr == 0 &&
 		    item->blob != NULL && i == 0) {
-			g_autoptr(GByteArray) st_loc = NULL;
+			g_autoptr(FuStructTpmEfiStartupLocalityEvent) st_loc = NULL;
 			st_loc = fu_struct_tpm_efi_startup_locality_event_parse_bytes(item->blob,
 										      0x0,
 										      NULL);

--- a/plugins/tpm/fu-tpm-eventlog-parser.c
+++ b/plugins/tpm/fu-tpm-eventlog-parser.c
@@ -89,7 +89,7 @@ fu_tpm_eventlog_parser_parse_blob_v2(const guint8 *buf,
 		g_autoptr(GBytes) checksum_sha1 = NULL;
 		g_autoptr(GBytes) checksum_sha256 = NULL;
 		g_autoptr(GBytes) checksum_sha384 = NULL;
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructTpmEventLog2) st = NULL;
 
 		/* read checksum block */
 		st = fu_struct_tpm_event_log2_parse(buf, bufsz, idx, error);

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -38,7 +38,7 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, GInputStream *stream, GError **error
 {
 	const gchar *needle = "$QUIRK";
 	gsize data_offset = 0;
-	g_autoptr(GByteArray) st_qrk = NULL;
+	g_autoptr(FuStructAcpiInsydeQuirk) st_qrk = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	fw = fu_input_stream_read_bytes(stream, 0x0, G_MAXSIZE, NULL, error);

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -290,7 +290,7 @@ fu_uefi_capsule_device_clear_status(FuUefiCapsuleDevice *self, GError **error)
 	gsize datasz = 0;
 	g_autofree gchar *varname = fu_uefi_capsule_device_build_varname(self);
 	g_autofree guint8 *data = NULL;
-	g_autoptr(GByteArray) st_inf = NULL;
+	g_autoptr(FuStructEfiUpdateInfo) st_inf = NULL;
 
 	g_return_val_if_fail(FU_IS_UEFI_CAPSULE_DEVICE(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
@@ -357,7 +357,7 @@ fu_uefi_capsule_device_fixup_firmware(FuUefiCapsuleDevice *self, GBytes *fw, GEr
 	gsize bufsz;
 	const guint8 *buf = g_bytes_get_data(fw, &bufsz);
 	g_autofree gchar *guid_new = NULL;
-	g_autoptr(GByteArray) st_cap = fu_struct_efi_capsule_header_new();
+	g_autoptr(FuStructEfiCapsuleHeader) st_cap = fu_struct_efi_capsule_header_new();
 
 	g_return_val_if_fail(FU_IS_UEFI_CAPSULE_DEVICE(self), NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
@@ -423,7 +423,7 @@ fu_uefi_capsule_device_write_update_info(FuUefiCapsuleDevice *self,
 	fwupd_guid_t guid = {0x0};
 	g_autoptr(FuEfiDevicePathList) dp_buf = NULL;
 	g_autoptr(GBytes) dp_blob = NULL;
-	g_autoptr(GByteArray) st_inf = fu_struct_efi_update_info_new();
+	g_autoptr(FuStructEfiUpdateInfo) st_inf = fu_struct_efi_update_info_new();
 
 	/* convert to EFI device path */
 	dp_buf = fu_uefi_capsule_device_build_dp_buf(priv->esp, capsule_path, error);

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -396,8 +396,8 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	g_autofree gchar *basename = NULL;
 	g_autofree gchar *directory = NULL;
 	g_autoptr(FuBitmapImage) bmp_image = fu_bitmap_image_new();
-	g_autoptr(GByteArray) st_cap = fu_struct_efi_capsule_header_new();
-	g_autoptr(GByteArray) st_uxh = fu_struct_efi_ux_capsule_header_new();
+	g_autoptr(FuStructEfiCapsuleHeader) st_cap = fu_struct_efi_capsule_header_new();
+	g_autoptr(FuStructEfiUxCapsuleHeader) st_uxh = fu_struct_efi_ux_capsule_header_new();
 	g_autoptr(GOutputStream) ostream = NULL;
 
 	/* get screen dimensions */

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -149,7 +149,7 @@ fu_uefi_update_info_parse(FuFirmware *firmware,
 {
 	FuUefiUpdateInfo *self = FU_UEFI_UPDATE_INFO(firmware);
 	gsize streamsz = 0;
-	g_autoptr(GByteArray) st_inf = NULL;
+	g_autoptr(FuStructEfiUpdateInfo) st_inf = NULL;
 
 	g_return_val_if_fail((self), FALSE);
 

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -224,7 +224,7 @@ fu_uf2_firmware_write_chunk(FuUf2Firmware *self, FuChunk *chk, guint chk_len, GE
 	gsize offset_ext = FU_STRUCT_UF2_OFFSET_DATA + fu_chunk_get_data_sz(chk);
 	guint32 addr = fu_firmware_get_addr(FU_FIRMWARE(self));
 	guint32 flags = FU_UF2_FIRMWARE_BLOCK_FLAG_NONE;
-	g_autoptr(GByteArray) st = fu_struct_uf2_new();
+	g_autoptr(FuStructUf2) st = fu_struct_uf2_new();
 	g_autoptr(GPtrArray) extensions =
 	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_struct_uf2_extension_unref);
 

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -39,7 +39,7 @@ fu_usi_dock_mcu_device_tx(FuUsiDockMcuDevice *self,
 			  gsize bufsz,
 			  GError **error)
 {
-	g_autoptr(GByteArray) st = fu_struct_usi_dock_mcu_cmd_req_new();
+	g_autoptr(FuStructUsiDockMcuCmdReq) st = fu_struct_usi_dock_mcu_cmd_req_new();
 
 	fu_struct_usi_dock_mcu_cmd_req_set_length(st, 0x3 + bufsz);
 	fu_struct_usi_dock_mcu_cmd_req_set_tag3(st, tag2);
@@ -70,7 +70,7 @@ fu_usi_dock_mcu_device_rx(FuUsiDockMcuDevice *self,
 			  GError **error)
 {
 	guint8 buf[64] = {0};
-	g_autoptr(GByteArray) st_rsp = NULL;
+	g_autoptr(FuStructUsiDockMcuCmdRes) st_rsp = NULL;
 
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      USB_HID_REPORT_ID2,
@@ -398,7 +398,7 @@ fu_usi_dock_mcu_device_setup(FuDevice *device, GError **error)
 static gboolean
 fu_usi_dock_mcu_device_write_chunk(FuUsiDockMcuDevice *self, FuChunk *chk, GError **error)
 {
-	g_autoptr(GByteArray) st_req = fu_struct_usi_dock_hid_req_new();
+	g_autoptr(FuStructUsiDockHidReq) st_req = fu_struct_usi_dock_hid_req_new();
 
 	fu_struct_usi_dock_hid_req_set_length(st_req, fu_chunk_get_data_sz(chk));
 	fu_struct_usi_dock_hid_req_set_tag3(st_req, FU_USI_DOCK_TAG2_MASS_DATA_SPI);

--- a/plugins/vli/fu-vli-pd-firmware.c
+++ b/plugins/vli/fu-vli-pd-firmware.c
@@ -43,7 +43,7 @@ fu_vli_pd_firmware_parse(FuFirmware *firmware,
 	FuVliPdFirmware *self = FU_VLI_PD_FIRMWARE(firmware);
 	gsize streamsz = 0;
 	guint32 fwver;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructVliPdHdr) st = NULL;
 
 	/* parse */
 	st = fu_struct_vli_pd_hdr_parse_stream(stream, VLI_USBHUB_PD_FLASHMAP_ADDR, error);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -26,8 +26,8 @@ struct _FuVliUsbhubDevice {
 	FuVliDevice parent_instance;
 	gboolean disable_powersave;
 	guint8 update_protocol;
-	GByteArray *st_hd1; /* factory */
-	GByteArray *st_hd2; /* update */
+	FuStructVliUsbhubHdr *st_hd1; /* factory */
+	FuStructVliUsbhubHdr *st_hd2; /* update */
 };
 
 G_DEFINE_TYPE(FuVliUsbhubDevice, fu_vli_usbhub_device, FU_TYPE_VLI_DEVICE)
@@ -991,7 +991,7 @@ fu_vli_usbhub_device_update_v2_recovery(FuVliUsbhubDevice *self,
 }
 
 static gboolean
-fu_vli_usbhub_device_hd1_is_valid(GByteArray *hdr)
+fu_vli_usbhub_device_hd1_is_valid(FuStructVliUsbhubHdr *hdr)
 {
 	if (fu_struct_vli_usbhub_hdr_get_prev_ptr(hdr) != VLI_USBHUB_FLASHMAP_IDX_INVALID)
 		return FALSE;
@@ -1002,7 +1002,7 @@ fu_vli_usbhub_device_hd1_is_valid(GByteArray *hdr)
 
 static gboolean
 fu_vli_usbhub_device_hd1_recover(FuVliUsbhubDevice *self,
-				 GByteArray *hdr,
+				 FuStructVliUsbhubHdr *hdr,
 				 FuProgress *progress,
 				 GError **error)
 {
@@ -1051,7 +1051,7 @@ fu_vli_usbhub_device_update_v2(FuVliUsbhubDevice *self,
 	guint32 hd2_fw_addr;
 	guint32 hd2_fw_offset;
 	const guint8 *buf_fw;
-	g_autoptr(GByteArray) st_hd = NULL;
+	g_autoptr(FuStructVliUsbhubHdr) st_hd = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	/* simple image */
@@ -1209,7 +1209,7 @@ fu_vli_usbhub_device_update_v3(FuVliUsbhubDevice *self,
 	guint32 hd2_fw_addr;
 	guint32 hd2_fw_offset;
 	const guint8 *buf_fw;
-	g_autoptr(GByteArray) st_hd = NULL;
+	g_autoptr(FuStructVliUsbhubHdr) st_hd = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	/* simple image */
@@ -1438,8 +1438,8 @@ static void
 fu_vli_usbhub_device_finalize(GObject *obj)
 {
 	FuVliUsbhubDevice *self = FU_VLI_USBHUB_DEVICE(obj);
-	g_byte_array_unref(self->st_hd1);
-	g_byte_array_unref(self->st_hd2);
+	fu_struct_vli_usbhub_hdr_unref(self->st_hd1);
+	fu_struct_vli_usbhub_hdr_unref(self->st_hd2);
 	G_OBJECT_CLASS(fu_vli_usbhub_device_parent_class)->finalize(obj);
 }
 

--- a/plugins/vli/fu-vli-usbhub-firmware.c
+++ b/plugins/vli/fu-vli-usbhub-firmware.c
@@ -137,7 +137,7 @@ fu_vli_usbhub_firmware_parse(FuFirmware *firmware,
 	guint8 tmp = 0x0;
 	guint8 fwtype = 0x0;
 	guint8 strapping1;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructVliUsbhubHdr) st = NULL;
 
 	/* map into header */
 	st = fu_struct_vli_usbhub_hdr_parse_stream(stream, 0x0, error);

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -49,7 +49,7 @@ fu_vli_usbhub_pd_device_setup(FuDevice *device, GError **error)
 	guint32 fwver;
 	gsize bufsz = FU_STRUCT_VLI_PD_HDR_SIZE;
 	g_autofree guint8 *buf = g_malloc0(bufsz);
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructVliPdHdr) st = NULL;
 
 	/* sanity check */
 	if (parent == NULL) {

--- a/plugins/wacom-raw/fu-wacom-raw-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-aes-device.c
@@ -77,8 +77,9 @@ fu_wacom_raw_aes_device_query_operation_mode(FuWacomRawAesDevice *self,
 					     FuWacomRawOperationMode *mode,
 					     GError **error)
 {
-	g_autoptr(GByteArray) st_req = fu_struct_wacom_raw_fw_query_mode_request_new();
-	g_autoptr(GByteArray) st_rsp = NULL;
+	g_autoptr(FuStructWacomRawFwQueryModeRequest) st_req =
+	    fu_struct_wacom_raw_fw_query_mode_request_new();
+	g_autoptr(FuStructWacomRawFwQueryModeResponse) st_rsp = NULL;
 
 	if (!fu_wacom_raw_device_get_feature(FU_WACOM_RAW_DEVICE(self),
 					     st_req->data,

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -60,9 +60,9 @@ fu_wac_module_bluetooth_id9_get_startcmd(GInputStream *stream, gboolean full_era
 	guint8 command = full_erase ? FU_WAC_MODULE_BLUETOOTH_ID9_CMD_FULLERASE
 				    : FU_WAC_MODULE_BLUETOOTH_ID9_CMD_NORMAL;
 	guint32 crc = ~0;
-	g_autoptr(GByteArray) loader_cmd = fu_struct_id9_loader_cmd_new();
-	g_autoptr(GByteArray) spi_cmd = fu_struct_id9_spi_cmd_new();
-	g_autoptr(GByteArray) unknown_cmd = fu_struct_id9_unknown_cmd_new();
+	g_autoptr(FuStructId9LoaderCmd) loader_cmd = fu_struct_id9_loader_cmd_new();
+	g_autoptr(FuStructId9SpiCmd) spi_cmd = fu_struct_id9_spi_cmd_new();
+	g_autoptr(FuStructId9UnknownCmd) unknown_cmd = fu_struct_id9_unknown_cmd_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))

--- a/plugins/wacom-usb/fu-wac-module-touch-id7.c
+++ b/plugins/wacom-usb/fu-wac-module-touch-id7.c
@@ -177,7 +177,7 @@ fu_wac_module_touch_id7_write_block(FuWacModule *self,
 				    GError **error)
 {
 	g_autoptr(GPtrArray) chunks = NULL;
-	g_autoptr(GByteArray) st_blk = NULL;
+	g_autoptr(FuStructWtaBlockHeader) st_blk = NULL;
 
 	/* generate chunks off of the raw block data */
 	st_blk = fu_struct_wta_block_header_parse(info->buf, info->bufsz, info->offset, error);

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -539,7 +539,7 @@ fu_wistron_dock_device_parse_wdit_img(FuWistronDockDevice *self,
 		g_autofree gchar *version0 = NULL;
 		g_autofree gchar *version1 = NULL;
 		g_autofree gchar *version2 = NULL;
-		g_autoptr(GByteArray) st = NULL;
+		g_autoptr(FuStructWistronDockWditImg) st = NULL;
 
 		/* parse */
 		st = fu_struct_wistron_dock_wdit_img_parse(buf, bufsz, offset, error);
@@ -579,7 +579,7 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 {
 	guint8 update_state = 0x0;
 	guint8 buf[FU_WISTRON_DOCK_WDIT_SIZE + 1] = {FU_WISTRON_DOCK_ID_DOCK_WDIT};
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructWistronDockWdit) st = NULL;
 
 	/* get WDIT */
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),


### PR DESCRIPTION
This does not help with type safety... yet.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
