### PR TITLE
trivial: Always require a GError when adding an image

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -193,3 +193,8 @@ Remember: Plugins should be upstream!
 ## 2.0.14
 
 * `fu_error_convert()`: Use `fwupd_error_convert()` instead
+
+## 2.0.17
+
+* `fu_firmware_add_image_full()`: Use `fu_firmware_add_image()` instead.
+* `fu_firmware_add_image()`: Add a `GError` and check the return value.

--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -50,7 +50,7 @@ fu_archive_firmware_parse_cb(FuArchive *self,
 	FuFirmware *firmware = FU_FIRMWARE(user_data);
 	g_autoptr(FuFirmware) img = fu_firmware_new_from_bytes(bytes);
 	fu_firmware_set_id(img, filename);
-	return fu_firmware_add_image_full(firmware, img, error);
+	return fu_firmware_add_image(firmware, img, error);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -492,7 +492,7 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 	}
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(img), stream, 0x0, helper->parse_flags, error))
 		return FALSE;
-	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
+	if (!fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
 		return FALSE;
 
 	/* set created date time */

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -167,7 +167,7 @@ fu_csv_firmware_parse_line_cb(GString *token, guint token_idx, gpointer user_dat
 	/* parse entry */
 	fw = g_bytes_new(token->str, token->len);
 	fu_firmware_set_idx(entry, token_idx);
-	if (!fu_firmware_add_image_full(FU_FIRMWARE(self), entry, error))
+	if (!fu_firmware_add_image(FU_FIRMWARE(self), entry, error))
 		return FALSE;
 	if (!fu_firmware_parse_bytes(entry, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
 		return FALSE;

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -154,7 +154,7 @@ fu_dfuse_firmware_parse(FuFirmware *firmware,
 							     error);
 		if (image == NULL)
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, image, error))
+		if (!fu_firmware_add_image(firmware, image, error))
 			return FALSE;
 	}
 	return TRUE;

--- a/libfwupdplugin/fu-efi-common.c
+++ b/libfwupdplugin/fu-efi-common.c
@@ -121,7 +121,7 @@ fu_efi_parse_sections(FuFirmware *firmware,
 		}
 
 		fu_firmware_set_offset(img, offset);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* next! */

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -100,7 +100,7 @@ fu_efi_device_path_list_parse(FuFirmware *firmware,
 		fu_firmware_set_offset(FU_FIRMWARE(efi_dp), offset);
 		if (!fu_firmware_parse_stream(FU_FIRMWARE(efi_dp), stream, offset, flags, error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, FU_FIRMWARE(efi_dp), error))
+		if (!fu_firmware_add_image(firmware, FU_FIRMWARE(efi_dp), error))
 			return FALSE;
 		offset += fu_firmware_get_size(FU_FIRMWARE(efi_dp));
 	}

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -70,7 +70,7 @@ fu_efi_filesystem_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		fu_firmware_set_offset(firmware, offset);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* next! */

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -335,7 +335,7 @@ fu_efi_load_option_parse(FuFirmware *firmware,
 	/* parse dp blob */
 	if (!fu_firmware_parse_stream(FU_FIRMWARE(device_path_list), stream, offset, flags, error))
 		return FALSE;
-	if (!fu_firmware_add_image_full(firmware, FU_FIRMWARE(device_path_list), error))
+	if (!fu_firmware_add_image(firmware, FU_FIRMWARE(device_path_list), error))
 		return FALSE;
 	offset += fu_struct_efi_load_option_get_dp_size(st);
 

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -69,8 +69,7 @@ fu_efi_section_parse_volume_image(FuEfiSection *self,
 				      error)) {
 		return FALSE;
 	}
-	fu_firmware_add_image(FU_FIRMWARE(self), img);
-	return TRUE;
+	return fu_firmware_add_image(FU_FIRMWARE(self), img, error);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -158,7 +158,7 @@ fu_efi_signature_list_parse_list(FuEfiSignatureList *self,
 		fu_firmware_set_size(FU_FIRMWARE(sig), size);
 		if (!fu_firmware_parse_stream(FU_FIRMWARE(sig), stream, offset_tmp, flags, error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(sig), error))
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(sig), error))
 			return FALSE;
 		offset_tmp += size;
 	}

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -106,12 +106,14 @@ fu_efi_volume_parse_nvram_evsa(FuEfiVolume *self,
 			g_autoptr(GBytes) blob_padded =
 			    fu_bytes_pad(blob, offset - offset_last, 0xFF);
 			g_autoptr(FuFirmware) img_padded = fu_firmware_new_from_bytes(blob_padded);
-			fu_firmware_add_image(FU_FIRMWARE(self), img_padded);
+			if (!fu_firmware_add_image(FU_FIRMWARE(self), img_padded, error))
+				return FALSE;
 		}
 
 		/* we found something */
 		fu_firmware_set_offset(img, offset);
-		fu_firmware_add_image(FU_FIRMWARE(self), img);
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
+			return FALSE;
 		offset += fu_firmware_get_size(img);
 		offset = fu_common_align_up(offset, FU_FIRMWARE_ALIGNMENT_4K);
 		found_cnt += 1;
@@ -275,7 +277,8 @@ fu_efi_volume_parse(FuFirmware *firmware,
 					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
-		fu_firmware_add_image(firmware, img);
+		if (!fu_firmware_add_image(firmware, img, error))
+			return FALSE;
 	} else if (g_strcmp0(guid_str, FU_EFI_VOLUME_GUID_NVRAM_EVSA) == 0 ||
 		   g_strcmp0(guid_str, FU_EFI_VOLUME_GUID_NVRAM_EVSA2) == 0) {
 		g_autoptr(GError) error_local = NULL;

--- a/libfwupdplugin/fu-efi-vss-auth-variable.c
+++ b/libfwupdplugin/fu-efi-vss-auth-variable.c
@@ -167,7 +167,8 @@ fu_efi_vss_auth_variable_parse(FuFirmware *firmware,
 			return FALSE;
 		if (!fu_firmware_parse_stream(img, partial_stream, 0x0, flags, error))
 			return FALSE;
-		fu_firmware_add_image(firmware, img);
+		if (!fu_firmware_add_image(firmware, img, error))
+			return FALSE;
 	} else {
 		g_autoptr(GBytes) data = NULL;
 		data = fu_input_stream_read_bytes(

--- a/libfwupdplugin/fu-efi-vss2-variable-store.c
+++ b/libfwupdplugin/fu-efi-vss2-variable-store.c
@@ -84,7 +84,8 @@ fu_efi_vss2_variable_store_parse(FuFirmware *firmware,
 		if (fu_efi_vss_auth_variable_get_state(FU_EFI_VSS_AUTH_VARIABLE(img)) ==
 		    FU_EFI_VARIABLE_STATE_VARIABLE_ADDED) {
 			fu_firmware_set_offset(img, offset);
-			fu_firmware_add_image(firmware, img);
+			if (!fu_firmware_add_image(firmware, img, error))
+				return FALSE;
 		}
 		offset += fu_firmware_get_size(img);
 		offset = fu_common_align_up(offset, FU_FIRMWARE_ALIGNMENT_4);

--- a/libfwupdplugin/fu-efivars.c
+++ b/libfwupdplugin/fu-efivars.c
@@ -749,7 +749,8 @@ fu_efivars_create_boot_entry_for_volume(FuEfivars *self,
 		g_autoptr(GBytes) img_blob = g_bytes_new_static("hello", 5);
 		fu_firmware_set_id(img_text, ".text");
 		fu_firmware_set_bytes(img_text, img_blob);
-		fu_firmware_add_image(pefile, img_text);
+		if (!fu_firmware_add_image(pefile, img_text, error))
+			return FALSE;
 		if (!fu_firmware_write_file(pefile, file, error))
 			return FALSE;
 	}
@@ -760,11 +761,14 @@ fu_efivars_create_boot_entry_for_volume(FuEfivars *self,
 	dp_fp = fu_efi_file_path_device_path_new();
 	if (!fu_efi_file_path_device_path_set_name(dp_fp, target, error))
 		return FALSE;
-	fu_firmware_add_image(FU_FIRMWARE(devpath_list), FU_FIRMWARE(dp_hdd));
-	fu_firmware_add_image(FU_FIRMWARE(devpath_list), FU_FIRMWARE(dp_fp));
+	if (!fu_firmware_add_image(FU_FIRMWARE(devpath_list), FU_FIRMWARE(dp_hdd), error))
+		return FALSE;
+	if (!fu_firmware_add_image(FU_FIRMWARE(devpath_list), FU_FIRMWARE(dp_fp), error))
+		return FALSE;
 
 	fu_firmware_set_id(FU_FIRMWARE(entry), name);
-	fu_firmware_add_image(FU_FIRMWARE(entry), FU_FIRMWARE(devpath_list));
+	if (!fu_firmware_add_image(FU_FIRMWARE(entry), FU_FIRMWARE(devpath_list), error))
+		return FALSE;
 	return fu_efivars_set_boot_entry(self, idx, entry, error);
 }
 

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -124,7 +124,7 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 				return FALSE;
 		}
 		fu_firmware_set_idx(img, i);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 	}
 

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -209,7 +209,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 			if (str->len > 0)
 				fu_firmware_set_id(image, str->str);
 			fu_firmware_set_offset(image, offset);
-			if (!fu_firmware_add_image_full(firmware_current, image, error))
+			if (!fu_firmware_add_image(firmware_current, image, error))
 				return FALSE;
 			g_set_object(&firmware_current, image);
 			continue;

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1355,7 +1355,7 @@ fu_firmware_build(FuFirmware *self, XbNode *n, GError **error)
 			} else {
 				img = fu_firmware_new();
 			}
-			if (!fu_firmware_add_image_full(self, img, error))
+			if (!fu_firmware_add_image(self, img, error))
 				return FALSE;
 			if (!fu_firmware_build(img, xb_image, error))
 				return FALSE;
@@ -1713,7 +1713,7 @@ fu_firmware_get_depth(FuFirmware *self)
 }
 
 /**
- * fu_firmware_add_image_full:
+ * fu_firmware_add_image:
  * @self: a #FuPlugin
  * @img: a child firmware image
  * @error: (nullable): optional return location for an error
@@ -1726,10 +1726,10 @@ fu_firmware_get_depth(FuFirmware *self)
  *
  * Returns: %TRUE if the image was added
  *
- * Since: 1.9.3
+ * Since: 1.9.3, but @error was added in 2.0.17
  **/
 gboolean
-fu_firmware_add_image_full(FuFirmware *self, FuFirmware *img, GError **error)
+fu_firmware_add_image(FuFirmware *self, FuFirmware *img, GError **error)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
 
@@ -1785,33 +1785,6 @@ fu_firmware_add_image_full(FuFirmware *self, FuFirmware *img, GError **error)
 
 	/* success */
 	return TRUE;
-}
-
-/**
- * fu_firmware_add_image:
- * @self: a #FuPlugin
- * @img: a child firmware image
- *
- * Adds an image to the firmware.
- *
- * NOTE: If adding images in a loop of any kind then fu_firmware_add_image_full() should be used
- * instead, and fu_firmware_set_images_max() should be set before adding images.
- *
- * If %FU_FIRMWARE_FLAG_DEDUPE_ID is set, an image with the same ID is already
- * present it is replaced.
- *
- * Since: 1.3.1
- **/
-void
-fu_firmware_add_image(FuFirmware *self, FuFirmware *img)
-{
-	g_autoptr(GError) error_local = NULL;
-
-	g_return_if_fail(FU_IS_FIRMWARE(self));
-	g_return_if_fail(FU_IS_FIRMWARE(img));
-
-	if (!fu_firmware_add_image_full(self, img, &error_local))
-		g_critical("failed to add image: %s", error_local->message);
 }
 
 /**

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -212,10 +212,8 @@ fu_firmware_check_compatible(FuFirmware *self,
 			     FuFirmwareParseFlags flags,
 			     GError **error) G_GNUC_NON_NULL(1, 2);
 
-void
-fu_firmware_add_image(FuFirmware *self, FuFirmware *img) G_GNUC_NON_NULL(1, 2);
 gboolean
-fu_firmware_add_image_full(FuFirmware *self, FuFirmware *img, GError **error) G_GNUC_NON_NULL(1, 2);
+fu_firmware_add_image(FuFirmware *self, FuFirmware *img, GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_firmware_remove_image(FuFirmware *self, FuFirmware *img, GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean

--- a/libfwupdplugin/fu-fit-firmware.c
+++ b/libfwupdplugin/fu-fit-firmware.c
@@ -39,7 +39,7 @@ fu_fit_firmware_get_image_root(FuFitFirmware *self)
 	fu_fdt_image_set_attr_uint32(FU_FDT_IMAGE(img), FU_FIT_FIRMWARE_ATTR_TIMESTAMP, 0x0);
 	fu_fdt_image_set_attr_str(FU_FDT_IMAGE(img), "description", "Firmware image");
 	fu_fdt_image_set_attr_str(FU_FDT_IMAGE(img), "creator", "fwupd");
-	fu_firmware_add_image(FU_FIRMWARE(self), img);
+	fu_firmware_add_image(FU_FIRMWARE(self), img, NULL);
 	return FU_FDT_IMAGE(img);
 }
 

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -101,7 +101,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		fu_firmware_set_id(img, area_name);
 		fu_firmware_set_idx(img, i + 1);
 		fu_firmware_set_addr(img, area_offset);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		if (g_strcmp0(area_name, FMAP_AREANAME) == 0) {

--- a/libfwupdplugin/fu-gcab.c
+++ b/libfwupdplugin/fu-gcab.c
@@ -40,7 +40,14 @@ main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			fu_firmware_set_bytes(FU_FIRMWARE(img), img_blob);
-			fu_firmware_add_image(FU_FIRMWARE(cab_firmware), FU_FIRMWARE(img));
+			if (!fu_firmware_add_image(FU_FIRMWARE(cab_firmware),
+						   FU_FIRMWARE(img),
+						   &error)) {
+				g_printerr("Failed to add image to %s: %s\n",
+					   argv[1],
+					   error->message);
+				return EXIT_FAILURE;
+			}
 		}
 		if (!fu_firmware_write_file(FU_FIRMWARE(cab_firmware), file, &error)) {
 			g_printerr("Failed to write file %s: %s\n", argv[1], error->message);

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -131,19 +131,19 @@ fu_hid_descriptor_parse(FuFirmware *firmware,
 			/* copy the table state to the new report */
 			for (guint i = 0; i < table_state->len; i++) {
 				FuHidReportItem *item_tmp = g_ptr_array_index(table_state, i);
-				if (!fu_firmware_add_image_full(FU_FIRMWARE(report),
-								FU_FIRMWARE(item_tmp),
-								error))
+				if (!fu_firmware_add_image(FU_FIRMWARE(report),
+							   FU_FIRMWARE(item_tmp),
+							   error))
 					return FALSE;
 			}
 			for (guint i = 0; i < table_local->len; i++) {
 				FuHidReportItem *item_tmp = g_ptr_array_index(table_local, i);
-				if (!fu_firmware_add_image_full(FU_FIRMWARE(report),
-								FU_FIRMWARE(item_tmp),
-								error))
+				if (!fu_firmware_add_image(FU_FIRMWARE(report),
+							   FU_FIRMWARE(item_tmp),
+							   error))
 					return FALSE;
 			}
-			if (!fu_firmware_add_image_full(firmware, FU_FIRMWARE(report), error))
+			if (!fu_firmware_add_image(firmware, FU_FIRMWARE(report), error))
 				return FALSE;
 
 			/* remove all the local items */

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -53,7 +53,7 @@ fu_ifd_bios_parse(FuFirmware *firmware,
 			continue;
 		}
 		fu_firmware_set_offset(firmware_tmp, offset);
-		if (!fu_firmware_add_image_full(firmware, firmware_tmp, error))
+		if (!fu_firmware_add_image(firmware, firmware_tmp, error))
 			return FALSE;
 
 		/* next! */

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -273,7 +273,7 @@ fu_ifd_firmware_parse(FuFirmware *firmware,
 		fu_firmware_set_idx(img, i);
 		if (freg_str != NULL)
 			fu_firmware_set_id(img, freg_str);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* is writable by anything other than the region itself */
@@ -339,7 +339,8 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 		fu_firmware_set_addr(img_desc, 0x0);
 		fu_firmware_set_idx(img_desc, FU_IFD_REGION_DESC);
 		fu_firmware_set_id(img_desc, "desc");
-		fu_firmware_add_image(firmware, img_desc);
+		if (!fu_firmware_add_image(firmware, img_desc, error))
+			return NULL;
 	}
 
 	/* generate ahead of time */

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -122,7 +122,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuFirmware *firmware,
 
 		/* success */
 		fu_firmware_set_offset(img, offset);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 		offset += extension_length;
 	}
@@ -217,7 +217,7 @@ fu_ifwi_cpd_firmware_parse(FuFirmware *firmware,
 		}
 
 		/* success */
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 		offset += st_ent->len;
 	}

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -113,7 +113,7 @@ fu_ifwi_fpt_firmware_parse(FuFirmware *firmware,
 				return FALSE;
 			fu_firmware_set_offset(img, data_offset);
 		}
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* next */

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -396,7 +396,7 @@ fu_ihex_firmware_parse(FuFirmware *firmware,
 				g_autoptr(FuFirmware) img_sig =
 				    fu_firmware_new_from_bytes(data_sig);
 				fu_firmware_set_id(img_sig, FU_FIRMWARE_ID_SIGNATURE);
-				if (!fu_firmware_add_image_full(firmware, img_sig, error))
+				if (!fu_firmware_add_image(firmware, img_sig, error))
 					return FALSE;
 			}
 			got_sig = TRUE;

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -558,7 +558,7 @@ fu_intel_thunderbolt_nvm_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_payload, stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
-	if (!fu_firmware_add_image_full(firmware, img_payload, error))
+	if (!fu_firmware_add_image(firmware, img_payload, error))
 		return FALSE;
 
 	/* success */

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -116,7 +116,7 @@ fu_linear_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		fu_firmware_set_offset(firmware, offset);
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* next! */

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -179,7 +179,8 @@ fu_oprom_firmware_parse(FuFirmware *firmware,
 		}
 		fu_firmware_set_id(img, "cpd");
 		fu_firmware_set_offset(img, expansion_header_offset);
-		fu_firmware_add_image(firmware, img);
+		if (!fu_firmware_add_image(firmware, img, error))
+			return FALSE;
 	}
 
 	/* success */

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -206,7 +206,7 @@ fu_pefile_firmware_parse_section(FuFirmware *firmware,
 	}
 
 	/* success */
-	return fu_firmware_add_image_full(firmware, img, error);
+	return fu_firmware_add_image(firmware, img, error);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-pkcs7.c
+++ b/libfwupdplugin/fu-pkcs7.c
@@ -52,7 +52,8 @@ fu_pkcs7_parse_x509_certificate(FuPkcs7 *self, gnutls_datum_t *data, GError **er
 				     FU_FIRMWARE_PARSE_FLAG_NONE,
 				     error))
 		return FALSE;
-	fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(crt));
+	if (!fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(crt), error))
+		return FALSE;
 
 	/* success */
 	return TRUE;

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -61,7 +61,7 @@ fu_sbatlevel_section_add_entry(FuFirmware *firmware,
 		g_prefix_error(error, "failed to parse %s: ", entry_name);
 		return FALSE;
 	}
-	if (!fu_firmware_add_image_full(firmware, entry_fw, error))
+	if (!fu_firmware_add_image(firmware, entry_fw, error))
 		return FALSE;
 
 	/* success */

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -109,7 +109,7 @@ fu_usb_bos_descriptor_from_json(FwupdCodec *codec, JsonNode *json_node, GError *
 					      error))
 			return FALSE;
 		fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);
-		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 			return FALSE;
 	}
 
@@ -197,7 +197,7 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 					      error))
 			return FALSE;
 		fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);
-		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 			return FALSE;
 	}
 
@@ -264,6 +264,6 @@ fu_usb_bos_descriptor_new(const struct libusb_bos_dev_capability_descriptor *bos
 	bytes = g_bytes_new(bos_cap->dev_capability_data, bos_cap->bLength - FU_USB_BOS_HDR_SIZE);
 	fu_firmware_set_bytes(img, bytes);
 	fu_firmware_set_id(img, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(FU_FIRMWARE(self), img);
+	fu_firmware_add_image(FU_FIRMWARE(self), img, NULL);
 	return FU_USB_BOS_DESCRIPTOR(self);
 }

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -1835,9 +1835,9 @@ fu_usb_device_parse_descriptor(FuUsbDevice *self, GInputStream *stream, GError *
 					FU_FIRMWARE_PARSE_FLAG_CACHE_BLOB,
 					error))
 					return FALSE;
-				if (!fu_firmware_add_image_full(FU_FIRMWARE(iface),
-								FU_FIRMWARE(img),
-								error))
+				if (!fu_firmware_add_image(FU_FIRMWARE(iface),
+							   FU_FIRMWARE(img),
+							   error))
 					return FALSE;
 				offset += fu_firmware_get_size(FU_FIRMWARE(img));
 			}

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -66,7 +66,7 @@ fu_usb_interface_parse_extra(FuUsbInterface *self, const guint8 *buf, gsize bufs
 					     FU_FIRMWARE_PARSE_FLAG_CACHE_BLOB,
 					     error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(img), error))
 			return FALSE;
 		offset += fu_firmware_get_size(FU_FIRMWARE(img));
 	}

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -166,7 +166,7 @@ fu_uswid_firmware_parse(FuFirmware *firmware,
 					     flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					     error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, firmware_coswid, error))
+		if (!fu_firmware_add_image(firmware, firmware_coswid, error))
 			return FALSE;
 		if (fu_firmware_get_size(firmware_coswid) == 0) {
 			g_set_error_literal(error,

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -47,7 +47,7 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, firmware_tmp, error))
+		if (!fu_firmware_add_image(firmware, firmware_tmp, error))
 			return FALSE;
 		offset += fu_firmware_get_size(firmware_tmp);
 	}

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -74,7 +74,7 @@ fu_acpi_phat_record_parse(FuFirmware *firmware,
 		fu_firmware_set_version_raw(firmware_rcd, revision);
 		if (!fu_firmware_parse_stream(firmware_rcd, partial_stream, 0x0, flags, error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, firmware_rcd, error))
+		if (!fu_firmware_add_image(firmware, firmware_rcd, error))
 			return FALSE;
 	}
 

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -55,7 +55,8 @@ fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_isp, stream_isp, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_isp, "isp");
-	fu_firmware_add_image(firmware, img_isp);
+	if (!fu_firmware_add_image(firmware, img_isp, error))
+		return FALSE;
 	offset += AG_ISP_SIZE;
 
 	/* payload */
@@ -66,7 +67,8 @@ fu_algoltek_usb_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	fu_firmware_set_version(img_payload, version);
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, img_payload);
+	if (!fu_firmware_add_image(firmware, img_payload, error))
+		return FALSE;
 
 	/* success */
 	return TRUE;

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -137,7 +137,8 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 		if (!fu_firmware_parse_stream(ish_img, stream, loc, flags, error))
 			return FALSE;
 		fu_firmware_set_addr(ish_img, loc);
-		fu_firmware_add_image(firmware, ish_img);
+		if (!fu_firmware_add_image(firmware, ish_img, error))
+			return FALSE;
 
 		/* parse the csm image */
 		loc = fu_struct_image_slot_header_get_loc_csm(ish);
@@ -164,7 +165,8 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 				    fu_struct_image_slot_header_get_fw_id(ish));
 			return FALSE;
 		}
-		fu_firmware_add_image(l2_img, csm_img);
+		if (!fu_firmware_add_image(l2_img, csm_img, error))
+			return FALSE;
 
 		l2_stream = fu_partial_input_stream_new(stream, loc, sz, error);
 		if (l2_stream == NULL)
@@ -172,7 +174,8 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 		fu_firmware_set_addr(l2_img, loc);
 		if (!fu_firmware_parse_stream(l2_img, l2_stream, 0x0, flags, error))
 			return FALSE;
-		fu_firmware_add_image(ish_img, l2_img);
+		if (!fu_firmware_add_image(ish_img, l2_img, error))
+			return FALSE;
 
 		/* parse the partition */
 		if (!fu_amd_gpu_psp_firmware_parse_l2(l2_img, stream, loc, error))

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -56,7 +56,8 @@ fu_analogix_firmware_parse(FuFirmware *firmware,
 		fw_ocm = fu_firmware_new_from_bytes(blob_ocm);
 		fu_firmware_set_id(fw_ocm, "ocm");
 		fu_firmware_set_addr(fw_ocm, FLASH_OCM_ADDR);
-		fu_firmware_add_image(firmware, fw_ocm);
+		if (!fu_firmware_add_image(firmware, fw_ocm, error))
+			return FALSE;
 
 		/* get OCM version */
 		buf = g_bytes_get_data(blob_ocm, &bufsz);
@@ -83,7 +84,8 @@ fu_analogix_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) fw2 = fu_firmware_new_from_bytes(blob_stx);
 		fu_firmware_set_id(fw2, "stx");
 		fu_firmware_set_addr(fw2, FLASH_TXFW_ADDR);
-		fu_firmware_add_image(firmware, fw2);
+		if (!fu_firmware_add_image(firmware, fw2, error))
+			return FALSE;
 	}
 
 	/* RXFW is optional */
@@ -93,13 +95,15 @@ fu_analogix_firmware_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) fw2 = fu_firmware_new_from_bytes(blob_srx);
 		fu_firmware_set_id(fw2, "srx");
 		fu_firmware_set_addr(fw2, FLASH_RXFW_ADDR);
-		fu_firmware_add_image(firmware, fw2);
+		if (!fu_firmware_add_image(firmware, fw2, error))
+			return FALSE;
 	}
 	if (blob_cus != NULL && !fu_bytes_is_empty(blob_cus)) {
 		g_autoptr(FuFirmware) fw2 = fu_firmware_new_from_bytes(blob_cus);
 		fu_firmware_set_id(fw2, "custom");
 		fu_firmware_set_addr(fw2, FLASH_CUSTOM_ADDR);
-		fu_firmware_add_image(firmware, fw2);
+		if (!fu_firmware_add_image(firmware, fw2, error))
+			return FALSE;
 	}
 
 	/* success */

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -54,9 +54,7 @@ fu_asus_hid_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_payload, stream_payload, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, img_payload);
-
-	return TRUE;
+	return fu_firmware_add_image(firmware, img_payload, error);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -381,14 +381,20 @@ fu_bcm57xx_device_prepare_firmware(FuDevice *device,
 
 	/* merge in all the provided images into the existing firmware */
 	img_stage1 = fu_firmware_get_image_by_id(firmware_tmp, "stage1", NULL);
-	if (img_stage1 != NULL)
-		fu_firmware_add_image(firmware, img_stage1);
+	if (img_stage1 != NULL) {
+		if (!fu_firmware_add_image(firmware, img_stage1, error))
+			return NULL;
+	}
 	img_stage2 = fu_firmware_get_image_by_id(firmware_tmp, "stage2", NULL);
-	if (img_stage2 != NULL)
-		fu_firmware_add_image(firmware, img_stage2);
+	if (img_stage2 != NULL) {
+		if (!fu_firmware_add_image(firmware, img_stage2, error))
+			return NULL;
+	}
 	img_ape = fu_firmware_get_image_by_id(firmware_tmp, "ape", NULL);
-	if (img_ape != NULL)
-		fu_firmware_add_image(firmware, img_ape);
+	if (img_ape != NULL) {
+		if (!fu_firmware_add_image(firmware, img_ape, error))
+			return NULL;
+	}
 
 	/* the src and dst dictionaries may be in different order */
 	images = fu_firmware_get_images(firmware);

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -248,8 +248,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 	if (dict_sz == 0) {
 		g_autoptr(GBytes) blob = g_bytes_new(NULL, 0);
 		fu_firmware_set_bytes(img, blob);
-		fu_firmware_add_image(FU_FIRMWARE(self), img);
-		return TRUE;
+		return fu_firmware_add_image(FU_FIRMWARE(self), img, error);
 	}
 
 	/* check against image size */
@@ -275,8 +274,7 @@ fu_bcm57xx_firmware_parse_dict(FuBcm57xxFirmware *self,
 		return FALSE;
 
 	/* success */
-	fu_firmware_add_image(FU_FIRMWARE(self), img);
-	return TRUE;
+	return fu_firmware_add_image(FU_FIRMWARE(self), img, error);
 }
 
 static gboolean
@@ -336,8 +334,7 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 		fu_bcm57xx_dict_image_set_kind(FU_BCM57XX_DICT_IMAGE(img), 0x0);
 		fu_firmware_set_addr(img, BCM_CODE_DIRECTORY_ADDR_APE);
 		fu_firmware_set_id(img, "ape");
-		fu_firmware_add_image(firmware, img);
-		return TRUE;
+		return fu_firmware_add_image(firmware, img, error);
 	}
 
 	/* standalone stage1 */
@@ -346,8 +343,7 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 		if (!fu_firmware_set_stream(img_stage1_standalone, stream, error))
 			return FALSE;
 		fu_firmware_set_id(img_stage1_standalone, "stage1");
-		fu_firmware_add_image(firmware, img_stage1_standalone);
-		return TRUE;
+		return fu_firmware_add_image(firmware, img_stage1_standalone, error);
 	}
 
 	/* not full NVRAM image */
@@ -392,7 +388,8 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 	fu_firmware_set_offset(img_info, BCM_NVRAM_INFO_BASE);
-	fu_firmware_add_image(firmware, img_info);
+	if (!fu_firmware_add_image(firmware, img_info, error))
+		return FALSE;
 
 	/* VPD */
 	stream_vpd =
@@ -405,7 +402,8 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 	}
 	fu_firmware_set_id(img_vpd, "vpd");
 	fu_firmware_set_offset(img_vpd, BCM_NVRAM_VPD_BASE);
-	fu_firmware_add_image(firmware, img_vpd);
+	if (!fu_firmware_add_image(firmware, img_vpd, error))
+		return FALSE;
 
 	/* info2 */
 	stream_info2 =
@@ -418,7 +416,8 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 	}
 	fu_firmware_set_id(img_info2, "info2");
 	fu_firmware_set_offset(img_info2, BCM_NVRAM_INFO2_BASE);
-	fu_firmware_add_image(firmware, img_info2);
+	if (!fu_firmware_add_image(firmware, img_info2, error))
+		return FALSE;
 
 	/* stage1 */
 	img_stage1 = fu_bcm57xx_firmware_parse_stage1(self, stream, &stage1_sz, flags, error);
@@ -426,7 +425,8 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 		g_prefix_error_literal(error, "failed to parse stage1: ");
 		return FALSE;
 	}
-	fu_firmware_add_image(firmware, img_stage1);
+	if (!fu_firmware_add_image(firmware, img_stage1, error))
+		return FALSE;
 
 	/* stage2 */
 	img_stage2 = fu_bcm57xx_firmware_parse_stage2(self, stream, stage1_sz, flags, error);
@@ -434,7 +434,8 @@ fu_bcm57xx_firmware_parse(FuFirmware *firmware,
 		g_prefix_error_literal(error, "failed to parse stage2: ");
 		return FALSE;
 	}
-	fu_firmware_add_image(firmware, img_stage2);
+	if (!fu_firmware_add_image(firmware, img_stage2, error))
+		return FALSE;
 
 	/* dictionaries, e.g. APE */
 	for (guint i = 0; i < 8; i++) {

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -108,7 +108,8 @@ fu_cfu_module_prepare_firmware(FuDevice *device,
 	if (!fu_firmware_parse_bytes(offer, blob_offer, 0x0, flags, error))
 		return NULL;
 	fu_firmware_set_id(offer, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_add_image(firmware, offer);
+	if (!fu_firmware_add_image(firmware, offer, error))
+		return NULL;
 
 	/* payload */
 	fw_payload = fu_archive_firmware_get_image_fnmatch(FU_ARCHIVE_FIRMWARE(firmware_archive),
@@ -122,7 +123,8 @@ fu_cfu_module_prepare_firmware(FuDevice *device,
 	if (!fu_firmware_parse_bytes(payload, blob_payload, 0x0, flags, error))
 		return NULL;
 	fu_firmware_set_id(payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, payload);
+	if (!fu_firmware_add_image(firmware, payload, error))
+		return NULL;
 
 	/* success */
 	return g_steal_pointer(&firmware);

--- a/plugins/dfu/fu-dfu-target.c
+++ b/plugins/dfu/fu-dfu-target.c
@@ -994,8 +994,7 @@ fu_dfu_target_upload(FuDfuTarget *self,
 	}
 
 	/* success */
-	fu_firmware_add_image(firmware, image);
-	return TRUE;
+	return fu_firmware_add_image(firmware, image, error);
 }
 
 static gchar *

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -57,7 +57,8 @@ fu_ebitdo_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_hdr, stream_hdr, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_hdr, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_add_image(firmware, img_hdr);
+	if (!fu_firmware_add_image(firmware, img_hdr, error))
+		return FALSE;
 
 	/* add payload */
 	stream_payload = fu_partial_input_stream_new(stream, st->len, payload_len, error);

--- a/plugins/elan-kbd/fu-elan-kbd-device.c
+++ b/plugins/elan-kbd/fu-elan-kbd-device.c
@@ -434,7 +434,8 @@ fu_elan_kbd_device_read_firmware(FuDevice *device, FuProgress *progress, GError 
 	}
 	img_bootloader = fu_firmware_new_from_bytes(blob_bootloader);
 	fu_firmware_set_id(img_bootloader, "bootloader");
-	fu_firmware_add_image(firmware, img_bootloader);
+	if (!fu_firmware_add_image(firmware, img_bootloader, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* app */
@@ -449,7 +450,8 @@ fu_elan_kbd_device_read_firmware(FuDevice *device, FuProgress *progress, GError 
 	}
 	img_app = fu_firmware_new_from_bytes(blob_app);
 	fu_firmware_set_idx(img_app, FU_ELAN_KBD_FIRMWARE_IDX_APP);
-	fu_firmware_add_image(firmware, img_app);
+	if (!fu_firmware_add_image(firmware, img_app, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* option */
@@ -461,7 +463,8 @@ fu_elan_kbd_device_read_firmware(FuDevice *device, FuProgress *progress, GError 
 	}
 	img_option = fu_firmware_new_from_bytes(blob_option);
 	fu_firmware_set_idx(img_option, FU_ELAN_KBD_FIRMWARE_IDX_OPTION);
-	fu_firmware_add_image(firmware, img_option);
+	if (!fu_firmware_add_image(firmware, img_option, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/elan-kbd/fu-elan-kbd-firmware.c
+++ b/plugins/elan-kbd/fu-elan-kbd-firmware.c
@@ -48,7 +48,8 @@ fu_elan_kbd_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_set_stream(firmware_bootloader, stream_bootloader, error))
 		return FALSE;
 	fu_firmware_set_idx(firmware_bootloader, FU_ELAN_KBD_FIRMWARE_IDX_BOOTLOADER);
-	fu_firmware_add_image(firmware, firmware_bootloader);
+	if (!fu_firmware_add_image(firmware, firmware_bootloader, error))
+		return FALSE;
 
 	/* app */
 	stream_app = fu_partial_input_stream_new(stream,
@@ -60,7 +61,8 @@ fu_elan_kbd_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_set_stream(firmware_app, stream_app, error))
 		return FALSE;
 	fu_firmware_set_idx(firmware_app, FU_ELAN_KBD_FIRMWARE_IDX_APP);
-	fu_firmware_add_image(firmware, firmware_app);
+	if (!fu_firmware_add_image(firmware, firmware_app, error))
+		return FALSE;
 
 	/* option */
 	stream_option = fu_partial_input_stream_new(stream,
@@ -72,7 +74,8 @@ fu_elan_kbd_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_set_stream(firmware_option, stream_option, error))
 		return FALSE;
 	fu_firmware_set_idx(firmware_option, FU_ELAN_KBD_FIRMWARE_IDX_OPTION);
-	fu_firmware_add_image(firmware, firmware_option);
+	if (!fu_firmware_add_image(firmware, firmware_option, error))
+		return FALSE;
 
 	/* success */
 	return TRUE;

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -140,7 +140,7 @@ fu_elanfp_firmware_parse(FuFirmware *firmware,
 					      flags | FU_FIRMWARE_PARSE_FLAG_NO_SEARCH,
 					      error))
 			return FALSE;
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		offset += 0x10;

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -64,13 +64,15 @@ fu_genesys_scaler_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(firmware_payload, stream_payload, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(firmware_payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, firmware_payload);
+	if (!fu_firmware_add_image(firmware, firmware_payload, error))
+		return FALSE;
 
 	/* set public-key */
 	blob_public_key = g_bytes_new(&self->public_key, sizeof(self->public_key));
 	firmware_public_key = fu_firmware_new_from_bytes(blob_public_key);
 	fu_firmware_set_id(firmware_public_key, FU_FIRMWARE_ID_SIGNATURE);
-	fu_firmware_add_image(firmware, firmware_public_key);
+	if (!fu_firmware_add_image(firmware, firmware_public_key, error))
+		return FALSE;
 
 	/* success */
 	return TRUE;

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -345,7 +345,8 @@ fu_genesys_usbhub_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		fu_firmware_set_offset(firmware_sub, offset);
-		fu_firmware_add_image(firmware, firmware_sub);
+		if (!fu_firmware_add_image(firmware, firmware_sub, error))
+			return FALSE;
 		offset += fu_firmware_get_size(firmware_sub);
 	}
 

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
@@ -61,7 +61,8 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 		if (fw_img == NULL)
 			return FALSE;
 		fu_firmware_set_bytes(img, fw_img);
-		fu_firmware_add_image(FU_FIRMWARE(self), img);
+		if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
+			return FALSE;
 		if (!fu_memread_uint8_safe(buf, bufsz, firmware_size + 64 + 34, &cfg_ver, error))
 			return FALSE;
 		g_debug("config size:0x%x, config ver:0x%02x",
@@ -113,7 +114,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 			if (fw_img == NULL)
 				return FALSE;
 			fu_firmware_set_bytes(img, fw_img);
-			if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
+			if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 				return FALSE;
 		}
 		offset_hdr += st_img->len;

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
@@ -156,7 +156,7 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 				if (fw_img == NULL)
 					return FALSE;
 				fu_firmware_set_bytes(img, fw_img);
-				if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
+				if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 					return FALSE;
 				if (!fu_memread_uint8_safe(buf, bufsz, cfg_offset, &cfg_ver, error))
 					return FALSE;
@@ -197,7 +197,7 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 			if (fw_img == NULL)
 				return FALSE;
 			fu_firmware_set_bytes(img, fw_img);
-			if (!fu_firmware_add_image_full(FU_FIRMWARE(self), img, error))
+			if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 				return FALSE;
 		}
 		offset_hdr += st_img->len;

--- a/plugins/ilitek-its/fu-ilitek-its-firmware.c
+++ b/plugins/ilitek-its/fu-ilitek-its-firmware.c
@@ -174,7 +174,8 @@ fu_ilitek_its_firmware_parse(FuFirmware *firmware,
 		fu_firmware_set_idx(block_img, i);
 		fu_firmware_set_parent(block_img, firmware);
 		fu_firmware_set_addr(block_img, start);
-		fu_firmware_add_image(firmware, block_img);
+		if (!fu_firmware_add_image(firmware, block_img, error))
+			return FALSE;
 	}
 
 	/* success */

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -156,7 +156,7 @@ fu_jabra_gnp_firmware_parse(FuFirmware *firmware,
 			g_propagate_error(error, g_steal_pointer(&error_local));
 			return FALSE;
 		}
-		if (!fu_firmware_add_image_full(firmware, FU_FIRMWARE(img), error))
+		if (!fu_firmware_add_image(firmware, FU_FIRMWARE(img), error))
 			return FALSE;
 	}
 

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -249,7 +249,7 @@ fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(isp_drv_img, isp_drv_stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_idx(isp_drv_img, FU_KINETIC_DP_FIRMWARE_IDX_ISP_DRV);
-	if (!fu_firmware_add_image_full(firmware, isp_drv_img, error))
+	if (!fu_firmware_add_image(firmware, isp_drv_img, error))
 		return FALSE;
 
 	/* add App FW as a new image into firmware */
@@ -272,7 +272,7 @@ fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(app_fw_img, app_fw_stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_idx(app_fw_img, FU_KINETIC_DP_FIRMWARE_IDX_APP_FW);
-	if (!fu_firmware_add_image_full(firmware, app_fw_img, error))
+	if (!fu_firmware_add_image(firmware, app_fw_img, error))
 		return FALSE;
 
 	/* figure out which chip App FW it is for */

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -225,7 +225,7 @@ fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(isp_drv_img, isp_drv_stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_idx(isp_drv_img, FU_KINETIC_DP_FIRMWARE_IDX_ISP_DRV);
-	if (!fu_firmware_add_image_full(firmware, isp_drv_img, error))
+	if (!fu_firmware_add_image(firmware, isp_drv_img, error))
 		return FALSE;
 
 	/* add App FW as a new image into firmware */
@@ -238,7 +238,7 @@ fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(app_fw_img, app_fw_stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_idx(app_fw_img, FU_KINETIC_DP_FIRMWARE_IDX_APP_FW);
-	if (!fu_firmware_add_image_full(firmware, app_fw_img, error))
+	if (!fu_firmware_add_image(firmware, app_fw_img, error))
 		return FALSE;
 
 	/* figure out which chip App FW it is for */

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -62,7 +62,8 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_sig, stream_sig, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_sig, FU_FIRMWARE_ID_SIGNATURE);
-	fu_firmware_add_image(firmware, img_sig);
+	if (!fu_firmware_add_image(firmware, img_sig, error))
+		return FALSE;
 
 	stream_payload =
 	    fu_partial_input_stream_new(stream,
@@ -74,7 +75,8 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_payload, stream_payload, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, img_payload);
+	if (!fu_firmware_add_image(firmware, img_payload, error))
+		return FALSE;
 
 	version = fu_struct_legion_hid2_version_parse_stream(stream, VERSION_OFFSET, error);
 	if (version == NULL)

--- a/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
+++ b/plugins/logitech-hidpp/fu-logitech-rdfu-firmware.c
@@ -301,7 +301,8 @@ fu_logitech_rdfu_firmware_parse(FuFirmware *firmware,
 			g_prefix_error(error, "RDFU firmware contents[%u]: ", i);
 			return FALSE;
 		}
-		fu_firmware_add_image(firmware, entity_fw);
+		if (!fu_firmware_add_image(firmware, entity_fw, error))
+			return FALSE;
 	}
 
 	if (!json_object_has_member(json_obj, "payloads")) {

--- a/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-firmware.c
@@ -220,7 +220,8 @@ fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_offset(ap_img, ap_end);
 	if (!fu_firmware_set_stream(ap_img, ap_stream, error))
 		return FALSE;
-	fu_firmware_add_image(firmware, ap_img);
+	if (!fu_firmware_add_image(firmware, ap_img, error))
+		return FALSE;
 
 	/* calculate basic checksum for dataflash (DF) */
 	df_stream = fu_partial_input_stream_new(stream, df_start, df_end - df_start, error);
@@ -235,7 +236,8 @@ fu_logitech_tap_touch_firmware_parse(FuFirmware *firmware,
 	fu_firmware_set_offset(df_img, df_end);
 	if (!fu_firmware_set_stream(df_img, df_stream, error))
 		return FALSE;
-	fu_firmware_add_image(firmware, df_img);
+	if (!fu_firmware_add_image(firmware, df_img, error))
+		return FALSE;
 
 	/* success */
 	return TRUE;

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -352,7 +352,7 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 			fu_firmware_set_addr(image, image_addr);
 		}
 
-		if (!fu_firmware_add_image_full(firmware, image, error))
+		if (!fu_firmware_add_image(firmware, image, error))
 			return FALSE;
 	}
 

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -700,7 +700,8 @@ fu_steelseries_sonic_read_firmware(FuDevice *device, FuProgress *progress, GErro
 	if (firmware_nordic == NULL)
 		return NULL;
 	fu_firmware_set_id(firmware_nordic, FU_STEELSERIES_SONIC_FIRMWARE_ID[chip]);
-	fu_firmware_add_image(firmware, firmware_nordic);
+	if (!fu_firmware_add_image(firmware, firmware_nordic, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* holtek */
@@ -710,7 +711,8 @@ fu_steelseries_sonic_read_firmware(FuDevice *device, FuProgress *progress, GErro
 	if (firmware_holtek == NULL)
 		return NULL;
 	fu_firmware_set_id(firmware_holtek, FU_STEELSERIES_SONIC_FIRMWARE_ID[chip]);
-	fu_firmware_add_image(firmware, firmware_holtek);
+	if (!fu_firmware_add_image(firmware, firmware_holtek, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* mouse */
@@ -720,7 +722,8 @@ fu_steelseries_sonic_read_firmware(FuDevice *device, FuProgress *progress, GErro
 	if (firmware_mouse == NULL)
 		return NULL;
 	fu_firmware_set_id(firmware_mouse, FU_STEELSERIES_SONIC_FIRMWARE_ID[chip]);
-	fu_firmware_add_image(firmware, firmware_mouse);
+	if (!fu_firmware_add_image(firmware, firmware_mouse, error))
+		return NULL;
 	fu_progress_step_done(progress);
 
 	/* success */

--- a/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-hid-firmware.c
@@ -69,7 +69,8 @@ fu_synaptics_cape_hid_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_hdr, stream_hdr, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_hdr, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_add_image(firmware, img_hdr);
+	if (!fu_firmware_add_image(firmware, img_hdr, error))
+		return FALSE;
 
 	/* body */
 	stream_body = fu_partial_input_stream_new(stream, st->len, streamsz - st->len, error);

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -122,7 +122,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 			hdrsz);
 		fu_firmware_set_idx(img, tag);
 		fu_firmware_set_id(img, fu_synaprom_firmware_tag_to_string(tag));
-		if (!fu_firmware_add_image_full(firmware, img, error))
+		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 
 		/* metadata */

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -58,7 +58,7 @@ fu_synaptics_rmi_firmware_add_image(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img, partial_stream, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img, id);
-	return fu_firmware_add_image_full(firmware, img, error);
+	return fu_firmware_add_image(firmware, img, error);
 }
 
 static gboolean
@@ -85,7 +85,8 @@ fu_synaptics_rmi_firmware_add_image_v10(FuFirmware *firmware,
 			return FALSE;
 		sig_id = g_strdup_printf("%s-signature", id);
 		fu_firmware_set_id(img, sig_id);
-		fu_firmware_add_image(firmware, img);
+		if (!fu_firmware_add_image(firmware, img, error))
+			return FALSE;
 	}
 	return TRUE;
 }

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -101,7 +101,8 @@ fu_telink_dfu_archive_load_file(FuTelinkDfuArchive *self,
 		guint image_addr = json_object_get_int_member(obj, "load_address");
 		fu_firmware_set_addr(image, image_addr);
 	}
-	fu_firmware_add_image(FU_FIRMWARE(self), image);
+	if (!fu_firmware_add_image(FU_FIRMWARE(self), image, error))
+		return FALSE;
 
 	if (!json_object_has_member(obj, "image_version")) {
 		g_set_error_literal(error,

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -57,7 +57,8 @@ fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_pubkey, stream_pubkey, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_pubkey, "pubkey");
-	fu_firmware_add_image(firmware, img_pubkey);
+	if (!fu_firmware_add_image(firmware, img_pubkey, error))
+		return FALSE;
 	offset += FU_TI_TPS6598X_FIRMWARE_PUBKEY_SIZE;
 
 	/* RSA signature */
@@ -68,7 +69,8 @@ fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_parse_stream(img_sig, stream_sig, 0x0, flags, error))
 		return FALSE;
 	fu_firmware_set_id(img_sig, FU_FIRMWARE_ID_SIGNATURE);
-	fu_firmware_add_image(firmware, img_sig);
+	if (!fu_firmware_add_image(firmware, img_sig, error))
+		return FALSE;
 	offset += FU_TI_TPS6598X_FIRMWARE_PUBKEY_SIZE;
 
 	/* payload */
@@ -88,10 +90,9 @@ fu_ti_tps6598x_firmware_parse(FuFirmware *firmware,
 	version_str = g_strdup_printf("%X.%X.%X", verbuf[2], verbuf[1], verbuf[0]);
 	fu_firmware_set_version(img_payload, version_str);
 	fu_firmware_set_id(img_payload, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, img_payload);
 
 	/* success */
-	return TRUE;
+	return fu_firmware_add_image(firmware, img_payload, error);
 }
 
 static GByteArray *

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -435,7 +435,8 @@ fu_uefi_bootmgr_bootnext(FuEfivars *efivars,
 	dp_buf = fu_uefi_capsule_device_build_dp_buf(esp, filepath, error);
 	if (dp_buf == NULL)
 		return FALSE;
-	fu_firmware_add_image(FU_FIRMWARE(loadopt), FU_FIRMWARE(dp_buf));
+	if (!fu_firmware_add_image(FU_FIRMWARE(loadopt), FU_FIRMWARE(dp_buf), error))
+		return FALSE;
 	fu_firmware_set_id(FU_FIRMWARE(loadopt), description);
 
 	/* save as BootNext */

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -343,8 +343,10 @@ fu_uefi_capsule_device_build_dp_buf(FuVolume *esp, const gchar *capsule_path, GE
 	name_with_root = g_strdup_printf("/%s", capsule_path);
 	if (!fu_efi_file_path_device_path_set_name(dp_file, name_with_root, error))
 		return NULL;
-	fu_firmware_add_image(FU_FIRMWARE(dp_buf), FU_FIRMWARE(dp_hd));
-	fu_firmware_add_image(FU_FIRMWARE(dp_buf), FU_FIRMWARE(dp_file));
+	if (!fu_firmware_add_image(FU_FIRMWARE(dp_buf), FU_FIRMWARE(dp_hd), error))
+		return NULL;
+	if (!fu_firmware_add_image(FU_FIRMWARE(dp_buf), FU_FIRMWARE(dp_file), error))
+		return NULL;
 	return g_steal_pointer(&dp_buf);
 }
 

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -130,7 +130,8 @@ fu_uefi_update_info_write(FuFirmware *firmware, GError **error)
 		g_autoptr(FuEfiFilePathDevicePath) dp_fp = fu_efi_file_path_device_path_new();
 		if (!fu_efi_file_path_device_path_set_name(dp_fp, self->capsule_fn, error))
 			return NULL;
-		fu_firmware_add_image(FU_FIRMWARE(dp_list), FU_FIRMWARE(dp_fp));
+		if (!fu_firmware_add_image(FU_FIRMWARE(dp_list), FU_FIRMWARE(dp_fp), error))
+			return NULL;
 		dpbuf = fu_firmware_write(FU_FIRMWARE(dp_list), error);
 		if (dpbuf == NULL)
 			return NULL;

--- a/plugins/uefi-dbx/fu-self-test.c
+++ b/plugins/uefi-dbx/fu-self-test.c
@@ -43,7 +43,7 @@ fu_uefi_dbx_zero_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(csum);
 	fu_firmware_set_bytes(FU_FIRMWARE(sig), csum);
-	fu_firmware_add_image(siglist, FU_FIRMWARE(sig));
+	fu_firmware_add_image(siglist, FU_FIRMWARE(sig), NULL);
 	blob = fu_firmware_write(siglist, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(blob);

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -248,7 +248,8 @@ fu_vbe_simple_device_prepare_firmware(FuDevice *device,
 		    fu_fdt_firmware_get_image_by_path(FU_FDT_FIRMWARE(firmware), path, error);
 		if (img_firmware == NULL)
 			return NULL;
-		fu_firmware_add_image(firmware_container, FU_FIRMWARE(img_firmware));
+		if (!fu_firmware_add_image(firmware_container, FU_FIRMWARE(img_firmware), error))
+			return NULL;
 	}
 
 	/* success: return the container */

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -245,7 +245,7 @@ fu_wac_firmware_tokenize_cb(GString *token, guint token_idx, gpointer user_data,
 		fu_firmware_set_bytes(img, fw_srec);
 		fu_firmware_set_addr(img, fu_firmware_get_addr(firmware_srec));
 		fu_firmware_set_idx(img, helper->images_cnt);
-		if (!fu_firmware_add_image_full(helper->firmware, img, error))
+		if (!fu_firmware_add_image(helper->firmware, img, error))
 			return FALSE;
 		helper->images_cnt++;
 

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -194,7 +194,8 @@ fu_wac_module_bluetooth_id9_prepare_firmware(FuDevice *device,
 		return NULL;
 	loader_fw = fu_firmware_new_from_bytes(loader_bytes);
 	fu_firmware_set_id(loader_fw, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_add_image(firmware, loader_fw);
+	if (!fu_firmware_add_image(firmware, loader_fw, error))
+		return NULL;
 
 	payload_len = blob_len - 2 - loader_len;
 	payload_bytes = fu_bytes_new_offset(fw, 2 + loader_len, payload_len, error);
@@ -202,7 +203,8 @@ fu_wac_module_bluetooth_id9_prepare_firmware(FuDevice *device,
 		return NULL;
 	payload_fw = fu_firmware_new_from_bytes(payload_bytes);
 	fu_firmware_set_id(payload_fw, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(firmware, payload_fw);
+	if (!fu_firmware_add_image(firmware, payload_fw, error))
+		return NULL;
 
 	return g_steal_pointer(&firmware);
 }

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -381,11 +381,14 @@ fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 
 	/* success */
 	fu_firmware_set_id(fw_wsig, FU_FIRMWARE_ID_SIGNATURE);
-	fu_firmware_add_image(fw_new, fw_wsig);
+	if (!fu_firmware_add_image(fw_new, fw_wsig, error))
+		return NULL;
 	fu_firmware_set_id(fw_wdfl, FU_FIRMWARE_ID_HEADER);
-	fu_firmware_add_image(fw_new, fw_wdfl);
+	if (!fu_firmware_add_image(fw_new, fw_wdfl, error))
+		return NULL;
 	fu_firmware_set_id(fw_cbin, FU_FIRMWARE_ID_PAYLOAD);
-	fu_firmware_add_image(fw_new, fw_cbin);
+	if (!fu_firmware_add_image(fw_new, fw_cbin, error))
+		return NULL;
 	return g_steal_pointer(&fw_new);
 }
 

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -95,7 +95,7 @@ fu_cabinet_add_file(FuCabinet *self, const gchar *basename, GBytes *data)
 
 	fu_firmware_set_bytes(FU_FIRMWARE(img), data);
 	fu_firmware_set_id(FU_FIRMWARE(img), basename);
-	fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(img));
+	fu_firmware_add_image(FU_FIRMWARE(self), FU_FIRMWARE(img), NULL);
 }
 
 /* sets the firmware and signature blobs on XbNode */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -5171,6 +5171,7 @@ fu_history_func(gconstpointer user_data)
 static GBytes *
 fu_test_build_cab(gboolean compressed, ...)
 {
+	gboolean ret;
 	va_list args;
 	g_autoptr(FuCabFirmware) cabinet = fu_cab_firmware_new();
 	g_autoptr(GError) error = NULL;
@@ -5201,7 +5202,9 @@ fu_test_build_cab(gboolean compressed, ...)
 		blob = g_bytes_new_static(text, strlen(text));
 		fu_firmware_set_id(FU_FIRMWARE(img), fn);
 		fu_firmware_set_bytes(FU_FIRMWARE(img), blob);
-		fu_firmware_add_image(FU_FIRMWARE(cabinet), FU_FIRMWARE(img));
+		ret = fu_firmware_add_image(FU_FIRMWARE(cabinet), FU_FIRMWARE(img), &error);
+		g_assert_no_error(error);
+		g_assert_true(ret);
 	} while (TRUE);
 	va_end(args);
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -3444,7 +3444,8 @@ fu_util_firmware_convert(FuUtil *self, gchar **values, GError **error)
 	images = fu_firmware_get_images(firmware_src);
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
-		fu_firmware_add_image(firmware_dst, img);
+		if (!fu_firmware_add_image(firmware_dst, img, error))
+			return FALSE;
 	}
 
 	/* copy data as fallback, preferring a binary blob to the export */
@@ -3458,7 +3459,8 @@ fu_util_firmware_convert(FuUtil *self, gchar **values, GError **error)
 				return FALSE;
 		}
 		img = fu_firmware_new_from_bytes(fw);
-		fu_firmware_add_image(firmware_dst, img);
+		if (!fu_firmware_add_image(firmware_dst, img, error))
+			return FALSE;
 	}
 
 	/* write new file */

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1830,7 +1830,8 @@ fu_util_report_export(FuUtil *self, gchar **values, GError **error)
 		payload_blob = g_bytes_new(data, strlen(data));
 		payload_img = fu_firmware_new_from_bytes(payload_blob);
 		fu_firmware_set_id(payload_img, "report.json");
-		fu_firmware_add_image(archive, payload_img);
+		if (!fu_firmware_add_image(archive, payload_img, error))
+			return FALSE;
 
 		/* self sign data */
 		if (self->sign) {
@@ -1848,7 +1849,8 @@ fu_util_report_export(FuUtil *self, gchar **values, GError **error)
 			sig_blob = g_bytes_new(sig, strlen(sig));
 			sig_img = fu_firmware_new_from_bytes(sig_blob);
 			fu_firmware_set_id(sig_img, "report.json.p7c");
-			fu_firmware_add_image(archive, sig_img);
+			if (!fu_firmware_add_image(archive, sig_img, error))
+				return FALSE;
 		}
 
 		/* save to local file */


### PR DESCRIPTION
The fuzzer is full of 'failed to add image: too many images' critical warnings and rather than play file-format whack-a-mole, just convert everything to actually check the image limit.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
