### PR TITLE
trivial: Fix deps when building the fwupdplugin self tests

### DIFF
--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -452,6 +452,7 @@ if get_option('tests')
   e = executable(
     'fwupdplugin-self-test',
     installed_firmware_zip,
+    colorhug_test_firmware,
     rustgen.process('fu-self-test.rs'),
     sources: ['fu-self-test-device.c', 'fu-self-test.c'],
     include_directories: [root_incdir, fwupd_incdir],


### PR DESCRIPTION
This allows us to do 'ninja libfwupdplugin/fwupdplugin-self-test' from a clean configured checkout.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
