### PR TITLE
Use an opaque struct to represent the rustgen struct

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -318,6 +318,16 @@ class Checker:
                 self.add_failure(f"static variable {varname} not allowed")
             break
 
+    def _test_rustgen_vars(self, line: str) -> None:
+        self._current_nocheck = "nocheck:rustgen"
+        if line.find(self._current_nocheck) != -1:
+            return
+        if line.find("g_autoptr(FuStruct") == -1:
+            return
+        tokens = line.split(" ")
+        if not tokens[1].startswith("st"):
+            self.add_failure(f"rustgen structure '{tokens[1]}' has to have 'st' prefix")
+
     def _test_zero_init(self, lines: List[str]) -> None:
         self._current_nocheck = "nocheck:zero-init"
         in_struct: bool = False
@@ -778,6 +788,9 @@ class Checker:
 
             # test for static variables
             self._test_static_vars(line)
+
+            # test for rustgen variables
+            self._test_rustgen_vars(line)
 
         # using too many hardcoded constants
         self._test_gobject_parents(lines)

--- a/contrib/ci/check-unused.py
+++ b/contrib/ci/check-unused.py
@@ -50,6 +50,10 @@ def test_files() -> int:
             continue
         if fnmatch.fnmatch(symb, "fu_struct_*_get_*"):
             continue
+        if fnmatch.fnmatch(symb, "fu_*_ref"):
+            continue
+        if fnmatch.fnmatch(symb, "fu_*_unref"):
+            continue
         if symb.find("__proto__") != -1:
             continue
         if symb in ["main", "fu_plugin_init_vfuncs"]:

--- a/libfwupdplugin/fu-acpi-table.c
+++ b/libfwupdplugin/fu-acpi-table.c
@@ -141,7 +141,7 @@ fu_acpi_table_parse(FuFirmware *firmware,
 	length = fu_struct_acpi_table_get_length(st);
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	if (length > streamsz || length < st->len) {
+	if (length > streamsz || length < st->buf->len) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,

--- a/libfwupdplugin/fu-cfu-offer.c
+++ b/libfwupdplugin/fu-cfu-offer.c
@@ -482,7 +482,7 @@ fu_cfu_offer_write(FuFirmware *firmware, GError **error)
 	fu_struct_cfu_offer_set_product_id(st, priv->product_id);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-cfu-payload.c
+++ b/libfwupdplugin/fu-cfu-payload.c
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+#include "fu-byte-array.h"
 #include "fu-cfu-firmware-struct.h"
 #include "fu-cfu-payload.h"
 #include "fu-input-stream.h"
@@ -47,7 +48,7 @@ fu_cfu_payload_parse(FuFirmware *firmware,
 		st = fu_struct_cfu_payload_parse_stream(stream, offset, error);
 		if (st == NULL)
 			return FALSE;
-		offset += st->len;
+		offset += st->buf->len;
 		chunk_size = fu_struct_cfu_payload_get_size(st);
 		if (chunk_size == 0) {
 			g_set_error_literal(error,
@@ -85,7 +86,7 @@ fu_cfu_payload_write(FuFirmware *firmware, GError **error)
 		g_autoptr(FuStructCfuPayload) st = fu_struct_cfu_payload_new();
 		fu_struct_cfu_payload_set_addr(st, fu_chunk_get_address(chk));
 		fu_struct_cfu_payload_set_size(st, fu_chunk_get_data_sz(chk));
-		g_byte_array_append(buf, st->data, st->len);
+		fu_byte_array_append_array(buf, st->buf);
 		g_byte_array_append(buf, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 	}
 	return g_steal_pointer(&buf);

--- a/libfwupdplugin/fu-dfu-firmware.c
+++ b/libfwupdplugin/fu-dfu-firmware.c
@@ -306,7 +306,7 @@ fu_dfu_firmware_append_footer(FuDfuFirmware *self, GBytes *contents, GError **er
 	fu_struct_dfu_ftr_set_pid(st, priv->pid);
 	fu_struct_dfu_ftr_set_vid(st, priv->vid);
 	fu_struct_dfu_ftr_set_ver(st, priv->dfu_version);
-	g_byte_array_append(buf, st->data, st->len - sizeof(guint32));
+	g_byte_array_append(buf, st->buf->data, st->buf->len - sizeof(guint32));
 	fu_byte_array_append_uint32(buf,
 				    fu_crc32(FU_CRC_KIND_B32_JAMCRC, buf->data, buf->len),
 				    G_LITTLE_ENDIAN);

--- a/libfwupdplugin/fu-edid.c
+++ b/libfwupdplugin/fu-edid.c
@@ -330,8 +330,10 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 			g_prefix_error_literal(error, "cannot write product name: ");
 			return NULL;
 		}
-		memcpy(st->data + offset_desc, st_desc->data, st_desc->len); /* nocheck:blocked */
-		offset_desc += st_desc->len;
+		memcpy(st->buf->data + offset_desc,
+		       st_desc->buf->data,
+		       st_desc->buf->len); /* nocheck:blocked */
+		offset_desc += st_desc->buf->len;
 	}
 	if (self->serial_number != NULL) {
 		g_autoptr(FuStructEdidDescriptor) st_desc = fu_struct_edid_descriptor_new();
@@ -345,8 +347,10 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 			g_prefix_error_literal(error, "cannot write serial number: ");
 			return NULL;
 		}
-		memcpy(st->data + offset_desc, st_desc->data, st_desc->len); /* nocheck:blocked */
-		offset_desc += st_desc->len;
+		memcpy(st->buf->data + offset_desc,
+		       st_desc->buf->data,
+		       st_desc->buf->len); /* nocheck:blocked */
+		offset_desc += st_desc->buf->len;
 	}
 	if (self->eisa_id != NULL) {
 		g_autoptr(FuStructEdidDescriptor) st_desc = fu_struct_edid_descriptor_new();
@@ -359,12 +363,14 @@ fu_edid_write(FuFirmware *firmware, GError **error)
 			g_prefix_error_literal(error, "cannot write EISA ID: ");
 			return NULL;
 		}
-		memcpy(st->data + offset_desc, st_desc->data, st_desc->len); /* nocheck:blocked */
-		offset_desc += st_desc->len;
+		memcpy(st->buf->data + offset_desc,
+		       st_desc->buf->data,
+		       st_desc->buf->len); /* nocheck:blocked */
+		offset_desc += st_desc->buf->len;
 	}
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -129,7 +129,7 @@ fu_efi_device_path_list_write(FuFirmware *firmware, GError **error)
 	st_dp_end = fu_struct_efi_device_path_new();
 	fu_struct_efi_device_path_set_type(st_dp_end, FU_EFI_DEVICE_PATH_TYPE_END);
 	fu_struct_efi_device_path_set_subtype(st_dp_end, 0xFF);
-	g_byte_array_append(buf, st_dp_end->data, st_dp_end->len);
+	fu_byte_array_append_array(buf, st_dp_end->buf);
 
 	/* success */
 	return g_steal_pointer(&buf);

--- a/libfwupdplugin/fu-efi-device-path.c
+++ b/libfwupdplugin/fu-efi-device-path.c
@@ -124,9 +124,13 @@ fu_efi_device_path_parse(FuFirmware *firmware,
 			fu_struct_efi_device_path_get_length(st),
 			(guint)dp_length);
 	}
-	if (dp_length > st->len) {
-		g_autoptr(GBytes) payload =
-		    fu_input_stream_read_bytes(stream, st->len, dp_length - st->len, NULL, error);
+	if (dp_length > st->buf->len) {
+		g_autoptr(GBytes) payload = NULL;
+		payload = fu_input_stream_read_bytes(stream,
+						     st->buf->len,
+						     dp_length - st->buf->len,
+						     NULL,
+						     error);
 		if (payload == NULL)
 			return FALSE;
 		fu_firmware_set_bytes(firmware, payload);
@@ -151,11 +155,11 @@ fu_efi_device_path_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	fu_struct_efi_device_path_set_type(st, fu_firmware_get_idx(firmware));
 	fu_struct_efi_device_path_set_subtype(st, priv->subtype);
-	fu_struct_efi_device_path_set_length(st, st->len + g_bytes_get_size(payload));
-	fu_byte_array_append_bytes(st, payload);
+	fu_struct_efi_device_path_set_length(st, st->buf->len + g_bytes_get_size(payload));
+	fu_byte_array_append_bytes(st->buf, payload);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -102,14 +102,14 @@ fu_efi_file_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		fu_struct_efi_file_unref(st);
-		st = fu_struct_efi_file2_parse_stream(stream, 0x0, error);
+		st = (FuStructEfiFile *)fu_struct_efi_file2_parse_stream(stream, 0x0, error);
 		if (st == NULL)
 			return FALSE;
-		size = fu_struct_efi_file2_get_extended_size(st);
+		size = fu_struct_efi_file2_get_extended_size((FuStructEfiFile2 *)st);
 	} else {
 		size = fu_struct_efi_file_get_size(st);
 	}
-	if (size < st->len) {
+	if (size < st->buf->len) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
@@ -123,7 +123,7 @@ fu_efi_file_parse(FuFirmware *firmware,
 		guint8 hdr_checksum_verify;
 		g_autoptr(GBytes) hdr_blob = NULL;
 
-		hdr_blob = fu_input_stream_read_bytes(stream, 0x0, st->len, NULL, error);
+		hdr_blob = fu_input_stream_read_bytes(stream, 0x0, st->buf->len, NULL, error);
 		if (hdr_blob == NULL)
 			return FALSE;
 		hdr_checksum_verify = fu_efi_file_hdr_checksum8(hdr_blob);
@@ -139,7 +139,8 @@ fu_efi_file_parse(FuFirmware *firmware,
 	}
 
 	/* add simple blob */
-	partial_stream = fu_partial_input_stream_new(stream, st->len, size - st->len, error);
+	partial_stream =
+	    fu_partial_input_stream_new(stream, st->buf->len, size - st->buf->len, error);
 	if (partial_stream == NULL) {
 		g_prefix_error_literal(error, "failed to cut EFI blob: ");
 		return FALSE;
@@ -254,15 +255,15 @@ fu_efi_file_write(FuFirmware *firmware, GError **error)
 	fu_struct_efi_file_set_data_checksum(st, 0x100 - fu_sum8_bytes(blob));
 	fu_struct_efi_file_set_type(st, priv->type);
 	fu_struct_efi_file_set_attrs(st, priv->attrib);
-	fu_struct_efi_file_set_size(st, g_bytes_get_size(blob) + st->len);
+	fu_struct_efi_file_set_size(st, g_bytes_get_size(blob) + st->buf->len);
 
 	/* fix up header checksum */
-	hdr_blob = g_bytes_new_static(st->data, st->len);
+	hdr_blob = g_bytes_new_static(st->buf->data, st->buf->len);
 	fu_struct_efi_file_set_hdr_checksum(st, fu_efi_file_hdr_checksum8(hdr_blob));
 
 	/* success */
-	fu_byte_array_append_bytes(st, blob);
-	return g_steal_pointer(&st);
+	fu_byte_array_append_bytes(st->buf, blob);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-ftw-store.c
+++ b/libfwupdplugin/fu-efi-ftw-store.c
@@ -80,14 +80,14 @@ fu_efi_ftw_store_parse(FuFirmware *firmware,
 	/* data area */
 	blob = fu_input_stream_read_bytes(
 	    stream,
-	    st->len,
+	    st->buf->len,
 	    fu_struct_efi_fault_tolerant_working_block_header64_get_write_queue_size(st),
 	    NULL,
 	    error);
 	if (blob == NULL)
 		return FALSE;
 	fu_firmware_set_bytes(firmware, blob);
-	fu_firmware_set_size(firmware, st->len + g_bytes_get_size(blob));
+	fu_firmware_set_size(firmware, st->buf->len + g_bytes_get_size(blob));
 
 	/* success */
 	return TRUE;
@@ -112,14 +112,14 @@ fu_efi_ftw_store_write(FuFirmware *firmware, GError **error)
 	    g_bytes_get_size(blob));
 	fu_struct_efi_fault_tolerant_working_block_header64_set_crc(
 	    st,
-	    fu_crc32(FU_CRC_KIND_B32_STANDARD, st->data, st->len));
+	    fu_crc32(FU_CRC_KIND_B32_STANDARD, st->buf->data, st->buf->len));
 
 	/* attrs + data area */
 	fu_struct_efi_fault_tolerant_working_block_header64_set_state(st, self->state);
-	fu_byte_array_append_bytes(st, blob);
+	fu_byte_array_append_bytes(st->buf, blob);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-hard-drive-device-path.c
+++ b/libfwupdplugin/fu-efi-hard-drive-device-path.c
@@ -111,7 +111,7 @@ fu_efi_hard_drive_device_path_parse(FuFirmware *firmware,
 	self->signature_type = fu_struct_efi_hard_drive_device_path_get_signature_type(st);
 
 	/* success */
-	fu_firmware_set_size(firmware, fu_struct_efi_device_path_get_length(st));
+	fu_firmware_set_size(firmware, st->buf->len);
 	return TRUE;
 }
 
@@ -131,7 +131,7 @@ fu_efi_hard_drive_device_path_write(FuFirmware *firmware, GError **error)
 	fu_struct_efi_hard_drive_device_path_set_signature_type(st, self->signature_type);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -188,7 +188,7 @@ fu_efi_load_option_parse_optional_hive(FuEfiLoadOption *self,
 		st_item = fu_struct_shim_hive_item_parse_stream(stream, offset, error);
 		if (st_item == NULL)
 			return FALSE;
-		offset += st_item->len;
+		offset += st_item->buf->len;
 
 		/* key */
 		keysz = fu_struct_shim_hive_item_get_key_length(st_item);
@@ -305,7 +305,7 @@ fu_efi_load_option_parse(FuFirmware *firmware,
 	if (st == NULL)
 		return FALSE;
 	self->attrs = fu_struct_efi_load_option_get_attrs(st);
-	offset += st->len;
+	offset += st->buf->len;
 
 	/* parse UTF-16 description */
 	if (!fu_input_stream_size(stream, &streamsz, error))
@@ -374,22 +374,24 @@ fu_efi_load_option_write_hive(FuEfiLoadOption *self, GError **error)
 		fu_struct_shim_hive_item_set_key_length(st_item, keysz);
 		fu_struct_shim_hive_item_set_value_length(st_item, value_safe->len);
 		if (keysz > 0)
-			g_byte_array_append(st_item, (const guint8 *)key, keysz);
+			g_byte_array_append(st_item->buf, (const guint8 *)key, keysz);
 		if (value_safe->len > 0) {
-			g_byte_array_append(st_item,
+			g_byte_array_append(st_item->buf,
 					    (const guint8 *)value_safe->str,
 					    value_safe->len);
 		}
 
 		/* add to hive */
-		g_byte_array_append(st, st_item->data, st_item->len);
+		fu_byte_array_append_array(st->buf, st_item->buf);
 	}
 
 	/* this covers all items, and so has to be done last */
-	fu_struct_shim_hive_set_crc32(st, fu_crc32(FU_CRC_KIND_B32_STANDARD, st->data, st->len));
+	fu_struct_shim_hive_set_crc32(
+	    st,
+	    fu_crc32(FU_CRC_KIND_B32_STANDARD, st->buf->data, st->buf->len));
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static GByteArray *
@@ -436,14 +438,14 @@ fu_efi_load_option_write(FuFirmware *firmware, GError **error)
 						error);
 	if (buf_utf16 == NULL)
 		return NULL;
-	g_byte_array_append(st, buf_utf16->data, buf_utf16->len);
+	g_byte_array_append(st->buf, buf_utf16->data, buf_utf16->len);
 
 	/* dpbuf */
 	dpbuf = fu_firmware_get_image_by_gtype_bytes(firmware, FU_TYPE_EFI_DEVICE_PATH_LIST, error);
 	if (dpbuf == NULL)
 		return NULL;
 	fu_struct_efi_load_option_set_dp_size(st, g_bytes_get_size(dpbuf));
-	fu_byte_array_append_bytes(st, dpbuf);
+	fu_byte_array_append_bytes(st->buf, dpbuf);
 
 	/* hive, path or data */
 	if (self->kind == FU_EFI_LOAD_OPTION_KIND_HIVE) {
@@ -451,20 +453,20 @@ fu_efi_load_option_write(FuFirmware *firmware, GError **error)
 		buf_hive = fu_efi_load_option_write_hive(self, error);
 		if (buf_hive == NULL)
 			return NULL;
-		g_byte_array_append(st, buf_hive->data, buf_hive->len);
-		fu_byte_array_align_up(st, FU_FIRMWARE_ALIGNMENT_512, 0x0); /* make atomic */
+		g_byte_array_append(st->buf, buf_hive->data, buf_hive->len);
+		fu_byte_array_align_up(st->buf, FU_FIRMWARE_ALIGNMENT_512, 0x0); /* make atomic */
 	} else if (self->kind == FU_EFI_LOAD_OPTION_KIND_PATH) {
 		g_autoptr(GByteArray) buf_path = NULL;
 		buf_path = fu_efi_load_option_write_path(self, error);
 		if (buf_path == NULL)
 			return NULL;
-		g_byte_array_append(st, buf_path->data, buf_path->len);
+		g_byte_array_append(st->buf, buf_path->data, buf_path->len);
 	} else if (self->kind == FU_EFI_LOAD_OPTION_KIND_DATA && self->optional_data != NULL) {
-		fu_byte_array_append_bytes(st, self->optional_data);
+		fu_byte_array_append_bytes(st->buf, self->optional_data);
 	}
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-lz77-decompressor.c
+++ b/libfwupdplugin/fu-efi-lz77-decompressor.c
@@ -623,7 +623,7 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 	if (st == NULL)
 		return FALSE;
 	src_bufsz = fu_struct_efi_lz77_decompressor_header_get_src_size(st);
-	if (streamsz < src_bufsz + st->len) {
+	if (streamsz < src_bufsz + st->buf->len) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
@@ -659,7 +659,7 @@ fu_efi_lz77_decompressor_parse(FuFirmware *firmware,
 		};
 		g_autoptr(GError) error_local = NULL;
 
-		if (!g_seekable_seek(G_SEEKABLE(stream), st->len, G_SEEK_SET, NULL, error))
+		if (!g_seekable_seek(G_SEEKABLE(stream), st->buf->len, G_SEEK_SET, NULL, error))
 			return FALSE;
 		if (fu_efi_lz77_decompressor_internal(&helper,
 						      decompressor_versions[i],

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -166,14 +166,18 @@ fu_efi_section_parse_compression_sections(FuEfiSection *self,
 		return FALSE;
 	if (fu_struct_efi_section_compression_get_compression_type(st) ==
 	    FU_EFI_COMPRESSION_TYPE_NOT_COMPRESSED) {
-		if (!fu_efi_parse_sections(FU_FIRMWARE(self), stream, st->len, flags, error)) {
+		if (!fu_efi_parse_sections(FU_FIRMWARE(self), stream, st->buf->len, flags, error)) {
 			g_prefix_error_literal(error, "failed to parse sections: ");
 			return FALSE;
 		}
 	} else {
 		g_autoptr(FuFirmware) lz77_decompressor = fu_efi_lz77_decompressor_new();
 		g_autoptr(GInputStream) lz77_stream = NULL;
-		if (!fu_firmware_parse_stream(lz77_decompressor, stream, st->len, flags, error))
+		if (!fu_firmware_parse_stream(lz77_decompressor,
+					      stream,
+					      st->buf->len,
+					      flags,
+					      error))
 			return FALSE;
 		lz77_stream = fu_firmware_get_stream(lz77_decompressor, error);
 		if (lz77_stream == NULL)
@@ -252,6 +256,7 @@ fu_efi_section_parse(FuFirmware *firmware,
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
 	gsize offset = 0;
 	gsize streamsz = 0;
+	gsize stlen = 0;
 	guint32 size;
 	g_autoptr(FuStructEfiSection) st = NULL;
 	g_autoptr(GInputStream) partial_stream = NULL;
@@ -263,13 +268,17 @@ fu_efi_section_parse(FuFirmware *firmware,
 
 	/* use extended size */
 	if (fu_struct_efi_section_get_size(st) == 0xFFFFFF) {
-		fu_struct_efi_section_unref(st);
-		st = fu_struct_efi_section2_parse_stream(stream, offset, error);
-		if (st == NULL)
+		g_autoptr(FuStructEfiSection2) st2 = NULL;
+		st2 = fu_struct_efi_section2_parse_stream(stream, offset, error);
+		if (st2 == NULL)
 			return FALSE;
-		size = fu_struct_efi_section2_get_extended_size(st);
+		priv->type = fu_struct_efi_section2_get_type(st2);
+		size = fu_struct_efi_section2_get_extended_size(st2);
+		stlen = st2->buf->len;
 	} else {
+		priv->type = fu_struct_efi_section_get_type(st);
 		size = fu_struct_efi_section_get_size(st);
+		stlen = st->buf->len;
 	}
 	if (size < FU_STRUCT_EFI_SECTION_SIZE) {
 		g_set_error(error,
@@ -294,17 +303,16 @@ fu_efi_section_parse(FuFirmware *firmware,
 	}
 
 	/* name */
-	priv->type = fu_struct_efi_section_get_type(st);
 	if (priv->type == FU_EFI_SECTION_TYPE_GUID_DEFINED) {
 		g_autofree gchar *guid_str = NULL;
 		g_autoptr(FuStructEfiSectionGuidDefined) st_def = NULL;
-		st_def = fu_struct_efi_section_guid_defined_parse_stream(stream, st->len, error);
+		st_def = fu_struct_efi_section_guid_defined_parse_stream(stream, stlen, error);
 		if (st_def == NULL)
 			return FALSE;
 		guid_str = fwupd_guid_to_string(fu_struct_efi_section_guid_defined_get_name(st_def),
 						FWUPD_GUID_FLAG_MIXED_ENDIAN);
 		fu_firmware_set_id(firmware, guid_str);
-		if (fu_struct_efi_section_guid_defined_get_offset(st_def) < st_def->len) {
+		if (fu_struct_efi_section_guid_defined_get_offset(st_def) < st_def->buf->len) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
@@ -312,11 +320,11 @@ fu_efi_section_parse(FuFirmware *firmware,
 				    (guint)fu_struct_efi_section_guid_defined_get_offset(st_def));
 			return FALSE;
 		}
-		offset += fu_struct_efi_section_guid_defined_get_offset(st_def) - st->len;
+		offset += fu_struct_efi_section_guid_defined_get_offset(st_def) - stlen;
 	}
 
 	/* create blob */
-	offset += st->len;
+	offset += stlen;
 	partial_stream = fu_partial_input_stream_new(stream, offset, size - offset, error);
 	if (partial_stream == NULL) {
 		g_prefix_error_literal(error, "failed to cut data: ");
@@ -398,7 +406,7 @@ fu_efi_section_write(FuFirmware *firmware, GError **error)
 {
 	FuEfiSection *self = FU_EFI_SECTION(firmware);
 	FuEfiSectionPrivate *priv = GET_PRIVATE(self);
-	g_autoptr(FuStructEfiSection) buf = fu_struct_efi_section_new();
+	g_autoptr(FuStructEfiSection) st = fu_struct_efi_section_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	/* simple blob for now */
@@ -417,15 +425,16 @@ fu_efi_section_write(FuFirmware *firmware, GError **error)
 					    error))
 			return NULL;
 		fu_struct_efi_section_guid_defined_set_name(st_def, &guid);
-		fu_struct_efi_section_guid_defined_set_offset(st_def, buf->len + st_def->len);
-		g_byte_array_append(buf, st_def->data, st_def->len);
+		fu_struct_efi_section_guid_defined_set_offset(st_def,
+							      st->buf->len + st_def->buf->len);
+		fu_byte_array_append_array(st->buf, st_def->buf);
 	}
-	fu_struct_efi_section_set_type(buf, priv->type);
-	fu_struct_efi_section_set_size(buf, buf->len + g_bytes_get_size(blob));
+	fu_struct_efi_section_set_type(st, priv->type);
+	fu_struct_efi_section_set_size(st, st->buf->len + g_bytes_get_size(blob));
 
 	/* blob */
-	fu_byte_array_append_bytes(buf, blob);
-	return g_steal_pointer(&buf);
+	fu_byte_array_append_bytes(st->buf, blob);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -240,14 +240,14 @@ fu_efi_signature_list_write_x509(FuEfiSignature *sig, GError **error)
 	blob = fu_firmware_write(FU_FIRMWARE(sig), error);
 	if (blob == NULL)
 		return NULL;
-	fu_byte_array_append_bytes(st, blob);
+	fu_byte_array_append_bytes(st->buf, blob);
 	fu_struct_efi_signature_list_set_size(st, g_bytes_get_size(blob));
 	fu_struct_efi_signature_list_set_list_size(st,
 						   FU_STRUCT_EFI_SIGNATURE_LIST_SIZE +
 						       g_bytes_get_size(blob));
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static GByteArray *
@@ -272,15 +272,15 @@ fu_efi_signature_list_write_sha256(GPtrArray *sigs, GError **error)
 		img_blob = fu_firmware_write(FU_FIRMWARE(sig), error);
 		if (img_blob == NULL)
 			return NULL;
-		fu_byte_array_append_bytes(st, img_blob);
+		fu_byte_array_append_bytes(st->buf, img_blob);
 	}
 
 	/* fix up header */
 	fu_struct_efi_signature_list_set_size(st, sizeof(fwupd_guid_t) + 32); /* SHA256 */
-	fu_struct_efi_signature_list_set_list_size(st, st->len);
+	fu_struct_efi_signature_list_set_list_size(st, st->buf->len);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static GByteArray *

--- a/libfwupdplugin/fu-efi-variable-authentication2.c
+++ b/libfwupdplugin/fu-efi-variable-authentication2.c
@@ -181,12 +181,12 @@ fu_efi_variable_authentication2_parse(FuFirmware *firmware,
 
 	/* parse the EFI_SIGNATURE_LIST blob past the EFI_TIME + WIN_CERTIFICATE */
 	st_wincert = fu_struct_efi_variable_authentication2_get_auth_info(st);
-	if (fu_struct_efi_win_certificate_get_length(st_wincert) > st_wincert->len) {
+	if (fu_struct_efi_win_certificate_get_length(st_wincert) > st_wincert->buf->len) {
 		g_autoptr(GByteArray) buf = NULL;
 		buf = fu_input_stream_read_byte_array(
 		    stream,
-		    offset + st_wincert->len + offset_tmp,
-		    fu_struct_efi_win_certificate_get_length(st_wincert) - st_wincert->len,
+		    offset + st_wincert->buf->len + offset_tmp,
+		    fu_struct_efi_win_certificate_get_length(st_wincert) - st_wincert->buf->len,
 		    NULL,
 		    error);
 		if (buf == NULL)
@@ -210,17 +210,17 @@ fu_efi_variable_authentication2_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(FuStructEfiVariableAuthentication2) st =
 	    fu_struct_efi_variable_authentication2_new();
-	g_autoptr(GByteArray) st_parent = NULL;
+	g_autoptr(GByteArray) buf = NULL;
 
 	/* append EFI_SIGNATURE_LIST */
-	st_parent =
+	buf =
 	    FU_FIRMWARE_CLASS(fu_efi_variable_authentication2_parent_class)->write(firmware, error);
-	if (st_parent == NULL)
+	if (buf == NULL)
 		return NULL;
-	g_byte_array_append(st, st_parent->data, st_parent->len);
+	fu_byte_array_append_array(st->buf, buf);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-vss-auth-variable.c
+++ b/libfwupdplugin/fu-efi-vss-auth-variable.c
@@ -135,7 +135,7 @@ fu_efi_vss_auth_variable_parse(FuFirmware *firmware,
 	self->timestamp = fu_struct_efi_vss_auth_variable_header_get_timestamp(st);
 
 	/* read name */
-	offset += st->len;
+	offset += st->buf->len;
 	buf_name = fu_input_stream_read_byte_array(
 	    stream,
 	    offset,
@@ -239,11 +239,11 @@ fu_efi_vss_auth_variable_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* concat */
-	fu_byte_array_append_bytes(st, name);
-	fu_byte_array_append_bytes(st, blob);
+	fu_byte_array_append_bytes(st->buf, name);
+	fu_byte_array_append_bytes(st->buf, blob);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-efi.rs
+++ b/libfwupdplugin/fu-efi.rs
@@ -118,10 +118,11 @@ struct FuStructEfiSection {
     type: FuEfiSectionType,
 }
 
-#[derive(ParseStream)]
+#[derive(ParseStream, Default)]
 #[repr(C, packed)]
 struct FuStructEfiSection2 {
-    _base: FuStructEfiSection,
+    size: u24le == 0xFFFFFF,
+    type: FuEfiSectionType,
     extended_size: u32le,
 }
 

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -47,7 +47,7 @@ fu_elf_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuStructElfFileHeader64le) st_fhdr = NULL;
 	g_autoptr(GByteArray) shstrndx_buf = NULL;
 	g_autoptr(GPtrArray) sections =
-	    g_ptr_array_new_with_free_func((GDestroyNotify)g_byte_array_unref);
+	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_struct_elf_section_header64le_unref);
 
 	/* file header */
 	st_fhdr = fu_struct_elf_file_header64le_parse_stream(stream, 0x0, error);
@@ -288,7 +288,7 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* calculate the offset of each section */
-	section_offset = st_filehdr->len + st_proghdr->len + shstrtab->len;
+	section_offset = st_filehdr->buf->len + st_proghdr->buf->len + shstrtab->len;
 	for (guint i = 0; i < imgs->len; i++) {
 		FuFirmware *img = g_ptr_array_index(imgs, i);
 		fu_firmware_set_offset(img, section_offset);
@@ -305,7 +305,7 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 	if (imgs->len > 0) {
 		g_autoptr(FuStructElfSectionHeader64le) st_secthdr =
 		    fu_struct_elf_section_header64le_new();
-		g_byte_array_append(section_hdr, st_secthdr->data, st_secthdr->len);
+		fu_byte_array_append_array(section_hdr, st_secthdr->buf);
 	}
 	for (guint i = 0; i < imgs->len; i++) {
 		FuFirmware *img = g_ptr_array_index(imgs, i);
@@ -323,7 +323,7 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 		fu_struct_elf_section_header64le_set_offset(st_secthdr,
 							    fu_firmware_get_offset(img));
 		fu_struct_elf_section_header64le_set_size(st_secthdr, fu_firmware_get_size(img));
-		g_byte_array_append(section_hdr, st_secthdr->data, st_secthdr->len);
+		fu_byte_array_append_array(section_hdr, st_secthdr->buf);
 	}
 	if (shstrtab->len > 0) {
 		g_autoptr(FuStructElfSectionHeader64le) st_secthdr =
@@ -333,15 +333,16 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 		fu_struct_elf_section_header64le_set_type(st_secthdr,
 							  FU_ELF_SECTION_HEADER_TYPE_STRTAB);
 		fu_struct_elf_section_header64le_set_offset(st_secthdr,
-							    st_filehdr->len + st_proghdr->len);
+							    st_filehdr->buf->len +
+								st_proghdr->buf->len);
 		fu_struct_elf_section_header64le_set_size(st_secthdr, shstrtab->len);
-		g_byte_array_append(section_hdr, st_secthdr->data, st_secthdr->len);
+		fu_byte_array_append_array(section_hdr, st_secthdr->buf);
 	}
 
 	/* update with the new totals */
 	fu_struct_elf_file_header64le_set_entry(st_filehdr, physical_addr + 0x60);
 	fu_struct_elf_file_header64le_set_shoff(st_filehdr,
-						st_filehdr->len + st_proghdr->len +
+						st_filehdr->buf->len + st_proghdr->buf->len +
 						    section_data->len);
 	fu_struct_elf_file_header64le_set_phentsize(st_filehdr,
 						    FU_STRUCT_ELF_PROGRAM_HEADER64LE_SIZE);
@@ -353,17 +354,17 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 	fu_struct_elf_program_header64le_set_vaddr(st_proghdr, physical_addr);
 	fu_struct_elf_program_header64le_set_paddr(st_proghdr, physical_addr);
 	fu_struct_elf_program_header64le_set_filesz(st_proghdr,
-						    st_filehdr->len + st_proghdr->len +
+						    st_filehdr->buf->len + st_proghdr->buf->len +
 							section_data->len + section_hdr->len);
 	fu_struct_elf_program_header64le_set_memsz(st_proghdr,
-						   st_filehdr->len + st_proghdr->len +
+						   st_filehdr->buf->len + st_proghdr->buf->len +
 						       section_data->len + section_hdr->len);
 
 	/* add file header, sections, then section headers */
-	g_byte_array_append(buf, st_filehdr->data, st_filehdr->len);
-	g_byte_array_append(buf, st_proghdr->data, st_proghdr->len);
-	g_byte_array_append(buf, section_data->data, section_data->len);
-	g_byte_array_append(buf, section_hdr->data, section_hdr->len);
+	fu_byte_array_append_array(buf, st_filehdr->buf);
+	fu_byte_array_append_array(buf, st_proghdr->buf);
+	fu_byte_array_append_array(buf, section_data);
+	fu_byte_array_append_array(buf, section_hdr);
 	return g_steal_pointer(&buf);
 }
 

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -253,7 +253,7 @@ fu_fdt_firmware_parse_dt_struct(FuFdtFirmware *self, GBytes *fw, GByteArray *str
 				return FALSE;
 			prop_len = fu_struct_fdt_prop_get_len(st_prp);
 			prop_nameoff = fu_struct_fdt_prop_get_nameoff(st_prp);
-			offset += st_prp->len;
+			offset += st_prp->buf->len;
 
 			/* add property */
 			str = fu_fdt_firmware_string_new_safe(strtab->data,
@@ -479,7 +479,7 @@ fu_fdt_firmware_write_image(FuFdtFirmware *self,
 		fu_struct_fdt_prop_set_len(st_prp, g_bytes_get_size(blob));
 		fu_struct_fdt_prop_set_nameoff(st_prp,
 					       fu_fdt_firmware_append_to_strtab(helper, key));
-		g_byte_array_append(helper->dt_struct, st_prp->data, st_prp->len);
+		fu_byte_array_append_array(helper->dt_struct, st_prp->buf);
 		fu_byte_array_append_bytes(helper->dt_struct, blob);
 		fu_byte_array_align_up(helper->dt_struct, FU_FIRMWARE_ALIGNMENT_4, 0x0);
 	}
@@ -509,19 +509,19 @@ fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 	g_autoptr(GHashTable) strtab = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(FuStructFdt) st_hdr = fu_struct_fdt_new();
-	g_autoptr(FuStructFdtReserveEntry) mem_rsvmap = fu_struct_fdt_reserve_entry_new();
+	g_autoptr(FuStructFdtReserveEntry) st_rsvmap = fu_struct_fdt_reserve_entry_new();
 	FuFdtFirmwareBuildHelper helper = {
 	    .dt_strings = dt_strings,
 	    .dt_struct = dt_struct,
 	    .strtab = strtab,
 	};
 
-	/* empty mem_rsvmap */
-	off_mem_rsvmap = fu_common_align_up(st_hdr->len, FU_FIRMWARE_ALIGNMENT_4);
+	/* empty st_rsvmap */
+	off_mem_rsvmap = fu_common_align_up(st_hdr->buf->len, FU_FIRMWARE_ALIGNMENT_4);
 
 	/* dt_struct */
 	off_dt_struct =
-	    fu_common_align_up(off_mem_rsvmap + mem_rsvmap->len, FU_FIRMWARE_ALIGNMENT_4);
+	    fu_common_align_up(off_mem_rsvmap + st_rsvmap->buf->len, FU_FIRMWARE_ALIGNMENT_4);
 
 	/* only one root node supported */
 	if (images->len != 1) {
@@ -549,18 +549,18 @@ fu_fdt_firmware_write(FuFirmware *firmware, GError **error)
 	fu_struct_fdt_set_boot_cpuid_phys(st_hdr, priv->cpuid);
 	fu_struct_fdt_set_size_dt_strings(st_hdr, dt_strings->len);
 	fu_struct_fdt_set_size_dt_struct(st_hdr, dt_struct->len);
-	fu_byte_array_align_up(st_hdr, FU_FIRMWARE_ALIGNMENT_4, 0x0);
+	fu_byte_array_align_up(st_hdr->buf, FU_FIRMWARE_ALIGNMENT_4, 0x0);
 
-	/* write mem_rsvmap, dt_struct, dt_strings */
-	g_byte_array_append(st_hdr, mem_rsvmap->data, mem_rsvmap->len);
-	fu_byte_array_align_up(st_hdr, FU_FIRMWARE_ALIGNMENT_4, 0x0);
-	g_byte_array_append(st_hdr, dt_struct->data, dt_struct->len);
-	fu_byte_array_align_up(st_hdr, FU_FIRMWARE_ALIGNMENT_4, 0x0);
-	g_byte_array_append(st_hdr, dt_strings->data, dt_strings->len);
-	fu_byte_array_align_up(st_hdr, FU_FIRMWARE_ALIGNMENT_4, 0x0);
+	/* write st_rsvmap, dt_struct, dt_strings */
+	fu_byte_array_append_array(st_hdr->buf, st_rsvmap->buf);
+	fu_byte_array_align_up(st_hdr->buf, FU_FIRMWARE_ALIGNMENT_4, 0x0);
+	fu_byte_array_append_array(st_hdr->buf, dt_struct);
+	fu_byte_array_align_up(st_hdr->buf, FU_FIRMWARE_ALIGNMENT_4, 0x0);
+	fu_byte_array_append_array(st_hdr->buf, dt_strings);
+	fu_byte_array_align_up(st_hdr->buf, FU_FIRMWARE_ALIGNMENT_4, 0x0);
 
 	/* success */
-	return g_steal_pointer(&st_hdr);
+	return g_steal_pointer(&st_hdr->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-heci-device.c
+++ b/libfwupdplugin/fu-heci-device.c
@@ -69,8 +69,8 @@ fu_heci_device_read_file(FuHeciDevice *self, const gchar *filename, GError **err
 	fu_mkhi_read_file_request_set_data_size(st_req, datasz_req);
 	fu_mkhi_read_file_request_set_flags(st_req, (1 << 3)); /* ?? */
 	if (!fu_mei_device_write(FU_MEI_DEVICE(self),
-				 st_req->data,
-				 st_req->len,
+				 st_req->buf->data,
+				 st_req->buf->len,
 				 FU_HECI_DEVICE_TIMEOUT,
 				 error))
 		return NULL;
@@ -103,7 +103,7 @@ fu_heci_device_read_file(FuHeciDevice *self, const gchar *filename, GError **err
 	}
 
 	/* success */
-	g_byte_array_append(bufout, &buf_res->data[st_res->len], data_size);
+	g_byte_array_append(bufout, &buf_res->data[st_res->buf->len], data_size);
 	return g_steal_pointer(&bufout);
 }
 
@@ -142,8 +142,8 @@ fu_heci_device_read_file_ex(FuHeciDevice *self,
 	fu_mkhi_read_file_ex_request_set_data_size(st_req, datasz_req);
 	fu_mkhi_read_file_ex_request_set_flags(st_req, section);
 	if (!fu_mei_device_write(FU_MEI_DEVICE(self),
-				 st_req->data,
-				 st_req->len,
+				 st_req->buf->data,
+				 st_req->buf->len,
 				 FU_HECI_DEVICE_TIMEOUT,
 				 error))
 		return NULL;
@@ -177,7 +177,7 @@ fu_heci_device_read_file_ex(FuHeciDevice *self,
 	}
 
 	/* success */
-	g_byte_array_append(bufout, &buf_res->data[st_res->len], data_size);
+	g_byte_array_append(bufout, &buf_res->data[st_res->buf->len], data_size);
 	return g_steal_pointer(&bufout);
 }
 
@@ -214,8 +214,8 @@ fu_heci_device_arbh_svn_get_info(FuHeciDevice *self,
 
 	/* request */
 	if (!fu_mei_device_write(FU_MEI_DEVICE(self),
-				 st_req->data,
-				 st_req->len,
+				 st_req->buf->data,
+				 st_req->buf->len,
 				 FU_HECI_DEVICE_TIMEOUT,
 				 error))
 		return FALSE;
@@ -238,7 +238,7 @@ fu_heci_device_arbh_svn_get_info(FuHeciDevice *self,
 
 	/* verify we got what we asked for */
 	num_entries = fu_mkhi_arbh_svn_get_info_response_get_num_entries(st_res);
-	offset += st_res->len;
+	offset += st_res->buf->len;
 	for (guint32 i = 0; i < num_entries; i++) {
 		g_autoptr(FuMkhiArbhSvnInfoEntry) st_entry = NULL;
 
@@ -260,7 +260,7 @@ fu_heci_device_arbh_svn_get_info(FuHeciDevice *self,
 		}
 
 		/* next */
-		offset += st_entry->len;
+		offset += st_entry->buf->len;
 	}
 
 	/* did not find */

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -381,10 +381,10 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 	if (!fu_memcpy_safe(buf->data,
 			    buf->len,
 			    0x0,
-			    st_fdbar->data,
-			    st_fdbar->len,
+			    st_fdbar->buf->data,
+			    st_fdbar->buf->len,
 			    0x0,
-			    st_fdbar->len,
+			    st_fdbar->buf->len,
 			    error))
 		return NULL;
 
@@ -395,10 +395,10 @@ fu_ifd_firmware_write(FuFirmware *firmware, GError **error)
 	if (!fu_memcpy_safe(buf->data,
 			    buf->len,
 			    priv->flash_component_base_addr,
-			    st_fcba->data,
-			    st_fcba->len,
+			    st_fcba->buf->data,
+			    st_fcba->buf->len,
 			    0x0,
-			    st_fcba->len,
+			    st_fcba->buf->len,
 			    error))
 		return NULL;
 

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -11,6 +11,7 @@
 
 #include "config.h"
 
+#include "fu-byte-array.h"
 #include "fu-common.h"
 #include "fu-input-stream.h"
 #include "fu-intel-thunderbolt-nvm.h"
@@ -588,22 +589,22 @@ fu_intel_thunderbolt_nvm_write(FuFirmware *firmware, GError **error)
 	fu_intel_thunderbolt_nvm_digital_set_flags_is_native(st, priv->is_native ? 0x20 : 0x0);
 
 	/* drom section */
-	fu_intel_thunderbolt_nvm_digital_set_drom(st, st->len);
+	fu_intel_thunderbolt_nvm_digital_set_drom(st, st->buf->len);
 	fu_intel_thunderbolt_nvm_drom_set_vendor_id(st_drom, priv->vendor_id);
 	fu_intel_thunderbolt_nvm_drom_set_model_id(st_drom, priv->model_id);
-	g_byte_array_append(st, st_drom->data, st_drom->len);
+	fu_byte_array_append_array(st->buf, st_drom->buf);
 
 	/* ARC param section */
-	fu_intel_thunderbolt_nvm_digital_set_arc_params(st, st->len);
+	fu_intel_thunderbolt_nvm_digital_set_arc_params(st, st->buf->len);
 	fu_intel_thunderbolt_nvm_arc_params_set_pd_pointer(st_arc, priv->has_pd ? 0x1 : 0x0);
-	g_byte_array_append(st, st_arc->data, st_arc->len);
+	fu_byte_array_append_array(st->buf, st_arc->buf);
 
 	/* dram section */
-	fu_intel_thunderbolt_nvm_digital_set_ucode(st, st->len);
-	g_byte_array_append(st, st_dram->data, st_dram->len);
+	fu_intel_thunderbolt_nvm_digital_set_ucode(st, st->buf->len);
+	fu_byte_array_append_array(st->buf, st_dram->buf);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -199,7 +199,7 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	g_autoptr(GBytes) blob_cpd = NULL;
 
 	/* the smallest each image (and header) can be is 512 bytes */
-	image_size += fu_common_align_up(st_hdr->len, FU_FIRMWARE_ALIGNMENT_512);
+	image_size += fu_common_align_up(st_hdr->buf->len, FU_FIRMWARE_ALIGNMENT_512);
 	blob_cpd = fu_firmware_get_image_by_id_bytes(firmware, "cpd", NULL);
 	if (blob_cpd != NULL) {
 		image_size +=
@@ -216,7 +216,7 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 							    image_size -
 								FU_OPROM_FIRMWARE_ALIGN_LEN);
 	}
-	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
+	g_byte_array_append(buf, st_hdr->buf->data, st_hdr->buf->len);
 
 	/* add PCI section */
 	fu_struct_oprom_pci_set_vendor_id(st_pci, priv->vendor_id);
@@ -225,7 +225,7 @@ fu_oprom_firmware_write(FuFirmware *firmware, GError **error)
 	fu_struct_oprom_pci_set_code_type(st_pci, fu_firmware_get_idx(firmware));
 	if (fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_IS_LAST_IMAGE))
 		fu_struct_oprom_pci_set_indicator(st_pci, FU_OPROM_INDICATOR_FLAG_LAST);
-	g_byte_array_append(buf, st_pci->data, st_pci->len);
+	fu_byte_array_append_array(buf, st_pci->buf);
 	fu_byte_array_align_up(buf, FU_FIRMWARE_ALIGNMENT_512, 0xFF);
 
 	/* add CPD */

--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -1,3 +1,42 @@
+/**
+ * {{obj.c_method('Ref')}}: (skip):
+ **/
+{{obj.name}} *
+{{obj.c_method('Ref')}}({{obj.name}} *st)
+{
+    g_return_val_if_fail(st != NULL, NULL);
+    st->refcount++;
+    return st;
+}
+/**
+ * {{obj.c_method('Unref')}}: (skip):
+ **/
+void
+{{obj.c_method('Unref')}}({{obj.name}} *st)
+{
+    g_return_if_fail(st != NULL);
+    if (st->refcount == 0) {
+        g_critical("{{obj.name}} refcount already zero");
+        return;
+    }
+    if (--st->refcount > 0)
+        return;
+    if (st->buf != NULL)
+        g_byte_array_unref(st->buf);
+    g_free(st);
+}
+
+{%- set export = obj.export('NewInternal') %}
+{%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+static {{obj.name}} *
+{{obj.c_method('NewInternal')}}(void)
+{
+    {{obj.name}} *st = g_new0({{obj.name}}, 1);
+    st->refcount = 1;
+    return st;
+}
+{%- endif %}
+
 /* getters */
 {%- for item in obj.items | selectattr('enabled') %}
 {%- set export = item.export('Getters') %}
@@ -10,7 +49,7 @@
 {{item.c_getter}}(const {{obj.name}} *st)
 {
     g_return_val_if_fail(st != NULL, NULL);
-    return fu_memstrsafe(st->data, st->len, {{item.offset}}, {{item.size}}, NULL);
+    return fu_memstrsafe(st->buf->data, st->buf->len, {{item.offset}}, {{item.size}}, NULL);
 }
 
 {%- elif item.struct_obj %}
@@ -18,24 +57,26 @@
 {{export.value}}{{item.struct_obj.name}} *
 {{item.c_getter}}(const {{obj.name}} *st, guint idx)
 {
-    g_autoptr(GByteArray) buf = g_byte_array_new();
+    g_autoptr({{item.struct_obj.name}}) st_tmp = {{item.struct_obj.c_method('NewInternal')}}();
     g_return_val_if_fail(st != NULL, NULL);
     g_return_val_if_fail(idx < {{item.n_elements}}, NULL);
-    g_byte_array_append(buf,
-                        st->data
+    st_tmp->buf = g_byte_array_new();
+    g_byte_array_append(st_tmp->buf,
+                        st->buf->data
                             + {{item.c_define('OFFSET')}}
                             + ({{item.struct_obj.c_define('SIZE')}} * idx),
                         {{item.struct_obj.size}});
-    return g_steal_pointer(&buf);
+    return g_steal_pointer(&st_tmp);
 }
 {%- else %}
 {{export.value}}{{item.struct_obj.name}} *
 {{item.c_getter}}(const {{obj.name}} *st)
 {
-    g_autoptr(GByteArray) buf = g_byte_array_new();
+    g_autoptr({{item.struct_obj.name}}) st_tmp = {{item.struct_obj.c_method('NewInternal')}}();
     g_return_val_if_fail(st != NULL, NULL);
-    g_byte_array_append(buf, st->data + {{item.c_define('OFFSET')}}, {{item.size}});
-    return g_steal_pointer(&buf);
+    st_tmp->buf = g_byte_array_new();
+    g_byte_array_append(st_tmp->buf, st->buf->data + {{item.c_define('OFFSET')}}, {{item.size}});
+    return g_steal_pointer(&st_tmp);
 }
 {%- endif %}
 
@@ -46,7 +87,7 @@
     g_return_val_if_fail(st != NULL, NULL);
     if (bufsz != NULL)
         *bufsz = {{item.size}};
-    return st->data + {{item.offset}};
+    return st->buf->data + {{item.offset}};
 }
 
 {%- elif item.type == Type.GUID %}
@@ -54,7 +95,7 @@
 {{item.c_getter}}(const {{obj.name}} *st)
 {
     g_return_val_if_fail(st != NULL, NULL);
-    return (const fwupd_guid_t *) (st->data + {{item.offset}});
+    return (const fwupd_guid_t *) (st->buf->data + {{item.offset}});
 }
 
 {%- elif item.type == Type.U8 %}
@@ -62,7 +103,7 @@
 {{item.c_getter}}(const {{obj.name}} *st)
 {
     g_return_val_if_fail(st != NULL, 0x0);
-    return st->data[{{item.offset}}];
+    return st->buf->data[{{item.offset}}];
 }
 
 {%- elif item.type in [Type.U16, Type.U24, Type.U32, Type.U64, Type.I8, Type.I16, Type.I32, Type.I64] %}
@@ -71,7 +112,7 @@
 {{item.c_getter}}(const {{obj.name}} *st, guint idx)
 {
     g_return_val_if_fail(st != NULL, 0x0);
-    return fu_memread_{{item.type_mem}}(st->data + {{item.offset}} + (sizeof({{item.type_glib}}) * idx),
+    return fu_memread_{{item.type_mem}}(st->buf->data + {{item.offset}} + (sizeof({{item.type_glib}}) * idx),
                                         {{item.endian_glib}});
 }
 {%- else %}
@@ -79,7 +120,7 @@
 {{item.c_getter}}(const {{obj.name}} *st)
 {
     g_return_val_if_fail(st != NULL, 0x0);
-    return fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
+    return fu_memread_{{item.type_mem}}(st->buf->data + {{item.offset}}, {{item.endian_glib}});
 }
 {%- endif %}
 
@@ -89,8 +130,8 @@
 {
     guint32 val;
     g_return_val_if_fail(st != NULL, 0x0);
-    g_return_val_if_fail(st->len >= sizeof({{item.type_glib}}), 0x0);
-    val = fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
+    g_return_val_if_fail(st->buf->len >= sizeof({{item.type_glib}}), 0x0);
+    val = fu_memread_{{item.type_mem}}(st->buf->data + {{item.offset}}, {{item.endian_glib}});
     return (val >> {{item.bits_offset}}) & {{item.bits_mask}};
 }
 {%- endif %}
@@ -112,7 +153,7 @@
     g_return_val_if_fail(st != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     if (value == NULL) {
-        memset(st->data + {{item.offset}}, 0x0, {{item.size}});
+        memset(st->buf->data + {{item.offset}}, 0x0, {{item.size}});
         return TRUE;
     }
     len = strlen(value);
@@ -124,7 +165,7 @@
                     value, (guint) len, (guint) {{item.size}});
         return FALSE;
     }
-    return fu_memcpy_safe(st->data, st->len, {{item.offset}}, (const guint8 *)value, len, 0x0, len, error);
+    return fu_memcpy_safe(st->buf->data, st->buf->len, {{item.offset}}, (const guint8 *)value, len, 0x0, len, error);
 }
 
 {%- elif item.struct_obj %}
@@ -137,21 +178,21 @@
     g_return_val_if_fail(idx < {{item.n_elements}}, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-    if (st_donor->len > {{item.struct_obj.c_define('SIZE')}}) {
+    if (st_donor->buf->len > {{item.struct_obj.c_define('SIZE')}}) {
         g_set_error(error,
                     FWUPD_ERROR,
                     FWUPD_ERROR_INVALID_DATA,
                     "donor '{{item.struct_obj.name}}' (0x%x bytes) does not fit in "
                     "{{obj.name}}.{{item.element_id}} (0x%x bytes)",
-                    (guint) st_donor->len,
+                    (guint) st_donor->buf->len,
                     (guint) {{item.struct_obj.c_define('SIZE')}});
         return FALSE;
     }
-    memcpy(st->data
+    memcpy(st->buf->data
             + {{item.c_define('OFFSET')}}
             + ({{item.struct_obj.c_define('SIZE')}} * idx),
-           st_donor->data,
-           st_donor->len);
+           st_donor->buf->data,
+           st_donor->buf->len);
     return TRUE;
 }
 {%- else %}
@@ -162,17 +203,17 @@
     g_return_val_if_fail(st_donor != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-    if (st_donor->len > {{item.struct_obj.c_define('SIZE')}}) {
+    if (st_donor->buf->len > {{item.struct_obj.c_define('SIZE')}}) {
         g_set_error(error,
                     FWUPD_ERROR,
                     FWUPD_ERROR_INVALID_DATA,
                     "donor '{{item.struct_obj.name}}' (0x%x bytes) does not fit in "
                     "{{obj.name}}.{{item.element_id}} (0x%x bytes)",
-                    (guint) st_donor->len,
+                    (guint) st_donor->buf->len,
                     (guint) {{item.struct_obj.c_define('SIZE')}});
         return FALSE;
     }
-    memcpy(st->data + {{item.c_define('OFFSET')}}, st_donor->data, st_donor->len);
+    memcpy(st->buf->data + {{item.c_define('OFFSET')}}, st_donor->buf->data, st_donor->buf->len);
     return TRUE;
 }
 {%- endif %}
@@ -184,7 +225,7 @@
     g_return_val_if_fail(st != NULL, FALSE);
     g_return_val_if_fail(buf != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-    return fu_memcpy_safe(st->data, st->len, {{item.offset}}, buf, bufsz, 0x0, bufsz, error);
+    return fu_memcpy_safe(st->buf->data, st->buf->len, {{item.offset}}, buf, bufsz, 0x0, bufsz, error);
 }
 
 {%- elif item.type == Type.GUID %}
@@ -193,7 +234,7 @@
 {
     g_return_if_fail(st != NULL);
     g_return_if_fail(value != NULL);
-    memcpy(st->data + {{item.offset}}, value, sizeof(*value)); /* nocheck:blocked */
+    memcpy(st->buf->data + {{item.offset}}, value, sizeof(*value)); /* nocheck:blocked */
 }
 
 {%- elif item.type == Type.U8 %}
@@ -201,7 +242,7 @@
 {{item.c_setter}}({{obj.name}} *st, {{item.type_glib}} value)
 {
     g_return_if_fail(st != NULL);
-    st->data[{{item.offset}}] = value;
+    st->buf->data[{{item.offset}}] = value;
 }
 
 {%- elif item.type == Type.B32 %}
@@ -210,11 +251,11 @@
 {
     guint32 tmp;
     g_return_if_fail(st != NULL);
-    g_return_if_fail(st->len >= sizeof({{item.type_glib}}));
-    tmp = fu_memread_{{item.type_mem}}(st->data + {{item.offset}}, {{item.endian_glib}});
+    g_return_if_fail(st->buf->len >= sizeof({{item.type_glib}}));
+    tmp = fu_memread_{{item.type_mem}}(st->buf->data + {{item.offset}}, {{item.endian_glib}});
     tmp &= ~({{item.bits_mask}} << {{item.bits_offset}});
     tmp |= (value & {{item.bits_mask}}) << {{item.bits_offset}};
-    fu_memwrite_{{item.type_mem}}(st->data + {{item.offset}}, tmp, {{item.endian_glib}});
+    fu_memwrite_{{item.type_mem}}(st->buf->data + {{item.offset}}, tmp, {{item.endian_glib}});
 }
 
 {%- elif item.type in [Type.U16, Type.U24, Type.U32, Type.U64, Type.I8, Type.I16, Type.I32, Type.I64] %}
@@ -224,7 +265,7 @@
 {
     g_return_if_fail(st != NULL);
     g_return_if_fail(idx < {{item.n_elements}});
-    fu_memwrite_{{item.type_mem}}(st->data + {{item.offset}} + (sizeof({{item.type_glib}}) * idx),
+    fu_memwrite_{{item.type_mem}}(st->buf->data + {{item.offset}} + (sizeof({{item.type_glib}}) * idx),
                                   value,
                                   {{item.endian_glib}});
 }
@@ -234,7 +275,7 @@
 {{item.c_setter}}({{obj.name}} *st, {{item.type_glib}} value)
 {
     g_return_if_fail(st != NULL);
-    fu_memwrite_{{item.type_mem}}(st->data + {{item.offset}}, value, {{item.endian_glib}});
+    fu_memwrite_{{item.type_mem}}(st->buf->data + {{item.offset}}, value, {{item.endian_glib}});
 }
 {%- endif %}
 {%- endif %}
@@ -249,15 +290,16 @@
 {{export.value}}{{obj.name}} *
 {{obj.c_method('New')}}(void)
 {
-    {{obj.name}} *st = g_byte_array_sized_new({{obj.size}});
-    fu_byte_array_set_size(st, {{obj.size}}, 0x0);
+    {{obj.name}} *st = {{obj.c_method('NewInternal')}}();
+    st->buf = g_byte_array_sized_new({{obj.size}});
+    fu_byte_array_set_size(st->buf, {{obj.size}}, 0x0);
 {%- for item in obj.items | selectattr('padding') %}
-    memset(st->data + {{item.offset}}, {{item.padding}}, {{item.size}});
+    memset(st->buf->data + {{item.offset}}, {{item.padding}}, {{item.size}});
 {%- endfor %}
 {%- for item in obj.items | selectattr('struct_obj') %}
     {
-        g_autoptr(GByteArray) st_donor = {{item.struct_obj.c_method('New')}}();
-        memcpy(st->data + 0x{{'{:X}'.format(item.offset)}}, st_donor->data, st_donor->len); /* nocheck:blocked */
+        g_autoptr({{item.struct_obj.name}}) st_donor = {{item.struct_obj.c_method('New')}}();
+        memcpy(st->buf->data + 0x{{'{:X}'.format(item.offset)}}, st_donor->buf->data, st_donor->buf->len); /* nocheck:blocked */
     }
 {%- endfor %}
 {%- for item in obj.items | selectattr('default') %}
@@ -266,7 +308,7 @@
 {%- elif item.type == Type.GUID %}
     {{item.c_setter}}(st, (fwupd_guid_t *) "{{item.default}}");
 {%- elif item.type == Type.U8 and item.n_elements %}
-    memcpy(st->data + 0x{{'{:X}'.format(item.offset)}}, "{{item.default}}", {{item.size}}); /* nocheck:blocked */
+    memcpy(st->buf->data + 0x{{'{:X}'.format(item.offset)}}, "{{item.default}}", {{item.size}}); /* nocheck:blocked */
 {%- else %}
     {{item.c_setter}}(st, {{item.default}});
 {%- endif %}
@@ -343,13 +385,13 @@
 {%- elif item.struct_obj %}
 {%- if item.n_elements %}
     for (guint i = 0; i < {{item.n_elements}}; i++) {
-        g_autoptr(GByteArray) st_tmp = {{item.c_getter}}(st, i);
+        g_autoptr({{item.struct_obj.name}}) st_tmp = {{item.c_getter}}(st, i);
         g_autofree gchar *tmp = {{item.struct_obj.c_method('ToString')}}(st_tmp);
         g_string_append_printf(str, "  {{item.element_id}}[%u]: %s\n", i, tmp);
     }
 {%- else %}
     {
-        g_autoptr(GByteArray) st_tmp = {{item.c_getter}}(st);
+        g_autoptr({{item.struct_obj.name}}) st_tmp = {{item.c_getter}}(st);
         g_autofree gchar *tmp = {{item.struct_obj.c_method('ToString')}}(st_tmp);
         g_string_append_printf(str, "  {{item.element_id}}: %s\n", tmp);
     }
@@ -373,7 +415,7 @@
 {{obj.c_method('ToBytes')}}(const {{obj.name}} *st)
 {
     g_return_val_if_fail(st != NULL, NULL);
-    return g_bytes_new(st->data, st->len);
+    return g_bytes_new(st->buf->data, st->buf->len);
 }
 {%- endif %}
 
@@ -385,11 +427,11 @@
     g_return_val_if_fail(st != NULL, FALSE);
 {%- for item in obj.items | selectattr('constant') %}
 {%- if item.type == Type.STRING %}
-    if (strncmp((const gchar *) (st->data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
+    if (strncmp((const gchar *) (st->buf->data + {{item.offset}}), "{{item.constant}}", {{item.size}}) != 0) {
 {%- elif item.type == Type.GUID %}
     if (memcmp({{item.c_getter}}(st), "{{item.constant}}", {{item.size}}) != 0) {
 {%- elif item.type == Type.U8 and item.n_elements %}
-    if (memcmp(st->data + {{item.offset}}, "{{item.constant}}", {{item.size}}) != 0) {
+    if (memcmp(st->buf->data + {{item.offset}}, "{{item.constant}}", {{item.size}}) != 0) {
 {%- else %}
     if ({{item.c_getter}}(st) != {{item.constant}}) {
 {%- endif %}
@@ -422,10 +464,11 @@
 {%- endfor %}
 {%- for item in obj.items | selectattr('struct_obj') %}
     {
-        GByteArray st_tmp = {
-            .data = (guint8*) st->data + 0x{{'{:X}'.format(item.offset)}},
+        GByteArray buf_tmp = {
+            .data = (guint8*) st->buf->data + 0x{{'{:X}'.format(item.offset)}},
             .len = {{item.size}},
         };
+        {{item.struct_obj.name}} st_tmp = { .buf = &buf_tmp };
         if (!{{item.struct_obj.c_method('ValidateInternal')}}(&st_tmp, error))
             return FALSE;
     }
@@ -443,14 +486,15 @@
 {{export.value}}gboolean
 {{obj.c_method('Validate')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
-    GByteArray st = {.data = (guint8 *) buf + offset, .len = bufsz - offset, };
+    GByteArray st_buf = {.data = (guint8 *) buf + offset, .len = bufsz - offset, };
+    {{obj.name}} st_tmp = {.buf = &st_buf };
     g_return_val_if_fail(buf != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
     if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
         g_prefix_error_literal(error, "invalid struct {{obj.name}}: ");
         return FALSE;
     }
-    if (!{{obj.c_method('ValidateInternal')}}(&st, error))
+    if (!{{obj.c_method('ValidateInternal')}}(&st_tmp, error))
         return FALSE;
     return TRUE;
 }
@@ -464,21 +508,21 @@
 {{export.value}}gboolean
 {{obj.c_method('ValidateStream')}}(GInputStream *stream, gsize offset, GError **error)
 {
-    g_autoptr(GByteArray) st = NULL;
+    g_autoptr({{obj.name}}) st = {{obj.c_method('NewInternal')}}();
     g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-    st = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);
-    if (st == NULL) {
+    st->buf = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);
+    if (st->buf == NULL) {
         g_prefix_error(error, "{{obj.name}} failed read of 0x%x: ", (guint) {{obj.size}});
         return FALSE;
     }
-    if (st->len != {{obj.size}}) {
+    if (st->buf->len != {{obj.size}}) {
         g_set_error(error,
                     FWUPD_ERROR,
                     FWUPD_ERROR_INVALID_DATA,
                     "{{obj.name}} requested 0x%x and got 0x%x",
                     (guint) {{obj.size}},
-                    (guint) st->len);
+                    (guint) st->buf->len);
         return FALSE;
     }
     return {{obj.c_method('ValidateInternal')}}(st, error);
@@ -523,14 +567,15 @@
 {{export.value}}{{obj.name}} *
 {{obj.c_method('Parse')}}(const guint8 *buf, gsize bufsz, gsize offset, GError **error)
 {
-    g_autoptr(GByteArray) st = g_byte_array_new();
+    g_autoptr({{obj.name}}) st = {{obj.c_method('NewInternal')}}();
     g_return_val_if_fail(buf != NULL, NULL);
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
     if (!fu_memchk_read(bufsz, offset, {{obj.size}}, error)) {
         g_prefix_error_literal(error, "invalid struct {{obj.name}}: ");
         return NULL;
     }
-    g_byte_array_append(st, buf + offset, {{obj.size}});
+    st->buf = g_byte_array_new();
+    g_byte_array_append(st->buf, buf + offset, {{obj.size}});
     if (!{{obj.c_method('ParseInternal')}}(st, error))
         return NULL;
     return g_steal_pointer(&st);
@@ -559,19 +604,19 @@
 {{export.value}}{{obj.name}} *
 {{obj.c_method('ParseStream')}}(GInputStream *stream, gsize offset, GError **error)
 {
-    g_autoptr(GByteArray) st = NULL;
-    st = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);
-    if (st == NULL) {
+    g_autoptr({{obj.name}}) st = {{obj.c_method('NewInternal')}}();
+    st->buf = fu_input_stream_read_byte_array(stream, offset, {{obj.size}}, NULL, error);
+    if (st->buf == NULL) {
         g_prefix_error(error, "{{obj.name}} failed read of 0x%x: ", (guint) {{obj.size}});
         return NULL;
     }
-    if (st->len != {{obj.size}}) {
+    if (st->buf->len != {{obj.size}}) {
         g_set_error(error,
                     FWUPD_ERROR,
                     FWUPD_ERROR_INVALID_DATA,
                     "{{obj.name}} requested 0x%x and got 0x%x",
                     (guint) {{obj.size}},
-                    (guint) st->len);
+                    (guint) st->buf->len);
         return NULL;
     }
     if (!{{obj.c_method('ParseInternal')}}(st, error))

--- a/libfwupdplugin/fu-rustgen-struct.h.in
+++ b/libfwupdplugin/fu-rustgen-struct.h.in
@@ -1,6 +1,10 @@
-typedef GByteArray {{obj.name}};
+typedef struct {
+  GByteArray *buf;
+  guint refcount;
+} {{obj.name}};
 
-#define {{obj.c_method('Unref')}} g_byte_array_unref
+{{obj.name}} *{{obj.c_method('Ref')}}({{obj.name}} *st) G_GNUC_NON_NULL(1);
+void {{obj.c_method('Unref')}}({{obj.name}} *st) G_GNUC_NON_NULL(1);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC({{obj.name}}, {{obj.c_method('Unref')}})
 
 {%- if obj.export('New') == Export.PUBLIC %}

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -105,23 +105,23 @@ fu_sbatlevel_section_write(FuFirmware *firmware, GError **error)
 {
 	g_autoptr(FuFirmware) img_ltst = NULL;
 	g_autoptr(FuFirmware) img_prev = NULL;
-	g_autoptr(FuStructSbatLevelSectionHeader) buf = fu_struct_sbat_level_section_header_new();
+	g_autoptr(FuStructSbatLevelSectionHeader) st = fu_struct_sbat_level_section_header_new();
 	g_autoptr(GBytes) blob_ltst = NULL;
 	g_autoptr(GBytes) blob_prev = NULL;
 
 	/* previous */
-	fu_struct_sbat_level_section_header_set_previous(buf, sizeof(guint32) * 2);
+	fu_struct_sbat_level_section_header_set_previous(st, sizeof(guint32) * 2);
 	img_prev = fu_firmware_get_image_by_id(firmware, "previous", error);
 	if (img_prev == NULL)
 		return NULL;
 	blob_prev = fu_firmware_write(img_prev, error);
 	if (blob_prev == NULL)
 		return NULL;
-	fu_byte_array_append_bytes(buf, blob_prev);
-	fu_byte_array_append_uint8(buf, 0x0);
+	fu_byte_array_append_bytes(st->buf, blob_prev);
+	fu_byte_array_append_uint8(st->buf, 0x0);
 
 	/* latest */
-	fu_struct_sbat_level_section_header_set_latest(buf,
+	fu_struct_sbat_level_section_header_set_latest(st,
 						       (sizeof(guint32) * 2) +
 							   g_bytes_get_size(blob_prev) + 1);
 	img_ltst = fu_firmware_get_image_by_id(firmware, "latest", error);
@@ -130,11 +130,11 @@ fu_sbatlevel_section_write(FuFirmware *firmware, GError **error)
 	blob_ltst = fu_firmware_write(img_ltst, error);
 	if (blob_ltst == NULL)
 		return NULL;
-	fu_byte_array_append_bytes(buf, blob_ltst);
-	fu_byte_array_append_uint8(buf, 0x0);
+	fu_byte_array_append_bytes(st->buf, blob_ltst);
+	fu_byte_array_append_uint8(st->buf, 0x0);
 
 	/* success */
-	return g_steal_pointer(&buf);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -6926,14 +6926,14 @@ fu_plugin_struct_bits_func(void)
 	g_autoptr(GError) error = NULL;
 
 	/* 0b1111 + 0b1 + 0b0010 = 0b111110010 -> 0x1F2 */
-	g_assert_cmpint(st->len, ==, 4);
-	fu_dump_raw(G_LOG_DOMAIN, "buf", st->data, st->len);
-	g_assert_cmpint(st->data[0], ==, 0xF2);
-	g_assert_cmpint(st->data[1], ==, 0x01);
-	g_assert_cmpint(st->data[2], ==, 0x0);
-	g_assert_cmpint(st->data[3], ==, 0x0);
+	g_assert_cmpint(st->buf->len, ==, 4);
+	fu_dump_raw(G_LOG_DOMAIN, "buf", st->buf->data, st->buf->len);
+	g_assert_cmpint(st->buf->data[0], ==, 0xF2);
+	g_assert_cmpint(st->buf->data[1], ==, 0x01);
+	g_assert_cmpint(st->buf->data[2], ==, 0x0);
+	g_assert_cmpint(st->buf->data[3], ==, 0x0);
 
-	st2 = fu_struct_self_test_bits_parse(st->data, st->len, 0x0, &error);
+	st2 = fu_struct_self_test_bits_parse(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(st2);
 
@@ -6987,7 +6987,7 @@ fu_plugin_struct_list_func(void)
 	}
 
 	/* size */
-	str = fu_byte_array_to_string(st);
+	str = fu_byte_array_to_string(st->buf);
 	g_assert_cmpstr(
 	    str,
 	    ==,
@@ -7007,7 +7007,7 @@ fu_plugin_struct_func(void)
 	g_autofree gchar *oem_table_id = NULL;
 
 	/* size */
-	g_assert_cmpint(st->len, ==, 59);
+	g_assert_cmpint(st->buf->len, ==, 59);
 
 	/* getters and setters */
 	fu_struct_self_test_set_revision(st, 0xFF);
@@ -7019,14 +7019,14 @@ fu_plugin_struct_func(void)
 	g_assert_cmpint(fu_struct_self_test_get_length(st), ==, 0xDEAD);
 
 	/* pack */
-	str1 = fu_byte_array_to_string(st);
+	str1 = fu_byte_array_to_string(st->buf);
 	g_assert_cmpstr(str1,
 			==,
 			"12345678adde0000ff000000000000000000000000000000004142434445465800000000"
 			"00000000000000dfdfdfdf00000000ffffffffffffffff");
 
 	/* parse */
-	st2 = fu_struct_self_test_parse(st->data, st->len, 0x0, &error);
+	st2 = fu_struct_self_test_parse(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(st2);
 	g_assert_cmpint(fu_struct_self_test_get_revision(st2), ==, 0xFF);
@@ -7048,12 +7048,12 @@ fu_plugin_struct_func(void)
 			"  asl_compiler_revision: 0x0");
 
 	/* parse failing signature */
-	st->data[0] = 0xFF;
-	st3 = fu_struct_self_test_parse(st->data, st->len, 0x0, &error);
+	st->buf->data[0] = 0xFF;
+	st3 = fu_struct_self_test_parse(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(st3);
 	g_clear_error(&error);
-	ret = fu_struct_self_test_validate(st->data, st->len, 0x0, &error);
+	ret = fu_struct_self_test_validate(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }
@@ -7073,13 +7073,13 @@ fu_plugin_struct_wrapped_func(void)
 	g_autoptr(GError) error = NULL;
 
 	/* size */
-	g_assert_cmpint(st->len, ==, 61);
+	g_assert_cmpint(st->buf->len, ==, 61);
 
 	/* getters and setters */
 	fu_struct_self_test_wrapped_set_less(st, 0x99);
 	fu_struct_self_test_wrapped_set_more(st, 0x12);
 	g_assert_cmpint(fu_struct_self_test_wrapped_get_more(st), ==, 0x12);
-	str1 = fu_byte_array_to_string(st);
+	str1 = fu_byte_array_to_string(st->buf);
 	g_assert_cmpstr(str1,
 			==,
 			"99123456783b000000000000000000000000000000000000000041424344454600000000"
@@ -7090,14 +7090,14 @@ fu_plugin_struct_wrapped_func(void)
 	ret = fu_struct_self_test_wrapped_set_base(st, st_base, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	str4 = fu_byte_array_to_string(st);
+	str4 = fu_byte_array_to_string(st->buf);
 	g_assert_cmpstr(str4,
 			==,
 			"99123456783b000000fe0000000000000000000000000000000041424344454600000000"
 			"0000000000000000dfdfdfdf00000000ffffffffffffffff12");
 
 	/* parse */
-	st2 = fu_struct_self_test_wrapped_parse(st->data, st->len, 0x0, &error);
+	st2 = fu_struct_self_test_wrapped_parse(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(st2);
 	g_assert_cmpint(fu_struct_self_test_wrapped_get_more(st), ==, 0x12);
@@ -7121,12 +7121,12 @@ fu_plugin_struct_wrapped_func(void)
 			"  more: 0x12");
 
 	/* parse failing signature */
-	st->data[FU_STRUCT_SELF_TEST_WRAPPED_OFFSET_BASE] = 0xFF;
-	st3 = fu_struct_self_test_wrapped_parse(st->data, st->len, 0x0, &error);
+	st->buf->data[FU_STRUCT_SELF_TEST_WRAPPED_OFFSET_BASE] = 0xFF;
+	st3 = fu_struct_self_test_wrapped_parse(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_null(st3);
 	g_clear_error(&error);
-	ret = fu_struct_self_test_wrapped_validate(st->data, st->len, 0x0, &error);
+	ret = fu_struct_self_test_wrapped_validate(st->buf->data, st->buf->len, 0x0, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
 }

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -81,7 +81,7 @@ fu_smbios_setup_from_data(FuSmbios *self, const guint8 *buf, gsize bufsz, GError
 		if (st_str == NULL)
 			return FALSE;
 		length = fu_struct_smbios_structure_get_length(st_str);
-		if (length < st_str->len) {
+		if (length < st_str->buf->len) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -178,13 +178,13 @@ fu_usb_bos_descriptor_parse(FuFirmware *firmware,
 	self->bos_cap.bDevCapabilityType = fu_usb_bos_hdr_get_dev_capability_type(st);
 
 	/* data */
-	if (self->bos_cap.bLength > st->len) {
+	if (self->bos_cap.bLength > st->buf->len) {
 		g_autoptr(FuFirmware) img = fu_firmware_new();
 		g_autoptr(GInputStream) img_stream = NULL;
 
 		img_stream = fu_partial_input_stream_new(stream,
-							 st->len,
-							 self->bos_cap.bLength - st->len,
+							 st->buf->len,
+							 self->bos_cap.bLength - st->buf->len,
 							 error);
 		if (img_stream == NULL) {
 			g_prefix_error_literal(error, "failed to cut BOS descriptor: ");
@@ -215,12 +215,12 @@ fu_usb_bos_descriptor_write(FuFirmware *firmware, GError **error)
 	fu_usb_bos_hdr_set_dev_capability_type(st, self->bos_cap.bDevCapabilityType);
 	blob = fu_firmware_get_image_by_id_bytes(firmware, FU_FIRMWARE_ID_PAYLOAD, NULL);
 	if (blob != NULL) {
-		fu_byte_array_append_bytes(st, blob);
-		fu_usb_bos_hdr_set_length(st, st->len);
+		fu_byte_array_append_bytes(st->buf, blob);
+		fu_usb_bos_hdr_set_length(st, st->buf->len);
 	}
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/libfwupdplugin/fu-usb-device-ds20.c
+++ b/libfwupdplugin/fu-usb-device-ds20.c
@@ -245,7 +245,7 @@ fu_usb_device_ds20_write(FuFirmware *firmware, GError **error)
 	fu_struct_ds20_set_platform_ver(st, fu_firmware_get_version_raw(firmware));
 	fu_struct_ds20_set_total_length(st, fu_firmware_get_size(firmware));
 	fu_struct_ds20_set_vendor_code(st, fu_firmware_get_idx(firmware));
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -386,11 +386,11 @@ fu_usb_interface_parse(FuFirmware *firmware,
 	fu_firmware_set_size(FU_FIRMWARE(self), self->iface.bLength);
 
 	/* extra data */
-	if (self->iface.bLength > st->len) {
+	if (self->iface.bLength > st->buf->len) {
 		g_autoptr(GByteArray) buf = NULL;
 		buf = fu_input_stream_read_byte_array(stream,
-						      st->len,
-						      self->iface.bLength - st->len,
+						      st->buf->len,
+						      self->iface.bLength - st->buf->len,
 						      NULL,
 						      error);
 		if (buf == NULL)

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -187,7 +187,7 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuUswidFirmware *self = FU_USWID_FIRMWARE(firmware);
 	FuUswidFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_autoptr(FuStructUswid) buf = fu_struct_uswid_new();
+	g_autoptr(FuStructUswid) st = fu_struct_uswid_new();
 	g_autoptr(GByteArray) payload = g_byte_array_new();
 	g_autoptr(GBytes) payload_blob = NULL;
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
@@ -223,14 +223,14 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* pack */
-	fu_struct_uswid_set_hdrver(buf, priv->hdrver);
-	fu_struct_uswid_set_payloadsz(buf, g_bytes_get_size(payload_blob));
+	fu_struct_uswid_set_hdrver(st, priv->hdrver);
+	fu_struct_uswid_set_payloadsz(st, g_bytes_get_size(payload_blob));
 	if (priv->hdrver >= 3) {
 		guint8 flags = 0;
 		if (priv->compression != FU_USWID_PAYLOAD_COMPRESSION_NONE)
 			flags |= FU_USWID_HEADER_FLAG_COMPRESSED;
-		fu_struct_uswid_set_flags(buf, flags);
-		fu_struct_uswid_set_compression(buf, priv->compression);
+		fu_struct_uswid_set_flags(st, flags);
+		fu_struct_uswid_set_compression(st, priv->compression);
 	} else if (priv->hdrver >= 2) {
 		guint8 flags = 0;
 		if (priv->compression != FU_USWID_PAYLOAD_COMPRESSION_NONE) {
@@ -243,17 +243,17 @@ fu_uswid_firmware_write(FuFirmware *firmware, GError **error)
 			}
 			flags |= FU_USWID_HEADER_FLAG_COMPRESSED;
 		}
-		fu_struct_uswid_set_flags(buf, flags);
-		g_byte_array_set_size(buf, buf->len - 1);
-		fu_struct_uswid_set_hdrsz(buf, buf->len);
+		fu_struct_uswid_set_flags(st, flags);
+		g_byte_array_set_size(st->buf, st->buf->len - 1);
+		fu_struct_uswid_set_hdrsz(st, st->buf->len);
 	} else {
-		g_byte_array_set_size(buf, buf->len - 2);
-		fu_struct_uswid_set_hdrsz(buf, buf->len);
+		g_byte_array_set_size(st->buf, st->buf->len - 2);
+		fu_struct_uswid_set_hdrsz(st, st->buf->len);
 	}
-	fu_byte_array_append_bytes(buf, payload_blob);
+	fu_byte_array_append_bytes(st->buf, payload_blob);
 
 	/* success */
-	return g_steal_pointer(&buf);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -190,6 +190,7 @@ class StructObj:
             "ParseStream": Export.NONE,
             "ParseInternal": Export.NONE,
             "New": Export.NONE,
+            "NewInternal": Export.NONE,
             "ToString": Export.NONE,
             "ToBytes": Export.NONE,
             "Default": Export.NONE,
@@ -236,6 +237,7 @@ class StructObj:
         if derive == "Validate":
             self.add_private_export("ValidateInternal")
         elif derive == "ValidateStream":
+            self.add_private_export("NewInternal")
             self.add_private_export("ValidateInternal")
         elif derive == "ValidateBytes":
             self.add_private_export("Validate")
@@ -252,8 +254,10 @@ class StructObj:
                 if item.enum_obj and not item.constant and item.enabled:
                     item.enum_obj.add_private_export("ToString")
         elif derive == "Parse":
+            self.add_private_export("NewInternal")
             self.add_private_export("ParseInternal")
         elif derive == "ParseStream":
+            self.add_private_export("NewInternal")
             self.add_private_export("ParseInternal")
         elif derive == "ParseBytes":
             self.add_private_export("Parse")
@@ -270,6 +274,7 @@ class StructObj:
                 if item.struct_obj:
                     item.struct_obj.add_private_export("ValidateInternal")
         elif derive == "New":
+            self.add_private_export("NewInternal")
             for item in self.items:
                 if item.constant and not (item.type == Type.U8 and item.n_elements):
                     item.add_private_export("Setters")
@@ -282,6 +287,8 @@ class StructObj:
             for item in self.items:
                 if not item.constant:
                     item.add_public_export(derive)
+                if item.struct_obj:
+                    item.struct_obj.add_private_export("NewInternal")
         else:
             self.add_private_export(derive)
             self._exports[derive] = Export.PUBLIC

--- a/plugins/acpi-phat/fu-acpi-phat-health-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-health-record.c
@@ -113,7 +113,7 @@ fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 									error);
 		if (buf == NULL)
 			return NULL;
-		g_byte_array_append(st, buf->data, buf->len);
+		g_byte_array_append(st->buf, buf->data, buf->len);
 	}
 
 	/* data record */
@@ -123,12 +123,12 @@ fu_acpi_phat_health_record_write(FuFirmware *firmware, GError **error)
 			return NULL;
 		fu_struct_acpi_phat_health_record_set_device_signature(st, &guid);
 	}
-	fu_struct_acpi_phat_health_record_set_rcdlen(st, st->len);
+	fu_struct_acpi_phat_health_record_set_rcdlen(st, st->buf->len);
 	fu_struct_acpi_phat_health_record_set_version(st, fu_firmware_get_version_raw(firmware));
 	fu_struct_acpi_phat_health_record_set_flags(st, self->am_healthy);
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-element.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-element.c
@@ -42,7 +42,7 @@ fu_acpi_phat_version_element_parse(FuFirmware *firmware,
 	st = fu_struct_acpi_phat_version_element_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
-	fu_firmware_set_size(firmware, st->len);
+	fu_firmware_set_size(firmware, st->buf->len);
 	self->guid = fwupd_guid_to_string(fu_struct_acpi_phat_version_element_get_component_id(st),
 					  FWUPD_GUID_FLAG_MIXED_ENDIAN);
 	self->producer_id = fu_struct_acpi_phat_version_element_get_producer_id(st);
@@ -71,7 +71,7 @@ fu_acpi_phat_version_element_write(FuFirmware *firmware, GError **error)
 		return NULL;
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -35,12 +35,12 @@ fu_acpi_phat_version_record_parse(FuFirmware *firmware,
 		g_autoptr(FuFirmware) firmware_tmp = fu_acpi_phat_version_element_new();
 		g_autoptr(GInputStream) stream_tmp = NULL;
 		stream_tmp = fu_partial_input_stream_new(stream,
-							 offset + st->len,
+							 offset + st->buf->len,
 							 FU_STRUCT_ACPI_PHAT_VERSION_ELEMENT_SIZE,
 							 error);
 		if (stream_tmp == NULL)
 			return FALSE;
-		fu_firmware_set_offset(firmware_tmp, offset + st->len);
+		fu_firmware_set_offset(firmware_tmp, offset + st->buf->len);
 		if (!fu_firmware_parse_stream(firmware_tmp,
 					      stream_tmp,
 					      0x0,
@@ -71,13 +71,13 @@ fu_acpi_phat_version_record_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* data record */
-	fu_struct_acpi_phat_version_record_set_rcdlen(st, st->len + buf2->len);
+	fu_struct_acpi_phat_version_record_set_rcdlen(st, st->buf->len + buf2->len);
 	fu_struct_acpi_phat_version_record_set_version(st, fu_firmware_get_version_raw(firmware));
 	fu_struct_acpi_phat_version_record_set_record_count(st, images->len);
 
 	/* element data */
-	g_byte_array_append(st, buf2->data, buf2->len);
-	return g_steal_pointer(&st);
+	g_byte_array_append(st->buf, buf2->data, buf2->len);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -58,7 +58,10 @@ fu_algoltek_usbcr_device_write_reg(FuAlgoltekUsbcrDevice *self,
 	fu_struct_ag_usbcr_reg_cdb_set_addr(st, addr);
 	fu_struct_ag_usbcr_reg_cdb_set_val(st, value);
 
-	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self), st->data, st->len, error);
+	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self),
+					      st->buf->data,
+					      st->buf->len,
+					      error);
 }
 
 static gboolean
@@ -77,8 +80,8 @@ fu_algoltek_usbcr_device_read_reg(FuAlgoltekUsbcrDevice *self,
 	fu_struct_ag_usbcr_reg_cdb_set_addr(st, addr);
 
 	return fu_block_device_sg_io_cmd_read(FU_BLOCK_DEVICE(self),
-					      st->data,
-					      st->len,
+					      st->buf->data,
+					      st->buf->len,
 					      buf,
 					      bufsz,
 					      error);
@@ -100,8 +103,8 @@ fu_algoltek_usbcr_device_send_spi_cmd(FuAlgoltekUsbcrDevice *self, guint8 cmd, G
 	fu_struct_ag_usbcr_spi_cdb_set_spicmd(st, cmd);
 
 	return fu_block_device_sg_io_cmd_write(FU_BLOCK_DEVICE(self),
-					       st->data,
-					       st->len,
+					       st->buf->data,
+					       st->buf->len,
 					       buf,
 					       sizeof(buf),
 					       error);
@@ -127,8 +130,8 @@ fu_algoltek_usbcr_device_do_write_spi(FuAlgoltekUsbcrDevice *self,
 	fu_struct_ag_usbcr_spi_cdb_set_valid(st, FU_AG_SPIFLASH_VALID);
 
 	return fu_block_device_sg_io_cmd_write(FU_BLOCK_DEVICE(self),
-					       st->data,
-					       st->len,
+					       st->buf->data,
+					       st->buf->len,
 					       buf,
 					       bufsz,
 					       error);
@@ -150,8 +153,8 @@ fu_algoltek_usbcr_device_do_read_spi(FuAlgoltekUsbcrDevice *self,
 	fu_struct_ag_usbcr_spi_cdb_set_valid(st, FU_AG_SPIFLASH_VALID);
 
 	return fu_block_device_sg_io_cmd_read(FU_BLOCK_DEVICE(self),
-					      st->data,
-					      st->len,
+					      st->buf->data,
+					      st->buf->len,
 					      buf,
 					      bufsz,
 					      error);
@@ -381,7 +384,10 @@ fu_algoltek_usbcr_device_set_clear_soft_reset_flag(FuAlgoltekUsbcrDevice *self,
 	fu_struct_ag_usbcr_reset_cdb_set_val(st, 0x78);
 	fu_struct_ag_usbcr_reset_cdb_set_val2(st, val);
 
-	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self), st->data, st->len, error);
+	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self),
+					      st->buf->data,
+					      st->buf->len,
+					      error);
 }
 
 static gboolean
@@ -393,7 +399,10 @@ fu_algoltek_usbcr_device_reset_chip(FuAlgoltekUsbcrDevice *self, GError **error)
 	fu_struct_ag_usbcr_reset_cdb_set_subcmd(st, 0x95);
 	fu_struct_ag_usbcr_reset_cdb_set_val(st, 0x23);
 
-	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self), st->data, st->len, error);
+	return fu_block_device_sg_io_cmd_none(FU_BLOCK_DEVICE(self),
+					      st->buf->data,
+					      st->buf->len,
+					      error);
 }
 
 static gboolean

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -52,12 +52,11 @@ fu_amd_gpu_psp_firmware_validate(FuFirmware *firmware,
 				 gsize offset,
 				 GError **error)
 {
-	g_autoptr(FuStructEfs) efs = NULL;
-
-	efs = fu_struct_efs_parse_stream(stream, 0, error);
-	if (efs == NULL)
+	g_autoptr(FuStructEfs) st = NULL;
+	st = fu_struct_efs_parse_stream(stream, 0, error);
+	if (st == NULL)
 		return FALSE;
-	return fu_struct_psp_dir_validate_stream(stream, fu_struct_efs_get_psp_dir_loc(efs), error);
+	return fu_struct_psp_dir_validate_stream(stream, fu_struct_efs_get_psp_dir_loc(st), error);
 }
 
 static gboolean
@@ -66,19 +65,19 @@ fu_amd_gpu_psp_firmware_parse_l2(FuFirmware *firmware,
 				 gsize offset,
 				 GError **error)
 {
-	g_autoptr(FuStructPspDirTable) l2 = NULL;
+	g_autoptr(FuStructPspDir) st_dir = NULL;
 
 	/* parse the L2 entries */
-	l2 = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
-	if (l2 == NULL)
+	st_dir = fu_struct_psp_dir_parse_stream(stream, offset, error);
+	if (st_dir == NULL)
 		return FALSE;
-	offset += l2->len;
-	for (guint i = 0; i < fu_struct_psp_dir_get_total_entries(l2); i++) {
-		g_autoptr(FuStructPspDirTable) l2_entry = NULL;
-		l2_entry = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
-		if (l2_entry == NULL)
+	offset += st_dir->buf->len;
+	for (guint i = 0; i < fu_struct_psp_dir_get_total_entries(st_dir); i++) {
+		g_autoptr(FuStructPspDirTable) st_entry = NULL;
+		st_entry = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
+		if (st_entry == NULL)
 			return FALSE;
-		offset += l2_entry->len;
+		offset += st_entry->buf->len;
 	}
 
 	/* success */
@@ -92,28 +91,28 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 				 FuFirmwareParseFlags flags,
 				 GError **error)
 {
-	g_autoptr(FuStructPspDir) l1 = NULL;
+	g_autoptr(FuStructPspDir) st_dir = NULL;
 
 	/* parse the L1 entries */
-	l1 = fu_struct_psp_dir_parse_stream(stream, offset, error);
-	if (l1 == NULL)
+	st_dir = fu_struct_psp_dir_parse_stream(stream, offset, error);
+	if (st_dir == NULL)
 		return FALSE;
-	offset += l1->len;
-	for (guint i = 0; i < fu_struct_psp_dir_get_total_entries(l1); i++) {
+	offset += st_dir->buf->len;
+	for (guint i = 0; i < fu_struct_psp_dir_get_total_entries(st_dir); i++) {
 		guint loc;
 		guint sz;
-		g_autoptr(FuStructPspDirTable) l1_entry = NULL;
-		g_autoptr(FuStructImageSlotHeader) ish = NULL;
+		g_autoptr(FuStructPspDirTable) st_entry = NULL;
+		g_autoptr(FuStructImageSlotHeader) st_hdr = NULL;
 		g_autoptr(FuFirmware) ish_img = fu_firmware_new();
 		g_autoptr(FuFirmware) csm_img = fu_amd_gpu_atom_firmware_new();
 		g_autoptr(FuFirmware) l2_img = fu_firmware_new();
 		g_autoptr(GInputStream) l2_stream = NULL;
 
-		l1_entry = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
-		if (l1_entry == NULL)
+		st_entry = fu_struct_psp_dir_table_parse_stream(stream, offset, error);
+		if (st_entry == NULL)
 			return FALSE;
 
-		switch (fu_struct_psp_dir_table_get_fw_id(l1_entry)) {
+		switch (fu_struct_psp_dir_table_get_fw_id(st_entry)) {
 		case FU_FWID_ISH_A:
 			fu_firmware_set_id(ish_img, "ISH_A");
 			break;
@@ -125,14 +124,14 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
 				    "Unknown ISH FWID: %x",
-				    fu_struct_psp_dir_table_get_fw_id(l1_entry));
+				    fu_struct_psp_dir_table_get_fw_id(st_entry));
 			return FALSE;
 		}
 
 		/* parse the image slot header */
-		loc = fu_struct_psp_dir_table_get_loc(l1_entry);
-		ish = fu_struct_image_slot_header_parse_stream(stream, loc, error);
-		if (ish == NULL)
+		loc = fu_struct_psp_dir_table_get_loc(st_entry);
+		st_hdr = fu_struct_image_slot_header_parse_stream(stream, loc, error);
+		if (st_hdr == NULL)
 			return FALSE;
 		if (!fu_firmware_parse_stream(ish_img, stream, loc, flags, error))
 			return FALSE;
@@ -141,14 +140,14 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 			return FALSE;
 
 		/* parse the csm image */
-		loc = fu_struct_image_slot_header_get_loc_csm(ish);
+		loc = fu_struct_image_slot_header_get_loc_csm(st_hdr);
 		fu_firmware_set_addr(csm_img, loc);
 		if (!fu_firmware_parse_stream(csm_img, stream, loc, flags, error))
 			return FALSE;
 
-		loc = fu_struct_image_slot_header_get_loc(ish);
-		sz = fu_struct_image_slot_header_get_slot_max_size(ish);
-		switch (fu_struct_image_slot_header_get_fw_id(ish)) {
+		loc = fu_struct_image_slot_header_get_loc(st_hdr);
+		sz = fu_struct_image_slot_header_get_slot_max_size(st_hdr);
+		switch (fu_struct_image_slot_header_get_fw_id(st_hdr)) {
 		case FU_FWID_PARTITION_A_L2:
 			fu_firmware_set_id(l2_img, "PARTITION_A");
 			fu_firmware_set_id(csm_img, "ATOM_CSM_A");
@@ -162,7 +161,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
 				    "unknown Partition FWID: %x",
-				    fu_struct_image_slot_header_get_fw_id(ish));
+				    fu_struct_image_slot_header_get_fw_id(st_hdr));
 			return FALSE;
 		}
 		if (!fu_firmware_add_image(l2_img, csm_img, error))
@@ -182,7 +181,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuFirmware *firmware,
 			return FALSE;
 
 		/* next entry */
-		offset += l1_entry->len;
+		offset += st_entry->buf->len;
 	}
 
 	return TRUE;
@@ -195,12 +194,12 @@ fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
 			      GError **error)
 {
 	FuAmdGpuPspFirmware *self = FU_AMD_GPU_PSP_FIRMWARE(firmware);
-	g_autoptr(FuStructEfs) efs = NULL;
+	g_autoptr(FuStructEfs) st = NULL;
 
-	efs = fu_struct_efs_parse_stream(stream, 0, error);
-	if (efs == NULL)
+	st = fu_struct_efs_parse_stream(stream, 0, error);
+	if (st == NULL)
 		return FALSE;
-	self->dir_location = fu_struct_efs_get_psp_dir_loc(efs);
+	self->dir_location = fu_struct_efs_get_psp_dir_loc(st);
 
 	return fu_amd_gpu_psp_firmware_parse_l1(firmware, stream, self->dir_location, flags, error);
 }

--- a/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
+++ b/plugins/amd-kria/fu-amd-kria-persistent-firmware.c
@@ -28,12 +28,12 @@ fu_amd_kria_persistent_firmware_parse(FuFirmware *firmware,
 				      GError **error)
 {
 	FuAmdKriaPersistentFirmware *self = FU_AMD_KRIA_PERSISTENT_FIRMWARE(firmware);
-	g_autoptr(FuStructAmdKriaPersistReg) content = NULL;
+	g_autoptr(FuStructAmdKriaPersistReg) st = NULL;
 
-	content = fu_struct_amd_kria_persist_reg_parse_stream(stream, 0x0, error);
-	if (content == NULL)
+	st = fu_struct_amd_kria_persist_reg_parse_stream(stream, 0x0, error);
+	if (st == NULL)
 		return FALSE;
-	self->last_booted = fu_struct_amd_kria_persist_reg_get_last_booted_img(content);
+	self->last_booted = fu_struct_amd_kria_persist_reg_get_last_booted_img(st);
 
 	return TRUE;
 }

--- a/plugins/amd-kria/fu-amd-kria-som-eeprom.c
+++ b/plugins/amd-kria/fu-amd-kria-som-eeprom.c
@@ -38,24 +38,24 @@ fu_amd_kria_som_eeprom_parse(FuFirmware *firmware,
 	guint8 board_offset;
 	const guint8 *buf;
 	gsize bufsz = 0;
-	g_autoptr(FuStructIpmiCommon) common = NULL;
-	g_autoptr(FuStructBoardInfo) board = NULL;
+	g_autoptr(FuStructIpmiCommon) st_common = NULL;
+	g_autoptr(FuStructBoardInfo) st_board = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	/* parse IPMI common header */
-	common = fu_struct_ipmi_common_parse_stream(stream, 0x0, error);
-	if (common == NULL)
+	st_common = fu_struct_ipmi_common_parse_stream(stream, 0x0, error);
+	if (st_common == NULL)
 		return FALSE;
-	board_offset = fu_struct_ipmi_common_get_board_offset(common) * 8;
+	board_offset = fu_struct_ipmi_common_get_board_offset(st_common) * 8;
 
 	/* parse board info area */
-	board = fu_struct_board_info_parse_stream(stream, board_offset, error);
-	if (board == NULL)
+	st_board = fu_struct_board_info_parse_stream(stream, board_offset, error);
+	if (st_board == NULL)
 		return FALSE;
 
 	fw = fu_input_stream_read_bytes(stream,
 					board_offset,
-					fu_struct_board_info_get_length(board) * 8,
+					fu_struct_board_info_get_length(st_board) * 8,
 					NULL,
 					error);
 	if (fw == NULL)

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -37,16 +37,16 @@ fu_asus_hid_firmware_parse(FuFirmware *firmware,
 			   GError **error)
 {
 	FuAsusHidFirmware *self = FU_ASUS_HID_FIRMWARE(firmware);
-	g_autoptr(FuStructAsusHidDesc) desc = NULL;
+	g_autoptr(FuStructAsusHidDesc) st = NULL;
 	g_autoptr(FuFirmware) img_payload = fu_firmware_new();
 	g_autoptr(GInputStream) stream_payload = NULL;
 
-	desc = fu_struct_asus_hid_desc_parse_stream(stream, FGA_OFFSET, error);
-	if (desc == NULL)
+	st = fu_struct_asus_hid_desc_parse_stream(stream, FGA_OFFSET, error);
+	if (st == NULL)
 		return FALSE;
-	self->fga = fu_struct_asus_hid_desc_get_fga(desc);
-	self->product = fu_struct_asus_hid_desc_get_product(desc);
-	self->version = fu_struct_asus_hid_desc_get_version(desc);
+	self->fga = fu_struct_asus_hid_desc_get_fga(st);
+	self->product = fu_struct_asus_hid_desc_get_product(st);
+	self->version = fu_struct_asus_hid_desc_get_version(st);
 
 	stream_payload = fu_partial_input_stream_new(stream, 0x2000, G_MAXSIZE, error);
 	if (stream_payload == NULL)

--- a/plugins/asus-hid/fu-asus-hid.rs
+++ b/plugins/asus-hid/fu-asus-hid.rs
@@ -85,7 +85,7 @@ struct FuStructAsusHidFwInfo {
 
 #[derive(Default, New)]
 #[repr(C, packed)]
-struct FuStructAsusPreUpdateCommand {
+struct FuStructAsusHidPreUpdateCommand {
     report_id: FuAsusHidReportId == Info,
     cmd: u32le,
     length: u8,

--- a/plugins/aver-hid/fu-aver-hid.rs
+++ b/plugins/aver-hid/fu-aver-hid.rs
@@ -16,7 +16,7 @@ enum FuAverHidStatus {
     Stop,
 }
 
-#[derive(ToString)]
+#[repr(u8)]
 enum FuAverHidCustomIspCmd {
     Status = 0x01,
     FileStart,
@@ -35,7 +35,7 @@ enum FuAverHidCustomIspCmd {
     AllStart,
 }
 
-#[derive(ToString)]
+#[repr(u8)]
 enum FuAverSafeispCustomCmd {
     GetVersion = 0x14,
     Support = 0x29,
@@ -72,7 +72,7 @@ enum FuAverSafeispAckStatus {
 struct FuStructAverHidReqIsp {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     data: [u8; 508] = [0xFF; 508],
     end: u8 == 0x00,
 }
@@ -82,7 +82,7 @@ struct FuStructAverHidReqIsp {
 struct FuStructAverHidReqIspFileStart {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     file_name: [char; 52],
     file_size: u32le,
     free_space: u32le,
@@ -95,7 +95,7 @@ struct FuStructAverHidReqIspFileStart {
 struct FuStructAverHidReqIspFileDnload {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     data: [u8; 508] = [0xFF; 508],
 }
 
@@ -104,7 +104,7 @@ struct FuStructAverHidReqIspFileDnload {
 struct FuStructAverHidReqIspFileEnd {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     file_name: [char; 51],
     end_flag: u8,
     file_size: u32le,
@@ -113,13 +113,13 @@ struct FuStructAverHidReqIspFileEnd {
     end: u8 == 0x00,
 }
 
-#[derive(Getters, Setters, Default)]
+#[derive(Getters, New, Default)]
 #[repr(C, packed)]
 struct FuStructAverHidReqIspStart {
     report_id_custom_command: u8 == 0x08,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
-    isp_cmd: [u8; 60],
+    custom_isp_cmd: FuAverHidCustomIspCmd,
+    isp_cmd: [u8; 60] = [0xFF; 60],
     _reserved: [u8; 448] = [0xFF; 448],
     end: u8 == 0x00,
 }
@@ -139,7 +139,7 @@ struct FuStructAverHidReqDeviceVersion {
 struct FuStructAverHidResIspStatus {
     report_id_custom_command: u8 == 0x09,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     status: u8,
     status_string: [char; 58],
     progress: u8,
@@ -152,7 +152,7 @@ struct FuStructAverHidResIspStatus {
 struct FuStructAverHidResIsp {
     report_id_custom_command: u8 == 0x09,
     custom_cmd_isp: u8 == 0x10,
-    custom_isp_cmd: u8,
+    custom_isp_cmd: FuAverHidCustomIspCmd,
     _reserved: [u8; 508] = [0xFF; 508],
     end: u8 == 0x00,
 }
@@ -171,7 +171,7 @@ struct FuStructAverHidResDeviceVersion {
 #[repr(C, packed)]
 struct FuStructAverSafeispReq {
     report_id_custom_command: u8 == 0x08,
-    custom_cmd: u8,
+    custom_cmd: FuAverSafeispCustomCmd,
     custom_res: u16le,
     custom_parm0: u32le = 0x00,
     custom_parm1: u32le = 0x00,
@@ -189,11 +189,11 @@ struct FuStructAverSafeispRes {
     data: [u8; 4] = [0x00; 4],
 };
 
-#[derive(Getters, Validate, Default)]
+#[derive(New, Getters, Validate, Default)]
 #[repr(C, packed)]
 struct FuStructAverSafeispResDeviceVersion {
     report_id_custom_command: u8 == 0x09,
-    custom_cmd: u8 == 0x14,
+    custom_cmd: FuAverSafeispCustomCmd == GetVersion,
     ver: [u8; 11],
     _reserved: [u8; 3] = [0x00; 3],
 }

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -50,10 +50,6 @@ fu_aver_safeisp_device_transfer(FuAverSafeispDevice *self,
 			g_prefix_error_literal(error, "failed to receive packet: ");
 			return FALSE;
 		}
-		g_debug("custom-isp-cmd: %s [0x%x]",
-			fu_aver_safeisp_custom_cmd_to_string(
-			    fu_struct_aver_safeisp_res_get_custom_cmd(res)),
-			fu_struct_aver_safeisp_res_get_custom_cmd(res));
 	}
 	return TRUE;
 }
@@ -62,16 +58,21 @@ static gboolean
 fu_aver_safeisp_device_ensure_version(FuAverSafeispDevice *self, GError **error)
 {
 	g_autofree gchar *ver = NULL;
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(FuStructAverSafeispResDeviceVersion) res = fu_struct_aver_safeisp_res_new();
-	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_GET_VERSION);
-	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispResDeviceVersion) st_res =
+	    fu_struct_aver_safeisp_res_device_version_new();
+
+	fu_struct_aver_safeisp_req_set_custom_cmd(st_req, FU_AVER_SAFEISP_CUSTOM_CMD_GET_VERSION);
+	if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 		return FALSE;
-	if (!fu_struct_aver_safeisp_res_device_version_validate(res->data, res->len, 0x0, error))
+	if (!fu_struct_aver_safeisp_res_device_version_validate(st_res->buf->data,
+								st_res->buf->len,
+								0x0,
+								error))
 		return FALSE;
-	ver =
-	    fu_strsafe((const gchar *)fu_struct_aver_safeisp_res_device_version_get_ver(res, NULL),
-		       FU_STRUCT_AVER_SAFEISP_RES_DEVICE_VERSION_SIZE_VER);
+	ver = fu_strsafe(
+	    (const gchar *)fu_struct_aver_safeisp_res_device_version_get_ver(st_res, NULL),
+	    FU_STRUCT_AVER_SAFEISP_RES_DEVICE_VERSION_SIZE_VER);
 	fu_device_set_version(FU_DEVICE(self), ver);
 	return TRUE;
 }
@@ -95,15 +96,15 @@ fu_aver_safeisp_device_setup(FuDevice *device, GError **error)
 static gboolean
 fu_aver_safeisp_device_support(FuAverSafeispDevice *self, GError **error)
 {
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) st_res = fu_struct_aver_safeisp_res_new();
 
-	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_SUPPORT);
-	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+	fu_struct_aver_safeisp_req_set_custom_cmd(st_req, FU_AVER_SAFEISP_CUSTOM_CMD_SUPPORT);
+	if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 		return FALSE;
-	if (!fu_struct_aver_safeisp_res_validate(res->data, res->len, 0x0, error))
+	if (!fu_struct_aver_safeisp_res_validate(st_res->buf->data, st_res->buf->len, 0x0, error))
 		return FALSE;
-	if (fu_struct_aver_safeisp_res_get_custom_cmd(res) != FU_AVER_SAFEISP_ACK_STATUS_SUPPORT)
+	if (fu_struct_aver_safeisp_res_get_custom_cmd(st_res) != FU_AVER_SAFEISP_ACK_STATUS_SUPPORT)
 		return FALSE;
 	return TRUE;
 }
@@ -114,15 +115,16 @@ fu_aver_safeisp_device_upload_prepare(FuAverSafeispDevice *self,
 				      gsize size,
 				      GError **error)
 {
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) st_res = fu_struct_aver_safeisp_res_new();
 
-	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_PREPARE);
-	fu_struct_aver_safeisp_req_set_custom_parm0(req, partition);
-	fu_struct_aver_safeisp_req_set_custom_parm1(req, size);
-	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+	fu_struct_aver_safeisp_req_set_custom_cmd(st_req,
+						  FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_PREPARE);
+	fu_struct_aver_safeisp_req_set_custom_parm0(st_req, partition);
+	fu_struct_aver_safeisp_req_set_custom_parm1(st_req, size);
+	if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 		return FALSE;
-	if (!fu_struct_aver_safeisp_res_validate(res->data, res->len, 0x0, error))
+	if (!fu_struct_aver_safeisp_res_validate(st_res->buf->data, st_res->buf->len, 0x0, error))
 		return FALSE;
 	return TRUE;
 }
@@ -133,15 +135,15 @@ fu_aver_safeisp_device_erase_flash(FuAverSafeispDevice *self,
 				   gsize param1,
 				   GError **error)
 {
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) st_res = fu_struct_aver_safeisp_res_new();
 
-	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_ERASE_TEMP);
-	fu_struct_aver_safeisp_req_set_custom_parm0(req, param0);
-	fu_struct_aver_safeisp_req_set_custom_parm1(req, param1);
-	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+	fu_struct_aver_safeisp_req_set_custom_cmd(st_req, FU_AVER_SAFEISP_CUSTOM_CMD_ERASE_TEMP);
+	fu_struct_aver_safeisp_req_set_custom_parm0(st_req, param0);
+	fu_struct_aver_safeisp_req_set_custom_parm1(st_req, param1);
+	if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 		return FALSE;
-	if (!fu_struct_aver_safeisp_res_validate(res->data, res->len, 0x0, error))
+	if (!fu_struct_aver_safeisp_res_validate(st_res->buf->data, st_res->buf->len, 0x0, error))
 		return FALSE;
 	return TRUE;
 }
@@ -158,8 +160,8 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 	fu_progress_set_steps(progress, fu_chunk_array_length(chunks));
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
 		g_autoptr(FuChunk) chk = NULL;
-		g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-		g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
+		g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+		g_autoptr(FuStructAverSafeispRes) st_res = fu_struct_aver_safeisp_res_new();
 
 		/* prepare chunk */
 		chk = fu_chunk_array_index(chunks, i, error);
@@ -169,11 +171,11 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 		/* copy in payload */
 		if (partition == ISP_CX3) {
 			fu_struct_aver_safeisp_req_set_custom_cmd(
-			    req,
+			    st_req,
 			    FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_TO_CX3);
 		} else if (partition == ISP_M12) {
 			fu_struct_aver_safeisp_req_set_custom_cmd(
-			    req,
+			    st_req,
 			    FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_TO_M12MO);
 		} else {
 			g_set_error(error,
@@ -184,11 +186,11 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 			return FALSE;
 		}
 
-		fu_struct_aver_safeisp_req_set_custom_parm0(req, fu_chunk_get_address(chk));
-		fu_struct_aver_safeisp_req_set_custom_parm1(req, fu_chunk_get_data_sz(chk));
+		fu_struct_aver_safeisp_req_set_custom_parm0(st_req, fu_chunk_get_address(chk));
+		fu_struct_aver_safeisp_req_set_custom_parm1(st_req, fu_chunk_get_data_sz(chk));
 
-		if (!fu_memcpy_safe(req->data,
-				    req->len,
+		if (!fu_memcpy_safe(st_req->buf->data,
+				    st_req->buf->len,
 				    FU_STRUCT_AVER_SAFEISP_REQ_OFFSET_DATA, /* dst */
 				    fu_chunk_get_data(chk),
 				    fu_chunk_get_data_sz(chk),
@@ -200,12 +202,16 @@ fu_aver_safeisp_device_upload(FuAverSafeispDevice *self,
 		/* resize the last packet */
 		if ((i == (fu_chunk_array_length(chunks) - 1)) &&
 		    (fu_chunk_get_data_sz(chk) < 512)) {
-			fu_byte_array_set_size(req, 12 + fu_chunk_get_data_sz(chk), 0x0);
-			fu_struct_aver_safeisp_req_set_custom_parm1(req, fu_chunk_get_data_sz(chk));
+			fu_byte_array_set_size(st_req->buf, 12 + fu_chunk_get_data_sz(chk), 0x0);
+			fu_struct_aver_safeisp_req_set_custom_parm1(st_req,
+								    fu_chunk_get_data_sz(chk));
 		}
-		if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+		if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 			return FALSE;
-		if (!fu_struct_aver_safeisp_res_validate(res->data, res->len, 0x0, error))
+		if (!fu_struct_aver_safeisp_res_validate(st_res->buf->data,
+							 st_res->buf->len,
+							 0x0,
+							 error))
 			return FALSE;
 
 		/* update progress */
@@ -222,19 +228,19 @@ fu_aver_safeisp_device_upload_checksum(FuAverSafeispDevice *self,
 				       gsize param1,
 				       GError **error)
 {
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-	g_autoptr(FuStructAverSafeispRes) res = fu_struct_aver_safeisp_res_new();
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	g_autoptr(FuStructAverSafeispRes) st_res = fu_struct_aver_safeisp_res_new();
 
 	fu_struct_aver_safeisp_req_set_custom_cmd(
-	    req,
+	    st_req,
 	    FU_AVER_SAFEISP_CUSTOM_CMD_UPLOAD_COMPARE_CHECKSUM);
-	fu_struct_aver_safeisp_req_set_custom_parm0(req, param0);
-	fu_struct_aver_safeisp_req_set_custom_parm1(req, param1);
-	if (!fu_aver_safeisp_device_transfer(self, req, res, error))
+	fu_struct_aver_safeisp_req_set_custom_parm0(st_req, param0);
+	fu_struct_aver_safeisp_req_set_custom_parm1(st_req, param1);
+	if (!fu_aver_safeisp_device_transfer(self, st_req->buf, st_res->buf, error))
 		return FALSE;
-	if (!fu_struct_aver_safeisp_res_validate(res->data, res->len, 0x0, error))
+	if (!fu_struct_aver_safeisp_res_validate(st_res->buf->data, st_res->buf->len, 0x0, error))
 		return FALSE;
-	if (fu_struct_aver_safeisp_req_get_custom_cmd(res) != FU_AVER_SAFEISP_ACK_STATUS_SUCCESS)
+	if (fu_struct_aver_safeisp_res_get_custom_cmd(st_res) != FU_AVER_SAFEISP_ACK_STATUS_SUCCESS)
 		return FALSE;
 	return TRUE;
 }
@@ -242,14 +248,11 @@ fu_aver_safeisp_device_upload_checksum(FuAverSafeispDevice *self,
 static gboolean
 fu_aver_safeisp_device_update(FuAverSafeispDevice *self, gsize param0, gsize param1, GError **error)
 {
-	g_autoptr(FuStructAverSafeispReq) req = fu_struct_aver_safeisp_req_new();
-
-	fu_struct_aver_safeisp_req_set_custom_cmd(req, FU_AVER_SAFEISP_CUSTOM_CMD_UPDATE_START);
-	fu_struct_aver_safeisp_req_set_custom_parm0(req, param0);
-	fu_struct_aver_safeisp_req_set_custom_parm1(req, param1);
-	if (!fu_aver_safeisp_device_transfer(self, req, NULL, error))
-		return FALSE;
-	return TRUE;
+	g_autoptr(FuStructAverSafeispReq) st_req = fu_struct_aver_safeisp_req_new();
+	fu_struct_aver_safeisp_req_set_custom_cmd(st_req, FU_AVER_SAFEISP_CUSTOM_CMD_UPDATE_START);
+	fu_struct_aver_safeisp_req_set_custom_parm0(st_req, param0);
+	fu_struct_aver_safeisp_req_set_custom_parm1(st_req, param1);
+	return fu_aver_safeisp_device_transfer(self, st_req->buf, NULL, error);
 }
 
 static gboolean

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -114,8 +114,8 @@ fu_bnr_dp_device_write_request(FuBnrDpDevice *self,
 
 	/* write optional data */
 	checksum = fu_bnr_dp_device_xor_checksum(FU_BNR_DP_CHECKSUM_INIT_TX,
-						 st_request->data,
-						 st_request->len);
+						 st_request->buf->data,
+						 st_request->buf->len);
 	if (buf != NULL && bufsz > 0) {
 		if (!fu_dpaux_device_write(FU_DPAUX_DEVICE(self),
 					   FU_BNR_DP_DEVICE_DATA_OFFSET,
@@ -134,8 +134,8 @@ fu_bnr_dp_device_write_request(FuBnrDpDevice *self,
 	/* write header to kick off processing by the device */
 	return fu_dpaux_device_write(FU_DPAUX_DEVICE(self),
 				     FU_BNR_DP_DEVICE_HEADER_OFFSET,
-				     st_header->data,
-				     st_header->len,
+				     st_header->buf->data,
+				     st_header->buf->len,
 				     FU_BNR_DP_DEVICE_DPAUX_TIMEOUT_MSEC,
 				     error);
 }
@@ -169,8 +169,8 @@ fu_bnr_dp_device_read_response(FuBnrDpDevice *self, GByteArray *data, GError **e
 		return FALSE;
 
 	actual_checksum = fu_bnr_dp_device_xor_checksum(FU_BNR_DP_CHECKSUM_INIT_RX,
-							st_response->data,
-							st_response->len);
+							st_response->buf->data,
+							st_response->buf->len);
 
 	/* read command output data */
 	g_byte_array_set_size(data, fu_struct_bnr_dp_aux_response_get_data_len(st_response));

--- a/plugins/bnr-dp/fu-bnr-dp-firmware.c
+++ b/plugins/bnr-dp/fu-bnr-dp-firmware.c
@@ -448,7 +448,7 @@ fu_bnr_dp_firmware_patch_boot_counter(FuBnrDpFirmware *self,
 
 	/* check that the current CRC was correct */
 	crc = fu_crc16(FU_CRC_KIND_B16_BNR,
-		       st_header->data,
+		       st_header->buf->data,
 		       FU_STRUCT_BNR_DP_PAYLOAD_HEADER_SIZE - sizeof(crc));
 	if (fu_struct_bnr_dp_payload_header_get_crc(st_header) != crc) {
 		g_set_error(
@@ -473,7 +473,7 @@ fu_bnr_dp_firmware_patch_boot_counter(FuBnrDpFirmware *self,
 
 	/* update checksum */
 	crc = fu_crc16(FU_CRC_KIND_B16_BNR,
-		       st_header->data,
+		       st_header->buf->data,
 		       FU_STRUCT_BNR_DP_PAYLOAD_HEADER_SIZE - sizeof(crc));
 
 	fu_struct_bnr_dp_payload_header_set_crc(st_header, crc);

--- a/plugins/ccgx/fu-ccgx-firmware.c
+++ b/plugins/ccgx/fu-ccgx-firmware.c
@@ -460,10 +460,10 @@ fu_ccgx_firmware_write(FuFirmware *firmware, GError **error)
 	if (!fu_memcpy_safe(mdbuf->data,
 			    mdbuf->len,
 			    0x40, /* dst */
-			    st_metadata->data,
-			    st_metadata->len,
+			    st_metadata->buf->data,
+			    st_metadata->buf->len,
 			    0x0, /* src */
-			    st_metadata->len,
+			    st_metadata->buf->len,
 			    error))
 		return NULL;
 	fu_ccgx_firmware_write_record(str,

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1287,10 +1287,10 @@ fu_ccgx_hpi_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* invalidate metadata for alternate image */
-	if (!fu_ccgx_hpi_device_load_metadata(self, fw_mode_alt, st_metadata, error))
+	if (!fu_ccgx_hpi_device_load_metadata(self, fw_mode_alt, st_metadata->buf, error))
 		return FALSE;
 	fu_struct_ccgx_metadata_hdr_set_metadata_valid(st_metadata, 0x0);
-	if (!fu_ccgx_hpi_device_save_metadata(self, fw_mode_alt, st_metadata, error))
+	if (!fu_ccgx_hpi_device_save_metadata(self, fw_mode_alt, st_metadata->buf, error))
 		return FALSE;
 	fu_progress_step_done(progress);
 

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -34,19 +34,16 @@ fu_ccgx_pure_hid_device_command(FuCcgxPureHidDevice *self,
 				guint8 param2,
 				GError **error)
 {
-	g_autoptr(FuStructCcgxPureHidCommand) cmd = fu_struct_ccgx_pure_hid_command_new();
-	fu_struct_ccgx_pure_hid_command_set_cmd(cmd, param1);
-	fu_struct_ccgx_pure_hid_command_set_opt(cmd, param2);
-	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
-				      FU_CCGX_PURE_HID_REPORT_ID_COMMAND,
-				      cmd->data,
-				      cmd->len,
-				      FU_CCGX_PURE_HID_DEVICE_TIMEOUT,
-				      FU_HID_DEVICE_FLAG_NONE,
-				      error)) {
-		return FALSE;
-	}
-	return TRUE;
+	g_autoptr(FuStructCcgxPureHidCommand) st = fu_struct_ccgx_pure_hid_command_new();
+	fu_struct_ccgx_pure_hid_command_set_cmd(st, param1);
+	fu_struct_ccgx_pure_hid_command_set_opt(st, param2);
+	return fu_hid_device_set_report(FU_HID_DEVICE(self),
+					FU_CCGX_PURE_HID_REPORT_ID_COMMAND,
+					st->buf->data,
+					st->buf->len,
+					FU_CCGX_PURE_HID_DEVICE_TIMEOUT,
+					FU_HID_DEVICE_FLAG_NONE,
+					error);
 }
 
 static gboolean
@@ -318,8 +315,8 @@ fu_ccgx_pure_hid_device_write_row(FuCcgxPureHidDevice *self,
 	fu_struct_ccgx_pure_hid_write_hdr_set_pd_resp(st_hdr,
 						      FU_CCGX_PD_RESP_FLASH_READ_WRITE_CMD_SIG);
 	fu_struct_ccgx_pure_hid_write_hdr_set_addr(st_hdr, address);
-	if (!fu_memcpy_safe(st_hdr->data,
-			    st_hdr->len,
+	if (!fu_memcpy_safe(st_hdr->buf->data,
+			    st_hdr->buf->len,
 			    FU_STRUCT_CCGX_PURE_HID_WRITE_HDR_OFFSET_DATA,
 			    row,
 			    row_len,
@@ -329,9 +326,9 @@ fu_ccgx_pure_hid_device_write_row(FuCcgxPureHidDevice *self,
 		return FALSE;
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
-				      st_hdr->data[0],
-				      st_hdr->data,
-				      st_hdr->len,
+				      st_hdr->buf->data[0],
+				      st_hdr->buf->data,
+				      st_hdr->buf->len,
 				      FU_CCGX_PURE_HID_DEVICE_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {

--- a/plugins/cfu/fu-cfu-device.c
+++ b/plugins/cfu/fu-cfu-device.c
@@ -70,7 +70,7 @@ fu_cfu_device_send_offer_info(FuCfuDevice *self, FuCfuOfferInfoCode info_code, G
 	/* SetReport */
 	fu_struct_cfu_offer_info_req_set_code(st_req, info_code);
 	fu_byte_array_append_uint8(buf_out, self->offer_set_report.id);
-	g_byte_array_append(buf_out, st_req->data, st_req->len);
+	fu_byte_array_append_array(buf_out, st_req->buf);
 	fu_byte_array_set_size(buf_out, self->offer_set_report.ct, 0x0);
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      self->offer_set_report.id,
@@ -231,7 +231,7 @@ fu_cfu_device_send_payload(FuCfuDevice *self,
 		fu_struct_cfu_content_req_set_address(st_req, fu_chunk_get_address(chk));
 
 		fu_byte_array_append_uint8(buf_out, self->content_set_report.id);
-		g_byte_array_append(buf_out, st_req->data, st_req->len);
+		fu_byte_array_append_array(buf_out, st_req->buf);
 		g_byte_array_append(buf_out, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 		fu_byte_array_set_size(buf_out, self->content_set_report.ct + 1, 0x0);
 
@@ -474,7 +474,7 @@ fu_cfu_device_setup(FuDevice *device, GError **error)
 	modules_by_cid = g_hash_table_new(g_direct_hash, g_direct_equal);
 
 	/* read each component module version */
-	offset += 0x1 + st->len;
+	offset += 0x1 + st->buf->len;
 	component_cnt = fu_struct_cfu_get_version_rsp_get_component_cnt(st);
 	for (guint i = 0; i < component_cnt; i++) {
 		g_autoptr(FuCfuModule) module = fu_cfu_module_new(device);

--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.c
@@ -25,39 +25,37 @@ fu_dell_kestrel_ec_dev_entry(FuDellKestrelEc *self,
 			     FuDellKestrelEcDevSubtype subtype,
 			     FuDellKestrelEcDevInstance instance)
 {
-	g_autoptr(FuStructDellKestrelDockInfoHeader) hdr = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoHeader) st = NULL;
 	guint num = 0;
 
-	hdr = fu_struct_dell_kestrel_dock_info_get_header(self->dock_info);
-	num = fu_struct_dell_kestrel_dock_info_header_get_total_devices(hdr);
+	st = fu_struct_dell_kestrel_dock_info_get_header(self->dock_info);
+	num = fu_struct_dell_kestrel_dock_info_header_get_total_devices(st);
 	if (num < 1) {
-		g_debug("no device found in dock info hdr");
+		g_debug("no device found in dock info st");
 		return NULL;
 	}
 
 	for (guint i = 0; i < num; i++) {
-		g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) comp_dev = NULL;
-		g_autoptr(FuStructDellKestrelDockInfoEcAddrMap) comp_info = NULL;
+		g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st_dev = NULL;
+		g_autoptr(FuStructDellKestrelDockInfoEcAddrMap) st_info = NULL;
 
-		comp_dev = fu_struct_dell_kestrel_dock_info_get_devices(self->dock_info, i);
-		comp_info =
-		    fu_struct_dell_kestrel_dock_info_ec_query_entry_get_ec_addr_map(comp_dev);
+		st_dev = fu_struct_dell_kestrel_dock_info_get_devices(self->dock_info, i);
+		st_info = fu_struct_dell_kestrel_dock_info_ec_query_entry_get_ec_addr_map(st_dev);
 
 		if (dev_type !=
-		    fu_struct_dell_kestrel_dock_info_ec_addr_map_get_device_type(comp_info))
+		    fu_struct_dell_kestrel_dock_info_ec_addr_map_get_device_type(st_info))
 			continue;
 
 		if (subtype != 0 &&
-		    subtype != fu_struct_dell_kestrel_dock_info_ec_addr_map_get_subtype(comp_info))
+		    subtype != fu_struct_dell_kestrel_dock_info_ec_addr_map_get_subtype(st_info))
 			continue;
 
 		/* vary by instance index */
 		if (dev_type == FU_DELL_KESTREL_EC_DEV_TYPE_PD &&
-		    instance !=
-			fu_struct_dell_kestrel_dock_info_ec_addr_map_get_instance(comp_info))
+		    instance != fu_struct_dell_kestrel_dock_info_ec_addr_map_get_instance(st_info))
 			continue;
 
-		return g_steal_pointer(&comp_dev);
+		return g_steal_pointer(&st_dev);
 	}
 	return NULL;
 }
@@ -68,9 +66,9 @@ fu_dell_kestrel_ec_is_dev_present(FuDellKestrelEc *self,
 				  FuDellKestrelEcDevSubtype subtype,
 				  FuDellKestrelEcDevInstance instance)
 {
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
-	return dev_entry != NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
+	return st != NULL;
 }
 
 gboolean
@@ -213,10 +211,10 @@ fu_dell_kestrel_ec_probe_pd(FuDellKestrelEc *self,
 			    GError **error)
 {
 	g_autoptr(FuDellKestrelPd) pd_dev = NULL;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
-	if (dev_entry == NULL)
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
+	if (st == NULL)
 		return TRUE;
 
 	pd_dev = fu_dell_kestrel_pd_new(FU_DEVICE(self), subtype, instance);
@@ -226,9 +224,9 @@ fu_dell_kestrel_ec_probe_pd(FuDellKestrelEc *self,
 static gboolean
 fu_dell_kestrel_ec_probe_subcomponents(FuDellKestrelEc *self, GError **error)
 {
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry_ilan = NULL;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry_dpmux = NULL;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry_wt = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st_ilan = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st_dpmux = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st_wt = NULL;
 
 	/* Package */
 	if (!fu_dell_kestrel_ec_probe_package(self, error))
@@ -259,9 +257,8 @@ fu_dell_kestrel_ec_probe_subcomponents(FuDellKestrelEc *self, GError **error)
 		return FALSE;
 
 	/* DP MUX | Retimer */
-	dev_entry_dpmux =
-	    fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_DP_MUX, 0, 0);
-	if (dev_entry_dpmux != NULL) {
+	st_dpmux = fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_DP_MUX, 0, 0);
+	if (st_dpmux != NULL) {
 		g_autoptr(FuDellKestrelDpmux) dpmux_device = NULL;
 
 		dpmux_device = fu_dell_kestrel_dpmux_new(FU_DEVICE(self));
@@ -270,8 +267,8 @@ fu_dell_kestrel_ec_probe_subcomponents(FuDellKestrelEc *self, GError **error)
 	}
 
 	/* WT PD */
-	dev_entry_wt = fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_WTPD, 0, 0);
-	if (dev_entry_wt != NULL) {
+	st_wt = fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_WTPD, 0, 0);
+	if (st_wt != NULL) {
 		g_autoptr(FuDellKestrelWtpd) wt_dev = NULL;
 
 		wt_dev = fu_dell_kestrel_wtpd_new(FU_DEVICE(self));
@@ -280,8 +277,8 @@ fu_dell_kestrel_ec_probe_subcomponents(FuDellKestrelEc *self, GError **error)
 	}
 
 	/* LAN */
-	dev_entry_ilan = fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_LAN, 0, 0);
-	if (dev_entry_ilan != NULL) {
+	st_ilan = fu_dell_kestrel_ec_dev_entry(self, FU_DELL_KESTREL_EC_DEV_TYPE_LAN, 0, 0);
+	if (st_ilan != NULL) {
 		g_autoptr(FuDellKestrelIlan) ilan_device = NULL;
 
 		ilan_device = fu_dell_kestrel_ilan_new(FU_DEVICE(self));
@@ -350,14 +347,15 @@ static gboolean
 fu_dell_kestrel_ec_dock_info_cmd(FuDellKestrelEc *self, GError **error)
 {
 	FuDellKestrelEcCmd cmd = FU_DELL_KESTREL_EC_CMD_GET_DOCK_INFO;
-	g_autoptr(FuStructDellKestrelDockInfo) res = fu_struct_dell_kestrel_dock_info_new();
+	g_autoptr(FuStructDellKestrelDockInfo) st_res = fu_struct_dell_kestrel_dock_info_new();
 
 	/* get dock info over HID */
-	if (!fu_dell_kestrel_ec_read(self, cmd, res, error)) {
+	if (!fu_dell_kestrel_ec_read(self, cmd, st_res->buf, error)) {
 		g_prefix_error_literal(error, "failed to query dock info: ");
 		return FALSE;
 	}
-	self->dock_info = fu_struct_dell_kestrel_dock_info_parse(res->data, res->len, 0, error);
+	self->dock_info =
+	    fu_struct_dell_kestrel_dock_info_parse(st_res->buf->data, st_res->buf->len, 0, error);
 	return TRUE;
 }
 
@@ -387,17 +385,18 @@ static gboolean
 fu_dell_kestrel_ec_dock_data_cmd(FuDellKestrelEc *self, GError **error)
 {
 	FuDellKestrelEcCmd cmd = FU_DELL_KESTREL_EC_CMD_GET_DOCK_DATA;
-	g_autoptr(FuStructDellKestrelDockData) res = fu_struct_dell_kestrel_dock_data_new();
+	g_autoptr(FuStructDellKestrelDockData) st = fu_struct_dell_kestrel_dock_data_new();
 
 	/* get dock data over HID */
-	if (!fu_dell_kestrel_ec_read(self, cmd, res, error)) {
+	if (!fu_dell_kestrel_ec_read(self, cmd, st->buf, error)) {
 		g_prefix_error_literal(error, "failed to query dock data: ");
 		return FALSE;
 	}
 
 	if (self->dock_data != NULL)
 		fu_struct_dell_kestrel_dock_data_unref(self->dock_data);
-	self->dock_data = fu_struct_dell_kestrel_dock_data_parse(res->data, res->len, 0, error);
+	self->dock_data =
+	    fu_struct_dell_kestrel_dock_data_parse(st->buf->data, st->buf->len, 0, error);
 	if (self->dock_data == NULL)
 		return FALSE;
 	if (!fu_dell_kestrel_ec_dock_data_extract(self, error))
@@ -470,7 +469,7 @@ fu_dell_kestrel_ec_own_dock(FuDellKestrelEc *self, gboolean lock, GError **error
 		return FALSE;
 
 	fu_device_sleep(FU_DEVICE(self), 1000);
-	if (!fu_dell_kestrel_ec_write(self, st_req, &error_local)) {
+	if (!fu_dell_kestrel_ec_write(self, st_req->buf, &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND))
 			g_debug("ignoring: %s", error_local->message);
 		else {
@@ -505,7 +504,7 @@ fu_dell_kestrel_ec_run_passive_update(FuDellKestrelEc *self, GError **error)
 
 	for (guint i = 1; i <= max_tries; i++) {
 		g_debug("register passive update (uod) flow (%u/%u)", i, max_tries);
-		if (!fu_dell_kestrel_ec_write(self, st_req, error)) {
+		if (!fu_dell_kestrel_ec_write(self, st_req->buf, error)) {
 			g_prefix_error_literal(error, "failed to register uod flow: ");
 			return FALSE;
 		}
@@ -518,22 +517,22 @@ static gboolean
 fu_dell_kestrel_ec_set_dock_sku(FuDellKestrelEc *self, GError **error)
 {
 	if (self->base_type == FU_DELL_DOCK_BASE_TYPE_KESTREL) {
-		g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+		g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
 		/* TBT type yet available, do workaround */
-		dev_entry = fu_dell_kestrel_ec_dev_entry(self,
-							 FU_DELL_KESTREL_EC_DEV_TYPE_TBT,
-							 FU_DELL_KESTREL_EC_DEV_SUBTYPE_BR,
-							 0);
-		if (dev_entry != NULL) {
+		st = fu_dell_kestrel_ec_dev_entry(self,
+						  FU_DELL_KESTREL_EC_DEV_TYPE_TBT,
+						  FU_DELL_KESTREL_EC_DEV_SUBTYPE_BR,
+						  0);
+		if (st != NULL) {
 			self->base_sku = FU_DELL_KESTREL_DOCK_SKU_T5;
 			return TRUE;
 		}
-		dev_entry = fu_dell_kestrel_ec_dev_entry(self,
-							 FU_DELL_KESTREL_EC_DEV_TYPE_TBT,
-							 FU_DELL_KESTREL_EC_DEV_SUBTYPE_GR,
-							 0);
-		if (dev_entry != NULL) {
+		st = fu_dell_kestrel_ec_dev_entry(self,
+						  FU_DELL_KESTREL_EC_DEV_TYPE_TBT,
+						  FU_DELL_KESTREL_EC_DEV_SUBTYPE_GR,
+						  0);
+		if (st != NULL) {
 			self->base_sku = FU_DELL_KESTREL_DOCK_SKU_T4;
 			return TRUE;
 		}
@@ -554,72 +553,66 @@ fu_dell_kestrel_ec_get_pd_version(FuDellKestrelEc *self,
 				  FuDellKestrelEcDevInstance instance)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_PD;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, subtype, instance);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 guint32
 fu_dell_kestrel_ec_get_ilan_version(FuDellKestrelEc *self)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_LAN;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 guint32
 fu_dell_kestrel_ec_get_wtpd_version(FuDellKestrelEc *self)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_WTPD;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 guint32
 fu_dell_kestrel_ec_get_dpmux_version(FuDellKestrelEc *self)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_DP_MUX;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 guint32
 fu_dell_kestrel_ec_get_rmm_version(FuDellKestrelEc *self)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_RMM;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 static guint32
 fu_dell_kestrel_ec_get_ec_version(FuDellKestrelEc *self)
 {
 	FuDellKestrelEcDevType dev_type = FU_DELL_KESTREL_EC_DEV_TYPE_MAIN_EC;
-	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) dev_entry = NULL;
+	g_autoptr(FuStructDellKestrelDockInfoEcQueryEntry) st = NULL;
 
-	dev_entry = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
-	return (dev_entry == NULL)
-		   ? 0
-		   : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(dev_entry);
+	st = fu_dell_kestrel_ec_dev_entry(self, dev_type, 0, 0);
+	return (st == NULL) ? 0
+			    : fu_struct_dell_kestrel_dock_info_ec_query_entry_get_version_32(st);
 }
 
 guint32
@@ -661,9 +654,9 @@ fu_dell_kestrel_ec_commit_package(FuDellKestrelEc *self, GInputStream *stream, G
 	if (!fu_struct_dell_kestrel_ec_databytes_set_data(st_req, buf->data, buf->len, error))
 		return FALSE;
 
-	fu_dump_raw(G_LOG_DOMAIN, "->PACKAGE", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "->PACKAGE", st_req->buf->data, st_req->buf->len);
 
-	if (!fu_dell_kestrel_ec_write(self, st_req, error)) {
+	if (!fu_dell_kestrel_ec_write(self, st_req->buf, error)) {
 		g_prefix_error_literal(error, "failed to commit package: ");
 		return FALSE;
 	}

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
@@ -32,17 +32,17 @@ fu_dell_kestrel_rtshub_to_string(FuDevice *device, guint idt, GString *str)
 static gboolean
 fu_dell_kestrel_rtshub_set_clock_mode(FuDellKestrelRtshub *self, gboolean enable, GError **error)
 {
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_MCUMODIFYCLOCK);
-	fu_struct_rtshub_hid_cmd_buf_set_regaddr(cmd_buf, (guint8)enable);
-	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(cmd_buf, 0);
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_WRITE_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_MCUMODIFYCLOCK);
+	fu_struct_rtshub_hid_cmd_buf_set_regaddr(st_cmd, (guint8)enable);
+	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(st_cmd, 0);
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {
@@ -55,17 +55,17 @@ fu_dell_kestrel_rtshub_set_clock_mode(FuDellKestrelRtshub *self, gboolean enable
 static gboolean
 fu_dell_kestrel_rtshub_erase_spare_bank(FuDellKestrelRtshub *self, GError **error)
 {
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_ERASEBANK);
-	fu_struct_rtshub_hid_cmd_buf_set_regaddr(cmd_buf, 0x0100);
-	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(cmd_buf, 0);
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_WRITE_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_ERASEBANK);
+	fu_struct_rtshub_hid_cmd_buf_set_regaddr(st_cmd, 0x0100);
+	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(st_cmd, 0);
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT * 3,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {
@@ -80,17 +80,17 @@ fu_dell_kestrel_rtshub_verify_update_fw(FuDellKestrelRtshub *self,
 					FuProgress *progress,
 					GError **error)
 {
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_VERIFYUPDATE);
-	fu_struct_rtshub_hid_cmd_buf_set_regaddr(cmd_buf, 0x01);
-	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(cmd_buf, 0);
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_WRITE_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_VERIFYUPDATE);
+	fu_struct_rtshub_hid_cmd_buf_set_regaddr(st_cmd, 0x01);
+	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(st_cmd, 0);
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error))
@@ -98,15 +98,15 @@ fu_dell_kestrel_rtshub_verify_update_fw(FuDellKestrelRtshub *self,
 	fu_device_sleep_full(FU_DEVICE(self), 4000, progress); /* ms */
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error))
 		return FALSE;
 
 	/* check device status, 1 for success otherwise fail */
-	if (cmd_buf->data[0] != 0x01) {
+	if (st_cmd->buf->data[0] != 0x01) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "firmware flash failed");
 		return FALSE;
 	}
@@ -118,15 +118,15 @@ fu_dell_kestrel_rtshub_verify_update_fw(FuDellKestrelRtshub *self,
 static gboolean
 fu_dell_kestrel_rtshub_reset_device(FuDellKestrelRtshub *self, GError **error)
 {
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_RESET_TO_FLASH);
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_WRITE_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_RESET_TO_FLASH);
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {
@@ -144,23 +144,23 @@ fu_dell_kestrel_rtshub_write_flash(FuDellKestrelRtshub *self,
 				   guint16 data_sz,
 				   GError **error)
 {
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
 	g_return_val_if_fail(data_sz <= 128, FALSE);
 	g_return_val_if_fail(data != NULL, FALSE);
 	g_return_val_if_fail(data_sz != 0, FALSE);
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_WRITE_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_WRITEFLASH);
-	fu_struct_rtshub_hid_cmd_buf_set_regaddr(cmd_buf, addr);
-	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(cmd_buf, data_sz);
-	if (!fu_struct_rtshub_hid_cmd_buf_set_data(cmd_buf, data, data_sz, error))
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_WRITE_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_WRITEFLASH);
+	fu_struct_rtshub_hid_cmd_buf_set_regaddr(st_cmd, addr);
+	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(st_cmd, data_sz);
+	if (!fu_struct_rtshub_hid_cmd_buf_set_data(st_cmd, data, data_sz, error))
 		return FALSE;
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {
@@ -265,39 +265,39 @@ fu_dell_kestrel_rtshub_get_status(FuDevice *device, GError **error)
 {
 	FuDellKestrelRtshub *self = FU_DELL_KESTREL_RTSHUB(device);
 	g_autofree gchar *version = NULL;
-	g_autoptr(FuStructRtshubHidCmdBuf) cmd_buf = fu_struct_rtshub_hid_cmd_buf_new();
+	g_autoptr(FuStructRtshubHidCmdBuf) st_cmd = fu_struct_rtshub_hid_cmd_buf_new();
 
-	fu_struct_rtshub_hid_cmd_buf_set_cmd(cmd_buf, RTSHUB_CMD_READ_DATA);
-	fu_struct_rtshub_hid_cmd_buf_set_ext(cmd_buf, RTSHUB_EXT_READ_STATUS);
-	fu_struct_rtshub_hid_cmd_buf_set_regaddr(cmd_buf, 0x00);
-	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(cmd_buf, 12);
+	fu_struct_rtshub_hid_cmd_buf_set_cmd(st_cmd, RTSHUB_CMD_READ_DATA);
+	fu_struct_rtshub_hid_cmd_buf_set_ext(st_cmd, RTSHUB_EXT_READ_STATUS);
+	fu_struct_rtshub_hid_cmd_buf_set_regaddr(st_cmd, 0x00);
+	fu_struct_rtshub_hid_cmd_buf_set_bufferlen(st_cmd, 12);
 
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_RETRY_FAILURE,
 				      error))
 		return FALSE;
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      0x0,
-				      cmd_buf->data,
-				      cmd_buf->len,
+				      st_cmd->buf->data,
+				      st_cmd->buf->len,
 				      DELL_KESTREL_RTSHUB_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_RETRY_FAILURE,
 				      error))
 		return FALSE;
 
 	/* version: index 10, subversion: index 11 */
-	version = g_strdup_printf("%x.%x", cmd_buf->data[10], cmd_buf->data[11]);
+	version = g_strdup_printf("%x.%x", st_cmd->buf->data[10], st_cmd->buf->data[11]);
 	fu_device_set_version(device, version);
 
 	/* dual bank capability */
-	self->dual_bank = (cmd_buf->data[13] & 0xf0) == 0x80;
+	self->dual_bank = (st_cmd->buf->data[13] & 0xf0) == 0x80;
 
 	/* authentication capability */
-	self->fw_auth = (cmd_buf->data[13] & 0x02) > 0;
+	self->fw_auth = (st_cmd->buf->data[13] & 0x02) > 0;
 
 	return TRUE;
 }

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -40,7 +40,7 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 	g_autoptr(FuStructEbitdoPkt) st_hdr = fu_struct_ebitdo_pkt_new();
 	g_autoptr(GError) error_local = NULL;
 
-	fu_byte_array_set_size(st_hdr, FU_EBITDO_USB_EP_SIZE, 0x0);
+	fu_byte_array_set_size(st_hdr->buf, FU_EBITDO_USB_EP_SIZE, 0x0);
 
 	/* different */
 	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
@@ -64,8 +64,8 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 		fu_struct_ebitdo_pkt_set_cmd_len(st_hdr, in_len + 3);
 		fu_struct_ebitdo_pkt_set_cmd(st_hdr, cmd);
 		fu_struct_ebitdo_pkt_set_payload_len(st_hdr, in_len);
-		if (!fu_memcpy_safe(st_hdr->data,
-				    st_hdr->len,
+		if (!fu_memcpy_safe(st_hdr->buf->data,
+				    st_hdr->buf->len,
 				    FU_STRUCT_EBITDO_PKT_SIZE, /* dst */
 				    in,
 				    in_len,
@@ -79,13 +79,13 @@ fu_ebitdo_device_send(FuEbitdoDevice *self,
 		fu_struct_ebitdo_pkt_set_cmd(st_hdr, cmd);
 		fu_struct_ebitdo_pkt_set_pkt_len(st_hdr, 5);
 	}
-	fu_dump_raw(G_LOG_DOMAIN, "->DEVICE", st_hdr->data, st_hdr->len);
+	fu_dump_raw(G_LOG_DOMAIN, "->DEVICE", st_hdr->buf->data, st_hdr->buf->len);
 
 	/* get data from device */
 	if (!fu_usb_device_interrupt_transfer(FU_USB_DEVICE(self),
 					      ep_out,
-					      st_hdr->data,
-					      st_hdr->len,
+					      st_hdr->buf->data,
+					      st_hdr->buf->len,
 					      &actual_length,
 					      FU_EBITDO_USB_TIMEOUT,
 					      NULL, /* cancellable */

--- a/plugins/elan-kbd/fu-elan-kbd-device.c
+++ b/plugins/elan-kbd/fu-elan-kbd-device.c
@@ -180,7 +180,7 @@ fu_elan_kbd_device_attach(FuDevice *device, FuProgress *progress, GError **error
 	    fu_struct_elan_kbd_software_reset_req_new();
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	if (!fu_elan_kbd_device_status_check(self, buf, error))
@@ -197,7 +197,7 @@ fu_elan_kbd_device_ensure_ver_spec(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdGetVerSpecRes) st_res = NULL;
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	st_res = fu_struct_elan_kbd_get_ver_spec_res_parse(buf->data, buf->len, 0x0, error);
@@ -215,7 +215,7 @@ fu_elan_kbd_device_ensure_ver_fw(FuElanKbdDevice *self, GError **error)
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	st_res = fu_struct_elan_kbd_get_ver_fw_res_parse(buf->data, buf->len, 0x0, error);
@@ -233,7 +233,7 @@ fu_elan_kbd_device_ensure_dev_status(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdGetStatusRes) st_res = NULL;
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	st_res = fu_struct_elan_kbd_get_status_res_parse(buf->data, buf->len, 0x0, error);
@@ -251,7 +251,7 @@ fu_elan_kbd_device_ensure_boot_cond1(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdBootConditionRes) st_res = NULL;
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	st_res = fu_struct_elan_kbd_boot_condition_res_parse(buf->data, buf->len, 0x0, error);
@@ -267,7 +267,7 @@ fu_elan_kbd_device_abort(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdAbortReq) st_req = fu_struct_elan_kbd_abort_req_new();
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -308,7 +308,7 @@ fu_elan_kbd_device_cmd_read_rom_finished(FuElanKbdDevice *self, guint8 csum, GEr
 	g_autoptr(GByteArray) buf = NULL;
 
 	fu_struct_elan_kbd_read_rom_finished_req_set_csum(st_req, csum);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -332,7 +332,7 @@ fu_elan_kbd_device_cmd_read_rom(FuElanKbdDevice *self,
 	/* set up read */
 	fu_struct_elan_kbd_read_rom_req_set_addr(st_req, addr);
 	fu_struct_elan_kbd_read_rom_req_set_len(st_req, len);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return NULL;
 	if (!fu_elan_kbd_device_status_check(self, buf, error))
@@ -357,7 +357,7 @@ fu_elan_kbd_device_cmd_read_option_finished(FuElanKbdDevice *self, guint8 csum, 
 	g_autoptr(GByteArray) buf = NULL;
 
 	fu_struct_elan_kbd_read_option_finished_req_set_csum(st_req, csum);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -376,7 +376,7 @@ fu_elan_kbd_device_cmd_read_option(FuElanKbdDevice *self, FuProgress *progress, 
 	fu_progress_set_steps(progress, len / FU_ELAN_KBD_DEVICE_EP_DATA_SIZE);
 
 	/* set up read */
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return NULL;
 	if (!fu_elan_kbd_device_status_check(self, buf, error))
@@ -479,7 +479,7 @@ fu_elan_kbd_device_cmd_get_auth_lock(FuElanKbdDevice *self, guint8 *key, GError 
 	g_autoptr(FuStructElanKbdGetAuthLockRes) st_res = NULL;
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	st_res = fu_struct_elan_kbd_get_auth_lock_res_parse(buf->data, buf->len, 0x0, error);
@@ -497,7 +497,7 @@ fu_elan_kbd_device_cmd_set_auth_lock(FuElanKbdDevice *self, guint8 key, GError *
 	g_autoptr(GByteArray) buf = NULL;
 
 	fu_struct_elan_kbd_set_auth_lock_req_set_key(st_req, key ^ 0x58);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -518,7 +518,7 @@ fu_elan_kbd_device_cmd_entry_iap(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdEntryIapReq) st_req = fu_struct_elan_kbd_entry_iap_req_new();
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -530,7 +530,7 @@ fu_elan_kbd_device_cmd_finished_iap(FuElanKbdDevice *self, GError **error)
 	g_autoptr(FuStructElanKbdFinishedIapReq) st_req = fu_struct_elan_kbd_finished_iap_req_new();
 	g_autoptr(GByteArray) buf = NULL;
 
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -544,7 +544,7 @@ fu_elan_kbd_device_cmd_write_rom_finished(FuElanKbdDevice *self, guint8 csum, GE
 	g_autoptr(GByteArray) buf = NULL;
 
 	fu_struct_elan_kbd_write_rom_finished_req_set_csum(st_req, csum);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	return fu_elan_kbd_device_status_check(self, buf, error);
@@ -569,7 +569,7 @@ fu_elan_kbd_device_cmd_write_rom(FuElanKbdDevice *self,
 	/* set up write */
 	fu_struct_elan_kbd_write_rom_req_set_addr(st_req, addr);
 	fu_struct_elan_kbd_write_rom_req_set_len(st_req, bufsz);
-	buf = fu_elan_kbd_device_cmd(self, st_req, error);
+	buf = fu_elan_kbd_device_cmd(self, st_req->buf, error);
 	if (buf == NULL)
 		return FALSE;
 	if (!fu_elan_kbd_device_status_check(self, buf, error))

--- a/plugins/framework-qmk/fu-framework-qmk-device.c
+++ b/plugins/framework-qmk/fu-framework-qmk-device.c
@@ -24,12 +24,12 @@ fu_framework_qmk_device_detach(FuDevice *device, FuProgress *progress, GError **
 {
 	FuFrameworkQmkDevice *self = FU_FRAMEWORK_QMK_DEVICE(device);
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(FuStructFrameworkQmkResetRequest) req =
+	g_autoptr(FuStructFrameworkQmkResetRequest) st_req =
 	    fu_struct_framework_qmk_reset_request_new();
 
 	if (!fu_hidraw_device_set_report(FU_HIDRAW_DEVICE(self),
-					 req->data,
-					 req->len,
+					 st_req->buf->data,
+					 st_req->buf->len,
 					 FU_IO_CHANNEL_FLAG_NONE,
 					 error)) {
 		g_prefix_error_literal(error, "failed to write packet: ");

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -381,10 +381,10 @@ fu_genesys_usbhub_firmware_write(FuFirmware *firmware, GError **error)
 		if (!fu_memcpy_safe(buf->data,
 				    buf->len,
 				    GENESYS_USBHUB_STATIC_TOOL_STRING_OFFSET_GL3523, /* dst */
-				    self->st_static_ts->data,
-				    self->st_static_ts->len,
+				    self->st_static_ts->buf->data,
+				    self->st_static_ts->buf->len,
 				    0x0, /* src */
-				    self->st_static_ts->len,
+				    self->st_static_ts->buf->len,
 				    error))
 			return NULL;
 	}

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
@@ -94,7 +94,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 				    "invalid subsys_num");
 		return FALSE;
 	}
-	offset_hdr = st->len;
+	offset_hdr = st->buf->len;
 	for (guint i = 0; i < subsys_num; i++) {
 		guint32 img_size;
 		g_autoptr(FuStructGoodixBrlbImg) st_img = NULL;
@@ -117,7 +117,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 			if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 				return FALSE;
 		}
-		offset_hdr += st_img->len;
+		offset_hdr += st_img->buf->len;
 		offset_payload += img_size;
 	}
 

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
@@ -35,7 +35,7 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 	guint32 offset_hdr;
 	guint32 offset_payload = GTX8_FW_DATA_OFFSET;
 	const guint8 *buf;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructGoodixGtx8Hdr) st = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
 	st = fu_struct_goodix_gtx8_hdr_parse_stream(stream, 0x0, error);
@@ -179,10 +179,10 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 				    "subsys_num is 0");
 		return FALSE;
 	}
-	offset_hdr = st->len;
+	offset_hdr = st->buf->len;
 	for (guint i = 0; i < subsys_num; i++) {
 		guint32 img_size;
-		g_autoptr(GByteArray) st_img = NULL;
+		g_autoptr(FuStructGoodixGtx8Img) st_img = NULL;
 
 		st_img = fu_struct_goodix_gtx8_img_parse_stream(stream, offset_hdr, error);
 		if (st_img == NULL)
@@ -200,7 +200,7 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 			if (!fu_firmware_add_image(FU_FIRMWARE(self), img, error))
 				return FALSE;
 		}
-		offset_hdr += st_img->len;
+		offset_hdr += st_img->buf->len;
 		offset_payload += img_size;
 	}
 

--- a/plugins/hpi-cfu/fu-hpi-cfu-device.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-device.c
@@ -75,7 +75,7 @@ fu_hpi_cfu_device_start_entire_transaction(FuHpiCfuDevice *self, GError **error)
 	if (!fu_struct_hpi_cfu_buf_set_report_data(st_req, report_data, sizeof(report_data), error))
 		return FALSE;
 
-	fu_dump_raw(G_LOG_DOMAIN, "StartEntireTransaction", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "StartEntireTransaction", st_req->buf->data, st_req->buf->len);
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_HOST_TO_DEVICE,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -83,8 +83,8 @@ fu_hpi_cfu_device_start_entire_transaction(FuHpiCfuDevice *self, GError **error)
 					    SET_REPORT,
 					    OUT_REPORT_TYPE | OFFER_REPORT_ID,
 					    FU_HPI_CFU_INTERFACE,
-					    st_req->data,
-					    st_req->len,
+					    st_req->buf->data,
+					    st_req->buf->len,
 					    NULL,
 					    FU_HPI_CFU_DEVICE_TIMEOUT,
 					    NULL,
@@ -141,7 +141,7 @@ fu_hpi_cfu_device_send_start_offer_list(FuHpiCfuDevice *self, GError **error)
 	if (!fu_struct_hpi_cfu_buf_set_report_data(st_req, report_data, sizeof(report_data), error))
 		return FALSE;
 
-	fu_dump_raw(G_LOG_DOMAIN, "SendStartOfferList", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "SendStartOfferList", st_req->buf->data, st_req->buf->len);
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_HOST_TO_DEVICE,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -149,8 +149,8 @@ fu_hpi_cfu_device_send_start_offer_list(FuHpiCfuDevice *self, GError **error)
 					    SET_REPORT,
 					    OUT_REPORT_TYPE | OFFER_REPORT_ID,
 					    FU_HPI_CFU_INTERFACE,
-					    st_req->data,
-					    st_req->len,
+					    st_req->buf->data,
+					    st_req->buf->len,
 					    NULL,
 					    FU_HPI_CFU_DEVICE_TIMEOUT,
 					    NULL,
@@ -223,15 +223,15 @@ fu_hpi_cfu_device_send_offer_update_command(FuHpiCfuDevice *self,
 		return FALSE;
 	buf = g_bytes_get_data(blob_offer, &bufsz);
 
-	fu_struct_hpi_cfu_payload_cmd_set_report_id(st_req, OFFER_REPORT_ID);
-	if (!fu_memcpy_safe(st_req->data, st_req->len, 0x1, buf, bufsz, 0x0, 16, error))
+	fu_struct_hpi_cfu_offer_cmd_set_report_id(st_req, OFFER_REPORT_ID);
+	if (!fu_memcpy_safe(st_req->buf->data, st_req->buf->len, 0x1, buf, bufsz, 0x0, 16, error))
 		return FALSE;
 
 	FU_BIT_SET(flag_value, 7); /* (update now) */
 	FU_BIT_SET(flag_value, 6); /* (force update version) */
 	fu_struct_hpi_cfu_offer_cmd_set_flags(st_req, flag_value);
 
-	fu_dump_raw(G_LOG_DOMAIN, "SendOfferUpdateCommand", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "SendOfferUpdateCommand", st_req->buf->data, st_req->buf->len);
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_HOST_TO_DEVICE,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -239,8 +239,8 @@ fu_hpi_cfu_device_send_offer_update_command(FuHpiCfuDevice *self,
 					    SET_REPORT,
 					    OUT_REPORT_TYPE | FIRMWARE_REPORT_ID,
 					    FU_HPI_CFU_INTERFACE,
-					    st_req->data,
-					    st_req->len,
+					    st_req->buf->data,
+					    st_req->buf->len,
 					    NULL,
 					    FU_HPI_CFU_DEVICE_TIMEOUT,
 					    NULL,
@@ -380,7 +380,7 @@ fu_hpi_cfu_device_send_end_offer_list(FuHpiCfuDevice *self, GError **error)
 	if (!fu_struct_hpi_cfu_buf_set_report_data(st_req, report_data, sizeof(report_data), error))
 		return FALSE;
 
-	fu_dump_raw(G_LOG_DOMAIN, "SendEndOfferListCommand", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "SendEndOfferListCommand", st_req->buf->data, st_req->buf->len);
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_HOST_TO_DEVICE,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -388,8 +388,8 @@ fu_hpi_cfu_device_send_end_offer_list(FuHpiCfuDevice *self, GError **error)
 					    SET_REPORT,
 					    OUT_REPORT_TYPE | OFFER_REPORT_ID,
 					    FU_HPI_CFU_INTERFACE,
-					    st_req->data,
-					    st_req->len,
+					    st_req->buf->data,
+					    st_req->buf->len,
 					    NULL,
 					    FU_HPI_CFU_DEVICE_TIMEOUT,
 					    NULL,
@@ -606,7 +606,7 @@ fu_hpi_cfu_device_send_payload(FuHpiCfuDevice *self, GByteArray *cfu_buf, GError
 
 	self->currentaddress += cfu_buf->len;
 
-	fu_dump_raw(G_LOG_DOMAIN, "ToDevice", st_req->data, st_req->len);
+	fu_dump_raw(G_LOG_DOMAIN, "ToDevice", st_req->buf->data, st_req->buf->len);
 	if (!fu_usb_device_control_transfer(FU_USB_DEVICE(self),
 					    FU_USB_DIRECTION_HOST_TO_DEVICE,
 					    FU_USB_REQUEST_TYPE_VENDOR,
@@ -614,8 +614,8 @@ fu_hpi_cfu_device_send_payload(FuHpiCfuDevice *self, GByteArray *cfu_buf, GError
 					    SET_REPORT,
 					    OUT_REPORT_TYPE | FIRMWARE_REPORT_ID,
 					    FU_HPI_CFU_INTERFACE,
-					    st_req->data,
-					    st_req->len,
+					    st_req->buf->data,
+					    st_req->buf->len,
 					    NULL,
 					    FU_HPI_CFU_DEVICE_TIMEOUT,
 					    NULL,

--- a/plugins/huddly-usb/fu-huddly-usb-common.c
+++ b/plugins/huddly-usb/fu-huddly-usb-common.c
@@ -59,7 +59,7 @@ fu_huddly_usb_hlink_msg_write(FuHuddlyUsbHLinkMsg *msg, GError **error)
 	g_return_val_if_fail(msg != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-	g_byte_array_append(packet, msg->header->data, msg->header->len);
+	fu_byte_array_append_array(packet, msg->header->buf);
 	g_byte_array_append(packet, (const guint8 *)msg->msg_name, strlen(msg->msg_name));
 	if (msg->payload != NULL)
 		g_byte_array_append(packet, msg->payload->data, msg->payload->len);

--- a/plugins/ilitek-its/fu-ilitek-its-device.c
+++ b/plugins/ilitek-its/fu-ilitek-its-device.c
@@ -90,7 +90,7 @@ fu_ilitek_its_device_read_cb(FuDevice *device, gpointer data, GError **error)
 		return FALSE;
 	}
 
-	fu_dump_raw(G_LOG_DOMAIN, "HidReadReport", st_res->data, st_res->len);
+	fu_dump_raw(G_LOG_DOMAIN, "HidReadReport", st_res->buf->data, st_res->buf->len);
 
 	if (helper->rbuf != NULL)
 		g_byte_array_append(helper->rbuf, buf_data, bufsz_data);
@@ -112,8 +112,8 @@ fu_ilitek_its_device_send_cmd(FuIlitekItsDevice *self,
 	};
 
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st_cmd->data,
-					  st_cmd->len,
+					  st_cmd->buf->data,
+					  st_cmd->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error)) {
 		g_prefix_error_literal(error, "failed to send HID cmd: ");
@@ -170,8 +170,8 @@ fu_ilitek_its_device_send_long_cmd_then_wake_ack(FuIlitekItsDevice *self,
 	};
 
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st_cmd->data,
-					  st_cmd->len,
+					  st_cmd->buf->data,
+					  st_cmd->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error)) {
 		g_prefix_error_literal(error, "failed to send long HID cmd: ");
@@ -196,11 +196,11 @@ fu_ilitek_its_device_recalculate_crc(FuIlitekItsDevice *self,
 
 	fu_struct_ilitek_its_hid_cmd_set_write_len(st_cmd, 8);
 	fu_struct_ilitek_its_hid_cmd_set_cmd(st_cmd, FU_ILITEK_ITS_CMD_GET_BLOCK_CRC);
-	st_cmd->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = FU_ILITEK_ITS_CRC_RECALCULATE;
-	fu_memwrite_uint24(st_cmd->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 1,
+	st_cmd->buf->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = FU_ILITEK_ITS_CRC_RECALCULATE;
+	fu_memwrite_uint24(st_cmd->buf->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 1,
 			   start,
 			   G_LITTLE_ENDIAN);
-	fu_memwrite_uint24(st_cmd->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 4,
+	fu_memwrite_uint24(st_cmd->buf->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 4,
 			   end,
 			   G_LITTLE_ENDIAN);
 
@@ -216,7 +216,7 @@ fu_ilitek_its_device_get_block_crc(FuIlitekItsDevice *self, guint16 *crc, GError
 	fu_struct_ilitek_its_hid_cmd_set_write_len(st_cmd, 2);
 	fu_struct_ilitek_its_hid_cmd_set_read_len(st_cmd, 2);
 	fu_struct_ilitek_its_hid_cmd_set_cmd(st_cmd, FU_ILITEK_ITS_CMD_GET_BLOCK_CRC);
-	st_cmd->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = FU_ILITEK_ITS_CRC_GET;
+	st_cmd->buf->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = FU_ILITEK_ITS_CRC_GET;
 
 	if (!fu_ilitek_its_device_send_cmd(self, st_cmd, rbuf, error))
 		return FALSE;
@@ -235,14 +235,14 @@ fu_ilitek_its_device_flash_enable(FuIlitekItsDevice *self,
 
 	fu_struct_ilitek_its_hid_cmd_set_write_len(st_cmd, in_ap ? 3 : 9);
 	fu_struct_ilitek_its_hid_cmd_set_cmd(st_cmd, FU_ILITEK_ITS_CMD_FLASH_ENABLE);
-	fu_memwrite_uint16(st_cmd->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 0,
+	fu_memwrite_uint16(st_cmd->buf->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 0,
 			   FU_ILITEK_ITS_WRITE_ENABLE_KEY,
 			   G_BIG_ENDIAN);
 	if (!in_ap) {
-		fu_memwrite_uint24(st_cmd->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 2,
+		fu_memwrite_uint24(st_cmd->buf->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 2,
 				   start,
 				   G_LITTLE_ENDIAN);
-		fu_memwrite_uint24(st_cmd->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 5,
+		fu_memwrite_uint24(st_cmd->buf->data + FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 5,
 				   end,
 				   G_LITTLE_ENDIAN);
 	}
@@ -259,8 +259,8 @@ fu_ilitek_its_device_set_ctrl_mode(FuIlitekItsDevice *self,
 
 	fu_struct_ilitek_its_hid_cmd_set_write_len(st_cmd, 3);
 	fu_struct_ilitek_its_hid_cmd_set_cmd(st_cmd, FU_ILITEK_ITS_CMD_SET_CTRL_MODE);
-	st_cmd->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = mode;
-	st_cmd->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 1] = 0x0;
+	st_cmd->buf->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA] = mode;
+	st_cmd->buf->data[FU_STRUCT_ILITEK_ITS_HID_CMD_OFFSET_DATA + 1] = 0x0;
 
 	if (!fu_ilitek_its_device_send_cmd(self, st_cmd, NULL, error))
 		return FALSE;

--- a/plugins/intel-amt/fu-intel-amt-device.c
+++ b/plugins/intel-amt/fu-intel-amt-device.c
@@ -91,7 +91,7 @@ fu_intel_amt_device_get_provisioning_state(FuIntelAmtDevice *self,
 	    fu_amt_host_if_msg_provisioning_state_request_new();
 	g_autoptr(FuAmtHostIfMsgProvisioningStateResponse) st_res = NULL;
 
-	data = fu_intel_amt_device_host_if_call(self, st_req, error);
+	data = fu_intel_amt_device_host_if_call(self, st_req->buf, error);
 	if (data == NULL)
 		return FALSE;
 
@@ -122,7 +122,7 @@ fu_intel_amt_device_ensure_version(FuIntelAmtDevice *self, GError **error)
 	g_autoptr(GString) version_bl = g_string_new(NULL);
 	g_autoptr(GString) version_fw = g_string_new(NULL);
 
-	data = fu_intel_amt_device_host_if_call(self, st_req, error);
+	data = fu_intel_amt_device_host_if_call(self, st_req->buf, error);
 	if (data == NULL)
 		return FALSE;
 
@@ -142,10 +142,11 @@ fu_intel_amt_device_ensure_version(FuIntelAmtDevice *self, GError **error)
 		g_autofree gchar *version = NULL;
 		g_autoptr(FuAmtUnicodeString) st_str = NULL;
 
-		st_str = fu_amt_unicode_string_parse(data->data,
-						     data->len,
-						     st_res->len + (i * FU_AMT_UNICODE_STRING_SIZE),
-						     error);
+		st_str =
+		    fu_amt_unicode_string_parse(data->data,
+						data->len,
+						st_res->buf->len + (i * FU_AMT_UNICODE_STRING_SIZE),
+						error);
 		if (st_str == NULL)
 			return FALSE;
 

--- a/plugins/intel-cvs/fu-intel-cvs-device.c
+++ b/plugins/intel-cvs/fu-intel-cvs-device.c
@@ -202,7 +202,7 @@ fu_intel_cvs_device_write_firmware(FuDevice *device,
 	fu_struct_intel_cvs_write_set_fw_bin_fd(st_write, fu_io_channel_unix_get_fd(io_payload));
 	if (!fu_udev_device_write_sysfs_byte_array(FU_UDEV_DEVICE(self),
 						   "cvs_ctrl_data_pre",
-						   st_write,
+						   st_write->buf,
 						   FU_INTEL_CVS_DEVICE_SYSFS_TIMEOUT,
 						   error))
 		return FALSE;

--- a/plugins/intel-cvs/fu-intel-cvs-firmware.c
+++ b/plugins/intel-cvs/fu-intel-cvs-firmware.c
@@ -55,7 +55,7 @@ fu_intel_cvs_firmware_parse(FuFirmware *firmware,
 		return FALSE;
 
 	/* verify checksum of header */
-	checksum_new = fu_sum32w(st_hdr->data, st_hdr->len, G_LITTLE_ENDIAN);
+	checksum_new = fu_sum32w(st_hdr->buf->data, st_hdr->buf->len, G_LITTLE_ENDIAN);
 	if (checksum_new != 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,

--- a/plugins/intel-gsc/fu-igsc-common.c
+++ b/plugins/intel-gsc/fu-igsc-common.c
@@ -80,7 +80,7 @@ fu_igsc_fwdata_device_info_parse_device_id_array(GPtrArray *device_infos,
 		st = fu_igsc_fwdata_device_info4_parse_stream(stream, offset, error);
 		if (st == NULL)
 			return FALSE;
-		g_ptr_array_add(device_infos, g_steal_pointer(&st));
+		g_ptr_array_add(device_infos, g_steal_pointer(&st->buf));
 	}
 
 	/* success */

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -262,7 +262,11 @@ fu_intel_usb4_device_operation(FuIntelUsb4Device *self,
 	/* write the operation and poll completion or error */
 	fu_struct_intel_usb4_mbox_set_opcode(st_regex, opcode);
 	fu_struct_intel_usb4_mbox_set_status(st_regex, MBOX_OPVALID);
-	if (!fu_intel_usb4_device_set_mmio(self, MBOX_REG, st_regex->data, st_regex->len, error))
+	if (!fu_intel_usb4_device_set_mmio(self,
+					   MBOX_REG,
+					   st_regex->buf->data,
+					   st_regex->buf->len,
+					   error))
 		return FALSE;
 
 	/* leave early as successful USB4 AUTH resets the device immediately */
@@ -273,8 +277,8 @@ fu_intel_usb4_device_operation(FuIntelUsb4Device *self,
 		g_autoptr(GError) error_local = NULL;
 		if (fu_intel_usb4_device_get_mmio(self,
 						  MBOX_REG,
-						  st_regex->data,
-						  st_regex->len,
+						  st_regex->buf->data,
+						  st_regex->buf->len,
 						  &error_local))
 			return TRUE;
 		if (i == max_tries) {
@@ -310,8 +314,8 @@ fu_intel_usb4_device_nvm_read(FuIntelUsb4Device *self,
 								  fu_chunk_get_data_sz(chk) / 4);
 		if (!fu_intel_usb4_device_operation(self,
 						    FU_INTEL_USB4_OPCODE_NVM_READ,
-						    st->data,
-						    st->len,
+						    st->buf->data,
+						    st->buf->len,
 						    error)) {
 			g_prefix_error_literal(error, "hub NVM read error: ");
 			return FALSE;

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -85,8 +85,8 @@ fu_jabra_file_device_tx_cb(FuDevice *device, gpointer user_data, GError **error)
 	FuJabraFilePacket *cmd_req = (FuJabraFilePacket *)user_data;
 	if (!fu_usb_device_interrupt_transfer(FU_USB_DEVICE(self),
 					      self->epout,
-					      cmd_req->data,
-					      cmd_req->len,
+					      cmd_req->buf->data,
+					      cmd_req->buf->len,
 					      NULL,
 					      FU_JABRA_FILE_STANDARD_SEND_TIMEOUT,
 					      NULL, /* cancellable */
@@ -116,8 +116,8 @@ fu_jabra_file_device_rx_cb(FuDevice *device, gpointer user_data, GError **error)
 
 	if (!fu_usb_device_interrupt_transfer(FU_USB_DEVICE(self),
 					      self->epin,
-					      cmd_rsp->data,
-					      cmd_rsp->len,
+					      cmd_rsp->buf->data,
+					      cmd_rsp->buf->len,
 					      NULL,
 					      FU_JABRA_FILE_STANDARD_RECEIVE_TIMEOUT,
 					      NULL, /* cancellable */
@@ -125,18 +125,18 @@ fu_jabra_file_device_rx_cb(FuDevice *device, gpointer user_data, GError **error)
 		g_prefix_error_literal(error, "failed to read from device: ");
 		return FALSE;
 	}
-	if (cmd_rsp->data[2] == self->address &&
-	    (cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_IDENTITY &&
-	     cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_FILE &&
-	     cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_DFU &&
-	     cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_VIDEO &&
-	     cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK &&
-	     cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_NACK)) {
+	if (cmd_rsp->buf->data[2] == self->address &&
+	    (cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_IDENTITY &&
+	     cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_FILE &&
+	     cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_DFU &&
+	     cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_VIDEO &&
+	     cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK &&
+	     cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_NACK)) {
 		/* unrelated report, ignore and rx again */
 		if (!fu_usb_device_interrupt_transfer(FU_USB_DEVICE(self),
 						      0x82,
-						      cmd_rsp->data,
-						      cmd_rsp->len,
+						      cmd_rsp->buf->data,
+						      cmd_rsp->buf->len,
 						      NULL,
 						      FU_JABRA_FILE_STANDARD_RECEIVE_TIMEOUT,
 						      NULL, /* cancellable */
@@ -172,12 +172,12 @@ fu_jabra_file_device_rx_with_sequence_cb(FuDevice *device, gpointer user_data, G
 	cmd_rsp = fu_jabra_file_device_rx(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	if (self->sequence_number != cmd_rsp->data[3]) {
+	if (self->sequence_number != cmd_rsp->buf->data[3]) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_WRITE,
 			    "sequence_number error -- got 0x%x, expected 0x%x",
-			    cmd_rsp->data[3],
+			    cmd_rsp->buf->data[3],
 			    self->sequence_number);
 		return FALSE;
 	}
@@ -219,10 +219,10 @@ fu_jabra_file_device_ensure_name(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	name = fu_memstrsafe(cmd_rsp->data,
-			     cmd_rsp->len,
+	name = fu_memstrsafe(cmd_rsp->buf->data,
+			     cmd_rsp->buf->len,
 			     FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1,
-			     cmd_rsp->len - (FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1),
+			     cmd_rsp->buf->len - (FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1),
 			     error);
 	if (name == NULL)
 		return FALSE;
@@ -247,8 +247,8 @@ fu_jabra_file_device_ensure_dfu_pid(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	self->dfu_pid =
-	    fu_memread_uint16(cmd_rsp->data + FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD, G_LITTLE_ENDIAN);
+	self->dfu_pid = fu_memread_uint16(cmd_rsp->buf->data + FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD,
+					  G_LITTLE_ENDIAN);
 	return TRUE;
 }
 
@@ -270,10 +270,10 @@ fu_jabra_file_device_ensure_version(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	version = fu_memstrsafe(cmd_rsp->data,
-				cmd_rsp->len,
+	version = fu_memstrsafe(cmd_rsp->buf->data,
+				cmd_rsp->buf->len,
 				FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1,
-				cmd_rsp->len - (FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1),
+				cmd_rsp->buf->len - (FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + 1),
 				error);
 	if (version == NULL)
 		return FALSE;
@@ -321,15 +321,15 @@ fu_jabra_file_device_file_checksum(FuJabraFileDevice *self,
 	cmd_rsp2 = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp2 == NULL)
 		return FALSE;
-	if (cmd_rsp2->data[5] == FU_JABRA_FILE_PACKET_CMD_NACK) {
+	if (cmd_rsp2->buf->data[5] == FU_JABRA_FILE_PACKET_CMD_NACK) {
 		*match = FALSE;
 		return TRUE;
 	}
 	if (!fu_memcpy_safe(device_checksum,
 			    sizeof(device_checksum),
 			    0,
-			    cmd_rsp2->data,
-			    cmd_rsp2->len,
+			    cmd_rsp2->buf->data,
+			    cmd_rsp2->buf->len,
 			    12,
 			    sizeof(device_checksum),
 			    error))
@@ -373,17 +373,17 @@ fu_jabra_file_device_write_delete_file(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	if (cmd_rsp->data[5] == FU_JABRA_FILE_PACKET_CMD_NACK && cmd_rsp->data[6] == 0xF7)
+	if (cmd_rsp->buf->data[5] == FU_JABRA_FILE_PACKET_CMD_NACK && cmd_rsp->buf->data[6] == 0xF7)
 		return TRUE;
-	if (cmd_rsp->data[5] == FU_JABRA_FILE_PACKET_CMD_ACK)
+	if (cmd_rsp->buf->data[5] == FU_JABRA_FILE_PACKET_CMD_ACK)
 		return TRUE;
 
 	g_set_error(error,
 		    FWUPD_ERROR,
 		    FWUPD_ERROR_INTERNAL,
 		    "internal error: expected 0xFF, got 0x%02x 0x%02x",
-		    cmd_rsp->data[5],
-		    cmd_rsp->data[6]);
+		    cmd_rsp->buf->data[5],
+		    cmd_rsp->buf->data[6]);
 	return FALSE;
 }
 
@@ -406,8 +406,8 @@ fu_jabra_file_device_write_first_block(FuJabraFileDevice *self,
 	fu_memwrite_uint32(data + 1, fu_firmware_get_size(firmware), G_BIG_ENDIAN);
 	if (!fu_jabra_file_packet_set_payload(cmd_req, data, sizeof(data), error))
 		return FALSE;
-	if (!fu_memcpy_safe(cmd_req->data,
-			    cmd_req->len,
+	if (!fu_memcpy_safe(cmd_req->buf->data,
+			    cmd_req->buf->len,
 			    FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + sizeof(data),
 			    upgrade,
 			    sizeof(upgrade),
@@ -420,13 +420,13 @@ fu_jabra_file_device_write_first_block(FuJabraFileDevice *self,
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	if (cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
+	if (cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "internal error: expected 0xFF, got 0x%02x 0x%02x",
-			    cmd_rsp->data[5],
-			    cmd_rsp->data[6]);
+			    cmd_rsp->buf->data[5],
+			    cmd_rsp->buf->data[6]);
 		return FALSE;
 	}
 	return TRUE;
@@ -451,8 +451,8 @@ fu_jabra_file_device_write_next_block(FuJabraFileDevice *self,
 	fu_jabra_file_packet_set_cmd(cmd_req, FU_JABRA_FILE_PACKET_CMD_FILE);
 	if (!fu_jabra_file_packet_set_payload(cmd_req, data, sizeof(data), error))
 		return FALSE;
-	if (!fu_memcpy_safe(cmd_req->data,
-			    cmd_req->len,
+	if (!fu_memcpy_safe(cmd_req->buf->data,
+			    cmd_req->buf->len,
 			    FU_JABRA_FILE_PACKET_OFFSET_PAYLOAD + sizeof(data),
 			    buf,
 			    bufsz,
@@ -467,13 +467,13 @@ fu_jabra_file_device_write_next_block(FuJabraFileDevice *self,
 		cmd_rsp = fu_jabra_file_device_rx(self, error);
 		if (cmd_rsp == NULL)
 			return FALSE;
-		if (cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
+		if (cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INTERNAL,
 				    "internal error: expected 0xFF, got 0x%02x 0x%02x",
-				    cmd_rsp->data[5],
-				    cmd_rsp->data[6]);
+				    cmd_rsp->buf->data[5],
+				    cmd_rsp->buf->data[6]);
 			return FALSE;
 		}
 	}
@@ -527,7 +527,7 @@ fu_jabra_file_device_check_device_busy(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	if (cmd_rsp->data[7] != 0x00) {
+	if (cmd_rsp->buf->data[7] != 0x00) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_AUTH_FAILED, "is busy");
 		return FALSE;
 	}
@@ -556,13 +556,13 @@ fu_jabra_file_device_start_update(FuJabraFileDevice *self, GError **error)
 	cmd_rsp = fu_jabra_file_device_rx_with_sequence(self, error);
 	if (cmd_rsp == NULL)
 		return FALSE;
-	if (cmd_rsp->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
+	if (cmd_rsp->buf->data[5] != FU_JABRA_FILE_PACKET_CMD_ACK) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
 			    "internal error: expected 0xFF, got 0x%02x 0x%02x",
-			    cmd_rsp->data[5],
-			    cmd_rsp->data[6]);
+			    cmd_rsp->buf->data[5],
+			    cmd_rsp->buf->data[6]);
 		return FALSE;
 	}
 	return TRUE;

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -127,7 +127,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 	st = fu_struct_kinetic_dp_puma_header_parse_stream(stream, 0x0, error);
 	if (st == NULL)
 		return FALSE;
-	offset += st->len;
+	offset += st->buf->len;
 	code_size += FU_STRUCT_KINETIC_DP_PUMA_HEADER_SIZE;
 	for (guint i = 0; i < FU_STRUCT_KINETIC_DP_PUMA_HEADER_DEFAULT_OBJECT_COUNT; i++) {
 		g_autoptr(FuStructKineticDpPumaHeaderInfo) st_obj =
@@ -136,7 +136,7 @@ fu_kinetic_dp_puma_firmware_parse_app_fw(FuKineticDpPumaFirmware *self,
 			return FALSE;
 		code_size += fu_struct_kinetic_dp_puma_header_info_get_length(st_obj) +
 			     FU_STRUCT_KINETIC_DP_PUMA_HEADER_INFO_SIZE;
-		offset += st_obj->len;
+		offset += st_obj->buf->len;
 	}
 	if (code_size < (512 * 1024) + offset) {
 		g_set_error(error,

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -46,17 +46,18 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuFirmware) img_sig = fu_firmware_new();
 	g_autoptr(GInputStream) stream_payload = NULL;
 	g_autoptr(GInputStream) stream_sig = NULL;
-	g_autoptr(FuStructLegionHid2Header) header = NULL;
-	g_autoptr(FuStructLegionHid2Version) version = NULL;
+	g_autoptr(FuStructLegionHid2Header) st_header = NULL;
+	g_autoptr(FuStructLegionHid2Version) st_version = NULL;
 
-	header = fu_struct_legion_hid2_header_parse_stream(stream, 0x0, error);
-	if (header == NULL)
+	st_header = fu_struct_legion_hid2_header_parse_stream(stream, 0x0, error);
+	if (st_header == NULL)
 		return FALSE;
 
-	stream_sig = fu_partial_input_stream_new(stream,
-						 fu_struct_legion_hid2_header_get_sig_add(header),
-						 fu_struct_legion_hid2_header_get_sig_len(header),
-						 error);
+	stream_sig =
+	    fu_partial_input_stream_new(stream,
+					fu_struct_legion_hid2_header_get_sig_add(st_header),
+					fu_struct_legion_hid2_header_get_sig_len(st_header),
+					error);
 	if (stream_sig == NULL)
 		return FALSE;
 	if (!fu_firmware_parse_stream(img_sig, stream_sig, 0x0, flags, error))
@@ -67,8 +68,8 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 
 	stream_payload =
 	    fu_partial_input_stream_new(stream,
-					fu_struct_legion_hid2_header_get_data_add(header),
-					fu_struct_legion_hid2_header_get_data_len(header),
+					fu_struct_legion_hid2_header_get_data_add(st_header),
+					fu_struct_legion_hid2_header_get_data_len(st_header),
 					error);
 	if (stream_payload == NULL)
 		return FALSE;
@@ -78,10 +79,10 @@ fu_legion_hid2_firmware_parse(FuFirmware *firmware,
 	if (!fu_firmware_add_image(firmware, img_payload, error))
 		return FALSE;
 
-	version = fu_struct_legion_hid2_version_parse_stream(stream, VERSION_OFFSET, error);
-	if (version == NULL)
+	st_version = fu_struct_legion_hid2_version_parse_stream(stream, VERSION_OFFSET, error);
+	if (st_version == NULL)
 		return FALSE;
-	self->version = fu_struct_legion_hid2_version_get_version(version);
+	self->version = fu_struct_legion_hid2_version_get_version(st_version);
 
 	return TRUE;
 }

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller.rs
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller.rs
@@ -65,7 +65,7 @@ struct FuStructLogitechBulkcontrollerUpdateReq {
     payload_length: u32le,
 }
 
-#[derive(Getters)]
+#[derive(Parse)]
 #[repr(C, packed)]
 struct FuStructLogitechBulkcontrollerUpdateRes {
     cmd: FuLogitechBulkcontrollerCmd,

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -144,19 +144,19 @@ fu_logitech_hidpp_device_ping(FuLogitechHidppDevice *self, GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
+	g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
 	GPtrArray *children = NULL;
 
 	/* handle failure */
-	msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-	msg->device_id = priv->device_idx;
-	msg->sub_id = 0x00;	      /* rootIndex */
-	msg->function_id = 0x01 << 4; /* ping */
-	msg->data[0] = 0x00;
-	msg->data[1] = 0x00;
-	msg->data[2] = 0xaa; /* user-selected value */
-	msg->hidpp_version = priv->hidpp_version;
-	if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, &error_local)) {
+	st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+	st_req->device_id = priv->device_idx;
+	st_req->sub_id = 0x00;		 /* rootIndex */
+	st_req->function_id = 0x01 << 4; /* ping */
+	st_req->data[0] = 0x00;
+	st_req->data[1] = 0x00;
+	st_req->data[2] = 0xaa; /* user-selected value */
+	st_req->hidpp_version = priv->hidpp_version;
+	if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			priv->hidpp_version = 1;
 			return TRUE;
@@ -179,15 +179,15 @@ fu_logitech_hidpp_device_ping(FuLogitechHidppDevice *self, GError **error)
 
 	/* if the device index is unset, grab it from the reply */
 	if (priv->device_idx == FU_LOGITECH_HIDPP_DEVICE_IDX_WIRED &&
-	    msg->device_id != FU_LOGITECH_HIDPP_DEVICE_IDX_WIRED) {
-		priv->device_idx = msg->device_id;
+	    st_req->device_id != FU_LOGITECH_HIDPP_DEVICE_IDX_WIRED) {
+		priv->device_idx = st_req->device_id;
 		g_debug("device index is %02x", priv->device_idx);
 	}
 
 	/* format version in BCD format */
 	if (priv->hidpp_version != FU_LOGITECH_HIDPP_VERSION_BLE) {
-		/* minor version is in msg->data[1] */;
-		priv->hidpp_version = msg->data[0];
+		/* minor version is in st_req->data[1] */;
+		priv->hidpp_version = st_req->data[0];
 	}
 
 	/* success */
@@ -201,7 +201,7 @@ fu_logitech_hidpp_device_poll(FuDevice *device, GError **error)
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	const guint timeout = 1; /* ms */
 	g_autoptr(GError) error_local = NULL;
-	g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
+	g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	/* open */
@@ -210,9 +210,9 @@ fu_logitech_hidpp_device_poll(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* flush pending data */
-	msg->device_id = priv->device_idx;
-	msg->hidpp_version = priv->hidpp_version;
-	if (!fu_logitech_hidpp_receive(FU_UDEV_DEVICE(self), msg, timeout, &error_local)) {
+	st_req->device_id = priv->device_idx;
+	st_req->hidpp_version = priv->hidpp_version;
+	if (!fu_logitech_hidpp_receive(FU_UDEV_DEVICE(self), st_req, timeout, &error_local)) {
 		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT)) {
 			g_warning("failed to get pending read: %s", error_local->message);
 			return TRUE;
@@ -374,43 +374,44 @@ fu_logitech_hidpp_device_fetch_firmware_info(FuLogitechHidppDevice *self, GError
 		guint16 build;
 		g_autofree gchar *version = NULL;
 		g_autofree gchar *name = NULL;
-		g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
+		g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
 
-		msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-		msg->device_id = priv->device_idx;
-		msg->sub_id = idx;
-		msg->function_id = 0x01 << 4; /* getInfo */
-		msg->hidpp_version = priv->hidpp_version;
-		msg->data[0] = i;
-		if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, error)) {
+		st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+		st_req->device_id = priv->device_idx;
+		st_req->sub_id = idx;
+		st_req->function_id = 0x01 << 4; /* getInfo */
+		st_req->hidpp_version = priv->hidpp_version;
+		st_req->data[0] = i;
+		if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, error)) {
 			g_prefix_error_literal(error, "failed to get firmware info: ");
 			return FALSE;
 		}
 		/* use the single available slot, otherwise -- the slot which is not active */
-		if (msg->data[0] == 0) {
-			if (!app_ok || FU_BIT_IS_CLEAR(msg->data[8], 0))
+		if (st_req->data[0] == 0) {
+			if (!app_ok || FU_BIT_IS_CLEAR(st_req->data[8], 0))
 				priv->cached_fw_entity = i;
 			app_ok = TRUE;
 		}
-		if (msg->data[1] == 0x00 && msg->data[2] == 0x00 && msg->data[3] == 0x00 &&
-		    msg->data[4] == 0x00 && msg->data[5] == 0x00 && msg->data[6] == 0x00 &&
-		    msg->data[7] == 0x00) {
+		if (st_req->data[1] == 0x00 && st_req->data[2] == 0x00 && st_req->data[3] == 0x00 &&
+		    st_req->data[4] == 0x00 && st_req->data[5] == 0x00 && st_req->data[6] == 0x00 &&
+		    st_req->data[7] == 0x00) {
 			g_debug("no version set for entity %u", i);
 			continue;
 		}
-		name = g_strdup_printf("%c%c%c", msg->data[1], msg->data[2], msg->data[3]);
-		build = ((guint16)msg->data[6]) << 8 | msg->data[7];
-		version = fu_logitech_hidpp_format_version(name, msg->data[4], msg->data[5], build);
+		name = g_strdup_printf("%c%c%c", st_req->data[1], st_req->data[2], st_req->data[3]);
+		build = ((guint16)st_req->data[6]) << 8 | st_req->data[7];
+		version =
+		    fu_logitech_hidpp_format_version(name, st_req->data[4], st_req->data[5], build);
 		g_debug("firmware entity 0x%02x version is %s", i, version);
-		if (msg->data[0] == 0) {
+		if (st_req->data[0] == 0) {
 			/* set version from the active entity */
-			if (FU_BIT_IS_SET(msg->data[8], 0))
+			if (FU_BIT_IS_SET(st_req->data[8], 0))
 				fu_device_set_version(FU_DEVICE(self), version);
-		} else if (msg->data[0] == 1) {
+		} else if (st_req->data[0] == 1) {
 			fu_device_set_version_bootloader(FU_DEVICE(self), version);
-		} else if (msg->data[0] == 2) {
+		} else if (st_req->data[0] == 2) {
 			fu_device_set_metadata(FU_DEVICE(self), "version-hw", version);
-		} else if (msg->data[0] == 5 &&
+		} else if (st_req->data[0] == 5 &&
 			   fu_device_has_private_flag(FU_DEVICE(self),
 						      FU_LOGITECH_HIDPP_DEVICE_FLAG_ADD_RADIO)) {
 			if (!fu_logitech_hidpp_device_create_radio_child(self, i, build, error)) {
@@ -442,7 +443,7 @@ fu_logitech_hidpp_device_fetch_model_id(FuLogitechHidppDevice *self, GError **er
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
 	guint64 pid_tmp = 0;
-	g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
+	g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
 	g_autoptr(GString) str = g_string_new(NULL);
 
 	/* get the (optional) feature index */
@@ -451,19 +452,19 @@ fu_logitech_hidpp_device_fetch_model_id(FuLogitechHidppDevice *self, GError **er
 	if (idx == 0x00)
 		return TRUE;
 
-	msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-	msg->device_id = priv->device_idx;
-	msg->sub_id = idx;
-	msg->function_id = 0x00 << 4; /* getDeviceInfo */
-	msg->hidpp_version = priv->hidpp_version;
-	if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, error)) {
+	st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+	st_req->device_id = priv->device_idx;
+	st_req->sub_id = idx;
+	st_req->function_id = 0x00 << 4; /* getDeviceInfo */
+	st_req->hidpp_version = priv->hidpp_version;
+	if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, error)) {
 		g_prefix_error_literal(error, "failed to get the model ID: ");
 		return FALSE;
 	}
 
 	/* ignore extendedModelID in data[13] */
 	for (guint i = 7; i < 13; i++)
-		g_string_append_printf(str, "%02X", msg->data[i]);
+		g_string_append_printf(str, "%02X", st_req->data[i]);
 	fu_logitech_hidpp_device_set_model_id(self, str->str);
 
 	/* truncate to 4 chars and convert to a PID */
@@ -495,27 +496,27 @@ fu_logitech_hidpp_device_fetch_battery_level(FuLogitechHidppDevice *self, GError
 		    FU_LOGITECH_HIDPP_FEATURE_UNIFIED_BATTERY);
 		if (idx != 0x00) {
 			gboolean socc = FALSE; /* state of charge capability */
-			g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
-			msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-			msg->device_id = priv->device_idx;
-			msg->sub_id = idx;
-			msg->function_id = 0x00 << 4; /* get_capabilities */
-			msg->hidpp_version = priv->hidpp_version;
-			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, error)) {
+			g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
+			st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+			st_req->device_id = priv->device_idx;
+			st_req->sub_id = idx;
+			st_req->function_id = 0x00 << 4; /* get_capabilities */
+			st_req->hidpp_version = priv->hidpp_version;
+			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, error)) {
 				g_prefix_error_literal(error, "failed to get battery info: ");
 				return FALSE;
 			}
-			if (msg->data[1] & 0x02)
+			if (st_req->data[1] & 0x02)
 				socc = TRUE;
-			msg->function_id = 0x01 << 4; /* get_status */
-			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, error)) {
+			st_req->function_id = 0x01 << 4; /* get_status */
+			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, error)) {
 				g_prefix_error_literal(error, "failed to get battery info: ");
 				return FALSE;
 			}
 			if (socc) {
-				fu_device_set_battery_level(FU_DEVICE(self), msg->data[0]);
+				fu_device_set_battery_level(FU_DEVICE(self), st_req->data[0]);
 			} else {
-				switch (msg->data[1]) {
+				switch (st_req->data[1]) {
 				case 1: /* critical */
 					fu_device_set_battery_level(FU_DEVICE(self), 5);
 					break;
@@ -529,7 +530,7 @@ fu_logitech_hidpp_device_fetch_battery_level(FuLogitechHidppDevice *self, GError
 					fu_device_set_battery_level(FU_DEVICE(self), 90);
 					break;
 				default:
-					g_warning("unknown battery level: 0x%02x", msg->data[1]);
+					g_warning("unknown battery level: 0x%02x", st_req->data[1]);
 					break;
 				}
 			}
@@ -541,42 +542,42 @@ fu_logitech_hidpp_device_fetch_battery_level(FuLogitechHidppDevice *self, GError
 		    self,
 		    FU_LOGITECH_HIDPP_FEATURE_BATTERY_LEVEL_STATUS);
 		if (idx != 0x00) {
-			g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
-			msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-			msg->device_id = priv->device_idx;
-			msg->sub_id = idx;
-			msg->function_id = 0x00 << 4; /* GetBatteryLevelStatus */
-			msg->hidpp_version = priv->hidpp_version;
-			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, error)) {
+			g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
+			st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+			st_req->device_id = priv->device_idx;
+			st_req->sub_id = idx;
+			st_req->function_id = 0x00 << 4; /* GetBatteryLevelStatus */
+			st_req->hidpp_version = priv->hidpp_version;
+			if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, error)) {
 				g_prefix_error_literal(error, "failed to get battery info: ");
 				return FALSE;
 			}
-			if (msg->data[0] != 0x00)
-				fu_device_set_battery_level(FU_DEVICE(self), msg->data[0]);
+			if (st_req->data[0] != 0x00)
+				fu_device_set_battery_level(FU_DEVICE(self), st_req->data[0]);
 			return TRUE;
 		}
 	}
 
 	/* try HID++1.0 battery mileage */
 	if (priv->hidpp_version == 1) {
-		g_autoptr(FuLogitechHidppHidppMsg) msg = fu_logitech_hidpp_msg_new();
-		msg->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
-		msg->device_id = priv->device_idx;
-		msg->sub_id = FU_LOGITECH_HIDPP_SUBID_GET_REGISTER;
-		msg->function_id = FU_LOGITECH_HIDPP_REGISTER_BATTERY_MILEAGE << 4;
-		msg->hidpp_version = priv->hidpp_version;
-		if (fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, NULL)) {
-			if (msg->data[0] != 0x7F)
-				fu_device_set_battery_level(FU_DEVICE(self), msg->data[0]);
+		g_autoptr(FuLogitechHidppHidppMsg) st_req = fu_logitech_hidpp_msg_new();
+		st_req->report_id = FU_LOGITECH_HIDPP_REPORT_ID_SHORT;
+		st_req->device_id = priv->device_idx;
+		st_req->sub_id = FU_LOGITECH_HIDPP_SUBID_GET_REGISTER;
+		st_req->function_id = FU_LOGITECH_HIDPP_REGISTER_BATTERY_MILEAGE << 4;
+		st_req->hidpp_version = priv->hidpp_version;
+		if (fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, NULL)) {
+			if (st_req->data[0] != 0x7F)
+				fu_device_set_battery_level(FU_DEVICE(self), st_req->data[0]);
 			else
-				g_warning("unknown battery level: 0x%02x", msg->data[0]);
+				g_warning("unknown battery level: 0x%02x", st_req->data[0]);
 			return TRUE;
 		}
 
 		/* try HID++1.0 battery status instead */
-		msg->function_id = FU_LOGITECH_HIDPP_REGISTER_BATTERY_STATUS << 4;
-		if (fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), msg, NULL)) {
-			switch (msg->data[0]) {
+		st_req->function_id = FU_LOGITECH_HIDPP_REGISTER_BATTERY_STATUS << 4;
+		if (fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), st_req, NULL)) {
+			switch (st_req->data[0]) {
 			case 1: /* 0 - 10 */
 				fu_device_set_battery_level(FU_DEVICE(self), 5);
 				break;
@@ -590,7 +591,7 @@ fu_logitech_hidpp_device_fetch_battery_level(FuLogitechHidppDevice *self, GError
 				fu_device_set_battery_level(FU_DEVICE(self), 90);
 				break;
 			default:
-				g_warning("unknown battery percentage: 0x%02x", msg->data[0]);
+				g_warning("unknown battery percentage: 0x%02x", st_req->data[0]);
 				break;
 			}
 			return TRUE;
@@ -603,18 +604,20 @@ fu_logitech_hidpp_device_fetch_battery_level(FuLogitechHidppDevice *self, GError
 
 /* wrapper function to reuse the pre-rustgen communication */
 static gboolean
-fu_logitech_hidpp_device_transfer_msg(FuLogitechHidppDevice *self, GByteArray *msg, GError **error)
+fu_logitech_hidpp_device_transfer_msg(FuLogitechHidppDevice *self,
+				      GByteArray *st_req,
+				      GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	FuLogitechHidppHidppMsg *hidpp_msg = NULL;
 
-	g_return_val_if_fail(msg != NULL, FALSE);
+	g_return_val_if_fail(st_req != NULL, FALSE);
 
 	/* enlarge the size since fu_logitech_hidpp_transfer() returns the answer in the
 	 * same message */
-	fu_byte_array_set_size(msg, sizeof(FuLogitechHidppHidppMsg), 0);
+	fu_byte_array_set_size(st_req, sizeof(FuLogitechHidppHidppMsg), 0);
 
-	hidpp_msg = (FuLogitechHidppHidppMsg *)msg->data;
+	hidpp_msg = (FuLogitechHidppHidppMsg *)st_req->data;
 	hidpp_msg->hidpp_version = priv->hidpp_version;
 
 	if (!fu_logitech_hidpp_transfer(FU_UDEV_DEVICE(self), hidpp_msg, error))
@@ -640,9 +643,9 @@ fu_logitech_hidpp_device_rdfu_get_capabilities(FuLogitechHidppDevice *self, GErr
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
-	g_autoptr(FuStructLogitechHidppRdfuGetCapabilities) msg =
+	g_autoptr(FuStructLogitechHidppRdfuGetCapabilities) st_req =
 	    fu_struct_logitech_hidpp_rdfu_get_capabilities_new();
-	g_autoptr(FuStructLogitechHidppRdfuCapabilities) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuCapabilities) st_res = NULL;
 
 	priv->rdfu_capabilities = 0; /* set empty */
 
@@ -651,20 +654,23 @@ fu_logitech_hidpp_device_rdfu_get_capabilities(FuLogitechHidppDevice *self, GErr
 	if (idx == 0x00)
 		return TRUE;
 
-	fu_struct_logitech_hidpp_rdfu_get_capabilities_set_device_id(msg, priv->device_idx);
-	fu_struct_logitech_hidpp_rdfu_get_capabilities_set_sub_id(msg, idx);
+	fu_struct_logitech_hidpp_rdfu_get_capabilities_set_device_id(st_req, priv->device_idx);
+	fu_struct_logitech_hidpp_rdfu_get_capabilities_set_sub_id(st_req, idx);
 
 	g_debug("read capabilities");
-	if (!fu_logitech_hidpp_device_transfer_msg(self, msg, error)) {
+	if (!fu_logitech_hidpp_device_transfer_msg(self, st_req->buf, error)) {
 		g_prefix_error_literal(error, "failed to get capabilities: ");
 		return FALSE;
 	}
 
-	response = fu_struct_logitech_hidpp_rdfu_capabilities_parse(msg->data, msg->len, 0, error);
-	if (response == NULL)
+	st_res = fu_struct_logitech_hidpp_rdfu_capabilities_parse(st_req->buf->data,
+								  st_req->buf->len,
+								  0,
+								  error);
+	if (st_res == NULL)
 		return FALSE;
 	priv->rdfu_capabilities =
-	    fu_struct_logitech_hidpp_rdfu_capabilities_get_capabilities(response);
+	    fu_struct_logitech_hidpp_rdfu_capabilities_get_capabilities(st_res);
 	return TRUE;
 }
 
@@ -676,9 +682,9 @@ fu_logitech_hidpp_device_rdfu_start_dfu(FuLogitechHidppDevice *self,
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
 	guint8 status;
-	g_autoptr(FuStructLogitechHidppRdfuStartDfu) msg =
+	g_autoptr(FuStructLogitechHidppRdfuStartDfu) st_req =
 	    fu_struct_logitech_hidpp_rdfu_start_dfu_new();
-	g_autoptr(FuStructLogitechHidppRdfuStartDfuResponse) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuStartDfuResponse) st_res = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
 	if (idx == 0x00) {
@@ -689,23 +695,28 @@ fu_logitech_hidpp_device_rdfu_start_dfu(FuLogitechHidppDevice *self,
 		return FALSE;
 	}
 
-	fu_struct_logitech_hidpp_rdfu_start_dfu_set_device_id(msg, priv->device_idx);
-	fu_struct_logitech_hidpp_rdfu_start_dfu_set_sub_id(msg, idx);
-	fu_struct_logitech_hidpp_rdfu_start_dfu_set_fw_entity(msg, priv->cached_fw_entity);
-	if (!fu_struct_logitech_hidpp_rdfu_start_dfu_set_magic(msg, magic->data, magic->len, error))
+	fu_struct_logitech_hidpp_rdfu_start_dfu_set_device_id(st_req, priv->device_idx);
+	fu_struct_logitech_hidpp_rdfu_start_dfu_set_sub_id(st_req, idx);
+	fu_struct_logitech_hidpp_rdfu_start_dfu_set_fw_entity(st_req, priv->cached_fw_entity);
+	if (!fu_struct_logitech_hidpp_rdfu_start_dfu_set_magic(st_req,
+							       magic->data,
+							       magic->len,
+							       error))
 		return FALSE;
 
 	g_debug("startDfu");
-	if (!fu_logitech_hidpp_device_transfer_msg(self, msg, error)) {
+	if (!fu_logitech_hidpp_device_transfer_msg(self, st_req->buf, error)) {
 		g_prefix_error_literal(error, "startDfu failed: ");
 		return FALSE;
 	}
 
-	response =
-	    fu_struct_logitech_hidpp_rdfu_start_dfu_response_parse(msg->data, msg->len, 0, error);
-	if (response == NULL)
+	st_res = fu_struct_logitech_hidpp_rdfu_start_dfu_response_parse(st_req->buf->data,
+									st_req->buf->len,
+									0,
+									error);
+	if (st_res == NULL)
 		return FALSE;
-	status = fu_struct_logitech_hidpp_rdfu_start_dfu_response_get_status_code(msg);
+	status = fu_struct_logitech_hidpp_rdfu_start_dfu_response_get_status_code(st_res);
 	if (status != FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DATA_TRANSFER_READY) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -724,7 +735,7 @@ fu_logitech_hidpp_device_rdfu_start_dfu(FuLogitechHidppDevice *self,
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_check_status(FuLogitechHidppDevice *self,
-					   GByteArray *response,
+					   FuStructLogitechHidppRdfuResponse *st_res,
 					   GError **error);
 
 static void
@@ -738,23 +749,23 @@ fu_logitech_hidpp_device_rdfu_set_state(FuLogitechHidppDevice *self, FuLogitechH
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_status_data_transfer_ready(FuLogitechHidppDevice *self,
-							 GByteArray *response,
+							 FuStructLogitechHidppRdfuResponse *st_res,
 							 GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint16 block;
-	g_autoptr(GByteArray) params = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuDataTransferReady) st_params = NULL;
 
 	priv->rdfu_state = FU_LOGITECH_HIDPP_RDFU_STATE_TRANSFER;
-	params = fu_struct_logitech_hidpp_rdfu_data_transfer_ready_parse(
-	    response->data,
-	    response->len,
+	st_params = fu_struct_logitech_hidpp_rdfu_data_transfer_ready_parse(
+	    st_res->buf->data,
+	    st_res->buf->len,
 	    FU_STRUCT_LOGITECH_HIDPP_RDFU_RESPONSE_OFFSET_STATUS_CODE,
 	    error);
-	if (params == NULL)
+	if (st_params == NULL)
 		return FALSE;
 
-	block = fu_struct_logitech_hidpp_rdfu_data_transfer_ready_get_block_id(params);
+	block = fu_struct_logitech_hidpp_rdfu_data_transfer_ready_get_block_id(st_params);
 	if (block != 0 && block <= priv->rdfu_block) {
 		/* additional protection from misbehaviored devices */
 		fu_logitech_hidpp_device_rdfu_set_state(self,
@@ -769,23 +780,23 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_ready(FuLogitechHidppDevice *
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *self,
-							GByteArray *response,
+							FuStructLogitechHidppRdfuResponse *st_res,
 							GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint retry = 0;
-	g_autoptr(FuStructLogitechHidppRdfuDataTransferWait) params = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuDataTransferWait) st_params = NULL;
 
-	params = fu_struct_logitech_hidpp_rdfu_data_transfer_wait_parse(
-	    response->data,
-	    response->len,
+	st_params = fu_struct_logitech_hidpp_rdfu_data_transfer_wait_parse(
+	    st_res->buf->data,
+	    st_res->buf->len,
 	    FU_STRUCT_LOGITECH_HIDPP_RDFU_RESPONSE_OFFSET_STATUS_CODE,
 	    error);
-	if (params == NULL)
+	if (st_params == NULL)
 		return FALSE;
 
 	/* set the delay to wait the next event */
-	priv->rdfu_wait = fu_struct_logitech_hidpp_rdfu_data_transfer_wait_get_delay_ms(params);
+	priv->rdfu_wait = fu_struct_logitech_hidpp_rdfu_data_transfer_wait_get_delay_ms(st_params);
 
 	/* if we already in waiting loop just leave to avoid recursion */
 	if (priv->rdfu_state == FU_LOGITECH_HIDPP_RDFU_STATE_WAIT)
@@ -794,7 +805,7 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 	priv->rdfu_state = FU_LOGITECH_HIDPP_RDFU_STATE_WAIT;
 
 	while (priv->rdfu_state == FU_LOGITECH_HIDPP_RDFU_STATE_WAIT) {
-		g_autoptr(FuStructLogitechHidppRdfuResponse) wait_response = NULL;
+		g_autoptr(FuStructLogitechHidppRdfuResponse) st_wait_res = NULL;
 		g_autoptr(FuLogitechHidppHidppMsg) msg_in_wait = fu_logitech_hidpp_msg_new();
 		g_autoptr(GError) error_local = NULL;
 
@@ -817,16 +828,16 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 			return FALSE;
 		}
 
-		wait_response = fu_struct_logitech_hidpp_rdfu_response_parse(
+		st_wait_res = fu_struct_logitech_hidpp_rdfu_response_parse(
 		    (guint8 *)msg_in_wait,
 		    fu_logitech_hidpp_msg_get_payload_length(msg_in_wait),
 		    0,
 		    error);
-		if (wait_response == NULL)
+		if (st_wait_res == NULL)
 			return FALSE;
 
 		/* check the message and set the new delay if requested additional wait */
-		if (!fu_logitech_hidpp_device_rdfu_check_status(self, wait_response, error))
+		if (!fu_logitech_hidpp_device_rdfu_check_status(self, st_wait_res, error))
 			return FALSE;
 
 		/* too lot attempts in a raw, let's fail everything */
@@ -844,23 +855,23 @@ fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(FuLogitechHidppDevice *s
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_status_pkt_ack(FuLogitechHidppDevice *self,
-					     FuStructLogitechHidppRdfuResponse *response,
+					     FuStructLogitechHidppRdfuResponse *st_res,
 					     GError **error)
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint32 pkt;
-	g_autoptr(FuStructLogitechHidppRdfuDfuTransferPktAck) params = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuDfuTransferPktAck) st_params = NULL;
 
 	priv->rdfu_state = FU_LOGITECH_HIDPP_RDFU_STATE_TRANSFER;
-	params = fu_struct_logitech_hidpp_rdfu_dfu_transfer_pkt_ack_parse(
-	    response->data,
-	    response->len,
+	st_params = fu_struct_logitech_hidpp_rdfu_dfu_transfer_pkt_ack_parse(
+	    st_res->buf->data,
+	    st_res->buf->len,
 	    FU_STRUCT_LOGITECH_HIDPP_RDFU_RESPONSE_OFFSET_STATUS_CODE,
 	    error);
-	if (params == NULL)
+	if (st_params == NULL)
 		return FALSE;
 
-	pkt = fu_struct_logitech_hidpp_rdfu_dfu_transfer_pkt_ack_get_pkt_number(params);
+	pkt = fu_struct_logitech_hidpp_rdfu_dfu_transfer_pkt_ack_get_pkt_number(st_params);
 	/* expecting monotonic increase */
 	if (pkt != priv->rdfu_pkt + 1) {
 		/* additional protection from misbehaviored devices */
@@ -890,10 +901,10 @@ fu_logitech_hidpp_device_rdfu_status_pkt_ack(FuLogitechHidppDevice *self,
 
 static gboolean
 fu_logitech_hidpp_device_rdfu_check_status(FuLogitechHidppDevice *self,
-					   FuStructLogitechHidppRdfuResponse *response,
+					   FuStructLogitechHidppRdfuResponse *st_res,
 					   GError **error)
 {
-	guint8 status = fu_struct_logitech_hidpp_rdfu_response_get_status_code(response);
+	guint8 status = fu_struct_logitech_hidpp_rdfu_response_get_status_code(st_res);
 
 	switch (status) {
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DFU_NOT_STARTED:
@@ -902,19 +913,17 @@ fu_logitech_hidpp_device_rdfu_check_status(FuLogitechHidppDevice *self,
 		break;
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DATA_TRANSFER_READY:
 		/* ready for transfer, next block requested */
-		if (!fu_logitech_hidpp_device_rdfu_status_data_transfer_ready(self,
-									      response,
-									      error))
+		if (!fu_logitech_hidpp_device_rdfu_status_data_transfer_ready(self, st_res, error))
 			return FALSE;
 		break;
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DATA_TRANSFER_WAIT:
 		/* device requested to wait */
-		if (!fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(self, response, error))
+		if (!fu_logitech_hidpp_device_rdfu_status_data_transfer_wait(self, st_res, error))
 			return FALSE;
 		break;
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DFU_TRANSFER_PKT_ACK:
 		/* ok to transfer next packet */
-		if (!fu_logitech_hidpp_device_rdfu_status_pkt_ack(self, response, error))
+		if (!fu_logitech_hidpp_device_rdfu_status_pkt_ack(self, st_res, error))
 			return FALSE;
 		break;
 	case FU_LOGITECH_HIDPP_RDFU_RESPONSE_CODE_DFU_TRANSFER_COMPLETE:
@@ -951,9 +960,9 @@ fu_logitech_hidpp_device_rdfu_get_dfu_status(FuLogitechHidppDevice *self, GError
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
-	g_autoptr(FuStructLogitechHidppRdfuGetDfuStatus) msg =
+	g_autoptr(FuStructLogitechHidppRdfuGetDfuStatus) st_req =
 	    fu_struct_logitech_hidpp_rdfu_get_dfu_status_new();
-	g_autoptr(FuStructLogitechHidppRdfuResponse) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuResponse) st_res = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
@@ -965,21 +974,24 @@ fu_logitech_hidpp_device_rdfu_get_dfu_status(FuLogitechHidppDevice *self, GError
 		return FALSE;
 	}
 
-	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_device_id(msg, priv->device_idx);
-	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_sub_id(msg, idx);
-	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_fw_entity(msg, priv->cached_fw_entity);
+	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_device_id(st_req, priv->device_idx);
+	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_sub_id(st_req, idx);
+	fu_struct_logitech_hidpp_rdfu_get_dfu_status_set_fw_entity(st_req, priv->cached_fw_entity);
 
 	g_debug("getDfuStatus for entity %u", priv->cached_fw_entity);
-	if (!fu_logitech_hidpp_device_transfer_msg(self, msg, error)) {
+	if (!fu_logitech_hidpp_device_transfer_msg(self, st_req->buf, error)) {
 		g_prefix_error_literal(error, "getDfuStatus failed: ");
 		return FALSE;
 	}
 
-	response = fu_struct_logitech_hidpp_rdfu_response_parse(msg->data, msg->len, 0, error);
-	if (response == NULL)
+	st_res = fu_struct_logitech_hidpp_rdfu_response_parse(st_req->buf->data,
+							      st_req->buf->len,
+							      0,
+							      error);
+	if (st_res == NULL)
 		return FALSE;
 
-	return fu_logitech_hidpp_device_rdfu_check_status(self, response, error);
+	return fu_logitech_hidpp_device_rdfu_check_status(self, st_res, error);
 }
 
 static gboolean
@@ -990,10 +1002,10 @@ fu_logitech_hidpp_device_rdfu_apply_dfu(FuLogitechHidppDevice *self,
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
 	guint8 flags = FU_LOGITECH_HIDPP_RDFU_APPLY_FLAG_FORCE_DFU_BIT;
-	g_autoptr(FuStructLogitechHidppRdfuApplyDfu) msg =
+	g_autoptr(FuStructLogitechHidppRdfuApplyDfu) st_req =
 	    fu_struct_logitech_hidpp_rdfu_apply_dfu_new();
 	FuLogitechHidppHidppMsg *hidpp_msg = NULL;
-	g_autoptr(GByteArray) response = NULL;
+	g_autoptr(GByteArray) st_res = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
 	if (idx == 0x00) {
@@ -1014,13 +1026,13 @@ fu_logitech_hidpp_device_rdfu_apply_dfu(FuLogitechHidppDevice *self,
 
 	g_debug("applyDfu for entity %u", fw_entity);
 
-	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_device_id(msg, priv->device_idx);
-	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_sub_id(msg, idx);
-	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_fw_entity(msg, fw_entity);
-	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_flags(msg, flags);
+	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_device_id(st_req, priv->device_idx);
+	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_sub_id(st_req, idx);
+	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_fw_entity(st_req, fw_entity);
+	fu_struct_logitech_hidpp_rdfu_apply_dfu_set_flags(st_req, flags);
 
 	/* reuse pre-rustgen send */
-	hidpp_msg = (FuLogitechHidppHidppMsg *)msg->data;
+	hidpp_msg = (FuLogitechHidppHidppMsg *)st_req->buf->data;
 	hidpp_msg->hidpp_version = priv->hidpp_version;
 	/* don't expect the reply for forced applyDfu */
 	if (!fu_logitech_hidpp_send(FU_UDEV_DEVICE(self),
@@ -1041,9 +1053,9 @@ fu_logitech_hidpp_device_rdfu_transfer_pkt(FuLogitechHidppDevice *self,
 {
 	FuLogitechHidppDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 idx;
-	g_autoptr(FuStructLogitechHidppRdfuTransferDfuData) msg =
+	g_autoptr(FuStructLogitechHidppRdfuTransferDfuData) st_req =
 	    fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_new();
-	g_autoptr(FuStructLogitechHidppRdfuResponse) response = NULL;
+	g_autoptr(FuStructLogitechHidppRdfuResponse) st_res = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	idx = fu_logitech_hidpp_device_feature_get_idx(self, FU_LOGITECH_HIDPP_FEATURE_RDFU);
@@ -1055,22 +1067,25 @@ fu_logitech_hidpp_device_rdfu_transfer_pkt(FuLogitechHidppDevice *self,
 		return FALSE;
 	}
 
-	fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_device_id(msg, priv->device_idx);
-	fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_sub_id(msg, idx);
-	if (!fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_data(msg, data, datasz, error))
+	fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_device_id(st_req, priv->device_idx);
+	fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_sub_id(st_req, idx);
+	if (!fu_struct_logitech_hidpp_rdfu_transfer_dfu_data_set_data(st_req, data, datasz, error))
 		return FALSE;
 
 	g_debug("transferDfuData");
-	if (!fu_logitech_hidpp_device_transfer_msg(self, msg, error)) {
+	if (!fu_logitech_hidpp_device_transfer_msg(self, st_req->buf, error)) {
 		g_prefix_error_literal(error, "transferDfuData failed: ");
 		return FALSE;
 	}
 
-	response = fu_struct_logitech_hidpp_rdfu_response_parse(msg->data, msg->len, 0, error);
-	if (response == NULL)
+	st_res = fu_struct_logitech_hidpp_rdfu_response_parse(st_req->buf->data,
+							      st_req->buf->len,
+							      0,
+							      error);
+	if (st_res == NULL)
 		return FALSE;
 
-	return fu_logitech_hidpp_device_rdfu_check_status(self, response, error);
+	return fu_logitech_hidpp_device_rdfu_check_status(self, st_res, error);
 }
 
 static gboolean

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -91,7 +91,7 @@ fu_logitech_rallysystem_audio_device_set_serial(FuLogitechRallysystemAudioDevice
 			       fu_struct_audio_serial_number_get_month(st),
 			       fu_struct_audio_serial_number_get_day(st));
 	for (guint i = 0x0; i < FU_STRUCT_AUDIO_SERIAL_NUMBER_SIZE_MAC_ADDRESS; i++)
-		g_string_append_printf(serial, "%02x", st->data[i]);
+		g_string_append_printf(serial, "%02x", st->buf->data[i]);
 	fu_device_set_serial(FU_DEVICE(self), serial->str);
 
 	/* success */

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -237,7 +237,10 @@ fu_logitech_rallysystem_tablehub_device_write_firmware(FuDevice *device,
 		g_prefix_error_literal(error, "failed to copy download mode payload: ");
 		return FALSE;
 	}
-	if (!fu_logitech_rallysystem_tablehub_device_send(self, st_req->data, st_req->len, error)) {
+	if (!fu_logitech_rallysystem_tablehub_device_send(self,
+							  st_req->buf->data,
+							  st_req->buf->len,
+							  error)) {
 		g_prefix_error_literal(error, "failed to set download mode: ");
 		return FALSE;
 	}
@@ -298,7 +301,10 @@ fu_logitech_rallysystem_tablehub_device_send_init_cmd_cb(FuDevice *device,
 	g_autoptr(FuStructUsbInitRequest) st_req = fu_struct_usb_init_request_new();
 	g_autoptr(FuStructUsbInitResponse) st_res = NULL;
 
-	if (!fu_logitech_rallysystem_tablehub_device_send(self, st_req->data, st_req->len, error)) {
+	if (!fu_logitech_rallysystem_tablehub_device_send(self,
+							  st_req->buf->data,
+							  st_req->buf->len,
+							  error)) {
 		g_prefix_error_literal(error, "failed to send init packet: ");
 		return FALSE;
 	}
@@ -347,7 +353,10 @@ fu_logitech_rallysystem_tablehub_device_setup(FuDevice *device, GError **error)
 	}
 
 	/* query tablehub firmware version */
-	if (!fu_logitech_rallysystem_tablehub_device_send(self, st_req->data, st_req->len, error)) {
+	if (!fu_logitech_rallysystem_tablehub_device_send(self,
+							  st_req->buf->data,
+							  st_req->buf->len,
+							  error)) {
 		g_prefix_error_literal(error,
 				       "failed to send tablehub firmware version request: "
 				       "please reboot the device: ");

--- a/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
@@ -78,8 +78,8 @@ fu_logitech_tap_sensor_device_enable_tde(FuDevice *device, GError **error)
 	    FU_LOGITECH_TAP_SENSOR_HID_TDE_MODE_ENABLE);
 
 	return fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					    st->data,
-					    st->len,
+					    st->buf->data,
+					    st->buf->len,
 					    FU_IOCTL_FLAG_RETRY,
 					    error);
 }
@@ -99,8 +99,8 @@ fu_logitech_tap_sensor_device_disable_tde(FuDevice *device, GError **error)
 	    FU_LOGITECH_TAP_SENSOR_HID_TDE_MODE_DISABLE);
 
 	return fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					    st->data,
-					    st->len,
+					    st->buf->data,
+					    st->buf->len,
 					    FU_IOCTL_FLAG_RETRY,
 					    error);
 }
@@ -140,8 +140,8 @@ fu_logitech_tap_sensor_device_reboot_device(FuLogitechTapSensorDevice *self, GEr
 	    st,
 	    FU_LOGITECH_TAP_SENSOR_HID_REBOOT_PWR);
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st->data,
-					  st->len,
+					  st->buf->data,
+					  st->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
@@ -150,8 +150,8 @@ fu_logitech_tap_sensor_device_reboot_device(FuLogitechTapSensorDevice *self, GEr
 	    st,
 	    FU_LOGITECH_TAP_SENSOR_HID_REBOOT_RST);
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st->data,
-					  st->len,
+					  st->buf->data,
+					  st->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
@@ -165,8 +165,8 @@ fu_logitech_tap_sensor_device_reboot_device(FuLogitechTapSensorDevice *self, GEr
 	    st,
 	    FU_LOGITECH_TAP_SENSOR_HID_REBOOT_PWR);
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st->data,
-					  st->len,
+					  st->buf->data,
+					  st->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
@@ -177,8 +177,8 @@ fu_logitech_tap_sensor_device_reboot_device(FuLogitechTapSensorDevice *self, GEr
 	    st,
 	    FU_LOGITECH_TAP_SENSOR_HID_REBOOT_RST);
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st->data,
-					  st->len,
+					  st->buf->data,
+					  st->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
@@ -207,20 +207,20 @@ fu_logitech_tap_sensor_device_set_version(FuLogitechTapSensorDevice *self, GErro
 						      FU_LOGITECH_TAP_SENSOR_HID_GET_CMD_VERSION);
 	/* setup HID report to query current device version */
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st_req->data,
-					  st_req->len,
+					  st_req->buf->data,
+					  st_req->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
 	if (!fu_logitech_tap_sensor_device_get_feature(self,
-						       (guint8 *)st_res->data,
-						       st_res->len,
+						       (guint8 *)st_res->buf->data,
+						       st_res->buf->len,
 						       error))
 		return FALSE;
 
 	/* MinorVersion byte 3, MajorVersion byte 4, BuildVersion byte 2 & 1 */
-	if (!fu_memread_uint32_safe((guint8 *)st_res->data,
-				    st_res->len,
+	if (!fu_memread_uint32_safe((guint8 *)st_res->buf->data,
+				    st_res->buf->len,
 				    0x01,
 				    &version,
 				    G_LITTLE_ENDIAN,
@@ -267,8 +267,8 @@ fu_logitech_tap_sensor_device_set_serial(FuLogitechTapSensorDevice *self, GError
 
 	/* setup HID report for serial number */
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st_req->data,
-					  st_req->len,
+					  st_req->buf->data,
+					  st_req->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error))
 		return FALSE;
@@ -284,16 +284,16 @@ fu_logitech_tap_sensor_device_set_serial(FuLogitechTapSensorDevice *self, GError
 		    FU_LOGITECH_TAP_SENSOR_HID_GET_CMD_SERIAL_NUMBER);
 
 		if (!fu_logitech_tap_sensor_device_get_feature(self,
-							       (guint8 *)st_res->data,
-							       st_res->len,
+							       (guint8 *)st_res->buf->data,
+							       st_res->buf->len,
 							       error))
 			return FALSE;
 		g_string_append_printf(serial_number,
 				       "%c%c%c%c",
-				       st_res->data[1],
-				       st_res->data[2],
-				       st_res->data[3],
-				       st_res->data[4]);
+				       st_res->buf->data[1],
+				       st_res->buf->data[2],
+				       st_res->buf->data[3],
+				       st_res->buf->data[4]);
 	}
 	fu_device_set_serial(FU_DEVICE(self), serial_number->str);
 

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -94,10 +94,10 @@ fu_logitech_tap_touch_device_hid_transfer(FuLogitechTapTouchDevice *self,
 					  GByteArray *buf_res,
 					  GError **error)
 {
-	fu_byte_array_set_size(st_req, FU_LOGITECH_TAP_TOUCH_HID_SET_DATA_LEN, 0x0);
+	fu_byte_array_set_size(st_req->buf, FU_LOGITECH_TAP_TOUCH_HID_SET_DATA_LEN, 0x0);
 	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  st_req->data,
-					  st_req->len,
+					  st_req->buf->data,
+					  st_req->buf->len,
 					  FU_IOCTL_FLAG_RETRY,
 					  error)) {
 		g_prefix_error_literal(error, "failed to send packet to touch panel: ");
@@ -136,7 +136,7 @@ fu_logitech_tap_touch_device_enable_tde(FuDevice *device, GError **error)
 	fu_struct_logitech_tap_touch_hid_req_set_cmd(
 	    st,
 	    FU_STRUCT_LOGITECH_TAP_TOUCH_HID_CMD_SET_TDE_TEST_MODE);
-	fu_byte_array_append_uint8(st, 0x01);
+	fu_byte_array_append_uint8(st->buf, 0x01);
 	return fu_logitech_tap_touch_device_hid_transfer(self, st, 0, NULL, error);
 }
 
@@ -151,7 +151,7 @@ fu_logitech_tap_touch_device_disable_tde(FuDevice *device, GError **error)
 	fu_struct_logitech_tap_touch_hid_req_set_cmd(
 	    st,
 	    FU_STRUCT_LOGITECH_TAP_TOUCH_HID_CMD_SET_TDE_TEST_MODE);
-	fu_byte_array_append_uint8(st, 0x00);
+	fu_byte_array_append_uint8(st->buf, 0x00);
 	return fu_logitech_tap_touch_device_hid_transfer(self, st, 0, NULL, error);
 }
 
@@ -177,12 +177,12 @@ fu_logitech_tap_touch_device_write_enable(FuLogitechTapTouchDevice *self,
 	fu_struct_logitech_tap_touch_hid_req_set_cmd(
 	    st,
 	    FU_STRUCT_LOGITECH_TAP_TOUCH_HID_CMD_WRITE_ENABLE);
-	fu_byte_array_append_uint8(st, 0x5A);
-	fu_byte_array_append_uint8(st, 0xA5);
+	fu_byte_array_append_uint8(st->buf, 0x5A);
+	fu_byte_array_append_uint8(st->buf, 0xA5);
 	if (end > 0) {
-		fu_byte_array_append_uint8(st, write_ap ? 0x00 : 0x01);
-		fu_byte_array_append_uint24(st, end, G_BIG_ENDIAN);
-		fu_byte_array_append_uint24(st, checksum, G_BIG_ENDIAN);
+		fu_byte_array_append_uint8(st->buf, write_ap ? 0x00 : 0x01);
+		fu_byte_array_append_uint24(st->buf, end, G_BIG_ENDIAN);
+		fu_byte_array_append_uint24(st->buf, checksum, G_BIG_ENDIAN);
 	}
 
 	/* hid report to enable writing */
@@ -633,11 +633,11 @@ fu_logitech_tap_touch_device_write_blocks(FuLogitechTapTouchDevice *self,
 		fu_struct_logitech_tap_touch_hid_req_set_cmd(
 		    st,
 		    FU_STRUCT_LOGITECH_TAP_TOUCH_HID_CMD_WRITE_DATA);
-		g_byte_array_append(st, chunk_buf->data, chunk_buf->len);
+		g_byte_array_append(st->buf, chunk_buf->data, chunk_buf->len);
 		/* resize the last packet */
 		if ((i == (fu_chunk_array_length(chunks) - 1)) &&
 		    (fu_chunk_get_data_sz(chk) < FU_LOGITECH_TAP_TOUCH_TRANSFER_BLOCK_SIZE))
-			fu_byte_array_set_size(st, 37, in_ap ? 0xFF : 0x0);
+			fu_byte_array_set_size(st->buf, 37, in_ap ? 0xFF : 0x0);
 		if (!fu_logitech_tap_touch_device_hid_transfer(self, st, 0, NULL, error))
 			return FALSE;
 		fu_device_sleep(FU_DEVICE(self), 2);
@@ -734,7 +734,7 @@ fu_logitech_tap_touch_device_write_chunks_cb(FuDevice *device, gpointer user_dat
 	fu_struct_logitech_tap_touch_hid_req_set_cmd(
 	    st,
 	    FU_STRUCT_LOGITECH_TAP_TOUCH_HID_CMD_WRITE_DATA);
-	fu_byte_array_set_size(st,
+	fu_byte_array_set_size(st->buf,
 			       37,
 			       0xFF); /* 4 (req header) + 1 (cmd) +
 					 FU_LOGITECH_TAP_TOUCH_TRANSFER_BLOCK_SIZE (data buffer) */

--- a/plugins/qc-firehose/fu-qc-firehose-sahara-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-sahara-impl.c
@@ -72,7 +72,7 @@ fu_qc_firehose_sahara_impl_hello(FuQcFirehoseSaharaImpl *self, GByteArray *buf, 
 		return FALSE;
 	fu_qc_firehose_sahara_pkt_hello_resp_set_mode(st_resp,
 						      fu_qc_firehose_sahara_pkt_hello_get_mode(st));
-	return fu_qc_firehose_sahara_impl_write(self, st_resp->data, st_resp->len, error);
+	return fu_qc_firehose_sahara_impl_write(self, st_resp->buf->data, st_resp->buf->len, error);
 }
 
 static gboolean
@@ -150,7 +150,7 @@ fu_qc_firehose_sahara_impl_eoi(FuQcFirehoseSaharaImpl *self, GByteArray *buf, GE
 			    fu_qc_firehose_sahara_status_to_string(status));
 		return FALSE;
 	}
-	return fu_qc_firehose_sahara_impl_write(self, st_resp->data, st_resp->len, error);
+	return fu_qc_firehose_sahara_impl_write(self, st_resp->buf->data, st_resp->buf->len, error);
 }
 
 static gboolean

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-ble-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-ble-device.c
@@ -125,22 +125,22 @@ fu_qc_s5gen2_ble_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_l
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3UpgradeControlCmd) req =
+	g_autoptr(FuStructQcGaiaV3UpgradeControlCmd) st_req =
 	    fu_struct_qc_gaia_v3_upgrade_control_cmd_new();
-	g_autoptr(FuStructQcGaiaV3UpgradeControlAck) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeControlAck) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_upgrade_control_cmd_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_upgrade_control_cmd_set_vendor_id(st_req, self->vid_v3);
 
-	g_byte_array_append(req, data, data_len);
+	g_byte_array_append(st_req->buf, data, data_len);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	validate = fu_struct_qc_gaia_v3_upgrade_control_ack_parse(buf, read_len, 0, error);
-	if (validate == NULL) {
+	st_res = fu_struct_qc_gaia_v3_upgrade_control_ack_parse(buf, read_len, 0, error);
+	if (st_res == NULL) {
 		return FALSE;
 	}
 
@@ -203,23 +203,23 @@ fu_qc_s5gen2_ble_device_req_connect(FuQcS5gen2Impl *impl, GError **error)
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3UpgradeConnectCmd) req =
+	g_autoptr(FuStructQcGaiaV3UpgradeConnectCmd) st_req =
 	    fu_struct_qc_gaia_v3_upgrade_connect_cmd_new();
-	g_autoptr(FuStructQcGaiaV3UpgradeConnectAck) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeConnectAck) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_upgrade_connect_cmd_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_upgrade_connect_cmd_set_vendor_id(st_req, self->vid_v3);
 
 	if (!fu_qc_s5gen2_ble_device_notify_acquire(self, error))
 		return FALSE;
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	validate = fu_struct_qc_gaia_v3_upgrade_connect_ack_parse(buf, read_len, 0, error);
-	if (validate == NULL)
+	st_res = fu_struct_qc_gaia_v3_upgrade_connect_ack_parse(buf, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;
@@ -231,20 +231,20 @@ fu_qc_s5gen2_ble_device_req_disconnect(FuQcS5gen2Impl *impl, GError **error)
 	FuQcS5gen2BleDevice *self = FU_QC_S5GEN2_BLE_DEVICE(impl);
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectCmd) req =
+	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectCmd) st_req =
 	    fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_new();
-	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectAck) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3UpgradeDisconnectAck) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_upgrade_disconnect_cmd_set_vendor_id(st_req, self->vid_v3);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	validate = fu_struct_qc_gaia_v3_upgrade_disconnect_ack_parse(buf, read_len, 0, error);
-	if (validate == NULL)
+	st_res = fu_struct_qc_gaia_v3_upgrade_disconnect_ack_parse(buf, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return fu_qc_s5gen2_ble_device_notify_release(self, error);
@@ -276,23 +276,23 @@ fu_qc_s5gen2_ble_device_get_api(FuQcS5gen2BleDevice *self, GError **error)
 	gsize read_len;
 	guint8 api_major;
 	guint8 api_minor;
-	g_autoptr(FuStructQcGaiaV3ApiReq) req = fu_struct_qc_gaia_v3_api_req_new();
-	g_autoptr(FuStructQcGaiaV3Api) resp = NULL;
+	g_autoptr(FuStructQcGaiaV3ApiReq) st_req = fu_struct_qc_gaia_v3_api_req_new();
+	g_autoptr(FuStructQcGaiaV3Api) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_api_req_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_api_req_set_vendor_id(st_req, self->vid_v3);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	resp = fu_struct_qc_gaia_v3_api_parse(buf, read_len, 0, error);
-	if (resp == NULL)
+	st_res = fu_struct_qc_gaia_v3_api_parse(buf, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
-	api_major = fu_struct_qc_gaia_v3_api_get_major(resp);
-	api_minor = fu_struct_qc_gaia_v3_api_get_minor(resp);
+	api_major = fu_struct_qc_gaia_v3_api_get_major(st_res);
+	api_minor = fu_struct_qc_gaia_v3_api_get_minor(st_res);
 
 	if (api_major < FU_QC_S5GEN2_GAIA_V3_SUPPORTED_VERSION_MAJOR) {
 		g_set_error(error,
@@ -313,25 +313,25 @@ fu_qc_s5gen2_ble_device_get_features(FuQcS5gen2BleDevice *self, gboolean next, G
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3SupportedFeaturesReq) req =
+	g_autoptr(FuStructQcGaiaV3SupportedFeaturesReq) st_req =
 	    fu_struct_qc_gaia_v3_supported_features_req_new();
-	g_autoptr(FuStructQcGaiaV3SupportedFeatures) resp = NULL;
+	g_autoptr(FuStructQcGaiaV3SupportedFeatures) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_supported_features_req_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_supported_features_req_set_vendor_id(st_req, self->vid_v3);
 
 	fu_struct_qc_gaia_v3_supported_features_req_set_command(
-	    req,
+	    st_req,
 	    (next == FALSE) ? FU_QC_GAIA_V3_CMD_GET_SUPPORTED_FEATURES_REQ
 			    : FU_QC_GAIA_V3_CMD_GET_SUPPORTED_FEATURES_NEXT_REQ);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	resp = fu_struct_qc_gaia_v3_supported_features_parse(buf, read_len, 0, error);
-	if (resp == NULL)
+	st_res = fu_struct_qc_gaia_v3_supported_features_parse(buf, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	/* must be odd: header 5B + feature pairs */
@@ -362,7 +362,7 @@ fu_qc_s5gen2_ble_device_get_features(FuQcS5gen2BleDevice *self, gboolean next, G
 	}
 
 	/* request the rest of the list */
-	if (fu_struct_qc_gaia_v3_supported_features_get_more_features(resp) == FU_QC_MORE_MORE)
+	if (fu_struct_qc_gaia_v3_supported_features_get_more_features(st_res) == FU_QC_MORE_MORE)
 		return fu_qc_s5gen2_ble_device_get_features(self, TRUE, error);
 
 	return TRUE;
@@ -373,22 +373,21 @@ fu_qc_s5gen2_ble_device_get_serial(FuQcS5gen2BleDevice *self, GError **error)
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3SerialReq) req = fu_struct_qc_gaia_v3_serial_req_new();
-	g_autoptr(FuStructQcGaiaV3Serial) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3SerialReq) st_req = fu_struct_qc_gaia_v3_serial_req_new();
+	g_autoptr(FuStructQcGaiaV3Serial) st_res = NULL;
 	g_autofree gchar *serial = NULL;
 
-	fu_struct_qc_gaia_v3_serial_req_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_serial_req_set_vendor_id(st_req, self->vid_v3);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
 	/* Check if response is valid */
-	validate =
-	    fu_struct_qc_gaia_v3_serial_parse(buf, FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE, 0, error);
-	if (validate == NULL)
+	st_res = fu_struct_qc_gaia_v3_serial_parse(buf, FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	serial = fu_strsafe((gchar *)(buf + FU_STRUCT_QC_GAIA_V3_SERIAL_SIZE),
@@ -405,22 +404,22 @@ fu_qc_s5gen2_ble_device_get_variant(FuQcS5gen2BleDevice *self, GError **error)
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3VariantReq) req = fu_struct_qc_gaia_v3_variant_req_new();
-	g_autoptr(FuStructQcGaiaV3Variant) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3VariantReq) st_req = fu_struct_qc_gaia_v3_variant_req_new();
+	g_autoptr(FuStructQcGaiaV3Variant) st_res = NULL;
 	g_autofree gchar *variant = NULL;
 
-	fu_struct_qc_gaia_v3_variant_req_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_variant_req_set_vendor_id(st_req, self->vid_v3);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
 	/* check if response is valid */
-	validate =
+	st_res =
 	    fu_struct_qc_gaia_v3_variant_parse(buf, FU_STRUCT_QC_GAIA_V3_VARIANT_SIZE, 0, error);
-	if (validate == NULL)
+	if (st_res == NULL)
 		return FALSE;
 
 	variant = fu_strsafe((gchar *)(buf + FU_STRUCT_QC_GAIA_V3_VARIANT_SIZE),
@@ -449,26 +448,26 @@ fu_qc_s5gen2_ble_device_register_notification(FuQcS5gen2BleDevice *self, GError 
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len = 0;
-	g_autoptr(FuStructQcGaiaV3RegisterNotificationCmd) req =
+	g_autoptr(FuStructQcGaiaV3RegisterNotificationCmd) st_req =
 	    fu_struct_qc_gaia_v3_register_notification_cmd_new();
-	g_autoptr(FuStructQcGaiaV3RegisterNotificationAck) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3RegisterNotificationAck) st_res = NULL;
 
 	/* register only for update feature */
-	fu_struct_qc_gaia_v3_register_notification_cmd_set_vendor_id(req, self->vid_v3);
+	fu_struct_qc_gaia_v3_register_notification_cmd_set_vendor_id(st_req, self->vid_v3);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
 	/* Check if response is valid */
-	validate = fu_struct_qc_gaia_v3_register_notification_ack_parse(
+	st_res = fu_struct_qc_gaia_v3_register_notification_ack_parse(
 	    buf,
 	    FU_STRUCT_QC_GAIA_V3_REGISTER_NOTIFICATION_ACK_SIZE,
 	    0,
 	    error);
-	if (validate == NULL)
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;
@@ -481,22 +480,22 @@ fu_qc_s5gen2_ble_device_set_transport_protocol(FuQcS5gen2BleDevice *self,
 {
 	guint8 buf[FU_QC_S5GEN2_BLE_DEVICE_BUFFER_SZ] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcGaiaV3SetTransportInfoReq) req =
+	g_autoptr(FuStructQcGaiaV3SetTransportInfoReq) st_req =
 	    fu_struct_qc_gaia_v3_set_transport_info_req_new();
-	g_autoptr(FuStructQcGaiaV3SetTransportInfo) validate = NULL;
+	g_autoptr(FuStructQcGaiaV3SetTransportInfo) st_res = NULL;
 
-	fu_struct_qc_gaia_v3_set_transport_info_req_set_vendor_id(req, self->vid_v3);
-	fu_struct_qc_gaia_v3_set_transport_info_req_set_key(req, 0x07);
-	fu_struct_qc_gaia_v3_set_transport_info_req_set_value(req, version);
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_vendor_id(st_req, self->vid_v3);
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_key(st_req, 0x07);
+	fu_struct_qc_gaia_v3_set_transport_info_req_set_value(st_req, version);
 
-	if (!fu_qc_s5gen2_ble_device_send(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_ble_device_send(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	if (!fu_qc_s5gen2_ble_device_recv(self, buf, sizeof(buf), &read_len, error))
 		return FALSE;
 
-	validate = fu_struct_qc_gaia_v3_set_transport_info_parse(buf, read_len, 0, error);
-	if (validate == NULL)
+	st_res = fu_struct_qc_gaia_v3_set_transport_info_parse(buf, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -55,7 +55,7 @@ fu_qc_s5gen2_device_msg_in(FuQcS5gen2Device *self,
 			   GError **error)
 {
 	FuDevice *proxy = fu_device_get_proxy(FU_DEVICE(self));
-	g_autoptr(FuStructQcErrorInd) err_msg = NULL;
+	g_autoptr(FuStructQcErrorInd) st_err = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	if (proxy == NULL) {
@@ -76,16 +76,16 @@ fu_qc_s5gen2_device_msg_in(FuQcS5gen2Device *self,
 	}
 
 	/* error detected */
-	err_msg = fu_struct_qc_error_ind_parse(buf, *read_len, 0, &error_local);
-	if (err_msg != NULL) {
-		guint16 code = fu_struct_qc_error_ind_get_error_code(err_msg);
-		g_autoptr(GByteArray) confirm = fu_struct_qc_error_res_new();
+	st_err = fu_struct_qc_error_ind_parse(buf, *read_len, 0, &error_local);
+	if (st_err != NULL) {
+		guint16 code = fu_struct_qc_error_ind_get_error_code(st_err);
+		g_autoptr(FuStructQcErrorRes) st_confirm = fu_struct_qc_error_res_new();
 
 		/* confirm and stop */
-		fu_struct_qc_error_res_set_error_code(confirm, code);
+		fu_struct_qc_error_res_set_error_code(st_confirm, code);
 		if (!fu_qc_s5gen2_impl_msg_out(FU_QC_S5GEN2_IMPL(proxy),
-					       confirm->data,
-					       confirm->len,
+					       st_confirm->buf->data,
+					       st_confirm->buf->len,
 					       error))
 			return FALSE;
 
@@ -139,16 +139,16 @@ fu_qc_s5gen2_device_cmd_abort(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_ABORT_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcAbortReq) req = fu_struct_qc_abort_req_new();
-	g_autoptr(FuStructQcAbort) reply = NULL;
+	g_autoptr(FuStructQcAbortReq) st_req = fu_struct_qc_abort_req_new();
+	g_autoptr(FuStructQcAbort) st_res = NULL;
 
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
 
-	reply = fu_struct_qc_abort_parse(data, read_len, 0, error);
-	if (reply == NULL)
+	st_res = fu_struct_qc_abort_parse(data, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;
@@ -159,30 +159,30 @@ fu_qc_s5gen2_device_cmd_sync(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_SYNC_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcSyncReq) req = fu_struct_qc_sync_req_new();
-	g_autoptr(FuStructQcSync) reply = NULL;
+	g_autoptr(FuStructQcSyncReq) st_req = fu_struct_qc_sync_req_new();
+	g_autoptr(FuStructQcSync) st_res = NULL;
 
-	fu_struct_qc_sync_req_set_file_id(req, self->file_id);
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	fu_struct_qc_sync_req_set_file_id(st_req, self->file_id);
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
 
-	reply = fu_struct_qc_sync_parse(data, read_len, 0, error);
-	if (reply == NULL)
+	st_res = fu_struct_qc_sync_parse(data, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
-	if (self->file_version != fu_struct_qc_sync_get_protocol_version(reply)) {
+	if (self->file_version != fu_struct_qc_sync_get_protocol_version(st_res)) {
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
 			    "unsupported firmware protocol version on device %u, expected %u",
-			    fu_struct_qc_sync_get_protocol_version(reply),
+			    fu_struct_qc_sync_get_protocol_version(st_res),
 			    self->file_version);
 		return FALSE;
 	}
 
-	if (self->file_id != fu_struct_qc_sync_get_file_id(reply)) {
+	if (self->file_id != fu_struct_qc_sync_get_file_id(st_res)) {
 		g_autoptr(GError) error_local = NULL;
 		/* reset the update state */
 		if (!fu_qc_s5gen2_device_cmd_abort(self, &error_local))
@@ -192,13 +192,13 @@ fu_qc_s5gen2_device_cmd_sync(FuQcS5gen2Device *self, GError **error)
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_DATA,
 			    "unexpected file ID from the device (%u), expected (%u)",
-			    fu_struct_qc_sync_get_file_id(reply),
+			    fu_struct_qc_sync_get_file_id(st_res),
 			    self->file_id);
 
 		return FALSE;
 	}
 
-	self->resume_point = fu_struct_qc_sync_get_resume_point(reply);
+	self->resume_point = fu_struct_qc_sync_get_resume_point(st_res);
 	return TRUE;
 }
 
@@ -208,19 +208,19 @@ fu_qc_s5gen2_device_cmd_start(FuQcS5gen2Device *self, GError **error)
 	guint8 data[FU_STRUCT_QC_START_SIZE] = {0};
 	gsize read_len;
 	FuQcStartStatus status;
-	g_autoptr(FuStructQcStartReq) req = fu_struct_qc_start_req_new();
-	g_autoptr(FuStructQcStart) reply = NULL;
+	g_autoptr(FuStructQcStartReq) st_req = fu_struct_qc_start_req_new();
+	g_autoptr(FuStructQcStart) st_res = NULL;
 
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
 
-	reply = fu_struct_qc_start_parse(data, read_len, 0, error);
-	if (reply == NULL)
+	st_res = fu_struct_qc_start_parse(data, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
-	status = fu_struct_qc_start_get_status(reply);
+	status = fu_struct_qc_start_get_status(st_res);
 	if (status != FU_QC_START_STATUS_SUCCESS) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -231,7 +231,7 @@ fu_qc_s5gen2_device_cmd_start(FuQcS5gen2Device *self, GError **error)
 	}
 
 	/* mostly for debug: save raw battery level */
-	self->battery_raw = fu_struct_qc_start_get_battery_level(reply);
+	self->battery_raw = fu_struct_qc_start_get_battery_level(st_res);
 
 	return TRUE;
 }
@@ -239,9 +239,9 @@ fu_qc_s5gen2_device_cmd_start(FuQcS5gen2Device *self, GError **error)
 static gboolean
 fu_qc_s5gen2_device_cmd_start_data(FuQcS5gen2Device *self, GError **error)
 {
-	g_autoptr(GByteArray) req = fu_struct_qc_start_data_req_new();
+	g_autoptr(FuStructQcStartDataReq) st_req = fu_struct_qc_start_data_req_new();
 
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 
 	fu_device_sleep(FU_DEVICE(self), FU_QC_S5GEN2_DEVICE_DATA_REQ_SLEEP);
@@ -255,11 +255,12 @@ fu_qc_s5gen2_device_cmd_validation(FuQcS5gen2Device *self, GError **error)
 	guint16 delay_ms;
 	guint8 data[FU_STRUCT_QC_IS_VALIDATION_DONE_SIZE] = {0};
 	gsize read_len = 0;
-	g_autoptr(FuStructQcValidationReq) req = fu_struct_qc_validation_req_new();
-	g_autoptr(FuStructQcTransferCompleteInd) reply = NULL;
+	g_autoptr(FuStructQcValidationReq) st_req = fu_struct_qc_validation_req_new();
+	g_autoptr(FuStructQcTransferCompleteInd) st_res = NULL;
+	g_autoptr(FuStructQcIsValidationDone) st_res2 = NULL;
 	g_autoptr(GError) error_local = NULL;
 
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
@@ -275,16 +276,16 @@ fu_qc_s5gen2_device_cmd_validation(FuQcS5gen2Device *self, GError **error)
 	}
 
 	/* ignore the error */
-	reply = fu_struct_qc_transfer_complete_ind_parse(data, sizeof(data), 0, &error_local);
+	st_res = fu_struct_qc_transfer_complete_ind_parse(data, sizeof(data), 0, &error_local);
 	/* check if validation is complete */
-	if (reply != NULL)
+	if (st_res != NULL)
 		return TRUE;
 
-	reply = fu_struct_qc_is_validation_done_parse(data, sizeof(data), 0, error);
-	if (reply == NULL)
+	st_res2 = fu_struct_qc_is_validation_done_parse(data, sizeof(data), 0, error);
+	if (st_res2 == NULL)
 		return FALSE;
 
-	delay_ms = fu_struct_qc_is_validation_done_get_delay(reply);
+	delay_ms = fu_struct_qc_is_validation_done_get_delay(st_res2);
 	g_set_error(error,
 		    FWUPD_ERROR,
 		    FWUPD_ERROR_INVALID_DATA,
@@ -305,12 +306,12 @@ fu_qc_s5gen2_device_cmd_transfer_complete(FuQcS5gen2Device *self, GError **error
 {
 	/* reboot immediately */
 	FuQcTransferAction action = FU_QC_TRANSFER_ACTION_INTERACTIVE;
-	g_autoptr(FuStructQcTransferComplete) req = fu_struct_qc_transfer_complete_new();
+	g_autoptr(FuStructQcTransferComplete) st_req = fu_struct_qc_transfer_complete_new();
 
-	fu_struct_qc_transfer_complete_set_action(req, action);
+	fu_struct_qc_transfer_complete_set_action(st_req, action);
 
 	/* if reboot immediately, the write might return error */
-	return fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error);
+	return fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error);
 }
 
 static gboolean
@@ -318,18 +319,18 @@ fu_qc_s5gen2_device_cmd_proceed_to_commit(FuQcS5gen2Device *self, GError **error
 {
 	guint8 data[FU_STRUCT_QC_COMMIT_REQ_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcProceedToCommit) req = fu_struct_qc_proceed_to_commit_new();
-	g_autoptr(FuStructQcCommitReq) reply = NULL;
+	g_autoptr(FuStructQcProceedToCommit) st_req = fu_struct_qc_proceed_to_commit_new();
+	g_autoptr(FuStructQcCommitReq) st_res = NULL;
 
-	fu_struct_qc_proceed_to_commit_set_action(req, FU_QC_COMMIT_ACTION_PROCEED);
+	fu_struct_qc_proceed_to_commit_set_action(st_req, FU_QC_COMMIT_ACTION_PROCEED);
 
-	if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
 
-	reply = fu_struct_qc_commit_req_parse(data, read_len, 0, error);
-	if (reply == NULL)
+	st_res = fu_struct_qc_commit_req_parse(data, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;
@@ -340,21 +341,21 @@ fu_qc_s5gen2_device_cmd_commit_cfm(FuQcS5gen2Device *self, GError **error)
 {
 	guint8 data[FU_STRUCT_QC_COMPLETE_SIZE] = {0};
 	gsize read_len;
-	g_autoptr(FuStructQcCommitCfm) req = fu_struct_qc_commit_cfm_new();
-	g_autoptr(FuStructQcComplete) reply = NULL;
+	g_autoptr(FuStructQcCommitCfm) st_req = fu_struct_qc_commit_cfm_new();
+	g_autoptr(FuStructQcComplete) st_res = NULL;
 
-	fu_struct_qc_commit_cfm_set_action(req, FU_QC_COMMIT_CFM_ACTION_UPGRADE);
+	fu_struct_qc_commit_cfm_set_action(st_req, FU_QC_COMMIT_CFM_ACTION_UPGRADE);
 
 	if (self->resume_point != FU_QC_RESUME_POINT_POST_COMMIT) {
-		if (!fu_qc_s5gen2_device_msg_out(self, req->data, req->len, error))
+		if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 			return FALSE;
 	}
 
 	if (!fu_qc_s5gen2_device_msg_in(self, data, sizeof(data), &read_len, error))
 		return FALSE;
 
-	reply = fu_struct_qc_complete_parse(data, read_len, 0, error);
-	if (reply == NULL)
+	st_res = fu_struct_qc_complete_parse(data, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	return TRUE;
@@ -367,8 +368,8 @@ fu_qc_s5gen2_device_ensure_version(FuQcS5gen2Device *self, GError **error)
 	g_autofree gchar *ver_str = NULL;
 	gsize read_len;
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(FuStructQcVersion) version = NULL;
-	g_autoptr(FuStructQcVersionReq) version_req = fu_struct_qc_version_req_new();
+	g_autoptr(FuStructQcVersion) st_res = NULL;
+	g_autoptr(FuStructQcVersionReq) st_req = fu_struct_qc_version_req_new();
 
 	locker =
 	    fu_device_locker_new_full(FU_DEVICE(self),
@@ -378,18 +379,18 @@ fu_qc_s5gen2_device_ensure_version(FuQcS5gen2Device *self, GError **error)
 	if (locker == NULL)
 		return FALSE;
 
-	if (!fu_qc_s5gen2_device_msg_out(self, version_req->data, version_req->len, error))
+	if (!fu_qc_s5gen2_device_msg_out(self, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_device_msg_in(self, ver_raw, sizeof(ver_raw), &read_len, error))
 		return FALSE;
-	version = fu_struct_qc_version_parse(ver_raw, read_len, 0, error);
-	if (version == NULL)
+	st_res = fu_struct_qc_version_parse(ver_raw, read_len, 0, error);
+	if (st_res == NULL)
 		return FALSE;
 
 	ver_str = g_strdup_printf("%u.%u.%u",
-				  fu_struct_qc_version_get_major(version),
-				  fu_struct_qc_version_get_minor(version),
-				  fu_struct_qc_version_get_config(version));
+				  fu_struct_qc_version_get_major(st_res),
+				  fu_struct_qc_version_get_minor(st_res),
+				  fu_struct_qc_version_get_config(st_res));
 	fu_device_set_version(FU_DEVICE(self), ver_str);
 	return TRUE;
 }
@@ -495,23 +496,23 @@ fu_qc_s5gen2_device_write_bucket(FuQcS5gen2Device *self,
 					       data_sz);
 
 	for (guint i = 0; i < fu_chunk_array_length(chunks); i++) {
-		g_autoptr(FuStructQcData) pkt = fu_struct_qc_data_new();
+		g_autoptr(FuStructQcData) st_pkt = fu_struct_qc_data_new();
 		g_autoptr(FuChunk) chk = fu_chunk_array_index(chunks, i, error);
 
 		if (chk == NULL)
 			return FALSE;
 
-		fu_struct_qc_data_set_data_len(pkt, fu_chunk_get_data_sz(chk) + 1);
+		fu_struct_qc_data_set_data_len(st_pkt, fu_chunk_get_data_sz(chk) + 1);
 		/* only the last block of the last bucket should have flag LAST */
 		if ((i + 1) == fu_chunk_array_length(chunks))
-			fu_struct_qc_data_set_last_packet(pkt, last);
+			fu_struct_qc_data_set_last_packet(st_pkt, last);
 		else
-			fu_struct_qc_data_set_last_packet(pkt, FU_QC_MORE_DATA_MORE);
+			fu_struct_qc_data_set_last_packet(st_pkt, FU_QC_MORE_DATA_MORE);
 
-		g_byte_array_append(pkt, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
+		g_byte_array_append(st_pkt->buf, fu_chunk_get_data(chk), fu_chunk_get_data_sz(chk));
 
 		if (!fu_qc_s5gen2_device_msg_out(self,
-						 pkt->data,
+						 st_pkt->buf->data,
 						 FU_STRUCT_QC_DATA_SIZE + fu_chunk_get_data_sz(chk),
 						 error))
 			return FALSE;
@@ -541,18 +542,18 @@ fu_qc_s5gen2_device_write_blocks(FuQcS5gen2Device *self,
 		gsize read_len;
 		guint32 data_sz;
 		guint32 data_offset;
-		g_autoptr(FuStructQcDataReq) data_req = NULL;
+		g_autoptr(FuStructQcDataReq) st_req = NULL;
 		g_autoptr(GBytes) data_out = NULL;
 
 		if (!fu_qc_s5gen2_device_msg_in(self, buf_in, sizeof(buf_in), &read_len, error))
 			return FALSE;
-		data_req = fu_struct_qc_data_req_parse(buf_in, read_len, 0, error);
-		if (data_req == NULL)
+		st_req = fu_struct_qc_data_req_parse(buf_in, read_len, 0, error);
+		if (st_req == NULL)
 			return FALSE;
 
 		/* requested data */
-		data_sz = fu_struct_qc_data_req_get_fw_data_len(data_req);
-		data_offset = fu_struct_qc_data_req_get_fw_data_offset(data_req);
+		data_sz = fu_struct_qc_data_req_get_fw_data_len(st_req);
+		data_offset = fu_struct_qc_data_req_get_fw_data_offset(st_req);
 
 		/* FIXME: abort for now */
 		if (data_sz == 0) {

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-firmware.c
@@ -62,25 +62,25 @@ fu_qc_s5gen2_firmware_parse(FuFirmware *firmware,
 	gsize config_offset = 26;
 	guint16 config_ver;
 	g_autofree gchar *ver_str = NULL;
-	g_autoptr(FuStructQcFwUpdateHdr) hdr = NULL;
+	g_autoptr(FuStructQcFwUpdateHdr) st = NULL;
 
 	/* FIXME: deal with encrypted? */
-	hdr = fu_struct_qc_fw_update_hdr_parse_stream(stream, 0x0, error);
-	if (hdr == NULL)
+	st = fu_struct_qc_fw_update_hdr_parse_stream(stream, 0x0, error);
+	if (st == NULL)
 		return FALSE;
 
 	/* protocol version */
-	self->protocol_ver = fu_struct_qc_fw_update_hdr_get_protocol(hdr) - '0';
-	device_variant = fu_struct_qc_fw_update_hdr_get_dev_variant(hdr, NULL);
+	self->protocol_ver = fu_struct_qc_fw_update_hdr_get_protocol(st) - '0';
+	device_variant = fu_struct_qc_fw_update_hdr_get_dev_variant(st, NULL);
 	self->device_variant = fu_strsafe((const gchar *)device_variant, 8);
 
-	config_offset += fu_struct_qc_fw_update_hdr_get_upgrades(hdr) * 4;
+	config_offset += fu_struct_qc_fw_update_hdr_get_upgrades(st) * 4;
 	if (!fu_input_stream_read_u16(stream, config_offset, &config_ver, G_BIG_ENDIAN, error))
 		return FALSE;
 
 	ver_str = g_strdup_printf("%u.%u.%u",
-				  fu_struct_qc_fw_update_hdr_get_major(hdr),
-				  fu_struct_qc_fw_update_hdr_get_minor(hdr),
+				  fu_struct_qc_fw_update_hdr_get_major(st),
+				  fu_struct_qc_fw_update_hdr_get_minor(st),
 				  config_ver);
 	fu_firmware_set_version(firmware, ver_str);
 

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-hid-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-hid-device.c
@@ -38,16 +38,16 @@ static gboolean
 fu_qc_s5gen2_hid_device_msg_out(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
-	g_autoptr(FuStructQcHidDataTransfer) msg = fu_struct_qc_hid_data_transfer_new();
+	g_autoptr(FuStructQcHidDataTransfer) st_req = fu_struct_qc_hid_data_transfer_new();
 
-	fu_struct_qc_hid_data_transfer_set_payload_len(msg, data_len);
-	if (!fu_struct_qc_hid_data_transfer_set_payload(msg, data, data_len, error))
+	fu_struct_qc_hid_data_transfer_set_payload_len(st_req, data_len);
+	if (!fu_struct_qc_hid_data_transfer_set_payload(st_req, data, data_len, error))
 		return FALSE;
 
 	return fu_hid_device_set_report(FU_HID_DEVICE(self),
 					0x00,
-					msg->data,
-					FU_STRUCT_QC_HID_DATA_TRANSFER_SIZE,
+					st_req->buf->data,
+					st_req->buf->len,
 					FU_QC_S5GEN2_HID_DEVICE_TIMEOUT,
 					FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
 					error);
@@ -62,32 +62,32 @@ fu_qc_s5gen2_hid_device_msg_in(FuQcS5gen2Impl *impl,
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
 	guint8 buf[FU_STRUCT_QC_HID_RESPONSE_SIZE] = {0x0};
-	g_autoptr(FuStructQcHidResponse) msg = NULL;
+	g_autoptr(FuStructQcHidResponse) st_rsp = NULL;
 
 	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
 				      0x00,
 				      buf,
-				      FU_STRUCT_QC_HID_RESPONSE_SIZE,
+				      sizeof(buf),
 				      FU_QC_S5GEN2_HID_DEVICE_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
 				      error))
 		return FALSE;
 
-	msg = fu_struct_qc_hid_response_parse(buf, FU_STRUCT_QC_HID_RESPONSE_SIZE, 0, error);
-	if (msg == NULL)
+	st_rsp = fu_struct_qc_hid_response_parse(buf, FU_STRUCT_QC_HID_RESPONSE_SIZE, 0, error);
+	if (st_rsp == NULL)
 		return FALSE;
 
 	if (!fu_memcpy_safe(data,
 			    data_len,
 			    0,
-			    msg->data,
-			    msg->len,
+			    st_rsp->buf->data,
+			    st_rsp->buf->len,
 			    FU_STRUCT_QC_HID_RESPONSE_OFFSET_PAYLOAD,
-			    fu_struct_qc_hid_response_get_payload_len(msg),
+			    fu_struct_qc_hid_response_get_payload_len(st_rsp),
 			    error))
 		return FALSE;
 
-	*read_len = fu_struct_qc_hid_response_get_payload_len(msg);
+	*read_len = fu_struct_qc_hid_response_get_payload_len(st_rsp);
 
 	return TRUE;
 }
@@ -96,16 +96,16 @@ static gboolean
 fu_qc_s5gen2_hid_device_msg_cmd(FuQcS5gen2Impl *impl, guint8 *data, gsize data_len, GError **error)
 {
 	FuQcS5gen2HidDevice *self = FU_QC_S5GEN2_HID_DEVICE(impl);
-	g_autoptr(FuStructQcHidCommand) msg = fu_struct_qc_hid_command_new();
+	g_autoptr(FuStructQcHidCommand) st_req = fu_struct_qc_hid_command_new();
 
-	fu_struct_qc_hid_command_set_payload_len(msg, data_len);
-	if (!fu_struct_qc_hid_command_set_payload(msg, data, data_len, error))
+	fu_struct_qc_hid_command_set_payload_len(st_req, data_len);
+	if (!fu_struct_qc_hid_command_set_payload(st_req, data, data_len, error))
 		return FALSE;
 
 	return fu_hid_device_set_report(FU_HID_DEVICE(self),
 					0x03,
-					msg->data,
-					FU_STRUCT_QC_HID_COMMAND_SIZE,
+					st_req->buf->data,
+					st_req->buf->len,
 					0,
 					FU_HID_DEVICE_FLAG_IS_FEATURE,
 					error);
@@ -114,8 +114,8 @@ fu_qc_s5gen2_hid_device_msg_cmd(FuQcS5gen2Impl *impl, guint8 *data, gsize data_l
 static gboolean
 fu_qc_s5gen2_hid_device_cmd_req_disconnect(FuQcS5gen2Impl *impl, GError **error)
 {
-	g_autoptr(FuStructQcDisconnectReq) req = fu_struct_qc_disconnect_req_new();
-	return fu_qc_s5gen2_hid_device_msg_cmd(impl, req->data, req->len, error);
+	g_autoptr(FuStructQcDisconnectReq) st_req = fu_struct_qc_disconnect_req_new();
+	return fu_qc_s5gen2_hid_device_msg_cmd(impl, st_req->buf->data, st_req->buf->len, error);
 }
 
 static gboolean
@@ -124,10 +124,10 @@ fu_qc_s5gen2_hid_device_cmd_req_connect(FuQcS5gen2Impl *impl, GError **error)
 	guint8 data_in[FU_STRUCT_QC_UPDATE_STATUS_SIZE] = {0x0};
 	gsize read_len;
 	FuQcStatus update_status;
-	g_autoptr(FuStructQcConnectReq) req = fu_struct_qc_connect_req_new();
+	g_autoptr(FuStructQcConnectReq) st_req = fu_struct_qc_connect_req_new();
 	g_autoptr(FuStructQcUpdateStatus) st = NULL;
 
-	if (!fu_qc_s5gen2_hid_device_msg_cmd(impl, req->data, req->len, error))
+	if (!fu_qc_s5gen2_hid_device_msg_cmd(impl, st_req->buf->data, st_req->buf->len, error))
 		return FALSE;
 	if (!fu_qc_s5gen2_hid_device_msg_in(impl, data_in, sizeof(data_in), &read_len, error))
 		return FALSE;

--- a/plugins/redfish/fu-redfish-smbios.c
+++ b/plugins/redfish/fu-redfish-smbios.c
@@ -252,8 +252,8 @@ fu_redfish_smbios_parse_over_ip(FuRedfishSmbios *self,
 		if (!fu_input_stream_read_safe(stream,
 					       (guint8 *)hostname,
 					       hostname_length,
-					       0x0,		 /* dst */
-					       offset + st->len, /* seek */
+					       0x0,		      /* dst */
+					       offset + st->buf->len, /* seek */
 					       hostname_length,
 					       error))
 			return FALSE;
@@ -369,7 +369,7 @@ fu_redfish_smbios_write(FuFirmware *firmware, GError **error)
 
 	/* protocol record */
 	fu_byte_array_append_uint8(buf, REDFISH_PROTOCOL_REDFISH_OVER_IP);
-	fu_byte_array_append_uint8(buf, st->len + hostname_sz);
+	fu_byte_array_append_uint8(buf, st->buf->len + hostname_sz);
 
 	if (self->hostname != NULL)
 		hostname_sz = strlen(self->hostname);
@@ -381,7 +381,7 @@ fu_redfish_smbios_write(FuFirmware *firmware, GError **error)
 	    st,
 	    FU_REDFISH_IP_ASSIGNMENT_TYPE_STATIC);
 	fu_struct_redfish_protocol_over_ip_set_service_hostname_len(st, hostname_sz);
-	g_byte_array_append(buf, st->data, st->len);
+	g_byte_array_append(buf, st->buf->data, st->buf->len);
 	if (hostname_sz > 0)
 		g_byte_array_append(buf, (guint8 *)self->hostname, hostname_sz);
 	return g_steal_pointer(&buf);

--- a/plugins/steelseries/fu-steelseries-fizz-gen1.c
+++ b/plugins/steelseries/fu-steelseries-fizz-gen1.c
@@ -46,7 +46,7 @@ fu_steelseries_fizz_gen1_get_version(FuSteelseriesFizzImpl *self, gboolean tunne
 
 	st_req = fu_struct_steelseries_fizz_version_req_new();
 	fu_struct_steelseries_fizz_version_req_set_cmd(st_req, cmd);
-	if (!fu_steelseries_fizz_gen1_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen1_request(self, st_req->buf, error))
 		return NULL;
 	buf_res = fu_steelseries_fizz_gen1_response(self, error);
 	if (buf_res == NULL)
@@ -83,7 +83,7 @@ fu_steelseries_fizz_gen1_get_paired_status(FuSteelseriesFizzImpl *self,
 	g_autoptr(FuStructSteelseriesPairedStatusRes) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_fizz_gen1_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen1_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen1_response(self, error);
 	if (buf_res == NULL)
@@ -106,7 +106,7 @@ fu_steelseries_fizz_gen1_get_connection_status(FuSteelseriesFizzImpl *self,
 	g_autoptr(FuStructSteelseriesConnectionStatusRes) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_fizz_gen1_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen1_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen1_response(self, error);
 	if (buf_res == NULL)
@@ -137,7 +137,7 @@ fu_steelseries_fizz_gen1_get_battery_level(FuSteelseriesFizzImpl *self,
 
 	st_req = fu_struct_steelseries_battery_level_req_new();
 	fu_struct_steelseries_battery_level_req_set_cmd(st_req, cmd);
-	if (!fu_steelseries_fizz_gen1_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen1_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen1_response(self, error);
 	if (buf_res == NULL)

--- a/plugins/steelseries/fu-steelseries-fizz-gen2.c
+++ b/plugins/steelseries/fu-steelseries-fizz-gen2.c
@@ -127,7 +127,7 @@ fu_steelseries_fizz_gen2_get_version(FuSteelseriesFizzImpl *self, gboolean tunne
 	    fu_struct_steelseries_fizz_version2_req_new();
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return NULL;
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
 	if (buf_res == NULL)
@@ -150,7 +150,7 @@ fu_steelseries_fizz_gen2_get_battery_level(FuSteelseriesFizzImpl *self,
 	g_autoptr(FuStructSteelseriesBatteryLevel2Res) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_fizz_gen2_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen2_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen2_response(self, error);
 	if (buf_res == NULL)
@@ -189,7 +189,7 @@ fu_steelseries_fizz_gen2_get_paired_status(FuSteelseriesFizzImpl *self,
 	g_autoptr(FuStructSteelseriesConnectionStatus2Res) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_fizz_gen2_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen2_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen2_response(self, error);
 	if (buf_res == NULL)
@@ -225,7 +225,7 @@ fu_steelseries_fizz_gen2_get_connection_status(FuSteelseriesFizzImpl *self,
 	g_autoptr(FuStructSteelseriesConnectionStatus2Res) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_fizz_gen2_request(self, st_req, error))
+	if (!fu_steelseries_fizz_gen2_request(self, st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_fizz_gen2_response(self, error);
 	if (buf_res == NULL)
@@ -304,7 +304,7 @@ fu_steelseries_fizz_gen2_get_serial(FuSteelseriesFizzImpl *self, gboolean tunnel
 	g_autoptr(FuStructSteelseriesSerial2Req) st_req = fu_struct_steelseries_serial2_req_new();
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return NULL;
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
 	if (buf_res == NULL)

--- a/plugins/steelseries/fu-steelseries-fizz-hid.c
+++ b/plugins/steelseries/fu-steelseries-fizz-hid.c
@@ -113,14 +113,14 @@ static gboolean
 fu_steelseries_fizz_hid_ensure_version(FuSteelseriesFizzHid *self, GError **error)
 {
 	g_autofree gchar *version = NULL;
-	g_autoptr(GByteArray) st_buf = NULL;
+	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(FuStructSteelseriesFizzHidGetVersionReq) st =
 	    fu_struct_steelseries_fizz_hid_get_version_req_new();
 
-	st_buf = fu_steelseries_fizz_hid_command(self, st, error);
-	if (st_buf == NULL)
+	buf = fu_steelseries_fizz_hid_command(self, st->buf, error);
+	if (buf == NULL)
 		return FALSE;
-	version = fu_strsafe((const gchar *)st_buf->data, st_buf->len);
+	version = fu_strsafe((const gchar *)buf->data, buf->len);
 	if (version == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -170,7 +170,7 @@ fu_steelseries_fizz_write_fs(FuSteelseriesFizz *self,
 			fu_chunk_get_data_sz(chk),
 			error))
 			return FALSE;
-		buf_res = fu_steelseries_fizz_request_response(self, st_req, error);
+		buf_res = fu_steelseries_fizz_request_response(self, st_req->buf, error);
 		if (buf_res == NULL)
 			return FALSE;
 		fu_progress_step_done(progress);
@@ -198,7 +198,7 @@ fu_steelseries_fizz_erase_fs(FuSteelseriesFizz *self,
 	fu_struct_steelseries_fizz_erase_file_req_set_cmd(st_req, cmd);
 	fu_struct_steelseries_fizz_erase_file_req_set_filesystem(st_req, fs);
 	fu_struct_steelseries_fizz_erase_file_req_set_id(st_req, id);
-	buf_res = fu_steelseries_fizz_request_response(self, st_req, error);
+	buf_res = fu_steelseries_fizz_request_response(self, st_req->buf, error);
 	return buf_res != NULL;
 }
 
@@ -217,7 +217,7 @@ fu_steelseries_fizz_reset(FuSteelseriesFizz *self,
 	st_req = fu_struct_steelseries_fizz_reset_req_new();
 	fu_struct_steelseries_fizz_reset_req_set_cmd(st_req, cmd);
 	fu_struct_steelseries_fizz_reset_req_set_mode(st_req, mode);
-	return fu_steelseries_fizz_request(self, st_req, error);
+	return fu_steelseries_fizz_request(self, st_req->buf, error);
 }
 
 gboolean
@@ -241,7 +241,7 @@ fu_steelseries_fizz_get_crc32_fs(FuSteelseriesFizz *self,
 	fu_struct_steelseries_fizz_file_crc32_req_set_cmd(st_req, cmd);
 	fu_struct_steelseries_fizz_file_crc32_req_set_filesystem(st_req, fs);
 	fu_struct_steelseries_fizz_file_crc32_req_set_id(st_req, id);
-	buf_res = fu_steelseries_fizz_request_response(self, st_req, error);
+	buf_res = fu_steelseries_fizz_request_response(self, st_req->buf, error);
 	if (buf_res == NULL)
 		return FALSE;
 	st_res = fu_struct_steelseries_fizz_file_crc32_res_parse(buf_res->data,
@@ -295,7 +295,7 @@ fu_steelseries_fizz_read_fs(FuSteelseriesFizz *self,
 		fu_struct_steelseries_fizz_read_access_file_req_set_offset(
 		    st_req,
 		    fu_chunk_get_address(chk));
-		buf_res = fu_steelseries_fizz_request_response(self, st_req, error);
+		buf_res = fu_steelseries_fizz_request_response(self, st_req->buf, error);
 		if (buf_res == NULL)
 			return FALSE;
 		st_res = fu_struct_steelseries_fizz_read_access_file_res_parse(buf_res->data,

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -42,7 +42,7 @@ fu_steelseries_sonic_wireless_status(FuSteelseriesSonic *self,
 	g_autoptr(FuStructSteelseriesSonicWirelessStatusRes) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
 	if (buf_res == NULL)
@@ -67,7 +67,7 @@ fu_steelseries_sonic_ensure_battery_state(FuSteelseriesSonic *self, GError **err
 	g_autoptr(FuStructSteelseriesSonicBatteryRes) st_res = NULL;
 	g_autoptr(GByteArray) buf_res = NULL;
 
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
 	if (buf_res == NULL)
@@ -101,7 +101,7 @@ fu_steelseries_sonic_read_from_ram_chunk(FuSteelseriesSonic *self,
 	    FU_STEELSERIES_SONIC_READ_FROM_RAM_OPCODE[chip]);
 	fu_struct_steelseries_sonic_read_from_ram_req_set_offset(st_req, fu_chunk_get_address(chk));
 	fu_struct_steelseries_sonic_read_from_ram_req_set_size(st_req, fu_chunk_get_data_sz(chk));
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	buf_res = fu_steelseries_device_response(FU_STEELSERIES_DEVICE(self), error);
@@ -170,7 +170,7 @@ fu_steelseries_sonic_read_from_flash_chunk(FuSteelseriesSonic *self,
 	fu_struct_steelseries_sonic_read_from_flash_req_set_offset(st_req,
 								   fu_chunk_get_address(chk));
 	fu_struct_steelseries_sonic_read_from_flash_req_set_size(st_req, fu_chunk_get_data_sz(chk));
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	/* timeout to give some time to read from flash to ram */
@@ -236,7 +236,7 @@ fu_steelseries_sonic_write_to_ram_chunk(FuSteelseriesSonic *self,
 								   fu_chunk_get_data_sz(chk),
 								   error))
 		return FALSE;
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	/* timeout to give some time to write to ram */
@@ -306,7 +306,7 @@ fu_steelseries_sonic_write_to_flash_chunk(FuSteelseriesSonic *self,
 	fu_struct_steelseries_sonic_write_to_flash_req_set_offset(st_req,
 								  fu_chunk_get_address(chk));
 	fu_struct_steelseries_sonic_write_to_flash_req_set_size(st_req, fu_chunk_get_data_sz(chk));
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	/* timeout to give some time to write from ram to flash */
@@ -367,7 +367,7 @@ fu_steelseries_sonic_erase(FuSteelseriesSonic *self,
 	fu_struct_steelseries_sonic_erase_req_set_opcode(st_req,
 							 FU_STEELSERIES_SONIC_ERASE_OPCODE[chip]);
 	fu_struct_steelseries_sonic_erase_req_set_chipid(st_req, FU_STEELSERIES_SONIC_CHIP[chip]);
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	/* timeout to give some time to erase flash */
@@ -394,7 +394,7 @@ fu_steelseries_sonic_restart(FuSteelseriesSonic *self,
 	fu_struct_steelseries_sonic_restart_req_set_opcode(
 	    st_req,
 	    FU_STEELSERIES_SONIC_RESTART_OPCODE[chip]);
-	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req, error))
+	if (!fu_steelseries_device_request(FU_STEELSERIES_DEVICE(self), st_req->buf, error))
 		return FALSE;
 
 	/* timeout to give some time to restart chip */

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -69,8 +69,8 @@ fu_synaptics_cape_device_get_report(FuSynapticsCapeDevice *self,
 {
 	return fu_hid_device_get_report(FU_HID_DEVICE(self),
 					FU_SYNAPTICS_CAPE_CMD_HID_REPORT_DEFAULT_REPORT_ID,
-					st_report->data,
-					st_report->len,
+					st_report->buf->data,
+					st_report->buf->len,
 					FU_SYNAPTICS_CAPE_DEVICE_USB_CMD_READ_TIMEOUT,
 					FU_HID_DEVICE_FLAG_NONE,
 					error);
@@ -187,7 +187,7 @@ fu_synaptics_cape_device_sendcmd_ex(FuSynapticsCapeDevice *self,
 			    (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
 			     g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INTERNAL))) {
 				g_debug("ignoring: %s", error_local->message);
-				return g_byte_array_ref(st_msg_req);
+				return fu_synaptics_cape_msg_ref(st_msg_req);
 			}
 			g_propagate_prefixed_error(error,
 						   g_steal_pointer(&error_local),
@@ -211,7 +211,7 @@ fu_synaptics_cape_device_sendcmd_ex(FuSynapticsCapeDevice *self,
 						     FWUPD_ERROR,
 						     FWUPD_ERROR_INTERNAL))) {
 					g_debug("ignoring: %s", error_local->message);
-					g_byte_array_ref(st_msg_req);
+					return fu_synaptics_cape_msg_ref(st_msg_req);
 				}
 				g_propagate_prefixed_error(error,
 							   g_steal_pointer(&error_local),

--- a/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-sngl-firmware.c
@@ -111,18 +111,18 @@ static GByteArray *
 fu_synaptics_cape_sngl_firmware_write(FuFirmware *firmware, GError **error)
 {
 	FuSynapticsCapeSnglFirmware *self = FU_SYNAPTICS_CAPE_SNGL_FIRMWARE(firmware);
-	g_autoptr(FuStructSynapticsCapeSnglHdr) buf = fu_struct_synaptics_cape_sngl_hdr_new();
+	g_autoptr(FuStructSynapticsCapeSnglHdr) st = fu_struct_synaptics_cape_sngl_hdr_new();
 
 	/* pack */
 	fu_struct_synaptics_cape_sngl_hdr_set_vid(
-	    buf,
+	    st,
 	    fu_synaptics_cape_firmware_get_vid(FU_SYNAPTICS_CAPE_FIRMWARE(self)));
 	fu_struct_synaptics_cape_sngl_hdr_set_pid(
-	    buf,
+	    st,
 	    fu_synaptics_cape_firmware_get_pid(FU_SYNAPTICS_CAPE_FIRMWARE(self)));
 
 	/* success */
-	return g_steal_pointer(&buf);
+	return g_steal_pointer(&st->buf);
 }
 
 static void

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -315,7 +315,7 @@ fu_synaptics_cxaudio_device_eeprom_read_string(FuSynapticsCxaudioDevice *self,
 	if (st == NULL)
 		return NULL;
 	header_length = fu_struct_synaptics_cxaudio_string_header_get_length(st);
-	if (header_length < st->len) {
+	if (header_length < st->buf->len) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -324,7 +324,7 @@ fu_synaptics_cxaudio_device_eeprom_read_string(FuSynapticsCxaudioDevice *self,
 	}
 
 	/* allocate buffer + NUL terminator */
-	str = g_malloc0(header_length - st->len + 1);
+	str = g_malloc0(header_length - st->buf->len + 1);
 	if (!fu_synaptics_cxaudio_device_operation(self,
 						   FU_SYNAPTICS_CXAUDIO_OPERATION_READ,
 						   FU_SYNAPTICS_CXAUDIO_MEM_KIND_EEPROM,
@@ -773,8 +773,8 @@ fu_synaptics_cxaudio_device_write_firmware(FuDevice *device,
 				FU_SYNAPTICS_CXAUDIO_OPERATION_WRITE,
 				FU_SYNAPTICS_CXAUDIO_MEM_KIND_EEPROM,
 				FU_SYNAPTICS_CXAUDIO_EEPROM_PATCH_INFO_OFFSET,
-				st_pat->data,
-				st_pat->len,
+				st_pat->buf->data,
+				st_pat->buf->len,
 				FU_SYNAPTICS_CXAUDIO_OPERATION_FLAG_NONE,
 				error)) {
 				g_prefix_error_literal(error,

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -47,12 +47,12 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	fu_struct_synaprom_cmd_iota_find_set_itype(st_cmd, FU_SYNAPROM_IOTA_ITYPE_CONFIG_VERSION);
 	fu_struct_synaprom_cmd_iota_find_set_flags(st_cmd, FU_SYNAPROM_CMD_IOTA_FIND_FLAGS_READMAX);
 	fu_struct_synaprom_request_set_cmd(st_request, FU_SYNAPROM_CMD_IOTA_FIND);
-	g_byte_array_append(st_request, st_cmd->data, st_cmd->len);
+	fu_byte_array_append_array(st_request->buf, st_cmd->buf);
 
 	reply = fu_synaprom_reply_new(FU_STRUCT_SYNAPROM_REPLY_IOTA_FIND_HDR_SIZE +
 				      FU_SYNAPROM_MAX_IOTA_READ_SIZE);
 	if (!fu_synaprom_device_cmd_send(FU_SYNAPROM_DEVICE(parent),
-					 st_request,
+					 st_request->buf,
 					 reply,
 					 progress,
 					 5000,
@@ -81,7 +81,7 @@ fu_synaprom_config_setup(FuDevice *device, GError **error)
 	}
 	st_cfg = fu_struct_synaprom_iota_config_version_parse(reply->data,
 							      reply->len,
-							      st_hdr->len,
+							      st_hdr->buf->len,
 							      error);
 	if (st_cfg == NULL)
 		return FALSE;

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -173,7 +173,7 @@ fu_synaprom_device_setup(FuDevice *device, GError **error)
 	/* get version */
 	fu_struct_synaprom_request_set_cmd(st_request, FU_SYNAPROM_CMD_GET_VERSION);
 	reply = fu_synaprom_reply_new(FU_STRUCT_SYNAPROM_REPLY_GET_VERSION_SIZE);
-	if (!fu_synaprom_device_cmd_send(self, st_request, reply, progress, 250, error)) {
+	if (!fu_synaprom_device_cmd_send(self, st_request->buf, reply, progress, 250, error)) {
 		g_prefix_error_literal(error, "failed to get version: ");
 		return FALSE;
 	}
@@ -290,10 +290,10 @@ fu_synaprom_device_write_chunks(FuSynapromDevice *self,
 
 		/* patch */
 		fu_struct_synaprom_request_set_cmd(st_request, FU_SYNAPROM_CMD_BOOTLDR_PATCH);
-		g_byte_array_append(st_request, chunk->data, chunk->len);
+		g_byte_array_append(st_request->buf, chunk->data, chunk->len);
 		reply = fu_synaprom_reply_new(FU_STRUCT_SYNAPROM_REPLY_GENERIC_SIZE);
 		if (!fu_synaprom_device_cmd_send(self,
-						 st_request,
+						 st_request->buf,
 						 reply,
 						 fu_progress_get_child(progress),
 						 20000,

--- a/plugins/synaptics-prometheus/fu-synaprom-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-firmware.c
@@ -110,7 +110,7 @@ fu_synaprom_firmware_parse(FuFirmware *firmware,
 				    tag);
 			return FALSE;
 		}
-		offset += st_hdr->len;
+		offset += st_hdr->buf->len;
 		partial_stream = fu_partial_input_stream_new(stream, offset, hdrsz, error);
 		if (partial_stream == NULL)
 			return FALSE;
@@ -156,10 +156,10 @@ fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 
 	/* add header */
 	fu_struct_synaprom_hdr_set_tag(st_hdr, FU_SYNAPROM_FIRMWARE_TAG_MFW_UPDATE_HEADER);
-	fu_struct_synaprom_hdr_set_bufsz(st_hdr, st_mfw->len);
-	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
+	fu_struct_synaprom_hdr_set_bufsz(st_hdr, st_mfw->buf->len);
+	g_byte_array_append(buf, st_hdr->buf->data, st_hdr->buf->len);
 	fu_struct_synaprom_mfw_hdr_set_product(st_mfw, self->product_id);
-	g_byte_array_append(buf, st_mfw->data, st_mfw->len);
+	fu_byte_array_append_array(buf, st_mfw->buf);
 
 	/* add payload */
 	payload = fu_firmware_get_bytes_with_patches(firmware, error);
@@ -167,7 +167,7 @@ fu_synaprom_firmware_write(FuFirmware *firmware, GError **error)
 		return NULL;
 	fu_struct_synaprom_hdr_set_tag(st_hdr, FU_SYNAPROM_FIRMWARE_TAG_MFW_UPDATE_PAYLOAD);
 	fu_struct_synaprom_hdr_set_bufsz(st_hdr, g_bytes_get_size(payload));
-	g_byte_array_append(buf, st_hdr->data, st_hdr->len);
+	g_byte_array_append(buf, st_hdr->buf->data, st_hdr->buf->len);
 	fu_byte_array_append_bytes(buf, payload);
 
 	/* add signature */

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -163,24 +163,28 @@ fu_synaptics_vmm9_device_command(FuSynapticsVmm9Device *self,
 	fu_struct_hid_set_command_set_size(st, FU_STRUCT_HID_PAYLOAD_OFFSET_FIFO + src_bufsz);
 	if (!fu_struct_hid_set_command_set_payload(st, st_payload, error))
 		return FALSE;
-	checksum = 0x100 - fu_sum8(st->data + 1, st->len - 1);
+	checksum = 0x100 - fu_sum8(st->buf->data + 1, st->buf->len - 1);
 	if (flags & FU_SYNAPTICS_VMM9_COMMAND_FLAG_FULL_BUFFER) {
 		fu_struct_hid_set_command_set_checksum(st, checksum);
 	} else {
 		goffset offset_checksum = FU_STRUCT_HID_SET_COMMAND_OFFSET_PAYLOAD +
 					  FU_STRUCT_HID_PAYLOAD_OFFSET_FIFO + src_bufsz;
-		if (!fu_memwrite_uint8_safe(st->data, st->len, offset_checksum, checksum, error))
+		if (!fu_memwrite_uint8_safe(st->buf->data,
+					    st->buf->len,
+					    offset_checksum,
+					    checksum,
+					    error))
 			return FALSE;
 	}
-	fu_byte_array_set_size(st, FU_SYNAPTICS_VMM9_DEVICE_REPORT_SIZE, 0x0);
+	fu_byte_array_set_size(st->buf, FU_SYNAPTICS_VMM9_DEVICE_REPORT_SIZE, 0x0);
 
 	/* set */
 	str = fu_struct_hid_set_command_to_string(st);
 	g_debug("%s", str);
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      FU_STRUCT_HID_SET_COMMAND_DEFAULT_ID,
-				      st->data,
-				      st->len,
+				      st->buf->data,
+				      st->buf->len,
 				      FU_SYNAPTICS_VMM9_DEVICE_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_NONE,
 				      error)) {

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -35,7 +35,7 @@ fu_telink_dfu_ble_device_create_packet(guint16 preamble,
 	}
 	fu_struct_telink_dfu_ble_pkt_set_crc(
 	    st_pkt,
-	    ~fu_crc16(FU_CRC_KIND_B16_USB, st_pkt->data, st_pkt->len - 2));
+	    ~fu_crc16(FU_CRC_KIND_B16_USB, st_pkt->buf->data, st_pkt->buf->len - 2));
 	return g_steal_pointer(&st_pkt);
 }
 
@@ -64,7 +64,7 @@ fu_telink_dfu_ble_device_write_blocks(FuTelinkDfuBleDevice *self,
 			return FALSE;
 		if (!fu_bluez_device_write(FU_BLUEZ_DEVICE(self),
 					   FU_TELINK_DFU_BLE_DEVICE_UUID_OTA,
-					   st_pkt,
+					   st_pkt->buf,
 					   error))
 			return FALSE;
 		fu_device_sleep(FU_DEVICE(self), 5);
@@ -89,7 +89,7 @@ fu_telink_dfu_ble_device_ota_start(FuTelinkDfuBleDevice *self, GError **error)
 		return FALSE;
 	if (!fu_bluez_device_write(FU_BLUEZ_DEVICE(self),
 				   FU_TELINK_DFU_BLE_DEVICE_UUID_OTA,
-				   st_pkt,
+				   st_pkt->buf,
 				   error))
 		return FALSE;
 
@@ -109,14 +109,14 @@ fu_telink_dfu_ble_device_ota_stop(FuTelinkDfuBleDevice *self, guint number_chunk
 	fu_struct_telink_dfu_end_check_set_pkt_index(st_end_check, pkt_index);
 	fu_struct_telink_dfu_end_check_set_inverted_pkt_index(st_end_check, ~pkt_index);
 	st_pkt = fu_telink_dfu_ble_device_create_packet(FU_TELINK_DFU_CMD_OTA_END,
-							st_end_check->data,
-							st_end_check->len,
+							st_end_check->buf->data,
+							st_end_check->buf->len,
 							error);
 	if (st_pkt == NULL)
 		return FALSE;
 	if (!fu_bluez_device_write(FU_BLUEZ_DEVICE(self),
 				   FU_TELINK_DFU_BLE_DEVICE_UUID_OTA,
-				   st_pkt,
+				   st_pkt->buf,
 				   error))
 		return FALSE;
 
@@ -149,7 +149,7 @@ fu_telink_dfu_ble_device_write_blob(FuTelinkDfuBleDevice *self,
 		return FALSE;
 	if (!fu_bluez_device_write(FU_BLUEZ_DEVICE(self),
 				   FU_TELINK_DFU_BLE_DEVICE_UUID_OTA,
-				   st_pkt,
+				   st_pkt->buf,
 				   error))
 		return FALSE;
 	fu_device_sleep(FU_DEVICE(self), 5);

--- a/plugins/tpm/fu-tpm-eventlog-parser.c
+++ b/plugins/tpm/fu-tpm-eventlog-parser.c
@@ -95,7 +95,7 @@ fu_tpm_eventlog_parser_parse_blob_v2(const guint8 *buf,
 		st = fu_struct_tpm_event_log2_parse(buf, bufsz, idx, error);
 		if (st == NULL)
 			return NULL;
-		idx += st->len;
+		idx += st->buf->len;
 		digestcnt = fu_struct_tpm_event_log2_get_digest_count(st);
 		for (guint i = 0; i < digestcnt; i++) {
 			guint16 alg_type = 0;

--- a/plugins/uefi-capsule/fu-acpi-uefi.c
+++ b/plugins/uefi-capsule/fu-acpi-uefi.c
@@ -58,7 +58,7 @@ fu_acpi_uefi_parse_insyde(FuAcpiUefi *self, GInputStream *stream, GError **error
 	st_qrk = fu_struct_acpi_insyde_quirk_parse_stream(stream, data_offset, error);
 	if (st_qrk == NULL)
 		return FALSE;
-	if (fu_struct_acpi_insyde_quirk_get_size(st_qrk) < st_qrk->len) {
+	if (fu_struct_acpi_insyde_quirk_get_size(st_qrk) < st_qrk->buf->len) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_READ,

--- a/plugins/uefi-capsule/fu-bitmap-image.c
+++ b/plugins/uefi-capsule/fu-bitmap-image.c
@@ -41,7 +41,7 @@ fu_bitmap_image_parse(FuFirmware *firmware,
 		return FALSE;
 	}
 	fu_firmware_set_size(firmware, fu_struct_bitmap_file_header_get_size(st_file));
-	st_info = fu_struct_bitmap_info_header_parse_stream(stream, st_file->len, error);
+	st_info = fu_struct_bitmap_info_header_parse_stream(stream, st_file->buf->len, error);
 	if (st_info == NULL) {
 		g_prefix_error_literal(error, "header is corrupt: ");
 		return FALSE;

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -312,7 +312,7 @@ fu_uefi_capsule_device_clear_status(FuUefiCapsuleDevice *self, GError **error)
 
 	/* just copy the new EfiUpdateInfo and save it back */
 	fu_struct_efi_update_info_set_status(st_inf, FU_UEFI_UPDATE_INFO_STATUS_UNKNOWN);
-	memcpy(data, st_inf->data, st_inf->len); /* nocheck:blocked */
+	memcpy(data, st_inf->buf->data, st_inf->buf->len); /* nocheck:blocked */
 	if (!fu_efivars_set_data(efivars,
 				 FU_EFIVARS_GUID_FWUPDATE,
 				 varname,
@@ -407,8 +407,8 @@ fu_uefi_capsule_device_fixup_firmware(FuUefiCapsuleDevice *self, GBytes *fw, GEr
 	fu_struct_efi_capsule_header_set_guid(st_cap, &esrt_guid);
 
 	/* pad to the headersize then add the payload */
-	fu_byte_array_set_size(st_cap, hdrsize, 0x00);
-	g_byte_array_append(st_cap, buf, bufsz);
+	fu_byte_array_set_size(st_cap->buf, hdrsize, 0x00);
+	g_byte_array_append(st_cap->buf, buf, bufsz);
 	return fu_struct_efi_capsule_header_to_bytes(st_cap);
 }
 
@@ -442,12 +442,12 @@ fu_uefi_capsule_device_write_update_info(FuUefiCapsuleDevice *self,
 	fu_struct_efi_update_info_set_hw_inst(st_inf, priv->fmp_hardware_instance);
 	fu_struct_efi_update_info_set_status(st_inf, FU_UEFI_UPDATE_INFO_STATUS_ATTEMPT_UPDATE);
 	fu_struct_efi_update_info_set_guid(st_inf, &guid);
-	fu_byte_array_append_bytes(st_inf, dp_blob);
+	fu_byte_array_append_bytes(st_inf->buf, dp_blob);
 	if (!fu_efivars_set_data(efivars,
 				 FU_EFIVARS_GUID_FWUPDATE,
 				 varname,
-				 st_inf->data,
-				 st_inf->len,
+				 st_inf->buf->data,
+				 st_inf->buf->len,
 				 FU_EFIVARS_ATTR_NON_VOLATILE | FU_EFIVARS_ATTR_BOOTSERVICE_ACCESS |
 				     FU_EFIVARS_ATTR_RUNTIME_ACCESS,
 				 error)) {

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -448,16 +448,16 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	};
 
 	/* header, payload and image has to add to zero */
-	csum += fu_sum8(st_cap->data, st_cap->len);
-	csum += fu_sum8(st_uxh->data, st_uxh->len);
+	csum += fu_sum8(st_cap->buf->data, st_cap->buf->len);
+	csum += fu_sum8(st_uxh->buf->data, st_uxh->buf->len);
 	csum += fu_sum8_bytes(blob);
 	fu_struct_efi_ux_capsule_header_set_checksum(st_uxh, 0x100 - csum);
 
 	/* write capsule file */
-	size = g_output_stream_write(ostream, st_cap->data, st_cap->len, NULL, error);
+	size = g_output_stream_write(ostream, st_cap->buf->data, st_cap->buf->len, NULL, error);
 	if (size < 0)
 		return FALSE;
-	size = g_output_stream_write(ostream, st_uxh->data, st_uxh->len, NULL, error);
+	size = g_output_stream_write(ostream, st_uxh->buf->data, st_uxh->buf->len, NULL, error);
 	if (size < 0)
 		return FALSE;
 	if (!fu_output_stream_write_bytes(ostream, blob, NULL, error))

--- a/plugins/uefi-capsule/fu-uefi-update-info.c
+++ b/plugins/uefi-capsule/fu-uefi-update-info.c
@@ -135,11 +135,11 @@ fu_uefi_update_info_write(FuFirmware *firmware, GError **error)
 		dpbuf = fu_firmware_write(FU_FIRMWARE(dp_list), error);
 		if (dpbuf == NULL)
 			return NULL;
-		fu_byte_array_append_bytes(st, dpbuf);
+		fu_byte_array_append_bytes(st->buf, dpbuf);
 	}
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static gboolean

--- a/plugins/uf2/fu-uf2-firmware.c
+++ b/plugins/uf2/fu-uf2-firmware.c
@@ -50,8 +50,8 @@ fu_uf2_firmware_parse_extensions(FuUf2Firmware *self,
 			g_autofree gchar *str = NULL;
 			str = fu_memstrsafe(buf,
 					    bufsz,
-					    offset + st_ext->len,
-					    sz - st_ext->len,
+					    offset + st_ext->buf->len,
+					    sz - st_ext->buf->len,
 					    error);
 			if (str == NULL)
 				return FALSE;
@@ -60,8 +60,8 @@ fu_uf2_firmware_parse_extensions(FuUf2Firmware *self,
 			g_autofree gchar *str = NULL;
 			str = fu_memstrsafe(buf,
 					    bufsz,
-					    offset + st_ext->len,
-					    sz - st_ext->len,
+					    offset + st_ext->buf->len,
+					    sz - st_ext->buf->len,
 					    error);
 			if (str == NULL)
 				return FALSE;
@@ -89,7 +89,7 @@ fu_uf2_firmware_parse_chunk(FuUf2Firmware *self, FuChunk *chk, GByteArray *tmp, 
 	const guint8 *buf = fu_chunk_get_data(chk);
 	guint32 flags = 0;
 	guint32 datasz = 0;
-	g_autoptr(GByteArray) st = NULL;
+	g_autoptr(FuStructUf2) st = NULL;
 
 	/* parse */
 	st = fu_struct_uf2_parse(fu_chunk_get_data(chk),
@@ -212,9 +212,9 @@ fu_uf2_firmware_build_utf8_extension(FuUf2FirmwareTag tag, const gchar *str)
 {
 	g_autoptr(FuStructUf2Extension) st = fu_struct_uf2_extension_new();
 	fu_struct_uf2_extension_set_tag(st, tag);
-	fu_struct_uf2_extension_set_size(st, st->len + strlen(str));
-	g_byte_array_append(st, (const guint8 *)str, strlen(str));
-	fu_byte_array_align_up(st, FU_FIRMWARE_ALIGNMENT_4, 0x0);
+	fu_struct_uf2_extension_set_size(st, st->buf->len + strlen(str));
+	g_byte_array_append(st->buf, (const guint8 *)str, strlen(str));
+	fu_byte_array_align_up(st->buf, FU_FIRMWARE_ALIGNMENT_4, 0x0);
 	return g_steal_pointer(&st);
 }
 
@@ -268,20 +268,20 @@ fu_uf2_firmware_write_chunk(FuUf2Firmware *self, FuChunk *chk, guint chk_len, GE
 	/* copy in any extensions */
 	for (guint i = 0; i < extensions->len; i++) {
 		FuStructUf2Extension *st_ext = g_ptr_array_index(extensions, i);
-		if (!fu_memcpy_safe(st->data,
-				    st->len,
+		if (!fu_memcpy_safe(st->buf->data,
+				    st->buf->len,
 				    offset_ext,
-				    st_ext->data,
-				    st_ext->len,
+				    st_ext->buf->data,
+				    st_ext->buf->len,
 				    0x0,
-				    st_ext->len,
+				    st_ext->buf->len,
 				    error))
 			return NULL;
-		offset_ext += st_ext->len;
+		offset_ext += st_ext->buf->len;
 	}
 
 	/* success */
-	return g_steal_pointer(&st);
+	return g_steal_pointer(&st->buf);
 }
 
 static GByteArray *

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -49,14 +49,14 @@ fu_usi_dock_mcu_device_tx(FuUsiDockMcuDevice *self,
 	}
 
 	/* special cases */
-	if (st->data[FU_STRUCT_USI_DOCK_MCU_CMD_REQ_OFFSET_BUF + 0] ==
+	if (st->buf->data[FU_STRUCT_USI_DOCK_MCU_CMD_REQ_OFFSET_BUF + 0] ==
 	    FU_USI_DOCK_MCU_CMD_FW_UPDATE)
-		st->data[FU_STRUCT_USI_DOCK_MCU_CMD_REQ_OFFSET_BUF + 1] = 0xFF;
+		st->buf->data[FU_STRUCT_USI_DOCK_MCU_CMD_REQ_OFFSET_BUF + 1] = 0xFF;
 
 	return fu_hid_device_set_report(FU_HID_DEVICE(self),
 					USB_HID_REPORT_ID2,
-					st->data,
-					st->len,
+					st->buf->data,
+					st->buf->len,
 					FU_USI_DOCK_MCU_DEVICE_TIMEOUT,
 					FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
 					error);
@@ -402,8 +402,8 @@ fu_usi_dock_mcu_device_write_chunk(FuUsiDockMcuDevice *self, FuChunk *chk, GErro
 
 	fu_struct_usi_dock_hid_req_set_length(st_req, fu_chunk_get_data_sz(chk));
 	fu_struct_usi_dock_hid_req_set_tag3(st_req, FU_USI_DOCK_TAG2_MASS_DATA_SPI);
-	if (!fu_memcpy_safe(st_req->data,
-			    st_req->len,
+	if (!fu_memcpy_safe(st_req->buf->data,
+			    st_req->buf->len,
 			    FU_STRUCT_USI_DOCK_HID_REQ_OFFSET_BUF, /* dst */
 			    fu_chunk_get_data(chk),
 			    fu_chunk_get_data_sz(chk),
@@ -413,8 +413,8 @@ fu_usi_dock_mcu_device_write_chunk(FuUsiDockMcuDevice *self, FuChunk *chk, GErro
 		return FALSE;
 	if (!fu_hid_device_set_report(FU_HID_DEVICE(self),
 				      USB_HID_REPORT_ID2,
-				      st_req->data,
-				      st_req->len,
+				      st_req->buf->data,
+				      st_req->buf->len,
 				      FU_USI_DOCK_MCU_DEVICE_TIMEOUT,
 				      FU_HID_DEVICE_FLAG_USE_INTERRUPT_TRANSFER,
 				      error))

--- a/plugins/wacom-raw/fu-wacom-raw-aes-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-aes-device.c
@@ -28,21 +28,23 @@ fu_wacom_raw_aes_device_add_recovery_hwid(FuWacomRawAesDevice *self, GError **er
 	fu_struct_wacom_raw_request_set_addr(st_req, FU_WACOM_RAW_BL_START_ADDR);
 	fu_struct_wacom_raw_request_set_size8(st_req, FU_WACOM_RAW_BL_BYTES_CHECK / 8);
 	if (!fu_wacom_raw_device_set_feature(FU_WACOM_RAW_DEVICE(self),
-					     st_req->data,
-					     st_req->len,
+					     st_req->buf->data,
+					     st_req->buf->len,
 					     error)) {
 		g_prefix_error_literal(error, "failed to send: ");
 		return FALSE;
 	}
 	if (!fu_wacom_raw_device_get_feature(FU_WACOM_RAW_DEVICE(self),
-					     st_req->data,
-					     st_req->len,
+					     st_req->buf->data,
+					     st_req->buf->len,
 					     error)) {
 		g_prefix_error_literal(error, "failed to receive: ");
 		return FALSE;
 	}
-	st_rsp =
-	    fu_struct_wacom_raw_bl_verify_response_parse(st_req->data, st_req->len, 0x0, error);
+	st_rsp = fu_struct_wacom_raw_bl_verify_response_parse(st_req->buf->data,
+							      st_req->buf->len,
+							      0x0,
+							      error);
 	if (st_rsp == NULL)
 		return FALSE;
 	if (fu_struct_wacom_raw_bl_verify_response_get_size8(st_rsp) !=
@@ -82,12 +84,14 @@ fu_wacom_raw_aes_device_query_operation_mode(FuWacomRawAesDevice *self,
 	g_autoptr(FuStructWacomRawFwQueryModeResponse) st_rsp = NULL;
 
 	if (!fu_wacom_raw_device_get_feature(FU_WACOM_RAW_DEVICE(self),
-					     st_req->data,
-					     st_req->len,
+					     st_req->buf->data,
+					     st_req->buf->len,
 					     error))
 		return FALSE;
-	st_rsp =
-	    fu_struct_wacom_raw_fw_query_mode_response_parse(st_req->data, st_req->len, 0x0, error);
+	st_rsp = fu_struct_wacom_raw_fw_query_mode_response_parse(st_req->buf->data,
+								  st_req->buf->len,
+								  0x0,
+								  error);
 	if (st_rsp == NULL)
 		return FALSE;
 	if (mode != NULL)
@@ -119,12 +123,12 @@ fu_wacom_raw_aes_device_setup(FuDevice *device, GError **error)
 
 		/* get firmware version */
 		if (!fu_wacom_raw_device_get_feature(FU_WACOM_RAW_DEVICE(self),
-						     st_req->data,
-						     st_req->len,
+						     st_req->buf->data,
+						     st_req->buf->len,
 						     error))
 			return FALSE;
-		st_rsp = fu_struct_wacom_raw_fw_status_response_parse(st_req->data,
-								      st_req->len,
+		st_rsp = fu_struct_wacom_raw_fw_status_response_parse(st_req->buf->data,
+								      st_req->buf->len,
 								      0x0,
 								      error);
 		if (st_rsp == NULL)
@@ -160,7 +164,7 @@ fu_wacom_raw_aes_device_attach(FuDevice *device, FuProgress *progress, GError **
 
 	fu_struct_wacom_raw_request_set_report_id(st_req, FU_WACOM_RAW_BL_REPORT_ID_TYPE);
 	fu_struct_wacom_raw_request_set_cmd(st_req, FU_WACOM_RAW_BL_TYPE_FINALIZER);
-	if (!fu_wacom_raw_device_set_feature(self, st_req->data, st_req->len, error)) {
+	if (!fu_wacom_raw_device_set_feature(self, st_req->buf->data, st_req->buf->len, error)) {
 		g_prefix_error_literal(error, "failed to finalize the device: ");
 		return FALSE;
 	}

--- a/plugins/wacom-raw/fu-wacom-raw-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-device.c
@@ -104,7 +104,7 @@ fu_wacom_raw_device_detach(FuDevice *device, FuProgress *progress, GError **erro
 		g_debug("already in bootloader mode, skipping");
 		return TRUE;
 	}
-	if (!fu_wacom_raw_device_set_feature(self, st->data, st->len, &error_local)) {
+	if (!fu_wacom_raw_device_set_feature(self, st->buf->data, st->buf->len, &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INTERNAL)) {
 			g_debug("ignoring: %s", error_local->message);
 		} else {
@@ -252,7 +252,7 @@ fu_wacom_raw_device_cmd_response(FuWacomRawDevice *self,
 				 GError **error)
 {
 	guint8 buf[FU_STRUCT_WACOM_RAW_RESPONSE_SIZE] = {FU_WACOM_RAW_BL_REPORT_ID_GET, 0x0};
-	g_autoptr(FuStructWacomRawRequest) st_rsp = NULL;
+	g_autoptr(FuStructWacomRawResponse) st_rsp = NULL;
 
 	if (!fu_wacom_raw_device_get_feature(self, buf, sizeof(buf), error)) {
 		g_prefix_error_literal(error, "failed to receive: ");
@@ -302,7 +302,7 @@ fu_wacom_raw_device_cmd(FuWacomRawDevice *self,
 			FuWacomRawDeviceCmdFlags flags,
 			GError **error)
 {
-	if (!fu_wacom_raw_device_set_feature(self, st_req->data, st_req->len, error)) {
+	if (!fu_wacom_raw_device_set_feature(self, st_req->buf->data, st_req->buf->len, error)) {
 		g_prefix_error_literal(error, "failed to send: ");
 		return FALSE;
 	}

--- a/plugins/wacom-raw/fu-wacom-raw-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-emr-device.c
@@ -62,7 +62,7 @@ static gboolean
 fu_wacom_raw_emr_device_w9013_erase_data(FuWacomRawEmrDevice *self, GError **error)
 {
 	g_autoptr(FuStructWacomRawRequest) st_req = fu_struct_wacom_raw_request_new();
-	guint8 *buf = st_req->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_ADDR;
+	guint8 *buf = st_req->buf->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_ADDR;
 
 	fu_struct_wacom_raw_request_set_report_id(st_req, FU_WACOM_RAW_BL_REPORT_ID_SET);
 	fu_struct_wacom_raw_request_set_cmd(st_req, FU_WACOM_RAW_BL_CMD_ERASE_DATAMEM);
@@ -93,7 +93,7 @@ fu_wacom_raw_emr_device_w9013_erase_code(FuWacomRawEmrDevice *self,
 					 GError **error)
 {
 	g_autoptr(FuStructWacomRawRequest) st_req = fu_struct_wacom_raw_request_new();
-	guint8 *buf = st_req->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_ADDR;
+	guint8 *buf = st_req->buf->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_ADDR;
 
 	fu_struct_wacom_raw_request_set_report_id(st_req, FU_WACOM_RAW_BL_REPORT_ID_SET);
 	fu_struct_wacom_raw_request_set_cmd(st_req, FU_WACOM_RAW_BL_CMD_ERASE_FLASH);
@@ -152,7 +152,7 @@ fu_wacom_raw_emr_device_attach(FuDevice *device, FuProgress *progress, GError **
 	fu_struct_wacom_raw_request_set_echo(
 	    st_req,
 	    fu_wacom_raw_device_get_echo_next(FU_WACOM_RAW_DEVICE(self)));
-	if (!fu_wacom_raw_device_set_feature(self, st_req->data, st_req->len, error)) {
+	if (!fu_wacom_raw_device_set_feature(self, st_req->buf->data, st_req->buf->len, error)) {
 		g_prefix_error_literal(error, "failed to switch to runtime mode: ");
 		return FALSE;
 	}
@@ -178,7 +178,7 @@ fu_wacom_raw_emr_device_write_block(FuWacomRawEmrDevice *self,
 {
 	gsize blocksz = fu_wacom_raw_device_get_block_sz(FU_WACOM_RAW_DEVICE(self));
 	g_autoptr(FuStructWacomRawRequest) st_req = fu_struct_wacom_raw_request_new();
-	guint8 *data_unused = st_req->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_DATA_UNUSED;
+	guint8 *data_unused = st_req->buf->data + FU_STRUCT_WACOM_RAW_REQUEST_OFFSET_DATA_UNUSED;
 
 	/* check size */
 	if (datasz > FU_STRUCT_WACOM_RAW_REQUEST_SIZE_DATA) {
@@ -210,7 +210,7 @@ fu_wacom_raw_emr_device_write_block(FuWacomRawEmrDevice *self,
 
 	/* cmd and data checksums */
 	data_unused[0] =
-	    fu_wacom_raw_emr_device_calc_checksum(0x05 + 0x00 + 0x4c + 0x00, st_req->data, 8);
+	    fu_wacom_raw_emr_device_calc_checksum(0x05 + 0x00 + 0x4c + 0x00, st_req->buf->data, 8);
 	data_unused[1] = fu_wacom_raw_emr_device_calc_checksum(0x00, data, datasz);
 	if (!fu_wacom_raw_device_cmd(FU_WACOM_RAW_DEVICE(self),
 				     st_req,

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -60,31 +60,31 @@ fu_wac_module_bluetooth_id9_get_startcmd(GInputStream *stream, gboolean full_era
 	guint8 command = full_erase ? FU_WAC_MODULE_BLUETOOTH_ID9_CMD_FULLERASE
 				    : FU_WAC_MODULE_BLUETOOTH_ID9_CMD_NORMAL;
 	guint32 crc = ~0;
-	g_autoptr(FuStructId9LoaderCmd) loader_cmd = fu_struct_id9_loader_cmd_new();
-	g_autoptr(FuStructId9SpiCmd) spi_cmd = fu_struct_id9_spi_cmd_new();
-	g_autoptr(FuStructId9UnknownCmd) unknown_cmd = fu_struct_id9_unknown_cmd_new();
+	g_autoptr(FuStructId9LoaderCmd) st_loader = fu_struct_id9_loader_cmd_new();
+	g_autoptr(FuStructId9SpiCmd) st_spi = fu_struct_id9_spi_cmd_new();
+	g_autoptr(FuStructId9UnknownCmd) st_unknown = fu_struct_id9_unknown_cmd_new();
 	g_autoptr(GBytes) blob = NULL;
 
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return NULL;
-	fu_struct_id9_unknown_cmd_set_size(unknown_cmd, streamsz);
+	fu_struct_id9_unknown_cmd_set_size(st_unknown, streamsz);
 
-	fu_struct_id9_spi_cmd_set_size(spi_cmd, streamsz + FU_STRUCT_ID9_UNKNOWN_CMD_SIZE);
-	if (!fu_struct_id9_spi_cmd_set_data(spi_cmd, unknown_cmd, error))
+	fu_struct_id9_spi_cmd_set_size(st_spi, streamsz + FU_STRUCT_ID9_UNKNOWN_CMD_SIZE);
+	if (!fu_struct_id9_spi_cmd_set_data(st_spi, st_unknown, error))
 		return NULL;
 
-	fu_struct_id9_loader_cmd_set_command(loader_cmd, command);
-	fu_struct_id9_loader_cmd_set_size(loader_cmd, streamsz + FU_STRUCT_ID9_SPI_CMD_SIZE);
-	if (!fu_wac_module_bluetooth_id9_calculate_crc32(spi_cmd, stream, &crc, error))
+	fu_struct_id9_loader_cmd_set_command(st_loader, command);
+	fu_struct_id9_loader_cmd_set_size(st_loader, streamsz + FU_STRUCT_ID9_SPI_CMD_SIZE);
+	if (!fu_wac_module_bluetooth_id9_calculate_crc32(st_spi->buf, stream, &crc, error))
 		return NULL;
-	fu_struct_id9_loader_cmd_set_crc(loader_cmd, crc);
-	if (!fu_struct_id9_loader_cmd_set_data(loader_cmd, spi_cmd, error))
-		return NULL;
-
-	if (!fu_struct_id9_loader_cmd_validate(loader_cmd->data, loader_cmd->len, 0, error))
+	fu_struct_id9_loader_cmd_set_crc(st_loader, crc);
+	if (!fu_struct_id9_loader_cmd_set_data(st_loader, st_spi, error))
 		return NULL;
 
-	blob = fu_struct_id9_loader_cmd_to_bytes(loader_cmd);
+	if (!fu_struct_id9_loader_cmd_validate(st_loader->buf->data, st_loader->buf->len, 0, error))
+		return NULL;
+
+	blob = fu_struct_id9_loader_cmd_to_bytes(st_loader);
 	return fu_chunk_bytes_new(blob);
 }
 

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -570,7 +570,7 @@ fu_wistron_dock_device_parse_wdit_img(FuWistronDockDevice *self,
 			(guint)status & 0x0F,
 			(guint)(status & 0xF0) >> 4);
 
-		offset += st->len;
+		offset += st->buf->len;
 	}
 
 	/* success */
@@ -658,7 +658,7 @@ fu_wistron_dock_device_ensure_wdit(FuWistronDockDevice *self, GError **error)
 		self,
 		buf,
 		sizeof(buf),
-		st->len + 0x1,
+		st->buf->len + 0x1,
 		MIN(fu_struct_wistron_dock_wdit_get_device_cnt(st), 32),
 		error)) {
 		g_prefix_error_literal(error, "failed to parse imgs: ");


### PR DESCRIPTION
This allows us to typecheck the structure -- as in C typedefs to the same base type can be compared freely without any kind of warning.

This means putting the GByteArray as a pointer inside the defined struct type; we can't put in the deref struct as the public type is upcast to _GRealArray inside Glib so that the internal implementation details are hidden. This means we have to dereference the GByteArray as `->buf` which is a little clunky, but then also frees us to put other stuff (e.g. a GType) inside the defined rustgen structure in the future.

Also, to make clear that the rustgen types are not GByteArrays anymore, enforce that any rustgen types start with a `st` prefix. At least now, the compiler is on our side.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
