### PR TITLE
trivial: make meson detect rustgen changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -839,6 +839,21 @@ endif
 rustgen = generator(
   python3,
   output: ['@BASENAME@-struct.c', '@BASENAME@-struct.h'],
+  # fake custom target to ensure the generator reruns if these input files change
+  depends: custom_target(
+    'rustgen-files-timestamp',
+    input: files(
+      'libfwupdplugin/fu-rustgen-enum.c.in',
+      'libfwupdplugin/fu-rustgen-enum.h.in',
+      'libfwupdplugin/fu-rustgen-struct.c.in',
+      'libfwupdplugin/fu-rustgen-struct.h.in',
+      'libfwupdplugin/fu-rustgen.c.in',
+      'libfwupdplugin/fu-rustgen.h.in',
+      'libfwupdplugin/rustgen.py',
+    ),
+    output: 'rustgen-files-timestamp',
+    command: [python3, '-c', 'from pathlib import Path\nPath("@OUTPUT@").touch()'],
+  ),
   arguments: [
     join_paths(meson.project_source_root(), 'libfwupdplugin', 'rustgen.py'),
     '@INPUT@',


### PR DESCRIPTION
Add an intermediary custom target that the rustgen generator can depend on and that itself depends on rustgen.py and the template files as inputs. This makes meson rerun the generators if any of the input files for the custom target are changed.

The command itself is just `touch @OUTPUT@` but in python since `ninja` like `make` uses the timestamp of input vs. output files.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
