### PR TITLE
Revert "flashrom: Do not use deprecated API"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -669,12 +669,6 @@ if build_standalone
   )
     conf.set('HAVE_FLASHROM_SET_PROGRESS_CALLBACK_V2' , '1')
   endif
-  if libflashrom.type_name() == 'pkgconfig' and cc.has_function(
-    'flashrom_flash_probe_v2',
-    dependencies: libflashrom,
-  )
-    conf.set('HAVE_FLASHROM_FLASH_PROBE_V2' , '1')
-  endif
 endif
 
 if libsystemd.found()

--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -291,76 +291,12 @@ fu_flashrom_plugin_find_guid(FuPlugin *plugin, GError **error)
 	return NULL;
 }
 
-typedef char *flashrom_data;
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(flashrom_data, flashrom_data_free)
-
-static gboolean
-fu_flashrom_plugin_probe(FuFlashromPlugin *self, GError **error)
-{
-	gint rc;
-#ifdef HAVE_FLASHROM_FLASH_PROBE_V2
-	g_autoptr(flashrom_data) all_matched_names = NULL;
-
-	rc = flashrom_flash_probe_v2(self->flashctx,
-				     (const char ***const)&all_matched_names,
-				     self->flashprog,
-				     NULL);
-	if (rc == -1) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "flash probe failed: unknown error");
-		return FALSE;
-	}
-	if (rc == 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "flash probe failed: no chips matched");
-		return FALSE;
-	}
-	if (rc > 1) {
-		g_autofree gchar *names = g_strjoinv(",", all_matched_names);
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "flash probe failed: multiple chips were found: %s",
-			    names);
-		return FALSE;
-	}
-#else
-	rc = flashrom_flash_probe(&self->flashctx, self->flashprog, NULL);
-	if (rc == 3) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "flash probe failed: multiple chips were found");
-		return FALSE;
-	}
-	if (rc == 2) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "flash probe failed: no chip was found");
-		return FALSE;
-	}
-	if (rc != 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "flash probe failed: unknown error");
-		return FALSE;
-	}
-#endif
-	/* success */
-	return TRUE;
-}
-
 static gboolean
 fu_flashrom_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error)
 {
 	const gchar *flashrom_args;
 	const gchar *flashrom_prog;
+	gint rc;
 	const gchar *guid;
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuFlashromPlugin *self = FU_FLASHROM_PLUGIN(plugin);
@@ -405,8 +341,29 @@ fu_flashrom_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **erro
 				    "programmer initialization failed");
 		return FALSE;
 	}
-	if (!fu_flashrom_plugin_probe(self, error))
+
+	rc = flashrom_flash_probe(&self->flashctx, self->flashprog, NULL);
+	if (rc == 3) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "flash probe failed: multiple chips were found");
 		return FALSE;
+	}
+	if (rc == 2) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "flash probe failed: no chip was found");
+		return FALSE;
+	}
+	if (rc != 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "flash probe failed: unknown error");
+		return FALSE;
+	}
 	fu_progress_step_done(progress);
 
 	return TRUE;


### PR DESCRIPTION
This reverts commit 0731ac4730520b68adca26e8b06a26cc88b32ccb.

We can't use `flashrom_flash_probe_v2` as an external user of libflashrom as it expects to be allocated on the stack -- but according to the compiler, the `storage size of ‘structflashrom_flashctx’ isn't known` and there is no API interface to allocate a flashctx on the heap. The old `flashrom_flash_probe` method returned us a pointer to the allocated flashctx and didn't have this problem.

The new API is badly designed and unusable, so use the old deprecated method.

Fixes https://github.com/fwupd/fwupd/issues/9379

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
