### PR TITLE
plugins/nvme: Set commit-ca3 for Lexar SSDs

### DIFF
--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -52,7 +52,7 @@ Flags = needs-shutdown
 
 # Lexar
 [NVME\VEN_1D97]
-Flags = ensure-semver
+Flags = ensure-semver,commit-ca3
 
 [NVME\VEN_144D&DEV_A80A&VER_2B2QGXA7]
 Issue = https://www.pugetsystems.com/support/guides/critical-samsung-ssd-firmware-update/


### PR DESCRIPTION
Lexar have request this is set, to replicate their proprietry tools and their usage of `nvme fw-download`.

