### PR TITLE
Add support for client-side phased deployment

### DIFF
--- a/docs/fwupd-remotes.d.md
+++ b/docs/fwupd-remotes.d.md
@@ -85,6 +85,16 @@ The `[fwupd Remote]` section can contain the following parameters:
 
   If `true`, automatically sent HSI platform security reports when running `fwupdmgr security`.
 
+**NoPhasedUpdates=false**
+
+  If `true`, disregard the requirement check for random client phased deployment.
+
+  A systems eligibility to a phased update is determined by seeding random number generator
+  with /etc/machine-id, the archive filename, and the remote cache mtime. If the seed divides
+  by the metadata-provided `phased_update` value with no remainder then the release is considered.
+  This also implies that the seed will be different on a different machine, for a different update
+  or if the metadata is refreshed.
+
 **OrderBefore=**
 
   This remote will be ordered before any remotes listed here, using commas as the delimiter.

--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -31,6 +31,8 @@ void
 fwupd_remote_set_filename_cache(FwupdRemote *self, const gchar *filename) G_GNUC_NON_NULL(1);
 void
 fwupd_remote_set_metadata_uri(FwupdRemote *self, const gchar *metadata_uri) G_GNUC_NON_NULL(1);
+guint64
+fwupd_remote_get_mtime(FwupdRemote *self) G_GNUC_NON_NULL(1);
 void
 fwupd_remote_set_mtime(FwupdRemote *self, guint64 mtime) G_GNUC_NON_NULL(1);
 gboolean

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -108,6 +108,8 @@ fwupd_remote_flag_to_string(FwupdRemoteFlags flag)
 		return "allow-p2p-metadata";
 	if (flag == FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE)
 		return "allow-p2p-firmware";
+	if (flag == FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES)
+		return "no-phased-updates";
 	return NULL;
 }
 
@@ -136,6 +138,8 @@ fwupd_remote_flag_from_string(const gchar *flag)
 		return FWUPD_REMOTE_FLAG_ALLOW_P2P_METADATA;
 	if (g_strcmp0(flag, "allow-p2p-firmware") == 0)
 		return FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE;
+	if (g_strcmp0(flag, "no-phased-updates") == 0)
+		return FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES;
 	return FWUPD_REMOTE_FLAG_NONE;
 }
 
@@ -1048,6 +1052,24 @@ fwupd_remote_set_priority(FwupdRemote *self, gint priority)
 	FwupdRemotePrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FWUPD_IS_REMOTE(self));
 	priv->priority = priority;
+}
+
+/**
+ * fwupd_remote_get_mtime:
+ * @self: a #FwupdRemote
+ *
+ * Gets the remote mtime in seconds.
+ *
+ * Returns: value in seconds
+ *
+ * Since: 2.0.17
+ **/
+guint64
+fwupd_remote_get_mtime(FwupdRemote *self)
+{
+	FwupdRemotePrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_REMOTE(self), G_MAXUINT64);
+	return priv->mtime;
 }
 
 /**

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -123,6 +123,14 @@ typedef enum {
 	 * Since: 1.9.5
 	 */
 	FWUPD_REMOTE_FLAG_ALLOW_P2P_FIRMWARE = 1 << 5,
+	/**
+	 * FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES:
+	 *
+	 * Do not slow deployment using phased updates.
+	 *
+	 * Since: 2.0.17
+	 */
+	FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES = 1 << 6,
 } FwupdRemoteFlags;
 
 FwupdRemoteKind

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1044,5 +1044,6 @@ LIBFWUPD_2.0.17 {
     fwupd_client_get_hwids;
     fwupd_remote_ensure_checksum_sig;
     fwupd_remote_ensure_mtime;
+    fwupd_remote_get_mtime;
   local: *;
 } LIBFWUPD_2.0.16;

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -289,6 +289,21 @@ fu_release_set_remote(FuRelease *self, FwupdRemote *remote)
 }
 
 /**
+ * fu_release_get_remote:
+ * @self: a #FuRelease
+ *
+ * Gets the remote this release should use when loading.
+ *
+ * Returns: (transfer none): a #FwupdRemote, or %NULL if never set
+ **/
+FwupdRemote *
+fu_release_get_remote(FuRelease *self)
+{
+	g_return_val_if_fail(FU_IS_RELEASE(self), NULL);
+	return self->remote;
+}
+
+/**
  * fu_release_set_config:
  * @self: a #FuRelease
  * @config: (nullable): a #FuEngineConfig

--- a/src/fu-release.h
+++ b/src/fu-release.h
@@ -52,6 +52,8 @@ gchar *
 fu_release_to_string(FuRelease *self) G_GNUC_NON_NULL(1);
 FuDevice *
 fu_release_get_device(FuRelease *self) G_GNUC_NON_NULL(1);
+FwupdRemote *
+fu_release_get_remote(FuRelease *self) G_GNUC_NON_NULL(1);
 GInputStream *
 fu_release_get_stream(FuRelease *self) G_GNUC_NON_NULL(1);
 void

--- a/src/fu-remote.c
+++ b/src/fu-remote.c
@@ -91,6 +91,12 @@ fu_remote_load_from_filename(FwupdRemote *self,
 		else
 			fwupd_remote_remove_flag(self, FWUPD_REMOTE_FLAG_APPROVAL_REQUIRED);
 	}
+	if (g_key_file_has_key(kf, group, "NoPhasedUpdates", NULL)) {
+		if (g_key_file_get_boolean(kf, group, "NoPhasedUpdates", NULL))
+			fwupd_remote_add_flag(self, FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES);
+		else
+			fwupd_remote_remove_flag(self, FWUPD_REMOTE_FLAG_NO_PHASED_UPDATES);
+	}
 	if (g_key_file_has_key(kf, group, "Title", NULL)) {
 		g_autofree gchar *tmp = g_key_file_get_string(kf, group, "Title", NULL);
 		fwupd_remote_set_title(self, tmp);


### PR DESCRIPTION
Add a requirement type of `modulo_mtime` which can be used to control the real-world deployment of very popular firmware files. This cannot be done server-side as many customers just mirror the entire LVFS.

Use the modulus of the remote mtime to be specified, so that a value of 2 would match 50% of machines for example. The mtime is updated whenever new metadata is downloaded, which is 24h by default and can be forced manually.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
