### PR TITLE
trivial: Try harder to return a data from fu_firmware_get_stream()

### DIFF
--- a/libfwupdplugin/fu-firmware.rs
+++ b/libfwupdplugin/fu-firmware.rs
@@ -31,6 +31,7 @@ enum FuFirmwareFlags {
     NoAutoDetection = 1 << 7, // has no known header
     HasCheckCompatible = 1 << 8,
     IsLastImage = 1 << 9, // use for FuLinearFirmware when padding is present
+    InWrite = 1 << 10,
 }
 
 enum FuFirmwareAlignment {


### PR DESCRIPTION
If we use fu_firmware_build_from_filename() the image streams may be a subclass of FuFirmware, so write them to a blob and return those.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
