### PR TITLE
plugins/nvme: Add SNSUFFIX GUIDs

### DIFF
--- a/plugins/nvme/README.md
+++ b/plugins/nvme/README.md
@@ -38,6 +38,11 @@ Additionally, an extra instance IDs containing the serial number suffix may be a
 
 * `NVME\VEN_1179&DEV_010F&SNSUFFIX_12345`
 
+When the model name can be read from the controller data the instance ID also
+includes it:
+
+* `NVME\VEN_1179&DEV_010F&SNSUFFIX_12345&NAME_Lexar-SSD-NM790-1TB`
+
 Additionally, for NVMe drives with Dell vendor firmware two extra GUIDs are
 added:
 


### PR DESCRIPTION
Lexar drives have different firmware for different capacities, even withing the same variant so adjust the GUIDs to allow targeting `model + type + capacity`. i.e.

    ec2d976e-8e78-5448-a548-6f687e705d48 ← Lexar SSD NM790 1TB P2232
    06d71aa6-8322-5283-ae68-aeebb19af60f ← Lexar SSD NM790 1TB
