### PR TITLE
thunderbolt: Fix the controller rushing to finalize before onlining

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-controller.c
+++ b/plugins/thunderbolt/fu-thunderbolt-controller.c
@@ -203,7 +203,11 @@ fu_thunderbolt_controller_setup_usb4(FuThunderboltController *self, GError **err
 	if (self->host_online_timer_id > 0)
 		g_source_remove(self->host_online_timer_id);
 	self->host_online_timer_id =
-	    g_timeout_add_seconds(5, fu_thunderbolt_controller_set_port_online_cb, self);
+	    g_timeout_add_seconds_full(G_PRIORITY_DEFAULT,
+				       5, /* seconds */
+				       fu_thunderbolt_controller_set_port_online_cb,
+				       g_object_ref(self),
+				       g_object_unref);
 	return TRUE;
 }
 


### PR DESCRIPTION
Switch to using timeout_add_seconds_full with a g_object_ref holding onto the controller self to prevent fu_thunderbolt_controller_finalize from happening immediately after fu_thunderbolt_controller_setup_usb4, and clobbering the callback on a 5 second timer which will online the ports.

This fixes issue #8578, where Rex/Screebo Chromebooks' USB-C ports were set to the offline state and never onlined whenever fwupd starts.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
