### PR TITLE
trivial: Do not use 'FuDevice *self' when defining a derived GObject

### DIFF
--- a/libfwupdplugin/fu-block-partition.c
+++ b/libfwupdplugin/fu-block-partition.c
@@ -89,13 +89,13 @@ fu_block_partition_set_fs_label(FuBlockPartition *self, const gchar *fs_label, g
 }
 
 static void
-fu_block_partition_incorporate(FuDevice *self, FuDevice *donor)
+fu_block_partition_incorporate(FuDevice *device, FuDevice *donor)
 {
-	FuBlockPartition *uself = FU_BLOCK_PARTITION(self);
+	FuBlockPartition *uself = FU_BLOCK_PARTITION(device);
 	FuBlockPartition *udonor = FU_BLOCK_PARTITION(donor);
 	FuBlockPartitionPrivate *priv = GET_PRIVATE(uself);
 
-	g_return_if_fail(FU_IS_BLOCK_PARTITION(self));
+	g_return_if_fail(FU_IS_BLOCK_PARTITION(device));
 	g_return_if_fail(FU_IS_BLOCK_PARTITION(donor));
 
 	if (priv->fs_type == NULL)

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -985,14 +985,14 @@ fu_bluez_device_write_acquire(FuBluezDevice *self, const gchar *uuid, gint32 *mt
 }
 
 static void
-fu_bluez_device_incorporate(FuDevice *self, FuDevice *donor)
+fu_bluez_device_incorporate(FuDevice *device, FuDevice *donor)
 {
-	FuBluezDevice *uself = FU_BLUEZ_DEVICE(self);
+	FuBluezDevice *uself = FU_BLUEZ_DEVICE(device);
 	FuBluezDevice *udonor = FU_BLUEZ_DEVICE(donor);
 	FuBluezDevicePrivate *priv = GET_PRIVATE(uself);
 	FuBluezDevicePrivate *privdonor = GET_PRIVATE(udonor);
 
-	g_return_if_fail(FU_IS_BLUEZ_DEVICE(self));
+	g_return_if_fail(FU_IS_BLUEZ_DEVICE(device));
 	g_return_if_fail(FU_IS_BLUEZ_DEVICE(donor));
 
 	if (g_hash_table_size(priv->uuids) == 0) {

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -922,7 +922,7 @@ fu_cfi_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_cfi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_cfi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/libfwupdplugin/fu-efi-x509-device.c
+++ b/libfwupdplugin/fu-efi-x509-device.c
@@ -83,7 +83,7 @@ fu_efi_x509_device_convert_version(FuDevice *device, guint64 version_raw)
 }
 
 static FuFirmware *
-fu_efi_x509_device_prepare_firmware(FuDevice *self,
+fu_efi_x509_device_prepare_firmware(FuDevice *device,
 				    GInputStream *stream,
 				    FuProgress *progress,
 				    FuFirmwareParseFlags flags,
@@ -154,7 +154,7 @@ fu_efi_x509_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_efi_x509_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_efi_x509_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/libfwupdplugin/fu-pci-device.c
+++ b/libfwupdplugin/fu-pci-device.c
@@ -177,14 +177,14 @@ fu_pci_device_get_revision(FuPciDevice *self)
 }
 
 static void
-fu_pci_device_to_incorporate(FuDevice *self, FuDevice *donor)
+fu_pci_device_to_incorporate(FuDevice *device, FuDevice *donor)
 {
-	FuPciDevice *uself = FU_PCI_DEVICE(self);
+	FuPciDevice *uself = FU_PCI_DEVICE(device);
 	FuPciDevice *udonor = FU_PCI_DEVICE(donor);
 	FuPciDevicePrivate *priv = GET_PRIVATE(uself);
 	FuPciDevicePrivate *priv_donor = GET_PRIVATE(udonor);
 
-	g_return_if_fail(FU_IS_PCI_DEVICE(self));
+	g_return_if_fail(FU_IS_PCI_DEVICE(device));
 	g_return_if_fail(FU_IS_PCI_DEVICE(donor));
 
 	if (priv->class == 0x0)

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3922,9 +3922,9 @@ fu_firmware_build_func(void)
 }
 
 static gsize
-fu_test_firmware_dfuse_image_get_size(FuFirmware *self)
+fu_test_firmware_dfuse_image_get_size(FuFirmware *firmware)
 {
-	g_autoptr(GPtrArray) chunks = fu_firmware_get_chunks(self, NULL);
+	g_autoptr(GPtrArray) chunks = fu_firmware_get_chunks(firmware, NULL);
 	gsize length = 0;
 	for (guint i = 0; i < chunks->len; i++) {
 		FuChunk *chk = g_ptr_array_index(chunks, i);

--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -627,13 +627,13 @@ fu_udev_device_invalidate(FuDevice *device)
 }
 
 static void
-fu_udev_device_incorporate(FuDevice *self, FuDevice *donor)
+fu_udev_device_incorporate(FuDevice *device, FuDevice *donor)
 {
-	FuUdevDevice *uself = FU_UDEV_DEVICE(self);
+	FuUdevDevice *uself = FU_UDEV_DEVICE(device);
 	FuUdevDevice *udonor = FU_UDEV_DEVICE(donor);
 	FuUdevDevicePrivate *priv = GET_PRIVATE(uself);
 
-	g_return_if_fail(FU_IS_UDEV_DEVICE(self));
+	g_return_if_fail(FU_IS_UDEV_DEVICE(device));
 	g_return_if_fail(FU_IS_UDEV_DEVICE(donor));
 
 	if (priv->device_file == NULL)

--- a/plugins/algoltek-usb/fu-algoltek-usb-device.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-device.c
@@ -356,13 +356,13 @@ fu_algoltek_usb_device_ers(FuAlgoltekUsbDevice *self,
 }
 
 static gboolean
-fu_algoltek_usb_device_status_check_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_algoltek_usb_device_status_check_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	guint8 update_status;
 	g_autoptr(GByteArray) update_status_array = NULL;
 
 	update_status_array =
-	    fu_algoltek_usb_device_rdr(FU_ALGOLTEK_USB_DEVICE(self), AG_UPDATE_STATUS, error);
+	    fu_algoltek_usb_device_rdr(FU_ALGOLTEK_USB_DEVICE(device), AG_UPDATE_STATUS, error);
 	if (update_status_array == NULL)
 		return FALSE;
 
@@ -590,7 +590,7 @@ fu_algoltek_usb_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_algoltek_usb_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_algoltek_usb_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -663,7 +663,7 @@ fu_algoltek_usbcr_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_algoltek_usbcr_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_algoltek_usbcr_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/amd-gpu/fu-amd-gpu-device.c
+++ b/plugins/amd-gpu/fu-amd-gpu-device.c
@@ -417,7 +417,7 @@ fu_amd_gpu_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_amd_gpu_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_amd_gpu_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/analogix/fu-analogix-device.c
+++ b/plugins/analogix/fu-analogix-device.c
@@ -478,7 +478,7 @@ fu_analogix_device_attach(FuDevice *device, FuProgress *progress, GError **error
 }
 
 static void
-fu_analogix_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_analogix_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -887,7 +887,7 @@ fu_ata_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 }
 
 static void
-fu_ata_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ata_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -507,7 +507,7 @@ fu_aver_hid_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_aver_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_aver_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -396,7 +396,7 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_aver_safeisp_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_aver_safeisp_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -596,7 +596,7 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 }
 
 static void
-fu_bcm57xx_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_bcm57xx_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-recovery-device.c
@@ -837,7 +837,7 @@ fu_bcm57xx_recovery_device_close(FuDevice *device, GError **error)
 }
 
 static void
-fu_bcm57xx_recovery_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_bcm57xx_recovery_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/bnr-dp/fu-bnr-dp-device.c
+++ b/plugins/bnr-dp/fu-bnr-dp-device.c
@@ -818,13 +818,13 @@ fu_bnr_dp_device_write_firmware(FuDevice *device,
 }
 
 static gchar *
-fu_bnr_dp_device_convert_version(FuDevice *self, guint64 version_raw)
+fu_bnr_dp_device_convert_version(FuDevice *device, guint64 version_raw)
 {
 	return fu_bnr_dp_version_to_string(version_raw);
 }
 
 static void
-fu_bnr_dp_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_bnr_dp_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/bnr-dp/fu-bnr-dp-firmware.c
+++ b/plugins/bnr-dp/fu-bnr-dp-firmware.c
@@ -47,7 +47,7 @@ fu_bnr_dp_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbB
 }
 
 static gchar *
-fu_bnr_dp_firmware_convert_version(FuFirmware *self, guint64 version_raw)
+fu_bnr_dp_firmware_convert_version(FuFirmware *firmware, guint64 version_raw)
 {
 	return fu_bnr_dp_version_to_string(version_raw);
 }

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-device.c
@@ -809,7 +809,7 @@ fu_ccgx_dmc_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_ccgx_dmc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ccgx_dmc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE); /* actually 0, 20, 0, 80! */

--- a/plugins/ccgx/fu-ccgx-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-hid-device.c
@@ -77,7 +77,7 @@ fu_ccgx_hid_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_ccgx_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ccgx_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/ccgx/fu-ccgx-hpi-device.c
+++ b/plugins/ccgx/fu-ccgx-hpi-device.c
@@ -1561,7 +1561,7 @@ fu_ccgx_hpi_device_close(FuDevice *device, GError **error)
 }
 
 static void
-fu_ccgx_hpi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ccgx_hpi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/ccgx/fu-ccgx-pure-hid-device.c
+++ b/plugins/ccgx/fu-ccgx-pure-hid-device.c
@@ -392,7 +392,7 @@ fu_ccgx_pure_hid_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_ccgx_pure_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ccgx_pure_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -154,7 +154,7 @@ fu_cfu_module_write_firmware(FuDevice *device,
 }
 
 static void
-fu_cfu_module_set_progress(FuDevice *self, FuProgress *progress)
+fu_cfu_module_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/ch341a/fu-ch341a-cfi-device.c
+++ b/plugins/ch341a/fu-ch341a-cfi-device.c
@@ -396,7 +396,7 @@ fu_ch341a_cfi_device_dump_firmware(FuDevice *device, FuProgress *progress, GErro
 }
 
 static void
-fu_ch341a_cfi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ch341a_cfi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/corsair/fu-corsair-bp.c
+++ b/plugins/corsair/fu-corsair-bp.c
@@ -213,12 +213,12 @@ fu_corsair_bp_write_chunk(FuCorsairBp *self, FuChunk *chunk, GError **error)
 }
 
 static void
-fu_corsair_bp_incorporate(FuDevice *self, FuDevice *donor)
+fu_corsair_bp_incorporate(FuDevice *device, FuDevice *donor)
 {
-	FuCorsairBp *bp_self = FU_CORSAIR_BP(self);
+	FuCorsairBp *bp_self = FU_CORSAIR_BP(device);
 	FuCorsairBp *bp_donor = FU_CORSAIR_BP(donor);
 
-	g_return_if_fail(FU_IS_CORSAIR_BP(self));
+	g_return_if_fail(FU_IS_CORSAIR_BP(device));
 	g_return_if_fail(FU_IS_CORSAIR_BP(donor));
 
 	bp_self->epin = bp_donor->epin;

--- a/plugins/corsair/fu-corsair-device.c
+++ b/plugins/corsair/fu-corsair-device.c
@@ -432,7 +432,7 @@ fu_corsair_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static void
-fu_corsair_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_corsair_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/cros-ec/fu-cros-ec-usb-device.c
+++ b/plugins/cros-ec/fu-cros-ec-usb-device.c
@@ -1025,7 +1025,7 @@ fu_cros_ec_usb_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static void
-fu_cros_ec_usb_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_cros_ec_usb_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-dock/fu-dell-dock-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-ec.c
@@ -984,7 +984,7 @@ fu_dell_dock_ec_finalize(GObject *object)
 }
 
 static void
-fu_dell_dock_ec_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_dock_ec_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-dock/fu-dell-dock-hid.c
+++ b/plugins/dell-dock/fu-dell-dock-hid.c
@@ -74,10 +74,10 @@ typedef struct __attribute__((packed)) { /* nocheck:blocked */
 } FuTbtCmdBuffer;
 
 static gboolean
-fu_dell_dock_hid_set_report_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_dell_dock_hid_set_report_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	guint8 *outbuffer = (guint8 *)user_data;
-	return fu_hid_device_set_report(FU_HID_DEVICE(self),
+	return fu_hid_device_set_report(FU_HID_DEVICE(device),
 					0x0,
 					outbuffer,
 					192,
@@ -87,9 +87,9 @@ fu_dell_dock_hid_set_report_cb(FuDevice *self, gpointer user_data, GError **erro
 }
 
 static gboolean
-fu_dell_dock_hid_set_report(FuDevice *self, guint8 *outbuffer, GError **error)
+fu_dell_dock_hid_set_report(FuDevice *device, guint8 *outbuffer, GError **error)
 {
-	return fu_device_retry(self,
+	return fu_device_retry(device,
 			       fu_dell_dock_hid_set_report_cb,
 			       HID_MAX_RETRIES,
 			       outbuffer,
@@ -97,10 +97,10 @@ fu_dell_dock_hid_set_report(FuDevice *self, guint8 *outbuffer, GError **error)
 }
 
 static gboolean
-fu_dell_dock_hid_get_report_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_dell_dock_hid_get_report_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	guint8 *inbuffer = (guint8 *)user_data;
-	return fu_hid_device_get_report(FU_HID_DEVICE(self),
+	return fu_hid_device_get_report(FU_HID_DEVICE(device),
 					0x0,
 					inbuffer,
 					192,
@@ -110,9 +110,9 @@ fu_dell_dock_hid_get_report_cb(FuDevice *self, gpointer user_data, GError **erro
 }
 
 static gboolean
-fu_dell_dock_hid_get_report(FuDevice *self, guint8 *inbuffer, GError **error)
+fu_dell_dock_hid_get_report(FuDevice *device, guint8 *inbuffer, GError **error)
 {
-	return fu_device_retry(self,
+	return fu_device_retry(device,
 			       fu_dell_dock_hid_get_report_cb,
 			       HID_MAX_RETRIES,
 			       inbuffer,
@@ -120,7 +120,7 @@ fu_dell_dock_hid_get_report(FuDevice *self, guint8 *inbuffer, GError **error)
 }
 
 gboolean
-fu_dell_dock_hid_get_hub_version(FuDevice *self, GError **error)
+fu_dell_dock_hid_get_hub_version(FuDevice *device, GError **error)
 {
 	g_autofree gchar *version = NULL;
 	FuHIDCmdBuffer cmd_buffer = {
@@ -135,23 +135,23 @@ fu_dell_dock_hid_get_hub_version(FuDevice *self, GError **error)
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error_literal(error, "failed to query hub version: ");
 		return FALSE;
 	}
-	if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error)) {
+	if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error)) {
 		g_prefix_error_literal(error, "failed to query hub version: ");
 		return FALSE;
 	}
 
 	version = g_strdup_printf("%02x.%02x", cmd_buffer.data[10], cmd_buffer.data[11]);
-	fu_device_set_version_format(self, FWUPD_VERSION_FORMAT_PAIR);
-	fu_device_set_version(self, version);
+	fu_device_set_version_format(device, FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_set_version(device, version);
 	return TRUE;
 }
 
 gboolean
-fu_dell_dock_hid_raise_mcu_clock(FuDevice *self, gboolean enable, GError **error)
+fu_dell_dock_hid_raise_mcu_clock(FuDevice *device, gboolean enable, GError **error)
 {
 	FuHIDCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_WRITE_DATA,
@@ -165,7 +165,7 @@ fu_dell_dock_hid_raise_mcu_clock(FuDevice *self, gboolean enable, GError **error
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error(error, "failed to set mcu clock to %d: ", enable);
 		return FALSE;
 	}
@@ -174,7 +174,7 @@ fu_dell_dock_hid_raise_mcu_clock(FuDevice *self, gboolean enable, GError **error
 }
 
 gboolean
-fu_dell_dock_hid_erase_bank(FuDevice *self, guint8 idx, GError **error)
+fu_dell_dock_hid_erase_bank(FuDevice *device, guint8 idx, GError **error)
 {
 	FuHIDCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_WRITE_DATA,
@@ -188,7 +188,7 @@ fu_dell_dock_hid_erase_bank(FuDevice *self, guint8 idx, GError **error)
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error_literal(error, "failed to erase bank: ");
 		return FALSE;
 	}
@@ -197,7 +197,7 @@ fu_dell_dock_hid_erase_bank(FuDevice *self, guint8 idx, GError **error)
 }
 
 gboolean
-fu_dell_dock_hid_write_flash(FuDevice *self,
+fu_dell_dock_hid_write_flash(FuDevice *device,
 			     guint32 dwAddr,
 			     const guint8 *input,
 			     gsize write_size,
@@ -215,7 +215,7 @@ fu_dell_dock_hid_write_flash(FuDevice *self,
 	g_return_val_if_fail(write_size <= HIDI2C_MAX_WRITE, FALSE);
 
 	memcpy(cmd_buffer.data, input, write_size); /* nocheck:blocked */
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error(error,
 			       "failed to write %" G_GSIZE_FORMAT " flash to %x: ",
 			       write_size,
@@ -227,7 +227,7 @@ fu_dell_dock_hid_write_flash(FuDevice *self,
 }
 
 gboolean
-fu_dell_dock_hid_verify_update(FuDevice *self, gboolean *result, GError **error)
+fu_dell_dock_hid_verify_update(FuDevice *device, gboolean *result, GError **error)
 {
 	FuHIDCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_WRITE_DATA,
@@ -241,11 +241,11 @@ fu_dell_dock_hid_verify_update(FuDevice *self, gboolean *result, GError **error)
 	    .extended_cmdarea[0 ... 52] = 0,
 	};
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error_literal(error, "failed to verify update: ");
 		return FALSE;
 	}
-	if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error)) {
+	if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error)) {
 		g_prefix_error_literal(error, "failed to verify update: ");
 		return FALSE;
 	}
@@ -255,7 +255,7 @@ fu_dell_dock_hid_verify_update(FuDevice *self, gboolean *result, GError **error)
 }
 
 gboolean
-fu_dell_dock_hid_i2c_write(FuDevice *self,
+fu_dell_dock_hid_i2c_write(FuDevice *device,
 			   const guint8 *input,
 			   gsize write_size,
 			   const FuHIDI2CParameters *parameters,
@@ -276,11 +276,11 @@ fu_dell_dock_hid_i2c_write(FuDevice *self,
 
 	memcpy(cmd_buffer.data, input, write_size); /* nocheck:blocked */
 
-	return fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error);
+	return fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error);
 }
 
 gboolean
-fu_dell_dock_hid_i2c_read(FuDevice *self,
+fu_dell_dock_hid_i2c_read(FuDevice *device,
 			  guint32 cmd,
 			  gsize read_size,
 			  GBytes **bytes,
@@ -303,9 +303,9 @@ fu_dell_dock_hid_i2c_read(FuDevice *self,
 	g_return_val_if_fail(bytes != NULL, FALSE);
 	g_return_val_if_fail(parameters->regaddrlen < HIDI2C_MAX_REGISTER, FALSE);
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error))
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error))
 		return FALSE;
-	if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error))
+	if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error))
 		return FALSE;
 
 	*bytes = g_bytes_new(cmd_buffer.data, read_size);
@@ -314,7 +314,7 @@ fu_dell_dock_hid_i2c_read(FuDevice *self,
 }
 
 gboolean
-fu_dell_dock_hid_tbt_wake(FuDevice *self, const FuHIDI2CParameters *parameters, GError **error)
+fu_dell_dock_hid_tbt_wake(FuDevice *device, const FuHIDI2CParameters *parameters, GError **error)
 {
 	FuTbtCmdBuffer cmd_buffer = {
 	    .cmd = HUB_CMD_READ_DATA, /* special write command that reads status result */
@@ -327,11 +327,11 @@ fu_dell_dock_hid_tbt_wake(FuDevice *self, const FuHIDI2CParameters *parameters, 
 	    .data[0 ... 191] = 0,
 	};
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error_literal(error, "failed to set wake thunderbolt: ");
 		return FALSE;
 	}
-	if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error)) {
+	if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error)) {
 		g_prefix_error_literal(error, "failed to get wake thunderbolt status: ");
 		return FALSE;
 	}
@@ -352,7 +352,7 @@ fu_dell_dock_hid_tbt_map_error(guint32 code)
 }
 
 gboolean
-fu_dell_dock_hid_tbt_write(FuDevice *self,
+fu_dell_dock_hid_tbt_write(FuDevice *device,
 			   guint32 start_addr,
 			   const guint8 *input,
 			   gsize write_size,
@@ -376,11 +376,11 @@ fu_dell_dock_hid_tbt_write(FuDevice *self,
 	memcpy(cmd_buffer.data, input, write_size); /* nocheck:blocked */
 
 	for (gint i = 1; i <= TBT_MAX_RETRIES; i++) {
-		if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+		if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 			g_prefix_error_literal(error, "failed to run TBT update: ");
 			return FALSE;
 		}
-		if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error)) {
+		if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error)) {
 			g_prefix_error_literal(error, "failed to get TBT flash status: ");
 			return FALSE;
 		}
@@ -403,7 +403,7 @@ fu_dell_dock_hid_tbt_write(FuDevice *self,
 }
 
 gboolean
-fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
+fu_dell_dock_hid_tbt_authenticate(FuDevice *device,
 				  const FuHIDI2CParameters *parameters,
 				  GError **error)
 {
@@ -418,7 +418,7 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 	};
 	guint8 result;
 
-	if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+	if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 		g_prefix_error_literal(error, "failed to send authentication: ");
 		return FALSE;
 	}
@@ -426,13 +426,13 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 	cmd_buffer.tbt_command =
 	    GUINT32_TO_LE(TBT_COMMAND_AUTHENTICATE_STATUS); /* nocheck:blocked */
 	/* needs at least 2 seconds */
-	fu_device_sleep(self, 2000);
+	fu_device_sleep(device, 2000);
 	for (gint i = 1; i <= TBT_MAX_RETRIES; i++) {
-		if (!fu_dell_dock_hid_set_report(self, (guint8 *)&cmd_buffer, error)) {
+		if (!fu_dell_dock_hid_set_report(device, (guint8 *)&cmd_buffer, error)) {
 			g_prefix_error_literal(error, "failed to set check authentication: ");
 			return FALSE;
 		}
-		if (!fu_dell_dock_hid_get_report(self, cmd_buffer.data, error)) {
+		if (!fu_dell_dock_hid_get_report(device, cmd_buffer.data, error)) {
 			g_prefix_error_literal(error, "failed to get check authentication: ");
 			return FALSE;
 		}
@@ -443,7 +443,7 @@ fu_dell_dock_hid_tbt_authenticate(FuDevice *self,
 			i,
 			TBT_MAX_RETRIES,
 			result);
-		fu_device_sleep(self, 500); /* ms */
+		fu_device_sleep(device, 500); /* ms */
 	}
 	if (result != 0) {
 		g_set_error(error,

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -185,7 +185,7 @@ fu_dell_dock_hub_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_dell_dock_hub_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_dock_hub_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-dock/fu-dell-dock-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-mst.c
@@ -1232,7 +1232,7 @@ fu_dell_dock_mst_close(FuDevice *device, GError **error)
 }
 
 static void
-fu_dell_dock_mst_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_dock_mst_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -170,7 +170,7 @@ fu_dell_dock_status_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_dell_dock_status_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_dock_status_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-dpmux.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-dpmux.c
@@ -65,7 +65,7 @@ fu_dell_kestrel_dpmux_write(FuDevice *device,
 }
 
 static void
-fu_dell_kestrel_dpmux_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_dpmux_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-ec.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ec.c
@@ -779,7 +779,7 @@ fu_dell_kestrel_ec_finalize(GObject *object)
 }
 
 static void
-fu_dell_kestrel_ec_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_ec_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-hid-device.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-hid-device.c
@@ -75,10 +75,10 @@ fu_dell_kestrel_hid_device_fwup_pkg_new(FuChunk *chk,
 }
 
 static gboolean
-fu_dell_kestrel_hid_device_hid_set_report_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_dell_kestrel_hid_device_hid_set_report_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	GByteArray *buf = (GByteArray *)user_data;
-	return fu_hid_device_set_report(FU_HID_DEVICE(self),
+	return fu_hid_device_set_report(FU_HID_DEVICE(device),
 					0x0,
 					buf->data,
 					buf->len,
@@ -100,10 +100,10 @@ fu_dell_kestrel_hid_device_hid_set_report(FuDellKestrelHidDevice *self,
 }
 
 static gboolean
-fu_dell_kestrel_hid_device_get_report_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_dell_kestrel_hid_device_get_report_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	guint8 *inbuffer = (guint8 *)user_data;
-	return fu_hid_device_get_report(FU_HID_DEVICE(self),
+	return fu_hid_device_get_report(FU_HID_DEVICE(device),
 					0x0,
 					inbuffer,
 					192,

--- a/plugins/dell-kestrel/fu-dell-kestrel-ilan.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-ilan.c
@@ -62,7 +62,7 @@ fu_dell_kestrel_ilan_write(FuDevice *device,
 }
 
 static void
-fu_dell_kestrel_ilan_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_ilan_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-package.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-package.c
@@ -103,7 +103,7 @@ fu_dell_kestrel_package_attach(FuDevice *device, FuProgress *progress, GError **
 }
 
 static void
-fu_dell_kestrel_package_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_package_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-pd.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-pd.c
@@ -82,7 +82,7 @@ fu_dell_kestrel_pd_write(FuDevice *device,
 }
 
 static void
-fu_dell_kestrel_pd_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_pd_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-rmm.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rmm.c
@@ -78,7 +78,7 @@ fu_dell_kestrel_rmm_write(FuDevice *device,
 }
 
 static void
-fu_dell_kestrel_rmm_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_rmm_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-rtshub.c
@@ -370,7 +370,7 @@ fu_dell_kestrel_rtshub_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_dell_kestrel_rtshub_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_rtshub_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/dell-kestrel/fu-dell-kestrel-wtpd.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-wtpd.c
@@ -65,7 +65,7 @@ fu_dell_kestrel_wtpd_write(FuDevice *device,
 }
 
 static void
-fu_dell_kestrel_wtpd_set_progress(FuDevice *self, FuProgress *progress)
+fu_dell_kestrel_wtpd_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/devlink/fu-devlink-component.c
+++ b/plugins/devlink/fu-devlink-component.c
@@ -141,7 +141,7 @@ fu_devlink_component_cleanup(FuDevice *device,
 }
 
 static void
-fu_devlink_component_set_progress(FuDevice *self, FuProgress *progress)
+fu_devlink_component_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/dfu/fu-dfu-device.c
+++ b/plugins/dfu/fu-dfu-device.c
@@ -1372,7 +1372,7 @@ fu_dfu_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *valu
 }
 
 static void
-fu_dfu_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_dfu_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -656,7 +656,7 @@ fu_ebitdo_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_ebitdo_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ebitdo_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_NO_PROFILE);

--- a/plugins/egis-moc/fu-egis-moc-device.c
+++ b/plugins/egis-moc/fu-egis-moc-device.c
@@ -122,7 +122,7 @@ fu_egis_moc_device_cmd_send(FuEgisMocDevice *self, GByteArray *req, GError **err
 }
 
 static gboolean
-fu_egis_moc_device_cmd_recv_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_egis_moc_device_cmd_recv_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	gsize actual_len = 0;
 	guint32 csum = 0;
@@ -133,7 +133,7 @@ fu_egis_moc_device_cmd_recv_cb(FuDevice *self, gpointer user_data, GError **erro
 
 	/* package format = | zlp | ack | zlp | data | */
 	fu_byte_array_set_size(buf, FU_EGIS_MOC_FLASH_TRANSFER_BLOCK_SIZE, 0x00);
-	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(self),
+	if (!fu_usb_device_bulk_transfer(FU_USB_DEVICE(device),
 					 FU_EGIS_MOC_USB_BULK_EP_IN,
 					 buf->data,
 					 buf->len,
@@ -197,12 +197,11 @@ fu_egis_moc_device_cmd_recv_cb(FuDevice *self, gpointer user_data, GError **erro
 }
 
 static GByteArray *
-fu_egis_moc_device_fw_cmd(FuEgisMocDevice *device,
+fu_egis_moc_device_fw_cmd(FuEgisMocDevice *self,
 			  FuStructEgisMocCmdReq *st_req,
 			  gsize bufsz,
 			  GError **error)
 {
-	FuEgisMocDevice *self = FU_EGIS_MOC_DEVICE(device);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 
 	if (!fu_egis_moc_device_cmd_send(self, st_req->buf, error))
@@ -489,7 +488,7 @@ fu_egis_moc_device_detach(FuDevice *device, FuProgress *progress, GError **error
 }
 
 static void
-fu_egis_moc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_egis_moc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/elan-kbd/fu-elan-kbd-debug-device.c
+++ b/plugins/elan-kbd/fu-elan-kbd-debug-device.c
@@ -45,7 +45,7 @@ fu_elan_kbd_debug_device_detach(FuDevice *device, FuProgress *progress, GError *
 }
 
 static void
-fu_elan_kbd_debug_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elan_kbd_debug_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/elan-kbd/fu-elan-kbd-device.c
+++ b/plugins/elan-kbd/fu-elan-kbd-device.c
@@ -657,7 +657,7 @@ fu_elan_kbd_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_elan_kbd_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elan_kbd_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/elan-kbd/fu-elan-kbd-runtime.c
+++ b/plugins/elan-kbd/fu-elan-kbd-runtime.c
@@ -47,7 +47,7 @@ fu_elan_kbd_runtime_detach(FuDevice *device, FuProgress *progress, GError **erro
 }
 
 static void
-fu_elan_kbd_runtime_set_progress(FuDevice *self, FuProgress *progress)
+fu_elan_kbd_runtime_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/elanfp/fu-elanfp-device.c
+++ b/plugins/elanfp/fu-elanfp-device.c
@@ -446,7 +446,7 @@ fu_elanfp_device_init(FuElanfpDevice *device)
 }
 
 static void
-fu_elanfp_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elanfp_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -941,7 +941,7 @@ fu_elantp_hid_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_elantp_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elantp_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/elantp/fu-elantp-hid-haptic-device.c
+++ b/plugins/elantp/fu-elantp-hid-haptic-device.c
@@ -30,7 +30,7 @@ struct _FuElantpHidHapticDevice {
 G_DEFINE_TYPE(FuElantpHidHapticDevice, fu_elantp_hid_haptic_device, FU_TYPE_UDEV_DEVICE)
 
 static FuElantpHidDevice *
-fu_elantp_hid_haptic_device_get_parent(FuDevice *self, GError **error)
+fu_elantp_hid_haptic_device_get_parent(FuElantpHidHapticDevice *self, GError **error)
 {
 	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
 	if (parent == NULL) {
@@ -59,7 +59,7 @@ fu_elantp_hid_haptic_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
+fu_elantp_hid_haptic_device_send_cmd(FuElantpHidDevice *parent,
 				     const guint8 *tx,
 				     gsize txsz,
 				     guint8 *rx,
@@ -69,7 +69,7 @@ fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
 	g_autofree guint8 *buf = NULL;
 	gsize bufsz = rxsz + 3;
 
-	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
+	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(parent),
 					  tx,
 					  txsz,
 					  FU_IOCTL_FLAG_NONE,
@@ -81,7 +81,7 @@ fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
 	/* GetFeature */
 	buf = g_malloc0(bufsz);
 	buf[0] = tx[0]; /* report number */
-	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),
+	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(parent),
 					  buf,
 					  bufsz,
 					  FU_IOCTL_FLAG_NONE,
@@ -100,7 +100,7 @@ fu_elantp_hid_haptic_device_send_cmd(FuDevice *self,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_read_cmd(FuDevice *self,
+fu_elantp_hid_haptic_device_read_cmd(FuElantpHidDevice *parent,
 				     guint16 reg,
 				     guint8 *buf,
 				     gsize bufz,
@@ -108,21 +108,24 @@ fu_elantp_hid_haptic_device_read_cmd(FuDevice *self,
 {
 	guint8 tmp[5] = {0x0D, 0x05, 0x03};
 	fu_memwrite_uint16(tmp + 0x3, reg, G_LITTLE_ENDIAN);
-	return fu_elantp_hid_haptic_device_send_cmd(self, tmp, sizeof(tmp), buf, bufz, error);
+	return fu_elantp_hid_haptic_device_send_cmd(parent, tmp, sizeof(tmp), buf, bufz, error);
 }
 
 static gint
-fu_elantp_hid_haptic_device_write_cmd(FuDevice *self, guint16 reg, guint16 cmd, GError **error)
+fu_elantp_hid_haptic_device_write_cmd(FuElantpHidDevice *parent,
+				      guint16 reg,
+				      guint16 cmd,
+				      GError **error)
 {
 	guint8 buf[5] = {0x0D};
 	fu_memwrite_uint16(buf + 0x1, reg, G_LITTLE_ENDIAN);
 	fu_memwrite_uint16(buf + 0x3, cmd, G_LITTLE_ENDIAN);
-	return fu_elantp_hid_haptic_device_send_cmd(self, buf, sizeof(buf), NULL, 0, error);
+	return fu_elantp_hid_haptic_device_send_cmd(parent, buf, sizeof(buf), NULL, 0, error);
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_ensure_iap_ctrl(FuDevice *parent,
-					    FuElantpHidHapticDevice *self,
+fu_elantp_hid_haptic_device_ensure_iap_ctrl(FuElantpHidHapticDevice *self,
+					    FuElantpHidDevice *parent,
 					    GError **error)
 {
 	guint8 buf[2] = {0x0};
@@ -154,8 +157,8 @@ fu_elantp_hid_haptic_device_ensure_iap_ctrl(FuDevice *parent,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(FuDevice *parent,
-						   FuElantpHidHapticDevice *self,
+fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(FuElantpHidHapticDevice *self,
+						   FuElantpHidDevice *parent,
 						   GError **error)
 {
 	guint8 buf[2] = {0x0};
@@ -182,8 +185,8 @@ fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(FuDevice *parent,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_get_haptic_driver_ic(FuDevice *parent,
-						 FuElantpHidHapticDevice *self,
+fu_elantp_hid_haptic_device_get_haptic_driver_ic(FuElantpHidHapticDevice *self,
+						 FuElantpHidDevice *parent,
 						 GError **error)
 {
 	guint8 buf[2] = {0x0};
@@ -220,8 +223,8 @@ fu_elantp_hid_haptic_device_get_haptic_driver_ic(FuDevice *parent,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_get_version(FuDevice *parent,
-					FuElantpHidHapticDevice *self,
+fu_elantp_hid_haptic_device_get_version(FuElantpHidHapticDevice *self,
+					FuElantpHidDevice *parent,
 					GError **error)
 {
 	guint16 v_s = 0;
@@ -274,7 +277,7 @@ fu_elantp_hid_haptic_device_get_version(FuDevice *parent,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_write_fw_password(FuDevice *parent,
+fu_elantp_hid_haptic_device_write_fw_password(FuElantpHidDevice *parent,
 					      guint16 tp_ic_type,
 					      guint16 tp_iap_ver,
 					      GError **error)
@@ -321,8 +324,9 @@ typedef struct {
 } FuElantpHaptictpWaitFlashEEPROMChecksumHelper;
 
 static gboolean
-fu_elantp_hid_haptic_device_write_checksum_cb(FuDevice *parent, gpointer user_data, GError **error)
+fu_elantp_hid_haptic_device_write_checksum_cb(FuDevice *device, gpointer user_data, GError **error)
 {
+	FuElantpHidDevice *parent = FU_ELANTP_HID_DEVICE(device);
 	guint8 buf[2] = {0x0};
 	guint16 value;
 	FuElantpHaptictpWaitFlashEEPROMChecksumHelper *helper = user_data;
@@ -402,10 +406,11 @@ fu_elantp_hid_haptic_device_write_checksum_cb(FuDevice *parent, gpointer user_da
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_wait_calc_checksum_cb(FuDevice *parent,
+fu_elantp_hid_haptic_device_wait_calc_checksum_cb(FuDevice *device,
 						  gpointer user_data,
 						  GError **error)
 {
+	FuElantpHidDevice *parent = FU_ELANTP_HID_DEVICE(device);
 	guint16 ctrl;
 	guint8 buf[2] = {0x0};
 
@@ -438,7 +443,9 @@ fu_elantp_hid_haptic_device_wait_calc_checksum_cb(FuDevice *parent,
 }
 
 static gboolean
-fu_elantp_hid_haptic_device_get_checksum(FuDevice *parent, guint16 *checksum, GError **error)
+fu_elantp_hid_haptic_device_get_checksum(FuElantpHidDevice *parent,
+					 guint16 *checksum,
+					 GError **error)
 {
 	guint8 buf[2] = {0x0};
 	g_autoptr(GError) error_local = NULL;
@@ -448,7 +455,7 @@ fu_elantp_hid_haptic_device_get_checksum(FuDevice *parent, guint16 *checksum, GE
 						   FU_ETP_CMD_I2C_CALC_EEPROM_CHECKSUM,
 						   error))
 		return FALSE;
-	if (!fu_device_retry_full(parent,
+	if (!fu_device_retry_full(FU_DEVICE(parent),
 				  fu_elantp_hid_haptic_device_wait_calc_checksum_cb,
 				  100,
 				  ELANTP_EEPROM_READ_DELAY,
@@ -482,25 +489,25 @@ fu_elantp_hid_haptic_device_get_checksum(FuDevice *parent, guint16 *checksum, GE
 static gboolean
 fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 {
-	FuElantpHidDevice *parent;
 	FuElantpHidHapticDevice *self = FU_ELANTP_HID_HAPTIC_DEVICE(device);
+	FuElantpHidDevice *parent;
 	FuUdevDevice *udev_parent;
 	guint8 ic_type;
 	guint16 tmp;
 	guint8 buf[2] = {0x0};
 	g_autofree gchar *version_bl = NULL;
 
-	parent = fu_elantp_hid_haptic_device_get_parent(device, error);
+	parent = fu_elantp_hid_haptic_device_get_parent(self, error);
 	if (parent == NULL)
 		return FALSE;
 
-	if (!fu_elantp_hid_haptic_device_get_haptic_driver_ic(FU_DEVICE(parent), self, error)) {
+	if (!fu_elantp_hid_haptic_device_get_haptic_driver_ic(self, parent, error)) {
 		g_prefix_error_literal(error, "this module is not support haptic EEPROM: ");
 		return FALSE;
 	}
 
 	/* get pattern */
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  FU_ETP_CMD_I2C_GET_HID_ID,
 						  buf,
 						  sizeof(buf),
@@ -511,14 +518,14 @@ fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 	tmp = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	self->pattern = tmp != 0xFFFF ? (tmp & 0xFF00) >> 8 : 0;
 
-	if (!fu_elantp_hid_haptic_device_get_version(FU_DEVICE(parent), self, error))
+	if (!fu_elantp_hid_haptic_device_get_version(self, parent, error))
 		return FALSE;
 
 	version_bl = fu_version_from_uint16(self->iap_ver, FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_version_bootloader(device, version_bl);
 
 	/* get module ID */
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  FU_ETP_CMD_GET_MODULE_ID,
 						  buf,
 						  sizeof(buf),
@@ -545,7 +552,7 @@ fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 		return FALSE;
 
 	/* get OSM version */
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  FU_ETP_CMD_I2C_OSM_VERSION,
 						  buf,
 						  sizeof(buf),
@@ -555,7 +562,7 @@ fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 	}
 	tmp = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	if (tmp == FU_ETP_CMD_I2C_OSM_VERSION || tmp == 0xFFFF) {
-		if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+		if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 							  FU_ETP_CMD_I2C_IAP_ICBODY,
 							  buf,
 							  sizeof(buf),
@@ -599,7 +606,7 @@ fu_elantp_hid_haptic_device_setup(FuDevice *device, GError **error)
 	fu_device_set_firmware_size(device, 32768);
 
 	/* find out if in bootloader mode */
-	if (!fu_elantp_hid_haptic_device_ensure_iap_ctrl(FU_DEVICE(parent), self, error))
+	if (!fu_elantp_hid_haptic_device_ensure_iap_ctrl(self, parent, error))
 		return FALSE;
 
 	/* success */
@@ -652,7 +659,7 @@ fu_elantp_hid_haptic_device_write_chunks_cb(FuDevice *device, gpointer user_data
 	g_autoptr(FuChunkArray) chunks = NULL;
 
 	/* use parent */
-	parent = fu_elantp_hid_haptic_device_get_parent(device, error);
+	parent = fu_elantp_hid_haptic_device_get_parent(self, error);
 	if (parent == NULL)
 		return FALSE;
 
@@ -717,26 +724,21 @@ fu_elantp_hid_haptic_device_write_chunks_cb(FuDevice *device, gpointer user_data
 					   G_BIG_ENDIAN);
 		}
 
-		if (!fu_elantp_hid_haptic_device_send_cmd(FU_DEVICE(parent),
-							  blk,
-							  blksz,
-							  NULL,
-							  0,
-							  error))
+		if (!fu_elantp_hid_haptic_device_send_cmd(parent, blk, blksz, NULL, 0, error))
 			return FALSE;
 
 		fu_device_sleep(device,
 				self->fw_page_size == 512 ? ELANTP_DELAY_WRITE_BLOCK_512
 							  : ELANTP_DELAY_WRITE_BLOCK);
 
-		if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+		if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 							   FU_ETP_CMD_I2C_SET_EEPROM_CTRL,
 							   FU_ETP_CMD_I2C_SET_EEPROM_DATATYPE,
 							   error))
 			return FALSE;
 
-		if (!fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(FU_DEVICE(parent),
-									self,
+		if (!fu_elantp_hid_haptic_device_ensure_eeprom_iap_ctrl(self,
+									parent,
 									&error_iapctrl)) {
 			g_set_error(error,
 				    FWUPD_ERROR,
@@ -786,7 +788,7 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* use parent */
-	parent = fu_elantp_hid_haptic_device_get_parent(device, error);
+	parent = fu_elantp_hid_haptic_device_get_parent(self, error);
 	if (parent == NULL)
 		return FALSE;
 
@@ -807,14 +809,14 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 		return FALSE;
 	fu_progress_step_done(progress);
 
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_EEPROM_SETTING,
 						   FU_ETP_CMD_I2C_EEPROM_SETTING_INITIAL,
 						   error)) {
 		g_prefix_error_literal(error, "cannot disable EEPROM Long Transmission mode: ");
 		return FALSE;
 	}
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_SET_EEPROM_CTRL,
 						   FU_ETP_CMD_I2C_SET_EEPROM_LEAVE_IAP,
 						   error)) {
@@ -822,7 +824,7 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 	fu_device_sleep(device, ELANTP_DELAY_RESET);
-	if (!fu_elantp_hid_haptic_device_get_checksum(FU_DEVICE(parent), &checksum_device, error)) {
+	if (!fu_elantp_hid_haptic_device_get_checksum(parent, &checksum_device, error)) {
 		g_prefix_error_literal(error, "read device checksum fail: ");
 		return FALSE;
 	}
@@ -850,7 +852,7 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 		return FALSE;
 	}
 
-	if (!fu_elantp_hid_haptic_device_get_version(FU_DEVICE(parent), self, error))
+	if (!fu_elantp_hid_haptic_device_get_version(self, parent, error))
 		return FALSE;
 	fw_ver_device = fu_device_get_version(device);
 	fw_ver = fu_firmware_get_version(firmware);
@@ -866,7 +868,7 @@ fu_elantp_hid_haptic_device_write_firmware(FuDevice *device,
 	}
 	fu_progress_step_done(progress);
 
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_SET_EEPROM_CTRL,
 						   FU_ETP_CMD_I2C_HAPTIC_RESTART,
 						   error)) {
@@ -905,12 +907,12 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 			    (guint)self->iap_ver);
 		return FALSE;
 	}
-	parent = fu_elantp_hid_haptic_device_get_parent(device, error);
+	parent = fu_elantp_hid_haptic_device_get_parent(self, error);
 	if (parent == NULL)
 		return FALSE;
 
 	/* get OSM version */
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  FU_ETP_CMD_I2C_OSM_VERSION,
 						  buf,
 						  sizeof(buf),
@@ -920,7 +922,7 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 	}
 	tmp = fu_memread_uint16(buf, G_LITTLE_ENDIAN);
 	if (tmp == FU_ETP_CMD_I2C_OSM_VERSION || tmp == 0xFFFF) {
-		if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+		if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 							  FU_ETP_CMD_I2C_IAP_ICBODY,
 							  buf,
 							  sizeof(buf),
@@ -933,7 +935,7 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 		self->tp_ic_type = (tmp >> 8) & 0xFF;
 
 	/* get IAP firmware version */
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  self->pattern == 0 ? FU_ETP_CMD_I2C_IAP_VERSION
 								     : FU_ETP_CMD_I2C_IAP_VERSION_2,
 						  buf,
@@ -959,12 +961,12 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 				self->fw_page_size = 128;
 			}
 
-			if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+			if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 								   FU_ETP_CMD_I2C_IAP_TYPE,
 								   self->fw_page_size / 2,
 								   error))
 				return FALSE;
-			if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+			if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 								  FU_ETP_CMD_I2C_IAP_TYPE,
 								  buf,
 								  sizeof(buf),
@@ -983,7 +985,7 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 		}
 	}
 
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_EEPROM_SETTING,
 						   FU_ETP_CMD_I2C_EEPROM_LONG_TRANS_ENABLE,
 						   error)) {
@@ -991,7 +993,7 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 		return FALSE;
 	}
 
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_SET_EEPROM_CTRL,
 						   FU_ETP_CMD_I2C_SET_EEPROM_ENTER_IAP,
 						   error)) {
@@ -999,7 +1001,7 @@ fu_elantp_hid_haptic_device_detach(FuDevice *device, FuProgress *progress, GErro
 		return FALSE;
 	}
 
-	if (!fu_elantp_hid_haptic_device_read_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_read_cmd(parent,
 						  FU_ETP_CMD_I2C_SET_EEPROM_CTRL,
 						  buf,
 						  sizeof(buf),
@@ -1025,12 +1027,12 @@ fu_elantp_hid_haptic_device_attach(FuDevice *device, FuProgress *progress, GErro
 	FuElantpHidDevice *parent;
 	FuElantpHidHapticDevice *self = FU_ELANTP_HID_HAPTIC_DEVICE(device);
 
-	parent = fu_elantp_hid_haptic_device_get_parent(device, error);
+	parent = fu_elantp_hid_haptic_device_get_parent(self, error);
 	if (parent == NULL)
 		return FALSE;
 
 	/* reset back to runtime */
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_IAP_RESET,
 						   ETP_I2C_IAP_RESET,
 						   error)) {
@@ -1038,18 +1040,18 @@ fu_elantp_hid_haptic_device_attach(FuDevice *device, FuProgress *progress, GErro
 		return FALSE;
 	}
 	fu_device_sleep(device, ELANTP_DELAY_RESET);
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent),
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent,
 						   FU_ETP_CMD_I2C_IAP_RESET,
 						   ETP_I2C_ENABLE_REPORT,
 						   error)) {
 		g_prefix_error_literal(error, "cannot enable TP report: ");
 		return FALSE;
 	}
-	if (!fu_elantp_hid_haptic_device_write_cmd(FU_DEVICE(parent), 0x0306, 0x003, error)) {
+	if (!fu_elantp_hid_haptic_device_write_cmd(parent, 0x0306, 0x003, error)) {
 		g_prefix_error_literal(error, "cannot switch to TP PTP mode: ");
 		return FALSE;
 	}
-	if (!fu_elantp_hid_haptic_device_ensure_iap_ctrl(FU_DEVICE(parent), self, error))
+	if (!fu_elantp_hid_haptic_device_ensure_iap_ctrl(self, parent, error))
 		return FALSE;
 
 	/* sanity check */
@@ -1091,7 +1093,7 @@ fu_elantp_hid_haptic_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_elantp_hid_haptic_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elantp_hid_haptic_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/elantp/fu-elantp-i2c-device.c
+++ b/plugins/elantp/fu-elantp-i2c-device.c
@@ -777,7 +777,7 @@ fu_elantp_i2c_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_elantp_i2c_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_elantp_i2c_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -598,7 +598,7 @@ fu_emmc_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 }
 
 static void
-fu_emmc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_emmc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/ep963x/fu-ep963x-device.c
+++ b/plugins/ep963x/fu-ep963x-device.c
@@ -361,7 +361,7 @@ fu_ep963x_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_ep963x_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ep963x_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -694,7 +694,7 @@ fu_fastboot_device_attach(FuDevice *device, FuProgress *progress, GError **error
 }
 
 static void
-fu_fastboot_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_fastboot_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/flashrom/fu-flashrom-device.c
+++ b/plugins/flashrom/fu-flashrom-device.c
@@ -346,7 +346,7 @@ fu_flashrom_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_flashrom_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_flashrom_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/focalfp/fu-focalfp-hid-device.c
+++ b/plugins/focalfp/fu-focalfp-hid-device.c
@@ -627,7 +627,7 @@ fu_focalfp_hid_device_attach(FuDevice *device, FuProgress *progress, GError **er
 }
 
 static void
-fu_focalfp_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_focalfp_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/fpc/fu-fpc-device.c
+++ b/plugins/fpc/fu-fpc-device.c
@@ -661,7 +661,7 @@ fu_fpc_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_fpc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_fpc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/framework-qmk/fu-framework-qmk-device.c
+++ b/plugins/framework-qmk/fu-framework-qmk-device.c
@@ -41,7 +41,7 @@ fu_framework_qmk_device_detach(FuDevice *device, FuProgress *progress, GError **
 }
 
 static void
-fu_framework_qmk_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_framework_qmk_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/fresco-pd/fu-fresco-pd-device.c
+++ b/plugins/fresco-pd/fu-fresco-pd-device.c
@@ -402,7 +402,7 @@ fu_fresco_pd_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_fresco_pd_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_fresco_pd_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-device.c
@@ -742,7 +742,7 @@ fu_genesys_gl32xx_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_genesys_gl32xx_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_genesys_gl32xx_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/genesys/fu-genesys-scaler-device.c
+++ b/plugins/genesys/fu-genesys-scaler-device.c
@@ -1784,7 +1784,7 @@ fu_genesys_scaler_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_genesys_scaler_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_genesys_scaler_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/goodix-moc/fu-goodix-moc-device.c
+++ b/plugins/goodix-moc/fu-goodix-moc-device.c
@@ -422,7 +422,7 @@ fu_goodix_moc_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_goodix_moc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_goodix_moc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/goodix-tp/fu-goodixtp-hid-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-hid-device.c
@@ -115,7 +115,7 @@ fu_goodixtp_hid_device_set_report(FuGoodixtpHidDevice *self,
 }
 
 static void
-fu_goodixtp_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_goodixtp_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/hpi-cfu/fu-hpi-cfu-device.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-device.c
@@ -1474,7 +1474,7 @@ fu_hpi_cfu_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_hpi_cfu_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_hpi_cfu_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
+++ b/plugins/hughski-colorhug/fu-hughski-colorhug-device.c
@@ -572,7 +572,7 @@ fu_hughski_colorhug_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_hughski_colorhug_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_hughski_colorhug_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/ilitek-its/fu-ilitek-its-device.c
+++ b/plugins/ilitek-its/fu-ilitek-its-device.c
@@ -986,7 +986,7 @@ fu_ilitek_its_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_ilitek_its_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ilitek_its_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/intel-cvs/fu-intel-cvs-device.c
+++ b/plugins/intel-cvs/fu-intel-cvs-device.c
@@ -259,7 +259,7 @@ fu_intel_cvs_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_intel_cvs_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_intel_cvs_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/intel-gsc/fu-igsc-aux-device.c
+++ b/plugins/intel-gsc/fu-igsc-aux-device.c
@@ -174,7 +174,7 @@ fu_igsc_aux_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_igsc_aux_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_igsc_aux_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/intel-gsc/fu-igsc-device.c
+++ b/plugins/intel-gsc/fu-igsc-device.c
@@ -653,10 +653,10 @@ fu_igsc_device_wait_for_version(FuIgscDevice *self, GError **error)
 }
 
 static gboolean
-fu_igsc_device_reconnect_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_igsc_device_reconnect_cb(FuDevice *device, gpointer user_data, GError **error)
 {
-	fu_mei_device_disconnect(FU_MEI_DEVICE(self));
-	return fu_mei_device_connect(FU_MEI_DEVICE(self), FU_HECI_DEVICE_UUID_FWUPDATE, 0, error);
+	fu_mei_device_disconnect(FU_MEI_DEVICE(device));
+	return fu_mei_device_connect(FU_MEI_DEVICE(device), FU_HECI_DEVICE_UUID_FWUPDATE, 0, error);
 }
 
 static gboolean
@@ -832,7 +832,7 @@ fu_igsc_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_igsc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_igsc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/intel-gsc/fu-igsc-oprom-device.c
+++ b/plugins/intel-gsc/fu-igsc-oprom-device.c
@@ -269,7 +269,7 @@ fu_igsc_oprom_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_igsc_oprom_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_igsc_oprom_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/intel-usb4/fu-intel-usb4-device.c
+++ b/plugins/intel-usb4/fu-intel-usb4-device.c
@@ -566,7 +566,7 @@ fu_intel_usb4_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static void
-fu_intel_usb4_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_intel_usb4_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/jabra-file/fu-jabra-file-device.c
+++ b/plugins/jabra-file/fu-jabra-file-device.c
@@ -690,7 +690,7 @@ fu_jabra_file_device_attach(FuDevice *device, FuProgress *progress, GError **err
 }
 
 static void
-fu_jabra_file_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_jabra_file_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-child-device.c
@@ -373,7 +373,7 @@ fu_jabra_gnp_child_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_jabra_gnp_child_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_jabra_gnp_child_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/jabra-gnp/fu-jabra-gnp-common.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-common.c
@@ -78,7 +78,7 @@ fu_jabra_gnp_calculate_crc(GBytes *bytes)
 }
 
 gboolean
-fu_jabra_gnp_ensure_name(FuDevice *self, guint8 address, guint8 seq, GError **error)
+fu_jabra_gnp_ensure_name(FuDevice *device, guint8 address, guint8 seq, GError **error)
 {
 	FuJabraGnpTxData tx_data = {
 	    .txbuf =
@@ -99,7 +99,7 @@ fu_jabra_gnp_ensure_name(FuDevice *self, guint8 address, guint8 seq, GError **er
 	};
 	g_autofree gchar *name = NULL;
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -108,7 +108,7 @@ fu_jabra_gnp_ensure_name(FuDevice *self, guint8 address, guint8 seq, GError **er
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -124,12 +124,12 @@ fu_jabra_gnp_ensure_name(FuDevice *self, guint8 address, guint8 seq, GError **er
 			     error);
 	if (name == NULL)
 		return FALSE;
-	fu_device_set_name(FU_DEVICE(self), name);
+	fu_device_set_name(device, name);
 	return TRUE;
 }
 
 gboolean
-fu_jabra_gnp_ensure_battery_level(FuDevice *self, guint8 address, guint8 seq, GError **error)
+fu_jabra_gnp_ensure_battery_level(FuDevice *device, guint8 address, guint8 seq, GError **error)
 {
 	FuJabraGnpTxData tx_data = {
 	    .txbuf =
@@ -150,7 +150,7 @@ fu_jabra_gnp_ensure_battery_level(FuDevice *self, guint8 address, guint8 seq, GE
 	};
 	guint8 battery_level = 0;
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -159,7 +159,7 @@ fu_jabra_gnp_ensure_battery_level(FuDevice *self, guint8 address, guint8 seq, GE
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -177,13 +177,13 @@ fu_jabra_gnp_ensure_battery_level(FuDevice *self, guint8 address, guint8 seq, GE
 				    "battery level was 0");
 		return FALSE;
 	}
-	fu_device_set_battery_level(FU_DEVICE(self), battery_level);
-	fu_device_set_battery_threshold(FU_DEVICE(self), 30);
+	fu_device_set_battery_level(device, battery_level);
+	fu_device_set_battery_threshold(device, 30);
 	return TRUE;
 }
 
 gboolean
-fu_jabra_gnp_read_dfu_pid(FuDevice *self,
+fu_jabra_gnp_read_dfu_pid(FuDevice *device,
 			  guint8 address,
 			  guint8 seq,
 			  guint16 *dfu_pid,
@@ -207,7 +207,7 @@ fu_jabra_gnp_read_dfu_pid(FuDevice *self,
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -216,7 +216,7 @@ fu_jabra_gnp_read_dfu_pid(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -230,7 +230,7 @@ fu_jabra_gnp_read_dfu_pid(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_ensure_version(FuDevice *self, guint8 address, guint8 seq, GError **error)
+fu_jabra_gnp_ensure_version(FuDevice *device, guint8 address, guint8 seq, GError **error)
 {
 	FuJabraGnpTxData tx_data = {
 	    .txbuf =
@@ -251,7 +251,7 @@ fu_jabra_gnp_ensure_version(FuDevice *self, guint8 address, guint8 seq, GError *
 	};
 	g_autofree gchar *version = NULL;
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -260,7 +260,7 @@ fu_jabra_gnp_ensure_version(FuDevice *self, guint8 address, guint8 seq, GError *
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -288,12 +288,12 @@ fu_jabra_gnp_ensure_version(FuDevice *self, guint8 address, guint8 seq, GError *
 		 g_str_has_suffix(version, "8") || g_str_has_suffix(version, "9")))
 		version[strlen(version) - 1] = '\0';
 
-	fu_device_set_version(FU_DEVICE(self), version);
+	fu_device_set_version(device, version);
 	return TRUE;
 }
 
 gboolean
-fu_jabra_gnp_read_fwu_protocol(FuDevice *self,
+fu_jabra_gnp_read_fwu_protocol(FuDevice *device,
 			       guint8 address,
 			       guint8 seq,
 			       guint8 *fwu_protocol,
@@ -317,7 +317,7 @@ fu_jabra_gnp_read_fwu_protocol(FuDevice *self,
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -326,7 +326,7 @@ fu_jabra_gnp_read_fwu_protocol(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -349,7 +349,7 @@ fu_jabra_gnp_read_fwu_protocol(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_write_partition(FuDevice *self,
+fu_jabra_gnp_write_partition(FuDevice *device,
 			     guint8 address,
 			     guint8 seq,
 			     guint8 part,
@@ -374,7 +374,7 @@ fu_jabra_gnp_write_partition(FuDevice *self,
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -383,7 +383,7 @@ fu_jabra_gnp_write_partition(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -405,7 +405,7 @@ fu_jabra_gnp_write_partition(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_start(FuDevice *self, guint8 address, guint8 seq, GError **error)
+fu_jabra_gnp_start(FuDevice *device, guint8 address, guint8 seq, GError **error)
 {
 	FuJabraGnpTxData tx_data = {
 	    .txbuf =
@@ -425,7 +425,7 @@ fu_jabra_gnp_start(FuDevice *self, guint8 address, guint8 seq, GError **error)
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -434,7 +434,7 @@ fu_jabra_gnp_start(FuDevice *self, guint8 address, guint8 seq, GError **error)
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -456,7 +456,7 @@ fu_jabra_gnp_start(FuDevice *self, guint8 address, guint8 seq, GError **error)
 }
 
 gboolean
-fu_jabra_gnp_flash_erase_done(FuDevice *self, guint8 address, GError **error)
+fu_jabra_gnp_flash_erase_done(FuDevice *device, guint8 address, GError **error)
 {
 	const guint8 match_buf[FU_JABRA_GNP_BUF_SIZE] = {
 	    FU_JABRA_GNP_IFACE,
@@ -472,7 +472,7 @@ fu_jabra_gnp_flash_erase_done(FuDevice *self, guint8 address, GError **error)
 	    .timeout = FU_JABRA_GNP_EXTRA_LONG_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_cb
 				      : fu_jabra_gnp_device_rx_cb,
@@ -492,7 +492,7 @@ fu_jabra_gnp_flash_erase_done(FuDevice *self, guint8 address, GError **error)
 }
 
 gboolean
-fu_jabra_gnp_write_crc(FuDevice *self,
+fu_jabra_gnp_write_crc(FuDevice *device,
 		       guint8 address,
 		       guint8 seq,
 		       guint32 crc,
@@ -522,7 +522,7 @@ fu_jabra_gnp_write_crc(FuDevice *self,
 	fu_memwrite_uint16(tx_data.txbuf + 11, total_chunks, G_LITTLE_ENDIAN);
 	fu_memwrite_uint16(tx_data.txbuf + 13, preload_count, G_LITTLE_ENDIAN);
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -531,7 +531,7 @@ fu_jabra_gnp_write_crc(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -553,7 +553,7 @@ fu_jabra_gnp_write_crc(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_write_extended_crc(FuDevice *self,
+fu_jabra_gnp_write_extended_crc(FuDevice *device,
 				guint8 address,
 				guint8 seq,
 				guint32 crc,
@@ -584,7 +584,7 @@ fu_jabra_gnp_write_extended_crc(FuDevice *self,
 	fu_memwrite_uint16(tx_data.txbuf + 13, preload_count, G_LITTLE_ENDIAN);
 	fu_memwrite_uint32(tx_data.txbuf + 15, total_chunks, G_LITTLE_ENDIAN);
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -593,7 +593,7 @@ fu_jabra_gnp_write_extended_crc(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -615,7 +615,7 @@ fu_jabra_gnp_write_extended_crc(FuDevice *self,
 }
 
 static gboolean
-fu_jabra_gnp_write_chunk(FuDevice *self,
+fu_jabra_gnp_write_chunk(FuDevice *device,
 			 guint8 address,
 			 guint32 chunk_number,
 			 const guint8 *buf,
@@ -648,7 +648,7 @@ fu_jabra_gnp_write_chunk(FuDevice *self,
 			    bufsz,
 			    error))
 		return FALSE;
-	return fu_device_retry_full(FU_DEVICE(self),
+	return fu_device_retry_full(device,
 				    address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 					? fu_jabra_gnp_child_device_tx_cb
 					: fu_jabra_gnp_device_tx_cb,
@@ -659,7 +659,7 @@ fu_jabra_gnp_write_chunk(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_write_chunks(FuDevice *self,
+fu_jabra_gnp_write_chunks(FuDevice *device,
 			  guint8 address,
 			  FuChunkArray *chunks,
 			  FuProgress *progress,
@@ -692,7 +692,7 @@ fu_jabra_gnp_write_chunks(FuDevice *self,
 		chk = fu_chunk_array_index(chunks, chunk_number, error);
 		if (chk == NULL)
 			return FALSE;
-		if (!fu_jabra_gnp_write_chunk(self,
+		if (!fu_jabra_gnp_write_chunk(device,
 					      address,
 					      chunk_number,
 					      fu_chunk_get_data(chk),
@@ -701,7 +701,7 @@ fu_jabra_gnp_write_chunks(FuDevice *self,
 			return FALSE;
 		if (((chunk_number % FU_JABRA_GNP_PRELOAD_COUNT) == 0) ||
 		    (guint)chunk_number == fu_chunk_array_length(chunks) - 1) {
-			if (!fu_device_retry_full(FU_DEVICE(self),
+			if (!fu_device_retry_full(device,
 						  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 						      ? fu_jabra_gnp_child_device_rx_cb
 						      : fu_jabra_gnp_device_rx_cb,
@@ -735,7 +735,7 @@ fu_jabra_gnp_write_chunks(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_read_verify_status(FuDevice *self, guint8 address, GError **error)
+fu_jabra_gnp_read_verify_status(FuDevice *device, guint8 address, GError **error)
 {
 	const guint8 match_buf[FU_JABRA_GNP_BUF_SIZE] = {
 	    FU_JABRA_GNP_IFACE,
@@ -751,7 +751,7 @@ fu_jabra_gnp_read_verify_status(FuDevice *self, guint8 address, GError **error)
 	    .timeout = FU_JABRA_GNP_LONG_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_cb
 				      : fu_jabra_gnp_device_rx_cb,
@@ -771,7 +771,7 @@ fu_jabra_gnp_read_verify_status(FuDevice *self, guint8 address, GError **error)
 }
 
 gboolean
-fu_jabra_gnp_write_version(FuDevice *self,
+fu_jabra_gnp_write_version(FuDevice *device,
 			   guint8 address,
 			   guint8 seq,
 			   FuJabraGnpVersionData *version_data,
@@ -798,7 +798,7 @@ fu_jabra_gnp_write_version(FuDevice *self,
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -807,7 +807,7 @@ fu_jabra_gnp_write_version(FuDevice *self,
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,
@@ -829,7 +829,7 @@ fu_jabra_gnp_write_version(FuDevice *self,
 }
 
 gboolean
-fu_jabra_gnp_write_dfu_from_squif(FuDevice *self, guint8 address, guint8 seq, GError **error)
+fu_jabra_gnp_write_dfu_from_squif(FuDevice *device, guint8 address, guint8 seq, GError **error)
 {
 	FuJabraGnpTxData tx_data = {
 	    .txbuf =
@@ -849,7 +849,7 @@ fu_jabra_gnp_write_dfu_from_squif(FuDevice *self, guint8 address, guint8 seq, GE
 	    .timeout = FU_JABRA_GNP_STANDARD_RECEIVE_TIMEOUT,
 	};
 
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_tx_cb
 				      : fu_jabra_gnp_device_tx_cb,
@@ -858,7 +858,7 @@ fu_jabra_gnp_write_dfu_from_squif(FuDevice *self, guint8 address, guint8 seq, GE
 				  &tx_data,
 				  error))
 		return FALSE;
-	if (!fu_device_retry_full(FU_DEVICE(self),
+	if (!fu_device_retry_full(device,
 				  address == FU_JABRA_GNP_ADDRESS_OTA_CHILD
 				      ? fu_jabra_gnp_child_device_rx_with_sequence_cb
 				      : fu_jabra_gnp_device_rx_with_sequence_cb,

--- a/plugins/jabra-gnp/fu-jabra-gnp-device.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-device.c
@@ -534,7 +534,7 @@ fu_jabra_gnp_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_jabra_gnp_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_jabra_gnp_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-device.c
@@ -546,7 +546,7 @@ fu_kinetic_dp_puma_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_kinetic_dp_puma_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_kinetic_dp_puma_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-device.c
@@ -1005,7 +1005,7 @@ fu_kinetic_dp_secure_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_kinetic_dp_secure_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_kinetic_dp_secure_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/legion-hid2/fu-legion-hid2-iap-device.c
+++ b/plugins/legion-hid2/fu-legion-hid2-iap-device.c
@@ -355,7 +355,7 @@ fu_legion_hid2_iap_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_legion_hid2_iap_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_legion_hid2_iap_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-child.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-child.c
@@ -32,7 +32,7 @@ fu_logitech_bulkcontroller_child_write_firmware(FuDevice *device,
 }
 
 static void
-fu_logitech_bulkcontroller_child_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_bulkcontroller_child_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-device.c
@@ -1449,7 +1449,7 @@ fu_logitech_bulkcontroller_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_bulkcontroller_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_bulkcontroller_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-device.c
@@ -1935,7 +1935,7 @@ fu_logitech_hidpp_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_logitech_hidpp_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_hidpp_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-radio.c
@@ -76,7 +76,7 @@ fu_logitech_hidpp_radio_write_firmware(FuDevice *device,
 }
 
 static void
-fu_logitech_hidpp_radio_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_hidpp_radio_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-runtime-unifying.c
@@ -153,7 +153,7 @@ fu_logitech_hidpp_runtime_unifying_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_hidpp_runtime_unifying_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_hidpp_runtime_unifying_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-audio-device.c
@@ -110,7 +110,7 @@ fu_logitech_rallysystem_audio_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_rallysystem_audio_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_rallysystem_audio_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-tablehub-device.c
@@ -384,7 +384,7 @@ fu_logitech_rallysystem_tablehub_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_rallysystem_tablehub_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_rallysystem_tablehub_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -632,7 +632,7 @@ fu_logitech_scribe_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_scribe_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_scribe_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-hdmi-device.c
@@ -511,7 +511,7 @@ fu_logitech_tap_hdmi_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_tap_hdmi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_tap_hdmi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-sensor-device.c
@@ -314,7 +314,7 @@ fu_logitech_tap_sensor_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_logitech_tap_sensor_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_tap_sensor_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/logitech-tap/fu-logitech-tap-touch-device.c
+++ b/plugins/logitech-tap/fu-logitech-tap-touch-device.c
@@ -796,7 +796,7 @@ fu_logitech_tap_touch_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_logitech_tap_touch_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_logitech_tap_touch_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-device.c
@@ -887,13 +887,13 @@ fu_mediatek_scaler_device_prepare_firmware(FuDevice *device,
 }
 
 static gchar *
-fu_mediatek_scaler_device_convert_version(FuDevice *self, guint64 version_raw)
+fu_mediatek_scaler_device_convert_version(FuDevice *device, guint64 version_raw)
 {
 	return fu_mediatek_scaler_version_to_string(version_raw);
 }
 
 static void
-fu_mediatek_scaler_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mediatek_scaler_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/modem-manager/fu-mm-dfota-device.c
+++ b/plugins/modem-manager/fu-mm-dfota-device.c
@@ -456,7 +456,7 @@ fu_mm_dfota_device_cleanup(FuDevice *device,
 }
 
 static void
-fu_mm_dfota_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_dfota_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-fastboot-device.c
+++ b/plugins/modem-manager/fu-mm-fastboot-device.c
@@ -97,7 +97,7 @@ fu_mm_fastboot_device_add_json(FuDevice *device, JsonBuilder *builder, FwupdCode
 }
 
 static void
-fu_mm_fastboot_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_fastboot_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-fdl-device.c
+++ b/plugins/modem-manager/fu-mm-fdl-device.c
@@ -337,7 +337,7 @@ fu_mm_fdl_device_cleanup(FuDevice *device,
 }
 
 static void
-fu_mm_fdl_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_fdl_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-firehose-device.c
+++ b/plugins/modem-manager/fu-mm-firehose-device.c
@@ -63,7 +63,7 @@ fu_mm_firehose_device_cleanup(FuDevice *device,
 }
 
 static void
-fu_mm_firehose_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_firehose_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-mhi-qcdm-device.c
@@ -167,7 +167,7 @@ fu_mm_mhi_qcdm_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_mm_mhi_qcdm_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_mhi_qcdm_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-qcdm-device.c
+++ b/plugins/modem-manager/fu-mm-qcdm-device.c
@@ -90,7 +90,7 @@ fu_mm_qcdm_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_mm_qcdm_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_qcdm_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/modem-manager/fu-mm-qmi-device.c
+++ b/plugins/modem-manager/fu-mm-qmi-device.c
@@ -918,7 +918,7 @@ fu_mm_qmi_device_cleanup(FuDevice *device,
 }
 
 static void
-fu_mm_qmi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_mm_qmi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -1402,7 +1402,7 @@ fu_nordic_hid_cfg_channel_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_nordic_hid_cfg_channel_set_progress(FuDevice *self, FuProgress *progress)
+fu_nordic_hid_cfg_channel_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -525,7 +525,7 @@ fu_nvme_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 }
 
 static void
-fu_nvme_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_nvme_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/parade-lspcon/fu-parade-lspcon-device.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-device.c
@@ -887,7 +887,7 @@ fu_parade_lspcon_device_dump_firmware(FuDevice *device, FuProgress *progress, GE
 }
 
 static void
-fu_parade_lspcon_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_parade_lspcon_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/parade-usbhub/fu-parade-usbhub-device.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-device.c
@@ -1216,7 +1216,7 @@ fu_parade_usbhub_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_parade_usbhub_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_parade_usbhub_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/pixart-rf/fu-pxi-ble-device.c
+++ b/plugins/pixart-rf/fu-pxi-ble-device.c
@@ -901,7 +901,7 @@ fu_pxi_ble_device_setup(FuDevice *device, GError **error)
 }
 
 static void
-fu_pxi_ble_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_pxi_ble_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/pixart-rf/fu-pxi-receiver-device.c
+++ b/plugins/pixart-rf/fu-pxi-receiver-device.c
@@ -850,7 +850,7 @@ fu_pxi_receiver_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_pxi_receiver_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_pxi_receiver_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/pixart-rf/fu-pxi-wireless-device.c
+++ b/plugins/pixart-rf/fu-pxi-wireless-device.c
@@ -40,9 +40,9 @@ fu_pxi_wireless_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static FuPxiReceiverDevice *
-fu_pxi_wireless_device_get_parent(FuDevice *self, GError **error)
+fu_pxi_wireless_device_get_parent(FuDevice *device, GError **error)
 {
-	FuDevice *parent = fu_device_get_parent(FU_DEVICE(self));
+	FuDevice *parent = fu_device_get_parent(device);
 	if (parent == NULL) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "no parent set");
 		return NULL;
@@ -765,7 +765,7 @@ fu_pxi_wireless_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_pxi_wireless_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_pxi_wireless_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/qc-firehose/fu-qc-firehose-usb-device.c
+++ b/plugins/qc-firehose/fu-qc-firehose-usb-device.c
@@ -269,7 +269,7 @@ fu_qc_firehose_usb_device_replace(FuDevice *device, FuDevice *donor)
 }
 
 static void
-fu_qc_firehose_usb_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_qc_firehose_usb_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-device.c
@@ -711,7 +711,7 @@ fu_qc_s5gen2_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_qc_s5gen2_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_qc_s5gen2_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
+++ b/plugins/qsi-dock/fu-qsi-dock-mcu-device.c
@@ -565,7 +565,7 @@ fu_qsi_dock_mcu_device_attach(FuDevice *device, FuProgress *progress, GError **e
 }
 
 static void
-fu_qsi_dock_mcu_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_qsi_dock_mcu_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/realtek-mst/fu-realtek-mst-device.c
+++ b/plugins/realtek-mst/fu-realtek-mst-device.c
@@ -793,7 +793,7 @@ fu_realtek_mst_device_attach(FuDevice *device, FuProgress *progress, GError **er
 }
 
 static void
-fu_realtek_mst_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_realtek_mst_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/redfish/fu-redfish-hpe-device.c
+++ b/plugins/redfish/fu-redfish-hpe-device.c
@@ -299,7 +299,7 @@ fu_redfish_hpe_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_redfish_hpe_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_redfish_hpe_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 3, "prepare-fw");

--- a/plugins/redfish/fu-redfish-legacy-device.c
+++ b/plugins/redfish/fu-redfish-legacy-device.c
@@ -120,7 +120,7 @@ fu_redfish_legacy_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_redfish_legacy_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_redfish_legacy_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/redfish/fu-redfish-multipart-device.c
+++ b/plugins/redfish/fu-redfish-multipart-device.c
@@ -171,7 +171,7 @@ fu_redfish_multipart_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_redfish_multipart_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_redfish_multipart_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/redfish/fu-redfish-smc-device.c
+++ b/plugins/redfish/fu-redfish-smc-device.c
@@ -224,7 +224,7 @@ fu_redfish_smc_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_redfish_smc_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_redfish_smc_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/rp-pico/fu-rp-pico-device.c
+++ b/plugins/rp-pico/fu-rp-pico-device.c
@@ -80,7 +80,7 @@ fu_rp_pico_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_rp_pico_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_rp_pico_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -568,7 +568,7 @@ fu_rts54hub_device_prepare_firmware(FuDevice *device,
 }
 
 static void
-fu_rts54hub_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_rts54hub_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/scsi/fu-scsi-device.c
+++ b/plugins/scsi/fu-scsi-device.c
@@ -434,7 +434,7 @@ fu_scsi_device_set_quirk_kv(FuDevice *device, const gchar *key, const gchar *val
 }
 
 static void
-fu_scsi_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_scsi_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/steelseries/fu-steelseries-fizz-tunnel.c
+++ b/plugins/steelseries/fu-steelseries-fizz-tunnel.c
@@ -421,7 +421,7 @@ fu_steelseries_fizz_tunnel_read_firmware(FuDevice *device, FuProgress *progress,
 }
 
 static void
-fu_steelseries_fizz_tunnel_set_progress(FuDevice *self, FuProgress *progress)
+fu_steelseries_fizz_tunnel_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/steelseries/fu-steelseries-fizz.c
+++ b/plugins/steelseries/fu-steelseries-fizz.c
@@ -699,7 +699,7 @@ fu_steelseries_fizz_read_firmware(FuDevice *device, FuProgress *progress, GError
 }
 
 static void
-fu_steelseries_fizz_set_progress(FuDevice *self, FuProgress *progress)
+fu_steelseries_fizz_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/steelseries/fu-steelseries-fizz.h
+++ b/plugins/steelseries/fu-steelseries-fizz.h
@@ -14,9 +14,6 @@
 #define FU_TYPE_STEELSERIES_FIZZ (fu_steelseries_fizz_get_type())
 G_DECLARE_FINAL_TYPE(FuSteelseriesFizz, fu_steelseries_fizz, FU, STEELSERIES_FIZZ, FuUsbDevice)
 
-FuSteelseriesFizz *
-fu_steelseries_fizz_new(FuDevice *self);
-
 #define FU_STEELSERIES_FIZZ_BATTERY_LEVEL_CHARGING_BIT 0x80U
 #define FU_STEELSERIES_FIZZ_BATTERY_LEVEL_STATUS_BITS  0x7fU
 

--- a/plugins/steelseries/fu-steelseries-gamepad.c
+++ b/plugins/steelseries/fu-steelseries-gamepad.c
@@ -263,7 +263,7 @@ fu_steelseries_gamepad_write_firmware(FuDevice *device,
 }
 
 static void
-fu_steelseries_gamepad_set_progress(FuDevice *self, FuProgress *progress)
+fu_steelseries_gamepad_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/steelseries/fu-steelseries-sonic.c
+++ b/plugins/steelseries/fu-steelseries-sonic.c
@@ -904,7 +904,7 @@ fu_steelseries_sonic_prepare_firmware(FuDevice *device,
 }
 
 static void
-fu_steelseries_sonic_set_progress(FuDevice *self, FuProgress *progress)
+fu_steelseries_sonic_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-cape/fu-synaptics-cape-device.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-device.c
@@ -631,7 +631,7 @@ fu_synaptics_cape_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_synaptics_cape_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaptics_cape_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-device.c
@@ -867,7 +867,7 @@ fu_synaptics_cxaudio_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_synaptics_cxaudio_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaptics_cxaudio_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -1832,7 +1832,7 @@ fu_synaptics_mst_device_set_quirk_kv(FuDevice *device,
 }
 
 static void
-fu_synaptics_mst_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaptics_mst_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-prometheus/fu-synaprom-device.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-device.c
@@ -471,7 +471,7 @@ fu_synaprom_device_detach(FuDevice *device, FuProgress *progress, GError **error
 }
 
 static void
-fu_synaprom_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaprom_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-hid-device.c
@@ -522,7 +522,7 @@ fu_synaptics_rmi_hid_device_query_status(FuSynapticsRmiDevice *rmi_device, GErro
 }
 
 static void
-fu_synaptics_rmi_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaptics_rmi_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-device.c
@@ -61,7 +61,7 @@ typedef struct {
 } FuSynapticsVmm9DeviceCommandHelper;
 
 static gboolean
-fu_synaptics_vmm9_device_command_cb(FuDevice *self, gpointer user_data, GError **error)
+fu_synaptics_vmm9_device_command_cb(FuDevice *device, gpointer user_data, GError **error)
 {
 	FuSynapticsVmm9DeviceCommandHelper *helper =
 	    (FuSynapticsVmm9DeviceCommandHelper *)user_data;
@@ -70,7 +70,7 @@ fu_synaptics_vmm9_device_command_cb(FuDevice *self, gpointer user_data, GError *
 	g_autoptr(FuStructHidPayload) st_payload = NULL;
 
 	/* get, and parse */
-	if (!fu_hid_device_get_report(FU_HID_DEVICE(self),
+	if (!fu_hid_device_get_report(FU_HID_DEVICE(device),
 				      FU_STRUCT_HID_GET_COMMAND_DEFAULT_ID,
 				      buf,
 				      sizeof(buf),
@@ -652,7 +652,7 @@ fu_synaptics_vmm9_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_synaptics_vmm9_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_synaptics_vmm9_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/system76-launch/fu-system76-launch-device.c
+++ b/plugins/system76-launch/fu-system76-launch-device.c
@@ -231,7 +231,7 @@ fu_system76_launch_device_detach(FuDevice *device, FuProgress *progress, GError 
 }
 
 static void
-fu_system76_launch_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_system76_launch_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -207,7 +207,7 @@ fu_telink_dfu_ble_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_telink_dfu_ble_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_telink_dfu_ble_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/telink-dfu/fu-telink-dfu-hid-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-hid-device.c
@@ -347,7 +347,7 @@ fu_telink_dfu_hid_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_telink_dfu_hid_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_telink_dfu_hid_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/test/fu-test-device.c
+++ b/plugins/test/fu-test-device.c
@@ -15,7 +15,7 @@ struct _FuTestDevice {
 G_DEFINE_TYPE(FuTestDevice, fu_test_device, FU_TYPE_DEVICE)
 
 static void
-fu_test_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_test_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 1, "prepare-fw");

--- a/plugins/thelio-io/fu-thelio-io-device.c
+++ b/plugins/thelio-io/fu-thelio-io-device.c
@@ -89,7 +89,7 @@ fu_thelio_io_device_detach(FuDevice *device, FuProgress *progress, GError **erro
 }
 
 static void
-fu_thelio_io_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_thelio_io_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -396,7 +396,7 @@ fu_thunderbolt_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_thunderbolt_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_thunderbolt_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 17, "prepare-fw");

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-device.c
@@ -738,7 +738,7 @@ fu_ti_tps6598x_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_ti_tps6598x_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ti_tps6598x_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-pd-device.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-pd-device.c
@@ -166,7 +166,7 @@ fu_ti_tps6598x_pd_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_ti_tps6598x_pd_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_ti_tps6598x_pd_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -745,7 +745,7 @@ fu_uefi_capsule_device_set_property(GObject *object,
 }
 
 static void
-fu_uefi_capsule_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uefi_capsule_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/uefi-db/fu-uefi-db-device.c
+++ b/plugins/uefi-db/fu-uefi-db-device.c
@@ -131,7 +131,7 @@ fu_uefi_db_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
 }
 
 static void
-fu_uefi_db_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uefi_db_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -258,7 +258,7 @@ fu_uefi_dbx_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_uefi_dbx_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uefi_dbx_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");
@@ -269,12 +269,14 @@ fu_uefi_dbx_device_set_progress(FuDevice *self, FuProgress *progress)
 }
 
 static gboolean
-fu_uefi_dbx_device_cleanup(FuDevice *self,
+fu_uefi_dbx_device_cleanup(FuDevice *device,
 			   FuProgress *progress,
 			   FwupdInstallFlags flags,
 			   GError **error)
 {
-	if (!fu_uefi_dbx_device_maybe_notify_snapd_cleanup(FU_UEFI_DBX_DEVICE(self), error))
+	FuUefiDbxDevice *self = FU_UEFI_DBX_DEVICE(device);
+
+	if (!fu_uefi_dbx_device_maybe_notify_snapd_cleanup(self, error))
 		return FALSE;
 
 	return TRUE;

--- a/plugins/uefi-kek/fu-uefi-kek-device.c
+++ b/plugins/uefi-kek/fu-uefi-kek-device.c
@@ -92,7 +92,7 @@ fu_uefi_kek_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_uefi_kek_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uefi_kek_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/uefi-sbat/fu-uefi-sbat-device.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-device.c
@@ -185,7 +185,7 @@ fu_uefi_sbat_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_uefi_sbat_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uefi_sbat_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -385,7 +385,7 @@ fu_uf2_device_replace(FuDevice *device, FuDevice *donor)
 }
 
 static void
-fu_uf2_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_uf2_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/usi-dock/fu-usi-dock-mcu-device.c
+++ b/plugins/usi-dock/fu-usi-dock-mcu-device.c
@@ -795,7 +795,7 @@ fu_usi_dock_mcu_device_replace(FuDevice *device, FuDevice *donor)
 }
 
 static void
-fu_usi_dock_mcu_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_usi_dock_mcu_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -442,7 +442,7 @@ fu_vbe_simple_device_upload(FuDevice *device, FuProgress *progress, GError **err
 }
 
 static void
-fu_vbe_simple_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vbe_simple_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -878,7 +878,7 @@ fu_vli_pd_device_kind_changed_cb(FuVliDevice *device, GParamSpec *pspec, gpointe
 }
 
 static void
-fu_vli_pd_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_pd_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/vli/fu-vli-pd-parade-device.c
+++ b/plugins/vli/fu-vli-pd-parade-device.c
@@ -698,7 +698,7 @@ fu_vli_pd_parade_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_vli_pd_parade_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_pd_parade_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -1401,7 +1401,7 @@ fu_vli_usbhub_device_write_firmware(FuDevice *device,
 }
 
 static void
-fu_vli_usbhub_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_usbhub_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/vli/fu-vli-usbhub-msp430-device.c
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.c
@@ -316,7 +316,7 @@ fu_vli_usbhub_msp430_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_vli_usbhub_msp430_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_usbhub_msp430_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/vli/fu-vli-usbhub-pd-device.c
+++ b/plugins/vli/fu-vli-usbhub-pd-device.c
@@ -282,7 +282,7 @@ fu_vli_usbhub_pd_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_vli_usbhub_pd_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_usbhub_pd_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.c
@@ -527,7 +527,7 @@ fu_vli_usbhub_rtd21xx_device_probe(FuDevice *device, GError **error)
 }
 
 static void
-fu_vli_usbhub_rtd21xx_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_vli_usbhub_rtd21xx_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_flag(progress, FU_PROGRESS_FLAG_GUESSED);

--- a/plugins/wacom-raw/fu-wacom-raw-device.c
+++ b/plugins/wacom-raw/fu-wacom-raw-device.c
@@ -364,7 +364,7 @@ fu_wacom_raw_device_replace(FuDevice *device, FuDevice *donor)
 }
 
 static void
-fu_wacom_raw_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_wacom_raw_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -927,7 +927,7 @@ fu_wac_device_close(FuDevice *device, GError **error)
 }
 
 static void
-fu_wac_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_wac_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/wacom-usb/fu-wac-module-sub-cpu.c
+++ b/plugins/wacom-usb/fu-wac-module-sub-cpu.c
@@ -206,7 +206,7 @@ fu_wac_module_sub_cpu_write_firmware(FuDevice *device,
 }
 
 static FuFirmware *
-fu_wac_module_sub_cpu_prepare_firmware(FuDevice *self,
+fu_wac_module_sub_cpu_prepare_firmware(FuDevice *device,
 				       GInputStream *stream,
 				       FuProgress *progress,
 				       FuFirmwareParseFlags flags,

--- a/plugins/wacom-usb/fu-wac-module.c
+++ b/plugins/wacom-usb/fu-wac-module.c
@@ -309,7 +309,7 @@ fu_wac_module_constructed(GObject *object)
 }
 
 static void
-fu_wac_module_set_progress(FuDevice *self, FuProgress *progress)
+fu_wac_module_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -795,7 +795,7 @@ fu_wistron_dock_device_attach(FuDevice *device, FuProgress *progress, GError **e
 }
 
 static void
-fu_wistron_dock_device_set_progress(FuDevice *self, FuProgress *progress)
+fu_wistron_dock_device_set_progress(FuDevice *device, FuProgress *progress)
 {
 	fu_progress_set_id(progress, G_STRLOC);
 	fu_progress_add_step(progress, FWUPD_STATUS_DECOMPRESSING, 0, "prepare-fw");

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -721,6 +721,7 @@ fu_device_list_clear_wait_for_replug(FuDeviceList *self, FuDeviceItem *item)
 	g_debug("\n%s", str);
 }
 
+/* nocheck:name */
 static void
 _fu_device_incorporate_problem_update_in_progress(FuDevice *self, FuDevice *donor)
 {

--- a/src/fu-engine-requirements.c
+++ b/src/fu-engine-requirements.c
@@ -243,6 +243,7 @@ fu_engine_requirements_check_vendor_id(FuEngine *self,
 	return TRUE;
 }
 
+/* nocheck:name */
 static gboolean
 _fu_device_has_guids_any(FuDevice *self, gchar **guids)
 {


### PR DESCRIPTION
This fixes some potential "type reduction" bugs where everything is pushed down into a `FuDevice`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
