### PR TITLE
trivial: Use fu_memread_uint32() in more places to be endian safe

### DIFF
--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -141,11 +141,11 @@ fu_cab_firmware_compute_checksum(const guint8 *buf, gsize bufsz, guint32 *checks
 	for (gsize i = 0; i < bufsz; i += 4) {
 		gsize chunksz = bufsz - i;
 		if (G_LIKELY(chunksz >= 4)) {
-			/* 3,2,1,0 */
+			/* 3,2,1,0 nocheck:endian */
 			tmp ^= ((guint32)buf[i + 3] << 24) | ((guint32)buf[i + 2] << 16) |
 			       ((guint32)buf[i + 1] << 8) | (guint32)buf[i + 0];
 		} else if (chunksz == 3) {
-			/* 0,1,2 -- yes, weird */
+			/* 0,1,2 -- yes, weird, nocheck:endian */
 			tmp ^= ((guint32)buf[i + 0] << 16) | ((guint32)buf[i + 1] << 8) |
 			       (guint32)buf[i + 2];
 		} else if (chunksz == 2) {

--- a/plugins/dell-dock/fu-dell-dock-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-mst.c
@@ -570,8 +570,8 @@ fu_dell_dock_mst_checksum_bank(FuDevice *device,
 					    error))
 		return FALSE;
 	data = g_bytes_get_data(csum_bytes, NULL);
-	bank_sum = GUINT32_FROM_LE(data[0] | data[1] << 8 | data[2] << 16 | /* nocheck:blocked */
-				   data[3] << 24);
+	bank_sum = GUINT32_FROM_LE(data[0] | data[1] << 8 | /* nocheck:blocked nocheck:endian */
+				   data[2] << 16 | data[3] << 24);
 	g_debug("MST: Bank %u checksum: 0x%x", bank, bank_sum);
 
 	*checksum = (bank_sum == payload_sum);

--- a/plugins/emmc/fu-emmc-device.c
+++ b/plugins/emmc/fu-emmc-device.c
@@ -393,8 +393,7 @@ fu_emmc_device_write_firmware(FuDevice *device,
 	check_sect_done = (ext_csd[EXT_CSD_FFU_FEATURES] & 1) > 0;
 
 	/* set CMD ARG */
-	arg = ext_csd[EXT_CSD_FFU_ARG_0] | ext_csd[EXT_CSD_FFU_ARG_1] << 8 |
-	      ext_csd[EXT_CSD_FFU_ARG_2] << 16 | ext_csd[EXT_CSD_FFU_ARG_3] << 24;
+	arg = fu_memread_uint32(ext_csd + EXT_CSD_FFU_ARG_0, G_LITTLE_ENDIAN);
 
 	/* prepare multi_cmd to be sent */
 	multi_cmdsz = sizeof(struct mmc_ioc_multi_cmd) + 4 * sizeof(struct mmc_ioc_cmd);
@@ -484,11 +483,8 @@ fu_emmc_device_write_firmware(FuDevice *device,
 		if (!fu_emmc_device_read_extcsd(self, ext_csd, sizeof(ext_csd), error))
 			return FALSE;
 
-		sect_done = ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_0] |
-			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_1] << 8 |
-			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_2] << 16 |
-			    ext_csd[EXT_CSD_NUM_OF_FW_SEC_PROG_3] << 24;
-
+		sect_done =
+		    fu_memread_uint32(ext_csd + EXT_CSD_NUM_OF_FW_SEC_PROG_0, G_LITTLE_ENDIAN);
 		if (sect_done != 0)
 			break;
 

--- a/plugins/logitech-scribe/fu-logitech-scribe-device.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-device.c
@@ -598,7 +598,7 @@ fu_logitech_scribe_device_ensure_version(FuLogitechScribeDevice *self, GError **
 						      error))
 		return FALSE;
 
-	/*  little-endian data. MinorVersion byte 0, MajorVersion byte 1, BuildVersion byte 3 & 2 */
+	/*  nocheck:endian -- MinorVersion byte 0, MajorVersion byte 1, BuildVersion byte 3 & 2 */
 	fwversion =
 	    (query_data[1] << 24) + (query_data[0] << 16) + (query_data[3] << 8) + query_data[2];
 	fu_device_set_version_raw(FU_DEVICE(self), fwversion);


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
