### PR TITLE
mtd: Ignore all the Intel GPU MTD devices

### DIFF
--- a/plugins/mtd/README.md
+++ b/plugins/mtd/README.md
@@ -27,6 +27,7 @@ be used instead, e.g.
 * `MTD\NAME_Factory`
 * `MTD\VEN_1234&DEV_5678`
 * `MTD\VEN_1234&DEV_5678&NAME_Factory`
+* `MTD\DRIVER_xe` (quirk-only)
 
 If the `FirmwareGType` quirk is set for the device then the firmware is read back from the device at
 daemon startup and parsed for the version number.

--- a/plugins/mtd/mtd.quirk
+++ b/plugins/mtd/mtd.quirk
@@ -23,3 +23,7 @@ Name = PCH SPI Controller
 [MTD\VEN_1677&DEV_28A4]
 Flags = ~needs-reboot,needs-shutdown,usable-during-update,unsigned-payload
 VersionFormat = number
+
+# Intel GPUs
+[MTD\DRIVER_xe]
+Flags = no-probe


### PR DESCRIPTION
We already have an intel-gsc plugin at home.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
