### PR TITLE
Increase USB write timeout for huddly products from 2 to 5 seconds

### DIFF
--- a/plugins/huddly-usb/fu-huddly-usb-device.c
+++ b/plugins/huddly-usb/fu-huddly-usb-device.c
@@ -93,7 +93,7 @@ fu_huddly_usb_device_bulk_write(FuHuddlyUsbDevice *self,
 						 src->data + offset,
 						 chunk_size,
 						 &transmitted,
-						 3000,
+						 5000,
 						 NULL,
 						 error)) {
 			return FALSE;


### PR DESCRIPTION
USB timeouts were sometimes observed during testing of C1 upgrade. Increasing the timeout of write operations seems to fix this.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
