### PR TITLE
plugins/nvme: Add quirk entry for Maxio SSDs

### DIFF
--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -56,6 +56,11 @@ Flags = needs-shutdown
 Flags = ensure-semver,commit-ca3
 NvmeSerialSuffixChars = 5
 
+# Maxio
+[NVME\VEN_1E4B]
+Flags = ensure-semver,commit-ca3
+NvmeSerialSuffixChars = 5
+
 [NVME\VEN_144D&DEV_A80A&VER_2B2QGXA7]
 Issue = https://www.pugetsystems.com/support/guides/critical-samsung-ssd-firmware-update/
 [NVME\VEN_144D&DEV_A80A&VER_3B2QGXA7]


### PR DESCRIPTION
Lexar and Maxio seem to make SSDs together, and choose at random who's vendor ID to use.

Copy Lexar's quirk to Maxio so they can both be updated.


