### PR TITLE
Allow fu_input_stream_find() to work on streams larger than 0x10000

### DIFF
--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -738,7 +738,7 @@ fu_input_stream_find(GInputStream *stream,
 	g_return_val_if_fail(bufsz < blocksz, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	while (offset_cur < bufsz) {
+	while (TRUE) {
 		g_autoptr(GByteArray) buf_tmp = NULL;
 		g_autoptr(GError) error_local = NULL;
 


### PR DESCRIPTION
When we reach the end of the stream we'll hit the FWUPD_ERROR_INVALID_FILE case.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
