### PR TITLE
Improve firmware stream searching speed by a huge amount

### DIFF
--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -327,6 +327,22 @@ fu_efi_signature_list_write(FuFirmware *firmware, GError **error)
 	return g_steal_pointer(&buf);
 }
 
+static void
+fu_efi_signature_list_add_magic(FuFirmware *firmware)
+{
+	fwupd_guid_t guid = {0};
+	fwupd_guid_from_string(FU_EFI_SIGNATURE_LIST_GUID_SHA256,
+			       &guid,
+			       FWUPD_GUID_FLAG_MIXED_ENDIAN,
+			       NULL);
+	fu_firmware_add_magic(firmware, guid, sizeof(guid), 0x0);
+	fwupd_guid_from_string(FU_EFI_SIGNATURE_LIST_GUID_X509,
+			       &guid,
+			       FWUPD_GUID_FLAG_MIXED_ENDIAN,
+			       NULL);
+	fu_firmware_add_magic(firmware, guid, sizeof(guid), 0x0);
+}
+
 /**
  * fu_efi_signature_list_new:
  *
@@ -347,6 +363,7 @@ fu_efi_signature_list_class_init(FuEfiSignatureListClass *klass)
 	firmware_class->validate = fu_efi_signature_list_validate;
 	firmware_class->parse = fu_efi_signature_list_parse;
 	firmware_class->write = fu_efi_signature_list_write;
+	firmware_class->add_magic = fu_efi_signature_list_add_magic;
 }
 
 static void

--- a/libfwupdplugin/fu-efi-variable-authentication2.c
+++ b/libfwupdplugin/fu-efi-variable-authentication2.c
@@ -224,6 +224,16 @@ fu_efi_variable_authentication2_write(FuFirmware *firmware, GError **error)
 }
 
 static void
+fu_efi_variable_authentication2_add_magic(FuFirmware *firmware)
+{
+	fu_firmware_add_magic(firmware,
+			      (const guint8 *)FU_STRUCT_EFI_WIN_CERTIFICATE_DEFAULT_GUID,
+			      sizeof(fwupd_guid_t),
+			      FU_STRUCT_EFI_VARIABLE_AUTHENTICATION2_OFFSET_AUTH_INFO +
+				  FU_STRUCT_EFI_WIN_CERTIFICATE_OFFSET_GUID);
+}
+
+static void
 fu_efi_variable_authentication2_init(FuEfiVariableAuthentication2 *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALWAYS_SEARCH);
@@ -249,4 +259,5 @@ fu_efi_variable_authentication2_class_init(FuEfiVariableAuthentication2Class *kl
 	firmware_class->parse = fu_efi_variable_authentication2_parse;
 	firmware_class->export = fu_efi_variable_authentication2_export;
 	firmware_class->write = fu_efi_variable_authentication2_write;
+	firmware_class->add_magic = fu_efi_variable_authentication2_add_magic;
 }

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -48,6 +48,7 @@ typedef struct {
 	guint depth;
 	GPtrArray *chunks;  /* nullable, element-type FuChunk */
 	GPtrArray *patches; /* nullable, element-type FuFirmwarePatch */
+	GPtrArray *magic;   /* nullable, element-type FuFirmwarePatch */
 } FuFirmwarePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuFirmware, fu_firmware, G_TYPE_OBJECT)
@@ -818,6 +819,35 @@ fu_firmware_add_chunk(FuFirmware *self, FuChunk *chk)
 }
 
 /**
+ * fu_firmware_add_magic:
+ * @self: a #FuFirmware
+ * @buf: some data
+ * @bufsz: sizeof @buf
+ * @offset: offset to start parsing, typically 0x0
+ *
+ * Adds a possible magic signature to the image.
+ *
+ * Since: 2.0.18
+ **/
+void
+fu_firmware_add_magic(FuFirmware *self, const guint8 *buf, gsize bufsz, gsize offset)
+{
+	FuFirmwarePrivate *priv = GET_PRIVATE(self);
+	g_autofree FuFirmwarePatch *patch = g_new0(FuFirmwarePatch, 1);
+
+	g_return_if_fail(FU_IS_FIRMWARE(self));
+	g_return_if_fail(buf != NULL);
+	g_return_if_fail(bufsz != 0);
+
+	if (priv->magic == NULL)
+		priv->magic =
+		    g_ptr_array_new_with_free_func((GDestroyNotify)fu_firmware_patch_free);
+	patch->blob = g_bytes_new(buf, bufsz);
+	patch->offset = offset;
+	g_ptr_array_add(priv->magic, g_steal_pointer(&patch));
+}
+
+/**
  * fu_firmware_get_checksum:
  * @self: a #FuPlugin
  * @csum_kind: a checksum type, e.g. %G_CHECKSUM_SHA256
@@ -941,11 +971,13 @@ fu_firmware_check_compatible(FuFirmware *self,
 static gboolean
 fu_firmware_validate_for_offset(FuFirmware *self,
 				GInputStream *stream,
-				gsize *offset,
+				gsize offset,
+				gsize *offset_found,
 				FuFirmwareParseFlags flags,
 				GError **error)
 {
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
+	FuFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize streamsz = 0;
 
 	/* not implemented */
@@ -955,38 +987,50 @@ fu_firmware_validate_for_offset(FuFirmware *self,
 	/* fuzzing */
 	if (!fu_firmware_has_flag(self, FU_FIRMWARE_FLAG_ALWAYS_SEARCH) &&
 	    (flags & FU_FIRMWARE_PARSE_FLAG_NO_SEARCH) > 0) {
-		if (!klass->validate(self, stream, *offset, error))
-			return FALSE;
-		return TRUE;
+		return klass->validate(self, stream, offset, error);
 	}
 
-	/* limit the size of firmware we search */
+	/* try all the magic values, if provided */
+	if (priv->magic != NULL) {
+		for (guint i = 0; i < priv->magic->len; i++) {
+			FuFirmwarePatch *patch = g_ptr_array_index(priv->magic, i);
+			gsize offset_tmp = 0;
+			g_debug("searching for 0x%x bytes of magic",
+				(guint)g_bytes_get_size(patch->blob));
+			if (fu_input_stream_find(stream,
+						 g_bytes_get_data(patch->blob, NULL),
+						 g_bytes_get_size(patch->blob),
+						 offset,
+						 &offset_tmp,
+						 NULL)) {
+				offset_tmp -= patch->offset;
+				g_debug("found magic @0x%x", (guint)offset_tmp);
+				if (offset_found != NULL)
+					*offset_found = offset_tmp;
+				return klass->validate(self, stream, *offset_found, error);
+			}
+		}
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "failed to find magic bytes");
+		return FALSE;
+	}
+
+	/* limit the size of firmware we search as brute force is expensive */
 	if (!fu_input_stream_size(stream, &streamsz, error))
 		return FALSE;
-	if (streamsz > FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX) {
-		if (!klass->validate(self, stream, *offset, error)) {
-			g_prefix_error(error,
-				       "failed to search for magic as firmware size was 0x%x and "
-				       "limit was 0x%x: ",
-				       (guint)streamsz,
-				       (guint)FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX);
-			return FALSE;
-		}
-		return TRUE;
-	}
-
-	/* increment the offset, looking for the magic */
-	for (gsize offset_tmp = *offset; offset_tmp < streamsz; offset_tmp++) {
-		if (klass->validate(self, stream, offset_tmp, NULL)) {
-			fu_firmware_set_offset(self, offset_tmp);
-			*offset = offset_tmp;
-			return TRUE;
+	if (streamsz < FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX) {
+		for (gsize offset_tmp = offset; offset_tmp < streamsz; offset_tmp++) {
+			if (klass->validate(self, stream, offset_tmp, NULL)) {
+				*offset_found = offset_tmp;
+				return TRUE;
+			}
 		}
 	}
 
-	/* did not find what we were looking for */
-	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "did not find magic");
-	return FALSE;
+	/* check in more detail */
+	return klass->validate(self, stream, offset, error);
 }
 
 /**
@@ -1054,8 +1098,9 @@ fu_firmware_parse_stream(FuFirmware *self,
 	}
 
 	/* optional */
-	if (!fu_firmware_validate_for_offset(self, seekable_stream, &offset, flags, error))
+	if (!fu_firmware_validate_for_offset(self, seekable_stream, offset, &offset, flags, error))
 		return FALSE;
+	fu_firmware_set_offset(self, offset);
 
 	/* save stream size */
 	priv->streamsz = streamsz - offset;
@@ -2358,6 +2403,17 @@ fu_firmware_export(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode 
 		}
 	}
 
+	/* magic */
+	if (priv->magic != NULL && priv->magic->len > 0) {
+		g_autoptr(XbBuilderNode) bp = xb_builder_node_insert(bn, "magic", NULL);
+		for (guint i = 0; i < priv->magic->len; i++) {
+			FuFirmwarePatch *patch = g_ptr_array_index(priv->magic, i);
+			g_autofree gchar *str = fu_bytes_to_string(patch->blob);
+			g_autofree gchar *offset = g_strdup_printf("0x%x", (guint)patch->offset);
+			xb_builder_node_insert_text(bp, "data", str, "offset", offset, NULL);
+		}
+	}
+
 	/* vfunc */
 	if (klass->export != NULL)
 		klass->export(self, flags, bn);
@@ -2461,6 +2517,15 @@ fu_firmware_init(FuFirmware *self)
 }
 
 static void
+fu_firmware_constructed(GObject *obj)
+{
+	FuFirmware *self = FU_FIRMWARE(obj);
+	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
+	if (klass->add_magic != NULL)
+		klass->add_magic(self);
+}
+
+static void
 fu_firmware_finalize(GObject *object)
 {
 	FuFirmware *self = FU_FIRMWARE(object);
@@ -2476,6 +2541,8 @@ fu_firmware_finalize(GObject *object)
 		g_ptr_array_unref(priv->chunks);
 	if (priv->patches != NULL)
 		g_ptr_array_unref(priv->patches);
+	if (priv->magic != NULL)
+		g_ptr_array_unref(priv->magic);
 	if (priv->parent != NULL)
 		g_object_remove_weak_pointer(G_OBJECT(priv->parent), (gpointer *)&priv->parent);
 	g_ptr_array_unref(priv->images);
@@ -2491,6 +2558,7 @@ fu_firmware_class_init(FuFirmwareClass *klass)
 	object_class->finalize = fu_firmware_finalize;
 	object_class->get_property = fu_firmware_get_property;
 	object_class->set_property = fu_firmware_set_property;
+	object_class->constructed = fu_firmware_constructed;
 
 	/**
 	 * FuFirmware:parent:

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -42,6 +42,7 @@ struct _FuFirmwareClass {
 				     FuFirmwareParseFlags flags,
 				     GError **error);
 	gchar *(*convert_version)(FuFirmware *self, guint64 version_raw);
+	void (*add_magic)(FuFirmware *self);
 };
 
 /**
@@ -69,7 +70,7 @@ struct _FuFirmwareClass {
  **/
 #define FU_FIRMWARE_ID_HEADER "header"
 
-#define FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX (32 * 1024 * 1024)
+#define FU_FIRMWARE_SEARCH_MAGIC_BUFSZ_MAX (64 * 1024)
 
 FuFirmware *
 fu_firmware_new(void);
@@ -157,6 +158,9 @@ void
 fu_firmware_set_alignment(FuFirmware *self, FuFirmwareAlignment alignment) G_GNUC_NON_NULL(1);
 void
 fu_firmware_add_chunk(FuFirmware *self, FuChunk *chk) G_GNUC_NON_NULL(1);
+void
+fu_firmware_add_magic(FuFirmware *self, const guint8 *buf, gsize bufsz, gsize offset)
+    G_GNUC_NON_NULL(1, 2);
 GPtrArray *
 fu_firmware_get_chunks(FuFirmware *self, GError **error) G_GNUC_NON_NULL(1);
 FuFirmware *

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -290,6 +290,15 @@ fu_uswid_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 }
 
 static void
+fu_uswid_firmware_add_magic(FuFirmware *firmware)
+{
+	fu_firmware_add_magic(firmware,
+			      (const guint8 *)FU_STRUCT_USWID_DEFAULT_MAGIC,
+			      sizeof(fwupd_guid_t),
+			      0x0);
+}
+
+static void
 fu_uswid_firmware_init(FuUswidFirmware *self)
 {
 	FuUswidFirmwarePrivate *priv = GET_PRIVATE(self);
@@ -310,6 +319,7 @@ fu_uswid_firmware_class_init(FuUswidFirmwareClass *klass)
 	firmware_class->write = fu_uswid_firmware_write;
 	firmware_class->build = fu_uswid_firmware_build;
 	firmware_class->export = fu_uswid_firmware_export;
+	firmware_class->add_magic = fu_uswid_firmware_add_magic;
 }
 
 /**

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -5144,7 +5144,7 @@ fu_backend_usb_invalid_func(gconstpointer user_data)
 			      "*invalid platform version 0x0000000a, expected >= 0x00010805*");
 	g_test_expect_message("FuUsbDevice",
 			      G_LOG_LEVEL_WARNING,
-			      "failed to parse * BOS descriptor: *did not find magic*");
+			      "failed to parse * BOS descriptor: *invalid UUID*");
 #endif
 
 	/* load the JSON into the backend */


### PR DESCRIPTION
This reduces the time taken to parse a 32MB MTD image for a 2kB uSWID blob from ~10s to almost nothing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
