### PR TITLE
trivial Never block forever if udisks fails to respond

### DIFF
--- a/libfwupdplugin/fu-common-linux.c
+++ b/libfwupdplugin/fu-common-linux.c
@@ -19,6 +19,8 @@
 #define UDISKS_DBUS_MANAGER_PATH      "/org/freedesktop/UDisks2/Manager"
 #define UDISKS_DBUS_MANAGER_INTERFACE "org.freedesktop.UDisks2.Manager"
 
+#define UDISKS_METHOD_TIMEOUT 10000 /* ms */
+
 /* required for udisks <= 2.1.7 */
 static GPtrArray *
 fu_common_get_block_devices_legacy(GError **error)
@@ -114,7 +116,7 @@ fu_common_get_block_devices(GError **error)
 					"GetBlockDevices",
 					g_variant_new("(a{sv})", &builder),
 					G_DBUS_CALL_FLAGS_NONE,
-					-1,
+					UDISKS_METHOD_TIMEOUT,
 					NULL,
 					&error_local);
 	if (output == NULL) {


### PR DESCRIPTION
Probably not the fix for https://github.com/fwupd/fwupd/issues/9189, but was noticed on the Adafruit Circuit Playground Express.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
