### PR TITLE
Fix parsing USB BOS descriptors

### DIFF
--- a/libfwupdplugin/fu-usb.rs
+++ b/libfwupdplugin/fu-usb.rs
@@ -71,14 +71,14 @@ enum FuUsbDescriptorKind {
     SsEndpointCompanion = 0x30,
 }
 
-#[derive(ParseStream, Parse)]
+#[derive(ParseStream, ParseBytes, Parse)]
 #[repr(C, packed)]
 struct FuUsbBaseHdr {
     length: u8,
     descriptor_type: FuUsbDescriptorKind,
 }
 
-#[derive(ParseStream, Default)]
+#[derive(ParseBytes, Default)]
 #[repr(C, packed)]
 struct FuUsbDeviceHdr {
     length: u8,


### PR DESCRIPTION
For some devices we don't get valid data (weirdly, 0xFFFF...) when doing `SEEK_END`, so rather than coercing everything into a GInputStream just read as raw data and use GBytes.

Probably not the fix for https://github.com/fwupd/fwupd/issues/9189, but was noticed on the Adafruit Circuit Playground Express.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
