### PR TITLE
Add an optional offset into FuFirmware->parse()

### DIFF
--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -1166,7 +1166,9 @@ fu_firmware_parse_stream(FuFirmware *self,
 	}
 
 	/* optional */
-	if (klass->parse != NULL)
+	if (klass->parse_full != NULL)
+		return klass->parse_full(self, seekable_stream, offset, flags, error);
+	else if (klass->parse != NULL)
 		return klass->parse(self, partial_stream, flags, error);
 
 	/* verify alignment */

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -26,6 +26,11 @@ struct _FuFirmwareClass {
 			  GInputStream *stream,
 			  FuFirmwareParseFlags flags,
 			  GError **error) G_GNUC_WARN_UNUSED_RESULT;
+	gboolean (*parse_full)(FuFirmware *self,
+			       GInputStream *stream,
+			       gsize offset,
+			       FuFirmwareParseFlags flags,
+			       GError **error) G_GNUC_WARN_UNUSED_RESULT;
 	GByteArray *(*write)(FuFirmware *self, GError **error)G_GNUC_WARN_UNUSED_RESULT;
 	void (*export)(FuFirmware *self, FuFirmwareExportFlags flags, XbBuilderNode *bn);
 	gboolean (*tokenize)(FuFirmware *self,

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -21,59 +21,19 @@
  *
  * A FMAP firmware image.
  *
+ * NOTE: the `__FMAP__` header may point to sections lower than the stream offset.
+ *
  * See also: [class@FuFirmware]
  */
 
-#define FMAP_AREANAME "FMAP"
-
 typedef struct {
-	gsize signature_offset;
+	gsize signature_offset; /* only for constructing the image */
 	guint8 ver_major;
 	guint8 ver_minor;
 } FuFmapFirmwarePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuFmapFirmware, fu_fmap_firmware, FU_TYPE_FIRMWARE)
 #define GET_PRIVATE(o) (fu_fmap_firmware_get_instance_private(o))
-
-/**
- * fu_fmap_firmware_set_signature_offset:
- * @self: a #FuFmapFirmware
- * @signature_offset: raw offset
- *
- * Sets the signature offset. This is different to the offset returned by fu_firmware_get_offset()
- * which points to the position of the entire image with regards to the parent.
- *
- * The `FLASH` region for example enumerates the entire size of the stream, and the `__FMAP__`
- * header may be positioned in a `FMAP` section *within* the image. This "signature offset" points
- * to the `__FMAP__` header itself.
- *
- * Since: 2.0.17
- **/
-void
-fu_fmap_firmware_set_signature_offset(FuFmapFirmware *self, gsize signature_offset)
-{
-	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FU_IS_FMAP_FIRMWARE(self));
-	priv->signature_offset = signature_offset;
-}
-
-/**
- * fu_fmap_firmware_get_signature_offset:
- * @self: a #FuFmapFirmware
- *
- * Gets the signature offset.
- *
- * Returns: offset, or %G_MAXSIZE for unset
- *
- * Since: 2.0.17
- **/
-gsize
-fu_fmap_firmware_get_signature_offset(FuFmapFirmware *self)
-{
-	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FU_IS_FMAP_FIRMWARE(self), G_MAXSIZE);
-	return priv->signature_offset;
-}
 
 static void
 fu_fmap_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
@@ -82,8 +42,7 @@ fu_fmap_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBui
 	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
 	fu_xmlb_builder_insert_kx(bn, "ver_major", priv->ver_major);
 	fu_xmlb_builder_insert_kx(bn, "ver_minor", priv->ver_minor);
-	if (priv->signature_offset != G_MAXSIZE)
-		fu_xmlb_builder_insert_kx(bn, "signature_offset", priv->signature_offset);
+	fu_xmlb_builder_insert_kx(bn, "signature_offset", priv->signature_offset);
 }
 
 static gboolean
@@ -121,31 +80,26 @@ fu_fmap_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 }
 
 static gboolean
+fu_fmap_firmware_validate(FuFirmware *firmware, GInputStream *stream, gsize offset, GError **error)
+{
+	return fu_struct_fmap_validate_stream(stream, offset, error);
+}
+
+static gboolean
 fu_fmap_firmware_parse(FuFirmware *firmware,
 		       GInputStream *stream,
+		       gsize offset,
 		       FuFirmwareParseFlags flags,
 		       GError **error)
 {
 	FuFmapFirmware *self = FU_FMAP_FIRMWARE(firmware);
 	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
-	gsize offset;
 	gsize streamsz = 0;
 	guint32 nareas;
 	g_autoptr(FuStructFmap) st_hdr = NULL;
 
-	/* find the magic token if not already specified */
-	if (priv->signature_offset == G_MAXSIZE) {
-		if (!fu_input_stream_find(stream,
-					  (const guint8 *)FU_STRUCT_FMAP_DEFAULT_SIGNATURE,
-					  FU_STRUCT_FMAP_SIZE_SIGNATURE,
-					  0x0,
-					  &priv->signature_offset,
-					  error))
-			return FALSE;
-	}
-
 	/* parse */
-	st_hdr = fu_struct_fmap_parse_stream(stream, priv->signature_offset, error);
+	st_hdr = fu_struct_fmap_parse_stream(stream, offset, error);
 	if (st_hdr == NULL)
 		return FALSE;
 	fu_firmware_set_addr(firmware, fu_struct_fmap_get_base(st_hdr));
@@ -171,7 +125,7 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 				    "number of areas invalid");
 		return FALSE;
 	}
-	offset = priv->signature_offset + st_hdr->buf->len;
+	offset += st_hdr->buf->len;
 	for (gsize i = 0; i < nareas; i++) {
 		guint32 area_offset;
 		guint32 area_size;
@@ -187,6 +141,8 @@ fu_fmap_firmware_parse(FuFirmware *firmware,
 		area_size = fu_struct_fmap_area_get_size(st_area);
 		if (area_size == 0)
 			continue;
+
+		/* this is an absolute stream, referencing from the start of the base stream */
 		area_offset = fu_struct_fmap_area_get_offset(st_area);
 		img_stream = fu_partial_input_stream_new(stream,
 							 (gsize)area_offset,
@@ -231,15 +187,12 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
 	gsize total_sz;
 	gsize offset;
-	gsize signature_offset = 0;
 	g_autoptr(GPtrArray) images = fu_firmware_get_images(firmware);
 	g_autoptr(GByteArray) buf = g_byte_array_new();
 	g_autoptr(FuStructFmap) st_hdr = fu_struct_fmap_new();
 
 	/* pad to offset */
-	if (priv->signature_offset > 0 && priv->signature_offset != G_MAXSIZE)
-		signature_offset = priv->signature_offset;
-	fu_byte_array_set_size(buf, signature_offset, 0x00);
+	fu_byte_array_set_size(buf, priv->signature_offset, 0x00);
 
 	/* write each image if not already a blob */
 	for (guint i = 0; i < images->len; i++) {
@@ -266,7 +219,7 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 	fu_struct_fmap_set_ver_minor(st_hdr, priv->ver_minor);
 	fu_struct_fmap_set_base(st_hdr, fu_firmware_get_addr(firmware));
 	fu_struct_fmap_set_nareas(st_hdr, images->len);
-	fu_struct_fmap_set_size(st_hdr, signature_offset + total_sz);
+	fu_struct_fmap_set_size(st_hdr, priv->signature_offset + total_sz);
 	fu_byte_array_append_array(buf, st_hdr->buf);
 
 	/* add each area */
@@ -274,7 +227,7 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GBytes) fw = fu_firmware_get_bytes(img, NULL);
 		g_autoptr(FuStructFmapArea) st_area = fu_struct_fmap_area_new();
-		fu_struct_fmap_area_set_offset(st_area, signature_offset + offset);
+		fu_struct_fmap_area_set_offset(st_area, priv->signature_offset + offset);
 		fu_struct_fmap_area_set_size(st_area, g_bytes_get_size(fw));
 		if (fu_firmware_get_id(img) != NULL) {
 			if (!fu_struct_fmap_area_set_name(st_area, fu_firmware_get_id(img), error))
@@ -298,11 +251,19 @@ fu_fmap_firmware_write(FuFirmware *firmware, GError **error)
 }
 
 static void
+fu_fmap_firmware_add_magic(FuFirmware *firmware)
+{
+	fu_firmware_add_magic(firmware,
+			      (const guint8 *)FU_STRUCT_FMAP_DEFAULT_SIGNATURE,
+			      FU_STRUCT_FMAP_SIZE_SIGNATURE,
+			      0x0);
+}
+
+static void
 fu_fmap_firmware_init(FuFmapFirmware *self)
 {
 	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_type_ensure(FU_TYPE_USWID_FIRMWARE);
-	priv->signature_offset = G_MAXSIZE;
 	priv->ver_major = FU_STRUCT_FMAP_DEFAULT_VER_MAJOR;
 	priv->ver_minor = FU_STRUCT_FMAP_DEFAULT_VER_MINOR;
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
@@ -312,10 +273,12 @@ static void
 fu_fmap_firmware_class_init(FuFmapFirmwareClass *klass)
 {
 	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
-	firmware_class->parse = fu_fmap_firmware_parse;
+	firmware_class->parse_full = fu_fmap_firmware_parse;
+	firmware_class->validate = fu_fmap_firmware_validate;
 	firmware_class->write = fu_fmap_firmware_write;
 	firmware_class->export = fu_fmap_firmware_export;
 	firmware_class->build = fu_fmap_firmware_build;
+	firmware_class->add_magic = fu_fmap_firmware_add_magic;
 }
 
 /**

--- a/libfwupdplugin/fu-fmap-firmware.h
+++ b/libfwupdplugin/fu-fmap-firmware.h
@@ -20,9 +20,3 @@ struct _FuFmapFirmwareClass {
 
 FuFirmware *
 fu_fmap_firmware_new(void);
-
-gsize
-fu_fmap_firmware_get_signature_offset(FuFmapFirmware *self) G_GNUC_NON_NULL(1);
-void
-fu_fmap_firmware_set_signature_offset(FuFmapFirmware *self, gsize signature_offset)
-    G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -4008,9 +4008,6 @@ fu_firmware_fmap_func(void)
 	ret = fu_firmware_build_from_filename(firmware, filename, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	g_assert_cmpint(fu_fmap_firmware_get_signature_offset(FU_FMAP_FIRMWARE(firmware)),
-			==,
-			0x10);
 
 	/* check image count */
 	images = fu_firmware_get_images(firmware);

--- a/plugins/mtd/fu-mtd-device.c
+++ b/plugins/mtd/fu-mtd-device.c
@@ -212,10 +212,9 @@ fu_mtd_device_metadata_load_fmap(FuMtdDevice *self, GInputStream *stream, GError
 	g_autoptr(GPtrArray) imgs = NULL;
 
 	/* parse as firmware image */
-	fu_fmap_firmware_set_signature_offset(FU_FMAP_FIRMWARE(firmware), priv->fmap_offset);
 	if (!fu_firmware_parse_stream(firmware,
 				      stream,
-				      0x0,
+				      priv->fmap_offset,
 				      FU_FIRMWARE_PARSE_FLAG_CACHE_STREAM |
 					  FU_FIRMWARE_PARSE_FLAG_ONLY_PARTITION_LAYOUT,
 				      error)) {
@@ -887,8 +886,7 @@ fu_mtd_device_fmap_prepare_firmware(FuMtdDevice *self,
 	g_autoptr(FuFirmware) firmware = fu_fmap_firmware_new();
 
 	/* parse FMAP header */
-	fu_fmap_firmware_set_signature_offset(FU_FMAP_FIRMWARE(firmware), priv->fmap_offset);
-	if (!fu_firmware_parse_stream(firmware, stream, 0x0, flags, error))
+	if (!fu_firmware_parse_stream(firmware, stream, priv->fmap_offset, flags, error))
 		return NULL;
 
 	/* check each FMAP area in order */


### PR DESCRIPTION
The FMAP parser needs to look *backwards* and so we using a partial stream is not good enough.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
