### PR TITLE
trivial: fix a test failure on 32 bit x86

### DIFF
--- a/data/tests/fwupdtool.sh
+++ b/data/tests/fwupdtool.sh
@@ -59,7 +59,7 @@ run export-hwids ${TMPDIR}/hwids.ini
 expect_rc 0
 
 UNAME=$(uname -m)
-if [ "${UNAME}" = "x86_64" ] || [ "${UNAME}" = "x86" ]; then
+if [ "${UNAME}" = "x86_64" ] || [ "${UNAME}" = "i686" ]; then
     EXPECTED=0
 else
     EXPECTED=1


### PR DESCRIPTION
Debian's autopkgtest keeps failing:

```
 91s  ● Showing security
 91s  ● cmd: fwupdtool -v --plugins test security
...
 91s  ● exit code was 0 and expected 1
 91s FAIL: fwupd/fwupdtool.test (Child process exited with code 1)
```

This is because `uname -m` on a 32 bit x86 machine is not `x86`, it's `i686`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
