### PR TITLE
Only convert the release uint32_t to device version format for UEFI devices

### DIFF
--- a/libfwupdplugin/fu-device-private.h
+++ b/libfwupdplugin/fu-device-private.h
@@ -93,3 +93,5 @@ fu_device_add_json(FuDevice *self, JsonBuilder *builder, FwupdCodecFlags flags)
     G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_device_from_json(FuDevice *self, JsonObject *json_object, GError **error) G_GNUC_NON_NULL(1, 2);
+gchar *
+fu_device_convert_version(FuDevice *self, guint64 version_raw, GError **error) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-device.c
+++ b/libfwupdplugin/fu-device.c
@@ -318,6 +318,7 @@ fu_device_register_private_flags(FuDevice *self)
 	    FU_DEVICE_PRIVATE_FLAG_INSTALL_LOOP_RESTART,
 	    FU_DEVICE_PRIVATE_FLAG_MD_SET_REQUIRED_FREE,
 	    FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX,
+	    FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT,
 	};
 	GQuark quarks_tmp[G_N_ELEMENTS(flags)] = {0};
 	if (G_LIKELY(priv->private_flags_registered->len > 0))
@@ -3612,6 +3613,34 @@ fu_device_set_version_lowest_raw(FuDevice *self, guint64 version_raw)
 		if (version != NULL)
 			fu_device_set_version_lowest(self, version);
 	}
+}
+
+/**
+ * fu_device_convert_version:
+ * @self: a #FuDevice
+ * @version_raw: an integer
+ * @error: (nullable): optional return location for an error
+ *
+ * Converts the integer version to a string version, using the device-specific converter.
+ *
+ * Returns: a string value, or %NULL for error.
+ *
+ * Since: 2.0.18
+ **/
+gchar *
+fu_device_convert_version(FuDevice *self, guint64 version_raw, GError **error)
+{
+	FuDeviceClass *device_class = FU_DEVICE_GET_CLASS(self);
+	g_return_val_if_fail(FU_IS_DEVICE(self), NULL);
+
+	if (device_class->convert_version == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "->convert_version not implemented");
+		return NULL;
+	}
+	return device_class->convert_version(self, version_raw);
 }
 
 /* private */

--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -853,6 +853,16 @@ fu_device_new(FuContext *ctx);
  * Since: 2.0.15
  */
 #define FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX "parent-name-prefix"
+/**
+ * FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT:
+ *
+ * Allow the device version to be specified as an integer in the release XML.
+ *
+ * NOTE: This has only ever been a best-effort fallback for ESRT-derived UEFI devices.
+ *
+ * Since: 2.0.18
+ */
+#define FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT "lazy-verfmt"
 
 /* standard icons */
 

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -763,6 +763,7 @@ fu_uefi_capsule_device_init(FuUefiCapsuleDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_VERFMT);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_ICON);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_VENDOR);

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -818,6 +818,7 @@ fu_wistron_dock_device_init(FuWistronDockDevice *self)
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_QUAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_USABLE_DURING_UPDATE);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT);
 	fu_device_add_request_flag(FU_DEVICE(self), FWUPD_REQUEST_FLAG_ALLOW_GENERIC_MESSAGE);
 	fu_device_set_remove_delay(FU_DEVICE(self), 5 * 60 * 1000);
 }

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -341,31 +341,26 @@ fu_release_get_localized_xpath(FuRelease *self, const gchar *element)
 static gchar *
 fu_release_get_release_version(FuRelease *self, const gchar *version, GError **error)
 {
-	FwupdVersionFormat fmt = fu_device_get_version_format(self->device);
-	guint64 ver_uint32;
-	g_autoptr(GError) error_local = NULL;
-
 	/* already dotted notation */
 	if (g_strstr_len(version, -1, ".") != NULL)
 		return g_strdup(version);
 
-	/* don't touch my version! */
-	if (fmt == FWUPD_VERSION_FORMAT_PLAIN || fmt == FWUPD_VERSION_FORMAT_UNKNOWN)
-		return g_strdup(version);
-
-	/* parse as integer */
-	if (!fu_strtoull(version,
-			 &ver_uint32,
-			 1,
-			 G_MAXUINT32,
-			 FU_INTEGER_BASE_AUTO,
-			 &error_local)) {
-		g_warning("invalid release version %s: %s", version, error_local->message);
-		return g_strdup(version);
+	/* fallback for ESRT-derived UEFI devices */
+	if (fu_device_has_private_flag(self->device, FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT)) {
+		guint64 version_raw = 0;
+		if (!fu_strtoull(version,
+				 &version_raw,
+				 1,
+				 G_MAXUINT64,
+				 FU_INTEGER_BASE_AUTO,
+				 error)) {
+			return NULL;
+		}
+		return fu_device_convert_version(self->device, version_raw, error);
 	}
 
-	/* convert to dotted decimal */
-	return fu_version_from_uint32((guint32)ver_uint32, fmt);
+	/* fallback */
+	return g_strdup(version);
 }
 
 static gboolean


### PR DESCRIPTION
For a long time we've allowed cabinet archives with the release version number specified in hex, like you'd see in the ESRT.

Trying to parse _every_ release version in this way is much too permissive, so use a device flag to prevent a nasty red warning when matching releases to devices.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
