### PR TITLE
trivial: Fix the mtd installed tests location

### DIFF
--- a/plugins/mtd/meson.build
+++ b/plugins/mtd/meson.build
@@ -54,6 +54,6 @@ if get_option('tests')
       'tests/mtd-uswid.builder.xml',
       'tests/mtd-fwupd.conf',
     ],
-    install_dir: join_paths(installed_test_datadir, 'tests', 'mtd'),
+    install_dir: join_paths(installed_test_datadir, 'tests'),
   )
 endif


### PR DESCRIPTION
Closes: https://github.com/fwupd/fwupd/issues/9553
Fixes: 84f490630 ("mtd: Fall back to the SMBIOS version for BIOS MTD devices")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
