### PR TITLE
Allow changing the child name when using _PARENT_NAME_PREFIX

### DIFF
--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -951,6 +951,7 @@ fu_cfi_device_init(FuCfiDevice *self)
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_VERIFY_IMAGE);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_PARENT_FOR_OPEN);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
 	fu_device_build_vendor_id(FU_DEVICE(self), "SPI", "*");
 	fu_device_set_summary(FU_DEVICE(self), "CFI flash chip");
 }

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -6791,6 +6791,30 @@ fu_device_possible_plugin_func(void)
 }
 
 static void
+fu_device_parent_name_prefix_func(void)
+{
+	g_autoptr(FuDevice) device = fu_device_new(NULL);
+	g_autoptr(FuDevice) parent = fu_device_new(NULL);
+
+	fu_device_set_id(parent, "0000000000000000000000000000000000000000");
+	fu_device_set_name(parent, "Parent1");
+
+	fu_device_set_id(device, "1111111111111111111111111111111111111111");
+	fu_device_set_name(device, "Child1");
+	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX);
+	fu_device_set_parent(device, parent);
+
+	g_assert_cmpstr(fu_device_get_name(parent), ==, "Parent1");
+	g_assert_cmpstr(fu_device_get_name(device), ==, "Parent1 (Child1)");
+
+	/* still set, change child */
+	g_assert_true(
+	    fu_device_has_private_flag(device, FU_DEVICE_PRIVATE_FLAG_PARENT_NAME_PREFIX));
+	fu_device_set_name(device, "Child2");
+	g_assert_cmpstr(fu_device_get_name(device), ==, "Parent1 (Child2)");
+}
+
+static void
 fu_device_id_display_func(void)
 {
 	g_autoptr(FuDevice) device = fu_device_new(NULL);
@@ -7472,6 +7496,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/archive{invalid}", fu_archive_invalid_func);
 	g_test_add_func("/fwupd/archive{cab}", fu_archive_cab_func);
 	g_test_add_func("/fwupd/device", fu_device_func);
+	g_test_add_func("/fwupd/device{parent-name-prefix}", fu_device_parent_name_prefix_func);
 	g_test_add_func("/fwupd/device{id-for-display}", fu_device_id_display_func);
 	g_test_add_func("/fwupd/device{possible-plugin}", fu_device_possible_plugin_func);
 	g_test_add_func("/fwupd/device{udev}", fu_device_udev_func);


### PR DESCRIPTION
When the SPI devices get matched, the more permissive name gets set first, e.g. `CFI\FLASHID_C840->GD25Qxxx` -- this is then matched again to a more specific device, e.g. `CFI\FLASHID_C84016->GD25Q32C`.

If we set `_PARENT_NAME_PREFIX` on the child this gets 'undone' for the second name match. To prevent this keep the 'original name' in the FuDevice instance state and only set the 'exported' name on the GObject parent.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
