### PR TITLE
Fix a crash when trying to record an i2c emulation

### DIFF
--- a/libfwupdplugin/fu-i2c-device.c
+++ b/libfwupdplugin/fu-i2c-device.c
@@ -154,11 +154,11 @@ fu_i2c_device_set_address(FuI2cDevice *self, guint8 address, gboolean force, GEr
 
 	if (!fu_ioctl_execute(ioctl,
 			      force ? I2C_SLAVE_FORCE : I2C_SLAVE,
-			      (guint8 *)(guintptr)address,
-			      sizeof(guintptr),
+			      GUINT_TO_POINTER(address),
+			      sizeof(guint32),
 			      NULL,
 			      FU_I2C_DEVICE_IOCTL_TIMEOUT,
-			      FU_IOCTL_FLAG_NONE,
+			      FU_IOCTL_FLAG_PTR_AS_INTEGER,
 			      error)) {
 		g_prefix_error(error, "failed to set address 0x%02x: ", address);
 		return FALSE;

--- a/libfwupdplugin/fu-ioctl.h
+++ b/libfwupdplugin/fu-ioctl.h
@@ -16,12 +16,14 @@ G_DECLARE_FINAL_TYPE(FuIoctl, fu_ioctl, FU, IOCTL, GObject)
  * FuIoctlFlags:
  * @FU_IOCTL_FLAG:			No flags set
  * @FU_IOCTL_FLAG_RETRY:		Retry the call on failure
+ * @FU_IOCTL_FLAG_PTR_AS_INTEGER:	The @ptr passed to ioctl is an integer, not a buffer
  *
  * Flags used when calling fu_ioctl_execute() and fu_udev_device_ioctl().
  **/
 typedef enum {
 	FU_IOCTL_FLAG_NONE = 0,
 	FU_IOCTL_FLAG_RETRY = 1 << 0,
+	FU_IOCTL_FLAG_PTR_AS_INTEGER = 1 << 1,
 	/*< private >*/
 	FU_IOCTL_FLAG_LAST
 } G_GNUC_FLAG_ENUM FuIoctlFlags;


### PR DESCRIPTION
In some rare instances, what we pass to ioctl() is an integer, not a pointer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
