### PR TITLE
trivial: Do not tokenize char constants as matched tokens

### DIFF
--- a/contrib/ci/ctokenizer.py
+++ b/contrib/ci/ctokenizer.py
@@ -333,6 +333,7 @@ class Tokenizer:
                 ]
                 and not is_comment_mode
                 and not is_quote_mode
+                and not (data[pos - 1] == "'" and data[pos + 1] == "'")
             ):
                 self.dump_acc()
                 dump_char = True


### PR DESCRIPTION
e.g. this is perfectly fine `if (byte == '{')`...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
