### PR TITLE
trivial: Do not expect `UNKNOWN` enum values to be non-NULL

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -21,8 +21,6 @@
 const gchar *
 fwupd_status_to_string(FwupdStatus status)
 {
-	if (status == FWUPD_STATUS_UNKNOWN)
-		return "unknown";
 	if (status == FWUPD_STATUS_IDLE)
 		return "idle";
 	if (status == FWUPD_STATUS_DECOMPRESSING)
@@ -67,8 +65,6 @@ fwupd_status_to_string(FwupdStatus status)
 FwupdStatus
 fwupd_status_from_string(const gchar *status)
 {
-	if (g_strcmp0(status, "unknown") == 0)
-		return FWUPD_STATUS_UNKNOWN;
 	if (g_strcmp0(status, "idle") == 0)
 		return FWUPD_STATUS_IDLE;
 	if (g_strcmp0(status, "decompressing") == 0)
@@ -97,7 +93,7 @@ fwupd_status_from_string(const gchar *status)
 		return FWUPD_STATUS_SHUTDOWN;
 	if (g_strcmp0(status, "waiting-for-user") == 0)
 		return FWUPD_STATUS_WAITING_FOR_USER;
-	return FWUPD_STATUS_LAST;
+	return FWUPD_STATUS_UNKNOWN;
 }
 
 /**
@@ -517,8 +513,6 @@ fwupd_plugin_flag_from_string(const gchar *plugin_flag)
 const gchar *
 fwupd_update_state_to_string(FwupdUpdateState update_state)
 {
-	if (update_state == FWUPD_UPDATE_STATE_UNKNOWN)
-		return "unknown";
 	if (update_state == FWUPD_UPDATE_STATE_PENDING)
 		return "pending";
 	if (update_state == FWUPD_UPDATE_STATE_SUCCESS)
@@ -545,8 +539,6 @@ fwupd_update_state_to_string(FwupdUpdateState update_state)
 FwupdUpdateState
 fwupd_update_state_from_string(const gchar *update_state)
 {
-	if (g_strcmp0(update_state, "unknown") == 0)
-		return FWUPD_UPDATE_STATE_UNKNOWN;
 	if (g_strcmp0(update_state, "pending") == 0)
 		return FWUPD_UPDATE_STATE_PENDING;
 	if (g_strcmp0(update_state, "success") == 0)

--- a/libfwupd/fwupd-request.c
+++ b/libfwupd/fwupd-request.c
@@ -68,8 +68,6 @@ G_DEFINE_TYPE_EXTENDED(FwupdRequest,
 const gchar *
 fwupd_request_kind_to_string(FwupdRequestKind kind)
 {
-	if (kind == FWUPD_REQUEST_KIND_UNKNOWN)
-		return "unknown";
 	if (kind == FWUPD_REQUEST_KIND_POST)
 		return "post";
 	if (kind == FWUPD_REQUEST_KIND_IMMEDIATE)
@@ -90,13 +88,11 @@ fwupd_request_kind_to_string(FwupdRequestKind kind)
 FwupdRequestKind
 fwupd_request_kind_from_string(const gchar *kind)
 {
-	if (g_strcmp0(kind, "unknown") == 0)
-		return FWUPD_REQUEST_KIND_UNKNOWN;
 	if (g_strcmp0(kind, "post") == 0)
 		return FWUPD_REQUEST_KIND_POST;
 	if (g_strcmp0(kind, "immediate") == 0)
 		return FWUPD_REQUEST_KIND_IMMEDIATE;
-	return FWUPD_REQUEST_KIND_LAST;
+	return FWUPD_REQUEST_KIND_UNKNOWN;
 }
 
 /**

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -58,17 +58,17 @@ fwupd_enums_func(void)
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_error_from_string(tmp), ==, i);
 	}
-	for (guint i = 0; i < FWUPD_STATUS_LAST; i++) {
+	for (guint i = FWUPD_STATUS_UNKNOWN + 1; i < FWUPD_STATUS_LAST; i++) {
 		const gchar *tmp = fwupd_status_to_string(i);
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_status_from_string(tmp), ==, i);
 	}
-	for (guint i = 0; i < FWUPD_UPDATE_STATE_LAST; i++) {
+	for (guint i = FWUPD_UPDATE_STATE_UNKNOWN + 1; i < FWUPD_UPDATE_STATE_LAST; i++) {
 		const gchar *tmp = fwupd_update_state_to_string(i);
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_update_state_from_string(tmp), ==, i);
 	}
-	for (guint i = 0; i < FWUPD_REQUEST_KIND_LAST; i++) {
+	for (guint i = FWUPD_REQUEST_KIND_UNKNOWN + 1; i < FWUPD_REQUEST_KIND_LAST; i++) {
 		const gchar *tmp = fwupd_request_kind_to_string(i);
 		g_assert_cmpstr(tmp, !=, NULL);
 		g_assert_cmpint(fwupd_request_kind_from_string(tmp), ==, i);


### PR DESCRIPTION
Also, never return `LAST` if the value is unknown. Returning a private enum was a werid thing to do 10 years ago, and an even weirder thing now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
