### PR TITLE
Add gtk-doc comments and 'since' values to the generated rustgen enums

### DIFF
--- a/libfwupdplugin/fu-common.h
+++ b/libfwupdplugin/fu-common.h
@@ -12,36 +12,6 @@
 #include "fu-common-struct.h"
 
 /**
- * FuCpuVendor:
- *
- * The CPU vendor.
- **/
-
-/**
- * FuPowerState:
- *
- * The system power state.
- *
- * This does not have to be exactly what the battery is doing, but is supposed to represent the
- * 40,000ft view of the system power state.
- *
- * For example, it is perfectly correct to set %FU_POWER_STATE_AC if the system is connected to
- * AC power, but the battery cells are discharging for health or for other performance reasons.
- **/
-
-/**
- * FuLidState:
- *
- * The device lid state.
- **/
-
-/**
- * FuDisplayState:
- *
- * The device lid state.
- **/
-
-/**
  * FU_BIT_SET:
  * @val: integer value
  * @pos: bit position, where 0 is the least significant byte

--- a/libfwupdplugin/fu-common.rs
+++ b/libfwupdplugin/fu-common.rs
@@ -1,12 +1,22 @@
 // Copyright 2024 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+// The CPU vendor.
+// Since: 1.5.5
 enum FuCpuVendor {
     Unknown,
     Intel,
     Amd,
 }
 
+// The system power state.
+//
+// This does not have to be exactly what the battery is doing, but is supposed to represent the
+// 40,000ft view of the system power state.
+//
+// For example, it is perfectly correct to set %FU_POWER_STATE_AC if the system is connected to
+// AC power, but the battery cells are discharging for health or for other performance reasons.
+// Since: 1.8.11
 #[derive(ToString)]
 enum FuPowerState {
     Unknown,
@@ -14,6 +24,8 @@ enum FuPowerState {
     Battery,                // On system battery
 }
 
+// The device lid state.
+// Since: 1.7.4
 #[derive(ToString)]
 enum FuLidState {
     Unknown,
@@ -21,6 +33,8 @@ enum FuLidState {
     Closed,
 }
 
+// The device lid state.
+// Since: 1.9.6
 #[derive(ToString, FromString)]
 enum FuDisplayState {
     Unknown,

--- a/libfwupdplugin/fu-rustgen-enum.c.in
+++ b/libfwupdplugin/fu-rustgen-enum.c.in
@@ -1,6 +1,19 @@
 {%- set export = obj.export('ToString') %}
 {%- if export in [Export.PUBLIC, Export.PRIVATE] %}
 {%- if obj.is_bitfield %}
+/**
+ * {{obj.c_method('ToString')}}:
+ * @val: value, e.g. %{{obj.items[1].c_define}}
+ *
+ * Converts an enumerated value to a string.
+ *
+ * Returns: identifier string
+ *
+{%- if obj.since('ToString') %}
+ *
+ * Since: {{obj.since('ToString')}}
+{%- endif %}
+ **/
 {{export.value}}gchar *
 {{obj.c_method('ToString')}}({{obj.c_type}} val)
 {
@@ -15,6 +28,18 @@
     return g_strjoinv(",", (gchar **)data);
 }
 {%- else %}
+/**
+ * {{obj.c_method('ToString')}}:
+ * @val: value{%- if obj.items|length > 1 %}, e.g. %{{obj.items[1].c_define}}{%- endif %}
+ *
+ * Converts an enumerated value to a string.
+ *
+ * Returns: identifier string
+{%- if obj.since('ToString') %}
+ *
+ * Since: {{obj.since('ToString')}}
+{%- endif %}
+ **/
 {{export.value}}const gchar *
 {{obj.c_method('ToString')}}({{obj.c_type}} val)
 {
@@ -29,6 +54,18 @@
 
 {%- set export = obj.export('FromString') %}
 {%- if export in [Export.PUBLIC, Export.PRIVATE] %}
+/**
+ * {{obj.c_method('FromString')}}:
+ * @val: (nullable): a string{%- if obj.items|length > 1 %}, e.g. `{{obj.items[1].value}}`{%- endif %}
+ *
+ * Converts a string to an enumerated value.
+ *
+ * Returns: enumerated value
+{%- if obj.since('FromString') %}
+ *
+ * Since: {{obj.since('FromString')}}
+{%- endif %}
+ **/
 {{export.value}}{{obj.c_type}}
 {{obj.c_method('FromString')}}(const gchar *val)
 {

--- a/libfwupdplugin/fu-rustgen-enum.h.in
+++ b/libfwupdplugin/fu-rustgen-enum.h.in
@@ -1,5 +1,27 @@
+/**
+ * {{obj.c_type}}:
+{%- if obj.comments %}
+ *
+{%- for comment in obj.comments %}
+ * {{comment}}
+{%- endfor %}
+{%- endif %}
+ */
 typedef enum {
 {%- for item in obj.items %}
+    /**
+     * {{item.c_define}}:
+{%- if item.comments %}
+     *
+{%- for comment in item.comments %}
+     * {{comment}}
+{%- endfor %}
+{%- endif %}
+{%- if item.since %}
+     *
+     * Since: {{item.since}}
+{%- endif %}
+     */
 {%- if item.default %}
     {{item.c_define}} = {{item.default}},
 {%- else %}

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -67,6 +67,8 @@ def _camel_to_snake(name: str) -> str:
 class EnumObj:
     def __init__(self, name: str) -> None:
         self.name: str = name
+        self._since: Optional[str] = None
+        self.comments: list[str] = []
         self.repr_type: Optional[str] = None
         self.items: List[EnumItem] = []
         self.is_imported: bool = False
@@ -78,6 +80,9 @@ class EnumObj:
 
     def c_method(self, suffix: str):
         return f"{_camel_to_snake(self.name)}_{_camel_to_snake(suffix)}"
+
+    def since(self, derive: str) -> Optional[str]:
+        return self._since
 
     @property
     def c_type(self):
@@ -145,6 +150,8 @@ class EnumItem:
         self.obj: EnumObj = obj
         self.name: str = ""
         self.default: Optional[str] = None
+        self.comments: list[str] = []
+        self.since: Optional[str] = None
         self.is_bitfield = False
 
     @property
@@ -673,8 +680,10 @@ class Generator:
         offset: int = 0
         struct_seen_b32: bool = False
         bits_offset: int = 0
+        since: Optional[str] = None
         struct_cur: Optional[StructObj] = None
         enum_cur: Optional[EnumObj] = None
+        comments_cur: list[str] = []
 
         for line_num, line in enumerate(contents.split("\n")):
             # replace all tabs with spaces
@@ -686,7 +695,19 @@ class Generator:
                 self._use_import(where, why, what)
 
             # remove comments and indent
-            line = line.split("//")[0].strip()
+            try:
+                line, comment = line.split("//", maxsplit=1)
+            except ValueError:
+                pass
+            else:
+                comment = comment.strip()
+                if comment.startswith("Since:"):
+                    since = comment[6:].strip()
+                elif comment.startswith("SPDX") or comment.startswith("Copyright"):
+                    pass
+                elif comment:
+                    comments_cur.append(comment.strip())
+            line = line.strip()
             if not line:
                 continue
 
@@ -706,7 +727,10 @@ class Generator:
                     raise ValueError(f"enum {name} already defined on line {line_num}")
                 enum_cur = EnumObj(name)
                 enum_cur.repr_type = repr_type
+                enum_cur._since = since
+                enum_cur.comments.extend(comments_cur)
                 self.enum_objs[name] = enum_cur
+                comments_cur.clear()
                 continue
 
             # the enum type
@@ -742,6 +766,8 @@ class Generator:
                 struct_cur = None
                 enum_cur = None
                 repr_type = None
+                comments_cur.clear()
+                since = None
                 derives.clear()
                 offset = 0
                 bits_offset = 0
@@ -758,11 +784,14 @@ class Generator:
             # split enumeration into sections
             if enum_cur:
                 enum_item = EnumItem(enum_cur)
+                enum_item._since = since
+                enum_item.comments.extend(comments_cur)
                 parts = line.replace(" ", "").split("=", maxsplit=2)
                 enum_item.name = parts[0]
                 if len(parts) > 1:
                     enum_item.parse_default(parts[1])
                 enum_cur.items.append(enum_item)
+                comments_cur.clear()
 
             # split structure into sections
             if struct_cur:


### PR DESCRIPTION
When converting to Rust format we lost the gtk-doc documentation annotations from the c source. We can collect these and show them in the generated (and processed) files.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
