### PR TITLE
trivial: Check for HIDIOCGINPUT

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -553,7 +553,11 @@ endif
 if cc.has_header('mtd/mtd-user.h')
   conf.set('HAVE_MTD_USER_H', '1')
 endif
-if cc.has_header('linux/hidraw.h')
+has_HIDIOCGINPUT = cc.has_header_symbol('linux/hidraw.h',
+  'HIDIOCGINPUT',
+   required: false,
+)
+if has_HIDIOCGINPUT
   conf.set('HAVE_HIDRAW_H', '1')
 endif
 if cc.has_header('sys/mman.h')


### PR DESCRIPTION
If the kernel is missing the symbol, don't try to use it in plugins.

Closes: https://github.com/fwupd/fwupd/issues/9650

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
