### PR TITLE
Re-enable deploy store job with the right channels

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -22,9 +22,9 @@ jobs:
     - id: channel
       run: |
         if git describe --exact-match; then
-          echo "channel=candidate" >> $GITHUB_OUTPUT
+          echo "name=channel::2.0.x/candidate" >> $GITHUB_OUTPUT
         else
-          echo "channel=edge" >> $GITHUB_OUTPUT
+          echo "name=channel::2.0.x/edge" >> $GITHUB_OUTPUT
         fi
     - id: prep
       run: |
@@ -74,3 +74,19 @@ jobs:
       run: |
         sudo TMPDIR="$SNAP_TEST_TMPDIR" \
             /snap/fwupd/current/share/installed-tests/fwupd/fwupdtool-efiboot.sh
+
+  deploy-store:
+    needs: [build-snap, test-snap]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.deploy }}
+    steps:
+    - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      id: download
+      with:
+        name: snap
+    - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{ needs.build-snap.outputs.snap_name }}
+        release: ${{ needs.build-snap.outputs.channel }}


### PR DESCRIPTION
We'll get a 2.0.x channel made in the snap store before we do a 2.0.x release.
This reverts commit 7a7a4cac82dda10ca810df48d40ad2e8fb3e0986.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
