### PR TITLE
trivial: Require a semicolon for Rust use statements

### DIFF
--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -747,7 +747,9 @@ class Generator:
 
             # import one file into another
             if line.startswith("use "):
-                where, why, what = line[4:].split("::", maxsplit=3)
+                if not line.endswith(";"):
+                    raise ValueError(f"use requires a semicolon on line {line_num}")
+                where, why, what = line[4:-1].split("::", maxsplit=3)
                 self._use_import(where, why, what)
 
             # remove comments and indent

--- a/plugins/uefi-capsule/fu-uefi.rs
+++ b/plugins/uefi-capsule/fu-uefi.rs
@@ -1,9 +1,9 @@
 // Copyright 2023 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-use fwupd::efi::FuEfiCapsuleHeaderFlags
-use fwupd::efi::FuEfiStatus
-use fwupd::efi::FuStructEfiTime
+use fwupd::efi::FuEfiCapsuleHeaderFlags;
+use fwupd::efi::FuEfiStatus;
+use fwupd::efi::FuStructEfiTime;
 
 #[derive(New, Getters, Default)]
 #[repr(C, packed)]


### PR DESCRIPTION
I missed this when looking at the schema.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
