### PR TITLE
Allow systems to use the udev event source without using systemd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -265,6 +265,9 @@ gmodule = dependency('gmodule-2.0')
 if host_machine.system() == 'linux'
   conf.set('HAVE_UDEV', '1')
 endif
+if get_option('udev_hotplug')
+  conf.set('HAVE_UDEV_HOTPLUG' , '1')
+endif
 if build_standalone
   bluez = get_option('bluez').disable_auto_if(host_machine.system() != 'linux')
   if bluez.allowed()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -123,6 +123,12 @@ option(
   description: 'Default P2P sharing policy',
 )
 option(
+  'udev_hotplug',
+  type: 'boolean',
+  value: true,
+  description: 'Use the udev netlink hotplug event source',
+)
+option(
   'passim',
   type: 'feature',
   description: 'Passim support',

--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -429,7 +429,7 @@ fu_udev_backend_netlink_parse_blob(FuUdevBackend *self, GBytes *blob, GError **e
 {
 	FuUdevAction action = FU_UDEV_ACTION_UNKNOWN;
 	g_autofree gchar *sysfsdir = fu_path_from_kind(FU_PATH_KIND_SYSFSDIR);
-#ifdef HAVE_SYSTEMD
+#ifdef HAVE_UDEV_HOTPLUG
 	FuContext *ctx = fu_backend_get_context(FU_BACKEND(self));
 	const guint8 *buf;
 	gsize bufsz = 0;
@@ -618,7 +618,7 @@ fu_udev_backend_netlink_setup(FuUdevBackend *self, GError **error)
 	struct sockaddr_nl nls = {
 	    .nl_family = AF_NETLINK,
 	    .nl_pid = getpid(),
-#ifdef HAVE_SYSTEMD
+#ifdef HAVE_UDEV_HOTPLUG
 	    .nl_groups = FU_UDEV_MONITOR_NETLINK_GROUP_UDEV,
 #else
 	    .nl_groups = FU_UDEV_MONITOR_NETLINK_GROUP_KERNEL,


### PR DESCRIPTION
For example, ChromeOS...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
