### PR TITLE
Enforce what firmware GTypes are allowed as children

### DIFF
--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -276,6 +276,7 @@ static void
 fu_archive_firmware_init(FuArchiveFirmware *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 10000);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -917,7 +917,7 @@ fu_cab_firmware_class_init(FuCabFirmwareClass *klass)
 static void
 fu_cab_firmware_init(FuCabFirmware *self)
 {
-	g_type_ensure(FU_TYPE_CAB_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CAB_IMAGE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_ID);

--- a/libfwupdplugin/fu-csv-firmware.c
+++ b/libfwupdplugin/fu-csv-firmware.c
@@ -252,7 +252,7 @@ fu_csv_firmware_init(FuCsvFirmware *self)
 	priv->write_column_ids = TRUE;
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 10000);
-	g_type_ensure(FU_TYPE_CSV_ENTRY);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CSV_ENTRY);
 }
 
 static void

--- a/libfwupdplugin/fu-dfuse-firmware.c
+++ b/libfwupdplugin/fu-dfuse-firmware.c
@@ -260,6 +260,7 @@ static void
 fu_dfuse_firmware_init(FuDfuseFirmware *self)
 {
 	fu_dfu_firmware_set_version(FU_DFU_FIRMWARE(self), FU_DFU_FIRMARE_VERSION_DFUSE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 255);
 }
 

--- a/libfwupdplugin/fu-efi-device-path-list.c
+++ b/libfwupdplugin/fu-efi-device-path-list.c
@@ -152,8 +152,8 @@ fu_efi_device_path_list_class_init(FuEfiDevicePathListClass *klass)
 static void
 fu_efi_device_path_list_init(FuEfiDevicePathList *self)
 {
-	g_type_ensure(FU_TYPE_EFI_FILE_PATH_DEVICE_PATH);
-	g_type_ensure(FU_TYPE_EFI_HARD_DRIVE_DEVICE_PATH);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_FILE_PATH_DEVICE_PATH);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_HARD_DRIVE_DEVICE_PATH);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), FU_EFI_DEVICE_PATH_LIST_IMAGES_MAX);
 }
 

--- a/libfwupdplugin/fu-efi-file.c
+++ b/libfwupdplugin/fu-efi-file.c
@@ -292,7 +292,7 @@ fu_efi_file_init(FuEfiFile *self)
 	priv->attrib = FU_EFI_FILE_ATTRIB_NONE;
 	priv->type = FU_EFI_FILE_TYPE_RAW;
 	fu_firmware_set_alignment(FU_FIRMWARE(self), FU_FIRMWARE_ALIGNMENT_8);
-	g_type_ensure(FU_TYPE_EFI_SECTION);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_SECTION);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-filesystem.c
+++ b/libfwupdplugin/fu-efi-filesystem.c
@@ -135,7 +135,8 @@ fu_efi_filesystem_init(FuEfiFilesystem *self)
 	fu_firmware_set_images_max(FU_FIRMWARE(self), FU_EFI_FILESYSTEM_FILES_MAX);
 #endif
 	fu_firmware_set_alignment(FU_FIRMWARE(self), FU_FIRMWARE_ALIGNMENT_8);
-	g_type_ensure(FU_TYPE_EFI_FILE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_FILESYSTEM);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_FILE);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-load-option.c
+++ b/libfwupdplugin/fu-efi-load-option.c
@@ -619,7 +619,7 @@ fu_efi_load_option_init(FuEfiLoadOption *self)
 {
 	self->attrs = FU_EFI_LOAD_OPTION_ATTR_ACTIVE;
 	self->metadata = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-	g_type_ensure(FU_TYPE_EFI_DEVICE_PATH_LIST);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_DEVICE_PATH_LIST);
 }
 
 /**

--- a/libfwupdplugin/fu-efi-section.c
+++ b/libfwupdplugin/fu-efi-section.c
@@ -478,7 +478,8 @@ fu_efi_section_init(FuEfiSection *self)
 #endif
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
 	//	fu_firmware_set_alignment (FU_FIRMWARE (self), FU_FIRMWARE_ALIGNMENT_8);
-	g_type_ensure(FU_TYPE_EFI_VOLUME);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_VOLUME);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_SECTION);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-signature-list.c
+++ b/libfwupdplugin/fu-efi-signature-list.c
@@ -371,6 +371,6 @@ fu_efi_signature_list_init(FuEfiSignatureList *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALWAYS_SEARCH);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
-	g_type_ensure(FU_TYPE_EFI_SIGNATURE);
-	g_type_ensure(FU_TYPE_EFI_X509_SIGNATURE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_SIGNATURE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_X509_SIGNATURE);
 }

--- a/libfwupdplugin/fu-efi-variable-authentication2.c
+++ b/libfwupdplugin/fu-efi-variable-authentication2.c
@@ -237,7 +237,7 @@ static void
 fu_efi_variable_authentication2_init(FuEfiVariableAuthentication2 *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALWAYS_SEARCH);
-	g_type_ensure(FU_TYPE_EFI_SIGNATURE_LIST);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_SIGNATURE_LIST);
 	self->signers = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 }
 

--- a/libfwupdplugin/fu-efi-volume.c
+++ b/libfwupdplugin/fu-efi-volume.c
@@ -446,9 +446,10 @@ fu_efi_volume_init(FuEfiVolume *self)
 	fu_firmware_set_size_max(FU_FIRMWARE(self), 0x10000000); /* 256MB */
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1000);
 #endif
-	g_type_ensure(FU_TYPE_EFI_FILESYSTEM);
-	g_type_ensure(FU_TYPE_EFI_VSS2_VARIABLE_STORE);
-	g_type_ensure(FU_TYPE_EFI_FTW_STORE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_FILESYSTEM);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_VSS2_VARIABLE_STORE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_FTW_STORE);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-vss-auth-variable.c
+++ b/libfwupdplugin/fu-efi-vss-auth-variable.c
@@ -279,6 +279,7 @@ static void
 fu_efi_vss_auth_variable_init(FuEfiVssAuthVariable *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_SIGNATURE_LIST);
 }
 
 static void

--- a/libfwupdplugin/fu-efi-vss2-variable-store.c
+++ b/libfwupdplugin/fu-efi-vss2-variable-store.c
@@ -146,7 +146,7 @@ fu_efi_vss2_variable_store_write(FuFirmware *firmware, GError **error)
 static void
 fu_efi_vss2_variable_store_init(FuEfiVss2VariableStore *self)
 {
-	g_type_ensure(FU_TYPE_EFI_VSS_AUTH_VARIABLE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_VSS_AUTH_VARIABLE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_ID);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 #ifdef HAVE_FUZZER

--- a/libfwupdplugin/fu-elf-firmware.c
+++ b/libfwupdplugin/fu-elf-firmware.c
@@ -371,6 +371,7 @@ fu_elf_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_elf_firmware_init(FuElfFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/libfwupdplugin/fu-fdt-firmware.c
+++ b/libfwupdplugin/fu-fdt-firmware.c
@@ -579,7 +579,7 @@ fu_fdt_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 static void
 fu_fdt_firmware_init(FuFdtFirmware *self)
 {
-	g_type_ensure(FU_TYPE_FDT_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FDT_IMAGE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
 }
 

--- a/libfwupdplugin/fu-fdt-image.c
+++ b/libfwupdplugin/fu-fdt-image.c
@@ -635,6 +635,7 @@ fu_fdt_image_init(FuFdtImage *self)
 	priv->hash_attrs =
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_bytes_unref);
 	priv->hash_attrs_format = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FDT_IMAGE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 10000);
 }
 

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -223,6 +223,8 @@ fu_firmware_check_compatible(FuFirmware *self,
 
 gboolean
 fu_firmware_add_image(FuFirmware *self, FuFirmware *img, GError **error) G_GNUC_NON_NULL(1, 2);
+void
+fu_firmware_add_image_gtype(FuFirmware *self, GType type) G_GNUC_NON_NULL(1);
 gboolean
 fu_firmware_remove_image(FuFirmware *self, FuFirmware *img, GError **error) G_GNUC_NON_NULL(1, 2);
 gboolean

--- a/libfwupdplugin/fu-fmap-firmware.c
+++ b/libfwupdplugin/fu-fmap-firmware.c
@@ -263,9 +263,10 @@ static void
 fu_fmap_firmware_init(FuFmapFirmware *self)
 {
 	FuFmapFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_type_ensure(FU_TYPE_USWID_FIRMWARE);
 	priv->ver_major = FU_STRUCT_FMAP_DEFAULT_VER_MAJOR;
 	priv->ver_minor = FU_STRUCT_FMAP_DEFAULT_VER_MINOR;
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_USWID_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/libfwupdplugin/fu-hid-descriptor.c
+++ b/libfwupdplugin/fu-hid-descriptor.c
@@ -295,8 +295,7 @@ fu_hid_descriptor_init(FuHidDescriptor *self)
 #else
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 #endif
-	g_type_ensure(FU_TYPE_HID_REPORT);
-	g_type_ensure(FU_TYPE_HID_REPORT_ITEM);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_HID_REPORT);
 }
 
 static void

--- a/libfwupdplugin/fu-hid-report.c
+++ b/libfwupdplugin/fu-hid-report.c
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+#include "fu-hid-report-item.h"
 #include "fu-hid-report.h"
 
 /**
@@ -27,6 +28,7 @@ fu_hid_report_init(FuHidReport *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_IDX);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_HID_REPORT_ITEM);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), G_MAXUINT8);
 }
 

--- a/libfwupdplugin/fu-ifd-bios.c
+++ b/libfwupdplugin/fu-ifd-bios.c
@@ -78,6 +78,7 @@ static void
 fu_ifd_bios_init(FuIfdBios *self)
 {
 	fu_firmware_set_alignment(FU_FIRMWARE(self), FU_FIRMWARE_ALIGNMENT_4K);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_VOLUME);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/libfwupdplugin/fu-ifd-firmware.c
+++ b/libfwupdplugin/fu-ifd-firmware.c
@@ -519,9 +519,10 @@ fu_ifd_firmware_init(FuIfdFirmware *self)
 	priv->flash_master[3] = 0x00800900;
 	priv->flash_ich_strap_base_addr = 0x100;
 	priv->flash_mch_strap_base_addr = 0x300;
-	g_type_ensure(FU_TYPE_IFD_BIOS);
-	g_type_ensure(FU_TYPE_IFD_IMAGE);
-	g_type_ensure(FU_TYPE_EFI_VOLUME);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_IFD_BIOS);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_IFD_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_EFI_VOLUME);
 }
 
 static void

--- a/libfwupdplugin/fu-ifwi-cpd-firmware.c
+++ b/libfwupdplugin/fu-ifwi-cpd-firmware.c
@@ -131,6 +131,7 @@ fu_ifwi_cpd_firmware_parse_manifest(FuIfwiCpdFirmware *self,
 
 		/* success */
 		fu_firmware_set_offset(img, offset);
+		fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
 		if (!fu_firmware_add_image(firmware, img, error))
 			return FALSE;
 		offset += extension_length;
@@ -343,6 +344,7 @@ fu_ifwi_cpd_firmware_convert_version(FuFirmware *firmware, guint64 version_raw)
 static void
 fu_ifwi_cpd_firmware_init(FuIfwiCpdFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), FU_IFWI_CPD_FIRMWARE_ENTRIES_MAX);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_QUAD);
 }

--- a/libfwupdplugin/fu-ifwi-fpt-firmware.c
+++ b/libfwupdplugin/fu-ifwi-fpt-firmware.c
@@ -176,6 +176,7 @@ fu_ifwi_fpt_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_ifwi_fpt_firmware_init(FuIfwiFptFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), FU_IFWI_FPT_MAX_ENTRIES);
 }
 

--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -543,6 +543,7 @@ fu_ihex_firmware_init(FuIhexFirmware *self)
 	priv->padding_value = 0x00; /* chosen as we can't write 0xffff to PIC14 */
 	priv->records = g_ptr_array_new_with_free_func((GFreeFunc)fu_ihex_firmware_record_free);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 10);
 }
 

--- a/libfwupdplugin/fu-intel-thunderbolt-nvm.c
+++ b/libfwupdplugin/fu-intel-thunderbolt-nvm.c
@@ -749,6 +749,7 @@ static void
 fu_intel_thunderbolt_nvm_init(FuIntelThunderboltNvm *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_BCD);
 }

--- a/libfwupdplugin/fu-linear-firmware.c
+++ b/libfwupdplugin/fu-linear-firmware.c
@@ -79,6 +79,7 @@ fu_linear_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 				    tmp);
 			return FALSE;
 		}
+		fu_firmware_add_image_gtype(firmware, priv->image_gtype);
 	}
 
 	/* success */
@@ -190,6 +191,7 @@ fu_linear_firmware_set_property(GObject *object,
 	switch (prop_id) {
 	case PROP_IMAGE_GTYPE:
 		priv->image_gtype = g_value_get_gtype(value);
+		fu_firmware_add_image_gtype(FU_FIRMWARE(self), priv->image_gtype);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);

--- a/libfwupdplugin/fu-oprom-firmware.c
+++ b/libfwupdplugin/fu-oprom-firmware.c
@@ -291,6 +291,8 @@ fu_oprom_firmware_init(FuOpromFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALLOW_LINEAR);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_IFWI_CPD_FIRMWARE);
 }
 
 static void

--- a/libfwupdplugin/fu-pefile-firmware.c
+++ b/libfwupdplugin/fu-pefile-firmware.c
@@ -519,8 +519,9 @@ fu_pefile_firmware_get_checksum(FuFirmware *firmware, GChecksumType csum_kind, G
 static void
 fu_pefile_firmware_init(FuPefileFirmware *self)
 {
-	g_type_ensure(FU_TYPE_CSV_FIRMWARE);
-	g_type_ensure(FU_TYPE_SBATLEVEL_SECTION);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CSV_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_SBATLEVEL_SECTION);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 100);
 }
 

--- a/libfwupdplugin/fu-pkcs7.c
+++ b/libfwupdplugin/fu-pkcs7.c
@@ -131,6 +131,7 @@ fu_pkcs7_parse(FuFirmware *firmware,
 static void
 fu_pkcs7_init(FuPkcs7 *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_X509_CERTIFICATE);
 }
 
 static void

--- a/libfwupdplugin/fu-sbatlevel-section.c
+++ b/libfwupdplugin/fu-sbatlevel-section.c
@@ -150,6 +150,7 @@ fu_sbatlevel_section_write(FuFirmware *firmware, GError **error)
 static void
 fu_sbatlevel_section_init(FuSbatlevelSection *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CSV_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2);
 }
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -3927,6 +3927,7 @@ fu_firmware_build_func(void)
 	g_assert_nonnull(n);
 
 	/* build object */
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
 	ret = fu_firmware_build(firmware, n, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -4062,6 +4063,7 @@ fu_firmware_sorted_func(void)
 	fu_firmware_set_idx(firmware2, 0x200);
 	fu_firmware_set_idx(firmware3, 0x100);
 
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
 	ret = fu_firmware_add_image(firmware, firmware1, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -4588,6 +4590,8 @@ fu_firmware_func(void)
 	g_autoptr(GPtrArray) images = NULL;
 	g_autofree gchar *str = NULL;
 
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
+
 	fu_firmware_set_addr(img1, 0x200);
 	fu_firmware_set_idx(img1, 13);
 	fu_firmware_set_id(img1, "primary");
@@ -4633,6 +4637,9 @@ fu_firmware_func(void)
 	g_assert_cmpstr(str,
 			==,
 			"<firmware>\n"
+			"  <image_gtypes>\n"
+			"    <gtype>FuFirmware</gtype>\n"
+			"  </image_gtypes>\n"
 			"  <firmware>\n"
 			"    <id>primary</id>\n"
 			"    <idx>0xd</idx>\n"
@@ -4706,6 +4713,7 @@ fu_firmware_dedupe_func(void)
 
 	fu_firmware_add_flag(firmware, FU_FIRMWARE_FLAG_DEDUPE_ID);
 	fu_firmware_add_flag(firmware, FU_FIRMWARE_FLAG_DEDUPE_IDX);
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(firmware, 2);
 
 	fu_firmware_set_idx(img1_old, 13);
@@ -5685,7 +5693,6 @@ fu_firmware_builder_round_trip_func(void)
 	    },
 #endif
 	};
-	g_type_ensure(FU_TYPE_COSWID_FIRMWARE);
 	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
 		gboolean ret;
 		g_autofree gchar *csum1 = NULL;
@@ -7362,7 +7369,6 @@ main(int argc, char **argv)
 
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
-	g_type_ensure(FU_TYPE_IFD_BIOS);
 
 	/* only critical and error are fatal */
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);

--- a/libfwupdplugin/fu-usb-bos-descriptor.c
+++ b/libfwupdplugin/fu-usb-bos-descriptor.c
@@ -244,6 +244,7 @@ static void
 fu_usb_bos_descriptor_init(FuUsbBosDescriptor *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALLOW_LINEAR);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 /**

--- a/libfwupdplugin/fu-usb-interface.c
+++ b/libfwupdplugin/fu-usb-interface.c
@@ -422,6 +422,7 @@ static void
 fu_usb_interface_init(FuUsbInterface *self)
 {
 	self->endpoints = g_ptr_array_new_with_free_func(g_object_unref);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_USB_DESCRIPTOR);
 }
 
 static void

--- a/libfwupdplugin/fu-uswid-firmware.c
+++ b/libfwupdplugin/fu-uswid-firmware.c
@@ -307,7 +307,7 @@ fu_uswid_firmware_init(FuUswidFirmware *self)
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_ALWAYS_SEARCH);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
-	g_type_ensure(FU_TYPE_COSWID_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_COSWID_FIRMWARE);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-version-record.c
+++ b/plugins/acpi-phat/fu-acpi-phat-version-record.c
@@ -85,7 +85,7 @@ fu_acpi_phat_version_record_init(FuAcpiPhatVersionRecord *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
-	g_type_ensure(FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat.c
+++ b/plugins/acpi-phat/fu-acpi-phat.c
@@ -310,8 +310,8 @@ fu_acpi_phat_init(FuAcpiPhat *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 2000);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
-	g_type_ensure(FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
-	g_type_ensure(FU_TYPE_ACPI_PHAT_VERSION_RECORD);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_ACPI_PHAT_VERSION_RECORD);
 }
 
 static void

--- a/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-firmware.c
@@ -97,6 +97,7 @@ fu_algoltek_usb_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_algoltek_usb_firmware_init(FuAlgoltekUsbFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -164,6 +164,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
 				    fu_struct_image_slot_header_get_fw_id(st_hdr));
 			return FALSE;
 		}
+		fu_firmware_add_image_gtype(l2_img, FU_TYPE_AMD_GPU_ATOM_FIRMWARE);
 		if (!fu_firmware_add_image(l2_img, csm_img, error))
 			return FALSE;
 
@@ -173,6 +174,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
 		fu_firmware_set_addr(l2_img, loc);
 		if (!fu_firmware_parse_stream(l2_img, l2_stream, 0x0, flags, error))
 			return FALSE;
+		fu_firmware_add_image_gtype(ish_img, FU_TYPE_FIRMWARE);
 		if (!fu_firmware_add_image(ish_img, l2_img, error))
 			return FALSE;
 
@@ -207,6 +209,7 @@ fu_amd_gpu_psp_firmware_parse(FuFirmware *firmware,
 static void
 fu_amd_gpu_psp_firmware_init(FuAmdGpuPspFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/analogix/fu-analogix-firmware.c
+++ b/plugins/analogix/fu-analogix-firmware.c
@@ -121,6 +121,7 @@ fu_analogix_firmware_init(FuAnalogixFirmware *self)
 {
 	fu_ihex_firmware_set_padding_value(FU_IHEX_FIRMWARE(self), 0xFF);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_PAIR);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/asus-hid/fu-asus-hid-firmware.c
+++ b/plugins/asus-hid/fu-asus-hid-firmware.c
@@ -61,6 +61,7 @@ static void
 fu_asus_hid_firmware_init(FuAsusHidFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-firmware.c
+++ b/plugins/bcm57xx/fu-bcm57xx-firmware.c
@@ -633,9 +633,10 @@ fu_bcm57xx_firmware_init(FuBcm57xxFirmware *self)
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_ID);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
-	g_type_ensure(FU_TYPE_BCM57XX_STAGE1_IMAGE);
-	g_type_ensure(FU_TYPE_BCM57XX_STAGE2_IMAGE);
-	g_type_ensure(FU_TYPE_BCM57XX_DICT_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_BCM57XX_STAGE1_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_BCM57XX_STAGE2_IMAGE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_BCM57XX_DICT_IMAGE);
 }
 
 static void

--- a/plugins/bcm57xx/fu-self-test.c
+++ b/plugins/bcm57xx/fu-self-test.c
@@ -149,9 +149,6 @@ main(int argc, char **argv)
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", TRUE);
 
 	g_test_init(&argc, &argv, NULL);
-	g_type_ensure(FU_TYPE_BCM57XX_STAGE1_IMAGE);
-	g_type_ensure(FU_TYPE_BCM57XX_STAGE2_IMAGE);
-	g_type_ensure(FU_TYPE_BCM57XX_DICT_IMAGE);
 
 	/* only critical and error are fatal */
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);

--- a/plugins/cfu/fu-cfu-module.c
+++ b/plugins/cfu/fu-cfu-module.c
@@ -93,6 +93,9 @@ fu_cfu_module_prepare_firmware(FuDevice *device,
 	g_autoptr(GBytes) blob_offer = NULL;
 	g_autoptr(GBytes) blob_payload = NULL;
 
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_CFU_OFFER);
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_CFU_PAYLOAD);
+
 	/* parse archive */
 	if (!fu_firmware_parse_stream(firmware_archive, stream, 0x0, flags, error))
 		return NULL;

--- a/plugins/cros-ec/fu-cros-ec-firmware.c
+++ b/plugins/cros-ec/fu-cros-ec-firmware.c
@@ -172,6 +172,8 @@ fu_cros_ec_firmware_init(FuCrosEcFirmware *self)
 	section = g_new0(FuCrosEcFirmwareSection, 1);
 	section->name = "RW";
 	g_ptr_array_add(self->sections, section);
+
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/ebitdo/fu-ebitdo-firmware.c
+++ b/plugins/ebitdo/fu-ebitdo-firmware.c
@@ -98,6 +98,7 @@ static void
 fu_ebitdo_firmware_init(FuEbitdoFirmware *self)
 {
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_PAIR);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/elan-kbd/fu-elan-kbd-firmware.c
+++ b/plugins/elan-kbd/fu-elan-kbd-firmware.c
@@ -118,6 +118,7 @@ fu_elan_kbd_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_elan_kbd_firmware_init(FuElanKbdFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/elanfp/fu-elanfp-firmware.c
+++ b/plugins/elanfp/fu-elanfp-firmware.c
@@ -201,8 +201,8 @@ static void
 fu_elanfp_firmware_init(FuElanfpFirmware *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 256);
-	g_type_ensure(FU_TYPE_CFU_OFFER);
-	g_type_ensure(FU_TYPE_CFU_PAYLOAD);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CFU_OFFER);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_CFU_PAYLOAD);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-scaler-firmware.c
+++ b/plugins/genesys/fu-genesys-scaler-firmware.c
@@ -154,6 +154,7 @@ fu_genesys_scaler_firmware_write(FuFirmware *firmware, GError **error)
 static void
 fu_genesys_scaler_firmware_init(FuGenesysScalerFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-usbhub-firmware.c
+++ b/plugins/genesys/fu-genesys-usbhub-firmware.c
@@ -530,6 +530,8 @@ fu_genesys_usbhub_firmware_init(FuGenesysUsbhubFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_PAIR);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_GENESYS_USBHUB_DEV_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_GENESYS_USBHUB_PD_FIRMWARE);
 }
 
 static void

--- a/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-brlb-firmware.c
@@ -129,6 +129,7 @@ fu_goodixtp_brlb_firmware_parse(FuGoodixtpFirmware *self,
 static void
 fu_goodixtp_brlb_firmware_init(FuGoodixtpBrlbFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
+++ b/plugins/goodix-tp/fu-goodixtp-gtx8-firmware.c
@@ -212,6 +212,7 @@ fu_goodixtp_gtx8_firmware_parse(FuGoodixtpFirmware *self,
 static void
 fu_goodixtp_gtx8_firmware_init(FuGoodixtpGtx8Firmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/plugins/ilitek-its/fu-ilitek-its-firmware.c
+++ b/plugins/ilitek-its/fu-ilitek-its-firmware.c
@@ -198,6 +198,7 @@ static void
 fu_ilitek_its_firmware_init(FuIlitekItsFirmware *self)
 {
 	fu_ihex_firmware_set_padding_value(FU_IHEX_FIRMWARE(self), 0xFF);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_ILITEK_ITS_BLOCK);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 100);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_QUAD);
 }

--- a/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-firmware.c
@@ -183,6 +183,7 @@ fu_jabra_gnp_firmware_init(FuJabraGnpFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_JABRA_GNP_IMAGE);
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-puma-firmware.c
@@ -290,6 +290,7 @@ fu_kinetic_dp_puma_firmware_parse(FuFirmware *firmware,
 static void
 fu_kinetic_dp_puma_firmware_init(FuKineticDpPumaFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-secure-firmware.c
@@ -259,6 +259,7 @@ fu_kinetic_dp_secure_firmware_parse(FuFirmware *firmware,
 static void
 fu_kinetic_dp_secure_firmware_init(FuKineticDpSecureFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/legion-hid/fu-legion-hid-firmware.c
+++ b/plugins/legion-hid/fu-legion-hid-firmware.c
@@ -97,6 +97,7 @@ fu_legion_hid_firmware_parse(FuFirmware *firmware,
 static void
 fu_legion_hid_firmware_init(FuLegionHidFirmware *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/legion-hid2/fu-legion-hid2-firmware.c
+++ b/plugins/legion-hid2/fu-legion-hid2-firmware.c
@@ -73,6 +73,7 @@ static void
 fu_legion_hid2_firmware_init(FuLegionHid2Firmware *self)
 {
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_QUAD);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static gchar *

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -314,6 +314,8 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 static void
 fu_nordic_hid_archive_init(FuNordicHidArchive *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_NORDIC_HID_FIRMWARE_B0);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
 }
 

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-firmware.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-firmware.c
@@ -207,6 +207,7 @@ static void
 fu_synaptics_prometheus_firmware_init(FuSynapticsPrometheusFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), FU_SYNAPTICS_PROMETHEUS_FIRMWARE_COUNT_MAX);
 	self->signature_size = FU_SYNAPTICS_PROMETHEUS_FIRMWARE_PROMETHEUS_SIGSIZE;
 }

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-firmware.c
@@ -714,6 +714,7 @@ static void
 fu_synaptics_rmi_firmware_init(FuSynapticsRmiFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 	fu_firmware_set_images_max(FU_FIRMWARE(self), RMI_IMG_MAX_CONTAINERS);
 }
 

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -195,6 +195,7 @@ fu_telink_dfu_archive_parse(FuFirmware *firmware,
 static void
 fu_telink_dfu_archive_init(FuTelinkDfuArchive *self)
 {
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-firmware.c
@@ -134,6 +134,7 @@ static void
 fu_ti_tps6598x_firmware_init(FuTiTps6598xFirmware *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_DEDUPE_ID);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
 }
 
 static void

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -248,6 +248,7 @@ fu_vbe_simple_device_prepare_firmware(FuDevice *device,
 		    fu_fdt_firmware_get_image_by_path(FU_FDT_FIRMWARE(firmware), path, error);
 		if (img_firmware == NULL)
 			return NULL;
+		fu_firmware_add_image_gtype(firmware_container, FU_TYPE_FDT_IMAGE);
 		if (!fu_firmware_add_image(firmware_container, FU_FIRMWARE(img_firmware), error))
 			return NULL;
 	}

--- a/plugins/wacom-usb/fu-self-test.c
+++ b/plugins/wacom-usb/fu-self-test.c
@@ -89,7 +89,6 @@ main(int argc, char **argv)
 {
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
-	g_type_ensure(FU_TYPE_SREC_FIRMWARE);
 
 	/* only critical and error are fatal */
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);

--- a/plugins/wacom-usb/fu-wac-firmware.c
+++ b/plugins/wacom-usb/fu-wac-firmware.c
@@ -368,7 +368,8 @@ static void
 fu_wac_firmware_init(FuWacFirmware *self)
 {
 	fu_firmware_set_images_max(FU_FIRMWARE(self), 1024);
-	g_type_ensure(FU_TYPE_SREC_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_FIRMWARE);
+	fu_firmware_add_image_gtype(FU_FIRMWARE(self), FU_TYPE_SREC_FIRMWARE);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth-id9.c
@@ -203,6 +203,7 @@ fu_wac_module_bluetooth_id9_prepare_firmware(FuDevice *device,
 		return NULL;
 	payload_fw = fu_firmware_new_from_bytes(payload_bytes);
 	fu_firmware_set_id(payload_fw, FU_FIRMWARE_ID_PAYLOAD);
+	fu_firmware_add_image_gtype(firmware, FU_TYPE_FIRMWARE);
 	if (!fu_firmware_add_image(firmware, payload_fw, error))
 		return NULL;
 

--- a/plugins/wistron-dock/fu-wistron-dock-device.c
+++ b/plugins/wistron-dock/fu-wistron-dock-device.c
@@ -380,6 +380,7 @@ fu_wistron_dock_device_prepare_firmware(FuDevice *device,
 	}
 
 	/* success */
+	fu_firmware_add_image_gtype(fw_new, FU_TYPE_FIRMWARE);
 	fu_firmware_set_id(fw_wsig, FU_FIRMWARE_ID_SIGNATURE);
 	if (!fu_firmware_add_image(fw_new, fw_wsig, error))
 		return NULL;


### PR DESCRIPTION
This means we no longer have to do FU_IS_{image} when getting images from the untrusted parent firmware.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
