### PR TITLE
engine: always attach device to history releases

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5285,6 +5285,9 @@ fu_engine_fixup_history_device_for_rel(FuEngine *self,
 		return TRUE;
 	}
 
+
+        /* set the device so version format is applied correctly */
+        fu_release_set_device(FU_RELEASE(release), device);
 	if (!fu_release_load(FU_RELEASE(release),
 			     NULL,
 			     component,


### PR DESCRIPTION
Version formatting requires a device to be attached to FuRelease. When reconstructing history entries this was not guaranteed, causing raw integer versions (e.g. 73984, 0x01070000) to be displayed instead of formatted versions.

This enforces attaching the device once a history release is matched, making version formatting reliable across snap and non-snap builds.

Fixes recurring regressions seen in #8177 and #9652. Related to #9356.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
