### PR TITLE
Always show the correct new firmware version in 'fwupdmgr get-history'

### DIFF
--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -1010,7 +1010,9 @@ fu_release_load(FuRelease *self,
 			return FALSE;
 		fwupd_release_set_version(FWUPD_RELEASE(self), version_rel);
 	} else {
-		fwupd_release_set_version(FWUPD_RELEASE(self), tmp);
+		/* historical releases have ->convert_version() already done */
+		if (fu_release_get_version(self) == NULL)
+			fu_release_set_version(self, tmp);
 	}
 
 	/* optional release ID -- currently a integer but maybe namespaced in the future */


### PR DESCRIPTION
Never overwrite the historical device new-version with the release hex version.

Fixes: https://github.com/fwupd/fwupd/issues/9652

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
