### PR TITLE
Auto-enable lazy-verfmt when required

### DIFF
--- a/libfwupdplugin/fu-version-common.c
+++ b/libfwupdplugin/fu-version-common.c
@@ -412,8 +412,18 @@ _g_ascii_is_xdigits(const gchar *str)
 	return TRUE;
 }
 
-static guint
-fu_version_format_number_sections(FwupdVersionFormat fmt)
+/**
+ * fu_version_format_get_sections:
+ * @fmt: a version format, e.g. %FWUPD_VERSION_FORMAT_TRIPLET
+ *
+ * Returns the number or "dotted" sections for the given version format.
+ *
+ * Returns: integer, e.g. `1.2.3` would return 3, or 0 if the version format was not valid
+ *
+ * Since: 2.1.1
+ */
+guint
+fu_version_format_get_sections(FwupdVersionFormat fmt)
 {
 	if (fmt == FWUPD_VERSION_FORMAT_PLAIN || fmt == FWUPD_VERSION_FORMAT_NUMBER ||
 	    fmt == FWUPD_VERSION_FORMAT_HEX)
@@ -446,7 +456,7 @@ gchar *
 fu_version_ensure_semver(const gchar *version, FwupdVersionFormat fmt)
 {
 	guint sections_actual;
-	guint sections_expected = fu_version_format_number_sections(fmt);
+	guint sections_expected = fu_version_format_get_sections(fmt);
 	g_autofree gchar *tmp = NULL;
 	g_auto(GStrv) split = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);

--- a/libfwupdplugin/fu-version-common.h
+++ b/libfwupdplugin/fu-version-common.h
@@ -33,3 +33,5 @@ gboolean
 fu_version_verify_format(const gchar *version,
 			 FwupdVersionFormat fmt,
 			 GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+guint
+fu_version_format_get_sections(FwupdVersionFormat fmt);

--- a/src/fu-release.c
+++ b/src/fu-release.c
@@ -1005,6 +1005,23 @@ fu_release_load(FuRelease *self,
 	}
 	if (self->device != NULL) {
 		g_autofree gchar *version_rel = NULL;
+		FwupdVersionFormat verfmt = fu_device_get_version_format(self->device);
+
+		/* auto-detect missing lazy-verfmt */
+		if (fu_version_format_get_sections(verfmt) > 1 &&
+		    g_strstr_len(tmp, -1, ".") == NULL) {
+#ifdef SUPPORTED_BUILD
+			g_autofree gchar *id_display = fu_device_get_id_display(self->device);
+			g_critical("device %s has a release with un-dotted release version of %s, "
+				   "use 'fu_device_add_private_flag(device, "
+				   "FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT)' in the %s plugin",
+				   id_display,
+				   tmp,
+				   fu_device_get_plugin(self->device));
+#endif
+			fu_device_add_private_flag(self->device,
+						   FU_DEVICE_PRIVATE_FLAG_LAZY_VERFMT);
+		}
 		version_rel = fu_release_get_release_version(self, tmp, error);
 		if (version_rel == NULL)
 			return FALSE;


### PR DESCRIPTION
I don't think this fixes the bug I'm looking for, but it seems a sensible thing to do.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
