### PR TITLE
fastboot: Add support for Rolling RW101-CAT12.

### DIFF
--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -44,3 +44,4 @@ FastbootBlockSize = 16384
 FastbootOperationDelay = 0
 Summary = Rolling RW101 Modem (fastboot)
 CounterpartGuid = USB\VID_33F8&PID_0301
+CounterpartGuid = USB\VID_33F8&PID_0302

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -219,3 +219,10 @@ GType = FuMmFastbootDevice
 Summary = Rolling RW101-GL Module
 Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
 CounterpartGuid = USB\VID_33F8&PID_D00D
+
+# Rolling RW101-CAT12
+[USB\VID_33F8&PID_0302]
+GType = FuMmFastbootDevice
+Summary = Rolling RW101-GL Module
+Flags = uninhibit-modemmanager-after-fastboot-reboot,detach-at-fastboot-has-no-response
+CounterpartGuid = USB\VID_33F8&PID_D00D


### PR DESCRIPTION
When entering fastboot mode, RW101-CAT12(VID_33F8&PID_0302) and RW101(VID_33F8&PID_0301) both appear as VID_33F8&PID_D00D, so add a CounterpartGuid item of RW101-CAT12 in VID_33F8&PID_D00D entry.

modem-manager: Add support for Rolling RW101-CAT12.


