### PR TITLE
plugins/qc-firehose: clear the remaining power reset logs

### DIFF
--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -749,6 +749,10 @@ fu_qc_firehose_impl_reset(FuQcFirehoseImpl *self, GError **error)
 		}
 	}
 
+	/* ensure there are no logs left to prevent device release failure */
+	if (!fu_qc_firehose_impl_read_xml(self, 500, &helper, &error_local))
+		g_debug("ignoring: %s", error_local->message);
+
 	/* success */
 	return TRUE;
 }


### PR DESCRIPTION
After receiving the `<power value="reset">` command and replying with a response, some devices(e.g. Quectel EM160R) may still output logs before the actual reset occurs. These logs are buffered in the device driver and may prevent the driver from releasing and resetting the device if not read.

The following is the output from the device(e.g. Quectel EM160R) while processing the power reset command. 
Ensure it is all completely read. 

``` 
> <power value="reset">

< <log value="INFO: Calling handler for power" /></data>
< <response value="ACK" rawmode="false" /></data>
< <log value="INFO: Will issue reset/power off 100 useconds, \
                    if this hangs check if watchdog is enabled" /></data>
< <log value="INFO: bsp_target_reset() 1" /></data>
```

Fix Verification Results:

 - [x] Quectel EM160R (PCIe): Fix validated
 - [x] Quectel RM520N (PCIe): No side effects observed
 - [x] Quectel EM061K (USB): No side effects observed
 - [ ] Pending: Compatibility with other models

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
