### PR TITLE
Add fu_firmware_new_from_xml() to build firmware easier

### DIFF
--- a/contrib/ci/oss-fuzz.py
+++ b/contrib/ci/oss-fuzz.py
@@ -304,8 +304,8 @@ class Fuzzer:
         return acc
 
     @property
-    def new_gtype(self) -> str:
-        return f"g_object_new(FU_TYPE_{self.pattern.replace('-', '_').upper()}, NULL)"
+    def gtype(self) -> str:
+        return f"FU_TYPE_{self.pattern.replace('-', '_').upper()}"
 
     @property
     def header(self) -> str:
@@ -447,12 +447,12 @@ def _build(bld: Builder) -> None:
         Fuzzer("efi-filesystem", pattern="efi-filesystem"),
         Fuzzer("efi-volume", pattern="efi-volume"),
         Fuzzer("efi-load-option", pattern="efi-load-option"),
-        Fuzzer("ifd"),
+        Fuzzer("ifd-bios", pattern="ifd-bios"),
     ]:
         src = bld.substitute(
             "fwupd/libfwupdplugin/fu-fuzzer-firmware.c.in",
             {
-                "@FIRMWARENEW@": fzr.new_gtype,
+                "@GTYPE@": fzr.gtype,
                 "@INCLUDE@": os.path.join("libfwupdplugin", fzr.header),
             },
         )
@@ -463,7 +463,7 @@ def _build(bld: Builder) -> None:
         src_generator = bld.substitute(
             "fwupd/libfwupdplugin/fu-fuzzer-generate.c.in",
             {
-                "@FIRMWARENEW@": fzr.new_gtype,
+                "@GTYPE@": fzr.gtype,
                 "@INCLUDE@": os.path.join("libfwupdplugin", fzr.header),
             },
         )
@@ -521,7 +521,7 @@ def _build(bld: Builder) -> None:
         src = bld.substitute(
             "fwupd/libfwupdplugin/fu-fuzzer-firmware.c.in",
             {
-                "@FIRMWARENEW@": fzr.new_gtype,
+                "@GTYPE@": fzr.gtype,
                 "@INCLUDE@": os.path.join("plugins", fzr.srcdir, fzr.header),
             },
         )
@@ -534,7 +534,7 @@ def _build(bld: Builder) -> None:
         src_generator = bld.substitute(
             "fwupd/libfwupdplugin/fu-fuzzer-generate.c.in",
             {
-                "@FIRMWARENEW@": fzr.new_gtype,
+                "@GTYPE@": fzr.gtype,
                 "@INCLUDE@": os.path.join("plugins", fzr.srcdir, fzr.header),
             },
         )

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -205,3 +205,9 @@ Use `./contrib/migrate.py` to migrate up out-of-tree plugins to the new API.
 * `fu_input_stream_find()`: Add a start offset, typically `0x0`.
 * `fu_device_get_parent()`: Add a `GError`
 * `fu_device_get_proxy()`: Add a `GError`
+
+## 2.1.1
+
+* `fu_context_add_firmware_gtype()`: Drop the `id` parameter.
+* `fu_firmware_build_from_xml()`: Use `fu_firmware_new_from_xml()` instead.
+* `fu_firmware_build_from_filename()`: Use `fu_firmware_new_from_filename()` instead.

--- a/libfwupdplugin/fu-context-helper.c
+++ b/libfwupdplugin/fu-context-helper.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#define G_LOG_DOMAIN "FuEngine"
+
+#include "config.h"
+
+#include <libfwupdplugin/fu-acpi-table.h>
+#include <libfwupdplugin/fu-archive-firmware.h>
+#include <libfwupdplugin/fu-cab-firmware.h>
+#include <libfwupdplugin/fu-cfu-offer.h>
+#include <libfwupdplugin/fu-cfu-payload.h>
+#include <libfwupdplugin/fu-context-private.h>
+#include <libfwupdplugin/fu-coswid-firmware.h>
+#include <libfwupdplugin/fu-csv-firmware.h>
+#include <libfwupdplugin/fu-dfuse-firmware.h>
+#include <libfwupdplugin/fu-edid.h>
+#include <libfwupdplugin/fu-efi-device-path-list.h>
+#include <libfwupdplugin/fu-efi-file.h>
+#include <libfwupdplugin/fu-efi-filesystem.h>
+#include <libfwupdplugin/fu-efi-ftw-store.h>
+#include <libfwupdplugin/fu-efi-section.h>
+#include <libfwupdplugin/fu-efi-signature-list.h>
+#include <libfwupdplugin/fu-efi-signature.h>
+#include <libfwupdplugin/fu-efi-variable-authentication2.h>
+#include <libfwupdplugin/fu-efi-volume.h>
+#include <libfwupdplugin/fu-efi-vss2-variable-store.h>
+#include <libfwupdplugin/fu-elf-firmware.h>
+#include <libfwupdplugin/fu-fdt-firmware.h>
+#include <libfwupdplugin/fu-fit-firmware.h>
+#include <libfwupdplugin/fu-fmap-firmware.h>
+#include <libfwupdplugin/fu-hid-descriptor.h>
+#include <libfwupdplugin/fu-ifd-bios.h>
+#include <libfwupdplugin/fu-ifd-firmware.h>
+#include <libfwupdplugin/fu-ifwi-cpd-firmware.h>
+#include <libfwupdplugin/fu-ifwi-fpt-firmware.h>
+#include <libfwupdplugin/fu-ihex-firmware.h>
+#include <libfwupdplugin/fu-intel-thunderbolt-firmware.h>
+#include <libfwupdplugin/fu-json-firmware.h>
+#include <libfwupdplugin/fu-linear-firmware.h>
+#include <libfwupdplugin/fu-oprom-firmware.h>
+#include <libfwupdplugin/fu-pefile-firmware.h>
+#include <libfwupdplugin/fu-sbatlevel-section.h>
+#include <libfwupdplugin/fu-srec-firmware.h>
+#include <libfwupdplugin/fu-usb-device-fw-ds20.h>
+#include <libfwupdplugin/fu-usb-device-ms-ds20.h>
+#include <libfwupdplugin/fu-uswid-firmware.h>
+#include <libfwupdplugin/fu-x509-certificate.h>
+
+#include "fu-context-helper.h"
+
+void
+fu_context_add_firmware_gtypes(FuContext *self)
+{
+	fu_context_add_firmware_gtype(self, FU_TYPE_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_CAB_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_DFU_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_FDT_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_CSV_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_FIT_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_DFUSE_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_IFWI_CPD_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_IFWI_FPT_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_OPROM_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_FMAP_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_IHEX_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_LINEAR_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_SREC_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_HID_DESCRIPTOR);
+	fu_context_add_firmware_gtype(self, FU_TYPE_ARCHIVE_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_SMBIOS);
+	fu_context_add_firmware_gtype(self, FU_TYPE_ACPI_TABLE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_SBATLEVEL_SECTION);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EDID);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_FILE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_SIGNATURE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_SIGNATURE_LIST);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_VARIABLE_AUTHENTICATION2);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_LOAD_OPTION);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_DEVICE_PATH_LIST);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_FILESYSTEM);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_SECTION);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_VOLUME);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_FTW_STORE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_EFI_VSS2_VARIABLE_STORE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_JSON_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_IFD_BIOS);
+	fu_context_add_firmware_gtype(self, FU_TYPE_IFD_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_CFU_OFFER);
+	fu_context_add_firmware_gtype(self, FU_TYPE_CFU_PAYLOAD);
+	fu_context_add_firmware_gtype(self, FU_TYPE_USWID_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_COSWID_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_PEFILE_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_ELF_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_X509_CERTIFICATE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_INTEL_THUNDERBOLT_FIRMWARE);
+	fu_context_add_firmware_gtype(self, FU_TYPE_INTEL_THUNDERBOLT_NVM);
+	fu_context_add_firmware_gtype(self, FU_TYPE_USB_DEVICE_FW_DS20);
+	fu_context_add_firmware_gtype(self, FU_TYPE_USB_DEVICE_MS_DS20);
+}

--- a/libfwupdplugin/fu-context-helper.h
+++ b/libfwupdplugin/fu-context-helper.h
@@ -16,3 +16,5 @@ fu_context_add_backend(FuContext *self, FuBackend *backend) G_GNUC_NON_NULL(1, 2
 FuBackend *
 fu_context_get_backend_by_name(FuContext *self, const gchar *name, GError **error)
     G_GNUC_NON_NULL(1, 2);
+void
+fu_context_add_firmware_gtypes(FuContext *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -36,7 +36,7 @@ fu_context_get_runtime_versions(FuContext *self) G_GNUC_NON_NULL(1);
 GHashTable *
 fu_context_get_compile_versions(FuContext *self) G_GNUC_NON_NULL(1);
 void
-fu_context_add_firmware_gtype(FuContext *self, const gchar *id, GType gtype) G_GNUC_NON_NULL(1, 2);
+fu_context_add_firmware_gtype(FuContext *self, GType gtype) G_GNUC_NON_NULL(1);
 GPtrArray *
 fu_context_get_firmware_gtype_ids(FuContext *self) G_GNUC_NON_NULL(1);
 GArray *

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -859,28 +859,60 @@ fu_context_get_udev_subsystems(FuContext *self)
 	return g_steal_pointer(&subsystems);
 }
 
+static gchar *
+fu_context_convert_firmware_gtype_to_id(GType gtype)
+{
+	const gchar *gtype_name = g_type_name(gtype);
+	gsize len = strlen(gtype_name);
+	g_autoptr(GString) str = g_string_new(NULL);
+
+	/* no format */
+	if (g_strcmp0(gtype_name, "FuFirmware") == 0)
+		return g_strdup("raw");
+
+	/* not useful */
+	if (g_str_has_suffix(gtype_name, "Firmware"))
+		len -= 8;
+
+	/* normal plugins */
+	for (guint j = 2; j < len; j++) {
+		gchar tmp = gtype_name[j];
+		if (g_ascii_isupper(tmp)) {
+			if (str->len > 0)
+				g_string_append_c(str, '-');
+			g_string_append_c(str, g_ascii_tolower(tmp));
+		} else {
+			g_string_append_c(str, tmp);
+		}
+	}
+	if (str->len == 0)
+		return NULL;
+	return g_string_free(g_steal_pointer(&str), FALSE);
+}
+
 /**
  * fu_context_add_firmware_gtype:
  * @self: a #FuContext
- * @id: (nullable): an optional string describing the type, e.g. `ihex`
  * @gtype: a #GType e.g. `FU_TYPE_FOO_FIRMWARE`
  *
- * Adds a firmware #GType which is used when creating devices. If @id is not
- * specified then it is guessed using the #GType name.
+ * Adds a firmware #GType which is used when creating devices.
  *
  * Plugins can use this method only in fu_plugin_init()
  *
- * Since: 1.6.0
+ * Since: 2.1.1
  **/
 void
-fu_context_add_firmware_gtype(FuContext *self, const gchar *id, GType gtype)
+fu_context_add_firmware_gtype(FuContext *self, GType gtype)
 {
 	FuContextPrivate *priv = GET_PRIVATE(self);
+
 	g_return_if_fail(FU_IS_CONTEXT(self));
-	g_return_if_fail(id != NULL);
 	g_return_if_fail(gtype != G_TYPE_INVALID);
+
 	g_type_ensure(gtype);
-	g_hash_table_insert(priv->firmware_gtypes, g_strdup(id), GSIZE_TO_POINTER(gtype));
+	g_hash_table_insert(priv->firmware_gtypes,
+			    fu_context_convert_firmware_gtype_to_id(gtype),
+			    GSIZE_TO_POINTER(gtype));
 }
 
 /**

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -82,6 +82,12 @@ fu_firmware_new(void);
 FuFirmware *
 fu_firmware_new_from_bytes(GBytes *fw);
 FuFirmware *
+fu_firmware_new_from_xml(const gchar *xml, GError **error) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
+FuFirmware *
+fu_firmware_new_from_filename(const gchar *filename, GError **error) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
+FuFirmware *
 fu_firmware_new_from_gtypes(GInputStream *stream,
 			    gsize offset,
 			    FuFirmwareParseFlags flags,
@@ -181,14 +187,6 @@ fu_firmware_tokenize(FuFirmware *self,
 gboolean
 fu_firmware_build(FuFirmware *self, XbNode *n, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1, 2);
-gboolean
-fu_firmware_build_from_xml(FuFirmware *self,
-			   const gchar *xml,
-			   GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
-gboolean
-fu_firmware_build_from_filename(FuFirmware *self,
-				const gchar *filename,
-				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2);
 gboolean
 fu_firmware_parse_stream(FuFirmware *self,
 			 GInputStream *stream,

--- a/libfwupdplugin/fu-fuzzer-firmware.c.in
+++ b/libfwupdplugin/fu-fuzzer-firmware.c.in
@@ -11,7 +11,7 @@
 int
 LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 {
-	g_autoptr(FuFirmware) firmware = FU_FIRMWARE(@FIRMWARENEW@);
+	g_autoptr(FuFirmware) firmware = FU_FIRMWARE(g_object_new(@GTYPE@, NULL));
 	g_autoptr(GBytes) fw = g_bytes_new(data, size);
 	gboolean ret;
 
@@ -20,7 +20,7 @@ LLVMFuzzerTestOneInput(const guint8 *data, gsize size)
 	ret = fu_firmware_parse_bytes(firmware, fw, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, NULL);
 	if (!ret && fu_firmware_has_flag(firmware, FU_FIRMWARE_FLAG_HAS_CHECKSUM)) {
 		g_clear_object(&firmware);
-		firmware = FU_FIRMWARE(@FIRMWARENEW@);
+		firmware = FU_FIRMWARE(g_object_new(@GTYPE@, NULL));
 		ret = fu_firmware_parse_bytes(firmware,
 					fw,
 					0x0,

--- a/libfwupdplugin/fu-fuzzer-generate.c.in
+++ b/libfwupdplugin/fu-fuzzer-generate.c.in
@@ -11,7 +11,7 @@
 int
 main(int argc, char **argv)
 {
-	g_autoptr(FuFirmware) firmware = FU_FIRMWARE(@FIRMWARENEW@);
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) blob_dst = NULL;
 	g_autoptr(GError) error = NULL;
 
@@ -21,7 +21,9 @@ main(int argc, char **argv)
 		g_printerr("Invalid arguments, expected %s XML BIN\n", argv[0]);
 		return EXIT_FAILURE;
 	}
-	if (!fu_firmware_build_from_filename(firmware, argv[1], &error)) {
+	g_type_ensure(@GTYPE@);
+	firmware = fu_firmware_new_from_filename(argv[1], &error);
+	if (firmware == NULL) {
 		g_printerr("Failed to build: %s\n", error->message);
 		return EXIT_FAILURE;
 	}

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -1528,22 +1528,6 @@ fu_plugin_set_device_gtype_default(FuPlugin *self, GType device_gtype)
 	priv->device_gtype_default = device_gtype;
 }
 
-static gchar *
-fu_plugin_string_uncamelcase(const gchar *str)
-{
-	GString *tmp = g_string_new(NULL);
-	for (guint i = 0; str[i] != '\0'; i++) {
-		if (g_ascii_islower(str[i]) || g_ascii_isdigit(str[i])) {
-			g_string_append_c(tmp, str[i]);
-			continue;
-		}
-		if (i > 0)
-			g_string_append_c(tmp, '-');
-		g_string_append_c(tmp, g_ascii_tolower(str[i]));
-	}
-	return g_string_free(tmp, FALSE);
-}
-
 static gboolean
 fu_plugin_check_amdgpu_dpaux(FuPlugin *self, GError **error)
 {
@@ -1629,31 +1613,19 @@ fu_plugin_add_udev_subsystem(FuPlugin *self, const gchar *subsystem)
 /**
  * fu_plugin_add_firmware_gtype:
  * @self: a #FuPlugin
- * @id: (nullable): an optional string describing the type, e.g. `ihex`
  * @gtype: a #GType e.g. `FU_TYPE_FOO_FIRMWARE`
  *
- * Adds a firmware #GType which is used when creating devices. If @id is not
- * specified then it is guessed using the #GType name.
+ * Adds a firmware #GType which is used when creating devices.
  *
  * Plugins can use this method only in fu_plugin_init()
  *
- * Since: 1.3.3
+ * Since: 2.1.1
  **/
 void
-fu_plugin_add_firmware_gtype(FuPlugin *self, const gchar *id, GType gtype)
+fu_plugin_add_firmware_gtype(FuPlugin *self, GType gtype)
 {
 	FuPluginPrivate *priv = GET_PRIVATE(self);
-	g_autofree gchar *id_safe = NULL;
-	if (id != NULL) {
-		id_safe = g_strdup(id);
-	} else {
-		g_autoptr(GString) str = g_string_new(g_type_name(gtype));
-		if (g_str_has_prefix(str->str, "Fu"))
-			g_string_erase(str, 0, 2);
-		g_string_replace(str, "Firmware", "", 1);
-		id_safe = fu_plugin_string_uncamelcase(str->str);
-	}
-	fu_context_add_firmware_gtype(priv->ctx, id_safe, gtype);
+	fu_context_add_firmware_gtype(priv->ctx, gtype);
 }
 
 static gboolean

--- a/libfwupdplugin/fu-plugin.h
+++ b/libfwupdplugin/fu-plugin.h
@@ -510,7 +510,7 @@ fu_plugin_get_device_gtype_default(FuPlugin *self) G_GNUC_NON_NULL(1);
 void
 fu_plugin_set_device_gtype_default(FuPlugin *self, GType device_gtype) G_GNUC_NON_NULL(1);
 void
-fu_plugin_add_firmware_gtype(FuPlugin *self, const gchar *id, GType gtype) G_GNUC_NON_NULL(1);
+fu_plugin_add_firmware_gtype(FuPlugin *self, GType gtype) G_GNUC_NON_NULL(1);
 void
 fu_plugin_add_device_udev_subsystem(FuPlugin *self, const gchar *subsystem) G_GNUC_NON_NULL(1, 2);
 void

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -967,19 +967,19 @@ fu_context_firmware_gtypes_func(void)
 	g_autoptr(GArray) gtypes = NULL;
 	g_autoptr(GPtrArray) gtype_ids = NULL;
 
-	fu_context_add_firmware_gtype(ctx, "base", FU_TYPE_FIRMWARE);
+	fu_context_add_firmware_gtype(ctx, FU_TYPE_FIRMWARE);
 
 	gtype_ids = fu_context_get_firmware_gtype_ids(ctx);
 	g_assert_nonnull(gtype_ids);
 	g_assert_cmpint(gtype_ids->len, ==, 1);
-	g_assert_cmpstr(g_ptr_array_index(gtype_ids, 0), ==, "base");
+	g_assert_cmpstr(g_ptr_array_index(gtype_ids, 0), ==, "raw");
 
 	gtypes = fu_context_get_firmware_gtypes(ctx);
 	g_assert_nonnull(gtypes);
 	g_assert_cmpint(gtypes->len, ==, 1);
 	g_assert_cmpint(g_array_index(gtypes, GType, 0), ==, FU_TYPE_FIRMWARE);
 
-	g_assert_cmpint(fu_context_get_firmware_gtype_by_id(ctx, "base"), ==, FU_TYPE_FIRMWARE);
+	g_assert_cmpint(fu_context_get_firmware_gtype_by_id(ctx, "raw"), ==, FU_TYPE_FIRMWARE);
 	g_assert_cmpint(fu_context_get_firmware_gtype_by_id(ctx, "n/a"), ==, G_TYPE_INVALID);
 }
 
@@ -1032,14 +1032,13 @@ fu_context_hwids_fdt_func(void)
 	g_autofree gchar *dump = NULL;
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
-	g_autoptr(FuFirmware) fdt_tmp = fu_fdt_firmware_new();
+	g_autoptr(FuFirmware) fdt_tmp = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GFile) file =
 	    g_file_new_for_path("/tmp/fwupd-self-test/var/lib/fwupd/system.dtb");
 
 	/* write file */
-	ret = fu_firmware_build_from_xml(
-	    FU_FIRMWARE(fdt_tmp),
+	fdt_tmp = fu_firmware_new_from_xml(
 	    "<firmware gtype=\"FuFdtFirmware\">\n"
 	    "  <firmware gtype=\"FuFdtImage\">\n"
 	    "    <metadata key=\"compatible\" format=\"str\">pine64,rockpro64-v2.1</metadata>\n"
@@ -1066,7 +1065,7 @@ fu_context_hwids_fdt_func(void)
 	    "</firmware>\n",
 	    &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(fdt_tmp);
 	ret = fu_firmware_write_file(FU_FIRMWARE(fdt_tmp), file, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -1592,7 +1591,7 @@ fu_plugin_fdt_func(void)
 	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuFirmware) fdt = NULL;
 	g_autoptr(FuFirmware) fdt_root = NULL;
-	g_autoptr(FuFirmware) fdt_tmp = fu_fdt_firmware_new();
+	g_autoptr(FuFirmware) fdt_tmp = NULL;
 	g_autoptr(FuFirmware) img2 = NULL;
 	g_autoptr(FuFirmware) img3 = NULL;
 	g_autoptr(FuFirmware) img4 = NULL;
@@ -1601,8 +1600,7 @@ fu_plugin_fdt_func(void)
 	    g_file_new_for_path("/tmp/fwupd-self-test/var/lib/fwupd/system.dtb");
 
 	/* write file */
-	ret = fu_firmware_build_from_xml(
-	    FU_FIRMWARE(fdt_tmp),
+	fdt_tmp = fu_firmware_new_from_xml(
 	    "<firmware gtype=\"FuFdtFirmware\">\n"
 	    "  <firmware gtype=\"FuFdtImage\">\n"
 	    "    <metadata key=\"compatible\" format=\"str\">pine64,rockpro64-v2.1</metadata>\n"
@@ -1610,7 +1608,7 @@ fu_plugin_fdt_func(void)
 	    "</firmware>\n",
 	    &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(fdt_tmp);
 	ret = fu_firmware_write_file(FU_FIRMWARE(fdt_tmp), file, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -3628,20 +3626,19 @@ static void
 fu_firmware_ihex_func(void)
 {
 	const guint8 *data;
-	gboolean ret;
 	gsize len;
 	g_autofree gchar *filename_hex = NULL;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuFirmware) firmware = fu_ihex_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) data_fw = NULL;
 	g_autoptr(GBytes) data_hex = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* load a Intel hex32 file */
 	filename_hex = g_test_build_filename(G_TEST_DIST, "tests", "ihex.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename_hex, &error);
+	firmware = fu_firmware_new_from_filename(filename_hex, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	data_fw = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_fw);
@@ -3670,19 +3667,18 @@ static void
 fu_firmware_ihex_signed_func(void)
 {
 	const guint8 *data;
-	gboolean ret;
 	gsize len;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_ihex_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) data_fw = NULL;
 	g_autoptr(GBytes) data_sig = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* load a signed Intel hex32 file */
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "ihex-signed.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	data_fw = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_fw);
@@ -3745,16 +3741,15 @@ fu_firmware_ihex_offset_func(void)
 static void
 fu_firmware_srec_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_srec_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) data_bin = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "srec.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	data_bin = fu_firmware_get_bytes(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_bin);
@@ -3770,15 +3765,15 @@ fu_firmware_fdt_func(void)
 	g_autofree gchar *filename = NULL;
 	g_autofree gchar *val = NULL;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuFirmware) firmware = fu_fdt_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) img1 = NULL;
 	g_autoptr(FuFdtImage) img2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "fdt.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	g_assert_cmpint(fu_fdt_firmware_get_cpuid(FU_FDT_FIRMWARE(firmware)), ==, 0x0);
 	str = fu_firmware_to_string(firmware);
 	g_debug("%s", str);
@@ -3816,13 +3811,13 @@ fu_firmware_fit_func(void)
 	g_autofree gchar *str = NULL;
 	g_auto(GStrv) val = NULL;
 	g_autoptr(FuFdtImage) img1 = NULL;
-	g_autoptr(FuFirmware) firmware = fu_fit_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "fit.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	g_assert_cmpint(fu_fit_firmware_get_timestamp(FU_FIT_FIRMWARE(firmware)), ==, 0x629D4ABD);
 	str = fu_firmware_to_string(firmware);
 	g_debug("%s", str);
@@ -3975,17 +3970,16 @@ fu_test_firmware_dfuse_get_size(FuFirmware *firmware)
 static void
 fu_firmware_dfuse_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_dfuse_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* load a DfuSe firmware */
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "dfuse.builder.xml", NULL);
 	g_assert_nonnull(filename);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	g_assert_cmpint(fu_dfu_firmware_get_vid(FU_DFU_FIRMWARE(firmware)), ==, 0x1234);
 	g_assert_cmpint(fu_dfu_firmware_get_pid(FU_DFU_FIRMWARE(firmware)), ==, 0x5678);
 	g_assert_cmpint(fu_dfu_firmware_get_release(FU_DFU_FIRMWARE(firmware)), ==, 0x8642);
@@ -3995,11 +3989,10 @@ fu_firmware_dfuse_func(void)
 static void
 fu_firmware_fmap_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
 	g_autofree gchar *csum = NULL;
 	g_autofree gchar *img_str = NULL;
-	g_autoptr(FuFirmware) firmware = fu_fmap_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) img = NULL;
 	g_autoptr(GBytes) img_blob = NULL;
 	g_autoptr(GBytes) roundtrip = NULL;
@@ -4014,9 +4007,9 @@ fu_firmware_fmap_func(void)
 	/* load firmware */
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "fmap-offset.builder.xml", NULL);
 	g_assert_nonnull(filename);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 
 	/* check image count */
 	images = fu_firmware_get_images(firmware);
@@ -4124,9 +4117,8 @@ fu_firmware_sorted_func(void)
 static void
 fu_firmware_new_from_gtypes_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_dfu_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) firmware1 = NULL;
 	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware3 = NULL;
@@ -4135,9 +4127,9 @@ fu_firmware_new_from_gtypes_func(void)
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	fw = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(fw);
@@ -4323,16 +4315,15 @@ fu_firmware_linear_func(void)
 static void
 fu_firmware_dfu_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_dfu_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) data_bin = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	g_assert_cmpint(fu_dfu_firmware_get_vid(FU_DFU_FIRMWARE(firmware)), ==, 0x1234);
 	g_assert_cmpint(fu_dfu_firmware_get_pid(FU_DFU_FIRMWARE(firmware)), ==, 0x4321);
 	g_assert_cmpint(fu_dfu_firmware_get_release(FU_DFU_FIRMWARE(firmware)), ==, 0xdead);
@@ -4345,18 +4336,17 @@ fu_firmware_dfu_func(void)
 static void
 fu_firmware_ifwi_cpd_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_ifwi_cpd_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) img1 = NULL;
 	g_autoptr(FuFirmware) img2 = NULL;
 	g_autoptr(GBytes) data_bin = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "ifwi-cpd.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	g_assert_cmpint(fu_firmware_get_idx(firmware), ==, 0x1234);
 	data_bin = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
@@ -4379,18 +4369,17 @@ fu_firmware_ifwi_cpd_func(void)
 static void
 fu_firmware_ifwi_fpt_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_ifwi_fpt_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) img1 = NULL;
 	g_autoptr(FuFirmware) img2 = NULL;
 	g_autoptr(GBytes) data_bin = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "ifwi-fpt.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 	data_bin = fu_firmware_write(firmware, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(data_bin);
@@ -4414,16 +4403,16 @@ fu_firmware_oprom_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_oprom_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
 	g_autoptr(FuFirmware) firmware2 = fu_oprom_firmware_new();
 	g_autoptr(FuFirmware) img1 = NULL;
 	g_autoptr(GBytes) data_bin = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "oprom.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware1, filename, &error);
+	firmware1 = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	g_assert_cmpint(fu_firmware_get_idx(firmware1), ==, 0x1);
 	data_bin = fu_firmware_write(firmware1, &error);
 	g_assert_no_error(error);
@@ -4448,19 +4437,18 @@ fu_firmware_oprom_func(void)
 static void
 fu_firmware_dfu_patch_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *csum = NULL;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_dfu_firmware_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) data_new = NULL;
 	g_autoptr(GBytes) data_patch0 = g_bytes_new_static("XXXX", 4);
 	g_autoptr(GBytes) data_patch1 = g_bytes_new_static("HELO", 4);
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "dfu.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 
 	/* add a couple of patches */
 	fu_firmware_add_patch(firmware, 0x0, data_patch0);
@@ -4483,17 +4471,16 @@ fu_firmware_dfu_patch_func(void)
 static void
 fu_hid_descriptor_container_func(void)
 {
-	gboolean ret;
 	g_autofree gchar *filename = NULL;
-	g_autoptr(FuFirmware) firmware = fu_hid_descriptor_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuFirmware) item_id = NULL;
 	g_autoptr(FuHidReport) report = NULL;
 	g_autoptr(GError) error = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "hid-descriptor2.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 
 	/* find report-id from usage */
 	report = fu_hid_descriptor_find_report(FU_HID_DESCRIPTOR(firmware),
@@ -4516,8 +4503,7 @@ fu_hid_descriptor_container_func(void)
 static void
 fu_hid_descriptor_func(void)
 {
-	gboolean ret;
-	g_autoptr(FuFirmware) firmware = fu_hid_descriptor_new();
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuHidReport) report1 = NULL;
 	g_autoptr(FuHidReport) report2 = NULL;
 	g_autoptr(FuHidReport) report3 = NULL;
@@ -4528,9 +4514,9 @@ fu_hid_descriptor_func(void)
 	g_autofree gchar *filename = NULL;
 
 	filename = g_test_build_filename(G_TEST_DIST, "tests", "hid-descriptor.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware, filename, &error);
+	firmware = fu_firmware_new_from_filename(filename, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware);
 
 	/* find report-id from usage */
 	report4 =
@@ -5661,12 +5647,6 @@ fu_firmware_builder_round_trip_func(void)
 		FU_FIRMWARE_BUILDER_FLAG_NO_BINARY_COMPARE,
 	    },
 	    {
-		FU_TYPE_INTEL_THUNDERBOLT_FIRMWARE,
-		"intel-thunderbolt.builder.xml",
-		"1a2dec48aab3e1e29907f2148ab16e4730387325",
-		FU_FIRMWARE_BUILDER_FLAG_NO_BINARY_COMPARE,
-	    },
-	    {
 		FU_TYPE_USB_BOS_DESCRIPTOR,
 		"usb-bos-descriptor.builder.xml",
 		"a305749853781c6899c4b28039cb4c7d9059b910",
@@ -5700,8 +5680,8 @@ fu_firmware_builder_round_trip_func(void)
 		g_autofree gchar *filename = NULL;
 		g_autofree gchar *xml1 = NULL;
 		g_autofree gchar *xml2 = NULL;
-		g_autoptr(FuFirmware) firmware1 = g_object_new(map[i].gtype, NULL);
-		g_autoptr(FuFirmware) firmware2 = g_object_new(map[i].gtype, NULL);
+		g_autoptr(FuFirmware) firmware1 = NULL;
+		g_autoptr(FuFirmware) firmware2 = NULL;
 		g_autoptr(FuFirmware) firmware3 = g_object_new(map[i].gtype, NULL);
 		g_autoptr(GError) error = NULL;
 		g_autoptr(GBytes) blob = NULL;
@@ -5712,9 +5692,9 @@ fu_firmware_builder_round_trip_func(void)
 		ret = g_file_get_contents(filename, &xml1, NULL, &error);
 		g_assert_no_error(error);
 		g_assert_true(ret);
-		ret = fu_firmware_build_from_xml(firmware1, xml1, &error);
+		firmware1 = fu_firmware_new_from_xml(xml1, &error);
 		g_assert_no_error(error);
-		g_assert_true(ret);
+		g_assert_nonnull(firmware1);
 		csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(csum1);
@@ -5751,9 +5731,9 @@ fu_firmware_builder_round_trip_func(void)
 		/* ensure we can round-trip to XML */
 		xml2 = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 		g_assert_no_error(error);
-		ret = fu_firmware_build_from_xml(firmware2, xml2, &error);
+		firmware2 = fu_firmware_new_from_xml(xml2, &error);
 		g_assert_no_error(error);
-		g_assert_true(ret);
+		g_assert_nonnull(firmware2);
 		csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 		g_assert_nonnull(csum2);
 		g_assert_no_error(error);
@@ -7366,6 +7346,7 @@ int
 main(int argc, char **argv)
 {
 	g_autofree gchar *testdatadir = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new();
 
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
@@ -7387,6 +7368,9 @@ main(int argc, char **argv)
 	(void)g_setenv("FWUPD_PROFILE", "1", TRUE);
 	(void)g_setenv("FWUPD_EFIVARS", "dummy", TRUE);
 	(void)g_setenv("CACHE_DIRECTORY", "/tmp/fwupd-self-test/cache", TRUE);
+
+	/* register all the GTypes manually */
+	fu_context_add_firmware_gtypes(ctx);
 
 	g_test_add_func("/fwupd/cab{checksum}", fu_cab_checksum_func);
 	g_test_add_func("/fwupd/efi-lz77{decompressor}", fu_efi_lz77_decompressor_func);
@@ -7501,6 +7485,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/firmware", fu_firmware_func);
 	g_test_add_func("/fwupd/firmware{common}", fu_firmware_common_func);
 	g_test_add_func("/fwupd/firmware{convert-version}", fu_firmware_convert_version_func);
+	g_test_add_func("/fwupd/firmware{builder-round-trip}", fu_firmware_builder_round_trip_func);
 	g_test_add_func("/fwupd/firmware{csv}", fu_firmware_csv_func);
 	g_test_add_func("/fwupd/firmware{archive}", fu_firmware_archive_func);
 	g_test_add_func("/fwupd/firmware{linear}", fu_firmware_linear_func);
@@ -7520,7 +7505,6 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/firmware{dfu}", fu_firmware_dfu_func);
 	g_test_add_func("/fwupd/firmware{dfu-patch}", fu_firmware_dfu_patch_func);
 	g_test_add_func("/fwupd/firmware{dfuse}", fu_firmware_dfuse_func);
-	g_test_add_func("/fwupd/firmware{builder-round-trip}", fu_firmware_builder_round_trip_func);
 	g_test_add_func("/fwupd/firmware{fmap}", fu_firmware_fmap_func);
 	g_test_add_func("/fwupd/firmware{gtypes}", fu_firmware_new_from_gtypes_func);
 	g_test_add_func("/fwupd/firmware{sorted}", fu_firmware_sorted_func);

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -86,6 +86,7 @@ fwupdplugin_src = [
   'fu-composite-input-stream.c', # fuzzing
   'fu-config.c', # fuzzing
   'fu-context.c', # fuzzing
+  'fu-context-helper.c',
   'fu-coswid-common.c', # fuzzing
   'fu-coswid-firmware.c', # fuzzing
   'fu-crc.c', # fuzzing

--- a/libfwupdplugin/tests/efi-filesystem.builder.xml
+++ b/libfwupdplugin/tests/efi-filesystem.builder.xml
@@ -1,4 +1,4 @@
-<firmware gtype="FuEfiVolume">
+<firmware gtype="FuEfiFilesystem">
   <id>8c8ce578-8a3d-4f1c-9935-896185c32dd3</id>
   <firmware gtype="FuEfiFilesystem">
     <firmware gtype="FuEfiFile">

--- a/libfwupdplugin/tests/intel-thunderbolt.builder.xml
+++ b/libfwupdplugin/tests/intel-thunderbolt.builder.xml
@@ -1,4 +1,4 @@
-<firmware gtype="FuIntelNvmFirmware">
+<firmware gtype="FuIntelThunderboltNvm">
   <offset>0x10</offset>
   <vendor_id>0xd4</vendor_id>
   <device_id>0x15ef</device_id>

--- a/libfwupdplugin/tests/usb-bos-descriptor.builder.xml
+++ b/libfwupdplugin/tests/usb-bos-descriptor.builder.xml
@@ -1,4 +1,4 @@
-<firmware gtype="FuUsbDescriptor">
+<firmware gtype="FuUsbBosDescriptor">
   <dev_capability_type>bos</dev_capability_type>
   <firmware>
     <id>payload</id>

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -56,10 +56,10 @@ static void
 fu_acpi_phat_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ACPI_PHAT);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ACPI_PHAT_VERSION_RECORD);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_VERSION_RECORD);
 }
 
 static void

--- a/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
@@ -27,7 +27,7 @@ fu_algoltek_usb_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ALGOLTEK_USB_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ALGOLTEK_USB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ALGOLTEK_USB_FIRMWARE);
 }
 
 static void

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-plugin.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-plugin.c
@@ -27,7 +27,7 @@ fu_algoltek_usbcr_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_udev_subsystem(plugin, "block:disk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ALGOLTEK_USBCR_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ALGOLTEK_USBCR_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ALGOLTEK_USBCR_FIRMWARE);
 }
 
 static void

--- a/plugins/amd-gpu/fu-amd-gpu-plugin.c
+++ b/plugins/amd-gpu/fu-amd-gpu-plugin.c
@@ -34,9 +34,9 @@ fu_amd_gpu_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMDGPU_DEVICE);
 	/* navi3x and later use PSP firmware container */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_GPU_PSP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_GPU_PSP_FIRMWARE);
 	/* navi 2x and older have the ATOM firmware at start of image */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_GPU_ATOM_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_GPU_ATOM_FIRMWARE);
 }
 
 static void

--- a/plugins/amd-kria/fu-amd-kria-plugin.c
+++ b/plugins/amd-kria/fu-amd-kria-plugin.c
@@ -149,13 +149,13 @@ fu_amd_kria_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 
 	/* for parsing QSPI in registered callback */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_IMAGE_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_PERSISTENT_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_KRIA_IMAGE_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_KRIA_PERSISTENT_FIRMWARE);
 
 	/* for reading FRU inventory */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMD_KRIA_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AMD_KRIA_SOM_EEPROM);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_KRIA_SOM_EEPROM);
 }
 
 static void

--- a/plugins/analogix/fu-analogix-plugin.c
+++ b/plugins/analogix/fu-analogix-plugin.c
@@ -27,7 +27,7 @@ fu_analogix_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ANALOGIX_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ANALOGIX_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ANALOGIX_FIRMWARE);
 }
 
 static void

--- a/plugins/asus-hid/fu-asus-hid-plugin.c
+++ b/plugins/asus-hid/fu-asus-hid-plugin.c
@@ -29,7 +29,7 @@ fu_asus_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ASUS_HID_CHILD_DEVICE); /* coverage */
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_ASUS_HID_DEVICE);
 	fu_context_add_quirk_key(ctx, "AsusHidNumMcu");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ASUS_HID_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ASUS_HID_FIRMWARE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 }
 

--- a/plugins/aver-hid/fu-aver-hid-plugin.c
+++ b/plugins/aver-hid/fu-aver-hid-plugin.c
@@ -30,7 +30,7 @@ fu_aver_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_SAFEISP_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_AVER_HID_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AVER_HID_FIRMWARE);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-plugin.c
+++ b/plugins/bcm57xx/fu-bcm57xx-plugin.c
@@ -89,10 +89,10 @@ fu_bcm57xx_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_DICT_IMAGE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_STAGE1_IMAGE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BCM57XX_STAGE2_IMAGE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_DICT_IMAGE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_STAGE1_IMAGE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_STAGE2_IMAGE);
 }
 
 static void

--- a/plugins/bcm57xx/fu-self-test.c
+++ b/plugins/bcm57xx/fu-self-test.c
@@ -116,8 +116,8 @@ fu_bcm57xx_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_bcm57xx_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_bcm57xx_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -125,9 +125,9 @@ fu_bcm57xx_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "a3ac108905c37857cf48612b707c1c72c582f914");
@@ -135,9 +135,9 @@ fu_bcm57xx_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -154,6 +154,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_BCM57XX_FIRMWARE);
 	g_test_add_func("/fwupd/bcm57xx/firmware{xml}", fu_bcm57xx_firmware_xml_func);
 	g_test_add_func("/fwupd/bcm57xx/firmware{talos}", fu_bcm57xx_firmware_talos_func);
 	g_test_add_func("/fwupd/bcm57xx/common{veritem}", fu_bcm57xx_common_veritem_func);

--- a/plugins/bnr-dp/fu-bnr-dp-plugin.c
+++ b/plugins/bnr-dp/fu-bnr-dp-plugin.c
@@ -28,7 +28,7 @@ fu_bnr_dp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "drm");
 	fu_plugin_add_device_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BNR_DP_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_BNR_DP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BNR_DP_FIRMWARE);
 }
 
 static void

--- a/plugins/bnr-dp/fu-self-test.c
+++ b/plugins/bnr-dp/fu-self-test.c
@@ -17,8 +17,8 @@ fu_bnr_dp_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_bnr_dp_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_bnr_dp_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -26,9 +26,9 @@ fu_bnr_dp_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "b83504af44c2a53561f9e5f25fb133903e1c19fc");
@@ -36,9 +36,9 @@ fu_bnr_dp_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -53,6 +53,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_BNR_DP_FIRMWARE);
 	g_test_add_func("/bnr-dp/firmware{xml}", fu_bnr_dp_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
@@ -30,7 +30,7 @@ fu_ccgx_dmc_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "CcgxDmcTriggerCode");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_DMC_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_CCGX_DMC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_DMC_DEVX_DEVICE); /* coverage */
 }

--- a/plugins/ccgx-dmc/fu-self-test.c
+++ b/plugins/ccgx-dmc/fu-self-test.c
@@ -17,8 +17,8 @@ fu_ccgx_dmc_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_ccgx_dmc_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_ccgx_dmc_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -26,9 +26,9 @@ fu_ccgx_dmc_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "8bfcf543805d54280164813d792581764bd4b48b");
@@ -36,9 +36,9 @@ fu_ccgx_dmc_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -53,6 +53,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_CCGX_DMC_FIRMWARE);
 	g_test_add_func("/ccgx-dmc/firmware{xml}", fu_ccgx_dmc_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/ccgx/fu-ccgx-plugin.c
+++ b/plugins/ccgx/fu-ccgx-plugin.c
@@ -33,7 +33,7 @@ fu_ccgx_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CcgxFlashSize");
 	fu_context_add_quirk_key(ctx, "CcgxImageKind");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CCGX_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_CCGX_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_PURE_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HPI_DEVICE);

--- a/plugins/ccgx/fu-self-test.c
+++ b/plugins/ccgx/fu-self-test.c
@@ -17,8 +17,8 @@ fu_ccgx_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_ccgx_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_ccgx_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -26,9 +26,9 @@ fu_ccgx_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "ccc06acf112b7e3baf0b4ff6574d759110c7bd5d");
@@ -36,9 +36,9 @@ fu_ccgx_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -53,6 +53,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_CCGX_FIRMWARE);
 	g_test_add_func("/ccgx/firmware{xml}", fu_ccgx_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -27,7 +27,7 @@ fu_cros_ec_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_CROS_EC_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_CROS_EC_FIRMWARE);
 }
 
 static void

--- a/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
@@ -489,7 +489,7 @@ fu_dell_kestrel_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DELL_KESTREL_RTSHUB); /* coverage */
 
 	/* register firmware parser */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_DELL_KESTREL_RTSHUB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_DELL_KESTREL_RTSHUB_FIRMWARE);
 
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
 	fu_plugin_set_config_default(plugin, FWUPD_DELL_KESTREL_PLUGIN_CONFIG_UOD, "false");

--- a/plugins/ebitdo/fu-ebitdo-plugin.c
+++ b/plugins/ebitdo/fu-ebitdo-plugin.c
@@ -27,7 +27,7 @@ fu_ebitdo_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EBITDO_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EBITDO_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_EBITDO_FIRMWARE);
 }
 
 static void

--- a/plugins/elan-kbd/fu-elan-kbd-plugin.c
+++ b/plugins/elan-kbd/fu-elan-kbd-plugin.c
@@ -32,7 +32,7 @@ fu_elan_kbd_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELAN_KBD_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELAN_KBD_DEBUG_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_ELAN_KBD_RUNTIME);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELAN_KBD_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELAN_KBD_FIRMWARE);
 }
 
 static void

--- a/plugins/elanfp/fu-elanfp-plugin.c
+++ b/plugins/elanfp/fu-elanfp-plugin.c
@@ -27,7 +27,7 @@ fu_elanfp_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANFP_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANFP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELANFP_FIRMWARE);
 }
 
 static void

--- a/plugins/elantp/fu-elantp-plugin.c
+++ b/plugins/elantp/fu-elantp-plugin.c
@@ -45,7 +45,7 @@ fu_elantp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_udev_subsystem(plugin, "i2c-dev");
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ELANTP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELANTP_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_I2C_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_HID_DEVICE);
 }

--- a/plugins/elantp/fu-self-test.c
+++ b/plugins/elantp/fu-self-test.c
@@ -17,8 +17,8 @@ fu_elantp_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_elantp_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_elantp_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -26,9 +26,9 @@ fu_elantp_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "de53a29a438ff297202055151381433b86a2f64d");
@@ -36,9 +36,9 @@ fu_elantp_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -53,6 +53,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_ELANTP_FIRMWARE);
 	g_test_add_func("/elantp/firmware{xml}", fu_elantp_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/ep963x/fu-ep963x-plugin.c
+++ b/plugins/ep963x/fu-ep963x-plugin.c
@@ -28,7 +28,7 @@ fu_ep963x_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EP963X_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EP963X_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_EP963X_FIRMWARE);
 }
 
 static void

--- a/plugins/focalfp/fu-focalfp-plugin.c
+++ b/plugins/focalfp/fu-focalfp-plugin.c
@@ -26,7 +26,7 @@ fu_focalfp_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_FOCALFP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FOCALFP_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCALFP_HID_DEVICE);
 }
 

--- a/plugins/fpc/fu-fpc-plugin.c
+++ b/plugins/fpc/fu-fpc-plugin.c
@@ -27,7 +27,7 @@ fu_fpc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FPC_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_FPC_FF2_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FPC_FF2_FIRMWARE);
 }
 
 static void

--- a/plugins/fresco-pd/fu-fresco-pd-plugin.c
+++ b/plugins/fresco-pd/fu-fresco-pd-plugin.c
@@ -27,7 +27,7 @@ fu_fresco_pd_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FRESCO_PD_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_FRESCO_PD_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FRESCO_PD_FIRMWARE);
 }
 
 static void

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
@@ -28,7 +28,7 @@ fu_genesys_gl32xx_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_plugin_add_udev_subsystem(plugin, "block");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_GL32XX_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_GL32XX_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_GL32XX_FIRMWARE);
 	fu_context_add_quirk_key(ctx, "GenesysGl32xxCompatibleModel");
 }
 

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -54,8 +54,8 @@ fu_genesys_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_USBHUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_HUBHID_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_USBHUB_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GENESYS_SCALER_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_USBHUB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_SCALER_FIRMWARE);
 }
 
 static FuDevice *

--- a/plugins/goodix-tp/fu-goodixtp-plugin.c
+++ b/plugins/goodix-tp/fu-goodixtp-plugin.c
@@ -34,9 +34,9 @@ fu_goodixtp_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_GOODIXTP_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GOODIXTP_GTX8_DEVICE); /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GOODIXTP_BRLB_DEVICE); /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GOODIXTP_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GOODIXTP_GTX8_FIRMWARE); /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_GOODIXTP_BRLB_FIRMWARE); /* coverage */
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_GTX8_FIRMWARE); /* coverage */
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_BRLB_FIRMWARE); /* coverage */
 }
 
 static FuGoodixtpIcType

--- a/plugins/ilitek-its/fu-ilitek-its-plugin.c
+++ b/plugins/ilitek-its/fu-ilitek-its-plugin.c
@@ -78,7 +78,7 @@ fu_ilitek_its_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ILITEK_ITS_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_ILITEK_ITS_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ILITEK_ITS_FIRMWARE);
 }
 
 static void

--- a/plugins/intel-cvs/fu-intel-cvs-plugin.c
+++ b/plugins/intel-cvs/fu-intel-cvs-plugin.c
@@ -31,7 +31,7 @@ fu_intel_cvs_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "IntelCvsMaxRetryCount");
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_CVS_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_INTEL_CVS_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_INTEL_CVS_FIRMWARE);
 }
 
 static void

--- a/plugins/intel-gsc/fu-igsc-plugin.c
+++ b/plugins/intel-gsc/fu-igsc-plugin.c
@@ -89,9 +89,9 @@ fu_igsc_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_IGSC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_IGSC_OPROM_DEVICE); /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_IGSC_AUX_DEVICE);   /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_IGSC_CODE_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_IGSC_AUX_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_IGSC_OPROM_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_CODE_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_AUX_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_OPROM_FIRMWARE);
 }
 
 static void

--- a/plugins/jabra-file/fu-jabra-file-plugin.c
+++ b/plugins/jabra-file/fu-jabra-file-plugin.c
@@ -28,7 +28,7 @@ fu_jabra_file_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_FILE_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_FILE_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_FILE_FIRMWARE);
 }
 
 static void

--- a/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
@@ -30,8 +30,8 @@ fu_jabra_gnp_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "JabraGnpAddress");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_GNP_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_GNP_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_JABRA_GNP_IMAGE); /* coverage */
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_GNP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_GNP_IMAGE); /* coverage */
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
@@ -122,8 +122,8 @@ fu_kinetic_dp_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "drm"); /* used for uevent only */
 	fu_plugin_add_device_udev_subsystem(plugin, "drm_dp_aux_dev");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_KINETIC_DP_PUMA_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_KINETIC_DP_SECURE_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_KINETIC_DP_PUMA_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_KINETIC_DP_SECURE_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_KINETIC_DP_PUMA_DEVICE);   /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_KINETIC_DP_SECURE_DEVICE); /* coverage */
 }

--- a/plugins/legion-hid/fu-legion-hid-plugin.c
+++ b/plugins/legion-hid/fu-legion-hid-plugin.c
@@ -27,7 +27,7 @@ fu_legion_hid_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_LEGION_HID_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LEGION_HID_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID_CHILD);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LEGION_HID_DEVICE);
 }

--- a/plugins/legion-hid2/fu-legion-hid2-plugin.c
+++ b/plugins/legion-hid2/fu-legion-hid2-plugin.c
@@ -32,7 +32,7 @@ fu_legion_hid2_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID2_SIPO_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID2_BL_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LEGION_HID2_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_LEGION_HID2_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LEGION_HID2_FIRMWARE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 }
 

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -43,7 +43,7 @@ fu_logitech_hidpp_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_RUNTIME_BOLT);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_RADIO); /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_LOGITECH_RDFU_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LOGITECH_RDFU_FIRMWARE);
 }
 
 static void

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-plugin.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-plugin.c
@@ -28,7 +28,7 @@ fu_mediatek_scaler_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "drm");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MEDIATEK_SCALER_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_MEDIATEK_SCALER_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_MEDIATEK_SCALER_FIRMWARE);
 }
 
 static void

--- a/plugins/mtd/fu-self-test.c
+++ b/plugins/mtd/fu-self-test.c
@@ -64,7 +64,7 @@ fu_test_mtd_prepare_mtdram_device(FuMtdDevice *device,
 {
 	gboolean ret;
 	gsize bufsz = fu_device_get_firmware_size_max(FU_DEVICE(device));
-	g_autoptr(FuFirmware) firmware = g_object_new(firmware_gtype, NULL);
+	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(NULL);
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GError) error = NULL;
@@ -76,15 +76,16 @@ fu_test_mtd_prepare_mtdram_device(FuMtdDevice *device,
 
 		filename = g_test_build_filename(G_TEST_DIST, "tests", filename_xml, NULL);
 		g_debug("loading from %s", filename);
-		ret = fu_firmware_build_from_filename(firmware, filename, &error);
+		firmware = fu_firmware_new_from_filename(filename, &error);
 		g_assert_no_error(error);
-		g_assert_true(ret);
+		g_assert_nonnull(firmware);
 		blob_tmp = fu_firmware_write(firmware, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(blob_tmp);
 		blob = fu_bytes_pad(blob_tmp, bufsz, 0xFF);
 	} else {
 		g_autoptr(GByteArray) buf = g_byte_array_new();
+		firmware = fu_firmware_new();
 		fu_byte_array_set_size(buf, bufsz, 0xFF);
 		blob = g_bytes_new(buf->data, buf->len);
 	}

--- a/plugins/nordic-hid/fu-nordic-hid-plugin.c
+++ b/plugins/nordic-hid/fu-nordic-hid-plugin.c
@@ -31,9 +31,9 @@ fu_nordic_hid_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "NordicHidBootloader");
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NORDIC_HID_CFG_CHANNEL);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_ARCHIVE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_FIRMWARE_B0);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_ARCHIVE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_FIRMWARE_B0);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT);
 }
 
 static void

--- a/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
@@ -29,7 +29,7 @@ fu_parade_usbhub_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "ParadeUsbhubChip");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PARADE_USBHUB_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_PARADE_USBHUB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PARADE_USBHUB_FIRMWARE);
 }
 
 static void

--- a/plugins/pixart-rf/fu-pixart-rf-plugin.c
+++ b/plugins/pixart-rf/fu-pixart-rf-plugin.c
@@ -31,7 +31,7 @@ fu_pixart_rf_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_RF_BLE_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_RF_RECEIVER_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_RF_WIRELESS_DEVICE); /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, "pixart", FU_TYPE_PIXART_RF_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_RF_FIRMWARE);
 }
 
 static void

--- a/plugins/pixart-rf/fu-self-test.c
+++ b/plugins/pixart-rf/fu-self-test.c
@@ -17,8 +17,8 @@ fu_pixart_rf_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_pixart_rf_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_pixart_rf_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware3 = fu_pixart_rf_firmware_new();
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GError) error = NULL;
@@ -28,9 +28,9 @@ fu_pixart_rf_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	fw = fu_firmware_write(firmware1, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(fw);
@@ -46,9 +46,9 @@ fu_pixart_rf_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -63,6 +63,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
-	g_test_add_func("/pxi/firmware{xml}", fu_pixart_rf_firmware_xml_func);
+	g_type_ensure(FU_TYPE_PIXART_RF_FIRMWARE);
+	g_test_add_func("/pixart-rf/firmware{xml}", fu_pixart_rf_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/pixart-tp/fu-pixart-tp-plugin.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plugin.c
@@ -38,8 +38,8 @@ fu_pixart_tp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_PIXART_TP_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_HAPTIC_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_PIXART_TP_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_PIXART_TP_SECTION); /* coverage */
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_SECTION); /* coverage */
 }
 
 static void

--- a/plugins/pixart-tp/fu-self-test.c
+++ b/plugins/pixart-tp/fu-self-test.c
@@ -12,8 +12,8 @@ fu_pixart_tp_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_pixart_tp_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_pixart_tp_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -21,9 +21,9 @@ fu_pixart_tp_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "a9ed17b970a867c190f62be59338dbad89d07553");
@@ -31,9 +31,9 @@ fu_pixart_tp_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -48,6 +48,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_PIXART_TP_FIRMWARE);
 	g_test_add_func("/pixart-tp/firmware{xml}", fu_pixart_tp_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
@@ -34,7 +34,7 @@ fu_qc_s5gen2_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_BLE_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_HID_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QC_S5GEN2_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_QC_S5GEN2_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_QC_S5GEN2_FIRMWARE);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -224,8 +224,9 @@ fu_redfish_plugin_discover_smbios_table(FuPlugin *plugin, GError **error)
 	/* in self tests */
 	smbios_data_fn = g_getenv("FWUPD_REDFISH_SMBIOS_DATA");
 	if (smbios_data_fn != NULL) {
-		g_autoptr(FuRedfishSmbios) smbios = fu_redfish_smbios_new();
-		if (!fu_firmware_build_from_filename(FU_FIRMWARE(smbios), smbios_data_fn, error)) {
+		g_autoptr(FuRedfishSmbios) smbios = NULL;
+		smbios = FU_REDFISH_SMBIOS(fu_firmware_new_from_filename(smbios_data_fn, error));
+		if (smbios == NULL) {
 			g_prefix_error_literal(error, "failed to build SMBIOS entry type 42: ");
 			return FALSE;
 		}
@@ -713,7 +714,7 @@ fu_redfish_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "RedfishResetPreDelay");
 	fu_context_add_quirk_key(ctx, "RedfishResetPostDelay");
 	self->backend = fu_redfish_backend_new(ctx);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_REDFISH_SMBIOS);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_REDFISH_SMBIOS);
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_SECURE_CONFIG);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_REDFISH_HPE_DEVICE);	      /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_REDFISH_LEGACY_DEVICE);    /* coverage */

--- a/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
@@ -29,8 +29,8 @@ fu_synaptics_cape_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CAPE_HID_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CAPE_SNGL_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_HID_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_SNGL_FIRMWARE);
 }
 
 static void

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
@@ -33,7 +33,7 @@ fu_synaptics_cxaudio_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CxaudioSoftwareReset");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-self-test.c
+++ b/plugins/synaptics-mst/fu-self-test.c
@@ -175,8 +175,8 @@ fu_synaptics_mst_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_synaptics_mst_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_synaptics_mst_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -184,9 +184,9 @@ fu_synaptics_mst_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "67b8fc4661f7585a8cd6c46ef6088293d4399135");
@@ -194,9 +194,9 @@ fu_synaptics_mst_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -51,7 +51,7 @@ fu_synaptics_mst_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "drm"); /* used for uevent only */
 	fu_plugin_add_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_MST_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
 }
 
 static void

--- a/plugins/synaptics-prometheus/fu-self-test.c
+++ b/plugins/synaptics-prometheus/fu-self-test.c
@@ -95,8 +95,8 @@ fu_synaptics_prometheus_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_synaptics_prometheus_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_synaptics_prometheus_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -105,9 +105,9 @@ fu_synaptics_prometheus_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "5fa24664fb28e78cbd88970e6026d996fc051550");
@@ -115,9 +115,9 @@ fu_synaptics_prometheus_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -128,6 +128,7 @@ main(int argc, char **argv)
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+	g_type_ensure(FU_TYPE_SYNAPTICS_PROMETHEUS_FIRMWARE);
 	g_test_add_func("/synaptics-prometheus/firmware",
 			fu_test_synaptics_prometheus_firmware_func);
 	g_test_add_func("/synaptics-prometheus/firmware{xml}",

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-plugin.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-plugin.c
@@ -29,7 +29,7 @@ fu_synaptics_prometheus_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_CONFIG); /* for coverage */
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_PROMETHEUS_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_FIRMWARE);
 }
 
 static void

--- a/plugins/synaptics-prometheus/tests/synaptics-prometheus.builder.xml
+++ b/plugins/synaptics-prometheus/tests/synaptics-prometheus.builder.xml
@@ -1,4 +1,4 @@
-<firmware gtype="FuSynapromFirmware">
+<firmware gtype="FuSynapticsPrometheusFirmware">
   <version>1.2</version>
   <product_id>0x42</product_id>
   <data>aGVsbG8gd29ybGQ=</data> <!-- base64 -->

--- a/plugins/synaptics-rmi/fu-self-test.c
+++ b/plugins/synaptics-rmi/fu-self-test.c
@@ -17,8 +17,8 @@ fu_synaptics_rmi_firmware_0x_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_synaptics_rmi_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_synaptics_rmi_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -27,9 +27,9 @@ fu_synaptics_rmi_firmware_0x_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "8b097c034028a69e6416bcc39f312e2fa9247381");
@@ -37,9 +37,9 @@ fu_synaptics_rmi_firmware_0x_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -53,8 +53,8 @@ fu_synaptics_rmi_firmware_10_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_synaptics_rmi_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_synaptics_rmi_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -63,9 +63,9 @@ fu_synaptics_rmi_firmware_10_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "bd85539bb100e5bd6debb00b06b5a7e7fa9bd030");
@@ -73,9 +73,9 @@ fu_synaptics_rmi_firmware_10_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -90,6 +90,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
 	g_test_add_func("/synaptics-rmi/firmware{0x}", fu_synaptics_rmi_firmware_0x_func);
 	g_test_add_func("/synaptics-rmi/firmware{10}", fu_synaptics_rmi_firmware_10_func);
 	return g_test_run();

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
@@ -30,7 +30,7 @@ fu_synaptics_rmi_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "serio");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_PS2_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
 }
 
 static void

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
@@ -28,7 +28,7 @@ fu_synaptics_vmm9_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_VMM9_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_SYNAPTICS_VMM9_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_VMM9_FIRMWARE);
 }
 
 static void

--- a/plugins/telink-dfu/fu-telink-dfu-plugin.c
+++ b/plugins/telink-dfu/fu-telink-dfu-plugin.c
@@ -31,7 +31,7 @@ fu_telink_dfu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "TelinkHidToolVer");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TELINK_DFU_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TELINK_DFU_BLE_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_TELINK_DFU_ARCHIVE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_TELINK_DFU_ARCHIVE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 }
 

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -334,14 +334,14 @@ write_controller_fw(const gchar *nvm)
 	g_autoptr(GInputStream) is = NULL;
 	g_autoptr(GOutputStream) os = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuFirmware) firmware_ctl = fu_intel_thunderbolt_nvm_new();
+	g_autoptr(FuFirmware) firmware_ctl = NULL;
 	gssize n;
 
 	fw_path =
 	    g_test_build_filename(G_TEST_DIST, "tests", "minimal-fw-controller.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware_ctl, fw_path, &error);
+	firmware_ctl = fu_firmware_new_from_filename(fw_path, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware_ctl);
 	fw_blob = fu_firmware_write(firmware_ctl, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(fw_blob);
@@ -959,13 +959,13 @@ test_set_up(FuThunderboltTest *tt, gconstpointer params)
 	if (flags & TEST_PREPARE_FIRMWARE) {
 		g_autofree gchar *fw_path = NULL;
 		g_autoptr(GBytes) fw_blob = NULL;
-		g_autoptr(FuFirmware) firmware = fu_intel_thunderbolt_firmware_new();
+		g_autoptr(FuFirmware) firmware = NULL;
 
 		fw_path =
 		    g_test_build_filename(G_TEST_DIST, "tests", "minimal-fw.builder.xml", NULL);
-		ret = fu_firmware_build_from_filename(firmware, fw_path, &error);
+		firmware = fu_firmware_new_from_filename(fw_path, &error);
 		g_assert_no_error(error);
-		g_assert_true(ret);
+		g_assert_nonnull(firmware);
 		tt->fw_data = fu_firmware_write(firmware, &error);
 		g_assert_no_error(error);
 		g_assert_nonnull(tt->fw_data);
@@ -1046,22 +1046,22 @@ test_image_validation(FuThunderboltTest *tt, gconstpointer user_data)
 	g_autoptr(GMappedFile) bad_file = NULL;
 	g_autoptr(GBytes) bad_data = NULL;
 	g_autoptr(GError) error = NULL;
-	g_autoptr(FuFirmware) firmware_fwi = fu_intel_thunderbolt_firmware_new();
-	g_autoptr(FuFirmware) firmware_ctl = fu_intel_thunderbolt_nvm_new();
+	g_autoptr(FuFirmware) firmware_fwi = NULL;
+	g_autoptr(FuFirmware) firmware_ctl = NULL;
 	g_autoptr(FuFirmware) firmware_bad = fu_intel_thunderbolt_nvm_new();
 
 	/* image as if read from the controller (i.e. no headers) */
 	ctl_path =
 	    g_test_build_filename(G_TEST_DIST, "tests", "minimal-fw-controller.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware_ctl, ctl_path, &error);
+	firmware_ctl = fu_firmware_new_from_filename(ctl_path, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware_ctl);
 
 	/* valid firmware update image */
 	fwi_path = g_test_build_filename(G_TEST_DIST, "tests", "minimal-fw.builder.xml", NULL);
-	ret = fu_firmware_build_from_filename(firmware_fwi, fwi_path, &error);
+	firmware_fwi = fu_firmware_new_from_filename(fwi_path, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware_fwi);
 
 	/* a wrong/bad firmware update image */
 	bad_path = g_test_build_filename(G_TEST_DIST, "tests", "colorhug.txt", NULL);

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
@@ -30,7 +30,7 @@ fu_ti_tps6598x_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_TI_TPS6598X_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TI_TPS6598X_PD_DEVICE); /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, "ti-tps6598x", FU_TYPE_TI_TPS6598X_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_TI_TPS6598X_FIRMWARE);
 }
 
 static void

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -892,8 +892,8 @@ fu_uefi_update_info_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = FU_FIRMWARE(fu_uefi_update_info_new());
-	g_autoptr(FuFirmware) firmware2 = FU_FIRMWARE(fu_uefi_update_info_new());
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(FuFirmware) firmware3 = FU_FIRMWARE(fu_uefi_update_info_new());
 	g_autoptr(GBytes) fw = NULL;
 	g_autoptr(GError) error = NULL;
@@ -904,9 +904,9 @@ fu_uefi_update_info_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	fw = fu_firmware_write(firmware1, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(fw);
@@ -922,9 +922,9 @@ fu_uefi_update_info_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1306,9 +1306,9 @@ fu_uefi_capsule_plugin_constructed(GObject *obj)
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "linux_lockdown");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "acpi_phat");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_CONFLICTS, "uefi"); /* old name */
-	fu_plugin_add_firmware_gtype(FU_PLUGIN(self), NULL, FU_TYPE_ACPI_UEFI);
-	fu_plugin_add_firmware_gtype(FU_PLUGIN(self), NULL, FU_TYPE_UEFI_UPDATE_INFO);
-	fu_plugin_add_firmware_gtype(FU_PLUGIN(self), NULL, FU_TYPE_BITMAP_IMAGE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_UEFI);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_UEFI_UPDATE_INFO);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BITMAP_IMAGE);
 	fu_plugin_add_device_gtype(FU_PLUGIN(self), FU_TYPE_UEFI_COD_DEVICE);	/* coverage */
 	fu_plugin_add_device_gtype(FU_PLUGIN(self), FU_TYPE_UEFI_GRUB_DEVICE);	/* coverage */
 	fu_plugin_add_device_gtype(FU_PLUGIN(self), FU_TYPE_UEFI_NVRAM_DEVICE); /* coverage */

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -45,7 +45,7 @@ fu_uefi_dbx_plugin_constructed(GObject *obj)
 
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_capsule");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_EFI_SIGNATURE_LIST);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_EFI_SIGNATURE_LIST);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DBX_DEVICE);
 
 	/* ensure that an ESP was found */

--- a/plugins/uefi-sbat/fu-uefi-sbat-plugin.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-plugin.c
@@ -96,7 +96,7 @@ fu_uefi_sbat_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_UEFI_SBAT_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_UEFI_SBAT_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_UEFI_SBAT_FIRMWARE);
 }
 
 static void

--- a/plugins/uf2/fu-self-test.c
+++ b/plugins/uf2/fu-self-test.c
@@ -17,7 +17,7 @@ fu_uf2_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_uf2_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
 	g_autoptr(FuFirmware) firmware2 = fu_uf2_firmware_new();
 	g_autoptr(GBytes) blob = NULL;
 	g_autoptr(GError) error = NULL;
@@ -27,9 +27,9 @@ fu_uf2_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "4e130c6617496bee0dfbdff48f7248eccb1c696d");
@@ -60,6 +60,7 @@ main(int argc, char **argv)
 	g_log_set_fatal_mask(NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_UF2_FIRMWARE);
 	g_test_add_func("/uf2/firmware{xml}", fu_uf2_firmware_xml_func);
 	return g_test_run();
 }

--- a/plugins/uf2/fu-uf2-plugin.c
+++ b/plugins/uf2/fu-uf2-plugin.c
@@ -26,7 +26,7 @@ fu_uf2_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UF2_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, "uf2", FU_TYPE_UF2_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_UF2_FIRMWARE);
 	fu_plugin_add_device_udev_subsystem(plugin, "block:partition");
 }
 

--- a/plugins/vendor-example/fu-vendor-example-plugin.c.in
+++ b/plugins/vendor-example/fu-vendor-example-plugin.c.in
@@ -34,7 +34,7 @@ fu_{{vendor_example}}_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 {%- endif %}
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_{{VENDOR_EXAMPLE}}_DEVICE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_{{VENDOR_EXAMPLE}}_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_{{VENDOR_EXAMPLE}}_FIRMWARE);
 }
 
 static void

--- a/plugins/vli/fu-vli-plugin.c
+++ b/plugins/vli/fu-vli-plugin.c
@@ -35,8 +35,8 @@ fu_vli_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "VliDeviceKind");
 	fu_context_add_quirk_key(ctx, "VliSpiAutoDetect");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_USBHUB_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, NULL, FU_TYPE_VLI_PD_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_VLI_USBHUB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_VLI_PD_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_PD_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_PD_PARADE_DEVICE);      /* coverage */

--- a/plugins/wacom-usb/fu-self-test.c
+++ b/plugins/wacom-usb/fu-self-test.c
@@ -58,8 +58,8 @@ fu_wacom_usb_firmware_xml_func(void)
 	g_autofree gchar *csum2 = NULL;
 	g_autofree gchar *xml_out = NULL;
 	g_autofree gchar *xml_src = NULL;
-	g_autoptr(FuFirmware) firmware1 = fu_wacom_usb_firmware_new();
-	g_autoptr(FuFirmware) firmware2 = fu_wacom_usb_firmware_new();
+	g_autoptr(FuFirmware) firmware1 = NULL;
+	g_autoptr(FuFirmware) firmware2 = NULL;
 	g_autoptr(GError) error = NULL;
 
 	/* build and write */
@@ -67,9 +67,9 @@ fu_wacom_usb_firmware_xml_func(void)
 	ret = g_file_get_contents(filename, &xml_src, NULL, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
-	ret = fu_firmware_build_from_xml(firmware1, xml_src, &error);
+	firmware1 = fu_firmware_new_from_xml(xml_src, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware1);
 	csum1 = fu_firmware_get_checksum(firmware1, G_CHECKSUM_SHA1, &error);
 	g_assert_no_error(error);
 	g_assert_cmpstr(csum1, ==, "346f6196449b356777cf241f6edb039d503b88a1");
@@ -77,9 +77,9 @@ fu_wacom_usb_firmware_xml_func(void)
 	/* ensure we can round-trip */
 	xml_out = fu_firmware_export_to_xml(firmware1, FU_FIRMWARE_EXPORT_FLAG_NONE, &error);
 	g_assert_no_error(error);
-	ret = fu_firmware_build_from_xml(firmware2, xml_out, &error);
+	firmware2 = fu_firmware_new_from_xml(xml_out, &error);
 	g_assert_no_error(error);
-	g_assert_true(ret);
+	g_assert_nonnull(firmware2);
 	csum2 = fu_firmware_get_checksum(firmware2, G_CHECKSUM_SHA1, &error);
 	g_assert_cmpstr(csum1, ==, csum2);
 }
@@ -97,6 +97,7 @@ main(int argc, char **argv)
 	(void)g_setenv("G_MESSAGES_DEBUG", "all", FALSE);
 
 	/* tests go here */
+	g_type_ensure(FU_TYPE_WACOM_USB_FIRMWARE);
 	g_test_add_func("/wacom-usb/firmware{parse}", fu_wacom_usb_firmware_parse_func);
 	g_test_add_func("/wacom-usb/firmware{xml}", fu_wacom_usb_firmware_xml_func);
 	return g_test_run();

--- a/plugins/wacom-usb/fu-wacom-usb-plugin.c
+++ b/plugins/wacom-usb/fu-wacom-usb-plugin.c
@@ -116,7 +116,7 @@ fu_wacom_usb_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_USB_MODULE_SUB_CPU);	    /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_USB_MODULE_TOUCH);	    /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_USB_MODULE_TOUCH_ID7);	    /* coverage */
-	fu_plugin_add_firmware_gtype(plugin, "wacom", FU_TYPE_WACOM_USB_FIRMWARE);
+	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_WACOM_USB_FIRMWARE);
 }
 
 static void

--- a/plugins/wacom-usb/tests/wacom-usb.builder.xml
+++ b/plugins/wacom-usb/tests/wacom-usb.builder.xml
@@ -1,4 +1,4 @@
-<firmware gtype="FuWacFirmware">
+<firmware gtype="FuWacomUsbFirmware">
   <firmware gtype="FuSrecFirmware">
     <idx>0x0</idx>
     <addr>0x8008000</addr>

--- a/src/fu-engine-helper.c
+++ b/src/fu-engine-helper.c
@@ -24,56 +24,8 @@ void
 fu_engine_add_firmware_gtypes(FuEngine *self)
 {
 	FuContext *ctx = fu_engine_get_context(self);
-	fu_context_add_firmware_gtype(ctx, "raw", FU_TYPE_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "cab", FU_TYPE_CAB_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "cabinet", FU_TYPE_CABINET);
-	fu_context_add_firmware_gtype(ctx, "dfu", FU_TYPE_DFU_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "fdt", FU_TYPE_FDT_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "csv", FU_TYPE_CSV_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "fit", FU_TYPE_FIT_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "dfuse", FU_TYPE_DFUSE_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "ifwi-cpd", FU_TYPE_IFWI_CPD_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "ifwi-fpt", FU_TYPE_IFWI_FPT_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "oprom", FU_TYPE_OPROM_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "fmap", FU_TYPE_FMAP_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "ihex", FU_TYPE_IHEX_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "linear", FU_TYPE_LINEAR_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "srec", FU_TYPE_SREC_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "hid-descriptor", FU_TYPE_HID_DESCRIPTOR);
-	fu_context_add_firmware_gtype(ctx, "archive", FU_TYPE_ARCHIVE_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "smbios", FU_TYPE_SMBIOS);
-	fu_context_add_firmware_gtype(ctx, "acpi-table", FU_TYPE_ACPI_TABLE);
-	fu_context_add_firmware_gtype(ctx, "sbatlevel", FU_TYPE_SBATLEVEL_SECTION);
-	fu_context_add_firmware_gtype(ctx, "edid", FU_TYPE_EDID);
-	fu_context_add_firmware_gtype(ctx, "efi-file", FU_TYPE_EFI_FILE);
-	fu_context_add_firmware_gtype(ctx, "efi-signature", FU_TYPE_EFI_SIGNATURE);
-	fu_context_add_firmware_gtype(ctx, "efi-signature-list", FU_TYPE_EFI_SIGNATURE_LIST);
-	fu_context_add_firmware_gtype(ctx,
-				      "efi-variable-authentication2",
-				      FU_TYPE_EFI_VARIABLE_AUTHENTICATION2);
-	fu_context_add_firmware_gtype(ctx, "efi-load-option", FU_TYPE_EFI_LOAD_OPTION);
-	fu_context_add_firmware_gtype(ctx, "efi-device-path-list", FU_TYPE_EFI_DEVICE_PATH_LIST);
-	fu_context_add_firmware_gtype(ctx, "efi-filesystem", FU_TYPE_EFI_FILESYSTEM);
-	fu_context_add_firmware_gtype(ctx, "efi-section", FU_TYPE_EFI_SECTION);
-	fu_context_add_firmware_gtype(ctx, "efi-volume", FU_TYPE_EFI_VOLUME);
-	fu_context_add_firmware_gtype(ctx, "efi-ftw-store", FU_TYPE_EFI_FTW_STORE);
-	fu_context_add_firmware_gtype(ctx,
-				      "efi-vss2-variable-store",
-				      FU_TYPE_EFI_VSS2_VARIABLE_STORE);
-	fu_context_add_firmware_gtype(ctx, "json", FU_TYPE_JSON_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "ifd-bios", FU_TYPE_IFD_BIOS);
-	fu_context_add_firmware_gtype(ctx, "ifd-firmware", FU_TYPE_IFD_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "cfu-offer", FU_TYPE_CFU_OFFER);
-	fu_context_add_firmware_gtype(ctx, "cfu-payload", FU_TYPE_CFU_PAYLOAD);
-	fu_context_add_firmware_gtype(ctx, "uswid", FU_TYPE_USWID_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "coswid", FU_TYPE_COSWID_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "pefile", FU_TYPE_PEFILE_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "elf", FU_TYPE_ELF_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "x509-certificate", FU_TYPE_X509_CERTIFICATE);
-	fu_context_add_firmware_gtype(ctx, "intel-thunderbolt", FU_TYPE_INTEL_THUNDERBOLT_FIRMWARE);
-	fu_context_add_firmware_gtype(ctx, "intel-thunderbolt-nvm", FU_TYPE_INTEL_THUNDERBOLT_NVM);
-	fu_context_add_firmware_gtype(ctx, "usb-device-fw-ds20", FU_TYPE_USB_DEVICE_FW_DS20);
-	fu_context_add_firmware_gtype(ctx, "usb-device-ms-ds20", FU_TYPE_USB_DEVICE_MS_DS20);
+	fu_context_add_firmware_gtypes(ctx);
+	fu_context_add_firmware_gtype(ctx, FU_TYPE_CABINET);
 }
 
 static FwupdRelease *

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1451,6 +1451,7 @@ fu_engine_plugin_firmware_gtype(FuTest *self, GType gtype)
 	g_autoptr(GBytes) fw = g_bytes_new_static((const guint8 *)"x", 1);
 	g_autoptr(GError) error = NULL;
 	const gchar *noxml[] = {
+	    "FuFirmware",
 	    "FuArchiveFirmware",
 	    "FuGenesysUsbhubFirmware",
 	    "FuIntelThunderboltFirmware",
@@ -1495,9 +1496,9 @@ fu_engine_plugin_firmware_gtype(FuTest *self, GType gtype)
 		    FU_FIRMWARE_EXPORT_FLAG_INCLUDE_DEBUG | FU_FIRMWARE_EXPORT_FLAG_ASCII_DATA,
 		    NULL);
 		if (xml != NULL) {
-			ret = fu_firmware_build_from_xml(firmware, xml, &error);
+			g_autoptr(FuFirmware) firmware2 = fu_firmware_new_from_xml(xml, &error);
 			g_assert_no_error(error);
-			g_assert_true(ret);
+			g_assert_nonnull(firmware2);
 		}
 	}
 }


### PR DESCRIPTION
This gets the GType from the builder.xml rather than expecting the code to do it beforehand.

This also moves registering the GTypes provided by libfwupdplugin into a native fu_context_add_firmware_gtypes() function.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
