### PR TITLE
emulation-save: Add newline to json files

### DIFF
--- a/libfwupd/fwupd-json-object.c
+++ b/libfwupd/fwupd-json-object.c
@@ -1010,6 +1010,8 @@ fwupd_json_object_to_string(FwupdJsonObject *self, FwupdJsonExportFlags flags)
 {
 	GString *str = g_string_new(NULL);
 	fwupd_json_object_append_string(self, str, 0, flags);
+	if (flags & FWUPD_JSON_EXPORT_FLAG_TRAILING_NEWLINE)
+		g_string_append_c(str, '\n');
 	return str;
 }
 
@@ -1029,5 +1031,7 @@ fwupd_json_object_to_bytes(FwupdJsonObject *self, FwupdJsonExportFlags flags)
 {
 	GString *str = g_string_new(NULL);
 	fwupd_json_object_append_string(self, str, 0, flags);
+	if (flags & FWUPD_JSON_EXPORT_FLAG_TRAILING_NEWLINE)
+		g_string_append_c(str, '\n');
 	return g_string_free_to_bytes(str);
 }

--- a/libfwupd/fwupd-json.rs
+++ b/libfwupd/fwupd-json.rs
@@ -16,6 +16,7 @@ enum FwupdJsonNodeKind {
 enum FwupdJsonExportFlags {
     None = 0,
     Indent = 1 << 0,
+    TrailingNewline = 2 << 0,
 }
 
 // JSON load flags.

--- a/src/fu-engine-emulator.c
+++ b/src/fu-engine-emulator.c
@@ -188,7 +188,9 @@ fu_engine_emulator_save_phase(FuEngineEmulator *self,
 	fn = fu_engine_emulator_phase_to_filename(composite_cnt, phase, write_cnt);
 	g_debug("saving %s", fn);
 	blob_old = g_hash_table_lookup(self->phase_blobs, fn);
-	blob_new = fwupd_json_object_to_bytes(json_obj, FWUPD_JSON_EXPORT_FLAG_INDENT);
+	blob_new = fwupd_json_object_to_bytes(json_obj,
+					      FWUPD_JSON_EXPORT_FLAG_INDENT |
+						  FWUPD_JSON_EXPORT_FLAG_TRAILING_NEWLINE);
 
 	if (g_bytes_get_size(blob_new) == 0) {
 		g_info("no data for phase %s [%u]",


### PR DESCRIPTION
Since those files will usually be committed to the repository, make sure that `fwupdmgr emulation-save foo.zip` puts newlines at the end of the file. The pre-commit hook fails otherwise.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
