### PR TITLE
freebsd: Update CI

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -167,7 +167,7 @@ jobs:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Build
       id: test
-      uses: vmactions/freebsd-vm@v1
+      uses: vmactions/freebsd-vm@v1.3.6
       env:
         CI: true
         CC: gcc


### PR DESCRIPTION
FreeBSD 15 has been released, so we need to update the actions.

At least to: https://github.com/vmactions/freebsd-vm/releases/tag/v1.2.8

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
