### PR TITLE
trivial: Fix the debian CI by removing library-not-linked-against-libc

### DIFF
--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -51,7 +51,6 @@ lintian ../*changes \
     --pedantic \
     --tag-display-limit 0 \
     --suppress-tags missing-build-dependency-for-dh-addon \
-    --suppress-tags library-not-linked-against-libc \
     --suppress-tags bad-distribution-in-changes-file \
     --suppress-tags source-nmu-has-incorrect-version-number \
     --suppress-tags no-symbols-control-file \

--- a/contrib/debian/fwupd-tests.install
+++ b/contrib/debian/fwupd-tests.install
@@ -4,5 +4,4 @@
 #https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872458
 usr/share/installed-tests/*
 usr/libexec/installed-tests/fwupd/*-self-test
-debian/lintian/fwupd-tests usr/share/lintian/overrides
 usr/share/fwupd/remotes.d/fwupd-tests.conf

--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -16,5 +16,4 @@ usr/share/man/*
 data/fwupd.conf etc/fwupd
 debian/fwupd.pkla /var/lib/polkit-1/localauthority/10-vendor.d
 usr/lib/*/fwupd-*/*.so
-debian/lintian/fwupd usr/share/lintian/overrides
 obj*/data/motd/85-fwupd /etc/update-motd.d

--- a/contrib/debian/lintian/fwupd
+++ b/contrib/debian/lintian/fwupd
@@ -1,2 +1,0 @@
-#see Debian bug 896012
-fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-*/*

--- a/contrib/debian/lintian/fwupd-tests
+++ b/contrib/debian/lintian/fwupd-tests
@@ -1,2 +1,0 @@
-#see Debian bug 896012
-fwupd-tests: library-not-linked-against-libc usr/lib/*/fwupd-plugins-*/*


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
