### PR TITLE
trivial: Show the rustgen constants in the -vv output

### DIFF
--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -330,7 +330,7 @@ void
 {
     g_autoptr(GString) str = g_string_new("{{obj.name}}:\n");
     g_return_val_if_fail(st != NULL, NULL);
-{%- for item in obj.items | selectattr('enabled') | rejectattr('constant') %}
+{%- for item in obj.items | selectattr('enabled') %}
 
 {%- if item.enum_obj %}
     {

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -7380,16 +7380,20 @@ fu_plugin_struct_func(void)
 
 	/* to string */
 	str2 = fu_struct_self_test_to_string(st);
-	g_assert_cmpstr(str2,
-			==,
-			"FuStructSelfTest:\n"
-			"  length: 0xdead\n"
-			"  revision: 0xff [all]\n"
-			"  owner: 00000000-0000-0000-0000-000000000000\n"
-			"  oem_table_id: X\n"
-			"  oem_revision: 0x0\n"
-			"  asl_compiler_id: 0xDFDFDFDF\n"
-			"  asl_compiler_revision: 0x0");
+	ret = fu_test_compare_lines(str2,
+				    "FuStructSelfTest:\n"
+				    "  signature: 0x12345678\n"
+				    "  length: 0xdead\n"
+				    "  revision: 0xff [all]\n"
+				    "  owner: 00000000-0000-0000-0000-000000000000\n"
+				    "  oem_id: ABCDEF\n"
+				    "  oem_table_id: X\n"
+				    "  oem_revision: 0x0\n"
+				    "  asl_compiler_id: 0xDFDFDFDF\n"
+				    "  asl_compiler_revision: 0x0",
+				    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* parse failing signature */
 	st->buf->data[0] = 0xFF;
@@ -7451,18 +7455,22 @@ fu_plugin_struct_wrapped_func(void)
 	/* to string */
 	str2 = fu_struct_self_test_wrapped_to_string(st);
 	g_debug("%s", str2);
-	g_assert_cmpstr(str2,
-			==,
-			"FuStructSelfTestWrapped:\n"
-			"  less: 0x99\n"
-			"  base: FuStructSelfTest:\n"
-			"  length: 0x3b\n"
-			"  revision: 0xfe\n"
-			"  owner: 00000000-0000-0000-0000-000000000000\n"
-			"  oem_revision: 0x0\n"
-			"  asl_compiler_id: 0xDFDFDFDF\n"
-			"  asl_compiler_revision: 0x0\n"
-			"  more: 0x12");
+	fu_test_compare_lines(str2,
+			      "FuStructSelfTestWrapped:\n"
+			      "  less: 0x99\n"
+			      "  base: FuStructSelfTest:\n"
+			      "  signature: 0x12345678\n"
+			      "  length: 0x3b\n"
+			      "  revision: 0xfe\n"
+			      "  owner: 00000000-0000-0000-0000-000000000000\n"
+			      "  oem_id: ABCDEF\n"
+			      "  oem_revision: 0x0\n"
+			      "  asl_compiler_id: 0xDFDFDFDF\n"
+			      "  asl_compiler_revision: 0x0\n"
+			      "  more: 0x12",
+			      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	/* parse failing signature */
 	st->buf->data[FU_STRUCT_SELF_TEST_WRAPPED_OFFSET_BASE] = 0xFF;

--- a/libfwupdplugin/rustgen.py
+++ b/libfwupdplugin/rustgen.py
@@ -310,8 +310,10 @@ class StructObj:
             for item in self.items:
                 if item.struct_obj:
                     item.struct_obj.add_private_export("ToString")
-                if item.enum_obj and not item.constant and item.enabled:
+                elif item.enum_obj and item.enabled:
                     item.enum_obj.add_private_export("ToString")
+                elif item.enabled:
+                    item.add_private_export("Getters")
         elif derive == "Parse":
             self.add_private_export("NewInternal")
             self.add_private_export("ParseInternal")
@@ -324,12 +326,6 @@ class StructObj:
             self.add_private_export("ToString")
             self.add_private_export("ValidateInternal")
             for item in self.items:
-                if (
-                    item.constant
-                    and item.type != Type.STRING
-                    and not (item.type == Type.U8 and item.n_elements)
-                ):
-                    item.add_private_export("Getters")
                 if item.struct_obj:
                     item.struct_obj.add_private_export("ValidateInternal")
         elif derive == "New":


### PR DESCRIPTION
This makes debugging of low-level protocol issues much easier...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
