### PR TITLE
pixart-tp: Add quirk for PJP274 (Framework Laptop)

### DIFF
--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -1,3 +1,7 @@
+[HIDRAW\VEN_093A&DEV_0274]
+Plugin = pixart_tp
+PixartTpSramSelect = 0x08
+
 [HIDRAW\VEN_093A&DEV_0343]
 Plugin = pixart_tp
 


### PR DESCRIPTION
Can read firmware version on Framework Laptop 13 and Laptop 16. Reports the same version as the official Pixart tool (previously used on ChromeOS).

> sudo ./pixtpfwup /dev/hidraw1 get_fwver
Pixart Touchpad Utility (v0.1.6)
IC Type: 0274
Firmware Version: 0905

> fwupdtool get-devices --plugins pixart-tp
Framework Laptop 16 (AMD Ryzen 7040 Series)
│
└─PIXA3854:00 093A:0274:
      Device ID:          2555c513c826db32fa938b47ca1eeace640bbaa1
      Summary:            Touchpad
      Current version:    0x0905
      Vendor:             Pixart Imaging, Inc. (HIDRAW:0x093A)
      GUID:               2a62ed27-652b-5223-8a24-53e40176e152 ← HIDRAW\VEN_093A&DEV_0274
      Device Flags:       • Updatable
                          • Unsigned Payload
                          • Can tag for emulation