### PR TITLE
pixart-tp: Add support for :0239

### DIFF
--- a/plugins/pixart-tp/fu-pixart-tp-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-device.c
@@ -1210,6 +1210,7 @@ fu_pixart_tp_device_setup(FuDevice *device, GError **error)
 {
 	FuPixartTpDevice *self = FU_PIXART_TP_DEVICE(device);
 	guint8 buf[2] = {0};
+	guint16 part_id = fu_device_get_pid(device);
 
 	/* read TP boot status*/
 	if (!fu_pixart_tp_device_register_user_read(self,
@@ -1225,21 +1226,41 @@ fu_pixart_tp_device_setup(FuDevice *device, GError **error)
 			return FALSE;
 	}
 
-	/* read low byte */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    self->ver_bank,
-						    (guint8)(self->ver_addr + 0),
-						    &buf[0],
-						    error))
-		return FALSE;
+	switch (part_id) {
+	case FU_PIXART_TP_PART_ID_PJP239:
+		/* read low byte */
+		if (!fu_pixart_tp_device_register_read(self,
+							    self->ver_bank,
+							    (guint8)(self->ver_addr + 0),
+							    &buf[0],
+							    error))
+			return FALSE;
 
-	/* read high byte */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    self->ver_bank,
-						    (guint8)(self->ver_addr + 1),
-						    &buf[1],
-						    error))
-		return FALSE;
+		/* read high byte */
+		if (!fu_pixart_tp_device_register_read(self,
+							    self->ver_bank,
+							    (guint8)(self->ver_addr + 2),
+							    &buf[1],
+							    error))
+			return FALSE;
+		break;
+	default:
+		/* read low byte */
+		if (!fu_pixart_tp_device_register_user_read(self,
+							    self->ver_bank,
+							    (guint8)(self->ver_addr + 0),
+							    &buf[0],
+							    error))
+			return FALSE;
+
+		/* read high byte */
+		if (!fu_pixart_tp_device_register_user_read(self,
+							    self->ver_bank,
+							    (guint8)(self->ver_addr + 1),
+							    &buf[1],
+							    error))
+			return FALSE;
+	}
 
 	/* success */
 	fu_device_set_version_raw(device, fu_memread_uint16(buf, G_LITTLE_ENDIAN));

--- a/plugins/pixart-tp/fu-pixart-tp.rs
+++ b/plugins/pixart-tp/fu-pixart-tp.rs
@@ -142,6 +142,7 @@ enum FuPixartTpFlashCcr {
 
 #[repr(u16)]
 enum FuPixartTpPartId {
+    Pjp239 = 0x0239,
     Pjp274 = 0x0274,
 }
 

--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -1,3 +1,7 @@
+[HIDRAW\VEN_093A&DEV_0239]
+Plugin = pixart_tp
+PixartTpHidVersionAddr = 0x16
+
 [HIDRAW\VEN_093A&DEV_0274]
 Plugin = pixart_tp
 PixartTpSramSelect = 0x08


### PR DESCRIPTION
Reading the expected version number works.

> fwupdtool get-devices --plugins pixart-tp
Framework Laptop 12 (13th Gen Intel Core)
│
└─PIXA3854:00 093A:0239:
      Device ID:          2555c513c826db32fa938b47ca1eeace640bbaa1
      Summary:            Touchpad
      Current version:    0x0e08
      Vendor:             Pixart Imaging, Inc. (HIDRAW:0x093A)
      GUID:               5c30256d-d711-51ca-b3e4-665910007369 ← HIDRAW\VEN_093A&DEV_0239
      Device Flags:       • Updatable
                          • Unsigned Payload
                          • Can tag for emulation

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
