### PR TITLE
Revert "trivial: Remove some dead JCat compat code"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -362,7 +362,7 @@ if build_standalone
 endif
 libjcat = dependency(
   'jcat',
-  version: '>= 0.2.0',
+  version: '>= 0.1.6',
   fallback: ['libjcat', 'libjcat_dep'],
 )
 libblkid = dependency(

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -12,6 +12,11 @@
 
 #include "fu-cabinet.h"
 
+/* fixed in 0.1.14 */
+#ifndef JCAT_CHECK_VERSION
+#define JCAT_CHECK_VERSION LIBJCAT_CHECK_VERSION
+#endif
+
 /**
  * FuCabinet:
  *
@@ -225,6 +230,7 @@ fu_cabinet_parse_release(FuCabinet *self,
 
 	/* the jcat file signed the *checksum of the payload*, not the payload itself */
 	item = jcat_file_get_item_by_id(self->jcat_file, basename, NULL);
+#if JCAT_CHECK_VERSION(0, 2, 0)
 	if (item != NULL && jcat_item_has_target(item)) {
 		g_autofree gchar *checksum_sha256 = NULL;
 		g_autofree gchar *checksum_sha512 = NULL;
@@ -265,7 +271,9 @@ fu_cabinet_parse_release(FuCabinet *self,
 			g_info("verified indirect payload %s: %u", basename, results->len);
 			release_flags |= FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD;
 		}
-	} else if (item != NULL) {
+	}
+#endif
+	if (item != NULL) {
 		g_autoptr(GBytes) blob = NULL;
 		g_autoptr(GError) error_local = NULL;
 		g_autoptr(GPtrArray) results = NULL;
@@ -1079,10 +1087,12 @@ fu_cabinet_init(FuCabinet *self)
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();
 	self->jcat_context = jcat_context_new();
+#if JCAT_CHECK_VERSION(0, 1, 13)
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_SHA256);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_SHA512);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_PKCS7);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_GPG);
+#endif
 }
 
 static void

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -76,6 +76,11 @@
 /* only needed until we hard depend on jcat 0.1.3 */
 #include <libjcat/jcat-version.h>
 
+/* fixed in 0.1.14 */
+#ifndef JCAT_CHECK_VERSION
+#define JCAT_CHECK_VERSION LIBJCAT_CHECK_VERSION
+#endif
+
 #ifdef HAVE_SYSTEMD
 #include "fu-systemd.h"
 #endif
@@ -9324,10 +9329,12 @@ fu_engine_constructed(GObject *obj)
 
 	/* setup Jcat context */
 	self->jcat_context = jcat_context_new();
+#if JCAT_CHECK_VERSION(0, 1, 13)
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_SHA256);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_SHA512);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_PKCS7);
 	jcat_context_blob_kind_allow(self->jcat_context, JCAT_BLOB_KIND_GPG);
+#endif
 	keyring_path = fu_path_from_kind(FU_PATH_KIND_LOCALSTATEDIR_PKG);
 	jcat_context_set_keyring_path(self->jcat_context, keyring_path);
 	pkidir_fw = fu_path_build(FU_PATH_KIND_SYSCONFDIR, "pki", "fwupd", NULL);
@@ -9337,7 +9344,9 @@ fu_engine_constructed(GObject *obj)
 
 	/* add some runtime versions of things the daemon depends on */
 	fu_engine_add_runtime_version(self, "org.freedesktop.fwupd", VERSION);
+#if JCAT_CHECK_VERSION(0, 1, 11)
 	fu_engine_add_runtime_version(self, "com.hughsie.libjcat", jcat_version_string());
+#endif
 	fu_engine_add_runtime_version(self, "com.hughsie.libxmlb", xb_version_string());
 
 	/* optional kernel version */


### PR DESCRIPTION
This reverts commit b3cd790875065fdda7b8bf7328c325af8ce30a52 so we can build on RHEL 9 without also upreving libjcat.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
