### PR TITLE
Disable the UEFI plugins on 32bit x86

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -885,7 +885,7 @@ if dbusmock.returncode() != 0 and get_option('umockdev_tests').allowed()
 endif
 
 allow_uefi = host_machine.system() in ['linux', 'freebsd'] and \
-  host_machine.cpu_family() in ['x86', 'x86_64', 'aarch64', 'riscv64', 'loongarch64']
+  host_machine.cpu_family() in ['x86_64', 'aarch64', 'riscv64', 'loongarch64']
 
 subdir('generate-build')
 subdir('libfwupd')


### PR DESCRIPTION
Although UEFI on 32 bit i686 is certainly possible to support, the dbx update for IA32 has been downloaded only *once* by real users of fwupd, the other downloads all being by bots or people syncing the entire LVFS repo.

There have been no KEKs uploaded for 32 bit-only targets, and all the platforms are seemlying EOL. I'm not even going to bother to upload the next dbx for IA32.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
