### PR TITLE
Allow systemd service to access block-sr (cdrom) devices

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -94,6 +94,7 @@ if build_daemon
 
     device_allows = [
       'block-sd',
+      'block-sr',
       'char-aux',
       'char-cpu/*',
       'char-drm',


### PR DESCRIPTION
Otherwise the daemon can't interact with them.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
