### PR TITLE
Verify the uncompressed size when decompressing CAB files

### DIFF
--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -7136,6 +7136,52 @@ fu_cab_checksum_func(void)
 }
 
 static void
+fu_cab_compressed_size_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuCabFirmware) cab2 = fu_cab_firmware_new();
+	g_autoptr(FuCabFirmware) cab = fu_cab_firmware_new();
+	g_autoptr(FuCabImage) img = fu_cab_image_new();
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GBytes) blob2 = NULL;
+	g_autoptr(GBytes) blob_img = g_bytes_new_static("abc", 3);
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* build a cab file and then tweak the payload */
+	fu_cab_firmware_set_compressed(cab, TRUE);
+	fu_firmware_set_bytes(FU_FIRMWARE(img), blob_img);
+	fu_firmware_set_id(FU_FIRMWARE(img), "foo.txt");
+	ret = fu_firmware_add_image(FU_FIRMWARE(cab), FU_FIRMWARE(img), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* write to a mutable buffer */
+	blob = fu_firmware_write(FU_FIRMWARE(cab), &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob);
+	buf = g_bytes_unref_to_array(g_steal_pointer(&blob));
+	g_assert_nonnull(buf);
+	g_assert_nonnull(buf->data);
+
+	/* change FuStructCabData.uncomp to be too small */
+	g_assert_cmpint(buf->len, ==, 0x53);
+	g_assert_cmpint(buf->data[0x4A], ==, 0x03);
+	buf->data[0x4A] = 0x02;
+
+	/* parse the new blob */
+	blob2 = g_bytes_new(buf->data, buf->len);
+	ret = fu_firmware_parse_bytes(FU_FIRMWARE(cab2),
+				      blob2,
+				      0x0,
+				      FU_FIRMWARE_PARSE_FLAG_IGNORE_CHECKSUM,
+				      &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
+	g_assert_true(g_str_has_prefix(error->message, "decompressed size mismatch"));
+	g_assert_false(ret);
+}
+
+static void
 fu_efi_lz77_decompressor_func(void)
 {
 	gboolean ret;
@@ -7618,6 +7664,7 @@ main(int argc, char **argv)
 	g_type_ensure(FU_TYPE_USB_BOS_DESCRIPTOR);
 
 	g_test_add_func("/fwupd/cab{checksum}", fu_cab_checksum_func);
+	g_test_add_func("/fwupd/cab{compressed-size}", fu_cab_compressed_size_func);
 	g_test_add_func("/fwupd/efi-lz77{decompressor}", fu_efi_lz77_decompressor_func);
 	g_test_add_func("/fwupd/input-stream", fu_input_stream_func);
 	g_test_add_func("/fwupd/input-stream{sum-overflow}", fu_input_stream_sum_overflow_func);


### PR DESCRIPTION
This prevents a decompression bomb that allows a 2MB cab file to use over 500MB of RSS.

Fixes https://github.com/fwupd/fwupd/issues/9790

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
