### PR TITLE
Do not use NULL as a delimiter for constant data

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -7104,7 +7104,7 @@ static FwupdJsonObject *
 fwupd_client_build_report_history_device(FwupdDevice *dev)
 {
 	FwupdRelease *rel = fwupd_device_get_release_default(dev);
-	GChecksumType checksum_types[] = {G_CHECKSUM_SHA256, G_CHECKSUM_SHA1, 0};
+	GChecksumType checksum_types[] = {G_CHECKSUM_SHA256, G_CHECKSUM_SHA1};
 	GHashTable *metadata = fwupd_release_get_metadata(rel);
 	GPtrArray *checksums;
 	GPtrArray *guids;
@@ -7112,7 +7112,7 @@ fwupd_client_build_report_history_device(FwupdDevice *dev)
 
 	/* identify the firmware used */
 	checksums = fwupd_release_get_checksums(rel);
-	for (guint i = 0; checksum_types[i] != 0; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		const gchar *checksum = fwupd_checksum_get_by_kind(checksums, checksum_types[i]);
 		if (checksum != NULL) {
 			fwupd_json_object_add_string(json_obj, "Checksum", checksum);

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -130,13 +130,14 @@ fwupd_checksum_get_by_kind(GPtrArray *checksums, GChecksumType kind)
 const gchar *
 fwupd_checksum_get_best(GPtrArray *checksums)
 {
-	GChecksumType checksum_types[] = {G_CHECKSUM_SHA512,
-					  G_CHECKSUM_SHA256,
-					  G_CHECKSUM_SHA384,
-					  G_CHECKSUM_SHA1,
-					  0};
+	GChecksumType checksum_types[] = {
+	    G_CHECKSUM_SHA512,
+	    G_CHECKSUM_SHA256,
+	    G_CHECKSUM_SHA384,
+	    G_CHECKSUM_SHA1,
+	};
 	g_return_val_if_fail(checksums != NULL, NULL);
-	for (guint i = 0; checksum_types[i] != 0; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		for (guint j = 0; j < checksums->len; j++) {
 			const gchar *checksum = g_ptr_array_index(checksums, j);
 			if (fwupd_checksum_guess_kind(checksum) == checksum_types[i])

--- a/libfwupdplugin/fu-common-linux.c
+++ b/libfwupdplugin/fu-common-linux.c
@@ -247,14 +247,13 @@ fu_common_get_kernel_cmdline_impl(GError **error)
 	    "vt.handoff",
 	    "zfs",
 	    "zswap.enabled",
-	    NULL, /* last entry */
 	};
 
 	/* get a PII-safe kernel command line */
 	hash = fu_kernel_get_cmdline(error);
 	if (hash == NULL)
 		return NULL;
-	for (guint i = 0; ignore[i] != NULL; i++)
+	for (guint i = 0; i < G_N_ELEMENTS(ignore); i++)
 		g_hash_table_remove(hash, ignore[i]);
 	g_hash_table_iter_init(&iter, hash);
 	while (g_hash_table_iter_next(&iter, &key, &value)) {

--- a/libfwupdplugin/fu-config.c
+++ b/libfwupdplugin/fu-config.c
@@ -293,18 +293,19 @@ fu_config_migrate_keyfiles(FuConfig *self, GError **error)
 {
 	FuConfigPrivate *priv = GET_PRIVATE(self);
 	g_autoptr(GPtrArray) legacy_cfg_files = g_ptr_array_new_with_free_func(g_free);
-	const gchar *fn_merge[] = {"daemon.conf",
-				   "msr.conf",
-				   "redfish.conf",
-				   "thunderbolt.conf",
-				   "uefi_capsule.conf",
-				   NULL};
+	const gchar *fn_merge[] = {
+	    "daemon.conf",
+	    "msr.conf",
+	    "redfish.conf",
+	    "thunderbolt.conf",
+	    "uefi_capsule.conf",
+	};
 
 	for (guint i = 0; i < priv->items->len; i++) {
 		FuConfigItem *item = g_ptr_array_index(priv->items, i);
 		g_autofree gchar *dirname = g_path_get_dirname(item->filename);
 
-		for (guint j = 0; fn_merge[j] != NULL; j++) {
+		for (guint j = 0; j < G_N_ELEMENTS(fn_merge); j++) {
 			g_autofree gchar *fncompat = g_build_filename(dirname, fn_merge[j], NULL);
 			if (g_file_test(fncompat, G_FILE_TEST_EXISTS)) {
 				g_autoptr(GBytes) blob_compat =

--- a/libfwupdplugin/fu-hwids-darwin.c
+++ b/libfwupdplugin/fu-hwids-darwin.c
@@ -20,10 +20,11 @@ fu_hwids_darwin_setup(FuContext *ctx, FuHwids *self, GError **error)
 	struct {
 		const gchar *hwid;
 		const gchar *key;
-	} map[] = {{FU_HWIDS_KEY_BIOS_VERSION, "System Firmware Version"},
-		   {FU_HWIDS_KEY_FAMILY, "Model Name"},
-		   {FU_HWIDS_KEY_PRODUCT_NAME, "Model Identifier"},
-		   {NULL}};
+	} map[] = {
+	    {FU_HWIDS_KEY_BIOS_VERSION, "System Firmware Version"},
+	    {FU_HWIDS_KEY_FAMILY, "Model Name"},
+	    {FU_HWIDS_KEY_PRODUCT_NAME, "Model Identifier"},
+	};
 	const gchar *family = NULL;
 	g_autofree gchar *standard_output = NULL;
 	g_auto(GStrv) lines = NULL;
@@ -37,7 +38,7 @@ fu_hwids_darwin_setup(FuContext *ctx, FuHwids *self, GError **error)
 		return FALSE;
 	lines = g_strsplit(standard_output, "\n", -1);
 	for (guint j = 0; lines[j] != NULL; j++) {
-		for (guint i = 0; map[i].key != NULL; i++) {
+		for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
 			g_auto(GStrv) chunks = g_strsplit(lines[j], ":", 2);
 			if (g_strv_length(chunks) != 2)
 				continue;

--- a/libfwupdplugin/fu-hwids-fdt.c
+++ b/libfwupdplugin/fu-hwids-fdt.c
@@ -24,10 +24,11 @@ fu_hwids_fdt_setup(FuContext *ctx, FuHwids *self, GError **error)
 	struct {
 		const gchar *hwid;
 		const gchar *key;
-	} map[] = {{FU_HWIDS_KEY_MANUFACTURER, "vendor"},
-		   {FU_HWIDS_KEY_FAMILY, "model-name"},
-		   {FU_HWIDS_KEY_PRODUCT_NAME, "model"},
-		   {NULL, NULL}};
+	} map[] = {
+	    {FU_HWIDS_KEY_MANUFACTURER, "vendor"},
+	    {FU_HWIDS_KEY_FAMILY, "model-name"},
+	    {FU_HWIDS_KEY_PRODUCT_NAME, "model"},
+	};
 
 	/* adds compatible GUIDs */
 	fdt = fu_context_get_fdt(ctx, error);
@@ -45,7 +46,7 @@ fu_hwids_fdt_setup(FuContext *ctx, FuHwids *self, GError **error)
 	}
 
 	/* root node */
-	for (guint i = 0; map[i].key != NULL; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
 		g_autofree gchar *tmp = NULL;
 		fu_fdt_image_get_attr_str(FU_FDT_IMAGE(fdt_img), map[i].key, &tmp, NULL);
 		if (tmp == NULL)

--- a/libfwupdplugin/fu-hwids.c
+++ b/libfwupdplugin/fu-hwids.c
@@ -103,22 +103,23 @@ GPtrArray *
 fu_hwids_get_keys(FuHwids *self)
 {
 	GPtrArray *array = g_ptr_array_new();
-	const gchar *keys[] = {FU_HWIDS_KEY_BIOS_VENDOR,
-			       FU_HWIDS_KEY_BIOS_VERSION,
-			       FU_HWIDS_KEY_BIOS_MAJOR_RELEASE,
-			       FU_HWIDS_KEY_BIOS_MINOR_RELEASE,
-			       FU_HWIDS_KEY_FIRMWARE_MAJOR_RELEASE,
-			       FU_HWIDS_KEY_FIRMWARE_MINOR_RELEASE,
-			       FU_HWIDS_KEY_MANUFACTURER,
-			       FU_HWIDS_KEY_FAMILY,
-			       FU_HWIDS_KEY_PRODUCT_NAME,
-			       FU_HWIDS_KEY_PRODUCT_SKU,
-			       FU_HWIDS_KEY_ENCLOSURE_KIND,
-			       FU_HWIDS_KEY_BASEBOARD_MANUFACTURER,
-			       FU_HWIDS_KEY_BASEBOARD_PRODUCT,
-			       NULL};
+	const gchar *keys[] = {
+	    FU_HWIDS_KEY_BIOS_VENDOR,
+	    FU_HWIDS_KEY_BIOS_VERSION,
+	    FU_HWIDS_KEY_BIOS_MAJOR_RELEASE,
+	    FU_HWIDS_KEY_BIOS_MINOR_RELEASE,
+	    FU_HWIDS_KEY_FIRMWARE_MAJOR_RELEASE,
+	    FU_HWIDS_KEY_FIRMWARE_MINOR_RELEASE,
+	    FU_HWIDS_KEY_MANUFACTURER,
+	    FU_HWIDS_KEY_FAMILY,
+	    FU_HWIDS_KEY_PRODUCT_NAME,
+	    FU_HWIDS_KEY_PRODUCT_SKU,
+	    FU_HWIDS_KEY_ENCLOSURE_KIND,
+	    FU_HWIDS_KEY_BASEBOARD_MANUFACTURER,
+	    FU_HWIDS_KEY_BASEBOARD_PRODUCT,
+	};
 	g_return_val_if_fail(FU_IS_HWIDS(self), NULL);
-	for (guint i = 0; keys[i] != NULL; i++)
+	for (guint i = 0; i < G_N_ELEMENTS(keys); i++)
 		g_ptr_array_add(array, (gpointer)keys[i]);
 	return array;
 }

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -800,7 +800,11 @@ fu_plugin_device_read_firmware(FuPlugin *self,
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(FuFirmware) firmware = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	GChecksumType checksum_types[] = {G_CHECKSUM_SHA1, G_CHECKSUM_SHA256, 0};
+	GChecksumType checksum_types[] = {
+	    G_CHECKSUM_SHA1,
+	    G_CHECKSUM_SHA256,
+	};
+
 	locker = fu_device_locker_new(proxy, error);
 	if (locker == NULL)
 		return FALSE;
@@ -822,7 +826,7 @@ fu_plugin_device_read_firmware(FuPlugin *self,
 		g_prefix_error_literal(error, "failed to write firmware: ");
 		return FALSE;
 	}
-	for (guint i = 0; checksum_types[i] != 0; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		g_autofree gchar *hash = NULL;
 		hash = g_compute_checksum_for_bytes(checksum_types[i], fw);
 		fu_device_add_checksum(device, hash);

--- a/libfwupdplugin/fu-string.c
+++ b/libfwupdplugin/fu-string.c
@@ -728,8 +728,8 @@ fu_strpassmask(const gchar *str)
 		gboolean is_password = FALSE;
 		gboolean is_url = FALSE;
 		for (guint i = 0; i < tmp->len; i++) {
-			const gchar *url_prefixes[] = {"http://", "https://", NULL};
-			for (guint j = 0; url_prefixes[j] != NULL; j++) {
+			const gchar *url_prefixes[] = {"http://", "https://"};
+			for (guint j = 0; j < G_N_ELEMENTS(url_prefixes); j++) {
 				if (g_str_has_prefix(tmp->str + i, url_prefixes[j])) {
 					is_url = TRUE;
 					i += strlen(url_prefixes[j]);

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -246,7 +246,7 @@ static gboolean
 fu_ebitdo_device_validate(FuEbitdoDevice *self, GError **error)
 {
 	const gchar *ven;
-	const gchar *allowlist[] = {"8Bitdo", "8BitDo", "SFC30", NULL};
+	const gchar *allowlist[] = {"8Bitdo", "8BitDo", "SFC30"};
 
 	/* this is a new, always valid, VID */
 	if (fu_device_get_vid(FU_DEVICE(self)) == 0x2dc8)
@@ -261,7 +261,7 @@ fu_ebitdo_device_validate(FuEbitdoDevice *self, GError **error)
 				    "could not check vendor descriptor");
 		return FALSE;
 	}
-	for (guint i = 0; allowlist[i] != NULL; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(allowlist); i++) {
 		if (g_str_has_prefix(ven, allowlist[i]))
 			return TRUE;
 	}

--- a/plugins/redfish/fu-ipmi-device.c
+++ b/plugins/redfish/fu-ipmi-device.c
@@ -471,10 +471,10 @@ static gboolean
 fu_ipmi_device_probe(FuDevice *device, GError **error)
 {
 	FuIpmiDevice *self = FU_IPMI_DEVICE(device);
-	const gchar *physical_ids[] = {"/dev/ipmi0", "/dev/ipmi/0", "/dev/ipmidev/0", NULL};
+	const gchar *physical_ids[] = {"/dev/ipmi0", "/dev/ipmi/0", "/dev/ipmidev/0"};
 
 	/* look for the IPMI device */
-	for (guint i = 0; physical_ids[i] != NULL; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(physical_ids); i++) {
 		gboolean exists_fn = FALSE;
 		if (!fu_device_query_file_exists(device, physical_ids[i], &exists_fn, error))
 			return FALSE;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -803,12 +803,15 @@ fu_engine_get_releases_for_container_checksum(FuEngine *self, const gchar *csum)
 gchar *
 fu_engine_get_remote_id_for_stream(FuEngine *self, GInputStream *stream)
 {
-	GChecksumType checksum_types[] = {G_CHECKSUM_SHA256, G_CHECKSUM_SHA1, 0};
+	GChecksumType checksum_types[] = {
+	    G_CHECKSUM_SHA256,
+	    G_CHECKSUM_SHA1,
+	};
 
 	g_return_val_if_fail(FU_IS_ENGINE(self), NULL);
 	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), NULL);
 
-	for (guint i = 0; checksum_types[i] != 0; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		g_autofree gchar *csum = NULL;
 		g_autoptr(GPtrArray) rels = NULL;
 
@@ -2725,8 +2728,11 @@ fu_engine_install_release(FuEngine *self,
 
 	/* add the checksum of the container blob if not already set */
 	if (fwupd_release_get_checksums(FWUPD_RELEASE(release))->len == 0) {
-		GChecksumType checksum_types[] = {G_CHECKSUM_SHA256, G_CHECKSUM_SHA1, 0};
-		for (guint i = 0; checksum_types[i] != 0; i++) {
+		GChecksumType checksum_types[] = {
+		    G_CHECKSUM_SHA256,
+		    G_CHECKSUM_SHA1,
+		};
+		for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 			g_autofree gchar *checksum =
 			    fu_input_stream_compute_checksum(stream, checksum_types[i], error);
 			if (checksum == NULL)
@@ -5041,7 +5047,10 @@ fu_engine_get_details(FuEngine *self,
 		      GInputStream *stream,
 		      GError **error)
 {
-	GChecksumType checksum_types[] = {G_CHECKSUM_SHA256, G_CHECKSUM_SHA1, 0};
+	GChecksumType checksum_types[] = {
+	    G_CHECKSUM_SHA256,
+	    G_CHECKSUM_SHA1,
+	};
 	g_autoptr(GPtrArray) components = NULL;
 	g_autoptr(GPtrArray) details = NULL;
 	g_autoptr(GPtrArray) checksums = g_ptr_array_new_with_free_func(g_free);
@@ -5062,7 +5071,7 @@ fu_engine_get_details(FuEngine *self,
 		return NULL;
 
 	/* calculate the checksums of the blob */
-	for (guint i = 0; checksum_types[i] != 0; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(checksum_types); i++) {
 		g_autofree gchar *checksum =
 		    fu_input_stream_compute_checksum(stream, checksum_types[i], error);
 		if (checksum == NULL)
@@ -7868,10 +7877,11 @@ fu_engine_plugins_init(FuEngine *self, FuProgress *progress, GError **error)
 static gboolean
 fu_engine_cleanup_state(GError **error)
 {
-	const gchar *filenames[] = {"/var/cache/app-info/xmls/fwupd-verify.xml",
-				    "/var/cache/app-info/xmls/fwupd.xml",
-				    NULL};
-	for (guint i = 0; filenames[i] != NULL; i++) {
+	const gchar *filenames[] = {
+	    "/var/cache/app-info/xmls/fwupd-verify.xml",
+	    "/var/cache/app-info/xmls/fwupd.xml",
+	};
+	for (guint i = 0; i < G_N_ELEMENTS(filenames); i++) {
 		g_autoptr(GFile) file = g_file_new_for_path(filenames[i]);
 		if (g_file_query_exists(file, NULL)) {
 			if (!g_file_delete(file, NULL, error))
@@ -8447,12 +8457,13 @@ fu_engine_context_set_battery_threshold(FuContext *ctx)
 static gboolean
 fu_engine_ensure_paths_exist(GError **error)
 {
-	FuPathKind path_kinds[] = {FU_PATH_KIND_LOCALSTATEDIR_QUIRKS,
-				   FU_PATH_KIND_LOCALSTATEDIR_METADATA,
-				   FU_PATH_KIND_LOCALSTATEDIR_REMOTES,
-				   FU_PATH_KIND_CACHEDIR_PKG,
-				   FU_PATH_KIND_LAST};
-	for (guint i = 0; path_kinds[i] != FU_PATH_KIND_LAST; i++) {
+	FuPathKind path_kinds[] = {
+	    FU_PATH_KIND_LOCALSTATEDIR_QUIRKS,
+	    FU_PATH_KIND_LOCALSTATEDIR_METADATA,
+	    FU_PATH_KIND_LOCALSTATEDIR_REMOTES,
+	    FU_PATH_KIND_CACHEDIR_PKG,
+	};
+	for (guint i = 0; i < G_N_ELEMENTS(path_kinds); i++) {
 		g_autofree gchar *fn = fu_path_from_kind(path_kinds[i]);
 		if (!fu_path_mkdir(fn, error))
 			return FALSE;

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -7753,12 +7753,13 @@ fu_config_migrate_1_7_func(void)
 {
 	const gchar *sysconfdir = "/tmp/fwupd-self-test/conf-migration-1.7/var/etc";
 	gboolean ret;
-	const gchar *fn_merge[] = {"daemon.conf",
-				   "msr.conf",
-				   "redfish.conf",
-				   "thunderbolt.conf",
-				   "uefi_capsule.conf",
-				   NULL};
+	const gchar *fn_merge[] = {
+	    "daemon.conf",
+	    "msr.conf",
+	    "redfish.conf",
+	    "thunderbolt.conf",
+	    "uefi_capsule.conf",
+	};
 	g_autofree gchar *localconf_data = NULL;
 	g_autofree gchar *fn_mut = NULL;
 	g_autofree gchar *testdatadir = NULL;
@@ -7786,7 +7787,7 @@ fu_config_migrate_1_7_func(void)
 	g_assert_true(ret);
 
 	/* copy all files to working directory */
-	for (guint i = 0; fn_merge[i] != NULL; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(fn_merge); i++) {
 		g_autofree gchar *source =
 		    g_build_filename(testdatadir, "fwupd", fn_merge[i], NULL);
 		g_autofree gchar *target = g_build_filename(sysconfdir, "fwupd", fn_merge[i], NULL);
@@ -7800,7 +7801,7 @@ fu_config_migrate_1_7_func(void)
 	g_assert_true(ret);
 
 	/* make sure all migrated files were renamed */
-	for (guint i = 0; fn_merge[i] != NULL; i++) {
+	for (guint i = 0; i < G_N_ELEMENTS(fn_merge); i++) {
 		g_autofree gchar *old = g_build_filename(sysconfdir, "fwupd", fn_merge[i], NULL);
 		g_autofree gchar *new = g_strdup_printf("%s.old", old);
 		ret = g_file_test(old, G_FILE_TEST_EXISTS);


### PR DESCRIPTION
Using G_N_ELEMENTS allows the compiler to do this more efficiently -- and it also looks nicer too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
