### PR TITLE
trivial: Enforce that fu_quirks_load() is called before fu_quirks_lookup_by_id()

### DIFF
--- a/libfwupdplugin/fu-context-private.h
+++ b/libfwupdplugin/fu-context-private.h
@@ -20,6 +20,8 @@
 
 FuContext *
 fu_context_new(void);
+FuContext *
+fu_context_new_full(FuContextFlags flags);
 void
 fu_context_housekeeping(FuContext *self) G_GNUC_NON_NULL(1);
 gboolean

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1110,6 +1110,8 @@ fu_context_lookup_quirk_by_id_iter(FuContext *self,
 	g_return_val_if_fail(FU_IS_CONTEXT(self), FALSE);
 	g_return_val_if_fail(guid != NULL, FALSE);
 	g_return_val_if_fail(iter_cb != NULL, FALSE);
+	if (priv->flags & FU_CONTEXT_FLAG_NO_QUIRKS)
+		return TRUE;
 	return fu_quirks_lookup_by_id_iter(priv->quirks,
 					   guid,
 					   key,
@@ -2695,6 +2697,13 @@ fu_context_init(FuContext *self)
 	priv->backends = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 }
 
+/* private */
+FuContext *
+fu_context_new_full(FuContextFlags flags)
+{
+	return FU_CONTEXT(g_object_new(FU_TYPE_CONTEXT, "flags", (guint64)flags, NULL));
+}
+
 /**
  * fu_context_new:
  *
@@ -2707,5 +2716,5 @@ fu_context_init(FuContext *self)
 FuContext *
 fu_context_new(void)
 {
-	return FU_CONTEXT(g_object_new(FU_TYPE_CONTEXT, NULL));
+	return fu_context_new_full(FU_CONTEXT_FLAG_NONE);
 }

--- a/libfwupdplugin/fu-context.rs
+++ b/libfwupdplugin/fu-context.rs
@@ -17,6 +17,7 @@ enum FuContextFlags {
     IsHypervisorPrivileged  = 1 << 10, // privileged xen can access most hardware
     IsContainer             = 1 << 11,
     SmbiosUefiEnabled       = 1 << 12,
+    NoQuirks                = 1 << 13,
 }
 
 enum FuContextHwidFlags {

--- a/libfwupdplugin/fu-quirks.c
+++ b/libfwupdplugin/fu-quirks.c
@@ -78,6 +78,7 @@ struct _FuQuirks {
 	XbQuery *query_kv;
 	XbQuery *query_vs;
 	gboolean verbose;
+	gboolean loaded;
 #ifdef HAVE_SQLITE
 	sqlite3 *db;
 #endif
@@ -463,6 +464,7 @@ fu_quirks_lookup_by_id(FuQuirks *self, const gchar *guid, const gchar *key)
 	g_auto(XbQueryContext) context = XB_QUERY_CONTEXT_INIT();
 
 	g_return_val_if_fail(FU_IS_QUIRKS(self), NULL);
+	g_return_val_if_fail(self->loaded, NULL);
 	g_return_val_if_fail(guid != NULL, NULL);
 	g_return_val_if_fail(key != NULL, NULL);
 
@@ -543,6 +545,7 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 	g_auto(XbQueryContext) context = XB_QUERY_CONTEXT_INIT();
 
 	g_return_val_if_fail(FU_IS_QUIRKS(self), FALSE);
+	g_return_val_if_fail(self->loaded, FALSE);
 	g_return_val_if_fail(guid != NULL, FALSE);
 	g_return_val_if_fail(iter_cb != NULL, FALSE);
 
@@ -589,7 +592,7 @@ fu_quirks_lookup_by_id_iter(FuQuirks *self,
 
 	/* no quirk data */
 	if (self->query_vs == NULL) {
-		g_debug("no quirk data");
+		g_warning("no quirk data");
 		return FALSE;
 	}
 
@@ -999,6 +1002,7 @@ fu_quirks_load(FuQuirks *self, FuQuirksLoadFlags load_flags, GError **error)
 	g_return_val_if_fail(FU_IS_QUIRKS(self), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+	self->loaded = TRUE;
 	self->load_flags = load_flags;
 	self->verbose = g_getenv("FWUPD_XMLB_VERBOSE") != NULL;
 

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -1013,7 +1013,7 @@ static void
 fu_context_hwids_dmi_func(void)
 {
 	g_autofree gchar *dump = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
@@ -1032,7 +1032,7 @@ static void
 fu_context_hwids_unset_func(void)
 {
 	g_autofree gchar *testdatadir = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
@@ -1056,7 +1056,7 @@ fu_context_hwids_fdt_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *dump = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(FuFirmware) fdt_tmp = NULL;
 	g_autoptr(GError) error = NULL;
@@ -1249,7 +1249,7 @@ fu_strsafe_func(void)
 		    {NULL, NULL}};
 	GPtrArray *instance_ids;
 	gboolean ret;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuDevice) dev = fu_device_new(ctx);
 	g_autoptr(GError) error = NULL;
 
@@ -1272,9 +1272,8 @@ fu_strsafe_func(void)
 static void
 fu_hwids_func(void)
 {
-	g_autofree gchar *testdatadir = NULL;
 	g_autofree gchar *full_path = NULL;
-	g_autoptr(FuContext) context = NULL;
+	g_autoptr(FuContext) context = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
@@ -1305,10 +1304,6 @@ fu_hwids_func(void)
 	return;
 #endif
 
-	/* these tests will not write */
-	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
-	(void)g_setenv("FWUPD_SYSFSFWDIR", testdatadir, TRUE);
-
 	/* DMI */
 	full_path = g_test_build_filename(G_TEST_DIST, "tests", "dmi", "tables", NULL);
 	if (!g_file_test(full_path, G_FILE_TEST_IS_DIR)) {
@@ -1316,7 +1311,6 @@ fu_hwids_func(void)
 		return;
 	}
 
-	context = fu_context_new();
 	ret = fu_context_load_hwinfo(context, progress, FU_CONTEXT_HWID_FLAG_LOAD_SMBIOS, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
@@ -6580,7 +6574,7 @@ static void
 fu_plugin_efi_x509_signature_func(void)
 {
 	gboolean ret;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuEfiX509Signature) sig = fu_efi_x509_signature_new();
 	g_autoptr(FuEfiX509Device) device = fu_efi_x509_device_new(ctx, sig);
 	g_autoptr(GError) error = NULL;
@@ -6839,7 +6833,7 @@ fu_intel_me16_device_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuIntelMeDevice) device = fu_intel_me_device_new(ctx);
 	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
 	g_autoptr(FuStructIntelMeHfsts) st_hfsts1 = fu_struct_intel_me_hfsts_new();
@@ -6932,7 +6926,7 @@ fu_intel_me18_device_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuIntelMeDevice) device = fu_intel_me_device_new(ctx);
 	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
 	g_autoptr(FuStructIntelMeHfsts) st_hfsts1 = fu_struct_intel_me_hfsts_new();
@@ -7020,7 +7014,7 @@ fu_intel_me16_device_hap_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuIntelMeDevice) device = fu_intel_me_device_new(ctx);
 	g_autoptr(FuSecurityAttrs) attrs = fu_security_attrs_new();
 	g_autoptr(FuStructIntelMeHfsts) st_hfsts1 = fu_struct_intel_me_hfsts_new();

--- a/plugins/intel-me-pci/fu-self-test.c
+++ b/plugins/intel-me-pci/fu-self-test.c
@@ -21,7 +21,7 @@ fu_intel_me_pci_plugin_func(void)
 	gboolean ret;
 	g_autofree gchar *json = NULL;
 	g_autofree gchar *path = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuBackend) backend =
 	    g_object_new(FU_TYPE_BACKEND, "context", ctx, "device-gtype", FU_TYPE_PCI_DEVICE, NULL);
 	g_autoptr(FuPlugin) plugin =

--- a/plugins/intel-me-smbios/fu-self-test.c
+++ b/plugins/intel-me-smbios/fu-self-test.c
@@ -21,7 +21,7 @@ fu_intel_me_smbios_plugin_subtype18_func(void)
 	GPtrArray *devices;
 	g_autofree gchar *str = NULL;
 	g_autofree gchar *fn = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuPlugin) plugin =
 	    g_object_new(FU_TYPE_INTEL_ME_SMBIOS_PLUGIN, "context", ctx, NULL);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
@@ -63,7 +63,7 @@ fu_intel_me_smbios_plugin_subtype30_func(void)
 	GPtrArray *devices;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuPlugin) plugin =
 	    g_object_new(FU_TYPE_INTEL_ME_SMBIOS_PLUGIN, "context", ctx, NULL);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);

--- a/plugins/lenovo-thinklmi/fu-self-test.c
+++ b/plugins/lenovo-thinklmi/fu-self-test.c
@@ -42,7 +42,7 @@ static void
 fu_test_self_init(FuTest *self)
 {
 	gboolean ret;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 

--- a/plugins/modem-manager/fu-self-test.c
+++ b/plugins/modem-manager/fu-self-test.c
@@ -14,7 +14,7 @@ fu_mm_device_func(void)
 {
 	gboolean ret;
 	g_autofree gchar *str = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuMmDevice) mm_device = g_object_new(FU_TYPE_MM_DEVICE, "context", ctx, NULL);
 	g_autoptr(GError) error = NULL;
 

--- a/plugins/uefi-dbx/fu-self-test.c
+++ b/plugins/uefi-dbx/fu-self-test.c
@@ -17,7 +17,7 @@ static void
 fu_uefi_dbx_zero_func(void)
 {
 	gboolean ret;
-	g_autoptr(FuContext) ctx = fu_context_new();
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
 	g_autoptr(FuDevice) device = g_object_new(FU_TYPE_UEFI_DBX_DEVICE, "context", ctx, NULL);
 	g_autoptr(FuEfiSignature) sig = fu_efi_signature_new(FU_EFI_SIGNATURE_KIND_SHA256);
 	g_autoptr(FuFirmware) siglist = fu_efi_signature_list_new();


### PR DESCRIPTION
Also, allow self test code run without actually using the quirks at all.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
