### PR TITLE
Use crc32() from zlib.h when computing the most common kind of CRC32

### DIFF
--- a/libfwupdplugin/fu-input-stream.c
+++ b/libfwupdplugin/fu-input-stream.c
@@ -615,6 +615,9 @@ fu_input_stream_compute_crc32(GInputStream *stream, FuCrcKind kind, guint32 *crc
 	g_return_val_if_fail(G_IS_INPUT_STREAM(stream), FALSE);
 	g_return_val_if_fail(crc != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (kind == FU_CRC_KIND_B32_STANDARD)
+		helper.crc = 0;
 	if (!fu_input_stream_chunkify(stream, fu_input_stream_compute_crc32_cb, &helper, error))
 		return FALSE;
 	*crc = fu_crc32_done(kind, helper.crc);


### PR DESCRIPTION
The implementation in zlib uses a combination of architecture-specific assembly code and precomputed tables -- and person-years of profiling optimisations.

This speeds up using `FU_CRC_KIND_B32_STANDARD` in fwupd by an amazing 98%.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
