### PR TITLE
trivial: Convert 'only-basename' to a parse flag

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -208,6 +208,7 @@ Use `./contrib/migrate.py` to migrate up out-of-tree plugins to the new API.
 
 ## 2.1.1
 
+* `fu_cab_firmware_set_only_basename()`: Use `FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME` instead.
 * `fu_context_add_firmware_gtype()`: Drop the `id` parameter.
 * `fu_firmware_build_from_xml()`: Use `fu_firmware_new_from_xml()` instead.
 * `fu_firmware_build_from_filename()`: Use `fu_firmware_new_from_filename()` instead.

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -24,7 +24,6 @@
 
 typedef struct {
 	gboolean compressed;
-	gboolean only_basename;
 } FuCabFirmwarePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(FuCabFirmware, fu_cab_firmware, FU_TYPE_FIRMWARE)
@@ -68,41 +67,6 @@ fu_cab_firmware_set_compressed(FuCabFirmware *self, gboolean compressed)
 	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
 	g_return_if_fail(FU_IS_CAB_FIRMWARE(self));
 	priv->compressed = compressed;
-}
-
-/**
- * fu_cab_firmware_get_only_basename:
- * @self: a #FuCabFirmware
- *
- * Gets if the cabinet archive filenames should have the path component removed.
- *
- * Returns: boolean
- *
- * Since: 1.9.7
- **/
-gboolean
-fu_cab_firmware_get_only_basename(FuCabFirmware *self)
-{
-	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_return_val_if_fail(FU_IS_CAB_FIRMWARE(self), FALSE);
-	return priv->only_basename;
-}
-
-/**
- * fu_cab_firmware_set_only_basename:
- * @self: a #FuCabFirmware
- * @only_basename: boolean
- *
- * Sets if the cabinet archive filenames should have the path component removed.
- *
- * Since: 1.9.7
- **/
-void
-fu_cab_firmware_set_only_basename(FuCabFirmware *self, gboolean only_basename)
-{
-	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FU_IS_CAB_FIRMWARE(self));
-	priv->only_basename = only_basename;
 }
 
 typedef struct {
@@ -424,9 +388,9 @@ static gboolean
 fu_cab_firmware_parse_file(FuCabFirmware *self,
 			   FuCabFirmwareParseHelper *helper,
 			   gsize *offset,
+			   FuFirmwareParseFlags flags,
 			   GError **error)
 {
-	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
 	GInputStream *folder_data;
 	guint16 date;
 	guint16 index;
@@ -480,7 +444,7 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 	}
 
 	/* add image */
-	if (priv->only_basename) {
+	if (flags & FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME) {
 		g_autofree gchar *id = g_path_get_basename(filename->str);
 		fu_firmware_set_id(FU_FIRMWARE(img), id);
 	} else {
@@ -664,7 +628,7 @@ fu_cab_firmware_parse(FuFirmware *firmware,
 
 	/* parse CFFILEs */
 	for (guint i = 0; i < fu_struct_cab_header_get_nr_files(st); i++) {
-		if (!fu_cab_firmware_parse_file(self, helper, &off_cffile, error))
+		if (!fu_cab_firmware_parse_file(self, helper, &off_cffile, flags, error))
 			return FALSE;
 	}
 
@@ -888,11 +852,6 @@ fu_cab_firmware_build(FuFirmware *firmware, XbNode *n, GError **error)
 		if (!fu_strtobool(tmp, &priv->compressed, error))
 			return FALSE;
 	}
-	tmp = xb_node_query_text(n, "only_basename", NULL);
-	if (tmp != NULL) {
-		if (!fu_strtobool(tmp, &priv->only_basename, error))
-			return FALSE;
-	}
 
 	/* success */
 	return TRUE;
@@ -904,7 +863,6 @@ fu_cab_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuil
 	FuCabFirmware *self = FU_CAB_FIRMWARE(firmware);
 	FuCabFirmwarePrivate *priv = GET_PRIVATE(self);
 	fu_xmlb_builder_insert_kb(bn, "compressed", priv->compressed);
-	fu_xmlb_builder_insert_kb(bn, "only_basename", priv->only_basename);
 }
 
 static void

--- a/libfwupdplugin/fu-cab-firmware.h
+++ b/libfwupdplugin/fu-cab-firmware.h
@@ -20,10 +20,6 @@ gboolean
 fu_cab_firmware_get_compressed(FuCabFirmware *self) G_GNUC_NON_NULL(1);
 void
 fu_cab_firmware_set_compressed(FuCabFirmware *self, gboolean compressed) G_GNUC_NON_NULL(1);
-gboolean
-fu_cab_firmware_get_only_basename(FuCabFirmware *self) G_GNUC_NON_NULL(1);
-void
-fu_cab_firmware_set_only_basename(FuCabFirmware *self, gboolean only_basename) G_GNUC_NON_NULL(1);
 
 FuCabFirmware *
 fu_cab_firmware_new(void) G_GNUC_WARN_UNUSED_RESULT;

--- a/libfwupdplugin/fu-firmware.rs
+++ b/libfwupdplugin/fu-firmware.rs
@@ -17,6 +17,7 @@ enum FuFirmwareParseFlags {
     CacheBlob = 1 << 11,
     OnlyTrustPqSignatures = 1 << 12,
     OnlyPartitionLayout = 1 << 13,
+    OnlyBasename = 1 << 14,
 }
 
 enum FuFirmwareBuilderFlags {

--- a/src/fu-cabinet.c
+++ b/src/fu-cabinet.c
@@ -976,7 +976,10 @@ fu_cabinet_parse(FuFirmware *firmware,
 			return FALSE;
 		}
 		if (!FU_FIRMWARE_CLASS(fu_cabinet_parent_class)
-			 ->parse(firmware, stream, flags, error))
+			 ->parse(firmware,
+				 stream,
+				 flags | FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME,
+				 error))
 			return FALSE;
 		self->container_checksum =
 		    fu_input_stream_compute_checksum(stream, G_CHECKSUM_SHA1, error);
@@ -1082,7 +1085,6 @@ fu_cabinet_get_component(FuCabinet *self, const gchar *id, GError **error)
 static void
 fu_cabinet_init(FuCabinet *self)
 {
-	fu_cab_firmware_set_only_basename(FU_CAB_FIRMWARE(self), TRUE);
 	fu_firmware_set_size_max(FU_FIRMWARE(self), G_MAXUINT32); /* ~4GB */
 	self->builder = xb_builder_new();
 	self->jcat_file = jcat_file_new();


### PR DESCRIPTION
We only need this during parsing, and never during construction -- and can't be changed once parsed -- and so it makes no sense at all as a property.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
