### PR TITLE
trivial: Use FuFirmwareParseFlags rather than FuArchiveFlags

### DIFF
--- a/libfwupdplugin/fu-archive-firmware.c
+++ b/libfwupdplugin/fu-archive-firmware.c
@@ -62,7 +62,7 @@ fu_archive_firmware_parse(FuFirmware *firmware,
 	g_autoptr(FuArchive) archive = NULL;
 
 	/* load archive */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, flags, error);
 	if (archive == NULL)
 		return FALSE;
 
@@ -214,7 +214,7 @@ fu_archive_firmware_write(FuFirmware *firmware, GError **error)
 	}
 
 	/* save archive and compress each image to the archive */
-	archive = fu_archive_new(NULL, FU_ARCHIVE_FLAG_NONE, NULL);
+	archive = fu_archive_new(NULL, FU_FIRMWARE_PARSE_FLAG_NONE, NULL);
 	for (guint i = 0; i < images->len; i++) {
 		FuFirmware *img = g_ptr_array_index(images, i);
 		g_autoptr(GBytes) blob = NULL;

--- a/libfwupdplugin/fu-archive.c
+++ b/libfwupdplugin/fu-archive.c
@@ -258,7 +258,10 @@ fu_archive_read_new(GError **error)
 }
 
 static gboolean
-fu_archive_read(FuArchive *self, _archive_read_ctx *arch, FuArchiveFlags flags, GError **error)
+fu_archive_read(FuArchive *self,
+		_archive_read_ctx *arch,
+		FuFirmwareParseFlags flags,
+		GError **error)
 {
 	int r;
 	while (TRUE) {
@@ -321,7 +324,7 @@ fu_archive_read(FuArchive *self, _archive_read_ctx *arch, FuArchiveFlags flags, 
 				    bufsz);
 			return FALSE;
 		}
-		if (flags & FU_ARCHIVE_FLAG_IGNORE_PATH) {
+		if (flags & FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME) {
 			fn_key = g_path_get_basename(fn);
 		} else {
 			fn_key = g_strdup(fn);
@@ -339,7 +342,7 @@ fu_archive_read(FuArchive *self, _archive_read_ctx *arch, FuArchiveFlags flags, 
 /**
  * fu_archive_new:
  * @data: (nullable): archive contents
- * @flags: archive flags, e.g. %FU_ARCHIVE_FLAG_NONE
+ * @flags: archive flags, e.g. %FU_FIRMWARE_PARSE_FLAG_NONE
  * @error: (nullable): optional return location for an error
  *
  * Parses @data as an archive and decompresses all files to memory blobs.
@@ -351,7 +354,7 @@ fu_archive_read(FuArchive *self, _archive_read_ctx *arch, FuArchiveFlags flags, 
  * Since: 1.2.2
  **/
 FuArchive *
-fu_archive_new(GBytes *data, FuArchiveFlags flags, GError **error)
+fu_archive_new(GBytes *data, FuFirmwareParseFlags flags, GError **error)
 {
 #ifdef HAVE_LIBARCHIVE
 	g_autoptr(FuArchive) self = g_object_new(FU_TYPE_ARCHIVE, NULL);
@@ -470,7 +473,7 @@ fu_archive_seek_cb(struct archive *arch, void *client_data, gint64 offset, gint 
 /**
  * fu_archive_new_stream:
  * @stream: a #GInputStream
- * @flags: archive flags, e.g. %FU_ARCHIVE_FLAG_NONE
+ * @flags: archive flags, e.g. %FU_FIRMWARE_PARSE_FLAG_NONE
  * @error: (nullable): optional return location for an error
  *
  * Parses @stream as an archive and decompresses all files to memory blobs.
@@ -480,7 +483,7 @@ fu_archive_seek_cb(struct archive *arch, void *client_data, gint64 offset, gint 
  * Since: 2.0.0
  **/
 FuArchive *
-fu_archive_new_stream(GInputStream *stream, FuArchiveFlags flags, GError **error)
+fu_archive_new_stream(GInputStream *stream, FuFirmwareParseFlags flags, GError **error)
 {
 #ifdef HAVE_LIBARCHIVE
 	g_autoptr(FuArchive) self = g_object_new(FU_TYPE_ARCHIVE, NULL);

--- a/libfwupdplugin/fu-archive.h
+++ b/libfwupdplugin/fu-archive.h
@@ -10,6 +10,7 @@
 #include <gio/gio.h>
 
 #include "fu-archive-struct.h"
+#include "fu-firmware-struct.h"
 
 #define FU_TYPE_ARCHIVE (fu_archive_get_type())
 
@@ -33,10 +34,10 @@ typedef gboolean (*FuArchiveIterateFunc)(FuArchive *self,
     G_GNUC_NON_NULL(1);
 
 FuArchive *
-fu_archive_new(GBytes *data, FuArchiveFlags flags, GError **error) G_GNUC_WARN_UNUSED_RESULT;
+fu_archive_new(GBytes *data, FuFirmwareParseFlags flags, GError **error) G_GNUC_WARN_UNUSED_RESULT;
 FuArchive *
 fu_archive_new_stream(GInputStream *stream,
-		      FuArchiveFlags flags,
+		      FuFirmwareParseFlags flags,
 		      GError **error) G_GNUC_WARN_UNUSED_RESULT;
 void
 fu_archive_add_entry(FuArchive *self, const gchar *fn, GBytes *blob) G_GNUC_NON_NULL(1, 2);

--- a/libfwupdplugin/fu-archive.rs
+++ b/libfwupdplugin/fu-archive.rs
@@ -38,9 +38,3 @@ enum FuArchiveCompression {
     Lz4,      // Since: 1.8.1
     Zstd,     // Since: 1.8.1
 }
-
-// Flags to use when loading the archive
-enum FuArchiveFlags {
-    None = 0,
-    IgnorePath = 1 << 0,
-}

--- a/libfwupdplugin/fu-self-test.c
+++ b/libfwupdplugin/fu-self-test.c
@@ -298,7 +298,7 @@ fu_archive_invalid_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(data);
 
-	archive = fu_archive_new(data, FU_ARCHIVE_FLAG_NONE, &error);
+	archive = fu_archive_new(data, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
 	g_assert_null(archive);
 }
@@ -330,7 +330,7 @@ fu_archive_cab_func(void)
 	g_assert_no_error(error);
 	g_assert_nonnull(data);
 
-	archive = fu_archive_new(data, FU_ARCHIVE_FLAG_NONE, &error);
+	archive = fu_archive_new(data, FU_FIRMWARE_PARSE_FLAG_NONE, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(archive);
 

--- a/plugins/aver-hid/fu-aver-hid-device.c
+++ b/plugins/aver-hid/fu-aver-hid-device.c
@@ -430,7 +430,7 @@ fu_aver_hid_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* decompress */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_NONE, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_NONE, error);
 	if (archive == NULL)
 		return FALSE;
 	aver_fw_name = fu_firmware_get_filename(firmware);

--- a/plugins/aver-hid/fu-aver-hid-firmware.c
+++ b/plugins/aver-hid/fu-aver-hid-firmware.c
@@ -37,7 +37,7 @@ fu_aver_hid_firmware_parse(FuFirmware *firmware,
 			   GError **error)
 {
 	g_autoptr(FuArchive) archive = NULL;
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_NONE, error);
+	archive = fu_archive_new_stream(stream, flags, error);
 	if (archive == NULL)
 		return FALSE;
 	if (!fu_archive_iterate(archive, fu_aver_hid_firmware_parse_archive_cb, firmware, error))

--- a/plugins/aver-hid/fu-aver-safeisp-device.c
+++ b/plugins/aver-hid/fu-aver-safeisp-device.c
@@ -290,7 +290,7 @@ fu_aver_safeisp_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* decompress */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_NONE, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_NONE, error);
 	if (archive == NULL)
 		return FALSE;
 	cx3_fw = fu_archive_lookup_by_fn(archive, "update/cx3uvc.img", error);

--- a/plugins/modem-manager/fu-mm-qdu-mbim-device.c
+++ b/plugins/modem-manager/fu-mm-qdu-mbim-device.c
@@ -211,7 +211,7 @@ fu_mm_qdu_mbim_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 

--- a/plugins/modem-manager/fu-mm-qmi-device.c
+++ b/plugins/modem-manager/fu-mm-qmi-device.c
@@ -850,7 +850,7 @@ fu_mm_qmi_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 

--- a/plugins/nordic-hid/fu-nordic-hid-archive.c
+++ b/plugins/nordic-hid/fu-nordic-hid-archive.c
@@ -200,7 +200,7 @@ fu_nordic_hid_archive_parse(FuFirmware *firmware,
 	fwupd_json_parser_set_max_quoted(json_parser, 10000);
 
 	/* load archive */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 	manifest = fu_archive_lookup_by_fn(archive, "manifest.json", error);

--- a/plugins/telink-dfu/fu-telink-dfu-archive.c
+++ b/plugins/telink-dfu/fu-telink-dfu-archive.c
@@ -127,7 +127,7 @@ fu_telink_dfu_archive_parse(FuFirmware *firmware,
 	fwupd_json_parser_set_max_quoted(json_parser, 10000);
 
 	/* load archive */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 

--- a/plugins/telink-dfu/fu-telink-dfu-ble-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-ble-device.c
@@ -197,7 +197,7 @@ fu_telink_dfu_ble_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 	blob = fu_archive_lookup_by_fn(archive, "firmware.bin", error);

--- a/plugins/telink-dfu/fu-telink-dfu-hid-device.c
+++ b/plugins/telink-dfu/fu-telink-dfu-hid-device.c
@@ -337,7 +337,7 @@ fu_telink_dfu_hid_device_write_firmware(FuDevice *device,
 	stream = fu_firmware_get_stream(firmware, error);
 	if (stream == NULL)
 		return FALSE;
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_IGNORE_PATH, error);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_ONLY_BASENAME, error);
 	if (archive == NULL)
 		return FALSE;
 	blob = fu_archive_lookup_by_fn(archive, "firmware.bin", error);

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -326,7 +326,7 @@ fu_uefi_capsule_plugin_get_splash_data(guint width, guint height, GError **error
 	stream_archive = fu_input_stream_from_path(filename_archive, error);
 	if (stream_archive == NULL)
 		return NULL;
-	archive = fu_archive_new_stream(stream_archive, FU_ARCHIVE_FLAG_NONE, error);
+	archive = fu_archive_new_stream(stream_archive, FU_FIRMWARE_PARSE_FLAG_NONE, error);
 	if (archive == NULL)
 		return NULL;
 

--- a/src/fu-engine-emulator.c
+++ b/src/fu-engine-emulator.c
@@ -49,7 +49,7 @@ fu_engine_emulator_save(FuEngineEmulator *self, GOutputStream *stream, GError **
 	gpointer value;
 	g_autoptr(GByteArray) buf = NULL;
 	g_autoptr(GBytes) blob = NULL;
-	g_autoptr(FuArchive) archive = fu_archive_new(NULL, FU_ARCHIVE_FLAG_NONE, NULL);
+	g_autoptr(FuArchive) archive = fu_archive_new(NULL, FU_FIRMWARE_PARSE_FLAG_NONE, NULL);
 
 	g_return_val_if_fail(FU_IS_ENGINE_EMULATOR(self), FALSE);
 	g_return_val_if_fail(G_IS_OUTPUT_STREAM(stream), FALSE);
@@ -278,7 +278,7 @@ fu_engine_emulator_load(FuEngineEmulator *self, GInputStream *stream, GError **e
 	g_hash_table_remove_all(self->phase_blobs);
 
 	/* load archive */
-	archive = fu_archive_new_stream(stream, FU_ARCHIVE_FLAG_NONE, &error_archive);
+	archive = fu_archive_new_stream(stream, FU_FIRMWARE_PARSE_FLAG_NONE, &error_archive);
 	if (archive == NULL) {
 		g_autoptr(GBytes) blob = NULL;
 		g_debug("no archive found, using JSON as phase setup: %s", error_archive->message);


### PR DESCRIPTION
FuArchiveFirmware was unconditionally only including the basename, which isn't always what we want...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
