### PR TITLE
fu-engine: fix debug message when there is no checksums in metadata

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -5620,7 +5620,7 @@ fu_engine_add_releases_for_device_component(FuEngine *self,
 		checksums = fu_release_get_checksums(release);
 		if (checksums->len == 0) {
 			g_autofree gchar *str = fwupd_codec_to_string(FWUPD_CODEC(release));
-			g_debug("no locations for %s", str);
+			g_debug("no checksums for %s", str);
 			continue;
 		}
 


### PR DESCRIPTION
This used to be a little bit confusing,
the message was indicating "no locations for"
while this was a checksum error.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
