### PR TITLE
Only load the history database in the daemon when required

### DIFF
--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -2943,7 +2943,7 @@ fu_dbus_daemon_setup(FuDaemon *daemon,
 				FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS |
 				FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS |
 				FU_ENGINE_LOAD_FLAG_ENSURE_CLIENT_CERT |
-				FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG,
+				FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG | FU_ENGINE_LOAD_FLAG_HISTORY,
 			    fu_progress_get_child(progress),
 			    error)) {
 		g_prefix_error_literal(error, "failed to load engine: ");

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2726,6 +2726,10 @@ fu_engine_install_release(FuEngine *self,
 	if (request != NULL)
 		feature_flags = fu_engine_request_get_feature_flags(request);
 
+	/* engine was loaded with no history support */
+	if ((self->load_flags & FU_ENGINE_LOAD_FLAG_HISTORY) == 0)
+		flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
+
 	/* add the checksum of the container blob if not already set */
 	if (fwupd_release_get_checksums(FWUPD_RELEASE(release))->len == 0) {
 		GChecksumType checksum_types[] = {
@@ -2772,12 +2776,14 @@ fu_engine_install_release(FuEngine *self,
 	if (plugin == NULL)
 		return FALSE;
 
+	/* add metadata */
+	if (!fu_engine_add_release_metadata(self, release, error))
+		return FALSE;
+	if (!fu_engine_add_release_plugin_metadata(self, release, plugin, error))
+		return FALSE;
+
 	/* add device to database */
 	if ((flags & FWUPD_INSTALL_FLAG_NO_HISTORY) == 0) {
-		if (!fu_engine_add_release_metadata(self, release, error))
-			return FALSE;
-		if (!fu_engine_add_release_plugin_metadata(self, release, plugin, error))
-			return FALSE;
 		if (!fu_history_add_device(self->history, device, release, error))
 			return FALSE;
 	}
@@ -6710,6 +6716,8 @@ fu_engine_device_inherit_history(FuEngine *self, FuDevice *device)
 	/* ignore */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED))
 		return;
+	if ((self->load_flags & FU_ENGINE_LOAD_FLAG_HISTORY) == 0)
+		return;
 
 	/* any success or failed update? */
 	device_history = fu_history_get_device_by_id(self->history, fu_device_get_id(device), NULL);
@@ -8662,11 +8670,11 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 {
 	FuPlugin *plugin_uefi;
 	FuQuirksLoadFlags quirks_flags = FU_QUIRKS_LOAD_FLAG_NONE;
+	GPtrArray *config_approved;
+	GPtrArray *config_blocked;
 	GPtrArray *backends = fu_context_get_backends(self->ctx);
 	GPtrArray *plugins = fu_plugin_list_get_all(self->plugin_list);
 	const gchar *host_emulate = g_getenv("FWUPD_HOST_EMULATE");
-	g_autoptr(GPtrArray) checksums_approved = NULL;
-	g_autoptr(GPtrArray) checksums_blocked = NULL;
 	g_autoptr(GError) error_quirks = NULL;
 	g_autoptr(GError) error_json_devices = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -8765,31 +8773,36 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	fu_progress_step_done(progress);
 
 	/* get hardcoded approved and blocked firmware */
-	checksums_approved = fu_engine_config_get_approved_firmware(self->config);
-	for (guint i = 0; i < checksums_approved->len; i++) {
-		const gchar *csum = g_ptr_array_index(checksums_approved, i);
+	config_approved = fu_engine_config_get_approved_firmware(self->config);
+	for (guint i = 0; i < config_approved->len; i++) {
+		const gchar *csum = g_ptr_array_index(config_approved, i);
 		fu_engine_add_approved_firmware(self, csum);
 	}
-	checksums_blocked = fu_engine_config_get_blocked_firmware(self->config);
-	for (guint i = 0; i < checksums_blocked->len; i++) {
-		const gchar *csum = g_ptr_array_index(checksums_blocked, i);
+	config_blocked = fu_engine_config_get_blocked_firmware(self->config);
+	for (guint i = 0; i < config_blocked->len; i++) {
+		const gchar *csum = g_ptr_array_index(config_blocked, i);
 		fu_engine_add_blocked_firmware(self, csum);
 	}
 
 	/* get extra firmware saved to the database */
-	checksums_approved = fu_history_get_approved_firmware(self->history, error);
-	if (checksums_approved == NULL)
-		return FALSE;
-	for (guint i = 0; i < checksums_approved->len; i++) {
-		const gchar *csum = g_ptr_array_index(checksums_approved, i);
-		fu_engine_add_approved_firmware(self, csum);
-	}
-	checksums_blocked = fu_history_get_blocked_firmware(self->history, error);
-	if (checksums_blocked == NULL)
-		return FALSE;
-	for (guint i = 0; i < checksums_blocked->len; i++) {
-		const gchar *csum = g_ptr_array_index(checksums_blocked, i);
-		fu_engine_add_blocked_firmware(self, csum);
+	if (flags & FU_ENGINE_LOAD_FLAG_HISTORY) {
+		g_autoptr(GPtrArray) history_approved = NULL;
+		g_autoptr(GPtrArray) history_blocked = NULL;
+
+		history_approved = fu_history_get_approved_firmware(self->history, error);
+		if (history_approved == NULL)
+			return FALSE;
+		for (guint i = 0; i < history_approved->len; i++) {
+			const gchar *csum = g_ptr_array_index(history_approved, i);
+			fu_engine_add_approved_firmware(self, csum);
+		}
+		history_blocked = fu_history_get_blocked_firmware(self->history, error);
+		if (history_blocked == NULL)
+			return FALSE;
+		for (guint i = 0; i < history_blocked->len; i++) {
+			const gchar *csum = g_ptr_array_index(history_blocked, i);
+			fu_engine_add_blocked_firmware(self, csum);
+		}
 	}
 	fu_progress_step_done(progress);
 
@@ -8992,8 +9005,10 @@ fu_engine_load(FuEngine *self, FuEngineLoadFlags flags, FuProgress *progress, GE
 	}
 
 	/* update the db for devices that were updated during the reboot */
-	if (!fu_engine_update_history_database(self, error))
-		return FALSE;
+	if (flags & FU_ENGINE_LOAD_FLAG_HISTORY) {
+		if (!fu_engine_update_history_database(self, error))
+			return FALSE;
+	}
 	fu_progress_step_done(progress);
 
 	/* update the devices JSON file */

--- a/src/fu-engine.rs
+++ b/src/fu-engine.rs
@@ -48,6 +48,7 @@ enum FuEngineLoadFlags {
     DeviceHotplug = 1 << 9,
     ColdplugForce = 1 << 10,    // even without a matched plugin
     Ready = 1 << 11,
+    History = 1 << 12,
 }
 
 #[derive(ToString)]

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -3484,7 +3484,10 @@ fu_engine_history_func(gconstpointer user_data)
 	g_assert_true(ret);
 	fu_engine_add_plugin(engine, plugin);
 
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_NO_CACHE | FU_ENGINE_LOAD_FLAG_HISTORY,
+			     progress,
+			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3610,7 +3613,10 @@ fu_engine_history_verfmt_func(gconstpointer user_data)
 
 	/* set up dummy plugin */
 	fu_engine_add_plugin(engine, plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_NO_CACHE | FU_ENGINE_LOAD_FLAG_HISTORY,
+			     progress,
+			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3863,7 +3869,10 @@ fu_engine_history_inherit(gconstpointer user_data)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	fu_engine_add_plugin(engine, plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_NO_CACHE | FU_ENGINE_LOAD_FLAG_HISTORY,
+			     progress,
+			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 
@@ -3935,6 +3944,12 @@ fu_engine_history_inherit(gconstpointer user_data)
 	engine = fu_engine_new(self->ctx);
 	fu_engine_set_silo(engine, silo_empty);
 	fu_engine_add_plugin(engine, plugin);
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_NO_CACHE | FU_ENGINE_LOAD_FLAG_HISTORY,
+			     progress,
+			     &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 	device = fu_device_new(self->ctx);
 	fu_device_add_private_flag(device, FU_DEVICE_PRIVATE_FLAG_INHERIT_ACTIVATION);
 	fu_device_set_id(device, "test_device");
@@ -4207,7 +4222,10 @@ fu_engine_history_error_func(gconstpointer user_data)
 	g_assert_no_error(error);
 	g_assert_true(ret);
 	fu_engine_add_plugin(engine, plugin);
-	ret = fu_engine_load(engine, FU_ENGINE_LOAD_FLAG_NO_CACHE, progress, &error);
+	ret = fu_engine_load(engine,
+			     FU_ENGINE_LOAD_FLAG_NO_CACHE | FU_ENGINE_LOAD_FLAG_HISTORY,
+			     progress,
+			     &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -694,7 +694,7 @@ fu_util_get_updates(FuUtil *self, gchar **values, GError **error)
 	/* load engine */
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
-				      FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;
@@ -813,7 +813,7 @@ fu_util_get_details(FuUtil *self, gchar **values, GError **error)
 	/* load engine */
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
-				      FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;
@@ -937,8 +937,8 @@ fu_util_get_devices_as_json(FuUtil *self, GPtrArray *devs, GError **error)
 static gboolean
 fu_util_get_devices(FuUtil *self, gchar **values, GError **error)
 {
-	FuEngineLoadFlags load_flags =
-	    FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO;
+	FuEngineLoadFlags load_flags = FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
+				       FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY;
 	g_autoptr(FuUtilNode) root = g_node_new(NULL);
 	g_autoptr(GPtrArray) devs = NULL;
 
@@ -1089,7 +1089,8 @@ fu_util_install_blob(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
 				      FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG |
-				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO |
+				      FU_ENGINE_LOAD_FLAG_HISTORY,
 				  fu_progress_get_child(self->progress),
 				  error))
 		return FALSE;
@@ -1508,7 +1509,8 @@ fu_util_install(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
 				      FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG |
-				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO |
+				      FU_ENGINE_LOAD_FLAG_HISTORY,
 				  fu_progress_get_child(self->progress),
 				  error))
 		return FALSE;
@@ -1679,7 +1681,8 @@ fu_util_update(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
 				      FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG |
-				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO |
+				      FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;
@@ -1847,7 +1850,8 @@ fu_util_reinstall(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
 				      FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG |
-				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO |
+				      FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;
@@ -2839,7 +2843,7 @@ fu_util_activate(FuUtil *self, gchar **values, GError **error)
 		FU_ENGINE_LOAD_FLAG_READONLY | FU_ENGINE_LOAD_FLAG_COLDPLUG |
 		    FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
 		    FU_ENGINE_LOAD_FLAG_EXTERNAL_PLUGINS | FU_ENGINE_LOAD_FLAG_BUILTIN_PLUGINS |
-		    FU_ENGINE_LOAD_FLAG_HWINFO,
+		    FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY,
 		fu_progress_get_child(self->progress),
 		error))
 		return FALSE;
@@ -3913,7 +3917,7 @@ fu_util_get_history(FuUtil *self, gchar **values, GError **error)
 	/* load engine */
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG | FU_ENGINE_LOAD_FLAG_REMOTES |
-				      FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_HWINFO | FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;
@@ -4664,7 +4668,8 @@ fu_util_get_results(FuUtil *self, gchar **values, GError **error)
 	if (!fu_util_start_engine(self,
 				  FU_ENGINE_LOAD_FLAG_COLDPLUG |
 				      FU_ENGINE_LOAD_FLAG_DEVICE_HOTPLUG |
-				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO,
+				      FU_ENGINE_LOAD_FLAG_REMOTES | FU_ENGINE_LOAD_FLAG_HWINFO |
+				      FU_ENGINE_LOAD_FLAG_HISTORY,
 				  self->progress,
 				  error))
 		return FALSE;


### PR DESCRIPTION
This makes the self tests smaller and quicker.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
