### PR TITLE
ccgx-dmc: Fix a regression when installing on the HP G5 dock

### DIFF
--- a/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-firmware.c
@@ -430,6 +430,15 @@ fu_ccgx_dmc_firmware_convert_version(FuFirmware *firmware, guint64 version_raw)
 }
 
 static void
+fu_ccgx_dmc_firmware_add_magic(FuFirmware *firmware)
+{
+	fu_firmware_add_magic(firmware,
+			      (const guint8 *)FU_STRUCT_CCGX_DMC_FWCT_INFO_DEFAULT_SIGNATURE,
+			      strlen(FU_STRUCT_CCGX_DMC_FWCT_INFO_DEFAULT_SIGNATURE),
+			      0x0);
+}
+
+static void
 fu_ccgx_dmc_firmware_init(FuCcgxDmcFirmware *self)
 {
 	self->image_records =
@@ -464,6 +473,7 @@ fu_ccgx_dmc_firmware_class_init(FuCcgxDmcFirmwareClass *klass)
 	firmware_class->parse = fu_ccgx_dmc_firmware_parse;
 	firmware_class->write = fu_ccgx_dmc_firmware_write;
 	firmware_class->export = fu_ccgx_dmc_firmware_export;
+	firmware_class->add_magic = fu_ccgx_dmc_firmware_add_magic;
 }
 
 FuFirmware *

--- a/plugins/ccgx-dmc/fu-ccgx-dmc.rs
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc.rs
@@ -214,7 +214,7 @@ struct FuStructCcgxDmcIntRqt {
 #[derive(New, ParseStream, ValidateStream, Default)]
 #[repr(C, packed)]
 struct FuStructCcgxDmcFwctInfo {
-    signature: u32le == 0x54435746, // 'F' 'W' 'C' 'T'
+    signature: [char; 4] == "FWCT",
     size: u16le,
     checksum: u8,
     version: u8,


### PR DESCRIPTION
The regression happened in 87678dd -- the HP firmware parser was relying on the signature finder to find the magic bytes -- and the new firmware just happened to be slightly too big to catch the new size of `MAGIC_BUFSZ_MAX`.

The fix of course is to explicitly add the magic, rather than parsing the same 8MB section one byte at a time...

Fixes https://github.com/fwupd/fwupd/issues/9858

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
