### PR TITLE
Fix a regression causing MBIM QDU updates to fail

### DIFF
--- a/libfwupdplugin/fu-udev-device.c
+++ b/libfwupdplugin/fu-udev-device.c
@@ -740,6 +740,9 @@ const gchar *
 fu_udev_device_get_sysfs_path(FuUdevDevice *self)
 {
 	g_return_val_if_fail(FU_IS_UDEV_DEVICE(self), NULL);
+
+	if (fu_device_has_private_flag(FU_DEVICE(self), FU_UDEV_DEVICE_FLAG_SYSFS_USE_PHYSICAL_ID))
+		return fu_device_get_physical_id(FU_DEVICE(self));
 	return fu_device_get_backend_id(FU_DEVICE(self));
 }
 
@@ -2562,6 +2565,7 @@ fu_udev_device_init(FuUdevDevice *self)
 	priv->properties = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	fu_device_set_acquiesce_delay(FU_DEVICE(self), 2500);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_CAN_EMULATION_TAG);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_UDEV_DEVICE_FLAG_SYSFS_USE_PHYSICAL_ID);
 	g_signal_connect(FU_DEVICE(self),
 			 "notify::vid",
 			 G_CALLBACK(fu_udev_device_vid_notify_cb),

--- a/libfwupdplugin/fu-udev-device.h
+++ b/libfwupdplugin/fu-udev-device.h
@@ -24,6 +24,13 @@ struct _FuUdevDeviceClass {
  */
 #define FU_UDEV_DEVICE_ATTR_READ_TIMEOUT_DEFAULT 50 /* ms */
 
+/**
+ * FU_UDEV_DEVICE_FLAG_SYSFS_USE_PHYSICAL_ID:
+ *
+ * Use the physical ID for the sysfs path rather than the backend ID.
+ */
+#define FU_UDEV_DEVICE_FLAG_SYSFS_USE_PHYSICAL_ID "sysfs-use-physical-id"
+
 const gchar *
 fu_udev_device_get_device_file(FuUdevDevice *self) G_GNUC_NON_NULL(1);
 void

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -967,6 +967,7 @@ fu_mm_device_init(FuMmDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_REPLUG_MATCH_GUID);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_VERFMT);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ADD_INSTANCE_ID_REV);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_UDEV_DEVICE_FLAG_SYSFS_USE_PHYSICAL_ID);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);
 	fu_device_set_summary(FU_DEVICE(self), "Mobile broadband device");


### PR DESCRIPTION
This is a confusion between the physical ID and the backend ID. In the case where the backend ID is not set we fall back to the physical ID when getting the backend ID.

This has the effect of making it look like they're the same thing in most FuDevice subclasses. In ModemManager we're setting both and so we need to be a bit more careful with that assumption.

This regressed in 101ac92.

Fixes https://github.com/fwupd/fwupd/issues/9747

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
