### PR TITLE
Only use crc32_z from zlib for standard initial values

### DIFF
--- a/libfwupdplugin/fu-crc-private.h
+++ b/libfwupdplugin/fu-crc-private.h
@@ -12,6 +12,8 @@ guint32
 fu_crc32_step(FuCrcKind kind, const guint8 *buf, gsize bufsz, guint32 crc);
 guint32
 fu_crc32_done(FuCrcKind kind, guint32 crc);
+guint32
+fu_crc32_fast(const guint8 *buf, gsize bufsz, guint32 crc);
 
 guint16
 fu_crc16_step(FuCrcKind kind, const guint8 *buf, gsize bufsz, guint16 crc);

--- a/libfwupdplugin/fu-input-stream-test.c
+++ b/libfwupdplugin/fu-input-stream-test.c
@@ -102,6 +102,13 @@ fu_input_stream_chunkify_func(void)
 	g_assert_true(ret);
 	g_assert_cmpint(crc16, ==, fu_crc16(FU_CRC_KIND_B16_XMODEM, buf->data, buf->len));
 
+	ret = fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_MPEG2, &crc32, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(crc32, ==, fu_crc32(FU_CRC_KIND_B32_MPEG2, buf->data, buf->len));
+
+	/* use zlib speedup */
+	crc32 = G_MAXUINT32;
 	ret = fu_input_stream_compute_crc32(stream, FU_CRC_KIND_B32_STANDARD, &crc32, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);


### PR DESCRIPTION
Ths fixes a regression in the nordic-hid plugin, which (unusually) uses 0x1 as the CRC initial value, rather than ~0.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
