### PR TITLE
trivial: Fix CI to use ghcr.io rather than docker.pkg.github.com

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Docker login
-        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        run: docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Download tarball
@@ -35,7 +35,7 @@ jobs:
         run: |
           docker run --privileged -e CI_NETWORK=$CI_NETWORK -e CI=$CI -e VERSION=$VERSION -t \
               -v $GITHUB_WORKSPACE:/github/workspace \
-              docker.pkg.github.com/fwupd/fwupd/fwupd-${{matrix.os}}:latest
+              ghcr.io/fwupd/fwupd/fwupd-${{matrix.os}}:latest
       - name: Save any applicable artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -58,7 +58,7 @@ jobs:
         run: |
           docker run --privileged -e CI_NETWORK=$CI_NETWORK -e CI=$CI -t \
               -v $GITHUB_WORKSPACE:/github/workspace \
-              docker.pkg.github.com/fwupd/fwupd/fwupd-${{matrix.os}}:latest \
+              ghcr.io/fwupd/fwupd/fwupd-${{matrix.os}}:latest \
               contrib/ci/${{matrix.os}}-test.sh
       - name: Save any coverage data
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/pull-request-reviews.yml
+++ b/.github/workflows/pull-request-reviews.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Docker login
-        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+        run: docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Run pre-commit hooks
         run: |
-          docker run --privileged -t -v $GITHUB_WORKSPACE:/github/workspace docker.pkg.github.com/fwupd/fwupd/fwupd-precommit:latest
+          docker run --privileged -t -v $GITHUB_WORKSPACE:/github/workspace ghcr.io/fwupd/fwupd/fwupd-precommit:latest
 
   snap:
     needs: pre-commit


### PR DESCRIPTION
It's no-longer just an alias, for some dumb reason.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
