### PR TITLE
trivial: Use fu_bytes_get_data_safe() in rustgen-generated code

### DIFF
--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -550,7 +550,9 @@ void
 {{obj.c_method('ValidateBytes')}}(GBytes *blob, gsize offset, GError **error)
 {
     gsize bufsz = 0;
-    const guint8 *buf = g_bytes_get_data(blob, &bufsz);
+    const guint8 *buf = fu_bytes_get_data_safe(blob, &bufsz, error);
+    if (buf == NULL)
+        return FALSE;
     return {{obj.c_method('Validate')}}(buf, bufsz, offset, error);
 }
 {%- endif %}
@@ -603,7 +605,9 @@ void
 {{obj.c_method('ParseBytes')}}(GBytes *blob, gsize offset, GError **error)
 {
     gsize bufsz = 0;
-    const guint8 *buf = g_bytes_get_data(blob, &bufsz);
+    const guint8 *buf = fu_bytes_get_data_safe(blob, &bufsz, error);
+    if (buf == NULL)
+        return NULL;
     return {{obj.c_method('Parse')}}(buf, bufsz, offset, error);
 }
 {%- endif %}

--- a/libfwupdplugin/fu-rustgen.c.in
+++ b/libfwupdplugin/fu-rustgen.c.in
@@ -11,6 +11,7 @@
 #include "{{basename}}"
 {%- if struct_objs %}
 #include "fu-byte-array.h"
+#include "fu-bytes.h"
 #include "fu-mem-private.h"
 #include "fu-string.h"
 {%- endif %}


### PR DESCRIPTION
The fuzzer can emit an empty array, which GLib helpfully wraps as a GBytes with NULL data.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
