### PR TITLE
Lightware Taurus HC40&HC60 devices quirk for fastboot

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -331,6 +331,7 @@ class Checker:
 
         if self._current_fn and os.path.basename(self._current_fn) in [
             "fu-firmware.c",
+            "fu-firmware-private.h",
         ]:
             return
         if node.depth != 0:

--- a/data/vendors.quirk
+++ b/data/vendors.quirk
@@ -22,6 +22,8 @@ Vendor = Egistec
 Vendor = Ilitek
 [USB\VID_273F]
 Vendor = Hughski
+[USB\VID_276F]
+Vendor = Lightware
 [USB\VID_27C6]
 Vendor = Goodix
 [USB\VID_32AC]

--- a/libfwupdplugin/fu-firmware-private.h
+++ b/libfwupdplugin/fu-firmware-private.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-firmware.h"
+
+GArray *
+fu_firmware_get_image_gtypes(FuFirmware *self) G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -8,6 +8,8 @@
 
 #include <fwupdplugin.h>
 
+#include "fwupd-test.h"
+
 #include "fu-context-private.h"
 
 static void
@@ -726,24 +728,26 @@ fu_firmware_func(void)
 	g_assert_cmpstr(fu_firmware_get_id(img_idx), ==, "secondary");
 
 	str = fu_firmware_to_string(firmware);
-	g_assert_cmpstr(str,
-			==,
-			"<firmware>\n"
-			"  <image_gtypes>\n"
-			"    <gtype>FuFirmware</gtype>\n"
-			"  </image_gtypes>\n"
-			"  <firmware>\n"
-			"    <id>primary</id>\n"
-			"    <idx>0xd</idx>\n"
-			"    <addr>0x200</addr>\n"
-			"    <filename>BIOS.bin</filename>\n"
-			"  </firmware>\n"
-			"  <firmware>\n"
-			"    <id>secondary</id>\n"
-			"    <idx>0x17</idx>\n"
-			"    <addr>0x400</addr>\n"
-			"  </firmware>\n"
-			"</firmware>\n");
+	ret = fu_test_compare_lines(str,
+				    "<firmware>\n"
+				    "  <image_gtypes>\n"
+				    "    <gtype>FuFirmware</gtype>\n"
+				    "  </image_gtypes>\n"
+				    "  <firmware>\n"
+				    "    <id>primary</id>\n"
+				    "    <idx>0xd</idx>\n"
+				    "    <addr>0x200</addr>\n"
+				    "    <filename>BIOS.bin</filename>\n"
+				    "  </firmware>\n"
+				    "  <firmware>\n"
+				    "    <id>secondary</id>\n"
+				    "    <idx>0x17</idx>\n"
+				    "    <addr>0x400</addr>\n"
+				    "  </firmware>\n"
+				    "</firmware>\n",
+				    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	ret = fu_firmware_remove_image_by_idx(firmware, 0xd, &error);
 	g_assert_no_error(error);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -12,7 +12,7 @@
 #include "fu-bytes.h"
 #include "fu-chunk-private.h"
 #include "fu-common.h"
-#include "fu-firmware.h"
+#include "fu-firmware-private.h"
 #include "fu-fuzzer.h"
 #include "fu-input-stream.h"
 #include "fu-mem.h"
@@ -1816,6 +1816,25 @@ fu_firmware_add_image_gtype(FuFirmware *self, GType type)
 	g_array_append_val(priv->image_gtypes, type);
 }
 
+/**
+ * fu_firmware_get_image_gtypes:
+ * @self: a #FuFirmware
+ *
+ * Returns all the possible image GTypes.
+ *
+ * Returns: (element-type GType) (transfer none) (nullable): array of #GType.
+ *
+ * Since: 2.1.1
+ **/
+GArray *
+fu_firmware_get_image_gtypes(FuFirmware *self)
+{
+	FuFirmwarePrivate *priv = GET_PRIVATE(self);
+
+	g_return_val_if_fail(FU_IS_FIRMWARE(self), NULL);
+	return priv->image_gtypes;
+}
+
 static gboolean
 fu_firmware_check_image_gtype(FuFirmware *self, GType gtype, GError **error)
 {
@@ -2623,6 +2642,9 @@ fu_firmware_constructed(GObject *obj)
 	FuFirmwareClass *klass = FU_FIRMWARE_GET_CLASS(self);
 	if (klass->add_magic != NULL)
 		klass->add_magic(self);
+	if (G_TYPE_FROM_CLASS(klass) != FU_TYPE_FIRMWARE && klass->parse_full == NULL &&
+	    klass->parse == NULL)
+		fu_firmware_add_flag(self, FU_FIRMWARE_FLAG_IS_ABSTRACT);
 }
 
 static void

--- a/libfwupdplugin/fu-firmware.rs
+++ b/libfwupdplugin/fu-firmware.rs
@@ -40,6 +40,7 @@ enum FuFirmwareFlags {
     HasCheckCompatible = 1 << 8,
     IsLastImage = 1 << 9, // use for FuLinearFirmware when padding is present
     AllowLinear = 1 << 10, // parse as an array of firmwares
+    IsAbstract = 1 << 11, // cannot parse a blob directly
 }
 
 enum FuFirmwareAlignment {

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -6,10 +6,7 @@
 
 #include "config.h"
 
-#include "fu-acpi-phat-health-record.h"
 #include "fu-acpi-phat-plugin.h"
-#include "fu-acpi-phat-version-element.h"
-#include "fu-acpi-phat-version-record.h"
 #include "fu-acpi-phat.h"
 
 struct _FuAcpiPhatPlugin {
@@ -60,9 +57,6 @@ fu_acpi_phat_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_HEALTH_RECORD);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_VERSION_ELEMENT);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT_VERSION_RECORD);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-plugin.c
+++ b/plugins/bcm57xx/fu-bcm57xx-plugin.c
@@ -7,11 +7,8 @@
 #include "config.h"
 
 #include "fu-bcm57xx-device.h"
-#include "fu-bcm57xx-dict-image.h"
 #include "fu-bcm57xx-firmware.h"
 #include "fu-bcm57xx-plugin.h"
-#include "fu-bcm57xx-stage1-image.h"
-#include "fu-bcm57xx-stage2-image.h"
 
 struct _FuBcm57xxPlugin {
 	FuPlugin parent_instance;
@@ -90,9 +87,6 @@ fu_bcm57xx_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_DICT_IMAGE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_STAGE1_IMAGE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_STAGE2_IMAGE);
 }
 
 static void

--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -45,3 +45,59 @@ FastbootOperationDelay = 0
 Summary = Rolling RW101 Modem (fastboot)
 CounterpartGuid = USB\VID_33F8&PID_0301
 CounterpartGuid = USB\VID_33F8&PID_0302
+
+# Taurus HC40 4x2
+[USB\VID_276F&PID_0188]
+Plugin = fastboot
+Name = Taurus UCX 4x2 HC40
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC40 4x3
+[USB\VID_276F&PID_0189]
+Plugin = fastboot
+Name = Taurus UCX 4x3 HC40
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC40D
+[USB\VID_276F&PID_018A]
+Plugin = fastboot
+Name = Taurus UCX 4x2 HC40D
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC40-BD
+[USB\VID_276F&PID_018B]
+Plugin = fastboot
+Name = Taurus UCX 4x3 HC40-BD
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC60 4x2
+[USB\VID_276F&PID_0193]
+Plugin = fastboot
+Name = Taurus UCX 4x2 HC60
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC60 4x3
+[USB\VID_276F&PID_0194]
+Plugin = fastboot
+Name = Taurus UCX 4x3 HC60
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC60D
+[USB\VID_276F&PID_0195]
+Plugin = fastboot
+Name = Taurus UCX 4x2 HC60D
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000
+
+# Taurus HC60-BD
+[USB\VID_276F&PID_0196]
+Plugin = fastboot
+Name = Taurus UCX 4x3 HC60-BD
+Flags = unsigned-payload,will-disappear
+FastbootBlockSize = 0x4000

--- a/plugins/ilitek-its/fu-ilitek-its-block.c
+++ b/plugins/ilitek-its/fu-ilitek-its-block.c
@@ -57,6 +57,7 @@ fu_ilitek_its_block_get_crc(FuIlitekItsBlock *self)
 static void
 fu_ilitek_its_block_init(FuIlitekItsBlock *self)
 {
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_NO_AUTO_DETECTION);
 }
 
 static void

--- a/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
@@ -8,7 +8,6 @@
 
 #include "fu-jabra-gnp-device.h"
 #include "fu-jabra-gnp-firmware.h"
-#include "fu-jabra-gnp-image.h"
 #include "fu-jabra-gnp-plugin.h"
 
 struct _FuJabraGnpPlugin {
@@ -31,7 +30,6 @@ fu_jabra_gnp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_GNP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_GNP_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_GNP_IMAGE); /* coverage */
 }
 
 static void

--- a/plugins/nordic-hid/fu-nordic-hid-plugin.c
+++ b/plugins/nordic-hid/fu-nordic-hid-plugin.c
@@ -8,8 +8,6 @@
 
 #include "fu-nordic-hid-archive.h"
 #include "fu-nordic-hid-cfg-channel.h"
-#include "fu-nordic-hid-firmware-b0.h"
-#include "fu-nordic-hid-firmware-mcuboot.h"
 #include "fu-nordic-hid-plugin.h"
 
 struct _FuNordicHidPlugin {
@@ -32,8 +30,6 @@ fu_nordic_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NORDIC_HID_CFG_CHANNEL);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_ARCHIVE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_FIRMWARE_B0);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_FIRMWARE_MCUBOOT);
 }
 
 static void

--- a/plugins/pixart-tp/fu-pixart-tp-plugin.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plugin.c
@@ -11,7 +11,6 @@
 #include "fu-pixart-tp-firmware.h"
 #include "fu-pixart-tp-haptic-device.h"
 #include "fu-pixart-tp-plugin.h"
-#include "fu-pixart-tp-section.h"
 
 struct _FuPixartTpPlugin {
 	FuPlugin parent_instance;
@@ -39,7 +38,6 @@ fu_pixart_tp_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_PIXART_TP_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_HAPTIC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_FIRMWARE);
-	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_SECTION); /* coverage */
 }
 
 static void


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
- [X] Quirk file update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition for eight Taurus HC40/HC60 device variants (4x2 and 4x3 layouts, including D and BD models) so they are handled by fastboot flows.
  * Added a Lightware USB vendor entry so these devices are properly identified by the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->