### PR TITLE
logind-like support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -678,6 +678,15 @@ else
   allow_flashrom = false
 endif
 
+logind = dependency(
+  'systemd', 'libelogind',
+  required: get_option('logind').disable_auto_if(host_machine.system() != 'linux'),
+)
+
+if logind.found()
+  conf.set('HAVE_LOGIND', '1')
+endif
+
 if libsystemd.found()
   systemd = dependency(
     'systemd',
@@ -685,7 +694,6 @@ if libsystemd.found()
     required: get_option('systemd'),
   )
   conf.set('HAVE_SYSTEMD' , '1')
-  conf.set('HAVE_LOGIND' , '1')
   systemd_root_prefix = get_option('systemd_root_prefix')
   if systemd_root_prefix == ''
     systemdunitdir = systemd.get_variable(
@@ -946,6 +954,7 @@ summary(
     'introspection': introspection.allowed(),
     'libblkid': libblkid,
     'libdrm': libdrm,
+    'logind': logind,
     'valgrind': valgrind,
     'polkit': polkit,
     'python3': python3,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -97,6 +97,11 @@ option(
   description: 'libmnl support',
 )
 option(
+  'logind',
+  type: 'feature',
+  description: 'logind-like support',
+)
+option(
   'lvfs',
   type: 'combo',
   choices: ['true', 'false', 'disabled'],

--- a/plugins/logind/meson.build
+++ b/plugins/logind/meson.build
@@ -1,4 +1,4 @@
-libsystemd.found() or subdir_done()
+logind.found() or subdir_done()
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginLogind"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
@@ -10,5 +10,8 @@ plugin_builtins += static_library('fu_plugin_logind',
   include_directories: plugin_incdirs,
   link_with: plugin_libs,
   c_args: cargs,
-  dependencies: plugin_deps,
+  dependencies: [
+    plugin_deps,
+    logind,
+  ],
 )


### PR DESCRIPTION
This allows reboots on systems where `systemd` is unavailable but `logind`-compatible software is available (e.g., `elogind`). This feature complements the systemd-agnostic startup provided in #8690 

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation

I'm not sure whether this should be considered a feature or a bug fix.