### PR TITLE
Remove unused runtime Python dependency

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -31,7 +31,6 @@ depends=(
   libxmlb
   passim
   polkit
-  python
   shared-mime-info
   sqlite
   systemd-libs


### PR DESCRIPTION
Based on my observation, Python is not required as a runtime dependency.

---

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Python from package dependencies, reducing the installation footprint and simplifying runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->