### PR TITLE
Update pixart-tp.quirk to support Acer CP7 Chrome Glass device with PID:3317

### DIFF
--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -9,6 +9,10 @@ Plugin = pixart_tp
 Plugin = pixart_tp
 PixartTpSramSelect = 0x08
 
+[HIDRAW\VEN_093A&DEV_3317]
+Plugin = pixart_tp
+PixartTpSramSelect = 0x08
+
 [HIDRAW\VEN_093A&DEV_4F07]
 Plugin = pixart_tp
 PixartTpHasHaptic = true


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
- [x] Quirk file update 

* **New Features**
  * Added recognition for Acer CP7 Chrome Glass device with PID:3317

<img width="914" height="288" alt="image" src="https://github.com/user-attachments/assets/143cc8a3-1761-4056-ad9f-7e07461e9521" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional HIDRAW touchpad device, extending hardware compatibility and enabling touchpad functionality on compatible systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->