### PR TITLE
Revert "trivial: require polkit 0.114 or later"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -377,19 +377,14 @@ libdrm = dependency(
 if libdrm.found()
   conf.set('HAVE_LIBDRM' , '1')
 endif
-polkit = dependency(
-  'polkit-gobject-1',
-  version: '>= 0.114',
-  required: get_option('polkit').disable_auto_if(host_machine.system() != 'linux'),
-)
+polkit = dependency('polkit-gobject-1', version: '>= 0.103',
+         required: get_option('polkit').disable_auto_if(host_machine.system() != 'linux'))
 if polkit.found()
   conf.set('HAVE_POLKIT', '1')
-  conf.set_quoted(
-    'POLKIT_ACTIONDIR',
-    polkit.get_variable(
-      pkgconfig: 'actiondir'
-    ),
-  )
+  if polkit.version().version_compare('>= 0.114')
+    conf.set('HAVE_POLKIT_0_114', '1')
+  endif
+  conf.set_quoted ('POLKIT_ACTIONDIR', polkit.get_variable(pkgconfig: 'actiondir'))
 endif
 if build_daemon
   if not polkit.found()

--- a/src/fu-polkit-authority.c
+++ b/src/fu-polkit-authority.c
@@ -14,6 +14,16 @@
 
 #include "fu-polkit-authority.h"
 
+#ifdef HAVE_POLKIT
+#ifndef HAVE_POLKIT_0_114
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitSubject, g_object_unref)
+#pragma clang diagnostic pop
+#endif /* HAVE_POLKIT_0_114 */
+#endif /* HAVE_POLKIT */
+
 struct _FuPolkitAuthority {
 	GObject parent_instance;
 #ifdef HAVE_POLKIT


### PR DESCRIPTION
This reverts commit 53d8bf7f931b105410778d7b40a9ebadcc2962d2.

Ubuntu 22.04 unfortunately does not have a new enough polkit to satisfy this requirement.

I'm filing this PR in order to make fwupd more easily backportable, but I understand if upstream wishes to reject this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended compatibility with older polkit library versions (0.103 and later, down from 0.114)
  * Optimized version detection and handling for polkit functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->