### PR TITLE
Add a strict-emulation-order flag which can be used for plugin refactoring

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -710,6 +710,19 @@ fu_device_new(FuContext *ctx);
  */
 #define FU_DEVICE_PRIVATE_FLAG_NO_VERSION_EXPECTED "no-version-expected"
 
+/**
+ * FU_DEVICE_PRIVATE_FLAG_STRICT_EMULATION_ORDER:
+ *
+ * Do not allow out-of-order or skipped emulation events. This allows a developer to refactor a
+ * plugin ensuring that the device behavior remains 100% unchanged.
+ *
+ * NOTE: This is probably only useful to set in `FuDevice->prepare()` or
+ * `FuDevice->write_firmware()` as enumeration may be different when loading emulated devices.
+ *
+ * Since: 2.1.1
+ */
+#define FU_DEVICE_PRIVATE_FLAG_STRICT_EMULATION_ORDER "strict-emulation-order"
+
 /* standard icons */
 
 /**


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Devices gain a strict event emulation ordering mode so events are processed in a predictable, sequential order; out-of-order or missing events are reported as not found.

* **Tests**
  * Added tests validating strict event ordering behavior, including handling of skipped, matched, and out-of-order events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->