### PR TITLE
vli: Add CI coverage for the VL103 PD chip and use proxies for emulation

### DIFF
--- a/plugins/vli/fu-vli-pd-device.c
+++ b/plugins/vli/fu-vli-pd-device.c
@@ -293,12 +293,12 @@ fu_vli_pd_device_spi_write_data(FuVliDevice *self,
 static gboolean
 fu_vli_pd_device_parade_setup(FuVliPdDevice *self, GError **error)
 {
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuVliPdParadeDevice) device_child = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* add child */
-	dev = fu_vli_pd_parade_device_new(FU_VLI_DEVICE(self));
-	if (!fu_device_probe(dev, &error_local)) {
+	device_child = fu_vli_pd_parade_device_new(FU_DEVICE(self));
+	if (!fu_device_setup(FU_DEVICE(device_child), &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_debug("%s", error_local->message);
 		} else {
@@ -306,11 +306,7 @@ fu_vli_pd_device_parade_setup(FuVliPdDevice *self, GError **error)
 		}
 		return TRUE;
 	}
-	if (!fu_device_setup(dev, error)) {
-		g_prefix_error_literal(error, "failed to set up parade device: ");
-		return FALSE;
-	}
-	fu_device_add_child(FU_DEVICE(self), dev);
+	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(device_child));
 	return TRUE;
 }
 

--- a/plugins/vli/fu-vli-pd-parade-device.h
+++ b/plugins/vli/fu-vli-pd-parade-device.h
@@ -18,5 +18,5 @@ G_DECLARE_FINAL_TYPE(FuVliPdParadeDevice,
 		     VLI_PD_PARADE_DEVICE,
 		     FuUsbDevice)
 
-FuDevice *
-fu_vli_pd_parade_device_new(FuVliDevice *parent);
+FuVliPdParadeDevice *
+fu_vli_pd_parade_device_new(FuDevice *proxy);

--- a/plugins/vli/fu-vli-usbhub-device.c
+++ b/plugins/vli/fu-vli-usbhub-device.c
@@ -674,14 +674,12 @@ fu_vli_usbhub_device_probe(FuDevice *device, GError **error)
 static gboolean
 fu_vli_usbhub_device_pd_setup(FuVliUsbhubDevice *self, GError **error)
 {
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuVliUsbhubPdDevice) device_child = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* add child */
-	dev = fu_vli_usbhub_pd_device_new(self);
-	if (!fu_device_probe(dev, error))
-		return FALSE;
-	if (!fu_device_setup(dev, &error_local)) {
+	device_child = fu_vli_usbhub_pd_device_new(FU_DEVICE(self));
+	if (!fu_device_setup(FU_DEVICE(device_child), &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_debug("%s", error_local->message);
 		} else {
@@ -689,21 +687,19 @@ fu_vli_usbhub_device_pd_setup(FuVliUsbhubDevice *self, GError **error)
 		}
 		return TRUE;
 	}
-	fu_device_add_child(FU_DEVICE(self), dev);
+	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(device_child));
 	return TRUE;
 }
 
 static gboolean
 fu_vli_usbhub_device_msp430_setup(FuVliUsbhubDevice *self, GError **error)
 {
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuVliUsbhubMsp430Device) device_child = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* add child */
-	dev = fu_vli_usbhub_msp430_device_new(self);
-	if (!fu_device_probe(dev, error))
-		return FALSE;
-	if (!fu_device_setup(dev, &error_local)) {
+	device_child = fu_vli_usbhub_msp430_device_new(FU_DEVICE(self));
+	if (!fu_device_setup(FU_DEVICE(device_child), &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_debug("%s", error_local->message);
 		} else {
@@ -711,21 +707,19 @@ fu_vli_usbhub_device_msp430_setup(FuVliUsbhubDevice *self, GError **error)
 		}
 		return TRUE;
 	}
-	fu_device_add_child(FU_DEVICE(self), dev);
+	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(device_child));
 	return TRUE;
 }
 
 static gboolean
 fu_vli_usbhub_device_rtd21xx_setup(FuVliUsbhubDevice *self, GError **error)
 {
-	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuVliUsbhubRtd21xxDevice) device_child = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* add child */
-	dev = fu_vli_usbhub_rtd21xx_device_new(self);
-	if (!fu_device_probe(dev, error))
-		return FALSE;
-	if (!fu_device_setup(dev, &error_local)) {
+	device_child = fu_vli_usbhub_rtd21xx_device_new(FU_DEVICE(self));
+	if (!fu_device_setup(FU_DEVICE(device_child), &error_local)) {
 		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
 			g_debug("%s", error_local->message);
 		} else {
@@ -733,7 +727,7 @@ fu_vli_usbhub_device_rtd21xx_setup(FuVliUsbhubDevice *self, GError **error)
 		}
 		return TRUE;
 	}
-	fu_device_add_child(FU_DEVICE(self), dev);
+	fu_device_add_child(FU_DEVICE(self), FU_DEVICE(device_child));
 	return TRUE;
 }
 

--- a/plugins/vli/fu-vli-usbhub-msp430-device.h
+++ b/plugins/vli/fu-vli-usbhub-msp430-device.h
@@ -17,5 +17,5 @@ G_DECLARE_FINAL_TYPE(FuVliUsbhubMsp430Device,
 		     VLI_USBHUB_MSP430_DEVICE,
 		     FuDevice)
 
-FuDevice *
-fu_vli_usbhub_msp430_device_new(FuVliUsbhubDevice *parent);
+FuVliUsbhubMsp430Device *
+fu_vli_usbhub_msp430_device_new(FuDevice *proxy);

--- a/plugins/vli/fu-vli-usbhub-pd-device.h
+++ b/plugins/vli/fu-vli-usbhub-pd-device.h
@@ -8,8 +8,6 @@
 
 #include <fwupdplugin.h>
 
-#include "fu-vli-usbhub-device.h"
-
 #define FU_TYPE_VLI_USBHUB_PD_DEVICE (fu_vli_usbhub_pd_device_get_type())
 G_DECLARE_FINAL_TYPE(FuVliUsbhubPdDevice,
 		     fu_vli_usbhub_pd_device,
@@ -17,5 +15,5 @@ G_DECLARE_FINAL_TYPE(FuVliUsbhubPdDevice,
 		     VLI_USBHUB_PD_DEVICE,
 		     FuDevice)
 
-FuDevice *
-fu_vli_usbhub_pd_device_new(FuVliUsbhubDevice *parent);
+FuVliUsbhubPdDevice *
+fu_vli_usbhub_pd_device_new(FuDevice *proxy);

--- a/plugins/vli/fu-vli-usbhub-rtd21xx-device.h
+++ b/plugins/vli/fu-vli-usbhub-rtd21xx-device.h
@@ -17,5 +17,5 @@ G_DECLARE_FINAL_TYPE(FuVliUsbhubRtd21xxDevice,
 		     VLI_USBHUB_RTD21XX_DEVICE,
 		     FuDevice)
 
-FuDevice *
-fu_vli_usbhub_rtd21xx_device_new(FuVliUsbhubDevice *parent);
+FuVliUsbhubRtd21xxDevice *
+fu_vli_usbhub_rtd21xx_device_new(FuDevice *proxy);

--- a/plugins/vli/tests/bizlink-no-sku-vli.json
+++ b/plugins/vli/tests/bizlink-no-sku-vli.json
@@ -3,7 +3,8 @@
   "interactive": false,
   "steps": [
     {
-      "url": "e0d6f62140663744f114d59b1ec48dd3e4743006bb06d0643efe178b8bdb2a04-BizLink-Cayenne_New.cab",
+      "url": "e827aa06440e89dd90feb9c5f84efa685cff7a08711576f1a9d0ad89951fd397-BizLink-Cayenne_New.cab",
+      "emulation-url": "9c380dd11ad99f59769034a850b2690010813534a0a7f86ccc711333ffa8a9df-BizLink-Cayenne_New.zip",
       "components": [
         {
           "name": "tier1",
@@ -26,7 +27,7 @@
       "components": [
         {
           "name": "tier1",
-          "version": "06.83",
+          "version": "6.83",
           "guids": [
             "a0eff862-6b0b-5571-91ec-a0c4bb25b539"
           ]


### PR DESCRIPTION
We can actually simplify FuVliUsbhubPdDevice a little using a proxy, plus it allows the emulations to be recorded properly.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation