### PR TITLE
uefi-capsule: Find shim when using systemd-boot and distro-specific locations

### DIFF
--- a/plugins/uefi-capsule/README.md
+++ b/plugins/uefi-capsule/README.md
@@ -155,10 +155,6 @@ This alternative format may be needed for some early InsydeH2O firmwares.
 
 Do not use the additional UX capsule.
 
-### `Flags=use-shim-unique`
-
-Use a unique shim filename to work around a common BIOS bug.
-
 ### `Flags=use-legacy-bootmgr-desc`
 
 Use the legacy boot manager description to work around a Lenovo BIOS bug.

--- a/plugins/uefi-capsule/fu-self-test.c
+++ b/plugins/uefi-capsule/fu-self-test.c
@@ -292,7 +292,7 @@ fu_uefi_capsule_fake_esp_new(FuTemporaryDirectory *tmpdir)
 	fu_volume_set_partition_kind(esp, FU_VOLUME_KIND_ESP);
 	fu_volume_set_partition_uuid(esp, "00000000-0000-0000-0000-000000000000");
 
-	/* make fu_uefi_get_esp_path_for_os() distro-neutral */
+	/* make fu_uefi_capsule_device_build_efi_path() distro-neutral */
 	tmpdir_efi = g_build_filename(tmpdir_path, "EFI", EFI_OS_DIR, NULL);
 	g_assert_cmpint(g_mkdir_with_parents(tmpdir_efi, 0700), ==, 0);
 

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.c
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.c
@@ -97,11 +97,12 @@ fu_uefi_bootmgr_verify_fwupd(FuEfivars *efivars, GError **error)
 }
 
 static gboolean
-fu_uefi_bootmgr_setup_bootnext_with_loadopt(FuEfivars *efivars,
+fu_uefi_bootmgr_setup_bootnext_with_loadopt(FuUefiCapsuleDevice *capsule_device,
 					    FuEfiLoadOption *loadopt,
-					    FuUefiBootmgrFlags flags,
 					    GError **error)
 {
+	FuContext *ctx = fu_device_get_context(FU_DEVICE(capsule_device));
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
 	const gchar *name = NULL;
 	guint16 boot_next = G_MAXUINT16;
 	g_autofree guint8 *set_entries = g_malloc0(G_MAXUINT16);
@@ -205,7 +206,8 @@ fu_uefi_bootmgr_setup_bootnext_with_loadopt(FuEfivars *efivars,
 	}
 
 	/* TODO: conditionalize this on the UEFI version? */
-	if (flags & FU_UEFI_BOOTMGR_FLAG_MODIFY_BOOTORDER) {
+	if (fu_device_has_private_flag(FU_DEVICE(capsule_device),
+				       FU_UEFI_CAPSULE_DEVICE_FLAG_MODIFY_BOOTORDER)) {
 		if (!fu_uefi_bootmgr_add_to_boot_order(efivars, boot_next, error))
 			return FALSE;
 	}
@@ -339,109 +341,96 @@ fu_uefi_bootmgr_shim_is_safe(FuEfivars *efivars, const gchar *source_shim, GErro
 }
 
 gboolean
-fu_uefi_bootmgr_bootnext(FuPathStore *pstore,
-			 FuEfivars *efivars,
-			 FuVolume *esp,
+fu_uefi_bootmgr_bootnext(FuUefiCapsuleDevice *capsule_device,
 			 const gchar *description,
-			 FuUefiBootmgrFlags flags,
 			 GError **error)
 {
-	const gchar *filepath = NULL;
-	gboolean use_fwup_path = TRUE;
+	FuContext *ctx = fu_device_get_context(FU_DEVICE(capsule_device));
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
+	FuVolume *esp = fu_uefi_capsule_device_get_esp(capsule_device);
+	FuPathStore *pstore = fu_context_get_path_store(ctx);
 	gboolean secureboot_enabled = FALSE;
-	g_autofree gchar *shim_app = NULL;
-	g_autofree gchar *shim_cpy = NULL;
-	g_autofree gchar *source_app = NULL;
-	g_autofree gchar *source_shim = NULL;
-	g_autofree gchar *target_app = NULL;
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
-	g_autoptr(FuEfiDevicePathList) dp_buf = NULL;
+	g_autofree gchar *shim_dst = NULL;
+	g_autofree gchar *app_src = NULL;
+	g_autofree gchar *app_basename = NULL;
+	g_autofree gchar *app_dst = NULL;
 	g_autoptr(FuEfiLoadOption) loadopt = fu_efi_load_option_new();
 	g_autoptr(GError) error_local = NULL;
 
-	/* if secure boot was turned on this might need to be installed separately */
-	source_app = fu_uefi_get_built_app_path(pstore, efivars, "fwupd", error);
-	if (source_app == NULL)
+	/* copy fwupdx64.efi to the ESP */
+	app_basename = fu_uefi_capsule_build_app_basename(pstore, "fwupd", error);
+	if (app_basename == NULL)
 		return FALSE;
+	app_src = fu_uefi_get_built_app_path(pstore, efivars, app_basename, error);
+	if (app_src == NULL)
+		return FALSE;
+	app_dst = fu_uefi_capsule_device_build_efi_path(capsule_device, error, app_basename, NULL);
+	if (app_dst == NULL)
+		return FALSE;
+	if (!fu_uefi_esp_target_verify(app_src, app_dst)) {
+		if (!fu_uefi_esp_target_copy(app_src, app_dst, error))
+			return FALSE;
+	}
 
-	/* test if we should use shim */
+	/* SecureBoot has to use shim */
 	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, &error_local))
 		g_debug("ignoring: %s", error_local->message);
-	if (secureboot_enabled) {
-		shim_app = fu_uefi_get_esp_app_path(pstore, esp_path, "shim", error);
-		if (shim_app == NULL)
+	if (fu_device_has_private_flag(FU_DEVICE(capsule_device),
+				       FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_FOR_SB) &&
+	    secureboot_enabled) {
+		g_autoptr(FuEfiDevicePathList) dp_buf = NULL;
+		g_autofree gchar *shim_basename = NULL;
+		g_autofree gchar *shim_src = NULL;
+
+		shim_basename = fu_uefi_capsule_build_app_basename(pstore, "shim", error);
+		if (shim_basename == NULL)
+			return FALSE;
+		shim_dst = fu_uefi_capsule_device_build_efi_path(capsule_device,
+								 error,
+								 shim_basename,
+								 NULL);
+		if (shim_dst == NULL)
 			return FALSE;
 
-		/* copy in an updated shim if we have one */
-		source_shim = fu_uefi_get_built_app_path(pstore, efivars, "shim", NULL);
-		if (source_shim != NULL) {
-			if (!fu_uefi_esp_target_verify(source_shim, esp, shim_app)) {
-				if (!fu_uefi_bootmgr_shim_is_safe(efivars, source_shim, error))
+		/* copy an updated shim if we have one */
+		shim_src = fu_uefi_get_built_app_path(pstore, efivars, shim_basename, NULL);
+		if (shim_src != NULL) {
+			if (!fu_uefi_esp_target_verify(shim_src, shim_dst)) {
+				if (!fu_uefi_bootmgr_shim_is_safe(efivars, shim_src, error))
 					return FALSE;
-				if (!fu_uefi_esp_target_copy(source_shim, esp, shim_app, error))
+				if (!fu_uefi_esp_target_copy(shim_src, shim_dst, error))
 					return FALSE;
 			}
-		}
-
-		if (fu_uefi_esp_target_exists(esp, shim_app)) {
-			/* use a custom copy of shim for firmware updates */
-			if (flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_UNIQUE) {
-				shim_cpy =
-				    fu_uefi_get_esp_app_path(pstore, esp_path, "shimfwupd", error);
-				if (shim_cpy == NULL)
-					return FALSE;
-				if (!fu_uefi_esp_target_verify(shim_app, esp, shim_cpy)) {
-					if (!fu_uefi_esp_target_copy(shim_app,
-								     esp,
-								     shim_cpy,
-								     error))
-						return FALSE;
-				}
-				filepath = shim_cpy;
-			} else {
-				filepath = shim_app;
-			}
-			use_fwup_path = FALSE;
-		} else if ((flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB) > 0) {
+		} else if (!g_file_test(shim_dst, G_FILE_TEST_EXISTS)) {
 			g_set_error(error,
 				    FWUPD_ERROR,
-				    FWUPD_ERROR_BROKEN_SYSTEM,
-				    "Secure boot is enabled, but shim isn't installed to "
-				    "%s",
-				    shim_app);
+				    FWUPD_ERROR_NOT_FOUND,
+				    "shim is required but was not found: %s",
+				    shim_dst);
 			return FALSE;
 		}
-	}
 
-	/* test if correct asset in place */
-	target_app = fu_uefi_get_esp_app_path(pstore, esp_path, "fwupd", error);
-	if (target_app == NULL)
-		return FALSE;
-	if (!fu_uefi_esp_target_verify(source_app, esp, target_app)) {
-		if (!fu_uefi_esp_target_copy(source_app, esp, target_app, error))
+		/* shim chainloads fwupd */
+		dp_buf = fu_uefi_capsule_device_build_dp_buf(esp, shim_dst, error);
+		if (dp_buf == NULL)
+			return FALSE;
+		if (!fu_firmware_add_image(FU_FIRMWARE(loadopt), FU_FIRMWARE(dp_buf), error))
+			return FALSE;
+		fu_efi_load_option_set_metadata(loadopt,
+						FU_EFI_LOAD_OPTION_METADATA_PATH,
+						app_basename);
+	} else {
+		g_autoptr(FuEfiDevicePathList) dp_buf = NULL;
+
+		/* fwupd is loaded directly */
+		dp_buf = fu_uefi_capsule_device_build_dp_buf(esp, app_dst, error);
+		if (dp_buf == NULL)
+			return FALSE;
+		if (!fu_firmware_add_image(FU_FIRMWARE(loadopt), FU_FIRMWARE(dp_buf), error))
 			return FALSE;
 	}
 
-	/* no shim, so use this directly */
-	if (use_fwup_path)
-		filepath = target_app;
-
-	/* add the fwupdx64.efi ESP path as the shim loadopt data */
-	if (!use_fwup_path) {
-		g_autofree gchar *fwup_fs_basename = g_path_get_basename(target_app);
-		fu_efi_load_option_set_metadata(loadopt,
-						FU_EFI_LOAD_OPTION_METADATA_PATH,
-						fwup_fs_basename);
-	}
-
-	/* add DEVICE_PATH */
-	dp_buf = fu_uefi_capsule_device_build_dp_buf(esp, filepath, error);
-	if (dp_buf == NULL)
-		return FALSE;
-	if (!fu_firmware_add_image(FU_FIRMWARE(loadopt), FU_FIRMWARE(dp_buf), error))
-		return FALSE;
-	fu_firmware_set_id(FU_FIRMWARE(loadopt), description);
-
 	/* save as BootNext */
-	return fu_uefi_bootmgr_setup_bootnext_with_loadopt(efivars, loadopt, flags, error);
+	fu_firmware_set_id(FU_FIRMWARE(loadopt), description);
+	return fu_uefi_bootmgr_setup_bootnext_with_loadopt(capsule_device, loadopt, error);
 }

--- a/plugins/uefi-capsule/fu-uefi-bootmgr.h
+++ b/plugins/uefi-capsule/fu-uefi-bootmgr.h
@@ -9,20 +9,11 @@
 
 #include <fwupdplugin.h>
 
-typedef enum {
-	FU_UEFI_BOOTMGR_FLAG_NONE = 0,
-	FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB = 1 << 0,
-	FU_UEFI_BOOTMGR_FLAG_USE_SHIM_UNIQUE = 1 << 1,
-	FU_UEFI_BOOTMGR_FLAG_MODIFY_BOOTORDER = 1 << 2,
-	FU_UEFI_BOOTMGR_FLAG_LAST
-} G_GNUC_FLAG_ENUM FuUefiBootmgrFlags;
+#include "fu-uefi-capsule-device.h"
 
 gboolean
 fu_uefi_bootmgr_verify_fwupd(FuEfivars *efivars, GError **error);
 gboolean
-fu_uefi_bootmgr_bootnext(FuPathStore *pstore,
-			 FuEfivars *efivars,
-			 FuVolume *esp,
+fu_uefi_bootmgr_bootnext(FuUefiCapsuleDevice *capsule_device,
 			 const gchar *description,
-			 FuUefiBootmgrFlags flags,
 			 GError **error);

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.c
@@ -348,18 +348,36 @@ fu_uefi_capsule_device_clear_status(FuUefiCapsuleDevice *self, GError **error)
 }
 
 FuEfiDevicePathList *
-fu_uefi_capsule_device_build_dp_buf(FuVolume *esp, const gchar *capsule_path, GError **error)
+fu_uefi_capsule_device_build_dp_buf(FuVolume *esp, const gchar *filename, GError **error)
 {
 	g_autoptr(FuEfiDevicePathList) dp_buf = fu_efi_device_path_list_new();
 	g_autoptr(FuEfiFilePathDevicePath) dp_file = fu_efi_file_path_device_path_new();
 	g_autoptr(FuEfiHardDriveDevicePath) dp_hd = NULL;
-	g_autofree gchar *name_with_root = NULL;
+	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
+
+	/* capsule path should have the ESP mountpoint prefixed, so remove it */
+	if (esp_path == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "ESP is not mounted");
+		return NULL;
+	}
+	if (!g_str_has_prefix(filename, esp_path)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "%s was not prefixed by the ESP %s",
+			    filename,
+			    esp_path);
+		return NULL;
+	}
+	filename += strlen(esp_path);
 
 	dp_hd = fu_efi_hard_drive_device_path_new_from_volume(esp, error);
 	if (dp_hd == NULL)
 		return NULL;
-	name_with_root = g_strdup_printf("/%s", capsule_path);
-	if (!fu_efi_file_path_device_path_set_name(dp_file, name_with_root, error))
+	if (!fu_efi_file_path_device_path_set_name(dp_file, filename, error))
 		return NULL;
 	if (!fu_firmware_add_image(FU_FIRMWARE(dp_buf), FU_FIRMWARE(dp_hd), error))
 		return NULL;
@@ -484,23 +502,21 @@ fu_uefi_capsule_device_check_asset(FuUefiCapsuleDevice *self, GError **error)
 	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
 	FuPathStore *pstore = fu_context_get_path_store(ctx);
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
-	gboolean secureboot_enabled = FALSE;
-	g_autofree gchar *source_app = NULL;
-	g_autoptr(GError) error_local = NULL;
-
-	if (!fu_efivars_get_secure_boot(efivars, &secureboot_enabled, &error_local))
-		g_debug("ignoring: %s", error_local->message);
+	g_autofree gchar *app_basename = NULL;
+	g_autofree gchar *app_fn = NULL;
 
 	/* if fwupd-efi isn't in use, skip checks for the signed binary */
 	if (!fu_device_has_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_USE_FWUPD_EFI))
 		return TRUE;
 
-	source_app = fu_uefi_get_built_app_path(pstore, efivars, "fwupd", error);
-	if (source_app == NULL && secureboot_enabled) {
-		g_prefix_error_literal(error, "missing signed bootloader for secure boot: ");
+	app_basename = fu_uefi_capsule_build_app_basename(pstore, "fwupd", error);
+	if (app_basename == NULL)
 		return FALSE;
-	}
+	app_fn = fu_uefi_get_built_app_path(pstore, efivars, app_basename, error);
+	if (app_fn == NULL)
+		return FALSE;
 
+	/* success*/
 	return TRUE;
 }
 
@@ -694,6 +710,84 @@ fu_uefi_capsule_device_get_esp(FuUefiCapsuleDevice *self)
 	return priv->esp;
 }
 
+/**
+ * fu_uefi_capsule_device_build_efi_path:
+ * @self: a #FuUefiCapsuleDevice
+ * @path: a filename to append to the EFI path
+ * @error: a #GError or %NULL
+ *
+ * Builds the full local path where @filename should be loaded or saved from.
+ *
+ * If `EFI_OS_DIR` has not been set then we look for the presence of the `systemd` directory,
+ * falling back to the os-release `ID` or `ID_LIKE` directories.
+ *
+ * Returns: (transfer full): a path or %NULL for error
+ */
+gchar *
+fu_uefi_capsule_device_build_efi_path(FuUefiCapsuleDevice *self,
+				      GError **error,
+				      const gchar *filename,
+				      ...)
+{
+	FuUefiCapsuleDevicePrivate *priv = GET_PRIVATE(self);
+	g_autofree gchar *esp_path = fu_volume_get_mount_point(priv->esp);
+	va_list args;
+	g_autofree gchar *filename_built = NULL;
+#ifndef EFI_OS_DIR
+	g_autofree gchar *os_release_id = NULL;
+	g_autofree gchar *os_release_id_like = NULL;
+	g_autofree gchar *systemd_path = NULL;
+#endif
+
+	/* sanity check */
+	if (esp_path == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "ESP is not mounted");
+		return NULL;
+	}
+
+	va_start(args, filename);
+	filename_built = g_build_filename_valist(filename, &args);
+	va_end(args);
+
+#ifndef EFI_OS_DIR
+	/* distro (or user) is using systemd-boot */
+	systemd_path = g_build_filename(esp_path, "EFI", "systemd", NULL);
+	if (g_file_test(systemd_path, G_FILE_TEST_IS_DIR))
+		return g_build_filename(systemd_path, filename_built, NULL);
+
+	/* try to lookup /etc/os-release ID and ID_LIKE keys */
+	os_release_id = g_get_os_info(G_OS_INFO_KEY_ID);
+	if (os_release_id != NULL) {
+		g_autofree gchar *path_tmp = g_build_filename(esp_path, "EFI", os_release_id, NULL);
+		if (g_file_test(path_tmp, G_FILE_TEST_IS_DIR))
+			return g_build_filename(path_tmp, filename_built, NULL);
+	}
+	os_release_id_like = g_get_os_info("ID_LIKE");
+	if (os_release_id_like != NULL) {
+		g_auto(GStrv) id_like_parts = g_strsplit(os_release_id_like, " ", -1);
+		for (guint i = 0; id_like_parts[i] != NULL; i++) {
+			g_autofree gchar *path_tmp =
+			    g_build_filename(esp_path, "EFI", id_like_parts[i], NULL);
+			if (g_file_test(path_tmp, G_FILE_TEST_IS_DIR))
+				return g_build_filename(path_tmp, filename_built, NULL);
+		}
+	}
+
+	/* nothing sensible to do*/
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_BROKEN_SYSTEM,
+		    "cannot find either EFI/systemd or EFI/%s in ESP",
+		    os_release_id);
+	return NULL;
+#else
+	return g_build_filename(esp_path, "EFI", EFI_OS_DIR, filename_built, NULL);
+#endif
+}
+
 static FuFirmware *
 fu_uefi_capsule_device_prepare_firmware(FuDevice *device,
 					GInputStream *stream,
@@ -802,8 +896,6 @@ fu_uefi_capsule_device_init(FuUefiCapsuleDevice *self)
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_SIGNED);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_MD_SET_FLAGS);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_UEFI_CAPSULE_DEVICE_FLAG_NO_UX_CAPSULE);
-	fu_device_register_private_flag(FU_DEVICE(self),
-					FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_UNIQUE);
 	fu_device_register_private_flag(FU_DEVICE(self),
 					FU_UEFI_CAPSULE_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC);
 	fu_device_register_private_flag(FU_DEVICE(self),

--- a/plugins/uefi-capsule/fu-uefi-capsule-device.h
+++ b/plugins/uefi-capsule/fu-uefi-capsule-device.h
@@ -23,7 +23,6 @@ struct _FuUefiCapsuleDeviceClass {
 };
 
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_NO_UX_CAPSULE	     "no-ux-capsule"
-#define FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_UNIQUE	     "use-shim-unique"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC  "use-legacy-bootmgr-desc"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_SUPPORTS_BOOT_ORDER_LOCK "supports-boot-order-lock"
 #define FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_FOR_SB	     "use-shim-for-sb"
@@ -46,6 +45,12 @@ const gchar *
 fu_uefi_capsule_device_get_guid(FuUefiCapsuleDevice *self);
 FuVolume *
 fu_uefi_capsule_device_get_esp(FuUefiCapsuleDevice *self);
+gchar *
+fu_uefi_capsule_device_build_efi_path(FuUefiCapsuleDevice *self,
+				      GError **error,
+				      const gchar *filename,
+				      ...) G_GNUC_NULL_TERMINATED;
+
 gchar *
 fu_uefi_capsule_device_build_varname(FuUefiCapsuleDevice *self);
 guint32

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -380,11 +380,8 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	guint32 width;
 	guint8 csum = 0;
 	fwupd_guid_t guid = {0x0};
-	g_autofree gchar *capsule_path = NULL;
-	g_autofree gchar *esp_path = NULL;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *basename = NULL;
-	g_autofree gchar *directory = NULL;
 	g_autoptr(FuBitmapImage) bmp_image = fu_bitmap_image_new();
 	g_autoptr(FuStructEfiCapsuleHeader) st_cap = fu_struct_efi_capsule_header_new();
 	g_autoptr(FuStructEfiUxCapsuleHeader) st_uxh = fu_struct_efi_ux_capsule_header_new();
@@ -402,11 +399,14 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 	width = fu_bitmap_image_get_width(bmp_image);
 
 	/* save to a predictable filename */
-	esp_path = fu_volume_get_mount_point(self->esp);
-	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", FU_EFIVARS_GUID_UX_CAPSULE);
-	capsule_path = g_build_filename(directory, "fw", basename, NULL);
-	fn = g_build_filename(esp_path, capsule_path, NULL);
+	fn = fu_uefi_capsule_device_build_efi_path(FU_UEFI_CAPSULE_DEVICE(device),
+						   error,
+						   "fw",
+						   basename,
+						   NULL);
+	if (fn == NULL)
+		return FALSE;
 	if (!fu_path_mkdir_parent(fn, error))
 		return FALSE;
 	ostream = fu_output_stream_from_path(fn, error);
@@ -455,7 +455,7 @@ fu_uefi_capsule_plugin_write_splash_data(FuUefiCapsulePlugin *self,
 
 	/* write display capsule location as UPDATE_INFO */
 	return fu_uefi_capsule_device_write_update_info(FU_UEFI_CAPSULE_DEVICE(device),
-							capsule_path,
+							fn,
 							"fwupd-ux-capsule",
 							FU_EFIVARS_GUID_UX_CAPSULE,
 							error);

--- a/plugins/uefi-capsule/fu-uefi-common.c
+++ b/plugins/uefi-capsule/fu-uefi-common.c
@@ -64,26 +64,20 @@ fu_uefi_bootmgr_get_suffix(FuPathStore *pstore, GError **error)
 	return NULL;
 }
 
-/* return without the ESP dir prepended */
 gchar *
-fu_uefi_get_esp_app_path(FuPathStore *pstore,
-			 const gchar *esp_path,
-			 const gchar *cmd,
-			 GError **error)
+fu_uefi_capsule_build_app_basename(FuPathStore *pstore, const gchar *cmd, GError **error)
 {
 	const gchar *suffix;
-	g_autofree gchar *base = NULL;
 
 	suffix = fu_uefi_bootmgr_get_suffix(pstore, error);
 	if (suffix == NULL)
 		return NULL;
-	base = fu_uefi_get_esp_path_for_os(esp_path);
-	return g_strdup_printf("%s/%s%s.efi", base, cmd, suffix);
+	return g_strdup_printf("%s%s.efi", cmd, suffix);
 }
 
 /**
  * fu_uefi_get_built_app_path:
- * @basename: the prefix for the binary
+ * @basename: the binary basename, e.g. `shimx64.efi`
  * @error: (nullable): optional return location for an error
  *
  * Gets the path intended to be used for an EFI binary on the local system.
@@ -97,28 +91,24 @@ fu_uefi_get_esp_app_path(FuPathStore *pstore,
 gchar *
 fu_uefi_get_built_app_path(FuPathStore *pstore,
 			   FuEfivars *efivars,
-			   const gchar *binary,
+			   const gchar *basename,
 			   GError **error)
 {
-	const gchar *suffix;
 	const gchar *prefix = NULL;
 	g_autofree gchar *source_path = NULL;
 	g_autofree gchar *source_path_signed = NULL;
+	g_autofree gchar *basename_signed = g_strdup_printf("%s.signed", basename);
 	gboolean secureboot_enabled = FALSE;
 	gboolean source_path_exists = FALSE;
 	gboolean source_path_signed_exists = FALSE;
 	g_autoptr(GError) error_local = NULL;
 
-	suffix = fu_uefi_bootmgr_get_suffix(pstore, error);
-	if (suffix == NULL)
-		return NULL;
 	prefix = fu_path_store_get_path(pstore, FU_PATH_KIND_EFIAPPDIR, error);
 	if (prefix == NULL)
 		return NULL;
 
-	source_path = g_strdup_printf("%s/%s%s.efi", prefix, binary, suffix);
-	source_path_signed = g_strdup_printf("%s.signed", source_path);
-
+	source_path = g_build_filename(prefix, basename, NULL);
+	source_path_signed = g_build_filename(prefix, basename_signed, NULL);
 	source_path_exists = g_file_test(source_path, G_FILE_TEST_EXISTS);
 	source_path_signed_exists = g_file_test(source_path_signed, G_FILE_TEST_EXISTS);
 
@@ -191,68 +181,6 @@ fu_uefi_get_framebuffer_size(FuPathStore *pstore, guint32 *width, guint32 *heigh
 	return TRUE;
 }
 
-/**
- * fu_uefi_get_esp_path_for_os:
- * @esp_base: The base path of the EFI System Partition (ESP).
- *
- * Retrieves the directory structure of the EFI System Partition (ESP) for
- * the operating system.
- *
- * This function constructs and returns the path of the directory to use
- * within the ESP based on the provided base path.
- *
- * Returns: (transfer full): A newly allocated string containing the directory
- * structure within the ESP for the operating system. The caller is
- * responsible for freeing the returned string.
- */
-gchar *
-fu_uefi_get_esp_path_for_os(const gchar *esp_base)
-{
-#ifndef EFI_OS_DIR
-	g_autofree gchar *os_release_id = NULL;
-	g_autofree gchar *id_like = NULL;
-	g_autofree gchar *esp_path = NULL;
-	g_autofree gchar *full_path = NULL;
-	g_autofree gchar *systemd_path = NULL;
-	g_autofree gchar *full_systemd_path = NULL;
-
-	/* distro (or user) is using systemd-boot */
-	systemd_path = g_build_filename("EFI", "systemd", NULL);
-	full_systemd_path = g_build_filename(esp_base, systemd_path, NULL);
-	if (g_file_test(full_systemd_path, G_FILE_TEST_IS_DIR))
-		return g_steal_pointer(&systemd_path);
-
-	/* try to lookup /etc/os-release ID key */
-	os_release_id = g_get_os_info(G_OS_INFO_KEY_ID);
-	if (os_release_id == NULL)
-		os_release_id = g_strdup("unknown");
-
-	/* if ID key points at something existing return it */
-	esp_path = g_build_filename("EFI", os_release_id, NULL);
-	full_path = g_build_filename(esp_base, esp_path, NULL);
-	if (g_file_test(full_path, G_FILE_TEST_IS_DIR))
-		return g_steal_pointer(&esp_path);
-
-	/* if ID key doesn't exist, try ID_LIKE */
-	id_like = g_get_os_info("ID_LIKE");
-	if (id_like != NULL) {
-		g_auto(GStrv) split = g_strsplit(id_like, " ", -1);
-		for (guint i = 0; split[i] != NULL; i++) {
-			g_autofree gchar *id_like_path = g_build_filename("EFI", split[i], NULL);
-			g_autofree gchar *id_like_full_path =
-			    g_build_filename(esp_base, id_like_path, NULL);
-			if (!g_file_test(id_like_full_path, G_FILE_TEST_IS_DIR))
-				continue;
-			g_debug("using ID_LIKE key from os-release");
-			return g_steal_pointer(&id_like_path);
-		}
-	}
-	return g_steal_pointer(&esp_path);
-#else
-	return g_build_filename("EFI", EFI_OS_DIR, NULL);
-#endif
-}
-
 guint64
 fu_uefi_read_file_as_uint64(const gchar *path, const gchar *attr_name)
 {
@@ -271,48 +199,33 @@ fu_uefi_read_file_as_uint64(const gchar *path, const gchar *attr_name)
 }
 
 gboolean
-fu_uefi_esp_target_verify(const gchar *source_fn, FuVolume *esp, const gchar *target_no_mountpoint)
+fu_uefi_esp_target_verify(const gchar *fn_src, const gchar *fn_dst)
 {
 	gsize len = 0;
 	g_autofree gchar *source_csum = NULL;
 	g_autofree gchar *source_data = NULL;
 	g_autofree gchar *target_csum = NULL;
 	g_autofree gchar *target_data = NULL;
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
-	g_autofree gchar *target_fn = g_build_filename(esp_path, target_no_mountpoint, NULL);
 
 	/* nothing in target yet */
-	if (!g_file_test(target_fn, G_FILE_TEST_EXISTS))
+	if (!g_file_test(fn_dst, G_FILE_TEST_EXISTS))
 		return FALSE;
 
 	/* test if the file needs to be updated */
-	if (!g_file_get_contents(source_fn, &source_data, &len, NULL))
+	if (!g_file_get_contents(fn_src, &source_data, &len, NULL))
 		return FALSE;
 	source_csum = g_compute_checksum_for_data(G_CHECKSUM_SHA256, (guchar *)source_data, len);
-	if (!g_file_get_contents(target_fn, &target_data, &len, NULL))
+	if (!g_file_get_contents(fn_dst, &target_data, &len, NULL))
 		return FALSE;
 	target_csum = g_compute_checksum_for_data(G_CHECKSUM_SHA256, (guchar *)target_data, len);
 	return g_strcmp0(target_csum, source_csum) == 0;
 }
 
 gboolean
-fu_uefi_esp_target_exists(FuVolume *esp, const gchar *target_no_mountpoint)
+fu_uefi_esp_target_copy(const gchar *fn_src, const gchar *fn_dst, GError **error)
 {
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
-	g_autofree gchar *target_fn = g_build_filename(esp_path, target_no_mountpoint, NULL);
-	return g_file_test(target_fn, G_FILE_TEST_EXISTS);
-}
-
-gboolean
-fu_uefi_esp_target_copy(const gchar *source_fn,
-			FuVolume *esp,
-			const gchar *target_no_mountpoint,
-			GError **error)
-{
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
-	g_autofree gchar *target_fn = g_build_filename(esp_path, target_no_mountpoint, NULL);
-	g_autoptr(GFile) source_file = g_file_new_for_path(source_fn);
-	g_autoptr(GFile) target_file = g_file_new_for_path(target_fn);
+	g_autoptr(GFile) source_file = g_file_new_for_path(fn_src);
+	g_autoptr(GFile) target_file = g_file_new_for_path(fn_dst);
 
 	if (!g_file_copy(source_file,
 			 target_file,
@@ -321,7 +234,7 @@ fu_uefi_esp_target_copy(const gchar *source_fn,
 			 NULL,
 			 NULL,
 			 error)) {
-		g_prefix_error(error, "failed to copy %s to %s: ", source_fn, target_fn);
+		g_prefix_error(error, "failed to copy %s to %s: ", fn_src, fn_dst);
 		return FALSE;
 	}
 

--- a/plugins/uefi-capsule/fu-uefi-common.h
+++ b/plugins/uefi-capsule/fu-uefi-common.h
@@ -16,24 +16,17 @@
 #define EFI_OS_INDICATIONS_FILE_CAPSULE_DELIVERY_SUPPORTED 0x0000000000000004ULL
 
 gchar *
-fu_uefi_get_esp_app_path(FuPathStore *pstore, const gchar *base, const gchar *cmd, GError **error);
+fu_uefi_capsule_build_app_basename(FuPathStore *pstore, const gchar *cmd, GError **error);
 gchar *
 fu_uefi_get_built_app_path(FuPathStore *pstore,
 			   FuEfivars *efivars,
-			   const gchar *binary,
+			   const gchar *basename,
 			   GError **error);
 gboolean
 fu_uefi_get_framebuffer_size(FuPathStore *pstore, guint32 *width, guint32 *height, GError **error);
-gchar *
-fu_uefi_get_esp_path_for_os(const gchar *base);
 guint64
 fu_uefi_read_file_as_uint64(const gchar *path, const gchar *attr_name);
 gboolean
-fu_uefi_esp_target_exists(FuVolume *esp, const gchar *target_no_mountpoint);
+fu_uefi_esp_target_verify(const gchar *fn_src, const gchar *fn_dst);
 gboolean
-fu_uefi_esp_target_verify(const gchar *source_fn, FuVolume *esp, const gchar *target_no_mountpoint);
-gboolean
-fu_uefi_esp_target_copy(const gchar *source_fn,
-			FuVolume *esp,
-			const gchar *target_no_mountpoint,
-			GError **error);
+fu_uefi_esp_target_copy(const gchar *fn_src, const gchar *fn_dst, GError **error);

--- a/plugins/uefi-capsule/fu-uefi-grub-device.c
+++ b/plugins/uefi-capsule/fu-uefi-grub-device.c
@@ -17,21 +17,37 @@ struct _FuUefiGrubDevice {
 G_DEFINE_TYPE(FuUefiGrubDevice, fu_uefi_grub_device, FU_TYPE_UEFI_CAPSULE_DEVICE)
 
 static gboolean
-fu_uefi_grub_device_mkconfig(FuUefiCapsuleDevice *self,
-			     const gchar *esp_path,
-			     const gchar *target_app,
-			     GError **error)
+fu_uefi_grub_device_mkconfig(FuUefiCapsuleDevice *self, const gchar *app_dst, GError **error)
 {
 	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
+	FuVolume *esp = fu_uefi_capsule_device_get_esp(self);
 	g_autofree gchar *fn_grub_cfg = NULL;
 	const gchar *argv_mkconfig[] = {"", "-o", "grub.cfg", NULL};
 	const gchar *argv_reboot[] = {"", "fwupd", NULL};
 	gboolean exists_mkconfig = FALSE;
+	g_autofree gchar *esp_path = NULL;
 	g_autofree gchar *grub_mkconfig = NULL;
 	g_autofree gchar *grub_reboot = NULL;
 	g_autofree gchar *grub_target = NULL;
 	g_autofree gchar *output = NULL;
 	g_autoptr(GString) str = g_string_new(NULL);
+
+	/* sanity check */
+	if (esp == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_FOUND,
+				    "could not find ESP volume");
+		return FALSE;
+	}
+	esp_path = fu_volume_get_mount_point(esp);
+	if (esp_path == NULL) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "could not determine ESP mount point");
+		return FALSE;
+	}
 
 	/* find grub.conf */
 	fn_grub_cfg = fu_context_build_filename(ctx,
@@ -92,7 +108,7 @@ fu_uefi_grub_device_mkconfig(FuUefiCapsuleDevice *self,
 	}
 
 	/* replace ESP info in conf with what we detected */
-	g_string_append_printf(str, "EFI_PATH=%s\n", target_app);
+	g_string_append_printf(str, "EFI_PATH=%s\n", app_dst);
 	g_string_replace(str, esp_path, "", 0);
 	g_string_append_printf(str, "ESP=%s\n", esp_path);
 	grub_target = fu_context_build_filename(ctx,
@@ -162,15 +178,12 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
 	FuPathStore *pstore = fu_context_get_path_store(ctx);
 	FuUefiCapsuleDevice *self = FU_UEFI_CAPSULE_DEVICE(device);
-	FuVolume *esp = fu_uefi_capsule_device_get_esp(self);
 	const gchar *fw_class = fu_uefi_capsule_device_get_guid(self);
 	g_autofree gchar *basename = NULL;
-	g_autofree gchar *capsule_path = NULL;
-	g_autofree gchar *directory = NULL;
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
 	g_autofree gchar *fn = NULL;
-	g_autofree gchar *source_app = NULL;
-	g_autofree gchar *target_app = NULL;
+	g_autofree gchar *app_basename = NULL;
+	g_autofree gchar *app_src = NULL;
+	g_autofree gchar *app_dst = NULL;
 	g_autofree gchar *varname = fu_uefi_capsule_device_build_varname(self);
 	g_autoptr(GBytes) fixed_fw = NULL;
 	g_autoptr(GBytes) fw = NULL;
@@ -190,10 +203,14 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* save the blob to the ESP */
-	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", fw_class);
-	capsule_path = g_build_filename(directory, "fw", basename, NULL);
-	fn = g_build_filename(esp_path, capsule_path, NULL);
+	fn = fu_uefi_capsule_device_build_efi_path(FU_UEFI_CAPSULE_DEVICE(device),
+						   error,
+						   "fw",
+						   basename,
+						   NULL);
+	if (fn == NULL)
+		return FALSE;
 	if (!fu_path_mkdir_parent(fn, error))
 		return FALSE;
 	fixed_fw = fu_uefi_capsule_device_fixup_firmware(self, fw, error);
@@ -216,25 +233,31 @@ fu_uefi_grub_device_write_firmware(FuDevice *device,
 	}
 
 	/* set the blob header shared with fwupd.efi */
-	if (!fu_uefi_capsule_device_write_update_info(self, capsule_path, varname, fw_class, error))
+	if (!fu_uefi_capsule_device_write_update_info(self, fn, varname, fw_class, error))
 		return FALSE;
 
 	/* if secure boot was turned on this might need to be installed separately */
-	source_app = fu_uefi_get_built_app_path(pstore, efivars, "fwupd", error);
-	if (source_app == NULL)
+	app_basename = fu_uefi_capsule_build_app_basename(pstore, "fwupd", error);
+	if (app_basename == NULL)
+		return FALSE;
+	app_src = fu_uefi_get_built_app_path(pstore, efivars, app_basename, error);
+	if (app_src == NULL)
+		return FALSE;
+	app_dst = fu_uefi_capsule_device_build_efi_path(FU_UEFI_CAPSULE_DEVICE(device),
+							error,
+							app_basename,
+							NULL);
+	if (app_dst == NULL)
 		return FALSE;
 
 	/* test if correct asset in place */
-	target_app = fu_uefi_get_esp_app_path(pstore, esp_path, "fwupd", error);
-	if (target_app == NULL)
-		return FALSE;
-	if (!fu_uefi_esp_target_verify(source_app, esp, target_app)) {
-		if (!fu_uefi_esp_target_copy(source_app, esp, target_app, error))
+	if (!fu_uefi_esp_target_verify(app_src, app_dst)) {
+		if (!fu_uefi_esp_target_copy(app_src, app_dst, error))
 			return FALSE;
 	}
 
 	/* we are using GRUB instead of NVRAM variables */
-	return fu_uefi_grub_device_mkconfig(self, esp_path, target_app, error);
+	return fu_uefi_grub_device_mkconfig(self, app_dst, error);
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-nvram-device.c
+++ b/plugins/uefi-capsule/fu-uefi-nvram-device.c
@@ -56,18 +56,12 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 {
 	FuContext *ctx = fu_device_get_context(device);
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
-	FuPathStore *pstore = fu_context_get_path_store(ctx);
 	FuUefiCapsuleDevice *self = FU_UEFI_CAPSULE_DEVICE(device);
-	FuUefiBootmgrFlags bootmgr_flags = FU_UEFI_BOOTMGR_FLAG_NONE;
 	const gchar *bootmgr_desc = "Linux Firmware Updater";
 	const gchar *fw_class = fu_uefi_capsule_device_get_guid(self);
-	FuVolume *esp = fu_uefi_capsule_device_get_esp(self);
-	g_autofree gchar *esp_path = fu_volume_get_mount_point(esp);
 	g_autoptr(GBytes) fixed_fw = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autofree gchar *capsule_path = NULL;
 	g_autofree gchar *basename = NULL;
-	g_autofree gchar *directory = NULL;
 	g_autofree gchar *fn = NULL;
 	g_autofree gchar *varname = fu_uefi_capsule_device_build_varname(self);
 
@@ -86,10 +80,14 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 		return FALSE;
 
 	/* save the blob to the ESP */
-	directory = fu_uefi_get_esp_path_for_os(esp_path);
 	basename = g_strdup_printf("fwupd-%s.cap", fw_class);
-	capsule_path = g_build_filename(directory, "fw", basename, NULL);
-	fn = g_build_filename(esp_path, capsule_path, NULL);
+	fn = fu_uefi_capsule_device_build_efi_path(FU_UEFI_CAPSULE_DEVICE(device),
+						   error,
+						   "fw",
+						   basename,
+						   NULL);
+	if (fn == NULL)
+		return FALSE;
 	if (!fu_path_mkdir_parent(fn, error))
 		return FALSE;
 	fixed_fw = fu_uefi_capsule_device_fixup_firmware(self, fw, error);
@@ -112,25 +110,17 @@ fu_uefi_nvram_device_write_firmware(FuDevice *device,
 	}
 
 	/* set the blob header shared with fwupd.efi */
-	if (!fu_uefi_capsule_device_write_update_info(self, capsule_path, varname, fw_class, error))
+	if (!fu_uefi_capsule_device_write_update_info(self, fn, varname, fw_class, error))
 		return FALSE;
 
 	/* if fwupd-efi is not in use, no need to change boot order or copy bootloader files */
 	if (!fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_USE_FWUPD_EFI))
 		return TRUE;
 
-	/* update the firmware before the bootloader runs */
-	if (fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_FOR_SB))
-		bootmgr_flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB;
-	if (fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_USE_SHIM_UNIQUE))
-		bootmgr_flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_UNIQUE;
-	if (fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_MODIFY_BOOTORDER))
-		bootmgr_flags |= FU_UEFI_BOOTMGR_FLAG_MODIFY_BOOTORDER;
-
 	/* some legacy devices use the old name to deduplicate boot entries */
 	if (fu_device_has_private_flag(device, FU_UEFI_CAPSULE_DEVICE_FLAG_USE_LEGACY_BOOTMGR_DESC))
 		bootmgr_desc = "Linux-Firmware-Updater";
-	if (!fu_uefi_bootmgr_bootnext(pstore, efivars, esp, bootmgr_desc, bootmgr_flags, error))
+	if (!fu_uefi_bootmgr_bootnext(self, bootmgr_desc, error))
 		return FALSE;
 
 	/* success! */


### PR DESCRIPTION
This also removes the unused `Flags=use-shim-unique` to simplify the code.

Fixes https://github.com/fwupd/fwupd/issues/9249

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
