### PR TITLE
elantp: Match each HID device VID+PID explicitly

### DIFF
--- a/plugins/elantp/elantp.quirk
+++ b/plugins/elantp/elantp.quirk
@@ -1,4 +1,9 @@
-[HIDRAW\VEN_04F3]
+# i2c-hid
+[HIDRAW\VEN_04F3&DEV_0400]
+Plugin = elantp
+GType = FuElantpHidDevice
+
+[HIDRAW\VEN_04F3&DEV_3010]
 Plugin = elantp
 GType = FuElantpHidDevice
 
@@ -7,6 +12,9 @@ GType = FuElantpHidDevice
 Flags = elantp-recovery
 
 # Lenovo X1 Nano Gen1
+[HIDRAW\VEN_04F3&DEV_314F]
+Plugin = elantp
+GType = FuElantpHidDevice
 [4c20262a-aee0-5d6e-ba72-6d29b23fe350]
 Flags = elantp-recovery
 

--- a/plugins/elantp/fu-elantp-hid-device.c
+++ b/plugins/elantp/fu-elantp-hid-device.c
@@ -45,34 +45,6 @@ fu_elantp_hid_device_to_string(FuDevice *device, guint idt, GString *str)
 }
 
 static gboolean
-fu_elantp_hid_device_probe(FuDevice *device, GError **error)
-{
-	guint16 device_id = fu_device_get_pid(device);
-
-	/* check is valid */
-	if (g_strcmp0(fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)), "hidraw") != 0) {
-		g_set_error(error,
-			    FWUPD_ERROR,
-			    FWUPD_ERROR_NOT_SUPPORTED,
-			    "is not correct subsystem=%s, expected hidraw",
-			    fu_udev_device_get_subsystem(FU_UDEV_DEVICE(device)));
-		return FALSE;
-	}
-
-	/* i2c-hid */
-	if (device_id != 0x400 && (device_id < 0x3000 || device_id >= 0x4000)) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_SUPPORTED,
-				    "not i2c-hid touchpad");
-		return FALSE;
-	}
-
-	/* success */
-	return TRUE;
-}
-
-static gboolean
 fu_elantp_hid_device_send_cmd(FuElantpHidDevice *self,
 			      guint8 *tx,
 			      gsize txsz,
@@ -996,7 +968,6 @@ fu_elantp_hid_device_class_init(FuElantpHidDeviceClass *klass)
 	device_class->reload = fu_elantp_hid_device_setup;
 	device_class->write_firmware = fu_elantp_hid_device_write_firmware;
 	device_class->check_firmware = fu_elantp_hid_device_check_firmware;
-	device_class->probe = fu_elantp_hid_device_probe;
 	device_class->set_progress = fu_elantp_hid_device_set_progress;
 	device_class->convert_version = fu_elantp_hid_device_convert_version;
 }


### PR DESCRIPTION
The 'wildcard' PID range vendor match becomes very unhelpful when we're adding new hardware support in the future.

We also wouldn't allow a vendor quirk match for new plugins.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
