### PR TITLE
contrib/setup: Only use bash completions for bash-compatibles

### DIFF
--- a/contrib/setup
+++ b/contrib/setup
@@ -105,8 +105,11 @@ echo ""
 echo "To leave fwupd development environment run:"
 echo ""
 echo "# deactivate"
-. data/bash-completion/fwupdtool
-. data/bash-completion/fwupdmgr
+
+if [ -n "\$BASH_VERSION" ]; then
+    . data/bash-completion/fwupdtool
+    . data/bash-completion/fwupdmgr
+fi
 export MANPATH=./venv/dist/share/man:
 EOF
 }


### PR DESCRIPTION
Running venv/bin/activate on e.g. zsh causes an error because the "complete" command used by the bash-completion doesn't exist.

We could use `$SHELL` but that's the login shell only, checking for `$BASH_VERSION` seems to be the reliable option of verifying we're on bash.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
