### PR TITLE
Do not allow efivar update without TIME_BASED_AUTHENTICATED_WRITE_ACCESS

### DIFF
--- a/libfwupdplugin/fu-efivars.c
+++ b/libfwupdplugin/fu-efivars.c
@@ -199,6 +199,41 @@ fu_efivars_get_data(FuEfivars *self,
 }
 
 /**
+ * fu_efivars_get_attrs:
+ * @self: a #FuEfivars
+ * @guid: Globally unique identifier
+ * @name: Variable name
+ * @attrs: (nullable) (out): #FuEfiVariableAttrs, e.g. %FU_EFI_VARIABLE_ATTR_NON_VOLATILE
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the attributes from a UEFI variable in NVRAM
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 2.1.1
+ **/
+gboolean
+fu_efivars_get_attrs(FuEfivars *self,
+		     const gchar *guid,
+		     const gchar *name,
+		     FuEfiVariableAttrs *attrs,
+		     GError **error)
+{
+	FuEfivarsClass *efivars_class = FU_EFIVARS_GET_CLASS(self);
+
+	g_return_val_if_fail(FU_IS_EFIVARS(self), FALSE);
+	g_return_val_if_fail(guid != NULL, FALSE);
+	g_return_val_if_fail(name != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (efivars_class->get_data == NULL) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "not supported");
+		return FALSE;
+	}
+	return efivars_class->get_data(self, guid, name, NULL, NULL, attrs, error);
+}
+
+/**
  * fu_efivars_get_data_bytes:
  * @self: a #FuEfivars
  * @guid: Globally unique identifier

--- a/libfwupdplugin/fu-efivars.h
+++ b/libfwupdplugin/fu-efivars.h
@@ -79,6 +79,12 @@ fu_efivars_get_data(FuEfivars *self,
 		    gsize *data_sz,
 		    FuEfiVariableAttrs *attr,
 		    GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
+gboolean
+fu_efivars_get_attrs(FuEfivars *self,
+		     const gchar *guid,
+		     const gchar *name,
+		     FuEfiVariableAttrs *attrs,
+		     GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
 GBytes *
 fu_efivars_get_data_bytes(FuEfivars *self,
 			  const gchar *guid,

--- a/libfwupdplugin/fu-uefi-device-private.h
+++ b/libfwupdplugin/fu-uefi-device-private.h
@@ -9,7 +9,7 @@
 #include "fu-uefi-device.h"
 
 FuUefiDevice *
-fu_uefi_device_new(const gchar *guid, const gchar *name) G_GNUC_NON_NULL(1, 2);
+fu_uefi_device_new(FuContext *ctx, const gchar *guid, const gchar *name) G_GNUC_NON_NULL(1, 2, 3);
 void
 fu_uefi_device_set_guid(FuUefiDevice *self, const gchar *guid) G_GNUC_NON_NULL(1);
 const gchar *

--- a/libfwupdplugin/fu-uefi-device-test.c
+++ b/libfwupdplugin/fu-uefi-device-test.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-context-private.h"
+#include "fu-uefi-device-private.h"
+
+static void
+fu_uefi_device_auth_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS | FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuUefiDevice) uefi_device = NULL;
+	g_autoptr(GError) error = NULL;
+	const guint8 buf[] = {0xFF};
+
+	ret = fu_efivars_set_data(fu_context_get_efivars(ctx),
+				  FU_EFIVARS_GUID_EFI_GLOBAL,
+				  "db",
+				  buf,
+				  sizeof(buf),
+				  FU_EFI_VARIABLE_ATTR_RUNTIME_ACCESS |
+				      FU_EFI_VARIABLE_ATTR_BOOTSERVICE_ACCESS |
+				      FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+				      FU_EFI_VARIABLE_ATTR_TIME_BASED_AUTHENTICATED_WRITE_ACCESS,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	uefi_device = fu_uefi_device_new(ctx, FU_EFIVARS_GUID_EFI_GLOBAL, "db");
+	ret = fu_device_probe(FU_DEVICE(uefi_device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_false(
+	    fu_device_has_problem(FU_DEVICE(uefi_device), FWUPD_DEVICE_PROBLEM_INSECURE_PLATFORM));
+}
+
+static void
+fu_uefi_device_no_auth_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS | FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuUefiDevice) uefi_device = NULL;
+	g_autoptr(GError) error = NULL;
+	const guint8 buf[] = {0xFF};
+
+	ret = fu_efivars_set_data(fu_context_get_efivars(ctx),
+				  FU_EFIVARS_GUID_EFI_GLOBAL,
+				  "db",
+				  buf,
+				  sizeof(buf),
+				  FU_EFI_VARIABLE_ATTR_RUNTIME_ACCESS |
+				      FU_EFI_VARIABLE_ATTR_BOOTSERVICE_ACCESS |
+				      FU_EFI_VARIABLE_ATTR_NON_VOLATILE,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	uefi_device = fu_uefi_device_new(ctx, FU_EFIVARS_GUID_EFI_GLOBAL, "db");
+	ret = fu_device_probe(FU_DEVICE(uefi_device), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(
+	    fu_device_has_problem(FU_DEVICE(uefi_device), FWUPD_DEVICE_PROBLEM_INSECURE_PLATFORM));
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/uefi-device/auth", fu_uefi_device_auth_func);
+	g_test_add_func("/fwupd/uefi-device/no-auth", fu_uefi_device_no_auth_func);
+	return g_test_run();
+}

--- a/libfwupdplugin/fu-uefi-device.c
+++ b/libfwupdplugin/fu-uefi-device.c
@@ -244,8 +244,41 @@ fu_uefi_device_incorporate(FuDevice *device, FuDevice *donor)
 }
 
 static gboolean
+fu_uefi_device_check_attrs(FuUefiDevice *self, GError **error)
+{
+	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
+	FuEfiVariableAttrs attrs = 0;
+	FuUefiDevicePrivate *priv = GET_PRIVATE(self);
+
+	/* sanity check */
+	if (fu_device_has_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_EMULATED) &&
+	    !fu_device_check_fwupd_version(FU_DEVICE(self), "2.1.1"))
+		return TRUE;
+	if (priv->guid == NULL || priv->name == NULL)
+		return TRUE;
+
+	/* if variables has been set up incorrectly do not allow update */
+	if (!fu_efivars_get_attrs(fu_context_get_efivars(ctx),
+				  priv->guid,
+				  priv->name,
+				  &attrs,
+				  error))
+		return FALSE;
+	if ((attrs & FU_EFI_VARIABLE_ATTR_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) == 0)
+		fu_device_add_problem(FU_DEVICE(self), FWUPD_DEVICE_PROBLEM_INSECURE_PLATFORM);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_uefi_device_probe(FuDevice *device, GError **error)
 {
+	FuUefiDevice *self = FU_UEFI_DEVICE(device);
+
+	/* verify that the EFI variable is secure */
+	if (!fu_uefi_device_check_attrs(self, error))
+		return FALSE;
 	return fu_device_build_instance_id_full(device,
 						FU_DEVICE_INSTANCE_FLAG_QUIRKS,
 						NULL,
@@ -390,13 +423,17 @@ fu_uefi_device_class_init(FuUefiDeviceClass *klass)
 }
 
 FuUefiDevice *
-fu_uefi_device_new(const gchar *guid, const gchar *name)
+fu_uefi_device_new(FuContext *ctx, const gchar *guid, const gchar *name)
 {
 	g_autofree gchar *backend_id = NULL;
 	g_autoptr(FuUefiDevice) self = NULL;
 
+	g_return_val_if_fail(FU_IS_CONTEXT(ctx), NULL);
+	g_return_val_if_fail(guid != NULL, NULL);
+	g_return_val_if_fail(name != NULL, NULL);
+
 	backend_id = g_strdup_printf("%s-%s", guid, name);
-	self = g_object_new(FU_TYPE_UEFI_DEVICE, "backend-id", backend_id, NULL);
+	self = g_object_new(FU_TYPE_UEFI_DEVICE, "context", ctx, "backend-id", backend_id, NULL);
 	fu_uefi_device_set_guid(self, guid);
 	fu_uefi_device_set_name(self, name);
 	return g_steal_pointer(&self);

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -544,6 +544,7 @@ if get_option('tests')
     'struct',
     'temporary-directory',
     'tpm-eventlog',
+    'uefi-device',
     'udev-device',
     'version',
     'volume',

--- a/src/fu-uefi-backend.c
+++ b/src/fu-uefi-backend.c
@@ -43,7 +43,7 @@ fu_uefi_backend_coldplug(FuBackend *backend, FuProgress *progress, GError **erro
 			fu_progress_step_done(progress);
 			continue;
 		}
-		uefi_device = fu_uefi_device_new(guid_names[i].guid, guid_names[i].name);
+		uefi_device = fu_uefi_device_new(ctx, guid_names[i].guid, guid_names[i].name);
 		fu_backend_device_added(backend, FU_DEVICE(uefi_device));
 		fu_progress_step_done(progress);
 	}


### PR DESCRIPTION
If the KEK, db or dbx variables has been set up incorrectly do not allow update and show a console problem; the update won't work anyway.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
