### PR TITLE
pixarttp: Add support for the 239 device

### DIFF
--- a/plugins/pixart-tp/README.md
+++ b/plugins/pixart-tp/README.md
@@ -29,6 +29,10 @@ These devices use the standard HID DeviceInstanceId values, e.g.
 
 - `HIDRAW\VEN_093A&DEV_0343`
 
+Additionally, the plugin reads the internal Part ID from the device to generate a custom, quirk-specific instance ID. This allows for targeting quirks to specific silicon regardless of the USB/HID PID:
+
+- `PIXARTTP\PARTID_0274`
+
 > Note: If the same silicon enumerates as a USB interface on some systems,
 > an additional USB GUID like `USB\VID_093A&PID_0343` may also be provided
 > in the firmware metadata. GUIDs derived from hardware IDs are **stable

--- a/plugins/pixart-tp/fu-pixart-tp-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-device.c
@@ -12,15 +12,17 @@
 #include "fu-pixart-tp-haptic-device.h"
 #include "fu-pixart-tp-section.h"
 
-struct _FuPixartTpDevice {
-	FuHidrawDevice parent_instance;
+typedef struct {
 	guint8 sram_select;
 	guint8 ver_bank;
 	guint16 ver_addr;
+	guint16 part_id;
 	gboolean has_tf_child;
-};
+} FuPixartTpDevicePrivate;
 
-G_DEFINE_TYPE(FuPixartTpDevice, fu_pixart_tp_device, FU_TYPE_HIDRAW_DEVICE)
+G_DEFINE_TYPE_WITH_PRIVATE(FuPixartTpDevice, fu_pixart_tp_device, FU_TYPE_HIDRAW_DEVICE)
+
+#define GET_PRIVATE(o) (fu_pixart_tp_device_get_instance_private(o))
 
 #define FU_PIXART_TP_DEVICE_SECTOR_SIZE 4096
 #define FU_PIXART_TP_DEVICE_PAGE_SIZE	256
@@ -29,10 +31,12 @@ static void
 fu_pixart_tp_device_to_string(FuDevice *device, guint idt, GString *str)
 {
 	FuPixartTpDevice *self = FU_PIXART_TP_DEVICE(device);
-	fwupd_codec_string_append_hex(str, idt, "SramSelect", self->sram_select);
-	fwupd_codec_string_append_hex(str, idt, "VerBank", self->ver_bank);
-	fwupd_codec_string_append_hex(str, idt, "VerAddr", self->ver_addr);
-	fwupd_codec_string_append_bool(str, idt, "HasTfChild", self->has_tf_child);
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
+
+	fwupd_codec_string_append_hex(str, idt, "SramSelect", priv->sram_select);
+	fwupd_codec_string_append_hex(str, idt, "VerBank", priv->ver_bank);
+	fwupd_codec_string_append_hex(str, idt, "VerAddr", priv->ver_addr);
+	fwupd_codec_string_append_bool(str, idt, "HasTfChild", priv->has_tf_child);
 }
 
 #define REPORT_ID_SINGLE 0x42
@@ -41,7 +45,7 @@ fu_pixart_tp_device_to_string(FuDevice *device, guint idt, GString *str)
 
 #define OP_READ 0x10
 
-static gboolean
+gboolean
 fu_pixart_tp_device_register_write(FuPixartTpDevice *self,
 				   FuPixartTpSystemBank bank,
 				   guint8 addr,
@@ -67,7 +71,79 @@ fu_pixart_tp_device_register_write(FuPixartTpDevice *self,
 	return TRUE;
 }
 
-static gboolean
+gboolean
+fu_pixart_tp_device_register_write_uint16(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint16 val,
+					  GError **error)
+{
+	guint8 buf[2] = {0};
+
+	/* prepare little-endian buffer */
+	fu_memwrite_uint16(buf, val, G_LITTLE_ENDIAN);
+
+	for (guint i = 0; i < sizeof(buf); i++) {
+		if (!fu_pixart_tp_device_register_write(self,
+							bank,
+							(guint8)(addr + i),
+							buf[i],
+							error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean
+fu_pixart_tp_device_register_write_uint24(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint32 val,
+					  GError **error)
+{
+	guint8 buf[3] = {0};
+
+	/* prepare little-endian buffer */
+	fu_memwrite_uint24(buf, val, G_LITTLE_ENDIAN);
+
+	for (guint i = 0; i < sizeof(buf); i++) {
+		if (!fu_pixart_tp_device_register_write(self,
+							bank,
+							(guint8)(addr + i),
+							buf[i],
+							error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean
+fu_pixart_tp_device_register_write_uint32(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint32 val,
+					  GError **error)
+{
+	guint8 buf[4] = {0};
+
+	/* prepare little-endian buffer */
+	fu_memwrite_uint32(buf, val, G_LITTLE_ENDIAN);
+
+	for (guint i = 0; i < sizeof(buf); i++) {
+		if (!fu_pixart_tp_device_register_write(self,
+							bank,
+							(guint8)(addr + i),
+							buf[i],
+							error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean
 fu_pixart_tp_device_register_read(FuPixartTpDevice *self,
 				  FuPixartTpSystemBank bank,
 				  guint8 addr,
@@ -89,6 +165,8 @@ fu_pixart_tp_device_register_read(FuPixartTpDevice *self,
 		return FALSE;
 	}
 
+	fu_device_sleep(FU_DEVICE(self), 10);
+
 	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),
 					  resp,
 					  sizeof(resp),
@@ -104,6 +182,31 @@ fu_pixart_tp_device_register_read(FuPixartTpDevice *self,
 	/* success */
 	*out_val = resp[3];
 	return TRUE;
+}
+
+GByteArray *
+fu_pixart_tp_device_register_read_array(FuPixartTpDevice *self,
+					FuPixartTpSystemBank bank,
+					guint8 addr,
+					gsize len,
+					GError **error)
+{
+	g_autoptr(GByteArray) array = g_byte_array_sized_new(len);
+
+	for (gsize i = 0; i < len; i++) {
+		guint8 val = 0;
+		if (!fu_pixart_tp_device_register_read(self,
+						       bank,
+						       (guint8)(addr + i),
+						       &val,
+						       error)) {
+			g_prefix_error(error, "failed to read array at index %u: ", (guint)i);
+			return NULL;
+		}
+		g_byte_array_append(array, &val, 1);
+	}
+
+	return g_steal_pointer(&array);
 }
 
 gboolean
@@ -153,6 +256,9 @@ fu_pixart_tp_device_register_user_read(FuPixartTpDevice *self,
 			       addr);
 		return FALSE;
 	}
+
+	fu_device_sleep(FU_DEVICE(self), 10);
+
 	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),
 					  resp,
 					  sizeof(resp),
@@ -170,32 +276,125 @@ fu_pixart_tp_device_register_user_read(FuPixartTpDevice *self,
 	return TRUE;
 }
 
-static gboolean
+static GByteArray *
+fu_pixart_tp_device_register_user_read_array(FuPixartTpDevice *self,
+					     FuPixartTpUserBank bank,
+					     guint8 addr,
+					     gsize len,
+					     GError **error)
+{
+	g_autoptr(GByteArray) array = g_byte_array_sized_new(len);
+
+	for (gsize i = 0; i < len; i++) {
+		guint8 val = 0;
+		/* assume the device supports address auto-increment or sequential reading */
+		if (!fu_pixart_tp_device_register_user_read(self,
+							    bank,
+							    (guint8)(addr + i),
+							    &val,
+							    error)) {
+			g_prefix_error(error, "failed to read user array at index %u: ", (guint)i);
+			return NULL;
+		}
+		g_byte_array_append(array, &val, 1);
+	}
+
+	return g_steal_pointer(&array);
+}
+
+gboolean
 fu_pixart_tp_device_register_burst_write(FuPixartTpDevice *self,
 					 const guint8 *buf,
 					 gsize bufsz,
 					 GError **error)
 {
-	guint8 payload[257] = {REPORT_ID_BURST};
+	g_autoptr(GPtrArray) chunks = NULL;
 
-	if (!fu_memcpy_safe(payload,
-			    sizeof(payload),
-			    1, /* dst offset: payload[1..] */
-			    buf,
-			    bufsz,
-			    0, /* src offset: buf[0..] */
-			    bufsz,
-			    error)) {
-		g_prefix_error_literal(error, "burst write memcpy failed: ");
+	/* split the data, max 256 bytes per chunk */
+	chunks = fu_chunk_array_new(buf, bufsz, 0x0, 0x0, 256);
+	if (chunks == NULL)
 		return FALSE;
+
+	/* send each chunk sequentially */
+	for (guint i = 0; i < chunks->len; i++) {
+		FuChunk *chk = g_ptr_array_index(chunks, i);
+		gsize chunk_sz = 0;
+		const guint8 *chunk_data = g_bytes_get_data(fu_chunk_get_bytes(chk), &chunk_sz);
+
+		/* initialize payload with zeros */
+		guint8 payload[257] = {0};
+		payload[0] = REPORT_ID_BURST;
+
+		/* safely copy chunk data to payload */
+		if (!fu_memcpy_safe(payload,
+				    sizeof(payload),
+				    1, /* dst offset: start from payload[1] */
+				    chunk_data,
+				    chunk_sz,
+				    0, /* src offset */
+				    chunk_sz,
+				    error)) {
+			g_prefix_error_literal(error, "burst write memcpy failed: ");
+			return FALSE;
+		}
+
+		/* send this 257 bytes feature report */
+		if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
+						  payload,
+						  sizeof(payload),
+						  FU_IOCTL_FLAG_NONE,
+						  error)) {
+			g_prefix_error_literal(error, "burst write feature report failed: ");
+			return FALSE;
+		}
 	}
-	if (!fu_hidraw_device_set_feature(FU_HIDRAW_DEVICE(self),
-					  payload,
-					  sizeof(payload),
-					  FU_IOCTL_FLAG_NONE,
-					  error)) {
-		g_prefix_error_literal(error, "burst write feature report failed: ");
-		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+gboolean
+fu_pixart_tp_device_register_burst_read(FuPixartTpDevice *self,
+					guint8 *buf,
+					gsize bufsz,
+					GError **error)
+{
+	gsize offset = 0;
+
+	/* loop until all requested data is read into buf */
+	while (offset < bufsz) {
+		/* calculate chunk size, maximum 256 bytes per payload */
+		gsize chunk_sz = MIN(bufsz - offset, 256);
+
+		/* init payload buffer with report id for get_feature */
+		guint8 payload[257] = {0};
+		payload[0] = REPORT_ID_BURST;
+
+		/* request this 257 bytes feature report */
+		if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),
+						  payload,
+						  sizeof(payload),
+						  FU_IOCTL_FLAG_NONE,
+						  error)) {
+			g_prefix_error_literal(error, "burst read feature report failed: ");
+			return FALSE;
+		}
+
+		/* copy read data from payload to the target buffer */
+		if (!fu_memcpy_safe(buf,
+				    bufsz,
+				    offset, /* dst offset: advance with loop */
+				    payload,
+				    sizeof(payload),
+				    1, /* src offset: skip report id at payload[0] */
+				    chunk_sz,
+				    error)) {
+			g_prefix_error_literal(error, "burst read memcpy failed: ");
+			return FALSE;
+		}
+
+		/* advance offset for the next chunk */
+		offset += chunk_sz;
 	}
 
 	/* success */
@@ -222,7 +421,6 @@ fu_pixart_tp_device_reset(FuPixartTpDevice *self, FuPixartTpResetMode mode, GErr
 						error))
 		return FALSE;
 	fu_device_sleep(FU_DEVICE(self), mode == FU_PIXART_TP_RESET_MODE_APPLICATION ? 500 : 10);
-
 	/* success */
 	return TRUE;
 }
@@ -262,50 +460,31 @@ fu_pixart_tp_device_flash_execute(FuPixartTpDevice *self,
 {
 	guint8 out_val = 0;
 
+	/* set instruction command */
 	if (!fu_pixart_tp_device_register_write(self,
 						FU_PIXART_TP_SYSTEM_BANK_BANK4,
 						FU_PIXART_TP_REG_SYS4_FLASH_INST_CMD,
 						inst_cmd,
 						error))
 		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_CCR0,
-						(guint8)((ccr_cmd >> 0) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_CCR1,
-						(guint8)((ccr_cmd >> 8) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_CCR2,
-						(guint8)((ccr_cmd >> 16) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_CCR3,
-						(guint8)((ccr_cmd >> 24) & 0xff),
-						error))
+
+	/* set ccr command */
+	if (!fu_pixart_tp_device_register_write_uint32(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_FLASH_CCR,
+						       ccr_cmd,
+						       error))
 		return FALSE;
 
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_DATA_CNT0,
-						(guint8)((data_cnt >> 0) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_DATA_CNT1,
-						(guint8)((data_cnt >> 8) & 0xff),
-						error))
+	/* set data count */
+	if (!fu_pixart_tp_device_register_write_uint16(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_FLASH_DATA_CNT,
+						       data_cnt,
+						       error))
 		return FALSE;
 
+	/* start flash execution */
 	if (!fu_pixart_tp_device_register_write(self,
 						FU_PIXART_TP_SYSTEM_BANK_BANK4,
 						FU_PIXART_TP_REG_SYS4_FLASH_EXECUTE,
@@ -313,6 +492,7 @@ fu_pixart_tp_device_flash_execute(FuPixartTpDevice *self,
 						error))
 		return FALSE;
 
+	/* wait for execution to complete */
 	if (!fu_device_retry_full(FU_DEVICE(self),
 				  fu_pixart_tp_device_flash_execute_wait_cb,
 				  10,
@@ -420,7 +600,7 @@ fu_pixart_tp_device_flash_wait_busy_cb(FuDevice *device, gpointer user_data, GEr
 		return FALSE;
 
 	/* busy bit cleared? */
-	if ((*out_val & FU_PIXART_TP_FLASH_STATUS_BUSY) != 0) {
+	if ((*out_val & FU_PIXART_TP_FLASH_WRITE_ENABLE_BUSY) != 0) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "flash still busy");
 		return FALSE;
 	}
@@ -453,37 +633,23 @@ fu_pixart_tp_device_flash_erase_sector(FuPixartTpDevice *self, guint8 sector, GE
 {
 	guint32 flash_address = (guint32)sector * FU_PIXART_TP_DEVICE_SECTOR_SIZE;
 
+	/* wait for flash ready and enable write */
 	if (!fu_pixart_tp_device_flash_wait_busy(self, error))
 		return FALSE;
 	if (!fu_pixart_tp_device_flash_write_enable(self, error))
 		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR0,
-						(guint8)((flash_address >> 0) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR1,
-						(guint8)((flash_address >> 8) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR2,
-						(guint8)((flash_address >> 16) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR3,
-						(guint8)((flash_address >> 24) & 0xff),
-						error))
+
+	/* set flash address */
+	if (!fu_pixart_tp_device_register_write_uint32(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_FLASH_ADDR,
+						       flash_address,
+						       error))
 		return FALSE;
 
 	g_debug("erase sector %u (addr=0x%08x)", (guint)sector, flash_address);
 
+	/* execute erase command */
 	if (!fu_pixart_tp_device_flash_execute(self,
 					       FU_PIXART_TP_FLASH_INST_NONE,
 					       FU_PIXART_TP_FLASH_CCR_ERASE_SECTOR,
@@ -504,48 +670,29 @@ fu_pixart_tp_device_flash_program_256b_to_flash(FuPixartTpDevice *self,
 	guint32 flash_address = (guint32)sector * FU_PIXART_TP_DEVICE_SECTOR_SIZE +
 				(guint32)page * FU_PIXART_TP_DEVICE_PAGE_SIZE;
 
+	/* wait for flash ready and enable write */
 	if (!fu_pixart_tp_device_flash_wait_busy(self, error))
 		return FALSE;
 	if (!fu_pixart_tp_device_flash_write_enable(self, error))
 		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_BUF_ADDR0,
-						0x00,
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_BUF_ADDR1,
-						0x00,
-						error))
+
+	/* set internal sram buffer address (usually 0x0000) */
+	if (!fu_pixart_tp_device_register_write_uint16(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_FLASH_BUF_ADDR,
+						       0x0000,
+						       error))
 		return FALSE;
 
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR0,
-						(guint8)((flash_address >> 0) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR1,
-						(guint8)((flash_address >> 8) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR2,
-						(guint8)((flash_address >> 16) & 0xff),
-						error))
-		return FALSE;
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK4,
-						FU_PIXART_TP_REG_SYS4_FLASH_ADDR3,
-						(guint8)((flash_address >> 24) & 0xff),
-						error))
+	/* set target flash address */
+	if (!fu_pixart_tp_device_register_write_uint32(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_FLASH_ADDR,
+						       flash_address,
+						       error))
 		return FALSE;
 
+	/* execute page program from sram to flash */
 	if (!fu_pixart_tp_device_flash_execute(self,
 					       FU_PIXART_TP_FLASH_INST_PROGRAM |
 						   FU_PIXART_TP_FLASH_INST_INTERNAL_SRAM_ACCESS,
@@ -563,6 +710,7 @@ fu_pixart_tp_device_flash_program_256b_to_flash(FuPixartTpDevice *self,
 static gboolean
 fu_pixart_tp_device_write_sram_256b(FuPixartTpDevice *self, const guint8 *data, GError **error)
 {
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
 	enum {
 		/*
 		 * SRAM_TRIGGER (bank6)
@@ -573,24 +721,18 @@ fu_pixart_tp_device_write_sram_256b(FuPixartTpDevice *self, const guint8 *data, 
 		PIXART_TP_SRAM_TRIGGER_NCS_DISABLE = 0x01,
 	};
 
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK6,
-						FU_PIXART_TP_REG_SYS6_SRAM_ADDR0,
-						0x00,
-						error))
-		return FALSE;
-
-	if (!fu_pixart_tp_device_register_write(self,
-						FU_PIXART_TP_SYSTEM_BANK_BANK6,
-						FU_PIXART_TP_REG_SYS6_SRAM_ADDR1,
-						0x00,
-						error))
+	/* set sram address (usually 0x0000) */
+	if (!fu_pixart_tp_device_register_write_uint16(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						       FU_PIXART_TP_REG_SYS6_SRAM_ADDR,
+						       0x0000,
+						       error))
 		return FALSE;
 
 	if (!fu_pixart_tp_device_register_write(self,
 						FU_PIXART_TP_SYSTEM_BANK_BANK6,
 						FU_PIXART_TP_REG_SYS6_SRAM_SELECT,
-						self->sram_select,
+						priv->sram_select,
 						error))
 		return FALSE;
 
@@ -637,6 +779,7 @@ fu_pixart_tp_device_firmware_clear(FuPixartTpDevice *self,
 		return FALSE;
 	start_address = fu_pixart_tp_section_get_target_flash_start(section);
 	g_debug("clear firmware at start address 0x%08x", start_address);
+
 	if (!fu_pixart_tp_device_flash_erase_sector(
 		self,
 		(guint8)(start_address / FU_PIXART_TP_DEVICE_SECTOR_SIZE),
@@ -678,75 +821,35 @@ fu_pixart_tp_device_crc_firmware_wait_cb(FuDevice *device, gpointer user_data, G
 static gboolean
 fu_pixart_tp_device_crc_firmware(FuPixartTpDevice *self, guint32 *crc, GError **error)
 {
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 out_val = 0;
-	guint8 swap_flag = 0;
-	guint16 part_id = 0;
-	guint32 return_value = 0;
-
-	g_return_val_if_fail(crc != NULL, FALSE);
+	guint8 crc_ctrl = FU_PIXART_TP_CRC_CTRL_FW_BANK0;
+	g_autoptr(GByteArray) buf = NULL;
 	*crc = 0;
 
-	/* read swap_flag from system bank4 */
-	if (!fu_pixart_tp_device_register_read(self,
-					       FU_PIXART_TP_SYSTEM_BANK_BANK4,
-					       FU_PIXART_TP_REG_SYS4_SWAP_FLAG,
-					       &out_val,
-					       error))
-		return FALSE;
-	swap_flag = out_val;
-
-	/* read part_id from user bank0 (little-endian) */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_PART_ID0,
-						    &out_val,
-						    error))
-		return FALSE;
-	part_id = out_val;
-
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_PART_ID1,
-						    &out_val,
-						    error))
-		return FALSE;
-	part_id |= (guint16)out_val << 8;
-
-	switch (part_id) {
-	case FU_PIXART_TP_PART_ID_PJP274:
-		if (swap_flag != 0) {
-			/* PJP274 + swap enabled → firmware on bank1 */
-			if (!fu_pixart_tp_device_register_user_write(
-				self,
-				FU_PIXART_TP_USER_BANK_BANK0,
-				FU_PIXART_TP_REG_USER0_CRC_CTRL,
-				FU_PIXART_TP_CRC_CTRL_FW_BANK1,
-				error))
-				return FALSE;
-		} else {
-			/* PJP274 normal boot → firmware on bank0 */
-			if (!fu_pixart_tp_device_register_user_write(
-				self,
-				FU_PIXART_TP_USER_BANK_BANK0,
-				FU_PIXART_TP_REG_USER0_CRC_CTRL,
-				FU_PIXART_TP_CRC_CTRL_FW_BANK0,
-				error))
-				return FALSE;
-		}
-		break;
-
-	default:
-		/* other part_id: always use bank0 firmware CRC */
-		if (!fu_pixart_tp_device_register_user_write(self,
-							     FU_PIXART_TP_USER_BANK_BANK0,
-							     FU_PIXART_TP_REG_USER0_CRC_CTRL,
-							     FU_PIXART_TP_CRC_CTRL_FW_BANK0,
-							     error))
+	/* handle pjp274 swap_flag */
+	if (priv->part_id == FU_PIXART_TP_PART_ID_PJP274) {
+		guint8 swap_flag = 0;
+		/* read swap_flag from system bank4 */
+		if (!fu_pixart_tp_device_register_read(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_SWAP_FLAG,
+						       &swap_flag,
+						       error))
 			return FALSE;
-		break;
+		if (swap_flag != 0)
+			crc_ctrl = FU_PIXART_TP_CRC_CTRL_FW_BANK1;
 	}
 
-	/* wait CRC calculation completed */
+	/* write crc trigger */
+	if (!fu_pixart_tp_device_register_user_write(self,
+						     FU_PIXART_TP_USER_BANK_BANK0,
+						     FU_PIXART_TP_REG_USER0_CRC_CTRL,
+						     crc_ctrl,
+						     error))
+		return FALSE;
+
+	/* wait crc calculation completed */
 	if (!fu_device_retry_full(FU_DEVICE(self),
 				  fu_pixart_tp_device_crc_firmware_wait_cb,
 				  1000,
@@ -757,43 +860,21 @@ fu_pixart_tp_device_crc_firmware(FuPixartTpDevice *self, guint32 *crc, GError **
 		return FALSE;
 	}
 
-	/* read CRC result (32-bit, little-endian) */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT0,
-						    &out_val,
-						    error))
+	/* read crc result (32-bit LE) */
+	buf = fu_pixart_tp_device_register_user_read_array(self,
+							   FU_PIXART_TP_USER_BANK_BANK0,
+							   FU_PIXART_TP_REG_USER0_CRC_RESULT,
+							   4,
+							   error);
+	if (buf == NULL)
 		return FALSE;
-	return_value |= (guint32)out_val;
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT1,
-						    &out_val,
-						    error))
+	/* safely read 32-bit CRC with bounds checking (using buf instead of res) */
+	if (!fu_memread_uint32_safe(buf->data, buf->len, 0x0, crc, G_LITTLE_ENDIAN, error))
 		return FALSE;
-	return_value |= (guint32)out_val << 8;
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT2,
-						    &out_val,
-						    error))
-		return FALSE;
-	return_value |= (guint32)out_val << 16;
+	g_debug("firmware CRC: 0x%08x", *crc);
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT3,
-						    &out_val,
-						    error))
-		return FALSE;
-	return_value |= (guint32)out_val << 24;
-
-	*crc = return_value;
-	g_debug("firmware CRC: 0x%08x", (guint)*crc);
-
-	/* success */
 	return TRUE;
 }
 
@@ -826,73 +907,35 @@ fu_pixart_tp_device_crc_parameter_wait_cb(FuDevice *device, gpointer user_data, 
 static gboolean
 fu_pixart_tp_device_crc_parameter(FuPixartTpDevice *self, guint32 *crc, GError **error)
 {
-	guint16 part_id = 0;
-	guint32 result = 0;
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
 	guint8 out_val = 0;
-	guint8 swap_flag;
-
-	g_return_val_if_fail(crc != NULL, FALSE);
+	guint8 crc_ctrl = FU_PIXART_TP_CRC_CTRL_PARAM_BANK0;
+	g_autoptr(GByteArray) buf = NULL;
 	*crc = 0;
 
-	/* read swap_flag from system bank4 */
-	if (!fu_pixart_tp_device_register_read(self,
-					       FU_PIXART_TP_SYSTEM_BANK_BANK4,
-					       FU_PIXART_TP_REG_SYS4_SWAP_FLAG,
-					       &out_val,
-					       error))
-		return FALSE;
-	swap_flag = out_val;
-
-	/* read part_id from user bank0 (little-endian) */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_PART_ID0,
-						    &out_val,
-						    error))
-		return FALSE;
-	part_id = out_val;
-
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_PART_ID1,
-						    &out_val,
-						    error))
-		return FALSE;
-	part_id |= (guint16)out_val << 8;
-
-	/* select CRC source */
-	switch (part_id) {
-	case FU_PIXART_TP_PART_ID_PJP274:
-		if (swap_flag != 0) {
-			if (!fu_pixart_tp_device_register_user_write(
-				self,
-				FU_PIXART_TP_USER_BANK_BANK0,
-				FU_PIXART_TP_REG_USER0_CRC_CTRL,
-				FU_PIXART_TP_CRC_CTRL_PARAM_BANK1,
-				error))
-				return FALSE;
-		} else {
-			if (!fu_pixart_tp_device_register_user_write(
-				self,
-				FU_PIXART_TP_USER_BANK_BANK0,
-				FU_PIXART_TP_REG_USER0_CRC_CTRL,
-				FU_PIXART_TP_CRC_CTRL_PARAM_BANK0,
-				error))
-				return FALSE;
-		}
-		break;
-
-	default:
-		if (!fu_pixart_tp_device_register_user_write(self,
-							     FU_PIXART_TP_USER_BANK_BANK0,
-							     FU_PIXART_TP_REG_USER0_CRC_CTRL,
-							     FU_PIXART_TP_CRC_CTRL_PARAM_BANK0,
-							     error))
+	/* handle pjp274 swap_flag */
+	if (priv->part_id == FU_PIXART_TP_PART_ID_PJP274) {
+		guint8 swap_flag = 0;
+		/* read swap_flag from system bank4 */
+		if (!fu_pixart_tp_device_register_read(self,
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_SWAP_FLAG,
+						       &swap_flag,
+						       error))
 			return FALSE;
-		break;
+		if (swap_flag != 0)
+			crc_ctrl = FU_PIXART_TP_CRC_CTRL_PARAM_BANK1;
 	}
 
-	/* wait CRC calculation completed */
+	/* write crc trigger */
+	if (!fu_pixart_tp_device_register_user_write(self,
+						     FU_PIXART_TP_USER_BANK_BANK0,
+						     FU_PIXART_TP_REG_USER0_CRC_CTRL,
+						     crc_ctrl,
+						     error))
+		return FALSE;
+
+	/* wait crc calculation completed */
 	if (!fu_device_retry_full(FU_DEVICE(self),
 				  fu_pixart_tp_device_crc_parameter_wait_cb,
 				  1000,
@@ -903,43 +946,21 @@ fu_pixart_tp_device_crc_parameter(FuPixartTpDevice *self, guint32 *crc, GError *
 		return FALSE;
 	}
 
-	/* read CRC result (32-bit LE) */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT0,
-						    &out_val,
-						    error))
+	/* read crc result (32-bit LE) */
+	buf = fu_pixart_tp_device_register_user_read_array(self,
+							   FU_PIXART_TP_USER_BANK_BANK0,
+							   FU_PIXART_TP_REG_USER0_CRC_RESULT,
+							   4,
+							   error);
+	if (buf == NULL)
 		return FALSE;
-	result |= (guint32)out_val;
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT1,
-						    &out_val,
-						    error))
+	/* safely read 32-bit CRC with bounds checking */
+	if (!fu_memread_uint32_safe(buf->data, buf->len, 0x0, crc, G_LITTLE_ENDIAN, error))
 		return FALSE;
-	result |= (guint32)out_val << 8;
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT2,
-						    &out_val,
-						    error))
-		return FALSE;
-	result |= (guint32)out_val << 16;
+	g_debug("parameter CRC: 0x%08x", *crc);
 
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    FU_PIXART_TP_USER_BANK_BANK0,
-						    FU_PIXART_TP_REG_USER0_CRC_RESULT3,
-						    &out_val,
-						    error))
-		return FALSE;
-	result |= (guint32)out_val << 24;
-
-	*crc = result;
-	g_debug("parameter CRC: 0x%08x", result);
-
-	/* success */
 	return TRUE;
 }
 
@@ -1119,8 +1140,8 @@ fu_pixart_tp_device_write_sections(FuPixartTpDevice *self,
 		}
 
 		/* skip TF_FORCE sections:
-		 *   - handled by TF/haptic child device using its own image
-		 *   - parent TP only handles TP firmware/parameter sections */
+		 * - handled by TF/haptic child device using its own image
+		 * - parent TP only handles TP firmware/parameter sections */
 		if (update_type == FU_PIXART_TP_UPDATE_TYPE_TF_FORCE) {
 			g_debug("skip TF_FORCE section %u for TP parent device", i);
 			fu_progress_step_done(progress);
@@ -1131,6 +1152,7 @@ fu_pixart_tp_device_write_sections(FuPixartTpDevice *self,
 			fu_progress_step_done(progress);
 			continue;
 		}
+
 		if (!fu_pixart_tp_device_write_section(self,
 						       section,
 						       fu_progress_get_child(progress),
@@ -1209,40 +1231,70 @@ static gboolean
 fu_pixart_tp_device_setup(FuDevice *device, GError **error)
 {
 	FuPixartTpDevice *self = FU_PIXART_TP_DEVICE(device);
-	guint8 buf[2] = {0};
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
+	guint8 val = 0;
+	guint16 version_raw = 0;
+	g_autoptr(GByteArray) buf = NULL;
 
-	/* read TP boot status*/
+	/* read tp part id */
+	buf = fu_pixart_tp_device_register_read_array(self,
+						      FU_PIXART_TP_SYSTEM_BANK_BANK0,
+						      FU_PIXART_TP_REG_SYS0_PART_ID,
+						      2,
+						      error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* safely read 16-bit part_id with bounds checking */
+	if (!fu_memread_uint16_safe(buf->data,
+				    buf->len,
+				    0x0,
+				    &priv->part_id,
+				    G_LITTLE_ENDIAN,
+				    error))
+		return FALSE;
+
+	/* define the extra instance IDs for quirks (e.g., PIXARTTP\PARTID_0274) */
+	fu_device_add_instance_u16(device, "PARTID", priv->part_id);
+	fu_device_build_instance_id_full(device,
+					 FU_DEVICE_INSTANCE_FLAG_QUIRKS,
+					 NULL,
+					 "PIXARTTP",
+					 "PARTID",
+					 NULL);
+
+	/* read tp boot status */
 	if (!fu_pixart_tp_device_register_user_read(self,
 						    FU_PIXART_TP_USER_BANK_BANK0,
 						    FU_PIXART_TP_REG_USER0_BOOT_STAUS,
-						    &buf[0],
+						    &val,
 						    error))
 		return FALSE;
 
-	/* avoid tp stuck in bootloader */
-	if (buf[0] == FU_PIXART_TP_BOOT_STATUS_ROM) {
-		if (!fu_pixart_tp_device_reset(self, FU_PIXART_TP_RESET_MODE_APPLICATION, error))
-			return FALSE;
+	/* sync bootloader flag from hardware state */
+	if (val == FU_PIXART_TP_BOOT_STATUS_ROM) {
+		g_debug("device is in bootloader mode");
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	} else {
+		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 	}
 
-	/* read low byte */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    self->ver_bank,
-						    (guint8)(self->ver_addr + 0),
-						    &buf[0],
-						    error))
+	/* read firmware version */
+	g_clear_pointer(&buf, g_byte_array_unref);
+	buf = fu_pixart_tp_device_register_user_read_array(self,
+							   priv->ver_bank,
+							   priv->ver_addr,
+							   2,
+							   error);
+	if (buf == NULL)
 		return FALSE;
 
-	/* read high byte */
-	if (!fu_pixart_tp_device_register_user_read(self,
-						    self->ver_bank,
-						    (guint8)(self->ver_addr + 1),
-						    &buf[1],
-						    error))
+	/* safely read 16-bit firmware version with bounds checking */
+	if (!fu_memread_uint16_safe(buf->data, buf->len, 0x0, &version_raw, G_LITTLE_ENDIAN, error))
 		return FALSE;
 
 	/* success */
-	fu_device_set_version_raw(device, fu_memread_uint16(buf, G_LITTLE_ENDIAN));
+	fu_device_set_version_raw(device, version_raw);
 	return TRUE;
 }
 
@@ -1274,8 +1326,8 @@ fu_pixart_tp_device_write_firmware(FuDevice *device,
 
 	/* calculate total bytes for valid internal TP sections
 	 * NOTE:
-	 *   - TF_FORCE sections are skipped here; they are handled by the
-	 *     TF/haptic child-device using its own firmware image.
+	 * - TF_FORCE sections are skipped here; they are handled by the
+	 * TF/haptic child-device using its own firmware image.
 	 */
 	for (guint i = 0; i < sections->len; i++) {
 		FuPixartTpSection *section = g_ptr_array_index(sections, i);
@@ -1336,28 +1388,29 @@ fu_pixart_tp_device_set_quirk_kv(FuDevice *device,
 				 GError **error)
 {
 	FuPixartTpDevice *self = FU_PIXART_TP_DEVICE(device);
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
 	guint64 tmp = 0;
 
 	if (g_strcmp0(key, "PixartTpHidVersionBank") == 0) {
 		if (!fu_strtoull(value, &tmp, 0, 0xff, FU_INTEGER_BASE_AUTO, error))
 			return FALSE;
-		self->ver_bank = (guint8)tmp;
+		priv->ver_bank = (guint8)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "PixartTpHidVersionAddr") == 0) {
 		if (!fu_strtoull(value, &tmp, 0, 0xffff, FU_INTEGER_BASE_AUTO, error))
 			return FALSE;
-		self->ver_addr = (guint16)tmp;
+		priv->ver_addr = (guint16)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "PixartTpSramSelect") == 0) {
 		if (!fu_strtoull(value, &tmp, 0, 0xff, FU_INTEGER_BASE_AUTO, error))
 			return FALSE;
-		self->sram_select = (guint8)tmp;
+		priv->sram_select = (guint8)tmp;
 		return TRUE;
 	}
 	if (g_strcmp0(key, "PixartTpHasHaptic") == 0)
-		return fu_strtobool(value, &self->has_tf_child, error);
+		return fu_strtobool(value, &priv->has_tf_child, error);
 
 	/* unknown quirk */
 	g_set_error(error,
@@ -1449,8 +1502,9 @@ static gboolean
 fu_pixart_tp_device_probe(FuDevice *device, GError **error)
 {
 	FuPixartTpDevice *self = FU_PIXART_TP_DEVICE(device);
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
 
-	if (self->has_tf_child) {
+	if (priv->has_tf_child) {
 		g_autoptr(FuPixartTpHapticDevice) child = fu_pixart_tp_haptic_device_new(device);
 		fu_device_add_child(device, FU_DEVICE(child));
 	}
@@ -1468,6 +1522,8 @@ fu_pixart_tp_device_convert_version(FuDevice *device, guint64 version_raw)
 static void
 fu_pixart_tp_device_init(FuPixartTpDevice *self)
 {
+	FuPixartTpDevicePrivate *priv = GET_PRIVATE(self);
+
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_HEX);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 	fu_device_add_protocol(FU_DEVICE(self), "com.pixart.tp");
@@ -1475,10 +1531,12 @@ fu_pixart_tp_device_init(FuPixartTpDevice *self)
 	fu_device_add_icon(FU_DEVICE(self), "input-touchpad");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 	fu_device_set_firmware_gtype(FU_DEVICE(self), FU_TYPE_PIXART_TP_FIRMWARE);
-	self->sram_select = 0x0F;
-	self->ver_bank = 0x00;
-	self->ver_addr = 0xB2;
+
+	priv->sram_select = 0x0F;
+	priv->ver_bank = 0x00;
+	priv->ver_addr = 0xB2;
 }
 
 static void

--- a/plugins/pixart-tp/fu-pixart-tp-device.h
+++ b/plugins/pixart-tp/fu-pixart-tp-device.h
@@ -8,11 +8,61 @@
 #pragma once
 
 #include <fwupdplugin.h>
-
 #include "fu-pixart-tp-struct.h"
 
 #define FU_TYPE_PIXART_TP_DEVICE (fu_pixart_tp_device_get_type())
-G_DECLARE_FINAL_TYPE(FuPixartTpDevice, fu_pixart_tp_device, FU, PIXART_TP_DEVICE, FuHidrawDevice)
+
+G_DECLARE_DERIVABLE_TYPE(FuPixartTpDevice,
+			 fu_pixart_tp_device,
+			 FU,
+			 PIXART_TP_DEVICE,
+			 FuHidrawDevice)
+
+struct _FuPixartTpDeviceClass {
+	FuHidrawDeviceClass parent_class;
+};
+
+gboolean
+fu_pixart_tp_device_register_write(FuPixartTpDevice *self,
+				   FuPixartTpSystemBank bank,
+				   guint8 addr,
+				   guint8 val,
+				   GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_pixart_tp_device_register_write_uint16(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint16 val,
+					  GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_pixart_tp_device_register_write_uint24(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint32 val,
+					  GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_pixart_tp_device_register_write_uint32(FuPixartTpDevice *self,
+					  FuPixartTpSystemBank bank,
+					  guint8 addr,
+					  guint32 val,
+					  GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_pixart_tp_device_register_read(FuPixartTpDevice *self,
+				  FuPixartTpSystemBank bank,
+				  guint8 addr,
+				  guint8 *out_val,
+				  GError **error) G_GNUC_NON_NULL(1, 4);
+
+GByteArray *
+fu_pixart_tp_device_register_read_array(FuPixartTpDevice *self,
+					FuPixartTpSystemBank bank,
+					guint8 addr,
+					gsize len,
+					GError **error) G_GNUC_NON_NULL(1);
 
 gboolean
 fu_pixart_tp_device_register_user_write(FuPixartTpDevice *self,
@@ -20,3 +70,15 @@ fu_pixart_tp_device_register_user_write(FuPixartTpDevice *self,
 					guint8 addr,
 					guint8 val,
 					GError **error) G_GNUC_NON_NULL(1);
+
+gboolean
+fu_pixart_tp_device_register_burst_write(FuPixartTpDevice *self,
+					 const guint8 *buf,
+					 gsize bufsz,
+					 GError **error) G_GNUC_NON_NULL(1, 2);
+
+gboolean
+fu_pixart_tp_device_register_burst_read(FuPixartTpDevice *self,
+					guint8 *buf,
+					gsize bufsz,
+					GError **error) G_GNUC_NON_NULL(1, 2);

--- a/plugins/pixart-tp/fu-pixart-tp-plp239-device.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plp239-device.c
@@ -1,0 +1,1585 @@
+/*
+ * Copyright 2025 Harris Tai <harris_tai@pixart.com>
+ * Copyright 2025 Micky Hsieh <micky_hsieh@pixart.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-pixart-tp-firmware.h"
+#include "fu-pixart-tp-plp239-device.h"
+#include "fu-pixart-tp-section.h"
+
+struct _FuPixartTpPlp239Device {
+	FuPixartTpDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuPixartTpPlp239Device, fu_pixart_tp_plp239_device, FU_TYPE_PIXART_TP_DEVICE)
+
+#define FU_PIXART_TP_DEVICE_SECTOR_SIZE 4096
+#define FU_PIXART_TP_DEVICE_PAGE_SIZE	256
+
+static gboolean
+fu_pixart_tp_plp239_device_set_flash_command(FuPixartTpPlp239Device *self,
+					     FuPixartTpSfcCommandPlp239 command,
+					     GError **error)
+{
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						FU_PIXART_TP_REG_SYS6_PLP239_SFC_COMMAND,
+						command,
+						error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_get_flash_controller_status(
+    FuPixartTpPlp239Device *self,
+    FuPixartTpFlashControllerStatusPlp239 *status,
+    GError **error)
+{
+	guint8 flash_status = 0;
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK6,
+					       FU_PIXART_TP_REG_SYS6_PLP239_FLASH_CONTROLLER_STATUS,
+					       &flash_status,
+					       error))
+		return FALSE;
+
+	*status = (FuPixartTpFlashControllerStatusPlp239)flash_status;
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_reset_sram_offset(FuPixartTpPlp239Device *self, GError **error)
+{
+	guint16 sram_address = 0x0000;
+	if (!fu_pixart_tp_device_register_write_uint16(FU_PIXART_TP_DEVICE(self),
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_PLP239_SRAM_OFFSET,
+						       sram_address,
+						       error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_flash_command_finish(FuPixartTpPlp239Device *self, GError **error)
+{
+	FuPixartTpFlashControllerStatusPlp239 flash_status;
+	/* execute finish command */
+	if (!fu_pixart_tp_plp239_device_set_flash_command(self,
+							  FU_PIXART_TP_SFC_COMMAND_PLP239_FINISH,
+							  error))
+		return FALSE;
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &flash_status, error))
+		return FALSE;
+
+	if (((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_HIGH_LEVEL_ENABLE) != 0) ||
+	    ((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_LEVEL1_ENABLE) != 0)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "cannot disable flash controller");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_lock_low_level_protection(FuPixartTpPlp239Device *self, GError **error)
+{
+	/* lock low level protection */
+	return fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						  FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						  FU_PIXART_TP_REG_SYS4_PLP239_LOW_LEVEL_PROTECTION,
+						  FU_PIXART_TP_LOW_LEVEL_PROTECTION_KEY_PLP239_LOCK,
+						  error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_unlock_low_level_protection(FuPixartTpPlp239Device *self, GError **error)
+{
+	/* unlock low level protection */
+	return fu_pixart_tp_device_register_write(
+	    FU_PIXART_TP_DEVICE(self),
+	    FU_PIXART_TP_SYSTEM_BANK_BANK4,
+	    FU_PIXART_TP_REG_SYS4_PLP239_LOW_LEVEL_PROTECTION,
+	    FU_PIXART_TP_LOW_LEVEL_PROTECTION_KEY_PLP239_UNLOCK,
+	    error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_unlock_level_zero_protection(FuPixartTpPlp239Device *self,
+							GError **error)
+{
+	FuPixartTpFlashControllerStatusPlp239 flash_status;
+
+	/* unlock level zero protection */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK6,
+		FU_PIXART_TP_REG_SYS6_PLP239_ZERO_LEVEL_PROTECT_KEY,
+		FU_PIXART_TP_ZERO_LEVEL_PROTECT_KEY_PLP239_PROTECT_KEY,
+		error))
+		return FALSE;
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &flash_status, error))
+		return FALSE;
+
+	if ((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_HIGH_LEVEL_ENABLE) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "can not unlock level 0 protection");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_unlock_level_one_protection(FuPixartTpPlp239Device *self, GError **error)
+{
+	FuPixartTpFlashControllerStatusPlp239 flash_status;
+
+	/* unlock level one protection */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK6,
+		FU_PIXART_TP_REG_SYS6_PLP239_ONE_LEVEL_PROTECT_KEY,
+		FU_PIXART_TP_ONE_LEVEL_PROTECT_KEY_PLP239_PROTECT_KEY,
+		error))
+		return FALSE;
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &flash_status, error))
+		return FALSE;
+
+	if ((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_LEVEL1_ENABLE) !=
+	    FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_LEVEL1_ENABLE) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "can not unlock level 1 protection");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_set_flash_sector_address(FuPixartTpPlp239Device *self,
+						    guint8 sector,
+						    guint8 sector_length,
+						    GError **error)
+{
+	/* write flash sector address*/
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						FU_PIXART_TP_REG_SYS6_PLP239_FLASH_SECTOR_ADDRESS,
+						sector,
+						error))
+		return FALSE;
+
+	/* write flash sector length*/
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						FU_PIXART_TP_REG_SYS6_PLP239_FLASH_SECTOR_LENGTH,
+						sector_length,
+						error))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_disable_cpu_access(FuPixartTpPlp239Device *self, GError **error)
+{
+	/* disable cpu access */
+	return fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						  FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						  FU_PIXART_TP_REG_SYS4_PLP239_MASK_CPU_ACCESS,
+						  FU_PIXART_TP_CPU_ACCESS_MASK_PLP239_DISABLE,
+						  error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_enable_watchdog(FuPixartTpPlp239Device *self,
+					   gboolean enable,
+					   GError **error)
+{
+	guint8 val = enable ? FU_PIXART_TP_WATCH_DOG_KEY_PLP239_ENABLE
+			    : FU_PIXART_TP_WATCH_DOG_KEY_PLP239_DISABLE;
+
+	/* set watchdog state */
+	return fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						  FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						  FU_PIXART_TP_REG_SYS6_PLP239_WATCHDOG_DISABLE,
+						  val,
+						  error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_disable_cpu_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+	guint8 clock_pu = 0;
+	guint8 clock_pd = 0;
+
+	/* write protect key to allow clock changes */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK0,
+						FU_PIXART_TP_REG_SYS0_PLP239_BANK0_PROTECT_KEY,
+						FU_PIXART_TP_REG_SYS0_PLP239_BANK0_PROTECT_KEY,
+						error))
+		return FALSE;
+
+	/* set clock power down/up bits */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK0,
+						FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PD,
+						FU_PIXART_TP_CLOCKS_POWER_DISABLE_PLP239_CPU,
+						error))
+		return FALSE;
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK0,
+						FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PU2,
+						FU_PIXART_TP_CLOCKS_POWER_UP_NYQ |
+						    FU_PIXART_TP_CLOCKS_POWER_UP_NYQ_F,
+						error))
+		return FALSE;
+
+	/* verify status */
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK0,
+					       FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PU2,
+					       &clock_pu,
+					       error))
+		return FALSE;
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK0,
+					       FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PD,
+					       &clock_pd,
+					       error))
+		return FALSE;
+
+	if (clock_pu != (FU_PIXART_TP_CLOCKS_POWER_UP_NYQ | FU_PIXART_TP_CLOCKS_POWER_UP_NYQ_F) ||
+	    clock_pd != FU_PIXART_TP_CLOCKS_POWER_DISABLE_PLP239_CPU) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "clock state mismatch");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_enable_cpu(FuPixartTpPlp239Device *self, gboolean enable, GError **error)
+{
+	/* enable cpu clock */
+	if (enable) {
+		if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+							FU_PIXART_TP_SYSTEM_BANK_BANK0,
+							FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PU,
+							FU_PIXART_TP_CLOCKS_POWER_UP_CPU,
+							error))
+			return FALSE;
+		return fu_pixart_tp_device_register_write(
+		    FU_PIXART_TP_DEVICE(self),
+		    FU_PIXART_TP_SYSTEM_BANK_BANK0,
+		    FU_PIXART_TP_REG_SYS0_PLP239_CLOCK_PD,
+		    FU_PIXART_TP_CLOCKS_POWER_DISABLE_PLP239_NONE,
+		    error);
+	}
+
+	/* disable cpu clock with retry */
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_pixart_tp_plp239_device_disable_cpu_cb,
+				  10,	/* count */
+				  0,	/* delay ms */
+				  NULL, /* user_data */
+				  error)) {
+		g_prefix_error_literal(error, "failed to disable cpu: ");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_check_nav_ready_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+	guint8 boot_status = 0;
+	/* sometimes the boot status will get a 0xff value, which is a FW not ready */
+	guint8 busy_mask = 0xff;
+
+	/* check if nav is ready */
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK6,
+					       FU_PIXART_TP_REG_SYS6_PLP239_BOOT_STATUS,
+					       &boot_status,
+					       error))
+		return FALSE;
+
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_NAV_READY) != 0 &&
+	    boot_status != busy_mask)
+		return TRUE;
+
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "navigation is not ready yet");
+	return FALSE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_check_device_boot_status(FuPixartTpPlp239Device *self, GError **error)
+{
+	guint8 boot_status = 0;
+	g_autoptr(GError) error_local = NULL;
+
+	/* check nav_ready with 50 retries and 10ms delay */
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_pixart_tp_plp239_device_check_nav_ready_cb,
+				  50,	/* count */
+				  10,	/* delay ms */
+				  NULL, /* user_data */
+				  &error_local)) {
+		g_debug("ignoring: %s", error_local->message);
+	} else {
+		return TRUE;
+	}
+
+	/* read status to determine exact failure reason */
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK6,
+					       FU_PIXART_TP_REG_SYS6_PLP239_BOOT_STATUS,
+					       &boot_status,
+					       error)) {
+		return FALSE;
+	}
+
+	/* verify hardware and firmware checks */
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_HW_READY) == 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "hardware is not ready");
+		return FALSE;
+	}
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_FW_CODE_PASS) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "firmware code checking did not pass");
+		return FALSE;
+	}
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_IFB_CHECK_SUM_PASS) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "information block checksum failed");
+		return FALSE;
+	}
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_WDOG) != 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "watchdog was signaled");
+		return FALSE;
+	}
+
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "unknown boot status error");
+	return FALSE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_clear_hid_firmware_ready(FuPixartTpPlp239Device *self, GError **error)
+{
+	/* clear hid firmware ready signal */
+	return fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						  FU_PIXART_TP_SYSTEM_BANK_BANK8,
+						  FU_PIXART_TP_REG_SYS8_PLP239_HID_FIRMWARE_READY,
+						  FU_PIXART_TP_HID_FIRMWARE_READY_PLP239_NONE,
+						  error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_flash_rstqio_step(FuPixartTpPlp239Device *self,
+					     guint8 quad_mode,
+					     GError **error)
+{
+	/* set flash quad mode */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						FU_PIXART_TP_REG_SYS4_PLP239_FLASH_QUAD,
+						quad_mode,
+						error))
+		return FALSE;
+
+	/* reset flash quad I/O, EoN */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_COMMAND,
+		FU_PIXART_TP_FLASH_COMMAND_PLP239_FLASH_CMD_RSTQIO_EON,
+		error))
+		return FALSE;
+
+	/* set flash data count to 0 */
+	if (!fu_pixart_tp_device_register_write_uint16(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_DATA_COUNT,
+		0x0000,
+		error))
+		return FALSE;
+
+	/* flash write instruction */
+	return fu_pixart_tp_device_register_write(
+	    FU_PIXART_TP_DEVICE(self),
+	    FU_PIXART_TP_SYSTEM_BANK_BANK4,
+	    FU_PIXART_TP_REG_SYS4_PLP239_FLASH_INSTRUCTION,
+	    FU_PIXART_TP_FLASH_INST_PLP239_FLASH_WRITE_INSTRUCTION,
+	    error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_release_flash_quad_enhance_mode(FuPixartTpPlp239Device *self,
+							   GError **error)
+{
+	guint32 addr = 0;
+	guint8 q_mode_en = FU_PIXART_TP_FLASH_QUAD_EQIO_EON | FU_PIXART_TP_FLASH_QUAD_QUAD_MD;
+
+	/* flash quad mode and enhance performance for read data */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						FU_PIXART_TP_REG_SYS4_PLP239_FLASH_QUAD,
+						FU_PIXART_TP_FLASH_QUAD_QUAD_ENPERF_MD,
+						error))
+		return FALSE;
+
+	/* set flash data count to 1 */
+	if (!fu_pixart_tp_device_register_write_uint16(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_DATA_COUNT,
+		0x0001,
+		error))
+		return FALSE;
+
+	/* set flash address to 0*/
+	if (!fu_pixart_tp_device_register_write_uint24(FU_PIXART_TP_DEVICE(self),
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_PLP239_FLASH_ADDRESS,
+						       addr,
+						       error))
+		return FALSE;
+
+	/* toggle dummy bits to escape performance enhance mode */
+	if (!fu_pixart_tp_device_register_write_uint24(FU_PIXART_TP_DEVICE(self),
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_PLP239_DUMMY_BY,
+						       0,
+						       error))
+		return FALSE;
+
+	/* flash read data */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						FU_PIXART_TP_REG_SYS4_PLP239_FLASH_INSTRUCTION,
+						FU_PIXART_TP_FLASH_INST_PLP239_FLASH_READ_DATA,
+						error))
+		return FALSE;
+
+	/* IMPORTANT: this sequence is a mandatory hardware workaround (errata)
+	 * do not refactor or remove this redundant flow, as it is required for ic stability */
+	if (!fu_pixart_tp_plp239_device_flash_rstqio_step(self, q_mode_en, error))
+		return FALSE; /* retry 1 */
+	if (!fu_pixart_tp_plp239_device_flash_rstqio_step(self,
+							  FU_PIXART_TP_FLASH_QUAD_NONE,
+							  error))
+		return FALSE; /* turn off */
+	if (!fu_pixart_tp_plp239_device_flash_rstqio_step(self, q_mode_en, error))
+		return FALSE; /* retry 2 */
+	if (!fu_pixart_tp_plp239_device_flash_rstqio_step(self, q_mode_en, error))
+		return FALSE; /* retry 3 */
+	if (!fu_pixart_tp_plp239_device_flash_rstqio_step(self,
+							  FU_PIXART_TP_FLASH_QUAD_NONE,
+							  error))
+		return FALSE; /* turn off */
+
+	/* clear flash quad mode setting */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						FU_PIXART_TP_REG_SYS4_PLP239_FLASH_QUAD,
+						FU_PIXART_TP_FLASH_QUAD_NONE,
+						error))
+		return FALSE;
+
+	/* set flash command to WRSR (Write Status, EoN/Winbond) */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						FU_PIXART_TP_REG_SYS4_PLP239_FLASH_COMMAND,
+						FU_PIXART_TP_FLASH_COMMAND_PLP239_FLASH_CMD_WRSR,
+						error))
+		return FALSE;
+
+	/* set flash data count to 1 */
+	if (!fu_pixart_tp_device_register_write_uint16(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_DATA_COUNT,
+		0x0001,
+		error))
+		return FALSE;
+
+	/* write data word 0 to flash*/
+	if (!fu_pixart_tp_device_register_write_uint32(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_WRITE_DATA_WORD0,
+		0,
+		error))
+		return FALSE;
+
+	/* flash write instruction */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_INSTRUCTION,
+		FU_PIXART_TP_FLASH_INST_PLP239_FLASH_WRITE_INSTRUCTION,
+		error))
+		return FALSE;
+
+	/* release power down */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_COMMAND,
+		FU_PIXART_TP_FLASH_COMMAND_PLP239_FLASH_CMD_RELEASE_POWER_DOWN,
+		error))
+		return FALSE;
+
+	/* set flash data count to 1 */
+	if (!fu_pixart_tp_device_register_write_uint16(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK4,
+		FU_PIXART_TP_REG_SYS4_PLP239_FLASH_DATA_COUNT,
+		0x0001,
+		error))
+		return FALSE;
+
+	/* set flash address to 0*/
+	if (!fu_pixart_tp_device_register_write_uint24(FU_PIXART_TP_DEVICE(self),
+						       FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						       FU_PIXART_TP_REG_SYS4_PLP239_FLASH_ADDRESS,
+						       addr,
+						       error))
+		return FALSE;
+
+	/* flash read data */
+	return fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						  FU_PIXART_TP_SYSTEM_BANK_BANK4,
+						  FU_PIXART_TP_REG_SYS4_PLP239_FLASH_INSTRUCTION,
+						  FU_PIXART_TP_FLASH_INST_PLP239_FLASH_READ_DATA,
+						  error);
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_wait_hardware_done_cb(FuDevice *device,
+						 gpointer user_data,
+						 GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+	FuPixartTpFlashControllerStatusPlp239 status;
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &status, error))
+		return FALSE;
+
+	if ((status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_FINISH) == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_WRITE,
+				    "hardware operation is not finished yet");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_get_crc_firmware(FuPixartTpPlp239Device *self,
+					    guint32 *crc,
+					    GError **error)
+{
+	g_autoptr(GByteArray) buf = NULL;
+	*crc = 0;
+
+	/* read crc result (32-bit LE) */
+	buf = fu_pixart_tp_device_register_read_array(FU_PIXART_TP_DEVICE(self),
+						      FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						      FU_PIXART_TP_REG_SYS6_PLP239_FIRMWARE_CRC,
+						      4,
+						      error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* safely read 32-bit CRC with bounds checking */
+	if (!fu_memread_uint32_safe(buf->data, buf->len, 0x0, crc, G_LITTLE_ENDIAN, error))
+		return FALSE;
+
+	g_debug("firmware CRC: 0x%08x", *crc);
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_get_crc_parameter(FuPixartTpPlp239Device *self,
+					     guint32 *crc,
+					     GError **error)
+{
+	g_autoptr(GByteArray) buf = NULL;
+	*crc = 0;
+
+	/* read crc result (32-bit LE) */
+	buf = fu_pixart_tp_device_register_read_array(FU_PIXART_TP_DEVICE(self),
+						      FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						      FU_PIXART_TP_REG_SYS6_PLP239_PARAMETER_CRC,
+						      4,
+						      error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* safely read 32-bit CRC with bounds checking */
+	if (!fu_memread_uint32_safe(buf->data, buf->len, 0x0, crc, G_LITTLE_ENDIAN, error))
+		return FALSE;
+
+	g_debug("parameter CRC: 0x%08x", *crc);
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_get_crc_hid_descriptor(FuPixartTpPlp239Device *self,
+						  guint32 *crc,
+						  GError **error)
+{
+	guint8 crc_ctrl = FU_PIXART_TP_CRC_CTRL_HID_DESCRIPTOR;
+	g_autoptr(GByteArray) buf = NULL;
+
+	*crc = 0;
+
+	/* write crc trigger */
+	if (!fu_pixart_tp_device_register_write(
+		FU_PIXART_TP_DEVICE(self),
+		FU_PIXART_TP_SYSTEM_BANK_BANK6,
+		FU_PIXART_TP_REG_SYS6_PLP239_HID_DESCRIPTOR_CRC_CTRL,
+		crc_ctrl,
+		error))
+		return FALSE;
+
+	fu_device_sleep(FU_DEVICE(self), 250);
+
+	/* read crc result (32-bit LE) */
+	buf =
+	    fu_pixart_tp_device_register_read_array(FU_PIXART_TP_DEVICE(self),
+						    FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						    FU_PIXART_TP_REG_SYS6_PLP239_HID_DESCRIPTOR_CRC,
+						    4,
+						    error);
+	if (buf == NULL)
+		return FALSE;
+
+	/* safely read 32-bit CRC with bounds checking */
+	if (!fu_memread_uint32_safe(buf->data, buf->len, 0x0, crc, G_LITTLE_ENDIAN, error))
+		return FALSE;
+
+	g_debug("hid CRC: 0x%08x", *crc);
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_flash_program_4096b_to_flash(FuPixartTpPlp239Device *self,
+							guint8 sector,
+							GError **error)
+{
+	guint8 enable_bist = 0x01;
+
+	/* reset sram offset to zero */
+	if (!fu_pixart_tp_plp239_device_reset_sram_offset(self, error))
+		return FALSE;
+
+	/* unlock level zero protection*/
+	if (!fu_pixart_tp_plp239_device_unlock_level_zero_protection(self, error))
+		return FALSE;
+
+	/* unlock level one protection */
+	if (!fu_pixart_tp_plp239_device_unlock_level_one_protection(self, error))
+		return FALSE;
+
+	/* enable BIST */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6,
+						FU_PIXART_TP_REG_SYS6_PLP239_PROGRAM_BIST,
+						enable_bist,
+						error))
+		return FALSE;
+
+	/* set flash sector address */
+	if (!fu_pixart_tp_plp239_device_set_flash_sector_address(
+		self,
+		sector,
+		FU_PIXART_TP_FLASH_SECTOR_LENGTH_PLP239_KB_4,
+		error))
+		return FALSE;
+
+	/* set program flash command */
+	if (!fu_pixart_tp_plp239_device_set_flash_command(self,
+							  FU_PIXART_TP_SFC_COMMAND_PLP239_PROGRAM,
+							  error))
+		return FALSE;
+
+	/* wait hardware done */
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_pixart_tp_plp239_device_wait_hardware_done_cb,
+				  8000, /* count */
+				  0,	/* delay ms */
+				  NULL, /* user_data */
+				  error)) {
+		g_prefix_error_literal(
+		    error,
+		    "failed to wait for hardware done after dump flash to sram: ");
+		return FALSE;
+	}
+
+	/* finish program */
+	if (!fu_pixart_tp_plp239_device_flash_command_finish(self, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_flash_dump_4096b_from_flash_to_sram(FuPixartTpPlp239Device *self,
+							       guint8 sector,
+							       GError **error)
+{
+	if (!fu_pixart_tp_plp239_device_unlock_level_zero_protection(self, error))
+		return FALSE;
+
+	/* set flash read address */
+	if (!fu_pixart_tp_plp239_device_set_flash_sector_address(
+		self,
+		sector,
+		FU_PIXART_TP_FLASH_SECTOR_LENGTH_PLP239_KB_4,
+		error))
+		return FALSE;
+
+	/* set read flash command */
+	if (!fu_pixart_tp_plp239_device_set_flash_command(self,
+							  FU_PIXART_TP_SFC_COMMAND_PLP239_READ,
+							  error))
+		return FALSE;
+
+	/* wait hardware done */
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_pixart_tp_plp239_device_wait_hardware_done_cb,
+				  8000, /* count */
+				  0,	/* delay ms */
+				  NULL, /* user_data */
+				  error)) {
+		g_prefix_error_literal(
+		    error,
+		    "failed to wait for hardware done after dump flash to sram: ");
+		return FALSE;
+	}
+
+	/* finish read */
+	if (!fu_pixart_tp_plp239_device_flash_command_finish(self, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_write_sram_4096b(FuPixartTpPlp239Device *self,
+					    const guint8 *data,
+					    GError **error)
+{
+	guint8 dummy = 0x00;
+	guint8 work_around_mask = 0x10;
+	FuPixartTpFlashControllerStatusPlp239 flash_status;
+	if (!fu_pixart_tp_plp239_device_unlock_level_zero_protection(self, error))
+		return FALSE;
+
+	if (!fu_pixart_tp_plp239_device_set_flash_command(
+		self,
+		FU_PIXART_TP_SFC_COMMAND_PLP239_SRAM_READ_WRITE,
+		error))
+		return FALSE;
+
+	/* * WORKAROUND: Force the register pointer to Bank 6, 0x25 before burst read/write.
+	 * Applying bitwise OR with 0x10 instructs(read operation) the IC to only set the address
+	 * focus without executing an actual data write.
+	 */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6 | work_around_mask,
+						FU_PIXART_TP_REG_SYS6_PLP239_SRAM_ACCESS_DATA,
+						dummy,
+						error))
+		return FALSE;
+
+	/* burst write data*/
+	if (!fu_pixart_tp_device_register_burst_write(FU_PIXART_TP_DEVICE(self),
+						      data,
+						      FU_PIXART_TP_DEVICE_SECTOR_SIZE,
+						      error)) {
+		g_prefix_error_literal(error, "burst write buffer failure: ");
+		return FALSE;
+	}
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &flash_status, error))
+		return FALSE;
+
+	if ((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_BUFFER_OVER_FLOW) != 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "sram access overflow");
+		return FALSE;
+	}
+
+	/* write finish */
+	if (!fu_pixart_tp_plp239_device_flash_command_finish(self, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_read_sram_4096b(FuPixartTpPlp239Device *self,
+					   guint8 *data,
+					   GError **error)
+{
+	guint8 dummy = 0x00;
+	guint8 work_around_mask = 0x10;
+	FuPixartTpFlashControllerStatusPlp239 flash_status;
+
+	if (!fu_pixart_tp_plp239_device_unlock_level_zero_protection(self, error))
+		return FALSE;
+
+	if (!fu_pixart_tp_plp239_device_set_flash_command(
+		self,
+		FU_PIXART_TP_SFC_COMMAND_PLP239_SRAM_READ_WRITE,
+		error))
+		return FALSE;
+
+	/* * WORKAROUND: Force the register pointer to Bank 6, 0x25 before burst read/write.
+	 * Applying bitwise OR with 0x10 instructs(read operation) the IC to only set the address
+	 * focus without executing an actual data write.
+	 */
+	if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+						FU_PIXART_TP_SYSTEM_BANK_BANK6 | work_around_mask,
+						FU_PIXART_TP_REG_SYS6_PLP239_SRAM_ACCESS_DATA,
+						dummy,
+						error))
+		return FALSE;
+
+	/* burst read data*/
+	if (!fu_pixart_tp_device_register_burst_read(FU_PIXART_TP_DEVICE(self),
+						     data,
+						     FU_PIXART_TP_DEVICE_SECTOR_SIZE,
+						     error)) {
+		g_prefix_error_literal(error, "burst read buffer failure: ");
+		return FALSE;
+	}
+
+	if (!fu_pixart_tp_plp239_device_get_flash_controller_status(self, &flash_status, error))
+		return FALSE;
+
+	if ((flash_status & FU_PIXART_TP_FLASH_CONTROLLER_STATUS_PLP239_BUFFER_OVER_FLOW) != 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_WRITE, "sram access overflow");
+		return FALSE;
+	}
+
+	/* write finish */
+	if (!fu_pixart_tp_plp239_device_flash_command_finish(self, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_write_sector(FuPixartTpPlp239Device *self,
+					guint8 sector,
+					FuChunk *chk,
+					GError **error)
+{
+	g_autoptr(GByteArray) sector_buf = g_byte_array_new();
+	g_autoptr(GBytes) blob = fu_chunk_get_bytes(chk);
+
+	/* initialize all extra bytes to 0xFF */
+	fu_byte_array_append_bytes(sector_buf, blob);
+	fu_byte_array_set_size(sector_buf, FU_PIXART_TP_DEVICE_SECTOR_SIZE, 0xFF);
+
+	/* write to SRAM using the 4096-byte buffer */
+	if (!fu_pixart_tp_plp239_device_write_sram_4096b(self, sector_buf->data, error))
+		return FALSE;
+
+	/* program SRAM 4096byte to flash */
+	if (!fu_pixart_tp_plp239_device_flash_program_4096b_to_flash(self, sector, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_read_sector(FuPixartTpPlp239Device *self,
+				       guint8 sector,
+				       guint8 *data,
+				       GError **error)
+{
+	/* dump flash to sram */
+	if (!fu_pixart_tp_plp239_device_flash_dump_4096b_from_flash_to_sram(self, sector, error))
+		return FALSE;
+
+	/* read sram */
+	if (!fu_pixart_tp_plp239_device_read_sram_4096b(self, data, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_reset(FuPixartTpPlp239Device *self,
+				 FuPixartTpResetMode mode,
+				 GError **error)
+{
+	if (mode == FU_PIXART_TP_RESET_MODE_APPLICATION) {
+		if (!fu_pixart_tp_plp239_device_lock_low_level_protection(self, error))
+			return FALSE;
+
+		if (!fu_pixart_tp_plp239_device_disable_cpu_access(self, error))
+			return FALSE;
+
+		if (!fu_pixart_tp_plp239_device_enable_watchdog(self, TRUE, error))
+			return FALSE;
+
+		/* write reset keys */
+		if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+							FU_PIXART_TP_SYSTEM_BANK_BANK1,
+							FU_PIXART_TP_REG_SYS1_PLP239_RESET_KEY1,
+							FU_PIXART_TP_RESET_KEY1_SUSPEND,
+							error))
+			return FALSE;
+		if (!fu_pixart_tp_device_register_write(FU_PIXART_TP_DEVICE(self),
+							FU_PIXART_TP_SYSTEM_BANK_BANK1,
+							FU_PIXART_TP_REG_SYS1_PLP239_RESET_KEY2,
+							FU_PIXART_TP_RESET_KEY2_REGULAR,
+							error))
+			return FALSE;
+
+		fu_device_sleep(FU_DEVICE(self), 50);
+		if (!fu_pixart_tp_plp239_device_enable_cpu(self, TRUE, error))
+			return FALSE;
+
+		fu_device_sleep(FU_DEVICE(self), 20);
+		if (!fu_pixart_tp_plp239_device_check_device_boot_status(self, error))
+			return FALSE;
+
+	} else {
+		if (!fu_pixart_tp_plp239_device_clear_hid_firmware_ready(self, error))
+			return FALSE;
+
+		fu_device_sleep(FU_DEVICE(self), 200);
+
+		if (!fu_pixart_tp_plp239_device_enable_watchdog(self, FALSE, error))
+			return FALSE;
+		if (!fu_pixart_tp_plp239_device_enable_cpu(self, FALSE, error))
+			return FALSE;
+		if (!fu_pixart_tp_plp239_device_unlock_low_level_protection(self, error))
+			return FALSE;
+		if (!fu_pixart_tp_plp239_device_disable_cpu_access(self, error))
+			return FALSE;
+		if (!fu_pixart_tp_plp239_device_release_flash_quad_enhance_mode(self, error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_flash_erase_sector(FuPixartTpPlp239Device *self,
+					      guint8 erase_sector,
+					      GError **error)
+{
+	if (!fu_pixart_tp_plp239_device_unlock_level_zero_protection(self, error))
+		return FALSE;
+	if (!fu_pixart_tp_plp239_device_unlock_level_one_protection(self, error))
+		return FALSE;
+
+	/* set erased flash sector address */
+	if (!fu_pixart_tp_plp239_device_set_flash_sector_address(
+		self,
+		erase_sector,
+		FU_PIXART_TP_FLASH_SECTOR_LENGTH_PLP239_KB_4,
+		error))
+		return FALSE;
+
+	g_debug("erase sector %u", (guint)erase_sector);
+
+	/* execute erase command */
+	if (!fu_pixart_tp_plp239_device_set_flash_command(self,
+							  FU_PIXART_TP_SFC_COMMAND_PLP239_ERASE,
+							  error))
+		return FALSE;
+
+	/* wait hardware done */
+	if (!fu_device_retry_full(FU_DEVICE(self),
+				  fu_pixart_tp_plp239_device_wait_hardware_done_cb,
+				  8000, /* count */
+				  0,	/* delay ms */
+				  NULL, /* user_data */
+				  error)) {
+		g_prefix_error_literal(error,
+				       "failed to wait for hardware done after flash erase: ");
+		return FALSE;
+	}
+
+	/* finish erase */
+	if (!fu_pixart_tp_plp239_device_flash_command_finish(self, error))
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_verify_extend_flash(FuPixartTpPlp239Device *self,
+					       guint8 sector,
+					       FuChunk *chk,
+					       GError **error)
+{
+	guint8 read_buf[FU_PIXART_TP_DEVICE_SECTOR_SIZE] = {0};
+	gsize blob_sz = 0;
+	const guint8 *blob_data;
+	gboolean verify_ok;
+	g_autoptr(GBytes) blob = fu_chunk_get_bytes(chk);
+
+	blob_data = g_bytes_get_data(blob, &blob_sz);
+
+	/* read back the sector to sram and then to our buffer */
+	if (!fu_pixart_tp_plp239_device_read_sector(self, sector, read_buf, error)) {
+		g_prefix_error(error,
+			       "failed to read back sector 0x%x for verification: ",
+			       (guint)sector);
+		return FALSE;
+	}
+
+	/* safely compare the actual payload with bounds checking */
+	verify_ok =
+	    fu_memcmp_safe(read_buf, sizeof(read_buf), 0x0, blob_data, blob_sz, 0x0, blob_sz, NULL);
+
+	/* assert that the remaining padded region is all 0xFF */
+	if (verify_ok) {
+		for (gsize j = blob_sz; j < FU_PIXART_TP_DEVICE_SECTOR_SIZE; j++) {
+			if (read_buf[j] != 0xFF) {
+				verify_ok = FALSE;
+				break;
+			}
+		}
+	}
+
+	if (!verify_ok) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "extend flash verification failed at sector 0x%x",
+			    (guint)sector);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_write_section(FuPixartTpPlp239Device *self,
+					 FuPixartTpSection *section,
+					 FuProgress *progress,
+					 GError **error)
+{
+	/* normal fw: sector 0 ~ 8 (9 sectors)
+	** extend fw: sector 9 ~ 10 (2 sectors)
+	*/
+	const guint8 extend_flash_sector = 9;
+	FuPixartTpUpdateType update_type = FU_PIXART_TP_UPDATE_TYPE_GENERAL;
+	guint32 target_flash_start = fu_pixart_tp_section_get_target_flash_start(section);
+	guint8 start_sector;
+	guint sector_count;
+	guint first_idx;
+	g_autoptr(FuChunkArray) chunks = NULL;
+	g_autoptr(GInputStream) stream = NULL;
+
+	/* nothing to do */
+	if (fu_firmware_get_size(FU_FIRMWARE(section)) == 0)
+		return TRUE;
+
+	update_type = fu_pixart_tp_section_get_update_type(section);
+	if (update_type != FU_PIXART_TP_UPDATE_TYPE_GENERAL &&
+	    update_type != FU_PIXART_TP_UPDATE_TYPE_FW_SECTION &&
+	    update_type != FU_PIXART_TP_UPDATE_TYPE_PARAM &&
+	    update_type != FU_PIXART_TP_UPDATE_TYPE_HID_DESCRIPTOR) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "unsupported update type %u for TP section",
+			    (guint)update_type);
+		return FALSE;
+	}
+
+	/* chunk section data into sectors */
+	stream = fu_firmware_get_stream(FU_FIRMWARE(section), error);
+	if (stream == NULL)
+		return FALSE;
+	chunks = fu_chunk_array_new_from_stream(stream,
+						0x0,
+						0x0,
+						FU_PIXART_TP_DEVICE_SECTOR_SIZE,
+						error);
+	if (chunks == NULL)
+		return FALSE;
+
+	sector_count = fu_chunk_array_length(chunks);
+	if (sector_count == 0)
+		return TRUE;
+
+	/* progress: 2 steps per sector (erase + program) */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, sector_count * 2);
+
+	start_sector = (guint8)(target_flash_start / FU_PIXART_TP_DEVICE_SECTOR_SIZE);
+
+	/* keep sector 0 valid until the end */
+	first_idx = (start_sector == 0) ? 1 : 0;
+
+	/* erase phase: erase remaining sectors first in physical order */
+	for (guint i = first_idx; i < sector_count; i++) {
+		if (!fu_pixart_tp_plp239_device_flash_erase_sector(self,
+								   (guint8)(start_sector + i),
+								   error)) {
+			g_prefix_error(error,
+				       "failed to erase sector 0x%x: ",
+				       (guint8)(start_sector + i));
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	/* write phase: write remaining sectors first */
+	for (guint i = first_idx; i < sector_count; i++) {
+		g_autoptr(FuChunk) chk = NULL;
+
+		chk = fu_chunk_array_index(chunks, i, error);
+		if (chk == NULL)
+			return FALSE;
+
+		/* write chunk to the corresponding flash sector */
+		if (!fu_pixart_tp_plp239_device_write_sector(self,
+							     (guint8)(start_sector + i),
+							     chk,
+							     error)) {
+			g_prefix_error(error,
+				       "failed to write sector 0x%x: ",
+				       (guint8)(start_sector + i));
+			return FALSE;
+		}
+
+		/* workaround: for the plp239, there is an extendflash block that is not included in
+		 * the crc check. if the burning process is incomplete, this block may not be
+		 * detected by the crc verification. we need read flash back to verify manually */
+		if (start_sector == 0 && i >= extend_flash_sector) {
+			if (!fu_pixart_tp_plp239_device_verify_extend_flash(
+				self,
+				(guint8)(start_sector + i),
+				chk,
+				error))
+				return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	/* final phase: erase + write sector 0 last */
+	if (start_sector == 0 && sector_count > 0) {
+		g_autoptr(FuChunk) chk_0 = NULL;
+
+		/* erase sector 0 */
+		if (!fu_pixart_tp_plp239_device_flash_erase_sector(self, 0, error)) {
+			g_prefix_error_literal(error, "failed to erase sector 0x0: ");
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+
+		/* write sector 0 */
+		chk_0 = fu_chunk_array_index(chunks, 0, error);
+		if (chk_0 == NULL)
+			return FALSE;
+
+		if (!fu_pixart_tp_plp239_device_write_sector(self, 0, chk_0, error)) {
+			g_prefix_error_literal(error, "failed to write sector 0x0: ");
+			return FALSE;
+		}
+		fu_progress_step_done(progress);
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_verify_crc(FuPixartTpPlp239Device *self,
+				      FuPixartTpFirmware *firmware,
+				      FuProgress *progress,
+				      GError **error)
+{
+	guint32 crc_value;
+	FuPixartTpSection *section;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 49, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 8, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 43, NULL);
+
+	/* important: 239 device must reset to application to recalculate the CRC, not reset to
+	 * bootloader */
+	if (!fu_pixart_tp_plp239_device_reset(self, FU_PIXART_TP_RESET_MODE_APPLICATION, error))
+		return FALSE;
+
+	/* firmware CRC */
+	if (!fu_pixart_tp_plp239_device_get_crc_firmware(self, &crc_value, error))
+		return FALSE;
+	section = fu_pixart_tp_firmware_find_section_by_type(firmware,
+							     FU_PIXART_TP_UPDATE_TYPE_FW_SECTION,
+							     error);
+	if (section == NULL)
+		return FALSE;
+	if (crc_value != fu_pixart_tp_section_get_crc(section)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "firmware CRC compare failed");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* parameter CRC */
+	if (!fu_pixart_tp_plp239_device_get_crc_parameter(self, &crc_value, error))
+		return FALSE;
+	section = fu_pixart_tp_firmware_find_section_by_type(firmware,
+							     FU_PIXART_TP_UPDATE_TYPE_PARAM,
+							     error);
+	if (section == NULL)
+		return FALSE;
+	if (crc_value != fu_pixart_tp_section_get_crc(section)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "parameter CRC compare failed");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* hid descriptor CRC*/
+	if (!fu_pixart_tp_plp239_device_get_crc_hid_descriptor(self, &crc_value, error))
+		return FALSE;
+	section =
+	    fu_pixart_tp_firmware_find_section_by_type(firmware,
+						       FU_PIXART_TP_UPDATE_TYPE_HID_DESCRIPTOR,
+						       error);
+	if (section == NULL)
+		return FALSE;
+	if (crc_value != fu_pixart_tp_section_get_crc(section)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "hid CRC compare failed");
+		return FALSE;
+	}
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_setup(FuDevice *device, GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+	guint8 ver_l = 0;
+	guint8 ver_h = 0;
+	guint8 boot_status = 0;
+
+	/* sync bootloader flag from hardware state before doing anything else */
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK6,
+					       FU_PIXART_TP_REG_SYS6_PLP239_BOOT_STATUS,
+					       &boot_status,
+					       error)) {
+		g_prefix_error_literal(error, "failed to read boot status: ");
+		return FALSE;
+	}
+
+	/* check if nav is ready to imply application mode */
+	if ((boot_status & FU_PIXART_TP_BOOT_STATUS_PLP239_NAV_READY) == 0 || boot_status == 0xff) {
+		g_debug("device is in bootloader mode (status: 0x%02x)", boot_status);
+		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	} else {
+		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	}
+
+	/* read firmware version: 0x18 is high byte, 0x16 is low byte */
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK0,
+					       FU_PIXART_TP_REG_SYS0_PLP239_VERSION_HIGH,
+					       &ver_h,
+					       error)) {
+		g_prefix_error_literal(error, "failed to read version high: ");
+		return FALSE;
+	}
+	if (!fu_pixart_tp_device_register_read(FU_PIXART_TP_DEVICE(self),
+					       FU_PIXART_TP_SYSTEM_BANK_BANK0,
+					       FU_PIXART_TP_REG_SYS0_PLP239_VERSION_LOW,
+					       &ver_l,
+					       error)) {
+		g_prefix_error_literal(error, "failed to read version low: ");
+		return FALSE;
+	}
+
+	/* success */
+	fu_device_set_version_raw(device, (guint32)(ver_h << 8 | ver_l));
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_write_sections(FuPixartTpPlp239Device *self,
+					  GPtrArray *sections,
+					  FuProgress *progress,
+					  GError **error)
+{
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_set_steps(progress, sections->len);
+
+	for (guint i = 0; i < sections->len; i++) {
+		FuPixartTpSection *section = g_ptr_array_index(sections, i);
+		FuPixartTpUpdateType update_type = fu_pixart_tp_section_get_update_type(section);
+
+		/* skip non-updatable sections */
+		if (!fu_pixart_tp_section_has_flag(section, FU_PIXART_TP_FIRMWARE_FLAG_VALID) ||
+		    fu_pixart_tp_section_has_flag(section,
+						  FU_PIXART_TP_FIRMWARE_FLAG_IS_EXTERNAL)) {
+			fu_progress_step_done(progress);
+			continue;
+		}
+
+		if (update_type == FU_PIXART_TP_UPDATE_TYPE_TF_FORCE) {
+			g_debug("skip TF_FORCE section %u for TP parent device", i);
+			fu_progress_step_done(progress);
+			continue;
+		}
+
+		if (fu_firmware_get_size(FU_FIRMWARE(section)) == 0) {
+			fu_progress_step_done(progress);
+			continue;
+		}
+
+		if (!fu_pixart_tp_plp239_device_write_section(self,
+							      section,
+							      fu_progress_get_child(progress),
+							      error))
+			return FALSE;
+
+		fu_progress_step_done(progress);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_write_firmware(FuDevice *device,
+					  FuFirmware *firmware,
+					  FuProgress *progress,
+					  FwupdInstallFlags flags,
+					  GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+	g_autoptr(GPtrArray) sections = NULL;
+	guint64 total_update_bytes = 0;
+	FuPixartTpSection *fw_section = NULL;
+
+	/* progress */
+	fu_progress_set_id(progress, G_STRLOC);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 98, NULL);
+	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 2, NULL);
+
+	/* sanity check */
+	sections = fu_firmware_get_images(firmware);
+	if (sections->len == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "no sections to write");
+		return FALSE;
+	}
+
+	/* calculate total bytes for valid internal TP sections
+	 * NOTE:
+	 * - TF_FORCE sections are skipped here; they are handled by the
+	 * TF/haptic child-device using its own firmware image.
+	 */
+	for (guint i = 0; i < sections->len; i++) {
+		FuPixartTpSection *section = g_ptr_array_index(sections, i);
+		guint32 section_length = 0;
+		FuPixartTpUpdateType update_type;
+
+		if (!fu_pixart_tp_section_has_flag(section, FU_PIXART_TP_FIRMWARE_FLAG_VALID) ||
+		    fu_pixart_tp_section_has_flag(section, FU_PIXART_TP_FIRMWARE_FLAG_IS_EXTERNAL))
+			continue;
+
+		update_type = fu_pixart_tp_section_get_update_type(section);
+		if (update_type == FU_PIXART_TP_UPDATE_TYPE_TF_FORCE)
+			continue;
+
+		section_length = fu_firmware_get_size(FU_FIRMWARE(section));
+		if (section_length > 0)
+			total_update_bytes += (guint64)section_length;
+	}
+
+	/* sanity check */
+	if (total_update_bytes == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "no internal/valid TP sections to write");
+		return FALSE;
+	}
+	g_debug("total TP update bytes=%" G_GUINT64_FORMAT, total_update_bytes);
+
+	/* erase old firmware using 239 specific logic */
+	fw_section = fu_pixart_tp_firmware_find_section_by_type(FU_PIXART_TP_FIRMWARE(firmware),
+								FU_PIXART_TP_UPDATE_TYPE_FW_SECTION,
+								error);
+	if (fw_section != NULL) {
+		guint32 start_address = fu_pixart_tp_section_get_target_flash_start(fw_section);
+		if (!fu_pixart_tp_plp239_device_flash_erase_sector(
+			self,
+			(guint8)(start_address / FU_PIXART_TP_DEVICE_SECTOR_SIZE),
+			error))
+			return FALSE;
+	}
+
+	/* program all TP sections (TF_FORCE handled by child device) */
+	if (!fu_pixart_tp_plp239_device_write_sections(self,
+						       sections,
+						       fu_progress_get_child(progress),
+						       error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* verify CRC (firmware + parameter) */
+	if (!fu_pixart_tp_plp239_device_verify_crc(self,
+						   FU_PIXART_TP_FIRMWARE(firmware),
+						   fu_progress_get_child(progress),
+						   error))
+		return FALSE;
+	fu_progress_step_done(progress);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_attach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+
+	/* nothing to do if already in application mode */
+	if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
+		return TRUE;
+
+	if (!fu_pixart_tp_plp239_device_reset(self, FU_PIXART_TP_RESET_MODE_APPLICATION, error))
+		return FALSE;
+
+	/* success */
+	fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_detach(FuDevice *device, FuProgress *progress, GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+
+	/* already in bootloader, nothing to do */
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER))
+		return TRUE;
+
+	if (!fu_pixart_tp_plp239_device_reset(self, FU_PIXART_TP_RESET_MODE_BOOTLOADER, error))
+		return FALSE;
+
+	/* success */
+	fu_device_add_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_cleanup(FuDevice *device,
+				   FuProgress *progress,
+				   FwupdInstallFlags flags,
+				   GError **error)
+{
+	FuPixartTpPlp239Device *self = FU_PIXART_TP_PLP239_DEVICE(device);
+
+	/* ensure we are not stuck in bootloader */
+	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
+		if (!fu_pixart_tp_plp239_device_reset(self,
+						      FU_PIXART_TP_RESET_MODE_APPLICATION,
+						      error))
+			return FALSE;
+		fu_device_remove_flag(device, FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_pixart_tp_plp239_device_reload(FuDevice *device, GError **error)
+{
+	g_autoptr(GError) error_local = NULL;
+
+	/* best-effort: do not fail the whole update just because reload failed */
+	if (!fu_pixart_tp_plp239_device_setup(device, &error_local))
+		g_debug("failed to refresh firmware version: %s", error_local->message);
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fu_pixart_tp_plp239_device_class_init(FuPixartTpPlp239DeviceClass *klass)
+{
+	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->setup = fu_pixart_tp_plp239_device_setup;
+	device_class->write_firmware = fu_pixart_tp_plp239_device_write_firmware;
+	device_class->attach = fu_pixart_tp_plp239_device_attach;
+	device_class->detach = fu_pixart_tp_plp239_device_detach;
+	device_class->cleanup = fu_pixart_tp_plp239_device_cleanup;
+	device_class->reload = fu_pixart_tp_plp239_device_reload;
+}
+
+static void
+fu_pixart_tp_plp239_device_init(FuPixartTpPlp239Device *self)
+{
+}

--- a/plugins/pixart-tp/fu-pixart-tp-plp239-device.h
+++ b/plugins/pixart-tp/fu-pixart-tp-plp239-device.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Harris Tai <harris_tai@pixart.com>
+ * Copyright 2025 Micky Hsieh <micky_hsieh@pixart.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fu-pixart-tp-device.h"
+
+#define FU_TYPE_PIXART_TP_PLP239_DEVICE (fu_pixart_tp_plp239_device_get_type())
+G_DECLARE_FINAL_TYPE(FuPixartTpPlp239Device,
+		     fu_pixart_tp_plp239_device,
+		     FU,
+		     PIXART_TP_PLP239_DEVICE,
+		     FuPixartTpDevice)

--- a/plugins/pixart-tp/fu-pixart-tp-plugin.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plugin.c
@@ -10,6 +10,7 @@
 #include "fu-pixart-tp-device.h"
 #include "fu-pixart-tp-firmware.h"
 #include "fu-pixart-tp-haptic-device.h"
+#include "fu-pixart-tp-plp239-device.h"
 #include "fu-pixart-tp-plugin.h"
 
 struct _FuPixartTpPlugin {
@@ -36,6 +37,7 @@ fu_pixart_tp_plugin_constructed(GObject *obj)
 
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_PIXART_TP_DEVICE);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_PLP239_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_HAPTIC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_FIRMWARE);
 }

--- a/plugins/pixart-tp/fu-pixart-tp.rs
+++ b/plugins/pixart-tp/fu-pixart-tp.rs
@@ -2,6 +2,12 @@
 // Copyright 2025 Micky Hsieh
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#[repr(u8)]
+enum FuPixartTpResetMode {
+    Application,
+    Bootloader,
+}
+
 // bank ids
 #[repr(u8)]
 enum FuPixartTpSystemBank {
@@ -10,6 +16,7 @@ enum FuPixartTpSystemBank {
     Bank2 = 0x02,
     Bank4 = 0x04,
     Bank6 = 0x06,
+    Bank8 = 0x08,
 }
 
 #[repr(u8)]
@@ -19,24 +26,31 @@ enum FuPixartTpUserBank {
     Bank2 = 0x02,
 }
 
+// ------------------- Register Definition -----------------// 
+// system bank 0 (reset control registers)
+#[repr(u8)]
+enum FuPixartTpRegSys0 {
+    PartId  = 0x78,
+}
+
+// system bank 1 (reset control registers)
+#[repr(u8)]
+enum FuPixartTpRegSys1 {
+    ClocksPowerUp   = 0x0d,
+    ResetKey1       = 0x2c,
+    ResetKey2       = 0x2d,
+}
+
 // system bank 4 (flash engine registers)
 #[repr(u8)]
 enum FuPixartTpRegSys4 {
     FlashStatus   = 0x1c,
     SwapFlag      = 0x29,
     FlashInstCmd  = 0x2c,
-    FlashBufAddr0 = 0x2e,
-    FlashBufAddr1 = 0x2f,
-    FlashCcr0     = 0x40,
-    FlashCcr1     = 0x41,
-    FlashCcr2     = 0x42,
-    FlashCcr3     = 0x43,
-    FlashDataCnt0 = 0x44,
-    FlashDataCnt1 = 0x45,
-    FlashAddr0    = 0x48,
-    FlashAddr1    = 0x49,
-    FlashAddr2    = 0x4a,
-    FlashAddr3    = 0x4b,
+    FlashBufAddr  = 0x2e,
+    FlashCcr      = 0x40,
+    FlashDataCnt  = 0x44,
+    FlashAddr     = 0x48,
     FlashExecute  = 0x56,
 }
 
@@ -48,16 +62,7 @@ enum FuPixartTpRegSys6 {
     SramTrigger    = 0x0a,
     SramData       = 0x0b,
     SramChecksum   = 0x0c,
-    SramAddr0      = 0x10,
-    SramAddr1      = 0x11,
-}
-
-// system bank 1 (reset control registers)
-#[repr(u8)]
-enum FuPixartTpRegSys1 {
-    ClocksPowerUp   = 0x0d,
-    ResetKey1       = 0x2c,
-    ResetKey2       = 0x2d,
+    SramAddr       = 0x10,
 }
 
 // user bank 0 (part id + crc registers)
@@ -66,43 +71,99 @@ enum FuPixartTpRegUser0 {
     BootStaus  = 0x00,
     RunMode    = 0x16,
     ProxyMode  = 0x56,
-    PartId0    = 0x78,
-    PartId1    = 0x79,
     CrcCtrl    = 0x82,
-    CrcResult0 = 0x84,
-    CrcResult1 = 0x85,
-    CrcResult2 = 0x86,
-    CrcResult3 = 0x87,
+    CrcResult  = 0x84,
 }
-
+// ------------------- Register Definition (PLP239) -----------------// 
+// system bank 0 for PLP239
 #[repr(u8)]
-enum FuPixartTpBootStatus{
-    Rom = 0x8c,
+enum FuPixartTpRegSys0Plp239 {
+    ClockPu         = 0x00,
+    ClockPu2        = 0x02,
+    ClockPd         = 0x04,
+    VersionLow      = 0x16,
+    VersionHigh     = 0x18,
+    Bank0ProtectKey = 0x7c,
 }
 
+// system bank 1 for PLP239
 #[repr(u8)]
-enum FuPixartTpRunMode {
-    Auto     = 0x00,
-    ForceRun = 0x01,
+enum FuPixartTpRegSys1Plp239 {
+    ResetKey1       = 0x20,
+    ResetKey2       = 0x21,
 }
 
+// system bank 4 for PLP239
 #[repr(u8)]
-enum FuPixartTpResetMode {
-    Application,
-    Bootloader,
+enum FuPixartTpRegSys4Plp239 {
+    LowLevelProtection  = 0x18,
+    MaskCpuAccess       = 0x19,
+    FlashCommand        = 0x1a,
+    SramOffset          = 0x1c,
+    FlashDataCount      = 0x1e,
+    FlashAddress        = 0x20,
+    FlashWriteDataWord0 = 0x24,      
+    FlashInstruction    = 0x2c,
+    FlashQuad           = 0x2f,
+    DummyBy             = 0x30,
 }
 
+// system bank 6 for PLP239
+#[repr(u8)]
+enum FuPixartTpRegSys6Plp239 {
+    FirmwareCrc             = 0x08,
+    ParameterCrc            = 0x0c,
+    BootStatus              = 0x10,
+    ZeroLevelProtectKey     = 0x20,
+    ProgramBist             = 0x21,
+    OneLevelProtectKey      = 0x22,
+    FlashSectorAddress      = 0x23,
+    FlashSectorLength       = 0x24,
+    SfcCommand              = 0x25,
+    SramAccessData          = 0x26,
+    FlashControllerStatus   = 0x27,
+    HidDescriptorCrcCtrl    = 0x6b,
+    HidDescriptorCrc        = 0x6c,
+    WatchdogDisable         = 0x7d,
+}
+
+// system bank 8 for PLP239
+#[repr(u8)]
+enum FuPixartTpRegSys8Plp239 {
+    HidFirmwareReady    = 0x68,
+}
+
+// ------------------- System Bank 1 Key -----------------// 
+// 0x0d: ClocksPowerUp
+#[repr(u8)]
+enum FuPixartTpClocksPowerUp {
+    None    = 0,
+    Cpu     = 1 << 1,
+    Nyq     = 1 << 6,
+    NyqF    = 1 << 7,
+}
+
+// 0x2c: ResetKey1
 #[repr(u8)]
 enum FuPixartTpResetKey1 {
     Suspend = 0xaa,
 }
-
+// 0x2d: ResetKey2
 #[repr(u8)]
 enum FuPixartTpResetKey2 {
     Regular    = 0xbb,
     Bootloader = 0xcc,
 }
 
+// ------------------- System Bank 4 Key -----------------//
+// 0x1c: FlashStatus
+#[repr(u8)]
+enum FuPixartTpFlashWriteEnable {
+    Busy = 0x01,
+    Success = 0x02,
+}
+
+// 0x2c: FlashInstCmd
 #[repr(u8)]
 enum FuPixartTpFlashInst {
     None               = 0,
@@ -111,27 +172,7 @@ enum FuPixartTpFlashInst {
     InternalSramAccess = 1 << 7,
 }
 
-#[repr(u8)]
-enum FuPixartTpClocksPowerUp {
-    Cpu = 1 << 1,
-}
-
-#[repr(u8)]
-enum FuPixartTpFlashExecState {
-    Busy    = 0x01,
-    Success = 0x00,
-}
-
-#[repr(u8)]
-enum FuPixartTpFlashWriteEnable {
-    Success = 0x02,
-}
-
-#[repr(u8)]
-enum FuPixartTpFlashStatus {
-    Busy = 0x01,
-}
-
+// 0x40: FlashCcr
 #[repr(u32)]
 enum FuPixartTpFlashCcr {
     WriteEnable = 0x0000_0106,
@@ -140,20 +181,205 @@ enum FuPixartTpFlashCcr {
     ProgramPage = 0x0100_2502,
 }
 
+// 0x56: FlashExecute
+#[repr(u8)]
+enum FuPixartTpFlashExecState {
+    Busy    = 0x01,
+    Success = 0x00,
+}
+
+// ------------------- User Bank 0 Key -----------------// 
+// 0x00: BootStaus
+#[repr(u8)]
+enum FuPixartTpBootStatus{
+    Rom = 0x8c,
+}
+
+// 0x16: RunMode
+#[repr(u8)]
+enum FuPixartTpRunMode {
+    Auto     = 0x00,
+    ForceRun = 0x01,
+}
+
+// 0x78: PartId
 #[repr(u16)]
 enum FuPixartTpPartId {
+    Plp239 = 0x0239,
     Pjp274 = 0x0274,
 }
 
+// 0x82: CrcCtrl
 #[repr(u8)]
 enum FuPixartTpCrcCtrl {
-    FwBank0    = 0x02,
-    FwBank1    = 0x10,
-    ParamBank0 = 0x04,
-    ParamBank1 = 0x20,
-    Busy       = 0x01,
+    FwBank0         = 0x02,
+    FwBank1         = 0x10,
+    ParamBank0      = 0x04,
+    ParamBank1      = 0x20,
+    HidDescriptor   = 0x0a,
+    Busy            = 0x01,
 }
 
+// ------------------- System Bank 0 Key (PLP239) -----------------// 
+// 0x04: ClockPd
+#[repr(u8)]
+enum FuPixartTpClocksPowerDisablePlp239 {
+    None    = 0,
+    Cpu     = 1 << 1,
+}
+
+// ------------------- System Bank 4 Key (PLP239) -----------------// 
+// 0x18: LowLevelProtection
+#[repr(u8)]
+enum FuPixartTpLowLevelProtectionKeyPlp239 {
+    Lock    = 0x00,
+    Unlock  = 0xcc,
+}
+
+// 0x19: MaskCpuAccess
+#[repr(u8)]
+enum FuPixartTpCpuAccessMaskPlp239 {
+    Enable    = 0x00,
+    Disable   = 0x01,
+}
+
+// 0x1a: FlashCommand
+#[repr(u8)]
+enum FuPixartTpFlashCommandPlp239 {
+    // Generic Control
+    FlashCmdWrsr    = 0x01, // Write Status, EoN/Winbond
+    FlashCmdRdsr    = 0x05, // Read Status, EoN/Winbond
+    FlashCmdRdsr2Wb = 0x35, // Read Status Register 2, Winbond
+    FlashCmdWren    = 0x06, // Write Enable, EoN/Winbond
+    FlashCmdWrdi    = 0x04, // Write Disable, EoN/Winbond
+
+    // Program / Erase
+    FlashCmdPp       = 0x02, // Page Program, EoN/Winbond
+    FlashCmdQualPpWb = 0x32, // Quad Page Program, Winbond
+    FlashCmdSe       = 0x20, // Sector Erase (4K), EoN/Winbond
+    FlashCmdHbe      = 0x52, // Half Block Erase (32K), EoN/Winbond
+    FlashCmdBe       = 0xd8, // Block Erase (64K), EoN/Winbond
+    FlashCmdCe0      = 0x60, // Chip Erase Alt, EoN/Winbond
+    FlashCmdCe       = 0xc7, // Chip Erase, EoN/Winbond
+
+    // Identification & Reset
+    FlashCmdRdid      = 0x9f, // Read JEDEC ID, EoN/Winbond
+    FlashCmdRstenEon  = 0x66, // Reset Enable, EoN
+    FlashCmdRstEon    = 0x99, // Reset, EoN
+    FlashCmdEqpiEon   = 0x38, // Enable Quad Peripheral Interface, EoN
+    FlashCmdRstqioEon = 0xff, // Reset Quad I/O, EoN
+
+    // Read Operations
+    FlashCmdRead                 = 0x03, // Read Data
+    FlashCmdFastRead             = 0x0b, // Fast Read
+    FlashCmdFastReadDualOutput   = 0x3b, // Dual Output Fast Read
+    FlashCmdFastReadQualOutputWb = 0x6b, // Quad Output Fast Read, Winbond
+    FlashCmdDualIoFastRead       = 0xbb, // Dual I/O Fast Read
+    FlashCmdQuadIoFastRead       = 0xeb, // Quad I/O Fast Read
+
+    // Power Management
+    FlashCmdPowrDown         = 0xb9, // Power down
+    FlashCmdReleasePowerDown = 0xab, // Release power down
+}
+
+// 0x2c: FlashInstruction
+#[repr(u8)]
+enum FuPixartTpFlashInstPlp239 {
+    None                    = 0,
+    FlashWriteData          = 1 << 0,
+    FlashWriteInstruction   = 1 << 1,
+    FlashReadData           = 1 << 2,
+    FlashReadInstruction    = 1 << 3,
+    InternalSramAccess      = 1 << 7,
+}
+
+// 0x2f: FlashQuad
+#[repr(u8)]
+enum FuPixartTpFlashQuad {
+    None            = 0,
+    EqioEon         = 1 << 0,
+    Q4ppWinb        = 1 << 1,
+    Q4ppEon         = 1 << 2,
+    Q4ppMxic        = 1 << 3,
+    QuadEnperfMd    = 1 << 4,
+    QuadDualMd      = 1 << 5,
+    QuadMd          = 1 << 6,
+    FdualoutMd      = 1 << 7,
+}
+
+// ------------------- System Bank 6 Key (PLP239) -----------------// 
+// 0x10: BootStatus
+#[repr(u8)]
+enum FuPixartTpBootStatusPlp239{
+    None                = 0,
+    HwReady             = 1 << 0,
+    FwCodePass          = 1 << 1,
+    HidPass             = 1 << 2,
+    IfbCheckSumPass     = 1 << 3,
+    Wdog                = 1 << 4,
+    EhiReady            = 1 << 5,
+    Error               = 1 << 6,
+    NavReady            = 1 << 7,
+}
+
+// 0x20: ZeroLevelProtectKey
+#[repr(u8)]
+enum FuPixartTpZeroLevelProtectKeyPlp239 {
+    ProtectKey  = 0xcc,
+}
+
+// 0x22: OneLevelProtectKey
+#[repr(u8)]
+enum FuPixartTpOneLevelProtectKeyPlp239 {
+    ProtectKey  = 0xee,
+}
+
+// 0x24: FlashSectorLength
+#[repr(u8)]
+enum FuPixartTpFlashSectorLengthPlp239 {
+    KB_4  = 0x00, // 4 KB
+}
+
+// 0x25: SfcCommand
+#[repr(u8)]
+enum FuPixartTpSfcCommandPlp239 {
+    SramReadWrite   = 0x11,
+    Program         = 0x33,
+    Erase           = 0x44,
+    Read            = 0x77,
+    Finish          = 0xdd,
+}
+
+// 0x27: FlashControllerStatus
+#[repr(u8)]
+enum FuPixartTpFlashControllerStatusPlp239 {
+    Finish          = 1 << 0,
+    BufferOverFlow  = 1 << 1,
+    ProgramOverFlow = 1 << 2,
+    BistError       = 1 << 3,
+    ProtectError    = 1 << 4,
+    HighLevelEnable = 1 << 5,
+    Level1Enable    = 1 << 6,
+    CpuClockEnable  = 1 << 7,
+}
+
+// 0x7d: WatchdogDisable
+#[repr(u8)]
+enum FuPixartTpWatchDogKeyPlp239 {
+    Enable  = 0x00,
+    Disable = 0xad,
+}
+
+// ------------------- System Bank 8 Key (PLP239) -----------------// 
+// 0x68: HidFirmwareReady
+#[repr(u8)]
+enum FuPixartTpHidFirmwareReadyPlp239 {
+    None                = 0,
+    HidFirmwareReady    = 1 << 1,
+    FirmwareReady       = 1 << 2,
+}
+
+// ------------------- TF Haptic Command -----------------// 
 // host <-> tf pass-through proxy mode
 #[repr(u8)]
 enum FuPixartTpProxyMode {
@@ -285,11 +511,12 @@ struct FuStructPixartTpTfReplyHdr {
 #[derive(ToString, FromString)]
 #[repr(u8)]
 enum FuPixartTpUpdateType {
-    General    = 0,
-    FwSection  = 1,
-    Bootloader = 2,
-    Param      = 3,
-    TfForce    = 16,
+    General         = 0,
+    FwSection       = 1,
+    Bootloader      = 2,
+    Param           = 3,
+    HidDescriptor   = 4,
+    TfForce         = 16,
 }
 
 #[derive(ToString, FromString)]

--- a/plugins/pixart-tp/meson.build
+++ b/plugins/pixart-tp/meson.build
@@ -6,6 +6,7 @@ plugin_quirks += files('pixart-tp.quirk')
 plugin_builtin_pixart_tp = static_library('fu_plugin_pixart_tp',
   rustgen.process('fu-pixart-tp.rs'),
   sources: [
+    'fu-pixart-tp-plp239-device.c',
     'fu-pixart-tp-haptic-device.c',
     'fu-pixart-tp-device.c',
     'fu-pixart-tp-section.c',
@@ -19,7 +20,11 @@ plugin_builtin_pixart_tp = static_library('fu_plugin_pixart_tp',
 )
 plugin_builtins += plugin_builtin_pixart_tp
 
-device_tests += files('tests/pixart-tp.json')
+device_tests += files(
+  'tests/pixart-tp.json',
+  'tests/pixart-tp-plp239.json',
+  'tests/pixart-tp-pjp274.json',
+)
 
 if get_option('tests')
   install_data(

--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -1,18 +1,22 @@
+[HIDRAW\VEN_093A&DEV_0239]
+Plugin = pixart_tp
+GType = FuPixartTpPlp239Device
+
 [HIDRAW\VEN_093A&DEV_0274]
 Plugin = pixart_tp
-PixartTpSramSelect = 0x08
 
 [HIDRAW\VEN_093A&DEV_0343]
 Plugin = pixart_tp
 
 [HIDRAW\VEN_093A&DEV_3307]
 Plugin = pixart_tp
-PixartTpSramSelect = 0x08
 
 [HIDRAW\VEN_093A&DEV_3317]
 Plugin = pixart_tp
-PixartTpSramSelect = 0x08
 
 [HIDRAW\VEN_093A&DEV_4F07]
 Plugin = pixart_tp
 PixartTpHasHaptic = true
+
+[PIXARTTP\PARTID_0274]
+PixartTpSramSelect = 0x08

--- a/plugins/pixart-tp/tests/pixart-tp-pjp274.json
+++ b/plugins/pixart-tp/tests/pixart-tp-pjp274.json
@@ -1,0 +1,18 @@
+{
+  "name": "PixArt POCO 3348QC Touchpad",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "df0bae2833853aedfc79064cce447553426d34d9dfc1a61a83be63e7c14fdf47-firmware.cab",
+      "emulation-url": "04c3700cdf7a6e8408be615f446fa5b7cf94d20b641f572efd89412f4488a5fa-pxi-tp-update.zip",
+      "components": [
+        {
+          "version": "0x3c02",
+          "guids": [
+            "2a62ed27-652b-5223-8a24-53e40176e152"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/pixart-tp/tests/pixart-tp-plp239.json
+++ b/plugins/pixart-tp/tests/pixart-tp-plp239.json
@@ -1,0 +1,18 @@
+{
+  "name": "PixArt POCO 2642QC Touchpad",
+  "interactive": false,
+  "steps": [
+    {
+      "url": "94a2c86c548eb6261db02cad2aa02e8ae2917c81ac82d222d3cdf7e585322e9e-firmware.cab",
+      "emulation-url": "b1bbe92aec1779c9596992330dcfced8e7b4acd4fc910cdad2b69741f5aaa2d3-pxi-tp-update.zip",
+      "components": [
+        {
+          "version": "0x8002",
+          "guids": [
+            "5c30256d-d711-51ca-b3e4-665910007369"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/pixart-tp/tests/pixart-tp.json
+++ b/plugins/pixart-tp/tests/pixart-tp.json
@@ -3,11 +3,11 @@
   "interactive": false,
   "steps": [
     {
-      "url": "f4cfe7e15d7a33e66e8357c9fb924633bc85ef411ff9d4c789fb67478461d3b9-firmware.cab",
-      "emulation-url": "b8c9243c0a5dc14f36a56874564c57d0515168bb9da59dab7b1e957db36b606f-pxi-tp-update.zip",
+      "url": "1593b66fe80d0a60dbb2c007df6a799f29ece453904a3d42e75514a40c02baeb-firmware.cab",
+      "emulation-url": "5ba798f709655376f64d07c9ae65b4a5257f0efaf33c17d390dd760d15bc790f-pxi-tp-update.zip",
       "components": [
         {
-          "version": "0xff02",
+          "version": "0x0205",
           "guids": [
             "86407e75-7d7f-5d09-97db-700776490493"
           ]


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Release Note:
- Add support for the 239 device
- Fix reading the part ID from the wrong bank
- Update the emulated device file
- Add read/write register helper functions to simplify code for consecutive register addresses