### PR TITLE
goodix-moc: Retry open to avoid conflict with the kernel

### DIFF
--- a/plugins/goodix-moc/fu-goodix-moc-device.c
+++ b/plugins/goodix-moc/fu-goodix-moc-device.c
@@ -438,6 +438,7 @@ fu_goodix_moc_device_init(FuGoodixMocDevice *self)
 {
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SELF_RECOVERY);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_RETRY_OPEN);
 	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_USE_RUNTIME_VERSION);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PLAIN);


### PR DESCRIPTION
Sometimes when updating, after restarting, fwupd cannot claim the device again:

failed to add device /sys/devices/pci0000:00/0000:00:08.3/0000:c5:00.0/usb3/3-4/3- 4.1: failed to subclass open: failed to claim interface 0x00: USB error: Resource busy [-6]

Apply the same fix as in 3252573ac733beb35c8fd6b5a9cbb0f014131c57

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
