### PR TITLE
trivial: fix Debian container build setup

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -151,11 +151,6 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency id="gcc-multilib-s390x-linux-gnu">
-    <distro id="debian">
-      <package variant="s390x" />
-    </distro>
-  </dependency>
   <dependency id="libcairo-dev">
     <distro id="centos">
       <package variant="x86_64">cairo-devel</package>


### PR DESCRIPTION
Package doesn't appear to exist anymore. Should be handled by the crossbuild-essential-s390x package, hopefully.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
