### PR TITLE
trivial: misc container build fixes

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/fwupd/fwupd/fwupd-${{ matrix.distro }}:latest
+          tags: ghcr.io/fwupd/fwupd/fwupd-${{ matrix.distro }}-${{ runner.arch }}:latest

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -9,7 +9,6 @@ RUN set -euxo pipefail; \
     apt-get install --yes --no-install-recommends \
     python3-apt \
 %%%DEPENDENCIES%%%; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean
 WORKDIR /github/workspace
 CMD ["./contrib/ci/ubuntu.sh"]


### PR DESCRIPTION
Unfortunately, multiplatform builds with separate Dockerfiles doesn't work really with the docker/build-push-action because then only one of the architecture images will have the "latest" tag. So let's just put the arch in the container name instead, the containers are only for CI anyway.

Some of the ubuntu scripts wants to install more packages and likely doesn't run `apt update`.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
