### PR TITLE
trivial: fix container builds some more

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/fwupd/fwupd/fwupd-${{ matrix.distro }}-${{ runner.arch }}:latest
+          tags: ghcr.io/fwupd/fwupd/fwupd-${{ matrix.distro }}-${{ case(runner.arch == 'ARM64', 'arm64', 'amd64') }}:latest


### PR DESCRIPTION
We have to translate the name here as well from the weird github runner.arch naming convention.

ERROR: failed to build: invalid tag "ghcr.io/fwupd/fwupd/fwupd-debian-X64:latest": repository name must be lowercase

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
