### PR TITLE
uf2: fix race with UDisks2 volume discovery during replug

### DIFF
--- a/plugins/uf2/fu-uf2-device.c
+++ b/plugins/uf2/fu-uf2-device.c
@@ -166,11 +166,21 @@ static gboolean
 fu_uf2_device_volume_mount(FuUf2Device *self, GError **error)
 {
 	const gchar *devfile = fu_udev_device_get_device_file(FU_UDEV_DEVICE(self));
+	g_autoptr(FuVolume) volume = NULL;
 
 	/* mount volume if required */
-	self->volume = fu_volume_new_by_device(devfile, error);
-	if (self->volume == NULL)
+	volume = fu_volume_new_by_device(devfile, error);
+	if (volume == NULL)
 		return FALSE;
+
+	/* already mounted by user session, nothing to do */
+	if (fu_volume_is_mounted(volume)) {
+		g_debug("volume %s is already mounted, skipping mount", devfile);
+		return TRUE;
+	}
+
+	/* mount it ourselves -- close() will unmount */
+	self->volume = g_steal_pointer(&volume);
 	return fu_volume_mount(self->volume, error);
 }
 
@@ -183,7 +193,7 @@ fu_uf2_device_check_volume_mounted_cb(FuDevice *device, gpointer user_data, GErr
 	if (devfile == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
-				    FWUPD_ERROR_NOT_FOUND,
+				    FWUPD_ERROR_INTERNAL,
 				    "invalid path: no devfile");
 		return FALSE;
 	}
@@ -226,8 +236,9 @@ fu_uf2_device_open(FuDevice *device, GError **error)
 				  50, /* ms */
 				  NULL,
 				  &error_local)) {
-		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
-			/* maybe no session running? */
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
+		    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND)) {
+			/* maybe no session running, or UDisks2 was slow to discover the volume */
 			if (!fu_uf2_device_volume_mount(self, error))
 				return FALSE;
 		} else {


### PR DESCRIPTION
Plugins like framework-qmk first reset the device into the UF2 bootloader, so they have to wait for the device to reappear and be auto-mounted by udisks2 or fwupd.

If udisks2 hasn't processed the new block device yet, fu_volume_new_by_device() returns NOT_FOUND. This would happen occasionally if the timing was off between the mounting and fwupd checking.

Previously, only NOT_SUPPORTED (volume found but not mounted) triggered the fallback mount path. NOT_FOUND (UDisks2 doesn't know about it yet) was treated as a fatal error, causing the UF2 device to never be added. The SCSI plugin would then claim the device without REPLUG_MATCH_GUID, so replug matching would fail with "device did not come back".

So the fixes are:

Fallback to manually mount in case of FWUPD_ERROR_NOT_FOUND after timeout of waiting for udisks automount. That should always work.

Check if the volume is already mounted before attempting to mount in the fallback case, to avoid AlreadyMounted errors when udisks2 auto-mounted the volume during the retry/fallback window.

I first tried to increase the retries and retry wait but that didn't help and is not necessary with these changes here.

Fixes: https://github.com/fwupd/fwupd/issues/9150

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
