### PR TITLE
trivial: fix debian dockerfile

### DIFF
--- a/.github/workflows/create_containers.yml
+++ b/.github/workflows/create_containers.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest]
         distro: [arch, centos, debian, fedora, ubuntu]
+        runner: [ubuntu-latest]
         include:
-          - runner: ubuntu-24.04-arm
-            distro: debian
-          - runner: ubuntu-24.04-arm
-            distro: precommit
+          - distro: debian
+            runner: ubuntu-24.04-arm
+          - distro: precommit
+            runner: ubuntu-24.04-arm
     steps:
       - name: Check out the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -9,6 +9,8 @@ RUN set -euxo pipefail; \
     dpkg --add-architecture s390x; \
     apt-get update; \
     apt-get install --yes --no-install-recommends \
+    build-essential \
+    dpkg-dev \
     python3-apt \
 %%%DEPENDENCIES%%%; \
     apt-get clean; \

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -981,8 +981,6 @@
     <distro id="debian">
       <control />
       <package variant="x86_64" />
-      <package variant="s390x" />
-      <package variant="i386" />
     </distro>
     <distro id="ubuntu">
       <control />


### PR DESCRIPTION
Strangely these packages only seem to need to be specified for the arm64 container.

Also change the ordering because it influences how the actions are listed and it's confusing to read ubuntu first everywhere when the actual distro being used is something else.

Changing the locales dep in dependencies.xml is something I am not that sure about, noticed that `apt build-dep --host-architecture s390x fwupd` (using control file from Debian distro package) fails because of wanting locales:s390x.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
