### PR TITLE
trivial: Bump libxmlb requirement to 0.3.24

### DIFF
--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.3.21
+revision = 0.3.24


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Noticed this because of a compiler warning that is fixed on libxmlb `main` but not in a released version yet. Better than this here would be to release libxmlb 0.3.25 first and bump to that, until then this is the next-best approach :)