### PR TITLE
focal-touch: Update BinLength response format for official firmware

### DIFF
--- a/plugins/focal-touch/fu-focal-touch.rs
+++ b/plugins/focal-touch/fu-focal-touch.rs
@@ -79,7 +79,8 @@ struct FuStructFocalTouchBinLengthRes {
     report_id: u8 == 0x06,
     _pad: [u8; 2],
     len: u8 == $struct_size,
-    cmd: FuFocalTouchCmd == Ack,
+    cmd: FuFocalTouchCmd == WriteRegister,
+    reg: FuFocalTouchCmd == BinLength,
 }
 
 #[derive(New, Default)]


### PR DESCRIPTION
The plugin was originally developed against a pre-release version  of the touchscreen firmware. However, the response format for the  `SendBinLength` command was modified in the first official firmware  release.

This commit updates the `BinLength` response structure to match  the official firmware specification, fixing the 
`constant FuStructFocalTouchBinLengthRes.len was not valid` error  during the update process.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation
