### PR TITLE
sunwinon-hid: enhance

### DIFF
--- a/plugins/sunwinon-hid/fu-sunwinon-hid-device.c
+++ b/plugins/sunwinon-hid/fu-sunwinon-hid-device.c
@@ -120,6 +120,41 @@ fu_sunwinon_hid_device_dfu_send_frame(FuSunwinonHidDevice *self,
 					   error);
 }
 
+static gboolean
+fu_sunwinon_hid_device_dfu_recv_cb(FuDevice *device, gpointer user_data, GError **error)
+{
+	FuSunwinonHidDevice *self = FU_SUNWINON_HID_DEVICE(device);
+	guint8 *buf = (guint8 *)user_data;
+	guint8 report_id = 0;
+	g_autoptr(GError) error_local = NULL;
+
+	memset(buf, 0, FU_STRUCT_SUNWINON_HID_IN_SIZE);
+	/* may not get a full length report here */
+	if (!fu_hidraw_device_get_report(FU_HIDRAW_DEVICE(self),
+					 buf,
+					 FU_STRUCT_SUNWINON_HID_IN_SIZE,
+					 FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
+					 &error_local)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_READ)) {
+			g_propagate_error(error, g_steal_pointer(&error_local));
+			return FALSE;
+		}
+	}
+	fu_dump_raw(G_LOG_DOMAIN, "raw input report", buf, FU_STRUCT_SUNWINON_HID_IN_SIZE);
+
+	/* discard reports not matching the OTA report ID */
+	report_id = buf[FU_STRUCT_SUNWINON_HID_IN_OFFSET_REPORT_ID];
+	if (report_id != FU_SUNWINON_HID_REPORT_CHANNEL_ID) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "discarding report with non-OTA report ID 0x%02x",
+			    report_id);
+		return FALSE;
+	}
+	return TRUE;
+}
+
 static GByteArray *
 fu_sunwinon_hid_device_dfu_recv_frame(FuSunwinonHidDevice *self,
 				      FuSunwinonDfuCmd cmd_expected,
@@ -131,42 +166,14 @@ fu_sunwinon_hid_device_dfu_recv_frame(FuSunwinonHidDevice *self,
 	guint8 buf[FU_STRUCT_SUNWINON_HID_IN_SIZE] = {0};
 	g_autoptr(FuStructSunwinonHidIn) st = NULL;
 	g_autoptr(GByteArray) bufout = g_byte_array_new();
-	g_autoptr(GError) error_local = NULL;
 
 	/* retry receiving until we get a report with the correct OTA report ID */
-	for (gsize i = 0; i < FU_SUNWINON_HID_DEVICE_RECV_RETRY_COUNT; i++) {
-		memset(buf, 0, sizeof(buf));
-		/* may not get a full length report here */
-		if (!fu_hidraw_device_get_report(FU_HIDRAW_DEVICE(self),
-						 buf,
-						 sizeof(buf),
-						 FU_IO_CHANNEL_FLAG_SINGLE_SHOT,
-						 &error_local)) {
-			if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_READ)) {
-				g_propagate_error(error, g_steal_pointer(&error_local));
-				return NULL;
-			}
-			g_clear_error(&error_local);
-		}
-		fu_dump_raw(G_LOG_DOMAIN, "raw input report", buf, sizeof(buf));
-
-		/* discard reports not matching the OTA report ID */
-		if (buf[FU_STRUCT_SUNWINON_HID_IN_OFFSET_REPORT_ID] ==
-		    FU_SUNWINON_HID_REPORT_CHANNEL_ID)
-			break;
-		g_debug("discarding report with non-OTA report ID 0x%02x, retry %u/%u",
-			buf[FU_STRUCT_SUNWINON_HID_IN_OFFSET_REPORT_ID],
-			(guint)(i + 1),
-			(guint)FU_SUNWINON_HID_DEVICE_RECV_RETRY_COUNT);
-		if (i >= FU_SUNWINON_HID_DEVICE_RECV_RETRY_COUNT - 1) {
-			g_set_error(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "did not receive OTA report after %u retries",
-				    (guint)FU_SUNWINON_HID_DEVICE_RECV_RETRY_COUNT);
-			return NULL;
-		}
-	}
+	if (!fu_device_retry(FU_DEVICE(self),
+			     fu_sunwinon_hid_device_dfu_recv_cb,
+			     FU_SUNWINON_HID_DEVICE_RECV_RETRY_COUNT,
+			     buf,
+			     error))
+		return NULL;
 
 	/* check command */
 	st = fu_struct_sunwinon_hid_in_parse(buf, sizeof(buf), 0, error);
@@ -642,6 +649,7 @@ fu_sunwinon_hid_device_init(FuSunwinonHidDevice *self)
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_READ);
 	fu_udev_device_add_open_flag(FU_UDEV_DEVICE(self), FU_IO_CHANNEL_OPEN_FLAG_WRITE);
 	fu_device_set_remove_delay(FU_DEVICE(self), FU_SUNWINON_HID_DEVICE_REPLUG_WAIT_TIME);
+	fu_device_retry_add_recovery(FU_DEVICE(self), FWUPD_ERROR, FWUPD_ERROR_TIMED_OUT, NULL);
 }
 
 static void


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This patch contains a few fix and enhancement according to feedback from collaborators:
- A filter on report id is applied to recv so that device is still functional during firmware downloading, and these unrelated report do not break OTA;
- Make replug wait time and reboot wait time longer due to test firmware often faces unexpected regression on time of reconnection, making OTA procedure superficially fail.

The old emulation still works.
