### PR TITLE
trivial: Chain up the `GObjectClass->constructed()` vfunc

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -815,6 +815,20 @@ class Checker:
                     "did not have parent ->finalize()", linecnt=token.linecnt
                 )
 
+    def _test_gobject_constructed(self, node: Node) -> None:
+
+        if node.tokens_pre.endswith_fuzzy(
+            ["void", "~*_constructed", "(", "GObject", "*", "~*", ")"]
+        ):
+            token = node.tokens_pre[-1]
+            idx = node.tokens.find_fuzzy(
+                ["G_OBJECT_CLASS", "(", "~*_parent_class", ")", "-", ">", "constructed"]
+            )
+            if idx == -1:
+                self.add_failure(
+                    "did not have parent ->constructed()", linecnt=token.linecnt
+                )
+
     def _test_blocked_funcs(self, node: Node) -> None:
 
         for token, msg in {
@@ -1438,6 +1452,7 @@ class Checker:
             self._current_nocheck = "nocheck:finalize"
             if self._should_process_node(node):
                 self._test_gobject_finalize(node)
+                self._test_gobject_constructed(node)
 
             # test for blocked functions
             self._current_nocheck = "nocheck:blocked"

--- a/libfwupdplugin/fu-cfi-device.c
+++ b/libfwupdplugin/fu-cfi-device.c
@@ -964,6 +964,9 @@ fu_cfi_device_constructed(GObject *obj)
 {
 	FuCfiDevice *self = FU_CFI_DEVICE(obj);
 	fu_device_add_instance_id(FU_DEVICE(self), "SPI");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_cfi_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -2676,6 +2676,9 @@ fu_context_constructed(GObject *obj)
 	priv->efivars = (priv->flags & FU_CONTEXT_FLAG_DUMMY_EFIVARS) > 0
 			    ? fu_dummy_efivars_new()
 			    : fu_efivars_new(priv->pstore);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_context_parent_class)->constructed(obj);
 }
 
 static void

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -2645,6 +2645,9 @@ fu_firmware_constructed(GObject *obj)
 	if (G_TYPE_FROM_CLASS(klass) != FU_TYPE_FIRMWARE && klass->parse_full == NULL &&
 	    klass->parse == NULL)
 		fu_firmware_add_flag(self, FU_FIRMWARE_FLAG_IS_ABSTRACT);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_firmware_parent_class)->constructed(obj);
 }
 
 static void

--- a/libfwupdplugin/fu-intel-me-device.c
+++ b/libfwupdplugin/fu-intel-me-device.c
@@ -762,6 +762,9 @@ fu_intel_me_device_constructed(GObject *obj)
 	fu_device_add_instance_id_full(FU_DEVICE(self),
 				       "PCI\\VEN_8086",
 				       FU_DEVICE_INSTANCE_FLAG_QUIRKS);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_me_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/acpi-phat/fu-acpi-phat-plugin.c
+++ b/plugins/acpi-phat/fu-acpi-phat-plugin.c
@@ -57,6 +57,9 @@ fu_acpi_phat_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ACPI_PHAT);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_acpi_phat_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
+++ b/plugins/algoltek-usb/fu-algoltek-usb-plugin.c
@@ -28,6 +28,9 @@ fu_algoltek_usb_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ALGOLTEK_USB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ALGOLTEK_USB_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_algoltek_usb_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-plugin.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-plugin.c
@@ -28,6 +28,9 @@ fu_algoltek_usbcr_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_udev_subsystem(plugin, "block:disk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ALGOLTEK_USBCR_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ALGOLTEK_USBCR_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_algoltek_usbcr_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/amd-gpu/fu-amd-gpu-plugin.c
+++ b/plugins/amd-gpu/fu-amd-gpu-plugin.c
@@ -37,6 +37,9 @@ fu_amd_gpu_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_GPU_PSP_FIRMWARE);
 	/* navi 2x and older have the ATOM firmware at start of image */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_GPU_ATOM_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_amd_gpu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/amd-kria/fu-amd-kria-device.c
+++ b/plugins/amd-kria/fu-amd-kria-device.c
@@ -223,6 +223,9 @@ fu_amd_kria_device_constructed(GObject *obj)
 	priv->esp = fu_context_get_default_esp(ctx, &error_esp);
 	if (priv->esp == NULL)
 		fu_device_inhibit(FU_DEVICE(obj), "no-esp", error_esp->message);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_amd_kria_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/amd-kria/fu-amd-kria-plugin.c
+++ b/plugins/amd-kria/fu-amd-kria-plugin.c
@@ -161,6 +161,9 @@ fu_amd_kria_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMD_KRIA_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_AMD_KRIA_SOM_EEPROM);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_amd_kria_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/amd-pmc/fu-amd-pmc-plugin.c
+++ b/plugins/amd-pmc/fu-amd-pmc-plugin.c
@@ -31,6 +31,9 @@ fu_amd_pmc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "platform");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AMD_PMC_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_amd_pmc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/analogix/fu-analogix-plugin.c
+++ b/plugins/analogix/fu-analogix-plugin.c
@@ -28,6 +28,9 @@ fu_analogix_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ANALOGIX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ANALOGIX_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_analogix_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/android-boot/fu-android-boot-plugin.c
+++ b/plugins/android-boot/fu-android-boot-plugin.c
@@ -26,6 +26,9 @@ fu_android_boot_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ANDROID_BOOT_DEVICE);
 	fu_plugin_add_device_udev_subsystem(plugin, "block:partition");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_android_boot_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/asus-hid/fu-asus-hid-plugin.c
+++ b/plugins/asus-hid/fu-asus-hid-plugin.c
@@ -31,6 +31,9 @@ fu_asus_hid_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "AsusHidNumMcu");
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ASUS_HID_FIRMWARE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_asus_hid_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ata/fu-ata-plugin.c
+++ b/plugins/ata/fu-ata-plugin.c
@@ -26,6 +26,9 @@ fu_ata_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_udev_subsystem(plugin, "block:disk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ATA_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ata_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/aver-hid/fu-aver-hid-plugin.c
+++ b/plugins/aver-hid/fu-aver-hid-plugin.c
@@ -29,6 +29,9 @@ fu_aver_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_AVER_SAFEISP_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_aver_hid_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/bcm57xx/fu-bcm57xx-plugin.c
+++ b/plugins/bcm57xx/fu-bcm57xx-plugin.c
@@ -87,6 +87,9 @@ fu_bcm57xx_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BCM57XX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BCM57XX_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_bcm57xx_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/blestech-tp/fu-blestech-tp-plugin.c
+++ b/plugins/blestech-tp/fu-blestech-tp-plugin.c
@@ -28,6 +28,9 @@ fu_blestech_tp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BLESTECH_TP_HID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BLESTECH_TP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_blestech_tp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/bnr-dp/fu-bnr-dp-plugin.c
+++ b/plugins/bnr-dp/fu-bnr-dp-plugin.c
@@ -29,6 +29,9 @@ fu_bnr_dp_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_BNR_DP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_BNR_DP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_bnr_dp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
+++ b/plugins/ccgx-dmc/fu-ccgx-dmc-plugin.c
@@ -33,6 +33,9 @@ fu_ccgx_dmc_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_CCGX_DMC_FIRMWARE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_CCGX_DMC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_DMC_DEVX_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ccgx_dmc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ccgx/fu-ccgx-plugin.c
+++ b/plugins/ccgx/fu-ccgx-plugin.c
@@ -37,6 +37,9 @@ fu_ccgx_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_PURE_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CCGX_HPI_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ccgx_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/cfu/fu-cfu-plugin.c
+++ b/plugins/cfu/fu-cfu-plugin.c
@@ -33,6 +33,9 @@ fu_cfu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "CfuContentGetReport");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CFU_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_cfu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/corsair/fu-corsair-plugin.c
+++ b/plugins/corsair/fu-corsair-plugin.c
@@ -31,6 +31,9 @@ fu_corsair_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_CORSAIR_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CORSAIR_SUBDEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_corsair_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/cpu/fu-cpu-plugin.c
+++ b/plugins/cpu/fu-cpu-plugin.c
@@ -40,6 +40,9 @@ fu_cpu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "ProcessorEntrysignPspVersion");
 	fu_context_add_quirk_key(ctx, "ProcessorKind");
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_BEFORE, "msr");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_cpu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/cros-ec/fu-cros-ec-plugin.c
+++ b/plugins/cros-ec/fu-cros-ec-plugin.c
@@ -28,6 +28,9 @@ fu_cros_ec_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_CROS_EC_USB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_CROS_EC_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_cros_ec_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/dell-dock/fu-dell-dock-plugin.c
+++ b/plugins/dell-dock/fu-dell-dock-plugin.c
@@ -354,6 +354,9 @@ fu_dell_dock_plugin_constructed(GObject *obj)
 	/* currently slower performance, but more reliable in corner cases */
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_BETTER_THAN, "synaptics_mst");
 #endif
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_dell_dock_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
+++ b/plugins/dell-kestrel/fu-dell-kestrel-plugin.c
@@ -493,6 +493,9 @@ fu_dell_kestrel_plugin_constructed(GObject *obj)
 
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
 	fu_plugin_set_config_default(plugin, FWUPD_DELL_KESTREL_PLUGIN_CONFIG_UOD, "true");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_dell_kestrel_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/dell/fu-dell-plugin.c
+++ b/plugins/dell/fu-dell-plugin.c
@@ -237,6 +237,9 @@ fu_dell_plugin_constructed(GObject *obj)
 
 	/* make sure that UEFI plugin is ready to receive devices */
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_AFTER, "uefi_capsule");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_dell_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/devlink/fu-devlink-plugin.c
+++ b/plugins/devlink/fu-devlink-plugin.c
@@ -354,6 +354,9 @@ fu_devlink_plugin_constructed(GObject *obj)
 	fu_context_add_backend(ctx, FU_BACKEND(self->backend));
 	fu_context_add_quirk_key(ctx, "DevlinkFixedVersions");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DEVLINK_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_devlink_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/dfu/fu-dfu-plugin.c
+++ b/plugins/dfu/fu-dfu-plugin.c
@@ -30,6 +30,9 @@ fu_dfu_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "DfuForceVersion");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_DFU_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_dfu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ebitdo/fu-ebitdo-plugin.c
+++ b/plugins/ebitdo/fu-ebitdo-plugin.c
@@ -28,6 +28,9 @@ fu_ebitdo_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EBITDO_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_EBITDO_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ebitdo_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/egis-moc/fu-egis-moc-plugin.c
+++ b/plugins/egis-moc/fu-egis-moc-plugin.c
@@ -26,6 +26,9 @@ fu_egis_moc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EGIS_MOC_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_egis_moc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/elan-kbd/fu-elan-kbd-plugin.c
+++ b/plugins/elan-kbd/fu-elan-kbd-plugin.c
@@ -33,6 +33,9 @@ fu_elan_kbd_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELAN_KBD_DEBUG_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_ELAN_KBD_RUNTIME);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELAN_KBD_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_elan_kbd_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/elanfp/fu-elanfp-plugin.c
+++ b/plugins/elanfp/fu-elanfp-plugin.c
@@ -28,6 +28,9 @@ fu_elanfp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANFP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELANFP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_elanfp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/elantp/fu-elantp-plugin.c
+++ b/plugins/elantp/fu-elantp-plugin.c
@@ -48,6 +48,9 @@ fu_elantp_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ELANTP_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_I2C_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ELANTP_HID_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_elantp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/emmc/fu-emmc-plugin.c
+++ b/plugins/emmc/fu-emmc-plugin.c
@@ -29,6 +29,9 @@ fu_emmc_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "EmmcBlockSize");
 	fu_plugin_add_device_udev_subsystem(plugin, "block:disk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EMMC_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_emmc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ep963x/fu-ep963x-plugin.c
+++ b/plugins/ep963x/fu-ep963x-plugin.c
@@ -29,6 +29,9 @@ fu_ep963x_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_EP963X_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_EP963X_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ep963x_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/fastboot/fu-fastboot-plugin.c
+++ b/plugins/fastboot/fu-fastboot-plugin.c
@@ -29,6 +29,9 @@ fu_fastboot_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "FastbootOperationDelay");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FASTBOOT_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_fastboot_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/flashrom/fu-flashrom-plugin.c
+++ b/plugins/flashrom/fu-flashrom-plugin.c
@@ -388,6 +388,8 @@ fu_flashrom_plugin_constructed(GObject *obj)
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_MEASURE_SYSTEM_INTEGRITY);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FLASHROM_DEVICE); /* coverage */
+
+	/* nocheck:finalize */
 }
 
 static void

--- a/plugins/focal-fp/fu-focal-fp-plugin.c
+++ b/plugins/focal-fp/fu-focal-fp-plugin.c
@@ -28,6 +28,9 @@ fu_focal_fp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FOCAL_FP_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCAL_FP_HID_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_focal_fp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/focal-touch/fu-focal-touch-plugin.c
+++ b/plugins/focal-touch/fu-focal-touch-plugin.c
@@ -29,6 +29,9 @@ fu_focal_touch_plugin_constructed(GObject *obj)
 
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FOCAL_TOUCH_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FOCAL_TOUCH_HID_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_focal_touch_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/fpc/fu-fpc-plugin.c
+++ b/plugins/fpc/fu-fpc-plugin.c
@@ -28,6 +28,9 @@ fu_fpc_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FPC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FPC_FF2_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_fpc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/framework-qmk/fu-framework-qmk-plugin.c
+++ b/plugins/framework-qmk/fu-framework-qmk-plugin.c
@@ -26,6 +26,9 @@ fu_framework_qmk_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FRAMEWORK_QMK_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_framework_qmk_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/fresco-pd/fu-fresco-pd-plugin.c
+++ b/plugins/fresco-pd/fu-fresco-pd-plugin.c
@@ -28,6 +28,9 @@ fu_fresco_pd_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_FRESCO_PD_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_FRESCO_PD_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_fresco_pd_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
+++ b/plugins/genesys-gl32xx/fu-genesys-gl32xx-plugin.c
@@ -30,6 +30,9 @@ fu_genesys_gl32xx_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GENESYS_GL32XX_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_GL32XX_FIRMWARE);
 	fu_context_add_quirk_key(ctx, "GenesysGl32xxCompatibleModel");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_genesys_gl32xx_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/genesys/fu-genesys-plugin.c
+++ b/plugins/genesys/fu-genesys-plugin.c
@@ -64,6 +64,9 @@ fu_genesys_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_USBHUB_PD_FIRMWARE); /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_USBHUB_CODESIGN_FIRMWARE); /* cov */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GENESYS_USBHUB_DEV_FIRMWARE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_genesys_plugin_parent_class)->constructed(obj);
 }
 
 static FuDevice *

--- a/plugins/goodix-moc/fu-goodix-moc-plugin.c
+++ b/plugins/goodix-moc/fu-goodix-moc-plugin.c
@@ -27,6 +27,9 @@ fu_goodix_moc_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GOODIX_MOC_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_goodix_moc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/goodix-tp/fu-goodixtp-plugin.c
+++ b/plugins/goodix-tp/fu-goodixtp-plugin.c
@@ -37,6 +37,9 @@ fu_goodixtp_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_GTX8_FIRMWARE); /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_GOODIXTP_BRLB_FIRMWARE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_goodixtp_plugin_parent_class)->constructed(obj);
 }
 
 static FuGoodixtpIcType

--- a/plugins/gpio/fu-gpio-plugin.c
+++ b/plugins/gpio/fu-gpio-plugin.c
@@ -169,6 +169,9 @@ fu_gpio_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "GpioForUpdate");
 	fu_plugin_add_device_udev_subsystem(plugin, "gpio");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_GPIO_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_gpio_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/himax-tp/fu-himax-tp-plugin.c
+++ b/plugins/himax-tp/fu-himax-tp-plugin.c
@@ -28,6 +28,9 @@ fu_himax_tp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HIMAX_TP_HID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_HIMAX_TP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_himax_tp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
+++ b/plugins/hpi-cfu/fu-hpi-cfu-plugin.c
@@ -27,6 +27,9 @@ fu_hpi_cfu_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HPI_CFU_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_hpi_cfu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/huddly-usb/fu-huddly-usb-plugin.c
+++ b/plugins/huddly-usb/fu-huddly-usb-plugin.c
@@ -26,6 +26,9 @@ fu_huddly_usb_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HUDDLY_USB_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_huddly_usb_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/hughski-colorhug/fu-hughski-colorhug-plugin.c
+++ b/plugins/hughski-colorhug/fu-hughski-colorhug-plugin.c
@@ -26,6 +26,9 @@ fu_hughski_colorhug_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_HUGHSKI_COLORHUG_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_hughski_colorhug_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ilitek-its/fu-ilitek-its-plugin.c
+++ b/plugins/ilitek-its/fu-ilitek-its-plugin.c
@@ -79,6 +79,9 @@ fu_ilitek_its_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_ILITEK_ITS_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_ILITEK_ITS_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ilitek_its_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-amt/fu-intel-amt-plugin.c
+++ b/plugins/intel-amt/fu-intel-amt-plugin.c
@@ -26,6 +26,9 @@ fu_intel_amt_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "mei");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_AMT_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_amt_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-cvs/fu-intel-cvs-plugin.c
+++ b/plugins/intel-cvs/fu-intel-cvs-plugin.c
@@ -32,6 +32,9 @@ fu_intel_cvs_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_CVS_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_INTEL_CVS_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_cvs_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-gsc/fu-igsc-plugin.c
+++ b/plugins/intel-gsc/fu-igsc-plugin.c
@@ -92,6 +92,9 @@ fu_igsc_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_CODE_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_AUX_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_IGSC_OPROM_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_igsc_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-mchi/fu-intel-mchi-plugin.c
+++ b/plugins/intel-mchi/fu-intel-mchi-plugin.c
@@ -26,6 +26,9 @@ fu_intel_mchi_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "mei");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_MCHI_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_mchi_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-me-pci/fu-intel-me-pci-plugin.c
+++ b/plugins/intel-me-pci/fu-intel-me-pci-plugin.c
@@ -137,6 +137,9 @@ fu_intel_me_pci_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "pci");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_me_pci_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-me-smbios/fu-intel-me-smbios-plugin.c
+++ b/plugins/intel-me-smbios/fu-intel-me-smbios-plugin.c
@@ -221,6 +221,9 @@ fu_intel_me_smbios_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_ME_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_me_smbios_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-mkhi/fu-intel-mkhi-plugin.c
+++ b/plugins/intel-mkhi/fu-intel-mkhi-plugin.c
@@ -26,6 +26,9 @@ fu_intel_mkhi_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "mei");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_MKHI_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_mkhi_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/intel-usb4/fu-intel-usb4-plugin.c
+++ b/plugins/intel-usb4/fu-intel-usb4-plugin.c
@@ -27,6 +27,9 @@ fu_intel_usb4_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_INTEL_USB4_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_intel_usb4_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/iommu/fu-iommu-plugin.c
+++ b/plugins/iommu/fu-iommu-plugin.c
@@ -110,6 +110,9 @@ fu_iommu_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_udev_subsystem(plugin, "iommu");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_iommu_plugin_parent_class)->constructed(obj);
 }
 
 static gboolean

--- a/plugins/jabra-file/fu-jabra-file-plugin.c
+++ b/plugins/jabra-file/fu-jabra-file-plugin.c
@@ -29,6 +29,9 @@ fu_jabra_file_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_FILE_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_FILE_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_jabra_file_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
+++ b/plugins/jabra-gnp/fu-jabra-gnp-plugin.c
@@ -30,6 +30,9 @@ fu_jabra_gnp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_GNP_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_JABRA_GNP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_jabra_gnp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/jabra/fu-jabra-plugin.c
+++ b/plugins/jabra/fu-jabra-plugin.c
@@ -63,6 +63,9 @@ fu_jabra_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "JabraMagic");
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_JABRA_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_jabra_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
+++ b/plugins/kinetic-dp/fu-kinetic-dp-plugin.c
@@ -126,6 +126,9 @@ fu_kinetic_dp_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_KINETIC_DP_SECURE_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_KINETIC_DP_PUMA_DEVICE);   /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_KINETIC_DP_SECURE_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_kinetic_dp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/legion-hid/fu-legion-hid-plugin.c
+++ b/plugins/legion-hid/fu-legion-hid-plugin.c
@@ -30,6 +30,9 @@ fu_legion_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LEGION_HID_FIRMWARE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LEGION_HID_CHILD);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LEGION_HID_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_legion_hid_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/legion-hid2/fu-legion-hid2-plugin.c
+++ b/plugins/legion-hid2/fu-legion-hid2-plugin.c
@@ -34,6 +34,9 @@ fu_legion_hid2_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LEGION_HID2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LEGION_HID2_FIRMWARE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_legion_hid2_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
+++ b/plugins/lenovo-accessory/fu-lenovo-accessory-plugin.c
@@ -31,6 +31,9 @@ fu_lenovo_accessory_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_HID_BOOTLOADER);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LENOVO_ACCESSORY_BLE_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_lenovo_accessory_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/linux-display/fu-linux-display-plugin.c
+++ b/plugins/linux-display/fu-linux-display-plugin.c
@@ -107,6 +107,9 @@ fu_linux_display_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_udev_subsystem(plugin, "drm");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_linux_display_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
+++ b/plugins/logitech-bulkcontroller/fu-logitech-bulkcontroller-plugin.c
@@ -68,6 +68,9 @@ fu_logitech_bulkcontroller_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_LOGITECH_BULKCONTROLLER_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_BULKCONTROLLER_CHILD); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_logitech_bulkcontroller_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
+++ b/plugins/logitech-hidpp/fu-logitech-hidpp-plugin.c
@@ -42,6 +42,9 @@ fu_logitech_hidpp_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_HIDPP_RUNTIME_BOLT);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_LOGITECH_RDFU_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_logitech_hidpp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/logitech-rallysystem/fu-logitech-rallysystem-plugin.c
+++ b/plugins/logitech-rallysystem/fu-logitech-rallysystem-plugin.c
@@ -75,6 +75,9 @@ fu_logitech_rallysystem_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_RALLYSYSTEM_TABLEHUB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_RALLYSYSTEM_AUDIO_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_logitech_rallysystem_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/logitech-scribe/fu-logitech-scribe-plugin.c
+++ b/plugins/logitech-scribe/fu-logitech-scribe-plugin.c
@@ -26,6 +26,9 @@ fu_logitech_scribe_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "video4linux");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_SCRIBE_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_logitech_scribe_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/logitech-tap/fu-logitech-tap-plugin.c
+++ b/plugins/logitech-tap/fu-logitech-tap-plugin.c
@@ -64,6 +64,9 @@ fu_logitech_tap_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_TAP_HDMI_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_TAP_SENSOR_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_LOGITECH_TAP_TOUCH_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_logitech_tap_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/mediatek-scaler/fu-mediatek-scaler-plugin.c
+++ b/plugins/mediatek-scaler/fu-mediatek-scaler-plugin.c
@@ -29,6 +29,9 @@ fu_mediatek_scaler_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "drm");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MEDIATEK_SCALER_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_MEDIATEK_SCALER_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_mediatek_scaler_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/modem-manager/fu-mm-plugin.c
+++ b/plugins/modem-manager/fu-mm-plugin.c
@@ -67,6 +67,8 @@ fu_mm_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MM_QCDM_DEVICE);	/* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MM_QDU_MBIM_DEVICE); /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MM_QMI_DEVICE);	/* coverage */
+
+	/* nocheck:finalize */
 }
 
 void

--- a/plugins/msr/fu-msr-plugin.c
+++ b/plugins/msr/fu-msr-plugin.c
@@ -756,6 +756,9 @@ fu_msr_plugin_constructed(GObject *obj)
 
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
 	fu_plugin_set_config_default(plugin, "MinimumSmeKernelVersion", "5.18.0");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_msr_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/mtd/fu-mtd-plugin.c
+++ b/plugins/mtd/fu-mtd-plugin.c
@@ -46,6 +46,9 @@ fu_mtd_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_udev_subsystem(plugin, "mtd");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_MTD_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_MTD_IFD_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_mtd_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/nordic-hid/fu-nordic-hid-plugin.c
+++ b/plugins/nordic-hid/fu-nordic-hid-plugin.c
@@ -30,6 +30,9 @@ fu_nordic_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NORDIC_HID_CFG_CHANNEL);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NORDIC_HID_ARCHIVE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_nordic_hid_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/novatek-ts/fu-novatek-ts-device.c
+++ b/plugins/novatek-ts/fu-novatek-ts-device.c
@@ -1521,10 +1521,13 @@ fu_novatek_ts_device_init(FuNovatekTsDevice *self)
 }
 
 static void
-fu_novatek_ts_device_constructed(GObject *object)
+fu_novatek_ts_device_constructed(GObject *obj)
 {
-	FuNovatekTsDevice *self = FU_NOVATEK_TS_DEVICE(object);
+	FuNovatekTsDevice *self = FU_NOVATEK_TS_DEVICE(obj);
 	self->cfi_device = fu_cfi_device_new(FU_DEVICE(self), NULL);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_novatek_ts_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/novatek-ts/fu-novatek-ts-plugin.c
+++ b/plugins/novatek-ts/fu-novatek-ts-plugin.c
@@ -22,6 +22,9 @@ fu_novatek_ts_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NOVATEK_TS_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_NOVATEK_TS_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_novatek_ts_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/nvme/fu-nvme-plugin.c
+++ b/plugins/nvme/fu-nvme-plugin.c
@@ -29,6 +29,9 @@ fu_nvme_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "NvmeSerialSuffixChars");
 	fu_plugin_add_device_udev_subsystem(plugin, "nvme");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_NVME_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_nvme_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/parade-lspcon/fu-parade-lspcon-plugin.c
+++ b/plugins/parade-lspcon/fu-parade-lspcon-plugin.c
@@ -26,6 +26,9 @@ fu_parade_lspcon_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PARADE_LSPCON_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_parade_lspcon_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/parade-usbhub/fu-parade-usbhub-device.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-device.c
@@ -1278,11 +1278,14 @@ fu_parade_usbhub_device_init(FuParadeUsbhubDevice *self)
 }
 
 static void
-fu_parade_usbhub_device_constructed(GObject *object)
+fu_parade_usbhub_device_constructed(GObject *obj)
 {
-	FuParadeUsbhubDevice *self = FU_PARADE_USBHUB_DEVICE(object);
+	FuParadeUsbhubDevice *self = FU_PARADE_USBHUB_DEVICE(obj);
 	self->chip = FU_PARADE_USBHUB_CHIP_PS5512;
 	self->cfi_device = fu_cfi_device_new(FU_DEVICE(self), NULL);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_parade_usbhub_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
+++ b/plugins/parade-usbhub/fu-parade-usbhub-plugin.c
@@ -30,6 +30,9 @@ fu_parade_usbhub_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PARADE_USBHUB_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PARADE_USBHUB_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_parade_usbhub_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/pci-bcr/fu-pci-bcr-plugin.c
+++ b/plugins/pci-bcr/fu-pci-bcr-plugin.c
@@ -231,6 +231,9 @@ fu_pci_bcr_plugin_constructed(GObject *obj)
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	fu_context_add_quirk_key(ctx, "PciBcrAddr");
 	fu_plugin_add_udev_subsystem(plugin, "pci");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_pci_bcr_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/pci-psp/fu-pci-psp-plugin.c
+++ b/plugins/pci-psp/fu-pci-psp-plugin.c
@@ -32,6 +32,9 @@ fu_pci_psp_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "pci");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PCI_PSP_DEVICE);
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_AFTER, "cpu");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_pci_psp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/pixart-rf/fu-pixart-rf-plugin.c
+++ b/plugins/pixart-rf/fu-pixart-rf-plugin.c
@@ -32,6 +32,9 @@ fu_pixart_rf_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_RF_RECEIVER_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_RF_WIRELESS_DEVICE); /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_RF_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_pixart_rf_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/pixart-tp/fu-pixart-tp-plugin.c
+++ b/plugins/pixart-tp/fu-pixart-tp-plugin.c
@@ -40,6 +40,9 @@ fu_pixart_tp_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_PLP239_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_PIXART_TP_HAPTIC_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_PIXART_TP_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_pixart_tp_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/qc-firehose/fu-qc-firehose-plugin.c
+++ b/plugins/qc-firehose/fu-qc-firehose-plugin.c
@@ -28,6 +28,9 @@ fu_qc_firehose_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_FIREHOSE_USB_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_FIREHOSE_RAW_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "wwan");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_qc_firehose_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
+++ b/plugins/qc-s5gen2/fu-qc-s5gen2-plugin.c
@@ -35,6 +35,9 @@ fu_qc_s5gen2_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QC_S5GEN2_HID_DEVICE);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QC_S5GEN2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_QC_S5GEN2_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_qc_s5gen2_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/qsi-dock/fu-qsi-dock-plugin.c
+++ b/plugins/qsi-dock/fu-qsi-dock-plugin.c
@@ -30,6 +30,9 @@ fu_qsi_dock_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_QSI_DOCK_MCU_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_QSI_DOCK_CHILD_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_qsi_dock_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/realtek-mst/fu-realtek-mst-plugin.c
+++ b/plugins/realtek-mst/fu-realtek-mst-plugin.c
@@ -26,6 +26,9 @@ fu_realtek_mst_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "i2c");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_REALTEK_MST_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_realtek_mst_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -730,6 +730,9 @@ fu_redfish_plugin_constructed(GObject *obj)
 	fu_plugin_set_config_default(plugin, "Uri", NULL);
 	fu_plugin_set_config_default(plugin, "Username", NULL);
 	fu_plugin_set_config_default(plugin, "UserUri", NULL);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_redfish_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/rp-pico/fu-rp-pico-plugin.c
+++ b/plugins/rp-pico/fu-rp-pico-plugin.c
@@ -27,6 +27,9 @@ fu_rp_pico_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RP_PICO_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_rp_pico_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/rts54hub/fu-rts54hub-plugin.c
+++ b/plugins/rts54hub/fu-rts54hub-plugin.c
@@ -37,6 +37,9 @@ fu_rts54hub_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_BACKGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_FOREGROUND);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_RTS54HUB_RTD21XX_MERGEINFO);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_rts54hub_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/scsi/fu-scsi-plugin.c
+++ b/plugins/scsi/fu-scsi-plugin.c
@@ -29,6 +29,9 @@ fu_scsi_plugin_constructed(GObject *obj)
 	fu_context_add_quirk_key(ctx, "ScsiWriteBufferSize");
 	fu_plugin_add_device_udev_subsystem(plugin, "block:disk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SCSI_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_scsi_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/steelseries/fu-steelseries-plugin.c
+++ b/plugins/steelseries/fu-steelseries-plugin.c
@@ -45,6 +45,9 @@ fu_steelseries_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_STEELSERIES_MOUSE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_STEELSERIES_SONIC);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_steelseries_plugin_parent_class)->constructed(obj);
 }
 
 static FuDevice *

--- a/plugins/sunwinon-hid/fu-sunwinon-hid-plugin.c
+++ b/plugins/sunwinon-hid/fu-sunwinon-hid-plugin.c
@@ -28,6 +28,9 @@ fu_sunwinon_hid_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SUNWINON_HID_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SUNWINON_HID_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_sunwinon_hid_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
+++ b/plugins/synaptics-cape/fu-synaptics-cape-plugin.c
@@ -31,6 +31,9 @@ fu_synaptics_cape_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_HID_FIRMWARE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CAPE_SNGL_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_cape_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
+++ b/plugins/synaptics-cxaudio/fu-synaptics-cxaudio-plugin.c
@@ -34,6 +34,9 @@ fu_synaptics_cxaudio_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_CXAUDIO_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_cxaudio_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-plugin.c
@@ -51,6 +51,9 @@ fu_synaptics_mst_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "drm_dp_aux_dev");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_MST_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_MST_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_mst_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-prometheus/fu-synaptics-prometheus-plugin.c
+++ b/plugins/synaptics-prometheus/fu-synaptics-prometheus-plugin.c
@@ -30,6 +30,9 @@ fu_synaptics_prometheus_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_CONFIG); /* for coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_PROMETHEUS_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_prometheus_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
+++ b/plugins/synaptics-rmi/fu-synaptics-rmi-plugin.c
@@ -31,6 +31,9 @@ fu_synaptics_rmi_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_HID_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_PS2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_RMI_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_rmi_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
+++ b/plugins/synaptics-vmm9/fu-synaptics-vmm9-plugin.c
@@ -29,6 +29,9 @@ fu_synaptics_vmm9_plugin_constructed(GObject *obj)
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYNAPTICS_VMM9_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_SYNAPTICS_VMM9_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_synaptics_vmm9_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/system76-launch/fu-system76-launch-plugin.c
+++ b/plugins/system76-launch/fu-system76-launch-plugin.c
@@ -27,6 +27,9 @@ fu_system76_launch_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_SYSTEM76_LAUNCH_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_system76_launch_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/telink-dfu/fu-telink-dfu-plugin.c
+++ b/plugins/telink-dfu/fu-telink-dfu-plugin.c
@@ -33,6 +33,9 @@ fu_telink_dfu_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TELINK_DFU_BLE_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_TELINK_DFU_ARCHIVE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_telink_dfu_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/test/fu-test-ble-plugin.c
+++ b/plugins/test/fu-test-ble-plugin.c
@@ -26,6 +26,9 @@ fu_test_ble_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TEST_BLE_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_test_ble_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -404,6 +404,9 @@ fu_test_plugin_constructed(GObject *obj)
 	fu_plugin_set_config_default(plugin, "VerifyDelay", "0");
 	fu_plugin_set_config_default(plugin, "WriteDelay", "0");
 	fu_plugin_set_config_default(plugin, "WriteSupported", "true");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_test_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/thelio-io/fu-thelio-io-plugin.c
+++ b/plugins/thelio-io/fu-thelio-io-plugin.c
@@ -27,6 +27,9 @@ fu_thelio_io_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_THELIO_IO_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_thelio_io_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/thunderbolt/fu-thunderbolt-plugin.c
+++ b/plugins/thunderbolt/fu-thunderbolt-plugin.c
@@ -125,6 +125,9 @@ fu_thunderbolt_plugin_constructed(GObject *obj)
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
 	fu_plugin_set_config_default(plugin, "DelayedActivation", "false");
 	fu_plugin_set_config_default(plugin, "MinimumKernelVersion", "4.13.0");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_thunderbolt_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
+++ b/plugins/ti-tps6598x/fu-ti-tps6598x-plugin.c
@@ -31,6 +31,9 @@ fu_ti_tps6598x_plugin_constructed(GObject *obj)
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_TI_TPS6598X_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TI_TPS6598X_PD_DEVICE); /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_TI_TPS6598X_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_ti_tps6598x_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/tpm/fu-tpm-plugin.c
+++ b/plugins/tpm/fu-tpm-plugin.c
@@ -402,6 +402,9 @@ fu_tpm_plugin_constructed(GObject *obj)
 		fu_plugin_add_device_udev_subsystem(plugin, "tpm");
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_TPM_V2_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_TPM_V1_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_tpm_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-plugin.c
@@ -1350,6 +1350,9 @@ fu_uefi_capsule_plugin_constructed(GObject *obj)
 	/* add a requirement on the fwupd-efi version -- which can change  */
 	if (!fu_uefi_capsule_plugin_fwupd_efi_probe(self, &error_local))
 		g_debug("failed to get fwupd-efi runtime version: %s", error_local->message);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_capsule_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-db/fu-uefi-db-plugin.c
+++ b/plugins/uefi-db/fu-uefi-db-plugin.c
@@ -26,6 +26,9 @@ fu_uefi_db_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_DB_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_db_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-plugin.c
@@ -56,6 +56,9 @@ fu_uefi_dbx_plugin_constructed(GObject *obj)
 		fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_CLEAR_UPDATABLE);
 		fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_USER_WARNING);
 	}
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_dbx_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-kek/fu-uefi-kek-plugin.c
+++ b/plugins/uefi-kek/fu-uefi-kek-plugin.c
@@ -26,6 +26,9 @@ fu_uefi_kek_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_METADATA_SOURCE, "uefi_pk");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UEFI_KEK_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_kek_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-pk/fu-uefi-pk-plugin.c
+++ b/plugins/uefi-pk/fu-uefi-pk-plugin.c
@@ -25,6 +25,9 @@ fu_uefi_pk_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_UEFI_PK_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_pk_plugin_parent_class)->constructed(obj);
 }
 
 static gboolean

--- a/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
+++ b/plugins/uefi-recovery/fu-uefi-recovery-plugin.c
@@ -61,6 +61,9 @@ fu_uefi_recovery_plugin_constructed(GObject *obj)
 	/* make sure that UEFI plugin is ready to receive devices */
 	fu_plugin_add_rule(plugin, FU_PLUGIN_RULE_RUN_AFTER, "uefi_capsule");
 	fu_plugin_add_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_recovery_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uefi-sbat/fu-uefi-sbat-plugin.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-plugin.c
@@ -97,6 +97,9 @@ fu_uefi_sbat_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_set_device_gtype_default(plugin, FU_TYPE_UEFI_SBAT_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_UEFI_SBAT_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uefi_sbat_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/uf2/fu-uf2-plugin.c
+++ b/plugins/uf2/fu-uf2-plugin.c
@@ -28,6 +28,9 @@ fu_uf2_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_UF2_DEVICE);
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_UF2_FIRMWARE);
 	fu_plugin_add_device_udev_subsystem(plugin, "block:partition");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_uf2_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/usi-dock/fu-usi-dock-plugin.c
+++ b/plugins/usi-dock/fu-usi-dock-plugin.c
@@ -112,6 +112,9 @@ fu_usi_dock_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_MCU_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_DMC_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_USI_DOCK_CHILD_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_usi_dock_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/vbe/fu-vbe-plugin.c
+++ b/plugins/vbe/fu-vbe-plugin.c
@@ -134,6 +134,9 @@ fu_vbe_plugin_constructed(GObject *obj)
 {
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VBE_SIMPLE_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_vbe_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/vbe/fu-vbe-simple-device.c
+++ b/plugins/vbe/fu-vbe-simple-device.c
@@ -468,6 +468,9 @@ fu_vbe_simple_device_constructed(GObject *obj)
 {
 	FuVbeSimpleDevice *self = FU_VBE_SIMPLE_DEVICE(obj);
 	fu_device_add_instance_id(FU_DEVICE(self), "bb3b05a8-ebef-11ec-be98-d3a15278be95");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_vbe_simple_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/vli/fu-vli-device.c
+++ b/plugins/vli/fu-vli-device.c
@@ -666,6 +666,9 @@ fu_vli_device_constructed(GObject *obj)
 	FuVliDevice *self = FU_VLI_DEVICE(obj);
 	FuVliDevicePrivate *priv = GET_PRIVATE(self);
 	priv->cfi_device = fu_cfi_device_new(FU_DEVICE(self), NULL);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_vli_device_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/vli/fu-vli-plugin.c
+++ b/plugins/vli/fu-vli-plugin.c
@@ -44,6 +44,9 @@ fu_vli_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_MSP430_DEVICE);  /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_PD_DEVICE);      /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_VLI_USBHUB_RTD21XX_DEVICE); /* coverage */
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_vli_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/wacom-raw/fu-wacom-raw-plugin.c
+++ b/plugins/wacom-raw/fu-wacom-raw-plugin.c
@@ -56,6 +56,9 @@ fu_wacom_raw_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_RAW_AES_DEVICE);
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_RAW_EMR_DEVICE);
 	fu_plugin_add_udev_subsystem(plugin, "hidraw");
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_wacom_raw_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/wacom-usb/fu-wacom-usb-plugin.c
+++ b/plugins/wacom-usb/fu-wacom-usb-plugin.c
@@ -117,6 +117,9 @@ fu_wacom_usb_plugin_constructed(GObject *obj)
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_USB_MODULE_TOUCH);	    /* coverage */
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WACOM_USB_MODULE_TOUCH_ID7);	    /* coverage */
 	fu_plugin_add_firmware_gtype(plugin, FU_TYPE_WACOM_USB_FIRMWARE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_wacom_usb_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/wch-ch341a/fu-wch-ch341a-plugin.c
+++ b/plugins/wch-ch341a/fu-wch-ch341a-plugin.c
@@ -26,6 +26,9 @@ fu_wch_ch341a_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WCH_CH341A_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_wch_ch341a_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/wch-ch347/fu-wch-ch347-plugin.c
+++ b/plugins/wch-ch347/fu-wch-ch347-plugin.c
@@ -26,6 +26,9 @@ fu_wch_ch347_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WCH_CH347_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_wch_ch347_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/plugins/wistron-dock/fu-wistron-dock-plugin.c
+++ b/plugins/wistron-dock/fu-wistron-dock-plugin.c
@@ -27,6 +27,9 @@ fu_wistron_dock_plugin_constructed(GObject *obj)
 	FuPlugin *plugin = FU_PLUGIN(obj);
 	fu_plugin_add_udev_subsystem(plugin, "usb");
 	fu_plugin_add_device_gtype(plugin, FU_TYPE_WISTRON_DOCK_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_wistron_dock_plugin_parent_class)->constructed(obj);
 }
 
 static void

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -9423,6 +9423,9 @@ fu_engine_constructed(GObject *obj)
 					       "io.snapcraft.fwupd",
 					       g_getenv("SNAP_REVISION"));
 	}
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_engine_parent_class)->constructed(obj);
 }
 
 static void


### PR DESCRIPTION
According to the docs:

...constructed implementors should chain up to the constructed call of their parent class to allow it to complete its initialisation.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
