### PR TITLE
Add missing fu-usb-descriptor.h to fwupdplugin.h

### DIFF
--- a/libfwupdplugin/fwupdplugin.h
+++ b/libfwupdplugin/fwupdplugin.h
@@ -126,6 +126,7 @@
 #include <libfwupdplugin/fu-temporary-directory.h>
 #include <libfwupdplugin/fu-udev-device.h>
 #include <libfwupdplugin/fu-usb-bos-descriptor.h>
+#include <libfwupdplugin/fu-usb-descriptor.h>
 #include <libfwupdplugin/fu-v4l-device.h>
 #include <libfwupdplugin/fu-volume-locker.h>
 #include <libfwupdplugin/fu-x509-certificate.h>

--- a/libfwupdplugin/meson.build
+++ b/libfwupdplugin/meson.build
@@ -377,6 +377,7 @@ fwupdplugin_headers = [
   'fu-usb-bos-descriptor-private.h',
   'fu-usb-config-descriptor.h',
   'fu-usb-config-descriptor-private.h',
+  'fu-usb-descriptor.h',
   'fu-usb-device.h',
   'fu-usb-endpoint.h',
   'fu-usb-endpoint-private.h',


### PR DESCRIPTION
This header describes a type that is used by others that are already in the fwupdplugin.h header, causing the GIR scanner to generate broken type references.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation


---

There are other headers but afaict they describe final types and/or some that aren't subclassed (yet):
- `fu-usb-config-descriptor.h`
- `fu-usb-hid-descriptor.h`
- `fu-usb-device-ds20.h`
- `fu-usb-device-fw-ds20.h`
- `fu-usb-device-ms-ds20.h`