### PR TITLE
Revert "Adding vendor stability changes"

### DIFF
--- a/contrib/android/android_arm64-cross-file.ini
+++ b/contrib/android/android_arm64-cross-file.ini
@@ -1,5 +1,5 @@
 [constants]
-ndk_path = '/opt/android/android-ndk-r29/'
+ndk_path = '/opt/android/android-ndk-r27/'
 toolchain = ndk_path / 'toolchains/llvm/prebuilt/linux-x86_64'
 toolchain_bin = toolchain / 'bin'
 target_triple = 'aarch64-linux-android35'

--- a/contrib/android/android_x86_64-cross-file.ini
+++ b/contrib/android/android_x86_64-cross-file.ini
@@ -1,5 +1,5 @@
 [constants]
-ndk_path = '/opt/android/android-ndk-r29/'
+ndk_path = '/opt/android/android-ndk-r27/'
 toolchain = ndk_path / 'toolchains/llvm/prebuilt/linux-x86_64'
 toolchain_bin = toolchain / 'bin'
 target_triple = 'x86_64-linux-android35'

--- a/src/meson.build
+++ b/src/meson.build
@@ -295,7 +295,6 @@ if host_machine.system() == 'android' and binder_ndk.found()
       fwupdplugin_incdir,
       binder_ndk_platform_incdir,
     ],
-    c_args: ['-D__ANDROID_VENDOR__'],
     dependencies: [
       valgrind,
       libsystemd,
@@ -324,7 +323,6 @@ if host_machine.system() == 'android' and binder_ndk.found()
       fwupdplugin_incdir,
       binder_ndk_platform_incdir,
     ],
-    c_args: ['-D__ANDROID_VENDOR__'],
     dependencies: [
       libfwupd_deps,
       client_dep,


### PR DESCRIPTION
Reverts fwupd/fwupd#10018. I made changes in the previous PR and forgot to abandon this. D__ANDROID_VENDOR__ and  ndk-r29 are not needed for now