### PR TITLE
Add alias get-upgrades to manpage.

### DIFF
--- a/src/fwupdmgr.md
+++ b/src/fwupdmgr.md
@@ -50,6 +50,8 @@ The following actions can be used to view details about the enumerated devices o
 
 **get-updates**: Show all the available updates for a specific device.
 
+**get-upgrades**: Alias to get-updates.
+
 **get-releases**: Show all the installable versions (older, the same, or newer) for a specific device.
 
 **get-details**: View details about a specific .cab archive, even if the target device has not been found on this system.


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation

So far the `fwupdmgr(1)` lacks information regarding the available alias `get-upgrades`. This pull requests adds the information available in the output of `fwupdmgr --help` for consistency.