### PR TITLE
novatek-ts: fix for repairing capability if update is interrupted

### DIFF
--- a/plugins/novatek-ts/fu-novatek-ts-device.c
+++ b/plugins/novatek-ts/fu-novatek-ts-device.c
@@ -1365,8 +1365,15 @@ fu_novatek_ts_device_setup(FuDevice *device, GError **error)
 	}
 	g_clear_error(&error_local);
 	if (!fu_novatek_ts_device_ensure_fw_ver(self, &error_local)) {
-		g_warning("failed to read firmware version: %s", error_local->message);
-		fu_device_set_version_raw(FU_DEVICE(self), 0);
+		if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_BUSY) &&
+		    g_strrstr(error_local->message, "fw info not ready") != NULL) {
+			g_warning("firmware version unavailable: %s", error_local->message);
+			fu_device_set_version_raw(FU_DEVICE(self), 0);
+			g_clear_error(&error_local);
+		} else {
+			g_propagate_error(error, g_steal_pointer(&error_local));
+			return FALSE;
+		}
 	}
 
 	if (!fu_novatek_ts_device_bootloader_reset(self, error))


### PR DESCRIPTION
When fw update is interrupted fw would not show version correctly after reboot.
Do not make version check to block device setup to enable repairing.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
