### PR TITLE
Replace manual buffer summation with fu_sum8

### DIFF
--- a/libfwupdplugin/fu-ihex-firmware.c
+++ b/libfwupdplugin/fu-ihex-firmware.c
@@ -15,6 +15,7 @@
 #include "fu-ihex-firmware.h"
 #include "fu-mem.h"
 #include "fu-string.h"
+#include "fu-sum.h"
 
 /**
  * FuIhexFirmware:
@@ -447,8 +448,7 @@ fu_ihex_firmware_emit_chunk(GString *str,
 	checksum += (guint8)((address & 0xff00) >> 8);
 	checksum += (guint8)(address & 0xff);
 	checksum += record_type;
-	for (gsize j = 0; j < sz; j++)
-		checksum += data[j];
+	checksum += fu_sum8(data, sz);
 	g_string_append_printf(str, "%02X\n", (guint)(((~checksum) + 0x01) & 0xff));
 }
 

--- a/libfwupdplugin/fu-smbios.c
+++ b/libfwupdplugin/fu-smbios.c
@@ -25,6 +25,7 @@
 #include "fu-smbios-private.h"
 #include "fu-smbios-struct.h"
 #include "fu-string.h"
+#include "fu-sum.h"
 
 /**
  * FuSmbios:
@@ -199,8 +200,7 @@ fu_smbios_parse_ep32(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **er
 	st_ep32 = fu_struct_smbios_ep32_parse(buf, bufsz, 0x0, error);
 	if (st_ep32 == NULL)
 		return FALSE;
-	for (guint i = 0; i < bufsz; i++)
-		csum += buf[i];
+	csum = fu_sum8(buf, bufsz);
 	if (csum != 0x00) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -219,8 +219,7 @@ fu_smbios_parse_ep32(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **er
 			    intermediate_anchor_str);
 		return FALSE;
 	}
-	for (guint i = 10; i < bufsz; i++)
-		csum += buf[i];
+	csum = fu_sum8(buf + 10, bufsz - 10);
 	if (csum != 0x00) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -251,8 +250,7 @@ fu_smbios_parse_ep64(FuSmbios *self, const guint8 *buf, gsize bufsz, GError **er
 	st_ep64 = fu_struct_smbios_ep64_parse(buf, bufsz, 0x0, error);
 	if (st_ep64 == NULL)
 		return FALSE;
-	for (guint i = 0; i < bufsz; i++)
-		csum += buf[i];
+	csum = fu_sum8(buf, bufsz);
 	if (csum != 0x00) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,

--- a/libfwupdplugin/fu-srec-firmware.c
+++ b/libfwupdplugin/fu-srec-firmware.c
@@ -15,6 +15,7 @@
 #include "fu-firmware-common.h"
 #include "fu-srec-firmware.h"
 #include "fu-string.h"
+#include "fu-sum.h"
 
 /**
  * FuSrecFirmware:
@@ -568,10 +569,8 @@ fu_srec_firmware_write_line(GString *str,
 
 	/* bytecount + address + data */
 	csum = buf_addr->len + bufsz + 1;
-	for (guint i = 0; i < buf_addr->len; i++)
-		csum += buf_addr->data[i];
-	for (guint i = 0; i < bufsz; i++)
-		csum += buf[i];
+	csum += fu_sum8(buf_addr->data, buf_addr->len);
+	csum += fu_sum8(buf, bufsz);
 	csum ^= 0xff;
 
 	/* output record */

--- a/libfwupdplugin/fu-sum.c
+++ b/libfwupdplugin/fu-sum.c
@@ -26,7 +26,7 @@ guint8
 fu_sum8(const guint8 *buf, gsize bufsz)
 {
 	guint8 checksum = 0;
-	g_return_val_if_fail(buf != NULL, G_MAXUINT8);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, G_MAXUINT8);
 	for (gsize i = 0; i < bufsz; i++)
 		checksum += buf[i];
 	return checksum;
@@ -54,7 +54,7 @@ fu_sum8(const guint8 *buf, gsize bufsz)
 gboolean
 fu_sum8_safe(const guint8 *buf, gsize bufsz, gsize offset, gsize n, guint8 *value, GError **error)
 {
-	g_return_val_if_fail(buf != NULL, FALSE);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (!fu_memchk_read(bufsz, offset, n, error))
@@ -98,7 +98,7 @@ guint16
 fu_sum16(const guint8 *buf, gsize bufsz)
 {
 	guint16 checksum = 0;
-	g_return_val_if_fail(buf != NULL, G_MAXUINT16);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, G_MAXUINT16);
 	for (gsize i = 0; i < bufsz; i++)
 		checksum += buf[i];
 	return checksum;
@@ -126,7 +126,7 @@ fu_sum16(const guint8 *buf, gsize bufsz)
 gboolean
 fu_sum16_safe(const guint8 *buf, gsize bufsz, gsize offset, gsize n, guint16 *value, GError **error)
 {
-	g_return_val_if_fail(buf != NULL, FALSE);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	if (!fu_memchk_read(bufsz, offset, n, error))
@@ -170,7 +170,7 @@ guint16
 fu_sum16w(const guint8 *buf, gsize bufsz, FuEndianType endian)
 {
 	guint16 checksum = 0;
-	g_return_val_if_fail(buf != NULL, G_MAXUINT16);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, G_MAXUINT16);
 	g_return_val_if_fail(bufsz % 2 == 0, G_MAXUINT16);
 	for (gsize i = 0; i < bufsz; i += 2)
 		checksum += fu_memread_uint16(&buf[i], endian);
@@ -211,7 +211,7 @@ guint32
 fu_sum32(const guint8 *buf, gsize bufsz)
 {
 	guint32 checksum = 0;
-	g_return_val_if_fail(buf != NULL, G_MAXUINT32);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, G_MAXUINT32);
 	for (gsize i = 0; i < bufsz; i++)
 		checksum += buf[i];
 	return checksum;
@@ -251,7 +251,7 @@ guint32
 fu_sum32w(const guint8 *buf, gsize bufsz, FuEndianType endian)
 {
 	guint32 checksum = 0;
-	g_return_val_if_fail(buf != NULL, G_MAXUINT32);
+	g_return_val_if_fail(buf != NULL || bufsz == 0, G_MAXUINT32);
 	g_return_val_if_fail(bufsz % 4 == 0, G_MAXUINT32);
 	for (gsize i = 0; i < bufsz; i += 4)
 		checksum += fu_memread_uint32(&buf[i], endian);

--- a/libfwupdplugin/fu-sum.h
+++ b/libfwupdplugin/fu-sum.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "fwupd.h"
+
 #include "fu-endian.h"
 
 guint8

--- a/plugins/novatek-ts/fu-novatek-ts-device.c
+++ b/plugins/novatek-ts/fu-novatek-ts-device.c
@@ -626,8 +626,7 @@ fu_novatek_ts_device_page_program_gcm(FuNovatekTsDevice *self,
 	checksum += ((flash_addr >> 16) & 0xFF);
 	checksum += ((bufsz + 3) & 0xFF);
 	checksum += (((bufsz + 3) >> 8) & 0xFF);
-	for (guint i = 0; i < bufsz; i++)
-		checksum += buf[i];
+	checksum += fu_sum16(buf, bufsz);
 	checksum = ~checksum + 1;
 
 	/* prepare gcm command transfer */


### PR DESCRIPTION
Replace all instances of manual buffer summation loops with calls to the fu_sum8() utility function for improved code consistency and readability.

The fu_sum8() function provides the same functionality while reducing code duplication and making the intent clearer.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
