### PR TITLE
windows: require Windows 8+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -229,6 +229,8 @@ libdir = join_paths(prefix, get_option('libdir'))
 libexecdir = join_paths(prefix, get_option('libexecdir'))
 #this ends up in compiled code, ignore prefix
 if host_machine.system() == 'windows'
+  # require Windows 8+ for GetFirmwareType() and other modern APIs
+  add_project_arguments('-D_WIN32_WINNT=0x0602', language: 'c')
   sysconfdir = get_option('sysconfdir')
   localstatedir = get_option('localstatedir')
   datadir = get_option('datadir')


### PR DESCRIPTION
Trying to build locally in msys2 wingw64 and I ran into this error:

```
../../libfwupdplugin/fu-windows-efivars.c:31:14: error: implicit declaration of function 'GetFirmwareType'; did you mean 'GetFileType'? [-Wimplicit-function-declaration]
   31 |         if (!GetFirmwareType(&firmware_type)) {
      |              ^~~~~~~~~~~~~~~
      |              GetFileType
```

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
