### PR TITLE
plugins/snapd-uefi: improve error reporting when snapd requests fail

### DIFF
--- a/plugins/snapd-uefi/fu-self-test.c
+++ b/plugins/snapd-uefi/fu-self-test.c
@@ -21,6 +21,7 @@ typedef struct {
 	gboolean snapd_fde_detected;
 	gboolean snapd_supported;
 	const gchar *mock_snapd_scenario;
+	const gchar *expected_error_message;
 } FuTestCase;
 
 typedef struct {
@@ -400,8 +401,11 @@ fu_uefi_dbx_test_plugin_failed_update(FuTestFixture *fixture, gconstpointer user
 						       /* skip verification of ESP binaries*/
 						       FWUPD_INSTALL_FLAG_FORCE,
 						       &error);
-	if (g_str_equal(tc->mock_snapd_scenario, "failed-prepare")) {
+	if (g_str_equal(tc->mock_snapd_scenario, "failed-prepare") ||
+	    g_str_equal(tc->mock_snapd_scenario, "failed-prepare-invalid-json")) {
 		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+		g_assert_nonnull(tc->expected_error_message);
+		g_assert_cmpstr(error->message, ==, tc->expected_error_message);
 		g_clear_error(&error);
 	} else {
 		g_assert_no_error(error);
@@ -412,6 +416,8 @@ fu_uefi_dbx_test_plugin_failed_update(FuTestFixture *fixture, gconstpointer user
 	ret = fu_device_cleanup(FU_DEVICE(uefi_device), progress, 0, &error);
 	if (g_str_equal(tc->mock_snapd_scenario, "failed-cleanup")) {
 		g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL);
+		g_assert_nonnull(tc->expected_error_message);
+		g_assert_cmpstr(error->message, ==, tc->expected_error_message);
 	} else {
 		g_assert_no_error(error);
 		g_assert_true(ret);
@@ -508,8 +514,7 @@ fu_uefi_dbx_test_plugin_startup(FuTestFixture *fixture, gconstpointer user_data)
 int
 main(int argc, char **argv)
 {
-	FuTestCase simple = {
-	};
+	FuTestCase simple = {};
 	/* test variants with snapd, see tests/snapd.py for what a specific scenario
 	 * supports */
 	FuTestCase running_in_snap = {
@@ -556,20 +561,39 @@ main(int argc, char **argv)
 	FuTestCase running_in_snap_update_failed_prepare = {
 	    .snapd_supported = TRUE,
 	    .mock_snapd_scenario = "failed-prepare",
+	    .expected_error_message =
+		"failed to notify snapd of prepare: snapd request failed with status 400: "
+		"cannot reseal keys in prepare",
 	};
 	FuTestCase snapd_fde_detected_update_failed_prepare = {
 	    .snapd_fde_detected = TRUE,
 	    .snapd_supported = TRUE,
 	    .mock_snapd_scenario = "failed-prepare",
+	    .expected_error_message =
+		"failed to notify snapd of prepare: snapd request failed with status 400: "
+		"cannot reseal keys in prepare",
+	};
+	FuTestCase snapd_fde_detected_update_failed_prepare_invalid_json = {
+	    .snapd_fde_detected = TRUE,
+	    .snapd_supported = TRUE,
+	    .mock_snapd_scenario = "failed-prepare-invalid-json",
+	    .expected_error_message =
+		"failed to notify snapd of prepare: snapd request failed with status 400",
 	};
 	FuTestCase running_in_snap_update_failed_cleanup = {
 	    .snapd_supported = TRUE,
 	    .mock_snapd_scenario = "failed-cleanup",
+	    .expected_error_message =
+		"failed to notify snapd of cleanup: snapd request failed with status 500: "
+		"cannot reseal keys in cleanup",
 	};
 	FuTestCase snapd_fde_detected_update_failed_cleanup = {
 	    .snapd_fde_detected = TRUE,
 	    .snapd_supported = TRUE,
 	    .mock_snapd_scenario = "failed-cleanup",
+	    .expected_error_message =
+		"failed to notify snapd of cleanup: snapd request failed with status 500: "
+		"cannot reseal keys in cleanup",
 	};
 
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
@@ -698,6 +722,13 @@ main(int argc, char **argv)
 	g_test_add("/uefi-dbx/update/snapd/fde-detected/failed-prepare",
 		   FuTestFixture,
 		   &snapd_fde_detected_update_failed_prepare,
+		   fu_self_test_set_up,
+		   fu_uefi_dbx_test_plugin_failed_update,
+		   fu_self_test_tear_down);
+
+	g_test_add("/uefi-dbx/update/snapd/fde-detected/failed-prepare-invalid-json",
+		   FuTestFixture,
+		   &snapd_fde_detected_update_failed_prepare_invalid_json,
 		   fu_self_test_set_up,
 		   fu_uefi_dbx_test_plugin_failed_update,
 		   fu_self_test_tear_down);

--- a/plugins/snapd-uefi/fu-snapd-uefi-plugin.c
+++ b/plugins/snapd-uefi/fu-snapd-uefi-plugin.c
@@ -66,6 +66,44 @@ fu_snapd_uefi_plugin_rsp_cb(char *ptr, size_t size, size_t nmemb, void *userdata
 	return sz;
 }
 
+/*
+ * Extract the error message from the snapd JSON error response.
+ * The response format is:
+ *   {"type": "error", "status-code": <N>, "result": {"message": "<error description>"}}
+ *
+ * Returns: (transfer full) (nullable): the error message string, or NULL
+ */
+static gchar *
+fu_snapd_uefi_plugin_extract_error_message(const guint8 *data, gsize len)
+{
+	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	g_autoptr(FwupdJsonNode) json_node = NULL;
+	g_autoptr(FwupdJsonObject) json_rsp = NULL;
+	g_autoptr(FwupdJsonObject) json_result = NULL;
+	g_autoptr(GBytes) blob = g_bytes_new(data, len);
+	GRefString *msg;
+
+	/* set appropriate limits for a small error response */
+	fwupd_json_parser_set_max_depth(json_parser, 5);
+	fwupd_json_parser_set_max_items(json_parser, 10);
+	fwupd_json_parser_set_max_quoted(json_parser, 1000);
+
+	json_node =
+	    fwupd_json_parser_load_from_bytes(json_parser, blob, FWUPD_JSON_LOAD_FLAG_NONE, NULL);
+	if (json_node == NULL)
+		return NULL;
+	json_rsp = fwupd_json_node_get_object(json_node, NULL);
+	if (json_rsp == NULL)
+		return NULL;
+	json_result = fwupd_json_object_get_object(json_rsp, "result", NULL);
+	if (json_result == NULL)
+		return NULL;
+	msg = fwupd_json_object_get_string(json_result, "message", NULL);
+	if (msg == NULL)
+		return NULL;
+	return g_strdup(msg);
+}
+
 static gboolean
 fu_snapd_uefi_plugin_simple_req(FuSnapPlugin *self,
 				const gchar *endpoint,
@@ -101,7 +139,7 @@ fu_snapd_uefi_plugin_simple_req(FuSnapPlugin *self,
 
 	res = curl_easy_perform(curl);
 	if (res != CURLE_OK) {
-		/* TODO inspect the error */
+		/* TODO inspect curl specific error */
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,
@@ -120,16 +158,29 @@ fu_snapd_uefi_plugin_simple_req(FuSnapPlugin *self,
 	}
 
 	if (status_code != 200) {
+		g_autofree gchar *snapd_msg = NULL;
 		g_autofree gchar *rsp = NULL;
+
 		if (rsp_buf->len > 0) {
+			snapd_msg =
+			    fu_snapd_uefi_plugin_extract_error_message(rsp_buf->data, rsp_buf->len);
 			/* make sure the response is printable */
 			rsp = fu_strsafe((const char *)rsp_buf->data, rsp_buf->len);
 		}
 
-		/* TODO check whether the response is even printable? */
 		g_info("snapd request failed with status %ld, response: %s",
 		       (glong)status_code,
 		       rsp != NULL ? rsp : "<none>");
+
+		if (snapd_msg != NULL) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "snapd request failed with status %ld: %s",
+				    (glong)status_code,
+				    snapd_msg);
+			return FALSE;
+		}
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INTERNAL,

--- a/plugins/snapd-uefi/tests/snapd.py
+++ b/plugins/snapd-uefi/tests/snapd.py
@@ -98,7 +98,19 @@ def not_supported(req: dict[str, Any]) -> Response:
 
 def failed_startup(req: dict[str, Any]) -> Response:
     assert_startup_req(req)
-    return Response(None, status=400)
+    return Response(
+        json.dumps(
+            {
+                "type": "error",
+                "status-code": 400,
+                "status": "Bad Request",
+                "result": {
+                    "message": "cannot notify of manager startup",
+                },
+            }
+        ),
+        status=400,
+    )
 
 
 def happy_prepare(req: dict[str, Any]) -> Response:
@@ -115,14 +127,31 @@ def failed_prepare(req: dict[str, Any]) -> Response:
         return Response(
             json.dumps(
                 {
-                    "status": "500",
-                    "error": {
-                        "kind": "internal-error",
+                    "type": "error",
+                    "status-code": 400,
+                    "status": "Bad Request",
+                    "result": {
                         "message": "cannot reseal keys in prepare",
                     },
                 }
             ),
-            status=500,
+            status=400,
+        )
+    if action == "efi-secureboot-update-startup":
+        return happy_startup(req)
+
+    raise AssertionError(f"unexpected action {action}")
+
+
+def failed_prepare_invalid_json(req: dict[str, Any]) -> Response:
+    action = req.get("action")
+    if action == "efi-secureboot-update-db-cleanup":
+        return happy_cleanup(req)
+    if action == "efi-secureboot-update-db-prepare":
+        assert_prepare_req(req)
+        return Response(
+            "this is not valid json",
+            status=400,
         )
     if action == "efi-secureboot-update-startup":
         return happy_startup(req)
@@ -137,9 +166,10 @@ def failed_cleanup(req: dict[str, Any]) -> Response:
         return Response(
             json.dumps(
                 {
-                    "status": "500",
-                    "error": {
-                        "kind": "internal-error",
+                    "type": "error",
+                    "status-code": 500,
+                    "status": "Internal Server Error",
+                    "result": {
                         "message": "cannot reseal keys in cleanup",
                     },
                 }
@@ -180,6 +210,8 @@ playbook: dict[str, Scenario] = {
     "not-supported": Scenario(handler=not_supported),
     # prepare step fails
     "failed-prepare": Scenario(handler=failed_prepare),
+    # prepare step fails, response is not valid JSON
+    "failed-prepare-invalid-json": Scenario(handler=failed_prepare_invalid_json),
     # prepare is successful, but cleanup fails
     "failed-cleanup": Scenario(handler=failed_cleanup),
     # successful update cycle


### PR DESCRIPTION
Improve error reporting of failed snapd requests. Specifically, the API may return a JSON object in failed request with the actual error 'message'. Include it in the error value if available.

Relates to: #10082

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
