### PR TITLE
dell-dock: Validate firmware values

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -83,6 +83,17 @@ fu_dell_dock_hub_write_fw(FuDevice *device,
 	if (fw == NULL)
 		return FALSE;
 	data = g_bytes_get_data(fw, &fw_size);
+	if (self->blob_major_offset >= fw_size || self->blob_minor_offset >= fw_size) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_FILE,
+			    "version offset out of bounds (major=0x%x, minor=0x%x, size=0x%x)",
+			    (guint)self->blob_major_offset,
+			    (guint)self->blob_minor_offset,
+			    (guint)fw_size);
+		return FALSE;
+	}
+
 	write_size = (fw_size / HIDI2C_MAX_WRITE) >= 1 ? HIDI2C_MAX_WRITE : fw_size;
 
 	dynamic_version = g_strdup_printf("%02x.%02x",

--- a/plugins/dell-dock/fu-dell-dock-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-mst.c
@@ -970,6 +970,7 @@ fu_dell_dock_mst_write_firmware(FuDevice *device,
 	g_autofree gchar *dynamic_version = NULL;
 	g_autoptr(GBytes) fw = NULL;
 	FuDellDockMstType type;
+	gsize fw_size;
 
 	g_return_val_if_fail(device != NULL, FALSE);
 	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
@@ -989,7 +990,16 @@ fu_dell_dock_mst_write_firmware(FuDevice *device,
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
-	data = g_bytes_get_data(fw, NULL);
+
+	data = g_bytes_get_data(fw, &fw_size);
+	if (self->blob_major_offset >= fw_size || self->blob_minor_offset >= fw_size ||
+	    self->blob_build_offset >= fw_size) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "version offset out of bounds");
+		return FALSE;
+	}
 
 	dynamic_version = g_strdup_printf("%02x.%02x.%02x",
 					  data[self->blob_major_offset],

--- a/plugins/dell-dock/fu-dell-dock-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-tbt.c
@@ -73,6 +73,21 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 		return FALSE;
 	buffer = g_bytes_get_data(fw, &image_size);
 
+	if (image_size < sizeof(guint32)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "firmware image too small for header");
+		return FALSE;
+	}
+	if (self->blob_major_offset >= image_size || self->blob_minor_offset >= image_size) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "version offset out of bounds");
+		return FALSE;
+	}
+
 	dynamic_version = g_strdup_printf("%02x.%02x",
 					  buffer[self->blob_major_offset],
 					  buffer[self->blob_minor_offset]);


### PR DESCRIPTION
The configurable offsets read from the firmware are not checked for validity on the bounds or size of the fields, which could cause issues with incorrect firmware images.

Validate them all before using the values as offsets into different arrays.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
