### PR TITLE
trivial: Sanity check the cab archive filename

### DIFF
--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -219,3 +219,7 @@ Use `./contrib/migrate.py` to migrate up out-of-tree plugins to the new API.
 * `fu_plugin_device_add()`: Use `fu_plugin_add_device()` instead.
 * `fu_plugin_device_remove()`: Use `fu_plugin_remove_device()` instead.
 * `fu_cfi_device_new()`: Use a proxy rather than a context.
+
+## 2.1.2
+
+* `fu_firmware_set_filename()`: add `GError`

--- a/libfwupdplugin/fu-cab-firmware.c
+++ b/libfwupdplugin/fu-cab-firmware.c
@@ -460,9 +460,6 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 				    value);
 			return FALSE;
 		}
-		/* convert to UNIX path */
-		if (value == '\\')
-			value = '/';
 		g_string_append_c(filename, (gchar)value);
 	}
 
@@ -471,7 +468,8 @@ fu_cab_firmware_parse_file(FuCabFirmware *self,
 		g_autofree gchar *id = g_path_get_basename(filename->str);
 		fu_firmware_set_id(FU_FIRMWARE(img), id);
 	} else {
-		fu_firmware_set_id(FU_FIRMWARE(img), filename->str);
+		if (!fu_firmware_set_filename(FU_FIRMWARE(img), filename->str, error))
+			return FALSE;
 	}
 	stream = fu_partial_input_stream_new(folder_data,
 					     fu_struct_cab_file_get_uoffset(st),

--- a/libfwupdplugin/fu-cab-image.c
+++ b/libfwupdplugin/fu-cab-image.c
@@ -164,6 +164,7 @@ fu_cab_image_class_init(FuCabImageClass *klass)
 static void
 fu_cab_image_init(FuCabImage *self)
 {
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_FILENAME_FOR_ID);
 }
 
 /**

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -2116,7 +2116,8 @@ fu_context_esp_load_pe_file(const gchar *filename, GError **error)
 {
 	g_autoptr(FuFirmware) firmware = fu_pefile_firmware_new();
 	g_autoptr(GFile) file = g_file_new_for_path(filename);
-	fu_firmware_set_filename(firmware, filename);
+	if (!fu_firmware_set_filename(firmware, filename, error))
+		return NULL;
 	if (!fu_firmware_parse_file(firmware, file, FU_FIRMWARE_PARSE_FLAG_NONE, error)) {
 		g_prefix_error(error, "failed to load %s: ", filename);
 		return NULL;

--- a/libfwupdplugin/fu-efi-x509-signature.c
+++ b/libfwupdplugin/fu-efi-x509-signature.c
@@ -260,7 +260,8 @@ fu_efi_x509_signature_parse(FuFirmware *firmware,
 		g_autofree gchar *filename = g_strdup_printf("%s_%s.der",
 							     fu_firmware_get_id(FU_FIRMWARE(crt)),
 							     fu_x509_certificate_get_subject(crt));
-		fu_firmware_set_filename(firmware, filename);
+		if (!fu_firmware_set_filename(firmware, filename, error))
+			return FALSE;
 	}
 
 	/* success */

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -689,7 +689,9 @@ fu_firmware_func(void)
 	fu_firmware_set_addr(img1, 0x200);
 	fu_firmware_set_idx(img1, 13);
 	fu_firmware_set_id(img1, "primary");
-	fu_firmware_set_filename(img1, "BIOS.bin");
+	ret = fu_firmware_set_filename(img1, "BIOS.bin", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 	ret = fu_firmware_add_image(firmware, img1, &error);
 	g_assert_no_error(error);
 	g_assert_true(ret);

--- a/libfwupdplugin/fu-firmware.c
+++ b/libfwupdplugin/fu-firmware.c
@@ -276,23 +276,74 @@ fu_firmware_get_filename(FuFirmware *self)
  * fu_firmware_set_filename:
  * @self: a #FuFirmware
  * @filename: (nullable): a string filename
+ * @error: (nullable): optional return location for an error
  *
  * Sets an optional filename that represents the image source or destination.
  *
- * Since: 1.6.0
+ * Returns: %TRUE on success
+ *
+ * Since: 2.1.2
  **/
-void
-fu_firmware_set_filename(FuFirmware *self, const gchar *filename)
+gboolean
+fu_firmware_set_filename(FuFirmware *self, const gchar *filename, GError **error)
 {
 	FuFirmwarePrivate *priv = GET_PRIVATE(self);
-	g_return_if_fail(FU_IS_FIRMWARE(self));
+	g_autofree gchar *filename_unix = NULL;
+
+	g_return_val_if_fail(FU_IS_FIRMWARE(self), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	/* not changed */
 	if (g_strcmp0(priv->filename, filename) == 0)
-		return;
+		return TRUE;
 
+	/* sanity check */
+	if (g_strcmp0(filename, ".") == 0 || g_strcmp0(filename, "..") == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "special paths not allowed");
+		return FALSE;
+	}
+
+	/* convert to UNIX path */
+	filename_unix = g_strdup(filename);
+	if (filename_unix != NULL)
+		g_strdelimit(filename_unix, "\\", '/');
+
+	/* use the filename as the child identifier */
+	if (fu_firmware_has_flag(self, FU_FIRMWARE_FLAG_FILENAME_FOR_ID)) {
+		if (filename_unix == NULL) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "filename required for FILENAME_FOR_ID");
+			return FALSE;
+		}
+		if (g_path_is_absolute(filename_unix)) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "absolute paths not allowed");
+			return FALSE;
+		}
+		if (g_str_has_prefix(filename_unix, "../") ||
+		    g_strstr_len(filename_unix, -1, "/../") != NULL ||
+		    g_str_has_suffix(filename_unix, "/..")) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "path traversal detected");
+			return FALSE;
+		}
+		fu_firmware_set_id(self, filename_unix);
+		return TRUE;
+	}
+
+	/* success */
 	g_free(priv->filename);
-	priv->filename = g_strdup(filename);
+	priv->filename = g_steal_pointer(&filename_unix);
+	return TRUE;
 }
 
 /**
@@ -1385,7 +1436,8 @@ fu_firmware_build(FuFirmware *self, XbNode *n, GError **error)
 				return FALSE;
 			fu_firmware_set_bytes(self, blob);
 		}
-		fu_firmware_set_filename(self, tmp);
+		if (!fu_firmware_set_filename(self, tmp, error))
+			return FALSE;
 	}
 
 	/* optional chunks */

--- a/libfwupdplugin/fu-firmware.h
+++ b/libfwupdplugin/fu-firmware.h
@@ -122,8 +122,9 @@ fu_firmware_has_flag(FuFirmware *self, FuFirmwareFlags flag) G_GNUC_WARN_UNUSED_
     G_GNUC_NON_NULL(1);
 const gchar *
 fu_firmware_get_filename(FuFirmware *self) G_GNUC_NON_NULL(1);
-void
-fu_firmware_set_filename(FuFirmware *self, const gchar *filename) G_GNUC_NON_NULL(1);
+gboolean
+fu_firmware_set_filename(FuFirmware *self, const gchar *filename, GError **error)
+    G_GNUC_NON_NULL(1);
 const gchar *
 fu_firmware_get_id(FuFirmware *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupdplugin/fu-firmware.rs
+++ b/libfwupdplugin/fu-firmware.rs
@@ -41,6 +41,7 @@ enum FuFirmwareFlags {
     IsLastImage = 1 << 9, // use for FuLinearFirmware when padding is present
     AllowLinear = 1 << 10, // parse as an array of firmwares
     IsAbstract = 1 << 11, // cannot parse a blob directly
+    FilenameForId = 1 << 12, // use the filename as the child ID
 }
 
 enum FuFirmwareAlignment {

--- a/libfwupdplugin/fu-zip-file.c
+++ b/libfwupdplugin/fu-zip-file.c
@@ -92,6 +92,7 @@ fu_zip_file_init(FuZipFile *self)
 {
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_STORED_SIZE);
+	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_FILENAME_FOR_ID);
 }
 
 /**

--- a/libfwupdplugin/fu-zip-firmware.c
+++ b/libfwupdplugin/fu-zip-firmware.c
@@ -185,7 +185,8 @@ fu_zip_firmware_parse_lfh(FuZipFirmware *self,
 		g_autofree gchar *filename_basename = g_path_get_basename(filename);
 		fu_firmware_set_id(zip_file, filename_basename);
 	} else {
-		fu_firmware_set_id(zip_file, filename);
+		if (!fu_firmware_set_filename(zip_file, filename, error))
+			return NULL;
 	}
 
 	/* success */

--- a/plugins/pixart-tp/fu-pixart-tp-section.c
+++ b/plugins/pixart-tp/fu-pixart-tp-section.c
@@ -166,8 +166,10 @@ fu_pixart_tp_section_parse(FuFirmware *firmware,
 
 	/* extname */
 	extname = fu_struct_pixart_tp_firmware_section_hdr_get_extname(st);
-	if (extname != NULL)
-		fu_firmware_set_filename(FU_FIRMWARE(self), extname);
+	if (extname != NULL) {
+		if (!fu_firmware_set_filename(FU_FIRMWARE(self), extname, error))
+			return FALSE;
+	}
 
 	/* data */
 	if (section_length != 0) {

--- a/plugins/redfish/fu-self-test.c
+++ b/plugins/redfish/fu-self-test.c
@@ -498,7 +498,7 @@ fu_redfish_hpe_update_func(gconstpointer user_data)
 	dev = g_ptr_array_index(devices, 0);
 	blob_fw = g_bytes_new_static("hello", 5);
 	stream_fw = fu_firmware_new_from_bytes(blob_fw);
-	fu_firmware_set_filename(stream_fw, "test.fwpkg");
+	fu_firmware_set_filename(stream_fw, "test.fwpkg", NULL);
 	ret = fu_plugin_runner_write_firmware(self->hpe_plugin,
 					      dev,
 					      stream_fw,
@@ -538,7 +538,7 @@ fu_redfish_update_func(gconstpointer user_data)
 	dev = g_ptr_array_index(devices, 1);
 	blob_fw = g_bytes_new_static("hello", 5);
 	firmware = fu_firmware_new_from_bytes(blob_fw);
-	fu_firmware_set_filename(firmware, "firmware.exe");
+	fu_firmware_set_filename(firmware, "firmware.exe", NULL);
 	ret = fu_plugin_runner_write_firmware(self->plugin,
 					      dev,
 					      firmware,
@@ -592,7 +592,7 @@ fu_redfish_smc_update_func(gconstpointer user_data)
 	dev = g_ptr_array_index(devices, 1);
 	blob_fw1 = g_bytes_new_static("hello", 5);
 	firmware1 = fu_firmware_new_from_bytes(blob_fw1);
-	fu_firmware_set_filename(firmware1, "firmware.bin");
+	fu_firmware_set_filename(firmware1, "firmware.bin", NULL);
 	ret = fu_plugin_runner_write_firmware(self->plugin,
 					      dev,
 					      firmware1,

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3752,7 +3752,8 @@ fu_engine_install_loop(FuEngine *self,
 			fu_firmware_set_version(firmware, fu_release_get_version(release));
 		if (fu_firmware_get_filename(firmware) == NULL) {
 			fu_firmware_set_filename(firmware,
-						 fu_release_get_firmware_basename(release));
+						 fu_release_get_firmware_basename(release),
+						 NULL);
 		}
 		fu_progress_step_done(progress);
 
@@ -3780,8 +3781,10 @@ fu_engine_install_loop(FuEngine *self,
 		if (fu_firmware_get_version(firmware) == NULL)
 			fu_firmware_set_version(firmware, fu_release_get_version(release));
 		if (fu_firmware_get_filename(firmware) == NULL) {
-			fu_firmware_set_filename(firmware,
-						 fu_release_get_firmware_basename(release));
+			if (!fu_firmware_set_filename(firmware,
+						      fu_release_get_firmware_basename(release),
+						      error))
+				return FALSE;
 		}
 		fu_progress_step_done(progress);
 


### PR DESCRIPTION
This isn't a security issue as the daemon does not extract the archive to a temp directory, but it makes a security scanner happy.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
