### PR TITLE
thunderbolt: Fix the version number by ignoring reserved bits

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-device.c
+++ b/plugins/thunderbolt/fu-thunderbolt-device.c
@@ -148,7 +148,9 @@ fu_thunderbolt_device_get_version(FuThunderboltDevice *self, GError **error)
 		return FALSE;
 	if (!fu_strtoull(split[1], &version_minor, 0, G_MAXUINT64, FU_INTEGER_BASE_16, error))
 		return FALSE;
-	version = g_strdup_printf("%02x.%02x", (guint)version_major, (guint)version_minor);
+	version = g_strdup_printf("%02x.%02x",
+				  (guint)(version_major & 0b00111111),
+				  (guint)(version_minor & 0b00111111));
 	fu_device_set_version(FU_DEVICE(self), version);
 	return TRUE;
 }


### PR DESCRIPTION
The two highest bits are reserved for Intel and should not be used for display.

Fixes https://github.com/fwupd/fwupd/issues/10112

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
