### PR TITLE
dell-dock: Use safe buffer access when building firmware values

### DIFF
--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -66,6 +66,8 @@ fu_dell_dock_hub_write_fw(FuDevice *device,
 	gsize nwritten = 0;
 	guint32 address = 0;
 	gboolean result = FALSE;
+	guint8 major_version = 0;
+	guint8 minor_version = 0;
 	g_autofree gchar *dynamic_version = NULL;
 	g_autoptr(GBytes) fw = NULL;
 
@@ -85,9 +87,11 @@ fu_dell_dock_hub_write_fw(FuDevice *device,
 	data = g_bytes_get_data(fw, &fw_size);
 	write_size = (fw_size / HIDI2C_MAX_WRITE) >= 1 ? HIDI2C_MAX_WRITE : fw_size;
 
-	dynamic_version = g_strdup_printf("%02x.%02x",
-					  data[self->blob_major_offset],
-					  data[self->blob_minor_offset]);
+	if (!fu_memread_uint8_safe(data, fw_size, self->blob_major_offset, &major_version, error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(data, fw_size, self->blob_minor_offset, &minor_version, error))
+		return FALSE;
+	dynamic_version = g_strdup_printf("%02x.%02x", major_version, minor_version);
 	g_info("writing hub firmware version %s", dynamic_version);
 
 	if (!fu_dell_dock_set_power(device, self->unlock_target, TRUE, error))

--- a/plugins/dell-dock/fu-dell-dock-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-mst.c
@@ -970,6 +970,10 @@ fu_dell_dock_mst_write_firmware(FuDevice *device,
 	g_autofree gchar *dynamic_version = NULL;
 	g_autoptr(GBytes) fw = NULL;
 	FuDellDockMstType type;
+	gsize datasz;
+	guint8 major_version = 0;
+	guint8 minor_version = 0;
+	guint8 build_version = 0;
 
 	g_return_val_if_fail(device != NULL, FALSE);
 	g_return_val_if_fail(FU_IS_FIRMWARE(firmware), FALSE);
@@ -989,12 +993,15 @@ fu_dell_dock_mst_write_firmware(FuDevice *device,
 	fw = fu_firmware_get_bytes(firmware, error);
 	if (fw == NULL)
 		return FALSE;
-	data = g_bytes_get_data(fw, NULL);
-
-	dynamic_version = g_strdup_printf("%02x.%02x.%02x",
-					  data[self->blob_major_offset],
-					  data[self->blob_minor_offset],
-					  data[self->blob_build_offset]);
+	data = g_bytes_get_data(fw, &datasz);
+	if (!fu_memread_uint8_safe(data, datasz, self->blob_major_offset, &major_version, error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(data, datasz, self->blob_minor_offset, &minor_version, error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(data, datasz, self->blob_build_offset, &build_version, error))
+		return FALSE;
+	dynamic_version =
+	    g_strdup_printf("%02x.%02x.%02x", major_version, minor_version, build_version);
 	g_info("writing MST firmware version %s", dynamic_version);
 
 	/* enable remote control */

--- a/plugins/dell-dock/fu-dell-dock-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-tbt.c
@@ -60,6 +60,8 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 	gsize image_size = 0;
 	const guint8 *buffer;
 	guint16 target_system = 0;
+	guint8 major_version = 0;
+	guint8 minor_version = 0;
 	g_autoptr(GTimer) timer = g_timer_new();
 	g_autofree gchar *dynamic_version = NULL;
 	g_autoptr(GBytes) fw = NULL;
@@ -72,10 +74,19 @@ fu_dell_dock_tbt_write_fw(FuDevice *device,
 	if (fw == NULL)
 		return FALSE;
 	buffer = g_bytes_get_data(fw, &image_size);
-
-	dynamic_version = g_strdup_printf("%02x.%02x",
-					  buffer[self->blob_major_offset],
-					  buffer[self->blob_minor_offset]);
+	if (!fu_memread_uint8_safe(buffer,
+				   image_size,
+				   self->blob_major_offset,
+				   &major_version,
+				   error))
+		return FALSE;
+	if (!fu_memread_uint8_safe(buffer,
+				   image_size,
+				   self->blob_minor_offset,
+				   &minor_version,
+				   error))
+		return FALSE;
+	dynamic_version = g_strdup_printf("%02x.%02x", major_version, minor_version);
 	g_info("writing Thunderbolt firmware version %s", dynamic_version);
 	g_debug("total image size: %" G_GSIZE_FORMAT, image_size);
 


### PR DESCRIPTION
Based on a patch by Greg Kroah-Hartman <gregkh@linuxfoundation.org>

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
