### PR TITLE
Fix warning when probing removable USB devices with no medium

### DIFF
--- a/libfwupd/fwupd-error.c
+++ b/libfwupd/fwupd-error.c
@@ -234,7 +234,15 @@ fwupd_error_convert(GError **perror)
 	if (error->domain == FWUPD_ERROR)
 		return;
 
-	/* correct some company names */
+	/* special case: G_IO_ERROR_FAILED with "No medium found" from removable devices */
+	if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_FAILED) &&
+	    g_strstr_len(error->message, -1, "No medium found") != NULL) {
+		error->domain = FWUPD_ERROR;
+		error->code = FWUPD_ERROR_NOT_FOUND;
+		return;
+	}
+
+	/* convert GError to FwupdError */
 	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
 		if (g_error_matches(error, map[i].domain, map[i].code)) {
 			error->domain = FWUPD_ERROR;


### PR DESCRIPTION
When a USB storage device is unplugged or has no medium, the system returns ENOMEDIUM (errno 123) which GLib converts to G_IO_ERROR_FAILED with the message "No medium found". This was being converted to FWUPD_ERROR_INTERNAL, causing the engine to log a warning instead of silently ignoring the transient device.

This commit adds support for message-based error matching in the error conversion table and maps G_IO_ERROR_FAILED with "No medium found" to FWUPD_ERROR_NOT_FOUND, which is treated as an ignorable condition.

Fixes regression introduced between 2.0.20 and 2.1.1 where these warnings started appearing in logs during USB device removal.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
