### PR TITLE
Calculate and export a floating point percentage progress value

### DIFF
--- a/libfwupd/fwupd-client-test.c
+++ b/libfwupd/fwupd-client-test.c
@@ -176,6 +176,7 @@ fwupd_client_api(void)
 	g_value_set_int(&value_int, 50);
 	g_object_set_property(G_OBJECT(client), "percentage", &value_int);
 	g_assert_cmpint(fwupd_client_get_percentage(client), ==, 50);
+	g_assert_cmpfloat_with_epsilon(fwupd_client_get_percentage_full(client), 50, 0.01f);
 	g_object_set_property(G_OBJECT(client), "percentage", &value_int);
 
 	/* set all properties */

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -59,7 +59,7 @@ typedef struct {
 	FwupdStatus status;
 	gboolean tainted;
 	gboolean interactive;
-	guint percentage;
+	gdouble percentage;
 	guint32 battery_level;
 	guint32 battery_threshold;
 	guint download_retries;
@@ -107,6 +107,7 @@ enum {
 	PROP_0,
 	PROP_STATUS,
 	PROP_PERCENTAGE,
+	PROP_PERCENTAGE_FULL,
 	PROP_DAEMON_VERSION,
 	PROP_TAINTED,
 	PROP_HOST_PRODUCT,
@@ -530,13 +531,15 @@ fwupd_client_set_status(FwupdClient *self, FwupdStatus status)
 }
 
 static void
-fwupd_client_set_percentage(FwupdClient *self, guint percentage)
+fwupd_client_set_percentage(FwupdClient *self, gdouble percentage)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
-	if (priv->percentage == percentage)
-		return;
+	gboolean notify = fwupd_percentage_delta_notify(priv->percentage, percentage);
 	priv->percentage = percentage;
-	fwupd_client_object_notify(self, "percentage");
+	if (notify) {
+		fwupd_client_object_notify(self, "percentage");
+		fwupd_client_object_notify(self, "percentage-full");
+	}
 }
 
 static void
@@ -592,7 +595,12 @@ fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 			fwupd_client_object_notify(self, "interactive");
 		}
 	}
-	if (g_variant_dict_contains(dict, "Percentage")) {
+	if (g_variant_dict_contains(dict, "PercentageFull")) {
+		g_autoptr(GVariant) val = NULL;
+		val = g_dbus_proxy_get_cached_property(proxy, "PercentageFull");
+		if (val != NULL)
+			fwupd_client_set_percentage(self, g_variant_get_double(val));
+	} else if (g_variant_dict_contains(dict, "Percentage")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "Percentage");
 		if (val != NULL)
@@ -853,14 +861,14 @@ fwupd_client_progress_callback_cb(void *clientp,
 
 	/* calculate percentage */
 	if (dltotal > 0 && dlnow >= 0 && dlnow <= dltotal) {
-		guint percentage = (guint)((100 * dlnow) / dltotal);
-		if (priv->percentage != percentage)
-			g_info("download progress: %u%%", percentage);
+		gdouble percentage = ((100.0 * (gdouble)dlnow) / (gdouble)dltotal);
+		if (fwupd_percentage_delta_notify(priv->percentage, percentage))
+			g_info("download progress: %.1f%%", percentage);
 		fwupd_client_set_percentage(self, percentage);
 	} else if (ultotal > 0 && ulnow >= 0 && ulnow <= ultotal) {
-		guint percentage = (guint)((100 * ulnow) / ultotal);
-		if (priv->percentage != percentage)
-			g_info("upload progress: %u%%", percentage);
+		gdouble percentage = ((100.0 * (gdouble)ulnow) / (gdouble)ultotal);
+		if (fwupd_percentage_delta_notify(priv->percentage, percentage))
+			g_info("upload progress: %.1f%%", percentage);
 		fwupd_client_set_percentage(self, percentage);
 	}
 
@@ -4119,6 +4127,24 @@ fwupd_client_get_percentage(FwupdClient *self)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
 	g_return_val_if_fail(FWUPD_IS_CLIENT(self), 0);
+	return (guint)priv->percentage;
+}
+
+/**
+ * fwupd_client_get_percentage_full:
+ * @self: a #FwupdClient
+ *
+ * Gets the last returned percentage value.
+ *
+ * Returns: a percentage, or %FWUPD_PERCENTAGE_UNKNOWN for unknown.
+ *
+ * Since: 2.1.3
+ **/
+gdouble
+fwupd_client_get_percentage_full(FwupdClient *self)
+{
+	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	g_return_val_if_fail(FWUPD_IS_CLIENT(self), FWUPD_PERCENTAGE_UNKNOWN);
 	return priv->percentage;
 }
 
@@ -5780,7 +5806,7 @@ fwupd_client_download_ipfs(FwupdClient *self,
 
 	/* we get no detailed progress details */
 	fwupd_client_set_status(self, FWUPD_STATUS_DOWNLOADING);
-	fwupd_client_set_percentage(self, 0);
+	fwupd_client_set_percentage(self, 0.0);
 
 	/* convert from URI to path */
 	if (g_str_has_prefix(url, "ipfs://")) {
@@ -5797,7 +5823,6 @@ fwupd_client_download_ipfs(FwupdClient *self,
 		return NULL;
 	if (!g_subprocess_communicate(subprocess, NULL, cancellable, &bstdout, &bstderr, error))
 		return NULL;
-	fwupd_client_set_status(self, FWUPD_STATUS_IDLE);
 	if (g_subprocess_get_exit_status(subprocess) != 0) {
 		gsize msgsz = 0;
 		const gchar *msgdata = g_bytes_get_data(bstderr, &msgsz);
@@ -5837,8 +5862,7 @@ fwupd_client_download_http(FwupdClient *self, CURL *curl, const gchar *url, GErr
 			       fwupd_client_download_write_callback_cb);
 	(void)curl_easy_setopt(curl, CURLOPT_WRITEDATA, buf);
 	res = curl_easy_perform(curl);
-	fwupd_client_set_status(self, FWUPD_STATUS_IDLE);
-	fwupd_client_set_percentage(self, 100);
+	fwupd_client_set_percentage(self, 100.0);
 	if (res == CURLE_SEND_ERROR || res == CURLE_RECV_ERROR) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -6028,8 +6052,7 @@ fwupd_client_download_bytes_thread_cb(GTask *task,
 			g_task_return_error(task, g_steal_pointer(&error));
 			return;
 		}
-		fwupd_client_set_percentage(self, 0);
-		fwupd_client_set_status(self, FWUPD_STATUS_IDLE);
+		fwupd_client_set_percentage(self, 0.0);
 		g_info("failed to download %s: %s, trying next URI…", url, error->message);
 	}
 	g_task_return_pointer(task, g_steal_pointer(&blob), (GDestroyNotify)g_bytes_unref);
@@ -6152,7 +6175,7 @@ fwupd_client_upload_bytes_thread_cb(GTask *task,
 			       fwupd_client_download_write_callback_cb);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_WRITEDATA, buf);
 	res = curl_easy_perform(helper->curl);
-	fwupd_client_set_status(self, FWUPD_STATUS_IDLE);
+	fwupd_client_set_percentage(self, 100.0);
 	if (res != CURLE_OK) {
 		glong status_code = 0;
 		curl_easy_getinfo(helper->curl, CURLINFO_RESPONSE_CODE, &status_code);
@@ -6261,7 +6284,6 @@ fwupd_client_upload_bytes_async(FwupdClient *self,
 		(void)curl_easy_setopt(helper->curl, CURLOPT_SSL_VERIFYHOST, 2L);
 	}
 
-	fwupd_client_set_status(self, FWUPD_STATUS_IDLE);
 	g_info("uploading to %s", url);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_URL, url);
 	g_task_set_task_data(task,
@@ -7409,6 +7431,9 @@ fwupd_client_get_property(GObject *object, guint prop_id, GValue *value, GParamS
 	case PROP_PERCENTAGE:
 		g_value_set_uint(value, priv->percentage);
 		break;
+	case PROP_PERCENTAGE_FULL:
+		g_value_set_double(value, priv->percentage);
+		break;
 	case PROP_DAEMON_VERSION:
 		g_value_set_string(value, priv->daemon_version);
 		break;
@@ -7457,6 +7482,9 @@ fwupd_client_set_property(GObject *object, guint prop_id, const GValue *value, G
 		break;
 	case PROP_PERCENTAGE:
 		priv->percentage = g_value_get_uint(value);
+		break;
+	case PROP_PERCENTAGE_FULL:
+		priv->percentage = g_value_get_double(value);
 		break;
 	case PROP_BATTERY_LEVEL:
 		fwupd_client_set_battery_level(self, g_value_get_uint(value));
@@ -7683,6 +7711,22 @@ fwupd_client_class_init(FwupdClientClass *klass)
 	g_object_class_install_property(object_class, PROP_PERCENTAGE, pspec);
 
 	/**
+	 * FwupdClient:percentage-full:
+	 *
+	 * The last-reported percentage of the daemon.
+	 *
+	 * Since: 2.1.3
+	 */
+	pspec = g_param_spec_double("percentage-full",
+				    NULL,
+				    NULL,
+				    -1.0,
+				    100.0,
+				    -1.0,
+				    G_PARAM_READWRITE | G_PARAM_STATIC_NAME);
+	g_object_class_install_property(object_class, PROP_PERCENTAGE_FULL, pspec);
+
+	/**
 	 * FwupdClient:daemon-version:
 	 *
 	 * The daemon version number.
@@ -7817,6 +7861,7 @@ static void
 fwupd_client_init(FwupdClient *self)
 {
 	FwupdClientPrivate *priv = GET_PRIVATE(self);
+	priv->percentage = FWUPD_PERCENTAGE_UNKNOWN;
 	g_mutex_init(&priv->proxy_mutex);
 	g_mutex_init(&priv->idle_mutex);
 	priv->idle_sources =

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -469,6 +469,8 @@ gboolean
 fwupd_client_get_daemon_interactive(FwupdClient *self) G_GNUC_NON_NULL(1);
 guint
 fwupd_client_get_percentage(FwupdClient *self) G_GNUC_NON_NULL(1);
+gdouble
+fwupd_client_get_percentage_full(FwupdClient *self) G_GNUC_NON_NULL(1);
 const gchar *
 fwupd_client_get_daemon_version(FwupdClient *self) G_GNUC_NON_NULL(1);
 void

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -607,3 +607,48 @@ fwupd_variant_get_uint64(GVariant *value)
 		return (guint64)g_variant_get_int64(value);
 	return g_variant_get_uint64(value);
 }
+
+/**
+ * fwupd_percentage_is_valid:
+ * @value: maybe a percentage value
+ *
+ * Calculates is a percentage value is valid, i.e. `>= 0.0` and `<= 100.0`.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_percentage_is_valid(gdouble value)
+{
+	return value >= 0.0 && value <= 100.0;
+}
+
+#define FWUPD_PERCENTAGE_CHANGE_EPSILON (0.01)
+
+/**
+ * fwupd_percentage_delta_notify:
+ * @value_old: a percentage value
+ * @value_new: another percentage value
+ *
+ * Calculates if a percentage change is significant, and worth notifying the client about.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_percentage_delta_notify(gdouble value_old, gdouble value_new)
+{
+	if (value_old - value_new > FWUPD_PERCENTAGE_CHANGE_EPSILON)
+		return TRUE;
+	if (value_new - value_old > FWUPD_PERCENTAGE_CHANGE_EPSILON)
+		return TRUE;
+	if (value_old < 100.0 && value_new >= 100.0)
+		return TRUE;
+	if (fwupd_percentage_is_valid(value_old) && !fwupd_percentage_is_valid(value_new))
+		return TRUE;
+	if (fwupd_percentage_is_valid(value_new) && !fwupd_percentage_is_valid(value_old))
+		return TRUE;
+	return FALSE;
+}

--- a/libfwupd/fwupd-common.h
+++ b/libfwupd/fwupd-common.h
@@ -111,4 +111,19 @@ fwupd_guid_hash_string(const gchar *str);
 gchar *
 fwupd_guid_hash_data(const guint8 *data, gsize datasz, FwupdGuidFlags flags) G_GNUC_NON_NULL(1);
 
+/**
+ * FWUPD_PERCENTAGE_UNKNOWN:
+ *
+ * The percentage value when the daemon does not know the current progress value. This usually
+ * results in a "bouncing" progressbar.
+ *
+ * Since: 2.1.3
+ */
+#define FWUPD_PERCENTAGE_UNKNOWN (-1.0)
+
+gboolean
+fwupd_percentage_is_valid(gdouble value);
+gboolean
+fwupd_percentage_delta_notify(gdouble value_old, gdouble value_new);
+
 G_END_DECLS

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1136,6 +1136,7 @@ LIBFWUPD_2.1.2 {
 
 LIBFWUPD_2.1.3 {
   global:
+    fwupd_client_get_percentage_full;
     fwupd_jcat_blob_flags_to_string;
     fwupd_jcat_blob_get_data;
     fwupd_jcat_blob_get_data_as_string;
@@ -1175,5 +1176,7 @@ LIBFWUPD_2.1.3 {
     fwupd_jcat_item_has_target;
     fwupd_jcat_item_new;
     fwupd_jcat_item_remove_alias_id;
+    fwupd_percentage_delta_notify;
+    fwupd_percentage_is_valid;
   local: *;
 } LIBFWUPD_2.1.2;

--- a/libfwupdplugin/README.md
+++ b/libfwupdplugin/README.md
@@ -227,3 +227,5 @@ Use `./contrib/migrate.py` to migrate up out-of-tree plugins to the new API.
 * `fu_chunk_array_mutable_new()`: Add `GError`
 * `fu_composite_input_stream_add_bytes()`: Add `GError`
 * `fu_composite_input_stream_add_partial_stream()`: Add `GError`
+* `fu_progress_get_percentage()`: Convert `guint` to `gdouble`
+* `fu_progress_set_percentage()`: Convert `guint` to `gdouble`

--- a/libfwupdplugin/fu-device-progress.c
+++ b/libfwupdplugin/fu-device-progress.c
@@ -23,7 +23,9 @@ struct _FuDeviceProgress {
 G_DEFINE_TYPE(FuDeviceProgress, fu_device_progress, G_TYPE_OBJECT)
 
 static void
-fu_device_progress_percentage_changed_cb(FuProgress *progress, guint percentage, gpointer user_data)
+fu_device_progress_percentage_changed_cb(FuProgress *progress,
+					 gdouble percentage,
+					 gpointer user_data)
 {
 	FuDeviceProgress *self = FU_DEVICE_PROGRESS(user_data);
 	fu_device_set_percentage(self->device, percentage);

--- a/libfwupdplugin/fu-progress-test.c
+++ b/libfwupdplugin/fu-progress-test.c
@@ -12,12 +12,12 @@
 #include "fu-test.h"
 
 typedef struct {
-	guint last_percentage;
+	gdouble last_percentage;
 	guint updates;
 } FuProgressHelper;
 
 static void
-fu_progress_percentage_changed_cb(FuProgress *progress, guint percentage, gpointer data)
+fu_progress_percentage_changed_cb(FuProgress *progress, gdouble percentage, gpointer data)
 {
 	FuProgressHelper *helper = (FuProgressHelper *)data;
 	helper->last_percentage = percentage;
@@ -40,21 +40,21 @@ fu_progress_func(void)
 
 	fu_progress_set_profile(progress, TRUE);
 	fu_progress_set_steps(progress, 5);
-	g_assert_cmpint(helper.last_percentage, ==, 0);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 0.0, 0.001);
 
 	g_usleep(20 * 1000);
 	fu_progress_step_done(progress);
 	g_assert_cmpint(helper.updates, ==, 2);
-	g_assert_cmpint(helper.last_percentage, ==, 20);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 20.0, 0.001);
 
 	for (guint i = 0; i < 4; i++) {
 		g_usleep(20 * 1000);
 		fu_progress_step_done(progress);
 	}
 
-	g_assert_cmpint(helper.last_percentage, ==, 100);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 100.0, 0.001);
 	g_assert_cmpint(helper.updates, ==, 6);
-	g_assert_cmpfloat_with_epsilon(fu_progress_get_duration(progress), 0.1f, 0.05);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_duration(progress), 0.1, 0.05);
 	str = fu_progress_traceback(progress);
 	g_debug("%s", str);
 }
@@ -106,7 +106,7 @@ fu_progress_child_func(void)
 	g_debug("parent update #1");
 	fu_progress_step_done(progress);
 	g_assert_cmpint(helper.updates, ==, 1);
-	g_assert_cmpint(helper.last_percentage, ==, 50);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 50.0, 0.001);
 
 	/* now test with a child */
 	child = fu_progress_get_child(progress);
@@ -116,13 +116,13 @@ fu_progress_child_func(void)
 	g_debug("child update #1");
 	fu_progress_step_done(child);
 	g_assert_cmpint(helper.updates, ==, 2);
-	g_assert_cmpint(helper.last_percentage, ==, 75);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 75.0, 0.001);
 
 	/* child update */
 	g_debug("child update #2");
 	fu_progress_step_done(child);
 	g_assert_cmpint(helper.updates, ==, 3);
-	g_assert_cmpint(helper.last_percentage, ==, 100);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 100.0, 0.001);
 
 	/* parent update */
 	g_debug("parent update #2");
@@ -130,7 +130,7 @@ fu_progress_child_func(void)
 
 	/* ensure we ignored the duplicate */
 	g_assert_cmpint(helper.updates, ==, 3);
-	g_assert_cmpint(helper.last_percentage, ==, 100);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 100.0, 0.001);
 }
 
 static void
@@ -142,14 +142,14 @@ fu_progress_scaling_func(void)
 	fu_progress_set_steps(progress, insane_steps);
 	for (guint i = 0; i < insane_steps / 2; i++)
 		fu_progress_step_done(progress);
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 50);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 50.0, 0.01f);
 	for (guint i = 0; i < insane_steps / 2; i++) {
 		FuProgress *progress_child = fu_progress_get_child(progress);
 		fu_progress_set_percentage(progress_child, 0);
 		fu_progress_set_percentage(progress_child, 100);
 		fu_progress_step_done(progress);
 	}
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 100);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 100.0, 0.01f);
 }
 
 static void
@@ -172,11 +172,11 @@ fu_progress_parent_one_step_proxy_func(void)
 	fu_progress_set_steps(child, 2);
 
 	/* child set value */
-	fu_progress_set_percentage(child, 33);
+	fu_progress_set_percentage(child, 33.3);
 
 	/* ensure 1 updates for progress with one step and ensure using child value as parent */
 	g_assert_cmpint(helper.updates, ==, 1);
-	g_assert_cmpint(helper.last_percentage, ==, 33);
+	g_assert_cmpfloat_with_epsilon(helper.last_percentage, 33.3, 0.001);
 }
 
 static void
@@ -191,7 +191,7 @@ fu_progress_non_equal_steps_func(void)
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_ERASE, 20, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 60, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_READ, 20, NULL);
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 0);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 0.0, 0.01f);
 	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_ERASE);
 
 	/* child step should increment according to the custom steps */
@@ -205,7 +205,7 @@ fu_progress_non_equal_steps_func(void)
 	fu_progress_step_done(child);
 
 	/* verify 10% */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 10);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 10.0, 0.01f);
 
 	/* finish child */
 	fu_progress_step_done(child);
@@ -217,7 +217,7 @@ fu_progress_non_equal_steps_func(void)
 	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_WRITE);
 
 	/* verify 20% */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 20);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 20.0, 0.01f);
 
 	/* child step should increment according to the custom steps */
 	child = fu_progress_get_child(progress);
@@ -232,7 +232,7 @@ fu_progress_non_equal_steps_func(void)
 	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_WRITE);
 
 	/* verify bilinear interpolation is working */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 35);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 35.0, 0.01f);
 
 	/*
 	 * 0        20                             80         100
@@ -250,7 +250,7 @@ fu_progress_non_equal_steps_func(void)
 	fu_progress_step_done(grandchild);
 
 	/* verify bilinear interpolation (twice) is working for subpercentage */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 75);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 75.5, 0.01f);
 
 	fu_progress_step_done(grandchild);
 
@@ -261,12 +261,12 @@ fu_progress_non_equal_steps_func(void)
 	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_DEVICE_READ);
 
 	/* verify 80% */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 80);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 80.0, 0.01f);
 
 	fu_progress_step_done(progress);
 
 	/* verify 100% */
-	g_assert_cmpint(fu_progress_get_percentage(progress), ==, 100);
+	g_assert_cmpfloat_with_epsilon(fu_progress_get_percentage(progress), 100.0, 0.01f);
 	g_assert_cmpint(fu_progress_get_status(progress), ==, FWUPD_STATUS_UNKNOWN);
 }
 

--- a/libfwupdplugin/fu-progress.c
+++ b/libfwupdplugin/fu-progress.c
@@ -62,7 +62,7 @@ struct _FuProgress {
 	gchar *id;
 	gchar *name;
 	FuProgressFlags flags;
-	guint percentage;
+	gdouble percentage;
 	FwupdStatus status;
 	GPtrArray *children; /* of FuProgress */
 	gboolean profile;
@@ -285,16 +285,14 @@ fu_progress_set_status(FuProgress *self, FwupdStatus status)
  *
  * Get the last set progress percentage.
  *
- * Return value: The percentage value, or %G_MAXUINT for error
+ * Return value: The percentage value, or %FWUPD_PERCENTAGE_UNKNOWN for error
  *
- * Since: 1.7.0
+ * Since: 2.1.2
  **/
-guint
+gdouble
 fu_progress_get_percentage(FuProgress *self)
 {
-	g_return_val_if_fail(FU_IS_PROGRESS(self), G_MAXUINT);
-	if (self->percentage == G_MAXUINT)
-		return 0;
+	g_return_val_if_fail(FU_IS_PROGRESS(self), FWUPD_PERCENTAGE_UNKNOWN);
 	return self->percentage;
 }
 
@@ -351,27 +349,25 @@ fu_progress_build_parent_chain(FuProgress *self, GString *str, guint level)
  *
  * NOTE: this must be above what was previously set, or it will be rejected.
  *
- * Since: 1.7.0
+ * Since: 2.1.2
  **/
 void
-fu_progress_set_percentage(FuProgress *self, guint percentage)
+fu_progress_set_percentage(FuProgress *self, gdouble percentage)
 {
-	g_return_if_fail(FU_IS_PROGRESS(self));
-	g_return_if_fail(percentage <= 100);
+	gboolean notify;
 
-	/* is it the same */
-	if (percentage == self->percentage)
-		return;
+	g_return_if_fail(FU_IS_PROGRESS(self));
+	g_return_if_fail(percentage <= 100.0);
 
 	/* stop idle action */
 	fu_progress_sleep_idle_stop(self);
 
 	/* is it less */
-	if (self->percentage != G_MAXUINT && percentage < self->percentage) {
+	if (self->percentage >= 0 && percentage < self->percentage) {
 		if (self->profile) {
 			g_autoptr(GString) str = g_string_new(NULL);
 			fu_progress_build_parent_chain(self, str, 0);
-			g_warning("percentage should not go down from %u to %u: %s",
+			g_warning("percentage should not go down from %.1f to %.1f: %s",
 				  self->percentage,
 				  percentage,
 				  str->str);
@@ -380,7 +376,7 @@ fu_progress_set_percentage(FuProgress *self, guint percentage)
 	}
 
 	/* done */
-	if (percentage == 100) {
+	if (percentage >= 100.0) {
 		fu_progress_set_duration(self, g_timer_elapsed(self->timer, NULL));
 		for (guint i = 0; i < self->children->len; i++) {
 			FuProgress *child = g_ptr_array_index(self->children, i);
@@ -389,8 +385,10 @@ fu_progress_set_percentage(FuProgress *self, guint percentage)
 	}
 
 	/* save */
+	notify = fwupd_percentage_delta_notify(self->percentage, percentage);
 	self->percentage = percentage;
-	g_signal_emit(self, signals[SIGNAL_PERCENTAGE_CHANGED], 0, percentage);
+	if (notify)
+		g_signal_emit(self, signals[SIGNAL_PERCENTAGE_CHANGED], 0, percentage);
 }
 
 /**
@@ -410,8 +408,8 @@ fu_progress_set_percentage_full(FuProgress *self, gsize progress_done, gsize pro
 	g_return_if_fail(FU_IS_PROGRESS(self));
 	g_return_if_fail(progress_done <= progress_total);
 	if (progress_total > 0)
-		percentage = (100.f * (gdouble)progress_done) / (gdouble)progress_total;
-	fu_progress_set_percentage(self, (guint)percentage);
+		percentage = (100.0 * (gdouble)progress_done) / (gdouble)progress_total;
+	fu_progress_set_percentage(self, percentage);
 }
 
 /**
@@ -466,7 +464,7 @@ fu_progress_reset(FuProgress *self)
 
 	/* reset values */
 	self->step_now = 0;
-	self->percentage = G_MAXUINT;
+	self->percentage = FWUPD_PERCENTAGE_UNKNOWN;
 
 	/* only use the timer if profiling; it's expensive */
 	if (self->profile) {
@@ -536,7 +534,7 @@ fu_progress_set_steps(FuProgress *self, guint step_max)
 gdouble
 fu_progress_get_global_fraction(FuProgress *self)
 {
-	g_return_val_if_fail(FU_IS_PROGRESS(self), -1.f);
+	g_return_val_if_fail(FU_IS_PROGRESS(self), -1.0);
 	return self->global_fraction;
 }
 
@@ -568,7 +566,7 @@ fu_progress_discrete_to_percent(guint discrete, guint step_max)
 		g_warning("step_max is 0!");
 		return 0;
 	}
-	return ((gdouble)discrete * (100.0f / (gdouble)(step_max)));
+	return MIN(((gdouble)discrete * (100.0f / (gdouble)(step_max))), 100.0);
 }
 
 static gdouble
@@ -579,7 +577,7 @@ fu_progress_get_step_percentage(FuProgress *self, guint idx)
 
 	/* just use proportional */
 	if (!self->any_child_has_step_weighting)
-		return -1;
+		return FWUPD_PERCENTAGE_UNKNOWN;
 
 	/* work out percentage */
 	for (guint i = 0; i < self->children->len; i++) {
@@ -589,8 +587,8 @@ fu_progress_get_step_percentage(FuProgress *self, guint idx)
 		total += child->step_weighting;
 	}
 	if (total == 0)
-		return -1;
-	return ((gdouble)current * 100.f) / (gdouble)total;
+		return FWUPD_PERCENTAGE_UNKNOWN;
+	return MIN(((gdouble)current * 100.0) / (gdouble)total, 100.0);
 }
 
 static void
@@ -600,12 +598,12 @@ fu_progress_child_status_changed_cb(FuProgress *child, FwupdStatus status, FuPro
 }
 
 static void
-fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuProgress *self)
+fu_progress_child_percentage_changed_cb(FuProgress *child, gdouble percentage, FuProgress *self)
 {
 	gdouble offset;
 	gdouble range;
 	gdouble extra;
-	guint parent_percentage = G_MAXUINT;
+	gdouble parent_percentage = FWUPD_PERCENTAGE_UNKNOWN;
 
 	/* propagate up the stack if FuProgress has only one priv */
 	if (self->children->len == 1) {
@@ -624,7 +622,7 @@ fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuP
 	}
 
 	/* if the child finished, set the status back to the last parent status */
-	if (percentage == 100) {
+	if (percentage >= 100.0) {
 		FuProgress *child_tmp = g_ptr_array_index(self->children, self->step_now);
 		if (fu_progress_get_status(child_tmp) != FWUPD_STATUS_UNKNOWN)
 			fu_progress_set_status(self, fu_progress_get_status(child_tmp));
@@ -634,7 +632,7 @@ fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuP
 	if (self->step_now == 0) {
 		gdouble pc = fu_progress_get_step_percentage(self, 0);
 		if (pc > 0)
-			parent_percentage = percentage * pc / 100;
+			parent_percentage = percentage * pc / 100.0;
 	} else {
 		gdouble pc1 = fu_progress_get_step_percentage(self, self->step_now - 1);
 		gdouble pc2 = fu_progress_get_step_percentage(self, self->step_now);
@@ -642,7 +640,7 @@ fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuP
 		if (pc1 >= 0 && pc2 >= 0)
 			parent_percentage = (((100 - percentage) * pc1) + (percentage * pc2)) / 100;
 	}
-	if (parent_percentage != G_MAXUINT) {
+	if (parent_percentage >= 0.0) {
 		fu_progress_set_percentage(self, parent_percentage);
 		return;
 	}
@@ -654,10 +652,10 @@ fu_progress_child_percentage_changed_cb(FuProgress *child, guint percentage, FuP
 		return;
 
 	/* get the extra contributed by the child */
-	extra = ((gdouble)percentage / 100.0f) * range;
+	extra = (percentage / 100.0f) * range;
 
 	/* emit from the parent */
-	parent_percentage = (guint)(offset + extra);
+	parent_percentage = offset + extra;
 	fu_progress_set_percentage(self, parent_percentage);
 }
 
@@ -694,7 +692,7 @@ fu_progress_add_step(FuProgress *self, FwupdStatus status, guint value, const gc
 
 	/* adjust global percentage */
 	if (value > 0)
-		child->global_fraction = self->global_fraction * (gdouble)value / 100.f;
+		child->global_fraction = self->global_fraction * (gdouble)value / 100.0;
 
 	/* connect signals as required */
 	if (fu_progress_get_global_fraction(self) > 0.001f) {
@@ -720,6 +718,9 @@ fu_progress_add_step(FuProgress *self, FwupdStatus status, guint value, const gc
 
 	/* reset child timer */
 	g_timer_start(self->timer_child);
+
+	/* now ready */
+	self->percentage = 0.0;
 }
 
 /**
@@ -744,7 +745,7 @@ fu_progress_finished(FuProgress *self)
 
 	/* all done */
 	self->step_now = self->children->len;
-	fu_progress_set_percentage(self, 100);
+	fu_progress_set_percentage(self, 100.0);
 
 	/* we finished early, so invalidate children */
 	for (guint i = 0; i < self->children->len; i++) {
@@ -946,7 +947,7 @@ fu_progress_step_done(FuProgress *self)
 	percentage = fu_progress_get_step_percentage(self, self->step_now - 1);
 	if (percentage < 0)
 		percentage = fu_progress_discrete_to_percent(self->step_now, self->children->len);
-	fu_progress_set_percentage(self, (guint)percentage);
+	fu_progress_set_percentage(self, percentage);
 
 	/* show any profiling stats */
 	if (self->profile && self->step_now == self->children->len)
@@ -972,7 +973,7 @@ fu_progress_sleep(FuProgress *self, guint delay_ms)
 	g_return_if_fail(FU_IS_PROGRESS(self));
 	g_return_if_fail(delay_ms > 0);
 
-	fu_progress_set_percentage(self, 0);
+	fu_progress_set_percentage(self, 0.0);
 	for (guint i = 0; i < 100; i++) {
 		g_usleep(delay_us_pc);
 		fu_progress_set_percentage(self, i + 1);
@@ -985,11 +986,12 @@ fu_progress_sleep_idle_cb(gpointer user_data)
 	FuProgress *self = FU_PROGRESS(user_data);
 
 	/* emit directly to avoid canceling the idle timer */
-	g_signal_emit(self, signals[SIGNAL_PERCENTAGE_CHANGED], 0, ++self->percentage);
-	g_debug("progress on idle @%u%%", self->percentage);
+	self->percentage = MIN(self->percentage + 1.0, 100.0);
+	g_signal_emit(self, signals[SIGNAL_PERCENTAGE_CHANGED], 0, self->percentage);
+	g_debug("progress on idle @%.1f%%", self->percentage);
 
 	/* we're done here */
-	if (self->percentage >= 100) {
+	if (self->percentage >= 100.0) {
 		fu_progress_sleep_idle_stop(self);
 		return G_SOURCE_REMOVE;
 	}
@@ -1015,10 +1017,10 @@ fu_progress_sleep_idle(FuProgress *self, guint delay_ms)
 	g_return_if_fail(delay_ms > 0);
 
 	fu_progress_sleep_idle_stop(self);
-	fu_progress_set_percentage(self, 0);
+	fu_progress_set_percentage(self, 0.0);
 	fu_progress_set_duration(self, (gdouble)delay_ms / 1000.f);
 	self->sleep_timeout_id =
-	    g_timeout_add(MAX(delay_ms / 100, 1), fu_progress_sleep_idle_cb, self);
+	    g_timeout_add(MAX(delay_ms / 1000, 1), fu_progress_sleep_idle_cb, self);
 }
 
 static void
@@ -1041,7 +1043,7 @@ fu_progress_traceback_cb(FuProgress *self,
 			g_string_append_printf(str, ":%s", self->name);
 		if (self->id == NULL && self->name == NULL && child_idx != G_MAXUINT)
 			g_string_append_printf(str, "@%u", child_idx);
-		g_string_append_printf(str, " [%.2fms]", fu_progress_get_duration(self) * 1000.f);
+		g_string_append_printf(str, " [%.2fms]", fu_progress_get_duration(self) * 1000.0);
 		g_string_append(str, self->children->len > 0 ? ":\n" : "\n");
 	}
 	for (guint i = 0; i < self->children->len; i++) {
@@ -1096,12 +1098,12 @@ fu_progress_add_string(FwupdCodec *codec, guint idt, GString *str)
 
 	fwupd_codec_string_append(str, idt, "Id", self->id);
 	fwupd_codec_string_append(str, idt, "Name", self->name);
-	if (self->percentage != G_MAXUINT)
-		fwupd_codec_string_append_int(str, idt, "Percentage", self->percentage);
+	if (self->percentage >= 0.0)
+		fwupd_codec_string_append_int(str, idt, "Percentage", (guint)self->percentage);
 	if (self->status != FWUPD_STATUS_UNKNOWN)
 		fwupd_codec_string_append(str, idt, "Status", fwupd_status_to_string(self->status));
 	if (self->duration > 0.0001)
-		fwupd_codec_string_append_int(str, idt, "DurationMs", self->duration * 1000.f);
+		fwupd_codec_string_append_int(str, idt, "DurationMs", self->duration * 1000.0);
 	fwupd_codec_string_append_int(str, idt, "StepWeighting", self->step_weighting);
 	fwupd_codec_string_append_int(str, idt, "StepNow", self->step_now);
 	for (guint i = 0; i < self->children->len; i++) {
@@ -1121,7 +1123,7 @@ fu_progress_init(FuProgress *self)
 {
 	self->status = FWUPD_STATUS_UNKNOWN;
 	self->step_scaling = 1;
-	self->percentage = G_MAXUINT;
+	self->percentage = FWUPD_PERCENTAGE_UNKNOWN;
 	self->timer = g_timer_new();
 	self->timer_child = g_timer_new();
 	self->children = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
@@ -1163,7 +1165,7 @@ fu_progress_class_init(FuProgressClass *klass)
 	 *
 	 * The ::percentage-changed signal is emitted when the tasks completion has changed.
 	 *
-	 * Since: 1.7.0
+	 * Since: 2.1.2
 	 **/
 	signals[SIGNAL_PERCENTAGE_CHANGED] = g_signal_new("percentage-changed",
 							  G_TYPE_FROM_CLASS(object_class),
@@ -1171,10 +1173,10 @@ fu_progress_class_init(FuProgressClass *klass)
 							  0,
 							  NULL,
 							  NULL,
-							  g_cclosure_marshal_VOID__UINT,
+							  g_cclosure_marshal_VOID__DOUBLE,
 							  G_TYPE_NONE,
 							  1,
-							  G_TYPE_UINT);
+							  G_TYPE_DOUBLE);
 	/**
 	 * FuProgress::status-changed:
 	 * @self: the #FuProgress instance that emitted the signal

--- a/libfwupdplugin/fu-progress.h
+++ b/libfwupdplugin/fu-progress.h
@@ -36,11 +36,11 @@ fu_progress_get_status(FuProgress *self) G_GNUC_NON_NULL(1);
 void
 fu_progress_set_status(FuProgress *self, FwupdStatus status) G_GNUC_NON_NULL(1);
 void
-fu_progress_set_percentage(FuProgress *self, guint percentage) G_GNUC_NON_NULL(1);
+fu_progress_set_percentage(FuProgress *self, gdouble percentage) G_GNUC_NON_NULL(1);
 void
 fu_progress_set_percentage_full(FuProgress *self, gsize progress_done, gsize progress_total)
     G_GNUC_NON_NULL(1);
-guint
+gdouble
 fu_progress_get_percentage(FuProgress *self) G_GNUC_NON_NULL(1);
 gdouble
 fu_progress_get_duration(FuProgress *self) G_GNUC_NON_NULL(1);

--- a/src/fu-console-test.c
+++ b/src/fu-console-test.c
@@ -24,14 +24,14 @@ fu_console_func(void)
 	}
 	fu_console_set_progress(console, FWUPD_STATUS_IDLE, 0);
 	for (guint i = 0; i <= 100; i++) {
-		guint pc = (i > 25 && i < 75) ? 0 : i;
+		gdouble pc = (i > 25 && i < 75) ? FWUPD_PERCENTAGE_UNKNOWN : i;
 		fu_console_set_progress(console, FWUPD_STATUS_LOADING, pc);
 		g_usleep(10000);
 	}
 	fu_console_set_progress(console, FWUPD_STATUS_IDLE, 0);
 
 	for (guint i = 0; i < 5000; i++) {
-		fu_console_set_progress(console, FWUPD_STATUS_LOADING, 0);
+		fu_console_set_progress(console, FWUPD_STATUS_LOADING, FWUPD_PERCENTAGE_UNKNOWN);
 		g_usleep(1000);
 	}
 	fu_console_set_progress(console, FWUPD_STATUS_IDLE, 0);

--- a/src/fu-console.c
+++ b/src/fu-console.c
@@ -31,7 +31,7 @@ struct _FuConsole {
 	guint spinner_idx;	   /* width in visible chars */
 	guint length_percentage;   /* width in visible chars */
 	guint length_status;	   /* width in visible chars */
-	guint percentage;
+	gdouble percentage;
 	GSource *timer_source;
 	gint64 last_animated; /* monotonic */
 	GTimer *time_elapsed;
@@ -445,13 +445,13 @@ _fu_status_is_predictable(FwupdStatus status)
 }
 
 static gboolean
-fu_console_estimate_ready(FuConsole *self, guint percentage)
+fu_console_estimate_ready(FuConsole *self, gdouble percentage)
 {
 	gdouble old;
 	gdouble elapsed;
 
 	/* now invalid */
-	if (percentage == 0 || percentage == 100) {
+	if (!fwupd_percentage_is_valid(percentage)) {
 		g_timer_start(self->time_elapsed);
 		self->last_estimate = 0;
 		return FALSE;
@@ -463,7 +463,7 @@ fu_console_estimate_ready(FuConsole *self, guint percentage)
 
 	old = self->last_estimate;
 	elapsed = g_timer_elapsed(self->time_elapsed, NULL);
-	self->last_estimate = elapsed / percentage * (100 - percentage);
+	self->last_estimate = elapsed / percentage * (100.0 - percentage);
 
 	/* estimate is ready if we have decreased */
 	return old > self->last_estimate;
@@ -521,12 +521,11 @@ fu_console_refresh(FuConsole *self)
 
 	/* add console */
 	g_string_append(str, "▕");
-	if (self->percentage == 100) {
+	if (self->percentage >= 100.0) {
 		for (i = 0; i < self->length_percentage - 1; i++)
 			g_string_append(str, "⣿");
-	} else if (self->percentage > 0) {
-		gdouble midpoint =
-		    (self->length_percentage - 1) * (gdouble)self->percentage / 100.f;
+	} else if (fwupd_percentage_is_valid(self->percentage)) {
+		gdouble midpoint = (self->length_percentage - 1) * self->percentage / 100.0;
 		guint midpoint_floor = (guint)midpoint;
 		for (i = 0; i < midpoint_floor; i++)
 			g_string_append(str, "⣿");
@@ -710,7 +709,7 @@ static void
 fu_console_spin_start(FuConsole *self)
 {
 	if (self->timer_source != NULL)
-		g_source_destroy(self->timer_source);
+		return;
 	self->timer_source = g_timeout_source_new(40);
 	g_source_set_callback(self->timer_source, fu_console_spin_cb, self, NULL);
 	g_source_attach(self->timer_source, self->main_ctx);
@@ -720,21 +719,17 @@ fu_console_spin_start(FuConsole *self)
  * fu_console_set_progress:
  * @self: A #FuConsole
  * @status: A #FwupdStatus
- * @percentage: unsigned integer
+ * @percentage: value
  *
  * Refreshes the progress bar with the new percentage and status.
  **/
 void
-fu_console_set_progress(FuConsole *self, FwupdStatus status, guint percentage)
+fu_console_set_progress(FuConsole *self, FwupdStatus status, gdouble percentage)
 {
 	g_return_if_fail(FU_IS_CONSOLE(self));
 
 	/* not useful */
 	if (status == FWUPD_STATUS_UNKNOWN)
-		return;
-
-	/* ignore duplicates */
-	if (self->status == status && self->percentage == percentage)
 		return;
 
 	/* cache */
@@ -743,13 +738,17 @@ fu_console_set_progress(FuConsole *self, FwupdStatus status, guint percentage)
 
 	/* dumb */
 	if (!self->interactive) {
-		g_printerr("%s: %u%%\n", fu_console_status_to_string(status), percentage);
+		if (fwupd_percentage_is_valid(percentage)) {
+			g_printerr("%s: %.1f%%\n", fu_console_status_to_string(status), percentage);
+		} else {
+			g_printerr("%s\n", fu_console_status_to_string(status));
+		}
 		return;
 	}
 
 	/* if the main loop isn't spinning and we've not had a chance to
 	 * execute the callback just do the refresh now manually */
-	if (percentage == 0 && status != FWUPD_STATUS_IDLE &&
+	if (percentage <= 0.0 && status != FWUPD_STATUS_IDLE &&
 	    self->status != FWUPD_STATUS_UNKNOWN) {
 		if ((g_get_monotonic_time() - self->last_animated) / 1000 > 40) {
 			fu_console_spin_inc(self);
@@ -758,7 +757,7 @@ fu_console_set_progress(FuConsole *self, FwupdStatus status, guint percentage)
 	}
 
 	/* enable or disable the spinner timeout */
-	if (percentage > 0) {
+	if (fwupd_percentage_is_valid(percentage)) {
 		fu_console_spin_end(self);
 	} else {
 		fu_console_spin_start(self);

--- a/src/fu-console.h
+++ b/src/fu-console.h
@@ -63,7 +63,7 @@ void
 fu_console_beep(FuConsole *self, guint count) G_GNUC_NON_NULL(1);
 
 void
-fu_console_set_progress(FuConsole *self, FwupdStatus status, guint percentage) G_GNUC_NON_NULL(1);
+fu_console_set_progress(FuConsole *self, FwupdStatus status, gdouble percentage) G_GNUC_NON_NULL(1);
 void
 fu_console_set_status_length(FuConsole *self, guint len) G_GNUC_NON_NULL(1);
 void

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -41,7 +41,7 @@ struct _FuDbusDaemon {
 	guint32 clients_inhibit_id;
 	FuPolkitAuthority *authority;
 	FwupdStatus status; /* last emitted */
-	guint percentage;   /* last emitted */
+	gdouble percentage; /* last emitted */
 	guint owner_id;
 	GPtrArray *system_inhibits;
 };
@@ -554,16 +554,22 @@ fu_dbus_daemon_reset_config_cb(GObject *source, GAsyncResult *res, gpointer user
 
 static void
 fu_dbus_daemon_progress_percentage_changed_cb(FuProgress *progress,
-					      guint percentage,
+					      gdouble percentage,
 					      FuDbusDaemon *self)
 {
-	/* sanity check */
-	if (self->percentage == percentage)
-		return;
+	gboolean notify = fwupd_percentage_delta_notify(self->percentage, percentage);
 	self->percentage = percentage;
-
-	g_debug("emitting PropertyChanged('Percentage'='%u%%')", percentage);
-	fu_dbus_daemon_emit_property_changed(self, "Percentage", g_variant_new_uint32(percentage));
+	if (notify) {
+		g_debug("emitting PropertyChanged('Percentage'='%.1f%%')", percentage);
+		fu_dbus_daemon_emit_property_changed(
+		    self,
+		    "Percentage",
+		    g_variant_new_uint32(fwupd_percentage_is_valid(percentage) ? (guint32)percentage
+									       : 0));
+		fu_dbus_daemon_emit_property_changed(self,
+						     "PercentageFull",
+						     g_variant_new_double(percentage));
+	}
 }
 
 static void
@@ -2653,7 +2659,11 @@ fu_dbus_daemon_get_property(GDBusConnection *connection_,
 		return g_variant_new_uint32(self->status);
 
 	if (g_strcmp0(property_name, "Percentage") == 0)
-		return g_variant_new_uint32(self->percentage);
+		return g_variant_new_uint32(
+		    fwupd_percentage_is_valid(self->percentage) ? (guint32)self->percentage : 0);
+
+	if (g_strcmp0(property_name, "PercentageFull") == 0)
+		return g_variant_new_double(self->percentage);
 
 	if (g_strcmp0(property_name, FWUPD_RESULT_KEY_BATTERY_LEVEL) == 0) {
 		FuContext *ctx = fu_engine_get_context(engine);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -110,7 +110,6 @@ struct _FuEngine {
 	FuDeviceList *device_list;
 	gboolean write_history;
 	gboolean host_emulation;
-	guint percentage;
 	FuHistory *history;
 	FuIdle *idle;
 	XbSilo *silo;
@@ -9474,7 +9473,6 @@ fu_engine_constructed(GObject *obj)
 static void
 fu_engine_init(FuEngine *self)
 {
-	self->percentage = 0;
 	self->device_list = fu_device_list_new();
 	self->idle = fu_idle_new();
 	self->plugin_list = fu_plugin_list_new();

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -98,7 +98,7 @@ fu_util_client_notify_cb(GObject *object, GParamSpec *pspec, FuUtil *self)
 		return;
 	fu_console_set_progress(self->console,
 				fwupd_client_get_status(self->client),
-				fwupd_client_get_percentage(self->client));
+				fwupd_client_get_percentage_full(self->client));
 }
 
 static void
@@ -453,7 +453,7 @@ fu_util_engine_status_changed_cb(FuEngine *engine, FwupdStatus status, FuUtil *s
 }
 
 static void
-fu_util_progress_percentage_changed_cb(FuProgress *progress, guint percentage, FuUtil *self)
+fu_util_progress_percentage_changed_cb(FuProgress *progress, gdouble percentage, FuUtil *self)
 {
 	if (self->as_json)
 		return;

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -83,7 +83,7 @@ fu_util_client_notify_cb(GObject *object, GParamSpec *pspec, FuUtil *self)
 		return;
 	fu_console_set_progress(self->console,
 				fwupd_client_get_status(self->client),
-				fwupd_client_get_percentage(self->client));
+				fwupd_client_get_percentage_full(self->client));
 }
 
 static void

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -123,6 +123,17 @@
     </property>
 
     <!--***********************************************************-->
+    <property name='PercentageFull' type='d' access='read'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            The job percentage completion, or 0.0 for unknown.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+    </property>
+
+    <!--***********************************************************-->
     <property name='BatteryLevel' type='u' access='read'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
We caculate this internally with 0.01% precision, and then quantize it to 100 discrete levels (u32) and *then* interpolate it back to higher precision for the time estimation. Just export a double precision value via D-Bus.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
