### PR TITLE
algoltek-usbcr: Restore vendor ID check in probe function

### DIFF
--- a/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
+++ b/plugins/algoltek-usbcr/fu-algoltek-usbcr-device.c
@@ -415,6 +415,25 @@ fu_algoltek_usbcr_device_ensure_version(FuAlgoltekUsbcrDevice *self, GError **er
 }
 
 static gboolean
+fu_algoltek_usbcr_device_probe(FuDevice *device, GError **error)
+{
+	/* FuUdevDevice->probe */
+	if (!FU_DEVICE_CLASS(fu_algoltek_usbcr_device_parent_class)->probe(device, error))
+		return FALSE;
+	if (fu_device_get_vid(device) != FU_ALGOLTEK_USBCR_VENDOR_ID) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "vendor id 0x%x not supported",
+			    fu_device_get_vid(device));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_algoltek_usbcr_device_setup(FuDevice *device, GError **error)
 {
 	FuAlgoltekUsbcrDevice *self = FU_ALGOLTEK_USBCR_DEVICE(device);
@@ -652,6 +671,7 @@ static void
 fu_algoltek_usbcr_device_class_init(FuAlgoltekUsbcrDeviceClass *klass)
 {
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
+	device_class->probe = fu_algoltek_usbcr_device_probe;
 	device_class->setup = fu_algoltek_usbcr_device_setup;
 	device_class->check_firmware = fu_algoltek_usbcr_device_check_firmware;
 	device_class->write_firmware = fu_algoltek_usbcr_device_write_firmware;


### PR DESCRIPTION
This fixes a regression introduced in e7683a4fff5e where the probe function was removed, causing the plugin to attempt handling incompatible USB devices (like Kingston USB sticks with VID 0x951) instead of only Algoltek card readers (VID 0x58F).

Without the vendor ID check, non-Algoltek devices fail with "FuEngine failed to add device" errors when the plugin tries to perform vendor-specific operations on incompatible hardware.

Fixes: e7683a4fff5e ("algoltek-usbcr: Do not overwrite the physical ID for no reason")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
