### PR TITLE
contrib/setup: Add support for nixos

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -1,9 +1,21 @@
 #!/bin/sh -e
 
-VENV=$(dirname $0)/..
+. "$(dirname "$(readlink -f "$0")")/nix.sh"
+
+VENV=$(dirname "$0")/..
 BUILD=${VENV}/build
 DIST=${VENV}/dist
 EXTRA_ARGS="-Dlibxmlb:gtkdoc=false -Dsystemd=disabled"
+
+# NixOS: extract vendor_ids_dir from mesonFlags set by nix-shell
+# plugin_uefi_capsule_splash disabled, same as in nixpkgs
+if [ -f "${VENV}/.nixos" ] && [ -n "$mesonFlags" ]; then
+    for flag in $mesonFlags; do
+        case "$flag" in
+        -Dvendor_ids_dir=* | -Dplugin_uefi_capsule_splash=*) EXTRA_ARGS="$EXTRA_ARGS $flag" ;;
+        esac
+    done
+fi
 
 #build and install
 if [ ! -d ${BUILD} ] || ! [ -e ${BUILD}/build.ninja ]; then

--- a/contrib/ci/fwupd_setup_helpers.py
+++ b/contrib/ci/fwupd_setup_helpers.py
@@ -18,7 +18,16 @@ MINIMUM_MARKDOWN = (3, 2, 0)
 
 
 def get_possible_profiles():
-    return ["fedora", "centos", "debian", "ubuntu", "arch", "darwin", "freebsd"]
+    return [
+        "fedora",
+        "centos",
+        "debian",
+        "ubuntu",
+        "arch",
+        "darwin",
+        "freebsd",
+        "nixos",
+    ]
 
 
 def detect_profile():
@@ -225,6 +234,8 @@ def _get_installer_cmd(profile: str, yes: bool):
 def install_packages(profile: str, variant: str, yes: bool, debugging: bool, packages):
     import subprocess
 
+    if profile == "nixos":
+        return
     if packages == "build-dependencies":
         packages = get_build_dependencies(profile, variant)
     installer = _get_installer_cmd(profile, yes)

--- a/contrib/launch-venv.sh
+++ b/contrib/launch-venv.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S bash -e
+
+. "$(dirname "$(realpath "$0")")/nix.sh"
+
 cc=$(cc -dumpmachine)
 DIST="$(dirname $0)/../dist"
 BIN="$(basename $0)"

--- a/contrib/launch-venv.sh
+++ b/contrib/launch-venv.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
+
+set -e
 
 . "$(dirname "$(realpath "$0")")/nix.sh"
 

--- a/contrib/nix.sh
+++ b/contrib/nix.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Re-exec into nix-shell for build dependencies on NixOS.
+# Intended to be sourced by wrappers before use of build deps;
+# exec replaces the caller so control does not return.
+if [ -f "$(dirname "$0")/../.nixos" ] && [ -z "$IN_NIX_SHELL" ]; then
+    exec nix-shell '<nixpkgs>' -A fwupd --run "$(printf '%q ' "$0" "$@")"
+fi

--- a/contrib/setup
+++ b/contrib/setup
@@ -1,5 +1,7 @@
-#!/usr/bin/env -S bash -e
+#!/usr/bin/env bash
 # Setup the repository and local system for development
+
+set -e
 
 cd "$(dirname "$0")/.."
 

--- a/contrib/setup
+++ b/contrib/setup
@@ -84,10 +84,15 @@ install_pip() {
 
 setup_virtualenv() {
     echo "Setting up virtualenv"
-    if ! which virtualenv >/dev/null 2>&1; then
-        install_pip virtualenv
+    if [ "$OS" = "nixos" ]; then
+        python3 -m venv venv --prompt fwupd
+        touch venv/.nixos
+    else
+        if ! command -v virtualenv >/dev/null 2>&1; then
+            install_pip virtualenv
+        fi
+        virtualenv --system-site-packages venv --prompt fwupd
     fi
-    virtualenv --system-site-packages venv --prompt fwupd
     source venv/bin/activate
     cat >>venv/bin/activate <<EOF
 echo "To build or rebuild fwupd within development environment run:"
@@ -208,6 +213,9 @@ if [ -t 2 ]; then
     case $OS in
     debian | ubuntu | arch | fedora | darwin | freebsd)
         setup_deps
+        ;;
+    nixos)
+        echo "NixOS detected, using nix-shell for build dependencies"
         ;;
     esac
     rename_branch

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 
-VENV=$(dirname $0)/..
+. "$(dirname "$(readlink -f "$0")")/nix.sh"
+
+VENV=$(dirname "$0")/..
 BUILD=${VENV}/build
 INSTALLED_TESTS=${VENV}/dist/share/installed-tests/fwupd
 SUDO=$(which sudo)


### PR DESCRIPTION
On NixOS don't install dependencies, get them from nix-shell

This only works if '<nixpkgs>' is provided, which it is on normal NixOS setups.

Ideally we'd have it self-contained in the fwupd repo, for example with flake.nix

Tested commands in venv:
- build-fwupd
- test-fwupd
- fwupd
- fwupdmgr
- fwupdtool

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
