### PR TITLE
build: Add support for ttyUSB device in fwupd.service file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -121,6 +121,7 @@ if build_daemon
     endif
     if get_option('plugin_modem_manager').allowed()
       device_allows += ['char-wwan_port']
+      device_allows += ['char-ttyUSB']
     endif
     foreach device_allow : device_allows
       dynamic_options += ['DeviceAllow=' + device_allow + ' rw']


### PR DESCRIPTION
When enabling the ModemManager plugin, in addition to requiring permission support for the char-wwan_port port, it also requires permission support for the ttyUSB port.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [* ] Code fix
- [ ] Feature
- [ ] Documentation
