### PR TITLE
synaptics-rmi: Remove gnutls dependency requirement

### DIFF
--- a/plugins/synaptics-rmi/meson.build
+++ b/plugins/synaptics-rmi/meson.build
@@ -1,5 +1,4 @@
 host_machine.system() in ['linux', 'android'] or subdir_done()
-gnutls.found() or subdir_done()
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginSynapticsRmi"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}


### PR DESCRIPTION
Since the source code already uses the HAVE_GNUTLS macro to skip the relevant checks when gnutls is absent, and some firmware may not provide the pubkey in flash for checking, there is no need to strictly require it during the build.

Removing this dependency requirement ensures the plugin can still be built successfully on environments where gnutls is not available.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
