### PR TITLE
Allow setting context flags from HWID matches

### DIFF
--- a/data/context.quirk
+++ b/data/context.quirk
@@ -1,0 +1,5 @@
+# use this file when we want to set (or unset) specific context flags by a DMI match
+
+# Manufacturer="Red Hat", BiosVendor="EDK II"
+[c714d9bb-922c-57c2-94e7-3a383887c95b]
+Flags = ignore-efivars-free-space

--- a/data/meson.build
+++ b/data/meson.build
@@ -32,7 +32,13 @@ if build_standalone
     install_dir: join_paths(sysconfdir, 'fwupd'),
     install_mode: 'rw-r-----',
   )
-  plugin_quirks += files('cfi.quirk', 'ds20.quirk', 'power.quirk', 'vendors.quirk')
+  plugin_quirks += files(
+    'cfi.quirk',
+    'ds20.quirk',
+    'power.quirk',
+    'vendors.quirk',
+    'context.quirk',
+  )
 endif
 
 if get_option('metainfo')

--- a/libfwupdplugin/fu-context-test.c
+++ b/libfwupdplugin/fu-context-test.c
@@ -142,14 +142,19 @@ fu_context_hwids_dmi_func(void)
 {
 	g_autofree gchar *dump = NULL;
 	g_autofree gchar *testdatadir = NULL;
-	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuContext) ctx = fu_context_new();
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
 	g_autoptr(GError) error = NULL;
 	gboolean ret;
 
 	/* set up test harness */
 	testdatadir = g_test_build_filename(G_TEST_DIST, "tests", NULL);
+	fu_context_set_path(ctx, FU_PATH_KIND_DATADIR_QUIRKS, testdatadir);
 	fu_context_set_path(ctx, FU_PATH_KIND_SYSFSDIR_DMI, testdatadir);
+
+	ret = fu_context_load_quirks(ctx, FU_QUIRKS_LOAD_FLAG_NO_CACHE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 
 	ret = fu_context_load_hwinfo(ctx, progress, FU_CONTEXT_HWID_FLAG_LOAD_DMI, &error);
 	g_assert_no_error(error);
@@ -159,6 +164,13 @@ fu_context_hwids_dmi_func(void)
 
 	g_assert_cmpstr(fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_MANUFACTURER), ==, "FwupdTest");
 	g_assert_cmpuint(fu_context_get_chassis_kind(ctx), ==, 16);
+
+	/* check quirked flags were set */
+	g_assert_true(fu_context_has_flag(ctx, FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE));
+	g_assert_false(fu_context_has_flag(ctx, FU_CONTEXT_FLAG_INSECURE_UEFI));
+
+	/* not allowed to be set from a quirk */
+	g_assert_false(fu_context_has_flag(ctx, FU_CONTEXT_FLAG_DUMMY_EFIVARS));
 }
 
 static void

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1193,6 +1193,17 @@ fu_context_detect_full_disk_encryption(FuContext *self)
 	}
 }
 
+static gboolean
+fu_context_flag_is_quirk_controlled(FuContextFlags flag)
+{
+	return (flag & (FU_CONTEXT_FLAG_SYSTEM_INHIBIT | FU_CONTEXT_FLAG_INHIBIT_VOLUME_MOUNT |
+			FU_CONTEXT_FLAG_FDE_BITLOCKER | FU_CONTEXT_FLAG_FDE_SNAPD |
+			FU_CONTEXT_FLAG_IGNORE_EFIVARS_FREE_SPACE | FU_CONTEXT_FLAG_INSECURE_UEFI |
+			FU_CONTEXT_FLAG_IS_HYPERVISOR | FU_CONTEXT_FLAG_IS_HYPERVISOR_PRIVILEGED |
+			FU_CONTEXT_FLAG_IS_CONTAINER | FU_CONTEXT_FLAG_SMBIOS_UEFI_ENABLED |
+			FU_CONTEXT_FLAG_IS_SERVER)) > 0;
+}
+
 static void
 fu_context_hwid_quirk_cb(FuContext *self,
 			 const gchar *key,
@@ -1205,9 +1216,20 @@ fu_context_hwid_quirk_cb(FuContext *self,
 		g_auto(GStrv) values = g_strsplit(value, ",", -1);
 		for (guint i = 0; values[i] != NULL; i++) {
 			const gchar *value_tmp = values[i];
-			if (g_str_has_prefix(value, "~")) {
+			if (g_str_has_prefix(value_tmp, "~")) {
+				if (g_strcmp0(key, FU_QUIRKS_FLAGS) == 0) {
+					FuContextFlags flag =
+					    fu_context_flag_from_string(value_tmp + 1);
+					if (fu_context_flag_is_quirk_controlled(flag))
+						fu_context_remove_flag(self, flag);
+				}
 				g_hash_table_remove(priv->hwid_flags, value_tmp + 1);
 				continue;
+			}
+			if (g_strcmp0(key, FU_QUIRKS_FLAGS) == 0) {
+				FuContextFlags flag = fu_context_flag_from_string(value_tmp);
+				if (fu_context_flag_is_quirk_controlled(flag))
+					fu_context_add_flag(self, flag);
 			}
 			g_hash_table_add(priv->hwid_flags, g_strdup(value_tmp));
 		}

--- a/libfwupdplugin/fu-context.rs
+++ b/libfwupdplugin/fu-context.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 Richard Hughes <richard@hughsie.com>
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#[derive(Bitfield)]
+#[derive(Bitfield, FromString(enum))]
 enum FuContextFlags {
     None                    = 0,
     SaveEvents              = 1 << 0, // so that they can be replayed to emulate devices

--- a/libfwupdplugin/tests/context.quirk
+++ b/libfwupdplugin/tests/context.quirk
@@ -1,0 +1,2 @@
+[6fdfc346-23d8-57ee-b0de-72b13a540906]
+Flags = ignore-efivars-free-space,dummy-efivars,insecure-uefi,~insecure-uefi

--- a/libfwupdplugin/tests/meson.build
+++ b/libfwupdplugin/tests/meson.build
@@ -22,6 +22,7 @@ install_data(
     'cfu-offer.builder.xml',
     'cfu-payload.builder.xml',
     'chassis_type',
+    'context.quirk',
     'csv.builder.xml',
     'dfu.builder.xml',
     'dfuse.builder.xml',


### PR DESCRIPTION
This allows us to set the ignore-efivars-free-space for old EDK2 VMs.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
