### PR TITLE
nordic-hid: Do not probe all devices with USB VID 0x1915

### DIFF
--- a/plugins/nordic-hid/nordic-hid.quirk
+++ b/plugins/nordic-hid/nordic-hid.quirk
@@ -1,5 +1,5 @@
-# Nordic Semiconductor ASA HID Devices
-[HIDRAW\VEN_1915]
+# Nordic nRF52840 DK
+[HIDRAW\VEN_1915&DEV_52DE]
 Plugin = nordic_hid
 Flags = no-generic-guids
 GType = FuNordicHidCfgChannel


### PR DESCRIPTION
I told them might a bad idea. As it turns out, it _was_ a bad idea.

Fixes: https://github.com/fwupd/fwupd/issues/10207

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
