### PR TITLE
nvme: Use CA1 for a SK Hynix NVMe drive

### DIFF
--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -31,7 +31,7 @@ Flags = signed-payload
 [NVME\VEN_1C5C]
 Flags = signed-payload
 [NVME\VEN_1C5C&DEV_1D59]
-Flags = commit-ca3
+Flags = needs-shutdown
 
 # Kingston
 [NVME\VEN_2646&DEV_5013]


### PR DESCRIPTION
Also require a full system shutdown to deploy the new version.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
