### PR TITLE
trivial: Use PRIx64 to correctly print u64 numbers as hex

### DIFF
--- a/libfwupd/fwupd-codec.c
+++ b/libfwupd/fwupd-codec.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <inttypes.h>
+
 #include "fwupd-codec.h"
 #include "fwupd-error.h"
 #include "fwupd-json-array.h"
@@ -557,7 +559,7 @@ fwupd_codec_string_append_hex(GString *str, guint idt, const gchar *key, guint64
 	/* ignore */
 	if (value == 0)
 		return;
-	tmp = g_strdup_printf("0x%" G_GUINT64_FORMAT "x", value);
+	tmp = g_strdup_printf("0x%" PRIx64, value);
 	fwupd_codec_string_append(str, idt, key, tmp);
 }
 


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
