### PR TITLE
raydium-tp: Match a specific device to prevent resetting older hardware

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,6 +62,7 @@ plugins/pixart-tp/ @PixartHarris
 plugins/qc-firehose/ @hughsie
 plugins/qc-s5gen2/ @d4s
 plugins/qsi-dock/ @hssinf
+plugins/raydium-tp/ @Maker-Rad
 plugins/realtek-mst/ @tari
 plugins/rp-pico/ @mntmn
 plugins/rts54hub/ @AnyProblem

--- a/plugins/raydium-tp/raydium-tp.quirk
+++ b/plugins/raydium-tp/raydium-tp.quirk
@@ -1,2 +1,2 @@
-[HIDRAW\VEN_2386]
+[HIDRAW\VEN_2386&DEV_8C08]
 Plugin = raydium_tp


### PR DESCRIPTION
Fixes: https://github.com/fwupd/fwupd/issues/10221

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
