### PR TITLE
Only copy the HIDRAW USB properties if a DS-20 has been provided

### DIFF
--- a/libfwupdplugin/fu-device.h
+++ b/libfwupdplugin/fu-device.h
@@ -713,6 +713,15 @@ fu_device_new(FuContext *ctx);
  */
 #define FU_DEVICE_PRIVATE_FLAG_STRICT_EMULATION_ORDER "strict-emulation-order"
 
+/**
+ * FU_DEVICE_PRIVATE_FLAG_HAS_DS20:
+ *
+ * The device provided a DS-20 quirk descriptor.
+ *
+ * Since: 2.1.3
+ */
+#define FU_DEVICE_PRIVATE_FLAG_HAS_DS20 "has-ds20"
+
 /* standard icons */
 
 /**

--- a/libfwupdplugin/fu-hidraw-device.c
+++ b/libfwupdplugin/fu-hidraw-device.c
@@ -131,10 +131,14 @@ fu_hidraw_device_probe_usb(FuHidrawDevice *self, GError **error)
 	    fu_device_get_backend_parent_with_subsystem(FU_DEVICE(self), "usb:usb_device", error);
 	if (usb_device == NULL)
 		return FALSE;
-	fu_device_incorporate(FU_DEVICE(self),
-			      FU_DEVICE(usb_device),
-			      FU_DEVICE_INCORPORATE_FLAG_POSSIBLE_PLUGINS |
-				  FU_DEVICE_INCORPORATE_FLAG_GTYPE);
+	if (fu_device_has_private_flag(usb_device, FU_DEVICE_PRIVATE_FLAG_HAS_DS20)) {
+		fu_device_incorporate(FU_DEVICE(self),
+				      FU_DEVICE(usb_device),
+				      FU_DEVICE_INCORPORATE_FLAG_ICONS |
+					  FU_DEVICE_INCORPORATE_FLAG_PRIVATE_FLAGS |
+					  FU_DEVICE_INCORPORATE_FLAG_POSSIBLE_PLUGINS |
+					  FU_DEVICE_INCORPORATE_FLAG_GTYPE);
+	}
 
 	/* success */
 	return TRUE;

--- a/libfwupdplugin/fu-usb-device.c
+++ b/libfwupdplugin/fu-usb-device.c
@@ -277,6 +277,7 @@ fu_usb_device_init(FuUsbDevice *self)
 	priv->cfg_descriptors = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	priv->hid_descriptors = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 	fu_device_set_acquiesce_delay(FU_DEVICE(self), 2500);
+	fu_device_register_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_HAS_DS20);
 	fu_device_retry_add_recovery(FU_DEVICE(self),
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_PERMISSION_DENIED,
@@ -898,6 +899,7 @@ fu_usb_device_probe_bos_descriptor(FuUsbDevice *self, FuUsbBosDescriptor *bos, G
 		g_prefix_error_literal(error, "failed to apply DS20 data: ");
 		return FALSE;
 	}
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_HAS_DS20);
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Additionally, copy across the icons and flags to match the DS-20 example.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
