### PR TITLE
trivial: fix tartan scan-build call

### DIFF
--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -32,4 +32,4 @@ RUN set -euxo pipefail; \
     tartan-build --help
 WORKDIR /github/workspace
 ENV SCANBUILD=./contrib/tartan.sh
-CMD sh -euxc 'meson setup build && meson compile -C build scan-build'
+CMD sh -euxc 'meson setup build && ninja -C build scan-build'


### PR DESCRIPTION
For some reason `meson compile` apparently does not support the `scan-build` target.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
