### PR TITLE
android-boot: Add additional ABL A and B entries for SHIFT6mq

### DIFF
--- a/plugins/android-boot/android-boot.quirk
+++ b/plugins/android-boot/android-boot.quirk
@@ -5,8 +5,20 @@ Vendor = SHIFT
 VendorId = DRIVE:SHIFT
 AndroidBootVersionProperty = androidboot.abl.revision
 
+[DRIVE\UUID_587959e1-f210-7e70-8322-16d55668ed30&LABEL_abl-a]
+Flags = updatable,signed-payload
+Vendor = SHIFT
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision
+
 # SHIFT6mq ABL B
 [DRIVE\UUID_3d7b21e8-048b-db0b-0c18-d07a9bb32f2d&LABEL_abl-b]
+Flags = updatable,signed-payload
+Vendor = SHIFT
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision
+
+[DRIVE\UUID_5fcb6730-88f0-7047-2957-9df59613e5ad&LABEL_abl-b]
 Flags = updatable,signed-payload
 Vendor = SHIFT
 VendorId = DRIVE:SHIFT


### PR DESCRIPTION
udisksctl info -b /dev/sde8

  org.freedesktop.UDisks2.Partition:
    Flags:              1188668826649100288
    IsContained:        false
    IsContainer:        false
    Name:               abl_a
    Number:             8
    Offset:             167796736
    Size:               1048576
    Table:              '/org/freedesktop/UDisks2/block_devices/sde'
    Type:               bd6928a1-4ce0-a038-4f3a-1495e3eddffb
    UUID:               587959e1-f210-7e70-8322-16d55668ed30

udisksctl info -b /dev/sde30

  org.freedesktop.UDisks2.Partition:
    Flags:              1187542926742257664
    IsContained:        false
    IsContainer:        false
    Name:               abl_b
    Number:             30
    Offset:             549478400
    Size:               1048576
    Table:              '/org/freedesktop/UDisks2/block_devices/sde'
    Type:               77036cd4-03d5-42bb-8ed1-37e5a88baa34
    UUID:               5fcb6730-88f0-7047-2957-9df59613e5ad

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
