### PR TITLE
Parse Jcat files in libfwupd without using libjcat

### DIFF
--- a/libfwupd/fwupd-codec.rs
+++ b/libfwupd/fwupd-codec.rs
@@ -11,4 +11,7 @@ enum FwupdCodecFlags {
     // Compress values to the smallest possible size.
     // Since: 2.0.8
     Compressed = 1 << 1,
+    // Do not include timestamps.
+    // Since: 2.1.3
+    NoTimestamp = 1 << 2,
 }

--- a/libfwupd/fwupd-jcat-blob.c
+++ b/libfwupd/fwupd-jcat-blob.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fwupd-codec.h"
+#include "fwupd-error.h"
+#include "fwupd-jcat-blob.h"
+
+struct _FwupdJcatBlob {
+	GObject parent_instance;
+	FwupdJcatBlobKind kind;
+	FwupdJcatBlobKind target;
+	FwupdJcatBlobFlags flags;
+	GBytes *data;
+	guint64 timestamp;
+};
+
+static void
+fwupd_jcat_blob_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FwupdJcatBlob,
+		       fwupd_jcat_blob,
+		       G_TYPE_OBJECT,
+		       0,
+		       G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC, fwupd_jcat_blob_codec_iface_init));
+
+static void
+fwupd_jcat_blob_add_string(FwupdCodec *codec, guint idt, GString *str)
+{
+	FwupdJcatBlob *self = FWUPD_JCAT_BLOB(codec);
+	g_autofree gchar *flags = fwupd_jcat_blob_flags_to_string(self->flags);
+
+	fwupd_codec_string_append(str, idt, "Kind", fwupd_jcat_blob_kind_to_string(self->kind));
+	if (self->target != FWUPD_JCAT_BLOB_KIND_UNKNOWN) {
+		fwupd_codec_string_append(str,
+					  idt,
+					  "Target",
+					  fwupd_jcat_blob_kind_to_string(self->target));
+	}
+	fwupd_codec_string_append(str, idt, "Flags", flags);
+	if (self->timestamp != 0) {
+		g_autoptr(GDateTime) dt = g_date_time_new_from_unix_utc(self->timestamp);
+		if (dt != NULL) {
+#if GLIB_CHECK_VERSION(2, 62, 0)
+			g_autofree gchar *tmp = g_date_time_format_iso8601(dt);
+#else
+			g_autofree gchar *tmp = g_date_time_format(dt, "%FT%TZ");
+#endif
+			fwupd_codec_string_append(str, idt, "Timestamp", tmp);
+		}
+	}
+	if (self->data != NULL) {
+		g_autofree gchar *tmp = fwupd_jcat_blob_get_data_as_string(self);
+		g_autofree gchar *size =
+		    g_strdup_printf("0x%x", (guint)g_bytes_get_size(self->data));
+		fwupd_codec_string_append(str, idt, "Size", size);
+		fwupd_codec_string_append(str, idt, "Data", tmp);
+	}
+}
+
+/**
+ * fwupd_jcat_blob_get_timestamp:
+ * @self: #FwupdJcatBlob
+ *
+ * Gets the creation timestamp for the blob.
+ *
+ * Returns: UTC UNIX time, or 0 if unset
+ *
+ * Since: 2.1.3
+ **/
+guint64
+fwupd_jcat_blob_get_timestamp(FwupdJcatBlob *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_BLOB(self), 0);
+	return self->timestamp;
+}
+
+/**
+ * fwupd_jcat_blob_set_timestamp:
+ * @self: #FwupdJcatBlob
+ * @timestamp: UTC timestamp
+ *
+ * Sets the creation timestamp for the blob.
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_blob_set_timestamp(FwupdJcatBlob *self, guint64 timestamp)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_BLOB(self));
+	self->timestamp = timestamp;
+}
+
+/**
+ * fwupd_jcat_blob_get_data:
+ * @self: #FwupdJcatBlob
+ *
+ * Gets the data stored in the blob, typically in binary (unprintable) form.
+ *
+ * Returns: (transfer none): a #GBytes, or %NULL if the filename was not found
+ *
+ * Since: 2.1.3
+ **/
+GBytes *
+fwupd_jcat_blob_get_data(FwupdJcatBlob *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_BLOB(self), NULL);
+	return self->data;
+}
+
+/**
+ * fwupd_jcat_blob_get_data_as_string:
+ * @self: #FwupdJcatBlob
+ *
+ * Gets the data stored in the blob, in human readable form.
+ *
+ * Returns: (transfer full): either UTF-8 text, or base64 encoded version of binary data
+ *
+ * Since: 2.1.3
+ **/
+gchar *
+fwupd_jcat_blob_get_data_as_string(FwupdJcatBlob *self)
+{
+	gsize bufsz = 0;
+	const guchar *buf;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_BLOB(self), NULL);
+
+	/* may be binary data or not NULL terminated */
+	if (self->data == NULL)
+		return NULL;
+	buf = g_bytes_get_data(self->data, &bufsz);
+	if ((self->flags & FWUPD_JCAT_BLOB_FLAG_IS_UTF8) == 0)
+		return g_base64_encode(buf, bufsz);
+	return g_strndup((const gchar *)buf, bufsz);
+}
+
+static void
+fwupd_jcat_blob_set_data_raw(FwupdJcatBlob *self, const guint8 *buf, gsize bufsz)
+{
+	if (self->data != NULL)
+		g_bytes_unref(self->data);
+	self->data = g_bytes_new(buf, bufsz);
+}
+
+/**
+ * fwupd_jcat_blob_get_kind:
+ * @self: #FwupdJcatBlob
+ *
+ * gets the blob kind
+ *
+ * Returns: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatBlobKind
+fwupd_jcat_blob_get_kind(FwupdJcatBlob *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_BLOB(self), 0);
+	return self->kind;
+}
+
+/**
+ * fwupd_jcat_blob_get_target:
+ * @self: #FwupdJcatBlob
+ *
+ * Gets the blob target.
+ *
+ * Returns: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatBlobKind
+fwupd_jcat_blob_get_target(FwupdJcatBlob *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_BLOB(self), 0);
+	return self->target;
+}
+
+/**
+ * fwupd_jcat_blob_set_target:
+ * @self: #FwupdJcatBlob
+ * @target: a #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ *
+ * Sets the blob target.
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_blob_set_target(FwupdJcatBlob *self, FwupdJcatBlobKind target)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_BLOB(self));
+	self->target = target;
+}
+
+static gboolean
+fwupd_jcat_blob_from_json(FwupdCodec *codec, FwupdJsonObject *json_obj, GError **error)
+{
+	FwupdJcatBlob *self = FWUPD_JCAT_BLOB(codec);
+	const gchar *data_str;
+	gint64 timestamp_tmp = 0;
+	gint64 flags_tmp = 0;
+	gint64 kind_tmp = 0;
+
+	/* get kind, which can be unknown to us for forward compat */
+	if (!fwupd_json_object_get_integer(json_obj, "Kind", &kind_tmp, error))
+		return FALSE;
+	if (kind_tmp < 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "invalid kind");
+		return FALSE;
+	}
+	self->kind = (FwupdJcatBlobKind)kind_tmp;
+
+	/* get flags, which can also be unknown to us */
+	if (!fwupd_json_object_get_integer(json_obj, "Flags", &flags_tmp, error))
+		return FALSE;
+	if (flags_tmp < 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA, "invalid flags");
+		return FALSE;
+	}
+	self->flags = (FwupdJcatBlobFlags)flags_tmp;
+
+	/* all optional */
+	if (!fwupd_json_object_get_integer_with_default(json_obj,
+							"Timestamp",
+							&timestamp_tmp,
+							0,
+							error))
+		return FALSE;
+	if (timestamp_tmp < 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid timestamp");
+		return FALSE;
+	}
+	fwupd_jcat_blob_set_timestamp(self, (guint64)timestamp_tmp);
+
+	if (fwupd_json_object_has_node(json_obj, "Target")) {
+		gint64 target_tmp = 0;
+		if (!fwupd_json_object_get_integer(json_obj, "Target", &target_tmp, error))
+			return FALSE;
+		if (target_tmp < 0) {
+			g_set_error_literal(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_INVALID_DATA,
+					    "invalid target");
+			return FALSE;
+		}
+		fwupd_jcat_blob_set_target(self, (FwupdJcatBlobKind)target_tmp);
+	}
+
+	/* get compressed data */
+	data_str = fwupd_json_object_get_string(json_obj, "Data", error);
+	if (data_str == NULL)
+		return FALSE;
+	if ((self->flags & FWUPD_JCAT_BLOB_FLAG_IS_UTF8) == 0) {
+		gsize bufsz = 0;
+		g_autofree guchar *buf = g_base64_decode(data_str, &bufsz);
+		fwupd_jcat_blob_set_data_raw(self, (guint8 *)buf, bufsz);
+	} else {
+		fwupd_jcat_blob_set_data_raw(self, (const guint8 *)data_str, strlen(data_str));
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fwupd_jcat_blob_add_json(FwupdCodec *codec, FwupdJsonObject *json_obj, FwupdCodecFlags flags)
+{
+	FwupdJcatBlob *self = FWUPD_JCAT_BLOB(codec);
+	g_autofree gchar *data_str = fwupd_jcat_blob_get_data_as_string(self);
+
+	fwupd_json_object_add_integer(json_obj, "Kind", self->kind);
+	if (self->target != FWUPD_JCAT_BLOB_KIND_UNKNOWN)
+		fwupd_json_object_add_integer(json_obj, "Target", self->target);
+	fwupd_json_object_add_integer(json_obj, "Flags", self->flags);
+	if (self->timestamp > 0 && (flags & FWUPD_CODEC_FLAG_NO_TIMESTAMP) == 0)
+		fwupd_json_object_add_integer(json_obj, "Timestamp", self->timestamp);
+	if (data_str != NULL)
+		fwupd_json_object_add_string(json_obj, "Data", data_str);
+}
+
+static void
+fwupd_jcat_blob_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_string = fwupd_jcat_blob_add_string;
+	iface->add_json = fwupd_jcat_blob_add_json;
+	iface->from_json = fwupd_jcat_blob_from_json;
+}
+
+static void
+fwupd_jcat_blob_finalize(GObject *obj)
+{
+	FwupdJcatBlob *self = FWUPD_JCAT_BLOB(obj);
+	if (self->data != NULL)
+		g_bytes_unref(self->data);
+	G_OBJECT_CLASS(fwupd_jcat_blob_parent_class)->finalize(obj);
+}
+
+static void
+fwupd_jcat_blob_class_init(FwupdJcatBlobClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fwupd_jcat_blob_finalize;
+}
+
+static void
+fwupd_jcat_blob_init(FwupdJcatBlob *self)
+{
+	self->timestamp = g_get_real_time() / G_USEC_PER_SEC;
+}
+
+/**
+ * fwupd_jcat_blob_new:
+ * @kind: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ * @data: #GBytes
+ * @flags: #FwupdJcatBlobFlags
+ *
+ * Creates a new blob.
+ *
+ * Returns: a #FwupdJcatBlob
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatBlob *
+fwupd_jcat_blob_new(FwupdJcatBlobKind kind, GBytes *data, FwupdJcatBlobFlags flags)
+{
+	g_autoptr(FwupdJcatBlob) self = g_object_new(FWUPD_TYPE_JCAT_BLOB, NULL);
+
+	g_return_val_if_fail(data != NULL, NULL);
+
+	self->kind = kind;
+	self->data = g_bytes_ref(data);
+	self->flags = flags;
+	return g_steal_pointer(&self);
+}
+
+/**
+ * fwupd_jcat_blob_new_utf8:
+ * @kind: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ * @data: (not nullable): ASCII data
+ *
+ * Creates a new ASCII blob.
+ *
+ * Returns: a #FwupdJcatBlob
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatBlob *
+fwupd_jcat_blob_new_utf8(FwupdJcatBlobKind kind, const gchar *data)
+{
+	g_autoptr(FwupdJcatBlob) self = g_object_new(FWUPD_TYPE_JCAT_BLOB, NULL);
+
+	g_return_val_if_fail(data != NULL, NULL);
+
+	self->flags = FWUPD_JCAT_BLOB_FLAG_IS_UTF8;
+	self->kind = kind;
+	fwupd_jcat_blob_set_data_raw(self, (const guint8 *)data, strlen(data));
+	return g_steal_pointer(&self);
+}

--- a/libfwupd/fwupd-jcat-blob.h
+++ b/libfwupd/fwupd-jcat-blob.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+#include "fwupd-jcat-struct.h"
+
+G_BEGIN_DECLS
+
+#define FWUPD_TYPE_JCAT_BLOB fwupd_jcat_blob_get_type()
+
+G_DECLARE_FINAL_TYPE(FwupdJcatBlob, fwupd_jcat_blob, FWUPD, JCAT_BLOB, GObject)
+
+FwupdJcatBlob *
+fwupd_jcat_blob_new(FwupdJcatBlobKind kind,
+		    GBytes *data,
+		    FwupdJcatBlobFlags flags) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(2);
+FwupdJcatBlob *
+fwupd_jcat_blob_new_utf8(FwupdJcatBlobKind kind, const gchar *data) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(2);
+GBytes *
+fwupd_jcat_blob_get_data(FwupdJcatBlob *self) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);
+gchar *
+fwupd_jcat_blob_get_data_as_string(FwupdJcatBlob *self) G_GNUC_WARN_UNUSED_RESULT
+    G_GNUC_NON_NULL(1);
+FwupdJcatBlobKind
+fwupd_jcat_blob_get_kind(FwupdJcatBlob *self) G_GNUC_NON_NULL(1);
+FwupdJcatBlobKind
+fwupd_jcat_blob_get_target(FwupdJcatBlob *self) G_GNUC_NON_NULL(1);
+void
+fwupd_jcat_blob_set_target(FwupdJcatBlob *self, FwupdJcatBlobKind target) G_GNUC_NON_NULL(1);
+guint64
+fwupd_jcat_blob_get_timestamp(FwupdJcatBlob *self) G_GNUC_NON_NULL(1);
+void
+fwupd_jcat_blob_set_timestamp(FwupdJcatBlob *self, guint64 timestamp) G_GNUC_NON_NULL(1);
+
+G_END_DECLS

--- a/libfwupd/fwupd-jcat-file.c
+++ b/libfwupd/fwupd-jcat-file.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fwupd-codec.h"
+#include "fwupd-error.h"
+#include "fwupd-jcat-file.h"
+#include "fwupd-json-array.h"
+#include "fwupd-json-parser.h"
+
+struct _FwupdJcatFile {
+	GObject parent_instance;
+	GPtrArray *items;
+	guint32 version_major;
+	guint32 version_minor;
+};
+
+static void
+fwupd_jcat_file_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FwupdJcatFile,
+		       fwupd_jcat_file,
+		       G_TYPE_OBJECT,
+		       0,
+		       G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC, fwupd_jcat_file_codec_iface_init));
+
+static void
+fwupd_jcat_file_add_string(FwupdCodec *codec, guint idt, GString *str)
+{
+	FwupdJcatFile *self = FWUPD_JCAT_FILE(codec);
+
+	if (self->version_major > 0 || self->version_minor > 0) {
+		g_autofree gchar *version = NULL;
+		version = g_strdup_printf("%u.%u", self->version_major, self->version_minor);
+		fwupd_codec_string_append(str, idt, "Version", version);
+	}
+	for (guint i = 0; i < self->items->len; i++) {
+		FwupdJcatItem *item = g_ptr_array_index(self->items, i);
+		fwupd_codec_add_string(FWUPD_CODEC(item), idt, str);
+	}
+}
+
+static gboolean
+fwupd_jcat_file_import_node(FwupdJcatFile *self,
+			    FwupdJsonNode *json_node,
+			    GError **error)
+{
+	gint64 version = 0;
+	g_autoptr(FwupdJsonObject) json_obj = NULL;
+	g_autoptr(FwupdJsonArray) json_array = NULL;
+
+	/* get version */
+	json_obj = fwupd_json_node_get_object(json_node, error);
+	if (json_obj == NULL)
+		return FALSE;
+	if (!fwupd_json_object_get_integer(json_obj, "JcatVersionMajor", &version, error))
+		return FALSE;
+	if (version < 0 || version > G_MAXUINT32) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid major version");
+		return FALSE;
+	}
+	self->version_major = (guint32)version;
+	if (!fwupd_json_object_get_integer(json_obj, "JcatVersionMinor", &version, error))
+		return FALSE;
+	if (version < 0 || version > G_MAXUINT32) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid minor version");
+		return FALSE;
+	}
+	self->version_minor = (guint32)version;
+
+	/* get items */
+	json_array = fwupd_json_object_get_array(json_obj, "Items", error);
+	if (json_array == NULL)
+		return FALSE;
+	for (guint i = 0; i < fwupd_json_array_get_size(json_array); i++) {
+		g_autoptr(FwupdJsonObject) json_item = NULL;
+		g_autoptr(FwupdJcatItem) item = g_object_new(FWUPD_TYPE_JCAT_ITEM, NULL);
+
+		json_item = fwupd_json_array_get_object(json_array, i, error);
+		if (json_item == NULL)
+			return FALSE;
+		if (!fwupd_codec_from_json(FWUPD_CODEC(item), json_item, error))
+			return FALSE;
+		fwupd_jcat_file_add_item(self, item);
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static FwupdJsonObject *
+fwupd_jcat_file_export_builder(FwupdJcatFile *self, FwupdCodecFlags flags)
+{
+	g_autoptr(FwupdJsonObject) json_obj = fwupd_json_object_new();
+	g_autoptr(FwupdJsonArray) json_array = fwupd_json_array_new();
+
+	/* add metadata */
+	fwupd_json_object_add_integer(json_obj, "JcatVersionMajor", self->version_major);
+	fwupd_json_object_add_integer(json_obj, "JcatVersionMinor", self->version_minor);
+
+	/* add items */
+	for (guint i = 0; i < self->items->len; i++) {
+		FwupdJcatItem *item = g_ptr_array_index(self->items, i);
+		g_autoptr(FwupdJsonObject) json_item = fwupd_json_object_new();
+		fwupd_codec_to_json(FWUPD_CODEC(item), json_item, flags);
+		fwupd_json_array_add_object(json_array, json_item);
+	}
+	fwupd_json_object_add_array(json_obj, "Items", json_array);
+
+	/* success */
+	return g_steal_pointer(&json_obj);
+}
+
+static FwupdJsonParser *
+fwupd_jcat_file_json_parser_new(void)
+{
+	g_autoptr(FwupdJsonParser) json_parser = fwupd_json_parser_new();
+	fwupd_json_parser_set_max_depth(json_parser, 5);
+	fwupd_json_parser_set_max_items(json_parser, 100);
+	fwupd_json_parser_set_max_quoted(json_parser, 100 * 1024);
+	return g_steal_pointer(&json_parser);
+}
+
+/**
+ * fwupd_jcat_file_import_json:
+ * @self: #FwupdJcatFile
+ * @json: (not nullable): JSON data
+ * @error: #GError, or %NULL
+ *
+ * Imports a FwupdJcat file from raw JSON.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_jcat_file_import_json(FwupdJcatFile *self,
+			    const gchar *json,
+			    GError **error)
+{
+	g_autoptr(FwupdJsonNode) json_node = NULL;
+	g_autoptr(FwupdJsonParser) json_parser = fwupd_jcat_file_json_parser_new();
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), FALSE);
+	g_return_val_if_fail(json != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	json_node =
+	    fwupd_json_parser_load_from_data(json_parser, json, FWUPD_JSON_LOAD_FLAG_NONE, error);
+	if (json_node == NULL)
+		return FALSE;
+	return fwupd_jcat_file_import_node(self, json_node, error);
+}
+
+/**
+ * fwupd_jcat_file_import_stream:
+ * @self: #FwupdJcatFile
+ * @istream: (not nullable): #GInputStream
+ * @error: #GError, or %NULL
+ *
+ * Imports a compressed FwupdJcat file from a file.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_jcat_file_import_stream(FwupdJcatFile *self,
+			      GInputStream *istream,
+			      GError **error)
+{
+	g_autoptr(FwupdJsonNode) json_node = NULL;
+	g_autoptr(FwupdJsonParser) json_parser = fwupd_jcat_file_json_parser_new();
+	g_autoptr(GConverter) conv = NULL;
+	g_autoptr(GInputStream) istream_uncompressed = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), FALSE);
+	g_return_val_if_fail(G_IS_INPUT_STREAM(istream), FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	conv = G_CONVERTER(g_zlib_decompressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP));
+	istream_uncompressed = g_converter_input_stream_new(istream, conv);
+	g_filter_input_stream_set_close_base_stream(G_FILTER_INPUT_STREAM(istream_uncompressed),
+						    FALSE);
+	json_node = fwupd_json_parser_load_from_stream(json_parser,
+						       istream_uncompressed,
+						       FWUPD_JSON_LOAD_FLAG_NONE,
+						       error);
+	if (json_node == NULL)
+		return FALSE;
+	return fwupd_jcat_file_import_node(self, json_node, error);
+}
+
+/**
+ * fwupd_jcat_file_import_bytes:
+ * @self: #FwupdJcatFile
+ * @blob: (not nullable): a #GBytes
+ * @error: #GError, or %NULL
+ *
+ * Imports a compressed FwupdJcat file from a blob of data.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_jcat_file_import_bytes(FwupdJcatFile *self,
+			     GBytes *blob,
+			     GError **error)
+{
+	g_autoptr(GInputStream) istream = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), FALSE);
+	g_return_val_if_fail(blob != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	istream = g_memory_input_stream_new_from_bytes(blob);
+	return fwupd_jcat_file_import_stream(self, istream, error);
+}
+
+/**
+ * fwupd_jcat_file_export_json:
+ * @self: #FwupdJcatFile
+ * @flags: a #FwupdCodecFlags, typically %FWUPD_CODEC_FLAG_NONE
+ * @error: #GError, or %NULL
+ *
+ * Exports a FwupdJcat file to raw JSON.
+ *
+ * Returns: (transfer full): JSON output, or %NULL for error
+ *
+ * Since: 2.1.3
+ **/
+gchar *
+fwupd_jcat_file_export_json(FwupdJcatFile *self, FwupdCodecFlags flags, GError **error)
+{
+	g_autoptr(FwupdJsonObject) json_obj = NULL;
+	g_autoptr(GString) str = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	json_obj = fwupd_jcat_file_export_builder(self, flags);
+	str = fwupd_json_object_to_string(json_obj, FWUPD_JSON_EXPORT_FLAG_INDENT);
+	return g_string_free(g_steal_pointer(&str), FALSE);
+}
+
+/**
+ * fwupd_jcat_file_export_bytes:
+ * @self: #FwupdJcatFile
+ * @error: #GError, or %NULL
+ *
+ * Exports a FwupdJcat file to a compressed blob.
+ *
+ * Returns: (transfer full): a #GBytes
+ *
+ * Since: 2.1.3
+ **/
+GBytes *
+fwupd_jcat_file_export_bytes(FwupdJcatFile *self, GError **error)
+{
+	g_autoptr(FwupdJsonObject) json_obj = NULL;
+	g_autoptr(GConverter) converter = NULL;
+	g_autoptr(GBytes) blob = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* export all */
+	json_obj = fwupd_jcat_file_export_builder(self, FWUPD_CODEC_FLAG_NONE);
+	blob = fwupd_json_object_to_bytes(json_obj, FWUPD_JSON_EXPORT_FLAG_INDENT);
+
+	/* compress blob */
+	converter = G_CONVERTER(g_zlib_compressor_new(G_ZLIB_COMPRESSOR_FORMAT_GZIP, -1));
+#if GLIB_CHECK_VERSION(2, 82, 0)
+	return g_converter_convert_bytes(converter, blob, error);
+#else
+	{
+		guint8 tmp[0x8000]; /* nocheck:zero-init */
+		g_autoptr(GInputStream) istream1 = NULL;
+		g_autoptr(GInputStream) istream2 = NULL;
+		g_autoptr(GByteArray) buf = g_byte_array_new();
+		g_autoptr(GError) error_local = NULL;
+
+		istream1 = g_memory_input_stream_new_from_bytes(blob);
+		istream2 = g_converter_input_stream_new(istream1, converter);
+		while (TRUE) {
+			gssize sz;
+			sz = g_input_stream_read(istream2, tmp, sizeof(tmp), NULL, &error_local);
+			if (sz == 0)
+				break;
+			if (sz < 0) {
+				g_set_error_literal(error,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_INVALID_FILE,
+						    error_local->message);
+				return NULL;
+			}
+			g_byte_array_append(buf, tmp, sz);
+		}
+		return g_byte_array_free_to_bytes(g_steal_pointer(&buf)); /* nocheck:blocked */
+	}
+#endif
+}
+
+/**
+ * fwupd_jcat_file_get_items:
+ * @self: #FwupdJcatFile
+ *
+ * Returns all the items in the file.
+ *
+ * Returns: (transfer container) (element-type FwupdJcatItem): all the items in the file
+ *
+ * Since: 2.1.3
+ **/
+GPtrArray *
+fwupd_jcat_file_get_items(FwupdJcatFile *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), NULL);
+	return g_ptr_array_ref(self->items);
+}
+
+/**
+ * fwupd_jcat_file_get_item_by_id:
+ * @self: #FwupdJcatFile
+ * @id: (not nullable): An ID, typically a filename basename
+ * @error: #GError, or %NULL
+ *
+ * Finds the item with the specified ID, falling back to the ID alias if set.
+ *
+ * Returns: (transfer full): a #FwupdJcatItem, or %NULL if the filename was not found
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatItem *
+fwupd_jcat_file_get_item_by_id(FwupdJcatFile *self, const gchar *id, GError **error)
+{
+	g_autoptr(FwupdJcatItem) item_found = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), NULL);
+	g_return_val_if_fail(id != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* exact ID match */
+	for (guint i = 0; i < self->items->len; i++) {
+		FwupdJcatItem *item = g_ptr_array_index(self->items, i);
+		if (g_strcmp0(fwupd_jcat_item_get_id(item), id) == 0) {
+			if (item_found != NULL) {
+				g_set_error(error,
+					    FWUPD_ERROR,
+					    FWUPD_ERROR_NOT_SUPPORTED,
+					    "multiple matches for %s",
+					    id);
+				return NULL;
+			}
+			item_found = g_object_ref(item);
+		}
+	}
+	if (item_found != NULL)
+		return g_steal_pointer(&item_found);
+
+	/* try aliases this time */
+	for (guint i = 0; i < self->items->len; i++) {
+		FwupdJcatItem *item = g_ptr_array_index(self->items, i);
+		g_autoptr(GPtrArray) alias_ids = fwupd_jcat_item_get_alias_ids(item);
+		for (guint j = 0; j < alias_ids->len; j++) {
+			const gchar *id_tmp = g_ptr_array_index(alias_ids, j);
+			if (g_strcmp0(id_tmp, id) == 0) {
+				if (item_found != NULL) {
+					g_set_error(error,
+						    FWUPD_ERROR,
+						    FWUPD_ERROR_NOT_SUPPORTED,
+						    "multiple aliases for %s",
+						    id);
+					return NULL;
+				}
+				item_found = g_object_ref(item);
+			}
+		}
+	}
+	if (item_found != NULL)
+		return g_steal_pointer(&item_found);
+
+	/* failed */
+	g_set_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "failed to find %s", id);
+	return NULL;
+}
+
+/**
+ * fwupd_jcat_file_get_item_default:
+ * @self: #FwupdJcatFile
+ * @error: #GError, or %NULL
+ *
+ * Finds the default item. If more than one #FwupdJcatItem exists this function will
+ * return with an error.
+ *
+ * Returns: (transfer full): a #FwupdJcatItem, or %NULL if no default exists
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatItem *
+fwupd_jcat_file_get_item_default(FwupdJcatFile *self, GError **error)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* sanity check */
+	if (self->items->len == 0) {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND, "no items found");
+		return NULL;
+	}
+	if (self->items->len > 1) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "multiple items found, no default possible");
+		return NULL;
+	}
+
+	/* only one possible */
+	return g_object_ref(g_ptr_array_index(self->items, 0));
+}
+
+/**
+ * fwupd_jcat_file_add_item:
+ * @self: #FwupdJcatFile
+ * @item: (not nullable): #FwupdJcatItem
+ *
+ * Adds an item to a file.
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_file_add_item(FwupdJcatFile *self, FwupdJcatItem *item)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_FILE(self));
+	g_return_if_fail(FWUPD_IS_JCAT_ITEM(item));
+	g_ptr_array_add(self->items, g_object_ref(item));
+}
+
+/**
+ * fwupd_jcat_file_get_version_major:
+ * @self: #FwupdJcatFile
+ *
+ * Returns the major version number of the FwupdJcat specification
+ *
+ * Returns: integer
+ *
+ * Since: 2.1.3
+ **/
+guint32
+fwupd_jcat_file_get_version_major(FwupdJcatFile *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), 0);
+	return self->version_major;
+}
+
+/**
+ * fwupd_jcat_file_get_version_minor:
+ * @self: #FwupdJcatFile
+ *
+ * Returns the minor version number of the FwupdJcat specification
+ *
+ * Returns: integer
+ *
+ * Since: 2.1.3
+ **/
+guint32
+fwupd_jcat_file_get_version_minor(FwupdJcatFile *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_FILE(self), 0);
+	return self->version_minor;
+}
+
+static void
+fwupd_jcat_file_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_string = fwupd_jcat_file_add_string;
+}
+
+static void
+fwupd_jcat_file_finalize(GObject *obj)
+{
+	FwupdJcatFile *self = FWUPD_JCAT_FILE(obj);
+
+	g_ptr_array_unref(self->items);
+	G_OBJECT_CLASS(fwupd_jcat_file_parent_class)->finalize(obj);
+}
+
+static void
+fwupd_jcat_file_class_init(FwupdJcatFileClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fwupd_jcat_file_finalize;
+}
+
+static void
+fwupd_jcat_file_init(FwupdJcatFile *self)
+{
+	self->items = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	self->version_major = 0;
+	self->version_minor = 1;
+}
+
+/**
+ * fwupd_jcat_file_new:
+ *
+ * Creates a new file.
+ *
+ * Returns: a #FwupdJcatFile
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatFile *
+fwupd_jcat_file_new(void)
+{
+	return g_object_new(FWUPD_TYPE_JCAT_FILE, NULL);
+}

--- a/libfwupd/fwupd-jcat-file.h
+++ b/libfwupd/fwupd-jcat-file.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupd.h>
+
+#include "fwupd-jcat-item.h"
+
+G_BEGIN_DECLS
+
+#define FWUPD_TYPE_JCAT_FILE (fwupd_jcat_file_get_type())
+
+G_DECLARE_FINAL_TYPE(FwupdJcatFile, fwupd_jcat_file, FWUPD, JCAT_FILE, GObject)
+
+FwupdJcatFile *
+fwupd_jcat_file_new(void);
+gboolean
+fwupd_jcat_file_import_stream(FwupdJcatFile *self,
+			      GInputStream *istream,
+			      GError **error) G_GNUC_NON_NULL(1, 2);
+gboolean
+fwupd_jcat_file_import_bytes(FwupdJcatFile *self,
+			     GBytes *blob,
+			     GError **error) G_GNUC_NON_NULL(1, 2);
+gboolean
+fwupd_jcat_file_import_json(FwupdJcatFile *self,
+			    const gchar *json,
+			    GError **error) G_GNUC_NON_NULL(1, 2);
+GBytes *
+fwupd_jcat_file_export_bytes(FwupdJcatFile *self, GError **error) G_GNUC_NON_NULL(1);
+gchar *
+fwupd_jcat_file_export_json(FwupdJcatFile *self, FwupdCodecFlags flags, GError **error)
+    G_GNUC_NON_NULL(1);
+GPtrArray *
+fwupd_jcat_file_get_items(FwupdJcatFile *self) G_GNUC_NON_NULL(1);
+FwupdJcatItem *
+fwupd_jcat_file_get_item_by_id(FwupdJcatFile *self, const gchar *id, GError **error)
+    G_GNUC_NON_NULL(1, 2);
+FwupdJcatItem *
+fwupd_jcat_file_get_item_default(FwupdJcatFile *self, GError **error) G_GNUC_NON_NULL(1);
+void
+fwupd_jcat_file_add_item(FwupdJcatFile *self, FwupdJcatItem *item) G_GNUC_NON_NULL(1, 2);
+guint32
+fwupd_jcat_file_get_version_major(FwupdJcatFile *self) G_GNUC_NON_NULL(1);
+guint32
+fwupd_jcat_file_get_version_minor(FwupdJcatFile *self) G_GNUC_NON_NULL(1);
+
+G_END_DECLS

--- a/libfwupd/fwupd-jcat-item.c
+++ b/libfwupd/fwupd-jcat-item.c
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fwupd-codec.h"
+#include "fwupd-error.h"
+#include "fwupd-jcat-item.h"
+#include "fwupd-json-array.h"
+
+struct _FwupdJcatItem {
+	GObject parent_instance;
+	gchar *id;
+	GPtrArray *blobs;
+	GPtrArray *alias_ids;
+};
+
+static void
+fwupd_jcat_item_codec_iface_init(FwupdCodecInterface *iface);
+
+G_DEFINE_TYPE_EXTENDED(FwupdJcatItem,
+		       fwupd_jcat_item,
+		       G_TYPE_OBJECT,
+		       0,
+		       G_IMPLEMENT_INTERFACE(FWUPD_TYPE_CODEC, fwupd_jcat_item_codec_iface_init));
+
+static void
+fwupd_jcat_item_add_string(FwupdCodec *codec, guint idt, GString *str)
+{
+	FwupdJcatItem *self = FWUPD_JCAT_ITEM(codec);
+
+	fwupd_codec_string_append(str, idt, "ID", self->id);
+	for (guint i = 0; i < self->alias_ids->len; i++) {
+		const gchar *alias_id = g_ptr_array_index(self->alias_ids, i);
+		fwupd_codec_string_append(str, idt, "AliasId", alias_id);
+	}
+	for (guint i = 0; i < self->blobs->len; i++) {
+		FwupdJcatBlob *blob = g_ptr_array_index(self->blobs, i);
+		fwupd_codec_add_string(FWUPD_CODEC(blob), idt, str);
+	}
+}
+
+static void
+fwupd_jcat_item_set_id(FwupdJcatItem *self, const gchar *id)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_ITEM(self));
+	g_return_if_fail(id != NULL);
+	g_free(self->id);
+	self->id = g_strdup(id);
+}
+
+static gboolean
+fwupd_jcat_item_from_json(FwupdCodec *codec, FwupdJsonObject *json_obj, GError **error)
+{
+	FwupdJcatItem *self = FWUPD_JCAT_ITEM(codec);
+	const gchar *id;
+
+	/* get ID */
+	id = fwupd_json_object_get_string(json_obj, "Id", error);
+	if (id == NULL)
+		return FALSE;
+	fwupd_jcat_item_set_id(self, id);
+
+	/* get blobs */
+	if (fwupd_json_object_has_node(json_obj, "Blobs")) {
+		g_autoptr(FwupdJsonArray) json_array = NULL;
+		json_array = fwupd_json_object_get_array(json_obj, "Blobs", error);
+		if (json_array == NULL)
+			return FALSE;
+		for (guint i = 0; i < fwupd_json_array_get_size(json_array); i++) {
+			g_autoptr(FwupdJsonObject) json_item = NULL;
+			g_autoptr(FwupdJcatBlob) blob = g_object_new(FWUPD_TYPE_JCAT_BLOB, NULL);
+
+			json_item = fwupd_json_array_get_object(json_array, i, error);
+			if (json_item == NULL)
+				return FALSE;
+			if (!fwupd_codec_from_json(FWUPD_CODEC(blob), json_item, error))
+				return FALSE;
+			fwupd_jcat_item_add_blob(self, blob);
+		}
+	}
+
+	/* get alias_ids */
+	if (fwupd_json_object_has_node(json_obj, "AliasIds")) {
+		g_autoptr(FwupdJsonArray) json_array = NULL;
+		json_array = fwupd_json_object_get_array(json_obj, "AliasIds", error);
+		if (json_array == NULL)
+			return FALSE;
+		for (guint i = 0; i < fwupd_json_array_get_size(json_array); i++) {
+			const gchar *alias_id;
+			alias_id = fwupd_json_array_get_string(json_array, i, error);
+			if (alias_id == NULL)
+				return FALSE;
+			fwupd_jcat_item_add_alias_id(self, alias_id);
+		}
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static void
+fwupd_jcat_item_add_json(FwupdCodec *codec, FwupdJsonObject *json_obj, FwupdCodecFlags flags)
+{
+	FwupdJcatItem *self = FWUPD_JCAT_ITEM(codec);
+
+	/* add metadata */
+	fwupd_json_object_add_string(json_obj, "Id", self->id);
+
+	/* add alias_ids */
+	if (self->alias_ids->len > 0) {
+		g_autoptr(FwupdJsonArray) json_array = fwupd_json_array_new();
+		for (guint i = 0; i < self->alias_ids->len; i++) {
+			const gchar *id_tmp = g_ptr_array_index(self->alias_ids, i);
+			fwupd_json_array_add_string(json_array, id_tmp);
+		}
+		fwupd_json_object_add_array(json_obj, "AliasIds", json_array);
+	}
+
+	/* add items */
+	if (self->blobs->len > 0) {
+		g_autoptr(FwupdJsonArray) json_array = fwupd_json_array_new();
+		for (guint i = 0; i < self->blobs->len; i++) {
+			FwupdJcatBlob *blob = g_ptr_array_index(self->blobs, i);
+			g_autoptr(FwupdJsonObject) json_blob = fwupd_json_object_new();
+			fwupd_codec_to_json(FWUPD_CODEC(blob), json_blob, flags);
+			fwupd_json_array_add_object(json_array, json_blob);
+		}
+		fwupd_json_object_add_array(json_obj, "Blobs", json_array);
+	}
+}
+
+/**
+ * fwupd_jcat_item_get_blobs:
+ * @self: #FwupdJcatItem
+ *
+ * Gets all the blobs for this item.
+ *
+ * Returns: (transfer container) (element-type FwupdJcatBlob): blobs
+ *
+ * Since: 2.1.3
+ **/
+GPtrArray *
+fwupd_jcat_item_get_blobs(FwupdJcatItem *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	return g_ptr_array_ref(self->blobs);
+}
+
+/**
+ * fwupd_jcat_item_get_blobs_by_kind:
+ * @self: #FwupdJcatItem
+ * @kind: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ *
+ * Gets the item blobs by a specific kind.
+ *
+ * Returns: (transfer container) (element-type FwupdJcatBlob): blobs
+ *
+ * Since: 2.1.3
+ **/
+GPtrArray *
+fwupd_jcat_item_get_blobs_by_kind(FwupdJcatItem *self, FwupdJcatBlobKind kind)
+{
+	g_autoptr(GPtrArray) blobs = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	g_return_val_if_fail(kind != FWUPD_JCAT_BLOB_KIND_UNKNOWN, NULL);
+
+	for (guint i = 0; i < self->blobs->len; i++) {
+		FwupdJcatBlob *blob = g_ptr_array_index(self->blobs, i);
+		if (fwupd_jcat_blob_get_kind(blob) == kind)
+			g_ptr_array_add(blobs, g_object_ref(blob));
+	}
+	return g_steal_pointer(&blobs);
+}
+
+/**
+ * fwupd_jcat_item_get_blob_by_kind:
+ * @self: #FwupdJcatItem
+ * @kind: #FwupdJcatBlobKind, e.g. %FWUPD_JCAT_BLOB_KIND_SHA256
+ * @error: #GError, or %NULL
+ *
+ * Gets the item blobs by a specific kind.
+ *
+ * Returns: (transfer full): a blob, or %NULL
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatBlob *
+fwupd_jcat_item_get_blob_by_kind(FwupdJcatItem *self, FwupdJcatBlobKind kind, GError **error)
+{
+	g_autoptr(GPtrArray) target_blobs = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	g_return_val_if_fail(kind != FWUPD_JCAT_BLOB_KIND_UNKNOWN, NULL);
+
+	target_blobs = fwupd_jcat_item_get_blobs_by_kind(self, kind);
+	if (target_blobs->len == 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "no existing checksum of type %s",
+			    fwupd_jcat_blob_kind_to_string(kind));
+		return NULL;
+	}
+	if (target_blobs->len > 1) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "multiple checksums of type %s",
+			    fwupd_jcat_blob_kind_to_string(kind));
+		return NULL;
+	}
+	return g_object_ref(FWUPD_JCAT_BLOB(g_ptr_array_index(target_blobs, 0)));
+}
+
+/**
+ * fwupd_jcat_item_add_blob:
+ * @self: #FwupdJcatItem
+ * @blob: (not nullable): #FwupdJcatBlob
+ *
+ * Adds a new blob to the item.
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_item_add_blob(FwupdJcatItem *self, FwupdJcatBlob *blob)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_ITEM(self));
+	g_return_if_fail(FWUPD_IS_JCAT_BLOB(blob));
+
+	/* add */
+	g_ptr_array_add(self->blobs, g_object_ref(blob));
+}
+
+/**
+ * fwupd_jcat_item_get_id:
+ * @self: #FwupdJcatItem
+ *
+ * Returns the item ID.
+ *
+ * Returns: (transfer none): string
+ *
+ * Since: 2.1.3
+ **/
+const gchar *
+fwupd_jcat_item_get_id(FwupdJcatItem *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	return self->id;
+}
+
+/**
+ * fwupd_jcat_item_get_id_safe:
+ * @self: a #FwupdJcatItem
+ * @error: (nullable): optional return location for an error
+ *
+ * Returns the item ID, if safe to use as a path.
+ *
+ * Returns: string
+ *
+ * Since: 2.1.3
+ **/
+const gchar *
+fwupd_jcat_item_get_id_safe(FwupdJcatItem *self, GError **error)
+{
+	g_autofree gchar *id_basename = NULL;
+
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* sanity check */
+	if (self->id == NULL || self->id[0] == '\0') {
+		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "ID not set");
+		return NULL;
+	}
+
+	/* verify there is no path component */
+	id_basename = g_path_get_basename(self->id);
+	if (g_strcmp0(self->id, id_basename) != 0 ||
+	    g_strcmp0(id_basename, G_DIR_SEPARATOR_S) == 0 || g_strcmp0(id_basename, "..") == 0 ||
+	    g_strcmp0(id_basename, ".") == 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_FILE,
+				    "ID cannot contain path components");
+		return NULL;
+	}
+
+	/* success */
+	return self->id;
+}
+
+/**
+ * fwupd_jcat_item_add_alias_id:
+ * @self: #FwupdJcatItem
+ * @id: (not nullable): An item ID alias, typically a file basename
+ *
+ * Adds an item alias ID. Alias IDs are matched when using functions such as
+ * fwupd_jcat_file_get_item_by_id().
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_item_add_alias_id(FwupdJcatItem *self, const gchar *id)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_ITEM(self));
+	g_return_if_fail(id != NULL);
+	for (guint i = 0; i < self->alias_ids->len; i++) {
+		const gchar *id_tmp = g_ptr_array_index(self->alias_ids, i);
+		if (g_strcmp0(id, id_tmp) == 0)
+			return;
+	}
+	g_ptr_array_add(self->alias_ids, g_strdup(id));
+}
+
+/**
+ * fwupd_jcat_item_remove_alias_id:
+ * @self: #FwupdJcatItem
+ * @id: (not nullable): An item ID alias, typically a file basename
+ *
+ * Removes an item alias ID.
+ *
+ * Since: 2.1.3
+ **/
+void
+fwupd_jcat_item_remove_alias_id(FwupdJcatItem *self, const gchar *id)
+{
+	g_return_if_fail(FWUPD_IS_JCAT_ITEM(self));
+	g_return_if_fail(id != NULL);
+	for (guint i = 0; i < self->alias_ids->len; i++) {
+		const gchar *id_tmp = g_ptr_array_index(self->alias_ids, i);
+		if (g_strcmp0(id, id_tmp) == 0) {
+			g_ptr_array_remove(self->alias_ids, (gpointer)id_tmp);
+			return;
+		}
+	}
+}
+
+/**
+ * fwupd_jcat_item_get_alias_ids:
+ * @self: #FwupdJcatItem
+ *
+ * Gets the list of alias IDs.
+ *
+ * Returns: (transfer container) (element-type utf8): array
+ *
+ * Since: 2.1.3
+ **/
+GPtrArray *
+fwupd_jcat_item_get_alias_ids(FwupdJcatItem *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), NULL);
+	return g_ptr_array_ref(self->alias_ids);
+}
+
+/**
+ * fwupd_jcat_item_has_target:
+ * @self: #FwupdJcatItem
+ *
+ * Finds out if any of the blobs are targeting an internal checksum.
+ * If this returns with success then the caller might be able to use functions like
+ * fwupd_jcat_context_verify_target() supplying some target checksums.
+ *
+ * Returns: %TRUE on success
+ *
+ * Since: 2.1.3
+ **/
+gboolean
+fwupd_jcat_item_has_target(FwupdJcatItem *self)
+{
+	g_return_val_if_fail(FWUPD_IS_JCAT_ITEM(self), FALSE);
+	for (guint i = 0; i < self->blobs->len; i++) {
+		FwupdJcatBlob *blob_tmp = g_ptr_array_index(self->blobs, i);
+		if (fwupd_jcat_blob_get_target(blob_tmp) != FWUPD_JCAT_BLOB_KIND_UNKNOWN)
+			return TRUE;
+	}
+	return FALSE;
+}
+
+static void
+fwupd_jcat_item_codec_iface_init(FwupdCodecInterface *iface)
+{
+	iface->add_string = fwupd_jcat_item_add_string;
+	iface->add_json = fwupd_jcat_item_add_json;
+	iface->from_json = fwupd_jcat_item_from_json;
+}
+
+static void
+fwupd_jcat_item_finalize(GObject *obj)
+{
+	FwupdJcatItem *self = FWUPD_JCAT_ITEM(obj);
+	g_free(self->id);
+	if (self->blobs != NULL)
+		g_ptr_array_unref(self->blobs);
+	if (self->alias_ids != NULL)
+		g_ptr_array_unref(self->alias_ids);
+	G_OBJECT_CLASS(fwupd_jcat_item_parent_class)->finalize(obj);
+}
+
+static void
+fwupd_jcat_item_class_init(FwupdJcatItemClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->finalize = fwupd_jcat_item_finalize;
+}
+
+static void
+fwupd_jcat_item_init(FwupdJcatItem *self)
+{
+	self->blobs = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	self->alias_ids = g_ptr_array_new_with_free_func(g_free);
+}
+
+/**
+ * fwupd_jcat_item_new:
+ * @id: (not nullable): An item ID, typically a file basename
+ *
+ * Creates a new item.
+ *
+ * Returns: a #FwupdJcatItem
+ *
+ * Since: 2.1.3
+ **/
+FwupdJcatItem *
+fwupd_jcat_item_new(const gchar *id)
+{
+	g_autoptr(FwupdJcatItem) self = g_object_new(FWUPD_TYPE_JCAT_ITEM, NULL);
+	g_return_val_if_fail(id != NULL, NULL);
+	self->id = g_strdup(id);
+	return g_steal_pointer(&self);
+}

--- a/libfwupd/fwupd-jcat-item.h
+++ b/libfwupd/fwupd-jcat-item.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include "fwupd-jcat-blob.h"
+
+G_BEGIN_DECLS
+
+#define FWUPD_TYPE_JCAT_ITEM (fwupd_jcat_item_get_type())
+
+G_DECLARE_FINAL_TYPE(FwupdJcatItem, fwupd_jcat_item, FWUPD, JCAT_ITEM, GObject)
+
+FwupdJcatItem *
+fwupd_jcat_item_new(const gchar *id);
+GPtrArray *
+fwupd_jcat_item_get_blobs(FwupdJcatItem *self) G_GNUC_NON_NULL(1);
+GPtrArray *
+fwupd_jcat_item_get_blobs_by_kind(FwupdJcatItem *self, FwupdJcatBlobKind kind) G_GNUC_NON_NULL(1);
+FwupdJcatBlob *
+fwupd_jcat_item_get_blob_by_kind(FwupdJcatItem *self, FwupdJcatBlobKind kind, GError **error)
+    G_GNUC_NON_NULL(1);
+void
+fwupd_jcat_item_add_blob(FwupdJcatItem *self, FwupdJcatBlob *blob) G_GNUC_NON_NULL(1, 2);
+const gchar *
+fwupd_jcat_item_get_id(FwupdJcatItem *self) G_GNUC_NON_NULL(1);
+const gchar *
+fwupd_jcat_item_get_id_safe(FwupdJcatItem *self, GError **error) G_GNUC_NON_NULL(1);
+void
+fwupd_jcat_item_add_alias_id(FwupdJcatItem *self, const gchar *id) G_GNUC_NON_NULL(1, 2);
+void
+fwupd_jcat_item_remove_alias_id(FwupdJcatItem *self, const gchar *id) G_GNUC_NON_NULL(1, 2);
+GPtrArray *
+fwupd_jcat_item_get_alias_ids(FwupdJcatItem *self) G_GNUC_NON_NULL(1);
+gboolean
+fwupd_jcat_item_has_target(FwupdJcatItem *self) G_GNUC_NON_NULL(1);
+
+G_END_DECLS

--- a/libfwupd/fwupd-jcat-test.c
+++ b/libfwupd/fwupd-jcat-test.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fwupd-codec.h"
+#include "fwupd-error.h"
+#include "fwupd-jcat-blob.h"
+#include "fwupd-jcat-file.h"
+#include "fwupd-jcat-item.h"
+#include "fwupd-test.h"
+
+static void
+fwupd_jcat_blob_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *str = NULL;
+	g_autoptr(FwupdJcatBlob) blob = NULL;
+	g_autoptr(GError) error = NULL;
+	const gchar *str_perfect = "FwupdJcatBlob:\n"
+				   "  Kind:                 gpg\n"
+				   "  Target:               sha256\n"
+				   "  Flags:                is-utf8\n"
+				   "  Timestamp:            1970-01-01T03:25:45Z\n"
+				   "  Size:                 0x5\n"
+				   "  Data:                 BEGIN\n";
+
+	/* enums */
+	for (guint i = FWUPD_JCAT_BLOB_KIND_UNKNOWN + 1; i < FWUPD_JCAT_BLOB_KIND_LAST; i++) {
+		const gchar *tmp = fwupd_jcat_blob_kind_to_string(i);
+		g_assert_nonnull(tmp);
+		g_assert_cmpint(fwupd_jcat_blob_kind_from_string(tmp), ==, i);
+	}
+
+	/* sanity check */
+	blob = fwupd_jcat_blob_new_utf8(FWUPD_JCAT_BLOB_KIND_GPG, "BEGIN");
+	g_assert_cmpint(fwupd_jcat_blob_get_kind(blob), ==, FWUPD_JCAT_BLOB_KIND_GPG);
+	g_assert_nonnull(fwupd_jcat_blob_get_data(blob));
+	fwupd_jcat_blob_set_timestamp(blob, 12345);
+	g_assert_cmpint(fwupd_jcat_blob_get_timestamp(blob), ==, 12345);
+	fwupd_jcat_blob_set_target(blob, FWUPD_JCAT_BLOB_KIND_SHA256);
+	g_assert_cmpint(fwupd_jcat_blob_get_target(blob), ==, FWUPD_JCAT_BLOB_KIND_SHA256);
+
+	/* to string */
+	str = fwupd_codec_to_string(FWUPD_CODEC(blob));
+	g_debug("%s", str);
+	ret = fu_test_compare_lines(str, str_perfect, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fwupd_jcat_item_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *str = NULL;
+	g_autoptr(FwupdJcatItem) item = NULL;
+	g_autoptr(GError) error = NULL;
+	const gchar *str_perfect = "FwupdJcatItem:\n"
+				   "  ID:                   filename.bin\n"
+				   "  AliasId:              foo.bin\n";
+
+	/* sanity check */
+	item = fwupd_jcat_item_new("filename.bin");
+	fwupd_jcat_item_add_alias_id(item, "foo.bin");
+	fwupd_jcat_item_add_alias_id(item, "bar.bin");
+	fwupd_jcat_item_remove_alias_id(item, "bar.bin");
+	g_assert_cmpstr(fwupd_jcat_item_get_id(item), ==, "filename.bin");
+
+	/* to string */
+	str = fwupd_codec_to_string(FWUPD_CODEC(item));
+	g_debug("%s", str);
+	ret = fu_test_compare_lines(str, str_perfect, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fwupd_jcat_file_json_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *json1 = NULL;
+	g_autofree gchar *json2 = NULL;
+	g_autofree gchar *str = NULL;
+	g_autoptr(FwupdJcatFile) file1 = fwupd_jcat_file_new();
+	g_autoptr(FwupdJcatFile) file2 = fwupd_jcat_file_new();
+	g_autoptr(GError) error = NULL;
+
+	json1 = fwupd_jcat_file_export_json(file1, FWUPD_CODEC_FLAG_NO_TIMESTAMP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(json1);
+
+	ret = fwupd_jcat_file_import_json(file2, json1, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	str = fwupd_codec_to_string(FWUPD_CODEC(file2));
+	g_debug("%s", str);
+	json2 = fwupd_jcat_file_export_json(file2, FWUPD_CODEC_FLAG_NO_TIMESTAMP, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(json2);
+
+	ret = fu_test_compare_lines(json1, json2, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+static void
+fwupd_jcat_file_func(void)
+{
+	gboolean ret;
+	g_autofree gchar *json1 = NULL;
+	g_autofree gchar *json2 = NULL;
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GBytes) data = g_bytes_new("hello world", 12);
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GPtrArray) blobs0 = NULL;
+	g_autoptr(GPtrArray) blobs1 = NULL;
+	g_autoptr(GPtrArray) blobs2 = NULL;
+	g_autoptr(GPtrArray) blobs3 = NULL;
+	g_autoptr(GPtrArray) items0 = NULL;
+	g_autoptr(GPtrArray) items1 = NULL;
+	g_autoptr(FwupdJcatBlob) blob1 = NULL;
+	g_autoptr(FwupdJcatBlob) blob2 = NULL;
+	g_autoptr(FwupdJcatFile) file2 = fwupd_jcat_file_new();
+	g_autoptr(FwupdJcatFile) file = fwupd_jcat_file_new();
+	g_autoptr(FwupdJcatItem) item1 = NULL;
+	g_autoptr(FwupdJcatItem) item2 = NULL;
+	g_autoptr(FwupdJcatItem) item3 = NULL;
+	g_autoptr(FwupdJcatItem) item4 = NULL;
+	g_autoptr(FwupdJcatItem) item = fwupd_jcat_item_new("firmware.bin");
+	const gchar *json_perfect = "{\n"
+				    "  \"JcatVersionMajor\": 0,\n"
+				    "  \"JcatVersionMinor\": 1,\n"
+				    "  \"Items\": [\n"
+				    "    {\n"
+				    "      \"Id\": \"firmware.bin\",\n"
+				    "      \"AliasIds\": [\n"
+				    "        \"foo.bin\"\n"
+				    "      ],\n"
+				    "      \"Blobs\": [\n"
+				    "        {\n"
+				    "          \"Kind\": 2,\n"
+				    "          \"Flags\": 1,\n"
+				    "          \"Data\": \"BEGIN\"\n"
+				    "        },\n"
+				    "        {\n"
+				    "          \"Kind\": 1,\n"
+				    "          \"Flags\": 0,\n"
+				    "          \"Data\": \"aGVsbG8gd29ybGQA\"\n"
+				    "        }\n"
+				    "      ]\n"
+				    "    }\n"
+				    "  ]\n"
+				    "}";
+
+	/* check blob */
+	blob2 = fwupd_jcat_blob_new(FWUPD_JCAT_BLOB_KIND_SHA256, data, FWUPD_JCAT_BLOB_FLAG_NONE);
+	g_assert(fwupd_jcat_blob_get_data(blob2) == data); /* nocheck:blocked */
+	blob1 = fwupd_jcat_blob_new_utf8(FWUPD_JCAT_BLOB_KIND_GPG, "BEGIN");
+	fwupd_jcat_blob_set_timestamp(blob1, 0);
+	g_assert_cmpint(fwupd_jcat_blob_get_timestamp(blob1), ==, 0);
+	fwupd_jcat_blob_set_timestamp(blob2, 0);
+	g_assert_cmpint(fwupd_jcat_blob_get_timestamp(blob2), ==, 0);
+
+	/* get default item */
+	item4 = fwupd_jcat_file_get_item_default(file, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_null(item4);
+	g_clear_error(&error);
+
+	/* check item */
+	g_assert_cmpstr(fwupd_jcat_item_get_id(item), ==, "firmware.bin");
+	blobs0 = fwupd_jcat_item_get_blobs(item);
+	g_assert_cmpint(blobs0->len, ==, 0);
+	fwupd_jcat_item_add_blob(item, blob1);
+	fwupd_jcat_item_add_blob(item, blob2);
+	fwupd_jcat_item_add_alias_id(item, "foo.bin");
+	blobs1 = fwupd_jcat_item_get_blobs(item);
+	g_assert_cmpint(blobs1->len, ==, 2);
+	blobs2 = fwupd_jcat_item_get_blobs_by_kind(item, FWUPD_JCAT_BLOB_KIND_GPG);
+	g_assert_cmpint(blobs2->len, ==, 1);
+	blobs3 = fwupd_jcat_item_get_blobs_by_kind(item, FWUPD_JCAT_BLOB_KIND_PKCS7);
+	g_assert_cmpint(blobs3->len, ==, 0);
+
+	/* check file */
+	g_assert_cmpint(fwupd_jcat_file_get_version_major(file), ==, 0);
+	g_assert_cmpint(fwupd_jcat_file_get_version_minor(file), ==, 1);
+	items0 = fwupd_jcat_file_get_items(file);
+	g_assert_cmpint(items0->len, ==, 0);
+	fwupd_jcat_file_add_item(file, item);
+	items1 = fwupd_jcat_file_get_items(file);
+	g_assert_cmpint(items1->len, ==, 1);
+	item1 = fwupd_jcat_file_get_item_by_id(file, "firmware.bin", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(item1);
+	g_assert(item == item1);
+	item2 = fwupd_jcat_file_get_item_by_id(file, "dave.bin", &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_null(item2);
+	g_clear_error(&error);
+
+	/* get default item */
+	item3 = fwupd_jcat_file_get_item_default(file, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(item3);
+
+	/* export as string */
+	json1 = fwupd_jcat_file_export_json(file, FWUPD_CODEC_FLAG_NO_TIMESTAMP, &error);
+	g_debug("%s", json1);
+	ret = fu_test_compare_lines(json1, json_perfect, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* export as compressed file */
+	blob = fwupd_jcat_file_export_bytes(file, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob);
+
+	/* load compressed file */
+	ret = fwupd_jcat_file_import_bytes(file2, blob, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	json2 = fwupd_jcat_file_export_json(file2, FWUPD_CODEC_FLAG_NO_TIMESTAMP, &error);
+	g_debug("%s", json2);
+	ret = fu_test_compare_lines(json1, json2, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/jcat/blob", fwupd_jcat_blob_func);
+	g_test_add_func("/fwupd/jcat/item", fwupd_jcat_item_func);
+	g_test_add_func("/fwupd/jcat/file", fwupd_jcat_file_func);
+	g_test_add_func("/fwupd/jcat/file/json", fwupd_jcat_file_json_func);
+	return g_test_run();
+}

--- a/libfwupd/fwupd-jcat.rs
+++ b/libfwupd/fwupd-jcat.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 Richard Hughes <richard@hughsie.com>
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Since: 2.1.3
+#[derive(ToString, FromString)]
+enum FwupdJcatBlobKind {
+    Unknown,
+    Sha256,
+    Gpg,
+    Pkcs7,
+    Sha1,
+    BtManifest,
+    BtCheckpoint,
+    BtInclusionProof,
+    BtVerifier,
+    Ed25519,
+    Sha512,
+    BtLogindex,
+}
+
+// Since: 2.1.3
+#[derive(ToString)]
+enum FwupdJcatBlobMethod {
+    Unknown,
+    Checksum,
+    Signature,
+}
+
+// Since: 2.1.3
+#[derive(ToString)]
+enum FwupdJcatBlobFlags {
+    None = 0,
+    IsUtf8 = 1 << 0,
+}

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -7,12 +7,13 @@
 #include "config.h"
 
 #include <curl/curl.h>
-#include <jcat.h>
 
 #include "fwupd-codec.h"
 #include "fwupd-common-private.h"
 #include "fwupd-enums-private.h"
 #include "fwupd-error.h"
+#include "fwupd-jcat-blob.h"
+#include "fwupd-jcat-file.h"
 #include "fwupd-remote-private.h"
 
 /**
@@ -1411,74 +1412,36 @@ fwupd_remote_get_metadata_uri(FwupdRemote *self)
 	return priv->metadata_uri;
 }
 
-/**
- * fwupd_remote_jcat_item_get_id_safe:
- * @jcat_item: a #JcatItem
- * @error: (nullable): optional return location for an error
- *
- * Returns the item ID, if safe to use as a path.
- *
- * Returns: string
- **/
-static const gchar *
-fwupd_remote_jcat_item_get_id_safe(JcatItem *jcat_item, GError **error)
-{
-	const gchar *id;
-	g_autofree gchar *id_basename = NULL;
-
-	g_return_val_if_fail(JCAT_IS_ITEM(jcat_item), NULL);
-	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
-
-	/* sanity check */
-	id = jcat_item_get_id(jcat_item);
-	if (id == NULL || id[0] == '\0') {
-		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE, "ID not set");
-		return NULL;
-	}
-
-	/* verify there is no path component */
-	id_basename = g_path_get_basename(id);
-	if (g_strcmp0(id, id_basename) != 0 || g_strcmp0(id_basename, G_DIR_SEPARATOR_S) == 0 ||
-	    g_strcmp0(id_basename, "..") == 0 || g_strcmp0(id_basename, ".") == 0) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "ID cannot contain path components");
-		return NULL;
-	}
-
-	/* success */
-	return id;
-}
-
 static gboolean
-fwupd_remote_load_signature_jcat(FwupdRemote *self, JcatFile *jcat_file, GError **error)
+fwupd_remote_load_signature_jcat(FwupdRemote *self, FwupdJcatFile *jcat_file, GError **error)
 {
 	FwupdRemotePrivate *priv = GET_PRIVATE(self);
 	const gchar *id;
+	g_autofree gchar *id_basename = NULL;
 	g_autofree gchar *basename = NULL;
 	g_autofree gchar *baseuri = NULL;
 	g_autofree gchar *metadata_uri = NULL;
 	g_autoptr(GPtrArray) jcat_blobs = NULL;
-	g_autoptr(JcatItem) jcat_item = NULL;
+	g_autoptr(FwupdJcatItem) jcat_item = NULL;
 
 	/* this seems pointless to get the item by ID then just read the ID,
 	 * but _get_item_by_id() uses the AliasIds as a fallback */
 	basename = g_path_get_basename(priv->metadata_uri);
-	jcat_item = jcat_file_get_item_by_id(jcat_file, basename, NULL);
+	jcat_item = fwupd_jcat_file_get_item_by_id(jcat_file, basename, NULL);
 	if (jcat_item == NULL) {
 		/* if we're using libjcat 0.1.0 just get the default item */
-		jcat_item = jcat_file_get_item_default(jcat_file, error);
+		jcat_item = fwupd_jcat_file_get_item_default(jcat_file, error);
 		if (jcat_item == NULL)
 			return FALSE;
 	}
-	id = fwupd_remote_jcat_item_get_id_safe(jcat_item, error);
+	id = fwupd_jcat_item_get_id_safe(jcat_item, error);
 	if (id == NULL)
 		return FALSE;
 
 	/* replace the URI if required */
 	baseuri = g_path_get_dirname(priv->metadata_uri);
-	metadata_uri = g_build_path("/", baseuri, id, NULL);
+	id_basename = g_path_get_basename(id);
+	metadata_uri = g_build_path("/", baseuri, id_basename, NULL);
 	if (g_strcmp0(metadata_uri, priv->metadata_uri) != 0) {
 		g_info("changing metadata URI from %s to %s", priv->metadata_uri, metadata_uri);
 		g_free(priv->metadata_uri);
@@ -1486,10 +1449,10 @@ fwupd_remote_load_signature_jcat(FwupdRemote *self, JcatFile *jcat_file, GError 
 	}
 
 	/* look for the metadata hash */
-	jcat_blobs = jcat_item_get_blobs_by_kind(jcat_item, JCAT_BLOB_KIND_SHA256);
+	jcat_blobs = fwupd_jcat_item_get_blobs_by_kind(jcat_item, FWUPD_JCAT_BLOB_KIND_SHA256);
 	if (jcat_blobs->len >= 1) {
-		JcatBlob *blob = g_ptr_array_index(jcat_blobs, 0);
-		g_autofree gchar *hash = jcat_blob_get_data_as_string(blob);
+		FwupdJcatBlob *blob = g_ptr_array_index(jcat_blobs, 0);
+		g_autofree gchar *hash = fwupd_jcat_blob_get_data_as_string(blob);
 		fwupd_remote_set_checksum_sig_metadata(self, hash);
 	}
 
@@ -1512,15 +1475,13 @@ fwupd_remote_load_signature_jcat(FwupdRemote *self, JcatFile *jcat_file, GError 
 gboolean
 fwupd_remote_load_signature_bytes(FwupdRemote *self, GBytes *bytes, GError **error)
 {
-	g_autoptr(GInputStream) istr = NULL;
-	g_autoptr(JcatFile) jcat_file = jcat_file_new();
+	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
 
 	g_return_val_if_fail(FWUPD_IS_REMOTE(self), FALSE);
 	g_return_val_if_fail(bytes != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	istr = g_memory_input_stream_new_from_bytes(bytes);
-	if (!jcat_file_import_stream(jcat_file, istr, JCAT_IMPORT_FLAG_NONE, NULL, error))
+	if (!fwupd_jcat_file_import_bytes(jcat_file, bytes, error))
 		return FALSE;
 	return fwupd_remote_load_signature_jcat(self, jcat_file, error);
 }
@@ -1541,7 +1502,8 @@ gboolean
 fwupd_remote_load_signature(FwupdRemote *self, const gchar *filename, GError **error)
 {
 	g_autoptr(GFile) gfile = NULL;
-	g_autoptr(JcatFile) jcat_file = jcat_file_new();
+	g_autoptr(GInputStream) istream = NULL;
+	g_autoptr(FwupdJcatFile) jcat_file = fwupd_jcat_file_new();
 
 	g_return_val_if_fail(FWUPD_IS_REMOTE(self), FALSE);
 	g_return_val_if_fail(filename != NULL, FALSE);
@@ -1549,10 +1511,11 @@ fwupd_remote_load_signature(FwupdRemote *self, const gchar *filename, GError **e
 
 	/* load JCat file */
 	gfile = g_file_new_for_path(filename);
-	if (!jcat_file_import_file(jcat_file, gfile, JCAT_IMPORT_FLAG_NONE, NULL, error)) {
-		fwupd_error_convert(error);
+	istream = G_INPUT_STREAM(g_file_read(gfile, NULL, error));
+	if (istream == NULL)
 		return FALSE;
-	}
+	if (!fwupd_jcat_file_import_stream(jcat_file, istream, error))
+		return FALSE;
 	return fwupd_remote_load_signature_jcat(self, jcat_file, error);
 }
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -1133,3 +1133,47 @@ LIBFWUPD_2.1.2 {
     fwupd_device_set_version_highest_raw;
   local: *;
 } LIBFWUPD_2.1.1;
+
+LIBFWUPD_2.1.3 {
+  global:
+    fwupd_jcat_blob_flags_to_string;
+    fwupd_jcat_blob_get_data;
+    fwupd_jcat_blob_get_data_as_string;
+    fwupd_jcat_blob_get_kind;
+    fwupd_jcat_blob_get_target;
+    fwupd_jcat_blob_get_timestamp;
+    fwupd_jcat_blob_get_type;
+    fwupd_jcat_blob_kind_from_string;
+    fwupd_jcat_blob_kind_to_string;
+    fwupd_jcat_blob_method_to_string;
+    fwupd_jcat_blob_new;
+    fwupd_jcat_blob_new_utf8;
+    fwupd_jcat_blob_set_target;
+    fwupd_jcat_blob_set_timestamp;
+    fwupd_jcat_file_add_item;
+    fwupd_jcat_file_export_bytes;
+    fwupd_jcat_file_export_json;
+    fwupd_jcat_file_get_item_by_id;
+    fwupd_jcat_file_get_item_default;
+    fwupd_jcat_file_get_items;
+    fwupd_jcat_file_get_type;
+    fwupd_jcat_file_get_version_major;
+    fwupd_jcat_file_get_version_minor;
+    fwupd_jcat_file_import_bytes;
+    fwupd_jcat_file_import_json;
+    fwupd_jcat_file_import_stream;
+    fwupd_jcat_file_new;
+    fwupd_jcat_item_add_alias_id;
+    fwupd_jcat_item_add_blob;
+    fwupd_jcat_item_get_alias_ids;
+    fwupd_jcat_item_get_blob_by_kind;
+    fwupd_jcat_item_get_blobs;
+    fwupd_jcat_item_get_blobs_by_kind;
+    fwupd_jcat_item_get_id;
+    fwupd_jcat_item_get_id_safe;
+    fwupd_jcat_item_get_type;
+    fwupd_jcat_item_has_target;
+    fwupd_jcat_item_new;
+    fwupd_jcat_item_remove_alias_id;
+  local: *;
+} LIBFWUPD_2.1.2;

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -17,6 +17,7 @@ fwupd_structs = [
   'fwupd-device.rs', # fuzzing
   'fwupd-enums.rs', # fuzzing
   'fwupd-error.rs', # fuzzing
+  'fwupd-jcat.rs', # fuzzing
   'fwupd-json.rs', # fuzzing
   'fwupd-plugin.rs', # fuzzing
   'fwupd-release.rs', # fuzzing
@@ -93,7 +94,7 @@ install_headers(
   subdir: join_paths(base_dir, 'libfwupd'),
 )
 
-libfwupd_deps = [giounix, libjcat, libcurl]
+libfwupd_deps = [gio, giounix, libcurl]
 
 libfwupd_src = [
   'fwupd-client.c',
@@ -103,6 +104,9 @@ libfwupd_src = [
   'fwupd-device.c', # fuzzing
   'fwupd-error.c', # fuzzing
   'fwupd-bios-setting.c', # fuzzing
+  'fwupd-jcat-blob.c', # fuzzing
+  'fwupd-jcat-file.c', # fuzzing
+  'fwupd-jcat-item.c', # fuzzing
   'fwupd-json-array.c', # fuzzing
   'fwupd-json-common.c', # fuzzing
   'fwupd-json-node.c', # fuzzing
@@ -184,6 +188,12 @@ if introspection.allowed()
       'fwupd-error.h',
       'fwupd-bios-setting.c',
       'fwupd-bios-setting.h',
+      'fwupd-jcat-blob.c',
+      'fwupd-jcat-blob.h',
+      'fwupd-jcat-file.c',
+      'fwupd-jcat-file.h',
+      'fwupd-jcat-item.c',
+      'fwupd-jcat-item.h',
       'fwupd-json-array.c',
       'fwupd-json-array.h',
       'fwupd-json-common.c',
@@ -270,6 +280,7 @@ if get_option('tests')
     'common',
     'device',
     'enums',
+    'jcat',
     'json',
     'plugin',
     'release',


### PR DESCRIPTION
Thie means fwupdmgr (and other tools using libfwupd) no longer depend on libjcat, which in turn depends on libassuan, libgpg-error, libgpgme and libjson-glib.

The small amount of code in FwupdRemote that loads the Jcat file does not actually do any cryptographic operations; it only needs to decompress the blob and find out the name of the signature file contained so it knows what to download.

Longer term we could merge in the JcatEngines into to avoid depending on libjcat there too.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
