### PR TITLE
trivial: fix SCANBUILD env variable

### DIFF
--- a/contrib/ci/Dockerfile-debian-tartan.in
+++ b/contrib/ci/Dockerfile-debian-tartan.in
@@ -31,5 +31,5 @@ RUN set -euxo pipefail; \
     ninja -vC build install; \
     tartan-build --help
 WORKDIR /github/workspace
-ENV SCANBUILD=./contrib/tartan.sh
+ENV SCANBUILD=/github/workspace/contrib/tartan.sh
 CMD sh -euxc 'meson setup build && ninja -C build scan-build'


### PR DESCRIPTION
Use an absolute path here because the relative doesn't work when switching into the build directory.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
