### PR TITLE
trivial: specify tartan plugin location

### DIFF
--- a/contrib/tartan.sh
+++ b/contrib/tartan.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
+set -eu
+
+plugin=/usr/lib64/tartan/18.1/libtartan.so
+[ -f "$plugin" ] || plugin="$(systemd-path system-library-arch)/tartan/18.1/libtartan.so"
+[ -f "$plugin" ] || {
+    echo "failed to find tartan plugin" 1>&2
+    exit 1
+}
+
 /usr/bin/scan-build-18 \
-    -load-plugin /usr/lib64/tartan/18.1/libtartan.so \
+    -load-plugin "$plugin" \
     -disable-checker core.CallAndMessage \
     -disable-checker core.NullDereference \
     -disable-checker deadcode.DeadStores \


### PR DESCRIPTION
Seems that there is no existing logic in tartan for Debian-style multiarch locations, so we have to specify this manually.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
