### PR TITLE
android-boot: Add additional ABL A and B entries for SHIFTphone 8

### DIFF
--- a/plugins/android-boot/android-boot.quirk
+++ b/plugins/android-boot/android-boot.quirk
@@ -31,8 +31,20 @@ Vendor = SHIFT
 VendorId = DRIVE:SHIFT
 AndroidBootVersionProperty = androidboot.abl.revision
 
+[DRIVE\UUID_18b70f04-4bd9-16ac-4397-036c8411526b&LABEL_abl-a]
+Flags = updatable,signed-payload
+Vendor = SHIFT
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision
+
 # SHIFTphone 8 ABL B
 [DRIVE\UUID_584e4f5f-6023-f6d6-eb3f-48bb7da59feb&LABEL_abl-b]
+Flags = updatable,signed-payload
+Vendor = SHIFT
+VendorId = DRIVE:SHIFT
+AndroidBootVersionProperty = androidboot.abl.revision
+
+[DRIVE\UUID_08eee555-61cc-7b82-a313-bbc64f941dab&LABEL_abl-b]
 Flags = updatable,signed-payload
 Vendor = SHIFT
 VendorId = DRIVE:SHIFT


### PR DESCRIPTION
`udisksctl info -b /dev/disk/by-partlabel/abl_a`

```
  org.freedesktop.UDisks2.Partition:
    Flags:              1188668826649100288
    IsContained:        false
    IsContainer:        false
    Name:               abl_a
    Number:             8
    Offset:             285761536
    Size:               1048576
    Table:              '/org/freedesktop/UDisks2/block_devices/sde'
    Type:               bd6928a1-4ce0-a038-4f3a-1495e3eddffb
    UUID:               18b70f04-4bd9-16ac-4397-036c8411526b
```

`udisksctl info -b /dev/disk/by-partlabel/abl_b`

```
  org.freedesktop.UDisks2.Partition:
    Flags:              1223571723761221632
    IsContained:        false
    IsContainer:        false
    Name:               abl_b
    Number:             32
    Offset:             904208384
    Size:               1048576
    Table:              '/org/freedesktop/UDisks2/block_devices/sde'
    Type:               77036cd4-03d5-42bb-8ed1-37e5a88baa34
    UUID:               08eee555-61cc-7b82-a313-bbc64f941dab
```

-----

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
