### PR TITLE
redfish: add support for going through a proxy

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -142,6 +142,7 @@ test_modify_config_opts=(
 )
 
 redfish_modify_config_opts=(
+	'BearerToken'
 	'CACheck'
 	'IpmiDisableCreateUser'
 	'ManagerResetTimeout'

--- a/docs/fwupd.conf.md
+++ b/docs/fwupd.conf.md
@@ -311,6 +311,10 @@ The `[redfish]` section can contain the following parameters:
 
   The password to use when connecting to the Redfish service.
 
+**BearerToken={{redfish_BearerToken}}**
+
+  The bearer token to use for authenticating to the Redfish service.
+
 **CACheck={{redfish_CACheck}}**
 
   Whether to verify the server certificate or not. This is turned off by default.

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -22,6 +22,7 @@ struct _FuRedfishBackend {
 	gchar *hostname;
 	gchar *username;
 	gchar *password;
+	gchar *bearer_token;
 	gchar *session_key;
 	guint port;
 	gchar *vendor;
@@ -79,13 +80,21 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 	(void)curl_url_set(uri, CURLUPART_HOST, self->hostname, 0);
 	(void)curl_url_set(uri, CURLUPART_PORT, port, 0);
 	(void)curl_easy_setopt(curl, CURLOPT_CURLU, uri);
-
-	/* since DSP0266 makes Basic Authorization a requirement,
-	 * it is safe to use Basic Auth for all implementations */
-	(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BASIC);
 	(void)curl_easy_setopt(curl, CURLOPT_TIMEOUT, (glong)180);
-	(void)curl_easy_setopt(curl, CURLOPT_USERNAME, self->username);
-	(void)curl_easy_setopt(curl, CURLOPT_PASSWORD, self->password);
+
+	if (self->bearer_token != NULL) {
+		/* Some custom implementation require special authentication through bearer token.
+		 * Let's use that if configured to do so. */
+		(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BEARER);
+		(void)curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, self->bearer_token);
+	} else {
+		/* Here is the common auth scenario, when no specific bearer token is configured.
+		 * since DSP0266 makes Basic Authorization a requirement,
+		 * it is safe to use Basic Auth for all implementations */
+		(void)curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (glong)CURLAUTH_BASIC);
+		(void)curl_easy_setopt(curl, CURLOPT_USERNAME, self->username);
+		(void)curl_easy_setopt(curl, CURLOPT_PASSWORD, self->password);
+	}
 
 	/* setup networking */
 	user_agent = g_strdup_printf("%s/%s", PACKAGE_NAME, PACKAGE_VERSION);
@@ -609,6 +618,13 @@ fu_redfish_backend_set_password(FuRedfishBackend *self, const gchar *password)
 	self->password = g_strdup(password);
 }
 
+void
+fu_redfish_backend_set_bearer_token(FuRedfishBackend *self, const gchar *bearer_token)
+{
+	g_free(self->bearer_token);
+	self->bearer_token = g_strdup(bearer_token);
+}
+
 const gchar *
 fu_redfish_backend_get_push_uri_path(FuRedfishBackend *self)
 {
@@ -628,6 +644,7 @@ fu_redfish_backend_to_string(FuBackend *backend, guint idt, GString *str)
 	fwupd_codec_string_append(str, idt, "Hostname", self->hostname);
 	fwupd_codec_string_append(str, idt, "Username", self->username);
 	fwupd_codec_string_append_bool(str, idt, "Password", self->password != NULL);
+	fwupd_codec_string_append_bool(str, idt, "BearerToken", self->bearer_token != NULL);
 	fwupd_codec_string_append(str, idt, "SessionKey", self->session_key);
 	fwupd_codec_string_append_int(str, idt, "Port", self->port);
 	fwupd_codec_string_append(str, idt, "UpdateUriPath", self->update_uri_path);
@@ -651,6 +668,7 @@ fu_redfish_backend_finalize(GObject *object)
 	g_free(self->hostname);
 	g_free(self->username);
 	g_free(self->password);
+	g_free(self->bearer_token);
 	g_free(self->session_key);
 	g_free(self->vendor);
 	g_free(self->version);

--- a/plugins/redfish/fu-redfish-backend.c
+++ b/plugins/redfish/fu-redfish-backend.c
@@ -30,6 +30,7 @@ struct _FuRedfishBackend {
 	gchar *uuid;
 	gchar *update_uri_path;
 	gchar *push_uri_path;
+	gchar *path_prefix;
 	gboolean use_https;
 	gboolean cacheck;
 	gboolean wildcard_targets;
@@ -72,6 +73,8 @@ fu_redfish_backend_request_new(FuRedfishBackend *self)
 	/* set the cache location */
 	fu_redfish_request_set_cache(request, self->request_cache);
 	fu_redfish_request_set_curlsh(request, self->curlsh);
+	if (self->path_prefix != NULL)
+		fu_redfish_request_set_path_prefix(request, self->path_prefix);
 
 	/* set up defaults */
 	curl = fu_redfish_request_get_curl(request);
@@ -295,6 +298,13 @@ fu_redfish_backend_set_push_uri_path(FuRedfishBackend *self, const gchar *push_u
 {
 	g_free(self->push_uri_path);
 	self->push_uri_path = g_strdup(push_uri_path);
+}
+
+void
+fu_redfish_backend_set_path_prefix(FuRedfishBackend *self, const gchar *path_prefix)
+{
+	g_free(self->path_prefix);
+	self->path_prefix = g_strdup(path_prefix);
 }
 
 static gboolean
@@ -649,6 +659,8 @@ fu_redfish_backend_to_string(FuBackend *backend, guint idt, GString *str)
 	fwupd_codec_string_append_int(str, idt, "Port", self->port);
 	fwupd_codec_string_append(str, idt, "UpdateUriPath", self->update_uri_path);
 	fwupd_codec_string_append(str, idt, "PushUriPath", self->push_uri_path);
+	if (self->path_prefix != NULL)
+		fwupd_codec_string_append(str, idt, "PathPrefix", self->path_prefix);
 	fwupd_codec_string_append_bool(str, idt, "UseHttps", self->use_https);
 	fwupd_codec_string_append_bool(str, idt, "Cacheck", self->cacheck);
 	fwupd_codec_string_append_bool(str, idt, "WildcardTargets", self->wildcard_targets);
@@ -665,6 +677,7 @@ fu_redfish_backend_finalize(GObject *object)
 	curl_share_cleanup(self->curlsh);
 	g_free(self->update_uri_path);
 	g_free(self->push_uri_path);
+	g_free(self->path_prefix);
 	g_free(self->hostname);
 	g_free(self->username);
 	g_free(self->password);

--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -31,6 +31,8 @@ fu_redfish_backend_get_username(FuRedfishBackend *self);
 void
 fu_redfish_backend_set_password(FuRedfishBackend *self, const gchar *password);
 void
+fu_redfish_backend_set_bearer_token(FuRedfishBackend *self, const gchar *bearer_token);
+void
 fu_redfish_backend_set_port(FuRedfishBackend *self, guint port);
 void
 fu_redfish_backend_set_https(FuRedfishBackend *self, gboolean use_https);

--- a/plugins/redfish/fu-redfish-backend.h
+++ b/plugins/redfish/fu-redfish-backend.h
@@ -40,6 +40,8 @@ void
 fu_redfish_backend_set_cacheck(FuRedfishBackend *self, gboolean cacheck);
 void
 fu_redfish_backend_set_wildcard_targets(FuRedfishBackend *self, gboolean wildcard_targets);
+void
+fu_redfish_backend_set_path_prefix(FuRedfishBackend *self, const gchar *path_prefix);
 const gchar *
 fu_redfish_backend_get_push_uri_path(FuRedfishBackend *self);
 const gchar *

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -453,6 +453,7 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 	if (redfish_uri != NULL) {
 		const gchar *ip_str = NULL;
 		g_auto(GStrv) split = NULL;
+		g_auto(GStrv) split_prefix = NULL;
 		guint64 port = 0;
 
 		if (g_str_has_prefix(redfish_uri, "https://")) {
@@ -469,6 +470,13 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 					    FWUPD_ERROR_NOT_SUPPORTED,
 					    "invalid scheme");
 			return FALSE;
+		}
+
+		/* if our uri contains a /, split it between host:port and path_prefix */
+		split_prefix = g_strsplit(ip_str, "/", 2);
+		if (g_strv_length(split_prefix) > 1) {
+			ip_str = split_prefix[0];
+			fu_redfish_backend_set_path_prefix(self->backend, split_prefix[1]);
 		}
 
 		split = g_strsplit(ip_str, ":", 2);

--- a/plugins/redfish/fu-redfish-plugin.c
+++ b/plugins/redfish/fu-redfish-plugin.c
@@ -430,6 +430,7 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 	gboolean credentials_invalid = FALSE;
 #endif
 	g_autofree gchar *password = NULL;
+	g_autofree gchar *bearer_token = NULL;
 	g_autofree gchar *redfish_uri = NULL;
 	g_autofree gchar *username = NULL;
 #ifdef HAVE_LINUX_IPMI_H
@@ -496,6 +497,9 @@ fu_redfish_plugin_startup(FuPlugin *plugin, FuProgress *progress, GError **error
 	password = fu_plugin_get_config_value(plugin, "Password");
 	if (password != NULL)
 		fu_redfish_backend_set_password(self->backend, password);
+	bearer_token = fu_plugin_get_config_value(plugin, "BearerToken");
+	if (bearer_token != NULL)
+		fu_redfish_backend_set_bearer_token(self->backend, bearer_token);
 	fu_redfish_backend_set_cacheck(self->backend,
 				       fu_plugin_get_config_value_boolean(plugin, "CACheck"));
 	if (fu_context_has_hwid_flag(fu_plugin_get_context(plugin), "wildcard-targets"))
@@ -682,6 +686,7 @@ fu_redfish_plugin_modify_config(FuPlugin *plugin,
 				GError **error)
 {
 	const gchar *keys[] = {"CACheck",
+			       "BearerToken",
 			       "IpmiDisableCreateUser",
 			       "ManagerResetTimeout",
 			       "Password",
@@ -724,6 +729,7 @@ fu_redfish_plugin_constructed(GObject *obj)
 
 	/* defaults changed here will also be reflected in the fwupd.conf man page */
 	fu_plugin_set_config_default(plugin, "CACheck", "false");
+	fu_plugin_set_config_default(plugin, "BearerToken", NULL);
 	fu_plugin_set_config_default(plugin, "IpmiDisableCreateUser", "false");
 	fu_plugin_set_config_default(plugin, "ManagerResetTimeout", "1800"); /* seconds */
 	fu_plugin_set_config_default(plugin, "Password", NULL);

--- a/plugins/redfish/fu-redfish-request.c
+++ b/plugins/redfish/fu-redfish-request.c
@@ -12,6 +12,7 @@ struct _FuRedfishRequest {
 	GObject parent_instance;
 	CURL *curl;
 	CURLU *uri;
+	gchar *path_prefix;
 	GByteArray *buf;
 	glong status_code;
 	FwupdJsonParser *json_parser;
@@ -152,7 +153,12 @@ fu_redfish_request_perform(FuRedfishRequest *self,
 	}
 
 	/* do request */
-	(void)curl_url_set(self->uri, CURLUPART_PATH, path, 0);
+	if (self->path_prefix != NULL) {
+		g_autofree gchar *full_path = g_strconcat(self->path_prefix, path, NULL);
+		(void)curl_url_set(self->uri, CURLUPART_PATH, full_path, 0);
+	} else {
+		(void)curl_url_set(self->uri, CURLUPART_PATH, path, 0);
+	}
 	(void)curl_url_get(self->uri, CURLUPART_URL, &uri_str, 0);
 	res = curl_easy_perform(self->curl);
 	curl_easy_getinfo(self->curl, CURLINFO_RESPONSE_CODE, &self->status_code);
@@ -268,6 +274,14 @@ fu_redfish_request_write_cb(char *ptr, size_t size, size_t nmemb, void *userdata
 }
 
 void
+fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_prefix)
+{
+	g_return_if_fail(FU_IS_REDFISH_REQUEST(self));
+	g_free(self->path_prefix);
+	self->path_prefix = g_strdup(path_prefix);
+}
+
+void
 fu_redfish_request_set_cache(FuRedfishRequest *self, GHashTable *cache)
 {
 	g_return_if_fail(FU_IS_REDFISH_REQUEST(self));
@@ -308,6 +322,7 @@ fu_redfish_request_finalize(GObject *object)
 		g_hash_table_unref(self->cache);
 	g_object_unref(self->json_parser);
 	g_byte_array_unref(self->buf);
+	g_free(self->path_prefix);
 	curl_easy_cleanup(self->curl);
 	curl_url_cleanup(self->uri);
 	G_OBJECT_CLASS(fu_redfish_request_parent_class)->finalize(object);

--- a/plugins/redfish/fu-redfish-request.h
+++ b/plugins/redfish/fu-redfish-request.h
@@ -38,4 +38,6 @@ fu_redfish_request_get_uri(FuRedfishRequest *self);
 glong
 fu_redfish_request_get_status_code(FuRedfishRequest *self);
 void
+fu_redfish_request_set_path_prefix(FuRedfishRequest *self, const gchar *path_prefix);
+void
 fu_redfish_request_set_cache(FuRedfishRequest *self, GHashTable *cache);


### PR DESCRIPTION
At Criteo, communication to the BMC goes through a proxy which uses a bearer token for authentication and a path prefix to access the BMC.
Hook up support for setting a bearer token in the configuration and prefer it over basic auth if configured.
Tolerate URIs containing a path prefix.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
