### PR TITLE
test: cover remote empty-credentials normalization and util interesting-device branches

### DIFF
--- a/src/fu-remote-test.c
+++ b/src/fu-remote-test.c
@@ -6,6 +6,8 @@
 
 #include "config.h"
 
+#include <glib/gstdio.h>
+
 #include "fwupd-remote-private.h"
 
 #include "fu-remote.h"
@@ -228,6 +230,47 @@ fu_remote_duplicate_func(void)
 			"/tmp/fwupd-self-test/stable.xml");
 }
 
+static void
+fu_remote_empty_credentials_func(void)
+{
+	gboolean ret;
+	gint fd;
+	g_autofree gchar *fn = NULL;
+	g_autoptr(FwupdRemote) remote = fwupd_remote_new();
+	g_autoptr(GError) error = NULL;
+
+	fd = g_file_open_tmp("fwupd-remote-empty-credentials-XXXXXX", &fn, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(fd, >=, 0);
+	ret = g_close(fd, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = g_file_set_contents(fn,
+				  "[fwupd Remote]\n"
+				  "Enabled=true\n"
+				  "MetadataURI=https://example.test/firmware.xml.gz\n"
+				  "Username=\n"
+				  "Password=\n",
+				  -1,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	ret = fu_remote_load_from_filename(remote, fn, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(fwupd_remote_get_kind(remote), ==, FWUPD_REMOTE_KIND_DOWNLOAD);
+	g_assert_true(fwupd_remote_has_flag(remote, FWUPD_REMOTE_FLAG_ENABLED));
+	g_assert_cmpstr(fwupd_remote_get_metadata_uri(remote),
+			==,
+			"https://example.test/firmware.xml.gz");
+	g_assert_cmpstr(fwupd_remote_get_username(remote), ==, NULL);
+	g_assert_cmpstr(fwupd_remote_get_password(remote), ==, NULL);
+
+	g_assert_cmpint(g_unlink(fn), ==, 0);
+}
+
 /* verify we used the metadata path for firmware */
 static void
 fu_remote_nopath_func(void)
@@ -336,6 +379,7 @@ main(int argc, char **argv)
 	g_test_add_func("/fwupd/remote/no-path", fu_remote_nopath_func);
 	g_test_add_func("/fwupd/remote/local", fu_remote_local_func);
 	g_test_add_func("/fwupd/remote/duplicate", fu_remote_duplicate_func);
+	g_test_add_func("/fwupd/remote/empty-credentials", fu_remote_empty_credentials_func);
 	g_test_add_func("/fwupd/remote/auth", fu_remote_auth_func);
 	return g_test_run();
 }

--- a/src/fu-util-test.c
+++ b/src/fu-util-test.c
@@ -47,10 +47,71 @@ fu_util_func(void)
 	}
 }
 
+static void
+fu_util_interesting_device_func(void)
+{
+	struct {
+		const gchar *name;
+		FwupdDeviceFlags flags;
+		const gchar *version;
+		const gchar *update_error;
+		FwupdDeviceFlags child_flags;
+		gboolean expected;
+	} map[] = {
+	    {"updatable", FWUPD_DEVICE_FLAG_UPDATABLE, NULL, NULL, FWUPD_DEVICE_FLAG_NONE, TRUE},
+	    {"update-error",
+	     FWUPD_DEVICE_FLAG_INTERNAL,
+	     NULL,
+	     "failed",
+	     FWUPD_DEVICE_FLAG_NONE,
+	     TRUE},
+	    {"version", FWUPD_DEVICE_FLAG_INTERNAL, "1.2.3", NULL, FWUPD_DEVICE_FLAG_NONE, TRUE},
+	    {"get-details", FWUPD_DEVICE_FLAG_NONE, NULL, NULL, FWUPD_DEVICE_FLAG_NONE, TRUE},
+	    {"unrelated-flag",
+	     FWUPD_DEVICE_FLAG_INTERNAL,
+	     NULL,
+	     NULL,
+	     FWUPD_DEVICE_FLAG_NONE,
+	     FALSE},
+	    {"interesting-child",
+	     FWUPD_DEVICE_FLAG_INTERNAL,
+	     NULL,
+	     NULL,
+	     FWUPD_DEVICE_FLAG_UPDATABLE,
+	     TRUE},
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
+		g_autoptr(FwupdDevice) child = NULL;
+		g_autoptr(FwupdDevice) device = fwupd_device_new();
+		g_autoptr(GPtrArray) devices =
+		    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+
+		g_test_message("checking %s", map[i].name);
+		if (map[i].flags != FWUPD_DEVICE_FLAG_NONE)
+			fwupd_device_add_flag(device, map[i].flags);
+		if (map[i].version != NULL)
+			fwupd_device_set_version(device, map[i].version);
+		if (map[i].update_error != NULL)
+			fwupd_device_set_update_error(device, map[i].update_error);
+		g_ptr_array_add(devices, g_object_ref(device));
+
+		if (map[i].child_flags != FWUPD_DEVICE_FLAG_NONE) {
+			child = fwupd_device_new();
+			fwupd_device_add_flag(child, map[i].child_flags);
+			fwupd_device_set_parent(child, device);
+			g_ptr_array_add(devices, g_object_ref(child));
+		}
+
+		g_assert_cmpint(fu_util_is_interesting_device(devices, device), ==, map[i].expected);
+	}
+}
+
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/util", fu_util_func);
+	g_test_add_func("/fwupd/util/interesting-device", fu_util_interesting_device_func);
 	return g_test_run();
 }


### PR DESCRIPTION
## Summary

- **TGL-TC-001** (`fu-remote-test.c`): adds `/fwupd/remote/empty-credentials` to cover the documented migration path where old fwupd configs stored empty strings for `Username=` and `Password=`. The test writes a temporary keyfile with both credentials set to `""`, loads it via `fu_remote_load_from_filename()`, and asserts both are normalized to `NULL` (matching the explicit normalization at `src/fu-remote.c:153-157`).

- **TGL-TC-002** (`fu-util-test.c`): adds `/fwupd/util/interesting-device`, a table-driven test for `fu_util_is_interesting_device()` covering all six branches — updatable, update-error, version set, no-flags/get-details, unrelated nonzero flag (false case), and parent promoted by an updatable child.

## Test plan

- [ ] `meson test -C build fu-remote-test --print-errorlogs` passes with new `/fwupd/remote/empty-credentials` case
- [ ] `meson test -C build fu-util-test --print-errorlogs` passes with new `/fwupd/util/interesting-device` case
- [ ] No fixtures, snapshots, golden files, or production code changed
- [ ] `git diff --check` clean, no lines over 100 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)