### PR TITLE
test: add /fwupd/util/interesting-device test case

### DIFF
--- a/src/fu-util-test.c
+++ b/src/fu-util-test.c
@@ -47,10 +47,98 @@ fu_util_func(void)
 	}
 }
 
+static void
+fu_util_interesting_device_func(void)
+{
+	struct {
+		const gchar *name;
+		FwupdDeviceFlags flags;
+		const gchar *version;
+		const gchar *update_error;
+		FwupdDeviceFlags child_flags;
+		gboolean expected;
+	} map[] = {
+	    {
+		"updatable",
+		FWUPD_DEVICE_FLAG_UPDATABLE,
+		NULL,
+		NULL,
+		FWUPD_DEVICE_FLAG_NONE,
+		TRUE,
+	    },
+	    {
+		"update-error",
+		FWUPD_DEVICE_FLAG_INTERNAL,
+		NULL,
+		"failed",
+		FWUPD_DEVICE_FLAG_NONE,
+		TRUE,
+	    },
+	    {
+		"version",
+		FWUPD_DEVICE_FLAG_INTERNAL,
+		"1.2.3",
+		NULL,
+		FWUPD_DEVICE_FLAG_NONE,
+		TRUE,
+	    },
+	    {
+		"get-details",
+		FWUPD_DEVICE_FLAG_NONE,
+		NULL,
+		NULL,
+		FWUPD_DEVICE_FLAG_NONE,
+		TRUE,
+	    },
+	    {
+		"unrelated-flag",
+		FWUPD_DEVICE_FLAG_INTERNAL,
+		NULL,
+		NULL,
+		FWUPD_DEVICE_FLAG_NONE,
+		FALSE,
+	    },
+	    {
+		"interesting-child",
+		FWUPD_DEVICE_FLAG_INTERNAL,
+		NULL,
+		NULL,
+		FWUPD_DEVICE_FLAG_UPDATABLE,
+		TRUE,
+	    },
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(map); i++) {
+		g_autoptr(FwupdDevice) child = NULL;
+		g_autoptr(FwupdDevice) device = fwupd_device_new();
+		g_autoptr(GPtrArray) devices =
+		    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+
+		g_test_message("checking %s", map[i].name);
+		if (map[i].flags != FWUPD_DEVICE_FLAG_NONE)
+			fwupd_device_add_flag(device, map[i].flags);
+		if (map[i].version != NULL)
+			fwupd_device_set_version(device, map[i].version);
+		if (map[i].update_error != NULL)
+			fwupd_device_set_update_error(device, map[i].update_error);
+		g_ptr_array_add(devices, g_object_ref(device));
+
+		if (map[i].child_flags != FWUPD_DEVICE_FLAG_NONE) {
+			child = fwupd_device_new();
+			fwupd_device_add_flag(child, map[i].child_flags);
+			fwupd_device_set_parent(child, device);
+			g_ptr_array_add(devices, g_object_ref(child));
+		}
+
+		g_assert_cmpint(fu_util_is_interesting_device(devices, device), ==, map[i].expected);
+	}
+}
+
 int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/util", fu_util_func);
+	g_test_add_func("/fwupd/util/interesting-device", fu_util_interesting_device_func);
 	return g_test_run();
 }


### PR DESCRIPTION
Table-driven test for `fu_util_is_interesting_device()` covering all six branches:

| Case | Flags | Extra | Expected |
|---|---|---|---|
| updatable | `FWUPD_DEVICE_FLAG_UPDATABLE` | — | `TRUE` |
| update-error | `FWUPD_DEVICE_FLAG_INTERNAL` | `update_error` set | `TRUE` |
| version | `FWUPD_DEVICE_FLAG_INTERNAL` | `version` set | `TRUE` |
| get-details | none | — | `TRUE` |
| unrelated-flag | `FWUPD_DEVICE_FLAG_INTERNAL` | — | `FALSE` |
| interesting-child | `FWUPD_DEVICE_FLAG_INTERNAL` | child has `UPDATABLE` | `TRUE` |

## Test plan

- [ ] `meson test -C build fu-util-test --print-errorlogs` passes with new `/fwupd/util/interesting-device` case
- [ ] No fixtures, snapshots, or production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)