### PR TITLE
uefi-dbx: Load well-known paths in dbxtool

### DIFF
--- a/plugins/uefi-dbx/fu-dbxtool.c
+++ b/plugins/uefi-dbx/fu-dbxtool.c
@@ -192,6 +192,9 @@ main(int argc, char *argv[])
 		g_log_set_handler(G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, fu_util_ignore_cb, NULL);
 	}
 
+	/* load well-known paths into the context's path store */
+	fu_context_load_path_store(ctx);
+
 	/* override the default ESP path */
 	if (esp_path != NULL)
 		fu_context_set_esp_location(ctx, esp_path);


### PR DESCRIPTION
Without this, dbxtool -l fails with "Failed to load system dbx: no path set for sysfsdir-fw" because FuPathStore starts empty by design and the defaults are only applied via fu_context_load_path_store(), which fwupd and fwupdtool already call but dbxtool was missed.

Fixes: 69859e10b3 ("Port everything to FuPathStore")

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
