### PR TITLE
Qubes fwupdmgr allow reinstalls, workaround for PQ CA fails, fix automated tests

### DIFF
--- a/contrib/qubes/src/fwupd_receive_updates.py
+++ b/contrib/qubes/src/fwupd_receive_updates.py
@@ -42,7 +42,26 @@ class FwupdReceiveUpdates:
             self.clean_cache()
             raise ValueError(f"Computed checksum {c_sha} did NOT match {sha}.")
 
-    def _jcat_verification(self, file_path, file_directory):
+    def _jcat_verification_without_postquantum(self, verification_output):
+        """Return True e ven if the PQ CA verification fails as long as
+        at least sha256 plus one pkcs7 entry passed for the classic LVFS CA.
+        """
+        passed = set()
+        for line in verification_output.splitlines():
+            line = line.strip()
+            if line.startswith("PASSED "):
+                kind = line.split()[1].rstrip(":")
+                passed.add(kind)
+            elif line.startswith("FAILED ") and "FAILED: " not in line:
+                if "LVFS CA 2025PQ" in line and "[-89]" in line:
+                    print(
+                        "--ignore-postquantum is set, ignoring LVFS CA 2025PQ failure"
+                    )
+                    continue
+                return False
+        return "sha256" in passed and "pkcs7" in passed
+
+    def _jcat_verification(self, file_path, file_directory, ignore_postquantum=False):
         """Verifies SHA1+SHA256 checksum and PKCS#7 signature.
 
         Keyword argument:
@@ -58,14 +77,17 @@ class FwupdReceiveUpdates:
         verification = stdout.decode("utf-8")
         print(verification)
         if p.returncode != 0:
+            if ignore_postquantum and self._jcat_verification_without_postquantum(
+                verification
+            ):
+                return
             self.clean_cache()
             stderr_str = stderr.decode()
             if "SignatureNotValidYet" in stderr_str:
                 raise Exception(
                     "PGP signature creation time is in the"
                     " future (update-vm clock may be out of sync).\n"
-                    "Run /usr/bin/qvm-sync-clock to update the time.\n"
-                    + stderr_str
+                    "Run /usr/bin/qvm-sync-clock to update the time.\n" + stderr_str
                 )
             else:
                 raise Exception("jcat-tool: Verification failed")
@@ -109,7 +131,7 @@ class FwupdReceiveUpdates:
             self.arch_path = os.path.join(FWUPD_DOM0_UPDATES_DIR, filename)
             shutil.move(dom0_firmware_untrusted_path, self.arch_path)
 
-    def handle_metadata_update(self, updatevm, metadata_url):
+    def handle_metadata_update(self, updatevm, metadata_url, ignore_postquantum=False):
         """Copies metadata files from the updateVM.
 
         Keyword argument:
@@ -163,6 +185,7 @@ class FwupdReceiveUpdates:
             self._jcat_verification(
                 untrusted_metadata_file + ".jcat",
                 os.path.dirname(untrusted_metadata_file),
+                ignore_postquantum,
             )
             # verified, move into trusted dir
             shutil.move(untrusted_metadata_file, self.metadata_file)

--- a/contrib/qubes/src/fwupd_receive_updates.py
+++ b/contrib/qubes/src/fwupd_receive_updates.py
@@ -70,8 +70,14 @@ class FwupdReceiveUpdates:
         """
         assert file_path.startswith("/"), f"bad file path {file_path!r}"
         cmd_jcat = ["jcat-tool", "verify", file_path, "--public-keys", FWUPD_PKI]
+        environ = os.environ.copy()
+        environ["LC_ALL"] = "C"
         p = subprocess.Popen(
-            cmd_jcat, cwd=file_directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd_jcat,
+            cwd=file_directory,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environ,
         )
         stdout, stderr = p.communicate()
         verification = stdout.decode("utf-8")

--- a/contrib/qubes/src/fwupd_receive_updates.py
+++ b/contrib/qubes/src/fwupd_receive_updates.py
@@ -54,12 +54,21 @@ class FwupdReceiveUpdates:
         p = subprocess.Popen(
             cmd_jcat, cwd=file_directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        stdout, __ = p.communicate()
+        stdout, stderr = p.communicate()
         verification = stdout.decode("utf-8")
         print(verification)
         if p.returncode != 0:
             self.clean_cache()
-            raise Exception("jcat-tool: Verification failed")
+            stderr_str = stderr.decode()
+            if "SignatureNotValidYet" in stderr_str:
+                raise Exception(
+                    "PGP signature creation time is in the"
+                    " future (update-vm clock may be out of sync).\n"
+                    "Run /usr/bin/qvm-sync-clock to update the time.\n"
+                    + stderr_str
+                )
+            else:
+                raise Exception("jcat-tool: Verification failed")
 
     def handle_fw_update(self, updatevm, sha, filename):
         """Copies firmware update archives from the updateVM.

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -64,6 +64,7 @@ HELP = {
             "update": "Update chosen device to latest firmware version",
             "update-heads": "Updates heads firmware to the latest version (EXPERIMENTAL, not fully supported yet)",
             "downgrade": "Downgrade chosen device to chosen firmware version",
+            "install": "Install firmware: DEVICE-UUID [VERSION] or --url with --sha",
             "clean": "Delete all cached update files\n",
         }
     ],
@@ -71,7 +72,11 @@ HELP = {
         {
             "--whonix": "Download firmware updates via Tor",
             "--device": "Specify device for heads update (default - x230)",
-            "--url": "Address of the custom metadata remote server\n",
+            "--url": "Address of the firmware or metadata remote server",
+            "--sha": "SHA256 checksum of the firmware archive (required for install)",
+            "--allow-older": "Allow installing an older firmware version",
+            "--allow-reinstall": "Allow reinstalling the same firmware version",
+            "--force": "Force the firmware update even if not required\n",
         }
     ],
     "Help": [{"-h --help": "Show help options\n"}],
@@ -174,9 +179,14 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             except Exception as e:
                 print(f"Failed to refresh remote '{name}': {e}")
 
-    def _get_dom0_updates(self):
+    def _get_dom0_updates(self, allow_older=False, allow_reinstall=False):
         """Gathers information about available updates."""
-        cmd_get_dom0_updates = [FWUPDMGR, "--json", "get-updates"]
+        cmd_get_dom0_updates = [FWUPDMGR]
+        if allow_older:
+            cmd_get_dom0_updates.append("--allow-older")
+        if allow_reinstall:
+            cmd_get_dom0_updates.append("--allow-reinstall")
+        cmd_get_dom0_updates += ["--json", "get-updates"]
         p = subprocess.Popen(cmd_get_dom0_updates, stdout=subprocess.PIPE)
         self.dom0_updates_info = p.communicate()[0].decode()
         if p.returncode != 0 and p.returncode != 2:
@@ -298,18 +308,6 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 self.url = ver_check["Url"]
                 self.sha = ver_check["Checksum"]
 
-    def _install_dom0_firmware_update(self, arch_path):
-        """Installs firmware update for specified device in dom0.
-
-        Keywords arguments:
-        arch_path - absolute path to firmware update archive
-        """
-        cmd_install = [FWUPDMGR, "install", arch_path]
-        p = subprocess.Popen(cmd_install)
-        p.wait()
-        if p.returncode != 0:
-            raise Exception("fwupd-qubes: Firmware update failed")
-
     def _read_dmi(self):
         """Reads BIOS information from DMI."""
         cmd_dmidecode_version = ["dmidecode", "-s", "bios-version"]
@@ -359,14 +357,22 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if p.returncode != 0:
             raise Exception("fwupd-qubes: Getting devices info failed")
 
-    def update_firmware(self, whonix=False):
+    def update_firmware(
+        self, whonix=False, allow_older=False, allow_reinstall=False, force=False
+    ):
         """Updates firmware of the specified device.
 
         Keyword arguments:
         whonix -- Flag enforces downloading the metadata updates via Tor
+        allow_older - allow installing an older firmware version
+        allow_reinstall - allow reinstalling the same firmware version
+        force - force installation even when not required
         """
-        self._get_dom0_updates()
+        self._get_dom0_updates(allow_older=allow_older, allow_reinstall=allow_reinstall)
         self._parse_dom0_updates_info(self.dom0_updates_info)
+        self._get_dom0_updates_string_based(
+            allow_older=allow_older, allow_reinstall=allow_reinstall
+        )
         updates_list = self.dom0_updates_list
         ret_input = self._user_input(updates_list)
         if ret_input == -EXIT_CODES["NOTHING_TO_DO"]:
@@ -377,7 +383,12 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if self.name == "System Firmware":
             Path(BIOS_UPDATE_FLAG).touch(mode=0o644, exist_ok=True)
             self._verify_dmi(self.arch_path, self.version)
-        self._install_dom0_firmware_update(self.arch_path)
+        self._install_dom0_firmware(
+            self.arch_path,
+            allow_older=allow_older,
+            allow_reinstall=allow_reinstall,
+            force=force,
+        )
 
     def _parse_downgrades(self, device_list):
         """Parses information about possible downgrades.
@@ -425,6 +436,155 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         p.wait()
         if p.returncode != 0:
             raise Exception("fwupd-qubes: Firmware downgrade failed")
+
+    def _install_dom0_firmware(
+        self, arch_path, allow_older=False, allow_reinstall=False, force=False
+    ):
+        """Installs firmware archive with optional install flags.
+
+        Keywords arguments:
+        arch_path - absolute path to firmware archive
+        allow_older - pass --allow-older to fwupdmgr
+        allow_reinstall - pass --allow-reinstall to fwupdmgr
+        force - pass --force to fwupdmgr
+        """
+        cmd_install = [FWUPDMGR]
+        if allow_older:
+            cmd_install.append("--allow-older")
+        if allow_reinstall:
+            cmd_install.append("--allow-reinstall")
+        if force:
+            cmd_install.append("--force")
+        cmd_install += ["install", arch_path]
+        p = subprocess.Popen(cmd_install)
+        p.wait()
+        if p.returncode != 0:
+            sys.exit(p.returncode)
+
+    def _find_device_release(
+        self, device_id, version=None, allow_older=False, allow_reinstall=False
+    ):
+        """Look up firmware URL and SHA for a device by ID.
+
+        Keywords arguments:
+        device_id - DeviceId to identify the device
+        version - exact firmware version to install, omit for best available
+        allow_older - accept releases with a version older than current
+        allow_reinstall - accept a release at the same version as current
+        """
+        self._get_dom0_devices()
+        devices_dict = json.loads(self.dom0_devices_info)
+
+        target_device = None
+        for device in devices_dict.get("Devices", []):
+            if device.get("DeviceId") == device_id:
+                target_device = device
+                break
+        if target_device is None:
+            raise Exception(f"Device '{device_id}' not found")
+
+        current = target_device.get("Version", "0")
+        # Use the canonical DeviceId from fwupd rather than the user-supplied
+        canonical_id = target_device.get("DeviceId", device_id)
+        releases = target_device.get("Releases", [])
+
+        # get-devices may omit Releases when fwupd sees no update candidates
+        # fall back to get-releases which queries all metadata for the device
+        result = None
+        if not releases:
+            cmd_get_releases = [FWUPDMGR, "--json"]
+            if allow_older:
+                cmd_get_releases.append("--allow-older")
+            if allow_reinstall:
+                cmd_get_releases.append("--allow-reinstall")
+            cmd_get_releases += ["get-releases", "--", canonical_id]
+            result = subprocess.run(
+                cmd_get_releases,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                releases = json.loads(result.stdout.decode()).get("Releases", [])
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                releases = []
+
+        if not releases:
+            stderr_msg = (
+                result.stderr.decode(errors="replace").strip()
+                if result is not None
+                else ""
+            )
+            detail = f"\n  fwupdmgr: {stderr_msg}" if stderr_msg else ""
+            raise Exception(
+                f"No releases available for device '{device_id}'.{detail}\n"
+                "  Try: sudo qubes-fwupdmgr refresh\n"
+                "  If firmware is in the testing channel:\n"
+                "    sudo fwupdmgr enable-remote lvfs-testing\n"
+                "    sudo qubes-fwupdmgr refresh"
+            )
+
+        if version is not None:
+            for release in releases:
+                if release.get("Version") == version:
+                    return self._release_uri(release), release["Checksum"][-1]
+            raise Exception(f"Version '{version}' not found for device '{device_id}'")
+
+        candidates = []
+        cv = pversion.parse(current)
+        for release in releases:
+            rel_ver = release.get("Version")
+            rv = pversion.parse(rel_ver)
+            if rv > cv:
+                candidates.append(release)
+            elif rv == cv and allow_reinstall:
+                candidates.append(release)
+            elif rv < cv and allow_older:
+                candidates.append(release)
+        if not candidates:
+            raise Exception(f"No eligible release found for device '{device_id}")
+
+        best = max(candidates, key=lambda r: pversion.parse(r["Version"]))
+        return self._release_uri(best), best["Checksum"][-1]
+
+    def install_firmware(
+        self,
+        device_id=None,
+        version=None,
+        url=None,
+        sha=None,
+        allow_older=False,
+        allow_reinstall=False,
+        force=False,
+        whonix=False,
+    ):
+        """Downloads and installs firmware for a device or from a direct URL.
+
+        Keyword arguments:
+        device_id - DeviceId or GUID to identify the target device
+        version - specific firmware version to install (used with device_id)
+        url - direct LVFS URL of the firmware cabinet (alternative to device_id)
+        sha - SHA256 checksum matching url
+        allow_older - allow installing an older firmware version
+        allow_reinstall - allow reinstalling the same firmware version
+        force - force installation even when not required
+        whonix - route download through sys-whonix (Tor)
+        """
+        if device_id is not None:
+            url, sha = self._find_device_release(
+                device_id,
+                version=version,
+                allow_older=allow_older,
+                allow_reinstall=allow_reinstall,
+            )
+        elif not (url and sha):
+            raise Exception("install requires a device UUID or --url and --sha")
+        self._download_firmware_updates(url, sha, whonix=whonix)
+        self._install_dom0_firmware(
+            self.arch_path,
+            allow_older=allow_older,
+            allow_reinstall=allow_reinstall,
+            force=force,
+        )
 
     def downgrade_firmware(self, whonix=False):
         """Downgrades firmware of the specified device.
@@ -560,9 +720,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         for name, uri in remotes.items():
             print(f"  {name}: {uri}")
 
-    def get_updates_qubes(self):
+    def get_updates_qubes(self, allow_older=False, allow_reinstall=False):
         """Gathers and prints updates information."""
-        self._get_dom0_updates()
+        self._get_dom0_updates(allow_older=allow_older, allow_reinstall=allow_reinstall)
         self._parse_dom0_updates_info(self.dom0_updates_info)
         self._updates_crawler(self.dom0_updates_list)
 
@@ -643,6 +803,19 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if not os.path.exists(FWUPD_DOM0_UPDATES_DIR):
             create_dirs(FWUPD_DOM0_UPDATES_DIR)
 
+    def _release_uri(self, release):
+        """Return the download URL from a release dict.
+
+        Older fwupd emits 'Uri' (string), newer fwupd emits 'Locations' (list).
+        """
+        uri = release.get("Uri")
+        if uri:
+            return uri
+        locations = release.get("Locations")
+        if locations:
+            return locations[0]
+        return None
+
 
 def main():
     if os.geteuid() != 0:
@@ -657,7 +830,11 @@ def main():
 
     metadata_url = None
     device_override = None
+    firmware_sha = None
     whonix = False
+    allow_older = False
+    allow_reinstall = False
+    force = False
 
     for arg in sys.argv:
         if "--url=" in arg:
@@ -669,10 +846,18 @@ def main():
                 )
                 print("Exiting...")
                 exit(1)
+        if "--sha=" in arg:
+            firmware_sha = arg.replace("--sha=", "")
         if "--device=" in arg:
             device_override = arg.replace("--device=", "")
         if "--whonix" == arg:
             whonix = True
+        if "--allow-older" == arg:
+            allow_older = True
+        if "--allow-reinstall" == arg:
+            allow_reinstall = True
+        if "--force" == arg:
+            force = True
 
     q.validate_dom0_dirs()
     q.trusted_cleanup()
@@ -685,15 +870,39 @@ def main():
             q.refresh_metadata_all(whonix=whonix)
 
     if sys.argv[1] == "get-updates":
-        q.get_updates_qubes()
+        q.get_updates_qubes(allow_older=allow_older, allow_reinstall=allow_reinstall)
     elif sys.argv[1] == "get-devices":
         q.get_devices_qubes()
     elif sys.argv[1] == "get-remotes":
         q.get_remotes_qubes()
     elif sys.argv[1] == "update":
-        q.update_firmware(whonix=whonix)
+        q.update_firmware(
+            whonix=whonix, allow_older=allow_older, allow_reinstall=allow_reinstall
+        )
     elif sys.argv[1] == "downgrade":
         q.downgrade_firmware(whonix=whonix)
+    elif sys.argv[1] == "install":
+        install_pos = [a for a in sys.argv[2:] if not a.startswith("--")]
+        install_device_id = install_pos[0] if install_pos else None
+        install_version = install_pos[1] if len(install_pos) > 1 else None
+        if install_device_id and metadata_url:
+            print("install: use either DEVICE-UUID or --url, not both")
+            exit(EXIT_CODES["ERROR"])
+        if not install_device_id and not (metadata_url and firmware_sha):
+            print(
+                "install requires DEVICE-UUID [VERSION] or --url=<URL> --sha=<SHA256>"
+            )
+            exit(EXIT_CODES["ERROR"])
+        q.install_firmware(
+            device_id=install_device_id,
+            version=install_version,
+            url=metadata_url,
+            sha=firmware_sha,
+            allow_older=allow_older,
+            allow_reinstall=allow_reinstall,
+            force=force,
+            whonix=whonix,
+        )
     elif sys.argv[1] == "clean":
         q.clean_cache()
     elif sys.argv[1] == "refresh":

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -983,7 +983,7 @@ def main():
         q.get_remotes_qubes()
     elif sys.argv[1] == "update":
         q.update_firmware(
-            whonix=whonix, allow_older=allow_older, allow_reinstall=allow_reinstall
+            whonix=whonix, allow_older=allow_older, allow_reinstall=allow_reinstall, force=force
         )
     elif sys.argv[1] == "downgrade":
         q.downgrade_firmware(whonix=whonix)

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -59,6 +59,7 @@ HELP = {
         {
             "get-devices": "Get all devices that support firmware updates",
             "get-updates": "Get the list of updates for connected hardware",
+            "get-remotes": "Get all enabled metadata remotes",
             "refresh": "Refresh metadata from remote server",
             "update": "Update chosen device to latest firmware version",
             "update-heads": "Updates heads firmware to the latest version (EXPERIMENTAL, not fully supported yet)",
@@ -546,6 +547,19 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         dom0_devices_info_dict = json.loads(self.dom0_devices_info)
         self._output_crawler(dom0_devices_info_dict, 0)
 
+    def get_remotes_qubes(self):
+        """Prints enabled download remotes and their metadata URIs."""
+        remotes = self.get_remotes()
+        if not remotes:
+            print("No enabled download remotes found.")
+            return
+        decorator = "======================================================"
+        print(decorator)
+        print("Enabled remotes:")
+        print(decorator)
+        for name, uri in remotes.items():
+            print(f"  {name}: {uri}")
+
     def get_updates_qubes(self):
         """Gathers and prints updates information."""
         self._get_dom0_updates()
@@ -674,6 +688,8 @@ def main():
         q.get_updates_qubes()
     elif sys.argv[1] == "get-devices":
         q.get_devices_qubes()
+    elif sys.argv[1] == "get-remotes":
+        q.get_remotes_qubes()
     elif sys.argv[1] == "update":
         q.update_firmware(whonix=whonix)
     elif sys.argv[1] == "downgrade":

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -76,7 +76,8 @@ HELP = {
             "--sha": "SHA256 checksum of the firmware archive (required for install)",
             "--allow-older": "Allow installing an older firmware version",
             "--allow-reinstall": "Allow reinstalling the same firmware version",
-            "--force": "Force the firmware update even if not required\n",
+            "--force": "Force the firmware update even if not required",
+            "--ignore-postquantum": "Ignore pkcs7 failures for LVFS CA 2025PQ if at least one other CA signature is verified\n",
         }
     ],
     "Help": [{"-h --help": "Show help options\n"}],
@@ -84,7 +85,9 @@ HELP = {
 
 
 class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
-    def _download_metadata(self, whonix=False, metadata_url=None):
+    def _download_metadata(
+        self, whonix=False, metadata_url=None, ignore_postquantum=False
+    ):
         """Initialize downloading metadata files.
 
         Keywords arguments:
@@ -94,7 +97,11 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if not metadata_url:
             raise Exception("missing metadata URL")
         self.download_metadata(whonix=whonix, metadata_url=metadata_url)
-        self.handle_metadata_update(self.updatevm, metadata_url=metadata_url)
+        self.handle_metadata_update(
+            self.updatevm,
+            metadata_url=metadata_url,
+            ignore_postquantum=ignore_postquantum,
+        )
         if not os.path.exists(self.metadata_file):
             raise FileNotFoundError("Metadata file does not exist")
 
@@ -128,7 +135,13 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         self._remotes_cache = remotes
         return self._remotes_cache
 
-    def refresh_metadata(self, whonix=False, metadata_url=None, remote_name=None):
+    def refresh_metadata(
+        self,
+        whonix=False,
+        metadata_url=None,
+        remote_name=None,
+        ignore_postquantum=False,
+    ):
         """Updates metadata with downloaded files.
 
         Keyword arguments:
@@ -149,7 +162,11 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 remote_name = "lvfs-testing"
             else:
                 remote_name = "lvfs"
-        self._download_metadata(whonix=whonix, metadata_url=metadata_url)
+        self._download_metadata(
+            whonix=whonix,
+            metadata_url=metadata_url,
+            ignore_postquantum=ignore_postquantum,
+        )
         cmd_refresh = [
             FWUPDMGR,
             "refresh",
@@ -167,7 +184,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 f"Manual metadata refresh failed: {output.strip() or '(no output)'}"
             )
 
-    def refresh_metadata_all(self, whonix=False):
+    def refresh_metadata_all(self, whonix=False, ignore_postquantum=False):
         """Refresh metadata for all 'download' remotes
 
         Keyword arguments:
@@ -175,7 +192,12 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         """
         for name, url in self.get_remotes().items():
             try:
-                self.refresh_metadata(whonix=whonix, remote_name=name, metadata_url=url)
+                self.refresh_metadata(
+                    whonix=whonix,
+                    remote_name=name,
+                    metadata_url=url,
+                    ignore_postquantum=ignore_postquantum,
+                )
             except Exception as e:
                 print(f"Failed to refresh remote '{name}': {e}")
 
@@ -747,7 +769,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 self.refresh_metadata_all()
             os.remove(BIOS_UPDATE_FLAG)
 
-    def heads_update(self, device=None, whonix=False, metadata_url=None):
+    def heads_update(
+        self, device=None, whonix=False, metadata_url=None, ignore_postquantum=False
+    ):
         """
         Updates heads firmware
 
@@ -763,7 +787,11 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         self._get_hwids()
         if device is None:
             device = self._get_hwid_device()
-        self._download_metadata(whonix=whonix, metadata_url=metadata_url)
+        self._download_metadata(
+            whonix=whonix,
+            metadata_url=metadata_url,
+            ignore_postquantum=ignore_postquantum,
+        )
         self._parse_metadata(self.metadata_file)
         if self._gather_firmware_version() == EXIT_CODES["NOTHING_TO_DO"]:
             return EXIT_CODES["NOTHING_TO_DO"]
@@ -835,6 +863,7 @@ def main():
     allow_older = False
     allow_reinstall = False
     force = False
+    ignore_postquantum = False
 
     for arg in sys.argv:
         if "--url=" in arg:
@@ -858,6 +887,8 @@ def main():
             allow_reinstall = True
         if "--force" == arg:
             force = True
+        if "--ignore-postquantum" == arg:
+            ignore_postquantum = True
 
     q.validate_dom0_dirs()
     q.trusted_cleanup()
@@ -865,7 +896,11 @@ def main():
 
     if not os.path.exists(FWUPD_DOM0_DIR):
         if metadata_url:
-            q.refresh_metadata(whonix=whonix, metadata_url=metadata_url)
+            q.refresh_metadata(
+                whonix=whonix,
+                metadata_url=metadata_url,
+                ignore_postquantum=ignore_postquantum,
+            )
         else:
             q.refresh_metadata_all(whonix=whonix)
 
@@ -907,11 +942,20 @@ def main():
         q.clean_cache()
     elif sys.argv[1] == "refresh":
         if metadata_url:
-            q.refresh_metadata(whonix=whonix, metadata_url=metadata_url)
+            q.refresh_metadata(
+                whonix=whonix,
+                metadata_url=metadata_url,
+                ignore_postquantum=ignore_postquantum,
+            )
         else:
-            q.refresh_metadata_all(whonix=whonix)
+            q.refresh_metadata_all(whonix=whonix, ignore_postquantum=ignore_postquantum)
     elif sys.argv[1] == "update-heads":
-        q.heads_update(device=device_override, metadata_url=metadata_url, whonix=whonix)
+        q.heads_update(
+            device=device_override,
+            metadata_url=metadata_url,
+            whonix=whonix,
+            ignore_postquantum=ignore_postquantum,
+        )
     else:
         q.help()
         exit(1)

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -635,7 +635,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         for updev_key in updev_dict:
             style = "\t" * level
             output = style + _tabs(updev_key + ":")
-            if len(updev_key) > 12:
+            if len(updev_key) > 20:
                 continue
             if updev_key == "Icons":
                 continue

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -481,7 +481,9 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         p = subprocess.Popen(cmd_install)
         p.wait()
         if p.returncode != 0:
-            sys.exit(p.returncode)
+            raise Exception(
+                f"fwupd-qubes: Firmware install failed (fwupdmgr exit {p.returncode})"
+            )
 
     def _find_device_release(
         self, device_id, version=None, allow_older=False, allow_reinstall=False
@@ -526,7 +528,12 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
                 raise Exception(
                     f"Version '{version}' not found for device '{device_id}'"
                 )
-            return self._release_uri(match), match["Checksum"][-1]
+            uri = self._release_uri(match)
+            if not uri:
+                raise Exception(
+                    f"Release '{version}' for device '{device_id}' has no download URL"
+                )
+            return uri, match["Checksum"][-1]
 
         current = target_device.get("Version", "0")
         candidates = [
@@ -539,7 +546,12 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if not candidates:
             raise Exception(f"No eligible release found for device '{device_id}'")
         best = max(candidates, key=lambda r: pversion.Version(r["Version"]))
-        return self._release_uri(best), best["Checksum"][-1]
+        uri = self._release_uri(best)
+        if not uri:
+            raise Exception(
+                f"Best release for device '{device_id}' has no download URL"
+            )
+        return uri, best["Checksum"][-1]
 
     def install_firmware(
         self,
@@ -983,7 +995,10 @@ def main():
         q.get_remotes_qubes()
     elif sys.argv[1] == "update":
         q.update_firmware(
-            whonix=whonix, allow_older=allow_older, allow_reinstall=allow_reinstall, force=force
+            whonix=whonix,
+            allow_older=allow_older,
+            allow_reinstall=allow_reinstall,
+            force=force,
         )
     elif sys.argv[1] == "downgrade":
         q.downgrade_firmware(whonix=whonix)

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -939,7 +939,7 @@ def main():
     for arg in sys.argv:
         if "--url=" in arg:
             metadata_url = arg.replace("--url=", "")
-            if FWUPD_DOWNLOAD_PREFIX not in metadata_url:
+            if not metadata_url.startswith(FWUPD_DOWNLOAD_PREFIX):
                 print(
                     "Metadata must be stored in the Linux"
                     " Vendor Firmware Service (https://fwupd.org/)"

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -156,8 +156,10 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         print(output)
         if p.returncode != 0:
             raise Exception("fwupd-qubes: Refresh failed")
-        if not output != "Successfully refreshed metadata manually":
-            raise Exception("Manual metadata refresh failed!!!")
+        if "Successfully refreshed metadata manually" not in output:
+            raise Exception(
+                f"Manual metadata refresh failed: {output.strip() or '(no output)'}"
+            )
 
     def refresh_metadata_all(self, whonix=False):
         """Refresh metadata for all 'download' remotes

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -109,8 +109,8 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         remotes = {}
         for remote in remotes_list:
             name = remote["Id"]
-            # skip disabled
-            if remote.get("Enabled", "true") != "true":
+            # fwupd 2.x emits "Enabled": true (bool), older versions used "true" (str)
+            if remote.get("Enabled", True) not in (True, "true"):
                 continue
             # skip local - for metadata refresh, we only care about those
             # actually needing refreshing

--- a/contrib/qubes/src/qubes_fwupdmgr.py
+++ b/contrib/qubes/src/qubes_fwupdmgr.py
@@ -506,66 +506,39 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
             raise Exception(f"Device '{device_id}' not found")
 
         current = target_device.get("Version", "0")
-        # Use the canonical DeviceId from fwupd rather than the user-supplied
-        canonical_id = target_device.get("DeviceId", device_id)
         releases = target_device.get("Releases", [])
 
-        # get-devices may omit Releases when fwupd sees no update candidates
-        # fall back to get-releases which queries all metadata for the device
-        result = None
+        stderr = ""
         if not releases:
-            cmd_get_releases = [FWUPDMGR, "--json"]
-            if allow_older:
-                cmd_get_releases.append("--allow-older")
-            if allow_reinstall:
-                cmd_get_releases.append("--allow-reinstall")
-            cmd_get_releases += ["get-releases", "--", canonical_id]
-            result = subprocess.run(
-                cmd_get_releases,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+            releases, stderr = self._fwupd_get_releases(
+                device_id, allow_older, allow_reinstall
             )
-            try:
-                releases = json.loads(result.stdout.decode()).get("Releases", [])
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                releases = []
-
         if not releases:
-            stderr_msg = (
-                result.stderr.decode(errors="replace").strip()
-                if result is not None
-                else ""
-            )
-            detail = f"\n  fwupdmgr: {stderr_msg}" if stderr_msg else ""
+            detail = f"\n  fwupdmgr: {stderr}" if stderr else ""
             raise Exception(
                 f"No releases available for device '{device_id}'.{detail}\n"
-                "  Try: sudo qubes-fwupdmgr refresh\n"
-                "  If firmware is in the testing channel:\n"
-                "    sudo fwupdmgr enable-remote lvfs-testing\n"
-                "    sudo qubes-fwupdmgr refresh"
+                "  Try: sudo qubes-fwupdmgr refresh"
             )
 
         if version is not None:
-            for release in releases:
-                if release.get("Version") == version:
-                    return self._release_uri(release), release["Checksum"][-1]
-            raise Exception(f"Version '{version}' not found for device '{device_id}'")
+            match = next((r for r in releases if r.get("Version") == version), None)
+            if match is None:
+                raise Exception(
+                    f"Version '{version}' not found for device '{device_id}'"
+                )
+            return self._release_uri(match), match["Checksum"][-1]
 
-        candidates = []
-        cv = pversion.parse(current)
-        for release in releases:
-            rel_ver = release.get("Version")
-            rv = pversion.parse(rel_ver)
-            if rv > cv:
-                candidates.append(release)
-            elif rv == cv and allow_reinstall:
-                candidates.append(release)
-            elif rv < cv and allow_older:
-                candidates.append(release)
+        current = target_device.get("Version", "0")
+        candidates = [
+            r
+            for r in releases
+            if self._release_eligible(
+                r.get("Version"), current, allow_older, allow_reinstall
+            )
+        ]
         if not candidates:
-            raise Exception(f"No eligible release found for device '{device_id}")
-
-        best = max(candidates, key=lambda r: pversion.parse(r["Version"]))
+            raise Exception(f"No eligible release found for device '{device_id}'")
+        best = max(candidates, key=lambda r: pversion.Version(r["Version"]))
         return self._release_uri(best), best["Checksum"][-1]
 
     def install_firmware(
@@ -746,7 +719,18 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         """Gathers and prints updates information."""
         self._get_dom0_updates(allow_older=allow_older, allow_reinstall=allow_reinstall)
         self._parse_dom0_updates_info(self.dom0_updates_info)
+        self._get_dom0_updates_string_based(
+            allow_older=allow_older, allow_reinstall=allow_reinstall
+        )
         self._updates_crawler(self.dom0_updates_list)
+
+    def _get_dom0_updates_string_based(self, allow_older=False, allow_reinstall=False):
+        devices_with_releases = sum(1 for d in self.dom0_updates_list if d["Releases"])
+        if devices_with_releases == 0:
+            self.dom0_updates_list = self._string_based_updates(
+                allow_older=allow_older,
+                allow_reinstall=allow_reinstall,
+            )
 
     def help(self):
         """Prints help information"""
@@ -843,6 +827,93 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
         if locations:
             return locations[0]
         return None
+
+    def _string_based_updates(self, allow_older=False, allow_reinstall=False):
+        """Fallback update scan using version-string comparison."""
+        self._get_dom0_devices()
+        devices = json.loads(self.dom0_devices_info).get("Devices", [])
+
+        updates_list = []
+        for device in devices:
+            if "updatable" not in device.get("Flags", []):
+                continue
+            dev_id = device.get("DeviceId")
+            if not dev_id:
+                continue
+            dev_ver = device.get("Version", "0")
+
+            releases, _ = self._fwupd_get_releases(dev_id, allow_older, allow_reinstall)
+            candidates = [
+                r
+                for r in releases
+                if self._release_eligible(
+                    r.get("Version"), dev_ver, allow_older, allow_reinstall
+                )
+            ]
+            if not candidates:
+                continue
+
+            updates_list.append(
+                {
+                    "Name": device.get("Name", "Unknown"),
+                    "Version": dev_ver,
+                    "Releases": [
+                        {
+                            "Version": r["Version"],
+                            "Url": self._release_uri(r),
+                            "Checksum": r["Checksum"][-1],
+                            "Description": r.get("Description", ""),
+                        }
+                        for r in candidates
+                        if self._release_uri(r) and r.get("Checksum")
+                    ],
+                }
+            )
+        return updates_list
+
+    def _release_eligible(self, rel_ver_str, cur_ver_str, allow_older, allow_reinstall):
+        """Return True if a release is eligible to install over current using
+        packaging.version human-readable Version strings.
+        """
+        if not rel_ver_str:
+            return False
+        try:
+            rv = pversion.parse(rel_ver_str)
+            cv = pversion.parse(cur_ver_str or "0")
+        except Exception:
+            return False
+        if rv > cv:
+            return True
+        if rv == cv and allow_reinstall:
+            return True
+        if rv < cv and allow_older:
+            return True
+        return False
+
+    def _fwupd_get_releases(self, device_id, allow_older=False, allow_reinstall=False):
+        """Run `fwupdmgr --json get-releases <id>` and return its Releases list.
+
+        Returns ([], stderr_str) on failure so the caller can build a useful
+        error message. stderr_str is "" when nothing went wrong.
+        """
+        cmd = [FWUPDMGR, "--json"]
+        if allow_older:
+            cmd.append("--allow-older")
+        if allow_reinstall:
+            cmd.append("--allow-reinstall")
+        cmd += ["get-releases", "--", device_id]
+        try:
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except Exception as e:
+            return [], str(e)
+        try:
+            releases = json.loads(result.stdout.decode(errors="replace")).get(
+                "Releases", []
+            )
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            releases = []
+        stderr = result.stderr.decode(errors="replace").strip()
+        return releases, stderr
 
 
 def main():

--- a/contrib/qubes/src/vms/fwupd_download_updates.py
+++ b/contrib/qubes/src/vms/fwupd_download_updates.py
@@ -89,6 +89,8 @@ class DownloadData(FwupdVmCommon):
             if not line.startswith("Wrote "):
                 continue
             path = line.split(" ", 1)[1]
+            if not os.path.exists(path):
+                continue
             base_path, ext = os.path.splitext(path)
             if base_path == self.metadata_file:
                 continue

--- a/contrib/qubes/test/logs/get_devices.log
+++ b/contrib/qubes/test/logs/get_devices.log
@@ -19,4 +19,6 @@ Dom0 Devices:
 	Vendor:				Hughski Ltd.
 	VendorId:			USB:0x273F
 	Version:			2.0.6
+	VersionFormat:			triplet
+	InstallDuration:		8
 	Created:			1614224175

--- a/contrib/qubes/test/logs/help.log
+++ b/contrib/qubes/test/logs/help.log
@@ -1,25 +1,29 @@
 ======================================================================
-Usage:				
+Usage:
 ======================================================================
 	Command:			qubes-fwupdmgr [OPTION…][FLAG..]
 	Example:			qubes-fwupdmgr refresh --whonix --url=<url>
 
-Options:			
+Options:
 ======================================================================
 	get-devices:			Get all devices that support firmware updates
 	get-updates:			Get the list of updates for connected hardware
+	get-remotes:			Get all enabled metadata remotes
 	refresh:			Refresh metadata from remote server
 	update:				Update chosen device to latest firmware version
 	update-heads:			Updates heads firmware to the latest version (EXPERIMENTAL, not fully supported yet)
 	downgrade:			Downgrade chosen device to chosen firmware version
+	install:			Install firmware: DEVICE-UUID [VERSION] or --url with --sha
 	clean:				Delete all cached update files
 
-Flags:				
+Flags:
 ======================================================================
 	--whonix:			Download firmware updates via Tor
 	--device:			Specify device for heads update (default - x230)
-	--url:				Address of the custom metadata remote server
+	--url:				Address of the firmware or metadata remote server
+	--sha:				SHA256 checksum of the firmware archive (required for install)
+	--force:			Force the firmware update even if not required
 
-Help:				
+Help:
 ======================================================================
 	-h --help:			Show help options

--- a/contrib/qubes/test/logs/help.log
+++ b/contrib/qubes/test/logs/help.log
@@ -22,6 +22,8 @@ Flags:
 	--device:			Specify device for heads update (default - x230)
 	--url:				Address of the firmware or metadata remote server
 	--sha:				SHA256 checksum of the firmware archive (required for install)
+	--allow-older:			Allow installing an older firmware version
+	--allow-reinstall:		Allow reinstalling the same firmware version
 	--force:			Force the firmware update even if not required
 
 Help:

--- a/contrib/qubes/test/test_qubes_fwupd_heads.py
+++ b/contrib/qubes/test/test_qubes_fwupd_heads.py
@@ -11,7 +11,7 @@ import io
 import os
 import platform
 import shutil
-import imp
+import importlib.util
 import src.qubes_fwupd_heads as qf_heads
 import sys
 import unittest
@@ -26,9 +26,15 @@ QUBES_FWUPDMGR_BINDIR = "/usr/sbin/qubes-fwupdmgr"
 class TestQubesFwupdHeads(unittest.TestCase):
     def setUp(self):
         if os.path.exists(QUBES_FWUPDMGR_REPO):
-            self.qfwupd = imp.load_source("qubes_fwupdmgr", QUBES_FWUPDMGR_REPO)
+            path = QUBES_FWUPDMGR_REPO
         elif os.path.exists(QUBES_FWUPDMGR_BINDIR):
-            self.qfwupd = imp.load_source("qubes_fwupdmgr", QUBES_FWUPDMGR_BINDIR)
+            path = QUBES_FWUPDMGR_BINDIR
+        else:
+            path = None
+        if path is not None:
+            spec = importlib.util.spec_from_file_location("qubes_fwupdmgr", path)
+            self.qfwupd = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(self.qfwupd)
         self.q = qf_heads.FwupdHeads()
         self.maxDiff = 2000
         self.captured_output = io.StringIO()

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -283,7 +283,16 @@ class TestQubesFwupdmgr(unittest.TestCase):
         sys.stdout = help_output
         self.q.help()
         with open("test/logs/help.log") as help_log:
-            self.assertEqual(help_log.read(), help_output.getvalue().strip() + "\n")
+
+            def _strip_lines(text):
+                return (
+                    "\n".join(line.rstrip() for line in text.strip().splitlines())
+                    + "\n"
+                )
+
+            self.assertEqual(
+                _strip_lines(help_log.read()), _strip_lines(help_output.getvalue())
+            )
         sys.stdout = self.captured_output
 
     @patch(

--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
+++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
@@ -12,7 +12,7 @@ import unittest
 import os
 import subprocess
 import sys
-import imp
+import importlib.util
 import io
 import platform
 import tempfile
@@ -22,13 +22,22 @@ from .fwupd_logs import GET_DEVICES_NO_VERSION
 from unittest.mock import patch
 
 
-QUBES_FWUPDMGR_REPO = "./src/qubes_fwupdmgr.py"
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+QUBES_FWUPDMGR_REPO = os.path.join(_THIS_DIR, "..", "src", "qubes_fwupdmgr.py")
 QUBES_FWUPDMGR_BINDIR = "/usr/sbin/qubes-fwupdmgr"
 
 if os.path.exists(QUBES_FWUPDMGR_REPO):
-    qfwupd = imp.load_source("qubes_fwupdmgr", QUBES_FWUPDMGR_REPO)
+    _qfwupd_path = QUBES_FWUPDMGR_REPO
 elif os.path.exists(QUBES_FWUPDMGR_BINDIR):
-    qfwupd = imp.load_source("qubes_fwupdmgr", QUBES_FWUPDMGR_BINDIR)
+    _qfwupd_path = QUBES_FWUPDMGR_BINDIR
+else:
+    _qfwupd_path = None
+
+qfwupd = None
+if _qfwupd_path is not None:
+    _spec = importlib.util.spec_from_file_location("qubes_fwupdmgr", _qfwupd_path)
+    qfwupd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(qfwupd)
 
 FWUPD_DOM0_DIR = "/var/cache/fwupd/qubes"
 FWUPD_DOM0_UPDATES_DIR = os.path.join(FWUPD_DOM0_DIR, "updates")


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [X] Feature
- [ ] Documentation

Fixes:
- https://github.com/fwupd/fwupd/issues/9820
- https://github.com/fwupd/fwupd/issues/9933

~~The automated tests don't work on modern python. The `imp` library is deprecated since `3.11`.~~
Replaced the deprecated `imp` library with `importlib`.
Automatic tests, some tests related to building cabinets fail. I don't think they're related.
<details>

```
qubesos@dom0:/usr/share/qubes-fwupd$ python3 -m unittest test.test_qubes_fwupdmgr
.s  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15093  100 15093    0     0  17319      0 --:--:-- --:--:-- --:--:-- 17328
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9204  100  9204    0     0  13639      0 --:--:-- --:--:-- --:--:-- 13655
Validating directories
.  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   433  100   433    0     0    685      0 --:--:-- --:--:-- --:--:--   686
100 41213  100 41213    0     0  44101      0 --:--:-- --:--:-- --:--:--  503k
Validating directories
Update file downloaded successfully
.s  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15061  100 15061    0     0  16994      0 --:--:-- --:--:-- --:--:-- 16979
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1611k  100 1611k    0     0   719k      0  0:00:02  0:00:02 --:--:--  719k
Validating directories
.s...s......  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15061  100 15061    0     0  17436      0 --:--:-- --:--:-- --:--:-- 17451
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1611k  100 1611k    0     0   594k      0  0:00:02  0:00:02 --:--:--  593k
Validating directories
Idle…: 0%
.  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15093  100 15093    0     0  18215      0 --:--:-- --:--:-- --:--:-- 18206
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9204  100  9204    0     0  13868      0 --:--:-- --:--:-- --:--:-- 13861
Validating directories
Idle…: 0%
Failed to update metadata for lvfs: new signing timestamp was 594238 seconds older
xss.....Invalid arguments, expected at least ARCHIVE FIRMWARE METAINFO
EInvalid arguments, expected at least ARCHIVE FIRMWARE METAINFO
EInvalid arguments, expected at least ARCHIVE FIRMWARE METAINFO
E
======================================================================
ERROR: test_verify_dmi (test.test_qubes_fwupdmgr.TestQubesFwupdmgr.test_verify_dmi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.13/unittest/mock.py", line 1426, in patched
    return func(*newargs, **newkeywargs)
  File "/usr/share/qubes-fwupd/test/test_qubes_fwupdmgr.py", line 307, in test_verify_dmi
    subprocess.check_call(
    ~~~~~~~~~~~~~~~~~~~~~^
        ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        cwd="test/logs",
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib64/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['fwupdtool', 'build-cabinet', '/tmp/tmpnf8c4bvc/firmware.cab', 'firmware.metainfo.xml']' returned non-zero exit status 2.

======================================================================
ERROR: test_verify_dmi_version (test.test_qubes_fwupdmgr.TestQubesFwupdmgr.test_verify_dmi_version)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.13/unittest/mock.py", line 1426, in patched
    return func(*newargs, **newkeywargs)
  File "/usr/share/qubes-fwupd/test/test_qubes_fwupdmgr.py", line 338, in test_verify_dmi_version
    subprocess.check_call(
    ~~~~~~~~~~~~~~~~~~~~~^
        ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        cwd="test/logs/metainfo_version",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib64/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['fwupdtool', 'build-cabinet', '/tmp/tmp2282nxma/firmware.cab', 'firmware.metainfo.xml']' returned non-zero exit status 2.

======================================================================
ERROR: test_verify_dmi_wrong_vendor (test.test_qubes_fwupdmgr.TestQubesFwupdmgr.test_verify_dmi_wrong_vendor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.13/unittest/mock.py", line 1426, in patched
    return func(*newargs, **newkeywargs)
  File "/usr/share/qubes-fwupd/test/test_qubes_fwupdmgr.py", line 322, in test_verify_dmi_wrong_vendor
    subprocess.check_call(
    ~~~~~~~~~~~~~~~~~~~~~^
        ["fwupdtool", "build-cabinet", arch_name, "firmware.metainfo.xml"],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        cwd="test/logs/metainfo_name",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib64/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['fwupdtool', 'build-cabinet', '/tmp/tmp42vwi0wt/firmware.cab', 'firmware.metainfo.xml']' returned non-zero exit status 2.

----------------------------------------------------------------------
Ran 29 tests in 14.979s

FAILED (errors=3, skipped=6, expected failures=1)
```

</details>

Some manual tests:

### Metadata refresh

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr refresh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15067  100 15067    0     0   136k      0 --:--:-- --:--:-- --:--:--  137k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  319k  100  319k    0     0  1981k      0 --:--:-- --:--:-- --:--:-- 1987k
Validating directories
firmware-06874-testing.xml.zst:
    PASSED sha1: OK
    PASSED sha256: OK
    FAILED pkcs7: failed to verify data for CN=LVFS CA 2025PQ,O=Linux Vendor Firmware Project: Public key signature verification has failed. [-89]
    PASSED pkcs7: O=Linux Vendor Firmware Project,CN=LVFS CA
    FAILED: Validation failed
Validation failed

Idle…: 0%
Successfully refreshed metadata manually

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15055  100 15055    0     0   156k      0 --:--:-- --:--:-- --:--:--  158k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1808k  100 1808k    0     0  8810k      0 --:--:-- --:--:-- --:--:-- 8820k
Validating directories
firmware-08786-stable.xml.zst:
    PASSED sha1: OK
    PASSED sha256: OK
    FAILED pkcs7: failed to verify data for CN=LVFS CA 2025PQ,O=Linux Vendor Firmware Project: Public key signature verification has failed. [-89]
    PASSED pkcs7: O=Linux Vendor Firmware Project,CN=LVFS CA
    FAILED: Validation failed
Validation failed

Idle…: 0%
Successfully refreshed metadata manually
```

### Looking for updates

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr get-updates
======================================================
Dom0 updates:
======================================================
No updates available.
```

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr update
No updates available.
```

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr get-updates --allow-older
======================================================
Dom0 updates:
======================================================
No updates available.
```

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr get-updates --allow-reinstall
======================================================
Dom0 updates:
======================================================
Available updates:
======================================================
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1. Device: System Firmware
   Current firmware version:	 1.0.0
======================================================
   Firmware update version:	 1.0.0
   URL:	 https://fwupd.org/downloads/376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae-novacustom_v54x_mtl_dgpu_v1.0.0_btg_prod.cab
   SHA256 checksum:	 376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae
   Description: New Dasharo firmware release for the NovaCustom Meteor Lake laptops
	with integrated graphics, featuring numerous bug fixes, performance
	improvements and stability fixes.

======================================================
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2. Device: UEFI CA
   Current firmware version:	 2023
======================================================
   Firmware update version:	 2023
   URL:	 https://fwupd.org/downloads/6819c8098f09f4332a102194df6a033563aa288073b16315c5b88860fefb7e74-DBUpdate-3P2023_OROM2023.cab
   SHA256 checksum:	 6819c8098f09f4332a102194df6a033563aa288073b16315c5b88860fefb7e74
   Description: This updates the 3rd Party UEFI Signature Database (the &quot;db&quot;) to the latest release from Microsoft.It also adds the latest OptionROM UEFI Signature Database update.

======================================================
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
3. Device: UEFI dbx
   Current firmware version:	 20250902
======================================================
   Firmware update version:	 20250902
   URL:	 https://fwupd.org/downloads/7178302fa23fcb875e7540900e299fb30a76758663efb7e1c56edc25cd3f316a-DBXUpdate-20250902-x64.cab
   SHA256 checksum:	 7178302fa23fcb875e7540900e299fb30a76758663efb7e1c56edc25cd3f316a
   Description: This updates the list of forbidden signatures (the &quot;dbx&quot;) to the latest release from Microsoft.
	Some insecure versions of the IGEL bootloader were added, due to a security vulnerability that allowed an attacker to bypass UEFI Secure Boot.

======================================================
```

### Reinstalling

#### No newer version available

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr install 6207b46473cbf71bd7e89bbf75e3ff28eee736d6
Traceback (most recent call last):
  File "/usr/sbin/qubes-fwupdmgr", line 1001, in <module>
    main()
    ~~~~^^
  File "/usr/sbin/qubes-fwupdmgr", line 976, in main
    q.install_firmware(
    ~~~~~~~~~~~~~~~~~~^
        device_id=install_device_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        whonix=whonix,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/usr/sbin/qubes-fwupdmgr", line 555, in install_firmware
    url, sha = self._find_device_release(
               ~~~~~~~~~~~~~~~~~~~~~~~~~^
        device_id,
        ^^^^^^^^^^
    ...<2 lines>...
        allow_reinstall=allow_reinstall,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/sbin/qubes-fwupdmgr", line 527, in _find_device_release
    raise Exception(f"No eligible release found for device '{device_id}'")
Exception: No eligible release found for device '6207b46473cbf71bd7e89bbf75e3ff28eee736d6'
```

#### Works with --allow-reinstall
```console
qubesos@dom0:~$ sudo qubes-fwupdmgr install 6207b46473cbf71bd7e89bbf75e3ff28eee736d6 --allow-reinstall
Firmware already downloaded. Using cached files.
Waiting…                 [***************************************]
Successfully installed firmware
Do not turn off your computer or remove the AC adapter while the update is in progress.
An update requires a reboot to complete. Restart now? [y|N]: N
```

#### Works when providing URL & SHA
```console
qubesos@dom0:~$ sudo qubes-fwupdmgr install --allow-reinstall --url="https://fwupd.org/downloads/376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae-novacustom_v54x_mtl_dgpu_v1.0.0_btg_prod.cab" --sha=376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae
Firmware already downloaded. Using cached files.
Waiting…                 [***************************************]
Successfully installed firmware
An update requires a reboot to complete. Restart now? [y|N]: N
```
#### Fails with invalid SHA

```console
qubesos@dom0:~$ sudo qubes-fwupdmgr install --url="https://fwupd.org/downloads/376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae-novacustom_v54x_mtl_dgpu_v1.0.0_btg_prod.cab" --sha=376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a56546
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32.4M  100 32.4M    0     0  3763k      0  0:00:08  0:00:08 --:--:-- 4719k
Validating directories
Cleaning cache directories
Traceback (most recent call last):
  File "/usr/libexec/qubes-fwupd/fwupd_download_updates.py", line 156, in <module>
    main()
    ~~~~^^
  File "/usr/libexec/qubes-fwupd/fwupd_download_updates.py", line 150, in main
    dn.download_updates(url, sha)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/libexec/qubes-fwupd/fwupd_download_updates.py", line 134, in download_updates
    self.check_shasum(update_path, sha)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/qubes-fwupd/fwupd_common_vm.py", line 56, in check_shasum
    raise ValueError(f"Computed checksum {c_sha} did NOT match {sha}. ")
ValueError: Computed checksum 376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a543ae did NOT match 376424b49feab49c95a31eebb18c0781e4f05072dcba1de8a5c0777ae1a56546.
Traceback (most recent call last):
  File "/usr/sbin/qubes-fwupdmgr", line 1001, in <module>
    main()
    ~~~~^^
  File "/usr/sbin/qubes-fwupdmgr", line 976, in main
    q.install_firmware(
    ~~~~~~~~~~~~~~~~~~^
        device_id=install_device_id,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        whonix=whonix,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/usr/sbin/qubes-fwupdmgr", line 563, in install_firmware
    self._download_firmware_updates(url, sha, whonix=whonix)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/sbin/qubes-fwupdmgr", line 228, in _download_firmware_updates
    self.download_firmware_updates(url, sha, whonix=whonix)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/qubes-fwupd/src/qubes_fwupd_update.py", line 126, in download_firmware_updates
    raise Exception("Firmware download failed.")
Exception: Firmware download failed.
```
