### PR TITLE
Don't print clean remote success message if aborted

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -2414,10 +2414,10 @@ fu_util_remote_disable(FuUtil *self, gchar **values, GError **error)
 					  _("Delete the now-unused remote cache files?"))) {
 			if (!fu_engine_clean_remote(self->engine, values[0], error))
 				return FALSE;
+			fu_console_print_literal(self->console,
+						 /* TRANSLATORS: success message */
+						 _("Successfully cleaned remote"));
 		}
-		fu_console_print_literal(self->console,
-					 /* TRANSLATORS: success message */
-					 _("Successfully cleaned remote"));
 	}
 
 	/* success */

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -3494,10 +3494,10 @@ fu_util_remote_disable(FuUtil *self, gchar **values, GError **error)
 						       self->cancellable,
 						       error))
 				return FALSE;
+			fu_console_print_literal(self->console,
+						 /* TRANSLATORS: success message */
+						 _("Successfully cleaned remote"));
 		}
-		fu_console_print_literal(self->console,
-					 /* TRANSLATORS: success message */
-					 _("Successfully cleaned remote"));
 	}
 
 	/* success */


### PR DESCRIPTION
`fwupdmgr disable-remote lvfs-testing`
would print the success message even if I answered n(o).

---

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
