### PR TITLE
fastboot: Avoid firmware matching errors for Cat-6 and Cat-12 modems.

### DIFF
--- a/plugins/fastboot/fastboot.quirk
+++ b/plugins/fastboot/fastboot.quirk
@@ -43,8 +43,6 @@ Plugin = fastboot
 FastbootBlockSize = 16384
 FastbootOperationDelay = 0
 Summary = Rolling RW101 Modem (fastboot)
-CounterpartGuid = USB\VID_33F8&PID_0301
-CounterpartGuid = USB\VID_33F8&PID_0302
 
 # Taurus HC40 4x2
 [USB\VID_276F&PID_0188]


### PR DESCRIPTION
When entering fastboot mode, RW101-CAT12(VID_33F8&PID_0302) and RW101(VID_33F8&PID_0301) both appear as VID_33F8&PID_D00D, so when the modem is in DOOD mode, both Cat-6 and Cat-12 firmware packages will be retrieved. Fix the problem by removing CounterpartGuid configures of modem in fastboot mode.


