### PR TITLE
trivial: try pre-commit CI caching differently

### DIFF
--- a/.github/workflows/pull-request-reviews.yml
+++ b/.github/workflows/pull-request-reviews.yml
@@ -12,26 +12,19 @@ jobs:
       SKIP: no-commit-to-branch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up APT caching
+      - name: Set up pre-commit caching
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: pre-commit-apt-${{ runner.os }}-${{ hashFiles('.github/workflows/*.yml') }}
-          restore-keys: pre-commit-apt-${{ runner.os }}-
+            $XDG_CACHE_HOME/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-${{ runner.os }}-
       - name: Set up pre-commit
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
-            -o APT::Keep-Downloaded-Packages=true \
-            -o Binary::apt::APT::Keep-Downloaded-Packages=true \
-            black \
             clang-format \
-            codespell \
             git \
-            gitleaks \
-            markdownlint \
             meson \
             patch \
             pre-commit \


### PR DESCRIPTION
Caching apt packages seems fraught after finding many open issues on the actions/cache repo that complain about not being able to cache files belonging to root, especially when they're not world-readable either.

The added packages also don't seem to have improved anything.

Let's just do a different approach and cache `~/.cache/pre-commit` instead, given that this targets the pre-commit step that takes the most time in this action.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
