### PR TITLE
usi-dock: Do not set the Parade USB2 dock as a child proxy

### DIFF
--- a/plugins/usi-dock/fu-usi-dock-plugin.c
+++ b/plugins/usi-dock/fu-usi-dock-plugin.c
@@ -17,7 +17,6 @@
 struct _FuUsiDockPlugin {
 	FuPlugin parent_instance;
 	FuDevice *device_tbt;
-	FuDevice *device_usb2;
 };
 
 G_DEFINE_TYPE(FuUsiDockPlugin, fu_usi_dock_plugin, FU_TYPE_PLUGIN)
@@ -55,28 +54,9 @@ fu_usi_dock_plugin_ensure_tbt4(FuPlugin *plugin)
 }
 
 static void
-fu_usi_dock_plugin_ensure_usb2(FuPlugin *plugin)
-{
-	FuUsiDockPlugin *self = FU_USI_DOCK_PLUGIN(plugin);
-	g_autoptr(FuDevice) device_usi = NULL;
-	g_autoptr(FuUsiDockMcuDevice) device_mcu = NULL;
-
-	if (self->device_usb2 == NULL)
-		return;
-	device_mcu = fu_usi_dock_plugin_find_mcu_device(plugin);
-	if (device_mcu == NULL)
-		return;
-	device_usi = fu_usi_dock_mcu_device_find_child(device_mcu, FU_USI_DOCK_FIRMWARE_IDX_USB2);
-	if (device_usi == NULL)
-		return;
-	fu_device_set_proxy(device_usi, self->device_usb2);
-}
-
-static void
 fu_usi_dock_plugin_device_added(FuPlugin *plugin, FuDevice *device)
 {
 	fu_usi_dock_plugin_ensure_tbt4(plugin);
-	fu_usi_dock_plugin_ensure_usb2(plugin);
 }
 
 static void
@@ -89,12 +69,6 @@ fu_usi_dock_plugin_device_registered(FuPlugin *plugin, FuDevice *device)
 	    fu_device_has_guid(device, USI_DOCK_TBT_INSTANCE_ID)) {
 		g_set_object(&self->device_tbt, device);
 		fu_usi_dock_plugin_ensure_tbt4(plugin);
-	}
-
-	/* we may need to reset this manually */
-	if (fu_device_get_vid(device) == 0x17EF && fu_device_get_pid(device) == 0x30BA) {
-		g_set_object(&self->device_usb2, device);
-		fu_usi_dock_plugin_ensure_usb2(plugin);
 	}
 }
 
@@ -122,7 +96,6 @@ fu_usi_dock_plugin_finalize(GObject *obj)
 {
 	FuUsiDockPlugin *self = FU_USI_DOCK_PLUGIN(obj);
 	g_clear_object(&self->device_tbt);
-	g_clear_object(&self->device_usb2);
 	G_OBJECT_CLASS(fu_usi_dock_plugin_parent_class)->finalize(obj);
 }
 


### PR DESCRIPTION
This wasn't actually used (the plugin uses fu_backend_create_device) and was causing a warning at enumeration time.

Fixes half of https://github.com/fwupd/firmware-lenovo/issues/600

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
