### PR TITLE
plugins: clear Sunplus camera download state

### DIFF
--- a/plugins/sunplus-camera/README.md
+++ b/plugins/sunplus-camera/README.md
@@ -37,6 +37,7 @@ another node such as `/dev/video4`.
 The normal update flow is:
 
 * enable ISP/download mode using selector `9`
+* clear ASIC register `0x2501` if the previous download-state value is nonzero
 * stream the raw payload using selector `10`
 * compare the XOR checksum using selector `11`
 * finalize the transfer using selector `12`

--- a/plugins/sunplus-camera/fu-sunplus-camera-device.c
+++ b/plugins/sunplus-camera/fu-sunplus-camera-device.c
@@ -151,7 +151,7 @@ fu_sunplus_camera_device_set_read_addr(FuSunplusCameraDevice *self, guint32 addr
 
 static gboolean
 fu_sunplus_camera_device_set_asic_register(FuSunplusCameraDevice *self,
-					   guint16 reg,
+					   FuSunplusCameraAsicRegister reg,
 					   guint8 value,
 					   GError **error)
 {
@@ -162,16 +162,84 @@ fu_sunplus_camera_device_set_asic_register(FuSunplusCameraDevice *self,
 						 FU_SUNPLUS_CAMERA_SELECTOR_REG16_CMD,
 						 cmd,
 						 sizeof(cmd),
-						 error))
+						 error)) {
+		g_prefix_error(error,
+			       "failed to select ASIC register %s: ",
+			       fu_sunplus_camera_asic_register_to_string(reg));
 		return FALSE;
+	}
 	if (!fu_sunplus_camera_device_xu_set_cur(self,
 						 FU_SUNPLUS_CAMERA_SELECTOR_REG8_DATA,
 						 &value,
 						 sizeof(value),
-						 error))
+						 error)) {
+		g_prefix_error(error,
+			       "failed to set ASIC register %s: ",
+			       fu_sunplus_camera_asic_register_to_string(reg));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_sunplus_camera_device_get_asic_register(FuSunplusCameraDevice *self,
+					   FuSunplusCameraAsicRegister reg,
+					   guint8 *value,
+					   GError **error)
+{
+	guint8 cmd[2] = {0x0};
+
+	fu_memwrite_uint16(cmd, reg, G_LITTLE_ENDIAN);
+
+	if (!fu_sunplus_camera_device_xu_set_cur(self,
+						 FU_SUNPLUS_CAMERA_SELECTOR_REG16_CMD,
+						 cmd,
+						 sizeof(cmd),
+						 error)) {
+		g_prefix_error(error,
+			       "failed to select ASIC register %s: ",
+			       fu_sunplus_camera_asic_register_to_string(reg));
+		return FALSE;
+	}
+	if (!fu_sunplus_camera_device_xu_get_cur(self,
+						 FU_SUNPLUS_CAMERA_SELECTOR_REG8_DATA,
+						 value,
+						 sizeof(*value),
+						 error)) {
+		g_prefix_error(error,
+			       "failed to get ASIC register %s: ",
+			       fu_sunplus_camera_asic_register_to_string(reg));
+		return FALSE;
+	}
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_sunplus_camera_device_clear_download_state(FuSunplusCameraDevice *self, GError **error)
+{
+	guint8 value = 0;
+
+	if (!fu_sunplus_camera_device_get_asic_register(
+		self,
+		FU_SUNPLUS_CAMERA_ASIC_REGISTER_DOWNLOAD_STATE_REG,
+		&value,
+		error))
+		return FALSE;
+	if (value == 0x00)
+		return TRUE;
+	if (!fu_sunplus_camera_device_set_asic_register(
+		self,
+		FU_SUNPLUS_CAMERA_ASIC_REGISTER_DOWNLOAD_STATE_REG,
+		0x00,
+		error))
 		return FALSE;
 
 	/* success */
+	fu_device_sleep(FU_DEVICE(self), 10);
 	return TRUE;
 }
 
@@ -523,6 +591,8 @@ fu_sunplus_camera_device_write_firmware(FuDevice *device,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_VERIFY, 20, "verify");
 
 	if (!fu_sunplus_camera_device_set_enabled(self, 0x01, error))
+		return FALSE;
+	if (!fu_sunplus_camera_device_clear_download_state(self, error))
 		return FALSE;
 	fu_progress_step_done(progress);
 

--- a/plugins/sunplus-camera/fu-sunplus-camera.rs
+++ b/plugins/sunplus-camera/fu-sunplus-camera.rs
@@ -17,3 +17,8 @@ enum FuSunplusCameraSelector {
     ReadAddr = 0x0E,
     ReadChunk = 0x16,
 }
+
+#[derive(ToString)]
+enum FuSunplusCameraAsicRegister {
+    DownloadStateReg = 0x2501,
+}


### PR DESCRIPTION
## Summary

Clear Sunplus camera ASIC register `0x2501` after entering download mode and before streaming the firmware payload. The latest vendor updater added this read/conditional-clear sequence, and it appears to be part of the reliable first-update path.

The plugin now reads the register through the existing selector 2/3 ASIC register mechanism, writes `0x00` only when the current value is nonzero, and waits 10 ms before continuing the transfer. The plugin README update documents the extra step in the normal update flow.

## Validation

- `git diff --check -- plugins/sunplus-camera/fu-sunplus-camera-device.c plugins/sunplus-camera/README.md`
- fwupd pre-commit hooks passed for the committed files

Full local build was not possible in this checkout because the current machine is missing GLib/GIO development files (`gio-2.0` / `glib-object.h`). The pre-push test hook also could not run because `test-fwupd` is not present in this build tree.
