### PR TITLE
lenovo-dock: Add provisioned Dock support

### DIFF
--- a/plugins/lenovo-dock/fu-lenovo-dock-device.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-device.c
@@ -14,9 +14,10 @@
 #define FU_LENOVO_DOCK_DEVICE_IFACE1_LEN 64
 #define FU_LENOVO_DOCK_DEVICE_IFACE2_LEN 272
 
-#define FU_LENOVO_DOCK_DEVICE_DELAY	 25   /* ms */
-#define FU_LENOVO_DOCK_DEVICE_DELAY_LONG 2500 /* ms */
-#define FU_LENOVO_DOCK_DEVICE_RETRIES	 10
+#define FU_LENOVO_DOCK_DEVICE_DELAY	 25    /* ms */
+#define FU_LENOVO_DOCK_DEVICE_DELAY_LONG 200 /* ms */
+#define FU_LENOVO_DOCK_DEVICE_RETRIES	 200
+#define FU_LENOVO_DOCK_DEVICE_PHASE2_DELAY 30000 /* ms */
 #define FU_LENOVO_DOCK_DEVICE_TIMEOUT	 250 /* ms */
 
 #define FU_LENOVO_DOCK_DEVICE_USAGE_INFO_SIZE  (4 * FU_KB)
@@ -27,6 +28,7 @@
 struct _FuLenovoDockDevice {
 	FuHidDevice parent_instance;
 	guint16 image_pid;
+	FuLenovoDockProvisionStatus provision_status;
 	FuStructLenovoDockUsage *st_usage;
 	GPtrArray *st_usage_items; /* element-type: FuStructLenovoDockUsageItem */
 };
@@ -39,6 +41,11 @@ fu_lenovo_dock_device_to_string(FuDevice *device, guint idt, GString *str)
 	FuLenovoDockDevice *self = FU_LENOVO_DOCK_DEVICE(device);
 
 	fwupd_codec_string_append_hex(str, idt, "ImagePid", self->image_pid);
+	fwupd_codec_string_append(
+	    str,
+	    idt,
+	    "ProvisionStatus",
+	    fu_lenovo_dock_provision_status_to_string(self->provision_status));
 	if (self->st_usage != NULL) {
 		g_autofree gchar *tmp = fu_struct_lenovo_dock_usage_to_string(self->st_usage);
 		fwupd_codec_string_append(str, idt, "Usage", tmp);
@@ -284,13 +291,62 @@ fu_lenovo_dock_device_dfu_control(FuLenovoDockDevice *self,
 }
 
 static gboolean
+fu_lenovo_dock_device_get_dfu_control_state(FuLenovoDockDevice *self,
+					    FuLenovoDockFwCtrlUpgradeStatus *upgrade_status,
+					    FuLenovoDockFwCtrlUpgradePhaseCtrl *ctrl,
+					    GError **error)
+{
+	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(FuStructLenovoDockGetDfuControlReq) st_req =
+	    fu_struct_lenovo_dock_get_dfu_control_req_new();
+	g_autoptr(FuStructLenovoDockGetDfuControlRes) st_res = NULL;
+
+	if (!fu_lenovo_dock_device_set_report1(self, st_req->buf, error))
+		return FALSE;
+	buf = fu_lenovo_dock_device_get_report1(self, FU_LENOVO_DOCK_DEVICE_DELAY, error);
+	if (buf == NULL)
+		return FALSE;
+	st_res = fu_struct_lenovo_dock_get_dfu_control_res_parse(buf->data, buf->len, 0x0, error);
+	if (st_res == NULL)
+		return FALSE;
+	if (upgrade_status != NULL)
+		*upgrade_status =
+		    fu_struct_lenovo_dock_get_dfu_control_res_get_upgrade_status(st_res);
+	if (ctrl != NULL)
+		*ctrl = fu_struct_lenovo_dock_get_dfu_control_res_get_ctrl(st_res);
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
 fu_lenovo_dock_device_ensure_version(FuLenovoDockDevice *self, GError **error)
 {
 	g_autofree gchar *version = NULL;
 	g_autoptr(GByteArray) buf = NULL;
+	g_autoptr(GError) error_local = NULL;
 	g_autoptr(FuStructLenovoDockGetVersionReq) st_req =
 	    fu_struct_lenovo_dock_get_version_req_new();
 	g_autoptr(FuStructLenovoDockGetVersionRes) st_res = NULL;
+	FuLenovoDockFwCtrlUpgradeStatus upgrade_status =
+	    FU_LENOVO_DOCK_FW_CTRL_UPGRADE_STATUS_NON_LOCK;
+	FuLenovoDockFwCtrlUpgradePhaseCtrl ctrl = FU_LENOVO_DOCK_FW_CTRL_UPGRADE_PHASE_CTRL_NA;
+
+	/* query upgrade status -- is dock in phase2? */
+	if (fu_lenovo_dock_device_get_dfu_control_state(self,
+							&upgrade_status,
+							&ctrl,
+							&error_local)) {
+		if (upgrade_status == FU_LENOVO_DOCK_FW_CTRL_UPGRADE_STATUS_LOCKED &&
+		    ctrl == FU_LENOVO_DOCK_FW_CTRL_UPGRADE_PHASE_CTRL_NON_UNPLUG) {
+			g_debug("lenovo-dock: delaying 0x81 for %ums while dock is in phase2",
+				(guint)FU_LENOVO_DOCK_DEVICE_PHASE2_DELAY);
+			fu_device_sleep(FU_DEVICE(self), FU_LENOVO_DOCK_DEVICE_PHASE2_DELAY);
+		}
+	} else {
+		g_debug("lenovo-dock: failed to query 0x8A before version: %s",
+			error_local->message);
+	}
 
 	if (!fu_lenovo_dock_device_set_report1(self, st_req->buf, error))
 		return FALSE;
@@ -330,11 +386,7 @@ fu_lenovo_dock_device_ensure_edition_state(FuLenovoDockDevice *self, GError **er
 	st_res = fu_struct_lenovo_dock_get_edition_res_parse(buf->data, buf->len, 0x0, error);
 	if (st_res == NULL)
 		return FALSE;
-	if (fu_struct_lenovo_dock_get_edition_res_get_provision_status(st_res) ==
-	    FU_LENOVO_DOCK_PROVISION_STATUS_PROVISIONED) {
-		g_debug("device is provisioned, locking firmware");
-		fu_device_add_problem(FU_DEVICE(self), FWUPD_DEVICE_PROBLEM_FIRMWARE_LOCKED);
-	}
+	self->provision_status = fu_struct_lenovo_dock_get_edition_res_get_provision_status(st_res);
 
 	/* success */
 	return TRUE;

--- a/plugins/lenovo-dock/fu-lenovo-dock.rs
+++ b/plugins/lenovo-dock/fu-lenovo-dock.rs
@@ -174,6 +174,7 @@ enum FuLenovoDockCfgType {
     MqttCa,
 }
 
+#[derive(ToString)]
 #[repr(u8)]
 enum FuLenovoDockProvisionStatus {
     None,
@@ -357,8 +358,11 @@ enum FuLenovoDockFwCtrlUpgradeStatus {
 enum FuLenovoDockFwCtrlUpgradePhaseCtrl {
     Na,
     InPhase1,
+    // done phase 1 and wait for UFP disconnect or the next power cycle
     Unplug,
+    // done phase 1 and immediately start phase 2
     NonUnplug,
+    // done phase 1 and schedule phase 2 later
     WaitForTimer,
 }
 
@@ -386,6 +390,31 @@ struct FuStructLenovoDockDfuControlRes {
     _reserved: u8,
     upgrade_status: FuLenovoDockFwCtrlUpgradeStatus,
     ctrl: FuLenovoDockFwCtrlUpgradePhaseCtrl,
+}
+
+#[derive(Default, New)]
+#[repr(C, packed)]
+struct FuStructLenovoDockGetDfuControlReq {
+    status: FuLenovoDockStatus == Default,
+    datasz: u8 == 0x00,
+    cmd_class: FuLenovoDockCmdClass == Dock,
+    cmd_id: FuLenovoDockExternalDockCmd == GetDockFirmwareUpgradeCtrl,
+    component_id: FuLenovoDockComponentId == None,
+    _reserved: u8,
+}
+
+#[derive(Default, Parse)]
+#[repr(C, packed)]
+struct FuStructLenovoDockGetDfuControlRes {
+    status: FuLenovoDockStatus == Success,
+    datasz: u8 == 0x06,
+    cmd_class: FuLenovoDockCmdClass == Dock,
+    cmd_id: FuLenovoDockExternalDockCmd == GetDockFirmwareUpgradeCtrl,
+    component_id: FuLenovoDockComponentId == None,
+    _reserved: u8,
+    upgrade_status: FuLenovoDockFwCtrlUpgradeStatus,
+    ctrl: FuLenovoDockFwCtrlUpgradePhaseCtrl,
+    _schedule_time: u32le,
 }
 
 #[derive(Default, New, ToString)]


### PR DESCRIPTION
For the lenovo-dock plugin update, I've modified the provisioned dock for LVFS support and cover the case of provisioned dock network status changing the command busy time might be longer for response.
For the retries enlarge from 10 to 200, it could fixed the responding of provisioned dock busy state for the command handling but it might let AMD system get the dock response for the query version before dock actual completed the Phase2 update. (original plugin handle 10 times retries but the dock will keeping response busy around 16 times since DMC is under processing the setup for Phase2 beginning and plugin will wait for device re-enumerate then query the version by original plugin)
It cause by AMD system design to detect the Dock U2 Hub/device even it setup the disconnect by PD (Not happen under Intel platform system) and I add the mechanism to detect the dock under phase 2 and flash locked or not before query version.
If get dock under phase 2 and flash locked, we'll delay get version after 30 sec by Phase2_Delay and the plugin query the device version after 30 sec it would found device not existed under system since DMC updated and reset the DMC device won't enumerate to system and plugin will wait for the device resume to get the updated version for the version info update. (Verified by AMD platform system)
If user using the Intel platform, it would saw the 0x8A can't get the response since Intel platform U2 Hub/device would eject from system once it set for the Nonunplug and it'll wait for the device resume to get the dock state and updated version for the version detection after update completed.(Verified by Intel platform system)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
•	Remove FWUPD_DEVICE_PROBLEM_FIRMWARE_LOCKED when dock is provisioned for provisioned dock update support
•	Add support for querying dock firmware upgrade control state (0x8A)
•	Add DFU control state before check version if device under Phase2 updating, postpone version query for AMD system behavior support
•	Modify the retry and delay from DELAY_LONG=2500ms/RETRIES=10 and DELAY_LONG=200ms/RETRIES=200
•	Add PHASE2_DELAY=30000ms to delay version query when device under Phase 2
