### PR TITLE
trivial: normalize shebangs, move sh args to `set`

### DIFF
--- a/contrib/build-venv.sh
+++ b/contrib/build-venv.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 . "$(dirname "$(readlink -f "$0")")/nix.sh"
 

--- a/contrib/ci/arch-test.sh
+++ b/contrib/ci/arch-test.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -ex
+#!/bin/sh
+set -ex
 
 pacman -Sy --noconfirm qt5-base gcovr python-flask swtpm tpm2-tools
 pacman -U --noconfirm dist/*.pkg.*

--- a/contrib/ci/arch.sh
+++ b/contrib/ci/arch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 shopt -s extglob

--- a/contrib/ci/build_macos.sh
+++ b/contrib/ci/build_macos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/contrib/ci/centos-test.sh
+++ b/contrib/ci/centos-test.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 #install RPM packages
 dnf install -y dist/*.rpm

--- a/contrib/ci/centos.sh
+++ b/contrib/ci/centos.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/contrib/ci/coverage.sh
+++ b/contrib/ci/coverage.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 # if invoked outside of CI
 if [ "$CI" != "true" ]; then

--- a/contrib/ci/ctokenizer.py
+++ b/contrib/ci/ctokenizer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2025 Richard Hughes <richard@hughsie.com>
 #

--- a/contrib/ci/ctokenizer_test.py
+++ b/contrib/ci/ctokenizer_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2025 Richard Hughes <richard@hughsie.com>
 #

--- a/contrib/ci/debian-test.sh
+++ b/contrib/ci/debian-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Set up fatal-criticals systemd override

--- a/contrib/ci/debian.sh
+++ b/contrib/ci/debian.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # Set Qubes Os vars if -Dqubes=true is parameter

--- a/contrib/ci/fedora-test.sh
+++ b/contrib/ci/fedora-test.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 # workaround dnf bug
 export FORCE_COLUMNS=100

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -x
 

--- a/contrib/test-venv.sh
+++ b/contrib/test-venv.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 . "$(dirname "$(readlink -f "$0")")/nix.sh"
 

--- a/data/tests/fwupd.sh
+++ b/data/tests/fwupd.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 exec 0>/dev/null
 exec 2>&1

--- a/generate-build/unittest_inspector.py
+++ b/generate-build/unittest_inspector.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
 # Copyright 2020 Canonical Ltd

--- a/plugins/uefi-capsule/fwupd.grub.conf.in
+++ b/plugins/uefi-capsule/fwupd.grub.conf.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -e
 

--- a/plugins/uefi-capsule/tests/example/build.sh
+++ b/plugins/uefi-capsule/tests/example/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 appstream-util validate-relax firmware.metainfo.xml
 echo -n "hello world" >firmware.bin
 fwupdtool build-cabinet firmware.cab firmware.bin firmware.metainfo.xml


### PR DESCRIPTION
In order to have shell scripts behave the same regardless of if they're executed using the shebang or directly calling sh/bash to run the script.

Some of these are arguably not important because some of these scripts are specifically intended for just running on a certain distro that does follow FHS and has e.g. /bin/bash but this way it's consistent across the repo.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
