### PR TITLE
pixart-tp: Add PID 0x1343

### DIFF
--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -8,6 +8,9 @@ Plugin = pixart_tp
 [HIDRAW\VEN_093A&DEV_0343]
 Plugin = pixart_tp
 
+[HIDRAW\VEN_093A&DEV_1343]
+Plugin = pixart_tp
+
 [HIDRAW\VEN_093A&DEV_3307]
 Plugin = pixart_tp
 


### PR DESCRIPTION
Same touch IC as 0x0343 but different board revision. For Framework Laptop 13 Pro Haptic Touchpad

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
