### PR TITLE
pixart-tp: Add PID 0x1343

### DIFF
--- a/plugins/pixart-tp/pixart-tp.quirk
+++ b/plugins/pixart-tp/pixart-tp.quirk
@@ -5,6 +5,9 @@ PixartTpSramSelect = 0x08
 [HIDRAW\VEN_093A&DEV_0343]
 Plugin = pixart_tp
 
+[HIDRAW\VEN_093A&DEV_1343]
+Plugin = pixart_tp
+
 [HIDRAW\VEN_093A&DEV_3307]
 Plugin = pixart_tp
 PixartTpSramSelect = 0x08


### PR DESCRIPTION
Same touch IC as 0x0343 but different board revision. For Framework Laptop 13 Pro Haptic Touchpad


(cherry picked from #10306)