### PR TITLE
himax-tp: change versioning source

### DIFF
--- a/plugins/himax-tp/fu-himax-tp-hid-device.c
+++ b/plugins/himax-tp/fu-himax-tp-hid-device.c
@@ -860,10 +860,10 @@ fu_himax_tp_hid_device_setup(FuDevice *device, GError **error)
 	if (!fu_device_build_instance_id(device, error, "HIDRAW", "VEN", "DEV", "CID", NULL))
 		return FALSE;
 
-	/* version format : pid.cid (decimal) */
-	version_str = g_strdup_printf("%u.%u",
-				      fu_struct_himax_tp_hid_info_get_pid(self->st_info),
-				      fu_struct_himax_tp_hid_info_get_cid(self->st_info));
+	/* version format : cid(minor).tp_cfg_ver (decimal) */
+	version_str = g_strdup_printf("%hhu.%hhu",
+				      fu_struct_himax_tp_hid_info_get_cid(self->st_info) & 0xFF,
+				      fu_struct_himax_tp_hid_info_get_tp_cfg_ver(self->st_info));
 	fu_device_set_version(device, version_str);
 
 	/* success */

--- a/plugins/himax-tp/fu-himax-tp.rs
+++ b/plugins/himax-tp/fu-himax-tp.rs
@@ -30,7 +30,7 @@ struct FuStructHimaxTpHidInfo {
     vid: u16be,
     pid: u16be,
     _reserved_11: [u8; 32],
-    _reserved_12: u8,
+    tp_cfg_ver: u8,
     _reserved_13: u8,
     _reserved_14: u8,
     _reserved_15: u8,

--- a/plugins/himax-tp/tests/himax-touch.json
+++ b/plugins/himax-tp/tests/himax-touch.json
@@ -3,11 +3,11 @@
   "interactive": false,
   "steps": [
     {
-      "url": "30896caf56cd9cff760aa4b4be18cec9412ff6cb463948d36dc4d8cc3ab649f3-himax-21f3.cab",
-      "emulation-url": "d43510b2d1e64262ada322a41c89d8965d33eacc1dee155039fcb0b54a115d3e-himaxtp-21f3.zip",
+      "url": "c25e327db58240bb17f6252faabfb2b38370d92a6a62f7a1910966a19565a9dc-himax-21f3-243.0.cab",
+      "emulation-url": "bf9efb66d4e8898bef0fa91e6fc69c57cc8ee70b8d795ce109386c710d42a60c-new-emu-21f3-243.0.zip",
       "components": [
         {
-          "version": "5373.8691",
+          "version": "243.0",
           "guids": [
             "3df6137a-8ba8-5394-894d-31080301bba0"
           ]


### PR DESCRIPTION
Original version format is PID.CID, but there's an additional TP config version represent configuration optimization but not changing firmware algorithm version(represented as CID). This one remove not truely-needed PID and use CID minor version as current major version and TP config version as current minor version: (CID minor).(TP config version)

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
