### PR TITLE
Use the correct converter flags when returning device and firmware results

### DIFF
--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1872,7 +1872,8 @@ fu_dbus_daemon_method_get_results(FuDbusDaemon *self,
 		fu_dbus_daemon_method_invocation_return_gerror(invocation, error);
 		return;
 	}
-	val = fwupd_codec_to_variant(FWUPD_CODEC(device), FWUPD_CODEC_FLAG_TRUSTED);
+	val = fwupd_codec_to_variant(FWUPD_CODEC(device),
+				     fu_engine_request_get_converter_flags(request));
 	g_dbus_method_invocation_return_value(invocation, g_variant_new_tuple(&val, 1));
 }
 
@@ -2417,7 +2418,7 @@ fu_dbus_daemon_method_get_details(FuDbusDaemon *self,
 	}
 	g_dbus_method_invocation_return_value(
 	    invocation,
-	    fwupd_codec_array_to_variant(results, FWUPD_CODEC_FLAG_TRUSTED));
+	    fwupd_codec_array_to_variant(results, fu_engine_request_get_converter_flags(request)));
 #else
 	g_dbus_method_invocation_return_error_literal(invocation,
 						      FWUPD_ERROR,


### PR DESCRIPTION
The handlers were unconditionally using FWUPD_CODEC_FLAG_TRUSTED rather than using the converter flags from the request.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
