### PR TITLE
trivial: Handle the error return value when getting a failed HSI D-Bus property

### DIFF
--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -2750,6 +2750,14 @@ fu_dbus_daemon_get_property(GDBusConnection *connection_,
 	if (g_strcmp0(property_name, "HostSecurityId") == 0) {
 #ifdef HAVE_HSI
 		g_autofree gchar *tmp = fu_engine_get_host_security_id(engine, NULL);
+		if (tmp == NULL) {
+			g_set_error(error, /* nocheck:error */
+				    G_DBUS_ERROR,
+				    G_DBUS_ERROR_NOT_SUPPORTED,
+				    "failed to get daemon property %s",
+				    property_name);
+			return NULL;
+		}
 		return g_variant_new_string(tmp);
 #else
 		g_set_error(error, /* nocheck:error */


### PR DESCRIPTION
If the function failed and returned NULL, a critical assertion would be logged.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
