### PR TITLE
trivial: Validate variant types when parsing GVariant data

### DIFF
--- a/libfwupd/fwupd-bios-setting.c
+++ b/libfwupd/fwupd-bios-setting.c
@@ -895,52 +895,77 @@ static void
 fwupd_bios_setting_from_key_value(FwupdBiosSetting *self, const gchar *key, GVariant *value)
 {
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_TYPE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_bios_setting_set_kind(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FILENAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_path(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_CURRENT_VALUE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_current_value(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_FILENAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_filename(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DESCRIPTION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_bios_setting_set_description(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_POSSIBLE_VALUES) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_bios_setting_add_possible_value(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_LOWER_BOUND) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_bios_setting_set_lower_bound(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_UPPER_BOUND) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_bios_setting_set_upper_bound(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_SCALAR_INCREMENT) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_bios_setting_set_scalar_increment(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_READ_ONLY) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_BOOLEAN))
+			return;
 		fwupd_bios_setting_set_read_only(self, g_variant_get_boolean(value));
 		return;
 	}

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -576,13 +576,13 @@ fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 	if (g_variant_dict_contains(dict, "Status")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "Status");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_UINT32))
 			fwupd_client_set_status(self, g_variant_get_uint32(val));
 	}
 	if (g_variant_dict_contains(dict, "Tainted")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "Tainted");
-		if (val != NULL) {
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_BOOLEAN)) {
 			priv->tainted = g_variant_get_boolean(val);
 			fwupd_client_object_notify(self, "tainted");
 		}
@@ -590,7 +590,7 @@ fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 	if (g_variant_dict_contains(dict, "Interactive")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "Interactive");
-		if (val != NULL) {
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_BOOLEAN)) {
 			priv->interactive = g_variant_get_boolean(val);
 			fwupd_client_object_notify(self, "interactive");
 		}
@@ -598,65 +598,65 @@ fwupd_client_properties_changed_cb(GDBusProxy *proxy,
 	if (g_variant_dict_contains(dict, "PercentageFull")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "PercentageFull");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_DOUBLE))
 			fwupd_client_set_percentage(self, g_variant_get_double(val));
 	} else if (g_variant_dict_contains(dict, "Percentage")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "Percentage");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_UINT32))
 			fwupd_client_set_percentage(self, g_variant_get_uint32(val));
 	}
 	if (g_variant_dict_contains(dict, FWUPD_RESULT_KEY_BATTERY_LEVEL)) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, FWUPD_RESULT_KEY_BATTERY_LEVEL);
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_UINT32))
 			fwupd_client_set_battery_level(self, g_variant_get_uint32(val));
 	}
 	if (g_variant_dict_contains(dict, FWUPD_RESULT_KEY_BATTERY_THRESHOLD)) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, FWUPD_RESULT_KEY_BATTERY_THRESHOLD);
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_UINT32))
 			fwupd_client_set_battery_threshold(self, g_variant_get_uint32(val));
 	}
 	if (g_variant_dict_contains(dict, "DaemonVersion")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "DaemonVersion");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_daemon_version(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "HostBkc")) {
 		g_autoptr(GVariant) val = g_dbus_proxy_get_cached_property(proxy, "HostBkc");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_host_bkc(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "HostVendor")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "HostVendor");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_host_vendor(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "HostProduct")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "HostProduct");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_host_product(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "HostMachineId")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "HostMachineId");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_host_machine_id(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "HostSecurityId")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "HostSecurityId");
-		if (val != NULL)
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 			fwupd_client_set_host_security_id(self, g_variant_get_string(val, NULL));
 	}
 	if (g_variant_dict_contains(dict, "OnlyTrusted")) {
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy, "OnlyTrusted");
-		if (val != NULL) {
+		if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_BOOLEAN)) {
 			priv->only_trusted = g_variant_get_boolean(val);
 			fwupd_client_object_notify(self, "only-trusted");
 		}
@@ -1016,34 +1016,34 @@ fwupd_client_connect_get_proxy_cb(GObject *source, GAsyncResult *res, gpointer u
 			 G_CALLBACK(fwupd_client_name_owner_changed_cb),
 			 self);
 	val = g_dbus_proxy_get_cached_property(priv->proxy, "DaemonVersion");
-	if (val != NULL)
+	if (val != NULL && g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_daemon_version(self, g_variant_get_string(val, NULL));
 	val2 = g_dbus_proxy_get_cached_property(priv->proxy, "Tainted");
-	if (val2 != NULL)
+	if (val2 != NULL && g_variant_is_of_type(val2, G_VARIANT_TYPE_BOOLEAN))
 		priv->tainted = g_variant_get_boolean(val2);
 	val3 = g_dbus_proxy_get_cached_property(priv->proxy, "Status");
-	if (val3 != NULL)
+	if (val3 != NULL && g_variant_is_of_type(val3, G_VARIANT_TYPE_UINT32))
 		fwupd_client_set_status(self, g_variant_get_uint32(val3));
 	val4 = g_dbus_proxy_get_cached_property(priv->proxy, "Interactive");
-	if (val4 != NULL)
+	if (val4 != NULL && g_variant_is_of_type(val4, G_VARIANT_TYPE_BOOLEAN))
 		priv->interactive = g_variant_get_boolean(val4);
 	val5 = g_dbus_proxy_get_cached_property(priv->proxy, "HostProduct");
-	if (val5 != NULL)
+	if (val5 != NULL && g_variant_is_of_type(val5, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_host_product(self, g_variant_get_string(val5, NULL));
 	val10 = g_dbus_proxy_get_cached_property(priv->proxy, "HostVendor");
-	if (val10 != NULL)
+	if (val10 != NULL && g_variant_is_of_type(val10, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_host_vendor(self, g_variant_get_string(val10, NULL));
 	val6 = g_dbus_proxy_get_cached_property(priv->proxy, "HostMachineId");
-	if (val6 != NULL)
+	if (val6 != NULL && g_variant_is_of_type(val6, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_host_machine_id(self, g_variant_get_string(val6, NULL));
 	val7 = g_dbus_proxy_get_cached_property(priv->proxy, "HostSecurityId");
-	if (val7 != NULL)
+	if (val7 != NULL && g_variant_is_of_type(val7, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_host_security_id(self, g_variant_get_string(val7, NULL));
 	val8 = g_dbus_proxy_get_cached_property(priv->proxy, "HostBkc");
-	if (val8 != NULL)
+	if (val8 != NULL && g_variant_is_of_type(val8, G_VARIANT_TYPE_STRING))
 		fwupd_client_set_host_bkc(self, g_variant_get_string(val8, NULL));
 	val9 = g_dbus_proxy_get_cached_property(priv->proxy, "OnlyTrusted");
-	if (val9 != NULL)
+	if (val9 != NULL && g_variant_is_of_type(val9, G_VARIANT_TYPE_BOOLEAN))
 		priv->only_trusted = g_variant_get_boolean(val9);
 
 	val_hwids = g_dbus_proxy_get_cached_property(priv->proxy, "Hwids");

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -2516,14 +2516,20 @@ fwupd_device_from_key_value(FwupdDevice *self, const gchar *key, GVariant *value
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DEVICE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_PARENT_DEVICE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_parent_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_COMPOSITE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_composite_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
@@ -2552,56 +2558,82 @@ fwupd_device_from_key_value(FwupdDevice *self, const gchar *key, GVariant *value
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_GUID) == 0) {
-		g_autofree const gchar **guids = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **guids = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		guids = g_variant_get_strv(value, NULL);
 		for (guint i = 0; guids != NULL && guids[i] != NULL; i++)
 			fwupd_device_add_guid(self, guids[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_INSTANCE_IDS) == 0) {
-		g_autofree const gchar **instance_ids = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **instance_ids = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		instance_ids = g_variant_get_strv(value, NULL);
 		for (guint i = 0; instance_ids != NULL && instance_ids[i] != NULL; i++)
 			fwupd_device_add_instance_id(self, instance_ids[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_ICON) == 0) {
-		g_autofree const gchar **icons = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **icons = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		icons = g_variant_get_strv(value, NULL);
 		for (guint i = 0; icons != NULL && icons[i] != NULL; i++)
 			fwupd_device_add_icon(self, icons[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VENDOR) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_vendor(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VENDOR_ID) == 0) {
 		g_auto(GStrv) vendor_ids = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		vendor_ids = g_strsplit(g_variant_get_string(value, NULL), "|", -1);
 		for (guint i = 0; vendor_ids[i] != NULL; i++)
 			fwupd_device_add_vendor_id(self, vendor_ids[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SERIAL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_serial(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SUMMARY) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_summary(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DETAILS_URL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_details_url(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BRANCH) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_branch(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CHECKSUM) == 0) {
-		const gchar *checksums = g_variant_get_string(value, NULL);
+		const gchar *checksums = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
+		checksums = g_variant_get_string(value, NULL);
 		if (checksums != NULL) {
 			g_auto(GStrv) split = g_strsplit(checksums, ",", -1);
 			for (guint i = 0; split[i] != NULL; i++)
@@ -2610,35 +2642,50 @@ fwupd_device_from_key_value(FwupdDevice *self, const gchar *key, GVariant *value
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_PLUGIN) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_plugin(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_PROTOCOL) == 0) {
 		g_auto(GStrv) protocols = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		protocols = g_strsplit(g_variant_get_string(value, NULL), "|", -1);
 		for (guint i = 0; protocols[i] != NULL; i++)
 			fwupd_device_add_protocol(self, protocols[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_ISSUES) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_device_add_issue(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_version(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION_LOWEST) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_version_lowest(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION_HIGHEST) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_version_highest(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION_BOOTLOADER) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_version_bootloader(self, g_variant_get_string(value, NULL));
 		return;
 	}
@@ -2659,6 +2706,8 @@ fwupd_device_from_key_value(FwupdDevice *self, const gchar *key, GVariant *value
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_ERROR) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_device_set_update_error(self, g_variant_get_string(value, NULL));
 		return;
 	}

--- a/libfwupd/fwupd-plugin.c
+++ b/libfwupd/fwupd-plugin.c
@@ -211,10 +211,14 @@ static void
 fwupd_plugin_from_key_value(FwupdPlugin *self, const gchar *key, GVariant *value)
 {
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_plugin_set_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FLAGS) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_plugin_set_flags(self, g_variant_get_uint64(value));
 		return;
 	}

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -1879,42 +1879,62 @@ fwupd_release_from_key_value(FwupdRelease *self, const gchar *key, GVariant *val
 {
 	FwupdReleasePrivate *priv = GET_PRIVATE(self);
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_REMOTE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_remote_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_APPSTREAM_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_appstream_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_RELEASE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DETACH_CAPTION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_detach_caption(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DETACH_IMAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_detach_image(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FILENAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_filename(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_PROTOCOL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_protocol(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_LICENSE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_license(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME_VARIANT_SUFFIX) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_name_variant_suffix(self, g_variant_get_string(value, NULL));
 		return;
 	}
@@ -1927,73 +1947,109 @@ fwupd_release_from_key_value(FwupdRelease *self, const gchar *key, GVariant *val
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SUMMARY) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_summary(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BRANCH) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_branch(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DESCRIPTION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_description(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CATEGORIES) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_release_add_category(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_ISSUES) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_release_add_issue(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CHECKSUM) == 0) {
-		const gchar *checksums = g_variant_get_string(value, NULL);
-		g_auto(GStrv) split = g_strsplit(checksums, ",", -1);
+		const gchar *checksums = NULL;
+		g_auto(GStrv) split = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
+		checksums = g_variant_get_string(value, NULL);
+		split = g_strsplit(checksums, ",", -1);
 		for (guint i = 0; split[i] != NULL; i++)
 			fwupd_release_add_checksum(self, split[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_LOCATIONS) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_release_add_location(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_TAGS) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_release_add_tag(self, strv[i]);
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_URI) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_add_location(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_HOMEPAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_homepage(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DETAILS_URL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_details_url(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SOURCE_URL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_source_url(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SBOM_URL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_sbom_url(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_version(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VENDOR) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_vendor(self, g_variant_get_string(value, NULL));
 		return;
 	}
@@ -2010,10 +2066,14 @@ fwupd_release_from_key_value(FwupdRelease *self, const gchar *key, GVariant *val
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_MESSAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_update_message(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_IMAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_release_set_update_image(self, g_variant_get_string(value, NULL));
 		return;
 	}

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -1721,7 +1721,8 @@ fwupd_remote_from_variant_iter(FwupdCodec *codec, GVariantIter *iter)
 
 	/* three passes, as we have to construct Id -> Url -> * */
 	while (g_variant_iter_loop(iter, "{&sv}", &key, &value)) {
-		if (g_strcmp0(key, FWUPD_RESULT_KEY_REMOTE_ID) == 0)
+		if (g_strcmp0(key, FWUPD_RESULT_KEY_REMOTE_ID) == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
 			fwupd_remote_set_id(self, g_variant_get_string(value, NULL));
 		if (g_strcmp0(key, "Type") == 0)
 			fwupd_remote_set_kind(self, fwupd_variant_get_uint32(value));
@@ -1729,35 +1730,47 @@ fwupd_remote_from_variant_iter(FwupdCodec *codec, GVariantIter *iter)
 			fwupd_remote_set_flags(self, fwupd_variant_get_uint64(value));
 	}
 	while (g_variant_iter_loop(iter2, "{&sv}", &key, &value)) {
-		if (g_strcmp0(key, FWUPD_RESULT_KEY_URI) == 0)
+		if (g_strcmp0(key, FWUPD_RESULT_KEY_URI) == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
 			fwupd_remote_set_metadata_uri(self, g_variant_get_string(value, NULL));
-		if (g_strcmp0(key, "FilenameCache") == 0)
+		if (g_strcmp0(key, "FilenameCache") == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
 			fwupd_remote_set_filename_cache(self, g_variant_get_string(value, NULL));
-		if (g_strcmp0(key, "FilenameSource") == 0)
+		if (g_strcmp0(key, "FilenameSource") == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
 			fwupd_remote_set_filename_source(self, g_variant_get_string(value, NULL));
-		if (g_strcmp0(key, "ReportUri") == 0)
+		if (g_strcmp0(key, "ReportUri") == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
 			fwupd_remote_set_report_uri(self, g_variant_get_string(value, NULL));
 	}
 	while (g_variant_iter_loop(iter3, "{&sv}", &key, &value)) {
-		if (g_strcmp0(key, "Username") == 0) {
+		if (g_strcmp0(key, "Username") == 0 &&
+		    g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_username(self, g_variant_get_string(value, NULL));
-		} else if (g_strcmp0(key, "Password") == 0) {
+		} else if (g_strcmp0(key, "Password") == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_password(self, g_variant_get_string(value, NULL));
-		} else if (g_strcmp0(key, "Title") == 0) {
+		} else if (g_strcmp0(key, "Title") == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_title(self, g_variant_get_string(value, NULL));
-		} else if (g_strcmp0(key, "PrivacyUri") == 0) {
+		} else if (g_strcmp0(key, "PrivacyUri") == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_privacy_uri(self, g_variant_get_string(value, NULL));
-		} else if (g_strcmp0(key, "Agreement") == 0) {
+		} else if (g_strcmp0(key, "Agreement") == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_agreement(self, g_variant_get_string(value, NULL));
-		} else if (g_strcmp0(key, FWUPD_RESULT_KEY_CHECKSUM) == 0) {
+		} else if (g_strcmp0(key, FWUPD_RESULT_KEY_CHECKSUM) == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_checksum_sig(self, g_variant_get_string(value, NULL));
 		} else if (g_strcmp0(key, "Priority") == 0) {
-			priv->priority = g_variant_get_int32(value);
+			if (g_variant_is_of_type(value, G_VARIANT_TYPE_INT32))
+				priv->priority = g_variant_get_int32(value);
 		} else if (g_strcmp0(key, "ModificationTime") == 0) {
 			priv->mtime = fwupd_variant_get_uint64(value);
 		} else if (g_strcmp0(key, "RefreshInterval") == 0) {
 			priv->refresh_interval = fwupd_variant_get_uint64(value);
-		} else if (g_strcmp0(key, "FirmwareBaseUri") == 0) {
+		} else if (g_strcmp0(key, "FirmwareBaseUri") == 0 &&
+			   g_variant_is_of_type(value, G_VARIANT_TYPE_STRING)) {
 			fwupd_remote_set_firmware_base_uri(self, g_variant_get_string(value, NULL));
 		}
 	}

--- a/libfwupd/fwupd-report.c
+++ b/libfwupd/fwupd-report.c
@@ -549,42 +549,62 @@ fwupd_report_from_key_value(FwupdReport *self, const gchar *key, GVariant *value
 {
 	FwupdReportPrivate *priv = GET_PRIVATE(self);
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DISTRO_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_distro_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DISTRO_VARIANT) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_distro_variant(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DISTRO_VERSION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_distro_version(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VENDOR) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_vendor(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VENDOR_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_report_set_vendor_id(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DEVICE_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_device_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CREATED) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_report_set_created(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION_OLD) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_version_old(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_REMOTE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_report_set_remote_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FLAGS) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_report_set_flags(self, g_variant_get_uint64(value));
 		return;
 	}

--- a/libfwupd/fwupd-request.c
+++ b/libfwupd/fwupd-request.c
@@ -243,30 +243,44 @@ static void
 fwupd_request_from_key_value(FwupdRequest *self, const gchar *key, GVariant *value)
 {
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_APPSTREAM_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_request_set_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CREATED) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_request_set_created(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DEVICE_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_request_set_device_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_MESSAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_request_set_message(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_UPDATE_IMAGE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_request_set_image(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_REQUEST_KIND) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_request_set_kind(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FLAGS) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_request_set_flags(self, g_variant_get_uint64(value));
 		return;
 	}

--- a/libfwupd/fwupd-security-attr.c
+++ b/libfwupd/fwupd-security-attr.c
@@ -1387,59 +1387,88 @@ fwupd_security_attr_from_key_value(FwupdSecurityAttr *self, const gchar *key, GV
 	FwupdSecurityAttrPrivate *priv = GET_PRIVATE(self);
 
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_APPSTREAM_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_appstream_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_CREATED) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_security_attr_set_created(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_NAME) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_name(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_SUMMARY) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_title(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_DESCRIPTION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_description(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_PLUGIN) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_plugin(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_VERSION) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_fwupd_version(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_URI) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_url(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_FLAGS) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT64))
+			return;
 		fwupd_security_attr_set_flags(self, g_variant_get_uint64(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_HSI_LEVEL) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_security_attr_set_level(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_HSI_RESULT) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_security_attr_set_result(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_HSI_RESULT_FALLBACK) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_security_attr_set_result_fallback(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_HSI_RESULT_SUCCESS) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_UINT32))
+			return;
 		fwupd_security_attr_set_result_success(self, g_variant_get_uint32(value));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_GUID) == 0) {
-		g_autofree const gchar **strv = g_variant_get_strv(value, NULL);
+		g_autofree const gchar **strv = NULL;
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING_ARRAY))
+			return;
+		strv = g_variant_get_strv(value, NULL);
 		for (guint i = 0; strv[i] != NULL; i++)
 			fwupd_security_attr_add_guid(self, strv[i]);
 		return;
@@ -1451,27 +1480,37 @@ fwupd_security_attr_from_key_value(FwupdSecurityAttr *self, const gchar *key, GV
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_ID) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_bios_setting_id(self, g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_TARGET_VALUE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_bios_setting_target_value(
 		    self,
 		    g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_BIOS_SETTING_CURRENT_VALUE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_bios_setting_current_value(
 		    self,
 		    g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_KERNEL_CURRENT_VALUE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_kernel_current_value(self,
 							     g_variant_get_string(value, NULL));
 		return;
 	}
 	if (g_strcmp0(key, FWUPD_RESULT_KEY_KERNEL_TARGET_VALUE) == 0) {
+		if (!g_variant_is_of_type(value, G_VARIANT_TYPE_STRING))
+			return;
 		fwupd_security_attr_set_kernel_target_value(self,
 							    g_variant_get_string(value, NULL));
 		return;

--- a/libfwupdplugin/fu-bluez-device.c
+++ b/libfwupdplugin/fu-bluez-device.c
@@ -411,6 +411,8 @@ fu_bluez_device_read_battery_interface(FuBluezDevice *self,
 		return TRUE;
 	}
 
+	if (!g_variant_is_of_type(obj_percentage, G_VARIANT_TYPE_BYTE))
+		return TRUE;
 	percentage = g_variant_get_byte(obj_percentage);
 	fu_device_set_battery_level(FU_DEVICE(self), percentage);
 
@@ -582,7 +584,7 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 	}
 
 	val_address = g_dbus_proxy_get_cached_property(priv->proxy, "Address");
-	if (val_address == NULL) {
+	if (val_address == NULL || !g_variant_is_of_type(val_address, G_VARIANT_TYPE_STRING)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -591,12 +593,11 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 	}
 	fu_device_set_logical_id(device, g_variant_get_string(val_address, NULL));
 	val_adapter = g_dbus_proxy_get_cached_property(priv->proxy, "Adapter");
-	if (val_adapter != NULL)
+	if (val_adapter != NULL && g_variant_is_of_type(val_adapter, G_VARIANT_TYPE_STRING))
 		fu_device_set_physical_id(device, g_variant_get_string(val_adapter, NULL));
 	val_name = g_dbus_proxy_get_cached_property(priv->proxy, "Name");
-	if (val_name != NULL) {
+	if (val_name != NULL && g_variant_is_of_type(val_name, G_VARIANT_TYPE_STRING)) {
 		fu_device_set_name(device, g_variant_get_string(val_name, NULL));
-		/* register the device by its alias, since modalias could be absent */
 		fu_device_add_instance_str(FU_DEVICE(self),
 					   "NAME",
 					   g_variant_get_string(val_name, NULL));
@@ -609,9 +610,8 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 						 NULL);
 	}
 	val_alias = g_dbus_proxy_get_cached_property(priv->proxy, "Alias");
-	if (val_alias != NULL) {
+	if (val_alias != NULL && g_variant_is_of_type(val_alias, G_VARIANT_TYPE_STRING)) {
 		fu_device_set_name(device, g_variant_get_string(val_alias, NULL));
-		/* register the device by its alias, since modalias could be absent */
 		fu_device_add_instance_str(FU_DEVICE(self),
 					   "ALIAS",
 					   g_variant_get_string(val_alias, NULL));
@@ -623,10 +623,10 @@ fu_bluez_device_probe(FuDevice *device, GError **error)
 						 NULL);
 	}
 	val_icon = g_dbus_proxy_get_cached_property(priv->proxy, "Icon");
-	if (val_icon != NULL)
+	if (val_icon != NULL && g_variant_is_of_type(val_icon, G_VARIANT_TYPE_STRING))
 		fu_device_add_icon(device, g_variant_get_string(val_icon, NULL));
 	val_modalias = g_dbus_proxy_get_cached_property(priv->proxy, "Modalias");
-	if (val_modalias != NULL)
+	if (val_modalias != NULL && g_variant_is_of_type(val_modalias, G_VARIANT_TYPE_STRING))
 		fu_bluez_device_set_modalias(self, g_variant_get_string(val_modalias, NULL));
 
 	/* success, if we added one service or characteristic */

--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -1181,11 +1181,13 @@ fu_context_detect_full_disk_encryption(FuContext *self)
 		g_autoptr(GVariant) id_type = g_dbus_proxy_get_cached_property(proxy, "IdType");
 		g_autoptr(GVariant) device = g_dbus_proxy_get_cached_property(proxy, "Device");
 		g_autoptr(GVariant) id_label = g_dbus_proxy_get_cached_property(proxy, "IdLabel");
-		if (id_type != NULL && device != NULL &&
+		if (id_type != NULL && g_variant_is_of_type(id_type, G_VARIANT_TYPE_STRING) &&
+		    device != NULL &&
 		    g_strcmp0(g_variant_get_string(id_type, NULL), "BitLocker") == 0)
 			priv->flags |= FU_CONTEXT_FLAG_FDE_BITLOCKER;
 
-		if (id_type != NULL && id_label != NULL &&
+		if (id_type != NULL && g_variant_is_of_type(id_type, G_VARIANT_TYPE_STRING) &&
+		    id_label != NULL && g_variant_is_of_type(id_label, G_VARIANT_TYPE_STRING) &&
 		    g_strcmp0(g_variant_get_string(id_label, NULL), "ubuntu-data-enc") == 0 &&
 		    g_strcmp0(g_variant_get_string(id_type, NULL), "crypto_LUKS") == 0) {
 			priv->flags |= FU_CONTEXT_FLAG_FDE_SNAPD;

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -271,7 +271,7 @@ fu_volume_get_size(FuVolume *self)
 	if (self->proxy_blk == NULL)
 		return 0;
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "Size");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_UINT64))
 		return 0;
 	return g_variant_get_uint64(val);
 }
@@ -296,7 +296,7 @@ fu_volume_get_partition_size(FuVolume *self)
 	if (self->proxy_part == NULL)
 		return 0;
 	val = g_dbus_proxy_get_cached_property(self->proxy_part, "Size");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_UINT64))
 		return 0;
 	return g_variant_get_uint64(val);
 }
@@ -321,7 +321,7 @@ fu_volume_get_partition_offset(FuVolume *self)
 	if (self->proxy_part == NULL)
 		return 0;
 	val = g_dbus_proxy_get_cached_property(self->proxy_part, "Offset");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_UINT64))
 		return 0;
 	return g_variant_get_uint64(val);
 }
@@ -346,7 +346,7 @@ fu_volume_get_partition_number(FuVolume *self)
 	if (self->proxy_part == NULL)
 		return 0;
 	val = g_dbus_proxy_get_cached_property(self->proxy_part, "Number");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_UINT32))
 		return 0;
 	return g_variant_get_uint32(val);
 }
@@ -496,7 +496,7 @@ fu_volume_is_mdraid(FuVolume *self)
 	if (self->proxy_blk == NULL)
 		return FALSE;
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "MDRaid");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 		return FALSE;
 	return g_strcmp0(g_variant_get_string(val, NULL), "/") != 0;
 }
@@ -603,7 +603,7 @@ fu_volume_get_block_size(FuVolume *self, GError **error)
 	}
 
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "Device");
-	if (val == NULL) {
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_BYTESTRING)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -639,7 +639,7 @@ fu_volume_get_mount_point(FuVolume *self)
 	if (self->proxy_fs == NULL)
 		return NULL;
 	val = g_dbus_proxy_get_cached_property(self->proxy_fs, "MountPoints");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_BYTESTRING_ARRAY))
 		return NULL;
 	mountpoints = g_variant_get_bytestring_array(val, NULL);
 	return g_strdup(mountpoints[0]);
@@ -746,7 +746,7 @@ fu_volume_is_encrypted(FuVolume *self)
 	if (self->proxy_blk == NULL)
 		return FALSE;
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "CryptoBackingDevice");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 		return FALSE;
 	if (g_strcmp0(g_variant_get_string(val, NULL), "/") == 0)
 		return FALSE;
@@ -820,7 +820,7 @@ fu_volume_is_internal(FuVolume *self)
 	g_return_val_if_fail(FU_IS_VOLUME(self), FALSE);
 
 	val_system = g_dbus_proxy_get_cached_property(self->proxy_blk, "HintSystem");
-	if (val_system == NULL)
+	if (val_system == NULL || !g_variant_is_of_type(val_system, G_VARIANT_TYPE_BOOLEAN))
 		return FALSE;
 
 	return g_variant_get_boolean(val_system);
@@ -843,7 +843,7 @@ fu_volume_get_id_type(FuVolume *self)
 	g_return_val_if_fail(FU_IS_VOLUME(self), NULL);
 
 	val = g_dbus_proxy_get_cached_property(self->proxy_blk, "IdType");
-	if (val == NULL)
+	if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_STRING))
 		return NULL;
 
 	return g_strdup(g_variant_get_string(val, NULL));
@@ -1032,7 +1032,8 @@ fu_volume_new_by_kind(const gchar *kind, GError **error)
 
 		/* ignore anything in a zfs zvol */
 		symlinks = g_dbus_proxy_get_cached_property(proxy_blk, "Symlinks");
-		if (symlinks != NULL) {
+		if (symlinks != NULL &&
+		    g_variant_is_of_type(symlinks, G_VARIANT_TYPE_BYTESTRING_ARRAY)) {
 			g_autofree const gchar **symlinks_strv =
 			    g_variant_get_bytestring_array(symlinks, NULL);
 			if (!fu_volume_check_block_device_symlinks(symlinks_strv, &error_local)) {
@@ -1158,7 +1159,7 @@ fu_volume_new_by_device(const gchar *device, GError **error)
 		GDBusProxy *proxy_blk = g_ptr_array_index(devices, i);
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy_blk, "Device");
-		if (val == NULL)
+		if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_BYTESTRING))
 			continue;
 		if (g_strcmp0(g_variant_get_bytestring(val), device) == 0) {
 			g_autoptr(GDBusProxy) proxy_fs = NULL;
@@ -1226,7 +1227,7 @@ fu_volume_new_by_devnum(guint32 devnum, GError **error)
 		GDBusProxy *proxy_blk = g_ptr_array_index(devices, i);
 		g_autoptr(GVariant) val = NULL;
 		val = g_dbus_proxy_get_cached_property(proxy_blk, "DeviceNumber");
-		if (val == NULL)
+		if (val == NULL || !g_variant_is_of_type(val, G_VARIANT_TYPE_UINT64))
 			continue;
 		if (devnum == g_variant_get_uint64(val)) {
 			return g_object_new(FU_TYPE_VOLUME, "proxy-block", proxy_blk, NULL);

--- a/plugins/redfish/fu-redfish-network-device.c
+++ b/plugins/redfish/fu-redfish-network-device.c
@@ -39,7 +39,7 @@ fu_redfish_network_device_get_state(FuRedfishNetworkDevice *self,
 	if (proxy == NULL)
 		return FALSE;
 	retval = g_dbus_proxy_get_cached_property(proxy, "State");
-	if (retval == NULL) {
+	if (retval == NULL || !g_variant_is_of_type(retval, G_VARIANT_TYPE_UINT32)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_FOUND,
@@ -130,7 +130,7 @@ fu_redfish_network_device_get_address(FuRedfishNetworkDevice *self, GError **err
 	if (proxy == NULL)
 		return NULL;
 	ip4_config = g_dbus_proxy_get_cached_property(proxy, "Ip4Config");
-	if (ip4_config == NULL) {
+	if (ip4_config == NULL || !g_variant_is_of_type(ip4_config, G_VARIANT_TYPE_STRING)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_FOUND,

--- a/plugins/redfish/fu-redfish-network.c
+++ b/plugins/redfish/fu-redfish-network.c
@@ -43,7 +43,7 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 		g_autoptr(GVariant) hw_address = NULL;
 
 		hw_address = g_dbus_proxy_get_cached_property(proxy, "HwAddress");
-		if (hw_address == NULL)
+		if (hw_address == NULL || !g_variant_is_of_type(hw_address, G_VARIANT_TYPE_STRING))
 			return TRUE;
 		mac_addr = g_variant_get_string(hw_address, NULL);
 
@@ -61,7 +61,7 @@ fu_redfish_network_device_match_device(FuRedfishNetworkMatchHelper *helper,
 		g_autoptr(GVariant) udi = NULL;
 
 		udi = g_dbus_proxy_get_cached_property(proxy, "Udi");
-		if (udi == NULL)
+		if (udi == NULL || !g_variant_is_of_type(udi, G_VARIANT_TYPE_STRING))
 			return TRUE;
 		udev_backend = fu_context_get_backend_by_name(helper->ctx, "udev", error);
 		if (udev_backend == NULL)

--- a/plugins/upower/fu-upower-plugin.c
+++ b/plugins/upower/fu-upower-plugin.c
@@ -27,7 +27,8 @@ fu_upower_plugin_rescan_devices(FuPlugin *plugin)
 
 	/* check that we "have" a battery */
 	type_val = g_dbus_proxy_get_cached_property(self->proxy, "Type");
-	if (type_val == NULL || g_variant_get_uint32(type_val) == 0) {
+	if (type_val == NULL || !g_variant_is_of_type(type_val, G_VARIANT_TYPE_UINT32) ||
+	    g_variant_get_uint32(type_val) == 0) {
 		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 		return;
 	}
@@ -39,11 +40,16 @@ fu_upower_plugin_rescan_devices(FuPlugin *plugin)
 		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 		return;
 	}
+	if (!g_variant_is_of_type(percentage_val, G_VARIANT_TYPE_DOUBLE)) {
+		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
+		return;
+	}
 	fu_context_set_battery_level(ctx, g_variant_get_double(percentage_val));
 
 	/* get state */
 	state_val = g_dbus_proxy_get_cached_property(self->proxy, "State");
-	if (state_val == NULL || g_variant_get_uint32(state_val) == 0) {
+	if (state_val == NULL || !g_variant_is_of_type(state_val, G_VARIANT_TYPE_UINT32) ||
+	    g_variant_get_uint32(state_val) == 0) {
 		g_warning("failed to query power state");
 		fu_context_set_battery_level(ctx, FWUPD_BATTERY_LEVEL_INVALID);
 	}
@@ -62,6 +68,11 @@ fu_upower_plugin_update_lid(FuPlugin *plugin)
 	lid_is_closed = g_dbus_proxy_get_cached_property(self->proxy_manager, "LidIsClosed");
 	if (lid_is_present == NULL || lid_is_closed == NULL) {
 		g_warning("failed to query lid state");
+		fu_context_set_lid_state(ctx, FU_LID_STATE_UNKNOWN);
+		return;
+	}
+	if (!g_variant_is_of_type(lid_is_present, G_VARIANT_TYPE_BOOLEAN) ||
+	    !g_variant_is_of_type(lid_is_closed, G_VARIANT_TYPE_BOOLEAN)) {
 		fu_context_set_lid_state(ctx, FU_LID_STATE_UNKNOWN);
 		return;
 	}
@@ -85,6 +96,10 @@ fu_upower_plugin_update_battery(FuPlugin *plugin)
 
 	on_battery = g_dbus_proxy_get_cached_property(self->proxy_manager, "OnBattery");
 	if (on_battery == NULL) {
+		fu_context_set_power_state(ctx, FU_POWER_STATE_AC);
+		return;
+	}
+	if (!g_variant_is_of_type(on_battery, G_VARIANT_TYPE_BOOLEAN)) {
 		fu_context_set_power_state(ctx, FU_POWER_STATE_AC);
 		return;
 	}

--- a/src/fu-bluez-backend.c
+++ b/src/fu-bluez-backend.c
@@ -41,6 +41,10 @@ fu_bluez_backend_object_properties_changed(FuBluezBackend *self, GDBusProxy *pro
 	val_services_resolved = g_dbus_proxy_get_cached_property(proxy, "ServicesResolved");
 	if (val_services_resolved == NULL)
 		return;
+	if (!g_variant_is_of_type(val_connected, G_VARIANT_TYPE_BOOLEAN) ||
+	    !g_variant_is_of_type(val_paired, G_VARIANT_TYPE_BOOLEAN) ||
+	    !g_variant_is_of_type(val_services_resolved, G_VARIANT_TYPE_BOOLEAN))
+		return;
 
 	suitable = g_variant_get_boolean(val_connected) && g_variant_get_boolean(val_paired) &&
 		   g_variant_get_boolean(val_services_resolved);

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1401,9 +1401,11 @@ fu_dbus_daemon_method_self_sign(FuDbusDaemon *self,
 	while (g_variant_iter_next(iter, "{&sv}", &prop_key, &prop_value)) {
 		g_debug("got option %s", prop_key);
 		if (g_strcmp0(prop_key, "add-timestamp") == 0 &&
+		    g_variant_is_of_type(prop_value, G_VARIANT_TYPE_BOOLEAN) &&
 		    g_variant_get_boolean(prop_value) == TRUE)
 			helper->flags |= FU_JCAT_SIGN_FLAG_ADD_TIMESTAMP;
 		if (g_strcmp0(prop_key, "add-cert") == 0 &&
+		    g_variant_is_of_type(prop_value, G_VARIANT_TYPE_BOOLEAN) &&
 		    g_variant_get_boolean(prop_value) == TRUE)
 			helper->flags |= FU_JCAT_SIGN_FLAG_ADD_CERT;
 		g_variant_unref(prop_value);


### PR DESCRIPTION
Although unlikely, if a caller sent a differently-typed variant, this would trigger a GLib critical warning.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
