### PR TITLE
starlabs-coreboot: Warn Star Labs coreboot users before flashrom removal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@ plugins/realtek-mst/ @tari
 plugins/rp-pico/ @mntmn
 plugins/rts54hub/ @AnyProblem
 plugins/snapd-uefi/ @BAMF0 @bboozzoo
+plugins/starlabs-coreboot/ @Sean-StarLabs
 plugins/sunwinon-hid/ @xiaosa-zhz
 plugins/synaptics-cape/ @CNXT-Simon
 plugins/synaptics-mst/ @ApolloLing

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -118,6 +118,7 @@ plugins = {
   'redfish': false,
   'rp-pico': false,
   'rts54hub': false,
+  'starlabs-coreboot': false,
   'steelseries': false,
   'sunplus-camera': false,
   'scsi': false,

--- a/plugins/starlabs-coreboot/README.md
+++ b/plugins/starlabs-coreboot/README.md
@@ -1,0 +1,12 @@
+---
+title: Plugin: Star Labs Coreboot
+---
+
+## Introduction
+
+The plugin exports a device that informs Star Labs users that they need to update their firmware
+manually before it can be updatable by fwupd via MTD.
+
+## Version Considerations
+
+This plugin has been available since fwupd version `2.1.4`.

--- a/plugins/starlabs-coreboot/fu-self-test.c
+++ b/plugins/starlabs-coreboot/fu-self-test.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Sean Rhodes <sean@starlabs.systems>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-context-private.h"
+#include "fu-plugin-private.h"
+#include "fu-starlabs-coreboot-plugin.h"
+
+static void
+fu_test_bios_plugin_device_added_cb(FuPlugin *plugin, FuDevice *device, gpointer user_data)
+{
+	FuDevice **device_added = (FuDevice **)user_data;
+	*device_added = device;
+}
+
+static FuPlugin *
+fu_starlabs_coreboot_plugin_new(const gchar *manufacturer, const gchar *bios_version)
+{
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuPlugin) plugin = NULL;
+	FuHwids *hwids = fu_context_get_hwids(ctx);
+
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_LOADED_HWINFO);
+	fu_hwids_add_value(hwids, FU_HWIDS_KEY_BIOS_VENDOR, "coreboot");
+	fu_hwids_add_value(hwids, FU_HWIDS_KEY_MANUFACTURER, manufacturer);
+	fu_hwids_add_value(hwids, FU_HWIDS_KEY_PRODUCT_NAME, "StarBook");
+	if (bios_version != NULL)
+		fu_hwids_add_value(hwids, FU_HWIDS_KEY_BIOS_VERSION, bios_version);
+
+	plugin = fu_plugin_new_from_gtype(fu_starlabs_coreboot_plugin_get_type(), ctx);
+	fu_plugin_remove_flag(plugin, FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
+	return g_steal_pointer(&plugin);
+}
+
+static void
+fu_bios_plugin_starlabs_coreboot_legacy_func(void)
+{
+	gboolean ret;
+	gulong added_id;
+	FuDevice *device_added = NULL;
+	g_autoptr(FuPlugin) plugin = fu_starlabs_coreboot_plugin_new("Star Labs", "CBET4000 25.01");
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	added_id = g_signal_connect(plugin,
+				    "device-added",
+				    G_CALLBACK(fu_test_bios_plugin_device_added_cb),
+				    &device_added);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_nonnull(device_added);
+	g_assert_cmpstr(fu_device_get_name(device_added), ==, "Coreboot");
+	g_assert_cmpstr(fu_device_get_summary(device_added), ==, "Manual update required");
+	g_assert_nonnull(fu_device_get_details_url(device_added));
+	g_assert_cmpstr(fu_device_get_version(device_added), ==, "25.01");
+	g_assert_true(
+	    fu_device_has_private_flag(device_added, FU_DEVICE_PRIVATE_FLAG_HOST_FIRMWARE));
+	g_assert_nonnull(fu_device_get_update_error(device_added));
+	g_assert_nonnull(
+	    g_strstr_len(fu_device_get_update_error(device_added), -1, "updating-your-firmware"));
+	g_signal_handler_disconnect(plugin, added_id);
+}
+
+static void
+fu_bios_plugin_starlabs_coreboot_supported_func(void)
+{
+	GPtrArray *devices;
+	gboolean ret;
+	g_autoptr(FuPlugin) plugin = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GError) error = NULL;
+
+	plugin = fu_starlabs_coreboot_plugin_new("Star Labs", "CBET4000 26.02");
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED);
+	g_assert_false(ret);
+	devices = fu_plugin_get_devices(plugin);
+	g_assert_cmpint(devices->len, ==, 0);
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+
+	g_test_add_func("/fwupd/plugin/bios/starlabs/coreboot-legacy",
+			fu_bios_plugin_starlabs_coreboot_legacy_func);
+	g_test_add_func("/fwupd/plugin/bios/starlabs/coreboot-supported",
+			fu_bios_plugin_starlabs_coreboot_supported_func);
+	return g_test_run();
+}

--- a/plugins/starlabs-coreboot/fu-starlabs-coreboot-device.c
+++ b/plugins/starlabs-coreboot/fu-starlabs-coreboot-device.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Sean Rhodes <sean@starlabs.systems>
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-starlabs-coreboot-device.h"
+
+struct _FuStarlabsCorebootDevice {
+	FuDevice parent_instance;
+};
+
+G_DEFINE_TYPE(FuStarlabsCorebootDevice, fu_starlabs_coreboot_device, FU_TYPE_DEVICE)
+
+static void
+fu_starlabs_coreboot_device_init(FuStarlabsCorebootDevice *self)
+{
+	g_autoptr(GString) msg = g_string_new(NULL);
+
+	fu_device_set_id(FU_DEVICE(self), "star-labs-coreboot-manual-update");
+	fu_device_set_vendor(FU_DEVICE(self), "Star Labs");
+	fu_device_set_name(FU_DEVICE(self), "Coreboot");
+	fu_device_set_summary(FU_DEVICE(self), "Manual update required");
+	fu_device_set_version_format(FU_DEVICE(self), FWUPD_VERSION_FORMAT_PAIR);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_ENSURE_SEMVER);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_INTERNAL);
+	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_COMPUTER);
+	fu_device_set_details_url(FU_DEVICE(self), FU_STARLABS_COREBOOT_SUPPORT_URL);
+	fu_device_add_private_flag(FU_DEVICE(self), FU_DEVICE_PRIVATE_FLAG_HOST_FIRMWARE);
+
+	g_string_append_printf(msg,
+			       "This Star Labs coreboot firmware must be updated manually before "
+			       "it can be updated by fwupd. Follow: %s",
+			       FU_STARLABS_COREBOOT_SUPPORT_URL);
+	fu_device_set_update_error(FU_DEVICE(self), msg->str);
+}
+
+static void
+fu_starlabs_coreboot_device_constructed(GObject *obj)
+{
+	FuStarlabsCorebootDevice *self = FU_STARLABS_COREBOOT_DEVICE(obj);
+	FuContext *ctx = fu_device_get_context(FU_DEVICE(self));
+	GPtrArray *hwids = fu_context_get_hwid_guids(ctx);
+	const gchar *version = fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_BIOS_VERSION);
+
+	fu_device_set_vendor(FU_DEVICE(self),
+			     fu_context_get_hwid_value(ctx, FU_HWIDS_KEY_MANUFACTURER));
+	if (version != NULL) {
+		if (strlen(version) > 9 && g_str_has_prefix(version, "CBET"))
+			version += 9;
+		fu_device_set_version(FU_DEVICE(self), version);
+	}
+	for (guint i = 0; i < hwids->len; i++) {
+		const gchar *hwid = g_ptr_array_index(hwids, i);
+		fu_device_add_instance_id(FU_DEVICE(self), hwid);
+	}
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_starlabs_coreboot_device_parent_class)->constructed(obj);
+}
+
+static void
+fu_starlabs_coreboot_device_class_init(FuStarlabsCorebootDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+	object_class->constructed = fu_starlabs_coreboot_device_constructed;
+}

--- a/plugins/starlabs-coreboot/fu-starlabs-coreboot-device.h
+++ b/plugins/starlabs-coreboot/fu-starlabs-coreboot-device.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_STARLABS_COREBOOT_DEVICE (fu_starlabs_coreboot_device_get_type())
+G_DECLARE_FINAL_TYPE(FuStarlabsCorebootDevice,
+		     fu_starlabs_coreboot_device,
+		     FU,
+		     STARLABS_COREBOOT_DEVICE,
+		     FuDevice)
+
+#define FU_STARLABS_COREBOOT_VERSION_MIN "26.02"
+#define FU_STARLABS_COREBOOT_SUPPORT_URL                                                           \
+	"https://support.starlabs.systems/hc/star-labs/articles/updating-your-firmware"

--- a/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.c
+++ b/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Sean Rhodes <sean@starlabs.systems>
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-starlabs-coreboot-device.h"
+#include "fu-starlabs-coreboot-plugin.h"
+
+struct _FuStarlabsCorebootPlugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuStarlabsCorebootPlugin, fu_starlabs_coreboot_plugin, FU_TYPE_PLUGIN)
+
+static void
+fu_starlabs_coreboot_plugin_init(FuStarlabsCorebootPlugin *self)
+{
+	fu_plugin_add_flag(FU_PLUGIN(self), FWUPD_PLUGIN_FLAG_REQUIRE_HWID);
+}
+
+static void
+fu_starlabs_coreboot_plugin_constructed(GObject *obj)
+{
+	FuPlugin *plugin = FU_PLUGIN(obj);
+	fu_plugin_add_device_gtype(plugin, FU_TYPE_STARLABS_COREBOOT_DEVICE);
+
+	/* chain up to parent */
+	G_OBJECT_CLASS(fu_starlabs_coreboot_plugin_parent_class)->constructed(obj);
+}
+
+static gboolean
+fu_starlabs_coreboot_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	g_autoptr(FuDevice) device = NULL;
+
+	device = g_object_new(FU_TYPE_STARLABS_COREBOOT_DEVICE, "context", ctx, NULL);
+	if (fu_version_compare(fu_device_get_version(device),
+			       FU_STARLABS_COREBOOT_VERSION_MIN,
+			       FWUPD_VERSION_FORMAT_PAIR) >= 0) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_NOT_SUPPORTED,
+				    "device is new enough to support mtd");
+		return FALSE;
+	}
+	fu_plugin_add_device(plugin, device);
+	return TRUE;
+}
+
+static void
+fu_starlabs_coreboot_plugin_class_init(FuStarlabsCorebootPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->constructed = fu_starlabs_coreboot_plugin_constructed;
+	plugin_class->coldplug = fu_starlabs_coreboot_plugin_coldplug;
+}

--- a/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.h
+++ b/plugins/starlabs-coreboot/fu-starlabs-coreboot-plugin.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+G_DECLARE_FINAL_TYPE(FuStarlabsCorebootPlugin,
+		     fu_starlabs_coreboot_plugin,
+		     FU,
+		     STARLABS_COREBOOT_PLUGIN,
+		     FuPlugin)

--- a/plugins/starlabs-coreboot/meson.build
+++ b/plugins/starlabs-coreboot/meson.build
@@ -1,0 +1,37 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginStarlabsCoreboot"']
+
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+plugin_quirks += files('starlabs-coreboot.quirk')
+plugin_builtin_starlabs_coreboot = static_library('fu_plugin_starlabs_coreboot',
+  sources: [
+    'fu-starlabs-coreboot-device.c',
+    'fu-starlabs-coreboot-plugin.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+plugin_builtins += plugin_builtin_starlabs_coreboot
+
+if get_option('tests')
+  env = environment()
+  env.set('G_DEBUG', 'fatal-criticals')
+  e = executable(
+    'starlabs-coreboot-self-test',
+    sources: [
+      'fu-self-test.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: plugin_deps,
+    link_with: [
+      fwupd,
+      fwupdplugin,
+      plugin_builtin_starlabs_coreboot,
+    ],
+    c_args: [
+      cargs,
+    ],
+  )
+  test('starlabs-coreboot-self-test', e, env: env)
+endif

--- a/plugins/starlabs-coreboot/starlabs-coreboot.quirk
+++ b/plugins/starlabs-coreboot/starlabs-coreboot.quirk
@@ -1,0 +1,3 @@
+# Manufacturer="Star Labs", BiosVendor="coreboot"
+[b8cf5af6-8a46-5deb-ac01-a35b1ea5fb48]
+Plugin = starlabs_coreboot


### PR DESCRIPTION
Based on a patch by Sean Rhodes <sean@starlabs.systems>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
