### PR TITLE
trivial: Use device object ID for verify file path

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1424,7 +1424,7 @@ fu_engine_verify_update(FuEngine *self,
 	localstatedir = fu_context_get_path(self->ctx, FU_PATH_KIND_LOCALSTATEDIR_PKG, error);
 	if (localstatedir == NULL)
 		return FALSE;
-	fn = g_strdup_printf("%s/verify/%s.xml", localstatedir, device_id);
+	fn = g_strdup_printf("%s/verify/%s.xml", localstatedir, fu_device_get_id(device));
 	if (!fu_path_mkdir_parent(fn, error))
 		return FALSE;
 	file = g_file_new_for_path(fn);


### PR DESCRIPTION
Use the device ID from the validated device object rather than the raw input parameter when constructing the verification file path.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
