### PR TITLE
pre-commit: check quirk files with the end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,12 @@ repos:
       - id: check-xml
       - id: end-of-file-fixer
         types_or: [c, shell, python, proto]
+      - id: end-of-file-fixer
+        files: \.quirk$
       - id: trailing-whitespace
         types_or: [c, shell, python, xml]
+      - id: trailing-whitespace
+        files: \.quirk$
       - id: check-docstring-first
       - id: check-merge-conflict
       - id: mixed-line-ending

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -541,4 +541,3 @@ Flags = enforce-requires
 [USB\VID_10A5&PID_D805]
 DfuForceVersion = 0x0
 Flags = enforce-requires
-

--- a/plugins/synaptics-prometheus/synaptics-prometheus.quirk
+++ b/plugins/synaptics-prometheus/synaptics-prometheus.quirk
@@ -81,4 +81,3 @@ InstallDuration = 2
 [USB\VID_06CB&PID_0108]
 Plugin = synaptics_prometheus
 InstallDuration = 2
-

--- a/plugins/vli/vli-goodway.quirk
+++ b/plugins/vli/vli-goodway.quirk
@@ -28,4 +28,3 @@ Plugin = vli
 GType = FuVliPdDevice
 Flags = skips-rom
 VliDeviceKind = vl105
-


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation

The current whitespace and end-of-file checks are limited to a few file types only but based on https://github.com/fwupd/fwupd/pull/10332#discussion_r3263397697 we want the same to happen in quirk files.