### PR TITLE
lenovo-dock: Allow recovery if the device usage table is invalid

### DIFF
--- a/plugins/lenovo-dock/fu-lenovo-dock-device.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-device.c
@@ -9,7 +9,6 @@
 #include "fu-lenovo-dock-device.h"
 #include "fu-lenovo-dock-firmware.h"
 #include "fu-lenovo-dock-image.h"
-#include "fu-lenovo-dock-struct.h"
 
 #define FU_LENOVO_DOCK_DEVICE_IFACE1_LEN 64
 #define FU_LENOVO_DOCK_DEVICE_IFACE2_LEN 272
@@ -700,8 +699,28 @@ fu_lenovo_dock_device_check_firmware(FuDevice *device,
 	return TRUE;
 }
 
+static void
+fu_lenovo_dock_device_set_usage(FuLenovoDockDevice *self, FuStructLenovoDockUsage *st)
+{
+	if (self->st_usage != NULL)
+		fu_struct_lenovo_dock_usage_unref(self->st_usage);
+	self->st_usage = fu_struct_lenovo_dock_usage_ref(st);
+}
+
+static void
+fu_lenovo_dock_device_add_usage_item(FuLenovoDockDevice *self, FuStructLenovoDockUsageItem *st)
+{
+	g_ptr_array_add(self->st_usage_items, fu_struct_lenovo_dock_usage_item_ref(st));
+}
+
+static void
+fu_lenovo_dock_device_clear_usage_items(FuLenovoDockDevice *self)
+{
+	g_ptr_array_set_size(self->st_usage_items, 0);
+}
+
 static gboolean
-fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, gboolean *valid, GError **error)
+fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, GError **error)
 {
 	guint32 crc_actual = 0;
 	guint32 crc_calculated;
@@ -735,7 +754,15 @@ fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, gboolean *valid, GE
 				    G_LITTLE_ENDIAN,
 				    error))
 		return FALSE;
-	g_debug("usage info CRC got 0x%08x, expected 0x%08x", crc_actual, crc_calculated);
+	if (crc_calculated != crc_actual) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_SIGNATURE_INVALID,
+			    "usage info CRC got 0x%08x, expected 0x%08x",
+			    crc_actual,
+			    crc_calculated);
+		return FALSE;
+	}
 
 	/* parse the usage metadata */
 	st = fu_struct_lenovo_dock_usage_parse(buf->data, buf->len, offset, error);
@@ -748,12 +775,10 @@ fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, gboolean *valid, GE
 		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 
 	/* save so we can reconstruct for erase + program */
-	if (self->st_usage != NULL)
-		fu_struct_lenovo_dock_usage_unref(self->st_usage);
-	self->st_usage = fu_struct_lenovo_dock_usage_ref(st);
+	fu_lenovo_dock_device_set_usage(self, st);
 
 	/* parse each usage metadata item */
-	g_ptr_array_set_size(self->st_usage_items, 0);
+	fu_lenovo_dock_device_clear_usage_items(self);
 	offset += FU_STRUCT_LENOVO_DOCK_USAGE_SIZE;
 	for (guint i = 0; i < usage_items; i++) {
 		g_autoptr(FuStructLenovoDockUsageItem) st_item = NULL;
@@ -761,14 +786,11 @@ fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, gboolean *valid, GE
 		    fu_struct_lenovo_dock_usage_item_parse(buf->data, buf->len, offset, error);
 		if (st_item == NULL)
 			return FALSE;
-		g_ptr_array_add(self->st_usage_items,
-				fu_struct_lenovo_dock_usage_item_ref(st_item));
+		fu_lenovo_dock_device_add_usage_item(self, st_item);
 		offset += FU_STRUCT_LENOVO_DOCK_USAGE_ITEM_SIZE;
 	}
 
 	/* success */
-	if (valid != NULL)
-		*valid = crc_calculated == crc_actual;
 	return TRUE;
 }
 
@@ -1128,6 +1150,30 @@ fu_lenovo_dock_device_flash_memory_access_release_cb(FuDevice *device, GError **
 	return TRUE;
 }
 
+static void
+fu_lenovo_dock_device_set_usage_from_firmware(FuLenovoDockDevice *self,
+					      FuLenovoDockFirmware *firmware)
+{
+	FuStructLenovoDockUsage *st_usage = fu_lenovo_dock_firmware_get_usage(firmware);
+	GPtrArray *st_usage_items = fu_lenovo_dock_firmware_get_usage_items(firmware);
+
+	if (st_usage != NULL) {
+		fu_lenovo_dock_device_set_usage(self, st_usage);
+		if (fu_struct_lenovo_dock_usage_get_dsa(st_usage) != FU_LENOVO_DOCK_DSA_TYPE_NONE)
+			fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+		else
+			fu_device_remove_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
+	}
+	if (st_usage_items != NULL) {
+		fu_lenovo_dock_device_clear_usage_items(self);
+		for (guint i = 0; i < st_usage_items->len; i++) {
+			FuStructLenovoDockUsageItem *st_usage_item =
+			    g_ptr_array_index(st_usage_items, i);
+			fu_lenovo_dock_device_add_usage_item(self, st_usage_item);
+		}
+	}
+}
+
 static gboolean
 fu_lenovo_dock_device_write_firmware(FuDevice *device,
 				     FuFirmware *firmware,
@@ -1136,10 +1182,10 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 				     GError **error)
 {
 	FuLenovoDockDevice *self = FU_LENOVO_DOCK_DEVICE(device);
-	gboolean usage_info_valid = FALSE;
 	guint8 component_id_total = 0;
 	guint8 total_number;
 	g_autoptr(FuDeviceLocker) flash_locker = NULL;
+	g_autoptr(GError) error_local = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
@@ -1166,19 +1212,16 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* verify existing CRC */
-	if (!fu_lenovo_dock_device_ensure_usage(self, &usage_info_valid, error)) {
-		g_prefix_error_literal(error, "failed to validate usage info: ");
-		return FALSE;
-	}
-	if (!usage_info_valid) {
-		if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INVALID_DATA,
-					    "device usage info CRC was not valid");
+	if (!fu_lenovo_dock_device_ensure_usage(self, &error_local)) {
+		if (!g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_SIGNATURE_INVALID)) {
+			g_propagate_prefixed_error(error,
+						   g_steal_pointer(&error_local),
+						   "failed to validate usage info: ");
 			return FALSE;
 		}
-		g_warning("usage info CRC was not valid, but continuing");
+		g_debug("recovery from firmware: %s", error_local->message);
+		fu_lenovo_dock_device_set_usage_from_firmware(self,
+							      FU_LENOVO_DOCK_FIRMWARE(firmware));
 	}
 	fu_progress_step_done(progress);
 

--- a/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
@@ -15,15 +15,66 @@
 struct _FuLenovoDockFirmware {
 	FuFirmware parent_instance;
 	guint16 pid;
+	FuStructLenovoDockUsage *st_usage;
+	GPtrArray *st_usage_items;
 };
 
 G_DEFINE_TYPE(FuLenovoDockFirmware, fu_lenovo_dock_firmware, FU_TYPE_FIRMWARE)
+
+static void
+fu_lenovo_dock_firmware_export_usage(FuStructLenovoDockUsage *st, XbBuilderNode *bn)
+{
+	fu_xmlb_builder_insert_kx(bn,
+				  "total_number",
+				  fu_struct_lenovo_dock_usage_get_total_number(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "composite_version",
+				  fu_struct_lenovo_dock_usage_get_composite_version(st));
+	fu_xmlb_builder_insert_kx(bn, "pid", fu_struct_lenovo_dock_usage_get_pid(st));
+}
+
+static void
+fu_lenovo_dock_firmware_export_usage_item(FuStructLenovoDockUsageItem *st, XbBuilderNode *bn)
+{
+	fu_xmlb_builder_insert_kx(bn, "addr", fu_struct_lenovo_dock_usage_item_get_address(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "max_size",
+				  fu_struct_lenovo_dock_usage_item_get_max_size(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_version",
+				  fu_struct_lenovo_dock_usage_item_get_target_version(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_size",
+				  fu_struct_lenovo_dock_usage_item_get_target_size(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_crc32",
+				  fu_struct_lenovo_dock_usage_item_get_target_crc32(st));
+}
+
+static void
+fu_lenovo_dock_firmware_export_usage_items(GPtrArray *st_usage_items, XbBuilderNode *bn)
+{
+	for (guint i = 0; i < st_usage_items->len; i++) {
+		FuStructLenovoDockUsageItem *st_usage_item = g_ptr_array_index(st_usage_items, i);
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "item", NULL);
+		fu_lenovo_dock_firmware_export_usage_item(st_usage_item, bc);
+	}
+}
 
 static void
 fu_lenovo_dock_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
 {
 	FuLenovoDockFirmware *self = FU_LENOVO_DOCK_FIRMWARE(firmware);
 	fu_xmlb_builder_insert_kx(bn, "pid", self->pid);
+
+	if (self->st_usage != NULL) {
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "usage", NULL);
+		fu_lenovo_dock_firmware_export_usage(self->st_usage, bc);
+	}
+	if (self->st_usage_items->len > 0) {
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "items", NULL);
+		fu_lenovo_dock_firmware_export_usage_items(self->st_usage_items, bc);
+	}
 }
 
 static gboolean
@@ -61,8 +112,6 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 		return FALSE;
 	}
 	target_size = fu_struct_lenovo_dock_usage_item_get_target_size(st_item);
-	if (target_size == 0)
-		return TRUE;
 	if (target_size > max_size) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -71,6 +120,13 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 			    target_size,
 			    max_size);
 		return FALSE;
+	}
+
+	/* preserve zero-sized items so the total_number is valid */
+	if (target_size == 0) {
+		g_ptr_array_add(self->st_usage_items,
+				fu_struct_lenovo_dock_usage_item_ref(st_item));
+		return TRUE;
 	}
 
 	fu_firmware_set_idx(img, component_id);
@@ -122,6 +178,9 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 		}
 	}
 	fu_lenovo_dock_image_set_crc(FU_LENOVO_DOCK_IMAGE(img), target_crc32);
+
+	/* for recovery */
+	g_ptr_array_add(self->st_usage_items, fu_struct_lenovo_dock_usage_item_ref(st_item));
 
 	/* success */
 	return TRUE;
@@ -176,6 +235,9 @@ fu_lenovo_dock_firmware_parse(FuFirmware *firmware,
 			return FALSE;
 	}
 
+	/* for recovery */
+	self->st_usage = fu_struct_lenovo_dock_usage_ref(st);
+
 	/* success */
 	return TRUE;
 }
@@ -185,6 +247,20 @@ fu_lenovo_dock_firmware_get_pid(FuLenovoDockFirmware *self)
 {
 	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), G_MAXUINT16);
 	return self->pid;
+}
+
+FuStructLenovoDockUsage *
+fu_lenovo_dock_firmware_get_usage(FuLenovoDockFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), NULL);
+	return self->st_usage;
+}
+
+GPtrArray *
+fu_lenovo_dock_firmware_get_usage_items(FuLenovoDockFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), NULL);
+	return self->st_usage_items;
 }
 
 static gchar *
@@ -199,6 +275,8 @@ fu_lenovo_dock_firmware_convert_version(FuFirmware *firmware, guint64 version_ra
 static void
 fu_lenovo_dock_firmware_init(FuLenovoDockFirmware *self)
 {
+	self->st_usage_items =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_struct_lenovo_dock_usage_item_unref);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_TRIPLET);
@@ -208,9 +286,22 @@ fu_lenovo_dock_firmware_init(FuLenovoDockFirmware *self)
 }
 
 static void
+fu_lenovo_dock_firmware_finalize(GObject *object)
+{
+	FuLenovoDockFirmware *self = FU_LENOVO_DOCK_FIRMWARE(object);
+	if (self->st_usage != NULL)
+		fu_struct_lenovo_dock_usage_unref(self->st_usage);
+	if (self->st_usage_items != NULL)
+		g_ptr_array_unref(self->st_usage_items);
+	G_OBJECT_CLASS(fu_lenovo_dock_firmware_parent_class)->finalize(object);
+}
+
+static void
 fu_lenovo_dock_firmware_class_init(FuLenovoDockFirmwareClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	object_class->finalize = fu_lenovo_dock_firmware_finalize;
 	firmware_class->parse = fu_lenovo_dock_firmware_parse;
 	firmware_class->export = fu_lenovo_dock_firmware_export;
 	firmware_class->convert_version = fu_lenovo_dock_firmware_convert_version;

--- a/plugins/lenovo-dock/fu-lenovo-dock-firmware.h
+++ b/plugins/lenovo-dock/fu-lenovo-dock-firmware.h
@@ -8,6 +8,8 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-lenovo-dock-struct.h"
+
 #define FU_TYPE_LENOVO_DOCK_FIRMWARE (fu_lenovo_dock_firmware_get_type())
 G_DECLARE_FINAL_TYPE(FuLenovoDockFirmware,
 		     fu_lenovo_dock_firmware,
@@ -19,3 +21,9 @@ G_DECLARE_FINAL_TYPE(FuLenovoDockFirmware,
 
 guint16
 fu_lenovo_dock_firmware_get_pid(FuLenovoDockFirmware *self);
+
+FuStructLenovoDockUsage *
+fu_lenovo_dock_firmware_get_usage(FuLenovoDockFirmware *self);
+
+GPtrArray *
+fu_lenovo_dock_firmware_get_usage_items(FuLenovoDockFirmware *self);


### PR DESCRIPTION
If the CRC is not correct, use the firmware as the 'source of truth' for each item.

Based on a patch by Felix <Felix_F_Chen@wistron.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
