### PR TITLE
Add support Compal's BIOS version format

### DIFF
--- a/libfwupd/fwupd-enums.rs
+++ b/libfwupd/fwupd-enums.rs
@@ -194,4 +194,7 @@ enum FwupdVersionFormat {
     // Intel ME-style bitshifted notation, with offset 19.
     // Since: 2.0.4
     IntelCsme19,
+    // Compal BIOS-style version number, as two hex bytes.
+    // Since: 2.1.4
+    CompalBios,
 }

--- a/libfwupdplugin/fu-version-common.c
+++ b/libfwupdplugin/fu-version-common.c
@@ -16,6 +16,10 @@
 #include "fu-string.h"
 #include "fu-version-common.h"
 
+/*
+ * nocheck:magic-inlines=81
+ */
+
 #define FU_COMMON_VERSION_DECODE_BCD(val) ((((val) >> 4) & 0x0f) * 10 + ((val) & 0x0f))
 
 static gchar *
@@ -51,6 +55,12 @@ fu_version_from_uint64(guint64 val, FwupdVersionFormat kind)
 		return g_strdup_printf("%" G_GUINT64_FORMAT ".%" G_GUINT64_FORMAT "",
 				       (val >> 32) & 0xffffffff,
 				       val & 0xffffffff);
+	}
+	if (kind == FWUPD_VERSION_FORMAT_COMPAL_BIOS) {
+		/* AA.BB */
+		return g_strdup_printf("%02x.%02x",
+				       (guint)((val >> 8) & 0xff),
+				       (guint)(val & 0xff));
 	}
 	if (kind == FWUPD_VERSION_FORMAT_NUMBER || kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		/* AABBCCDD */
@@ -100,6 +110,10 @@ fu_version_from_uint32(guint32 val, FwupdVersionFormat kind)
 	if (kind == FWUPD_VERSION_FORMAT_PAIR) {
 		/* AABB.CCDD */
 		return g_strdup_printf("%u.%u", (val >> 16) & 0xffff, val & 0xffff);
+	}
+	if (kind == FWUPD_VERSION_FORMAT_COMPAL_BIOS) {
+		/* AA.BB */
+		return g_strdup_printf("%02x.%02x", (val >> 8) & 0xff, val & 0xff);
 	}
 	if (kind == FWUPD_VERSION_FORMAT_NUMBER || kind == FWUPD_VERSION_FORMAT_PLAIN) {
 		/* AABBCCDD */
@@ -294,6 +308,8 @@ fu_version_from_uint16(guint16 val, FwupdVersionFormat kind)
 	}
 	if (kind == FWUPD_VERSION_FORMAT_PAIR)
 		return g_strdup_printf("%u.%u", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
+	if (kind == FWUPD_VERSION_FORMAT_COMPAL_BIOS)
+		return g_strdup_printf("%02x.%02x", (guint)(val >> 8) & 0xff, (guint)val & 0xff);
 	if (kind == FWUPD_VERSION_FORMAT_QUAD) {
 		return g_strdup_printf("%u.%u.%u.%u",
 				       (guint)(val >> 12) & 0xF,
@@ -418,7 +434,8 @@ fu_version_format_number_sections(FwupdVersionFormat fmt)
 	if (fmt == FWUPD_VERSION_FORMAT_PLAIN || fmt == FWUPD_VERSION_FORMAT_NUMBER ||
 	    fmt == FWUPD_VERSION_FORMAT_HEX)
 		return 1;
-	if (fmt == FWUPD_VERSION_FORMAT_PAIR || fmt == FWUPD_VERSION_FORMAT_BCD)
+	if (fmt == FWUPD_VERSION_FORMAT_PAIR || fmt == FWUPD_VERSION_FORMAT_COMPAL_BIOS ||
+	    fmt == FWUPD_VERSION_FORMAT_BCD)
 		return 2;
 	if (fmt == FWUPD_VERSION_FORMAT_TRIPLET || fmt == FWUPD_VERSION_FORMAT_SURFACE_LEGACY ||
 	    fmt == FWUPD_VERSION_FORMAT_SURFACE || fmt == FWUPD_VERSION_FORMAT_DELL_BIOS ||
@@ -680,6 +697,8 @@ fu_version_verify_format(const gchar *version, FwupdVersionFormat fmt, GError **
 	fmt_guess = fu_version_guess_format(version);
 	if (fmt == FWUPD_VERSION_FORMAT_BCD &&
 	    (fmt_guess == FWUPD_VERSION_FORMAT_PAIR || fmt_guess == FWUPD_VERSION_FORMAT_QUAD))
+		return TRUE;
+	if (fmt_guess == FWUPD_VERSION_FORMAT_PAIR && fmt == FWUPD_VERSION_FORMAT_COMPAL_BIOS)
 		return TRUE;
 	if (fmt_guess != fu_version_format_convert_base(fmt)) {
 		g_set_error(error,

--- a/libfwupdplugin/fu-version-test.c
+++ b/libfwupdplugin/fu-version-test.c
@@ -38,6 +38,10 @@ fu_version_verify_format_func(void)
 	ret = fu_version_verify_format("1A", FWUPD_VERSION_FORMAT_NUMBER, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_DATA);
 	g_assert_false(ret);
+	g_clear_error(&error);
+	ret = fu_version_verify_format("12.34", FWUPD_VERSION_FORMAT_COMPAL_BIOS, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
 }
 
 static void
@@ -92,6 +96,10 @@ fu_version_func(void)
 	    {0x00ff0001, "255.0.1", FWUPD_VERSION_FORMAT_DELL_BIOS},
 	    {0x010f0201, "1.15.2", FWUPD_VERSION_FORMAT_DELL_BIOS_MSB},
 	    {0xc8, "0x000000c8", FWUPD_VERSION_FORMAT_HEX},
+	    {0x0, "00.00", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0xff, "00.ff", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0x0000ff01, "ff.01", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0x00001234, "12.34", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
 	};
 	struct {
 		guint32 val;
@@ -115,6 +123,10 @@ fu_version_func(void)
 	    {0xffffffffffffffff, "4294967295.4294967295", FWUPD_VERSION_FORMAT_PAIR},
 	    {0x0, "0", FWUPD_VERSION_FORMAT_NUMBER},
 	    {0x11000000c8, "0x00000011000000c8", FWUPD_VERSION_FORMAT_HEX},
+	    {0x0, "00.00", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0xff, "00.ff", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0xff01, "ff.01", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0x1234, "12.34", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
 	};
 	struct {
 		guint16 val;
@@ -130,6 +142,10 @@ fu_version_func(void)
 	    {0x0, "0", FWUPD_VERSION_FORMAT_NUMBER},
 	    {0x1234, "4660", FWUPD_VERSION_FORMAT_NUMBER},
 	    {0x1234, "1.2.52", FWUPD_VERSION_FORMAT_TRIPLET},
+	    {0x0, "00.00", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0xff, "00.ff", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0xff01, "ff.01", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
+	    {0x1234, "12.34", FWUPD_VERSION_FORMAT_COMPAL_BIOS},
 	};
 	struct {
 		const gchar *old;

--- a/plugins/uefi-capsule/uefi-capsule.quirk
+++ b/plugins/uefi-capsule/uefi-capsule.quirk
@@ -119,3 +119,7 @@ VersionFormat = bcd
 # HP Dev One
 [9f7962c7-7d0e-473d-8a01-c168912f1f14]
 Flags = no-ux-capsule
+
+# AMD Halo Box
+[07b49333-279c-47be-be97-852a4dfe8885]
+VersionFormat = compal-bios


### PR DESCRIPTION
The format is:
AA.BB

But when pulled out of a uint32 it would be
0x0000AABB

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
