### PR TITLE
trivial: Add NULL check for out-of-range timestamps

### DIFF
--- a/libfwupd/fwupd-codec.c
+++ b/libfwupd/fwupd-codec.c
@@ -607,8 +607,10 @@ fwupd_codec_string_append_time(GString *str, guint idt, const gchar *key, guint6
 		return;
 
 	date = g_date_time_new_from_unix_utc((gint64)value);
-	if (date == NULL)
+	if (date == NULL) {
+		g_warning("timestamp %" G_GUINT64_FORMAT " is out of range", value);
 		return;
+	}
 	tmp = g_date_time_format(date, "%F %T");
 	fwupd_codec_string_append(str, idt, key, tmp);
 }


### PR DESCRIPTION
Prevent daemon/client crash when hostile firmware metadata contains out-of-range timestamp values (e.g., year < 1 or > 9999) that cause g_date_time_new_from_unix_utc() to return NULL.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
