### PR TITLE
trivial: Fix integer truncation in AMD GPU PSP firmware parser

### DIFF
--- a/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
+++ b/plugins/amd-gpu/fu-amd-gpu-psp-firmware.c
@@ -110,7 +110,7 @@ fu_amd_gpu_psp_firmware_parse_l1(FuAmdGpuPspFirmware *self,
 	}
 
 	for (guint i = 0; i < fu_struct_psp_dir_get_total_entries(st_dir); i++) {
-		guint loc;
+		guint64 loc;
 		guint sz;
 		g_autoptr(FuStructPspDirTable) st_entry = NULL;
 		g_autoptr(FuStructImageSlotHeader) st_hdr = NULL;


### PR DESCRIPTION
Prevent potential parser confusion when processing PSP directory entries with location values >= 2^32 by using the correct 64-bit type.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
