### PR TITLE
trivial: Validate SECTOR_SIZE_IN_BYTES to prevent division by zero

### DIFF
--- a/plugins/qc-firehose/fu-qc-firehose-impl.c
+++ b/plugins/qc-firehose/fu-qc-firehose-impl.c
@@ -584,11 +584,11 @@ fu_qc_firehose_impl_program(FuQcFirehoseImpl *self,
 				    "program is not supported");
 		return FALSE;
 	}
-	if (sector_size == 0) {
+	if (sector_size == 0 || sector_size == G_MAXUINT64) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_FILE,
-				    "invalid or missing sector size");
+				    FWUPD_ERROR_INVALID_DATA,
+				    "SECTOR_SIZE_IN_BYTES invalid");
 		return FALSE;
 	}
 


### PR DESCRIPTION
Reject sector_size values of 0 or G_MAXUINT64 from the firehose XML before using as a divisor. A malicious .cab with SECTOR_SIZE_IN_BYTES="0" would cause SIGFPE in the root daemon, potentially soft-bricking devices in EDL mode.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
