### PR TITLE
libfwupd: Restrict curl protocols to prevent SSRF attacks

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -928,12 +928,10 @@ fwupd_client_curl_new(FwupdClient *self, GError **error)
 	(void)curl_easy_setopt(helper->curl, CURLOPT_FOLLOWLOCATION, 1L);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_MAXREDIRS, 5L);
 #if CURL_AT_LEAST_VERSION(7, 85, 0)
-	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS_STR, "http,https,ipfs");
+	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS_STR, "http,https");
 	(void)curl_easy_setopt(helper->curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 #else
-	(void)curl_easy_setopt(helper->curl,
-			       CURLOPT_PROTOCOLS,
-			       CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_IPFS);
+	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 	(void)curl_easy_setopt(helper->curl,
 			       CURLOPT_REDIR_PROTOCOLS,
 			       CURLPROTO_HTTP | CURLPROTO_HTTPS);

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -927,6 +927,17 @@ fwupd_client_curl_new(FwupdClient *self, GError **error)
 	(void)curl_easy_setopt(helper->curl, CURLOPT_NOPROGRESS, 0L);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_FOLLOWLOCATION, 1L);
 	(void)curl_easy_setopt(helper->curl, CURLOPT_MAXREDIRS, 5L);
+#if CURL_AT_LEAST_VERSION(7, 85, 0)
+	(void)curl_easy_setopt(helper->curl, CURLOPT_PROTOCOLS_STR, "http,https,ipfs");
+	(void)curl_easy_setopt(helper->curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
+	(void)curl_easy_setopt(helper->curl,
+			       CURLOPT_PROTOCOLS,
+			       CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_IPFS);
+	(void)curl_easy_setopt(helper->curl,
+			       CURLOPT_REDIR_PROTOCOLS,
+			       CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
 #ifdef _WIN32
 	(void)curl_easy_setopt(helper->curl, CURLOPT_CAINFO, "ca-bundle.crt");
 #endif


### PR DESCRIPTION
Set CURLOPT_PROTOCOLS_STR and CURLOPT_REDIR_PROTOCOLS_STR to prevent malicious redirects to dangerous protocols like file:// or gopher://. A compromised LVFS mirror or MITM attacker could previously redirect downloads to local files or internal network resources, enabling SSRF attacks for arbitrary file disclosure or metadata service access.

Initial requests allow http, https, and ipfs (for IPFS support), while redirects are restricted to http and https only.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
