### PR TITLE
Require authorization for firmware installation on emulated devices

### DIFF
--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -346,4 +346,15 @@
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.fwupd.emulation-load</annotate>
   </action>
 
+  <action id="org.freedesktop.fwupd.device-emulate">
+    <description>Install firmware on emulated device</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to install firmware on an emulated device</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -897,6 +897,7 @@ fu_dbus_daemon_install_with_helper_device(FuMainAuthHelper *helper,
 	/* make a second pass */
 	for (guint i = 0; i < releases->len; i++) {
 		FuRelease *release_tmp = g_ptr_array_index(releases, i);
+		const gchar *action_id;
 		if (!fu_engine_requirements_check(engine,
 						  release_tmp,
 						  helper->flags,
@@ -914,11 +915,11 @@ fu_dbus_daemon_install_with_helper_device(FuMainAuthHelper *helper,
 		}
 
 		/* get the action IDs for the valid device */
-		if (!fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)) {
-			const gchar *action_id = fu_release_get_action_id(release_tmp);
-			if (!g_ptr_array_find(helper->action_ids, action_id, NULL))
-				g_ptr_array_add(helper->action_ids, g_strdup(action_id));
-		}
+		action_id = fu_device_has_flag(device, FWUPD_DEVICE_FLAG_EMULATED)
+				? "org.freedesktop.fwupd.device-emulate"
+				: fu_release_get_action_id(release_tmp);
+		if (!g_ptr_array_find(helper->action_ids, action_id, NULL))
+			g_ptr_array_add(helper->action_ids, g_strdup(action_id));
 		g_ptr_array_add(helper->releases, g_object_ref(release_tmp));
 	}
 


### PR DESCRIPTION
Emulated devices were previously excluded from PolKit authorization during firmware installation, allowing unprivileged users to exercise firmware parsers as root without authentication. This exposed the full firmware-parsing pipeline to potential attacks.

Add org.freedesktop.fwupd.device-emulate PolKit action and ensure all emulated device firmware installations require authorization.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
