### PR TITLE
nordic-hid: Fix heap buffer overflow in peer_id validation

### DIFF
--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -609,6 +609,16 @@ fu_nordic_hid_cfg_channel_update_peers(FuNordicHidCfgChannel *self,
 		if (peer_id == INVALID_PEER_ID)
 			break;
 
+		/* validate peer_id to prevent out-of-bounds access */
+		if (peer_id == 0 || peer_id > PEERS_CACHE_LEN) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid peer_id 0x%02x from device",
+				    peer_id);
+			return FALSE;
+		}
+
 		g_debug("detected peer: 0x%02x", peer_id);
 
 		if (peers_cache == NULL) {


### PR DESCRIPTION
Add bounds checking for peer_id value read from HID feature report to prevent out-of-bounds heap access. A malicious or compromised Nordic nRF52-based wireless receiver could send peer_id values of 0x00 or values > 16, causing:

- peer_id = 0: idx wraps to 255 via unsigned underflow (peer_id - 1)
- peer_id > 16: idx exceeds PEERS_CACHE_LEN bounds

This would lead to out-of-bounds read/write on the peers_cache array during peer enumeration, potentially corrupting adjacent heap structures in the fwupd daemon.

The fix validates peer_id immediately after reading from the device, rejecting any value outside the valid range [1, PEERS_CACHE_LEN].

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
