### PR TITLE
Fix path traversal vulnerability in firmware backup

### DIFF
--- a/libfwupdplugin/fu-path-test.c
+++ b/libfwupdplugin/fu-path-test.c
@@ -42,11 +42,43 @@ fu_path_verify_safe_func(void)
 	}
 }
 
+static void
+fu_path_sanitize_basename_func(void)
+{
+	struct {
+		const gchar *input;
+		const gchar *expected;
+	} tests[] = {
+	    {"normal", "normal"},
+	    {"with/slash", "with_slash"},
+	    {"with\\backslash", "with_backslash"},
+	    {"../../../etc/passwd", "______etc_passwd"},
+	    {"../../../../etc/cron.d", "________etc_cron.d"},
+	    {".hidden", "_hidden"},
+	    {".../etc/passwd", "_._etc_passwd"},
+	    {"multiple///slashes", "multiple___slashes"},
+	    {"valid-filename.bin", "valid-filename.bin"},
+	    {"1.2.3.4", "1.2.3.4"},
+	};
+
+	for (guint i = 0; i < G_N_ELEMENTS(tests); i++) {
+		g_autofree gchar *result = fu_path_sanitize_basename(tests[i].input);
+		g_assert_cmpstr(result, ==, tests[i].expected);
+
+		/* ensure sanitized output cannot be used for path traversal */
+		g_assert_false(g_str_has_prefix(result, "/"));
+		g_assert_false(g_str_has_prefix(result, ".."));
+		g_assert_null(g_strstr_len(result, -1, "/"));
+		g_assert_null(g_strstr_len(result, -1, "\\"));
+	}
+}
+
 int
 main(int argc, char **argv)
 {
 	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
 	g_test_init(&argc, &argv, NULL);
 	g_test_add_func("/fwupd/path/verify_safe", fu_path_verify_safe_func);
+	g_test_add_func("/fwupd/path/sanitize_component", fu_path_sanitize_basename_func);
 	return g_test_run();
 }

--- a/libfwupdplugin/fu-path.c
+++ b/libfwupdplugin/fu-path.c
@@ -423,3 +423,33 @@ fu_path_verify_safe(const gchar *filename, GError **error)
 	/* success */
 	return TRUE;
 }
+
+/**
+ * fu_path_sanitize_basename:
+ * @str: a string to sanitize
+ *
+ * Sanitizes a string for use as a path basename by replacing path separators
+ * and other dangerous characters with underscores.
+ *
+ * Returns: (transfer full): a newly allocated sanitized string
+ *
+ * Since: 2.1.4
+ **/
+gchar *
+fu_path_sanitize_basename(const gchar *str)
+{
+	g_autoptr(GString) result = g_string_new(str);
+
+	g_return_val_if_fail(str != NULL, NULL);
+
+	/* replace dangerous characters */
+	g_string_replace(result, "/", "_", 0);
+	g_string_replace(result, "\\", "_", 0);
+	g_string_replace(result, "..", "_", 0);
+
+	/* detect hidden files */
+	if (g_str_has_prefix(result->str, "."))
+		result->str[0] = '_';
+
+	return g_string_free(g_steal_pointer(&result), FALSE);
+}

--- a/libfwupdplugin/fu-path.h
+++ b/libfwupdplugin/fu-path.h
@@ -34,3 +34,5 @@ fu_path_get_symlink_target(const gchar *filename, GError **error) G_GNUC_WARN_UN
 gboolean
 fu_path_verify_safe(const gchar *filename, GError **error) G_GNUC_WARN_UNUSED_RESULT
     G_GNUC_NON_NULL(1);
+gchar *
+fu_path_sanitize_basename(const gchar *str) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1);

--- a/libfwupdplugin/fu-plugin.c
+++ b/libfwupdplugin/fu-plugin.c
@@ -735,9 +735,13 @@ fu_plugin_device_write_firmware(FuPlugin *self,
 
 	/* back the old firmware up to /var/lib/fwupd */
 	if (fu_device_has_flag(device, FWUPD_DEVICE_FLAG_BACKUP_BEFORE_INSTALL)) {
+		const gchar *serial_raw;
+		const gchar *version_raw;
 		g_autoptr(GBytes) fw_old = NULL;
 		g_autofree gchar *path = NULL;
 		g_autofree gchar *fn = NULL;
+		g_autofree gchar *serial_safe = NULL;
+		g_autofree gchar *version_safe = NULL;
 
 		/* progress */
 		fu_progress_set_id(progress, G_STRLOC);
@@ -750,16 +754,25 @@ fu_plugin_device_write_firmware(FuPlugin *self,
 			g_prefix_error_literal(error, "failed to backup old firmware: ");
 			return FALSE;
 		}
-		fn = g_strdup_printf("%s.bin", fu_device_get_version(device));
-		path = fu_context_build_filename(
-		    priv->ctx,
-		    error,
-		    FU_PATH_KIND_LOCALSTATEDIR_PKG,
-		    "backup",
-		    fu_device_get_id(device),
-		    fu_device_get_serial(device) != NULL ? fu_device_get_serial(device) : "default",
-		    fn,
-		    NULL);
+
+		/* sanitize device-controlled strings to prevent path traversal */
+		serial_raw = fu_device_get_serial(device);
+		version_raw = fu_device_get_version(device);
+
+		if (serial_raw != NULL)
+			serial_safe = fu_path_sanitize_basename(serial_raw);
+		if (version_raw != NULL)
+			version_safe = fu_path_sanitize_basename(version_raw);
+
+		fn = g_strdup_printf("%s.bin", version_safe != NULL ? version_safe : "unknown");
+		path = fu_context_build_filename(priv->ctx,
+						 error,
+						 FU_PATH_KIND_LOCALSTATEDIR_PKG,
+						 "backup",
+						 fu_device_get_id(device),
+						 serial_safe != NULL ? serial_safe : "default",
+						 fn,
+						 NULL);
 		if (path == NULL)
 			return FALSE;
 		fu_progress_step_done(progress);


### PR DESCRIPTION
A malicious peripheral could exploit device serial and version strings to write firmware backups to arbitrary root-writable locations via path traversal (e.g., serial="../../../../etc/cron.d").

Add fu_path_sanitize_component() to replace path separators and leading dots with underscores, ensuring device-controlled strings cannot escape the intended backup directory.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
