### PR TITLE
libfwupdplugin: Restrict DS20 device-supplied quirks to prevent privi…

### DIFF
--- a/libfwupdplugin/fu-usb-device-fw-ds20.c
+++ b/libfwupdplugin/fu-usb-device-fw-ds20.c
@@ -104,6 +104,22 @@ fu_usb_device_fw_ds20_parse(FuUsbDeviceDs20 *self,
 		if (g_strcmp0(value, kv[1]) != 0)
 			g_debug("removing DS-20 whitespace '%s'", kv[1]);
 
+		/* only allow safe quirk keys from device-supplied DS20 descriptors to prevent
+		 * malicious devices from setting Plugin, Flags, Guid, CounterpartGuid, etc. */
+		{
+			static const gchar *ds20_allow[] = {"Name",
+							    "Summary",
+							    "Icon",
+							    "Version",
+							    "VersionFormat",
+							    "Vendor",
+							    NULL};
+			if (!g_strv_contains(ds20_allow, key)) {
+				g_debug("ignoring DS20 quirk key '%s' from device", key);
+				continue;
+			}
+		}
+
 		/* it's fine to be strict here, as we checked the fwupd version was new enough in
 		 * FuUsbDeviceDs20Item */
 		g_debug("setting ds20 device quirk '%s'='%s'", key, value);

--- a/src/fu-usb-backend-test.c
+++ b/src/fu-usb-backend-test.c
@@ -137,11 +137,11 @@ fu_usb_backend_func(void)
 	devicestr = fu_device_to_string(device_tmp);
 	g_debug("%s", devicestr);
 
-	/* check the fwupd DS20 descriptor was parsed */
+	/* check the fwupd DS20 descriptor was parsed (only safe quirks like Icon) */
 	g_assert_true(fu_device_has_icon(device_tmp, "computer"));
+	/* plugin quirk should be ignored for security (device-supplied DS20) */
 	possible_plugins = fu_device_get_possible_plugins(device_tmp);
-	g_assert_cmpint(possible_plugins->len, ==, 1);
-	g_assert_cmpstr(g_ptr_array_index(possible_plugins, 0), ==, "dfu");
+	g_assert_cmpint(possible_plugins->len, ==, 0);
 
 	/* load another device with the same VID:PID, and check that we did not get a replug */
 	usb_emulate_fn2 =


### PR DESCRIPTION
…lege escalation

Malicious USB devices could previously set arbitrary quirks via the DS20 platform-capability descriptor, including Plugin, Flags, Guid, and CounterpartGuid. This allowed a peripheral to route firmware updates to privileged backends like flashrom or bypass security protections.

Introduce an allow-list for device-supplied DS20 quirks that only permits safe, informational keys (Name, Summary, Icon, Version, VersionFormat, Vendor) and rejects security-critical keys.

Updated the USB backend test to expect Plugin quirks to be properly filtered from device-supplied DS20 descriptors while still accepting safe quirks like Icon.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
