### PR TITLE
fu-engine: Restrict ModifyRemote to prevent supply-chain redirection

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -970,11 +970,7 @@ fu_engine_modify_remote(FuEngine *self,
 	    "AutomaticReports",
 	    "AutomaticSecurityReports",
 	    "Enabled",
-	    "FirmwareBaseURI",
-	    "MetadataURI",
 	    "ReportURI",
-	    "Username",
-	    "Password",
 	    NULL,
 	};
 


### PR DESCRIPTION
Remove MetadataURI, FirmwareBaseURI, Username, and Password from the runtime-writable keys in fu_engine_modify_remote() to prevent attackers from redirecting firmware updates to hostile servers after obtaining a single PolKit authorization.

The ModifyRemote D-Bus method now only allows modification of user preference toggles (ApprovalRequired, AutomaticReports, Enabled, etc.) while keeping critical URIs and credentials restricted to static configuration files.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
