### PR TITLE
trivial: Do not allow security critical config keys to be set at runtime

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -892,15 +892,10 @@ fu_engine_modify_config(FuEngine *self,
 	if (g_strcmp0(section, "fwupd") == 0) {
 		const gchar *keys[] = {
 		    "ArchiveSizeMax",
-		    "ApprovedFirmware",
-		    "DisabledDevices",
-		    "DisabledPlugins",
 		    "EnumerateAllDevices",
-		    "EspLocation",
 		    "HostBkc",
 		    "IdleTimeout",
 		    "IgnorePower",
-		    "OnlyTrusted",
 		    "P2pPolicy",
 		    "ReleaseDedupe",
 		    "ReleasePriority",
@@ -908,12 +903,13 @@ fu_engine_modify_config(FuEngine *self,
 		    "ShowDevicePrivate",
 		    "TestDevices",
 		    "TrustedReports",
-		    "TrustedUids",
 		    "UpdateMotd",
 		    "UriSchemes",
 		    "VerboseDomains",
 		    NULL,
 		};
+		/* OnlyTrusted / TrustedUids / EspLocation / DisabledPlugins / DisabledDevices /
+		 * ApprovedFirmware are intentionally NOT writable at runtime */
 		if (!g_strv_contains(keys, key)) {
 			g_set_error(error,
 				    FWUPD_ERROR,


### PR DESCRIPTION
Prevent ModifyConfig D-Bus method from writing OnlyTrusted, TrustedUids, EspLocation, DisabledPlugins, DisabledDevices, and ApprovedFirmware to avoid privilege escalation where a single PolKit authorization could persistently disable signature verification or grant root-equivalent capabilities.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
