### PR TITLE
trivial: Fail closed when PolicyKit daemon is unavailable

### DIFF
--- a/src/fu-polkit-authority.c
+++ b/src/fu-polkit-authority.c
@@ -99,8 +99,15 @@ fu_polkit_authority_check(FuPolkitAuthority *self,
 	g_task_set_source_tag(task, fu_polkit_authority_check);
 
 #ifdef HAVE_POLKIT
-	if (owner != NULL && sender != NULL) {
+	if (sender != NULL) {
 		g_autoptr(PolkitSubject) pksubject = polkit_system_bus_name_new(sender);
+		if (owner == NULL) {
+			g_task_return_new_error_literal(task,
+							FWUPD_ERROR,
+							FWUPD_ERROR_AUTH_FAILED,
+							"PolicyKit daemon is not available");
+			return;
+		}
 		if (flags & FU_POLKIT_AUTHORITY_CHECK_FLAG_ALLOW_USER_INTERACTION)
 			pkflags |= POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
 		polkit_authority_check_authorization(self->pkauthority,


### PR DESCRIPTION
Previously, fu_polkit_authority_check() would fall through to a weak USER_IS_TRUSTED check when polkit_authority_get_owner() returned NULL (polkitd crashed, restarting, or absent). This allowed authorization bypass in environments where polkitd could be made unavailable.

Now explicitly fail with FWUPD_ERROR_AUTH_FAILED when a bus sender exists but polkitd is not running, preventing the fallthrough.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
