### PR TITLE
Prevent NVRAM-seeded path traversal when loading ESP files

### DIFF
--- a/libfwupdplugin/fu-context.c
+++ b/libfwupdplugin/fu-context.c
@@ -2227,6 +2227,8 @@ fu_context_get_esp_files_for_entry(FuContext *self,
 	dp_filename = fu_efi_file_path_device_path_get_name(dp_path, error);
 	if (dp_filename == NULL)
 		return FALSE;
+	if (!fu_path_verify_safe(dp_filename, error))
+		return FALSE;
 
 	/* the file itself */
 	mount_point = fu_volume_get_mount_point(volume);
@@ -2347,6 +2349,7 @@ fu_context_get_esp_files(FuContext *self, FuContextEspFileFlags flags, GError **
 		g_autoptr(GError) error_local = NULL;
 		if (!fu_context_get_esp_files_for_entry(self, entry, files, flags, &error_local)) {
 			if (g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND) ||
+			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED) ||
 			    g_error_matches(error_local, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE)) {
 				g_debug("ignoring %s: %s",
 					fu_firmware_get_id(FU_FIRMWARE(entry)),

--- a/plugins/uefi-sbat/fu-uefi-sbat-device.c
+++ b/plugins/uefi-sbat/fu-uefi-sbat-device.c
@@ -167,6 +167,8 @@ fu_uefi_sbat_device_write_firmware(FuDevice *device,
 	fp_name = fu_efi_file_path_device_path_get_name(FU_EFI_FILE_PATH_DEVICE_PATH(dp_fp), error);
 	if (fp_name == NULL)
 		return FALSE;
+	if (!fu_path_verify_safe(fp_name, error))
+		return FALSE;
 	filename_shim = g_build_filename(mount_point, fp_name, NULL);
 	dirname = g_path_get_dirname(filename_shim);
 	filename_revocation = g_build_filename(dirname, "revocations.efi", NULL);


### PR DESCRIPTION
Similar to the SBAT plugin vulnerability, fu_context_get_esp_files_for_entry() reads the FilePath component from Boot#### NVRAM entries and uses it to construct filesystem paths for reading ESP PE files.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
