### PR TITLE
Use g_autofd and g_steal_fd

### DIFF
--- a/libfwupd/fwupd-build.h
+++ b/libfwupd/fwupd-build.h
@@ -22,9 +22,56 @@
 #define g_prefix_error_literal	  g_prefix_error
 #define g_spawn_check_wait_status g_spawn_check_exit_status
 #define g_source_set_static_name(n1, n2)
+static inline int
+g_steal_fd(int *fd_ptr)
+{
+	int fd = *fd_ptr;
+	*fd_ptr = -1;
+	return fd;
+}
 #endif
 #if !GLIB_CHECK_VERSION(2, 72, 0)
 #define g_log_get_debug_enabled() (g_getenv("FWUPD_VERBOSE") != NULL)
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 76, 0)
+static inline gboolean
+g_clear_fd(int *fd_ptr, GError **error)
+{
+	int fd = *fd_ptr;
+
+	*fd_ptr = -1;
+
+	if (fd < 0)
+		return TRUE;
+
+	/* suppress "Not available before" warning */
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	return g_close(fd, error);
+	G_GNUC_END_IGNORE_DEPRECATIONS
+}
+
+/* Not public API */
+static inline void
+_g_clear_fd_ignore_error(int *fd_ptr)
+{
+	/* Don't overwrite thread-local errno if closing the fd fails */
+	int errsv = errno;
+
+	/* suppress "Not available before" warning */
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+
+	if (!g_clear_fd(fd_ptr, NULL)) {
+		/* Do nothing: we ignore all errors, except for EBADF which
+		 * is a programming error, checked for by g_close(). */
+	}
+
+	G_GNUC_END_IGNORE_DEPRECATIONS
+
+	errno = errsv;
+}
+
+#define g_autofd _GLIB_CLEANUP(_g_clear_fd_ignore_error)
 #endif
 
 #if !GLIB_CHECK_VERSION(2, 80, 0)

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -508,7 +508,7 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 GUnixInputStream *
 fwupd_unix_input_stream_from_fn(const gchar *fn, GError **error)
 {
-	gint fd = open(fn, O_RDONLY);
+	g_autofd gint fd = open(fn, O_RDONLY);
 	if (fd < 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -518,7 +518,7 @@ fwupd_unix_input_stream_from_fn(const gchar *fn, GError **error)
 			    fwupd_strerror(errno));
 		return NULL;
 	}
-	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(fd, TRUE));
+	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(g_steal_fd(&fd), TRUE));
 }
 
 /**
@@ -527,7 +527,7 @@ fwupd_unix_input_stream_from_fn(const gchar *fn, GError **error)
 GUnixOutputStream *
 fwupd_unix_output_stream_from_fn(const gchar *fn, GError **error)
 {
-	gint fd = g_open(fn, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+	g_autofd gint fd = g_open(fn, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -537,7 +537,7 @@ fwupd_unix_output_stream_from_fn(const gchar *fn, GError **error)
 			    fwupd_strerror(errno));
 		return NULL;
 	}
-	return G_UNIX_OUTPUT_STREAM(g_unix_output_stream_new(fd, TRUE));
+	return G_UNIX_OUTPUT_STREAM(g_unix_output_stream_new(g_steal_fd(&fd), TRUE));
 }
 #endif
 

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -452,7 +452,7 @@ fwupd_guid_hash_string(const gchar *str)
 GUnixInputStream *
 fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 {
-	gint fd;
+	g_autofd gint fd = -1;
 	gssize rc;
 #ifndef HAVE_MEMFD_CREATE
 	gchar tmp_file[] = "/tmp/fwupd.XXXXXX";
@@ -466,10 +466,6 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 	if (fd != -1) {
 		rc = g_unlink(tmp_file);
 		if (rc != 0) {
-			if (!g_close(fd, error)) {
-				g_prefix_error_literal(error, "failed to close temporary file: ");
-				return NULL;
-			}
 			g_set_error_literal(error,
 					    FWUPD_ERROR,
 					    FWUPD_ERROR_INVALID_FILE,
@@ -503,7 +499,7 @@ fwupd_unix_input_stream_from_bytes(GBytes *bytes, GError **error)
 			    fwupd_strerror(errno));
 		return NULL;
 	}
-	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(fd, TRUE));
+	return G_UNIX_INPUT_STREAM(g_unix_input_stream_new(g_steal_fd(&fd), TRUE));
 }
 
 /**

--- a/libfwupdplugin/fu-io-channel.c
+++ b/libfwupdplugin/fu-io-channel.c
@@ -625,7 +625,7 @@ fu_io_channel_unix_new(gint fd)
 FuIOChannel *
 fu_io_channel_new_file(const gchar *filename, FuIoChannelOpenFlags open_flags, GError **error)
 {
-	gint fd;
+	g_autofd gint fd = -1;
 	int flags = 0;
 
 	g_return_val_if_fail(filename != NULL, NULL);
@@ -662,7 +662,7 @@ fu_io_channel_new_file(const gchar *filename, FuIoChannelOpenFlags open_flags, G
 		fwupd_error_convert(error);
 		return NULL;
 	}
-	return fu_io_channel_unix_new(fd);
+	return fu_io_channel_unix_new(g_steal_fd(&fd));
 }
 
 /**
@@ -680,7 +680,7 @@ FuIOChannel *
 fu_io_channel_virtual_new(const gchar *name, GError **error)
 {
 #ifdef HAVE_MEMFD_CREATE
-	gint fd;
+	g_autofd gint fd = -1;
 
 	g_return_val_if_fail(name != NULL, NULL);
 	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
@@ -700,7 +700,7 @@ fu_io_channel_virtual_new(const gchar *name, GError **error)
 		fwupd_error_convert(error);
 		return NULL;
 	}
-	return fu_io_channel_unix_new(fd);
+	return fu_io_channel_unix_new(g_steal_fd(&fd));
 #else
 	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "memfd not supported");
 	return NULL;

--- a/libfwupdplugin/fu-linux-efivars.c
+++ b/libfwupdplugin/fu-linux-efivars.c
@@ -13,6 +13,7 @@
 #include <fcntl.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
+#include <glib/gstdio.h>
 #include <linux/fs.h>
 #include <string.h>
 #include <sys/ioctl.h>
@@ -130,7 +131,7 @@ fu_linux_efivars_set_immutable_fd(int fd, gboolean value, gboolean *value_old, G
 static gboolean
 fu_linux_efivars_set_immutable(const gchar *fn, gboolean value, gboolean *value_old, GError **error)
 {
-	gint fd;
+	g_autofd gint fd = -1;
 	g_autoptr(GInputStream) istr = NULL;
 
 	/* not bare-metal */
@@ -147,7 +148,7 @@ fu_linux_efivars_set_immutable(const gchar *fn, gboolean value, gboolean *value_
 			    fwupd_strerror(errno));
 		return FALSE;
 	}
-	istr = g_unix_input_stream_new(fd, TRUE);
+	istr = g_unix_input_stream_new(g_steal_fd(&fd), TRUE);
 	if (istr == NULL) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
@@ -155,7 +156,11 @@ fu_linux_efivars_set_immutable(const gchar *fn, gboolean value, gboolean *value_
 				    "failed to create stream");
 		return FALSE;
 	}
-	return fu_linux_efivars_set_immutable_fd(fd, value, value_old, error);
+	return fu_linux_efivars_set_immutable_fd(
+	    g_unix_input_stream_get_fd(G_UNIX_INPUT_STREAM(istr)),
+	    value,
+	    value_old,
+	    error);
 }
 
 static gboolean
@@ -510,7 +515,7 @@ fu_linux_efivars_set_data(FuEfivars *efivars,
 			  FuEfiVariableAttrs attr,
 			  GError **error)
 {
-	int fd;
+	g_autofd int fd = -1;
 	int open_wflags = O_WRONLY;
 	gboolean was_immutable = TRUE;
 	g_autofree gchar *fn = NULL;
@@ -543,7 +548,7 @@ fu_linux_efivars_set_data(FuEfivars *efivars,
 			    fwupd_strerror(errno));
 		return FALSE;
 	}
-	ostr = g_unix_output_stream_new(fd, TRUE);
+	ostr = g_unix_output_stream_new(g_steal_fd(&fd), TRUE);
 	memcpy(buf, &attr, sizeof(attr));     /* nocheck:blocked */
 	memcpy(buf + sizeof(attr), data, sz); /* nocheck:blocked */
 	if (g_output_stream_write(ostr, buf, sizeof(attr) + sz, NULL, error) < 0) {

--- a/libfwupdplugin/fu-volume.c
+++ b/libfwupdplugin/fu-volume.c
@@ -505,7 +505,7 @@ static guint32
 fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **error)
 {
 #if defined(HAVE_IOCTL_H) && defined(HAVE_BLKSSZGET)
-	gint fd;
+	g_autofd gint fd = -1;
 	gint rc;
 	gint sector_size = 0;
 
@@ -533,7 +533,6 @@ fu_volume_get_block_size_from_device_name(const gchar *device_name, GError **err
 				    "failed to get non-zero logical sector size");
 		/* nocheck:error-false-return */
 	}
-	g_close(fd, NULL);
 	return sector_size;
 #else
 	g_set_error_literal(error,

--- a/plugins/bcm57xx/fu-bcm57xx-device.c
+++ b/plugins/bcm57xx/fu-bcm57xx-device.c
@@ -568,7 +568,7 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 {
 #ifdef HAVE_SOCKET_H
 	FuBcm57xxDevice *self = FU_BCM57XX_DEVICE(device);
-	gint fd;
+	g_autofd gint fd = -1;
 	g_autoptr(FuIOChannel) io_channel = NULL;
 
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -584,7 +584,7 @@ fu_bcm57xx_device_open(FuDevice *device, GError **error)
 #endif
 		return FALSE;
 	}
-	io_channel = fu_io_channel_unix_new(fd);
+	io_channel = fu_io_channel_unix_new(g_steal_fd(&fd));
 	fu_udev_device_set_io_channel(FU_UDEV_DEVICE(self), io_channel);
 	return TRUE;
 #else

--- a/plugins/synaptics-mst/fu-synaptics-mst-device.c
+++ b/plugins/synaptics-mst/fu-synaptics-mst-device.c
@@ -11,6 +11,7 @@
 #include "config.h"
 
 #include <fcntl.h>
+#include <glib/gstdio.h>
 
 #include "fu-synaptics-mst-device.h"
 #include "fu-synaptics-mst-firmware.h"
@@ -1528,7 +1529,7 @@ fu_synaptics_mst_device_ensure_board_id(FuSynapticsMstDevice *self, GError **err
 		g_autofree gchar *filename = NULL;
 		g_autofree gchar *dirname = NULL;
 		gboolean exists_eeprom = FALSE;
-		gint fd;
+		g_autofd gint fd = -1;
 		dirname = g_path_get_dirname(fu_udev_device_get_device_file(FU_UDEV_DEVICE(self)));
 		filename = g_strdup_printf("%s/remote/%s_eeprom",
 					   dirname,
@@ -1558,11 +1559,9 @@ fu_synaptics_mst_device_ensure_board_id(FuSynapticsMstDevice *self, GError **err
 				    FWUPD_ERROR_INVALID_DATA,
 				    "error reading EEPROM file %s",
 				    filename);
-			close(fd);
 			return FALSE;
 		}
 		self->board_id = fu_memread_uint16(buf, G_BIG_ENDIAN);
-		close(fd);
 		return TRUE;
 	}
 

--- a/plugins/uefi-capsule/fu-uefi-capsule-backend-freebsd.c
+++ b/plugins/uefi-capsule/fu-uefi-capsule-backend-freebsd.c
@@ -115,7 +115,7 @@ fu_uefi_capsule_backend_freebsd_coldplug(FuBackend *backend, FuProgress *progres
 	FuUefiCapsuleBackend *self = FU_UEFI_CAPSULE_BACKEND(backend);
 	const gchar *esrt_dev = "/dev/efi";
 	struct efi_get_table_ioc table = {.uuid = EFI_TABLE_ESRT};
-	gint efi_fd;
+	g_autofd gint efi_fd = -1;
 	struct efi_esrt_entry_v1 *entries;
 	g_autofree struct efi_esrt_table *esrt = NULL;
 
@@ -130,7 +130,6 @@ fu_uefi_capsule_backend_freebsd_coldplug(FuBackend *backend, FuProgress *progres
 	}
 
 	if (ioctl(efi_fd, EFIIOC_GET_TABLE, &table) == -1) /* nocheck:blocked */ {
-		g_close(efi_fd, NULL);
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -140,7 +139,6 @@ fu_uefi_capsule_backend_freebsd_coldplug(FuBackend *backend, FuProgress *progres
 
 	esrt = g_malloc(table.table_len);
 	if (esrt == NULL) {
-		g_close(efi_fd, NULL);
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,
@@ -151,7 +149,6 @@ fu_uefi_capsule_backend_freebsd_coldplug(FuBackend *backend, FuProgress *progres
 	table.buf = esrt;
 	table.buf_len = table.table_len;
 	if (ioctl(efi_fd, EFIIOC_GET_TABLE, &table) == -1) {
-		g_close(efi_fd, NULL);
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOT_SUPPORTED,

--- a/src/fu-dbus-daemon.c
+++ b/src/fu-dbus-daemon.c
@@ -1079,7 +1079,7 @@ fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GE
 #ifdef HAVE_GIO_UNIX
 	GDBusMessage *message;
 	GUnixFDList *fd_list;
-	gint fd;
+	g_autofd gint fd = -1;
 	g_autoptr(GInputStream) stream = NULL;
 
 	/* get the fd */
@@ -1105,7 +1105,7 @@ fu_dbus_daemon_invocation_get_input_stream(GDBusMethodInvocation *invocation, GE
 		return NULL;
 
 	/* get details about the file (will close the fd when done) */
-	stream = fu_unix_seekable_input_stream_new(fd, TRUE, error);
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, error);
 	if (stream == NULL)
 		return NULL;
 	return g_steal_pointer(&stream);
@@ -1121,7 +1121,7 @@ fu_dbus_daemon_invocation_get_output_stream(GDBusMethodInvocation *invocation, G
 #ifdef HAVE_GIO_UNIX
 	GDBusMessage *message;
 	GUnixFDList *fd_list;
-	gint fd;
+	g_autofd gint fd = -1;
 	g_autoptr(GOutputStream) stream = NULL;
 
 	/* get the fd */
@@ -1147,7 +1147,7 @@ fu_dbus_daemon_invocation_get_output_stream(GDBusMethodInvocation *invocation, G
 		return NULL;
 
 	/* get details about the file (will close the fd when done) */
-	stream = g_unix_output_stream_new(fd, TRUE);
+	stream = g_unix_output_stream_new(g_steal_fd(&fd), TRUE);
 	if (stream == NULL) {
 		g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL, "invalid stream");
 		return NULL;
@@ -1929,8 +1929,8 @@ fu_dbus_daemon_authorize_update_metadata_cb(GObject *source, GAsyncResult *res, 
 	FuEngine *engine = fu_daemon_get_engine(FU_DAEMON(helper->self));
 	GDBusMessage *message;
 	GUnixFDList *fd_list;
-	gint fd_data;
-	gint fd_sig;
+	g_autofd gint fd_data = -1;
+	g_autofd gint fd_sig = -1;
 
 	/* get result */
 	if (!fu_polkit_authority_check_finish(FU_POLKIT_AUTHORITY(source), res, &error)) {
@@ -1970,7 +1970,11 @@ fu_dbus_daemon_authorize_update_metadata_cb(GObject *source, GAsyncResult *res, 
 	}
 
 	/* store new metadata (will close the fds when done) */
-	if (!fu_engine_update_metadata(engine, helper->remote_id, fd_data, fd_sig, &error)) {
+	if (!fu_engine_update_metadata(engine,
+				       helper->remote_id,
+				       g_steal_fd(&fd_data),
+				       g_steal_fd(&fd_sig),
+				       &error)) {
 		g_prefix_error(&error, "Failed to update metadata for %s: ", helper->remote_id);
 		fu_dbus_daemon_method_invocation_return_gerror(helper->invocation, error);
 		return;

--- a/src/fu-remote-list.c
+++ b/src/fu-remote-list.c
@@ -98,7 +98,7 @@ static void
 fu_remote_list_fixup_inotify_error(GError **error) /* nocheck:error */
 {
 #ifdef HAVE_INOTIFY_H
-	int fd;
+	g_autofd int fd = -1;
 	int wd;
 	const gchar *fn = "/proc/sys/fs/inotify/max_user_instances";
 
@@ -119,7 +119,6 @@ fu_remote_list_fixup_inotify_error(GError **error) /* nocheck:error */
 	} else {
 		inotify_rm_watch(fd, wd);
 	}
-	close(fd);
 #endif
 }
 

--- a/src/fu-unix-seekable-input-stream-test.c
+++ b/src/fu-unix-seekable-input-stream-test.c
@@ -18,7 +18,7 @@ fu_unix_seekable_input_stream_func(void)
 {
 #ifdef HAVE_GIO_UNIX
 	gssize ret;
-	gint fd;
+	g_autofd gint fd = -1;
 	guint8 buf[6] = {0};
 	g_autofree gchar *fn = NULL;
 	g_autoptr(GError) error = NULL;
@@ -29,7 +29,7 @@ fu_unix_seekable_input_stream_func(void)
 	fd = g_open(fn, O_RDONLY, 0);
 	g_assert_cmpint(fd, >=, 0);
 
-	stream = fu_unix_seekable_input_stream_new(fd, TRUE, &error);
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(stream);
 
@@ -62,14 +62,14 @@ static void
 fu_unix_seekable_input_stream_non_regular_func(void)
 {
 #ifdef HAVE_GIO_UNIX
-	gint fd;
+	g_autofd gint fd = -1;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GInputStream) stream = NULL;
 
 	fd = g_open("/dev/zero", O_RDONLY, 0);
 	g_assert_cmpint(fd, >=, 0);
 
-	stream = fu_unix_seekable_input_stream_new(fd, TRUE, &error);
+	stream = fu_unix_seekable_input_stream_new(g_steal_fd(&fd), TRUE, &error);
 	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE);
 	g_assert_null(stream);
 #else


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Follow-up from https://github.com/fwupd/fwupd/pull/10344#pullrequestreview-4325074559 with the backports for older glib versions. This now also includes a few more fd leaks (all in error paths) and as last commit changing all current fd-related functions to use g_autofd.