### PR TITLE
lenovo-dock: Allow recovery if the device usage table is invalid

### DIFF
--- a/plugins/lenovo-dock/fu-lenovo-dock-device.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-device.c
@@ -9,7 +9,6 @@
 #include "fu-lenovo-dock-device.h"
 #include "fu-lenovo-dock-firmware.h"
 #include "fu-lenovo-dock-image.h"
-#include "fu-lenovo-dock-struct.h"
 
 #define FU_LENOVO_DOCK_DEVICE_IFACE1_LEN 64
 #define FU_LENOVO_DOCK_DEVICE_IFACE2_LEN 272
@@ -29,8 +28,6 @@ struct _FuLenovoDockDevice {
 	FuHidDevice parent_instance;
 	guint16 image_pid;
 	FuLenovoDockProvisionStatus provision_status;
-	FuStructLenovoDockUsage *st_usage;
-	GPtrArray *st_usage_items; /* element-type: FuStructLenovoDockUsageItem */
 };
 
 G_DEFINE_TYPE(FuLenovoDockDevice, fu_lenovo_dock_device, FU_TYPE_HID_DEVICE)
@@ -46,36 +43,6 @@ fu_lenovo_dock_device_to_string(FuDevice *device, guint idt, GString *str)
 	    idt,
 	    "ProvisionStatus",
 	    fu_lenovo_dock_provision_status_to_string(self->provision_status));
-	if (self->st_usage != NULL) {
-		g_autofree gchar *tmp = fu_struct_lenovo_dock_usage_to_string(self->st_usage);
-		fwupd_codec_string_append(str, idt, "Usage", tmp);
-	}
-	for (guint i = 0; i < self->st_usage_items->len; i++) {
-		FuStructLenovoDockUsageItem *st_usage_item =
-		    g_ptr_array_index(self->st_usage_items, i);
-		g_autofree gchar *tmp = fu_struct_lenovo_dock_usage_item_to_string(st_usage_item);
-		fwupd_codec_string_append(str, idt, "UsageItem", tmp);
-	}
-}
-
-static FuStructLenovoDockUsageItem *
-fu_lenovo_dock_device_get_usage_item(FuLenovoDockDevice *self,
-				     FuLenovoDockComponentId component_id,
-				     GError **error)
-{
-	for (guint i = 0; i < self->st_usage_items->len; i++) {
-		FuStructLenovoDockUsageItem *st_usage_item =
-		    g_ptr_array_index(self->st_usage_items, i);
-		if (fu_struct_lenovo_dock_usage_item_get_component_id(st_usage_item) ==
-		    component_id)
-			return st_usage_item;
-	}
-	g_set_error(error,
-		    FWUPD_ERROR,
-		    FWUPD_ERROR_NOT_FOUND,
-		    "cannot find component ID 0x%x",
-		    component_id);
-	return NULL;
 }
 
 static gboolean
@@ -423,50 +390,6 @@ fu_lenovo_dock_device_get_component_attrs_list(FuLenovoDockDevice *self,
 	return TRUE;
 }
 
-static GByteArray *
-fu_lenovo_dock_device_flash_read_memory(FuLenovoDockDevice *self,
-					FuLenovoDockComponentId component_id,
-					guint32 addr,
-					gsize datasz,
-					GError **error)
-{
-	g_autoptr(GByteArray) data = g_byte_array_new();
-
-	for (gsize i = 0; i < datasz; i += FU_STRUCT_LENOVO_DOCK_FLASH_READ_RES_N_ELEMENTS_DATA) {
-		const guint8 *datatmp;
-		gsize datatmpsz = 0;
-		g_autoptr(GByteArray) buf = NULL;
-		g_autoptr(FuStructLenovoDockFlashReadReq) st_req =
-		    fu_struct_lenovo_dock_flash_read_req_new();
-		g_autoptr(FuStructLenovoDockFlashReadRes) st_res = NULL;
-
-		fu_struct_lenovo_dock_flash_read_req_set_size(
-		    st_req,
-		    FU_STRUCT_LENOVO_DOCK_FLASH_READ_RES_N_ELEMENTS_DATA);
-		fu_struct_lenovo_dock_flash_read_req_set_component_id(st_req, component_id);
-		fu_struct_lenovo_dock_flash_read_req_set_addr(st_req, addr + i);
-		if (g_log_get_debug_enabled()) {
-			g_autofree gchar *str =
-			    fu_struct_lenovo_dock_flash_read_req_to_string(st_req);
-			g_log("FuStruct", G_LOG_LEVEL_DEBUG, "%s", str);
-		}
-		if (!fu_lenovo_dock_device_set_report2(self, st_req->buf, error))
-			return NULL;
-		buf = fu_lenovo_dock_device_get_report2(self, FU_LENOVO_DOCK_DEVICE_DELAY, error);
-		if (buf == NULL)
-			return NULL;
-		st_res =
-		    fu_struct_lenovo_dock_flash_read_res_parse(buf->data, buf->len, 0x0, error);
-		if (st_res == NULL)
-			return NULL;
-		datatmp = fu_struct_lenovo_dock_flash_read_res_get_data(st_res, &datatmpsz);
-		g_byte_array_append(data, datatmp, datatmpsz);
-	}
-
-	/* success */
-	return g_steal_pointer(&data);
-}
-
 static gboolean
 fu_lenovo_dock_device_flash_erase_chunk(FuLenovoDockDevice *self,
 					FuLenovoDockComponentId component_id,
@@ -700,78 +623,6 @@ fu_lenovo_dock_device_check_firmware(FuDevice *device,
 }
 
 static gboolean
-fu_lenovo_dock_device_ensure_usage(FuLenovoDockDevice *self, gboolean *valid, GError **error)
-{
-	guint32 crc_actual = 0;
-	guint32 crc_calculated;
-	guint8 usage_items;
-	gsize offset = 0;
-	g_autoptr(GByteArray) buf = NULL;
-	g_autoptr(FuStructLenovoDockUsage) st = NULL;
-
-	/* read the device metadata table */
-	buf = fu_lenovo_dock_device_flash_read_memory(self,
-						      FU_LENOVO_DOCK_COMPONENT_ID_USAGE,
-						      FU_LENOVO_DOCK_DEVICE_USAGE_INFO_START,
-						      FU_LENOVO_DOCK_DEVICE_USAGE_INFO_SIZE,
-						      error);
-	if (buf == NULL) {
-		g_prefix_error_literal(error, "failed to get usage info: ");
-		return FALSE;
-	}
-	if (buf->len < FU_LENOVO_DOCK_DEVICE_USAGE_INFO_SIZE) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "not enough usage info");
-		return FALSE;
-	}
-	crc_calculated = fu_crc32(FU_CRC_KIND_B32_STANDARD, buf->data, buf->len - 4);
-	if (!fu_memread_uint32_safe(buf->data,
-				    buf->len,
-				    buf->len - 4,
-				    &crc_actual,
-				    G_LITTLE_ENDIAN,
-				    error))
-		return FALSE;
-	g_debug("usage info CRC got 0x%08x, expected 0x%08x", crc_actual, crc_calculated);
-
-	/* parse the usage metadata */
-	st = fu_struct_lenovo_dock_usage_parse(buf->data, buf->len, offset, error);
-	if (st == NULL)
-		return FALSE;
-	usage_items = fu_struct_lenovo_dock_usage_get_total_number(st);
-
-	/* are payloads signed */
-	if (fu_struct_lenovo_dock_usage_get_dsa(st) != FU_LENOVO_DOCK_DSA_TYPE_NONE)
-		fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
-
-	/* save so we can reconstruct for erase + program */
-	if (self->st_usage != NULL)
-		fu_struct_lenovo_dock_usage_unref(self->st_usage);
-	self->st_usage = fu_struct_lenovo_dock_usage_ref(st);
-
-	/* parse each usage metadata item */
-	g_ptr_array_set_size(self->st_usage_items, 0);
-	offset += FU_STRUCT_LENOVO_DOCK_USAGE_SIZE;
-	for (guint i = 0; i < usage_items; i++) {
-		g_autoptr(FuStructLenovoDockUsageItem) st_item = NULL;
-		st_item =
-		    fu_struct_lenovo_dock_usage_item_parse(buf->data, buf->len, offset, error);
-		if (st_item == NULL)
-			return FALSE;
-		g_ptr_array_add(self->st_usage_items,
-				fu_struct_lenovo_dock_usage_item_ref(st_item));
-		offset += FU_STRUCT_LENOVO_DOCK_USAGE_ITEM_SIZE;
-	}
-
-	/* success */
-	if (valid != NULL)
-		*valid = crc_calculated == crc_actual;
-	return TRUE;
-}
-
-static gboolean
 fu_lenovo_dock_device_get_component_attrs(FuLenovoDockDevice *self,
 					  FuLenovoDockComponentId component_id,
 					  FuLenovoDockComponentPurpose *purpose,
@@ -808,8 +659,13 @@ fu_lenovo_dock_device_get_component_attrs(FuLenovoDockDevice *self,
 }
 
 static gboolean
-fu_lenovo_dock_device_write_usage(FuLenovoDockDevice *self, FuProgress *progress, GError **error)
+fu_lenovo_dock_device_write_usage(FuLenovoDockDevice *self,
+				  FuLenovoDockFirmware *firmware,
+				  FuProgress *progress,
+				  GError **error)
 {
+	FuStructLenovoDockUsage *st_usage = fu_lenovo_dock_firmware_get_usage(firmware);
+	GPtrArray *st_usage_items = fu_lenovo_dock_firmware_get_usage_items(firmware);
 	guint16 erase_size = 0;
 	guint16 program_size = 0;
 	guint32 storage_size = 0;
@@ -845,10 +701,9 @@ fu_lenovo_dock_device_write_usage(FuLenovoDockDevice *self, FuProgress *progress
 	}
 
 	/* erase and write new table */
-	g_byte_array_append(buf, self->st_usage->buf->data, self->st_usage->buf->len);
-	for (guint i = 0; i < self->st_usage_items->len; i++) {
-		FuStructLenovoDockUsageItem *st_usage_item =
-		    g_ptr_array_index(self->st_usage_items, i);
+	g_byte_array_append(buf, st_usage->buf->data, st_usage->buf->len);
+	for (guint i = 0; i < st_usage_items->len; i++) {
+		FuStructLenovoDockUsageItem *st_usage_item = g_ptr_array_index(st_usage_items, i);
 		g_byte_array_append(buf, st_usage_item->buf->data, st_usage_item->buf->len);
 	}
 	if (buf->len > FU_LENOVO_DOCK_DEVICE_USAGE_INFO_SIZE) {
@@ -918,6 +773,7 @@ fu_lenovo_dock_device_write_usage(FuLenovoDockDevice *self, FuProgress *progress
 
 static gboolean
 fu_lenovo_dock_device_write_image(FuLenovoDockDevice *self,
+				  FuLenovoDockFirmware *firmware,
 				  FuLenovoDockComponentId component_id,
 				  FuFirmware *img,
 				  FuProgress *progress,
@@ -950,7 +806,7 @@ fu_lenovo_dock_device_write_image(FuLenovoDockDevice *self,
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_WRITE, 4, "usage");
 
 	/* get image + item */
-	st_usage_item = fu_lenovo_dock_device_get_usage_item(self, component_id, error);
+	st_usage_item = fu_lenovo_dock_firmware_get_usage_item(firmware, component_id, error);
 	if (st_usage_item == NULL)
 		return FALSE;
 
@@ -1035,11 +891,10 @@ fu_lenovo_dock_device_write_image(FuLenovoDockDevice *self,
 	/* write target fw version - but do *not* set flag=DoUpdate */
 	fu_struct_lenovo_dock_usage_item_set_target_version(st_usage_item,
 							    fu_firmware_get_version_raw(img));
-	fu_struct_lenovo_dock_usage_item_set_target_size(
-	    st_usage_item,
-	    fu_firmware_get_size(img) - FU_LENOVO_DOCK_FIRMWARE_SIGNATURE_SIZE);
-	fu_struct_lenovo_dock_usage_item_set_target_crc32(st_usage_item, crc_provided);
-	if (!fu_lenovo_dock_device_write_usage(self, fu_progress_get_child(progress), error))
+	if (!fu_lenovo_dock_device_write_usage(self,
+					       FU_LENOVO_DOCK_FIRMWARE(firmware),
+					       fu_progress_get_child(progress),
+					       error))
 		return FALSE;
 	fu_progress_step_done(progress);
 
@@ -1049,12 +904,13 @@ fu_lenovo_dock_device_write_image(FuLenovoDockDevice *self,
 
 static gboolean
 fu_lenovo_dock_device_write_images(FuLenovoDockDevice *self,
-				   FuFirmware *firmware,
+				   FuLenovoDockFirmware *firmware,
 				   FuProgress *progress,
 				   FwupdInstallFlags flags,
 				   GError **error)
 {
-	guint8 total_number = fu_struct_lenovo_dock_usage_get_total_number(self->st_usage);
+	FuStructLenovoDockUsage *st_usage = fu_lenovo_dock_firmware_get_usage(firmware);
+	guint8 total_number = fu_struct_lenovo_dock_usage_get_total_number(st_usage);
 
 	/* sanity check */
 	if (total_number == 0) {
@@ -1071,13 +927,15 @@ fu_lenovo_dock_device_write_images(FuLenovoDockDevice *self,
 		g_autoptr(FuFirmware) img = NULL;
 		g_autoptr(GError) error_local = NULL;
 
-		img = fu_firmware_get_image_by_idx(firmware, component_id, &error_local);
+		img =
+		    fu_firmware_get_image_by_idx(FU_FIRMWARE(firmware), component_id, &error_local);
 		if (img == NULL) {
 			g_debug("ignoring: %s", error_local->message);
 			fu_progress_step_done(progress);
 			continue;
 		}
 		if (!fu_lenovo_dock_device_write_image(self,
+						       firmware,
 						       component_id,
 						       img,
 						       fu_progress_get_child(progress),
@@ -1135,14 +993,15 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 				     GError **error)
 {
 	FuLenovoDockDevice *self = FU_LENOVO_DOCK_DEVICE(device);
-	gboolean usage_info_valid = FALSE;
+	FuStructLenovoDockUsage *st_usage =
+	    fu_lenovo_dock_firmware_get_usage(FU_LENOVO_DOCK_FIRMWARE(firmware));
 	guint8 component_id_total = 0;
 	guint8 total_number;
 	g_autoptr(FuDeviceLocker) flash_locker = NULL;
+	g_autoptr(GError) error_local = NULL;
 
 	/* progress */
 	fu_progress_set_id(progress, G_STRLOC);
-	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, NULL);
 	fu_progress_add_step(progress, FWUPD_STATUS_DEVICE_BUSY, 1, NULL);
@@ -1164,23 +1023,6 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 	g_debug("flash ID total: 0x%x", component_id_total);
 	fu_progress_step_done(progress);
 
-	/* verify existing CRC */
-	if (!fu_lenovo_dock_device_ensure_usage(self, &usage_info_valid, error)) {
-		g_prefix_error_literal(error, "failed to validate usage info: ");
-		return FALSE;
-	}
-	if (!usage_info_valid) {
-		if ((flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
-			g_set_error_literal(error,
-					    FWUPD_ERROR,
-					    FWUPD_ERROR_INVALID_DATA,
-					    "device usage info CRC was not valid");
-			return FALSE;
-		}
-		g_warning("usage info CRC was not valid, but continuing");
-	}
-	fu_progress_step_done(progress);
-
 	/* set dock FW Update Ctrl */
 	if (!fu_lenovo_dock_device_dfu_control(self,
 					       FU_LENOVO_DOCK_FW_CTRL_UPGRADE_STATUS_NON_LOCK,
@@ -1192,28 +1034,26 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 	fu_progress_step_done(progress);
 
 	/* clear all the target versions and write the new usage table with new sizes  */
-	total_number = fu_struct_lenovo_dock_usage_get_total_number(self->st_usage);
-	fu_struct_lenovo_dock_usage_set_composite_version(self->st_usage,
-							  fu_firmware_get_version_raw(firmware));
+	total_number = fu_struct_lenovo_dock_usage_get_total_number(st_usage);
 	for (guint component_id = 1; component_id < total_number; component_id++) {
 		FuStructLenovoDockUsageItem *st_usage_item;
 		g_autoptr(FuFirmware) img = NULL;
 
-		st_usage_item = fu_lenovo_dock_device_get_usage_item(self, component_id, error);
+		st_usage_item =
+		    fu_lenovo_dock_firmware_get_usage_item(FU_LENOVO_DOCK_FIRMWARE(firmware),
+							   component_id,
+							   error);
 		if (st_usage_item == NULL)
 			return FALSE;
 		img = fu_firmware_get_image_by_idx(firmware, component_id, NULL);
 		if (img == NULL)
 			continue;
 		fu_struct_lenovo_dock_usage_item_set_target_version(st_usage_item, 0);
-		fu_struct_lenovo_dock_usage_item_set_target_size(
-		    st_usage_item,
-		    fu_firmware_get_size(img) - FU_LENOVO_DOCK_FIRMWARE_SIGNATURE_SIZE);
-		fu_struct_lenovo_dock_usage_item_set_target_crc32(
-		    st_usage_item,
-		    fu_lenovo_dock_image_get_crc(FU_LENOVO_DOCK_IMAGE(img)));
 	}
-	if (!fu_lenovo_dock_device_write_usage(self, fu_progress_get_child(progress), error)) {
+	if (!fu_lenovo_dock_device_write_usage(self,
+					       FU_LENOVO_DOCK_FIRMWARE(firmware),
+					       fu_progress_get_child(progress),
+					       error)) {
 		g_prefix_error_literal(error, "failed to write usage table: ");
 		return FALSE;
 	}
@@ -1221,7 +1061,7 @@ fu_lenovo_dock_device_write_firmware(FuDevice *device,
 
 	/* write each flash ID */
 	if (!fu_lenovo_dock_device_write_images(self,
-						firmware,
+						FU_LENOVO_DOCK_FIRMWARE(firmware),
 						fu_progress_get_child(progress),
 						flags,
 						error))
@@ -1281,13 +1121,12 @@ fu_lenovo_dock_device_set_progress(FuDevice *device, FuProgress *progress)
 static void
 fu_lenovo_dock_device_init(FuLenovoDockDevice *self)
 {
-	self->st_usage_items =
-	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_struct_lenovo_dock_usage_item_unref);
 	fu_device_set_remove_delay(FU_DEVICE(self), 300000);
 	fu_device_add_protocol(FU_DEVICE(self), "com.lenovo.dock");
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_UNSIGNED_PAYLOAD);
 	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_DUAL_IMAGE);
+	fu_device_add_flag(FU_DEVICE(self), FWUPD_DEVICE_FLAG_SIGNED_PAYLOAD);
 	fu_device_add_icon(FU_DEVICE(self), FU_DEVICE_ICON_DOCK_USB);
 	fu_device_set_install_duration(FU_DEVICE(self), 330);
 	fu_device_register_private_flag(FU_DEVICE(self), FU_LENOVO_DOCK_DEVICE_FLAG_CAN_PROVISION);
@@ -1300,21 +1139,9 @@ fu_lenovo_dock_device_init(FuLenovoDockDevice *self)
 }
 
 static void
-fu_lenovo_dock_device_finalize(GObject *object)
-{
-	FuLenovoDockDevice *self = FU_LENOVO_DOCK_DEVICE(object);
-	if (self->st_usage != NULL)
-		fu_struct_lenovo_dock_usage_unref(self->st_usage);
-	g_ptr_array_unref(self->st_usage_items);
-	G_OBJECT_CLASS(fu_lenovo_dock_device_parent_class)->finalize(object);
-}
-
-static void
 fu_lenovo_dock_device_class_init(FuLenovoDockDeviceClass *klass)
 {
-	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuDeviceClass *device_class = FU_DEVICE_CLASS(klass);
-	object_class->finalize = fu_lenovo_dock_device_finalize;
 	device_class->to_string = fu_lenovo_dock_device_to_string;
 	device_class->setup = fu_lenovo_dock_device_setup;
 	device_class->check_firmware = fu_lenovo_dock_device_check_firmware;

--- a/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
+++ b/plugins/lenovo-dock/fu-lenovo-dock-firmware.c
@@ -15,15 +15,66 @@
 struct _FuLenovoDockFirmware {
 	FuFirmware parent_instance;
 	guint16 pid;
+	FuStructLenovoDockUsage *st_usage;
+	GPtrArray *st_usage_items;
 };
 
 G_DEFINE_TYPE(FuLenovoDockFirmware, fu_lenovo_dock_firmware, FU_TYPE_FIRMWARE)
+
+static void
+fu_lenovo_dock_firmware_export_usage(FuStructLenovoDockUsage *st, XbBuilderNode *bn)
+{
+	fu_xmlb_builder_insert_kx(bn,
+				  "total_number",
+				  fu_struct_lenovo_dock_usage_get_total_number(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "composite_version",
+				  fu_struct_lenovo_dock_usage_get_composite_version(st));
+	fu_xmlb_builder_insert_kx(bn, "pid", fu_struct_lenovo_dock_usage_get_pid(st));
+}
+
+static void
+fu_lenovo_dock_firmware_export_usage_item(FuStructLenovoDockUsageItem *st, XbBuilderNode *bn)
+{
+	fu_xmlb_builder_insert_kx(bn, "addr", fu_struct_lenovo_dock_usage_item_get_address(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "max_size",
+				  fu_struct_lenovo_dock_usage_item_get_max_size(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_version",
+				  fu_struct_lenovo_dock_usage_item_get_target_version(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_size",
+				  fu_struct_lenovo_dock_usage_item_get_target_size(st));
+	fu_xmlb_builder_insert_kx(bn,
+				  "target_crc32",
+				  fu_struct_lenovo_dock_usage_item_get_target_crc32(st));
+}
+
+static void
+fu_lenovo_dock_firmware_export_usage_items(GPtrArray *st_usage_items, XbBuilderNode *bn)
+{
+	for (guint i = 0; i < st_usage_items->len; i++) {
+		FuStructLenovoDockUsageItem *st_usage_item = g_ptr_array_index(st_usage_items, i);
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "item", NULL);
+		fu_lenovo_dock_firmware_export_usage_item(st_usage_item, bc);
+	}
+}
 
 static void
 fu_lenovo_dock_firmware_export(FuFirmware *firmware, FuFirmwareExportFlags flags, XbBuilderNode *bn)
 {
 	FuLenovoDockFirmware *self = FU_LENOVO_DOCK_FIRMWARE(firmware);
 	fu_xmlb_builder_insert_kx(bn, "pid", self->pid);
+
+	if (self->st_usage != NULL) {
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "usage", NULL);
+		fu_lenovo_dock_firmware_export_usage(self->st_usage, bc);
+	}
+	if (self->st_usage_items->len > 0) {
+		g_autoptr(XbBuilderNode) bc = xb_builder_node_insert(bn, "items", NULL);
+		fu_lenovo_dock_firmware_export_usage_items(self->st_usage_items, bc);
+	}
 }
 
 static gboolean
@@ -61,8 +112,6 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 		return FALSE;
 	}
 	target_size = fu_struct_lenovo_dock_usage_item_get_target_size(st_item);
-	if (target_size == 0)
-		return TRUE;
 	if (target_size > max_size) {
 		g_set_error(error,
 			    FWUPD_ERROR,
@@ -71,6 +120,13 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 			    target_size,
 			    max_size);
 		return FALSE;
+	}
+
+	/* preserve zero-sized items so the total_number is valid */
+	if (target_size == 0) {
+		g_ptr_array_add(self->st_usage_items,
+				fu_struct_lenovo_dock_usage_item_ref(st_item));
+		return TRUE;
 	}
 
 	fu_firmware_set_idx(img, component_id);
@@ -122,6 +178,7 @@ fu_lenovo_dock_firmware_parse_image(FuLenovoDockFirmware *self,
 		}
 	}
 	fu_lenovo_dock_image_set_crc(FU_LENOVO_DOCK_IMAGE(img), target_crc32);
+	g_ptr_array_add(self->st_usage_items, fu_struct_lenovo_dock_usage_item_ref(st_item));
 
 	/* success */
 	return TRUE;
@@ -175,6 +232,7 @@ fu_lenovo_dock_firmware_parse(FuFirmware *firmware,
 		if (!fu_size_checked_inc(&offset, FU_STRUCT_LENOVO_DOCK_USAGE_ITEM_SIZE, error))
 			return FALSE;
 	}
+	self->st_usage = fu_struct_lenovo_dock_usage_ref(st);
 
 	/* success */
 	return TRUE;
@@ -185,6 +243,43 @@ fu_lenovo_dock_firmware_get_pid(FuLenovoDockFirmware *self)
 {
 	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), G_MAXUINT16);
 	return self->pid;
+}
+
+FuStructLenovoDockUsage *
+fu_lenovo_dock_firmware_get_usage(FuLenovoDockFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), NULL);
+	return self->st_usage;
+}
+
+GPtrArray *
+fu_lenovo_dock_firmware_get_usage_items(FuLenovoDockFirmware *self)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), NULL);
+	return self->st_usage_items;
+}
+
+FuStructLenovoDockUsageItem *
+fu_lenovo_dock_firmware_get_usage_item(FuLenovoDockFirmware *self,
+				       FuLenovoDockComponentId component_id,
+				       GError **error)
+{
+	g_return_val_if_fail(FU_IS_LENOVO_DOCK_FIRMWARE(self), NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	for (guint i = 0; i < self->st_usage_items->len; i++) {
+		FuStructLenovoDockUsageItem *st_usage_item =
+		    g_ptr_array_index(self->st_usage_items, i);
+		if (fu_struct_lenovo_dock_usage_item_get_component_id(st_usage_item) ==
+		    component_id)
+			return st_usage_item;
+	}
+	g_set_error(error,
+		    FWUPD_ERROR,
+		    FWUPD_ERROR_NOT_FOUND,
+		    "cannot find component ID 0x%x",
+		    component_id);
+	return NULL;
 }
 
 static gchar *
@@ -199,6 +294,8 @@ fu_lenovo_dock_firmware_convert_version(FuFirmware *firmware, guint64 version_ra
 static void
 fu_lenovo_dock_firmware_init(FuLenovoDockFirmware *self)
 {
+	self->st_usage_items =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)fu_struct_lenovo_dock_usage_item_unref);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_CHECKSUM);
 	fu_firmware_add_flag(FU_FIRMWARE(self), FU_FIRMWARE_FLAG_HAS_VID_PID);
 	fu_firmware_set_version_format(FU_FIRMWARE(self), FWUPD_VERSION_FORMAT_TRIPLET);
@@ -208,9 +305,22 @@ fu_lenovo_dock_firmware_init(FuLenovoDockFirmware *self)
 }
 
 static void
+fu_lenovo_dock_firmware_finalize(GObject *object)
+{
+	FuLenovoDockFirmware *self = FU_LENOVO_DOCK_FIRMWARE(object);
+	if (self->st_usage != NULL)
+		fu_struct_lenovo_dock_usage_unref(self->st_usage);
+	if (self->st_usage_items != NULL)
+		g_ptr_array_unref(self->st_usage_items);
+	G_OBJECT_CLASS(fu_lenovo_dock_firmware_parent_class)->finalize(object);
+}
+
+static void
 fu_lenovo_dock_firmware_class_init(FuLenovoDockFirmwareClass *klass)
 {
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
 	FuFirmwareClass *firmware_class = FU_FIRMWARE_CLASS(klass);
+	object_class->finalize = fu_lenovo_dock_firmware_finalize;
 	firmware_class->parse = fu_lenovo_dock_firmware_parse;
 	firmware_class->export = fu_lenovo_dock_firmware_export;
 	firmware_class->convert_version = fu_lenovo_dock_firmware_convert_version;

--- a/plugins/lenovo-dock/fu-lenovo-dock-firmware.h
+++ b/plugins/lenovo-dock/fu-lenovo-dock-firmware.h
@@ -8,6 +8,8 @@
 
 #include <fwupdplugin.h>
 
+#include "fu-lenovo-dock-struct.h"
+
 #define FU_TYPE_LENOVO_DOCK_FIRMWARE (fu_lenovo_dock_firmware_get_type())
 G_DECLARE_FINAL_TYPE(FuLenovoDockFirmware,
 		     fu_lenovo_dock_firmware,
@@ -19,3 +21,12 @@ G_DECLARE_FINAL_TYPE(FuLenovoDockFirmware,
 
 guint16
 fu_lenovo_dock_firmware_get_pid(FuLenovoDockFirmware *self);
+
+FuStructLenovoDockUsage *
+fu_lenovo_dock_firmware_get_usage(FuLenovoDockFirmware *self);
+GPtrArray *
+fu_lenovo_dock_firmware_get_usage_items(FuLenovoDockFirmware *self);
+FuStructLenovoDockUsageItem *
+fu_lenovo_dock_firmware_get_usage_item(FuLenovoDockFirmware *self,
+				       FuLenovoDockComponentId component_id,
+				       GError **error);

--- a/plugins/lenovo-dock/fu-lenovo-dock.rs
+++ b/plugins/lenovo-dock/fu-lenovo-dock.rs
@@ -30,7 +30,7 @@ enum FuLenovoDockIotFlag {
     Managed = 0x01,
 }
 
-#[derive(Parse, ParseStream, Default, ToString, Setters)]
+#[derive(Parse, ParseStream, Default)]
 #[repr(C, packed)]
 struct FuStructLenovoDockUsage {
     total_number: u8,
@@ -51,7 +51,7 @@ enum FuLenovoDockUsageItemFlag {
     DoUpdate,
 }
 
-#[derive(Parse, ParseStream, Default, ToString, Setters)]
+#[derive(ParseStream, Default, Setters)]
 #[repr(C, packed)]
 struct FuStructLenovoDockUsageItem {
     address: u32le,


### PR DESCRIPTION
Alway use the firmware as the 'source of truth' for each update.

Based on a patch by Felix <Felix_F_Chen@wistron.com>, many thanks.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
