### PR TITLE
egis-moc: add support for PID 9201

### DIFF
--- a/plugins/egis-moc/README.md
+++ b/plugins/egis-moc/README.md
@@ -20,6 +20,7 @@ This plugin supports the following protocol ID:
 These devices use the standard USB DeviceInstanceId values, e.g.
 
 * `USB\VID_1C7A&PID_05AE`
+* `USB\VID_1C7A&PID_9201`
 
 ## Update Behavior
 

--- a/plugins/egis-moc/egis-moc.quirk
+++ b/plugins/egis-moc/egis-moc.quirk
@@ -2,3 +2,7 @@
 [USB\VID_1C7A&PID_05AE]
 Plugin = egis_moc
 Flags = enforce-requires
+
+[USB\VID_1C7A&PID_9201]
+Plugin = egis_moc
+Flags = enforce-requires


### PR DESCRIPTION
Add USB VID 1C7A PID 9201 to the egis-moc plugin quirks and documentation.

Type of pull request:

- [x] Feature
- [x] Documentation
