### PR TITLE
trivial: Split up the glib-backports into minor-version headers

### DIFF
--- a/libfwupd/fwupd-build-glib-2-70.h
+++ b/libfwupd/fwupd-build-glib-2-70.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#define g_prefix_error_literal	  g_prefix_error
+#define g_spawn_check_wait_status g_spawn_check_exit_status
+#define g_source_set_static_name(n1, n2)
+
+static inline int
+g_steal_fd(int *fd_ptr)
+{
+	int fd = *fd_ptr;
+	*fd_ptr = -1;
+	return fd;
+}

--- a/libfwupd/fwupd-build-glib-2-72.h
+++ b/libfwupd/fwupd-build-glib-2-72.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#define g_log_get_debug_enabled() (g_getenv("FWUPD_VERBOSE") != NULL)

--- a/libfwupd/fwupd-build-glib-2-76.h
+++ b/libfwupd/fwupd-build-glib-2-76.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+static inline gboolean
+g_clear_fd(int *fd_ptr, GError **error)
+{
+	int fd = *fd_ptr;
+	*fd_ptr = -1;
+	if (fd < 0)
+		return TRUE;
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	return g_close(fd, error);
+	G_GNUC_END_IGNORE_DEPRECATIONS
+}
+
+static inline void
+_g_clear_fd_ignore_error(int *fd_ptr)
+{
+	int errsv = errno;
+	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+	if (!g_clear_fd(fd_ptr, NULL)) {
+		/* do nothing: we ignore all errors, except for EBADF which
+		 * is a programming error, checked for by g_close(). */
+	}
+	G_GNUC_END_IGNORE_DEPRECATIONS
+	errno = errsv;
+}
+
+#define g_autofd _GLIB_CLEANUP(_g_clear_fd_ignore_error)

--- a/libfwupd/fwupd-build-glib-2-80.h
+++ b/libfwupd/fwupd-build-glib-2-80.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#define g_task_return_new_error_literal g_task_return_new_error

--- a/libfwupd/fwupd-build.h
+++ b/libfwupd/fwupd-build.h
@@ -18,70 +18,23 @@
 #endif
 #endif
 
-#if !GLIB_CHECK_VERSION(2, 70, 0)
-#define g_prefix_error_literal	  g_prefix_error
-#define g_spawn_check_wait_status g_spawn_check_exit_status
-#define g_source_set_static_name(n1, n2)
-static inline int
-g_steal_fd(int *fd_ptr)
-{
-	int fd = *fd_ptr;
-	*fd_ptr = -1;
-	return fd;
-}
-#endif
-#if !GLIB_CHECK_VERSION(2, 72, 0)
-#define g_log_get_debug_enabled() (g_getenv("FWUPD_VERBOSE") != NULL)
-#endif
-
-#if !GLIB_CHECK_VERSION(2, 76, 0)
-static inline gboolean
-g_clear_fd(int *fd_ptr, GError **error)
-{
-	int fd = *fd_ptr;
-
-	*fd_ptr = -1;
-
-	if (fd < 0)
-		return TRUE;
-
-	/* suppress "Not available before" warning */
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-	return g_close(fd, error);
-	G_GNUC_END_IGNORE_DEPRECATIONS
-}
-
-/* Not public API */
-static inline void
-_g_clear_fd_ignore_error(int *fd_ptr)
-{
-	/* Don't overwrite thread-local errno if closing the fd fails */
-	int errsv = errno;
-
-	/* suppress "Not available before" warning */
-	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-
-	if (!g_clear_fd(fd_ptr, NULL)) {
-		/* Do nothing: we ignore all errors, except for EBADF which
-		 * is a programming error, checked for by g_close(). */
-	}
-
-	G_GNUC_END_IGNORE_DEPRECATIONS
-
-	errno = errsv;
-}
-
-#define g_autofd _GLIB_CLEANUP(_g_clear_fd_ignore_error)
-#endif
-
-#if !GLIB_CHECK_VERSION(2, 80, 0)
-#define g_task_return_new_error_literal g_task_return_new_error
-#endif
-
 #ifndef G_GNUC_FLAG_ENUM
 #if g_macro__has_attribute(flag_enum)
 #define G_GNUC_FLAG_ENUM __attribute__((flag_enum))
 #else
 #define G_GNUC_FLAG_ENUM
 #endif
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 70, 0)
+#include "fwupd-build-glib-2-70.h"
+#endif
+#if !GLIB_CHECK_VERSION(2, 72, 0)
+#include "fwupd-build-glib-2-72.h"
+#endif
+#if !GLIB_CHECK_VERSION(2, 76, 0)
+#include "fwupd-build-glib-2-76.h"
+#endif
+#if !GLIB_CHECK_VERSION(2, 80, 0)
+#include "fwupd-build-glib-2-80.h"
 #endif

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -70,6 +70,10 @@ install_headers(
 install_headers(
   [
     'fwupd-build.h',
+    'fwupd-build-glib-2-70.h',
+    'fwupd-build-glib-2-72.h',
+    'fwupd-build-glib-2-76.h',
+    'fwupd-build-glib-2-80.h',
     'fwupd-client.h',
     'fwupd-client-sync.h',
     'fwupd-common.h',


### PR DESCRIPTION
This is a bin unmaintainable now, and I'm about to add a few more...

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
