### PR TITLE
trivial: Use __has_attribute() to allow building with old Glib versions

### DIFF
--- a/contrib/ci/check-source.py
+++ b/contrib/ci/check-source.py
@@ -104,6 +104,9 @@ class Checker:
         return False
 
     def _test_function_names_prefix_private(self, func_name: str, token: Token) -> None:
+
+        if func_name.startswith("__"):
+            return
         valid_prefixes = ["_fwupd_", "_fu_", "_g_", "_xb_"]
         for prefix in valid_prefixes:
             if func_name.startswith(prefix):

--- a/libfwupd/fwupd-build.h
+++ b/libfwupd/fwupd-build.h
@@ -19,7 +19,7 @@
 #endif
 
 #ifndef G_GNUC_FLAG_ENUM
-#if g_macro__has_attribute(flag_enum)
+#if __has_attribute(flag_enum)
 #define G_GNUC_FLAG_ENUM __attribute__((flag_enum))
 #else
 #define G_GNUC_FLAG_ENUM


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
