### PR TITLE
hp-bioscfg: Do not link in the unused uefi capsule plugin

### DIFF
--- a/plugins/hp-bioscfg/meson.build
+++ b/plugins/hp-bioscfg/meson.build
@@ -31,7 +31,6 @@ if get_option('tests')
       fwupd,
       fwupdplugin,
       plugin_builtin_hp_bioscfg,
-      plugin_builtin_uefi_capsule,
     ],
     c_args: [
       cargs,


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
