### PR TITLE
meson: enable efi_app_location to be overrideable at build-time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -645,7 +645,10 @@ endif
 
 # EFI
 if build_standalone
-  efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
+  efi_app_location = get_option('efi_app_location')
+  if efi_app_location == 'auto'
+    efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
+  endif
   conf.set_quoted('EFI_APP_LOCATION', efi_app_location)
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -646,7 +646,7 @@ endif
 # EFI
 if build_standalone
   efi_app_location = get_option('efi_app_location')
-  if efi_app_location == 'auto'
+  if efi_app_location == ''
     efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
   endif
   conf.set_quoted('EFI_APP_LOCATION', efi_app_location)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,6 +32,11 @@ option(
   type: 'feature',
   description: 'Build developer documentation',
 )
+option('efi_app_location',
+  type: 'string',
+  value: 'auto',
+  description: 'EFI app location ("auto" uses $libexecdir/fwupd/efi)',
+)
 option(
   'efi_binary',
   type: 'boolean',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,8 +34,8 @@ option(
 )
 option('efi_app_location',
   type: 'string',
-  value: 'auto',
-  description: 'EFI app location ("auto" uses $libexecdir/fwupd/efi)',
+  value: '',
+  description: 'EFI app location (empty uses $libexecdir/fwupd/efi)',
 )
 option(
   'efi_binary',


### PR DESCRIPTION
Certain distributions like NixOS puts the EFI app template in a RO location. This makes it very hard for signers to come and sign it in the same location (because it's RO).

Some of the usual signers (Limine & Lanzaboote, 2 Secure Boot enablement solutions in the NixOS space) copied the EFI app template from the RO location in /run/fwupd-efi and signed over there.

Since FWUPD_EFIAPPDIR has been removed, this trick cannot be accomplished anymore. NixOS is now moving everything along to /run/fwupd-efi, but to do that nicely, it needs to override `efi_app_location`. Overriding `libexecdir` to `/run` is wrong and lead to build failures.

An alternative could be to split an `efi_app_location_template` (which can be RO) and an `efi_app_location_rw` which *MUST BE* RW to allow for signers to do the right things. This change is instead a minimally invasive solution that allows for distributions like NixOS to perform the change without patching fwupd's meson.build file.

See #10202 for more information.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
