### PR TITLE
Fix a bug in goodix-tp

### DIFF
--- a/plugins/goodix-tp/fu-goodixtp-hid-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-hid-device.c
@@ -85,7 +85,7 @@ fu_goodixtp_hid_device_get_report(FuGoodixtpHidDevice *self,
 	rcv_buf[0] = REPORT_ID;
 	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),
 					  rcv_buf,
-					  sizeof(rcv_buf),
+					  PACKAGE_LEN,
 					  FU_IOCTL_FLAG_NONE,
 					  error)) {
 		g_prefix_error_literal(error, "failed get report: ");


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This bug will cause ioctl error when device probing on some machines. Like follow:
<img width="2728" height="226" alt="Screenshot from 2026-06-01 17-03-27" src="https://github.com/user-attachments/assets/689f0028-7bf3-4bf9-a791-438987f4145c" />
