### PR TITLE
Fix HID feature read buffer size in goodix-tp device probe

### DIFF
--- a/plugins/goodix-tp/fu-goodixtp-hid-device.c
+++ b/plugins/goodix-tp/fu-goodixtp-hid-device.c
@@ -80,7 +80,7 @@ fu_goodixtp_hid_device_get_report(FuGoodixtpHidDevice *self,
 				  gsize bufsz,
 				  GError **error)
 {
-	guint8 rcv_buf[PACKAGE_LEN + 1] = {0};
+	guint8 rcv_buf[PACKAGE_LEN] = {0};
 
 	rcv_buf[0] = REPORT_ID;
 	if (!fu_hidraw_device_get_feature(FU_HIDRAW_DEVICE(self),


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This bug will cause ioctl error when device probing on some machines, like follow:
<img width="2728" height="226" alt="Screenshot from 2026-06-01 17-03-27" src="https://github.com/user-attachments/assets/ab35ce48-ec72-4165-8c83-4859594ad9af" />

