### PR TITLE
coreboot-cfr: expose runtime CFR settings

### DIFF
--- a/plugins/coreboot-cfr/README.md
+++ b/plugins/coreboot-cfr/README.md
@@ -1,0 +1,3 @@
+# Coreboot CFR
+
+This plugin exposes coreboot CFR settings that publish runtime apply metadata.

--- a/plugins/coreboot-cfr/README.md
+++ b/plugins/coreboot-cfr/README.md
@@ -1,3 +1,21 @@
 # Coreboot CFR
 
+## Introduction
+
 This plugin exposes coreboot CFR settings that publish runtime apply metadata.
+The coreboot CFR documentation is available at <https://doc.coreboot.org/drivers/cfr.html>.
+
+The plugin reads the `CorebootCfrSettings` EFI variable and registers settings that include
+runtime apply metadata. Settings without a runtime apply hook are ignored.
+
+## Update Behavior
+
+When a supported setting is changed, the plugin writes the matching CFR EFI variable and then
+triggers the firmware runtime apply hook. The current implementation supports the `APM_CNT` apply
+method used by the StarFighter keyboard-backlight timeout setting.
+
+## External Interface Access
+
+This plugin reads and writes EFI variables using the coreboot CFR GUID. For `APM_CNT` settings it
+also opens `/dev/port` and writes the firmware-provided runtime apply ID to the APM status and
+control ports to trigger the SMI handler.

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.c
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.c
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026 Star Labs
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include "fu-coreboot-cfr-plugin.h"
+#include "fu-coreboot-cfr-setting.h"
+
+#define COREBOOT_CFR_GUID	       "ceae4c1d-335b-4685-a4a0-fc4a94eea085"
+#define COREBOOT_CFR_SETTINGS_VARIABLE "CorebootCfrSettings"
+#define COREBOOT_CFR_SETTINGS_MAGIC    0x44574643 /* CFWD */
+#define COREBOOT_CFR_SETTINGS_VERSION	  2
+#define COREBOOT_CFR_FLAG_READONLY     (1u << 0)
+#define COREBOOT_CFR_TYPE_ENUM	       1
+#define COREBOOT_CFR_TYPE_NUMBER       2
+#define COREBOOT_CFR_TYPE_BOOL	       3
+#define COREBOOT_CFR_APPLY_METHOD_NONE	  0
+#define COREBOOT_CFR_APPLY_METHOD_APM_CNT 1
+#define COREBOOT_CFR_SETTINGS_HDR_SZ   16
+#define COREBOOT_CFR_OPTION_RECORD_SZ	  60
+#define COREBOOT_CFR_ENUM_RECORD_SZ    8
+
+typedef struct {
+	guint32 magic;
+	guint16 version;
+	guint16 header_size;
+	guint32 size;
+	guint32 record_count;
+} FuCorebootCfrSettingsHeader;
+
+typedef struct {
+	guint16 type;
+	guint16 header_size;
+	guint32 cfr_flags;
+	guint64 object_id;
+	guint32 runtime_apply_method;
+	guint32 runtime_apply_id;
+	guint32 default_value;
+	guint32 min;
+	guint32 max;
+	guint32 step;
+	guint32 display_flags;
+	guint32 name_size;
+	guint32 ui_name_size;
+	guint32 help_text_size;
+	guint32 enum_count;
+} FuCorebootCfrOptionRecord;
+
+typedef struct {
+	guint32 value;
+	guint32 ui_name_size;
+} FuCorebootCfrEnumRecord;
+
+struct _FuCorebootCfrPlugin {
+	FuPlugin parent_instance;
+};
+
+G_DEFINE_TYPE(FuCorebootCfrPlugin, fu_coreboot_cfr_plugin, FU_TYPE_PLUGIN)
+
+static gboolean
+fu_coreboot_cfr_plugin_read_uint16(const guint8 *buf,
+				   gsize bufsz,
+				   gsize *offset,
+				   guint16 *value,
+				   GError **error)
+{
+	if (!fu_memread_uint16_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
+		return FALSE;
+	*offset += sizeof(guint16);
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_read_uint32(const guint8 *buf,
+				   gsize bufsz,
+				   gsize *offset,
+				   guint32 *value,
+				   GError **error)
+{
+	if (!fu_memread_uint32_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
+		return FALSE;
+	*offset += sizeof(guint32);
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_read_uint64(const guint8 *buf,
+				   gsize bufsz,
+				   gsize *offset,
+				   guint64 *value,
+				   GError **error)
+{
+	if (!fu_memread_uint64_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
+		return FALSE;
+	*offset += sizeof(guint64);
+	return TRUE;
+}
+
+static gchar *
+fu_coreboot_cfr_plugin_read_string(const guint8 *buf,
+				   gsize bufsz,
+				   gsize *offset,
+				   guint32 sz,
+				   GError **error)
+{
+	gchar *str = NULL;
+
+	if (sz == 0)
+		return g_strdup("");
+
+	if (*offset > bufsz || sz > bufsz - *offset) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CFR settings metadata is truncated");
+		return NULL;
+	}
+
+	if (buf[*offset + sz - 1] == '\0') {
+		str = g_strndup((const gchar *)buf + *offset, sz - 1);
+		*offset += sz;
+		return str;
+	}
+
+	str = g_strndup((const gchar *)buf + *offset, sz);
+	*offset += sz;
+	return str;
+}
+
+static FwupdBiosSettingKind
+fu_coreboot_cfr_plugin_setting_kind(guint16 type)
+{
+	if (type == COREBOOT_CFR_TYPE_NUMBER)
+		return FWUPD_BIOS_SETTING_KIND_INTEGER;
+	return FWUPD_BIOS_SETTING_KIND_ENUMERATION;
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_add_bool_values(GPtrArray *possible_values,
+				       GHashTable *value_map,
+				       GHashTable *reverse_value_map)
+{
+	g_ptr_array_add(possible_values, g_strdup("Disabled"));
+	g_ptr_array_add(possible_values, g_strdup("Enabled"));
+	g_hash_table_insert(value_map, g_strdup("Disabled"), g_strdup("0"));
+	g_hash_table_insert(value_map, g_strdup("Enabled"), g_strdup("1"));
+	g_hash_table_insert(reverse_value_map, g_strdup("0"), g_strdup("Disabled"));
+	g_hash_table_insert(reverse_value_map, g_strdup("1"), g_strdup("Enabled"));
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_read_header(const guint8 *buf,
+				   gsize bufsz,
+				   gsize *offset,
+				   FuCorebootCfrSettingsHeader *hdr,
+				   GError **error)
+{
+	return fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->magic, error) &&
+	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &hdr->version, error) &&
+	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &hdr->header_size, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->size, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->record_count, error);
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_read_option_record(const guint8 *buf,
+					  gsize bufsz,
+					  gsize *offset,
+					  FuCorebootCfrOptionRecord *rec,
+					  GError **error)
+{
+	return fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &rec->type, error) &&
+	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &rec->header_size, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->cfr_flags, error) &&
+	       fu_coreboot_cfr_plugin_read_uint64(buf, bufsz, offset, &rec->object_id, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf,
+						  bufsz,
+						  offset,
+						  &rec->runtime_apply_method,
+						  error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf,
+						  bufsz,
+						  offset,
+						  &rec->runtime_apply_id,
+						  error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->default_value, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->min, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->max, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->step, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->display_flags, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->name_size, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->ui_name_size, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf,
+						  bufsz,
+						  offset,
+						  &rec->help_text_size,
+						  error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->enum_count, error);
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_read_enum_record(const guint8 *buf,
+					gsize bufsz,
+					gsize *offset,
+					FuCorebootCfrEnumRecord *rec,
+					GError **error)
+{
+	return fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->value, error) &&
+	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->ui_name_size, error);
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_parse_option(FuEfivars *efivars,
+				    FuBiosSettings *bios_settings,
+				    const guint8 *buf,
+				    gsize bufsz,
+				    gsize *offset,
+				    GError **error)
+{
+	FuCorebootCfrOptionRecord rec;
+	FuEfiVariableAttrs attrs = 0;
+	g_autofree gchar *name = NULL;
+	g_autofree gchar *ui_name = NULL;
+	g_autofree gchar *help_text = NULL;
+	g_autoptr(FwupdBiosSetting) setting = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autoptr(GHashTable) reverse_value_map =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	g_autoptr(GHashTable) value_map =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	g_autoptr(GPtrArray) possible_values = g_ptr_array_new_with_free_func(g_free);
+
+	if (!fu_coreboot_cfr_plugin_read_option_record(buf, bufsz, offset, &rec, error))
+		return FALSE;
+
+	if (rec.header_size != COREBOOT_CFR_OPTION_RECORD_SZ) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CFR option record has unsupported size");
+		return FALSE;
+	}
+
+	name = fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.name_size, error);
+	if (name == NULL)
+		return FALSE;
+	ui_name = fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.ui_name_size, error);
+	if (ui_name == NULL)
+		return FALSE;
+	help_text =
+	    fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.help_text_size, error);
+	if (help_text == NULL)
+		return FALSE;
+
+	for (guint32 i = 0; i < rec.enum_count; i++) {
+		FuCorebootCfrEnumRecord enum_rec;
+		g_autofree gchar *enum_label = NULL;
+		g_autofree gchar *value = NULL;
+
+		if (!fu_coreboot_cfr_plugin_read_enum_record(buf, bufsz, offset, &enum_rec, error))
+			return FALSE;
+		enum_label = fu_coreboot_cfr_plugin_read_string(buf,
+								bufsz,
+								offset,
+								enum_rec.ui_name_size,
+								error);
+		if (enum_label == NULL)
+			return FALSE;
+
+		value = g_strdup_printf("%u", enum_rec.value);
+		g_ptr_array_add(possible_values, g_strdup(enum_label));
+		g_hash_table_insert(value_map, g_strdup(enum_label), g_strdup(value));
+		g_hash_table_insert(reverse_value_map,
+				    g_strdup(value),
+				    g_steal_pointer(&enum_label));
+	}
+
+	if (rec.type == COREBOOT_CFR_TYPE_BOOL)
+		fu_coreboot_cfr_plugin_add_bool_values(possible_values,
+						       value_map,
+						       reverse_value_map);
+
+	if (rec.runtime_apply_method == COREBOOT_CFR_APPLY_METHOD_NONE ||
+	    rec.runtime_apply_id == 0) {
+		g_debug("skipping CFR option %s without a runtime apply hook", name);
+		return TRUE;
+	}
+
+	if (rec.runtime_apply_method != COREBOOT_CFR_APPLY_METHOD_APM_CNT) {
+		g_debug("skipping CFR option %s with unsupported runtime apply method 0x%x",
+			name,
+			rec.runtime_apply_method);
+		return TRUE;
+	}
+
+	if (!fu_efivars_get_attrs(efivars, COREBOOT_CFR_GUID, name, &attrs, error)) {
+		g_prefix_error(error, "failed to get attributes for %s: ", name);
+		return FALSE;
+	}
+
+	setting = fu_coreboot_cfr_setting_new(efivars,
+					      name,
+					      ui_name,
+					      help_text,
+					      fu_coreboot_cfr_plugin_setting_kind(rec.type),
+					      attrs,
+					      rec.runtime_apply_method,
+					      rec.runtime_apply_id,
+					      rec.min,
+					      rec.max,
+					      rec.step,
+					      possible_values,
+					      value_map,
+					      reverse_value_map,
+					      error);
+	if (setting == NULL)
+		return FALSE;
+	fwupd_bios_setting_set_read_only(setting, (rec.cfr_flags & COREBOOT_CFR_FLAG_READONLY) > 0);
+
+	if (!fu_bios_settings_register_attr(bios_settings, setting, &error_local)) {
+		g_debug("failed to register CFR option %s: %s", name, error_local->message);
+		return TRUE;
+	}
+
+	g_debug("registered CFR option %s", name);
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError **error)
+{
+	FuContext *ctx = fu_plugin_get_context(plugin);
+	FuEfivars *efivars = fu_context_get_efivars(ctx);
+	FuCorebootCfrSettingsHeader hdr;
+	gsize bufsz = 0;
+	gsize offset = 0;
+	g_autofree guint8 *buf = NULL;
+	g_autoptr(FuBiosSettings) bios_settings = NULL;
+
+	if (!fu_efivars_exists(efivars, COREBOOT_CFR_GUID, COREBOOT_CFR_SETTINGS_VARIABLE)) {
+		g_debug("CFR settings metadata not found");
+		return TRUE;
+	}
+
+	if (!fu_efivars_get_data(efivars,
+				 COREBOOT_CFR_GUID,
+				 COREBOOT_CFR_SETTINGS_VARIABLE,
+				 &buf,
+				 &bufsz,
+				 NULL,
+				 error)) {
+		g_prefix_error_literal(error, "failed to read CFR settings metadata: ");
+		return FALSE;
+	}
+
+	if (!fu_coreboot_cfr_plugin_read_header(buf, bufsz, &offset, &hdr, error))
+		return FALSE;
+
+	if (hdr.magic != COREBOOT_CFR_SETTINGS_MAGIC ||
+	    hdr.version != COREBOOT_CFR_SETTINGS_VERSION ||
+	    hdr.header_size != COREBOOT_CFR_SETTINGS_HDR_SZ || hdr.size != bufsz) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CFR settings metadata has an unsupported header");
+		return FALSE;
+	}
+
+	bios_settings = fu_context_get_bios_settings(ctx);
+	if (bios_settings == NULL)
+		return TRUE;
+
+	for (guint32 i = 0; i < hdr.record_count; i++) {
+		if (!fu_coreboot_cfr_plugin_parse_option(efivars,
+							 bios_settings,
+							 buf,
+							 bufsz,
+							 &offset,
+							 error))
+			return FALSE;
+	}
+
+	if (offset != bufsz) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "CFR settings metadata has trailing data");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void
+fu_coreboot_cfr_plugin_class_init(FuCorebootCfrPluginClass *klass)
+{
+	FuPluginClass *plugin_class = FU_PLUGIN_CLASS(klass);
+	plugin_class->coldplug = fu_coreboot_cfr_plugin_coldplug;
+}
+
+static void
+fu_coreboot_cfr_plugin_init(FuCorebootCfrPlugin *self)
+{
+}

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.c
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.c
@@ -8,96 +8,16 @@
 
 #include "fu-coreboot-cfr-plugin.h"
 #include "fu-coreboot-cfr-setting.h"
+#include "fu-coreboot-cfr-struct.h"
 
 #define COREBOOT_CFR_GUID	       "ceae4c1d-335b-4685-a4a0-fc4a94eea085"
 #define COREBOOT_CFR_SETTINGS_VARIABLE "CorebootCfrSettings"
-#define COREBOOT_CFR_SETTINGS_MAGIC    0x44574643 /* CFWD */
-#define COREBOOT_CFR_SETTINGS_VERSION	  2
-#define COREBOOT_CFR_FLAG_READONLY     (1u << 0)
-#define COREBOOT_CFR_TYPE_ENUM	       1
-#define COREBOOT_CFR_TYPE_NUMBER       2
-#define COREBOOT_CFR_TYPE_BOOL	       3
-#define COREBOOT_CFR_APPLY_METHOD_NONE	  0
-#define COREBOOT_CFR_APPLY_METHOD_APM_CNT 1
-#define COREBOOT_CFR_SETTINGS_HDR_SZ   16
-#define COREBOOT_CFR_OPTION_RECORD_SZ	  60
-#define COREBOOT_CFR_ENUM_RECORD_SZ    8
-
-typedef struct {
-	guint32 magic;
-	guint16 version;
-	guint16 header_size;
-	guint32 size;
-	guint32 record_count;
-} FuCorebootCfrSettingsHeader;
-
-typedef struct {
-	guint16 type;
-	guint16 header_size;
-	guint32 cfr_flags;
-	guint64 object_id;
-	guint32 runtime_apply_method;
-	guint32 runtime_apply_id;
-	guint32 default_value;
-	guint32 min;
-	guint32 max;
-	guint32 step;
-	guint32 display_flags;
-	guint32 name_size;
-	guint32 ui_name_size;
-	guint32 help_text_size;
-	guint32 enum_count;
-} FuCorebootCfrOptionRecord;
-
-typedef struct {
-	guint32 value;
-	guint32 ui_name_size;
-} FuCorebootCfrEnumRecord;
 
 struct _FuCorebootCfrPlugin {
 	FuPlugin parent_instance;
 };
 
 G_DEFINE_TYPE(FuCorebootCfrPlugin, fu_coreboot_cfr_plugin, FU_TYPE_PLUGIN)
-
-static gboolean
-fu_coreboot_cfr_plugin_read_uint16(const guint8 *buf,
-				   gsize bufsz,
-				   gsize *offset,
-				   guint16 *value,
-				   GError **error)
-{
-	if (!fu_memread_uint16_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
-		return FALSE;
-	*offset += sizeof(guint16);
-	return TRUE;
-}
-
-static gboolean
-fu_coreboot_cfr_plugin_read_uint32(const guint8 *buf,
-				   gsize bufsz,
-				   gsize *offset,
-				   guint32 *value,
-				   GError **error)
-{
-	if (!fu_memread_uint32_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
-		return FALSE;
-	*offset += sizeof(guint32);
-	return TRUE;
-}
-
-static gboolean
-fu_coreboot_cfr_plugin_read_uint64(const guint8 *buf,
-				   gsize bufsz,
-				   gsize *offset,
-				   guint64 *value,
-				   GError **error)
-{
-	if (!fu_memread_uint64_safe(buf, bufsz, *offset, value, G_LITTLE_ENDIAN, error))
-		return FALSE;
-	*offset += sizeof(guint64);
-	return TRUE;
-}
 
 static gchar *
 fu_coreboot_cfr_plugin_read_string(const guint8 *buf,
@@ -131,9 +51,9 @@ fu_coreboot_cfr_plugin_read_string(const guint8 *buf,
 }
 
 static FwupdBiosSettingKind
-fu_coreboot_cfr_plugin_setting_kind(guint16 type)
+fu_coreboot_cfr_plugin_setting_kind(FuCorebootCfrType kind)
 {
-	if (type == COREBOOT_CFR_TYPE_NUMBER)
+	if (kind == FU_COREBOOT_CFR_TYPE_NUMBER)
 		return FWUPD_BIOS_SETTING_KIND_INTEGER;
 	return FWUPD_BIOS_SETTING_KIND_ENUMERATION;
 }
@@ -153,76 +73,19 @@ fu_coreboot_cfr_plugin_add_bool_values(GPtrArray *possible_values,
 }
 
 static gboolean
-fu_coreboot_cfr_plugin_read_header(const guint8 *buf,
-				   gsize bufsz,
-				   gsize *offset,
-				   FuCorebootCfrSettingsHeader *hdr,
-				   GError **error)
-{
-	return fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->magic, error) &&
-	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &hdr->version, error) &&
-	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &hdr->header_size, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->size, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &hdr->record_count, error);
-}
-
-static gboolean
-fu_coreboot_cfr_plugin_read_option_record(const guint8 *buf,
-					  gsize bufsz,
-					  gsize *offset,
-					  FuCorebootCfrOptionRecord *rec,
-					  GError **error)
-{
-	return fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &rec->type, error) &&
-	       fu_coreboot_cfr_plugin_read_uint16(buf, bufsz, offset, &rec->header_size, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->cfr_flags, error) &&
-	       fu_coreboot_cfr_plugin_read_uint64(buf, bufsz, offset, &rec->object_id, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf,
-						  bufsz,
-						  offset,
-						  &rec->runtime_apply_method,
-						  error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf,
-						  bufsz,
-						  offset,
-						  &rec->runtime_apply_id,
-						  error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->default_value, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->min, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->max, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->step, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->display_flags, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->name_size, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->ui_name_size, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf,
-						  bufsz,
-						  offset,
-						  &rec->help_text_size,
-						  error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->enum_count, error);
-}
-
-static gboolean
-fu_coreboot_cfr_plugin_read_enum_record(const guint8 *buf,
-					gsize bufsz,
-					gsize *offset,
-					FuCorebootCfrEnumRecord *rec,
-					GError **error)
-{
-	return fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->value, error) &&
-	       fu_coreboot_cfr_plugin_read_uint32(buf, bufsz, offset, &rec->ui_name_size, error);
-}
-
-static gboolean
 fu_coreboot_cfr_plugin_parse_option(FuEfivars *efivars,
 				    FuBiosSettings *bios_settings,
+				    GInputStream *stream,
 				    const guint8 *buf,
 				    gsize bufsz,
 				    gsize *offset,
 				    GError **error)
 {
-	FuCorebootCfrOptionRecord rec;
+	FuCorebootCfrApplyMethod runtime_apply_method = FU_COREBOOT_CFR_APPLY_METHOD_NONE;
+	FuCorebootCfrType kind = FU_COREBOOT_CFR_TYPE_ENUM;
 	FuEfiVariableAttrs attrs = 0;
+	guint32 runtime_apply_id = 0;
+	g_autoptr(FuStructCorebootCfrOptionRecord) st_option = NULL;
 	g_autofree gchar *name = NULL;
 	g_autofree gchar *ui_name = NULL;
 	g_autofree gchar *help_text = NULL;
@@ -234,44 +97,59 @@ fu_coreboot_cfr_plugin_parse_option(FuEfivars *efivars,
 	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 	g_autoptr(GPtrArray) possible_values = g_ptr_array_new_with_free_func(g_free);
 
-	if (!fu_coreboot_cfr_plugin_read_option_record(buf, bufsz, offset, &rec, error))
+	st_option = fu_struct_coreboot_cfr_option_record_parse_stream(stream, *offset, error);
+	if (st_option == NULL)
+		return FALSE;
+	if (!fu_size_checked_inc(offset, FU_STRUCT_COREBOOT_CFR_OPTION_RECORD_SIZE, error))
 		return FALSE;
 
-	if (rec.header_size != COREBOOT_CFR_OPTION_RECORD_SZ) {
-		g_set_error_literal(error,
-				    FWUPD_ERROR,
-				    FWUPD_ERROR_INVALID_DATA,
-				    "CFR option record has unsupported size");
-		return FALSE;
-	}
-
-	name = fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.name_size, error);
+	name = fu_coreboot_cfr_plugin_read_string(
+	    buf,
+	    bufsz,
+	    offset,
+	    fu_struct_coreboot_cfr_option_record_get_name_size(st_option),
+	    error);
 	if (name == NULL)
 		return FALSE;
-	ui_name = fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.ui_name_size, error);
+	ui_name = fu_coreboot_cfr_plugin_read_string(
+	    buf,
+	    bufsz,
+	    offset,
+	    fu_struct_coreboot_cfr_option_record_get_ui_name_size(st_option),
+	    error);
 	if (ui_name == NULL)
 		return FALSE;
-	help_text =
-	    fu_coreboot_cfr_plugin_read_string(buf, bufsz, offset, rec.help_text_size, error);
+	help_text = fu_coreboot_cfr_plugin_read_string(
+	    buf,
+	    bufsz,
+	    offset,
+	    fu_struct_coreboot_cfr_option_record_get_help_text_size(st_option),
+	    error);
 	if (help_text == NULL)
 		return FALSE;
 
-	for (guint32 i = 0; i < rec.enum_count; i++) {
-		FuCorebootCfrEnumRecord enum_rec;
+	for (guint32 i = 0; i < fu_struct_coreboot_cfr_option_record_get_enum_count(st_option);
+	     i++) {
+		g_autoptr(FuStructCorebootCfrEnumRecord) st_enum = NULL;
 		g_autofree gchar *enum_label = NULL;
 		g_autofree gchar *value = NULL;
 
-		if (!fu_coreboot_cfr_plugin_read_enum_record(buf, bufsz, offset, &enum_rec, error))
+		st_enum = fu_struct_coreboot_cfr_enum_record_parse_stream(stream, *offset, error);
+		if (st_enum == NULL)
 			return FALSE;
-		enum_label = fu_coreboot_cfr_plugin_read_string(buf,
-								bufsz,
-								offset,
-								enum_rec.ui_name_size,
-								error);
+		if (!fu_size_checked_inc(offset, FU_STRUCT_COREBOOT_CFR_ENUM_RECORD_SIZE, error))
+			return FALSE;
+		enum_label = fu_coreboot_cfr_plugin_read_string(
+		    buf,
+		    bufsz,
+		    offset,
+		    fu_struct_coreboot_cfr_enum_record_get_ui_name_size(st_enum),
+		    error);
 		if (enum_label == NULL)
 			return FALSE;
 
-		value = g_strdup_printf("%u", enum_rec.value);
+		value =
+		    g_strdup_printf("%u", fu_struct_coreboot_cfr_enum_record_get_value(st_enum));
 		g_ptr_array_add(possible_values, g_strdup(enum_label));
 		g_hash_table_insert(value_map, g_strdup(enum_label), g_strdup(value));
 		g_hash_table_insert(reverse_value_map,
@@ -279,21 +157,24 @@ fu_coreboot_cfr_plugin_parse_option(FuEfivars *efivars,
 				    g_steal_pointer(&enum_label));
 	}
 
-	if (rec.type == COREBOOT_CFR_TYPE_BOOL)
+	kind = fu_struct_coreboot_cfr_option_record_get_kind(st_option);
+	if (kind == FU_COREBOOT_CFR_TYPE_BOOL)
 		fu_coreboot_cfr_plugin_add_bool_values(possible_values,
 						       value_map,
 						       reverse_value_map);
 
-	if (rec.runtime_apply_method == COREBOOT_CFR_APPLY_METHOD_NONE ||
-	    rec.runtime_apply_id == 0) {
+	runtime_apply_method =
+	    fu_struct_coreboot_cfr_option_record_get_runtime_apply_method(st_option);
+	runtime_apply_id = fu_struct_coreboot_cfr_option_record_get_runtime_apply_id(st_option);
+	if (runtime_apply_method == FU_COREBOOT_CFR_APPLY_METHOD_NONE || runtime_apply_id == 0) {
 		g_debug("skipping CFR option %s without a runtime apply hook", name);
 		return TRUE;
 	}
 
-	if (rec.runtime_apply_method != COREBOOT_CFR_APPLY_METHOD_APM_CNT) {
+	if (runtime_apply_method != FU_COREBOOT_CFR_APPLY_METHOD_APM_CNT) {
 		g_debug("skipping CFR option %s with unsupported runtime apply method 0x%x",
 			name,
-			rec.runtime_apply_method);
+			runtime_apply_method);
 		return TRUE;
 	}
 
@@ -302,24 +183,28 @@ fu_coreboot_cfr_plugin_parse_option(FuEfivars *efivars,
 		return FALSE;
 	}
 
-	setting = fu_coreboot_cfr_setting_new(efivars,
-					      name,
-					      ui_name,
-					      help_text,
-					      fu_coreboot_cfr_plugin_setting_kind(rec.type),
-					      attrs,
-					      rec.runtime_apply_method,
-					      rec.runtime_apply_id,
-					      rec.min,
-					      rec.max,
-					      rec.step,
-					      possible_values,
-					      value_map,
-					      reverse_value_map,
-					      error);
+	setting =
+	    fu_coreboot_cfr_setting_new(efivars,
+					name,
+					ui_name,
+					help_text,
+					fu_coreboot_cfr_plugin_setting_kind(kind),
+					attrs,
+					runtime_apply_method,
+					runtime_apply_id,
+					fu_struct_coreboot_cfr_option_record_get_min(st_option),
+					fu_struct_coreboot_cfr_option_record_get_max(st_option),
+					fu_struct_coreboot_cfr_option_record_get_step(st_option),
+					possible_values,
+					value_map,
+					reverse_value_map,
+					error);
 	if (setting == NULL)
 		return FALSE;
-	fwupd_bios_setting_set_read_only(setting, (rec.cfr_flags & COREBOOT_CFR_FLAG_READONLY) > 0);
+	fwupd_bios_setting_set_read_only(
+	    setting,
+	    (fu_struct_coreboot_cfr_option_record_get_cfr_flags(st_option) &
+	     FU_COREBOOT_CFR_FLAG_READONLY) > 0);
 
 	if (!fu_bios_settings_register_attr(bios_settings, setting, &error_local)) {
 		g_debug("failed to register CFR option %s: %s", name, error_local->message);
@@ -335,11 +220,12 @@ fu_coreboot_cfr_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 {
 	FuContext *ctx = fu_plugin_get_context(plugin);
 	FuEfivars *efivars = fu_context_get_efivars(ctx);
-	FuCorebootCfrSettingsHeader hdr;
 	gsize bufsz = 0;
 	gsize offset = 0;
 	g_autofree guint8 *buf = NULL;
 	g_autoptr(FuBiosSettings) bios_settings = NULL;
+	g_autoptr(FuStructCorebootCfrSettingsHeader) st_hdr = NULL;
+	g_autoptr(GInputStream) stream = NULL;
 
 	if (!fu_efivars_exists(efivars, COREBOOT_CFR_GUID, COREBOOT_CFR_SETTINGS_VARIABLE)) {
 		g_debug("CFR settings metadata not found");
@@ -357,16 +243,18 @@ fu_coreboot_cfr_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 		return FALSE;
 	}
 
-	if (!fu_coreboot_cfr_plugin_read_header(buf, bufsz, &offset, &hdr, error))
+	stream = g_memory_input_stream_new_from_data(buf, bufsz, NULL);
+	st_hdr = fu_struct_coreboot_cfr_settings_header_parse_stream(stream, offset, error);
+	if (st_hdr == NULL)
+		return FALSE;
+	if (!fu_size_checked_inc(&offset, FU_STRUCT_COREBOOT_CFR_SETTINGS_HEADER_SIZE, error))
 		return FALSE;
 
-	if (hdr.magic != COREBOOT_CFR_SETTINGS_MAGIC ||
-	    hdr.version != COREBOOT_CFR_SETTINGS_VERSION ||
-	    hdr.header_size != COREBOOT_CFR_SETTINGS_HDR_SZ || hdr.size != bufsz) {
+	if (fu_struct_coreboot_cfr_settings_header_get_size(st_hdr) != bufsz) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_DATA,
-				    "CFR settings metadata has an unsupported header");
+				    "CFR settings metadata has invalid size");
 		return FALSE;
 	}
 
@@ -374,9 +262,11 @@ fu_coreboot_cfr_plugin_coldplug(FuPlugin *plugin, FuProgress *progress, GError *
 	if (bios_settings == NULL)
 		return TRUE;
 
-	for (guint32 i = 0; i < hdr.record_count; i++) {
+	for (guint32 i = 0; i < fu_struct_coreboot_cfr_settings_header_get_record_count(st_hdr);
+	     i++) {
 		if (!fu_coreboot_cfr_plugin_parse_option(efivars,
 							 bios_settings,
+							 stream,
 							 buf,
 							 bufsz,
 							 &offset,

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.h
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-plugin.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 Star Labs
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_COREBOOT_CFR_PLUGIN (fu_coreboot_cfr_plugin_get_type())
+G_DECLARE_FINAL_TYPE(FuCorebootCfrPlugin, fu_coreboot_cfr_plugin, FU, COREBOOT_CFR_PLUGIN, FuPlugin)

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-setting.c
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-setting.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2026 Star Labs
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+
+#include "fu-coreboot-cfr-setting.h"
+
+#define COREBOOT_CFR_GUID	   "ceae4c1d-335b-4685-a4a0-fc4a94eea085"
+#define COREBOOT_CFR_APPLY_DEVICE  "/dev/port"
+#define COREBOOT_CFR_APM_CNT_PORT  0xb2
+#define COREBOOT_CFR_APM_STS_PORT  0xb3
+#define COREBOOT_CFR_APM_APPLY_CMD 0xe3
+#define COREBOOT_CFR_APPLY_METHOD_NONE	  0
+#define COREBOOT_CFR_APPLY_METHOD_APM_CNT 1
+
+struct _FuCorebootCfrSetting {
+	FwupdBiosSetting parent_instance;
+	FuEfivars *efivars;
+	FuEfiVariableAttrs attrs;
+	GHashTable *reverse_value_map;
+	GHashTable *value_map;
+	gchar *name;
+	guint32 runtime_apply_method;
+	guint32 runtime_apply_id;
+};
+
+G_DEFINE_TYPE(FuCorebootCfrSetting, fu_coreboot_cfr_setting, FWUPD_TYPE_BIOS_SETTING)
+
+static gboolean
+fu_coreboot_cfr_setting_read_current(FuCorebootCfrSetting *self, guint32 *value, GError **error);
+
+static gboolean
+fu_coreboot_cfr_setting_value_from_display(FuCorebootCfrSetting *self,
+					   const gchar *value,
+					   guint32 *value_u32,
+					   GError **error)
+{
+	g_autofree gchar *value_raw = NULL;
+	const gchar *mapped = NULL;
+	guint64 tmp = 0;
+
+	mapped = g_hash_table_lookup(self->value_map, value);
+	if (mapped != NULL)
+		value = mapped;
+
+	if (!fu_strtoull(value, &tmp, 0, G_MAXUINT32, FU_INTEGER_BASE_AUTO, error))
+		return FALSE;
+
+	if (mapped == NULL && g_hash_table_size(self->value_map) > 0) {
+		value_raw = g_strdup_printf("%" G_GUINT64_FORMAT, tmp);
+		if (!g_hash_table_contains(self->reverse_value_map, value_raw)) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "%s is not a valid value for %s",
+				    value,
+				    self->name);
+			return FALSE;
+		}
+	}
+
+	*value_u32 = (guint32)tmp;
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_setting_port_write(gint fd, goffset port, guint8 value, GError **error)
+{
+	if (pwrite(fd, &value, sizeof(value), port) != sizeof(value)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_WRITE,
+			    "failed to write I/O port 0x%x: %s",
+			    (guint)port,
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_setting_port_read(gint fd, goffset port, guint8 *value, GError **error)
+{
+	if (pread(fd, value, sizeof(*value), port) != sizeof(*value)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_READ,
+			    "failed to read I/O port 0x%x: %s",
+			    (guint)port,
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_setting_apply_apm_cnt(FuCorebootCfrSetting *self, guint32 value, GError **error)
+{
+	guint8 cmd = COREBOOT_CFR_APM_APPLY_CMD;
+	guint8 runtime_apply_id = (guint8)self->runtime_apply_id;
+	guint8 status = 0;
+	g_autofd gint fd = -1;
+
+	if (self->runtime_apply_id == 0)
+		return TRUE;
+	if (self->runtime_apply_id > G_MAXUINT8) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "%s has invalid runtime apply ID 0x%x",
+			    self->name,
+			    self->runtime_apply_id);
+		return FALSE;
+	}
+
+	fd = open(COREBOOT_CFR_APPLY_DEVICE, O_RDWR | O_CLOEXEC);
+	if (fd < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "failed to open %s: %s",
+			    COREBOOT_CFR_APPLY_DEVICE,
+			    fwupd_strerror(errno));
+		return FALSE;
+	}
+
+	if (!fu_coreboot_cfr_setting_port_write(fd,
+						COREBOOT_CFR_APM_STS_PORT,
+						runtime_apply_id,
+						error) ||
+	    !fu_coreboot_cfr_setting_port_write(fd, COREBOOT_CFR_APM_CNT_PORT, cmd, error) ||
+	    !fu_coreboot_cfr_setting_port_read(fd, COREBOOT_CFR_APM_STS_PORT, &status, error)) {
+		g_prefix_error(error, "failed to apply %s at runtime: ", self->name);
+		return FALSE;
+	}
+
+	if (status != 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "failed to apply %s at runtime: SMI returned 0x%02x",
+			    self->name,
+			    status);
+		return FALSE;
+	}
+
+	g_debug("applied %s=%u at runtime", self->name, value);
+	return TRUE;
+}
+
+static gboolean
+fu_coreboot_cfr_setting_apply(FuCorebootCfrSetting *self, guint32 value, GError **error)
+{
+	switch (self->runtime_apply_method) {
+	case COREBOOT_CFR_APPLY_METHOD_NONE:
+		return TRUE;
+	case COREBOOT_CFR_APPLY_METHOD_APM_CNT:
+		return fu_coreboot_cfr_setting_apply_apm_cnt(self, value, error);
+	default:
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_NOT_SUPPORTED,
+			    "%s has unsupported runtime apply method 0x%x",
+			    self->name,
+			    self->runtime_apply_method);
+		return FALSE;
+	}
+}
+
+static gboolean
+fu_coreboot_cfr_setting_write_value(FwupdBiosSetting *setting, const gchar *value, GError **error)
+{
+	FuCorebootCfrSetting *self = FU_COREBOOT_CFR_SETTING(setting);
+	guint32 old_value = 0;
+	guint8 old_value_buf[sizeof(guint32)] = {0};
+	guint32 value_u32 = 0;
+	guint8 value_buf[sizeof(guint32)] = {0};
+	g_autoptr(GError) error_local = NULL;
+
+	if (!fu_coreboot_cfr_setting_value_from_display(self, value, &value_u32, error))
+		return FALSE;
+
+	if (!fu_coreboot_cfr_setting_read_current(self, &old_value, error))
+		return FALSE;
+
+	if (!fu_memwrite_uint32_safe(value_buf,
+				     sizeof(value_buf),
+				     0x0,
+				     value_u32,
+				     G_LITTLE_ENDIAN,
+				     error))
+		return FALSE;
+
+	if (!fu_efivars_set_data(self->efivars,
+				 COREBOOT_CFR_GUID,
+				 self->name,
+				 value_buf,
+				 sizeof(value_buf),
+				 self->attrs,
+				 error)) {
+		g_prefix_error(error, "failed to write %s: ", self->name);
+		return FALSE;
+	}
+
+	if (!fu_coreboot_cfr_setting_apply(self, value_u32, &error_local)) {
+		if (!fu_memwrite_uint32_safe(old_value_buf,
+					     sizeof(old_value_buf),
+					     0x0,
+					     old_value,
+					     G_LITTLE_ENDIAN,
+					     error))
+			return FALSE;
+
+		if (!fu_efivars_set_data(self->efivars,
+					 COREBOOT_CFR_GUID,
+					 self->name,
+					 old_value_buf,
+					 sizeof(old_value_buf),
+					 self->attrs,
+					 error)) {
+			g_prefix_error(error,
+				       "failed to restore %s after apply failure: %s: ",
+				       self->name,
+				       error_local->message);
+			return FALSE;
+		}
+
+		g_propagate_error(error, g_steal_pointer(&error_local));
+		return FALSE;
+	}
+
+	fwupd_bios_setting_set_current_value(setting, value);
+	g_debug("set %s to %s", fwupd_bios_setting_get_id(setting), value);
+	return TRUE;
+}
+
+static void
+fu_coreboot_cfr_setting_finalize(GObject *obj)
+{
+	FuCorebootCfrSetting *self = FU_COREBOOT_CFR_SETTING(obj);
+
+	g_clear_object(&self->efivars);
+	g_clear_pointer(&self->reverse_value_map, g_hash_table_unref);
+	g_clear_pointer(&self->value_map, g_hash_table_unref);
+	g_free(self->name);
+
+	G_OBJECT_CLASS(fu_coreboot_cfr_setting_parent_class)->finalize(obj);
+}
+
+static void
+fu_coreboot_cfr_setting_class_init(FuCorebootCfrSettingClass *klass)
+{
+	FwupdBiosSettingClass *bios_setting_class = FWUPD_BIOS_SETTING_CLASS(klass);
+	GObjectClass *object_class = G_OBJECT_CLASS(klass);
+
+	bios_setting_class->write_value = fu_coreboot_cfr_setting_write_value;
+	object_class->finalize = fu_coreboot_cfr_setting_finalize;
+}
+
+static void
+fu_coreboot_cfr_setting_init(FuCorebootCfrSetting *self)
+{
+}
+
+static gboolean
+fu_coreboot_cfr_setting_read_current(FuCorebootCfrSetting *self, guint32 *value, GError **error)
+{
+	gsize data_sz = 0;
+	g_autofree guint8 *data = NULL;
+
+	if (!fu_efivars_get_data(self->efivars,
+				 COREBOOT_CFR_GUID,
+				 self->name,
+				 &data,
+				 &data_sz,
+				 NULL,
+				 error))
+		return FALSE;
+
+	if (data_sz != sizeof(guint32)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "%s has invalid size 0x%x",
+			    self->name,
+			    (guint)data_sz);
+		return FALSE;
+	}
+
+	return fu_memread_uint32_safe(data, data_sz, 0x0, value, G_LITTLE_ENDIAN, error);
+}
+
+FwupdBiosSetting *
+fu_coreboot_cfr_setting_new(FuEfivars *efivars,
+			    const gchar *name,
+			    const gchar *ui_name,
+			    const gchar *description,
+			    FwupdBiosSettingKind kind,
+			    FuEfiVariableAttrs attrs,
+			    guint32 runtime_apply_method,
+			    guint32 runtime_apply_id,
+			    guint32 lower_bound,
+			    guint32 upper_bound,
+			    guint32 scalar_increment,
+			    GPtrArray *possible_values,
+			    GHashTable *value_map,
+			    GHashTable *reverse_value_map,
+			    GError **error)
+{
+	FuCorebootCfrSetting *setting = NULL;
+	guint32 current = 0;
+	g_autofree gchar *id = NULL;
+	g_autofree gchar *current_raw = NULL;
+	g_autoptr(FuCorebootCfrSetting) self = NULL;
+
+	self = g_object_new(FU_TYPE_COREBOOT_CFR_SETTING, NULL);
+	setting = FU_COREBOOT_CFR_SETTING(self);
+	setting->efivars = g_object_ref(efivars);
+	setting->attrs = attrs;
+	setting->name = g_strdup(name);
+	setting->runtime_apply_method = runtime_apply_method;
+	setting->runtime_apply_id = runtime_apply_id;
+	setting->value_map = g_hash_table_ref(value_map);
+	setting->reverse_value_map = g_hash_table_ref(reverse_value_map);
+
+	id = g_strdup_printf("org.coreboot.cfr.%s", name);
+	fwupd_bios_setting_set_id(FWUPD_BIOS_SETTING(self), id);
+	fwupd_bios_setting_set_name(FWUPD_BIOS_SETTING(self), name);
+	fwupd_bios_setting_set_description(FWUPD_BIOS_SETTING(self),
+					   description[0] != '\0' ? description : ui_name);
+	fwupd_bios_setting_set_kind(FWUPD_BIOS_SETTING(self), kind);
+
+	if (kind == FWUPD_BIOS_SETTING_KIND_INTEGER) {
+		fwupd_bios_setting_set_lower_bound(FWUPD_BIOS_SETTING(self), lower_bound);
+		fwupd_bios_setting_set_upper_bound(FWUPD_BIOS_SETTING(self), upper_bound);
+		fwupd_bios_setting_set_scalar_increment(FWUPD_BIOS_SETTING(self), scalar_increment);
+	}
+
+	if (kind == FWUPD_BIOS_SETTING_KIND_ENUMERATION) {
+		for (guint i = 0; i < possible_values->len; i++) {
+			const gchar *possible = g_ptr_array_index(possible_values, i);
+			fwupd_bios_setting_add_possible_value(FWUPD_BIOS_SETTING(self), possible);
+		}
+	}
+
+	if (!fu_coreboot_cfr_setting_read_current(setting, &current, error))
+		return NULL;
+
+	current_raw = g_strdup_printf("%u", current);
+	if (kind == FWUPD_BIOS_SETTING_KIND_ENUMERATION) {
+		const gchar *display = g_hash_table_lookup(reverse_value_map, current_raw);
+		fwupd_bios_setting_set_current_value(FWUPD_BIOS_SETTING(self),
+						     display != NULL ? display : current_raw);
+	} else {
+		fwupd_bios_setting_set_current_value(FWUPD_BIOS_SETTING(self), current_raw);
+	}
+
+	return FWUPD_BIOS_SETTING(g_steal_pointer(&self));
+}

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-setting.c
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-setting.c
@@ -12,14 +12,13 @@
 #include <unistd.h>
 
 #include "fu-coreboot-cfr-setting.h"
+#include "fu-coreboot-cfr-struct.h"
 
 #define COREBOOT_CFR_GUID	   "ceae4c1d-335b-4685-a4a0-fc4a94eea085"
 #define COREBOOT_CFR_APPLY_DEVICE  "/dev/port"
 #define COREBOOT_CFR_APM_CNT_PORT  0xb2
 #define COREBOOT_CFR_APM_STS_PORT  0xb3
 #define COREBOOT_CFR_APM_APPLY_CMD 0xe3
-#define COREBOOT_CFR_APPLY_METHOD_NONE	  0
-#define COREBOOT_CFR_APPLY_METHOD_APM_CNT 1
 
 struct _FuCorebootCfrSetting {
 	FwupdBiosSetting parent_instance;
@@ -137,9 +136,15 @@ fu_coreboot_cfr_setting_apply_apm_cnt(FuCorebootCfrSetting *self, guint32 value,
 	if (!fu_coreboot_cfr_setting_port_write(fd,
 						COREBOOT_CFR_APM_STS_PORT,
 						runtime_apply_id,
-						error) ||
-	    !fu_coreboot_cfr_setting_port_write(fd, COREBOOT_CFR_APM_CNT_PORT, cmd, error) ||
-	    !fu_coreboot_cfr_setting_port_read(fd, COREBOOT_CFR_APM_STS_PORT, &status, error)) {
+						error)) {
+		g_prefix_error(error, "failed to apply %s at runtime: ", self->name);
+		return FALSE;
+	}
+	if (!fu_coreboot_cfr_setting_port_write(fd, COREBOOT_CFR_APM_CNT_PORT, cmd, error)) {
+		g_prefix_error(error, "failed to apply %s at runtime: ", self->name);
+		return FALSE;
+	}
+	if (!fu_coreboot_cfr_setting_port_read(fd, COREBOOT_CFR_APM_STS_PORT, &status, error)) {
 		g_prefix_error(error, "failed to apply %s at runtime: ", self->name);
 		return FALSE;
 	}
@@ -162,9 +167,9 @@ static gboolean
 fu_coreboot_cfr_setting_apply(FuCorebootCfrSetting *self, guint32 value, GError **error)
 {
 	switch (self->runtime_apply_method) {
-	case COREBOOT_CFR_APPLY_METHOD_NONE:
+	case FU_COREBOOT_CFR_APPLY_METHOD_NONE:
 		return TRUE;
-	case COREBOOT_CFR_APPLY_METHOD_APM_CNT:
+	case FU_COREBOOT_CFR_APPLY_METHOD_APM_CNT:
 		return fu_coreboot_cfr_setting_apply_apm_cnt(self, value, error);
 	default:
 		g_set_error(error,

--- a/plugins/coreboot-cfr/fu-coreboot-cfr-setting.h
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr-setting.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Star Labs
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#pragma once
+
+#include <fwupdplugin.h>
+
+#define FU_TYPE_COREBOOT_CFR_SETTING (fu_coreboot_cfr_setting_get_type())
+G_DECLARE_FINAL_TYPE(FuCorebootCfrSetting,
+		     fu_coreboot_cfr_setting,
+		     FU,
+		     COREBOOT_CFR_SETTING,
+		     FwupdBiosSetting)
+
+FwupdBiosSetting *
+fu_coreboot_cfr_setting_new(FuEfivars *efivars,
+			    const gchar *name,
+			    const gchar *ui_name,
+			    const gchar *description,
+			    FwupdBiosSettingKind kind,
+			    FuEfiVariableAttrs attrs,
+			    guint32 runtime_apply_method,
+			    guint32 runtime_apply_id,
+			    guint32 lower_bound,
+			    guint32 upper_bound,
+			    guint32 scalar_increment,
+			    GPtrArray *possible_values,
+			    GHashTable *value_map,
+			    GHashTable *reverse_value_map,
+			    GError **error) G_GNUC_NON_NULL(1, 2, 3);

--- a/plugins/coreboot-cfr/fu-coreboot-cfr.rs
+++ b/plugins/coreboot-cfr/fu-coreboot-cfr.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 Star Labs
+// SPDX-License-Identifier: LGPL-2.1-or-later OR MIT
+
+#[repr(u32le)]
+enum FuCorebootCfrFlags {
+    None = 0x0,
+    Readonly = 1 << 0,
+}
+
+#[repr(u16le)]
+enum FuCorebootCfrType {
+    Enum = 1,
+    Number = 2,
+    Bool = 3,
+}
+
+#[repr(u32le)]
+enum FuCorebootCfrApplyMethod {
+    None,
+    ApmCnt,
+}
+
+#[derive(ParseStream, ValidateStream, Default)]
+#[repr(C, packed)]
+struct FuStructCorebootCfrSettingsHeader {
+    magic: u32le == 0x44574643, // CFWD
+    version: u16le == 0x0002,
+    header_size: u16le == 0x0010,
+    size: u32le,
+    record_count: u32le,
+}
+
+#[derive(ParseStream, ValidateStream, Default)]
+#[repr(C, packed)]
+struct FuStructCorebootCfrOptionRecord {
+    kind: FuCorebootCfrType,
+    header_size: u16le == 0x003c,
+    cfr_flags: FuCorebootCfrFlags,
+    object_id: u64le,
+    runtime_apply_method: FuCorebootCfrApplyMethod,
+    runtime_apply_id: u32le,
+    default_value: u32le,
+    min: u32le,
+    max: u32le,
+    step: u32le,
+    display_flags: u32le,
+    name_size: u32le,
+    ui_name_size: u32le,
+    help_text_size: u32le,
+    enum_count: u32le,
+}
+
+#[derive(ParseStream)]
+#[repr(C, packed)]
+struct FuStructCorebootCfrEnumRecord {
+    value: u32le,
+    ui_name_size: u32le,
+}

--- a/plugins/coreboot-cfr/fu-self-test.c
+++ b/plugins/coreboot-cfr/fu-self-test.c
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 Star Labs
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-bios-settings-private.h"
+#include "fu-byte-array.h"
+#include "fu-context-private.h"
+#include "fu-coreboot-cfr-plugin.h"
+#include "fu-coreboot-cfr-setting.h"
+#include "fu-dummy-efivars.h"
+#include "fu-plugin-private.h"
+
+#define COREBOOT_CFR_GUID		  "ceae4c1d-335b-4685-a4a0-fc4a94eea085"
+#define COREBOOT_CFR_SETTINGS_VARIABLE	  "CorebootCfrSettings"
+#define COREBOOT_CFR_SETTINGS_MAGIC	  0x44574643 /* CFWD */
+#define COREBOOT_CFR_SETTINGS_VERSION	  2
+#define COREBOOT_CFR_TYPE_ENUM		  1
+#define COREBOOT_CFR_TYPE_NUMBER	  2
+#define COREBOOT_CFR_TYPE_BOOL		  3
+#define COREBOOT_CFR_APPLY_METHOD_NONE	  0
+#define COREBOOT_CFR_APPLY_METHOD_APM_CNT 1
+#define COREBOOT_CFR_SETTINGS_HDR_SZ	  16
+#define COREBOOT_CFR_OPTION_RECORD_SZ	  60
+
+typedef struct {
+	guint32 value;
+	const gchar *ui_name;
+} FuCorebootCfrEnumTestValue;
+
+static void
+fu_coreboot_cfr_test_append_string(GByteArray *buf, const gchar *str)
+{
+	g_byte_array_append(buf, (const guint8 *)str, strlen(str) + 1);
+}
+
+static void
+fu_coreboot_cfr_test_append_option(GByteArray *buf,
+				   guint16 type,
+				   guint32 cfr_flags,
+				   const gchar *name,
+				   const gchar *ui_name,
+				   const gchar *help_text,
+				   guint32 runtime_apply_method,
+				   guint32 runtime_apply_id,
+				   guint32 default_value,
+				   guint32 min,
+				   guint32 max,
+				   guint32 step,
+				   const FuCorebootCfrEnumTestValue *enum_values,
+				   guint32 enum_count)
+{
+	fu_byte_array_append_uint16(buf, type, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint16(buf, COREBOOT_CFR_OPTION_RECORD_SZ, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, cfr_flags, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint64(buf, 0x1234, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, runtime_apply_method, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, runtime_apply_id, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, default_value, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, min, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, max, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, step, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, strlen(name) + 1, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, strlen(ui_name) + 1, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, strlen(help_text) + 1, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, enum_count, G_LITTLE_ENDIAN);
+
+	fu_coreboot_cfr_test_append_string(buf, name);
+	fu_coreboot_cfr_test_append_string(buf, ui_name);
+	fu_coreboot_cfr_test_append_string(buf, help_text);
+
+	for (guint32 i = 0; i < enum_count; i++) {
+		fu_byte_array_append_uint32(buf, enum_values[i].value, G_LITTLE_ENDIAN);
+		fu_byte_array_append_uint32(buf,
+					    strlen(enum_values[i].ui_name) + 1,
+					    G_LITTLE_ENDIAN);
+		fu_coreboot_cfr_test_append_string(buf, enum_values[i].ui_name);
+	}
+}
+
+static GByteArray *
+fu_coreboot_cfr_test_build_metadata(void)
+{
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GByteArray) buf = g_byte_array_new();
+	const FuCorebootCfrEnumTestValue kbl_timeout[] = {
+	    {0, "30 seconds"},
+	    {1, "1 minute"},
+	};
+
+	fu_byte_array_append_uint32(buf, COREBOOT_CFR_SETTINGS_MAGIC, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint16(buf, COREBOOT_CFR_SETTINGS_VERSION, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint16(buf, COREBOOT_CFR_SETTINGS_HDR_SZ, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, 0x0, G_LITTLE_ENDIAN);
+	fu_byte_array_append_uint32(buf, 0x3, G_LITTLE_ENDIAN);
+
+	fu_coreboot_cfr_test_append_option(buf,
+					   COREBOOT_CFR_TYPE_ENUM,
+					   0x0,
+					   "kbl_timeout",
+					   "Keyboard Backlight Timeout",
+					   "Time before the keyboard backlight turns off",
+					   COREBOOT_CFR_APPLY_METHOD_APM_CNT,
+					   0x1,
+					   0x0,
+					   0x0,
+					   0x1,
+					   0x1,
+					   kbl_timeout,
+					   G_N_ELEMENTS(kbl_timeout));
+	fu_coreboot_cfr_test_append_option(buf,
+					   COREBOOT_CFR_TYPE_BOOL,
+					   0x0,
+					   "fan_always_on",
+					   "Fan Always On",
+					   "Keeps the fan running",
+					   COREBOOT_CFR_APPLY_METHOD_APM_CNT,
+					   0x2,
+					   0x0,
+					   0x0,
+					   0x1,
+					   0x1,
+					   NULL,
+					   0x0);
+	fu_coreboot_cfr_test_append_option(buf,
+					   COREBOOT_CFR_TYPE_NUMBER,
+					   0x0,
+					   "kbd_brightness",
+					   "Keyboard Brightness",
+					   "Keyboard backlight brightness",
+					   COREBOOT_CFR_APPLY_METHOD_APM_CNT,
+					   0x3,
+					   0x2,
+					   0x0,
+					   0x3,
+					   0x1,
+					   NULL,
+					   0x0);
+
+	g_assert_true(
+	    fu_memwrite_uint32_safe(buf->data, buf->len, 0x8, buf->len, G_LITTLE_ENDIAN, &error));
+	g_assert_no_error(error);
+
+	return g_steal_pointer(&buf);
+}
+
+static gboolean
+fu_coreboot_cfr_test_set_uint32(FuEfivars *efivars,
+				const gchar *name,
+				guint32 value,
+				GError **error)
+{
+	guint8 buf[sizeof(guint32)] = {0};
+
+	if (!fu_memwrite_uint32_safe(buf, sizeof(buf), 0x0, value, G_LITTLE_ENDIAN, error))
+		return FALSE;
+	return fu_efivars_set_data(efivars,
+				   COREBOOT_CFR_GUID,
+				   name,
+				   buf,
+				   sizeof(buf),
+				   FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+				       FU_EFI_VARIABLE_ATTR_BOOTSERVICE_ACCESS |
+				       FU_EFI_VARIABLE_ATTR_RUNTIME_ACCESS,
+				   error);
+}
+
+static void
+fu_coreboot_cfr_coldplug_func(void)
+{
+	gboolean ret;
+	FuEfivars *efivars = NULL;
+	FwupdBiosSetting *setting = NULL;
+	GPtrArray *possible_values = NULL;
+	g_autoptr(FuBiosSettings) bios_settings = NULL;
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_NO_QUIRKS | FU_CONTEXT_FLAG_DUMMY_EFIVARS);
+	g_autoptr(FuPlugin) plugin = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GByteArray) metadata = fu_coreboot_cfr_test_build_metadata();
+	g_autoptr(GError) error = NULL;
+
+	efivars = fu_context_get_efivars(ctx);
+	ret = fu_efivars_set_data(efivars,
+				  COREBOOT_CFR_GUID,
+				  COREBOOT_CFR_SETTINGS_VARIABLE,
+				  metadata->data,
+				  metadata->len,
+				  FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+				      FU_EFI_VARIABLE_ATTR_BOOTSERVICE_ACCESS |
+				      FU_EFI_VARIABLE_ATTR_RUNTIME_ACCESS,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_coreboot_cfr_test_set_uint32(efivars, "kbl_timeout", 0x1, &error));
+	g_assert_no_error(error);
+	g_assert_true(fu_coreboot_cfr_test_set_uint32(efivars, "fan_always_on", 0x0, &error));
+	g_assert_no_error(error);
+	g_assert_true(fu_coreboot_cfr_test_set_uint32(efivars, "kbd_brightness", 0x2, &error));
+	g_assert_no_error(error);
+
+	plugin = fu_plugin_new_from_gtype(fu_coreboot_cfr_plugin_get_type(), ctx);
+	ret = fu_plugin_runner_startup(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	ret = fu_plugin_runner_coldplug(plugin, progress, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	bios_settings = fu_context_get_bios_settings(ctx);
+
+	setting = fu_bios_settings_get_attr(bios_settings, "org.coreboot.cfr.kbl_timeout");
+	g_assert_nonnull(setting);
+	g_assert_cmpstr(fwupd_bios_setting_get_name(setting), ==, "kbl_timeout");
+	g_assert_cmpstr(fwupd_bios_setting_get_description(setting),
+			==,
+			"Time before the keyboard backlight turns off");
+	g_assert_cmpint(fwupd_bios_setting_get_kind(setting),
+			==,
+			FWUPD_BIOS_SETTING_KIND_ENUMERATION);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "1 minute");
+	possible_values = fwupd_bios_setting_get_possible_values(setting);
+	g_assert_cmpint(possible_values->len, ==, 2);
+	g_assert_cmpstr(g_ptr_array_index(possible_values, 0), ==, "30 seconds");
+	g_assert_cmpstr(g_ptr_array_index(possible_values, 1), ==, "1 minute");
+
+	setting = fu_bios_settings_get_attr(bios_settings, "org.coreboot.cfr.fan_always_on");
+	g_assert_nonnull(setting);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "Disabled");
+	possible_values = fwupd_bios_setting_get_possible_values(setting);
+	g_assert_cmpint(possible_values->len, ==, 2);
+	g_assert_cmpstr(g_ptr_array_index(possible_values, 0), ==, "Disabled");
+	g_assert_cmpstr(g_ptr_array_index(possible_values, 1), ==, "Enabled");
+
+	setting = fu_bios_settings_get_attr(bios_settings, "org.coreboot.cfr.kbd_brightness");
+	g_assert_nonnull(setting);
+	g_assert_cmpint(fwupd_bios_setting_get_kind(setting), ==, FWUPD_BIOS_SETTING_KIND_INTEGER);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "2");
+	g_assert_cmpint(fwupd_bios_setting_get_lower_bound(setting), ==, 0);
+	g_assert_cmpint(fwupd_bios_setting_get_upper_bound(setting), ==, 3);
+	g_assert_cmpint(fwupd_bios_setting_get_scalar_increment(setting), ==, 1);
+}
+
+static void
+fu_coreboot_cfr_write_value_func(void)
+{
+	gboolean ret;
+	gsize data_sz = 0;
+	guint32 value = 0;
+	g_autofree guint8 *data = NULL;
+	g_autoptr(FuEfivars) efivars = fu_dummy_efivars_new();
+	g_autoptr(FwupdBiosSetting) setting = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GHashTable) reverse_value_map =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	g_autoptr(GHashTable) value_map =
+	    g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	g_autoptr(GPtrArray) possible_values = g_ptr_array_new_with_free_func(g_free);
+
+	g_ptr_array_add(possible_values, g_strdup("30 seconds"));
+	g_ptr_array_add(possible_values, g_strdup("1 minute"));
+	g_hash_table_insert(value_map, g_strdup("30 seconds"), g_strdup("0"));
+	g_hash_table_insert(value_map, g_strdup("1 minute"), g_strdup("1"));
+	g_hash_table_insert(reverse_value_map, g_strdup("0"), g_strdup("30 seconds"));
+	g_hash_table_insert(reverse_value_map, g_strdup("1"), g_strdup("1 minute"));
+
+	g_assert_true(fu_coreboot_cfr_test_set_uint32(efivars, "kbl_timeout", 0x0, &error));
+	g_assert_no_error(error);
+
+	setting = fu_coreboot_cfr_setting_new(efivars,
+					      "kbl_timeout",
+					      "Keyboard Backlight Timeout",
+					      "Time before the keyboard backlight turns off",
+					      FWUPD_BIOS_SETTING_KIND_ENUMERATION,
+					      FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+						  FU_EFI_VARIABLE_ATTR_BOOTSERVICE_ACCESS |
+						  FU_EFI_VARIABLE_ATTR_RUNTIME_ACCESS,
+					      COREBOOT_CFR_APPLY_METHOD_NONE,
+					      0x0,
+					      0x0,
+					      0x1,
+					      0x1,
+					      possible_values,
+					      value_map,
+					      reverse_value_map,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(setting);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "30 seconds");
+
+	ret = fwupd_bios_setting_write_value(setting, "1 minute", &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpstr(fwupd_bios_setting_get_current_value(setting), ==, "1 minute");
+
+	ret = fu_efivars_get_data(efivars,
+				  COREBOOT_CFR_GUID,
+				  "kbl_timeout",
+				  &data,
+				  &data_sz,
+				  NULL,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_cmpint(data_sz, ==, sizeof(guint32));
+	g_assert_true(fu_memread_uint32_safe(data, data_sz, 0x0, &value, G_LITTLE_ENDIAN, &error));
+	g_assert_no_error(error);
+	g_assert_cmpint(value, ==, 0x1);
+}
+
+int
+main(int argc, char **argv)
+{
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/plugin/coreboot-cfr/coldplug", fu_coreboot_cfr_coldplug_func);
+	g_test_add_func("/fwupd/plugin/coreboot-cfr/write-value", fu_coreboot_cfr_write_value_func);
+	return g_test_run();
+}

--- a/plugins/coreboot-cfr/meson.build
+++ b/plugins/coreboot-cfr/meson.build
@@ -1,0 +1,38 @@
+host_machine.system() == 'linux' or subdir_done()
+
+cargs = ['-DG_LOG_DOMAIN="FuPluginCorebootCfr"']
+plugins += {meson.current_source_dir().split('/')[-1]: true}
+
+plugin_builtin_coreboot_cfr = static_library('fu_plugin_coreboot_cfr',
+  sources: [
+    'fu-coreboot-cfr-plugin.c',
+    'fu-coreboot-cfr-setting.c',
+  ],
+  include_directories: plugin_incdirs,
+  link_with: plugin_libs,
+  c_args: cargs,
+  dependencies: plugin_deps,
+)
+plugin_builtins += plugin_builtin_coreboot_cfr
+
+if get_option('tests')
+  env = environment()
+  env.set('G_DEBUG', 'fatal-criticals')
+  e = executable(
+    'coreboot-cfr-self-test',
+    sources: [
+      'fu-self-test.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: plugin_deps,
+    link_with: [
+      fwupd,
+      fwupdplugin,
+      plugin_builtin_coreboot_cfr,
+    ],
+    c_args: [
+      cargs,
+    ],
+  )
+  test('coreboot-cfr-self-test', e, env: env)
+endif

--- a/plugins/coreboot-cfr/meson.build
+++ b/plugins/coreboot-cfr/meson.build
@@ -4,6 +4,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginCorebootCfr"']
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 
 plugin_builtin_coreboot_cfr = static_library('fu_plugin_coreboot_cfr',
+  rustgen.process('fu-coreboot-cfr.rs'),
   sources: [
     'fu-coreboot-cfr-plugin.c',
     'fu-coreboot-cfr-setting.c',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -34,6 +34,7 @@ plugins = {
   'ccgx-dmc': false,
   'cfu': false,
   'corsair': false,
+  'coreboot-cfr': false,
   'cpu': false,
   'cros-ec': false,
   'dell': false,


### PR DESCRIPTION
This adds a coreboot CFR plugin that reads the firmware-published CFR metadata variable and exposes runtime-applicable CFR options through fwupd BIOS settings.

Writes update the matching CFR UEFI variable and then trigger the firmware SMI apply hook, allowing supported settings to take effect in S0 without a reboot. The initial hardware path is keyboard-backlight timeout on StarFighter MTL.

Tested:
- ninja -C build
- ninja -C build-codex
- meson test -C build coreboot-cfr-self-test --print-errorlogs
- StarFighter MTL: fwupdtool set-bios-setting kbl_timeout changed the efivar and EC RAM in S0, then restored cleanly