### PR TITLE
uefi-dbx: Skip dbx entries with NULL checksum before logging

### DIFF
--- a/plugins/uefi-dbx/fu-uefi-dbx-device.c
+++ b/plugins/uefi-dbx/fu-uefi-dbx-device.c
@@ -118,6 +118,9 @@ fu_uefi_dbx_device_ensure_checksum(FuUefiDbxDevice *self, GError **error)
 		g_autofree gchar *csum =
 		    fu_firmware_get_checksum(FU_FIRMWARE(sig), G_CHECKSUM_SHA256, NULL);
 
+		if (csum == NULL)
+			continue;
+
 		if (g_strcmp0(owner, FU_EFI_SIGNATURE_GUID_MICROSOFT) != 0) {
 			g_debug("skipping dbx entry %s as non-microsoft (%s)", csum, owner);
 			continue;


### PR DESCRIPTION
I don't think it's possible to hit this in reality, but it pops up when doing a security scan and it's an easy fix.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
