### PR TITLE
uefi-db: Do not break loop early when finding Microsoft UEFI CAs

### DIFF
--- a/plugins/uefi-db/fu-uefi-db-device.c
+++ b/plugins/uefi-db/fu-uefi-db-device.c
@@ -109,13 +109,11 @@ fu_uefi_db_device_add_security_attrs(FuDevice *device, FuSecurityAttrs *attrs)
 					      "UEFI\\CRT_7CD7437C555F89E7C2B50E21937E420C4E583E80",
 					      FU_DEVICE_INSTANCE_FLAG_VISIBLE)) {
 			seen_new = TRUE;
-			break;
 		}
 		if (fu_device_has_instance_id(child,
 					      "UEFI\\CRT_E30CF09DABEAB32A6E3B07A7135245DE05FFB658",
 					      FU_DEVICE_INSTANCE_FLAG_VISIBLE)) {
 			seen_old = TRUE;
-			break;
 		}
 	}
 


### PR DESCRIPTION
This means we detect both correctly if they're in the "wrong" order.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
