### PR TITLE
Claim the udev netlink backend before old libusb versions

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -9367,20 +9367,22 @@ fu_engine_constructed(GObject *obj)
 			 self);
 
 	/* backends */
+#ifdef HAVE_UDEV
 	{
-		g_autoptr(FuBackend) backend = fu_usb_backend_new(self->ctx);
+		g_autoptr(FuBackend) backend = fu_udev_backend_new(self->ctx);
+		/* list this before FuUsbBackend in case LIBUSB_OPTION_NO_DEVICE_DISCOVERY is
+		 * not available -- we want to bind the netlink socket, not libusb */
 		fu_context_add_backend(self->ctx, backend);
 	}
+#endif
 	{
 		g_autoptr(FuBackend) backend = fu_uefi_backend_new(self->ctx);
 		fu_context_add_backend(self->ctx, backend);
 	}
-#ifdef HAVE_UDEV
 	{
-		g_autoptr(FuBackend) backend = fu_udev_backend_new(self->ctx);
+		g_autoptr(FuBackend) backend = fu_usb_backend_new(self->ctx);
 		fu_context_add_backend(self->ctx, backend);
 	}
-#endif
 #ifdef HAVE_BLUEZ
 	{
 		g_autoptr(FuBackend) backend = fu_bluez_backend_new(self->ctx);


### PR DESCRIPTION
Prior to libusb 1.0.27 we could not tell libusb_init() to not claim the udev netlink socket, so rearrange the backends so that the udev backend gets to claim the socket first.

Weirdly, libusb_init() still returns with success (on all versions) if the netlink socket is already busy.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
