### PR TITLE
Fix `check-reboot-needed` command

### DIFF
--- a/plugins/test/fu-test-plugin.c
+++ b/plugins/test/fu-test-plugin.c
@@ -284,6 +284,7 @@ fu_test_plugin_write_firmware(FuPlugin *plugin,
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 	} else if (fu_plugin_get_config_value_boolean(plugin, "NeedsReboot")) {
 		fu_device_add_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+		fu_device_set_update_state(device, FWUPD_UPDATE_STATE_NEEDS_REBOOT);
 	} else {
 		g_autofree gchar *ver = NULL;
 		g_autoptr(GBytes) blob_fw = NULL;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3918,8 +3918,9 @@ fu_engine_install_blob(FuEngine *self,
 	self->emulator_write_cnt = FU_ENGINE_EMULATOR_WRITE_COUNT_DEFAULT;
 	fu_progress_step_done(progress);
 
-	/* update history database */
-	fu_device_set_update_state(device, FWUPD_UPDATE_STATE_SUCCESS);
+	/* update history database -- only set to success if not already needs reboot */
+	if (fu_device_get_update_state(device) != FWUPD_UPDATE_STATE_NEEDS_REBOOT)
+		fu_device_set_update_state(device, FWUPD_UPDATE_STATE_SUCCESS);
 	fu_device_set_install_duration(device, g_timer_elapsed(timer, NULL));
 	if ((flags & FWUPD_INSTALL_FLAG_NO_HISTORY) == 0) {
 		if (!fu_history_modify_device(self->history, device, error)) {

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -531,10 +531,9 @@ fu_util_check_reboot_needed(FuUtil *self, gchar **values, GError **error)
 		for (guint i = 0; i < devices->len; i++) {
 			FwupdDevice *device = g_ptr_array_index(devices, i);
 
-			if (fwupd_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT))
+			if (fwupd_device_get_update_state(device) ==
+			    FWUPD_UPDATE_STATE_NEEDS_REBOOT)
 				self->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_REBOOT;
-			if (fwupd_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN))
-				self->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN;
 		}
 	} else {
 		for (guint i = 0; values[i] != NULL; i++) {
@@ -542,15 +541,13 @@ fu_util_check_reboot_needed(FuUtil *self, gchar **values, GError **error)
 			device = fu_util_get_device_by_id(self, values[i], error);
 			if (device == NULL)
 				return FALSE;
-			if (fwupd_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_REBOOT))
+			if (fwupd_device_get_update_state(device) ==
+			    FWUPD_UPDATE_STATE_NEEDS_REBOOT)
 				self->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_REBOOT;
-			if (fwupd_device_has_flag(device, FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN))
-				self->completion_flags |= FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN;
 		}
 	}
 
-	if (!(self->completion_flags &
-	      (FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN | FWUPD_DEVICE_FLAG_NEEDS_REBOOT))) {
+	if (!(self->completion_flags & FWUPD_DEVICE_FLAG_NEEDS_REBOOT)) {
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOTHING_TO_DO,


### PR DESCRIPTION
The command needs to check device state not device flags.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
