### PR TITLE
fix(ebitdo): detect SN30 Pro for Android in normal mode

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -103,11 +103,11 @@ InstallDuration = 120
 # SN30 Pro for Android
 [USB\VID_2DC8&PID_2100]
 Plugin = ebitdo
-Flags = ~is-bootloader
+Flags = will-disappear
 InstallDuration = 120
 [USB\VID_2DC8&PID_2101]
 Plugin = ebitdo
-Flags = ~is-bootloader
+Flags = will-disappear
 InstallDuration = 120
 
 # N30 Pro 2


### PR DESCRIPTION
Type of pull request:

* [ ] New plugin
* [x] Code fix
* [ ] Feature
* [ ] Documentation

## Problem

The SN30 Pro for Android (`VID_2DC8&PID_2100` and `VID_2DC8&PID_2101`) is not detected by `fwupdmgr` when connected in normal mode.

The device can only be recognized after manually entering bootloader mode.

After investigation, the issue appears to be caused by an incorrect quirk in `plugins/ebitdo/ebitdo.quirk`, where these devices are marked with:

```ini
Flags = ~is-bootloader
```

This does not match the actual device behavior.

See fwupd/8bitdo-firmware#47 for the original report.

## Fix

Replace the incorrect `~is-bootloader` flag with `will-disappear` for both SN30 Pro for Android device IDs:

* USB\VID_2DC8&PID_2100
* USB\VID_2DC8&PID_2101

This allows the devices to be correctly detected in normal mode while still handling the expected disconnect/re-enumeration behavior during firmware updates.

## Testing

Tested with an SN30 Pro for Android device.

Verified that:

* The device is detected by `fwupdmgr get-devices` in normal mode
* Manual entry into bootloader mode is no longer required for detection
* Device behavior remains consistent during firmware update operations

Fixes fwupd/8bitdo-firmware#47