### PR TITLE
trivial: Show the curl error code for download failure

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -5894,15 +5894,17 @@ fwupd_client_download_http(FwupdClient *self, CURL *curl, const gchar *url, GErr
 			g_set_error(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_INVALID_FILE,
-				    "failed to download file: %s",
-				    errbuf);
+				    "failed to download file: %s [%u]",
+				    errbuf,
+				    (guint)res);
 			return NULL;
 		}
 		g_set_error(error,
 			    FWUPD_ERROR,
 			    FWUPD_ERROR_INVALID_FILE,
-			    "failed to download file: %s",
-			    curl_easy_strerror(res));
+			    "failed to download file: %s [%u]",
+			    curl_easy_strerror(res),
+			    (guint)res);
 		return NULL;
 	}
 


### PR DESCRIPTION
I feel like we're missing some enums in fwupd_client_download_error_is_fatal().

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
