### PR TITLE
trivial: say "exporting" not "uploading" in report-export

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1791,7 +1791,7 @@ fu_util_report_export(FuUtil *self, gchar **values, GError **error)
 		g_set_error_literal(error,
 				    FWUPD_ERROR,
 				    FWUPD_ERROR_NOTHING_TO_DO,
-				    "No reports require uploading");
+				    "No reports require exporting");
 		return FALSE;
 	}
 


### PR DESCRIPTION
In the export path it should say "exporting" not "uploading".

Previously:

> fwupdmgr report-export --sign
No reports require uploading

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
