### PR TITLE
Install the db updates on more hardware

### DIFF
--- a/libfwupdplugin/fu-uefi-device-test.c
+++ b/libfwupdplugin/fu-uefi-device-test.c
@@ -9,7 +9,78 @@
 #include <fwupdplugin.h>
 
 #include "fu-context-private.h"
+#include "fu-efi-signature-private.h"
 #include "fu-uefi-device-private.h"
+
+static void
+fu_uefi_device_read_default_func(void)
+{
+	gboolean ret;
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS | FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuUefiDevice) uefi_device = NULL;
+	g_autoptr(FuEfiSignature) sig = fu_efi_signature_new(FU_EFI_SIGNATURE_KIND_SHA256);
+	g_autoptr(FuFirmware) siglist = fu_efi_signature_list_new();
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(GBytes) blob = NULL;
+	g_autoptr(GBytes) csum = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(GPtrArray) images = NULL;
+
+	/* create a signature list of one SHA-256 signature for dbDefault */
+	csum =
+	    fu_bytes_from_string("0000000000000000000000000000000000000000000000000000000000000000",
+				 &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(csum);
+	fu_firmware_set_bytes(FU_FIRMWARE(sig), csum);
+	ret = fu_firmware_add_image(siglist, FU_FIRMWARE(sig), &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	blob = fu_firmware_write(siglist, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob);
+
+	/* set the dbDefault EFI variable */
+	uefi_device = fu_uefi_device_new(ctx, FU_EFIVARS_GUID_EFI_GLOBAL, "db");
+	fu_device_set_firmware_gtype(FU_DEVICE(uefi_device), FU_TYPE_EFI_SIGNATURE_LIST);
+	ret = fu_uefi_device_set_efivar_bytes(uefi_device,
+					      FU_EFIVARS_GUID_EFI_GLOBAL,
+					      "dbDefault",
+					      blob,
+					      FU_EFI_VARIABLE_ATTR_NON_VOLATILE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* read back the default */
+	firmware =
+	    fu_uefi_device_read_default(uefi_device, FU_EFIVARS_GUID_EFI_GLOBAL, "db", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(firmware);
+	g_assert_true(FU_IS_EFI_SIGNATURE_LIST(firmware));
+	images = fu_firmware_get_images(firmware);
+	g_assert_nonnull(images);
+	g_assert_cmpuint(images->len, ==, 1);
+}
+
+static void
+fu_uefi_device_read_default_missing_func(void)
+{
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS | FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuUefiDevice) uefi_device = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(GError) error = NULL;
+
+	/* no dbDefault set, should fail */
+	uefi_device = fu_uefi_device_new(ctx, FU_EFIVARS_GUID_EFI_GLOBAL, "db");
+	fu_device_set_firmware_gtype(FU_DEVICE(uefi_device), FU_TYPE_EFI_SIGNATURE_LIST);
+	firmware =
+	    fu_uefi_device_read_default(uefi_device, FU_EFIVARS_GUID_EFI_GLOBAL, "db", &error);
+	g_assert_error(error, FWUPD_ERROR, FWUPD_ERROR_NOT_FOUND);
+	g_assert_null(firmware);
+}
 
 static void
 fu_uefi_device_auth_func(void)
@@ -76,6 +147,9 @@ int
 main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/fwupd/uefi-device/read-default", fu_uefi_device_read_default_func);
+	g_test_add_func("/fwupd/uefi-device/read-default{missing}",
+			fu_uefi_device_read_default_missing_func);
 	g_test_add_func("/fwupd/uefi-device/auth", fu_uefi_device_auth_func);
 	g_test_add_func("/fwupd/uefi-device/no-auth", fu_uefi_device_no_auth_func);
 	return g_test_run();

--- a/libfwupdplugin/fu-uefi-device.c
+++ b/libfwupdplugin/fu-uefi-device.c
@@ -225,6 +225,45 @@ fu_uefi_device_get_efivar_bytes(FuUefiDevice *self,
 	return g_steal_pointer(&blob);
 }
 
+/**
+ * fu_uefi_device_read_default:
+ * @self: a #FuUefiDevice
+ * @guid: Globally unique identifier
+ * @name: Variable name, e.g. `db`
+ * @error: (nullable): optional return location for an error
+ *
+ * Gets the data from a UEFI variable in NVRAM, emulating if required.
+ *
+ * Returns: (transfer full): a #FuFirmware, or %NULL on error
+ *
+ * Since: 2.1.5
+ **/
+FuFirmware *
+fu_uefi_device_read_default(FuUefiDevice *self,
+			    const gchar *guid,
+			    const gchar *name,
+			    GError **error)
+{
+	g_autofree gchar *name_default = NULL;
+	g_autoptr(FuFirmware) firmware = NULL;
+	g_autoptr(GBytes) blob = NULL;
+
+	g_return_val_if_fail(FU_IS_UEFI_DEVICE(self), NULL);
+	g_return_val_if_fail(guid != NULL, NULL);
+	g_return_val_if_fail(name != NULL, NULL);
+	g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+	/* sanity check */
+	name_default = g_strdup_printf("%sDefault", name);
+	blob = fu_uefi_device_get_efivar_bytes(self, guid, name_default, NULL, error);
+	if (blob == NULL)
+		return NULL;
+	firmware = g_object_new(fu_device_get_firmware_gtype(FU_DEVICE(self)), NULL);
+	if (!fu_firmware_parse_bytes(firmware, blob, 0x0, FU_FIRMWARE_PARSE_FLAG_NONE, error))
+		return NULL;
+	return g_steal_pointer(&firmware);
+}
+
 static void
 fu_uefi_device_to_string(FuDevice *device, guint idt, GString *str)
 {

--- a/libfwupdplugin/fu-uefi-device.h
+++ b/libfwupdplugin/fu-uefi-device.h
@@ -28,3 +28,8 @@ fu_uefi_device_get_efivar_bytes(FuUefiDevice *self,
 				const gchar *name,
 				FuEfiVariableAttrs *attr,
 				GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);
+FuFirmware *
+fu_uefi_device_read_default(FuUefiDevice *self,
+			    const gchar *guid,
+			    const gchar *name,
+			    GError **error) G_GNUC_WARN_UNUSED_RESULT G_GNUC_NON_NULL(1, 2, 3);

--- a/libfwupdplugin/fu-x509-certificate.c
+++ b/libfwupdplugin/fu-x509-certificate.c
@@ -9,6 +9,7 @@
 #ifdef HAVE_GNUTLS
 #include <gnutls/abstract.h>
 #include <gnutls/crypto.h>
+#include <gnutls/x509.h>
 #endif
 
 #include "fu-common.h"
@@ -24,10 +25,18 @@ fu_x509_certificate_gnutls_datum_deinit(gnutls_datum_t *d)
 	gnutls_free(d);
 }
 
+static void
+fu_x509_certificate_gnutls_datum_clear(gnutls_datum_t *d)
+{
+	gnutls_free(d->data);
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(gnutls_datum_t, fu_x509_certificate_gnutls_datum_deinit)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(gnutls_datum_t, fu_x509_certificate_gnutls_datum_clear)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_x509_crt_t, gnutls_x509_crt_deinit, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_x509_privkey_t, gnutls_x509_privkey_deinit, NULL)
 #pragma clang diagnostic pop
 #endif
 
@@ -73,8 +82,16 @@ fu_x509_certificate_get_issuer(FuX509Certificate *self)
 	return self->issuer;
 }
 
-#ifdef HAVE_GNUTLS
-static void
+/**
+ * fu_x509_certificate_set_issuer:
+ * @self: A #FuX509Certificate
+ * @issuer: the certificate issuer
+ *
+ * Sets the certificate issuer.
+ *
+ * Since: 2.1.5
+ **/
+void
 fu_x509_certificate_set_issuer(FuX509Certificate *self, const gchar *issuer)
 {
 	g_return_if_fail(FU_IS_X509_CERTIFICATE(self));
@@ -84,7 +101,16 @@ fu_x509_certificate_set_issuer(FuX509Certificate *self, const gchar *issuer)
 	self->issuer = g_strdup(issuer);
 }
 
-static void
+/**
+ * fu_x509_certificate_set_subject:
+ * @self: A #FuX509Certificate
+ * @subject: the certificate subject
+ *
+ * Sets the certificate subject.
+ *
+ * Since: 2.0.13
+ **/
+void
 fu_x509_certificate_set_subject(FuX509Certificate *self, const gchar *subject)
 {
 	g_return_if_fail(FU_IS_X509_CERTIFICATE(self));
@@ -94,7 +120,16 @@ fu_x509_certificate_set_subject(FuX509Certificate *self, const gchar *subject)
 	self->subject = g_strdup(subject);
 }
 
-static void
+/**
+ * fu_x509_certificate_set_activation_time:
+ * @self: A #FuX509Certificate
+ * @activation_time: the activation time as a UNIX epoch
+ *
+ * Sets the certificate activation time.
+ *
+ * Since: 2.1.5
+ **/
+void
 fu_x509_certificate_set_activation_time(FuX509Certificate *self, gint64 activation_time)
 {
 	g_return_if_fail(FU_IS_X509_CERTIFICATE(self));
@@ -102,7 +137,6 @@ fu_x509_certificate_set_activation_time(FuX509Certificate *self, gint64 activati
 		g_date_time_unref(self->activation_time);
 	self->activation_time = g_date_time_new_from_unix_utc(activation_time);
 }
-#endif
 
 /**
  * fu_x509_certificate_get_subject:
@@ -244,6 +278,148 @@ fu_x509_certificate_parse(FuFirmware *firmware,
 #endif
 }
 
+static GByteArray *
+fu_x509_certificate_write(FuFirmware *firmware, GError **error)
+{
+#ifdef HAVE_GNUTLS
+	FuX509Certificate *self = FU_X509_CERTIFICATE(firmware);
+	int rc;
+	g_auto(gnutls_datum_t) d = {0};
+	g_auto(gnutls_x509_crt_t) crt = NULL;
+	g_auto(gnutls_x509_privkey_t) key = NULL;
+	g_autoptr(GByteArray) buf = NULL;
+
+	/* generate a small private key */
+	rc = gnutls_x509_privkey_init(&key);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "privkey_init: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_privkey_generate(key,
+					  GNUTLS_PK_ECDSA,
+					  GNUTLS_CURVE_TO_BITS(GNUTLS_ECC_CURVE_SECP256R1),
+					  0);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "privkey_generate: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+
+	/* create a self-signed certificate */
+	rc = gnutls_x509_crt_init(&crt);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_init: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_crt_set_version(crt, 3);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_set_version: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	if (self->subject != NULL) {
+		rc = gnutls_x509_crt_set_dn(crt, self->subject, NULL);
+		if (rc < 0) {
+			g_set_error(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INTERNAL,
+				    "crt_set_dn: %s [%i]",
+				    gnutls_strerror(rc),
+				    rc);
+			return NULL;
+		}
+	}
+	rc = gnutls_x509_crt_set_serial(crt, "\x01", 1);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_set_serial: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_crt_set_activation_time(
+	    crt,
+	    self->activation_time != NULL ? g_date_time_to_unix(self->activation_time) : 0);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_set_activation_time: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_crt_set_expiration_time(crt, (time_t)-1);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_set_expiration_time: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_crt_set_key(crt, key);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_set_key: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	rc = gnutls_x509_crt_sign2(crt, crt, key, GNUTLS_DIG_SHA256, 0);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_sign2: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+
+	/* export as DER */
+	rc = gnutls_x509_crt_export2(crt, GNUTLS_X509_FMT_DER, &d);
+	if (rc < 0) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INTERNAL,
+			    "crt_export2: %s [%i]",
+			    gnutls_strerror(rc),
+			    rc);
+		return NULL;
+	}
+	buf = g_byte_array_sized_new(d.size);
+	g_byte_array_append(buf, d.data, d.size);
+	return g_steal_pointer(&buf);
+#else
+	g_set_error_literal(error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED, "no GnuTLS support");
+	return NULL;
+#endif
+}
+
 static void
 fu_x509_certificate_init(FuX509Certificate *self)
 {
@@ -269,6 +445,7 @@ fu_x509_certificate_class_init(FuX509CertificateClass *klass)
 	object_class->finalize = fu_x509_certificate_finalize;
 	firmware_class->export = fu_x509_certificate_export;
 	firmware_class->parse = fu_x509_certificate_parse;
+	firmware_class->write = fu_x509_certificate_write;
 }
 
 /**

--- a/libfwupdplugin/fu-x509-certificate.h
+++ b/libfwupdplugin/fu-x509-certificate.h
@@ -17,5 +17,12 @@ const gchar *
 fu_x509_certificate_get_issuer(FuX509Certificate *self) G_GNUC_NON_NULL(1);
 const gchar *
 fu_x509_certificate_get_subject(FuX509Certificate *self) G_GNUC_NON_NULL(1);
+void
+fu_x509_certificate_set_issuer(FuX509Certificate *self, const gchar *issuer) G_GNUC_NON_NULL(1);
+void
+fu_x509_certificate_set_subject(FuX509Certificate *self, const gchar *subject) G_GNUC_NON_NULL(1);
+void
+fu_x509_certificate_set_activation_time(FuX509Certificate *self, gint64 activation_time)
+    G_GNUC_NON_NULL(1);
 GDateTime *
 fu_x509_certificate_get_activation_time(FuX509Certificate *self) G_GNUC_NON_NULL(1);

--- a/plugins/uefi-db/README.md
+++ b/plugins/uefi-db/README.md
@@ -26,6 +26,11 @@ These devices use the GUID constructed of the uppercase SHA256 of the X.509 cert
 
 * `UEFI\CRT_{sha256}`
 
+If the device has been vendor-quirked with `use-db-default-ids` then the keys from `dbDefault`
+are also added as a suffix:
+
+* `UEFI\CRT_{sha256}&CRTD_{sha256}`
+
 Additionally, the subject vendor and name are used if provided.
 
 * `UEFI\VENDOR_{vendor}&NAME_{name}`
@@ -34,6 +39,21 @@ Additionally, the subject vendor and name are used if provided.
 
 The firmware is deployed when the machine is in normal runtime mode, but it is only activated when
 the system is restarted.
+
+## Quirk Use
+
+This plugin uses the following plugin-specific quirks:
+
+### `Flags=use-db-default-ids`
+
+Use the contents of `dbDefault` to build the instance ID.
+
+For instance, for HP machines we want to only offer the 2023 UEFI db update to machines with
+firmware new enough to not be bricked. We can identify these by looking at `dbDefault` and matching
+the 2011 CA in `db` and the 2023 CA in `dbDefault`. e.g.
+`UEFI\CRT_E30CF09DABEAB32A6E3B07A7135245DE05FFB658&CRTD_7CD7437C555F89E7C2B50E21937E420C4E583E80`
+
+Since: 2.1.5
 
 ## Vendor ID Security
 

--- a/plugins/uefi-db/fu-self-test.c
+++ b/plugins/uefi-db/fu-self-test.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#include "fu-context-private.h"
+#include "fu-efi-x509-signature-private.h"
+#include "fu-uefi-db-device.h"
+#include "fu-uefi-device-private.h"
+
+static GBytes *
+fu_uefi_db_self_test_build_siglist(GBytes *der, GError **error)
+{
+	g_autoptr(FuEfiX509Signature) sig = fu_efi_x509_signature_new();
+	g_autoptr(FuFirmware) siglist = fu_efi_signature_list_new();
+
+	fu_firmware_set_bytes(FU_FIRMWARE(sig), der);
+	if (!fu_firmware_add_image(siglist, FU_FIRMWARE(sig), error))
+		return NULL;
+	return fu_firmware_write(siglist, error);
+}
+
+static void
+fu_uefi_db_default_ids_func(void)
+{
+	gboolean ret;
+	GPtrArray *children;
+	gboolean found_crtd = FALSE;
+	g_autofree gchar *quirk_fn = NULL;
+	g_autoptr(FuContext) ctx = fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS);
+	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuTemporaryDirectory) tmpdir = NULL;
+	g_autoptr(FuX509Certificate) crt_db = fu_x509_certificate_new();
+	g_autoptr(FuX509Certificate) crt_default = fu_x509_certificate_new();
+	g_autoptr(GBytes) blob_db = NULL;
+	g_autoptr(GBytes) blob_default = NULL;
+	g_autoptr(GBytes) der_db = NULL;
+	g_autoptr(GBytes) der_default = NULL;
+	g_autoptr(GError) error = NULL;
+
+#ifndef HAVE_GNUTLS
+	g_test_skip("requires GnuTLS");
+	return;
+#endif
+
+	/* set up quirks */
+	tmpdir = fu_temporary_directory_new("uefi-db", &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(tmpdir);
+	quirk_fn = fu_temporary_directory_build(tmpdir, "uefi-db.quirk", NULL);
+	ret = g_file_set_contents(quirk_fn,
+				  "[93f84748-c854-5d6b-b78a-13c2361e0758]\n"
+				  "Flags = use-db-default-ids\n",
+				  -1,
+				  &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	fu_context_set_tmpdir(ctx, FU_PATH_KIND_DATADIR_QUIRKS, tmpdir);
+
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_NO_CACHE);
+	fu_hwids_add_guid(fu_context_get_hwids(ctx), "93f84748-c854-5d6b-b78a-13c2361e0758");
+	ret = fu_context_load(ctx, progress, FU_CONTEXT_LOAD_FLAG_HWID_CONFIG, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+	g_assert_true(fu_context_has_hwid_flag(ctx, "use-db-default-ids"));
+
+	/* generate test certificates at runtime */
+	fu_x509_certificate_set_subject(crt_db, "O=Test,CN=Test UEFI CA 2011");
+	der_db = fu_firmware_write(FU_FIRMWARE(crt_db), &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(der_db);
+	fu_x509_certificate_set_subject(crt_default, "O=Test,CN=Test UEFI CA 2023");
+	der_default = fu_firmware_write(FU_FIRMWARE(crt_default), &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(der_default);
+
+	/* build signature lists */
+	blob_db = fu_uefi_db_self_test_build_siglist(der_db, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob_db);
+	blob_default = fu_uefi_db_self_test_build_siglist(der_default, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob_default);
+
+	/* create the device */
+	device = g_object_new(FU_TYPE_UEFI_DB_DEVICE, "context", ctx, NULL);
+	fu_uefi_device_set_guid(FU_UEFI_DEVICE(device), FU_EFIVARS_GUID_SECURITY_DATABASE);
+	fu_uefi_device_set_name(FU_UEFI_DEVICE(device), "db");
+
+	/* set the db EFI variable */
+	ret = fu_uefi_device_set_efivar_bytes(
+	    FU_UEFI_DEVICE(device),
+	    FU_EFIVARS_GUID_SECURITY_DATABASE,
+	    "db",
+	    blob_db,
+	    FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+		FU_EFI_VARIABLE_ATTR_TIME_BASED_AUTHENTICATED_WRITE_ACCESS,
+	    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* set the dbDefault EFI variable */
+	ret = fu_uefi_device_set_efivar_bytes(FU_UEFI_DEVICE(device),
+					      FU_EFIVARS_GUID_EFI_GLOBAL,
+					      "dbDefault",
+					      blob_default,
+					      FU_EFI_VARIABLE_ATTR_NON_VOLATILE,
+					      &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* probe should create children with CRTD instance IDs */
+	ret = fu_device_probe(device, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* verify at least one child has a CRTD instance ID */
+	children = fu_device_get_children(device);
+	g_assert_cmpint(children->len, >, 0);
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *child = g_ptr_array_index(children, i);
+		GPtrArray *instance_ids = fu_device_get_instance_ids(child);
+		for (guint j = 0; j < instance_ids->len; j++) {
+			const gchar *instance_id = g_ptr_array_index(instance_ids, j);
+			if (g_strstr_len(instance_id, -1, "CRTD_") != NULL) {
+				found_crtd = TRUE;
+				break;
+			}
+		}
+	}
+	g_assert_true(found_crtd);
+}
+
+static void
+fu_uefi_db_no_default_ids_func(void)
+{
+	gboolean ret;
+	GPtrArray *children;
+	g_autoptr(FuContext) ctx =
+	    fu_context_new_full(FU_CONTEXT_FLAG_DUMMY_EFIVARS | FU_CONTEXT_FLAG_NO_QUIRKS);
+	g_autoptr(FuDevice) device = NULL;
+	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(FuX509Certificate) crt_db = fu_x509_certificate_new();
+	g_autoptr(GBytes) blob_db = NULL;
+	g_autoptr(GBytes) der_db = NULL;
+	g_autoptr(GError) error = NULL;
+
+#ifndef HAVE_GNUTLS
+	g_test_skip("requires GnuTLS");
+	return;
+#endif
+
+	fu_context_add_flag(ctx, FU_CONTEXT_FLAG_NO_CACHE);
+	ret = fu_context_load(ctx, progress, FU_CONTEXT_LOAD_FLAG_NONE, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* flag should NOT be set */
+	g_assert_false(fu_context_has_hwid_flag(ctx, "use-db-default-ids"));
+
+	/* generate test certificate for db */
+	fu_x509_certificate_set_subject(crt_db, "O=Test,CN=Test UEFI CA 2011");
+	der_db = fu_firmware_write(FU_FIRMWARE(crt_db), &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(der_db);
+	blob_db = fu_uefi_db_self_test_build_siglist(der_db, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(blob_db);
+
+	/* create the device */
+	device = g_object_new(FU_TYPE_UEFI_DB_DEVICE, "context", ctx, NULL);
+	fu_uefi_device_set_guid(FU_UEFI_DEVICE(device), FU_EFIVARS_GUID_SECURITY_DATABASE);
+	fu_uefi_device_set_name(FU_UEFI_DEVICE(device), "db");
+
+	/* set the db EFI variable */
+	ret = fu_uefi_device_set_efivar_bytes(
+	    FU_UEFI_DEVICE(device),
+	    FU_EFIVARS_GUID_SECURITY_DATABASE,
+	    "db",
+	    blob_db,
+	    FU_EFI_VARIABLE_ATTR_NON_VOLATILE |
+		FU_EFI_VARIABLE_ATTR_TIME_BASED_AUTHENTICATED_WRITE_ACCESS,
+	    &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* probe should create children without CRTD instance IDs */
+	ret = fu_device_probe(device, &error);
+	g_assert_no_error(error);
+	g_assert_true(ret);
+
+	/* verify no child has a CRTD instance ID */
+	children = fu_device_get_children(device);
+	g_assert_cmpint(children->len, >, 0);
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *child = g_ptr_array_index(children, i);
+		GPtrArray *instance_ids = fu_device_get_instance_ids(child);
+		for (guint j = 0; j < instance_ids->len; j++) {
+			const gchar *instance_id = g_ptr_array_index(instance_ids, j);
+			g_assert_null(g_strstr_len(instance_id, -1, "CRTD_"));
+		}
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	(void)g_setenv("G_TEST_SRCDIR", SRCDIR, FALSE);
+	g_test_init(&argc, &argv, NULL);
+	g_test_add_func("/uefi-db/default-ids", fu_uefi_db_default_ids_func);
+	g_test_add_func("/uefi-db/no-default-ids", fu_uefi_db_no_default_ids_func);
+	return g_test_run();
+}

--- a/plugins/uefi-db/fu-uefi-db-device.c
+++ b/plugins/uefi-db/fu-uefi-db-device.c
@@ -22,11 +22,27 @@ fu_uefi_db_device_probe(FuDevice *device, GError **error)
 	FuContext *ctx = fu_device_get_context(device);
 	g_autoptr(FuFirmware) siglist = NULL;
 	g_autoptr(FuProgress) progress = fu_progress_new(G_STRLOC);
+	g_autoptr(GPtrArray) default_sigs = NULL;
 	g_autoptr(GPtrArray) sigs = NULL;
 
 	/* FuUefiDevice->probe */
 	if (!FU_DEVICE_CLASS(fu_uefi_db_device_parent_class)->probe(device, error))
 		return FALSE;
+
+	/* for specific vendors we care about the default value */
+	if (fu_context_has_hwid_flag(ctx, "use-db-default-ids")) {
+		g_autoptr(FuFirmware) firmware_default = NULL;
+		g_autoptr(GError) error_local = NULL;
+		firmware_default = fu_uefi_device_read_default(FU_UEFI_DEVICE(device),
+							       FU_EFIVARS_GUID_EFI_GLOBAL,
+							       "db",
+							       &error_local);
+		if (firmware_default == NULL) {
+			g_debug("failed to get dbDefault, ignoring: %s", error_local->message);
+		} else {
+			default_sigs = fu_firmware_get_images(firmware_default);
+		}
+	}
 
 	/* add each subdevice */
 	siglist = fu_device_read_firmware(device,
@@ -47,6 +63,26 @@ fu_uefi_db_device_probe(FuDevice *device, GError **error)
 		fu_device_add_flag(FU_DEVICE(x509_device), FWUPD_DEVICE_FLAG_AFFECTS_FDE);
 		fu_device_set_physical_id(FU_DEVICE(x509_device), "db");
 		fu_device_set_proxy(FU_DEVICE(x509_device), device);
+		if (!fu_device_probe(FU_DEVICE(x509_device), error))
+			return FALSE;
+		for (guint j = 0; default_sigs != NULL && j < default_sigs->len; j++) {
+			FuFirmware *default_sig = g_ptr_array_index(default_sigs, j);
+			if (fu_firmware_get_id(default_sig) == NULL)
+				continue;
+			if (g_strcmp0(fu_firmware_get_id(default_sig),
+				      fu_firmware_get_id(FU_FIRMWARE(sig))) == 0)
+				continue;
+			fu_device_add_instance_strup(FU_DEVICE(x509_device),
+						     "CRTD",
+						     fu_firmware_get_id(default_sig));
+			if (!fu_device_build_instance_id(FU_DEVICE(x509_device),
+							 error,
+							 "UEFI",
+							 "CRT",
+							 "CRTD",
+							 NULL))
+				return FALSE;
+		}
 		fu_device_add_child(device, FU_DEVICE(x509_device));
 	}
 

--- a/plugins/uefi-db/meson.build
+++ b/plugins/uefi-db/meson.build
@@ -4,7 +4,7 @@ cargs = ['-DG_LOG_DOMAIN="FuPluginUefiDb"']
 
 plugins += {meson.current_source_dir().split('/')[-1]: true}
 plugin_quirks += files('uefi-db.quirk')
-plugin_builtins += static_library('fu_plugin_uefi_db',
+plugin_builtin_uefi_db = static_library('fu_plugin_uefi_db',
   sources: [
     'fu-uefi-db-device.c',
     'fu-uefi-db-plugin.c',
@@ -14,3 +14,32 @@ plugin_builtins += static_library('fu_plugin_uefi_db',
   c_args: cargs,
   dependencies: plugin_deps,
 )
+plugin_builtins += plugin_builtin_uefi_db
+
+if get_option('tests')
+  env = environment()
+  env.set('G_TEST_SRCDIR', meson.current_source_dir())
+  env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+  env.set('G_DEBUG', 'fatal-criticals')
+  e = executable(
+    'uefi-db-self-test',
+    sources: [
+      'fu-self-test.c',
+    ],
+    include_directories: plugin_incdirs,
+    dependencies: plugin_deps,
+    link_with: [
+      plugin_libs,
+      plugin_builtin_uefi_db,
+    ],
+    install: true,
+    install_rpath: libdir_pkg,
+    install_tag: 'tests',
+    install_dir: installed_test_bindir,
+    c_args: [
+      cargs,
+      '-DSRCDIR="' + meson.current_source_dir() + '"',
+    ],
+  )
+  test('uefi-db-self-test', e, env: env)
+endif

--- a/plugins/uefi-db/uefi-db.quirk
+++ b/plugins/uefi-db/uefi-db.quirk
@@ -11,3 +11,7 @@ Name = Laptop DB
 Vendor = ASUS
 VendorId = UEFI:ASUS
 Name = SW Key CA
+
+# HP
+[93f84748-c854-5d6b-b78a-13c2361e0758]
+Flags = use-db-default-ids


### PR DESCRIPTION
HP have told me that any machine with the 2023 CA in dbDefault is new enough to not get bricked when deploying the db update at runtime, so build a new instance ID for those vendors that includes the default certificate hashes.

This requires a different component on the LVFS for machines that use this, but that's probably a good idea from an analytics and demotion point of view.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
