### PR TITLE
rustgen: bound the array index in generated getters

### DIFF
--- a/libfwupdplugin/fu-rustgen-struct.c.in
+++ b/libfwupdplugin/fu-rustgen-struct.c.in
@@ -115,6 +115,7 @@ void
 {{item.c_getter}}(const {{obj.name}} *st, guint idx)
 {
     g_return_val_if_fail(st != NULL, 0x0);
+    g_return_val_if_fail(idx < {{item.n_elements}}, 0x0);
     return fu_memread_{{item.type_mem}}(st->buf->data + {{item.offset}} + (sizeof({{item.type_glib}}) * idx),
                                         {{item.endian_glib}});
 }


### PR DESCRIPTION
**Unchecked index in generated array getters**
The getter rustgen emits for `[uNN; N]` fields only checks the struct pointer, so an out-of-range `idx` makes `fu_memread_*` read `sizeof(type) * idx` bytes past the parsed buffer. The matching setter and the nested-struct getter already guard `idx < n_elements`, so this brings the primitive getter into line and keeps the generated accessors consistent.