### PR TITLE
Partially revert "Use fu_memstrsafe() in more places for safety"

### DIFF
--- a/libfwupdplugin/fu-msgpack-item.c
+++ b/libfwupdplugin/fu-msgpack-item.c
@@ -590,6 +590,24 @@ fu_msgpack_item_read_binary(GByteArray *buf, gsize offset, gsize n, GError **err
 	return g_steal_pointer(&tmp);
 }
 
+static gchar *
+fu_msgpack_item_read_string(GByteArray *buf, gsize offset, gsize n, GError **error)
+{
+	g_autofree gchar *tmp = NULL;
+
+	if (!fu_memchk_read(buf->len, offset, n, error))
+		return NULL;
+	tmp = g_strndup((const gchar *)buf->data + offset, n);
+	if (!g_utf8_validate_len(tmp, n, NULL)) {
+		g_set_error_literal(error,
+				    FWUPD_ERROR,
+				    FWUPD_ERROR_INVALID_DATA,
+				    "invalid UTF-8 string");
+		return NULL;
+	}
+	return g_steal_pointer(&tmp);
+}
+
 FuMsgpackItem *
 fu_msgpack_item_parse(GByteArray *buf, gsize *offset, GError **error)
 {
@@ -682,7 +700,7 @@ fu_msgpack_item_parse(GByteArray *buf, gsize *offset, GError **error)
 	/* string */
 	if (cmd >= FU_MSGPACK_CMD_FIXSTR && cmd <= FU_MSGPACK_CMD_FIXSTR_END) {
 		gsize n = cmd & 0b00011111;
-		tmp_string = fu_memstrsafe(buf->data, buf->len, *offset, n, error);
+		tmp_string = fu_msgpack_item_read_string(buf, *offset, n, error);
 		if (tmp_string == NULL)
 			return NULL;
 		if (!fu_size_checked_inc(offset, n, error))
@@ -693,7 +711,7 @@ fu_msgpack_item_parse(GByteArray *buf, gsize *offset, GError **error)
 		guint8 n = 0;
 		if (!fu_memread_uint8_safe(buf->data, buf->len, *offset, &n, error))
 			return NULL;
-		tmp_string = fu_memstrsafe(buf->data, buf->len, (*offset) + sizeof(n), n, error);
+		tmp_string = fu_msgpack_item_read_string(buf, (*offset) + sizeof(n), n, error);
 		if (tmp_string == NULL)
 			return NULL;
 		if (!fu_size_checked_inc(offset, sizeof(n) + n, error))
@@ -704,7 +722,7 @@ fu_msgpack_item_parse(GByteArray *buf, gsize *offset, GError **error)
 		guint16 n = 0;
 		if (!fu_memread_uint16_safe(buf->data, buf->len, *offset, &n, G_BIG_ENDIAN, error))
 			return NULL;
-		tmp_string = fu_memstrsafe(buf->data, buf->len, (*offset) + sizeof(n), n, error);
+		tmp_string = fu_msgpack_item_read_string(buf, (*offset) + sizeof(n), n, error);
 		if (tmp_string == NULL)
 			return NULL;
 		if (!fu_size_checked_inc(offset, sizeof(n) + n, error))
@@ -715,7 +733,7 @@ fu_msgpack_item_parse(GByteArray *buf, gsize *offset, GError **error)
 		guint32 n = 0;
 		if (!fu_memread_uint32_safe(buf->data, buf->len, *offset, &n, G_BIG_ENDIAN, error))
 			return NULL;
-		tmp_string = fu_memstrsafe(buf->data, buf->len, (*offset) + sizeof(n), n, error);
+		tmp_string = fu_msgpack_item_read_string(buf, (*offset) + sizeof(n), n, error);
 		if (tmp_string == NULL)
 			return NULL;
 		if (!fu_size_checked_inc(offset, sizeof(n) + n, error))

--- a/libfwupdplugin/fu-msgpack-test.c
+++ b/libfwupdplugin/fu-msgpack-test.c
@@ -129,6 +129,7 @@ fu_msgpack_func(void)
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) items_new = NULL;
 	g_autoptr(GPtrArray) items = g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
+	GString *str;
 	FuMsgpackItemKind kinds[] = {
 	    FU_MSGPACK_ITEM_KIND_MAP,
 	    FU_MSGPACK_ITEM_KIND_STRING,
@@ -162,16 +163,18 @@ fu_msgpack_func(void)
 	g_ptr_array_add(items, fu_msgpack_item_new_string("array-of-data"));
 	g_ptr_array_add(items, fu_msgpack_item_new_array(1));
 	g_ptr_array_add(items, fu_msgpack_item_new_binary(buf_in));
+	g_ptr_array_add(items, fu_msgpack_item_new_string(""));
+	g_ptr_array_add(items, fu_msgpack_item_new_string("UTF-8™"));
 	buf2 = fu_msgpack_write(items, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(buf2);
-	g_assert_cmpint(buf2->len, ==, 53);
+	g_assert_cmpint(buf2->len, ==, 63);
 
 	/* parse it back */
 	items_new = fu_msgpack_parse(buf2, &error);
 	g_assert_no_error(error);
 	g_assert_nonnull(items_new);
-	g_assert_cmpint(items_new->len, ==, 10);
+	g_assert_cmpint(items_new->len, ==, 12);
 
 	for (guint i = 0; i < G_N_ELEMENTS(kinds); i++) {
 		FuMsgpackItem *item = g_ptr_array_index(items_new, i);
@@ -184,6 +187,12 @@ fu_msgpack_func(void)
 				       1.0,
 				       0.00001);
 	g_assert_cmpint(fu_msgpack_item_get_array(g_ptr_array_index(items_new, 8)), ==, 1);
+	str = fu_msgpack_item_get_string(g_ptr_array_index(items_new, 10));
+	g_assert_nonnull(str);
+	g_assert_cmpstr(str->str, ==, "");
+	str = fu_msgpack_item_get_string(g_ptr_array_index(items_new, 11));
+	g_assert_nonnull(str);
+	g_assert_cmpstr(str->str, ==, "UTF-8™");
 }
 
 int


### PR DESCRIPTION
This partially reverts commit e9a9a006ce53bd130a66a613362b8eb5632a9c10 as it caused regressions with empty msgpack strings, and UTF-8 msgpack strings.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
