### PR TITLE
Prevent netlink packet loss and stall during event floods

### DIFF
--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -431,8 +431,6 @@ fu_udev_backend_devnode_wait_cb(FuDevice *device, gpointer user_data, GError **e
 		return TRUE;
 
 	const gchar *dev_file = fu_udev_device_get_device_file(FU_UDEV_DEVICE(device));
-	if (dev_file == NULL)
-		return FALSE;
 
 	/* if the device has no associated /dev/ node (e.g. pure sysfs), we skip it */
 	if (dev_file != NULL && !g_file_test(dev_file, G_FILE_TEST_EXISTS)) {
@@ -653,8 +651,12 @@ fu_udev_backend_netlink_cb(gint fd, GIOCondition condition, gpointer user_data)
 		       MSG_DONTWAIT,
 		       (struct sockaddr *)&sender_addr,
 		       &sender_len);
-	if (len < 0)
+	if (len < 0) {
+		if (errno != EAGAIN && errno != EWOULDBLOCK) {
+			g_warning("netlink recvfrom failed: %s", g_strerror(errno));
+		}
 		return TRUE;
+	}
 
 	/* only accept messages from kernel (pid 0) to prevent spoofing attacks */
 	if (sender_addr.nl_groups == FU_UDEV_MONITOR_NETLINK_GROUP_KERNEL &&
@@ -714,6 +716,12 @@ fu_udev_backend_netlink_setup(FuUdevBackend *self, GError **error)
 			    "failed to connect to netlink: %s",
 			    fwupd_strerror(errno));
 		return FALSE;
+	}
+	{
+		int rcvbuf = 8 * 1024 * 1024; /* 8MB */
+		if (setsockopt(self->netlink_fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) < 0) {
+			g_warning("failed to set SO_RCVBUF: %s", g_strerror(errno));
+		}
 	}
 	if (bind(self->netlink_fd, (void *)&nls, sizeof(nls))) {
 		g_set_error(error,


### PR DESCRIPTION
When running without systemd-udevd (eg: Android), massive kernel hotplug activity (such as composite USB gadget initialization) can flood the raw netlink socket.

    This commit resolves two bottlenecks under heavy event load:
    1. Expands SO_RCVBUF to 8MB to prevent packet dropping (ENOBUFS) during event floods.
    2. Removes dev_file == NULL checks to let virtual sysfs devices pass through instantly, avoiding heavy retry loops.
    3. Adds warning logs when recvfrom() encounters unexpected socket errors.

Type of pull request: Code Fix


