### PR TITLE
udev: Remove null dev_file check to bypass virtual device stalling

### DIFF
--- a/src/fu-udev-backend.c
+++ b/src/fu-udev-backend.c
@@ -431,8 +431,6 @@ fu_udev_backend_devnode_wait_cb(FuDevice *device, gpointer user_data, GError **e
 		return TRUE;
 
 	const gchar *dev_file = fu_udev_device_get_device_file(FU_UDEV_DEVICE(device));
-	if (dev_file == NULL)
-		return FALSE;
 
 	/* if the device has no associated /dev/ node (e.g. pure sysfs), we skip it */
 	if (dev_file != NULL && !g_file_test(dev_file, G_FILE_TEST_EXISTS)) {


### PR DESCRIPTION
This commit removes the null check in fu_udev_backend_devnode_wait_cb, allowing pure
virtual sysfs devices to pass through instantly rather than stalling the daemon in heavy retry
loops.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
