### PR TITLE
csv: bound the column index in fu_csv_entry_get_value_by_column_id

### DIFF
--- a/libfwupdplugin/fu-csv-entry.c
+++ b/libfwupdplugin/fu-csv-entry.c
@@ -90,6 +90,9 @@ fu_csv_entry_get_value_by_column_id(FuCsvEntry *self, const gchar *column_id)
 	g_return_val_if_fail(idx != G_MAXUINT, NULL);
 	g_return_val_if_fail(column_id != NULL, NULL);
 
+	/* the column may be defined in the header but absent from this shorter row */
+	if (idx >= priv->values->len)
+		return NULL;
 	return g_ptr_array_index(priv->values, idx);
 }
 

--- a/libfwupdplugin/fu-firmware-test.c
+++ b/libfwupdplugin/fu-firmware-test.c
@@ -424,6 +424,7 @@ static void
 fu_firmware_csv_func(void)
 {
 	FuCsvEntry *entry_tmp;
+	FuCsvEntry *entry_short;
 	gboolean ret;
 	g_autofree gchar *str = NULL;
 	g_autoptr(FuFirmware) firmware = fu_csv_firmware_new();
@@ -432,7 +433,8 @@ fu_firmware_csv_func(void)
 	g_autoptr(GPtrArray) imgs = NULL;
 	const gchar *data =
 	    "sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md\n"
-	    "grub,1,Free Software Foundation,grub,2.04,https://www.gnu.org/software/grub/\n";
+	    "grub,1,Free Software Foundation,grub,2.04,https://www.gnu.org/software/grub/\n"
+	    "shorty,9\n";
 
 	fu_csv_firmware_add_column_id(FU_CSV_FIRMWARE(firmware), "$id");
 	fu_csv_firmware_add_column_id(FU_CSV_FIRMWARE(firmware), "component_generation");
@@ -458,7 +460,7 @@ fu_firmware_csv_func(void)
 	g_debug("%s", str);
 
 	imgs = fu_firmware_get_images(firmware);
-	g_assert_cmpint(imgs->len, ==, 2);
+	g_assert_cmpint(imgs->len, ==, 3);
 
 	entry_tmp = g_ptr_array_index(imgs, 1);
 
@@ -468,6 +470,13 @@ fu_firmware_csv_func(void)
 	g_assert_cmpstr(fu_csv_entry_get_value_by_column_id(entry_tmp, "vendor_version"),
 			==,
 			"2.04");
+
+	/* a row with fewer values than the header has columns must not read past
+	 * the row when a far column is looked up by ID */
+	entry_short = g_ptr_array_index(imgs, 2);
+	g_assert_cmpstr(fu_csv_entry_get_value_by_idx(entry_short, 0), ==, "shorty");
+	g_assert_cmpstr(fu_csv_entry_get_value_by_idx(entry_short, 5), ==, NULL);
+	g_assert_cmpstr(fu_csv_entry_get_value_by_column_id(entry_short, "vendor_url"), ==, NULL);
 }
 
 static void


### PR DESCRIPTION
Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

**Out-of-bounds read in fu_csv_entry_get_value_by_column_id**
The index for a column ID is bounded against the header column count rather than the per-row value array, so an entry with fewer fields than the looked-up column reads past the GPtrArray through the unchecked g_ptr_array_index and hands back a stray pointer (the .sbatlevel/SBAT path in uefi-capsule then parses it as a uint64). The sibling get_value_by_idx already bounds idx against the array length, so the same guard is applied here and a short row now returns NULL, which the uint64 wrapper already reports as a missing value.
