### PR TITLE
nordic-hid: bound device-set data_len in cfg_channel receive path

### DIFF
--- a/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
+++ b/plugins/nordic-hid/fu-nordic-hid-cfg-channel.c
@@ -157,6 +157,18 @@ fu_nordic_hid_cfg_channel_receive(FuNordicHidCfgChannel *self,
 			break;
 		fu_device_sleep(FU_DEVICE(self), 1); /* ms */
 	}
+
+	/* the length is chosen by the device, so sanity check it before any
+	 * caller reads recv_msg->data using recv_msg->data_len as the bound */
+	if (recv_msg->data_len > sizeof(recv_msg->data)) {
+		g_set_error(error,
+			    FWUPD_ERROR,
+			    FWUPD_ERROR_INVALID_DATA,
+			    "received %u bytes, while maximum is %u",
+			    recv_msg->data_len,
+			    (guint)sizeof(recv_msg->data));
+		return FALSE;
+	}
 	if (!fu_memcpy_safe(buf,
 			    bufsz,
 			    0,


### PR DESCRIPTION
the receive path in fu_nordic_hid_cfg_channel_receive copies a hid feature report straight from the device but never bounds the data_len byte, which the device picks freely up to 255. callers such as the board-name, bootloader-name and module-option readers then hand that value to fu_memstrsafe as both the buffer size and the read length, so fu_memchk_read can never fail and the 25-byte res->data is read well past its end (the generation string does the same through g_strndup). the send path already rejects an oversized data_len, so this mirrors that check on the receive side and keeps every consumer bounded in one spot rather than patching each call site.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
