### PR TITLE
trivial: add gcc -fanalyzer CI build

### DIFF
--- a/.github/workflows/gcc-analyzer.yml
+++ b/.github/workflows/gcc-analyzer.yml
@@ -1,0 +1,33 @@
+name: gcc-analyzer
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gcc-analyzer:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/fwupd/fwupd/fwupd-debian-amd64:latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: configure
+        env:
+          # FIXME: really ugly trick to make glib set `G_ANALYZER_NORETURN` to something that GCC
+          # can understand. Otherwise, GCC analyzer will complain a lot because it thinks that
+          # `g_assert_nonnull()` doesn't affect control flow.
+          CFLAGS: -D__COVERITY__
+        run: |-
+          meson setup -Dwerror=true -Dstatic_analysis=true build
+      - name: build with `-fanalyzer`
+        run: |-
+          ninja -C build


### PR DESCRIPTION
Seems to be pretty usable in more recent GCC versions now.

Type of pull request:

- [ ] New plugin (Please include [new plugin checklist](https://github.com/fwupd/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
