### PR TITLE
plugins/lxs-touch: split version to exclude boot from comparison

### DIFF
--- a/plugins/lxs-touch/README.md
+++ b/plugins/lxs-touch/README.md
@@ -35,9 +35,16 @@ It communicates over the HID RAW interface (hidraw) and handles two protocol mod
 
 ## Version Format
 
-The version consists of four fields in hex: `{boot_ver}.{core_ver}.{app_ver}.{param_ver}`
+The device version used for update comparison consists of three application fields
+(excluding the bootloader version):
 
-Example: `00A1.00B2.00C3.00D4`
+`{core_ver}.{app_ver}.{param_ver}`
+
+Example: `0000.0400.0000`
+
+The bootloader version is stored separately via `fu_device_set_version_bootloader()`
+and is not included in upgrade/downgrade comparisons. This prevents false downgrade
+detection when the boot firmware is updated independently of the application firmware.
 
 ## Communication Protocol
 

--- a/plugins/lxs-touch/fu-lxs-touch-device.c
+++ b/plugins/lxs-touch/fu-lxs-touch-device.c
@@ -147,6 +147,7 @@ fu_lxs_touch_device_ensure_version(FuLxsTouchDevice *self, GError **error)
 {
 	guint8 buf[8] = {0};
 	g_autofree gchar *version = NULL;
+	g_autofree gchar *version_bootloader = NULL;
 	g_autoptr(FuStructLxsTouchVersion) st_ver = NULL;
 
 	if (!fu_lxs_touch_device_read_data(self,
@@ -158,12 +159,17 @@ fu_lxs_touch_device_ensure_version(FuLxsTouchDevice *self, GError **error)
 	st_ver = fu_struct_lxs_touch_version_parse(buf, sizeof(buf), 0x0, error);
 	if (st_ver == NULL)
 		return FALSE;
-	version = g_strdup_printf("%04X.%04X.%04X.%04X",
-				  fu_struct_lxs_touch_version_get_boot_ver(st_ver),
+	/* application version only: core.app.param (excludes boot from comparison) */
+	version = g_strdup_printf("%04X.%04X.%04X",
 				  fu_struct_lxs_touch_version_get_core_ver(st_ver),
 				  fu_struct_lxs_touch_version_get_app_ver(st_ver),
 				  fu_struct_lxs_touch_version_get_param_ver(st_ver));
 	fu_device_set_version(FU_DEVICE(self), version);
+
+	/* bootloader version: informational only, not used for comparison */
+	version_bootloader = g_strdup_printf("%04X",
+					     fu_struct_lxs_touch_version_get_boot_ver(st_ver));
+	fu_device_set_version_bootloader(FU_DEVICE(self), version_bootloader);
 
 	/* success */
 	return TRUE;

--- a/plugins/lxs-touch/tests/lxs-touch.json
+++ b/plugins/lxs-touch/tests/lxs-touch.json
@@ -3,11 +3,11 @@
   "interactive": false,
   "steps": [
     {
-      "url": "https://fwupd.org/downloads/cf7a082092ab3bd42b0830a45703977a0d7d870252b236395b492937e2ac41c2-lxs-touch-0A.02.cab",
+      "url": "https://fwupd.org/downloads/de02854169176787fccc9fd9c7ab2bd8e10ea6020aa9cc505b040791e922735f-lxs-touch-0A.02.cab",
       "emulation-url": "https://fwupd.org/downloads/9561cedd41469670778858e8234394aabfb666b572848146a85ca13d932cbac3-lxs-touch-emulation.zip",
       "components": [
         {
-          "version": "0305.0000.0002.0A02",
+          "version": "0000.0002.0A02",
           "guids": [
             "caa39ae6-7e34-5216-8d6b-6071d32f468e"
           ]


### PR DESCRIPTION
## Summary

- Separate device version into app-only (core.app.param) and bootloader (boot_ver)
- Boot version stored via `fu_device_set_version_bootloader()` for display only
- `fu_device_set_version()` now reports only the application area that the cab updates

## Problem

The composite version string `{boot}.{core}.{app}.{param}` included the bootloader version in upgrade/downgrade comparisons. When the boot firmware was updated independently (e.g. 0305→0309), subsequent app-only cab installs were falsely detected as downgrades, requiring `--ignore-requirements --allow-older --force` to bypass.

This violates standard security practices as reported by customers who cannot use forced upgrade commands in their environments.

## Solution

| Before | After |
|--------|-------|
| Device version: `0309.0000.0400.0000` | Device version: `0000.0400.0000` |
| Cab version: `0305.0000.0400.0000` | Cab version: `0000.0400.0000` |
| Result: **downgrade** (needs --force) | Result: **same version** (--allow-reinstall) |

The boot version is now stored separately via `fu_device_set_version_bootloader()` and displayed as informational metadata without affecting version comparison logic.

## Cab metainfo.xml

The `<release version="...">` field must now use only the application area:

```xml
<release version="0000.0400.0000" date="2026-01-15">
```

## Verification

| Field | Value |
|-------|-------|
| GUID | `caa39ae6-7e34-5216-8d6b-6071d32f468e` |
| Protocol | `com.lxsemicon.touch` |
| Version Format | `FWUPD_VERSION_FORMAT_PLAIN` |
| Version Pattern | `{Core}.{App}.{Param}` (hex, 4-digit each) |